### PR TITLE
feat(notifications): zalo_bot pilot — 10 events + is_self_action condition

### DIFF
--- a/Backend_FastAPI/alembic/versions/zalobot002_seed_zalo_bot_actions_for_10_events.py
+++ b/Backend_FastAPI/alembic/versions/zalobot002_seed_zalo_bot_actions_for_10_events.py
@@ -4,41 +4,47 @@ Revision ID: zalobot002
 Revises: zalobot001
 Create Date: 2026-04-27
 
-Adds a ``channel='zalo_bot'`` action to 9 notification rules (rule #1
-``lead_assigned`` already had one added by hand in the smoke session, so
-this migration is idempotent and skips it). After this lands, every event
-in the pilot scope dispatches through the Zalo Bot channel for any user
+Adds a ``channel='zalo_bot'`` action to up to 10 notification rules so
+the v5 pilot events dispatch through the Zalo Bot channel for any user
 whose preferences allow it.
 
-Pilot scope (Tier 1 + Tier 2):
+Pilot scope (Tier 1 + Tier 2 — see project_zalo_bot_plan_audit memory):
 
-| Event                       | Recipient            | Self-condition needed? |
-|-----------------------------|----------------------|------------------------|
-| lead_assigned (already had) | officer              | yes (admin via wizard) |
-| lead_reassigned             | old + new officer    | (deferred)             |
-| lead_assignment_failed      | unit manager         | no                     |
-| consultation_reminder       | officer              | no                     |
-| application_created         | unit manager + own.  | (deferred)             |
-| application_status_changed  | profile owner        | (deferred)             |
-| application_fee_paid        | officer + accountant | (deferred)             |
-| payment_overdue             | accountant           | no                     |
-| suspicious_login            | affected user        | no                     |
-| system_alert                | admin                | no                     |
+| Event                       | Recipient            |
+|-----------------------------|----------------------|
+| lead_assigned               | officer              |
+| lead_reassigned             | old + new officer    |
+| lead_assignment_failed      | unit manager         |
+| consultation_reminder       | officer              |
+| application_created         | unit manager + own.  |
+| application_status_changed  | profile owner        |
+| application_fee_paid        | officer + accountant |
+| payment_overdue             | accountant           |
+| suspicious_login            | affected user        |
+| system_alert                | admin                |
 
-Each row is inserted with ``content_mode='inherit_default'`` so the bot
-reuses the rule's existing title/message templates (browser/email shape).
-We deliberately do NOT override per-channel templates yet — that's a
-follow-up after the operator decides which event needs a bot-friendly
-multi-line layout.
+Idempotency
+-----------
+Insert is gated by ``WHERE NOT EXISTS`` on the same (rule, channel)
+pair, so re-running the migration is a no-op. ``content_mode`` is
+``inherit_default`` so the bot reuses the rule's existing title /
+message templates — per-bot template overrides are deferred until the
+operator decides whether each event needs a bot-friendly multi-line
+layout.
 
-The migration uses ``INSERT ... WHERE NOT EXISTS`` so re-running is
-safe. ``step`` is computed as ``MAX(step) + 1`` per rule so we don't
-collide with existing actions; ``branch_key`` follows the existing
-convention ``group_<step>_<channel>`` used by the wizard.
+Marker / safe downgrade
+-----------------------
+Each row inserted by THIS migration is tagged via
+``config = {"seeded_by": "zalobot002"}``. ``downgrade()`` deletes only
+rows carrying this marker. Pre-existing ``zalo_bot`` actions added by
+hand earlier (rule #1 ``lead_assigned`` was seeded via SQL during the
+2026-04-27 smoke session, BEFORE this migration was written) carry
+no marker and are therefore preserved across a downgrade. Likewise,
+any zalo_bot action added later by an admin via the
+``/admin/notification-rules`` wizard is not touched.
 
