### PR TITLE
chore(ops): add docker log rotation for backend services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,18 @@
 #   Development: docker compose up -d (uses override file)
 # =============================================================================
 
+# Default log rotation policy. Docker's json-file driver retains logs
+# indefinitely without explicit limits, and a deploy/restart wipes the
+# in-memory ring buffer that `docker logs` reads. Cap at 50MB × 10 files
+# (compressed) → ~500MB per service, ~7-10 days retention at current traffic.
+# Anchor referenced by services that benefit most from post-mortem log access.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "50m"
+    max-file: "10"
+    compress: "true"
+
 services:
   # --- PostgreSQL ---
   postgres:
@@ -84,6 +96,7 @@ services:
       timeout: 10s
       start_period: 40s
       retries: 3
+    logging: *default-logging
 
   # --- Celery Worker ---
   celery-worker:
@@ -112,6 +125,7 @@ services:
           memory: 512M
     healthcheck:
       disable: true
+    logging: *default-logging
 
   # --- Celery Beat (SINGLETON - never scale beyond 1) ---
   celery-beat:
@@ -141,6 +155,7 @@ services:
           memory: 256M
     healthcheck:
       disable: true
+    logging: *default-logging
 
   # --- Frontend (Next.js Standalone) ---
   frontend:
@@ -203,6 +218,7 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
+    logging: *default-logging
 
   # --- Certbot (SSL Certificate Management) ---
   certbot:


### PR DESCRIPTION
## Summary
Cap docker `json-file` driver retention at 50MB × 10 files (gzip compressed) for backend, celery-worker, celery-beat, and nginx — services where post-mortem log access matters most.

## Why
Today's deploy of #132/#133/#134 surfaced a gap: the backend container held only ~12 minutes of `docker logs` history because the default driver has no size cap and the in-memory ring buffer is wiped on each restart. Investigating any prior incident is therefore impossible past the most recent restart window.

With this change, ~7-10 days of logs survive across restarts, matching the retention we already get from postgres + redis (which handle their own rotation).

## Impact
- Disk: ~2GB worst-case across 4 services. VPS has ample headroom after the 2026-04-20 prune (51% → 15%).
- Restart required to apply (next deploy will re-create containers with new logging config).
- No code change, no migration, no schema impact.

## Test plan
- [ ] CI green (no test job touched here, only Dependency Audit)
- [ ] Post-merge, after next deploy: `docker inspect qlts-backend-1 --format='{{json .HostConfig.LogConfig}}'` returns `max-size: 50m, max-file: 10`
- [ ] Verify `du -sh /var/lib/docker/containers/<id>/<id>-json.log*` grows then plateaus around 500MB after a few days

🤖 Generated with [Claude Code](https://claude.com/claude-code)