### PR TITLE
fix(notifications): rule condition hydration + 5 follow-up bugs

### DIFF
--- a/Backend_FastAPI/app/repositories/notification_delivery_repository.py
+++ b/Backend_FastAPI/app/repositories/notification_delivery_repository.py
@@ -572,7 +572,11 @@ class NotificationDeliveryRepository(BaseRepository[NotificationDelivery]):
                 "event": r[0],
                 "total": r[1],
                 "failed": r[2],
-                "fail_rate": round(r[2] / r[1] * 100, 1) if r[1] > 0 else 0.0,
+                # Returned as ratio (0–1) to match the convention used by
+                # `get_failure_rate` and the frontend `TopEventsTable` /
+                # `AlertBanner` consumers, which apply ×100 themselves. The
+                # earlier `* 100` here caused a "5000.0%" double-percent display.
+                "fail_rate": round(r[2] / r[1], 4) if r[1] > 0 else 0.0,
             }
             for r in rows
         ]

--- a/Backend_FastAPI/app/services/notification_rule_crud_service.py
+++ b/Backend_FastAPI/app/services/notification_rule_crud_service.py
@@ -399,10 +399,15 @@ async def update_rule(
             log.warning("Unknown event for condition validation", event=event_name)
             raise BadRequest(f"Unknown event '{event_name}' — condition validation failed. Verify event name.")
 
+    # Fields whose model column is nullable — admin can clear them by
+    # explicitly sending `null`. Other fields skip null (treated as
+    # "field not changed" rather than "wipe a non-nullable column").
+    _CLEARABLE_FIELDS = {"condition", "link_template", "template_id"}
     for field, value in update_data.items():
-        if value is not None:
-            setattr(rule, field, value)
-            updated_fields.append(field)
+        if value is None and field not in _CLEARABLE_FIELDS:
+            continue
+        setattr(rule, field, value)
+        updated_fields.append(field)
 
     # Handle actions update
     if rule_update.actions is not None:

--- a/Backend_FastAPI/app/services/notification_template_service.py
+++ b/Backend_FastAPI/app/services/notification_template_service.py
@@ -132,12 +132,17 @@ async def update_template(
     # Track which fields were updated
     updated_fields = []
 
-    # Update fields if provided
+    # Update fields if provided. `exclude_unset=True` already filters
+    # fields the client didn't touch, so we only need to guard non-nullable
+    # columns against an explicit `null` from a stale client. Nullable
+    # columns are clearable — admin can blank them by sending `null`.
     update_data = template_update.model_dump(exclude_unset=True)
+    _CLEARABLE_FIELDS = {"description", "link_template", "variables", "category", "allowed_events"}
     for field, value in update_data.items():
-        if value is not None:
-            setattr(template, field, value)
-            updated_fields.append(field)
+        if value is None and field not in _CLEARABLE_FIELDS:
+            continue
+        setattr(template, field, value)
+        updated_fields.append(field)
 
     # 1.9e: Find rules that reference this template (for cache invalidation)
     from sqlalchemy import select

--- a/Backend_FastAPI/tests/api/test_notification_delivery_ops_d5.py
+++ b/Backend_FastAPI/tests/api/test_notification_delivery_ops_d5.py
@@ -174,10 +174,29 @@ async def test_top_events_limit(client: AsyncClient, seeded):
 
 @pytest.mark.asyncio
 async def test_top_events_fail_rate(client: AsyncClient, seeded):
+    """`fail_rate` is a ratio (0..1), matching `get_failure_rate` and the
+    frontend `TopEventsTable`/`AlertBanner` consumers (which apply ×100
+    themselves). Pin both bounds AND the actual ratios from the seed
+    fixture so a regression to "percent" output (which would render as
+    "5000.0%") fails this test instead of slipping past `<= 100.0`.
+    """
     resp = await client.get(f"{URL}/stats/top-events", headers=seeded["headers"])
-    for ev in resp.json()["events"]:
+    events = {ev["event"]: ev for ev in resp.json()["events"]}
+    for ev in events.values():
         assert "fail_rate" in ev
-        assert 0.0 <= ev["fail_rate"] <= 100.0
+        assert 0.0 <= ev["fail_rate"] <= 1.0, (
+            f"fail_rate must be a ratio (0..1), got {ev['fail_rate']} for {ev['event']}"
+        )
+    # Seed: lead_assigned = 1 failed / 3 total ≈ 0.3333
+    if "lead_assigned" in events:
+        assert events["lead_assigned"]["total"] == 3
+        assert events["lead_assigned"]["failed"] == 1
+        assert abs(events["lead_assigned"]["fail_rate"] - (1 / 3)) < 0.01
+    # Seed: profile_submitted = 1 failed / 2 total = 0.5
+    if "profile_submitted" in events:
+        assert events["profile_submitted"]["total"] == 2
+        assert events["profile_submitted"]["failed"] == 1
+        assert abs(events["profile_submitted"]["fail_rate"] - 0.5) < 0.01
 
 
 # ============================================

--- a/frontend/src/app/(dashboard)/notifications/_components/NotificationTable.tsx
+++ b/frontend/src/app/(dashboard)/notifications/_components/NotificationTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { formatDistanceToNow } from "date-fns";
+import { vi } from "date-fns/locale";
 import { Check, MoreVertical, Trash2 } from "lucide-react";
 import Link from "next/link";
 
@@ -118,6 +119,7 @@ function MobileNotificationCard({
           >
             {formatDistanceToNow(new Date(notification.created_at), {
               addSuffix: true,
+              locale: vi,
             })}
           </p>
         </div>
@@ -301,6 +303,7 @@ export function NotificationTable({
                 >
                   {formatDistanceToNow(new Date(notification.created_at), {
                     addSuffix: true,
+                    locale: vi,
                   })}
                 </TableCell>
                 <TableCell className="text-right">

--- a/frontend/src/app/(dashboard)/notifications/_components/NotificationsClient.tsx
+++ b/frontend/src/app/(dashboard)/notifications/_components/NotificationsClient.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Bell, Check, CheckCheck, Trash2, X, LayoutList, LayoutGrid, Search } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
+import { vi } from "date-fns/locale";
 import Link from "next/link";
 import { toast } from "sonner";
 
@@ -482,6 +483,7 @@ export function NotificationsClient({ initialData }: NotificationsClientProps) {
                               <span>
                                 {formatDistanceToNow(new Date(notification.created_at), {
                                   addSuffix: true,
+                                  locale: vi,
                                 })}
                               </span>
                             </div>

--- a/frontend/src/components/admin/notifications/NotificationRuleEditor.tsx
+++ b/frontend/src/components/admin/notifications/NotificationRuleEditor.tsx
@@ -11,7 +11,7 @@
  */
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -239,9 +239,20 @@ export function NotificationRuleEditor({
   const titleTemplate = form.watch("title_template");
   const messageTemplate = form.watch("message_template");
 
-  // Reset condition state on event change (only if not hydrating)
+  // Reset condition state when the user picks a different event.
+  // `null` sentinel = "not yet observed" so the first run after
+  // edit-mode hydration (or the first run in create mode) only records
+  // the current event without resetting — preventing the just-hydrated
+  // condition state from being wiped when `isHydrated` flips true.
+  const prevSelectedEvent = useRef<string | null>(null);
   useEffect(() => {
     if (isEditMode && !isHydrated) return;
+    if (prevSelectedEvent.current === null) {
+      prevSelectedEvent.current = selectedEvent;
+      return;
+    }
+    if (prevSelectedEvent.current === selectedEvent) return;
+    prevSelectedEvent.current = selectedEvent;
     setConditionField("");
     setConditionOperator("eq");
     setConditionValue("");

--- a/frontend/src/components/admin/notifications/TemplateForm.tsx
+++ b/frontend/src/components/admin/notifications/TemplateForm.tsx
@@ -316,7 +316,10 @@ export function TemplateForm({ templateId, open, onOpenChange }: TemplateFormPro
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Danh mục</FormLabel>
-                    <Select value={field.value} onValueChange={field.onChange}>
+                    {/* `key` forces remount when value changes from undefined→string
+                        post-mount (form.reset after async template fetch). Without
+                        it Radix Select stays stuck on the placeholder. */}
+                    <Select key={field.value ?? "__empty__"} value={field.value} onValueChange={field.onChange}>
                       <FormControl>
                         <SelectTrigger>
                           <SelectValue placeholder="Select a category" />

--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -4,6 +4,7 @@
 import React, { useState } from "react";
 import { Bell, Check, CheckCheck, X } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
+import { vi } from "date-fns/locale";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -180,7 +181,7 @@ export function NotificationDropdown() {
                         <p className="text-muted-foreground text-xs">
                           {formatDistanceToNow(
                             new Date(notification.created_at),
-                            { addSuffix: true }
+                            { addSuffix: true, locale: vi }
                           )}
                         </p>
                         {/* ✅ Show "Tự động" badge for automatic assignments */}


### PR DESCRIPTION
## Summary

Surfaced 6 runtime bugs while QA-walking the entire notification suite and fixed all of them on this branch. Plus one tightened test assertion to lock the contract.

## Bugs fixed

1. **FE rule editor — condition state wipe on hydration** (`NotificationRuleEditor.tsx:242-262`): toggle "Bật điều kiện lọc" hiển thị OFF khi mở edit rule có condition; reset effect fire khi `isHydrated` flip true → wipe form state. Fixed: useRef null sentinel chỉ reset khi `selectedEvent` thật sự đổi.

2. **BE rule update — null skip** (`notification_rule_crud_service.py:402-409`): `update_rule` skip None values → admin tắt toggle + save không clear condition khỏi DB. Fixed: allowlist nullable columns (`condition`, `link_template`, `template_id`).

3. **FE template editor — Radix Select stuck on placeholder** (`TemplateForm.tsx:319`): category dropdown empty lần đầu mở dialog; Radix không bind `undefined→string` post-mount. Fixed: `key={field.value ?? "__empty__"}` force remount.

4. **BE template update — null skip** (`notification_template_service.py:137-140`): same pattern — không clear được `description`/`link_template`/`variables`/`category`/`allowed_events`. Fixed: same allowlist approach.

5. **BE deliveries — double percent** (`notification_delivery_repository.py:575`): Top Events fail rate hiển thị "5000.0%" vì backend ×100 cộng FE ×100. Fixed: backend trả ratio (0-1) khớp convention `get_failure_rate` + AlertBanner.

6. **FE notifications — i18n English on Vietnamese app** (`NotificationTable.tsx`, `NotificationsClient.tsx`, `NotificationDropdown.tsx`): "2 minutes ago"/"3 days ago"; thiếu `locale: vi` trong `formatDistanceToNow`. Fixed: import + pass `vi`.

## Test plan

- [x] Backend: `test_notification_rule_crud + test_notification_dispatcher + test_notification_bundle + test_notification_preference + test_notification_rules_preview + test_notification_consents + test_notification_deliveries + test_notification_delivery_ops_d5` → **49 passed, 2 skipped**
- [x] Frontend: `tsc --noEmit` exit=0 (chỉ lỗi auto-generated `.next/dev/types/`)
- [x] Browser runtime test 6 trang: rule list/edit/create, templates, deliveries (3 tabs), consents, settings/notifications, inbox
- [x] Tightened `test_top_events_fail_rate` → `<= 1.0` + pin seed ratios (catch regression về percent output)
- [x] DB roundtrip verified: edit rule id=1 condition save/reload/clear/restore — all persistent đúng

🤖 Generated with [Claude Code](https://claude.com/claude-code)