### PR TITLE
feat(zalo-bot): audit trail + chat_id displacement notification + V-1/V-2 follow-ups

### DIFF
--- a/Backend_FastAPI/alembic/versions/zbaudit001_backfill_zalo_bot_link_audit_rows.py
+++ b/Backend_FastAPI/alembic/versions/zbaudit001_backfill_zalo_bot_link_audit_rows.py
@@ -26,12 +26,17 @@ Prod state audit (verified 2026-04-28 via DB query):
 
 Idempotency
 -----------
-``INSERT ... SELECT ... WHERE NOT EXISTS`` over the same
-(entity_type, entity_id, source='backfill') triple, so re-running the
-migration (or running on a DB where some rows were already backfilled)
-inserts nothing for already-handled rows. Safe to re-apply.
+``INSERT ... SELECT ... WHERE NOT EXISTS`` keyed on
+(entity_type, entity_id, action='created') — ANY source. The stricter
+key matters for the downgrade-then-reupgrade scenario: if the live
+service has already written a real ``action='created'`` row for the
+link (source='zalo_bot_webhook' or 'api') BEFORE this migration is
+re-applied, a predicate scoped to ``source='backfill'`` would still
+fire and double the audit row. Keying on action='created' regardless
+of source means the live row blocks the backfill — which is what
+operators actually want (the live row carries truth).
 
-Downgrade deletes only the rows tagged ``source='backfill'`` for entity
+Downgrade deletes only rows tagged ``source='backfill'`` for entity
 type ``StaffZaloBotLink``. Audit rows written by the live service
 (``source='zalo_bot_webhook'`` or ``source='api'``) are NOT touched —
 those represent real operator actions and must persist across
@@ -78,10 +83,15 @@ _BACKFILL_SQL = """
     FROM staff_zalo_bot_link l
     WHERE l.is_active = true
       AND NOT EXISTS (
+          -- Block on ANY existing 'created' row, regardless of source.
+          -- A live row written by zalo_bot_link_service (source =
+          -- 'zalo_bot_webhook' / 'api') after a previous downgrade
+          -- represents truth and must not be duplicated by a synthetic
+          -- backfill on re-upgrade.
           SELECT 1 FROM entity_audit_log a
           WHERE a.entity_type = 'StaffZaloBotLink'
             AND a.entity_id = l.id
-            AND a.source = 'backfill'
+            AND a.action = 'created'
       );
 """
 

--- a/Backend_FastAPI/alembic/versions/zbaudit001_backfill_zalo_bot_link_audit_rows.py
+++ b/Backend_FastAPI/alembic/versions/zbaudit001_backfill_zalo_bot_link_audit_rows.py
@@ -1,0 +1,101 @@
+"""Backfill entity_audit_log rows for existing staff_zalo_bot_link.
+
+Revision ID: zbaudit001
+Revises: adm003path001
+Create Date: 2026-04-28
+
+Why
+---
+``zalo_bot_link_service`` started writing ``entity_audit_log`` rows for
+link/unlink/displacement/preference-flip ops in this PR. Prior to this
+change, no audit rows existed for the 6 active staff bot links already
+on prod (1 admin + 5 officer, all linked 2026-04-27/28). Without
+backfill, the audit timeline begins arbitrarily at "first action after
+this migration" — compliance/forensic queries would show those 6 links
+as having no creation provenance.
+
+This migration writes 1 ``entity_audit_log`` row per active link with
+``action="created"`` and ``source="backfill"``. The original link
+timestamp is in ``staff_zalo_bot_link.linked_at``; we retain it via
+``new_value`` JSONB so downstream tooling can reconcile.
+
+Prod state audit (verified 2026-04-28 via DB query):
+- ``staff_zalo_bot_link``: 6 rows, all ``is_active=true``
+- ``entity_audit_log`` filtered by ``entity_type='StaffZaloBotLink'``: 0 rows
+- After upgrade: should show exactly 6 rows with ``source='backfill'``.
+
+Idempotency
+-----------
+``INSERT ... SELECT ... WHERE NOT EXISTS`` over the same
+(entity_type, entity_id, source='backfill') triple, so re-running the
+migration (or running on a DB where some rows were already backfilled)
+inserts nothing for already-handled rows. Safe to re-apply.
+
+Downgrade deletes only the rows tagged ``source='backfill'`` for entity
+type ``StaffZaloBotLink``. Audit rows written by the live service
+(``source='zalo_bot_webhook'`` or ``source='api'``) are NOT touched —
+those represent real operator actions and must persist across
+migration roll-back.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "zbaudit001"
+down_revision: Union[str, None] = "adm003path001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_BACKFILL_SQL = """
+    INSERT INTO entity_audit_log (
+        entity_type, entity_id, action,
+        actor_user_id, field_name,
+        old_value, new_value, changes,
+        reason, source, ip_address, user_agent,
+        created_at
+    )
+    SELECT
+        'StaffZaloBotLink',
+        l.id,
+        'created',
+        l.user_id,
+        NULL,
+        NULL,
+        json_build_object(
+            'user_id', l.user_id,
+            'is_active', l.is_active,
+            'linked_at', l.linked_at,
+            'note', 'backfilled — actual link predates audit instrumentation'
+        )::jsonb,
+        NULL,
+        'backfilled 2026-04-28; original linked_at preserved in new_value',
+        'backfill',
+        NULL,
+        NULL,
+        l.linked_at
+    FROM staff_zalo_bot_link l
+    WHERE l.is_active = true
+      AND NOT EXISTS (
+          SELECT 1 FROM entity_audit_log a
+          WHERE a.entity_type = 'StaffZaloBotLink'
+            AND a.entity_id = l.id
+            AND a.source = 'backfill'
+      );
+"""
+
+
+_DOWNGRADE_SQL = """
+    DELETE FROM entity_audit_log
+    WHERE entity_type = 'StaffZaloBotLink'
+      AND source = 'backfill';
+"""
+
+
+def upgrade() -> None:
+    op.execute(_BACKFILL_SQL)
+
+
+def downgrade() -> None:
+    op.execute(_DOWNGRADE_SQL)

--- a/Backend_FastAPI/app/core/event_catalog.py
+++ b/Backend_FastAPI/app/core/event_catalog.py
@@ -1276,7 +1276,17 @@ _SYSTEM_EVENTS: tuple = (
         # nếu muốn cảnh báo mạnh hơn.
         default_channels=("browser",),
         priority=10,
-        dedup_key_template="security:${user_id}:zalo_bot_link_displaced:${displaced_by_user_id}",
+        # Dedup key includes chat_id_prefix (and not just the user pair)
+        # because a single (displaced_user, new_user) pair can legitimately
+        # produce multiple events: A links chat_X → B displaces A → A
+        # re-links chat_Y → B displaces A again. Without chat_id_prefix
+        # the second notification would be suppressed by the 5-minute
+        # cooldown (NOTIFICATION_COOLDOWN_SECONDS) — leaving A unaware
+        # of the second hijack.
+        dedup_key_template=(
+            "security:${user_id}:zalo_bot_link_displaced:"
+            "${displaced_by_user_id}:${chat_id_prefix}"
+        ),
         link_strategy="/settings/notifications",
         # Sensitive: contains targeted recipient + potential security event
         privacy="sensitive",

--- a/Backend_FastAPI/app/core/event_catalog.py
+++ b/Backend_FastAPI/app/core/event_catalog.py
@@ -1254,6 +1254,33 @@ _SYSTEM_EVENTS: tuple = (
         # Sensitive: contains lead/applicant/user/fee PII or targeted recipient
         privacy="sensitive",
     ),
+    EventDefinition(
+        event=SystemEvents.ZALO_BOT_LINK_DISPLACED,
+        category="security",
+        display_name="Liên kết Zalo Bot bị thay thế",
+        description=(
+            "Khi chat_id Zalo Bot của bạn được liên kết bởi một tài khoản "
+            "QLTS khác — bạn sẽ ngừng nhận thông báo qua Zalo cho đến khi "
+            "thiết lập lại liên kết."
+        ),
+        variables=(
+            _var("user_id", "integer", "ID user bị displace (recipient)"),
+            _var("displaced_by_user_id", "integer", "ID user mới chiếm liên kết"),
+            _var("chat_id_prefix", "string", "Prefix chat_id (đã mask)", False),
+            _var("actor_id", "integer", "ID user mới (actor)"),
+        ),
+        default_resolver="specific_users",
+        allowed_resolvers=("specific_users",),
+        # Browser-only by default per design decision (minimal blast).
+        # Admin có thể thêm channel email qua /admin/notification-rules
+        # nếu muốn cảnh báo mạnh hơn.
+        default_channels=("browser",),
+        priority=10,
+        dedup_key_template="security:${user_id}:zalo_bot_link_displaced:${displaced_by_user_id}",
+        link_strategy="/settings/notifications",
+        # Sensitive: contains targeted recipient + potential security event
+        privacy="sensitive",
+    ),
 )
 
 # -------------------------------------------------------------------

--- a/Backend_FastAPI/app/core/event_groups.py
+++ b/Backend_FastAPI/app/core/event_groups.py
@@ -130,6 +130,7 @@ EVENT_GROUP_MAPPING: Dict[SystemEvents, NotificationEventGroup] = {
 
     # Security events
     SystemEvents.SUSPICIOUS_LOGIN: NotificationEventGroup.SECURITY,
+    SystemEvents.ZALO_BOT_LINK_DISPLACED: NotificationEventGroup.SECURITY,
 
     # System operational events
     SystemEvents.HOLIDAY_CALENDAR_INCOMPLETE: NotificationEventGroup.SYSTEM,

--- a/Backend_FastAPI/app/core/events.py
+++ b/Backend_FastAPI/app/core/events.py
@@ -1106,6 +1106,26 @@ class SystemEvents(str, Enum):
     Recipients: The user who logged in (for awareness)
     """
 
