### PR TITLE
refactor(admissions): extract DocumentActionPolicy as single source of truth

### DIFF
--- a/Backend_FastAPI/app/services/admission_document_policy.py
+++ b/Backend_FastAPI/app/services/admission_document_policy.py
@@ -1,0 +1,198 @@
+"""Single source of truth for the document-action permission matrix.
+
+Two sites consult the same 5-action matrix and previously hand-rolled
+the rules in parallel:
+
+- ``_compute_document_permissions`` (in ``_compute_frontend_fields``)
+  — produces ``can_upload`` / ``can_verify`` / ``can_reject`` /
+  ``can_reset`` / ``can_mark_paper_submitted`` flags for the
+  ``documents_checklist`` response.
+- ``_authorize_document_action`` (service-side gate, called from
+  document mutation services) — enforces the same matrix at request
+  time, raises :class:`PermissionDeniedError` on fail.
+
+Keeping two implementations in sync via comments + tests is brittle:
+update one branch and forget the other and the FE flag promises
+something the BE will refuse, or vice versa. ``DocumentActionPolicy``
+lifts the matrix into a small class both call sites consume.
+
+Why a class instead of a free function?
+---------------------------------------
+The matrix needs five derived booleans (``is_admin``, ``is_owner``,
+``manager_in_scope``, ``reviewer_scope``, ``profile_editable``) that
+depend only on ``(profile, user)`` and never change between the five
+``authorize()`` calls a single response makes. Computing them once on
+construction avoids re-deriving on each ``authorize()`` invocation
+and keeps the per-call signature small (``action``, ``doc_status``,
+``requires_upload``).
+
+Allowed actions
+---------------
+``"upload"``: applicant/officer/manager-in-scope/admin uploads a file
+for an editable profile, document is missing or previously rejected.
+``"paper_submitted"``: same actor, paper-only doc (``requires_upload
+== False``), document still missing.
+``"verify"``: reviewer (admin/manager-in-scope), status is
+``uploaded`` or ``paper_submitted``.
+``"reject"``: reviewer, status is anything past ``missing`` except
+the rejected/missing terminal states (= ``uploaded`` / ``paper_submitted`` /
+``verified``).
+``"reset"``: reviewer, anything except ``missing``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from app.core.constants import UserRole
+from app import models
+
+
+DocumentAction = Literal[
+    "upload",
+    "paper_submitted",
+    "verify",
+    "reject",
+    "reset",
+]
+
+
+# Cached derived flags — computed once per (profile, user) pair so the
+# five authorize() calls a single response makes don't re-derive them.
+@dataclass(frozen=True)
+class _UserProfileContext:
+    is_admin: bool
+    is_owner: bool
+    manager_in_scope: bool
+    reviewer_scope: bool
+    profile_editable: bool
+
+
+def _build_context(
+    profile: models.AdmissionProfile,
+    user: models.User,
+) -> _UserProfileContext:
+    """Resolve role/ownership/scope flags from the (profile, user) pair.
+
+    Uses ``profile.__dict__.get("lead")`` so a missing eager-load
+    silently treats the profile as ``no lead`` (no owner, no
+    manager-in-scope) rather than triggering a sync lazy-load that
+    would crash with MissingGreenlet inside an async session — same
+    defensive pattern as ``_compute_frontend_fields``.
+    """
+    lead = profile.__dict__.get("lead")
+    is_admin = user.role == UserRole.ADMIN
+    is_manager = user.role == UserRole.MANAGER
+    is_owner = bool(
+        lead is not None
+        and lead.assigned_officer_id is not None
+        and lead.assigned_officer_id == user.id
+    )
+    manager_in_scope = bool(
+        is_manager
+        and lead is not None
+        and lead.unit_id is not None
+        and lead.unit_id == user.unit_id
+    )
+    reviewer_scope = is_admin or manager_in_scope
+    profile_editable = profile.status in (
+        "draft",
+        "rejected",
+        "revision_requested",
+    )
+    return _UserProfileContext(
+        is_admin=is_admin,
+        is_owner=is_owner,
+        manager_in_scope=manager_in_scope,
+        reviewer_scope=reviewer_scope,
+        profile_editable=profile_editable,
+    )
+
+
+@dataclass(frozen=True)
+class DocumentActionPolicy:
+    """Pre-resolved policy object for a single (profile, user) pair.
+
+    Construct once per response/request and call ``authorize()`` per
+    document action. The five flags computed on construction stay
+    stable across the call sequence, so the per-action logic is just
+    a small status-table lookup.
+
+    Usage (response shaping)::
+
+        policy = DocumentActionPolicy.for_(profile, user)
+        for doc in docs:
+            flags = {
+                "can_upload": policy.authorize("upload", doc.status, doc.requires_upload),
+                "can_verify": policy.authorize("verify", doc.status, doc.requires_upload),
+                ...
+            }
+
+    Usage (service guard)::
+
+        policy = DocumentActionPolicy.for_(profile, current_user)
+        if not policy.authorize("verify", doc.status, doc.requires_upload):
+            raise PermissionDeniedError(...)
+    """
+
+    ctx: _UserProfileContext
+    profile_status: str = ""  # kept for future hooks / debug logging
+
+    @classmethod
+    def for_(
+        cls,
+        profile: models.AdmissionProfile,
+        user: models.User,
+    ) -> "DocumentActionPolicy":
+        """Build a policy bound to ``(profile, user)``."""
+        return cls(
+            ctx=_build_context(profile, user),
+            profile_status=profile.status,
+        )
+
+    def authorize(
+        self,
+        action: DocumentAction,
+        doc_status: str,
+        requires_upload: bool,
+    ) -> bool:
+        """Return True iff ``user`` may perform ``action`` on a document.
+
+        Pure function over the cached context — no DB access. Callers
+        that need to fail-closed map ``False`` to their own exception
+        (e.g. the service-side guard raises ``PermissionDeniedError``).
+        """
+        ctx = self.ctx
+
+        if action == "upload":
+            return (
+                requires_upload
+                and ctx.profile_editable
+                and (ctx.is_owner or ctx.is_admin or ctx.manager_in_scope)
+                and doc_status in ("missing", "rejected")
+            )
+        if action == "paper_submitted":
+            return (
+                (not requires_upload)
+                and ctx.profile_editable
+                and (ctx.is_owner or ctx.is_admin or ctx.manager_in_scope)
+                and doc_status == "missing"
+            )
+        if action == "verify":
+            return ctx.reviewer_scope and doc_status in (
+                "uploaded",
+                "paper_submitted",
+            )
+        if action == "reject":
+            return ctx.reviewer_scope and doc_status in (
+                "uploaded",
+                "paper_submitted",
+                "verified",
+            )
+        if action == "reset":
+            return ctx.reviewer_scope and doc_status != "missing"
+
+        # Unknown action — treat as deny so a typo in calling code
+        # never grants access. Service guard surfaces the bug as a
+        # PermissionDeniedError; response shaping skips the flag.
+        return False

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -83,66 +83,34 @@ def _authorize_document_action(
 ) -> None:
     """Enforce the PR #5 document-action matrix at the service layer.
 
