### PR TITLE
feat(finance): PR 1 — semester tuition schema + compat patch

### DIFF
--- a/Backend_FastAPI/alembic/versions/st20260412001_semester_tuition_schema.py
+++ b/Backend_FastAPI/alembic/versions/st20260412001_semester_tuition_schema.py
@@ -1,0 +1,348 @@
+"""semester tuition schema - offering_semester_tuition + fee.semester_no
+
+Revision ID: st20260412001
+Revises: b2_drop_processed_event
+Create Date: 2026-04-12
+
+Implements PR 1 of the semester_tuition epic (ADR-002, Deferred Decisions
+D1-D3 + Gap A). Scope: schema foundation + mandatory runtime compatibility
+patch for live tuition creation. All other runtime logic (router, admission
+gate, event mapping, feature flags, discount hooks, public schema) is
+untouched — those belong to PR 3/4/5/6.
+
+Changes:
+1. CREATE TABLE offering_semester_tuition (lean: id, academic_info_id,
+   semester_no, amount, notes, audit columns; no is_published/window).
+2. ALTER TABLE fee ADD COLUMN semester_no INTEGER NULL.
+3. Backfill: every existing fee row with fee_type='tuition' gets
+   semester_no = 1. Non-tuition rows stay NULL.
+4. Add CHECK chk_fee_tuition_semester_no_required
+   (fee_type <> 'tuition' OR (semester_no IS NOT NULL AND semester_no >= 1)).
+4b. Add CHECK chk_fee_nontuition_semester_no_null
+   (fee_type = 'tuition' OR semester_no IS NULL). Locks the non-tuition
+   invariant that the partial indexes rely on.
+5. Drop UniqueConstraint uq_fee_profile_type_year (pre-PR1 constraint).
+6. Create partial UNIQUE INDEX uq_fee_profile_type_year_nontuition
+   WHERE fee_type <> 'tuition'  -- preserves pre-PR1 non-tuition behavior.
+7. Create partial UNIQUE INDEX uq_fee_profile_type_semester_tuition
+   WHERE fee_type = 'tuition'   -- new semester-scoped uniqueness.
+
+Compatibility patch (bundled to keep PR 1 deployable):
+- fee_calculation_service.calculate_fee() now sets
+  semester_no=1 when fee_type == tuition, else None. Without this
+  patch, every live tuition fee creation after migration would fail
+  chk_fee_tuition_semester_no_required. No other runtime logic changes
+  in PR 1; semester-aware duplicate check and offering_semester_tuition
+  reads are PR 3 work.
+
+Safety:
+- Backfill runs BEFORE the CHECK constraint so existing data cannot trip
+  it.
+- Partial indexes are installed AFTER the old constraint is dropped, so
+  there is no moment at which two uniqueness rules conflict.
+- Pre-backfill sanity check scans for profiles with multi-year tuition
+  rows that would collide on semester_no=1 after backfill; fails loud.
+- Downgrade has two guards: new table must be empty, and the pre-PR1
+  unique tuple must still be unique across ALL fee types.
+
+NOT in scope for PR 1:
+- fee_calculation_service semester-aware logic beyond the minimal compat
+  patch above (offering_semester_tuition reads, HK2+ creation, duplicate
+  check semester-awareness — all PR 3)
+- fee_repository.check_duplicate (PR 3 — still uses academic_year for
+  all fee types, which remains correct under the partial-index strategy)
+- admission_service.py gate logic (PR 4)
+- admission_event_mapping.py projection gating (PR 5)
+- Public/admin API additive fields (PR 6)
+- Dropping OfferingAcademicInfo.tuition_fee_per_year (deprecated but
+  still live throughout the epic)
+
+Autogenerate warning: partial unique indexes often show spurious
+drop/create proposals on `alembic revision --autogenerate` due to
+whitespace/quoting differences in postgresql_where. DO NOT run autogenerate
+against this migration's parent tree. Hand-written migrations only for
+this epic.
+
+References:
+- Backend_FastAPI/docs/adr/ADR-002-semester-tuition-refactor.md
+  (Closed Decisions > Decision 3, Gap A, Deferred Decisions D1-D3)
+- Backend_FastAPI/docs/SEMESTER_TUITION_SPEC.md Section 2 and Section 3
+- Backend_FastAPI/app/models/finance/fee.py (current __table_args__)
+- Backend_FastAPI/app/repositories/fee_repository.py:287-321
+  (check_duplicate — unchanged in PR 1, still queries by academic_year
+  for all fee types)
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'st20260412001'
+down_revision = 'b2_drop_processed_event'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # Step 1: Create offering_semester_tuition (lean canonical catalog)
+    # ------------------------------------------------------------------
+    op.create_table(
+        'offering_semester_tuition',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column(
+            'academic_info_id', sa.Integer(),
+            sa.ForeignKey('offering_academic_info.id', ondelete='CASCADE'),
+            nullable=False,
+            comment='Link to parent OfferingAcademicInfo (program-year)',
+        ),
+        sa.Column(
+            'semester_no', sa.Integer(), nullable=False,
+            comment='Semester index within the full course, 1-based (HK1=1)',
+        ),
+        sa.Column(
+            'amount', sa.Numeric(15, 2), nullable=False,
+            comment='Tuition amount for this semester (VND)',
+        ),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True),
+            nullable=False, server_default=sa.func.now(),
+        ),
+        sa.Column(
+            'updated_at', sa.DateTime(timezone=True),
+            nullable=False, server_default=sa.func.now(),
+        ),
+        sa.Column(
+            'created_by_user_id', sa.Integer(),
+            sa.ForeignKey('user.id', ondelete='SET NULL'),
+            nullable=True,
+        ),
+        sa.Column(
+            'updated_by_user_id', sa.Integer(),
+            sa.ForeignKey('user.id', ondelete='SET NULL'),
+            nullable=True,
+        ),
+        sa.UniqueConstraint(
+            'academic_info_id', 'semester_no',
+            name='uq_offering_semester_tuition_info_semester',
+        ),
+        sa.CheckConstraint(
+            'semester_no >= 1',
+            name='chk_offering_semester_tuition_semester_no_positive',
+        ),
+        sa.CheckConstraint(
+            'amount >= 0',
+            name='chk_offering_semester_tuition_amount_non_negative',
+        ),
+    )
+    op.create_index(
+        'ix_offering_semester_tuition_academic_info_id',
+        'offering_semester_tuition',
+        ['academic_info_id'],
+    )
+    op.create_index(
+        'ix_offering_semester_tuition_semester_no',
+        'offering_semester_tuition',
+        ['semester_no'],
+    )
+
+    # ------------------------------------------------------------------
+    # Step 2: Add fee.semester_no (nullable, no default)
+    # ------------------------------------------------------------------
+    op.add_column(
+        'fee',
+        sa.Column(
+            'semester_no', sa.Integer(),
+            nullable=True,
+            comment='Semester index (1..N) for tuition fees. NULL for '
+                    'non-tuition fees. See ADR-002 Gap A (v2 partial '
+                    'index strategy).',
+        ),
+    )
+    op.create_index('ix_fee_semester_no', 'fee', ['semester_no'])
+
+    # ------------------------------------------------------------------
+    # Step 3a: Pre-backfill sanity check — no multi-year tuition rows on
+    # the same profile (would collide on semester_no=1 after backfill
+    # and violate the new partial unique index).
+    # ------------------------------------------------------------------
+    bind = op.get_bind()
+    dup = bind.execute(sa.text(
+        """
+        SELECT admission_profile_id, COUNT(*) AS c
+          FROM fee
+         WHERE fee_type = 'tuition'
+         GROUP BY admission_profile_id
+        HAVING COUNT(*) > 1
+         LIMIT 5
+        """
+    )).fetchall()
+    if dup:
+        raise RuntimeError(
+            "Pre-backfill check failed: profiles with multiple existing "
+            "tuition fee rows would collapse to semester_no=1 after "
+            "backfill and violate the new partial unique index. "
+            f"Offenders: {dup}. Resolve manually (pick one row to become "
+            "HK1; decide what to do with the others) before retrying."
+        )
+
+    # ------------------------------------------------------------------
+    # Step 3b: Backfill existing tuition rows to semester_no = 1
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        UPDATE fee
+           SET semester_no = 1
+         WHERE fee_type = 'tuition'
+           AND semester_no IS NULL
+        """
+    )
+
+    # Defensive post-backfill check: no tuition row should still be NULL
+    leftover = bind.execute(sa.text(
+        "SELECT COUNT(*) FROM fee "
+        "WHERE fee_type='tuition' AND semester_no IS NULL"
+    )).scalar()
+    if leftover:
+        raise RuntimeError(
+            f"Backfill sanity check failed: {leftover} tuition fee row(s) "
+            "still have NULL semester_no. Aborting migration."
+        )
+
+    # ------------------------------------------------------------------
+    # Step 4: Add CHECK constraint — tuition rows require semester_no>=1
+    # ------------------------------------------------------------------
+    op.create_check_constraint(
+        'chk_fee_tuition_semester_no_required',
+        'fee',
+        "fee_type <> 'tuition' "
+        "OR (semester_no IS NOT NULL AND semester_no >= 1)",
+    )
+
+    # ------------------------------------------------------------------
+    # Step 4b: Add CHECK constraint — non-tuition rows must have NULL.
+    # Locks the "non-tuition = NULL" invariant that PR 3+ relies on.
+    # All existing non-tuition rows are already NULL (the ADD COLUMN in
+    # Step 2 added NULL for every row and Step 3 only UPDATEd tuition).
+    # ------------------------------------------------------------------
+    op.create_check_constraint(
+        'chk_fee_nontuition_semester_no_null',
+        'fee',
+        "fee_type = 'tuition' OR semester_no IS NULL",
+    )
+
+    # ------------------------------------------------------------------
+    # Step 5: Drop the old unified unique constraint
+    # ------------------------------------------------------------------
+    op.drop_constraint(
+        'uq_fee_profile_type_year', 'fee', type_='unique',
+    )
+
+    # ------------------------------------------------------------------
+    # Step 6: Create partial unique index for non-tuition fees.
+    # Preserves the pre-PR1 (profile, fee_type, academic_year) uniqueness
+    # for application / enrollment / insurance / dormitory / other.
+    # ------------------------------------------------------------------
+    op.create_index(
+        'uq_fee_profile_type_year_nontuition',
+        'fee',
+        ['admission_profile_id', 'fee_type', 'academic_year'],
+        unique=True,
+        postgresql_where=sa.text("fee_type <> 'tuition'"),
+    )
+
+    # ------------------------------------------------------------------
+    # Step 7: Create partial unique index for tuition fees.
+    # Enforces the new (profile, fee_type, semester_no) uniqueness,
+    # letting HK1/HK2/... coexist on the same profile in the same year.
+    # ------------------------------------------------------------------
+    op.create_index(
+        'uq_fee_profile_type_semester_tuition',
+        'fee',
+        ['admission_profile_id', 'fee_type', 'semester_no'],
+        unique=True,
+        postgresql_where=sa.text("fee_type = 'tuition'"),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    # Guard A: new table must be empty. Post-upgrade inserts cannot be
+    # represented in the pre-PR1 schema; losing them silently is worse
+    # than failing the downgrade.
+    sem_rows = bind.execute(sa.text(
+        "SELECT COUNT(*) FROM offering_semester_tuition"
+    )).scalar()
+    if sem_rows:
+        raise RuntimeError(
+            f"Refusing to downgrade: offering_semester_tuition has "
+            f"{sem_rows} row(s). Archive or delete them explicitly "
+            "before downgrading."
+        )
+
+    # Guard B: the pre-PR1 unique tuple (profile, fee_type, academic_year)
+    # must still be unique across ALL fee_types (including tuition). If
+    # PR 3 has already created HK2 rows, this guard trips and forces
+    # explicit operator reconciliation.
+    dup_year = bind.execute(sa.text(
+        """
+        SELECT COUNT(*) FROM (
+            SELECT admission_profile_id, fee_type, academic_year
+              FROM fee
+             GROUP BY admission_profile_id, fee_type, academic_year
+            HAVING COUNT(*) > 1
+        ) d
+        """
+    )).scalar()
+    if dup_year:
+        raise RuntimeError(
+            f"Refusing to downgrade: {dup_year} duplicate "
+            "(admission_profile_id, fee_type, academic_year) group(s) "
+            "found. The pre-PR1 unique constraint cannot be restored. "
+            "Resolve duplicates (likely HK2+ tuition rows created after "
+            "PR 3 merged) before retrying."
+        )
+
+    # Step 7 reverse: drop tuition partial index
+    op.drop_index(
+        'uq_fee_profile_type_semester_tuition', table_name='fee',
+    )
+
+    # Step 6 reverse: drop non-tuition partial index
+    op.drop_index(
+        'uq_fee_profile_type_year_nontuition', table_name='fee',
+    )
+
+    # Step 5 reverse: re-create original unified unique constraint
+    op.create_unique_constraint(
+        'uq_fee_profile_type_year',
+        'fee',
+        ['admission_profile_id', 'fee_type', 'academic_year'],
+    )
+
+    # Step 4b reverse: drop the non-tuition CHECK
+    op.drop_constraint(
+        'chk_fee_nontuition_semester_no_null', 'fee', type_='check',
+    )
+
+    # Step 4 reverse: drop the tuition CHECK
+    op.drop_constraint(
+        'chk_fee_tuition_semester_no_required', 'fee', type_='check',
+    )
+
+    # Steps 2/3 reverse: drop column (backfilled values go away with it)
+    op.drop_index('ix_fee_semester_no', table_name='fee')
+    op.drop_column('fee', 'semester_no')
+
+    # Step 1 reverse: drop the new table and its indexes
+    op.drop_index(
+        'ix_offering_semester_tuition_semester_no',
+        table_name='offering_semester_tuition',
+    )
+    op.drop_index(
+        'ix_offering_semester_tuition_academic_info_id',
+        table_name='offering_semester_tuition',
+    )
+    op.drop_table('offering_semester_tuition')

--- a/Backend_FastAPI/app/models/__init__.py
+++ b/Backend_FastAPI/app/models/__init__.py
@@ -71,6 +71,7 @@ from .organization import OfferingDistributionConfig, OrganizationUnit
 from .major_program import MajorProgram  # Level 1
 from .program_offering import ProgramOffering  # Level 2
 from .offering_academic_info import OfferingAcademicInfo  # Level 3
+from .offering_semester_tuition import OfferingSemesterTuition  # PR 1 (ADR-002)
 
 # Tuition Discount Policy
 from .tuition_discount_policy import TuitionDiscountPolicy, DiscountTypeEnum
@@ -183,6 +184,7 @@ __all__ = [
     "MajorProgram",
     "ProgramOffering",
     "OfferingAcademicInfo",
+    "OfferingSemesterTuition",
     # Tuition Discount Policy
     "TuitionDiscountPolicy",
     "DiscountTypeEnum",

--- a/Backend_FastAPI/app/models/finance/fee.py
+++ b/Backend_FastAPI/app/models/finance/fee.py
@@ -16,8 +16,18 @@ Security Features:
 - Audit Trail: calculated_by_id, timestamps
 - Amount Validation: CHECK constraints ensure amounts >= 0
 
-Unique Constraint:
-- (admission_profile_id, fee_type, academic_year) - One fee per type per year
+Uniqueness (PR 1 of the semester_tuition epic, ADR-002):
+- Non-tuition fees: one row per (admission_profile_id, fee_type,
+  academic_year). Enforced by partial unique index
+  `uq_fee_profile_type_year_nontuition` WHERE fee_type <> 'tuition'.
+  Preserves pre-PR1 behavior exactly.
+- Tuition fees: one row per (admission_profile_id, fee_type,
+  semester_no). Enforced by partial unique index
+  `uq_fee_profile_type_semester_tuition` WHERE fee_type = 'tuition'.
+  Allows HK1/HK2/... to coexist on the same profile in the same
+  academic_year.
+- The legacy constraint `uq_fee_profile_type_year` was dropped in
+  migration `st20260412001_semester_tuition_schema.py`.
 """
 import enum
 from datetime import datetime, timezone, date
@@ -25,8 +35,8 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, List, Optional
 
 from sqlalchemy import (
-    CheckConstraint, Date, DateTime, ForeignKey,
-    Integer, Numeric, String, Text, UniqueConstraint
+    CheckConstraint, Date, DateTime, ForeignKey, Index,
+    Integer, Numeric, String, Text, UniqueConstraint, text
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -68,17 +78,34 @@ class Fee(Base):
     Main fee record for a student's admission profile.
 
     Business Rules:
-    - One fee per (profile, type, year) combination
+    - Non-tuition fees: one row per (profile, fee_type, academic_year).
+    - Tuition fees: one row per (profile, fee_type, semester_no). HK1/HK2
+      may coexist in the same academic_year. `semester_no` is NULL for
+      non-tuition rows; tuition rows require a positive value.
     - final_amount = base_amount - total_discount
     - remaining = final_amount - paid_amount - waived_amount
     - Status transitions follow FINANCE_MODULE_DESIGN.md Section 4.1
+      (historical — see docs/adr/ADR-002-semester-tuition-refactor.md
+      for the current model direction).
     """
     __tablename__ = "fee"
 
     __table_args__ = (
-        UniqueConstraint(
+        # Partial unique index: preserve pre-PR1 non-tuition behavior.
+        # Matches fee_repository.check_duplicate() semantics exactly.
+        Index(
+            'uq_fee_profile_type_year_nontuition',
             'admission_profile_id', 'fee_type', 'academic_year',
-            name='uq_fee_profile_type_year'
+            unique=True,
+            postgresql_where=text("fee_type <> 'tuition'"),
+        ),
+        # Partial unique index: new per-semester uniqueness for tuition.
+        # Allows HK1/HK2/HK3/... on the same profile in the same year.
+        Index(
+            'uq_fee_profile_type_semester_tuition',
+            'admission_profile_id', 'fee_type', 'semester_no',
+            unique=True,
+            postgresql_where=text("fee_type = 'tuition'"),
         ),
         CheckConstraint(
             'base_amount >= 0 AND total_discount >= 0 AND final_amount >= 0 '
@@ -98,6 +125,26 @@ class Fee(Base):
             "status IN ('pending', 'calculated', 'invoiced', 'partial', "
             "'paid', 'overdue', 'waived', 'cancelled')",
             name='chk_fee_status_valid'
+        ),
+        # PR 1: tuition fees must carry a positive semester_no. Non-tuition
+        # fees leave semester_no NULL (no semantic). The partial index
+        # above would also block invalid rows, but this CHECK is a second
+        # line of defense against bugs inserting tuition rows with NULL
+        # semester_no that would silently escape the index predicate.
+        CheckConstraint(
+            "fee_type <> 'tuition' "
+            "OR (semester_no IS NOT NULL AND semester_no >= 1)",
+            name='chk_fee_tuition_semester_no_required'
+        ),
+        # PR 1 hardening: non-tuition fees must leave semester_no NULL.
+        # The partial index uq_fee_profile_type_year_nontuition keys on
+        # academic_year (not semester_no), so a non-tuition row with a
+        # stray semester_no value would not cause uniqueness corruption
+        # but would break the "non-tuition = NULL" invariant that PR 3+
+        # relies on. This CHECK closes the slack before it becomes a bug.
+        CheckConstraint(
+            "fee_type = 'tuition' OR semester_no IS NULL",
+            name='chk_fee_nontuition_semester_no_null'
         ),
     )
 
@@ -133,6 +180,16 @@ class Fee(Base):
         nullable=False,
         index=True,
         comment="Academic year (e.g., 2026)"
+    )
+    semester_no: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        nullable=True,
+        index=True,
+        comment="Semester index (1..N) for tuition fees (HK1=1, HK2=2, ...). "
+                "NULL for non-tuition fee types. See ADR-002 Gap A (v2 "
+                "partial-index strategy). Enforced by partial unique index "
+                "uq_fee_profile_type_semester_tuition and CHECK "
+                "chk_fee_tuition_semester_no_required."
     )
 
     # Amount Calculation

--- a/Backend_FastAPI/app/models/offering_academic_info.py
+++ b/Backend_FastAPI/app/models/offering_academic_info.py
@@ -137,6 +137,16 @@ class OfferingAcademicInfo(Base):
         cascade="all, delete-orphan"
     )
 