+    ZALO_BOT_LINK_DISPLACED = "zalo_bot_link_displaced"
+    """
+    Triggered when an existing active Zalo Bot link is taken over by another
+    user. Happens in ``zalo_bot_link_service.verify_and_link`` when the
+    incoming chat_id was previously bound to a different staff user — the
+    old binding is marked inactive (and ``zalo_bot_enabled`` flipped off)
+    so the new link can be enforced by the partial unique index. The
+    displaced user receives this event as a security awareness signal.
+
+    Payload Schema:
+        {
+            "user_id": int,               # Required: displaced user (recipient)
+            "displaced_by_user_id": int,  # Required: new linker (actor)
+            "chat_id_prefix": str,        # First 4 + last 2 chars of chat_id
+            "actor_id": int               # Same as displaced_by_user_id
+        }
+
+    Recipients: The displaced user (resolver = specific_users on user_id).
+    """
+
 
 # =============================================================================
 # EVENT DISPATCHER PATTERN

--- a/Backend_FastAPI/app/core/notification_seed_defaults.py
+++ b/Backend_FastAPI/app/core/notification_seed_defaults.py
@@ -421,6 +421,16 @@ NOTIFICATION_SEED_DEFAULTS: Dict[SystemEvents, Dict[str, Any]] = {
         "notification_type": "warning",
         "recipient_config": {"resolver_type": "specific_users", "params": {}},
     },
