### PR TITLE
fix(admissions): ADM-021 role-aware path action flags

### DIFF
--- a/Backend_FastAPI/app/routers/admission_paths.py
+++ b/Backend_FastAPI/app/routers/admission_paths.py
@@ -50,28 +50,31 @@ router = APIRouter(prefix="/admission-config", tags=["Admission Configuration"])
 # HELPER FUNCTIONS
 # =============================================================================
 
+
 def build_criteria_nested(path) -> AdmissionCriteriaNested | None:
     """
     Build AdmissionCriteriaNested from ORM model.
-    
+
     Extracts subject_groups from the relation chain:
     AdmissionPath.criteria.subject_group_mappings[].subject_group
     """
     if not path.criteria:
         return None
-    
+
     criteria = path.criteria
     subject_groups = []
-    
-    if hasattr(criteria, 'subject_group_mappings') and criteria.subject_group_mappings:
+
+    if hasattr(criteria, "subject_group_mappings") and criteria.subject_group_mappings:
         for mapping in criteria.subject_group_mappings:
             if mapping.subject_group:
-                subject_groups.append(SubjectGroupNested(
-                    id=mapping.subject_group.id,
-                    code=mapping.subject_group.code,
-                    name=mapping.subject_group.name,
-                ))
-    
+                subject_groups.append(
+                    SubjectGroupNested(
+                        id=mapping.subject_group.id,
+                        code=mapping.subject_group.code,
+                        name=mapping.subject_group.name,
+                    )
+                )
+
     return AdmissionCriteriaNested(
         id=criteria.id,
         code=criteria.code,
@@ -88,9 +91,33 @@ def build_criteria_nested(path) -> AdmissionCriteriaNested | None:
     )
 
 
+async def build_path_response(
+    path: models.AdmissionPath,
+    service: AdmissionPathService,
+    current_user: models.User,
+    *,
+    include_validation_errors: bool = False,
+) -> AdmissionPathResponse:
+    """Build AdmissionPathResponse with role-aware control fields.
+
+    ADM-021: the FE reads ``available_actions`` / ``can_*`` directly, so
+    these fields must mirror route/service authorization gates.
+    """
+    response = AdmissionPathResponse.model_validate(path)
+    response.criteria = build_criteria_nested(path)
+    response.available_actions = service.compute_available_actions(path, current_user)
+    response.can_edit = service.compute_can_edit(path, current_user)
+    response.can_activate = await service.compute_can_activate(path, current_user)
+    if include_validation_errors:
+        _, errors = await service.validate_activation(path)
+        response.validation_errors = errors
+    return response
+
+
 # =============================================================================
 # IDOR DEPENDENCY (inline for now, can move to deps.py later)
 # =============================================================================
