### PR TITLE
docs(events): canonical event/notification architecture (Phase A)

### DIFF
--- a/Backend_FastAPI/CLAUDE.md
+++ b/Backend_FastAPI/CLAUDE.md
@@ -24,6 +24,16 @@
     - Use `selectinload` for relationships (Anti-N+1).
     - No direct SQL in Routers. Use Repository pattern.
 
+5.  **Notification Dispatch** (see `MASTER_ARCHITECTURE.md` PART 7 for full rules):
+    - **Four primitives**: `SystemEvents` enum + `EventDefinition` catalog + **`notification_rule` DB table row** + `dispatch()`/`safe_dispatch()`. A new event WITHOUT a seeded rule row silently fires zero notifications (fail-closed at `notification_dispatcher.py:~530`) — always pair catalog entry + rule row.
+    - **Service layer for atomic events**: Use `dispatch()`, return `(result, callback)` from service. Router commits then **MUST** await the callback.
+    - **Router post-commit fanout**: Use `safe_dispatch()` only AFTER `db.commit()`.
+    - **Atomic pairs on same business unit**: Wrap multiple dispatches in `async with db.begin_nested()` (ref: `lead_service.py:1163`).
+    - **Service-returned `post_commit` closures**: `safe_dispatch()` INSIDE such a closure is a valid pattern (ref: `payment_service.py:208/380`, `commission_service.py:156`). The rule is about which *transaction frame* the call runs in, not which *file* defines the closure.
+    - **Celery task with own session + commit**: `dispatch()` + explicit `await db.commit()` + `await notif_cb()` (ref: `tasks/notification_tasks.py:~247`).
+    - **Projections are NOT notifications**: In-transaction lead-state sync goes through `admission_event_mapping.py` + `lead_admission_sync.py`, NOT through `SystemEvents`.
+    - **No new event systems**: Use existing `SystemEvents` + `event_catalog.py` + `notification_rule` + dispatcher. See `docs/adr/ADR-001-remove-finance-events.md`.
+
 ---
 
 ## 📦 Quick Imports
@@ -83,6 +93,29 @@ async def update_lead(self, db, lead):
 async def get_lead_for_user(lead_id, user):
     if lead.owner_id != user.id:
         raise HTTPException(403)  # ❌ WRONG - should be 404
+
+# ❌ safe_dispatch in service body BEFORE router commits
+async def my_service(db):
+    db.add(Payment(...))
+    await db.flush()
+    await safe_dispatch(...)       # WRONG - notification references uncommitted data
+
+# ❌ Router forgets to await callback (silent notification loss)
+result, callback = await service(db)
+await db.commit()
+return result                      # WRONG - callback never awaited, zero notifications
+
+# ✅ Correct service + router pattern
+# Service side:
+notif_ids, notif_cb = await dispatch(db, event=..., payload=...)
+async def post_commit():
+    if notif_cb: await notif_cb()
+return result, post_commit
+# Router side:
+result, cb = await service(db)
+await db.commit()
+if cb: await cb()                  # DO NOT forget this line
+return result
 ```
 
 ---

--- a/Backend_FastAPI/EVENT_AUDIT_MATRIX.md
+++ b/Backend_FastAPI/EVENT_AUDIT_MATRIX.md
@@ -29,6 +29,8 @@
 
 ## 1. Kiến trúc 3 hệ thống event
 
+> **Canonical architecture reference**: See `MASTER_ARCHITECTURE.md` PART 7 for rules + decision tree, `docs/EVENT_ARCHITECTURE.md` for deep-dive + worked examples, `CLAUDE.md` Section 5 for quick reference. This audit matrix tracks **gaps and findings** only.
+
 Hệ thống hiện tại có **3 event system chạy song song**:
 
 | Hệ thống | File gốc | Cơ chế | Mục đích | Runtime status |
@@ -334,18 +336,25 @@ Events có đầy đủ registry config (resolver, template, channels) nhưng **
 
 **Decision needed:** Wire up DomainEvent properly, hoặc chấp nhận inline calls và remove dead code.
 
-### Finding 2: `safe_dispatch()` trong service layer (architecture violation)
+### Finding 2: `safe_dispatch()` trong service layer — ~~architecture violation~~ **WONTFIX — accepted pattern** (reclassified 2026-04-09)
+
+> **Reclassification rationale (v6 verification, 2026-04-09)**: 4 parallel sub-agents read all 3 sites and verified they are ALL inside `async def post_commit()` closures returned as `(result, callback)` tuples to the router, and executed AFTER the router's `db.commit()`. This IS the `safe_dispatch()` contract per `notification_dispatcher.py:1612-1614` docstring. The fact that the closure is defined in a service file is a code-layout detail; the execution frame is post-commit. Additionally, `commission_service.py:156` loops over N commission records needing independent best-effort — bundling into `dispatch()` would break the per-row failure isolation semantic. See `MASTER_ARCHITECTURE.md` PART 7 Section 7.2, decision tree row #5.
+>
+> **No Phase C fix needed for Arch-2.** Phase C scope is now **Arch-3 only** (admission paired dispatch atomicity).
 
 `payment_service.py` dùng `safe_dispatch()` trong `post_commit()` callback:
 ```python
 # payment_service.py:207-213
 async def post_commit():
-    from app.services.notification_dispatcher import safe_dispatch  # ← Service import router-level function
+    from app.services.notification_dispatcher import safe_dispatch
     await safe_dispatch(db=_db, event=SystemEvents.PAYMENT_RECEIVED, ...)
