### PR TITLE
feat(admissions): MissingGreenlet fixes + computed fields in mutation responses + permanent residence detail

### DIFF
--- a/Backend_FastAPI/CLAUDE.md
+++ b/Backend_FastAPI/CLAUDE.md
@@ -141,6 +141,32 @@ Event namespace `APPLICATION_*` and payload key `application_id` are retained
 for backward compatibility — they refer to `AdmissionProfile.id`, not the removed model.
 Do NOT rename these. See `APPLICATION_LEGACY_CLEANUP.md` for full context.
 
+### Mutation response contract
+
+Any service function that returns an `AdmissionProfile` destined for an API
+response with computed fields **must** call `_populate_response_fields()`
+after `await db.flush()` and before returning. This ensures `permissions`,
+`available_actions`, `step_status`, `eligibility_status`, `validation_errors`,
+`completion_percent`, `assigned_officer_name`, and `assigned_reviewer_name`
+are populated and consistent with what a subsequent `GET` response would
+return. Without this call, computed fields silently fall back to schema
+defaults (`permissions={}`, `eligibility_status="pending"`, etc.) and any
+client that trusts the mutation response will see broken state.
+
+The helper handles `current_user=None` (system callbacks) by skipping
+silently. For functions that delegate to `reload_profile_with_lead`, pass
+`documents=profile.documents` to reuse the eager-loaded list and avoid a
+redundant query. Mutation queries that return their own profile must use
+the nested eager-load pattern:
+```python
+.options(
+    selectinload(models.AdmissionProfile.lead)
+    .selectinload(models.Lead.assigned_officer),
+    selectinload(models.AdmissionProfile.assigned_reviewer),
+)
+```
+Otherwise denormalized name fields will be silently `null`.
+
 ---
 
 ## Common Commands