-    Mirrors ``_compute_document_permissions`` in ``_compute_frontend_fields``
-    so the ``can_*`` flag promised to the FE is always backed by a route
-    that actually authorises the call. Casbin gates the route at role
-    level (officer can hit /paper-submitted, manager /verify-format,
-    /reject, /reset); this helper adds the fine-grained rules Casbin
-    can't express: unit scope for manager, owner check for officer,
-    allowed ``doc_status`` transition, and ``requires_upload`` flag for
+    Delegates to :class:`DocumentActionPolicy` — same matrix
+    ``_compute_document_permissions`` (in ``_compute_frontend_fields``)
+    consults to build the per-document ``can_*`` response flags.
+    Single source of truth means the FE flag promise and the BE gate
+    stay in lockstep automatically; updating one branch without the
+    other is no longer possible.
+
+    Casbin gates the route at role level (officer can hit
+    ``/paper-submitted``, manager ``/verify-format`` / ``/reject`` /
+    ``/reset``); the policy adds the fine-grained rules Casbin can't
+    express: unit scope for manager, owner check for officer, allowed
+    ``doc_status`` transition, and ``requires_upload`` flag for
     paper-submit.
 
-    ``action`` is one of: "upload", "paper_submitted", "verify",
-    "reject", "reset". Raises :class:`PermissionDeniedError` on fail —
-    the router maps that to 404 (no existence leak).
+    ``action`` is one of: ``"upload"``, ``"paper_submitted"``,
+    ``"verify"``, ``"reject"``, ``"reset"``. Raises
+    :class:`PermissionDeniedError` on fail — the router maps that to
+    404 (no existence leak).
     """
-    lead = profile.__dict__.get("lead")
-    is_admin = current_user.role == UserRole.ADMIN
-    is_manager = current_user.role == UserRole.MANAGER
-    is_officer = current_user.role == UserRole.OFFICER
-    is_owner = bool(
-        lead
-        and lead.assigned_officer_id is not None
-        and lead.assigned_officer_id == current_user.id
-    )
-    manager_in_scope = bool(
-        is_manager
-        and lead is not None
-        and lead.unit_id is not None
-        and lead.unit_id == current_user.unit_id
-    )
-    reviewer_scope = is_admin or manager_in_scope
-    profile_editable = profile.status in ("draft", "rejected", "revision_requested")
+    from .admission_document_policy import DocumentActionPolicy
 
     applied_rules = profile.applied_rules or {}
     doc_configs = applied_rules.get("doc_configs", {}) or {}
     config = doc_configs.get(doc_code, {}) or {}
     requires_upload = bool(config.get("requires_upload", True))
 
-    if action == "upload":
-        ok = (
-            requires_upload
-            and profile_editable
-            and (is_owner or is_admin or manager_in_scope)
-            and doc_status in ("missing", "rejected")
-        )
-    elif action == "paper_submitted":
-        ok = (
-            (not requires_upload)
-            and profile_editable
-            and (is_owner or is_admin or manager_in_scope)
-            and doc_status == "missing"
-        )
-    elif action == "verify":
-        ok = reviewer_scope and doc_status in ("uploaded", "paper_submitted")
-    elif action == "reject":
-        ok = reviewer_scope and doc_status in ("uploaded", "paper_submitted", "verified")
-    elif action == "reset":
-        ok = reviewer_scope and doc_status != "missing"
-    else:
-        raise PermissionDeniedError(f"Unknown document action '{action}'")
-
-    if not ok:
+    policy = DocumentActionPolicy.for_(profile, current_user)
+    if not policy.authorize(action, doc_status, requires_upload):
         # 404 per IDOR convention — router translates.
         raise PermissionDeniedError(
             f"Action '{action}' not permitted on document '{doc_code}' "
@@ -1169,25 +1137,20 @@ def _compute_frontend_fields(
                     "label_from_db": doc.document_type.name,
                 }
     
-    # PR #5 — scope gate for manager/admin on per-document actions.
-    # Admin sees all profiles; manager is scoped to the lead's unit.
-    _lead = profile.__dict__.get("lead")
-    _manager_in_scope = (
-        is_manager
-        and _lead is not None
-        and _lead.unit_id is not None
-        and _lead.unit_id == current_user.unit_id
-    )
-    _reviewer_scope = is_admin or _manager_in_scope
-    _profile_editable = status in ("draft", "rejected", "revision_requested")
+    # PR #5 — per-document action permissions delegate to the
+    # DocumentActionPolicy class so the FE can_* flag matrix and the
+    # service-side _authorize_document_action gate are computed from a
+    # single source of truth. Update one place; both stay in sync.
+    from .admission_document_policy import DocumentActionPolicy
+    _doc_policy = DocumentActionPolicy.for_(profile, current_user)
 
     def _compute_document_permissions(
         doc_status: str,
         requires_upload: bool,
     ) -> dict[str, bool]:
-        """Per-document action flags for the current user.
+        """Per-document action flags via :class:`DocumentActionPolicy`.
 
-        Mirrors the route contracts exactly:
+        Route contracts mirrored:
         - Upload  : POST /admissions/{id}/documents/{code}/upload
                     officer assigned to the lead, profile in editable state,
                     doc expects an upload and isn't already verified/paper.
@@ -1201,34 +1164,14 @@ def _compute_frontend_fields(
                     officer assigned to the lead, paper-only doc (requires_upload=False),
                     status still missing.
         """
