### PR TITLE
feat(finance): PR 3 — semester-aware fee calculation + discount recalculation

### DIFF
--- a/Backend_FastAPI/app/models/finance/installment_plan.py
+++ b/Backend_FastAPI/app/models/finance/installment_plan.py
@@ -13,7 +13,7 @@ Default Plans (seeded):
 - TWO_TERM: Two payments (50% each)
 - QUARTERLY: Four payments (25% each)
 """
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
@@ -126,7 +126,11 @@ class InstallmentPlan(Base):
     def __repr__(self) -> str:
         return f"<InstallmentPlan {self.code}: {self.installment_count} installments>"
 
-    def get_installment_schedule(self, total_amount: Decimal) -> List[Dict[str, Any]]:
+    def get_installment_schedule(
+        self,
+        total_amount: Decimal,
+        anchor_date: Optional[date] = None,
+    ) -> List[Dict[str, Any]]:
         """
         Calculate actual amounts for each installment based on total fee.
 
@@ -134,38 +138,50 @@ class InstallmentPlan(Base):
 
         Args:
             total_amount: Total fee amount
+            anchor_date: Optional reference date for computing due_date per
+                installment. When provided, each item gains a ``due_date``
+                field = ``anchor_date + timedelta(days=due_days_offset)``.
+                When None (default), output is unchanged from prior behavior
+                (backward compat). Per ADR-002 Decision 3: for HK1 the
+                anchor_date is the admission approval timestamp; for HK2+
+                it is the semester start date.
 
         Returns:
             List of installment details with calculated amounts
         """
         if self.installment_count == 1:
-            return [{
+            entry: Dict[str, Any] = {
                 "installment_no": 1,
                 "amount": total_amount,
                 "due_days_offset": 0,
-                "percent": Decimal("100.0")
-            }]
+                "percent": Decimal("100.0"),
+            }
+            if anchor_date is not None:
+                entry["due_date"] = anchor_date.isoformat()
+            return [entry]
 
         result = []
         cumulative = Decimal("0")
 
         for i, item in enumerate(self.schedule):
             if i < len(self.schedule) - 1:
-                # Normal installment: calculate based on percentage
                 amount = (total_amount * Decimal(str(item.get("percent", 0))) / 100).quantize(
                     Decimal("1")  # Round to VND
                 )
             else:
-                # Last installment: take remainder to ensure exact total
                 amount = total_amount - cumulative
 
+            offset = item.get("due_days_offset", 0)
             cumulative += amount
-            result.append({
+            entry = {
                 "installment_no": item.get("installment_no", i + 1),
                 "amount": amount,
-                "due_days_offset": item.get("due_days_offset", 0),
+                "due_days_offset": offset,
                 "percent": Decimal(str(item.get("percent", 0))),
-                "description": item.get("description", f"Đợt {i + 1}")
-            })
+                "description": item.get("description", f"Đợt {i + 1}"),
+            }
+            if anchor_date is not None:
+                entry["due_date"] = (anchor_date + timedelta(days=offset)).isoformat()
+            result.append(entry)
 
         return result

--- a/Backend_FastAPI/app/repositories/fee_repository.py
+++ b/Backend_FastAPI/app/repositories/fee_repository.py
@@ -289,37 +289,57 @@ class FeeRepository(BaseRepository[Fee]):
         profile_id: int,
         fee_type: str,
         academic_year: Union[str, int],
-        exclude_id: Optional[int] = None
+        semester_no: Optional[int] = None,
+        exclude_id: Optional[int] = None,
     ) -> bool:
         """
-        Check if a fee already exists for profile/type/year.
+        Check if a fee already exists.
+
+        For tuition fees (when ``semester_no`` is provided), checks the
+        semester-aware tuple ``(profile, fee_type, semester_no)`` which
+        matches the partial unique index ``uq_fee_profile_type_semester_tuition``.
+
+        For non-tuition fees (``semester_no=None``), keeps the legacy
+        year-based tuple ``(profile, fee_type, academic_year)`` which
+        matches ``uq_fee_profile_type_year_nontuition``.
 
         Args:
             profile_id: Admission profile ID
             fee_type: Fee type
             academic_year: Academic year (e.g., "2025" or 2025)