--- a/Backend_FastAPI/alembic/versions/5448988f1a77_add_permanent_residential_group_and_.py
+++ b/Backend_FastAPI/alembic/versions/5448988f1a77_add_permanent_residential_group_and_.py
@@ -1,0 +1,66 @@
+"""add permanent residential_group and street_address to admission_profile
+
+Revision ID: 5448988f1a77
+Revises: 0e58c2f554f7
+Create Date: 2026-04-06 14:33:40.964088
+
+Adds two free-text fields below the existing province/district/ward
+columns so the admission profile can capture the full Vietnamese
+permanent address per the CCCD form (mẫu CC01):
+
+- ``permanent_residential_group`` (VARCHAR 150) — community sub-unit
+  (Tổ dân phố / Thôn / Buôn / Ấp / Khóm / Khu phố). Free-text because
+  there is no national database of sub-ward units and naming varies
+  across regions.
+- ``permanent_street_address`` (VARCHAR 255) — street address line
+  (số nhà, tên đường). Free-text.
+
+Pure additive migration: no data backfill, both columns nullable, no
+existing column touched. Downgrade simply drops the two columns.
+
+NOTE: ``alembic revision --autogenerate`` produced a much larger diff
+including unrelated column-comment drift on many tables and a
+``DROP TABLE casbin_rule`` operation. That noise has been stripped —
+only the two real ``add_column`` / ``drop_column`` ops remain. If you
+need to clean up the unrelated drift, do it in a separate, focused
+migration.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5448988f1a77'
+down_revision: Union[str, Sequence[str], None] = '0e58c2f554f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the two new permanent address columns."""
+    op.add_column(
+        'admission_profile',
+        sa.Column(
+            'permanent_residential_group',
+            sa.String(length=150),
+            nullable=True,
+            comment='Tổ dân phố / Thôn / Buôn / Ấp / Khóm / Khu phố — community sub-unit, free-text',
+        ),
+    )
+    op.add_column(
+        'admission_profile',
+        sa.Column(
+            'permanent_street_address',
+            sa.String(length=255),
+            nullable=True,
+            comment='Số nhà, tên đường — street address line, free-text',
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the two new permanent address columns."""
+    op.drop_column('admission_profile', 'permanent_street_address')
+    op.drop_column('admission_profile', 'permanent_residential_group')

--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -2220,7 +2220,8 @@ async def get_admission_for_manager(
         select(models.AdmissionProfile)
         .where(models.AdmissionProfile.id == profile_id)
         .options(
-            selectinload(models.AdmissionProfile.lead),
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
             selectinload(models.AdmissionProfile.assigned_reviewer),
         )
         .with_for_update()  # ✅ CRITICAL: Prevent concurrent approve/reject
@@ -2297,7 +2298,8 @@ async def get_admission_for_user(
         select(models.AdmissionProfile)
         .where(models.AdmissionProfile.id == profile_id)
         .options(
-            selectinload(models.AdmissionProfile.lead),
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
             selectinload(models.AdmissionProfile.assigned_reviewer),
         )
         .with_for_update()

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -131,7 +131,21 @@ class AdmissionProfile(Base):
     permanent_province: Mapped[str] = mapped_column(String(100), nullable=True)
     permanent_district: Mapped[str] = mapped_column(String(100), nullable=True)
     permanent_ward: Mapped[str] = mapped_column(String(100), nullable=True)
-    
+    # Sub-ward + street address — free-text. There is no national database
+    # of sub-ward units (tổ dân phố / thôn / buôn / ấp / khóm / khu phố...);
+    # naming varies by region (north/south/highland/Khmer areas) and tổ
+    # numbers are renumbered as populations shift, so a structured lookup
+    # is impractical for the QLTS scope. The CCCD form (mẫu CC01) uses
+    # the same two-line free-text pattern.
+    permanent_residential_group: Mapped[str] = mapped_column(
+        String(150), nullable=True,
+        comment="Tổ dân phố / Thôn / Buôn / Ấp / Khóm / Khu phố — community sub-unit, free-text"
+    )
+    permanent_street_address: Mapped[str] = mapped_column(
+        String(255), nullable=True,
+        comment="Số nhà, tên đường — street address line, free-text"
+    )
+
     place_of_birth: Mapped[str] = mapped_column(String(255), nullable=True)
     native_place: Mapped[str] = mapped_column(String(255), nullable=True)
     

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -603,7 +603,8 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             select(models.AdmissionProfile)
             .where(models.AdmissionProfile.id == profile_id)
             .options(
-                joinedload(models.AdmissionProfile.lead),
+                joinedload(models.AdmissionProfile.lead).joinedload(models.Lead.assigned_officer),
+                selectinload(models.AdmissionProfile.assigned_reviewer),
                 selectinload(models.AdmissionProfile.student),  # Prevent MissingGreenlet
                 selectinload(models.AdmissionProfile.subject_scores).selectinload(ProfileSubjectScore.subject),
                 selectinload(models.AdmissionProfile.documents).joinedload(ProfileDocument.document_type),

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -325,6 +325,14 @@ class AdmissionProfileUpdate(BaseModel):
     permanent_province: Optional[str] = Field(None, max_length=100)
     permanent_district: Optional[str] = Field(None, max_length=100)
     permanent_ward: Optional[str] = Field(None, max_length=100)
+    permanent_residential_group: Optional[str] = Field(
+        None, max_length=150,
+        description="Tổ dân phố / Thôn / Buôn / Ấp / Khóm / Khu phố — community sub-unit, free-text"
+    )
+    permanent_street_address: Optional[str] = Field(
+        None, max_length=255,
+        description="Số nhà, tên đường — street address line, free-text"
+    )
     place_of_birth: Optional[str] = Field(None, max_length=255)
     native_place: Optional[str] = Field(None, max_length=255)
     
@@ -360,9 +368,10 @@ class AdmissionProfileUpdate(BaseModel):
             return None
         return v
 
-    @field_validator('email', 'full_name', 'gender', 'social_insurance_number', 
+    @field_validator('email', 'full_name', 'gender', 'social_insurance_number',
                      'nationality', 'ethnicity', 'religion', 'disability_type',
                      'permanent_province', 'permanent_district', 'permanent_ward',
+                     'permanent_residential_group', 'permanent_street_address',
                      'place_of_birth', 'native_place', mode='before')
     @classmethod
     def empty_str_to_none_text(cls, v):
@@ -533,6 +542,8 @@ class AdmissionProfileResponse(BaseModel):
     permanent_province: Optional[str] = None
     permanent_district: Optional[str] = None
     permanent_ward: Optional[str] = None
+    permanent_residential_group: Optional[str] = None
+    permanent_street_address: Optional[str] = None
     place_of_birth: Optional[str] = None
     native_place: Optional[str] = None
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -768,6 +768,65 @@ def _compute_frontend_fields(
     profile.citizen_id_masked = mask_citizen_id(profile.citizen_id)
 
 
+async def _populate_response_fields(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    current_user: Optional[models.User],
+    *,
+    documents: Optional[List[models.ProfileDocument]] = None,
+) -> None:
+    """Populate transient computed fields on a profile for API response serialization.
+
+    Call this AFTER ``await db.flush()`` and BEFORE returning from any mutation
+    function whose return value is serialized via ``AdmissionProfileResponse``.
+    Without this call, computed fields (``permissions``, ``available_actions``,
+    ``eligibility_status``, ``step_status``, ``completion_percent``,
+    ``validation_errors``, ``assigned_officer_name``, ``assigned_reviewer_name``)
+    silently fall back to schema defaults — making mutation responses diverge
+    from subsequent ``GET`` responses.
+
+    Args:
+        db: AsyncSession used to (optionally) load fresh documents.
+        profile: AdmissionProfile mutated in-place by ``_compute_frontend_fields``.
+        current_user: Acting user. May be ``None`` for system callbacks (e.g. a
+            future payment gateway hitting ``record_application_fee_payment``
+            without a user context). When ``None`` the helper is a no-op:
+            computed fields stay at schema defaults, which is acceptable for
+            non-user-facing flows because there is no UI rendering that needs
+            ``permissions``.
+        documents: Optional pre-loaded list of ``ProfileDocument``. If ``None``
+            the helper fetches them via ``AdmissionRepository.get_all_documents``.
+            Pass when documents are already loaded (e.g. after
+            ``reload_profile_with_lead``) to avoid a redundant query.
+
+    Requires ``profile.lead`` (with nested ``lead.assigned_officer``) and
+    ``profile.assigned_reviewer`` to already be eager-loaded by the caller —
+    use the nested ``selectinload`` pattern from ``update_profile`` or the
+    ``get_admission_for_manager`` / ``get_admission_for_user`` dependencies.
+    Missing eager-loads will silently produce ``null`` denormalized name fields
+    rather than crash, because ``_compute_frontend_fields`` uses
+    ``profile.__dict__.get(...)``.
+    """
+    if current_user is None:
+        # System callback path: no role/permissions to compute. Skip silently.
+        return
+
+    from app.repositories import AdmissionRepository
+    admission_repo = AdmissionRepository(db)
+
+    # Populate transient score fields (average_score, total_score, snapshot_score,
+    # admission_scores). _compute_frontend_fields → _validate_scores reads these
+    # via direct attribute access and would AttributeError on a freshly DB-loaded
+    # profile. Mirror update_profile's pattern: fetch fresh scores then compute.
+    fresh_scores = await admission_repo.get_profile_scores(profile.id)
+    _calculate_and_update_totals(profile, scores=fresh_scores)
+
+    if documents is None:
+        documents = await admission_repo.get_all_documents(profile.id)
+
+    _compute_frontend_fields(profile, current_user, documents)
+
+
 async def _create_admission_milestone_consultation(
     db: AsyncSession,
     lead: models.Lead,
@@ -3302,12 +3361,16 @@ async def approve_profile(
     stmt = (
         select(models.AdmissionProfile)
         .where(models.AdmissionProfile.id == profile_id)
-        .options(selectinload(models.AdmissionProfile.lead)) 
+        .options(
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
         .with_for_update() # Lock the row
     )
     result = await db.execute(stmt)
     profile = result.scalar_one_or_none()
-    
+
     if not profile:
         raise ResourceNotFoundError(f"Admission profile {profile_id} not found")
 
@@ -3383,6 +3446,9 @@ async def approve_profile(
 
     await db.flush()  # Flush, don't commit! Router commits.
 
+    # Populate transient computed fields so the mutation response matches GET.
+    await _populate_response_fields(db, profile, approver)
+
     # Audit trail: log approval
     from ..services import audit_service
     await audit_service.log_status_change(
@@ -3457,12 +3523,16 @@ async def reject_profile(
     stmt = (
         select(models.AdmissionProfile)
         .where(models.AdmissionProfile.id == profile_id)
-        .options(selectinload(models.AdmissionProfile.lead)) 
+        .options(
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
         .with_for_update() # Lock the row
     )
     result = await db.execute(stmt)
     profile = result.scalar_one_or_none()
-    
+
     if not profile:
         raise ResourceNotFoundError(f"Admission profile {profile_id} not found")
 
@@ -3523,6 +3593,9 @@ async def reject_profile(
         )
 
     await db.flush()
+
+    # Populate transient computed fields so the mutation response matches GET.
+    await _populate_response_fields(db, profile, rejector)
 
     # Audit trail: log rejection
     from ..services import audit_service
@@ -3592,7 +3665,11 @@ async def request_revision(
     stmt = (
         select(models.AdmissionProfile)
         .where(models.AdmissionProfile.id == profile_id)
-        .options(selectinload(models.AdmissionProfile.lead))
+        .options(
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
         .with_for_update()
     )
     result = await db.execute(stmt)
@@ -3653,6 +3730,9 @@ async def request_revision(
         )
 
     await db.flush()
+
+    # Populate transient computed fields so the mutation response matches GET.
+    await _populate_response_fields(db, profile, reviewer)
 
     # Audit trail
     from ..services import audit_service
@@ -3731,7 +3811,11 @@ async def record_application_fee_payment(
     stmt = (
         select(models.AdmissionProfile)
         .where(models.AdmissionProfile.id == profile_id)
-        .options(selectinload(models.AdmissionProfile.lead))
+        .options(
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
         .with_for_update()
     )
     result = await db.execute(stmt)
@@ -3785,6 +3869,10 @@ async def record_application_fee_payment(
     )
 
     await db.flush()
+
+    # Populate transient computed fields so the mutation response matches GET.
+    # Helper handles recorded_by=None silently (system callback path).
+    await _populate_response_fields(db, profile, recorded_by)
 
     log.info(
         "Application fee payment recorded",
@@ -3869,12 +3957,16 @@ async def resubmit_profile(
     stmt = (
         select(models.AdmissionProfile)
         .where(models.AdmissionProfile.id == profile_id)
-        .options(selectinload(models.AdmissionProfile.lead)) 
+        .options(
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
         .with_for_update() # Lock the row
     )
     result = await db.execute(stmt)
     profile = result.scalar_one_or_none()
-    
+
     if not profile:
         raise ResourceNotFoundError(f"Admission profile {profile_id} not found")
 
@@ -3948,6 +4040,9 @@ async def resubmit_profile(
     )
 
     await db.flush()
+
+    # Populate transient computed fields so the mutation response matches GET.
+    await _populate_response_fields(db, profile, officer)
 
     # Audit trail: log resubmission
     from ..services import audit_service
@@ -4161,6 +4256,9 @@ async def override_profile(
 
     await db.flush()
 
+    # Populate transient computed fields so the mutation response matches GET.
+    await _populate_response_fields(db, profile, admin)
+
     # AUDIT LOG (per AUTHORIZATION_DECISIONS.md Decision 11)
     # TODO: Implement proper audit log table
     log.warning(
@@ -4214,7 +4312,11 @@ async def claim_review(
 
     if profile.assigned_reviewer_id:
         if profile.assigned_reviewer_id == reviewer.id:
-            # Idempotent success (already claimed by self)
+            # Idempotent success (already claimed by self).
+            # Still populate transient computed fields so the response matches
+            # what a fresh GET would return — router holds the same `profile`
+            # reference via the dependency.
+            await _populate_response_fields(db, profile, reviewer)
             return
 
         # Already claimed by someone else
@@ -4229,6 +4331,9 @@ async def claim_review(
     profile.updated_at = datetime.now(timezone.utc)
 
     await db.flush()
+
+    # Populate transient computed fields so the mutation response matches GET.
+    await _populate_response_fields(db, profile, reviewer)
 
     # Audit trail
     from ..services import audit_service
@@ -4288,6 +4393,9 @@ async def unclaim_review(
     profile.updated_at = datetime.now(timezone.utc)
 
     await db.flush()
+
+    # Populate transient computed fields so the mutation response matches GET.
+    await _populate_response_fields(db, profile, current_user)
 
     # Audit trail
     from ..services import audit_service
@@ -4378,6 +4486,10 @@ async def finalize_profile(
     from app.repositories import AdmissionRepository
     admission_repo = AdmissionRepository(db)
     profile = await admission_repo.reload_profile_with_lead(profile.id)
+
+    # Populate transient computed fields so the mutation response matches GET.
+    # reload_profile_with_lead already eager-loads documents, so reuse them.
+    await _populate_response_fields(db, profile, admin, documents=profile.documents)
 
     # POST-COMMIT CALLBACK
     async def post_commit():
@@ -4653,7 +4765,11 @@ async def mark_student_dropped(
     stmt = (
         select(models.AdmissionProfile)
         .where(models.AdmissionProfile.id == profile_id)
-        .options(selectinload(models.AdmissionProfile.lead))
+        .options(
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
         .with_for_update()
     )
     result = await db.execute(stmt)
@@ -4704,6 +4820,9 @@ async def mark_student_dropped(
         )
 
     await db.flush()
+
+    # Populate transient computed fields so the mutation response matches GET.
+    await _populate_response_fields(db, profile, actor)
 
     # Audit trail
     from ..services import audit_service

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1533,8 +1533,19 @@ async def create_profile(
     # Step 17: Reload with relationships for response
     new_profile = await admission_repo.reload_profile_with_lead(new_profile.id)
 
-    # Calculate totals for response
-    _calculate_and_update_totals(new_profile)
+    # Populate transient computed fields so the create response matches GET.
+    # Without this, permissions={}, available_actions=[], validation_errors=[],
+    # and assigned_officer_name=None leak to the client, breaking any frontend
+    # that trusts the create response without re-fetching (MEDIUM #2 followup —
+    # commit 1528bc89 fixed the 10 state-changing mutations but missed create).
+    # reload_profile_with_lead already eager-loads documents + lead.assigned_officer
+    # + assigned_reviewer + student + subject_scores, so pass the loaded documents
+    # to avoid a redundant get_all_documents() query inside the helper. The helper
+    # also calls _calculate_and_update_totals() internally, so we don't need a
+    # separate call here.
+    await _populate_response_fields(
+        db, new_profile, current_user, documents=new_profile.documents
+    )
 
     # ✅ SYNC: Update lead consultation status to match admission status
     from .lead_admission_sync import sync_lead_from_admission

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2000,12 +2000,18 @@ async def update_profile(
     
     # ✅ Fix: Fetch fresh scores but do NOT assign to profile.subject_scores (avoid SA error)
     fresh_scores = await admission_repo.get_profile_scores(profile.id)
-    
+
     # Calculate totals for response using fresh data
     _calculate_and_update_totals(profile, scores=fresh_scores)
 
-    # ✅ Fix: Re-compute validation errors/status with new scores
-    _compute_frontend_fields(profile, current_user)
+    # ✅ Fix: Re-compute validation errors/status with new scores + fresh documents.
+    # Must pass documents, otherwise _validate_documents() short-circuits (returns no doc errors)
+    # and documents_checklist is rebuilt with all statuses = "missing", causing the response to
+    # claim validation_errors=[] and eligibility="eligible" even when mandatory docs are missing
+    # (or, conversely, showing "missing" for docs that are actually uploaded). See MEDIUM #1 in
+    # the post-BUG-001 residual risks audit.
+    documents = await admission_repo.get_all_documents(profile.id)
+    _compute_frontend_fields(profile, current_user, documents)
 
     # Audit trail: log profile update with field-level changes
     from ..services import audit_service

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -456,18 +456,15 @@ def _compute_frontend_fields(
     profile.available_actions = [action for action, allowed in permissions.items() if allowed]
 
     # Denormalized display names (avoid N+1 in frontend)
-    profile.assigned_reviewer_name = (
-        profile.assigned_reviewer.full_name
-        if hasattr(profile, 'assigned_reviewer') and profile.assigned_reviewer
-        else None
-    )
-    profile.assigned_officer_name = (
-        profile.lead.assigned_officer.full_name
-        if (profile.lead
-            and hasattr(profile.lead, 'assigned_officer')
-            and profile.lead.assigned_officer)
-        else None
-    )
+    # ⚠️ Use __dict__.get() instead of hasattr/getattr to avoid triggering
+    # SQLAlchemy lazy-load from a sync function (raises MissingGreenlet in async session).
+    # Callers MUST eager-load these relationships via selectinload() before reaching here.
+    _reviewer = profile.__dict__.get("assigned_reviewer")
+    profile.assigned_reviewer_name = _reviewer.full_name if _reviewer else None
+
+    _lead = profile.__dict__.get("lead")
+    _officer = _lead.__dict__.get("assigned_officer") if _lead else None
+    profile.assigned_officer_name = _officer.full_name if _officer else None
 
     # =========================================================================
     # 3. ELIGIBILITY STATUS & VALIDATION ERRORS
@@ -1803,7 +1800,13 @@ async def update_profile(
     stmt = (
         select(models.AdmissionProfile)
         .where(models.AdmissionProfile.id == profile_id)
-        .options(selectinload(models.AdmissionProfile.lead)) # Eager load lead for IDOR check
+        .options(
+            # Eager load lead for IDOR check + nested assigned_officer for _compute_frontend_fields
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            # Eager load assigned_reviewer for _compute_frontend_fields
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
         .with_for_update() # Lock the row
     )
     result = await db.execute(stmt)

--- a/Backend_FastAPI/tests/fixtures/database.py
+++ b/Backend_FastAPI/tests/fixtures/database.py
@@ -5,6 +5,7 @@ Track T: Extracted database management fixtures from conftest.py.
 Contains: safety check, schema init, table truncation.
 Uses NullPool to avoid asyncpg prepared-statement cache pollution.
 """
+import asyncio
 import logging
 
 from sqlalchemy import text
@@ -52,7 +53,42 @@ async def init_schema_once(settings, AppBase, CasbinBase=None):
 
     Uses a SEPARATE short-lived engine (NullPool) for DDL to avoid
     asyncpg prepared-statement cache pollution.
+
+    The pg_terminate_backend cleanup runs in its own short-lived engine and
+    transaction, BEFORE any DDL. Doing it inline with DROP SCHEMA / CREATE
+    SCHEMA inside the same transaction caused intermittent
+    ConnectionDoesNotExistError flakes — pg_terminate_backend is async at
+    PostgreSQL level (sends SIGTERM but doesn't wait for cleanup), so the
+    killed backends could still hold locks when the next DDL statement ran.
     """
+    # Phase 0: Kill orphaned backends from any previous test process /
+    # interrupted run, in its own dedicated engine + transaction. After this
+    # connection closes, PostgreSQL has time to actually reap the killed
+    # backends before the schema-reset engine opens its first connection.
+    kill_engine = _create_engine(
+        settings.DATABASE_URL,
+        poolclass=NullPool,
+        connect_args={"command_timeout": 60},
+    )
+    try:
+        async with kill_engine.begin() as kill_conn:
+            await kill_conn.execute(text(
+                "SELECT pg_terminate_backend(pid) "
+                "FROM pg_stat_activity "
+                "WHERE datname = current_database() "
+                "AND pid <> pg_backend_pid()"
+            ))
+        log.info("[Schema Init] Phase 0: orphan backend cleanup complete")
+    finally:
+        await kill_engine.dispose()
+
+    # Brief pause so PostgreSQL can actually finish releasing the locks
+    # held by the just-killed backends. 200ms is empirically enough; without
+    # it, DROP SCHEMA in Phase 1 can race with backend teardown.
+    await asyncio.sleep(0.2)
+
+    # Phase 1: DROP + CREATE schema in a fresh engine + transaction.
+    # No more pg_terminate_backend mixed in here.
     setup_engine = _create_engine(
         settings.DATABASE_URL,
         poolclass=NullPool,
@@ -60,21 +96,14 @@ async def init_schema_once(settings, AppBase, CasbinBase=None):
     )
 
     try:
-        # Step 1: DROP SCHEMA CASCADE (clean slate)
         async with setup_engine.begin() as conn:
-            await conn.execute(text(
-                "SELECT pg_terminate_backend(pid) "
-                "FROM pg_stat_activity "
-                "WHERE datname = current_database() "
-                "AND pid <> pg_backend_pid()"
-            ))
             await conn.execute(text("DROP SCHEMA public CASCADE"))
             await conn.execute(text("CREATE SCHEMA public"))
-        log.info("[Schema Init] Step 1: DROP SCHEMA CASCADE complete")
+        log.info("[Schema Init] Phase 1: DROP SCHEMA CASCADE complete")
 
         await setup_engine.dispose()
 
-        # Step 2: Recreate with fresh engine
+        # Phase 2: Recreate tables with another fresh engine
         setup_engine = _create_engine(
             settings.DATABASE_URL,
             poolclass=NullPool,
@@ -130,7 +159,7 @@ async def init_schema_once(settings, AppBase, CasbinBase=None):
                 "SELECT COUNT(*) FROM pg_tables WHERE schemaname = 'public'"
             ))
             table_count = tc.scalar()
-            log.info(f"[Schema Init] Step 2: Created {table_count} tables")
+            log.info(f"[Schema Init] Phase 2: Created {table_count} tables")
             if table_count == 0:
                 raise RuntimeError("Schema init produced 0 tables!")
     finally:

--- a/Backend_FastAPI/tests/services/test_admission_resubmit_flow.py
+++ b/Backend_FastAPI/tests/services/test_admission_resubmit_flow.py
@@ -278,7 +278,7 @@ class TestResubmitEndpoint:
 
         resubmit_response = await client.post(
             f"/api/admissions/{profile.id}/resubmit",
-            json={"notes": "Uploaded all missing documents"},
+            json={"version": profile.version, "notes": "Uploaded all missing documents"},
             headers=headers,
         )
 
@@ -313,7 +313,7 @@ class TestResubmitEndpoint:
 
         resubmit_response = await client.post(
             f"/api/admissions/{profile.id}/resubmit",
-            json={"notes": "Should not work"},
+            json={"version": profile.version, "notes": "Should not work"},
             headers=headers,
         )
 
@@ -338,7 +338,7 @@ class TestResubmitEndpoint:
 
         resubmit_response = await client.post(
             f"/api/admissions/{profile.id}/resubmit",
-            json={"notes": "Should not work"},
+            json={"version": profile.version, "notes": "Should not work"},
             headers=headers,
         )
 

--- a/Backend_FastAPI/tests/services/test_admission_service.py
+++ b/Backend_FastAPI/tests/services/test_admission_service.py
@@ -1116,3 +1116,505 @@ class TestAutoAssignOfficer:
             lead = result.scalar_one()
             assert lead.assigned_officer_id == officer_user_in_db["id"], \
                 f"Expected auto-assign to officer {officer_user_in_db['id']}, got {lead.assigned_officer_id}"
+
+
+# ==============================================================================
+# TEST: MEDIUM #2 — MUTATION RESPONSE CONTRACT
+# ==============================================================================
+#
+# Background: 10 admission mutation endpoints (approve/reject/request_revision/
+# resubmit/record_fee/override/finalize/claim/unclaim/mark_dropped) used to
+# return AdmissionProfileResponse with empty defaults for every computed field
+# (permissions={}, available_actions=[], eligibility_status="pending", etc.)
+# because the service functions never called _compute_frontend_fields() before
+# returning. The fix added a single helper `_populate_response_fields` that is
+# called after `await db.flush()` in each function.
+#
+# These tests assert the post-mutation response has populated computed fields,
+# proving the helper ran. They also cross-check key fields against a subsequent
+# GET response to lock in the contract that PUT/POST responses match GET.
+#
+# Test strength was verified across 3 patterns by reverting helper calls in
+# approve_profile (own-query), claim_review (dependency + idempotent), and
+# finalize_profile (delegated/reload). Each revert produced a clear FAIL.
+# ==============================================================================
+
+
+async def _create_profile_with_state(
+    client: AsyncClient,
+    setup_user: dict,
+    seed_lead_dependencies: dict,
+    target_status: str,
+    *,
+    mandatory_doc_codes: list = None,
+    assigned_reviewer_id: int = None,
+    rejection_reason: str = None,
+    requires_application_fee: bool = False,
+) -> tuple[int, int, dict]:
+    """Create a profile via API then patch its state directly in DB.
+
+    Bypasses state machine validation. State machine correctness is covered by
+    tests/integration/test_admission_state_transitions.py separately.
+
+    Returns:
+        (profile_id, version, setup_headers)
+    """
+    from sqlalchemy import update as sql_update
+
+    unit_id = seed_lead_dependencies["unit_id"]
+    major_id = seed_lead_dependencies["major_program_id"]
+
+    data = await setup_admission_api_data(
+        major_id=major_id,
+        unit_id=unit_id,
+        officer_id=setup_user["id"],
+        academic_year=2025,
+    )
+    headers = await get_auth_headers(client, setup_user)
+
+    create_response = await client.post(
+        "/api/admissions",
+        json={
+            "lead_id": data["lead_id"],
+            "admission_method_id": data["admission_method_id"],
+        },
+        headers=headers,
+    )
+    assert create_response.status_code == 201, f"Create failed: {create_response.text}"
+    profile_id = create_response.json()["id"]
+
+    # Patch DB to put the profile into the requested state
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            result = await session.execute(
+                select(models.AdmissionProfile).where(
+                    models.AdmissionProfile.id == profile_id
+                )
+            )
+            profile = result.scalar_one()
+            patched_rules = dict(profile.applied_rules or {})
+            if mandatory_doc_codes is not None:
+                patched_rules["mandatory_docs"] = mandatory_doc_codes
+                patched_rules["upload_required_docs"] = mandatory_doc_codes
+            if requires_application_fee:
+                patched_rules["requires_application_fee"] = True
+                patched_rules["fee_amount"] = 500000
+                patched_rules["fee_status"] = "pending"
+
+            update_values = {
+                "status": target_status,
+                "applied_rules": patched_rules,
+                "citizen_id": f"099{random.randint(100000000, 999999999)}",
+            }
+            if assigned_reviewer_id is not None:
+                update_values["assigned_reviewer_id"] = assigned_reviewer_id
+                update_values["assigned_at"] = datetime.now(timezone.utc)
+            if rejection_reason is not None:
+                update_values["rejection_reason"] = rejection_reason
+
+            await session.execute(
+                sql_update(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == profile_id)
+                .values(**update_values)
+            )
+
+    # Return current version (always 1 right after create+patch since version is not bumped by sql_update)
+    return profile_id, 1, headers
+
+
+def _assert_computed_fields_populated(body: dict, context: str = "") -> None:
+    """Assert response body has populated computed fields (not schema defaults).
+
+    These three checks prove `_compute_frontend_fields` ran:
+    - permissions: dict, default={}, populated should have ≥1 key
+    - step_status: dict, default={}, populated should have keys "1".."7"
+    - eligibility_status: default="pending", populated should be "eligible"/"ineligible"
+    """
+    msg_prefix = f"[{context}] " if context else ""
+
+    permissions = body.get("permissions")
+    assert isinstance(permissions, dict) and len(permissions) > 0, (
+        f"{msg_prefix}permissions should be non-empty dict (computed by helper), "
+        f"got {permissions!r}. MEDIUM #2 regressed — _populate_response_fields "
+        f"call may be missing or didn't run."
+    )
+
+    step_status = body.get("step_status")
+    assert isinstance(step_status, dict) and len(step_status) > 0, (
+        f"{msg_prefix}step_status should be non-empty dict (computed by helper), "
+        f"got {step_status!r}"
+    )
+
+    eligibility = body.get("eligibility_status")
+    assert eligibility in ("eligible", "ineligible"), (
+        f"{msg_prefix}eligibility_status should be 'eligible' or 'ineligible' "
+        f"(computed), got {eligibility!r}. Default 'pending' indicates the "
+        f"helper didn't run."
+    )
+
+
+class TestApproveResponseFields:
+    """Mutation: POST /api/admissions/{id}/approve must populate computed fields."""
+
+    async def test_approve_response_has_populated_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        profile_id, version, _ = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="submitted",
+        )
+        manager_headers = await get_auth_headers(client, manager_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile_id}/approve",
+            json={"version": version, "notes": "Approved for test"},
+            headers=manager_headers,
+        )
+        assert response.status_code in (200, 201), f"Approve failed: {response.text}"
+        body = response.json()
+        _assert_computed_fields_populated(body, context="approve")
+
+        # Cross-check with GET — PUT/POST response should match GET
+        get_response = await client.get(
+            f"/api/admissions/{profile_id}", headers=manager_headers
+        )
+        assert get_response.status_code == 200
+        get_body = get_response.json()
+        assert body.get("eligibility_status") == get_body.get("eligibility_status"), (
+            "approve response eligibility_status diverges from GET"
+        )
+
+
+class TestRejectResponseFields:
+    """Mutation: POST /api/admissions/{id}/reject must populate computed fields."""
+
+    async def test_reject_response_has_populated_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        profile_id, version, _ = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="submitted",
+        )
+        manager_headers = await get_auth_headers(client, manager_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile_id}/reject",
+            json={"version": version, "reason": "Missing required documents for test"},
+            headers=manager_headers,
+        )
+        assert response.status_code in (200, 201), f"Reject failed: {response.text}"
+        _assert_computed_fields_populated(response.json(), context="reject")
+
+
+class TestRequestRevisionResponseFields:
+    """Mutation: POST /api/admissions/{id}/request-revision must populate computed fields."""
+
+    async def test_request_revision_response_has_populated_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        profile_id, version, _ = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="submitted",
+        )
+        manager_headers = await get_auth_headers(client, manager_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile_id}/request-revision",
+            json={"version": version, "reason": "Please clarify the academic history section"},
+            headers=manager_headers,
+        )
+        assert response.status_code in (200, 201), f"Request revision failed: {response.text}"
+        _assert_computed_fields_populated(response.json(), context="request-revision")
+
+
+class TestResubmitResponseFields:
+    """Mutation: POST /api/admissions/{id}/resubmit must populate computed fields."""
+
+    async def test_resubmit_response_has_populated_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        profile_id, version, officer_headers = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="rejected",
+            rejection_reason="Previous rejection reason for test",
+        )
+
+        response = await client.post(
+            f"/api/admissions/{profile_id}/resubmit",
+            json={"version": version, "notes": "Fixed all issues"},
+            headers=officer_headers,
+        )
+        assert response.status_code in (200, 201), f"Resubmit failed: {response.text}"
+        _assert_computed_fields_populated(response.json(), context="resubmit")
+
+
+class TestRecordFeePaymentResponseFields:
+    """Mutation: POST /api/admissions/{id}/record-fee-payment must populate computed fields."""
+
+    async def test_record_fee_payment_response_has_populated_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        profile_id, _, _ = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="submitted",
+            requires_application_fee=True,
+        )
+        admin_headers = await get_auth_headers(client, admin_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile_id}/record-fee-payment"
+            f"?transaction_id=TXN-TEST-{random.randint(10000, 99999)}&amount=500000",
+            headers=admin_headers,
+        )
+        assert response.status_code in (200, 201), f"Record fee failed: {response.text}"
+        _assert_computed_fields_populated(response.json(), context="record-fee-payment")
+
+
+class TestDropStudentResponseFields:
+    """Mutation: POST /api/admissions/{id}/drop must populate computed fields."""
+
+    async def test_drop_response_has_populated_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        profile_id, version, _ = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="enrolled",
+        )
+        manager_headers = await get_auth_headers(client, manager_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile_id}/drop",
+            json={"version": version, "reason": "Test drop: student transferred"},
+            headers=manager_headers,
+        )
+        assert response.status_code in (200, 201), f"Drop failed: {response.text}"
+        _assert_computed_fields_populated(response.json(), context="drop")
+
+
+class TestOverrideResponseFields:
+    """Mutation: POST /api/admissions/{id}/override must populate computed fields."""
+
+    async def test_override_response_has_populated_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        profile_id, _, _ = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="approved",
+        )
+        admin_headers = await get_auth_headers(client, admin_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile_id}/override",
+            json={"reason": "Special case for scholarship recipient", "bypass_rules": []},
+            headers=admin_headers,
+        )
+        assert response.status_code in (200, 201), f"Override failed: {response.text}"
+        _assert_computed_fields_populated(response.json(), context="override")
+
+
+class TestFinalizeResponseFields:
+    """Mutation: POST /api/admissions/{id}/finalize must populate computed fields.
+
+    finalize_profile is the trickiest in-scope function: it delegates to
+    enroll_student (which creates a Student record) then calls
+    reload_profile_with_lead. The helper is called with pre-loaded documents
+    to avoid a redundant query.
+    """
+
+    async def test_finalize_response_has_populated_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        profile_id, _, _ = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="confirmed",
+        )
+        admin_headers = await get_auth_headers(client, admin_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile_id}/finalize",
+            json={},
+            headers=admin_headers,
+        )
+        assert response.status_code in (200, 201), f"Finalize failed: {response.text}"
+        _assert_computed_fields_populated(response.json(), context="finalize")
+
+
+class TestClaimResponseFields:
+    """Mutation: POST /api/admissions/{id}/claim must populate computed fields."""
+
+    async def test_claim_response_has_populated_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        profile_id, version, _ = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="submitted",
+        )
+        manager_headers = await get_auth_headers(client, manager_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile_id}/claim",
+            json={"version": version},
+            headers=manager_headers,
+        )
+        assert response.status_code in (200, 201), f"Claim failed: {response.text}"
+        _assert_computed_fields_populated(response.json(), context="claim")
+
+
+class TestUnclaimResponseFields:
+    """Mutation: POST /api/admissions/{id}/unclaim must populate computed fields."""
+
+    async def test_unclaim_response_has_populated_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        profile_id, version, _ = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="submitted",
+            assigned_reviewer_id=manager_user_in_db["id"],
+        )
+        manager_headers = await get_auth_headers(client, manager_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile_id}/unclaim",
+            json={"version": version},
+            headers=manager_headers,
+        )
+        assert response.status_code in (200, 201), f"Unclaim failed: {response.text}"
+        _assert_computed_fields_populated(response.json(), context="unclaim")
+
+
+# ==============================================================================
+# SPECIAL TESTS: edge cases highlighted by plan v3 evaluation
+# ==============================================================================
+
+
+class TestRecordFeePaymentNoneRecordedBy:
+    """Direct service-level call: helper must not crash when recorded_by=None.
+
+    Simulates a future payment-gateway callback that has no user context.
+    The helper signature accepts Optional[User] and skips silently when None,
+    preventing AttributeError at _compute_frontend_fields:419 (current_user.role).
+    """
+
+    async def test_record_fee_payment_with_none_recorded_by_does_not_crash(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        from app.services import admission_service
+
+        profile_id, _, _ = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="submitted",
+            requires_application_fee=True,
+        )
+
+        # Direct service call with recorded_by=None — must not raise
+        async with AsyncSessionLocal() as session:
+            try:
+                profile, _callback = await admission_service.record_application_fee_payment(
+                    db=session,
+                    profile_id=profile_id,
+                    payment_data={
+                        "transaction_id": f"TXN-NONE-{random.randint(10000, 99999)}",
+                        "amount": 500000,
+                    },
+                    recorded_by=None,
+                )
+                await session.commit()
+            except AttributeError as exc:
+                pytest.fail(
+                    f"record_application_fee_payment crashed when recorded_by=None: {exc}. "
+                    f"_populate_response_fields may not be handling the None case."
+                )
+
+        # Status should be updated
+        assert profile is not None
+        assert profile.id == profile_id
+
+
+class TestClaimReviewIdempotent:
+    """Idempotent claim path: when same reviewer claims twice, the second call
+    must still return populated computed fields. The fix adds a helper call
+    BEFORE the early `return` in the idempotent branch of claim_review.
+    """
+
+    async def test_claim_review_idempotent_response_has_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        profile_id, version, _ = await _create_profile_with_state(
+            client, officer_user_in_db, seed_lead_dependencies,
+            target_status="submitted",
+        )
+        manager_headers = await get_auth_headers(client, manager_user_in_db)
+
+        # First claim — normal path (state mutation)
+        first_response = await client.post(
+            f"/api/admissions/{profile_id}/claim",
+            json={"version": version},
+            headers=manager_headers,
+        )
+        assert first_response.status_code in (200, 201), (
+            f"First claim failed: {first_response.text}"
+        )
+        first_body = first_response.json()
+        _assert_computed_fields_populated(first_body, context="claim-first")
+
+        # Second claim by SAME reviewer — idempotent early-return path.
+        # Use the version returned by the first claim (it was bumped).
+        second_version = first_body.get("version", version + 1)
+        second_response = await client.post(
+            f"/api/admissions/{profile_id}/claim",
+            json={"version": second_version},
+            headers=manager_headers,
+        )
+        assert second_response.status_code in (200, 201), (
+            f"Second (idempotent) claim failed: {second_response.text}"
+        )
+        _assert_computed_fields_populated(
+            second_response.json(),
+            context="claim-idempotent (proves helper ran in early-return path)",
+        )

--- a/Backend_FastAPI/tests/services/test_admission_service.py
+++ b/Backend_FastAPI/tests/services/test_admission_service.py
@@ -1618,3 +1618,110 @@ class TestClaimReviewIdempotent:
             second_response.json(),
             context="claim-idempotent (proves helper ran in early-return path)",
         )
+
+
+class TestCreateProfileResponseFields:
+    """Mutation: POST /api/admissions must populate computed fields in create response.
+
+    MEDIUM #2 followup: commit 1528bc89 fixed the 10 state-changing mutations
+    (approve/reject/update/resubmit/claim/etc.) but missed create_profile. Without
+    the _populate_response_fields call, the create response returns permissions={},
+    available_actions=[], step_status={}, and eligibility_status="pending", breaking
+    any frontend that renders edit/submit buttons based on the create response
+    without re-fetching.
+
+    Covers the first mutation a user hits in the admission workflow.
+    """
+
+    async def test_create_response_has_populated_computed_fields(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """POST /api/admissions response body must have populated computed fields.
+
+        Uses the same 3-signal assertion as the other Test*ResponseFields classes:
+        - permissions non-empty dict
+        - step_status non-empty dict
+        - eligibility_status resolved to 'eligible' / 'ineligible' (not 'pending')
+        """
+        unit_id = seed_lead_dependencies["unit_id"]
+        major_id = seed_lead_dependencies["major_program_id"]
+
+        data = await setup_admission_api_data(
+            major_id=major_id,
+            unit_id=unit_id,
+            officer_id=officer_user_in_db["id"],
+            academic_year=2026,
+        )
+        headers = await get_auth_headers(client, officer_user_in_db)
+
+        response = await client.post(
+            "/api/admissions",
+            json={
+                "lead_id": data["lead_id"],
+                "admission_method_id": data["admission_method_id"],
+            },
+            headers=headers,
+        )
+        assert response.status_code == 201, f"Create failed: {response.text}"
+        body = response.json()
+        _assert_computed_fields_populated(body, context="create")
+
+    async def test_create_response_matches_subsequent_get(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """The create response must match what a fresh GET returns.
+
+        This is the core guarantee of the mutation response contract: a client
+        that uses the create response directly (without re-fetching) sees the
+        same computed state as a client that does re-fetch.
+        """
+        unit_id = seed_lead_dependencies["unit_id"]
+        major_id = seed_lead_dependencies["major_program_id"]
+
+        data = await setup_admission_api_data(
+            major_id=major_id,
+            unit_id=unit_id,
+            officer_id=officer_user_in_db["id"],
+            academic_year=2026,
+        )
+        headers = await get_auth_headers(client, officer_user_in_db)
+
+        create_response = await client.post(
+            "/api/admissions",
+            json={
+                "lead_id": data["lead_id"],
+                "admission_method_id": data["admission_method_id"],
+            },
+            headers=headers,
+        )
+        assert create_response.status_code == 201, f"Create failed: {create_response.text}"
+        create_body = create_response.json()
+
+        get_response = await client.get(
+            f"/api/admissions/{create_body['id']}", headers=headers
+        )
+        assert get_response.status_code == 200, f"GET failed: {get_response.text}"
+        get_body = get_response.json()
+
+        # Cross-check computed fields between create response and GET response.
+        # These are the fields _populate_response_fields is responsible for.
+        for field in (
+            "permissions",
+            "available_actions",
+            "step_status",
+            "eligibility_status",
+            "completion_percent",
+            "assigned_officer_name",
+            "assigned_reviewer_name",
+        ):
+            assert create_body.get(field) == get_body.get(field), (
+                f"[create vs GET] field {field!r} diverges: "
+                f"create={create_body.get(field)!r}, get={get_body.get(field)!r}. "
+                f"_populate_response_fields may be missing from create_profile."
+            )

--- a/Backend_FastAPI/tests/services/test_admission_service.py
+++ b/Backend_FastAPI/tests/services/test_admission_service.py
@@ -581,6 +581,183 @@ class TestUpdateProfileLazyLoadRegression:
         )
 
 
+class TestUpdateProfileDocumentsInResponse:
+    """Regression tests for MEDIUM #1: update_profile response must reflect actual document state.
+
+    Background: update_profile() used to call _compute_frontend_fields(profile, current_user)
+    without passing `documents`, causing _validate_documents() to short-circuit (it only runs
+    when `documents is not None`, per admission_service.py:283) and documents_checklist to be
+    rebuilt from applied_rules with all statuses = "missing" (per admission_service.py:640).
+
+    Result: PUT /api/admissions/{id} returned validation_errors=[] and eligibility="eligible"
+    even when mandatory documents were missing, and conversely reported documents_checklist
+    statuses as "missing" even when docs were already uploaded. This broke API contract
+    consistency — clients trusting the response of PUT would render wrong state.
+
+    The fix loads documents via admission_repo.get_all_documents() right before the
+    _compute_frontend_fields call, mirroring the pattern already used in get_profile
+    (admission_service.py:1759).
+
+    Note: these tests use a direct DB patch of `applied_rules` to inject mandatory_docs,
+    because setup_admission_api_data() does not seed an AdmissionPath with mandatory docs.
+    The bug is only observable when applied_rules.mandatory_docs is non-empty.
+    """
+
+    async def _create_draft_with_mandatory_docs(
+        self,
+        client: AsyncClient,
+        user_info: dict,
+        major_id: int,
+        unit_id: int,
+        mandatory_doc_codes: list[str],
+    ) -> tuple[int, dict]:
+        """Create a draft profile via API, then patch applied_rules in DB to add mandatory_docs.
+
+        Returns (profile_id, auth_headers).
+        """
+        data = await setup_admission_api_data(
+            major_id=major_id,
+            unit_id=unit_id,
+            officer_id=user_info["id"],
+            academic_year=2025,
+        )
+        headers = await get_auth_headers(client, user_info)
+
+        create_response = await client.post(
+            "/api/admissions",
+            json={
+                "lead_id": data["lead_id"],
+                "admission_method_id": data["admission_method_id"],
+            },
+            headers=headers,
+        )
+        assert create_response.status_code == 201, f"Create failed: {create_response.text}"
+        profile_id = create_response.json()["id"]
+
+        # Directly patch applied_rules.mandatory_docs in DB so _validate_documents has
+        # something to report on
+        from sqlalchemy import update as sql_update
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                result = await session.execute(
+                    select(models.AdmissionProfile).where(
+                        models.AdmissionProfile.id == profile_id
+                    )
+                )
+                profile = result.scalar_one()
+                patched_rules = dict(profile.applied_rules or {})
+                patched_rules["mandatory_docs"] = mandatory_doc_codes
+                patched_rules["upload_required_docs"] = mandatory_doc_codes
+                await session.execute(
+                    sql_update(models.AdmissionProfile)
+                    .where(models.AdmissionProfile.id == profile_id)
+                    .values(applied_rules=patched_rules)
+                )
+
+        return profile_id, headers
+
+    async def test_update_profile_response_reports_missing_mandatory_docs(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """
+        Profile's applied_rules requires ["hoc_ba_thpt", "cccd"] but no documents are
+        uploaded. PUT /api/admissions/{id} response MUST include these in validation_errors.
+
+        Before fix: validation_errors was [] (documents=None short-circuited _validate_documents).
+        After fix: validation_errors contains "Thiếu tài liệu bắt buộc: hoc_ba_thpt" and
+        "Thiếu tài liệu bắt buộc: cccd".
+        """
+        profile_id, headers = await self._create_draft_with_mandatory_docs(
+            client=client,
+            user_info=officer_user_in_db,
+            major_id=seed_lead_dependencies["major_program_id"],
+            unit_id=seed_lead_dependencies["unit_id"],
+            mandatory_doc_codes=["hoc_ba_thpt", "cccd"],
+        )
+
+        # PUT to update a trivial field. No documents uploaded.
+        update_response = await client.put(
+            f"/api/admissions/{profile_id}",
+            json={"gender": "Nam", "version": 1},
+            headers=headers,
+        )
+
+        assert update_response.status_code == 200, (
+            f"Expected 200, got {update_response.status_code}: {update_response.text}"
+        )
+        body = update_response.json()
+
+        validation_errors = body.get("validation_errors") or []
+        assert any("hoc_ba_thpt" in e for e in validation_errors), (
+            f"Expected validation_errors to report missing 'hoc_ba_thpt', "
+            f"got {validation_errors!r}. "
+            f"This indicates _compute_frontend_fields was called without `documents` — "
+            f"MEDIUM #1 regressed."
+        )
+        assert any("cccd" in e for e in validation_errors), (
+            f"Expected validation_errors to report missing 'cccd', got {validation_errors!r}"
+        )
+
+        # Eligibility should NOT be "eligible" when mandatory docs are missing
+        assert body.get("eligibility_status") == "ineligible", (
+            f"Expected eligibility_status='ineligible' when mandatory docs missing, "
+            f"got {body.get('eligibility_status')!r}. MEDIUM #1 regressed."
+        )
+
+    async def test_update_profile_response_consistent_with_get_profile(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """
+        Response of PUT /api/admissions/{id} must match a subsequent GET on key computed
+        fields. Before the fix, PUT returned validation_errors=[] and eligibility="eligible"
+        while GET returned validation_errors=[...missing docs] and eligibility="ineligible".
+        """
+        profile_id, headers = await self._create_draft_with_mandatory_docs(
+            client=client,
+            user_info=officer_user_in_db,
+            major_id=seed_lead_dependencies["major_program_id"],
+            unit_id=seed_lead_dependencies["unit_id"],
+            mandatory_doc_codes=["hoc_ba_thpt"],
+        )
+
+        update_response = await client.put(
+            f"/api/admissions/{profile_id}",
+            json={"gender": "Nam", "version": 1},
+            headers=headers,
+        )
+        assert update_response.status_code == 200
+        put_body = update_response.json()
+
+        get_response = await client.get(
+            f"/api/admissions/{profile_id}",
+            headers=headers,
+        )
+        assert get_response.status_code == 200
+        get_body = get_response.json()
+
+        # Key computed fields must agree between PUT and GET responses
+        assert put_body.get("validation_errors") == get_body.get("validation_errors"), (
+            f"PUT validation_errors {put_body.get('validation_errors')!r} != "
+            f"GET validation_errors {get_body.get('validation_errors')!r}. "
+            f"MEDIUM #1 regressed — update_profile is not loading documents before "
+            f"_compute_frontend_fields."
+        )
+        assert put_body.get("eligibility_status") == get_body.get("eligibility_status"), (
+            f"PUT eligibility {put_body.get('eligibility_status')!r} != "
+            f"GET eligibility {get_body.get('eligibility_status')!r}"
+        )
+        assert put_body.get("completion_percent") == get_body.get("completion_percent"), (
+            f"PUT completion {put_body.get('completion_percent')} != "
+            f"GET completion {get_body.get('completion_percent')}"
+        )
+
+
 # ==============================================================================
 # TEST: SUBMIT AND EVALUATE
 # ==============================================================================

--- a/Backend_FastAPI/tests/services/test_admission_service.py
+++ b/Backend_FastAPI/tests/services/test_admission_service.py
@@ -435,6 +435,152 @@ class TestUpdateProfileCitizenId:
         assert update_response.status_code == 409, f"Expected 409 Conflict: {update_response.text}"
 
 
+class TestUpdateProfileLazyLoadRegression:
+    """Regression tests for MissingGreenlet / lazy-load bugs in update_profile.
+
+    Background: Before the fix, `_compute_frontend_fields()` (sync helper called at the
+    end of update_profile) accessed `profile.lead.assigned_officer.full_name`, but
+    the `update_profile` query only eager-loaded `lead` — not the nested
+    `lead.assigned_officer`. This triggered a lazy-load from a sync function inside
+    an async SQLAlchemy session, causing `sqlalchemy.exc.MissingGreenlet` and a 500
+    response with no CORS headers (which the browser reported as a misleading
+    "CORS policy blocked" error).
+
+    The fix does two things:
+    1. `update_profile` now eager-loads `lead.assigned_officer` and `assigned_reviewer`
+    2. `_compute_frontend_fields` uses `profile.__dict__.get(...)` instead of
+       `hasattr/getattr` to avoid triggering lazy-loads entirely
+    """
+
+    async def test_update_draft_profile_with_assigned_officer_does_not_crash(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """
+        PUT /api/admissions/{id} must NOT raise MissingGreenlet when:
+        - The profile's lead has an assigned_officer_id set
+        - _compute_frontend_fields is called after the update
+
+        Before fix: returned 500 with SQLAlchemy MissingGreenlet traceback
+        After fix: returns 200 with updated profile including assigned_officer_name
+        """
+        unit_id = seed_lead_dependencies["unit_id"]
+        major_id = seed_lead_dependencies["major_program_id"]
+
+        # Create lead with assigned_officer_id pointing to officer_user_in_db
+        # This is the key condition that triggered the lazy-load bug
+        data = await setup_admission_api_data(
+            major_id=major_id,
+            unit_id=unit_id,
+            officer_id=officer_user_in_db["id"],
+            academic_year=2025,
+        )
+
+        headers = await get_auth_headers(client, officer_user_in_db)
+
+        # Create profile in draft state
+        create_response = await client.post(
+            "/api/admissions",
+            json={
+                "lead_id": data["lead_id"],
+                "admission_method_id": data["admission_method_id"],
+            },
+            headers=headers,
+        )
+        assert create_response.status_code == 201, f"Create failed: {create_response.text}"
+        profile_id = create_response.json()["id"]
+
+        # Update the draft profile — this call must NOT raise MissingGreenlet.
+        # Changing gender is sufficient; the bug triggers regardless of which field changes.
+        update_response = await client.put(
+            f"/api/admissions/{profile_id}",
+            json={"gender": "Nam", "version": 1},
+            headers=headers,
+        )
+
+        # Primary assertion: no 500 (no MissingGreenlet)
+        assert update_response.status_code == 200, (
+            f"Expected 200 but got {update_response.status_code}. "
+            f"Response: {update_response.text}. "
+            f"If this is a 500 with MissingGreenlet, the eager-load fix in "
+            f"update_profile() or the __dict__.get() fix in _compute_frontend_fields() "
+            f"regressed."
+        )
+
+        body = update_response.json()
+
+        # Secondary assertion: update actually applied
+        assert body.get("gender") == "Nam", f"Gender not updated: {body}"
+
+        # Tertiary assertion: _compute_frontend_fields ran and populated denormalized
+        # display names (proving the sync helper didn't crash on lazy-load).
+        # assigned_officer_name is set from profile.lead.assigned_officer.full_name
+        # via profile.__dict__.get("lead").__dict__.get("assigned_officer").
+        # Note: officer_user_in_db fixture may not set full_name, so we only assert
+        # the KEY exists (schema contract), not a specific value.
+        assert "assigned_officer_name" in body, (
+            "assigned_officer_name missing from response — _compute_frontend_fields "
+            "may not have run correctly"
+        )
+
+    async def test_update_draft_profile_without_assigned_officer_does_not_crash(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """
+        Edge case: lead has NO assigned_officer (officer_id=None).
+        The __dict__.get() fallback must return None without raising.
+        """
+        unit_id = seed_lead_dependencies["unit_id"]
+        major_id = seed_lead_dependencies["major_program_id"]
+
+        # Note: setup_admission_api_data requires officer for consultation, so we still
+        # pass officer_id, but we then manually null out lead.assigned_officer_id below.
+        data = await setup_admission_api_data(
+            major_id=major_id,
+            unit_id=unit_id,
+            officer_id=officer_user_in_db["id"],
+            academic_year=2025,
+        )
+
+        # Null out the assigned_officer_id directly in DB
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                lead = await session.get(models.Lead, data["lead_id"])
+                lead.assigned_officer_id = None
+
+        headers = await get_auth_headers(client, officer_user_in_db)
+
+        create_response = await client.post(
+            "/api/admissions",
+            json={
+                "lead_id": data["lead_id"],
+                "admission_method_id": data["admission_method_id"],
+            },
+            headers=headers,
+        )
+        assert create_response.status_code == 201, f"Create failed: {create_response.text}"
+        profile_id = create_response.json()["id"]
+
+        update_response = await client.put(
+            f"/api/admissions/{profile_id}",
+            json={"gender": "Nữ", "version": 1},
+            headers=headers,
+        )
+
+        assert update_response.status_code == 200, (
+            f"Expected 200, got {update_response.status_code}: {update_response.text}"
+        )
+        body = update_response.json()
+        assert body.get("assigned_officer_name") is None, (
+            f"Expected None when lead has no assigned_officer, got {body.get('assigned_officer_name')!r}"
+        )
+
+
 # ==============================================================================
 # TEST: SUBMIT AND EVALUATE
 # ==============================================================================

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
@@ -8,11 +8,12 @@ import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/comp
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Combobox } from "@/components/ui/combobox"
 
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import type { AddressMode } from "@/lib/api/administrative"
 import { AdaptiveAddressSelect } from "@/components/forms/AdaptiveAddressSelect"
 import type { AdmissionProfileResponse, AdmissionProfileUpdateInput } from "@/lib/zod/admissions"
 import { useConfigData } from "@/lib/hooks/useConfigData"
+import { useProvinces } from "@/lib/hooks/useAdministrative"
 import { format } from "date-fns" // Optional if needed for display, but input date handles ISO
 
 interface PersonalInfoTabProps {
@@ -27,7 +28,17 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
   const { data: religions } = useConfigData("religion")
   const { data: nationalities } = useConfigData("nationality")
   const { data: disabilities } = useConfigData("disability_type")
-  const { data: provinces } = useConfigData("province")
+
+  // Provinces come from administrative API, not config categories.
+  // Use the legacy snapshot (63 provinces) for `place_of_birth` / `native_place`
+  // because those fields store free-text province names from the applicant's
+  // historical records — legacy keeps the old province set users typically
+  // wrote in their birth certificates / household books.
+  const { data: provinces = [] } = useProvinces("legacy")
+  const provinceOptions = useMemo(
+    () => provinces.map((p) => ({ value: p.name, label: p.name })),
+    [provinces],
+  )
 
   // Watch address fields for reactivity (useWatch triggers re-render on change)
   const permanentProvince = useWatch({ control: form.control, name: "permanent_province" }) || ""
@@ -163,7 +174,7 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
                   <Combobox
                     value={field.value || ""}
                     onChange={field.onChange}
-                    suggestions={provinces?.map(p => p.name) || []}
+                    options={provinceOptions}
                     placeholder="Chọn tỉnh/thành phố"
                     searchPlaceholder="Tìm kiếm tỉnh/thành phố..."
                     emptyText="Không tìm thấy"
@@ -186,7 +197,7 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
                   <Combobox
                     value={field.value || ""}
                     onChange={field.onChange}
-                    suggestions={provinces?.map(p => p.name) || []}
+                    options={provinceOptions}
                     placeholder="Chọn tỉnh/thành phố"
                     searchPlaceholder="Tìm kiếm tỉnh/thành phố..."
                     emptyText="Không tìm thấy"

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
@@ -44,6 +44,8 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
   const permanentProvince = useWatch({ control: form.control, name: "permanent_province" }) || ""
   const permanentDistrict = useWatch({ control: form.control, name: "permanent_district" }) || null
   const permanentWard = useWatch({ control: form.control, name: "permanent_ward" }) || ""
+  const permanentResidentialGroup = useWatch({ control: form.control, name: "permanent_residential_group" }) || ""
+  const permanentStreetAddress = useWatch({ control: form.control, name: "permanent_street_address" }) || ""
 
   // Address mode: local state, re-derived when profile.version changes.
   // Uses React's "adjusting state during render" pattern — no useEffect.
@@ -249,9 +251,13 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
               provinceValue={permanentProvince}
               districtValue={permanentDistrict}
               wardValue={permanentWard}
+              residentialGroupValue={permanentResidentialGroup}
+              streetAddressValue={permanentStreetAddress}
               onProvinceChange={(value) => form.setValue("permanent_province", value)}
               onDistrictChange={(value) => form.setValue("permanent_district", value || "")}
               onWardChange={(value) => form.setValue("permanent_ward", value)}
+              onResidentialGroupChange={(value) => form.setValue("permanent_residential_group", value)}
+              onStreetAddressChange={(value) => form.setValue("permanent_street_address", value)}
               mode={addressMode}
               onModeChange={setAddressMode}
               disabled={!isEditable}

--- a/frontend/src/components/forms/AdaptiveAddressSelect.tsx
+++ b/frontend/src/components/forms/AdaptiveAddressSelect.tsx
@@ -19,14 +19,21 @@ import { useDistricts, useProvinces, useWards } from "@/lib/hooks/useAdministrat
 
 import { Label } from "@/components/ui/label"
 import { Combobox } from "@/components/ui/combobox"
+import { Input } from "@/components/ui/input"
 
 interface AdaptiveAddressSelectProps {
   provinceValue: string
   districtValue: string | null
   wardValue: string
+  /** Tổ dân phố / Thôn / Buôn / Ấp / Khóm / Khu phố — community sub-unit, free-text. */
+  residentialGroupValue?: string
+  /** Số nhà, tên đường — street address line, free-text. */
+  streetAddressValue?: string
   onProvinceChange: (province: string) => void
   onDistrictChange: (district: string | null) => void
   onWardChange: (ward: string) => void
+  onResidentialGroupChange?: (residentialGroup: string) => void
+  onStreetAddressChange?: (streetAddress: string) => void
   /** Address mode: "current" (2-level) or "legacy" (3-level) */
   mode: AddressMode
   onModeChange: (mode: AddressMode) => void
@@ -38,9 +45,13 @@ export function AdaptiveAddressSelect({
   provinceValue,
   districtValue,
   wardValue,
+  residentialGroupValue,
+  streetAddressValue,
   onProvinceChange,
   onDistrictChange,
   onWardChange,
+  onResidentialGroupChange,
+  onStreetAddressChange,
   mode,
   onModeChange,
   label = "Hộ khẩu thường trú",
@@ -192,6 +203,34 @@ export function AdaptiveAddressSelect({
           />
         </div>
       </div>
+
+      {/* Sub-ward + street address — free-text rows below the selectors.
+          Rendered only when the parent wires up handlers, so legacy callers
+          that haven't adopted the new fields keep working unchanged. */}
+      {(onResidentialGroupChange || onStreetAddressChange) && (
+        <div className="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2">
+          {onResidentialGroupChange && (
+            <div>
+              <Input
+                value={residentialGroupValue ?? ""}
+                onChange={(e) => onResidentialGroupChange(e.target.value)}
+                placeholder="Tổ dân phố / Thôn / Buôn / Ấp / Khóm / Khu phố"
+                disabled={disabled}
+              />
+            </div>
+          )}
+          {onStreetAddressChange && (
+            <div>
+              <Input
+                value={streetAddressValue ?? ""}
+                onChange={(e) => onStreetAddressChange(e.target.value)}
+                placeholder="Số nhà, tên đường"
+                disabled={disabled}
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -270,6 +270,9 @@ export const admissionProfileUpdateSchema = z.object({
   permanent_province: nullableString(100),
   permanent_district: nullableString(100),
   permanent_ward: nullableString(100),
+  // Sub-ward + street (free-text). See backend admission.py model comment.
+  permanent_residential_group: nullableString(150),
+  permanent_street_address: nullableString(255),
   place_of_birth: nullableString(255),
   native_place: nullableString(255),
   
@@ -416,6 +419,8 @@ export const admissionProfileResponseSchema = z.object({
   permanent_province: z.string().nullable(),
   permanent_district: z.string().nullable(),
   permanent_ward: z.string().nullable(),
+  permanent_residential_group: z.string().nullable(),
+  permanent_street_address: z.string().nullable(),
   place_of_birth: z.string().nullable(),
   native_place: z.string().nullable(),
   union_entry_date: z.string().datetime({ offset: true }).nullable(),


### PR DESCRIPTION
## Summary

7 commits, 3 themes:

**SQLAlchemy MissingGreenlet hardening** (commits 1, 2):
- Eager-load nested relationships in `update_profile` so post-mutation
  serialization doesn't trigger lazy load outside the async context
- Load `documents` before `_compute_frontend_fields` to avoid lazy load
  during response building

**Computed fields in mutation responses (MEDIUM #2)** (commit 3):
- Mutation handlers now return profiles with `permissions`,
  `available_actions`, `step_status`, `eligibility_status`,
  `validation_errors`, `completion_percent`, `assigned_officer_name`,
  `assigned_reviewer_name` populated. Previously these silently fell back
  to schema defaults, breaking any frontend that trusted the mutation
  response without re-fetching.
- Adds `_populate_response_fields()` helper. Mutation queries that return
  their own profile must use the nested eager-load pattern (documented in
  `Backend_FastAPI/CLAUDE.md` "Mutation response contract" section)
- Covered by 825 lines of new tests in `test_admission_service.py`

**Test infra + admissions UX** (commits 4–7):
- Test fixture: split `pg_terminate_backend` out of DDL transaction in
  `init_schema_once` so it doesn't roll back the schema setup
- Resubmit test: add required `version` field to request bodies
- UI: populate Nơi sinh / Quê quán dropdowns from administrative API
- **Migration**: add `permanent_residential_group` + `street_address`
  columns to `admission_profile`; UI dialog updated to capture them

## Commits

- `a48e46c8` fix(admissions): eager-load nested relationships to prevent MissingGreenlet
- `36186926` fix(admissions): load documents before _compute_frontend_fields
- `1528bc89` fix(admissions): populate computed fields in mutation responses (MEDIUM #2)
- `9ba08909` fix(tests): split pg_terminate_backend out of DDL transaction
- `e47fcb90` test(admissions): add required version field to resubmit request bodies
- `3e26dc4a` fix(admissions): populate Nơi sinh / Quê quán dropdowns from administrative API
- `53f290c8` feat(admissions): add residential_group + street_address to permanent residence

## Test plan

- [x] Backend `tests/services/test_admission_service.py` — pass
- [x] Backend `tests/services/test_admission_resubmit_flow.py` — pass
- [x] Total: **36/36 pass** (4:36 runtime)
- [x] Migration `5448988f1a77` validated: clean syntax, linked at head
      (`0e58c2f554f7 -> 5448988f1a77`)
- [x] Frontend `npm run type-check` — clean
- [x] Frontend `npm run build` — clean (after dev container memory bump 3G→6G)

## ⚠️ DB Migration

This PR adds an Alembic migration:
`5448988f1a77_add_permanent_residential_group_and_.py`

Adds 2 columns to `admission_profile`:
- `permanent_residential_group` (string, nullable)
- `street_address` (string, nullable)

`alembic upgrade head` will run automatically on container start (via
`docker-entrypoint.sh`). Both columns are nullable → existing rows
unaffected. Recommend deploying outside peak hours.

## Known CI noise

Same baseline as PR #98 #99 #100 #101 (Dependency Audit + Frontend Lint).

## Deploy

Manual SSH (Frontend Lint gate broken). After merge:
```bash
ssh -i ~/.ssh/id_ed25519_qlts root@qlts.tnpc.edu.vn
cd /opt/qlts && git pull --ff-only origin main
# Migration runs automatically via docker-entrypoint.sh
docker compose -f docker-compose.yml --profile production --env-file .env.production build backend frontend
docker compose -f docker-compose.yml --profile production --env-file .env.production up -d --no-deps backend frontend
```

## Rollback

`gh pr revert` will revert code, but the schema migration must be reverted
manually:
```bash
docker compose exec backend alembic downgrade 0e58c2f554f7
```
The downgrade is safe (drops 2 nullable columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)