### PR TITLE
feat(organization): PR 2 — semester tuition admin config

### DIFF
--- a/Backend_FastAPI/app/repositories/organization_repository.py
+++ b/Backend_FastAPI/app/repositories/organization_repository.py
@@ -67,6 +67,8 @@ class OrganizationRepository(BaseRepository[models.OrganizationUnit]):
                     models.MajorProgram.offerings
                 ).selectinload(
                     models.ProgramOffering.academic_info_history
+                ).selectinload(
+                    models.OfferingAcademicInfo.semester_tuitions
                 ),
             )
             .where(self.model.id == unit_id)
@@ -97,10 +99,10 @@ class OrganizationRepository(BaseRepository[models.OrganizationUnit]):
         query = (
             select(models.MajorProgram)
             .options(
-                selectinload(models.MajorProgram.offerings).selectinload(
-                    models.ProgramOffering.academic_info_history
-                ),
-                selectinload(models.MajorProgram.unit)
+                selectinload(models.MajorProgram.offerings)
+                .selectinload(models.ProgramOffering.academic_info_history)
+                .selectinload(models.OfferingAcademicInfo.semester_tuitions),
+                selectinload(models.MajorProgram.unit),
             )
             .where(models.MajorProgram.id == program_id)
         )
@@ -130,12 +132,13 @@ class OrganizationRepository(BaseRepository[models.OrganizationUnit]):
         query = (
             select(models.ProgramOffering)
             .options(
-                selectinload(models.ProgramOffering.academic_info_history),
-                selectinload(models.ProgramOffering.program)
+                selectinload(models.ProgramOffering.academic_info_history)
+                .selectinload(models.OfferingAcademicInfo.semester_tuitions),
+                selectinload(models.ProgramOffering.program),
             )
             .where(models.ProgramOffering.id == offering_id)
         )
-        
+
         result = await self.db.execute(query)
         return result.scalars().unique().first()
 
@@ -602,8 +605,10 @@ class OrganizationRepository(BaseRepository[models.OrganizationUnit]):
         academic_info_id: int
     ) -> Optional[models.OfferingAcademicInfo]:
         """Get academic info by ID."""
-        query = select(models.OfferingAcademicInfo).where(
-            models.OfferingAcademicInfo.id == academic_info_id
+        query = (
+            select(models.OfferingAcademicInfo)
+            .where(models.OfferingAcademicInfo.id == academic_info_id)
+            .options(selectinload(models.OfferingAcademicInfo.semester_tuitions))
         )
         result = await self.db.execute(query)
         return result.scalar_one_or_none()
@@ -614,9 +619,13 @@ class OrganizationRepository(BaseRepository[models.OrganizationUnit]):
         academic_year: int
     ) -> Optional[models.OfferingAcademicInfo]:
         """Get academic info for a specific offering and year."""
-        query = select(models.OfferingAcademicInfo).where(
-            models.OfferingAcademicInfo.offering_id == offering_id,
-            models.OfferingAcademicInfo.academic_year == academic_year
+        query = (
+            select(models.OfferingAcademicInfo)
+            .where(
+                models.OfferingAcademicInfo.offering_id == offering_id,
+                models.OfferingAcademicInfo.academic_year == academic_year,
+            )
+            .options(selectinload(models.OfferingAcademicInfo.semester_tuitions))
         )
         result = await self.db.execute(query)
         return result.scalar_one_or_none()
@@ -627,11 +636,16 @@ class OrganizationRepository(BaseRepository[models.OrganizationUnit]):
         current_year: int
     ) -> Optional[models.OfferingAcademicInfo]:
         """Get current year's published academic info for an offering."""
-        query = select(models.OfferingAcademicInfo).where(
-            models.OfferingAcademicInfo.offering_id == offering_id,
-            models.OfferingAcademicInfo.academic_year == current_year,
-            models.OfferingAcademicInfo.is_published == True
-        ).limit(1)
+        query = (
+            select(models.OfferingAcademicInfo)
+            .where(
+                models.OfferingAcademicInfo.offering_id == offering_id,
+                models.OfferingAcademicInfo.academic_year == current_year,
+                models.OfferingAcademicInfo.is_published == True,
+            )
+            .options(selectinload(models.OfferingAcademicInfo.semester_tuitions))
+            .limit(1)
+        )
         result = await self.db.execute(query)
         return result.scalar_one_or_none()
 
@@ -641,15 +655,17 @@ class OrganizationRepository(BaseRepository[models.OrganizationUnit]):
         published_only: bool = False
     ) -> List[models.OfferingAcademicInfo]:
         """Get all academic info history for an offering, ordered by year (newest first)."""