+            semester_no: Semester number for tuition fees (None for non-tuition)
             exclude_id: Exclude this fee ID from check (for updates)
 
         Returns:
             True if duplicate exists
         """
-        # Convert string academic_year to int (model stores as Integer)
-        if isinstance(academic_year, str):
-            # Handle formats like "2024-2025" by taking the first year
-            academic_year_int = int(academic_year.split("-")[0])
-        else:
-            academic_year_int = academic_year
-
-        query = (
-            select(func.count(Fee.id))
-            .where(
-                and_(
-                    Fee.admission_profile_id == profile_id,
-                    Fee.fee_type == fee_type,
-                    Fee.academic_year == academic_year_int,
+        if fee_type == "tuition" and semester_no is not None:
+            query = (
+                select(func.count(Fee.id))
+                .where(
+                    and_(
+                        Fee.admission_profile_id == profile_id,
+                        Fee.fee_type == fee_type,
+                        Fee.semester_no == semester_no,
+                    )
                 )
             )
-        )
+        else:
+            if isinstance(academic_year, str):
+                academic_year_int = int(academic_year.split("-")[0])
+            else:
+                academic_year_int = academic_year
+
+            query = (
+                select(func.count(Fee.id))
+                .where(
+                    and_(
+                        Fee.admission_profile_id == profile_id,
+                        Fee.fee_type == fee_type,
+                        Fee.academic_year == academic_year_int,
+                    )
+                )
+            )
 
         if exclude_id is not None:
             query = query.where(Fee.id != exclude_id)

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -130,6 +130,7 @@ async def list_fees(
             id=fee.id,
             fee_type=fee.fee_type,
             academic_year=f"{fee.academic_year}-{fee.academic_year + 1}",
+            semester_no=fee.semester_no,
             final_amount=fee.final_amount,
             paid_amount=fee.paid_amount,
             remaining_amount=fee.remaining_amount,
@@ -193,33 +194,61 @@ async def calculate_fee(
         if not profile:
             raise ResourceNotFoundError("Admission profile not found")
 
-        # Get base amount from offering's tuition fee
+        # Resolve base_amount + discount_policy_ids depending on fee type.
+        # For tuition: service looks up amount from offering_semester_tuition
+        # (PR 3 — ADR-002). Router only needs discount policy IDs.
+        # For non-tuition: keep existing path via academic_info.tuition_fee_per_year.
         base_amount = Decimal("0")
+        discount_policy_ids: list = []
         academic_info = None
-        oac = profile.offering_admission_config
-        if oac and oac.academic_info:
-            academic_info = oac.academic_info
 
-        # Fallback: lookup via applied_rules.academic_info_id (for profiles created before OAC linkage)
-        if not academic_info and profile.applied_rules:
-            ai_id = profile.applied_rules.get("academic_info_id")
-            if ai_id:
-                from app.models.offering_academic_info import OfferingAcademicInfo
-                ai_result = await db.execute(
-                    sa.select(OfferingAcademicInfo).where(OfferingAcademicInfo.id == int(ai_id))
+        if data.fee_type != FeeTypeEnum.tuition:
+            # Non-tuition: existing path — look up from academic_info
+            oac = profile.offering_admission_config
+            if oac and oac.academic_info:
+                academic_info = oac.academic_info
+
+            if not academic_info and profile.applied_rules:
+                ai_id = profile.applied_rules.get("academic_info_id")
+                if ai_id:
+                    from app.models.offering_academic_info import OfferingAcademicInfo
+                    ai_result = await db.execute(
+                        sa.select(OfferingAcademicInfo).where(
+                            OfferingAcademicInfo.id == int(ai_id)
+                        )
+                    )
+                    academic_info = ai_result.scalars().first()
+
+            if academic_info:
+                base_amount = academic_info.tuition_fee_per_year or Decimal("0")
+
+            if base_amount <= 0:
+                raise BadRequest(
+                    "Cannot calculate fee: No fee amount configured for this offering"
                 )
-                academic_info = ai_result.scalars().first()
 
-        if academic_info:
-            base_amount = academic_info.tuition_fee_per_year or Decimal("0")
+            if academic_info:
+                discount_policy_ids = academic_info.applied_discount_policy_ids or []
+        else:
+            # Tuition: service will look up amount from offering_semester_tuition.
+            # Router still resolves discount policy IDs from academic_info.
+            oac = profile.offering_admission_config
+            if oac and oac.academic_info:
+                academic_info = oac.academic_info
 
-        if base_amount <= 0:
-            raise BadRequest("Cannot calculate fee: No tuition fee configured for this offering")
+            if not academic_info and profile.applied_rules:
+                ai_id = profile.applied_rules.get("academic_info_id")
+                if ai_id:
+                    from app.models.offering_academic_info import OfferingAcademicInfo
+                    ai_result = await db.execute(
+                        sa.select(OfferingAcademicInfo).where(
+                            OfferingAcademicInfo.id == int(ai_id)
+                        )
+                    )
+                    academic_info = ai_result.scalars().first()
 
-        # Get applicable discount policy IDs
-        discount_policy_ids = []
-        if academic_info:
-            discount_policy_ids = academic_info.applied_discount_policy_ids or []
+            if academic_info:
+                discount_policy_ids = academic_info.applied_discount_policy_ids or []
 
         # Calculate fee
         fee, post_commit = await fee_service.calculate_fee(
@@ -231,15 +260,28 @@ async def calculate_fee(
             installment_plan_id=plan_id,
             user_id=current_user.id,
             unit_id=unit_id,
+            semester_no=data.semester_no,
         )
 
-        # Generate invoices based on installment plan
+        # Generate invoices based on installment plan.
+        # For tuition fees (PR 3): anchor installment due dates to the
+        # profile's approval timestamp when available, so HK1 payment
+        # schedules align with the admission timeline rather than the
+        # fee-creation date. Non-tuition fees keep the legacy
+        # due_date_base = today + 30 days.
+        invoice_anchor: date | None = None
+        if data.fee_type == FeeTypeEnum.tuition and hasattr(profile, "approved_at"):
+            approved_at = getattr(profile, "approved_at", None)
+            if approved_at is not None:
+                invoice_anchor = approved_at.date() if hasattr(approved_at, "date") else approved_at
+
         invoices, _ = await invoice_service.generate_invoices_for_fee(
             fee_id=fee.id,
             due_date_base=date.today() + timedelta(days=30),
             user_id=current_user.id,
             unit_id=unit_id,
             auto_issue=False,
+            anchor_date=invoice_anchor,
         )
 
         await db.commit()
@@ -345,6 +387,7 @@ async def get_fees_by_profile(
             id=f.id,
             fee_type=f.fee_type,
             academic_year=f.academic_year,
+            semester_no=f.semester_no,
             final_amount=f.final_amount,
             paid_amount=f.paid_amount,
             remaining_amount=f.remaining_amount,
@@ -399,6 +442,7 @@ async def get_profile_finance_summary(
                 id=f.id,
                 fee_type=f.fee_type,
                 academic_year=f.academic_year,
+                semester_no=f.semester_no,
                 final_amount=f.final_amount,
                 paid_amount=f.paid_amount,
                 remaining_amount=f.remaining_amount,
@@ -637,6 +681,7 @@ def _build_fee_response(
         installment_plan_id=fee.installment_plan_id,
         fee_type=fee.fee_type,
         academic_year=f"{fee.academic_year}-{fee.academic_year + 1}",
+        semester_no=fee.semester_no,
         base_amount=fee.base_amount,
         total_discount=fee.total_discount,
         final_amount=fee.final_amount,
@@ -649,11 +694,9 @@ def _build_fee_response(
         created_at=fee.created_at,
         updated_at=fee.updated_at,
         applied_discounts=applied_discounts,
-        # P1: Permission flags
         can_waive=can_waive,
         can_cancel=can_cancel,
         can_recalculate=can_recalculate,
-        # P3: First invoice due date
         due_date=first_due_date,
     )
 

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -18,7 +18,7 @@ from decimal import Decimal
 from typing import List, Optional, Dict, Any
 import html
 
-from pydantic import BaseModel, Field, field_validator, ConfigDict
+from pydantic import BaseModel, Field, field_validator, model_validator, ConfigDict
 
 from app.models.finance import (
     FeeTypeEnum,
@@ -245,10 +245,25 @@ class FeeCreate(FeeBase):
 
 
 class FeeCalculateRequest(BaseModel):
-    """Request schema for fee calculation."""
+    """Request schema for fee calculation.
+
+    For tuition fees, `semester_no` defaults to 1 (HK1) if not provided.
+    The service looks up the canonical amount from `offering_semester_tuition`.
+    For non-tuition fees, `semester_no` must be None (the service ignores it).
+    """
     admission_profile_id: int
     fee_type: FeeTypeEnum = FeeTypeEnum.tuition
     installment_plan_code: str = Field(default="FULL", max_length=50)
+    semester_no: Optional[int] = Field(
+        None, ge=1,
+        description="Số học kỳ (HK1=1). Mặc định 1 cho tuition, None cho non-tuition."
+    )
+
+    @model_validator(mode="after")
+    def default_semester_for_tuition(self):
+        if self.fee_type == FeeTypeEnum.tuition and self.semester_no is None:
+            self.semester_no = 1
+        return self
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -259,6 +274,9 @@ class FeeResponse(FeeBase):
     admission_profile_id: int
     installment_plan_id: Optional[int]
     academic_year: str  # Formatted as "YYYY-YYYY" by router
+
+    # Semester (PR 3 — ADR-002)
+    semester_no: Optional[int] = None
 
     # Amounts
     base_amount: Decimal
@@ -281,9 +299,6 @@ class FeeResponse(FeeBase):
     applied_discounts: List[FeeAppliedDiscountResponse] = []
 
     # P1: Permission flags - computed in router based on status and amounts
-    # can_waive: status not in terminal states AND remaining_amount > 0
-    # can_cancel: status not in terminal states AND paid_amount == 0
-    # can_recalculate: status not in terminal states AND paid_amount == 0
     can_waive: bool = False
     can_cancel: bool = False
     can_recalculate: bool = False
@@ -299,6 +314,7 @@ class FeeSummaryResponse(BaseModel):
     id: int
     fee_type: FeeTypeEnum
     academic_year: int
+    semester_no: Optional[int] = None
     final_amount: Decimal
     paid_amount: Decimal
     remaining_amount: Decimal

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -68,6 +68,54 @@ class FeeCalculationService:
     # FEE CALCULATION
     # ==========================================================================
 
+    async def _resolve_academic_info_id(
+        self, profile: models.AdmissionProfile,
+    ) -> int:
+        """Resolve academic_info_id from profile via 2-step fallback.
+
+        Step 1: profile.offering_admission_config.academic_info_id (modern)
+        Step 2: profile.applied_rules["academic_info_id"] (legacy, matches
+                current fees.py:203-211)
+        """
+        oac = getattr(profile, "offering_admission_config", None)
+        if oac is not None and getattr(oac, "academic_info_id", None):
+            return oac.academic_info_id
+
+        applied = profile.applied_rules or {}
+        ai_id = applied.get("academic_info_id")
+        if ai_id is not None:
+            return int(ai_id)
+
+        raise BadRequest(
+            "Không tìm được thông tin tuyển sinh cho hồ sơ này. "
+            "Profile thiếu cả offering_admission_config lẫn "
+            "applied_rules.academic_info_id."
+        )
+
+    async def _lookup_semester_tuition_amount(
+        self, profile: models.AdmissionProfile, semester_no: int,
+    ) -> Decimal:
+        """Look up canonical tuition amount from offering_semester_tuition.
+
+        Direct query — does NOT navigate ORM relationships to avoid
+        async lazy-load issues.
+        """
+        academic_info_id = await self._resolve_academic_info_id(profile)
+        result = await self.db.execute(
+            select(models.OfferingSemesterTuition.amount).where(
+                models.OfferingSemesterTuition.academic_info_id == academic_info_id,
+                models.OfferingSemesterTuition.semester_no == semester_no,
+            )
+        )
+        amount = result.scalar_one_or_none()
+        if amount is None:
+            raise BadRequest(
+                f"Chưa cấu hình học phí cho HK{semester_no} "
+                f"(academic_info_id={academic_info_id}). "
+                "Vui lòng nhập học phí theo học kỳ trong quản trị trước."
+            )
+        return Decimal(str(amount))
+
     async def calculate_fee(
         self,
         admission_profile_id: int,
@@ -78,39 +126,70 @@ class FeeCalculationService:
         installment_plan_id: Optional[int] = None,
         user_id: Optional[int] = None,
         unit_id: Optional[int] = None,
+        semester_no: Optional[int] = None,
     ) -> Tuple[Fee, Optional[Callable]]:
         """
         Calculate fee for an admission profile.
 
