### PR TITLE
fix(security): add session IDOR dependency for OWASP compliance

### DIFF
--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -888,6 +888,45 @@ async def get_notification_for_user(
     )
 
 
+async def get_session_for_user(
+    session_id: int = Path(..., description="ID of the Session"),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> models.UserSession:
+    """
+    Verify ownership and retrieve a user session.
+
+    **IDOR Prevention:**
+    Returns 404 (not 403) when session doesn't belong to user,
+    preventing attackers from enumerating valid session IDs.
+
+    Args:
+        session_id: ID of the session to access
+        db: Database session (injected)
+        current_user: Current authenticated user (injected)
+
+    Returns:
+        UserSession model if access is permitted
+
+    Raises:
+        ResourceNotFoundError: If session doesn't exist OR user doesn't own it
+    """
+    from ..repositories.session_repository import SessionRepository
+
+    repo = SessionRepository(db)
+    session = await repo.get_for_update(session_id, current_user.id)
+
+    if not session:
+        log.warning(
+            "IDOR attempt or session not found",
+            session_id=session_id,
+            user_id=current_user.id,
+        )
+        raise ResourceNotFoundError(detail="Session not found")
+
+    return session
+
+
 async def get_user_managed_units(
     db: AsyncSession,
     user_id: int

--- a/Backend_FastAPI/app/routers/sessions.py
+++ b/Backend_FastAPI/app/routers/sessions.py
@@ -98,7 +98,7 @@ async def get_active_sessions(
 @router.delete("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def revoke_session(
     request: Request,
-    session_id: int,
+    session: models.UserSession = Depends(deps.get_session_for_user),
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(deps.get_current_user),
 ):
@@ -107,36 +107,36 @@ async def revoke_session(
 
     Security:
         - Requires authentication
-        - Users can only revoke their own sessions
+        - IDOR protection via get_session_for_user dependency (returns 404 if not owned)
 
     Raises:
         404: Session not found or doesn't belong to user
     """
-    log.info("Revoking session", user_id=current_user.id, session_id=session_id)
+    log.info("Revoking session", user_id=current_user.id, session_id=session.id)
 
     success, callback = await session_service.revoke_session(
         db=db,
-        session_id=session_id,
+        session_id=session.id,
         user_id=current_user.id
     )
 
     if not success:
         log.warning(
-            "Session not found or already revoked",
+            "Session already revoked",
             user_id=current_user.id,
-            session_id=session_id,
+            session_id=session.id,
         )
         raise SessionNotFoundError(detail="Session not found or already revoked")
 
     await db.commit()
-    
+
     if callback:
         await callback()
 
     log.info(
         "Session revoked successfully",
         user_id=current_user.id,
-        session_id=session_id,
+        session_id=session.id,
     )
 
     return None  # 204 No Content


### PR DESCRIPTION
## Summary
- Add `get_session_for_user` dependency in `deps.py` for session ownership verification at the dependency layer
- Refactor `sessions.py` revoke endpoint to use the new dependency
- Completes the last code-fixable item from the OWASP Top 10:2025 audit

## Changes
- **`app/core/deps.py`**: Add `get_session_for_user()` dependency that verifies session ownership and returns 404 (not 403) to prevent session ID enumeration — consistent with existing patterns (`get_lead_for_user`, `get_notification_for_user`, etc.)
- **`app/routers/sessions.py`**: Refactor `revoke_session` endpoint to use `Depends(get_session_for_user)` instead of passing raw `session_id` to service layer

## Test plan
- [ ] Verify revoking own session returns 204
- [ ] Verify revoking another user's session returns 404 (not 403)
- [ ] Verify revoking non-existent session returns 404
- [ ] Verify existing session list endpoint still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)