### PR TITLE
feat(admissions): PR 5 — HK1 cleared-state pipeline semantics

### DIFF
--- a/Backend_FastAPI/app/core/admission_event_mapping.py
+++ b/Backend_FastAPI/app/core/admission_event_mapping.py
@@ -179,48 +179,53 @@ ADMISSION_EVENT_PROJECTIONS = {
     # -------------------------------------------------------------------------
     # TUITION FEE CALCULATED (Finance Phase - Gate 1)
     # -------------------------------------------------------------------------
-    # Triggers when tuition fee is calculated for approved profile
-    # Lead moves to "Chờ học phí" - waiting for payment
+    # ADR-002 PR 5: HK1-only. Callers gate to semester_no == 1.
+    # Triggers when HK1 tuition fee is calculated for approved profile.
+    # Lead moves to "Chờ học phí" - waiting for payment.
     "tuition_fee_calculated": AdmissionEventProjection(
         event="tuition_fee_calculated",
-        admission_status="approved",  # Profile is approved, waiting for fee payment
+        admission_status="approved",
         consultation_status_id="sts14",
         consultation_name="Chưa hoàn tất học phí",
-        pipeline_stage_id="stg05",  # Move to "Xử lý học phí" stage (fee phase)
+        pipeline_stage_id="stg05",
         stage_name="Xử lý học phí",
-        system_note_template="[HỆ THỐNG] Học phí đã được tính toán - Profile #{profile_id}, Số tiền: {amount} VND",
+        system_note_template="[HỆ THỐNG] Học phí HK1 đã được tính toán - Profile #{profile_id}, Số tiền: {amount} VND",
         skip_if_converted=True,
     ),
 
     # -------------------------------------------------------------------------
     # TUITION FEE PAID (Finance Phase - Gate 2 Passed)
     # -------------------------------------------------------------------------
-    # Triggers when tuition fee is fully paid or waived
-    # Lead moves to "Đã hoàn tất học phí" - ready for enrollment
+    # ADR-002 PR 5: HK1-only, cleared-state semantics. Callers fire this
+    # when HK1 reaches cleared state for the first time:
+    # paid, waived, or partial with paid_amount > 0.
+    # "Cleared" does NOT require full payment — any non-zero HK1 payment
+    # qualifies. Lead moves to "Đã hoàn tất học phí" once.
     "tuition_fee_paid": AdmissionEventProjection(
         event="tuition_fee_paid",
-        admission_status="confirmed",  # Profile is confirmed, fee cleared
+        admission_status="confirmed",
         consultation_status_id="sts10",
         consultation_name="Đã hoàn tất học phí",
-        pipeline_stage_id="stg05",  # Stay in "Xử lý học phí" stage
+        pipeline_stage_id="stg05",
         stage_name="Xử lý học phí",
-        system_note_template="[HỆ THỐNG] Học phí đã được thanh toán đầy đủ - Profile #{profile_id}, Mã GD: {transaction_id}",
+        system_note_template="[HỆ THỐNG] Học phí HK1 đã được xử lý - Profile #{profile_id}, Mã GD: {transaction_id}",
         skip_if_converted=True,
     ),
 
     # -------------------------------------------------------------------------
     # TUITION FEE REFUNDED (Finance Phase - Withdrawal)
     # -------------------------------------------------------------------------
-    # Triggers when tuition fee is refunded (full or partial leading to withdrawal)
+    # ADR-002 PR 5: HK1-only. Callers gate to semester_no == 1.
+    # HK2+ refunds do not project into the admission pipeline.
     "tuition_fee_refunded": AdmissionEventProjection(
         event="tuition_fee_refunded",
-        admission_status="confirmed",  # Was confirmed but withdrew
+        admission_status="confirmed",
         consultation_status_id="sts18",
         consultation_name="Đã hoàn học phí",
-        pipeline_stage_id="stg05",  # Stay in "Xử lý học phí" stage
+        pipeline_stage_id="stg05",
         stage_name="Xử lý học phí",
-        system_note_template="[HỆ THỐNG] Học phí đã được hoàn trả - Profile #{profile_id}, Số tiền hoàn: {amount} VND",
-        skip_if_converted=False,  # Allow transition even if converted (dropout)
+        system_note_template="[HỆ THỐNG] Học phí HK1 đã được hoàn trả - Profile #{profile_id}, Số tiền hoàn: {amount} VND",
+        skip_if_converted=False,
     ),
 
     # -------------------------------------------------------------------------

--- a/Backend_FastAPI/app/models/finance/fee.py
+++ b/Backend_FastAPI/app/models/finance/fee.py
@@ -321,7 +321,17 @@ class Fee(Base):
 
     @property
     def is_fully_paid(self) -> bool:
-        """Check if fee is fully paid or waived."""
+        """Check if fee is fully paid or waived.
+
+        Under the per-semester model (ADR-002), each Fee row represents
+        one semester. This property means "this semester's fee is fully
+        settled", not "all tuition across all semesters is paid".
+
+        Note: admission pipeline projection uses is_hk1_cleared() from
+        fee_calculation_service instead of this property, because the
+        pipeline fires on first partial payment (cleared state), not
+        only on full payment.
+        """
         return self.remaining_amount <= Decimal("0")
 
     @property

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -48,6 +48,31 @@ from app.config import settings
 log = structlog.get_logger(__name__)
 
 
+def is_hk1_cleared(
+    fee_type: str,
+    semester_no: Optional[int],
+    status: str,
+    paid_amount: Decimal,
+) -> bool:
+    """Check if a fee is in HK1 cleared state.
+
+    Cleared = tuition + semester_no=1 + one of:
+      - status in (paid, waived)
+      - status == partial AND paid_amount > 0
+
+    Used by PR 5 (ADR-002) to detect transition into cleared state
+    at payment/waiver call sites. Callers snapshot pre-state, apply
+    mutation, then check post-state: sync only on False -> True.
+    """
+    if fee_type != "tuition" or semester_no != 1:
+        return False
+    if status in ("paid", "waived"):
+        return True
+    if status == "partial" and paid_amount > 0:
+        return True
+    return False
+
+
 class FeeCalculationService:
     """
     Service for fee calculation and lifecycle management.
@@ -260,8 +285,8 @@ class FeeCalculationService:
             user_id=user_id,
         )
 
-        # SYNC LEAD STATUS: For tuition fee, move lead to sts14 (Chờ học phí)
-        if fee_type == FeeTypeEnum.tuition:
+        # ADR-002 PR 5: Only HK1 fee creation projects into admission pipeline.
+        if fee_type == FeeTypeEnum.tuition and semester_no == 1:
             from app.services.lead_admission_sync import sync_lead_tuition_calculated
             await sync_lead_tuition_calculated(
                 db=self.db,
@@ -409,8 +434,8 @@ class FeeCalculationService:
 
         await self.db.flush()
 
-        # ✅ SYNC LEAD STATUS: If tuition fee is now fully waived, move lead to sts10
-        if fee_became_paid and fee.fee_type == FeeTypeEnum.tuition.value:
+        # ADR-002 PR 5: Only HK1 waiver projects into admission pipeline.
+        if fee_became_paid and fee.fee_type == FeeTypeEnum.tuition.value and fee.semester_no == 1:
             # Need to load profile with lead for sync
             profile = await self._get_profile(fee.admission_profile_id, unit_id)
             if profile:

--- a/Backend_FastAPI/app/services/lead_admission_sync.py
+++ b/Backend_FastAPI/app/services/lead_admission_sync.py
@@ -322,11 +322,13 @@ async def sync_lead_tuition_calculated(
     reason: Optional[str] = None,
 ) -> bool:
     """
-    Sync lead consultation status when tuition fee is calculated.
+    Sync lead consultation status when HK1 tuition fee is calculated.
 
     Moves lead to sts14 (Chưa hoàn tất học phí / Chờ đóng học phí).
 
-    This indicates the profile is approved and waiting for tuition payment.
+    ADR-002 PR 5: This function is for HK1 only. Callers MUST gate
+    invocation to semester_no == 1 before calling. HK2+ fee creation
+    must not project into the admission pipeline.
 
     Args:
         db: Database session (same transaction as caller)
@@ -419,11 +421,15 @@ async def sync_lead_tuition_paid(
     reason: Optional[str] = None,
 ) -> bool:
     """
-    Sync lead consultation status when tuition fee is fully paid or waived.
+    Sync lead consultation status when HK1 tuition reaches cleared state.
 
     Moves lead to sts10 (Đã hoàn tất học phí).
 
-    This indicates the profile is ready for enrollment (fee gate passed).
+    ADR-002 PR 5: "Cleared" means paid, waived, or partial with
+    paid_amount > 0. Does NOT require full payment. Callers MUST:
+    1. Gate invocation to semester_no == 1 (HK1 only)
+    2. Fire only on the first transition into cleared state (use
+       is_hk1_cleared pre/post pattern to avoid duplicate syncs)
 
     Args:
         db: Database session (same transaction as caller)
@@ -516,9 +522,12 @@ async def sync_lead_tuition_refunded(
     reason: Optional[str] = None,
 ) -> bool:
     """
-    Sync lead consultation status when tuition fee is refunded.
+    Sync lead consultation status when HK1 tuition fee is refunded.
 
     Moves lead to sts18 (Đã hoàn học phí).
+
+    ADR-002 PR 5: HK1-only. Callers MUST gate invocation to
+    semester_no == 1. HK2+ refunds must not affect the admission pipeline.
 
     This is a terminal state indicating the student has withdrawn after payment.
 

--- a/Backend_FastAPI/app/services/payment_intent_service.py
+++ b/Backend_FastAPI/app/services/payment_intent_service.py
@@ -565,6 +565,12 @@ class PaymentIntentService:
         elif invoice.paid_amount > 0:
             invoice.status = InvoiceStatusEnum.partial.value
 
+        # ADR-002 PR 5: snapshot cleared state BEFORE fee mutation
+        from app.services.fee_calculation_service import is_hk1_cleared
+        was_hk1_cleared = is_hk1_cleared(
+            fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+        )
+
         # Update fee paid_amount
         fee.paid_amount = fee.paid_amount + intent.amount
         fee.last_payment_at = datetime.now(timezone.utc)
@@ -607,21 +613,18 @@ class PaymentIntentService:
             )
             profile = result.scalar_one_or_none()
 
