### PR TITLE
fix(notification-ops): accept zalo_bot in delivery list channel filter

### DIFF
--- a/Backend_FastAPI/app/routers/notification_delivery_ops.py
+++ b/Backend_FastAPI/app/routers/notification_delivery_ops.py
@@ -27,7 +27,7 @@ router = APIRouter(
 async def list_deliveries(
     request: Request,
     event: Optional[str] = Query(None, description="Filter by event name"),
-    channel: Optional[str] = Query(None, description="Filter by channel", pattern="^(browser|email|zalo|sms)$"),
+    channel: Optional[str] = Query(None, description="Filter by channel", pattern="^(browser|email|zalo|zalo_bot|sms)$"),
     status: Optional[str] = Query(None, description="Filter by status", pattern="^(queued|sent|delivered|read|failed|skipped|dead_lettered)$"),
     user_id: Optional[int] = Query(None, description="Filter by user ID"),
     source_type: Optional[str] = Query(None, description="Filter by source type"),

--- a/Backend_FastAPI/tests/api/test_notification_deliveries.py
+++ b/Backend_FastAPI/tests/api/test_notification_deliveries.py
@@ -108,6 +108,57 @@ async def test_list_deliveries_filter_by_channel(
 
 
 @pytest.mark.asyncio
+async def test_list_deliveries_filter_by_zalo_bot_channel(
+    client: AsyncClient,
+    admin_token_headers: dict,
+):
+    """
+    Regression: ``channel=zalo_bot`` must be accepted by the Pydantic
+    regex on the list endpoint. Pre-fix the pattern was
+    ``^(browser|email|zalo|sms)$`` so the FE filter dropdown — which
+    has had a "Zalo Bot" option since v5 Step 24 — produced 422 from
+    the BE and operators saw an empty / errored Delivery Ops table
+    even though zalo_bot rows were being written normally.
+
+    Seed one zalo_bot delivery and assert the filter returns it (and
+    only it).
+    """
+    async with AsyncSessionLocal() as db:
+        zb = models.NotificationDelivery(
+            event="lead_assigned",
+            channel="zalo_bot",
+            recipient_kind="internal",
+            source_type="lead",
+            source_id=999,
+            status="sent",
+        )
+        db.add(zb)
+        await db.commit()
+        await db.refresh(zb)
+        zb_id = zb.id
+
+    response = await client.get(
+        DELIVERIES_URL,
+        headers=admin_token_headers,
+        params={"channel": "zalo_bot"},
+    )
+    assert response.status_code == 200, (
+        f"channel=zalo_bot must not 422 — got {response.status_code} "
+        f"body={response.text[:200]}"
+    )
+    data = response.json()
+    assert data["total_count"] >= 1
+    # Filter must be exact: every row in the response is a zalo_bot row.
+    assert all(d["channel"] == "zalo_bot" for d in data["deliveries"]), (
+        "Filter leaked non-zalo_bot rows: "
+        f"{[d['channel'] for d in data['deliveries']]}"
+    )
+    # Specifically the row we seeded must be present.
+    returned_ids = {d["id"] for d in data["deliveries"]}
+    assert zb_id in returned_ids
+
+
+@pytest.mark.asyncio
 async def test_list_deliveries_filter_by_status(
     client: AsyncClient,
     admin_token_headers: dict,


### PR DESCRIPTION
## Summary

Pydantic Query regex on `GET /api/notification-deliveries` was

```python
pattern="^(browser|email|zalo|sms)$"
```

which rejected `channel=zalo_bot` with **422**. The admin Delivery Ops table (`DeliveryOpsTable.tsx`) has had a "Zalo Bot" filter dropdown option, `<Bot/>` icon and label since v5 Step 24 — picking it produced an empty / errored table even though `zalo_bot` rows were being written normally. FE/BE schema drifted when zalo_bot landed but this one regex was missed.

Widen to `^(browser|email|zalo|zalo_bot|sms)$` — semantics-preserving for the four pre-existing values, only adds the missing one.

## Symptom matrix (pre-fix)

| Filter user picks | Request | BE response |
|---|---|---|
| "Tất cả kênh" | `channel=undefined` | 200, includes zalo_bot rows |
| "Browser/Email/Zalo/SMS" | `channel=<value>` | 200 |
| **"Zalo Bot"** | **`channel=zalo_bot`** | **422 Validation Error** |

After fix, "Zalo Bot" filter returns 200 with exact-match `zalo_bot` rows.

## Test

`tests/api/test_notification_deliveries.py::test_list_deliveries_filter_by_zalo_bot_channel` seeds a `zalo_bot` delivery and asserts:
- response is 200 (not 422)
- every row in the response has `channel == "zalo_bot"` (no leak)
- the seeded id is present

Local run: **8/8 PASS** (existing 7 + new test) in 56s.

## Risk

- Read-only endpoint, regex widen only.
- No migration, no schema change, no frontend change.
- No logic change in service/repository — repo already filters by literal string match `WHERE channel = :channel`.

## Test plan
- [x] Local 8/8 PASS targeted suite
- [ ] CI green
- [ ] Post-merge spot-check: open admin Delivery Ops, pick "Zalo Bot" filter, confirm rows appear (or empty list with 200 if no recent deliveries match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)