+    # PR 1 (ADR-002): canonical per-semester tuition catalog.
+    # Replaces tuition_fee_per_year as source of truth during the epic.
+    # The legacy scalar is retained as a deprecated compatibility field.
+    semester_tuitions = relationship(
+        "OfferingSemesterTuition",
+        back_populates="academic_info",
+        cascade="all, delete-orphan",
+        order_by="OfferingSemesterTuition.semester_no",
+    )
+
     __table_args__ = (
         UniqueConstraint('offering_id', 'academic_year', name='uq_offering_academic_year'),
     )

--- a/Backend_FastAPI/app/models/offering_semester_tuition.py
+++ b/Backend_FastAPI/app/models/offering_semester_tuition.py
@@ -1,0 +1,124 @@
+# app/models/offering_semester_tuition.py
+"""
+Offering Semester Tuition - Canonical per-semester tuition catalog.
+
+Introduced by PR 1 of the semester_tuition epic (ADR-002). One row per
+(academic_info_id, semester_no). Replaces the single-scalar
+OfferingAcademicInfo.tuition_fee_per_year as the canonical source of
+tuition data, with a transition window during which both coexist.
+
+Business rules:
+- semester_no >= 1 (HK1 = 1)
+- One row per (academic_info_id, semester_no)
+- amount is stored as VND with two decimal places (NUMERIC(15,2))
+
+Non-goals for PR 1:
+- No is_published / effective_from / effective_to (lean; add later if
+  consumers need publish/window semantics). OfferingAcademicInfo already
+  has is_published at the parent level.
+- No soft-delete column.
+
+Related:
+- docs/adr/ADR-002-semester-tuition-refactor.md
+  (Closed Decisions > Decision 3, Gap A, Deferred Decisions D1-D3)
+- docs/SEMESTER_TUITION_SPEC.md Section 2
+"""
+from datetime import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import (
+    CheckConstraint, DateTime, ForeignKey,
+    Integer, Numeric, Text, UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from .base import Base
+
+if TYPE_CHECKING:
+    from .offering_academic_info import OfferingAcademicInfo
+    from .user import User
+
+
+class OfferingSemesterTuition(Base):
+    """Per-semester tuition catalog row."""
+
+    __tablename__ = "offering_semester_tuition"
+
+    __table_args__ = (
+        UniqueConstraint(
+            'academic_info_id', 'semester_no',
+            name='uq_offering_semester_tuition_info_semester',
+        ),
+        CheckConstraint(
+            'semester_no >= 1',
+            name='chk_offering_semester_tuition_semester_no_positive',
+        ),
+        CheckConstraint(
+            'amount >= 0',
+            name='chk_offering_semester_tuition_amount_non_negative',
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    academic_info_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("offering_academic_info.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Link to the parent OfferingAcademicInfo (program-year)",
+    )
+    semester_no: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        index=True,
+        comment="Semester index within the full course, 1-based (HK1=1)",
+    )
+    amount: Mapped[Decimal] = mapped_column(
+        Numeric(15, 2),
+        nullable=False,
+        comment="Tuition amount for this semester (VND)",
+    )
+    notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+    created_by_user_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    updated_by_user_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    academic_info: Mapped["OfferingAcademicInfo"] = relationship(
+        "OfferingAcademicInfo",
+        back_populates="semester_tuitions",
+    )
+    created_by: Mapped[Optional["User"]] = relationship(
+        "User", foreign_keys=[created_by_user_id]
+    )
+    updated_by: Mapped[Optional["User"]] = relationship(
+        "User", foreign_keys=[updated_by_user_id]
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<OfferingSemesterTuition "
+            f"academic_info_id={self.academic_info_id} "
+            f"HK{self.semester_no} amount={self.amount}>"
+        )

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -133,10 +133,25 @@ class FeeCalculationService:
             academic_year_int = academic_year
 
         # Create fee record
+        # PR 1 (ADR-002) compat patch: tuition rows MUST carry a positive
+        # semester_no to satisfy chk_fee_tuition_semester_no_required and
+        # the new uq_fee_profile_type_semester_tuition partial unique
+        # index. PR 1 does not introduce semester-aware logic anywhere
+        # else — existing callers still pass academic_year, and the
+        # duplicate check at check_duplicate() is still year-based. The
+        # only thing PR 1 guarantees is that every new tuition fee
+        # created by this service lands with semester_no=1 (HK1), which
+        # matches the backfill of pre-existing tuition rows. Non-tuition
+        # fees leave semester_no NULL, matching the non-tuition partial
+        # index (keyed on academic_year, not semester_no).
+        # PR 3 will replace this compat patch with proper semester-aware
+        # tuition creation driven by offering_semester_tuition rows.
+        fee_semester_no = 1 if fee_type == FeeTypeEnum.tuition else None
         fee = Fee(
             admission_profile_id=admission_profile_id,
             fee_type=fee_type.value,
             academic_year=academic_year_int,
+            semester_no=fee_semester_no,
             installment_plan_id=installment_plan_id,
             base_amount=base_amount,
             total_discount=total_discount,


### PR DESCRIPTION
**Stacked on #111** (`spec/semester-tuition-refactor` — ADR-002 + SEMESTER_TUITION_SPEC).

## Summary

PR 1 of the **Semester Tuition Refactor** epic. Schema foundation + the minimal runtime compatibility patch that keeps live tuition creation working the moment the migration lands.

Per ADR-002 Decision 3 / Gap A / Deferred Decisions D1–D3.

## Scope

**Schema foundation**:
- New table `offering_semester_tuition` — lean canonical per-semester tuition catalog, keyed `(academic_info_id, semester_no)`. Replaces the deprecated scalar `OfferingAcademicInfo.tuition_fee_per_year` as canonical source.
- New nullable column `fee.semester_no`. Tuition rows must have `semester_no >= 1`; non-tuition rows must have `NULL`.
- Two partial unique indexes replacing the legacy `uq_fee_profile_type_year`:
  - `uq_fee_profile_type_year_nontuition` WHERE `fee_type <> 'tuition'` — preserves pre-PR1 `(profile, type, year)` uniqueness for application/enrollment/insurance/dormitory/other.
  - `uq_fee_profile_type_semester_tuition` WHERE `fee_type = 'tuition'` — new `(profile, type, semester_no)` uniqueness, letting HK1/HK2/... coexist in the same `academic_year`.
- Two CHECK constraints (`chk_fee_tuition_semester_no_required`, `chk_fee_nontuition_semester_no_null`).
- Hand-written Alembic migration with pre/post backfill sanity checks and guarded downgrade (refuses if `offering_semester_tuition` has rows or if old-tuple uniqueness has been violated).

**Runtime compatibility patch** (minimal, mandatory):
- `fee_calculation_service.calculate_fee()` now sets `semester_no=1` for tuition, `None` for non-tuition. Without this patch every live tuition insert after migration would fail `chk_fee_tuition_semester_no_required`. This is the **only** service touch in PR 1. PR 3 will replace this patch with proper semester-aware logic.

## Gap A / Gap B closures

- **Gap A** — uniqueness tuple: `(admission_profile_id, fee_type, semester_no)` via partial index for tuition; `academic_year` demoted to metadata (kept as `NOT NULL` column, no longer in uniqueness).
- **Gap B** — fee creation strategy: hybrid. HK1 eager at admission approval (existing flow). HK2..HKn lazy via a post-admission service (not built — later epic, ADR-002 D13).

## Non-tuition uniqueness decision (v3)

An earlier sentinel `semester_no=0` approach was rejected during review because it silently collapsed non-tuition uniqueness from `(profile, type, year)` to `(profile, type)`. The partial-index approach in this PR preserves existing non-tuition behavior exactly — `fee_repository.check_duplicate()` continues to work unchanged, and no service-layer semantics drift.

## Files changed — 6

| File | Change |
|---|---|
| `Backend_FastAPI/app/models/offering_semester_tuition.py` | **NEW** — `OfferingSemesterTuition` model (lean). |
| `Backend_FastAPI/alembic/versions/st20260412001_semester_tuition_schema.py` | **NEW** — single hand-written migration. |
| `Backend_FastAPI/app/models/finance/fee.py` | Add `semester_no` column + 2 partial indexes + 2 CHECKs. Update docstrings. |
| `Backend_FastAPI/app/models/offering_academic_info.py` | Add `semester_tuitions` relationship. |
| `Backend_FastAPI/app/models/__init__.py` | Import + `__all__` for `OfferingSemesterTuition`. |
| `Backend_FastAPI/app/services/fee_calculation_service.py` | Compat patch: set `semester_no` in `Fee(...)` constructor. |

No changes to routers, schemas, admission event mapping, public API, config, or discount hooks.

## Verification

All checks run inside the dev container:

- [x] Model import smoke: `Fee.semester_no` nullable; both partial indexes present; both CHECKs present
- [x] `alembic upgrade head` — passes (pre/post backfill sanity checks pass on dev DB with 20 existing tuition rows)
- [x] `alembic downgrade -1` — passes (guards A/B OK)
- [x] `alembic upgrade head` re-apply — passes (idempotent backfill via `IS NULL` guard)
- [x] Backfill: 20/20 tuition rows at `semester_no=1`, 0 non-tuition rows with stray value
- [x] Live `calculate_fee()` service test:
  - [x] Tuition fee created with `semester_no=1`, projection `sync_lead_tuition_calculated` fires correctly
  - [x] Application fee created with `semester_no=None`
- [x] CHECK enforcement live sanity tests:
  - [x] Two non-tuition fees in different years — both insert (preserves existing behavior)
  - [x] Duplicate non-tuition same year — blocked by `uq_fee_profile_type_year_nontuition`
  - [x] HK1 + HK2 tuition same profile same year — both insert (new feature)
  - [x] Duplicate HK1 tuition — blocked by `uq_fee_profile_type_semester_tuition`
  - [x] Tuition with NULL `semester_no` — blocked by `chk_fee_tuition_semester_no_required`
  - [x] Non-tuition with stray `semester_no=2` — blocked by `chk_fee_nontuition_semester_no_null`

## Operator notes

- **Do NOT run `alembic revision --autogenerate`** against this migration's parent. Partial unique indexes produce spurious drop/create proposals due to whitespace/quoting differences in `postgresql_where`.
- **Production rollout**: migration must run inside the maintenance-window runbook used by previous DDL-heavy migrations (acquires `ACCESS EXCLUSIVE` on `fee`). Pre-backfill scan fails loud if any profile has multi-year tuition rows (should be zero in production, but verified before running the UPDATE).
- **Downgrade after PR 3 merge**: guarded. If HK2+ rows exist (added by PR 3's proper semester-aware service), downgrade will refuse until the rows are reconciled.

## Roadmap context

Part of the 8-PR epic started by #111 (ADR-002 spec):

| PR | Phase | Status |
|---|---|---|
| PR 0 (#111) | Spec / ADR | Draft |
| **PR 1 (this)** | Schema + compat patch | Draft, stacked on #111 |
| PR 2 | Admin config backend + frontend | Not started |
| PR 3 | Finance core refactor (semester-aware) | Not started |
| PR 4 | Admission clearance model + flag | Not started |
| PR 5 | Pipeline / event semantics | Not started |
| PR 6 | Public / admin / frontend contract | Not started |
| PR 7 | KPI / analytics realignment | Not started |
| PR 8 | Finance event parity re-write on new model | Not started |

## Test plan

- [ ] Review `fee.py` docstring vs new `__table_args__` for consistency (both CHECKs + 2 partial indexes documented)
- [ ] Review migration header for scope wording (no stale "schema-only" claim)
- [ ] Review `fee_calculation_service.py` patch for scope creep (single-line change + comment)
- [ ] Verify `git diff --name-only spec/semester-tuition-refactor..HEAD` returns exactly 6 files
- [ ] Reviewer runs `alembic upgrade head && alembic downgrade -1 && alembic upgrade head` on a dev snapshot to confirm round-trip
- [ ] Reviewer confirms `fee_repository.check_duplicate` is untouched
- [ ] Reviewer confirms no router, schema, event mapping, or config file is modified