### PR TITLE
ci(deploy): serialize VPS deploys via concurrency group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,6 +157,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: true
 
     steps:
       - name: Deploy via SSH


### PR DESCRIPTION
## Summary
- Adds `concurrency: deploy-production` with `cancel-in-progress: true` to the **deploy job only** (not workflow level → test job still runs per push, no CI waste).
- When 3 PRs merge back-to-back, only the latest deploy reaches the VPS; the earlier two get cancelled before they grab `.git/index.lock` or `docker compose restart`.

## Why now
About to land #132/#133/#134 sequentially. Without this guard, three deploys would race on the VPS workdir → `.git/index.lock` contention or partial restarts. With it, batch merging costs ≈ one deploy window instead of three.

## Test plan
- [ ] CI green on this PR (test job uses default behaviour)
- [ ] After merge, verify next deploy run shows `concurrency: deploy-production` group on the workflow page
- [ ] During #132→#133→#134 merge sequence, observe earlier deploys auto-cancel (yellow ⊘ in Actions tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)