### PR TITLE
docs(finance): ADR-002 + semester tuition spec (PR 0 — spec-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,7 +229,14 @@ Documents/Seeding data/GitHistory/
 .agent/
 .agents/
 .claude/
-docs/
+# Previously a single `docs/` rule ignored every `docs/` directory in the
+# tree. That swept up `Backend_FastAPI/docs/` too, which is where real
+# backend design docs (ADRs, specs) live. Scope the rule to the specific
+# paths that should stay ignored so `Backend_FastAPI/docs/**` remains
+# trackable for new files. Existing tracked files are unaffected either way.
+/docs/
+frontend/docs/
+Backend_FastAPI/docs/CTV_ORIGINAL_*.md
 
 # Debug scripts
 Backend_FastAPI/debug_*.py

--- a/Backend_FastAPI/MASTER_ARCHITECTURE.md
+++ b/Backend_FastAPI/MASTER_ARCHITECTURE.md
@@ -515,3 +515,21 @@ These match **decision tree row #5**. They are documented because `git grep "saf
 6.  Verify end-to-end: check `notification_delivery` rows created, check channel delivery logs.
 
 For troubleshooting missing notifications, see `docs/EVENT_ARCHITECTURE.md` Section 7.
+
+---
+
+## PART 8: DOMAIN SEMANTICS POINTERS
+
+These documents lock business semantics that this architecture file does
+not restate. When the rules differ, the domain document is authoritative
+for its area.
+
+- **Finance — Semester Tuition Refactor** (active epic): canonical source
+  of truth for tuition is per-semester. HK1 is the admission fee. The
+  admission finance gate becomes HK1 financial clearance under a mode
+  switch. See `docs/adr/ADR-002-semester-tuition-refactor.md` and
+  `docs/SEMESTER_TUITION_SPEC.md`. Until this epic lands, the current
+  `tuition_fee_per_year` path remains in place; new code must not rely on
+  it as canonical.
+- **Finance — Dead event cluster removal** (shipped): no `DomainEvent` /
+  `emit_event()`. See `docs/adr/ADR-001-remove-finance-events.md`.

--- a/Backend_FastAPI/docs/FINANCE_MODULE_DESIGN.md
+++ b/Backend_FastAPI/docs/FINANCE_MODULE_DESIGN.md
@@ -20,6 +20,13 @@
 > - Accounting: `accounting_service.py`, `accounting.py` (model)
 > - Architecture: `MASTER_ARCHITECTURE.md` PART 7, `docs/EVENT_ARCHITECTURE.md`
 > - Dead code removal: `docs/adr/ADR-001-remove-finance-events.md`
+> - **Tuition model refactor (active epic, 2026-04-11)**:
+>   `docs/adr/ADR-002-semester-tuition-refactor.md` and
+>   `docs/SEMESTER_TUITION_SPEC.md`. This epic moves the canonical tuition
+>   unit from `tuition_fee_per_year` to per-semester `semester_tuition`.
+>   The year-based modeling anywhere in this historical document is
+>   superseded by that ADR/spec. Do not implement against the year-based
+>   description below without first reading ADR-002.
 
 # Finance Module Design - QLTS
 

--- a/Backend_FastAPI/docs/SEMESTER_TUITION_SPEC.md
+++ b/Backend_FastAPI/docs/SEMESTER_TUITION_SPEC.md
@@ -1,0 +1,336 @@
+# Semester Tuition Spec
+
+> **Status**: PR 0 spec-only draft (2026-04-11). Companion to
+> `docs/adr/ADR-002-semester-tuition-refactor.md`. No runtime code, schema,
+> or migration changes accompany this document.
+
+This document is the canonical description of the semester tuition model
+QLTS is moving to. It restates the business rules declaratively, draws the
+boundary between admission and post-admission finance flows, and lists the
+contract compatibility rules that every PR in the epic must respect.
+
+The binding decisions live in ADR-002. This spec is **reference material
+for implementers**: if the ADR and the spec disagree, the ADR wins and the
+spec is wrong and must be fixed.
+
+---
+
+## 1. Vocabulary
+
+| Term | Meaning |
+|---|---|
+| `semester_tuition` | The per-major, per-semester tuition catalog. One row per (program academic info, semester number). Canonical source of tuition. |
+| `HK1` | Semester 1. The only semester the admission workflow cares about. |
+| `semester_no` | Integer index of a semester within a program's full course duration. `1` for HK1. Non-nullable for `tuition` fees. |
+| `tạm thu` | The operational state of an HK1 fee while payment is in progress. **Not** a fee type. **Not** a separate table or enum value. |
+| `HK1 financial clearance` | The gate condition that lets a profile transition to `enrolled` under the new model. See §4.2. |
+| `fee` (per the model) | One semester financial obligation. After refactor, a tuition fee row is always per-semester. |
+| `invoice` (per the model) | One collection installment belonging to a fee. A fee may have many invoices. |
+| `InstallmentPlan` | A reusable catalog of payment schedules. Attached per-fee. Not cross-semester. |
+| `admission profile` | An enrollment attempt. Scopes which HK1 fee is in play. |
+| `post-admission finance flow` | Everything related to HK2..HKn. Out of admission_service scope. |
+
+---
+
+## 2. Canonical Data Model (Conceptual)
+
+```
+                 +---------------------------+
+                 |   offering_academic_info  |
+                 |  (program / major / year) |
+                 +-------------+-------------+
+                               |
+                               | 1 .. N  (one row per semester in the full course)
+                               v
+                 +---------------------------+
+                 |   offering_semester_tuition|
+                 |   (semester_no, amount)    |  <-- CANONICAL SOURCE
+                 +---------------------------+
+
+                 +---------------------------+
+                 |     admission_profile     |
+                 +-------------+-------------+
+                               |
+                               | 1 .. N
+                               v
+                 +---------------------------+
+                 |            fee            |
+                 | (fee_type, semester_no,   |
+                 |  status, amounts,         |
+                 |  installment_plan_id)     |
+                 +-------------+-------------+
+                               |
+                               | 1 .. N
+                               v
+                 +---------------------------+
+                 |          invoice          |
+                 +---------------------------+
+```
+
+Key structural rules:
+
+1. `offering_semester_tuition` is a new table introduced in PR 1. Its
+   shape is declared there; this spec only fixes its role as the canonical
+   source of tuition data.
+2. `Fee` gains a `semester_no` column. For `fee_type='tuition'`, the value
+   must be `>= 1`. For other fee types, PR 1 picks the shape (nullable vs
+   sentinel) per ADR-002 Decision 3 / Gap A.
+3. `Fee` retains the existing `installment_plan_id` FK. The
+   `InstallmentPlan` catalog is unchanged; only the call site becomes
+   per-semester.
+4. `FeeAppliedDiscount` keys remain `(fee_id, policy_id)`. A discount on
+   HK1 does **not** propagate to HK2.
+
+---
+
+## 3. Fee Uniqueness
+
+Effective after PR 1 migration:
+
+```sql
+-- DROP: uq_fee_profile_type_year  (see fee.py:79-82)
+-- ADD:
+UNIQUE (admission_profile_id, fee_type, semester_no)
+  -- partial or full per PR 1's choice for non-tuition rows
+```
+
+`academic_year` remains on `Fee` as a **non-unique metadata column**. Its
+semantics during the transition:
+
+- For legacy rows migrated from the year-based model: preserved as-is.
+- For new per-semester rows: PR 1 picks the interpretation (e.g. "the
+  calendar year in which the semester begins") and documents it in the
+  migration message. The choice does not affect uniqueness.
+
+---
+
+## 4. Admission Flow
+
+### 4.1 Lifecycle
+
+```
+draft -> submitted -> approved -> [HK1 fee created] -> confirmed -> enrolled
+                                  ^                    ^            ^
+                                  |                    |            |
+                         HK1 semester_tuition    HK1 gate passes   state change
+                         lookup + Fee insert     (see 4.2)
+```
+
+HK1 fee creation stays in the existing `fee_calculation_service` call site
+triggered by profile approval. The only change is that the amount source
+switches from `OfferingAcademicInfo.tuition_fee_per_year` to
+`offering_semester_tuition` for `semester_no = 1`, and the resulting `Fee`
+row carries `semester_no = 1`.
+
+### 4.2 HK1 Financial Clearance
+
+A profile is cleared for enrollment when its HK1 fee satisfies **all** of:
+
+1. The fee exists: `fee_type='tuition' AND semester_no=1 AND
+   admission_profile_id=<profile>`.
+2. The fee is in a cleared state. Cleared means **any** of:
+   - **Full payment** — `status = paid`. Entire HK1 amount settled.
+   - **Any non-zero HK1 payment** — one or more valid payments have been
+     recorded against the HK1 fee with total paid amount `> 0`. This
+     covers all three business cases explicitly allowed by the spec:
+     paying the full amount, paying exactly the operational `tạm thu`
+     amount, and paying **less than `tạm thu`**. All three pass the gate.
+     Any unpaid remainder stays as HK1 debt and does **not** block
+     enrollment. Expected fee `status` is `partial` (or `paid` if the
+     payment fully settles the amount).
+   - **Formal waiver** — `status = waived`, backed by an explicit HK1
+     waiver marker. A waiver clears the gate without booking revenue.
+
+**Locked business decision**: there is no minimum payment threshold for
+passing the HK1 gate. A non-zero payment is sufficient. If the business
+ever wants a minimum threshold, it must be added by updating this spec
+and ADR-002 first — not by silently rejecting low-amount partial
+payments in the gate logic.
+
+The exact `FeeStatusEnum` set to accept in code and the concrete
+mechanism for recording "waiver without revenue" (e.g. `waived_amount`
+column usage, explicit waiver record, audit trail shape) are implemented
+in PR 4 (see ADR-002 Deferred Decision D8). This spec fixes only the
+intent: any non-zero payment **or** a valid waiver clears the gate.
+
+### 4.3 Events
+
+Three existing projections at
+`Backend_FastAPI/app/core/admission_event_mapping.py:184,200,215`
+(`tuition_fee_calculated`, `tuition_fee_paid`, `tuition_fee_refunded`)
+must be gated to `semester_no == 1` in PR 5. This spec fixes the intent:
+
+- `tuition_fee_calculated`: fires only for the HK1 fee created at
+  approval time. HK2+ fee creation events must not project here.
+- `tuition_fee_paid`: fires only when the HK1 fee reaches a cleared state
+  for the first time. HK2+ payments must not touch the admission pipeline.
+- `tuition_fee_refunded`: fires only on an HK1 refund. HK2+ refunds are a
+  post-admission concern.
+
+---
+
+## 5. Post-Admission Flow (HK2..HKn)
+
+Out of admission_service scope. HK2+ fees are created lazily by a later
+service not yet built (ADR-002 D13). Their relationship to `Fee`,
+`Invoice`, and `InstallmentPlan` reuses the same tables but none of them
+project into the admission pipeline.
+
+Rules this spec fixes for HK2+:
+
+1. HK2+ fees must set `semester_no >= 2`.
+2. HK2+ payment events (`PAYMENT_VERIFIED`, `PAYMENT_REJECTED`,
+   `REFUND_PROCESSED`, etc.) may fire normally; they stay in the finance
+   notification surface. They must not trigger admission projections.
+3. HK2+ fee anchor date is the respective semester start date. The source
+   of this date (calendar table, program metadata, manual admin input) is
+   decided later.
+4. HK2+ discount application is independent from HK1 by default (ADR-002
+   Decision 4).
+
+---
+
+## 6. Installment Plan Usage
+
+The catalog is unchanged. Every fee may optionally attach a plan:
+
+```
+Fee.installment_plan_id  -> InstallmentPlan.id
+```
+
+Plans stay global and reusable. There is no per-semester plan variant and
+no cross-semester plan.
+
+The invoice generation call site must provide an explicit `anchor_date`
+to `InstallmentPlan.get_installment_schedule()` (new PR 3 parameter). The
+anchor date is:
+
+- For HK1: the admission approval timestamp.
+- For HK2+: the semester start date (see §5 rule 3).
+
+Invoice count per fee is `1..N` depending on the plan. The current
+`schedule` JSON model (`installment_plan.py:32-45`) already supports this
+shape; no model change needed.
+
+---
+
+## 7. Discounts
+
+`FeeAppliedDiscount` remains per-fee. The unique constraint
+`uq_fee_applied_discount_fee_policy` (`fee.py:294-297`) stays.
+
+Rule: applying a discount policy to the HK1 fee of a profile does **not**
+cause automatic application of the same policy to HK2+ fees of the same
+profile.
+
+Multi-semester scholarship encoding (when business asks for it later):
+
+- New convention on `TuitionDiscountPolicy.applicable_scope` JSON:
+  `{"semesters": [1, 2, 3, 4]}`.
+- The discount application service (PR 3 scope) must honor this field
+  when creating per-semester fees. Absent the field, default behavior is
+  "single fee only".
+
+ADR-002 Decision 4 follow-up: the discount invalidation hook at
+`Backend_FastAPI/app/services/organization_service.py:1370-1374` must
+gain a mirror for `semester_tuition` CRUD in PR 2 or PR 3.
+
+---
+
+## 8. Public / Admin Contract Compatibility
+
+### 8.1 Current surface (frozen as legacy)
+
+| Field | Location | Status during epic |
+|---|---|---|
+| `tuition_fee_per_year` | `public_admissions.py:24`, `AcademicInfoPanel.tsx:58`, `OfferingAcademicInfoDialog.tsx:59` | Deprecated compatibility. Value unchanged during transition. Not canonical. |
+| `tuition_min` / `tuition_max` | `public_admissions.py:48-49,59-60` | Deprecated compatibility. Same rule. |
+| `avg_tuition_fee`, `min_tuition_fee`, `max_tuition_fee` | `organization_service.py:1699-1713` | Deprecated compatibility. Labels will be realigned in PR 7. |
+| lost-revenue proxies | `officer_repository.py:447-539` | Deprecated compatibility. Formula realigned in PR 7. |
+
+Rule: none of these fields is silently redefined to mean "HK1 amount".
+They continue to return the value they return today until they are
+removed or renamed in a later PR.
+
+### 8.2 New additive surface (PR 6 scope)
+
+| Field | Shape | Purpose |
+|---|---|---|
+| `semester_tuitions[]` | Array of `{semester_no, amount}` | Full-course tuition table. |
+| `semester_1_tuition` | Scalar amount | HK1 amount, directly surfaced for admission contexts. |
+| `semester_1_tuition_min` / `semester_1_tuition_max` | Aggregate scalars | HK1 range per program / degree-level group. |
+
+All new fields are additive. No existing field is removed until frontend
+and public consumers have migrated to the new ones.
+
+### 8.3 Frontend wording
+
+Frontend display text must make clear which fields are per-semester and
+which are legacy annual values. Example:
+
+- HK1 prominent card: labeled "Học phí HK1" — sourced from
+  `semester_1_tuition`.
+- Full-course table: labeled "Bảng học phí toàn khóa theo từng học kỳ" —
+  sourced from `semester_tuitions[]`.
+- Legacy annual value (if still displayed): must be labeled
+  "Học phí năm (giá trị cũ)" or similar and must not be presented as the
+  canonical tuition number. Preferred: remove from UI in PR 6.
+
+---
+
+## 9. Flags
+
+Two controls govern the admission gate during rollout. See ADR-002
+§"Flags and Truth Table" for the binding table. In summary:
+
+- `ENABLE_FEE_VERIFICATION` — circuit breaker. When `false`, gate is
+  bypassed regardless of mode.
+- `ADMISSION_FEE_GATE_MODE` — mode switch, `legacy` (current logic) or
+  `semester_hk1` (new logic). Default `legacy` during rollout.
+
+---
+
+## 10. Non-goals (Spec scope)
+
+Same as ADR-002 non-goals. In particular, this spec does **not**:
+
+- Name the exact DB columns or migration SQL for `offering_semester_tuition`
+  (PR 1).
+- Define the academic calendar source for HK2+ semester start dates
+  (later PR, ADR-002 D13).
+- Prescribe KPI label wording (PR 7).
+- Specify the API schema version bumping strategy (not bumped; rollout is
+  additive).
+- Describe the operations runbook for flipping the two flags in prod.
+
+---
+
+## 11. Open-but-closed items (hardened wording to prevent drift)
+
+The following items have been asked about repeatedly and are **closed**.
+If a future PR disagrees, it must update ADR-002 first.
+
+1. **`tạm thu` is not a fee type**. It is an operational state of an HK1
+   fee whose payment is in progress. Anyone introducing a new fee_type
+   for it is wrong.
+2. **`tuition_fee_per_year` is not redefined**. It is not "the same as
+   HK1". It is a deprecated compatibility field with its current value.
+3. **Admission flow binds only to HK1**. HK2..HKn do not affect
+   `admission_service`, `admission_event_mapping`, or lead pipeline
+   projections.
+4. **Partial HK1 payment passes the gate**. Anyone rejecting partial in
+   the new gate logic is wrong.
+5. **Formal HK1 waiver passes the gate without booking revenue**.
+   Booking revenue for a waiver is wrong.
+6. **`ENABLE_FEE_VERIFICATION` is a circuit breaker, not a semantics
+   switch**. Using it to flip legacy vs semester_hk1 is wrong.
+7. **InstallmentPlan stays global**. Nobody should create a
+   per-semester-variant catalog.
+8. **Discounts do not auto carry-over between semesters**. Silent
+   propagation is wrong.
+9. **No `DomainEvent` / `emit_event()` revival** (ADR-001 rule,
+   reinforced here).
+10. **Ember branch ships three events ahead of this epic**:
+    `PAYMENT_REJECTED`, `REFUND_PROCESSED`, `PAYMENT_VERIFIED` online
+    callback parity. `FEE_FULLY_PAID`, `INVOICE_ISSUED`, `PAYMENT_OVERDUE`
+    are deferred to PR 8.

--- a/Backend_FastAPI/docs/adr/ADR-002-semester-tuition-refactor.md
+++ b/Backend_FastAPI/docs/adr/ADR-002-semester-tuition-refactor.md
@@ -1,0 +1,463 @@
+# ADR-002: Semester Tuition Refactor
+
+## Status
+
+Proposed (2026-04-11) — PR 0 (spec-only, no runtime changes)
+
+## Context
+
+QLTS currently stores tuition as a single annual amount per academic program:
+`OfferingAcademicInfo.tuition_fee_per_year` (see
+`Backend_FastAPI/app/models/offering_academic_info.py:43`). The admission
+workflow and all public/admin UI, KPI analytics, and the fee calculation
+pipeline derive their numbers from this one scalar per year.
+
+The real business process is **per semester**, not per year:
+
+- Each major/program has a tuition table covering the full course duration,
+  broken down per semester (HK1, HK2, HK3, ...).
+- Semester 1 (HK1) is the financial object the admission flow cares about.
+- The operational term *tạm thu* (provisional collection) collected at the
+  time of enrollment is, in business reality, **HK1 tuition** — not a
+  separate deposit concept.
+- Partial payment of HK1 is valid and must still let the student cross the
+  enrollment gate; the unpaid remainder stays as HK1 debt.
+- Formal fee waivers (`đặc cách miễn`) clear HK1 for gate purposes without
+  producing recognized revenue.
+- HK2 and beyond are a post-admission finance flow, not an admission flow
+  concern.
+
+This ADR is spec-only. It does not change runtime code, schema, migrations,
+or contracts. It locks the semantics and rollout rules that the subsequent
+PRs (PR 1..PR 8 in the epic roadmap) must follow.
+
+## Problem Statement
+
+The current `tuition_fee_per_year` model is **wrong at the conceptual level**:
+
+1. **Canonical unit mismatch.** The business unit is a semester; the model
+   unit is a year. Every downstream piece (admission gate, discount,
+   installment plan, KPI, public API) inherits this mismatch.
+
+2. **Admission gate is too strict.** The gate at
+   `Backend_FastAPI/app/services/admission_service.py:175` only accepts
+   `fee.status in (paid, waived)`. `partial` is a legitimate `FeeStatusEnum`
+   value (`fee.py:59`) but is rejected, even though the business says
+   partial HK1 payment must pass the gate.
+
+3. **Schema blocks multi-semester fees.** The constraint
+   `uq_fee_profile_type_year` (`fee.py:79-82`) forbids more than one
+   `tuition` row per (profile, academic_year). Even if we add `semester_no`
+   to `Fee`, the current constraint would reject a second HK2 tuition row
+   in the same year.
+
+4. **Public/admin contracts expose `tuition_fee_per_year` directly**
+   (`Backend_FastAPI/app/schemas/public_admissions.py:24,48-49,59-60`).
+   Silently redefining this field to mean HK1 would break contract trust.
+
+5. **KPI/analytics use annual tuition as a revenue proxy**
+   (`Backend_FastAPI/app/repositories/officer_repository.py:447-539`,
+   `Backend_FastAPI/app/services/organization_service.py:1699-1713`).
+   Their meaning silently drifts if the underlying field is reinterpreted.
+
+6. **Events already reference tuition milestones** in admission projections
+   (`Backend_FastAPI/app/core/admission_event_mapping.py:184,200,215`:
+   `tuition_fee_calculated`, `tuition_fee_paid`, `tuition_fee_refunded`).
+   These currently carry no semester context and would pull HK2+ payments
+   into the admission pipeline incorrectly after refactor.
+
+## Business Semantics (Locked)
+
+The following rules are the source of truth for all PRs in this epic:
+
+1. The canonical tuition source is a **per-major, per-semester tuition
+   table**, named `semester_tuition` at the technical level.
+2. `HK1` (semester 1) is the financial object of the **admission** flow.
+3. `tạm thu` is **not** a separate fee type; it is the operational state of
+   an HK1 `semester_tuition` fee whose payment is in progress.
+4. Students may settle HK1 via any of:
+   - full payment,
+   - payment equal to the `tạm thu` amount,
+   - payment less than `tạm thu` (still valid),
+   - formal waiver (`đặc cách miễn`).
+5. The admission gate is **HK1 financial clearance**, not "HK1 fully paid".
+6. Partial payment satisfies the gate; the remainder stays as HK1 debt.
+7. Formal waiver satisfies the gate but **does not** book revenue.
+8. Each semester is **one `Fee` row**.
+9. A semester fee may have one or more invoices (collection installments).
+10. The admission workflow only binds to HK1. HK2+ is post-admission.
+11. Public-facing UI must surface HK1 prominently **and** a
+    full-course-per-semester table.
+
+## Canonical Data Model Direction
+
+> Detailed shape lives in `docs/SEMESTER_TUITION_SPEC.md`. This ADR fixes
+> only the decisions that gate PR 1 schema design.
+
+The per-major, per-semester tuition table is a new `offering_semester_tuition`
+(or equivalent name chosen in PR 1) row-per-semester model, keyed by
+`(academic_info_id, semester_no)` with a monetary `amount` and active-window
+metadata. It becomes the canonical tuition source.
+
+`OfferingAcademicInfo.tuition_fee_per_year` remains in place throughout the
+transition as a **deprecated compatibility field**, not the canonical source
+of truth. Its value during transition is defined by Decision 5 below; it
+must not be silently redefined to mean "HK1 amount".
+
+`Fee` gains a `semester_no` dimension. See `Closed Decisions > Gap A` for
+the exact uniqueness tuple and migration rules.
+
+`InstallmentPlan` is unchanged structurally and remains a global catalog
+attached per semester fee via `Fee.installment_plan_id`. See
+`Closed Decisions > Decision 3`.
+
+`FeeAppliedDiscount` remains keyed per fee. Multi-semester scholarship, if
+needed later, must go through `TuitionDiscountPolicy.applicable_scope` with
+an explicit `semesters` field — never via implicit carry-over. See
+`Closed Decisions > Decision 4`.
+
+## Admission vs Post-Admission Financial Boundary
+
+**Admission flow (in scope for admission_service.py)**:
+- Only HK1 fees exist as a precondition of the enrollment gate.
+- Only HK1 fee events project into the admission pipeline.
+- Only HK1 financial clearance gates the transition to `enrolled`.
+
+**Post-admission flow (out of scope for admission_service.py)**:
+- HK2..HKn fees, their invoices, payments, refunds, discounts.
+- Per-semester scheduling, due dates, reminders, overdue handling.
+- These may reuse `Fee`, `Invoice`, `InstallmentPlan`, and `PAYMENT_*`
+  events, but **must not** fire admission projections.
+
+**Concrete consequence**: the projections at
+`admission_event_mapping.py:184,200,215` (`tuition_fee_calculated`,
+`tuition_fee_paid`, `tuition_fee_refunded`) must be gated to
+`semester_no == 1` once `Fee.semester_no` exists. This is explicitly
+assigned to PR 5 in the roadmap; this ADR only locks the intent.
+
+## Flags and Truth Table
+
+Two orthogonal controls govern the admission finance gate during rollout:
+
+| Flag | Role | Allowed values |
+|---|---|---|
+| `ENABLE_FEE_VERIFICATION` | Circuit breaker — does the gate run at all? | `true` / `false` (default `false`, see `config.py:376-377`, `.env.example:177`) |
+| `ADMISSION_FEE_GATE_MODE` | Which gate semantics apply when the circuit breaker is on? | `legacy` / `semester_hk1` (default `legacy` during rollout) |
+
+### Truth Table
+
+| `ENABLE_FEE_VERIFICATION` | `ADMISSION_FEE_GATE_MODE` | Gate behavior | Notes |
+|---|---|---|---|
+| `false` | `legacy` | **Bypassed.** No finance check runs before `enrolled`. | Current production default. |
+| `false` | `semester_hk1` | **Bypassed.** Mode is ignored when circuit breaker is off. | Safe to flip mode without enabling the gate. |
+| `true` | `legacy` | Check: exactly one `tuition` fee per profile; accept only `status in (paid, waived)`. | Current `admission_service.py:175` logic. Partial rejected. |
+| `true` | `semester_hk1` | Check: `HK1` fee exists (`fee_type='tuition'`, `semester_no=1`) **and** is cleared. Cleared means: `status in (paid, partial, waived)` **or** an explicit HK1 waiver marker, per the clearance definition in the spec. | New logic. Partial passes. Waiver passes without booking revenue. |
+
+**Rollout sequence**:
+1. Ship `ADMISSION_FEE_GATE_MODE` as a new setting, defaulting to `legacy`.
+   No runtime behavior change.
+2. After PR 3/PR 4 land, flip `ADMISSION_FEE_GATE_MODE=semester_hk1` in
+   staging with `ENABLE_FEE_VERIFICATION=true` to validate.
+3. Production rollout flips both flags per the operations runbook in the
+   epic (out of scope for PR 0).
+
+**Non-rule**: the two flags are never collapsed into a single boolean.
+Circuit breaker and mode switch are independent concerns.
+
+## Closed Decisions
+
+### Decision 1 — Payment Event Parity is only partially blocked
+
+`feat/finance-payment-event-parity` (the ember branch) is **not fully
+blocked** by this epic.
+
+**Ship before the semester refactor** (payment-event parity work, semester
+model not required):
+- `PAYMENT_REJECTED`
+- `REFUND_PROCESSED`
+- online callback parity for `PAYMENT_VERIFIED` (including the
+  `verified_by_id=None` fix for `chk_payment_no_self_approval`)
+
+**Defer until semester semantics are stable**:
+- `FEE_FULLY_PAID`
+- `INVOICE_ISSUED`
+- `PAYMENT_OVERDUE`
+
+The ember branch (`feat/finance-payment-event-parity`) has WIP event catalog
+additions whose payloads already use opaque `fee_id` references, so the
+semester refactor will not require rewriting their payloads. The branch may
+ship the three ship-safe items above independently of this epic.
+
+**Known follow-ups owned by PR 5** (not blocking ember merge):
+- `sync_lead_tuition_refunded()` currently projects unconditionally into
+  the admission pipeline. It must be gated to `semester_no == 1` once
+  `Fee.semester_no` exists.
+- `PAYMENT_VERIFIED` payload carries an `is_fully_paid` flag derived from
+  `Fee.is_fully_paid` (`fee.py:266`). Under the per-semester model, this
+  flag means "HK1 fully paid" and must be reinterpreted; ADR-001 already
+  notes that `FeeFullyPaid` is only partially bridged via this flag.
+
+**Compatibility constraint (from ADR-001)**: this decision does **not**
+allow reintroducing `DomainEvent` / `emit_event()`. Any new notification
+must use `SystemEvents` + `EventDefinition` + `notification_rule` seed.
+See `Backend_FastAPI/docs/adr/ADR-001-remove-finance-events.md:104-106`.
+
+### Decision 2 — Keep `ENABLE_FEE_VERIFICATION` as a circuit breaker
+
+`ENABLE_FEE_VERIFICATION` is the on/off switch for the admission finance
+gate and nothing else. The semester refactor introduces a **separate** mode
+control `ADMISSION_FEE_GATE_MODE=legacy|semester_hk1`.
+
+Rationale: the legacy gate means "tuition fee must be `paid` or `waived`"
+and the new gate means "HK1 financial clearance". These are different
+semantics; overloading one boolean makes rollout impossible to reason about.
+
+The truth table above is part of this decision and must not be modified
+without updating this ADR.
+
+### Decision 3 — InstallmentPlan stays global, applies per semester fee
+
+`InstallmentPlan` remains a shared catalog (`installment_plan.py:47`). Each
+semester fee is a separate `Fee` row and attaches to a plan via
+`Fee.installment_plan_id`. There is no cross-semester installment plan.
+
+Semantic clarification:
+- `fee` = one semester financial obligation.
+- `invoice` = one or more collection installments belonging to that fee.
+- `tạm thu` is **not** a distinct `fee_type`; it is the operational state
+  of an HK1 `semester_tuition` fee with `status in (calculated, partial)`.
+
+**Installment schedule calculation** must accept an explicit `anchor_date`
+parameter instead of implicitly reading the fee creation date. The
+existing `InstallmentPlan.get_installment_schedule()` signature
+(`installment_plan.py:129-171`) is compatible with this change — it
+already takes `total_amount` explicitly — but a new `anchor_date` parameter
+is required so HK1 and HK2 fees using the same plan code can produce
+consistent or intentionally different schedules. This is PR 3 work.
+
+#### Gap A — Uniqueness tuple (closed)
+
+The new uniqueness constraint on `fee` is:
+
+```
+UNIQUE (admission_profile_id, fee_type, semester_no)
+```
+
+`academic_year` is **removed from the uniqueness tuple** but **retained as
+a non-unique metadata column** on `Fee`.
+
+**Rationale**:
+- A single `admission_profile_id` represents one enrollment attempt.
+  Within that attempt, the (fee_type, semester_no) pair is naturally
+  unique — a student does not pay tuition twice for HK1 of the same
+  program instance.
+- `academic_year` is ambiguous when a Vietnamese school year spans two
+  calendar years (e.g. school year 2026-2027 contains HK1 in Fall 2026
+  and HK2 in Spring 2027). Keeping it in uniqueness would force a
+  policy decision about how the calendar split is stored, which is a
+  reporting concern, not an integrity concern.
+- Demoting `academic_year` to metadata means PR 1 can choose any
+  interpretation (e.g. "the calendar year in which the semester begins"
+  or "the school year label") without breaking schema migrations later.
+
+**Migration rules for existing rows** (PR 1 scope):
+- Every existing `tuition` row is logically an "annual tuition" today.
+  Backfill `semester_no = 1` on those rows during PR 1 migration.
+- Drop `uq_fee_profile_type_year` and create
+  `uq_fee_profile_type_semester` in the same migration (constraint
+  name reflects the new tuple — `academic_year` is not part of it).
+- Preserve `academic_year` values as-is; they become metadata.
+- Backfill is safe because the old uniqueness guarantees at most one
+  `tuition` row per (profile, year) today, so the new tuple
+  (profile, type, semester_no=1) is also unique.
+
+**Non-`tuition` fee types** (`application`, `enrollment`, `insurance`,
+`dormitory`, `other` — `fee.py:44-51`) do not have a meaningful semester
+dimension. PR 1 must decide one of:
+  1. allow `semester_no = NULL` for non-tuition rows and add a partial
+     unique index that only applies when `semester_no IS NOT NULL`; or
+  2. force `semester_no = 0` (or similar sentinel) for non-tuition rows
+     and keep the constraint as above.
+The ADR does not prescribe which — PR 1 chooses based on migration
+ergonomics. The only rule is: whichever shape PR 1 picks, `tuition` rows
+must always have `semester_no >= 1`.
+
+#### Gap B — Fee creation strategy (closed)
+
+The strategy is **hybrid**:
+
+- **HK1 is created eagerly** at admission approval time by the existing
+  fee calculation flow (`fee_calculation_service.py`). Its `anchor_date`
+  is the admission approval timestamp. This preserves the current gate
+  evaluation window: the HK1 fee always exists by the time the gate runs.
+- **HK2..HKn are created lazily** by a post-admission service or
+  scheduler, not by `admission_service.py`. Their `anchor_date` is the
+  respective semester start date, sourced from the academic calendar.
+  PR 0 does not pick the calendar source — see `Deferred Decisions`.
+
+**Rationale**:
+- The admission gate only needs HK1 to exist. Eager creation of HK2+ at
+  approval time creates stale fees for students who drop out before HK2
+  begins.
+- Lazy creation of HK2+ matches the business spec that "HK2+ is a
+  post-admission flow".
+- The HK1 gate behavior is independent of the strategy choice, which
+  isolates the admission flow from calendar concerns.
+
+**Concrete consequence**: `admission_service.py` never creates HK2+ fees.
+A later PR (roadmap position TBD, not PR 1..PR 8 scope) will introduce
+the post-admission semester-fee service. PR 0 only locks the boundary.
+
+### Decision 4 — Discounts are per semester fee, no auto carry-over
+
+Discounts in `FeeAppliedDiscount` (`fee.py:280-363`) remain keyed per
+`(fee_id, policy_id)`. No discount applied to HK1 auto-propagates to HK2+.
+
+Multi-semester scholarships, when needed, must be encoded explicitly
+through `TuitionDiscountPolicy.applicable_scope` with a new convention
+(e.g. `applicable_scope.semesters = [1, 2, 3, 4]`). This convention is
+proposed but not yet implemented and is out of scope for PR 0.
+
+**Required follow-up for PR 2/PR 3**: the invalidation hook at
+`organization_service.py:1370-1374` currently only fires on
+`tuition_fee_per_year` edits. A mirror path must be added for
+`semester_tuition` CRUD so discount recalculation triggers correctly when
+the underlying per-semester amount changes.
+
+### Decision 5 — Public API rollout is additive and non-breaking
+
+Public and frontend contracts migrate in an additive, non-breaking way
+first. The canonical switchover happens only after UI has consumed the new
+fields.
+
+**New fields to add** (exact names chosen in PR 6):
+- `semester_tuitions[]` — per-semester tuition rows for the full course.
+- `semester_1_tuition` — the HK1 amount, surfaced directly for admission
+  contexts.
+- `semester_1_tuition_min` / `semester_1_tuition_max` — aggregates at
+  program and degree-level group level, parallel to the existing
+  `tuition_min`/`tuition_max`.
+
+**Existing `tuition_fee_per_year` is NOT redefined**. It is treated as a
+**deprecated compatibility field**, not canonical. Its transition value is:
+
+> During the rollout window, `tuition_fee_per_year` continues to return
+> the value stored in `OfferingAcademicInfo.tuition_fee_per_year`
+> unchanged. It is not derived from semester tuition data. It is not
+> silently overwritten. Whether and when the column is dropped is a
+> separate PR after frontend/admin/public consumers have migrated.
+
+**Aggregate fields are in scope** for this decision as well, not only the
+scalar:
+- `tuition_min` / `tuition_max` on `PublicAdmissionsProgramSummary`
+  (`public_admissions.py:48-49`) and `PublicAdmissionsDegreeLevelGroup`
+  (`public_admissions.py:59-60`).
+- `avg_tuition_fee`, `min_tuition_fee`, `max_tuition_fee` on the
+  organization summary (`organization_service.py:1699-1713`).
+- Lost-revenue proxies in `officer_repository.py:447-539`.
+
+All of these remain as legacy contract fields during the rollout. Their
+relabeling is deferred to PR 7 — see `Deferred Decisions`.
+
+## Deferred Decisions / Later PR Ownership
+
+| # | Item | Owner |
+|---|---|---|
+| D1 | Concrete DB column name, type, and index for `offering_semester_tuition` | PR 1 |
+| D2 | `semester_no` nullable-vs-sentinel shape for non-tuition fee types | PR 1 |
+| D3 | Backfill migration for existing `tuition` rows to `semester_no=1` | PR 1 |
+| D4 | Admin config UI for per-semester tuition input (replaces single annual input) | PR 2 |
+| D5 | Mirror invalidation hook for `semester_tuition` CRUD (Decision 4 follow-up) | PR 2 or PR 3 |
+| D6 | `Fee.semester_no` column + adjusted `fee_calculation_service.py` | PR 3 |
+| D7 | `anchor_date` parameter on `InstallmentPlan.get_installment_schedule()` | PR 3 |
+| D8 | New gate logic for `ADMISSION_FEE_GATE_MODE=semester_hk1`, including the clearance definition (what counts as `cleared`) and the explicit waiver marker | PR 4 |
+| D9 | Gating `sync_lead_tuition_refunded` to `semester_no == 1` | PR 5 |
+| D10 | Reinterpreting `PAYMENT_VERIFIED.is_fully_paid` under per-semester model | PR 5 |
+| D11 | Additive public API fields + frontend contract changes | PR 6 |
+| D12 | KPI/analytics relabeling (revenue proxies, aggregates) | PR 7 |
+| D13 | Post-admission HK2+ lazy fee creation service + academic calendar source | Later PR, out of PR 1..PR 8 scope |
+| D14 | `FEE_FULLY_PAID`, `INVOICE_ISSUED`, `PAYMENT_OVERDUE` events with semester context | PR 8 |
+| D15 | Rewrite of `cached-imagining-ember` plan under the new model | PR 8 |
+
+## Consequences
+
+### Positive
+
+- One canonical tuition unit matches business reality; downstream
+  inconsistencies disappear by construction.
+- Admission gate becomes correct for partial payment and waiver cases
+  without special-casing in service code.
+- Event semantics stop lying about HK1/HK2+ boundaries.
+- `ENABLE_FEE_VERIFICATION` stays a clean circuit breaker; rollout is
+  reversible with a flag flip.
+- ADR-001's rule (no `DomainEvent` revival) is reinforced.
+
+### Negative
+
+- Medium-size schema change (`Fee.semester_no` + constraint swap) with a
+  destructive migration path for the old unique constraint.
+- Two flags to coordinate during rollout instead of one.
+- Compatibility maintenance for `tuition_fee_per_year` and all its
+  aggregates until PR 7 lands — the field lingers as deprecated for
+  multiple PRs.
+- KPI/analytics fields silently continue using annual semantics until
+  PR 7. Dashboards must not be treated as authoritative during the
+  transition window.
+
+### Neutral
+
+- `InstallmentPlan` model is unchanged; only the calling convention
+  (`anchor_date`) evolves.
+- `FeeAppliedDiscount` model is unchanged; only the policy scope
+  convention evolves.
+
+## Non-goals
+
+This ADR and PR 0 explicitly do not cover:
+
+1. Any runtime code change, migration, or test.
+2. The HK2..HKn post-admission finance workflow. That is a later epic.
+3. Academic calendar modeling. PR 0 does not pick the source of semester
+   start dates.
+4. Deleting `tuition_fee_per_year`. The column remains during the epic.
+5. KPI/analytics relabeling. All proxy-based revenue calculations keep
+   their current semantics until PR 7.
+6. Public API versioning. The rollout is additive; there is no v1/v2
+   split.
+7. Reintroducing `DomainEvent` / `emit_event()`. ADR-001 still governs.
+8. Changing `InstallmentPlan` catalog shape.
+9. Choosing the column name of the new per-semester tuition table (PR 1).
+10. Re-scoping the ember branch beyond the three ship-safe items listed
+    in Decision 1.
+
+## References
+
+- `Backend_FastAPI/docs/SEMESTER_TUITION_SPEC.md` — canonical model, flows,
+  contract compatibility, migration roadmap.
+- `Backend_FastAPI/docs/adr/ADR-001-remove-finance-events.md` — no
+  `DomainEvent` reintroduction rule.
+- `Backend_FastAPI/app/models/finance/fee.py:79-82` — current unique
+  constraint that Decision 3 / Gap A replaces.
+- `Backend_FastAPI/app/models/finance/fee.py:44-51` — `FeeTypeEnum`.
+- `Backend_FastAPI/app/models/finance/fee.py:54-63` — `FeeStatusEnum`
+  (including the existing `partial` value).
+- `Backend_FastAPI/app/models/finance/installment_plan.py:129-171` —
+  `get_installment_schedule()` to gain `anchor_date`.
+- `Backend_FastAPI/app/services/admission_service.py:125-196` — current
+  fee gate logic.
+- `Backend_FastAPI/app/services/admission_service.py:3153` — the
+  `ENABLE_FEE_VERIFICATION` gate site.
+- `Backend_FastAPI/app/config.py:376-377` — current flag default.
+- `Backend_FastAPI/app/core/admission_event_mapping.py:184,200,215` —
+  `tuition_fee_calculated/paid/refunded` projections to gate.
+- `Backend_FastAPI/app/schemas/public_admissions.py:24,48-49,59-60` —
+  public contract surface.
+- `Backend_FastAPI/app/services/organization_service.py:1370-1374` —
+  discount invalidation hook.
+- `Backend_FastAPI/app/services/organization_service.py:1699-1713` —
+  KPI aggregates on annual tuition.
+- `Backend_FastAPI/app/repositories/officer_repository.py:447-539` —
+  lost-revenue proxy on annual tuition.
+- `feat/finance-payment-event-parity` branch — in-flight payment event
+  parity work; partially unblocked by Decision 1 (ship three items
+  independently of this epic).


### PR DESCRIPTION
## Summary

PR 0 of the **Semester Tuition Refactor** epic. Spec/ADR only — no runtime code, schema, migration, or test changes.

Locks business semantics and rollout rules before PR 1 (schema) lands:
- Canonical tuition unit becomes per-semester (`semester_tuition`); `tuition_fee_per_year` is demoted to a deprecated compatibility field, **not silently redefined**.
- HK1 is the admission fee. Admission flow binds only to HK1; HK2..HKn are post-admission finance flow.
- Admission gate becomes **HK1 financial clearance**, not "fully paid": any non-zero HK1 payment (including less than `tạm thu`) or a formal waiver clears the gate. Waiver does not book revenue.
- Rollout via a new mode switch `ADMISSION_FEE_GATE_MODE=legacy|semester_hk1`; `ENABLE_FEE_VERIFICATION` stays as the circuit breaker. Truth table in ADR.

## Closed decisions (locked in ADR)

1. **Ember branch partial-block** — `PAYMENT_REJECTED`, `REFUND_PROCESSED`, `PAYMENT_VERIFIED` online callback parity ship independently. `FEE_FULLY_PAID`, `INVOICE_ISSUED`, `PAYMENT_OVERDUE` deferred.
2. **Circuit breaker vs mode switch** — two independent flags, never one boolean.
3. **InstallmentPlan stays global**, attaches per semester fee. `tạm thu` is a state of the HK1 fee, not a separate fee type.
4. **Discounts per-fee, no auto carry-over** across semesters. Multi-semester scholarship requires explicit `applicable_scope.semesters`.
5. **Public API rollout additive** — new fields `semester_tuitions[]`, `semester_1_tuition(_min/_max)` added alongside existing annual fields. No silent redefinition. KPI/analytics relabeling deferred to PR 7.

## Gap closures (no punt)

- **Gap A — uniqueness tuple**: `UNIQUE (admission_profile_id, fee_type, semester_no)`. `academic_year` demoted to non-unique metadata column. Existing rows backfill `semester_no=1`.
- **Gap B — fee creation strategy**: hybrid. HK1 eager at admission approval. HK2..HKn lazy via a post-admission service (not built in this epic).

## Files

- `Backend_FastAPI/docs/adr/ADR-002-semester-tuition-refactor.md` (new, 463 lines)
- `Backend_FastAPI/docs/SEMESTER_TUITION_SPEC.md` (new, 336 lines)
- `Backend_FastAPI/MASTER_ARCHITECTURE.md` — adds PART 8 domain semantics pointer to ADR-001 + ADR-002
- `Backend_FastAPI/docs/FINANCE_MODULE_DESIGN.md` — banner pointer to ADR-002 (the design doc stays historical)
- `.gitignore` — narrows `docs/` rule so `Backend_FastAPI/docs/**` remains trackable for new files; previously ignored paths (`/docs/`, `frontend/docs/`, `Backend_FastAPI/docs/CTV_ORIGINAL_*.md`) preserved

## Roadmap context

This is the first of an 8-PR epic:

| PR | Phase |
|---|---|
| **PR 0 (this)** | Spec / ADR / semantics lock |
| PR 1 | Additive schema: `offering_semester_tuition` + `Fee.semester_no` + migration |
| PR 2 | Admin config backend + frontend for per-semester tuition input |
| PR 3 | Finance core refactor: per-semester fee, `anchor_date`, invoice scoping |
| PR 4 | Admission clearance model (new gate logic behind `ADMISSION_FEE_GATE_MODE=semester_hk1`) |
| PR 5 | Pipeline / event semantics rewrite (`tuition_fee_*` projections gated to `semester_no==1`) |
| PR 6 | Public / admin / frontend contract additive rollout |
| PR 7 | KPI / analytics realignment (revenue proxies, aggregates) |
| PR 8 | Finance event parity re-write on new model (deferred ember items) |

## Test plan

- [ ] Review ADR-002 business semantics section against current product decisions
- [ ] Review SEMESTER_TUITION_SPEC §4.2 (HK1 financial clearance) for business sign-off
- [ ] Review flags truth table for ops runbook implications
- [ ] Confirm `.gitignore` narrowing does not accidentally include unwanted files (`git status` on a clean checkout)
- [ ] Confirm no runtime files changed (`git show --stat HEAD` shows only docs + .gitignore)