### PR TITLE
test(fixtures): manager_other_unit_user_in_db conftest fixture

### DIFF
--- a/Backend_FastAPI/tests/api/test_manager_other_unit_fixture.py
+++ b/Backend_FastAPI/tests/api/test_manager_other_unit_fixture.py
@@ -1,0 +1,74 @@
+"""Smoke test for the ``manager_other_unit_user_in_db`` conftest fixture.
+
+Closes admission audit follow-up #5 (memory
+``project_admission_audit_followups``). Lifts the cross-unit manager
+pattern (previously inlined in test_commission_api / test_collaborator_api
+/ test_admission_idor) into a reusable conftest fixture so admission
+tests can DI it instead of re-seeding the unit + manager rows per file.
+
+Verifies fixture wiring (distinct unit + login round-trip). The
+concrete cross-unit IDOR contracts (404 on profile GET, etc.) are
+covered by ``tests/integration/test_admission_idor.py`` and the
+upcoming admission test files that DI this fixture — duplicating
+that here would only buy fixture-cost without new coverage.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from app.database import AsyncSessionLocal
+from app import models
+from tests.fixtures.constants import AuthURLs, TestUsers
+
+
+ADMISSIONS = "/api/admissions"
+
+
+async def _login(client: AsyncClient, username: str, password: str) -> dict:
+    """Mirror of the login helper used by the surrounding admission test
+    files — duplicated locally to keep this fixture-smoke file
+    self-contained."""
+    r = await client.post(
+        AuthURLs.LOGIN, data={"username": username, "password": password}
+    )
+    assert r.status_code == 200, f"Login {username}: {r.text}"
+    return {"Authorization": f"Bearer {r.cookies.get('access_token')}"}
+
+
+@pytest.mark.asyncio
+async def test_fixture_manager_other_unit_uses_distinct_unit(
+    manager_other_unit_user_in_db: dict,
+    manager_user_in_db: dict,
+):
+    """Both manager fixtures coexist in the same test DB and live in
+    different units. The default ``manager_user_in_db`` lives in the
+    seed_lead_dependencies unit; ``manager_other_unit_user_in_db``
+    lives in ``TestOrgData.UNIT_2``.
+    """
+    assert manager_other_unit_user_in_db["id"] != manager_user_in_db["id"]
+    # Verify the persisted unit_id matches what the fixture promises.
+    async with AsyncSessionLocal() as s:
+        other = await s.get(models.User, manager_other_unit_user_in_db["id"])
+        default = await s.get(models.User, manager_user_in_db["id"])
+        assert other.unit_id != default.unit_id, (
+            "Cross-unit fixture must seed a manager outside the default unit"
+        )
+
+
+@pytest.mark.asyncio
+async def test_fixture_manager_other_unit_can_authenticate(
+    client: AsyncClient,
+    manager_other_unit_user_in_db: dict,
+):
+    """Login round-trip surfaces fixture wiring bugs early (Casbin role
+    assignment, password hash, etc.). A list endpoint check confirms
+    the token also resolves Casbin enforcement for the manager role."""
+    headers = await _login(
+        client,
+        TestUsers.MANAGER_OTHER_UNIT["username"],
+        TestUsers.MANAGER_OTHER_UNIT["password"],
+    )
+    assert "Authorization" in headers
+    r = await client.get(ADMISSIONS, headers=headers)
+    assert r.status_code == 200, r.text

--- a/Backend_FastAPI/tests/conftest.py
+++ b/Backend_FastAPI/tests/conftest.py
@@ -348,6 +348,80 @@ async def manager_user_in_db(
 
 
 @pytest_asyncio.fixture(scope="function")
+async def seed_other_unit(setup_test_database):
+    """Create a SECOND organization unit for cross-unit IDOR scenarios.
+
+    Distinct from ``seed_lead_dependencies['unit_id']`` so a fixture
+    user attached here truly sits outside the seeded admission/lead
+    tree. ID is picked above the auto-increment range
+    (``TestOrgData.UNIT_2 = 9001``) to avoid collision.
+
+    Idempotent: returns the existing row if a previous test already
+    inserted UNIT_2 in the same DB session.
+    """
+    from app import models
+    log.info(
+        f"--- [FIXTURE] Ensuring second unit (id={TestOrgData.UNIT_2['id']}) ---"
+    )
+    # Idempotent insert in a single transaction frame: open ``begin()``,
+    # check existence, insert if missing. ``session.get(...)`` opens an
+    # implicit transaction on its own — calling ``session.begin()``
+    # afterwards triggers SQLAlchemy's "transaction already begun"
+    # error, so we wrap the whole get-then-insert under one explicit
+    # frame.
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            existing = await session.get(
+                models.OrganizationUnit, TestOrgData.UNIT_2["id"]
+            )
+            if existing is None:
+                unit = models.OrganizationUnit(
+                    id=TestOrgData.UNIT_2["id"],
+                    name=TestOrgData.UNIT_2["name"],
+                    type=TestOrgData.UNIT_2["type"],
+                )
+                session.add(unit)
+    return {"unit_id": TestOrgData.UNIT_2["id"]}
+
+
+@pytest_asyncio.fixture(scope="function")
+async def manager_other_unit_user_in_db(
+    setup_test_database,
+    seed_other_unit: dict,
+):
+    """Manager user in a DIFFERENT unit from the default
+    ``manager_user_in_db`` fixture.
+
+    Use for cross-unit IDOR tests — pair with
+    ``seed_lead_dependencies`` (which seeds the default unit + its
+    profiles) and exercise the contract that a manager outside the
+    profile's unit gets 404 on ``GET /admissions/{id}``,
+    ``available_actions`` lists no `assign_officer`, etc.
+
+    Inline equivalents of this pattern existed in
+    ``test_commission_api.py::manager_api_unit2`` and
+    ``test_collaborator_api.py::collab_in_unit2`` — lifted to conftest
+    so admission tests + future scope can DI rather than re-seed.
+
+    Memory tracker: ``project_admission_audit_followups`` item #5.
+    """
+    log.info(
+        "--- [FIXTURE] Creating manager user in OTHER unit "
+        f"({seed_other_unit['unit_id']}) ---"
+    )
+    user_info = await _create_user_and_role(
+        TestUsers.MANAGER_OTHER_UNIT,
+        "role:manager",
+        unit_id=seed_other_unit["unit_id"],
+    )
+    log.info(
+        f"--- [FIXTURE] Manager-other-unit created (ID: {user_info['id']}) "
+        f"in Unit {seed_other_unit['unit_id']} ---"
+    )
+    return user_info
+
+
+@pytest_asyncio.fixture(scope="function")
 async def officer_user_in_db(
     setup_test_database, seed_lead_dependencies: dict
 ):  # ✅ NHẬN fixture làm tham số

--- a/Backend_FastAPI/tests/fixtures/constants.py
+++ b/Backend_FastAPI/tests/fixtures/constants.py
@@ -204,6 +204,20 @@ class TestUsers:
         "status": "active",
     }
 
+    # Manager in a DIFFERENT organization unit from the default
+    # ``seed_lead_dependencies`` unit. Use with the
+    # ``manager_other_unit_user_in_db`` fixture for cross-unit IDOR
+    # tests (manager attempting to access a profile outside their
+    # unit). Distinct username/email so it can coexist with MANAGER
+    # in the same test database without unique constraint conflicts.
+    MANAGER_OTHER_UNIT = {
+        "username": "testmanager_unit2",
+        "email": "manager_unit2@example.com",
+        "password": "ManagerPassword!789",
+        "role": "manager",
+        "status": "active",
+    }
+
     # --- User Officer (Bổ sung) ---
     OFFICER = {
         "username": "testofficer",
@@ -293,6 +307,10 @@ class TestOrgData:
     """Dữ liệu mẫu cho Organization Units và MajorPrograms."""
 
     UNIT_1 = {"id": 1, "name": "Test Unit 1", "type": "Faculty"}
+    # Distinct second unit for cross-unit IDOR fixtures. ``id`` is
+    # picked above the seed_lead_dependencies range so it never
+    # collides with auto-allocated org unit IDs in the test DB.
+    UNIT_2 = {"id": 9001, "name": "Test Unit 2", "type": "department"}
     # ✅ FIX: Updated to match MajorProgram schema (added degree_level)
     MAJOR_1 = {
         "id": 1,


### PR DESCRIPTION
## Summary

Closes admission audit follow-up #5 (memory `project_admission_audit_followups`).

Lifts the cross-unit manager pattern (previously inlined in `test_commission_api.py::manager_api_unit2`, `test_collaborator_api.py::collab_in_unit2`, `test_admission_idor.py` via `create_second_unit()`) lên conftest.py thành reusable fixture. Admission/finance/lead test files DI thay vì re-seed unit + manager rows từng file.

## What lands

- **`TestUsers.MANAGER_OTHER_UNIT`** trong `fixtures/constants.py` — username/email distinct từ `TestUsers.MANAGER` để cả 2 cùng tồn tại trong test DB không vi phạm unique constraint.
- **`TestOrgData.UNIT_2`** (id=9001) — chọn ngoài auto-increment range để tránh collision với `seed_lead_dependencies`.
- **`seed_other_unit`** fixture — idempotent insert UNIT_2. Single transaction frame để tránh SQLAlchemy "transaction already begun" khi get-then-insert.
- **`manager_other_unit_user_in_db`** fixture — manager bound to UNIT_2, distinct với default `manager_user_in_db` ở `seed_lead_dependencies` unit.

## Test plan

- ✅ `tests/api/test_manager_other_unit_fixture.py` (2 cases) — fixture wiring (distinct unit + login round-trip)
- ✅ Full regression admission test sweep: **67/67 PASS** (12m06s):
  - test_admission_assign_officer_permission (2)
  - test_admission_document_permissions (4)
  - test_admissions_minor_correction (33)
  - test_admissions_partial_update_invariants (10)
  - test_admission_workflow_api (13)
  - test_admission_submit_requires_verified_docs (3)
  - test_manager_other_unit_fixture (2)

Pure additive — không ảnh hưởng existing tests vì:
- Fixtures function-scope, pull-only — chỉ test DI mới trigger setup
- Constants distinct username/email/id (no unique conflict)
- UNIT_2 id=9001 ngoài auto-increment range

## Out of scope

Concrete cross-unit IDOR contracts (404 on profile GET, etc.) đã cover ở `tests/integration/test_admission_idor.py`. PR này ship reusable fixture; downstream tests opt-in bằng cách DI thay vì inline `OrganizationUnit(...)` setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)