### PR TITLE
fix(admissions): audit Wave 1 — 7 findings (security + validation)

### DIFF
--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -58,6 +58,7 @@ __all__ = [
     # Admission State Machine IDOR (State Machine Implementation)
     "get_admission_for_manager",  # Manager approve/reject
     "get_admission_for_user",  # Officer resubmit
+    "get_admission_for_user_read",  # Read-only fee-status / detail (no lock)
 
     # Admission Configuration Console IDOR
     "get_admission_path_for_user",  # Phase 1: Config Console
@@ -2306,6 +2307,100 @@ async def get_admission_for_user(
             if profile.lead.assigned_officer_id != current_user.id:
                 log.warning(
                     "IDOR attempt: Officer tried to access profile not assigned to them",
+                    user_id=current_user.id,
+                    profile_id=profile_id,
+                    assigned_officer_id=profile.lead.assigned_officer_id,
+                )
+                raise ResourceNotFoundError(detail=f"Admission profile {profile_id} not found")
+
+    return profile
+
+
+# Roles allowed to hit admission read endpoints. Anything outside this
+# allow-list (accountant, regular user, collaborator, etc.) is rejected
+# at the dependency layer regardless of unit_id, so callers can't sneak
+# in via routes that aren't behind CasbinAuth. ADM-001 review fix.
+_ADMISSION_READ_ALLOWED_ROLES = frozenset({
+    UserRole.ADMIN,
+    UserRole.MANAGER,
+    UserRole.OFFICER,
+})
+
+
+async def get_admission_for_user_read(
+    profile_id: int = Path(..., description="Admission Profile ID"),
+    current_user: models.User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(database.get_db),
+) -> models.AdmissionProfile:
+    """
+    IDOR Protection for read-only admission endpoints (fee-status, detail).
+
+    Same 3-tier scope as ``get_admission_for_user`` but WITHOUT
+    ``SELECT FOR UPDATE``. State-changing endpoints (approve/reject/resubmit)
+    must keep using the locking variants.
+
+    Role allow-list (ADM-001 review fix): only ADMIN, MANAGER, OFFICER may
+    reach this dependency. Accountant / regular user / collaborator are
+    rejected up front so a route that forgets to add CasbinAuth doesn't
+    silently leak fee fields to staff outside the admission scope.
+
+    - Admin: Can access all profiles
+    - Officer: Can access profiles where lead.unit_id == user.unit_id
+              AND lead.assigned_officer_id == user.id
+    - Manager: Can access profiles where lead.unit_id == user.unit_id
+    - Anyone else: rejected (404 fake)
+    - Return 404 (not 403) for unauthorized access
+
+    Used by:
+    - GET /admissions/{id}/fee-status
+
+    Raises:
+        ResourceNotFoundError: Profile not found OR unauthorized (fake 404)
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    # Defense-in-depth role gate (in addition to any RBAC at the route).
+    # Outside the admission allow-list → fake 404, never 403, to avoid
+    # leaking that the profile ID is real.
+    if current_user.role not in _ADMISSION_READ_ALLOWED_ROLES:
+        log.warning(
+            "IDOR attempt: non-admission role tried to read profile",
+            user_id=current_user.id,
+            user_role=str(current_user.role),
+            profile_id=profile_id,
+        )
+        raise ResourceNotFoundError(detail=f"Admission profile {profile_id} not found")
+
+    stmt = (
+        select(models.AdmissionProfile)
+        .where(models.AdmissionProfile.id == profile_id)
+        .options(
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
+    )
+    result = await db.execute(stmt)
+    profile = result.scalar_one_or_none()
+
+    if not profile:
+        raise ResourceNotFoundError(detail=f"Admission profile {profile_id} not found")
+
+    if current_user.role != UserRole.ADMIN:
+        if not profile.lead or profile.lead.unit_id != current_user.unit_id:
+            log.warning(
+                "IDOR attempt: User tried to read profile from different unit",
+                user_id=current_user.id,
+                user_unit_id=current_user.unit_id,
+                profile_id=profile_id,
+                profile_unit_id=profile.lead.unit_id if profile.lead else None,
+            )
+            raise ResourceNotFoundError(detail=f"Admission profile {profile_id} not found")
+        if current_user.role == UserRole.OFFICER:
+            if profile.lead.assigned_officer_id != current_user.id:
+                log.warning(
+                    "IDOR attempt: Officer tried to read profile not assigned to them",
                     user_id=current_user.id,
                     profile_id=profile_id,
                     assigned_officer_id=profile.lead.assigned_officer_id,

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -45,10 +45,30 @@ from ..utils.exceptions import (
     ValidationError,
 )
 from ..core.constants import UserRole
+from ..utils.csv_helpers import sanitize_csv_row
 
 log = structlog.get_logger(__name__)
 
 router = APIRouter(prefix="/admissions", tags=["Admissions"])
+
+
+# ADM-010: Single source of truth for payment_status enum values shared by
+# list, status-counts, and export endpoints. Repository helper silently
+# drops anything outside this set, so router-level validation is required
+# to keep the contract honest.
+ALLOWED_PAYMENT_STATUSES = ("paid", "unpaid", "partial", "no_fee")
+
+
+def _validate_payment_status(value: Optional[str]) -> None:
+    """Raise 400 if ``value`` is set but not in ALLOWED_PAYMENT_STATUSES."""
+    if value and value not in ALLOWED_PAYMENT_STATUSES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Invalid payment_status. Must be: "
+                + ", ".join(ALLOWED_PAYMENT_STATUSES)
+            ),
+        )
 
 
 def get_client_ip(request: Request) -> str:
@@ -109,9 +129,8 @@ async def list_admission_profiles(
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid major_id format")
 
-    # Validate payment_status
-    if payment_status and payment_status not in ("paid", "unpaid", "partial", "no_fee"):
-        raise HTTPException(status_code=400, detail="Invalid payment_status. Must be: paid, unpaid, partial, no_fee")
+    # Validate payment_status (ADM-010: shared helper)
+    _validate_payment_status(payment_status)
 
     profiles, total_count = await admission_service.get_profiles(
         db=db,
@@ -180,6 +199,9 @@ async def get_status_counts(
             major_ids = [int(m.strip()) for m in major_id.split(",") if m.strip()]
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid major_id format")
+
+    # Validate payment_status (ADM-010: keep parity with list/export)
+    _validate_payment_status(payment_status)
 
     return await admission_service.get_status_counts(
         db=db,
@@ -476,6 +498,9 @@ async def export_admissions_csv(
     statuses = [s.strip() for s in status.split(",")] if status else None
     major_ids = [int(m.strip()) for m in major_id.split(",") if m.strip().isdigit()] if major_id else None
 
+    # Validate payment_status (ADM-010: keep parity with list/status-counts)
+    _validate_payment_status(payment_status)
+
     # Export path: no page cap, lightweight hydration (only completion_percent)
     profiles = await admission_service.get_profiles_for_export(
         db=db,
@@ -508,10 +533,12 @@ async def export_admissions_csv(
         "Ngày cập nhật",
     ])
 
-    # Data rows
+    # Data rows — sanitize_csv_row guards against formula/DDE injection
+    # via lead-controlled fields (full_name, email, phone, citizen_id,
+    # program name). See ADM-006 / app/utils/csv_helpers.py.
     for profile in profiles:
         lead = profile.lead
-        writer.writerow([
+        writer.writerow(sanitize_csv_row([
             profile.id,
             lead.full_name if lead else "",
             lead.email if lead else "",
@@ -522,7 +549,7 @@ async def export_admissions_csv(
             lead.offering.program.name if lead and lead.offering and lead.offering.program else "",
             profile.created_at.strftime("%Y-%m-%d %H:%M") if profile.created_at else "",
             profile.updated_at.strftime("%Y-%m-%d %H:%M") if profile.updated_at else "",
-        ])
+        ]))
 
     # Prepare response
     output.seek(0)

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -31,6 +31,7 @@ from ..core.deps import (
     CasbinAuth,  # ✅ Phase 2.2: Use standard alias
     get_admission_for_manager,
     get_admission_for_user,
+    get_admission_for_user_read,
 )
 from ..services import admission_service
 from ..services.notification_dispatcher import safe_dispatch, _rooms_for_admission, _rooms_for_lead
@@ -1253,12 +1254,18 @@ async def unclaim_admission_review(
 )
 async def get_fee_status(
     request: Request,
-    profile_id: int,
+    profile: models.AdmissionProfile = Depends(get_admission_for_user_read),  # Layer 3: IDOR
     current_user: models.User = Depends(deps.get_current_active_user),
     db: AsyncSession = Depends(database.get_db),
 ):
     """
     Get application fee status for an admission profile.
+
+    **Authorization (3-tier IDOR via ``get_admission_for_user_read``):**
+    - Admin: any profile
+    - Manager: profiles in their unit
+    - Officer: profiles assigned to them in their unit
+    - Returns 404 (fake) for out-of-scope access.
 
     Returns:
     - requires_fee: Whether this profile requires application fee
@@ -1269,7 +1276,7 @@ async def get_fee_status(
     try:
         result = await admission_service.check_application_fee_status(
             db=db,
-            profile_id=profile_id,
+            profile_id=profile.id,
         )
         return result
     except ResourceNotFoundError as e:

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -48,6 +48,31 @@ async def _noop_callback() -> None:
     pass
 
 
+def _check_lifecycle_guard(path: AdmissionPath, user: User) -> None:
+    """ADM-005: Lifecycle guard shared by ``update_path``,
+    ``upsert_criteria`` and ``upsert_documents``.
+
+    Per Q2 product decision (b — basic guard, durable audit deferred to
+    Wave 2):
+
+    - Archived paths cannot be modified at all.
+    - Manager can only modify paths in ``draft`` status. ``Admin
+      approves = activate``, so once a path is past draft only admin may
+      edit its criteria / documents / fields.
+    - Admin can edit any non-archived path.
+
+    Raises ``BusinessRuleViolation`` when the caller fails the guard so
+    routers can map to 400 / domain copy.
+    """
+    if path.status == "archived":
+        raise BusinessRuleViolation("Cannot update archived path")
+    if user.role != UserRole.ADMIN and path.status != "draft":
+        raise BusinessRuleViolation(
+            f"Manager can only update paths in 'draft' status. "
+            f"Current status: '{path.status}'. Contact Admin to modify."
+        )
+
+
 class AdmissionPathService:
     """
     Service for AdmissionPath business logic.
@@ -172,21 +197,16 @@ class AdmissionPathService:
         - Archived paths cannot be updated
         - Manager can ONLY update paths in 'draft' status
         - Admin can update any non-archived path
-        
+
         Raises:
             BusinessRuleViolation: If path is archived
             BusinessRuleViolation: If manager tries to edit non-draft path
         """
-        if path.status == "archived":
-            raise BusinessRuleViolation("Cannot update archived path")
-        
-        # Manager can only edit draft paths (Admin approves = activate)
-        if user.role == UserRole.MANAGER and path.status != "draft":
-            raise BusinessRuleViolation(
-                f"Manager can only update paths in 'draft' status. "
-                f"Current status: '{path.status}'. Contact Admin to modify."
-            )
-        
+        # ADM-005: shared lifecycle guard — also enforced on
+        # upsert_criteria / upsert_documents so manager cannot bypass
+        # the "manager edits draft only" rule by hitting a sub-route.
+        _check_lifecycle_guard(path, user)
+
         update_data = data.model_dump(exclude_unset=True)
 
         # Governance guard: minor_correction_allowed_fields is admin-only.
@@ -216,7 +236,14 @@ class AdmissionPathService:
     ) -> Tuple[AdmissionPath, PostCommitCallback]:
         """
         Create or update admission criteria for a path.
+
+        ADM-005: enforces the same lifecycle guard as ``update_path`` —
+        archived paths reject; non-admin can only mutate ``draft``. Without
+        this guard, manager could bypass the "draft-only" rule by hitting
+        ``PUT /paths/{id}/criteria`` directly.
         """
+        _check_lifecycle_guard(path, user)
+
         # 1. Update/Create Criteria
         if path.criteria:
             # Update existing
@@ -263,11 +290,18 @@ class AdmissionPathService:
     ) -> Tuple[List[ResolvedDocumentResponse], PostCommitCallback]:
         """
         Update document requirements for a path.
-        
+
         Logic:
         1. Find/Create method-specific DocumentGroup for this path's offering_type + method.
         2. Sync items in that group.
+
+        ADM-005: enforces the same lifecycle guard as ``update_path`` —
+        archived paths reject; non-admin can only mutate ``draft``. Without
+        this guard, manager could bypass the "draft-only" rule by hitting
+        ``PUT /paths/{id}/documents`` directly.
         """
+        _check_lifecycle_guard(path, user)
+
         if not path.academic_info or not path.academic_info.offering:
             # Force load if missing (though repo loads it)
              path = await self.repo.get_by_id_with_relations(path.id)
@@ -336,36 +370,61 @@ class AdmissionPathService:
     ) -> Tuple[bool, List[str]]:
         """
         Validate if path can be activated.
-        
-        Activation Checklist:
-        1. Has criteria (via OfferingAdmissionConfig)
-        2. Has document config
-        3. Has quota > 0
-        
+
+        ADM-004: criteria + documents are now checked inline using the same
+        rules as ``get_coverage_matrix`` so the route guard, coverage UI and
+        ``can_activate`` flag agree on a single readiness contract:
+
+        1. Status must be ``draft`` or ``inactive``.
+        2. ``academic_info.annual_admission_quota`` must be > 0.
+        3. ``path.criteria_id`` must be set.
+        4. A ``DocumentGroup`` must exist for the path's offering type +
+           admission method (method-specific or shared fallback).
+
         Returns:
             (can_activate, validation_errors)
         """
