### PR TITLE
fix(admissions): apply logical-date invariants on partial updates

### DIFF
--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -648,6 +648,13 @@ async def update_admission_profile(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
+    except ValidationError as e:
+        # Cross-field date invariant violations (candidate state check)
+        # surface as ValidationError. Map to 400 like other input errors.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
 
 
 @limiter.limit(RateLimits.DATA_WRITE)  # 200/hour

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -442,33 +442,25 @@ class AdmissionProfileUpdate(BaseModel):
         validate_assignment=True
     )
 
-    # ✅ FIX Finding 1.5: Cross-field Date Validation
+    # Cross-field date invariants — delegate to standalone utility so
+    # service-layer partial-update flows (apply_minor_correction,
+    # update_profile candidate-state checks) share the exact same rules.
+    # See feedback memory ``partial-update-loses-cross-field-invariants``.
     from pydantic import model_validator
-    
+
     @model_validator(mode='after')
     def validate_logical_dates(self) -> 'AdmissionProfileUpdate':
-        """
-        Validate logical sequence of dates to prevent invalid data.
-        Failed validation raises ValueError (422 Unprocessable Entity).
-        """
-        # 1. Political Dates Logic
-        # Union Entry < Party Entry (Probationary) < Party Official Entry
-        if self.union_entry_date and self.party_entry_date:
-            if self.union_entry_date > self.party_entry_date:
-                raise ValueError("Ngày vào Đoàn phải trước Ngày vào Đảng (dự bị)")
-        
-        if self.party_entry_date and self.party_official_entry_date:
-            if self.party_entry_date > self.party_official_entry_date:
-                raise ValueError("Ngày vào Đảng (dự bị) phải trước Ngày vào Đảng (chính thức)")
+        """Schema-level entry point — runs on the partial payload only.
 
-        # 2. Birth Date Logic
-        # DOB must be reasonable (e.g., < Union Entry if both exist)
-        # Typically Union entry is at age 15+
-        # Note: dob is date, union_entry_date is datetime — extract .date() for comparison
-        if self.dob and self.union_entry_date:
-            if self.dob > self.union_entry_date.date():
-               raise ValueError("Ngày sinh phải trước Ngày vào Đoàn")
-
+        IMPORTANT: this catches violations within the payload itself, but
+        does NOT catch a partial update that conflicts with values
+        already in the database. Callers doing partial updates must
+        build a candidate state (DB + payload) and call
+        ``validate_logical_dates`` from
+        ``app.services.admission_invariants`` directly.
+        """
+        from app.services.admission_invariants import validate_logical_dates
+        validate_logical_dates(self.model_dump())
         return self
 
 

