### PR TITLE
fix(celery): subscribe worker to default queue alongside celery queue

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -22,7 +22,7 @@ services:
       - "8000:8000"
 
   celery-worker:
-    command: celery -A app.celery_app worker --loglevel=debug --concurrency=1
+    command: celery -A app.celery_app worker -Q default,celery --loglevel=debug --concurrency=1
     env_file:
       - ./Backend_FastAPI/.env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       context: ./Backend_FastAPI
       dockerfile: Dockerfile
     restart: unless-stopped
-    command: celery -A app.celery_app worker --loglevel=info --concurrency=2
+    command: celery -A app.celery_app worker -Q default,celery --loglevel=info --concurrency=2
     env_file:
       - .env.production
     environment:


### PR DESCRIPTION
## Summary
Add `-Q default,celery` to the celery worker command in both `docker-compose.yml` and `docker-compose.override.yml` so the worker actually consumes the queue that beat publishes to.

## Root cause
- `Backend_FastAPI/app/celery_app.py:108` declares every periodic task with `options={\"queue\": \"default\"}`.
- `docker-compose.yml:94` runs `celery -A app.celery_app worker --loglevel=info --concurrency=2` (no `-Q`), so the worker listens on the default Celery queue named `celery`.
- `celery_app.py` does not set `task_default_queue` or `task_queues`, and the routing block at line 84 is commented out — no override reconciles the two sides.
- Tasks dispatched from FastAPI via `.delay()` go to `celery` and worked normally → masked the bug for users who didn't watch periodic jobs.

## Evidence (production VPS, 2026-04-07)
Verified directly on prod Redis db 2:
```
LLEN celery   → 0
LLEN default  → 28767
```
~28,767 stale scheduled jobs accumulated over ~13 days (~90 tasks/h × 320h). The fix in celery_app.py:20 already documents the correct command:
```
celery -A app.celery_app worker -Q default,celery --concurrency=4
```

Affected periodic jobs (none have been running):
- `check_consultation_reminders_task` (60s)
- `sweep_retry_deliveries` (120s)
- `reconcile_stale_deliveries` (15min)
- `sync_notification_quotas` (6h)
- `check_notification_alerts` (5min)
- `recalculate_lead_caches_task`, `sync_kpi_*`, `cleanup_*`, `check_ctv_*`

## Fix
Smallest patch: add `-Q default,celery` to both compose files. No changes to `celery_app.py`, no routing reconfiguration.

## Pre-deploy step (manual SSH, NOT in PR)
The 28k Redis backlog must be flushed BEFORE the new worker comes up; otherwise it would replay 13 days of stale scheduled jobs. Audit of `app/tasks/{notification,delivery,collaborator}_tasks.py` shows all tasks are repeat-safe (time-window queries / dedupe keys / Redis distributed locks), but the worker would still burn ~23min of DB cycles on no-op replays.

```bash
# Run while old worker is still up (old worker doesn't read default queue, safe to delete)
docker compose -f docker-compose.yml --env-file .env.production \
    exec -T redis redis-cli -n 2 DEL default
```

## Test plan
- [x] Audit all 8 periodic task types in `app/tasks/`: all repeat-safe (`notification_tasks.py:227 reminder_sent==False`, `delivery_tasks.py:348 acquire_redis_lock`, `collaborator_tasks.py:119,138,245 dedupe_key`, etc.)
- [ ] **Pre-deploy**: SSH to VPS, `redis-cli -n 2 DEL default`, verify `LLEN default → 0`
- [ ] **Deploy**: `git pull origin main`, then `docker compose up -d --no-deps celery-worker celery-beat` (no rebuild needed — same image, command-only change)
- [ ] **Post-deploy log check**: worker boot must show `[queues] default ... celery ...` (now subscribing to both)
- [ ] **Beat verify**: wait 90s, check beat publishes `check_consultation_reminders_task` and worker actually receives + executes it
- [ ] **Steady state**: `LLEN default` should stay near 0 instead of growing (worker draining as fast as beat publishes)

## Risk
- **Patch itself**: trivially low. Two-character flag in 2 files. No code changes.
- **Backlog flood without flush**: ~23 minutes of no-op replays + DB load spike. Mitigated by pre-deploy flush step.
- **Backend NOT touched**: the Celery loop fix from #98 lives in the backend image which is already deployed. Worker just needs container recreate to pick up new compose command.
- **Rollback**: `git revert <merge>` → CI redeploys baseline (which restores the broken-but-stable behavior we had before).

## Note on CI
This PR will fail the same Frontend Lint gate that was already broken in CI. Backend contract tests (the gate that PR #99 just unblocked) should now PASS. Manual SSH deploy will be used as fallback until lint debt is addressed in a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)