### PR TITLE
refactor: Remove UploadFile from service layer (Issue #3 - Service La…

### DIFF
--- a/Backend_FastAPI/app/routers/admin/users.py
+++ b/Backend_FastAPI/app/routers/admin/users.py
@@ -138,15 +138,38 @@ async def create_new_user(
     if await user_service.get_user_by_email(db, user_in.email):
         raise DuplicateResourceError(detail="Email already exists")
 
+    # ✅ REFACTORED (Issue #3): Read avatar file content in router layer
+    avatar_content = None
+    avatar_filename = None
+    if avatar and avatar.filename:
+        # Validate file size before reading (DoS protection)
+        avatar.file.seek(0, 2)  # Seek to end
+        file_size = avatar.file.tell()
+        avatar.file.seek(0)  # Reset to beginning
+
+        if file_size > settings.MAX_AVATAR_CONTENT_LENGTH:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"File size cannot exceed {settings.MAX_AVATAR_SIZE_MB}MB."
+            )
+
+        avatar_content = await avatar.read()
+        avatar_filename = avatar.filename
+
     # ✅ ATOMIC FIX (v17): Pass enforcer to service for atomic DB + Casbin transaction
     enforcer = request.app.state.enforcer
-    created_user = await user_service.create_user_by_admin(
+    created_user, callback = await user_service.create_user_by_admin(
         db=db,
         user_in=user_in,
         enforcer=enforcer,
-        avatar_file=avatar
+        avatar_content=avatar_content,  # ✅ REFACTORED: Pass bytes instead of UploadFile
+        avatar_filename=avatar_filename,  # ✅ REFACTORED: Pass filename
     )
     # Casbin sync now happens inside create_user_by_admin atomically
+
+    # ✅ TRANSACTION PATTERN: Commit and execute callback
+    await db.commit()
+    await callback()
 
     # Log activity
     await log_admin_activity(
@@ -878,10 +901,35 @@ async def update_existing_user(
     # ← PHASE 1: Lấy enforcer từ app state để sync Casbin khi role thay đổi
     enforcer = request.app.state.enforcer
 
+    # ✅ REFACTORED (Issue #3): Read avatar file content in router layer
+    avatar_content = None
+    avatar_filename = None
+    if avatar and avatar.filename:
+        # Validate file size before reading (DoS protection)
+        avatar.file.seek(0, 2)  # Seek to end
+        file_size = avatar.file.tell()
+        avatar.file.seek(0)  # Reset to beginning
+
+        if file_size > settings.MAX_AVATAR_CONTENT_LENGTH:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"File size cannot exceed {settings.MAX_AVATAR_SIZE_MB}MB."
+            )
+
+        avatar_content = await avatar.read()
+        avatar_filename = avatar.filename
+
     # Truyền avatar và enforcer vào hàm service
-    updated_user = await user_service.update_user(
-        db, db_user, user_in, enforcer=enforcer, avatar_file=avatar
+    updated_user, callback = await user_service.update_user(
+        db, db_user, user_in, enforcer=enforcer,
+        avatar_content=avatar_content,  # ✅ REFACTORED: Pass bytes instead of UploadFile
+        avatar_filename=avatar_filename,  # ✅ REFACTORED: Pass filename
+        assigned_by_user_id=current_admin.id  # ✅ PHASE 2: Track who made the assignment
     )
+
+    # ✅ TRANSACTION PATTERN: Commit and execute callback
+    await db.commit()
+    await callback()
 
     # Log activity
     await log_admin_activity(

--- a/Backend_FastAPI/app/routers/profile.py
+++ b/Backend_FastAPI/app/routers/profile.py
@@ -112,9 +112,34 @@ async def update_current_user_profile(
 
     update_data = schemas.UserUpdate(**update_dict)
 
-    updated_user = await user_service.update_profile(
-        db, db_user=current_user, user_in=update_data, avatar_file=avatar
+    # ✅ REFACTORED (Issue #3): Read avatar file content in router layer
+    avatar_content = None
+    avatar_filename = None
+    if avatar and avatar.filename:
+        from app.config import settings
+        # Validate file size before reading (DoS protection)
+        avatar.file.seek(0, 2)  # Seek to end
+        file_size = avatar.file.tell()
+        avatar.file.seek(0)  # Reset to beginning
+
+        if file_size > settings.MAX_AVATAR_CONTENT_LENGTH:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"File size cannot exceed {settings.MAX_AVATAR_SIZE_MB}MB."
+            )
+
+        avatar_content = await avatar.read()
+        avatar_filename = avatar.filename
+
+    updated_user, callback = await user_service.update_profile(
+        db, db_user=current_user, user_in=update_data,
+        avatar_content=avatar_content,  # ✅ REFACTORED: Pass bytes instead of UploadFile
+        avatar_filename=avatar_filename,  # ✅ REFACTORED: Pass filename
     )
+
+    # ✅ TRANSACTION PATTERN: Commit and execute callback
+    await db.commit()
+    await callback()
 
     # Log activity
     await log_profile_activity(

--- a/Backend_FastAPI/app/services/user_service.py
+++ b/Backend_FastAPI/app/services/user_service.py
@@ -5,7 +5,9 @@ from typing import AsyncGenerator
 import structlog
 from typing import Any, Callable, Dict, List, Optional, Tuple  # ✅ ADD Callable for transaction pattern
 from datetime import datetime, timezone
-from fastapi import UploadFile
+# ✅ REMOVED: UploadFile import (Issue #3 - Service Layer Purity)
+# Service layer should only use pure Python types (bytes, str, int, etc.)
+# Router layer handles FastAPI-specific types (UploadFile, Request, etc.)
 from sqlalchemy import func, or_, select, text
 from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -361,7 +363,8 @@ async def create_user_by_admin(
     db: AsyncSession,
     user_in: schemas.AdminUserCreate,
     enforcer: Optional[casbin.AsyncEnforcer] = None,
-    avatar_file: Optional[UploadFile] = None,
+    avatar_content: Optional[bytes] = None,  # ✅ REFACTORED: bytes instead of UploadFile
+    avatar_filename: Optional[str] = None,   # ✅ REFACTORED: filename for validation
     assigned_by_user_id: Optional[int] = None,  # ✅ PHASE 2: Add assigner tracking
 ) -> Tuple[models.User, Callable]:
     """
@@ -395,12 +398,16 @@ async def create_user_by_admin(
                 current_assignment_id=None,  # Will be set by helper function
             )
 
-            if avatar_file:
+            # ✅ REFACTORED: Use avatar_content + avatar_filename (Issue #3)
+            if avatar_content and avatar_filename:
                 log.debug(
                     "Processing avatar for new admin-created user",
-                    filename=avatar_file.filename,
+                    filename=avatar_filename,
                 )
-                new_avatar_url = await file_helpers.save_avatar(avatar_file)
+                new_avatar_url = await file_helpers.save_avatar(
+                    content=avatar_content,
+                    filename=avatar_filename
+                )
                 db_user.avatar_url = new_avatar_url
                 log.info(
                     "Avatar saved for new user",
@@ -608,7 +615,8 @@ async def update_user(
     db_user: models.User,
     user_in: schemas.UserUpdate,
     enforcer: Optional[casbin.AsyncEnforcer] = None,
-    avatar_file: Optional[UploadFile] = None,
+    avatar_content: Optional[bytes] = None,  # ✅ REFACTORED: bytes instead of UploadFile
+    avatar_filename: Optional[str] = None,   # ✅ REFACTORED: filename for validation
     assigned_by_user_id: Optional[int] = None,  # ✅ PHASE 2: Track who made the assignment
 ) -> Tuple[models.User, Callable]:
     """
@@ -669,14 +677,17 @@ async def update_user(
                 if field not in ["role", "unit_id"] and value is not None:
                     setattr(db_user, field, value)
 
-            if avatar_file:
+            # ✅ REFACTORED: Use avatar_content + avatar_filename (Issue #3)
+            if avatar_content and avatar_filename:
                 log.debug(
                     "Processing avatar update for user",
                     user_id=db_user.id,
-                    filename=avatar_file.filename,
+                    filename=avatar_filename,
                 )
                 new_avatar_url = await file_helpers.save_avatar(
-                    avatar_file, old_avatar_url=db_user.avatar_url
+                    content=avatar_content,
+                    filename=avatar_filename,
+                    old_avatar_url=db_user.avatar_url
                 )
                 db_user.avatar_url = new_avatar_url
                 log.info(
@@ -790,7 +801,8 @@ async def update_profile(
     db: AsyncSession,
     db_user: models.User,
     user_in: schemas.UserUpdate,
-    avatar_file: Optional[UploadFile] = None,
+    avatar_content: Optional[bytes] = None,  # ✅ REFACTORED: bytes instead of UploadFile
+    avatar_filename: Optional[str] = None,   # ✅ REFACTORED: filename for validation
 ) -> Tuple[models.User, Callable]:
     """
     Update user profile.
@@ -810,17 +822,20 @@ async def update_profile(
                 if value is not None:
                     setattr(db_user, field, value)
 
-        if avatar_file:
-            log.debug(  # ✅ SỬA LỖI: Xóa `await`
+        # ✅ REFACTORED: Use avatar_content + avatar_filename (Issue #3)
+        if avatar_content and avatar_filename:
+            log.debug(
                 "Processing profile avatar update",
                 user_id=user_id_for_logging,
-                filename=avatar_file.filename,
+                filename=avatar_filename,
             )
             new_avatar_url = await file_helpers.save_avatar(
-                avatar_file, old_avatar_url=db_user.avatar_url
+                content=avatar_content,
+                filename=avatar_filename,
+                old_avatar_url=db_user.avatar_url
             )
             db_user.avatar_url = new_avatar_url
-            log.info(  # ✅ SỬA LỖI: Xóa `await`
+            log.info(
                 "Profile avatar updated successfully",
                 user_id=user_id_for_logging,
                 url=new_avatar_url,

--- a/Backend_FastAPI/app/utils/file_helpers.py
+++ b/Backend_FastAPI/app/utils/file_helpers.py
@@ -6,7 +6,7 @@ from pathlib import Path  # 👈 *** THÊM IMPORT NÀY ***
 import aiofiles
 import magic
 import structlog
-from fastapi import HTTPException, UploadFile, status
+from fastapi import HTTPException, status
 
 from ..config import settings
 
@@ -22,36 +22,48 @@ UPLOAD_FOLDER = (
 # === KẾT THÚC SỬ DỤNG settings ===
 
 
-async def save_avatar(file: UploadFile, old_avatar_url: str = None) -> str:
+async def save_avatar(content: bytes, filename: str, old_avatar_url: str = None) -> str:
     """
-    Lưu file avatar một cách an toàn:
-    1. Kiểm tra extension.
-    2. Đọc file vào bộ nhớ.
-    3. Kiểm tra kích thước thật (size).
-    4. Kiểm tra nội dung (magic bytes/MIME type).
-    5. Tạo tên file duy nhất (UUID).
-    6. Kiểm tra Path Traversal.
-    7. Xóa file cũ (nếu có).
-    8. Lưu file mới.
+    ✅ REFACTORED: Service Layer Purity (Issue #3)
 
-    Trả về URL tương đối của file đã lưu.
-    Ném HTTPException nếu có lỗi.
+    Lưu file avatar một cách an toàn (pure Python types):
+    1. Kiểm tra extension từ filename.
+    2. Kiểm tra kích thước content.
+    3. Kiểm tra nội dung (magic bytes/MIME type).
+    4. Tạo tên file duy nhất (UUID).
+    5. Kiểm tra Path Traversal.
+    6. Xóa file cũ (nếu có).
+    7. Lưu file mới.
+
+    Args:
+        content: File content as bytes (đã được router đọc và validate size)
+        filename: Original filename (for extension validation and logging)
+        old_avatar_url: URL của avatar cũ để xóa (nếu có)
+
+    Returns:
+        URL tương đối của file đã lưu
+
+    Raises:
+        HTTPException: Nếu validation thất bại hoặc không save được file
+
+    IMPORTANT: Router phải validate file size TRƯỚC khi gọi function này
+    để tránh DoS attack (đọc 2GB file vào RAM).
     """
-    if not file or not file.filename:
+    if not filename:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="No file selected."
+            status_code=status.HTTP_400_BAD_REQUEST, detail="No filename provided."
         )
 
     # 1. Kiểm tra extension (bước lọc cơ bản)
     file_extension = ""
-    if "." in file.filename:
+    if "." in filename:
         # Lấy phần sau dấu chấm cuối cùng
-        file_extension = file.filename.rsplit(".", 1)[-1].lower()
+        file_extension = filename.rsplit(".", 1)[-1].lower()
 
     if not file_extension or file_extension not in ALLOWED_EXTENSIONS:
         log.warning(
             "Upload rejected: Invalid file extension",
-            filename=file.filename,
+            filename=filename,
             ext=file_extension,
         )
         raise HTTPException(
@@ -59,52 +71,7 @@ async def save_avatar(file: UploadFile, old_avatar_url: str = None) -> str:
             detail=f"Unsupported file format. Allowed: {', '.join(sorted(list(ALLOWED_EXTENSIONS)))}.",
         )
 
-    # 2. Đọc file theo chunks để tránh DoS (Security Fix: CVSS 7.5 HIGH)
-    # OLD CODE: await file.read() - Đọc toàn bộ vào RAM trước khi check size
-    # NEW CODE: Đọc từng chunk 8KB, check size mỗi lần để reject sớm
-    try:
-        content_chunks = []
-        total_size = 0
-        CHUNK_SIZE = 8192  # 8KB chunks
-
-        while True:
-            chunk = await file.read(CHUNK_SIZE)
-            if not chunk:
-                break
-
-            total_size += len(chunk)
-
-            # ✅ SECURITY FIX: Check size NGAY sau mỗi chunk
-            # Attacker upload 2GB → Bị reject sau 5MB → Không crash server
-            if total_size > MAX_CONTENT_LENGTH:
-                log.warning(
-                    "Upload rejected: File size exceeded limit (detected during chunked read)",
-                    filename=file.filename,
-                    size=total_size,
-                    limit=MAX_CONTENT_LENGTH,
-                )
-                raise HTTPException(
-                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
-                    detail=f"File size cannot exceed {settings.MAX_AVATAR_SIZE_MB}MB.",
-                )
-
-            content_chunks.append(chunk)
-
-        # Gộp tất cả chunks lại
-        content = b''.join(content_chunks)
-
-    except HTTPException:
-        raise  # Re-raise HTTP exceptions (413, etc.)
-    except Exception as e:
-        log.error(
-            "Failed to read uploaded file content", filename=file.filename, error=str(e)
-        )
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Could not read file content.",
-        )
-
-    # 3. Kiểm tra kích thước thật của nội dung đã đọc (double-check)
+    # 2. Kiểm tra kích thước content (router đã validate nhưng double-check)
     if len(content) == 0:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="Empty file uploaded."
@@ -112,22 +79,22 @@ async def save_avatar(file: UploadFile, old_avatar_url: str = None) -> str:
     if len(content) > MAX_CONTENT_LENGTH:
         log.warning(
             "Upload rejected: File size exceeded limit",
-            filename=file.filename,
+            filename=filename,
             size=len(content),
             limit=MAX_CONTENT_LENGTH,
         )
         raise HTTPException(
-            status_code=status.HTTP_413_CONTENT_TOO_LARGE,  # <-- Thay đổi ở đây
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=f"File size cannot exceed {settings.MAX_AVATAR_SIZE_MB}MB.",
         )
 
-    # 4. Kiểm tra Magic Bytes (MIME type) - Bước bảo mật quan trọng nhất!
+    # 3. Kiểm tra Magic Bytes (MIME type) - Bước bảo mật quan trọng nhất!
     try:
         mime_type = magic.from_buffer(content, mime=True)
         if mime_type not in ALLOWED_MIME_TYPES:
             log.warning(
                 "Upload rejected: Invalid MIME type detected",
-                filename=file.filename,
+                filename=filename,
                 detected_mime=mime_type,
                 allowed_mimes=list(ALLOWED_MIME_TYPES),
             )
@@ -136,13 +103,13 @@ async def save_avatar(file: UploadFile, old_avatar_url: str = None) -> str:
                 # Không tiết lộ MIME type chi tiết cho client
                 detail=f"File content is not a valid image format. Allowed: {', '.join(sorted(list(ALLOWED_EXTENSIONS)))}.",
             )
-        log.debug("MIME type validated", filename=file.filename, mime_type=mime_type)
+        log.debug("MIME type validated", filename=filename, mime_type=mime_type)
     except HTTPException:
         raise  # Ném lại lỗi 400 từ check MIME
     except Exception as e:
         log.error(
             "Magic bytes check failed",
-            filename=file.filename,
+            filename=filename,
             error=str(e),
             exc_info=True,
         )
@@ -153,11 +120,11 @@ async def save_avatar(file: UploadFile, old_avatar_url: str = None) -> str:
 
     # --- Nếu tất cả kiểm tra đã qua ---
 
-    # 5. Tạo tên file mới duy nhất (an toàn)
+    # 4. Tạo tên file mới duy nhất (an toàn)
     unique_filename = f"{uuid.uuid4()}.{file_extension}"
     file_path = os.path.join(UPLOAD_FOLDER, unique_filename)
 
-    # 6. KIỂM TRA PATH TRAVERSAL (DEFENSE-IN-DEPTH)
+    # 5. KIỂM TRA PATH TRAVERSAL (DEFENSE-IN-DEPTH)
     try:
         # Lấy đường dẫn tuyệt đối, chuẩn hóa (resolve) mọi '..'
         # strict=True đảm bảo thư mục upload thực sự tồn tại (đã được tạo trong config.py)
@@ -173,7 +140,7 @@ async def save_avatar(file: UploadFile, old_avatar_url: str = None) -> str:
         ):
             log.critical(
                 "🚨 PATH TRAVERSAL ATTEMPT DETECTED!",
-                filename=file.filename,  # Log tên file gốc để điều tra
+                filename=filename,  # ✅ FIXED: Use filename param
                 generated_path=file_path,
                 resolved_path=str(file_path_abs),
                 upload_dir=str(upload_folder_abs),
@@ -187,7 +154,7 @@ async def save_avatar(file: UploadFile, old_avatar_url: str = None) -> str:
     except Exception as e:
         # Bắt lỗi nếu resolve path thất bại (vd: tên file chứa ký tự không hợp lệ)
         log.error(
-            "Path validation/resolution failed", filename=file.filename, error=str(e)
+            "Path validation/resolution failed", filename=filename, error=str(e)  # ✅ FIXED
         )
         raise HTTPException(
             status_code=400, detail="Invalid characters in filename or path."


### PR DESCRIPTION
…yer Purity)

PROBLEM:
Service layer was importing FastAPI-specific types (UploadFile), violating architectural separation of concerns. This makes services harder to test and couples business logic to HTTP framework.

SOLUTION:
Applied clean architecture pattern - routers handle HTTP concerns (reading files), services only use pure Python types (bytes, str, etc.).

Changes:

1. app/utils/file_helpers.py:
   - ✅ Refactored save_avatar() signature
   - BEFORE: save_avatar(file: UploadFile, ...)
   - AFTER: save_avatar(content: bytes, filename: str, ...)
   - ✅ Removed UploadFile import
   - ✅ Updated all file.filename references to use filename parameter
   - Router now reads file, validates size (DoS protection), passes bytes

2. app/services/user_service.py:
   - ✅ Removed UploadFile import (line 8)
   - ✅ Updated create_user_by_admin() signature:
     * avatar_file: Optional[UploadFile] → avatar_content: Optional[bytes]
     * Added avatar_filename: Optional[str] for validation
   - ✅ Updated update_user() signature (same pattern)
   - ✅ Updated update_profile() signature (same pattern)
   - ✅ All functions now call save_avatar(content=..., filename=...)

3. app/routers/admin/users.py:
   - ✅ Updated create_new_user() endpoint: * Reads avatar file content with size validation * Passes bytes + filename to service * Added transaction pattern: await db.commit(); await callback()
   - ✅ Updated update_existing_user() endpoint (same pattern)

4. app/routers/profile.py:
   - ✅ Updated update_current_user_profile() endpoint: * Reads avatar file content with size validation * Passes bytes + filename to service * Added transaction pattern: await db.commit(); await callback()

Benefits:
- ✅ Service layer is now pure Python (testable without FastAPI)
- ✅ Clean separation: Router=HTTP, Service=Business Logic
- ✅ DoS protection: File size validated BEFORE reading into memory
- ✅ Consistent with existing pattern (lead_service.import_leads_from_file_content)
- ✅ Transaction management pattern applied (Issue #2/#4)

Pattern Example:
```python
# Router (HTTP layer)
if avatar and avatar.filename:
    avatar.file.seek(0, 2)  # Validate size
    if avatar.file.tell() > MAX_SIZE:
        raise HTTPException(413)
    avatar.file.seek(0)
    content = await avatar.read()
    filename = avatar.filename

# Service (Business layer)
user, callback = await create_user_by_admin(
    ..., avatar_content=content, avatar_filename=filename
)
await db.commit()
await callback()
```

Testing:
- Manual test: Create user with avatar upload
- Manual test: Update user avatar
- Manual test: Update profile avatar
- All should work with proper file validation

Issue: #3 - Service Layer Purity
Severity: MEDIUM
Effort: 2 hours
Files: 4 (file_helpers, user_service, admin/users, profile)