### PR TITLE
fix(admissions): ADM-013 profile-first FOR UPDATE lock for confirm/override/finalize

### DIFF
--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -1086,28 +1086,106 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         token: str,
     ) -> Optional[models.AdmissionConfirmationToken]:
         """
-        Get confirmation token with pessimistic lock on both token and profile.
-        Used exclusively by verify_and_confirm to prevent race conditions.
+        ADM-013: profile-first 3-step pessimistic lock for the magic-link
+        confirm flow. Earlier shape used a single ``selectinload(profile)
+        + with_for_update()`` query, which only locks the token row —
+        the relationship load runs as a separate SELECT without a lock,
+        so confirm could race override/finalize on the profile row.
+
+        The new shape locks profile first, then token, then re-validates
+        the FK so that confirm, override, and finalize all share the
+        same lock order (profile → token-related work). With identical
+        ordering across the three flows Postgres serialises them
+        cleanly without deadlocks.
+
+        Steps:
+          1. Resolve ``profile_id`` from the token value (no lock; fast
+             bail-out when the token is missing or already purged).
+          2. ``SELECT AdmissionProfile FOR UPDATE`` for that
+             ``profile_id`` (eager-load lead so the service can read
+             ``profile.lead`` without firing a lazy load on the locked
+             instance).
+          3. ``SELECT AdmissionConfirmationToken FOR UPDATE`` by token
+             value.
+          4. Re-validate that ``token.profile_id`` still matches the
+             locked profile. If override invalidated the token while we
+             were waiting on the profile lock — or, in the unlikely
+             event of a token recreated for a different profile — bail.
+
+        Caller-side idempotency (``confirmed_at``, ``locked_at``,
+        ``expires_at``) is preserved untouched: this method only
+        changes when/where locks are acquired, never the validation
+        rules in ``verify_and_confirm``.
 
         Args:
-            token: Token string from URL
+            token: Token string from URL.
 
         Returns:
-            AdmissionConfirmationToken with profile + lead locked, or None
+            ``AdmissionConfirmationToken`` row-locked, with the
+            ``profile`` relationship pre-bound to the *same* locked
+            profile instance (no extra round-trip), or ``None`` if any
+            of the four steps fails.
         """
         from sqlalchemy.orm import selectinload
+        from sqlalchemy.orm.attributes import set_committed_value
 
