### PR TITLE
fix(admissions): audit Wave 2 deferred code-only fixes

### DIFF
--- a/Backend_FastAPI/app/routers/admission_config.py
+++ b/Backend_FastAPI/app/routers/admission_config.py
@@ -113,18 +113,25 @@ async def get_subjects(
 @router.get("/subjects/{code}", response_model=SubjectResponse)
 async def get_subject_by_code(
     code: str,
+    active_only: bool = Depends(get_config_filter),
     repo: AdmissionConfigRepository = Depends(get_admission_config_repo),
-    # current_user unused
 ):
-    """Get subject by code."""
+    """Get subject by code.
+
+    ADM-009: detail endpoint mirrors the list-scope filter — non-admin
+    callers must not see inactive items via the by-code route while the
+    list route hides them. ``active_only`` is True for non-admin per
+    ``get_config_filter``; an inactive item then 404s with the same
+    message as a missing one to avoid leaking existence.
+    """
     subject = await repo.get_subject_by_code(code)
-    
-    if not subject:
+
+    if not subject or (active_only and not subject.is_active):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Subject '{code}' not found"
         )
-    
+
     return SubjectResponse.model_validate(subject)
 
 
@@ -223,12 +230,17 @@ async def get_subject_groups(
 @router.get("/subject-groups/{code}", response_model=SubjectGroupResponse)
 async def get_subject_group_by_code(
     code: str,
+    active_only: bool = Depends(get_config_filter),
     repo: AdmissionConfigRepository = Depends(get_admission_config_repo),
 ):
-    """Get subject group by code with subjects."""
+    """Get subject group by code with subjects.
+
+    ADM-009: see ``get_subject_by_code``. Inactive groups 404 for
+    non-admin to keep parity with the list-scope filter.
+    """
     group = await repo.get_subject_group_by_code(code, with_subjects=True)
-    
-    if not group:
+
+    if not group or (active_only and not group.is_active):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Subject group '{code}' not found"
@@ -355,18 +367,22 @@ async def get_admission_methods(
 @router.get("/methods/{code}", response_model=AdmissionMethodResponse)
 async def get_method_by_code(
     code: str,
+    active_only: bool = Depends(get_config_filter),
     repo: AdmissionConfigRepository = Depends(get_admission_config_repo),
-    # current_user unused
 ):
-    """Get admission method by code."""
+    """Get admission method by code.
+
+    ADM-009: see ``get_subject_by_code``. Inactive methods 404 for
+    non-admin to keep parity with the list-scope filter.
+    """
     method = await repo.get_method_by_code(code)
-    
-    if not method:
+
+    if not method or (active_only and not method.is_active):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Method '{code}' not found"
         )
-    
+
     return AdmissionMethodResponse.model_validate(method)
 
 
@@ -809,18 +825,22 @@ def _build_doc_group_response(group) -> Optional[SharedDocumentGroupResponse]:
 @router.get("/document-groups/shared/{offering_type_id}", response_model=Optional[SharedDocumentGroupResponse])
 async def get_shared_document_group(
     offering_type_id: int,
+    active_only: bool = Depends(get_config_filter),
     db: AsyncSession = Depends(get_db),
-    # Read access allowed for all
 ):
     """
     Get shared document group configuration for an Offering Type.
+
+    ADM-009: non-admin must not see inactive shared document groups.
+    Returns ``None`` (the list-shape contract) when filtered out, same
+    as when no group exists for the offering type.
     """
     service = AdmissionConfigService(db)
     group = await service.get_shared_document_group(offering_type_id)
-    
-    if not group:
+
+    if not group or (active_only and not group.is_active):
         return None
-        
+
     return _build_doc_group_response(group)
 
 

--- a/Backend_FastAPI/app/routers/admission_paths.py
+++ b/Backend_FastAPI/app/routers/admission_paths.py
@@ -22,6 +22,7 @@ from app.core.constants import UserRole
 from app.core.deps import (
     get_current_active_user,
     check_permission,
+    require_admin,
     require_admin_or_manager,
 )
 from app.schemas.admission_path import (
@@ -409,15 +410,20 @@ async def update_admission_documents(
 @router.post(
     "/paths/{path_id}/activate",
     response_model=AdmissionPathResponse,
-    summary="Activate admission path"
+    summary="Activate admission path (admin-only)"
 )
 async def activate_admission_path(
     path: models.AdmissionPath = Depends(get_admission_path_for_user),
     db: AsyncSession = Depends(database.get_db),
-    current_user: models.User = Depends(get_current_active_user),
+    current_user: models.User = Depends(require_admin),  # ADM-008: admin-only per Q3=a
 ):
     """
     Activate an admission path.
+
+    **Authorization (ADM-008 / Q3=a):** Admin only. Manager can create/edit
+    draft paths but cannot activate or deactivate — Admin "approves =
+    activates". Manager attempting this route gets 403 from
+    ``require_admin``.
 
     Validation:
     - Must have criteria
@@ -446,15 +452,18 @@ async def activate_admission_path(
 @router.post(
     "/paths/{path_id}/deactivate",
     response_model=AdmissionPathResponse,
-    summary="Deactivate admission path"
+    summary="Deactivate admission path (admin-only)"
 )
 async def deactivate_admission_path(
     path: models.AdmissionPath = Depends(get_admission_path_for_user),
     db: AsyncSession = Depends(database.get_db),
-    current_user: models.User = Depends(get_current_active_user),
+    current_user: models.User = Depends(require_admin),  # ADM-008: admin-only per Q3=a
 ):
     """
     Deactivate an active admission path.
+
+    **Authorization (ADM-008 / Q3=a):** Admin only. Symmetric to activate —
+    once a path goes live, only Admin may take it back down.
 
     IDOR: Protected via get_admission_path_for_user dependency.
     """

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -37,6 +37,7 @@ from app.utils.exceptions import (
     ResourceNotFoundError,
     DuplicateResourceError,
     BusinessRuleViolation,
+    PermissionDeniedError,
 )
 
 # Type alias for post-commit callback
@@ -435,26 +436,38 @@ class AdmissionPathService:
     ) -> Tuple[AdmissionPath, PostCommitCallback]:
         """
         Activate an AdmissionPath.
-        
+
+        ADM-008 (Q3=a): admin-only. Manager creates/edits drafts but
+        cannot activate — Admin "approves = activates". Service-level
+        gate is defense-in-depth; the route also guards via
+        ``Depends(require_admin)``.
+
         Raises:
-            BusinessRuleViolation: If validation fails
+            PermissionDeniedError: If caller is not admin
+            BusinessRuleViolation: If readiness validation fails
         """
+        if user.role != UserRole.ADMIN:
+            raise PermissionDeniedError(
+                "Chỉ admin được activate admission path. "
+                "Manager tạo/sửa draft, admin duyệt = activate."
+            )
+
         can_activate, errors = await self.validate_activation(path)
-        
+
         if not can_activate:
             raise BusinessRuleViolation(
                 f"Cannot activate path: {'; '.join(errors)}"
             )
-        
+
         # Activate
         path = await self.repo.update(path, {
             "status": "active",
             "activated_at": datetime.now(timezone.utc),
             "activated_by": user.id,
         })
-        
+
         return path, _noop_callback
-    
+
     async def deactivate_path(
         self,
         path: AdmissionPath,
@@ -462,19 +475,27 @@ class AdmissionPathService:
     ) -> Tuple[AdmissionPath, PostCommitCallback]:
         """
         Deactivate an active AdmissionPath.
-        
+
+        ADM-008 (Q3=a): admin-only, symmetric to ``activate_path``.
+
         Raises:
+            PermissionDeniedError: If caller is not admin
             BusinessRuleViolation: If path is not active
         """
+        if user.role != UserRole.ADMIN:
+            raise PermissionDeniedError(
+                "Chỉ admin được deactivate admission path."
+            )
+
         if path.status != "active":
             raise BusinessRuleViolation(
                 f"Cannot deactivate path with status '{path.status}'"
             )
-        
+
         path = await self.repo.update(path, {
             "status": "inactive",
         })
-        
+
         return path, _noop_callback
     
     async def archive_path(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -5282,6 +5282,10 @@ async def override_profile(
             "Please refresh and try again."
         )
 
+    # ADM-014: capture pre-mutation state for the audit row.
+    _audit_old_status = profile.status
+    _audit_old_version = profile.version
+
     # STATE CHANGE
     profile.status = "overridden"
     profile.overridden_at = datetime.now(timezone.utc)
@@ -5319,9 +5323,33 @@ async def override_profile(
     # Populate transient computed fields so the mutation response matches GET.
     await _populate_response_fields(db, profile, admin)
 
-    # AUDIT LOG (per AUTHORIZATION_DECISIONS.md Decision 11)
-    # TODO: Wire admin-override audit into audit_service.log_*.
-    # entity_audit_log table already exists; this path still only emits log.warning.
+    # AUDIT LOG (per AUTHORIZATION_DECISIONS.md Decision 11) — ADM-014:
+    # admin override is a bypass action that absolutely needs durable audit
+    # in entity_audit_log, not just runtime log.warning. The fields below
+    # mirror what claim/unclaim/approve/reject already write.
+    from ..services import audit_service
+    await audit_service.log_changes(
+        db,
+        "AdmissionProfile",
+        profile.id,
+        "overridden",
+        changes={
+            "status": {"old": _audit_old_status, "new": "overridden"},
+            "version": {"old": _audit_old_version, "new": profile.version},
+            "override_reason": {"old": None, "new": data["reason"]},
+            "bypass_rules": {
+                "old": None,
+                "new": list(data.get("bypass_rules") or []),
+            },
+            "overridden_by_id": {"old": None, "new": admin.id},
+        },
+        actor_user_id=admin.id,
+        reason=data["reason"],
+        source="api",
+    )
+
+    # Keep the warning log too — useful for live alerting / SIEM, separate
+    # from the durable DB row.
     log.warning(
         "AUDIT: Admin override action",
         profile_id=profile.id,

--- a/Backend_FastAPI/tests/api/test_admission_config_detail_filter.py
+++ b/Backend_FastAPI/tests/api/test_admission_config_detail_filter.py
@@ -1,0 +1,271 @@
+"""ADM-009 regression: admission-config detail endpoints must respect
+the same ``active_only`` filter as the list endpoints.
+
+The list routes already plug ``Depends(get_config_filter)`` so non-admin
+callers (officer / regular user) only see active items. Before the fix,
+the by-code detail endpoints (subject, subject-group, method) and the
+shared document-group endpoint had no filter — a non-admin could read
+inactive/draft config rows by knowing the code, leaking what's in the
+admin pipeline. The filter is now applied consistently.
+"""
+
+import time
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _login(client: AsyncClient, user_info: dict) -> dict:
+    res = await client.post(
+        "/api/auth/login",
+        data={"username": user_info["username"], "password": user_info["password"]},
+    )
+    if res.status_code != 200:
+        pytest.fail(f"Login failed: {res.status_code} - {res.text}")
+    token = res.cookies.get("access_token")
+    if not token:
+        pytest.fail("Login succeeded but access_token cookie not found")
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest_asyncio.fixture
+async def inactive_subject(setup_test_database):
+    ts = int(time.time() * 1000)
+    code = f"INACT_SUBJ_{ts}"
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            subject = models.Subject(
+                code=code,
+                name_vi="Môn ẩn",
+                is_active=False,
+            )
+            s.add(subject)
+    return code
+
+
+@pytest_asyncio.fixture
+async def inactive_subject_group(setup_test_database):
+    # SubjectGroup.code is VARCHAR(10); keep tail short.
+    ts_tail = str(int(time.time() * 1000))[-6:]
+    code = f"IG{ts_tail}"
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            sg = models.SubjectGroup(
+                code=code,
+                name="Khối ẩn",
+                is_active=False,
+            )
+            s.add(sg)
+    return code
+
+
+@pytest_asyncio.fixture
+async def inactive_admission_method(setup_test_database):
+    ts = int(time.time() * 1000)
+    code = f"INACT_AM_{ts}"
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            am = models.AdmissionMethod(
+                code=code,
+                name="Phương thức ẩn",
+                requires_gpa=False,
+                requires_subject_scores=False,
+                is_active=False,
+            )
+            s.add(am)
+    return code
+
+
+@pytest_asyncio.fixture
+async def inactive_shared_doc_group(setup_test_database):
+    """Create an inactive shared DocumentGroup (no admission_method_id =
+    shared) for an offering type."""
+    ts_tail = str(int(time.time() * 1000))[-9:]
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ot = models.ConfigOfferingType(
+                code=f"OT_{ts_tail}",
+                name=f"OT inactive {ts_tail}",
+            )
+            s.add(ot)
+            await s.flush()
+            grp = models.DocumentGroup(
+                offering_type_id=ot.id,
+                admission_method_id=None,  # shared
+                code=f"DG_{ts_tail}",
+                name="Hồ sơ ẩn",
+                is_active=False,
+            )
+            s.add(grp)
+            await s.flush()
+            return ot.id
+
+
+class TestSubjectByCodeFilter:
+    async def test_officer_cannot_read_inactive_subject_by_code(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        inactive_subject: str,
+    ):
+        headers = await _login(client, officer_user_in_db)
+        response = await client.get(
+            f"/api/admission-config/subjects/{inactive_subject}",
+            headers=headers,
+        )
+        assert response.status_code == 404, (
+            f"ADM-009: officer must not see inactive subject by code; "
+            f"got {response.status_code} - {response.text[:200]}"
+        )
+
+    async def test_admin_can_read_inactive_subject_with_active_only_false(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        inactive_subject: str,
+    ):
+        headers = await _login(client, admin_user_in_db)
+        response = await client.get(
+            f"/api/admission-config/subjects/{inactive_subject}"
+            "?active_only=false",
+            headers=headers,
+        )
+        assert response.status_code == 200, (
+            f"Admin with active_only=false must see inactive subject; "
+            f"got {response.status_code} - {response.text[:200]}"
+        )
+
+
+class TestSubjectGroupByCodeFilter:
+    async def test_officer_cannot_read_inactive_subject_group_by_code(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        inactive_subject_group: str,
+    ):
+        headers = await _login(client, officer_user_in_db)
+        response = await client.get(
+            f"/api/admission-config/subject-groups/{inactive_subject_group}",
+            headers=headers,
+        )
+        assert response.status_code == 404, (
+            f"ADM-009: officer must not see inactive subject group by code; "
+            f"got {response.status_code} - {response.text[:200]}"
+        )
+
+    async def test_admin_can_read_inactive_subject_group_with_override(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        inactive_subject_group: str,
+    ):
+        headers = await _login(client, admin_user_in_db)
+        response = await client.get(
+            f"/api/admission-config/subject-groups/{inactive_subject_group}"
+            "?active_only=false",
+            headers=headers,
+        )
+        assert response.status_code == 200, (
+            f"Admin with active_only=false must see inactive subject group; "
+            f"got {response.status_code} - {response.text[:200]}"
+        )
+
+
+class TestMethodByCodeFilter:
+    async def test_officer_cannot_read_inactive_method_by_code(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        inactive_admission_method: str,
+    ):
+        headers = await _login(client, officer_user_in_db)
+        response = await client.get(
+            f"/api/admission-config/methods/{inactive_admission_method}",
+            headers=headers,
+        )
+        assert response.status_code == 404, (
+            f"ADM-009: officer must not see inactive admission method by code; "
+            f"got {response.status_code} - {response.text[:200]}"
+        )
+
+    async def test_admin_can_read_inactive_method_with_override(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        inactive_admission_method: str,
+    ):
+        headers = await _login(client, admin_user_in_db)
+        response = await client.get(
+            f"/api/admission-config/methods/{inactive_admission_method}"
+            "?active_only=false",
+            headers=headers,
+        )
+        assert response.status_code == 200, (
+            f"Admin with active_only=false must see inactive method; "
+            f"got {response.status_code} - {response.text[:200]}"
+        )
+
+
+class TestSharedDocumentGroupFilter:
+    async def test_officer_cannot_read_inactive_shared_doc_group(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        inactive_shared_doc_group: int,
+    ):
+        headers = await _login(client, officer_user_in_db)
+        response = await client.get(
+            f"/api/admission-config/document-groups/shared/{inactive_shared_doc_group}",
+            headers=headers,
+        )
+        # The shared-doc endpoint returns ``None`` (200 with null body)
+        # for "no group / filtered out" — that's the existing list-shape
+        # contract. Either an explicit 404 or a null body counts as
+        # "not visible to officer".
+        if response.status_code == 200:
+            assert response.json() is None, (
+                "ADM-009: officer must not see inactive shared doc group; "
+                f"got body {response.text[:200]}"
+            )
+        else:
+            assert response.status_code in (403, 404), (
+                f"ADM-009: officer must not see inactive shared doc group; "
+                f"got {response.status_code} - {response.text[:200]}"
+            )
+
+    async def test_admin_with_override_currently_still_filtered_by_repo(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        inactive_shared_doc_group: int,
+    ):
+        """Note: ``DocumentGroupRepository.get_shared_groups`` hard-codes
+        ``is_active == True`` on the SQL query, so even when the route
+        passes ``active_only=False`` the repo never returns an inactive
+        row. ADM-009 only adds the *route-level* filter for parity with
+        the other three detail endpoints; making admin override actually
+        return inactive shared groups would require widening the repo
+        signature, which is intentionally out of PR scope.
+        """
+        headers = await _login(client, admin_user_in_db)
+        response = await client.get(
+            f"/api/admission-config/document-groups/shared/{inactive_shared_doc_group}"
+            "?active_only=false",
+            headers=headers,
+        )
+        # Endpoint contract is "200 with null body when not found".
+        # Either null body or 404 counts as filtered.
+        if response.status_code == 200:
+            assert response.json() is None, (
+                "Repo always filters inactive — body must be null"
+            )
+        else:
+            assert response.status_code == 404

--- a/Backend_FastAPI/tests/integration/test_admission_override_audit.py
+++ b/Backend_FastAPI/tests/integration/test_admission_override_audit.py
@@ -1,0 +1,214 @@
+"""ADM-014 regression: ``override_profile`` writes a durable audit row to
+``entity_audit_log``, not just ``log.warning``.
+
+Admin override is a bypass action that must be queryable for compliance
+long after runtime logs rotate. The service now calls
+``audit_service.log_changes`` mirroring claim/unclaim/approve, recording
+old/new status, version bump, override_reason, and bypass_rules.
+"""
+
+import time
+
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _login(client: AsyncClient, user_info: dict) -> dict:
+    res = await client.post(
+        "/api/auth/login",
+        data={"username": user_info["username"], "password": user_info["password"]},
+    )
+    if res.status_code != 200:
+        pytest.fail(f"Login failed: {res.status_code} - {res.text}")
+    token = res.cookies.get("access_token")
+    if not token:
+        pytest.fail("Login succeeded but access_token cookie not found")
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _create_lead(unit_id: int, assigned_officer_id: int | None = None) -> int:
+    """Minimal lead seed for an override test (we don't go through full
+    workflow — just need an approved profile attached to a lead in the
+    seeded unit)."""
+    ts = int(time.time() * 1000)
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            lead = models.Lead(
+                full_name="ADM-014 Lead",
+                phone=f"09{str(ts)[-9:]}"[-10:],
+                email=f"adm014_{ts}@test.com",
+                source="website",
+                unit_id=unit_id,
+                assigned_officer_id=assigned_officer_id,
+            )
+            s.add(lead)
+            await s.flush()
+            return lead.id
+
+
+async def _create_approved_profile(
+    lead_id: int, citizen_id: str
+) -> models.AdmissionProfile:
+    """Create an AdmissionProfile already in 'approved' status — that's
+    the only state from which override is a valid transition."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            profile = models.AdmissionProfile(
+                lead_id=lead_id,
+                status="approved",
+                citizen_id=citizen_id,
+                academic_year=2026,
+                version=1,
+                applied_rules={
+                    "min_gpa": 0,
+                    "mandatory_docs": [],
+                    "fee_status": "exempt",
+                    "requires_application_fee": False,
+                },
+            )
+            s.add(profile)
+            await s.flush()
+            profile_id = profile.id
+
+        result = await s.execute(
+            select(models.AdmissionProfile).where(
+                models.AdmissionProfile.id == profile_id
+            )
+        )
+        return result.scalar_one()
+
+
+class TestAdminOverrideAuditTrail:
+    """ADM-014: admin override must persist to entity_audit_log."""
+
+    async def test_override_writes_durable_audit_row(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        lead_id = await _create_lead(unit_id)
+        profile = await _create_approved_profile(lead_id, "888800001111")
+
+        admin_headers = await _login(client, admin_user_in_db)
+
+        before_call = datetime.now(timezone.utc)
+
+        response = await client.post(
+            f"/api/admissions/{profile.id}/override",
+            json={
+                "reason": "ADM-014 audit regression — VIP applicant override",
+                "bypass_rules": ["confirmation_required", "fee_required"],
+                "version": profile.version,
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == 200, (
+            f"Override failed: {response.status_code} - {response.text}"
+        )
+        assert response.json()["status"] == "overridden"
+
+        # Query entity_audit_log for the override row directly.
+        async with AsyncSessionLocal() as s:
+            result = await s.execute(
+                select(models.EntityAuditLog)
+                .where(
+                    models.EntityAuditLog.entity_type == "AdmissionProfile",
+                    models.EntityAuditLog.entity_id == profile.id,
+                    models.EntityAuditLog.action == "overridden",
+                )
+                .order_by(models.EntityAuditLog.created_at.desc())
+            )
+            rows = list(result.scalars().all())
+
+        assert len(rows) == 1, (
+            f"ADM-014: expected exactly 1 audit row for override, got {len(rows)}"
+        )
+        row = rows[0]
+
+        # Actor + timestamp + source
+        assert row.actor_user_id == admin_user_in_db["id"], (
+            "Audit row must record the admin who fired the override"
+        )
+        assert row.created_at >= before_call, (
+            "Audit row timestamp must be at-or-after the request start"
+        )
+        assert row.source == "api"
+        assert row.reason and "VIP applicant override" in row.reason
+
+        # Changes payload — status transition + override metadata
+        assert row.changes is not None, (
+            "Audit row must carry the structured changes JSONB"
+        )
+        changes = row.changes
+
+        assert changes.get("status", {}).get("old") == "approved"
+        assert changes.get("status", {}).get("new") == "overridden"
+
+        assert changes.get("override_reason", {}).get("old") is None
+        assert "VIP applicant override" in (
+            changes.get("override_reason", {}).get("new") or ""
+        )
+
+        assert changes.get("bypass_rules", {}).get("new") == [
+            "confirmation_required",
+            "fee_required",
+        ]
+
+        # Version was bumped
+        assert (
+            changes.get("version", {}).get("new")
+            == changes.get("version", {}).get("old") + 1
+        )
+
+        assert changes.get("overridden_by_id", {}).get("new") == admin_user_in_db["id"]
+
+    async def test_override_with_empty_bypass_rules_still_audits(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """``bypass_rules`` is optional — empty list (or missing) must
+        still produce a clean audit row. Catches a regression where the
+        helper coerces None → empty list rather than crashing."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        lead_id = await _create_lead(unit_id)
+        profile = await _create_approved_profile(lead_id, "888800002222")
+
+        admin_headers = await _login(client, admin_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile.id}/override",
+            json={
+                "reason": "ADM-014 — bypass_rules omitted, audit must still run",
+                "version": profile.version,
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == 200, (
+            f"Override failed: {response.status_code} - {response.text}"
+        )
+
+        async with AsyncSessionLocal() as s:
+            result = await s.execute(
+                select(models.EntityAuditLog).where(
+                    models.EntityAuditLog.entity_type == "AdmissionProfile",
+                    models.EntityAuditLog.entity_id == profile.id,
+                    models.EntityAuditLog.action == "overridden",
+                )
+            )
+            row = result.scalars().first()
+
+        assert row is not None
+        assert row.changes.get("bypass_rules", {}).get("new") == []

--- a/Backend_FastAPI/tests/unit/test_admission_path_admin_only_lifecycle.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_admin_only_lifecycle.py
@@ -1,0 +1,136 @@
+"""ADM-008 regression: activate/deactivate admission path is admin-only.
+
+Per Q3=a in the audit thread: Manager creates and edits draft paths but
+cannot activate or deactivate — Admin "approves = activates". The
+service-level gate is defense-in-depth; the route also guards via
+``Depends(require_admin)``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.constants import UserRole
+from app.services.admission_path_service import AdmissionPathService
+from app.utils.exceptions import PermissionDeniedError
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_service(*, method_group=object(), shared_groups=None):
+    """Service stub with a patched DocumentGroupRepository so
+    validate_activation can resolve documents without a real DB."""
+    service = AdmissionPathService.__new__(AdmissionPathService)
+    service.db = MagicMock()
+    service.repo = MagicMock()
+
+    # repo.update needs to return a path-shaped object; mirror the input
+    async def _fake_update(path, data):
+        for k, v in data.items():
+            setattr(path, k, v)
+        return path
+
+    service.repo.update = AsyncMock(side_effect=_fake_update)
+
+    doc_repo = MagicMock()
+    doc_repo.get_method_specific_group = AsyncMock(return_value=method_group)
+    doc_repo.get_shared_groups = AsyncMock(return_value=shared_groups or [])
+    return service, doc_repo
+
+
+def _patch_doc_repo(doc_repo):
+    return patch(
+        "app.repositories.document_group_repository.DocumentGroupRepository",
+        return_value=doc_repo,
+    )
+
+
+def _ready_path(status: str = "draft"):
+    """Build a fully-ready AdmissionPath stand-in so readiness validation
+    inside ``activate_path`` won't trip — we want the role check to be
+    the failure surface, not the readiness gate."""
+    offering = SimpleNamespace(offering_type_id=1)
+    academic_info = SimpleNamespace(
+        annual_admission_quota=100,
+        offering=offering,
+    )
+    return SimpleNamespace(
+        id=42,
+        status=status,
+        academic_info=academic_info,
+        criteria_id=7,
+        admission_method_id=1,
+    )
+
+
+def _user(role: UserRole):
+    return SimpleNamespace(id=1, role=role)
+
+
+class TestActivatePathAdminOnly:
+    async def test_manager_cannot_activate(self):
+        service, doc_repo = _make_service()
+        with _patch_doc_repo(doc_repo):
+            with pytest.raises(PermissionDeniedError, match="admin"):
+                await service.activate_path(
+                    _ready_path("draft"), _user(UserRole.MANAGER)
+                )
+
+    @pytest.mark.parametrize(
+        "role",
+        [UserRole.OFFICER, UserRole.ACCOUNTANT, UserRole.USER],
+    )
+    async def test_non_admin_cannot_activate(self, role):
+        service, doc_repo = _make_service()
+        with _patch_doc_repo(doc_repo):
+            with pytest.raises(PermissionDeniedError, match="admin"):
+                await service.activate_path(_ready_path("draft"), _user(role))
+
+    async def test_admin_can_activate_ready_path(self):
+        service, doc_repo = _make_service()
+        path = _ready_path("draft")
+        with _patch_doc_repo(doc_repo):
+            updated, _cb = await service.activate_path(
+                path, _user(UserRole.ADMIN)
+            )
+        assert updated.status == "active"
+        assert updated.activated_by == 1
+
+
+class TestDeactivatePathAdminOnly:
+    async def test_manager_cannot_deactivate(self):
+        service, _doc_repo = _make_service()
+        with pytest.raises(PermissionDeniedError, match="admin"):
+            await service.deactivate_path(
+                _ready_path("active"), _user(UserRole.MANAGER)
+            )
+
+    @pytest.mark.parametrize(
+        "role",
+        [UserRole.OFFICER, UserRole.ACCOUNTANT, UserRole.USER],
+    )
+    async def test_non_admin_cannot_deactivate(self, role):
+        service, _doc_repo = _make_service()
+        with pytest.raises(PermissionDeniedError, match="admin"):
+            await service.deactivate_path(_ready_path("active"), _user(role))
+
+    async def test_admin_can_deactivate_active_path(self):
+        service, _doc_repo = _make_service()
+        path = _ready_path("active")
+        updated, _cb = await service.deactivate_path(
+            path, _user(UserRole.ADMIN)
+        )
+        assert updated.status == "inactive"
+
+    async def test_role_check_runs_before_status_check(self):
+        """Manager hitting deactivate on a non-active path must still
+        get PermissionDeniedError — the role gate is the first thing
+        evaluated, otherwise we'd leak that the path is in a wrong
+        state to a caller who shouldn't have reached the route."""
+        service, _doc_repo = _make_service()
+        with pytest.raises(PermissionDeniedError, match="admin"):
+            await service.deactivate_path(
+                _ready_path("draft"), _user(UserRole.MANAGER)
+            )


### PR DESCRIPTION
## Summary

Wave 2 of the admission audit (`Documents/ADMISSION_MODULE_AUDIT_2026-04-27.md`). Three deferred code-only findings that didn't make Wave 1 because they needed the chat-thread Q&A decisions (Q3=a for ADM-008) or were intentionally separated from the security/contract pack.

## Findings fixed

| ID | Severity | Fix |
|---|---|---|
| **ADM-008** | P2 RBAC | Admin-only activate/deactivate admission path (per Q3=a). Manager creates/edits draft; Admin "approves = activates". Route uses `Depends(require_admin)` + service raises `PermissionDeniedError` for defense-in-depth. |
| **ADM-009** | P2 Security | `Depends(get_config_filter)` applied to all four `/admission-config/*/{code}` detail endpoints (subject, subject-group, method, shared document-group). Non-admin callers can't read inactive/draft config rows by knowing the code — parity with the list-scope filter. |
| **ADM-014** | P2 Audit | Override now writes a durable row to `entity_audit_log` via `audit_service.log_changes` with structured `changes` JSONB (status / version / override_reason / bypass_rules / overridden_by_id). `log.warning` kept for live SIEM, additive. |

## No migration

PR2 ships zero migrations. `entity_audit_log` table already exists from prior work; ADM-014 only wires the call. Alembic head unchanged.

## Targeted verification: 21/21 passed

Local backend tests against this branch on a clean worktree:

- `tests/unit/test_admission_path_admin_only_lifecycle.py` — **11/11 PASS** (admin allowed, manager rejected, parametrized non-admin rejection officer/accountant/user, role check fires before status check)
- `tests/api/test_admission_config_detail_filter.py` — **8/8 PASS** (officer cannot read inactive subject/subject-group/method/shared-doc by code; admin with `?active_only=false` overrides on the first three)
- `tests/integration/test_admission_override_audit.py` — **2/2 PASS** (override writes exactly one EntityAuditLog row with the expected `changes` JSONB; omitting `bypass_rules` still produces a clean audit row with `[]`)

Adjacent regression check (PR1 path tests + override flow in `test_admission_state_transitions.py`): **21/21 PASS**, zero new regression.

## Out-of-scope notes

### Shared document-group admin override limitation (existing repo behavior)

`DocumentGroupRepository.get_shared_groups` hardcodes `is_active == True` at the SQL layer:

```python
.where(
    DocumentGroup.offering_type_id == offering_type_id,
    DocumentGroup.admission_method_id.is_(None),
    DocumentGroup.is_active == True,
)
```

Even when the route now passes `active_only=False`, the repo never returns an inactive row. PR2 only adds the **route-level** filter for parity / defense-in-depth with the other three detail endpoints. Widening the repo signature so admin override actually returns inactive shared groups is a separate hardening item (not blocking PR2). The behavior is pinned by `test_admin_with_override_currently_still_filtered_by_repo` so future regressions stay caught.

### Sporadic dirty-state test DB failure (pre-existing, not introduced by PR2)

When running the full integration sweep back-to-back, `test_admission_state_transitions.py::TestClaimUnclaimWorkflow::test_admin_can_unclaim_anyone` can fail with:

```
asyncpg.exceptions.UniqueViolationError: duplicate key value violates unique constraint "ix_user_username"
DETAIL: Key (username)=(testadmin) already exists.
```

This is the known `qlts_test` dirty-state issue (test fixtures inserting `testadmin` across tests without a clean truncation between sessions in some run orders). The same test passes when run in isolation. Documented in the team's test-DB-schema reference; **not introduced by PR2 changes**.

## Test plan

- [x] Targeted backend tests: 21/21 passed
- [x] Adjacent PR1 path / override regression: 21/21 passed (1 sporadic failure verified pre-existing in isolation)
- [x] Static signature checks: 4 detail endpoints all wire `get_config_filter`; 2 lifecycle routes both wire `require_admin`
- [x] Audit-trail leak check: ADM-014 diff has zero `str(e)` / traceback / exc_info / secret / token references
- [x] Worktree clean before push (only intentional untracked files left out — `Documents/ADMISSION_MODULE_AUDIT_2026-04-27.md` and `scripts/plan-loop.ps1`)
- [ ] Reviewer: pull and run `pytest tests/unit/test_admission_path_admin_only_lifecycle.py tests/api/test_admission_config_detail_filter.py tests/integration/test_admission_override_audit.py`
- [ ] Reviewer: confirm three commits are individually revertable (1 commit per finding, no file overlap)
- [ ] Post-merge: try POST `/admission-config/admission-paths/{id}/activate` as a manager via prod UI — expect 403; same as admin — expect 200 (assuming readiness rules are met)
- [ ] Post-merge: query `SELECT * FROM entity_audit_log WHERE entity_type='AdmissionProfile' AND action='overridden' ORDER BY created_at DESC LIMIT 5` after the next override action

🤖 Generated with [Claude Code](https://claude.com/claude-code)