-        # Sync lead pipeline for tuition payments (mirrors manual verify path
-        # at payment_service.py:322-333). Only fires when the tuition fee is
-        # fully paid after this online payment.
-        if (
-            fee_remaining <= 0
-            and fee.fee_type == "tuition"
-            and profile is not None
-        ):
+        # ADR-002 PR 5: Sync lead only on HK1 cleared-state transition.
+        now_hk1_cleared = is_hk1_cleared(
+            fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+        )
+        if not was_hk1_cleared and now_hk1_cleared and profile is not None:
             from app.services.lead_admission_sync import sync_lead_tuition_paid
             await sync_lead_tuition_paid(
                 db=self.db,
                 profile=profile,
                 transaction_id=payment.reference_code or f"PAY-{payment.id}",
-                changed_by_user_id=1,  # system user
-                reason=f"Online tuition payment via {intent.method.code}",
+                changed_by_user_id=1,
+                reason=f"HK1 tuition cleared via online payment ({intent.method.code})",
             )
 
         return payment, fee, profile

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -274,8 +274,12 @@ class PaymentService:
         if not fee:
             raise ResourceNotFoundError("Fee not found")
 
-        # Capture balance before
+        # Capture balance + cleared state BEFORE mutation (PR 5 transition detection)
         fee_balance_before = fee.final_amount - fee.paid_amount - fee.waived_amount
