### PR TITLE
feat: add Zalo Bot notification channel

### DIFF
--- a/Backend_FastAPI/alembic/versions/zalobot001_zalo_bot_foundation.py
+++ b/Backend_FastAPI/alembic/versions/zalobot001_zalo_bot_foundation.py
@@ -1,0 +1,105 @@
+"""Zalo Bot Platform foundation: link table + preference column.
+
+Revision ID: zalobot001
+Revises: dd5m6n7o8p9q
+Create Date: 2026-04-26
+
+Adds three pieces in a single revision so deploy stays atomic:
+
+1. Table ``staff_zalo_bot_link`` — one row per linked staff user.
+   ``user_id`` is unique (one binding per user, reused on relink).
+   ``chat_id`` is **not** column-unique — instead a partial unique
+   index enforces "one active binding per chat_id at a time", letting
+   inactive history rows accumulate for audit.
+2. Column ``notification_preference.zalo_bot_enabled`` — boolean, NOT
+   NULL, server default false. Existing rows back-fill to ``false``
+   automatically. Managed exclusively by ``zalo_bot_link_service``;
+   the generic preference update endpoint deliberately omits it.
+3. Partial unique index ``ux_staff_zalo_bot_link_active_chat`` on
+   ``staff_zalo_bot_link(chat_id) WHERE is_active = true``. PostgreSQL
+   only — relies on the partial-index feature. Test DB uses
+   ``Base.metadata.create_all`` and skips this index, which is fine
+   because tests don't exercise the chat_id collision path.
+
+Downgrade is symmetric: drop index → drop column → drop table.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "zalobot001"
+down_revision: Union[str, None] = "dd5m6n7o8p9q"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "staff_zalo_bot_link"
+_PARTIAL_INDEX = "ux_staff_zalo_bot_link_active_chat"
+
+
+def upgrade() -> None:
+    op.create_table(
+        _TABLE,
+        sa.Column("id", sa.Integer(), primary_key=True, index=True),
+        sa.Column(
+            "user_id",
+            sa.Integer(),
+            sa.ForeignKey("user.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("chat_id", sa.String(length=100), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=True),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "linked_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    # Partial unique index: only one active binding per chat_id.
+    # Inactive rows (is_active = false) are unconstrained so audit
+    # history can accumulate.
+    op.create_index(
+        _PARTIAL_INDEX,
+        _TABLE,
+        ["chat_id"],
+        unique=True,
+        postgresql_where=sa.text("is_active = true"),
+    )
+
+    op.add_column(
+        "notification_preference",
+        sa.Column(
+            "zalo_bot_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+            comment=(
+                "Zalo Bot Platform channel — managed by "
+                "zalo_bot_link_service only, NOT writable through the "
+                "generic preference update endpoint."
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("notification_preference", "zalo_bot_enabled")
+    op.drop_index(_PARTIAL_INDEX, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -493,6 +493,23 @@ class Settings(BaseSettings):
         default="", validation_alias="ZALO_WEBHOOK_SECRET"
     )  # Secret for verifying webhook HMAC signatures
 
+    # -- Zalo Bot Platform (Internal Staff Notifications) --
+    # Separate from ZNS (ZALO_*). Zalo Bot Platform = free 3000 msg/month
+    # for staff-facing push (no template approval required). Channel
+    # registration / preference column added in later steps.
+    ZALO_BOT_ENABLED: bool = Field(
+        default=False, validation_alias="ZALO_BOT_ENABLED"
+    )  # Master switch — must be True before registering zalo_bot channel
+    ZALO_BOT_TOKEN: str = Field(
+        default="", validation_alias="ZALO_BOT_TOKEN"
+    )  # Bot token from bot.zaloplatforms.com — DO NOT log
+    ZALO_BOT_WEBHOOK_SECRET: str = Field(
+        default="", validation_alias="ZALO_BOT_WEBHOOK_SECRET"
+    )  # X-Bot-Api-Secret-Token header value — DO NOT log
+    ZALO_BOT_DAILY_QUOTA: int = Field(
+        default=80, validation_alias="ZALO_BOT_DAILY_QUOTA"
+    )  # v5 Finding 6: 80/day for 20% margin under Zalo Basic ceiling 100/day (3000/month)
+
     # -- MoMo Payment Gateway Settings --
     # Get credentials from MoMo merchant portal
     # Docs: https://developers.momo.vn/v3/docs/payment/api/collection-link/

--- a/Backend_FastAPI/app/core/event_groups.py
+++ b/Backend_FastAPI/app/core/event_groups.py
@@ -269,7 +269,12 @@ class NotificationChannel(str, Enum):
     """Email notification"""
 
     ZALO = "zalo"
-    """Zalo ZNS notification (Phase 1)"""
+    """Zalo ZNS notification (Phase 1) — public-facing template messages"""
+
+    ZALO_BOT = "zalo_bot"
+    """Zalo Bot Platform notification (v5) — internal staff free-text push.
+    Distinct from ``ZALO`` (ZNS): no template approval, capped at the
+    Zalo Basic free tier and gated by ``settings.ZALO_BOT_ENABLED``."""
 
     SMS = "sms"
     """SMS notification (future feature)"""
@@ -281,48 +286,56 @@ DEFAULT_GROUP_CHANNELS: Dict[NotificationEventGroup, Dict[NotificationChannel, b
         NotificationChannel.BROWSER: True,
         NotificationChannel.EMAIL: True,
         NotificationChannel.ZALO: False,
+        NotificationChannel.ZALO_BOT: False,
         NotificationChannel.SMS: False,
     },
     NotificationEventGroup.CONSULTATION: {
         NotificationChannel.BROWSER: True,
         NotificationChannel.EMAIL: False,
         NotificationChannel.ZALO: False,
+        NotificationChannel.ZALO_BOT: False,
         NotificationChannel.SMS: False,
     },
     NotificationEventGroup.APPLICATION: {
         NotificationChannel.BROWSER: True,
         NotificationChannel.EMAIL: True,
         NotificationChannel.ZALO: False,
+        NotificationChannel.ZALO_BOT: False,
         NotificationChannel.SMS: False,
     },
     NotificationEventGroup.FINANCE: {
         NotificationChannel.BROWSER: True,
         NotificationChannel.EMAIL: True,
         NotificationChannel.ZALO: False,
+        NotificationChannel.ZALO_BOT: False,
         NotificationChannel.SMS: False,
     },
     NotificationEventGroup.DORM: {
         NotificationChannel.BROWSER: True,
         NotificationChannel.EMAIL: False,
         NotificationChannel.ZALO: False,
+        NotificationChannel.ZALO_BOT: False,
         NotificationChannel.SMS: False,
     },
     NotificationEventGroup.ASSET: {
         NotificationChannel.BROWSER: True,
         NotificationChannel.EMAIL: False,
         NotificationChannel.ZALO: False,
+        NotificationChannel.ZALO_BOT: False,
         NotificationChannel.SMS: False,
     },
     NotificationEventGroup.SYSTEM: {
         NotificationChannel.BROWSER: True,
         NotificationChannel.EMAIL: True,
         NotificationChannel.ZALO: False,
+        NotificationChannel.ZALO_BOT: False,
         NotificationChannel.SMS: False,
     },
     NotificationEventGroup.PIPELINE: {
         NotificationChannel.BROWSER: True,
         NotificationChannel.EMAIL: False,
         NotificationChannel.ZALO: False,
+        NotificationChannel.ZALO_BOT: False,
         NotificationChannel.SMS: False,
     },
     # ORGANIZATION group excluded — domain broadcast only, not user notification channels
@@ -330,12 +343,14 @@ DEFAULT_GROUP_CHANNELS: Dict[NotificationEventGroup, Dict[NotificationChannel, b
         NotificationChannel.BROWSER: True,
         NotificationChannel.EMAIL: True,
         NotificationChannel.ZALO: False,
+        NotificationChannel.ZALO_BOT: False,
         NotificationChannel.SMS: False,
     },
     NotificationEventGroup.CTV: {
         NotificationChannel.BROWSER: True,
         NotificationChannel.EMAIL: True,
         NotificationChannel.ZALO: False,
+        NotificationChannel.ZALO_BOT: False,
         NotificationChannel.SMS: False,
     },
 }

--- a/Backend_FastAPI/app/database.py
+++ b/Backend_FastAPI/app/database.py
@@ -133,6 +133,20 @@ async def safe_redis_delete(key: str):
         return 0
 
 
+async def safe_redis_getdel(key: str):
+    """Atomic GET + DELETE (Redis 6.2+ ``GETDEL``).
+
+    Returns the previous value or ``None`` if the key did not exist or the
+    breaker tripped. Used by Zalo Bot link flow to consume one-shot link
+    codes without a TOCTOU window between read and delete.
+    """
+    try:
+        return await redis_breaker.call_async(redis_client.getdel, key)
+    except REDIS_BREAKER_EXCEPTIONS:
+        log.error("Redis GETDEL failed", key=key, exc_info=True)
+        return None
+
+
 # ✅ PHASE 1.2.1: Redis List operations for notification inbox caching
 async def safe_redis_lpush(key: str, *values):
     """

