### PR TITLE
fix(admissions): gate MinorCorrectionDialog with can('minor_correction')

### DIFF
--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
@@ -290,12 +290,21 @@ export function AdmissionActions({
             <SendConfirmationButton profileId={profile.id} />
           )}
 
-          {/* Post-approval minor correction. Self-managed dialog — the
-              component checks `profile.permissions.minor_correction` +
-              `profile.minor_correction_fields` internally so no extra
-              gate here. Both flags come from the API resolver
-              (_resolve_minor_correction_state); FE never derives. */}
-          <MinorCorrectionDialog profile={profile} />
+          {/* Post-approval minor correction. External `can()` gate
+              mirrors SendConfirmationButton's pattern — caller decides
+              visibility so the dialog component (and its
+              useMinorCorrection mutation hook) never mounts when the
+              backend hasn't authorized this profile. Without the gate,
+              tests without a QueryClientProvider crash on hook
+              instantiation; with the gate, only profiles whose backend
+              flag is true ever invoke the hook. The dialog also
+              double-checks `minor_correction_fields` length internally
+              so a flag=true / fields=[] state stays renderable but
+              empty (matching the contract documented in
+              `_resolve_minor_correction_state`). */}
+          {can('minor_correction') && (
+            <MinorCorrectionDialog profile={profile} />
+          )}
 
           {/* Enroll - can('enroll') when status ∈ {approved, confirmed, overridden}.
               Label is "Ghi danh" (not "Xác nhận nhập học") so officers don't


### PR DESCRIPTION
## Summary

Hotfix cho PR #129 (post-approval minor correction). PR ship `<MinorCorrectionDialog profile={profile} />` unconditionally trong `AdmissionActions`. Component dùng `useMinorCorrection` hook → `useQueryClient`. Nhưng `AdmissionActions.test.tsx` (CI gate vitest file) render component mà không wrap `QueryClientProvider`, nên hook crash với `No QueryClient set`.

29/29 AdmissionActions tests fail → PR Gate fail → Deploy job skipped → VPS không update.

## Fix

Gate dialog ở caller giống pattern `SendConfirmationButton` (đã được gate bằng `can('send_confirmation')`):

```diff
- <MinorCorrectionDialog profile={profile} />
+ {can('minor_correction') && <MinorCorrectionDialog profile={profile} />}
```

Test fixtures default `permissions: {}` → `can('minor_correction')` false → dialog không mount → hook không fire → tests pass.

## Why không tighten test fixture thay vì code?

Chọn fix code vì:
- Pattern đã chuẩn hóa: SendConfirmationButton, Approve, Reject, Resubmit, Delete đều gate bằng `can('...')` ở caller. MinorCorrectionDialog là outlier.
- Internal check trong dialog vẫn giữ làm belt-and-braces (dialog tự return null nếu permission/fields không hợp lệ).
- Tighten test fixture để wrap QueryClientProvider sẽ phải sửa nhiều test khác chia chung fixture pattern, scope creep.

## Test plan

- [x] `vitest run AdmissionActions.test.tsx` → **29/29 PASS** (was 0/29)
- [x] CI gate trio (AdmissionActions + PersonalInfoTab + LeadsTable) → **42/42 PASS**

## Impact

VPS hiện vẫn ở `ab0db9bc` (PR #128 hotfix) — PR #129 deploy bị skip nên feature minor_correction CHƯA active trên prod. Sau khi hotfix này merge, deploy auto-trigger → bring up cả PR #129 + hotfix → feature live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)