### PR TITLE
feat(insights): Lead Insights Upgrade with Officer Rating

### DIFF
--- a/Backend_FastAPI/alembic/versions/b1c2d3e4f5g6_add_lead_insights_cache_fields.py
+++ b/Backend_FastAPI/alembic/versions/b1c2d3e4f5g6_add_lead_insights_cache_fields.py
@@ -1,0 +1,111 @@
+"""add_lead_insights_cache_fields
+
+Revision ID: b1c2d3e4f5g6
+Revises: a9cd4ab78906
+Create Date: 2024-12-13
+
+Lead Insights Upgrade - Phase 1
+Add cached fields for Lead metrics to support fast sorting/filtering in DataTable.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b1c2d3e4f5g6'
+down_revision = 'a9cd4ab78906'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add Lead Insights cached fields."""
+    
+    # 1. last_consultation_at - Ngày tư vấn cuối cùng
+    op.add_column('lead', sa.Column(
+        'last_consultation_at',
+        sa.DateTime(timezone=True),
+        nullable=True,
+        comment='Ngày tư vấn cuối cùng (auto-updated)'
+    ))
+    op.create_index(
+        'ix_lead_last_consultation_at',
+        'lead',
+        ['last_consultation_at'],
+        unique=False
+    )
+    
+    # 2. consultation_count - Số lần tư vấn
+    op.add_column('lead', sa.Column(
+        'consultation_count',
+        sa.Integer(),
+        nullable=False,
+        server_default='0',
+        comment='Số lần tư vấn (auto-updated)'
+    ))
+    
+    # 3. cached_urgency_score - Điểm khẩn cấp 0-100
+    op.add_column('lead', sa.Column(
+        'cached_urgency_score',
+        sa.Integer(),
+        nullable=False,
+        server_default='50',
+        comment='Điểm khẩn cấp 0-100 (auto-calculated)'
+    ))
+    op.create_index(
+        'ix_lead_cached_urgency_score',
+        'lead',
+        ['cached_urgency_score'],
+        unique=False
+    )
+    
+    # 4. is_hot_lead - Lead score >= 70
+    op.add_column('lead', sa.Column(
+        'is_hot_lead',
+        sa.Boolean(),
+        nullable=False,
+        server_default='false',
+        comment='Lead score >= 70'
+    ))
+    op.create_index(
+        'ix_lead_is_hot_lead',
+        'lead',
+        ['is_hot_lead'],
+        unique=False
+    )
+    
+    # 5. is_overdue - next_activity_at đã quá hạn
+    op.add_column('lead', sa.Column(
+        'is_overdue',
+        sa.Boolean(),
+        nullable=False,
+        server_default='false',
+        comment='next_activity_at đã quá hạn'
+    ))
+    op.create_index(
+        'ix_lead_is_overdue',
+        'lead',
+        ['is_overdue'],
+        unique=False
+    )
+    
+    print("✅ Added 5 cached fields to Lead model for Insights Upgrade")
+
+
+def downgrade() -> None:
+    """Remove Lead Insights cached fields."""
+    
+    # Drop indexes first
+    op.drop_index('ix_lead_is_overdue', table_name='lead')
+    op.drop_index('ix_lead_is_hot_lead', table_name='lead')
+    op.drop_index('ix_lead_cached_urgency_score', table_name='lead')
+    op.drop_index('ix_lead_last_consultation_at', table_name='lead')
+    
+    # Drop columns
+    op.drop_column('lead', 'is_overdue')
+    op.drop_column('lead', 'is_hot_lead')
+    op.drop_column('lead', 'cached_urgency_score')
+    op.drop_column('lead', 'consultation_count')
+    op.drop_column('lead', 'last_consultation_at')
+    
+    print("✅ Removed Lead Insights cached fields")

--- a/Backend_FastAPI/app/celery_utils.py
+++ b/Backend_FastAPI/app/celery_utils.py
@@ -6,6 +6,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
 from celery import Celery
+from celery.schedules import crontab
 from celery.signals import worker_process_init, worker_process_shutdown
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -738,9 +739,107 @@ celery_app.conf.beat_schedule = {
         "task": "check_consultation_reminders_task",
         "schedule": 60.0,  # Every 60 seconds
     },
+    # ✅ LEAD INSIGHTS UPGRADE: Nightly cache recalculation
+    "recalculate-lead-caches-nightly": {
+        "task": "recalculate_lead_caches_task",
+        "schedule": crontab(hour=0, minute=5),  # Runs at 00:05 daily
+    },
 }
 
 # Use configured timezone for consistency with local time
 # Can be set via TIMEZONE environment variable (default: Asia/Ho_Chi_Minh)
 celery_app.conf.timezone = settings.TIMEZONE
 celery_app.conf.enable_utc = False
+
+
+# ==================================================================
+# === Lead Insights Upgrade: Nightly Cache Recalculation ===
+# ==================================================================
+
+@celery_app.task(
+    name="recalculate_lead_caches_task",
+    bind=True,
+    autoretry_for=(Exception,),
+    max_retries=2,
+    default_retry_delay=300,  # 5 minutes between retries
+)
+def recalculate_lead_caches_task(self):
+    """
+    Celery Beat nightly task to recalculate lead insight caches.
+    
+    Runs at 00:05 daily to update:
+    - is_overdue (time-sensitive, needs daily recalc)
+    - cached_urgency_score (depends on is_overdue)
+    
+    This ensures accuracy for leads that weren't recently touched
+    but may have become overdue overnight.
+    """
+    task_log = logging.getLogger("recalculate_lead_caches_task")
+    task_log.info("Starting nightly lead cache recalculation...")
+
+    async def _run_recalculation() -> dict:
+        from sqlalchemy import select, func
+        from . import models
+        from .services.lead_cache_service import update_lead_cache
+
+        # Create engine INSIDE async context
+        engine = _create_task_async_engine()
+        session_maker = _create_task_session_maker(engine)
+
+        result = {"total": 0, "updated": 0, "errors": 0}
+
+        try:
+            async with session_maker() as session:
+                # Get count of active leads
+                count_result = await session.execute(
+                    select(func.count(models.Lead.id))
+                    .where(models.Lead.deleted_at.is_(None))
+                )
+                result["total"] = count_result.scalar() or 0
+                
+                if result["total"] == 0:
+                    task_log.info("No leads to recalculate")
+                    return result
+                
+                # Get all lead IDs
+                ids_result = await session.execute(
+                    select(models.Lead.id)
+                    .where(models.Lead.deleted_at.is_(None))
+                    .order_by(models.Lead.id)
+                )
+                lead_ids = [row[0] for row in ids_result.all()]
+                
+                # Process in batches
+                batch_size = 100
+                for i in range(0, len(lead_ids), batch_size):
+                    batch = lead_ids[i:i + batch_size]
+                    
+                    for lead_id in batch:
+                        try:
+                            await update_lead_cache(session, lead_id)
+                            result["updated"] += 1
+                        except Exception as e:
+                            task_log.warning(f"Error updating lead {lead_id}: {e}")
+                            result["errors"] += 1
+                    
+                    # Commit after each batch
+                    await session.commit()
+                    
+                    progress = min(i + batch_size, len(lead_ids))
+                    task_log.info(f"Progress: {progress}/{result['total']}")
+
+        finally:
+            await engine.dispose()
+
+        return result
+
+    try:
+        result = asyncio.run(_run_recalculation())
+        task_log.info(
+            f"Nightly recalculation completed: total={result['total']}, "
+            f"updated={result['updated']}, errors={result['errors']}"
+        )
+        return result
+    except Exception as e:
+        task_log.error(f"Nightly recalculation failed: {e}", exc_info=True)
+        raise e

--- a/Backend_FastAPI/app/models/lead.py
+++ b/Backend_FastAPI/app/models/lead.py
@@ -112,6 +112,46 @@ class Lead(Base):
     deleted_at = Column(DateTime(timezone=True), nullable=True, index=True)
     # Quick Disposition: Next activity timestamp for bubble-up sorting
     next_activity_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    
+    # =========================================================================
+    # CACHED METRICS (Lead Insights Upgrade)
+    # Updated by LeadCacheService after consultation changes
+    # =========================================================================
+    last_consultation_at = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        index=True,
+        comment="Ngày tư vấn cuối cùng (auto-updated)"
+    )
+    consultation_count = Column(
+        Integer,
+        nullable=False,
+        default=0,
+        comment="Số lần tư vấn (auto-updated)"
+    )
+    cached_urgency_score = Column(
+        Integer,
+        nullable=False,
+        default=50,
+        index=True,
+        comment="Điểm khẩn cấp 0-100 (auto-calculated)"
+    )
+    is_hot_lead = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        index=True,
+        comment="Lead score >= 70"
+    )
+    is_overdue = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        index=True,
+        comment="next_activity_at đã quá hạn"
+    )
+    # =========================================================================
+    
     # NEW 3-TIER ARCHITECTURE: Link to ProgramOffering instead of Major
     offering_id = Column(Integer, ForeignKey("program_offering.id", ondelete="SET NULL"), nullable=True, index=True)
     unit_id = Column(Integer, ForeignKey("organization_unit.id"), nullable=False, index=True)  # ✅ FIX: Added index

--- a/Backend_FastAPI/app/repositories/lead_repository.py
+++ b/Backend_FastAPI/app/repositories/lead_repository.py
@@ -381,10 +381,13 @@ class LeadRepository(BaseRepository[models.Lead]):
         """
         Update lead's next_activity_at field.
 
-        Finds earliest scheduled consultation that:
-        - Hasn't sent reminder yet
-        - Is in the future
-        - Belongs to this lead
+        ✅ FIXED: Finds earliest PENDING consultation regardless of time.
+        Task quá hạn vẫn là next activity (nhưng overdue).
+        
+        Logic mới:
+        - Tìm consultation có scheduled_at AND status chưa hoàn thành
+        - KHÔNG filter theo time (>= now)
+        - KHÔNG dùng reminder_sent
 
         Args:
             lead_id: Lead ID to update
@@ -395,7 +398,8 @@ class LeadRepository(BaseRepository[models.Lead]):
         if not lead:
             return
 
-        now = datetime.now(timezone.utc)
+        # Các status được coi là "pending" (chưa hoàn thành)
+        PENDING_STATUS_IDS = ["sts01", "sts03"]  # Lên lịch, Cần theo dõi
 
         result = await self.db.execute(
             select(func.min(models.Consultation.scheduled_at))
@@ -403,8 +407,7 @@ class LeadRepository(BaseRepository[models.Lead]):
                 and_(
                     models.Consultation.lead_id == lead_id,
                     models.Consultation.scheduled_at.isnot(None),
-                    models.Consultation.scheduled_at >= now,
-                    models.Consultation.reminder_sent == False,
+                    models.Consultation.consultation_status_id.in_(PENDING_STATUS_IDS),
                 )
             )
         )
@@ -509,6 +512,56 @@ class LeadRepository(BaseRepository[models.Lead]):
 
         result = await self.db.execute(query)
         return {row.status: row.count for row in result}
+
+    # =========================================================================
+    # LEAD INSIGHTS CACHE: Aggregation methods for cache update
+    # =========================================================================
+
+    async def get_consultation_aggregates(
+        self,
+        lead_id: int
+    ) -> dict:
+        """
+        Get consultation aggregates for cache update.
+        
+        ✅ ARCHITECTURE COMPLIANT: Repository handles all queries.
+        Called by LeadCacheService to update cached fields.
+        
+        Args:
+            lead_id: Lead ID
+            
+        Returns:
+            Dict with: last_consultation_at, consultation_count, 
+                       pending_next_activity (earliest pending task)
+        """
+        # Query 1: Get consultation stats
+        stats_query = select(
+            func.max(models.Consultation.consultation_date).label("last_consultation_at"),
+            func.count(models.Consultation.id).label("consultation_count"),
+        ).where(models.Consultation.lead_id == lead_id)
+        
+        stats_result = await self.db.execute(stats_query)
+        stats = stats_result.one()
+        
+        # Query 2: Get earliest pending activity (not completed)
+        PENDING_STATUS_IDS = ["sts01", "sts03"]  # Lên lịch, Cần theo dõi
+        
+        pending_query = select(
+            func.min(models.Consultation.scheduled_at)
+        ).where(
+            models.Consultation.lead_id == lead_id,
+            models.Consultation.scheduled_at.isnot(None),
+            models.Consultation.consultation_status_id.in_(PENDING_STATUS_IDS),
+        )
+        
+        pending_result = await self.db.execute(pending_query)
+        pending_next_activity = pending_result.scalar_one_or_none()
+        
+        return {
+            "last_consultation_at": stats.last_consultation_at,
+            "consultation_count": stats.consultation_count or 0,
+            "pending_next_activity": pending_next_activity,
+        }
 
     # =========================================================================
     # SPRINT 5: Additional Methods for lead_service Migration

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -273,6 +273,20 @@ class Lead(LeadBase):
     education_level: Optional[str] = None
     gpa: Optional[float] = None
     location: Optional[str] = None
+    
+    # =========================================================================
+    # CACHED METRICS (Lead Insights Upgrade)
+    # Auto-updated by LeadCacheService after consultation changes
+    # =========================================================================
+    last_consultation_at: Optional[datetime] = None
+    consultation_count: int = 0
+    cached_urgency_score: int = 50
+    is_hot_lead: bool = False
+    is_overdue: bool = False
+    # Officer input fields (from LeadUpdate)
+    officer_rating: Optional[int] = None
+    officer_summary: Optional[str] = None
+    # =========================================================================
 
     offering: Optional[ProgramOffering] = None
     # THAY ĐỔI Ở ĐÂY: Sử dụng OrganizationUnitShallow

--- a/Backend_FastAPI/app/services/insights_service.py
+++ b/Backend_FastAPI/app/services/insights_service.py
@@ -93,65 +93,46 @@ async def _calculate_engagement_score(db: AsyncSession, lead_id: int) -> int:
 
 
 def _calculate_fit_score(lead: models.Lead) -> int:
-    # ... (Hàm này giữ nguyên, không thay đổi) ...
-    score = 0
-    points_config = settings.LEAD_SCORING_FIT_POINTS
-    score += points_config["source"].get(lead.source, 0)
-    if lead.gpa:
-        for threshold, points in sorted(
-            points_config["gpa_thresholds"].items(), reverse=True
-        ):
-            if lead.gpa >= threshold:
-                score += points
-                break
-    if lead.education_level:
-        score += points_config["education_level"].get(lead.education_level, 0)
-    if lead.location:
-        score += points_config["location"].get(lead.location, 0)
-    return max(0, min(score, points_config["max_score"]))
+    """
+    Fit Score = lead_score + Officer Rating bonus
+
+    Công thức minh bạch cho Officers:
+    - Base: lead_score (0-100) - đã tính từ education, GPA, source, location
+    - Bonus: officer_rating × 4 (1-5 stars → +4 to +20 điểm)
+
+    Ví dụ:
+    - lead_score=50, officer_rating=5 → 50 + 20 = 70
+    - lead_score=60, officer_rating=None → 60
+    - lead_score=90, officer_rating=3 → min(90+12, 100) = 100
+
+    Max: 100
+    """
+    base_score = lead.lead_score or 0
+
+    officer_bonus = 0
+    if lead.officer_rating:
+        try:
+            officer_bonus = int(lead.officer_rating) * 4  # 1-5 → +4 to +20
+        except (ValueError, TypeError):
+            officer_bonus = 0
+
+    return min(base_score + officer_bonus, 100)
 
 
-def _calculate_urgency_score(lead: models.Lead, timeline: List[dict]) -> int:
-    # ... (Hàm này giữ nguyên, không thay đổi) ...
-    score = 0
-    points_config = settings.LEAD_SCORING_URGENCY_POINTS
-    if hasattr(lead, "pipeline_stage") and lead.pipeline_stage:
-        score += lead.pipeline_stage.order * points_config["stage_order_multiplier"]
-    else:
-        initial_stage_order = 1
-        score += initial_stage_order * points_config["stage_order_multiplier"]
+def _get_urgency_score(lead: models.Lead) -> int:
+    """
+    Urgency Score = cached_urgency_score từ Lead model
 