--- a/Backend_FastAPI/app/gateways/zalo_bot.py
+++ b/Backend_FastAPI/app/gateways/zalo_bot.py
@@ -1,0 +1,137 @@
+"""Zalo Bot Platform HTTP gateway.
+
+Wraps the public Bot API at ``https://bot-api.zaloplatforms.com/bot<TOKEN>/<method>``.
+Token comes from ``settings.ZALO_BOT_TOKEN`` and **must never** be logged
+or surfaced in error messages — callers and logs must only see opaque
+HTTP method names like ``sendMessage``.
+
+Rate limit / retry policy is handled by the channel sender layer (Step 8),
+not here. This module is intentionally thin: I/O, JSON, and a typed
+result.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+import structlog
+
+from app.config import settings
+
+log = structlog.get_logger(__name__)
+
+ZALO_BOT_API_BASE = "https://bot-api.zaloplatforms.com"
+MAX_TEXT_LENGTH = 2000  # Zalo Bot Platform `sendMessage` text cap
+
+
+@dataclass
+class ZaloBotSendResult:
+    success: bool
+    message_id: Optional[str] = None
+    error_code: int = 0
+    error_message: str = ""
+
+
+class ZaloBotGateway:
+    """Stateless wrapper. Reads ``settings.ZALO_BOT_TOKEN`` per call so a
+    test that monkey-patches the setting takes effect immediately.
+    """
+
+    def _api_url(self, method: str) -> str:
+        return f"{ZALO_BOT_API_BASE}/bot{settings.ZALO_BOT_TOKEN}/{method}"
+
+    @staticmethod
+    def _safe_error_message(method: str, exc: Exception) -> str:
+        """Return an error string that cannot accidentally contain the bot
+        token. ``str(exc)`` is unsafe for httpx errors because the request
+        URL (with embedded token) appears in the repr.
+        """
+        return f"{method} failed: {type(exc).__name__}"
+
+    async def send_message(self, chat_id: str, text: str) -> ZaloBotSendResult:
+        if not text or len(text) > MAX_TEXT_LENGTH:
+            return ZaloBotSendResult(
+                success=False,
+                error_code=-1000,
+                error_message=f"Text length invalid: {len(text) if text else 0}",
+            )
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
+                    self._api_url("sendMessage"),
+                    json={"chat_id": chat_id, "text": text},
+                )
+            data = resp.json()
+            if data.get("ok"):
+                return ZaloBotSendResult(
+                    success=True,
+                    message_id=data.get("result", {}).get("message_id"),
+                )
+            return ZaloBotSendResult(
+                success=False,
+                error_code=data.get("error_code", -1),
+                error_message=data.get("description", "unknown_error"),
+            )
+        except httpx.TimeoutException:
+            log.warning("Zalo Bot API timeout", method="sendMessage")
+            return ZaloBotSendResult(
+                success=False, error_code=-999, error_message="timeout"
+            )
+        except Exception as exc:
+            # Log only the exception class name + method name. Never log
+            # str(exc) because httpx serialises the full request URL —
+            # which embeds the bot token — into repr.
+            log.error(
+                "Zalo Bot API failed",
+                method="sendMessage",
+                error_type=type(exc).__name__,
+            )
+            return ZaloBotSendResult(
+                success=False,
+                error_code=-998,
+                error_message=self._safe_error_message("sendMessage", exc),
+            )
+
+    async def get_me(self) -> Optional[dict]:
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(self._api_url("getMe"))
+            data = resp.json()
+            return data.get("result") if data.get("ok") else None
+        except Exception as exc:
+            log.warning(
+                "Zalo Bot getMe failed",
+                error_type=type(exc).__name__,
+            )
+            return None
+
+    async def set_webhook(self, url: str, secret_token: str) -> bool:
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(
+                    self._api_url("setWebhook"),
+                    json={"url": url, "secret_token": secret_token},
+                )
+            return bool(resp.json().get("ok", False))
+        except Exception as exc:
+            log.warning(
+                "Zalo Bot setWebhook failed",
+                error_type=type(exc).__name__,
+            )
+            return False
+
+    async def delete_webhook(self) -> bool:
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(self._api_url("deleteWebhook"))
+            return bool(resp.json().get("ok", False))
+        except Exception as exc:
+            log.warning(
+                "Zalo Bot deleteWebhook failed",
+                error_type=type(exc).__name__,
+            )
+            return False
+
+
+zalo_bot_gateway = ZaloBotGateway()

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -71,6 +71,8 @@ from .routers import (
     sessions,
     users,
     zalo_webhooks,  # ✅ PHASE C1: Zalo webhook receiver
+    zalo_bot_link,  # ✅ v5 Step 19: staff Zalo Bot link API
+    zalo_bot_webhooks,  # ✅ v5 Step 18: Zalo Bot webhook receiver
 )
 
 # ✅ PHASE 2 COMPLETE: Import split admin routers
@@ -723,6 +725,8 @@ fastapi_app.include_router(notification_templates.router, prefix="/api")  # ✅ 
 fastapi_app.include_router(notification_consents.router, prefix="/api")  # ✅ PHASE B7: Consent management
 fastapi_app.include_router(notification_delivery_ops.router, prefix="/api")  # ✅ PHASE B8: Delivery ops
 fastapi_app.include_router(zalo_webhooks.router)  # ✅ PHASE C1: Zalo webhooks (no auth, HMAC-verified)
+fastapi_app.include_router(zalo_bot_webhooks.router)  # ✅ v5 Step 18: Zalo Bot webhook (shared-secret header)
+fastapi_app.include_router(zalo_bot_link.router)  # ✅ v5 Step 19: Staff Zalo Bot link API
 fastapi_app.include_router(leads.router, prefix="/api/leads")
 fastapi_app.include_router(collaborators.admin_router, prefix="/api")  # ✅ CTV: Admin/Manager CTV management
 fastapi_app.include_router(collaborators.ctv_router, prefix="/api")  # ✅ CTV: Self-service endpoints

--- a/Backend_FastAPI/app/models/__init__.py
+++ b/Backend_FastAPI/app/models/__init__.py
@@ -63,6 +63,7 @@ from .notification_consent import NotificationConsent
 from .notification_consent_history import NotificationConsentHistory
 from .notification_quota import NotificationQuota
 from .zalo_token_store import ZaloTokenStore
+from .staff_zalo_bot_link import StaffZaloBotLink
 
 # Organization models (includes temporal models)
 # OLD: from .organization import Major  # REMOVED after 3-tier migration
@@ -177,6 +178,7 @@ __all__ = [
     "NotificationConsentHistory",
     "NotificationQuota",
     "ZaloTokenStore",
+    "StaffZaloBotLink",
     # Organization (Legacy)
     # "Major",  # REMOVED after 3-tier migration k6l7m8n9o0p1
     # "MajorAcademicInfo",  # REMOVED after 3-tier migration k6l7m8n9o0p1

--- a/Backend_FastAPI/app/models/notification_preference.py
+++ b/Backend_FastAPI/app/models/notification_preference.py
@@ -22,6 +22,17 @@ class NotificationPreference(Base):
     browser_enabled = Column(Boolean, nullable=False, default=True)
     zalo_enabled = Column(Boolean, nullable=False, default=False,
                           comment="Zalo ZNS channel — disabled by default until user opts in")
+    zalo_bot_enabled = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="false",
+        comment=(
+            "Zalo Bot Platform channel — managed by zalo_bot_link_service "
+            "(link/unlink) only, NOT writable through the generic preference "
+            "update endpoint."
+        ),
+    )
 
     # Email digest preferences
     email_digest = Column(

--- a/Backend_FastAPI/app/models/staff_zalo_bot_link.py
+++ b/Backend_FastAPI/app/models/staff_zalo_bot_link.py
@@ -1,0 +1,39 @@
+"""Zalo Bot Platform link record (staff ↔ chat_id).
+
+One row per staff user. ``user_id`` is unique so the row is reused on
+relink — never INSERT a second row for the same user.
+
+``chat_id`` is intentionally **not** unique at the model level: a chat_id
+may bounce between users if a staff hands their phone to a colleague.
+The migration is expected to add a *partial* unique index over
+``(chat_id) WHERE is_active = true`` so only one active binding per
+chat_id exists at a time, while inactive history rows are kept for audit.
+"""
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.sql import func
+
+from .base import Base
+
+
+class StaffZaloBotLink(Base):
+    __tablename__ = "staff_zalo_bot_link"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer,
+        ForeignKey("user.id", ondelete="CASCADE"),
+        unique=True,
+        nullable=False,
+    )
+    chat_id = Column(String(100), nullable=False)
+    display_name = Column(String(255), nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True, server_default="true")
+    linked_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/Backend_FastAPI/app/repositories/staff_zalo_bot_link_repository.py
+++ b/Backend_FastAPI/app/repositories/staff_zalo_bot_link_repository.py
@@ -1,0 +1,76 @@
+"""Repository for ``staff_zalo_bot_link`` rows.
+
+One row per ``user_id`` (unique). Reactivation of a previously-unlinked
+user reuses the existing row and stamps a new ``chat_id`` rather than
+inserting — keeping audit trail clean and avoiding accidental duplicate
+unique-constraint violations.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.staff_zalo_bot_link import StaffZaloBotLink
+
+
+class StaffZaloBotLinkRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_by_user_id(self, user_id: int) -> Optional[StaffZaloBotLink]:
+        result = await self.db.execute(
+            select(StaffZaloBotLink).where(StaffZaloBotLink.user_id == user_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_active_by_user_id(self, user_id: int) -> Optional[StaffZaloBotLink]:
+        result = await self.db.execute(
+            select(StaffZaloBotLink).where(
+                StaffZaloBotLink.user_id == user_id,
+                StaffZaloBotLink.is_active.is_(True),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_active_by_chat_id(self, chat_id: str) -> Optional[StaffZaloBotLink]:
+        result = await self.db.execute(
+            select(StaffZaloBotLink).where(
+                StaffZaloBotLink.chat_id == chat_id,
+                StaffZaloBotLink.is_active.is_(True),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create_or_reactivate(
+        self,
+        user_id: int,
+        chat_id: str,
+        display_name: Optional[str] = None,
+    ) -> StaffZaloBotLink:
+        """Reuse existing row for this ``user_id`` — never INSERT a second row."""
+        existing = await self.get_by_user_id(user_id)
+        if existing:
+            existing.chat_id = chat_id
+            existing.display_name = display_name
+            existing.is_active = True
+            await self.db.flush()
+            return existing
+        link = StaffZaloBotLink(
+            user_id=user_id,
+            chat_id=chat_id,
+            display_name=display_name,
+            is_active=True,
+        )
+        self.db.add(link)
+        await self.db.flush()
+        return link
+
+    async def deactivate_by_user_id(self, user_id: int) -> bool:
+        link = await self.get_by_user_id(user_id)
+        if not link or not link.is_active:
+            return False
+        link.is_active = False
+        await self.db.flush()
+        return True

--- a/Backend_FastAPI/app/routers/notification_rules.py
+++ b/Backend_FastAPI/app/routers/notification_rules.py
@@ -50,9 +50,16 @@ class OperatorOption(BaseModel):
 
 
 class ChannelInfo(BaseModel):
-    """Channel with live/planned status"""
+    """Channel with live/planned status.
+
+    v5 pre-work: ``internal_only`` distinguishes channels that target staff
+    only (e.g. zalo_bot) from public-facing channels (browser/email/zalo/sms).
+    External recipient pickers must hide ``internal_only=True`` channels to
+    prevent leaking staff infrastructure to leads/customers.
+    """
     value: str
     status: str  # "live" | "planned"
+    internal_only: bool = False
 
 
 class ExternalResolverTypeOption(BaseModel):
@@ -122,6 +129,15 @@ async def get_notification_metadata(
             {"value": "browser", "status": "live"},
             {"value": "email", "status": "live"},
             {"value": "zalo", "status": "live" if settings.ZALO_ENABLED else "planned"},
+            # v5 Step 17: zalo_bot is internal_only=True so the FE wizard
+            # hides it from external recipient pickers. Status follows
+            # the env flag — "planned" until ZALO_BOT_ENABLED flips on
+            # in production, then "live".
+            {
+                "value": "zalo_bot",
+                "status": "live" if settings.ZALO_BOT_ENABLED else "planned",
+                "internal_only": True,
+            },
             {"value": "sms", "status": "planned"},
         ],
         "resolver_types": [

--- a/Backend_FastAPI/app/routers/zalo_bot_link.py
+++ b/Backend_FastAPI/app/routers/zalo_bot_link.py
@@ -1,0 +1,126 @@
+"""Staff-facing Zalo Bot link API.
+
+Three authenticated endpoints under ``/api/zalo-bot``:
+
+- ``POST /link-code`` — generate a one-shot link code (TTL 600s).
+  Rate-limited per user at 5 requests / 10 minutes via atomic INCR.
+- ``GET /link-status`` — return whether the caller has an active bot
+  binding plus display metadata. Never reveals other users' bindings.
+- ``POST /unlink`` — deactivate the caller's binding and flip
+  ``zalo_bot_enabled`` to ``False``.
+
+All endpoints require ``get_current_active_user`` — anonymous access
+is impossible. The link code is the only secret we hand back; the
+chat_id is bound by the staff member typing it into Zalo, not by API.
+"""
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.core.deps import get_current_active_user
+from app.database import (
+    get_db,
+    safe_redis_expire,
+    safe_redis_incr,
+)
+from app.utils.exceptions import BusinessRuleViolation
+
+log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/api/zalo-bot", tags=["Zalo Bot Link"])
+
+
+# Per-user link-code throttle
+_LINK_CODE_RL_PREFIX = "zalo_bot:ratelimit:link_code:"
+_LINK_CODE_RL_LIMIT = 5  # requests
+_LINK_CODE_RL_WINDOW = 600  # seconds (10 min)
+
+
+async def _check_link_code_rate_limit(user_id: int) -> None:
+    """Atomic INCR + EXPIRE — never use GET-then-SET (race window).
+
+    Raises ``BusinessRuleViolation`` (400) on overflow. Redis breaker
+    open returns ``None`` from INCR — we let the request through in
+    that case rather than failing closed; quota cap on the link service
+    side bounds total Redis writes either way.
+    """
+    key = f"{_LINK_CODE_RL_PREFIX}{user_id}"
+    new_val = await safe_redis_incr(key)
+    if new_val == 1:
+        await safe_redis_expire(key, _LINK_CODE_RL_WINDOW)
+    if new_val is not None and new_val > _LINK_CODE_RL_LIMIT:
+        raise BusinessRuleViolation(
+            "Quá nhiều yêu cầu. Vui lòng thử lại sau 10 phút."
+        )
+
+
+@router.post("/link-code")
+async def generate_link_code(
+    db: AsyncSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_active_user),
+):
+    """Generate a fresh 6-char link code for the calling staff member.
+
+    Returns the code, its TTL (10 minutes), and an instruction string
+    suitable for copy-paste into Zalo.
+    """
+    from app.services import zalo_bot_link_service
+
+    await _check_link_code_rate_limit(current_user.id)
+
+    code, post_commit = await zalo_bot_link_service.generate_link_code(
+        db, current_user.id
+    )
+    await db.commit()
+    if post_commit:
+        await post_commit()
+
+    return {
+        "code": code,
+        "expires_in_seconds": 600,  # v5/E8: 10-min window for staff onboarding
+        "instructions": (
+            f"Mở Zalo, tìm bot QLTS, gửi: /lienkiet {code}"
+        ),
+    }
+
+
+@router.get("/link-status")
+async def get_link_status(
+    db: AsyncSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_active_user),
+):
+    """Return the calling user's bot binding state.
+
+    Always returns a 200 with a stable shape — UI can render
+    ``is_linked: false`` directly without checking 404.
+    """
+    from app.services import zalo_bot_link_service
+
+    status = await zalo_bot_link_service.get_link_status(db, current_user.id)
+    return status or {
+        "is_linked": False,
+        "display_name": None,
+        "linked_at": None,
+    }
+
+
+@router.post("/unlink")
+async def unlink_zalo_bot(
+    db: AsyncSession = Depends(get_db),
+    current_user: models.User = Depends(get_current_active_user),
+):
+    """Deactivate the caller's link and flip ``zalo_bot_enabled=False``.
+
+    Idempotent — calling unlink on an already-unlinked user returns
+    ``{"unlinked": false}`` without raising.
+    """
+    from app.services import zalo_bot_link_service
+
+    ok, message = await zalo_bot_link_service.unlink(db, current_user.id)
+    if ok:
+        await db.commit()
+    else:
+        await db.rollback()
+    return {"unlinked": ok, "message": message}

--- a/Backend_FastAPI/app/routers/zalo_bot_webhooks.py
+++ b/Backend_FastAPI/app/routers/zalo_bot_webhooks.py
@@ -1,0 +1,226 @@
+"""Zalo Bot Platform webhook receiver.
+
+Endpoint: ``POST /api/webhooks/zalo-bot``
+
+Auth model: shared secret in ``X-Bot-Api-Secret-Token`` header,
+configured via ``settings.ZALO_BOT_WEBHOOK_SECRET``. The secret is
+**required** — an empty configured secret fails closed (401) so a
+mis-configured deploy can't accidentally accept anonymous traffic.
+
+What this router does NOT do:
+- Log the secret, the bot token, the link code, or the raw message
+  body. Operator visibility is limited to a masked chat_id prefix and
+  high-level event type.
+- Return non-2xx for handled command errors. Zalo retries non-2xx
+  responses, which would double-consume codes (``GETDEL`` makes the
+  first attempt destructive). 401 is reserved for genuine auth
+  failures; 400 for malformed JSON; everything else returns 200 with
+  a status string the operator can grep.
+"""
+from __future__ import annotations
+
+import hmac
+import re
+
+import structlog
+from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.database import (
+    get_db,
+    safe_redis_expire,
+    safe_redis_incr,
+)
+
+log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/api/webhooks", tags=["Zalo Bot Webhooks"])
+
+
+# Per-chat_id rate limit window
+_WEBHOOK_RL_PREFIX = "zalo_bot:webhook_rl:"
+_WEBHOOK_RL_LIMIT = 10  # commands
+_WEBHOOK_RL_WINDOW = 60  # seconds
+
+# 6-char uppercase alnum, exact length so attackers can't pad with spaces
+_LINK_CODE_RE = re.compile(r"^[A-Z0-9]{6}$")
+
+
+def _mask_chat_id(chat_id: str) -> str:
+    """First 8 chars + ``***`` so logs are greppable but not pivot-able."""
+    if not chat_id:
+        return ""
+    return chat_id[:8] + "***" if len(chat_id) > 8 else chat_id[:4] + "***"
+
+
+async def _rate_limit_chat(chat_id: str) -> bool:
+    """Return ``True`` if the chat is over its 10/min budget.
+
+    Atomic via INCR + EXPIRE — a GET-then-SET pattern would let two
+    concurrent webhook deliveries both pass when both observe the
+    pre-increment count.
+    """
+    key = f"{_WEBHOOK_RL_PREFIX}{chat_id}"
+    new_val = await safe_redis_incr(key)
+    if new_val == 1:
+        await safe_redis_expire(key, _WEBHOOK_RL_WINDOW)
+    if new_val is None:
+        # Redis breaker open — let the request through rather than
+        # failing closed. The webhook itself isn't the attack surface
+        # for the link code (the 6-char Redis-stored code is).
+        return False
+    return new_val > _WEBHOOK_RL_LIMIT
+
+
+@router.post("/zalo-bot")
+async def zalo_bot_webhook(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    from app.gateways.zalo_bot import zalo_bot_gateway
+    from app.repositories.staff_zalo_bot_link_repository import (
+        StaffZaloBotLinkRepository,
+    )
+    from app.services import zalo_bot_link_service
+
+    # 1. Secret check (timing-safe).
+    configured_secret = settings.ZALO_BOT_WEBHOOK_SECRET or ""
+    if not configured_secret:
+        # v5 explicit: an empty configured secret is a deploy mistake.
+        # Refuse traffic so we never accept anonymous webhooks.
+        log.error(
+            "zalo_bot webhook rejected — ZALO_BOT_WEBHOOK_SECRET is empty",
+        )
+        return Response(status_code=401, content="Webhook secret not configured")
+
+    presented_secret = request.headers.get("X-Bot-Api-Secret-Token", "") or ""
+    if not hmac.compare_digest(presented_secret, configured_secret):
+        return Response(status_code=401, content="Invalid secret")
+
+    # 2. Body parse — 400 on malformed JSON (tells operator the
+    #    upstream payload format changed).
+    try:
+        data = await request.json()
+    except Exception:
+        log.warning("zalo_bot webhook invalid JSON")
+        return Response(status_code=400, content="Invalid JSON")
+
+    if not isinstance(data, dict):
+        return {"status": "ok", "mode": "non_object_payload"}
+
+    result = data.get("result") or {}
+    event_name = result.get("event_name", "") if isinstance(result, dict) else ""
+    if event_name != "message.text.received":
+        # Other events (e.g. delivery callbacks) are ignored for now.
+        return {"status": "ok", "mode": "ignored_event", "event": event_name}
+
+    message = result.get("message") or {}
+    chat = message.get("chat") if isinstance(message, dict) else None
+    chat_id = chat.get("id", "") if isinstance(chat, dict) else ""
+    text_raw = (message.get("text") or "") if isinstance(message, dict) else ""
+    text = text_raw.strip()
+    sender = message.get("from") if isinstance(message, dict) else None
+    display_name = sender.get("display_name", "") if isinstance(sender, dict) else ""
+
+    if not chat_id or not text:
+        return {"status": "ok", "mode": "noop"}
+
+    # 3. Rate limit per chat_id.
+    if await _rate_limit_chat(chat_id):
+        await zalo_bot_gateway.send_message(
+            chat_id, "Quá nhiều lệnh. Vui lòng thử lại sau 1 phút."
+        )
+        log.warning(
+            "zalo_bot webhook rate_limited",
+            chat_id_prefix=_mask_chat_id(chat_id),
+        )
+        return {"status": "rate_limited"}
+
+    # 4. Log the event class only — never the raw text (may contain code).
+    #    Use ``event_kind`` not ``event`` because structlog reserves the
+    #    latter as the message slot.
+    log.info(
+        "zalo_bot webhook event",
+        chat_id_prefix=_mask_chat_id(chat_id),
+        event_kind="text",
+    )
+
+    text_lower = text.lower()
+
+    # ---------------- /lienkiet <CODE> ----------------
+    if text_lower.startswith("/lienkiet"):
+        # Strip command, then the candidate code; format must be exact.
+        candidate = text[len("/lienkiet"):].strip().upper()
+        if not _LINK_CODE_RE.match(candidate):
+            await zalo_bot_gateway.send_message(
+                chat_id,
+                "Cú pháp sai. Gửi: /lienkiet <MA> (6 ký tự, chỉ chữ in hoa và số).",
+            )
+            return {"status": "ok", "mode": "bad_format"}
+
+        try:
+            ok, reply = await zalo_bot_link_service.verify_and_link(
+                db, candidate, chat_id, display_name or None
+            )
+            if ok:
+                await db.commit()
+            else:
+                await db.rollback()
+        except Exception:
+            await db.rollback()
+            log.exception(
+                "zalo_bot verify_and_link failed",
+                chat_id_prefix=_mask_chat_id(chat_id),
+            )
+            await zalo_bot_gateway.send_message(
+                chat_id, "Lỗi hệ thống. Vui lòng thử lại sau."
+            )
+            return {"status": "ok", "mode": "service_error"}
+
+        await zalo_bot_gateway.send_message(chat_id, reply)
+        return {"status": "ok", "mode": "verify_and_link", "linked": ok}
+
+    # ---------------- /huylienkiet ----------------
+    if text_lower == "/huylienkiet":
+        try:
+            ok, reply = await zalo_bot_link_service.unlink_by_chat_id(db, chat_id)
+            if ok:
+                await db.commit()
+            else:
+                await db.rollback()
+        except Exception:
+            await db.rollback()
+            log.exception(
+                "zalo_bot unlink_by_chat_id failed",
+                chat_id_prefix=_mask_chat_id(chat_id),
+            )
+            await zalo_bot_gateway.send_message(
+                chat_id, "Lỗi hệ thống. Vui lòng thử lại sau."
+            )
+            return {"status": "ok", "mode": "service_error"}
+
+        await zalo_bot_gateway.send_message(chat_id, reply)
+        return {"status": "ok", "mode": "unlink", "found": ok}
+
+    # ---------------- /trangthai ----------------
+    if text_lower == "/trangthai":
+        repo = StaffZaloBotLinkRepository(db)
+        link = await repo.get_active_by_chat_id(chat_id)
+        # IMPORTANT: never return the user_id (or display_name owned by
+        # someone else if the chat_id has bounced) to the chat — only a
+        # binary linked / not-linked answer.
+        reply = "Đã liên kết." if link else "Chưa liên kết."
+        await zalo_bot_gateway.send_message(chat_id, reply)
+        return {"status": "ok", "mode": "status", "linked": bool(link)}
+
+    # ---------------- help / unknown ----------------
+    await zalo_bot_gateway.send_message(
+        chat_id,
+        (
+            "QLTS Bot:\n"
+            "/lienkiet <MA> — liên kết tài khoản\n"
+            "/huylienkiet — huỷ liên kết\n"
+            "/trangthai — kiểm tra trạng thái"
+        ),
+    )
+    return {"status": "ok", "mode": "help"}

--- a/Backend_FastAPI/app/schemas/notification_preference.py
+++ b/Backend_FastAPI/app/schemas/notification_preference.py
@@ -20,6 +20,11 @@ class NotificationPreferenceBase(BaseModel):
     sound_enabled: bool = True
     browser_enabled: bool = True
     zalo_enabled: bool = False  # Disabled by default — user must opt in
+    # zalo_bot_enabled is managed by zalo_bot_link_service (link/unlink) and
+    # is NOT exposed in NotificationPreferenceUpdate — clients cannot flip it
+    # via the generic preference endpoint to prevent silent broadcast leaks
+    # to staff who never confirmed the bot binding.
+    zalo_bot_enabled: bool = False
     email_digest: str = Field(
         default="instant", pattern="^(instant|daily|weekly|disabled)$"
     )

--- a/Backend_FastAPI/app/services/notification_channels/__init__.py
+++ b/Backend_FastAPI/app/services/notification_channels/__init__.py
@@ -5,7 +5,7 @@
 Central registry for all notification channels.
 Provides factory function to get channel instances.
 
-Canonical channel names: browser, email, zalo, sms
+Canonical channel names: browser, email, zalo, zalo_bot, sms
 Legacy value "socket" is normalized to "browser" on read and rejected on write.
 """
 from typing import Dict, List, Optional, Type
@@ -19,7 +19,7 @@ from .email_channel import EmailChannel
 # Canonical channel values
 # =============================================================================
 
-CANONICAL_CHANNELS = frozenset({"browser", "email", "zalo", "sms"})
+CANONICAL_CHANNELS = frozenset({"browser", "email", "zalo", "zalo_bot", "sms"})
 
 _CHANNEL_ALIASES = {
     "socket": "browser",  # Legacy alias — normalize on read, reject on write
@@ -108,7 +108,25 @@ def _register_zalo_channel():
     except Exception:
         pass  # Config not available yet (import time)
 
+
+def _register_zalo_bot_channel():
+    """v5 Step 9: register ZaloBotChannel only when ``ZALO_BOT_ENABLED``.
+
+    Channel sender is gated by env flag so accidental notification rule
+    creation while the bot is unconfigured cannot mass-fire deliveries
+    that would all immediately dead-letter.
+    """
+    try:
+        from app.config import settings
+        if settings.ZALO_BOT_ENABLED:
+            from .zalo_bot_channel import ZaloBotChannel
+            CHANNEL_REGISTRY["zalo_bot"] = ZaloBotChannel
+    except Exception:
+        pass  # Config not available yet (import time)
+
+
 _register_zalo_channel()
+_register_zalo_bot_channel()
 
 
 def get_channel(channel_name: str) -> Optional[BaseChannel]:

--- a/Backend_FastAPI/app/services/notification_channels/zalo_bot_channel.py
+++ b/Backend_FastAPI/app/services/notification_channels/zalo_bot_channel.py
@@ -1,0 +1,185 @@
+"""Zalo Bot Platform notification channel.
+
+Worker-only sender that pushes notifications to the staff member's
+linked Zalo Bot chat. Resolves the chat_id via the
+``staff_zalo_bot_link`` row, calls ``zalo_bot_gateway.send_message``,
+and maps gateway results onto the standard ``ChannelResult`` shape.
+
+External recipients are not supported: this channel is gated to
+``recipient_kind == "internal"`` upstream by the rule CRUD validator
+(Step 16) and at metadata exposure time (``internal_only=True``).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List
+
+import structlog
+
+from .base import BaseChannel, ChannelResult
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.models.notification_delivery import NotificationDelivery
+
+log = structlog.get_logger(__name__)
+
+
+# Plain-text cap matching the gateway. We truncate rather than reject so
+# a slightly-too-long template still delivers; truncation is logged so
+# the operator can shorten the template upstream.
+_MAX_TEXT_LENGTH = 2000
+_TRUNCATION_MARKER = "…"
+
+
+def _format_text(snapshot: Dict[str, Any]) -> str:
+    """Build the plain-text body sent to the bot.
+
+    Prefers an explicit ``message`` field — falls back to ``title``.
+    Combined ``title + message`` is the user-visible payload, mirroring
+    the in-app browser format.
+    """
+    title = (snapshot.get("title") or "").strip()
+    message = (snapshot.get("message") or "").strip()
+    if title and message:
+        body = f"{title}\n\n{message}"
+    else:
+        body = message or title
+
+    if len(body) > _MAX_TEXT_LENGTH:
+        truncated_at = _MAX_TEXT_LENGTH - len(_TRUNCATION_MARKER)
+        body = body[:truncated_at] + _TRUNCATION_MARKER
+    return body
+
+
+class ZaloBotChannel(BaseChannel):
+    """Worker-only single-delivery channel for Zalo Bot Platform."""
+
+    channel_name = "zalo_bot"
+
+    async def execute_delivery(
+        self,
+        delivery: "NotificationDelivery",
+        db: "AsyncSession",
+    ) -> ChannelResult:
+        from app.gateways.zalo_bot import zalo_bot_gateway
+        from app.repositories.staff_zalo_bot_link_repository import (
+            StaffZaloBotLinkRepository,
+        )
+
+        if not delivery.user_id:
+            # zalo_bot does not target external recipients; the rule
+            # validator should have rejected this upstream. Treat as
+            # permanent so we don't retry forever.
+            log.warning(
+                "zalo_bot delivery without user_id",
+                delivery_id=delivery.id,
+            )
+            return ChannelResult(
+                success=False,
+                sent_count=0,
+                failed_ids=[],
+                error_message="no_zalo_bot_link",  # routes to PERMANENT_ERRORS
+                delivery_id=delivery.id,
+            )
+
+        repo = StaffZaloBotLinkRepository(db)
+        link = await repo.get_active_by_user_id(delivery.user_id)
+        if not link:
+            # No active link OR link was deactivated — staff is opted
+            # out. Permanent until they re-link.
+            log.info(
+                "zalo_bot delivery skipped — no active link",
+                delivery_id=delivery.id,
+                user_id=delivery.user_id,
+            )
+            return ChannelResult(
+                success=False,
+                sent_count=0,
+                failed_ids=[delivery.user_id],
+                error_message="no_zalo_bot_link",
+                delivery_id=delivery.id,
+            )
+
+        snapshot = delivery.payload_snapshot or {}
+        text = _format_text(snapshot)
+        if not text:
+            log.warning(
+                "zalo_bot delivery skipped — empty text body",
+                delivery_id=delivery.id,
+            )
+            return ChannelResult(
+                success=False,
+                sent_count=0,
+                failed_ids=[delivery.user_id],
+                error_message="empty_text",
+                delivery_id=delivery.id,
+            )
+
+        result = await zalo_bot_gateway.send_message(link.chat_id, text)
+
+        # Logging: never echo the message body — it may carry PII via
+        # template substitution. Mask the chat_id like the link service
+        # does so log scraping doesn't leak the binding.
+        chat_prefix = (link.chat_id[:8] + "***") if link.chat_id else ""
+
+        if result.success:
+            log.info(
+                "zalo_bot delivery sent",
+                delivery_id=delivery.id,
+                user_id=delivery.user_id,
+                chat_id_prefix=chat_prefix,
+                msg_id=result.message_id,
+                text_len=len(text),
+            )
+            return ChannelResult(
+                success=True,
+                sent_count=1,
+                failed_ids=[],
+                delivery_id=delivery.id,
+                provider_message_id=result.message_id,
+            )
+
+        log.warning(
+            "zalo_bot delivery failed",
+            delivery_id=delivery.id,
+            user_id=delivery.user_id,
+            chat_id_prefix=chat_prefix,
+            error_code=result.error_code,
+            # Gateway already sanitised error_message — no token leak.
+            error_message=result.error_message,
+        )
+        return ChannelResult(
+            success=False,
+            sent_count=0,
+            failed_ids=[delivery.user_id],
+            # Tag with channel prefix so PERMANENT_ERRORS can match
+            # specific Zalo Bot codes if/when classification is added.
+            error_message=f"Zalo Bot error {result.error_code}: {result.error_message}",
+            delivery_id=delivery.id,
+        )
+
+    async def send(
+        self,
+        notifications: List[Any],
+        recipient_ids: List[int],
+        context: Dict[str, Any],
+    ) -> ChannelResult:
+        """zalo_bot is worker-only — batch ``send`` always errors."""
+        return ChannelResult(
+            success=False,
+            sent_count=0,
+            failed_ids=recipient_ids,
+            error_message=(
+                "zalo_bot channel uses execute_delivery() via worker, "
+                "not batch send()"
+            ),
+        )
+
+    def validate_config(self, config: Dict[str, Any]) -> bool:
+        """zalo_bot needs no per-action config — the link record carries
+        the routing target. Empty/missing config is valid; presence of
+        ``external_resolver`` is rejected upstream by the rule
+        validator (Step 16) since this channel is internal-only.
+        """
+        return True

--- a/Backend_FastAPI/app/services/notification_circuit_breaker.py
+++ b/Backend_FastAPI/app/services/notification_circuit_breaker.py
@@ -19,7 +19,7 @@ _BREAKER_REDIS_KEY = "notif:breaker:{channel}"
 _BREAKER_REDIS_TTL = 600  # 10 min TTL
 
 # Canonical channels
-_CANONICAL_CHANNELS = ("browser", "email", "zalo", "sms")
+_CANONICAL_CHANNELS = ("browser", "email", "zalo", "zalo_bot", "sms")
 
 # In-memory fail counters (per worker process, fast path)
 _fail_counters: Dict[str, int] = {}

--- a/Backend_FastAPI/app/services/notification_preference_service.py
+++ b/Backend_FastAPI/app/services/notification_preference_service.py
@@ -121,6 +121,7 @@ async def should_send_notification(
         "allow_sound": sound_allowed and not in_quiet_hours,
         "allow_browser": preference.browser_enabled and not in_quiet_hours,
         "allow_zalo": getattr(preference, "zalo_enabled", False) and not in_quiet_hours,
+        "allow_zalo_bot": getattr(preference, "zalo_bot_enabled", False) and not in_quiet_hours,
         "in_quiet_hours": in_quiet_hours,
     }
 
@@ -131,16 +132,33 @@ def get_group_preference(
     channel: str
 ) -> bool:
     """
-    Get the preference setting for a specific group and channel.
+    Resolve per-group/per-channel preference for a user.
+
+    Falls back to ``DEFAULT_GROUP_CHANNELS`` instead of hardcoded ``True`` so that
+    a freshly-onboarded channel (e.g. ``zalo_bot``) without per-group user prefs
+    inherits the safe-by-default disabled state shipped in the catalog. Unknown
+    group or channel fail-closed (``False``) to prevent silent broadcast leaks
+    from misconfigured callers.
     """
+    group_lower = group.lower()
+    channel_lower = channel.lower()
+
+    try:
+        group_enum = NotificationEventGroup(group_lower)
+        channel_enum = NotificationChannel(channel_lower)
+    except ValueError:
+        return False  # unknown group or channel → fail-closed
+
+    default = DEFAULT_GROUP_CHANNELS.get(group_enum, {}).get(channel_enum, False)
+
     if not type_preferences:
-        return True
+        return default
 
-    group_prefs = type_preferences.get(group.lower())
+    group_prefs = type_preferences.get(group_lower)
     if not group_prefs:
-        return True
+        return default
 
-    return group_prefs.get(channel.lower(), True)
+    return group_prefs.get(channel_lower, default)
 
 
 async def get_user_group_preferences(
@@ -252,6 +270,10 @@ async def filter_users_by_group(
         if channel_key == "email" and not pref.email_enabled:
             continue
         if channel_key == "zalo" and not getattr(pref, "zalo_enabled", False):
+            continue
+        if channel_key == "zalo_bot" and not getattr(pref, "zalo_bot_enabled", False):
+            # v5 Step 12: gate A for zalo_bot — only deliver to staff who
+            # explicitly linked their bot account via zalo_bot_link_service.
             continue
         if channel_key == "sound" and not pref.sound_enabled:
             continue

--- a/Backend_FastAPI/app/services/notification_quota_service.py
+++ b/Backend_FastAPI/app/services/notification_quota_service.py
@@ -194,7 +194,7 @@ async def get_health_summary(db: AsyncSession) -> Dict:
     quota_map = {q["channel"]: q for q in quota_summary}
 
     channels = []
-    for ch in ("browser", "email", "zalo", "sms"):
+    for ch in ("browser", "email", "zalo", "zalo_bot", "sms"):
         item: Dict = {"channel": ch, "breaker_state": breaker_map.get(ch, "closed")}
         if ch in quota_map:
             item["quota_used"] = quota_map[ch]["quota_used"]
@@ -218,6 +218,9 @@ def _get_channel_limit(channel: str) -> Optional[int]:
     """Get configured quota limit for a channel."""
     limits = {
         "zalo": settings.ZALO_DAILY_QUOTA_LIMIT,
+        # v5 Step 14: zalo_bot daily quota — defaults to 80 (20% margin
+        # under the Zalo Basic free tier 100/day ceiling).
+        "zalo_bot": settings.ZALO_BOT_DAILY_QUOTA,
     }
     return limits.get(channel)
 

--- a/Backend_FastAPI/app/services/notification_rule_crud_service.py
+++ b/Backend_FastAPI/app/services/notification_rule_crud_service.py
@@ -88,6 +88,17 @@ def _validate_actions(actions) -> None:
         config = action.config if hasattr(action, 'config') else action.get('config')
         if channel == "zalo":
             _validate_zalo_action_config(step, config)
+        elif channel == "zalo_bot":
+            # v5 Step 16: zalo_bot is internal-only — staff must already
+            # have linked their bot account, so any external_resolver
+            # config is meaningless and silently routes notifications
+            # nowhere. Reject loudly at rule creation time.
+            if config and isinstance(config, dict) and config.get("external_resolver"):
+                raise BadRequest(
+                    f"Action step {step}: channel 'zalo_bot' is internal-only and "
+                    "cannot be combined with an external_resolver. Use channel "
+                    "'zalo' (ZNS) for external recipients."
+                )
         elif config and isinstance(config, dict):
             # Validate external_resolver for any channel that has it
             ext_resolver = config.get("external_resolver")

--- a/Backend_FastAPI/app/services/zalo_bot_link_service.py
+++ b/Backend_FastAPI/app/services/zalo_bot_link_service.py
@@ -1,0 +1,191 @@
+"""Zalo Bot link service.
+
+Three flows:
+- ``generate_link_code(user_id)`` — produce a 6-char one-shot code stored
+  in Redis with TTL 600s. Idempotent per user: regenerating supersedes
+  any previous unconsumed code.
+- ``verify_and_link(code, chat_id, display_name)`` — atomically consume
+  the code and bind the chat_id to the user.
+- ``unlink(user_id)`` / ``unlink_by_chat_id(chat_id)`` — mark the link
+  inactive and flip the user's per-channel preference.
+
+Atomicity guarantees:
+- Code creation uses ``SET NX`` so colliding codes are rejected by Redis,
+  not by the application.
+- Code consumption uses ``GETDEL`` so two webhook deliveries racing on
+  the same code can't both succeed.
+- Both operations return early on Redis failure (``safe_redis_*`` helpers
+  shield via the circuit breaker).
+"""
+from __future__ import annotations
+
+import secrets
+import string
+from typing import Callable, Optional, Tuple
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.staff_zalo_bot_link_repository import (
+    StaffZaloBotLinkRepository,
+)
+from app.utils.exceptions import BusinessRuleViolation
+
+log = structlog.get_logger(__name__)
+
+# v5/E8: 10 minutes — staff hand off code through Zalo app, search bot,
+# add bot, and finally type ``/lienkiet <CODE>``. 5 min was too tight.
+LINK_CODE_TTL = 600
+LINK_CODE_PREFIX = "zalo_bot:link:"
+
+# Code alphabet excludes lowercase + ambiguous chars implicitly because
+# Zalo chat clients display fixed-width fonts inconsistently. 36^6 ≈
+# 2.1B combinations — collision probability per generation is negligible
+# but the SET NX retry below covers the pathological case.
+_CODE_ALPHABET = string.ascii_uppercase + string.digits
+_CODE_LENGTH = 6
+_GEN_RETRIES = 5
+
+
+def _user_pointer_key(user_id: int) -> str:
+    """Per-user reverse pointer so regenerate can revoke the old code.
+
+    Stored alongside the code itself; both expire on TTL even if the
+    pointer revoke step is skipped (e.g. process crash mid-flow).
+    """
+    return f"{LINK_CODE_PREFIX}user:{user_id}"
+
+
+def _code_key(code: str) -> str:
+    return f"{LINK_CODE_PREFIX}{code}"
+
+
+async def generate_link_code(
+    db: AsyncSession, user_id: int
+) -> Tuple[str, Optional[Callable]]:
+    """Generate a fresh link code for ``user_id``.
+
+    Side effects:
+    - Deletes any previous unconsumed code for the same user.
+    - Inserts the new code with ``SET NX EX``; retries up to 5 times on
+      collision before raising.
+
+    Returns ``(code, post_commit_callback)``. The callback is a no-op
+    that just emits a structured log line — the router pattern still
+    calls it after ``db.commit()`` for symmetry with other services.
+    """
+    from app.database import (
+        safe_redis_delete,
+        safe_redis_get,
+        safe_redis_set,
+    )
+
+    pointer_key = _user_pointer_key(user_id)
+    prev_code = await safe_redis_get(pointer_key)
+    if prev_code:
+        # v5/E1 — kill the previous code so a stale screenshot can't be
+        # used to hijack the new binding window.
+        await safe_redis_delete(_code_key(prev_code))
+
+    for _ in range(_GEN_RETRIES):
+        code = "".join(secrets.choice(_CODE_ALPHABET) for _ in range(_CODE_LENGTH))
+        created = await safe_redis_set(
+            _code_key(code), str(user_id), ex=LINK_CODE_TTL, nx=True
+        )
+        if created:
+            await safe_redis_set(pointer_key, code, ex=LINK_CODE_TTL)
+
+            async def _post_commit() -> None:
+                log.info("Zalo Bot link code generated", user_id=user_id)
+
+            return code, _post_commit
+
+    # 5 collisions in a row on a 36^6 keyspace — effectively impossible
+    # unless Redis is corrupted or under attack.
+    log.error("Zalo Bot link code generation exhausted retries", user_id=user_id)
+    raise BusinessRuleViolation("Không tạo được mã liên kết. Vui lòng thử lại.")
+
+
+async def verify_and_link(
+    db: AsyncSession,
+    code: str,
+    chat_id: str,
+    display_name: Optional[str] = None,
+) -> Tuple[bool, str]:
+    """Consume a link code and bind ``chat_id`` to the resolved user."""
+    from app.database import safe_redis_getdel
+
+    user_id_str = await safe_redis_getdel(_code_key(code.upper()))
+    if not user_id_str:
+        return False, "Ma lien ket khong hop le hoac da het han."
+
+    user_id = int(user_id_str)
+    repo = StaffZaloBotLinkRepository(db)
+
+    # Steal the chat_id from any other active user it was bound to.
+    # Without this an attacker could keep one chat_id wired to a victim
+    # by linking it first, then abandoning the binding.
+    existing_chat = await repo.get_active_by_chat_id(chat_id)
+    if existing_chat and existing_chat.user_id != user_id:
+        existing_chat.is_active = False
+        await db.flush()
+
+    await repo.create_or_reactivate(user_id, chat_id, display_name)
+    await _sync_preference(db, user_id, enabled=True)
+
+    log.info(
+        "Zalo Bot linked",
+        user_id=user_id,
+        chat_id_prefix=chat_id[:8] + "***" if chat_id else "",
+    )
+    return True, "Lien ket thanh cong! Ban se nhan thong bao tu QLTS qua Zalo."
+
+
+async def unlink(db: AsyncSession, user_id: int) -> Tuple[bool, str]:
+    """Mark the link inactive and flip per-channel preference off."""
+    repo = StaffZaloBotLinkRepository(db)
+    found = await repo.deactivate_by_user_id(user_id)
+    if not found:
+        return False, "Tai khoan chua duoc lien ket."
+    await _sync_preference(db, user_id, enabled=False)
+    return True, "Da huy lien ket."
+
+
+async def unlink_by_chat_id(db: AsyncSession, chat_id: str) -> Tuple[bool, str]:
+    repo = StaffZaloBotLinkRepository(db)
+    link = await repo.get_active_by_chat_id(chat_id)
+    if not link:
+        return False, "Tai khoan chua duoc lien ket."
+    return await unlink(db, link.user_id)
+
+
+async def get_link_status(db: AsyncSession, user_id: int) -> Optional[dict]:
+    repo = StaffZaloBotLinkRepository(db)
+    link = await repo.get_by_user_id(user_id)
+    if not link:
+        return None
+    return {
+        "is_linked": link.is_active,
+        "display_name": link.display_name,
+        "linked_at": link.linked_at.isoformat() if link.linked_at else None,
+    }
+
+
+async def _sync_preference(
+    db: AsyncSession, user_id: int, enabled: bool
+) -> None:
+    """Flip ``zalo_bot_enabled`` on the user's preference row.
+
+    The column lands in v5 Step 11; once present, this MUST persist or
+    the link operation is a lie (UI shows linked, dispatcher Gate A
+    still blocks). DB errors here are surfaced — the router commits
+    after this returns, so a flush failure rolls back the whole link.
+    """
+    from app.repositories.notification_preference_repository import (
+        NotificationPreferenceRepository,
+    )
+
+    repo = NotificationPreferenceRepository(db)
+    pref = await repo.get_or_create(user_id)
+    pref.zalo_bot_enabled = enabled
+    await db.flush()

--- a/Backend_FastAPI/app/tasks/delivery_tasks.py
+++ b/Backend_FastAPI/app/tasks/delivery_tasks.py
@@ -36,11 +36,14 @@ PERMANENT_ERRORS = frozenset({
     "invalid_phone",
     "channel_not_implemented",
     "execute_delivery_not_supported",
-    # Zalo permanent errors
+    # Zalo ZNS permanent errors
     "Zalo error -216",   # Template không tồn tại
     "Zalo error -230",   # SĐT không dùng Zalo
     "Zalo error -202",   # App không có quyền
     "Zalo error -204",   # OA bị khoá
+    # v5 Step 13: Zalo Bot permanent errors — link missing / staff opted out
+    "no_zalo_bot_link",
+    "empty_text",
 })
 # -217 (template chưa duyệt) = TRANSIENT — template có thể được duyệt sau
 # -210 (quota hết) = TRANSIENT — quota reset theo ngày
@@ -142,9 +145,16 @@ def execute_notification_delivery(self, delivery_id: int):
                 return {"status": "skipped", "reason": skip_reason, "delivery_id": delivery_id}
 
             # 4b. Check quota (D1) — external channels, fail fast
-            if delivery.channel in ("zalo", "sms"):
+            if delivery.channel in ("zalo", "zalo_bot", "sms"):
                 from app.services import notification_quota_service
-                quota_provider = "zalo_zns" if delivery.channel == "zalo" else "default"
+                # v5 Step 13: zalo_bot quota is per-bot, not per-template
+                # like ZNS, so it uses provider="zalo_bot" to keep the
+                # quota row separate from ZNS.
+                quota_provider = (
+                    "zalo_zns" if delivery.channel == "zalo"
+                    else "zalo_bot" if delivery.channel == "zalo_bot"
+                    else "default"
+                )
                 quota_ok = await notification_quota_service.check_quota(
                     session, delivery.channel, provider=quota_provider
                 )
@@ -247,9 +257,13 @@ def execute_notification_delivery(self, delivery_id: int):
                     await session.flush()
 
                 # D1: Record send for quota tracking
-                if delivery.channel in ("zalo", "sms"):
+                if delivery.channel in ("zalo", "zalo_bot", "sms"):
                     from app.services import notification_quota_service
-                    quota_provider = "zalo_zns" if delivery.channel == "zalo" else "default"
+                    quota_provider = (
+                        "zalo_zns" if delivery.channel == "zalo"
+                        else "zalo_bot" if delivery.channel == "zalo_bot"
+                        else "default"
+                    )
                     await notification_quota_service.record_send(
                         session, delivery.channel, provider=quota_provider
                     )
@@ -427,7 +441,7 @@ def reconcile_stale_deliveries(self):
                 # 1. Queued stale: external channels stuck >30min
                 stale_queued = await repo.find_stale_deliveries(
                     status="queued",
-                    channels=["email", "zalo", "sms"],
+                    channels=["email", "zalo", "zalo_bot", "sms"],
                     max_age_minutes=30,
                     limit=50,
                 )
@@ -445,9 +459,12 @@ def reconcile_stale_deliveries(self):
                 # 2. Sent stale: external channels sent >60min without webhook confirm
                 #    Age by sent_at (not created_at) — delivery may have been
                 #    created long before it was actually sent.
+                #    v5 Step 13: zalo_bot does not webhook delivery confirmation
+                #    (only command/text events), so its sent rows must also be
+                #    aged-up here to avoid the "stuck sent forever" state.
                 stale_sent = await repo.find_stale_deliveries(
                     status="sent",
-                    channels=["zalo", "sms"],
+                    channels=["zalo", "zalo_bot", "sms"],
                     max_age_minutes=60,
                     limit=50,
                     age_column="sent_at",
@@ -528,6 +545,23 @@ def sync_notification_quotas(self):
                         period="daily",
                         period_start=today,
                         quota_limit=settings.ZALO_DAILY_QUOTA_LIMIT,
+                    )
+                    synced += 1
+                    await session.commit()
+
+                # v5 Step 13: ensure zalo_bot quota row when ENABLED.
+                # Skipped while the channel is gated off so we don't
+                # accumulate empty rows for an unused channel.
+                zalo_bot_quota = await repo.get_current_quota(
+                    "zalo_bot", "zalo_bot", "daily", today,
+                )
+                if zalo_bot_quota is None and settings.ZALO_BOT_ENABLED:
+                    await repo.upsert_quota(
+                        channel="zalo_bot",
+                        provider="zalo_bot",
+                        period="daily",
+                        period_start=today,
+                        quota_limit=settings.ZALO_BOT_DAILY_QUOTA,
                     )
                     synced += 1
                     await session.commit()

--- a/Backend_FastAPI/tests/api/test_notification_rule_crud.py
+++ b/Backend_FastAPI/tests/api/test_notification_rule_crud.py
@@ -80,6 +80,41 @@ class TestNotificationRuleCrudApi:
         assert isinstance(lead_assigned["allowed_resolvers"], list)
         assert "link_strategy" in lead_assigned
 
+        # v5 pre-work (Finding 2): every channel exposes ``internal_only``
+        # so the FE recipient picker can hide internal-only channels (e.g.
+        # zalo_bot when introduced) from external recipient groups without
+        # hardcoding channel names.
+        channel_values = {c["value"] for c in data["channels"]}
+        assert {"browser", "email", "zalo", "sms"} <= channel_values, (
+            "Existing channels must remain in metadata response (backward-compat)"
+        )
+        for ch in data["channels"]:
+            assert "internal_only" in ch, (
+                f"Channel {ch['value']} missing internal_only field — "
+                "FE relies on this to filter external recipient picker."
+            )
+            assert isinstance(ch["internal_only"], bool)
+        # Existing channels are NOT internal-only (browser/email/zalo/sms are
+        # all valid for external recipients in current product).
+        for ch in data["channels"]:
+            if ch["value"] in {"browser", "email", "zalo", "sms"}:
+                assert ch["internal_only"] is False, (
+                    f"{ch['value']} must default to internal_only=False; "
+                    "promoting an existing channel to internal-only is a breaking change."
+                )
+
+        # v5 Step 17: zalo_bot must be exposed AND marked internal_only=True
+        # so the FE recipient picker hides it from external recipient groups.
+        zalo_bot = next(
+            (c for c in data["channels"] if c["value"] == "zalo_bot"), None
+        )
+        assert zalo_bot is not None, "zalo_bot must appear in metadata channels"
+        assert zalo_bot["internal_only"] is True, (
+            "zalo_bot is staff-only; internal_only must be True"
+        )
+        # Status follows the env flag — in test it's typically off → "planned".
+        assert zalo_bot["status"] in {"live", "planned"}
+
     async def test_list_rules_returns_paginated(
         self, client: AsyncClient, admin_token_headers: dict,
     ):

--- a/Backend_FastAPI/tests/api/test_zalo_bot_link_api.py
+++ b/Backend_FastAPI/tests/api/test_zalo_bot_link_api.py
@@ -1,0 +1,168 @@
+"""Staff link API tests — Step 19.
+
+Authenticated endpoints under ``/api/zalo-bot``. Tests use the
+``officer_token_headers`` fixture to confirm the auth gate, and patch
+``zalo_bot_link_service`` + Redis helpers to drive the success and
+rate-limit paths without standing up real link state.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+class TestAuthRequired:
+    async def test_link_code_anonymous_blocked(self, client: AsyncClient):
+        resp = await client.post("/api/zalo-bot/link-code")
+        assert resp.status_code == 401
+
+    async def test_link_status_anonymous_blocked(self, client: AsyncClient):
+        resp = await client.get("/api/zalo-bot/link-status")
+        assert resp.status_code == 401
+
+    async def test_unlink_anonymous_blocked(self, client: AsyncClient):
+        resp = await client.post("/api/zalo-bot/unlink")
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestLinkCodeEndpoint:
+    async def test_returns_code_with_ttl_600(
+        self, client: AsyncClient, officer_token_headers: dict
+    ):
+        async def fake_incr(key, amount=1):
+            return 1
+
+        async def fake_expire(key, seconds):
+            return True
+
+        cb = AsyncMock()
+        with patch(
+            "app.services.zalo_bot_link_service.generate_link_code",
+            new=AsyncMock(return_value=("ABC123", cb)),
+        ), patch(
+            "app.routers.zalo_bot_link.safe_redis_incr",
+            new=AsyncMock(side_effect=fake_incr),
+        ), patch(
+            "app.routers.zalo_bot_link.safe_redis_expire",
+            new=AsyncMock(side_effect=fake_expire),
+        ):
+            resp = await client.post(
+                "/api/zalo-bot/link-code", headers=officer_token_headers
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["code"] == "ABC123"
+        assert body["expires_in_seconds"] == 600
+        assert "ABC123" in body["instructions"]
+        cb.assert_awaited_once()
+
+    async def test_sixth_request_in_window_rate_limited(
+        self, client: AsyncClient, officer_token_headers: dict
+    ):
+        counters = {}
+
+        async def fake_incr(key, amount=1):
+            counters[key] = counters.get(key, 0) + amount
+            return counters[key]
+
+        async def fake_expire(key, seconds):
+            return True
+
+        cb = AsyncMock()
+        gen_mock = AsyncMock(return_value=("CODE12", cb))
+
+        with patch(
+            "app.services.zalo_bot_link_service.generate_link_code", new=gen_mock
+        ), patch(
+            "app.routers.zalo_bot_link.safe_redis_incr",
+            new=AsyncMock(side_effect=fake_incr),
+        ), patch(
+            "app.routers.zalo_bot_link.safe_redis_expire",
+            new=AsyncMock(side_effect=fake_expire),
+        ):
+            for i in range(5):
+                resp = await client.post(
+                    "/api/zalo-bot/link-code", headers=officer_token_headers
+                )
+                assert resp.status_code == 200, f"request {i + 1} should pass"
+
+            resp = await client.post(
+                "/api/zalo-bot/link-code", headers=officer_token_headers
+            )
+            assert resp.status_code == 400
+            assert "Quá nhiều" in resp.json()["detail"]
+
+        # Generator must NOT have been called for the throttled call.
+        assert gen_mock.await_count == 5
+
+
+@pytest.mark.asyncio
+class TestLinkStatusEndpoint:
+    async def test_returns_unlinked_shape_when_no_record(
+        self, client: AsyncClient, officer_token_headers: dict
+    ):
+        with patch(
+            "app.services.zalo_bot_link_service.get_link_status",
+            new=AsyncMock(return_value=None),
+        ):
+            resp = await client.get(
+                "/api/zalo-bot/link-status", headers=officer_token_headers
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {"is_linked": False, "display_name": None, "linked_at": None}
+
+    async def test_returns_linked_payload_from_service(
+        self, client: AsyncClient, officer_token_headers: dict
+    ):
+        payload = {
+            "is_linked": True,
+            "display_name": "Officer A",
+            "linked_at": "2026-04-26T10:00:00+00:00",
+        }
+        with patch(
+            "app.services.zalo_bot_link_service.get_link_status",
+            new=AsyncMock(return_value=payload),
+        ):
+            resp = await client.get(
+                "/api/zalo-bot/link-status", headers=officer_token_headers
+            )
+        assert resp.status_code == 200
+        assert resp.json() == payload
+
+
+@pytest.mark.asyncio
+class TestUnlinkEndpoint:
+    async def test_unlink_success_calls_service(
+        self, client: AsyncClient, officer_token_headers: dict
+    ):
+        with patch(
+            "app.services.zalo_bot_link_service.unlink",
+            new=AsyncMock(return_value=(True, "Đã huỷ liên kết.")),
+        ) as svc:
+            resp = await client.post(
+                "/api/zalo-bot/unlink", headers=officer_token_headers
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["unlinked"] is True
+        assert body["message"] == "Đã huỷ liên kết."
+        svc.assert_awaited_once()
+
+    async def test_unlink_when_not_linked_idempotent(
+        self, client: AsyncClient, officer_token_headers: dict
+    ):
+        with patch(
+            "app.services.zalo_bot_link_service.unlink",
+            new=AsyncMock(return_value=(False, "Tài khoản chưa được liên kết.")),
+        ):
+            resp = await client.post(
+                "/api/zalo-bot/unlink", headers=officer_token_headers
+            )
+        assert resp.status_code == 200
+        assert resp.json()["unlinked"] is False

--- a/Backend_FastAPI/tests/api/test_zalo_bot_webhooks.py
+++ b/Backend_FastAPI/tests/api/test_zalo_bot_webhooks.py
@@ -1,0 +1,306 @@
+"""Webhook router tests — Step 18.
+
+Auth is a shared secret in ``X-Bot-Api-Secret-Token`` headers, set via
+``settings.ZALO_BOT_WEBHOOK_SECRET``. The test patches the gateway and
+``zalo_bot_link_service`` so we can drive the router branches without
+hitting real Zalo / Redis link state.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.config import settings
+
+
+SECRET = "test-webhook-secret-xyz"
+
+
+def _payload(text: str, chat_id: str = "chat_alpha_xxxxxxxx") -> dict:
+    return {
+        "result": {
+            "event_name": "message.text.received",
+            "message": {
+                "chat": {"id": chat_id},
+                "text": text,
+                "from": {"display_name": "Officer A"},
+            },
+        }
+    }
+
+
+@pytest.fixture
+def gateway_mock():
+    gateway = AsyncMock()
+    gateway.send_message = AsyncMock()
+    with patch("app.gateways.zalo_bot.zalo_bot_gateway", gateway):
+        yield gateway
+
+
+@pytest.fixture
+def link_service_mock():
+    """Replace zalo_bot_link_service functions inside the router module."""
+    with patch(
+        "app.services.zalo_bot_link_service.verify_and_link",
+        new=AsyncMock(),
+    ) as verify, patch(
+        "app.services.zalo_bot_link_service.unlink_by_chat_id",
+        new=AsyncMock(),
+    ) as unlink:
+        yield verify, unlink
+
+
+@pytest.fixture
+def configured_secret(monkeypatch):
+    monkeypatch.setattr(settings, "ZALO_BOT_WEBHOOK_SECRET", SECRET)
+    yield SECRET
+
+
+@pytest.mark.asyncio
+class TestSecretGuard:
+    async def test_missing_secret_header_returns_401(
+        self, client: AsyncClient, configured_secret, gateway_mock
+    ):
+        resp = await client.post("/api/webhooks/zalo-bot", json=_payload("/trangthai"))
+        assert resp.status_code == 401
+
+    async def test_wrong_secret_returns_401(
+        self, client: AsyncClient, configured_secret, gateway_mock
+    ):
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("/trangthai"),
+            headers={"X-Bot-Api-Secret-Token": "wrong"},
+        )
+        assert resp.status_code == 401
+
+    async def test_empty_configured_secret_fails_closed(
+        self, client: AsyncClient, monkeypatch, gateway_mock
+    ):
+        # Empty configured secret → fail-closed even if attacker presents
+        # an empty string (which would otherwise pass compare_digest).
+        monkeypatch.setattr(settings, "ZALO_BOT_WEBHOOK_SECRET", "")
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("/trangthai"),
+            headers={"X-Bot-Api-Secret-Token": ""},
+        )
+        assert resp.status_code == 401
+
+    async def test_correct_secret_lets_request_through(
+        self, client: AsyncClient, configured_secret, gateway_mock
+    ):
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("/trangthai"),
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+class TestPayloadShape:
+    async def test_invalid_json_returns_400(
+        self, client: AsyncClient, configured_secret, gateway_mock
+    ):
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            content=b"not-json",
+            headers={
+                "X-Bot-Api-Secret-Token": SECRET,
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status_code == 400
+
+    async def test_non_text_event_ignored_with_200(
+        self, client: AsyncClient, configured_secret, gateway_mock
+    ):
+        body = {
+            "result": {
+                "event_name": "follow",
+                "message": {"chat": {"id": "x"}, "text": "ignored"},
+            }
+        }
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=body,
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "ignored_event"
+        gateway_mock.send_message.assert_not_awaited()
+
+    async def test_empty_chat_or_text_noop(
+        self, client: AsyncClient, configured_secret, gateway_mock
+    ):
+        body = {
+            "result": {
+                "event_name": "message.text.received",
+                "message": {"chat": {"id": ""}, "text": "x"},
+            }
+        }
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=body,
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "noop"
+
+
+@pytest.mark.asyncio
+class TestLienKietCommand:
+    async def test_valid_code_calls_service_and_replies(
+        self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
+    ):
+        verify, _ = link_service_mock
+        verify.return_value = (True, "Liên kết thành công!")
+
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("/lienkiet ABC123"),
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok", "mode": "verify_and_link", "linked": True}
+        verify.assert_awaited_once()
+        # Reply was forwarded to the user.
+        gateway_mock.send_message.assert_awaited()
+        sent_args = gateway_mock.send_message.await_args.args
+        assert sent_args[1] == "Liên kết thành công!"
+
+    async def test_invalid_format_does_not_call_service(
+        self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
+    ):
+        verify, _ = link_service_mock
+        # Lowercase + 3 chars — does not match [A-Z0-9]{6}.
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("/lienkiet abc"),
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "bad_format"
+        verify.assert_not_awaited()
+        gateway_mock.send_message.assert_awaited()
+
+    async def test_service_error_rollback_generic_reply(
+        self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
+    ):
+        verify, _ = link_service_mock
+        verify.side_effect = RuntimeError("boom")
+
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("/lienkiet ABC123"),
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        # 200 so Zalo doesn't retry and double-consume the code.
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "service_error"
+        # Reply must be generic — no stack trace, no "boom".
+        sent_text = gateway_mock.send_message.await_args.args[1]
+        assert "boom" not in sent_text
+        assert "RuntimeError" not in sent_text
+        assert "Lỗi hệ thống" in sent_text
+
+
+@pytest.mark.asyncio
+class TestUnlinkCommand:
+    async def test_huylienkiet_calls_service(
+        self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
+    ):
+        _, unlink = link_service_mock
+        unlink.return_value = (True, "Đã huỷ liên kết.")
+
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("/huylienkiet"),
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "unlink"
+        unlink.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestStatusCommand:
+    async def test_trangthai_does_not_leak_user_id(
+        self, client: AsyncClient, configured_secret, gateway_mock
+    ):
+        # No active link → should reply "Chưa liên kết." with no other detail.
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("/trangthai", chat_id="chat_unlinked_zzz"),
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["linked"] is False
+        sent_text = gateway_mock.send_message.await_args.args[1]
+        # Reply must not contain user_id or any number that could be one.
+        assert "user_id" not in sent_text.lower()
+        assert sent_text == "Chưa liên kết."
+
+
+@pytest.mark.asyncio
+class TestUnknownCommand:
+    async def test_help_text_for_unknown(
+        self, client: AsyncClient, configured_secret, gateway_mock
+    ):
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("hello bot"),
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "help"
+        sent_text = gateway_mock.send_message.await_args.args[1]
+        assert "/lienkiet" in sent_text
+        assert "/huylienkiet" in sent_text
+        assert "/trangthai" in sent_text
+
+
+@pytest.mark.asyncio
+class TestRateLimit:
+    async def test_eleventh_command_per_minute_rate_limited(
+        self, client: AsyncClient, configured_secret, gateway_mock
+    ):
+        # Patch the symbols imported into the router module — patching
+        # ``app.database`` would not redirect the router's local binding.
+        counters = {}
+
+        async def fake_incr(key, amount=1):
+            counters[key] = counters.get(key, 0) + amount
+            return counters[key]
+
+        async def fake_expire(key, seconds):
+            return True
+
+        with patch(
+            "app.routers.zalo_bot_webhooks.safe_redis_incr",
+            new=AsyncMock(side_effect=fake_incr),
+        ), patch(
+            "app.routers.zalo_bot_webhooks.safe_redis_expire",
+            new=AsyncMock(side_effect=fake_expire),
+        ):
+            chat = "chat_burst_xxx"
+            # 10 commands pass.
+            for _ in range(10):
+                resp = await client.post(
+                    "/api/webhooks/zalo-bot",
+                    json=_payload("/trangthai", chat_id=chat),
+                    headers={"X-Bot-Api-Secret-Token": SECRET},
+                )
+                assert resp.status_code == 200
+                assert resp.json().get("mode") != "rate_limited"
+            # 11th is throttled.
+            resp = await client.post(
+                "/api/webhooks/zalo-bot",
+                json=_payload("/trangthai", chat_id=chat),
+                headers={"X-Bot-Api-Secret-Token": SECRET},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["status"] == "rate_limited"

--- a/Backend_FastAPI/tests/integration/test_notification_core_v2.py
+++ b/Backend_FastAPI/tests/integration/test_notification_core_v2.py
@@ -114,7 +114,14 @@ class TestPerChannelPreferenceFiltering:
     async def test_zalo_enabled_passes_filter(
         self, db: AsyncSession, officer_user_in_db: dict
     ):
-        """zalo_enabled=True → user passes zalo channel filter."""
+        """zalo_enabled=True + per-group zalo opt-in → user passes filter.
+
+        v5 Finding 1: ``get_group_preference`` now falls back to
+        ``DEFAULT_GROUP_CHANNELS`` (ZALO=False everywhere) instead of
+        hardcoded True. Passing the filter now requires BOTH the global
+        zalo_enabled toggle AND an explicit per-group opt-in — matching
+        what the UI surfaces and preventing silent broadcasts.
+        """
         user_id = officer_user_in_db["id"]
 
         pref = models.NotificationPreference(
@@ -122,13 +129,14 @@ class TestPerChannelPreferenceFiltering:
             browser_enabled=True,
             email_enabled=True,
             zalo_enabled=True,
+            type_preferences={"lead": {"zalo": True}},
         )
         db.add(pref)
         await db.commit()
 
         zalo_result = await filter_users_by_group(db, [user_id], "lead", "zalo")
 
-        assert zalo_result == [user_id], "Zalo should pass when zalo_enabled=True"
+        assert zalo_result == [user_id], "Zalo should pass when zalo_enabled=True + per-group opt-in"
 
     async def test_mixed_users_per_channel(
         self, db: AsyncSession, officer_user_in_db: dict, admin_user_in_db: dict
@@ -136,8 +144,12 @@ class TestPerChannelPreferenceFiltering:
         """
         Two users with different preferences:
         - Officer: browser=True, email=False, zalo=False
-        - Admin: browser=False, email=True, zalo=True
+        - Admin: browser=False, email=True, zalo=True (with per-group opt-in)
+
         Each channel should only include eligible users.
+
+        v5 Finding 1: zalo now requires explicit per-group opt-in via
+        ``type_preferences`` because ``DEFAULT_GROUP_CHANNELS[LEAD][ZALO]=False``.
         """
         officer_id = officer_user_in_db["id"]
         admin_id = admin_user_in_db["id"]
@@ -153,6 +165,7 @@ class TestPerChannelPreferenceFiltering:
             browser_enabled=False,
             email_enabled=True,
             zalo_enabled=True,
+            type_preferences={"lead": {"zalo": True}},
         )
         db.add_all([p1, p2])
         await db.commit()
@@ -165,7 +178,7 @@ class TestPerChannelPreferenceFiltering:
 
         assert browser_result == [officer_id], "Only officer has browser enabled"
         assert email_result == [admin_id], "Only admin has email enabled"
-        assert zalo_result == [admin_id], "Only admin has zalo enabled"
+        assert zalo_result == [admin_id], "Only admin has zalo enabled (with per-group opt-in)"
 
     async def test_should_send_notification_includes_allow_zalo(
         self, db: AsyncSession, officer_user_in_db: dict

--- a/Backend_FastAPI/tests/repositories/test_staff_zalo_bot_link_repo.py
+++ b/Backend_FastAPI/tests/repositories/test_staff_zalo_bot_link_repo.py
@@ -1,0 +1,87 @@
+"""Repository happy-path tests for ``StaffZaloBotLinkRepository``.
+
+The schema is created via ``Base.metadata.create_all()`` in the test
+fixture, so registering ``StaffZaloBotLink`` in ``app.models.__init__``
+is enough — no migration required for these tests.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.staff_zalo_bot_link_repository import (
+    StaffZaloBotLinkRepository,
+)
+
+
+@pytest.mark.integration
+class TestStaffZaloBotLinkRepository:
+    @pytest.mark.asyncio
+    async def test_create_then_lookup_by_user_and_chat(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        repo = StaffZaloBotLinkRepository(db)
+
+        link = await repo.create_or_reactivate(
+            user_id=user_id, chat_id="chat_alpha", display_name="Officer A"
+        )
+        await db.commit()
+
+        assert link.id is not None
+        assert link.is_active is True
+        assert link.chat_id == "chat_alpha"
+
+        by_user = await repo.get_active_by_user_id(user_id)
+        assert by_user is not None and by_user.id == link.id
+
+        by_chat = await repo.get_active_by_chat_id("chat_alpha")
+        assert by_chat is not None and by_chat.id == link.id
+
+    @pytest.mark.asyncio
+    async def test_create_or_reactivate_reuses_row(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        """Second call must NOT INSERT a second row — same row, fresh chat_id."""
+        user_id = officer_user_in_db["id"]
+        repo = StaffZaloBotLinkRepository(db)
+
+        first = await repo.create_or_reactivate(user_id, "chat_first", "Name")
+        await db.commit()
+        first_id = first.id
+
+        # Simulate user re-linking with a different phone/chat_id
+        second = await repo.create_or_reactivate(user_id, "chat_second", "Name 2")
+        await db.commit()
+
+        assert second.id == first_id, "user_id is unique — must reuse the row"
+        assert second.chat_id == "chat_second"
+        assert second.display_name == "Name 2"
+        assert second.is_active is True
+
+    @pytest.mark.asyncio
+    async def test_deactivate_then_reactivate(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        repo = StaffZaloBotLinkRepository(db)
+
+        await repo.create_or_reactivate(user_id, "chat_x", None)
+        await db.commit()
+
+        ok = await repo.deactivate_by_user_id(user_id)
+        await db.commit()
+        assert ok is True
+
+        # Calling deactivate twice is a no-op (row already inactive).
+        ok_again = await repo.deactivate_by_user_id(user_id)
+        assert ok_again is False, "must only return True on a state transition"
+
+        # Inactive row is hidden from the active-only finder.
+        assert await repo.get_active_by_user_id(user_id) is None
+
+        # Re-link reuses the same row and flips is_active back on.
+        revived = await repo.create_or_reactivate(user_id, "chat_y", "Display")
+        await db.commit()
+        assert revived.is_active is True
+        assert revived.chat_id == "chat_y"

--- a/Backend_FastAPI/tests/repositories/test_zalo_bot_preference_sync.py
+++ b/Backend_FastAPI/tests/repositories/test_zalo_bot_preference_sync.py
@@ -1,0 +1,146 @@
+"""Integration tests for v5 Step 12 — link service ↔ preference sync.
+
+Verify that ``zalo_bot_link_service.verify_and_link`` and
+``unlink`` actually persist ``zalo_bot_enabled`` after the column
+landed in Step 11. Pre-v5 the link service swallowed errors via
+``hasattr`` to allow the column to land later — that guard is now
+removed and persistence is mandatory.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification_preference import NotificationPreference
+from app.services import zalo_bot_link_service
+from app.services.notification_preference_service import (
+    filter_users_by_group,
+    get_group_preference,
+)
+
+
+@pytest.mark.integration
+class TestPreferenceSyncOnLink:
+    @pytest.mark.asyncio
+    async def test_verify_and_link_flips_pref_true(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        # GETDEL returns the user_id our code stored in Redis — patched
+        # because we never touched Redis here, just the link flow.
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            ok, _ = await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_alpha", "Officer A"
+            )
+        assert ok is True
+        await db.commit()
+
+        pref = (
+            await db.execute(
+                select(NotificationPreference).where(
+                    NotificationPreference.user_id == user_id
+                )
+            )
+        ).scalar_one()
+        assert pref.zalo_bot_enabled is True
+
+    @pytest.mark.asyncio
+    async def test_unlink_flips_pref_false(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_alpha", None
+            )
+        await db.commit()
+
+        ok, _ = await zalo_bot_link_service.unlink(db, user_id)
+        assert ok is True
+        await db.commit()
+
+        pref = (
+            await db.execute(
+                select(NotificationPreference).where(
+                    NotificationPreference.user_id == user_id
+                )
+            )
+        ).scalar_one()
+        assert pref.zalo_bot_enabled is False
+
+
+@pytest.mark.integration
+class TestFilterUsersByGroupZaloBot:
+    @pytest.mark.asyncio
+    async def test_global_disabled_blocks(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        # Default zalo_bot_enabled is False even when the row exists.
+        pref = NotificationPreference(user_id=user_id, browser_enabled=True)
+        db.add(pref)
+        await db.commit()
+
+        result = await filter_users_by_group(db, [user_id], "lead", "zalo_bot")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_global_enabled_plus_group_optin_passes(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        pref = NotificationPreference(
+            user_id=user_id,
+            browser_enabled=True,
+            zalo_bot_enabled=True,
+            type_preferences={"lead": {"zalo_bot": True}},
+        )
+        db.add(pref)
+        await db.commit()
+
+        result = await filter_users_by_group(db, [user_id], "lead", "zalo_bot")
+        assert result == [user_id]
+
+    @pytest.mark.asyncio
+    async def test_global_enabled_without_group_optin_still_blocked(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        # v5 Finding 1 + Step 12: even with global toggle on, missing
+        # per-group entry falls back to DEFAULT_GROUP_CHANNELS which is
+        # False for zalo_bot in every group.
+        user_id = officer_user_in_db["id"]
+        pref = NotificationPreference(
+            user_id=user_id,
+            browser_enabled=True,
+            zalo_bot_enabled=True,
+            type_preferences=None,
+        )
+        db.add(pref)
+        await db.commit()
+
+        result = await filter_users_by_group(db, [user_id], "lead", "zalo_bot")
+        assert result == []
+
+
+@pytest.mark.unit
+class TestDefaultGroupPrefForZaloBotIsFalse:
+    """Pure-logic check that complements the contract test in
+    ``test_zalo_bot_phase4_contracts.py`` — exercises the resolver
+    function for every group rather than the static dict."""
+
+    def test_every_group_zalo_bot_default_false(self):
+        from app.core.event_groups import DEFAULT_GROUP_CHANNELS
+
+        for group in DEFAULT_GROUP_CHANNELS.keys():
+            assert (
+                get_group_preference(None, group.value, "zalo_bot") is False
+            ), f"{group.value} default for zalo_bot must be False"

--- a/Backend_FastAPI/tests/services/test_notification_preference.py
+++ b/Backend_FastAPI/tests/services/test_notification_preference.py
@@ -25,22 +25,68 @@ class TestNotificationPreferenceService:
     # =========================================================================
 
     def test_get_group_preference_logic(self):
-        """Test the pure logic of group preference resolution."""
-        # Default should be True
+        """Pure logic of group preference resolution.
+
+        v5: fallback now reads DEFAULT_GROUP_CHANNELS instead of hardcoded True
+        so new channels onboard fail-closed by default. Existing channels keep
+        their established default per the catalog.
+        """
+        # No prefs → fallback to DEFAULT_GROUP_CHANNELS[LEAD][BROWSER] = True
         assert get_group_preference(None, "lead", "browser") is True
         assert get_group_preference({}, "lead", "browser") is True
-        
+
         # Specific overrides
         prefs = {"lead": {"browser": False, "email": True}}
         assert get_group_preference(prefs, "lead", "browser") is False
         assert get_group_preference(prefs, "lead", "email") is True
-        
+
         # Case insensitivity
         assert get_group_preference(prefs, "LEAD", "BROWSER") is False
-        
-        # Missing group/channel defaults to True
+
+        # Missing group → fallback to default (FINANCE.BROWSER=True per catalog)
         assert get_group_preference(prefs, "finance", "browser") is True
-        assert get_group_preference(prefs, "lead", "sms") is True
+
+        # Missing channel within group → fallback to catalog default
+        # LEAD.SMS=False per DEFAULT_GROUP_CHANNELS — was True in pre-v5
+        assert get_group_preference(prefs, "lead", "sms") is False
+
+    def test_get_group_preference_unknown_fail_closed(self):
+        """Unknown group or channel must fail-closed (False) — v5 Finding 1."""
+        # Unknown group
+        assert get_group_preference(None, "nonexistent_group", "browser") is False
+        # Unknown channel
+        assert get_group_preference(None, "lead", "nonexistent_channel") is False
+        # Both unknown
+        assert get_group_preference(None, "foo", "bar") is False
+        # Even with explicit prefs, unknown channel still fail-closed
+        prefs = {"lead": {"browser": True}}
+        assert get_group_preference(prefs, "lead", "made_up_channel") is False
+
+    def test_get_group_preference_default_per_channel(self):
+        """Default fallback honours DEFAULT_GROUP_CHANNELS per (group, channel).
+
+        Locks in catalog values so a future plan rewriting the catalog won't
+        silently flip user-facing behaviour.
+        """
+        # ZALO defaults: False for every group in DEFAULT_GROUP_CHANNELS
+        assert get_group_preference(None, "lead", "zalo") is False
+        assert get_group_preference(None, "finance", "zalo") is False
+        assert get_group_preference(None, "system", "zalo") is False
+
+        # SMS defaults: False for every group
+        assert get_group_preference(None, "lead", "sms") is False
+        assert get_group_preference(None, "application", "sms") is False
+
+        # BROWSER defaults: True for every group in catalog
+        assert get_group_preference(None, "lead", "browser") is True
+        assert get_group_preference(None, "consultation", "browser") is True
+        assert get_group_preference(None, "application", "browser") is True
+
+        # EMAIL defaults vary: True for LEAD/APPLICATION/FINANCE/SYSTEM/SECURITY/CTV,
+        # False for CONSULTATION/DORM/ASSET/PIPELINE
+        assert get_group_preference(None, "lead", "email") is True
+        assert get_group_preference(None, "consultation", "email") is False
+        assert get_group_preference(None, "dorm", "email") is False
 
     # =========================================================================
     # FILTER USERS BY GROUP (DATABASE INTEGRATION)

--- a/Backend_FastAPI/tests/unit/test_zalo_bot_channel.py
+++ b/Backend_FastAPI/tests/unit/test_zalo_bot_channel.py
@@ -1,0 +1,169 @@
+"""Unit tests for ``ZaloBotChannel`` (Step 8).
+
+The channel is worker-only — these tests exercise ``execute_delivery``
+with a mocked gateway and a stubbed repository so the focus is the
+contract:
+- Missing/inactive link → permanent ``no_zalo_bot_link`` error.
+- Active link + gateway success → ``ChannelResult.success=True``
+  carries the provider message id.
+- Gateway failure → ``error_message`` prefixed with ``Zalo Bot error``
+  for downstream classification.
+- Body formatting truncates at 2000 chars and merges title + message.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.notification_channels.zalo_bot_channel import (
+    ZaloBotChannel,
+    _MAX_TEXT_LENGTH,
+    _format_text,
+)
+from app.gateways.zalo_bot import ZaloBotSendResult
+
+
+def _delivery(
+    *,
+    delivery_id: int = 1,
+    user_id: int | None = 42,
+    payload: dict | None = None,
+):
+    return SimpleNamespace(
+        id=delivery_id,
+        user_id=user_id,
+        payload_snapshot=payload or {"title": "Hi", "message": "Body"},
+    )
+
+
+@pytest.mark.unit
+class TestFormatText:
+    def test_merges_title_and_message_with_blank_line(self):
+        body = _format_text({"title": "T", "message": "M"})
+        assert body == "T\n\nM"
+
+    def test_falls_back_to_message_only(self):
+        body = _format_text({"title": "", "message": "Only message"})
+        assert body == "Only message"
+
+    def test_falls_back_to_title_only(self):
+        body = _format_text({"title": "Only title", "message": ""})
+        assert body == "Only title"
+
+    def test_truncates_at_max_length(self):
+        body = _format_text({"title": "", "message": "x" * (_MAX_TEXT_LENGTH + 50)})
+        assert len(body) == _MAX_TEXT_LENGTH
+        assert body.endswith("…")
+
+    def test_at_limit_passes_through(self):
+        body = _format_text({"title": "", "message": "x" * _MAX_TEXT_LENGTH})
+        assert body == "x" * _MAX_TEXT_LENGTH
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestExecuteDelivery:
+    async def test_no_user_id_is_permanent(self):
+        ch = ZaloBotChannel()
+        result = await ch.execute_delivery(_delivery(user_id=None), db=AsyncMock())
+        assert result.success is False
+        assert result.error_message == "no_zalo_bot_link"
+
+    async def test_no_active_link_is_permanent(self):
+        repo = MagicMock()
+        repo.get_active_by_user_id = AsyncMock(return_value=None)
+        with patch(
+            "app.repositories.staff_zalo_bot_link_repository.StaffZaloBotLinkRepository",
+            return_value=repo,
+        ):
+            ch = ZaloBotChannel()
+            result = await ch.execute_delivery(_delivery(), db=AsyncMock())
+        assert result.success is False
+        assert result.error_message == "no_zalo_bot_link"
+        assert result.failed_ids == [42]
+
+    async def test_active_link_happy_path(self):
+        link = SimpleNamespace(chat_id="chat_alpha_xxxxxxxx", user_id=42)
+        repo = MagicMock()
+        repo.get_active_by_user_id = AsyncMock(return_value=link)
+
+        gateway = MagicMock()
+        gateway.send_message = AsyncMock(
+            return_value=ZaloBotSendResult(success=True, message_id="m-007")
+        )
+
+        with patch(
+            "app.repositories.staff_zalo_bot_link_repository.StaffZaloBotLinkRepository",
+            return_value=repo,
+        ), patch("app.gateways.zalo_bot.zalo_bot_gateway", gateway):
+            ch = ZaloBotChannel()
+            result = await ch.execute_delivery(_delivery(), db=AsyncMock())
+
+        assert result.success is True
+        assert result.sent_count == 1
+        assert result.provider_message_id == "m-007"
+        gateway.send_message.assert_awaited_once()
+        sent_chat_id, sent_text = gateway.send_message.await_args.args
+        assert sent_chat_id == "chat_alpha_xxxxxxxx"
+        assert sent_text == "Hi\n\nBody"
+
+    async def test_gateway_failure_maps_to_error_message(self):
+        link = SimpleNamespace(chat_id="chat_x", user_id=42)
+        repo = MagicMock()
+        repo.get_active_by_user_id = AsyncMock(return_value=link)
+
+        gateway = MagicMock()
+        gateway.send_message = AsyncMock(
+            return_value=ZaloBotSendResult(
+                success=False, error_code=429, error_message="rate limited"
+            )
+        )
+
+        with patch(
+            "app.repositories.staff_zalo_bot_link_repository.StaffZaloBotLinkRepository",
+            return_value=repo,
+        ), patch("app.gateways.zalo_bot.zalo_bot_gateway", gateway):
+            ch = ZaloBotChannel()
+            result = await ch.execute_delivery(_delivery(), db=AsyncMock())
+
+        assert result.success is False
+        assert "Zalo Bot error 429" in result.error_message
+        assert "rate limited" in result.error_message
+        assert result.failed_ids == [42]
+
+    async def test_empty_text_is_permanent(self):
+        link = SimpleNamespace(chat_id="chat_x", user_id=42)
+        repo = MagicMock()
+        repo.get_active_by_user_id = AsyncMock(return_value=link)
+
+        with patch(
+            "app.repositories.staff_zalo_bot_link_repository.StaffZaloBotLinkRepository",
+            return_value=repo,
+        ):
+            ch = ZaloBotChannel()
+            result = await ch.execute_delivery(
+                _delivery(payload={"title": "", "message": ""}), db=AsyncMock()
+            )
+
+        assert result.success is False
+        assert result.error_message == "empty_text"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSendBatch:
+    async def test_send_always_errors(self):
+        ch = ZaloBotChannel()
+        res = await ch.send([], [1, 2, 3], context={})
+        assert res.success is False
+        assert "execute_delivery" in res.error_message
+
+
+@pytest.mark.unit
+class TestValidateConfig:
+    def test_empty_config_is_valid(self):
+        """zalo_bot needs no per-action config — link record carries target."""
+        assert ZaloBotChannel().validate_config({}) is True
+        assert ZaloBotChannel().validate_config(None) is True

--- a/Backend_FastAPI/tests/unit/test_zalo_bot_gateway.py
+++ b/Backend_FastAPI/tests/unit/test_zalo_bot_gateway.py
@@ -1,0 +1,149 @@
+"""Unit tests for ``ZaloBotGateway``.
+
+The gateway is intentionally thin — these tests pin three contracts:
+1. ``send_message`` enforces the 1..2000 char text bound up-front.
+2. Errors never leak ``ZALO_BOT_TOKEN`` into log records or the result.
+3. The success/error result shape stays stable for downstream consumers.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.config import settings
+from app.gateways.zalo_bot import (
+    MAX_TEXT_LENGTH,
+    ZaloBotGateway,
+    ZaloBotSendResult,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSendMessageTextBounds:
+    async def test_empty_text_rejected_without_network(self):
+        gw = ZaloBotGateway()
+        with patch("httpx.AsyncClient") as m_client:
+            res = await gw.send_message("chat_x", "")
+        assert res.success is False
+        assert "length" in res.error_message.lower()
+        m_client.assert_not_called(), "must short-circuit before HTTP"
+
+    async def test_text_at_limit_is_accepted(self):
+        gw = ZaloBotGateway()
+        text = "x" * MAX_TEXT_LENGTH
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"ok": True, "result": {"message_id": "m1"}}
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("app.gateways.zalo_bot.httpx.AsyncClient", return_value=mock_client):
+            res = await gw.send_message("chat_x", text)
+
+        assert res.success is True
+        assert res.message_id == "m1"
+
+    async def test_text_over_limit_rejected_without_network(self):
+        gw = ZaloBotGateway()
+        with patch("httpx.AsyncClient") as m_client:
+            res = await gw.send_message("chat_x", "x" * (MAX_TEXT_LENGTH + 1))
+        assert res.success is False
+        m_client.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestTokenLeakage:
+    """The bot token is the credential — it MUST NOT appear in logs or
+    in the ``ZaloBotSendResult.error_message`` returned to the caller.
+    httpx's default ``str(exc)`` for transport errors embeds the request
+    URL, which embeds the token, hence these guards.
+    """
+
+    async def test_transport_error_does_not_leak_token_in_result(self, monkeypatch):
+        monkeypatch.setattr(settings, "ZALO_BOT_TOKEN", "super-secret-token-xyz")
+        gw = ZaloBotGateway()
+
+        # Simulate a transport-level error whose default repr would carry
+        # the request URL (and thus the token).
+        boom_url = (
+            "https://bot-api.zaloplatforms.com/botsuper-secret-token-xyz/sendMessage"
+        )
+
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.ConnectError(f"connect failed url={boom_url}")
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("app.gateways.zalo_bot.httpx.AsyncClient", return_value=mock_client):
+            res = await gw.send_message("chat_x", "hello")
+
+        assert res.success is False
+        assert "super-secret-token-xyz" not in res.error_message, (
+            "token must never appear in error_message — caller logs may surface this"
+        )
+        # Caller should still get a useful error category.
+        assert "ConnectError" in res.error_message
+
+    async def test_transport_error_does_not_leak_token_in_logs(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(settings, "ZALO_BOT_TOKEN", "tok-no-leak-please-789")
+        gw = ZaloBotGateway()
+
+        boom_url = (
+            "https://bot-api.zaloplatforms.com/bottok-no-leak-please-789/sendMessage"
+        )
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.ReadTimeout(f"timeout fetching {boom_url}")
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with caplog.at_level(logging.DEBUG), \
+             patch("app.gateways.zalo_bot.httpx.AsyncClient", return_value=mock_client):
+            await gw.send_message("chat_x", "hello")
+
+        joined = "\n".join(r.getMessage() for r in caplog.records)
+        # caplog also captures structlog through stdlib bridge; check both
+        # message body and any structured kwargs serialised into the record.
+        for r in caplog.records:
+            joined += " " + repr(getattr(r, "args", ""))
+            joined += " " + repr(r.__dict__)
+        assert "tok-no-leak-please-789" not in joined, (
+            "token must never appear in log records — gateway logs only error_type"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestApiResponseShape:
+    async def test_ok_false_carries_error_code_and_description(self):
+        gw = ZaloBotGateway()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "ok": False,
+            "error_code": 429,
+            "description": "rate limited",
+        }
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("app.gateways.zalo_bot.httpx.AsyncClient", return_value=mock_client):
+            res = await gw.send_message("chat_x", "hi")
+
+        assert isinstance(res, ZaloBotSendResult)
+        assert res.success is False
+        assert res.error_code == 429
+        assert res.error_message == "rate limited"

--- a/Backend_FastAPI/tests/unit/test_zalo_bot_link_service.py
+++ b/Backend_FastAPI/tests/unit/test_zalo_bot_link_service.py
@@ -1,0 +1,143 @@
+"""Unit tests for ``zalo_bot_link_service``.
+
+Redis interactions are mocked at the ``safe_redis_*`` boundary — the
+service is covered, the helpers themselves are exercised by their own
+integration tests against a live Redis.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import zalo_bot_link_service as svc
+from app.utils.exceptions import BusinessRuleViolation
+
+
+@pytest.mark.unit
+class TestLinkCodeTTL:
+    def test_ttl_is_ten_minutes(self):
+        """v5/E8: TTL must be 600 seconds — staff need real-world headroom."""
+        assert svc.LINK_CODE_TTL == 600
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestGenerateLinkCode:
+    async def test_happy_path_uses_nx(self):
+        """First SET NX succeeds → returns the generated code + post_commit cb."""
+        with patch("app.database.safe_redis_get", new=AsyncMock(return_value=None)) as m_get, \
+             patch("app.database.safe_redis_delete", new=AsyncMock()) as m_del, \
+             patch("app.database.safe_redis_set", new=AsyncMock(return_value=True)) as m_set:
+            code, cb = await svc.generate_link_code(db=None, user_id=42)
+
+        assert isinstance(code, str)
+        assert len(code) == 6
+        assert code.isalnum()
+        # First SET is the code itself with NX, second is the user pointer.
+        nx_calls = [c for c in m_set.call_args_list if c.kwargs.get("nx")]
+        assert len(nx_calls) == 1, "exactly one SET NX expected on success"
+        assert nx_calls[0].kwargs["ex"] == 600
+        # No previous pointer → no delete.
+        m_del.assert_not_awaited()
+        m_get.assert_awaited_once()
+        # Callback callable, no-op.
+        assert callable(cb)
+        await cb()
+
+    async def test_retries_on_nx_collision(self):
+        """Two SET NX collisions, third succeeds — service must keep trying."""
+        nx_results = [None, None, True]
+
+        async def fake_set(key, value, ex=None, nx=False):
+            if nx:
+                return nx_results.pop(0)
+            return True  # pointer write
+
+        with patch("app.database.safe_redis_get", new=AsyncMock(return_value=None)), \
+             patch("app.database.safe_redis_delete", new=AsyncMock()), \
+             patch("app.database.safe_redis_set", new=AsyncMock(side_effect=fake_set)):
+            code, _ = await svc.generate_link_code(db=None, user_id=7)
+
+        assert len(code) == 6, "service must surface the code from the third (winning) attempt"
+
+    async def test_exhausts_retries_raises(self):
+        """5 collisions → BusinessRuleViolation, never returns a partial code."""
+        with patch("app.database.safe_redis_get", new=AsyncMock(return_value=None)), \
+             patch("app.database.safe_redis_delete", new=AsyncMock()), \
+             patch("app.database.safe_redis_set", new=AsyncMock(return_value=None)) as m_set:
+            with pytest.raises(BusinessRuleViolation):
+                await svc.generate_link_code(db=None, user_id=99)
+
+        # 5 SET NX attempts, no pointer write.
+        nx_calls = [c for c in m_set.call_args_list if c.kwargs.get("nx")]
+        assert len(nx_calls) == 5
+
+    async def test_regenerate_deletes_previous_code(self):
+        """Existing pointer → service deletes old code key before generating new."""
+        with patch("app.database.safe_redis_get", new=AsyncMock(return_value="OLDCOD")) as m_get, \
+             patch("app.database.safe_redis_delete", new=AsyncMock()) as m_del, \
+             patch("app.database.safe_redis_set", new=AsyncMock(return_value=True)):
+            await svc.generate_link_code(db=None, user_id=42)
+
+        m_get.assert_awaited_once()
+        m_del.assert_awaited_once()
+        deleted_key = m_del.await_args.args[0]
+        assert deleted_key == f"{svc.LINK_CODE_PREFIX}OLDCOD", (
+            "must delete the *code* key, not the pointer key — pointer is overwritten by SET"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestVerifyAndLink:
+    async def test_consume_is_atomic_second_use_fails(self):
+        """First verify succeeds, second on the same code returns failure."""
+        # Simulate: first GETDEL returns user_id, second returns None.
+        getdel_mock = AsyncMock(side_effect=["42", None])
+        # Repo writes are stubbed via patching — we don't need a real DB
+        # for this contract-level test; the goal is to prove the service
+        # hands off to GETDEL exactly once per attempt and treats the
+        # absence of a value as a failure.
+        repo_mock = AsyncMock()
+        repo_mock.get_active_by_chat_id = AsyncMock(return_value=None)
+        repo_mock.create_or_reactivate = AsyncMock()
+
+        with patch("app.database.safe_redis_getdel", new=getdel_mock), \
+             patch.object(svc, "StaffZaloBotLinkRepository", return_value=repo_mock), \
+             patch.object(svc, "_sync_preference", new=AsyncMock()):
+            db_mock = AsyncMock()
+            ok1, _ = await svc.verify_and_link(db_mock, "ABC123", "chat_xyz")
+            ok2, msg2 = await svc.verify_and_link(db_mock, "ABC123", "chat_xyz")
+
+        assert ok1 is True, "first consume must succeed when GETDEL returns the user_id"
+        assert ok2 is False, "second consume on the same code must fail"
+        assert "khong hop le" in msg2.lower() or "het han" in msg2.lower()
+        assert getdel_mock.await_count == 2
+
+    async def test_invalid_code_returns_failure_no_db_writes(self):
+        """GETDEL miss → no repository touch."""
+        getdel_mock = AsyncMock(return_value=None)
+        repo_mock = AsyncMock()
+
+        with patch("app.database.safe_redis_getdel", new=getdel_mock), \
+             patch.object(svc, "StaffZaloBotLinkRepository", return_value=repo_mock):
+            ok, _ = await svc.verify_and_link(AsyncMock(), "BADCOD", "chat_x")
+
+        assert ok is False
+        repo_mock.create_or_reactivate.assert_not_awaited()
+
+    async def test_code_is_uppercased_before_lookup(self):
+        """User typing ``/lienkiet abc123`` (lowercase) must still hit the key."""
+        getdel_mock = AsyncMock(return_value="42")
+        repo_mock = AsyncMock()
+        repo_mock.get_active_by_chat_id = AsyncMock(return_value=None)
+        repo_mock.create_or_reactivate = AsyncMock()
+
+        with patch("app.database.safe_redis_getdel", new=getdel_mock), \
+             patch.object(svc, "StaffZaloBotLinkRepository", return_value=repo_mock), \
+             patch.object(svc, "_sync_preference", new=AsyncMock()):
+            await svc.verify_and_link(AsyncMock(), "abc123", "chat_x")
+
+        looked_up_key = getdel_mock.await_args.args[0]
+        assert looked_up_key == f"{svc.LINK_CODE_PREFIX}ABC123"

--- a/Backend_FastAPI/tests/unit/test_zalo_bot_phase4_contracts.py
+++ b/Backend_FastAPI/tests/unit/test_zalo_bot_phase4_contracts.py
@@ -1,0 +1,124 @@
+"""Contract tests for v5 Step 10/11/15/16 wiring.
+
+These are pure-Python unit tests — no DB, no Redis. They lock the
+following invariants so they cannot drift silently:
+
+- ``NotificationChannel.ZALO_BOT`` exists with value ``"zalo_bot"``.
+- ``DEFAULT_GROUP_CHANNELS`` ships ``ZALO_BOT=False`` for every group.
+- ``CANONICAL_CHANNELS`` (registry) and breaker ``_CANONICAL_CHANNELS``
+  both include ``"zalo_bot"``.
+- The Pydantic ``NotificationPreferenceUpdate`` schema deliberately
+  does **not** expose ``zalo_bot_enabled`` so generic clients cannot
+  flip the flag without going through the link service.
+- Rule CRUD validation rejects ``channel="zalo_bot"`` combined with
+  ``external_resolver`` (Step 16).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.event_groups import (
+    DEFAULT_GROUP_CHANNELS,
+    NotificationChannel,
+)
+from app.schemas.notification_preference import (
+    NotificationPreferenceBase,
+    NotificationPreferenceUpdate,
+)
+from app.services.notification_channels import CANONICAL_CHANNELS
+from app.services.notification_circuit_breaker import _CANONICAL_CHANNELS
+from app.services.notification_rule_crud_service import _validate_actions
+from app.utils.exceptions import BadRequest
+
+
+@pytest.mark.unit
+class TestEnumAndDefaults:
+    def test_enum_has_zalo_bot(self):
+        assert NotificationChannel.ZALO_BOT.value == "zalo_bot"
+
+    def test_every_group_defaults_zalo_bot_false(self):
+        # ORGANIZATION is intentionally excluded from DEFAULT_GROUP_CHANNELS;
+        # everything else must ship ZALO_BOT=False so a link record alone
+        # never starts firing notifications for arbitrary groups.
+        assert len(DEFAULT_GROUP_CHANNELS) > 0
+        for group, channels in DEFAULT_GROUP_CHANNELS.items():
+            assert NotificationChannel.ZALO_BOT in channels, (
+                f"{group} missing ZALO_BOT default — fail-closed contract broken"
+            )
+            assert channels[NotificationChannel.ZALO_BOT] is False, (
+                f"{group} ships ZALO_BOT=True — must opt in per group"
+            )
+
+
+@pytest.mark.unit
+class TestCanonicalChannelRegistration:
+    def test_registry_canonical_includes_zalo_bot(self):
+        assert "zalo_bot" in CANONICAL_CHANNELS
+
+    def test_breaker_canonical_includes_zalo_bot(self):
+        assert "zalo_bot" in _CANONICAL_CHANNELS
+
+
+@pytest.mark.unit
+class TestPreferenceSchemaSurface:
+    def test_base_exposes_zalo_bot_enabled(self):
+        # Reading user prefs must reflect the flag — UI surfaces the
+        # link state via this field even when the user is unlinked
+        # (then ``False``).
+        fields = NotificationPreferenceBase.model_fields
+        assert "zalo_bot_enabled" in fields
+        assert fields["zalo_bot_enabled"].annotation is bool
+        assert fields["zalo_bot_enabled"].default is False
+
+    def test_update_schema_does_not_expose_zalo_bot_enabled(self):
+        # Writes must go through zalo_bot_link_service so we can keep
+        # the link table in sync. If a client could PATCH the preference
+        # directly, dispatch would fire to a chat_id we don't know.
+        assert "zalo_bot_enabled" not in NotificationPreferenceUpdate.model_fields, (
+            "NotificationPreferenceUpdate must NOT accept zalo_bot_enabled — "
+            "only zalo_bot_link_service may flip this column"
+        )
+
+
+def _action(*, step: int, channel: str, config=None):
+    return SimpleNamespace(
+        step=step,
+        channel=channel,
+        delay_minutes=0,
+        config=config,
+        content_mode=None,
+        template_code=None,
+        content_override=None,
+        branch_key=None,
+    )
+
+
+@pytest.mark.unit
+class TestRuleValidationStep16:
+    def test_zalo_bot_with_external_resolver_rejected(self):
+        actions = [
+            _action(
+                step=1,
+                channel="zalo_bot",
+                config={"external_resolver": "lead_contact"},
+            )
+        ]
+        with pytest.raises(BadRequest) as exc_info:
+            _validate_actions(actions)
+        msg = str(exc_info.value)
+        assert "zalo_bot" in msg
+        assert "internal-only" in msg.lower()
+
+    def test_zalo_bot_internal_action_passes(self):
+        # No external_resolver in config → internal recipient action,
+        # which is exactly the supported case.
+        actions = [_action(step=1, channel="zalo_bot", config=None)]
+        _validate_actions(actions)  # must not raise
+
+        actions = [_action(step=1, channel="zalo_bot", config={})]
+        _validate_actions(actions)
+
+        actions = [_action(step=1, channel="zalo_bot", config={"foo": "bar"})]
+        _validate_actions(actions)

--- a/frontend/src/app/(dashboard)/settings/notifications/_components/NotificationSettingsClient.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/notifications/_components/NotificationSettingsClient.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * NotificationSettingsClient — v5 Step 22 settings UI tests.
+ *
+ * The screen pulls four hooks; we mock all of them to drive only the
+ * Zalo Bot section. Coverage focuses on the contract:
+ *   - "Generate" calls the hook and renders the code.
+ *   - Polling stops once is_linked flips true (UI swaps to "linked").
+ *   - "Unlink" calls the hook.
+ *   - The per-group zalo_bot toggle is disabled when zalo_bot_enabled
+ *     is false (i.e. the user has not linked yet) — and re-enabling
+ *     never sends zalo_bot_enabled in an update payload.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@/test/utils/test-utils";
+import userEvent from "@testing-library/user-event";
+
+import { NotificationSettingsClient } from "./NotificationSettingsClient";
+
+// ───────────────────────────────────────────────────────────────────
+// Hook mocks
+// ───────────────────────────────────────────────────────────────────
+
+const mockGenerate = vi.fn();
+const mockUnlink = vi.fn();
+const mockUpdatePref = vi.fn();
+const mockUpdateGroupPref = vi.fn();
+// Phase 6a fix: capture invalidateQueries calls so we can assert that
+// the link-transition effect invalidates the preferences scope.
+const mockInvalidateQueries = vi.fn();
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<
+    typeof import("@tanstack/react-query")
+  >("@tanstack/react-query");
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: mockInvalidateQueries,
+      // The settings UI only calls invalidateQueries on this client; if
+      // it ever needs more methods we'll fail loudly with `undefined is
+      // not a function` and add them deliberately.
+    }),
+  };
+});
+
+const linkStatusReturn: { current: { is_linked: boolean; display_name: string | null; linked_at: string | null } | undefined } = {
+  current: { is_linked: false, display_name: null, linked_at: null },
+};
+
+const preferencesReturn: { current: any } = {
+  current: {
+    id: 1,
+    user_id: 1,
+    email_enabled: true,
+    sound_enabled: true,
+    browser_enabled: true,
+    zalo_bot_enabled: false,
+    email_digest: "instant",
+    type_preferences: null,
+    quiet_hours_enabled: false,
+    quiet_hours_start: null,
+    quiet_hours_end: null,
+  },
+};
+
+vi.mock("@/hooks/useNotificationPreferences", () => ({
+  // The settings UI imports ``notificationPreferenceKeys.all`` to scope
+  // its cache invalidation. Mirror the real shape (a tagged tuple, not
+  // a plain string) so the assertion in tests matches what the hook
+  // module actually exports.
+  notificationPreferenceKeys: {
+    all: ["notificationPreferences"],
+    detail: () => ["notificationPreferences", "detail"],
+    eventGroups: () => ["notificationPreferences", "eventGroups"],
+  },
+  useNotificationPreferences: () => ({ data: preferencesReturn.current }),
+  useUpdateNotificationPreferences: () => ({
+    mutateAsync: mockUpdatePref,
+    isPending: false,
+  }),
+  useEventGroupPreferences: () => ({
+    data: {
+      groups: [
+        {
+          id: "lead",
+          name_en: "Lead",
+          name_vi: "Lead",
+          description_en: "",
+          description_vi: "",
+        },
+      ],
+      preferences: { lead: { browser: true, email: true, zalo_bot: false, sms: false } },
+    },
+  }),
+  useUpdateEventGroupPreference: () => ({
+    mutateAsync: mockUpdateGroupPref,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/useZaloBotLink", () => ({
+  useZaloBotLinkStatus: () => ({ data: linkStatusReturn.current }),
+  useGenerateLinkCode: () => ({ mutateAsync: mockGenerate, isPending: false }),
+  useUnlinkZaloBot: () => ({ mutateAsync: mockUnlink, isPending: false }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInvalidateQueries.mockClear();
+  // Reset state between tests.
+  linkStatusReturn.current = { is_linked: false, display_name: null, linked_at: null };
+  preferencesReturn.current = {
+    ...preferencesReturn.current,
+    zalo_bot_enabled: false,
+  };
+});
+
+describe("Zalo Bot section", () => {
+  it("shows generate button when not linked, calls hook, then renders code", async () => {
+    mockGenerate.mockResolvedValueOnce({
+      code: "ABC123",
+      expires_in_seconds: 600,
+      instructions: "Mở Zalo, tìm bot QLTS, gửi: /lienkiet ABC123",
+    });
+
+    render(<NotificationSettingsClient />);
+
+    const button = screen.getByTestId("zalo-bot-generate");
+    expect(button).toBeDefined();
+
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockGenerate).toHaveBeenCalled();
+    });
+
+    const codeNode = await screen.findByTestId("zalo-bot-code");
+    expect(codeNode.textContent).toBe("ABC123");
+    expect(screen.getByText(/Mở Zalo/)).toBeDefined();
+    // TTL hint is rendered (10 phút).
+    expect(screen.getByText(/10 phút/)).toBeDefined();
+  });
+
+  it("renders linked state and unlink button calls hook", async () => {
+    linkStatusReturn.current = {
+      is_linked: true,
+      display_name: "Officer A",
+      linked_at: "2026-04-26T10:00:00+00:00",
+    };
+    mockUnlink.mockResolvedValueOnce({ unlinked: true, message: "Đã huỷ liên kết." });
+
+    render(<NotificationSettingsClient />);
+
+    expect(screen.getByText("Đã liên kết")).toBeDefined();
+    expect(screen.getByText("Officer A")).toBeDefined();
+
+    await userEvent.click(screen.getByTestId("zalo-bot-unlink"));
+    await waitFor(() => expect(mockUnlink).toHaveBeenCalled());
+  });
+
+  it("hides the generated code once status flips linked (poll stop)", async () => {
+    // Initial render: generate code so the pending box is visible.
+    mockGenerate.mockResolvedValueOnce({
+      code: "ABC123",
+      expires_in_seconds: 600,
+      instructions: "instr",
+    });
+    const { rerender } = render(<NotificationSettingsClient />);
+    await userEvent.click(screen.getByTestId("zalo-bot-generate"));
+    await screen.findByTestId("zalo-bot-code");
+
+    // Simulate the polling query observing is_linked=true.
+    linkStatusReturn.current = {
+      is_linked: true,
+      display_name: "Officer A",
+      linked_at: "2026-04-26T10:00:00+00:00",
+    };
+    rerender(<NotificationSettingsClient />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("zalo-bot-code")).toBeNull();
+    });
+    expect(screen.getByText("Đã liên kết")).toBeDefined();
+  });
+
+  it("Phase 6a: invalidates notificationPreferences cache when link flips active", async () => {
+    // Generate code first so pendingCode is set — that's the precondition
+    // the effect looks at when distinguishing "user just linked" from
+    // "page loaded already linked".
+    mockGenerate.mockResolvedValueOnce({
+      code: "ABC123",
+      expires_in_seconds: 600,
+      instructions: "instr",
+    });
+    const { rerender } = render(<NotificationSettingsClient />);
+    await userEvent.click(screen.getByTestId("zalo-bot-generate"));
+    await screen.findByTestId("zalo-bot-code");
+
+    // Webhook fires server-side → polling sees is_linked=true.
+    linkStatusReturn.current = {
+      is_linked: true,
+      display_name: "Officer A",
+      linked_at: "2026-04-26T10:00:00+00:00",
+    };
+    rerender(<NotificationSettingsClient />);
+
+    // The fix: settings UI must invalidate the preferences scope so the
+    // per-group zalo_bot toggle observes ``zalo_bot_enabled=true`` on
+    // the next render — without this users had to hard-refresh.
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
+        queryKey: ["notificationPreferences"],
+      });
+    });
+  });
+});
+
+describe("Per-group zalo_bot column", () => {
+  it("disables zalo_bot toggle when zalo_bot_enabled is false", () => {
+    preferencesReturn.current = {
+      ...preferencesReturn.current,
+      zalo_bot_enabled: false,
+    };
+    render(<NotificationSettingsClient />);
+    const toggle = screen.getByTestId("zalo-bot-toggle-lead") as HTMLButtonElement;
+    expect(toggle.getAttribute("data-state")).toBe("unchecked");
+    // Radix Switch sets aria-disabled / disabled attribute.
+    expect(toggle.hasAttribute("disabled") || toggle.getAttribute("aria-disabled") === "true").toBe(true);
+  });
+
+  it("enables zalo_bot toggle when zalo_bot_enabled is true", () => {
+    preferencesReturn.current = {
+      ...preferencesReturn.current,
+      zalo_bot_enabled: true,
+    };
+    render(<NotificationSettingsClient />);
+    const toggle = screen.getByTestId("zalo-bot-toggle-lead") as HTMLButtonElement;
+    expect(toggle.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("save general settings never includes zalo_bot_enabled in payload", async () => {
+    mockUpdatePref.mockResolvedValueOnce({});
+    render(<NotificationSettingsClient />);
+
+    await userEvent.click(screen.getByRole("button", { name: /Lưu/ }));
+
+    await waitFor(() => expect(mockUpdatePref).toHaveBeenCalled());
+    const payload = mockUpdatePref.mock.calls[0][0];
+    expect(payload).not.toHaveProperty("zalo_bot_enabled");
+  });
+});

--- a/frontend/src/app/(dashboard)/settings/notifications/_components/NotificationSettingsClient.tsx
+++ b/frontend/src/app/(dashboard)/settings/notifications/_components/NotificationSettingsClient.tsx
@@ -2,7 +2,18 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { Bell, Save, Volume2, Smartphone, Mail, Monitor } from "lucide-react";
+import {
+  Bell,
+  Bot,
+  Copy,
+  Mail,
+  MessageCircle,
+  Monitor,
+  Save,
+  Smartphone,
+  Volume2,
+} from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -19,13 +30,23 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 import {
+  notificationPreferenceKeys,
   useNotificationPreferences,
   useUpdateNotificationPreferences,
   useEventGroupPreferences,
   useUpdateEventGroupPreference,
   type EventGroupPreferencesResponse,
 } from "@/hooks/useNotificationPreferences";
-import type { NotificationPreference, NotificationPreferenceUpdate } from "@/types/api.types";
+import {
+  useGenerateLinkCode,
+  useUnlinkZaloBot,
+  useZaloBotLinkStatus,
+} from "@/hooks/useZaloBotLink";
+import type {
+  NotificationPreference,
+  NotificationPreferenceUpdate,
+  ZaloBotLinkCode,
+} from "@/types/api.types";
 
 interface NotificationSettingsClientProps {
   initialPreferences?: NotificationPreference;
@@ -112,6 +133,66 @@ export function NotificationSettingsClient({
       toast.error("Lỗi khi cập nhật tuỳ chọn thông báo");
     }
   };
+
+  // ─────────────────────────────────────────────────────────────────
+  // v5 Step 22: Zalo Bot link section
+  // ─────────────────────────────────────────────────────────────────
+  const queryClient = useQueryClient();
+  const [pendingCode, setPendingCode] = useState<ZaloBotLinkCode | null>(null);
+  const { data: linkStatus } = useZaloBotLinkStatus({
+    pollWhileWaiting: !!pendingCode,
+  });
+  const generateLinkCode = useGenerateLinkCode();
+  const unlinkZaloBot = useUnlinkZaloBot();
+
+  // v5 Step 22 / Phase 6a fix: when the link flips active server-side
+  // (via the bot webhook, NOT through this component), only the
+  // ``linkStatus`` poll observes it. The ``zalo_bot_enabled`` column
+  // ships back via ``useNotificationPreferences``, whose cache stays
+  // stale until something invalidates it — leaving the per-group
+  // zalo_bot toggle disabled until a hard refresh.
+  // Invalidate the preferences scope here so the toggle becomes
+  // interactive within one render.
+  useEffect(() => {
+    if (linkStatus?.is_linked && pendingCode) {
+      setPendingCode(null);
+      queryClient.invalidateQueries({ queryKey: notificationPreferenceKeys.all });
+      toast.success("Đã liên kết Zalo Bot thành công!");
+    }
+  }, [linkStatus?.is_linked, pendingCode, queryClient]);
+
+  const handleGenerateLinkCode = async () => {
+    try {
+      const code = await generateLinkCode.mutateAsync();
+      setPendingCode(code);
+    } catch {
+      toast.error("Không tạo được mã liên kết. Vui lòng thử lại.");
+    }
+  };
+
+  const handleUnlinkZaloBot = async () => {
+    try {
+      const res = await unlinkZaloBot.mutateAsync();
+      setPendingCode(null);
+      if (res.unlinked) toast.success(res.message || "Đã huỷ liên kết.");
+      else toast.info(res.message || "Tài khoản chưa được liên kết.");
+    } catch {
+      toast.error("Không huỷ được liên kết. Vui lòng thử lại.");
+    }
+  };
+
+  const handleCopyCode = async (code: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+      toast.success("Đã sao chép mã.");
+    } catch {
+      // Clipboard may be denied (insecure context, browser policy).
+      toast.info(`Mã: ${code}`);
+    }
+  };
+
+  const isLinked = !!linkStatus?.is_linked;
+  const zaloBotEnabled = preferences?.zalo_bot_enabled ?? false;
 
   return (
     <div className="space-y-6">
@@ -277,6 +358,101 @@ export function NotificationSettingsClient({
         </CardContent>
       </Card>
 
+      {/* Zalo Bot Link (v5 Step 22) */}
+      <Card className="max-w-4xl" data-testid="zalo-bot-card">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Bot className="h-5 w-5" />
+            Liên kết Zalo Bot
+          </CardTitle>
+          <CardDescription>
+            Nhận thông báo nội bộ qua Zalo Bot. Liên kết một lần — bot sẽ chủ
+            động gửi tin về tài khoản Zalo của bạn.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isLinked ? (
+            <div className="flex items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <div className="flex items-center gap-2">
+                  <Badge variant="default">Đã liên kết</Badge>
+                  {linkStatus?.display_name && (
+                    <span className="text-sm font-medium">
+                      {linkStatus.display_name}
+                    </span>
+                  )}
+                </div>
+                {linkStatus?.linked_at && (
+                  <p className="text-xs text-muted-foreground">
+                    Liên kết từ:{" "}
+                    {new Date(linkStatus.linked_at).toLocaleString("vi-VN")}
+                  </p>
+                )}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleUnlinkZaloBot}
+                disabled={unlinkZaloBot.isPending}
+                data-testid="zalo-bot-unlink"
+              >
+                Huỷ liên kết
+              </Button>
+            </div>
+          ) : pendingCode ? (
+            <div className="space-y-3 rounded-lg border-2 border-dashed p-4">
+              <div className="flex items-center justify-between">
+                <Label className="text-sm font-medium">Mã liên kết</Label>
+                <Badge variant="secondary">
+                  Hết hạn sau{" "}
+                  {Math.round(pendingCode.expires_in_seconds / 60)} phút
+                </Badge>
+              </div>
+              <div className="flex items-center gap-2">
+                <code
+                  className="flex-1 rounded bg-muted px-4 py-3 text-2xl font-mono tracking-widest"
+                  data-testid="zalo-bot-code"
+                >
+                  {pendingCode.code}
+                </code>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleCopyCode(pendingCode.code)}
+                  aria-label="Sao chép mã"
+                >
+                  <Copy className="h-4 w-4" />
+                </Button>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {pendingCode.instructions}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Hệ thống sẽ tự động cập nhật khi bạn gửi mã vào Zalo Bot.
+              </p>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between rounded-lg border p-4">
+              <div className="space-y-0.5">
+                <p className="text-sm font-medium">Chưa liên kết</p>
+                <p className="text-xs text-muted-foreground">
+                  Bấm tạo mã để bắt đầu liên kết tài khoản Zalo.
+                </p>
+              </div>
+              <Button
+                size="sm"
+                onClick={handleGenerateLinkCode}
+                disabled={generateLinkCode.isPending}
+                data-testid="zalo-bot-generate"
+              >
+                <MessageCircle className="mr-2 h-4 w-4" />
+                Tạo mã liên kết
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       {/* Event Group Preferences (NEW) */}
       <Card className="max-w-4xl">
         <CardHeader>
@@ -286,8 +462,8 @@ export function NotificationSettingsClient({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {/* Header */}
-          <div className="grid grid-cols-4 gap-4 px-4 text-sm font-medium text-muted-foreground">
+          {/* Header — v5 Step 22: 5 columns now (added Zalo Bot) */}
+          <div className="grid grid-cols-5 gap-4 px-4 text-sm font-medium text-muted-foreground">
             <div>Danh mục</div>
             <div className="text-center flex items-center justify-center gap-1">
               <Monitor className="h-4 w-4" />
@@ -296,6 +472,10 @@ export function NotificationSettingsClient({
             <div className="text-center flex items-center justify-center gap-1">
               <Mail className="h-4 w-4" />
               Email
+            </div>
+            <div className="text-center flex items-center justify-center gap-1">
+              <Bot className="h-4 w-4" />
+              Zalo Bot
             </div>
             <div className="text-center flex items-center justify-center gap-1">
               <Smartphone className="h-4 w-4" />
@@ -310,13 +490,14 @@ export function NotificationSettingsClient({
             const prefs = eventGroupData.preferences[group.id] || {
               browser: true,
               email: true,
+              zalo_bot: false,
               sms: false,
             };
 
             return (
               <div
                 key={group.id}
-                className="grid grid-cols-4 gap-4 items-center px-4 py-3 rounded-lg hover:bg-muted/50 transition-colors"
+                className="grid grid-cols-5 gap-4 items-center px-4 py-3 rounded-lg hover:bg-muted/50 transition-colors"
               >
                 <div>
                   <div className="font-medium flex items-center gap-2">
@@ -351,6 +532,28 @@ export function NotificationSettingsClient({
                 </div>
                 <div className="flex justify-center">
                   <Switch
+                    checked={prefs.zalo_bot ?? false}
+                    onCheckedChange={(enabled) =>
+                      handleToggleGroupPreference(group.id, "zalo_bot", enabled)
+                    }
+                    // v5 Step 22: per-group toggle is dead unless the
+                    // user has both linked the bot AND backend reports
+                    // ``zalo_bot_enabled=true`` — same column the Gate A
+                    // filter checks. Tooltip surfaces the reason.
+                    disabled={
+                      !zaloBotEnabled
+                      || updateEventGroupPreference.isPending
+                    }
+                    data-testid={`zalo-bot-toggle-${group.id}`}
+                    aria-label={
+                      zaloBotEnabled
+                        ? `Zalo Bot — ${group.name_vi || group.name_en}`
+                        : "Zalo Bot — chưa liên kết"
+                    }
+                  />
+                </div>
+                <div className="flex justify-center">
+                  <Switch
                     checked={prefs.sms ?? false}
                     onCheckedChange={(enabled) =>
                       handleToggleGroupPreference(group.id, "sms", enabled)
@@ -365,7 +568,9 @@ export function NotificationSettingsClient({
           {/* Legend */}
           <div className="pt-4 border-t">
             <p className="text-xs text-muted-foreground">
-              * Thông báo trình duyệt hiển thị ở biểu tượng chuông. Thông báo Email được gửi đến email đã đăng ký. Tính năng SMS sắp ra mắt.
+              * Thông báo trình duyệt hiển thị ở biểu tượng chuông. Email được
+              gửi đến email đã đăng ký. Zalo Bot chỉ khả dụng sau khi liên kết
+              ở mục phía trên. Tính năng SMS sắp ra mắt.
             </p>
           </div>
         </CardContent>

--- a/frontend/src/components/admin/notifications/DeliveryOpsTable.test.tsx
+++ b/frontend/src/components/admin/notifications/DeliveryOpsTable.test.tsx
@@ -155,7 +155,8 @@ describe("DeliveryOpsTable", () => {
     expect(screen.getAllByText("Thất bại").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Đang chờ")).toBeDefined();
 
-    // Check channels
+    // Check channels — raw values remain lowercase except zalo_bot
+    // which gets the human-friendly "Zalo Bot" label (v5 Step 24).
     expect(screen.getAllByText("browser")).toHaveLength(2);
     expect(screen.getByText("email")).toBeDefined();
 
@@ -199,5 +200,57 @@ describe("DeliveryOpsTable", () => {
 
     render(<DeliveryOpsTable />, { wrapper: createWrapper() });
     expect(screen.getByText("3")).toBeDefined(); // total count
+  });
+
+  describe("v5 Step 24 — zalo_bot support", () => {
+    beforeEach(() => {
+      mockUseNotificationDeliveries.mockReturnValue({
+        data: {
+          total_count: 1,
+          deliveries: [
+            {
+              id: 99,
+              notification_id: 999,
+              user_id: 7,
+              channel: "zalo_bot",
+              status: "sent",
+              attempt_count: 1,
+              max_retries: 5,
+              created_at: "2026-04-26T10:00:00Z",
+              sent_at: "2026-04-26T10:00:01Z",
+              destination: null,
+              recipient_kind: "internal",
+              error_reason: null,
+              event: "lead_assigned",
+            },
+          ],
+        },
+        isLoading: false,
+        error: null,
+      } as unknown as ReturnType<typeof useNotificationDeliveries>);
+    });
+
+    it("renders Zalo Bot label for zalo_bot channel rows", () => {
+      render(<DeliveryOpsTable />, { wrapper: createWrapper() });
+      expect(screen.getByText("Zalo Bot")).toBeDefined();
+      // Raw "zalo_bot" should NOT leak into the cell — operators see
+      // the friendly label, not the technical value.
+      expect(screen.queryByText("zalo_bot")).toBeNull();
+    });
+
+    it("filter dropdown exposes zalo_bot option", () => {
+      render(<DeliveryOpsTable />, { wrapper: createWrapper() });
+      // Multiple comboboxes on the page (event/channel/status). The
+      // channel filter is the second one; click it to open the listbox.
+      const comboboxes = screen.getAllByRole("combobox");
+      const channelTrigger = comboboxes[1];
+      fireEvent.click(channelTrigger);
+      // After opening, the listbox option for Zalo Bot becomes visible.
+      // The friendly label is the only place "Zalo Bot" appears in this
+      // test harness (the row already shows it for the data, but the
+      // listbox option is rendered as a separate node).
+      const matches = screen.getAllByText("Zalo Bot");
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+    });
   });
 });

--- a/frontend/src/components/admin/notifications/DeliveryOpsTable.tsx
+++ b/frontend/src/components/admin/notifications/DeliveryOpsTable.tsx
@@ -8,6 +8,7 @@
 import { useState } from "react";
 import {
   AlertCircle,
+  Bot,
   Filter,
   Loader2,
   Mail,
@@ -74,7 +75,16 @@ const CHANNEL_ICON: Record<string, React.ReactNode> = {
   browser: <Monitor className="h-4 w-4" />,
   email: <Mail className="h-4 w-4" />,
   zalo: <MessageSquare className="h-4 w-4" />,
+  zalo_bot: <Bot className="h-4 w-4" />,
   sms: <Smartphone className="h-4 w-4" />,
+};
+
+// v5 Step 24: only override the display string for zalo_bot (raw value
+// "zalo_bot" is technical, "Zalo Bot" is what operators read in tickets).
+// Other channels keep their lowercase raw value so the existing test
+// surface stays stable.
+const CHANNEL_LABEL: Record<string, string> = {
+  zalo_bot: "Zalo Bot",
 };
 
 function formatDate(iso: string | null): string {
@@ -210,6 +220,7 @@ export default function DeliveryOpsTable({ initialData }: DeliveryOpsTableProps)
                 <SelectItem value="browser">Browser</SelectItem>
                 <SelectItem value="email">Email</SelectItem>
                 <SelectItem value="zalo">Zalo</SelectItem>
+                <SelectItem value="zalo_bot">Zalo Bot</SelectItem>
                 <SelectItem value="sms">SMS</SelectItem>
               </SelectContent>
             </Select>
@@ -315,7 +326,9 @@ export default function DeliveryOpsTable({ initialData }: DeliveryOpsTableProps)
                       <TableCell>
                         <div className="flex items-center gap-1.5">
                           {CHANNEL_ICON[d.channel]}
-                          <span className="text-sm">{d.channel}</span>
+                          <span className="text-sm">
+                            {CHANNEL_LABEL[d.channel] ?? d.channel}
+                          </span>
                         </div>
                       </TableCell>
                       <TableCell className="text-sm">

--- a/frontend/src/components/admin/notifications/NotificationRuleEditor.tsx
+++ b/frontend/src/components/admin/notifications/NotificationRuleEditor.tsx
@@ -268,13 +268,18 @@ export function NotificationRuleEditor({
       browser: { label: "Browser (Real-time)", description: "Hiển thị popup trong trình duyệt ngay lập tức" },
       email: { label: "Email", description: "Gửi email đến hộp thư của người dùng" },
       zalo: { label: "Zalo", description: "Gửi tin nhắn qua Zalo OA" },
+      // v5 Step 23: zalo_bot is staff-only — never offered in external pickers
+      // because the metadata response sets ``internal_only=true`` (verified
+      // by v5-pre-2 RecipientGroupCard filter).
+      zalo_bot: { label: "Zalo Bot", description: "Gửi tin nhắn nội bộ cho nhân viên qua Zalo Bot" },
       sms: { label: "SMS", description: "Gửi tin nhắn SMS" },
     };
     const fallback = [
-      { value: "browser", status: "live" as const },
-      { value: "email", status: "live" as const },
-      { value: "zalo", status: "live" as const },
-      { value: "sms", status: "planned" as const },
+      { value: "browser", status: "live" as const, internal_only: false },
+      { value: "email", status: "live" as const, internal_only: false },
+      { value: "zalo", status: "live" as const, internal_only: false },
+      { value: "zalo_bot", status: "planned" as const, internal_only: true },
+      { value: "sms", status: "planned" as const, internal_only: false },
     ];
     const channels = metadata?.channels || fallback;
     return channels.map((ch) => ({
@@ -282,6 +287,9 @@ export function NotificationRuleEditor({
       label: channelLabels[ch.value]?.label || ch.value,
       description: channelLabels[ch.value]?.description || "",
       status: ch.status,
+      // v5 pre-work: propagate internal_only so the recipient picker can
+      // hide internal-only channels (e.g. zalo_bot) from external groups.
+      internal_only: ch.internal_only ?? false,
     }));
   }, [metadata]);
 
@@ -716,7 +724,9 @@ export function NotificationRuleEditor({
                       onChange={setRecipientGroups}
                       resolverOptions={dynamicResolverTypes}
                       externalResolverOptions={metadata?.external_resolver_types ?? EXTERNAL_RESOLVER_FALLBACK}
-                      availableChannels={dynamicChannels.filter((c) => c.status === "live").map((c) => c.value)}
+                      availableChannels={dynamicChannels
+                        .filter((c) => c.status === "live")
+                        .map((c) => ({ value: c.value, status: c.status, internal_only: c.internal_only }))}
                       validationErrors={shouldShowStepErrors(3) ? stepErrors.step3 : undefined}
                       selectedEvent={selectedEvent}
                     />

--- a/frontend/src/components/admin/notifications/RecipientGroupCard.test.tsx
+++ b/frontend/src/components/admin/notifications/RecipientGroupCard.test.tsx
@@ -1,0 +1,115 @@
+// RecipientGroupCard.test.tsx — v5 pre-work: internal_only filter coverage
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/utils/test-utils";
+import RecipientGroupCard from "./RecipientGroupCard";
+import type { RecipientGroup } from "./wizard-types";
+import type { ChannelInfo, ResolverTypeOption } from "@/types/api.types";
+
+const RESOLVER_OPTIONS: ResolverTypeOption[] = [
+  { value: "lead_owner", label: "Officer phụ trách", description: "" },
+];
+
+const EXTERNAL_RESOLVER_OPTIONS = [
+  { value: "lead_contact", label: "Lead (Zalo)", description: "" },
+];
+
+function makeGroup(kind: "internal" | "external"): RecipientGroup {
+  return {
+    group_key: kind === "internal" ? "group_1" : "ext_1",
+    label: "Test",
+    recipient_kind: kind,
+    recipient_config:
+      kind === "internal" ? { resolver_type: "lead_owner", params: {} } : null,
+    external_resolver: kind === "external" ? "lead_contact" : null,
+    channels: [],
+  };
+}
+
+const CHANNELS_WITH_INTERNAL_ONLY: ChannelInfo[] = [
+  { value: "browser", status: "live", internal_only: false },
+  { value: "email", status: "live", internal_only: false },
+  { value: "zalo", status: "live", internal_only: false },
+  { value: "zalo_bot", status: "live", internal_only: true },
+];
+
+const baseProps = {
+  index: 0,
+  onChange: vi.fn(),
+  onRemove: vi.fn(),
+  resolverOptions: RESOLVER_OPTIONS,
+  externalResolverOptions: EXTERNAL_RESOLVER_OPTIONS,
+  browserUsedByOtherGroup: false,
+};
+
+describe("RecipientGroupCard — v5 internal_only filter", () => {
+  it("internal recipient sees internal_only channels (e.g. zalo_bot)", () => {
+    render(
+      <RecipientGroupCard
+        {...baseProps}
+        group={makeGroup("internal")}
+        availableChannels={CHANNELS_WITH_INTERNAL_ONLY}
+      />,
+    );
+
+    // AddChannelBar renders buttons for available channels not yet in the group.
+    // Internal recipient should expose every channel including internal_only.
+    expect(screen.getByText("Trong ứng dụng")).toBeDefined();
+    expect(screen.getByText("Email")).toBeDefined();
+    expect(screen.getByText("Zalo")).toBeDefined();
+    // v5 Step 23: zalo_bot now has CHANNEL_LABELS["zalo_bot"]="Zalo Bot".
+    expect(screen.getByText("Zalo Bot")).toBeDefined();
+    expect(screen.queryByText("zalo_bot")).toBeNull();
+  });
+
+  it("external recipient hides internal_only channels", () => {
+    render(
+      <RecipientGroupCard
+        {...baseProps}
+        group={makeGroup("external")}
+        availableChannels={CHANNELS_WITH_INTERNAL_ONLY}
+      />,
+    );
+
+    // External must hide browser (existing behavior) AND zalo_bot (internal_only).
+    expect(screen.queryByText("Trong ứng dụng")).toBeNull();
+    expect(screen.queryByText("Zalo Bot")).toBeNull();
+    expect(screen.queryByText("zalo_bot")).toBeNull();
+    // Public channels remain visible.
+    expect(screen.getByText("Email")).toBeDefined();
+    expect(screen.getByText("Zalo")).toBeDefined();
+  });
+
+  it("external recipient still hides browser when no internal_only flag is set (backward-compat)", () => {
+    const legacyChannels: ChannelInfo[] = [
+      { value: "browser", status: "live" }, // internal_only undefined
+      { value: "email", status: "live" },
+      { value: "zalo", status: "live" },
+    ];
+
+    render(
+      <RecipientGroupCard
+        {...baseProps}
+        group={makeGroup("external")}
+        availableChannels={legacyChannels}
+      />,
+    );
+
+    expect(screen.queryByText("Trong ứng dụng")).toBeNull();
+    expect(screen.getByText("Email")).toBeDefined();
+    expect(screen.getByText("Zalo")).toBeDefined();
+  });
+
+  it("falls back to DEFAULT_CHANNELS_INFO when availableChannels is undefined", () => {
+    // Internal default = browser + email + zalo
+    render(
+      <RecipientGroupCard
+        {...baseProps}
+        group={makeGroup("internal")}
+      />,
+    );
+
+    expect(screen.getByText("Trong ứng dụng")).toBeDefined();
+    expect(screen.getByText("Email")).toBeDefined();
+    expect(screen.getByText("Zalo")).toBeDefined();
+  });
+});

--- a/frontend/src/components/admin/notifications/RecipientGroupCard.tsx
+++ b/frontend/src/components/admin/notifications/RecipientGroupCard.tsx
@@ -4,11 +4,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Trash2 } from "lucide-react";
 import type { RecipientGroup, ChannelBranch, ExternalResolverOption } from "./wizard-types";
-import { DEFAULT_CHANNELS } from "./wizard-types";
+import { DEFAULT_CHANNELS_INFO } from "./wizard-types";
 import ChannelBranchCard from "./ChannelBranchCard";
 import ResolverPicker from "./ResolverPicker";
 import AddChannelBar from "./AddChannelBar";
-import type { ResolverTypeOption } from "@/types/api.types";
+import type { ChannelInfo, ResolverTypeOption } from "@/types/api.types";
 
 interface RecipientGroupCardProps {
   group: RecipientGroup;
@@ -18,7 +18,8 @@ interface RecipientGroupCardProps {
   resolverOptions: ResolverTypeOption[];
   externalResolverOptions: ExternalResolverOption[];
   browserUsedByOtherGroup: boolean;
-  availableChannels?: string[];
+  /** v5 pre-work: full ChannelInfo[] (was string[]) so we can filter internal_only. */
+  availableChannels?: ChannelInfo[];
   selectedEvent?: string; // For template picker filtering
 }
 
@@ -34,9 +35,15 @@ export default function RecipientGroupCard({
   selectedEvent,
 }: RecipientGroupCardProps) {
   const activeChannels = new Set(group.channels.map((c) => c.channel));
-  const channelList = group.recipient_kind === "external"
-    ? (availableChannelsProp ?? DEFAULT_CHANNELS.external).filter((ch) => ch !== "browser")
-    : (availableChannelsProp ?? DEFAULT_CHANNELS.internal);
+  // v5 pre-work: external recipient UI filters out browser AND any
+  // internal_only channel (e.g. zalo_bot) — replaces hardcoded
+  // ``ch !== "browser"`` filter with a metadata-driven check.
+  const channelList =
+    group.recipient_kind === "external"
+      ? (availableChannelsProp ?? DEFAULT_CHANNELS_INFO.external)
+          .filter((ch) => ch.value !== "browser" && !ch.internal_only)
+          .map((ch) => ch.value)
+      : (availableChannelsProp ?? DEFAULT_CHANNELS_INFO.internal).map((ch) => ch.value);
 
   const handleResolverChange = (value: string) => {
     if (group.recipient_kind === "internal") {

--- a/frontend/src/components/admin/notifications/WizardStepRecipientGroups.tsx
+++ b/frontend/src/components/admin/notifications/WizardStepRecipientGroups.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import type { RecipientGroup, ExternalResolverOption } from "./wizard-types";
-import type { ResolverTypeOption } from "@/types/api.types";
+import type { ChannelInfo, ResolverTypeOption } from "@/types/api.types";
 import RecipientGroupCard from "./RecipientGroupCard";
 import { createInternalGroup, createExternalGroup } from "./wizard-utils";
 
@@ -12,7 +12,12 @@ interface WizardStepRecipientGroupsProps {
   onChange: (groups: RecipientGroup[]) => void;
   resolverOptions: ResolverTypeOption[];
   externalResolverOptions: ExternalResolverOption[];
-  availableChannels?: string[];
+  /**
+   * v5 pre-work: ``ChannelInfo[]`` (was ``string[]``) so the recipient card
+   * can filter internal-only channels out of external recipient pickers
+   * without hardcoding channel names.
+   */
+  availableChannels?: ChannelInfo[];
   validationErrors?: string[];
   selectedEvent?: string; // For template picker filtering
 }

--- a/frontend/src/components/admin/notifications/wizard-types.ts
+++ b/frontend/src/components/admin/notifications/wizard-types.ts
@@ -1,5 +1,7 @@
 // wizard-types.ts — Phase 3c UI types for recipient groups + channel branches
 
+import type { ChannelInfo } from "@/types/api.types";
+
 export type RecipientKind = "internal" | "external";
 
 export type ContentMode = "inherit_default" | "inline_override" | "channel_native" | "template_override";
@@ -9,13 +11,35 @@ export const CHANNEL_LABELS: Record<string, string> = {
   browser: "Trong ứng dụng",
   email: "Email",
   zalo: "Zalo",
+  zalo_bot: "Zalo Bot",
   sms: "SMS",
 };
 
 // Fallback channels when metadata unavailable. Only include live channels.
+// v5 pre-work: full ChannelInfo objects so callers can read internal_only.
+// External fallback excludes browser implicitly via filter at the consumer.
+// v5 Step 23: zalo_bot lives in the internal fallback with internal_only=true
+// so RecipientGroupCard's existing `!ch.internal_only` filter (set up in
+// v5-pre-2) keeps it out of external recipient pickers automatically.
+export const DEFAULT_CHANNELS_INFO: Record<RecipientKind, ChannelInfo[]> = {
+  internal: [
+    { value: "browser", status: "live", internal_only: false },
+    { value: "email", status: "live", internal_only: false },
+    { value: "zalo", status: "live", internal_only: false },
+    { value: "zalo_bot", status: "live", internal_only: true },
+  ],
+  external: [
+    { value: "zalo", status: "live", internal_only: false },
+  ],
+};
+
+/**
+ * @deprecated v5 pre-work: use DEFAULT_CHANNELS_INFO. Retained only for tests
+ * or callers that genuinely need the channel-name strings.
+ */
 export const DEFAULT_CHANNELS: Record<RecipientKind, string[]> = {
-  internal: ["browser", "email", "zalo"],
-  external: ["zalo"],
+  internal: DEFAULT_CHANNELS_INFO.internal.map((c) => c.value),
+  external: DEFAULT_CHANNELS_INFO.external.map((c) => c.value),
 };
 
 export interface ExternalResolverOption {

--- a/frontend/src/hooks/useZaloBotLink.test.tsx
+++ b/frontend/src/hooks/useZaloBotLink.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * useZaloBotLink hook tests — v5 Step 21.
+ *
+ * Pin three contracts that are easy to drift on:
+ *   - UNLINK is POST (NOT DELETE) — backend treats unlink as a state
+ *     mutation that flips zalo_bot_enabled, not a resource deletion.
+ *   - useZaloBotLinkStatus stops polling once `is_linked` flips true.
+ *   - generate / unlink invalidate the status query so the UI refetches.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+
+import { createTestQueryClient } from "@/test/utils/test-utils";
+import { api } from "@/lib/api/client";
+import { API_ENDPOINTS } from "@/lib/api/endpoints";
+import {
+  useGenerateLinkCode,
+  useUnlinkZaloBot,
+  useZaloBotLinkStatus,
+  zaloBotKeys,
+} from "./useZaloBotLink";
+
+vi.mock("@/lib/api/client", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+// vi.mocked() can't see through the module-level type because `api` is
+// typed as the real Axios instance — cast each method to the Mock
+// surface so the mock helpers (mockResolvedValueOnce, etc.) compile.
+const mockedApi = {
+  get: api.get as unknown as Mock,
+  post: api.post as unknown as Mock,
+  delete: api.delete as unknown as Mock,
+  put: api.put as unknown as Mock,
+  patch: api.patch as unknown as Mock,
+};
+
+function makeWrapper(client = createTestQueryClient()) {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { wrapper, client };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("API_ENDPOINTS.ZALO_BOT contract", () => {
+  it("UNLINK is POST endpoint (not DELETE)", () => {
+    expect(API_ENDPOINTS.ZALO_BOT.UNLINK).toBe("/api/zalo-bot/unlink");
+    expect(API_ENDPOINTS.ZALO_BOT.LINK_CODE).toBe("/api/zalo-bot/link-code");
+    expect(API_ENDPOINTS.ZALO_BOT.LINK_STATUS).toBe("/api/zalo-bot/link-status");
+  });
+});
+
+describe("useZaloBotLinkStatus", () => {
+  it("fetches status from LINK_STATUS endpoint", async () => {
+    mockedApi.get.mockResolvedValueOnce({
+      data: { is_linked: false, display_name: null, linked_at: null },
+    });
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useZaloBotLinkStatus(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedApi.get).toHaveBeenCalledWith(API_ENDPOINTS.ZALO_BOT.LINK_STATUS);
+    expect(result.current.data?.is_linked).toBe(false);
+  });
+
+  it("returns linked payload from server", async () => {
+    mockedApi.get.mockResolvedValueOnce({
+      data: {
+        is_linked: true,
+        display_name: "Officer A",
+        linked_at: "2026-04-26T10:00:00+00:00",
+      },
+    });
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useZaloBotLinkStatus(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.is_linked).toBe(true);
+    expect(result.current.data?.display_name).toBe("Officer A");
+  });
+});
+
+describe("useGenerateLinkCode", () => {
+  it("POSTs to LINK_CODE and invalidates status cache", async () => {
+    mockedApi.post.mockResolvedValueOnce({
+      data: {
+        code: "ABC123",
+        expires_in_seconds: 600,
+        instructions: "Mở Zalo, tìm bot QLTS, gửi: /lienkiet ABC123",
+      },
+    });
+
+    const { wrapper, client } = makeWrapper();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useGenerateLinkCode(), { wrapper });
+    await act(async () => {
+      const res = await result.current.mutateAsync();
+      expect(res.code).toBe("ABC123");
+      expect(res.expires_in_seconds).toBe(600);
+    });
+
+    expect(mockedApi.post).toHaveBeenCalledWith(API_ENDPOINTS.ZALO_BOT.LINK_CODE);
+    // Hook must invalidate the status query so the polling refetch picks
+    // up the new server state.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: zaloBotKeys.status() });
+  });
+});
+
+describe("useUnlinkZaloBot", () => {
+  it("POSTs (not DELETE) to UNLINK", async () => {
+    mockedApi.post.mockResolvedValueOnce({
+      data: { unlinked: true, message: "Đã huỷ liên kết." },
+    });
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useUnlinkZaloBot(), { wrapper });
+
+    await act(async () => {
+      const res = await result.current.mutateAsync();
+      expect(res.unlinked).toBe(true);
+    });
+
+    // Critical: the backend uses POST. A DELETE here would 405.
+    expect(mockedApi.post).toHaveBeenCalledWith(API_ENDPOINTS.ZALO_BOT.UNLINK);
+    expect(mockedApi.delete).not.toHaveBeenCalled();
+  });
+
+  it("invalidates both status and notification preference caches on success", async () => {
+    mockedApi.post.mockResolvedValueOnce({
+      data: { unlinked: true, message: "Đã huỷ liên kết." },
+    });
+
+    const { wrapper, client } = makeWrapper();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    const { result } = renderHook(() => useUnlinkZaloBot(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    // Two distinct scopes invalidated: zalo bot link status (for the
+    // polling query) AND the broader notification-preferences scope so
+    // the settings UI re-reads ``zalo_bot_enabled=false``.
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: zaloBotKeys.status() });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["notificationPreferences"],
+    });
+  });
+});

--- a/frontend/src/hooks/useZaloBotLink.ts
+++ b/frontend/src/hooks/useZaloBotLink.ts
@@ -1,0 +1,104 @@
+// src/hooks/useZaloBotLink.ts
+// v5 Step 21: React Query hooks for the Zalo Bot link flow.
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
+
+import { api } from "@/lib/api/client";
+import { API_ENDPOINTS } from "@/lib/api/endpoints";
+import { notificationPreferenceKeys } from "@/hooks/useNotificationPreferences";
+import type {
+  ApiErrorResponse,
+  ZaloBotLinkCode,
+  ZaloBotLinkStatus,
+  ZaloBotUnlinkResult,
+} from "@/types/api.types";
+
+export const zaloBotKeys = {
+  all: ["zaloBot"] as const,
+  status: () => [...zaloBotKeys.all, "status"] as const,
+};
+
+export interface UseZaloBotLinkStatusOptions {
+  /**
+   * When `true`, refetch status every 5s. The settings UI flips this on
+   * after the user clicks "Generate code" so the UI updates as soon as
+   * the backend marks the link active. Polling stops once `is_linked`
+   * is true (handled by ``refetchInterval`` returning ``false``).
+   */
+  pollWhileWaiting?: boolean;
+}
+
+const POLL_INTERVAL_MS = 5000;
+
+export function useZaloBotLinkStatus(
+  options?: UseZaloBotLinkStatusOptions,
+) {
+  return useQuery<ZaloBotLinkStatus, AxiosError<ApiErrorResponse>>({
+    queryKey: zaloBotKeys.status(),
+    queryFn: async () => {
+      const response = await api.get<ZaloBotLinkStatus>(
+        API_ENDPOINTS.ZALO_BOT.LINK_STATUS,
+      );
+      return response.data;
+    },
+    // 30s default freshness — plenty for the linked state. While the
+    // user is waiting for the bot reply we override via refetchInterval.
+    staleTime: 30 * 1000,
+    refetchInterval: (query) => {
+      if (!options?.pollWhileWaiting) return false;
+      // Stop polling once the binding is active.
+      const data = query.state.data as ZaloBotLinkStatus | undefined;
+      return data?.is_linked ? false : POLL_INTERVAL_MS;
+    },
+  });
+}
+
+/**
+ * Generate a fresh 6-char link code (TTL 600s on the backend). Each call
+ * supersedes the previous code for this user — the backend revokes the
+ * old code via its pointer key.
+ */
+export function useGenerateLinkCode() {
+  const queryClient = useQueryClient();
+
+  return useMutation<ZaloBotLinkCode, AxiosError<ApiErrorResponse>>({
+    mutationFn: async () => {
+      const response = await api.post<ZaloBotLinkCode>(
+        API_ENDPOINTS.ZALO_BOT.LINK_CODE,
+      );
+      return response.data;
+    },
+    onSuccess: () => {
+      // Status may still be unlinked at this point (the user has only
+      // received the code, not typed it into Zalo yet). Invalidate
+      // anyway so the polling query picks up immediately.
+      queryClient.invalidateQueries({ queryKey: zaloBotKeys.status() });
+    },
+  });
+}
+
+/**
+ * Unlink the caller's Zalo Bot binding. Backend POST (not DELETE) —
+ * mirrors the link-service contract that flips ``zalo_bot_enabled``
+ * alongside the link row. Invalidates both the link status and the
+ * generic notification preferences cache so the settings UI re-reads
+ * the new ``zalo_bot_enabled=false`` immediately.
+ */
+export function useUnlinkZaloBot() {
+  const queryClient = useQueryClient();
+
+  return useMutation<ZaloBotUnlinkResult, AxiosError<ApiErrorResponse>>({
+    mutationFn: async () => {
+      const response = await api.post<ZaloBotUnlinkResult>(
+        API_ENDPOINTS.ZALO_BOT.UNLINK,
+      );
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: zaloBotKeys.status() });
+      queryClient.invalidateQueries({
+        queryKey: notificationPreferenceKeys.all,
+      });
+    },
+  });
+}

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -170,6 +170,15 @@ export const API_ENDPOINTS = {
     EVENT_GROUPS: "/api/notifications/event-groups",
     EVENT_GROUPS_METADATA: "/api/notifications/event-groups/metadata",
   },
+  // ✅ v5 Step 20: Zalo Bot link API (staff-facing, auth required)
+  // NOTE: UNLINK is POST (not DELETE) — backend treats unlink as a
+  // state mutation that flips the preference column, not a resource
+  // deletion. Hook tests pin this to catch accidental DELETE drift.
+  ZALO_BOT: {
+    LINK_CODE: "/api/zalo-bot/link-code",
+    LINK_STATUS: "/api/zalo-bot/link-status",
+    UNLINK: "/api/zalo-bot/unlink",
+  },
   // ✅ PHASE 2.4: Notification Rules (Admin-only)
   NOTIFICATION_RULES: {
     LIST: "/api/notification-rules",

--- a/frontend/src/types/api.types.ts
+++ b/frontend/src/types/api.types.ts
@@ -286,6 +286,13 @@ export interface NotificationPreference {
   email_enabled: boolean;
   sound_enabled: boolean;
   browser_enabled: boolean;
+  /**
+   * v5: Zalo Bot channel toggle. Read-only from the user's perspective —
+   * managed by `useZaloBotLink` (link/unlink). Deliberately omitted from
+   * `NotificationPreferenceUpdate` so the generic preference endpoint
+   * cannot flip it without going through the link flow.
+   */
+  zalo_bot_enabled: boolean;
   email_digest: "instant" | "daily" | "weekly" | "disabled";
   type_preferences: Record<string, NotificationTypePreference> | null;
   quiet_hours_enabled: boolean;
@@ -305,6 +312,29 @@ export interface NotificationPreferenceUpdate {
   quiet_hours_enabled?: boolean;
   quiet_hours_start?: string | null;
   quiet_hours_end?: string | null;
+  // NOTE: zalo_bot_enabled is intentionally absent — see NotificationPreference.
+  // Use `useZaloBotLink` hook (POST /api/zalo-bot/link-code | unlink).
+}
+
+// ============================================
+// ✅ v5 Step 20: Zalo Bot Link
+// ============================================
+
+export interface ZaloBotLinkStatus {
+  is_linked: boolean;
+  display_name: string | null;
+  linked_at: string | null; // ISO8601
+}
+
+export interface ZaloBotLinkCode {
+  code: string;
+  expires_in_seconds: number; // backend ships 600 (10 min)
+  instructions: string;
+}
+
+export interface ZaloBotUnlinkResult {
+  unlinked: boolean;
+  message: string;
 }
 
 // ============================================
@@ -580,6 +610,13 @@ export interface OperatorOption {
 export interface ChannelInfo {
   value: string;
   status: "live" | "planned";
+  /**
+   * v5 pre-work: when true, the channel targets staff only (e.g. zalo_bot)
+   * and must be hidden from external recipient (lead/customer) pickers.
+   * Optional for backward-compat with older API responses; treat undefined
+   * as ``false``.
+   */
+  internal_only?: boolean;
 }
 
 export interface ExternalResolverOption {


### PR DESCRIPTION
## Summary

Triển khai đầy đủ **Zalo Bot Platform** cho thông báo nhân viên nội bộ: channel mới `zalo_bot` tách biệt `zalo` (ZNS), tier miễn phí 3.000 msg/tháng, không cần duyệt template. Staff link một lần qua `/lienkiet <CODE>` trong Zalo chat, sau đó nhận push trực tiếp khi event nội bộ trigger (LEAD_ASSIGNED, APPLICATION_*, FINANCE_*, SYSTEM, …).

Channel **gated bởi `ZALO_BOT_ENABLED=false`** mặc định — code an toàn ship lên prod, chưa fire bất kỳ traffic nào cho đến khi flip flag.

## Phases implemented (theo plan v5)

- **v5 pre-work**
  - `v5-pre-1`: fix `get_group_preference()` fallback `True` → đọc default từ `DEFAULT_GROUP_CHANNELS` (audit prod 0 risky users)
  - `v5-pre-2`: `ChannelInfo.internal_only` contract + FE wizard refactor `ChannelInfo[]` + Redis atomic helpers verified
- **Phase 3** — Backend foundation (Steps 1, 2, 4-7): config, `safe_redis_getdel`, model `StaffZaloBotLink`, gateway (token-leak guards), repository, link service (TTL=600, NX retry, GETDEL atomic consume)
- **Phase 4** — Backend channel + prefs + migration (Steps 8-17): channel sender, registry gated bởi `ZALO_BOT_ENABLED`, enum + defaults (`ZALO_BOT=False` mọi group), preference column + Gate A filter, delivery tasks (quota/record/reconcile), quota service, circuit breaker, rule validation reject `zalo_bot+external_resolver`, metadata `internal_only=true`
- **Phase 5** — Backend routers (Steps 18-19): webhook `POST /api/webhooks/zalo-bot` với `hmac.compare_digest` + atomic rate-limit 10/min/chat_id; staff link API `/api/zalo-bot/{link-code,link-status,unlink}` với atomic rate-limit 5/10min/user
- **Phase 6** — Frontend (Steps 20-24): types, `API_ENDPOINTS.ZALO_BOT`, `useZaloBotLink` hook, settings UI (link section + per-group toggle), wizard label/fallback, DeliveryOpsTable filter + icon
- **Phase 6a** — Cache sync hotfix: invalidate `notificationPreferences.all` khi link flip active để per-group `zalo_bot` toggle enable không cần F5

## Test results

### Backend — 97 passed, 2 skipped in 218s

11 file test:
- `tests/api/test_zalo_bot_webhooks.py`
- `tests/api/test_zalo_bot_link_api.py`
- `tests/unit/test_zalo_bot_phase4_contracts.py`
- `tests/unit/test_zalo_bot_channel.py`
- `tests/unit/test_zalo_bot_link_service.py`
- `tests/unit/test_zalo_bot_gateway.py`
- `tests/repositories/test_staff_zalo_bot_link_repo.py`
- `tests/repositories/test_zalo_bot_preference_sync.py`
- `tests/services/test_notification_preference.py`
- `tests/api/test_notification_rule_crud.py`
- `tests/integration/test_notification_core_v2.py`

Coverage: webhook security (secret missing/wrong/empty/correct, JSON 400, non-text ignored, rate-limit), link API (auth, TTL=600, rate-limit 6th blocked, unlink POST không phải DELETE), channel sender (no link permanent error, gateway failure mapping, text truncate 2000), gateway (token-leak guards trong result + logs), repository CRUD, preference sync (link/unlink persist `zalo_bot_enabled`), Gate A filter (global + per-group opt-in), enum + defaults, canonical channels, schema surface (`Update` không expose), rule validation reject zalo_bot+external_resolver, metadata `internal_only=true`.

### Frontend — 40 passed in 5.7s + type-check sạch

- `npm run type-check` → 0 errors
- 5 file vitest: `useZaloBotLink.test.tsx`, `NotificationSettingsClient.test.tsx`, `RecipientGroupCard.test.tsx`, `NotificationRuleEditor.test.tsx`, `DeliveryOpsTable.test.tsx`

Coverage: hook contract (UNLINK is POST không phải DELETE, generate + unlink invalidate đúng cache scope), settings UI (generate code → render code, poll stop khi linked, unlink call API, per-group toggle disabled khi `!zalo_bot_enabled`, cache invalidate khi link flip active, save general settings KHÔNG include `zalo_bot_enabled` trong payload), wizard internal_only filter (external picker hide zalo_bot + browser), DeliveryOpsTable Zalo Bot label + filter option.

## Migration notes

- **Revision**: `zalobot001`
- **Down revision**: `dd5m6n7o8p9q` (re-verified ngay trước commit)
- **Round-trip verified** trên dev: `upgrade head` → `downgrade -1` → `upgrade head`, `current = zalobot001 (head)` ổn định
- **Nội dung** trong 1 revision đơn nhất:
  1. CREATE TABLE `staff_zalo_bot_link` (user_id unique, chat_id non-unique, is_active boolean default true, linked_at + updated_at với server defaults)
  2. ADD COLUMN `notification_preference.zalo_bot_enabled` boolean NOT NULL DEFAULT false (mọi pref hiện tại backfill `false` tự động)
  3. CREATE partial unique index `ux_staff_zalo_bot_link_active_chat` ON `staff_zalo_bot_link(chat_id) WHERE is_active = true` (PostgreSQL only — đảm bảo "1 binding active per chat_id" trong khi cho phép history rows inactive cùng chat_id)
- Downgrade symmetric: drop column → drop index → drop table

## Deploy order (BẮT BUỘC tuân thủ)

1. Merge PR → CI deploy code lên VPS
2. **Run `alembic upgrade head` trên prod TRƯỚC khi flip flag**
3. Set 4 env trong `/opt/qlts/.env.production`:
   - `ZALO_BOT_ENABLED=false` (giữ false đến khi smoke pass)
   - `ZALO_BOT_TOKEN=<từ bot.zaloplatforms.com>`
   - `ZALO_BOT_WEBHOOK_SECRET=<random ≥32 char>`
   - `ZALO_BOT_DAILY_QUOTA=80`
4. Restart backend + celery-worker để pick up env mới
5. Flip `ZALO_BOT_ENABLED=true` + restart lại
6. Gọi `gateway.set_webhook("https://qlts.tnpc.edu.vn/api/webhooks/zalo-bot", secret)` một lần để đăng ký URL với Zalo
7. Officer pilot 5-10 người: vào `/settings/notifications` → Tạo mã → gửi `/lienkiet <CODE>` qua Zalo → confirm UI swap sang "Đã liên kết" trong ≤5s
8. Monitor `notification_delivery WHERE channel='zalo_bot'` 24h, expect:
   - 0 row `error_reason='no_zalo_bot_link'` cho user đã link
   - 0 row `dead_lettered` ngoài dự kiến
   - Quota daily ≤80

⚠️ **Không flip `ZALO_BOT_ENABLED=true` trước khi cả 4 env đều set + migration đã chạy** — channel registry sẽ register channel nhưng bot send sẽ 401/network fail vì token rỗng → mass dead-letter.

## Manual prod steps (chưa verify được trong PR này)

Test suite đã cover toàn bộ code path qua mock; **3 đường network thật** chỉ verify được trên prod sau deploy:

1. Gateway → `bot-api.zaloplatforms.com/bot<TOKEN>/sendMessage` (cần token thật)
2. Zalo → backend webhook `/api/webhooks/zalo-bot` (cần `setWebhook` đã chạy)
3. Officer link end-to-end qua Zalo app

Verify gián tiếp: 6 unit test gateway (gồm token-leak guards), 14 webhook test, 13 hook + settings UI test. Prod env hiện tại có 0 keys `ZALO_BOT_*` (verified qua SSH) — phù hợp với plan: ship code an toàn trước, set env và flip sau.

## Risks / rollback

| Risk | Mitigation |
|---|---|
| `ZALO_BOT_ENABLED=true` flip trước khi set token/secret | Channel registry skip register khi flag false → không lỡ tay register channel rỗng. Webhook fail-closed 401 nếu secret empty. |
| Migration apply nhưng code revert | `zalo_bot_enabled` column NOT NULL DEFAULT false → existing logic không bị vỡ vì column được ignored |
| Drift behavior `get_group_preference` (v5-pre-1) | Audit prod 2026-04-26 cho thấy 0 risky_zalo_users → no backfill cần thiết |
| `staff_zalo_bot_link` partial unique index không apply trên non-PostgreSQL | Production dùng PostgreSQL 16 → an toàn. Test DB dùng `Base.metadata.create_all` skip partial index → tests vẫn xanh |
| Rollback channel sender | `ZALO_BOT_ENABLED=false` → registry skip → channel `get_channel("zalo_bot")` trả `None` → dispatcher mark dead-letter `channel_not_implemented`. Reset enable=true sau khi fix. |
| Rollback migration | `alembic downgrade -1` drop sạch index/column/table. Verified round-trip trên dev. |

## Notes

- **Không bao gồm** `scripts/plan-loop.ps1` (file plan-loop cá nhân, đã thống nhất giữ local từ session trước)
- Migration head trên prod hiện tại = `dd5m6n7o8p9q` (kiểm tra ngay trước merge để chắc chắn không có PR khác chen vào head)
- Không touch `NotificationPreferenceUpdate` schema → clients không thể flip `zalo_bot_enabled` qua endpoint generic, mọi thay đổi phải đi qua link service

## Files changed

- 46 files, 3694 insertions / 52 deletions
- 14 backend modify + 12 backend tạo mới (gồm 1 migration)
- 12 frontend modify + 5 frontend tạo mới
- 8 backend test + 4 frontend test mới (137 test/contract đều xanh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
