### PR TITLE
feat(public): PR 6 — semester tuition in public & admin API + frontend

### DIFF
--- a/Backend_FastAPI/app/schemas/public_admissions.py
+++ b/Backend_FastAPI/app/schemas/public_admissions.py
@@ -18,6 +18,12 @@ class PublicAdmissionsMethodTag(BaseModel):
     name: str
 
 
+class PublicSemesterTuitionItem(BaseModel):
+    """Per-semester tuition row for public display (PR 6 — ADR-002)."""
+    semester_no: int = Field(..., ge=1)
+    amount: Decimal = Field(..., ge=0)
+
+
 class PublicAdmissionsAcademicInfoSummary(BaseModel):
     id: int
     academic_year: int = Field(..., ge=2000, le=2100)
@@ -26,6 +32,9 @@ class PublicAdmissionsAcademicInfoSummary(BaseModel):
     cutoff_score_previous_year: Optional[Decimal] = Field(default=None, ge=0)
     target_audience: Optional[str] = None
     applied_discount_policy_ids: List[int] = Field(default_factory=list)
+    # PR 6 (ADR-002 Decision 5): additive semester tuition fields
+    semester_tuitions: List[PublicSemesterTuitionItem] = Field(default_factory=list)
+    semester_1_tuition: Optional[Decimal] = Field(default=None, ge=0)
 
 
 class PublicAdmissionsOfferingSummary(BaseModel):
@@ -47,6 +56,8 @@ class PublicAdmissionsProgramSummary(BaseModel):
     academic_years: List[int] = Field(default_factory=list)
     tuition_min: Optional[Decimal] = Field(default=None, ge=0)
     tuition_max: Optional[Decimal] = Field(default=None, ge=0)
+    semester_1_tuition_min: Optional[Decimal] = Field(default=None, ge=0)
+    semester_1_tuition_max: Optional[Decimal] = Field(default=None, ge=0)
     offerings: List[PublicAdmissionsOfferingSummary] = Field(default_factory=list)
 
 
@@ -58,6 +69,8 @@ class PublicAdmissionsDegreeLevelGroup(BaseModel):
     academic_years: List[int] = Field(default_factory=list)
     tuition_min: Optional[Decimal] = Field(default=None, ge=0)
     tuition_max: Optional[Decimal] = Field(default=None, ge=0)
+    semester_1_tuition_min: Optional[Decimal] = Field(default=None, ge=0)
+    semester_1_tuition_max: Optional[Decimal] = Field(default=None, ge=0)
     programs: List[PublicAdmissionsProgramSummary] = Field(default_factory=list)
 
 
@@ -180,6 +193,8 @@ class PublicAdmissionsTuitionOffering(BaseModel):
     tuition_fee_per_year: Optional[Decimal] = Field(default=None, ge=0)
     annual_admission_quota: Optional[int] = Field(default=None, ge=0)
     applied_discount_policy_ids: List[int] = Field(default_factory=list)
+    semester_tuitions: List[PublicSemesterTuitionItem] = Field(default_factory=list)
+    semester_1_tuition: Optional[Decimal] = Field(default=None, ge=0)
 
 
 class PublicAdmissionsTuitionBand(BaseModel):
@@ -188,6 +203,8 @@ class PublicAdmissionsTuitionBand(BaseModel):
     academic_years: List[int] = Field(default_factory=list)
     tuition_min: Optional[Decimal] = Field(default=None, ge=0)
     tuition_max: Optional[Decimal] = Field(default=None, ge=0)
+    semester_1_tuition_min: Optional[Decimal] = Field(default=None, ge=0)
+    semester_1_tuition_max: Optional[Decimal] = Field(default=None, ge=0)
 
 
 class PublicAdmissionsTuitionMeta(BaseModel):