+        For tuition fees (PR 3 — ADR-002): the canonical amount is looked
+        up from ``offering_semester_tuition`` based on ``semester_no``. The
+        ``base_amount`` parameter is ignored for tuition — the caller need
+        not provide it. For non-tuition fees, ``base_amount`` is used as
+        before and ``semester_no`` stays None.
+
         Args:
             admission_profile_id: Profile to create fee for
             fee_type: Type of fee (application, tuition, etc.)
-            base_amount: Base fee amount before discounts
+            base_amount: Base fee amount before discounts (ignored for tuition)
             academic_year: Academic year (e.g., "2024-2025")
             discount_policy_ids: List of discount policy IDs to apply
             installment_plan_id: Installment plan for payment scheduling
             user_id: User performing calculation (for audit)
             unit_id: Unit ID for IDOR protection
+            semester_no: Semester number for tuition fees (None for non-tuition).
+                Defaults to 1 for tuition if not provided — lives in service
+                so both HTTP callers and direct callers get the default.
 
         Returns:
             Tuple of (Fee, post_commit_callback)
 
         Raises:
             ResourceNotFoundError: If profile not found
-            BadRequest: If fee already exists for this profile/type/year
+            BadRequest: If fee already exists or semester tuition not configured
         """
+        # Normalize semester_no: tuition defaults to HK1, non-tuition
+        # MUST be None (the DB CHECK chk_fee_nontuition_semester_no_null
+        # rejects non-tuition rows with a non-NULL semester_no). Lives in
+        # service so both HTTP callers and direct callers get it.
+        if fee_type == FeeTypeEnum.tuition and semester_no is None:
+            semester_no = 1
+        elif fee_type != FeeTypeEnum.tuition:
+            semester_no = None
+
         # Validate profile exists and is accessible
         profile = await self._get_profile(admission_profile_id, unit_id)
         if not profile:
             raise ResourceNotFoundError("Admission profile not found")
 
-        # Check for duplicate fee
+        # For tuition: look up canonical amount from offering_semester_tuition
+        if fee_type == FeeTypeEnum.tuition:
+            base_amount = await self._lookup_semester_tuition_amount(
+                profile, semester_no
+            )
+
+        # Semester-aware duplicate check for tuition, year-based for others
         existing = await self.fee_repo.check_duplicate(
-            admission_profile_id, fee_type.value, academic_year
+            admission_profile_id, fee_type.value, academic_year,
+            semester_no=semester_no,
         )
         if existing:
+            if fee_type == FeeTypeEnum.tuition:
+                raise BadRequest(
+                    f"Học phí HK{semester_no} đã được tính cho hồ sơ này."
+                )
             raise BadRequest(
-                f"Fee of type '{fee_type.value}' already exists for academic year {academic_year}"
+                f"Fee of type '{fee_type.value}' already exists for "
+                f"academic year {academic_year}"
             )
 
         # Calculate discounts
@@ -132,26 +211,13 @@ class FeeCalculationService:
         else:
             academic_year_int = academic_year
 
-        # Create fee record
-        # PR 1 (ADR-002) compat patch: tuition rows MUST carry a positive
-        # semester_no to satisfy chk_fee_tuition_semester_no_required and
-        # the new uq_fee_profile_type_semester_tuition partial unique
-        # index. PR 1 does not introduce semester-aware logic anywhere
-        # else — existing callers still pass academic_year, and the
-        # duplicate check at check_duplicate() is still year-based. The
-        # only thing PR 1 guarantees is that every new tuition fee
-        # created by this service lands with semester_no=1 (HK1), which
-        # matches the backfill of pre-existing tuition rows. Non-tuition
-        # fees leave semester_no NULL, matching the non-tuition partial
-        # index (keyed on academic_year, not semester_no).
-        # PR 3 will replace this compat patch with proper semester-aware
-        # tuition creation driven by offering_semester_tuition rows.
-        fee_semester_no = 1 if fee_type == FeeTypeEnum.tuition else None
+        # Create fee record. semester_no is set from the service-level
+        # default or caller-provided value (tuition) / None (non-tuition).
         fee = Fee(
             admission_profile_id=admission_profile_id,
             fee_type=fee_type.value,
             academic_year=academic_year_int,
-            semester_no=fee_semester_no,
+            semester_no=semester_no,
             installment_plan_id=installment_plan_id,
             base_amount=base_amount,
             total_discount=total_discount,
@@ -186,14 +252,14 @@ class FeeCalculationService:
             fee_id=fee.id,
             profile_id=admission_profile_id,
             fee_type=fee_type.value,
+            semester_no=semester_no,
             base_amount=str(base_amount),
             total_discount=str(total_discount),
             final_amount=str(final_amount),
             user_id=user_id,
         )
 
-        # ✅ SYNC LEAD STATUS: For tuition fee, move lead to sts14 (Chờ học phí)
-        # This keeps Lead consultation status in sync with Finance phase
+        # SYNC LEAD STATUS: For tuition fee, move lead to sts14 (Chờ học phí)
         if fee_type == FeeTypeEnum.tuition:
             from app.services.lead_admission_sync import sync_lead_tuition_calculated
             await sync_lead_tuition_calculated(
@@ -201,11 +267,9 @@ class FeeCalculationService:
                 profile=profile,
                 fee_amount=str(final_amount),
                 changed_by_user_id=user_id,
-                reason=f"Tuition fee calculated: {final_amount:,.0f} VND",
+                reason=f"Tuition fee calculated: {final_amount:,.0f} VND (HK{semester_no})",
             )
 
-        # Post-commit callback (no events to emit — fee calculation is a
-        # pure service-internal flow, not a cross-module notification. See ADR-001.)
         async def post_commit():
             pass
 

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -25,6 +25,7 @@ from decimal import Decimal, ROUND_HALF_UP
 from typing import List, Optional, Tuple, Callable, Any
 import structlog
 
+import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
@@ -690,3 +691,166 @@ def calculate_installment_amounts(
         f"Installment sum {sum(amounts)} != total {total_amount}"
 
     return amounts
+
+
+# =============================================================================
+# Discount recalculation on semester tuition change — PR 3 (ADR-002 Decision 4)
+# =============================================================================
+
+async def recalculate_fees_for_semester_tuition_change(
+    db: AsyncSession,
+    academic_info_id: int,
+) -> int:
+    """Recalculate tuition fees when admin edits a semester tuition amount.
+
+    Finds tuition Fee rows linked to the affected academic_info_id,
+    re-reads the canonical amount from offering_semester_tuition, and
+    updates base_amount / total_discount / final_amount.
+
+    **Safety invariants** (mirrors M10 rule from recalculate_fee):
+    - Only recalculates fees with ``paid_amount == 0``. Any fee that
+      has received partial or full payment is left untouched — editing
+      a live receivable after money has been collected is forbidden.
+    - Only recalculates fees whose invoices are all in draft status
+      (or no invoices at all). If any invoice has been issued/partial/
+      paid, the fee is skipped to avoid fee↔invoice total mismatch.
+    - Skips terminal status fees (paid, waived, cancelled).
+    - Skips fees whose semester_tuition row was deleted (clear-all).
+
+    Returns the count of fees recalculated.
+    """
+    from sqlalchemy.orm import selectinload
+
+    # Single query: join Fee -> AdmissionProfile to resolve
+    # academic_info_id linkage in SQL rather than per-fee Python loop.
+    # Uses applied_rules->>'academic_info_id' for legacy path and
+    # offering_admission_config.academic_info_id for modern path.
+    # Step 1: Find eligible fee IDs via JOIN query (no selectinload
+    # here — selectinload doesn't work reliably with multi-table JOINs
+    # in async SQLAlchemy).
+    id_result = await db.execute(
+        select(Fee.id)
+        .join(
+            models.AdmissionProfile,
+            models.AdmissionProfile.id == Fee.admission_profile_id,
+        )
+        .outerjoin(
+            models.OfferingAdmissionConfig,
+            models.OfferingAdmissionConfig.id == models.AdmissionProfile.offering_admission_config_id,
+        )
+        .where(
+            Fee.fee_type == "tuition",
+            Fee.status.notin_(["paid", "waived", "cancelled"]),
+            Fee.paid_amount == 0,
+            sa.or_(
+                models.OfferingAdmissionConfig.academic_info_id == academic_info_id,
+                models.AdmissionProfile.applied_rules["academic_info_id"].as_string().cast(sa.Integer) == academic_info_id,
+            ),
+        )
+    )
+    eligible_fee_ids = [row[0] for row in id_result.fetchall()]
+
+    if not eligible_fee_ids:
+        return 0
+
+    # Step 2: Re-load fees with relationships. Use populate_existing=True
+    # to force SQLAlchemy to refresh cached Fee objects and their
+    # selectinload'd relationships (invoices may have been generated
+    # after the fee was first loaded into the session's identity map).
+    fee_result = await db.execute(
+        select(Fee)
+        .where(Fee.id.in_(eligible_fee_ids))
+        .options(
+            selectinload(Fee.applied_discounts),
+            selectinload(Fee.invoices),
+            selectinload(Fee.installment_plan),
+        )
+        .execution_options(populate_existing=True)
+    )
+    eligible_fees = fee_result.scalars().all()
+
+    recalc_count = 0
+    for fee in eligible_fees:
+        # Skip if any invoice is beyond draft — recalculating would
+        # leave fee.final_amount out of sync with issued invoice totals.
+        if fee.invoices:
+            has_non_draft = any(
+                inv.status != "draft" for inv in fee.invoices
+            )
+            if has_non_draft:
+                log.info(
+                    "fee_recalc_skipped_non_draft_invoices",
+                    fee_id=fee.id,
+                    semester_no=fee.semester_no,
+                )
+                continue
+
+        # Look up new semester tuition amount
+        sem_result = await db.execute(
+            select(models.OfferingSemesterTuition.amount).where(
+                models.OfferingSemesterTuition.academic_info_id == academic_info_id,
+                models.OfferingSemesterTuition.semester_no == fee.semester_no,
+            )
+        )
+        new_amount = sem_result.scalar_one_or_none()
+        if new_amount is None:
+            continue
+
+        new_base = Decimal(str(new_amount))
+        if new_base == fee.base_amount:
+            continue
+
+        # Recalculate: re-apply existing discount percentages
+        total_discount = Decimal("0")
+        for ad in fee.applied_discounts:
+            if ad.discount_percent is not None:
+                disc = (new_base * ad.discount_percent / 100).quantize(Decimal("1"))
+            else:
+                disc = ad.discount_amount
+            ad.discount_amount = disc
+            total_discount += disc
+
+        old_final = fee.final_amount
+        fee.base_amount = new_base
+        fee.total_discount = min(total_discount, new_base)
+        fee.final_amount = max(Decimal("0"), new_base - fee.total_discount)
+        fee.version += 1
+
+        # If fee has draft invoices, rewrite their amounts to match
+        # the new final_amount so fee↔invoice totals stay in sync.
+        # Uses direct UPDATE statements to avoid ORM identity-map issues
+        # where selectinload'd Invoice objects may not be dirty-tracked.
+        if fee.invoices and fee.installment_plan:
+            new_schedule = fee.installment_plan.get_installment_schedule(
+                fee.final_amount
+            )
+            for inv, sched in zip(
+                sorted(fee.invoices, key=lambda x: x.installment_no),
+                new_schedule,
+            ):
+                await db.execute(
+                    sa.update(Invoice)
+                    .where(Invoice.id == inv.id)
+                    .values(amount=sched["amount"])
+                )
+        elif fee.invoices and len(fee.invoices) == 1:
+            await db.execute(
+                sa.update(Invoice)
+                .where(Invoice.id == fee.invoices[0].id)
+                .values(amount=fee.final_amount)
+            )
+
+        recalc_count += 1
+        log.info(
+            "fee_recalculated_by_semester_change",
+            fee_id=fee.id,
+            semester_no=fee.semester_no,
+            old_final=str(old_final),
+            new_base=str(new_base),
+            new_final=str(fee.final_amount),
+        )
+
+    if recalc_count > 0:
+        await db.flush()
+
+    return recalc_count

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -76,6 +76,7 @@ class InvoiceService:
         user_id: int,
         unit_id: Optional[int] = None,
         auto_issue: bool = False,
+        anchor_date: Optional[date] = None,
     ) -> Tuple[List[Invoice], Optional[Callable]]:
         """
         Generate all invoices for a fee based on its installment plan.
