### PR TITLE
fix(redis): lazy-init Redis client for Celery worker context

### DIFF
--- a/Backend_FastAPI/app/utils/redis_lock.py
+++ b/Backend_FastAPI/app/utils/redis_lock.py
@@ -58,18 +58,16 @@ async def close_redis_client():
 
 def get_redis_client() -> aioredis.Redis:
     """
-    Get Redis client instance.
+    Get Redis client instance. Lazy-initializes on first call if not yet
+    created.
 
-    Returns:
-        Redis client
-
-    Raises:
-        RuntimeError: If Redis client not initialized
+    Safe to call from both contexts:
+    - FastAPI: pre-initialized at lifespan startup (main.py:449); this is a no-op.
+    - Celery worker: main.py is never imported, so first acquire_redis_lock
+      call here triggers init via init_redis_client() (idempotent).
     """
     if _redis_client is None:
-        raise RuntimeError(
-            "Redis client not initialized. Call init_redis_client() in main.py startup."
-        )
+        init_redis_client()
     return _redis_client
 
 

--- a/Backend_FastAPI/tests/unit/test_redis_lock_lazy_init.py
+++ b/Backend_FastAPI/tests/unit/test_redis_lock_lazy_init.py
@@ -1,0 +1,45 @@
+"""Regression: redis_lock client must lazy-init for Celery worker context.
+
+Celery worker boots via `celery -A app.celery_app worker ...` and never
+runs FastAPI lifespan main.py:449 init_redis_client(). Before the lazy-
+init fix, any task calling acquire_redis_lock() raised RuntimeError.
+"""
+from unittest.mock import patch
+
+import app.utils.redis_lock as redis_lock_module
+
+
+def test_get_redis_client_lazy_inits_when_uninitialized():
+    """First call from worker context must self-heal, not raise."""
+    original = redis_lock_module._redis_client
+    redis_lock_module._redis_client = None
+    try:
+        client = redis_lock_module.get_redis_client()
+        assert client is not None
+        assert redis_lock_module._redis_client is client
+        # Second call returns same cached instance (no double init)
+        assert redis_lock_module.get_redis_client() is client
+    finally:
+        redis_lock_module._redis_client = original
+
+
+def test_get_redis_client_skips_init_call_when_already_set():
+    """FastAPI eager init path is preserved: init_redis_client() is NOT called
+    again on subsequent get_redis_client() calls.
+
+    Spy on init_redis_client to catch a regression where someone removes the
+    `if _redis_client is None` guard in get_redis_client. A pure
+    `assert result is sentinel` would not catch that, because
+    init_redis_client() is itself idempotent (redis_lock.py:39) — calling it
+    extra times would still return the same client and the assert would pass.
+    """
+    original = redis_lock_module._redis_client
+    sentinel = object()
+    redis_lock_module._redis_client = sentinel  # type: ignore[assignment]
+    try:
+        with patch.object(redis_lock_module, "init_redis_client") as init_spy:
+            result = redis_lock_module.get_redis_client()
+            assert result is sentinel
+            init_spy.assert_not_called()
+    finally:
+        redis_lock_module._redis_client = original


### PR DESCRIPTION
## Problem

Celery worker boots via `celery -A app.celery_app worker` and never imports
`app/main.py`, so the FastAPI lifespan hook that calls `init_redis_client()`
never runs in worker context. The module-level `_redis_client` global stays
`None`, and any task calling `acquire_redis_lock()` crashes with
`RuntimeError("Redis client not initialized")`.

## Affected call sites (4 Celery-reachable)

- `delivery_tasks.sweep_retry_deliveries` — every 2 min
- `delivery_tasks.reconcile_stale_deliveries` — every 15 min
- `delivery_tasks.sync_notification_quotas` — every 6h + 00:01 daily
- `gateways/zalo.refresh_access_token` — ~1×/day at TTL boundary

(Two additional FastAPI-only call sites in `admission_service.py:1151,3177`
are not affected.)

## Fix

Self-heal in `get_redis_client()` by calling `init_redis_client()` (already
idempotent at `redis_lock.py:39`) when `_redis_client is None`. FastAPI
behavior preserved verbatim — `_redis_client` is non-None during handler
context, so the new branch is a no-op there.

**Why this approach**: smallest patch (4 lines), heals all 4 call sites in
one place, race-free under Celery `--pool=prefork` (each prefork child has
own process memory, only one task per process), no test fixture conflicts.

## Test plan

- [x] New regression: `tests/unit/test_redis_lock_lazy_init.py` — 2 tests
  - `test_get_redis_client_lazy_inits_when_uninitialized` (bug fix path)
  - `test_get_redis_client_skips_init_call_when_already_set` (FastAPI eager
    init preserved; uses spy on `init_redis_client` to catch a regression
    where someone removes the `if _redis_client is None` guard)
- [x] No regression: `tests/unit/test_zalo_phase1_review_findings.py` — 56/56 pass
- [x] Smoke: `tests/unit/test_task_utils.py` (from PR #98) — 2/2 pass

## Deploy (manual SSH required)

CI Frontend Lint gate is broken (out of scope here). Same pattern as PR #98/#100:

\`\`\`bash
ssh -i ~/.ssh/id_ed25519_qlts root@qlts.tnpc.edu.vn
cd /opt/qlts && git pull --ff-only origin main
docker compose -f docker-compose.yml --profile production --env-file .env.production build celery-worker celery-beat backend
docker compose -f docker-compose.yml --profile production --env-file .env.production up -d --no-deps celery-worker celery-beat backend
docker compose --env-file .env.production logs celery-worker -f --tail=200
\`\`\`

**Pass criteria** (tail logs ≥30 min):
- Zero `Redis client not initialized` occurrences
- `Sweep enqueued N deliveries for retry` ≥1 (every 2 min, ~15 in 30 min)
- `Reconciliation done: ... queued, ... sent resolved` ≥1 (every 15 min)
- `check_consultation_reminders_task ... succeeded` continues every minute
  (sanity check that PR #98 loop fix still works alongside this)

## Rollback

Single commit, no DB migration, no schema/config change.

\`\`\`bash
gh pr revert <pr-number>
\`\`\`

## Out of scope

- Tech debt: 2 Redis clients (`database.redis_client` vs `redis_lock._redis_client`) duplication
- Tech debt: 2 distributed lock APIs (`acquire_redis_lock` vs `database.redis_distributed_lock`)
- Frontend Lint CI gate (12 ESLint errors blocking auto-deploy)
- 9 pre-existing failing unit tests (csrf, notification_e2, dispatcher, delivery_branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)