--- a/Backend_FastAPI/app/services/public_admissions_service.py
+++ b/Backend_FastAPI/app/services/public_admissions_service.py
@@ -81,6 +81,24 @@ def _money_range(values: Iterable[Optional[Decimal]]) -> Tuple[Optional[Decimal]
     return min(valid_values), max(valid_values)
 
 
+def _extract_semester_data(
+    academic_info,
+) -> Tuple[List["PublicSemesterTuitionItem"], Optional[Decimal]]:
+    """Extract per-semester tuition items + HK1 amount from a loaded academic info.
+
+    Returns (items_ordered_by_semester_no, hk1_amount_or_None).
+    """
+    from app.schemas.public_admissions import PublicSemesterTuitionItem
+
+    items = []
+    hk1_amount = None
+    for st in getattr(academic_info, "semester_tuitions", None) or []:
+        items.append(PublicSemesterTuitionItem(semester_no=st.semester_no, amount=st.amount))
+        if st.semester_no == 1:
+            hk1_amount = st.amount
+    return items, hk1_amount
+
+
 async def _load_public_program_snapshot(
     db: AsyncSession,
 ) -> Tuple[
@@ -266,6 +284,7 @@ async def get_public_programs_catalog(
     for program in programs:
         program_offerings: List[PublicAdmissionsOfferingSummary] = []
         program_tuition_values: List[Optional[Decimal]] = []
+        program_hk1_values: List[Optional[Decimal]] = []
         program_years: Set[int] = set()
 
         ordered_offerings = sorted(
@@ -282,6 +301,9 @@ async def get_public_programs_catalog(
             program_years.add(academic_info.academic_year)
             program_tuition_values.append(academic_info.tuition_fee_per_year)
 
+            sem_items, hk1_amount = _extract_semester_data(academic_info)
+            program_hk1_values.append(hk1_amount)
+
             program_offerings.append(
                 PublicAdmissionsOfferingSummary(
                     id=offering.id,
@@ -296,6 +318,8 @@ async def get_public_programs_catalog(
                         cutoff_score_previous_year=academic_info.cutoff_score_previous_year,
                         target_audience=academic_info.target_audience,
                         applied_discount_policy_ids=academic_info.applied_discount_policy_ids or [],
+                        semester_tuitions=sem_items,
+                        semester_1_tuition=hk1_amount,
                     ),
                     admission_methods=method_tags_by_info_id.get(academic_info.id, []),
                 )
@@ -305,6 +329,7 @@ async def get_public_programs_catalog(
             continue
 
         tuition_min, tuition_max = _money_range(program_tuition_values)
+        hk1_min, hk1_max = _money_range(program_hk1_values)
         degree_groups[program.degree_level].append(
             PublicAdmissionsProgramSummary(
                 id=program.id,
@@ -316,6 +341,8 @@ async def get_public_programs_catalog(
                 academic_years=sorted(program_years, reverse=True),
                 tuition_min=tuition_min,
                 tuition_max=tuition_max,
+                semester_1_tuition_min=hk1_min,
+                semester_1_tuition_max=hk1_max,
                 offerings=program_offerings,
             )
         )
@@ -331,6 +358,11 @@ async def get_public_programs_catalog(
             for program in programs_in_group
             for offering in program.offerings
         ]
+        group_hk1_values = [
+            offering.academic_info.semester_1_tuition
+            for program in programs_in_group
+            for offering in program.offerings
+        ]
         group_years = sorted(
             {year for program in programs_in_group for year in program.academic_years},
             reverse=True,
@@ -340,6 +372,7 @@ async def get_public_programs_catalog(
             key=_sort_offering_type,
         )
         tuition_min, tuition_max = _money_range(group_tuition_values)
+        hk1_min, hk1_max = _money_range(group_hk1_values)
         degree_level_items.append(
             PublicAdmissionsDegreeLevelGroup(
                 degree_level=degree_level,
@@ -349,6 +382,8 @@ async def get_public_programs_catalog(
                 academic_years=group_years,
                 tuition_min=tuition_min,
                 tuition_max=tuition_max,
+                semester_1_tuition_min=hk1_min,
+                semester_1_tuition_max=hk1_max,
                 programs=programs_in_group,
             )
         )
@@ -620,6 +655,7 @@ async def get_public_tuition_catalog(
             for policy_id in academic_info.applied_discount_policy_ids or []:
                 policy_ids.add(policy_id)
 
+            sem_items, hk1_amount = _extract_semester_data(academic_info)
             item = PublicAdmissionsTuitionOffering(
                 program_id=program.id,
                 program_name=program.name,
@@ -632,6 +668,8 @@ async def get_public_tuition_catalog(
                 tuition_fee_per_year=academic_info.tuition_fee_per_year,
                 annual_admission_quota=academic_info.annual_admission_quota,
                 applied_discount_policy_ids=academic_info.applied_discount_policy_ids or [],
+                semester_tuitions=sem_items,
+                semester_1_tuition=hk1_amount,
             )
             tuition_offerings.append(item)
             degree_level_bands[program.degree_level].append(item)
@@ -670,6 +708,7 @@ async def get_public_tuition_catalog(
     for degree_level in sorted(degree_level_bands.keys(), key=_sort_degree_level):
         items = degree_level_bands[degree_level]
         tuition_min, tuition_max = _money_range(item.tuition_fee_per_year for item in items)
+        hk1_min, hk1_max = _money_range(item.semester_1_tuition for item in items)
         degree_levels.append(
             PublicAdmissionsTuitionBand(
                 degree_level=degree_level,
@@ -677,6 +716,8 @@ async def get_public_tuition_catalog(
                 academic_years=sorted({item.academic_year for item in items}, reverse=True),
                 tuition_min=tuition_min,
                 tuition_max=tuition_max,
+                semester_1_tuition_min=hk1_min,
+                semester_1_tuition_max=hk1_max,
             )
         )
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.tsx
@@ -218,9 +218,13 @@ export function TuitionTab({ profile }: TuitionTabProps) {
                     <FileText className="h-4 w-4 text-primary" />
                   </div>
                   <div>
-                    <p className="font-medium">{FEE_TYPE_LABELS[fee.fee_type] ?? fee.fee_type}</p>
+                    <p className="font-medium">
+                      {FEE_TYPE_LABELS[fee.fee_type] ?? fee.fee_type}
+                      {fee.semester_no ? ` — HK${fee.semester_no}` : ""}
+                    </p>
                     <p className="text-xs text-muted-foreground">
                       Năm học: {fee.academic_year}
+                      {fee.semester_no ? ` | HK${fee.semester_no}` : ""}
                     </p>
                   </div>
                 </div>

--- a/frontend/src/components/public/PublicProgramsPage.tsx
+++ b/frontend/src/components/public/PublicProgramsPage.tsx
@@ -257,7 +257,10 @@ export default function PublicProgramsPage({ catalog }: PublicProgramsPageProps)
 
                             <div className="mt-5 space-y-3">
                               {program.offerings.map((offering) => {
-                                const tuitionLabel = formatCurrency(offering.academic_info.tuition_fee_per_year)
+                                const hasHK1 = offering.academic_info.semester_1_tuition != null
+                                const tuitionLabel = hasHK1
+                                  ? formatCurrency(offering.academic_info.semester_1_tuition)
+                                  : formatCurrency(offering.academic_info.tuition_fee_per_year)
                                 const quotaLabel =
                                   offering.academic_info.annual_admission_quota !== null
                                     ? `${offering.academic_info.annual_admission_quota} chỉ tiêu`
@@ -281,7 +284,7 @@ export default function PublicProgramsPage({ catalog }: PublicProgramsPageProps)
                                     <div className="mt-3 grid gap-3 sm:grid-cols-2">
                                       <div>
                                         <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                                          Học phí
+                                          {hasHK1 ? "Học phí HK1" : "Học phí"}
                                         </p>
                                         <p className="mt-1 text-sm font-medium text-foreground">
                                           {tuitionLabel ?? "Đang cập nhật"}
@@ -316,6 +319,22 @@ export default function PublicProgramsPage({ catalog }: PublicProgramsPageProps)
                                         {offering.academic_info.target_audience}
                                       </p>
                                     ) : null}
+
+                                    {offering.academic_info.semester_tuitions && offering.academic_info.semester_tuitions.length > 0 && (
+                                      <div className="mt-4">
+                                        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground mb-2">
+                                          Bảng học phí toàn khóa theo từng học kỳ
+                                        </p>
+                                        <div className="grid grid-cols-2 gap-1 text-xs sm:grid-cols-4">
+                                          {offering.academic_info.semester_tuitions.map((st) => (
+                                            <div key={st.semester_no} className="rounded bg-muted/50 px-2 py-1">
+                                              <span className="font-medium">HK{st.semester_no}:</span>{" "}
+                                              {formatCurrency(st.amount)}
+                                            </div>
+                                          ))}
+                                        </div>
+                                      </div>
+                                    )}
 
                                     {offering.admission_methods.length > 0 ? (
                                       <div className="mt-4 space-y-2">

--- a/frontend/src/lib/zod/finance.ts
+++ b/frontend/src/lib/zod/finance.ts
@@ -209,6 +209,7 @@ export const feeSummarySchema = z.object({
   id: z.number().int().positive(),
   fee_type: feeTypeSchema,
   academic_year: z.string(),
+  semester_no: z.number().int().positive().nullable().optional(),
   final_amount: z.string(),
   paid_amount: z.string(),
   remaining_amount: z.string(),

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -130,6 +130,7 @@ export interface FeeSummary {
   id: number
   fee_type: FeeType
   academic_year: string
+  semester_no?: number | null
   final_amount: string
   paid_amount: string
   remaining_amount: string

--- a/frontend/src/types/public-admissions.types.ts
+++ b/frontend/src/types/public-admissions.types.ts
@@ -1,5 +1,10 @@
 export type PublicAdmissionsMoney = number | string | null
 
+export interface PublicSemesterTuitionItem {
+  semester_no: number
+  amount: PublicAdmissionsMoney
+}
+
 export interface PublicAdmissionsMethodTag {
   id: number
   code: string
@@ -14,6 +19,8 @@ export interface PublicAdmissionsAcademicInfoSummary {
   cutoff_score_previous_year: PublicAdmissionsMoney
   target_audience: string | null
   applied_discount_policy_ids: number[]
+  semester_tuitions?: PublicSemesterTuitionItem[]
+  semester_1_tuition?: PublicAdmissionsMoney
 }
 
 export interface PublicAdmissionsOfferingSummary {
@@ -35,6 +42,8 @@ export interface PublicAdmissionsProgramSummary {
   academic_years: number[]
   tuition_min: PublicAdmissionsMoney
   tuition_max: PublicAdmissionsMoney
+  semester_1_tuition_min?: PublicAdmissionsMoney
+  semester_1_tuition_max?: PublicAdmissionsMoney
   offerings: PublicAdmissionsOfferingSummary[]
 }
 
@@ -46,6 +55,8 @@ export interface PublicAdmissionsDegreeLevelGroup {
   academic_years: number[]
   tuition_min: PublicAdmissionsMoney
   tuition_max: PublicAdmissionsMoney
+  semester_1_tuition_min?: PublicAdmissionsMoney
+  semester_1_tuition_max?: PublicAdmissionsMoney
   programs: PublicAdmissionsProgramSummary[]
 }
 
@@ -168,6 +179,8 @@ export interface PublicAdmissionsTuitionOffering {
   tuition_fee_per_year: PublicAdmissionsMoney
   annual_admission_quota: number | null
   applied_discount_policy_ids: number[]
+  semester_tuitions?: PublicSemesterTuitionItem[]
+  semester_1_tuition?: PublicAdmissionsMoney
 }
 
 export interface PublicAdmissionsTuitionBand {
@@ -176,6 +189,8 @@ export interface PublicAdmissionsTuitionBand {
   academic_years: number[]
   tuition_min: PublicAdmissionsMoney
   tuition_max: PublicAdmissionsMoney
+  semester_1_tuition_min?: PublicAdmissionsMoney
+  semester_1_tuition_max?: PublicAdmissionsMoney
 }
 
 export interface PublicAdmissionsTuitionMeta {


### PR DESCRIPTION
PR 6 of semester_tuition epic. Additive non-breaking: semester_tuitions[], semester_1_tuition, semester_1_tuition_min/max added to public API + frontend. Legacy fields kept unchanged. 7 files (2 backend + 5 frontend). No migration.