### PR TITLE
fix(admissions): ADM-015 require optimistic-lock version on override + finalize

### DIFF
--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -1742,7 +1742,8 @@ async def override_admission(
     **Request Body:**
     - reason: Override reason (REQUIRED, min 10 chars, max 1000)
     - bypass_rules: List of rules bypassed (optional, for documentation)
-    - version: Optional version for optimistic locking
+    - version: REQUIRED — current profile version for optimistic locking
+      (ADM-015). Stale version → 409 Conflict.
 
     **Returns:**
     - Updated AdmissionProfile with status='overridden'
@@ -1900,7 +1901,8 @@ async def finalize_enrollment(
     - Final state enforcement (no transitions from ENROLLED)
 
     **Request Body:**
-    - version: Optional version for optimistic locking
+    - version: REQUIRED — current profile version for optimistic locking
+      (ADM-015). Stale version → 409 Conflict.
 
     **Returns:**
     - Updated AdmissionProfile with status='enrolled'

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1208,6 +1208,7 @@ class OverrideRequest(BaseModel):
     - Admin only
     - Reason MANDATORY (audit requirement)
     - Full audit logging required
+    - REQUIRED version for optimistic locking (ADM-015)
     """
     reason: str = Field(
         ...,
@@ -1218,6 +1219,11 @@ class OverrideRequest(BaseModel):
     bypass_rules: List[str] = Field(
         default_factory=list,
         description="List of rules bypassed (e.g., ['min_gpa', 'missing_documents'])"
+    )
+    version: int = Field(
+        ...,
+        ge=1,
+        description="REQUIRED: Current profile version for optimistic locking (prevents race conditions)"
     )
 
     @field_validator('reason')
@@ -1237,9 +1243,13 @@ class FinalizeRequest(BaseModel):
     - Transition: OVERRIDDEN/CONFIRMED → ENROLLED
     - Admin only
     - Creates Student record
+    - REQUIRED version for optimistic locking (ADM-015)
     """
-    # No fields required - triggers enrollment
-    pass
+    version: int = Field(
+        ...,
+        ge=1,
+        description="REQUIRED: Current profile version for optimistic locking (prevents race conditions)"
+    )
 
     model_config = ConfigDict(str_strip_whitespace=True)
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -5468,8 +5468,13 @@ async def override_profile(
     if not data.get("reason"):
         raise BadRequest("Override reason is required (min 10 characters)")
 
-    # VERSION CHECK
-    if data.get("version") is not None and data["version"] != profile.version:
+    # ADM-015: schema makes ``version`` required (REQUIRED + ge=1), so we
+    # compare directly. The previous ``data.get("version") is not None``
+    # guard silently skipped the check whenever the field was absent —
+    # which was *always*, because OverrideRequest didn't expose it. If
+    # the schema/router ever drift again the KeyError below fails loud
+    # instead of giving a false sense of optimistic locking.
+    if data["version"] != profile.version:
         raise ConflictError(
             f"Profile was modified by another user. "
             f"Expected version {data['version']}, but current version is {profile.version}. "
@@ -5746,8 +5751,9 @@ async def finalize_profile(
         )
         raise BadRequest(str(e))
 
-    # VERSION CHECK
-    if data.get("version") is not None and data["version"] != profile.version:
+    # ADM-015: FinalizeRequest now requires ``version`` (ge=1). Direct
+    # compare; KeyError fails loud if the schema ever drops the field.
+    if data["version"] != profile.version:
         raise ConflictError(
             f"Profile was modified by another user. "
             f"Expected version {data['version']}, but current version is {profile.version}. "

--- a/Backend_FastAPI/tests/integration/test_admission_state_transitions.py
+++ b/Backend_FastAPI/tests/integration/test_admission_state_transitions.py
@@ -676,10 +676,18 @@ class TestStateTransitionWorkflows:
         assert correct_confirm_response.status_code == 200, f"Confirm failed: {correct_confirm_response.text}"
         assert correct_confirm_response.json()["status"] == "confirmed"
 
-        # 7. Admin finalizes
+        # 7. Admin finalizes — ADM-015 requires current ``version``.
+        # ``ConfirmTokenResponse`` (the magic-link confirm response
+        # shape) does not carry ``version``, so we fetch the latest
+        # profile state via GET before issuing the finalize.
+        profile_after_confirm = await client.get(
+            f"/api/admissions/{profile.id}",
+            headers=admin_headers,
+        )
+        assert profile_after_confirm.status_code == 200, profile_after_confirm.text
         finalize_response = await client.post(
             f"/api/admissions/{profile.id}/finalize",
-            json={},
+            json={"version": profile_after_confirm.json()["version"]},
             headers=admin_headers,
         )
         assert finalize_response.status_code == 200, f"Finalize failed: {finalize_response.text}"
@@ -762,10 +770,10 @@ class TestStateTransitionWorkflows:
         assert override_response.status_code == 200, f"Override failed: {override_response.text}"
         assert override_response.json()["status"] == "overridden"
 
-        # 2. Admin finalizes
+        # 2. Admin finalizes — ADM-015 requires current ``version``
         finalize_response = await client.post(
             f"/api/admissions/{profile.id}/finalize",
-            json={},
+            json={"version": override_response.json()["version"]},
             headers=admin_headers,
         )
         assert finalize_response.status_code == 200, f"Finalize failed: {finalize_response.text}"

--- a/Backend_FastAPI/tests/integration/test_admission_version_lock_required.py
+++ b/Backend_FastAPI/tests/integration/test_admission_version_lock_required.py
@@ -1,0 +1,393 @@
+"""ADM-015 regression suite: optimistic-lock ``version`` required for
+override + finalize.
+
+Pre-fix, ``OverrideRequest`` had no ``version`` field and
+``FinalizeRequest`` was an empty model. Pydantic stripped any
+``version`` the client sent and the service ``data.get("version") is
+not None`` guard silently skipped the check — the route doc claimed
+optimistic locking, the implementation never enforced it.
+
+After the fix, both schemas mirror the existing ``ApproveRequest``
+pattern: ``version: int = Field(..., ge=1)`` REQUIRED. Service
+compares ``data["version"] != profile.version`` directly so a future
+schema/router drift fails loud (KeyError) instead of silently
+skipping.
+
+Three corners of the contract are pinned per endpoint:
+
+1. Missing ``version`` → 422 (Pydantic validation error).
+2. Stale ``version`` → 409 (ConflictError → router maps).
+3. Current ``version`` → 200 + ``profile.version`` increments by 1.
+"""
+
+import time
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _login(client: AsyncClient, user_info: dict) -> dict:
+    res = await client.post(
+        "/api/auth/login",
+        data={"username": user_info["username"], "password": user_info["password"]},
+    )
+    if res.status_code != 200:
+        pytest.fail(f"Login failed: {res.status_code} - {res.text}")
+    token = res.cookies.get("access_token")
+    if not token:
+        pytest.fail("Login succeeded but access_token cookie not found")
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _create_lead(unit_id: int) -> int:
+    ts = int(time.time() * 1000)
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            lead = models.Lead(
+                full_name="ADM-015 Lead",
+                phone=f"09{str(ts)[-9:]}"[-10:],
+                email=f"adm015_{ts}@test.com",
+                source="website",
+                unit_id=unit_id,
+            )
+            s.add(lead)
+            await s.flush()
+            return lead.id
+
+
+async def _create_approved_profile(
+    lead_id: int, citizen_id: str
+) -> models.AdmissionProfile:
+    """Approved-state profile is the only valid source-state for
+    override; finalize tests transition through override then call
+    finalize on the resulting overridden state."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            profile = models.AdmissionProfile(
+                lead_id=lead_id,
+                status="approved",
+                citizen_id=citizen_id,
+                academic_year=2026,
+                version=1,
+                applied_rules={
+                    "min_gpa": 0,
+                    "mandatory_docs": [],
+                    "fee_status": "exempt",
+                    "requires_application_fee": False,
+                },
+            )
+            s.add(profile)
+            await s.flush()
+            profile_id = profile.id
+
+        result = await s.execute(
+            select(models.AdmissionProfile).where(
+                models.AdmissionProfile.id == profile_id
+            )
+        )
+        return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# OverrideRequest
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideRequiresVersion:
+    """ADM-015: ``version`` is required by Pydantic at the schema layer
+    AND enforced by the service against the current row."""
+
+    async def test_missing_version_returns_422(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        lead_id = await _create_lead(unit_id)
+        profile = await _create_approved_profile(lead_id, "915001000001")
+
+        admin_headers = await _login(client, admin_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile.id}/override",
+            json={
+                "reason": "ADM-015 missing-version regression",
+                # version field intentionally omitted
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == 422, (
+            f"Missing version must surface as Pydantic 422, got "
+            f"{response.status_code}: {response.text[:300]}"
+        )
+        body = response.json()
+        # The project's exception handler maps Pydantic 422s to a body
+        # of shape ``{"detail": "Request validation failed",
+        # "error_code": "VALIDATION_ERROR", "errors": [<list of err
+        # dicts>]}`` — each err dict carries a ``loc`` ending with the
+        # missing field name.
+        errors = body.get("errors") or []
+        assert any(
+            "version" in (item.get("loc") or [])
+            for item in errors
+        ), f"422 must reference the missing ``version`` field: {body}"
+
+    async def test_stale_version_returns_409(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        lead_id = await _create_lead(unit_id)
+        profile = await _create_approved_profile(lead_id, "915002000002")
+
+        admin_headers = await _login(client, admin_user_in_db)
+
+        # Send a version that's ≥ 1 (so Pydantic ``ge=1`` accepts it)
+        # but mismatches ``profile.version`` so the service raises
+        # ConflictError → router maps to 409. We use ``+999`` rather
+        # than ``-1`` because the seeded ``version=1`` would underflow
+        # past the Pydantic constraint and surface a 422 instead of
+        # the 409 we want to assert here.
+        response = await client.post(
+            f"/api/admissions/{profile.id}/override",
+            json={
+                "reason": "ADM-015 stale-version regression",
+                "version": profile.version + 999,
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == 409, (
+            f"Stale version must surface as 409 Conflict, got "
+            f"{response.status_code}: {response.text[:300]}"
+        )
+        # The error message should at least mention "version" or
+        # "modified" so an end client can show a meaningful refresh
+        # prompt.
+        body = response.json()
+        detail = (body.get("detail") or "").lower()
+        assert "version" in detail or "modified" in detail
+
+    async def test_current_version_succeeds_and_increments(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        lead_id = await _create_lead(unit_id)
+        profile = await _create_approved_profile(lead_id, "915003000003")
+        old_version = profile.version
+
+        admin_headers = await _login(client, admin_user_in_db)
+
+        response = await client.post(
+            f"/api/admissions/{profile.id}/override",
+            json={
+                "reason": "ADM-015 happy-path regression",
+                "version": profile.version,
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == 200, (
+            f"Current version must succeed, got {response.status_code}: "
+            f"{response.text[:300]}"
+        )
+        body = response.json()
+        assert body["status"] == "overridden"
+        assert body["version"] == old_version + 1, (
+            "Override must bump version so the next state-changing call "
+            "(finalize) cannot reuse the same value"
+        )
+
+
+# ---------------------------------------------------------------------------
+# FinalizeRequest
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeRequiresVersion:
+    """Finalize tests transition: approved → overridden (via override)
+    → enrolled (via finalize). Each finalize call uses the version
+    returned from the prior override response."""
+
+    async def _override_to_overridden(
+        self,
+        client: AsyncClient,
+        profile: models.AdmissionProfile,
+        admin_headers: dict,
+    ) -> int:
+        """Drive profile from approved → overridden, return the new
+        version that the next finalize call must carry."""
+        response = await client.post(
+            f"/api/admissions/{profile.id}/override",
+            json={
+                "reason": "ADM-015 setup — overridden so finalize is valid",
+                "version": profile.version,
+            },
+            headers=admin_headers,
+        )
+        assert response.status_code == 200, response.text
+        return response.json()["version"]
+
+    async def test_missing_version_returns_422(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        lead_id = await _create_lead(unit_id)
+        profile = await _create_approved_profile(lead_id, "915004000004")
+        admin_headers = await _login(client, admin_user_in_db)
+        await self._override_to_overridden(client, profile, admin_headers)
+
+        response = await client.post(
+            f"/api/admissions/{profile.id}/finalize",
+            json={},  # version intentionally omitted
+            headers=admin_headers,
+        )
+        assert response.status_code == 422, (
+            f"Missing version must surface as Pydantic 422, got "
+            f"{response.status_code}: {response.text[:300]}"
+        )
+        body = response.json()
+        # See ``test_missing_version_returns_422`` on
+        # OverrideRequiresVersion for the project's 422 body shape.
+        errors = body.get("errors") or []
+        assert any(
+            "version" in (item.get("loc") or [])
+            for item in errors
+        ), f"422 must reference the missing ``version`` field: {body}"
+
+    async def test_stale_version_returns_409(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        lead_id = await _create_lead(unit_id)
+        profile = await _create_approved_profile(lead_id, "915005000005")
+        admin_headers = await _login(client, admin_user_in_db)
+        version_after_override = await self._override_to_overridden(
+            client, profile, admin_headers,
+        )
+
+        # See ``test_stale_version_returns_409`` on OverrideRequiresVersion
+        # for why we use ``+999`` rather than ``-1``: any non-equal
+        # ``int >= 1`` triggers the service-layer ConflictError without
+        # tripping Pydantic's ``ge=1`` constraint first.
+        response = await client.post(
+            f"/api/admissions/{profile.id}/finalize",
+            json={"version": version_after_override + 999},
+            headers=admin_headers,
+        )
+        assert response.status_code == 409, (
+            f"Stale version must surface as 409 Conflict, got "
+            f"{response.status_code}: {response.text[:300]}"
+        )
+        body = response.json()
+        detail = (body.get("detail") or "").lower()
+        assert "version" in detail or "modified" in detail
+
+    async def test_current_version_succeeds_and_increments(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        lead_id = await _create_lead(unit_id)
+        profile = await _create_approved_profile(lead_id, "915006000006")
+        admin_headers = await _login(client, admin_user_in_db)
+        version_after_override = await self._override_to_overridden(
+            client, profile, admin_headers,
+        )
+
+        response = await client.post(
+            f"/api/admissions/{profile.id}/finalize",
+            json={"version": version_after_override},
+            headers=admin_headers,
+        )
+        assert response.status_code == 200, (
+            f"Current version must succeed, got {response.status_code}: "
+            f"{response.text[:300]}"
+        )
+        body = response.json()
+        assert body["status"] == "enrolled"
+        # Finalize is the terminal transition; version is bumped by
+        # the enrollment core. Just assert it moved forward, don't
+        # pin the exact delta — that's enrollment's contract, not
+        # this test's contract.
+        assert body["version"] > version_after_override
+
+
+# ---------------------------------------------------------------------------
+# Schema-level validation (no DB required)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemasRejectMissingVersion:
+    """Belt-and-braces: even if a future test or caller bypasses the
+    HTTP layer and constructs the schema directly, missing ``version``
+    must raise a Pydantic ``ValidationError``."""
+
+    def test_override_schema_rejects_missing_version(self):
+        from pydantic import ValidationError
+
+        from app.schemas.admission import OverrideRequest
+
+        with pytest.raises(ValidationError) as exc_info:
+            OverrideRequest(
+                reason="ADM-015 schema regression — version is required",
+                bypass_rules=[],
+            )
+        # ``loc`` should point at the missing ``version`` field
+        errors = exc_info.value.errors()
+        assert any("version" in (e.get("loc") or ()) for e in errors), (
+            f"Validation error must mention the missing version field: {errors}"
+        )
+
+    def test_finalize_schema_rejects_missing_version(self):
+        from pydantic import ValidationError
+
+        from app.schemas.admission import FinalizeRequest
+
+        with pytest.raises(ValidationError) as exc_info:
+            FinalizeRequest()
+        errors = exc_info.value.errors()
+        assert any("version" in (e.get("loc") or ()) for e in errors), (
+            f"Validation error must mention the missing version field: {errors}"
+        )
+
+    def test_override_schema_rejects_zero_version(self):
+        """``ge=1`` constraint — version must be a positive int."""
+        from pydantic import ValidationError
+
+        from app.schemas.admission import OverrideRequest
+
+        with pytest.raises(ValidationError):
+            OverrideRequest(
+                reason="ADM-015 ge=1 regression",
+                version=0,
+            )
+
+    def test_finalize_schema_rejects_zero_version(self):
+        from pydantic import ValidationError
+
+        from app.schemas.admission import FinalizeRequest
+
+        with pytest.raises(ValidationError):
+            FinalizeRequest(version=0)

--- a/Backend_FastAPI/tests/services/test_admission_service.py
+++ b/Backend_FastAPI/tests/services/test_admission_service.py
@@ -1424,7 +1424,9 @@ class TestOverrideResponseFields:
         admin_user_in_db: dict,
         seed_lead_dependencies: dict,
     ):
-        profile_id, _, _ = await _create_profile_with_state(
+        # ADM-015: override now requires the current version. The
+        # helper hands it back so we don't need a separate GET.
+        profile_id, version, _ = await _create_profile_with_state(
             client, officer_user_in_db, seed_lead_dependencies,
             target_status="approved",
         )
@@ -1432,7 +1434,11 @@ class TestOverrideResponseFields:
 
         response = await client.post(
             f"/api/admissions/{profile_id}/override",
-            json={"reason": "Special case for scholarship recipient", "bypass_rules": []},
+            json={
+                "reason": "Special case for scholarship recipient",
+                "bypass_rules": [],
+                "version": version,
+            },
             headers=admin_headers,
         )
         assert response.status_code in (200, 201), f"Override failed: {response.text}"
@@ -1455,7 +1461,8 @@ class TestFinalizeResponseFields:
         admin_user_in_db: dict,
         seed_lead_dependencies: dict,
     ):
-        profile_id, _, _ = await _create_profile_with_state(
+        # ADM-015: finalize now requires the current version.
+        profile_id, version, _ = await _create_profile_with_state(
             client, officer_user_in_db, seed_lead_dependencies,
             target_status="confirmed",
         )
@@ -1463,7 +1470,7 @@ class TestFinalizeResponseFields:
 
         response = await client.post(
             f"/api/admissions/{profile_id}/finalize",
-            json={},
+            json={"version": version},
             headers=admin_headers,
         )
         assert response.status_code in (200, 201), f"Finalize failed: {response.text}"

--- a/frontend/src/test/e2e/admission-lifecycle.spec.ts
+++ b/frontend/src/test/e2e/admission-lifecycle.spec.ts
@@ -544,12 +544,20 @@ test.describe("Admission Profile Lifecycle", () => {
 
     // --- Step 10: Admin overrides ---
     await test.step("Admin overrides profile", async () => {
+      // ADM-015: override now requires the current profile version
+      // (optimistic locking). Fetch it just before the call.
+      const profileBefore = await (
+        await page.request.get(`${API_URL}/api/admissions/${profileId1}`, {
+          headers: adminHeaders,
+        })
+      ).json();
       const resp = await page.request.post(
         `${API_URL}/api/admissions/${profileId1}/override`,
         {
           headers: adminHeaders,
           data: {
             reason: "E2E happy path test - override to bypass confirmation",
+            version: profileBefore.version,
           },
         }
       );
@@ -570,10 +578,19 @@ test.describe("Admission Profile Lifecycle", () => {
         const body = await enrollResp.json();
         console.log(`Enrolled! student_code=${body.student_code}`);
       } else {
-        // Fallback to finalize
+        // Fallback to finalize — ADM-015 requires current version
+        const profileBefore = await (
+          await page.request.get(
+            `${API_URL}/api/admissions/${profileId1}`,
+            { headers: adminHeaders }
+          )
+        ).json();
         const finalizeResp = await page.request.post(
           `${API_URL}/api/admissions/${profileId1}/finalize`,
-          { headers: adminHeaders, data: {} }
+          {
+            headers: adminHeaders,
+            data: { version: profileBefore.version },
+          }
         );
         expect(finalizeResp.ok()).toBeTruthy();
         const body = await finalizeResp.json();
@@ -832,9 +849,19 @@ test.describe("Admission Profile Lifecycle", () => {
         const body = await enrollResp.json();
         console.log(`Enrolled! student_code=${body.student_code}`);
       } else {
+        // ADM-015: finalize requires current version
+        const profileBefore = await (
+          await page.request.get(
+            `${API_URL}/api/admissions/${profileId3}`,
+            { headers: adminHeaders }
+          )
+        ).json();
         const finalizeResp = await page.request.post(
           `${API_URL}/api/admissions/${profileId3}/finalize`,
-          { headers: adminHeaders, data: {} }
+          {
+            headers: adminHeaders,
+            data: { version: profileBefore.version },
+          }
         );
         expect(finalizeResp.ok()).toBeTruthy();
         console.log(`Finalized: ${(await finalizeResp.json()).status}`);
@@ -1364,11 +1391,20 @@ test.describe("Admission Profile Lifecycle", () => {
 
     // --- Step 3: Admin overrides ---
     await test.step("Admin overrides profile", async () => {
+      // ADM-015: fetch current version before override
+      const profileBefore = await (
+        await page.request.get(`${API_URL}/api/admissions/${profileId7A}`, {
+          headers: adminHeaders,
+        })
+      ).json();
       const resp = await page.request.post(
         `${API_URL}/api/admissions/${profileId7A}/override`,
         {
           headers: adminHeaders,
-          data: { reason: "Override for drop test 7A — bypass confirmation" },
+          data: {
+            reason: "Override for drop test 7A — bypass confirmation",
+            version: profileBefore.version,
+          },
         }
       );
       expect(resp.ok()).toBeTruthy();
@@ -1385,9 +1421,19 @@ test.describe("Admission Profile Lifecycle", () => {
       if (enrollResp.ok() || enrollResp.status() === 201) {
         console.log(`Enrolled 7A: student_code=${(await enrollResp.json()).student_code}`);
       } else {
+        // ADM-015: finalize requires current version
+        const profileBefore = await (
+          await page.request.get(
+            `${API_URL}/api/admissions/${profileId7A}`,
+            { headers: adminHeaders }
+          )
+        ).json();
         const finalizeResp = await page.request.post(
           `${API_URL}/api/admissions/${profileId7A}/finalize`,
-          { headers: adminHeaders, data: {} }
+          {
+            headers: adminHeaders,
+            data: { version: profileBefore.version },
+          }
         );
         expect(finalizeResp.ok()).toBeTruthy();
         console.log(`Finalized 7A: ${(await finalizeResp.json()).status}`);
@@ -1501,9 +1547,19 @@ test.describe("Admission Profile Lifecycle", () => {
       if (enrollResp.ok() || enrollResp.status() === 201) {
         console.log(`Enrolled 7B: student_code=${(await enrollResp.json()).student_code}`);
       } else {
+        // ADM-015: finalize requires current version
+        const profileBefore = await (
+          await page.request.get(
+            `${API_URL}/api/admissions/${profileId7B}`,
+            { headers: adminHeaders }
+          )
+        ).json();
         const finalizeResp = await page.request.post(
           `${API_URL}/api/admissions/${profileId7B}/finalize`,
-          { headers: adminHeaders, data: {} }
+          {
+            headers: adminHeaders,
+            data: { version: profileBefore.version },
+          }
         );
         expect(finalizeResp.ok()).toBeTruthy();
         console.log(`Finalized 7B: ${(await finalizeResp.json()).status}`);


### PR DESCRIPTION
## Summary

Closes **ADM-015** (P2 Contract). The route docstrings for ``POST /admissions/{id}/override`` and ``/finalize`` claim "Optimistic locking via version check", but the implementation never enforced it: ``OverrideRequest`` had no ``version`` field and ``FinalizeRequest`` was an empty model, so Pydantic stripped any ``version`` the client sent and the service guard ``if data.get("version") is not None and data["version"] != profile.version`` silently skipped the check whenever the field was absent — which was *always*. Two admins racing the same override/finalize could both succeed and double-bump the version without either seeing the other's mutation.

## What this PR does

### Schemas — mirror existing pattern

Both schemas now match ``ApproveRequest`` / ``RejectRequest`` / ``WithdrawRequest`` / ``MinorCorrectionRequest`` ("CRITICAL FIX #4" pattern, already shipped on every other state-changing admission action):

```python
version: int = Field(
    ..., ge=1,
    description="REQUIRED: Current profile version for optimistic locking (prevents race conditions)",
)
```

``FinalizeRequest`` was an empty ``pass`` model; now carries only the required ``version``.

### Service — direct compare, fail-loud

``override_profile`` and ``finalize_profile`` drop the ``data.get("version") is not None`` guard. Direct compare:

```python
if data["version"] != profile.version:
    raise ConflictError(...)
```

If the schema ever drops ``version`` again, the resulting ``KeyError`` fails loud rather than reverting the silent-skip behavior we just removed.

### Route docstrings

``Optional version`` → ``REQUIRED — current profile version for optimistic locking (ADM-015). Stale version → 409 Conflict.``

## Scope (Option C from chat-thread brainstorm)

**Fixed only the live schemas:** ``OverrideRequest`` + ``FinalizeRequest``.

**``ConfirmRequest`` intentionally skipped** — it's declared in ``schemas/admission.py`` and exported in ``__init__.py``, but no router consumes it. The active confirm path is the magic-link flow (``POST /confirm/{token}``) which uses ``ConfirmTokenVerifyRequest`` and the ``verify_and_confirm`` service, not ``ConfirmRequest``. Adding ``version`` to dead code would be cosmetic. Tracked as a separate dead-schema cleanup candidate, not folded into this PR.

ADM-013 remains the right place to handle applicant-side concurrency on the magic-link confirm — explicitly NOT in this PR.

## Targeted verification

Backend (sequential in Docker):

- ``tests/services/test_admission_service.py::TestOverrideResponseFields`` + ``TestFinalizeResponseFields`` — **2/2 PASS** (these had to be updated to fetch + pass current ``version``; reviewer flagged this as the blocker on first review)
- ``tests/integration/test_admission_version_lock_required.py`` (new, 10 cases) + ``tests/integration/test_admission_override_audit.py`` (ADM-014 regression) — **12/12 PASS**. 4 warnings are pre-existing pytest-asyncio marks on synchronous schema tests sharing ``pytestmark`` with the async tests in the same file; not a regression.
- ``tests/api/test_admission_workflow_api.py`` + selected ``test_finalize_uses_confirmed_pre_status`` — **14/14 PASS**

**Total backend: 28 passed.**

Frontend:
- ``npm run type-check`` — **pass** (lần đầu trả exit 1 không có diagnostic, ``npx tsc --noEmit --pretty false`` pass, rerun npm script pass — flaky build runner, not a real type error)

Playwright E2E:
- Source updated for 6 call sites in ``admission-lifecycle.spec.ts`` (each now fetches profile + passes ``version``); ``lead-to-admission-workflow.spec.ts`` already passed ``version`` from the prior response chain. **Full browser E2E not run** in this environment — source-updated only.

## Adjacent test debt observed (NOT introduced by this PR)

``test_drop_clears_available_actions`` in ``test_admission_state_transitions.py`` fails on main and on this branch with the same message: dropped students still see the ``calculate_fee`` action because the test allowlist only permits ``{"view", "assign_officer"}``. Same drift class as ``test_officer_template_lacks_finance_operations`` — both stem from the chat-thread decision ``admission-audit-decisions-2026-04-24`` ("officer scoped fee calc") that updated the Casbin policy without updating these test allowlists. Tracked in the test-debt memory; one fix already on the test-debt branch.

## Files changed (7)

| Type | Path | Change |
|---|---|---|
| MOD | ``Backend_FastAPI/app/schemas/admission.py`` | Add ``version: int = Field(..., ge=1)`` to both schemas |
| MOD | ``Backend_FastAPI/app/services/admission_service.py`` | Drop optional guard, direct compare |
| MOD | ``Backend_FastAPI/app/routers/admissions.py`` | Docstrings: Optional → REQUIRED |
| MOD | ``Backend_FastAPI/tests/services/test_admission_service.py`` | 2 sites: capture + pass ``version`` |
| MOD | ``Backend_FastAPI/tests/integration/test_admission_state_transitions.py`` | 2 finalize sites: GET fresh ``version`` before call |
| ADD | ``Backend_FastAPI/tests/integration/test_admission_version_lock_required.py`` | 10 cases: missing → 422, stale → 409, current → 200 + bump (HTTP + Pydantic-only schema) |
| MOD | ``frontend/src/test/e2e/admission-lifecycle.spec.ts`` | 6 call sites: GET ``version`` immediately before override/finalize |

## Squash-on-merge requested

Three atomic commits (schema/service/router; backend tests; e2e tests). Please **squash-on-merge** to keep ``main`` history matching the ``(#NNN)`` convention from PR #150 / #151 / #152 / #153 / #154.

## Test plan

- [x] Backend targeted suites: 28 passed
- [x] Frontend ``npm run type-check`` pass
- [x] Source-updated for E2E; full Playwright run deferred to QA environment
- [x] No ``Documents/ADMISSION_MODULE_AUDIT_2026-04-27.md`` or ``scripts/plan-loop.ps1`` in PR
- [ ] Reviewer: pull and re-run ``pytest tests/integration/test_admission_version_lock_required.py tests/services/test_admission_service.py::TestOverrideResponseFields tests/services/test_admission_service.py::TestFinalizeResponseFields -v``
- [ ] Post-merge prod smoke: trigger an override + finalize via swagger / curl as admin without ``version`` → expect ``422``; re-run with current ``version`` → expect ``200``

🤖 Generated with [Claude Code](https://claude.com/claude-code)