### PR TITLE
refactor(finance): drop processed_event table per ADR-001 (Phase B2)

### DIFF
--- a/Backend_FastAPI/EVENT_AUDIT_MATRIX.md
+++ b/Backend_FastAPI/EVENT_AUDIT_MATRIX.md
@@ -325,14 +325,14 @@ Events có đầy đủ registry config (resolver, template, channels) nhưng **
 
 ### Finding 1: `finance_events.py` DomainEvent system là dead code
 
-| Component | Defined | Runtime | Evidence |
-|---|---|---|---|
-| 18 DomainEvent classes | Yes | **Dead** | 0 `emit_event()` calls trong service layer |
-| `emit_event()` function | Yes | **Never called** | `fee_calculation_service.py:193` có `# TODO: Emit FeeCalculated domain event` |
-| Handler registry | Yes | **Always empty** | 0 `register_handler()` hoặc `@event_handler` trong production code |
-| `ProcessedEvent` table | Defined | **Never populated** | Idempotency tracking, chỉ dùng trong test |
+| Component | Defined | Runtime | Evidence (at audit time 2026-03-31) | Post-cleanup status |
+|---|---|---|---|---|
+| 18 DomainEvent classes | Yes | **Dead** | 0 `emit_event()` calls trong service layer | **Removed** (B1) |
+| `emit_event()` function | Yes | **Never called** | ~~`fee_calculation_service.py:193` có `# TODO`~~ | **Removed** (B1 — file deleted, TODO deleted) |
+| Handler registry | Yes | **Always empty** | 0 `register_handler()` hoặc `@event_handler` | **Removed** (B1) |
+| `ProcessedEvent` table | Defined | **Never populated** | Idempotency tracking, chỉ dùng trong test | **Dropped** (B2) |
 
