### PR TITLE
feat(admissions): post-approval minor correction flow

### DIFF
--- a/Backend_FastAPI/alembic/versions/dd4l5m6n7o8p_add_minor_correction_allowlist.py
+++ b/Backend_FastAPI/alembic/versions/dd4l5m6n7o8p_add_minor_correction_allowlist.py
@@ -1,0 +1,59 @@
+"""add minor_correction_allowed_fields to admission_path
+
+Revision ID: dd4l5m6n7o8p
+Revises: cc3k4l5m6n7o
+Create Date: 2026-04-25
+
+Per-path allowlist for post-approval minor corrections. Governance
+setting — admin opts in field-by-field for each AdmissionPath. Default
+empty list (no corrections allowed) means every path explicitly grants
+fields; the SAFE catalog cap stays the absolute upper bound regardless
+of what admin selects.
+
+Rationale:
+- JSONB array (not Postgres array) for forward-compat with future
+  metadata (e.g. per-field expiry dates, per-role caps).
+- NOT NULL with server_default '[]'::jsonb so missing-key reads always
+  return [] without app-side coalesce.
+- Check constraint asserts the column is always a JSONB array — defense
+  against accidental dict/string assignment in service code.
+- No backfill: empty default for every existing path. Admin must
+  explicitly enable each field per path. Hồ sơ cũ vẫn không sửa được
+  cho đến khi admin bật.
+
+Rollback drops the column (and the check constraint with it).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "dd4l5m6n7o8p"
+down_revision: Union[str, None] = "cc3k4l5m6n7o"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE admission_path
+        ADD COLUMN IF NOT EXISTS minor_correction_allowed_fields JSONB
+        NOT NULL DEFAULT '[]'::jsonb
+        """
+    )
+    op.create_check_constraint(
+        "ck_admission_path_minor_correction_is_array",
+        "admission_path",
+        "jsonb_typeof(minor_correction_allowed_fields) = 'array'",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_admission_path_minor_correction_is_array",
+        "admission_path",
+        type_="check",
+    )
+    op.drop_column("admission_path", "minor_correction_allowed_fields")

--- a/Backend_FastAPI/alembic/versions/dd5m6n7o8p9q_minor_correction_policy.py
+++ b/Backend_FastAPI/alembic/versions/dd5m6n7o8p9q_minor_correction_policy.py
@@ -1,0 +1,69 @@
+"""seed Casbin policy for POST /api/admissions/{id}/minor-correction
+
+Revision ID: dd5m6n7o8p9q
+Revises: dd4l5m6n7o8p
+Create Date: 2026-04-25
+
+Casbin enforcer reads policies from the ``casbin_rule`` table at request
+time, so adding entries to ``policy_templates.py`` alone is not enough —
+without an INSERT migration the route returns 403 for every caller.
+
+Per-profile IDOR (admin all / manager same-unit / officer same-unit AND
+assigned) is enforced inside ``get_admission_for_user`` (deps.py:2240),
+so granting role-level access here is safe — the dependency narrows
+scope before the service runs.
+
+Pattern matches existing policies (verified live on production
+2026-04-25): ``/api/admissions/{id}/submit``,
+``/api/admissions/{id}/resubmit``, ``/api/admissions/{id}/documents/{doc_code}/upload``
+all use ``{id}`` literal placeholder, NOT ``*`` wildcard. Casbin matcher
+is configured for keyMatch over ``{id}``, so plan must follow.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "dd5m6n7o8p9q"
+down_revision: Union[str, None] = "dd4l5m6n7o8p"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+NEW_POLICIES = [
+    # Admin wildcard row covers admin globally, but seeding the explicit
+    # row keeps grep-by-route audits self-contained.
+    ("role:admin", "/api/admissions/{id}/minor-correction", "POST"),
+    ("role:manager", "/api/admissions/{id}/minor-correction", "POST"),
+    ("role:officer", "/api/admissions/{id}/minor-correction", "POST"),
+]
+
+
+def upgrade() -> None:
+    for subject, obj, action in NEW_POLICIES:
+        op.execute(
+            f"""
+            INSERT INTO casbin_rule (ptype, v0, v1, v2)
+            SELECT 'p', '{subject}', '{obj}', '{action}'
+            WHERE NOT EXISTS (
+                SELECT 1 FROM casbin_rule
+                WHERE ptype = 'p'
+                  AND v0 = '{subject}'
+                  AND v1 = '{obj}'
+                  AND v2 = '{action}'
+            )
+            """
+        )
+
+
+def downgrade() -> None:
+    for subject, obj, action in NEW_POLICIES:
+        op.execute(
+            f"""
+            DELETE FROM casbin_rule
+            WHERE ptype = 'p'
+              AND v0 = '{subject}'
+              AND v1 = '{obj}'
+              AND v2 = '{action}'
+            """
+        )

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -137,6 +137,11 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/admissions/{id}/resubmit", "action": "POST"},  # Resubmit after rejection
         {"subject": "{role}", "object": "/api/admissions/{id}/withdraw", "action": "POST"},  # Withdraw applicant-initiated
         {"subject": "{role}", "object": "/api/admissions/{id}/send-confirmation", "action": "POST"},  # Send magic link
+        # Post-approval minor correction — Casbin admits the role; service
+        # narrows further with status whitelist + per-path allowlist +
+        # HARD_DENY checks. IDOR via get_admission_for_user (admin all /
+        # manager unit / officer unit + assigned).
+        {"subject": "{role}", "object": "/api/admissions/{id}/minor-correction", "action": "POST"},
         # REMOVED: enroll is ADMIN-ONLY per Decision 10 (Admission State ≠ Authorization)
         # {"subject": "{role}", "object": "/api/admissions/{id}/enroll", "action": "POST"},
         {"subject": "{role}", "object": "/api/admissions/{id}/documents/{doc_code}/upload", "action": "POST"},  # Upload doc

--- a/Backend_FastAPI/app/core/admission_correction_constants.py
+++ b/Backend_FastAPI/app/core/admission_correction_constants.py
@@ -1,0 +1,148 @@
+"""Constants for the post-approval minor correction flow.
+
+Pure-data module — no schemas, no services, no FastAPI imports. Lives
+in ``app.core`` so any layer (schema validators, services, routers,
+tests) can import without creating circular dependencies. Schemas-aware
+parsing helpers live in ``app.services.admission_correction_helpers``.
+
+The two frozensets here form the system-level safety net for
+``POST /admissions/{id}/minor-correction``:
+
+- ``SAFE_MINOR_CORRECTION_FIELDS``: fields admin CAN choose to expose
+  for officer correction on a given AdmissionPath. Per-path allowlist
+  is ANDed with this set, so admin can never grant more.
+- ``HARD_DENY_FIELDS``: fields that must NEVER be touchable through the
+  flow, even if a future admin/dev mistakenly adds them to the safe
+  catalog or per-path allowlist. Service-side check raises 400 before
+  reaching the path config — defense in depth.
+
+Adding a field to ``SAFE_MINOR_CORRECTION_FIELDS`` requires also adding
+its TypeAdapter to ``FIELD_ADAPTERS`` in
+``admission_correction_helpers``; the parity is asserted at import time
+in that module so drift fails loudly.
+"""
+from __future__ import annotations
+
+
+SAFE_MINOR_CORRECTION_FIELDS: frozenset[str] = frozenset({
+    # Demographic supplements
+    "gender",
+    "nationality",
+    "ethnicity",
+    "religion",
+    "disability_type",
+    "social_insurance_number",
+    "place_of_birth",
+    "native_place",
+    # Đoàn / Đảng entry dates
+    "union_entry_date",
+    "party_entry_date",
+    "party_official_entry_date",
+    # Permanent residence (CCCD-style sub-ward + street free text)
+    "permanent_province",
+    "permanent_district",
+    "permanent_ward",
+    "permanent_residential_group",
+    "permanent_street_address",
+    # Family / guardian array
+    "family_info",
+})
+
+
+# Defense-in-depth blocklist for fields that must never flow through this
+# endpoint, regardless of admin path config. Includes:
+# - Identity / contact (require Lead-side sync + magic-link refresh)
+# - Scoring / academic history (would alter eligibility post-approval)
+# - Workflow state (status, version, timestamps)
+# - Foreign keys to upstream config (admission_path / program / offering)
+# - Documents / finance (have their own dedicated flows)
+# - Free-form keys client might invent: documents/fees/fee/invoice/payment
+HARD_DENY_FIELDS: frozenset[str] = frozenset({
+    # Identity
+    "full_name",
+    "dob",
+    "citizen_id",
+    "phone",
+    "email",
+    # Scoring
+    "academic_history",
+    "admission_scores",
+    # State machine
+    "status",
+    "version",
+    # Foreign keys
+    "lead_id",
+    "admission_method_id",
+    "admission_path_id",
+    "program_id",
+    "offering_id",
+    "academic_info_id",
+    "applied_rules",
+    # Workflow timestamps
+    "approved_at",
+    "approved_by_id",
+    "approval_notes",
+    "rejected_at",
+    "rejection_reason",
+    "confirmed_at",
+    "enrolled_at",
+    "is_dropped",
+    "survey_sent_at",
+    "survey_tracking_id",
+    # Catch-all for client-invented keys outside the model
+    "documents",
+    "fees",
+    "fee_status",
+    "fee",
+    "invoice",
+    "payment",
+    "lead",
+    "assigned_reviewer_id",
+    "assigned_reviewer",
+})
+
+
+# Whitelist for ``gender`` correction. Matches the dropdown options on
+# the admission detail PersonalInfoTab (frontend src/.../PersonalInfoTab.tsx)
+# — Vietnamese labels stored as-is in the model column.
+ALLOWED_GENDERS: frozenset[str] = frozenset({"Nam", "Nữ", "Khác"})
+
+
+# Vietnamese labels surfaced in the correction dialog and the admin
+# allowlist multi-select. FE mirrors this map (single source of truth
+# is backend; FE imports a copy for typing convenience).
+FIELD_LABELS_VI: dict[str, str] = {
+    "gender": "Giới tính",
+    "nationality": "Quốc tịch",
+    "ethnicity": "Dân tộc",
+    "religion": "Tôn giáo",
+    "disability_type": "Loại khuyết tật",
+    "social_insurance_number": "Số sổ BHXH",
+    "place_of_birth": "Nơi sinh",
+    "native_place": "Nguyên quán",
+    "union_entry_date": "Ngày vào Đoàn",
+    "party_entry_date": "Ngày vào Đảng",
+    "party_official_entry_date": "Ngày chính thức vào Đảng",
+    "permanent_province": "Tỉnh/TP thường trú",
+    "permanent_district": "Quận/Huyện thường trú",
+    "permanent_ward": "Phường/Xã thường trú",
+    "permanent_residential_group": "Tổ/Thôn/Khu phố",
+    "permanent_street_address": "Địa chỉ chi tiết",
+    "family_info": "Thông tin gia đình / người giám hộ",
+}
+
+
+# Self-check: every label entry must be in SAFE catalog. Catches drift
+# if someone adds a label without expanding the safe set (which would
+# render an unsupported field in the dialog).
+assert set(FIELD_LABELS_VI.keys()) == SAFE_MINOR_CORRECTION_FIELDS, (
+    "FIELD_LABELS_VI keys must match SAFE_MINOR_CORRECTION_FIELDS exactly"
+)
+
+
+# Hard-deny invariant: SAFE and HARD_DENY must be disjoint. Catches the
+# nightmare scenario of someone accidentally adding citizen_id or status
+# to the safe catalog.
+assert SAFE_MINOR_CORRECTION_FIELDS.isdisjoint(HARD_DENY_FIELDS), (
+    "SAFE_MINOR_CORRECTION_FIELDS and HARD_DENY_FIELDS must be disjoint"
+)

--- a/Backend_FastAPI/app/core/event_catalog.py
+++ b/Backend_FastAPI/app/core/event_catalog.py
@@ -1299,6 +1299,33 @@ _BROADCAST_EVENTS: tuple = tuple(
         # Sensitive: payload carries lead/profile/fee IDs linked to PII.
         privacy="sensitive",
     ),
+    # Realtime cache hint emitted after a post-approval minor correction.
+    # Same broadcast-only treatment as FEE_CALCULATED — no DB rule, no
+    # seeded notification, just a socket signal so other sessions
+    # viewing the profile re-fetch. Payload deliberately carries field
+    # NAMES only (changed_fields), never values, so the broadcast itself
+    # leaks no PII; old/new values stay behind the audit-log RBAC gate.
+    EventDefinition(
+        event=SystemEvents.APPLICATION_MINOR_CORRECTED,
+        category="application",
+        display_name="Hồ sơ được hiệu chỉnh sau duyệt",
+        description=(
+            "Realtime sync cho admission detail sau khi sửa thông tin "
+            "nhỏ trên hồ sơ approved/confirmed"
+        ),
+        variables=(
+            _var("application_id", "integer", "ID hồ sơ"),
+            _var("lead_id", "integer", "ID lead"),
+            _var("changed_fields", "array", "Tên các trường đã đổi (no values)"),
+            _var("actor_id", "integer", "ID người sửa"),
+            _var("corrected_at", "string", "Thời gian sửa (ISO 8601)"),
+        ),
+        link_strategy="/admissions/${application_id}",
+        notification_class="broadcast_only",
+        # Sensitive: payload links to lead/profile rows even though
+        # values are scrubbed — must be scoped to admin + unit + officer.
+        privacy="sensitive",
+    ),
 )
 
 # -------------------------------------------------------------------

--- a/Backend_FastAPI/app/core/event_groups.py
+++ b/Backend_FastAPI/app/core/event_groups.py
@@ -91,6 +91,7 @@ EVENT_GROUP_MAPPING: Dict[SystemEvents, NotificationEventGroup] = {
     SystemEvents.APPLICATION_DELETED: NotificationEventGroup.APPLICATION,
     SystemEvents.APPLICATION_FEE_PAID: NotificationEventGroup.APPLICATION,
     SystemEvents.APPLICATION_SURVEY_DUE: NotificationEventGroup.APPLICATION,
+    SystemEvents.APPLICATION_MINOR_CORRECTED: NotificationEventGroup.APPLICATION,
 
     # Finance events
     SystemEvents.DORM_FEE_CREATED: NotificationEventGroup.FINANCE,

--- a/Backend_FastAPI/app/core/events.py
+++ b/Backend_FastAPI/app/core/events.py
@@ -345,6 +345,32 @@ class SystemEvents(str, Enum):
     — this is a customer-facing survey, not an officer notification.
     """
 
