### PR TITLE
fix(zalo-bot): wrap link-active effect setState in queueMicrotask

### DIFF
--- a/frontend/src/app/(dashboard)/settings/notifications/_components/NotificationSettingsClient.tsx
+++ b/frontend/src/app/(dashboard)/settings/notifications/_components/NotificationSettingsClient.tsx
@@ -155,9 +155,15 @@ export function NotificationSettingsClient({
   // interactive within one render.
   useEffect(() => {
     if (linkStatus?.is_linked && pendingCode) {
-      setPendingCode(null);
-      queryClient.invalidateQueries({ queryKey: notificationPreferenceKeys.all });
-      toast.success("Đã liên kết Zalo Bot thành công!");
+      // Defer setState + cache invalidation through queueMicrotask to avoid
+      // the cascading-render lint rule (same pattern used at the
+      // initial preferences-hydration effect above). Synchronous setState
+      // inside an effect body is rejected by the project's ESLint config.
+      queueMicrotask(() => {
+        setPendingCode(null);
+        queryClient.invalidateQueries({ queryKey: notificationPreferenceKeys.all });
+        toast.success("Đã liên kết Zalo Bot thành công!");
+      });
     }
   }, [linkStatus?.is_linked, pendingCode, queryClient]);
 


### PR DESCRIPTION
## Summary

Hotfix for deploy.yml CI failure on PR #137. The Phase 6a effect that
invalidates the preferences cache after the Zalo Bot link flips active
called `setPendingCode(null)` synchronously inside `useEffect`, which
triggers the project's ESLint rule `react-hooks/set-state-in-effect`:

> Calling setState synchronously within an effect can trigger cascading
> renders that can hurt performance, and is not recommended.

`Frontend — Lint` job in PR #137's workflow failed with exit 1
(1 error, 217 warnings) → `Deploy to VPS` job skipped → prod still on
commit `7b42123d` without `staff_zalo_bot_link` table.

## Fix

Wrap setState + invalidate + toast in `queueMicrotask`. Mirrors the
existing pattern at line 68 of the same file (initial preferences
hydration effect). The microtask resolves before the next render
observation, so the existing 7 vitest cases pass unchanged — including
the Phase 6a `Phase 6a: invalidates notificationPreferences cache when
link flips active` test.

## Why local CI didn't catch it

Phase 6 verification ran `npm run type-check` only. The project lints
in CI but not in the local sweep — gap I'll add to the standard
verify checklist (Phase 7).

## Test plan

- [x] `docker compose run --rm --no-deps frontend npm run lint` → 0 errors, 207 warnings (pre-existing)
- [x] `docker compose exec -T frontend npx vitest run NotificationSettingsClient.test.tsx` → 7 passed
- [ ] CI deploy.yml passes after merge → `staff_zalo_bot_link` table created on prod
- [ ] Resume Zalo Bot rollout (set 4 env, restart, flip ENABLED, setWebhook, pilot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)