### PR TITLE
fix(celery): reuse per-worker event loop instead of asyncio.run() per task

### DIFF
--- a/Backend_FastAPI/app/tasks/utils.py
+++ b/Backend_FastAPI/app/tasks/utils.py
@@ -5,7 +5,10 @@ Provides shared infrastructure like database session management,
 result validation, and standardized error handling.
 """
 import asyncio
+import atexit
 import logging
+import os
+import threading
 from contextlib import asynccontextmanager
 from functools import wraps
 from typing import Any, AsyncGenerator, Callable, Dict, List, Optional
@@ -20,15 +23,103 @@ log = logging.getLogger(__name__)
 
 
 # ============================================================================
+# Celery task event loop management
+# ============================================================================
+
+_task_event_loop: Optional[asyncio.AbstractEventLoop] = None
+_task_event_loop_pid: Optional[int] = None
+
+
+def _close_task_event_loop() -> None:
+    """Close the cached Celery task loop when the worker process exits."""
+    global _task_event_loop, _task_event_loop_pid
+
+    loop = _task_event_loop
+    _task_event_loop = None
+    _task_event_loop_pid = None
+
+    if loop is None or loop.is_closed():
+        return
+
+    try:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+    except Exception:
+        log.debug("Failed to shutdown cached task async generators", exc_info=True)
+
+    loop.close()
+
+
+def _get_task_event_loop() -> asyncio.AbstractEventLoop:
+    """
+    Return a stable event loop for the current Celery worker process.
+
+    Celery task code uses long-lived async resources such as Redis, Socket.IO,
+    and occasionally app-global SQLAlchemy session factories. Re-creating and
+    closing the event loop for every task leaves those resources bound to a
+    dead loop, which later surfaces as ``RuntimeError: Event loop is closed``.
+
+    Keeping one loop per worker process avoids that churn while still staying
+    isolated across Celery's prefork children.
+    """
+    global _task_event_loop, _task_event_loop_pid
+
+    current_pid = os.getpid()
+    if _task_event_loop_pid != current_pid:
+        _close_task_event_loop()
+
+    if _task_event_loop is None or _task_event_loop.is_closed():
+        _task_event_loop = asyncio.new_event_loop()
+        _task_event_loop_pid = current_pid
+        asyncio.set_event_loop(_task_event_loop)
+
+    return _task_event_loop
+
+
+def _run_async_task_in_fresh_thread(async_func: Callable) -> Dict:
+    """
+    Fallback for environments that already have a running event loop.
+
+    Celery tasks are synchronous entrypoints, but some unit tests may invoke
+    them from ``pytest.mark.asyncio`` contexts. In that case, we spin up a
+    temporary thread with its own loop instead of nesting loops in-place.
+    """
+    result_holder: Dict[str, Any] = {}
+    error_holder: Dict[str, BaseException] = {}
+
+    def _runner() -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            result_holder["result"] = loop.run_until_complete(async_func())
+            loop.run_until_complete(loop.shutdown_asyncgens())
+        except BaseException as exc:  # pragma: no cover - re-raised below
+            error_holder["error"] = exc
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+    thread.join()
+
+    if "error" in error_holder:
+        raise error_holder["error"]
+
+    return result_holder["result"]
+
+
+atexit.register(_close_task_event_loop)
+
+
+# ============================================================================
 # Database Session Management
 # ============================================================================
 
 def _create_task_async_engine():
     """
-    Create a new async engine for use within a task's event loop.
+    Create a new async engine for use within the current task event loop.
 
-    This must be called INSIDE asyncio.run() context to avoid the
-    "Future attached to a different loop" error with asyncpg.
+    This must be called while the per-worker task loop is running to avoid
+    binding asyncpg connections to the wrong event loop.
     """
     return create_async_engine(
         settings.DATABASE_URL,
@@ -179,7 +270,13 @@ def run_async_task(
         Exception: All other exceptions are logged and re-raised
     """
     try:
-        result = asyncio.run(async_func())
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            loop = _get_task_event_loop()
+            result = loop.run_until_complete(async_func())
+        else:
+            result = _run_async_task_in_fresh_thread(async_func)
         
         # Validate result if keys provided
         if validate_keys:

--- a/Backend_FastAPI/tests/unit/test_task_utils.py
+++ b/Backend_FastAPI/tests/unit/test_task_utils.py
@@ -1,0 +1,75 @@
+import logging
+
+import pytest
+
+
+def test_run_async_task_reuses_worker_loop_for_loop_bound_resources():
+    """
+    Celery tasks keep async clients alive across task boundaries.
+
+    A per-call asyncio.run() closes the loop after every task, which breaks
+    those reused clients on the next task. This test models a loop-bound
+    resource and ensures the helper keeps using the same worker loop.
+    """
+    from app.tasks.utils import _close_task_event_loop, run_async_task
+
+    class LoopBoundResource:
+        def __init__(self) -> None:
+            self.bound_loop = None
+            self.calls = 0
+
+        async def use(self) -> dict:
+            import asyncio
+
+            loop = asyncio.get_running_loop()
+            if self.bound_loop is None:
+                self.bound_loop = loop
+            elif loop is not self.bound_loop:
+                raise RuntimeError("resource rebound to a different loop")
+
+            self.calls += 1
+            return {"status": "ok", "call": self.calls}
+
+    resource = LoopBoundResource()
+    task_log = logging.getLogger("test_task_utils")
+
+    try:
+        first = run_async_task(
+            async_func=resource.use,
+            task_name="loop_reuse_first",
+            task_log=task_log,
+            validate_keys=["status", "call"],
+        )
+        second = run_async_task(
+            async_func=resource.use,
+            task_name="loop_reuse_second",
+            task_log=task_log,
+            validate_keys=["status", "call"],
+        )
+    finally:
+        _close_task_event_loop()
+
+    assert first["call"] == 1
+    assert second["call"] == 2
+    assert resource.bound_loop is not None
+
+
+@pytest.mark.asyncio
+async def test_run_async_task_supports_callers_with_existing_event_loop():
+    """Async test harnesses should still be able to invoke Celery helpers."""
+    from app.tasks.utils import _close_task_event_loop, run_async_task
+
+    async def sample() -> dict:
+        return {"status": "ok", "delivery_id": 123}
+
+    try:
+        result = run_async_task(
+            async_func=sample,
+            task_name="existing_loop",
+            task_log=logging.getLogger("test_task_utils"),
+            validate_keys=["status", "delivery_id"],
+        )
+    finally:
+        _close_task_event_loop()
+
+    assert result == {"status": "ok", "delivery_id": 123}


### PR DESCRIPTION
## Summary
- Cache one asyncio event loop per Celery worker process so long-lived async resources (Redis sync-breaker client, Socket.IO Redis manager, asyncpg pool) survive across tasks.
- Add a thread-based fallback for callers with an already-running loop (test contexts) to avoid nested-loop errors.
- Add regression test that models a loop-bound resource across two consecutive `run_async_task` calls, plus a second test for the async-context fallback.

## Root cause
`run_async_task()` in `app/tasks/utils.py` was effectively running each Celery task with `asyncio.run()`, which closes the loop after every task. Resources bound to the closed loop blew up on the next task with `RuntimeError: Event loop is closed`. In production this surfaced as continuous worker log noise:

- `Failed to sync breaker state to Redis`
- `Failed to emit domain event`
- `asyncpg ... Event loop is closed`

After fix, the worker keeps one stable loop per process (PID-keyed for prefork safety) and resources stay valid across task boundaries.

## Risk assessment
| | |
|---|---|
| **Pool model** | `prefork` (default, no `--pool` flag in `docker-compose.yml`) → safe with module-global cached loop. PID check at `utils.py:67` handles fork. |
| **Worker recycling** | `worker_max_tasks_per_child=50` (`celery_app.py:61`) → loop and any resident state get recycled every 50 tasks → bounded leak risk. |
| **Blast radius** | Only `celery-worker` + `celery-beat` need restart. FastAPI backend has its own loop and is unaffected. |
| **Migrations** | None in this PR. |
| **Rollback** | `git revert <merge-commit>` → CI auto-redeploys baseline `431200df`. |

## Test plan
- [x] `pytest tests/unit/test_task_utils.py` — 2 regression tests for loop reuse + thread fallback (passed)
- [x] `pytest tests/unit/test_notification_d2.py tests/unit/test_zalo_phase1_review_findings.py` — adjacent task-related tests (62 passed, total 64 passed)
- [x] Verified VPS git state matches `origin/main` and `utils.py` md5 matches git source (no manual edits)
- [ ] **Post-deploy**: tail `docker compose logs celery-worker` for 5–10 minutes, confirm absence of:
  - `Event loop is closed`
  - `Failed to sync breaker state to Redis`
  - `Failed to emit domain event`
- [ ] **Post-deploy 24–48h**: monitor `celery-worker` RSS to confirm no leak accumulation (loop now lives longer, so any leak would show)

🤖 Generated with [Claude Code](https://claude.com/claude-code)