+        from app.repositories.document_group_repository import DocumentGroupRepository
+
         errors: List[str] = []
-        
+
         # Check 1: Status must be draft or inactive
         if path.status not in ["draft", "inactive"]:
             errors.append(f"Cannot activate path with status '{path.status}'")
-        
-        # Check 2: Must have academic_info with quota
+
+        # Check 2: academic_info + quota
         academic_info = path.academic_info
         if not academic_info:
-            errors.append("Path has no academic info")
-        elif not academic_info.annual_admission_quota or academic_info.annual_admission_quota <= 0:
-            errors.append("Quota must be greater than 0")
-        
-        # Check 3: Should have criteria (via admission_configs)
-        # This would require loading OfferingAdmissionConfig
-        # For now, we'll add a placeholder check
-        # In production, this would check for actual criteria
-        
-        # Check 4: Should have document config
-        # This would check if DocumentGroup exists for this offering type + method
-        
+            errors.append("Chưa thiết lập thông tin tuyển sinh (Academic Info)")
+        else:
+            quota = academic_info.annual_admission_quota or 0
+            if quota <= 0:
+                errors.append("Chưa thiết lập chỉ tiêu (Quota)")
+
+        # Check 3: Criteria must be configured
+        if path.criteria_id is None:
+            errors.append("Chưa cấu hình tiêu chí (Criteria)")
+
+        # Check 4: Documents must resolve (method-specific or shared)
+        offering_type_id = None
+        if academic_info and academic_info.offering:
+            offering_type_id = academic_info.offering.offering_type_id
+
+        has_documents = False
+        if offering_type_id:
+            doc_repo = DocumentGroupRepository(self.db)
+            method_group = await doc_repo.get_method_specific_group(
+                offering_type_id, path.admission_method_id
+            )
+            if method_group:
+                has_documents = True
+            else:
+                shared_groups = await doc_repo.get_shared_groups(offering_type_id)
+                has_documents = len(shared_groups) > 0
+
+        if not has_documents:
+            errors.append("Chưa cấu hình hồ sơ (Documents)")
+
         can_activate = len(errors) == 0
         return can_activate, errors
     

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -69,6 +69,93 @@ from ..utils.masking import mask_citizen_id
 log = structlog.get_logger(__name__)
 
 
