### PR TITLE
ci(deploy): provide MAIL_* env vars to backend contract test job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,19 @@ jobs:
     name: PR Gate — Contract Tests
     runs-on: ubuntu-latest
 
+    env:
+      APP_ENV: test
+      DATABASE_URL: postgresql+asyncpg://test:test@localhost:5432/qlts_test
+      REDIS_URL: redis://localhost:6379/0
+      SECRET_KEY: test-secret-key-for-ci-only
+      JWT_SECRET_KEY: test-jwt-secret-for-ci-only
+      # Mail settings — placeholders so app/config.py Settings() can instantiate.
+      # Tests must not actually send mail; smtp.example.com is unroutable on purpose.
+      MAIL_USERNAME: ci-test@example.com
+      MAIL_PASSWORD: ci-test-placeholder
+      MAIL_FROM: ci-test@example.com
+      MAIL_SERVER: smtp.example.com
+
     services:
       postgres:
         image: postgres:16-alpine
@@ -57,12 +70,6 @@ jobs:
 
       - name: Backend — Lead assignment contract
         working-directory: Backend_FastAPI
-        env:
-          APP_ENV: test
-          DATABASE_URL: postgresql+asyncpg://test:test@localhost:5432/qlts_test
-          REDIS_URL: redis://localhost:6379/0
-          SECRET_KEY: test-secret-key-for-ci-only
-          JWT_SECRET_KEY: test-jwt-secret-for-ci-only
         run: >-
           python -m pytest
           tests/api/test_lead_assignment_api.py::test_lead_assignment_lifecycle_end_to_end
@@ -70,12 +77,6 @@ jobs:
 
       - name: Backend — Admission workflow contract
         working-directory: Backend_FastAPI
-        env:
-          APP_ENV: test
-          DATABASE_URL: postgresql+asyncpg://test:test@localhost:5432/qlts_test
-          REDIS_URL: redis://localhost:6379/0
-          SECRET_KEY: test-secret-key-for-ci-only
-          JWT_SECRET_KEY: test-jwt-secret-for-ci-only
         run: >-
           python -m pytest
           tests/api/test_admission_workflow_api.py


### PR DESCRIPTION
## Summary
Lift backend contract test env vars to job level and add 4 required `MAIL_*` placeholders so `Settings()` can instantiate during pytest collection.

## Root cause
`Backend_FastAPI/app/config.py:76-79` declares `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM`, `MAIL_SERVER` as required (no defaults), and `Backend_FastAPI/app/config.py:527` calls `settings = Settings()` at module import. The contract test job only exported 5 env vars per step (`APP_ENV`, `DATABASE_URL`, `REDIS_URL`, `SECRET_KEY`, `JWT_SECRET_KEY`), so `Settings()` raised:

```
pydantic_core._pydantic_core.ValidationError: 4 validation errors for Settings
  MAIL_USERNAME / MAIL_PASSWORD / MAIL_FROM / MAIL_SERVER
    Field required
```

This crashes at `conftest.py` import → all subsequent contract tests fail with `exit code 4` → `Deploy to VPS` job is `skipped` → every push to `main` since the mail fields were added has been unable to auto-deploy.

Verified by:
- favouritekid/QLTS#98 deploy run failed with this exact error (PR Gate — Contract Tests: failure → Deploy to VPS: skipped)
- Same failure pattern on the previous 2 deploys to main (`24003389013`, `24002823324`)
- `gh run list --workflow \"Deploy to Production\" --branch main` shows consecutive failures

## Fix
- Lift the existing 5 env vars from per-step blocks to a single job-level `env:` block.
- Add the 4 missing `MAIL_*` vars as placeholders. `smtp.example.com` is intentionally unroutable — tests must not actually send mail; we just need `Settings()` to instantiate.
- Removes 2 duplicated step env blocks which would have drifted apart silently next time someone added a variable.

## Risk
- **Very low**: only changes `.github/workflows/deploy.yml`. No production code touched.
- Frontend steps inherit the job-level env vars but ignore them (Node tooling reads its own env).
- If any contract test actually calls `send_mail`, it'll fail with a connection error to `smtp.example.com` — that's a per-test failure, not an import-time crash, and would be visible/diagnosable.

## Test plan
- [ ] After merge, watch `Deploy to Production` workflow run for the merge commit.
- [ ] Expect `PR Gate — Contract Tests` to PASS (no more `ValidationError` at conftest import).
- [ ] Expect `Deploy to VPS` job to start (no longer `skipped`).
- [ ] Verify VPS pulls latest commit and rolling restarts services.

## Follow-ups (separate PRs)
- Celery queue mismatch (worker not subscribed to `default` queue while beat publishes there) — separate PR with the docker-compose patch.
- 9 pre-existing failing unit tests (csrf middleware, notification e2, dispatcher, delivery branch) — out of scope here; require code/test updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)