-    stage_changes = []
-    sorted_timeline = sorted(timeline, key=lambda x: x["timestamp"])
+    Công thức minh bạch cho Officers (đã tính trong lead_cache_service):
+    - Task quá hạn (is_overdue): +30
+    - Hoạt động tiếp theo trong 24h: +20
+    - Giai đoạn pipeline: stage_order × 5
+    - Ngày không hoạt động: +2/ngày (max +20)
 
-    for item in sorted_timeline:
-        consultation_status = None
-        if item["type"] == "consultation":
-            if hasattr(item["data"], "consultation_status"):
-                consultation_status = item["data"].consultation_status
-
-        if consultation_status:
-            stage_id = consultation_status.stage_id
-            if not stage_changes or stage_changes[-1]["stage_id"] != stage_id:
-                stage_changes.append(
-                    {"stage_id": stage_id, "timestamp": item["timestamp"]}
-                )
-
-    for i in range(1, len(stage_changes)):
-        ts_i = stage_changes[i]["timestamp"]
-        ts_prev = stage_changes[i - 1]["timestamp"]
-        if ts_i.tzinfo is None:
-            ts_i = ts_i.replace(tzinfo=timezone.utc)
-        if ts_prev.tzinfo is None:
-            ts_prev = ts_prev.replace(tzinfo=timezone.utc)
-
-        time_diff_days = (ts_i - ts_prev).days
-        if time_diff_days <= 3:
-            score += points_config["fast_conversion_bonus"]
-        elif time_diff_days > 14:
-            score -= abs(points_config["slow_conversion_penalty"])
-
-    return max(0, min(score, points_config["max_score"]))
+    Sử dụng cached value để đảm bảo đồng bộ với Lead model.
+    Max: 100
+    """
+    return lead.cached_urgency_score or 0
 
 
 async def get_lead_insights(
@@ -188,9 +169,9 @@ async def get_lead_insights(
     # 1. Gọi hàm async mới (chạy song song)
     engagement_score_task = _calculate_engagement_score(db, lead.id)
 
-    # 2. Các hàm sync cũ (vẫn cần 'lead' object)
+    # 2. Các hàm sync (không cần timeline cho urgency nữa - dùng cached)
     fit_score = _calculate_fit_score(lead)
-    urgency_score = _calculate_urgency_score(lead, timeline)
+    urgency_score = _get_urgency_score(lead)
 
     # 3. Lấy kết quả
     engagement_score = await engagement_score_task

--- a/Backend_FastAPI/app/services/lead_cache_service.py
+++ b/Backend_FastAPI/app/services/lead_cache_service.py
@@ -1,0 +1,207 @@
+# app/services/lead_cache_service.py
+"""
+Lead Cache Service - Maintains cached metrics for Lead Insights.
+
+✅ ARCHITECTURE COMPLIANT:
+- Uses Repository pattern (no direct DB queries)
+- Transaction propagation (accepts session from caller)
+- Sync execution within transaction
+
+Called after:
+- Consultation create/update/delete
+- Lead score update
+- Pipeline stage changes
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.repositories.lead_repository import LeadRepository
+
+
+log = structlog.get_logger(__name__)
+
+
+def calculate_urgency_score(
+    days_since_contact: int,
+    lead_score: int,
+    consultation_count: int,
+    overdue_days: int,
+    is_final_stage: bool
+) -> int:
+    """
+    Calculate Urgency Score (0-100).
+    
+    Components:
+    - Base: 30
+    - Inactivity: days × 3 (max 45)
+    - Hot Lead: +15 if score >= 70
+    - Never Contacted: +25 if count = 0
+    - Overdue: days × 5 (max 30)
+    - Final Stage: -50
+    
+    Args:
+        days_since_contact: Days since last consultation
+        lead_score: Lead's current score
+        consultation_count: Number of consultations
+        overdue_days: Days overdue for next_activity_at
+        is_final_stage: Whether lead is in final pipeline stage
+        
+    Returns:
+        Urgency score 0-100
+    """
+    score = 30  # Base
+    
+    # Inactivity penalty (max +45)
+    score += min(days_since_contact * 3, 45)
+    
+    # Hot lead bonus
+    if lead_score >= 70:
+        score += 15
+    
+    # Never contacted penalty
+    if consultation_count == 0:
+        score += 25
+    
+    # Overdue penalty (max +30)
+    if overdue_days > 0:
+        score += min(overdue_days * 5, 30)
+    
+    # Final stage reduction
+    if is_final_stage:
+        score -= 50
+    
+    return max(0, min(score, 100))
+
+
+async def update_lead_cache(
+    db: AsyncSession,
+    lead_id: int,
+    lead: Optional[models.Lead] = None
+) -> None:
+    """
+    Update cached fields for a lead.
+    
+    ✅ TRANSACTION SAFE: Uses provided session, no commit.
+    Caller is responsible for commit/rollback.
+    
+    Flow:
+    1. Query consultation aggregates via Repository
+    2. Calculate urgency score
+    3. Update Lead fields
+    4. Flush (no commit)
+    
+    Args:
+        db: SQLAlchemy session (from caller's transaction)
+        lead_id: Lead ID to update
+        lead: Optional pre-loaded Lead object
+    """
+    repo = LeadRepository(db)
+    
+    # Get lead if not provided
+    if lead is None:
+        lead = await db.get(models.Lead, lead_id)
+        if not lead:
+            log.warning("Lead not found for cache update", lead_id=lead_id)
+            return
+    
+    now = datetime.now(timezone.utc)
+    
+    # 1. Get consultation aggregates via Repository
+    aggregates = await repo.get_consultation_aggregates(lead_id)
+    
+    last_consultation_at = aggregates["last_consultation_at"]
+    consultation_count = aggregates["consultation_count"]
+    pending_next_activity = aggregates["pending_next_activity"]
+    
+    # 2. Calculate days since contact
+    if last_consultation_at:
+        # Ensure timezone aware
+        if last_consultation_at.tzinfo is None:
+            last_consultation_at = last_consultation_at.replace(tzinfo=timezone.utc)
+        days_since_contact = (now - last_consultation_at).days
+    else:
+        # Fallback to created_at
+        created_at = lead.created_at
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        days_since_contact = (now - created_at).days
+    
+    # 3. Calculate overdue days
+    overdue_days = 0
+    if pending_next_activity:
+        if pending_next_activity.tzinfo is None:
+            pending_next_activity = pending_next_activity.replace(tzinfo=timezone.utc)
+        if pending_next_activity < now:
+            overdue_days = (now - pending_next_activity).days
+    
+    # 4. Check final stage
+    is_final_stage = False
+    if lead.pipeline_stage_id:
+        # Need to check pipeline_stage.is_final
+        # For now, check common final stage IDs
+        FINAL_STAGE_IDS = ["stg05", "stg06"]  # Converted, Lost
+        is_final_stage = lead.pipeline_stage_id in FINAL_STAGE_IDS
+    
+    # 5. Calculate urgency score
+    urgency_score = calculate_urgency_score(
+        days_since_contact=days_since_contact,
+        lead_score=lead.lead_score or 0,
+        consultation_count=consultation_count,
+        overdue_days=overdue_days,
+        is_final_stage=is_final_stage
+    )
+    
+    # 6. Update lead cached fields
+    lead.last_consultation_at = last_consultation_at
+    lead.consultation_count = consultation_count
+    lead.cached_urgency_score = urgency_score
+    lead.is_hot_lead = (lead.lead_score or 0) >= 70
+    lead.is_overdue = overdue_days > 0
+    lead.next_activity_at = pending_next_activity
+    
+    # 7. Flush (no commit - caller handles transaction)
+    await db.flush()
+    
+    log.debug(
+        "Lead cache updated",
+        lead_id=lead_id,
+        urgency_score=urgency_score,
+        consultation_count=consultation_count,
+        is_hot_lead=lead.is_hot_lead,
+        is_overdue=lead.is_overdue,
+    )
+
+
+async def batch_update_lead_caches(
+    db: AsyncSession,
+    lead_ids: list[int]
+) -> int:
+    """
+    Batch update cached fields for multiple leads.
+    
+    Used by:
+    - Nightly cron job (recalculate all urgency scores)
+    - Backfill script
+    
+    Args:
+        db: SQLAlchemy session
+        lead_ids: List of Lead IDs to update
+        
+    Returns:
+        Number of leads updated
+    """
+    updated = 0
+    for lead_id in lead_ids:
+        try:
+            await update_lead_cache(db, lead_id)
+            updated += 1
+        except Exception as e:
+            log.error("Failed to update lead cache", lead_id=lead_id, error=str(e))
+    
+    await db.commit()
+    return updated

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -1166,6 +1166,11 @@ async def update_lead(
                 reason=f"Lead details updated by {updated_by.role}",
             )
 
+            # ✅ LEAD INSIGHTS UPGRADE: Update cached metrics
+            # Especially important when lead_score changes (affects is_hot_lead)
+            from app.services import lead_cache_service
+            await lead_cache_service.update_lead_cache(db, lead_id, db_lead)
+
             log.info("Lead updated successfully within transaction", lead_id=lead_id)
             # Transaction sẽ commit khi ra khỏi `async with db.begin_nested()`
 