-Downgrade removes only the rows this migration inserted (matched on
-rule + channel = 'zalo_bot'). Other zalo_bot actions added later by an
-admin via the wizard are left intact.
+This guarantees a downgrade of zalobot002 is reversible without
+collateral damage to operator-curated rule state.
 """
 from typing import Sequence, Union
 
@@ -52,9 +58,8 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 # Events that should dispatch through Zalo Bot for v5 pilot.
-# Order matches the user-confirmed Tier 1 + Tier 2 list. Rule lookup is
-# by ``event`` (string) so this works even if a fresh DB has different
-# auto-increment ids than prod.
+# Lookup is by ``event`` (string) so this works on any DB regardless
+# of auto-increment id assignment.
 PILOT_EVENTS = [
     "lead_assigned",
     "lead_reassigned",
@@ -69,13 +74,20 @@ PILOT_EVENTS = [
 ]
 
 
+# Marker stamped onto every row inserted by this migration. Downgrade
+# deletes only rows carrying this exact value, so rows created outside
+# this migration (manual SQL, admin wizard, future migrations) are
+# preserved.
+MARKER_CONFIG_JSON = '{"seeded_by": "zalobot002"}'
+
+
 def upgrade() -> None:
     for event in PILOT_EVENTS:
         op.execute(
             f"""
             INSERT INTO notification_action (
                 rule_id, step, channel, delay_minutes, content_mode,
-                branch_key, created_at, updated_at
+                branch_key, config, created_at, updated_at
             )
             SELECT
                 nr.id,
@@ -84,6 +96,7 @@ def upgrade() -> None:
                 0,
                 'inherit_default',
                 'group_' || (COALESCE(MAX(na.step), 0) + 1) || '_zalo_bot',
+                '{MARKER_CONFIG_JSON}'::json,
                 now(),
                 now()
             FROM notification_rule nr
