### PR TITLE
fix(zalo-bot): correct command spelling /lienket + debug log for payload drift

### DIFF
--- a/Backend_FastAPI/app/routers/zalo_bot_link.py
+++ b/Backend_FastAPI/app/routers/zalo_bot_link.py
@@ -81,7 +81,7 @@ async def generate_link_code(
         "code": code,
         "expires_in_seconds": 600,  # v5/E8: 10-min window for staff onboarding
         "instructions": (
-            f"Mở Zalo, tìm bot QLTS, gửi: /lienkiet {code}"
+            f"Mở Zalo, tìm bot QLTS, gửi: /lienket {code}"
         ),
     }
 

--- a/Backend_FastAPI/app/routers/zalo_bot_webhooks.py
+++ b/Backend_FastAPI/app/routers/zalo_bot_webhooks.py
@@ -106,26 +106,34 @@ async def zalo_bot_webhook(
         return Response(status_code=400, content="Invalid JSON")
 
     if not isinstance(data, dict):
+        log.warning("zalo_bot webhook non-object payload")
         return {"status": "ok", "mode": "non_object_payload"}
 
     result = data.get("result") or {}
-    # Zalo Bot Platform actually ships ``event_name`` at the **top level**
-    # of the payload (per https://bot.zaloplatforms.com/docs). Plan v5 +
-    # initial code mistakenly read it from ``data["result"]["event_name"]``,
-    # which silently returned ``ignored_event`` for every real message
-    # (smoke 2026-04-27 captured `/lienkiet` POST → 200 with no handler
-    # activity). Read top-level first, fall back to legacy nested shape so
-    # any provider variant still routes correctly.
+    # Zalo Bot Platform variants observed:
+    #   - top level: data["event_name"]
+    #   - nested:    data["result"]["event_name"]
+    # Smoke 2026-04-27 still hit ignored_event after PR #139 → real
+    # payload may use a 3rd shape. Log the structure (keys only, no
+    # values) when no event_name is found so we can iterate.
     event_name = (
         data.get("event_name")
         or (result.get("event_name") if isinstance(result, dict) else "")
         or ""
     )
     if event_name != "message.text.received":
-        # Other events (e.g. delivery callbacks) are ignored for now.
+        # Debug: surface the actual payload shape so future drift is
+        # visible. Keys only — values may contain link codes / chat
+        # IDs that are sensitive.
+        log.info(
+            "zalo_bot webhook ignored_event — debug shape",
+            top_keys=sorted(list(data.keys())),
+            result_keys=sorted(list(result.keys())) if isinstance(result, dict) else None,
+            event_name_seen=event_name or "<empty>",
+        )
         return {"status": "ok", "mode": "ignored_event", "event": event_name}
 
-    message = result.get("message") or {}
+    message = result.get("message") or data.get("message") or {}
     chat = message.get("chat") if isinstance(message, dict) else None
     chat_id = chat.get("id", "") if isinstance(chat, dict) else ""
     text_raw = (message.get("text") or "") if isinstance(message, dict) else ""
@@ -134,6 +142,14 @@ async def zalo_bot_webhook(
     display_name = sender.get("display_name", "") if isinstance(sender, dict) else ""
 
     if not chat_id or not text:
+        log.info(
+            "zalo_bot webhook noop — debug shape",
+            top_keys=sorted(list(data.keys())),
+            result_keys=sorted(list(result.keys())) if isinstance(result, dict) else None,
+            message_keys=sorted(list(message.keys())) if isinstance(message, dict) else None,
+            has_chat_id=bool(chat_id),
+            has_text=bool(text),
+        )
         return {"status": "ok", "mode": "noop"}
 
     # 3. Rate limit per chat_id.
@@ -158,14 +174,17 @@ async def zalo_bot_webhook(
 
     text_lower = text.lower()
 
-    # ---------------- /lienkiet <CODE> ----------------
-    if text_lower.startswith("/lienkiet"):
-        # Strip command, then the candidate code; format must be exact.
-        candidate = text[len("/lienkiet"):].strip().upper()
+    # ---------------- /lienket <CODE> ----------------
+    # "liên kết" without diacritics is "lien ket" (kết → ket, NOT kiet).
+    # Accept legacy "/lienkiet" too in case staff cached old instruction
+    # text — both route to the same handler.
+    if text_lower.startswith("/lienket") or text_lower.startswith("/lienkiet"):
+        prefix_len = len("/lienkiet") if text_lower.startswith("/lienkiet") else len("/lienket")
+        candidate = text[prefix_len:].strip().upper()
         if not _LINK_CODE_RE.match(candidate):
             await zalo_bot_gateway.send_message(
                 chat_id,
-                "Cú pháp sai. Gửi: /lienkiet <MA> (6 ký tự, chỉ chữ in hoa và số).",
+                "Cú pháp sai. Gửi: /lienket <MA> (6 ký tự, chỉ chữ in hoa và số).",
             )
             return {"status": "ok", "mode": "bad_format"}
 
@@ -191,8 +210,9 @@ async def zalo_bot_webhook(
         await zalo_bot_gateway.send_message(chat_id, reply)
         return {"status": "ok", "mode": "verify_and_link", "linked": ok}
 
-    # ---------------- /huylienkiet ----------------
-    if text_lower == "/huylienkiet":
+    # ---------------- /huylienket ----------------
+    # Same correction as /lienket above. Accept legacy "/huylienkiet" too.
+    if text_lower == "/huylienket" or text_lower == "/huylienkiet":
         try:
             ok, reply = await zalo_bot_link_service.unlink_by_chat_id(db, chat_id)
             if ok:
@@ -229,8 +249,8 @@ async def zalo_bot_webhook(
         chat_id,
         (
             "QLTS Bot:\n"
-            "/lienkiet <MA> — liên kết tài khoản\n"
-            "/huylienkiet — huỷ liên kết\n"
+            "/lienket <MA> — liên kết tài khoản\n"
+            "/huylienket — huỷ liên kết\n"
             "/trangthai — kiểm tra trạng thái"
         ),
     )

--- a/Backend_FastAPI/tests/api/test_zalo_bot_webhooks.py
+++ b/Backend_FastAPI/tests/api/test_zalo_bot_webhooks.py
@@ -165,7 +165,7 @@ class TestPayloadShape:
         verify.return_value = (False, "invalid")
         resp = await client.post(
             "/api/webhooks/zalo-bot",
-            json=_payload("/lienkiet ABC123"),  # uses top-level shape
+            json=_payload("/lienket ABC123"),  # uses top-level shape
             headers={"X-Bot-Api-Secret-Token": SECRET},
         )
         assert resp.status_code == 200
@@ -183,7 +183,7 @@ class TestPayloadShape:
         verify.return_value = (False, "invalid")
         resp = await client.post(
             "/api/webhooks/zalo-bot",
-            json=_payload_legacy_nested("/lienkiet ABC123"),
+            json=_payload_legacy_nested("/lienket ABC123"),
             headers={"X-Bot-Api-Secret-Token": SECRET},
         )
         assert resp.status_code == 200
@@ -217,7 +217,7 @@ class TestLienKietCommand:
 
         resp = await client.post(
             "/api/webhooks/zalo-bot",
-            json=_payload("/lienkiet ABC123"),
+            json=_payload("/lienket ABC123"),
             headers={"X-Bot-Api-Secret-Token": SECRET},
         )
         assert resp.status_code == 200
@@ -235,7 +235,7 @@ class TestLienKietCommand:
         # Lowercase + 3 chars — does not match [A-Z0-9]{6}.
         resp = await client.post(
             "/api/webhooks/zalo-bot",
-            json=_payload("/lienkiet abc"),
+            json=_payload("/lienket abc"),
             headers={"X-Bot-Api-Secret-Token": SECRET},
         )
         assert resp.status_code == 200
@@ -251,7 +251,7 @@ class TestLienKietCommand:
 
         resp = await client.post(
             "/api/webhooks/zalo-bot",
-            json=_payload("/lienkiet ABC123"),
+            json=_payload("/lienket ABC123"),
             headers={"X-Bot-Api-Secret-Token": SECRET},
         )
         # 200 so Zalo doesn't retry and double-consume the code.
@@ -266,7 +266,45 @@ class TestLienKietCommand:
 
 @pytest.mark.asyncio
 class TestUnlinkCommand:
-    async def test_huylienkiet_calls_service(
+    async def test_huylienket_calls_service(
+        self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
+    ):
+        _, unlink = link_service_mock
+        unlink.return_value = (True, "Đã huỷ liên kết.")
+
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("/huylienket"),
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "unlink"
+        unlink.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestLegacyCommandSpelling:
+    """Backward-compat: accept the old (incorrect Vietnamese) spelling
+    ``/lienkiet`` and ``/huylienkiet`` so staff who copied previous
+    instruction text still link successfully. Canonical spelling is
+    ``/lienket`` (liên kết without diacritics)."""
+
+    async def test_legacy_lienkiet_still_routed(
+        self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
+    ):
+        verify, _ = link_service_mock
+        verify.return_value = (True, "Liên kết thành công!")
+
+        resp = await client.post(
+            "/api/webhooks/zalo-bot",
+            json=_payload("/lienkiet ABC123"),
+            headers={"X-Bot-Api-Secret-Token": SECRET},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "verify_and_link"
+        verify.assert_awaited_once()
+
+    async def test_legacy_huylienkiet_still_routed(
         self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
     ):
         _, unlink = link_service_mock
@@ -314,8 +352,8 @@ class TestUnknownCommand:
         assert resp.status_code == 200
         assert resp.json()["mode"] == "help"
         sent_text = gateway_mock.send_message.await_args.args[1]
-        assert "/lienkiet" in sent_text
-        assert "/huylienkiet" in sent_text
+        assert "/lienket" in sent_text
+        assert "/huylienket" in sent_text
         assert "/trangthai" in sent_text
 
 

--- a/frontend/src/app/(dashboard)/settings/notifications/_components/NotificationSettingsClient.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/notifications/_components/NotificationSettingsClient.test.tsx
@@ -124,7 +124,7 @@ describe("Zalo Bot section", () => {
     mockGenerate.mockResolvedValueOnce({
       code: "ABC123",
       expires_in_seconds: 600,
-      instructions: "Mở Zalo, tìm bot QLTS, gửi: /lienkiet ABC123",
+      instructions: "Mở Zalo, tìm bot QLTS, gửi: /lienket ABC123",
     });
 
     render(<NotificationSettingsClient />);

--- a/frontend/src/hooks/useZaloBotLink.test.tsx
+++ b/frontend/src/hooks/useZaloBotLink.test.tsx
@@ -98,7 +98,7 @@ describe("useGenerateLinkCode", () => {
       data: {
         code: "ABC123",
         expires_in_seconds: 600,
-        instructions: "Mở Zalo, tìm bot QLTS, gửi: /lienkiet ABC123",
+        instructions: "Mở Zalo, tìm bot QLTS, gửi: /lienket ABC123",
       },
     });
 


### PR DESCRIPTION
## Summary

2 bugs in 1 fix, ship on prod that's currently silent for every real `/lienket` user types.

### Bug 1 — Wrong Vietnamese romanization

\"liên kết\" bỏ dấu = **`lien ket`** (kết → ket, **không phải kiet**). Code ban đầu viết `/lienkiet` (thừa chữ `i`). User thử `/lienket` đầu tiên — đúng tiếng Việt — nhưng code không match → bot im.

**Fix**: canonical command đổi sang `/lienket` + `/huylienket`. Legacy `/lienkiet` + `/huylienkiet` vẫn route về cùng handler để staff cached instruction cũ vẫn link được. Help text + instruction string + frontend fixtures đều update.

### Bug 2 — event_name parse vẫn miss sau PR #139

PR #139 thêm fallback top-level OR `result.event_name`, nhưng real Zalo webhook vẫn rơi vào early-return (no `zalo_bot webhook event` log on 2026-04-27 smoke). Real shape có thể là cái thứ 3 chưa cover.

**Fix**: thêm structured debug log cho cả 2 early-return path (`ignored_event`, `noop`) — log `top_keys`, `result_keys`, `message_keys` (KHÔNG log values vì link code nhạy cảm). Webhook hit tiếp theo sẽ surface real shape qua structured log → iterate không cần đoán mò. Cũng widen message extraction để accept `data.message` flat (phòng Zalo flatten cho một số event).

## Test plan

- [x] `pytest tests/api/test_zalo_bot_webhooks.py` → 18 passed (gồm 2 legacy compat test)
- [ ] Deploy → user retry với `/lienket <CODE>` đúng cú pháp → bot reply "Liên kết thành công"
- [ ] Nếu vẫn fail: kiểm tra backend log structured debug để biết shape thật → iterate

## Backward compat

| Old command | New canonical | Behavior |
|---|---|---|
| `/lienkiet ABC123` | `/lienket ABC123` | Both work — same handler |
| `/huylienkiet` | `/huylienket` | Both work — same handler |

Help text giờ chỉ show canonical (`/lienket`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)