+# ADM-012: Safe domain exceptions whose ``str()`` is user-facing copy.
+# Anything outside this tuple becomes "Unexpected error" + correlation id
+# in bulk-action error maps so internal DB/stack details cannot leak to
+# the client. Keep this tuple in sync with imports above.
+_BULK_SAFE_DOMAIN_EXCEPTIONS = (
+    ResourceNotFoundError,
+    BadRequest,
+    BusinessRuleViolation,
+    PermissionDeniedError,
+    ConflictError,
+    ValidationError,
+)
+
+
+def _sniff_document_signature(stream) -> Optional[str]:
+    """ADM-019: detect a document upload's true type by magic bytes.
+
+    Returns ``"pdf"`` / ``"jpeg"`` / ``"png"`` when the first bytes of
+    ``stream`` match a known signature, ``None`` otherwise. The stream
+    cursor is restored to the start so the caller can still write the
+    file out.
+
+    Why magic bytes:
+    - ``UploadFile.content_type`` is taken straight from the multipart
+      header — fully attacker-controlled.
+    - The filename extension is just as untrusted.
+    - Without sniffing, a renamed ``.exe`` or HTML file with a forged
+      ``Content-Type: application/pdf`` would still pass validation.
+
+    We deliberately avoid pulling in ``python-magic`` / libmagic so the
+    check works in any container without an extra system dep.
+    """
+    try:
+        stream.seek(0)
+        head = stream.read(8)
+    finally:
+        try:
+            stream.seek(0)
+        except Exception:  # pragma: no cover — defensive
+            pass
+
+    if not head:
+        return None
+
+    if head.startswith(b"%PDF-"):
+        return "pdf"
+    if head.startswith(b"\xff\xd8\xff"):
+        return "jpeg"
+    if head.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    return None
+
+
+def _safe_bulk_error_message(
+    exc: Exception,
+    *,
+    bulk_label: str,
+    profile_id: int,
+    actor_id: Optional[int] = None,
+) -> str:
+    """Return a client-safe message for a bulk-action failure.
+
+    - Domain exceptions: pass through their message (already user-facing).
+    - Anything else: log full detail server-side with a correlation id and
+      return ``"Unexpected error (ref: <uuid>)"`` so internals do not leak.
+
+    The correlation id is logged alongside the original exception so ops
+    can pivot from a client report ("ref abc-123") to the full traceback.
+    """
+    import uuid as _uuid
+
+    if isinstance(exc, _BULK_SAFE_DOMAIN_EXCEPTIONS):
+        return str(exc)
+
+    correlation_id = _uuid.uuid4().hex[:12]
+    log.exception(
+        "bulk_action_unexpected_error",
+        bulk_label=bulk_label,
+        profile_id=profile_id,
+        actor_id=actor_id,
+        correlation_id=correlation_id,
+        error=str(exc),
+        error_type=exc.__class__.__name__,
+    )
+    return f"Unexpected error (ref: {correlation_id})"
+
+
 # ==============================================================================
 # HELPER FUNCTIONS
 # ==============================================================================
