### PR TITLE
feat(notifications): exclude actor from their own notifications

### DIFF
--- a/Backend_FastAPI/app/services/notification_dispatcher.py
+++ b/Backend_FastAPI/app/services/notification_dispatcher.py
@@ -777,6 +777,29 @@ async def dispatch(
                 resolved = []
         action_user_map[action.step] = resolved
 
+    # v5: Exclude the actor from their own notifications. Officer self-assigns
+    # a lead → don't spam themselves. Manager self-creates a lead → same.
+    # Applies universally because every current EventDefinition with a
+    # ``user_id_int`` actor follows the "tell others, not the actor" pattern.
+    # If a future event genuinely needs to notify the actor (e.g. an audit
+    # confirmation), gate this with a per-event opt-out flag — none today.
+    actor_id = payload.get("actor_id")
+    if isinstance(actor_id, int):
+        excluded_count = 0
+        for step in list(action_user_map.keys()):
+            before = action_user_map[step]
+            after = [uid for uid in before if uid != actor_id]
+            if len(after) != len(before):
+                excluded_count += len(before) - len(after)
+                action_user_map[step] = after
+        if excluded_count:
+            log.debug(
+                "Excluded actor from recipients",
+                event_type=event.value,
+                actor_id=actor_id,
+                excluded_count=excluded_count,
+            )
+
     all_internal_user_ids = sorted(set(uid for uids in action_user_map.values() for uid in uids))
 
     if not all_internal_user_ids and not has_external_actions:

--- a/Backend_FastAPI/tests/services/test_notification_dispatcher.py
+++ b/Backend_FastAPI/tests/services/test_notification_dispatcher.py
@@ -108,6 +108,104 @@ class TestNotificationDispatcher:
         mock_domain_emit.assert_called_once()
         mock_channel_send.assert_called_once()
 
+    async def test_dispatch_excludes_actor_self_assignment(
+        self,
+        db: AsyncSession,
+        officer_user_in_db: dict,
+        mocker,
+    ):
+        """v5: Actor must not receive notification of their own action.
+
+        Officer self-assigns a lead → don't spam themselves. Generic
+        across every event with ``actor_id``: dispatcher filters the
+        actor out of the resolved recipient list before persistence.
+        """
+        user_id = officer_user_in_db["id"]
+        event = SystemEvents.SYSTEM_ALERT
+
+        rule = models.NotificationRule(
+            event=event.value,
+            title_template="Self-action",
+            message_template="Should not arrive in inbox",
+            recipient_config={"resolver_type": "specific_users", "params": {}},
+            enabled=True,
+        )
+        db.add(rule)
+        await db.flush()
+        db.add(models.NotificationAction(
+            rule_id=rule.id, step=1, channel="browser",
+            content_mode="inherit_default",
+        ))
+        await db.commit()
+
+        mocker.patch(
+            "app.services.notification_dispatcher._emit_domain_event",
+            new_callable=AsyncMock,
+        )
+        mocker.patch(
+            "app.services.notification_dispatcher._send_via_channel",
+            new_callable=AsyncMock,
+            return_value=("browser", MagicMock(sent_count=0, failed_ids=[], success=True), None),
+        )
+
+        # actor_id == user_id → resolver returns [user_id], dispatcher
+        # then filters it out → no notification rows, no channel send.
+        payload = {"user_id": user_id, "actor_id": user_id}
+        notification_ids, callback = await dispatch(db, event, payload)
+        if callback:
+            await callback()
+
+        assert notification_ids == [], (
+            f"Actor {user_id} should be excluded from their own notification, "
+            f"got ids: {notification_ids}"
+        )
+
+    async def test_dispatch_keeps_recipient_when_actor_is_different(
+        self,
+        db: AsyncSession,
+        officer_user_in_db: dict,
+        admin_user_in_db: dict,
+        mocker,
+    ):
+        """Different actor → recipient still notified (no over-exclusion)."""
+        user_id = officer_user_in_db["id"]
+        actor_id = admin_user_in_db["id"]
+        event = SystemEvents.SYSTEM_ALERT
+
+        rule = models.NotificationRule(
+            event=event.value,
+            title_template="Different actor",
+            message_template="Recipient should still get this",
+            recipient_config={"resolver_type": "specific_users", "params": {}},
+            enabled=True,
+        )
+        db.add(rule)
+        await db.flush()
+        db.add(models.NotificationAction(
+            rule_id=rule.id, step=1, channel="browser",
+            content_mode="inherit_default",
+        ))
+        await db.commit()
+
+        mocker.patch(
+            "app.services.notification_dispatcher._emit_domain_event",
+            new_callable=AsyncMock,
+        )
+        mocker.patch(
+            "app.services.notification_dispatcher._send_via_channel",
+            new_callable=AsyncMock,
+            return_value=("browser", MagicMock(sent_count=1, failed_ids=[], success=True), None),
+        )
+
+        payload = {"user_id": user_id, "actor_id": actor_id}
+        notification_ids, callback = await dispatch(db, event, payload)
+        if callback:
+            await callback()
+
+        assert len(notification_ids) == 1, (
+            "Officer should still be notified when actor (admin) is a different user"
+        )
+
     async def test_dispatch_deduplication(
         self, 
         db: AsyncSession, 


### PR DESCRIPTION
## Summary

Officer self-assigns a lead → bot spams họ về LEAD_ASSIGNED của chính họ. User báo 2026-04-27 sau khi pilot thành công nhưng UX kém vì self-spam.

## Fix

Dispatcher-level filter sau resolver chain: drop `payload["actor_id"]` khỏi resolved recipient list. Universal cho mọi event vì hiện không event nào cần notify actor về action của chính họ.

## Affected events (đều improve UX)

| Event | Trước | Sau |
|---|---|---|
| LEAD_ASSIGNED self-assign | spam officer | im ✓ |
| LEAD_CREATED by manager (in their own unit) | spam manager | im ✓ |
| LEAD_UPDATED khi actor cũng là lead_owner | spam | im ✓ |
| LEAD_REASSIGNED actor=manager, recipient=officer | đã đúng | giữ nguyên |

## Tests

- `test_dispatch_excludes_actor_self_assignment` — actor == recipient → 0 notifications
- `test_dispatch_keeps_recipient_when_actor_is_different` — actor != recipient → vẫn notify (no over-exclusion)

```
pytest tests/services/test_notification_dispatcher.py -k "actor or excludes or keeps" → 2 passed
pytest tests/services/test_notification_dispatcher.py tests/integration/test_notification_core_v2.py → 25 passed (1 batch pollution unrelated)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)