@@ -131,16 +132,24 @@ class InvoiceService:
         # Get installment schedule
         if fee.installment_plan:
             # Use plan's schedule with proper due_days_offset per installment
-            installment_schedule = fee.installment_plan.get_installment_schedule(amount_to_invoice)
+            installment_schedule = fee.installment_plan.get_installment_schedule(
+                amount_to_invoice, anchor_date=anchor_date
+            )
         else:
-            # Single payment fallback
-            installment_schedule = [{
+            # Single payment fallback. When anchor_date is provided
+            # (tuition HK1 anchored to approval date), set due_date so
+            # the invoice loop picks it up instead of falling back to
+            # due_date_base + offset.
+            entry: dict = {
                 "installment_no": 1,
                 "amount": amount_to_invoice,
                 "due_days_offset": 0,
                 "percent": Decimal("100.0"),
-                "description": "Thanh toán một lần"
-            }]
+                "description": "Thanh toán một lần",
+            }
+            if anchor_date is not None:
+                entry["due_date"] = anchor_date.isoformat()
+            installment_schedule = [entry]
 
         # Generate invoices
         invoices = []
@@ -149,8 +158,13 @@ class InvoiceService:
             amount = item["amount"]
             due_days_offset = item.get("due_days_offset", 0)
 
-            # Calculate due date based on offset from base date
-            installment_due = due_date_base + timedelta(days=due_days_offset)
+            # Due date: prefer pre-computed date from anchor_date path
+            # (when get_installment_schedule was called with anchor_date).
+            # Fall back to due_date_base + offset (legacy path).
+            if "due_date" in item and item["due_date"] is not None:
+                installment_due = date.fromisoformat(item["due_date"])
+            else:
+                installment_due = due_date_base + timedelta(days=due_days_offset)
 
             # Generate unique invoice number
             invoice_number = await self._generate_invoice_number()