+    SystemEvents.ZALO_BOT_LINK_DISPLACED: {
+        "title_template": "Liên kết Zalo Bot bị thay thế",
+        "message_template": (
+            "Liên kết Zalo Bot của bạn vừa bị thay thế bởi một tài khoản "
+            "khác (chat_id ${chat_id_prefix}). Bạn sẽ ngừng nhận thông báo "
+            "qua Zalo cho đến khi thiết lập lại liên kết."
+        ),
+        "notification_type": "warning",
+        "recipient_config": {"resolver_type": "specific_users", "params": {}},
+    },
     SystemEvents.SYSTEM_ALERT: {
         "title_template": "[${severity}] System Alert",
         "message_template": "${message}",

--- a/Backend_FastAPI/app/routers/zalo_bot_link.py
+++ b/Backend_FastAPI/app/routers/zalo_bot_link.py
@@ -118,7 +118,7 @@ async def unlink_zalo_bot(
     """
     from app.services import zalo_bot_link_service
 
-    ok, message = await zalo_bot_link_service.unlink(db, current_user.id)
+    ok, message, _ = await zalo_bot_link_service.unlink(db, current_user.id)
     if ok:
         await db.commit()
     else:

--- a/Backend_FastAPI/app/routers/zalo_bot_webhooks.py
+++ b/Backend_FastAPI/app/routers/zalo_bot_webhooks.py
@@ -233,14 +233,16 @@ async def zalo_bot_webhook(
             )
             return {"status": "ok", "mode": "bad_format"}
 
+        post_commit_cb = None
         try:
-            ok, reply = await zalo_bot_link_service.verify_and_link(
+            ok, reply, post_commit_cb = await zalo_bot_link_service.verify_and_link(
                 db, candidate, chat_id, display_name or None
             )
             if ok:
                 await db.commit()
             else:
                 await db.rollback()
+                post_commit_cb = None  # Don't fan out on failed verify.
         except Exception:
             await db.rollback()
             log.exception(
@@ -251,13 +253,26 @@ async def zalo_bot_webhook(
             return {"status": "ok", "mode": "service_error"}
 
         await _send_reply(chat_id, reply)
+        if post_commit_cb is not None:
+            # Displacement happened — fan out the security notification
+            # AFTER commit so the displaced user sees it (browser only by
+            # default per ZALO_BOT_LINK_DISPLACED catalog entry).
+            try:
+                await post_commit_cb()
+            except Exception:
+                # Never fail the webhook because of a notification fan-out
+                # issue — the link itself is already committed.
+                log.exception(
+                    "zalo_bot displacement post_commit failed",
+                    chat_id_prefix=_mask_chat_id(chat_id),
+                )
         return {"status": "ok", "mode": "verify_and_link", "linked": ok}
 
     # ---------------- /huylienket ----------------
     # Same correction as /lienket above. Accept legacy "/huylienkiet" too.
     if text_lower == "/huylienket" or text_lower == "/huylienkiet":
         try:
-            ok, reply = await zalo_bot_link_service.unlink_by_chat_id(db, chat_id)
+            ok, reply, _ = await zalo_bot_link_service.unlink_by_chat_id(db, chat_id)
             if ok:
                 await db.commit()
             else:

--- a/Backend_FastAPI/app/services/zalo_bot_link_service.py
+++ b/Backend_FastAPI/app/services/zalo_bot_link_service.py
@@ -106,18 +106,43 @@ async def generate_link_code(
     raise BusinessRuleViolation("Không tạo được mã liên kết. Vui lòng thử lại.")
 
 
+def _audit_chat_id_prefix(chat_id: str) -> str:
+    """Mask chat_id for audit/log payload — first 4 + last 2 chars.
+
+    Tighter than the webhook-side ``_mask_chat_id`` (which exposes 8 chars)
+    so audit history doesn't leak more than necessary while still letting
+    operators correlate rows.
+    """
+    if not chat_id:
+        return ""
+    if len(chat_id) <= 6:
+        return chat_id[:2] + "***"
+    return chat_id[:4] + "***" + chat_id[-2:]
+
+
 async def verify_and_link(
     db: AsyncSession,
     code: str,
     chat_id: str,
     display_name: Optional[str] = None,
-) -> Tuple[bool, str]:
-    """Consume a link code and bind ``chat_id`` to the resolved user."""
+    *,
+    source: str = "zalo_bot_webhook",
+) -> Tuple[bool, str, Optional[Callable]]:
+    """Consume a link code and bind ``chat_id`` to the resolved user.
+
+    Returns ``(ok, reply_text, post_commit)``. ``post_commit`` is non-None
+    only when an existing chat_id binding was displaced — caller (webhook
+    router) MUST await it after ``db.commit()`` so the displaced user
+    receives a ``ZALO_BOT_LINK_DISPLACED`` notification. Audit rows are
+    written inline (same txn as the link write) — caller does not need
+    to await anything for audit.
+    """
     from app.database import safe_redis_getdel
+    from app.services import audit_service
 
     user_id_str = await safe_redis_getdel(_code_key(code.upper()))
     if not user_id_str:
-        return False, "Mã liên kết không hợp lệ hoặc đã hết hạn."
+        return False, "Mã liên kết không hợp lệ hoặc đã hết hạn.", None
 
     user_id = int(user_id_str)
     repo = StaffZaloBotLinkRepository(db)
@@ -126,37 +151,140 @@ async def verify_and_link(
     # Without this an attacker could keep one chat_id wired to a victim
     # by linking it first, then abandoning the binding.
     existing_chat = await repo.get_active_by_chat_id(chat_id)
+    displaced_user_id: Optional[int] = None
+    displaced_link_id: Optional[int] = None
     if existing_chat and existing_chat.user_id != user_id:
+        displaced_user_id = existing_chat.user_id
+        displaced_link_id = existing_chat.id
         existing_chat.is_active = False
         await db.flush()
+        # Flip displaced user's master toggle off so downstream dispatch
+        # doesn't treat them as bot-eligible (active link gone, but pref
+        # column would otherwise stay True → confusing orphan state).
+        await _sync_preference(
+            db, displaced_user_id, enabled=False, actor_user_id=user_id
+        )
+        # Audit: the displaced row stops being the active binding.
+        await audit_service.log_audit(
+            db,
+            entity_type="StaffZaloBotLink",
+            entity_id=displaced_link_id,
+            action="chat_id_reassigned",
+            actor_user_id=user_id,
+            old_value={"is_active": True, "user_id": displaced_user_id},
+            new_value={"is_active": False},
+            reason=f"chat_id reassigned to user_id={user_id}",
+            source=source,
+        )
 
-    await repo.create_or_reactivate(user_id, chat_id, display_name)
-    await _sync_preference(db, user_id, enabled=True)
+    link = await repo.create_or_reactivate(user_id, chat_id, display_name)
+    await _sync_preference(db, user_id, enabled=True, actor_user_id=user_id)
+
+    # Audit the link create/reactivate. ``action`` is "created" whether
+    # this is a brand-new row or a reactivation of an inactive row — the
+    # audit log captures intent ("user is now linked") not row physics.
+    await audit_service.log_created(
+        db,
+        entity_type="StaffZaloBotLink",
+        entity_id=link.id,
+        actor_user_id=user_id,
+        new_values={
+            "user_id": user_id,
+            "chat_id_prefix": _audit_chat_id_prefix(chat_id),
+            "display_name": display_name,
+            "is_active": True,
+        },
+        source=source,
+    )
 
     log.info(
         "Zalo Bot linked",
         user_id=user_id,
-        chat_id_prefix=chat_id[:8] + "***" if chat_id else "",
+        chat_id_prefix=_audit_chat_id_prefix(chat_id),
+        displaced_user_id=displaced_user_id,
     )
-    return True, "Liên kết thành công! Bạn sẽ nhận thông báo từ QLTS qua Zalo."
+
+    post_commit: Optional[Callable] = None
+    if displaced_user_id is not None:
+        # Build a closure that dispatches the displacement notification
+        # AFTER the router commits — safe_dispatch must NEVER fire while
+        # the link write is still in-flight (see MASTER_ARCHITECTURE Part 7).
+        from app.core.events import SystemEvents
+        from app.services.notification_dispatcher import safe_dispatch
+
+        _displaced_user_id = displaced_user_id
+        _new_user_id = user_id
+        _chat_prefix = _audit_chat_id_prefix(chat_id)
+
+        async def _post_commit() -> None:
+            await safe_dispatch(
+                db=db,
+                event=SystemEvents.ZALO_BOT_LINK_DISPLACED,
+                payload={
+                    "user_id": _displaced_user_id,
+                    "displaced_by_user_id": _new_user_id,
+                    "chat_id_prefix": _chat_prefix,
+                    "actor_id": _new_user_id,
+                },
+            )
+
+        post_commit = _post_commit
+
+    return (
+        True,
+        "Liên kết thành công! Bạn sẽ nhận thông báo từ QLTS qua Zalo.",
+        post_commit,
+    )
 
 
-async def unlink(db: AsyncSession, user_id: int) -> Tuple[bool, str]:
-    """Mark the link inactive and flip per-channel preference off."""
+async def unlink(
+    db: AsyncSession,
+    user_id: int,
+    *,
+    source: str = "api",
+) -> Tuple[bool, str, Optional[Callable]]:
+    """Mark the link inactive and flip per-channel preference off.
+
+    Returns ``(ok, reply_text, post_commit)``. ``post_commit`` is always
+    None for unlink (no fan-out); kept for signature parity with
+    ``verify_and_link``.
+    """
+    from app.services import audit_service
+
     repo = StaffZaloBotLinkRepository(db)
+    link = await repo.get_by_user_id(user_id)
+    if not link or not link.is_active:
+        return False, "Tài khoản chưa được liên kết.", None
+
+    link_id = link.id
     found = await repo.deactivate_by_user_id(user_id)
     if not found:
-        return False, "Tài khoản chưa được liên kết."
-    await _sync_preference(db, user_id, enabled=False)
-    return True, "Đã huỷ liên kết."
+        return False, "Tài khoản chưa được liên kết.", None
+
+    await _sync_preference(db, user_id, enabled=False, actor_user_id=user_id)
+
+    await audit_service.log_deleted(
+        db,
+        entity_type="StaffZaloBotLink",
+        entity_id=link_id,
+        actor_user_id=user_id,
+        old_values={"user_id": user_id, "is_active": True},
+        reason="user-initiated unlink",
+        source=source,
+    )
+
+    return True, "Đã huỷ liên kết.", None
 
 
-async def unlink_by_chat_id(db: AsyncSession, chat_id: str) -> Tuple[bool, str]:
+async def unlink_by_chat_id(
+    db: AsyncSession, chat_id: str
+) -> Tuple[bool, str, Optional[Callable]]:
+    """Unlink whoever owns ``chat_id`` (called from webhook ``/huylienket``)."""
     repo = StaffZaloBotLinkRepository(db)
     link = await repo.get_active_by_chat_id(chat_id)
     if not link:
-        return False, "Tài khoản chưa được liên kết."
-    return await unlink(db, link.user_id)
+        return False, "Tài khoản chưa được liên kết.", None
+    return await unlink(db, link.user_id, source="zalo_bot_webhook")
 
 
 async def get_link_status(db: AsyncSession, user_id: int) -> Optional[dict]:
@@ -172,20 +300,46 @@ async def get_link_status(db: AsyncSession, user_id: int) -> Optional[dict]:
 
 
 async def _sync_preference(
-    db: AsyncSession, user_id: int, enabled: bool
+    db: AsyncSession,
+    user_id: int,
+    enabled: bool,
+    *,
+    actor_user_id: Optional[int] = None,
 ) -> None:
-    """Flip ``zalo_bot_enabled`` on the user's preference row.
+    """Flip ``zalo_bot_enabled`` on the user's preference row + audit.
 
     The column lands in v5 Step 11; once present, this MUST persist or
     the link operation is a lie (UI shows linked, dispatcher Gate A
     still blocks). DB errors here are surfaced — the router commits
     after this returns, so a flush failure rolls back the whole link.
+
+    Audit row is written only when the value actually changes; toggling
+    the column to its current value is a no-op for both DB and audit.
     """
     from app.repositories.notification_preference_repository import (
         NotificationPreferenceRepository,
     )
+    from app.services import audit_service
 
     repo = NotificationPreferenceRepository(db)
     pref = await repo.get_or_create(user_id)
+    old_value = bool(pref.zalo_bot_enabled)
+    if old_value == enabled:
+        return  # No-op — nothing to flip, nothing to audit.
     pref.zalo_bot_enabled = enabled
     await db.flush()
+
+    await audit_service.log_field_change(
+        db,
+        entity_type="NotificationPreference",
+        entity_id=pref.id,
+        field_name="zalo_bot_enabled",
+        old_value=old_value,
+        new_value=enabled,
+        actor_user_id=actor_user_id if actor_user_id is not None else user_id,
+        reason=(
+            "synced from staff_zalo_bot_link link/unlink/displacement "
+            "(zalo_bot_link_service._sync_preference)"
+        ),
+        source="zalo_bot_link_service",
+    )

--- a/Backend_FastAPI/app/services/zalo_bot_link_service.py
+++ b/Backend_FastAPI/app/services/zalo_bot_link_service.py
@@ -299,6 +299,43 @@ async def get_link_status(db: AsyncSession, user_id: int) -> Optional[dict]:
     }
 
 
+async def _get_or_create_pref_safe(db: AsyncSession, user_id: int):
+    """Concurrency-safe wrapper around ``NotificationPreferenceRepository.get_or_create``.
+
+    The base ``get_or_create`` is read-then-insert with no upsert, so two
+    concurrent requests for the same user that both observe "no row"
+    will both INSERT and the second hits the unique-on-user_id constraint
+    with ``IntegrityError``. Realistic trigger paths for zalo bot:
+    user opens 2 browser tabs and clicks "Tạo mã" twice, or sends
+    ``/lienket`` from two chat_ids in quick succession.
+
+    We wrap the call in a SAVEPOINT so a constraint violation rolls back
+    only the failed INSERT (not the link write that called us). On
+    rollback we re-fetch — the winning concurrent INSERT must have
+    committed by then. If re-fetch still returns None, the failure was
+    not a race and the original ``IntegrityError`` is re-raised so the
+    router can rollback + return 5xx. Pre-existing repo behavior is
+    unchanged for non-racing callers.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    from app.repositories.notification_preference_repository import (
+        NotificationPreferenceRepository,
+    )
+
+    repo = NotificationPreferenceRepository(db)
+    try:
+        async with db.begin_nested():
+            return await repo.get_or_create(user_id)
+    except IntegrityError:
+        # Race: another transaction inserted the row between our SELECT
+        # and INSERT. Re-fetch — the winning row is now visible.
+        existing = await repo.get_by_user_id(user_id)
+        if existing is None:
+            raise
+        return existing
+
+
 async def _sync_preference(
     db: AsyncSession,
     user_id: int,
@@ -316,13 +353,9 @@ async def _sync_preference(
     Audit row is written only when the value actually changes; toggling
     the column to its current value is a no-op for both DB and audit.
     """
-    from app.repositories.notification_preference_repository import (
-        NotificationPreferenceRepository,
-    )
     from app.services import audit_service
 
-    repo = NotificationPreferenceRepository(db)
-    pref = await repo.get_or_create(user_id)
+    pref = await _get_or_create_pref_safe(db, user_id)
     old_value = bool(pref.zalo_bot_enabled)
     if old_value == enabled:
         return  # No-op — nothing to flip, nothing to audit.

--- a/Backend_FastAPI/tests/api/test_zalo_bot_link_api.py
+++ b/Backend_FastAPI/tests/api/test_zalo_bot_link_api.py
@@ -143,7 +143,7 @@ class TestUnlinkEndpoint:
     ):
         with patch(
             "app.services.zalo_bot_link_service.unlink",
-            new=AsyncMock(return_value=(True, "Đã huỷ liên kết.")),
+            new=AsyncMock(return_value=(True, "Đã huỷ liên kết.", None)),
         ) as svc:
             resp = await client.post(
                 "/api/zalo-bot/unlink", headers=officer_token_headers
@@ -159,7 +159,7 @@ class TestUnlinkEndpoint:
     ):
         with patch(
             "app.services.zalo_bot_link_service.unlink",
-            new=AsyncMock(return_value=(False, "Tài khoản chưa được liên kết.")),
+            new=AsyncMock(return_value=(False, "Tài khoản chưa được liên kết.", None)),
         ):
             resp = await client.post(
                 "/api/zalo-bot/unlink", headers=officer_token_headers

--- a/Backend_FastAPI/tests/api/test_zalo_bot_webhooks.py
+++ b/Backend_FastAPI/tests/api/test_zalo_bot_webhooks.py
@@ -162,7 +162,7 @@ class TestPayloadShape:
         ignored every real message — repro of 2026-04-27 smoke regression.
         """
         verify, _ = link_service_mock
-        verify.return_value = (False, "invalid")
+        verify.return_value = (False, "invalid", None)
         resp = await client.post(
             "/api/webhooks/zalo-bot",
             json=_payload("/lienket ABC123"),  # uses top-level shape
@@ -180,7 +180,7 @@ class TestPayloadShape:
         """Legacy shape (event_name nested under result) keeps working as
         a fallback, so any provider variant doesn't regress."""
         verify, _ = link_service_mock
-        verify.return_value = (False, "invalid")
+        verify.return_value = (False, "invalid", None)
         resp = await client.post(
             "/api/webhooks/zalo-bot",
             json=_payload_legacy_nested("/lienket ABC123"),
@@ -213,7 +213,7 @@ class TestLienKietCommand:
         self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
     ):
         verify, _ = link_service_mock
-        verify.return_value = (True, "Liên kết thành công!")
+        verify.return_value = (True, "Liên kết thành công!", None)
 
         resp = await client.post(
             "/api/webhooks/zalo-bot",
@@ -270,7 +270,7 @@ class TestUnlinkCommand:
         self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
     ):
         _, unlink = link_service_mock
-        unlink.return_value = (True, "Đã huỷ liên kết.")
+        unlink.return_value = (True, "Đã huỷ liên kết.", None)
 
         resp = await client.post(
             "/api/webhooks/zalo-bot",
@@ -293,7 +293,7 @@ class TestLegacyCommandSpelling:
         self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
     ):
         verify, _ = link_service_mock
-        verify.return_value = (True, "Liên kết thành công!")
+        verify.return_value = (True, "Liên kết thành công!", None)
 
         resp = await client.post(
             "/api/webhooks/zalo-bot",
@@ -308,7 +308,7 @@ class TestLegacyCommandSpelling:
         self, client: AsyncClient, configured_secret, gateway_mock, link_service_mock
     ):
         _, unlink = link_service_mock
-        unlink.return_value = (True, "Đã huỷ liên kết.")
+        unlink.return_value = (True, "Đã huỷ liên kết.", None)
 
         resp = await client.post(
             "/api/webhooks/zalo-bot",
@@ -374,7 +374,7 @@ class TestReplyDeliveryFailure:
         from app.gateways.zalo_bot import ZaloBotSendResult
 
         verify, _ = link_service_mock
-        verify.return_value = (True, "Liên kết thành công!")
+        verify.return_value = (True, "Liên kết thành công!", None)
         gateway_mock.send_message.return_value = ZaloBotSendResult(
             success=False, error_code=429, error_message="quota exceeded"
         )
@@ -399,7 +399,7 @@ class TestReplyDeliveryFailure:
         from app.gateways.zalo_bot import ZaloBotSendResult
 
         verify, _ = link_service_mock
-        verify.return_value = (True, "Liên kết thành công!")
+        verify.return_value = (True, "Liên kết thành công!", None)
         gateway_mock.send_message.return_value = ZaloBotSendResult(
             success=True, message_id="msg_xyz"
         )

--- a/Backend_FastAPI/tests/integration/test_zalo_bot_audit_trail.py
+++ b/Backend_FastAPI/tests/integration/test_zalo_bot_audit_trail.py
@@ -398,6 +398,99 @@ class TestBackfillMigrationIdempotency:
         assert len(second) == 1, "second run must be a no-op"
 
 
+class TestDedupKeyAllowsRepeatDisplacement:
+    """V-2 fix: ZALO_BOT_LINK_DISPLACED dedup key MUST include
+    chat_id_prefix so two genuine displacements involving the same
+    (displaced_user, new_user) pair but different chat_ids both reach
+    the recipient instead of the second being suppressed by the
+    5-minute cooldown.
+    """
+
+    def test_dedup_key_changes_with_chat_id_prefix(self):
+        from app.core.event_catalog import render_dedup_key
+        from app.core.events import SystemEvents
+
+        payload_first = {
+            "user_id": 1,
+            "displaced_by_user_id": 2,
+            "chat_id_prefix": "abcd***ef",
+            "actor_id": 2,
+        }
+        payload_second = dict(payload_first, chat_id_prefix="ghij***kl")
+
+        key_first = render_dedup_key(
+            SystemEvents.ZALO_BOT_LINK_DISPLACED, payload_first
+        )
+        key_second = render_dedup_key(
+            SystemEvents.ZALO_BOT_LINK_DISPLACED, payload_second
+        )
+
+        assert key_first != key_second, (
+            "different chat_id_prefix MUST produce different dedup keys; "
+            "otherwise repeat-displacement notifications get cooldown-suppressed"
+        )
+        # Both should still be deterministic + contain the user pair.
+        assert "1" in key_first and "2" in key_first
+        assert "abcd" in key_first
+        assert "ghij" in key_second
+
+
+class TestSyncPreferenceConcurrencySafe:
+    """V-1 fix: ``_sync_preference`` must survive a concurrent INSERT
+    race on ``notification_preference.user_id`` (read-then-insert
+    pattern in the base repo). The savepoint + re-fetch in
+    ``_get_or_create_pref_safe`` is the contract under test.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pref_already_present_on_concurrent_insert_is_handled(
+        self, db: AsyncSession, officer_user_in_db: dict, monkeypatch
+    ):
+        """Simulate the race: first SELECT returns None (as if a parallel
+        request hadn't committed yet), but the INSERT then collides with
+        the parallel insert that just landed. Service must catch
+        ``IntegrityError`` from the savepoint, re-fetch, and proceed.
+        """
+        from app.models.notification_preference import NotificationPreference
+        from app.repositories.notification_preference_repository import (
+            NotificationPreferenceRepository,
+        )
+
+        user_id = officer_user_in_db["id"]
+
+        # Pre-create the pref row to simulate the "winning" parallel insert.
+        winner = NotificationPreference(user_id=user_id, browser_enabled=True)
+        db.add(winner)
+        await db.commit()
+
+        # Force the in-service get_by_user_id to return None ONCE (the
+        # racing read), then the savepoint INSERT will fail with IntegrityError.
+        original_get = NotificationPreferenceRepository.get_by_user_id
+        call_state = {"count": 0}
+
+        async def fake_get(self, uid):
+            call_state["count"] += 1
+            if call_state["count"] == 1:
+                return None  # race: caller doesn't see the winner yet
+            return await original_get(self, uid)
+
+        monkeypatch.setattr(
+            NotificationPreferenceRepository, "get_by_user_id", fake_get
+        )
+
+        # Should NOT raise — savepoint catches the IntegrityError, re-fetch
+        # returns the winner row, and the audit + flip proceed normally.
+        await zalo_bot_link_service._sync_preference(
+            db, user_id, enabled=True, actor_user_id=user_id
+        )
+        await db.commit()
+
+        # Final state: winner row updated, exactly 1 audit row written.
+        pref_audits = await _audit_rows(db, "NotificationPreference")
+        assert len(pref_audits) == 1
+        assert pref_audits[0].new_value is True
+
+
 class TestPreferenceSyncIdempotency:
     @pytest.mark.asyncio
     async def test_no_audit_row_when_value_unchanged(

--- a/Backend_FastAPI/tests/integration/test_zalo_bot_audit_trail.py
+++ b/Backend_FastAPI/tests/integration/test_zalo_bot_audit_trail.py
@@ -1,0 +1,294 @@
+"""Audit trail coverage for Zalo Bot link/unlink/displacement/preference flips.
+
+PR-Audit-1 (post-PR #154 reply-confirm fix). Locks in:
+- Every link op writes one ``entity_audit_log`` row.
+- Displacement writes a ``chat_id_reassigned`` audit + flips displaced
+  user's ``zalo_bot_enabled`` to False + builds a ``post_commit``
+  closure that fans out ``ZALO_BOT_LINK_DISPLACED`` to the displaced
+  user.
+- ``_sync_preference`` is a no-op on no-change (no audit row written
+  when toggling to current value).
+- Source naming: ``zalo_bot_webhook`` for webhook ops, ``api`` for REST.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.entity_audit_log import EntityAuditLog
+from app.models.staff_zalo_bot_link import StaffZaloBotLink
+from app.services import zalo_bot_link_service
+
+
+pytestmark = pytest.mark.integration
+
+
+async def _audit_rows(db: AsyncSession, entity_type: str, entity_id=None):
+    q = select(EntityAuditLog).where(EntityAuditLog.entity_type == entity_type)
+    if entity_id is not None:
+        q = q.where(EntityAuditLog.entity_id == entity_id)
+    return (await db.execute(q.order_by(EntityAuditLog.id))).scalars().all()
+
+
+class TestVerifyAndLinkAudit:
+    @pytest.mark.asyncio
+    async def test_first_link_writes_created_audit_row(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            ok, _, post_commit = await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_first_link", "Officer A"
+            )
+        assert ok is True
+        assert post_commit is None  # No displacement → no fan-out.
+        await db.commit()
+
+        rows = await _audit_rows(db, "StaffZaloBotLink")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.action == "created"
+        assert row.actor_user_id == user_id
+        assert row.source == "zalo_bot_webhook"
+        # chat_id is masked in audit payload — never store the full id.
+        assert "chat_first_link"[:4] in row.new_value["chat_id_prefix"]
+        assert row.new_value["is_active"] is True
+
+    @pytest.mark.asyncio
+    async def test_pref_flip_writes_field_change_audit_row(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_pref", None
+            )
+        await db.commit()
+
+        # One field-change audit on NotificationPreference, value False→True.
+        pref_rows = await _audit_rows(db, "NotificationPreference")
+        assert len(pref_rows) == 1
+        row = pref_rows[0]
+        assert row.action == "updated"
+        assert row.field_name == "zalo_bot_enabled"
+        assert row.old_value is False
+        assert row.new_value is True
+        assert row.source == "zalo_bot_link_service"
+
+    @pytest.mark.asyncio
+    async def test_relink_same_chat_id_no_displacement_audit(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        """Same user re-links with same chat_id → no displacement, no
+        chat_id_reassigned audit. Pref flip is also a no-op (already True)."""
+        user_id = officer_user_in_db["id"]
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_self", None
+            )
+            await db.commit()
+
+            await zalo_bot_link_service.verify_and_link(
+                db, "DEF456", "chat_self", None
+            )
+            await db.commit()
+
+        link_audits = await _audit_rows(db, "StaffZaloBotLink")
+        # Two created actions (one per verify_and_link call) but no
+        # chat_id_reassigned action.
+        actions = [r.action for r in link_audits]
+        assert actions.count("created") == 2
+        assert "chat_id_reassigned" not in actions
+
+        # Pref audit fires only on first link (False→True). Second is a
+        # no-op (True→True) and writes no audit row.
+        pref_audits = await _audit_rows(db, "NotificationPreference")
+        assert len(pref_audits) == 1
+
+
+class TestDisplacementAudit:
+    @pytest.mark.asyncio
+    async def test_displacement_writes_reassigned_audit_and_flips_old_pref(
+        self, db: AsyncSession, officer_user_in_db: dict, manager_user_in_db: dict
+    ):
+        """Critical security event: chat_id moves from user A to user B.
+        Must record on the displaced row + flip displaced user's pref +
+        return a post_commit closure for fan-out.
+        """
+        user_a = officer_user_in_db["id"]
+        user_b = manager_user_in_db["id"]
+
+        # Step 1: user A links chat_shared.
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_a)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "AAA111", "chat_shared", None
+            )
+            await db.commit()
+
+        # Step 2: user B claims the same chat_shared.
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_b)),
+        ):
+            ok, _, post_commit = await zalo_bot_link_service.verify_and_link(
+                db, "BBB222", "chat_shared", None
+            )
+            assert ok is True
+            await db.commit()
+
+        # Displacement closure must exist for fan-out.
+        assert post_commit is not None
+
+        # Audit assertions.
+        link_audits = await _audit_rows(db, "StaffZaloBotLink")
+        actions = [(r.action, r.actor_user_id) for r in link_audits]
+        assert ("chat_id_reassigned", user_b) in actions
+        # Two created rows (one per user) + one chat_id_reassigned.
+        assert len([a for a, _ in actions if a == "created"]) == 2
+        assert len([a for a, _ in actions if a == "chat_id_reassigned"]) == 1
+
+        # Displaced user's preference row must be flipped to False with
+        # an audit trail attributing the change to user_b (the actor).
+        pref_audits = await _audit_rows(db, "NotificationPreference")
+        # Find the row that toggled user_a's pref off — actor=user_b.
+        toggled_off = [
+            r for r in pref_audits
+            if r.new_value is False and r.actor_user_id == user_b
+        ]
+        assert len(toggled_off) == 1, (
+            "displaced user's pref must be flipped off with actor=new linker"
+        )
+
+    @pytest.mark.asyncio
+    async def test_displacement_post_commit_dispatches_event(
+        self, db: AsyncSession, officer_user_in_db: dict, manager_user_in_db: dict
+    ):
+        """The post_commit closure must call safe_dispatch with the
+        ZALO_BOT_LINK_DISPLACED event targeting the displaced user."""
+        user_a = officer_user_in_db["id"]
+        user_b = manager_user_in_db["id"]
+
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_a)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "AAA111", "chat_dispatch", None
+            )
+            await db.commit()
+
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_b)),
+        ), patch(
+            "app.services.notification_dispatcher.safe_dispatch",
+            new=AsyncMock(),
+        ) as dispatch_mock:
+            _, _, post_commit = await zalo_bot_link_service.verify_and_link(
+                db, "BBB222", "chat_dispatch", None
+            )
+            await db.commit()
+            assert post_commit is not None
+            await post_commit()
+
+        dispatch_mock.assert_awaited_once()
+        kwargs = dispatch_mock.await_args.kwargs
+        from app.core.events import SystemEvents
+        assert kwargs["event"] == SystemEvents.ZALO_BOT_LINK_DISPLACED
+        assert kwargs["payload"]["user_id"] == user_a
+        assert kwargs["payload"]["displaced_by_user_id"] == user_b
+        assert kwargs["payload"]["actor_id"] == user_b
+
+
+class TestUnlinkAudit:
+    @pytest.mark.asyncio
+    async def test_unlink_rest_writes_deleted_audit_with_api_source(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_unlink_rest", None
+            )
+            await db.commit()
+
+        ok, _, _ = await zalo_bot_link_service.unlink(db, user_id)
+        assert ok is True
+        await db.commit()
+
+        link_audits = await _audit_rows(db, "StaffZaloBotLink")
+        deleted = [r for r in link_audits if r.action == "deleted"]
+        assert len(deleted) == 1
+        assert deleted[0].source == "api"
+        assert deleted[0].actor_user_id == user_id
+
+    @pytest.mark.asyncio
+    async def test_unlink_via_chat_id_uses_webhook_source(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_unlink_wh", None
+            )
+            await db.commit()
+
+        ok, _, _ = await zalo_bot_link_service.unlink_by_chat_id(
+            db, "chat_unlink_wh"
+        )
+        assert ok is True
+        await db.commit()
+
+        link_audits = await _audit_rows(db, "StaffZaloBotLink")
+        deleted = [r for r in link_audits if r.action == "deleted"]
+        assert len(deleted) == 1
+        assert deleted[0].source == "zalo_bot_webhook"
+
+
+class TestPreferenceSyncIdempotency:
+    @pytest.mark.asyncio
+    async def test_no_audit_row_when_value_unchanged(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        """Calling _sync_preference with the current value writes 0 audit
+        rows — prevents log spam from defensive double-flips."""
+        user_id = officer_user_in_db["id"]
+        # Initial flip True (real link op).
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_idem", None
+            )
+            await db.commit()
+
+        before = len(await _audit_rows(db, "NotificationPreference"))
+        # Call _sync_preference directly with same value (True).
+        await zalo_bot_link_service._sync_preference(
+            db, user_id, enabled=True, actor_user_id=user_id
+        )
+        await db.commit()
+        after = len(await _audit_rows(db, "NotificationPreference"))
+        assert after == before, "no-op flip must not produce audit row"