-        can_upload = bool(
-            requires_upload
-            and _profile_editable
-            and (is_owner or is_admin or _manager_in_scope)
-            and doc_status in ("missing", "rejected")
-        )
-        can_verify = bool(
-            _reviewer_scope and doc_status in ("uploaded", "paper_submitted")
-        )
-        can_reject = bool(
-            _reviewer_scope
-            and doc_status in ("uploaded", "paper_submitted", "verified")
-        )
-        can_reset = bool(
-            _reviewer_scope and doc_status != "missing"
-        )
-        can_mark_paper_submitted = bool(
-            (not requires_upload)
-            and _profile_editable
-            and (is_owner or is_admin or _manager_in_scope)
-            and doc_status == "missing"
-        )
         return {
-            "can_upload": can_upload,
-            "can_verify": can_verify,
-            "can_reject": can_reject,
-            "can_reset": can_reset,
-            "can_mark_paper_submitted": can_mark_paper_submitted,
+            "can_upload": _doc_policy.authorize("upload", doc_status, requires_upload),
+            "can_verify": _doc_policy.authorize("verify", doc_status, requires_upload),
+            "can_reject": _doc_policy.authorize("reject", doc_status, requires_upload),
+            "can_reset": _doc_policy.authorize("reset", doc_status, requires_upload),
+            "can_mark_paper_submitted": _doc_policy.authorize(
+                "paper_submitted", doc_status, requires_upload
+            ),
         }
 
     # Build documents_checklist

