### PR TITLE
fix(admissions): ADM-007 stage admission document filesystem mutations behind DB commit

### DIFF
--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -797,7 +797,7 @@ async def upload_document(
     - actual_submission_format: Type of document (original | certified_copy | photo)
     """
     try:
-        profile = await admission_service.upload_document(
+        profile, finalize = await admission_service.upload_document(
             db=db,
             profile_id=profile_id,
             doc_code=doc_code,
@@ -805,7 +805,14 @@ async def upload_document(
             current_user=current_user,
             actual_submission_format=actual_submission_format,
         )
-        await db.commit()
+        # ADM-007: file is staged on disk; promote/cleanup happens
+        # via ``finalize`` only after the commit branch is decided.
+        try:
+            await db.commit()
+        except Exception:
+            await finalize(False)
+            raise
+        await finalize(True)
         await db.refresh(profile)
         return profile
 
@@ -1000,13 +1007,21 @@ async def reset_document_endpoint(
     - Full AdmissionProfileResponse with updated validation_summary
     """
     try:
-        profile = await admission_service.reset_document(
+        profile, finalize = await admission_service.reset_document(
             db=db,
             profile_id=profile_id,
             doc_code=doc_code,
             current_user=current_user,
         )
-        await db.commit()
+        # ADM-007: defer the file delete to ``finalize(True)`` so a
+        # commit failure leaves the file (and the rolled-back DB
+        # reference to it) in place.
+        try:
+            await db.commit()
+        except Exception:
+            await finalize(False)
+            raise
+        await finalize(True)
         await db.refresh(profile)
         return profile
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -3277,27 +3277,45 @@ async def upload_document(
     file: Any,  # UploadFile
     current_user: models.User,
     actual_submission_format: Optional[str] = None,
-) -> models.AdmissionProfile:
+) -> tuple[models.AdmissionProfile, Callable]:
     """
     Upload a document for an admission profile.
 
     Workflow:
-    1. Verify access (IDOR)
-    2. Verify profile status (draft/rejected)
-    3. Verify doc_code exists in ProfileDocument
-    4. Save file to disk (uploads/admissions/{id}/{doc_code}_{filename})
-    5. Update ProfileDocument status='uploaded', file_path, and actual_submission_format
-    6. Re-compute validation_summary with updated documents
+    1. Verify access (IDOR).
+    2. Verify profile status (draft/rejected/revision_requested).
+    3. Verify doc_code exists in ProfileDocument.
+    4. Stage file to ``uploads/admissions/{id}/.staging.{uuid}.{ext}``
+       (NOT yet at the final path the DB will reference).
+    5. Update ProfileDocument with the FINAL ``file_path`` it will live
+       at after promotion + ``status='uploaded'`` + format.
+    6. Re-compute validation_summary, audit-log the upload.
 
-    IMPORTANT: This function does NOT commit the transaction.
-    Router must call db.commit().
+    ADM-007: filesystem mutations must not become permanent before the
+    DB commit. The service writes to a staging path and the caller
+    receives a ``finalize(committed: bool)`` callback that does the
+    real promotion (or cleanup) AFTER the router's ``db.commit()``
+    settles. See the return shape below.
+
+    IMPORTANT: This function does NOT commit the transaction. Router
+    must call ``await db.commit()`` and then ``await finalize(True)``;
+    on commit failure the router must call ``await finalize(False)``
+    instead. The caller-side pattern lives in
+    ``app/routers/admissions.py::upload_document``.
 
     Args:
         actual_submission_format: Type of document submitted (original | certified_copy | photo)
             User must declare what type of physical document they scanned/uploaded.
 
     Returns:
-        AdmissionProfile with updated validation_summary
+        Tuple of:
+          - ``AdmissionProfile`` with updated validation_summary.
+          - ``finalize(committed: bool)`` async callback. When
+            ``committed=True``: rename staging → final, then delete
+            the previous file (if any). When ``committed=False``:
+            delete the staging file. Idempotent best-effort: each
+            branch checks ``os.path.exists`` before acting and never
+            raises on the cleanup branch.
 
     Security:
     - Path Traversal: filename sanitization (inherent in modern frameworks but good practice)
@@ -3370,7 +3388,7 @@ async def upload_document(
 
     # doc_record was already fetched above for the authz guard — no need to re-query.
 
-    # Prepare file path with security measures
+    # Prepare file paths with security measures
     import os
     import shutil
     import uuid
@@ -3378,14 +3396,10 @@ async def upload_document(
     upload_dir = f"uploads/admissions/{profile_id}"
     os.makedirs(upload_dir, exist_ok=True)
 
-    # SECURITY: Delete old file if exists (prevent orphan files)
+    # ADM-007: capture the previous file path so the post-commit
+    # callback can delete it. We do NOT delete it here — that would
+    # make the FS change permanent before the DB commit settles.
     old_file_path = doc_record.file_path
-    if old_file_path and os.path.exists(old_file_path):
-        try:
-            os.remove(old_file_path)
-            log.info("Old document file deleted", old_path=old_file_path)
-        except OSError as e:
-            log.warning("Failed to delete old file", path=old_file_path, error=str(e))
 
     # ADM-019: extension is taken from the sniffed content, not from
     # the client-supplied filename, so we never fall back to ".bin" on
@@ -3393,62 +3407,202 @@ async def upload_document(
     extension_for_kind = {"pdf": ".pdf", "jpeg": ".jpg", "png": ".png"}
     file_extension = extension_for_kind[sniffed_kind]
 
-    unique_filename = f"{doc_code}_{uuid.uuid4().hex[:12]}{file_extension}"
-    file_path = f"{upload_dir}/{unique_filename}"
+    unique_id = uuid.uuid4().hex[:12]
+    unique_filename = f"{doc_code}_{unique_id}{file_extension}"
+    final_path = f"{upload_dir}/{unique_filename}"
+    # ADM-007: stage to a sibling path in the same directory so the
+    # post-commit promotion is a single ``os.rename`` (atomic on the
+    # same filesystem). Hidden by leading ``.staging.`` prefix so it
+    # does not show up in casual ``ls`` of the uploads dir.
+    staging_path = f"{upload_dir}/.staging.{unique_id}{file_extension}"
 
-    # Save file
+    # Stage the file to the staging path. If this fails, clean up the
+    # partially-written staging file before raising — we never let
+    # filesystem state diverge from "no upload happened".
     try:
-        with open(file_path, "wb") as buffer:
+        with open(staging_path, "wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
     except Exception as e:
-        log.error("File upload failed", error=str(e), profile_id=profile_id)
+        log.error(
+            "File staging failed",
+            error=str(e),
+            profile_id=profile_id,
+            staging_path=staging_path,
+        )
+        if os.path.exists(staging_path):
+            try:
+                os.remove(staging_path)
+            except OSError:  # pragma: no cover — best-effort cleanup
+                pass
         raise BadRequest("Failed to save file")
 
-    # Update ProfileDocument record (replaces JSONB flag_modified workaround)
-    uploaded_at_dt = datetime.now(timezone.utc)
-    await admission_repo.update_document_status(
-        profile_id=profile_id,
-        document_type_code=doc_code,
-        status="uploaded",
-        file_path=file_path,
-        uploaded_at=uploaded_at_dt.isoformat(),
-        actual_submission_format=actual_submission_format
-    )
+    # ADM-007: from this point on, the staging file is on disk.
+    # Anything that raises BEFORE we return ``finalize`` to the router
+    # would leak the staging file (the router never sees the callback
+    # to clean it up). Wrap the entire post-staging block — DB
+    # update, flush, refresh, frontend-field compute, audit log —
+    # so any exception triggers a best-effort cleanup before
+    # re-raising the original error.
+    try:
+        # Update ProfileDocument record to point at the FINAL path.
+        # The staging file lives at ``staging_path`` until
+        # ``finalize(True)`` renames it; readers that hit the DB
+        # before commit + finalize will see ``final_path`` but the
+        # file will not exist there yet. That is acceptable because
+        # the only caller that observes this window is the router
+        # itself (between ``db.flush`` and ``db.commit``), and routers
+        # do not serve reads to clients in that window.
+        uploaded_at_dt = datetime.now(timezone.utc)
+        await admission_repo.update_document_status(
+            profile_id=profile_id,
+            document_type_code=doc_code,
+            status="uploaded",
+            file_path=final_path,
+            uploaded_at=uploaded_at_dt.isoformat(),
+            actual_submission_format=actual_submission_format
+        )
 
-    profile.updated_at = uploaded_at_dt
+        profile.updated_at = uploaded_at_dt
 
-    await db.flush()
+        await db.flush()
 
-    # ✅ Re-compute validation_summary with updated documents
-    from app.repositories import AdmissionRepository
-    admission_repo_refresh = AdmissionRepository(db)
-    documents = await admission_repo_refresh.get_all_documents(profile_id)
-    _compute_frontend_fields(profile, current_user, documents)
+        # ✅ Re-compute validation_summary with updated documents
+        from app.repositories import AdmissionRepository
+        admission_repo_refresh = AdmissionRepository(db)
+        documents = await admission_repo_refresh.get_all_documents(profile_id)
+        _compute_frontend_fields(profile, current_user, documents)
 
-    # ✅ AUDIT LOG: Track document upload
-    from .document_audit_service import log_document_upload
-    await log_document_upload(
-        db=db,
-        profile_document_id=doc_record.id,
-        actor_user_id=current_user.id,
-        old_status=doc_record.status if doc_record.status != "uploaded" else "missing",
-        new_file_path=file_path,
-        original_filename=file.filename or "unknown",
-        file_size_bytes=file_size,
-        content_type=file.content_type,
-        old_file_path=old_file_path,
-        declared_format=actual_submission_format,
-    )
+        # ✅ AUDIT LOG: Track document upload
+        from .document_audit_service import log_document_upload
+        await log_document_upload(
+            db=db,
+            profile_document_id=doc_record.id,
+            actor_user_id=current_user.id,
+            old_status=doc_record.status if doc_record.status != "uploaded" else "missing",
+            new_file_path=final_path,
+            original_filename=file.filename or "unknown",
+            file_size_bytes=file_size,
+            content_type=file.content_type,
+            old_file_path=old_file_path,
+            declared_format=actual_submission_format,
+        )
+    except Exception as exc:
+        # Service blew up between stage-write and return-finalize.
+        # The router is never going to see ``finalize`` so we own the
+        # cleanup ourselves. Best-effort — never mask the original
+        # exception.
+        log.error(
+            "ADM-007 upload service failed after staging write; "
+            "cleaning staging file before re-raising",
+            error=str(exc),
+            profile_id=profile_id,
+            staging_path=staging_path,
+        )
+        if os.path.exists(staging_path):
+            try:
+                os.remove(staging_path)
+            except OSError as cleanup_error:
+                log.warning(
+                    "Failed to clean staging file after service error",
+                    staging_path=staging_path,
+                    cleanup_error=str(cleanup_error),
+                )
+        raise
 
     log.info(
-        "Document uploaded with audit log",
+        "Document staged with audit log (awaiting commit)",
         profile_id=profile_id,
         doc_code=doc_code,
-        file_path=file_path,
-        user_id=current_user.id
+        staging_path=staging_path,
+        final_path=final_path,
+        user_id=current_user.id,
     )
 
-    return profile
+    async def finalize(committed: bool) -> None:
+        """ADM-007 file-ops finalize callback.
+
+        - ``committed=True``: rename staging → final, then delete the
+          previous file (if any). If the rename fails (disk full,
+          permission, race), we raise so the router can surface a 500
+          and the operator can investigate. The old file is kept in
+          place on rename failure so the user can re-upload without
+          first losing their existing copy.
+        - ``committed=False``: delete the staging file. Best-effort:
+          warns on failure, never raises (the router is unwinding).
+
+        Idempotent: each branch checks ``os.path.exists`` before
+        acting so a double-call (rare, but possible if the router
+        retries) does not raise.
+        """
+        if not committed:
+            if os.path.exists(staging_path):
+                try:
+                    os.remove(staging_path)
+                    log.info(
+                        "Staging file cleaned up after rollback",
+                        staging_path=staging_path,
+                    )
+                except OSError as e:
+                    log.warning(
+                        "Failed to clean staging file after rollback",
+                        staging_path=staging_path,
+                        error=str(e),
+                    )
+            return
+
+        # committed=True: promote staging → final. Use ``os.replace``
+        # rather than ``os.rename`` so the semantics are atomic across
+        # both POSIX and Windows even when the destination already
+        # exists (rare, but possible if the same uuid collides on a
+        # retry).
+        try:
+            if os.path.exists(staging_path):
+                os.replace(staging_path, final_path)
+                log.info(
+                    "Document file promoted from staging post-commit",
+                    final_path=final_path,
+                )
+            elif not os.path.exists(final_path):
+                # Neither staging nor final exists — something has gone
+                # very wrong (concurrent finalize, or the staging file
+                # was removed out-of-band). Surface as an error rather
+                # than silently leaving the DB pointing at a missing
+                # file.
+                raise OSError(
+                    f"ADM-007 finalize: neither staging nor final "
+                    f"file exists for profile={profile_id} "
+                    f"doc={doc_code}"
+                )
+            # else: final already exists (idempotent re-call) — nothing
+            # to do. Continue to old-file cleanup below.
+        except OSError as e:
+            log.error(
+                "ADM-007 finalize promote failed; old file kept intact",
+                staging_path=staging_path,
+                final_path=final_path,
+                old_file_path=old_file_path,
+                error=str(e),
+            )
+            raise
+
+        # Old-file delete is best-effort: the new file is already in
+        # place + DB committed, so a leftover old file is at worst
+        # storage waste, not a correctness issue.
+        if old_file_path and old_file_path != final_path and os.path.exists(old_file_path):
+            try:
+                os.remove(old_file_path)
+                log.info(
+                    "Old document file deleted post-commit",
+                    old_path=old_file_path,
+                )
+            except OSError as e:
+                log.warning(
+                    "Failed to delete old file post-commit",
+                    old_path=old_file_path,
+                    error=str(e),
+                )
+
+    return profile, finalize
 
 
 async def confirm_document_format(
@@ -3729,12 +3883,19 @@ async def reset_document(
     profile_id: int,
     doc_code: str,
     current_user: models.User,
-) -> models.AdmissionProfile:
+) -> tuple[models.AdmissionProfile, Callable]:
     """
     Reset a document to 'missing' status (undo submission).
 
     Use case: User accidentally clicked "Đã nộp" or uploaded wrong file.
     Allows simple undo without complex audit trail.
+
+    ADM-007: filesystem deletion is deferred to a post-commit
+    callback. The old file stays on disk until the router's
+    ``db.commit()`` settles; if commit fails the file remains on disk
+    and the rolled-back DB still references it, which keeps DB and FS
+    consistent. The caller-side pattern lives in
+    ``app/routers/admissions.py::reset_document_endpoint``.
 
     Permissions:
     - Officer: Can reset documents for profiles in draft/rejected status
@@ -3747,7 +3908,13 @@ async def reset_document(
         current_user: Current authenticated user
 
     Returns:
-        AdmissionProfile with updated validation_summary
+        Tuple of:
+          - ``AdmissionProfile`` with updated validation_summary.
+          - ``finalize(committed: bool)`` async callback. When
+            ``committed=True``: delete the previous file (if any).
+            When ``committed=False``: no-op — the service never
+            mutated the filesystem, so there is nothing to undo.
+            Idempotent best-effort.
 
     Raises:
         ResourceNotFoundError: Document not found
@@ -3797,15 +3964,10 @@ async def reset_document(
         reason="User requested reset",
     )
 
-    # Delete physical file if exists
-    if old_file_path:
-        import os
-        if os.path.exists(old_file_path):
-            try:
-                os.remove(old_file_path)
-                log.info("Document file deleted during reset", file_path=old_file_path)
-            except OSError as e:
-                log.warning("Failed to delete document file", error=str(e), file_path=old_file_path)
+    # ADM-007: defer the file delete to the post-commit callback. If
+    # commit fails the file stays on disk and the rolled-back DB still
+    # references it — DB ↔ FS remain consistent. The deletion only
+    # becomes visible to the world after ``db.commit()`` settles.
 
     await db.flush()
 
@@ -3814,13 +3976,45 @@ async def reset_document(
     _compute_frontend_fields(profile, current_user, documents)
 
     log.info(
-        "Document reset to missing",
+        "Document reset staged (awaiting commit)",
         profile_id=profile_id,
         doc_code=doc_code,
         user_id=current_user.id,
+        old_file_path=old_file_path,
     )
 
-    return profile
+    async def finalize(committed: bool) -> None:
+        """ADM-007 reset finalize callback.
+
+        - ``committed=True``: delete the old file if it exists. Best
+          effort — log a warning on failure (storage waste, not a
+          correctness issue).
+        - ``committed=False``: no-op. The service never wrote to the
+          filesystem, so there is nothing to undo.
+
+        Idempotent: ``os.path.exists`` check before unlink.
+        """
+        if not committed:
+            return
+
+        if old_file_path:
+            import os
+
+            if os.path.exists(old_file_path):
+                try:
+                    os.remove(old_file_path)
+                    log.info(
+                        "Document file deleted post-commit during reset",
+                        file_path=old_file_path,
+                    )
+                except OSError as e:
+                    log.warning(
+                        "Failed to delete document file post-commit",
+                        error=str(e),
+                        file_path=old_file_path,
+                    )
+
+    return profile, finalize
 
 
 async def _perform_enrollment_core(

--- a/Backend_FastAPI/tests/integration/test_admission_document_staging.py
+++ b/Backend_FastAPI/tests/integration/test_admission_document_staging.py
@@ -1,0 +1,527 @@
+"""ADM-007 regression suite: filesystem staging for document upload + reset.
+
+Pins the contract that filesystem mutations never become permanent
+before the DB commit settles. Covers four scenarios:
+
+1. **Upload happy path** — service stages to ``.staging.{uuid}``,
+   ``finalize(True)`` promotes to final + deletes old file.
+2. **Upload rollback** — ``finalize(False)`` cleans the staging file
+   and leaves the previous (old) file intact.
+3. **Reset happy path** — ``finalize(True)`` deletes the old file
+   after the DB commit settles.
+4. **Reset rollback** — ``finalize(False)`` is a no-op; the old file
+   remains on disk so it stays consistent with the rolled-back DB.
+"""
+
+import io
+import os
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app import models
+from app.services import admission_service
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Test data fixtures (mirrors the layout in test_document_operations.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def staging_user(db: AsyncSession, seeded_dependencies: dict) -> models.User:
+    """Admin user — sidesteps the document-action policy matrix that
+    blocks officer overwrite/reset on already-uploaded docs. Auth
+    matrix is exercised by other test files; here we focus solely on
+    the ADM-007 filesystem-staging contract."""
+    from app.security import get_password_hash
+
+    ts = datetime.now().timestamp()
+    user = models.User(
+        username=f"staging_admin_{ts:.6f}",
+        email=f"staging_admin_{ts:.6f}@test.com",
+        password_hash=get_password_hash("testpass123"),
+        full_name="ADM-007 Staging Admin",
+        role="admin",
+        status="active",
+        unit_id=seeded_dependencies["unit_id"],
+    )
+    db.add(user)
+    await db.flush()
+    await db.refresh(user)
+    return user
+
+
+@pytest_asyncio.fixture
+async def staging_lead(
+    db: AsyncSession,
+    seeded_dependencies: dict,
+    staging_user: models.User,
+) -> models.Lead:
+    ts = datetime.now().timestamp()
+    lead = models.Lead(
+        full_name="ADM-007 Staging Lead",
+        phone=f"09{int(ts) % 10_000_000:07d}",
+        email=f"staging_lead_{ts:.6f}@test.com",
+        source="website",
+        unit_id=seeded_dependencies["unit_id"],
+        assigned_officer_id=staging_user.id,
+        consultation_status_id=seeded_dependencies["initial_status_id"],
+        consultation_count=1,
+        status="new",
+    )
+    db.add(lead)
+    await db.flush()
+    await db.refresh(lead)
+    return lead
+
+
+@pytest_asyncio.fixture
+async def staging_doc_type(db: AsyncSession) -> models.ConfigDocumentType:
+    ts = datetime.now().timestamp()
+    doc_type = models.ConfigDocumentType(
+        code=f"ADM007_DOC_{ts:.6f}",
+        name=f"ADM-007 Doc {ts:.6f}",
+        description="Document type for staging tests",
+        display_order=300,
+        is_active=True,
+    )
+    db.add(doc_type)
+    await db.flush()
+    await db.refresh(doc_type)
+    return doc_type
+
+
+@pytest_asyncio.fixture
+async def staging_profile(
+    db: AsyncSession,
+    staging_lead: models.Lead,
+) -> models.AdmissionProfile:
+    ts = datetime.now().timestamp()
+    profile = models.AdmissionProfile(
+        lead_id=staging_lead.id,
+        status="draft",
+        citizen_id=f"7{int(ts * 1000) % 10**11:011d}"[:12],
+        version=1,
+        applied_rules={"min_gpa": 6.0, "mandatory_docs": []},
+        academic_year=2025,
+        full_name=staging_lead.full_name,
+        phone=staging_lead.phone,
+        email=staging_lead.email,
+    )
+    db.add(profile)
+    await db.flush()
+
+    result = await db.execute(
+        select(models.AdmissionProfile)
+        .where(models.AdmissionProfile.id == profile.id)
+        .options(selectinload(models.AdmissionProfile.lead))
+    )
+    return result.scalar_one()
+
+
+def _make_upload_file(content: bytes = b"%PDF-1.4\nADM-007 test", filename: str = "doc.pdf") -> MagicMock:
+    """Build a mock ``UploadFile`` carrying real bytes so the
+    magic-byte sniff in ADM-019 still passes."""
+    mock = MagicMock()
+    mock.filename = filename
+    mock.content_type = "application/pdf"
+    mock.file = io.BytesIO(content)
+    return mock
+
+
+def _seed_old_file_on_disk(profile_id: int, doc_code: str) -> str:
+    """Write a realistic 'previous upload' file on disk under the
+    canonical uploads directory and return its path. Tests use this
+    to simulate the case where the user has already uploaded once."""
+    upload_dir = f"uploads/admissions/{profile_id}"
+    os.makedirs(upload_dir, exist_ok=True)
+    old_path = f"{upload_dir}/{doc_code}_old_existing.pdf"
+    with open(old_path, "wb") as f:
+        f.write(b"%PDF-1.4\nold content from a previous upload")
+    return old_path
+
+
+# ---------------------------------------------------------------------------
+# 1. Upload — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestUploadFinalizeTrue:
+    async def test_promotes_staging_to_final_and_deletes_old_file(
+        self,
+        db: AsyncSession,
+        staging_profile: models.AdmissionProfile,
+        staging_doc_type: models.ConfigDocumentType,
+        staging_user: models.User,
+    ):
+        # Seed an existing uploaded doc with a real file on disk.
+        old_path = _seed_old_file_on_disk(
+            staging_profile.id, staging_doc_type.code,
+        )
+        # Document was previously uploaded then REJECTED — file is
+        # still on disk, status=rejected. This is the realistic
+        # upload-over-existing-file scenario for the auth matrix
+        # (upload allowed only on missing/rejected).
+        existing = models.ProfileDocument(
+            profile_id=staging_profile.id,
+            document_type_id=staging_doc_type.id,
+            status="rejected",
+            file_path=old_path,
+            uploaded_at=datetime.now(timezone.utc),
+            rejection_reason="too blurry",
+        )
+        db.add(existing)
+        await db.flush()
+        existing_doc_id = existing.id
+
+        upload_file = _make_upload_file(content=b"%PDF-1.4\nNEW content")
+
+        profile, finalize = await admission_service.upload_document(
+            db=db,
+            profile_id=staging_profile.id,
+            doc_code=staging_doc_type.code,
+            file=upload_file,
+            current_user=staging_user,
+            actual_submission_format="photo",
+        )
+
+        # Pre-finalize state: DB points at FINAL path, but only the
+        # staging file exists on disk yet.
+        await db.refresh(existing)
+        final_path_in_db = existing.file_path
+        assert final_path_in_db != old_path, (
+            "DB must point at the new (final) path before finalize"
+        )
+        assert os.path.exists(old_path), (
+            "Old file must still be on disk before finalize — service "
+            "must NOT delete it"
+        )
+        assert not os.path.exists(final_path_in_db), (
+            "Final path must not exist yet; staging holds the bytes"
+        )
+
+        # Locate staging file
+        upload_dir = f"uploads/admissions/{staging_profile.id}"
+        staging_files = [
+            f for f in os.listdir(upload_dir) if f.startswith(".staging.")
+        ]
+        assert len(staging_files) == 1, (
+            f"Exactly one staging file must exist; got {staging_files}"
+        )
+
+        # Promote
+        await db.commit()
+        await finalize(True)
+
+        # Final exists, staging gone, old gone
+        assert os.path.exists(final_path_in_db)
+        with open(final_path_in_db, "rb") as f:
+            assert f.read().startswith(b"%PDF-1.4\nNEW content")
+        remaining_staging = [
+            f for f in os.listdir(upload_dir) if f.startswith(".staging.")
+        ]
+        assert remaining_staging == [], "Staging file must be promoted, not left behind"
+        assert not os.path.exists(old_path), "Old file must be deleted post-commit"
+
+        # Cleanup
+        if os.path.exists(final_path_in_db):
+            os.remove(final_path_in_db)
+        _ = existing_doc_id  # kept for symmetry / future assertions
+
+
+# ---------------------------------------------------------------------------
+# 2. Upload — rollback path
+# ---------------------------------------------------------------------------
+
+
+class TestUploadFinalizeFalse:
+    async def test_cleans_staging_and_keeps_old_file_intact(
+        self,
+        db: AsyncSession,
+        staging_profile: models.AdmissionProfile,
+        staging_doc_type: models.ConfigDocumentType,
+        staging_user: models.User,
+    ):
+        old_path = _seed_old_file_on_disk(
+            staging_profile.id, staging_doc_type.code,
+        )
+        # Same rejected-doc scenario as the happy-path test.
+        existing = models.ProfileDocument(
+            profile_id=staging_profile.id,
+            document_type_id=staging_doc_type.id,
+            status="rejected",
+            file_path=old_path,
+            uploaded_at=datetime.now(timezone.utc),
+            rejection_reason="needs reupload",
+        )
+        db.add(existing)
+        await db.flush()
+
+        upload_file = _make_upload_file(content=b"%PDF-1.4\nrolled-back upload")
+
+        _profile, finalize = await admission_service.upload_document(
+            db=db,
+            profile_id=staging_profile.id,
+            doc_code=staging_doc_type.code,
+            file=upload_file,
+            current_user=staging_user,
+        )
+
+        upload_dir = f"uploads/admissions/{staging_profile.id}"
+        staging_files = [
+            f for f in os.listdir(upload_dir) if f.startswith(".staging.")
+        ]
+        assert len(staging_files) == 1
+        staging_full = os.path.join(upload_dir, staging_files[0])
+
+        # Simulate router catching a commit failure: rollback session,
+        # then call finalize(False) for FS cleanup.
+        await db.rollback()
+        await finalize(False)
+
+        assert not os.path.exists(staging_full), (
+            "Staging file must be cleaned up on rollback path"
+        )
+        assert os.path.exists(old_path), (
+            "Old file must remain intact when commit fails"
+        )
+
+        # Cleanup
+        if os.path.exists(old_path):
+            os.remove(old_path)
+
+    async def test_service_failure_after_stage_write_cleans_staging_before_reraise(
+        self,
+        db: AsyncSession,
+        staging_profile: models.AdmissionProfile,
+        staging_doc_type: models.ConfigDocumentType,
+        staging_user: models.User,
+        monkeypatch,
+    ):
+        """ADM-007 review fix: if the service raises AFTER the staging
+        write but BEFORE returning the ``finalize`` callback, the
+        router will never see ``finalize(False)``. The service itself
+        must clean the staging file in that path so an audit-log /
+        repo failure does not leak ``.staging.*`` artefacts onto disk.
+        """
+        existing = models.ProfileDocument(
+            profile_id=staging_profile.id,
+            document_type_id=staging_doc_type.id,
+            status="missing",
+        )
+        db.add(existing)
+        await db.flush()
+
+        # Force ``log_document_upload`` to raise AFTER the upload
+        # service has staged the file + flushed the DB row. This is
+        # exactly the leak window the reviewer flagged.
+        from app.services import document_audit_service as _audit_mod
+
+        async def _boom(**_kwargs):
+            raise RuntimeError("simulated audit-log failure")
+
+        monkeypatch.setattr(_audit_mod, "log_document_upload", _boom)
+
+        upload_file = _make_upload_file(content=b"%PDF-1.4\nleak-test bytes")
+
+        upload_dir = f"uploads/admissions/{staging_profile.id}"
+        before_staging = (
+            [f for f in os.listdir(upload_dir) if f.startswith(".staging.")]
+            if os.path.exists(upload_dir)
+            else []
+        )
+
+        with pytest.raises(RuntimeError, match="simulated audit-log failure"):
+            await admission_service.upload_document(
+                db=db,
+                profile_id=staging_profile.id,
+                doc_code=staging_doc_type.code,
+                file=upload_file,
+                current_user=staging_user,
+            )
+
+        # After the service raised, the staging file from THIS call
+        # must be gone — even though the router never received a
+        # finalize callback to invoke.
+        after_staging = (
+            [f for f in os.listdir(upload_dir) if f.startswith(".staging.")]
+            if os.path.exists(upload_dir)
+            else []
+        )
+        assert after_staging == before_staging, (
+            f"ADM-007: staging file leaked when service failed after "
+            f"stage write. Before={before_staging}, After={after_staging}"
+        )
+
+    async def test_finalize_false_is_idempotent(
+        self,
+        db: AsyncSession,
+        staging_profile: models.AdmissionProfile,
+        staging_doc_type: models.ConfigDocumentType,
+        staging_user: models.User,
+    ):
+        """Calling ``finalize(False)`` twice must not raise — staging
+        already gone is the steady state we want, not an error."""
+        existing = models.ProfileDocument(
+            profile_id=staging_profile.id,
+            document_type_id=staging_doc_type.id,
+            status="missing",
+        )
+        db.add(existing)
+        await db.flush()
+
+        upload_file = _make_upload_file()
+        _profile, finalize = await admission_service.upload_document(
+            db=db,
+            profile_id=staging_profile.id,
+            doc_code=staging_doc_type.code,
+            file=upload_file,
+            current_user=staging_user,
+        )
+
+        await db.rollback()
+        await finalize(False)
+        await finalize(False)  # second call must not raise
+
+        upload_dir = f"uploads/admissions/{staging_profile.id}"
+        if os.path.exists(upload_dir):
+            staging_files = [
+                f for f in os.listdir(upload_dir) if f.startswith(".staging.")
+            ]
+            assert staging_files == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Reset — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestResetFinalizeTrue:
+    async def test_deletes_old_file_post_commit(
+        self,
+        db: AsyncSession,
+        staging_profile: models.AdmissionProfile,
+        staging_doc_type: models.ConfigDocumentType,
+        staging_user: models.User,
+    ):
+        old_path = _seed_old_file_on_disk(
+            staging_profile.id, staging_doc_type.code,
+        )
+        existing = models.ProfileDocument(
+            profile_id=staging_profile.id,
+            document_type_id=staging_doc_type.id,
+            status="uploaded",
+            file_path=old_path,
+            uploaded_at=datetime.now(timezone.utc),
+        )
+        db.add(existing)
+        await db.flush()
+        existing_id = existing.id
+
+        _profile, finalize = await admission_service.reset_document(
+            db=db,
+            profile_id=staging_profile.id,
+            doc_code=staging_doc_type.code,
+            current_user=staging_user,
+        )
+
+        # Service must NOT have deleted the file yet.
+        assert os.path.exists(old_path), (
+            "Reset must defer file delete to post-commit; service "
+            "alone must not remove the file"
+        )
+
+        await db.commit()
+        await finalize(True)
+
+        # Post-finalize: file deleted, DB cleared.
+        assert not os.path.exists(old_path)
+
+        # Re-read doc state after commit
+        async with db.bind.connect() as conn:
+            from app.database import AsyncSessionLocal as _ASL
+            async with _ASL() as fresh:
+                result = await fresh.execute(
+                    select(models.ProfileDocument).where(
+                        models.ProfileDocument.id == existing_id,
+                    )
+                )
+                refreshed = result.scalar_one()
+                assert refreshed.status == "missing"
+                assert refreshed.file_path is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Reset — rollback path
+# ---------------------------------------------------------------------------
+
+
+class TestResetFinalizeFalse:
+    async def test_keeps_file_when_commit_fails(
+        self,
+        db: AsyncSession,
+        staging_profile: models.AdmissionProfile,
+        staging_doc_type: models.ConfigDocumentType,
+        staging_user: models.User,
+    ):
+        old_path = _seed_old_file_on_disk(
+            staging_profile.id, staging_doc_type.code,
+        )
+        existing = models.ProfileDocument(
+            profile_id=staging_profile.id,
+            document_type_id=staging_doc_type.id,
+            status="uploaded",
+            file_path=old_path,
+            uploaded_at=datetime.now(timezone.utc),
+        )
+        db.add(existing)
+        await db.flush()
+        existing_id = existing.id
+
+        _profile, finalize = await admission_service.reset_document(
+            db=db,
+            profile_id=staging_profile.id,
+            doc_code=staging_doc_type.code,
+            current_user=staging_user,
+        )
+
+        # Simulate the router's commit failing → rollback + finalize(False).
+        await db.rollback()
+        await finalize(False)
+
+        assert os.path.exists(old_path), (
+            "Reset rollback must keep the old file on disk; the "
+            "rolled-back DB still references it"
+        )
+
+        # The DB rollback should have undone the status change too.
+        # Re-fetch the document via a fresh session because db has rolled back.
+        from app.database import AsyncSessionLocal as _ASL
+        async with _ASL() as fresh:
+            result = await fresh.execute(
+                select(models.ProfileDocument).where(
+                    models.ProfileDocument.id == existing_id,
+                )
+            )
+            after_rollback = result.scalar_one_or_none()
+            # The row may not exist post-rollback because db.add(existing)
+            # was never committed in this test session — both branches
+            # are acceptable for the rollback contract. What matters is
+            # that no half-state remains: file present + DB says
+            # "missing" would be the bug we're guarding against.
+            if after_rollback is not None:
+                assert after_rollback.status == "uploaded"
+                assert after_rollback.file_path == old_path
+
+        # Cleanup
+        if os.path.exists(old_path):
+            os.remove(old_path)


### PR DESCRIPTION
## Summary

Closes **ADM-007** (P1 Data integrity). Filesystem mutations for admission document upload + reset must not become permanent before the DB commit settles. The previous implementation deleted the old file and wrote the new one inline in the service, then ``await db.flush()``-ed and let the router commit. If the commit failed (constraint violation, network blip, app crash) the DB rolled back to its pre-call state but the filesystem could not be unwound — DB and FS then disagreed about which file the document points at, and any subsequent read would 404.

## Pattern (4-corner contract)

| Action | Pre-finalize | ``finalize(True)`` | ``finalize(False)`` |
|---|---|---|---|
| Upload over rejected doc | DB → final, ``.staging.*`` exists, old still on disk, final empty | final = new bytes (``os.replace``), staging gone, old gone | staging cleaned, old intact |
| Reset uploaded doc | DB cleared, file still on disk | file deleted | file intact, DB rolled back → consistent |

Service flushes only and returns ``(profile, finalize)``. Router pattern is the same for both endpoints:

```python
result, finalize = await service_call(...)
try:
    await db.commit()
except Exception:
    await finalize(False)
    raise
await finalize(True)
```

The 2-tuple ``(result, post_commit_callback)`` convention used elsewhere in the project is preserved; the ``committed: bool`` argument differentiates commit vs rollback paths.

## Implementation highlights

### upload_document
- Stages the new file to ``uploads/admissions/{id}/.staging.{uuid}.{ext}`` (sibling of the canonical filename so the post-commit promotion is a single ``os.replace``, atomic across POSIX and Windows even when the destination already exists).
- Updates the DB row to point at the FINAL path. The only window where DB references a path the file hasn't reached yet is between ``db.flush`` and ``db.commit + finalize(True)``, observed only by the router.
- **Reviewer-fix (P2)**: the entire post-staging block (``update_document_status`` → ``db.flush`` → ``_compute_frontend_fields`` → ``log_document_upload``) is wrapped in ``try/except`` so that if any of those raise BEFORE the service returns the ``finalize`` callback, the staging file is best-effort removed and the original exception re-raised. Without this guard the router would never see the callback and the ``.staging.*`` file would leak.

### reset_document
- No longer deletes the file inline. Returns ``(profile, finalize)``.
- ``finalize(True)`` deletes the old file post-commit; ``finalize(False)`` is a no-op (service never wrote to the FS, nothing to undo, and the rolled-back DB still references the file → consistent).

### finalize callback contract
- Idempotent best-effort: each branch checks ``os.path.exists`` first, double-call is a no-op rather than an error.
- ``finalize(True)`` raises only if the ``os.replace`` itself fails (disk full, permission). On that path the old file is left intact so the user can re-upload without first losing their existing copy.
- ``finalize(True)`` old-file delete is best-effort: warns on failure, never raises (leftover is storage waste, not a correctness issue).
- ``finalize(False)`` never raises (router is unwinding).

## Targeted verification

- `tests/integration/test_admission_document_staging.py` (new, 6 cases) — **6/6 PASS**:
  - upload happy path: stage → commit → ``finalize(True)`` promotes + deletes old
  - upload rollback: stage → ``rollback`` + ``finalize(False)`` cleans staging, keeps old
  - upload pre-finalize-return failure: monkeypatched ``log_document_upload`` raises after stage write → service cleans staging itself before re-raising (P2 reviewer pin)
  - upload ``finalize(False)`` idempotent
  - reset happy path: commit → ``finalize(True)`` deletes file
  - reset rollback: rollback + ``finalize(False)`` keeps file (DB rolled back too → consistent)
- Regression `test_document_operations.py` — **23/23 PASS**
- Regression `test_document_audit_log.py` — **19/19 PASS** (1 pre-existing pytest-asyncio mark warning, unrelated)
- Regression `test_admission_upload.py` (services) — **4/4 PASS**
- Regression `test_admission_document_permissions.py` (api) — **4/4 PASS**

**Total: 56/56 pass** sequentially in Docker. Zero new failures or regressions.

(A first parallel-pytest run hit ``ConnectionDoesNotExistError`` from concurrent ``DROP SCHEMA public`` against the same test DB — unrelated test-infra race, sequential rerun was clean.)

## Out-of-scope (per chat decision)

- ❌ ADM-020 quarantine / retention bucket — defer to separate PR
- ❌ Periodic scheduled cleanup of orphan ``.staging.*`` files — defer (residual risk: only leaks if process crashes between service ``return`` and router ``finalize`` call, narrow window the reviewer accepted as "narrow-fix" tradeoff)
- ❌ Outbox / WAL-style filesystem ops — defer

## Squash-on-merge requested

Two atomic commits (service+router fix + tests). Please **squash-on-merge** to keep ``main`` history matching the ``(#NNN)`` convention from PR #150 / #151 / #152. The squash commit body summarizes the four-corner contract.

## Test plan

- [x] Targeted suite + adjacent regression: 56/56 pass sequentially in Docker
- [x] Reviewer P2 fix verified by dedicated regression test
- [x] ``os.rename`` → ``os.replace`` swap reviewed
- [x] Worktree clean before push (only intentional untracked: ``Documents/ADMISSION_MODULE_AUDIT_2026-04-27.md`` and ``scripts/plan-loop.ps1``)
- [ ] Reviewer: pull and run ``pytest tests/integration/test_admission_document_staging.py -v``
- [ ] Post-merge prod smoke: upload a document, hit a known-bad commit path (e.g. through admin / canary), confirm no leftover ``.staging.*`` files in ``uploads/admissions/<id>/``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)