### PR TITLE
fix(admissions): ADM-031 DocumentsTab UI overhaul + verifier identity + artifact contract gating

### DIFF
--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -933,13 +933,19 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         if not doc:
             return None
 
-        # Reset to missing state
+        # Reset to missing state. ADM-031 round 10 review (B2): verified_by
+        # was previously left dangling — every other verifier-side column
+        # was cleared but the user id stuck around, so audit queries on
+        # verified_by saw a verifier id for a document that is currently
+        # missing. Clear it alongside verified_at so the row is fully
+        # rewound.
         doc.status = "missing"
         doc.file_path = None
         doc.actual_submission_format = None
         doc.verified_format = None
         doc.uploaded_at = None
         doc.verified_at = None
+        doc.verified_by = None
         doc.paper_submitted_at = None
         doc.paper_submitted_by = None
         doc.rejected_at = None

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -237,6 +237,11 @@ class DocumentItemSchema(BaseModel):
         None,
         description="Upload timestamp (UTC)"
     )
+    # ADM-031 round 7: paper-receipt timestamp
+    paper_submitted_at: Optional[datetime] = Field(
+        None,
+        description="Timestamp when officer marked the paper document as received"
+    )
     # ✅ FIX Finding 2.3: Document Internal Verification
     verified_format: Optional[Literal["original", "certified_copy", "photo"]] = Field(
         None,

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -254,6 +254,23 @@ class DocumentItemSchema(BaseModel):
         None,
         description="Format actually declared by the officer at upload/paper-receipt time"
     )
+    # ADM-031 round 10: surface the verifier identity + timestamp so the FE
+    # row can render "Đã duyệt — <Tên> · <ngày>" under the status badge and
+    # show full datetime on hover. verified_at + verified_by come straight
+    # from ProfileDocument; verified_by_name is resolved server-side via a
+    # batched User lookup to keep the listing N+1-free.
+    verified_at: Optional[datetime] = Field(
+        None,
+        description="Timestamp when officer marked status=verified",
+    )
+    verified_by: Optional[int] = Field(
+        None,
+        description="User id of the officer who verified the document",
+    )
+    verified_by_name: Optional[str] = Field(
+        None,
+        description="Display name (full_name or email) of the verifier; null if user no longer exists",
+    )
 
     # =========================================================================
     # Checklist-only display fields populated by _compute_frontend_fields.

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -242,6 +242,13 @@ class DocumentItemSchema(BaseModel):
         None,
         description="Format verified by officer (original/certified_copy/photo)"
     )