--- a/Backend_FastAPI/tests/integration/test_zalo_bot_audit_trail.py
+++ b/Backend_FastAPI/tests/integration/test_zalo_bot_audit_trail.py
@@ -266,6 +266,138 @@ class TestUnlinkAudit:
         assert deleted[0].source == "zalo_bot_webhook"
 
 
+class TestBackfillMigrationIdempotency:
+    """The backfill migration runs ``INSERT ... WHERE NOT EXISTS`` on
+    ``(entity_type, entity_id, action='created')``. Verify that:
+
+    - Re-running the SQL on a DB where the live service has already
+      written a 'created' row (different source) does NOT duplicate.
+    - Re-running after a previous backfill (source='backfill') is also
+      a no-op.
+
+    Reproduces the exact SQL from
+    ``alembic/versions/zbaudit001_backfill_zalo_bot_link_audit_rows.py``
+    so a future tweak to the migration predicate will fail this test
+    if the idempotency contract regresses.
+    """
+
+    BACKFILL_SQL = """
+        INSERT INTO entity_audit_log (
+            entity_type, entity_id, action,
+            actor_user_id, field_name,
+            old_value, new_value, changes,
+            reason, source, ip_address, user_agent,
+            created_at
+        )
+        SELECT
+            'StaffZaloBotLink',
+            l.id,
+            'created',
+            l.user_id,
+            NULL,
+            NULL,
+            json_build_object(
+                'user_id', l.user_id,
+                'is_active', l.is_active,
+                'linked_at', l.linked_at,
+                'note', 'backfilled — actual link predates audit instrumentation'
+            )::jsonb,
+            NULL,
+            'backfilled 2026-04-28; original linked_at preserved in new_value',
+            'backfill',
+            NULL,
+            NULL,
+            l.linked_at
+        FROM staff_zalo_bot_link l
+        WHERE l.is_active = true
+          AND NOT EXISTS (
+              SELECT 1 FROM entity_audit_log a
+              WHERE a.entity_type = 'StaffZaloBotLink'
+                AND a.entity_id = l.id
+                AND a.action = 'created'
+          );
+    """
+
+    @pytest.mark.asyncio
+    async def test_live_created_row_blocks_backfill_after_downgrade_reupgrade(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        """Reproduces the failure mode flagged in /review:
+        downgrade → live link op writes 'created' (source='zalo_bot_webhook')
+        → upgrade re-runs migration. The stricter predicate must NOT
+        insert a synthetic backfill row alongside the live one.
+        """
+        from sqlalchemy import text
+
+        user_id = officer_user_in_db["id"]
+        # Step 1: live link op writes the 'created' audit row with the
+        # service's own source label.
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_idem_live", None
+            )
+            await db.commit()
+
+        link = (
+            await db.execute(
+                select(StaffZaloBotLink).where(
+                    StaffZaloBotLink.user_id == user_id
+                )
+            )
+        ).scalar_one()
+
+        before = await _audit_rows(db, "StaffZaloBotLink", link.id)
+        assert len(before) == 1
+        assert before[0].source == "zalo_bot_webhook"
+
+        # Step 2: simulate post-downgrade re-upgrade by running the
+        # migration SQL directly. The stricter predicate must skip.
+        await db.execute(text(self.BACKFILL_SQL))
+        await db.commit()
+
+        after = await _audit_rows(db, "StaffZaloBotLink", link.id)
+        assert len(after) == 1, (
+            "backfill must NOT duplicate when a live 'created' row "
+            "already exists for this entity (any source)"
+        )
+        assert after[0].source == "zalo_bot_webhook"
+
+    @pytest.mark.asyncio
+    async def test_running_backfill_twice_is_noop(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        """Re-running the migration on a DB already backfilled produces
+        no extra rows."""
+        from sqlalchemy import text
+
+        user_id = officer_user_in_db["id"]
+        # Insert a link directly (bypass service so no audit row exists).
+        link = StaffZaloBotLink(
+            user_id=user_id,
+            chat_id="chat_idem_twice",
+            display_name=None,
+            is_active=True,
+        )
+        db.add(link)
+        await db.commit()
+
+        # First run: should insert 1 backfill row.
+        await db.execute(text(self.BACKFILL_SQL))
+        await db.commit()
+        first = await _audit_rows(db, "StaffZaloBotLink", link.id)
+        assert len(first) == 1
+        assert first[0].source == "backfill"
+
+        # Second run: predicate blocks, no-op.
+        await db.execute(text(self.BACKFILL_SQL))
+        await db.commit()
+        second = await _audit_rows(db, "StaffZaloBotLink", link.id)
+        assert len(second) == 1, "second run must be a no-op"
+
+
 class TestPreferenceSyncIdempotency:
     @pytest.mark.asyncio
     async def test_no_audit_row_when_value_unchanged(

--- a/Backend_FastAPI/tests/repositories/test_zalo_bot_preference_sync.py
+++ b/Backend_FastAPI/tests/repositories/test_zalo_bot_preference_sync.py
@@ -35,7 +35,7 @@ class TestPreferenceSyncOnLink:
             "app.database.safe_redis_getdel",
             new=AsyncMock(return_value=str(user_id)),
         ):
-            ok, _ = await zalo_bot_link_service.verify_and_link(
+            ok, _, _ = await zalo_bot_link_service.verify_and_link(
                 db, "ABC123", "chat_alpha", "Officer A"
             )
         assert ok is True
@@ -64,7 +64,7 @@ class TestPreferenceSyncOnLink:
             )
         await db.commit()
 
-        ok, _ = await zalo_bot_link_service.unlink(db, user_id)
+        ok, _, _ = await zalo_bot_link_service.unlink(db, user_id)
         assert ok is True
         await db.commit()
 

--- a/Backend_FastAPI/tests/unit/test_notification_contract.py
+++ b/Backend_FastAPI/tests/unit/test_notification_contract.py
@@ -447,6 +447,9 @@ class TestUserEventsHaveDispatchCallers:
         "user_deactivated", "user_profile_updated", "pipeline_config_updated",
         "officer_availability_changed", "suspicious_login",
         "holiday_calendar_incomplete",
+        # PR-Audit-1: dispatched from zalo_bot_link_service.verify_and_link
+        # post_commit closure when chat_id displacement happens.
+        "zalo_bot_link_displaced",
     })
 
     def test_user_events_have_dispatch_in_codebase(self):