@@ -99,17 +112,14 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Only delete rows that match (event in PILOT_EVENTS, channel='zalo_bot').
-    # Any zalo_bot action added by an admin via the wizard for a different
-    # event is left untouched.
-    event_list = ", ".join(f"'{e}'" for e in PILOT_EVENTS)
+    # Only rows tagged with our marker are removed. ``config->>'seeded_by'``
+    # extracts the marker value as text; rows without the marker (or
+    # with NULL config) keep config->>'seeded_by' = NULL → not matched.
     op.execute(
-        f"""
+        """
         DELETE FROM notification_action
         WHERE channel = 'zalo_bot'
-          AND rule_id IN (
-              SELECT id FROM notification_rule
-              WHERE event IN ({event_list})
-          );
+          AND config IS NOT NULL
+          AND config->>'seeded_by' = 'zalobot002';
         """
     )

--- a/Backend_FastAPI/alembic/versions/zalobot002_seed_zalo_bot_actions_for_10_events.py
+++ b/Backend_FastAPI/alembic/versions/zalobot002_seed_zalo_bot_actions_for_10_events.py
@@ -1,0 +1,115 @@
+"""Seed zalo_bot NotificationAction rows for 10 v5-pilot events.
+
+Revision ID: zalobot002
+Revises: zalobot001
+Create Date: 2026-04-27
+
+Adds a ``channel='zalo_bot'`` action to 9 notification rules (rule #1
+``lead_assigned`` already had one added by hand in the smoke session, so
+this migration is idempotent and skips it). After this lands, every event
+in the pilot scope dispatches through the Zalo Bot channel for any user
+whose preferences allow it.
+
+Pilot scope (Tier 1 + Tier 2):
+
+| Event                       | Recipient            | Self-condition needed? |
+|-----------------------------|----------------------|------------------------|
+| lead_assigned (already had) | officer              | yes (admin via wizard) |
+| lead_reassigned             | old + new officer    | (deferred)             |
+| lead_assignment_failed      | unit manager         | no                     |
+| consultation_reminder       | officer              | no                     |
+| application_created         | unit manager + own.  | (deferred)             |
+| application_status_changed  | profile owner        | (deferred)             |
+| application_fee_paid        | officer + accountant | (deferred)             |
+| payment_overdue             | accountant           | no                     |
+| suspicious_login            | affected user        | no                     |
+| system_alert                | admin                | no                     |
+
+Each row is inserted with ``content_mode='inherit_default'`` so the bot
+reuses the rule's existing title/message templates (browser/email shape).
+We deliberately do NOT override per-channel templates yet — that's a
+follow-up after the operator decides which event needs a bot-friendly
+multi-line layout.
+
+The migration uses ``INSERT ... WHERE NOT EXISTS`` so re-running is
+safe. ``step`` is computed as ``MAX(step) + 1`` per rule so we don't
+collide with existing actions; ``branch_key`` follows the existing
+convention ``group_<step>_<channel>`` used by the wizard.
+
+Downgrade removes only the rows this migration inserted (matched on
+rule + channel = 'zalo_bot'). Other zalo_bot actions added later by an
+admin via the wizard are left intact.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "zalobot002"
+down_revision: Union[str, None] = "zalobot001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Events that should dispatch through Zalo Bot for v5 pilot.
+# Order matches the user-confirmed Tier 1 + Tier 2 list. Rule lookup is
+# by ``event`` (string) so this works even if a fresh DB has different
+# auto-increment ids than prod.
+PILOT_EVENTS = [
+    "lead_assigned",
+    "lead_reassigned",
+    "lead_assignment_failed",
+    "consultation_reminder",
+    "application_created",
+    "application_status_changed",
+    "application_fee_paid",
+    "payment_overdue",
+    "suspicious_login",
+    "system_alert",
+]
+
+
+def upgrade() -> None:
+    for event in PILOT_EVENTS:
+        op.execute(
+            f"""
+            INSERT INTO notification_action (
+                rule_id, step, channel, delay_minutes, content_mode,
+                branch_key, created_at, updated_at
+            )
+            SELECT
+                nr.id,
+                COALESCE(MAX(na.step), 0) + 1,
+                'zalo_bot',
+                0,
+                'inherit_default',
+                'group_' || (COALESCE(MAX(na.step), 0) + 1) || '_zalo_bot',
+                now(),
+                now()
+            FROM notification_rule nr
+            LEFT JOIN notification_action na ON na.rule_id = nr.id
+            WHERE nr.event = '{event}'
+              AND NOT EXISTS (
+                  SELECT 1 FROM notification_action
+                  WHERE rule_id = nr.id AND channel = 'zalo_bot'
+              )
+            GROUP BY nr.id;
+            """
+        )
+
+
+def downgrade() -> None:
+    # Only delete rows that match (event in PILOT_EVENTS, channel='zalo_bot').
+    # Any zalo_bot action added by an admin via the wizard for a different
+    # event is left untouched.
+    event_list = ", ".join(f"'{e}'" for e in PILOT_EVENTS)
+    op.execute(
+        f"""
+        DELETE FROM notification_action
+        WHERE channel = 'zalo_bot'
+          AND rule_id IN (
+              SELECT id FROM notification_rule
+              WHERE event IN ({event_list})
+          );
+        """
+    )

--- a/Backend_FastAPI/app/core/event_catalog.py
+++ b/Backend_FastAPI/app/core/event_catalog.py
@@ -174,6 +174,17 @@ _LEAD_EVENTS: tuple = (
             _var("lead_name", "string", "Tên lead", False),
             _var("lead_phone", "string", "SĐT lead", False),
             _var("offering_name", "string", "Tên chương trình", False),
+            # v5: Derived flag auto-injected by the dispatcher when
+            # ``actor_id == officer_id``. Admin can add a condition
+            # ``is_self_action eq false`` in the rule wizard to
+            # suppress notifications when an officer self-assigns a
+            # lead (avoid self-spam).
+            _var(
+                "is_self_action",
+                "boolean",
+                "True nếu officer tự assign lead cho chính mình. Dùng để filter self-spam qua condition.",
+                False,
+            ),
         ),
         condition_fields=_ACTOR_CONDS + _LEAD_CONDS,
         default_resolver="lead_owner",

--- a/Backend_FastAPI/app/core/event_catalog.py
+++ b/Backend_FastAPI/app/core/event_catalog.py
@@ -186,7 +186,18 @@ _LEAD_EVENTS: tuple = (
                 False,
             ),
         ),
-        condition_fields=_ACTOR_CONDS + _LEAD_CONDS,
+        # ``is_self_action`` is also exposed as a condition field so the
+        # admin wizard can offer it in the rule builder dropdown and the
+        # rule-CRUD validator accepts ``{field: "is_self_action", ...}``
+        # without rejecting it as unknown. Boolean operators only.
+        condition_fields=_ACTOR_CONDS + _LEAD_CONDS + (
+            _cond(
+                "is_self_action",
+                "boolean",
+                "Officer tự assign lead cho chính mình (dispatcher derives from actor_id == officer_id)",
+                _OPS_BOOL,
+            ),
+        ),
         default_resolver="lead_owner",
         allowed_resolvers=_LEAD_RESOLVERS,
         default_channels=("browser", "email"),