+    APPLICATION_MINOR_CORRECTED = "application_minor_corrected"
+    """
+    Triggered when officer/manager/admin applies a post-approval minor
+    correction to an AdmissionProfile in approved/confirmed state. The
+    flow only allows a strict allowlist of low-risk demographic +
+    address fields (configured per AdmissionPath); document, finance,
+    and identity fields are hard-denied. See
+    ``app/core/admission_correction_constants.py`` for the safe catalog.
+
+    Payload Schema:
+        {
+            "application_id": int,         # AdmissionProfile.id
+            "lead_id": int,                # Lead.id (room scoping key)
+            "changed_fields": List[str],   # KEY NAMES ONLY — no values, no PII
+            "actor_id": int,               # User.id who applied the correction
+            "corrected_at": str,           # ISO 8601 UTC timestamp
+        }
+
+    Recipients: broadcast-only (socket). No DB notification rule, no
+    seed default — purely a realtime cache-invalidation signal so other
+    sessions viewing the profile refresh. Privacy: payload carries
+    field NAMES only; old/new values stay in the audit log behind RBAC.
+    Rooms scope = role_admin + unit_<lead.unit_id> +
+    user_room_<lead.assigned_officer_id> via ``_rooms_for_admission``.
+    """
+
     # =========================================================================
     # FINANCE EVENTS (Future: Dorm, Tuition, etc.)
     # =========================================================================

--- a/Backend_FastAPI/app/models/admission_config/admission_path.py
+++ b/Backend_FastAPI/app/models/admission_config/admission_path.py
@@ -13,6 +13,7 @@ This is the CENTRAL ENTITY for:
 
 import sqlalchemy as sa
 from sqlalchemy import CheckConstraint, Column, Integer, String, Boolean, ForeignKey, DateTime, UniqueConstraint, Numeric
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
@@ -123,6 +124,25 @@ class AdmissionPath(Base):
             "When True, the submit validator accepts documents in "
             "`uploaded` status. When False (default), only `verified` "
             "or `paper_submitted` count toward submission."
+        ),
+    )
+
+    # Per-path allowlist for post-approval minor corrections (governance setting).
+    # Empty default = no corrections allowed. Admin opts in field-by-field per
+    # path. Effective allowlist = SAFE_MINOR_CORRECTION_FIELDS ∩ this list,
+    # so admin cannot widen scope beyond the system-level safe catalog.
+    # NOT snapshotted to AdmissionProfile.applied_rules: admin changes apply
+    # live across all profiles attached to the path (different from PR #6's
+    # allow_unverified_submission which IS snapshotted).
+    minor_correction_allowed_fields = Column(
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default=sa.text("'[]'::jsonb"),
+        comment=(
+            "Per-path allowlist for post-approval minor corrections. "
+            "Effective = SAFE_MINOR_CORRECTION_FIELDS ∩ this list. "
+            "Live config (not snapshotted to applied_rules)."
         ),
     )
 

--- a/Backend_FastAPI/app/repositories/__init__.py
+++ b/Backend_FastAPI/app/repositories/__init__.py
@@ -10,6 +10,7 @@ Export all repositories for easy import:
 
 from app.repositories.base import BaseRepository
 from app.repositories.activity_repository import ActivityRepository
+from app.repositories.admission_path_repository import AdmissionPathRepository
 from app.repositories.admission_repository import AdmissionRepository
 from app.repositories.config_repository import (
     AssignmentConfigRepository,
@@ -40,6 +41,7 @@ from app.repositories.trusted_device_repository import TrustedDeviceRepository
 __all__ = [
     "BaseRepository",
     "ActivityRepository",
+    "AdmissionPathRepository",
     "AdmissionRepository",
     "AssignmentConfigRepository",
     "DegreeLevelRepository",

--- a/Backend_FastAPI/app/repositories/admission_path_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_path_repository.py
@@ -8,7 +8,7 @@ Provides data access for AdmissionPath entities with:
 - No business logic (pure data access)
 """
 
-from typing import List, Optional, Tuple
+from typing import Iterable, List, Optional, Tuple
 from sqlalchemy import select, func, distinct
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -44,8 +44,23 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
     # STANDARD CRUD WITH EAGER LOADING
     # =========================================================================
     
+    async def get_by_ids(self, ids: Iterable[int]) -> List[AdmissionPath]:
+        """Batch fetch paths by ID list — used by the list-endpoint
+        minor-correction resolver to avoid N+1 path queries.
+
+        Returns the matching rows in undefined order; callers that need
+        a dict keyed by id should build it from the result. Empty input
+        short-circuits to avoid emitting an ``IN ()`` clause.
+        """
+        unique_ids = list({i for i in ids if i is not None})
+        if not unique_ids:
+            return []
+        stmt = select(AdmissionPath).where(AdmissionPath.id.in_(unique_ids))
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
     async def get_by_id_with_relations(
-        self, 
+        self,
         path_id: int
     ) -> Optional[AdmissionPath]:
         """

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -38,8 +38,10 @@ from ..core.events import SystemEvents
 from ..utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
+    BusinessRuleViolation,
     PermissionDeniedError,
     ConflictError,
+    ValidationError,
 )
 from ..core.constants import UserRole
 
@@ -1576,6 +1578,73 @@ async def resubmit_admission(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except ConflictError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "/{profile_id}/minor-correction",
+    response_model=schemas.AdmissionProfileResponse,
+    summary="Apply post-approval minor correction (Officer/Manager/Admin)",
+)
+async def minor_correction(
+    request: Request,
+    profile_id: int,
+    payload: schemas.MinorCorrectionRequest,
+    db: AsyncSession = Depends(database.get_db),
+    profile: models.AdmissionProfile = Depends(get_admission_for_user),
+    current_user: models.User = CasbinAuth,
+):
+    """Apply a SAFE-catalog-bounded correction to an approved/confirmed profile.
+
+    Three-layer gate before the service runs:
+    - **Casbin** admits the route (role:admin/manager/officer have policy
+      `/api/admissions/{id}/minor-correction POST` seeded by alembic).
+    - **IDOR** via ``get_admission_for_user`` (admin all / manager unit /
+      officer unit + assigned). Returns 404 (not 403) on miss to avoid
+      leaking profile existence.
+    - **Lock** — same dependency uses ``with_for_update`` so concurrent
+      corrections on the same profile serialize.
+
+    Service then enforces:
+    - Status whitelist (approved/confirmed only)
+    - Optimistic version match (409 on mismatch)
+    - SAFE catalog ∩ AdmissionPath allowlist (live, not snapshotted)
+    - HARD_DENY blocklist (citizen_id, dob, status, etc.)
+    - Per-field type + business-rule validation
+
+    Post-commit emits a broadcast-only ``application_minor_corrected``
+    socket event scoped to admin + unit + assigned officer rooms — no
+    DB notification rule, payload carries field NAMES only (no PII).
+    """
+    try:
+        result, socket_envelope = await admission_service.apply_minor_correction(
+            db=db,
+            profile=profile,
+            payload=payload,
+            current_user=current_user,
+        )
+
+        await db.commit()
+
+        # Best-effort post-commit fanout. Network/socket glitch never
+        # rolls back the business mutation. Rooms are mandatory because
+        # the catalog tags this event privacy="sensitive" — dispatcher
+        # fail-closed guard would block a no-rooms emit otherwise.
+        await safe_dispatch(
+            db=db,
+            event=SystemEvents.APPLICATION_MINOR_CORRECTED,
+            payload=socket_envelope["payload"],
+            rooms=socket_envelope["rooms"],
+        )
+
+        return result
+
+    except ConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except BusinessRuleViolation as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @limiter.limit(RateLimits.DATA_WRITE)  # 200/hour

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -182,6 +182,7 @@ from .admission import (
     WithdrawRequest,
     FinalizeRequest,
     DropStudentRequest,
+    MinorCorrectionRequest,
     # Confirmation token schemas (Magic Link)
     ConfirmTokenVerifyRequest,
     ConfirmTokenResponse,

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -14,10 +14,10 @@ Architecture Compliance:
 """
 
 from datetime import date, datetime
-from typing import List, Optional, Literal, Dict, Any
+from typing import Annotated, Any, Dict, List, Literal, Optional
 import html
 
-from pydantic import BaseModel, EmailStr, Field, field_validator, ConfigDict
+from pydantic import BaseModel, EmailStr, Field, StringConstraints, field_validator, ConfigDict
 
 
 # ==============================================================================
@@ -723,6 +723,19 @@ class AdmissionProfileResponse(BaseModel):
         default_factory=list,
         description="List of currently available actions (e.g., ['save', 'submit'])"
     )
+
+    # Per-profile effective allowlist for the post-approval correction
+    # dialog. Resolved server-side from
+    # SAFE_MINOR_CORRECTION_FIELDS ∩ admission_path.minor_correction_allowed_fields,
+    # so FE renders only the fields admin enabled for this profile's path
+    # without needing to fetch path config separately.
+    minor_correction_fields: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Effective per-profile allowlist for minor correction. "
+            "FE renders dialog rows from this list."
+        )
+    )
     
     # Profile completion percentage (0-100)
     completion_percent: int = Field(
@@ -1273,6 +1286,61 @@ class ClaimRequest(BaseModel):
     Only version is needed for optimistic locking.
     """
     version: int = Field(..., description="Optimistic locking version")
+
+
+# StringConstraints applies strip_whitespace BEFORE checking min/max
+# length, so a payload like "          a" (9 spaces + 1 char, length 10)
+# fails the min=10 check after stripping. Defends against accidental
+# zero-effort reasons that bypass min_length when validated via
+# Field(min_length=...).
+TrimmedReason = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=10, max_length=1000),
+]
+
+
+class MinorCorrectionRequest(BaseModel):
+    """Request schema for ``POST /admissions/{id}/minor-correction``.
+
+    Three required fields:
+    - ``version`` for optimistic locking (matches the version-on-state
+      pattern used by approve/reject/etc., raises 409 on mismatch).
+    - ``reason`` whose effective length is checked AFTER strip; an
+      operator must supply real justification per audit policy.
+    - ``changes`` is a dict of ``{field_key: new_value}``. Field-level
+      type validation runs server-side via the FIELD_ADAPTERS map in
+      ``admission_correction_helpers.py``; we keep the schema as
+      ``dict[str, Any]`` here so unknown / hard-deny keys surface in
+      the service-side check rather than failing Pydantic with a
+      cryptic union error.
+    """
+
+    version: int = Field(
+        ...,
+        ge=1,
+        description="Current profile version for optimistic locking"
+    )
+    reason: TrimmedReason = Field(
+        ...,
+        description=(
+            "Why this correction is being made. Stored on the audit row. "
+            "Min 10 characters AFTER trim — pure-whitespace inputs reject."
+        ),
+    )
+    changes: Dict[str, Any] = Field(
+        ...,
+        description=(
+            "Map of {field_key: new_value}. Field validation happens "
+            "server-side after status / IDOR / allowlist gates."
+        ),
+    )
+
+    @field_validator("changes")
+    @classmethod
+    def changes_not_empty(cls, v: Dict[str, Any]) -> Dict[str, Any]:
+        if not v:
+            raise ValueError("changes must contain at least one field")
+        return v
 
 
 # ==============================================================================

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -12,7 +12,31 @@ FRONTEND_ARCHITECTURE_V3.md Compliance:
 from datetime import datetime, date
 from decimal import Decimal
 from typing import List, Literal, Optional
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.core.admission_correction_constants import SAFE_MINOR_CORRECTION_FIELDS
+
+
+def _validate_minor_correction_allowlist(
+    cls, v: Optional[List[str]]
+) -> Optional[List[str]]:
+    """Reject fields outside the SAFE catalog.
+
+    Module-level helper attached to Create + Update via ``field_validator``
+    inside each class. Defining once and binding twice keeps the rule
+    in lockstep without relying on pydantic v2's ``check_fields=False``
+    escape hatch (which silently skips validation on classes that don't
+    declare the field).
+    """
+    if v is None:
+        return v
+    invalid = set(v) - SAFE_MINOR_CORRECTION_FIELDS
+    if invalid:
+        raise ValueError(
+            f"Fields outside safe catalog: {sorted(invalid)}. "
+            f"Allowed: {sorted(SAFE_MINOR_CORRECTION_FIELDS)}"
+        )
+    return list(v)
 
 
 # =============================================================================
@@ -130,6 +154,21 @@ class AdmissionPathCreate(BaseModel):
             "the submit gate."
         ),
     )
+    # Per-path post-approval correction allowlist (governance setting).
+    # Empty default = corrections disabled for the path. Admin opts in
+    # field-by-field; effective set = SAFE catalog ∩ this list.
+    minor_correction_allowed_fields: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Fields admin allows officer/manager to correct on profiles "
+            "in approved/confirmed status under this path. Must be a "
+            "subset of SAFE_MINOR_CORRECTION_FIELDS."
+        ),
+    )
+
+    _v_minor_correction_allowlist = field_validator(
+        "minor_correction_allowed_fields"
+    )(_validate_minor_correction_allowlist)
 
 
 class AdmissionPathUpdate(BaseModel):
@@ -152,6 +191,21 @@ class AdmissionPathUpdate(BaseModel):
             "profiles created after the flip inherit the new setting."
         ),
     )