--- a/Backend_FastAPI/tests/unit/test_zalo_bot_link_service.py
+++ b/Backend_FastAPI/tests/unit/test_zalo_bot_link_service.py
@@ -103,12 +103,18 @@ class TestVerifyAndLink:
         repo_mock.get_active_by_chat_id = AsyncMock(return_value=None)
         repo_mock.create_or_reactivate = AsyncMock()
 
+        # Patch audit_service so unit tests don't need a real DB. The
+        # full audit semantics are covered in
+        # tests/integration/test_zalo_bot_audit_trail.py against a real
+        # session — this test only verifies the GETDEL contract.
         with patch("app.database.safe_redis_getdel", new=getdel_mock), \
              patch.object(svc, "StaffZaloBotLinkRepository", return_value=repo_mock), \
-             patch.object(svc, "_sync_preference", new=AsyncMock()):
+             patch.object(svc, "_sync_preference", new=AsyncMock()), \
+             patch("app.services.audit_service.log_created", new=AsyncMock()), \
+             patch("app.services.audit_service.log_audit", new=AsyncMock()):
             db_mock = AsyncMock()
-            ok1, _ = await svc.verify_and_link(db_mock, "ABC123", "chat_xyz")
-            ok2, msg2 = await svc.verify_and_link(db_mock, "ABC123", "chat_xyz")
+            ok1, _, _ = await svc.verify_and_link(db_mock, "ABC123", "chat_xyz")
+            ok2, msg2, _ = await svc.verify_and_link(db_mock, "ABC123", "chat_xyz")
 
         assert ok1 is True, "first consume must succeed when GETDEL returns the user_id"
         assert ok2 is False, "second consume on the same code must fail"