--- a/Backend_FastAPI/app/services/notification_dispatcher.py
+++ b/Backend_FastAPI/app/services/notification_dispatcher.py
@@ -711,6 +711,23 @@ async def dispatch(
         channels=config.channel_values
     )
 
+    # v5: Inject ``is_self_action`` derived field so admins can add a
+    # condition like ``is_self_action eq false`` to suppress notifications
+    # when the actor and the recipient are the same person (officer
+    # self-assigns a lead → don't spam themselves).
+    #
+    # We compute this from payload alone (NOT from resolver output) so it
+    # is available before condition eval. Currently only events whose
+    # payload contains both ``actor_id`` and ``officer_id`` are covered —
+    # that's LEAD_ASSIGNED today. Other events that want this filter can
+    # adopt by including ``officer_id`` in their payload, or via a future
+    # field-vs-field condition operator.
+    if "is_self_action" not in payload:
+        actor_id = payload.get("actor_id")
+        officer_id = payload.get("officer_id")
+        if isinstance(actor_id, int) and isinstance(officer_id, int):
+            payload["is_self_action"] = (actor_id == officer_id)
+
     # Step 1.5: ✅ PHASE 2.3: Check activation condition (database rules only)
     # Phase 2: Build evaluation context (nested dicts) for condition evaluation
     if rule_source == "database" and hasattr(config, 'should_activate'):

--- a/Backend_FastAPI/tests/api/test_notification_rule_crud.py
+++ b/Backend_FastAPI/tests/api/test_notification_rule_crud.py
@@ -115,6 +115,65 @@ class TestNotificationRuleCrudApi:
         # Status follows the env flag — in test it's typically off → "planned".
         assert zalo_bot["status"] in {"live", "planned"}
 
+        # v5: ``is_self_action`` is a derived boolean condition field on
+        # LEAD_ASSIGNED. The wizard reads this list to populate the
+        # condition-builder dropdown; backend validation rejects any
+        # condition referencing a field NOT in this list. Pin the shape.
+        lead_assigned_event = lead_assigned  # alias for readability
+        cond_fields = lead_assigned_event.get("condition_fields", [])
+        is_self = next(
+            (cf for cf in cond_fields if cf.get("path") == "is_self_action"),
+            None,
+        )
+        assert is_self is not None, (
+            "lead_assigned.condition_fields must expose is_self_action so the "
+            "admin wizard can offer it for self-exclude conditions"
+        )
+        assert is_self.get("type") == "boolean", (
+            "is_self_action must be typed boolean — wizard renders true/false"
+        )
+        ops = set(is_self.get("operators", []))
+        assert {"eq", "ne"} <= ops, (
+            f"is_self_action needs eq/ne operators, got {sorted(ops)}"
+        )
+
+    async def test_create_rule_with_is_self_action_condition_accepted(
+        self, client: AsyncClient, admin_token_headers: dict,
+    ):
+        """v5: rule CRUD accepts ``{is_self_action eq false}`` as the
+        admin's path to suppress officer self-spam without code change.
+        """
+        body = {
+            "event": "lead_assigned",
+            "title_template": "Lead mới",
+            "message_template": "Bạn có lead mới: ${lead_name}",
+            "notification_type": "info",
+            "recipient_config": {"resolver_type": "lead_owner", "params": {}},
+            "condition": {
+                "field": "is_self_action",
+                "operator": "eq",
+                "value": False,
+            },
+            "actions": [
+                {"step": 1, "channel": "browser", "delay_minutes": 0,
+                 "content_mode": "inherit_default"},
+            ],
+            "enabled": False,  # don't activate — keep test isolated
+        }
+        resp = await client.post(
+            "/api/notification-rules",
+            headers=admin_token_headers,
+            json=body,
+        )
+        # 200/201 = created; 409 = lead_assigned already has a rule (acceptable
+        # — an existing rule means the validator accepted the condition shape
+        # too). Anything else (400/422) means the validator wrongly rejected
+        # is_self_action as an unknown condition field.
+        assert resp.status_code in (200, 201, 409), (
+            f"is_self_action condition rejected by rule CRUD: "
+            f"status={resp.status_code} body={resp.text}"
+        )
+
     async def test_list_rules_returns_paginated(
         self, client: AsyncClient, admin_token_headers: dict,
     ):