+    # Optional on update so partial PATCH-style updates don't accidentally
+    # clear the config. Service-side guard rejects this field unless the
+    # caller is admin (governance setting).
+    minor_correction_allowed_fields: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Replace the per-path correction allowlist. Admin-only — "
+            "service raises BusinessRuleViolation for non-admin callers. "
+            "Pass `[]` to clear; omit to leave unchanged."
+        ),
+    )
+
+    _v_minor_correction_allowlist = field_validator(
+        "minor_correction_allowed_fields"
+    )(_validate_minor_correction_allowlist)
 
 
 class AdmissionCriteriaCreate(BaseModel):
@@ -225,6 +279,16 @@ class AdmissionPathResponse(BaseModel):
             "Current strict-mode setting for this path. False means "
             "the submit validator requires verified / paper-submitted "
             "documents; True allows uploaded."
+        ),
+    )
+    # Required (no default) so a backend that forgets to map the column
+    # surfaces in Zod parse on the FE side rather than silently rendering
+    # an empty allowlist. No validator on the response — data from DB has
+    # already passed the Create/Update gate.
+    minor_correction_allowed_fields: List[str] = Field(
+        description=(
+            "Per-path allowlist for post-approval minor corrections. "
+            "Subset of SAFE_MINOR_CORRECTION_FIELDS."
         ),
     )
 

--- a/Backend_FastAPI/app/services/admission_correction_helpers.py
+++ b/Backend_FastAPI/app/services/admission_correction_helpers.py
@@ -1,0 +1,181 @@
+"""Per-field parse + normalize helpers for the minor correction flow.
+
+Service layer module — may import schemas (``FamilyMemberSchema``) and
+constants. Routers/services that apply minor corrections call
+``parse_and_normalize`` to coerce the raw JSON value submitted by the
+client into the type SQLAlchemy expects on the column, then
+``post_parse_business_check`` for business-rule validation that runs
+AFTER type-level validation has succeeded.
+
+The TypeAdapter-driven design lets the validator stay declarative —
+adding a new field means adding a row to ``FIELD_ADAPTERS`` plus
+``SAFE_MINOR_CORRECTION_FIELDS``; the parity assert at module load
+fails loudly if either side drifts.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Annotated, Any, Optional
+
+from pydantic import Field, StringConstraints, TypeAdapter
+
+from app.core.admission_correction_constants import (
+    ALLOWED_GENDERS,
+    SAFE_MINOR_CORRECTION_FIELDS,
+)
+from app.schemas.admission import FamilyMemberSchema
+
+
+# ---------------------------------------------------------------------------
+# Field-level type adapters
+# ---------------------------------------------------------------------------
+# Each adapter mirrors the constraint of the corresponding model column
+# (admission.py:115-182). Max-length values are cross-checked by tests.
+#
+# DateTime caveat: union/party_*_date are ``DateTime`` columns WITHOUT
+# ``timezone=True`` (admission.py:153-155). We accept ISO strings with or
+# without offset, but ``parse_and_normalize`` strips tzinfo to UTC-naive
+# so the value matches what SQLAlchemy expects to write to the column.
+
+FIELD_ADAPTERS: dict[str, TypeAdapter] = {
+    # ``Field(max_length=10)`` mirrors the constraint on
+    # ``AdmissionProfileUpdate.family_info`` (admission.py:402-406) so
+    # minor correction can't bypass the array cap and persist >10
+    # guardian rows when the admin path enables this field.
+    "family_info": TypeAdapter(
+        Annotated[list[FamilyMemberSchema], Field(max_length=10)]
+    ),
+    "union_entry_date": TypeAdapter(Optional[datetime]),
+    "party_entry_date": TypeAdapter(Optional[datetime]),
+    "party_official_entry_date": TypeAdapter(Optional[datetime]),
+    "social_insurance_number": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(pattern=r"^\d{10}$")]]
+    ),
+    # gender — whitelist enforced in post_parse_business_check.
+    "gender": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=20)]]
+    ),
+    "nationality": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=100)]]
+    ),
+    "ethnicity": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=100)]]
+    ),
+    "religion": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=100)]]
+    ),
+    "disability_type": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=100)]]
+    ),
+    "place_of_birth": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=255)]]
+    ),
+    "native_place": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=255)]]
+    ),
+    "permanent_province": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=100)]]
+    ),
+    "permanent_district": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=100)]]
+    ),
+    "permanent_ward": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=100)]]
+    ),
+    "permanent_residential_group": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=150)]]
+    ),
+    "permanent_street_address": TypeAdapter(
+        Optional[Annotated[str, StringConstraints(strip_whitespace=True, max_length=255)]]
+    ),
+}
+
+
+# Drift guard — if SAFE catalog adds a field, FIELD_ADAPTERS must follow.
+# Module load fails before the service is wired up, surfacing the bug
+# during dev/CI rather than at request time.
+assert set(FIELD_ADAPTERS.keys()) == SAFE_MINOR_CORRECTION_FIELDS, (
+    "FIELD_ADAPTERS keys must match SAFE_MINOR_CORRECTION_FIELDS exactly. "
+    f"Missing adapters: {SAFE_MINOR_CORRECTION_FIELDS - set(FIELD_ADAPTERS)}; "
+    f"Stale adapters: {set(FIELD_ADAPTERS) - SAFE_MINOR_CORRECTION_FIELDS}"
+)
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def parse_and_normalize(field: str, raw_value: Any) -> Any:
+    """Validate + coerce one field value to the model's expected Python type.
+
+    Raises ``pydantic.ValidationError`` on type/constraint failure — the
+    caller wraps that into the project's domain ``ValidationError`` so
+    the router can map it to a 400 response.
+
+    Special handling:
+    - ``family_info``: parsed list of ``FamilyMemberSchema`` is dumped
+      back to plain dicts (JSON-mode) so SQLAlchemy can store the array
+      in the JSONB column.
+    - Naive-UTC datetime: union/party_*_date columns are timezone-naive,
+      so an offset-aware datetime is converted to UTC and stripped of
+      tzinfo before return. Passing through tz-aware values would let
+      SQLAlchemy raise on insert — out of scope to migrate columns to
+      ``DateTime(timezone=True)`` for this feature.
+    """
+    adapter = FIELD_ADAPTERS[field]
+    parsed = adapter.validate_python(raw_value)
+
+    if field == "family_info" and parsed is not None:
+        return [m.model_dump(mode="json") for m in parsed]
+
+    if isinstance(parsed, datetime) and parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+
+    return parsed
+
+
+def post_parse_business_check(field: str, value: Any) -> Optional[str]:
+    """Business-rule check that runs AFTER type-level validation.
+
+    Returns an error message string when the value fails a business
+    rule, or None when the value is acceptable. Returning a string
+    rather than raising lets the caller batch errors per-field if it
+    wants — current callers raise on the first error to keep the API
+    surface simple.
+
+    Rules:
+    - Đoàn / Đảng entry dates cannot be in the future. The value
+      arrives as naive-UTC after ``parse_and_normalize``; compare
+      against ``datetime.now(UTC).replace(tzinfo=None)`` to stay in
+      the same timezone-naive frame.
+    - ``gender`` must be one of the dropdown options enforced on the
+      admission detail page (Nam / Nữ / Khác); accepts None to allow
+      clearing the field.
+    """
+    if field.endswith("_date") and isinstance(value, datetime):
+        now_naive_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+        if value > now_naive_utc:
+            return f"{field} không được lớn hơn hôm nay"
+
+    if field == "gender" and value is not None and value not in ALLOWED_GENDERS:
+        return f"gender phải thuộc {sorted(ALLOWED_GENDERS)}"
+
+    return None
+
+
+def safe_serialize(value: Any) -> Any:
+    """Serialize a model attribute value for the audit JSON payload.
+
+    The audit log stores ``{"old": ..., "new": ...}`` per field. Most
+    SAFE fields are scalar str / int / list / dict already, but date
+    columns surface as ``datetime`` objects which json.dumps refuses to
+    handle. Coerce anything non-JSON-native to its string form so the
+    audit row stays insertable.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, (list, dict, str, int, float, bool)):
+        return value
+    return str(value)

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -125,6 +125,20 @@ class AdmissionPathService:
                 f"method={data.admission_method_id}"
             )
         
+        # Governance guard: minor_correction_allowed_fields is admin-only,
+        # same rule as on update. Manager creating a draft path always
+        # gets an empty allowlist regardless of what they submit. FE
+        # already disables the section for non-admins; this is the
+        # belt-and-braces server side.
+        if (
+            data.minor_correction_allowed_fields
+            and user.role != UserRole.ADMIN
+        ):
+            raise BusinessRuleViolation(
+                "Chỉ admin được set allowlist minor_correction khi tạo path. "
+                "Manager liên hệ admin nếu cần thay đổi."
+            )
+
         # Create path
         path = await self.repo.create({
             "academic_info_id": data.academic_info_id,
@@ -135,6 +149,12 @@ class AdmissionPathService:
             "status": "draft",  # Always start as draft
             # PR #6 — strict-by-default; admin may flip to True on create.
             "allow_unverified_submission": data.allow_unverified_submission,
+            # Per-path correction allowlist — empty by default, admin may
+            # seed a list at create time. Schema validator already
+            # filtered out non-SAFE entries before reaching here.
+            "minor_correction_allowed_fields": list(
+                data.minor_correction_allowed_fields or []
+            ),
         })
         
         return path, _noop_callback
@@ -168,8 +188,24 @@ class AdmissionPathService:
             )
         
         update_data = data.model_dump(exclude_unset=True)
+
+        # Governance guard: minor_correction_allowed_fields is admin-only.
+        # Manager can edit a draft path's display name / fee / etc. but
+        # must not flip the per-path correction allowlist — that's a
+        # security setting (decides which fields officer can post-edit
+        # on approved profiles). Reject the field rather than silently
+        # drop it so the FE form / API caller surfaces the failure.
+        if (
+            "minor_correction_allowed_fields" in update_data
+            and user.role != UserRole.ADMIN
+        ):
+            raise BusinessRuleViolation(
+                "Chỉ admin được sửa allowlist minor_correction. "
+                "Manager liên hệ admin nếu cần thay đổi."
+            )
+
         path = await self.repo.update(path, update_data)
-        
+
         return path, _noop_callback
     
     async def upsert_criteria(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -38,6 +38,10 @@ from sqlalchemy.orm.attributes import flag_modified
 
 from .. import models
 from ..core.events import SystemEvents
+from ..core.admission_correction_constants import (
+    SAFE_MINOR_CORRECTION_FIELDS,
+    HARD_DENY_FIELDS,
+)
 from ..schemas.admission import DEFAULT_UPLOAD_CONFIG
 from ..core.constants import UserRole
 from .commission_service import safe_check_commission_on_status_change
@@ -47,12 +51,18 @@ from .notification_bundle import (
     dispatch_bundle,
 )
 from .notification_dispatcher import _rooms_for_admission
+from .admission_correction_helpers import (
+    parse_and_normalize,
+    post_parse_business_check,
+    safe_serialize,
+)
 from ..utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
     BusinessRuleViolation,
     PermissionDeniedError,
     ConflictError,
+    ValidationError,
 )
 from ..utils.masking import mask_citizen_id
 
@@ -743,6 +753,91 @@ async def check_lead_level_admission_eligibility(
     return LeadAdmissionEligibility(True, None, None)
 
 
+def _sync_available_actions(profile: models.AdmissionProfile) -> None:
+    """Rebuild ``profile.available_actions`` from ``profile.permissions``.
+
+    Mirror of the line in ``_compute_frontend_fields`` (~line 858) that
+    derives ``available_actions`` from the permissions dict. Extracted
+    so the async ``_resolve_minor_correction_state`` resolver can flip
+    a permission flag and resync the action list without duplicating
+    the comprehension.
+
+    Safe to call repeatedly — idempotent given the same ``permissions``
+    dict.
+    """
+    perms = getattr(profile, "permissions", None) or {}
+    profile.available_actions = [
+        action for action, allowed in perms.items() if allowed
+    ]
+
+
+async def _resolve_minor_correction_state(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    current_user: Optional[models.User],
+) -> None:
+    """Resolve per-profile ``minor_correction_fields`` + flip the permission
+    flag based on the live AdmissionPath allowlist.
+
+    Must be called AFTER ``_compute_frontend_fields`` has populated
+    ``profile.permissions`` (the resolver only refines, never invents).
+    Safe defaults if context is missing: empty allowlist + permission =
+    False so FE renders no button rather than crashing.
+
+    Why async: AdmissionPath is fetched live (governance setting, not
+    snapshotted to applied_rules) so any admin change applies
+    immediately to all profiles tied to the path. Single-row fetch in
+    detail; the list endpoint should batch through ``get_by_ids`` and
+    then call this resolver per profile with the cached path object —
+    helper accepts ``path`` injection via ``_resolve_with_path`` below.
+    """
+    profile.minor_correction_fields = []
+
+    if current_user is None or not getattr(profile, "permissions", None):
+        return
+
+    if profile.status not in ("approved", "confirmed"):
+        profile.permissions["minor_correction"] = False
+        _sync_available_actions(profile)
+        return
+
+    path_id = (profile.applied_rules or {}).get("admission_path_id")
+    if path_id is None:
+        profile.permissions["minor_correction"] = False
+        _sync_available_actions(profile)
+        return
+
+    from app.repositories import AdmissionPathRepository
+    path = await AdmissionPathRepository(db).get_by_id(path_id)
+    _apply_minor_correction_state(profile, path)
+
+
+def _apply_minor_correction_state(
+    profile: models.AdmissionProfile,
+    path: Optional[Any],
+) -> None:
+    """Sync helper for the resolver — splits the path-application step
+    so the list endpoint can batch-fetch paths and apply state per row
+    without redundant async hops.
+
+    CONTRACT: action visible only when the effective allowlist is
+    NON-empty. A path with empty config (default after migration)
+    keeps the action hidden so officers don't see a button that opens
+    an empty dialog.
+    """
+    effective: set[str] = set()
+    if path is not None:
+        effective = SAFE_MINOR_CORRECTION_FIELDS & set(
+            getattr(path, "minor_correction_allowed_fields", []) or []
+        )
+
+    perms = profile.permissions
+    role_ok = perms.get("minor_correction", False)
+    perms["minor_correction"] = role_ok and len(effective) > 0
+    profile.minor_correction_fields = sorted(effective)
+    _sync_available_actions(profile)
+
+
 def _compute_frontend_fields(
     profile: models.AdmissionProfile,
     current_user: models.User,
@@ -838,6 +933,19 @@ def _compute_frontend_fields(
             )
         ),
         "delete": status == "draft" and is_admin,
+        # Tentative — true only when role + status + path_id snapshot
+        # exists. Async resolver _resolve_minor_correction_state flips
+        # this back to False if the per-path effective allowlist is
+        # empty, so FE never sees a button without renderable fields.
+        "minor_correction": (
+            status in ("approved", "confirmed")
+            and (profile.applied_rules or {}).get("admission_path_id") is not None
+            and (
+                is_admin
+                or is_manager
+                or (is_officer and is_owner)
+            )
+        ),
         "view": True,
     }
     profile.permissions = permissions
