### PR TITLE
fix(zalo-bot): read webhook event_name from top level (Zalo real shape)

### DIFF
--- a/Backend_FastAPI/app/routers/zalo_bot_webhooks.py
+++ b/Backend_FastAPI/app/routers/zalo_bot_webhooks.py
@@ -109,7 +109,18 @@ async def zalo_bot_webhook(
         return {"status": "ok", "mode": "non_object_payload"}
 
     result = data.get("result") or {}
-    event_name = result.get("event_name", "") if isinstance(result, dict) else ""
+    # Zalo Bot Platform actually ships ``event_name`` at the **top level**
+    # of the payload (per https://bot.zaloplatforms.com/docs). Plan v5 +
+    # initial code mistakenly read it from ``data["result"]["event_name"]``,
+    # which silently returned ``ignored_event`` for every real message
+    # (smoke 2026-04-27 captured `/lienkiet` POST → 200 with no handler
+    # activity). Read top-level first, fall back to legacy nested shape so
+    # any provider variant still routes correctly.
+    event_name = (
+        data.get("event_name")
+        or (result.get("event_name") if isinstance(result, dict) else "")
+        or ""
+    )
     if event_name != "message.text.received":
         # Other events (e.g. delivery callbacks) are ignored for now.
         return {"status": "ok", "mode": "ignored_event", "event": event_name}

--- a/Backend_FastAPI/tests/api/test_zalo_bot_webhooks.py
+++ b/Backend_FastAPI/tests/api/test_zalo_bot_webhooks.py
@@ -19,6 +19,27 @@ SECRET = "test-webhook-secret-xyz"
 
 
 def _payload(text: str, chat_id: str = "chat_alpha_xxxxxxxx") -> dict:
+    """Real Zalo Bot Platform shape: ``event_name`` at TOP level, message
+    nested under ``result``. Captured from a live webhook hit on
+    2026-04-27 after initial smoke showed ignored_event for every command.
+    """
+    return {
+        "event_name": "message.text.received",
+        "result": {
+            "message": {
+                "chat": {"id": chat_id},
+                "text": text,
+                "from": {"display_name": "Officer A"},
+            },
+        },
+    }
+
+
+def _payload_legacy_nested(text: str, chat_id: str = "chat_alpha_xxxxxxxx") -> dict:
+    """Legacy shape used by plan v5 examples — ``event_name`` nested under
+    ``result``. The router now accepts this too via fallback so any future
+    provider variant doesn't regress.
+    """
     return {
         "result": {
             "event_name": "message.text.received",
@@ -119,10 +140,10 @@ class TestPayloadShape:
         self, client: AsyncClient, configured_secret, gateway_mock
     ):
         body = {
+            "event_name": "follow",
             "result": {
-                "event_name": "follow",
                 "message": {"chat": {"id": "x"}, "text": "ignored"},
-            }
+            },
         }
         resp = await client.post(
             "/api/webhooks/zalo-bot",
@@ -133,14 +154,49 @@ class TestPayloadShape:
         assert resp.json()["mode"] == "ignored_event"
         gateway_mock.send_message.assert_not_awaited()
 
+    async def test_top_level_event_name_is_recognized(
+        self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
+    ):
+        """Real Zalo payload puts ``event_name`` at top level. Pre-fix the
+        router only read it from ``result.event_name`` and silently
+        ignored every real message — repro of 2026-04-27 smoke regression.
+        """
+        verify, _ = link_service_mock
+        verify.return_value = (False, "invalid")
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("/lienkiet ABC123"),  # uses top-level shape
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+        # Must NOT be ignored_event — handler must reach verify_and_link
+        assert resp.json().get("mode") != "ignored_event", (
+            "top-level event_name not recognised → real Zalo traffic dropped silently"
+        )
+
+    async def test_legacy_nested_event_name_still_works(
+        self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
+    ):
+        """Legacy shape (event_name nested under result) keeps working as
+        a fallback, so any provider variant doesn't regress."""
+        verify, _ = link_service_mock
+        verify.return_value = (False, "invalid")
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload_legacy_nested("/lienkiet ABC123"),
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+        assert resp.json().get("mode") != "ignored_event"
+
     async def test_empty_chat_or_text_noop(
         self, client: AsyncClient, configured_secret, gateway_mock
     ):
         body = {
+            "event_name": "message.text.received",
             "result": {
-                "event_name": "message.text.received",
                 "message": {"chat": {"id": ""}, "text": "x"},
-            }
+            },
         }
         resp = await client.post(
             "/api/webhooks/zalo-bot",


### PR DESCRIPTION
## Summary

Hotfix for live smoke regression on PR #137 deploy. Real Zalo Bot Platform webhook payload puts `event_name` at the **TOP level**, not nested under `result`:

```
{ "event_name": "message.text.received", "result": { "message": ... } }
```

Plan v5 examples + initial router code mistakenly read `event_name` from `data["result"]["event_name"]` → always empty for real traffic → router returned `{"status":"ok","mode":"ignored_event"}` with HTTP 200 and no log. Bot completely silent for `/lienkiet`, `/trangthai`, `/huylienkiet`.

## Repro on prod (2026-04-27)

- Officer (admin user_id=15) generated link code `VVMNEC` via `/settings/notifications`
- Officer typed `/lienkiet VVMNEC` in Zalo Bot chat
- nginx access log: `POST /api/webhooks/zalo-bot 200` from `118.102.2.29 (Java/1.8.0_192)` ← Zalo backend
- backend structured log: zero entries from `app.routers.zalo_bot_webhooks` ← router exited early at `event_name != "message.text.received"` check
- bot silent, no reply, link not created

## Fix

```python
event_name = (
    data.get("event_name")
    or (result.get("event_name") if isinstance(result, dict) else "")
    or ""
)
```

- Read top-level first (real Zalo shape per [official docs](https://bot.zaloplatforms.com/docs/build-your-bot/))
- Fall back to legacy nested shape so any provider variant still works

## Tests

- Updated `_payload()` helper to top-level shape (matches captured real payload)
- Added `_payload_legacy_nested()` for fallback coverage
- New `test_top_level_event_name_is_recognized` — pins the fix
- New `test_legacy_nested_event_name_still_works` — pins fallback

```
docker compose exec -T backend python -m pytest \
  tests/api/test_zalo_bot_webhooks.py -v --tb=short
→ 16 passed in 51.88s
```

## Test plan

- [x] All 16 webhook tests pass with both shapes
- [ ] CI deploy success
- [ ] Officer retries `/lienkiet <CODE>` after deploy → bot replies "Liên kết thành công" → UI swap "Đã liên kết"

🤖 Generated with [Claude Code](https://claude.com/claude-code)