+# Closure is returned as: return payment, post_commit
+# Router awaits post_commit() AFTER db.commit() → safe_dispatch contract holds
 ```
 
-**Đúng pattern V3:** Service dùng `dispatch()` + trả callback cho router.
-**Ảnh hưởng:** `PAYMENT_RECEIVED` (F1) và `PAYMENT_VERIFIED` (F2). Hoạt động đúng vì nằm trong post_commit, nhưng vi phạm separation of concerns.
+**Previously classified as** "Vi phạm V3 separation of concerns" (v1-v5). **Now classified as** accepted pattern (v6, decision tree row #5): the closure runs in the router's post-commit frame, which is the valid context for `safe_dispatch()`.
+
+**Ảnh hưởng:** `PAYMENT_RECEIVED` (F1) và `PAYMENT_VERIFIED` (F2). Hoạt động đúng VÀ kiến trúc đúng. Xem thêm: `commission_service.py:156` (`CTV_COMMISSION_CREATED`) cùng pattern.
 
 ### Finding 3: Admission cặp đôi dispatch không atomic
 
@@ -412,7 +421,7 @@ Cùng event, cùng registry config, **khác ngữ cảnh và payload format**. R
 | ID | Gap | Impact | Effort |
 |---|---|---|---|
 | Arch-1 | `finance_events.py` DomainEvent dead code | Kiến trúc mơ hồ, inline calls fragile | Decision: wire up hoặc remove |
-| Arch-2 | `payment_service` dùng `safe_dispatch()` | Vi phạm V3 separation, hoạt động nhưng không clean | Low — refactor về `dispatch()` |
+| Arch-2 | `payment_service` dùng `safe_dispatch()` trong post_commit closure | **WONTFIX — accepted pattern** (reclassified 2026-04-09). Closure runs post-commit, matches safe_dispatch contract. See decision tree row #5 in PART 7. | ~~Low — refactor về `dispatch()`~~ No action needed |
 | Arch-3 | Admission cặp đôi dispatch không atomic | Rare failure case: partial notification | Medium — bundle vào savepoint |
 | ~~A13~~ | ~~`application_documents_updated` legacy~~ | **RESOLVED** — event retired, file xóa (PR #93) | — |
 | F4 | `dorm_fee_created` ownership sai domain | Finance registry chứa Dorm event | Low — move khi build Dorm module |
@@ -454,7 +463,7 @@ Cùng event, cùng registry config, **khác ngữ cảnh và payload format**. R
 **Sprint 3: P3 — Kiến trúc cleanup**
 
 9. **Arch-1** — Quyết định số phận `finance_events.py`: wire up hoặc remove
-10. **Arch-2** — Refactor `payment_service` về `dispatch()` pattern
+10. ~~**Arch-2** — Refactor `payment_service` về `dispatch()` pattern~~ **WONTFIX** (2026-04-09) — accepted pattern, see decision tree row #5
 11. **Arch-3** — Bundle admission cặp đôi dispatch vào savepoint
 
 ---

--- a/Backend_FastAPI/MASTER_ARCHITECTURE.md
+++ b/Backend_FastAPI/MASTER_ARCHITECTURE.md
@@ -412,9 +412,9 @@ These rules are designed to be enforced by:
 
 Every notification in QLTS flows through exactly these four components:
 
-1.  **`SystemEvents` enum** (`app/core/events.py`) — single namespace for all cross-module events. 55 members. Each member has a payload schema documented as a docstring. Adding a new enum member is step 1 of the "add new event" checklist.
+1.  **`SystemEvents` enum** (`app/core/events.py`) — single namespace for all cross-module events. Each member has a payload schema documented as a docstring. Adding a new enum member is step 1 of the "add new event" checklist.
 
-2.  **`EventDefinition` catalog** (`app/core/event_catalog.py`) — code-owned half of event metadata. Defines: notification classification (`user` / `broadcast_only` / `internal_future`), allowed resolvers (who should receive), default channels (browser/email/Zalo/SMS), dedup-key template, link strategy. 44 entries. Adding a catalog entry is step 2.
+2.  **`EventDefinition` catalog** (`app/core/event_catalog.py`) — code-owned half of event metadata. Defines: notification classification (`user` / `broadcast_only` / `internal_future`), allowed resolvers (who should receive), default channels (browser/email/Zalo/SMS), dedup-key template, link strategy. Adding a catalog entry is step 2.
 
 3.  **`notification_rule` DB table row** (managed via `notification_rule_crud_service.py` + seed script `app/scripts/sync_notification_rules.py`) — DB-owned half of event metadata. Controls: which users / channels / conditions this event should notify. Admins can mutate rules without code deploy.
 
@@ -476,7 +476,7 @@ Rules:
 
 ### 7.5 Lead Pipeline Projection (NOT a Parallel Event Bus)
 
-- `AdmissionEventProjection` defined in `app/core/admission_event_mapping.py` — 20 projection definitions.
+- `AdmissionEventProjection` defined in `app/core/admission_event_mapping.py`.
 - `lead_admission_sync.py` is a pure mapper, called inline from admission service mutations.
 - **Intentionally NOT wired into the notification dispatcher** because lead pipeline state change is part of the same transaction as the admission write — must be atomic.
 - Clear separation: dispatcher path = post-commit best-effort; projection path = in-transaction atomic.

--- a/Backend_FastAPI/MASTER_ARCHITECTURE.md
+++ b/Backend_FastAPI/MASTER_ARCHITECTURE.md
@@ -398,3 +398,120 @@ These rules are designed to be enforced by:
 
 **Any code violating these rules MUST be rejected, even if it "works".**
 "It runs" is not an excuse for "It violates architecture".
+
+---
+
+## PART 7: NOTIFICATION & EVENT LAYER
+
+> Canonical reference for how QLTS dispatches cross-module notifications.
+> For deep-dive internals: `app/services/NOTIFICATION_ARCHITECTURE.md`.
+> For worked examples + troubleshooting: `docs/EVENT_ARCHITECTURE.md`.
+> For audit gaps + finding tracker: `EVENT_AUDIT_MATRIX.md`.
+
+### 7.1 Four Primitives
+
+Every notification in QLTS flows through exactly these four components:
+
+1.  **`SystemEvents` enum** (`app/core/events.py`) — single namespace for all cross-module events. 55 members. Each member has a payload schema documented as a docstring. Adding a new enum member is step 1 of the "add new event" checklist.
+
+2.  **`EventDefinition` catalog** (`app/core/event_catalog.py`) — code-owned half of event metadata. Defines: notification classification (`user` / `broadcast_only` / `internal_future`), allowed resolvers (who should receive), default channels (browser/email/Zalo/SMS), dedup-key template, link strategy. 44 entries. Adding a catalog entry is step 2.
+
+3.  **`notification_rule` DB table row** (managed via `notification_rule_crud_service.py` + seed script `app/scripts/sync_notification_rules.py`) — DB-owned half of event metadata. Controls: which users / channels / conditions this event should notify. Admins can mutate rules without code deploy.
+
+    **CRITICAL**: An event without a seeded rule row is a **silent no-op**. The dispatcher's fail-closed branch at `notification_dispatcher.py:~530` logs `"No enabled DB rule for active user event"` and emits zero notifications — no error, no exception, just a `log.error`. Always pair a catalog entry with a DB rule row.
+
+4.  **`dispatch()` and `safe_dispatch()`** (`app/services/notification_dispatcher.py`) — the only two ways to publish:
+
+    | Function | Signature | Transaction ownership | Returns |
+    |---|---|---|---|
+    | `dispatch()` (line 447) | `(db, event, payload, dedupe_key?, skip_preference_check?) → (List[int], Optional[Callable])` | **Caller** owns transaction. Service flushes, caller commits. | `(notification_ids, post_commit_callback)` |
+    | `safe_dispatch()` (line 1602) | Same params → `List[int]` | **Dispatcher** owns its own short transaction. Commits + runs callback internally. Swallows ALL exceptions. | `notification_ids` (empty list on failure) |
+
+Rule of thumb: **code-owned catalog + DB-owned rule row = one event unit**. Adding a catalog entry without a rule row is a broken event.
+
+### 7.2 Decision Tree
+
+When writing new code that needs to emit a notification, use this table to choose the right function:
+
+| # | Context | Use | Reason |
+|---|---|---|---|
+| 1 | **Service mutation in atomic flow** — the notification rows must commit or rollback with the business write | `dispatch()` → return `(result, callback)` from service → router calls `await db.commit()` → router awaits callback | V3 architecture: service flushes, router commits. Notification rows participate in same transaction as business data. |
+| 2 | **Router after-commit best-effort fanout** — fire notification after business data is already committed | `safe_dispatch()` after `await db.commit()` | Owns its own commit, swallows exceptions, never crashes the request. |
+| 3 | **Multiple events on same business unit** (e.g. `APPLICATION_STATUS_CHANGED` + `LEAD_STATUS_CHANGED` must both succeed or both rollback) | `async with db.begin_nested()` wrapping `dispatch()` calls, then one commit, then one combined callback | Atomic across the group via savepoint. If event #2 fails, event #1 is rolled back to the savepoint. Reference: `lead_service.py:1163`. |
+| 4a | **Cron / beat task with no own session** — short-lived fire-and-forget | `safe_dispatch()` with `skip_preference_check=True` if needed | No HTTP request to fail. Best-effort is the correct shape. |
+| 4b | **Celery task that owns its own `AsyncSession`** and commits its own business work (e.g. consultation reminder) | `dispatch()` → explicit `await db.commit()` → `await notif_cb()` | Task owns the transaction window, so the dispatch-then-commit-then-callback pattern from row #1 applies. Reference: `tasks/notification_tasks.py:~247`. |
+| 5 | **Service returns a `post_commit` closure** that runs fire-and-forget work AFTER the router commits (typical shape: multi-row loop, or single cross-entity notification) | `safe_dispatch()` **inside the closure** — this is NOT an anti-pattern | Closure runs in the router's post-commit frame (business data already committed). The fact that the closure is *defined* in a service file is a code-layout detail, not a transactional concern. Examples: `payment_service.py:208/380`, `commission_service.py:156`. |
+| 6 | **New in-transaction lead-state sync** (NOT a notification — e.g. a new pipeline state that mirrors an admission event) | Add `EventProjection` to `app/core/admission_event_mapping.py` + sync call in `app/services/lead_admission_sync.py` | Projection path is a deliberate sibling layer — in-transaction atomic, inline sync, no notification rows. Do NOT route through `SystemEvents`. See Section 7.5. |
+
+### 7.3 Lifetime of Post-Commit Callback
+
+```
+Service:   notif_ids, notif_cb = await dispatch(db, event=..., payload=...)
+           return (business_result, notif_cb)     # or wrap in a post_commit closure
+
+Router:    result, callback = await service.do_something(db, ...)
+           await db.commit()                       # 1. business data + notification rows committed
+           if callback:
+               await callback()                    # 2. post-commit: socket.io, email, worker enqueue
+           return result                           # 3. HTTP response
+```
+
+Rules:
+- Service creates the callback via `dispatch()`.
+- Service returns the callback as part of its return tuple — NEVER awaits it internally.
+- Router calls `await db.commit()` FIRST — this commits both business data and notification rows.
+- Router awaits the callback EXACTLY ONCE, after commit.
+- Callback is never called inside a nested transaction.
+- Callback never recursively dispatches (deadlock + infinite loop risk).
+- **If the router forgets to await the callback**, zero notifications fire silently — no error, no log. This is a real silent-failure trap.
+
+### 7.4 Atomic Guarantees
+
+| Pattern | Atomicity | Commit ownership |
+|---|---|---|
+| Single `dispatch()` | Atomic with caller's transaction | Caller commits. `dispatch()` code path MUST NOT call `db.commit()`. |
+| `begin_nested()` group | Atomic across the savepoint group | Caller commits the outer transaction. Savepoint provides rollback boundary within. |
+| `safe_dispatch()` | **NOT** atomic with caller's prior commit | `safe_dispatch()` owns its own short transaction. **Intentionally calls `db.commit()` internally** (line ~1650). This is by design — do NOT "fix" it. |
+| `safe_dispatch()` failure | Best-effort | Rolls back its own transaction, logs warning, returns empty list. Never raises. Never affects business data. |
+
+### 7.5 Lead Pipeline Projection (NOT a Parallel Event Bus)
+
+- `AdmissionEventProjection` defined in `app/core/admission_event_mapping.py` — 20 projection definitions.
+- `lead_admission_sync.py` is a pure mapper, called inline from admission service mutations.
+- **Intentionally NOT wired into the notification dispatcher** because lead pipeline state change is part of the same transaction as the admission write — must be atomic.
+- Clear separation: dispatcher path = post-commit best-effort; projection path = in-transaction atomic.
+- This is by design, not a missing bridge.
+- **To add a new projection**: add an `EventProjection` row in `admission_event_mapping.py` + a sync call in `lead_admission_sync.py`. Do NOT create a `SystemEvents` member for this — you would lose the atomic guarantee.
+
+### 7.6 Target-State Rules
+
+The rule is about **which transaction frame** a call runs in, NOT which file the import statement lives in.
+
+**MUST follow for new code**:
+1.  Any `safe_dispatch()` call must run in a frame where the caller's business commit has ALREADY happened. Valid frames: router after-commit block; service-returned `post_commit` closure; Celery task body after its own `db.commit()`. Invalid frame: a synchronous service-body line that runs BEFORE the router commits.
+2.  Service mutation flows that need to emit a single atomic event should use `dispatch()` and return `(result, callback)` to the router (decision tree row #1).
+3.  Recursive dispatch from inside a callback is forbidden (deadlock + infinite loop risk).
+4.  Hardcoded notification logic is forbidden — use `dispatch()` + DB rules (admin needs runtime mutation without code deploy).
+5.  New domain event systems are forbidden — use existing `SystemEvents` + `event_catalog.py` + `notification_rule` table. See `docs/adr/ADR-001-remove-finance-events.md`.
+6.  **Router MUST await the callback** from `(result, callback)` tuples — forgetting this line silently drops all notifications.
+
+**Accepted patterns that LOOK like "service-layer safe_dispatch" but are actually correct**:
+
+| Site | Pattern | Why it's correct |
+|---|---|---|
+| `payment_service.py:208` | `safe_dispatch()` inside `async def post_commit()` closure, returned as `(payment, post_commit)` | Closure runs AFTER router commit. `safe_dispatch` contract holds. |
+| `payment_service.py:380` | Same shape | Same reasoning |
+| `commission_service.py:156` | `safe_dispatch()` in loop inside `async def _notify()` closure, returned as `(records, _notify)` | Each commission record fires independently. Per-row best-effort is required — bundling into `dispatch()` would break "row 3 fails doesn't block rows 4..N". |
+
+These match **decision tree row #5**. They are documented because `git grep "safe_dispatch" Backend_FastAPI/app/services/` returns these hits, and a reader unfamiliar with this section would flag them as violations.
+
+### 7.7 How to Add a New Event (Checklist)
+
+1.  Add a new member to `SystemEvents` enum in `app/core/events.py` with a payload schema docstring.
+2.  Add an `EventDefinition` entry to `app/core/event_catalog.py` (classification, resolvers, channels, dedup-key template, link strategy).
+3.  Add a seed `notification_rule` row via `app/scripts/sync_notification_rules.py` or equivalent seed script. **Without this step, the event is a silent no-op.**
+4.  Call `dispatch()` (service, row #1) or `safe_dispatch()` (router/closure, row #2/#5) at the appropriate site. Consult the decision tree in Section 7.2.
+5.  Add a unit test asserting dispatch is invoked with expected event + payload.
+6.  Verify end-to-end: check `notification_delivery` rows created, check channel delivery logs.
+
+For troubleshooting missing notifications, see `docs/EVENT_ARCHITECTURE.md` Section 7.

--- a/Backend_FastAPI/docs/EVENT_ARCHITECTURE.md
+++ b/Backend_FastAPI/docs/EVENT_ARCHITECTURE.md
@@ -17,8 +17,8 @@ QLTS has two distinct event paths, each serving a different purpose:
 These are NOT interchangeable. See `MASTER_ARCHITECTURE.md` PART 7 Section 7.5 for why.
 
 **Four primitives** of the notification path (see PART 7 Section 7.1):
-1. `SystemEvents` enum (`app/core/events.py`) — 55 event names
-2. `EventDefinition` catalog (`app/core/event_catalog.py`) — 44 code-owned metadata entries
+1. `SystemEvents` enum (`app/core/events.py`) — event name namespace
+2. `EventDefinition` catalog (`app/core/event_catalog.py`) — code-owned metadata entries
 3. `notification_rule` DB table — admin-mutable routing rules
 4. `dispatch()` / `safe_dispatch()` (`app/services/notification_dispatcher.py`) — the only publish APIs
 
@@ -35,7 +35,7 @@ These are NOT interchangeable. See `MASTER_ARCHITECTURE.md` PART 7 Section 7.5 f
 │  events.py              event_catalog.py          notification_      │
 │  ┌─────────────┐        ┌─────────────────┐       dispatcher.py      │
 │  │ SystemEvents │        │ EventDefinition  │       ┌─────────────┐   │
-│  │ enum (55)    │───────>│ catalog (44)     │──────>│ dispatch()   │   │
+│  │ enum         │───────>│ catalog          │──────>│ dispatch()   │   │
 │  └─────────────┘        │ classification   │       │ safe_dispatch│   │
 │                         │ resolvers        │       └──────┬───────┘   │
 │                         │ channels         │              │           │
@@ -71,14 +71,14 @@ These are NOT interchangeable. See `MASTER_ARCHITECTURE.md` PART 7 Section 7.5 f
 
 | File | Role | Key line |
 |------|------|----------|
-| `app/core/events.py` | SystemEvents enum | 55 members |
-| `app/core/event_catalog.py` | EventDefinition metadata | 44 entries |
+| `app/core/events.py` | SystemEvents enum | All cross-module event names |
+| `app/core/event_catalog.py` | EventDefinition metadata | Code-owned half of each event |
 | `app/services/notification_dispatcher.py` | `dispatch()` + `safe_dispatch()` | L447, L1602 |
 | `app/services/notification_rule_loader.py` | DB rule lookup (cached) | `get_rule_for_event()` L560 |
 | `app/services/notification_resolvers.py` | Recipient resolution | `BaseResolver` L34 |
 | `app/services/notification_channels/` | Channel delivery (browser/email/Zalo/SMS) | directory |
 | `app/services/notification_rule_crud_service.py` | Admin CRUD for rules | import catalog L17 |
-| `app/core/admission_event_mapping.py` | Lead projection definitions | 20 projections |
+| `app/core/admission_event_mapping.py` | Lead projection definitions | Admission → Lead state mappings |
 | `app/services/lead_admission_sync.py` | Lead projection executor | inline sync |
 
 ---
@@ -239,4 +239,4 @@ If event sourcing becomes a real requirement, build with proper infrastructure (
 | `app/services/NOTIFICATION_ARCHITECTURE.md` | Deep-dive internals (guardrail table, phase history) |
 | `NOTIFICATION_PHASE_WORKLOG.md` | Historical worklog (do NOT update) |
 | `docs/adr/ADR-001-remove-finance-events.md` | Decision record for DomainEvent removal |
-| `docs/FINANCE_MODULE_DESIGN.md` | **HISTORICAL** — original finance module design. Drifted at 6 layers from current code. See doc-level banner. |
+| `docs/FINANCE_MODULE_DESIGN.md` | **HISTORICAL** — original finance module design. Drifted at 6 layers from current code (event architecture, data contracts, business flow, module structure, project status, tooling). Useful for business vocabulary only. A doc-level historical banner will be added in Phase B1. |

--- a/Backend_FastAPI/docs/EVENT_ARCHITECTURE.md
+++ b/Backend_FastAPI/docs/EVENT_ARCHITECTURE.md
@@ -1,0 +1,242 @@
+# Event & Notification Architecture — Deep Reference
+
+> This is the **deep-dive** reference for the QLTS notification system.
+> For quick rules, see `MASTER_ARCHITECTURE.md` PART 7.
+> For CLAUDE.md quick reference, see `CLAUDE.md` Section 5.
+> For audit gaps + finding tracker, see `EVENT_AUDIT_MATRIX.md`.
+
+---
+
+## 1. Overview
+
+QLTS has two distinct event paths, each serving a different purpose:
+
+1. **Notification Dispatcher** (`SystemEvents` + `dispatch()`/`safe_dispatch()`) — post-commit best-effort notifications to users via browser, email, Zalo, SMS.
+2. **Lead Pipeline Projection** (`AdmissionEventProjection` + `lead_admission_sync.py`) — in-transaction atomic state sync between admission profiles and lead pipeline.
+
+These are NOT interchangeable. See `MASTER_ARCHITECTURE.md` PART 7 Section 7.5 for why.
+
+**Four primitives** of the notification path (see PART 7 Section 7.1):
+1. `SystemEvents` enum (`app/core/events.py`) — 55 event names
+2. `EventDefinition` catalog (`app/core/event_catalog.py`) — 44 code-owned metadata entries
+3. `notification_rule` DB table — admin-mutable routing rules
+4. `dispatch()` / `safe_dispatch()` (`app/services/notification_dispatcher.py`) — the only publish APIs
+
+**Six-row decision tree** for choosing which function: see PART 7 Section 7.2.
+
+---
+
+## 2. Component Map
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                     CODE-OWNED (deploy-time)                         │
+│                                                                      │
+│  events.py              event_catalog.py          notification_      │
+│  ┌─────────────┐        ┌─────────────────┐       dispatcher.py      │
+│  │ SystemEvents │        │ EventDefinition  │       ┌─────────────┐   │
+│  │ enum (55)    │───────>│ catalog (44)     │──────>│ dispatch()   │   │
+│  └─────────────┘        │ classification   │       │ safe_dispatch│   │
+│                         │ resolvers        │       └──────┬───────┘   │
+│                         │ channels         │              │           │
+│                         │ dedup template   │              │           │
+│                         │ link strategy    │              │           │
+│                         └─────────────────┘              │           │
+├──────────────────────────────────────────────────────────┼───────────┤
+│                      DB-OWNED (runtime)                  │           │
+│                                                          v           │
+│  notification_rule         notification_rule_loader.py               │
+│  ┌──────────────┐          ┌──────────────────────┐                  │
+│  │ DB table rows │────────>│ get_rule_for_event()  │                  │
+│  │ (admin edit)  │         │ (line 560, cached)    │                  │
+│  └──────────────┘          └──────────┬───────────┘                  │
+│                                       │                              │
+│                                       v                              │
+│  notification_resolvers.py     notification_channels/                │
+│  ┌──────────────────────┐      ┌──────────────────────────┐          │
+│  │ BaseResolver (line 34)│      │ browser_channel.py       │          │
+│  │ LeadOwnerResolver    │      │ email_channel.py         │          │
+│  │ UnitStaffResolver    │─────>│ zalo_channel.py          │          │
+│  │ UnitManagersResolver │      │ sms_channel.py           │          │
+│  └──────────────────────┘      └──────────────────────────┘          │
+│                                                                      │
+│  ┌──────────────────────────────────────────────────────────────┐    │
+│  │ Dedup: notification_dispatcher._apply_deduplication()        │    │
+│  │        + Redis cooldown keys (notif:cooldown:*)              │    │
+│  └──────────────────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Key files
+
+| File | Role | Key line |
+|------|------|----------|
+| `app/core/events.py` | SystemEvents enum | 55 members |
+| `app/core/event_catalog.py` | EventDefinition metadata | 44 entries |
+| `app/services/notification_dispatcher.py` | `dispatch()` + `safe_dispatch()` | L447, L1602 |
+| `app/services/notification_rule_loader.py` | DB rule lookup (cached) | `get_rule_for_event()` L560 |
+| `app/services/notification_resolvers.py` | Recipient resolution | `BaseResolver` L34 |
+| `app/services/notification_channels/` | Channel delivery (browser/email/Zalo/SMS) | directory |
+| `app/services/notification_rule_crud_service.py` | Admin CRUD for rules | import catalog L17 |
+| `app/core/admission_event_mapping.py` | Lead projection definitions | 20 projections |
+| `app/services/lead_admission_sync.py` | Lead projection executor | inline sync |
+
+---
+
+## 3. Full Dispatch Flow (ASCII Trace)
+
+```
+Caller (service/router)
+  │
+  ├── dispatch(db, event, payload, dedupe_key?)
+  │     │
+  │     ├── 1. get_event(event) → EventDefinition from catalog
+  │     │     └── if retired or missing → log + return ([], None)
+  │     │
+  │     ├── 2. get_rule_for_event(db, event) → NotificationRule from DB
+  │     │     └── if no enabled rule → log.error "No enabled DB rule" + return ([], None)
+  │     │     └── ⚠️ THIS IS THE SILENT FAILURE TRAP — no exception raised
+  │     │
+  │     ├── 3. For each action in rule.actions:
+  │     │     ├── deserialize_resolver(action) → BaseResolver subclass
+  │     │     ├── resolver.resolve(db, payload) → [user_ids]
+  │     │     ├── filter by notification_preference (opt-out)
+  │     │     └── filter by dedup key (prevent duplicates)
+  │     │
+  │     ├── 4. Bulk insert Notification + NotificationDelivery rows
+  │     │     └── db.flush() (NOT commit — caller owns transaction)
+  │     │
+  │     └── 5. Build post_commit_callback:
+  │           └── callback → socket.io emit + enqueue email/Zalo worker
+  │
+  ├── return (notification_ids, callback)
+  │
+  │   [Caller: await db.commit()]     ← business data + notification rows
+  │   [Caller: await callback()]      ← post-commit side effects
+  │
+  └── Done
+```
+
+---
+
+## 4. Lead Projection Flow (ASCII Trace)
+
+```
+Admission Service (e.g., approve_profile)
+  │
+  ├── Business mutation (profile.status = "approved")
+  │
+  ├── sync_lead_from_admission(db, profile, ...)    ← inline call, same txn
+  │     │
+  │     ├── get_projection(old_status, new_status) → EventProjection
+  │     │     └── from admission_event_mapping.py (20 definitions)
+  │     │
+  │     ├── Update lead fields (status, stage, phase, substage)
+  │     │
+  │     ├── Create LeadStatusHistory row
+  │     │
+  │     └── return (no callback — all in same transaction)
+  │
+  ├── await db.flush()
+  │
+  └── [Router: await db.commit()]     ← business + projection committed atomically
+```
+
+---
+
+## 5. Worked Examples
+
+### Example 1: Lead assigned via `dispatch()` (atomic)
+
+**File**: `lead_service.py:1163-1190`
+
+```python
+# Inside begin_nested() savepoint for atomic dispatch
+async with db.begin_nested():
+    # ... business logic ...
+    notif_ids, notif_cb = await dispatch(
+        db=db,
+        event=SystemEvents.LEAD_ASSIGNED,
+        payload={"lead_id": lead.id, "officer_id": officer.id, ...},
+        dedupe_key=f"lead_assigned:{lead.id}:{officer.id}",
+    )
+# Router commits outer transaction, then awaits callback
+```
+
+### Example 2: Admission bulk approve via `safe_dispatch()` (router post-commit)
+
+**File**: `admissions.py:362`
+
+```python
+# Router — business commit already done
+await safe_dispatch(
+    db=db,
+    event=SystemEvents.APPLICATION_STATUS_CHANGED,
+    payload={...},
+)
+```
+
+### Example 3: Admission profile create via projection sync (in-transaction)
+
+**File**: `admission_service.py:1551-1560`
+
+```python
+# Inline sync — same transaction as profile creation
+from .lead_admission_sync import sync_lead_from_admission
+await sync_lead_from_admission(
+    db=db,
+    profile=new_profile,
+    changed_by_user_id=current_user.id,
+    reason="Admission profile created",
+)
+```
+
+---
+
+## 6. How to Add a New Event (Checklist)
+
+1. **Add enum member** to `SystemEvents` in `app/core/events.py` with payload schema docstring.
+2. **Add `EventDefinition`** to `app/core/event_catalog.py` — set classification, resolvers, channels, dedup template, link.
+3. **Seed `notification_rule` row** via `app/scripts/sync_notification_rules.py`. **Without this, event is silent.**
+4. **Call `dispatch()`** (service row #1) or **`safe_dispatch()`** (router/closure row #2/#5) at the call site. Consult the decision tree in `MASTER_ARCHITECTURE.md` PART 7 Section 7.2.
+5. **Add unit test** asserting dispatch is invoked with expected event + payload.
+6. **Verify end-to-end**: check `notification_delivery` rows, check channel logs.
+
+---
+
+## 7. How to Debug a Missing Notification
+
+If a notification should fire but doesn't, check in order:
+
+1. **Rule exists?** `SELECT * FROM notification_rule WHERE event_type = '<YOUR_EVENT>' AND is_enabled = true;` — no row = silent no-op.
+2. **Catalog entry?** `from app.core.event_catalog import get_event; print(get_event(SystemEvents.YOUR_EVENT))` — `None` = not in catalog.
+3. **Resolver returns users?** Add temp logging in the resolver's `resolve()` method. Empty list = no recipients.
+4. **Preference opt-out?** `SELECT * FROM notification_preference WHERE user_id = <USER> AND event_group = '<GROUP>';` — user may have opted out of this channel.
+5. **Dedup blocked?** Check Redis for `notif:cooldown:<dedupe_key>:<user_id>` keys. TTL = 1 hour default. Same notification won't fire twice within the window.
+6. **Channel delivery failed?** Check `notification_delivery` table for status = `failed` or `dead_lettered`. Check celery-worker logs for channel-specific errors.
+7. **Router forgot callback?** If using `dispatch()`, the router MUST `await callback()` after commit. Forgetting this line silently drops all notifications — no error, no log.
+8. **`classification` = `internal_future`?** Catalog entry with this classification is silently skipped (domain-only emission with no user notification). Check `event_catalog.py` for the entry's `notification_class`.
+
+---
+
+## 8. Why No DomainEvent System?
+
+QLTS originally scaffolded a `DomainEvent` system in `app/core/finance_events.py` (18 dataclasses + `emit_event()` + `@event_handler` decorator + `ProcessedEvent` table for idempotency). After 5 months of zero production usage, this was removed per **ADR-001** (`docs/adr/ADR-001-remove-finance-events.md`).
+
+The `SystemEvents` + dispatcher path fulfills all production notification needs. The `ProcessedEvent` table's idempotency tracking role is served by Redis dedupe keys in the dispatcher.
+
+If event sourcing becomes a real requirement, build with proper infrastructure (Kafka/RabbitMQ/EventStoreDB) rather than in-process scaffolding.
+
+---
+
+## 9. Cross-References
+
+| Document | Purpose |
+|---|---|
+| `MASTER_ARCHITECTURE.md` PART 7 | Canonical rules, decision tree, target-state |
+| `CLAUDE.md` Section 5 | Quick reference for agents/devs |
+| `EVENT_AUDIT_MATRIX.md` | Audit findings, gap tracker, priority matrix |
+| `app/services/NOTIFICATION_ARCHITECTURE.md` | Deep-dive internals (guardrail table, phase history) |
+| `NOTIFICATION_PHASE_WORKLOG.md` | Historical worklog (do NOT update) |
+| `docs/adr/ADR-001-remove-finance-events.md` | Decision record for DomainEvent removal |
+| `docs/FINANCE_MODULE_DESIGN.md` | **HISTORICAL** — original finance module design. Drifted at 6 layers from current code. See doc-level banner. |

--- a/Backend_FastAPI/docs/adr/ADR-001-remove-finance-events.md
+++ b/Backend_FastAPI/docs/adr/ADR-001-remove-finance-events.md
@@ -20,8 +20,11 @@ Finding 1 / Arch-1):
 
 - **0 production `emit_event()` calls** outside the dead files themselves
 - **0 `@event_handler` registrations** in any production code path
-- **0 rows** in the `processed_event` table (all environments, verified)
-- **0 consumers** (BI, ETL, replication, external systems)
+- **0 rows** in the `processed_event` table on **dev** (verified 2026-04-07).
+  Staging and production must be verified separately before Phase B2 ships —
+  see B2 preflight checklist in the execution plan.
+- **0 consumers** (BI, ETL, replication, external systems) — dev-verified;
+  staging/prod consumer scan pending B2 preflight
 
 The notification dispatch needs these events were meant to serve are fulfilled
 by the `SystemEvents` enum + `notification_dispatcher.py` path, which has been

--- a/Backend_FastAPI/docs/adr/ADR-001-remove-finance-events.md
+++ b/Backend_FastAPI/docs/adr/ADR-001-remove-finance-events.md
@@ -1,0 +1,122 @@
+# ADR-001: Remove finance_events.py DomainEvent system
+
+## Status
+
+Accepted (2026-04-09)
+
+## Context
+
+QLTS introduced `app/core/finance_events.py` in commit `db28a24d` (2026-01-31)
+as Phase 3 of the finance module, defining 18 `DomainEvent` dataclasses with an
+`emit_event()` function, `@event_handler` decorator, and an
+`IdempotentEventHandler` helper backed by a `processed_event` PostgreSQL table
+for deduplication.
+
+The intent was to provide a Domain-Driven Design event layer for cross-module
+finance flows (fee calculated, fee fully paid, payment verified, period closed).
+
+5 months later (2026-03-31 audit, documented in `EVENT_AUDIT_MATRIX.md`
+Finding 1 / Arch-1):
+
+- **0 production `emit_event()` calls** outside the dead files themselves
+- **0 `@event_handler` registrations** in any production code path
+- **0 rows** in the `processed_event` table (all environments, verified)
+- **0 consumers** (BI, ETL, replication, external systems)
+
+The notification dispatch needs these events were meant to serve are fulfilled
+by the `SystemEvents` enum + `notification_dispatcher.py` path, which has been
+the canonical production system since its introduction.
+
+## Decision
+
+Remove the dead code cluster:
+- `app/core/finance_events.py` (544 LOC, 18 DomainEvent dataclasses)
+- `app/core/idempotent_handler.py` (424 LOC)
+- `app/schemas/finance_events.py` (330 LOC)
+- `EventIdempotencyService` class in `app/services/accounting_service.py`
+- `ProcessedEvent` ORM model in `app/models/finance/accounting.py`
+- `processed_event` PostgreSQL table (via Alembic migration)
+- `tests/unit/test_finance_events.py` (573 LOC, 29 tests)
+- Related test functions in `tests/integration/test_finance_workflow.py`
+
+Two-PR split: Phase B1 (source cleanup, no migration) ships first; Phase B2
+(table drop via migration) ships after preflight verification across all
+environments.
+
+## Alternatives considered
+
+1. **Wire up DomainEvent properly**: ~1000+ LOC refactor across payment_service,
+   accounting_service, fee_calculation_service to emit events + add bridge
+   handlers to convert to SystemEvents. 5 months of zero usage signal suggests
+   this investment will not happen. Rejected.
+
+2. **Leave dead code with deprecation comment**: Doesn't reduce maintenance
+   burden, still confuses every audit/refactor cycle. Rejected.
+
+3. **Mark deprecated, stop writing tests**: Half-measure that leaves code
+   technically importable. Rejected.
+
+## Consequences
+
+### Positive
+
+- -1871 LOC source/test burden removed (v6-verified count)
+- Single canonical event path (SystemEvents + dispatcher + notification_rule)
+- Less developer confusion ("which event system do I use?")
+- Less audit churn in future cycles
+
+### Negative
+
+- Lose `ProcessedEvent` table primitive for durable idempotency tracking.
+  **Mitigation**: Redis dedupe keys in dispatcher already serve equivalent
+  production needs. If a future flow requires durable idempotency, add a
+  focused table at that time.
+
+- Lose `IdempotentEventHandler` decorator pattern.
+  **Mitigation**: Never used in production. Can be reintroduced if needed.
+
+- Lose `DomainEvent` base class as a future event sourcing primitive.
+  **Mitigation**: If event sourcing becomes a real requirement, build with
+  proper infrastructure (Kafka/RabbitMQ/EventStoreDB) rather than in-process
+  scaffolding.
+
+### Neutral
+
+- DB migration is destructive but reversible (downgrade recreates schema
+  with empty rows).
+
+## Post-migration replacements
+
+Some of the 18 dead `DomainEvent` dataclasses had spiritual successors
+promoted into the live `SystemEvents` path:
+
+| Dead DomainEvent | Live SystemEvents replacement | Reference |
+|---|---|---|
+| `PaymentVerified` | `SystemEvents.PAYMENT_VERIFIED` | `events.py:~361-365` (inline comment: "Bridged from finance domain event PaymentVerified"). Route: `safe_dispatch()` from `payment_service.py:380` post-commit closure via `payment_router.verify_payment`. |
+| `FeeCalculated` | No direct bridge | Fee calculation remains a pure service-internal flow. The dead `# TODO: Emit FeeCalculated domain event` at `fee_calculation_service.py:~193` is removed in B1. |
+| `FeeFullyPaid` | Partially via `PAYMENT_VERIFIED` | `PAYMENT_VERIFIED` payload includes an `is_fully_paid` flag. Not all fully-paid states produce a notification. |
+| `PeriodClosed` | No bridge needed | Period closure is admin-UI concern, writes to audit log directly. |
+| 14 others | Never wired up | No user-visible behavior lost. |
+
+**Rule**: to re-enable notification for any of the non-bridged events, add
+a new `SystemEvents` member + `EventDefinition` + seed a `notification_rule`
+row. Do NOT reintroduce `DomainEvent` / `emit_event()`.
+
+## Migration path
+
+- **Phase B1**: Source deletes + validator update + design doc historical banner.
+  Fully recoverable via `git revert`. No DB change.
+- **Phase B2**: Explicit `DROP TABLE processed_event` via manually-written
+  Alembic migration with pinned revision IDs (NOT `alembic downgrade -1`).
+  Downgrade recreates schema (rows lost). Gated by preflight: all envs must
+  show 0 rows + zero BI/ETL consumers.
+- **Rollback**: Code revert + (B2 only) `alembic downgrade <pinned_parent_rev>`
+  — downgrade FIRST (while migration file still on disk), revert SECOND.
+
+## References
+
+- `EVENT_AUDIT_MATRIX.md` — Finding 1 (Arch-1): dead code classification
+- `docs/EVENT_ARCHITECTURE.md` — Section 8: "Why no DomainEvent system?"
+- `MASTER_ARCHITECTURE.md` PART 7 — Canonical notification rules
+- Original commit: `db28a24d` (2026-01-31)
+- Plan: `velvet-swinging-moore.md` (v6, 2026-04-09)