--- a/Backend_FastAPI/tests/unit/test_admission_document_policy.py
+++ b/Backend_FastAPI/tests/unit/test_admission_document_policy.py
@@ -1,0 +1,326 @@
+"""Unit tests for the DocumentActionPolicy permission matrix.
+
+Closes admission audit follow-up #2 (memory
+``project_admission_audit_followups``). The policy class is the single
+source of truth shared by ``_compute_document_permissions`` (response
+shaping) and ``_authorize_document_action`` (service-side guard) — if
+either side drifts, both sides drift, so we lock the matrix here at
+unit level.
+
+Each parametrize row models one cell of the 5-action × N-status ×
+M-role matrix. Adding a new role or a new doc status requires
+extending these tests; that's the point.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from app.core.constants import UserRole
+from app.services.admission_document_policy import DocumentActionPolicy
+
+
+# ---------------------------------------------------------------------------
+# Lightweight stand-ins so we don't have to spin up the full ORM for a
+# pure logic test. The policy reads only ``profile.status``,
+# ``profile.applied_rules`` (not used here — caller resolves
+# requires_upload), ``profile.__dict__.get('lead')``, and the
+# user fields. ``__dict__`` access is what the policy uses to avoid
+# triggering SQLAlchemy lazy-load in async contexts; plain attribute
+# assignment on a dataclass populates ``__dict__`` correctly.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubLead:
+    unit_id: Optional[int] = None
+    assigned_officer_id: Optional[int] = None
+
+
+@dataclass
+class _StubProfile:
+    status: str = "draft"
+    lead: Optional[_StubLead] = None
+
+
+@dataclass
+class _StubUser:
+    id: int = 1
+    role: UserRole = UserRole.OFFICER
+    unit_id: Optional[int] = None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: 5 canonical actor profiles
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin():
+    return _StubUser(id=99, role=UserRole.ADMIN, unit_id=None)
+
+
+@pytest.fixture
+def manager_in_scope():
+    return _StubUser(id=10, role=UserRole.MANAGER, unit_id=42)
+
+
+@pytest.fixture
+def manager_other_unit():
+    return _StubUser(id=11, role=UserRole.MANAGER, unit_id=999)
+
+
+@pytest.fixture
+def officer_owner():
+    return _StubUser(id=20, role=UserRole.OFFICER, unit_id=42)
+
+
+@pytest.fixture
+def officer_not_owner():
+    return _StubUser(id=21, role=UserRole.OFFICER, unit_id=42)
+
+
+@pytest.fixture
+def profile_draft_lead42_owner20():
+    """Profile in editable state, lead in unit 42, assigned to officer 20."""
+    return _StubProfile(
+        status="draft",
+        lead=_StubLead(unit_id=42, assigned_officer_id=20),
+    )
+
+
+@pytest.fixture
+def profile_approved_lead42_owner20():
+    """Profile already approved (NOT editable), same lead context."""
+    return _StubProfile(
+        status="approved",
+        lead=_StubLead(unit_id=42, assigned_officer_id=20),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Upload action
+# ---------------------------------------------------------------------------
+
+
+class TestUpload:
+    """`upload`: editable profile + (owner | admin | manager_in_scope) +
+    requires_upload + status in (missing, rejected)."""
+
+    @pytest.mark.parametrize("doc_status", ["missing", "rejected"])
+    def test_owner_can_upload(self, profile_draft_lead42_owner20, officer_owner, doc_status):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
+        assert policy.authorize("upload", doc_status, requires_upload=True)
+
+    def test_admin_can_upload(self, profile_draft_lead42_owner20, admin):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, admin)
+        assert policy.authorize("upload", "missing", requires_upload=True)
+
+    def test_manager_same_unit_can_upload(
+        self, profile_draft_lead42_owner20, manager_in_scope,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, manager_in_scope)
+        assert policy.authorize("upload", "missing", requires_upload=True)
+
+    def test_manager_other_unit_cannot_upload(
+        self, profile_draft_lead42_owner20, manager_other_unit,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, manager_other_unit)
+        assert not policy.authorize("upload", "missing", requires_upload=True)
+
+    def test_officer_not_owner_cannot_upload(
+        self, profile_draft_lead42_owner20, officer_not_owner,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_not_owner)
+        assert not policy.authorize("upload", "missing", requires_upload=True)
+
+    def test_paper_only_doc_blocks_upload(
+        self, profile_draft_lead42_owner20, officer_owner,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
+        assert not policy.authorize("upload", "missing", requires_upload=False)
+
+    def test_uploaded_or_verified_doc_blocks_re_upload(
+        self, profile_draft_lead42_owner20, officer_owner,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
+        assert not policy.authorize("upload", "uploaded", requires_upload=True)
+        assert not policy.authorize("upload", "verified", requires_upload=True)
+        assert not policy.authorize("upload", "paper_submitted", requires_upload=True)
+
+    def test_non_editable_profile_blocks_upload(
+        self, profile_approved_lead42_owner20, officer_owner,
+    ):
+        policy = DocumentActionPolicy.for_(profile_approved_lead42_owner20, officer_owner)
+        assert not policy.authorize("upload", "missing", requires_upload=True)
+
+
+# ---------------------------------------------------------------------------
+# Paper-submitted action
+# ---------------------------------------------------------------------------
+
+
+class TestPaperSubmitted:
+    """`paper_submitted`: editable + (owner | admin | manager_in_scope) +
+    !requires_upload + status == missing."""
+
+    def test_owner_paper_only_missing_passes(
+        self, profile_draft_lead42_owner20, officer_owner,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
+        assert policy.authorize("paper_submitted", "missing", requires_upload=False)
+
+    def test_paper_already_submitted_blocks(
+        self, profile_draft_lead42_owner20, officer_owner,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
+        assert not policy.authorize(
+            "paper_submitted", "paper_submitted", requires_upload=False
+        )
+
+    def test_requires_upload_doc_blocks_paper(
+        self, profile_draft_lead42_owner20, officer_owner,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
+        assert not policy.authorize(
+            "paper_submitted", "missing", requires_upload=True
+        )
+
+    def test_officer_not_owner_blocks_paper(
+        self, profile_draft_lead42_owner20, officer_not_owner,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_not_owner)
+        assert not policy.authorize(
+            "paper_submitted", "missing", requires_upload=False
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verify action — reviewer-only (admin or manager-in-scope)
+# ---------------------------------------------------------------------------
+
+
+class TestVerify:
+    """`verify`: reviewer_scope (admin or manager_in_scope) +
+    status in (uploaded, paper_submitted)."""
+
+    @pytest.mark.parametrize("doc_status", ["uploaded", "paper_submitted"])
+    def test_admin_or_manager_can_verify(
+        self, profile_draft_lead42_owner20, admin, manager_in_scope, doc_status,
+    ):
+        for actor in (admin, manager_in_scope):
+            policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, actor)
+            assert policy.authorize("verify", doc_status, requires_upload=True), (
+                f"actor={actor.role}, status={doc_status}"
+            )
+
+    def test_owner_officer_cannot_verify(
+        self, profile_draft_lead42_owner20, officer_owner,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
+        assert not policy.authorize("verify", "uploaded", requires_upload=True)
+
+    def test_manager_other_unit_cannot_verify(
+        self, profile_draft_lead42_owner20, manager_other_unit,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, manager_other_unit)
+        assert not policy.authorize("verify", "uploaded", requires_upload=True)
+
+    @pytest.mark.parametrize("doc_status", ["missing", "rejected", "verified"])
+    def test_wrong_status_blocks_verify(
+        self, profile_draft_lead42_owner20, admin, doc_status,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, admin)
+        assert not policy.authorize("verify", doc_status, requires_upload=True)
+
+
+# ---------------------------------------------------------------------------
+# Reject action
+# ---------------------------------------------------------------------------
+
+
+class TestReject:
+    """`reject`: reviewer_scope + status in (uploaded, paper_submitted, verified)."""
+
+    @pytest.mark.parametrize(
+        "doc_status", ["uploaded", "paper_submitted", "verified"]
+    )
+    def test_admin_can_reject(
+        self, profile_draft_lead42_owner20, admin, doc_status,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, admin)
+        assert policy.authorize("reject", doc_status, requires_upload=True)
+
+    def test_officer_owner_cannot_reject(
+        self, profile_draft_lead42_owner20, officer_owner,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
+        assert not policy.authorize("reject", "uploaded", requires_upload=True)
+
+    @pytest.mark.parametrize("doc_status", ["missing", "rejected"])
+    def test_terminal_or_pre_upload_blocks_reject(
+        self, profile_draft_lead42_owner20, admin, doc_status,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, admin)
+        assert not policy.authorize("reject", doc_status, requires_upload=True)
+
+
+# ---------------------------------------------------------------------------
+# Reset action
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    """`reset`: reviewer_scope + status != missing."""
+
+    @pytest.mark.parametrize(
+        "doc_status", ["uploaded", "paper_submitted", "verified", "rejected"]
+    )
+    def test_admin_can_reset_non_missing(
+        self, profile_draft_lead42_owner20, admin, doc_status,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, admin)
+        assert policy.authorize("reset", doc_status, requires_upload=True)
+
+    def test_missing_blocks_reset(
+        self, profile_draft_lead42_owner20, admin,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, admin)
+        assert not policy.authorize("reset", "missing", requires_upload=True)
+
+    def test_officer_cannot_reset(
+        self, profile_draft_lead42_owner20, officer_owner,
+    ):
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
+        assert not policy.authorize("reset", "uploaded", requires_upload=True)
+
+
+# ---------------------------------------------------------------------------
+# Defensive: unknown action denies — typo in caller never grants access
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_action_returns_false(profile_draft_lead42_owner20, admin):
+    policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, admin)
+    assert not policy.authorize(
+        "delete",  # type: ignore[arg-type]  # intentional typo
+        "uploaded",
+        requires_upload=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Edge: missing lead (data integrity slip) treats profile as no-owner
+# ---------------------------------------------------------------------------
+
+
+def test_missing_lead_blocks_owner_actions(officer_owner):
+    profile = _StubProfile(status="draft", lead=None)
+    policy = DocumentActionPolicy.for_(profile, officer_owner)
+    # No lead → no owner / no manager-in-scope. Only admin can act.
+    assert not policy.authorize("upload", "missing", requires_upload=True)
+    assert not policy.authorize(
+        "paper_submitted", "missing", requires_upload=False
+    )


### PR DESCRIPTION
## Summary

Closes admission audit follow-up #2 (memory `project_admission_audit_followups`).

Hai sites trước đây hand-roll cùng 5-action document permission matrix song song:
- `_compute_document_permissions` (trong `_compute_frontend_fields`) → produce `can_*` response flags cho `documents_checklist`
- `_authorize_document_action` (service-side guard) → enforce cùng matrix at request time

Sync qua comments + tests rất brittle. Update 1 branch quên branch còn lại → FE flag promise BE refuse, hoặc ngược lại. Cả 2 giờ consult `DocumentActionPolicy` class.

## What lands

### `app/services/admission_document_policy.py` (NEW)

- `DocumentAction` literal type (`upload`, `paper_submitted`, `verify`, `reject`, `reset`)
- `_UserProfileContext` dataclass — cache `is_admin` / `is_owner` / `manager_in_scope` / `reviewer_scope` / `profile_editable` flags để 5 lần `authorize()` không re-derive
- `DocumentActionPolicy.for_(profile, user)` factory
- `policy.authorize(action, doc_status, requires_upload) -> bool` — pure function over cached context, no DB access
- Unknown action returns `False` (fail-closed: typo trong caller không grant access)

### Refactor 2 sites

- `_authorize_document_action`: 80 dòng inline matrix → 15 dòng delegate
- `_compute_document_permissions`: 30 dòng parallel matrix → 10 dòng (build policy 1 lần, gọi `authorize()` 5 lần)
- Local vars `_manager_in_scope` / `_reviewer_scope` / `_profile_editable` retired (giờ trong policy context)

### Tests

`tests/unit/test_admission_document_policy.py` — 34 cases lock matrix at unit level:
- 5 actions × multiple actor profiles (admin / manager-in-scope / manager-other-unit / officer-owner / officer-not-owner)
- Status state transitions
- Unknown action fail-closed
- Missing lead (data integrity slip) blocks owner-scoped actions

## Test plan

- ✅ `tests/unit/test_admission_document_policy.py`: **34/34 PASS** (~0.83s, pure logic)
- ✅ `tests/api/test_admission_document_permissions.py`: **4/4 PASS**
- ✅ `tests/api/test_admission_workflow_api.py`: **13/13 PASS**
- ✅ `tests/api/test_admissions_minor_correction.py`: **33/33 PASS**
- ✅ Combined sweep: **84/84 PASS** (no regression)

## Behavior preservation

Matrix unchanged — pure structural refactor. Tất cả rule upload/paper/verify/reject/reset giữ tương đương logic cũ:
- `upload`: requires_upload + editable + (owner|admin|manager_in_scope) + status in (missing, rejected)
- `paper_submitted`: !requires_upload + editable + (owner|admin|manager_in_scope) + status == missing
- `verify`: reviewer_scope + status in (uploaded, paper_submitted)
- `reject`: reviewer_scope + status in (uploaded, paper_submitted, verified)
- `reset`: reviewer_scope + status != missing

## Drift risk eliminated

Future PR cần extend matrix (action mới, role mới, status mới) → change ở 1 chỗ duy nhất. Cả FE flag + BE gate auto pickup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)