@@ -1392,18 +1397,21 @@ async def add_consultation(
             # Flush để lấy ID cho consultation mới (cần cho refresh)
             await db.flush([new_consultation])
 
+            # ✅ LEAD INSIGHTS UPGRADE: Update cached metrics
+            # Runs sync within transaction for consistency
+            from app.services import lead_cache_service
+            await lead_cache_service.update_lead_cache(db, lead_id, lead)
+
             # ✅ ARCHITECTURE FIX: Use Repository instead of direct query
             # Service must not query Model directly (Rule E: Repository Pattern)
             repo = LeadRepository(db)
             new_consultation = await repo.get_consultation_with_status_stage(new_consultation.id)
 
             # ✅ Quick Disposition: Cập nhật next_activity_at dựa trên tất cả consultations
+            # NOTE: update_lead_cache already updates next_activity_at
             if data.scheduled_at:
-                # ✅ FIX: Flush pending changes so query sees new consultation
-                await db.flush()
-                await update_lead_next_activity(db, lead_id)
                 log.info(
-                    "Updated lead.next_activity_at after adding consultation",
+                    "Consultation scheduled_at set",
                     lead_id=lead_id,
                     consultation_scheduled_at=data.scheduled_at.isoformat() if data.scheduled_at else None,
                 )
@@ -1765,8 +1773,11 @@ async def delete_consultation(
             # ✅ Quick Disposition: Cập nhật next_activity_at sau khi xóa consultation
             # FIX: Flush to ensure deletion is visible to query
             await db.flush()
-            await update_lead_next_activity(db, lead_id)
-            log.info("Updated lead.next_activity_at after deleting consultation", lead_id=lead_id, deleted_consultation_id=consultation_id)
+            
+            # ✅ LEAD INSIGHTS UPGRADE: Update cached metrics
+            from app.services import lead_cache_service
+            await lead_cache_service.update_lead_cache(db, lead_id, lead)
+            log.info("Updated lead cache after deleting consultation", lead_id=lead_id, deleted_consultation_id=consultation_id)
 
             # Store values for use after transaction
             _lead_id = lead_id
@@ -1988,9 +1999,10 @@ async def update_consultation(
             repo = LeadRepository(db)
             consultation = await repo.get_consultation_with_status_stage(consultation.id)
 
-            # ✅ Quick Disposition: Cập nhật next_activity_at nếu scheduled_at thay đổi
-            if "scheduled_at" in update_data:
-                await update_lead_next_activity(db, lead_id)
+            # ✅ LEAD INSIGHTS UPGRADE: Update cached metrics
+            # Runs on ANY consultation update (status change, scheduled_at change, etc.)
+            from app.services import lead_cache_service
+            await lead_cache_service.update_lead_cache(db, lead_id, lead)
 
             # Store values for use after transaction
             _lead_id = lead_id

--- a/Backend_FastAPI/scripts/backfill_lead_cache.py
+++ b/Backend_FastAPI/scripts/backfill_lead_cache.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Backfill script for Lead Insights cached fields.
+
+Runs update_lead_cache for all existing leads to populate:
+- last_consultation_at
+- consultation_count
+- cached_urgency_score
+- is_hot_lead
+- is_overdue
+
+Usage:
+    cd Backend_FastAPI
+    python scripts/backfill_lead_cache.py
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlalchemy import select, func
+from app.database import AsyncSessionLocal
+from app import models
+from app.services.lead_cache_service import update_lead_cache
+
+
+async def backfill_all_leads():
+    """Backfill cached fields for all leads."""
+    async with AsyncSessionLocal() as db:
+        # Get total count
+        count_result = await db.execute(
+            select(func.count(models.Lead.id))
+            .where(models.Lead.deleted_at.is_(None))
+        )
+        total = count_result.scalar() or 0
+        print(f"📊 Total leads to backfill: {total}")
+        
+        if total == 0:
+            print("✅ No leads to backfill")
+            return
+        
+        # Get all lead IDs
+        result = await db.execute(
+            select(models.Lead.id)
+            .where(models.Lead.deleted_at.is_(None))
+            .order_by(models.Lead.id)
+        )
+        lead_ids = [row[0] for row in result.all()]
+        
+        # Process in batches
+        batch_size = 50
+        updated = 0
+        errors = 0
+        
+        for i in range(0, len(lead_ids), batch_size):
+            batch = lead_ids[i:i + batch_size]
+            
+            for lead_id in batch:
+                try:
+                    await update_lead_cache(db, lead_id)
+                    updated += 1
+                except Exception as e:
+                    print(f"❌ Error updating lead {lead_id}: {e}")
+                    errors += 1
+            
+            # Commit after each batch
+            await db.commit()
+            
+            progress = min(i + batch_size, len(lead_ids))
+            print(f"⏳ Progress: {progress}/{total} ({progress * 100 // total}%)")
+        
+        print(f"\n✅ Backfill complete!")
+        print(f"   Updated: {updated}")
+        print(f"   Errors: {errors}")
+
+
+if __name__ == "__main__":
+    print("🚀 Starting Lead Insights Cache Backfill...")
+    asyncio.run(backfill_all_leads())

--- a/Documents/lead-insights-upgrade-plan-supplement.md
+++ b/Documents/lead-insights-upgrade-plan-supplement.md
@@ -1,0 +1,109 @@
+# Phụ Lục Bổ Sung: Lead Insights Upgrade Plan
+**Trạng thái:** Critical Updates Required
+**Ngày:** 2024-12-13
+
+Tài liệu này tổng hợp các điều chỉnh **BẮT BUỘC** phải thực hiện so với bản kế hoạch gốc `lead-insights-upgrade-plan.md`, dựa trên kết quả review kiến trúc và phân tích logic.
+
+---
+
+## 1. Điều chỉnh Kiến Trúc (Architecture & Database)
+
+### 1.1. Tuân thủ Repository Pattern (Bắt buộc)
+**Vấn đề:** Plan gốc đề xuất viết query trực tiếp trong `LeadCacheService`.
+**Thay đổi:**
+- **Không** viết SQL trực tiếp trong Service.
+- Di chuyển logic query vào `LeadRepository`.
+
+```python
+# app/repositories/lead_repository.py
+async def get_consultation_stats(self, lead_id: int) -> dict:
+    """
+    Lấy thống kê tư vấn để tính cache.
+    Trả về: {last_date, count, min_scheduled_future, ...}
+    """
+    stmt = select(...)
+    # ... implementation ...
+```
+
+### 1.2. Transaction Management & Anti-Locking
+**Vấn đề:** Update Cache chạy song song hoặc tách biệt có thể gây Deadlock/Race Condition khi người dùng thao tác nhanh.
+**Thay đổi:**
+- `LeadCacheService.update_lead_cache` **PHẢI** chấp nhận `db_session` từ transaction cha (Consultation creation context).
+- **CHẠY SYNCHRONOUS TRONG TRANSACTION:** Không offload việc tính toán cache sang background task (Celery) nếu muốn UI cập nhật tức thì. Vì tính toán chỉ mất vài ms, nên chạy ngay trong transaction `add_consultation` là an toàn nhất để đảm bảo Consistency.
+
+**Flow an toàn:**
+```
+BEGIN TRANSACTION
+  1. Create Consultation
+  2. Flush (để có ID)
+  3. Call LeadCacheService.update_lead_cache(session, lead_id)
+     -> Query stats (dùng session hiện tại)
+     -> Update Lead columns
+  4. Create Log / History
+COMMIT
+```
+
+---
+
+## 2. Điều chỉnh Logic Nghiệp Vụ (Critical Logic Fixes)
+
+### 2.1. Sửa lỗi `next_activity_at` (Quan trọng)
+**Hiện trạng:** Logic hiện tại `scheduled_at >= now` đang tự động xóa các task quá hạn khỏi hệ thống, làm sai lệch đánh giá Urgency.
+
+**Logic Mới:**
+1.  **Mục tiêu:** Tìm "Hành động tiếp theo" (Next Action) chưa hoàn thành.
+2.  **Filter Condition:**
+    - `lead_id` = match
+    - `scheduled_at` IS NOT NULL
+    - `consultation_status` IN ('planned', 'confirmed')  *(Hoặc các trạng thái mang nghĩa "Chưa xong")*
+    - **TUYỆT ĐỐI KHÔNG** filter theo time (`>= now`). Task quá khứ chưa xong vẫn là Next Action (nhưng là Overdue).
+    - **TUYỆT ĐỐI KHÔNG** dùng `reminder_sent`.
+
+### 2.2. Logic `Cached Urgency Score`
+Cập nhật công thức tính based on logic `next_activity_at` mới:
+```python
+# Nếu next_activity_at nằm trong quá khứ
+days_overdue = (now - lead.next_activity_at).days if lead.next_activity_at < now else 0
+urgency_score += min(days_overdue * 5, 30)
+```
+
+### 2.3. Quy tắc Follow-up & Cadence (1-3-5-7-14)
+**Yêu cầu:** Áp dụng quy tắc "1-3-5-7-14" để gợi ý lịch chăm sóc, tránh Lead bị nguội lạnh.
+
+**Cơ chế hoạt động:**
+Khi Officer hoàn thành một Consultation (VD: Gọi điện nhưng khách không nghe), hệ thống sẽ **Tự động gợi ý** `next_activity_at` dựa trên số lần đã tương tác (`consultation_count`).
+
+| Lần tương tác (Touchpoint) | Thời gian chờ (Cadence) | Gợi ý Next Activity |
+|---------------------------|-------------------------|---------------------|
+| Mới tạo (0) | Ngay lập tức (Day 1) | `created_at` + 15 mins |
+| Lần 1 (Day 1) | +2 ngày (Day 3) | `last_consultation_at` + 2 days |
+| Lần 2 (Day 3) | +2 ngày (Day 5) | `last_consultation_at` + 2 days |
+| Lần 3 (Day 5) | +2 ngày (Day 7) | `last_consultation_at` + 2 days |
+| Lần 4 (Day 7) | +7 ngày (Day 14) | `last_consultation_at` + 7 days |
+| Sau Day 14 | +30 ngày (Nurturing) | `last_consultation_at` + 30 days |
+
+**Logic Implementation:**
+- Nếu `next_activity_at` do Officer set tay -> Ưu tiên dùng.
+- Nếu `next_activity_at` là NULL -> Hệ thống hiển thị "Gợi ý: Gọi lại vào [Ngày tính theo bảng trên]" (Soft Reminder).
+
+
+---
+
+## 3. Checklist Thực Hiện (Updated)
+
+### Phase 1: Core Logic Fixes (Ưu tiên cao nhất)
+- [ ] Refactor `LeadRepository`: Thêm phương thức `get_consultation_aggregates`.
+- [ ] Fix `update_lead_next_activity`: Loại bỏ điều kiện `>= now` và `reminder_sent`.
+- [ ] Database Migration: Thêm các cột cached (như plan gốc).
+
+### Phase 2: Service Layer
+- [ ] Implement `LeadCacheService` sử dụng `LeadRepository`.
+- [ ] Inject `LeadCacheService` vào `ConsultationService`.
+- [ ] Đảm bảo Transaction Propagation (dùng chung session).
+
+### Phase 3: UI Integration
+- [ ] Update API response schema.
+- [ ] Frontend: Hiển thị Badge Urgency.
+
+---
+**Kết luận:** Cần thực hiện **Phase 1** ngay để fix logic dữ liệu nền tảng trước khi làm UI đẹp.

--- a/Documents/lead-insights-upgrade-plan.md
+++ b/Documents/lead-insights-upgrade-plan.md
@@ -1,0 +1,458 @@
+# Kế hoạch Nâng cấp Lead Insights & Data Visualization
+
+**Ngày tạo:** 2024-12-13  
+**Phiên bản:** 2.0 (REVISED)  
+**Người tạo:** AI Assistant  
+**Cập nhật:** Đã tích hợp góp ý từ `lead-insights-upgrade-plan-supplement.md`
+
+---
+
+## 📋 Mục lục
+
+1. [Tổng quan](#1-tổng-quan)
+2. [Phân tích hiện trạng](#2-phân-tích-hiện-trạng)
+3. [Yêu cầu nâng cấp](#3-yêu-cầu-nâng-cấp)
+4. [Thiết kế kỹ thuật](#4-thiết-kế-kỹ-thuật)
+5. [Kế hoạch triển khai](#5-kế-hoạch-triển-khai)
+6. [Rủi ro và giải pháp](#6-rủi-ro-và-giải-pháp)
+
+---
+
+## 1. Tổng quan
+
+### 1.1 Mục tiêu
+Nâng cấp hệ thống Lead Insights để cung cấp các chỉ số chính xác hơn cho officer, đồng thời expose các metrics quan trọng ra DataTable giúp officer ưu tiên công việc hiệu quả.
+
+### 1.2 Phạm vi
+- **Backend:** Nâng cấp `insights_service.py`, thêm fields mới vào Lead model
+- **Frontend:** Cập nhật `LeadsTable.tsx`, `LeadDetailPanel.tsx`
+- **Database:** Migration thêm cached fields
+
+### 1.3 Kết quả mong đợi
+- Officer có thể nhanh chóng nhận biết lead nào cần ưu tiên liên hệ
+- Giảm thời gian phân tích thủ công
+- Tăng tỷ lệ follow-up đúng hạn
+
+---
+
+## 2. Phân tích hiện trạng
+
+### 2.1 Lead Insights hiện tại
+
+| Chỉ số | Cách tính | Vấn đề |
+|--------|-----------|--------|
+| **Engagement Score** | Consultation count, method, duration, inactivity | ✅ Đã tốt |
+| **Fit Score** | Source, GPA, education, location | ✅ Đã tốt |
+| **Urgency Score** | Stage order, transition speed | ⚠️ Thiếu nhiều yếu tố |
+| **Overall Score** | Weighted average | ✅ Đã tốt |
+
+### 2.2 Các yếu tố thiếu trong Urgency Score
+
+| Yếu tố | Hiện trạng | Ảnh hưởng |
+|--------|------------|-----------|
+| `next_activity_at` overdue | ❌ Chưa dùng | Không biết lead nào quá hạn |
+| Lead Score bonus | ❌ Chưa dùng | Hot lead không được ưu tiên |
+| Consultation count = 0 | ❌ Chưa dùng | Lead mới không được highlight |
+| Final stage penalty | ❌ Logic ngược | Converted lead vẫn urgent |
+
+### 2.3 ActivityIndicator hiện tại
+
+**Vấn đề:** Đang dùng `created_at` thay vì `last_consultation_at`
+
+```
+Hiện tại:  Tính từ ngày TẠO lead
+Cần đổi:   Tính từ ngày TƯ VẤN CUỐI
+```
+
+---
+
+## 3. Yêu cầu nâng cấp
+
+### 3.1 Backend Requirements
+
+#### 3.1.1 Thêm cached fields vào Lead model
+
+```python
+# app/models/lead.py - Thêm mới
+class Lead(Base):
+    # ... existing fields
+    
+    # Cached metrics (updated on consultation change)
+    last_consultation_at = Column(DateTime, nullable=True, index=True)
+    consultation_count = Column(Integer, default=0)
+    cached_urgency_score = Column(Integer, default=50)
+    
+    # Computed flags
+    is_hot_lead = Column(Boolean, default=False)  # lead_score >= 70
+    is_overdue = Column(Boolean, default=False)   # next_activity_at < now
+```
+
+#### 3.1.2 Nâng cấp Urgency Score calculation
+
+```python
+# Công thức mới
+URGENCY = (
+    30                                    # Base
+    + min(days_since_contact × 3, 45)     # Inactivity (max +45)
+    + (lead_score >= 70 ? +15 : 0)        # Hot bonus
+    + (consultation_count == 0 ? +25 : 0) # Never contacted
+    + min(overdue_days × 5, 30)           # Overdue (max +30)
+    - (is_final_stage ? -50 : 0)          # Final stage
+)
+```
+
+#### 3.1.3 Trigger update cached fields
+
+Cập nhật khi:
+- Tạo/Xóa/Sửa Consultation
+- Cập nhật `next_activity_at`
+- Cập nhật `lead_score`
+- Chuyển pipeline stage
+
+### 3.2 Frontend Requirements
+
+#### 3.2.1 DataTable columns mới
+
+| Cột | Source | Visual |
+|-----|--------|--------|
+| Urgency | `cached_urgency_score` | Color-coded badge |
+| Hot Lead | `is_hot_lead` | 🔥 icon on Lead Score |
+| Activity | `last_consultation_at` | ActivityIndicator |
+
+#### 3.2.2 Lead Insights Panel upgrade
+
+- Thêm Urgency Breakdown section
+- Thêm Priority Indicators section
+- Hiển thị Activity Metrics
+
+---
+
+## 4. Thiết kế kỹ thuật
+
+### 4.1 Database Schema Changes
+
+```sql
+-- Migration: add_lead_insights_cache_fields
+
+ALTER TABLE lead ADD COLUMN last_consultation_at TIMESTAMP WITH TIME ZONE;
+ALTER TABLE lead ADD COLUMN consultation_count INTEGER DEFAULT 0;
+ALTER TABLE lead ADD COLUMN cached_urgency_score INTEGER DEFAULT 50;
+ALTER TABLE lead ADD COLUMN is_hot_lead BOOLEAN DEFAULT FALSE;
+ALTER TABLE lead ADD COLUMN is_overdue BOOLEAN DEFAULT FALSE;
+
+-- Index for sorting/filtering
+CREATE INDEX idx_lead_urgency_score ON lead(cached_urgency_score DESC);
+CREATE INDEX idx_lead_last_consultation ON lead(last_consultation_at DESC);
+CREATE INDEX idx_lead_is_overdue ON lead(is_overdue) WHERE is_overdue = TRUE;
+```
+
+### 4.2 API Response Changes
+
+```typescript
+// types/lead.types.ts - Thêm fields
+interface Lead {
+  // ... existing fields
+  
+  // New cached metrics
+  last_consultation_at?: string | null;
+  consultation_count: number;
+  cached_urgency_score: number;
+  is_hot_lead: boolean;
+  is_overdue: boolean;
+}
+```
+
+### 4.3 Urgency Score Calculation
+
+```python
+# app/services/insights_service.py
+
+def calculate_urgency_score(
+    days_since_contact: int,
+    lead_score: int,
+    consultation_count: int,
+    overdue_days: int,
+    is_final_stage: bool
+) -> int:
+    """
+    Calculate Urgency Score (0-100)
+    
+    Components:
+    - Base: 30
+    - Inactivity: days × 3 (max 45)
+    - Hot Lead: +15 if score >= 70
+    - Never Contacted: +25 if count = 0
+    - Overdue: days × 5 (max 30)
+    - Final Stage: -50
+    """
+    score = 30  # Base
+    
+    # Inactivity penalty
+    score += min(days_since_contact * 3, 45)
+    
+    # Hot lead bonus
+    if lead_score >= 70:
+        score += 15
+    
+    # Never contacted penalty
+    if consultation_count == 0:
+        score += 25
+    
+    # Overdue penalty
+    if overdue_days > 0:
+        score += min(overdue_days * 5, 30)
+    
+    # Final stage reduction
+    if is_final_stage:
+        score -= 50
+    
+    return max(0, min(score, 100))
+```
+
+### 4.4 Cache Update Service
+
+```python
+# app/services/lead_cache_service.py
+
+async def update_lead_cache(db: AsyncSession, lead_id: int) -> None:
+    """
+    Update cached fields for a lead.
+    Called after consultation changes or scheduled updates.
+    """
+    lead = await db.get(Lead, lead_id)
+    if not lead:
+        return
+    
+    # 1. Update last_consultation_at and count
+    result = await db.execute(
+        select(
+            func.max(Consultation.consultation_date),
+            func.count(Consultation.id)
+        ).where(Consultation.lead_id == lead_id)
+    )
+    row = result.one()
+    lead.last_consultation_at = row[0]
+    lead.consultation_count = row[1] or 0
+    
+    # 2. Calculate days since contact
+    now = datetime.now(timezone.utc)
+    if lead.last_consultation_at:
+        days_since = (now - lead.last_consultation_at).days
+    else:
+        days_since = (now - lead.created_at).days
+    
+    # 3. Calculate overdue days
+    overdue_days = 0
+    if lead.next_activity_at and lead.next_activity_at < now:
+        overdue_days = (now - lead.next_activity_at).days
+    
+    # 4. Check final stage
+    is_final = False
+    if lead.pipeline_stage:
+        is_final = lead.pipeline_stage.is_final
+    
+    # 5. Calculate urgency score
+    lead.cached_urgency_score = calculate_urgency_score(
+        days_since_contact=days_since,
+        lead_score=lead.lead_score or 0,
+        consultation_count=lead.consultation_count,
+        overdue_days=overdue_days,
+        is_final_stage=is_final
+    )
+    
+    # 6. Update flags
+    lead.is_hot_lead = (lead.lead_score or 0) >= 70
+    lead.is_overdue = overdue_days > 0
+    
+    await db.commit()
+```
+
+### 4.5 Frontend Components
+
+#### UrgencyBadge Component
+
+```tsx
+// components/common/UrgencyBadge.tsx
+
+interface UrgencyBadgeProps {
+  score: number;
+  showLabel?: boolean;
+}
+
+const URGENCY_LEVELS = {
+  urgent: { min: 80, color: 'red', label: 'URGENT' },
+  high:   { min: 60, color: 'yellow', label: 'HIGH' },
+  medium: { min: 40, color: 'blue', label: 'MEDIUM' },
+  normal: { min: 20, color: 'green', label: 'NORMAL' },
+  done:   { min: 0,  color: 'gray', label: 'DONE' },
+};
+
+export function UrgencyBadge({ score, showLabel = true }: UrgencyBadgeProps) {
+  const level = getUrgencyLevel(score);
+  
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className={`h-2 w-2 rounded-full bg-${level.color}-500`} />
+      <span className={`text-xs font-medium text-${level.color}-600`}>
+        {score}
+      </span>
+      {showLabel && (
+        <span className="text-[10px] text-muted-foreground">
+          {level.label}
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+---
+
+## 5. Kế hoạch triển khai
+
+### 5.1 Timeline
+
+```
+Phase 1: Backend (2-3 giờ)
+├── Step 1.1: Database migration
+├── Step 1.2: Update Lead model
+├── Step 1.3: Create cache update service
+├── Step 1.4: Update consultation service triggers
+└── Step 1.5: Backfill existing data
+
+Phase 2: API (1 giờ)
+├── Step 2.1: Update Lead schema
+├── Step 2.2: Include new fields in responses
+└── Step 2.3: Add sorting by urgency_score
+
+Phase 3: Frontend (2-3 giờ)
+├── Step 3.1: Update Lead types
+├── Step 3.2: Create UrgencyBadge component
+├── Step 3.3: Update LeadsTable columns
+├── Step 3.4: Update ActivityIndicator
+└── Step 3.5: Upgrade Lead Insights Panel
+
+Phase 4: Testing & Deploy (1-2 giờ)
+├── Step 4.1: Unit tests
+├── Step 4.2: Integration tests
+├── Step 4.3: Manual QA
+└── Step 4.4: Deploy
+```
+
+### 5.2 Chi tiết từng bước
+
+#### Phase 1: Backend
+
+| Step | Task | File | Est. Time |
+|------|------|------|-----------|
+| 1.1 | Tạo migration | `alembic/versions/xxx_add_lead_cache_fields.py` | 15 min |
+| 1.2 | Update Lead model | `app/models/lead.py` | 15 min |
+| 1.3 | Create cache service | `app/services/lead_cache_service.py` | 45 min |
+| 1.4 | Update triggers | `app/services/consultation_service.py` | 30 min |
+| 1.5 | Backfill script | `scripts/backfill_lead_cache.py` | 30 min |
+
+#### Phase 2: API
+
+| Step | Task | File | Est. Time |
+|------|------|------|-----------|
+| 2.1 | Update schema | `app/schemas/lead.py` | 15 min |
+| 2.2 | Update response | `app/routers/leads.py` | 15 min |
+| 2.3 | Add sorting | `app/services/lead_service.py` | 30 min |
+
+#### Phase 3: Frontend
+
+| Step | Task | File | Est. Time |
+|------|------|------|-----------|
+| 3.1 | Update types | `types/lead.types.ts` | 10 min |
+| 3.2 | UrgencyBadge | `components/common/UrgencyBadge.tsx` | 30 min |
+| 3.3 | Update table | `components/leads/command-center/LeadsTable.tsx` | 45 min |
+| 3.4 | ActivityIndicator | `components/common/ActivityIndicator.tsx` | 15 min |
+| 3.5 | Insights Panel | `components/leads/command-center/LeadDetailPanel.tsx` | 45 min |
+
+#### Phase 4: Testing
+
+| Step | Task | Est. Time |
+|------|------|-----------|
+| 4.1 | Unit tests | 30 min |
+| 4.2 | Integration tests | 30 min |
+| 4.3 | Manual QA | 30 min |
+| 4.4 | Deploy | 15 min |
+
+### 5.3 Tổng thời gian ước tính
+
+| Phase | Time |
+|-------|------|
+| Phase 1: Backend | 2.5 giờ |
+| Phase 2: API | 1 giờ |
+| Phase 3: Frontend | 2.5 giờ |
+| Phase 4: Testing | 2 giờ |
+| **TOTAL** | **~8 giờ** |
+
+---
+
+## 6. Rủi ro và giải pháp
+
+### 6.1 Rủi ro kỹ thuật
+
+| Rủi ro | Xác suất | Ảnh hưởng | Giải pháp |
+|--------|----------|-----------|-----------|
+| Migration fail | Thấp | Cao | Backup DB trước, test staging |
+| Cache không đồng bộ | Trung bình | Trung bình | Cron job recalculate hàng đêm |
+| Performance chậm | Thấp | Cao | Index đúng, lazy load |
+
+### 6.2 Rủi ro kinh doanh
+
+| Rủi ro | Giải pháp |
+|--------|-----------|
+| Officer không hiểu Urgency Score | Training + tooltips giải thích |
+| Công thức không phù hợp thực tế | Config trọng số có thể chỉnh |
+
+### 6.3 Kế hoạch rollback
+
+```
+1. Nếu migration fail:
+   → alembic downgrade -1
+
+2. Nếu cache không chính xác:
+   → Chạy lại backfill script
+
+3. Nếu frontend lỗi:
+   → Revert git commit, redeploy
+```
+
+---
+
+## 📎 Phụ lục
+
+### A. Urgency Score Lookup Table
+
+| Days Since | Score = 50 | Score = 70 | Score = 80 |
+|------------|------------|------------|------------|
+| 0 ngày | 30 | 45 | 55 |
+| 3 ngày | 39 | 54 | 64 |
+| 7 ngày | 51 | 66 | 76 |
+| 14 ngày | 72 | 87 | 97 |
+
+### B. Files cần thay đổi
+
+**Backend:**
+- `app/models/lead.py`
+- `app/schemas/lead.py`
+- `app/services/insights_service.py`
+- `app/services/lead_cache_service.py` (NEW)
+- `app/services/consultation_service.py`
+- `app/routers/leads.py`
+- `alembic/versions/xxx_add_lead_cache_fields.py` (NEW)
+
+**Frontend:**
+- `src/types/lead.types.ts`
+- `src/components/common/UrgencyBadge.tsx` (NEW)
+- `src/components/common/ActivityIndicator.tsx`
+- `src/components/leads/command-center/LeadsTable.tsx`
+- `src/components/leads/command-center/LeadDetailPanel.tsx`
+- `src/components/leads/command-center/TableToolbar.tsx`
+
+---
+
+**Người phê duyệt:** ________________  
+**Ngày phê duyệt:** ________________

--- a/Documents/lead-insights-upgrade-review.md
+++ b/Documents/lead-insights-upgrade-review.md
@@ -1,0 +1,72 @@
+# Nhận Định & Đánh Giá: Kế Hoạch Nâng Cấp Lead Insights
+
+**Ngày đánh giá:** 2024-12-13  
+**Người đánh giá:** AI Assistant (Antigravity)  
+**Tài liệu tham chiếu:** `Documents/lead-insights-upgrade-plan.md`
+
+---
+
+## 1. Tổng Quan
+Bản kế hoạch **Lead Insights Upgrade** được xây dựng rất bài bản, giải quyết đúng "nỗi đau" của người dùng (Officer) là thiếu thông tin định lượng để ưu tiên công việc.
+
+Giải pháp kỹ thuật đề xuất sử dụng chiến lược **Caching (Denormalization)** là hoàn toàn chính xác. Việc tính toán `Urgency Score` hay `Engagement Score` realtime mỗi khi load danh sách Lead (với hàng nghìn records) sẽ gây overload database. Việc lưu cache kết quả vào bảng `Lead` giúp việc sort/filter trở nên cực nhanh.
+
+## 2. Điểm Mạnh
+- **Chiến lược tối ưu hiệu năng:** Sử dụng cột `cached_...` giúp giảm tải query phức tạp khi xem danh sách.
+- **Tính thực tế cao:** Các metric như `days_since_contact` hay `overdue` phản ánh đúng nhu cầu quản lý.
+- **Backfill Strategy:** Có plan cho việc migrate dữ liệu cũ (Phase 1.5).
+- **Frontend/Backend đồng bộ:** Xác định rõ thay đổi ở cả API và UI.
+
+## 3. Các Vấn Đề Cần Lưu Ý (Critical Review)
+
+### 3.1. Tuân thủ Kiến trúc (Architecture Compliance)
+*Vấn đề:* Trong mục **4.4 Cache Update Service**, code mẫu đang sử dụng trực tiếp `db.execute(select(...))` để query dữ liệu Consultation.
+*Đánh giá:* Điều này vi phạm quy tắc **Repository Pattern** mà dự án đang hướng tới (đã refactor `LeadService`, `AdmissionService`...).
+*Khuyến nghị:*
+- Logic truy vấn database (Aggregate count, Max date...) cần được đưa vào `LeadRepository` hoặc `ConsultationRepository`.
+- `LeadCacheService` chỉ nên gọi Repository để lấy số liệu, sau đó thực hiện logic tính toán business.
+
+**Ví dụ refactor:**
+```python
+# Trong LeadRepository
+async def get_consultation_stats(self, lead_id: int):
+    stmt = select(...)
+    result = await self.session.execute(stmt)
+    return result.one()
+    
+# Trong LeadCacheService
+stats = await lead_repo.get_consultation_stats(lead_id)
+lead.last_consultation_at = stats.last_date
+```
+
+### 3.2. Quản lý Transaction & Race Conditions
+*Vấn đề:* Việc cập nhật cache xảy ra khi "Tạo/Sửa Consultation". Nếu không cẩn thận, việc update Lead trong khi đang update Consultation có thể gây lock hoặc conflict nếu không dùng chung session.
+*Khuyến nghị:*
+- Đảm bảo `update_lead_cache` nhận vào `db_session` hiện tại của transaction đang xử lý Consultation đó.
+- Code mẫu hiện tại `async def update_lead_cache(db: AsyncSession, ...)` là đúng hướng, cần đảm bảo nó được gọi **trước khi commit** transaction chính của `add_consultation` hoặc `update_consultation`.
+
+### 3.3. Urgency Score Logic
+*Vấn đề:* Công thức `days_since_contact` đang tính `now - last_consultation_at`.
+- Nếu officer vừa log consultation xong -> `days_since = 0`.
+- Tuy nhiên, một số loại consultation (như "Gọi điện - Không nghe máy") có thể không nên reset "tính khẩn cấp" hoàn toàn về 0 như "Gặp mặt trực tiếp".
+*Khuyến nghị:* (Optional) Cân nhắc trọng số reset dựa trên `consultation_result`. Tuy nhiên, để giữ đơn giản cho version 1, logic hiện tại là chấp nhận được.
+
+### 3.4. Trigger Update
+*Vấn đề:* Plan liệt kê các trigger:
+- *Cập nhật `next_activity_at`*: Cần hook vào `LeadService.update_lead`.
+- *Cập nhật `lead_score`*: Cần hook vào `Service` tính lead score.
+*Khuyến nghị:* Sử dụng một hàm wrapper hoặc Event Listener (SQLAlchemy Events) để đảm bảo không bỏ sót case nào. Tuy nhiên, gọi explicit trong Service method (như cách hiện tại) dễ debug hơn.
+
+## 4. Kết luận & Đề xuất hành động
+
+**Trạng thái:** ✅ **SẴN SÀNG TRIỂN KHAI** (với điều chỉnh nhỏ về Repository).
+
+**Các bước điều chỉnh plan:**
+1.  **Refactor Design 4.4:** Chuyển query SQL vào `LeadRepository`.
+2.  **Implementation:**
+    - Tạo migration thêm cột.
+    - Implement `LeadRepository` methods.
+    - Implement `LeadCacheService` (business logic).
+    - Inject service này vào `ConsultationService` và `LeadService`.
+
+Bạn có muốn tôi bắt đầu thực hiện **Phase 1: Backend** (Tạo migration và update Model) ngay bây giờ không?

--- a/Documents/next-activity-logic-analysis.md
+++ b/Documents/next-activity-logic-analysis.md
@@ -1,0 +1,51 @@
+# Phân Tích Sâu: Trường `next_activity_at`
+
+Dựa trên yêu cầu của bạn, tôi đã kiểm tra lại source code (cụ thể là hàm `update_lead_next_activity` trong `lead_service.py`) và phát hiện ra một số vấn đề quan trọng về cách trường này đang hoạt động. Nhận định của bạn là chính xác, và đánh giá trong kế hoạch cần được điều chỉnh.
+
+## 1. Cơ chế hiện tại của `next_activity_at`
+
+Hiện tại, giá trị này được cập nhật tự động mỗi khi Consultation thay đổi.
+**Logic Code (`lead_service.py`):**
+```python
+stmt = (
+    select(func.min(models.Consultation.scheduled_at))
+    .where(
+        and_(
+            models.Consultation.lead_id == lead_id,
+            models.Consultation.scheduled_at.isnot(None),
+            models.Consultation.scheduled_at >= now,  # <--- VẤN ĐỀ NẰM Ở ĐÂY
+            models.Consultation.reminder_sent == False,
+        )
+    )
+)
+```
+
+## 2. Các vấn đề phát hiện
+
+### Vấn đề 1: Tự động "ẩn" các task quá hạn (Critical)
+Dòng code `models.Consultation.scheduled_at >= now` đồng nghĩa với việc hệ thống **chỉ quan tâm đến tương lai**.
+- **Kịch bản:** Bạn có một lịch hẹn vào 9:00 sáng hôm qua (quá hạn). Lead chưa có lịch mới.
+- **Hành vi:**
+    - Nếu không ai đụng vào Lead: `next_activity_at` vẫn là 9:00 hôm qua (Hiển thị Overdue đúng).
+    - **NHƯNG**, nếu Officer vào sửa SĐT hoặc Email của Lead (trigger update): Hệ thống chạy lại hàm trên -> Thấy lịch 9:00 hôm qua < `now` -> Loại bỏ -> `next_activity_at` trở thành `NULL`.
+    => **Lead bị mất dấu hiệu Overdue chỉ vì Officer cập nhật thông tin khác.**
+
+### Vấn đề 2: Dựa vào `reminder_sent` thay vì trạng thái task
+Query đang dùng `reminder_sent == False` để xác định task "còn hiệu lực". Điều này rủi ro vì:
+- Reminder thường được gửi bởi Cronjob trước giờ hẹn (VD: trước 15p).
+- Nếu Reminder đã gửi -> `reminder_sent = True` -> Task bị loại khỏi việc tính `next_activity_at` ngay cả khi giờ hẹn chưa đến hoặc Officer chưa thực hiện.
+
+### Vấn đề 3: Chưa được dùng trong Urgency Score (Đúng như Plan nhận định)
+Mặc dù `next_activity_at` tồn tại, nhưng file `insights_service.py` hiện tại hoàn toàn **không đọc** giá trị này để tính điểm khẩn cấp. Do đó, một Lead bị trễ hẹn 5 ngày vẫn có điểm Urgency thấp.
+
+## 3. Kết luận & Đề xuất điều chỉnh Plan
+
+Trong bản kế hoạch nâng cấp, cần bổ sung task: **Fix logic tính toán `next_activity_at` trước, sau đó mới dùng nó để tính điểm.**
+
+**Logic đề xuất (Cần update vào `lead_service.py`):**
+1. Tìm `scheduled_at` nhỏ nhất.
+2. Điều kiện: Trạng thái Consultation **chưa hoàn thành** (VD: status thuộc nhóm "Pending/Scheduled").
+3. **BỎ điều kiện** `scheduled_at >= now` (Để chấp nhận cả task quá hạn).
+4. **BỎ điều kiện** `reminder_sent` (Vì không liên quan đến việc task hoàn thành hay chưa).
+
+Khi logic này đúng, cột `is_overdue` trong Plan mới hoạt động chính xác được.

--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
@@ -173,7 +173,7 @@ export function LeadDetailClient({ leadId, initialData }: LeadDetailClientProps)
         <div className="flex-1 overflow-y-auto">
           <div className="p-6 space-y-4">
             {/* AI Insights - Compact Bar */}
-            <LeadInsightsTab leadId={leadId} insights={insights} />
+            <LeadInsightsTab leadId={leadId} insights={insights} lead={lead} />
 
             {/* 2-column: Timeline (left) + Quick Consultation (right) */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadSidebar.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadSidebar.tsx
@@ -293,16 +293,16 @@ export function LeadSidebar({ lead, timeline, onAssign, hideHeader }: LeadSideba
           <div className="bg-background rounded-md p-2 border">
             <div className="flex items-center gap-1 text-muted-foreground mb-0.5">
               <Clock className="h-3 w-3" />
-              <span className="text-[10px]">Thời gian</span>
+              <span className="text-[10px]">Trong pipeline</span>
             </div>
             <div className="font-semibold text-sm">{daysInPipeline} ngày</div>
           </div>
           <div className="bg-background rounded-md p-2 border">
             <div className="flex items-center gap-1 text-muted-foreground mb-0.5">
               <History className="h-3 w-3" />
-              <span className="text-[10px]">Hoạt động</span>
+              <span className="text-[10px]">Số lần tư vấn</span>
             </div>
-            <div className="font-semibold text-sm">{timeline?.length || 0}</div>
+            <div className="font-semibold text-sm">{lead.consultation_count}</div>
           </div>
         </div>
 

--- a/frontend/src/components/common/ActivityIndicator.tsx
+++ b/frontend/src/components/common/ActivityIndicator.tsx
@@ -1,0 +1,264 @@
+// src/components/common/ActivityIndicator.tsx
+/**
+ * ActivityIndicator - Visual indicator for lead activity and urgency
+ * 
+ * Features:
+ * - Relative time display ("2 ngày trước" instead of date)
+ * - Activity status via colored text (active/warm/cold/frozen)
+ * - Small dot indicator
+ * - All details in tooltip (clean UI)
+ */
+
+"use client";
+
+import React, { useMemo } from "react";
+import { differenceInDays, differenceInHours, isPast, isToday, format } from "date-fns";
+import { vi } from "date-fns/locale";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export type ActivityLevel = "hot" | "active" | "warm" | "cold" | "frozen";
+
+interface ActivityIndicatorProps {
+  /** Date to calculate activity from (usually created_at or last consultation) */
+  date: string | null | undefined;
+  /** Optional next activity date (for follow-up reminders) */
+  nextActivityAt?: string | null;
+  /** Number of days to consider "cold" */
+  coldThresholdDays?: number;
+  /** Number of days to consider "frozen" */
+  frozenThresholdDays?: number;
+  /** Additional class names */
+  className?: string;
+}
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const ACTIVITY_CONFIG: Record<ActivityLevel, { 
+  textColor: string; 
+  dotColor: string;
+  label: string;
+}> = {
+  hot: {
+    textColor: "text-red-600 dark:text-red-400",
+    dotColor: "bg-red-500",
+    label: "Nóng",
+  },
+  active: {
+    textColor: "text-green-600 dark:text-green-400",
+    dotColor: "bg-green-500",
+    label: "Hoạt động",
+  },
+  warm: {
+    textColor: "text-blue-600 dark:text-blue-400",
+    dotColor: "bg-blue-500",
+    label: "Ấm",
+  },
+  cold: {
+    textColor: "text-yellow-600 dark:text-yellow-400",
+    dotColor: "bg-yellow-500",
+    label: "Lạnh",
+  },
+  frozen: {
+    textColor: "text-muted-foreground",
+    dotColor: "bg-gray-400",
+    label: "Đóng băng",
+  },
+};
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+function getActivityLevel(
+  daysSinceActivity: number,
+  coldThreshold: number = 7,
+  frozenThreshold: number = 14
+): ActivityLevel {
+  if (daysSinceActivity <= 1) return "active";
+  if (daysSinceActivity <= 3) return "warm";
+  if (daysSinceActivity <= coldThreshold) return "cold";
+  if (daysSinceActivity <= frozenThreshold) return "cold";
+  return "frozen";
+}
+
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const hoursDiff = differenceInHours(now, date);
+  const daysDiff = differenceInDays(now, date);
+  
+  if (hoursDiff < 1) return "Vừa xong";
+  if (hoursDiff < 24) return `${hoursDiff}h trước`;
+  if (daysDiff === 1) return "Hôm qua";
+  if (daysDiff < 7) return `${daysDiff} ngày`;
+  if (daysDiff < 14) return "1 tuần";
+  if (daysDiff < 30) return `${Math.floor(daysDiff / 7)} tuần`;
+  if (daysDiff < 60) return "1 tháng";
+  return `${Math.floor(daysDiff / 30)} tháng`;
+}
+
+// =============================================================================
+// MAIN COMPONENT
+// =============================================================================
+
+export function ActivityIndicator({
+  date,
+  nextActivityAt,
+  coldThresholdDays = 7,
+  frozenThresholdDays = 14,
+  className,
+}: ActivityIndicatorProps) {
+  const activityInfo = useMemo(() => {
+    if (!date) return null;
+    
+    const dateObj = new Date(date);
+    const now = new Date();
+    const daysSince = differenceInDays(now, dateObj);
+    const level = getActivityLevel(daysSince, coldThresholdDays, frozenThresholdDays);
+    const config = ACTIVITY_CONFIG[level];
+    const relativeTime = formatRelativeTime(dateObj);
+    const exactDate = format(dateObj, "dd/MM/yyyy HH:mm", { locale: vi });
+    
+    return {
+      level,
+      config,
+      relativeTime,
+      daysSince,
+      exactDate,
+    };
+  }, [date, coldThresholdDays, frozenThresholdDays]);
+
+  const followUpInfo = useMemo(() => {
+    if (!nextActivityAt) return null;
+    
+    const nextDate = new Date(nextActivityAt);
+    const now = new Date();
+    const isPastDue = isPast(nextDate) && !isToday(nextDate);
+    const isDueToday = isToday(nextDate);
+    const exactDate = format(nextDate, "dd/MM/yyyy HH:mm", { locale: vi });
+    
+    return {
+      isPastDue,
+      isDueToday,
+      exactDate,
+      status: isPastDue ? "Quá hạn" : isDueToday ? "Hôm nay" : "Đã lên lịch",
+    };
+  }, [nextActivityAt]);
+
+  if (!activityInfo) {
+    return <span className="text-muted-foreground text-xs">—</span>;
+  }
+
+  const { config, relativeTime, level, exactDate, daysSince } = activityInfo;
+  
+  // Determine if we should show a pulse animation (for urgent items)
+  const showPulse = followUpInfo?.isPastDue || followUpInfo?.isDueToday;
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className={cn(
+            "inline-flex items-center gap-1.5 cursor-default",
+            className
+          )}>
+            {/* Single dot - colored based on activity level */}
+            <div
+              className={cn(
+                "h-2 w-2 rounded-full shrink-0",
+                config.dotColor,
+                showPulse && "animate-pulse"
+              )}
+            />
+            
+            {/* Relative time - colored text */}
+            <span className={cn(
+              "text-xs tabular-nums whitespace-nowrap",
+              config.textColor
+            )}>
+              {relativeTime}
+            </span>
+          </div>
+        </TooltipTrigger>
+        
+        {/* Tooltip with all details */}
+        <TooltipContent side="top" className="text-xs space-y-1 max-w-[200px]">
+          <div className="font-medium">{config.label}</div>
+          <div className="text-muted-foreground">
+            Tạo: {exactDate}
+          </div>
+          <div className="text-muted-foreground">
+            ({daysSince} ngày trước)
+          </div>
+          
+          {/* Follow-up info in tooltip */}
+          {followUpInfo && (
+            <div className={cn(
+              "pt-1 border-t mt-1",
+              followUpInfo.isPastDue ? "text-red-500" : 
+              followUpInfo.isDueToday ? "text-orange-500" : 
+              "text-blue-500"
+            )}>
+              📅 {followUpInfo.status}: {followUpInfo.exactDate}
+            </div>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+// =============================================================================
+// SIMPLE DOT COMPONENT (for ultra-compact display)
+// =============================================================================
+
+interface ActivityDotProps {
+  date: string | null | undefined;
+  coldThresholdDays?: number;
+  frozenThresholdDays?: number;
+  className?: string;
+}
+
+export function ActivityDot({
+  date,
+  coldThresholdDays = 7,
+  frozenThresholdDays = 14,
+  className,
+}: ActivityDotProps) {
+  if (!date) return null;
+  
+  const dateObj = new Date(date);
+  const daysSince = differenceInDays(new Date(), dateObj);
+  const level = getActivityLevel(daysSince, coldThresholdDays, frozenThresholdDays);
+  const config = ACTIVITY_CONFIG[level];
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className={cn(
+            "h-2 w-2 rounded-full shrink-0",
+            config.dotColor,
+            className
+          )} />
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs">
+          {config.label} • {daysSince} ngày trước
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export default ActivityIndicator;

--- a/frontend/src/components/common/UrgencyBadge.tsx
+++ b/frontend/src/components/common/UrgencyBadge.tsx
@@ -1,0 +1,188 @@
+// src/components/common/UrgencyBadge.tsx
+/**
+ * UrgencyBadge - Visual indicator for lead urgency score
+ * 
+ * Urgency Levels:
+ * - URGENT (75-100): Red - Needs immediate attention
+ * - HIGH (50-74): Orange - Should act soon
+ * - MEDIUM (30-49): Yellow - Normal priority
+ * - NORMAL (10-29): Green - Low priority
+ * - DONE (0-9): Gray - Completed/Final stage
+ */
+
+"use client";
+
+import React, { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { CircleAlert, AlertCircle, Circle, CircleDot, CircleCheck } from "lucide-react";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export type UrgencyLevel = "urgent" | "high" | "medium" | "normal" | "done";
+
+interface UrgencyBadgeProps {
+  /** Urgency score 0-100 */
+  score: number;
+  /** Show label alongside badge */
+  showLabel?: boolean;
+  /** Compact mode (just dot) */
+  compact?: boolean;
+  /** Additional class names */
+  className?: string;
+}
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const URGENCY_CONFIG: Record<UrgencyLevel, {
+  label: string;
+  bgColor: string;
+  textColor: string;
+  dotColor: string;
+  icon: React.ElementType;
+  description: string;
+}> = {
+  urgent: {
+    label: "Khẩn cấp",
+    bgColor: "bg-red-100 dark:bg-red-900/30",
+    textColor: "text-red-700 dark:text-red-400",
+    dotColor: "bg-red-500",
+    icon: CircleAlert,
+    description: "Cần hành động ngay",
+  },
+  high: {
+    label: "Cao",
+    bgColor: "bg-orange-100 dark:bg-orange-900/30",
+    textColor: "text-orange-700 dark:text-orange-400",
+    dotColor: "bg-orange-500",
+    icon: AlertCircle,
+    description: "Nên xử lý sớm",
+  },
+  medium: {
+    label: "Trung bình",
+    bgColor: "bg-yellow-100 dark:bg-yellow-900/30",
+    textColor: "text-yellow-700 dark:text-yellow-400",
+    dotColor: "bg-yellow-500",
+    icon: Circle,
+    description: "Ưu tiên bình thường",
+  },
+  normal: {
+    label: "Thấp",
+    bgColor: "bg-green-100 dark:bg-green-900/30",
+    textColor: "text-green-700 dark:text-green-400",
+    dotColor: "bg-green-500",
+    icon: CircleDot,
+    description: "Không gấp",
+  },
+  done: {
+    label: "Xong",
+    bgColor: "bg-gray-100 dark:bg-gray-800",
+    textColor: "text-gray-600 dark:text-gray-400",
+    dotColor: "bg-gray-400",
+    icon: CircleCheck,
+    description: "Đã hoàn thành",
+  },
+};
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+export function getUrgencyLevel(score: number): UrgencyLevel {
+  if (score >= 75) return "urgent";
+  if (score >= 50) return "high";
+  if (score >= 30) return "medium";
+  if (score >= 10) return "normal";
+  return "done";
+}
+
+// =============================================================================
+// MAIN COMPONENT
+// =============================================================================
+
+export function UrgencyBadge({
+  score,
+  showLabel = true,
+  compact = false,
+  className,
+}: UrgencyBadgeProps) {
+  const urgencyInfo = useMemo(() => {
+    const level = getUrgencyLevel(score);
+    const config = URGENCY_CONFIG[level];
+    return { level, config };
+  }, [score]);
+
+  const { config } = urgencyInfo;
+  const Icon = config.icon;
+
+  // Compact mode: just a colored dot
+  if (compact) {
+    return (
+      <TooltipProvider delayDuration={200}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className={cn(
+                "h-2.5 w-2.5 rounded-full shrink-0",
+                config.dotColor,
+                className
+              )}
+            />
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            <div className="font-medium">{config.label}</div>
+            <div className="text-muted-foreground">Điểm: {score}</div>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  // Full badge with optional label
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className={cn(
+              "inline-flex items-center gap-1 text-xs",
+              config.textColor,
+              className
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {showLabel && <span>{config.label}</span>}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="text-xs space-y-1">
+          <div className="font-medium">{config.label} ({score})</div>
+          <div className="text-muted-foreground">{config.description}</div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+// =============================================================================
+// URGENCY DOT (Ultra-compact)
+// =============================================================================
+
+interface UrgencyDotProps {
+  score: number;
+  className?: string;
+}
+
+export function UrgencyDot({ score, className }: UrgencyDotProps) {
+  return <UrgencyBadge score={score} compact className={className} />;
+}
+
+export default UrgencyBadge;

--- a/frontend/src/components/leads/InsightsHelperDrawer.tsx
+++ b/frontend/src/components/leads/InsightsHelperDrawer.tsx
@@ -1,0 +1,274 @@
+// src/components/leads/InsightsHelperDrawer.tsx
+/**
+ * InsightsHelperDrawer - Hướng dẫn chi tiết về Lead Insights
+ * Drawer slide từ bên phải để officers có thể xem song song với data
+ */
+"use client";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { HelpCircle, Sparkles, Users, Target, Clock, Star, Lightbulb } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface InsightsHelperDrawerProps {
+  trigger?: React.ReactNode;
+}
+
+const INSIGHTS_DOCS = [
+  {
+    id: "overall",
+    label: "Điểm tổng hợp",
+    icon: Sparkles,
+    color: "text-violet-600",
+    bgColor: "bg-violet-100",
+    summary: "Chỉ số đánh giá tổng thể tiềm năng chuyển đổi của lead, kết hợp tất cả các yếu tố.",
+    interpretation: {
+      high: { range: "≥70", meaning: "Lead rất tiềm năng - ưu tiên chăm sóc hàng đầu" },
+      medium: { range: "50-69", meaning: "Lead có tiềm năng - cần theo dõi thường xuyên" },
+      low: { range: "<50", meaning: "Lead cần được chăm sóc thêm" },
+    },
+    formula: "= (Tương tác × 30%) + (Phù hợp × 40%) + (Khẩn cấp × 20%) + (Đánh giá × 10%)",
+    tips: [
+      "Tăng tần suất tư vấn và ghi nhận kết quả đầy đủ",
+      "Đánh giá lead dựa trên trải nghiệm tư vấn thực tế",
+      "Cập nhật thông tin lead (học vấn, GPA) để điểm Phù hợp chính xác hơn",
+    ],
+  },
+  {
+    id: "engagement",
+    label: "Mức độ tương tác",
+    icon: Users,
+    color: "text-blue-600",
+    bgColor: "bg-blue-100",
+    summary: "Đo lường mức độ chăm sóc lead thông qua lịch sử tư vấn và kết quả liên hệ.",
+    interpretation: {
+      high: { range: "≥70", meaning: "Lead được chăm sóc tốt, tương tác đều đặn" },
+      medium: { range: "50-69", meaning: "Lead cần được liên hệ thường xuyên hơn" },
+      low: { range: "<50", meaning: "Lead chưa được chăm sóc đầy đủ" },
+    },
+    formula: "Tính từ lịch sử tư vấn",
+    details: [
+      { label: "Mỗi lần tư vấn", points: "+5" },
+      { label: "Kết quả: Thành công", points: "+10" },
+      { label: "Kết quả: Cần theo dõi", points: "+5" },
+      { label: "Kết quả: Thất bại", points: "-5" },
+      { label: "Gặp mặt trực tiếp", points: "+15" },
+      { label: "Gọi điện", points: "+5" },
+      { label: "Email", points: "+2" },
+      { label: "Không liên hệ >3 ngày", points: "-1/ngày" },
+    ],
+    tips: [
+      "Liên hệ lead ít nhất 2-3 lần/tuần để giữ điểm tương tác",
+      "Ưu tiên gặp mặt trực tiếp hoặc gọi điện thay vì email",
+      "Ghi nhận kết quả tư vấn ngay sau mỗi cuộc gọi",
+    ],
+  },
+  {
+    id: "fit",
+    label: "Độ phù hợp",
+    icon: Target,
+    color: "text-green-600",
+    bgColor: "bg-green-100",
+    summary: "Đánh giá mức độ phù hợp của lead với chương trình, kết hợp dữ liệu hồ sơ và đánh giá chủ quan của bạn.",
+    interpretation: {
+      high: { range: "≥70", meaning: "Rất phù hợp - khả năng chuyển đổi cao" },
+      medium: { range: "50-69", meaning: "Phù hợp một phần - cần tìm hiểu thêm nhu cầu" },
+      low: { range: "<50", meaning: "Ít phù hợp hoặc chưa được đánh giá" },
+    },
+    formula: "= Điểm lead + (Đánh giá của bạn × 4)",
+    details: [
+      { label: "Điểm lead (tự động)", points: "0-100" },
+      { label: "Đánh giá 1 sao ⭐", points: "+4" },
+      { label: "Đánh giá 2 sao ⭐⭐", points: "+8" },
+      { label: "Đánh giá 3 sao ⭐⭐⭐", points: "+12" },
+      { label: "Đánh giá 4 sao ⭐⭐⭐⭐", points: "+16" },
+      { label: "Đánh giá 5 sao ⭐⭐⭐⭐⭐", points: "+20" },
+    ],
+    tips: [
+      "Đánh giá sao dựa trên: khả năng tài chính, động lực học tập, thái độ hợp tác",
+      "Cập nhật đánh giá sau mỗi buổi tư vấn để phản ánh đúng tiềm năng",
+      "Bổ sung thông tin học vấn, GPA để điểm lead tự động tăng",
+    ],
+  },
+  {
+    id: "urgency",
+    label: "Mức độ khẩn cấp",
+    icon: Clock,
+    color: "text-orange-600",
+    bgColor: "bg-orange-100",
+    // Urgency: màu ngược - cao = đỏ cảnh báo, thấp = xanh an toàn
+    isReversedColors: true,
+    summary: "Cho biết lead này có cần được liên hệ ngay không. Điểm càng cao = càng cần ưu tiên.",
+    interpretation: {
+      high: { range: "≥70", meaning: "CẦN LIÊN HỆ NGAY! Lead đang \"nóng\"" },
+      medium: { range: "50-69", meaning: "Nên liên hệ trong 1-2 ngày tới" },
+      low: { range: "<50", meaning: "Có thể theo lịch bình thường" },
+    },
+    formula: "Tính từ trạng thái lead",
+    details: [
+      { label: "Chưa liên hệ theo lịch hẹn", points: "+30" },
+      { label: "Chưa từng được tư vấn", points: "+25" },
+      { label: "Lead nóng (điểm ≥70)", points: "+15" },
+      { label: "Có lịch hẹn trong 24h tới", points: "+20" },
+      { label: "Mỗi ngày không liên hệ", points: "+3/ngày" },
+      { label: "Lead đã chuyển đổi/thất bại", points: "-50" },
+    ],
+    tips: [
+      "Liên hệ ngay các lead có điểm Khẩn cấp ≥70",
+      "Đặt lịch hẹn rõ ràng và tuân thủ để tránh bị cộng điểm quá hạn",
+      "Lead mới chưa từng tư vấn nên được liên hệ trong 24h đầu tiên",
+    ],
+  },
+  {
+    id: "rating",
+    label: "Đánh giá của bạn",
+    icon: Star,
+    color: "text-amber-600",
+    bgColor: "bg-amber-100",
+    summary: "Đánh giá chủ quan từ trải nghiệm tư vấn thực tế của bạn với lead này.",
+    interpretation: {
+      high: { range: "4-5 ⭐", meaning: "Lead rất tiềm năng theo kinh nghiệm của bạn" },
+      medium: { range: "3 ⭐", meaning: "Lead bình thường, cần theo dõi thêm" },
+      low: { range: "1-2 ⭐", meaning: "Lead khó chuyển đổi" },
+    },
+    formula: "Ảnh hưởng trực tiếp đến Độ phù hợp và Điểm tổng hợp",
+    details: [
+      { label: "Tác động lên Phù hợp", points: "sao × 4" },
+      { label: "Tác động lên Tổng hợp", points: "sao × 2" },
+    ],
+    tips: [
+      "Đánh giá dựa trên: sự quan tâm, khả năng tài chính, thời gian quyết định",
+      "Không ngại đánh giá thấp nếu lead thực sự khó - giúp ưu tiên đúng",
+      "Cập nhật đánh giá thường xuyên khi có thông tin mới",
+    ],
+  },
+];
+
+export function InsightsHelperDrawer({ trigger }: InsightsHelperDrawerProps) {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        {trigger || (
+          <Button variant="ghost" size="sm" className="gap-1.5 text-xs text-muted-foreground hover:text-primary">
+            <HelpCircle className="h-3.5 w-3.5" />
+            Cách tính điểm
+          </Button>
+        )}
+      </SheetTrigger>
+      <SheetContent side="right" className="w-[420px] sm:w-[520px] overflow-y-auto">
+        <SheetHeader className="mb-6">
+          <SheetTitle className="flex items-center gap-2 text-lg">
+            <HelpCircle className="h-5 w-5 text-primary" />
+            Hướng dẫn Lead Insights
+          </SheetTitle>
+          <p className="text-sm text-muted-foreground mt-1">
+            Hiểu rõ các chỉ số để chăm sóc lead hiệu quả hơn
+          </p>
+        </SheetHeader>
+
+        <div className="space-y-5">
+          {INSIGHTS_DOCS.map((doc) => (
+            <div key={doc.id} className="border rounded-lg overflow-hidden">
+              {/* Header */}
+              <div className={cn("flex items-center gap-2 px-4 py-3", doc.bgColor)}>
+                <doc.icon className={cn("h-5 w-5", doc.color)} />
+                <h3 className="font-semibold">{doc.label}</h3>
+              </div>
+
+              <div className="p-4 space-y-4">
+                {/* Mô tả */}
+                <p className="text-sm text-muted-foreground">{doc.summary}</p>
+
+                {/* Ý nghĩa điểm số */}
+                <div className="bg-muted/40 rounded-lg p-3">
+                  <p className="text-xs font-medium text-muted-foreground uppercase mb-2">
+                    Ý nghĩa điểm số
+                  </p>
+                  <div className="space-y-1.5 text-sm">
+                    <div className="flex items-start gap-2">
+                      <span className={cn(
+                        "font-semibold min-w-[50px]",
+                        doc.isReversedColors ? "text-red-600" : "text-green-600"
+                      )}>{doc.interpretation.high.range}</span>
+                      <span className="text-muted-foreground">{doc.interpretation.high.meaning}</span>
+                    </div>
+                    <div className="flex items-start gap-2">
+                      <span className="text-yellow-600 font-semibold min-w-[50px]">{doc.interpretation.medium.range}</span>
+                      <span className="text-muted-foreground">{doc.interpretation.medium.meaning}</span>
+                    </div>
+                    <div className="flex items-start gap-2">
+                      <span className={cn(
+                        "font-semibold min-w-[50px]",
+                        doc.isReversedColors ? "text-green-600" : "text-gray-500"
+                      )}>{doc.interpretation.low.range}</span>
+                      <span className="text-muted-foreground">{doc.interpretation.low.meaning}</span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Công thức */}
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground uppercase mb-1.5">Công thức</p>
+                  <code className="block bg-muted px-3 py-2 rounded text-sm font-mono text-primary">
+                    {doc.formula}
+                  </code>
+                </div>
+
+                {/* Chi tiết điểm */}
+                {doc.details && (
+                  <div>
+                    <p className="text-xs font-medium text-muted-foreground uppercase mb-1.5">Chi tiết cộng/trừ điểm</p>
+                    <div className="grid grid-cols-2 gap-1.5">
+                      {doc.details.map((item, idx) => (
+                        <div key={idx} className="flex justify-between bg-muted/30 px-2.5 py-1.5 rounded text-xs">
+                          <span className="text-muted-foreground">{item.label}</span>
+                          <span className={cn(
+                            "font-semibold",
+                            item.points.startsWith("-") ? "text-red-500" : "text-primary"
+                          )}>{item.points}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Mẹo tăng điểm */}
+                {doc.tips && (
+                  <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+                    <div className="flex items-center gap-1.5 mb-2">
+                      <Lightbulb className="h-4 w-4 text-amber-600" />
+                      <p className="text-xs font-semibold text-amber-700 uppercase">Mẹo tăng điểm</p>
+                    </div>
+                    <ul className="space-y-1">
+                      {doc.tips.map((tip, idx) => (
+                        <li key={idx} className="flex gap-2 text-xs text-amber-800">
+                          <span className="text-amber-500">→</span>
+                          <span>{tip}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="mt-6 pt-4 border-t text-center">
+          <p className="text-xs text-muted-foreground">
+            💡 Chăm sóc lead thường xuyên + Đánh giá chính xác = Tăng tỷ lệ chuyển đổi!
+          </p>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default InsightsHelperDrawer;

--- a/frontend/src/components/leads/LeadInsightsTab.tsx
+++ b/frontend/src/components/leads/LeadInsightsTab.tsx
@@ -4,7 +4,7 @@
  */
 "use client";
 
-import { HelpCircle, TrendingUp, Users, Target, Clock, Star, Sparkles } from "lucide-react";
+import { HelpCircle, Users, Target, Clock, Star, Sparkles } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -15,27 +15,30 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import type { LeadInsights } from "@/types/lead.types";
+import { InsightsHelperDrawer } from "@/components/leads/InsightsHelperDrawer";
+import type { LeadInsights, Lead } from "@/types/lead.types";
 
 interface LeadInsightsTabProps {
   leadId: number;
   insights?: LeadInsights;
+  /** Optional Lead object to use cached_urgency_score */
+  lead?: Lead;
 }
 
-// Helper descriptions for each metric
+// Helper tooltips - ngắn gọn để xem nhanh
 const INSIGHT_HELPERS = {
   overall: {
     label: "Điểm tổng hợp",
     icon: Sparkles,
-    description: "Đánh giá tổng thể dựa trên tất cả các chỉ số. Điểm cao = lead tiềm năng, ưu tiên chăm sóc.",
+    tooltip: "Điểm cao = lead tiềm năng, ưu tiên chăm sóc",
     color: "text-violet-600",
     bgColor: "bg-violet-100",
     borderColor: "border-violet-200",
   },
   engagement: {
-    label: "Tương tác",
+    label: "Mức độ tương tác",
     icon: Users,
-    description: "Mức độ tương tác của lead qua số lần tư vấn, phương thức liên hệ và kết quả các cuộc gọi.",
+    tooltip: "Điểm cao = lead đã được tư vấn nhiều, phản hồi tốt",
     color: "text-blue-600",
     bgColor: "bg-blue-100",
     borderColor: "border-blue-200",
@@ -43,7 +46,7 @@ const INSIGHT_HELPERS = {
   fit: {
     label: "Phù hợp",
     icon: Target,
-    description: "Độ phù hợp với chương trình dựa trên năm sinh, học vấn, vị trí địa lý và nghề nghiệp.",
+    tooltip: "Điểm cao = phù hợp với chương trình",
     color: "text-green-600",
     bgColor: "bg-green-100",
     borderColor: "border-green-200",
@@ -51,7 +54,7 @@ const INSIGHT_HELPERS = {
   urgency: {
     label: "Khẩn cấp",
     icon: Clock,
-    description: "Mức độ cần liên hệ gấp. Tăng khi lead ở giai đoạn cao trong pipeline hoặc có deadline sắp tới.",
+    tooltip: "Điểm cao = cần liên hệ ngay!",
     color: "text-orange-600",
     bgColor: "bg-orange-100",
     borderColor: "border-orange-200",
@@ -65,6 +68,14 @@ const getScoreStatus = (score: number) => {
   return { label: "Thấp", color: "text-gray-500", bg: "bg-gray-400" };
 };
 
+// Urgency có logic màu ngược lại: cao = cảnh báo đỏ, thấp = an toàn xanh
+const getUrgencyStatus = (score: number) => {
+  if (score >= 70) return { label: "Rất gấp!", color: "text-red-600", bg: "bg-red-500" };
+  if (score >= 50) return { label: "Cần sớm", color: "text-orange-600", bg: "bg-orange-500" };
+  if (score >= 30) return { label: "Bình thường", color: "text-yellow-600", bg: "bg-yellow-500" };
+  return { label: "Không gấp", color: "text-green-600", bg: "bg-green-500" };
+};
+
 interface MetricCardProps {
   metricKey: keyof typeof INSIGHT_HELPERS;
   value: number;
@@ -73,7 +84,8 @@ interface MetricCardProps {
 
 function MetricCard({ metricKey, value, isMain }: MetricCardProps) {
   const config = INSIGHT_HELPERS[metricKey];
-  const status = getScoreStatus(value);
+  // Urgency dùng logic màu ngược (cao = đỏ cảnh báo)
+  const status = metricKey === "urgency" ? getUrgencyStatus(value) : getScoreStatus(value);
   const Icon = config.icon;
 
   return (
@@ -101,8 +113,8 @@ function MetricCard({ metricKey, value, isMain }: MetricCardProps) {
             <TooltipTrigger asChild>
               <HelpCircle className="h-4 w-4 text-muted-foreground/50 cursor-help hover:text-muted-foreground transition-colors" />
             </TooltipTrigger>
-            <TooltipContent side="bottom" className="max-w-[280px] text-sm">
-              <p>{config.description}</p>
+            <TooltipContent side="bottom" className="max-w-[200px] text-xs">
+              <p>{config.tooltip}</p>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
@@ -133,7 +145,7 @@ function MetricCard({ metricKey, value, isMain }: MetricCardProps) {
   );
 }
 
-export function LeadInsightsTab({ insights }: LeadInsightsTabProps) {
+export function LeadInsightsTab({ insights, lead }: LeadInsightsTabProps) {
   if (!insights) {
     return (
       <div className="grid grid-cols-4 gap-3">
@@ -148,10 +160,13 @@ export function LeadInsightsTab({ insights }: LeadInsightsTabProps) {
     );
   }
 
+  // Use cached_urgency_score from Lead if available, otherwise fall back to API
+  const urgencyScore = lead?.cached_urgency_score ?? insights.urgency_score;
+
   return (
     <div className="space-y-3">
       {/* Main metric + secondary metrics grid */}
-      <div className="grid grid-cols-4 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
         <MetricCard 
           metricKey="overall" 
           value={insights.overall_score} 
@@ -167,8 +182,13 @@ export function LeadInsightsTab({ insights }: LeadInsightsTabProps) {
         />
         <MetricCard 
           metricKey="urgency" 
-          value={insights.urgency_score} 
+          value={urgencyScore} 
         />
+      </div>
+
+      {/* Helper drawer trigger */}
+      <div className="flex justify-end">
+        <InsightsHelperDrawer />
       </div>
 
       {/* Officer feedback if available */}
@@ -195,7 +215,7 @@ export function LeadInsightsTab({ insights }: LeadInsightsTabProps) {
           </div>
           {insights.officer_summary && (
             <p className="text-muted-foreground truncate flex-1" title={insights.officer_summary}>
-              "{insights.officer_summary}"
+              &ldquo;{insights.officer_summary}&rdquo;
             </p>
           )}
         </div>

--- a/frontend/src/components/leads/OfficerRatingInput.tsx
+++ b/frontend/src/components/leads/OfficerRatingInput.tsx
@@ -1,0 +1,148 @@
+// src/components/leads/OfficerRatingInput.tsx
+/**
+ * OfficerRatingInput - Star rating component for officers to rate leads
+ * 
+ * Features:
+ * - 5-star rating with hover effect
+ * - Tooltip explaining each rating level
+ * - Auto-save when changed
+ * - Shows impact on fit_score
+ */
+"use client";
+
+import React, { useState } from "react";
+import { Star } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useUpdateLead } from "@/hooks/useLeads";
+
+interface OfficerRatingInputProps {
+  leadId: number;
+  currentRating: number | null;
+  currentLeadScore?: number;
+  className?: string;
+  compact?: boolean;
+}
+
+const RATING_LABELS: Record<number, { label: string; description: string }> = {
+  1: { label: "Rất thấp", description: "Không phù hợp, khó chuyển đổi" },
+  2: { label: "Thấp", description: "Ít tiềm năng, cần nhiều nỗ lực" },
+  3: { label: "Trung bình", description: "Bình thường, có thể chuyển đổi" },
+  4: { label: "Cao", description: "Tiềm năng tốt, nên ưu tiên" },
+  5: { label: "Rất cao", description: "Rất tiềm năng, ưu tiên cao nhất" },
+};
+
+export function OfficerRatingInput({
+  leadId,
+  currentRating,
+  currentLeadScore = 0,
+  className,
+  compact = false,
+}: OfficerRatingInputProps) {
+  const [hoverRating, setHoverRating] = useState<number | null>(null);
+  // Local state để UI update ngay lập tức khi click
+  const [localRating, setLocalRating] = useState<number | null>(currentRating);
+  const updateLead = useUpdateLead();
+
+  // Sync local state when prop changes (e.g., after refetch)
+  // BUT only if mutation is not pending - otherwise we'd lose optimistic update
+  React.useEffect(() => {
+    if (!updateLead.isPending) {
+      setLocalRating(currentRating);
+    }
+  }, [currentRating, updateLead.isPending]);
+
+  const displayRating = hoverRating ?? localRating ?? 0;
+  
+  // Calculate fit_score impact
+  const currentFitScore = currentLeadScore + (localRating ? localRating * 4 : 0);
+  const hoverFitScore = hoverRating 
+    ? currentLeadScore + hoverRating * 4 
+    : currentFitScore;
+
+  const handleRate = (rating: number) => {
+    // Update local state immediately for instant UI feedback
+    setLocalRating(rating);
+    
+    updateLead.mutate(
+      {
+        id: leadId,
+        data: { officer_rating: rating },
+      },
+      {
+        onSuccess: () => {
+          // Local state already updated, toast comes from useUpdateLead
+        },
+        onError: () => {
+          // Rollback local state on error
+          setLocalRating(currentRating);
+        },
+      }
+    );
+  };
+
+  return (
+    <TooltipProvider delayDuration={200}>
+      <div className={cn("flex flex-col gap-1", className)}>
+        {/* Stars Row */}
+        <div className="flex items-center gap-0.5">
+          {[1, 2, 3, 4, 5].map((star) => (
+            <Tooltip key={star}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => handleRate(star)}
+                  onMouseEnter={() => setHoverRating(star)}
+                  onMouseLeave={() => setHoverRating(null)}
+                  disabled={updateLead.isPending}
+                  className={cn(
+                    "p-0.5 transition-colors focus:outline-none focus:ring-1 focus:ring-amber-400 rounded",
+                    updateLead.isPending && "opacity-50 cursor-not-allowed"
+                  )}
+                >
+                  <Star
+                    className={cn(
+                      "transition-colors",
+                      compact ? "h-4 w-4" : "h-5 w-5",
+                      star <= displayRating
+                        ? "fill-amber-400 text-amber-400"
+                        : "fill-transparent text-gray-300 hover:text-amber-200"
+                    )}
+                  />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="text-xs">
+                <div className="font-medium">{RATING_LABELS[star].label}</div>
+                <div className="text-muted-foreground">{RATING_LABELS[star].description}</div>
+                <div className="text-amber-600 mt-1">
+                  +{star * 4} điểm phù hợp
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          ))}
+          
+          {/* Current rating label */}
+          {!compact && currentRating && (
+            <span className="ml-2 text-xs text-muted-foreground">
+              {RATING_LABELS[currentRating]?.label}
+            </span>
+          )}
+        </div>
+
+        {/* Fit Score Impact (shown on hover) */}
+        {!compact && hoverRating && hoverRating !== currentRating && (
+          <div className="text-[10px] text-amber-600">
+            Điểm phù hợp: {currentFitScore} → {Math.min(hoverFitScore, 100)}
+          </div>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+}
+
+export default OfficerRatingInput;

--- a/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
@@ -37,7 +37,9 @@ import { LeadTimelineTab } from "@/components/leads/LeadTimelineTab";
 import { QuickConsultationSection } from "@/components/leads/QuickConsultationSection";
 import { ReassignLeadDialog } from "@/components/leads/ReassignLeadDialog";
 import { CopyableCell } from "@/components/common/CopyableCell";
+import { UrgencyBadge } from "@/components/common/UrgencyBadge";
 import { STAGE_COLORS } from "@/types/pipeline.types";
+import { OfficerRatingInput } from "@/components/leads/OfficerRatingInput";
 import type { Lead } from "@/types/lead.types";
 
 interface LeadDetailPanelProps {
@@ -352,6 +354,71 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
               <div className="text-muted-foreground flex items-center gap-3 text-sm">
                 <Calendar className="h-4 w-4 shrink-0" />
                 <span>Ngày tạo: {new Date(lead.created_at).toLocaleDateString("vi-VN")}</span>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Lead Insights Card */}
+          <Card>
+            <CardHeader className="px-4 py-3">
+              <CardTitle className="text-sm font-medium">Lead Insights</CardTitle>
+            </CardHeader>
+            <CardContent className="px-4 pt-0 pb-4">
+              <div className="grid grid-cols-2 gap-3">
+                {/* Urgency Score */}
+                <div className="flex flex-col gap-1">
+                  <span className="text-muted-foreground text-xs">Khẩn cấp</span>
+                  <UrgencyBadge score={lead.cached_urgency_score} />
+                </div>
+
+                {/* Lead Score */}
+                <div className="flex flex-col gap-1">
+                  <span className="text-muted-foreground text-xs">Điểm Lead</span>
+                  <span className={cn(
+                    "text-sm font-semibold",
+                    lead.lead_score >= 70 ? "text-red-600" :
+                    lead.lead_score >= 50 ? "text-orange-600" :
+                    lead.lead_score >= 30 ? "text-yellow-600" : "text-gray-600"
+                  )}>
+                    {lead.lead_score}
+                    {lead.is_hot_lead && <span className="ml-1">🔥</span>}
+                  </span>
+                </div>
+
+                {/* Consultation Count */}
+                <div className="flex flex-col gap-1">
+                  <span className="text-muted-foreground text-xs">Số lần tư vấn</span>
+                  <span className="text-sm font-medium">{lead.consultation_count}</span>
+                </div>
+
+                {/* Last Consultation */}
+                <div className="flex flex-col gap-1">
+                  <span className="text-muted-foreground text-xs">Tư vấn cuối</span>
+                  <span className="text-sm">
+                    {lead.last_consultation_at
+                      ? new Date(lead.last_consultation_at).toLocaleDateString("vi-VN")
+                      : "Chưa có"}
+                  </span>
+                </div>
+
+                {/* Overdue Status */}
+                {lead.is_overdue && (
+                  <div className="col-span-2 flex items-center gap-2 text-red-600 text-xs">
+                    <span>⚠️ Chưa liên hệ theo lịch hẹn</span>
+                  </div>
+                )}
+
+                {/* Officer Rating */}
+                <div className="col-span-2 flex flex-col gap-1 pt-2 border-t">
+                  <span className="text-muted-foreground text-xs">Đánh giá của bạn</span>
+                  <OfficerRatingInput
+                    key={`rating-${lead.id}`}
+                    leadId={lead.id}
+                    currentRating={lead.officer_rating ?? null}
+                    currentLeadScore={lead.lead_score}
+                    compact
+                  />
+                </div>
               </div>
             </CardContent>
           </Card>

--- a/frontend/src/components/leads/command-center/LeadsTable.tsx
+++ b/frontend/src/components/leads/command-center/LeadsTable.tsx
@@ -65,6 +65,8 @@ import { STAGE_COLORS } from "@/types/pipeline.types";
 import { TableToolbar, type DensityMode } from "./TableToolbar";
 import { BulkActionsBar } from "./BulkActionsBar";
 import { CopyableCell } from "@/components/common/CopyableCell";
+import { ActivityIndicator } from "@/components/common/ActivityIndicator";
+import { UrgencyBadge } from "@/components/common/UrgencyBadge";
 
 // =============================================================================
 // TYPES
@@ -176,6 +178,11 @@ export function LeadsTable({
       setRowSelection({});
     }
   }, [resetSelectionKey]);
+
+  // Reset focused row when leads data changes (after create/update/delete)
+  useEffect(() => {
+    setFocusedRowIndex(-1);
+  }, [leads]);
 
   // Column definitions
   const columns = useMemo(
@@ -333,7 +340,7 @@ export function LeadsTable({
         size: 60,
       }),
 
-      // Created at column - MEDIUM font
+      // Created at column - with Activity Indicator
       columnHelper.accessor("created_at", {
         header: ({ column }) => (
           <Button
@@ -341,7 +348,7 @@ export function LeadsTable({
             className="-ml-3 h-8 font-medium"
             onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
           >
-            Ngày tạo
+            Hoạt động
             {column.getIsSorted() === "asc" ? (
               <ArrowUp className="ml-1 h-3.5 w-3.5" />
             ) : column.getIsSorted() === "desc" ? (
@@ -351,16 +358,37 @@ export function LeadsTable({
             )}
           </Button>
         ),
-        cell: ({ row }) => {
-          const date = row.original.created_at;
-          if (!date) return "—";
-          return (
-            <div className="text-muted-foreground text-sm">
-              {format(new Date(date), "dd/MM/yyyy", { locale: vi })}
-            </div>
-          );
-        },
+        cell: ({ row }) => (
+          <ActivityIndicator
+            date={row.original.last_consultation_at || row.original.created_at}
+            nextActivityAt={row.original.next_activity_at}
+          />
+        ),
         size: 100,
+      }),
+
+      // Urgency Score column (Lead Insights Upgrade)
+      columnHelper.accessor("cached_urgency_score", {
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            className="-ml-3 h-8 font-medium"
+            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          >
+            Khẩn cấp
+            {column.getIsSorted() === "asc" ? (
+              <ArrowUp className="ml-1 h-3.5 w-3.5" />
+            ) : column.getIsSorted() === "desc" ? (
+              <ArrowDown className="ml-1 h-3.5 w-3.5" />
+            ) : (
+              <ArrowUpDown className="ml-1 h-3.5 w-3.5 opacity-50" />
+            )}
+          </Button>
+        ),
+        cell: ({ row }) => (
+          <UrgencyBadge score={row.original.cached_urgency_score} showLabel={false} />
+        ),
+        size: 80,
       }),
 
       // Actions column
@@ -411,7 +439,10 @@ export function LeadsTable({
     enableRowSelection: true,
     enableColumnResizing: true,
     columnResizeMode,
-    onSortingChange: setSorting,
+    onSortingChange: (updater) => {
+      setSorting(updater);
+      setFocusedRowIndex(-1); // Reset focus when sorting changes
+    },
     onRowSelectionChange: setRowSelection,
     onColumnVisibilityChange: setColumnVisibility,
     getCoreRowModel: getCoreRowModel(),

--- a/frontend/src/components/leads/command-center/TableToolbar.tsx
+++ b/frontend/src/components/leads/command-center/TableToolbar.tsx
@@ -58,7 +58,7 @@ const COLUMNS_CONFIG = [
   { id: "consultation_status", label: "Trạng thái TĐ" },
   { id: "assigned_officer", label: "Cán bộ" },
   { id: "lead_score", label: "Điểm" },
-  { id: "created_at", label: "Ngày tạo" },
+  { id: "created_at", label: "Hoạt động" },
 ];
 
 const DENSITY_OPTIONS: { value: DensityMode; label: string; icon: React.ElementType }[] = [

--- a/frontend/src/hooks/useLeads.ts
+++ b/frontend/src/hooks/useLeads.ts
@@ -91,7 +91,7 @@ export function useLead(
     },
     enabled: enabled && !!id,
     initialData: options?.initialData,
-    staleTime: 1000 * 10, // 10 seconds - shorter to ensure data is fresh after updates
+    staleTime: 0, // Always refetch when invalidated to ensure sync between panels
     gcTime: 1000 * 60 * 5, // 5 minutes in cache
   });
 }
@@ -130,7 +130,7 @@ export function useLeadInsights(leadId: number) {
       return await leadsApi.getLeadInsights(leadId);
     },
     enabled: !!leadId,
-    staleTime: 1000 * 60 * 5, // 5 minutes (insights don't change frequently)
+    staleTime: 1000 * 30, // 30 seconds - reduced for better responsiveness after lead updates
     gcTime: 1000 * 60 * 10, // 10 minutes in cache
   });
 }
@@ -265,7 +265,7 @@ export function useUpdateLead() {
       
       // Invalidate other related queries
       queryClient.invalidateQueries({ queryKey: leadsKeys.timeline(updatedLead.id) });
-      queryClient.invalidateQueries({ queryKey: leadsKeys.insights(updatedLead.id) });
+      await queryClient.refetchQueries({ queryKey: leadsKeys.insights(updatedLead.id) });
       queryClient.invalidateQueries({ queryKey: ["pipeline"] });
     },
   });

--- a/frontend/src/types/lead.types.ts
+++ b/frontend/src/types/lead.types.ts
@@ -85,6 +85,17 @@ export interface Lead {
   occupation_relevance: number; // 0=Không, 1=Gián tiếp, 2=Trực tiếp
   academic_performance: number; // 0=Yếu, 1=TB, 2=Khá, 3=Giỏi
 
+  // =========================================================================
+  // CACHED METRICS (Lead Insights Upgrade)
+  // Auto-updated by LeadCacheService after consultation changes
+  // =========================================================================
+  last_consultation_at?: string | null; // ISO datetime - Ngày tư vấn cuối
+  consultation_count: number; // Số lần tư vấn
+  cached_urgency_score: number; // Điểm khẩn cấp 0-100
+  is_hot_lead: boolean; // lead_score >= 70
+  is_overdue: boolean; // Chưa liên hệ theo lịch hẹn (next_activity_at đã qua)
+  // =========================================================================
+
   // Foreign Keys
   offering_id?: number | null;
   unit_id: number;


### PR DESCRIPTION
Backend:
- Add LeadCacheService for cached metrics (urgency, consultation count, etc.)
- Add officer_rating and officer_summary to Lead response schema
- Update fit_score calculation to include officer_rating (x4 bonus)
- Simplify urgency_score to use cached value from Lead model
- Add migration for lead cache fields

Frontend:
- Add InsightsHelperDrawer with detailed formula documentation
- Add OfficerRatingInput component with instant feedback
- Add UrgencyBadge and ActivityIndicator components
- Simplify tooltips in LeadInsightsTab (quick hints only)
- Fix urgency color logic (high = red warning, low = green safe)
- Reduce staleTime to 0 for immediate sync between panels
- Fix rating sync with local state and proper useEffect logic

Docs:
- Add lead-insights-upgrade-plan and supplement documents
- Add comprehensive walkthrough and analysis