### PR TITLE
feat(finance): PR A ember — payment event parity

### DIFF
--- a/Backend_FastAPI/app/core/event_catalog.py
+++ b/Backend_FastAPI/app/core/event_catalog.py
@@ -555,9 +555,66 @@ _FINANCE_USER_EVENTS: tuple = (
         priority=60,
         link_strategy="/finance/payments/${payment_id}",
     ),
+    EventDefinition(
+        event=SystemEvents.PAYMENT_REJECTED,
+        category="finance",
+        display_name="Thanh toán bị từ chối",
+        description="Khi checker từ chối một khoản thanh toán đang chờ",
+        variables=(
+            _var("payment_id", "integer", "ID thanh toán"),
+            _var("invoice_id", "integer", "ID hóa đơn"),
+            _var("fee_id", "integer", "ID phí"),
+            _var("amount", "string", "Số tiền"),
+            _var("rejection_reason", "string", "Lý do từ chối"),
+            _var("rejected_by_id", "integer", "ID người từ chối"),
+            _var("created_by_id", "integer", "ID người ghi nhận"),
+            _var("admission_profile_id", "integer", "ID hồ sơ"),
+            _var("lead_id", "integer", "ID lead"),
+            _var("unit_id", "integer", "ID đơn vị"),
+            _var("user_id", "integer", "ID maker (recipient)"),
+        ),
+        default_resolver="specific_users",  # resolves via payload["user_id"] → maker
+        allowed_resolvers=_FINANCE_RESOLVERS,
+        default_channels=("browser", "email"),
+        priority=65,
+        dedup_key_template="payment:${payment_id}:rejected",
+        link_strategy="/finance/payments/${payment_id}",
+    ),
 )
 
 _FINANCE_FUTURE_EVENTS: tuple = (
+    EventDefinition(
+        event=SystemEvents.REFUND_PROCESSED,
+        category="finance",
+        display_name="Hoàn tiền đã xử lý",
+        description="Khi yêu cầu hoàn tiền đã được thực hiện (funds returned)",
+        variables=(
+            _var("refund_id", "integer", "ID yêu cầu hoàn tiền"),
+            _var("payment_id", "integer", "ID thanh toán gốc"),
+            _var("invoice_id", "integer", "ID hóa đơn"),
+            _var("fee_id", "integer", "ID phí"),
+            _var("amount", "string", "Số tiền hoàn"),
+            _var("reason", "string", "Lý do hoàn tiền"),
+            _var("processor_id", "integer", "ID người xử lý"),
+            _var("admission_profile_id", "integer", "ID hồ sơ"),
+            _var("lead_id", "integer", "ID lead"),
+            _var("unit_id", "integer", "ID đơn vị"),
+            _var("user_ids", "array", "Recipients (officer + processor)"),
+        ),
+        default_resolver="specific_users",  # resolves via payload["user_ids"] → [officer, processor]
+        allowed_resolvers=_FINANCE_RESOLVERS,
+        default_channels=("browser", "email"),
+        priority=55,
+        dedup_key_template="refund:${refund_id}:processed",
+        link_strategy="/finance/payments/${payment_id}",
+        # PR A: dispatch site is wired in payment_service.process_approved_refund()
+        # but RefundService has no router endpoint yet — the entire refund
+        # flow (request, approve, process) is service-layer-only as of this
+        # commit. Mark internal_future so the user-event contract test does
+        # not require a reachable production caller. Promote to "user" class
+        # when the refund router ships (tracked as PR B or later follow-up).
+        notification_class="internal_future",
+    ),
     EventDefinition(
         event=SystemEvents.DORM_FEE_CREATED,
         category="dorm",   # D: F4 fix — wrong domain → dorm

--- a/Backend_FastAPI/app/core/event_groups.py
+++ b/Backend_FastAPI/app/core/event_groups.py
@@ -95,6 +95,8 @@ EVENT_GROUP_MAPPING: Dict[SystemEvents, NotificationEventGroup] = {
     SystemEvents.PAYMENT_RECEIVED: NotificationEventGroup.FINANCE,
     SystemEvents.PAYMENT_OVERDUE: NotificationEventGroup.FINANCE,
     SystemEvents.PAYMENT_VERIFIED: NotificationEventGroup.FINANCE,
+    SystemEvents.PAYMENT_REJECTED: NotificationEventGroup.FINANCE,
+    SystemEvents.REFUND_PROCESSED: NotificationEventGroup.FINANCE,
 
     # Dorm events
     SystemEvents.DORM_ROOM_ASSIGNED: NotificationEventGroup.DORM,

--- a/Backend_FastAPI/app/core/event_metadata.py
+++ b/Backend_FastAPI/app/core/event_metadata.py
@@ -543,6 +543,50 @@ EVENT_METADATA_REGISTRY: Dict[SystemEvents, EventMetadata] = {
         category="finance"
     ),
 
+    SystemEvents.PAYMENT_REJECTED: EventMetadata(
+        event=SystemEvents.PAYMENT_REJECTED,
+        display_name="Thanh toán bị từ chối",
+        description="Khi checker từ chối một khoản thanh toán đang chờ",
+        variables=[
+            EventVariable("payment_id", "integer", "ID thanh toán"),
+            EventVariable("invoice_id", "integer", "ID hóa đơn"),
+            EventVariable("fee_id", "integer", "ID phí"),
+            EventVariable("amount", "string", "Số tiền thanh toán"),
+            EventVariable("rejection_reason", "string", "Lý do từ chối"),
+            EventVariable("rejected_by_id", "integer", "ID người từ chối"),
+            EventVariable("created_by_id", "integer", "ID người ghi nhận (maker)"),
+            EventVariable("admission_profile_id", "integer", "ID hồ sơ tuyển sinh"),
+            EventVariable("lead_id", "integer", "ID lead"),
+            EventVariable("unit_id", "integer", "ID đơn vị"),
+            EventVariable("user_id", "integer", "ID maker (recipient)"),
+        ],
+        filter_fields=["payment_id", "fee_id", "amount", "admission_profile_id", "rejected_by_id"],
+        default_channels=["browser", "email"],
+        category="finance"
+    ),
+
+    SystemEvents.REFUND_PROCESSED: EventMetadata(
+        event=SystemEvents.REFUND_PROCESSED,
+        display_name="Hoàn tiền đã xử lý",
+        description="Khi yêu cầu hoàn tiền đã được thực hiện (funds returned)",
+        variables=[
+            EventVariable("refund_id", "integer", "ID yêu cầu hoàn tiền"),
+            EventVariable("payment_id", "integer", "ID thanh toán gốc"),
+            EventVariable("invoice_id", "integer", "ID hóa đơn"),
+            EventVariable("fee_id", "integer", "ID phí"),
+            EventVariable("amount", "string", "Số tiền hoàn"),
+            EventVariable("reason", "string", "Lý do hoàn tiền"),
+            EventVariable("processor_id", "integer", "ID người xử lý"),
+            EventVariable("admission_profile_id", "integer", "ID hồ sơ tuyển sinh"),
+            EventVariable("lead_id", "integer", "ID lead"),
+            EventVariable("unit_id", "integer", "ID đơn vị"),
+            EventVariable("user_ids", "array", "Recipients (officer + processor)"),
+        ],
+        filter_fields=["refund_id", "payment_id", "fee_id", "amount", "admission_profile_id"],
+        default_channels=["browser", "email"],
+        category="finance"
+    ),
+
     # =========================================================================
     # DORM EVENTS (2 events)
     # =========================================================================

--- a/Backend_FastAPI/app/core/events.py
+++ b/Backend_FastAPI/app/core/events.py
@@ -380,6 +380,59 @@ class SystemEvents(str, Enum):
     Recipients: Finance staff, the applicant (external via Zalo ZNS phase 1)
     """
 
+    PAYMENT_REJECTED = "payment_rejected"
+    """
+    Triggered when a checker rejects a pending payment.
+
+    Payload Schema:
+        {
+            "payment_id": int,            # Required: ID of the rejected payment
+            "invoice_id": int,            # Required: ID of the invoice
+            "fee_id": int,                # Required: ID of the fee
+            "amount": str,                # Payment amount (Decimal as string)
+            "rejection_reason": str,      # Required: Why the payment was rejected
+            "rejected_by_id": int,        # Required: Checker who rejected
+            "created_by_id": int,         # Required: Maker who recorded the payment
+            "admission_profile_id": int,  # Admission profile linked to fee
+            "lead_id": int,               # Lead linked to admission profile
+            "unit_id": int,               # Unit for scoping
+            "user_id": int                # Recipient (== created_by_id) for SpecificUsersResolver
+        }
+
+    Recipients: The maker (created_by_id) who recorded the payment
+    """
+
+    REFUND_PROCESSED = "refund_processed"
+    """
+    Triggered when an approved refund is processed (funds returned).
+
+    Payload Schema:
+        {
+            "refund_id": int,             # Required: ID of the refund request
+            "payment_id": int,            # Required: Original payment being refunded
+            "invoice_id": int,            # Required: Invoice affected
+            "fee_id": int,                # Required: Fee affected
+            "amount": str,                # Refund amount (Decimal as string)
+            "reason": str,                # Refund reason
+            "processor_id": int,          # User who processed the refund
+            "admission_profile_id": int,  # Admission profile linked to fee
+            "lead_id": int,               # Lead linked to admission profile
+            "unit_id": int,               # Unit for scoping
+            "user_ids": list[int]         # Resolved recipients (officer + processor)
+        }
+
+    Recipients: Assigned officer, processor (internal only — PR A scope).
+    Finance staff group deferred to PR B (needs dedicated resolver/action group).
+    External applicant notification deferred to Zalo ZNS Phase 2.
+
+    Status: DORMANT as of PR A. The dispatch site lives in
+    payment_service.process_approved_refund(), but RefundService has no
+    router endpoint — the request/approve/process flow is service-layer
+    only. Catalog tags this event notification_class="internal_future"
+    until the refund router ships. No live API path can fire this event
+    today.
+    """
+
     # =========================================================================
     # DORM EVENTS (Future)
     # =========================================================================

--- a/Backend_FastAPI/app/routers/payments.py
+++ b/Backend_FastAPI/app/routers/payments.py
@@ -615,13 +615,19 @@ async def payment_callback(
     intent_service = PaymentIntentService(db)
 
     try:
-        # Process callback (verify signature, create payment)
-        result = await intent_service.process_gateway_callback(
+        # Process callback (verify signature, create payment).
+        # process_gateway_callback returns (result_dict, post_commit_callback).
+        # The callback carries the PAYMENT_VERIFIED dispatch — we MUST await
+        # it after db.commit(), otherwise the notification is silently lost.
+        result, callback = await intent_service.process_gateway_callback(
             gateway_code=gateway_code,
             callback_data=callback_data,
         )
 
         await db.commit()
+
+        if callback is not None:
+            await callback()
 
         log.info(
             "payment_callback_processed",

--- a/Backend_FastAPI/app/scripts/reset_notification_rules_dev.py
+++ b/Backend_FastAPI/app/scripts/reset_notification_rules_dev.py
@@ -196,6 +196,20 @@ CURATED_RULES: dict[str, dict[str, Any]] = {
         link_template="/finance/payments/$payment_id",
         groups=[_internal_group("specific_users", ["browser", "email"])],
     ),
+    "payment_rejected": _build_rule(
+        event="payment_rejected",
+        title_template="Thanh toán bị từ chối",
+        message_template="Khoản thanh toán $amount đã bị từ chối. Lý do: $rejection_reason",
+        notification_type="warning",
+        link_template="/finance/payments/$payment_id",
+        groups=[_internal_group("specific_users", ["browser", "email"])],
+    ),
+    # refund_processed is intentionally absent from CURATED_RULES: the event
+    # is notification_class="internal_future" (catalog tag) because the
+    # refund flow has no router endpoint yet. The dispatch site exists in
+    # payment_service.process_approved_refund() but cannot be reached from
+    # any live API path. Restore this entry + promote catalog tag to "user"
+    # when refund endpoints ship.
     "system_alert": _build_rule(
         event="system_alert",
         title_template="[${severity}] Cảnh báo hệ thống",

--- a/Backend_FastAPI/app/scripts/sync_notification_rules.py
+++ b/Backend_FastAPI/app/scripts/sync_notification_rules.py
@@ -54,6 +54,23 @@ def _get_template(defn) -> tuple:
     title = defn.display_name
     var_names = {v.name for v in defn.variables} if defn.variables else set()
 
+    # Curated templates for specific events that need richer messaging than
+    # the generic category fallback. Added in PR A (finance payment event
+    # parity): PAYMENT_REJECTED surfaces rejection reason to the maker so
+    # they can act on it.
+    #
+    # REFUND_PROCESSED is intentionally not curated here — it is tagged
+    # notification_class="internal_future" because the refund flow has no
+    # router endpoint yet. sync_notification_rules only seeds rules for
+    # user-class events (via get_notifiable_events), so a curated template
+    # here would be unreachable. Restore + promote when the refund router
+    # ships.
+    if defn.event == SystemEvents.PAYMENT_REJECTED:
+        return (
+            "Thanh toán bị từ chối",
+            "Khoản thanh toán $amount đã bị từ chối. Lý do: $rejection_reason",
+        )
+
     # Build message from available variables — safe fallback per category
     cat = defn.category
     if cat == "lead" and "lead_id" in var_names:

--- a/Backend_FastAPI/app/services/notification_registry.py
+++ b/Backend_FastAPI/app/services/notification_registry.py
@@ -483,6 +483,32 @@ NOTIFICATION_REGISTRY: Dict[SystemEvents, NotificationConfig] = {
         priority=60,
     ),
 
+    SystemEvents.PAYMENT_REJECTED: NotificationConfig(
+        group=NotificationEventGroup.FINANCE,
+        resolver=SpecificUsersResolver(),
+        template=(
+            "Thanh toán bị từ chối",
+            "Khoản thanh toán ${amount} đã bị từ chối. Lý do: ${rejection_reason}"
+        ),
+        channels=(CH.BROWSER, CH.EMAIL),
+        notification_type=NT.WARNING,
+        link_template="/finance/payments/${payment_id}",
+        priority=65,
+    ),
+
+    SystemEvents.REFUND_PROCESSED: NotificationConfig(
+        group=NotificationEventGroup.FINANCE,
+        resolver=SpecificUsersResolver(),
+        template=(
+            "Hoàn tiền đã xử lý",
+            "Khoản hoàn tiền ${amount} đã được xử lý thành công."
+        ),
+        channels=(CH.BROWSER, CH.EMAIL),
+        notification_type=NT.INFO,
+        link_template="/finance/payments/${payment_id}",
+        priority=55,
+    ),
+
     # =========================================================================
     # 🏠 DORM EVENTS
     # =========================================================================

--- a/Backend_FastAPI/app/services/payment_intent_service.py
+++ b/Backend_FastAPI/app/services/payment_intent_service.py
@@ -31,6 +31,7 @@ import structlog
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app import models
 from app.models.finance import (
@@ -389,10 +390,14 @@ class PaymentIntentService:
         intent.gateway_response = callback_data
 
         payment = None
+        fee = None
+        profile = None
 
         if gateway_status == GatewayStatusEnum.success:
-            # Create verified payment
-            payment = await self._create_payment_from_intent(intent, unit_id)
+            # Create verified payment (returns payment, fee, profile)
+            payment, fee, profile = await self._create_payment_from_intent(
+                intent, unit_id
+            )
             intent.status = PaymentIntentStatusEnum.completed.value
             intent.completed_at = datetime.now(timezone.utc)
         elif gateway_status in [GatewayStatusEnum.failed, GatewayStatusEnum.expired]:
@@ -410,10 +415,49 @@ class PaymentIntentService:
             payment_id=payment.id if payment else None,
         )
 
-        # Post-commit: notify payment status
+        # Build PAYMENT_VERIFIED notification payload while the session is
+        # still active. Dispatched from the post-commit closure below,
+        # mirroring the manual verify_payment path at
+        # payment_service.py:358-387. Only dispatched when an officer is
+        # resolved for the lead — otherwise SpecificUsersResolver returns
+        # an empty recipient list and zero notifications are silently
+        # suppressed.
+        _notify_payload: Optional[Dict[str, Any]] = None
+        if payment is not None and fee is not None:
+            _officer_id: Optional[int] = None
+            if profile is not None and getattr(profile, "lead", None) is not None:
+                _officer_id = profile.lead.assigned_officer_id
+            _notify_payload = {
+                "payment_id": payment.id,
+                "invoice_id": intent.invoice_id,
+                "fee_id": fee.id,
+                "amount": str(intent.amount),
+                "verified_by_id": None,  # auto-verified by gateway
+                "verified_at": (
+                    payment.verified_at.isoformat()
+                    if payment.verified_at
+                    else datetime.now(timezone.utc).isoformat()
+                ),
+                "admission_profile_id": fee.admission_profile_id,
+                "lead_id": profile.lead_id if profile is not None else None,
+                "unit_id": unit_id,
+                "user_id": _officer_id,  # SpecificUsersResolver recipient
+            }
+        _db = self.db
+
         async def post_commit():
-            # TODO: Emit PaymentCompleted/PaymentFailed event
-            pass
+            # Dispatched AFTER router commits (gateway callback path).
+            # Skip silently if no recipient could be resolved — an empty
+            # dispatch would look like success but send nothing.
+            if _notify_payload is None or not _notify_payload.get("user_id"):
+                return
+            from app.services.notification_dispatcher import safe_dispatch
+            from app.core.events import SystemEvents
+            await safe_dispatch(
+                db=_db,
+                event=SystemEvents.PAYMENT_VERIFIED,
+                payload=_notify_payload,
+            )
 
         return intent, payment, post_commit
 
@@ -421,22 +465,25 @@ class PaymentIntentService:
         self,
         gateway_code: str,
         callback_data: Dict[str, Any],
-    ) -> Dict[str, Any]:
+    ) -> Tuple[Dict[str, Any], Optional[Callable]]:
         """
-        Process gateway callback and return result dict.
+        Process gateway callback and return (result dict, post_commit callback).
 
         This is a simplified wrapper around process_callback for router use.
-        Returns a dict suitable for JSON response.
+        The router must await the returned callback AFTER committing the
+        business transaction, otherwise the PAYMENT_VERIFIED notification
+        is silently dropped.
 
         Args:
             gateway_code: Gateway identifier (e.g., 'vnpay', 'momo')
             callback_data: Raw callback data from gateway
 
         Returns:
-            Dict with success status, message, and relevant IDs
+            Tuple of (result_dict, post_commit_callback_or_None). On error
+            paths the callback is None because no dispatch is owed.
         """
         try:
-            intent, payment, _ = await self.process_callback(
+            intent, payment, post_commit = await self.process_callback(
                 gateway_code=gateway_code,
                 callback_data=callback_data,
             )
@@ -447,30 +494,36 @@ class PaymentIntentService:
                 "intent_id": intent.id,
                 "payment_id": payment.id if payment else None,
                 "status": intent.status,
-            }
+            }, post_commit
 
         except ResourceNotFoundError as e:
             return {
                 "success": False,
                 "message": str(e),
                 "intent_id": None,
-            }
+            }, None
         except BusinessRuleViolation as e:
             return {
                 "success": False,
                 "message": str(e),
                 "intent_id": None,
-            }
+            }, None
 
     async def _create_payment_from_intent(
         self,
         intent: PaymentIntent,
         unit_id: Optional[int] = None,
-    ) -> Payment:
+    ) -> Tuple[Payment, "Fee", Optional["models.AdmissionProfile"]]:
         """
         Create Payment record from successful intent.
 
         Online payments are auto-verified (no maker-checker).
+
+        Returns:
+            Tuple of (payment, fee, profile_or_None). Profile is None when the
+            fee has no admission_profile_id linkage. Callers use `fee` and
+            `profile` for post-commit dispatch payload construction and lead
+            pipeline sync (for tuition fees).
         """
         # Get invoice and fee with locks
         invoice = await self.invoice_repo.get_for_update(intent.invoice_id, unit_id)
@@ -484,7 +537,10 @@ class PaymentIntentService:
         # Capture balance before
         fee_balance_before = fee.final_amount - fee.paid_amount - fee.waived_amount
 
-        # Create payment (auto-verified for online payments)
+        # Create payment (auto-verified for online payments).
+        # Issue C fix: verified_by_id must be NULL, not the same as created_by_id,
+        # otherwise chk_payment_no_self_approval fires. For the online path
+        # there is no human checker — the gateway callback IS the verification.
         payment = Payment(
             invoice_id=intent.invoice_id,
             method_id=intent.method_id,
@@ -494,8 +550,8 @@ class PaymentIntentService:
             status=PaymentStatusEnum.verified.value,  # Auto-verified
             payment_date=datetime.now(timezone.utc),
             verified_at=datetime.now(timezone.utc),
-            created_by_id=1,  # System user for online payments
-            verified_by_id=1,  # System user
+            created_by_id=1,   # System user for online payments
+            verified_by_id=None,  # NULL: auto-verified by gateway, no human checker
         )
 
         self.db.add(payment)
@@ -539,7 +595,36 @@ class PaymentIntentService:
         await self.db.flush()
         await self.db.refresh(payment)
 
-        return payment
+        # Resolve admission profile (with lead eager-loaded) for post-commit
+        # payload + lead sync. Mirrors payment_service._get_profile_for_fee
+        # pattern; inlined here to avoid cross-service dependency.
+        profile: Optional[models.AdmissionProfile] = None
+        if fee.admission_profile_id:
+            result = await self.db.execute(
+                select(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == fee.admission_profile_id)
+                .options(selectinload(models.AdmissionProfile.lead))
+            )
+            profile = result.scalar_one_or_none()
+
+        # Sync lead pipeline for tuition payments (mirrors manual verify path
+        # at payment_service.py:322-333). Only fires when the tuition fee is
+        # fully paid after this online payment.
+        if (
+            fee_remaining <= 0
+            and fee.fee_type == "tuition"
+            and profile is not None
+        ):
+            from app.services.lead_admission_sync import sync_lead_tuition_paid
+            await sync_lead_tuition_paid(
+                db=self.db,
+                profile=profile,
+                transaction_id=payment.reference_code or f"PAY-{payment.id}",
+                changed_by_user_id=1,  # system user
+                reason=f"Online tuition payment via {intent.method.code}",
+            )
+
+        return payment, fee, profile
 
     # ==========================================================================
     # INTENT LIFECYCLE

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -438,10 +438,40 @@ class PaymentService:
             rejector_id=rejector_id,
         )
 
-        # Post-commit: notify rejection
+        # Build PAYMENT_REJECTED notification payload while session is
+        # still active. payment.invoice.fee is joinedloaded by
+        # get_by_id_with_relations (payment_repository.py:64-86), so no
+        # extra queries are needed to reach the fee. The profile lookup
+        # gives us the lead_id for scoping and admission_profile_id for
+        # the payload.
+        _fee = payment.invoice.fee if payment.invoice else None
+        _profile = await self._get_profile_for_fee(_fee) if _fee else None
+        _lead_id = _profile.lead_id if _profile else None
+
+        _notify_payload = {
+            "payment_id": payment.id,
+            "invoice_id": payment.invoice_id,
+            "fee_id": _fee.id if _fee else None,
+            "amount": str(payment.amount),
+            "rejection_reason": reason,
+            "rejected_by_id": rejector_id,
+            "created_by_id": payment.created_by_id,
+            "admission_profile_id": _fee.admission_profile_id if _fee else None,
+            "lead_id": _lead_id,
+            "unit_id": unit_id,
+            # SpecificUsersResolver: notify the maker who recorded the payment
+            "user_id": payment.created_by_id,
+        }
+        _db = self.db
+
         async def post_commit():
-            # TODO: Emit PaymentRejected event for notifications
-            pass
+            from app.services.notification_dispatcher import safe_dispatch
+            from app.core.events import SystemEvents
+            await safe_dispatch(
+                db=_db,
+                event=SystemEvents.PAYMENT_REJECTED,
+                payload=_notify_payload,
+            )
 
         return payment, post_commit
 
@@ -850,20 +880,30 @@ class RefundService:
 
         await self.db.flush()
 
+        # Hoist profile resolution BEFORE the tuition-only branch.
+        # The notification payload below needs lead_id/admission_profile_id
+        # regardless of fee_type; scoping the profile lookup inside the
+        # tuition branch would leave `profile` unbound for non-tuition
+        # refunds and crash with UnboundLocalError when we build the
+        # payload. Same query is used by the inline lead sync below.
+        profile = await self._get_profile_for_fee(fee)
+
         # ✅ SYNC LEAD STATUS: If tuition fee refund, move lead to sts18 (Đã hoàn học phí)
-        # Only sync if this is a tuition fee refund
-        if fee.fee_type == "tuition":
-            # Load profile with lead for sync
-            profile = await self._get_profile_for_fee(fee)
-            if profile:
-                from app.services.lead_admission_sync import sync_lead_tuition_refunded
-                await sync_lead_tuition_refunded(
-                    db=self.db,
-                    profile=profile,
-                    refund_amount=str(refund.amount),
-                    changed_by_user_id=processor_id,
-                    reason=f"Tuition fee refunded: {refund.amount:,.0f} VND. Reason: {refund.reason}",
-                )
+        # Only sync if this is a tuition fee refund.
+        # NOTE (ADR-002 PR 5 follow-up): this projection currently fires
+        # unconditionally for any tuition refund. After the semester
+        # tuition epic lands, it must be gated to fee.semester_no == 1 so
+        # HK2+ refunds do not drag the admission pipeline backwards.
+        # Tracked in PR 5 checklist.
+        if fee.fee_type == "tuition" and profile is not None:
+            from app.services.lead_admission_sync import sync_lead_tuition_refunded
+            await sync_lead_tuition_refunded(
+                db=self.db,
+                profile=profile,
+                refund_amount=str(refund.amount),
+                changed_by_user_id=processor_id,
+                reason=f"Tuition fee refunded: {refund.amount:,.0f} VND. Reason: {refund.reason}",
+            )
 
         log.info(
             "refund_processed",
@@ -873,7 +913,43 @@ class RefundService:
             processor_id=processor_id,
         )
 
-        return refund, None
+        # Build REFUND_PROCESSED notification payload. Recipients are the
+        # assigned officer (when resolved) plus the processor. Finance
+        # staff group and external applicant notification are deferred
+        # (PR B + Zalo ZNS Phase 2 respectively — see events.py docstring).
+        _officer_id: Optional[int] = None
+        if profile is not None and getattr(profile, "lead", None) is not None:
+            _officer_id = profile.lead.assigned_officer_id
+        _recipient_ids = list({
+            uid for uid in [_officer_id, processor_id] if uid
+        })
+
+        _notify_payload = {
+            "refund_id": refund.id,
+            "payment_id": payment.id,
+            "invoice_id": invoice.id,
+            "fee_id": fee.id,
+            "amount": str(refund.amount),
+            "reason": refund.reason,
+            "processor_id": processor_id,
+            "admission_profile_id": fee.admission_profile_id,
+            "lead_id": profile.lead_id if profile is not None else None,
+            "unit_id": unit_id,
+            # SpecificUsersResolver: notify officer + processor.
+            "user_ids": _recipient_ids,
+        }
+        _db = self.db
+
+        async def post_commit():
+            from app.services.notification_dispatcher import safe_dispatch
+            from app.core.events import SystemEvents
+            await safe_dispatch(
+                db=_db,
+                event=SystemEvents.REFUND_PROCESSED,
+                payload=_notify_payload,
+            )
+
+        return refund, post_commit
 
     async def _get_profile_for_fee(
         self,

--- a/Backend_FastAPI/tests/services/test_payment_intent_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_intent_service.py
@@ -273,11 +273,6 @@ class TestCreateIntent:
 class TestProcessCallback:
     """Tests for gateway callback processing without adapter (mock path)."""
 
-    @pytest.mark.xfail(
-        reason="Service bug: _create_payment_from_intent uses created_by_id=1, "
-               "verified_by_id=1, violating chk_payment_no_self_approval constraint",
-        raises=Exception,
-    )
     async def test_process_callback_success(self, db, intent_fixtures, admin_user):
         """Successful callback creates payment and updates invoice."""
         service = PaymentIntentService(db)

--- a/Backend_FastAPI/tests/unit/test_notification_contract.py
+++ b/Backend_FastAPI/tests/unit/test_notification_contract.py
@@ -436,6 +436,11 @@ class TestUserEventsHaveDispatchCallers:
         "consultation_deleted", "consultation_reminder",
         "application_created", "application_status_changed", "application_deleted",
         "payment_received", "payment_verified",
+        "payment_rejected",
+        # refund_processed is notification_class="internal_future" — dispatch
+        # site wired in payment_service.process_approved_refund() but refund
+        # flow has no router endpoint yet. Promote to user-class when the
+        # refund router ships. See event_catalog.py _FINANCE_FUTURE_EVENTS.
         "ctv_claim_submitted", "ctv_claim_approved", "ctv_claim_rejected",
         "ctv_approved", "ctv_suspended", "ctv_commission_created",
         "ctv_attribution_expiring", "ctv_attribution_expired", "ctv_weekly_summary",


### PR DESCRIPTION
## Summary

Ember **PR A** — payment event parity. Ships the three ship-safe items from `~/.claude/plans/cached-imagining-ember.md` ahead of the FEE_FULLY_PAID / INVOICE_ISSUED / PAYMENT_OVERDUE work that remains blocked on the semester tuition epic (ADR-002).

Per ADR-001 (no `DomainEvent` revival), everything uses the existing `SystemEvents` + `EventDefinition` + `notification_rule` path.

## Scope

### Live-shipped (reachable from production today)

**PAYMENT_REJECTED** — new `notification_class=user`
- Dispatched from `payment_service.reject_payment()` post-commit closure
- Recipient: the maker (`created_by_id`) via `SpecificUsersResolver`
- Full 5-layer parity: `events` enum + `event_catalog` entry + `event_groups` mapping + `notification_registry` config + `event_metadata`
- Dev seed in `reset_notification_rules_dev`
- Production auto-seed via `sync_notification_rules._get_template()` curated Vietnamese strings
- Reachable from the existing `POST /payments/{id}/reject` router endpoint — live behavior starts the moment this merges

**PAYMENT_VERIFIED online callback parity** — completes the TODO path in `payment_intent_service.process_callback()`
- Real post-commit dispatch with full payload (`payment_id`, `invoice_id`, `fee_id`, `amount`, `verified_at`, `admission_profile_id`, `lead_id`, `unit_id`, `user_id=officer`)
- Dispatch silently skipped when no officer resolves (zero-recipient dispatches would look like success but send nothing)
- `process_gateway_callback()` now returns `(result_dict, callback)` instead of discarding the callback
- `payment_callback()` router awaits the callback after `db.commit()`
- **Issue C fix**: `_create_payment_from_intent()` sets `verified_by_id=None` on the auto-verified online path so `chk_payment_no_self_approval` does not fire. Previously `verified_by_id=1=created_by_id` violated the constraint and the integration test was `xfail`-ed. The xfail is removed; the test now passes.
- `_create_payment_from_intent()` returns `(payment, fee, profile)` instead of just `payment` and invokes `sync_lead_tuition_paid` for tuition payments fully settled on the callback path (mirror of the manual `verify_payment` flow at `payment_service.py:322-333`)

### Dormant-shipped (code wired, no reachable caller yet)

**REFUND_PROCESSED** — new `notification_class=internal_future`
- Tagged internal_future because `RefundService` has no router surface today: the request/approve/process flow is service-layer only and **no endpoint reaches it**. Grep for `RefundService(` or `process_approved_refund(` in `app/routers/` returns zero matches.
- Dispatch site is wired in `payment_service.process_approved_refund()`. Payload construction hoists the profile lookup BEFORE the tuition-only sync block so non-tuition refunds do not crash with `UnboundLocalError`.
- Catalog parity entries (`event_groups`, `notification_registry`, `event_metadata`) are present following the `PAYMENT_OVERDUE` / `DORM_FEE_CREATED` precedent — also internal_future finance events with full 5-layer parity — so `REFUND_PROCESSED` becomes ready to promote the instant the refund router lands. Only the `notification_class` tag and the `_DISPATCHED_EVENTS` test whitelist will need to flip.
- **Deliberate non-goal**: wiring a refund router in this PR would be scope creep (maker-checker rule, 3 endpoints, Pydantic schemas, authorization, tests). Keep ember focused on event parity.

## Why ship dormant code

Reviewed in-flight: `REFUND_PROCESSED` originally landed as `user` class. Review caught that this silently bypassed the intent of `test_user_events_have_dispatch_in_codebase` — the contract test scans a hand-maintained `_DISPATCHED_EVENTS` whitelist, so it would have gone green even with no production caller. Demoting to `internal_future` + matching the `PAYMENT_OVERDUE` precedent brings the parity layers in line with reality and makes the dormant status explicit in the catalog tag.

## Files changed — 12

| File | Change |
|---|---|
| `app/core/events.py` | 2 new enum members with full payload docstrings; `REFUND_PROCESSED` docstring notes DORMANT status |
| `app/core/event_catalog.py` | `PAYMENT_REJECTED` in `_FINANCE_USER_EVENTS`, `REFUND_PROCESSED` in `_FINANCE_FUTURE_EVENTS` (internal_future) |
| `app/core/event_groups.py` | +2 FINANCE mappings |
| `app/core/event_metadata.py` | +2 EventMetadata entries (filter_fields for admin rule builder) |
| `app/services/notification_registry.py` | +2 NotificationConfig entries (priorities 65/55, WARNING/INFO, VI templates) |
| `app/scripts/sync_notification_rules.py` | Curated template for PAYMENT_REJECTED only (REFUND_PROCESSED not seeded because internal_future) |
| `app/scripts/reset_notification_rules_dev.py` | Dev seed for payment_rejected only |
| `app/services/payment_intent_service.py` | Issue C fix + return `(payment, fee, profile)` + lead sync + full post-commit PAYMENT_VERIFIED dispatch + `process_gateway_callback` returns callback |
| `app/services/payment_service.py` | `reject_payment` post-commit filled; `process_approved_refund` hoists profile + dispatches REFUND_PROCESSED + returns `(refund, post_commit)` |
| `app/routers/payments.py` | `payment_callback` awaits callback after commit |
| `tests/services/test_payment_intent_service.py` | Remove xfail from `test_process_callback_success` |
| `tests/unit/test_notification_contract.py` | Add `payment_rejected` to `_DISPATCHED_EVENTS`; explain `refund_processed` absence |

No DB migration. No model change. No admission event mapping change. No deps/auth change. No frontend change.

## Follow-ups (not in this PR)

- **ADR-002 PR 5**: gate `sync_lead_tuition_refunded()` in `process_approved_refund()` to `fee.semester_no == 1` so HK2+ refunds stop dragging the admission pipeline backwards. Tracked inline with a comment at the call site.
- **ADR-002 PR 5**: reinterpret `PAYMENT_VERIFIED.is_fully_paid` under per-semester model. No payload field added in this PR.
- **PR B**: `REFUND_PROCESSED` finance staff group — needs a dedicated resolver.
- **Zalo ZNS Phase 2**: external applicant notification for rejected payments and refunds.
- **Refund router** (separate effort): wiring `POST /refunds`, `POST /refunds/{id}/approve`, `POST /refunds/{id}/process` will automatically light up the dormant `REFUND_PROCESSED` dispatch — just flip `notification_class` back to `user` and add to `_DISPATCHED_EVENTS`.

## Test plan

All runs inside the dev container.

- [x] Model/catalog import smoke
- [x] `test_notification_parity.py` — 32/32 (every SystemEvents value mapped, every mapping has registry config, every registry config has metadata)
- [x] `test_notification_contract.py` — 32/32 (including `test_user_events_have_dispatch_in_codebase` which now sees `payment_rejected`; `refund_processed` correctly skipped as internal_future)
- [x] `test_payment_intent_service.py` — 14/14, **including `test_process_callback_success` which was previously xfail**
- [x] `test_finance_workflow.py` — 14/14 (no regression in manual payment flow)
- [x] `test_finance_models.py` + `test_finance_schemas.py` + `test_finance_api.py` — 135/135 (no regression)
- [x] `test_admission_workflow_e2e.py` — 35/35 (no regression in admission gate / lead sync paths)
- [ ] Reviewer confirms `git diff --name-only main..HEAD` returns exactly 12 files
- [ ] Reviewer confirms no router surface exposes `RefundService` (should match plan assumption)
- [ ] Reviewer confirms the `_DISPATCHED_EVENTS` whitelist matches only reachable user-class dispatches
- [ ] Reviewer confirms the internal_future tag on `REFUND_PROCESSED` matches `PAYMENT_OVERDUE` / `DORM_FEE_CREATED` precedent

## Not related to the semester tuition epic

This branch is orthogonal to ADR-002 (`semester_tuition`). It does not touch `fee.py`, `offering_*`, `admission_service.py`, `admission_event_mapping.py`, or the schema migration. The only epic-adjacent reference is a comment in `process_approved_refund()` flagging a PR 5 follow-up for `sync_lead_tuition_refunded` gating — no behavior change.