+    # ADM-031 round 4: officer-declared actual format. Captured at upload /
+    # paper-receipt time; surfaced in the FE row badge so officers can see
+    # what was actually recorded vs the path-required submission_format.
+    actual_submission_format: Optional[Literal["original", "certified_copy", "photo"]] = Field(
+        None,
+        description="Format actually declared by the officer at upload/paper-receipt time"
+    )
 
     # =========================================================================
     # Checklist-only display fields populated by _compute_frontend_fields.

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -269,7 +269,13 @@ class DocumentItemSchema(BaseModel):
     )
     verified_by_name: Optional[str] = Field(
         None,
-        description="Display name (full_name or email) of the verifier; null if user no longer exists",
+        description=(
+            "Display name of the verifier — backend resolves "
+            "full_name → username via a batched User lookup. Null when the "
+            "verifier no longer exists or has neither field set; FE then "
+            "falls back to 'User #<verified_by>'. Email is never exposed "
+            "here (staff-to-staff privacy)."
+        ),
     )
 
     # =========================================================================

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -900,11 +900,19 @@ async def _resolve_verifier_names(
     """Batch-resolve verifier display names for a documents list.
 
     Returns ``{user_id: display_name}`` so the documents_checklist payload can
-    surface "duyệt bởi <Tên>" without an N+1 storm. Falls back to ``email``
-    when ``full_name`` is unset, and omits the entry entirely when the user
-    no longer exists (FE will then render "User #<id>"). One SELECT per
-    profile load — cost is bounded by the number of distinct verifiers, not
-    documents.
+    surface "duyệt bởi <Tên>" without an N+1 storm. Display precedence:
+    ``full_name`` → ``username`` → omitted (FE then renders "User #<id>").
+
+    REVIEW NOTE (Lane A round 10 follow-up): an earlier draft fell back to
+    ``email`` after ``full_name``. Admission/audit actor names elsewhere in
+    this codebase use ``full_name or username`` and never expose staff
+    emails to other staff readers — every officer/manager/admin who can read
+    a profile sees verifier identity, so leaking an internal email there
+    would be a quiet privacy regression. Aligned to the dominant pattern
+    here.
+
+    One SELECT per profile load — cost is bounded by the number of distinct
+    verifiers, not documents.
     """
     if not documents:
         return {}
@@ -917,14 +925,14 @@ async def _resolve_verifier_names(
         return {}
     rows = (
         await db.execute(
-            select(models.User.id, models.User.full_name, models.User.email).where(
-                models.User.id.in_(verifier_ids)
-            )
+            select(
+                models.User.id, models.User.full_name, models.User.username
+            ).where(models.User.id.in_(verifier_ids))
         )
     ).all()
     out: Dict[int, str] = {}
-    for user_id, full_name, email in rows:
-        display = (full_name or "").strip() or (email or "").strip()
+    for user_id, full_name, username in rows:
+        display = (full_name or "").strip() or (username or "").strip()
         if display:
             out[user_id] = display
     return out
@@ -1255,47 +1263,81 @@ def _compute_frontend_fields(
     # "User #<id>" using the raw ``verified_by`` field. Always safe.
     _verifier_names_local = verifier_names or {}
 
-    # Create lookup of uploaded documents by code
+    # Create lookup of uploaded documents by code.
+    #
+    # ADM-031 round 10 review (B1): the response contract for each row is
+    # gated by the CURRENT status, not by the raw DB columns. Reject /
+    # reset paths historically leave artifact columns dirty
+    # (``file_path``, ``uploaded_at``, ``actual_submission_format``,
+    # ``verified_format``, ``paper_submitted_at``, ``verified_at``,
+    # ``verified_by``). Emitting them unconditionally produced UI rows
+    # like "Đã ghi nhận: Chụp/scan · 29/04" alongside a "Từ chối" badge
+    # that says reception is "Chưa" — two halves of the same cell
+    # contradicting each other. Gate here so each terminal state shows
+    # only what it actually has:
+    #
+    #   * uploaded            : file artifact + officer-declared format
+    #   * paper_submitted     : paper receipt timestamp + declared format
+    #   * verified            : everything above + verifier identity +
+    #                           verified_format
+    #   * rejected / missing  : status only; reason for rejection;
+    #                           no artifact, no format, no verifier
+    #
+    # Avoids a DB backfill while keeping the API contract clean.
+    _ARTIFACT_STATUSES = ("uploaded", "paper_submitted", "verified")
     doc_by_code = {}
     if documents:
         for doc in documents:
             if doc.document_type:
+                _has_artifact = doc.status in _ARTIFACT_STATUSES
+                _is_verified = doc.status == "verified"
                 doc_by_code[doc.document_type.code] = {
                     "status": doc.status,
-                    "file_path": doc.file_path,
-                    "uploaded_at": doc.uploaded_at.isoformat() if doc.uploaded_at else None,
-                    "rejection_reason": doc.rejection_reason,
-                    # submission_format_confirmed: True if manager verified the format
-                    # Defaults to True for verified status, False otherwise
-                    "submission_format_confirmed": doc.status == "verified",
                     "label_from_db": doc.document_type.name,
-                    # ADM-031 round 4: surface the officer-declared format and
-                    # the manager-verified format so the FE can show "Đã ghi
-                    # nhận (loại bản): X" / "Đã kiểm tra (loại bản): Y" next
-                    # to the path-required submission_format. Without this,
-                    # the row badges only echo the requirement and an
-                    # actual/required mismatch stays invisible to officers.
-                    "actual_submission_format": doc.actual_submission_format,
-                    "verified_format": doc.verified_format,
-                    # ADM-031 round 7: paper-receipt timestamp so the FE can
-                    # render the "Đã ghi nhận" cell date for paper-only docs
-                    # the same way it does for uploaded ones (uploaded_at).
-                    "paper_submitted_at": (
-                        doc.paper_submitted_at.isoformat()
-                        if doc.paper_submitted_at
+                    # rejection_reason is the only field that is meaningful
+                    # specifically when status == rejected — keep it
+                    # visible in the rejected branch so the FE row can
+                    # render the "Lý do" line.
+                    "rejection_reason": doc.rejection_reason,
+                    # submission_format_confirmed: True if manager verified the format.
+                    "submission_format_confirmed": _is_verified,
+                    # Artifact fields — only meaningful while a usable
+                    # document exists on the row.
+                    "file_path": doc.file_path if _has_artifact else None,
+                    "uploaded_at": (
+                        doc.uploaded_at.isoformat()
+                        if _has_artifact and doc.uploaded_at
                         else None
                     ),
-                    # ADM-031 round 10: verifier identity for the FE
-                    # "Trạng thái" cell. verified_by_name is filled in
-                    # below from a batched User lookup to keep this loop
-                    # N+1-free.
-                    "verified_at": (
-                        doc.verified_at.isoformat() if doc.verified_at else None
+                    # ADM-031 round 4: officer-declared format. ADM-031
+                    # round 10 (B1): suppress on missing/rejected.
+                    "actual_submission_format": (
+                        doc.actual_submission_format if _has_artifact else None
                     ),
-                    "verified_by": doc.verified_by,
+                    # verified_format is only meaningful when the doc is
+                    # currently in the verified state — uploaded /
+                    # paper_submitted rows haven't been verified yet, so
+                    # the column should not surface even if it was set
+                    # before a manager later reset/rejected.
+                    "verified_format": doc.verified_format if _is_verified else None,
+                    # ADM-031 round 7: paper-receipt timestamp.
+                    "paper_submitted_at": (
+                        doc.paper_submitted_at.isoformat()
+                        if _has_artifact and doc.paper_submitted_at
+                        else None
+                    ),
+                    # ADM-031 round 10: verifier identity. verified_by_name
+                    # is filled from a batched User lookup so this loop
+                    # stays N+1-free. Suppress unless status == verified.
+                    "verified_at": (
+                        doc.verified_at.isoformat()
+                        if _is_verified and doc.verified_at
+                        else None
+                    ),
+                    "verified_by": doc.verified_by if _is_verified else None,
                     "verified_by_name": (
                         _verifier_names_local.get(doc.verified_by)
-                        if doc.verified_by is not None
+                        if _is_verified and doc.verified_by is not None
                         else None
                     ),
                 }
@@ -3586,11 +3628,11 @@ async def upload_document(
         admission_repo_refresh = AdmissionRepository(db)
         documents = await admission_repo_refresh.get_all_documents(profile_id)
         _compute_frontend_fields(
-        profile,
-        current_user,
-        documents,
-        await _resolve_verifier_names(db, documents),
-    )
+            profile,
+            current_user,
+            documents,
+            await _resolve_verifier_names(db, documents),
+        )
 
         # ✅ AUDIT LOG: Track document upload
         from .document_audit_service import log_document_upload

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1230,6 +1230,14 @@ def _compute_frontend_fields(
                     # actual/required mismatch stays invisible to officers.
                     "actual_submission_format": doc.actual_submission_format,
                     "verified_format": doc.verified_format,
+                    # ADM-031 round 7: paper-receipt timestamp so the FE can
+                    # render the "Đã ghi nhận" cell date for paper-only docs
+                    # the same way it does for uploaded ones (uploaded_at).
+                    "paper_submitted_at": (
+                        doc.paper_submitted_at.isoformat()
+                        if doc.paper_submitted_at
+                        else None
+                    ),
                 }
     
     # PR #5 — per-document action permissions delegate to the
@@ -1292,6 +1300,8 @@ def _compute_frontend_fields(
             "status": _doc_status,
             "file_path": uploaded_doc.get("file_path"),
             "uploaded_at": uploaded_doc.get("uploaded_at"),
+            # ADM-031 round 7: paper-receipt timestamp
+            "paper_submitted_at": uploaded_doc.get("paper_submitted_at"),
             "rejection_reason": uploaded_doc.get("rejection_reason"),
             "submission_format_confirmed": uploaded_doc.get("submission_format_confirmed", False),
             **_perms,

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1222,6 +1222,14 @@ def _compute_frontend_fields(
                     # Defaults to True for verified status, False otherwise
                     "submission_format_confirmed": doc.status == "verified",
                     "label_from_db": doc.document_type.name,
+                    # ADM-031 round 4: surface the officer-declared format and
+                    # the manager-verified format so the FE can show "Đã ghi
+                    # nhận (loại bản): X" / "Đã kiểm tra (loại bản): Y" next
+                    # to the path-required submission_format. Without this,
+                    # the row badges only echo the requirement and an
+                    # actual/required mismatch stays invisible to officers.
+                    "actual_submission_format": doc.actual_submission_format,
+                    "verified_format": doc.verified_format,
                 }
     
     # PR #5 — per-document action permissions delegate to the
@@ -1276,6 +1284,11 @@ def _compute_frontend_fields(
             "is_mandatory": True,
             "requires_upload": _requires_upload,
             "submission_format": config.get("submission_format"),
+            # ADM-031 round 4: pass through the officer-declared and
+            # manager-verified format codes so the FE row can render the
+            # actual/verified state next to the required format.
+            "actual_submission_format": uploaded_doc.get("actual_submission_format"),
+            "verified_format": uploaded_doc.get("verified_format"),
             "status": _doc_status,
             "file_path": uploaded_doc.get("file_path"),
             "uploaded_at": uploaded_doc.get("uploaded_at"),

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -893,10 +893,48 @@ def _apply_minor_correction_state(
     _sync_available_actions(profile)
 
 
+async def _resolve_verifier_names(
+    db: AsyncSession,
+    documents: Optional[List[models.ProfileDocument]],
+) -> Dict[int, str]:
+    """Batch-resolve verifier display names for a documents list.
+
+    Returns ``{user_id: display_name}`` so the documents_checklist payload can
+    surface "duyệt bởi <Tên>" without an N+1 storm. Falls back to ``email``
+    when ``full_name`` is unset, and omits the entry entirely when the user
+    no longer exists (FE will then render "User #<id>"). One SELECT per
+    profile load — cost is bounded by the number of distinct verifiers, not
+    documents.
+    """
+    if not documents:
+        return {}
+    verifier_ids: set[int] = {
+        doc.verified_by
+        for doc in documents
+        if getattr(doc, "verified_by", None) is not None
+    }
+    if not verifier_ids:
+        return {}
+    rows = (
+        await db.execute(
+            select(models.User.id, models.User.full_name, models.User.email).where(
+                models.User.id.in_(verifier_ids)
+            )
+        )
+    ).all()
+    out: Dict[int, str] = {}
+    for user_id, full_name, email in rows:
+        display = (full_name or "").strip() or (email or "").strip()
+        if display:
+            out[user_id] = display
+    return out
+
+
 def _compute_frontend_fields(
     profile: models.AdmissionProfile,
     current_user: models.User,
     documents: list = None,
+    verifier_names: Optional[Dict[int, str]] = None,
 ) -> None:
     """
     Phase 7: Frontend Thin Client Compliance
@@ -1208,6 +1246,15 @@ def _compute_frontend_fields(
     all_mandatory_docs = applied_rules.get("mandatory_docs", [])
     doc_configs = applied_rules.get("doc_configs", {})  # {code: {requires_upload, submission_format}}
     
+    # ADM-031 round 10: verifier display name comes from the pre-resolved
+    # ``verifier_names`` map (built once per profile load by
+    # ``_resolve_verifier_names`` — single SELECT for all distinct
+    # verified_by ids). ``None`` here means the caller didn't pass the map
+    # (mutation paths that go through ``_populate_response_fields`` do; a
+    # few internal recompute sites don't), in which case the FE renders
+    # "User #<id>" using the raw ``verified_by`` field. Always safe.
+    _verifier_names_local = verifier_names or {}
+
     # Create lookup of uploaded documents by code
     doc_by_code = {}
     if documents:
@@ -1236,6 +1283,19 @@ def _compute_frontend_fields(
                     "paper_submitted_at": (
                         doc.paper_submitted_at.isoformat()
                         if doc.paper_submitted_at
+                        else None
+                    ),
+                    # ADM-031 round 10: verifier identity for the FE
+                    # "Trạng thái" cell. verified_by_name is filled in
+                    # below from a batched User lookup to keep this loop
+                    # N+1-free.
+                    "verified_at": (
+                        doc.verified_at.isoformat() if doc.verified_at else None
+                    ),
+                    "verified_by": doc.verified_by,
+                    "verified_by_name": (
+                        _verifier_names_local.get(doc.verified_by)
+                        if doc.verified_by is not None
                         else None
                     ),
                 }
@@ -1302,6 +1362,10 @@ def _compute_frontend_fields(
             "uploaded_at": uploaded_doc.get("uploaded_at"),
             # ADM-031 round 7: paper-receipt timestamp
             "paper_submitted_at": uploaded_doc.get("paper_submitted_at"),
+            # ADM-031 round 10: verifier identity for the Trạng thái cell
+            "verified_at": uploaded_doc.get("verified_at"),
+            "verified_by": uploaded_doc.get("verified_by"),
+            "verified_by_name": uploaded_doc.get("verified_by_name"),
             "rejection_reason": uploaded_doc.get("rejection_reason"),
             "submission_format_confirmed": uploaded_doc.get("submission_format_confirmed", False),
             **_perms,
@@ -1473,7 +1537,11 @@ async def _populate_response_fields(
     if documents is None:
         documents = await admission_repo.get_all_documents(profile.id)
 
-    _compute_frontend_fields(profile, current_user, documents)
+    # ADM-031 round 10: resolve verifier display names in a single batched
+    # SELECT so the documents_checklist response carries verified_by_name
+    # without N+1.
+    verifier_names = await _resolve_verifier_names(db, documents)
+    _compute_frontend_fields(profile, current_user, documents, verifier_names)
 
     # Refine the tentative minor_correction permission flag against the
     # live AdmissionPath allowlist. Must run AFTER _compute_frontend_fields
@@ -2298,13 +2366,27 @@ async def get_profiles(
         order=order,
     )
 
+    # ADM-031 round 10: pre-resolve verifier names ACROSS all profiles in
+    # one SELECT so the listing endpoint stays free of N+1 even when many
+    # rows have verified documents.
+    list_verifier_names: Dict[int, str] = {}
+    if current_user and profiles:
+        all_docs: list = []
+        for profile in profiles:
+            if hasattr(profile, "documents") and profile.documents:
+                all_docs.extend(profile.documents)
+        if all_docs:
+            list_verifier_names = await _resolve_verifier_names(db, all_docs)
+
     # Hydrate computed fields (same as detail API) using eager-loaded relations
     for profile in profiles:
         _calculate_and_update_totals(profile)
         # documents already loaded via selectinload in get_filtered_with_count
         docs = profile.documents if hasattr(profile, "documents") else None
         if current_user:
-            _compute_frontend_fields(profile, current_user, docs)
+            _compute_frontend_fields(
+                profile, current_user, docs, list_verifier_names
+            )
 
     # Batch-resolve minor_correction state for the page in ONE query rather
     # than N path lookups. This keeps the list endpoint at exactly one
@@ -2517,7 +2599,12 @@ async def get_profile(
     # =========================================================================
     # Fetch documents for completion calculation
     documents = await admission_repo.get_all_documents(profile_id)
-    _compute_frontend_fields(profile, current_user, documents)
+    _compute_frontend_fields(
+        profile,
+        current_user,
+        documents,
+        await _resolve_verifier_names(db, documents),
+    )
 
     # Refine minor_correction permission against live AdmissionPath config
     # (governance setting, not snapshotted) — keeps detail in lockstep
@@ -2814,7 +2901,12 @@ async def update_profile(
     # (or, conversely, showing "missing" for docs that are actually uploaded). See MEDIUM #1 in
     # the post-BUG-001 residual risks audit.
     documents = await admission_repo.get_all_documents(profile.id)
-    _compute_frontend_fields(profile, current_user, documents)
+    _compute_frontend_fields(
+        profile,
+        current_user,
+        documents,
+        await _resolve_verifier_names(db, documents),
+    )
 
     # Audit trail: log profile update with field-level changes
     from ..services import audit_service
@@ -3493,7 +3585,12 @@ async def upload_document(
         from app.repositories import AdmissionRepository
         admission_repo_refresh = AdmissionRepository(db)
         documents = await admission_repo_refresh.get_all_documents(profile_id)
-        _compute_frontend_fields(profile, current_user, documents)
+        _compute_frontend_fields(
+        profile,
+        current_user,
+        documents,
+        await _resolve_verifier_names(db, documents),
+    )
 
         # ✅ AUDIT LOG: Track document upload
         from .document_audit_service import log_document_upload
@@ -3690,7 +3787,12 @@ async def confirm_document_format(
 
     # 3. Re-compute validation_summary with updated documents
     documents = await admission_repo.get_all_documents(profile_id)
-    _compute_frontend_fields(profile, current_user, documents)
+    _compute_frontend_fields(
+        profile,
+        current_user,
+        documents,
+        await _resolve_verifier_names(db, documents),
+    )
 
     # ✅ AUDIT LOG: Track document verification
     from .document_audit_service import log_document_verification
@@ -3792,7 +3894,12 @@ async def mark_paper_submitted(
 
     # ✅ Re-compute validation_summary with updated documents
     documents = await admission_repo.get_all_documents(profile_id)
-    _compute_frontend_fields(profile, current_user, documents)
+    _compute_frontend_fields(
+        profile,
+        current_user,
+        documents,
+        await _resolve_verifier_names(db, documents),
+    )
 
     log.info(
         "Document paper submitted confirmed with audit log",
@@ -3996,7 +4103,12 @@ async def reset_document(
 
     # Re-compute validation_summary with updated documents
     documents = await admission_repo.get_all_documents(profile_id)
-    _compute_frontend_fields(profile, current_user, documents)
+    _compute_frontend_fields(
+        profile,
+        current_user,
+        documents,
+        await _resolve_verifier_names(db, documents),
+    )
 
     log.info(
         "Document reset staged (awaiting commit)",

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -352,7 +352,7 @@ describe("DocumentsTab — ADM-031 round 5 reception & how-to columns", () => {
     expect(receptionCell?.textContent).toMatch(/^Chưa/);
   });
 
-  it("requires_upload=false row shows 'Nhận giấy tại quầy' how-to + 'Đánh dấu đã nhận giấy' button", () => {
+  it("requires_upload=false row shows 'Nhận giấy' how-to + 'Đã nhận giấy' visible button", () => {
     const profile = buildProfile([
       {
         code: "PHIEU",
@@ -365,12 +365,176 @@ describe("DocumentsTab — ADM-031 round 5 reception & how-to columns", () => {
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
     const table = screen.getByRole("table");
-    expect(within(table).getByText(/Nhận giấy tại quầy/)).toBeInTheDocument();
+    // Short verb in the table cell — the long "Nhận giấy tại quầy" was
+    // dropped in round 6 to match the screenshot. Tooltip still keeps
+    // the long copy.
+    expect(within(table).getByText(/^Nhận giấy$/)).toBeInTheDocument();
     expect(
-      within(table).getByRole("button", { name: /đánh dấu đã nhận giấy/i }),
-    ).toBeInTheDocument();
+      within(table).queryByText(/Nhận giấy tại quầy/i),
+    ).not.toBeInTheDocument();
+    // Button: visible "Đã nhận giấy", aria-label "Đánh dấu đã nhận giấy".
+    const paperButton = within(table).getByRole("button", {
+      name: /đánh dấu đã nhận giấy/i,
+    });
+    expect(paperButton).toBeInTheDocument();
+    expect(paperButton).toHaveAccessibleName(/đánh dấu đã nhận giấy/i);
+    expect(paperButton.textContent).toMatch(/^Đã nhận giấy$/);
     // No upload-flow copy on a paper-only row.
     expect(within(table).queryByText(/^Tải file$/)).not.toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// ADM-031 ROUND 6 — STATUS WORKFLOW LABELS
+// =============================================================================
+
+describe("DocumentsTab — ADM-031 round 6 status workflow labels", () => {
+  it("missing row shows 'Cần làm' status + 'Chưa' reception", () => {
+    const profile = buildProfile([
+      {
+        code: "C",
+        label: "Bằng",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/^Cần làm$/)).toBeInTheDocument();
+    expect(within(table).getByText(/^Chưa$/)).toBeInTheDocument();
+    // Old workflow copy must not leak.
+    expect(within(table).queryByText(/^Chưa nộp$/)).not.toBeInTheDocument();
+  });
+
+  it("uploaded row shows 'Chờ duyệt' status + 'File' reception", () => {
+    const profile = buildProfile([
+      {
+        code: "U",
+        label: "Học bạ",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/^Chờ duyệt$/)).toBeInTheDocument();
+    expect(within(table).getByText(/^File$/)).toBeInTheDocument();
+    expect(within(table).queryByText(/Đã ghi nhận file/)).not.toBeInTheDocument();
+  });
+
+  it("paper_submitted row shows 'Chờ duyệt' status + 'Giấy' reception", () => {
+    const profile = buildProfile([
+      {
+        code: "P",
+        label: "Phiếu",
+        status: "paper_submitted",
+        is_mandatory: true,
+        requires_upload: false,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/^Chờ duyệt$/)).toBeInTheDocument();
+    expect(within(table).getByText(/^Giấy$/)).toBeInTheDocument();
+    expect(within(table).queryByText(/Đã nhận bản giấy/)).not.toBeInTheDocument();
+  });
+
+  it("verified row shows 'Đã duyệt' status + 'File' reception", () => {
+    const profile = buildProfile([
+      {
+        code: "V",
+        label: "Học bạ",
+        status: "verified",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/^Đã duyệt$/)).toBeInTheDocument();
+    expect(within(table).getByText(/^File$/)).toBeInTheDocument();
+    expect(within(table).queryByText(/^Đã kiểm tra$/)).not.toBeInTheDocument();
+  });
+
+  it("rejected row shows 'Từ chối' status + 'Chưa' reception", () => {
+    const profile = buildProfile([
+      {
+        code: "R",
+        label: "Bằng",
+        status: "rejected",
+        is_mandatory: true,
+        requires_upload: true,
+        rejection_reason: "Mờ",
+      } as never,
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/^Từ chối$/)).toBeInTheDocument();
+    expect(within(table).getByText(/^Chưa$/)).toBeInTheDocument();
+    expect(within(table).queryByText(/^Không hợp lệ$/)).not.toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// ADM-031 ROUND 6 — SHORT FORMAT LABELS IN TABLE
+// =============================================================================
+
+describe("DocumentsTab — ADM-031 round 6 short format labels", () => {
+  it("table renders short format labels (Gốc / Chứng thực / Chụp/scan)", () => {
+    const profile = buildProfile([
+      {
+        code: "A",
+        label: "Bằng",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+        submission_format: "original",
+      },
+      {
+        code: "B",
+        label: "Học bạ",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+        submission_format: "certified_copy",
+      },
+      {
+        code: "C",
+        label: "Ảnh",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+        submission_format: "photo",
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/^Gốc$/)).toBeInTheDocument();
+    expect(within(table).getByText(/^Chứng thực$/)).toBeInTheDocument();
+    expect(within(table).getByText(/^Chụp\/scan$/)).toBeInTheDocument();
+  });
+
+  it("full format label still appears in tooltip / aria-label", () => {
+    const profile = buildProfile([
+      {
+        code: "C",
+        label: "Ảnh",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+        submission_format: "photo",
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    // The cell wrapping the short label carries the full string in
+    // aria-label / title so screen readers still get the long form.
+    const fullLabel = within(table).getByLabelText(
+      /Bản chụp\/scan không chứng thực/i,
+    );
+    expect(fullLabel).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -1,18 +1,23 @@
 /**
- * DocumentsTab — per-row permission gating + ADM-031 task-orientation.
+ * DocumentsTab — KPI strip + responsive table layout (ADM-031 round 5).
  *
- * Two concerns are exercised here:
+ * Three concerns are exercised here:
  *
  * 1. Per-row permission flags from PR #5 (`can_upload`, `can_reject`,
  *    `can_reset`, `can_mark_paper_submitted`). Each action button must
  *    only render when the matching backend flag is true.
  *
- * 2. ADM-031 wireframe — missing rows surface a task-oriented hint
- *    ("Cần tải ảnh/scan" vs "Nhận bản giấy tại quầy") and the action
- *    buttons carry explicit labels ("Tải file" / "Đánh dấu đã nhận
- *    giấy") instead of icon-only triggers. Format dialog wording was
- *    rewritten to clarify that the user is declaring the actual paper
- *    type, not uploading additional evidence.
+ * 2. ADM-031 task-orientation. Missing rows surface a task-oriented
+ *    hint and the action buttons carry explicit Vietnamese labels
+ *    ("Tải file" / "Đánh dấu đã nhận giấy") instead of icon-only
+ *    triggers. Format dialog wording was rewritten to clarify that
+ *    the user is declaring the actual paper type, not uploading
+ *    additional evidence.
+ *
+ * 3. ADM-031 round 5 layout. The card body now renders a KPI strip
+ *    on top and a semantic table on the desktop (md+) breakpoint, so
+ *    officers read the cohort state at a glance and the row actions
+ *    have a stable column. Mobile <md still gets a stacked card.
  */
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@/test/utils/test-utils";
@@ -21,10 +26,8 @@ import userEvent from "@testing-library/user-event";
 
 import { DocumentsTab } from "./DocumentsTab";
 
-// Mutation hooks issue network calls — stub them so the tab renders in
-// isolation without MSW handlers.
 vi.mock("@/hooks/admissions/useAdmissions", () => ({
-  useUploadAdmissionDocument: () => ({ mutate: vi.fn(), isPending: false }),
+  useUploadAdmissionDocument: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
   useMarkPaperSubmitted: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
   useRejectDocument: () => ({ mutate: vi.fn(), isPending: false }),
   useResetDocument: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
@@ -65,6 +68,10 @@ function buildProfile(docs: DocRow[]) {
   };
 }
 
+// =============================================================================
+// PER-ROW PERMISSION FLAGS (PR #5)
+// =============================================================================
+
 describe("DocumentsTab — per-row permission flags", () => {
   it("renders Upload only when can_upload=true", () => {
     const profile = buildProfile([
@@ -78,7 +85,10 @@ describe("DocumentsTab — per-row permission flags", () => {
       },
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
-    expect(screen.getByRole("button", { name: /tải file/i })).toBeInTheDocument();
+    // Both desktop table + mobile card render in jsdom (no media-query
+    // resolution); scope to the table so the duplicate doesn't clash.
+    const table = screen.getByRole("table");
+    expect(within(table).getByRole("button", { name: /tải file/i })).toBeInTheDocument();
   });
 
   it("hides Upload when can_upload=false even if status=missing", () => {
@@ -97,31 +107,34 @@ describe("DocumentsTab — per-row permission flags", () => {
   });
 
   it("shows Reject only when can_reject=true", () => {
-    const uploadedWithReject = buildProfile([
+    const allowed = buildProfile([
       {
         code: "HOC_BA",
-        label: "Học bạ",
+        label: "Học bạ THPT",
         status: "uploaded",
         is_mandatory: true,
         requires_upload: true,
         can_reject: true,
       },
     ]);
-    const { unmount } = render(<DocumentsTab profile={uploadedWithReject as never} isEditable />);
-    expect(screen.getByRole("button", { name: /từ chối/i })).toBeInTheDocument();
+    const { unmount } = render(<DocumentsTab profile={allowed as never} isEditable />);
+    const allowedTable = screen.getByRole("table");
+    expect(
+      within(allowedTable).getByRole("button", { name: /từ chối/i }),
+    ).toBeInTheDocument();
     unmount();
 
-    const uploadedNoReject = buildProfile([
+    const blocked = buildProfile([
       {
         code: "HOC_BA",
-        label: "Học bạ",
+        label: "Học bạ THPT",
         status: "uploaded",
         is_mandatory: true,
         requires_upload: true,
         can_reject: false,
       },
     ]);
-    render(<DocumentsTab profile={uploadedNoReject as never} isEditable />);
+    render(<DocumentsTab profile={blocked as never} isEditable />);
     expect(screen.queryByRole("button", { name: /từ chối/i })).not.toBeInTheDocument();
   });
 
@@ -130,18 +143,23 @@ describe("DocumentsTab — per-row permission flags", () => {
       {
         code: "BANG_TN",
         label: "Bằng tốt nghiệp",
-        status: "verified",
+        status: "rejected",
         is_mandatory: true,
         requires_upload: true,
         can_reset: true,
       },
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
-    expect(screen.getByRole("button", { name: /đặt lại/i })).toBeInTheDocument();
+    // Reset button is icon-only; assert via aria-label inside the table
+    // (mobile card duplicate would also match).
+    const table = screen.getByRole("table");
+    expect(
+      within(table).getByRole("button", { name: /đặt lại tài liệu về chưa nộp/i }),
+    ).toBeInTheDocument();
   });
 
   it("shows the paper-receipt button only when can_mark_paper_submitted=true", () => {
-    const paperAllowed = buildProfile([
+    const allowed = buildProfile([
       {
         code: "HD_NH",
         label: "Hợp đồng ngân hàng",
@@ -151,13 +169,17 @@ describe("DocumentsTab — per-row permission flags", () => {
         can_mark_paper_submitted: true,
       },
     ]);
-    const { unmount } = render(<DocumentsTab profile={paperAllowed as never} isEditable />);
+    // Both desktop table and mobile <ul> render in jsdom; tailwind md: media
+    // queries don't drop one layout, so the same button shows up twice.
+    // Scope to the table so the assertion is unambiguous.
+    const { unmount } = render(<DocumentsTab profile={allowed as never} isEditable />);
+    const table = screen.getByRole("table");
     expect(
-      screen.getByRole("button", { name: /đánh dấu đã nhận giấy/i })
+      within(table).getByRole("button", { name: /đánh dấu đã nhận giấy/i }),
     ).toBeInTheDocument();
     unmount();
 
-    const paperBlocked = buildProfile([
+    const blocked = buildProfile([
       {
         code: "HD_NH",
         label: "Hợp đồng ngân hàng",
@@ -167,35 +189,150 @@ describe("DocumentsTab — per-row permission flags", () => {
         can_mark_paper_submitted: false,
       },
     ]);
-    render(<DocumentsTab profile={paperBlocked as never} isEditable />);
+    render(<DocumentsTab profile={blocked as never} isEditable />);
     expect(
-      screen.queryByRole("button", { name: /đánh dấu đã nhận giấy/i })
-    ).not.toBeInTheDocument();
-  });
-
-  it("renders all buttons hidden when every flag is omitted (legacy row default)", () => {
-    const profile = buildProfile([
-      {
-        code: "CCCD",
-        label: "Căn cước",
-        status: "uploaded",
-        is_mandatory: true,
-        requires_upload: true,
-        // no can_* flags → optional() defaults surface as undefined → all hidden
-      },
-    ]);
-    render(<DocumentsTab profile={profile as never} isEditable />);
-    expect(screen.queryByRole("button", { name: /tải file/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /từ chối/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /đặt lại/i })).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /đánh dấu đã nhận giấy/i })
+      screen.queryByRole("button", { name: /đánh dấu đã nhận giấy/i }),
     ).not.toBeInTheDocument();
   });
 });
 
-describe("DocumentsTab — ADM-031 task-orientation", () => {
-  it("missing + requires_upload row shows 'Cần tải ảnh/scan' hint, 'Cần file' mode, and a Tải file button", () => {
+// =============================================================================
+// ADM-031 ROUND 5 — KPI STRIP
+// =============================================================================
+
+describe("DocumentsTab — ADM-031 round 5 KPI strip", () => {
+  it("renders 4 KPI tiles with the expected counts", () => {
+    const profile = buildProfile([
+      // Online row already verified → recorded + satisfied.
+      {
+        code: "B",
+        label: "Học bạ",
+        status: "verified",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+      // Online row officer has not verified yet → recorded + pending.
+      {
+        code: "A",
+        label: "Ảnh 3x4",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+      // Paper-only row marked received → recorded + satisfied.
+      {
+        code: "P",
+        label: "Phiếu cam kết",
+        status: "paper_submitted",
+        is_mandatory: true,
+        requires_upload: false,
+      },
+      // Mandatory missing → action queue.
+      {
+        code: "C",
+        label: "Bằng tốt nghiệp",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const kpi = screen.getByRole("group", { name: /tổng quan tài liệu/i });
+    // Tổng tài liệu = 4
+    expect(within(kpi).getByText(/^tổng tài liệu$/i)).toBeInTheDocument();
+    expect(within(kpi).getByText("4")).toBeInTheDocument();
+    // Đã ghi nhận = 3/4 (uploaded + verified + paper_submitted)
+    expect(within(kpi).getByText(/^đã ghi nhận$/i)).toBeInTheDocument();
+    expect(within(kpi).getByText("3/4")).toBeInTheDocument();
+    // Chờ kiểm tra = 1 (uploaded only)
+    expect(within(kpi).getByText(/^chờ kiểm tra$/i)).toBeInTheDocument();
+    expect(within(kpi).getByText("1")).toBeInTheDocument();
+    // Hoàn tất yêu cầu = 2/4 (verified + paper_submitted)
+    expect(within(kpi).getByText(/^hoàn tất yêu cầu$/i)).toBeInTheDocument();
+    expect(within(kpi).getByText("2/4")).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// ADM-031 ROUND 5 — TABLE LAYOUT
+// =============================================================================
+
+describe("DocumentsTab — ADM-031 round 5 desktop table", () => {
+  it("renders a semantic table with the 7-column header", () => {
+    const profile = buildProfile([
+      {
+        code: "CCCD",
+        label: "Căn cước",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    const headers = within(table).getAllByRole("columnheader");
+    const headerLabels = headers.map((h) => h.textContent?.trim());
+    expect(headerLabels).toEqual([
+      "#",
+      "Tên giấy tờ",
+      "Yêu cầu",
+      "Đã ghi nhận",
+      "Cách ghi nhận",
+      "Trạng thái",
+      "Thao tác",
+    ]);
+  });
+
+  it("sorts rows by work-queue priority: missing/rejected → uploaded/paper_submitted → verified", () => {
+    const profile = buildProfile([
+      // Intentionally out of order to verify sort.
+      {
+        code: "A",
+        label: "Verified mandatory",
+        status: "verified",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+      {
+        code: "B",
+        label: "Uploaded mandatory",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+      {
+        code: "C",
+        label: "Missing optional",
+        status: "missing",
+        is_mandatory: false,
+        requires_upload: true,
+      },
+      {
+        code: "D",
+        label: "Missing mandatory",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    const rows = within(table).getAllByRole("row").slice(1); // skip header
+    const labels = rows.map((r) => within(r).getAllByRole("cell")[1]?.textContent);
+    // Priority: missing(mandatory) → missing(optional) → uploaded → verified
+    expect(labels[0]).toContain("Missing mandatory");
+    expect(labels[1]).toContain("Missing optional");
+    expect(labels[2]).toContain("Uploaded mandatory");
+    expect(labels[3]).toContain("Verified mandatory");
+  });
+});
+
+// =============================================================================
+// ADM-031 ROUND 5 — RECEPTION + HOW-TO COLUMNS
+// =============================================================================
+
+describe("DocumentsTab — ADM-031 round 5 reception & how-to columns", () => {
+  it("requires_upload=true row shows 'Tải file' how-to and 'File'/'Chưa' reception bucket", () => {
     const profile = buildProfile([
       {
         code: "CCCD",
@@ -206,22 +343,20 @@ describe("DocumentsTab — ADM-031 task-orientation", () => {
         can_upload: true,
       },
     ]);
-    render(<DocumentsTab profile={profile as never} isEditable />);
-    expect(screen.getByText(/cần tải ảnh\/scan/i)).toBeInTheDocument();
-    // ADM-031 round 2: "Online" was replaced with "Cần file" so the mode
-    // badge actually describes the workflow.
-    expect(screen.getByText(/^Cần file$/i)).toBeInTheDocument();
-    expect(screen.queryByText(/^Online$/i)).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /tải file/i })).toBeInTheDocument();
-    // Paper hint must NOT appear for online docs.
-    expect(screen.queryByText(/nhận bản giấy tại quầy/i)).not.toBeInTheDocument();
+    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
+    expect(container.textContent).toMatch(/Tải file/);
+    // The row exposes the "Chưa" reception bucket for missing.
+    const table = screen.getByRole("table");
+    const cells = within(table).getAllByRole("cell");
+    const receptionCell = cells[3]; // # | Tên | Yêu cầu | Đã ghi nhận | ...
+    expect(receptionCell?.textContent).toMatch(/^Chưa/);
   });
 
-  it("missing + paper-only row shows 'Nhận bản giấy tại quầy' hint, 'Ghi nhận giấy' mode, and a Đánh dấu đã nhận giấy button", () => {
+  it("requires_upload=false row shows 'Nhận giấy tại quầy' how-to + 'Đánh dấu đã nhận giấy' button", () => {
     const profile = buildProfile([
       {
-        code: "HD_NH",
-        label: "Hợp đồng ngân hàng",
+        code: "PHIEU",
+        label: "Phiếu cam kết",
         status: "missing",
         is_mandatory: true,
         requires_upload: false,
@@ -229,41 +364,22 @@ describe("DocumentsTab — ADM-031 task-orientation", () => {
       },
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
-    expect(screen.getByText(/nhận bản giấy tại quầy/i)).toBeInTheDocument();
-    // ADM-031 round 2: "Nộp giấy" was replaced with "Ghi nhận giấy" to
-    // match the paper-only checklist semantic.
-    expect(screen.getByText(/^Ghi nhận giấy$/i)).toBeInTheDocument();
-    expect(screen.queryByText(/^Nộp giấy$/i)).not.toBeInTheDocument();
+    const table = screen.getByRole("table");
+    expect(within(table).getByText(/Nhận giấy tại quầy/)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /đánh dấu đã nhận giấy/i })
+      within(table).getByRole("button", { name: /đánh dấu đã nhận giấy/i }),
     ).toBeInTheDocument();
-    // Online hint must NOT appear for paper-only docs.
-    expect(screen.queryByText(/cần tải ảnh\/scan/i)).not.toBeInTheDocument();
+    // No upload-flow copy on a paper-only row.
+    expect(within(table).queryByText(/^Tải file$/)).not.toBeInTheDocument();
   });
+});
 
-  it("non-missing rows do not surface either task hint", () => {
-    const profile = buildProfile([
-      {
-        code: "CCCD",
-        label: "Căn cước",
-        status: "uploaded",
-        is_mandatory: true,
-        requires_upload: true,
-      },
-      {
-        code: "HD_NH",
-        label: "Hợp đồng",
-        status: "paper_submitted",
-        is_mandatory: false,
-        requires_upload: false,
-      },
-    ]);
-    render(<DocumentsTab profile={profile as never} isEditable />);
-    expect(screen.queryByText(/cần tải ảnh\/scan/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/nhận bản giấy tại quầy/i)).not.toBeInTheDocument();
-  });
+// =============================================================================
+// ADM-031 ROUND 5 — NO LEGACY "ONLINE" COPY ANYWHERE
+// =============================================================================
 
-  it("does not leak deprecated mode/status copy ('Online' / 'Nộp giấy' / '(online)' / 'Bản photocopy' / 'Bản photo/scan' / 'Ảnh chụp') in officer UI", () => {
+describe("DocumentsTab — ADM-031 round 5 deprecated copy guard", () => {
+  it("does not render any 'online' copy for any document state", () => {
     const profile = buildProfile([
       {
         code: "CCCD",
@@ -272,6 +388,7 @@ describe("DocumentsTab — ADM-031 task-orientation", () => {
         is_mandatory: true,
         requires_upload: true,
         submission_format: "photo",
+        actual_submission_format: "photo",
       },
       {
         code: "HD",
@@ -280,113 +397,79 @@ describe("DocumentsTab — ADM-031 task-orientation", () => {
         is_mandatory: false,
         requires_upload: false,
         submission_format: "certified_copy",
+        actual_submission_format: "certified_copy",
+      },
+      {
+        code: "BANG_TN",
+        label: "Bằng tốt nghiệp",
+        status: "verified",
+        is_mandatory: true,
+        requires_upload: true,
+        submission_format: "certified_copy",
+        verified_format: "certified_copy",
+        actual_submission_format: "certified_copy",
       },
     ]);
-    const { container } = render(
-      <DocumentsTab profile={profile as never} isEditable />
-    );
-    // Old mode labels and the deprecated "(online)" parenthetical that
-    // used to appear in the uploaded status — the workflow doesn't have
-    // an "online" concept, only "needs file" vs "paper-only".
-    expect(container.textContent).not.toMatch(/\bOnline\b/i);
-    expect(container.textContent).not.toMatch(/\bNộp giấy\b/);
+    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
+    // Forbidden legacy copy.
+    expect(container.textContent).not.toMatch(/\bonline\b/i);
+    expect(container.textContent).not.toMatch(/\bnộp giấy\b/i);
     expect(container.textContent).not.toMatch(/\(online\)/i);
-    // Old format labels (legacy duplicates) — the centralized source uses
-    // "Bản chụp/scan không chứng thực" for `photo`, never these.
     expect(container.textContent).not.toMatch(/Bản photocopy/);
     expect(container.textContent).not.toMatch(/Bản photo\/scan/);
     expect(container.textContent).not.toMatch(/Ảnh chụp hoặc scan/);
+    // Required new copy.
+    expect(container.textContent).toMatch(/Tải file/);
+    expect(container.textContent).toMatch(/Bản chụp\/scan không chứng thực/);
   });
 });
 
-describe("DocumentsTab — ADM-031 progress and status labels", () => {
-  it("splits header into ghi nhận / chờ kiểm tra / hoàn tất yêu cầu", () => {
+// =============================================================================
+// ADM-031 ROUND 5 — RECORDED FORMAT (round 4 carryover)
+// =============================================================================
+
+describe("DocumentsTab — ADM-031 recorded format display", () => {
+  it("shows actual_submission_format on uploaded rows", () => {
     const profile = buildProfile([
       {
-        // Online row: officer has not verified yet → counts as recorded
-        // and pending, but NOT as satisfying the requirement.
-        code: "A",
-        label: "A",
+        code: "anh_3x4",
+        label: "Ảnh 3x4",
         status: "uploaded",
         is_mandatory: true,
         requires_upload: true,
-      },
-      {
-        // Online row already verified → recorded + satisfied.
-        code: "B",
-        label: "B",
-        status: "verified",
-        is_mandatory: true,
-        requires_upload: true,
-      },
-      {
-        // Paper-only row marked received → recorded + satisfied
-        // (backend `paper_submitted` already completes the requirement).
-        code: "P",
-        label: "P",
-        status: "paper_submitted",
-        is_mandatory: true,
-        requires_upload: false,
-      },
-      {
-        code: "C",
-        label: "C",
-        status: "missing",
-        is_mandatory: true,
-        requires_upload: true,
+        submission_format: "certified_copy",
+        actual_submission_format: "photo",
       },
     ]);
-    render(<DocumentsTab profile={profile as never} isEditable />);
-    // Recorded = uploaded + verified + paper_submitted = 3 of 4
-    expect(screen.getByText(/đã ghi nhận 3\/4/i)).toBeInTheDocument();
-    // Pending verification = uploaded only = 1
-    expect(screen.getByText(/chờ kiểm tra 1/i)).toBeInTheDocument();
-    // Satisfied = verified + paper_submitted = 2 of 4 (backend gate)
-    expect(screen.getByText(/hoàn tất yêu cầu 2\/4/i)).toBeInTheDocument();
-    // Progress reflects backend mandatory-completion semantics. 2 of 4
-    // mandatory rows satisfy the requirement → 50%.
-    const progressBar = screen.getByRole("progressbar", {
-      name: /tiến độ hoàn tất tài liệu/i,
-    });
-    expect(progressBar).toHaveAttribute("aria-valuenow", "50");
+    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
+    // Required + recorded both visible.
+    expect(container.textContent).toMatch(/Bản sao chứng thực/);
+    expect(container.textContent).toMatch(/Bản chụp\/scan không chứng thực/);
   });
 
-  it("uploaded status renders as 'Đã ghi nhận', verified as 'Đã kiểm tra'", () => {
+  it("shows verified_format on verified rows", () => {
     const profile = buildProfile([
       {
-        code: "U",
-        label: "Uploaded row",
-        status: "uploaded",
-        is_mandatory: true,
-        requires_upload: true,
-      },
-      {
-        code: "V",
-        label: "Verified row",
+        code: "hoc_ba_thpt",
+        label: "Học bạ THPT",
         status: "verified",
         is_mandatory: true,
         requires_upload: true,
-      },
-      {
-        code: "P",
-        label: "Paper row",
-        status: "paper_submitted",
-        is_mandatory: false,
-        requires_upload: false,
+        submission_format: "certified_copy",
+        actual_submission_format: "certified_copy",
+        verified_format: "certified_copy",
       },
     ]);
-    render(<DocumentsTab profile={profile as never} isEditable />);
-    // Header summary already mentions both phrases, so a row badge would
-    // collide with the summary node. Match all and assert presence of at
-    // least one badge per status — header renders these phrases too.
-    // ADM-031 round 3: "Đã ghi nhận file" replaces the old
-    // "Đã ghi nhận (online)" so the document status copy never says
-    // "online" (the workflow distinction is needs-file vs paper-only).
-    expect(screen.getAllByText(/đã ghi nhận file/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/đã kiểm tra/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/đã nhận bản giấy/i).length).toBeGreaterThan(0);
+    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
+    // Reception bucket reads "File" + the format detail.
+    expect(container.textContent).toMatch(/File/);
+    expect(container.textContent).toMatch(/Bản sao chứng thực/);
   });
 });
+
+// =============================================================================
+// ADM-031 ROUND 2 — PAPER DIALOG
+// =============================================================================
 
 describe("DocumentsTab — ADM-031 paper-receipt dialog", () => {
   it("opens with paper-specific title, prompt, primary button, and centralized labels", async () => {
@@ -404,31 +487,25 @@ describe("DocumentsTab — ADM-031 paper-receipt dialog", () => {
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
 
+    const table = screen.getByRole("table");
     await user.click(
-      screen.getByRole("button", { name: /đánh dấu đã nhận giấy/i })
+      within(table).getByRole("button", { name: /đánh dấu đã nhận giấy/i }),
     );
 
     const dialog = await screen.findByRole("dialog");
-    // ADM-031 round 2: paper-specific dialog title (no file/upload word).
     expect(
-      screen.getByRole("heading", { name: /xác nhận bản giấy vừa nhận/i })
+      screen.getByRole("heading", { name: /xác nhận bản giấy vừa nhận/i }),
     ).toBeInTheDocument();
     expect(dialog).toHaveTextContent(/bản giấy vừa nhận là bản gì\?/i);
-    // Required-format requirement is surfaced verbatim.
     expect(dialog).toHaveTextContent(/yêu cầu hồ sơ:/i);
     expect(dialog).toHaveTextContent(/bản sao chứng thực/i);
-    // Centralized labels (admission-helpers) — old strings ("Bản chính",
-    // "Bản photocopy", "Bản sao có chứng thực") must not appear.
     expect(dialog).toHaveTextContent(/bản gốc/i);
     expect(dialog).toHaveTextContent(/bản chụp\/scan không chứng thực/i);
     expect(dialog).not.toHaveTextContent(/bản chính/i);
-    expect(dialog).not.toHaveTextContent(/^bản photocopy$/im);
-    // Paper-flow primary button is "Ghi nhận giấy", not the upload one.
     expect(screen.getByRole("button", { name: /^ghi nhận giấy$/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /^tải file$/i })).not.toBeInTheDocument();
   });
 
-  it("shows paper-specific soft warning when the chosen actual format differs from the required format", async () => {
+  it("shows paper-specific soft warning when actual ≠ required", async () => {
     const user = userEvent.setup();
     const profile = buildProfile([
       {
@@ -442,26 +519,24 @@ describe("DocumentsTab — ADM-031 paper-receipt dialog", () => {
       },
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
-
+    const table = screen.getByRole("table");
     await user.click(
-      screen.getByRole("button", { name: /đánh dấu đã nhận giấy/i })
+      within(table).getByRole("button", { name: /đánh dấu đã nhận giấy/i }),
     );
-
-    // Default selectedFormat is the required format → warning hidden.
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-
-    // Switch to a different actual format → paper-specific warning surfaces.
     await user.click(screen.getByRole("radio", { name: /bản gốc/i }));
     const alert = await screen.findByRole("alert");
     expect(alert).toHaveTextContent(/bản giấy thực tế khác yêu cầu hồ sơ/i);
     expect(alert).toHaveTextContent(/trước khi ghi nhận/i);
-    // Upload-flow copy must NOT leak into paper dialog.
-    expect(alert).not.toHaveTextContent(/trước khi tải file/i);
   });
 });
 
+// =============================================================================
+// ADM-031 ROUND 2 — UPLOAD DIALOG
+// =============================================================================
+
 describe("DocumentsTab — ADM-031 upload dialog", () => {
-  it("opens with upload-specific title, prompt, primary button after a file is selected", async () => {
+  it("opens with upload-specific title after a file is selected", async () => {
     const user = userEvent.setup();
     const profile = buildProfile([
       {
@@ -474,150 +549,25 @@ describe("DocumentsTab — ADM-031 upload dialog", () => {
         submission_format: "photo",
       },
     ]);
-    const { container } = render(
-      <DocumentsTab profile={profile as never} isEditable />
-    );
+    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
 
-    // Two-step upload flow: clicking the row's "Tải file" button arms the
-    // hidden file input + state; the submission-format dialog only opens
-    // AFTER the user picks a file. Mirror both steps in the test.
-    await user.click(screen.getByRole("button", { name: /^tải file$/i }));
+    // Click the row's "Tải file" button to arm the hidden file input,
+    // then fire the change with a fake file. Scope to the table so the
+    // duplicate mobile-card button doesn't clash.
+    const table = screen.getByRole("table");
+    await user.click(within(table).getByRole("button", { name: /^tải file$/i }));
     const fileInput = container.querySelector(
-      'input[type="file"]'
+      'input[type="file"]',
     ) as HTMLInputElement;
     expect(fileInput).toBeTruthy();
     const file = new File(["dummy"], "ccd.pdf", { type: "application/pdf" });
     await user.upload(fileInput, file);
 
     const dialog = await screen.findByRole("dialog");
-    // Upload-specific title and prompt.
     expect(
-      screen.getByRole("heading", { name: /^tải file tài liệu$/i })
+      screen.getByRole("heading", { name: /^tải file tài liệu$/i }),
     ).toBeInTheDocument();
     expect(dialog).toHaveTextContent(/file này là bản gì\?/i);
-    expect(dialog).toHaveTextContent(/yêu cầu hồ sơ:/i);
-    // Upload-flow primary button (in the dialog footer) is "Tải file".
-    // The row also has a "Tải file" button, so scope to the dialog.
-    expect(
-      within(dialog).getByRole("button", { name: /^tải file$/i })
-    ).toBeInTheDocument();
-    expect(
-      within(dialog).queryByRole("button", { name: /^ghi nhận giấy$/i })
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows upload-specific soft warning when the chosen actual format differs from the required format", async () => {
-    const user = userEvent.setup();
-    const profile = buildProfile([
-      {
-        code: "CCCD",
-        label: "Căn cước công dân",
-        status: "missing",
-        is_mandatory: true,
-        requires_upload: true,
-        can_upload: true,
-        submission_format: "certified_copy",
-      },
-    ]);
-    const { container } = render(
-      <DocumentsTab profile={profile as never} isEditable />
-    );
-
-    await user.click(screen.getByRole("button", { name: /^tải file$/i }));
-    const fileInput = container.querySelector(
-      'input[type="file"]'
-    ) as HTMLInputElement;
-    const file = new File(["dummy"], "ccd.pdf", { type: "application/pdf" });
-    await user.upload(fileInput, file);
-
-    // Default selectedFormat = required format → warning hidden.
-    await screen.findByRole("dialog");
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-
-    // Switch actual format → upload-specific warning surfaces.
-    await user.click(screen.getByRole("radio", { name: /bản gốc/i }));
-    const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent(/loại bản trong file khác yêu cầu hồ sơ/i);
-    expect(alert).toHaveTextContent(/trước khi tải file/i);
-    // Paper-flow copy must NOT leak into upload dialog.
-    expect(alert).not.toHaveTextContent(/trước khi ghi nhận/i);
-  });
-});
-
-describe("DocumentsTab — ADM-031 round 4 actual / verified format display", () => {
-  it("shows actual_submission_format on uploaded rows (officer-declared, info colour)", () => {
-    const profile = buildProfile([
-      {
-        code: "anh_3x4",
-        label: "Ảnh 3x4",
-        status: "uploaded",
-        is_mandatory: true,
-        requires_upload: true,
-        // Path requires certified_copy but officer uploaded a plain photo.
-        submission_format: "certified_copy",
-        actual_submission_format: "photo",
-      },
-    ]);
-    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
-    // Both required AND actual format must be visible — officer needs the
-    // diff at a glance to decide whether to redo the upload.
-    expect(container.textContent).toMatch(/bản sao chứng thực/i);
-    expect(container.textContent).toMatch(/bản chụp\/scan không chứng thực/i);
-    // Recorded label is mobile-only (md:hidden); rendered into DOM either way.
-    expect(container.textContent).toMatch(/đã ghi nhận \(loại bản\)/i);
-  });
-
-  it("shows verified_format on verified rows (manager-confirmed, success colour)", () => {
-    const profile = buildProfile([
-      {
-        code: "hoc_ba_thpt",
-        label: "Học bạ THPT",
-        status: "verified",
-        is_mandatory: true,
-        requires_upload: true,
-        submission_format: "certified_copy",
-        actual_submission_format: "certified_copy",
-        verified_format: "certified_copy",
-      },
-    ]);
-    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
-    // The "Đã kiểm tra (loại bản)" label replaces the "ghi nhận" variant
-    // once a manager confirms the format.
-    expect(container.textContent).toMatch(/đã kiểm tra \(loại bản\)/i);
-    expect(container.textContent).not.toMatch(/đã ghi nhận \(loại bản\)/i);
-  });
-
-  it("shows actual_submission_format on paper_submitted rows", () => {
-    const profile = buildProfile([
-      {
-        code: "giay_khai_sinh",
-        label: "Giấy khai sinh",
-        status: "paper_submitted",
-        is_mandatory: true,
-        requires_upload: false,
-        submission_format: "original",
-        actual_submission_format: "certified_copy",
-      },
-    ]);
-    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
-    expect(container.textContent).toMatch(/bản gốc/i);
-    expect(container.textContent).toMatch(/bản sao chứng thực/i);
-    expect(container.textContent).toMatch(/đã ghi nhận \(loại bản\)/i);
-  });
-
-  it("does not render the recorded-format badge when actual is missing (status=missing)", () => {
-    const profile = buildProfile([
-      {
-        code: "cccd",
-        label: "CCCD",
-        status: "missing",
-        is_mandatory: true,
-        requires_upload: true,
-        submission_format: "photo",
-      },
-    ]);
-    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
-    expect(container.textContent).not.toMatch(/đã ghi nhận \(loại bản\)/i);
-    expect(container.textContent).not.toMatch(/đã kiểm tra \(loại bản\)/i);
+    expect(within(dialog).getByRole("button", { name: /^tải file$/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -41,6 +41,8 @@ type DocRow = {
   can_reset?: boolean;
   can_mark_paper_submitted?: boolean;
   submission_format?: string | null;
+  actual_submission_format?: string | null;
+  verified_format?: string | null;
   file_path?: string | null;
   uploaded_at?: string | null;
 };
@@ -539,5 +541,83 @@ describe("DocumentsTab — ADM-031 upload dialog", () => {
     expect(alert).toHaveTextContent(/trước khi tải file/i);
     // Paper-flow copy must NOT leak into upload dialog.
     expect(alert).not.toHaveTextContent(/trước khi ghi nhận/i);
+  });
+});
+
+describe("DocumentsTab — ADM-031 round 4 actual / verified format display", () => {
+  it("shows actual_submission_format on uploaded rows (officer-declared, info colour)", () => {
+    const profile = buildProfile([
+      {
+        code: "anh_3x4",
+        label: "Ảnh 3x4",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+        // Path requires certified_copy but officer uploaded a plain photo.
+        submission_format: "certified_copy",
+        actual_submission_format: "photo",
+      },
+    ]);
+    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
+    // Both required AND actual format must be visible — officer needs the
+    // diff at a glance to decide whether to redo the upload.
+    expect(container.textContent).toMatch(/bản sao chứng thực/i);
+    expect(container.textContent).toMatch(/bản chụp\/scan không chứng thực/i);
+    // Recorded label is mobile-only (md:hidden); rendered into DOM either way.
+    expect(container.textContent).toMatch(/đã ghi nhận \(loại bản\)/i);
+  });
+
+  it("shows verified_format on verified rows (manager-confirmed, success colour)", () => {
+    const profile = buildProfile([
+      {
+        code: "hoc_ba_thpt",
+        label: "Học bạ THPT",
+        status: "verified",
+        is_mandatory: true,
+        requires_upload: true,
+        submission_format: "certified_copy",
+        actual_submission_format: "certified_copy",
+        verified_format: "certified_copy",
+      },
+    ]);
+    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
+    // The "Đã kiểm tra (loại bản)" label replaces the "ghi nhận" variant
+    // once a manager confirms the format.
+    expect(container.textContent).toMatch(/đã kiểm tra \(loại bản\)/i);
+    expect(container.textContent).not.toMatch(/đã ghi nhận \(loại bản\)/i);
+  });
+
+  it("shows actual_submission_format on paper_submitted rows", () => {
+    const profile = buildProfile([
+      {
+        code: "giay_khai_sinh",
+        label: "Giấy khai sinh",
+        status: "paper_submitted",
+        is_mandatory: true,
+        requires_upload: false,
+        submission_format: "original",
+        actual_submission_format: "certified_copy",
+      },
+    ]);
+    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
+    expect(container.textContent).toMatch(/bản gốc/i);
+    expect(container.textContent).toMatch(/bản sao chứng thực/i);
+    expect(container.textContent).toMatch(/đã ghi nhận \(loại bản\)/i);
+  });
+
+  it("does not render the recorded-format badge when actual is missing (status=missing)", () => {
+    const profile = buildProfile([
+      {
+        code: "cccd",
+        label: "CCCD",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+        submission_format: "photo",
+      },
+    ]);
+    const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
+    expect(container.textContent).not.toMatch(/đã ghi nhận \(loại bản\)/i);
+    expect(container.textContent).not.toMatch(/đã kiểm tra \(loại bản\)/i);
   });
 });

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -1,15 +1,22 @@
 /**
- * DocumentsTab per-row permission gating (PR #5).
+ * DocumentsTab — per-row permission gating + ADM-031 task-orientation.
  *
- * The tab now renders each action button based on the explicit backend
- * flag (`doc.can_upload`, `doc.can_reject`, `doc.can_reset`,
- * `doc.can_mark_paper_submitted`) instead of the coarse
- * `can('edit')` role check. These tests exercise combinations directly
- * against the rendered DOM so any regression that falls back to a role
- * check or inverts a flag gets caught.
+ * Two concerns are exercised here:
+ *
+ * 1. Per-row permission flags from PR #5 (`can_upload`, `can_reject`,
+ *    `can_reset`, `can_mark_paper_submitted`). Each action button must
+ *    only render when the matching backend flag is true.
+ *
+ * 2. ADM-031 wireframe — missing rows surface a task-oriented hint
+ *    ("Cần tải ảnh/scan" vs "Nhận bản giấy tại quầy") and the action
+ *    buttons carry explicit labels ("Tải file" / "Đánh dấu đã nhận
+ *    giấy") instead of icon-only triggers. Format dialog wording was
+ *    rewritten to clarify that the user is declaring the actual paper
+ *    type, not uploading additional evidence.
  */
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@/test/utils/test-utils";
+import userEvent from "@testing-library/user-event";
 
 import { DocumentsTab } from "./DocumentsTab";
 
@@ -32,6 +39,7 @@ type DocRow = {
   can_reject?: boolean;
   can_reset?: boolean;
   can_mark_paper_submitted?: boolean;
+  submission_format?: string | null;
   file_path?: string | null;
   uploaded_at?: string | null;
 };
@@ -67,7 +75,7 @@ describe("DocumentsTab — per-row permission flags", () => {
       },
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
-    expect(screen.getByRole("button", { name: /tải lên/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /tải file/i })).toBeInTheDocument();
   });
 
   it("hides Upload when can_upload=false even if status=missing", () => {
@@ -82,7 +90,7 @@ describe("DocumentsTab — per-row permission flags", () => {
       },
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
-    expect(screen.queryByRole("button", { name: /tải lên/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /tải file/i })).not.toBeInTheDocument();
   });
 
   it("shows Reject only when can_reject=true", () => {
@@ -129,7 +137,7 @@ describe("DocumentsTab — per-row permission flags", () => {
     expect(screen.getByRole("button", { name: /đặt lại/i })).toBeInTheDocument();
   });
 
-  it("shows paper-submit checkbox only when can_mark_paper_submitted=true", () => {
+  it("shows the paper-receipt button only when can_mark_paper_submitted=true", () => {
     const paperAllowed = buildProfile([
       {
         code: "HD_NH",
@@ -141,7 +149,9 @@ describe("DocumentsTab — per-row permission flags", () => {
       },
     ]);
     const { unmount } = render(<DocumentsTab profile={paperAllowed as never} isEditable />);
-    expect(screen.getByLabelText(/đã nộp/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /đánh dấu đã nhận giấy/i })
+    ).toBeInTheDocument();
     unmount();
 
     const paperBlocked = buildProfile([
@@ -155,7 +165,9 @@ describe("DocumentsTab — per-row permission flags", () => {
       },
     ]);
     render(<DocumentsTab profile={paperBlocked as never} isEditable />);
-    expect(screen.queryByLabelText(/đã nộp/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /đánh dấu đã nhận giấy/i })
+    ).not.toBeInTheDocument();
   });
 
   it("renders all buttons hidden when every flag is omitted (legacy row default)", () => {
@@ -170,9 +182,209 @@ describe("DocumentsTab — per-row permission flags", () => {
       },
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
-    expect(screen.queryByRole("button", { name: /tải lên/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /tải file/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /từ chối/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /đặt lại/i })).not.toBeInTheDocument();
-    expect(screen.queryByLabelText(/đã nộp/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /đánh dấu đã nhận giấy/i })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("DocumentsTab — ADM-031 task-orientation", () => {
+  it("missing + requires_upload row shows 'Cần tải ảnh/scan' hint and a Tải file button", () => {
+    const profile = buildProfile([
+      {
+        code: "CCCD",
+        label: "Căn cước công dân",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+        can_upload: true,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    expect(screen.getByText(/cần tải ảnh\/scan/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /tải file/i })).toBeInTheDocument();
+    // Paper hint must NOT appear for online docs.
+    expect(screen.queryByText(/nhận bản giấy tại quầy/i)).not.toBeInTheDocument();
+  });
+
+  it("missing + paper-only row shows 'Nhận bản giấy tại quầy' hint and a Đánh dấu đã nhận giấy button", () => {
+    const profile = buildProfile([
+      {
+        code: "HD_NH",
+        label: "Hợp đồng ngân hàng",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: false,
+        can_mark_paper_submitted: true,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    expect(screen.getByText(/nhận bản giấy tại quầy/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /đánh dấu đã nhận giấy/i })
+    ).toBeInTheDocument();
+    // Online hint must NOT appear for paper-only docs.
+    expect(screen.queryByText(/cần tải ảnh\/scan/i)).not.toBeInTheDocument();
+  });
+
+  it("non-missing rows do not surface either task hint", () => {
+    const profile = buildProfile([
+      {
+        code: "CCCD",
+        label: "Căn cước",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+      {
+        code: "HD_NH",
+        label: "Hợp đồng",
+        status: "paper_submitted",
+        is_mandatory: false,
+        requires_upload: false,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    expect(screen.queryByText(/cần tải ảnh\/scan/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/nhận bản giấy tại quầy/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("DocumentsTab — ADM-031 progress and status labels", () => {
+  it("distinguishes 'Đã ghi nhận' from 'Đã kiểm tra' in the header summary", () => {
+    const profile = buildProfile([
+      {
+        code: "A",
+        label: "A",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+      {
+        code: "B",
+        label: "B",
+        status: "verified",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+      {
+        code: "C",
+        label: "C",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    // 2 rows are recorded (uploaded + verified), 1 row is verified.
+    expect(screen.getByText(/đã ghi nhận 2\/3/i)).toBeInTheDocument();
+    expect(screen.getByText(/đã kiểm tra 1\/3/i)).toBeInTheDocument();
+    // Progress percentage is verified-share, not recorded-share.
+    const progressBar = screen.getByRole("progressbar", {
+      name: /tiến độ kiểm tra tài liệu/i,
+    });
+    expect(progressBar).toHaveAttribute("aria-valuenow", "33");
+  });
+
+  it("uploaded status renders as 'Đã ghi nhận', verified as 'Đã kiểm tra'", () => {
+    const profile = buildProfile([
+      {
+        code: "U",
+        label: "Uploaded row",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+      {
+        code: "V",
+        label: "Verified row",
+        status: "verified",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+      {
+        code: "P",
+        label: "Paper row",
+        status: "paper_submitted",
+        is_mandatory: false,
+        requires_upload: false,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    // Header summary already mentions both phrases, so a row badge would
+    // collide with the summary node. Match all and assert presence of at
+    // least one badge per status — header renders these phrases too.
+    expect(screen.getAllByText(/đã ghi nhận \(online\)/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/đã kiểm tra/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/đã nhận bản giấy/i).length).toBeGreaterThan(0);
+  });
+});
+
+describe("DocumentsTab — ADM-031 format dialog", () => {
+  it("opens with task-oriented title, required-format note, and centralized labels", async () => {
+    const user = userEvent.setup();
+    const profile = buildProfile([
+      {
+        code: "HD_NH",
+        label: "Hợp đồng ngân hàng",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: false,
+        can_mark_paper_submitted: true,
+        submission_format: "certified_copy",
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+
+    await user.click(
+      screen.getByRole("button", { name: /đánh dấu đã nhận giấy/i })
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    // Task-oriented title — declaring the actual format, not uploading
+    // additional evidence.
+    expect(
+      screen.getByRole("heading", { name: /loại bản thực tế trong file\/giấy này/i })
+    ).toBeInTheDocument();
+    // Required-format requirement is surfaced verbatim.
+    expect(dialog).toHaveTextContent(/yêu cầu hồ sơ:/i);
+    expect(dialog).toHaveTextContent(/bản sao chứng thực/i);
+    // Centralized labels (admission-helpers) — old strings ("Bản chính",
+    // "Bản photocopy", "Bản sao có chứng thực") must not appear.
+    expect(dialog).toHaveTextContent(/bản gốc/i);
+    expect(dialog).toHaveTextContent(/bản chụp\/scan không chứng thực/i);
+    expect(dialog).not.toHaveTextContent(/bản chính/i);
+    expect(dialog).not.toHaveTextContent(/^bản photocopy$/im);
+  });
+
+  it("shows a soft warning when the chosen actual format differs from the required format", async () => {
+    const user = userEvent.setup();
+    const profile = buildProfile([
+      {
+        code: "HD_NH",
+        label: "Hợp đồng ngân hàng",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: false,
+        can_mark_paper_submitted: true,
+        submission_format: "certified_copy",
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+
+    await user.click(
+      screen.getByRole("button", { name: /đánh dấu đã nhận giấy/i })
+    );
+
+    // Default selectedFormat is the required format → warning hidden.
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    // Switch to a different actual format → warning surfaces.
+    await user.click(screen.getByRole("radio", { name: /bản gốc/i }));
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/khác với yêu cầu hồ sơ/i);
   });
 });

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -286,7 +286,7 @@ describe("DocumentsTab — ADM-031 round 5 desktop table", () => {
     ]);
   });
 
-  it("sorts rows by work-queue priority: missing/rejected → uploaded/paper_submitted → verified", () => {
+  it("sorts rows by work-queue priority: missing/rejected → uploaded → verified", () => {
     const profile = buildProfile([
       // Intentionally out of order to verify sort.
       {
@@ -328,6 +328,42 @@ describe("DocumentsTab — ADM-031 round 5 desktop table", () => {
     expect(labels[1]).toContain("Missing optional");
     expect(labels[2]).toContain("Uploaded mandatory");
     expect(labels[3]).toContain("Verified mandatory");
+  });
+
+  it("paper_submitted sorts with verified (round 10 D1: both are 'satisfied')", () => {
+    // Round 9 made paper_submitted satisfy the mandatory gate; round 10
+    // sorts it into bucket 3 alongside verified so the work queue isn't
+    // interrupted by a "done" row labelled "Đã nhận giấy".
+    const profile = buildProfile([
+      {
+        code: "P",
+        label: "Paper submitted",
+        status: "paper_submitted",
+        is_mandatory: true,
+        requires_upload: false,
+      },
+      {
+        code: "U",
+        label: "Uploaded online",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+      {
+        code: "M",
+        label: "Missing mandatory",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    const rows = within(table).getAllByRole("row").slice(1);
+    const labels = rows.map((r) => within(r).getAllByRole("cell")[0]?.textContent);
+    expect(labels[0]).toContain("Missing mandatory"); // priority 1
+    expect(labels[1]).toContain("Uploaded online");   // priority 2
+    expect(labels[2]).toContain("Paper submitted");   // priority 3 (with verified)
   });
 });
 
@@ -527,6 +563,34 @@ describe("DocumentsTab — ADM-031 round 7 paper_submitted_at", () => {
     const receptionCell = cells[2];
     expect(receptionCell.textContent).toMatch(/File scan/);
     expect(receptionCell.textContent).toMatch(/15\/03\/2026/);
+  });
+
+  it("paper-only verified row preserves paper_submitted_at as the recorded date (round 10 E1)", () => {
+    // Paper docs (requires_upload=false) have no uploaded_at; once the
+    // manager flips them to verified, the FE must keep showing the
+    // paper-receipt date instead of falling back to a null uploaded_at.
+    const profile = buildProfile([
+      {
+        code: "GIAY",
+        label: "Bản giấy đã duyệt",
+        status: "verified",
+        is_mandatory: true,
+        requires_upload: false,
+        actual_submission_format: "original",
+        verified_format: "original",
+        paper_submitted_at: "2026-04-22T09:15:00+00:00",
+        // uploaded_at intentionally absent to mirror real paper docs.
+        verified_at: "2026-04-25T11:00:00+00:00",
+        verified_by: 7,
+        verified_by_name: "Nguyễn Văn A",
+      } as never,
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    const cells = within(table).getAllByRole("cell");
+    const receptionCell = cells[2];
+    // Paper-receipt date (22/04) must still render even though status is now verified.
+    expect(receptionCell.textContent).toMatch(/22\/04\/2026/);
   });
 });
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -254,9 +254,11 @@ describe("DocumentsTab — ADM-031 task-orientation", () => {
 });
 
 describe("DocumentsTab — ADM-031 progress and status labels", () => {
-  it("distinguishes 'Đã ghi nhận' from 'Đã kiểm tra' in the header summary", () => {
+  it("splits header into ghi nhận / chờ kiểm tra / hoàn tất yêu cầu", () => {
     const profile = buildProfile([
       {
+        // Online row: officer has not verified yet → counts as recorded
+        // and pending, but NOT as satisfying the requirement.
         code: "A",
         label: "A",
         status: "uploaded",
@@ -264,11 +266,21 @@ describe("DocumentsTab — ADM-031 progress and status labels", () => {
         requires_upload: true,
       },
       {
+        // Online row already verified → recorded + satisfied.
         code: "B",
         label: "B",
         status: "verified",
         is_mandatory: true,
         requires_upload: true,
+      },
+      {
+        // Paper-only row marked received → recorded + satisfied
+        // (backend `paper_submitted` already completes the requirement).
+        code: "P",
+        label: "P",
+        status: "paper_submitted",
+        is_mandatory: true,
+        requires_upload: false,
       },
       {
         code: "C",
@@ -279,14 +291,18 @@ describe("DocumentsTab — ADM-031 progress and status labels", () => {
       },
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
-    // 2 rows are recorded (uploaded + verified), 1 row is verified.
-    expect(screen.getByText(/đã ghi nhận 2\/3/i)).toBeInTheDocument();
-    expect(screen.getByText(/đã kiểm tra 1\/3/i)).toBeInTheDocument();
-    // Progress percentage is verified-share, not recorded-share.
+    // Recorded = uploaded + verified + paper_submitted = 3 of 4
+    expect(screen.getByText(/đã ghi nhận 3\/4/i)).toBeInTheDocument();
+    // Pending verification = uploaded only = 1
+    expect(screen.getByText(/chờ kiểm tra 1/i)).toBeInTheDocument();
+    // Satisfied = verified + paper_submitted = 2 of 4 (backend gate)
+    expect(screen.getByText(/hoàn tất yêu cầu 2\/4/i)).toBeInTheDocument();
+    // Progress reflects backend mandatory-completion semantics. 2 of 4
+    // mandatory rows satisfy the requirement → 50%.
     const progressBar = screen.getByRole("progressbar", {
-      name: /tiến độ kiểm tra tài liệu/i,
+      name: /tiến độ hoàn tất tài liệu/i,
     });
-    expect(progressBar).toHaveAttribute("aria-valuenow", "33");
+    expect(progressBar).toHaveAttribute("aria-valuenow", "50");
   });
 
   it("uploaded status renders as 'Đã ghi nhận', verified as 'Đã kiểm tra'", () => {

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -245,8 +245,8 @@ describe("DocumentsTab — ADM-031 round 5 KPI strip", () => {
     // Đã ghi nhận = 3/4 (uploaded + verified + paper_submitted)
     expect(within(kpi).getByText(/^đã ghi nhận$/i)).toBeInTheDocument();
     expect(within(kpi).getByText("3/4")).toBeInTheDocument();
-    // Chờ kiểm tra = 1 (uploaded only)
-    expect(within(kpi).getByText(/^chờ kiểm tra$/i)).toBeInTheDocument();
+    // File chờ duyệt = 1 (uploaded only) — round 9 rename.
+    expect(within(kpi).getByText(/^file chờ duyệt$/i)).toBeInTheDocument();
     expect(within(kpi).getByText("1")).toBeInTheDocument();
     // Hoàn tất yêu cầu = 2/4 (verified + paper_submitted)
     expect(within(kpi).getByText(/^hoàn tất yêu cầu$/i)).toBeInTheDocument();
@@ -566,7 +566,7 @@ describe("DocumentsTab — ADM-031 round 6 status workflow labels", () => {
     expect(within(table).queryByText(/Đã ghi nhận file/)).not.toBeInTheDocument();
   });
 
-  it("paper_submitted row shows 'Chờ duyệt' status + 'Bản giấy' reception", () => {
+  it("paper_submitted row shows 'Đã nhận giấy' status (round 9 — backend counts as satisfied) + 'Bản giấy' reception", () => {
     const profile = buildProfile([
       {
         code: "P",
@@ -578,8 +578,12 @@ describe("DocumentsTab — ADM-031 round 6 status workflow labels", () => {
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
     const table = screen.getByRole("table");
-    expect(within(table).getByText(/^Chờ duyệt$/)).toBeInTheDocument();
+    // Round 9: paper_submitted is "Đã nhận giấy" (success-tinted) so the
+    // row matches the KPI semantics — backend already treats it as
+    // satisfying the mandatory-doc gate, so it is NOT "Chờ duyệt".
+    expect(within(table).getByText(/^Đã nhận giấy$/)).toBeInTheDocument();
     expect(within(table).getByText(/^Bản giấy$/)).toBeInTheDocument();
+    // Long-form legacy copy must not leak.
     expect(within(table).queryByText(/Đã nhận bản giấy/)).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -261,7 +261,7 @@ describe("DocumentsTab — ADM-031 task-orientation", () => {
     expect(screen.queryByText(/nhận bản giấy tại quầy/i)).not.toBeInTheDocument();
   });
 
-  it("does not leak deprecated mode copy ('Online' / 'Nộp giấy' / 'Bản photocopy' / 'Bản photo/scan' / 'Ảnh chụp') in officer UI", () => {
+  it("does not leak deprecated mode/status copy ('Online' / 'Nộp giấy' / '(online)' / 'Bản photocopy' / 'Bản photo/scan' / 'Ảnh chụp') in officer UI", () => {
     const profile = buildProfile([
       {
         code: "CCCD",
@@ -283,9 +283,12 @@ describe("DocumentsTab — ADM-031 task-orientation", () => {
     const { container } = render(
       <DocumentsTab profile={profile as never} isEditable />
     );
-    // Old mode labels.
-    expect(container.textContent).not.toMatch(/\bOnline\b/);
+    // Old mode labels and the deprecated "(online)" parenthetical that
+    // used to appear in the uploaded status — the workflow doesn't have
+    // an "online" concept, only "needs file" vs "paper-only".
+    expect(container.textContent).not.toMatch(/\bOnline\b/i);
     expect(container.textContent).not.toMatch(/\bNộp giấy\b/);
+    expect(container.textContent).not.toMatch(/\(online\)/i);
     // Old format labels (legacy duplicates) — the centralized source uses
     // "Bản chụp/scan không chứng thực" for `photo`, never these.
     expect(container.textContent).not.toMatch(/Bản photocopy/);
@@ -374,7 +377,10 @@ describe("DocumentsTab — ADM-031 progress and status labels", () => {
     // Header summary already mentions both phrases, so a row badge would
     // collide with the summary node. Match all and assert presence of at
     // least one badge per status — header renders these phrases too.
-    expect(screen.getAllByText(/đã ghi nhận \(online\)/i).length).toBeGreaterThan(0);
+    // ADM-031 round 3: "Đã ghi nhận file" replaces the old
+    // "Đã ghi nhận (online)" so the document status copy never says
+    // "online" (the workflow distinction is needs-file vs paper-only).
+    expect(screen.getAllByText(/đã ghi nhận file/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/đã kiểm tra/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/đã nhận bản giấy/i).length).toBeGreaterThan(0);
   });

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -49,6 +49,10 @@ type DocRow = {
   verified_format?: string | null;
   file_path?: string | null;
   uploaded_at?: string | null;
+  paper_submitted_at?: string | null;
+  verified_at?: string | null;
+  verified_by?: number | null;
+  verified_by_name?: string | null;
 };
 
 function buildProfile(docs: DocRow[]) {
@@ -890,5 +894,98 @@ describe("DocumentsTab — ADM-031 upload dialog", () => {
     ).toBeInTheDocument();
     expect(dialog).toHaveTextContent(/file này là bản gì\?/i);
     expect(within(dialog).getByRole("button", { name: /^tải file$/i })).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// ADM-031 ROUND 10 — VERIFIER IDENTITY (who verified + when)
+// =============================================================================
+
+describe("DocumentsTab — ADM-031 round 10 verifier identity", () => {
+  it("renders verifier name + short date below the 'Đã duyệt' badge", () => {
+    const profile = buildProfile([
+      {
+        code: "HOC_BA",
+        label: "Học bạ THPT",
+        status: "verified",
+        is_mandatory: true,
+        requires_upload: true,
+        submission_format: "certified_copy",
+        verified_format: "certified_copy",
+        verified_at: "2026-04-29T08:30:00+00:00",
+        verified_by: 7,
+        verified_by_name: "Nguyễn Văn A",
+      },
+    ]);
+    const { container } = render(
+      <DocumentsTab profile={profile as never} isEditable />,
+    );
+    // Name appears at least once (desktop + mobile) alongside the dd/mm/yyyy date.
+    expect(container.textContent).toMatch(/Nguyễn Văn A/);
+    expect(container.textContent).toMatch(/29\/04\/2026/);
+  });
+
+  it("falls back to 'User #<id>' when verified_by_name is null but id is present", () => {
+    const profile = buildProfile([
+      {
+        code: "HOC_BA",
+        label: "Học bạ THPT",
+        status: "verified",
+        is_mandatory: true,
+        requires_upload: true,
+        verified_at: "2026-04-29T08:30:00+00:00",
+        verified_by: 42,
+        verified_by_name: null,
+      },
+    ]);
+    const { container } = render(
+      <DocumentsTab profile={profile as never} isEditable />,
+    );
+    expect(container.textContent).toMatch(/User #42/);
+  });
+
+  it("shows only the date when neither verified_by_name nor verified_by is set", () => {
+    const profile = buildProfile([
+      {
+        code: "HOC_BA",
+        label: "Học bạ THPT",
+        status: "verified",
+        is_mandatory: true,
+        requires_upload: true,
+        verified_at: "2026-04-29T08:30:00+00:00",
+        verified_by: null,
+        verified_by_name: null,
+      },
+    ]);
+    const { container } = render(
+      <DocumentsTab profile={profile as never} isEditable />,
+    );
+    expect(container.textContent).toMatch(/29\/04\/2026/);
+    expect(container.textContent).not.toMatch(/User #/);
+  });
+
+  it("does NOT render a verifier line for non-verified statuses (e.g. uploaded)", () => {
+    const profile = buildProfile([
+      {
+        code: "HOC_BA",
+        label: "Học bạ THPT",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+        // Stale verifier columns from a prior cycle should be ignored as
+        // long as status !== verified — only the latest workflow state
+        // drives the secondary line.
+        verified_at: "2026-04-20T08:30:00+00:00",
+        verified_by: 7,
+        verified_by_name: "Nguyễn Văn A",
+      },
+    ]);
+    const { container } = render(
+      <DocumentsTab profile={profile as never} isEditable />,
+    );
+    // The "Đã ghi nhận" cell renders the date next to format with a leading
+    // bullet ("Chứng thực · 20/04/2026") — but that's not the verifier line
+    // and the name should NOT appear anywhere when status is not verified.
+    expect(container.textContent).not.toMatch(/Nguyễn Văn A/);
   });
 });

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/hooks/admissions/useAdmissions", () => ({
   useMarkPaperSubmitted: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
   useRejectDocument: () => ({ mutate: vi.fn(), isPending: false }),
   useResetDocument: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+  useVerifyDocument: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
 }));
 
 type DocRow = {
@@ -258,7 +259,7 @@ describe("DocumentsTab — ADM-031 round 5 KPI strip", () => {
 // =============================================================================
 
 describe("DocumentsTab — ADM-031 round 5 desktop table", () => {
-  it("renders a semantic table with the 7-column header", () => {
+  it("renders a semantic table with the round-7 6-column header (Cách ghi nhận merged into Yêu cầu)", () => {
     const profile = buildProfile([
       {
         code: "CCCD",
@@ -273,11 +274,9 @@ describe("DocumentsTab — ADM-031 round 5 desktop table", () => {
     const headers = within(table).getAllByRole("columnheader");
     const headerLabels = headers.map((h) => h.textContent?.trim());
     expect(headerLabels).toEqual([
-      "#",
       "Tên giấy tờ",
       "Yêu cầu",
       "Đã ghi nhận",
-      "Cách ghi nhận",
       "Trạng thái",
       "Thao tác",
     ]);
@@ -318,7 +317,8 @@ describe("DocumentsTab — ADM-031 round 5 desktop table", () => {
     render(<DocumentsTab profile={profile as never} isEditable />);
     const table = screen.getByRole("table");
     const rows = within(table).getAllByRole("row").slice(1); // skip header
-    const labels = rows.map((r) => within(r).getAllByRole("cell")[1]?.textContent);
+    // Title cell is now index 0 (the "#" column was removed in round 7).
+    const labels = rows.map((r) => within(r).getAllByRole("cell")[0]?.textContent);
     // Priority: missing(mandatory) → missing(optional) → uploaded → verified
     expect(labels[0]).toContain("Missing mandatory");
     expect(labels[1]).toContain("Missing optional");
@@ -346,9 +346,11 @@ describe("DocumentsTab — ADM-031 round 5 reception & how-to columns", () => {
     const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
     expect(container.textContent).toMatch(/Tải file/);
     // The row exposes the "Chưa" reception bucket for missing.
+    // Round 7 dropped the "#" column → cells are
+    // Tên | Yêu cầu | Đã ghi nhận | Trạng thái | Thao tác (index 2 = reception).
     const table = screen.getByRole("table");
     const cells = within(table).getAllByRole("cell");
-    const receptionCell = cells[3]; // # | Tên | Yêu cầu | Đã ghi nhận | ...
+    const receptionCell = cells[2];
     expect(receptionCell?.textContent).toMatch(/^Chưa/);
   });
 
@@ -381,6 +383,142 @@ describe("DocumentsTab — ADM-031 round 5 reception & how-to columns", () => {
     expect(paperButton.textContent).toMatch(/^Đã nhận giấy$/);
     // No upload-flow copy on a paper-only row.
     expect(within(table).queryByText(/^Tải file$/)).not.toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// ADM-031 ROUND 7 — "YÊU CẦU" CELL ABSORBS "CÁCH GHI NHẬN"
+// =============================================================================
+
+describe("DocumentsTab — ADM-031 round 7 'Yêu cầu' merge", () => {
+  it("requires_upload=true row shows 'Bắt buộc · Chứng thực' + 'Tải file' inside the Yêu cầu cell", () => {
+    const profile = buildProfile([
+      {
+        code: "HOC_BA",
+        label: "Học bạ",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+        submission_format: "certified_copy",
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    // Cells in round 7 order: Tên | Yêu cầu | Đã ghi nhận | Trạng thái | Thao tác
+    const cells = within(table).getAllByRole("cell");
+    const yeuCauCell = cells[1];
+    expect(yeuCauCell.textContent).toMatch(/Bắt buộc/);
+    expect(yeuCauCell.textContent).toMatch(/Chứng thực/);
+    expect(yeuCauCell.textContent).toMatch(/Tải file/);
+  });
+
+  it("requires_upload=false row shows 'Bắt buộc · Gốc' + 'Nhận giấy' inside the Yêu cầu cell", () => {
+    const profile = buildProfile([
+      {
+        code: "PHIEU",
+        label: "Phiếu cam kết",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: false,
+        submission_format: "original",
+      },
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    const cells = within(table).getAllByRole("cell");
+    const yeuCauCell = cells[1];
+    expect(yeuCauCell.textContent).toMatch(/Bắt buộc/);
+    expect(yeuCauCell.textContent).toMatch(/Gốc/);
+    expect(yeuCauCell.textContent).toMatch(/Nhận giấy/);
+  });
+});
+
+// =============================================================================
+// ADM-031 ROUND 7 — VERIFY BUTTON
+// =============================================================================
+
+describe("DocumentsTab — ADM-031 round 7 verify button", () => {
+  it("renders 'Duyệt' button when can_verify=true", () => {
+    const profile = buildProfile([
+      {
+        code: "HOC_BA",
+        label: "Học bạ",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+        actual_submission_format: "certified_copy",
+        can_verify: true,
+      } as never,
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    expect(
+      within(table).getByRole("button", { name: /duyệt tài liệu/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides 'Duyệt' when can_verify=false", () => {
+    const profile = buildProfile([
+      {
+        code: "HOC_BA",
+        label: "Học bạ",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+        can_verify: false,
+      } as never,
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    expect(
+      screen.queryByRole("button", { name: /duyệt tài liệu/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// ADM-031 ROUND 7 — paper_submitted_at DATE IN RECEPTION CELL
+// =============================================================================
+
+describe("DocumentsTab — ADM-031 round 7 paper_submitted_at", () => {
+  it("paper_submitted row renders the paper_submitted_at date in the reception cell", () => {
+    const profile = buildProfile([
+      {
+        code: "PHIEU",
+        label: "Phiếu cam kết",
+        status: "paper_submitted",
+        is_mandatory: true,
+        requires_upload: false,
+        actual_submission_format: "original",
+        paper_submitted_at: "2026-04-28T10:30:00+00:00",
+      } as never,
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    const cells = within(table).getAllByRole("cell");
+    // Reception cell at index 2.
+    const receptionCell = cells[2];
+    expect(receptionCell.textContent).toMatch(/Giấy/);
+    expect(receptionCell.textContent).toMatch(/28\/04\/2026/);
+  });
+
+  it("uploaded row renders the uploaded_at date in the reception cell, not paper_submitted_at", () => {
+    const profile = buildProfile([
+      {
+        code: "HOC_BA",
+        label: "Học bạ",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+        actual_submission_format: "certified_copy",
+        uploaded_at: "2026-03-15T08:00:00+00:00",
+      } as never,
+    ]);
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const table = screen.getByRole("table");
+    const cells = within(table).getAllByRole("cell");
+    const receptionCell = cells[2];
+    expect(receptionCell.textContent).toMatch(/File/);
+    expect(receptionCell.textContent).toMatch(/15\/03\/2026/);
   });
 });
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -351,10 +351,10 @@ describe("DocumentsTab — ADM-031 round 5 reception & how-to columns", () => {
     const table = screen.getByRole("table");
     const cells = within(table).getAllByRole("cell");
     const receptionCell = cells[2];
-    expect(receptionCell?.textContent).toMatch(/^Chưa/);
+    expect(receptionCell?.textContent).toMatch(/Chưa/);
   });
 
-  it("requires_upload=false row shows 'Nhận giấy' how-to + 'Đã nhận giấy' visible button", () => {
+  it("requires_upload=false row shows 'Nhận giấy' how-to + icon button with 'Đánh dấu đã nhận giấy' aria-label", () => {
     const profile = buildProfile([
       {
         code: "PHIEU",
@@ -374,15 +374,12 @@ describe("DocumentsTab — ADM-031 round 5 reception & how-to columns", () => {
     expect(
       within(table).queryByText(/Nhận giấy tại quầy/i),
     ).not.toBeInTheDocument();
-    // Button: visible "Đã nhận giấy", aria-label "Đánh dấu đã nhận giấy".
+    // Round 8: action buttons are icon-only with Radix Tooltip — aria-label
+    // is the accessible name, no visible label text.
     const paperButton = within(table).getByRole("button", {
       name: /đánh dấu đã nhận giấy/i,
     });
-    expect(paperButton).toBeInTheDocument();
     expect(paperButton).toHaveAccessibleName(/đánh dấu đã nhận giấy/i);
-    expect(paperButton.textContent).toMatch(/^Đã nhận giấy$/);
-    // No upload-flow copy on a paper-only row.
-    expect(within(table).queryByText(/^Tải file$/)).not.toBeInTheDocument();
   });
 });
 
@@ -390,8 +387,8 @@ describe("DocumentsTab — ADM-031 round 5 reception & how-to columns", () => {
 // ADM-031 ROUND 7 — "YÊU CẦU" CELL ABSORBS "CÁCH GHI NHẬN"
 // =============================================================================
 
-describe("DocumentsTab — ADM-031 round 7 'Yêu cầu' merge", () => {
-  it("requires_upload=true row shows 'Bắt buộc · Chứng thực' + 'Tải file' inside the Yêu cầu cell", () => {
+describe("DocumentsTab — ADM-031 round 8 cells layout", () => {
+  it("Tên cell shows 'Bắt buộc' on line 2 (mandatory marker moved out of name and Yêu cầu cell)", () => {
     const profile = buildProfile([
       {
         code: "HOC_BA",
@@ -404,15 +401,22 @@ describe("DocumentsTab — ADM-031 round 7 'Yêu cầu' merge", () => {
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
     const table = screen.getByRole("table");
-    // Cells in round 7 order: Tên | Yêu cầu | Đã ghi nhận | Trạng thái | Thao tác
+    // Cells: Tên | Yêu cầu | Đã ghi nhận | Trạng thái | Thao tác
     const cells = within(table).getAllByRole("cell");
+    const tenCell = cells[0];
     const yeuCauCell = cells[1];
-    expect(yeuCauCell.textContent).toMatch(/Bắt buộc/);
+    expect(tenCell.textContent).toMatch(/Học bạ/);
+    expect(tenCell.textContent).toMatch(/Bắt buộc/);
+    // "Mã: ..." no longer visible in Tên cell (moved to title attribute).
+    expect(tenCell.textContent).not.toMatch(/Mã:/);
+    // Yêu cầu cell only carries format + how-to (Bắt buộc/Tùy chọn moved
+    // to Tên cell in round 8).
+    expect(yeuCauCell.textContent).not.toMatch(/Bắt buộc/);
     expect(yeuCauCell.textContent).toMatch(/Chứng thực/);
     expect(yeuCauCell.textContent).toMatch(/Tải file/);
   });
 
-  it("requires_upload=false row shows 'Bắt buộc · Gốc' + 'Nhận giấy' inside the Yêu cầu cell", () => {
+  it("requires_upload=false row puts 'Gốc' + 'Nhận giấy' in Yêu cầu cell", () => {
     const profile = buildProfile([
       {
         code: "PHIEU",
@@ -427,7 +431,6 @@ describe("DocumentsTab — ADM-031 round 7 'Yêu cầu' merge", () => {
     const table = screen.getByRole("table");
     const cells = within(table).getAllByRole("cell");
     const yeuCauCell = cells[1];
-    expect(yeuCauCell.textContent).toMatch(/Bắt buộc/);
     expect(yeuCauCell.textContent).toMatch(/Gốc/);
     expect(yeuCauCell.textContent).toMatch(/Nhận giấy/);
   });
@@ -495,9 +498,10 @@ describe("DocumentsTab — ADM-031 round 7 paper_submitted_at", () => {
     render(<DocumentsTab profile={profile as never} isEditable />);
     const table = screen.getByRole("table");
     const cells = within(table).getAllByRole("cell");
-    // Reception cell at index 2.
+    // Reception cell at index 2 — contains: actual format short ("Gốc")
+    // + date + reception bucket ("Bản giấy").
     const receptionCell = cells[2];
-    expect(receptionCell.textContent).toMatch(/Giấy/);
+    expect(receptionCell.textContent).toMatch(/Bản giấy/);
     expect(receptionCell.textContent).toMatch(/28\/04\/2026/);
   });
 
@@ -517,7 +521,7 @@ describe("DocumentsTab — ADM-031 round 7 paper_submitted_at", () => {
     const table = screen.getByRole("table");
     const cells = within(table).getAllByRole("cell");
     const receptionCell = cells[2];
-    expect(receptionCell.textContent).toMatch(/File/);
+    expect(receptionCell.textContent).toMatch(/File scan/);
     expect(receptionCell.textContent).toMatch(/15\/03\/2026/);
   });
 });
@@ -545,7 +549,7 @@ describe("DocumentsTab — ADM-031 round 6 status workflow labels", () => {
     expect(within(table).queryByText(/^Chưa nộp$/)).not.toBeInTheDocument();
   });
 
-  it("uploaded row shows 'Chờ duyệt' status + 'File' reception", () => {
+  it("uploaded row shows 'Chờ duyệt' status + 'File scan' reception", () => {
     const profile = buildProfile([
       {
         code: "U",
@@ -558,11 +562,11 @@ describe("DocumentsTab — ADM-031 round 6 status workflow labels", () => {
     render(<DocumentsTab profile={profile as never} isEditable />);
     const table = screen.getByRole("table");
     expect(within(table).getByText(/^Chờ duyệt$/)).toBeInTheDocument();
-    expect(within(table).getByText(/^File$/)).toBeInTheDocument();
+    expect(within(table).getByText(/^File scan$/)).toBeInTheDocument();
     expect(within(table).queryByText(/Đã ghi nhận file/)).not.toBeInTheDocument();
   });
 
-  it("paper_submitted row shows 'Chờ duyệt' status + 'Giấy' reception", () => {
+  it("paper_submitted row shows 'Chờ duyệt' status + 'Bản giấy' reception", () => {
     const profile = buildProfile([
       {
         code: "P",
@@ -575,11 +579,11 @@ describe("DocumentsTab — ADM-031 round 6 status workflow labels", () => {
     render(<DocumentsTab profile={profile as never} isEditable />);
     const table = screen.getByRole("table");
     expect(within(table).getByText(/^Chờ duyệt$/)).toBeInTheDocument();
-    expect(within(table).getByText(/^Giấy$/)).toBeInTheDocument();
+    expect(within(table).getByText(/^Bản giấy$/)).toBeInTheDocument();
     expect(within(table).queryByText(/Đã nhận bản giấy/)).not.toBeInTheDocument();
   });
 
-  it("verified row shows 'Đã duyệt' status + 'File' reception", () => {
+  it("verified row shows 'Đã duyệt' status + 'File scan' reception", () => {
     const profile = buildProfile([
       {
         code: "V",
@@ -592,7 +596,7 @@ describe("DocumentsTab — ADM-031 round 6 status workflow labels", () => {
     render(<DocumentsTab profile={profile as never} isEditable />);
     const table = screen.getByRole("table");
     expect(within(table).getByText(/^Đã duyệt$/)).toBeInTheDocument();
-    expect(within(table).getByText(/^File$/)).toBeInTheDocument();
+    expect(within(table).getByText(/^File scan$/)).toBeInTheDocument();
     expect(within(table).queryByText(/^Đã kiểm tra$/)).not.toBeInTheDocument();
   });
 
@@ -720,9 +724,15 @@ describe("DocumentsTab — ADM-031 round 5 deprecated copy guard", () => {
     expect(container.textContent).not.toMatch(/Bản photocopy/);
     expect(container.textContent).not.toMatch(/Bản photo\/scan/);
     expect(container.textContent).not.toMatch(/Ảnh chụp hoặc scan/);
-    // Required new copy.
+    // Forbidden by user spec for round 8.
+    expect(container.textContent).not.toMatch(/chứng cứ|evidence/i);
+    // Required new copy — short labels in body, full label in title attr.
     expect(container.textContent).toMatch(/Tải file/);
-    expect(container.textContent).toMatch(/Bản chụp\/scan không chứng thực/);
+    // Full label still reachable via title attribute on the format span.
+    const fullLabelEls = container.querySelectorAll(
+      '[title*="Bản chụp/scan không chứng thực"]',
+    );
+    expect(fullLabelEls.length).toBeGreaterThan(0);
   });
 });
 
@@ -731,7 +741,7 @@ describe("DocumentsTab — ADM-031 round 5 deprecated copy guard", () => {
 // =============================================================================
 
 describe("DocumentsTab — ADM-031 recorded format display", () => {
-  it("shows actual_submission_format on uploaded rows", () => {
+  it("shows actual_submission_format on uploaded rows (short label visible, full label in title)", () => {
     const profile = buildProfile([
       {
         code: "anh_3x4",
@@ -744,12 +754,17 @@ describe("DocumentsTab — ADM-031 recorded format display", () => {
       },
     ]);
     const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
-    // Required + recorded both visible.
-    expect(container.textContent).toMatch(/Bản sao chứng thực/);
-    expect(container.textContent).toMatch(/Bản chụp\/scan không chứng thực/);
+    // Both required ("Chứng thực") and recorded ("Chụp/scan") short
+    // labels are visible.
+    expect(container.textContent).toMatch(/Chứng thực/);
+    expect(container.textContent).toMatch(/Chụp\/scan/);
+    // Full label reachable via title attr (e.g., aria-label on format span).
+    expect(
+      container.querySelector('[aria-label="Bản sao chứng thực"]'),
+    ).toBeInTheDocument();
   });
 
-  it("shows verified_format on verified rows", () => {
+  it("shows verified_format on verified rows (reception bucket = 'File scan')", () => {
     const profile = buildProfile([
       {
         code: "hoc_ba_thpt",
@@ -763,9 +778,9 @@ describe("DocumentsTab — ADM-031 recorded format display", () => {
       },
     ]);
     const { container } = render(<DocumentsTab profile={profile as never} isEditable />);
-    // Reception bucket reads "File" + the format detail.
-    expect(container.textContent).toMatch(/File/);
-    expect(container.textContent).toMatch(/Bản sao chứng thực/);
+    // Reception bucket reads "File scan" + the format short label.
+    expect(container.textContent).toMatch(/File scan/);
+    expect(container.textContent).toMatch(/Chứng thực/);
   });
 });
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -16,6 +16,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@/test/utils/test-utils";
+import { within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { DocumentsTab } from "./DocumentsTab";
@@ -192,7 +193,7 @@ describe("DocumentsTab — per-row permission flags", () => {
 });
 
 describe("DocumentsTab — ADM-031 task-orientation", () => {
-  it("missing + requires_upload row shows 'Cần tải ảnh/scan' hint and a Tải file button", () => {
+  it("missing + requires_upload row shows 'Cần tải ảnh/scan' hint, 'Cần file' mode, and a Tải file button", () => {
     const profile = buildProfile([
       {
         code: "CCCD",
@@ -205,12 +206,16 @@ describe("DocumentsTab — ADM-031 task-orientation", () => {
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
     expect(screen.getByText(/cần tải ảnh\/scan/i)).toBeInTheDocument();
+    // ADM-031 round 2: "Online" was replaced with "Cần file" so the mode
+    // badge actually describes the workflow.
+    expect(screen.getByText(/^Cần file$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Online$/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /tải file/i })).toBeInTheDocument();
     // Paper hint must NOT appear for online docs.
     expect(screen.queryByText(/nhận bản giấy tại quầy/i)).not.toBeInTheDocument();
   });
 
-  it("missing + paper-only row shows 'Nhận bản giấy tại quầy' hint and a Đánh dấu đã nhận giấy button", () => {
+  it("missing + paper-only row shows 'Nhận bản giấy tại quầy' hint, 'Ghi nhận giấy' mode, and a Đánh dấu đã nhận giấy button", () => {
     const profile = buildProfile([
       {
         code: "HD_NH",
@@ -223,6 +228,10 @@ describe("DocumentsTab — ADM-031 task-orientation", () => {
     ]);
     render(<DocumentsTab profile={profile as never} isEditable />);
     expect(screen.getByText(/nhận bản giấy tại quầy/i)).toBeInTheDocument();
+    // ADM-031 round 2: "Nộp giấy" was replaced with "Ghi nhận giấy" to
+    // match the paper-only checklist semantic.
+    expect(screen.getByText(/^Ghi nhận giấy$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Nộp giấy$/i)).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /đánh dấu đã nhận giấy/i })
     ).toBeInTheDocument();
@@ -250,6 +259,38 @@ describe("DocumentsTab — ADM-031 task-orientation", () => {
     render(<DocumentsTab profile={profile as never} isEditable />);
     expect(screen.queryByText(/cần tải ảnh\/scan/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/nhận bản giấy tại quầy/i)).not.toBeInTheDocument();
+  });
+
+  it("does not leak deprecated mode copy ('Online' / 'Nộp giấy' / 'Bản photocopy' / 'Bản photo/scan' / 'Ảnh chụp') in officer UI", () => {
+    const profile = buildProfile([
+      {
+        code: "CCCD",
+        label: "Căn cước",
+        status: "uploaded",
+        is_mandatory: true,
+        requires_upload: true,
+        submission_format: "photo",
+      },
+      {
+        code: "HD",
+        label: "Hợp đồng",
+        status: "paper_submitted",
+        is_mandatory: false,
+        requires_upload: false,
+        submission_format: "certified_copy",
+      },
+    ]);
+    const { container } = render(
+      <DocumentsTab profile={profile as never} isEditable />
+    );
+    // Old mode labels.
+    expect(container.textContent).not.toMatch(/\bOnline\b/);
+    expect(container.textContent).not.toMatch(/\bNộp giấy\b/);
+    // Old format labels (legacy duplicates) — the centralized source uses
+    // "Bản chụp/scan không chứng thực" for `photo`, never these.
+    expect(container.textContent).not.toMatch(/Bản photocopy/);
+    expect(container.textContent).not.toMatch(/Bản photo\/scan/);
+    expect(container.textContent).not.toMatch(/Ảnh chụp hoặc scan/);
   });
 });
 
@@ -339,8 +380,8 @@ describe("DocumentsTab — ADM-031 progress and status labels", () => {
   });
 });
 
-describe("DocumentsTab — ADM-031 format dialog", () => {
-  it("opens with task-oriented title, required-format note, and centralized labels", async () => {
+describe("DocumentsTab — ADM-031 paper-receipt dialog", () => {
+  it("opens with paper-specific title, prompt, primary button, and centralized labels", async () => {
     const user = userEvent.setup();
     const profile = buildProfile([
       {
@@ -360,11 +401,11 @@ describe("DocumentsTab — ADM-031 format dialog", () => {
     );
 
     const dialog = await screen.findByRole("dialog");
-    // Task-oriented title — declaring the actual format, not uploading
-    // additional evidence.
+    // ADM-031 round 2: paper-specific dialog title (no file/upload word).
     expect(
-      screen.getByRole("heading", { name: /loại bản thực tế trong file\/giấy này/i })
+      screen.getByRole("heading", { name: /xác nhận bản giấy vừa nhận/i })
     ).toBeInTheDocument();
+    expect(dialog).toHaveTextContent(/bản giấy vừa nhận là bản gì\?/i);
     // Required-format requirement is surfaced verbatim.
     expect(dialog).toHaveTextContent(/yêu cầu hồ sơ:/i);
     expect(dialog).toHaveTextContent(/bản sao chứng thực/i);
@@ -374,9 +415,12 @@ describe("DocumentsTab — ADM-031 format dialog", () => {
     expect(dialog).toHaveTextContent(/bản chụp\/scan không chứng thực/i);
     expect(dialog).not.toHaveTextContent(/bản chính/i);
     expect(dialog).not.toHaveTextContent(/^bản photocopy$/im);
+    // Paper-flow primary button is "Ghi nhận giấy", not the upload one.
+    expect(screen.getByRole("button", { name: /^ghi nhận giấy$/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^tải file$/i })).not.toBeInTheDocument();
   });
 
-  it("shows a soft warning when the chosen actual format differs from the required format", async () => {
+  it("shows paper-specific soft warning when the chosen actual format differs from the required format", async () => {
     const user = userEvent.setup();
     const profile = buildProfile([
       {
@@ -398,9 +442,96 @@ describe("DocumentsTab — ADM-031 format dialog", () => {
     // Default selectedFormat is the required format → warning hidden.
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 
-    // Switch to a different actual format → warning surfaces.
+    // Switch to a different actual format → paper-specific warning surfaces.
     await user.click(screen.getByRole("radio", { name: /bản gốc/i }));
     const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent(/khác với yêu cầu hồ sơ/i);
+    expect(alert).toHaveTextContent(/bản giấy thực tế khác yêu cầu hồ sơ/i);
+    expect(alert).toHaveTextContent(/trước khi ghi nhận/i);
+    // Upload-flow copy must NOT leak into paper dialog.
+    expect(alert).not.toHaveTextContent(/trước khi tải file/i);
+  });
+});
+
+describe("DocumentsTab — ADM-031 upload dialog", () => {
+  it("opens with upload-specific title, prompt, primary button after a file is selected", async () => {
+    const user = userEvent.setup();
+    const profile = buildProfile([
+      {
+        code: "CCCD",
+        label: "Căn cước công dân",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+        can_upload: true,
+        submission_format: "photo",
+      },
+    ]);
+    const { container } = render(
+      <DocumentsTab profile={profile as never} isEditable />
+    );
+
+    // Two-step upload flow: clicking the row's "Tải file" button arms the
+    // hidden file input + state; the submission-format dialog only opens
+    // AFTER the user picks a file. Mirror both steps in the test.
+    await user.click(screen.getByRole("button", { name: /^tải file$/i }));
+    const fileInput = container.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+    const file = new File(["dummy"], "ccd.pdf", { type: "application/pdf" });
+    await user.upload(fileInput, file);
+
+    const dialog = await screen.findByRole("dialog");
+    // Upload-specific title and prompt.
+    expect(
+      screen.getByRole("heading", { name: /^tải file tài liệu$/i })
+    ).toBeInTheDocument();
+    expect(dialog).toHaveTextContent(/file này là bản gì\?/i);
+    expect(dialog).toHaveTextContent(/yêu cầu hồ sơ:/i);
+    // Upload-flow primary button (in the dialog footer) is "Tải file".
+    // The row also has a "Tải file" button, so scope to the dialog.
+    expect(
+      within(dialog).getByRole("button", { name: /^tải file$/i })
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).queryByRole("button", { name: /^ghi nhận giấy$/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows upload-specific soft warning when the chosen actual format differs from the required format", async () => {
+    const user = userEvent.setup();
+    const profile = buildProfile([
+      {
+        code: "CCCD",
+        label: "Căn cước công dân",
+        status: "missing",
+        is_mandatory: true,
+        requires_upload: true,
+        can_upload: true,
+        submission_format: "certified_copy",
+      },
+    ]);
+    const { container } = render(
+      <DocumentsTab profile={profile as never} isEditable />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^tải file$/i }));
+    const fileInput = container.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    const file = new File(["dummy"], "ccd.pdf", { type: "application/pdf" });
+    await user.upload(fileInput, file);
+
+    // Default selectedFormat = required format → warning hidden.
+    await screen.findByRole("dialog");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    // Switch actual format → upload-specific warning surfaces.
+    await user.click(screen.getByRole("radio", { name: /bản gốc/i }));
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/loại bản trong file khác yêu cầu hồ sơ/i);
+    expect(alert).toHaveTextContent(/trước khi tải file/i);
+    // Paper-flow copy must NOT leak into upload dialog.
+    expect(alert).not.toHaveTextContent(/trước khi ghi nhận/i);
   });
 });

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -76,6 +76,7 @@ import {
   useMarkPaperSubmitted,
   useRejectDocument,
   useResetDocument,
+  useVerifyDocument,
 } from "@/hooks/admissions/useAdmissions"
 import { useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
@@ -254,11 +255,14 @@ function computeRowState(doc: DocumentItem) {
 
   // Date-of-record — appears under the reception bucket in the
   // "Đã ghi nhận" cell so the title cell can stay focused on doc
-  // identity (label + code + reject reason).
+  // identity (label + code + reject reason). For paper-submitted
+  // rows, prefer the dedicated paper_submitted_at timestamp from
+  // ADM-031 round 7 backend addition; fall back to uploaded_at for
+  // online docs.
   const recordedAtIso =
-    doc.uploaded_at ??
-    (doc as DocumentItem & { paper_submitted_at?: string | null }).paper_submitted_at ??
-    null
+    doc.status === "paper_submitted"
+      ? (doc.paper_submitted_at ?? null)
+      : (doc.uploaded_at ?? null)
   const recordedAtFormatted = recordedAtIso
     ? VI_DATE_FORMATTER.format(new Date(recordedAtIso))
     : null
@@ -273,8 +277,9 @@ function computeRowState(doc: DocumentItem) {
   const canMarkPaperSubmitted = doc.can_mark_paper_submitted ?? false
   const canReject = doc.can_reject ?? false
   const canReset = doc.can_reset ?? false
+  const canVerify = doc.can_verify ?? false
   const hasAnyAction =
-    hasFile || canUpload || canMarkPaperSubmitted || canReject || canReset
+    hasFile || canUpload || canMarkPaperSubmitted || canReject || canReset || canVerify
 
   return {
     statusConfig,
@@ -294,6 +299,7 @@ function computeRowState(doc: DocumentItem) {
     canMarkPaperSubmitted,
     canReject,
     canReset,
+    canVerify,
     hasAnyAction,
     recordedAtFormatted,
   }
@@ -341,6 +347,8 @@ interface ActionsCellProps {
   isPaperPending: boolean
   isResetPending: boolean
   isCurrentResetTarget: boolean
+  isVerifyPending: boolean
+  isCurrentVerifyTarget: boolean
   onView: (filePath: string) => void
   onUpload: (
     code: string,
@@ -354,6 +362,7 @@ interface ActionsCellProps {
   ) => void
   onRejectClick: (code: string, label: string) => void
   onResetClick: (code: string, label: string) => void
+  onVerifyClick: (code: string, format: string) => void
   alignEnd?: boolean
 }
 
@@ -365,13 +374,23 @@ function DocumentRowActions(props: ActionsCellProps) {
     isPaperPending,
     isResetPending,
     isCurrentResetTarget,
+    isVerifyPending,
+    isCurrentVerifyTarget,
     onView,
     onUpload,
     onPaperSubmit,
     onRejectClick,
     onResetClick,
+    onVerifyClick,
     alignEnd,
   } = props
+
+  // Verify uses the actual / required format as the format claim. The
+  // verify dialog (executive checklist) is the deeper review surface;
+  // here the button is a one-click confirm for officers/managers who
+  // already match required to actual.
+  const verifyFormat =
+    doc.actual_submission_format ?? doc.submission_format ?? "photo"
 
   if (!state.hasAnyAction && !(state.isPaperOnly && doc.status === "paper_submitted")) {
     return <span className="text-xs text-muted-foreground">—</span>
@@ -432,21 +451,43 @@ function DocumentRowActions(props: ActionsCellProps) {
         </Button>
       )}
 
-      {state.isPaperOnly && doc.status === "paper_submitted" && !state.canReject && !state.canReset && (
+      {state.isPaperOnly && doc.status === "paper_submitted" && !state.canReject && !state.canReset && !state.canVerify && (
         <span className="inline-flex items-center text-success-600 text-xs">
           <Check className="h-4 w-4" aria-hidden="true" />
         </span>
       )}
 
+      {/* Verify — manager/admin one-click approve. Lives in the
+          DocumentsTab so officers/managers can clear the verify queue
+          without bouncing into the executive checklist. */}
+      {state.canVerify && (
+        <Button
+          size="sm"
+          variant="outline"
+          className="text-success-700 hover:text-success-800 hover:bg-success-50 border-success-300"
+          onClick={() => onVerifyClick(doc.code, verifyFormat)}
+          disabled={isVerifyPending && isCurrentVerifyTarget}
+          aria-label="Duyệt tài liệu"
+        >
+          {isVerifyPending && isCurrentVerifyTarget ? (
+            <Loader2 className="h-4 w-4 mr-1 animate-spin motion-reduce:animate-none" />
+          ) : (
+            <Check className="h-4 w-4 mr-1" />
+          )}
+          Duyệt
+        </Button>
+      )}
+
       {state.canReject && (
         <Button
           size="sm"
-          variant="ghost"
-          className="text-error-600 hover:text-error-700 hover:bg-error-50"
+          variant="outline"
+          className="text-error-600 hover:text-error-700 hover:bg-error-50 border-error-300"
           onClick={() => onRejectClick(doc.code, doc.label)}
           aria-label="Từ chối tài liệu"
         >
-          <Ban className="h-4 w-4" />
+          <Ban className="h-4 w-4 mr-1" />
+          Từ chối
         </Button>
       )}
 
@@ -482,6 +523,7 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
   const paperMutation = useMarkPaperSubmitted(profile.id)
   const rejectMutation = useRejectDocument(profile.id)
   const resetMutation = useResetDocument(profile.id)
+  const verifyMutation = useVerifyDocument(profile.id)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [selectedDocCode, setSelectedDocCode] = useState<string | null>(null)
@@ -674,6 +716,10 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
     setPendingResetDoc(null)
   }
 
+  const handleVerifyClick = (code: string, format: string) => {
+    verifyMutation.mutate({ docCode: code, format })
+  }
+
   // -- Per-row mutation helpers ---------------------------------------------
 
   const isUploadingForCode = (code: string) =>
@@ -682,6 +728,8 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
     paperMutation.isPending && paperMutation.variables?.docCode === code
   const isResetPendingForCode = (code: string) =>
     resetMutation.isPending && resetMutation.variables === code
+  const isVerifyPendingForCode = (code: string) =>
+    verifyMutation.isPending && verifyMutation.variables?.docCode === code
 
   // ============================================================================
   // RENDER
@@ -761,12 +809,6 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
-                      <th
-                        scope="col"
-                        className="py-2 pr-3 text-left font-medium tabular-nums w-10"
-                      >
-                        #
-                      </th>
                       <th scope="col" className="py-2 pr-3 text-left font-medium">
                         Tên giấy tờ
                       </th>
@@ -775,9 +817,6 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                       </th>
                       <th scope="col" className="py-2 pr-3 text-left font-medium">
                         Đã ghi nhận
-                      </th>
-                      <th scope="col" className="py-2 pr-3 text-left font-medium">
-                        Cách ghi nhận
                       </th>
                       <th scope="col" className="py-2 pr-3 text-left font-medium">
                         Trạng thái
@@ -801,9 +840,6 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                           key={doc.code || i}
                           className="hover:bg-muted/30 motion-reduce:transition-none"
                         >
-                          <td className="py-3 pr-3 align-top text-muted-foreground tabular-nums">
-                            {i + 1}
-                          </td>
                           <td className="py-3 pr-3 align-top min-w-0">
                             <div className="font-medium text-pretty break-words">
                               {doc.label}
@@ -829,6 +865,9 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                             )}
                           </td>
                           <td className="py-3 pr-3 align-top">
+                            {/* ADM-031 round 7: 3-line "Yêu cầu" cell — bắt buộc /
+                                loại bản / cách xử lý — replaces the separate
+                                "Cách ghi nhận" column. */}
                             <div className="text-sm">
                               {doc.is_mandatory ? "Bắt buộc" : "Tùy chọn"}
                             </div>
@@ -848,6 +887,17 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                                 </span>
                               </div>
                             )}
+                            <div
+                              className="text-xs text-muted-foreground inline-flex items-center gap-1 mt-0.5"
+                              title={state.howToReceiveTitle}
+                              aria-label={state.howToReceiveTitle}
+                            >
+                              <HowIcon
+                                className="h-3 w-3 shrink-0"
+                                aria-hidden="true"
+                              />
+                              <span>{state.howToReceiveLabel}</span>
+                            </div>
                           </td>
                           <td className="py-3 pr-3 align-top">
                             <Badge
@@ -893,22 +943,6 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                             )}
                           </td>
                           <td className="py-3 pr-3 align-top">
-                            {/* ADM-031 round 6 — light pill, NOT a button. The
-                                action lives in the "Thao tác" column; this cell
-                                only describes the workflow path. */}
-                            <span
-                              className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground bg-muted/60"
-                              title={state.howToReceiveTitle}
-                              aria-label={state.howToReceiveTitle}
-                            >
-                              <HowIcon
-                                className="h-3 w-3 shrink-0"
-                                aria-hidden="true"
-                              />
-                              {state.howToReceiveLabel}
-                            </span>
-                          </td>
-                          <td className="py-3 pr-3 align-top">
                             <Badge className={`${state.statusConfig.color} gap-1`}>
                               <StatusIcon
                                 className="h-3 w-3 shrink-0"
@@ -925,11 +959,14 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                               isPaperPending={isPaperPendingForCode(doc.code)}
                               isResetPending={resetMutation.isPending}
                               isCurrentResetTarget={isResetPendingForCode(doc.code)}
+                              isVerifyPending={verifyMutation.isPending}
+                              isCurrentVerifyTarget={isVerifyPendingForCode(doc.code)}
                               onView={handleViewDocument}
                               onUpload={handleUploadClick}
                               onPaperSubmit={handlePaperSubmit}
                               onRejectClick={handleRejectClick}
                               onResetClick={handleResetClick}
+                              onVerifyClick={handleVerifyClick}
                               alignEnd
                             />
                           </td>
@@ -995,16 +1032,31 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                           Yêu cầu
                         </dt>
                         <dd className="break-words">
-                          {doc.is_mandatory ? "Bắt buộc" : "Tùy chọn"}
-                          {state.formatBadge && (
-                            <span
-                              className="text-xs text-muted-foreground"
-                              title={state.formatBadge.label}
-                            >
-                              {" · "}
-                              {state.formatBadge.label}
-                            </span>
-                          )}
+                          <div>
+                            {doc.is_mandatory ? "Bắt buộc" : "Tùy chọn"}
+                            {state.formatBadge && (
+                              <span
+                                className="text-xs text-muted-foreground"
+                                title={state.formatBadge.label}
+                              >
+                                {" · "}
+                                {state.formatBadge.label}
+                              </span>
+                            )}
+                          </div>
+                          {/* Cách xử lý line — replaces the dropped
+                              "Cách ghi nhận" row from round 7. */}
+                          <div
+                            className="text-xs text-muted-foreground inline-flex items-center gap-1 mt-0.5"
+                            title={state.howToReceiveTitle}
+                            aria-label={state.howToReceiveTitle}
+                          >
+                            <HowIcon
+                              className="h-3 w-3 shrink-0"
+                              aria-hidden="true"
+                            />
+                            <span>{state.howToReceiveLabel}</span>
+                          </div>
                         </dd>
 
                         <dt className="text-xs text-muted-foreground self-center">
@@ -1037,25 +1089,6 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                             </div>
                           )}
                         </dd>
-
-                        <dt className="text-xs text-muted-foreground self-center">
-                          Cách ghi nhận
-                        </dt>
-                        <dd>
-                          {/* Light pill, NOT a button — actual action lives in
-                              the action group below. */}
-                          <span
-                            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground bg-muted/60"
-                            title={state.howToReceiveTitle}
-                            aria-label={state.howToReceiveTitle}
-                          >
-                            <HowIcon
-                              className="h-3 w-3 shrink-0"
-                              aria-hidden="true"
-                            />
-                            {state.howToReceiveLabel}
-                          </span>
-                        </dd>
                       </dl>
 
                       {state.hasAnyAction && (
@@ -1067,11 +1100,14 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                             isPaperPending={isPaperPendingForCode(doc.code)}
                             isResetPending={resetMutation.isPending}
                             isCurrentResetTarget={isResetPendingForCode(doc.code)}
+                            isVerifyPending={verifyMutation.isPending}
+                            isCurrentVerifyTarget={isVerifyPendingForCode(doc.code)}
                             onView={handleViewDocument}
                             onUpload={handleUploadClick}
                             onPaperSubmit={handlePaperSubmit}
                             onRejectClick={handleRejectClick}
                             onResetClick={handleResetClick}
+                            onVerifyClick={handleVerifyClick}
                           />
                         </div>
                       )}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -27,7 +27,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
+import { Badge, badgeVariants } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -86,7 +86,7 @@ import {
 } from "@/hooks/admissions/useAdmissions"
 import { useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
-import { isSafeFilePath } from "@/lib/utils"
+import { cn, isSafeFilePath } from "@/lib/utils"
 import {
   DOCUMENT_FORMAT_OPTIONS,
   getFormatLabel,
@@ -166,13 +166,22 @@ const RECEPTION_LABEL: Record<string, string> = {
 // Work-queue priority. Officers act on rows in this order: things they
 // (or a teammate) still owe -> things waiting for verification -> done.
 // Lower number = sorts first.
+//
+// ADM-031 round 10 review (D1): paper_submitted moved from bucket 2
+// (waiting) to bucket 3 (done). Backend strict-mode at
+// admission_service.py:566 counts paper_submitted as satisfying the
+// mandatory gate (round 9 alignment), the row badge is success-tinted
+// "Đã nhận giấy", and isDocumentRequirementSatisfied returns true for
+// it. Sorting it next to "uploaded" (Chờ duyệt) put a "done" row in
+// the middle of the work queue and contradicted the badge color in
+// the same row — keep all three "satisfied" states in one bucket.
 const STATUS_PRIORITY: Record<string, number> = {
   missing: 1,
   rejected: 1,
   revision_requested: 1,
   resubmitted: 2,
   uploaded: 2,
-  paper_submitted: 2,
+  paper_submitted: 3,
   verified: 3,
 }
 
@@ -281,13 +290,23 @@ function computeRowState(doc: DocumentItem) {
 
   // Date-of-record — appears under the reception bucket in the
   // "Đã ghi nhận" cell so the title cell can stay focused on doc
-  // identity (label + code + reject reason). For paper-submitted
-  // rows, prefer the dedicated paper_submitted_at timestamp from
-  // ADM-031 round 7 backend addition; fall back to uploaded_at for
-  // online docs.
+  // identity (label + code + reject reason).
+  //
+  // ADM-031 round 10 review (E1): paper-only rows that progress to
+  // verified must keep showing the paper-receipt date. Previous
+  // logic flipped to ``uploaded_at`` once status changed away from
+  // ``paper_submitted``, but ``uploaded_at`` is null for paper-only
+  // docs (no scan ever uploaded), so a verified paper doc rendered
+  // with no recorded date at all. Decision tree now:
+  //   - paper_submitted              → paper_submitted_at
+  //   - paper-only verified          → paper_submitted_at
+  //                                    (uploaded_at would be null)
+  //   - everything else (uploaded /  → uploaded_at
+  //     online verified)
+  const requiresUploadField = doc.requires_upload !== false
   const recordedAtIso =
-    doc.status === "paper_submitted"
-      ? (doc.paper_submitted_at ?? null)
+    doc.status === "paper_submitted" || !requiresUploadField
+      ? (doc.paper_submitted_at ?? doc.uploaded_at ?? null)
       : (doc.uploaded_at ?? null)
   const recordedAtFormatted = recordedAtIso
     ? VI_DATE_FORMATTER.format(new Date(recordedAtIso))
@@ -634,10 +653,21 @@ function DocumentRowActions(props: ActionsCellProps) {
 // COMPONENT
 // ============================================================================
 
-export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabProps) {
+export function DocumentsTab({ profile }: DocumentsTabProps) {
   // `isEditable` is retained on the props contract for parent callers, but
   // per-row visibility is now fully driven by `doc.can_*` flags (PR #5).
-  const documents = profile.documents_checklist || []
+  // We deliberately don't destructure it here — keeping it on the type so
+  // TS still validates parent usage without triggering no-unused-vars.
+  //
+  // ADM-031 round 10 review: wrap the documents array in useMemo so the
+  // identity is stable across renders. Without this, `useMemo`-based hooks
+  // downstream (sortedDocs, KPI counts memoizations) re-fire on every
+  // render because `profile.documents_checklist || []` allocates a fresh
+  // [] when the field is null.
+  const documents = useMemo(
+    () => profile.documents_checklist || [],
+    [profile.documents_checklist],
+  )
   const uploadMutation = useUploadAdmissionDocument(profile.id)
   const paperMutation = useMarkPaperSubmitted(profile.id)
   const rejectMutation = useRejectDocument(profile.id)
@@ -889,12 +919,21 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
           hint={pendingCount > 0 ? "Cần manager duyệt format" : "Không có"}
         />
         <KpiTile
+          // ADM-031 round 10 review (D2): headline shows the
+          // mandatory ratio because "yêu cầu" semantically refers to
+          // the submission gate (which is mandatory-only). Total
+          // (incl. optional) is demoted to the hint so the number
+          // officers act on is the gating one.
           label="Hoàn tất yêu cầu"
-          value={`${satisfiedCount}/${total}`}
+          value={
+            mandatoryDocs.length > 0
+              ? `${mandatorySatisfiedCount}/${mandatoryDocs.length}`
+              : `${satisfiedCount}/${total}`
+          }
           accent="success"
           hint={
             mandatoryDocs.length > 0
-              ? `Bắt buộc: ${mandatorySatisfiedCount}/${mandatoryDocs.length} • ${satisfiedPercent}%`
+              ? `Tổng: ${satisfiedCount}/${total} • ${satisfiedPercent}%`
               : `${satisfiedPercent}%`
           }
         />
@@ -1086,15 +1125,30 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                             {state.verifierTooltip ? (
                               <Tooltip>
                                 <TooltipTrigger asChild>
-                                  <Badge
-                                    className={`${state.statusConfig.color} gap-1 cursor-help`}
+                                  {/* P3 review fix: tooltip trigger must
+                                      be focusable (Badge is a non-focusable
+                                      <div>). Render as a real <button> styled
+                                      with badgeVariants() so keyboard users
+                                      can read the long-form tooltip
+                                      ("Duyệt bởi <Tên> lúc dd/mm/yyyy hh:mm")
+                                      via Tab + focus. aria-label carries the
+                                      same content as a fallback for SR users
+                                      who don't get tooltip events. */}
+                                  <button
+                                    type="button"
+                                    aria-label={state.verifierTooltip}
+                                    className={cn(
+                                      badgeVariants(),
+                                      state.statusConfig.color,
+                                      "gap-1 cursor-help",
+                                    )}
                                   >
                                     <StatusIcon
                                       className="h-3 w-3 shrink-0"
                                       aria-hidden="true"
                                     />
                                     {state.statusConfig.label}
-                                  </Badge>
+                                  </button>
                                 </TooltipTrigger>
                                 <TooltipContent>
                                   {state.verifierTooltip}
@@ -1186,15 +1240,21 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                           {state.verifierTooltip ? (
                             <Tooltip>
                               <TooltipTrigger asChild>
-                                <Badge
-                                  className={`${state.statusConfig.color} gap-1 cursor-help`}
+                                <button
+                                  type="button"
+                                  aria-label={state.verifierTooltip}
+                                  className={cn(
+                                    badgeVariants(),
+                                    state.statusConfig.color,
+                                    "gap-1 cursor-help",
+                                  )}
                                 >
                                   <StatusIcon
                                     className="h-3 w-3 shrink-0"
                                     aria-hidden="true"
                                   />
                                   {state.statusConfig.label}
-                                </Badge>
+                                </button>
                               </TooltipTrigger>
                               <TooltipContent>
                                 {state.verifierTooltip}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -405,12 +405,24 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                 const canReset = doc.can_reset ?? false
                 const canMarkPaperSubmitted = doc.can_mark_paper_submitted ?? false
                 
+                // ADM-031 round 2: mode badge replaces the old "Online" /
+                // "Nộp giấy" pair so the wording matches the actual workflow
+                // ("Cần file" = needs upload, "Ghi nhận giấy" = paper-only
+                // checklist). Tooltip explains the difference for officers
+                // unfamiliar with the term.
+                const modeLabel = requiresUpload ? "Cần file" : "Ghi nhận giấy"
+                const modeTitle = requiresUpload
+                  ? "Cần tải ảnh/scan/PDF của giấy tờ lên hệ thống"
+                  : "Chỉ ghi nhận đã nhận bản giấy, không cần upload file"
+                const ModeIcon = requiresUpload ? Globe : Building2
+
                 return (
                   <div
                     key={doc.code || index}
                     className="flex flex-col gap-3 p-3 border rounded-lg hover:bg-muted/30 transition-colors md:flex-row md:items-center md:gap-4"
                   >
-                    {/* Column 1: Tên giấy tờ */}
+                    {/* Title block — name + mandatory star + meta + task hint.
+                        Same on mobile and desktop. */}
                     <div className="flex items-start gap-3 flex-1 min-w-0">
                       <div className="p-2 bg-muted rounded shrink-0">
                         <FileText className="h-4 w-4 text-muted-foreground" />
@@ -441,45 +453,58 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                       </div>
                     </div>
 
-                    {/* Badge group — format + hình thức + status. Wraps on
-                        narrow widths so long Vietnamese copy ("Bản chụp/scan
-                        không chứng thực") doesn't overflow the row.
-                        ADM-031.5 follow-up. */}
-                    <div className="flex flex-wrap items-center gap-2 md:max-w-[20rem] md:justify-end">
+                    {/* Metadata block — labelled key/value rows on mobile per
+                        ADM-031 round 2 wireframe; collapses to horizontal
+                        badge cluster on desktop. The labels are
+                        ``md:hidden`` so they vanish on desktop without
+                        wrapping the badges in extra DOM. */}
+                    <div className="grid grid-cols-[8rem_1fr] gap-x-3 gap-y-1.5 text-sm md:flex md:flex-wrap md:items-center md:gap-2 md:max-w-[20rem] md:justify-end">
                       {formatBadge && (
-                        <Badge
-                          variant="outline"
-                          className="text-xs gap-1 max-w-full"
-                          title={formatBadge.label}
-                        >
-                          <FormatIcon className="h-3 w-3 shrink-0" />
-                          <span className="truncate">{formatBadge.label}</span>
-                        </Badge>
+                        <>
+                          <span className="text-xs text-muted-foreground self-center md:hidden">
+                            Yêu cầu bản nộp
+                          </span>
+                          <Badge
+                            variant="outline"
+                            className="text-xs gap-1 max-w-full justify-start md:justify-center"
+                            title={formatBadge.label}
+                          >
+                            <FormatIcon className="h-3 w-3 shrink-0" />
+                            <span className="truncate">{formatBadge.label}</span>
+                          </Badge>
+                        </>
                       )}
-                      <Badge variant="secondary" className="text-xs gap-1">
-                        {requiresUpload ? (
-                          <>
-                            <Globe className="h-3 w-3" />
-                            Online
-                          </>
-                        ) : (
-                          <>
-                            <Building2 className="h-3 w-3" />
-                            Nộp giấy
-                          </>
-                        )}
+                      <span className="text-xs text-muted-foreground self-center md:hidden">
+                        Cách ghi nhận
+                      </span>
+                      <Badge
+                        variant="secondary"
+                        className="text-xs gap-1 justify-start md:justify-center w-fit"
+                        title={modeTitle}
+                      >
+                        <ModeIcon className="h-3 w-3" />
+                        {modeLabel}
                       </Badge>
-                      <Badge className={`${statusConfig.color} max-w-full`} title={statusConfig.label}>
+                      <span className="text-xs text-muted-foreground self-center md:hidden">
+                        Trạng thái
+                      </span>
+                      <Badge
+                        className={`${statusConfig.color} max-w-full justify-start md:justify-center`}
+                        title={statusConfig.label}
+                      >
                         <StatusIcon className="h-3 w-3 mr-1 shrink-0" />
                         <span className="truncate">{statusConfig.label}</span>
                       </Badge>
                     </div>
 
-                    {/* Actions — wrap on narrow widths so explicit Vietnamese
-                        button labels ("Tải file" / "Đánh dấu đã nhận giấy")
-                        never overflow the action column.
-                        ADM-031.5 follow-up. */}
-                    <div className="flex flex-wrap items-center gap-2 md:justify-end md:shrink-0">
+                    {/* Actions — labelled on mobile, compact horizontal cluster
+                        on desktop. Inner div keeps the buttons grouped so
+                        flex-wrap operates within the action area only. */}
+                    <div className="grid grid-cols-[8rem_1fr] gap-x-3 gap-y-1.5 md:flex md:flex-wrap md:items-center md:gap-2 md:justify-end md:shrink-0">
+                      <span className="text-xs text-muted-foreground self-center md:hidden">
+                        Thao tác
+                      </span>
+                      <div className="flex flex-wrap items-center gap-2">
                       {/* View button for uploaded documents */}
                       {hasFile && (
                         <Button
@@ -570,6 +595,7 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                           )}
                         </Button>
                       )}
+                      </div>
                     </div>
                   </div>
                 )
@@ -590,20 +616,23 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
       
       {/* Submission Format Selection Dialog
           Officer / applicant declares the *actual* paper/file type they
-          just received. The dialog deliberately does NOT ask for an
-          extra evidence document — wording is task-oriented so the user
-          doesn't read this as a second upload step. */}
+          just received. ADM-031 round 2 splits the wording per action so
+          the upload flow ("File này là bản gì?") and the paper-receipt
+          flow ("Bản giấy vừa nhận là bản gì?") are unambiguous. The dialog
+          deliberately does NOT ask for an extra evidence document. */}
       <Dialog
         open={submissionFormatDialog?.isOpen || false}
         onOpenChange={(open) => !open && setSubmissionFormatDialog(null)}
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Loại bản thực tế trong file/giấy này</DialogTitle>
+            <DialogTitle>
+              {submissionFormatDialog?.action === "paper"
+                ? "Xác nhận bản giấy vừa nhận"
+                : "Tải file tài liệu"}
+            </DialogTitle>
             <DialogDescription>
-              Đây là loại bản của <strong>{submissionFormatDialog?.docLabel}</strong> bạn vừa{" "}
-              {submissionFormatDialog?.action === "paper" ? "nhận tại quầy" : "tải lên"}
-              {" "}— không phải tài liệu bổ sung. Hãy chọn đúng loại bản đang có trong tay.
+              Tài liệu: <strong>{submissionFormatDialog?.docLabel}</strong>
             </DialogDescription>
           </DialogHeader>
 
@@ -615,6 +644,12 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
               </span>
             </div>
           )}
+
+          <p className="text-sm font-medium">
+            {submissionFormatDialog?.action === "paper"
+              ? "Bản giấy vừa nhận là bản gì?"
+              : "File này là bản gì?"}
+          </p>
 
           <RadioGroup value={selectedFormat} onValueChange={setSelectedFormat}>
             {DOCUMENT_FORMAT_OPTIONS.map((option) => (
@@ -635,7 +670,9 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
 
           {/* Soft warning — selected actual format does not match the
               required format. Allowed (officer may still proceed) but
-              flagged so officer notices any mismatch before saving. */}
+              flagged so officer notices any mismatch before saving.
+              Wording is action-aware: upload flow says "trước khi tải
+              file"; paper flow says "trước khi ghi nhận". */}
           {submissionFormatDialog?.requiredFormat &&
             selectedFormat &&
             selectedFormat !== submissionFormatDialog.requiredFormat && (
@@ -645,10 +682,9 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
               >
                 <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
                 <span>
-                  Loại bản thực tế (<strong>{getFormatLabel(selectedFormat)}</strong>){" "}
-                  khác với yêu cầu hồ sơ (
-                  <strong>{getFormatLabel(submissionFormatDialog.requiredFormat)}</strong>
-                  ). Hãy kiểm tra lại trước khi xác nhận.
+                  {submissionFormatDialog.action === "paper"
+                    ? "Bản giấy thực tế khác yêu cầu hồ sơ. Hãy kiểm tra lại trước khi ghi nhận."
+                    : "Loại bản trong file khác yêu cầu hồ sơ. Hãy kiểm tra lại trước khi tải file."}
                 </span>
               </div>
             )}
@@ -661,7 +697,7 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
               onClick={handleSubmissionFormatConfirm}
               disabled={!selectedFormat}
             >
-              Xác nhận
+              {submissionFormatDialog?.action === "paper" ? "Ghi nhận giấy" : "Tải file"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -83,6 +83,7 @@ import { isSafeFilePath } from "@/lib/utils"
 import {
   DOCUMENT_FORMAT_OPTIONS,
   getFormatLabel,
+  getShortFormatLabel,
   isDocumentRecorded,
   isDocumentRequirementSatisfied,
   isDocumentPendingVerification,
@@ -97,35 +98,37 @@ interface DocumentsTabProps {
 // CONSTANTS
 // ============================================================================
 
-// Status labels distinguish "ghi nhận" (received) from "kiểm tra" (verified):
-// uploaded / paper_submitted are received but officer-review still pending,
-// while verified means officer has confirmed the submitted format.
+// ADM-031 round 6 — Trạng thái cell carries workflow state only:
+// "Cần làm" -> officer/applicant must act, "Chờ duyệt" -> waiting for
+// manager review, "Đã duyệt" -> verified, "Từ chối" -> rejected. The
+// "Đã ghi nhận" cell separately reports what was physically received
+// ("Chưa" / "File" / "Giấy") so the two cells don't echo each other.
 const STATUS_CONFIG: Record<
   string,
   { label: string; color: string; icon: typeof AlertCircle }
 > = {
   missing: {
-    label: "Chưa nộp",
+    label: "Cần làm",
     color: "bg-muted text-muted-foreground",
     icon: AlertCircle,
   },
   uploaded: {
-    label: "Đã ghi nhận file",
+    label: "Chờ duyệt",
     color: "bg-info-100 text-info-700",
     icon: Upload,
   },
   paper_submitted: {
-    label: "Đã nhận bản giấy",
+    label: "Chờ duyệt",
     color: "bg-info-100 text-info-700",
     icon: FileText,
   },
   verified: {
-    label: "Đã kiểm tra",
+    label: "Đã duyệt",
     color: "bg-success-100 text-success-700",
     icon: Check,
   },
   rejected: {
-    label: "Không hợp lệ",
+    label: "Từ chối",
     color: "bg-error-100 text-error-700",
     icon: XCircle,
   },
@@ -240,11 +243,29 @@ function computeRowState(doc: DocumentItem) {
     recordedFormatCode !== doc.submission_format
 
   const receptionLabel = getReceptionLabel(doc.status ?? "missing")
-  const howToReceiveLabel = requiresUpload ? "Tải file" : "Nhận giấy tại quầy"
+  // ADM-031 round 6 — table uses the shorter verb "Tải file" / "Nhận giấy"
+  // so the column doesn't drift outside its 5-rem width with the legacy
+  // "Nhận giấy tại quầy". Tooltip + aria-label keep the full meaning.
+  const howToReceiveLabel = requiresUpload ? "Tải file" : "Nhận giấy"
   const howToReceiveTitle = requiresUpload
     ? "Cần tải ảnh/scan/PDF của giấy tờ lên hệ thống"
-    : "Chỉ ghi nhận đã nhận bản giấy, không cần upload file"
+    : "Ghi nhận đã nhận bản giấy trực tiếp, không cần upload file"
   const HowToReceiveIcon = requiresUpload ? Globe : Building2
+
+  // Date-of-record — appears under the reception bucket in the
+  // "Đã ghi nhận" cell so the title cell can stay focused on doc
+  // identity (label + code + reject reason).
+  const recordedAtIso =
+    doc.uploaded_at ??
+    (doc as DocumentItem & { paper_submitted_at?: string | null }).paper_submitted_at ??
+    null
+  const recordedAtFormatted = recordedAtIso
+    ? VI_DATE_FORMATTER.format(new Date(recordedAtIso))
+    : null
+
+  const requiredFormatShort = doc.submission_format
+    ? getShortFormatLabel(doc.submission_format)
+    : null
 
   const hasFile =
     !!doc.file_path && (doc.status === "uploaded" || doc.status === "verified")
@@ -255,15 +276,12 @@ function computeRowState(doc: DocumentItem) {
   const hasAnyAction =
     hasFile || canUpload || canMarkPaperSubmitted || canReject || canReset
 
-  const formattedUploadedAt = doc.uploaded_at
-    ? VI_DATE_FORMATTER.format(new Date(doc.uploaded_at))
-    : null
-
   return {
     statusConfig,
     requiresUpload,
     isPaperOnly,
     formatBadge,
+    requiredFormatShort,
     recordedFormatCode,
     recordedFormatLabel,
     recordedDiffersFromRequired,
@@ -277,7 +295,7 @@ function computeRowState(doc: DocumentItem) {
     canReject,
     canReset,
     hasAnyAction,
-    formattedUploadedAt,
+    recordedAtFormatted,
   }
 }
 
@@ -403,13 +421,14 @@ function DocumentRowActions(props: ActionsCellProps) {
             onPaperSubmit(doc.code, doc.label, doc.submission_format ?? undefined)
           }
           disabled={isPaperPending}
+          aria-label="Đánh dấu đã nhận giấy"
         >
           {isPaperPending ? (
             <Loader2 className="h-4 w-4 mr-1 animate-spin motion-reduce:animate-none" />
           ) : (
             <Building2 className="h-4 w-4 mr-1" />
           )}
-          Đánh dấu đã nhận giấy
+          Đã nhận giấy
         </Button>
       )}
 
@@ -715,8 +734,8 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                 Tài liệu hồ sơ
               </CardTitle>
               <CardDescription>
-                Sắp xếp theo việc cần làm: chưa nộp / không hợp lệ trước, kế đến
-                là chờ kiểm tra, cuối cùng là đã hoàn tất.
+                Sắp xếp theo việc cần làm: cần làm / từ chối trước, kế đến là
+                chờ duyệt, cuối cùng là đã duyệt.
               </CardDescription>
             </div>
             <p
@@ -797,16 +816,11 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                                 </span>
                               )}
                             </div>
-                            <div className="text-xs text-muted-foreground">
-                              <span translate="no">Mã: {doc.code}</span>
-                              {state.formattedUploadedAt && (
-                                <>
-                                  {" • "}
-                                  <span className="tabular-nums">
-                                    {state.formattedUploadedAt}
-                                  </span>
-                                </>
-                              )}
+                            <div
+                              className="text-xs text-muted-foreground"
+                              translate="no"
+                            >
+                              Mã: {doc.code}
                             </div>
                             {doc.status === "rejected" && doc.rejection_reason && (
                               <div className="text-xs text-error-700 mt-1 break-words">
@@ -818,14 +832,19 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                             <div className="text-sm">
                               {doc.is_mandatory ? "Bắt buộc" : "Tùy chọn"}
                             </div>
-                            {state.formatBadge && FormatIcon && (
-                              <div className="text-xs text-muted-foreground inline-flex items-center gap-1 mt-0.5">
-                                <FormatIcon
-                                  className="h-3 w-3 shrink-0"
-                                  aria-hidden="true"
-                                />
-                                <span className="break-words">
-                                  {state.formatBadge.label}
+                            {state.requiredFormatShort && state.formatBadge && (
+                              <div
+                                className="text-xs text-muted-foreground inline-flex items-center gap-1 mt-0.5"
+                                title={state.formatBadge.label}
+                              >
+                                {FormatIcon && (
+                                  <FormatIcon
+                                    className="h-3 w-3 shrink-0"
+                                    aria-hidden="true"
+                                  />
+                                )}
+                                <span aria-label={state.formatBadge.label}>
+                                  {state.requiredFormatShort}
                                 </span>
                               </div>
                             )}
@@ -850,8 +869,8 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                                 }`}
                                 title={
                                   state.recordedDiffersFromRequired
-                                    ? `Khác yêu cầu hồ sơ (${state.formatBadge?.label ?? doc.submission_format})`
-                                    : undefined
+                                    ? `Đã ghi nhận: ${state.recordedFormatLabel} — KHÁC yêu cầu hồ sơ (${state.formatBadge?.label ?? doc.submission_format})`
+                                    : `Đã ghi nhận: ${state.recordedFormatLabel}`
                                 }
                               >
                                 {state.recordedDiffersFromRequired && (
@@ -860,22 +879,34 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                                     aria-label="Khác yêu cầu hồ sơ"
                                   />
                                 )}
-                                <span>{state.recordedFormatLabel}</span>
+                                <span>
+                                  {state.recordedFormatCode
+                                    ? getShortFormatLabel(state.recordedFormatCode)
+                                    : state.recordedFormatLabel}
+                                </span>
+                              </div>
+                            )}
+                            {state.recordedAtFormatted && (
+                              <div className="text-xs text-muted-foreground tabular-nums mt-1">
+                                {state.recordedAtFormatted}
                               </div>
                             )}
                           </td>
                           <td className="py-3 pr-3 align-top">
-                            <Badge
-                              variant="outline"
-                              className="text-xs gap-1"
+                            {/* ADM-031 round 6 — light pill, NOT a button. The
+                                action lives in the "Thao tác" column; this cell
+                                only describes the workflow path. */}
+                            <span
+                              className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground bg-muted/60"
                               title={state.howToReceiveTitle}
+                              aria-label={state.howToReceiveTitle}
                             >
                               <HowIcon
                                 className="h-3 w-3 shrink-0"
                                 aria-hidden="true"
                               />
                               {state.howToReceiveLabel}
-                            </Badge>
+                            </span>
                           </td>
                           <td className="py-3 pr-3 align-top">
                             <Badge className={`${state.statusConfig.color} gap-1`}>
@@ -942,11 +973,6 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                           >
                             Mã: {doc.code}
                           </div>
-                          {state.formattedUploadedAt && (
-                            <div className="text-xs text-muted-foreground tabular-nums">
-                              Cập nhật: {state.formattedUploadedAt}
-                            </div>
-                          )}
                           {doc.status === "rejected" && doc.rejection_reason && (
                             <div className="text-xs text-error-700 mt-1 break-words">
                               Lý do: {doc.rejection_reason}
@@ -971,7 +997,10 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                         <dd className="break-words">
                           {doc.is_mandatory ? "Bắt buộc" : "Tùy chọn"}
                           {state.formatBadge && (
-                            <span className="text-xs text-muted-foreground">
+                            <span
+                              className="text-xs text-muted-foreground"
+                              title={state.formatBadge.label}
+                            >
                               {" · "}
                               {state.formatBadge.label}
                             </span>
@@ -992,10 +1021,20 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                                   ? "text-warning-700"
                                   : "text-muted-foreground"
                               }`}
+                              title={
+                                state.recordedDiffersFromRequired
+                                  ? `Đã ghi nhận: ${state.recordedFormatLabel} — KHÁC yêu cầu hồ sơ`
+                                  : `Đã ghi nhận: ${state.recordedFormatLabel}`
+                              }
                             >
                               {state.recordedDiffersFromRequired ? "⚠ " : ""}
                               {state.recordedFormatLabel}
                             </span>
+                          )}
+                          {state.recordedAtFormatted && (
+                            <div className="text-xs text-muted-foreground tabular-nums mt-0.5">
+                              {state.recordedAtFormatted}
+                            </div>
                           )}
                         </dd>
 
@@ -1003,17 +1042,19 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                           Cách ghi nhận
                         </dt>
                         <dd>
-                          <Badge
-                            variant="outline"
-                            className="text-xs gap-1"
+                          {/* Light pill, NOT a button — actual action lives in
+                              the action group below. */}
+                          <span
+                            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground bg-muted/60"
                             title={state.howToReceiveTitle}
+                            aria-label={state.howToReceiveTitle}
                           >
                             <HowIcon
                               className="h-3 w-3 shrink-0"
                               aria-hidden="true"
                             />
                             {state.howToReceiveLabel}
-                          </Badge>
+                          </span>
                         </dd>
                       </dl>
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -17,7 +17,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
 import {
   Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle
 } from "@/components/ui/dialog"
@@ -29,14 +28,21 @@ import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import {
-  FileText, Check, AlertCircle, Clock, XCircle, Upload, Loader2, Eye, ExternalLink,
-  Camera, FileCheck, FileSpreadsheet, Globe, Building2, Ban, RotateCcw
+  FileText, Check, AlertCircle, XCircle, Upload, Loader2, Eye,
+  Camera, FileCheck, FileSpreadsheet, Globe, Building2, Ban, RotateCcw,
+  AlertTriangle,
 } from "lucide-react"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 import { useUploadAdmissionDocument, useMarkPaperSubmitted, useRejectDocument, useResetDocument } from "@/hooks/admissions/useAdmissions"
 import { useRef, useState } from "react"
 import { toast } from "sonner"
 import { isSafeFilePath } from "@/lib/utils"
+import {
+  DOCUMENT_FORMAT_OPTIONS,
+  getFormatLabel,
+  isDocumentVerified,
+  isDocumentRecorded,
+} from "@/lib/utils/admission-helpers"
 
 interface DocumentsTabProps {
   profile: AdmissionProfileResponse
@@ -47,6 +53,9 @@ interface DocumentsTabProps {
 // STATUS CONFIG
 // ============================================================================
 
+// Status labels distinguish "ghi nhận" (received) from "kiểm tra" (verified):
+// uploaded / paper_submitted are received but officer-review still pending,
+// while verified means officer has confirmed the submitted format.
 const STATUS_CONFIG: Record<string, {
   label: string
   color: string
@@ -58,17 +67,17 @@ const STATUS_CONFIG: Record<string, {
     icon: AlertCircle,
   },
   uploaded: {
-    label: "Đã tải",
+    label: "Đã ghi nhận (online)",
     color: "bg-info-100 text-info-700",
-    icon: Check,
+    icon: Upload,
   },
   paper_submitted: {
-    label: "Đã nộp",
-    color: "bg-success-100 text-success-700",
-    icon: Check,
+    label: "Đã nhận bản giấy",
+    color: "bg-info-100 text-info-700",
+    icon: FileText,
   },
   verified: {
-    label: "Đã xác minh",
+    label: "Đã kiểm tra",
     color: "bg-success-100 text-success-700",
     icon: Check,
   },
@@ -79,26 +88,12 @@ const STATUS_CONFIG: Record<string, {
   },
 }
 
-// ============================================================================
-// SUBMISSION FORMAT CONFIG
-// ============================================================================
-
-const FORMAT_CONFIG: Record<string, {
-  label: string
-  icon: typeof Camera
-}> = {
-  photo: {
-    label: "Ảnh chụp",
-    icon: Camera,
-  },
-  certified_copy: {
-    label: "Sao y",
-    icon: FileCheck,
-  },
-  original: {
-    label: "Bản gốc",
-    icon: FileSpreadsheet,
-  },
+// Icon mapping for submission format badges. Labels come from
+// admission-helpers (single source of truth) — do not duplicate text here.
+const FORMAT_ICONS: Record<string, typeof Camera> = {
+  photo: Camera,
+  certified_copy: FileCheck,
+  original: FileSpreadsheet,
 }
 
 function getStatusConfig(status: string) {
@@ -109,9 +104,12 @@ function getStatusConfig(status: string) {
   }
 }
 
-function getFormatConfig(format: string | null | undefined) {
+function getFormatBadge(format: string | null | undefined) {
   if (!format) return null
-  return FORMAT_CONFIG[format] ?? { label: format, icon: FileSpreadsheet }
+  return {
+    label: getFormatLabel(format),
+    icon: FORMAT_ICONS[format] ?? FileSpreadsheet,
+  }
 }
 
 // ============================================================================
@@ -276,14 +274,13 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
     window.open(url, "_blank", "noopener,noreferrer")
   }
   
-  // Stats
-  const completedCount = documents.filter(
-    (d) => d.status === "uploaded" || d.status === "verified" || d.status === "paper_submitted"
-  ).length
+  // Stats — distinguish "ghi nhận" (received in any form) from "kiểm tra"
+  // (officer-verified). Progress bar reflects fully-verified rows so
+  // received-but-unverified docs don't masquerade as complete.
+  const recordedCount = documents.filter((d) => isDocumentRecorded(d.status)).length
+  const verifiedCount = documents.filter((d) => isDocumentVerified(d.status)).length
   const mandatoryDocs = documents.filter((d) => d.is_mandatory)
-  const mandatoryCompletedCount = mandatoryDocs.filter(
-    (d) => d.status === "uploaded" || d.status === "verified" || d.status === "paper_submitted"
-  ).length
+  const mandatoryVerifiedCount = mandatoryDocs.filter((d) => isDocumentVerified(d.status)).length
 
   return (
     <>
@@ -296,29 +293,50 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                 Tài liệu hồ sơ
               </CardTitle>
               <CardDescription>
-                {completedCount} / {documents.length} tài liệu đã nộp
+                Đã ghi nhận {recordedCount}/{documents.length} • Đã kiểm tra {verifiedCount}/{documents.length}
                 {mandatoryDocs.length > 0 && (
                   <span className="ml-2">
-                    (Bắt buộc: {mandatoryCompletedCount}/{mandatoryDocs.length})
+                    (Bắt buộc đã kiểm tra: {mandatoryVerifiedCount}/{mandatoryDocs.length})
                   </span>
                 )}
               </CardDescription>
             </div>
-            {/* Progress indicator */}
+            {/* Progress bar reflects officer-verified rows only. The
+                ghi-nhận sliver shows up as the lighter background fill so
+                officers can still see incoming volume at a glance. */}
             <div className="flex items-center gap-2">
-              <div className="w-32 h-2 bg-muted rounded-full overflow-hidden">
+              <div
+                className="relative w-32 h-2 bg-muted rounded-full overflow-hidden"
+                role="progressbar"
+                aria-label="Tiến độ kiểm tra tài liệu"
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={
+                  documents.length > 0
+                    ? Math.round((verifiedCount / documents.length) * 100)
+                    : 0
+                }
+              >
                 <div
-                  className="h-full bg-primary transition-[width] duration-300"
+                  className="absolute inset-y-0 left-0 bg-info-200 transition-[width] duration-300"
                   style={{
                     width: documents.length > 0
-                      ? `${(completedCount / documents.length) * 100}%`
+                      ? `${(recordedCount / documents.length) * 100}%`
+                      : "0%",
+                  }}
+                />
+                <div
+                  className="absolute inset-y-0 left-0 bg-success-600 transition-[width] duration-300"
+                  style={{
+                    width: documents.length > 0
+                      ? `${(verifiedCount / documents.length) * 100}%`
                       : "0%",
                   }}
                 />
               </div>
               <span className="text-sm text-muted-foreground font-medium">
                 {documents.length > 0
-                  ? Math.round((completedCount / documents.length) * 100)
+                  ? Math.round((verifiedCount / documents.length) * 100)
                   : 0}%
               </span>
             </div>
@@ -339,15 +357,24 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
             <div className="space-y-2">
               {documents.map((doc, index) => {
                 const statusConfig = getStatusConfig(doc.status)
-                const formatConfig = getFormatConfig(doc.submission_format)
+                const formatBadge = getFormatBadge(doc.submission_format)
                 const StatusIcon = statusConfig.icon
-                const FormatIcon = formatConfig?.icon || FileSpreadsheet
-                
+                const FormatIcon = formatBadge?.icon || FileSpreadsheet
+
                 const isUploading = uploadMutation.isPending && selectedDocCode === doc.code
                 const isPaperPending = paperMutation.isPending && paperMutation.variables?.docCode === doc.code
                 const hasFile = doc.file_path && (doc.status === "uploaded" || doc.status === "verified")
                 const requiresUpload = doc.requires_upload !== false // Default true if undefined
                 const isPaperDoc = !requiresUpload
+                // Task-oriented hint surfaced inline for missing rows so the
+                // officer/applicant immediately knows the next physical step
+                // ("upload a scan" vs "bring paper to counter").
+                const isMissing = doc.status === "missing"
+                const taskHint = isMissing
+                  ? requiresUpload
+                    ? "Cần tải ảnh/scan"
+                    : "Nhận bản giấy tại quầy"
+                  : null
                 // PR #5: per-row permission flags from backend replace the
                 // coarse `can('edit')` gate — the matching button shows iff
                 // the route would authorise the action for this user.
@@ -384,15 +411,20 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                             </span>
                           )}
                         </div>
+                        {taskHint && (
+                          <p className="text-xs text-warning-700 font-medium mt-1">
+                            {taskHint}
+                          </p>
+                        )}
                       </div>
                     </div>
-                    
-                    {/* Column 2: Loại nộp (submission_format) */}
-                    <div className="w-24 flex-shrink-0">
-                      {formatConfig && (
+
+                    {/* Column 2: Yêu cầu loại bản nộp (submission_format) */}
+                    <div className="w-32 flex-shrink-0">
+                      {formatBadge && (
                         <Badge variant="outline" className="text-xs gap-1">
                           <FormatIcon className="h-3 w-3" />
-                          {formatConfig.label}
+                          {formatBadge.label}
                         </Badge>
                       )}
                     </div>
@@ -423,7 +455,7 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                     </div>
                     
                     {/* Column 5: Thao tác */}
-                    <div className="w-32 flex-shrink-0 flex items-center justify-end gap-2">
+                    <div className="w-44 flex-shrink-0 flex items-center justify-end gap-2">
                       {/* View button for uploaded documents */}
                       {hasFile && (
                         <Button
@@ -436,43 +468,47 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                           <Eye className="h-4 w-4" />
                         </Button>
                       )}
-                      
-                      {/* Upload button for online documents */}
+
+                      {/* Upload action — requires_upload=true rows. Label is
+                          "Tải file" to match the task-oriented hint above. */}
                       {canUpload && (
                         <Button
                           size="sm"
                           variant="outline"
                           onClick={() => handleUploadClick(doc.code, doc.label, doc.submission_format ?? undefined)}
                           disabled={uploadMutation.isPending}
-                          aria-label="Tải lên"
+                          aria-label="Tải file"
                         >
                           {isUploading ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
+                            <Loader2 className="h-4 w-4 mr-1 animate-spin" />
                           ) : (
-                            <Upload className="h-4 w-4" />
+                            <Upload className="h-4 w-4 mr-1" />
                           )}
+                          Tải file
                         </Button>
                       )}
-                      
-                      {/* Paper submission checkbox (Officer only) */}
+
+                      {/* Paper-receipt action — requires_upload=false rows.
+                          Officer-only by backend permission flag. The spec
+                          replaced the old "Đã nộp" checkbox with an explicit
+                          button so the action is unambiguous. */}
                       {canMarkPaperSubmitted && (
-                        <div className="flex items-center gap-1">
-                          <Checkbox
-                            id={`paper-${doc.code}`}
-                            disabled={isPaperPending}
-                            onCheckedChange={(checked) => {
-                              if (checked) handlePaperSubmit(doc.code, doc.label, doc.submission_format ?? undefined)
-                            }}
-                          />
-                          <label
-                            htmlFor={`paper-${doc.code}`}
-                            className="text-xs text-muted-foreground cursor-pointer select-none"
-                          >
-                            Đã nộp
-                          </label>
-                        </div>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handlePaperSubmit(doc.code, doc.label, doc.submission_format ?? undefined)}
+                          disabled={isPaperPending}
+                          aria-label="Đánh dấu đã nhận giấy"
+                        >
+                          {isPaperPending ? (
+                            <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+                          ) : (
+                            <Building2 className="h-4 w-4 mr-1" />
+                          )}
+                          Đánh dấu đã nhận giấy
+                        </Button>
                       )}
-                      
+
                       {/* Paper already submitted indicator */}
                       {isPaperDoc && doc.status === "paper_submitted" && (
                         <Check className="h-4 w-4 text-success-600" />
@@ -528,56 +564,70 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
         />
       </Card>
       
-      {/* Submission Format Selection Dialog */}
+      {/* Submission Format Selection Dialog
+          Officer / applicant declares the *actual* paper/file type they
+          just received. The dialog deliberately does NOT ask for an
+          extra evidence document — wording is task-oriented so the user
+          doesn't read this as a second upload step. */}
       <Dialog
         open={submissionFormatDialog?.isOpen || false}
         onOpenChange={(open) => !open && setSubmissionFormatDialog(null)}
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Xác nhận loại bản nộp</DialogTitle>
+            <DialogTitle>Loại bản thực tế trong file/giấy này</DialogTitle>
             <DialogDescription>
-              Tài liệu: <strong>{submissionFormatDialog?.docLabel}</strong>
-              <br />
-              {submissionFormatDialog?.requiredFormat && (
-                <span className="text-sm text-amber-600 mt-1 inline-block">
-                  Yêu cầu: {FORMAT_CONFIG[submissionFormatDialog.requiredFormat]?.label || submissionFormatDialog.requiredFormat}
-                </span>
-              )}
+              Đây là loại bản của <strong>{submissionFormatDialog?.docLabel}</strong> bạn vừa{" "}
+              {submissionFormatDialog?.action === "paper" ? "nhận tại quầy" : "tải lên"}
+              {" "}— không phải tài liệu bổ sung. Hãy chọn đúng loại bản đang có trong tay.
             </DialogDescription>
           </DialogHeader>
 
+          {submissionFormatDialog?.requiredFormat && (
+            <div className="rounded-md border bg-muted/40 px-3 py-2 text-sm">
+              <span className="text-muted-foreground">Yêu cầu hồ sơ: </span>
+              <span className="font-medium">
+                {getFormatLabel(submissionFormatDialog.requiredFormat)}
+              </span>
+            </div>
+          )}
+
           <RadioGroup value={selectedFormat} onValueChange={setSelectedFormat}>
-            <div className="flex items-center space-x-2 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
-              <RadioGroupItem value="original" id="original" />
-              <Label htmlFor="original" className="flex-1 cursor-pointer">
-                <div className="font-medium">Bản chính</div>
-                <div className="text-xs text-muted-foreground">
-                  Giấy tờ gốc do cơ quan có thẩm quyền cấp
-                </div>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
-              <RadioGroupItem value="certified_copy" id="certified_copy" />
-              <Label htmlFor="certified_copy" className="flex-1 cursor-pointer">
-                <div className="font-medium">Bản sao có chứng thực</div>
-                <div className="text-xs text-muted-foreground">
-                  Bản photocopy được công chứng/chứng thực
-                </div>
-              </Label>
-            </div>
-
-            <div className="flex items-center space-x-2 p-3 border rounded-lg hover:bg-muted/50 transition-colors">
-              <RadioGroupItem value="photo" id="photo" />
-              <Label htmlFor="photo" className="flex-1 cursor-pointer">
-                <div className="font-medium">Bản photocopy</div>
-                <div className="text-xs text-muted-foreground">
-                  Bản sao không công chứng
-                </div>
-              </Label>
-            </div>
+            {DOCUMENT_FORMAT_OPTIONS.map((option) => (
+              <div
+                key={option.value}
+                className="flex items-center space-x-2 p-3 border rounded-lg hover:bg-muted/50 transition-colors"
+              >
+                <RadioGroupItem value={option.value} id={option.value} />
+                <Label htmlFor={option.value} className="flex-1 cursor-pointer">
+                  <div className="font-medium">{option.label}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {option.description}
+                  </div>
+                </Label>
+              </div>
+            ))}
           </RadioGroup>
+
+          {/* Soft warning — selected actual format does not match the
+              required format. Allowed (officer may still proceed) but
+              flagged so officer notices any mismatch before saving. */}
+          {submissionFormatDialog?.requiredFormat &&
+            selectedFormat &&
+            selectedFormat !== submissionFormatDialog.requiredFormat && (
+              <div
+                className="flex items-start gap-2 rounded-md border border-warning-300 bg-warning-50 px-3 py-2 text-sm text-warning-800"
+                role="alert"
+              >
+                <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                <span>
+                  Loại bản thực tế (<strong>{getFormatLabel(selectedFormat)}</strong>){" "}
+                  khác với yêu cầu hồ sơ (
+                  <strong>{getFormatLabel(submissionFormatDialog.requiredFormat)}</strong>
+                  ). Hãy kiểm tra lại trước khi xác nhận.
+                </span>
+              </div>
+            )}
 
           <DialogFooter>
             <Button variant="outline" onClick={() => setSubmissionFormatDialog(null)}>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -192,6 +192,18 @@ const VI_DATE_FORMATTER = new Intl.DateTimeFormat("vi-VN", {
   year: "numeric",
 })
 
+// ADM-031 round 10 — full datetime (dd/mm/yyyy hh:mm) used by the verifier
+// tooltip on the Trạng thái cell so officers can see the exact verification
+// timestamp without hovering long enough for a relative-time tooltip.
+const VI_DATETIME_FORMATTER = new Intl.DateTimeFormat("vi-VN", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+})
+
 // ============================================================================
 // HELPERS
 // ============================================================================
@@ -285,6 +297,32 @@ function computeRowState(doc: DocumentItem) {
     ? getShortFormatLabel(doc.submission_format)
     : null
 
+  // ADM-031 round 10 — verifier identity for the "Đã duyệt" badge.
+  // verifiedDisplayName: full name from backend → fallback "User #<id>" →
+  // null when neither id nor timestamp is present (older legacy rows).
+  // verifiedAtShort feeds the secondary line under the badge; verifierTooltip
+  // is the long-form tooltip ("Duyệt bởi <Tên> lúc dd/mm/yyyy hh:mm").
+  const verifiedAtIso = doc.verified_at ?? null
+  const verifiedAtShort = verifiedAtIso
+    ? VI_DATE_FORMATTER.format(new Date(verifiedAtIso))
+    : null
+  const verifiedAtLong = verifiedAtIso
+    ? VI_DATETIME_FORMATTER.format(new Date(verifiedAtIso))
+    : null
+  const verifiedDisplayName =
+    doc.verified_by_name?.trim() ||
+    (doc.verified_by != null ? `User #${doc.verified_by}` : null)
+  let verifierTooltip: string | null = null
+  if (doc.status === "verified") {
+    if (verifiedDisplayName && verifiedAtLong) {
+      verifierTooltip = `Duyệt bởi ${verifiedDisplayName} lúc ${verifiedAtLong}`
+    } else if (verifiedDisplayName) {
+      verifierTooltip = `Duyệt bởi ${verifiedDisplayName}`
+    } else if (verifiedAtLong) {
+      verifierTooltip = `Đã duyệt lúc ${verifiedAtLong}`
+    }
+  }
+
   const hasFile =
     !!doc.file_path && (doc.status === "uploaded" || doc.status === "verified")
   const canUpload = doc.can_upload ?? false
@@ -316,6 +354,10 @@ function computeRowState(doc: DocumentItem) {
     canVerify,
     hasAnyAction,
     recordedAtFormatted,
+    // ADM-031 round 10
+    verifiedDisplayName,
+    verifiedAtShort,
+    verifierTooltip,
   }
 }
 
@@ -813,7 +855,11 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
   // ============================================================================
 
   return (
-    <>
+    // ADM-031 round 10 — wrap the whole tab in a single TooltipProvider so
+    // the Trạng thái-cell verifier tooltip and the action-icon tooltips
+    // (DocumentRowActions has its own provider for legacy reasons; nested
+    // is harmless) both have a context.
+    <TooltipProvider delayDuration={150}>
       {/* KPI strip — 4 tiles so officer reads the global state at a glance.
           Counts use tabular-nums so the digits stay aligned across columns. */}
       <div
@@ -1037,13 +1083,50 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                             )}
                           </td>
                           <td className="py-3 pr-3 align-top">
-                            <Badge className={`${state.statusConfig.color} gap-1`}>
-                              <StatusIcon
-                                className="h-3 w-3 shrink-0"
-                                aria-hidden="true"
-                              />
-                              {state.statusConfig.label}
-                            </Badge>
+                            {state.verifierTooltip ? (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Badge
+                                    className={`${state.statusConfig.color} gap-1 cursor-help`}
+                                  >
+                                    <StatusIcon
+                                      className="h-3 w-3 shrink-0"
+                                      aria-hidden="true"
+                                    />
+                                    {state.statusConfig.label}
+                                  </Badge>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  {state.verifierTooltip}
+                                </TooltipContent>
+                              </Tooltip>
+                            ) : (
+                              <Badge
+                                className={`${state.statusConfig.color} gap-1`}
+                              >
+                                <StatusIcon
+                                  className="h-3 w-3 shrink-0"
+                                  aria-hidden="true"
+                                />
+                                {state.statusConfig.label}
+                              </Badge>
+                            )}
+                            {doc.status === "verified" &&
+                              (state.verifiedDisplayName ||
+                                state.verifiedAtShort) && (
+                                <div className="mt-1 text-xs text-muted-foreground break-words">
+                                  {state.verifiedDisplayName}
+                                  {state.verifiedDisplayName &&
+                                  state.verifiedAtShort
+                                    ? " · "
+                                    : ""}
+                                  {state.verifiedAtShort && (
+                                    <span className="tabular-nums">
+                                      {state.verifiedAtShort}
+                                    </span>
+                                  )}
+                                </div>
+                              )}
                           </td>
                           <td className="py-3 pl-3 align-top">
                             <DocumentRowActions
@@ -1099,15 +1182,52 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                             </div>
                           )}
                         </div>
-                        <Badge
-                          className={`${state.statusConfig.color} gap-1 shrink-0`}
-                        >
-                          <StatusIcon
-                            className="h-3 w-3 shrink-0"
-                            aria-hidden="true"
-                          />
-                          {state.statusConfig.label}
-                        </Badge>
+                        <div className="flex flex-col items-end gap-0.5 shrink-0">
+                          {state.verifierTooltip ? (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Badge
+                                  className={`${state.statusConfig.color} gap-1 cursor-help`}
+                                >
+                                  <StatusIcon
+                                    className="h-3 w-3 shrink-0"
+                                    aria-hidden="true"
+                                  />
+                                  {state.statusConfig.label}
+                                </Badge>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                {state.verifierTooltip}
+                              </TooltipContent>
+                            </Tooltip>
+                          ) : (
+                            <Badge
+                              className={`${state.statusConfig.color} gap-1`}
+                            >
+                              <StatusIcon
+                                className="h-3 w-3 shrink-0"
+                                aria-hidden="true"
+                              />
+                              {state.statusConfig.label}
+                            </Badge>
+                          )}
+                          {doc.status === "verified" &&
+                            (state.verifiedDisplayName ||
+                              state.verifiedAtShort) && (
+                              <div className="text-xs text-muted-foreground text-right max-w-[10rem] break-words">
+                                {state.verifiedDisplayName}
+                                {state.verifiedDisplayName &&
+                                state.verifiedAtShort
+                                  ? " · "
+                                  : ""}
+                                {state.verifiedAtShort && (
+                                  <span className="tabular-nums">
+                                    {state.verifiedAtShort}
+                                  </span>
+                                )}
+                              </div>
+                            )}
+                        </div>
                       </div>
 
                       <dl className="grid grid-cols-[6.5rem_1fr] gap-x-3 gap-y-1.5 mt-3 text-sm">
@@ -1385,6 +1505,6 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </>
+    </TooltipProvider>
   )
 }

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -105,11 +105,14 @@ interface DocumentsTabProps {
 // CONSTANTS
 // ============================================================================
 
-// ADM-031 round 6 — Trạng thái cell carries workflow state only:
-// "Cần làm" -> officer/applicant must act, "Chờ duyệt" -> waiting for
-// manager review, "Đã duyệt" -> verified, "Từ chối" -> rejected. The
-// "Đã ghi nhận" cell separately reports what was physically received
-// ("Chưa" / "File" / "Giấy") so the two cells don't echo each other.
+// ADM-031 round 9 — Trạng thái cell carries workflow state only.
+// Backend strict mode (admission_service.py:566) treats `paper_submitted`
+// as already satisfying the mandatory-doc gate alongside `verified`, so
+// the badge for that state is "Đã nhận giấy" (officer received the
+// paper, no extra verify step needed) — NOT "Chờ duyệt", which would
+// imply the row is still pending the manager. "Đã ghi nhận" cell
+// separately reports physical reception ("Chưa" / "File scan" /
+// "Bản giấy") so the two cells don't echo each other.
 const STATUS_CONFIG: Record<
   string,
   { label: string; color: string; icon: typeof AlertCircle }
@@ -125,8 +128,12 @@ const STATUS_CONFIG: Record<
     icon: Upload,
   },
   paper_submitted: {
-    label: "Chờ duyệt",
-    color: "bg-info-100 text-info-700",
+    // Round 9: backend already treats paper_submitted as "đủ yêu cầu",
+    // so the badge reads "Đã nhận giấy" (success-tinted) instead of
+    // "Chờ duyệt" — keeping the row consistent with the
+    // "Hoàn tất yêu cầu" KPI count.
+    label: "Đã nhận giấy",
+    color: "bg-success-50 text-success-700",
     icon: FileText,
   },
   verified: {
@@ -826,10 +833,14 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
           }
         />
         <KpiTile
-          label="Chờ kiểm tra"
+          // Round 9: rename to "File chờ duyệt" so the tile matches the
+          // helper (`isDocumentPendingVerification`) which only counts
+          // `uploaded`. paper_submitted rows are NOT pending — backend
+          // already accepts them as satisfied.
+          label="File chờ duyệt"
           value={pendingCount}
           accent={pendingCount > 0 ? "warning" : "default"}
-          hint={pendingCount > 0 ? "File chưa duyệt" : "Không có"}
+          hint={pendingCount > 0 ? "Cần manager duyệt format" : "Không có"}
         />
         <KpiTile
           label="Hoàn tất yêu cầu"

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -68,7 +68,7 @@ const STATUS_CONFIG: Record<string, {
     icon: AlertCircle,
   },
   uploaded: {
-    label: "Đã ghi nhận (online)",
+    label: "Đã ghi nhận file",
     color: "bg-info-100 text-info-700",
     icon: Upload,
   },

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -934,16 +934,16 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                             )}
                           </td>
 
-                          {/* ----- Yêu cầu ----- round 8: 2 lines
+                          {/* ----- Yêu cầu ----- round 8: 2 lines stacked
                               line 1 = format (Gốc / Chứng thực / Chụp/scan)
                               line 2 = how-to (Tải file / Nhận giấy)
-                              Stacked alignment lets officers compare
-                              vertically with the matching 2 lines in the
-                              "Đã ghi nhận" cell. */}
+                              Use `flex` (not inline-flex) on each line so
+                              each div takes its own row, matching the
+                              2 stacked lines in "Đã ghi nhận". */}
                           <td className="py-3 pr-3 align-top">
                             {state.requiredFormatShort && state.formatBadge ? (
                               <div
-                                className="text-sm inline-flex items-center gap-1"
+                                className="text-sm flex items-center gap-1"
                                 title={state.formatBadge.label}
                               >
                                 {FormatIcon && (
@@ -962,7 +962,7 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                               </div>
                             )}
                             <div
-                              className="text-xs text-muted-foreground inline-flex items-center gap-1 mt-1"
+                              className="text-xs text-muted-foreground flex items-center gap-1 mt-1"
                               title={state.howToReceiveTitle}
                               aria-label={state.howToReceiveTitle}
                             >
@@ -984,43 +984,46 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                               so a row reads as a 2x2 mini grid. */}
                           <td className="py-3 pr-3 align-top">
                             {state.recordedFormatLabel ? (
-                              <div
-                                className={`text-sm inline-flex items-center gap-1 break-words ${
-                                  state.recordedDiffersFromRequired
-                                    ? "text-warning-700"
-                                    : ""
-                                }`}
-                                title={
-                                  state.recordedDiffersFromRequired
-                                    ? `Đã ghi nhận: ${state.recordedFormatLabel} — KHÁC yêu cầu hồ sơ (${state.formatBadge?.label ?? doc.submission_format})`
-                                    : `Đã ghi nhận: ${state.recordedFormatLabel}`
-                                }
-                              >
-                                {state.recordedDiffersFromRequired && (
-                                  <AlertTriangle
-                                    className="h-3 w-3 shrink-0"
-                                    aria-label="Khác yêu cầu hồ sơ"
-                                  />
-                                )}
-                                <span>
-                                  {state.recordedFormatCode
-                                    ? getShortFormatLabel(state.recordedFormatCode)
-                                    : state.recordedFormatLabel}
-                                </span>
-                                {state.recordedAtFormatted && (
-                                  <span className="text-muted-foreground tabular-nums">
-                                    · {state.recordedAtFormatted}
+                              <>
+                                <div
+                                  className={`text-sm flex items-center gap-1 break-words ${
+                                    state.recordedDiffersFromRequired
+                                      ? "text-warning-700"
+                                      : ""
+                                  }`}
+                                  title={
+                                    state.recordedDiffersFromRequired
+                                      ? `Đã ghi nhận: ${state.recordedFormatLabel} — KHÁC yêu cầu hồ sơ (${state.formatBadge?.label ?? doc.submission_format})`
+                                      : `Đã ghi nhận: ${state.recordedFormatLabel}`
+                                  }
+                                >
+                                  {state.recordedDiffersFromRequired && (
+                                    <AlertTriangle
+                                      className="h-3 w-3 shrink-0"
+                                      aria-label="Khác yêu cầu hồ sơ"
+                                    />
+                                  )}
+                                  <span>
+                                    {state.recordedFormatCode
+                                      ? getShortFormatLabel(state.recordedFormatCode)
+                                      : state.recordedFormatLabel}
                                   </span>
-                                )}
-                              </div>
+                                  {state.recordedAtFormatted && (
+                                    <span className="text-muted-foreground tabular-nums">
+                                      · {state.recordedAtFormatted}
+                                    </span>
+                                  )}
+                                </div>
+                                <div className="text-xs text-muted-foreground mt-1">
+                                  {state.receptionLabel}
+                                </div>
+                              </>
                             ) : (
-                              <div className="text-sm text-muted-foreground">
-                                —
-                              </div>
+                              // Nothing recorded yet — show only the reception
+                              // bucket ("Chưa"). No leading em-dash so the cell
+                              // doesn't read as "— Chưa".
+                              <div className="text-sm">{state.receptionLabel}</div>
                             )}
-                            <div className="text-xs text-muted-foreground mt-1">
-                              {state.receptionLabel}
-                            </div>
                           </td>
                           <td className="py-3 pr-3 align-top">
                             <Badge className={`${state.statusConfig.color} gap-1`}>
@@ -1103,7 +1106,7 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                         <dd className="break-words">
                           {state.requiredFormatShort && state.formatBadge ? (
                             <div
-                              className="inline-flex items-center gap-1"
+                              className="flex items-center gap-1"
                               title={state.formatBadge.label}
                             >
                               <span aria-label={state.formatBadge.label}>
@@ -1114,7 +1117,7 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                             <span className="text-muted-foreground">—</span>
                           )}
                           <div
-                            className="text-xs text-muted-foreground inline-flex items-center gap-1 mt-0.5"
+                            className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5"
                             title={state.howToReceiveTitle}
                             aria-label={state.howToReceiveTitle}
                           >
@@ -1131,41 +1134,45 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                         </dt>
                         <dd className="break-words">
                           {state.recordedFormatLabel ? (
-                            <div
-                              className={`inline-flex items-center gap-1 ${
-                                state.recordedDiffersFromRequired
-                                  ? "text-warning-700"
-                                  : ""
-                              }`}
-                              title={
-                                state.recordedDiffersFromRequired
-                                  ? `Đã ghi nhận: ${state.recordedFormatLabel} — KHÁC yêu cầu hồ sơ`
-                                  : `Đã ghi nhận: ${state.recordedFormatLabel}`
-                              }
-                            >
-                              {state.recordedDiffersFromRequired && (
-                                <AlertTriangle
-                                  className="h-3 w-3 shrink-0"
-                                  aria-label="Khác yêu cầu hồ sơ"
-                                />
-                              )}
-                              <span>
-                                {state.recordedFormatCode
-                                  ? getShortFormatLabel(state.recordedFormatCode)
-                                  : state.recordedFormatLabel}
-                              </span>
-                              {state.recordedAtFormatted && (
-                                <span className="text-muted-foreground tabular-nums">
-                                  · {state.recordedAtFormatted}
+                            <>
+                              <div
+                                className={`flex items-center gap-1 ${
+                                  state.recordedDiffersFromRequired
+                                    ? "text-warning-700"
+                                    : ""
+                                }`}
+                                title={
+                                  state.recordedDiffersFromRequired
+                                    ? `Đã ghi nhận: ${state.recordedFormatLabel} — KHÁC yêu cầu hồ sơ`
+                                    : `Đã ghi nhận: ${state.recordedFormatLabel}`
+                                }
+                              >
+                                {state.recordedDiffersFromRequired && (
+                                  <AlertTriangle
+                                    className="h-3 w-3 shrink-0"
+                                    aria-label="Khác yêu cầu hồ sơ"
+                                  />
+                                )}
+                                <span>
+                                  {state.recordedFormatCode
+                                    ? getShortFormatLabel(state.recordedFormatCode)
+                                    : state.recordedFormatLabel}
                                 </span>
-                              )}
-                            </div>
+                                {state.recordedAtFormatted && (
+                                  <span className="text-muted-foreground tabular-nums">
+                                    · {state.recordedAtFormatted}
+                                  </span>
+                                )}
+                              </div>
+                              <div className="text-xs text-muted-foreground mt-0.5">
+                                {state.receptionLabel}
+                              </div>
+                            </>
                           ) : (
-                            <span className="text-muted-foreground">—</span>
+                            // Nothing recorded yet — single "Chưa" line, no
+                            // em-dash placeholder above it.
+                            <div>{state.receptionLabel}</div>
                           )}
-                          <div className="text-xs text-muted-foreground mt-0.5">
-                            {state.receptionLabel}
-                          </div>
                         </dd>
                       </dl>
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -51,6 +51,12 @@ import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import {
   AlertCircle,
   AlertTriangle,
   Ban,
@@ -138,15 +144,16 @@ const STATUS_CONFIG: Record<
 // Reception bucket — compact "what-was-received" label that mirrors the
 // backend mandatory-completion gate. Showing this in the "Đã ghi nhận"
 // table cell avoids having to read the full status badge for the common
-// case ("File đã upload" / "Bản giấy đã nhận" / "Chưa nhận gì").
+// case. Round 8: longer phrasing ("File scan" / "Bản giấy") so the
+// reception verb is unambiguous on its own line.
 const RECEPTION_LABEL: Record<string, string> = {
   missing: "Chưa",
   rejected: "Chưa",
-  resubmitted: "File",
-  revision_requested: "File",
-  uploaded: "File",
-  verified: "File",
-  paper_submitted: "Giấy",
+  resubmitted: "File scan",
+  revision_requested: "File scan",
+  uploaded: "File scan",
+  verified: "File scan",
+  paper_submitted: "Bản giấy",
 }
 
 // Work-queue priority. Officers act on rows in this order: things they
@@ -366,6 +373,46 @@ interface ActionsCellProps {
   alignEnd?: boolean
 }
 
+/**
+ * Icon-only button with a Radix Tooltip popup on hover/focus. Uses
+ * `aria-label` for the accessible name; the tooltip content is meant
+ * to convey extra description ("Đặt lại về Chưa nộp" verbose form vs
+ * the short "Đặt lại" name) without duplicating the SR announcement.
+ */
+function IconActionButton({
+  ariaLabel,
+  tooltip,
+  onClick,
+  disabled,
+  children,
+  className,
+}: {
+  ariaLabel: string
+  tooltip: string
+  onClick: () => void
+  disabled?: boolean
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          size="sm"
+          variant="ghost"
+          className={`h-8 w-8 p-0 ${className ?? ""}`}
+          onClick={onClick}
+          disabled={disabled}
+          aria-label={ariaLabel}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top">{tooltip}</TooltipContent>
+    </Tooltip>
+  )
+}
+
 function DocumentRowActions(props: ActionsCellProps) {
   const {
     doc,
@@ -396,118 +443,141 @@ function DocumentRowActions(props: ActionsCellProps) {
     return <span className="text-xs text-muted-foreground">—</span>
   }
 
+  // ADM-031 round 8: 3 visual groups separated by thin dividers so the
+  // officer scans intent quickly:
+  //   - common: View
+  //   - officer (intake): Upload, Mark paper-submitted
+  //   - manager (review): Verify, Reject, Reset
+  // Each button is icon-only with Radix Tooltip on hover + aria-label
+  // for screen readers; no `title` attribute so SR doesn't double-read.
+  const hasCommon = state.hasFile
+  const hasOfficerGroup = state.canUpload || state.canMarkPaperSubmitted
+  const hasManagerGroup = state.canVerify || state.canReject || state.canReset
+
   return (
-    <div
-      className={`flex flex-wrap items-center gap-1.5 ${alignEnd ? "justify-end" : ""}`}
-    >
-      {/* WIG: drop duplicate `title` when aria-label conveys the same text;
-          keep aria-label only on icon-only buttons so screen readers don't
-          announce the same string twice. */}
-      {state.hasFile && (
-        <Button
-          size="sm"
-          variant="ghost"
-          onClick={() => doc.file_path && onView(doc.file_path)}
-          aria-label="Xem tài liệu"
-        >
-          <Eye className="h-4 w-4" />
-        </Button>
-      )}
+    <TooltipProvider delayDuration={150}>
+      <div
+        className={`flex flex-wrap items-center gap-0.5 ${alignEnd ? "justify-end" : ""}`}
+      >
+        {/* Common */}
+        {state.hasFile && (
+          <IconActionButton
+            ariaLabel="Xem tài liệu"
+            tooltip="Xem file đã tải lên"
+            onClick={() => doc.file_path && onView(doc.file_path)}
+          >
+            <Eye className="h-4 w-4" />
+          </IconActionButton>
+        )}
 
-      {state.canUpload && (
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() =>
-            onUpload(doc.code, doc.label, doc.submission_format ?? undefined)
-          }
-          disabled={isUploading}
-        >
-          {isUploading ? (
-            <Loader2 className="h-4 w-4 mr-1 animate-spin motion-reduce:animate-none" />
-          ) : (
-            <Upload className="h-4 w-4 mr-1" />
+        {hasCommon && (hasOfficerGroup || hasManagerGroup) && (
+          <span
+            aria-hidden="true"
+            className="mx-1 inline-block h-4 w-px bg-border"
+          />
+        )}
+
+        {/* Officer / intake group */}
+        {state.canUpload && (
+          <IconActionButton
+            ariaLabel="Tải file"
+            tooltip="Tải file ảnh/scan/PDF lên hệ thống"
+            disabled={isUploading}
+            onClick={() =>
+              onUpload(doc.code, doc.label, doc.submission_format ?? undefined)
+            }
+          >
+            {isUploading ? (
+              <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
+            ) : (
+              <Upload className="h-4 w-4" />
+            )}
+          </IconActionButton>
+        )}
+
+        {state.canMarkPaperSubmitted && (
+          <IconActionButton
+            ariaLabel="Đánh dấu đã nhận giấy"
+            tooltip="Đánh dấu đã nhận bản giấy tại quầy"
+            disabled={isPaperPending}
+            onClick={() =>
+              onPaperSubmit(
+                doc.code,
+                doc.label,
+                doc.submission_format ?? undefined,
+              )
+            }
+          >
+            {isPaperPending ? (
+              <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
+            ) : (
+              <Building2 className="h-4 w-4" />
+            )}
+          </IconActionButton>
+        )}
+
+        {state.isPaperOnly &&
+          doc.status === "paper_submitted" &&
+          !state.canReject &&
+          !state.canReset &&
+          !state.canVerify && (
+            <span className="inline-flex items-center text-success-600 text-xs">
+              <Check className="h-4 w-4" aria-hidden="true" />
+            </span>
           )}
-          Tải file
-        </Button>
-      )}
 
-      {state.canMarkPaperSubmitted && (
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() =>
-            onPaperSubmit(doc.code, doc.label, doc.submission_format ?? undefined)
-          }
-          disabled={isPaperPending}
-          aria-label="Đánh dấu đã nhận giấy"
-        >
-          {isPaperPending ? (
-            <Loader2 className="h-4 w-4 mr-1 animate-spin motion-reduce:animate-none" />
-          ) : (
-            <Building2 className="h-4 w-4 mr-1" />
-          )}
-          Đã nhận giấy
-        </Button>
-      )}
+        {hasOfficerGroup && hasManagerGroup && (
+          <span
+            aria-hidden="true"
+            className="mx-1 inline-block h-4 w-px bg-border"
+          />
+        )}
 
-      {state.isPaperOnly && doc.status === "paper_submitted" && !state.canReject && !state.canReset && !state.canVerify && (
-        <span className="inline-flex items-center text-success-600 text-xs">
-          <Check className="h-4 w-4" aria-hidden="true" />
-        </span>
-      )}
+        {/* Manager / review group */}
+        {state.canVerify && (
+          <IconActionButton
+            ariaLabel="Duyệt tài liệu"
+            tooltip="Duyệt — xác nhận tài liệu hợp lệ"
+            className="text-success-700 hover:text-success-800 hover:bg-success-50"
+            disabled={isVerifyPending && isCurrentVerifyTarget}
+            onClick={() => onVerifyClick(doc.code, verifyFormat)}
+          >
+            {isVerifyPending && isCurrentVerifyTarget ? (
+              <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
+            ) : (
+              <Check className="h-4 w-4" />
+            )}
+          </IconActionButton>
+        )}
 
-      {/* Verify — manager/admin one-click approve. Lives in the
-          DocumentsTab so officers/managers can clear the verify queue
-          without bouncing into the executive checklist. */}
-      {state.canVerify && (
-        <Button
-          size="sm"
-          variant="outline"
-          className="text-success-700 hover:text-success-800 hover:bg-success-50 border-success-300"
-          onClick={() => onVerifyClick(doc.code, verifyFormat)}
-          disabled={isVerifyPending && isCurrentVerifyTarget}
-          aria-label="Duyệt tài liệu"
-        >
-          {isVerifyPending && isCurrentVerifyTarget ? (
-            <Loader2 className="h-4 w-4 mr-1 animate-spin motion-reduce:animate-none" />
-          ) : (
-            <Check className="h-4 w-4 mr-1" />
-          )}
-          Duyệt
-        </Button>
-      )}
+        {state.canReject && (
+          <IconActionButton
+            ariaLabel="Từ chối tài liệu"
+            tooltip="Từ chối — yêu cầu nộp lại"
+            className="text-error-600 hover:text-error-700 hover:bg-error-50"
+            onClick={() => onRejectClick(doc.code, doc.label)}
+          >
+            <Ban className="h-4 w-4" />
+          </IconActionButton>
+        )}
 
-      {state.canReject && (
-        <Button
-          size="sm"
-          variant="outline"
-          className="text-error-600 hover:text-error-700 hover:bg-error-50 border-error-300"
-          onClick={() => onRejectClick(doc.code, doc.label)}
-          aria-label="Từ chối tài liệu"
-        >
-          <Ban className="h-4 w-4 mr-1" />
-          Từ chối
-        </Button>
-      )}
-
-      {state.canReset && (
-        <Button
-          size="sm"
-          variant="ghost"
-          className="text-warning-600 hover:text-warning-700 hover:bg-warning-50"
-          onClick={() => onResetClick(doc.code, doc.label)}
-          disabled={isResetPending && isCurrentResetTarget}
-          aria-label="Đặt lại tài liệu về Chưa nộp"
-        >
-          {isResetPending && isCurrentResetTarget ? (
-            <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
-          ) : (
-            <RotateCcw className="h-4 w-4" />
-          )}
-        </Button>
-      )}
-    </div>
+        {state.canReset && (
+          <IconActionButton
+            ariaLabel="Đặt lại tài liệu về Chưa nộp"
+            tooltip="Đặt lại — đưa về trạng thái Chưa nộp"
+            className="text-warning-600 hover:text-warning-700 hover:bg-warning-50"
+            disabled={isResetPending && isCurrentResetTarget}
+            onClick={() => onResetClick(doc.code, doc.label)}
+          >
+            {isResetPending && isCurrentResetTarget ? (
+              <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
+            ) : (
+              <RotateCcw className="h-4 w-4" />
+            )}
+          </IconActionButton>
+        )}
+      </div>
+    </TooltipProvider>
   )
 }
 
@@ -840,23 +910,22 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                           key={doc.code || i}
                           className="hover:bg-muted/30 motion-reduce:transition-none"
                         >
+                          {/* ----- Tên giấy tờ ----- round 8:
+                              line 1 = name
+                              line 2 = Bắt buộc / Tùy chọn
+                              Mã (doc.code) moves to a hover title on the
+                              name so officers don't see the technical
+                              token in the main UI but can still inspect
+                              it for support / debug. */}
                           <td className="py-3 pr-3 align-top min-w-0">
-                            <div className="font-medium text-pretty break-words">
-                              {doc.label}
-                              {doc.is_mandatory && (
-                                <span
-                                  className="text-error-500 ml-0.5"
-                                  aria-label="Bắt buộc"
-                                >
-                                  *
-                                </span>
-                              )}
-                            </div>
                             <div
-                              className="text-xs text-muted-foreground"
-                              translate="no"
+                              className="font-medium text-pretty break-words"
+                              title={`Mã: ${doc.code}`}
                             >
-                              Mã: {doc.code}
+                              {doc.label}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {doc.is_mandatory ? "Bắt buộc" : "Tùy chọn"}
                             </div>
                             {doc.status === "rejected" && doc.rejection_reason && (
                               <div className="text-xs text-error-700 mt-1 break-words">
@@ -864,21 +933,22 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                               </div>
                             )}
                           </td>
+
+                          {/* ----- Yêu cầu ----- round 8: 2 lines
+                              line 1 = format (Gốc / Chứng thực / Chụp/scan)
+                              line 2 = how-to (Tải file / Nhận giấy)
+                              Stacked alignment lets officers compare
+                              vertically with the matching 2 lines in the
+                              "Đã ghi nhận" cell. */}
                           <td className="py-3 pr-3 align-top">
-                            {/* ADM-031 round 7: 3-line "Yêu cầu" cell — bắt buộc /
-                                loại bản / cách xử lý — replaces the separate
-                                "Cách ghi nhận" column. */}
-                            <div className="text-sm">
-                              {doc.is_mandatory ? "Bắt buộc" : "Tùy chọn"}
-                            </div>
-                            {state.requiredFormatShort && state.formatBadge && (
+                            {state.requiredFormatShort && state.formatBadge ? (
                               <div
-                                className="text-xs text-muted-foreground inline-flex items-center gap-1 mt-0.5"
+                                className="text-sm inline-flex items-center gap-1"
                                 title={state.formatBadge.label}
                               >
                                 {FormatIcon && (
                                   <FormatIcon
-                                    className="h-3 w-3 shrink-0"
+                                    className="h-3 w-3 shrink-0 text-muted-foreground"
                                     aria-hidden="true"
                                   />
                                 )}
@@ -886,9 +956,13 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                                   {state.requiredFormatShort}
                                 </span>
                               </div>
+                            ) : (
+                              <div className="text-sm text-muted-foreground">
+                                —
+                              </div>
                             )}
                             <div
-                              className="text-xs text-muted-foreground inline-flex items-center gap-1 mt-0.5"
+                              className="text-xs text-muted-foreground inline-flex items-center gap-1 mt-1"
                               title={state.howToReceiveTitle}
                               aria-label={state.howToReceiveTitle}
                             >
@@ -899,23 +973,22 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                               <span>{state.howToReceiveLabel}</span>
                             </div>
                           </td>
+
+                          {/* ----- Đã ghi nhận ----- round 8: 2 lines
+                              line 1 = actual format short + recorded date
+                                       (e.g. "Chứng thực · 29/04/2026")
+                                       — empty for missing/rejected.
+                              line 2 = reception bucket
+                                       ("File scan" / "Bản giấy" / "Chưa")
+                              Alignment matches the 2 lines in "Yêu cầu"
+                              so a row reads as a 2x2 mini grid. */}
                           <td className="py-3 pr-3 align-top">
-                            <Badge
-                              variant={
-                                state.receptionLabel === "Chưa"
-                                  ? "outline"
-                                  : "secondary"
-                              }
-                              className="text-xs"
-                            >
-                              {state.receptionLabel}
-                            </Badge>
-                            {state.recordedFormatLabel && (
+                            {state.recordedFormatLabel ? (
                               <div
-                                className={`text-xs mt-1 inline-flex items-center gap-1 break-words ${
+                                className={`text-sm inline-flex items-center gap-1 break-words ${
                                   state.recordedDiffersFromRequired
                                     ? "text-warning-700"
-                                    : "text-muted-foreground"
+                                    : ""
                                 }`}
                                 title={
                                   state.recordedDiffersFromRequired
@@ -934,13 +1007,20 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                                     ? getShortFormatLabel(state.recordedFormatCode)
                                     : state.recordedFormatLabel}
                                 </span>
+                                {state.recordedAtFormatted && (
+                                  <span className="text-muted-foreground tabular-nums">
+                                    · {state.recordedAtFormatted}
+                                  </span>
+                                )}
+                              </div>
+                            ) : (
+                              <div className="text-sm text-muted-foreground">
+                                —
                               </div>
                             )}
-                            {state.recordedAtFormatted && (
-                              <div className="text-xs text-muted-foreground tabular-nums mt-1">
-                                {state.recordedAtFormatted}
-                              </div>
-                            )}
+                            <div className="text-xs text-muted-foreground mt-1">
+                              {state.receptionLabel}
+                            </div>
                           </td>
                           <td className="py-3 pr-3 align-top">
                             <Badge className={`${state.statusConfig.color} gap-1`}>
@@ -989,26 +1069,15 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                       className="rounded-lg border p-3 motion-reduce:transition-none"
                     >
                       <div className="flex items-start gap-2">
-                        <span className="text-xs text-muted-foreground tabular-nums shrink-0">
-                          #{i + 1}
-                        </span>
                         <div className="flex-1 min-w-0">
-                          <div className="font-medium text-pretty break-words">
-                            {doc.label}
-                            {doc.is_mandatory && (
-                              <span
-                                className="text-error-500 ml-0.5"
-                                aria-label="Bắt buộc"
-                              >
-                                *
-                              </span>
-                            )}
-                          </div>
                           <div
-                            className="text-xs text-muted-foreground"
-                            translate="no"
+                            className="font-medium text-pretty break-words"
+                            title={`Mã: ${doc.code}`}
                           >
-                            Mã: {doc.code}
+                            {doc.label}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {doc.is_mandatory ? "Bắt buộc" : "Tùy chọn"}
                           </div>
                           {doc.status === "rejected" && doc.rejection_reason && (
                             <div className="text-xs text-error-700 mt-1 break-words">
@@ -1027,25 +1096,23 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                         </Badge>
                       </div>
 
-                      <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-1.5 mt-3 text-sm">
-                        <dt className="text-xs text-muted-foreground self-center">
+                      <dl className="grid grid-cols-[6.5rem_1fr] gap-x-3 gap-y-1.5 mt-3 text-sm">
+                        <dt className="text-xs text-muted-foreground self-start mt-1">
                           Yêu cầu
                         </dt>
                         <dd className="break-words">
-                          <div>
-                            {doc.is_mandatory ? "Bắt buộc" : "Tùy chọn"}
-                            {state.formatBadge && (
-                              <span
-                                className="text-xs text-muted-foreground"
-                                title={state.formatBadge.label}
-                              >
-                                {" · "}
-                                {state.formatBadge.label}
+                          {state.requiredFormatShort && state.formatBadge ? (
+                            <div
+                              className="inline-flex items-center gap-1"
+                              title={state.formatBadge.label}
+                            >
+                              <span aria-label={state.formatBadge.label}>
+                                {state.requiredFormatShort}
                               </span>
-                            )}
-                          </div>
-                          {/* Cách xử lý line — replaces the dropped
-                              "Cách ghi nhận" row from round 7. */}
+                            </div>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
                           <div
                             className="text-xs text-muted-foreground inline-flex items-center gap-1 mt-0.5"
                             title={state.howToReceiveTitle}
@@ -1059,19 +1126,16 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                           </div>
                         </dd>
 
-                        <dt className="text-xs text-muted-foreground self-center">
+                        <dt className="text-xs text-muted-foreground self-start mt-1">
                           Đã ghi nhận
                         </dt>
                         <dd className="break-words">
-                          <span className="font-medium">
-                            {state.receptionLabel}
-                          </span>
-                          {state.recordedFormatLabel && (
-                            <span
-                              className={`text-xs ml-2 ${
+                          {state.recordedFormatLabel ? (
+                            <div
+                              className={`inline-flex items-center gap-1 ${
                                 state.recordedDiffersFromRequired
                                   ? "text-warning-700"
-                                  : "text-muted-foreground"
+                                  : ""
                               }`}
                               title={
                                 state.recordedDiffersFromRequired
@@ -1079,15 +1143,29 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                                   : `Đã ghi nhận: ${state.recordedFormatLabel}`
                               }
                             >
-                              {state.recordedDiffersFromRequired ? "⚠ " : ""}
-                              {state.recordedFormatLabel}
-                            </span>
-                          )}
-                          {state.recordedAtFormatted && (
-                            <div className="text-xs text-muted-foreground tabular-nums mt-0.5">
-                              {state.recordedAtFormatted}
+                              {state.recordedDiffersFromRequired && (
+                                <AlertTriangle
+                                  className="h-3 w-3 shrink-0"
+                                  aria-label="Khác yêu cầu hồ sơ"
+                                />
+                              )}
+                              <span>
+                                {state.recordedFormatCode
+                                  ? getShortFormatLabel(state.recordedFormatCode)
+                                  : state.recordedFormatLabel}
+                              </span>
+                              {state.recordedAtFormatted && (
+                                <span className="text-muted-foreground tabular-nums">
+                                  · {state.recordedAtFormatted}
+                                </span>
+                              )}
                             </div>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
                           )}
+                          <div className="text-xs text-muted-foreground mt-0.5">
+                            {state.receptionLabel}
+                          </div>
                         </dd>
                       </dl>
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -416,6 +416,31 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                   : "Chỉ ghi nhận đã nhận bản giấy, không cần upload file"
                 const ModeIcon = requiresUpload ? Globe : Building2
 
+                // ADM-031 round 4: surface the actually-recorded format so
+                // officers can verify what they (or a teammate) declared at
+                // upload/paper-receipt time. Priority mirrors the executive
+                // summary view: verified > actual > none. The required
+                // format stays in the "Yêu cầu bản nộp" badge regardless,
+                // so a mismatch between required and actual is visually
+                // diff-able at a glance.
+                const recordedFormatCode =
+                  doc.status === "verified" && doc.verified_format
+                    ? doc.verified_format
+                    : doc.actual_submission_format ?? null
+                const recordedFormatLabel = recordedFormatCode
+                  ? getFormatLabel(recordedFormatCode)
+                  : null
+                const recordedLabelHeader =
+                  doc.status === "verified" ? "Đã kiểm tra (loại bản)" : "Đã ghi nhận (loại bản)"
+                const recordedFormatColor =
+                  doc.status === "verified"
+                    ? "border-success-300 bg-success-50 text-success-800"
+                    : "border-info-300 bg-info-50 text-info-800"
+                const recordedDiffersFromRequired =
+                  recordedFormatCode &&
+                  doc.submission_format &&
+                  recordedFormatCode !== doc.submission_format
+
                 return (
                   <div
                     key={doc.code || index}
@@ -458,7 +483,7 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                         badge cluster on desktop. The labels are
                         ``md:hidden`` so they vanish on desktop without
                         wrapping the badges in extra DOM. */}
-                    <div className="grid grid-cols-[8rem_1fr] gap-x-3 gap-y-1.5 text-sm md:flex md:flex-wrap md:items-center md:gap-2 md:max-w-[20rem] md:justify-end">
+                    <div className="grid grid-cols-[8rem_1fr] gap-x-3 gap-y-1.5 text-sm md:flex md:flex-wrap md:items-center md:gap-2 md:max-w-[22rem] md:justify-end">
                       {formatBadge && (
                         <>
                           <span className="text-xs text-muted-foreground self-center md:hidden">
@@ -467,10 +492,41 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                           <Badge
                             variant="outline"
                             className="text-xs gap-1 max-w-full justify-start md:justify-center"
-                            title={formatBadge.label}
+                            title={`Yêu cầu hồ sơ: ${formatBadge.label}`}
                           >
                             <FormatIcon className="h-3 w-3 shrink-0" />
                             <span className="truncate">{formatBadge.label}</span>
+                          </Badge>
+                        </>
+                      )}
+                      {/* ADM-031 round 4: show the actual / verified format so
+                          officers don't have to re-open the document to recall
+                          what they declared. Border colour signals the source
+                          (verified vs officer-declared) without an extra
+                          legend; mismatch with the required format is also
+                          flagged via title tooltip. */}
+                      {recordedFormatLabel && (
+                        <>
+                          <span className="text-xs text-muted-foreground self-center md:hidden">
+                            {recordedLabelHeader}
+                          </span>
+                          <Badge
+                            variant="outline"
+                            className={`text-xs gap-1 max-w-full justify-start md:justify-center ${recordedFormatColor}`}
+                            title={
+                              recordedDiffersFromRequired
+                                ? `${recordedLabelHeader}: ${recordedFormatLabel} — KHÁC yêu cầu hồ sơ (${formatBadge?.label ?? doc.submission_format})`
+                                : `${recordedLabelHeader}: ${recordedFormatLabel}`
+                            }
+                          >
+                            <FormatIcon className="h-3 w-3 shrink-0" />
+                            <span className="truncate">{recordedFormatLabel}</span>
+                            {recordedDiffersFromRequired && (
+                              <AlertTriangle
+                                className="h-3 w-3 shrink-0 text-warning-700"
+                                aria-label="Khác yêu cầu hồ sơ"
+                              />
+                            )}
                           </Badge>
                         </>
                       )}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -40,8 +40,9 @@ import { isSafeFilePath } from "@/lib/utils"
 import {
   DOCUMENT_FORMAT_OPTIONS,
   getFormatLabel,
-  isDocumentVerified,
   isDocumentRecorded,
+  isDocumentRequirementSatisfied,
+  isDocumentPendingVerification,
 } from "@/lib/utils/admission-helpers"
 
 interface DocumentsTabProps {
@@ -274,13 +275,24 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
     window.open(url, "_blank", "noopener,noreferrer")
   }
   
-  // Stats — distinguish "ghi nhận" (received in any form) from "kiểm tra"
-  // (officer-verified). Progress bar reflects fully-verified rows so
-  // received-but-unverified docs don't masquerade as complete.
+  // Stats — split into three buckets so the surface matches the backend
+  // mandatory-doc gate (admission_service.py:566) without losing officer
+  // workflow visibility:
+  //   recordedCount   -> received in any form (uploaded | paper_submitted | verified)
+  //   satisfiedCount  -> backend would treat as completing the requirement
+  //                       (verified | paper_submitted). This is the
+  //                       "Hoàn tất yêu cầu" metric for the progress bar.
+  //   pendingCount    -> uploaded but not yet officer-verified ("Chờ kiểm tra")
+  // Without the satisfied/pending split, a paper-only mandatory row sitting
+  // at paper_submitted would render as incomplete in the UI even though
+  // the backend already accepts it as satisfied. ADM-031.6 follow-up.
   const recordedCount = documents.filter((d) => isDocumentRecorded(d.status)).length
-  const verifiedCount = documents.filter((d) => isDocumentVerified(d.status)).length
+  const satisfiedCount = documents.filter((d) => isDocumentRequirementSatisfied(d.status)).length
+  const pendingCount = documents.filter((d) => isDocumentPendingVerification(d.status)).length
   const mandatoryDocs = documents.filter((d) => d.is_mandatory)
-  const mandatoryVerifiedCount = mandatoryDocs.filter((d) => isDocumentVerified(d.status)).length
+  const mandatorySatisfiedCount = mandatoryDocs.filter((d) =>
+    isDocumentRequirementSatisfied(d.status),
+  ).length
 
   return (
     <>
@@ -293,27 +305,37 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                 Tài liệu hồ sơ
               </CardTitle>
               <CardDescription>
-                Đã ghi nhận {recordedCount}/{documents.length} • Đã kiểm tra {verifiedCount}/{documents.length}
+                Đã ghi nhận {recordedCount}/{documents.length}
+                {pendingCount > 0 && (
+                  <> • Chờ kiểm tra {pendingCount}</>
+                )}
+                {" • "}
+                Hoàn tất yêu cầu {satisfiedCount}/{documents.length}
                 {mandatoryDocs.length > 0 && (
                   <span className="ml-2">
-                    (Bắt buộc đã kiểm tra: {mandatoryVerifiedCount}/{mandatoryDocs.length})
+                    (Bắt buộc đã hoàn tất: {mandatorySatisfiedCount}/{mandatoryDocs.length})
                   </span>
                 )}
               </CardDescription>
             </div>
-            {/* Progress bar reflects officer-verified rows only. The
-                ghi-nhận sliver shows up as the lighter background fill so
-                officers can still see incoming volume at a glance. */}
+            {/* Progress bar reflects backend mandatory-completion semantics:
+                the success fill = `verified | paper_submitted` (rows the
+                backend already accepts as satisfying the requirement), the
+                lighter background fill = total received including the
+                pending-verify queue. Aligning with the backend gate
+                prevents paper-only rows that have been correctly logged as
+                paper_submitted from looking incomplete. ADM-031.6
+                follow-up. */}
             <div className="flex items-center gap-2">
               <div
                 className="relative w-32 h-2 bg-muted rounded-full overflow-hidden"
                 role="progressbar"
-                aria-label="Tiến độ kiểm tra tài liệu"
+                aria-label="Tiến độ hoàn tất tài liệu"
                 aria-valuemin={0}
                 aria-valuemax={100}
                 aria-valuenow={
                   documents.length > 0
-                    ? Math.round((verifiedCount / documents.length) * 100)
+                    ? Math.round((satisfiedCount / documents.length) * 100)
                     : 0
                 }
               >
@@ -329,14 +351,14 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                   className="absolute inset-y-0 left-0 bg-success-600 transition-[width] duration-300"
                   style={{
                     width: documents.length > 0
-                      ? `${(verifiedCount / documents.length) * 100}%`
+                      ? `${(satisfiedCount / documents.length) * 100}%`
                       : "0%",
                   }}
                 />
               </div>
               <span className="text-sm text-muted-foreground font-medium">
                 {documents.length > 0
-                  ? Math.round((verifiedCount / documents.length) * 100)
+                  ? Math.round((satisfiedCount / documents.length) * 100)
                   : 0}%
               </span>
             </div>
@@ -386,21 +408,21 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                 return (
                   <div
                     key={doc.code || index}
-                    className="flex items-center justify-between p-3 border rounded-lg hover:bg-muted/30 transition-colors"
+                    className="flex flex-col gap-3 p-3 border rounded-lg hover:bg-muted/30 transition-colors md:flex-row md:items-center md:gap-4"
                   >
                     {/* Column 1: Tên giấy tờ */}
-                    <div className="flex items-center gap-3 flex-1 min-w-0">
-                      <div className="p-2 bg-muted rounded">
+                    <div className="flex items-start gap-3 flex-1 min-w-0">
+                      <div className="p-2 bg-muted rounded shrink-0">
                         <FileText className="h-4 w-4 text-muted-foreground" />
                       </div>
-                      <div className="min-w-0">
+                      <div className="min-w-0 flex-1">
                         <p className="font-medium flex items-center gap-1 truncate">
                           {doc.label}
                           {doc.is_mandatory && (
                             <span className="text-error-500 text-xs">*</span>
                           )}
                         </p>
-                        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
                           <span>Mã: {doc.code}</span>
                           {doc.uploaded_at && (
                             <span>• {new Date(doc.uploaded_at).toLocaleDateString("vi-VN")}</span>
@@ -419,18 +441,21 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                       </div>
                     </div>
 
-                    {/* Column 2: Yêu cầu loại bản nộp (submission_format) */}
-                    <div className="w-32 flex-shrink-0">
+                    {/* Badge group — format + hình thức + status. Wraps on
+                        narrow widths so long Vietnamese copy ("Bản chụp/scan
+                        không chứng thực") doesn't overflow the row.
+                        ADM-031.5 follow-up. */}
+                    <div className="flex flex-wrap items-center gap-2 md:max-w-[20rem] md:justify-end">
                       {formatBadge && (
-                        <Badge variant="outline" className="text-xs gap-1">
-                          <FormatIcon className="h-3 w-3" />
-                          {formatBadge.label}
+                        <Badge
+                          variant="outline"
+                          className="text-xs gap-1 max-w-full"
+                          title={formatBadge.label}
+                        >
+                          <FormatIcon className="h-3 w-3 shrink-0" />
+                          <span className="truncate">{formatBadge.label}</span>
                         </Badge>
                       )}
-                    </div>
-                    
-                    {/* Column 3: Hình thức (Online vs Nộp giấy) */}
-                    <div className="w-24 flex-shrink-0">
                       <Badge variant="secondary" className="text-xs gap-1">
                         {requiresUpload ? (
                           <>
@@ -444,18 +469,17 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                           </>
                         )}
                       </Badge>
-                    </div>
-                    
-                    {/* Column 4: Trạng thái */}
-                    <div className="w-28 flex-shrink-0">
-                      <Badge className={statusConfig.color}>
-                        <StatusIcon className="h-3 w-3 mr-1" />
-                        {statusConfig.label}
+                      <Badge className={`${statusConfig.color} max-w-full`} title={statusConfig.label}>
+                        <StatusIcon className="h-3 w-3 mr-1 shrink-0" />
+                        <span className="truncate">{statusConfig.label}</span>
                       </Badge>
                     </div>
-                    
-                    {/* Column 5: Thao tác */}
-                    <div className="w-44 flex-shrink-0 flex items-center justify-end gap-2">
+
+                    {/* Actions — wrap on narrow widths so explicit Vietnamese
+                        button labels ("Tải file" / "Đánh dấu đã nhận giấy")
+                        never overflow the action column.
+                        ADM-031.5 follow-up. */}
+                    <div className="flex flex-wrap items-center gap-2 md:justify-end md:shrink-0">
                       {/* View button for uploaded documents */}
                       {hasFile && (
                         <Button

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -1,40 +1,83 @@
 "use client"
 
 /**
- * Documents Tab Component (REFACTORED)
- * 
- * Comprehensive document submission table per wireframe:
- * - Tên giấy tờ | Loại nộp | Hình thức | Trạng thái | Thao tác
- * 
- * Features:
- * - Display ALL documents from doc_configs (not just requires_upload=true)
- * - submission_format badges (photo, certified_copy, original)
- * - requires_upload column (Online vs Nộp giấy)
- * - paper_submitted status support
- * - Officer-only checkbox for paper submission
+ * Documents Tab Component
+ *
+ * Officer-facing documents surface for an admission profile. ADM-031
+ * round 5 refactor: replaces the per-row badge cluster with a KPI strip
+ * + responsive table layout so officers can see at a glance how many
+ * documents exist, what action each row needs, and the current state.
+ *
+ * Layout:
+ * - Top: KPI strip (Tổng tài liệu / Đã ghi nhận / Chờ kiểm tra / Hoàn tất).
+ * - Desktop md+: semantic <table> with columns
+ *     # | Tên giấy tờ | Yêu cầu | Đã ghi nhận | Cách ghi nhận | Trạng thái | Thao tác
+ * - Mobile <md: stacked card per row reusing the same row-state helpers.
+ *
+ * Rows are sorted by a work-queue priority so missing/rejected docs
+ * surface first, uploaded/paper_submitted docs (waiting for verify) are
+ * second, and verified docs sink to the bottom. Within the same
+ * priority, mandatory docs precede optional ones.
  */
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
-  Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from "@/components/ui/dialog"
 import {
-  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
-  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import {
-  FileText, Check, AlertCircle, XCircle, Upload, Loader2, Eye,
-  Camera, FileCheck, FileSpreadsheet, Globe, Building2, Ban, RotateCcw,
+  AlertCircle,
   AlertTriangle,
+  Ban,
+  Building2,
+  Camera,
+  Check,
+  Eye,
+  FileCheck,
+  FileSpreadsheet,
+  FileText,
+  Globe,
+  Loader2,
+  RotateCcw,
+  Upload,
+  XCircle,
 } from "lucide-react"
-import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
-import { useUploadAdmissionDocument, useMarkPaperSubmitted, useRejectDocument, useResetDocument } from "@/hooks/admissions/useAdmissions"
-import { useRef, useState } from "react"
+import type {
+  AdmissionProfileResponse,
+  DocumentItem,
+} from "@/lib/zod/admissions"
+import {
+  useUploadAdmissionDocument,
+  useMarkPaperSubmitted,
+  useRejectDocument,
+  useResetDocument,
+} from "@/hooks/admissions/useAdmissions"
+import { useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 import { isSafeFilePath } from "@/lib/utils"
 import {
@@ -51,17 +94,16 @@ interface DocumentsTabProps {
 }
 
 // ============================================================================
-// STATUS CONFIG
+// CONSTANTS
 // ============================================================================
 
 // Status labels distinguish "ghi nhận" (received) from "kiểm tra" (verified):
 // uploaded / paper_submitted are received but officer-review still pending,
 // while verified means officer has confirmed the submitted format.
-const STATUS_CONFIG: Record<string, {
-  label: string
-  color: string
-  icon: typeof AlertCircle
-}> = {
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; color: string; icon: typeof AlertCircle }
+> = {
   missing: {
     label: "Chưa nộp",
     color: "bg-muted text-muted-foreground",
@@ -89,20 +131,61 @@ const STATUS_CONFIG: Record<string, {
   },
 }
 
-// Icon mapping for submission format badges. Labels come from
-// admission-helpers (single source of truth) — do not duplicate text here.
+// Reception bucket — compact "what-was-received" label that mirrors the
+// backend mandatory-completion gate. Showing this in the "Đã ghi nhận"
+// table cell avoids having to read the full status badge for the common
+// case ("File đã upload" / "Bản giấy đã nhận" / "Chưa nhận gì").
+const RECEPTION_LABEL: Record<string, string> = {
+  missing: "Chưa",
+  rejected: "Chưa",
+  resubmitted: "File",
+  revision_requested: "File",
+  uploaded: "File",
+  verified: "File",
+  paper_submitted: "Giấy",
+}
+
+// Work-queue priority. Officers act on rows in this order: things they
+// (or a teammate) still owe -> things waiting for verification -> done.
+// Lower number = sorts first.
+const STATUS_PRIORITY: Record<string, number> = {
+  missing: 1,
+  rejected: 1,
+  revision_requested: 1,
+  resubmitted: 2,
+  uploaded: 2,
+  paper_submitted: 2,
+  verified: 3,
+}
+
+// Icon mapping for submission format. Labels come from admission-helpers
+// (single source of truth) — do not duplicate text here.
 const FORMAT_ICONS: Record<string, typeof Camera> = {
   photo: Camera,
   certified_copy: FileCheck,
   original: FileSpreadsheet,
 }
 
+// ADM-031.5 / WIG: cache the Intl.DateTimeFormat so we don't allocate one
+// per row. Vietnamese dd/mm/yyyy.
+const VI_DATE_FORMATTER = new Intl.DateTimeFormat("vi-VN", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+})
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
 function getStatusConfig(status: string) {
-  return STATUS_CONFIG[status] ?? {
-    label: status,
-    color: "bg-muted text-muted-foreground",
-    icon: AlertCircle,
-  }
+  return (
+    STATUS_CONFIG[status] ?? {
+      label: status,
+      color: "bg-muted text-muted-foreground",
+      icon: AlertCircle,
+    }
+  )
 }
 
 function getFormatBadge(format: string | null | undefined) {
@@ -111,6 +194,261 @@ function getFormatBadge(format: string | null | undefined) {
     label: getFormatLabel(format),
     icon: FORMAT_ICONS[format] ?? FileSpreadsheet,
   }
+}
+
+function getReceptionLabel(status: string): string {
+  return RECEPTION_LABEL[status] ?? "Chưa"
+}
+
+function sortByWorkQueue(docs: DocumentItem[]): DocumentItem[] {
+  return [...docs].sort((a, b) => {
+    const pa = STATUS_PRIORITY[a.status ?? ""] ?? 99
+    const pb = STATUS_PRIORITY[b.status ?? ""] ?? 99
+    if (pa !== pb) return pa - pb
+    // Mandatory before optional within the same priority bucket.
+    const ma = a.is_mandatory ? 0 : 1
+    const mb = b.is_mandatory ? 0 : 1
+    if (ma !== mb) return ma - mb
+    return (a.label ?? a.code ?? "").localeCompare(
+      b.label ?? b.code ?? "",
+      "vi",
+    )
+  })
+}
+
+// Per-row computed state — extracted so desktop table cells and mobile
+// stacked card share the same source of truth.
+type RowState = ReturnType<typeof computeRowState>
+
+function computeRowState(doc: DocumentItem) {
+  const statusConfig = getStatusConfig(doc.status ?? "missing")
+  const requiresUpload = doc.requires_upload !== false
+  const isPaperOnly = !requiresUpload
+  const formatBadge = getFormatBadge(doc.submission_format ?? null)
+
+  // ADM-031 round 4: officer-declared / manager-verified format.
+  const recordedFormatCode =
+    doc.status === "verified" && doc.verified_format
+      ? doc.verified_format
+      : (doc.actual_submission_format ?? null)
+  const recordedFormatLabel = recordedFormatCode
+    ? getFormatLabel(recordedFormatCode)
+    : null
+  const recordedDiffersFromRequired =
+    !!recordedFormatCode &&
+    !!doc.submission_format &&
+    recordedFormatCode !== doc.submission_format
+
+  const receptionLabel = getReceptionLabel(doc.status ?? "missing")
+  const howToReceiveLabel = requiresUpload ? "Tải file" : "Nhận giấy tại quầy"
+  const howToReceiveTitle = requiresUpload
+    ? "Cần tải ảnh/scan/PDF của giấy tờ lên hệ thống"
+    : "Chỉ ghi nhận đã nhận bản giấy, không cần upload file"
+  const HowToReceiveIcon = requiresUpload ? Globe : Building2
+
+  const hasFile =
+    !!doc.file_path && (doc.status === "uploaded" || doc.status === "verified")
+  const canUpload = doc.can_upload ?? false
+  const canMarkPaperSubmitted = doc.can_mark_paper_submitted ?? false
+  const canReject = doc.can_reject ?? false
+  const canReset = doc.can_reset ?? false
+  const hasAnyAction =
+    hasFile || canUpload || canMarkPaperSubmitted || canReject || canReset
+
+  const formattedUploadedAt = doc.uploaded_at
+    ? VI_DATE_FORMATTER.format(new Date(doc.uploaded_at))
+    : null
+
+  return {
+    statusConfig,
+    requiresUpload,
+    isPaperOnly,
+    formatBadge,
+    recordedFormatCode,
+    recordedFormatLabel,
+    recordedDiffersFromRequired,
+    receptionLabel,
+    howToReceiveLabel,
+    howToReceiveTitle,
+    HowToReceiveIcon,
+    hasFile,
+    canUpload,
+    canMarkPaperSubmitted,
+    canReject,
+    canReset,
+    hasAnyAction,
+    formattedUploadedAt,
+  }
+}
+
+// ============================================================================
+// SUB-COMPONENTS
+// ============================================================================
+
+interface KpiTileProps {
+  label: string
+  value: string | number
+  hint?: string
+  accent?: "default" | "warning" | "info" | "success"
+}
+
+function KpiTile({ label, value, hint, accent = "default" }: KpiTileProps) {
+  const accentClass =
+    accent === "warning"
+      ? "text-warning-700"
+      : accent === "info"
+        ? "text-info-700"
+        : accent === "success"
+          ? "text-success-700"
+          : "text-foreground"
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className={`mt-1 text-2xl font-semibold tabular-nums ${accentClass}`}>
+        {value}
+      </div>
+      {hint && (
+        <div className="mt-0.5 text-xs text-muted-foreground tabular-nums">
+          {hint}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface ActionsCellProps {
+  doc: DocumentItem
+  state: RowState
+  isUploading: boolean
+  isPaperPending: boolean
+  isResetPending: boolean
+  isCurrentResetTarget: boolean
+  onView: (filePath: string) => void
+  onUpload: (
+    code: string,
+    label: string,
+    requiredFormat?: string,
+  ) => void
+  onPaperSubmit: (
+    code: string,
+    label: string,
+    requiredFormat?: string,
+  ) => void
+  onRejectClick: (code: string, label: string) => void
+  onResetClick: (code: string, label: string) => void
+  alignEnd?: boolean
+}
+
+function DocumentRowActions(props: ActionsCellProps) {
+  const {
+    doc,
+    state,
+    isUploading,
+    isPaperPending,
+    isResetPending,
+    isCurrentResetTarget,
+    onView,
+    onUpload,
+    onPaperSubmit,
+    onRejectClick,
+    onResetClick,
+    alignEnd,
+  } = props
+
+  if (!state.hasAnyAction && !(state.isPaperOnly && doc.status === "paper_submitted")) {
+    return <span className="text-xs text-muted-foreground">—</span>
+  }
+
+  return (
+    <div
+      className={`flex flex-wrap items-center gap-1.5 ${alignEnd ? "justify-end" : ""}`}
+    >
+      {/* WIG: drop duplicate `title` when aria-label conveys the same text;
+          keep aria-label only on icon-only buttons so screen readers don't
+          announce the same string twice. */}
+      {state.hasFile && (
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => doc.file_path && onView(doc.file_path)}
+          aria-label="Xem tài liệu"
+        >
+          <Eye className="h-4 w-4" />
+        </Button>
+      )}
+
+      {state.canUpload && (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() =>
+            onUpload(doc.code, doc.label, doc.submission_format ?? undefined)
+          }
+          disabled={isUploading}
+        >
+          {isUploading ? (
+            <Loader2 className="h-4 w-4 mr-1 animate-spin motion-reduce:animate-none" />
+          ) : (
+            <Upload className="h-4 w-4 mr-1" />
+          )}
+          Tải file
+        </Button>
+      )}
+
+      {state.canMarkPaperSubmitted && (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() =>
+            onPaperSubmit(doc.code, doc.label, doc.submission_format ?? undefined)
+          }
+          disabled={isPaperPending}
+        >
+          {isPaperPending ? (
+            <Loader2 className="h-4 w-4 mr-1 animate-spin motion-reduce:animate-none" />
+          ) : (
+            <Building2 className="h-4 w-4 mr-1" />
+          )}
+          Đánh dấu đã nhận giấy
+        </Button>
+      )}
+
+      {state.isPaperOnly && doc.status === "paper_submitted" && !state.canReject && !state.canReset && (
+        <span className="inline-flex items-center text-success-600 text-xs">
+          <Check className="h-4 w-4" aria-hidden="true" />
+        </span>
+      )}
+
+      {state.canReject && (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-error-600 hover:text-error-700 hover:bg-error-50"
+          onClick={() => onRejectClick(doc.code, doc.label)}
+          aria-label="Từ chối tài liệu"
+        >
+          <Ban className="h-4 w-4" />
+        </Button>
+      )}
+
+      {state.canReset && (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-warning-600 hover:text-warning-700 hover:bg-warning-50"
+          onClick={() => onResetClick(doc.code, doc.label)}
+          disabled={isResetPending && isCurrentResetTarget}
+          aria-label="Đặt lại tài liệu về Chưa nộp"
+        >
+          {isResetPending && isCurrentResetTarget ? (
+            <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
+          ) : (
+            <RotateCcw className="h-4 w-4" />
+          )}
+        </Button>
+      )}
+    </div>
+  )
 }
 
 // ============================================================================
@@ -135,45 +473,77 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
     docCode: string
     docLabel: string
     requiredFormat?: string
-    action: 'upload' | 'paper'
+    action: "upload" | "paper"
     file?: File
   } | null>(null)
   const [selectedFormat, setSelectedFormat] = useState<string>("")
 
   // Reset/Undo Confirmation Dialog State
-  const [pendingResetDoc, setPendingResetDoc] = useState<{code: string, label: string} | null>(null)
+  const [pendingResetDoc, setPendingResetDoc] = useState<{
+    code: string
+    label: string
+  } | null>(null)
 
   // Rejection Dialog State
-  const [rejectItem, setRejectItem] = useState<{code: string, label: string} | null>(null)
+  const [rejectItem, setRejectItem] = useState<{
+    code: string
+    label: string
+  } | null>(null)
   const [rejectReason, setRejectReason] = useState("")
 
   // Upload config
   const uploadConfig = profile.applied_rules.upload_config
   const allowedTypes = uploadConfig?.allowed_types || []
   const maxFileSize = uploadConfig?.max_file_size || 0
-  const maxFileSizeMB = maxFileSize > 0 ? Math.round(maxFileSize / (1024 * 1024)) : 10
+  const maxFileSizeMB =
+    maxFileSize > 0 ? Math.round(maxFileSize / (1024 * 1024)) : 10
   const allowedExtensionsDisplay = uploadConfig?.allowed_extensions?.length
-    ? uploadConfig.allowed_extensions.map(ext => `.${ext}`).join(", ")
+    ? uploadConfig.allowed_extensions.map((ext) => `.${ext}`).join(", ")
     : "N/A"
-  // Separate accept value — never use display fallback "N/A" for the file input
   const acceptAttr = uploadConfig?.allowed_extensions?.length
-    ? uploadConfig.allowed_extensions.map(ext => `.${ext}`).join(",")
+    ? uploadConfig.allowed_extensions.map((ext) => `.${ext}`).join(",")
     : ""
 
-  const handleUploadClick = (code: string, label: string, requiredFormat?: string) => {
+  // Sort docs by work-queue priority — only resort when documents change.
+  const sortedDocs = useMemo(() => sortByWorkQueue(documents), [documents])
+
+  // KPI counts. Keep on the unsorted array — totals don't depend on order.
+  const total = documents.length
+  const recordedCount = documents.filter((d) =>
+    isDocumentRecorded(d.status ?? ""),
+  ).length
+  const satisfiedCount = documents.filter((d) =>
+    isDocumentRequirementSatisfied(d.status ?? ""),
+  ).length
+  const pendingCount = documents.filter((d) =>
+    isDocumentPendingVerification(d.status ?? ""),
+  ).length
+  const mandatoryDocs = documents.filter((d) => d.is_mandatory)
+  const mandatorySatisfiedCount = mandatoryDocs.filter((d) =>
+    isDocumentRequirementSatisfied(d.status ?? ""),
+  ).length
+  const satisfiedPercent =
+    total > 0 ? Math.round((satisfiedCount / total) * 100) : 0
+
+  // -- Action handlers -------------------------------------------------------
+
+  const handleUploadClick = (
+    code: string,
+    label: string,
+    requiredFormat?: string,
+  ) => {
     setSelectedDocCode(code)
     if (fileInputRef.current) {
       fileInputRef.current.value = ""
       fileInputRef.current.click()
     }
 
-    // Prepare dialog for format selection after file is chosen
     setSubmissionFormatDialog({
-      isOpen: false, // Will open after file selection
+      isOpen: false,
       docCode: code,
       docLabel: label,
       requiredFormat,
-      action: 'upload'
+      action: "upload",
     })
     setSelectedFormat(requiredFormat || "")
   }
@@ -184,7 +554,7 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
     }
     if (maxFileSize > 0 && file.size > maxFileSize) {
       const sizeMB = (file.size / (1024 * 1024)).toFixed(1)
-      return `File quá lớn (${sizeMB}MB). Tối đa ${maxFileSizeMB}MB.`
+      return `File quá lớn (${sizeMB} MB). Tối đa ${maxFileSizeMB} MB.`
     }
     return null
   }
@@ -199,24 +569,26 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
       return
     }
 
-    // Open format selection dialog with file
     if (submissionFormatDialog) {
       setSubmissionFormatDialog({
         ...submissionFormatDialog,
         isOpen: true,
-        file
+        file,
       })
     }
   }
 
-  const handlePaperSubmit = (code: string, label: string, requiredFormat?: string) => {
-    // Open format selection dialog
+  const handlePaperSubmit = (
+    code: string,
+    label: string,
+    requiredFormat?: string,
+  ) => {
     setSubmissionFormatDialog({
       isOpen: true,
       docCode: code,
       docLabel: label,
       requiredFormat,
-      action: 'paper'
+      action: "paper",
     })
     setSelectedFormat(requiredFormat || "")
   }
@@ -226,22 +598,19 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
 
     const { action, docCode, file } = submissionFormatDialog
 
-    if (action === 'upload' && file) {
-      // Upload with format
+    if (action === "upload" && file) {
       uploadMutation.mutate({
         docCode,
         file,
-        actualSubmissionFormat: selectedFormat
+        actualSubmissionFormat: selectedFormat,
       })
-    } else if (action === 'paper') {
-      // Mark paper submitted with format
+    } else if (action === "paper") {
       paperMutation.mutate({
         docCode,
-        actualSubmissionFormat: selectedFormat
+        actualSubmissionFormat: selectedFormat,
       })
     }
 
-    // Close dialog
     setSubmissionFormatDialog(null)
     setSelectedFormat("")
   }
@@ -250,21 +619,21 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
     setRejectItem({ code, label })
     setRejectReason("")
   }
-  
+
   const confirmReject = () => {
     if (!rejectItem) return
     if (!rejectReason.trim()) {
       toast.error("Vui lòng nhập lý do từ chối")
       return
     }
-    
+
     rejectMutation.mutate(
       { docCode: rejectItem.code, reason: rejectReason },
       {
         onSuccess: () => {
           setRejectItem(null)
-        }
-      }
+        },
+      },
     )
   }
 
@@ -274,408 +643,417 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
     const url = `${process.env.NEXT_PUBLIC_API_URL || ""}/${cleanPath}`
     window.open(url, "_blank", "noopener,noreferrer")
   }
-  
-  // Stats — split into three buckets so the surface matches the backend
-  // mandatory-doc gate (admission_service.py:566) without losing officer
-  // workflow visibility:
-  //   recordedCount   -> received in any form (uploaded | paper_submitted | verified)
-  //   satisfiedCount  -> backend would treat as completing the requirement
-  //                       (verified | paper_submitted). This is the
-  //                       "Hoàn tất yêu cầu" metric for the progress bar.
-  //   pendingCount    -> uploaded but not yet officer-verified ("Chờ kiểm tra")
-  // Without the satisfied/pending split, a paper-only mandatory row sitting
-  // at paper_submitted would render as incomplete in the UI even though
-  // the backend already accepts it as satisfied. ADM-031.6 follow-up.
-  const recordedCount = documents.filter((d) => isDocumentRecorded(d.status)).length
-  const satisfiedCount = documents.filter((d) => isDocumentRequirementSatisfied(d.status)).length
-  const pendingCount = documents.filter((d) => isDocumentPendingVerification(d.status)).length
-  const mandatoryDocs = documents.filter((d) => d.is_mandatory)
-  const mandatorySatisfiedCount = mandatoryDocs.filter((d) =>
-    isDocumentRequirementSatisfied(d.status),
-  ).length
+
+  const handleResetClick = (code: string, label: string) => {
+    setPendingResetDoc({ code, label })
+  }
+
+  const handleResetConfirm = () => {
+    if (pendingResetDoc) {
+      resetMutation.mutate(pendingResetDoc.code)
+    }
+    setPendingResetDoc(null)
+  }
+
+  // -- Per-row mutation helpers ---------------------------------------------
+
+  const isUploadingForCode = (code: string) =>
+    uploadMutation.isPending && selectedDocCode === code
+  const isPaperPendingForCode = (code: string) =>
+    paperMutation.isPending && paperMutation.variables?.docCode === code
+  const isResetPendingForCode = (code: string) =>
+    resetMutation.isPending && resetMutation.variables === code
+
+  // ============================================================================
+  // RENDER
+  // ============================================================================
 
   return (
     <>
+      {/* KPI strip — 4 tiles so officer reads the global state at a glance.
+          Counts use tabular-nums so the digits stay aligned across columns. */}
+      <div
+        role="group"
+        aria-label="Tổng quan tài liệu"
+        className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4"
+      >
+        <KpiTile label="Tổng tài liệu" value={total} />
+        <KpiTile
+          label="Đã ghi nhận"
+          value={`${recordedCount}/${total}`}
+          accent="info"
+          hint={
+            mandatoryDocs.length > 0
+              ? `Bắt buộc: ${mandatoryDocs.length}`
+              : undefined
+          }
+        />
+        <KpiTile
+          label="Chờ kiểm tra"
+          value={pendingCount}
+          accent={pendingCount > 0 ? "warning" : "default"}
+          hint={pendingCount > 0 ? "File chưa duyệt" : "Không có"}
+        />
+        <KpiTile
+          label="Hoàn tất yêu cầu"
+          value={`${satisfiedCount}/${total}`}
+          accent="success"
+          hint={
+            mandatoryDocs.length > 0
+              ? `Bắt buộc: ${mandatorySatisfiedCount}/${mandatoryDocs.length} • ${satisfiedPercent}%`
+              : `${satisfiedPercent}%`
+          }
+        />
+      </div>
+
       <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
+        <CardHeader className="pb-3">
+          <div className="flex flex-col gap-1 md:flex-row md:items-center md:justify-between md:gap-4">
             <div>
               <CardTitle className="text-lg flex items-center gap-2">
-                <FileText className="h-5 w-5" />
+                <FileText className="h-5 w-5" aria-hidden="true" />
                 Tài liệu hồ sơ
               </CardTitle>
               <CardDescription>
-                Đã ghi nhận {recordedCount}/{documents.length}
-                {pendingCount > 0 && (
-                  <> • Chờ kiểm tra {pendingCount}</>
-                )}
-                {" • "}
-                Hoàn tất yêu cầu {satisfiedCount}/{documents.length}
-                {mandatoryDocs.length > 0 && (
-                  <span className="ml-2">
-                    (Bắt buộc đã hoàn tất: {mandatorySatisfiedCount}/{mandatoryDocs.length})
-                  </span>
-                )}
+                Sắp xếp theo việc cần làm: chưa nộp / không hợp lệ trước, kế đến
+                là chờ kiểm tra, cuối cùng là đã hoàn tất.
               </CardDescription>
             </div>
-            {/* Progress bar reflects backend mandatory-completion semantics:
-                the success fill = `verified | paper_submitted` (rows the
-                backend already accepts as satisfying the requirement), the
-                lighter background fill = total received including the
-                pending-verify queue. Aligning with the backend gate
-                prevents paper-only rows that have been correctly logged as
-                paper_submitted from looking incomplete. ADM-031.6
-                follow-up. */}
-            <div className="flex items-center gap-2">
-              <div
-                className="relative w-32 h-2 bg-muted rounded-full overflow-hidden"
-                role="progressbar"
-                aria-label="Tiến độ hoàn tất tài liệu"
-                aria-valuemin={0}
-                aria-valuemax={100}
-                aria-valuenow={
-                  documents.length > 0
-                    ? Math.round((satisfiedCount / documents.length) * 100)
-                    : 0
-                }
-              >
-                <div
-                  className="absolute inset-y-0 left-0 bg-info-200 transition-[width] duration-300"
-                  style={{
-                    width: documents.length > 0
-                      ? `${(recordedCount / documents.length) * 100}%`
-                      : "0%",
-                  }}
-                />
-                <div
-                  className="absolute inset-y-0 left-0 bg-success-600 transition-[width] duration-300"
-                  style={{
-                    width: documents.length > 0
-                      ? `${(satisfiedCount / documents.length) * 100}%`
-                      : "0%",
-                  }}
-                />
-              </div>
-              <span className="text-sm text-muted-foreground font-medium">
-                {documents.length > 0
-                  ? Math.round((satisfiedCount / documents.length) * 100)
-                  : 0}%
-              </span>
-            </div>
+            <p
+              className="text-xs text-muted-foreground tabular-nums"
+              id="documents-upload-rules"
+            >
+              Định dạng: {allowedExtensionsDisplay} • Tối đa {maxFileSizeMB}
+              {" "}MB
+            </p>
           </div>
-          
-          <p className="text-xs text-muted-foreground mt-2">
-            Định dạng: {allowedExtensionsDisplay} • Tối đa {maxFileSizeMB}MB
-          </p>
         </CardHeader>
-        
-        <CardContent>
+
+        <CardContent className="pt-0">
           {documents.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
-              <FileText className="h-12 w-12 mx-auto mb-3 opacity-20" />
+              <FileText className="h-12 w-12 mx-auto mb-3 opacity-20" aria-hidden="true" />
               <p>Chưa có danh sách tài liệu</p>
             </div>
           ) : (
-            <div className="space-y-2">
-              {documents.map((doc, index) => {
-                const statusConfig = getStatusConfig(doc.status)
-                const formatBadge = getFormatBadge(doc.submission_format)
-                const StatusIcon = statusConfig.icon
-                const FormatIcon = formatBadge?.icon || FileSpreadsheet
+            <>
+              {/* ----- Desktop: semantic table ----- */}
+              <div className="hidden md:block overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
+                      <th
+                        scope="col"
+                        className="py-2 pr-3 text-left font-medium tabular-nums w-10"
+                      >
+                        #
+                      </th>
+                      <th scope="col" className="py-2 pr-3 text-left font-medium">
+                        Tên giấy tờ
+                      </th>
+                      <th scope="col" className="py-2 pr-3 text-left font-medium">
+                        Yêu cầu
+                      </th>
+                      <th scope="col" className="py-2 pr-3 text-left font-medium">
+                        Đã ghi nhận
+                      </th>
+                      <th scope="col" className="py-2 pr-3 text-left font-medium">
+                        Cách ghi nhận
+                      </th>
+                      <th scope="col" className="py-2 pr-3 text-left font-medium">
+                        Trạng thái
+                      </th>
+                      <th
+                        scope="col"
+                        className="py-2 pl-3 text-right font-medium"
+                      >
+                        Thao tác
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    {sortedDocs.map((doc, i) => {
+                      const state = computeRowState(doc)
+                      const StatusIcon = state.statusConfig.icon
+                      const HowIcon = state.HowToReceiveIcon
+                      const FormatIcon = state.formatBadge?.icon
+                      return (
+                        <tr
+                          key={doc.code || i}
+                          className="hover:bg-muted/30 motion-reduce:transition-none"
+                        >
+                          <td className="py-3 pr-3 align-top text-muted-foreground tabular-nums">
+                            {i + 1}
+                          </td>
+                          <td className="py-3 pr-3 align-top min-w-0">
+                            <div className="font-medium text-pretty break-words">
+                              {doc.label}
+                              {doc.is_mandatory && (
+                                <span
+                                  className="text-error-500 ml-0.5"
+                                  aria-label="Bắt buộc"
+                                >
+                                  *
+                                </span>
+                              )}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              <span translate="no">Mã: {doc.code}</span>
+                              {state.formattedUploadedAt && (
+                                <>
+                                  {" • "}
+                                  <span className="tabular-nums">
+                                    {state.formattedUploadedAt}
+                                  </span>
+                                </>
+                              )}
+                            </div>
+                            {doc.status === "rejected" && doc.rejection_reason && (
+                              <div className="text-xs text-error-700 mt-1 break-words">
+                                Lý do: {doc.rejection_reason}
+                              </div>
+                            )}
+                          </td>
+                          <td className="py-3 pr-3 align-top">
+                            <div className="text-sm">
+                              {doc.is_mandatory ? "Bắt buộc" : "Tùy chọn"}
+                            </div>
+                            {state.formatBadge && FormatIcon && (
+                              <div className="text-xs text-muted-foreground inline-flex items-center gap-1 mt-0.5">
+                                <FormatIcon
+                                  className="h-3 w-3 shrink-0"
+                                  aria-hidden="true"
+                                />
+                                <span className="break-words">
+                                  {state.formatBadge.label}
+                                </span>
+                              </div>
+                            )}
+                          </td>
+                          <td className="py-3 pr-3 align-top">
+                            <Badge
+                              variant={
+                                state.receptionLabel === "Chưa"
+                                  ? "outline"
+                                  : "secondary"
+                              }
+                              className="text-xs"
+                            >
+                              {state.receptionLabel}
+                            </Badge>
+                            {state.recordedFormatLabel && (
+                              <div
+                                className={`text-xs mt-1 inline-flex items-center gap-1 break-words ${
+                                  state.recordedDiffersFromRequired
+                                    ? "text-warning-700"
+                                    : "text-muted-foreground"
+                                }`}
+                                title={
+                                  state.recordedDiffersFromRequired
+                                    ? `Khác yêu cầu hồ sơ (${state.formatBadge?.label ?? doc.submission_format})`
+                                    : undefined
+                                }
+                              >
+                                {state.recordedDiffersFromRequired && (
+                                  <AlertTriangle
+                                    className="h-3 w-3 shrink-0"
+                                    aria-label="Khác yêu cầu hồ sơ"
+                                  />
+                                )}
+                                <span>{state.recordedFormatLabel}</span>
+                              </div>
+                            )}
+                          </td>
+                          <td className="py-3 pr-3 align-top">
+                            <Badge
+                              variant="outline"
+                              className="text-xs gap-1"
+                              title={state.howToReceiveTitle}
+                            >
+                              <HowIcon
+                                className="h-3 w-3 shrink-0"
+                                aria-hidden="true"
+                              />
+                              {state.howToReceiveLabel}
+                            </Badge>
+                          </td>
+                          <td className="py-3 pr-3 align-top">
+                            <Badge className={`${state.statusConfig.color} gap-1`}>
+                              <StatusIcon
+                                className="h-3 w-3 shrink-0"
+                                aria-hidden="true"
+                              />
+                              {state.statusConfig.label}
+                            </Badge>
+                          </td>
+                          <td className="py-3 pl-3 align-top">
+                            <DocumentRowActions
+                              doc={doc}
+                              state={state}
+                              isUploading={isUploadingForCode(doc.code)}
+                              isPaperPending={isPaperPendingForCode(doc.code)}
+                              isResetPending={resetMutation.isPending}
+                              isCurrentResetTarget={isResetPendingForCode(doc.code)}
+                              onView={handleViewDocument}
+                              onUpload={handleUploadClick}
+                              onPaperSubmit={handlePaperSubmit}
+                              onRejectClick={handleRejectClick}
+                              onResetClick={handleResetClick}
+                              alignEnd
+                            />
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
 
-                const isUploading = uploadMutation.isPending && selectedDocCode === doc.code
-                const isPaperPending = paperMutation.isPending && paperMutation.variables?.docCode === doc.code
-                const hasFile = doc.file_path && (doc.status === "uploaded" || doc.status === "verified")
-                const requiresUpload = doc.requires_upload !== false // Default true if undefined
-                const isPaperDoc = !requiresUpload
-                // Task-oriented hint surfaced inline for missing rows so the
-                // officer/applicant immediately knows the next physical step
-                // ("upload a scan" vs "bring paper to counter").
-                const isMissing = doc.status === "missing"
-                const taskHint = isMissing
-                  ? requiresUpload
-                    ? "Cần tải ảnh/scan"
-                    : "Nhận bản giấy tại quầy"
-                  : null
-                // PR #5: per-row permission flags from backend replace the
-                // coarse `can('edit')` gate — the matching button shows iff
-                // the route would authorise the action for this user.
-                const canUpload = doc.can_upload ?? false
-                const canReject = doc.can_reject ?? false
-                const canReset = doc.can_reset ?? false
-                const canMarkPaperSubmitted = doc.can_mark_paper_submitted ?? false
-                
-                // ADM-031 round 2: mode badge replaces the old "Online" /
-                // "Nộp giấy" pair so the wording matches the actual workflow
-                // ("Cần file" = needs upload, "Ghi nhận giấy" = paper-only
-                // checklist). Tooltip explains the difference for officers
-                // unfamiliar with the term.
-                const modeLabel = requiresUpload ? "Cần file" : "Ghi nhận giấy"
-                const modeTitle = requiresUpload
-                  ? "Cần tải ảnh/scan/PDF của giấy tờ lên hệ thống"
-                  : "Chỉ ghi nhận đã nhận bản giấy, không cần upload file"
-                const ModeIcon = requiresUpload ? Globe : Building2
-
-                // ADM-031 round 4: surface the actually-recorded format so
-                // officers can verify what they (or a teammate) declared at
-                // upload/paper-receipt time. Priority mirrors the executive
-                // summary view: verified > actual > none. The required
-                // format stays in the "Yêu cầu bản nộp" badge regardless,
-                // so a mismatch between required and actual is visually
-                // diff-able at a glance.
-                const recordedFormatCode =
-                  doc.status === "verified" && doc.verified_format
-                    ? doc.verified_format
-                    : doc.actual_submission_format ?? null
-                const recordedFormatLabel = recordedFormatCode
-                  ? getFormatLabel(recordedFormatCode)
-                  : null
-                const recordedLabelHeader =
-                  doc.status === "verified" ? "Đã kiểm tra (loại bản)" : "Đã ghi nhận (loại bản)"
-                const recordedFormatColor =
-                  doc.status === "verified"
-                    ? "border-success-300 bg-success-50 text-success-800"
-                    : "border-info-300 bg-info-50 text-info-800"
-                const recordedDiffersFromRequired =
-                  recordedFormatCode &&
-                  doc.submission_format &&
-                  recordedFormatCode !== doc.submission_format
-
-                return (
-                  <div
-                    key={doc.code || index}
-                    className="flex flex-col gap-3 p-3 border rounded-lg hover:bg-muted/30 transition-colors md:flex-row md:items-center md:gap-4"
-                  >
-                    {/* Title block — name + mandatory star + meta + task hint.
-                        Same on mobile and desktop. */}
-                    <div className="flex items-start gap-3 flex-1 min-w-0">
-                      <div className="p-2 bg-muted rounded shrink-0">
-                        <FileText className="h-4 w-4 text-muted-foreground" />
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <p className="font-medium flex items-center gap-1 truncate">
-                          {doc.label}
-                          {doc.is_mandatory && (
-                            <span className="text-error-500 text-xs">*</span>
-                          )}
-                        </p>
-                        <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
-                          <span>Mã: {doc.code}</span>
-                          {doc.uploaded_at && (
-                            <span>• {new Date(doc.uploaded_at).toLocaleDateString("vi-VN")}</span>
+              {/* ----- Mobile: stacked card per row, fewer badges, dl key/value ----- */}
+              <ul className="md:hidden space-y-3">
+                {sortedDocs.map((doc, i) => {
+                  const state = computeRowState(doc)
+                  const StatusIcon = state.statusConfig.icon
+                  const HowIcon = state.HowToReceiveIcon
+                  return (
+                    <li
+                      key={doc.code || i}
+                      className="rounded-lg border p-3 motion-reduce:transition-none"
+                    >
+                      <div className="flex items-start gap-2">
+                        <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+                          #{i + 1}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <div className="font-medium text-pretty break-words">
+                            {doc.label}
+                            {doc.is_mandatory && (
+                              <span
+                                className="text-error-500 ml-0.5"
+                                aria-label="Bắt buộc"
+                              >
+                                *
+                              </span>
+                            )}
+                          </div>
+                          <div
+                            className="text-xs text-muted-foreground"
+                            translate="no"
+                          >
+                            Mã: {doc.code}
+                          </div>
+                          {state.formattedUploadedAt && (
+                            <div className="text-xs text-muted-foreground tabular-nums">
+                              Cập nhật: {state.formattedUploadedAt}
+                            </div>
                           )}
                           {doc.status === "rejected" && doc.rejection_reason && (
-                            <span className="text-error-600 font-medium">
-                              • Lý do: {doc.rejection_reason}
-                            </span>
+                            <div className="text-xs text-error-700 mt-1 break-words">
+                              Lý do: {doc.rejection_reason}
+                            </div>
                           )}
                         </div>
-                        {taskHint && (
-                          <p className="text-xs text-warning-700 font-medium mt-1">
-                            {taskHint}
-                          </p>
-                        )}
+                        <Badge
+                          className={`${state.statusConfig.color} gap-1 shrink-0`}
+                        >
+                          <StatusIcon
+                            className="h-3 w-3 shrink-0"
+                            aria-hidden="true"
+                          />
+                          {state.statusConfig.label}
+                        </Badge>
                       </div>
-                    </div>
 
-                    {/* Metadata block — labelled key/value rows on mobile per
-                        ADM-031 round 2 wireframe; collapses to horizontal
-                        badge cluster on desktop. The labels are
-                        ``md:hidden`` so they vanish on desktop without
-                        wrapping the badges in extra DOM. */}
-                    <div className="grid grid-cols-[8rem_1fr] gap-x-3 gap-y-1.5 text-sm md:flex md:flex-wrap md:items-center md:gap-2 md:max-w-[22rem] md:justify-end">
-                      {formatBadge && (
-                        <>
-                          <span className="text-xs text-muted-foreground self-center md:hidden">
-                            Yêu cầu bản nộp
+                      <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-1.5 mt-3 text-sm">
+                        <dt className="text-xs text-muted-foreground self-center">
+                          Yêu cầu
+                        </dt>
+                        <dd className="break-words">
+                          {doc.is_mandatory ? "Bắt buộc" : "Tùy chọn"}
+                          {state.formatBadge && (
+                            <span className="text-xs text-muted-foreground">
+                              {" · "}
+                              {state.formatBadge.label}
+                            </span>
+                          )}
+                        </dd>
+
+                        <dt className="text-xs text-muted-foreground self-center">
+                          Đã ghi nhận
+                        </dt>
+                        <dd className="break-words">
+                          <span className="font-medium">
+                            {state.receptionLabel}
                           </span>
+                          {state.recordedFormatLabel && (
+                            <span
+                              className={`text-xs ml-2 ${
+                                state.recordedDiffersFromRequired
+                                  ? "text-warning-700"
+                                  : "text-muted-foreground"
+                              }`}
+                            >
+                              {state.recordedDiffersFromRequired ? "⚠ " : ""}
+                              {state.recordedFormatLabel}
+                            </span>
+                          )}
+                        </dd>
+
+                        <dt className="text-xs text-muted-foreground self-center">
+                          Cách ghi nhận
+                        </dt>
+                        <dd>
                           <Badge
                             variant="outline"
-                            className="text-xs gap-1 max-w-full justify-start md:justify-center"
-                            title={`Yêu cầu hồ sơ: ${formatBadge.label}`}
+                            className="text-xs gap-1"
+                            title={state.howToReceiveTitle}
                           >
-                            <FormatIcon className="h-3 w-3 shrink-0" />
-                            <span className="truncate">{formatBadge.label}</span>
+                            <HowIcon
+                              className="h-3 w-3 shrink-0"
+                              aria-hidden="true"
+                            />
+                            {state.howToReceiveLabel}
                           </Badge>
-                        </>
-                      )}
-                      {/* ADM-031 round 4: show the actual / verified format so
-                          officers don't have to re-open the document to recall
-                          what they declared. Border colour signals the source
-                          (verified vs officer-declared) without an extra
-                          legend; mismatch with the required format is also
-                          flagged via title tooltip. */}
-                      {recordedFormatLabel && (
-                        <>
-                          <span className="text-xs text-muted-foreground self-center md:hidden">
-                            {recordedLabelHeader}
-                          </span>
-                          <Badge
-                            variant="outline"
-                            className={`text-xs gap-1 max-w-full justify-start md:justify-center ${recordedFormatColor}`}
-                            title={
-                              recordedDiffersFromRequired
-                                ? `${recordedLabelHeader}: ${recordedFormatLabel} — KHÁC yêu cầu hồ sơ (${formatBadge?.label ?? doc.submission_format})`
-                                : `${recordedLabelHeader}: ${recordedFormatLabel}`
-                            }
-                          >
-                            <FormatIcon className="h-3 w-3 shrink-0" />
-                            <span className="truncate">{recordedFormatLabel}</span>
-                            {recordedDiffersFromRequired && (
-                              <AlertTriangle
-                                className="h-3 w-3 shrink-0 text-warning-700"
-                                aria-label="Khác yêu cầu hồ sơ"
-                              />
-                            )}
-                          </Badge>
-                        </>
-                      )}
-                      <span className="text-xs text-muted-foreground self-center md:hidden">
-                        Cách ghi nhận
-                      </span>
-                      <Badge
-                        variant="secondary"
-                        className="text-xs gap-1 justify-start md:justify-center w-fit"
-                        title={modeTitle}
-                      >
-                        <ModeIcon className="h-3 w-3" />
-                        {modeLabel}
-                      </Badge>
-                      <span className="text-xs text-muted-foreground self-center md:hidden">
-                        Trạng thái
-                      </span>
-                      <Badge
-                        className={`${statusConfig.color} max-w-full justify-start md:justify-center`}
-                        title={statusConfig.label}
-                      >
-                        <StatusIcon className="h-3 w-3 mr-1 shrink-0" />
-                        <span className="truncate">{statusConfig.label}</span>
-                      </Badge>
-                    </div>
+                        </dd>
+                      </dl>
 
-                    {/* Actions — labelled on mobile, compact horizontal cluster
-                        on desktop. Inner div keeps the buttons grouped so
-                        flex-wrap operates within the action area only. */}
-                    <div className="grid grid-cols-[8rem_1fr] gap-x-3 gap-y-1.5 md:flex md:flex-wrap md:items-center md:gap-2 md:justify-end md:shrink-0">
-                      <span className="text-xs text-muted-foreground self-center md:hidden">
-                        Thao tác
-                      </span>
-                      <div className="flex flex-wrap items-center gap-2">
-                      {/* View button for uploaded documents */}
-                      {hasFile && (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => handleViewDocument(doc.file_path!)}
-                          title="Xem tài liệu"
-                          aria-label="Xem tài liệu"
-                        >
-                          <Eye className="h-4 w-4" />
-                        </Button>
+                      {state.hasAnyAction && (
+                        <div className="mt-3 pt-3 border-t">
+                          <DocumentRowActions
+                            doc={doc}
+                            state={state}
+                            isUploading={isUploadingForCode(doc.code)}
+                            isPaperPending={isPaperPendingForCode(doc.code)}
+                            isResetPending={resetMutation.isPending}
+                            isCurrentResetTarget={isResetPendingForCode(doc.code)}
+                            onView={handleViewDocument}
+                            onUpload={handleUploadClick}
+                            onPaperSubmit={handlePaperSubmit}
+                            onRejectClick={handleRejectClick}
+                            onResetClick={handleResetClick}
+                          />
+                        </div>
                       )}
-
-                      {/* Upload action — requires_upload=true rows. Label is
-                          "Tải file" to match the task-oriented hint above. */}
-                      {canUpload && (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleUploadClick(doc.code, doc.label, doc.submission_format ?? undefined)}
-                          disabled={uploadMutation.isPending}
-                          aria-label="Tải file"
-                        >
-                          {isUploading ? (
-                            <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                          ) : (
-                            <Upload className="h-4 w-4 mr-1" />
-                          )}
-                          Tải file
-                        </Button>
-                      )}
-
-                      {/* Paper-receipt action — requires_upload=false rows.
-                          Officer-only by backend permission flag. The spec
-                          replaced the old "Đã nộp" checkbox with an explicit
-                          button so the action is unambiguous. */}
-                      {canMarkPaperSubmitted && (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handlePaperSubmit(doc.code, doc.label, doc.submission_format ?? undefined)}
-                          disabled={isPaperPending}
-                          aria-label="Đánh dấu đã nhận giấy"
-                        >
-                          {isPaperPending ? (
-                            <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                          ) : (
-                            <Building2 className="h-4 w-4 mr-1" />
-                          )}
-                          Đánh dấu đã nhận giấy
-                        </Button>
-                      )}
-
-                      {/* Paper already submitted indicator */}
-                      {isPaperDoc && doc.status === "paper_submitted" && (
-                        <Check className="h-4 w-4 text-success-600" />
-                      )}
-                      
-                      {/* Reject Button (Officer Only) */}
-                      {canReject && (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="text-error-600 hover:text-error-700 hover:bg-error-50"
-                          onClick={() => handleRejectClick(doc.code, doc.label)}
-                          title="Từ chối tài liệu"
-                          aria-label="Từ chối"
-                        >
-                          <Ban className="h-4 w-4" />
-                        </Button>
-                      )}
-
-                      {/* Reset/Undo Button — gated by backend can_reset flag */}
-                      {canReset && (
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          className="text-warning-600 hover:text-warning-700 hover:bg-warning-50"
-                          onClick={() => setPendingResetDoc({ code: doc.code, label: doc.label })}
-                          disabled={resetMutation.isPending}
-                          title="Hoàn tác (đưa về trạng thái chưa nộp)"
-                          aria-label="Đặt lại"
-                        >
-                          {resetMutation.isPending && resetMutation.variables === doc.code ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                          ) : (
-                            <RotateCcw className="h-4 w-4" />
-                          )}
-                        </Button>
-                      )}
-                      </div>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            </>
           )}
         </CardContent>
-        
-        {/* Hidden File Input */}
-        <input 
-          type="file" 
-          ref={fileInputRef} 
-          className="hidden" 
+
+        {/* Hidden file input */}
+        <input
+          type="file"
+          ref={fileInputRef}
+          className="hidden"
           onChange={handleFileChange}
           accept={acceptAttr}
+          aria-describedby="documents-upload-rules"
         />
       </Card>
-      
-      {/* Submission Format Selection Dialog
-          Officer / applicant declares the *actual* paper/file type they
-          just received. ADM-031 round 2 splits the wording per action so
-          the upload flow ("File này là bản gì?") and the paper-receipt
-          flow ("Bản giấy vừa nhận là bản gì?") are unambiguous. The dialog
-          deliberately does NOT ask for an extra evidence document. */}
+
+      {/* Submission Format Selection Dialog */}
       <Dialog
         open={submissionFormatDialog?.isOpen || false}
         onOpenChange={(open) => !open && setSubmissionFormatDialog(null)}
@@ -711,7 +1089,7 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
             {DOCUMENT_FORMAT_OPTIONS.map((option) => (
               <div
                 key={option.value}
-                className="flex items-center space-x-2 p-3 border rounded-lg hover:bg-muted/50 transition-colors"
+                className="flex items-center space-x-2 p-3 border rounded-lg hover:bg-muted/50 motion-reduce:transition-none"
               >
                 <RadioGroupItem value={option.value} id={option.value} />
                 <Label htmlFor={option.value} className="flex-1 cursor-pointer">
@@ -724,11 +1102,6 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
             ))}
           </RadioGroup>
 
-          {/* Soft warning — selected actual format does not match the
-              required format. Allowed (officer may still proceed) but
-              flagged so officer notices any mismatch before saving.
-              Wording is action-aware: upload flow says "trước khi tải
-              file"; paper flow says "trước khi ghi nhận". */}
           {submissionFormatDialog?.requiredFormat &&
             selectedFormat &&
             selectedFormat !== submissionFormatDialog.requiredFormat && (
@@ -736,7 +1109,10 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
                 className="flex items-start gap-2 rounded-md border border-warning-300 bg-warning-50 px-3 py-2 text-sm text-warning-800"
                 role="alert"
               >
-                <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                <AlertTriangle
+                  className="h-4 w-4 mt-0.5 flex-shrink-0"
+                  aria-hidden="true"
+                />
                 <span>
                   {submissionFormatDialog.action === "paper"
                     ? "Bản giấy thực tế khác yêu cầu hồ sơ. Hãy kiểm tra lại trước khi ghi nhận."
@@ -753,42 +1129,56 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
               onClick={handleSubmissionFormatConfirm}
               disabled={!selectedFormat}
             >
-              {submissionFormatDialog?.action === "paper" ? "Ghi nhận giấy" : "Tải file"}
+              {submissionFormatDialog?.action === "paper"
+                ? "Ghi nhận giấy"
+                : "Tải file"}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
       {/* Rejection Dialog */}
-      <Dialog open={!!rejectItem} onOpenChange={(open) => !open && setRejectItem(null)}>
+      <Dialog
+        open={!!rejectItem}
+        onOpenChange={(open) => !open && setRejectItem(null)}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Từ chối tài liệu</DialogTitle>
             <DialogDescription>
-              Vui lòng nhập lý do từ chối tài liệu <strong>{rejectItem?.label}</strong>.
-              Học sinh sẽ nhận được thông báo để nộp lại.
+              Vui lòng nhập lý do từ chối tài liệu{" "}
+              <strong>{rejectItem?.label}</strong>. Học sinh sẽ nhận được thông
+              báo để nộp lại.
             </DialogDescription>
           </DialogHeader>
 
           <div className="py-4">
-            <Label htmlFor="reject-reason" className="mb-2 block">Lý do từ chối</Label>
+            <Label htmlFor="reject-reason" className="mb-2 block">
+              Lý do từ chối
+            </Label>
             <Textarea
               id="reject-reason"
-              placeholder="VD: Tài liệu mờ, không đúng định dạng..."
+              placeholder="VD: Tài liệu mờ, không đúng định dạng…"
               value={rejectReason}
               onChange={(e) => setRejectReason(e.target.value)}
               rows={3}
+              autoFocus
+              spellCheck={false}
             />
           </div>
 
           <DialogFooter>
-            <Button variant="outline" onClick={() => setRejectItem(null)}>Huỷ</Button>
+            <Button variant="outline" onClick={() => setRejectItem(null)}>
+              Huỷ
+            </Button>
             <Button
               variant="destructive"
               onClick={confirmReject}
               disabled={rejectMutation.isPending || !rejectReason.trim()}
             >
-              {rejectMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {rejectMutation.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin motion-reduce:animate-none" />
+              )}
               Xác nhận từ chối
             </Button>
           </DialogFooter>
@@ -796,25 +1186,26 @@ export function DocumentsTab({ profile, isEditable: _isEditable }: DocumentsTabP
       </Dialog>
 
       {/* Reset/Undo Document Confirmation Dialog */}
-      <AlertDialog open={!!pendingResetDoc} onOpenChange={(open) => !open && setPendingResetDoc(null)}>
+      <AlertDialog
+        open={!!pendingResetDoc}
+        onOpenChange={(open) => !open && setPendingResetDoc(null)}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Hoàn tác tài liệu?</AlertDialogTitle>
             <AlertDialogDescription>
               Hoàn tác tài liệu &ldquo;{pendingResetDoc?.label}&rdquo;?
-              {"\n\n"}Tài liệu sẽ về trạng thái &ldquo;Chưa nộp&rdquo; và file sẽ bị xóa (nếu có).
             </AlertDialogDescription>
+            <p className="text-sm text-muted-foreground">
+              Tài liệu sẽ về trạng thái &ldquo;Chưa nộp&rdquo; và file sẽ bị xóa
+              (nếu có).
+            </p>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Hủy</AlertDialogCancel>
             <AlertDialogAction
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={() => {
-                if (pendingResetDoc) {
-                  resetMutation.mutate(pendingResetDoc.code)
-                }
-                setPendingResetDoc(null)
-              }}
+              onClick={handleResetConfirm}
             >
               Hoàn tác
             </AlertDialogAction>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/DocumentChecklist.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/DocumentChecklist.tsx
@@ -41,7 +41,7 @@ import { useState } from "react"
 import {
   getDocumentStatusConfig,
   getFormatLabel,
-  formatDateTime,
+  DOCUMENT_FORMAT_OPTIONS,
 } from "@/lib/utils/admission-helpers"
 import { useVerifyDocument, useRejectDocument } from "@/hooks/admissions"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
@@ -293,9 +293,12 @@ function DocumentRow({
 
         <TableCell className="text-center">
           {status === "verified" ? (
+            // "Đã kiểm tra" — officer-verified, fully complete. Distinct
+            // from "ghi nhận" states (uploaded / paper_submitted) which
+            // mean we received the row but haven't checked it yet.
             <Badge className="bg-success-600 hover:bg-success-700 gap-1">
               <CheckCircle2 className="w-3 h-3" />
-              Đã xác nhận
+              Đã kiểm tra
             </Badge>
           ) : (
             <Badge
@@ -318,9 +321,11 @@ function DocumentRow({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="original">Bản gốc</SelectItem>
-                <SelectItem value="certified_copy">Bản sao có công chứng</SelectItem>
-                <SelectItem value="photo">Bản photo/scan</SelectItem>
+                {DOCUMENT_FORMAT_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           ) : status === "verified" && doc.verified_format ? (

--- a/frontend/src/components/public/PublicDocumentsPage.tsx
+++ b/frontend/src/components/public/PublicDocumentsPage.tsx
@@ -13,6 +13,7 @@ import {
   publicAdmissionsMedia,
   publicDocumentBuckets,
 } from "@/lib/public-admissions/site"
+import { getFormatLabel } from "@/lib/utils/admission-helpers"
 import type {
   PublicAdmissionsDocumentRequirement,
   PublicAdmissionsDocumentsResponse,
@@ -22,18 +23,14 @@ interface PublicDocumentsPageProps {
   catalog?: PublicAdmissionsDocumentsResponse | null
 }
 
+// ADM-031.7 follow-up: use the shared `getFormatLabel` so applicant-facing
+// public docs and officer DocumentsTab agree on enum copy. Returns null
+// when the value is missing so the JSX can short-circuit the badge.
 function formatSubmissionFormat(value: string | null): string | null {
   if (!value) {
     return null
   }
-
-  const labels: Record<string, string> = {
-    photo: "Ảnh chụp hoặc scan",
-    certified_copy: "Bản sao công chứng",
-    original: "Bản gốc đối chiếu",
-  }
-
-  return labels[value] ?? value
+  return getFormatLabel(value)
 }
 
 function dedupeDocuments(

--- a/frontend/src/lib/utils/admission-helpers.ts
+++ b/frontend/src/lib/utils/admission-helpers.ts
@@ -64,19 +64,56 @@ export function getSubjectLabel(code: string): string {
 // ==============================================================================
 
 /**
- * Get Vietnamese label for document submission format.
- * @param format Format code (original | certified_copy | photo)
- * @returns Vietnamese format name
+ * Document submission format codes accepted by backend doc_configs and
+ * verify-format endpoints. Centralised so UI labels stay consistent across
+ * DocumentsTab, DocumentChecklist, and any future format picker.
  */
-export function getFormatLabel(format: string): string {
-  const labels: Record<string, string> = {
-    original: "Bản chính",
-    certified_copy: "Bản sao có chứng thực",
-    photo: "Bản photocopy",
-  }
+export type DocumentFormatCode = "original" | "certified_copy" | "photo"
 
-  return labels[format] ?? format
+const FORMAT_LABELS: Record<DocumentFormatCode, string> = {
+  original: "Bản gốc",
+  certified_copy: "Bản sao chứng thực",
+  photo: "Bản chụp/scan không chứng thực",
 }
+
+const FORMAT_DESCRIPTIONS: Record<DocumentFormatCode, string> = {
+  original: "Giấy tờ gốc do cơ quan có thẩm quyền cấp",
+  certified_copy: "Bản photocopy đã được công chứng/chứng thực",
+  photo: "Bản chụp ảnh hoặc scan, không có công chứng",
+}
+
+/**
+ * Get Vietnamese label for document submission format.
+ * Single source of truth — do not duplicate this map in components.
+ * @param format Format code (original | certified_copy | photo) or unknown
+ * @returns Vietnamese format name (falls back to raw code if unknown)
+ */
+export function getFormatLabel(format: string | null | undefined): string {
+  if (!format) return "-"
+  return FORMAT_LABELS[format as DocumentFormatCode] ?? format
+}
+
+/**
+ * Get short description for a document submission format.
+ * Used in pickers to clarify what each option physically represents.
+ */
+export function getFormatDescription(format: string | null | undefined): string {
+  if (!format) return ""
+  return FORMAT_DESCRIPTIONS[format as DocumentFormatCode] ?? ""
+}
+
+/**
+ * Ordered list of document format options for radio/select pickers.
+ */
+export const DOCUMENT_FORMAT_OPTIONS: ReadonlyArray<{
+  value: DocumentFormatCode
+  label: string
+  description: string
+}> = [
+  { value: "original", label: FORMAT_LABELS.original, description: FORMAT_DESCRIPTIONS.original },
+  { value: "certified_copy", label: FORMAT_LABELS.certified_copy, description: FORMAT_DESCRIPTIONS.certified_copy },
+  { value: "photo", label: FORMAT_LABELS.photo, description: FORMAT_DESCRIPTIONS.photo },
+]
 
 // ==============================================================================
 // DOCUMENT STATUS CONFIG
@@ -102,13 +139,16 @@ export function getDocumentStatusConfig(status: string): DocumentStatusConfig {
       iconName: "XCircle",
     },
     uploaded: {
+      // "Ghi nhận" (received) is intentionally distinct from "Kiểm tra"
+      // (verified). Officer still has to verify the upload before this row
+      // counts as fully complete.
       variant: "secondary",
-      label: "Đã tải lên",
+      label: "Đã ghi nhận (online)",
       iconName: "Upload",
     },
     verified: {
       variant: "default",
-      label: "Đã xác nhận",
+      label: "Đã kiểm tra",
       iconName: "CheckCircle2",
     },
     rejected: {
@@ -118,12 +158,31 @@ export function getDocumentStatusConfig(status: string): DocumentStatusConfig {
     },
     paper_submitted: {
       variant: "secondary",
-      label: "Nộp giấy",
+      label: "Đã nhận bản giấy",
       iconName: "FileText",
     },
   }
 
   return config[status] ?? config.missing
+}
+
+/**
+ * True when the row has been fully checked by an officer. Use this — not
+ * `status !== "missing"` — when computing "đã kiểm tra" progress so that
+ * uploaded / paper_submitted (received but not yet verified) don't get
+ * counted as complete.
+ */
+export function isDocumentVerified(status: string): boolean {
+  return status === "verified"
+}
+
+/**
+ * True when the row has been received in some form — either uploaded
+ * online or accepted as paper at the counter. Verified rows are also
+ * recorded.
+ */
+export function isDocumentRecorded(status: string): boolean {
+  return status === "uploaded" || status === "paper_submitted" || status === "verified"
 }
 
 // ==============================================================================

--- a/frontend/src/lib/utils/admission-helpers.ts
+++ b/frontend/src/lib/utils/admission-helpers.ts
@@ -103,6 +103,26 @@ export function getFormatDescription(format: string | null | undefined): string 
 }
 
 /**
+ * Compact format labels for dense surfaces like the documents table.
+ * Pair with `getFormatLabel` (full label) in the tooltip so the short
+ * form never strips meaning.
+ */
+const SHORT_FORMAT_LABELS: Record<DocumentFormatCode, string> = {
+  original: "Gốc",
+  certified_copy: "Chứng thực",
+  photo: "Chụp/scan",
+}
+
+/**
+ * Compact label for table cells / chips. Falls back to the raw code
+ * when unknown so callers don't render an empty cell.
+ */
+export function getShortFormatLabel(format: string | null | undefined): string {
+  if (!format) return "-"
+  return SHORT_FORMAT_LABELS[format as DocumentFormatCode] ?? format
+}
+
+/**
  * Ordered list of document format options for radio/select pickers.
  */
 export const DOCUMENT_FORMAT_OPTIONS: ReadonlyArray<{

--- a/frontend/src/lib/utils/admission-helpers.ts
+++ b/frontend/src/lib/utils/admission-helpers.ts
@@ -143,7 +143,7 @@ export function getDocumentStatusConfig(status: string): DocumentStatusConfig {
       // (verified). Officer still has to verify the upload before this row
       // counts as fully complete.
       variant: "secondary",
-      label: "Đã ghi nhận (online)",
+      label: "Đã ghi nhận file",
       iconName: "Upload",
     },
     verified: {

--- a/frontend/src/lib/utils/admission-helpers.ts
+++ b/frontend/src/lib/utils/admission-helpers.ts
@@ -167,10 +167,11 @@ export function getDocumentStatusConfig(status: string): DocumentStatusConfig {
 }
 
 /**
- * True when the row has been fully checked by an officer. Use this — not
- * `status !== "missing"` — when computing "đã kiểm tra" progress so that
- * uploaded / paper_submitted (received but not yet verified) don't get
- * counted as complete.
+ * True when the row has been fully checked by an officer. Use ONLY when
+ * you specifically need the "officer-verified" subset — for the
+ * mandatory-completion gauge, prefer ``isDocumentRequirementSatisfied``
+ * so that paper_submitted (which the backend already accepts as
+ * satisfying the requirement) is not surfaced as incomplete.
  */
 export function isDocumentVerified(status: string): boolean {
   return status === "verified"
@@ -183,6 +184,32 @@ export function isDocumentVerified(status: string): boolean {
  */
 export function isDocumentRecorded(status: string): boolean {
   return status === "uploaded" || status === "paper_submitted" || status === "verified"
+}
+
+/**
+ * ADM-031.6 follow-up: True when the row satisfies the backend's
+ * mandatory-document gate. Mirrors the strict-mode check at
+ * ``Backend_FastAPI/app/services/admission_service.py:566`` which
+ * accepts BOTH ``verified`` and ``paper_submitted`` as completing the
+ * requirement. ``uploaded`` (file received but officer hasn't verified
+ * yet) is intentionally excluded — that row is still pending check.
+ *
+ * Use this for the "Hoàn tất yêu cầu" / mandatory-progress metric so
+ * paper-only rows don't masquerade as incomplete just because they were
+ * never digitised.
+ */
+export function isDocumentRequirementSatisfied(status: string): boolean {
+  return status === "verified" || status === "paper_submitted"
+}
+
+/**
+ * ADM-031.6 follow-up: True when the row was uploaded online but still
+ * waits for officer verification. This is the "Chờ kiểm tra" bucket;
+ * surfacing it lets officers see the verification queue separately from
+ * fully completed rows.
+ */
+export function isDocumentPendingVerification(status: string): boolean {
+  return status === "uploaded"
 }
 
 // ==============================================================================

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -218,9 +218,10 @@ export const documentItemSchema = z.object({
    */
   verified_by: z.number().int().nullable().optional(),
   /**
-   * Display name of the verifier — backend resolves full_name → email →
-   * null via a batched User lookup (ADM-031 round 10). When null, the FE
-   * falls back to "User #<verified_by>".
+   * Display name of the verifier — backend resolves full_name → username
+   * via a batched User lookup (ADM-031 round 10). Email is intentionally
+   * NOT a fallback (staff-to-staff privacy). When null, the FE falls
+   * back to "User #<verified_by>".
    */
   verified_by_name: z.string().nullable().optional(),
   // ---------------------------------------------------------------------

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -217,6 +217,12 @@ export const documentItemSchema = z.object({
    * ID of officer who verified the document.
    */
   verified_by: z.number().int().nullable().optional(),
+  /**
+   * Display name of the verifier — backend resolves full_name → email →
+   * null via a batched User lookup (ADM-031 round 10). When null, the FE
+   * falls back to "User #<verified_by>".
+   */
+  verified_by_name: z.string().nullable().optional(),
   // ---------------------------------------------------------------------
   // PR #5 — explicit per-document permission flags.
   // Backend computes these per (role × doc status × profile status × unit

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -195,6 +195,13 @@ export const documentItemSchema = z.object({
     .string()
     .nullable()
     .optional(),
+  /**
+   * Paper-receipt timestamp — when officer marked the paper document as
+   * received. Surfaced in the FE so the "Đã ghi nhận" cell can show the
+   * receipt date for paper-only docs the same way it shows uploaded_at
+   * for online docs (ADM-031 round 7).
+   */
+  paper_submitted_at: z.string().nullable().optional(),
   rejection_reason: z.string().nullable().optional(),
   actual_submission_format: z.string().nullable().optional(),
   /**


### PR DESCRIPTION
## Summary
ADM-031 wave 7-2.5 (rounds 1-10 + 2 review fixup). Reworks the Documents tab on the admission profile detail page so officers see at a glance how many docs there are, what to do for each, and current status.

- 5-column responsive table (Tên | Yêu cầu | Đã ghi nhận | Trạng thái | Thao tác) + 4-tile KPI strip + mobile stacked card; icon-only Radix tooltip actions grouped (common/officer/manager).
- Workflow status labels aligned with backend strict-mode (round 9): `paper_submitted` is success-tinted "Đã nhận giấy" because backend counts it as satisfying the mandatory gate.
- Round 10 verifier identity: backend exposes `verified_at/verified_by/verified_by_name` (single batched User SELECT — N+1-free; full_name → username, email NEVER exposed for staff privacy). FE shows "<Tên> · dd/mm/yyyy" line under "Đã duyệt" badge with focusable button trigger + tooltip "Duyệt bởi <Tên> lúc dd/mm/yyyy hh:mm".
- **Round 10 review follow-up** (commits `7750ff41` + `a52b4fb2`):
  - **B1**: gate ALL artifact fields by `doc.status` in `_compute_frontend_fields`. Reject/reset paths leave columns dirty; response now suppresses unless status matches. Each terminal state shows only its own data.
  - **B2**: `reset_document` clears `verified_by` (was leaving user id while clearing verified_at).
  - **D1**: `STATUS_PRIORITY[paper_submitted] = 3` (sorts with verified, since it satisfies mandatory gate).
  - **E1**: paper-only docs keep `paper_submitted_at` as recorded date even at verified (was switching to null `uploaded_at`).
  - **D2**: KPI "Hoàn tất yêu cầu" headline = `mandatorySatisfied/mandatoryTotal`; total demoted to hint.
  - **B6**: Zod comment drift fixed.
  - **P3**: keyboard-focusable tooltip trigger.
  - **P2**: verifier name fallback `full_name → username` (not email).
  - **ESLint**: dropped `_isEditable` destructure; wrapped `documents` in useMemo.

## Test plan
- [x] Backend imports OK (`_compute_frontend_fields`, `_resolve_verifier_names`, `reset_document`).
- [x] Frontend type-check pass (`tsc --noEmit`).
- [x] Frontend production build pass.
- [x] DocumentsTab.test.tsx **35/35 pass** (33 pre-existing + 2 new for D1 sort + E1 paper-only verified date).
- [x] ESLint sạch trên file Lane A.
- [x] Dry-run merge into main: clean (no conflict).

## Deferred (separate PRs/follow-up)
- B3 / B4 / E3 — cần product confirm (verify on enrolled, paper_submitted policy mismatch, legacy doc-code drop).
- B5 — smoke prod cho legacy `verified_at` rows nếu có.
- G1 / G2 — ADM-032 cross-tab realtime + response-contract cleanup (`_populate_response_fields` standardization).

## Related
- Lane B parallel: `fix/admission-audit-w7-1-adm-026-quota` (ADM-026 quota enforcement) — verified merge-clean against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)