+        from app.services.fee_calculation_service import is_hk1_cleared
+        was_hk1_cleared = is_hk1_cleared(
+            fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+        )
 
         # Update payment status
         payment.status = PaymentStatusEnum.verified.value
@@ -318,9 +322,13 @@ class PaymentService:
 
         await self.db.flush()
 
-        # ✅ SYNC LEAD STATUS: If tuition fee is now fully paid, move lead to sts10
-        if fee_remaining <= 0 and fee.fee_type == "tuition":
-            # Load profile with lead for sync
+        # ADR-002 PR 5: Sync lead only on HK1 cleared-state transition.
+        # "Cleared" = paid OR waived OR (partial + paid_amount > 0).
+        # Only fires once: pre=not-cleared -> post=cleared.
+        now_hk1_cleared = is_hk1_cleared(
+            fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+        )
+        if not was_hk1_cleared and now_hk1_cleared:
             profile = await self._get_profile_for_fee(fee)
             if profile:
                 from app.services.lead_admission_sync import sync_lead_tuition_paid
@@ -329,7 +337,7 @@ class PaymentService:
                     profile=profile,
                     transaction_id=payment.reference_code or f"PAY-{payment.id}",
                     changed_by_user_id=verifier_id,
-                    reason=f"Tuition fee fully paid. Amount: {payment.amount:,.0f} VND",
+                    reason=f"HK1 tuition cleared. Payment: {payment.amount:,.0f} VND",
                 )
 
         log.info(
@@ -351,10 +359,11 @@ class PaymentService:
         if profile and hasattr(profile, 'lead') and profile.lead:
             _officer_id = profile.lead.assigned_officer_id
 
-        # Capture data for post-commit closure
-        # Recipient: the officer who owns the lead (not the verifier)
-        # Phase 1 internal: notify officer about payment confirmation
-        # Phase 2 external (Zalo ZNS): will also notify applicant via lead phone
+        # ADR-002 D10: Under the per-semester model, each Fee is one semester.
+        # fee_remaining <= 0 means "this semester's fee is fully paid", not
+        # "all tuition fully paid". The lead sync above (gated via
+        # is_hk1_cleared transition) handles the pipeline projection;
+        # this notification payload is semester-scoped by construction.
         _notify_payload = {
             "payment_id": payment.id,
             "invoice_id": invoice.id,
@@ -888,14 +897,8 @@ class RefundService:
         # payload. Same query is used by the inline lead sync below.
         profile = await self._get_profile_for_fee(fee)
 
-        # ✅ SYNC LEAD STATUS: If tuition fee refund, move lead to sts18 (Đã hoàn học phí)
-        # Only sync if this is a tuition fee refund.
-        # NOTE (ADR-002 PR 5 follow-up): this projection currently fires
-        # unconditionally for any tuition refund. After the semester
-        # tuition epic lands, it must be gated to fee.semester_no == 1 so
-        # HK2+ refunds do not drag the admission pipeline backwards.
-        # Tracked in PR 5 checklist.
-        if fee.fee_type == "tuition" and profile is not None:
+        # ADR-002 PR 5 (D9): Only HK1 refund projects into admission pipeline.
+        if fee.fee_type == "tuition" and fee.semester_no == 1 and profile is not None:
             from app.services.lead_admission_sync import sync_lead_tuition_refunded
             await sync_lead_tuition_refunded(
                 db=self.db,

--- a/Backend_FastAPI/tests/integration/test_finance_workflow.py
+++ b/Backend_FastAPI/tests/integration/test_finance_workflow.py
@@ -1066,3 +1066,87 @@ class TestSemesterTuitionRecalculation:
         await db.refresh(fee)
         assert fee.base_amount == original_base
 
+
+# =============================================================================
+# HK1 CLEARED-STATE PIPELINE GATE TESTS (PR 5 — ADR-002)
+# =============================================================================
+
+class TestHK1ClearedStatePipelineGate:
+    """Test that admission pipeline projections use HK1 cleared-state
+    semantics: fires once on first HK1 clearance, never for HK2+."""
+
+    @pytest.mark.asyncio
+    async def test_is_hk1_cleared_helper(self):
+        """Unit test for the shared is_hk1_cleared helper."""
+        from app.services.fee_calculation_service import is_hk1_cleared
+
+        # Cleared states for HK1
+        assert is_hk1_cleared("tuition", 1, "paid", Decimal("10000000")) is True
+        assert is_hk1_cleared("tuition", 1, "waived", Decimal("0")) is True
+        assert is_hk1_cleared("tuition", 1, "partial", Decimal("100000")) is True
+
+        # Not cleared
+        assert is_hk1_cleared("tuition", 1, "partial", Decimal("0")) is False
+        assert is_hk1_cleared("tuition", 1, "pending", Decimal("0")) is False
+        assert is_hk1_cleared("tuition", 1, "calculated", Decimal("0")) is False
+        assert is_hk1_cleared("tuition", 1, "invoiced", Decimal("0")) is False
+        assert is_hk1_cleared("tuition", 1, "overdue", Decimal("0")) is False
+        assert is_hk1_cleared("tuition", 1, "cancelled", Decimal("0")) is False
+
+        # Wrong semester / wrong type
+        assert is_hk1_cleared("tuition", 2, "paid", Decimal("10000000")) is False
+        assert is_hk1_cleared("tuition", 3, "paid", Decimal("10000000")) is False
+        assert is_hk1_cleared("application", 1, "paid", Decimal("10000000")) is False
+        assert is_hk1_cleared("tuition", None, "paid", Decimal("10000000")) is False
+
+    @pytest.mark.asyncio
+    async def test_hk1_first_partial_triggers_transition(self):
+        """First partial HK1 payment: False -> True transition = sync fires."""
+        from app.services.fee_calculation_service import is_hk1_cleared
+
+        was = is_hk1_cleared("tuition", 1, "calculated", Decimal("0"))
+        assert was is False
+
+        now = is_hk1_cleared("tuition", 1, "partial", Decimal("3000000"))
+        assert now is True
+        assert not was and now  # Transition detected
+
+    @pytest.mark.asyncio
+    async def test_hk1_second_payment_no_retrigger(self):
+        """Second payment on already-cleared HK1: True -> True = no sync."""
+        from app.services.fee_calculation_service import is_hk1_cleared
+
+        was = is_hk1_cleared("tuition", 1, "partial", Decimal("3000000"))
+        assert was is True
+
+        now = is_hk1_cleared("tuition", 1, "partial", Decimal("6000000"))
+        assert now is True
+        assert not (not was and now)  # No transition
+
+    @pytest.mark.asyncio
+    async def test_hk2_payment_never_triggers(self):
+        """HK2 payment: always False, no sync regardless of state."""
+        from app.services.fee_calculation_service import is_hk1_cleared
+
+        assert is_hk1_cleared("tuition", 2, "paid", Decimal("10000000")) is False
+        assert is_hk1_cleared("tuition", 2, "partial", Decimal("5000000")) is False
+        assert is_hk1_cleared("tuition", 2, "waived", Decimal("0")) is False
+
+    @pytest.mark.asyncio
+    async def test_hk1_waiver_triggers_transition(self):
+        """HK1 waiver: False -> True transition = sync fires."""
+        from app.services.fee_calculation_service import is_hk1_cleared
+
+        was = is_hk1_cleared("tuition", 1, "calculated", Decimal("0"))
+        now = is_hk1_cleared("tuition", 1, "waived", Decimal("0"))
+        assert not was and now
+
+    @pytest.mark.asyncio
+    async def test_hk1_full_payment_triggers_transition(self):
+        """HK1 full payment: False -> True transition = sync fires."""
+        from app.services.fee_calculation_service import is_hk1_cleared
+
+        was = is_hk1_cleared("tuition", 1, "invoiced", Decimal("0"))
+        now = is_hk1_cleared("tuition", 1, "paid", Decimal("10000000"))
+        assert not was and now
+


### PR DESCRIPTION
PR 5 of semester_tuition epic. Gates 3 admission tuition projections to HK1 cleared-state semantics. sync_lead_tuition_paid fires on first HK1 clearance (paid/waived/partial+paid>0), not on fee_remaining<=0. 7 files, 191 insertions, 6 focused tests. No migration.