### PR TITLE
fix(admissions): make filters SSR-safe and align prefetch query

### DIFF
--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -109,9 +109,13 @@ import {
   useBulkAssignAdmissions,
   useExportAdmissions,
 } from "@/hooks/admissions"
+import {
+  areAdmissionsListParamsEqual,
+  CURRENT_ADMISSIONS_YEAR,
+} from "@/hooks/admissions/filterDefaults"
 import { admissionsApi } from "@/lib/api/admissions"
 import { handleApiError, type ApiErrorResponse } from "@/lib/error-handler"
-import type { AdmissionProfileResponse, AdmissionsPage } from "@/lib/zod/admissions"
+import type { AdmissionListParams, AdmissionProfileResponse, AdmissionsPage } from "@/lib/zod/admissions"
 import { getColumns, STATUS_CONFIG, ELIGIBILITY_CONFIG } from "./columns"
 import { AdmissionsBulkActionsBar } from "./AdmissionsBulkActionsBar"
 import { BulkRejectDialog } from "./dialogs/BulkRejectDialog"
@@ -121,7 +125,7 @@ import { BulkAssignDialog } from "./dialogs/BulkAssignDialog"
 // CONSTANTS
 // =============================================================================
 
-const CURRENT_YEAR = new Date().getFullYear()
+const CURRENT_YEAR = CURRENT_ADMISSIONS_YEAR
 
 const STATUS_OPTIONS = [
   { value: "draft", label: "Nháp" },
@@ -209,9 +213,10 @@ function formatShortDate(str: string): string {
 
 interface AdmissionsClientProps {
   initialData?: AdmissionsPage
+  initialQueryParams?: AdmissionListParams
 }
 
-export function AdmissionsClient({ initialData }: AdmissionsClientProps) {
+export function AdmissionsClient({ initialData, initialQueryParams }: AdmissionsClientProps) {
   const queryClient = useQueryClient()
 
   // ── Filter state (URL sync + localStorage) ────────────────────────────
@@ -252,9 +257,9 @@ export function AdmissionsClient({ initialData }: AdmissionsClientProps) {
   }, [academicYears])
 
   // ── Data queries ──────────────────────────────────────────────────────
-  // Only use SSR initialData when filters match server defaults (no filters, page 1).
-  // Otherwise React Query treats stale initialData as "fresh" and skips refetch.
-  const safeInitialData = !hasActiveFilters && state.page === 1 ? initialData : undefined
+  // Only attach SSR data while the current query still matches the server query.
+  // After localStorage hydration or user edits, a new query must fetch its own data.
+  const safeInitialData = areAdmissionsListParamsEqual(apiFilters, initialQueryParams) ? initialData : undefined
   const { data, isLoading, isError, isFetching } = useListAdmissions(apiFilters, { initialData: safeInitialData })
   const { data: statusCounts } = useAdmissionStatusCounts(countFilters)
   const { data: stats } = useAdmissionStats(state.academicYear)

--- a/frontend/src/app/(dashboard)/admissions/page.tsx
+++ b/frontend/src/app/(dashboard)/admissions/page.tsx
@@ -10,6 +10,10 @@ import { Suspense } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { serverApi } from '@/lib/api/server';
+import {
+  parseAdmissionsSearchParamsToApiParams,
+  type AdmissionsSearchParamsRecord,
+} from '@/hooks/admissions/filterDefaults';
 import { AdmissionsClient } from './_components/AdmissionsClient';
 
 /**
@@ -56,22 +60,29 @@ function AdmissionsLoading() {
 /**
  * Server Component - Fetches initial admissions data
  */
-async function AdmissionsPageContent() {
-  const initialData = await serverApi.admissions.listProfiles({
-    page: 1,
-    page_size: 20,
-  });
+async function AdmissionsPageContent({
+  searchParams,
+}: {
+  searchParams: Promise<AdmissionsSearchParamsRecord>;
+}) {
+  const resolvedParams = await searchParams;
+  const initialQueryParams = parseAdmissionsSearchParamsToApiParams(resolvedParams);
+  const initialData = await serverApi.admissions.listProfiles(initialQueryParams);
 
-  return <AdmissionsClient initialData={initialData} />;
+  return <AdmissionsClient initialData={initialData} initialQueryParams={initialQueryParams} />;
 }
 
 /**
  * Page Component (Server Component)
  */
-export default function AdmissionsPage() {
+export default function AdmissionsPage({
+  searchParams,
+}: {
+  searchParams: Promise<AdmissionsSearchParamsRecord>;
+}) {
   return (
     <Suspense fallback={<AdmissionsLoading />}>
-      <AdmissionsPageContent />
+      <AdmissionsPageContent searchParams={searchParams} />
     </Suspense>
   );
 }

--- a/frontend/src/hooks/admissions/filterDefaults.ts
+++ b/frontend/src/hooks/admissions/filterDefaults.ts
@@ -1,0 +1,104 @@
+import type { AdmissionListParams } from "@/lib/zod/admissions"
+
+export type AdmissionsSearchParamsRecord = Record<string, string | string[] | undefined>
+
+export const ADMISSIONS_DEFAULT_PAGE_SIZE = 20
+export const ADMISSIONS_DEFAULT_SORT_BY: NonNullable<AdmissionListParams["sort_by"]> = "created_at"
+export const ADMISSIONS_DEFAULT_SORT_ORDER: NonNullable<AdmissionListParams["order"]> = "desc"
+export const CURRENT_ADMISSIONS_YEAR = new Date().getFullYear()
+
+const ADMISSIONS_LIST_PARAM_KEYS = [
+  "page",
+  "page_size",
+  "status",
+  "search",
+  "major_id",
+  "academic_year",
+  "degree_level",
+  "payment_status",
+  "date_from",
+  "date_to",
+  "sort_by",
+  "order",
+] as const satisfies readonly (keyof AdmissionListParams)[]
+
+function getFirstParam(
+  searchParams: AdmissionsSearchParamsRecord,
+  key: string,
+): string | undefined {
+  const value = searchParams[key]
+  return typeof value === "string" ? value : Array.isArray(value) ? value[0] : undefined
+}
+
+function parseIntegerParam(value: string | undefined): number | undefined {
+  if (!value) return undefined
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+export function getDefaultAdmissionsListParams(
+  pageSize: number = ADMISSIONS_DEFAULT_PAGE_SIZE,
+): AdmissionListParams {
+  return {
+    page: 1,
+    page_size: pageSize,
+    academic_year: CURRENT_ADMISSIONS_YEAR,
+    sort_by: ADMISSIONS_DEFAULT_SORT_BY,
+    order: ADMISSIONS_DEFAULT_SORT_ORDER,
+  }
+}
+
+export function parseAdmissionsSearchParamsToApiParams(
+  searchParams: AdmissionsSearchParamsRecord,
+  pageSize: number = ADMISSIONS_DEFAULT_PAGE_SIZE,
+): AdmissionListParams {
+  const params = getDefaultAdmissionsListParams(pageSize)
+
+  const page = parseIntegerParam(getFirstParam(searchParams, "page"))
+  if (page !== undefined && page > 0) params.page = page
+
+  const year = parseIntegerParam(getFirstParam(searchParams, "year"))
+  if (year !== undefined) params.academic_year = year
+
+  const status = getFirstParam(searchParams, "status")
+  if (status) params.status = status
+
+  const search = getFirstParam(searchParams, "q")
+  if (search) params.search = search
+
+  const major = getFirstParam(searchParams, "major")
+  if (major) params.major_id = major
+
+  const degree = getFirstParam(searchParams, "degree")
+  if (degree) params.degree_level = degree
+
+  const payment = getFirstParam(searchParams, "payment")
+  if (payment) params.payment_status = payment
+
+  const from = getFirstParam(searchParams, "from")
+  if (from) params.date_from = from
+
+  const to = getFirstParam(searchParams, "to")
+  if (to) params.date_to = to
+
+  return params
+}
+
+export function normalizeAdmissionsListParams(
+  params: AdmissionListParams = {},
+): AdmissionListParams {
+  return {
+    ...getDefaultAdmissionsListParams(params.page_size),
+    ...params,
+  }
+}
+
+export function areAdmissionsListParamsEqual(
+  a: AdmissionListParams | undefined,
+  b: AdmissionListParams | undefined,
+): boolean {
+  const normalizedA = normalizeAdmissionsListParams(a)
+  const normalizedB = normalizeAdmissionsListParams(b)
+
+  return ADMISSIONS_LIST_PARAM_KEYS.every((key) => normalizedA[key] === normalizedB[key])
+}

--- a/frontend/src/hooks/admissions/useAdmissionsFilter.test.ts
+++ b/frontend/src/hooks/admissions/useAdmissionsFilter.test.ts
@@ -8,7 +8,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { renderHook, act } from "@testing-library/react"
+import { createElement } from "react"
+import { renderToString } from "react-dom/server"
+import { renderHook, act, waitFor } from "@testing-library/react"
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -40,6 +42,72 @@ describe("useAdmissionsFilter", () => {
     vi.spyOn(Storage.prototype, "getItem").mockReturnValue(null)
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {})
     vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {})
+  })
+
+  describe("SSR-safe persisted filters", () => {
+    it("does not read localStorage during the server render path", () => {
+      const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockReturnValue(
+        JSON.stringify({
+          version: 1,
+          data: {
+            page: 1,
+            search: "",
+            statusFilters: ["draft"],
+            majorFilter: "",
+            academicYear: new Date().getFullYear(),
+            degreeLevelFilter: "",
+            paymentStatusFilter: "",
+            dateFrom: "",
+            dateTo: "",
+            activeTab: "draft",
+          },
+        }),
+      )
+
+      function Probe() {
+        const { state } = useAdmissionsFilter()
+        return createElement("span", null, state.activeTab)
+      }
+
+      expect(renderToString(createElement(Probe))).toContain("all")
+      expect(getItemSpy).not.toHaveBeenCalled()
+    })
+
+    it("restores localStorage filters after hydration", async () => {
+      vi.spyOn(Storage.prototype, "getItem").mockReturnValue(
+        JSON.stringify({
+          version: 1,
+          data: {
+            page: 2,
+            search: "Nguyen",
+            statusFilters: ["draft"],
+            majorFilter: "3",
+            academicYear: new Date().getFullYear() - 1,
+            degreeLevelFilter: "bachelor",
+            paymentStatusFilter: "paid",
+            dateFrom: "2026-01-01",
+            dateTo: "2026-01-31",
+            activeTab: "draft",
+          },
+        }),
+      )
+
+      const { result } = renderHook(() => useAdmissionsFilter())
+
+      await waitFor(() => {
+        expect(result.current.state.activeTab).toBe("draft")
+      })
+
+      expect(result.current.state.page).toBe(2)
+      expect(result.current.state.search).toBe("Nguyen")
+      expect(result.current.state.statusFilters).toEqual(["draft"])
+      expect(result.current.state.majorFilter).toBe("3")
+      expect(result.current.state.academicYear).toBe(new Date().getFullYear() - 1)
+      expect(result.current.state.degreeLevelFilter).toBe("bachelor")
+      expect(result.current.state.paymentStatusFilter).toBe("paid")
+      expect(result.current.state.dateFrom).toBe("2026-01-01")
+      expect(result.current.state.dateTo).toBe("2026-01-31")
+    })
   })
 
   describe("STATUS_TABS mapping (BUG-18)", () => {

--- a/frontend/src/hooks/admissions/useAdmissionsFilter.ts
+++ b/frontend/src/hooks/admissions/useAdmissionsFilter.ts
@@ -3,7 +3,7 @@
  * Admissions Filter Hook
  *
  * Manages all filter state for the Admissions list page:
- * - 3-tier init: URL params > localStorage > defaults
+ * - SSR-safe init: URL params > defaults, then localStorage after hydration
  * - URL sync via debounced History.replaceState (no RSC refetch)
  * - Versioned localStorage persistence
  * - Tab ↔ statusFilter synchronisation
@@ -17,6 +17,10 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from "react"
 import { useSearchParams, usePathname } from "next/navigation"
 import type { AdmissionListParams } from "@/lib/zod/admissions"
+import {
+  ADMISSIONS_DEFAULT_PAGE_SIZE,
+  CURRENT_ADMISSIONS_YEAR,
+} from "./filterDefaults"
 
 // =============================================================================
 // TYPES
@@ -70,7 +74,6 @@ export interface UseAdmissionsFilterReturn {
 
 const STORAGE_KEY = "admissions_filters"
 const STORAGE_VERSION = 1
-const CURRENT_YEAR = new Date().getFullYear()
 
 interface VersionedStorage {
   version: number
@@ -95,7 +98,7 @@ const DEFAULT_FILTERS: StoredFilters = {
   search: "",
   statusFilters: [],
   majorFilter: "",
-  academicYear: CURRENT_YEAR,
+  academicYear: CURRENT_ADMISSIONS_YEAR,
   degreeLevelFilter: "",
   paymentStatusFilter: "",
   dateFrom: "",
@@ -144,6 +147,18 @@ function clearFiltersFromStorage() {
   }
 }
 
+function arraysEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index])
+}
+
+function normalizeStoredFilters(filters: StoredFilters): StoredFilters {
+  return {
+    ...DEFAULT_FILTERS,
+    ...filters,
+    statusFilters: Array.isArray(filters.statusFilters) ? filters.statusFilters : [],
+  }
+}
+
 // =============================================================================
 // URL HELPERS
 // =============================================================================
@@ -170,7 +185,7 @@ function parseSearchParams(sp: URLSearchParams): StoredFilters {
     search: sp.get("q") || "",
     statusFilters: sp.get("status")?.split(",").filter(Boolean) || [],
     majorFilter: sp.get("major") || "",
-    academicYear: yearStr ? Number(yearStr) : CURRENT_YEAR,
+    academicYear: yearStr ? Number(yearStr) : CURRENT_ADMISSIONS_YEAR,
     degreeLevelFilter: sp.get("degree") || "",
     paymentStatusFilter: sp.get("payment") || "",
     dateFrom: sp.get("from") || "",
@@ -184,21 +199,21 @@ function parseSearchParams(sp: URLSearchParams): StoredFilters {
 // =============================================================================
 
 export function useAdmissionsFilter(
-  defaultPageSize: number = 20,
+  defaultPageSize: number = ADMISSIONS_DEFAULT_PAGE_SIZE,
 ): UseAdmissionsFilterReturn {
   const searchParams = useSearchParams()
   const pathname = usePathname()
   const isInitialMount = useRef(true)
+  const isStorageSyncInitialMount = useRef(true)
+  const hasInitialUrlFilters = useRef(hasUrlFilterParams(searchParams))
   const urlUpdateTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const prevSearchParamsStr = useRef(searchParams.toString())
 
-  // ── Determine initial values: URL > localStorage > defaults ───────────
+  // Determine initial values without reading localStorage, so SSR and hydration match.
   const initialValues = useMemo(() => {
     if (hasUrlFilterParams(searchParams)) {
       return parseSearchParams(searchParams)
     }
-    const stored = loadFiltersFromStorage()
-    if (stored) return stored
     return DEFAULT_FILTERS
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -217,6 +232,37 @@ export function useAdmissionsFilter(
   const [activeTab, setActiveTab] = useState(initialValues.activeTab)
   const [sortBy, setSortBy] = useState("created_at")
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc")
+
+  // Restore persisted filters only after hydration. URL params stay as the
+  // source of truth because the server can render them, while localStorage cannot.
+  useEffect(() => {
+    if (hasUrlFilterParams(searchParams)) return
+
+    const stored = loadFiltersFromStorage()
+    if (!stored) return
+
+    const restored = normalizeStoredFilters(stored)
+
+    setPage((current) => (current === restored.page ? current : restored.page))
+    setSearch((current) => (current === restored.search ? current : restored.search))
+    setStatusFilters((current) =>
+      arraysEqual(current, restored.statusFilters) ? current : [...restored.statusFilters],
+    )
+    setMajorFilter((current) => (current === restored.majorFilter ? current : restored.majorFilter))
+    setAcademicYear((current) =>
+      current === restored.academicYear ? current : restored.academicYear,
+    )
+    setDegreeLevelFilter((current) =>
+      current === restored.degreeLevelFilter ? current : restored.degreeLevelFilter,
+    )
+    setPaymentStatusFilter((current) =>
+      current === restored.paymentStatusFilter ? current : restored.paymentStatusFilter,
+    )
+    setDateFrom((current) => (current === restored.dateFrom ? current : restored.dateFrom))
+    setDateTo((current) => (current === restored.dateTo ? current : restored.dateTo))
+    setActiveTab((current) => (current === restored.activeTab ? current : restored.activeTab))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // ── EXTERNAL URL CHANGE DETECTION ─────────────────────────────────────
   const isInternalUrlChange = useRef(false)
@@ -262,7 +308,7 @@ export function useAdmissionsFilter(
       if (search) params.set("q", search)
       if (statusFilters.length > 0) params.set("status", statusFilters.join(","))
       if (majorFilter) params.set("major", majorFilter)
-      if (academicYear !== undefined && academicYear !== CURRENT_YEAR) {
+      if (academicYear !== undefined && academicYear !== CURRENT_ADMISSIONS_YEAR) {
         params.set("year", academicYear.toString())
       }
       if (degreeLevelFilter) params.set("degree", degreeLevelFilter)
@@ -299,12 +345,17 @@ export function useAdmissionsFilter(
       search ||
       statusFilters.length > 0 ||
       majorFilter ||
-      (academicYear !== undefined && academicYear !== CURRENT_YEAR) ||
+      (academicYear !== undefined && academicYear !== CURRENT_ADMISSIONS_YEAR) ||
       degreeLevelFilter ||
       paymentStatusFilter ||
       dateFrom ||
       dateTo ||
       activeTab !== "all"
+
+    if (isStorageSyncInitialMount.current) {
+      isStorageSyncInitialMount.current = false
+      if (!hasInitialUrlFilters.current) return
+    }
 
     if (shouldSave) {
       saveFiltersToStorage(data)
@@ -375,7 +426,7 @@ export function useAdmissionsFilter(
     setSearch("")
     setStatusFilters([])
     setMajorFilter("")
-    setAcademicYear(CURRENT_YEAR)
+    setAcademicYear(CURRENT_ADMISSIONS_YEAR)
     setDegreeLevelFilter("")
     setPaymentStatusFilter("")
     setDateFrom("")
@@ -397,7 +448,7 @@ export function useAdmissionsFilter(
       paymentStatusFilter ||
       dateFrom ||
       dateTo ||
-      (academicYear !== undefined && academicYear !== CURRENT_YEAR)
+      (academicYear !== undefined && academicYear !== CURRENT_ADMISSIONS_YEAR)
     )
   }, [
     search, statusFilters, majorFilter, degreeLevelFilter,

--- a/frontend/src/lib/api/server.ts
+++ b/frontend/src/lib/api/server.ts
@@ -66,7 +66,7 @@ import type {
   EventGroupPreferencesResponse,
   UserSessionListResponse,
 } from '@/types/api.types';
-import type { AdmissionProfileResponse, AdmissionsPage } from '@/lib/zod/admissions';
+import type { AdmissionListParams, AdmissionProfileResponse, AdmissionsPage } from '@/lib/zod/admissions';
 import type { EnhancedOfficerStats } from '@/hooks/useDashboardStats';
 import type { CollaboratorsPage } from '@/types/collaborator.types';
 import type {
@@ -538,12 +538,10 @@ const admissions = {
   /**
    * List admission profiles (Server-Side)
    */
-  async listProfiles(params?: {
-    status?: string;
-    page?: number;
-    page_size?: number;
-  }): Promise<AdmissionsPage> {
-    return serverFetch<AdmissionsPage>('/api/admissions', { params });
+  async listProfiles(params?: AdmissionListParams): Promise<AdmissionsPage> {
+    return serverFetch<AdmissionsPage>('/api/admissions', {
+      params: params as Record<string, unknown> | undefined,
+    });
   },
 };
 


### PR DESCRIPTION
## Summary

Pre-existing React hydration mismatch on `/admissions` surfaced during post-deploy smoke test of PR #123. Two independent root causes fixed together because they interact:

1. **localStorage in initial render** — `useAdmissionsFilter` read `loadFiltersFromStorage()` inside the initial `useMemo`, so whenever stored filters existed, the client's first render diverged from SSR. React logged *"Hydration failed"* and regenerated the whole table subtree on the client.
2. **SSR/client query parity drift** — SSR prefetch called `listProfiles({page:1, page_size:20})` (no `academic_year`), but client's default `apiFilters` always included `academic_year: CURRENT_YEAR`. Even with localStorage empty, the two React Query keys did not match → `initialData` was silently discarded → duplicate fetch fired post-mount.

## Changes

### New `hooks/admissions/filterDefaults.ts`
Central source of truth shared by SSR server component and client hook:
- `ADMISSIONS_DEFAULT_PAGE_SIZE`, `CURRENT_ADMISSIONS_YEAR`, sort defaults
- `getDefaultAdmissionsListParams()` → canonical default query (includes `academic_year`)
- `parseAdmissionsSearchParamsToApiParams(searchParams)` → Next.js `searchParams` → `AdmissionListParams`
- `areAdmissionsListParamsEqual(a, b)` → byte-exact shape comparison

### `useAdmissionsFilter.ts` — SSR-safe hydration
- Remove `loadFiltersFromStorage()` from initial `useMemo` (SSR returns `DEFAULT_FILTERS`)
- Post-mount `useEffect` restores localStorage with functional setState updaters (skip no-op writes)
- Refs `isStorageSyncInitialMount` + `hasInitialUrlFilters` prevent first-mount localStorage overwrite

### `page.tsx` — SSR parity
- Accept `searchParams: Promise<AdmissionsSearchParamsRecord>` (Next.js 15 async API)
- Parse URL → `initialQueryParams` → pass to client alongside `initialData`

### `AdmissionsClient.tsx` — robust attach guard
- New `initialQueryParams` prop
- `safeInitialData = areAdmissionsListParamsEqual(apiFilters, initialQueryParams) ? initialData : undefined` — replaces brittle `!hasActiveFilters && page === 1`

### `server.ts`
- Widen `listProfiles` params to full `AdmissionListParams`

## Test plan

- [x] New: `does not read localStorage during the server render path` — `react-dom/server#renderToString` + spied `Storage.prototype.getItem` to assert SSR pass never touches localStorage
- [x] New: `restores localStorage filters after hydration` — `renderHook` + `waitFor` verifies post-mount useEffect hydrates state
- [x] `useAdmissionsFilter.test.ts`: 7/7 pass (5 existing + 2 new)
- [x] `tsc --noEmit`: 0 errors
- [x] Runtime verified in Chrome dev:
  - `/admissions` (default, no URL, no localStorage) → 0 hydration error
  - `/admissions` with localStorage `statusFilters=['draft']` → 0 hydration error
  - `/admissions?status=submitted&tab=submitted` (URL filter) → 0 hydration error

## Behavior change

**UX**: If user has saved filters in localStorage and navigates back to `/admissions`, the first render now shows unfiltered data for one frame (~50ms), then filter applies. This is intentional — server cannot know localStorage, so the only way to eliminate hydration mismatch is to defer restore until after mount. URL params remain the primary source of truth and render correctly on first paint.

**Data fetch**: SSR prefetch now shares query shape with client's first request → `initialData` actually attaches (no duplicate fetch). Slight performance improvement for cold page loads without filter URL params.

## Risk notes

- No API contract change. Backend unchanged.
- URL param names unchanged (`status`, `q`, `major`, `year`, `degree`, `payment`, `from`, `to`, `tab`).
- Deep-links tested: `/admissions?status=draft` SSR-renders correctly post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)