+
 
 async def get_admission_path_for_user(
     path_id: int = PathParam(..., description="Admission Path ID"),
@@ -99,21 +126,21 @@ async def get_admission_path_for_user(
 ) -> models.AdmissionPath:
     """
     IDOR protection for AdmissionPath.
-    
+
     Security:
     - Admin/Manager: Full access
     - Returns 404 for unauthorized (not 403) per AUTHORIZATION_GUIDELINES
     """
     repo = AdmissionPathRepository(db)
     path = await repo.get_by_id_with_relations(path_id)
-    
+
     if not path:
         raise ResourceNotFoundError(f"Admission path {path_id} not found")
-    
+
     # Admin/Manager have full access (for config console)
     if current_user.role in [UserRole.ADMIN, UserRole.MANAGER]:
         return path
-    
+
     # For other roles, return 404 (IDOR protection)
     raise ResourceNotFoundError(f"Admission path {path_id} not found")
 
@@ -122,10 +149,9 @@ async def get_admission_path_for_user(
 # ACADEMIC YEAR ENDPOINTS
 # =============================================================================
 
+
 @router.get(
-    "/years",
-    response_model=AcademicYearListResponse,
-    summary="Get all academic years"
+    "/years", response_model=AcademicYearListResponse, summary="Get all academic years"
 )
 async def get_academic_years(
     db: AsyncSession = Depends(database.get_db),
@@ -133,7 +159,7 @@ async def get_academic_years(
 ):
     """
     Get all distinct academic years from the system.
-    
+
     Returns:
         List of years sorted DESC, plus current year
     """
@@ -141,18 +167,15 @@ async def get_academic_years(
     years, callback = await service.get_distinct_years()
     await db.commit()
     await callback()
-    
+
     current_year = datetime.now().year
-    return AcademicYearListResponse(
-        years=years,
-        current_year=current_year
-    )
+    return AcademicYearListResponse(years=years, current_year=current_year)
 
 
 @router.get(
     "/coverage-matrix",
     response_model=CoverageMatrixResponse,
-    summary="Get coverage matrix for paths"
+    summary="Get coverage matrix for paths",
 )
 async def get_coverage_matrix(
     academic_info_id: int = Query(..., description="Academic Info ID"),
@@ -161,9 +184,9 @@ async def get_coverage_matrix(
 ):
     """
     Get coverage matrix showing readiness status of all paths.
-    
+
     Used by Config Console to audit path configuration before activation.
-    
+
     Returns:
         Matrix with has_criteria, has_documents, has_quota, can_activate per path.
     """
@@ -171,7 +194,7 @@ async def get_coverage_matrix(
     result, callback = await service.get_coverage_matrix(academic_info_id)
     await db.commit()
     await callback()
-    
+
     return result
 
 
@@ -179,10 +202,11 @@ async def get_coverage_matrix(
 # ADMISSION PATH CRUD ENDPOINTS
 # =============================================================================
 
+
 @router.get(
     "/paths/for-offering/{offering_id}",
     response_model=AdmissionPathListResponse,
-    summary="Get active paths for an offering (public)"
+    summary="Get active paths for an offering (public)",
 )
 async def get_paths_for_offering(
     offering_id: int = PathParam(..., description="Program Offering ID"),
@@ -191,28 +215,26 @@ async def get_paths_for_offering(
 ):
     """
     Get all ACTIVE admission paths for a ProgramOffering.
-    
+
     Used by LeadApplicationForm to populate "Phương thức xét tuyển" dropdown.
     Returns paths with nested admission_method and criteria.
-    
+
     Security: Requires authenticated user (Officer+)
     """
     repo = AdmissionPathRepository(db)
     paths = await repo.get_active_paths_by_offering_id(offering_id)
-    
+
     # Build response with nested criteria (GAP-D fix for LeadApplicationForm)
+    service = AdmissionPathService(db)
     items = []
     for path in paths:
-        response = AdmissionPathResponse.model_validate(path)
-        response.criteria = build_criteria_nested(path)
-        items.append(response)
-    
+        items.append(await build_path_response(path, service, current_user))
+
     return AdmissionPathListResponse(total=len(items), items=items)
 
+
 @router.get(
-    "/paths",
-    response_model=AdmissionPathListResponse,
-    summary="List admission paths"
+    "/paths", response_model=AdmissionPathListResponse, summary="List admission paths"
 )
 async def list_admission_paths(
     academic_info_id: int = Query(..., description="Filter by academic info ID"),
@@ -222,24 +244,19 @@ async def list_admission_paths(
 ):
     """
     List all admission paths for a specific academic info (offering + year).
-    
+
     Requires: Admin or Manager role (via Casbin)
     """
     service = AdmissionPathService(db)
     paths, callback = await service.list_paths_by_academic_info(academic_info_id)
     await db.commit()
     await callback()
-    
+
     # Compute control fields for each path
     items = []
     for path in paths:
-        response = AdmissionPathResponse.model_validate(path)
-        response.criteria = build_criteria_nested(path)  # GAP-D fix
-        response.available_actions = service.compute_available_actions(path)
-        response.can_edit = service.compute_can_edit(path)
-        response.can_activate = await service.compute_can_activate(path)
-        items.append(response)
-    
+        items.append(await build_path_response(path, service, current_user))
+
     return AdmissionPathListResponse(total=len(items), items=items)
 
 
@@ -247,7 +264,7 @@ async def list_admission_paths(
     "/paths",
     response_model=AdmissionPathResponse,
     status_code=201,
-    summary="Create admission path"
+    summary="Create admission path",
 )
 async def create_admission_path(
     data: AdmissionPathCreate,
@@ -267,23 +284,18 @@ async def create_admission_path(
     # Reload with relationships
     path = await AdmissionPathRepository(db).get_by_id_with_relations(path.id)
 
-    response = AdmissionPathResponse.model_validate(path)
-    response.criteria = build_criteria_nested(path)  # Include criteria (will be None for new paths)
-    response.available_actions = service.compute_available_actions(path)
-    response.can_edit = service.compute_can_edit(path)
-    response.can_activate = await service.compute_can_activate(path)
-
-    return response
+    return await build_path_response(path, service, current_user)
 
 
 @router.get(
     "/paths/{path_id}",
     response_model=AdmissionPathResponse,
-    summary="Get admission path by ID"
+    summary="Get admission path by ID",
 )
 async def get_admission_path(
     path: models.AdmissionPath = Depends(get_admission_path_for_user),
     db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(get_current_active_user),
 ):
     """
     Get a single admission path by ID.
@@ -292,21 +304,18 @@ async def get_admission_path(
     """
     service = AdmissionPathService(db)
 
-    response = AdmissionPathResponse.model_validate(path)
-    response.criteria = build_criteria_nested(path)  # Include criteria with subject groups
-    response.available_actions = service.compute_available_actions(path)
-    response.can_edit = service.compute_can_edit(path)
-    response.can_activate = await service.compute_can_activate(path)
-    can_activate, errors = await service.validate_activation(path)
-    response.validation_errors = errors
-
-    return response
+    return await build_path_response(
+        path,
+        service,
+        current_user,
+        include_validation_errors=True,
+    )
 
 
 @router.put(
     "/paths/{path_id}",
     response_model=AdmissionPathResponse,
-    summary="Update admission path"
+    summary="Update admission path",
 )
 async def update_admission_path(
     data: AdmissionPathUpdate,
@@ -327,19 +336,13 @@ async def update_admission_path(
     # Reload
     path = await AdmissionPathRepository(db).get_by_id_with_relations(path.id)
 
-    response = AdmissionPathResponse.model_validate(path)
-    response.criteria = build_criteria_nested(path)  # Include criteria with subject groups
-    response.available_actions = service.compute_available_actions(path)
-    response.can_edit = service.compute_can_edit(path)
-    response.can_activate = await service.compute_can_activate(path)
-
-    return response
+    return await build_path_response(path, service, current_user)
 
 
 @router.put(
     "/paths/{path_id}/criteria",
     response_model=AdmissionPathResponse,
-    summary="Update admission criteria"
+    summary="Update admission criteria",
 )
 async def update_admission_criteria(
     data: AdmissionCriteriaCreate,
@@ -351,6 +354,7 @@ async def update_admission_criteria(
     Update Admission Criteria (GPA, Scores, Subject Groups).
     """
     import structlog
+
     logger = structlog.get_logger()
     logger.info("Updating criteria", path_id=path.id, data=data.model_dump())
 
@@ -358,23 +362,17 @@ async def update_admission_criteria(
     path, callback = await service.upsert_criteria(path, data, current_user)
     await db.commit()
     await callback()
-    
+
     # Reload
     path = await AdmissionPathRepository(db).get_by_id_with_relations(path.id)
-    
-    response = AdmissionPathResponse.model_validate(path)
-    response.criteria = build_criteria_nested(path)
-    response.available_actions = service.compute_available_actions(path)
-    response.can_edit = service.compute_can_edit(path)
-    response.can_activate = await service.compute_can_activate(path)
-    
-    return response
+
+    return await build_path_response(path, service, current_user)
 
 
 @router.put(
     "/paths/{path_id}/documents",
     response_model=ResolvedDocumentListResponse,
-    summary="Update document requirements"
+    summary="Update document requirements",
 )
 async def update_admission_documents(
     documents: List[AdmissionPathDocumentUpsert],
@@ -384,22 +382,24 @@ async def update_admission_documents(
 ):
     """
     Update Document Requirements (Checklist).
-    
+
     Overrides default document group for this Method + Offering Type.
     """
     service = AdmissionPathService(db)
-    resolved_docs, callback = await service.upsert_documents(path, documents, current_user)
+    resolved_docs, callback = await service.upsert_documents(
+        path, documents, current_user
+    )
     await db.commit()
     await callback()
-    
+
     # Need offering_type_id for response
     offering_type_id = path.academic_info.offering.offering_type_id
-    
+
     return ResolvedDocumentListResponse(
         path_id=path.id,
         offering_type_id=offering_type_id,
         admission_method_id=path.admission_method_id,
-        documents=resolved_docs
+        documents=resolved_docs,
     )
 
 
@@ -407,10 +407,11 @@ async def update_admission_documents(
 # ACTIVATION ENDPOINTS
 # =============================================================================
 
+
 @router.post(
     "/paths/{path_id}/activate",
     response_model=AdmissionPathResponse,
-    summary="Activate admission path (admin-only)"
+    summary="Activate admission path (admin-only)",
 )
 async def activate_admission_path(
     path: models.AdmissionPath = Depends(get_admission_path_for_user),
@@ -440,19 +441,13 @@ async def activate_admission_path(
     # Reload
     path = await AdmissionPathRepository(db).get_by_id_with_relations(path.id)
 
-    response = AdmissionPathResponse.model_validate(path)
-    response.criteria = build_criteria_nested(path)  # Include criteria with subject groups
-    response.available_actions = service.compute_available_actions(path)
-    response.can_edit = service.compute_can_edit(path)
-    response.can_activate = False  # Already activated
-
-    return response
+    return await build_path_response(path, service, current_user)
 
 
 @router.post(
     "/paths/{path_id}/deactivate",
     response_model=AdmissionPathResponse,
-    summary="Deactivate admission path (admin-only)"
+    summary="Deactivate admission path (admin-only)",
 )
 async def deactivate_admission_path(
     path: models.AdmissionPath = Depends(get_admission_path_for_user),
@@ -475,23 +470,18 @@ async def deactivate_admission_path(
     # Reload
     path = await AdmissionPathRepository(db).get_by_id_with_relations(path.id)
 
-    response = AdmissionPathResponse.model_validate(path)
-    response.criteria = build_criteria_nested(path)  # Include criteria with subject groups
-    response.available_actions = service.compute_available_actions(path)
-    response.can_edit = service.compute_can_edit(path)
-    response.can_activate = await service.compute_can_activate(path)
-
-    return response
+    return await build_path_response(path, service, current_user)
 
 
 # =============================================================================
 # DOCUMENT RESOLUTION ENDPOINTS
 # =============================================================================
 
+
 @router.get(
     "/paths/{path_id}/documents",
     response_model=ResolvedDocumentListResponse,
-    summary="Get resolved documents for path"
+    summary="Get resolved documents for path",
 )
 async def get_resolved_documents(
     path: models.AdmissionPath = Depends(get_admission_path_for_user),
@@ -510,7 +500,9 @@ async def get_resolved_documents(
     offering_type_id = path.academic_info.offering.offering_type_id
 
     service = AdmissionPathService(db)
-    documents, callback = await service.resolve_documents_for_path(path, offering_type_id)
+    documents, callback = await service.resolve_documents_for_path(
+        path, offering_type_id
+    )
     await db.commit()
     await callback()
 
@@ -518,30 +510,36 @@ async def get_resolved_documents(
         path_id=path.id,
         offering_type_id=offering_type_id,
         admission_method_id=path.admission_method_id,
-        documents=documents
+        documents=documents,
     )
 
 
 @router.get(
     "/paths/{path_id}/validate-activation",
     response_model=ActivationValidationResponse,
-    summary="Validate if path can be activated"
+    summary="Validate if path can be activated",
 )
 async def validate_path_activation(
     path: models.AdmissionPath = Depends(get_admission_path_for_user),
     db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(get_current_active_user),
 ):
     """
     Check if a path can be activated.
-    
+
     Returns:
         can_activate: bool
         validation_errors: List of reasons if blocked
     """
     service = AdmissionPathService(db)
     can_activate, errors = await service.validate_activation(path)
-    
+    if current_user.role != UserRole.ADMIN:
+        can_activate = False
+        errors = [
+            "Chỉ admin được activate admission path.",
+            *errors,
+        ]
+
     return ActivationValidationResponse(
-        can_activate=can_activate,
-        validation_errors=errors
+        can_activate=can_activate, validation_errors=errors
     )

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -77,123 +77,114 @@ def _check_lifecycle_guard(path: AdmissionPath, user: User) -> None:
 class AdmissionPathService:
     """
     Service for AdmissionPath business logic.
-    
+
     MASTER_ARCHITECTURE.md Rules:
     - No HTTPException
     - Returns (result, callback)
     - Domain exceptions only
     """
-    
+
     def __init__(self, db: AsyncSession):
         self.db = db
         self.repo = AdmissionPathRepository(db)
-    
+
     # =========================================================================
     # QUERY OPERATIONS
     # =========================================================================
-    
+
     async def get_path_by_id(
-        self,
-        path_id: int
+        self, path_id: int
     ) -> Tuple[AdmissionPath, PostCommitCallback]:
         """
         Get a single path by ID with relationships.
-        
+
         Raises:
             ResourceNotFoundError: If path not found
         """
         path = await self.repo.get_by_id_with_relations(path_id)
         if not path:
             raise ResourceNotFoundError(f"AdmissionPath {path_id} not found")
-        
+
         return path, _noop_callback
-    
+
     async def list_paths_by_academic_info(
-        self,
-        academic_info_id: int
+        self, academic_info_id: int
     ) -> Tuple[List[AdmissionPath], PostCommitCallback]:
         """
         List all paths for an academic info (offering + year).
         """
         paths = await self.repo.get_paths_by_academic_info(academic_info_id)
         return paths, _noop_callback
-    
+
     async def get_distinct_years(self) -> Tuple[List[int], PostCommitCallback]:
         """
         Get all distinct academic years.
         """
         years = await self.repo.get_distinct_years()
         return years, _noop_callback
-    
+
     # =========================================================================
     # MUTATION OPERATIONS
     # =========================================================================
-    
+
     async def create_path(
-        self,
-        data: AdmissionPathCreate,
-        user: User
+        self, data: AdmissionPathCreate, user: User
     ) -> Tuple[AdmissionPath, PostCommitCallback]:
         """
         Create a new AdmissionPath.
-        
+
         Raises:
             DuplicateResourceError: If path already exists for offering + method
         """
         # Check for duplicate
         existing = await self.repo.get_path_by_offering_and_method(
-            data.academic_info_id,
-            data.admission_method_id
+            data.academic_info_id, data.admission_method_id
         )
         if existing:
             raise DuplicateResourceError(
                 f"AdmissionPath already exists for academic_info={data.academic_info_id}, "
                 f"method={data.admission_method_id}"
             )
-        
+
         # Governance guard: minor_correction_allowed_fields is admin-only,
         # same rule as on update. Manager creating a draft path always
         # gets an empty allowlist regardless of what they submit. FE
         # already disables the section for non-admins; this is the
         # belt-and-braces server side.
-        if (
-            data.minor_correction_allowed_fields
-            and user.role != UserRole.ADMIN
-        ):
+        if data.minor_correction_allowed_fields and user.role != UserRole.ADMIN:
             raise BusinessRuleViolation(
                 "Chỉ admin được set allowlist minor_correction khi tạo path. "
                 "Manager liên hệ admin nếu cần thay đổi."
             )
 
         # Create path
-        path = await self.repo.create({
-            "academic_info_id": data.academic_info_id,
-            "admission_method_id": data.admission_method_id,
-            "display_name": data.display_name,
-            "display_order": data.display_order,
-            "visibility": data.visibility,
-            "status": "draft",  # Always start as draft
-            # PR #6 — strict-by-default; admin may flip to True on create.
-            "allow_unverified_submission": data.allow_unverified_submission,
-            # Per-path correction allowlist — empty by default, admin may
-            # seed a list at create time. Schema validator already
-            # filtered out non-SAFE entries before reaching here.
-            "minor_correction_allowed_fields": list(
-                data.minor_correction_allowed_fields or []
-            ),
-        })
-        
+        path = await self.repo.create(
+            {
+                "academic_info_id": data.academic_info_id,
+                "admission_method_id": data.admission_method_id,
+                "display_name": data.display_name,
+                "display_order": data.display_order,
+                "visibility": data.visibility,
+                "status": "draft",  # Always start as draft
+                # PR #6 — strict-by-default; admin may flip to True on create.
+                "allow_unverified_submission": data.allow_unverified_submission,
+                # Per-path correction allowlist — empty by default, admin may
+                # seed a list at create time. Schema validator already
+                # filtered out non-SAFE entries before reaching here.
+                "minor_correction_allowed_fields": list(
+                    data.minor_correction_allowed_fields or []
+                ),
+            }
+        )
+
         return path, _noop_callback
-    
+
     async def update_path(
-        self,
-        path: AdmissionPath,
-        data: AdmissionPathUpdate,
-        user: User
+        self, path: AdmissionPath, data: AdmissionPathUpdate, user: User
     ) -> Tuple[AdmissionPath, PostCommitCallback]:
         """
         Update an existing AdmissionPath.
-        
+
         Business Rules:
         - Archived paths cannot be updated
         - Manager can ONLY update paths in 'draft' status
@@ -228,12 +219,9 @@ class AdmissionPathService:
         path = await self.repo.update(path, update_data)
 
         return path, _noop_callback
-    
+
     async def upsert_criteria(
-        self,
-        path: AdmissionPath,
-        data: AdmissionCriteriaCreate,
-        user: User
+        self, path: AdmissionPath, data: AdmissionCriteriaCreate, user: User
     ) -> Tuple[AdmissionPath, PostCommitCallback]:
         """
         Create or update admission criteria for a path.
@@ -258,28 +246,30 @@ class AdmissionPathService:
                 method_id=path.admission_method_id,
                 code=code,
                 name=f"Criteria for Path {path.id}",
-                **data.model_dump(exclude={"subject_groups"})
+                **data.model_dump(exclude={"subject_groups"}),
             )
             self.db.add(criteria)
-            await self.db.flush() # Get ID
-            
+            await self.db.flush()  # Get ID
+
             path.criteria_id = criteria.id
             self.db.add(path)
-        
+
         # 2. Update Subject Groups
         # Clear existing
         from sqlalchemy import delete
+
         await self.db.execute(
-            delete(CriteriaSubjectGroup).where(CriteriaSubjectGroup.criteria_id == criteria.id)
+            delete(CriteriaSubjectGroup).where(
+                CriteriaSubjectGroup.criteria_id == criteria.id
+            )
         )
-        
+
         # Add new
         for group_id in data.subject_groups:
-            self.db.add(CriteriaSubjectGroup(
-                criteria_id=criteria.id,
-                subject_group_id=group_id
-            ))
-            
+            self.db.add(
+                CriteriaSubjectGroup(criteria_id=criteria.id, subject_group_id=group_id)
+            )
+
         await self.db.flush()
         return path, _noop_callback
 
@@ -287,7 +277,7 @@ class AdmissionPathService:
         self,
         path: AdmissionPath,
         documents: List[AdmissionPathDocumentUpsert],
-        user: User
+        user: User,
     ) -> Tuple[List[ResolvedDocumentResponse], PostCommitCallback]:
         """
         Update document requirements for a path.
@@ -305,41 +295,45 @@ class AdmissionPathService:
 
         if not path.academic_info or not path.academic_info.offering:
             # Force load if missing (though repo loads it)
-             path = await self.repo.get_by_id_with_relations(path.id)
-             
+            path = await self.repo.get_by_id_with_relations(path.id)
+
         offering_type_id = path.academic_info.offering.offering_type_id
         method_id = path.admission_method_id
-        
+
         # 1. Find Method-Specific Group
         # TODO: Move query to repo if complex
         from sqlalchemy import select
+
         stmt = select(DocumentGroup).where(
             DocumentGroup.offering_type_id == offering_type_id,
-            DocumentGroup.admission_method_id == method_id
+            DocumentGroup.admission_method_id == method_id,
         )
         result = await self.db.execute(stmt)
         group = result.scalars().first()
-        
+
         if not group:
             # Create new group override
-            code = f"DOC_{offering_type_id}_{method_id}_{datetime.now().strftime('%M%S')}"
+            code = (
+                f"DOC_{offering_type_id}_{method_id}_{datetime.now().strftime('%M%S')}"
+            )
             group = DocumentGroup(
                 offering_type_id=offering_type_id,
                 admission_method_id=method_id,
                 code=code,
                 name=f"Docs for Method {method_id} (Override)",
-                is_active=True
+                is_active=True,
             )
             self.db.add(group)
             await self.db.flush()
-            
+
         # 2. Sync Items
         # Clear existing
         from sqlalchemy import delete
+
         await self.db.execute(
             delete(DocumentGroupItem).where(DocumentGroupItem.group_id == group.id)
         )
-        
+
         # Add new
         for doc in documents:
             # Default submission_format if requires_upload is True (constraint fix)
@@ -347,28 +341,27 @@ class AdmissionPathService:
             if doc.requires_upload and not sub_fmt:
                 sub_fmt = "photo"
 
-            self.db.add(DocumentGroupItem(
-                group_id=group.id,
-                document_type_id=doc.document_type_id,
-                is_mandatory=doc.is_mandatory,
-                requires_upload=doc.requires_upload,
-                submission_format=sub_fmt,
-                display_order=doc.display_order
-            ))
-            
+            self.db.add(
+                DocumentGroupItem(
+                    group_id=group.id,
+                    document_type_id=doc.document_type_id,
+                    is_mandatory=doc.is_mandatory,
+                    requires_upload=doc.requires_upload,
+                    submission_format=sub_fmt,
+                    display_order=doc.display_order,
+                )
+            )
+
         await self.db.flush()
-        
+
         # Return resolved list
         return await self.resolve_documents_for_path(path, offering_type_id)
-    
+
     # =========================================================================
     # ACTIVATION LOGIC
     # =========================================================================
-    
-    async def validate_activation(
-        self,
-        path: AdmissionPath
-    ) -> Tuple[bool, List[str]]:
+
+    async def validate_activation(self, path: AdmissionPath) -> Tuple[bool, List[str]]:
         """
         Validate if path can be activated.
 
@@ -428,11 +421,9 @@ class AdmissionPathService:
 
         can_activate = len(errors) == 0
         return can_activate, errors
-    
+
     async def activate_path(
-        self,
-        path: AdmissionPath,
-        user: User
+        self, path: AdmissionPath, user: User
     ) -> Tuple[AdmissionPath, PostCommitCallback]:
         """
         Activate an AdmissionPath.
@@ -455,23 +446,22 @@ class AdmissionPathService:
         can_activate, errors = await self.validate_activation(path)
 
         if not can_activate:
-            raise BusinessRuleViolation(
-                f"Cannot activate path: {'; '.join(errors)}"
-            )
+            raise BusinessRuleViolation(f"Cannot activate path: {'; '.join(errors)}")
 
         # Activate
-        path = await self.repo.update(path, {
-            "status": "active",
-            "activated_at": datetime.now(timezone.utc),
-            "activated_by": user.id,
-        })
+        path = await self.repo.update(
+            path,
+            {
+                "status": "active",
+                "activated_at": datetime.now(timezone.utc),
+                "activated_by": user.id,
+            },
+        )
 
         return path, _noop_callback
 
     async def deactivate_path(
-        self,
-        path: AdmissionPath,
-        user: User
+        self, path: AdmissionPath, user: User
     ) -> Tuple[AdmissionPath, PostCommitCallback]:
         """
         Deactivate an active AdmissionPath.
@@ -483,71 +473,68 @@ class AdmissionPathService:
             BusinessRuleViolation: If path is not active
         """
         if user.role != UserRole.ADMIN:
-            raise PermissionDeniedError(
-                "Chỉ admin được deactivate admission path."
-            )
+            raise PermissionDeniedError("Chỉ admin được deactivate admission path.")
 
         if path.status != "active":
             raise BusinessRuleViolation(
                 f"Cannot deactivate path with status '{path.status}'"
             )
 
-        path = await self.repo.update(path, {
-            "status": "inactive",
-        })
+        path = await self.repo.update(
+            path,
+            {
+                "status": "inactive",
+            },
+        )
 
         return path, _noop_callback
-    
+
     async def archive_path(
-        self,
-        path: AdmissionPath,
-        user: User
+        self, path: AdmissionPath, user: User
     ) -> Tuple[AdmissionPath, PostCommitCallback]:
         """
         Archive an AdmissionPath.
-        
+
         Raises:
             BusinessRuleViolation: If path is active
         """
         if path.status == "active":
-            raise BusinessRuleViolation(
-                "Cannot archive active path. Deactivate first."
-            )
-        
-        path = await self.repo.update(path, {
-            "status": "archived",
-        })
-        
+            raise BusinessRuleViolation("Cannot archive active path. Deactivate first.")
+
+        path = await self.repo.update(
+            path,
+            {
+                "status": "archived",
+            },
+        )
+
         return path, _noop_callback
-    
+
     # =========================================================================
     # DOCUMENT OVERRIDE RESOLUTION
     # =========================================================================
-    
+
     async def resolve_documents_for_path(
-        self,
-        path: AdmissionPath,
-        offering_type_id: int
+        self, path: AdmissionPath, offering_type_id: int
     ) -> Tuple[List[ResolvedDocumentResponse], PostCommitCallback]:
         """
         Resolve document requirements for a path.
-        
+
         Override Resolution Rule:
         1. Load shared groups (admission_method_id = NULL)
         2. Load method-specific groups (admission_method_id = path.method)
         3. Merge: method-specific OVERRIDES shared for same document_type
-        
+
         Returns:
             List of resolved documents with source indicator
         """
         shared_groups, method_groups = await self.repo.get_document_groups_for_path(
-            offering_type_id,
-            path.admission_method_id
+            offering_type_id, path.admission_method_id
         )
-        
+
         # Build document map: document_type_id -> (item, source)
         doc_map: dict = {}
-        
+
         if method_groups:
             # Case 1: Method-specific config exists -> FULL OVERRIDE
             # We ignore shared groups completely to allow "deleting" default items
@@ -567,59 +554,93 @@ class AdmissionPathService:
                         doc_map[item.document_type_id] = (item, "shared")
                     elif item.is_mandatory and not existing[0].is_mandatory:
                         doc_map[item.document_type_id] = (item, "shared")
-        
+
         # Step 3: Build response
         resolved: List[ResolvedDocumentResponse] = []
         for doc_type_id, (item, source) in doc_map.items():
-            resolved.append(ResolvedDocumentResponse(
-                document_type_id=item.document_type_id,
-                document_type_code=item.document_type.code if item.document_type else "",
-                document_type_name=item.document_type.name if item.document_type else "",
-                is_mandatory=item.is_mandatory,
-                requires_upload=item.requires_upload,
-                submission_format=item.submission_format,
-                display_order=item.display_order,
-                source=source,
-            ))
-        
+            resolved.append(
+                ResolvedDocumentResponse(
+                    document_type_id=item.document_type_id,
+                    document_type_code=(
+                        item.document_type.code if item.document_type else ""
+                    ),
+                    document_type_name=(
+                        item.document_type.name if item.document_type else ""
+                    ),
+                    is_mandatory=item.is_mandatory,
+                    requires_upload=item.requires_upload,
+                    submission_format=item.submission_format,
+                    display_order=item.display_order,
+                    source=source,
+                )
+            )
+
         # Sort by display_order
         resolved.sort(key=lambda x: x.display_order)
-        
+
         return resolved, _noop_callback
-    
+
     # =========================================================================
     # CONTROL FIELD COMPUTATION (for response)
     # =========================================================================
-    
-    def compute_available_actions(self, path: AdmissionPath) -> List[str]:
+
+    def compute_available_actions(
+        self,
+        path: AdmissionPath,
+        user: User | None = None,
+    ) -> List[str]:
         """
-        Compute available actions based on status.
-        
+        Compute actions the current user is allowed to perform.
+
         FRONTEND_ARCHITECTURE_V3.md: FE reads this, not computes.
+
+        ADM-021: These flags must mirror backend role gates. Managers can
+        create/edit draft paths, but activate/deactivate is admin-only.
         """
         actions: List[str] = []
-        
-        if path.status == "draft":
-            actions = ["save", "activate", "archive"]
+
+        if self.compute_can_edit(path, user):
+            actions.append("save")
+
+        if not user or user.role != UserRole.ADMIN:
+            return actions
+
+        # Keep lifecycle intent visible to admin even when readiness is not
+        # satisfied; callers must use ``can_activate`` to enable/disable the
+        # button because it runs the heavier criteria/doc/quota validation.
+        if path.status in ["draft", "inactive"]:
+            actions.extend(["activate", "archive"])
         elif path.status == "active":
-            actions = ["save", "deactivate"]
-        elif path.status == "inactive":
-            actions = ["save", "activate", "archive"]
-        elif path.status == "archived":
-            actions = []  # No actions on archived
-        
+            actions.append("deactivate")
+
         return actions
-    
-    def compute_can_edit(self, path: AdmissionPath) -> bool:
+
+    def compute_can_edit(
+        self,
+        path: AdmissionPath,
+        user: User | None = None,
+    ) -> bool:
         """
-        Determine if path can be edited.
+        Determine if the current user can edit this path.
         """
-        return path.status != "archived"
-    
-    async def compute_can_activate(self, path: AdmissionPath) -> bool:
+        if path.status == "archived" or not user:
+            return False
+        if user.role == UserRole.ADMIN:
+            return True
+        if user.role == UserRole.MANAGER:
+            return path.status == "draft"
+        return False
+
+    async def compute_can_activate(
+        self,
+        path: AdmissionPath,
+        user: User | None = None,
+    ) -> bool:
         """
-        Determine if path can be activated.
+        Determine if the current user can activate this path.
         """
+        if not user or user.role != UserRole.ADMIN:
+            return False
         can_activate, _ = await self.validate_activation(path)
         return can_activate
 
@@ -628,39 +649,38 @@ class AdmissionPathService:
     # =========================================================================
 
     async def get_coverage_matrix(
-        self,
-        academic_info_id: int
+        self, academic_info_id: int
     ) -> Tuple[dict, PostCommitCallback]:
         """
         Get coverage matrix for all paths in an academic_info.
-        
+
         Returns matrix showing readiness status of each path:
         - has_criteria: criteria_id is set
         - has_documents: document group exists
         - has_quota: quota > 0
         - can_activate: all above are true
-        
+
         FE uses this to display audit table before bulk activation.
         """
         from app.schemas.admission_path import CoverageRow, CoverageMatrixResponse
         from app.repositories.document_group_repository import DocumentGroupRepository
-        
+
         paths = await self.repo.get_paths_by_academic_info(academic_info_id)
         doc_repo = DocumentGroupRepository(self.db)
-        
+
         rows = []
         paths_ready = 0
-        
+
         for path in paths:
             # Check has_criteria
             has_criteria = path.criteria_id is not None
-            
+
             # Check has_documents (based on offering_type + method)
             # Need to get offering_type_id from academic_info.offering
             offering_type_id = None
             if path.academic_info and path.academic_info.offering:
                 offering_type_id = path.academic_info.offering.offering_type_id
-            
+
             has_documents = False
             if offering_type_id:
                 # Check if method-specific group exists, else check shared
@@ -672,16 +692,16 @@ class AdmissionPathService:
                 else:
                     shared_groups = await doc_repo.get_shared_groups(offering_type_id)
                     has_documents = len(shared_groups) > 0
-            
+
             # Check has_quota
             has_quota = False
             if path.academic_info:
                 quota = path.academic_info.annual_admission_quota or 0
                 has_quota = quota > 0
-            
+
             # Compute can_activate
             can_activate = has_criteria and has_documents and has_quota
-            
+
             # Build validation errors
             validation_errors = []
             if not has_criteria:
@@ -690,32 +710,34 @@ class AdmissionPathService:
                 validation_errors.append("Chưa cấu hình hồ sơ (Documents)")
             if not has_quota:
                 validation_errors.append("Chưa thiết lập chỉ tiêu (Quota)")
-            
+
             if can_activate:
                 paths_ready += 1
-            
+
             # Get method info
             method_name = ""
             method_code = ""
             if path.admission_method:
                 method_name = path.admission_method.name
                 method_code = path.admission_method.code
-            
-            rows.append(CoverageRow(
-                path_id=path.id,
-                method_name=method_name,
-                method_code=method_code,
-                status=path.status,
-                has_criteria=has_criteria,
-                has_documents=has_documents,
-                has_quota=has_quota,
-                can_activate=can_activate,
-                validation_errors=validation_errors,
-            ))
-        
+
+            rows.append(
+                CoverageRow(
+                    path_id=path.id,
+                    method_name=method_name,
+                    method_code=method_code,
+                    status=path.status,
+                    has_criteria=has_criteria,
+                    has_documents=has_documents,
+                    has_quota=has_quota,
+                    can_activate=can_activate,
+                    validation_errors=validation_errors,
+                )
+            )
+
         total_paths = len(paths)
         all_ready = paths_ready == total_paths and total_paths > 0
-        
+
         result = CoverageMatrixResponse(
             academic_info_id=academic_info_id,
             rows=rows,
@@ -723,5 +745,5 @@ class AdmissionPathService:
             paths_ready=paths_ready,
             all_ready=all_ready,
         )
-        
+
         return result, _noop_callback

--- a/Backend_FastAPI/tests/unit/test_admission_path_action_flags.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_action_flags.py
@@ -1,0 +1,149 @@
+"""ADM-021: AdmissionPath response action flags are role-aware.
+
+The frontend must render from backend ``available_actions`` / ``can_*``
+fields rather than guessing from ``user.role``. These tests pin the backend
+contract after ADM-008 made activate/deactivate admin-only.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.constants import UserRole
+from app.services.admission_path_service import AdmissionPathService
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_service(*, method_group=object(), shared_groups=None):
+    service = AdmissionPathService.__new__(AdmissionPathService)
+    service.db = MagicMock()
+    service.repo = MagicMock()
+
+    doc_repo = MagicMock()
+    doc_repo.get_method_specific_group = AsyncMock(return_value=method_group)
+    doc_repo.get_shared_groups = AsyncMock(return_value=shared_groups or [])
+    return service, doc_repo
+
+
+def _patch_doc_repo(doc_repo):
+    return patch(
+        "app.repositories.document_group_repository.DocumentGroupRepository",
+        return_value=doc_repo,
+    )
+
+
+def _path(status: str = "draft", *, ready: bool = True):
+    offering = SimpleNamespace(offering_type_id=1)
+    academic_info = SimpleNamespace(
+        annual_admission_quota=100 if ready else 0,
+        offering=offering,
+    )
+    return SimpleNamespace(
+        id=42,
+        status=status,
+        academic_info=academic_info,
+        criteria_id=7 if ready else None,
+        admission_method_id=1,
+    )
+
+
+def _user(role: UserRole):
+    return SimpleNamespace(id=1, role=role)
+
+
+class TestAdmissionPathRoleAwareActionFlags:
+    async def test_admin_draft_ready_can_edit_and_activate(self):
+        service, doc_repo = _make_service()
+        path = _path("draft")
+        admin = _user(UserRole.ADMIN)
+
+        with _patch_doc_repo(doc_repo):
+            assert service.compute_available_actions(path, admin) == [
+                "save",
+                "activate",
+                "archive",
+            ]
+            assert service.compute_can_edit(path, admin) is True
+            assert await service.compute_can_activate(path, admin) is True
+
+    async def test_admin_active_can_edit_and_deactivate_only(self):
+        service, doc_repo = _make_service()
+        path = _path("active")
+        admin = _user(UserRole.ADMIN)
+
+        with _patch_doc_repo(doc_repo):
+            assert service.compute_available_actions(path, admin) == [
+                "save",
+                "deactivate",
+            ]
+            assert service.compute_can_edit(path, admin) is True
+            assert await service.compute_can_activate(path, admin) is False
+
+    async def test_admin_archived_has_no_actions(self):
+        service, doc_repo = _make_service()
+        path = _path("archived")
+        admin = _user(UserRole.ADMIN)
+
+        with _patch_doc_repo(doc_repo):
+            assert service.compute_available_actions(path, admin) == []
+            assert service.compute_can_edit(path, admin) is False
+            assert await service.compute_can_activate(path, admin) is False
+
+    async def test_admin_draft_not_ready_lists_activate_but_cannot_activate(self):
+        """The action list expresses lifecycle intent; ``can_activate`` pins
+        readiness and is what the UI uses to enable the activate button."""
+        service, doc_repo = _make_service()
+        path = _path("draft", ready=False)
+        admin = _user(UserRole.ADMIN)
+
+        with _patch_doc_repo(doc_repo):
+            assert service.compute_available_actions(path, admin) == [
+                "save",
+                "activate",
+                "archive",
+            ]
+            assert service.compute_can_edit(path, admin) is True
+            assert await service.compute_can_activate(path, admin) is False
+
+    async def test_manager_draft_can_save_but_not_activate(self):
+        service, doc_repo = _make_service()
+        path = _path("draft")
+        manager = _user(UserRole.MANAGER)
+
+        with _patch_doc_repo(doc_repo):
+            assert service.compute_available_actions(path, manager) == ["save"]
+            assert service.compute_can_edit(path, manager) is True
+            assert await service.compute_can_activate(path, manager) is False
+
+    @pytest.mark.parametrize("status", ["active", "inactive"])
+    async def test_manager_non_draft_has_no_lifecycle_actions(self, status):
+        service, doc_repo = _make_service()
+        path = _path(status)
+        manager = _user(UserRole.MANAGER)
+
+        with _patch_doc_repo(doc_repo):
+            assert service.compute_available_actions(path, manager) == []
+            assert service.compute_can_edit(path, manager) is False
+            assert await service.compute_can_activate(path, manager) is False
+
+    async def test_non_config_role_gets_no_path_actions(self):
+        service, doc_repo = _make_service()
+        path = _path("active")
+        officer = _user(UserRole.OFFICER)
+
+        with _patch_doc_repo(doc_repo):
+            assert service.compute_available_actions(path, officer) == []
+            assert service.compute_can_edit(path, officer) is False
+            assert await service.compute_can_activate(path, officer) is False
+
+    async def test_no_user_defaults_fail_closed(self):
+        service, doc_repo = _make_service()
+        path = _path("draft")
+
+        with _patch_doc_repo(doc_repo):
+            assert service.compute_available_actions(path) == []
+            assert service.compute_can_edit(path) is False
+            assert await service.compute_can_activate(path) is False


### PR DESCRIPTION
## Summary

Closes **ADM-021**: AdmissionPath response action flags (`available_actions`, `can_edit`, `can_activate`) are now computed against `(path, current_user)` instead of role-agnostic. Before this PR, FE bound action buttons to backend-supplied flags but those flags only checked `path.status` — a manager would see `activate`/`deactivate` buttons that the ADM-008 backend guard would then 403, producing a false-affordance UX.

## What changed

- `services/admission_path_service.py`:
  - `compute_available_actions(path, user)`, `compute_can_edit(path, user)`, `compute_can_activate(path, user)` extended to accept `User | None`. Default-None fails closed.
  - Role × status matrix matches ADM-008 / ADM-005 backend gates:

    | Role | draft | active | inactive | archived |
    |---|---|---|---|---|
    | Admin | `[save, activate, archive]` | `[save, deactivate]` | `[save, activate, archive]` | `[]` |
    | Manager | `[save]` | `[]` | `[]` | `[]` |
    | Officer / User / None | `[]` | `[]` | `[]` | `[]` |

  - Added a doc-comment in `compute_available_actions` clarifying that the action list expresses **lifecycle intent**, while `can_activate` carries the heavier readiness check (criteria + documents + quota). UI is expected to render the button from `available_actions` and enable/disable from `can_activate`.

- `routers/admission_paths.py`:
  - Extracted `build_path_response(path, service, current_user)` helper to compose the role-aware fields. Used by **8 path response sites** (list, detail, create, update, activate/deactivate, criteria, documents) so the contract stays in one place.
  - Routes that previously had `Depends(check_permission)` keep that for the auth/RBAC gate; this helper just makes sure `current_user` reaches the response builder.

- `tests/unit/test_admission_path_action_flags.py` (new, 8 cases):
  - admin draft ready, admin active, admin **archived → []**, admin **draft not-ready → lists activate but `can_activate=False`**, manager draft, manager non-draft (parametrized active+inactive), officer no actions, no-user fail-closed.

## No migration

Zero migrations. Alembic head unchanged.

## Targeted verification

- `tests/unit/test_admission_path_action_flags.py` — 8 cases ✓
- `tests/unit/test_admission_path_admin_only_lifecycle.py` (PR2 ADM-008) — 11 cases ✓
- `tests/unit/test_admission_path_activation.py` (PR1 ADM-004) — 7 cases ✓
- `tests/unit/test_admission_path_lifecycle_guard.py` (PR1 ADM-005) — 12 cases ✓

→ **38/38 path unit suites pass**, plus `test_admission_path_create_persists_allowlist_for_admin` API smoke passes — zero regression on adjacent ADM-004/005/008 work.

## Diff noise — please squash-on-merge

The commit also picks up a `black`-style reformat across the two source files (multi-line params → single-line, trailing-whitespace cleanup). With `-w` the diff is **314 insertions / 174 deletions across 3 files**. The format change was intentionally not split out because the branch was already verified end-to-end and re-splitting risked test churn.

**Please squash-on-merge** so main history stays clean (matches the convention from `(#NNN)` commits already on `main`). The squash commit body will summarize the logic change; the per-line format noise stays in the PR diff only.

## Review concerns addressed

This is the second pass after a code review on the prior `b3f7382f`:
- ✅ Added inline comment clarifying `available_actions` (intent) vs `can_activate` (readiness gate).
- ✅ Added pin tests for two edge cases the matrix didn't cover: admin+archived → `[]`, admin+draft+not-ready → lists `activate` but `can_activate=False`.
- 🟡 Format/logic split: deferred in favor of squash-on-merge (see "Diff noise" above).
- 🟡 N+1 risk on admin list: documented as follow-up. `compute_can_activate` runs `validate_activation` (2 doc-repo queries) per path for admin callers; serial because of memory `feedback_async_session_gather`. Acceptable at current admin-list size; revisit if bottleneck appears in prod.

## Test plan

- [x] Path unit suites: 38/38 pass
- [x] API create-path smoke: pass
- [x] Worktree clean before push (untracked `Documents/ADMISSION_MODULE_AUDIT_2026-04-27.md` + `scripts/plan-loop.ps1` intentionally excluded)
- [ ] Reviewer: pull and run `pytest tests/unit/test_admission_path_action_flags.py -v`
- [ ] Reviewer: spot-check Phase3Config UI as **manager** post-merge — must not see Activate / Deactivate buttons; must still see Save on draft paths.
- [ ] Reviewer: spot-check as **admin** — buttons match the matrix above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)