-**Impact:** 3 inline sync calls (`sync_lead_tuition_calculated`, `sync_lead_tuition_paid`, `sync_lead_tuition_refunded`) làm việc mà DomainEvent system lẽ ra phải làm. Nếu miss inline call ở flow nào → lead pipeline lệch, không có safety net.
+**Impact (historical — no longer applicable after B1+B2):** 3 inline sync calls (`sync_lead_tuition_calculated`, `sync_lead_tuition_paid`, `sync_lead_tuition_refunded`) làm việc mà DomainEvent system lẽ ra phải làm. Post-cleanup: inline calls remain as the canonical path; DomainEvent scaffold fully removed.
 
 **~~Decision needed:~~ RESOLVED (Phase B1 PR #107 + Phase B2 PR #110, 2026-04-11):** Decision = remove dead code. Source cluster deleted in B1 (`finance_events.py`, `idempotent_handler.py`, `schemas/finance_events.py`, `EventIdempotencyService`, `ProcessedEvent` ORM model). Table `processed_event` dropped in B2 (migration `b2_drop_processed_event`, rev `5448988f1a77` → `b2_drop_processed_event`). See `docs/adr/ADR-001-remove-finance-events.md`.
 

--- a/Backend_FastAPI/EVENT_AUDIT_MATRIX.md
+++ b/Backend_FastAPI/EVENT_AUDIT_MATRIX.md
@@ -334,7 +334,7 @@ Events có đầy đủ registry config (resolver, template, channels) nhưng **
 
 **Impact:** 3 inline sync calls (`sync_lead_tuition_calculated`, `sync_lead_tuition_paid`, `sync_lead_tuition_refunded`) làm việc mà DomainEvent system lẽ ra phải làm. Nếu miss inline call ở flow nào → lead pipeline lệch, không có safety net.
 
-**~~Decision needed:~~ PARTIALLY RESOLVED (Phase B1, PR #107, 2026-04-11):** Decision = remove dead code. Source cluster deleted (`finance_events.py`, `idempotent_handler.py`, `schemas/finance_events.py`, `EventIdempotencyService`, `ProcessedEvent` ORM model). Table `processed_event` still exists in DB — pending Phase B2 drop migration after staging/prod preflight. See `docs/adr/ADR-001-remove-finance-events.md`.
+**~~Decision needed:~~ RESOLVED (Phase B1 PR #107 + Phase B2 PR #110, 2026-04-11):** Decision = remove dead code. Source cluster deleted in B1 (`finance_events.py`, `idempotent_handler.py`, `schemas/finance_events.py`, `EventIdempotencyService`, `ProcessedEvent` ORM model). Table `processed_event` dropped in B2 (migration `b2_drop_processed_event`, rev `5448988f1a77` → `b2_drop_processed_event`). See `docs/adr/ADR-001-remove-finance-events.md`.
 
 ### Finding 2: `safe_dispatch()` trong service layer — ~~architecture violation~~ **WONTFIX — accepted pattern** (reclassified 2026-04-09)
 
@@ -420,7 +420,7 @@ Cùng event, cùng registry config, **khác ngữ cảnh và payload format**. R
 
 | ID | Gap | Impact | Effort |
 |---|---|---|---|
-| Arch-1 | `finance_events.py` DomainEvent dead code | ~~Kiến trúc mơ hồ~~ Source removed in B1 (PR #107), table drop pending B2 | **PARTIALLY RESOLVED** — ADR-001 accepted, source deleted, table pending |
+| Arch-1 | `finance_events.py` DomainEvent dead code | ~~Kiến trúc mơ hồ~~ Source removed B1, table dropped B2 | **RESOLVED** (B1 PR #107 + B2 PR #110) |
 | Arch-2 | `payment_service` dùng `safe_dispatch()` trong post_commit closure | **WONTFIX — accepted pattern** (reclassified 2026-04-09). Closure runs post-commit, matches safe_dispatch contract. See decision tree row #5 in PART 7. | ~~Low — refactor về `dispatch()`~~ No action needed |
 | Arch-3 | Admission cặp đôi dispatch không atomic | Rare failure case: partial notification | Medium — bundle vào savepoint |
 | ~~A13~~ | ~~`application_documents_updated` legacy~~ | **RESOLVED** — event retired, file xóa (PR #93) | — |
@@ -462,7 +462,7 @@ Cùng event, cùng registry config, **khác ngữ cảnh và payload format**. R
 
 **Sprint 3: P3 — Kiến trúc cleanup**
 
-9. ~~**Arch-1** — Quyết định số phận `finance_events.py`: wire up hoặc remove~~ **PARTIALLY RESOLVED** (B1 PR #107) — source removed, table drop pending B2
+9. ~~**Arch-1** — Quyết định số phận `finance_events.py`: wire up hoặc remove~~ **RESOLVED** (B1 PR #107 + B2 PR #110) — source removed, table dropped
 10. ~~**Arch-2** — Refactor `payment_service` về `dispatch()` pattern~~ **WONTFIX** (2026-04-09) — accepted pattern, see decision tree row #5
 11. **Arch-3** — Bundle admission cặp đôi dispatch vào savepoint
 

--- a/Backend_FastAPI/alembic/versions/b2_drop_processed_event_table.py
+++ b/Backend_FastAPI/alembic/versions/b2_drop_processed_event_table.py
@@ -1,0 +1,105 @@
+"""drop processed_event table per ADR-001
+
+Revision ID: b2_drop_processed_event
+Revises: 5448988f1a77
+Create Date: 2026-04-11
+
+Removes the ``processed_event`` table per ADR-001. The table was created by
+migration fin20260131001 for finance_events.py DomainEvent idempotency
+tracking but never populated by production code (zero rows verified on dev
+and production as of 2026-04-11).
+
+Source cluster (finance_events.py, idempotent_handler.py, EventIdempotencyService,
+ProcessedEvent ORM model) was already removed in Phase B1 (PR #107). This
+migration completes the cleanup by dropping the orphan table.
+
+DESTRUCTIVE: drops table. Down-migration recreates schema (rows lost).
+
+Schema source: fin20260131001_create_finance_foundation_tables.py lines 129-151.
+Verified 2026-04-09 by Agent 3 + 2026-04-11 by pg_dump backup DDL match.
+
+Pinned IDs:
+  B2_REVISION = b2_drop_processed_event
+  B2_DOWN_REVISION = 5448988f1a77
+
+References:
+- ADR-001: docs/adr/ADR-001-remove-finance-events.md
+- Audit: EVENT_AUDIT_MATRIX.md Finding 1
+- Original create: alembic/versions/fin20260131001_create_finance_foundation_tables.py:129-151
+- Plan: velvet-swinging-moore.md Phase B2
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision = 'b2_drop_processed_event'
+down_revision = '5448988f1a77'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Drop the processed_event table."""
+    op.drop_index('ix_processed_event_event_id', table_name='processed_event')
+    op.drop_index('ix_processed_event_event_type', table_name='processed_event')
+    op.drop_table('processed_event')
+
+
+def downgrade() -> None:
+    """Recreate processed_event table for rollback (rows lost on drop).
+
+    Schema mirrors fin20260131001_create_finance_foundation_tables.py:129-151
+    exactly. Verified against:
+    - Source file read (Agent 3, 2026-04-09)
+    - pg_dump backup DDL (2026-04-11)
+    - Plan v6 B2.1 section
+    """
+    op.create_table(
+        'processed_event',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column(
+            'event_id', sa.String(100), nullable=False,
+            comment='Unique event identifier (e.g., VNPay transaction ID)',
+        ),
+        sa.Column(
+            'event_type', sa.String(50), nullable=False,
+            comment='Event type (e.g., vnpay_callback, momo_callback)',
+        ),
+        sa.Column(
+            'event_version', sa.String(20), nullable=True,
+            comment='Event schema version',
+        ),
+        sa.Column(
+            'consumer_id', sa.String(50), nullable=False,
+            comment='Consumer identifier (e.g., payment_service)',
+        ),
+        sa.Column(
+            'processed_at', sa.DateTime(timezone=True),
+            nullable=False, server_default=sa.func.now(),
+        ),
+        sa.Column(
+            'processing_result', sa.String(20), nullable=False,
+            comment='Result: success|failed|skipped',
+        ),
+        sa.Column('error_message', sa.Text(), nullable=True),
+        sa.Column(
+            'event_payload', JSONB, nullable=True,
+            comment='Original event payload for debugging',
+        ),
+        sa.UniqueConstraint(
+            'event_id', 'consumer_id',
+            name='uq_processed_event_id_consumer',
+        ),
+        sa.CheckConstraint(
+            "processing_result IN ('success', 'failed', 'skipped')",
+            name='chk_processed_event_result',
+        ),
+    )
+    op.create_index(
+        'ix_processed_event_event_id', 'processed_event', ['event_id']
+    )
+    op.create_index(
+        'ix_processed_event_event_type', 'processed_event', ['event_type']
+    )


### PR DESCRIPTION
## Summary

Phase B2 — final step of the Event/Notification architecture cleanup plan. Drops the orphan `processed_event` table that has zero rows across all environments and zero consumers.

Prerequisite: Phase A (PR #106) + Phase B1 (PR #107) already merged.

## Migration

**Hand-written** (NOT autogenerate). File: `b2_drop_processed_event_table.py`

| ID | Value |
|---|---|
| **B2_REVISION** | `b2_drop_processed_event` |
| **B2_DOWN_REVISION** | `5448988f1a77` |

- `upgrade()`: DROP INDEX x2 + DROP TABLE `processed_event`
- `downgrade()`: CREATE TABLE with full schema from `fin20260131001:129-151` (9 columns, 2 indexes, 1 unique constraint, 1 check constraint)

## Go/No-Go Checklist (all verified 2026-04-11)

- [x] Dev DB: `SELECT COUNT(*) FROM processed_event` = **0**
- [x] Prod DB: **0**
- [x] Staging: **waived** (no staging env — dev + prod only)
- [x] External consumers: **0** (`pg_stat_activity` shows only `qlts_backend_api`, zero non-Docker connections)
- [x] Fresh backup: `/root/b2_pre_deploy_20260411_113105.sql` (3.5 MB, DDL verified)
- [x] No other migration touches this table (`git grep` source-only: zero hits outside `fin20260131001`)
- [x] Rollback order documented: downgrade FIRST, revert SECOND

## Round-trip verify (all pass on dev)

```
Step 0: table exists, version 5448988f1a77
Step 1: upgrade b2_drop_processed_event → table NULL (dropped), version b2_drop_processed_event ✅
Step 2: downgrade 5448988f1a77 → table recreated (9 cols, 2 idx, constraints), 0 rows, version restored ✅
Step 3: upgrade b2_drop_processed_event → table NULL again ✅
Step 4: backend restart → health OK ✅
Step 5: celery boot → no ImportError ✅
```

## Audit matrix update

Finding 1 / Arch-1: PARTIALLY RESOLVED → **RESOLVED**

## Deploy

Backend restart only. `docker-entrypoint.sh` runs `alembic upgrade head` automatically on boot.

## Rollback

```bash
# 1. Downgrade FIRST (while migration file still on disk!)
docker compose exec backend alembic downgrade 5448988f1a77

# 2. Verify table recreated
docker compose exec backend bash -c 'psql "$DATABASE_URL" -c "SELECT to_regclass('"'"'public.processed_event'"'"');"'

# 3. THEN revert source
git revert <commit>

# 4. Rebuild + restart
docker compose up -d --build backend celery-worker celery-beat
```

**DO NOT** `git revert` first — Alembic needs the migration file on disk to execute `downgrade()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)