-        stmt = (
-            select(models.AdmissionConfirmationToken)
-            .where(models.AdmissionConfirmationToken.token == token)
-            .options(
-                selectinload(models.AdmissionConfirmationToken.profile)
-                .selectinload(models.AdmissionProfile.lead)
-            )
+        # Step 1 — Resolve profile_id without locking. If the token
+        # has been deleted (e.g. an override invalidated it before this
+        # request landed), surface as not-found cheaply.
+        pid_stmt = select(models.AdmissionConfirmationToken.profile_id).where(
+            models.AdmissionConfirmationToken.token == token
+        )
+        profile_id = (await self.db.execute(pid_stmt)).scalar_one_or_none()
+        if profile_id is None:
+            return None
+
+        # Step 2 — Lock the profile row first. Eager-load lead so the
+        # service body can read ``profile.lead`` without triggering an
+        # async lazy load on the locked instance.
+        profile_stmt = (
+            select(models.AdmissionProfile)
+            .where(models.AdmissionProfile.id == profile_id)
+            .options(selectinload(models.AdmissionProfile.lead))
             .with_for_update()
         )
-        result = await self.db.execute(stmt)
-        return result.scalar_one_or_none()
+        locked_profile = (
+            await self.db.execute(profile_stmt)
+        ).scalar_one_or_none()
+        if locked_profile is None:
+            # Profile was deleted between resolve and lock (extremely
+            # unlikely under the cascade FK, but defensive).
+            return None
+
+        # Step 3 — Lock the token row. Lock acquired AFTER the profile
+        # lock so all three flows (confirm, override, finalize) share
+        # the same profile→token ordering.
+        token_stmt = (
+            select(models.AdmissionConfirmationToken)
+            .where(models.AdmissionConfirmationToken.token == token)
+            .with_for_update()
+        )
+        token_obj = (await self.db.execute(token_stmt)).scalar_one_or_none()
+        if token_obj is None:
+            # Override/finalize ran during our profile-lock wait and
+            # invalidated the token. Treat as not-found.
+            return None
+
+        # Step 4 — Re-validate FK after acquiring both locks. The
+        # only realistic way this fails is if an override deleted the
+        # token and a brand-new token was issued for a *different*
+        # profile under the same value (impossible with 256-bit
+        # randomness, but bail safely if it ever happens).
+        if token_obj.profile_id != locked_profile.id:
+            return None
+
+        # Bind the locked profile onto the token's ``profile``
+        # relationship without dirtying the session and without an
+        # extra SELECT. Identity map already holds ``locked_profile``
+        # for this PK, so this is the same instance the service will
+        # mutate; the token's lazy-loaded relationship is short-
+        # circuited to point at it.
+        set_committed_value(token_obj, "profile", locked_profile)
+        return token_obj
 
     async def increment_token_attempts(
         self,

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4017,6 +4017,71 @@ async def reset_document(
     return profile, finalize
 
 
+async def _lock_admission_profile_for_write(
+    db: AsyncSession, profile_id: int,
+) -> models.AdmissionProfile:
+    """
+    ADM-013: Acquire the profile-row write lock AND return a freshly
+    loaded ORM instance.
+
+    All three state-changing flows that race on a single
+    AdmissionProfile — magic-link confirm, admin override, admin
+    finalize — must acquire the profile lock FIRST so Postgres can
+    serialise them via row locking instead of falling back on the
+    optimistic version check alone.
+
+    Earlier shape returned ``None`` and only acquired the row lock.
+    That left a hole: a non-router caller that loaded ``profile``
+    *before* waiting on the lock would block on the SELECT, then
+    continue reading ``profile.status`` / ``profile.version`` from
+    the **stale** in-memory ORM instance. The lock would be honoured
+    on disk but the service body would still mutate against pre-lock
+    column values. ``populate_existing=True`` closes that hole by
+    refreshing the column values on the instance already in this
+    session's identity map; the returned object IS the same Python
+    instance the caller passed in (when they share a session) but
+    with fresh column data.
+
+    Eager loads mirror the router dependency chains
+    (``get_admission_for_manager`` / ``get_admission_for_user``) so
+    downstream code (``_populate_response_fields``, lead/officer
+    sync) can still read ``profile.lead.assigned_officer`` and
+    ``profile.assigned_reviewer`` without firing async lazy loads.
+
+    Args:
+        db: AsyncSession holding the transaction.
+        profile_id: Profile ID to lock.
+
+    Returns:
+        The locked + freshly populated ``AdmissionProfile``.
+
+    Raises:
+        ResourceNotFoundError: Profile no longer exists. Defensive —
+            the router dep usually catches this earlier.
+    """
+    from sqlalchemy import select as _select
+    from sqlalchemy.orm import selectinload
+
+    stmt = (
+        _select(models.AdmissionProfile)
+        .where(models.AdmissionProfile.id == profile_id)
+        .options(
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    result = await db.execute(stmt)
+    locked = result.scalar_one_or_none()
+    if locked is None:
+        raise ResourceNotFoundError(
+            f"Admission profile {profile_id} not found"
+        )
+    return locked
+
+
 async def _perform_enrollment_core(
     db: AsyncSession,
     profile_id: int,
@@ -5452,6 +5517,14 @@ async def override_profile(
     """
     from .admission_state_machine import validate_transition
 
+    # ADM-013: explicit profile-first FOR UPDATE lock before reading
+    # ``profile.status`` / ``profile.version`` and before deleting
+    # confirmation tokens. The helper returns a freshly populated ORM
+    # instance via ``populate_existing=True`` so we read post-lock
+    # column values even if the caller passed a stale instance loaded
+    # before the lock was waited on (non-router callers; tests).
+    profile = await _lock_admission_profile_for_write(db, profile.id)
+
     # STATE VALIDATION
     try:
         validate_transition(profile.status, "overridden")
@@ -5738,6 +5811,16 @@ async def finalize_profile(
         ConflictError: Version mismatch or enrollment conflict
     """
     from .admission_state_machine import validate_transition
+
+    # ADM-013: explicit profile-first FOR UPDATE lock before reading
+    # ``profile.status`` / ``profile.version``. Helper rebinds to a
+    # freshly populated ORM instance (``populate_existing=True``) so
+    # version + state validation never read pre-lock stale columns
+    # from a non-router caller. The downstream
+    # ``_perform_enrollment_core`` re-locks defensively as well, so a
+    # version mismatch or state-machine error here is an early bail
+    # under the same row lock contract used by override + confirm.
+    profile = await _lock_admission_profile_for_write(db, profile.id)
 
     # STATE VALIDATION
     try:
@@ -6705,7 +6788,12 @@ async def verify_and_confirm(
     from app.repositories import AdmissionRepository
 
     repo = AdmissionRepository(db)
-    # Pessimistic lock on token + profile to prevent concurrent confirms
+    # ADM-013: ``get_token_for_confirm`` performs a profile-first
+    # 3-step lock (resolve profile_id → SELECT profile FOR UPDATE →
+    # SELECT token FOR UPDATE → re-validate FK) so confirm shares the
+    # same lock order as override/finalize. The token row + the
+    # ``token_obj.profile`` instance are both locked when we proceed
+    # below; mutations land under the same row lock.
     token_obj = await repo.get_token_for_confirm(token_value)
 
     if not token_obj:

--- a/Backend_FastAPI/tests/integration/test_admission_confirm_lock.py
+++ b/Backend_FastAPI/tests/integration/test_admission_confirm_lock.py
@@ -1,0 +1,617 @@
+"""
+ADM-013 — profile-first FOR UPDATE lock contract tests.
+
+Covers the three concurrent flows that race on a single
+AdmissionProfile row:
+
+  - magic-link confirm (verify_and_confirm)
+  - admin override (override_profile)
+  - admin finalize (finalize_profile)
+
+The repository's ``get_token_for_confirm`` was rewritten to lock
+profile FIRST, then token, with FK re-validation. ``override_profile``
+and ``finalize_profile`` issue an explicit profile lock at service
+entry (reentrant w.r.t. the lock the dep acquires for HTTP callers
+but documents the invariant inside the service body).
+
+Tests run two AsyncSession instances through ``asyncio.gather`` so
+the lock contract is exercised end-to-end at the service layer —
+mirroring the proven pattern in
+``tests/integration/test_race_condition_probe.py``. A regression in
+locking shows up as either non-deterministic outcome (e.g. both
+mutations succeed) or a deadlock; both are caught here.
+"""
+from __future__ import annotations
+
+import asyncio
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.repositories import AdmissionRepository
+
+from tests.integration.test_admission_state_transitions import (
+    create_test_lead,
+    create_admission_profile,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+CITIZEN_ID = "001202999999"  # last 4: 9999
+LAST_DIGITS = "9999"
+
+
+async def _seed_approved_profile_with_token(unit_id: int) -> tuple[int, str, int]:
+    """Create lead + approved profile + active confirmation token.
+
+    Returns (profile_id, token_value, version)."""
+    lead_id = await create_test_lead(unit_id)
+    profile = await create_admission_profile(
+        lead_id, status="approved", citizen_id=CITIZEN_ID,
+    )
+    token_value = secrets.token_urlsafe(32)
+
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            session.add(
+                models.AdmissionConfirmationToken(
+                    profile_id=profile.id,
+                    token=token_value,
+                    expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+                )
+            )
+
+    return profile.id, token_value, profile.version
+
+
+async def _fetch_user(user_id: int) -> models.User:
+    async with AsyncSessionLocal() as session:
+        return await session.get(models.User, user_id)
+
+
+async def _final_state(profile_id: int) -> tuple[str, int]:
+    async with AsyncSessionLocal() as session:
+        row = await session.execute(
+            select(
+                models.AdmissionProfile.status,
+                models.AdmissionProfile.version,
+            ).where(models.AdmissionProfile.id == profile_id)
+        )
+        return row.one()
+
+
+async def _token_exists(token_value: str) -> bool:
+    async with AsyncSessionLocal() as session:
+        row = await session.execute(
+            select(models.AdmissionConfirmationToken.id).where(
+                models.AdmissionConfirmationToken.token == token_value
+            )
+        )
+        return row.scalar_one_or_none() is not None
+
+
+# ============================================================================
+# Repository contract
+# ============================================================================
+
+
+class TestRepositoryProfileFirstLock:
+    """``AdmissionRepository.get_token_for_confirm`` returns a token
+    whose ``profile`` attribute is the same instance the repo just
+    locked, not a freshly fetched (unlocked) row."""
+
+    async def test_get_token_for_confirm_binds_locked_profile(
+        self,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        profile_id, token_value, _ = await _seed_approved_profile_with_token(unit_id)
+
+        async with AsyncSessionLocal() as session:
+            repo = AdmissionRepository(session)
+            token_obj = await repo.get_token_for_confirm(token_value)
+
+            assert token_obj is not None, "Repo must return token for valid value"
+            assert token_obj.profile is not None, (
+                "ADM-013: repo must wire profile relationship to the locked "
+                "instance so the service does not re-fetch unlocked"
+            )
+            assert token_obj.profile.id == profile_id
+            await session.rollback()
+
+    async def test_get_token_for_confirm_missing_token_returns_none(
+        self,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        async with AsyncSessionLocal() as session:
+            repo = AdmissionRepository(session)
+            assert await repo.get_token_for_confirm("nonexistent-token") is None
+            await session.rollback()
+
+
+# ============================================================================
+# Concurrency contract — confirm vs confirm
+# ============================================================================
+
+
+class TestDoubleConfirm:
+    """Two concurrent confirms on the same token must serialise. Exactly
+    one wins; the other surfaces ``BadRequest`` (token already used)."""
+
+    async def test_concurrent_confirm_same_token(
+        self,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        from app.services import admission_service
+
+        unit_id = seed_lead_dependencies["unit_id"]
+        profile_id, token_value, _ = await _seed_approved_profile_with_token(unit_id)
+
+        async def run_confirm() -> tuple[str, str]:
+            async with AsyncSessionLocal() as session:
+                try:
+                    profile, _cb = await admission_service.verify_and_confirm(
+                        db=session,
+                        token_value=token_value,
+                        last_digits=LAST_DIGITS,
+                    )
+                    await session.commit()
+                    return ("ok", profile.status)
+                except Exception as e:
+                    await session.rollback()
+                    return ("err", type(e).__name__)
+
+        results = await asyncio.gather(run_confirm(), run_confirm())
+
+        ok = [r for r in results if r[0] == "ok"]
+        err = [r for r in results if r[0] == "err"]
+
+        assert len(ok) == 1, (
+            f"Profile-first lock must let exactly one confirm succeed; "
+            f"got {results}"
+        )
+        assert len(err) == 1, (
+            f"Profile-first lock must let exactly one confirm fail; "
+            f"got {results}"
+        )
+        assert ok[0][1] == "confirmed"
+        # The losing call surfaces "already used" → BadRequest.
+        assert err[0][1] in {"BadRequest"}, (
+            f"Loser must surface BadRequest (token already used); "
+            f"got {err[0][1]}"
+        )
+
+        final_status, _ = await _final_state(profile_id)
+        assert final_status == "confirmed"
+
+
+# ============================================================================
+# Concurrency contract — confirm vs override
+# ============================================================================
+
+
+class TestConfirmVsOverride:
+    """``confirm`` and ``override`` both target the approved state.
+    Whichever locks the profile first wins; the loser sees a state
+    that no longer permits its transition."""
+
+    async def test_confirm_vs_override_produces_one_winner(
+        self,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        from app.services import admission_service
+
+        unit_id = seed_lead_dependencies["unit_id"]
+        profile_id, token_value, version = await _seed_approved_profile_with_token(
+            unit_id
+        )
+        admin = await _fetch_user(admin_user_in_db["id"])
+
+        async def run_confirm() -> tuple[str, str]:
+            async with AsyncSessionLocal() as session:
+                try:
+                    profile, _cb = await admission_service.verify_and_confirm(
+                        db=session,
+                        token_value=token_value,
+                        last_digits=LAST_DIGITS,
+                    )
+                    await session.commit()
+                    return ("ok", profile.status)
+                except Exception as e:
+                    await session.rollback()
+                    return ("err", type(e).__name__)
+
+        async def run_override() -> tuple[str, str]:
+            async with AsyncSessionLocal() as session:
+                try:
+                    # Re-fetch profile inside this session so the
+                    # service operates on its own ORM instance — same
+                    # contract as the HTTP path.
+                    stmt = (
+                        select(models.AdmissionProfile)
+                        .where(models.AdmissionProfile.id == profile_id)
+                        .options(
+                            selectinload(models.AdmissionProfile.lead)
+                        )
+                        .with_for_update()
+                    )
+                    profile = (await session.execute(stmt)).scalar_one()
+                    result, _cb = await admission_service.override_profile(
+                        db=session,
+                        profile=profile,
+                        admin=admin,
+                        data={
+                            "version": version,
+                            "reason": "ADM-013 race override reason",
+                            "bypass_rules": [],
+                        },
+                    )
+                    await session.commit()
+                    return ("ok", result.status)
+                except Exception as e:
+                    await session.rollback()
+                    return ("err", type(e).__name__)
+
+        results = await asyncio.gather(run_confirm(), run_override())
+        ok = [r for r in results if r[0] == "ok"]
+        err = [r for r in results if r[0] == "err"]
+
+        assert len(ok) == 1, (
+            f"Profile lock must let exactly one of confirm+override "
+            f"succeed; got {results}"
+        )
+        assert len(err) == 1, (
+            f"The loser must fail under the same lock; got {results}"
+        )
+        # Winner status is whichever transition fired first.
+        assert ok[0][1] in {"confirmed", "overridden"}, (
+            f"Winner must land on a target state; got {ok[0][1]}"
+        )
+        # Loser surfaces BadRequest (state changed) or ConflictError
+        # (version stale, override reads new version after lock).
+        assert err[0][1] in {"BadRequest", "ConflictError"}, (
+            f"Loser must surface BadRequest/ConflictError; got {err[0][1]}"
+        )
+
+        final_status, final_version = await _final_state(profile_id)
+        assert final_status in {"confirmed", "overridden"}
+        assert final_version == version + 1, (
+            "Profile version must bump exactly once across two "
+            "concurrent state transitions"
+        )
+
+    async def test_override_first_invalidates_token_before_confirm(
+        self,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """Override winner deletes confirmation tokens; the late confirm
+        sees the token gone and surfaces ``ResourceNotFoundError``.
+
+        Lock order is identical (profile→token), so this is a clean
+        serial outcome — no deadlock, no mid-mutation visibility."""
+        from app.services import admission_service
+
+        unit_id = seed_lead_dependencies["unit_id"]
+        profile_id, token_value, version = await _seed_approved_profile_with_token(
+            unit_id
+        )
+        admin = await _fetch_user(admin_user_in_db["id"])
+
+        # Run override first to completion.
+        async with AsyncSessionLocal() as session:
+            stmt = (
+                select(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == profile_id)
+                .options(selectinload(models.AdmissionProfile.lead))
+                .with_for_update()
+            )
+            profile = (await session.execute(stmt)).scalar_one()
+            await admission_service.override_profile(
+                db=session,
+                profile=profile,
+                admin=admin,
+                data={
+                    "version": version,
+                    "reason": "ADM-013 override deletes tokens",
+                    "bypass_rules": [],
+                },
+            )
+            await session.commit()
+
+        # Token must be gone — override invalidates_existing_tokens.
+        assert not await _token_exists(token_value), (
+            "Override must purge active confirmation tokens"
+        )
+
+        # Late confirm sees the token vanished. Repo returns None →
+        # service raises ResourceNotFoundError.
+        async with AsyncSessionLocal() as session:
+            with pytest.raises(Exception) as exc_info:
+                await admission_service.verify_and_confirm(
+                    db=session,
+                    token_value=token_value,
+                    last_digits=LAST_DIGITS,
+                )
+            assert type(exc_info.value).__name__ == "ResourceNotFoundError"
+            await session.rollback()
+
+
+# ============================================================================
+# Concurrency contract — confirm-then-finalize serialise
+# ============================================================================
+
+
+class TestConfirmThenFinalize:
+    """Confirm winner moves profile to ``confirmed``; a follow-up
+    finalize must take the lock cleanly, see version+status updated,
+    and either succeed (with the bumped version) or surface
+    ConflictError (with stale version) — never silently lose state.
+    """
+
+    async def test_finalize_after_confirm_serialises_via_profile_lock(
+        self,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        from app.services import admission_service
+
+        unit_id = seed_lead_dependencies["unit_id"]
+        profile_id, token_value, version = await _seed_approved_profile_with_token(
+            unit_id
+        )
+        admin = await _fetch_user(admin_user_in_db["id"])
+
+        # Phase 1: confirm completes first.
+        async with AsyncSessionLocal() as session:
+            await admission_service.verify_and_confirm(
+                db=session,
+                token_value=token_value,
+                last_digits=LAST_DIGITS,
+            )
+            await session.commit()
+
+        confirmed_status, confirmed_version = await _final_state(profile_id)
+        assert confirmed_status == "confirmed"
+        assert confirmed_version == version + 1
+
+        # Phase 2: finalize with stale version → ConflictError under
+        # profile lock.
+        async with AsyncSessionLocal() as session:
+            stmt = (
+                select(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == profile_id)
+                .options(selectinload(models.AdmissionProfile.lead))
+                .with_for_update()
+            )
+            profile = (await session.execute(stmt)).scalar_one()
+            with pytest.raises(Exception) as exc_info:
+                await admission_service.finalize_profile(
+                    db=session,
+                    profile=profile,
+                    admin=admin,
+                    data={"version": version},  # stale
+                )
+            assert type(exc_info.value).__name__ == "ConflictError"
+            await session.rollback()
+
+        # Phase 3: finalize with fresh version succeeds; profile-row
+        # lock has been released between phases.
+        async with AsyncSessionLocal() as session:
+            stmt = (
+                select(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == profile_id)
+                .options(selectinload(models.AdmissionProfile.lead))
+                .with_for_update()
+            )
+            profile = (await session.execute(stmt)).scalar_one()
+            await admission_service.finalize_profile(
+                db=session,
+                profile=profile,
+                admin=admin,
+                data={"version": confirmed_version},
+            )
+            await session.commit()
+
+        final_status, _ = await _final_state(profile_id)
+        assert final_status == "enrolled"
+
+
+# ============================================================================
+# Stale-instance defense — service refreshes column values under lock
+# ============================================================================
+
+
+class TestStaleInstanceRefresh:
+    """``_lock_admission_profile_for_write`` returns a refreshed ORM
+    instance (``populate_existing=True``). A non-router caller that
+    loaded ``profile`` *before* waiting on the lock — and so has
+    stale ``status``/``version`` in memory — must surface a
+    deterministic error after the lock acquires, not silently mutate
+    against pre-lock columns.
+
+    The setup is contrived (router deps already lock + load), but
+    proves the service body's contract holds for non-router callers
+    too. If a future refactor drops ``populate_existing=True`` or
+    drops the rebinding in override/finalize, these tests fire.
+    """
+
+    async def test_override_refreshes_stale_instance_under_lock(
+        self,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """Session A loads stale profile, commits (closes read txn but
+        keeps the stale instance via ``expire_on_commit=False``).
+        Session B overrides + commits. Session A then calls
+        ``override_profile`` with the same stale instance — the
+        helper's lock+refresh must surface state/version drift, not
+        silently mutate against pre-lock columns.
+
+        The intermediate commit on Session A matters: without it,
+        Session A holds a read transaction open and Session B's
+        ``FOR UPDATE`` would block. We only need the stale ORM
+        snapshot in memory; the txn that loaded it can close."""
+        from app.services import admission_service
+
+        unit_id = seed_lead_dependencies["unit_id"]
+        profile_id, _token, version = await _seed_approved_profile_with_token(
+            unit_id
+        )
+        admin = await _fetch_user(admin_user_in_db["id"])
+
+        async with AsyncSessionLocal() as session_a:
+            # Session A — load profile WITHOUT FOR UPDATE; it sits in
+            # this session's identity map with version=N / status=approved.
+            stale_stmt = (
+                select(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == profile_id)
+                .options(selectinload(models.AdmissionProfile.lead))
+            )
+            stale_profile = (
+                await session_a.execute(stale_stmt)
+            ).scalar_one()
+            assert stale_profile.version == version
+            assert stale_profile.status == "approved"
+
+            # Close the read txn so Session B's FOR UPDATE doesn't
+            # block. expire_on_commit=False keeps stale_profile's
+            # column values addressable.
+            await session_a.commit()
+
+            # Session B — perform a real override + commit. DB row is
+            # now overridden / version+1.
+            async with AsyncSessionLocal() as session_b:
+                lock_stmt = (
+                    select(models.AdmissionProfile)
+                    .where(models.AdmissionProfile.id == profile_id)
+                    .options(selectinload(models.AdmissionProfile.lead))
+                    .with_for_update()
+                )
+                profile_b = (await session_b.execute(lock_stmt)).scalar_one()
+                await admission_service.override_profile(
+                    db=session_b,
+                    profile=profile_b,
+                    admin=admin,
+                    data={
+                        "version": version,
+                        "reason": "ADM-013 stale-instance setup",
+                        "bypass_rules": [],
+                    },
+                )
+                await session_b.commit()
+
+            # Session A — call service with the stale instance. The
+            # helper acquires the lock + repopulates columns; service
+            # then sees ``status="overridden"`` and raises BadRequest
+            # (state-machine: approved→overridden is the only legal
+            # transition; overridden→overridden is rejected).
+            with pytest.raises(Exception) as exc_info:
+                await admission_service.override_profile(
+                    db=session_a,
+                    profile=stale_profile,
+                    admin=admin,
+                    data={
+                        "version": version,  # stale
+                        "reason": "ADM-013 stale should be rejected",
+                        "bypass_rules": [],
+                    },
+                )
+            assert type(exc_info.value).__name__ in {
+                "BadRequest",
+                "ConflictError",
+            }, (
+                f"Service must reject stale-instance override after "
+                f"lock+refresh; got {type(exc_info.value).__name__}"
+            )
+            await session_a.rollback()
+
+        # Final DB state must be the session-B winner only — version
+        # bumps exactly once across both attempted overrides.
+        final_status, final_version = await _final_state(profile_id)
+        assert final_status == "overridden"
+        assert final_version == version + 1, (
+            "Stale-instance attempt must NOT mutate the row a second time"
+        )
+
+    async def test_finalize_refreshes_stale_instance_under_lock(
+        self,
+        admin_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """Session A loads stale approved profile, commits to release
+        the read txn (stale ORM snapshot survives via
+        ``expire_on_commit=False``). Session B magic-link confirms +
+        commits. Session A calls ``finalize_profile`` with the stale
+        version — helper's lock+refresh must surface the version
+        drift as ConflictError, not silently mutate."""
+        from app.services import admission_service
+
+        unit_id = seed_lead_dependencies["unit_id"]
+        profile_id, token_value, version = await _seed_approved_profile_with_token(
+            unit_id
+        )
+        admin = await _fetch_user(admin_user_in_db["id"])
+
+        async with AsyncSessionLocal() as session_a:
+            stale_stmt = (
+                select(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == profile_id)
+                .options(selectinload(models.AdmissionProfile.lead))
+            )
+            stale_profile = (
+                await session_a.execute(stale_stmt)
+            ).scalar_one()
+
+            # Release the read txn so Session B's FOR UPDATE in the
+            # confirm path doesn't block. The stale ORM instance keeps
+            # its column values (expire_on_commit=False).
+            await session_a.commit()
+
+            # Session B — magic-link confirm completes. DB row is now
+            # version+1 / status="confirmed"; stale_profile in
+            # memory still reads version=N / status="approved".
+            async with AsyncSessionLocal() as session_b:
+                await admission_service.verify_and_confirm(
+                    db=session_b,
+                    token_value=token_value,
+                    last_digits=LAST_DIGITS,
+                )
+                await session_b.commit()
+
+            # Session A — finalize with stale version against an
+            # already-confirmed profile. Helper repopulates → service
+            # sees version+1 (stale claim of N fails) and raises
+            # ConflictError.
+            with pytest.raises(Exception) as exc_info:
+                await admission_service.finalize_profile(
+                    db=session_a,
+                    profile=stale_profile,
+                    admin=admin,
+                    data={"version": version},  # stale
+                )
+            assert type(exc_info.value).__name__ == "ConflictError", (
+                f"Stale finalize must surface ConflictError after "
+                f"lock+refresh; got {type(exc_info.value).__name__}"
+            )
+            await session_a.rollback()
+
+        final_status, final_version = await _final_state(profile_id)
+        assert final_status == "confirmed", (
+            "Stale finalize must NOT have advanced status to enrolled"
+        )
+        assert final_version == version + 1, (
+            "Only the session-B confirm bumps version; stale finalize "
+            "must not write"
+        )


### PR DESCRIPTION
## Summary
Closes ADM-013 from `Documents/ADMISSION_MODULE_AUDIT_2026-04-27.md`.

Pin all three flows that race on a single `AdmissionProfile` row — magic-link `confirm`, admin `override`, admin `finalize` — to the same lock order: profile **first**, then token-related work. Eliminates the gap where the previous comment claimed "lock token + profile" but `selectinload` ran the profile load as a separate, unlocked SELECT.

## What changed

**Repository — `get_token_for_confirm` (4-step profile-first lock):**
1. Resolve `profile_id` from token value (no lock; cheap bail-out).
2. `SELECT AdmissionProfile FOR UPDATE` by `profile_id` (eager-load lead).
3. `SELECT AdmissionConfirmationToken FOR UPDATE` by token value.
4. Re-validate `token.profile_id == locked_profile.id`.

The locked profile is bound onto `token.profile` via `set_committed_value` so the service does not refetch unlocked.

**Service — `_lock_admission_profile_for_write` helper:**
Returns a freshly populated `AdmissionProfile` via `populate_existing=True` — eager-loads `lead.assigned_officer` + `assigned_reviewer` to mirror the router-dep load chain. `override_profile` and `finalize_profile` rebind `profile = await _lock_admission_profile_for_write(...)` before state/version validation, so a non-router caller passing a stale ORM instance reads post-lock columns instead of mutating against pre-lock state.

**No behavior change for happy paths:**
- Token idempotency (`confirmed_at`, `locked_at`, `expires_at`, `attempt_count`) preserved.
- `ConfirmRequest` schema untouched (lives in ADM-015 work).
- HTTP response shape unchanged.

## Tests

`tests/integration/test_admission_confirm_lock.py` — 8 cases, all PASS:

- `TestRepositoryProfileFirstLock` (2): repo binds locked profile onto token; missing token → None.
- `TestDoubleConfirm` (1): two concurrent confirms → exactly one wins, loser raises BadRequest "already used".
- `TestConfirmVsOverride` (2):
  - confirm + override race → exactly one mutation lands; loser raises BadRequest/ConflictError; version bumps once.
  - override-first deletes tokens → late confirm → ResourceNotFoundError.
- `TestConfirmThenFinalize` (1): finalize with stale version → ConflictError; finalize with fresh version → enrolled.
- `TestStaleInstanceRefresh` (2): non-router caller passes pre-lock stale instance to override / finalize. After helper's lock+refresh, service surfaces BadRequest/ConflictError instead of silent mutation; DB row only mutates once across both attempted writes.

Mirrors `test_race_condition_probe.py` pattern — two `AsyncSessionLocal()` via `asyncio.gather`. A regression in locking shows up as non-deterministic outcome, never as silent double-mutation.

**Regression suites verified locally:**
- `test_admission_state_transitions.py` (incl. 13 confirm cases): 13/13 PASS.
- `test_admission_version_lock_required.py + test_admission_override_audit.py + test_race_condition_probe.py`: 15/15 PASS.
- `TestOverrideResponseFields + TestFinalizeResponseFields`: 2/2 PASS.

## Lock order (no deadlock)

| Flow | Step 1 | Step 2 |
|------|--------|--------|
| confirm | profile FOR UPDATE | token FOR UPDATE |
| override | profile FOR UPDATE (dep + helper) | DELETE FROM token (per-row lock) |
| finalize | profile FOR UPDATE (dep + helper) | (no token op) |

All three acquire profile first → Postgres serialises cleanly, no cycle possible.

## Test plan
- [x] ADM-013 concurrency suite 8/8 PASS locally
- [x] Regression on adjacent admission test suites (15/15 + 13/13 + 2/2)
- [ ] CI green
- [ ] Smoke verify on staging/prod after merge: confirm via magic link still works for an approved profile; concurrent override during confirm flow returns deterministic 4xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)