### PR TITLE
fix(admissions): add passive_deletes to DocumentAuditLog backref

### DIFF
--- a/Backend_FastAPI/app/models/admission_config/profile_data.py
+++ b/Backend_FastAPI/app/models/admission_config/profile_data.py
@@ -8,7 +8,7 @@ Replaces JSON fields in AdmissionProfile:
 """
 
 from sqlalchemy import CheckConstraint, Column, Integer, String, ForeignKey, Numeric, DateTime, UniqueConstraint, Text, BigInteger
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import backref, relationship
 from sqlalchemy.dialects.postgresql import JSONB
 from datetime import datetime, timezone
 
@@ -337,7 +337,14 @@ class DocumentAuditLog(Base):
     )
 
     # Relationships
-    profile_document = relationship("ProfileDocument", backref="audit_logs")
+    # passive_deletes=True: let the DB-level ondelete="CASCADE" on the FK
+    # handle deletion. Without this, SQLAlchemy walks the backref and tries
+    # UPDATE SET NULL on profile_document_id — which violates the NOT NULL
+    # constraint and crashes with IntegrityError. See Issue #108.
+    profile_document = relationship(
+        "ProfileDocument",
+        backref=backref("audit_logs", passive_deletes=True),
+    )
     actor = relationship("User", foreign_keys=[actor_user_id])
 
     __table_args__ = (


### PR DESCRIPTION
Fixes #108.

## Problem

`DELETE /api/admissions/{id}` returns HTTP 500:

```
IntegrityError: null value in column "profile_document_id" of relation
"document_audit_log" violates not-null constraint

[SQL: UPDATE document_audit_log SET profile_document_id=NULL WHERE ...]
```

## Root Cause

`DocumentAuditLog.profile_document` relationship used `backref("audit_logs")` without `passive_deletes=True`. When SQLAlchemy deletes a `ProfileDocument` (via cascade from `AdmissionProfile` deletion), it walks the backref and emits `UPDATE SET NULL` on `profile_document_id` — but the column is `NOT NULL`.

The FK already has `ondelete="CASCADE"` at DB level, which is correct. SQLAlchemy just needed to be told to defer to it.

## Fix

```python
# Before (line 340)
profile_document = relationship("ProfileDocument", backref="audit_logs")

# After
profile_document = relationship(
    "ProfileDocument",
    backref=backref("audit_logs", passive_deletes=True),
)
```

1 file changed, +9/-2 lines.

## Test plan

- [x] Profile #133 (with 4 `document_audit_log` entries from QA doc reject/reset tests) deleted successfully — was HTTP 500, now HTTP 200
- [x] Audit log entries (ids 600-603) cascade-deleted by DB
- [x] `GET /admissions/133` returns 404 after delete
- [x] Backend boots cleanly, health check 200
- [x] Import smoke passes

## Deploy

Backend restart only. No migration, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)