### PR TITLE
fix(notifications): derive SYSTEM_ALERT broadcast from UserRole enum

### DIFF
--- a/Backend_FastAPI/app/routers/admin/system.py
+++ b/Backend_FastAPI/app/routers/admin/system.py
@@ -24,7 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database, models
 from app.core.deps import CasbinAuth  # Phase 2.2
-from app.services.notification_dispatcher import safe_dispatch
+from app.services.notification_dispatcher import _all_role_rooms, safe_dispatch
 from app.core.events import SystemEvents
 
 log = structlog.get_logger(__name__)
@@ -87,15 +87,10 @@ async def create_system_alert(
     # ✅ NOTIFICATION 2.0: Dispatch SYSTEM_ALERT.
     # SYSTEM_ALERT is catalog-sensitive; admin-triggered broadcast must
     # pass the full role matrix explicitly (no implicit all-users fanout).
-    # Socket rooms auto-joined in socket_manager.connect include
-    # role_<role_name> for each authenticated role.
-    _alert_rooms = [
-        "role_admin",
-        "role_manager",
-        "role_officer",
-        "role_accountant",
-        "role_user",
-    ]
+    # Use ``_all_role_rooms()`` helper so adding a new ``UserRole`` value
+    # (e.g. ``COLLABORATOR``) automatically picks up here without
+    # forgetting to extend a hardcoded list — silent broadcast gap to
+    # the new role would otherwise be invisible until a complaint.
     await safe_dispatch(
         db=db,
         event=SystemEvents.SYSTEM_ALERT,
@@ -106,7 +101,7 @@ async def create_system_alert(
             "expires_at": expires_at.isoformat() if expires_at else None,
         },
         dedupe_key=f"system_alert:{datetime.utcnow().isoformat()}",
-        rooms=_alert_rooms,
+        rooms=_all_role_rooms(),
     )
 
     log.info(

--- a/Backend_FastAPI/app/services/notification_dispatcher.py
+++ b/Backend_FastAPI/app/services/notification_dispatcher.py
@@ -400,6 +400,25 @@ def _rooms_for_user(user_id: Optional[int]) -> List[str]:
     return rooms
 
 
+def _all_role_rooms() -> List[str]:
+    """Rooms covering every authenticated role.
+
+    For genuinely all-hands broadcasts (SYSTEM_ALERT, system-wide
+    announcements). Derives the room list from ``UserRole`` enum so a
+    new role added to the enum (e.g. ``COLLABORATOR``) auto-picks up
+    here — eliminates the hardcoded-list drift risk where adding a
+    role + forgetting to update one broadcast site causes a silent
+    delivery gap to that role.
+
+    Format mirrors ``socket_manager.connect`` auto-join: each
+    authenticated socket joins ``role_<value>`` (e.g. ``role_admin``,
+    ``role_collaborator``). Sticking to ``UserRole`` as source of
+    truth means the helper stays self-correcting.
+    """
+    from app.core.constants import UserRole
+    return [f"role_{role.value}" for role in UserRole]
+
+
 async def _send_via_channel(
     channel_name: str,
     notifications: List[Any],

--- a/Backend_FastAPI/tests/unit/test_emit_domain_event_scoping.py
+++ b/Backend_FastAPI/tests/unit/test_emit_domain_event_scoping.py
@@ -105,3 +105,54 @@ async def test_legacy_flag_off_bypasses_scoping():
         assert mock_sio.emit.call_count == 1
         call = mock_sio.emit.await_args_list[0]
         assert "room" not in call.kwargs
+
+
+# ---------------------------------------------------------------------------
+# _all_role_rooms helper — derives room list from UserRole enum so adding a
+# new role auto-picks up everywhere the helper is used (vs hardcoded list
+# drift). Memory: project_admission_audit_followups.md item #3.
+# ---------------------------------------------------------------------------
+
+
+def test_all_role_rooms_covers_every_userrole_value():
+    """Helper must return one ``role_<value>`` per UserRole enum entry —
+    no missing role, no stale entry, no extra junk."""
+    from app.core.constants import UserRole
+    from app.services.notification_dispatcher import _all_role_rooms
+
+    rooms = _all_role_rooms()
+    expected = {f"role_{role.value}" for role in UserRole}
+
+    assert set(rooms) == expected, (
+        f"Mismatch: rooms={rooms!r}, expected={expected!r}"
+    )
+    # No duplicates — each role appears exactly once.
+    assert len(rooms) == len(set(rooms))
+
+
+def test_all_role_rooms_includes_collaborator():
+    """Regression for memory finding: hardcoded list at
+    routers/admin/system.py:88 historically had 5 entries (admin /
+    manager / officer / accountant / user) but UserRole gained
+    COLLABORATOR — silent broadcast gap.
+
+    Helper must include collaborator so SYSTEM_ALERT reaches them.
+    """
+    from app.services.notification_dispatcher import _all_role_rooms
+
+    assert "role_collaborator" in _all_role_rooms()
+
+
+def test_all_role_rooms_room_format_matches_socket_manager_join():
+    """Room name format must mirror socket_manager.connect's auto-join
+    pattern (``f\"role_{user.role}\"``). If the helper used a different
+    prefix, dispatched events would land in rooms no SID is in →
+    silent failure.
+    """
+    from app.services.notification_dispatcher import _all_role_rooms
+
+    for room in _all_role_rooms():
+        assert room.startswith("role_"), f"Unexpected format: {room!r}"
+        # Suffix must be a non-empty role name (no spaces, no upper).
+        suffix = room[len("role_"):]
+        assert suffix and suffix.islower() and " " not in suffix


### PR DESCRIPTION
## Summary

Closes admission audit follow-up #3 (memory `project_admission_audit_followups`).

Hardcoded role list at `routers/admin/system.py:88` had 5 entries (admin/manager/officer/accountant/user). `UserRole` enum gained `COLLABORATOR` từ trước nhưng broadcast site không bao giờ pick up → admin-triggered SYSTEM_ALERT silently skip collaborator. Same risk cho mọi role mới.

## Fix

Extract `_all_role_rooms()` helper trong `notification_dispatcher.py`, sister của các `_rooms_for_*` helpers hiện có. Helper derive `[f"role_{r.value}" for r in UserRole]` — UserRole là single source of truth, thêm role mới auto-pickup.

## What lands

- `notification_dispatcher._all_role_rooms()`: derive list từ enum, format mirror `socket_manager.connect` auto-join (`f"role_{user.role}"`).
- `routers/admin/system.py` SYSTEM_ALERT dispatch: replace 5-entry literal bằng `rooms=_all_role_rooms()`.
- 3 new unit tests trong `test_emit_domain_event_scoping.py`:
  - Exact set match với `UserRole` enum (no missing, no stale, no extra)
  - Explicit `role_collaborator` regression guard
  - Format mirrors `socket_manager.connect` auto-join

## Test plan

- ✅ `tests/unit/test_emit_domain_event_scoping.py`: 9/9 PASS (6 existing + 3 new)
- ✅ Full notification CI gate suite (6 files) + socket_scoping_contract: 105/105 PASS

## Out of scope

`SYSTEM_ANNOUNCEMENT` dispatch (routers/admin/system.py:169) — catalog tags `privacy=\"public\"` → falls through to global broadcast, no `rooms=` arg needed. Already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)