### PR TITLE
fix(notifications): rename Configuration tab to Channels + i18n delivery dashboard

### DIFF
--- a/frontend/src/app/(dashboard)/admin/notification-deliveries/DeliveryDashboard.tsx
+++ b/frontend/src/app/(dashboard)/admin/notification-deliveries/DeliveryDashboard.tsx
@@ -5,7 +5,7 @@
  *
  * Overview: charts + health panel + alert banner + top events
  * Deliveries: existing DeliveryOpsTable
- * Configuration: breaker states + quota readonly view
+ * Channels: breaker states + quota readonly view (per-channel focus)
  */
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -20,7 +20,7 @@ export default function DeliveryDashboard() {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold tracking-tight" data-testid="dashboard-heading">Delivery Monitoring</h1>
+        <h1 className="text-2xl font-bold tracking-tight" data-testid="dashboard-heading">Giám sát gửi thông báo</h1>
         <p className="text-muted-foreground">
           Theo dõi sức khỏe hệ thống thông báo
         </p>
@@ -31,9 +31,9 @@ export default function DeliveryDashboard() {
 
       <Tabs defaultValue="overview" className="space-y-4">
         <TabsList>
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="deliveries">Deliveries</TabsTrigger>
-          <TabsTrigger value="configuration">Configuration</TabsTrigger>
+          <TabsTrigger value="overview">Tổng quan</TabsTrigger>
+          <TabsTrigger value="deliveries">Lịch sử gửi</TabsTrigger>
+          <TabsTrigger value="configuration">Kênh</TabsTrigger>
         </TabsList>
 
         {/* Overview tab */}
@@ -48,7 +48,9 @@ export default function DeliveryDashboard() {
           <DeliveryOpsTable />
         </TabsContent>
 
-        {/* Configuration tab — breakers + quotas readonly */}
+        {/* Channels tab — breakers + quotas readonly (per-channel focus).
+            Tab value kept as "configuration" to preserve any deep links /
+            test selectors; only the user-visible label changed. */}
         <TabsContent value="configuration" className="space-y-6">
           <ChannelHealthPanel />
         </TabsContent>

--- a/frontend/src/components/admin/notifications/AlertBanner.tsx
+++ b/frontend/src/components/admin/notifications/AlertBanner.tsx
@@ -37,14 +37,14 @@ export default function AlertBanner() {
   if (!hasIssue || dismissed) return null;
 
   const messages: string[] = [];
-  if (failRate > FAIL_RATE_ALERT_THRESHOLD) messages.push(`Failure rate ${(failRate * 100).toFixed(0)}%`);
+  if (failRate > FAIL_RATE_ALERT_THRESHOLD) messages.push(`Tỷ lệ lỗi ${(failRate * 100).toFixed(0)}%`);
   if (openBreakers.length > 0) {
     // H6: channel names are backend enum values, but escape via textContent for safety
     const channelNames = openBreakers.map((b) => String(b.channel)).join(", ");
-    messages.push(`Breaker open: ${channelNames}`);
+    messages.push(`Ngắt mạch kênh: ${channelNames}`);
   }
-  if (queued > BACKLOG_ALERT_THRESHOLD) messages.push(`Backlog: ${queued} queued`);
-  if (alertCount > 0 && messages.length === 0) messages.push(`${alertCount} alert(s) active`);
+  if (queued > BACKLOG_ALERT_THRESHOLD) messages.push(`Tồn đọng: ${queued} mục đang chờ`);
+  if (alertCount > 0 && messages.length === 0) messages.push(`${alertCount} cảnh báo đang hoạt động`);
 
   return (
     <div role="alert" className="flex items-center gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
@@ -52,7 +52,7 @@ export default function AlertBanner() {
       <span className="flex-1">{messages.join(" · ")}</span>
       <button
         onClick={handleDismiss}
-        aria-label="Dismiss alert"
+        aria-label="Đóng cảnh báo"
         className="shrink-0 rounded p-1 hover:bg-red-100 dark:hover:bg-red-900"
       >
         <X className="h-4 w-4" />

--- a/frontend/src/components/admin/notifications/ChannelHealthPanel.tsx
+++ b/frontend/src/components/admin/notifications/ChannelHealthPanel.tsx
@@ -20,11 +20,11 @@ const FAIL_RATE_WARN_THRESHOLD = 0.1;
 function BreakerBadge({ state }: { state: string }) {
   switch (state) {
     case "closed":
-      return <Badge variant="default" className="gap-1"><CheckCircle className="h-3 w-3" /> Healthy</Badge>;
+      return <Badge variant="default" className="gap-1"><CheckCircle className="h-3 w-3" /> Hoạt động</Badge>;
     case "half_open":
-      return <Badge variant="secondary" className="gap-1"><AlertTriangle className="h-3 w-3" /> Half-Open</Badge>;
+      return <Badge variant="secondary" className="gap-1"><AlertTriangle className="h-3 w-3" /> Bán mở</Badge>;
     case "open":
-      return <Badge variant="destructive" className="gap-1"><XCircle className="h-3 w-3" /> Open</Badge>;
+      return <Badge variant="destructive" className="gap-1"><XCircle className="h-3 w-3" /> Ngắt mạch</Badge>;
     default:
       return <Badge variant="outline">{state}</Badge>;
   }
@@ -49,7 +49,7 @@ function ChannelCard({ ch }: { ch: ChannelHealthItem }) {
         {ch.quota_limit != null && ch.quota_used != null && (
           <div className="space-y-1">
             <div className="flex justify-between text-xs text-muted-foreground">
-              <span>Quota</span>
+              <span>Hạn mức</span>
               <span>{ch.quota_used}/{ch.quota_limit} ({quotaPct != null ? `${quotaPct}%` : "N/A"})</span>
             </div>
             <Progress value={quotaPct ?? 0} className="h-2" />
@@ -59,7 +59,7 @@ function ChannelCard({ ch }: { ch: ChannelHealthItem }) {
         {/* Failure rate */}
         {ch.failure_rate_24h != null && (
           <div className="flex justify-between text-xs">
-            <span className="text-muted-foreground">Fail rate (24h)</span>
+            <span className="text-muted-foreground">Tỷ lệ lỗi (24h)</span>
             <span className={ch.failure_rate_24h > FAIL_RATE_WARN_THRESHOLD ? "text-red-600 font-medium" : ""}>
               {(ch.failure_rate_24h * 100).toFixed(1)}%
             </span>
@@ -76,7 +76,7 @@ function ChannelCard({ ch }: { ch: ChannelHealthItem }) {
             onClick={() => resetMutation.mutate(ch.channel)}
           >
             <RotateCcw className="mr-1 h-3 w-3" />
-            Reset Breaker
+            Reset ngắt mạch
           </Button>
         )}
       </CardContent>
@@ -105,7 +105,7 @@ export default function ChannelHealthPanel() {
       <div className="grid gap-4 md:grid-cols-3" data-testid="status-cards">
         <Card data-testid="card-queued">
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm text-muted-foreground">Queued</CardTitle>
+            <CardTitle className="text-sm text-muted-foreground">Đang chờ</CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-2xl font-bold">{data?.total_queued ?? 0}</p>
@@ -113,7 +113,7 @@ export default function ChannelHealthPanel() {
         </Card>
         <Card data-testid="card-fail-rate">
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm text-muted-foreground">Fail Rate (30m)</CardTitle>
+            <CardTitle className="text-sm text-muted-foreground">Tỷ lệ lỗi (30 phút)</CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-2xl font-bold">
@@ -123,7 +123,7 @@ export default function ChannelHealthPanel() {
         </Card>
         <Card data-testid="card-active-alerts">
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm text-muted-foreground">Active Alerts</CardTitle>
+            <CardTitle className="text-sm text-muted-foreground">Cảnh báo đang hoạt động</CardTitle>
           </CardHeader>
           <CardContent>
             <p className={`text-2xl font-bold ${(data?.alerts_active ?? 0) > 0 ? "text-red-600" : ""}`}>

--- a/frontend/src/components/admin/notifications/DeliveryCharts.tsx
+++ b/frontend/src/components/admin/notifications/DeliveryCharts.tsx
@@ -43,7 +43,7 @@ export default function DeliveryCharts() {
   if (isLoading) {
     return (
       <Card>
-        <CardHeader><CardTitle>Delivery Trend</CardTitle></CardHeader>
+        <CardHeader><CardTitle>Xu hướng gửi thông báo</CardTitle></CardHeader>
         <CardContent className="h-64 flex items-center justify-center text-muted-foreground">
           Đang tải...
         </CardContent>
@@ -54,7 +54,7 @@ export default function DeliveryCharts() {
   if (chartData.length === 0) {
     return (
       <Card>
-        <CardHeader><CardTitle>Delivery Trend</CardTitle></CardHeader>
+        <CardHeader><CardTitle>Xu hướng gửi thông báo</CardTitle></CardHeader>
         <CardContent className="h-64 flex items-center justify-center text-muted-foreground">
           Chưa có dữ liệu
         </CardContent>
@@ -88,7 +88,7 @@ export default function DeliveryCharts() {
       {/* Status breakdown */}
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base">Status breakdown</CardTitle>
+          <CardTitle className="text-base">Phân loại theo trạng thái</CardTitle>
         </CardHeader>
         <CardContent>
           <ResponsiveContainer width="100%" height={240}>
@@ -98,9 +98,9 @@ export default function DeliveryCharts() {
               <YAxis tick={{ fontSize: 11 }} />
               <Tooltip />
               <Legend />
-              <Bar dataKey="success" stackId="a" fill="#22c55e" name="Sent" />
-              <Bar dataKey="failed" stackId="a" fill="#ef4444" name="Failed" />
-              <Bar dataKey="queued" stackId="a" fill="#f59e0b" name="Queued" />
+              <Bar dataKey="success" stackId="a" fill="#22c55e" name="Đã gửi" />
+              <Bar dataKey="failed" stackId="a" fill="#ef4444" name="Thất bại" />
+              <Bar dataKey="queued" stackId="a" fill="#f59e0b" name="Đang chờ" />
             </BarChart>
           </ResponsiveContainer>
         </CardContent>

--- a/frontend/src/components/admin/notifications/DeliveryOpsTable.tsx
+++ b/frontend/src/components/admin/notifications/DeliveryOpsTable.tsx
@@ -65,7 +65,7 @@ const STATUS_CONFIG: Record<string, { label: string; variant: "default" | "secon
   delivered: { label: "Đã nhận", variant: "default" },
   read: { label: "Đã đọc", variant: "default" },
   failed: { label: "Thất bại", variant: "destructive" },
-  dead_lettered: { label: "Dead Letter", variant: "destructive" },
+  dead_lettered: { label: "Hết hạn xử lý", variant: "destructive" },
   skipped: { label: "Bỏ qua", variant: "outline" },
 };
 
@@ -140,7 +140,7 @@ export default function DeliveryOpsTable({ initialData }: DeliveryOpsTableProps)
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">
-            Delivery Tracking
+            Theo dõi gửi thông báo
           </h1>
           <p className="text-muted-foreground">
             Theo dõi trạng thái gửi thông báo theo kênh
@@ -152,7 +152,7 @@ export default function DeliveryOpsTable({ initialData }: DeliveryOpsTableProps)
       <div className="grid gap-4 md:grid-cols-4">
         <Card>
           <CardHeader className="pb-2">
-            <CardDescription>Tổng deliveries</CardDescription>
+            <CardDescription>Tổng số bản gửi</CardDescription>
             <CardTitle className="text-3xl">{stats?.total ?? total}</CardTitle>
           </CardHeader>
         </Card>
@@ -174,7 +174,7 @@ export default function DeliveryOpsTable({ initialData }: DeliveryOpsTableProps)
         </Card>
         <Card>
           <CardHeader className="pb-2">
-            <CardDescription>Success Rate</CardDescription>
+            <CardDescription>Tỷ lệ thành công</CardDescription>
             <CardTitle className="text-3xl">
               {stats?.success_rate != null ? `${stats.success_rate}%` : "—"}
             </CardTitle>
@@ -195,7 +195,7 @@ export default function DeliveryOpsTable({ initialData }: DeliveryOpsTableProps)
             <div className="relative flex-1">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input
-                placeholder="Lọc theo event..."
+                placeholder="Lọc theo sự kiện..."
                 value={eventFilter}
                 onChange={(e) => {
                   setEventFilter(e.target.value);
@@ -241,7 +241,7 @@ export default function DeliveryOpsTable({ initialData }: DeliveryOpsTableProps)
                 <SelectItem value="sent">Đã gửi</SelectItem>
                 <SelectItem value="delivered">Đã nhận</SelectItem>
                 <SelectItem value="failed">Thất bại</SelectItem>
-                <SelectItem value="dead_lettered">Dead Letter</SelectItem>
+                <SelectItem value="dead_lettered">Hết hạn xử lý</SelectItem>
                 <SelectItem value="skipped">Bỏ qua</SelectItem>
               </SelectContent>
             </Select>
@@ -304,12 +304,12 @@ export default function DeliveryOpsTable({ initialData }: DeliveryOpsTableProps)
               <TableHeader>
                 <TableRow>
                   <TableHead className="w-[160px]">Thời gian</TableHead>
-                  <TableHead>Event</TableHead>
+                  <TableHead>Sự kiện</TableHead>
                   <TableHead className="w-[100px]">Kênh</TableHead>
                   <TableHead>Người nhận</TableHead>
                   <TableHead className="w-[110px]">Trạng thái</TableHead>
                   <TableHead>Lỗi</TableHead>
-                  <TableHead className="w-[80px]">Actions</TableHead>
+                  <TableHead className="w-[80px]">Thao tác</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -349,9 +349,10 @@ export default function DeliveryOpsTable({ initialData }: DeliveryOpsTableProps)
                             size="sm"
                             className="h-7 text-xs"
                             onClick={() => handleReplay(d.id)}
+                            aria-label="Gửi lại"
                             disabled={replayMutation.isPending}
                           >
-                            Replay
+                            Gửi lại
                           </Button>
                         )}
                       </TableCell>

--- a/frontend/src/components/admin/notifications/TopEventsTable.tsx
+++ b/frontend/src/components/admin/notifications/TopEventsTable.tsx
@@ -28,7 +28,7 @@ export default function TopEventsTable({ onEventClick }: TopEventsTableProps) {
   return (
     <Card>
       <CardHeader className="pb-2">
-        <CardTitle className="text-base">Top Events (by volume)</CardTitle>
+        <CardTitle className="text-base">Sự kiện hàng đầu (theo lưu lượng)</CardTitle>
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -39,10 +39,10 @@ export default function TopEventsTable({ onEventClick }: TopEventsTableProps) {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Event</TableHead>
-                <TableHead className="text-right">Total</TableHead>
-                <TableHead className="text-right">Failed</TableHead>
-                <TableHead className="text-right">Fail Rate</TableHead>
+                <TableHead>Sự kiện</TableHead>
+                <TableHead className="text-right">Tổng</TableHead>
+                <TableHead className="text-right">Thất bại</TableHead>
+                <TableHead className="text-right">Tỷ lệ lỗi</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>


### PR DESCRIPTION
## Summary

Address deferred follow-up **#5** from `notification-qa-followups-2026-04-27`: the third tab on `/admin/notification-deliveries` was labeled "Configuration" but only renders `ChannelHealthPanel` (a per-channel breaker/quota readonly view — no config UI). Rename to match the content.

While in there, finish translating the page to Vietnamese so it stops mixing English (anh's "sao còn lẫn tiếng Anh" flag).

## Scope

FE-only, **no behavior change**. Tab value `"configuration"` is intentionally preserved — only the user-visible label changed, so URL fragments / test selectors don't break.

| File | Change |
|---|---|
| `DeliveryDashboard.tsx` | h1 + 3 tab labels Vietnamese |
| `ChannelHealthPanel.tsx` | Breaker badges + summary cards Vietnamese |
| `TopEventsTable.tsx` | Card title + 4 column headers Vietnamese |
| `DeliveryCharts.tsx` | 2 chart titles + 3 bar legend names Vietnamese |
| `AlertBanner.tsx` | Dynamic alert messages + aria-label Vietnamese |
| `DeliveryOpsTable.tsx` | h1 + summary cards + filter placeholder + Replay button + Dead Letter label Vietnamese |

## Test plan

- [x] `tsc --noEmit` clean (EXIT=0)
- [x] `vitest DeliveryOpsTable.test.tsx` → 6 passed (existing tests assert structure, not changed label text)
- [x] Tab value `"configuration"` preserved → no breakage to URL deep-links / test selectors
- [x] No backend changes — no pytest needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)