### PR DESCRIPTION
## Summary

Phase A of the [Event/Notification architecture cleanup plan](https://github.com/favouritekid/QLTS/blob/main/Backend_FastAPI/docs/EVENT_ARCHITECTURE.md). **Documentation only — zero code changes.**

Consolidates the event/notification architecture into canonical docs, resolving the "3 event systems, no clear decision tree" dev confusion.

## Changes

- **MASTER_ARCHITECTURE.md**: Append PART 7 — 4 primitives, 6-row decision tree, target-state rules, accepted-patterns table, close-the-loop warning, "add new event" checklist
- **CLAUDE.md**: Add Section 5 — notification dispatch quick reference with anti-pattern examples
- **docs/EVENT_ARCHITECTURE.md** (NEW): Deep reference with ASCII diagrams, 3 worked examples, troubleshooting guide
- **EVENT_AUDIT_MATRIX.md**: Add docs cross-reference + reclassify Finding 2 (Arch-2) as WONTFIX — accepted pattern
- **docs/adr/ADR-001-remove-finance-events.md** (NEW): Decision record for DomainEvent removal with post-migration replacements table

## Key architectural decisions

1. **4 primitives** (not 3): `notification_rule` DB table row is a first-class primitive — without a seeded rule row, `dispatch()` silently fires zero notifications
2. **Finding 2 (Arch-2) = WONTFIX**: `safe_dispatch()` in service-returned `post_commit` closures is an accepted pattern (decision tree row #5), NOT a violation
3. **Phase C scope = Arch-3 only**: admission paired dispatch atomicity. No Arch-2 work needed.

## Test plan

- [x] Zero code changes — no tests to run
- [x] Self-review: `git grep` confirms accepted-patterns table matches exactly 3 service-layer sites
- [x] Cross-doc consistency: "Four primitives" mentioned in all 3 docs, decision tree row #5 referenced consistently
- [ ] Doc review: 1 backend dev + 1 frontend dev should verify decision tree completeness

## Blast radius

None — pure markdown. Unblocks Phase B1 (source cleanup) and B2 (table drop) as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)