@@ -1313,6 +1421,11 @@ async def _populate_response_fields(
         documents = await admission_repo.get_all_documents(profile.id)
 
     _compute_frontend_fields(profile, current_user, documents)
+
+    # Refine the tentative minor_correction permission flag against the
+    # live AdmissionPath allowlist. Must run AFTER _compute_frontend_fields
+    # since it reads profile.permissions and writes available_actions.
+    await _resolve_minor_correction_state(db, profile, current_user)
 
 
 async def _create_admission_milestone_consultation(
@@ -2140,6 +2253,25 @@ async def get_profiles(
         if current_user:
             _compute_frontend_fields(profile, current_user, docs)
 
+    # Batch-resolve minor_correction state for the page in ONE query rather
+    # than N path lookups. This keeps the list endpoint at exactly one
+    # extra round-trip regardless of page size, and keeps
+    # `permissions.minor_correction` + `minor_correction_fields` in sync
+    # with what detail returns. See _resolve_minor_correction_state for
+    # the per-row contract.
+    if current_user and profiles:
+        from app.repositories import AdmissionPathRepository
+        path_ids = {
+            (p.applied_rules or {}).get("admission_path_id")
+            for p in profiles
+        }
+        path_ids.discard(None)
+        paths = await AdmissionPathRepository(db).get_by_ids(path_ids)
+        path_by_id = {p.id: p for p in paths}
+        for profile in profiles:
+            pid = (profile.applied_rules or {}).get("admission_path_id")
+            _apply_minor_correction_state(profile, path_by_id.get(pid))
+
     return profiles, total_count
 
 
@@ -2333,6 +2465,11 @@ async def get_profile(
     # Fetch documents for completion calculation
     documents = await admission_repo.get_all_documents(profile_id)
     _compute_frontend_fields(profile, current_user, documents)
+
+    # Refine minor_correction permission against live AdmissionPath config
+    # (governance setting, not snapshotted) — keeps detail in lockstep
+    # with list endpoint resolver above.
+    await _resolve_minor_correction_state(db, profile, current_user)
 
     return profile
 
@@ -5686,6 +5823,208 @@ async def withdraw_profile(
     )
 
     return profile, final_callback
+
+
+# ==============================================================================
+# MINOR CORRECTION (post-approval governed update)
+# ==============================================================================
+
+async def apply_minor_correction(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    payload: "MinorCorrectionRequest",  # forward-ref to avoid import cycle below
+    current_user: models.User,
+) -> Tuple[models.AdmissionProfile, Dict[str, Any]]:
+    """Apply a post-approval correction governed by SAFE catalog ∩ per-path allowlist.
+
+    Contract:
+    - ``profile`` MUST be eager-loaded with ``lead.assigned_officer`` and
+      ``assigned_reviewer`` (router calls ``get_admission_for_user`` which
+      already does this + ``with_for_update`` lock).
+    - Returns ``(profile, socket_envelope)``. The router commits, then
+      uses ``socket_envelope["payload"]`` + ``["rooms"]`` for a
+      ``safe_dispatch`` post-commit. We do NOT dispatch here because the
+      bundle pattern is overkill — minor correction emits one
+      broadcast-only event with no DB rule.
+
+    Status whitelist (NOT blacklist) — only ``approved`` and ``confirmed``
+    accept corrections. ``draft`` / ``submitted`` go through update_profile;
+    ``rejected`` / ``revision_requested`` use resubmit; ``enrolled`` /
+    ``overridden`` / ``withdrawn`` / ``dropped`` are out of scope for v1.
+
+    Order of checks matters — defence in depth:
+    1. Status whitelist (cheapest)
+    2. Optimistic version (avoids wasted parsing on stale request)
+    3. Path resolution (live, never snapshotted) → effective allowlist
+    4. HARD_DENY check BEFORE allowlist check so a hard-denied key
+       always rejects with the same message regardless of path config
+    5. Per-field type parse + business-rule check
+    6. Diff old vs normalized new — empty diff means caller resent the
+       same values; reject so admin doesn't see noise audit rows.
+    """
+    # Local import: schema lives in same package, but defining the
+    # forward-ref string above keeps the type hint happy if the schema
+    # module is imported at a different time.
+    from ..schemas.admission import MinorCorrectionRequest  # noqa: F401
+    from ..services import audit_service
+
+    # 1. Status whitelist
+    if profile.status not in {"approved", "confirmed"}:
+        raise BusinessRuleViolation(
+            "Hiệu chỉnh chỉ áp dụng cho hồ sơ đã duyệt (approved) hoặc đã xác nhận (confirmed)"
+        )
+
+    # 2. Optimistic lock — pattern khớp admission_service.py:2424 / 4091 /
+    # 4309 / 4501 / 4877 (approve / reject / etc).
+    if payload.version != profile.version:
+        raise ConflictError(
+            f"Expected version {payload.version}, but current version is "
+            f"{profile.version}. Refresh and try again."
+        )
+
+    # 3. Resolve effective allowlist live from AdmissionPath.
+    # admission_path_id sits in applied_rules snapshot (admission_service.py:1956).
+    path_id = (profile.applied_rules or {}).get("admission_path_id")
+    if not path_id:
+        raise BusinessRuleViolation(
+            "Hồ sơ thiếu admission_path_id trong applied_rules — không thể hiệu chỉnh"
+        )
+
+    from ..repositories import AdmissionPathRepository
+    path = await AdmissionPathRepository(db).get_by_id(path_id)
+    if path is None:
+        raise BusinessRuleViolation(
+            "AdmissionPath gắn với hồ sơ đã bị xoá — không thể hiệu chỉnh"
+        )
+
+    effective_allowlist = SAFE_MINOR_CORRECTION_FIELDS & set(
+        path.minor_correction_allowed_fields or []
+    )
+    if not effective_allowlist:
+        raise BusinessRuleViolation(
+            "AdmissionPath chưa bật field nào cho hiệu chỉnh — liên hệ admin"
+        )
+
+    # 4. Hard-deny first — even if a future bug puts a hard-denied key
+    # in the path config, this check still rejects.
+    requested = set(payload.changes.keys())
+    hard_denied = requested & HARD_DENY_FIELDS
+    if hard_denied:
+        raise ValidationError(
+            f"Các trường sau không thể sửa qua flow hiệu chỉnh: {sorted(hard_denied)}"
+        )
+
+    not_allowed = requested - effective_allowlist
+    if not_allowed:
+        raise ValidationError(
+            f"Các trường sau không nằm trong allowlist của path này: {sorted(not_allowed)}"
+        )
+
+    # 5. Per-field parse + normalize, business-rule check.
+    from pydantic import ValidationError as PydanticValidationError
+
+    normalized: Dict[str, Any] = {}
+    for field_key, raw_value in payload.changes.items():
+        try:
+            normalized[field_key] = parse_and_normalize(field_key, raw_value)
+        except PydanticValidationError as exc:
+            # Surface the first error message in human-readable form.
+            errors = exc.errors()
+            first_msg = errors[0]["msg"] if errors else "invalid value"
+            raise ValidationError(f"{field_key}: {first_msg}")
+
+        biz_err = post_parse_business_check(field_key, normalized[field_key])
+        if biz_err:
+            raise ValidationError(biz_err)
+
+    # 5b. Cross-field invariants on the candidate state (existing values
+    # overlaid with normalized changes). Per-field validators above only
+    # see the value being changed; sneaking only `party_entry_date`
+    # backward could leave a profile where union > party in spite of
+    # `AdmissionProfileUpdate.validate_logical_dates` rejecting the
+    # same combination on a normal update.
+    def _candidate(field_key: str) -> Any:
+        return normalized[field_key] if field_key in normalized else getattr(profile, field_key)
+
+    cand_union = _candidate("union_entry_date")
+    cand_party = _candidate("party_entry_date")
+    cand_party_official = _candidate("party_official_entry_date")
+    cand_dob = profile.dob  # `dob` is HARD_DENY so always the original
+
+    if cand_union and cand_party and cand_union > cand_party:
+        raise ValidationError(
+            "Ngày vào Đoàn phải trước Ngày vào Đảng (dự bị)"
+        )
+    if cand_party and cand_party_official and cand_party > cand_party_official:
+        raise ValidationError(
+            "Ngày vào Đảng (dự bị) phải trước Ngày vào Đảng (chính thức)"
+        )
+    # `dob` is a `date`; entry dates are `datetime`. Compare on date
+    # boundary so the same comparison rule used in
+    # AdmissionProfileUpdate.validate_logical_dates applies.
+    if cand_dob and cand_union and cand_dob > cand_union.date():
+        raise ValidationError("Ngày sinh phải trước Ngày vào Đoàn")
+
+    # 6. Diff — compare AFTER normalization so e.g. "2025-09-01" parsing
+    # to datetime(2025,9,1) doesn't false-diff against an existing
+    # datetime(2025,9,1). Apply only fields that actually changed.
+    diff: Dict[str, Dict[str, Any]] = {}
+    for field_key, new_val in normalized.items():
+        old_val = getattr(profile, field_key)
+        if old_val != new_val:
+            diff[field_key] = {
+                "old": safe_serialize(old_val),
+                "new": safe_serialize(new_val),
+            }
+            setattr(profile, field_key, new_val)
+
+    if not diff:
+        raise BusinessRuleViolation(
+            "Không có thay đổi nào — giá trị mới trùng giá trị cũ"
+        )
+
+    # 7. Version bump + flush
+    profile.version += 1
+    profile.updated_at = datetime.now(timezone.utc)
+    await db.flush()
+
+    # 8. Audit log — past-tense action keeps log_changes convention.
+    await audit_service.log_changes(
+        db,
+        entity_type="AdmissionProfile",
+        entity_id=profile.id,
+        action="minor_corrected",
+        changes=diff,
+        actor_user_id=current_user.id,
+        reason=payload.reason,
+    )
+
+    # 9. Pre-resolve socket envelope IN-TRANSACTION while profile.lead is
+    # still loaded. Router will safe_dispatch post-commit so a network /
+    # socket glitch never rolls back the business mutation.
+    socket_envelope = {
+        "payload": {
+            "application_id": profile.id,
+            "lead_id": profile.lead_id,
+            "changed_fields": sorted(diff.keys()),  # KEYS ONLY — no PII
+            "actor_id": current_user.id,
+            "corrected_at": datetime.now(timezone.utc).isoformat(),
+        },
+        # Required because catalog marks the event privacy="sensitive";
+        # dispatcher fail-closed guard would block a no-rooms emit.
+        "rooms": _rooms_for_admission(profile),
+    }
+
+    # 10. Re-populate response fields. Pass documents=None — get_admission_for_user
+    # eager-loaded lead/officer/reviewer but NOT documents, so passing
+    # profile.documents would lazy-load (MissingGreenlet). The helper
+    # falls through to AdmissionRepository.get_all_documents.
+    # NOTE: _populate_response_fields calls _resolve_minor_correction_state
+    # at its tail (see plumbing in next section), so we DO NOT call the
+    # resolver again here — would be one wasted path query.
+    await _populate_response_fields(db, profile, current_user, documents=None)
+
+    return profile, socket_envelope
 
 
 async def mark_student_dropped(

--- a/Backend_FastAPI/tests/api/test_admissions_minor_correction.py
+++ b/Backend_FastAPI/tests/api/test_admissions_minor_correction.py
@@ -1,0 +1,850 @@
+"""API + service tests for the post-approval minor correction flow.
+
+Coverage organized around the security gates the service enforces:
+- Status whitelist (approved/confirmed only)
+- Optimistic version match
+- Per-path effective allowlist (SAFE catalog ∩ admin config)
+- HARD_DENY blocklist (citizen_id, dob, status, etc.)
+- Reason validation (≥10 chars after strip)
+- Empty diff (no-op submit) rejection
+- Audit log emission
+- ``permissions.minor_correction`` + ``minor_correction_fields`` in list + detail responses
+
+Builds the AdmissionPath inline so each test owns its own allowlist
+config — admin flips fields per-test without polluting other suites.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.core.admission_correction_constants import (
+    HARD_DENY_FIELDS,
+    SAFE_MINOR_CORRECTION_FIELDS,
+)
+from app.database import AsyncSessionLocal
+from tests.fixtures.constants import AuthURLs, LeadsURLs
+
+
+ADMISSIONS = "/api/admissions"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — copied inline (as per other admission test files in this dir)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def adm_config(seed_lead_dependencies: dict):
+    """Seed a fresh AdmissionPath + offering chain for each test.
+
+    Returned dict carries IDs the tests need: unit, offering, method, path.
+    Each test receives its own path so we can flip allowlist freely.
+    """
+    uid = seed_lead_dependencies["unit_id"]
+    mpid = seed_lead_dependencies["major_program_id"]
+    ts = f"{int(datetime.now().timestamp() * 1000)}"
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ot = models.ConfigOfferingType(code=f"tq_{ts}", name=f"TQ_{ts}", display_order=1)
+            s.add(ot); await s.flush()
+            dt = models.ConfigDocumentType(code=f"tcc_{ts}", name=f"TCC_{ts}", display_order=1)
+            s.add(dt); await s.flush()
+            po = models.ProgramOffering(
+                offering_type=f"TQ_{ts}", program_id=mpid, offering_type_id=ot.id,
+                is_active=True, duration_semesters=6,
+            )
+            s.add(po); await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=po.id, academic_year=2026,
+                tuition_fee_per_year=5000000, annual_admission_quota=100, is_published=True,
+            )
+            s.add(ai); await s.flush()
+            am = models.AdmissionMethod(
+                code=f"hb_{ts}", name=f"HB_{ts}",
+                requires_gpa=True, requires_subject_scores=False, is_active=True,
+            )
+            s.add(am); await s.flush()
+            ac = models.AdmissionCriteria(
+                method_id=am.id, code=f"TC_{ts}", name=f"TC_{ts}",
+                min_gpa=6.0, scoring_method="average", subject_selection_mode="fixed",
+                policy_version="2026.1", is_active=True,
+            )
+            s.add(ac); await s.flush()
+            ap = models.AdmissionPath(
+                academic_info_id=ai.id, admission_method_id=am.id, criteria_id=ac.id,
+                status="active", display_name="Test", display_order=0, visibility="public",
+            )
+            s.add(ap); await s.flush()
+            path_id = ap.id
+    return {
+        "unit_id": uid,
+        "offering_id": po.id,
+        "method_id": am.id,
+        "path_id": path_id,
+    }
+
+
+async def _login(client: AsyncClient, username: str, password: str) -> dict:
+    r = await client.post(AuthURLs.LOGIN, data={"username": username, "password": password})
+    assert r.status_code == 200, f"Login {username}: {r.text}"
+    return {"Authorization": f"Bearer {r.cookies.get('access_token')}"}
+
+
+async def _set_path_allowlist(path_id: int, fields: list[str]) -> None:
+    """Write allowlist directly via session — bypasses admin guard so the
+    fixture can prep state without minting an admin token."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            path = await s.get(models.AdmissionPath, path_id)
+            path.minor_correction_allowed_fields = list(fields)
+
+
+async def _force_profile_status(profile_id: int, new_status: str) -> int:
+    """Force a profile into approved/confirmed for the test scenario.
+
+    Bypasses the workflow because building a full lead → consultation →
+    submit → approve chain inflates each test ~5x. Returns the new
+    version number for use with optimistic-lock payloads.
+    """
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            prof = await s.get(models.AdmissionProfile, profile_id)
+            prof.status = new_status
+            prof.version = (prof.version or 1) + 1
+            # Ensure applied_rules carries the path_id snapshot the
+            # service reads — depending on creation flow the seed may
+            # have left it empty.
+            applied = dict(prof.applied_rules or {})
+            if "admission_path_id" not in applied:
+                # Pull the path_id from the lead's offering chain via
+                # a query — same way create_profile builds it.
+                row = await s.execute(
+                    select(models.AdmissionPath.id)
+                    .join(
+                        models.OfferingAcademicInfo,
+                        models.AdmissionPath.academic_info_id == models.OfferingAcademicInfo.id,
+                    )
+                    .where(models.OfferingAcademicInfo.offering_id == prof.offering_id)
+                    .limit(1)
+                )
+                pid = row.scalar_one_or_none()
+                if pid is not None:
+                    applied["admission_path_id"] = pid
+                    prof.applied_rules = applied
+            return prof.version
+
+
+async def _create_seed_profile(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    adm_config: dict,
+    officer_id: int,
+    full_name: str,
+) -> tuple[int, int]:
+    """Seed lead + consultation + admission profile under admin token.
+
+    Returns ``(profile_id, lead_id)``.
+    """
+    lead_resp = await client.post(LeadsURLs.LEADS, json={
+        "full_name": full_name,
+        "phone": f"098{int(datetime.now().timestamp()) % 10_000_000:07d}",
+        "source": "website",
+        "unit_id": adm_config["unit_id"],
+        "assigned_officer_id": officer_id,
+        "offering_id": adm_config["offering_id"],
+    }, headers=admin_token_headers)
+    assert lead_resp.status_code in (200, 201), lead_resp.text
+    lead_id = lead_resp.json()["id"]
+
+    from tests._lead_status_test_ids import INITIAL_LEAD_STATUS_ID
+    cons = await client.post(
+        f"{LeadsURLs.LEADS}/{lead_id}/consultations",
+        json={
+            "status_id": INITIAL_LEAD_STATUS_ID,
+            "method": "phone",
+            "notes": "Pre-admission consultation",
+        },
+        headers=admin_token_headers,
+    )
+    assert cons.status_code in (200, 201), cons.text
+
+    prof = await client.post(ADMISSIONS, json={
+        "lead_id": lead_id,
+        "admission_method_id": adm_config["method_id"],
+    }, headers=admin_token_headers)
+    assert prof.status_code in (200, 201), prof.text
+    return prof.json()["id"], lead_id
+
+
+# ---------------------------------------------------------------------------
+# Module-level invariants (run at import time)
+# ---------------------------------------------------------------------------
+
+
+def test_field_adapters_match_safe_catalog():
+    """FIELD_ADAPTERS keys must equal the SAFE catalog exactly. The
+    helper module asserts the same on import; this test surfaces the
+    contract in CI output if someone later replaces the assert with a
+    silent fallback."""
+    from app.services.admission_correction_helpers import FIELD_ADAPTERS
+
+    assert set(FIELD_ADAPTERS.keys()) == SAFE_MINOR_CORRECTION_FIELDS
+
+
+def test_safe_and_hard_deny_disjoint():
+    """Renaming a SAFE field by accident would create a column where
+    minor correction can edit AND a HARD_DENY entry rejects — leading
+    to confusing 400s. Asserts the contract holds."""
+    assert SAFE_MINOR_CORRECTION_FIELDS.isdisjoint(HARD_DENY_FIELDS)
+
+
+# ---------------------------------------------------------------------------
+# Status whitelist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_rejects_draft_status(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Profile in draft must reject — flow only accepts approved/confirmed."""
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Draft Probe",
+    )
+    # Don't promote — leave at draft.
+    payload = {
+        "version": 1,
+        "reason": "test correction reason ten chars",
+        "changes": {"nationality": "Việt Nam"},
+    }
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json=payload,
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+    assert "approved" in r.text.lower() or "confirmed" in r.text.lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target_status", ["approved", "confirmed"])
+async def test_minor_correction_accepts_approved_and_confirmed(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+    target_status: str,
+):
+    """approved + confirmed both pass status check."""
+    await _set_path_allowlist(adm_config["path_id"], ["nationality"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], f"Status Probe {target_status}",
+    )
+    new_version = await _force_profile_status(pid, target_status)
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {"nationality": "Việt Nam"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["nationality"] == "Việt Nam"
+    assert body["version"] == new_version + 1
+
+
+# ---------------------------------------------------------------------------
+# Hard-deny + allowlist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("denied_key", [
+    "citizen_id", "dob", "phone", "email", "status",
+    "admission_scores", "academic_history",
+    "documents", "fees", "applied_rules", "admission_path_id",
+])
+async def test_minor_correction_rejects_hard_deny_keys(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+    denied_key: str,
+):
+    """Hard-deny rejects regardless of path config — defense in depth."""
+    # Bend the path config to claim it allows everything (it can't
+    # because Pydantic refuses non-SAFE keys, but the denied keys are
+    # never in SAFE so we're testing the post-allowlist HARD_DENY gate
+    # against fields a malicious client invents in `changes`).
+    await _set_path_allowlist(adm_config["path_id"], list(SAFE_MINOR_CORRECTION_FIELDS))
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], f"Deny Probe {denied_key}",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {denied_key: "anything"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_empty_path_allowlist_rejects(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Path with empty allowlist (default) rejects every field — admin
+    must explicitly opt in."""
+    # Leave allowlist empty (migration default).
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Empty Allow Probe",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {"nationality": "Việt Nam"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_path_allows_only_specific_field(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Path allows ``nationality`` only — sending ``ethnicity`` rejects."""
+    await _set_path_allowlist(adm_config["path_id"], ["nationality"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Per-Field Allow Probe",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {"ethnicity": "Kinh"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+
+
+# ---------------------------------------------------------------------------
+# Optimistic lock + reason validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_version_mismatch_returns_409(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    await _set_path_allowlist(adm_config["path_id"], ["nationality"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Version Probe",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version + 99,
+            "reason": "test correction reason ten chars",
+            "changes": {"nationality": "Việt Nam"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 409, r.text
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_reason_too_short_after_strip(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """A reason of "          a" (9 spaces + 1 char, length 10) must
+    fail because StringConstraints strips before checking — bytes-on-the-
+    wire passing length 10 would be a sneaky bypass."""
+    await _set_path_allowlist(adm_config["path_id"], ["nationality"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Reason Strip Probe",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "          a",
+            "changes": {"nationality": "Việt Nam"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 422, r.text
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_empty_changes_rejected_by_pydantic(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Pydantic validator rejects empty ``changes`` dict (422)."""
+    await _set_path_allowlist(adm_config["path_id"], ["nationality"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Empty Changes Probe",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 422, r.text
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_no_op_diff_rejected(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Resending the same value the profile already holds = no diff =
+    400 ("Không có thay đổi nào")."""
+    await _set_path_allowlist(adm_config["path_id"], ["nationality"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "No-op Probe",
+    )
+    # Pre-set the field to a known value.
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            prof = await s.get(models.AdmissionProfile, pid)
+            prof.nationality = "Việt Nam"
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {"nationality": "Việt Nam"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+
+
+# ---------------------------------------------------------------------------
+# Adapter normalization + business-rule check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_normalizes_iso_date_string(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Sending union_entry_date as ISO string parses to naive UTC datetime."""
+    await _set_path_allowlist(adm_config["path_id"], ["union_entry_date"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Date Normalize Probe",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {"union_entry_date": "2020-09-01"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 200, r.text
+
+    async with AsyncSessionLocal() as s:
+        prof = await s.get(models.AdmissionProfile, pid)
+        assert prof.union_entry_date is not None
+        assert prof.union_entry_date.year == 2020
+        assert prof.union_entry_date.month == 9
+        assert prof.union_entry_date.day == 1
+        # Naive UTC — no tzinfo
+        assert prof.union_entry_date.tzinfo is None
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_future_date_rejected_by_business_rule(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Đoàn / Đảng entry dates in the future must reject."""
+    await _set_path_allowlist(adm_config["path_id"], ["party_entry_date"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Future Date Probe",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {"party_entry_date": "2999-01-01"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_invalid_gender_rejected(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """gender outside Nam/Nữ/Khác must reject."""
+    await _set_path_allowlist(adm_config["path_id"], ["gender"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Bad Gender Probe",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {"gender": "Male"},  # not in whitelist
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_invalid_social_insurance_format(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """social_insurance_number must match ``^\\d{10}$``."""
+    await _set_path_allowlist(adm_config["path_id"], ["social_insurance_number"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "BHXH Probe",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {"social_insurance_number": "abc-not-digits"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+
+
+# ---------------------------------------------------------------------------
+# Audit log
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_writes_audit_row(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Successful correction creates an EntityAuditLog row with reason +
+    diff containing old/new values per field."""
+    await _set_path_allowlist(adm_config["path_id"], ["nationality"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Audit Probe",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "Sửa lại quốc tịch theo yêu cầu",
+            "changes": {"nationality": "Việt Nam"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 200, r.text
+
+    async with AsyncSessionLocal() as s:
+        rows = await s.execute(
+            select(models.EntityAuditLog)
+            .where(models.EntityAuditLog.entity_type == "AdmissionProfile")
+            .where(models.EntityAuditLog.entity_id == pid)
+            .where(models.EntityAuditLog.action == "minor_corrected")
+        )
+        log_rows = rows.scalars().all()
+        assert len(log_rows) == 1
+        log = log_rows[0]
+        assert log.reason == "Sửa lại quốc tịch theo yêu cầu"
+        # changes JSONB has {field: {old, new}}
+        changes = log.changes or {}
+        assert "nationality" in changes
+        assert changes["nationality"]["new"] == "Việt Nam"
+
+
+# ---------------------------------------------------------------------------
+# Detail / list response wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_detail_response_shape(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """GET detail returns ``minor_correction_fields`` populated and
+    ``permissions.minor_correction = true`` when path has allowlist
+    configured + status is approved."""
+    await _set_path_allowlist(adm_config["path_id"], ["nationality", "ethnicity"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Detail Shape Probe",
+    )
+    await _force_profile_status(pid, "approved")
+    r = await client.get(f"{ADMISSIONS}/{pid}", headers=admin_token_headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert sorted(body["minor_correction_fields"]) == ["ethnicity", "nationality"]
+    assert body["permissions"]["minor_correction"] is True
+    assert "minor_correction" in body["available_actions"]
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_rejects_union_after_party(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Cross-field invariant: union_entry_date must precede
+    party_entry_date — service merges candidate state and applies the
+    same rule as AdmissionProfileUpdate.validate_logical_dates."""
+    await _set_path_allowlist(adm_config["path_id"], ["union_entry_date"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Cross-Field Date Probe",
+    )
+    # Pre-set party_entry_date so the candidate state has a baseline.
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            prof = await s.get(models.AdmissionProfile, pid)
+            prof.party_entry_date = datetime(2020, 6, 1, 0, 0, 0)
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            # Set union date AFTER existing party date — must reject.
+            "changes": {"union_entry_date": "2021-09-01"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+    assert "Đoàn" in r.text  # message references Vietnamese label
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_rejects_party_after_party_official(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """party_entry_date must precede party_official_entry_date."""
+    await _set_path_allowlist(adm_config["path_id"], ["party_entry_date"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Party Order Probe",
+    )
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            prof = await s.get(models.AdmissionProfile, pid)
+            prof.party_official_entry_date = datetime(2020, 6, 1, 0, 0, 0)
+    new_version = await _force_profile_status(pid, "approved")
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {"party_entry_date": "2021-09-01"},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_family_info_max_10_enforced(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """family_info adapter retains the max_length=10 cap from
+    AdmissionProfileUpdate so minor correction can't bypass the array
+    cap and persist 11+ guardian rows."""
+    await _set_path_allowlist(adm_config["path_id"], ["family_info"])
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Family Cap Probe",
+    )
+    new_version = await _force_profile_status(pid, "approved")
+    big = [
+        {
+            "relationship": "father",
+            "full_name": f"Nguyen Van Test {i}",
+            "occupation": "engineer",
+            "phone": f"098{i:07d}",
+            "is_primary_guardian": False,
+        }
+        for i in range(11)  # one over the cap
+    ]
+    r = await client.post(
+        f"{ADMISSIONS}/{pid}/minor-correction",
+        json={
+            "version": new_version,
+            "reason": "test correction reason ten chars",
+            "changes": {"family_info": big},
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+
+
+@pytest.mark.asyncio
+async def test_admission_path_create_persists_allowlist_for_admin(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    seed_lead_dependencies: dict,
+):
+    """Admin creating a path can seed the minor-correction allowlist;
+    the service must forward the field to the repository instead of
+    silently dropping it."""
+    # Build the supporting offering chain inline (mirrors adm_config but
+    # we need to drive the create endpoint, not the AdmissionPath model).
+    mpid = seed_lead_dependencies["major_program_id"]
+    ts = f"{int(datetime.now().timestamp() * 1000)}"
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ot = models.ConfigOfferingType(code=f"tq_{ts}", name=f"TQ_{ts}", display_order=1)
+            s.add(ot); await s.flush()
+            po = models.ProgramOffering(
+                offering_type=f"TQ_{ts}", program_id=mpid, offering_type_id=ot.id,
+                is_active=True, duration_semesters=6,
+            )
+            s.add(po); await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=po.id, academic_year=2026,
+                tuition_fee_per_year=5000000, annual_admission_quota=100, is_published=True,
+            )
+            s.add(ai); await s.flush()
+            am = models.AdmissionMethod(
+                code=f"hb_{ts}", name=f"HB_{ts}",
+                requires_gpa=True, requires_subject_scores=False, is_active=True,
+            )
+            s.add(am); await s.flush()
+            ai_id = ai.id
+            am_id = am.id
+
+    r = await client.post(
+        "/api/admission-config/paths",
+        json={
+            "academic_info_id": ai_id,
+            "admission_method_id": am_id,
+            "display_name": "AllowlistOnCreate",
+            "display_order": 1,
+            "visibility": "internal",
+            "allow_unverified_submission": False,
+            "minor_correction_allowed_fields": ["nationality", "ethnicity"],
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code in (200, 201), r.text
+    body = r.json()
+    assert sorted(body["minor_correction_allowed_fields"]) == ["ethnicity", "nationality"]
+
+
+@pytest.mark.asyncio
+async def test_minor_correction_detail_hides_when_allowlist_empty(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Path with empty allowlist (default) → permission False, fields []."""
+    pid, _ = await _create_seed_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Detail Empty Probe",
+    )
+    await _force_profile_status(pid, "approved")
+    r = await client.get(f"{ADMISSIONS}/{pid}", headers=admin_token_headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["minor_correction_fields"] == []
+    assert body["permissions"]["minor_correction"] is False
+    assert "minor_correction" not in body["available_actions"]

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/PathBasicInfo.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/PathBasicInfo.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -10,6 +11,8 @@ import { Switch } from "@/components/ui/switch";
 import { Loader2, ArrowRight } from "lucide-react";
 import { toast } from "sonner";
 import { useCreateAdmissionPath, useUpdateAdmissionPath } from "@/hooks/admissions/useAdmissionPaths";
+import { useAuth } from "@/hooks/useAuth";
+import { FIELD_GROUPS_VI, FIELD_LABELS_VI } from "@/lib/constants/minor-correction";
 import type { AdmissionPathResponse } from "@/lib/zod/admission-path";
 import type { AdmissionMethod } from "../shared/types";
 import type { AxiosError } from "axios";
@@ -33,8 +36,33 @@ export function PathBasicInfo({ path, methods, academicInfoId, onFinish }: PathB
     path?.allow_unverified_submission ?? false
   );
 
+  // Per-path minor correction allowlist. Admin-only — manager sees the
+  // section disabled (server raises BusinessRuleViolation if a manager
+  // tries to submit it anyway). Default empty = correction disabled.
+  const [allowedFields, setAllowedFields] = useState<Set<string>>(
+    new Set(path?.minor_correction_allowed_fields ?? [])
+  );
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+  const allowedFieldsArray = useMemo(
+    () => Array.from(allowedFields).sort(),
+    [allowedFields]
+  );
+
   const createMutation = useCreateAdmissionPath();
   const updateMutation = useUpdateAdmissionPath();
+
+  function toggleField(field: string) {
+    setAllowedFields((prev) => {
+      const next = new Set(prev);
+      if (next.has(field)) {
+        next.delete(field);
+      } else {
+        next.add(field);
+      }
+      return next;
+    });
+  }
 
   const handleSave = async () => {
     if (!selectedMethodId) {
@@ -46,7 +74,9 @@ export function PathBasicInfo({ path, methods, academicInfoId, onFinish }: PathB
       let savedId: number;
 
       if (path) {
-        // Update existing
+        // Update existing — only admin sends the allowlist field. Server
+        // raises BusinessRuleViolation if a non-admin caller submits it,
+        // so the FE has to make sure it's omitted entirely for managers.
         await updateMutation.mutateAsync({
           pathId: path.id,
           data: {
@@ -54,6 +84,9 @@ export function PathBasicInfo({ path, methods, academicInfoId, onFinish }: PathB
             display_order: displayOrder,
             visibility: visibility,
             allow_unverified_submission: allowUnverified,
+            ...(isAdmin
+              ? { minor_correction_allowed_fields: allowedFieldsArray }
+              : {}),
           },
         });
         savedId = path.id;
@@ -67,6 +100,9 @@ export function PathBasicInfo({ path, methods, academicInfoId, onFinish }: PathB
           display_order: displayOrder,
           visibility: visibility,
           allow_unverified_submission: allowUnverified,
+          // Only admin can seed the allowlist on create. Manager
+          // creating a new path always gets the empty default.
+          minor_correction_allowed_fields: isAdmin ? allowedFieldsArray : [],
         });
         savedId = newPath.id;
         toast.success("Tạo đợt tuyển sinh thành công");
@@ -179,6 +215,56 @@ export function PathBasicInfo({ path, methods, academicInfoId, onFinish }: PathB
               onCheckedChange={setAllowUnverified}
               aria-label="Cho phép nộp hồ sơ khi tài liệu chưa xác minh"
             />
+          </div>
+
+          {/* Minor-correction allowlist (governance setting). Admin-only.
+              Manager sees the section but inputs are disabled — server
+              enforces the same gate via BusinessRuleViolation. */}
+          <div className="space-y-3 rounded-md border p-3">
+            <div className="space-y-1">
+              <Label className="text-sm font-medium">
+                Hiệu chỉnh sau duyệt — danh sách trường được phép
+                {!isAdmin && (
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    (chỉ admin)
+                  </span>
+                )}
+              </Label>
+              <p className="text-xs text-muted-foreground max-w-lg">
+                Cho phép officer/manager hiệu chỉnh các trường không ảnh
+                hưởng tiêu chí xét tuyển trên hồ sơ đã duyệt/đã xác nhận.
+                Chỉ các trường tick bên dưới mới hiển thị trong dialog
+                hiệu chỉnh; mọi thay đổi đều bị log với lý do bắt buộc.
+              </p>
+            </div>
+            <div className="space-y-4">
+              {Object.entries(FIELD_GROUPS_VI).map(([groupName, fields]) => (
+                <div key={groupName} className="space-y-2">
+                  <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                    {groupName}
+                  </h4>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    {fields.map((field) => (
+                      <label
+                        key={field}
+                        className="flex items-start gap-2 text-sm cursor-pointer"
+                      >
+                        <Checkbox
+                          id={`mc-allow-${field}`}
+                          checked={allowedFields.has(field)}
+                          onCheckedChange={() => toggleField(field)}
+                          disabled={!isAdmin}
+                          aria-label={FIELD_LABELS_VI[field] ?? field}
+                        />
+                        <span className="leading-tight">
+                          {FIELD_LABELS_VI[field] ?? field}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
 
           <div className="flex justify-end pt-4">

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
@@ -27,6 +27,7 @@ import { usePermissions } from "@/hooks/usePermissions"
 import { getStatusConfig } from "@/lib/status-config"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 import { SendConfirmationButton } from "./SendConfirmationButton"
+import { MinorCorrectionDialog } from "./MinorCorrectionDialog"
 
 interface AdmissionActionsProps {
   profile: AdmissionProfileResponse
@@ -288,6 +289,13 @@ export function AdmissionActions({
           {can('send_confirmation') && (
             <SendConfirmationButton profileId={profile.id} />
           )}
+
+          {/* Post-approval minor correction. Self-managed dialog — the
+              component checks `profile.permissions.minor_correction` +
+              `profile.minor_correction_fields` internally so no extra
+              gate here. Both flags come from the API resolver
+              (_resolve_minor_correction_state); FE never derives. */}
+          <MinorCorrectionDialog profile={profile} />
 
           {/* Enroll - can('enroll') when status ∈ {approved, confirmed, overridden}.
               Label is "Ghi danh" (not "Xác nhận nhập học") so officers don't

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/MinorCorrectionDialog.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/MinorCorrectionDialog.tsx
@@ -1,0 +1,383 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Loader2, Pencil } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+import { useMinorCorrection } from "@/hooks/admissions/useAdmissions"
+import {
+  ALLOWED_GENDERS,
+  FIELD_GROUPS_VI,
+  FIELD_LABELS_VI,
+} from "@/lib/constants/minor-correction"
+import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+
+interface Props {
+  profile: AdmissionProfileResponse
+}
+
+type FieldValue = string | null | undefined | unknown[] | Record<string, unknown>
+
+/**
+ * Officer/manager/admin entry to ``POST /minor-correction``.
+ *
+ * Renders a button only when the backend tells us we're allowed
+ * (``permissions.minor_correction === true``) AND the resolved per-path
+ * allowlist is non-empty (``minor_correction_fields.length > 0``). Both
+ * gates come from the API response — FE never derives visibility itself.
+ *
+ * Form strategy: keep state lean (single ``values`` map keyed by field
+ * code) and diff against ``profile`` on submit so the wire payload only
+ * contains fields that actually changed. Date inputs use the model's
+ * native ``YYYY-MM-DD`` shape; ``family_info`` falls back to a JSON
+ * textarea — the officer copies the existing array, edits inline, and
+ * the backend re-validates via ``FamilyMemberSchema``.
+ */
+export function MinorCorrectionDialog({ profile }: Props) {
+  const [open, setOpen] = useState(false)
+  const [reason, setReason] = useState("")
+  const [values, setValues] = useState<Record<string, FieldValue>>({})
+  const [familyInfoText, setFamilyInfoText] = useState<string>("")
+  const [familyInfoError, setFamilyInfoError] = useState<string | null>(null)
+
+  const mutation = useMinorCorrection(profile.id)
+
+  // Visibility gate — strictly from API. Both checks must pass.
+  const allowed = profile.permissions?.minor_correction === true
+  const fieldsAvailable = profile.minor_correction_fields ?? []
+
+  // Allowed field set, in display order grouped by FIELD_GROUPS_VI.
+  const orderedGroups = useMemo(() => {
+    const allowSet = new Set(fieldsAvailable)
+    return Object.entries(FIELD_GROUPS_VI)
+      .map(([groupName, keys]) => [
+        groupName,
+        keys.filter((k) => allowSet.has(k)),
+      ] as const)
+      .filter(([, keys]) => keys.length > 0)
+  }, [fieldsAvailable])
+
+  // Read current value from the profile for display in the input. Date
+  // columns are emitted as ISO strings — slice to YYYY-MM-DD for the
+  // native date input. Null values render as empty string so React
+  // doesn't warn about controlled→uncontrolled flips.
+  function readDisplay(field: string): string {
+    const raw = (profile as unknown as Record<string, FieldValue>)[field]
+    if (raw == null) return ""
+    if (field.endsWith("_date") && typeof raw === "string") {
+      return raw.slice(0, 10)
+    }
+    if (field === "family_info" && Array.isArray(raw)) {
+      return JSON.stringify(raw, null, 2)
+    }
+    return String(raw)
+  }
+
+  function getCurrentValue(field: string): FieldValue {
+    if (field === "family_info") {
+      // Held in its own state because JSON parsing is deferred to submit.
+      return familyInfoText !== "" ? familyInfoText : readDisplay(field)
+    }
+    return values[field] !== undefined ? values[field] : readDisplay(field)
+  }
+
+  function setFieldValue(field: string, next: FieldValue): void {
+    setValues((prev) => ({ ...prev, [field]: next }))
+  }
+
+  // Build the diff against the original profile values. Returns null
+  // if family_info JSON failed to parse (caller surfaces error).
+  function buildChanges():
+    | { ok: true; changes: Record<string, unknown> }
+    | { ok: false; error: string } {
+    const changes: Record<string, unknown> = {}
+    for (const field of fieldsAvailable) {
+      if (field === "family_info") {
+        if (!familyInfoText) continue
+        try {
+          const parsed = JSON.parse(familyInfoText)
+          const original = JSON.stringify(
+            (profile as unknown as Record<string, FieldValue>).family_info ?? [],
+          )
+          if (JSON.stringify(parsed) !== original) {
+            changes.family_info = parsed
+          }
+        } catch (e) {
+          return {
+            ok: false,
+            error:
+              "Trường gia đình không phải JSON hợp lệ. Vui lòng kiểm tra lại.",
+          }
+        }
+        continue
+      }
+      const next = values[field]
+      if (next === undefined) continue // user didn't touch
+      const original = readDisplay(field)
+      if (typeof next === "string" && next === original) continue
+      // Empty string → null (clears the column)
+      changes[field] = next === "" ? null : next
+    }
+    return { ok: true, changes }
+  }
+
+  const reasonTrimmed = reason.trim()
+  const reasonValid = reasonTrimmed.length >= 10 && reasonTrimmed.length <= 1000
+
+  function reset() {
+    setReason("")
+    setValues({})
+    setFamilyInfoText("")
+    setFamilyInfoError(null)
+  }
+
+  function handleSubmit() {
+    setFamilyInfoError(null)
+    const result = buildChanges()
+    if (!result.ok) {
+      setFamilyInfoError(result.error)
+      return
+    }
+    if (Object.keys(result.changes).length === 0) {
+      setFamilyInfoError("Chưa có thay đổi nào để lưu.")
+      return
+    }
+    if (profile.version === undefined) {
+      // Should never happen: an approved/confirmed profile always has
+      // a version. Bail with a friendly error rather than ship an
+      // optimistic-lock payload the server can't validate.
+      setFamilyInfoError("Hồ sơ thiếu version — refresh trang rồi thử lại.")
+      return
+    }
+    mutation.mutate(
+      {
+        version: profile.version,
+        reason: reasonTrimmed,
+        changes: result.changes,
+      },
+      {
+        onSuccess: () => {
+          reset()
+          setOpen(false)
+        },
+      },
+    )
+  }
+
+  if (!allowed || fieldsAvailable.length === 0) return null
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setOpen(true)}
+      >
+        <Pencil className="h-4 w-4 mr-2" />
+        Hiệu chỉnh sau duyệt
+      </Button>
+
+      <Dialog
+        open={open}
+        onOpenChange={(next) => {
+          if (mutation.isPending) return
+          setOpen(next)
+          if (!next) reset()
+        }}
+      >
+        <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Hiệu chỉnh hồ sơ sau duyệt</DialogTitle>
+            <DialogDescription>
+              Chỉ áp dụng cho các trường được admin cho phép. Mọi thay đổi
+              được ghi lại với lý do.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-6 py-2">
+            {orderedGroups.map(([groupName, keys]) => (
+              <section key={groupName} className="space-y-3">
+                <h3 className="text-sm font-semibold text-muted-foreground">
+                  {groupName}
+                </h3>
+                <div className="space-y-3">
+                  {keys.map((field) => (
+                    <FieldRow
+                      key={field}
+                      field={field}
+                      currentValue={getCurrentValue(field) as string}
+                      onChange={(next) => {
+                        if (field === "family_info") {
+                          setFamilyInfoText(next)
+                        } else {
+                          setFieldValue(field, next)
+                        }
+                      }}
+                      disabled={mutation.isPending}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+
+            {familyInfoError && (
+              <p className="text-sm text-destructive">{familyInfoError}</p>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="minor-correction-reason">
+                Lý do hiệu chỉnh{" "}
+                <span className="text-muted-foreground text-xs">
+                  (≥ 10 ký tự, bắt buộc)
+                </span>
+              </Label>
+              <Textarea
+                id="minor-correction-reason"
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                disabled={mutation.isPending}
+                rows={3}
+                placeholder="Mô tả lý do — ví dụ: applicant báo qua điện thoại 25/04 yêu cầu sửa địa chỉ"
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                if (mutation.isPending) return
+                setOpen(false)
+                reset()
+              }}
+              disabled={mutation.isPending}
+            >
+              Hủy
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!reasonValid || mutation.isPending}
+            >
+              {mutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Lưu hiệu chỉnh
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// FieldRow — picks the right input shape per field key.
+// ---------------------------------------------------------------------------
+
+function FieldRow({
+  field,
+  currentValue,
+  onChange,
+  disabled,
+}: {
+  field: string
+  currentValue: string
+  onChange: (next: string) => void
+  disabled: boolean
+}) {
+  const label = FIELD_LABELS_VI[field] ?? field
+
+  if (field === "gender") {
+    return (
+      <div className="space-y-1.5">
+        <Label htmlFor={`mc-${field}`}>{label}</Label>
+        <Select
+          value={currentValue || ""}
+          onValueChange={onChange}
+          disabled={disabled}
+        >
+          <SelectTrigger id={`mc-${field}`}>
+            <SelectValue placeholder="Chọn giới tính" />
+          </SelectTrigger>
+          <SelectContent>
+            {ALLOWED_GENDERS.map((g) => (
+              <SelectItem key={g} value={g}>
+                {g}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    )
+  }
+
+  if (field.endsWith("_date")) {
+    return (
+      <div className="space-y-1.5">
+        <Label htmlFor={`mc-${field}`}>{label}</Label>
+        <Input
+          id={`mc-${field}`}
+          type="date"
+          value={currentValue}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+        />
+      </div>
+    )
+  }
+
+  if (field === "family_info") {
+    return (
+      <div className="space-y-1.5">
+        <Label htmlFor={`mc-${field}`}>
+          {label}{" "}
+          <span className="text-xs text-muted-foreground">
+            (JSON array — copy &amp; sửa)
+          </span>
+        </Label>
+        <Textarea
+          id={`mc-${field}`}
+          value={currentValue}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          rows={6}
+          className="font-mono text-xs"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={`mc-${field}`}>{label}</Label>
+      <Input
+        id={`mc-${field}`}
+        value={currentValue}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/layouts/SocketHandler.tsx
+++ b/frontend/src/components/layouts/SocketHandler.tsx
@@ -583,6 +583,26 @@ export function SocketHandler() {
       }
     };
 
+    // Realtime sync after a post-approval minor correction. Payload
+    // carries field NAMES only (no PII) — broadcast emit is scoped to
+    // admin + unit + assigned officer rooms server-side, so just
+    // refetch the admission tree on receipt. No lead/finance impact:
+    // SAFE catalog excludes any field that lead_admission_sync would
+    // project, so we don't need to touch lead/pipeline keys.
+    const handleApplicationMinorCorrected = (data: {
+      application_id: number;
+      lead_id: number;
+      changed_fields: string[];
+      actor_id: number;
+      corrected_at: string;
+    }) => {
+      console.log(
+        "[SocketHandler] application_minor_corrected → invalidating admission caches",
+        { profile: data.application_id, fields: data.changed_fields },
+      );
+      queryClient.invalidateQueries({ queryKey: admissionsKeys.all });
+    };
+
     // ✅ REAL-TIME PIPELINE CONFIG (Week 3): Lắng nghe sự kiện pipeline_config_updated
     const handlePipelineConfigUpdated = (data: {
       config_type: "pipeline_stage" | "consultation_status" | "allowed_transition";
@@ -1065,6 +1085,7 @@ export function SocketHandler() {
     socket.on("lead_status_changed", handleLeadStatusChanged);
     socket.on("application_created", handleApplicationCreated);
     socket.on("application_status_changed", handleApplicationStatusChanged);
+    socket.on("application_minor_corrected", handleApplicationMinorCorrected);
     socket.on("fee_calculated", handleFeeCalculated);
     socket.on("pipeline_config_updated", handlePipelineConfigUpdated);
     socket.on("consultation_created", handleConsultationCreated);
@@ -1111,6 +1132,7 @@ export function SocketHandler() {
       socket.off("lead_status_changed", handleLeadStatusChanged);
       socket.off("application_created", handleApplicationCreated);
       socket.off("application_status_changed", handleApplicationStatusChanged);
+      socket.off("application_minor_corrected", handleApplicationMinorCorrected);
       socket.off("fee_calculated", handleFeeCalculated);
       socket.off("pipeline_config_updated", handlePipelineConfigUpdated);
       socket.off("consultation_created", handleConsultationCreated);

--- a/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
+++ b/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
@@ -50,6 +50,9 @@ const mockAdmissionPathResponse: AdmissionPathResponse = {
   // PR #6: strict submit gate per path; default False in the fixture
   // mirrors the backend default for newly-created paths.
   allow_unverified_submission: false,
+  // Minor-correction allowlist — empty by default for fresh paths
+  // (admin opts in field-by-field after path creation).
+  minor_correction_allowed_fields: [],
 };
 
 /** The shape that PUT /paths/:id/documents returns. */

--- a/frontend/src/hooks/admissions/useAdmissions.ts
+++ b/frontend/src/hooks/admissions/useAdmissions.ts
@@ -267,6 +267,41 @@ export function useResubmitAdmission(id: number) {
 }
 
 /**
+ * Apply post-approval minor correction (Officer/Manager/Admin).
+ *
+ * Submits the diffed `changes` payload + reason + version to
+ * ``POST /admissions/{id}/minor-correction``. Status doesn't change
+ * server-side — the response is the refreshed profile with version+1.
+ *
+ * Cache invalidation uses ``admissionsKeys.all`` so list / detail /
+ * status-counts / stats all refetch in one cascade. Lead pipeline is
+ * NOT touched (verified backend doesn't project any SAFE field onto
+ * Lead state).
+ */
+export function useMinorCorrection(id: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: {
+      version: number
+      reason: string
+      changes: Record<string, unknown>
+    }) => admissionsApi.minorCorrection(id, data),
+    onSuccess: () => {
+      toast.success("Đã lưu hiệu chỉnh")
+      queryClient.invalidateQueries({ queryKey: admissionsKeys.all })
+    },
+    onError: (error: AxiosError<ApiErrorResponse>) => {
+      handleApiError(error, {
+        queryClient,
+        invalidateKeys: [[...admissionsKeys.detail(id)]],
+        context: "hiệu chỉnh hồ sơ",
+      })
+    },
+  })
+}
+
+/**
  * Approve Admission Hook
  * Manager/Admin action - transitions from submitted/resubmitted → approved
  * 

--- a/frontend/src/lib/api/admissions.ts
+++ b/frontend/src/lib/api/admissions.ts
@@ -114,6 +114,26 @@ export async function approveAdmission(
 }
 
 /**
+ * Apply post-approval minor correction (Officer/Manager/Admin)
+ * POST /api/admissions/{id}/minor-correction
+ *
+ * Allowed only on profiles in approved/confirmed status. Backend
+ * enforces SAFE catalog ∩ AdmissionPath allowlist; FE renders fields
+ * from ``profile.minor_correction_fields`` so the dialog never offers
+ * a key the server would reject.
+ */
+export async function minorCorrection(
+  id: number,
+  data: { version: number; reason: string; changes: Record<string, unknown> }
+): Promise<AdmissionProfileResponse> {
+  const response = await api.post<AdmissionProfileResponse>(
+    `/api/admissions/${id}/minor-correction`,
+    data
+  )
+  return response.data
+}
+
+/**
  * Reject admission profile (Manager/Admin action)
  * POST /api/admissions/{id}/reject
  * 
@@ -478,6 +498,7 @@ export const admissionsApi = {
   requestRevision,
   approveAdmission,
   rejectAdmission,
+  minorCorrection,
   dropStudent,
   enrollStudent,
   deleteAdmission,

--- a/frontend/src/lib/constants/minor-correction.ts
+++ b/frontend/src/lib/constants/minor-correction.ts
@@ -1,0 +1,105 @@
+/**
+ * Mirror of `app/core/admission_correction_constants.py`.
+ *
+ * Backend is the single source of truth — this file exists so the
+ * dialog + admin allowlist UI can render labels without round-tripping
+ * to fetch them and so Zod refinements can guard against drift at the
+ * client edge. Sync rule: changes here must follow a backend change,
+ * never lead it.
+ */
+
+export const SAFE_MINOR_CORRECTION_FIELDS = new Set<string>([
+  // Demographic supplements
+  "gender",
+  "nationality",
+  "ethnicity",
+  "religion",
+  "disability_type",
+  "social_insurance_number",
+  "place_of_birth",
+  "native_place",
+  // Đoàn / Đảng entry dates
+  "union_entry_date",
+  "party_entry_date",
+  "party_official_entry_date",
+  // Permanent residence
+  "permanent_province",
+  "permanent_district",
+  "permanent_ward",
+  "permanent_residential_group",
+  "permanent_street_address",
+  // Family / guardian
+  "family_info",
+])
+
+/** Vietnamese labels surfaced in the dialog + admin allowlist multi-select. */
+export const FIELD_LABELS_VI: Record<string, string> = {
+  gender: "Giới tính",
+  nationality: "Quốc tịch",
+  ethnicity: "Dân tộc",
+  religion: "Tôn giáo",
+  disability_type: "Loại khuyết tật",
+  social_insurance_number: "Số sổ BHXH",
+  place_of_birth: "Nơi sinh",
+  native_place: "Nguyên quán",
+  union_entry_date: "Ngày vào Đoàn",
+  party_entry_date: "Ngày vào Đảng",
+  party_official_entry_date: "Ngày chính thức vào Đảng",
+  permanent_province: "Tỉnh/TP thường trú",
+  permanent_district: "Quận/Huyện thường trú",
+  permanent_ward: "Phường/Xã thường trú",
+  permanent_residential_group: "Tổ/Thôn/Khu phố",
+  permanent_street_address: "Địa chỉ chi tiết",
+  family_info: "Thông tin gia đình / người giám hộ",
+}
+
+/**
+ * Visual grouping for the dialog + admin form. Order here is the
+ * render order; nothing else in the codebase depends on these group
+ * names, so renaming is safe.
+ */
+export const FIELD_GROUPS_VI: Record<string, readonly string[]> = {
+  "Thông tin bổ sung": [
+    "gender",
+    "nationality",
+    "ethnicity",
+    "religion",
+    "disability_type",
+    "social_insurance_number",
+    "place_of_birth",
+    "native_place",
+  ],
+  "Đoàn / Đảng": [
+    "union_entry_date",
+    "party_entry_date",
+    "party_official_entry_date",
+  ],
+  "Địa chỉ thường trú": [
+    "permanent_province",
+    "permanent_district",
+    "permanent_ward",
+    "permanent_residential_group",
+    "permanent_street_address",
+  ],
+  "Gia đình": ["family_info"],
+}
+
+/** Gender values matching backend ALLOWED_GENDERS + PersonalInfoTab dropdown. */
+export const ALLOWED_GENDERS = ["Nam", "Nữ", "Khác"] as const
+export type AllowedGender = (typeof ALLOWED_GENDERS)[number]
+
+/**
+ * Drift guard — every label entry must reference a SAFE field. Mirrors
+ * the assert in the backend constants module so dev catches the
+ * mismatch the moment the file imports rather than at runtime.
+ */
+const labelKeys = new Set(Object.keys(FIELD_LABELS_VI))
+const safeArr = Array.from(SAFE_MINOR_CORRECTION_FIELDS)
+if (
+  labelKeys.size !== SAFE_MINOR_CORRECTION_FIELDS.size ||
+  safeArr.some((f) => !labelKeys.has(f))
+) {
+  throw new Error(
+    "FIELD_LABELS_VI keys must match SAFE_MINOR_CORRECTION_FIELDS exactly",
+  )
+}

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -10,6 +10,8 @@
 
 import { z } from "zod"
 
+import { SAFE_MINOR_CORRECTION_FIELDS } from "@/lib/constants/minor-correction"
+
 // ==============================================================================
 // STATUS ENUM
 // ==============================================================================
@@ -122,6 +124,17 @@ export const admissionPathCreateSchema = z.object({
   // "uploaded = submittable" behaviour on a per-path basis. Default here
   // matches the backend default so the create form stays explicit.
   allow_unverified_submission: z.boolean().default(false),
+  // Per-path correction allowlist. Default empty list (admin must
+  // opt-in field-by-field). Refine guards against drift — schema
+  // mirrors backend ``SAFE_MINOR_CORRECTION_FIELDS`` so any UI
+  // accidentally posting a non-safe key fails Zod before round-trip.
+  minor_correction_allowed_fields: z
+    .array(z.string())
+    .default([])
+    .refine(
+      (arr) => arr.every((f) => SAFE_MINOR_CORRECTION_FIELDS.has(f as never)),
+      { message: "Field không nằm trong safe catalog" },
+    ),
 })
 
 export type AdmissionPathCreate = z.infer<typeof admissionPathCreateSchema>
@@ -137,6 +150,19 @@ export const admissionPathUpdateSchema = z.object({
   // Optional on update — callers that don't want to flip the flag omit
   // it entirely and the backend leaves the current value untouched.
   allow_unverified_submission: z.boolean().optional(),
+  // Optional on update so partial PATCH-style updates don't accidentally
+  // clear the allowlist. Backend service raises BusinessRuleViolation
+  // if a non-admin caller submits this key, so the FE form must hide
+  // the section for non-admins.
+  minor_correction_allowed_fields: z
+    .array(z.string())
+    .optional()
+    .refine(
+      (arr) =>
+        arr === undefined ||
+        arr.every((f) => SAFE_MINOR_CORRECTION_FIELDS.has(f as never)),
+      { message: "Field không nằm trong safe catalog" },
+    ),
 })
 
 export type AdmissionPathUpdate = z.infer<typeof admissionPathUpdateSchema>
@@ -215,6 +241,11 @@ export const admissionPathResponseSchema = z.object({
   // PR #6 — REQUIRED in the response so Zod fails loudly when the backend
   // forgets to emit the field. Admin UI mirrors this bool as a toggle.
   allow_unverified_submission: z.boolean(),
+  // Required so the admin form pre-checks the right boxes. No refine
+  // on response — data from DB has already passed Create/Update
+  // validation, so re-checking here would be redundant work that
+  // surfaces no new bugs.
+  minor_correction_allowed_fields: z.array(z.string()),
 })
 
 export type AdmissionPathResponse = z.infer<typeof admissionPathResponseSchema>

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -511,6 +511,12 @@ export const admissionProfileResponseSchema = z.object({
   
   // Available workflow actions
   available_actions: z.array(z.string()).default([]),
+
+  // Per-profile effective allowlist for the post-approval correction
+  // dialog (mirrors AdmissionProfileResponse.minor_correction_fields).
+  // Backend resolves SAFE catalog ∩ AdmissionPath config; FE renders
+  // the dialog rows from this list, never derives anything itself.
+  minor_correction_fields: z.array(z.string()).default([]),
   
   // Profile completion percentage (0-100)
   completion_percent: z.number().int().min(0).max(100).default(0),
@@ -1092,4 +1098,29 @@ export const ConfirmTokenInfoResponseSchema = z.object({
   expires_at: z.string().datetime({ offset: true }).nullable(),
 })
 export type ConfirmTokenInfoResponse = z.infer<typeof ConfirmTokenInfoResponseSchema>
+
+/**
+ * POST /api/admissions/{id}/minor-correction — request schema.
+ *
+ * Mirrors backend ``MinorCorrectionRequest``. ``reason`` is trimmed
+ * before length check so a "          a" (length 10 with 9 spaces)
+ * fails Zod the same way it fails backend StringConstraints. ``changes``
+ * is enforced non-empty; per-field type validation is left to the
+ * server (single source of truth for SAFE catalog adapters).
+ */
+export const MinorCorrectionRequestSchema = z.object({
+  version: z.number().int().min(1),
+  reason: z
+    .string()
+    .trim()
+    .min(10, "Vui lòng nhập lý do tối thiểu 10 ký tự")
+    .max(1000, "Lý do tối đa 1000 ký tự"),
+  changes: z
+    .record(z.string(), z.unknown())
+    .refine(
+      (obj) => Object.keys(obj).length > 0,
+      { message: "Chưa có thay đổi nào" },
+    ),
+})
+export type MinorCorrectionRequest = z.infer<typeof MinorCorrectionRequestSchema>
 


### PR DESCRIPTION
## Summary

Mở governed update path cho officer/manager/admin sửa thông tin nhỏ (BHXH, địa chỉ, gia đình, đoàn/đảng) trên hồ sơ approved/confirmed mà không cần override hoặc resubmit toàn bộ.

**Defense-in-depth 2-tier allowlist** + HARD_DENY blocklist + audit log + broadcast-only realtime sync — payload field-names-only, no PII leak.

## What lands

### Backend

**Migrations** (2):
- `dd4l5m6n7o8p`: add `admission_path.minor_correction_allowed_fields` JSONB array (NOT NULL DEFAULT \`[]\`) + check_constraint asserts array shape. **No backfill** — admin opts in field-by-field per path.
- `dd5m6n7o8p9q`: seed Casbin policies for admin/manager/officer on \`/api/admissions/{id}/minor-correction POST\`. Pattern uses \`{id}\` literal placeholder (matches existing prod policies, NOT \`*\` wildcard).

**Constants + helpers** (2 new files):
- \`app/core/admission_correction_constants.py\`: SAFE_MINOR_CORRECTION_FIELDS (17 fields), HARD_DENY_FIELDS (35 keys incl. \`dob\`, \`citizen_id\`, \`documents\`, \`applied_rules\`), ALLOWED_GENDERS, FIELD_LABELS_VI. Module-level asserts: SAFE ⊆ labels, SAFE ∩ HARD_DENY = ∅.
- \`app/services/admission_correction_helpers.py\`: per-field TypeAdapter map (\`FIELD_ADAPTERS\`), \`parse_and_normalize\`, \`post_parse_business_check\`, \`safe_serialize\`. Drift-guard assert catalog ↔ adapters at import. \`family_info\` adapter retains \`max_length=10\` constraint.

**Service**:
- \`apply_minor_correction(db, profile, payload, current_user) -> (profile, socket_envelope)\`: status whitelist (approved/confirmed) → optimistic version → resolve effective allowlist live from AdmissionPath (NOT snapshotted) → HARD_DENY before allowlist (defense in depth) → per-field parse + business check → **cross-field date invariants on candidate state** → diff → audit log via \`audit_service.log_changes\` (action=\`minor_corrected\`, reason mandatory ≥10 chars after strip) → pre-resolve socket envelope IN-TRANSACTION → re-populate response fields. Router commits then \`safe_dispatch\` post-commit.
- \`_resolve_minor_correction_state\` + \`_apply_minor_correction_state\` + \`_sync_available_actions\`: refines tentative \`permissions.minor_correction\` flag set in \`_compute_frontend_fields\` against the live AdmissionPath allowlist. Wired into list (batch path lookup, no N+1), detail (\`get_profile\`), and every mutation response (\`_populate_response_fields\`). **Action shows only when effective allowlist non-empty.**
- \`AdmissionPathService.update_path\` + \`create_path\`: admin-only guard rejects manager attempts to flip \`minor_correction_allowed_fields\` (governance setting).
- \`AdmissionPathRepository.get_by_ids\`: batch fetch helper (eliminates N+1 path queries on list endpoint).

**Router**: \`POST /admissions/{id}/minor-correction\` rate-limited DATA_WRITE, IDOR via \`get_admission_for_user\` (3-tier + row lock), Casbin via \`CasbinAuth\`, post-commit \`safe_dispatch\` with rooms scoped to admin + unit + assigned officer.

**Events**: \`SystemEvents.APPLICATION_MINOR_CORRECTED\`, mapped to \`NotificationEventGroup.APPLICATION\`, catalog entry with \`notification_class=\"broadcast_only\"\` + \`privacy=\"sensitive\"\` (no DB rule, no seed). Payload carries field NAMES only, never values.

**Schemas**:
- \`MinorCorrectionRequest\` (\`version\`, \`reason: TrimmedReason\`, \`changes: dict[str, Any]\`). \`TrimmedReason\` strips before length check so \"          a\" (length 10 with 9 spaces) fails.
- \`AdmissionProfileResponse.minor_correction_fields: List[str]\`.
- \`AdmissionPath{Create,Update,Response}.minor_correction_allowed_fields\` with module-level validator on Create + Update.

### Frontend

- **Zod**: \`MinorCorrectionRequestSchema\` mirrors backend; admission-path schemas extended with allowlist field + refine against SAFE catalog mirror; \`AdmissionProfileResponseSchema\` adds \`minor_correction_fields\`.
- **\`lib/constants/minor-correction.ts\`** (new): SAFE set, FIELD_LABELS_VI, FIELD_GROUPS_VI, ALLOWED_GENDERS — single source of truth is BE, FE mirrors with drift-guard at module load.
- **\`MinorCorrectionDialog.tsx\`** (new): self-managed dialog gated entirely by API flags (\`permissions.minor_correction\` + \`minor_correction_fields\`). Renders allowed fields grouped by FIELD_GROUPS_VI with type-specific inputs (date input for *_date, Select for gender, JSON textarea for family_info). Diffs against profile values, submits only changed fields.
- **\`useMinorCorrection(id)\`** hook: invalidates \`admissionsKeys.all\` (root cascade) on success; routes 409 through \`handleApiError\`.
- **\`AdmissionActions.tsx\`**: renders \`<MinorCorrectionDialog>\` (hidden internally if not allowed).
- **\`SocketHandler.tsx\`**: registers \`application_minor_corrected\` listener alongside \`application_*\` / \`fee_calculated\` handlers; cleanup \`off()\`.
- **\`PathBasicInfo.tsx\`** (admin form): adds \"Hiệu chỉnh sau duyệt\" section with multi-checkbox grouped by FIELD_GROUPS_VI; rendered for all admins, disabled for non-admins (server enforces same gate).

## Test plan

### Backend (33 cases — all passing local)
- Module invariants (SAFE ↔ adapters, SAFE ∩ HARD_DENY)
- Status whitelist (positive: approved/confirmed parametrize; negative: draft)
- HARD_DENY per-key parametrized (12 keys incl. \`citizen_id\`, \`dob\`, \`status\`, \`applied_rules\`, \`documents\`, \`fees\`)
- Per-path allowlist (empty path, field outside allowlist)
- Optimistic version (409)
- Reason strip (\"9 spaces + 1 char\" → 422)
- Empty changes (422), no-op diff (400)
- TypeAdapter normalize (ISO date → naive UTC datetime)
- Business rule (future *_date → 400)
- Gender whitelist, BHXH regex
- Audit row written
- Detail response shape (permissions + fields), detail hides when allowlist empty
- **Cross-field date invariants** (union after party → 400, party after official → 400)
- **\`family_info\` max 10 enforced**
- **\`create_path\` persists allowlist for admin**

### Local verification

- ✅ Backend full CI gate suite: **102/102** (test_notification_contract + parity + condition_dispatch + notification_core_v2 + bundle + bundle_contract). Per memory \`notification-event-gate-required-locally\` (PR #127 lesson).
- ✅ Backend new tests: **33/33** PASS in ~5 min.
- ✅ Frontend \`tsc --noEmit\`: EXIT=0.
- ✅ Frontend \`npm run lint\`: 0 errors.

## Migration notes

- Path migration is additive — empty default for existing paths. Admin must opt in field-by-field per path before officers see the dialog button.
- Casbin migration uses idempotent \`INSERT ... WHERE NOT EXISTS\` (matches PR #5/#7 pattern). Safe to re-run.
- No data backfill on profiles — \`minor_correction_fields\` is resolved live from AdmissionPath, not snapshotted.

## Known follow-up (separate PR scheduled)

Pre-existing bug discovered during code review: \`update_profile\` partial schema dump (\`exclude_unset=True\`) bypasses cross-field date invariants when payload contains only one date. Same lesson as this PR's apply_minor_correction fix, but in a different (older) flow. **Will ship as separate PR with Option 2 refactor** (extract \`validate_logical_dates\` utility shared by schema + minor_correction + update_profile) immediately after this PR merges. Tracked in memory \`admission-logical-dates-partial-update-followup\`.

## Out of scope (V1)

- Documents (separate re-upload flow exists).
- Phone / email primary contact (need Lead sync + magic-link refresh).
- Hồ sơ enrolled / overridden / dropped / withdrawn (need amendment flow).
- Applicant transparency UI (silent v1 — audit log + internal socket only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)