--- a/Backend_FastAPI/app/services/organization_service.py
+++ b/Backend_FastAPI/app/services/organization_service.py
@@ -2109,13 +2109,22 @@ async def update_semester_tuition(
     await db.flush()
     await db.refresh(row)
 
+    # PR 3: recalculate affected tuition fees (pre-commit)
+    from app.services.fee_calculation_service import (
+        recalculate_fees_for_semester_tuition_change,
+    )
+    recalc_count = await recalculate_fees_for_semester_tuition_change(
+        db, row.academic_info_id
+    )
+
     _year = db_info.academic_year
     _sem = row.semester_no
 
     async def _post_commit():
         log.info("semester_tuition_updated",
                  semester_tuition_id=semester_tuition_id,
-                 semester_no=_sem)
+                 semester_no=_sem,
+                 fees_recalculated=recalc_count)
         await _invalidate_semester_tuition_dependents(
             row.academic_info_id, _year, "update", f"HK{_sem}",
         )
@@ -2209,6 +2218,15 @@ async def bulk_upsert_semester_tuitions(
 
     await db.flush()
 
+    # PR 3 (ADR-002 Decision 4): recalculate affected tuition fees
+    # pre-commit so the new amounts are part of the same transaction.
+    from app.services.fee_calculation_service import (
+        recalculate_fees_for_semester_tuition_change,
+    )
+    recalc_count = await recalculate_fees_for_semester_tuition_change(
+        db, academic_info_id
+    )
+
     # Re-query for the final ordered list
     final_result = await db.execute(
         select(models.OfferingSemesterTuition)
@@ -2223,7 +2241,8 @@ async def bulk_upsert_semester_tuitions(
     async def _post_commit():
         log.info("semester_tuitions_bulk_upserted",
                  academic_info_id=academic_info_id,
-                 count=_count)
+                 count=_count,
+                 fees_recalculated=recalc_count)
         await _invalidate_semester_tuition_dependents(
             academic_info_id, _year, "bulk_upsert",
             f"{_count} học kỳ",

--- a/Backend_FastAPI/tests/integration/test_finance_workflow.py
+++ b/Backend_FastAPI/tests/integration/test_finance_workflow.py
@@ -18,6 +18,7 @@ import pytest_asyncio
 from datetime import datetime, timezone, date, timedelta
 from decimal import Decimal
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models
@@ -867,4 +868,201 @@ class TestAccountingPeriod:
             await service.create_period(month=2, year=2026, user_id=maker_user.id)
 
         assert "not closed" in str(exc_info.value).lower()
+
+
+# =============================================================================
+# SEMESTER TUITION RECALCULATION TESTS (PR 3 — ADR-002 Decision 4)
+# =============================================================================
+
+class TestSemesterTuitionRecalculation:
+    """Test discount recalculation when admin edits semester tuition amounts."""
+
+    @pytest.mark.asyncio
+    async def test_recalc_updates_draft_fee_and_invoices(
+        self,
+        db: AsyncSession,
+        finance_fixtures: dict,
+        maker_user: models.User,
+    ):
+        """When semester tuition amount changes, draft fees and their draft
+        invoices should be rewritten to match the new amount."""
+        from app.services.fee_calculation_service import (
+            recalculate_fees_for_semester_tuition_change,
+        )
+
+        fee_service = FeeCalculationService(db)
+        invoice_service = InvoiceService(db)
+        profile = finance_fixtures["admission_profile"]
+        plan = finance_fixtures["installment_plan"]
+
+        # Create tuition fee (reads 10M from semester_tuition fixture)
+        fee, _ = await fee_service.calculate_fee(
+            admission_profile_id=profile.id,
+            fee_type=FeeTypeEnum.tuition,
+            base_amount=Decimal("0"),  # ignored for tuition
+            academic_year=2025,
+            installment_plan_id=plan.id,
+            user_id=maker_user.id,
+            unit_id=finance_fixtures["unit_id"],
+        )
+        await db.commit()
+
+        assert fee.base_amount == Decimal("10000000")
+
+        # Generate draft invoices (3 installments)
+        invoices, _ = await invoice_service.generate_invoices_for_fee(
+            fee_id=fee.id,
+            due_date_base=date.today() + timedelta(days=30),
+            user_id=maker_user.id,
+            unit_id=finance_fixtures["unit_id"],
+        )
+        await db.commit()
+        assert len(invoices) == 3
+
+        # Change semester tuition from 10M to 12M
+        from app.models.offering_semester_tuition import OfferingSemesterTuition
+        ai_id = profile.applied_rules["academic_info_id"]
+        sem_result = await db.execute(
+            select(OfferingSemesterTuition).where(
+                OfferingSemesterTuition.academic_info_id == ai_id,
+                OfferingSemesterTuition.semester_no == 1,
+            )
+        )
+        sem_row = sem_result.scalar_one()
+        sem_row.amount = Decimal("12000000")
+        await db.flush()
+
+        # Recalculate
+        count = await recalculate_fees_for_semester_tuition_change(db, int(ai_id))
+        await db.commit()
+
+        assert count == 1, f"Expected 1 fee recalculated, got {count}. ai_id={ai_id}, fee.id={fee.id}"
+
+        # Verify fee updated
+        await db.refresh(fee)
+        assert fee.base_amount == Decimal("12000000")
+        assert fee.final_amount == Decimal("12000000")
+
+        # Verify invoices rewritten (34%/33%/33% of 12M).
+        # Use raw SQL text query to bypass ORM identity map caching.
+        from sqlalchemy import text
+        inv_rows = (await db.execute(
+            text("SELECT installment_no, amount FROM invoice WHERE fee_id = :fid ORDER BY installment_no"),
+            {"fid": fee.id},
+        )).fetchall()
+        assert len(inv_rows) == 3
+        assert inv_rows[0][1] == Decimal("4080000")  # 34% of 12M
+        assert inv_rows[1][1] == Decimal("3960000")  # 33%
+        assert inv_rows[2][1] == Decimal("3960000")  # 33%
+
+    @pytest.mark.asyncio
+    async def test_recalc_skips_paid_fee(
+        self,
+        db: AsyncSession,
+        finance_fixtures: dict,
+        maker_user: models.User,
+    ):
+        """Fees with paid_amount > 0 must not be recalculated."""
+        from app.services.fee_calculation_service import (
+            recalculate_fees_for_semester_tuition_change,
+        )
+
+        fee_service = FeeCalculationService(db)
+        profile = finance_fixtures["admission_profile"]
+
+        fee, _ = await fee_service.calculate_fee(
+            admission_profile_id=profile.id,
+            fee_type=FeeTypeEnum.tuition,
+            base_amount=Decimal("0"),
+            academic_year=2025,
+            user_id=maker_user.id,
+            unit_id=finance_fixtures["unit_id"],
+        )
+        # Simulate partial payment
+        fee.paid_amount = Decimal("5000000")
+        fee.status = FeeStatusEnum.partial.value
+        await db.flush()
+        await db.commit()
+
+        original_base = fee.base_amount
+
+        # Change semester tuition
+        from app.models.offering_semester_tuition import OfferingSemesterTuition
+        ai_id = profile.applied_rules["academic_info_id"]
+        sem_result = await db.execute(
+            select(OfferingSemesterTuition).where(
+                OfferingSemesterTuition.academic_info_id == ai_id,
+                OfferingSemesterTuition.semester_no == 1,
+            )
+        )
+        sem_row = sem_result.scalar_one()
+        sem_row.amount = Decimal("15000000")
+        await db.flush()
+
+        count = await recalculate_fees_for_semester_tuition_change(db, ai_id)
+        await db.commit()
+
+        assert count == 0
+
+        await db.refresh(fee)
+        assert fee.base_amount == original_base  # Unchanged
+
+    @pytest.mark.asyncio
+    async def test_recalc_skips_non_draft_invoices(
+        self,
+        db: AsyncSession,
+        finance_fixtures: dict,
+        maker_user: models.User,
+    ):
+        """Fees with issued invoices must not be recalculated."""
+        from app.services.fee_calculation_service import (
+            recalculate_fees_for_semester_tuition_change,
+        )
+
+        fee_service = FeeCalculationService(db)
+        invoice_service = InvoiceService(db)
+        profile = finance_fixtures["admission_profile"]
+
+        fee, _ = await fee_service.calculate_fee(
+            admission_profile_id=profile.id,
+            fee_type=FeeTypeEnum.tuition,
+            base_amount=Decimal("0"),
+            academic_year=2025,
+            user_id=maker_user.id,
+            unit_id=finance_fixtures["unit_id"],
+        )
+        await db.commit()
+
+        # Generate + issue invoices
+        invoices, _ = await invoice_service.generate_invoices_for_fee(
+            fee_id=fee.id,
+            due_date_base=date.today() + timedelta(days=30),
+            user_id=maker_user.id,
+            unit_id=finance_fixtures["unit_id"],
+            auto_issue=True,  # Issues immediately
+        )
+        await db.commit()
+
+        original_base = fee.base_amount
+
+        # Change semester tuition
+        from app.models.offering_semester_tuition import OfferingSemesterTuition
+        ai_id = profile.applied_rules["academic_info_id"]
+        sem_result = await db.execute(
+            select(OfferingSemesterTuition).where(
+                OfferingSemesterTuition.academic_info_id == ai_id,
+                OfferingSemesterTuition.semester_no == 1,
+            )
+        )
+        sem_row = sem_result.scalar_one()
+        sem_row.amount = Decimal("20000000")
+        await db.flush()
+
+        count = await recalculate_fees_for_semester_tuition_change(db, ai_id)
+        await db.commit()
+
+        assert count == 0  # Skipped because invoices are issued
+
+        await db.refresh(fee)
+        assert fee.base_amount == original_base
 

--- a/Backend_FastAPI/tests/integration/test_finance_workflow.py
+++ b/Backend_FastAPI/tests/integration/test_finance_workflow.py
@@ -94,14 +94,60 @@ async def finance_fixtures(db: AsyncSession, seeded_dependencies: dict) -> dict:
 
     await db.flush()
 
+    # Create academic info + semester tuition for the tuition fee lookup
+    # chain (PR 3 — ADR-002). The profile references this via
+    # applied_rules["academic_info_id"] (legacy fallback path).
+    from app.models.offering_academic_info import OfferingAcademicInfo
+    from app.models.offering_semester_tuition import OfferingSemesterTuition
+
+    # We need a ProgramOffering to attach academic info to. Use the first
+    # seeded offering if available, otherwise create a minimal one.
+    from sqlalchemy import select as sa_select
+    offering_result = await db.execute(
+        sa_select(models.ProgramOffering).limit(1)
+    )
+    offering = offering_result.scalar_one_or_none()
+    if not offering:
+        program = models.MajorProgram(
+            name="Test Program",
+            code="TEST-FW",
+            degree_level="Đại học",
+            unit_id=seeded_dependencies["unit_id"],
+        )
+        db.add(program)
+        await db.flush()
+        offering = models.ProgramOffering(
+            program_id=program.id,
+            offering_type="Chính quy",
+        )
+        db.add(offering)
+        await db.flush()
+
+    academic_info = OfferingAcademicInfo(
+        offering_id=offering.id,
+        academic_year=2025,
+        tuition_fee_per_year=10000000,  # Legacy field, still used by non-tuition path
+        is_published=True,
+    )
+    db.add(academic_info)
+    await db.flush()
+
+    semester_tuition = OfferingSemesterTuition(
+        academic_info_id=academic_info.id,
+        semester_no=1,
+        amount=10000000,  # HK1 amount (matches tuition_fee_per_year for test consistency)
+    )
+    db.add(semester_tuition)
+    await db.flush()
+
     # Create test lead with admission profile
     lead = models.Lead(
         full_name="Finance Test Student",
         email="finance_test@example.com",
         phone="0901234567",
-        source="test",  # Required field
+        source="test",
         unit_id=seeded_dependencies["unit_id"],
-        consultation_status_id=seeded_dependencies["initial_status_id"],  # FK to ConsultationStatus
+        consultation_status_id=seeded_dependencies["initial_status_id"],
     )
     db.add(lead)
     await db.flush()
@@ -109,8 +155,8 @@ async def finance_fixtures(db: AsyncSession, seeded_dependencies: dict) -> dict:
     admission_profile = models.AdmissionProfile(
         lead_id=lead.id,
         status="submitted",
-        academic_year=2025,  # Required field
-        applied_rules={},  # Required JSONB field - snapshot of rules at creation
+        academic_year=2025,
+        applied_rules={"academic_info_id": academic_info.id},
     )
     db.add(admission_profile)
     await db.flush()
@@ -235,7 +281,8 @@ class TestFeeCalculation:
                 unit_id=finance_fixtures["unit_id"],
             )
 
-        assert "already exists" in str(exc_info.value)
+        error_msg = str(exc_info.value)
+        assert "already exists" in error_msg or "đã được tính" in error_msg
 
     @pytest.mark.asyncio
     async def test_recalculate_fee_blocked_after_payment(
@@ -368,11 +415,15 @@ class TestInvoiceGeneration:
         profile = finance_fixtures["admission_profile"]
         plan = finance_fixtures["installment_plan"]
 
-        # Create fee with installment plan
+        # Create fee with installment plan.
+        # PR 3: tuition base_amount is now looked up from
+        # offering_semester_tuition (10M in fixture), so the explicit
+        # base_amount here is ignored for tuition. Use enrollment type
+        # instead for a clean installment-amount test with known base.
         fee, _ = await fee_service.calculate_fee(
             admission_profile_id=profile.id,
-            fee_type=FeeTypeEnum.tuition,
-            base_amount=Decimal("9000000"),  # Divisible by 3
+            fee_type=FeeTypeEnum.enrollment,
+            base_amount=Decimal("9000000"),
             academic_year=2025,
             installment_plan_id=plan.id,
             user_id=maker_user.id,
@@ -391,7 +442,7 @@ class TestInvoiceGeneration:
         await db.commit()
 
         assert len(invoices) == 3
-        # Amounts based on 34%/33%/33% split of 9000000
+        # Amounts based on 34%/33%/33% split of 9,000,000
         assert invoices[0].amount == Decimal("3060000")  # 34%
         assert invoices[1].amount == Decimal("2970000")  # 33%
         assert invoices[2].amount == Decimal("2970000")  # 33%


### PR DESCRIPTION
## Summary

PR 3 of the **Semester Tuition Refactor** epic. Heaviest PR — refactors finance core so tuition fees read canonical amounts from `offering_semester_tuition` instead of the deprecated `tuition_fee_per_year`. Per ADR-002 Deferred Decisions D6, D7, and Decision 3/4.

## Commits

1. **`0caed600`** — Batch A+B: semester-aware fee calculation + anchor_date
2. **`e186f840`** — Batch C: discount recalculation hook

## What changed

### Fee calculation is now semester-aware
- `calculate_fee()` gains `semester_no` param; tuition defaults to HK1
- Tuition base_amount looked up from `offering_semester_tuition` (not `tuition_fee_per_year`)
- 2-step fallback for legacy profiles: `offering_admission_config -> applied_rules["academic_info_id"]`
- Non-tuition `semester_no` normalized to `None` (prevents DB CHECK violation)
- PR 1 compat patch removed

### Duplicate check is semester-aware
- Tuition: checks `(profile, type, semester_no)` — allows HK1+HK2
- Non-tuition: keeps `(profile, type, year)` — no behavior change

### InstallmentPlan gains anchor_date
- `get_installment_schedule(amount, anchor_date=...)` computes `due_date` per installment
- For HK1: anchor = profile.approved_at
- Backward compat when `anchor_date=None`

### Invoice generation uses anchor_date
- `generate_invoices_for_fee()` gains `anchor_date` param
- Invoice loop uses pre-computed `due_date` when present (anchor path)
- Falls back to `due_date_base + offset` (legacy)
- Single-payment fallback also respects anchor_date

### FeeResponse exposes semester_no
- `FeeResponse`, `FeeSummaryResponse`, `FeeListItem` all gain `semester_no`
- All response builders updated consistently

### Discount recalculation on admin edit
- `recalculate_fees_for_semester_tuition_change()` runs pre-commit when admin edits semester tuition
- Re-applies percentage-based discounts to new base_amount
- Skips paid/waived/cancelled fees
- Skips fees whose semester_tuition row was deleted (clear-all: keep current amounts)
- Bumps fee.version for optimistic locking

## Files changed — 9

| File | Change |
|------|--------|
| `app/schemas/finance.py` | `semester_no` on request + responses; model_validator default |
| `app/models/finance/installment_plan.py` | `anchor_date` param + due_date computation |
| `app/repositories/fee_repository.py` | `check_duplicate` semester-aware branch |
| `app/services/fee_calculation_service.py` | Main refactor + `recalculate_fees_for_semester_tuition_change()` |
| `app/services/invoice_service.py` | `anchor_date` wiring + due_date from schedule item |
| `app/services/organization_service.py` | Recalculation hook in update + bulk_upsert |
| `app/routers/fees.py` | semester_no in all builders; tuition anchor_date from profile.approved_at |
| `tests/integration/test_finance_workflow.py` | Fixture adds semester_tuition chain; assertion updates |

## Verification

- [x] 149/149 tests pass (14 integration + 135 unit/schema/API)
- [x] Import smoke clean
- [ ] Browser: create tuition fee, verify base_amount from semester_tuition
- [ ] Browser: verify FeeResponse contains semester_no
- [ ] Browser: edit semester tuition as admin, verify fee recalculated

## Not in scope

- Admission gate logic (PR 4)
- Admission event mapping gating (PR 5)
- Public API additive fields (PR 6)
- KPI/analytics (PR 7)
- HK2+ lazy creation (post-PR 8)
- New notification events (PR 8)

## Roadmap

| PR | Phase | Status |
|---|---|---|
| PR 0 (#111) | Spec / ADR | **MERGED** |
| PR 1 (#113) | Schema + compat patch | **MERGED** |
| PR A (#114) | Ember payment event parity | **MERGED** |
| PR 2 (#115) | Admin config backend + frontend | **MERGED** |
| **PR 3 (this)** | Finance core refactor | Draft |
| PR 4 | Admission clearance model | Not started |
| PR 5 | Pipeline / event semantics | Not started |
| PR 6 | Public / admin contract | Not started |
| PR 7 | KPI / analytics | Not started |
| PR 8 | Event rewrite on new model | Not started |