--- a/Backend_FastAPI/app/services/admission_invariants.py
+++ b/Backend_FastAPI/app/services/admission_invariants.py
@@ -1,0 +1,100 @@
+"""Cross-field invariants for AdmissionProfile state.
+
+Single source of truth for invariants that span multiple fields.
+``AdmissionProfileUpdate.validate_logical_dates`` (schema-level model
+validator) and the service layer (`apply_minor_correction`,
+`update_profile`) both delegate here so partial-update flows can run
+the same checks against a candidate state without duplicating logic.
+
+Why this module exists
+----------------------
+Pydantic ``@model_validator(mode='after')`` only sees fields present
+on the instance. When a router does ``data.model_dump(exclude_unset=True)``
+for a partial update, the validator runs on the trimmed payload —
+fields the client did NOT send (but exist in the DB) are ``None``,
+so cross-field checks like "union ≤ party" silently pass when only
+``union_entry_date`` is being changed but ``party_entry_date`` already
+holds an earlier value in the database.
+
+Service layers using ``TypeAdapter(field_type)`` for per-field parsing
+have a parallel hole: they never instantiate the schema, so the
+model validator never runs at all.
+
+The fix is the same in both cases — build a candidate state (DB
+attributes + caller's changes overlaid), pass it to the standalone
+validator. This module exposes that validator. Callers that already
+have a complete state (full schema instance) can pass
+``self.model_dump()`` and get the same checks; callers with a partial
+payload merge against the existing model row first.
+
+Lesson reference
+----------------
+See feedback memory ``partial-update-loses-cross-field-invariants``
+for the broader pattern. ``apply_minor_correction`` (PR #129) shipped
+inline checks; this utility consolidates them so ``update_profile``
+(pre-existing partial-update flow) can apply the same rules.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Mapping, Optional
+
+
+def _coerce_date(value: Any) -> Optional[date]:
+    """Normalize a date/datetime/None into a ``date`` for comparison.
+
+    The model stores ``dob`` as ``date`` and the entry-date columns as
+    naive ``datetime``. Compare on the date boundary so a 23:00 entry
+    same calendar day as ``dob`` doesn't trip the rule.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    # Defensive: surfaces unexpected payload shape immediately rather than
+    # silently bypassing the rule.
+    raise TypeError(
+        f"validate_logical_dates: unsupported value type {type(value).__name__}"
+    )
+
+
+def validate_logical_dates(state: Mapping[str, Any]) -> None:
+    """Enforce admission logical-date ordering invariants.
+
+    ``state`` is a flat mapping containing (at minimum) any of:
+    ``dob``, ``union_entry_date``, ``party_entry_date``,
+    ``party_official_entry_date``. Missing keys are treated as not
+    asserted — callers building a candidate state from DB + partial
+    payload should include the existing DB values so the rule applies
+    against the merged result rather than only the payload subset.
+
+    Raises ``ValueError`` with a Vietnamese message describing the
+    violated invariant. Callers in the service layer convert that to
+    the project's domain ``ValidationError`` (utils.exceptions); the
+    schema-level model validator lets it propagate as Pydantic
+    validation error (422).
+
+    Rules (mirror of ``AdmissionProfileUpdate.validate_logical_dates``):
+    1. ``union_entry_date`` ≤ ``party_entry_date`` (probationary)
+    2. ``party_entry_date`` ≤ ``party_official_entry_date``
+    3. ``dob`` ≤ ``union_entry_date`` (treat dob as date boundary)
+    """
+    union = state.get("union_entry_date")
+    party = state.get("party_entry_date")
+    party_official = state.get("party_official_entry_date")
+    dob = state.get("dob")
+
+    if union and party and union > party:
+        raise ValueError("Ngày vào Đoàn phải trước Ngày vào Đảng (dự bị)")
+
+    if party and party_official and party > party_official:
+        raise ValueError(
+            "Ngày vào Đảng (dự bị) phải trước Ngày vào Đảng (chính thức)"
+        )
+
+    union_date = _coerce_date(union)
+    dob_date = _coerce_date(dob)
+    if dob_date and union_date and dob_date > union_date:
+        raise ValueError("Ngày sinh phải trước Ngày vào Đoàn")

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2605,6 +2605,42 @@ async def update_profile(
 
         profile.citizen_id = new_citizen_id
 
+    # Cross-field date invariants on the candidate state.
+    # Schema's @model_validator only sees the trimmed payload (router dumps
+    # via exclude_unset=True), so a request that updates ONLY
+    # union_entry_date can leave the row in a state where union > party
+    # (party already in DB). Build a candidate from DB attrs + payload
+    # and run the same shared utility schema uses. Lesson reference:
+    # feedback memory ``partial-update-loses-cross-field-invariants``.
+    #
+    # IMPORTANT: candidate must match setter semantics, NOT payload as-is.
+    # The dob setter (~line 2627) skips when value is None (`is not None`
+    # check), so a payload like ``{"dob": null, "union_entry_date": "..."}``
+    # leaves the existing DB dob untouched. If we naively copied payload
+    # null into the candidate, validate_logical_dates would skip the
+    # dob ≤ union check (None short-circuits), then the setter would
+    # preserve the original DB dob — re-introducing the same bypass we
+    # are trying to fix. The entry-date setters DO accept None (they
+    # clear the column), so candidate uses payload value as-is for those.
+    from .admission_invariants import validate_logical_dates
+    _date_keys = ("dob", "union_entry_date", "party_entry_date", "party_official_entry_date")
+    if any(k in data for k in _date_keys):
+        candidate_state: Dict[str, Any] = {}
+        for _k in _date_keys:
+            if _k not in data:
+                candidate_state[_k] = getattr(profile, _k)
+            elif _k == "dob" and data[_k] is None:
+                # Setter ignores ``dob: null`` — preserve existing DB value
+                # so the invariant runs against what will actually persist.
+                candidate_state[_k] = getattr(profile, _k)
+            else:
+                candidate_state[_k] = data[_k]
+        try:
+            validate_logical_dates(candidate_state)
+        except ValueError as exc:
+            from app.utils.exceptions import ValidationError as _ValidationError
+            raise _ValidationError(str(exc))
+
     # ✅ Sync with Lead: Full Name
     if "full_name" in data and data["full_name"] is not None:
         profile.full_name = data["full_name"]
@@ -5937,33 +5973,29 @@ async def apply_minor_correction(
         if biz_err:
             raise ValidationError(biz_err)
 
-    # 5b. Cross-field invariants on the candidate state (existing values
-    # overlaid with normalized changes). Per-field validators above only
-    # see the value being changed; sneaking only `party_entry_date`
-    # backward could leave a profile where union > party in spite of
-    # `AdmissionProfileUpdate.validate_logical_dates` rejecting the
-    # same combination on a normal update.
-    def _candidate(field_key: str) -> Any:
-        return normalized[field_key] if field_key in normalized else getattr(profile, field_key)
-
-    cand_union = _candidate("union_entry_date")
-    cand_party = _candidate("party_entry_date")
-    cand_party_official = _candidate("party_official_entry_date")
-    cand_dob = profile.dob  # `dob` is HARD_DENY so always the original
-
-    if cand_union and cand_party and cand_union > cand_party:
-        raise ValidationError(
-            "Ngày vào Đoàn phải trước Ngày vào Đảng (dự bị)"
-        )
-    if cand_party and cand_party_official and cand_party > cand_party_official:
-        raise ValidationError(
-            "Ngày vào Đảng (dự bị) phải trước Ngày vào Đảng (chính thức)"
-        )
-    # `dob` is a `date`; entry dates are `datetime`. Compare on date
-    # boundary so the same comparison rule used in
-    # AdmissionProfileUpdate.validate_logical_dates applies.
-    if cand_dob and cand_union and cand_dob > cand_union.date():
-        raise ValidationError("Ngày sinh phải trước Ngày vào Đoàn")
+    # 5b. Cross-field invariants on the candidate state (existing DB
+    # values overlaid with normalized changes). Delegate to shared
+    # utility — same rules schema's @model_validator runs, plus a few
+    # the schema can't see because partial dump strips DB-only fields.
+    # Lesson reference: feedback memory
+    # ``partial-update-loses-cross-field-invariants``.
+    from .admission_invariants import validate_logical_dates
+    candidate_state = {
+        "dob": profile.dob,  # HARD_DENY → always original DB value
+        "union_entry_date": normalized.get(
+            "union_entry_date", profile.union_entry_date
+        ),
+        "party_entry_date": normalized.get(
+            "party_entry_date", profile.party_entry_date
+        ),
+        "party_official_entry_date": normalized.get(
+            "party_official_entry_date", profile.party_official_entry_date
+        ),
+    }
+    try:
+        validate_logical_dates(candidate_state)
+    except ValueError as exc:
+        raise ValidationError(str(exc))
 
     # 6. Diff — compare AFTER normalization so e.g. "2025-09-01" parsing
     # to datetime(2025,9,1) doesn't false-diff against an existing

--- a/Backend_FastAPI/tests/api/test_admissions_partial_update_invariants.py
+++ b/Backend_FastAPI/tests/api/test_admissions_partial_update_invariants.py
@@ -1,0 +1,400 @@
+"""Tests for cross-field date invariants on partial profile updates.
+
+Pre-existing bug fixed in this PR: ``PUT /admissions/{id}`` accepted a
+partial payload via ``data.model_dump(exclude_unset=True)``, so
+``AdmissionProfileUpdate.validate_logical_dates`` only saw fields the
+client sent. A request that updated ONLY ``union_entry_date`` could
+leave the row with ``union > party`` because ``party_entry_date``
+already in the database was never visible to the validator.
+
+Fix: service builds a candidate state (DB attributes + payload
+overlay) and runs the shared
+``app.services.admission_invariants.validate_logical_dates`` utility
+before the per-field setattr loop.
+
+Lesson reference: feedback memory
+``partial-update-loses-cross-field-invariants``.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from app import models
+from app.database import AsyncSessionLocal
+from tests.fixtures.constants import LeadsURLs
+
+
+ADMISSIONS = "/api/admissions"
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures (kept inline to mirror existing admission test files)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def adm_config(seed_lead_dependencies: dict):
+    """Seed offering chain + path for each test (same shape as
+    test_admissions_minor_correction.adm_config)."""
+    uid = seed_lead_dependencies["unit_id"]
+    mpid = seed_lead_dependencies["major_program_id"]
+    ts = f"{int(datetime.now().timestamp() * 1000)}"
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ot = models.ConfigOfferingType(code=f"tq_{ts}", name=f"TQ_{ts}", display_order=1)
+            s.add(ot); await s.flush()
+            po = models.ProgramOffering(
+                offering_type=f"TQ_{ts}", program_id=mpid, offering_type_id=ot.id,
+                is_active=True, duration_semesters=6,
+            )
+            s.add(po); await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=po.id, academic_year=2026,
+                tuition_fee_per_year=5000000, annual_admission_quota=100, is_published=True,
+            )
+            s.add(ai); await s.flush()
+            am = models.AdmissionMethod(
+                code=f"hb_{ts}", name=f"HB_{ts}",
+                requires_gpa=True, requires_subject_scores=False, is_active=True,
+            )
+            s.add(am); await s.flush()
+            ac = models.AdmissionCriteria(
+                method_id=am.id, code=f"TC_{ts}", name=f"TC_{ts}",
+                min_gpa=6.0, scoring_method="average", subject_selection_mode="fixed",
+                policy_version="2026.1", is_active=True,
+            )
+            s.add(ac); await s.flush()
+            ap = models.AdmissionPath(
+                academic_info_id=ai.id, admission_method_id=am.id, criteria_id=ac.id,
+                status="active", display_name="Test", display_order=0, visibility="public",
+            )
+            s.add(ap); await s.flush()
+    return {
+        "unit_id": uid,
+        "offering_id": po.id,
+        "method_id": am.id,
+    }
+
+
+async def _create_draft_profile(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    adm_config: dict,
+    officer_id: int,
+    full_name: str,
+) -> int:
+    """Seed lead + consultation + admission profile under admin token.
+    Returns profile_id (status='draft' so PUT is allowed)."""
+    lead_resp = await client.post(LeadsURLs.LEADS, json={
+        "full_name": full_name,
+        "phone": f"098{int(datetime.now().timestamp()) % 10_000_000:07d}",
+        "source": "website",
+        "unit_id": adm_config["unit_id"],
+        "assigned_officer_id": officer_id,
+        "offering_id": adm_config["offering_id"],
+    }, headers=admin_token_headers)
+    assert lead_resp.status_code in (200, 201), lead_resp.text
+    lead_id = lead_resp.json()["id"]
+
+    from tests._lead_status_test_ids import INITIAL_LEAD_STATUS_ID
+    cons = await client.post(
+        f"{LeadsURLs.LEADS}/{lead_id}/consultations",
+        json={
+            "status_id": INITIAL_LEAD_STATUS_ID,
+            "method": "phone",
+            "notes": "Pre-admission consultation",
+        },
+        headers=admin_token_headers,
+    )
+    assert cons.status_code in (200, 201), cons.text
+
+    prof = await client.post(ADMISSIONS, json={
+        "lead_id": lead_id,
+        "admission_method_id": adm_config["method_id"],
+    }, headers=admin_token_headers)
+    assert prof.status_code in (200, 201), prof.text
+    return prof.json()["id"]
+
+
+async def _set_dates_in_db(
+    profile_id: int,
+    *,
+    dob=None,
+    union_entry_date=None,
+    party_entry_date=None,
+    party_official_entry_date=None,
+) -> None:
+    """Pre-populate date fields directly via session — bypasses normal
+    update_profile flow so the test can stage a state where partial
+    update will conflict."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            prof = await s.get(models.AdmissionProfile, profile_id)
+            if dob is not None:
+                prof.dob = dob
+            if union_entry_date is not None:
+                prof.union_entry_date = union_entry_date
+            if party_entry_date is not None:
+                prof.party_entry_date = party_entry_date
+            if party_official_entry_date is not None:
+                prof.party_official_entry_date = party_official_entry_date
+
+
+# ---------------------------------------------------------------------------
+# Schema-level (regression — make sure refactor didn't break payload-only check)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_update_within_payload_union_after_party_rejects(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """When BOTH union and party entry dates are in the payload AND
+    union > party, schema's @model_validator catches it (422). Existing
+    behavior — guards against schema refactor breaking this."""
+    pid = await _create_draft_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Schema Within-Payload Probe",
+    )
+    r = await client.put(
+        f"{ADMISSIONS}/{pid}",
+        json={
+            "version": 1,
+            "union_entry_date": "2021-09-01T00:00:00",
+            "party_entry_date": "2020-06-01T00:00:00",
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 422, r.text
+    assert "Đoàn" in r.text
+
+
+# ---------------------------------------------------------------------------
+# Candidate-state checks (the new fix — DB + partial payload merged)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_update_only_union_after_existing_party_rejects(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """DB has party_entry_date = 2020-06-01. Partial PUT sends ONLY
+    union_entry_date = 2021-09-01 (after existing party). Schema-level
+    validator on the trimmed payload would NOT see party_entry_date and
+    would silently pass. Service candidate-state check must catch this."""
+    pid = await _create_draft_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Candidate Union After Party",
+    )
+    await _set_dates_in_db(pid, party_entry_date=datetime(2020, 6, 1))
+
+    r = await client.put(
+        f"{ADMISSIONS}/{pid}",
+        json={
+            "version": 1,
+            "union_entry_date": "2021-09-01T00:00:00",
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+    assert "Đoàn" in r.text
+
+
+@pytest.mark.asyncio
+async def test_partial_update_only_party_after_existing_official_rejects(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """DB has party_official_entry_date = 2020-06-01. Partial PUT sends
+    ONLY party_entry_date = 2021-09-01 (after official). Must reject."""
+    pid = await _create_draft_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Candidate Party After Official",
+    )
+    await _set_dates_in_db(pid, party_official_entry_date=datetime(2020, 6, 1))
+
+    r = await client.put(
+        f"{ADMISSIONS}/{pid}",
+        json={
+            "version": 1,
+            "party_entry_date": "2021-09-01T00:00:00",
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+
+
+@pytest.mark.asyncio
+async def test_partial_update_dob_null_does_not_bypass_invariant(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Regression for review finding (P1): payload ``{"dob": null,
+    "union_entry_date": "<earlier>"}`` must NOT silently pass.
+
+    The dob setter skips ``None`` (``is not None`` check at the
+    per-field setattr block), so the existing DB dob is preserved.
+    A naive candidate-state merge that copies payload as-is would set
+    candidate dob to None → invariant ``dob ≤ union`` short-circuits →
+    validation passes → setter preserves DB dob → row ends up with the
+    original (post-union) dob, re-introducing the exact invariant bypass
+    the candidate-state merge is supposed to catch.
+
+    The fix: candidate-state merge mirrors setter semantics. For dob
+    specifically, ``payload['dob'] is None`` means "preserve DB
+    value", so the candidate uses ``profile.dob`` and the invariant
+    compares against the real future state.
+    """
+    from datetime import date as date_cls
+    pid = await _create_draft_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "DOB Null Bypass Probe",
+    )
+    # Pre-set DB dob AFTER the union entry the client will send. If the
+    # candidate-state merge incorrectly applied ``dob: null``, the
+    # invariant check would not see the conflict.
+    await _set_dates_in_db(pid, dob=date_cls(2020, 1, 1))
+
+    r = await client.put(
+        f"{ADMISSIONS}/{pid}",
+        json={
+            "version": 1,
+            "dob": None,                                # ← payload null
+            "union_entry_date": "2015-09-01T00:00:00",  # ← before existing dob
+        },
+        headers=admin_token_headers,
+    )
+    # Without the fix this returns 200 silently and persists an invalid
+    # state. With the fix candidate dob = DB value 2020-01-01, which is
+    # AFTER union 2015-09-01 → invariant raises → 400.
+    assert r.status_code == 400, r.text
+    assert "sinh" in r.text.lower() or "Ngày sinh" in r.text
+
+
+@pytest.mark.asyncio
+async def test_partial_update_only_dob_after_existing_union_rejects(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """DB has union_entry_date = 2015-09-01. Partial PUT sends ONLY
+    dob = 2020-01-01 (after existing union — applicant born after
+    joining the youth union, impossible). Must reject."""
+    from datetime import date as date_cls
+    pid = await _create_draft_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Candidate DOB After Union",
+    )
+    await _set_dates_in_db(pid, union_entry_date=datetime(2015, 9, 1))
+
+    r = await client.put(
+        f"{ADMISSIONS}/{pid}",
+        json={
+            "version": 1,
+            "dob": "2020-01-01",
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 400, r.text
+    assert "sinh" in r.text.lower() or "Ngày sinh" in r.text
+
+
+# ---------------------------------------------------------------------------
+# Happy paths (must keep working — refactor regression guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_update_valid_dates_through_against_existing_state(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """DB has party_entry_date = 2020-06-01. Partial PUT with
+    union_entry_date = 2019-01-01 (before party) must pass."""
+    pid = await _create_draft_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Candidate Happy Path",
+    )
+    await _set_dates_in_db(pid, party_entry_date=datetime(2020, 6, 1))
+
+    r = await client.put(
+        f"{ADMISSIONS}/{pid}",
+        json={
+            "version": 1,
+            "union_entry_date": "2019-01-01T00:00:00",
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.asyncio
+async def test_partial_update_no_date_fields_skips_invariant_check(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm_config: dict,
+):
+    """Update unrelated to date fields must not trigger the invariant
+    check (perf — avoid building candidate state when not needed)."""
+    pid = await _create_draft_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "Non-Date Update",
+    )
+
+    r = await client.put(
+        f"{ADMISSIONS}/{pid}",
+        json={
+            "version": 1,
+            "nationality": "Việt Nam",
+        },
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Utility unit tests (lightweight, surface contract)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_logical_dates_utility_empty_state_ok():
+    from app.services.admission_invariants import validate_logical_dates
+    validate_logical_dates({})  # all fields missing → no rule triggered
+
+
+def test_validate_logical_dates_utility_union_after_party_raises():
+    from app.services.admission_invariants import validate_logical_dates
+    with pytest.raises(ValueError, match="Đoàn"):
+        validate_logical_dates({
+            "union_entry_date": datetime(2021, 9, 1),
+            "party_entry_date": datetime(2020, 6, 1),
+        })
+
+
+def test_validate_logical_dates_utility_dob_as_date_object_compared():
+    from datetime import date as date_cls
+    from app.services.admission_invariants import validate_logical_dates
+    with pytest.raises(ValueError, match="sinh"):
+        validate_logical_dates({
+            "dob": date_cls(2020, 1, 1),
+            "union_entry_date": datetime(2015, 9, 1),
+        })

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.tsx
@@ -99,11 +99,13 @@ export function TuitionTab({ profile }: TuitionTabProps) {
 
         <NoticeCard canAccessFinanceModule={canAccessFinanceModule} />
 
-        <CalculateFeeDialog
-          open={calcDialogOpen}
-          onOpenChange={setCalcDialogOpen}
-          profileId={profile.id}
-        />
+        {calcDialogOpen && (
+          <CalculateFeeDialog
+            open={calcDialogOpen}
+            onOpenChange={setCalcDialogOpen}
+            profileId={profile.id}
+          />
+        )}
       </div>
     )
   }
@@ -134,11 +136,13 @@ export function TuitionTab({ profile }: TuitionTabProps) {
 
         <NoticeCard canAccessFinanceModule={canAccessFinanceModule} />
 
-        <CalculateFeeDialog
-          open={calcDialogOpen}
-          onOpenChange={setCalcDialogOpen}
-          profileId={profile.id}
-        />
+        {calcDialogOpen && (
+          <CalculateFeeDialog
+            open={calcDialogOpen}
+            onOpenChange={setCalcDialogOpen}
+            profileId={profile.id}
+          />
+        )}
       </div>
     )
   }
@@ -336,12 +340,20 @@ export function TuitionTab({ profile }: TuitionTabProps) {
 
       <NoticeCard canAccessFinanceModule={canAccessFinanceModule} />
 
-      {/* Dialog mount for the happy-path "Tính lại" trigger above. */}
-      <CalculateFeeDialog
-        open={calcDialogOpen}
-        onOpenChange={setCalcDialogOpen}
-        profileId={profile.id}
-      />
+      {/* Dialog mount for the happy-path "Tính lại" trigger above.
+          Conditional mount so React Query hooks inside the dialog
+          (useCalculateFee + useInstallmentPlans + useQueryClient) only
+          fire after the user opens the dialog — mirrors PR #130 fix
+          for MinorCorrectionDialog. Avoids breaking any future test
+          fixture that imports raw `render` from @testing-library/react
+          instead of the custom render with QueryClientProvider. */}
+      {calcDialogOpen && (
+        <CalculateFeeDialog
+          open={calcDialogOpen}
+          onOpenChange={setCalcDialogOpen}
+          profileId={profile.id}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Follow-up PR cho #129/#130 (post-approval minor correction). Fix:

1. **Pre-existing bug**: \`PUT /admissions/{id}\` partial update bypass cross-field date invariants với DB state hiện có
2. **Refactor Option 2**: Extract \`validate_logical_dates\` utility — single source of truth cho schema + minor_correction + update_profile
3. **Defuse landmine**: \`CalculateFeeDialog\` mount unconditional trong TuitionTab (mirror PR #130 fix cho MinorCorrectionDialog)

## Bug story

\`\`\`python
# Router (admissions.py:619)
update_data = data.model_dump(exclude_unset=True)  # ← payload trimmed
profile = await admission_service.update_profile(db, profile_id, update_data, ...)

# Service (admission_service.py:2647)
if \"union_entry_date\" in data: profile.union_entry_date = data[\"union_entry_date\"]
\`\`\`

\`AdmissionProfileUpdate.validate_logical_dates\` chạy trên \`exclude_unset=True\` payload — fields client không gửi (nhưng có trong DB) là \`None\`. Cross-field check như \"union ≤ party\" silent pass khi chỉ \`union_entry_date\` được sửa.

Demo: profile có \`party_entry_date = 2020-06-01\` trong DB. Client \`PUT {\"version\": 1, \"union_entry_date\": \"2021-09-01\"}\` (sau party). Schema validator chỉ thấy \`union=2021, party=None\` → skip. Service set \`union=2021\`. Final state: union > party → invariant violated silently.

Same bug family với PR #129 \`apply_minor_correction\` finding (per-field validation drops cross-field invariants).

### Subtle bug discovered in code review (P1)

Initial fix dùng \`data[k] if k in data else getattr(profile, k)\` để build candidate. Reviewer phát hiện setter \`dob\` skip null (\`is not None\` check, line 2663) nhưng entry-date setters accept null (clear column). Payload \`{\"dob\": null, \"union_entry_date\": \"2015-09-01\"}\` would:
- candidate dob = None (payload as-is)
- invariant \`dob ≤ union\` short-circuit (None) → skip
- setter: dob skipped (null), union set to 2015-09-01
- Final state: original DB dob (post-2015) + new union 2015-09-01 → bypass

**Fix**: candidate-state merge mirror setter semantics. \`dob: null\` payload → preserve DB value (mirror setter); entry-date null → take payload (setter accepts to clear).

## What lands

### Backend

- \`app/services/admission_invariants.py\` (NEW) — single source of truth \`validate_logical_dates(state)\` utility. Schema's \`@model_validator\` + \`apply_minor_correction\` + \`update_profile\` all delegate here.
- \`schemas/admission.AdmissionProfileUpdate.validate_logical_dates\` — refactor inline checks → utility delegate.
- \`services/admission_service.apply_minor_correction\` — replace inline \`_candidate(...)\` block với utility call (dedup, behavior unchanged).
- \`services/admission_service.update_profile\` (CORE FIX) — build candidate state DB+payload mirror setter semantics, run utility BEFORE setattr loop. Triggered only when payload touches date field (perf).
- \`routers/admissions.update_admission\` — add \`ValidationError → 400\` exception handler.

### Frontend

- \`TuitionTab.tsx\` — wrap 3 \`<CalculateFeeDialog>\` mount sites với \`{calcDialogOpen && ...}\`. Hooks \`useCalculateFee\`/\`useInstallmentPlans\`/\`useQueryClient\` only fire khi user mở dialog. Mirror PR #130 pattern. Defuses landmine + bonus perf (no fetch installment plans pre-open).

## Test plan

### New tests (10 cases)

\`tests/api/test_admissions_partial_update_invariants.py\`:

- Payload-only invariant (regression guard cho refactor) — schema-level still works
- **Candidate-state checks**:
  - Only \`union_entry_date\` after existing party → 400
  - Only \`party_entry_date\` after existing official → 400
  - Only \`dob\` after existing union → 400
  - **\`{\"dob\": null, \"union_entry_date\": \"<earlier>\"}\` regression** — caught reviewer's P1 finding
- Happy paths: valid dates + non-date update no-op
- Utility unit tests: empty state, ValueError, date-object coercion

### Local verification

- ✅ \`tests/api/test_admissions_partial_update_invariants.py\`: **10/10 PASS**
- ✅ \`tests/api/test_admissions_minor_correction.py\` (regression after refactor): **33/33 PASS**
- ✅ Full notification CI gate (6 files): **102/102 PASS**
- ✅ \`test_admission_workflow_api.py\`: **13/13 PASS**
- ✅ Frontend \`tsc --noEmit\`: EXIT=0
- ✅ Frontend \`npm run lint\`: 0 errors
- ✅ Frontend vitest CI gate (4 files): **44/44 PASS**

## Audit ngược: bug pattern có trong fix trước không?

Reviewer hỏi candidate-state vs setter mismatch có ở fix nào khác. Audit:

- \`apply_minor_correction\` (PR #129): **SAFE** — \`dob\` HARD_DENY (không touch được) + setter uniform (\`setattr(profile, k, v)\` không có \`is not None\`). Candidate match setter perfectly.
- Schema \`validate_logical_dates\`: **SAFE** — intentionally in-payload scope, không claim cover DB merge.
- \`family_info\` adapter, \`create_path\`, \`MinorCorrectionDialog\` gate: N/A (không có candidate-state logic).

Bug specific cho \`update_profile + dob\` (asymmetric \`is not None\` setter). Đã fix với regression test.

## Out of scope (future)

- Memory feedback rule: \"candidate must mirror setter semantics\" — sẽ ghi sau khi PR này merge.
- Future invariants (vd \`is_dropped → dropped_at\`) — nếu thêm và setter có asymmetry, cùng pattern sẽ tái phát; rule trên giúp catch sớm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)