@@ -122,7 +128,7 @@ class TestVerifyAndLink:
 
         with patch("app.database.safe_redis_getdel", new=getdel_mock), \
              patch.object(svc, "StaffZaloBotLinkRepository", return_value=repo_mock):
-            ok, _ = await svc.verify_and_link(AsyncMock(), "BADCOD", "chat_x")
+            ok, _, _ = await svc.verify_and_link(AsyncMock(), "BADCOD", "chat_x")
 
         assert ok is False
         repo_mock.create_or_reactivate.assert_not_awaited()
@@ -136,7 +142,9 @@ class TestVerifyAndLink:
 
         with patch("app.database.safe_redis_getdel", new=getdel_mock), \
              patch.object(svc, "StaffZaloBotLinkRepository", return_value=repo_mock), \
-             patch.object(svc, "_sync_preference", new=AsyncMock()):
+             patch.object(svc, "_sync_preference", new=AsyncMock()), \
+             patch("app.services.audit_service.log_created", new=AsyncMock()), \
+             patch("app.services.audit_service.log_audit", new=AsyncMock()):
             await svc.verify_and_link(AsyncMock(), "abc123", "chat_x")
 
         looked_up_key = getdel_mock.await_args.args[0]


### PR DESCRIPTION
## Summary

Two-PR-equivalent worth of work bundled in one branch since both ship together cleanly:

