### PR TITLE
fix(notifications): register FEE_CALCULATED in EVENT_GROUP_MAPPING

### DIFF
--- a/Backend_FastAPI/app/core/event_groups.py
+++ b/Backend_FastAPI/app/core/event_groups.py
@@ -100,6 +100,7 @@ EVENT_GROUP_MAPPING: Dict[SystemEvents, NotificationEventGroup] = {
     SystemEvents.PAYMENT_REJECTED: NotificationEventGroup.FINANCE,
     SystemEvents.REFUND_PROCESSED: NotificationEventGroup.FINANCE,
     SystemEvents.FEE_FULLY_PAID: NotificationEventGroup.FINANCE,
+    SystemEvents.FEE_CALCULATED: NotificationEventGroup.FINANCE,
     SystemEvents.INVOICE_ISSUED: NotificationEventGroup.FINANCE,
 
     # Dorm events


### PR DESCRIPTION
## Summary

Hotfix cho PR #127. PR #8 (FEE_CALCULATED realtime event) thêm \`SystemEvents.FEE_CALCULATED\` nhưng quên thêm vào \`app/core/event_groups.py\` → contract test \`test_all_system_events_have_group_mapping\` fail trên CI sau merge → \`deploy\` job bị skip → VPS chưa được update.

Local pre-merge tôi chỉ chạy 7 test files mới của PR #127 mà không chạy parity test → miss CI failure mode.

## Fix

Thêm 1 dòng \`SystemEvents.FEE_CALCULATED: NotificationEventGroup.FINANCE\` vào EVENT_GROUP_MAPPING. Cùng nhóm với \`FEE_FULLY_PAID\`, \`INVOICE_ISSUED\` (semantically đúng — fee event affecting finance UX).

## Test plan

- [x] \`tests/unit/test_notification_parity.py\` 29/29
- [x] Full CI gate suite local 102/102:
  - \`test_notification_contract.py\` (32)
  - \`test_notification_parity.py\` (29)  
  - \`test_condition_dispatch.py\` (4)
  - \`test_notification_core_v2.py\` (19)
  - \`test_notification_bundle.py\` (7)
  - \`test_admission_bundle_contract.py\` (11)

## Impact

VPS hiện vẫn ở commit cũ (deploy bị skip). Sau khi hotfix merge, deploy sẽ chạy lại với main = PR #127 + hotfix → bring up the actual 8-PR audit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)