### PR TITLE
feat: Add IDOR protection for assignment config endpoints (Issue #10)

### DIFF
--- a/Backend_FastAPI/app/routers/admin/config.py
+++ b/Backend_FastAPI/app/routers/admin/config.py
@@ -47,12 +47,23 @@ PermissionDep = Depends(deps.check_permission)
     response_model=schemas.AssignmentConfig,
 )
 async def get_assignment_config_route(
-    unit_id: int,
+    unit: models.OrganizationUnit = Depends(deps.get_organizational_unit_for_user),
     db: AsyncSession = Depends(database.get_db),
     current_admin: models.User = PermissionDep,
 ):
-    """(Admin only) Lấy cấu hình phân chia của một đơn vị."""
-    params = await config_service.get_assignment_config(db, unit_id)
+    """
+    (Admin/Manager) Get assignment config for an organizational unit.
+
+    **Security:**
+    - ✓ Role: Admin or Manager (Casbin)
+    - ✓ Ownership: Manager limited to managed units
+    - ✓ IDOR Protection: Enabled
+
+    **Access Levels:**
+    - **Admin**: Can access all units
+    - **Manager**: Can only access units they manage
+    """
+    params = await config_service.get_assignment_config(db, unit.id)
     return {"params": params}
 
 
@@ -62,14 +73,29 @@ async def get_assignment_config_route(
     response_model=schemas.AssignmentConfig,
 )
 async def update_assignment_config_route(
-    unit_id: int,
     config_in: schemas.AssignmentConfig,
+    unit: models.OrganizationUnit = Depends(deps.get_organizational_unit_for_user),
     db: AsyncSession = Depends(database.get_db),
     current_admin: models.User = PermissionDep,
 ):
-    """(Admin only) Cập nhật cấu hình phân chia của một đơn vị."""
+    """
+    (Admin/Manager) Update assignment config for an organizational unit.
+
+    **Security:**
+    - ✓ Role: Admin or Manager (Casbin)
+    - ✓ Ownership: Manager limited to managed units
+    - ✓ IDOR Protection: Enabled
+
+    **Access Levels:**
+    - **Admin**: Can update all units
+    - **Manager**: Can only update units they manage
+
+    **Business Rules:**
+    - Assignment config controls officer distribution settings per unit
+    - Changes affect future lead assignments only (not existing assignments)
+    """
     updated_model = await config_service.update_assignment_config(
-        db, unit_id, config_in.params
+        db, unit.id, config_in.params
     )
     # Trả về schema Pydantic dựa trên model đã cập nhật từ DB
     return schemas.AssignmentConfig(params=updated_model.params)


### PR DESCRIPTION
**Security Enhancement:**
- Added unit ownership verification for assignment config endpoints
- Managers can now only access/modify configs for their managed units
- Prevents cross-unit IDOR attacks in configuration management

**Changes:**
Backend_FastAPI/app/routers/admin/config.py:
- GET /assignment-config/{unit_id}
  - Added deps.get_organizational_unit_for_user dependency
  - Verifies manager has access to the unit before reading config
  - Updated documentation to reflect Admin/Manager access

- PUT /assignment-config/{unit_id}
  - Added deps.get_organizational_unit_for_user dependency
  - Verifies manager has access to the unit before updating config
  - Updated documentation with security details and business rules

**Security Benefits:**
- Prevents managers from accessing/modifying configs outside their units
- Consistent with existing IDOR protection pattern (Issue #1)
- Leverages existing get_organizational_unit_for_user dependency
- Provides detailed logging of access attempts

**Access Control:**
Before: Admin-only endpoints with no unit boundary checks After:
  - Admin: Full access to all unit configs (unchanged)
  - Manager: Access limited to their managed units only (new protection)
  - Officer: Denied by Casbin (unchanged)

**Related Endpoints Already Protected:**
- Distribution rules update/delete: Already use DistributionRuleAccessDep
- Distribution rules list: Already filters by managed units for managers
- Other config endpoints (degree levels, offering types, document types): System-wide configs, no unit ownership concept

**Related:** Issue #10 - Admin Config Unit IDOR
**Priority:** 3 (Medium)
**Estimated:** 0.5h-2h
**Completes:** 100% of IMPLEMENTATION_PLAN