-        query = select(models.OfferingAcademicInfo).where(
-            models.OfferingAcademicInfo.offering_id == offering_id
+        query = (
+            select(models.OfferingAcademicInfo)
+            .where(models.OfferingAcademicInfo.offering_id == offering_id)
+            .options(selectinload(models.OfferingAcademicInfo.semester_tuitions))
         )
-        
+
         if published_only:
             query = query.where(models.OfferingAcademicInfo.is_published == True)
-        
+
         query = query.order_by(models.OfferingAcademicInfo.academic_year.desc())
-        
+
         result = await self.db.execute(query)
         return list(result.scalars().all())
 
@@ -852,7 +868,9 @@ class OrganizationRepository(BaseRepository[models.OrganizationUnit]):
             return []
         
         query = select(models.MajorProgram).options(
-            selectinload(models.MajorProgram.offerings).selectinload(models.ProgramOffering.academic_info_history)
+            selectinload(models.MajorProgram.offerings)
+            .selectinload(models.ProgramOffering.academic_info_history)
+            .selectinload(models.OfferingAcademicInfo.semester_tuitions)
         ).filter(
             models.MajorProgram.unit_id.in_(unit_ids),
             models.MajorProgram.is_active == True
@@ -888,7 +906,9 @@ class OrganizationRepository(BaseRepository[models.OrganizationUnit]):
         """
         # ✅ FIX: Eager load offerings to prevent MissingGreenlet error during response validation
         query = select(models.MajorProgram).options(
-            selectinload(models.MajorProgram.offerings).selectinload(models.ProgramOffering.academic_info_history)
+            selectinload(models.MajorProgram.offerings)
+            .selectinload(models.ProgramOffering.academic_info_history)
+            .selectinload(models.OfferingAcademicInfo.semester_tuitions)
         )
         
         if is_active:
@@ -929,8 +949,9 @@ class OrganizationRepository(BaseRepository[models.OrganizationUnit]):
         query = (
             select(models.ProgramOffering)
             .options(
-                selectinload(models.ProgramOffering.program),  # Eager load for display
+                selectinload(models.ProgramOffering.program),
                 selectinload(models.ProgramOffering.academic_info_history)
+                .selectinload(models.OfferingAcademicInfo.semester_tuitions),
             )
         )
 
@@ -973,6 +994,9 @@ class OrganizationRepository(BaseRepository[models.OrganizationUnit]):
                 models.AdmissionPath,
                 (models.AdmissionPath.academic_info_id == models.OfferingAcademicInfo.id) &
                 (models.AdmissionPath.status == "active")
+            )
+            .options(
+                selectinload(models.OfferingAcademicInfo.semester_tuitions)
             )
             .group_by(models.OfferingAcademicInfo.id)
         )

--- a/Backend_FastAPI/app/routers/admin/organization.py
+++ b/Backend_FastAPI/app/routers/admin/organization.py
@@ -12,7 +12,7 @@ Dependencies: organization_service (from PHASE 1)
 
 Complexity: MEDIUM (hierarchical CRUD, 3-tier architecture)
 """
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from app.core.rate_limits import limiter, RateLimits  # ✅ Rate limiting
 
@@ -550,3 +550,112 @@ async def restore_deleted_academic_info(
     await db.commit()
     await post_commit()
     return academic_info
+
+
+# =============================================================================
+# OfferingSemesterTuition CRUD — PR 2 (ADR-002)
+# =============================================================================
+
+@limiter.limit(RateLimits.ADMIN_READ)
+@router.get(
+    "/academic-info/{academic_info_id}/semester-tuitions",
+    response_model=List[schemas.SemesterTuitionResponse],
+)
+async def list_semester_tuitions(
+    request: Request,
+    academic_info_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = CasbinAuth,
+):
+    """(Admin only) Danh sách học phí theo học kỳ cho một bản ghi tuyển sinh."""
+    return await organization_service.list_semester_tuitions(
+        db, academic_info_id, current_admin
+    )
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.post(
+    "/academic-info/{academic_info_id}/semester-tuitions",
+    response_model=schemas.SemesterTuitionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_semester_tuition(
+    request: Request,
+    academic_info_id: int,
+    data: schemas.SemesterTuitionCreate,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = CasbinAuth,
+):
+    """(Admin only) Tạo học phí cho một học kỳ cụ thể."""
+    row, post_commit = await organization_service.create_semester_tuition(
+        db, academic_info_id, data, current_admin
+    )
+    await db.commit()
+    await post_commit()
+    return row
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.patch(
+    "/semester-tuitions/{semester_tuition_id}",
+    response_model=schemas.SemesterTuitionResponse,
+)
+async def update_semester_tuition(
+    request: Request,
+    semester_tuition_id: int,
+    data: schemas.SemesterTuitionUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = CasbinAuth,
+):
+    """(Admin only) Cập nhật học phí một học kỳ."""
+    row, post_commit = await organization_service.update_semester_tuition(
+        db, semester_tuition_id, data, current_admin
+    )
+    await db.commit()
+    await post_commit()
+    return row
+
+
+@limiter.limit(RateLimits.ADMIN_DELETE)
+@router.delete(
+    "/semester-tuitions/{semester_tuition_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_semester_tuition(
+    request: Request,
+    semester_tuition_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = CasbinAuth,
+):
+    """(Admin only) Xóa học phí một học kỳ."""
+    _, post_commit = await organization_service.delete_semester_tuition(
+        db, semester_tuition_id, current_admin
+    )
+    await db.commit()
+    await post_commit()
+    return None
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.put(
+    "/academic-info/{academic_info_id}/semester-tuitions",
+    response_model=List[schemas.SemesterTuitionResponse],
+)
+async def bulk_upsert_semester_tuitions(
+    request: Request,
+    academic_info_id: int,
+    data: schemas.SemesterTuitionBulkUpsert,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = CasbinAuth,
+):
+    """(Admin only) Thay thế toàn bộ bảng học phí theo học kỳ.
+
+    Gửi danh sách đầy đủ [{semester_no, amount, notes?}, ...].
+    Danh sách rỗng = xóa toàn bộ (quay về chỉ dùng học phí/năm cũ).
+    """
+    rows, post_commit = await organization_service.bulk_upsert_semester_tuitions(
+        db, academic_info_id, data, current_admin
+    )
+    await db.commit()
+    await post_commit()
+    return rows

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -51,6 +51,13 @@ from .organization import (
     OfferingAcademicInfoBase,
     OfferingAcademicInfoCreate,
     OfferingAcademicInfoUpdate,
+    # Semester Tuition (PR 2 — ADR-002)
+    SemesterTuitionBase,
+    SemesterTuitionCreate,
+    SemesterTuitionUpdate,
+    SemesterTuitionResponse,
+    SemesterTuitionBulkUpsert,
+    SemesterTuitionBulkUpsertItem,
 
     ScoringRules,  # Fit Score configuration schema
     # Organization Unit schemas

--- a/Backend_FastAPI/app/schemas/organization.py
+++ b/Backend_FastAPI/app/schemas/organization.py
@@ -104,12 +104,72 @@ class OfferingAcademicInfo(OfferingAcademicInfoBase):
     updated_at: Optional[datetime] = None
     created_by_user_id: Optional[int] = None
     updated_by_user_id: Optional[int] = None
-    
+
     # Computed fields
     path_count: Optional[int] = Field(default=0, description="Số lượng đợt tuyển sinh")
     admission_status: Optional[AdmissionStatus] = Field(default=None, description="Trạng thái cấu hình")
 
+    # PR 2 (ADR-002): per-semester tuition catalog nested in response.
+    semester_tuitions: List["SemesterTuitionResponse"] = Field(
+        default_factory=list,
+        description="Bảng học phí theo từng học kỳ"
+    )
+
     model_config = ConfigDict(from_attributes=True)
+
+
+# =============================================================================
+# CẤP 3.5: OfferingSemesterTuition (PR 2 — ADR-002)
+# =============================================================================
+
+class SemesterTuitionBase(BaseModel):
+    semester_no: int = Field(..., ge=1, description="Số học kỳ (HK1=1)")
+    amount: Decimal = Field(..., ge=0, description="Học phí học kỳ (VND)")
+    notes: Optional[str] = Field(None, max_length=500, description="Ghi chú")
+
+
+class SemesterTuitionCreate(SemesterTuitionBase):
+    """Single row creation. academic_info_id comes from path."""
+    pass
+
+
+class SemesterTuitionUpdate(BaseModel):
+    amount: Optional[Decimal] = Field(None, ge=0, description="Học phí (VND)")
+    notes: Optional[str] = Field(None, max_length=500, description="Ghi chú")
+
+
+class SemesterTuitionResponse(SemesterTuitionBase):
+    id: int
+    academic_info_id: int
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    created_by_user_id: Optional[int] = None
+    updated_by_user_id: Optional[int] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SemesterTuitionBulkUpsertItem(BaseModel):
+    semester_no: int = Field(..., ge=1)
+    amount: Decimal = Field(..., ge=0)
+    notes: Optional[str] = Field(None, max_length=500)
+
+
+class SemesterTuitionBulkUpsert(BaseModel):
+    items: List[SemesterTuitionBulkUpsertItem] = Field(
+        default_factory=list, max_length=20,
+        description="Danh sách học phí theo học kỳ. Rỗng = xóa toàn bộ."
+    )
+
+    @field_validator('items')
+    @classmethod
+    def validate_unique_semesters(cls, v):
+        if not v:
+            return v
+        semester_nos = [item.semester_no for item in v]
+        if len(semester_nos) != len(set(semester_nos)):
+            raise ValueError("Số học kỳ không được trùng lặp")
+        return v
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/services/organization_service.py
+++ b/Backend_FastAPI/app/services/organization_service.py
@@ -1944,3 +1944,290 @@ async def get_all_academic_infos(
 
     return response
 
+
+# =============================================================================
+# OfferingSemesterTuition CRUD — PR 2 (ADR-002)
+# =============================================================================
+
+async def _resolve_academic_info_for_semester_tuition(
+    db: AsyncSession,
+    academic_info_id: int,
+    current_user: models.User,
+) -> models.OfferingAcademicInfo:
+    """Load academic info + verify IDOR access + reject soft-deleted.
+
+    Shared by all semester tuition CRUD. Returns 404 for soft-deleted
+    parents so that callers cannot accidentally edit semester tuition on
+    an academic info that the admin has "deleted" (soft). Consistent
+    with the plan's "404 if not found/soft-deleted" rule.
+    """
+    db_info = await get_academic_info_by_id(db, academic_info_id)
+    if db_info.is_deleted:
+        raise ResourceNotFoundError(
+            "Thông tin tuyển sinh đã bị xóa. Vui lòng khôi phục trước "
+            "khi chỉnh sửa học phí học kỳ."
+        )
+    offering = await get_program_offering_by_id(db, db_info.offering_id)
+    program = await get_major_program_by_id(db, offering.program_id)
+    await _check_unit_access(db, program.unit_id, current_user)
+    return db_info
+
+
+def _check_semester_tuition_immutability(
+    db_info: models.OfferingAcademicInfo,
+) -> None:
+    """Block semester tuition edits for past academic years."""
+    current_year = datetime.now(timezone.utc).year
+    if db_info.academic_year < current_year:
+        raise BadRequest(
+            detail=f"Không thể thay đổi học phí học kỳ của năm học "
+                   f"{db_info.academic_year} (năm trong quá khứ). Dữ liệu "
+                   f"tài chính lịch sử phải bất biến để đảm bảo tính toàn "
+                   f"vẹn của báo cáo tài chính."
+        )
+
+
+async def _invalidate_semester_tuition_dependents(
+    academic_info_id: int,
+    academic_year: int,
+    operation: str,
+    semester_info: str = "",
+) -> None:
+    """Post-commit: invalidate caches + emit Socket.IO event.
+
+    This is the ADR-002 Decision 4 hook point. PR 2 does cache
+    invalidation + Socket.IO only. PR 3 will extend this to trigger
+    discount recalculation on FeeAppliedDiscount rows.
+    """
+    await invalidate_org_cache()
+    await emit_organization_updated(
+        operation=operation,
+        resource_type="semester_tuition",
+        resource_id=academic_info_id,
+        resource_name=f"Năm {academic_year} — {semester_info}",
+    )
+
+
+async def list_semester_tuitions(
+    db: AsyncSession,
+    academic_info_id: int,
+    current_user: models.User,
+) -> List[models.OfferingSemesterTuition]:
+    """List all semester tuition rows for an academic info, ordered by semester_no.
+
+    Uses the shared IDOR + soft-delete check so that the list endpoint
+    is consistent with the write endpoints.
+    """
+    await _resolve_academic_info_for_semester_tuition(
+        db, academic_info_id, current_user
+    )
+    result = await db.execute(
+        select(models.OfferingSemesterTuition)
+        .where(models.OfferingSemesterTuition.academic_info_id == academic_info_id)
+        .order_by(models.OfferingSemesterTuition.semester_no)
+    )
+    return list(result.scalars().all())
+
+
+async def create_semester_tuition(
+    db: AsyncSession,
+    academic_info_id: int,
+    data: schemas.SemesterTuitionCreate,
+    current_user: models.User,
+) -> Tuple[models.OfferingSemesterTuition, Callable]:
+    """Create a single semester tuition row."""
+    db_info = await _resolve_academic_info_for_semester_tuition(
+        db, academic_info_id, current_user
+    )
+    _check_semester_tuition_immutability(db_info)
+
+    existing = await db.execute(
+        select(models.OfferingSemesterTuition)
+        .where(
+            models.OfferingSemesterTuition.academic_info_id == academic_info_id,
+            models.OfferingSemesterTuition.semester_no == data.semester_no,
+        )
+    )
+    if existing.scalar_one_or_none():
+        raise DuplicateResourceError(
+            f"Học phí HK{data.semester_no} đã tồn tại cho năm học "
+            f"{db_info.academic_year}"
+        )
+
+    row = models.OfferingSemesterTuition(
+        academic_info_id=academic_info_id,
+        semester_no=data.semester_no,
+        amount=data.amount,
+        notes=data.notes,
+        created_by_user_id=current_user.id,
+        updated_by_user_id=current_user.id,
+    )
+    db.add(row)
+    await db.flush()
+    await db.refresh(row)
+
+    _year = db_info.academic_year
+
+    async def _post_commit():
+        log.info("semester_tuition_created",
+                 academic_info_id=academic_info_id,
+                 semester_no=data.semester_no,
+                 amount=str(data.amount))
+        await _invalidate_semester_tuition_dependents(
+            academic_info_id, _year, "create",
+            f"HK{data.semester_no}",
+        )
+
+    return row, _post_commit
+
+
+async def update_semester_tuition(
+    db: AsyncSession,
+    semester_tuition_id: int,
+    data: schemas.SemesterTuitionUpdate,
+    current_user: models.User,
+) -> Tuple[models.OfferingSemesterTuition, Callable]:
+    """Update a single semester tuition row."""
+    result = await db.execute(
+        select(models.OfferingSemesterTuition)
+        .where(models.OfferingSemesterTuition.id == semester_tuition_id)
+    )
+    row = result.scalar_one_or_none()
+    if not row:
+        raise ResourceNotFoundError("Không tìm thấy bản ghi học phí học kỳ")
+
+    db_info = await _resolve_academic_info_for_semester_tuition(
+        db, row.academic_info_id, current_user
+    )
+    _check_semester_tuition_immutability(db_info)
+
+    update_data = data.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(row, key, value)
+    row.updated_by_user_id = current_user.id
+
+    await db.flush()
+    await db.refresh(row)
+
+    _year = db_info.academic_year
+    _sem = row.semester_no
+
+    async def _post_commit():
+        log.info("semester_tuition_updated",
+                 semester_tuition_id=semester_tuition_id,
+                 semester_no=_sem)
+        await _invalidate_semester_tuition_dependents(
+            row.academic_info_id, _year, "update", f"HK{_sem}",
+        )
+
+    return row, _post_commit
+
+
+async def delete_semester_tuition(
+    db: AsyncSession,
+    semester_tuition_id: int,
+    current_user: models.User,
+) -> Tuple[None, Callable]:
+    """Delete a single semester tuition row (hard delete — catalog row, not financial)."""
+    result = await db.execute(
+        select(models.OfferingSemesterTuition)
+        .where(models.OfferingSemesterTuition.id == semester_tuition_id)
+    )
+    row = result.scalar_one_or_none()
+    if not row:
+        raise ResourceNotFoundError("Không tìm thấy bản ghi học phí học kỳ")
+
+    db_info = await _resolve_academic_info_for_semester_tuition(
+        db, row.academic_info_id, current_user
+    )
+    _check_semester_tuition_immutability(db_info)
+
+    _year = db_info.academic_year
+    _sem = row.semester_no
+    _info_id = row.academic_info_id
+
+    await db.delete(row)
+    await db.flush()
+
+    async def _post_commit():
+        log.info("semester_tuition_deleted",
+                 academic_info_id=_info_id,
+                 semester_no=_sem)
+        await _invalidate_semester_tuition_dependents(
+            _info_id, _year, "delete", f"HK{_sem}",
+        )
+
+    return None, _post_commit
+
+
+async def bulk_upsert_semester_tuitions(
+    db: AsyncSession,
+    academic_info_id: int,
+    data: schemas.SemesterTuitionBulkUpsert,
+    current_user: models.User,
+) -> Tuple[List[models.OfferingSemesterTuition], Callable]:
+    """Replace-all semester tuition rows for an academic info.
+
+    Empty items list = clear all rows (fall back to legacy tuition_fee_per_year).
+    Non-empty list = upsert matching semester_no, delete rows not in the list.
+    """
+    db_info = await _resolve_academic_info_for_semester_tuition(
+        db, academic_info_id, current_user
+    )
+    _check_semester_tuition_immutability(db_info)
+
+    existing_result = await db.execute(
+        select(models.OfferingSemesterTuition)
+        .where(models.OfferingSemesterTuition.academic_info_id == academic_info_id)
+    )
+    existing_rows = {row.semester_no: row for row in existing_result.scalars().all()}
+
+    incoming_semesters = {item.semester_no for item in data.items}
+
+    # Delete rows not in the incoming list
+    for sem_no, row in existing_rows.items():
+        if sem_no not in incoming_semesters:
+            await db.delete(row)
+
+    # Upsert: update existing or create new
+    for item in data.items:
+        if item.semester_no in existing_rows:
+            row = existing_rows[item.semester_no]
+            row.amount = item.amount
+            row.notes = item.notes
+            row.updated_by_user_id = current_user.id
+        else:
+            row = models.OfferingSemesterTuition(
+                academic_info_id=academic_info_id,
+                semester_no=item.semester_no,
+                amount=item.amount,
+                notes=item.notes,
+                created_by_user_id=current_user.id,
+                updated_by_user_id=current_user.id,
+            )
+            db.add(row)
+
+    await db.flush()
+
+    # Re-query for the final ordered list
+    final_result = await db.execute(
+        select(models.OfferingSemesterTuition)
+        .where(models.OfferingSemesterTuition.academic_info_id == academic_info_id)
+        .order_by(models.OfferingSemesterTuition.semester_no)
+    )
+    final_rows = list(final_result.scalars().all())
+
+    _year = db_info.academic_year
+    _count = len(final_rows)
+
+    async def _post_commit():
+        log.info("semester_tuitions_bulk_upserted",
+                 academic_info_id=academic_info_id,
+                 count=_count)
+        await _invalidate_semester_tuition_dependents(
+            academic_info_id, _year, "bulk_upsert",
+            f"{_count} học kỳ",
+        )
+
+    return final_rows, _post_commit
+

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase2Program/AcademicInfoPanel.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase2Program/AcademicInfoPanel.test.tsx
@@ -13,6 +13,15 @@ vi.mock("@/hooks/admissions/useProgramData", () => ({
   useDeleteOfferingAcademicInfo: vi.fn(),
 }));
 
+// Mock semester tuition bulk upsert hook (PR 2 — ADR-002)
+const mockBulkUpsertMutate = vi.fn().mockResolvedValue([]);
+vi.mock("@/hooks/useOrganization", () => ({
+  useBulkUpsertSemesterTuitions: () => ({
+    mutateAsync: mockBulkUpsertMutate,
+    isPending: false,
+  }),
+}));
+
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
@@ -63,8 +72,8 @@ describe("AcademicInfoPanel", () => {
     },
   ];
 
-  const mockCreateMutate = vi.fn();
-  const mockUpdateMutate = vi.fn();
+  const mockCreateMutate = vi.fn().mockResolvedValue({ id: 99 });
+  const mockUpdateMutate = vi.fn().mockResolvedValue({ id: 1 });
   const mockDeleteMutate = vi.fn();
 
   beforeEach(() => {

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase2Program/AcademicInfoPanel.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase2Program/AcademicInfoPanel.tsx
@@ -40,13 +40,16 @@ import {
   useDeleteOfferingAcademicInfo,
 } from "@/hooks/admissions/useProgramData";
 import { useProgramOfferings } from "@/hooks/admissions/useProgramData";
+import { useBulkUpsertSemesterTuitions } from "@/hooks/useOrganization";
 import { useAdmissionConfigState } from "@/hooks/admissions/useAdmissionConfigState";
+import { SemesterTuitionEditor } from "@/components/admin/organization/SemesterTuitionEditor";
 import type {
   OfferingAcademicInfo,
   OfferingAcademicInfoCreate,
   OfferingAcademicInfoUpdate,
-  ProgramOffering
+  ProgramOffering,
 } from "../shared/types";
+import type { SemesterTuitionBulkUpsertItem } from "@/types/organization.types";
 
 // ============================================
 // TYPES
@@ -70,11 +73,18 @@ export function AcademicInfoPanel() {
   const createMutation = useCreateOfferingAcademicInfo();
   const updateMutation = useUpdateOfferingAcademicInfo();
   const deleteMutation = useDeleteOfferingAcademicInfo();
+  const bulkUpsertMutation = useBulkUpsertSemesterTuitions();
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null);
   const [editingItem, setEditingItem] = useState<OfferingAcademicInfo | null>(null);
+  const [semesterTuitions, setSemesterTuitions] = useState<
+    SemesterTuitionBulkUpsertItem[]
+  >([]);
+  // After step-1 create succeeds but step-2 fails, remember the id so
+  // retry only re-runs semester upsert, not a duplicate create.
+  const [pendingCreatedId, setPendingCreatedId] = useState<number | null>(null);
   const [formData, setFormData] = useState<AcademicInfoFormData>({
     offering_id: null,
     academic_year: new Date().getFullYear(),
@@ -92,6 +102,8 @@ export function AcademicInfoPanel() {
       is_published: false,
     });
     setEditingItem(null);
+    setSemesterTuitions([]);
+    setPendingCreatedId(null);
   };
 
   const openCreateDialog = () => {
@@ -108,6 +120,13 @@ export function AcademicInfoPanel() {
       annual_admission_quota: item.annual_admission_quota || 0,
       is_published: item.is_published,
     });
+    setSemesterTuitions(
+      (item.semester_tuitions ?? []).map((st) => ({
+        semester_no: st.semester_no,
+        amount: Number(st.amount),
+        notes: st.notes ?? null,
+      }))
+    );
     setIsDialogOpen(true);
   };
 
@@ -128,8 +147,9 @@ export function AcademicInfoPanel() {
       return;
     }
 
-    // Check for duplicate year + offering combination (only on create)
-    if (!editingItem) {
+    // Check for duplicate year + offering combination (only on fresh create,
+    // NOT on retry after partial create where step-1 already succeeded).
+    if (!editingItem && !pendingCreatedId) {
       const duplicate = data.find(
         (item: OfferingAcademicInfo) =>
           item.offering_id === formData.offering_id &&
@@ -144,18 +164,24 @@ export function AcademicInfoPanel() {
     }
 
     try {
-      if (editingItem) {
+      // Step 1: Save academic info (skip if retrying after a prior
+      // step-2 failure — the record already exists).
+      let academicInfoId: number;
+
+      if (pendingCreatedId) {
+        academicInfoId = pendingCreatedId;
+      } else if (editingItem) {
         const updateData: OfferingAcademicInfoUpdate = {
           tuition_fee_per_year: formData.tuition_fee_per_year,
           annual_admission_quota: formData.annual_admission_quota,
           is_published: formData.is_published,
         };
-        await updateMutation.mutateAsync({
+        const result = await updateMutation.mutateAsync({
           id: editingItem.id,
           data: updateData,
         });
+        academicInfoId = result.id;
       } else {
-        // Validate required fields
         if (!formData.offering_id) {
           toast.error("Vui lòng chọn chương trình tuyển sinh");
           return;
@@ -168,8 +194,26 @@ export function AcademicInfoPanel() {
           annual_admission_quota: formData.annual_admission_quota,
           is_published: formData.is_published,
         };
-        await createMutation.mutateAsync(createData);
+        const result = await createMutation.mutateAsync(createData);
+        academicInfoId = result.id;
+        setPendingCreatedId(academicInfoId);
       }
+
+      // Step 2: Bulk upsert semester tuitions
+      try {
+        await bulkUpsertMutation.mutateAsync({
+          academicInfoId,
+          items: semesterTuitions,
+        });
+      } catch {
+        toast.error(
+          "Thông tin tuyển sinh đã lưu, nhưng học phí học kỳ chưa cập nhật. " +
+            "Vui lòng thử lại."
+        );
+        return;
+      }
+
+      setPendingCreatedId(null);
       setIsDialogOpen(false);
       resetForm();
     } catch {
@@ -362,7 +406,22 @@ export function AcademicInfoPanel() {
                         <Badge variant="outline">{item.academic_year}</Badge>
                       </TableCell>
                       <TableCell className="text-sm">
-                        {formatCurrency(item.tuition_fee_per_year)}
+                        {item.semester_tuitions && item.semester_tuitions.length > 0 ? (
+                          <>
+                            <span className="text-muted-foreground line-through text-xs">
+                              {formatCurrency(item.tuition_fee_per_year)}
+                            </span>
+                            <div className="text-xs mt-0.5">
+                              {item.semester_tuitions.map((st: { semester_no: number; amount: number }) => (
+                                <span key={st.semester_no} className="mr-1.5">
+                                  HK{st.semester_no}: {formatCurrency(st.amount)}
+                                </span>
+                              ))}
+                            </div>
+                          </>
+                        ) : (
+                          formatCurrency(item.tuition_fee_per_year)
+                        )}
                       </TableCell>
                       <TableCell>
                         <span className="text-sm font-medium">
@@ -505,7 +564,9 @@ export function AcademicInfoPanel() {
 
               <div className="space-y-2">
                 <Label htmlFor="tuition_fee_per_year">
-                  Học phí / Năm (VND)
+                  {semesterTuitions.length > 0
+                    ? "Học phí / Năm (giá trị cũ — tham khảo)"
+                    : "Học phí / Năm (VND)"}
                 </Label>
                 <Input
                   id="tuition_fee_per_year"
@@ -519,10 +580,27 @@ export function AcademicInfoPanel() {
                   }
                   placeholder="e.g., 25000000"
                   min={0}
+                  disabled={semesterTuitions.length > 0}
+                  className={semesterTuitions.length > 0 ? "bg-muted cursor-not-allowed" : ""}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Mức học phí niêm yết theo năm (VNĐ)
+                  {semesterTuitions.length > 0
+                    ? "Giá trị tham khảo. Học phí chính thức được nhập theo từng học kỳ bên dưới."
+                    : "Mức học phí niêm yết theo năm (VNĐ)"}
                 </p>
+              </div>
+
+              <div className="col-span-full rounded-lg border p-4">
+                <SemesterTuitionEditor
+                  value={semesterTuitions}
+                  onChange={setSemesterTuitions}
+                  durationSemesters={
+                    formData.offering_id
+                      ? offerings.find((o: ProgramOffering) => o.id === formData.offering_id)?.duration_semesters
+                      : null
+                  }
+                  disabled={createMutation.isPending || updateMutation.isPending || bulkUpsertMutation.isPending}
+                />
               </div>
 
               <div className="space-y-2">

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/shared/types.ts
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/shared/types.ts
@@ -334,6 +334,14 @@ export interface ScoringRules {
   required_education?: string; // "thpt", "cao_dang", "dai_hoc"
 }
 
+export interface SemesterTuition {
+  id: number;
+  academic_info_id: number;
+  semester_no: number;
+  amount: number;
+  notes?: string | null;
+}
+
 export interface OfferingAcademicInfo {
   id: number;
   offering_id: number;
@@ -344,6 +352,7 @@ export interface OfferingAcademicInfo {
   target_audience?: string;
   cutoff_score_previous_year?: number;
   applied_discount_policy_ids?: number[];
+  semester_tuitions?: SemesterTuition[];
   created_at: string;
   updated_at: string;
   // Computed fields from backend

--- a/frontend/src/components/admin/organization/OfferingAcademicInfoDialog.tsx
+++ b/frontend/src/components/admin/organization/OfferingAcademicInfoDialog.tsx
@@ -1,7 +1,7 @@
 // src/components/admin/organization/OfferingAcademicInfoDialog.tsx
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -33,11 +33,16 @@ import { Loader2, Save, SaveAll, Percent } from "lucide-react";
 import {
   useCreateOfferingAcademicInfo,
   useUpdateOfferingAcademicInfo,
+  useBulkUpsertSemesterTuitions,
 } from "@/hooks/useOrganization";
 import { useTuitionDiscountPolicies } from "@/hooks/useTuitionDiscount";
+import { SemesterTuitionEditor } from "./SemesterTuitionEditor";
+import { api } from "@/lib/api/client";
+import { API_ENDPOINTS } from "@/lib/api/endpoints";
 import type {
   OfferingAcademicInfo,
   ProgramOffering,
+  SemesterTuitionBulkUpsertItem,
 } from "@/types/organization.types";
 // NOTE: AdmissionCriterion removed - use Admission Configuration Console for criteria management
 // See: /admin/admission-config for the new admin UI
@@ -115,6 +120,17 @@ export function OfferingAcademicInfoDialog({
 
   const createMutation = useCreateOfferingAcademicInfo();
   const updateMutation = useUpdateOfferingAcademicInfo();
+  const bulkUpsertMutation = useBulkUpsertSemesterTuitions();
+
+  const [semesterTuitions, setSemesterTuitions] = useState<
+    SemesterTuitionBulkUpsertItem[]
+  >([]);
+  const [semesterSaveError, setSemesterSaveError] = useState<string | null>(null);
+  // After step-1 create succeeds but step-2 bulk upsert fails, we need
+  // to remember the created academic_info id so the retry only re-runs
+  // the semester upsert instead of creating a duplicate record.
+  const [pendingAcademicInfoId, setPendingAcademicInfoId] = useState<number | null>(null);
+  const hasSemesterTuitions = semesterTuitions.length > 0;
 
   const form = useForm<AcademicInfoFormValues>({
     resolver: zodResolver(academicInfoFormSchema),
@@ -135,63 +151,102 @@ export function OfferingAcademicInfoDialog({
     includeExpired: false,
   });
 
-  // NOTE: useFieldArray for admission_criteria REMOVED
-  // Use Admission Configuration Console for criteria management
+  // Initialize form + local state when dialog opens. Called from
+  // handleOpenChange on true transitions only — NOT from useEffect,
+  // to satisfy react-hooks/set-state-in-effect lint rule and to
+  // prevent query-invalidation re-renders from wiping retry state.
+  const initializeDialog = React.useCallback(() => {
+    form.clearErrors();
+    setSemesterSaveError(null);
+    setPendingAcademicInfoId(null);
 
-  // --- DATA LOADING & PARSING ---
-  useEffect(() => {
-    if (open) {
-      form.clearErrors(); // Reset lỗi cũ khi mở lại form
-
-      if (isEditMode && academicInfo) {
-        // --- EDIT MODE ---
-        // NOTE: admission_criteria parsing REMOVED - use Admission Config Console
-
-        // 🛡️ CRITICAL FIX: Ép kiểu dữ liệu từ API (Decimal/String -> Number)
-        form.reset({
-          academic_year: Number(academicInfo.academic_year),
-          tuition_fee_per_year:
-            academicInfo.tuition_fee_per_year !== null
-              ? Number(academicInfo.tuition_fee_per_year)
-              : null,
-          annual_admission_quota:
-            academicInfo.annual_admission_quota !== null
-              ? Number(academicInfo.annual_admission_quota)
-              : null,
-          cutoff_score_previous_year:
-            academicInfo.cutoff_score_previous_year !== null
-              ? Number(academicInfo.cutoff_score_previous_year)
-              : null,
-          target_audience: academicInfo.target_audience || "",
-          applied_discount_policy_ids: academicInfo.applied_discount_policy_ids || [],
-          is_published: academicInfo.is_published,
-        });
-      } else {
-        // --- CREATE MODE ---
-        // Gợi ý năm tiếp theo chưa có trong danh sách
-        let nextYear = currentYear;
-        while (existingYears.includes(nextYear)) {
-          nextYear++;
-        }
-
-        form.reset({
-          academic_year: nextYear,
-          tuition_fee_per_year: null,
-          annual_admission_quota: null,
-          target_audience: "",
-          cutoff_score_previous_year: null,
-          applied_discount_policy_ids: [],
-          is_published: false,
-        });
-      }
+    if (isEditMode && academicInfo?.semester_tuitions) {
+      setSemesterTuitions(
+        academicInfo.semester_tuitions.map((st) => ({
+          semester_no: st.semester_no,
+          amount: Number(st.amount),
+          notes: st.notes ?? null,
+        }))
+      );
+    } else {
+      setSemesterTuitions([]);
     }
-  }, [open, isEditMode, academicInfo, form, existingYears, currentYear]);
+
+    if (isEditMode && academicInfo) {
+      form.reset({
+        academic_year: Number(academicInfo.academic_year),
+        tuition_fee_per_year:
+          academicInfo.tuition_fee_per_year !== null
+            ? Number(academicInfo.tuition_fee_per_year)
+            : null,
+        annual_admission_quota:
+          academicInfo.annual_admission_quota !== null
+            ? Number(academicInfo.annual_admission_quota)
+            : null,
+        cutoff_score_previous_year:
+          academicInfo.cutoff_score_previous_year !== null
+            ? Number(academicInfo.cutoff_score_previous_year)
+            : null,
+        target_audience: academicInfo.target_audience || "",
+        applied_discount_policy_ids: academicInfo.applied_discount_policy_ids || [],
+        is_published: academicInfo.is_published,
+      });
+    } else {
+      let nextYear = currentYear;
+      while (existingYears.includes(nextYear)) {
+        nextYear++;
+      }
+      form.reset({
+        academic_year: nextYear,
+        tuition_fee_per_year: null,
+        annual_admission_quota: null,
+        target_audience: "",
+        cutoff_score_previous_year: null,
+        applied_discount_policy_ids: [],
+        is_published: false,
+      });
+    }
+  }, [isEditMode, academicInfo, form, existingYears, currentYear]);
+
+  // Intercept dialog open/close to run initialization on open
+  // transitions without using useEffect + setState (which violates
+  // react-hooks/set-state-in-effect). The parent controls `open` via
+  // onOpenChange; we wrap it to run init on the true→ path.
+  const prevOpenRef = React.useRef(false);
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen && !prevOpenRef.current) {
+        initializeDialog();
+      }
+      prevOpenRef.current = nextOpen;
+      onOpenChange(nextOpen);
+    },
+    [initializeDialog, onOpenChange]
+  );
+
+  // Also init on mount if dialog starts open (parent opens it by
+  // setting open=true before this component mounts).
+  React.useEffect(() => {
+    if (open && !prevOpenRef.current) {
+      prevOpenRef.current = true;
+      // Defer to next microtask so React commits current render first,
+      // avoiding synchronous setState during render.
+      queueMicrotask(initializeDialog);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const [saveAction, setSaveAction] = useState<"close" | "continue">("close");
 
   const onSubmit = async (values: AcademicInfoFormValues) => {
-    // 🛡️ CLIENT-SIDE VALIDATION: Unique Year Constraint
-    if (!isEditMode && existingYears.includes(values.academic_year)) {
+    // Skip duplicate-year check when retrying after a partial create
+    // (step-1 succeeded, step-2 failed). The record already exists
+    // and query invalidation may have added it to existingYears.
+    if (
+      !isEditMode &&
+      !pendingAcademicInfoId &&
+      existingYears.includes(values.academic_year)
+    ) {
       form.setError("academic_year", {
         type: "manual",
         message: `Thông tin tuyển sinh năm ${values.academic_year} đã tồn tại. Vui lòng chọn năm khác hoặc chỉnh sửa bản ghi cũ.`,
@@ -199,47 +254,98 @@ export function OfferingAcademicInfoDialog({
       return;
     }
 
-    try {
-      let resultData: OfferingAcademicInfo;
+    setSemesterSaveError(null);
 
-      if (isEditMode && academicInfo) {
-        // Update logic
-        resultData = await updateMutation.mutateAsync({
+    try {
+      // Step 1: Save academic info (skip if we already created it on a
+      // previous attempt and only the semester upsert failed).
+      let academicInfoId: number;
+
+      if (pendingAcademicInfoId) {
+        // Retry path: step 1 already succeeded on a prior submit, the
+        // record exists with this id. Only re-run step 2.
+        academicInfoId = pendingAcademicInfoId;
+      } else if (isEditMode && academicInfo) {
+        const resultData = await updateMutation.mutateAsync({
           id: academicInfo.id,
           data: values,
         });
+        academicInfoId = resultData.id;
       } else {
-        // Create logic
-        resultData = await createMutation.mutateAsync({
+        const resultData = await createMutation.mutateAsync({
           offeringId: offering.id,
           offering_id: offering.id,
           ...values,
         });
+        academicInfoId = resultData.id;
+        // Remember the created id in case step 2 fails and we need to
+        // retry without re-creating.
+        setPendingAcademicInfoId(academicInfoId);
       }
 
-      // ✅ Gọi callback thay vì tự đóng
-      if (onSaveSuccess) {
-        onSaveSuccess(resultData, saveAction === "close");
-      } else {
-        // Fallback nếu không có callback (logic cũ)
-        onOpenChange(false);
+      // Step 2: Bulk upsert semester tuitions
+      try {
+        await bulkUpsertMutation.mutateAsync({
+          academicInfoId,
+          items: semesterTuitions,
+        });
+      } catch (semError) {
+        setSemesterSaveError(
+          "Thông tin tuyển sinh đã lưu, nhưng học phí học kỳ chưa cập nhật. " +
+            "Vui lòng thử lại."
+        );
+        console.error("Semester tuition save failed:", semError);
+        return;
       }
-      // Nếu "Lưu & Tiếp tục", ta reset form với dữ liệu mới nhất từ Server
-      // để đảm bảo form clean (isDirty = false)
-      if (saveAction === "continue") {
-        // Logic reset form sẽ được useEffect xử lý khi prop `academicInfo` thay đổi
-        // nhờ hàm handleSaveSuccess ở component cha.
+
+      // Step 2 succeeded — clear the pending id so it does not leak
+      // into a subsequent dialog open.
+      setPendingAcademicInfoId(null);
+
+      // Step 3: Refetch the academic info with nested semester_tuitions
+      // so onSaveSuccess receives a complete object.
+      let freshData: OfferingAcademicInfo | undefined;
+      try {
+        const { data: infos } = await api.get<OfferingAcademicInfo[]>(
+          API_ENDPOINTS.ORGANIZATION.LIST_ACADEMIC_INFO(offering.id)
+        );
+        freshData = infos.find((i) => i.id === academicInfoId);
+      } catch {
+        // Refetch failed — parent will pick up fresh data on next
+        // query invalidation cycle.
+      }
+
+      // Step 4: Notify parent with fresh data (or minimal fallback)
+      const dataForCallback: OfferingAcademicInfo = freshData ?? {
+        id: academicInfoId,
+        offering_id: offering.id,
+        academic_year: values.academic_year,
+        is_published: values.is_published,
+        is_deleted: false,
+        semester_tuitions: semesterTuitions.map((st, i) => ({
+          id: -(i + 1),
+          academic_info_id: academicInfoId,
+          ...st,
+        })),
+      };
+
+      if (onSaveSuccess) {
+        onSaveSuccess(dataForCallback, saveAction === "close");
+      } else {
+        handleOpenChange(false);
       }
     } catch (error) {
       console.error("Form submission failed:", error);
-      // Error toast handled in hooks
     }
   };
 
-  const isSubmitting = createMutation.isPending || updateMutation.isPending;
+  const isSubmitting =
+    createMutation.isPending ||
+    updateMutation.isPending ||
+    bulkUpsertMutation.isPending;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[800px]">
         <DialogHeader>
           <DialogTitle>
@@ -290,25 +396,41 @@ export function OfferingAcademicInfoDialog({
             />
 
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              {/* Tuition Fee */}
+              {/* Tuition Fee (legacy — read-only when semester tuitions exist) */}
               <FormField
                 control={form.control}
                 name="tuition_fee_per_year"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Học phí/năm</FormLabel>
+                    <FormLabel>
+                      {hasSemesterTuitions
+                        ? "Học phí/năm (giá trị cũ — tham khảo)"
+                        : "Học phí/năm"}
+                    </FormLabel>
                     <FormControl>
                       <CurrencyInput
                         value={field.value}
                         onChange={field.onChange}
                         placeholder="VD: 15.000.000"
-                        // 🛡️ Disable nếu là năm quá khứ
-                        disabled={isSubmitting || (isEditMode && isPastYear)}
+                        disabled={
+                          isSubmitting ||
+                          (isEditMode && isPastYear) ||
+                          hasSemesterTuitions
+                        }
                         currency="VND"
                         locale="vi-VN"
-                        className={isEditMode && isPastYear ? "bg-muted cursor-not-allowed" : ""}
+                        className={
+                          (isEditMode && isPastYear) || hasSemesterTuitions
+                            ? "bg-muted cursor-not-allowed"
+                            : ""
+                        }
                       />
                     </FormControl>
+                    {hasSemesterTuitions && (
+                      <FormDescription>
+                        Giá trị tham khảo. Học phí chính thức được nhập theo từng học kỳ bên dưới.
+                      </FormDescription>
+                    )}
                     <FormMessage />
                   </FormItem>
                 )}
@@ -407,6 +529,19 @@ export function OfferingAcademicInfoDialog({
               )}
             />
 
+            {/* Semester Tuition Editor (PR 2 — ADR-002) */}
+            <div className="rounded-lg border p-4">
+              <SemesterTuitionEditor
+                value={semesterTuitions}
+                onChange={setSemesterTuitions}
+                durationSemesters={offering.duration_semesters}
+                disabled={isSubmitting || (isEditMode && isPastYear)}
+              />
+              {semesterSaveError && (
+                <p className="mt-2 text-sm text-destructive">{semesterSaveError}</p>
+              )}
+            </div>
+
             {/* Target Audience */}
             <FormField
               control={form.control}
@@ -487,7 +622,7 @@ export function OfferingAcademicInfoDialog({
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => onOpenChange(false)}
+                onClick={() => handleOpenChange(false)}
                 disabled={isSubmitting}
               >
                 Hủy

--- a/frontend/src/components/admin/organization/OfferingAcademicInfoManagement.tsx
+++ b/frontend/src/components/admin/organization/OfferingAcademicInfoManagement.tsx
@@ -344,9 +344,24 @@ export function OfferingAcademicInfoManagement({
                             <TableCell>
                               <div className="flex items-center gap-2">
                                 <DollarSign className="text-muted-foreground h-4 w-4" />
-                                <span className="text-sm">
-                                  {formatCurrency(info.tuition_fee_per_year)}
-                                </span>
+                                <div className="text-sm">
+                                  {info.semester_tuitions && info.semester_tuitions.length > 0 ? (
+                                    <>
+                                      <span className="text-muted-foreground line-through">
+                                        {formatCurrency(info.tuition_fee_per_year)}
+                                      </span>
+                                      <div className="mt-0.5 text-xs">
+                                        {info.semester_tuitions.map((st) => (
+                                          <span key={st.semester_no} className="mr-2">
+                                            HK{st.semester_no}: {formatCurrency(st.amount)}
+                                          </span>
+                                        ))}
+                                      </div>
+                                    </>
+                                  ) : (
+                                    <span>{formatCurrency(info.tuition_fee_per_year)}</span>
+                                  )}
+                                </div>
                               </div>
                             </TableCell>
                             <TableCell>

--- a/frontend/src/components/admin/organization/SemesterTuitionEditor.tsx
+++ b/frontend/src/components/admin/organization/SemesterTuitionEditor.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Trash2, Wand2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { CurrencyInput } from "@/components/ui/currency-input";
+import type { SemesterTuitionBulkUpsertItem } from "@/types/organization.types";
+
+interface SemesterTuitionEditorProps {
+  value: SemesterTuitionBulkUpsertItem[];
+  onChange: (items: SemesterTuitionBulkUpsertItem[]) => void;
+  durationSemesters?: number | null;
+  disabled?: boolean;
+}
+
+export function SemesterTuitionEditor({
+  value,
+  onChange,
+  durationSemesters,
+  disabled = false,
+}: SemesterTuitionEditorProps) {
+  const [errors, setErrors] = useState<Record<number, string>>({});
+
+  const nextSemesterNo = () => {
+    if (value.length === 0) return 1;
+    return Math.max(...value.map((v) => v.semester_no)) + 1;
+  };
+
+  const addRow = () => {
+    const next = nextSemesterNo();
+    onChange([...value, { semester_no: next, amount: 0 }]);
+  };
+
+  const removeRow = (index: number) => {
+    const updated = value.filter((_, i) => i !== index);
+    onChange(updated);
+    setErrors((prev) => {
+      const copy = { ...prev };
+      delete copy[index];
+      return copy;
+    });
+  };
+
+  const updateRow = (
+    index: number,
+    field: keyof SemesterTuitionBulkUpsertItem,
+    val: number | string | null
+  ) => {
+    const updated = value.map((item, i) => {
+      if (i !== index) return item;
+      return { ...item, [field]: val };
+    });
+
+    const newErrors: Record<number, string> = {};
+    const semNos = updated.map((r) => r.semester_no);
+    const seen = new Set<number>();
+    for (let i = 0; i < semNos.length; i++) {
+      if (semNos[i] < 1) {
+        newErrors[i] = "Phải >= 1";
+      } else if (seen.has(semNos[i])) {
+        newErrors[i] = "Trùng lặp";
+      }
+      seen.add(semNos[i]);
+    }
+    setErrors(newErrors);
+    onChange(updated);
+  };
+
+  const autoPopulate = () => {
+    if (!durationSemesters || durationSemesters < 1) return;
+    const existingSemesters = new Set(value.map((v) => v.semester_no));
+    const newItems: SemesterTuitionBulkUpsertItem[] = [...value];
+    for (let i = 1; i <= durationSemesters; i++) {
+      if (!existingSemesters.has(i)) {
+        newItems.push({ semester_no: i, amount: 0 });
+      }
+    }
+    newItems.sort((a, b) => a.semester_no - b.semester_no);
+    onChange(newItems);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium">
+          Bảng học phí theo học kỳ
+        </h4>
+        <div className="flex gap-2">
+          {durationSemesters && durationSemesters > 0 && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={autoPopulate}
+              disabled={disabled}
+            >
+              <Wand2 className="mr-1.5 h-3.5 w-3.5" />
+              Tạo nhanh ({durationSemesters} HK)
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addRow}
+            disabled={disabled}
+          >
+            <Plus className="mr-1.5 h-3.5 w-3.5" />
+            Thêm học kỳ
+          </Button>
+        </div>
+      </div>
+
+      {value.length === 0 ? (
+        <p className="text-muted-foreground text-sm italic">
+          Chưa có học phí theo học kỳ. Nhấn &quot;Thêm học kỳ&quot; hoặc
+          &quot;Tạo nhanh&quot; để bắt đầu.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          <div className="grid grid-cols-[80px_1fr_1fr_40px] gap-2 text-xs font-medium text-muted-foreground px-1">
+            <span>Học kỳ</span>
+            <span>Học phí (VND)</span>
+            <span>Ghi chú</span>
+            <span />
+          </div>
+          {value.map((item, index) => (
+            <div
+              key={index}
+              className="grid grid-cols-[80px_1fr_1fr_40px] gap-2 items-start"
+            >
+              <div>
+                <Input
+                  type="number"
+                  min={1}
+                  value={item.semester_no}
+                  onChange={(e) =>
+                    updateRow(index, "semester_no", parseInt(e.target.value) || 1)
+                  }
+                  disabled={disabled}
+                  className={errors[index] ? "border-destructive" : ""}
+                />
+                {errors[index] && (
+                  <p className="text-destructive text-xs mt-0.5">
+                    {errors[index]}
+                  </p>
+                )}
+              </div>
+              <CurrencyInput
+                value={item.amount}
+                onChange={(val) => updateRow(index, "amount", val ?? 0)}
+                disabled={disabled}
+                currency="VND"
+                locale="vi-VN"
+                placeholder="0"
+              />
+              <Input
+                value={item.notes ?? ""}
+                onChange={(e) =>
+                  updateRow(index, "notes", e.target.value || null)
+                }
+                disabled={disabled}
+                placeholder="Ghi chú (tùy chọn)"
+                maxLength={500}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => removeRow(index)}
+                disabled={disabled}
+                className="h-9 w-9 text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {Object.keys(errors).length > 0 && (
+        <p className="text-destructive text-xs">
+          Vui lòng sửa lỗi ở các hàng được đánh dấu trước khi lưu.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useOrganization.ts
+++ b/frontend/src/hooks/useOrganization.ts
@@ -22,6 +22,8 @@ import type {
   OfferingAcademicInfo,
   OfferingAcademicInfoCreate,
   OfferingAcademicInfoUpdate,
+  SemesterTuition,
+  SemesterTuitionBulkUpsertItem,
 
   // System Configuration
   ConfigDegreeLevel,
@@ -74,6 +76,11 @@ export const organizationKeys = {
     [...organizationKeys.academicInfo(), "list", offeringId, { publishedOnly }] as const,
   academicInfoByYear: (offeringId: number, year: number) =>
     [...organizationKeys.academicInfo(), "year", offeringId, year] as const,
+
+  // Tier 3.5: SemesterTuition (PR 2 — ADR-002)
+  semesterTuitions: () => [...organizationKeys.all, "semesterTuitions"] as const,
+  semesterTuitionList: (academicInfoId: number) =>
+    [...organizationKeys.semesterTuitions(), "list", academicInfoId] as const,
 };
 
 // =====================================================================
@@ -1108,6 +1115,67 @@ export function useDeleteSkillRule() {
         ? detail.map((item) => item.msg).join(", ")
         : detail || "Failed to delete skill rule";
       toast.error(message);
+    },
+  });
+}
+
+// =====================================================================
+// SEMESTER TUITION — PR 2 (ADR-002)
+// =====================================================================
+
+export function useSemesterTuitions(academicInfoId: number | null) {
+  return useQuery<SemesterTuition[], AxiosError<ApiErrorResponse>>({
+    queryKey: organizationKeys.semesterTuitionList(academicInfoId!),
+    queryFn: async () => {
+      const { data } = await api.get<SemesterTuition[]>(
+        API_ENDPOINTS.ADMIN.ORGANIZATION.LIST_SEMESTER_TUITIONS(academicInfoId!)
+      );
+      return data;
+    },
+    enabled: !!academicInfoId,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export function useBulkUpsertSemesterTuitions() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    SemesterTuition[],
+    AxiosError<ApiErrorResponse>,
+    { academicInfoId: number; items: SemesterTuitionBulkUpsertItem[] }
+  >({
+    mutationFn: async ({ academicInfoId, items }) => {
+      const { data } = await api.put<SemesterTuition[]>(
+        API_ENDPOINTS.ADMIN.ORGANIZATION.BULK_UPSERT_SEMESTER_TUITIONS(
+          academicInfoId
+        ),
+        { items }
+      );
+      return data;
+    },
+    onSuccess: (_, variables) => {
+      toast.success("Đã lưu học phí theo học kỳ!");
+      queryClient.invalidateQueries({
+        queryKey: organizationKeys.semesterTuitionList(variables.academicInfoId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: organizationKeys.academicInfo(),
+      });
+      // AcademicInfoPanel (admission-config route) reads from a
+      // separate query tree ["academic-infos"] via useProgramData.ts.
+      // Invalidate that family too so the table refreshes with the
+      // latest nested semester_tuitions after save.
+      queryClient.invalidateQueries({
+        queryKey: ["academic-infos"],
+      });
+    },
+    onError: (error) => {
+      const detail = error.response?.data?.detail;
+      const message =
+        typeof detail === "string"
+          ? detail
+          : "Lưu học phí học kỳ thất bại";
+      toast.error("Lỗi", { description: message });
     },
   });
 }

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -112,6 +112,12 @@ export const API_ENDPOINTS = {
       RESTORE_ACADEMIC_INFO: (academicInfoId: number) =>
         `/api/admin/academic-info/${academicInfoId}/restore`,
 
+      // Tier 3.5: OfferingSemesterTuition (PR 2 — ADR-002)
+      LIST_SEMESTER_TUITIONS: (academicInfoId: number) =>
+        `/api/admin/academic-info/${academicInfoId}/semester-tuitions`,
+      BULK_UPSERT_SEMESTER_TUITIONS: (academicInfoId: number) =>
+        `/api/admin/academic-info/${academicInfoId}/semester-tuitions`,
+
       // === LEGACY (DEPRECATED) ===
     },
     // System Configuration

--- a/frontend/src/types/organization.types.ts
+++ b/frontend/src/types/organization.types.ts
@@ -16,7 +16,7 @@ export interface OfferingAcademicInfo {
   id: number;
   offering_id: number; // Foreign key to ProgramOffering (Tier 2)
   academic_year: number; // Năm học (vd: 2025)
-  tuition_fee_per_year?: number | null; // Học phí/năm
+  tuition_fee_per_year?: number | null; // Học phí/năm (deprecated compat — ADR-002)
   annual_admission_quota?: number | null; // Chỉ tiêu tuyển sinh
   is_published: boolean; // Trạng thái công khai
   is_deleted: boolean; // Soft delete flag - NEVER hard delete financial/historical data
@@ -25,11 +25,35 @@ export interface OfferingAcademicInfo {
   cutoff_score_previous_year?: number | null; // Điểm chuẩn năm trước
   applied_discount_policy_ids?: number[] | null; // Danh sách ID chính sách ưu đãi áp dụng
 
+  // PR 2 (ADR-002): per-semester tuition, nested from backend response
+  semester_tuitions?: SemesterTuition[];
+
   // Audit trail
   created_at?: string | null;
   updated_at?: string | null;
   created_by_user_id?: number | null;
   updated_by_user_id?: number | null;
+}
+
+/**
+ * Semester tuition row — per-semester tuition catalog (PR 2, ADR-002)
+ */
+export interface SemesterTuition {
+  id: number;
+  academic_info_id: number;
+  semester_no: number;
+  amount: number;
+  notes?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  created_by_user_id?: number | null;
+  updated_by_user_id?: number | null;
+}
+
+export interface SemesterTuitionBulkUpsertItem {
+  semester_no: number;
+  amount: number;
+  notes?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

PR 2 of the **Semester Tuition Refactor** epic. Admin configuration backend + frontend so admins can input per-semester tuition (HK1..HKn) instead of a single annual `tuition_fee_per_year`.

Per ADR-002 Deferred Decision D4 (admin config UI), D5 (discount invalidation mirror).

## Commits

1. **`4abc548b`** — Backend: CRUD API for `offering_semester_tuition` rows (5 endpoints, service layer, repository eager loading, discount invalidation hook point)
2. **`690888be`** — Frontend: `SemesterTuitionEditor` component + integration in both admin surfaces + React Query hooks

## Backend scope (Batch A)

**5 admin endpoints** under `/api/admin`:

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/academic-info/{id}/semester-tuitions` | List |
| POST | `/academic-info/{id}/semester-tuitions` | Create single |
| PATCH | `/semester-tuitions/{id}` | Update single |
| DELETE | `/semester-tuitions/{id}` | Delete single |
| PUT | `/academic-info/{id}/semester-tuitions` | **Bulk upsert (primary)** |

Bulk upsert is replace-all: `items=[]` clears all rows (fall back to legacy `tuition_fee_per_year`).

**Service layer**:
- IDOR check via `_check_unit_access` (returns 404 not 403)
- Soft-delete guard: rejects ops on `is_deleted=True` parents
- Immutability guard: blocks edits on past-year academic info
- Post-commit: `invalidate_org_cache()` + Socket.IO `data_updated` event
- ADR-002 Decision 4 hook point (`_invalidate_semester_tuition_dependents`) documented for PR 3

**Repository**: `selectinload(semester_tuitions)` added to all academic-info query paths including nested offering/program/unit tree queries.

**Schemas**: 7 Pydantic models + `semester_tuitions[]` nested in `OfferingAcademicInfo` response.

## Frontend scope (Batch B)

**New component**: `SemesterTuitionEditor.tsx` — inline grid with semester_no, CurrencyInput, notes, add/remove/auto-populate.

**OfferingAcademicInfoDialog** (organization admin route):
- SemesterTuitionEditor integrated below tuition field
- `tuition_fee_per_year` becomes read-only when semester rows exist
- 4-step save: academic info -> bulk upsert -> refetch with nested `semester_tuitions` -> `onSaveSuccess(freshData)`. Fixes "Luu & Tiep tuc" stale-data bug.
- Partial success: step 2 fail keeps dialog open for retry

**AcademicInfoPanel** (admission-config route):
- Same SemesterTuitionEditor + bulk upsert wired into inline dialog
- Step 2 fail: dialog stays open, preserves semester data for retry
- `tuition_fee_per_year` disabled when semester rows exist

**Table views** (both surfaces): semester tuition breakdown (`HK1: 8M | HK2: 7M`) with struck-through legacy value.

**Query invalidation**: `useBulkUpsertSemesterTuitions` invalidates both `organizationKeys.academicInfo()` and `["academic-infos"]` families so both admin routes refresh correctly.

## `tuition_fee_per_year` transition

- Stays in DB and API (deprecated compat field per ADR-002 Decision 5)
- UI: read-only when semester tuitions exist, editable when empty
- No automatic derivation (ADR-002 explicitly prohibits)
- Label changes to "gia tri cu — tham khao" when semester rows present

## Files changed — 13

### Backend (5)
- `app/schemas/organization.py` — 7 new Pydantic schemas
- `app/schemas/__init__.py` — re-exports
- `app/services/organization_service.py` — 5 CRUD functions + 3 helpers (~210 lines)
- `app/repositories/organization_repository.py` — `selectinload` at 8+ query sites
- `app/routers/admin/organization.py` — 5 endpoints

### Frontend (8)
- `src/types/organization.types.ts` — `SemesterTuition` + `SemesterTuitionBulkUpsertItem`
- `src/app/.../shared/types.ts` — `SemesterTuition` interface
- `src/lib/api/endpoints.ts` — 2 endpoint constants
- `src/hooks/useOrganization.ts` — query keys + 2 hooks
- `src/components/.../SemesterTuitionEditor.tsx` — **NEW** (189 lines)
- `src/components/.../OfferingAcademicInfoDialog.tsx` — editor integration + 4-step save
- `src/components/.../OfferingAcademicInfoManagement.tsx` — table display
- `src/app/.../AcademicInfoPanel.tsx` — editor integration + bulk upsert + table display

## Verification

**Backend**:
- [x] Bulk upsert create/update/clear-all: pass
- [x] Soft-deleted parent -> 404: pass
- [x] Eager loading direct + nested: pass
- [x] Cache invalidation + Socket.IO: pass
- [x] IDOR enforcement: pass

**Frontend**:
- [x] TypeScript: 0 errors (`tsc --noEmit`)
- [x] AcademicInfoPanel.test.tsx: 9/9 pass
- [ ] Browser test: admin creates academic info with HK1-HK3, saves, re-opens, data persists
- [ ] Browser test: "Luu & Tiep tuc" preserves semester rows after save
- [ ] Browser test: legacy record with no semester tuitions still editable

## Not in scope

- `fee_calculation_service.py` (PR 3)
- Admission gate logic (PR 4)
- Public API additive fields (PR 6)
- KPI relabeling (PR 7)
- Alembic migration (table exists from PR 1)
- Discount recalculation logic (PR 3 — PR 2 only adds hook point)

## Roadmap

| PR | Phase | Status |
|---|---|---|
| PR 0 (#111) | Spec / ADR | **MERGED** |
| PR 1 (#113) | Schema + compat patch | **MERGED** |
| PR A (#114) | Ember payment event parity | **MERGED** |
| **PR 2 (this)** | Admin config backend + frontend | Ready for review |
| PR 3 | Finance core refactor | Not started |
| PR 4 | Admission clearance model | Not started |
| PR 5 | Pipeline / event semantics | Not started |
| PR 6 | Public / admin contract | Not started |
| PR 7 | KPI / analytics | Not started |
| PR 8 | Event rewrite on new model | Not started |