- **Audit trail** for `staff_zalo_bot_link` lifecycle (create / unlink / displace / preference flip) — writes `entity_audit_log` rows tagged with actor, action, source.
- **Backfill migration** `zbaudit001` — 1 audit row per existing active link (6 rows on prod), `source='backfill'`, idempotent on re-run.
- **`ZALO_BOT_LINK_DISPLACED` notification** — recipient warned when their chat_id is hijacked by another link.
- **V-1 fix** (post-review): `_get_or_create_pref_safe` SAVEPOINT wrapper around `NotificationPreferenceRepository.get_or_create` to handle concurrent INSERT race (e.g. two browser tabs clicking "Tạo mã" at the same time).
- **V-2 fix** (post-review): `chat_id_prefix` added to `ZALO_BOT_LINK_DISPLACED` dedup key so genuine repeat displacements involving different chat_ids aren't suppressed by the 5-min Redis cooldown.

## Migration `zbaudit001` — backfill safety

| Property | Value |
|---|---|
| Schema change | None |
| Operation | `INSERT INTO entity_audit_log SELECT FROM staff_zalo_bot_link WHERE is_active=true` |
| Idempotency | `NOT EXISTS (SELECT 1 ... action='created')` blocks re-insert across all sources |
| Downgrade | `DELETE WHERE source='backfill'` — does not touch live-service-written rows |
| Lock duration | ms-scale, 6 INSERT statements |
| Down revision | `adm003path001` (chains correctly after ADM-013 squash) |

**Prod state pre-deploy** (verified via SSH):
- `staff_zalo_bot_link` active: 6 rows (1 admin user_id=15 + 5 officers, linked 2026-04-27/28)
- existing `entity_audit_log` for `StaffZaloBotLink`: 0 rows

After deploy → 6 backfill rows expected.

## Test plan
- [x] **88/88 tests pass locally** on commit `242d3df5` (post-rebase HEAD), 3 minutes:
  - `tests/integration/test_zalo_bot_audit_trail.py` (12)
  - `tests/api/test_zalo_bot_link_api.py` (9)
  - `tests/api/test_zalo_bot_webhooks.py` (21)
  - `tests/repositories/test_zalo_bot_preference_sync.py` (6)
  - `tests/unit/test_notification_contract.py` (32)
  - `tests/unit/test_zalo_bot_link_service.py` (8)
- [x] Rebase on `origin/main` (1a7dd817 = ADM-013) clean, 0 conflict
- [x] Migration content reviewed for idempotency + safe downgrade
- [x] Prod state confirmed (alembic = `adm003path001`, 6 active links, 0 audit rows)
- [ ] CI green
- [ ] Post-merge prod verify: alembic = `zbaudit001`, 6 audit rows tagged `source='backfill'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)