--- a/Backend_FastAPI/tests/services/test_notification_dispatcher.py
+++ b/Backend_FastAPI/tests/services/test_notification_dispatcher.py
@@ -108,6 +108,108 @@ class TestNotificationDispatcher:
         mock_domain_emit.assert_called_once()
         mock_channel_send.assert_called_once()
 
+    async def test_dispatch_suppresses_when_is_self_action_condition_set(
+        self,
+        db: AsyncSession,
+        officer_user_in_db: dict,
+        mocker,
+    ):
+        """v5: Admin can add condition ``is_self_action eq false`` on a
+        rule so the officer who self-assigns a lead doesn't get spammed.
+
+        The dispatcher injects ``is_self_action`` automatically when the
+        payload carries both ``actor_id`` and ``officer_id``. Condition
+        eval runs against this derived field and blocks the dispatch.
+        """
+        user_id = officer_user_in_db["id"]
+        event = SystemEvents.SYSTEM_ALERT  # any user-class event with a rule
+
+        rule = models.NotificationRule(
+            event=event.value,
+            title_template="Lead assigned",
+            message_template="Should not arrive on self-assign",
+            recipient_config={"resolver_type": "specific_users", "params": {}},
+            condition={"field": "is_self_action", "operator": "eq", "value": False},
+            enabled=True,
+        )
+        db.add(rule)
+        await db.flush()
+        db.add(models.NotificationAction(
+            rule_id=rule.id, step=1, channel="browser",
+            content_mode="inherit_default",
+        ))
+        await db.commit()
+
+        mocker.patch(
+            "app.services.notification_dispatcher._emit_domain_event",
+            new_callable=AsyncMock,
+        )
+        send_mock = mocker.patch(
+            "app.services.notification_dispatcher._send_via_channel",
+            new_callable=AsyncMock,
+            return_value=("browser", MagicMock(sent_count=0, failed_ids=[], success=True), None),
+        )
+
+        # actor == officer → dispatcher injects is_self_action=True →
+        # condition (is_self_action eq false) is NOT met → rule does
+        # not activate → no notification rows + no channel send.
+        payload = {"user_id": user_id, "actor_id": user_id, "officer_id": user_id}
+        notification_ids, callback = await dispatch(db, event, payload)
+        if callback:
+            await callback()
+
+        assert notification_ids == [], (
+            "Self-assign with is_self_action condition should block all notifications"
+        )
+        send_mock.assert_not_called()
+
+    async def test_dispatch_passes_when_actor_differs_from_officer(
+        self,
+        db: AsyncSession,
+        officer_user_in_db: dict,
+        admin_user_in_db: dict,
+        mocker,
+    ):
+        """Different actor → ``is_self_action=False`` → condition met → notify."""
+        user_id = officer_user_in_db["id"]
+        actor_id = admin_user_in_db["id"]
+        event = SystemEvents.SYSTEM_ALERT
+
+        rule = models.NotificationRule(
+            event=event.value,
+            title_template="Lead assigned",
+            message_template="Notify when actor differs",
+            recipient_config={"resolver_type": "specific_users", "params": {}},
+            condition={"field": "is_self_action", "operator": "eq", "value": False},
+            enabled=True,
+        )
+        db.add(rule)
+        await db.flush()
+        db.add(models.NotificationAction(
+            rule_id=rule.id, step=1, channel="browser",
+            content_mode="inherit_default",
+        ))
+        await db.commit()
+
+        mocker.patch(
+            "app.services.notification_dispatcher._emit_domain_event",
+            new_callable=AsyncMock,
+        )
+        mocker.patch(
+            "app.services.notification_dispatcher._send_via_channel",
+            new_callable=AsyncMock,
+            return_value=("browser", MagicMock(sent_count=1, failed_ids=[], success=True), None),
+        )
+
+        payload = {"user_id": user_id, "actor_id": actor_id, "officer_id": user_id}
+        notification_ids, callback = await dispatch(db, event, payload)
+        if callback:
+            await callback()
+
+        assert len(notification_ids) == 1, (
+            "Recipient should still receive the notification when actor != officer"
+        )
+
     async def test_dispatch_deduplication(
         self, 
         db: AsyncSession, 

--- a/Backend_FastAPI/tests/services/test_notification_dispatcher.py
+++ b/Backend_FastAPI/tests/services/test_notification_dispatcher.py
@@ -112,6 +112,7 @@ class TestNotificationDispatcher:
         self,
         db: AsyncSession,
         officer_user_in_db: dict,
+        clear_redis_keys,
         mocker,
     ):
         """v5: Admin can add condition ``is_self_action eq false`` on a
@@ -154,7 +155,9 @@ class TestNotificationDispatcher:
         # condition (is_self_action eq false) is NOT met → rule does
         # not activate → no notification rows + no channel send.
         payload = {"user_id": user_id, "actor_id": user_id, "officer_id": user_id}
-        notification_ids, callback = await dispatch(db, event, payload)
+        notification_ids, callback = await dispatch(
+            db, event, payload, dedupe_key="test_self_action_suppress",
+        )
         if callback:
             await callback()
 
@@ -168,6 +171,7 @@ class TestNotificationDispatcher:
         db: AsyncSession,
         officer_user_in_db: dict,
         admin_user_in_db: dict,
+        clear_redis_keys,
         mocker,
     ):
         """Different actor → ``is_self_action=False`` → condition met → notify."""
@@ -202,7 +206,9 @@ class TestNotificationDispatcher:
         )
 
         payload = {"user_id": user_id, "actor_id": actor_id, "officer_id": user_id}
-        notification_ids, callback = await dispatch(db, event, payload)
+        notification_ids, callback = await dispatch(
+            db, event, payload, dedupe_key="test_self_action_pass",
+        )
         if callback:
             await callback()
 


### PR DESCRIPTION
## Summary

Đóng gói hai thay đổi cùng goal "Zalo Bot pilot khả dụng end-to-end":

1. **Migration `zalobot002`** seed `NotificationAction(channel='zalo_bot')` cho 10 rule operator chốt
2. **Dispatcher inject `is_self_action`** để admin add condition self-exclude qua wizard

## 10 events trong scope pilot

| Tier | Event | Self-condition? |
|---|---|---|
| 1 | lead_assigned | ✅ (anh add qua wizard) |
| 1 | consultation_reminder | – |
| 1 | application_status_changed | (defer) |
| 1 | payment_overdue | – |
| 1 | suspicious_login | – |
| 2 | lead_reassigned | (defer multi-recipient) |
| 2 | lead_assignment_failed | – |
| 2 | application_fee_paid | (defer) |
| 2 | application_created | (defer) |
| 2 | system_alert | – |

Migration idempotent + roundtrip verified. ``content_mode='inherit_default'`` — bot dùng template hiện có (browser/email format), operator iterate per-event sau pilot.

## is_self_action filter

Dispatcher tự inject `is_self_action: bool = (actor_id == officer_id)` vào payload trước condition eval. Today chỉ LEAD_ASSIGNED có cả 2 field → admin có thể add condition `is_self_action eq false` qua `/admin/notification-rules` để chặn officer tự assign tự nhận tin.

## Replaces PR #141

PR #141 propose universal dispatcher-level exclude — operator review chỉ ra vi phạm V3 "Smart Config, Dumb Code" (hardcoded, không override được per-rule). Closed. PR này thay thế: derived field + admin condition trên rule.

## Test plan

```
pytest tests/services/test_notification_dispatcher.py -k "is_self_action or actor_differs" → 2 passed
```

- [x] Migration upgrade/downgrade idempotent
- [x] is_self_action injected only when actor_id + officer_id present
- [x] Self-assign blocked with condition
- [x] Actor != officer notify đúng
- [ ] Post-deploy: anh add condition lead_assigned + bật toggle Zalo Bot per group + smoke pilot

## Manual steps post-deploy

1. Vào `/admin/notification-rules` → edit `lead_assigned` → Step 1 Trigger → Add condition `is_self_action eq false` → Save
2. Vào `/settings/notifications` → bật toggle Zalo Bot cho 5 group: Lead, Application, Finance, Security, System
3. Smoke: tự tạo lead + assign cho mình → bot KHÔNG gửi (self-exclude) ; nhờ user khác assign về anh → bot GỬI

🤖 Generated with [Claude Code](https://claude.com/claude-code)