@@ -3242,23 +3329,43 @@ async def upload_document(
     # File validation constants
     ALLOWED_CONTENT_TYPES = ["application/pdf", "image/jpeg", "image/png"]
     MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
-    
+
     # Validate file type
     if file.content_type not in ALLOWED_CONTENT_TYPES:
         raise BadRequest(
             f"Invalid file type '{file.content_type}'. "
             "Allowed: PDF, JPG, PNG"
         )
-    
+
     # Validate file size (read file to check size)
     file.file.seek(0, 2)  # Seek to end
     file_size = file.file.tell()
     file.file.seek(0)  # Reset to beginning
-    
+
     if file_size > MAX_FILE_SIZE:
         size_mb = file_size / (1024 * 1024)
         raise BadRequest(
             f"File too large ({size_mb:.1f}MB). Maximum allowed: 10MB"
+        )
+
+    # ADM-019: content_type and extension are client-controlled. Sniff
+    # the first bytes of the actual stream and reject mismatches so an
+    # attacker cannot upload a .exe with content_type=application/pdf.
+    sniffed_kind = _sniff_document_signature(file.file)
+    if sniffed_kind is None:
+        raise BadRequest(
+            "Tệp tải lên không phải PDF, JPG hoặc PNG hợp lệ "
+            "(magic bytes không khớp)."
+        )
+    expected_content_type = {
+        "pdf": "application/pdf",
+        "jpeg": "image/jpeg",
+        "png": "image/png",
+    }[sniffed_kind]
+    if file.content_type != expected_content_type:
+        raise BadRequest(
+            f"Content-Type '{file.content_type}' không khớp nội dung "
+            f"thực tế ({expected_content_type})."
         )
 
     # doc_record was already fetched above for the authz guard — no need to re-query.
@@ -3280,13 +3387,11 @@ async def upload_document(
         except OSError as e:
             log.warning("Failed to delete old file", path=old_file_path, error=str(e))
 
-    # SECURITY: Generate UUID-based filename (prevents path traversal & leaks)
-    original_filename = file.filename or "document"
-    file_extension = os.path.splitext(original_filename)[1].lower()
-    # Whitelist extensions
-    allowed_extensions = {".pdf", ".jpg", ".jpeg", ".png"}
-    if file_extension not in allowed_extensions:
-        file_extension = ".bin"  # Fallback for unknown types
+    # ADM-019: extension is taken from the sniffed content, not from
+    # the client-supplied filename, so we never fall back to ".bin" on
+    # an official document upload.
+    extension_for_kind = {"pdf": ".pdf", "jpeg": ".jpg", "png": ".png"}
+    file_extension = extension_for_kind[sniffed_kind]
 
     unique_filename = f"{doc_code}_{uuid.uuid4().hex[:12]}{file_extension}"
     file_path = f"{upload_dir}/{unique_filename}"
@@ -6734,9 +6839,13 @@ async def bulk_approve(
             failed_ids.append(profile_id)
             errors[profile_id] = "Profile not found"
         except Exception as e:
-            log.error("Bulk approve failed for profile", profile_id=profile_id, error=str(e))
             failed_ids.append(profile_id)
-            errors[profile_id] = str(e)
+            errors[profile_id] = _safe_bulk_error_message(
+                e,
+                bulk_label="admission_bulk_approve",
+                profile_id=profile_id,
+                actor_id=approver.id,
+            )
 
     await db.flush()
 
@@ -6950,9 +7059,13 @@ async def bulk_reject(
             failed_ids.append(profile_id)
             errors[profile_id] = "Profile not found"
         except Exception as e:
-            log.error("Bulk reject failed for profile", profile_id=profile_id, error=str(e))
             failed_ids.append(profile_id)
-            errors[profile_id] = str(e)
+            errors[profile_id] = _safe_bulk_error_message(
+                e,
+                bulk_label="admission_bulk_reject",
+                profile_id=profile_id,
+                actor_id=rejector.id,
+            )
 
     await db.flush()
 
@@ -7062,9 +7175,13 @@ async def bulk_assign(
             )
 
         except Exception as e:
-            log.error("Bulk assign failed for profile", profile_id=profile_id, error=str(e))
             failed_ids.append(profile_id)
-            errors[profile_id] = str(e)
+            errors[profile_id] = _safe_bulk_error_message(
+                e,
+                bulk_label="admission_bulk_assign",
+                profile_id=profile_id,
+                actor_id=assigner.id,
+            )
 
     await db.flush()
 

--- a/Backend_FastAPI/tests/api/test_admission_payment_status_validation.py
+++ b/Backend_FastAPI/tests/api/test_admission_payment_status_validation.py
@@ -1,0 +1,93 @@
+"""ADM-010 regression: payment_status enum validation must be enforced
+on list, status-counts and export endpoints alike.
+
+Before the fix, only ``GET /api/admissions`` rejected invalid values; both
+``GET /api/admissions/status-counts`` and ``GET /api/admissions/export``
+silently dropped unknown values inside the repository helper, returning a
+broader dataset than the user expected. The router now shares
+``_validate_payment_status`` so all three endpoints fail closed.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _login(client: AsyncClient, user_info: dict) -> dict:
+    res = await client.post(
+        "/api/auth/login",
+        data={"username": user_info["username"], "password": user_info["password"]},
+    )
+    if res.status_code != 200:
+        pytest.fail(f"Login failed: {res.status_code} - {res.text}")
+    token = res.cookies.get("access_token")
+    if not token:
+        pytest.fail("Login succeeded but access_token cookie not found")
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestPaymentStatusValidationParity:
+    """All admission filter endpoints must reject invalid payment_status."""
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/api/admissions",
+            "/api/admissions/status-counts",
+            "/api/admissions/export",
+        ],
+    )
+    async def test_invalid_payment_status_returns_400(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        endpoint: str,
+    ):
+        headers = await _login(client, admin_user_in_db)
+        response = await client.get(
+            endpoint,
+            params={"payment_status": "paidd"},
+            headers=headers,
+        )
+        assert response.status_code == 400, (
+            f"ADM-010 regression: {endpoint} must reject invalid "
+            f"payment_status value, got {response.status_code}"
+        )
+        body = response.json()
+        # Detail message names the allowed enum so clients can self-correct
+        detail = (body.get("detail") or "").lower()
+        assert "payment_status" in detail or "payment status" in detail
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/api/admissions",
+            "/api/admissions/status-counts",
+            "/api/admissions/export",
+        ],
+    )
+    @pytest.mark.parametrize("value", ["paid", "unpaid", "partial", "no_fee"])
+    async def test_valid_payment_status_passes_validation(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        endpoint: str,
+        value: str,
+    ):
+        """Sanity check: known enum values still pass the new gate.
+
+        We only assert the response is not 400 (success or empty result is
+        fine — this test fixates on validation, not data).
+        """
+        headers = await _login(client, admin_user_in_db)
+        response = await client.get(
+            endpoint,
+            params={"payment_status": value},
+            headers=headers,
+        )
+        assert response.status_code != 400, (
+            f"ADM-010 regression: {endpoint} must accept {value!r}, "
+            f"got {response.status_code} - {response.text[:200]}"
+        )

--- a/Backend_FastAPI/tests/integration/test_admission_idor.py
+++ b/Backend_FastAPI/tests/integration/test_admission_idor.py
@@ -10,15 +10,46 @@ Uses real database via fixtures.
 """
 
 import pytest
+import pytest_asyncio
 from datetime import datetime, timezone
 from httpx import AsyncClient
 from sqlalchemy import select
 
 from app import models
 from app.database import AsyncSessionLocal
+from app.security import get_password_hash
 
 
 pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def non_staff_user_same_unit_in_db(seed_lead_dependencies: dict):
+    """ADM-001 review fix: a ``role=user`` user that lives in the seeded
+    lead's unit. Used to verify the dependency role allow-list rejects
+    accountant / regular user / collaborator even when their ``unit_id``
+    matches the profile's unit (``get_current_active_user`` alone is not
+    enough to gate fee-status).
+    """
+    unit_id = seed_lead_dependencies["unit_id"]
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            user = models.User(
+                username="testuser_non_staff_idor",
+                email="non_staff_idor@test.com",
+                password_hash=get_password_hash("NonStaffPwd!123"),
+                role="user",
+                status="active",
+                unit_id=unit_id,
+            )
+            session.add(user)
+            await session.flush()
+            return {
+                "id": user.id,
+                "username": "testuser_non_staff_idor",
+                "password": "NonStaffPwd!123",
+                "unit_id": unit_id,
+            }
 
 
 # ==============================================================================
@@ -416,3 +447,145 @@ class TestOfficerAssignmentIDOR:
 
         assert response.status_code in [403, 404], \
             f"Officer should not submit unassigned lead's profile: {response.status_code}"
+
+
+# ==============================================================================
+# TEST: FEE-STATUS IDOR (ADM-001 regression)
+# ==============================================================================
+
+
+class TestFeeStatusIDOR:
+    """GET /admissions/{id}/fee-status must enforce 3-tier IDOR scope.
+
+    Regression for ADM-001: previously the route only required login, so any
+    authenticated user could read fee fields of profiles outside their scope.
+    """
+
+    async def test_cross_unit_officer_cannot_read_fee_status(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_b_id = await create_second_unit()
+        lead_b = await create_test_lead(unit_b_id)
+        profile_b_id = await create_admission_profile(lead_b, "777700001111")
+
+        headers = await get_auth_headers(client, officer_user_in_db)
+        response = await client.get(
+            f"/api/admissions/{profile_b_id}/fee-status",
+            headers=headers,
+        )
+        assert response.status_code == 404, (
+            "ADM-001 regression: officer must not read fee-status across units"
+        )
+
+    async def test_same_unit_unassigned_officer_cannot_read_fee_status(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        # Lead in same unit but assigned to no one (or someone else)
+        lead_id = await create_test_lead(unit_id, assigned_officer_id=None)
+        profile_id = await create_admission_profile(lead_id, "777700002222")
+
+        headers = await get_auth_headers(client, officer_user_in_db)
+        response = await client.get(
+            f"/api/admissions/{profile_id}/fee-status",
+            headers=headers,
+        )
+        assert response.status_code == 404, (
+            "ADM-001 regression: officer must not read fee-status of unassigned profile"
+        )
+
+    async def test_cross_unit_manager_cannot_read_fee_status(
+        self,
+        client: AsyncClient,
+        manager_other_unit_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        lead_id = await create_test_lead(unit_id, assigned_officer_id=None)
+        profile_id = await create_admission_profile(lead_id, "777700003333")
+
+        headers = await get_auth_headers(client, manager_other_unit_user_in_db)
+        response = await client.get(
+            f"/api/admissions/{profile_id}/fee-status",
+            headers=headers,
+        )
+        assert response.status_code == 404, (
+            "ADM-001 regression: cross-unit manager must not read fee-status"
+        )
+
+    async def test_admin_can_read_fee_status_any_unit(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_b_id = await create_second_unit()
+        lead_b = await create_test_lead(unit_b_id)
+        profile_b_id = await create_admission_profile(lead_b, "777700004444")
+
+        headers = await get_auth_headers(client, admin_user_in_db)
+        response = await client.get(
+            f"/api/admissions/{profile_b_id}/fee-status",
+            headers=headers,
+        )
+        assert response.status_code == 200, (
+            f"Admin must read any unit's fee-status, got {response.status_code}"
+        )
+
+    async def test_assigned_officer_can_read_fee_status(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        lead_id = await create_test_lead(
+            unit_id, assigned_officer_id=officer_user_in_db["id"]
+        )
+        profile_id = await create_admission_profile(lead_id, "777700005555")
+
+        headers = await get_auth_headers(client, officer_user_in_db)
+        response = await client.get(
+            f"/api/admissions/{profile_id}/fee-status",
+            headers=headers,
+        )
+        assert response.status_code == 200, (
+            f"Assigned officer must read fee-status, got {response.status_code}"
+        )
+
+    async def test_same_unit_non_staff_role_cannot_read_fee_status(
+        self,
+        client: AsyncClient,
+        non_staff_user_same_unit_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """ADM-001 review fix: a ``role=user`` user in the SAME unit as
+        the lead used to slip through because the dependency only special-
+        cased OFFICER. Now the role allow-list rejects anything outside
+        {ADMIN, MANAGER, OFFICER} up front with a fake 404 — even though
+        the route itself only uses ``get_current_active_user`` (no Casbin
+        gate).
+        """
+        unit_id = seed_lead_dependencies["unit_id"]
+        lead_id = await create_test_lead(unit_id, assigned_officer_id=None)
+        profile_id = await create_admission_profile(lead_id, "777700006666")
+
+        headers = await get_auth_headers(client, non_staff_user_same_unit_in_db)
+        response = await client.get(
+            f"/api/admissions/{profile_id}/fee-status",
+            headers=headers,
+        )
+        # Dependency raises ResourceNotFoundError → 404. Treat 403 as
+        # acceptable in case a future Casbin gate lands on the route, but
+        # 200 must never happen.
+        assert response.status_code in (403, 404), (
+            "ADM-001 review fix: non-admission role with matching unit "
+            f"must NOT read fee-status; got {response.status_code} - "
+            f"{response.text[:200]}"
+        )

--- a/Backend_FastAPI/tests/security/test_csv_injection.py
+++ b/Backend_FastAPI/tests/security/test_csv_injection.py
@@ -182,3 +182,53 @@ class TestDangerousPrefixes:
                 assert result.startswith("'"), f"Prefix '{prefix}' not sanitized"
                 assert result == f"'{test_value}"
 
+
+class TestAdmissionExportSanitizes:
+    """ADM-006 regression: admission CSV export must wrap rows through
+    ``sanitize_csv_row`` so lead-controlled fields cannot smuggle formulas
+    into Excel/LibreOffice."""
+
+    def test_router_imports_sanitize_csv_row(self):
+        """Static guard: the admissions router pulls in the sanitizer."""
+        import app.routers.admissions as admissions_module
+        assert getattr(admissions_module, "sanitize_csv_row", None) is not None, (
+            "ADM-006 regression: admissions router must import sanitize_csv_row"
+        )
+
+    def test_admission_export_wraps_writerow_with_sanitize_csv_row(self):
+        """Static guard: every writerow data row in the export goes through
+        sanitize_csv_row, not raw lists. Catches future contributors who
+        re-introduce ``writer.writerow([profile.id, lead.full_name, ...])``
+        with raw lead-controlled fields.
+        """
+        import inspect
+        from app.routers import admissions as admissions_module
+
+        source = inspect.getsource(admissions_module.export_admissions_csv)
+        # Header row is allowed to be raw (static literals only)
+        assert "sanitize_csv_row(" in source, (
+            "ADM-006 regression: export_admissions_csv must wrap data rows "
+            "with sanitize_csv_row(...)"
+        )
+
+    def test_sanitize_protects_full_name_email_phone_program(self):
+        """Lead-controlled fields with formula prefixes get neutralized."""
+        row = sanitize_csv_row([
+            42,
+            "=HYPERLINK(\"http://evil.example/\",\"click\")",  # full_name
+            "+attacker@example.com",  # email
+            "-0901234567",  # phone
+            "@123456789",  # citizen_id
+            "draft",
+            "10%",
+            "=cmd|'/c calc'!A1",  # program name
+            "2026-04-27 10:00",
+            "2026-04-27 10:00",
+        ])
+        assert row[0] == "42"
+        assert row[1].startswith("'="), "full_name formula not neutralized"
+        assert row[2].startswith("'+"), "email + prefix not neutralized"
+        assert row[3].startswith("'-"), "phone - prefix not neutralized"
+        assert row[4].startswith("'@"), "citizen_id @ prefix not neutralized"
+        assert row[7].startswith("'="), "program name formula not neutralized"
+

--- a/Backend_FastAPI/tests/unit/test_admission_bulk_error_mapping.py
+++ b/Backend_FastAPI/tests/unit/test_admission_bulk_error_mapping.py
@@ -1,0 +1,95 @@
+"""ADM-012 regression: bulk admission actions must not leak raw exception
+text into the per-item error map.
+
+Domain exceptions carry safe user-facing copy and should pass through; any
+other exception (DB, validation library, downstream HTTP errors, etc.) is
+hidden behind ``Unexpected error (ref: <correlation>)`` and the full
+detail is logged server-side with a correlation id.
+"""
+
+import pytest
+
+from app.services.admission_service import _safe_bulk_error_message
+from app.utils.exceptions import (
+    BadRequest,
+    BusinessRuleViolation,
+    ConflictError,
+    PermissionDeniedError,
+    ResourceNotFoundError,
+    ValidationError,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ResourceNotFoundError("Profile 42 not found"),
+        BadRequest("Officer must be active"),
+        BusinessRuleViolation("Cannot approve a draft profile"),
+        PermissionDeniedError("Only managers can assign"),
+        ConflictError("Stale version"),
+        ValidationError("Citizen ID is required"),
+    ],
+)
+def test_domain_exception_message_passes_through(exc):
+    """Domain exceptions are user-facing — keep their copy."""
+    msg = _safe_bulk_error_message(
+        exc,
+        bulk_label="admission_bulk_approve",
+        profile_id=1,
+        actor_id=99,
+    )
+    assert msg == str(exc)
+
+
+def test_generic_exception_is_hidden_behind_correlation_id():
+    """Unknown exceptions must NOT leak ``str(e)`` into the response."""
+    # Mimic something the DB layer might raise — message contains a SQL
+    # snippet that we never want to surface to the API client.
+    leaky = RuntimeError(
+        "psycopg2.errors.UniqueViolation: duplicate key value violates unique "
+        'constraint "ix_admission_profiles_citizen_id"'
+    )
+
+    msg = _safe_bulk_error_message(
+        leaky,
+        bulk_label="admission_bulk_approve",
+        profile_id=42,
+        actor_id=99,
+    )
+
+    assert msg.startswith("Unexpected error"), msg
+    assert "ref:" in msg, msg
+    # SQL/library detail must not appear in the user-facing copy.
+    assert "psycopg2" not in msg
+    assert "UniqueViolation" not in msg
+    assert "ix_admission_profiles_citizen_id" not in msg
+
+
+def test_correlation_id_is_per_call_unique():
+    """Two unknown failures get distinct correlation ids so ops can pivot."""
+    msg1 = _safe_bulk_error_message(
+        RuntimeError("boom 1"),
+        bulk_label="admission_bulk_assign",
+        profile_id=1,
+    )
+    msg2 = _safe_bulk_error_message(
+        RuntimeError("boom 2"),
+        bulk_label="admission_bulk_assign",
+        profile_id=2,
+    )
+    assert msg1 != msg2
+
+
+def test_handles_missing_actor_id():
+    """``actor_id`` is optional — helper must not crash when it's None."""
+    msg = _safe_bulk_error_message(
+        BusinessRuleViolation("test"),
+        bulk_label="admission_bulk_reject",
+        profile_id=7,
+        actor_id=None,
+    )
+    assert msg == "test"

--- a/Backend_FastAPI/tests/unit/test_admission_file_signature.py
+++ b/Backend_FastAPI/tests/unit/test_admission_file_signature.py
@@ -1,0 +1,63 @@
+"""ADM-019 regression: document upload signature sniff.
+
+Helper ``_sniff_document_signature`` is the gate that closes two gaps in
+the original upload code:
+  1. ``UploadFile.content_type`` is fully client-controlled.
+  2. Whitelist on filename extension fell back to ``.bin`` for unknowns
+     instead of rejecting them.
+
+These unit tests pin the magic-byte detection contract for the file
+types we support (PDF, JPEG, PNG) and confirm that everything else
+returns ``None`` so the caller can raise ``BadRequest``.
+"""
+
+import io
+
+import pytest
+
+from app.services.admission_service import _sniff_document_signature
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestSniffDocumentSignature:
+    def test_detects_pdf(self):
+        stream = io.BytesIO(b"%PDF-1.7\n... rest of pdf bytes ...")
+        assert _sniff_document_signature(stream) == "pdf"
+        # Stream cursor is restored so caller can write the file out.
+        assert stream.read(5) == b"%PDF-"
+
+    def test_detects_jpeg(self):
+        stream = io.BytesIO(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        assert _sniff_document_signature(stream) == "jpeg"
+
+    def test_detects_png(self):
+        stream = io.BytesIO(b"\x89PNG\r\n\x1a\n<rest>")
+        assert _sniff_document_signature(stream) == "png"
+
+    def test_rejects_html_disguised_as_pdf(self):
+        """The original bug: an HTML upload with ``content_type=application/pdf``
+        would pass content-type check + ``.bin`` fallback. Magic-byte sniff
+        catches it."""
+        stream = io.BytesIO(b"<!DOCTYPE html><html>...")
+        assert _sniff_document_signature(stream) is None
+
+    def test_rejects_executable(self):
+        # PE/COFF "MZ" header
+        stream = io.BytesIO(b"MZ\x90\x00\x03\x00")
+        assert _sniff_document_signature(stream) is None
+
+    def test_rejects_zip_or_office_xml(self):
+        # ZIP-based files (docx/xlsx/pptx) start with PK\x03\x04
+        stream = io.BytesIO(b"PK\x03\x04 ...")
+        assert _sniff_document_signature(stream) is None
+
+    def test_rejects_empty_stream(self):
+        stream = io.BytesIO(b"")
+        assert _sniff_document_signature(stream) is None
+
+    def test_short_stream_with_partial_pdf_header_rejected(self):
+        # Less than the full ``%PDF-`` magic — must NOT match.
+        stream = io.BytesIO(b"%PDF")  # missing trailing dash
+        assert _sniff_document_signature(stream) is None

--- a/Backend_FastAPI/tests/unit/test_admission_path_activation.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_activation.py
@@ -1,0 +1,152 @@
+"""ADM-004 regression: ``validate_activation`` must enforce the same
+readiness contract as ``get_coverage_matrix``.
+
+Before the fix, ``validate_activation`` only checked status + quota and
+left criteria/documents as "placeholder" comments. The route therefore
+let admins activate paths that the coverage matrix flagged as not-ready.
+Now both code paths agree:
+
+- status in {draft, inactive}
+- academic_info.annual_admission_quota > 0
+- path.criteria_id is set
+- a DocumentGroup resolves for offering_type + admission_method
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.admission_path_service import AdmissionPathService
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_path(
+    *,
+    status: str = "draft",
+    quota: int = 100,
+    criteria_id: int | None = 7,
+    offering_type_id: int | None = 1,
+    admission_method_id: int = 1,
+):
+    """Build an in-memory AdmissionPath stand-in with just the attrs the
+    service touches. Avoids needing a DB session for unit tests."""
+    offering = SimpleNamespace(offering_type_id=offering_type_id)
+    academic_info = SimpleNamespace(
+        annual_admission_quota=quota,
+        offering=offering,
+    )
+    return SimpleNamespace(
+        id=1,
+        status=status,
+        academic_info=academic_info,
+        criteria_id=criteria_id,
+        admission_method_id=admission_method_id,
+    )
+
+
+def _make_service(
+    *,
+    method_group: object | None = None,
+    shared_groups: list | None = None,
+):
+    """Build an AdmissionPathService with a stub DocumentGroupRepository.
+
+    The service constructs ``DocumentGroupRepository(self.db)`` lazily
+    inside ``validate_activation``. We patch the import site so the stub
+    is returned regardless of the db arg.
+    """
+    service = AdmissionPathService.__new__(AdmissionPathService)
+    service.db = MagicMock()
+    service.repo = MagicMock()
+
+    doc_repo = MagicMock()
+    doc_repo.get_method_specific_group = AsyncMock(return_value=method_group)
+    doc_repo.get_shared_groups = AsyncMock(return_value=shared_groups or [])
+    return service, doc_repo
+
+
+def _patch_doc_repo(doc_repo):
+    return patch(
+        "app.repositories.document_group_repository.DocumentGroupRepository",
+        return_value=doc_repo,
+    )
+
+
+class TestValidateActivation:
+    async def test_ready_path_can_activate(self):
+        service, doc_repo = _make_service(method_group=object())
+        path = _make_path()
+
+        with _patch_doc_repo(doc_repo):
+            can_activate, errors = await service.validate_activation(path)
+
+        assert can_activate is True, errors
+        assert errors == []
+
+    async def test_active_status_blocks_activation(self):
+        service, doc_repo = _make_service(method_group=object())
+        path = _make_path(status="active")
+
+        with _patch_doc_repo(doc_repo):
+            can_activate, errors = await service.validate_activation(path)
+
+        assert can_activate is False
+        assert any("status" in e.lower() for e in errors)
+
+    async def test_zero_quota_blocks_activation(self):
+        service, doc_repo = _make_service(method_group=object())
+        path = _make_path(quota=0)
+
+        with _patch_doc_repo(doc_repo):
+            can_activate, errors = await service.validate_activation(path)
+
+        assert can_activate is False
+        assert any("Quota" in e or "chỉ tiêu" in e.lower() for e in errors)
+
+    async def test_missing_criteria_blocks_activation(self):
+        service, doc_repo = _make_service(method_group=object())
+        path = _make_path(criteria_id=None)
+
+        with _patch_doc_repo(doc_repo):
+            can_activate, errors = await service.validate_activation(path)
+
+        assert can_activate is False
+        assert any("Criteria" in e or "tiêu chí" in e.lower() for e in errors)
+
+    async def test_missing_documents_blocks_activation(self):
+        # Neither method-specific nor shared groups exist
+        service, doc_repo = _make_service(method_group=None, shared_groups=[])
+        path = _make_path()
+
+        with _patch_doc_repo(doc_repo):
+            can_activate, errors = await service.validate_activation(path)
+
+        assert can_activate is False
+        assert any("Documents" in e or "hồ sơ" in e.lower() for e in errors)
+
+    async def test_shared_documents_satisfy_requirement(self):
+        # No method-specific group, but shared group exists
+        service, doc_repo = _make_service(
+            method_group=None, shared_groups=[object()]
+        )
+        path = _make_path()
+
+        with _patch_doc_repo(doc_repo):
+            can_activate, errors = await service.validate_activation(path)
+
+        assert can_activate is True, errors
+
+    async def test_all_missing_collects_all_errors(self):
+        """validate_activation should accumulate every gap, not bail early."""
+        service, doc_repo = _make_service(method_group=None, shared_groups=[])
+        path = _make_path(quota=0, criteria_id=None)
+
+        with _patch_doc_repo(doc_repo):
+            can_activate, errors = await service.validate_activation(path)
+
+        assert can_activate is False
+        # Quota + criteria + documents — three independent gaps
+        assert len(errors) >= 3

--- a/Backend_FastAPI/tests/unit/test_admission_path_lifecycle_guard.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_lifecycle_guard.py
@@ -1,0 +1,72 @@
+"""ADM-005 regression: lifecycle guard must apply to ``update_path``,
+``upsert_criteria`` and ``upsert_documents`` alike.
+
+Before the fix, only ``update_path`` blocked managers from editing
+non-draft paths and rejected archived paths. Routes that delegated to
+``upsert_criteria`` / ``upsert_documents`` therefore let a manager edit
+the rules of an active or even archived path — which the audit flagged
+as a governance gap.
+
+The shared helper ``_check_lifecycle_guard`` is now invoked at the top of
+all three service methods. These tests pin its contract directly so a
+future regression at any one call site stays caught.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.constants import UserRole
+from app.services.admission_path_service import _check_lifecycle_guard
+from app.utils.exceptions import BusinessRuleViolation
+
+
+pytestmark = pytest.mark.unit
+
+
+def _path(status: str):
+    return SimpleNamespace(id=1, status=status)
+
+
+def _user(role: UserRole):
+    return SimpleNamespace(id=1, role=role)
+
+
+class TestLifecycleGuard:
+    def test_archived_blocks_admin(self):
+        with pytest.raises(BusinessRuleViolation, match="archived"):
+            _check_lifecycle_guard(_path("archived"), _user(UserRole.ADMIN))
+
+    def test_archived_blocks_manager(self):
+        with pytest.raises(BusinessRuleViolation, match="archived"):
+            _check_lifecycle_guard(_path("archived"), _user(UserRole.MANAGER))
+
+    def test_admin_can_edit_draft(self):
+        _check_lifecycle_guard(_path("draft"), _user(UserRole.ADMIN))
+
+    def test_admin_can_edit_active(self):
+        # Admin emergency edit of an active path is intent (Q2 decision a/b)
+        _check_lifecycle_guard(_path("active"), _user(UserRole.ADMIN))
+
+    def test_admin_can_edit_inactive(self):
+        _check_lifecycle_guard(_path("inactive"), _user(UserRole.ADMIN))
+
+    def test_manager_can_edit_draft(self):
+        _check_lifecycle_guard(_path("draft"), _user(UserRole.MANAGER))
+
+    def test_manager_blocked_on_active(self):
+        with pytest.raises(BusinessRuleViolation, match="draft"):
+            _check_lifecycle_guard(_path("active"), _user(UserRole.MANAGER))
+
+    def test_manager_blocked_on_inactive(self):
+        with pytest.raises(BusinessRuleViolation, match="draft"):
+            _check_lifecycle_guard(_path("inactive"), _user(UserRole.MANAGER))
+
+    @pytest.mark.parametrize(
+        "role",
+        [UserRole.OFFICER, UserRole.USER, UserRole.ACCOUNTANT],
+    )
+    def test_non_admin_non_manager_blocked_on_non_draft(self, role):
+        """Defense-in-depth: anything past Casbin must still hit draft-only."""
+        with pytest.raises(BusinessRuleViolation, match="draft"):
+            _check_lifecycle_guard(_path("active"), _user(role))


### PR DESCRIPTION
## Summary

Wave 1 of the admission module audit (`Documents/ADMISSION_MODULE_AUDIT_2026-04-27.md`). Seven findings, all code-only, no product input required. Three borderline code-only findings (ADM-008/009/014) are deferred per chat decision.

| ID | Severity | Fix |
|---|---|---|
| ADM-001 | P1 Security/IDOR | New `get_admission_for_user_read` dependency; 3-tier scope + role allow-list (admin/manager/officer only) wired into `GET /admissions/{id}/fee-status` |
| ADM-006 | P1 Security | CSV export wraps every data row through `app.utils.csv_helpers.sanitize_csv_row` to neutralize formula/DDE injection from lead-controlled fields |
| ADM-010 | P2 API contract | Centralized `_validate_payment_status` shared by list / status-counts / export — invalid enum now rejects with 400 across all three endpoints |
| ADM-012 | P2 Security | `_safe_bulk_error_message` masks unknown exceptions behind a correlation id in bulk approve/reject/assign; domain exceptions still surface their user-facing copy |
| ADM-004 | P1 Config | `validate_activation` now mirrors the coverage-matrix readiness rules (criteria + documents + quota + status) — the route guard and UI badge agree on a single contract |
| ADM-005 | P1 Config | Shared `_check_lifecycle_guard` applied to `update_path`, `upsert_criteria`, `upsert_documents` so manager cannot bypass "draft only" by hitting the criteria/documents sub-routes; archived rejects everywhere |
| ADM-019 | P3 Security | `_sniff_document_signature` magic-byte check on document upload; rejects `.bin` fallback, `Content-Type` mismatch, and non-PDF/JPEG/PNG content |

## Targeted verification

Targeted backend test runs on a clean worktree against this branch:

- `tests/integration/test_admission_idor.py` — **14/14 PASS** (includes 6 new fee-status IDOR cases: cross-unit officer/manager → 404, same-unit unassigned officer → 404, admin all-units → 200, assigned officer → 200, **same-unit non-staff role (role=user) → 403/404** for the role allow-list bite)
- `tests/services/test_admission_application_fee.py` — **14/14 PASS** (regression — fee-status happy path unchanged)
- `tests/unit/test_admission_file_signature.py` — **8/8 PASS** (PDF/JPEG/PNG accepted; HTML/PE/ZIP/empty/partial-PDF rejected)
- `tests/unit/test_admission_path_lifecycle_guard.py` — **11/11 PASS** (admin/manager × draft/active/archived matrix + parametrized non-admin defense-in-depth)
- `tests/unit/test_admission_bulk_error_mapping.py` — **9/9 PASS** (psycopg2/SQL fragments must NOT appear in the user-facing message; correlation id per-call unique)
- `tests/unit/test_admission_path_activation.py` — **7/7 PASS** (each readiness gap pinned independently + all-missing case)
- `tests/security/test_csv_injection.py` — **25/25 PASS** (includes 3 new admission-export-specific guards)
- `tests/api/test_admission_payment_status_validation.py` — **15/15 PASS** (parametrized invalid → 400 / valid → not-400 across all three endpoints)

**Total: 105 passed, 0 failed, 0 regression on admission core.**

## Pre-existing failures (verified on main, OUTSIDE PR1 scope)

The following 5 failures exist on `origin/main` (1dc296b6) without this branch and are NOT introduced by PR1:

- `test_admission_workflow_e2e.py::TestPhase3Finance::test_step12_issue_invoice` — `asyncpg.DeadlockDetectedError` in fixture chain
- `test_admission_workflow_e2e.py::TestPhase3Finance::test_step13_accountant_records_payment` — same fixture deadlock
- `test_admission_workflow_e2e.py::TestPhase3Finance::test_step14_manager_verifies_payment` — same fixture deadlock
- `test_admission_workflow_e2e.py::TestMakerCheckerSeparation::test_accountant_cannot_self_verify` — same fixture deadlock
- `test_admission_workflow_e2e.py::TestDiamondInheritancePermissions::test_officer_template_lacks_finance_operations` — outdated assertion: Casbin policy was updated per the chat-thread "officer scoped fee calc" decision (2026-04-24), but this test still expects officer to LACK `/api/fees/calculate`. Test bug, not a code bug.

The first four are a test-fixture race / session-sharing issue (fixture chain `test_step11 → 12 → 13 → 14` with cross-test session reuse) — refactor belongs in a dedicated `test-debt/admission-workflow-e2e-fixture-fix` PR, not here. The fifth is a one-line test update (deferred to align with whoever ships the matching policy follow-ups).

## Test plan

- [x] Targeted backend tests (105 passed, listed above)
- [x] Pre-existing main-branch failures verified unrelated (checked out `origin/main` and reproduced the 5 failures)
- [x] Worktree clean before push (only the two untracked files unrelated to PR1 — `Documents/ADMISSION_MODULE_AUDIT_2026-04-27.md` and `scripts/plan-loop.ps1` — were intentionally left out of the branch)
- [ ] Reviewer: pull branch and rerun `tests/integration/test_admission_idor.py::TestFeeStatusIDOR` (smoke-confirms the role allow-list)
- [ ] Reviewer: confirm the four thematic commits are individually revertable (the file overlap was kept tight so `git revert <sha>` per commit removes one finding-pair cleanly)
- [ ] Post-merge: smoke `GET /api/admissions/{id}/fee-status` on prod with an officer assigned to the lead's unit and an officer outside the unit, expect 200 vs 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)