### PR TITLE
feat(admissions): ADM-026 annual quota enforcement with admin bypass + audit trail

### DIFF
--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -489,6 +489,43 @@ async def require_admin_or_manager(
     return current_user
 
 
+def require_admin_for_quota_bypass(
+    user: "models.User",
+    bypass_quota: bool,
+) -> None:
+    """
+    ADM-026: enforce admin-only access to ``bypass_quota=True``.
+
+    Called explicitly from approve / finalize / bulk-approve routers AFTER
+    the body is parsed but BEFORE the service is invoked. Mirrors the
+    "Smart Dependency, Dumb Router" rule (CLAUDE.md): bypass admin gate is
+    a request-entry concern, not a service concern. The service still
+    enforces the same rule in ``_assert_quota_or_bypass`` as
+    defense-in-depth, but blocking at the router boundary keeps invalid
+    requests out of the locked-row + audit-log path entirely (no wasted
+    DB roundtrip, no risk of partial state on bug-induced bypass).
+
+    Why a function and not a `Depends(...)`:
+        - The (bypass_quota, bypass_reason) pair lives on the body and
+          differs per schema (ApproveRequest / BulkApproveItem /
+          FinalizeRequest). A single FastAPI dependency would require
+          parametric body typing; calling this helper from each router
+          is straightforward and keeps the body contract explicit.
+        - For bulk routes, callers iterate request items and invoke
+          this helper per item before the service entry.
+
+    Raises:
+        PermissionDeniedError → mapped to 403 by exception handler.
+    """
+    if bypass_quota and user.role != UserRole.ADMIN:
+        raise PermissionDeniedError(
+            detail=(
+                "Chỉ Admin được phép ghi đè chỉ tiêu tuyển sinh "
+                "(bypass_quota). Role hiện tại: " + str(user.role) + "."
+            )
+        )
+
+
 async def require_finance_staff(
     current_user: models.User = Depends(get_current_active_user),
 ) -> models.User:

--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -489,43 +489,6 @@ async def require_admin_or_manager(
     return current_user
 
 
-def require_admin_for_quota_bypass(
-    user: "models.User",
-    bypass_quota: bool,
-) -> None:
-    """
-    ADM-026: enforce admin-only access to ``bypass_quota=True``.
-
-    Called explicitly from approve / finalize / bulk-approve routers AFTER
-    the body is parsed but BEFORE the service is invoked. Mirrors the
-    "Smart Dependency, Dumb Router" rule (CLAUDE.md): bypass admin gate is
-    a request-entry concern, not a service concern. The service still
-    enforces the same rule in ``_assert_quota_or_bypass`` as
-    defense-in-depth, but blocking at the router boundary keeps invalid
-    requests out of the locked-row + audit-log path entirely (no wasted
-    DB roundtrip, no risk of partial state on bug-induced bypass).
-
-    Why a function and not a `Depends(...)`:
-        - The (bypass_quota, bypass_reason) pair lives on the body and
-          differs per schema (ApproveRequest / BulkApproveItem /
-          FinalizeRequest). A single FastAPI dependency would require
-          parametric body typing; calling this helper from each router
-          is straightforward and keeps the body contract explicit.
-        - For bulk routes, callers iterate request items and invoke
-          this helper per item before the service entry.
-
-    Raises:
-        PermissionDeniedError → mapped to 403 by exception handler.
-    """
-    if bypass_quota and user.role != UserRole.ADMIN:
-        raise PermissionDeniedError(
-            detail=(
-                "Chỉ Admin được phép ghi đè chỉ tiêu tuyển sinh "
-                "(bypass_quota). Role hiện tại: " + str(user.role) + "."
-            )
-        )
-
-
 async def require_finance_staff(
     current_user: models.User = Depends(get_current_active_user),
 ) -> models.User:

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -367,6 +367,11 @@ async def bulk_approve_admissions(
     db: AsyncSession = Depends(database.get_db),
 ):
     """Bulk approve multiple admission profiles."""
+    # ADM-026 review (Major #1): per-item admin-only bypass enforcement
+    # at request entry. Service-side check is defense-in-depth.
+    for _item in body.items:
+        deps.require_admin_for_quota_bypass(current_user, _item.bypass_quota)
+
     try:
         result, callback = await admission_service.bulk_approve(
             db=db,
@@ -1437,6 +1442,11 @@ async def approve_admission(
     if current_user.role not in [UserRole.ADMIN, UserRole.MANAGER]:
          raise PermissionDeniedError("Only Managers or Admins can approve profiles")
 
+    # ADM-026 review (Major #1): admin-only quota bypass enforced at request
+    # entry. Service-side check in `_assert_quota_or_bypass` remains as
+    # defense-in-depth.
+    deps.require_admin_for_quota_bypass(current_user, data.bypass_quota)
+
     try:
         # 1. DELEGATE to Service (Service handles Locking + IDOR + bundle)
         result, callback = await admission_service.approve_profile(
@@ -1911,6 +1921,10 @@ async def finalize_enrollment(
     - 400: Invalid state transition or version mismatch
     - 404: Profile not found (or IDOR protection)
     """
+    # ADM-026 review (Major #1): admin-only quota bypass enforced at
+    # request entry; service-side check is defense-in-depth.
+    deps.require_admin_for_quota_bypass(current_user, data.bypass_quota)
+
     try:
         # 1. DELEGATE to Service (service handles bundle + commission)
         result, callback = await admission_service.finalize_profile(

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -367,11 +367,9 @@ async def bulk_approve_admissions(
     db: AsyncSession = Depends(database.get_db),
 ):
     """Bulk approve multiple admission profiles."""
-    # ADM-026 review (Major #1): per-item admin-only bypass enforcement
-    # at request entry. Service-side check is defense-in-depth.
-    for _item in body.items:
-        deps.require_admin_for_quota_bypass(current_user, _item.bypass_quota)
-
+    # ADM-026 review (Round 2): per-item bypass admin gate + audit live
+    # in the service. Router-level pre-gate removed so manager bypass
+    # attempts produce an audit row (one per attempted item).
     try:
         result, callback = await admission_service.bulk_approve(
             db=db,
@@ -1442,10 +1440,13 @@ async def approve_admission(
     if current_user.role not in [UserRole.ADMIN, UserRole.MANAGER]:
          raise PermissionDeniedError("Only Managers or Admins can approve profiles")
 
-    # ADM-026 review (Major #1): admin-only quota bypass enforced at request
-    # entry. Service-side check in `_assert_quota_or_bypass` remains as
-    # defense-in-depth.
-    deps.require_admin_for_quota_bypass(current_user, data.bypass_quota)
+    # ADM-026 review (Round 2): admin-only bypass + audit are enforced
+    # together inside `_assert_quota_or_bypass`. The router pre-gate was
+    # removed so that EVERY denied bypass attempt — including manager
+    # attempts — flows through the service path that writes the
+    # `quota_bypass_denied_*` audit row via a separate session. Audit
+    # contract trumps the early-return optimisation here; the lock + count
+    # roundtrip on a denied attempt is acceptable since denial is rare.
 
     try:
         # 1. DELEGATE to Service (Service handles Locking + IDOR + bundle)
@@ -1921,10 +1922,10 @@ async def finalize_enrollment(
     - 400: Invalid state transition or version mismatch
     - 404: Profile not found (or IDOR protection)
     """
-    # ADM-026 review (Major #1): admin-only quota bypass enforced at
-    # request entry; service-side check is defense-in-depth.
-    deps.require_admin_for_quota_bypass(current_user, data.bypass_quota)
-
+    # ADM-026 review (Round 2): bypass admin gate + audit live in
+    # ``_assert_quota_or_bypass``. Router pre-gate removed so denied
+    # attempts always produce an audit row (manager-bypass would skip
+    # the service if pre-gated at router level).
     try:
         # 1. DELEGATE to Service (service handles bundle + commission)
         result, callback = await admission_service.finalize_profile(

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -17,7 +17,7 @@ from datetime import date, datetime
 from typing import Annotated, Any, Dict, List, Literal, Optional
 import html
 
-from pydantic import BaseModel, EmailStr, Field, StringConstraints, field_validator, ConfigDict
+from pydantic import BaseModel, EmailStr, Field, StringConstraints, field_validator, model_validator, ConfigDict
 
 
 # ==============================================================================
@@ -843,6 +843,27 @@ class BulkApproveItem(BaseModel):
     """Single item in a bulk approve request."""
     profile_id: int = Field(..., description="Admission profile ID")
     version: int = Field(..., ge=1, description="Current profile version for optimistic locking")
+    # ADM-026: per-item quota bypass. Admin-only at service layer.
+    # bypass_reason min length validated cross-field below.
+    bypass_quota: bool = Field(
+        False,
+        description="ADM-026: Override annual_admission_quota cap (admin only). Requires bypass_reason.",
+    )
+    bypass_reason: Optional[str] = Field(
+        None,
+        max_length=1000,
+        description="ADM-026: Required when bypass_quota=true. Min 20 chars. Audit log evidence.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_bypass_pair(self) -> "BulkApproveItem":
+        if self.bypass_quota:
+            reason = (self.bypass_reason or "").strip()
+            if len(reason) < 20:
+                raise ValueError(
+                    "bypass_reason is required and must be at least 20 characters when bypass_quota=true"
+                )
+        return self
 
 
 class BulkApproveRequest(BaseModel):
@@ -1061,6 +1082,26 @@ class ApproveRequest(BaseModel):
         ge=1,
         description="REQUIRED: Current profile version for optimistic locking (prevents race conditions)"
     )
+    # ADM-026: quota bypass (admin only). Manager bypass → 403 at service layer.
+    bypass_quota: bool = Field(
+        False,
+        description="ADM-026: Override annual_admission_quota cap (admin only). Requires bypass_reason.",
+    )
+    bypass_reason: Optional[str] = Field(
+        None,
+        max_length=1000,
+        description="ADM-026: Required when bypass_quota=true. Min 20 chars. Audit log evidence.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_bypass_pair(self) -> "ApproveRequest":
+        if self.bypass_quota:
+            reason = (self.bypass_reason or "").strip()
+            if len(reason) < 20:
+                raise ValueError(
+                    "bypass_reason is required and must be at least 20 characters when bypass_quota=true"
+                )
+        return self
 
     model_config = ConfigDict(str_strip_whitespace=True)
 
@@ -1250,6 +1291,26 @@ class FinalizeRequest(BaseModel):
         ge=1,
         description="REQUIRED: Current profile version for optimistic locking (prevents race conditions)"
     )
+    # ADM-026: quota bypass at finalize (admin only).
+    bypass_quota: bool = Field(
+        False,
+        description="ADM-026: Override annual_admission_quota cap at finalize (admin only). Requires bypass_reason.",
+    )
+    bypass_reason: Optional[str] = Field(
+        None,
+        max_length=1000,
+        description="ADM-026: Required when bypass_quota=true. Min 20 chars. Audit log evidence.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_bypass_pair(self) -> "FinalizeRequest":
+        if self.bypass_quota:
+            reason = (self.bypass_reason or "").strip()
+            if len(reason) < 20:
+                raise ValueError(
+                    "bypass_reason is required and must be at least 20 characters when bypass_quota=true"
+                )
+        return self
 
     model_config = ConfigDict(str_strip_whitespace=True)
 

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -839,12 +839,23 @@ class AdmissionsPage(BaseModel):
 # BULK ACTION SCHEMAS
 # ==============================================================================
 
-class BulkApproveItem(BaseModel):
-    """Single item in a bulk approve request."""
-    profile_id: int = Field(..., description="Admission profile ID")
-    version: int = Field(..., ge=1, description="Current profile version for optimistic locking")
-    # ADM-026: per-item quota bypass. Admin-only at service layer.
-    # bypass_reason min length validated cross-field below.
+# ------------------------------------------------------------------------------
+# ADM-026 review (Nit): the (bypass_quota, bypass_reason) pair previously
+# carried three verbatim copies of the cross-field validator across
+# BulkApproveItem / ApproveRequest / FinalizeRequest. Extract into a single
+# mixin so the contract — "bypass requires a reason ≥20 chars" — has one
+# definition. ``model_validator(mode="after")`` defined on a base class
+# still fires on subclasses, so each schema picks the rule up by
+# inheritance and the audit log evidence-string format stays identical.
+# Admin-only enforcement still lives in the request-entry dependency
+# (``require_admin_for_quota_bypass`` in ``deps.py``) plus the service-side
+# defense-in-depth check inside ``_assert_quota_or_bypass``.
+# ------------------------------------------------------------------------------
+
+
+class _QuotaBypassMixin(BaseModel):
+    """Shared (bypass_quota, bypass_reason) pair + cross-field validator."""
+
     bypass_quota: bool = Field(
         False,
         description="ADM-026: Override annual_admission_quota cap (admin only). Requires bypass_reason.",
@@ -856,7 +867,7 @@ class BulkApproveItem(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _validate_bypass_pair(self) -> "BulkApproveItem":
+    def _validate_bypass_pair(self):
         if self.bypass_quota:
             reason = (self.bypass_reason or "").strip()
             if len(reason) < 20:
@@ -864,6 +875,15 @@ class BulkApproveItem(BaseModel):
                     "bypass_reason is required and must be at least 20 characters when bypass_quota=true"
                 )
         return self
+
+
+class BulkApproveItem(_QuotaBypassMixin):
+    """Single item in a bulk approve request."""
+    profile_id: int = Field(..., description="Admission profile ID")
+    version: int = Field(..., ge=1, description="Current profile version for optimistic locking")
+    # ADM-026: per-item quota bypass. Admin-only enforced at request entry
+    # (``require_admin_for_quota_bypass`` in ``deps.py``); service-side check
+    # in ``_assert_quota_or_bypass`` is defense-in-depth.
 
 
 class BulkApproveRequest(BaseModel):
@@ -1058,7 +1078,7 @@ class StudentResponse(BaseModel):
 # STATE TRANSITION SCHEMAS (State Machine)
 # ==============================================================================
 
-class ApproveRequest(BaseModel):
+class ApproveRequest(_QuotaBypassMixin):
     """
     Schema for approve action (Manager/Admin).
 
@@ -1071,6 +1091,10 @@ class ApproveRequest(BaseModel):
     - Requires Manager or Admin role
     - Optional approval notes
     - REQUIRED version for optimistic locking (CRITICAL FIX #4)
+
+    ADM-026: bypass_quota / bypass_reason inherited from _QuotaBypassMixin.
+    Admin-only enforced at request entry (``require_admin_for_quota_bypass``
+    in ``deps.py``); service ``_assert_quota_or_bypass`` is defense-in-depth.
     """
     notes: Optional[str] = Field(
         None,
@@ -1082,26 +1106,6 @@ class ApproveRequest(BaseModel):
         ge=1,
         description="REQUIRED: Current profile version for optimistic locking (prevents race conditions)"
     )
-    # ADM-026: quota bypass (admin only). Manager bypass → 403 at service layer.
-    bypass_quota: bool = Field(
-        False,
-        description="ADM-026: Override annual_admission_quota cap (admin only). Requires bypass_reason.",
-    )
-    bypass_reason: Optional[str] = Field(
-        None,
-        max_length=1000,
-        description="ADM-026: Required when bypass_quota=true. Min 20 chars. Audit log evidence.",
-    )
-
-    @model_validator(mode="after")
-    def _validate_bypass_pair(self) -> "ApproveRequest":
-        if self.bypass_quota:
-            reason = (self.bypass_reason or "").strip()
-            if len(reason) < 20:
-                raise ValueError(
-                    "bypass_reason is required and must be at least 20 characters when bypass_quota=true"
-                )
-        return self
 
     model_config = ConfigDict(str_strip_whitespace=True)
 
@@ -1276,7 +1280,7 @@ class OverrideRequest(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
 
-class FinalizeRequest(BaseModel):
+class FinalizeRequest(_QuotaBypassMixin):
     """
     Schema for finalize action (Admin only).
 
@@ -1285,32 +1289,14 @@ class FinalizeRequest(BaseModel):
     - Admin only
     - Creates Student record
     - REQUIRED version for optimistic locking (ADM-015)
+
+    ADM-026: bypass_quota / bypass_reason inherited from _QuotaBypassMixin.
     """
     version: int = Field(
         ...,
         ge=1,
         description="REQUIRED: Current profile version for optimistic locking (prevents race conditions)"
     )
-    # ADM-026: quota bypass at finalize (admin only).
-    bypass_quota: bool = Field(
-        False,
-        description="ADM-026: Override annual_admission_quota cap at finalize (admin only). Requires bypass_reason.",
-    )
-    bypass_reason: Optional[str] = Field(
-        None,
-        max_length=1000,
-        description="ADM-026: Required when bypass_quota=true. Min 20 chars. Audit log evidence.",
-    )
-
-    @model_validator(mode="after")
-    def _validate_bypass_pair(self) -> "FinalizeRequest":
-        if self.bypass_quota:
-            reason = (self.bypass_reason or "").strip()
-            if len(reason) < 20:
-                raise ValueError(
-                    "bypass_reason is required and must be at least 20 characters when bypass_quota=true"
-                )
-        return self
 
     model_config = ConfigDict(str_strip_whitespace=True)
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -270,6 +270,257 @@ def _check_idor_access(
     raise ResourceNotFoundError(f"Admission profile {profile.id} not found")
 
 
+# =========================================================================
+# ADM-026: Quota enforcement helpers
+# =========================================================================
+
+# Statuses that occupy a quota slot. These are profiles already committed to
+# the cohort: approved or further along the funnel. ``withdrawn`` and
+# pre-approval states (draft/submitted/rejected/resubmitted/revision_requested)
+# are NOT counted because they have not yet committed a seat.
+#
+# Note: ``enrolled`` profiles with ``is_dropped=True`` ARE still counted —
+# they took a seat that cannot be reassigned for the same academic year.
+# This matches the legal/compliance reading that quota = seats consumed,
+# not seats currently active.
+QUOTA_OCCUPYING_STATUSES = (
+    "approved",
+    "overridden",
+    "confirmed",
+    "enrolled",
+)
+
+
+async def _resolve_quota_context(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    *,
+    lock: bool = True,
+) -> tuple[Optional[models.OfferingAcademicInfo], Optional[int]]:
+    """
+    Resolve the OfferingAcademicInfo + quota for ``profile``.
+
+    Strategy:
+    1. Prefer ``applied_rules.academic_info_id`` (snapshotted at create_profile).
+    2. Fall back to (lead.offering_id, profile.academic_year) for legacy
+       profiles that pre-date the snapshot.
+
+    If ``lock=True`` (default), the OfferingAcademicInfo row is acquired
+    with ``FOR UPDATE`` to serialize concurrent approve/finalize calls
+    against the same offering — without it, two parallel transactions can
+    each see ``count < quota`` and both insert, blowing the cap by 1+.
+
+    Returns:
+        (academic_info, quota). ``quota`` is ``None`` when the field is
+        unset (treat as unlimited / quota disabled). ``academic_info`` is
+        ``None`` when the profile cannot be linked to an offering academic
+        info row (legacy profile without offering_id, or seed/test data).
+    """
+    from sqlalchemy import select as _select
+
+    applied_rules = profile.applied_rules or {}
+    academic_info_id = applied_rules.get("academic_info_id")
+
+    stmt = _select(models.OfferingAcademicInfo)
+    if academic_info_id:
+        stmt = stmt.where(models.OfferingAcademicInfo.id == academic_info_id)
+    else:
+        # Fallback: legacy profile. Need lead.offering_id + academic_year.
+        if not profile.lead or not getattr(profile.lead, "offering_id", None):
+            return (None, None)
+        stmt = stmt.where(
+            models.OfferingAcademicInfo.offering_id == profile.lead.offering_id,
+            models.OfferingAcademicInfo.academic_year == profile.academic_year,
+        )
+
+    if lock:
+        stmt = stmt.with_for_update()
+
+    result = await db.execute(stmt)
+    academic_info = result.scalar_one_or_none()
+    if academic_info is None:
+        return (None, None)
+    return (academic_info, academic_info.annual_admission_quota)
+
+
+async def _count_quota_occupying_profiles(
+    db: AsyncSession,
+    *,
+    offering_id: int,
+    academic_year: int,
+    exclude_profile_id: Optional[int] = None,
+) -> int:
+    """
+    Count AdmissionProfile rows that currently occupy a quota seat for the
+    given (offering, academic_year). Excludes ``exclude_profile_id`` so a
+    transition INTO a quota-occupying status doesn't double-count itself
+    when the profile is mid-update.
+    """
+    from sqlalchemy import select as _select, func as _func
+
+    stmt = (
+        _select(_func.count(models.AdmissionProfile.id))
+        .join(models.Lead, models.AdmissionProfile.lead_id == models.Lead.id)
+        .where(
+            models.Lead.offering_id == offering_id,
+            models.AdmissionProfile.academic_year == academic_year,
+            models.AdmissionProfile.status.in_(QUOTA_OCCUPYING_STATUSES),
+        )
+    )
+    if exclude_profile_id is not None:
+        stmt = stmt.where(models.AdmissionProfile.id != exclude_profile_id)
+
+    result = await db.execute(stmt)
+    return int(result.scalar_one() or 0)
+
+
+async def _assert_quota_or_bypass(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    actor: models.User,
+    bypass_quota: bool,
+    bypass_reason: Optional[str],
+    *,
+    transition: str,
+    source: str = "api",
+) -> None:
+    """
+    ADM-026: Enforce ``annual_admission_quota`` for transitions INTO
+    quota-occupying statuses (approve / finalize). Emits a durable
+    ``entity_audit_log`` row whenever an admin bypasses the cap.
+
+    Behaviour:
+    - Profile not yet in a quota status + count + 1 ≤ quota → pass silently.
+    - Count + 1 > quota and ``bypass_quota=False`` → raise
+      ``BusinessRuleViolation`` (the standard hard-cap error path).
+    - ``bypass_quota=True`` and ``actor.role != ADMIN`` → raise
+      ``PermissionDeniedError``. Manager cannot bypass under Q12 Option B.
+    - ``bypass_quota=True`` without a ≥20-char reason → raise
+      ``ValidationError``. Schema-level validators catch this earlier for
+      Pydantic-bound payloads, but service-layer callers (tests, internal
+      flows) must still satisfy the contract.
+    - ``bypass_quota=True`` from admin with valid reason → pass and write
+      ``entity_audit_log`` with ``action="quota_bypassed"`` + full
+      changeset (quota, count_before/after, actor, reason).
+
+    The OfferingAcademicInfo row is locked (``FOR UPDATE``) before the
+    count so concurrent approve/finalize transactions serialize and the
+    cap holds under load.
+
+    Args:
+        db: Active session (caller's transaction frame).
+        profile: AdmissionProfile being transitioned. Must have ``lead``
+            eager-loaded so the offering-id fallback works.
+        actor: User performing the action.
+        bypass_quota: Whether the caller asked to override the cap.
+        bypass_reason: Audit-trail evidence. Required iff
+            ``bypass_quota=True`` (≥20 chars).
+        transition: Short label for audit/log (e.g. ``"approve"``,
+            ``"finalize"``, ``"bulk_approve"``).
+        source: Audit ``source`` field. Defaults to ``"api"``.
+
+    Raises:
+        BusinessRuleViolation: cap reached and no bypass.
+        PermissionDeniedError: bypass requested by non-admin.
+        ValidationError: bypass requested without valid reason.
+    """
+    academic_info, quota = await _resolve_quota_context(db, profile, lock=True)
+
+    # No academic_info found OR quota=None → quota disabled / legacy data.
+    # Treat as unlimited (no enforcement). Log at debug for observability.
+    if academic_info is None or quota is None or quota <= 0:
+        log.debug(
+            "Quota check skipped (unlimited / unconfigured)",
+            profile_id=profile.id,
+            transition=transition,
+            academic_info_id=getattr(academic_info, "id", None),
+            quota=quota,
+        )
+        return
+
+    # Count seats currently occupied by other profiles. Exclude self so a
+    # finalize on an already-approved profile doesn't double-count.
+    offering_id = profile.lead.offering_id if profile.lead else None
+    if offering_id is None:
+        # Cannot count without offering scope. Skip enforcement for safety.
+        log.warning(
+            "Quota check skipped: profile has no lead.offering_id",
+            profile_id=profile.id,
+            transition=transition,
+        )
+        return
+
+    count_before = await _count_quota_occupying_profiles(
+        db,
+        offering_id=offering_id,
+        academic_year=profile.academic_year,
+        exclude_profile_id=profile.id,
+    )
+    # If profile is ALREADY in a quota status (e.g. finalize on an approved
+    # profile), it was excluded from count_before, so count_after = count_before.
+    # If profile is transitioning INTO a quota status from outside (e.g.
+    # approve from submitted), count_after = count_before + 1.
+    is_already_occupying = profile.status in QUOTA_OCCUPYING_STATUSES
+    count_after = count_before if is_already_occupying else count_before + 1
+
+    over_cap = count_after > quota
+
+    if not over_cap:
+        return  # Under cap, allow.
+
+    # Cap reached. Either bypass or block.
+    if not bypass_quota:
+        raise BusinessRuleViolation(
+            f"Vượt chỉ tiêu tuyển sinh: chỉ tiêu năm {profile.academic_year} là "
+            f"{quota} hồ sơ, hiện đã đầy ({count_before}/{quota}). "
+            "Liên hệ admin nếu cần ghi đè (bypass_quota=true + bypass_reason ≥20 ký tự)."
+        )
+
+    # Bypass path. Admin-only.
+    if actor.role != UserRole.ADMIN:
+        raise PermissionDeniedError(
+            "Chỉ Admin được phép ghi đè chỉ tiêu tuyển sinh (bypass_quota). "
+            f"Role hiện tại: {actor.role}."
+        )
+
+    reason = (bypass_reason or "").strip()
+    if len(reason) < 20:
+        raise ValidationError(
+            "bypass_reason là bắt buộc và phải có ít nhất 20 ký tự khi bypass_quota=true."
+        )
+
+    # Admin bypass authorized. Write durable audit log evidence.
+    from ..services import audit_service
+    await audit_service.log_audit(
+        db,
+        entity_type="AdmissionProfile",
+        entity_id=profile.id,
+        action="quota_bypassed",
+        actor_user_id=actor.id,
+        changes={
+            "quota": {"old": None, "new": quota},
+            "enrolled_count_before": {"old": None, "new": count_before},
+            "enrolled_count_after": {"old": None, "new": count_after},
+            "academic_info_id": {"old": None, "new": academic_info.id},
+            "academic_year": {"old": None, "new": profile.academic_year},
+            "offering_id": {"old": None, "new": offering_id},
+            "transition": {"old": None, "new": transition},
+        },
+        reason=reason,
+        source=source,
+    )
+    log.warning(
+        "ADM-026 quota cap bypassed by admin",
+        profile_id=profile.id,
+        transition=transition,
+        quota=quota,
+        count_before=count_before,
+        count_after=count_after,
+        actor_id=actor.id,
+        reason=reason[:80],
+    )
+
+
 async def check_enrollment_fee_eligibility(
     db: AsyncSession,
     profile_id: int,
@@ -4590,6 +4841,19 @@ async def approve_profile(
             "Vui lòng xác nhận thanh toán lệ phí trước khi duyệt hồ sơ."
         )
 
+    # ADM-026: quota gate. Locks the OfferingAcademicInfo row before
+    # counting committed seats so concurrent approve calls cannot blow the
+    # cap. Admin can override with bypass_quota + bypass_reason; manager
+    # gets 403; missing reason gets 400.
+    await _assert_quota_or_bypass(
+        db,
+        profile,
+        approver,
+        bypass_quota=bool(data.get("bypass_quota", False)),
+        bypass_reason=data.get("bypass_reason"),
+        transition="approve",
+    )
+
     # STATE CHANGE
     _old_status_for_audit = profile.status
     profile.status = "approved"
@@ -5843,6 +6107,21 @@ async def finalize_profile(
             "Please refresh and try again."
         )
 
+    # ADM-026: quota gate at finalize. Profile is already in a
+    # quota-occupying status (confirmed/overridden) at this point, so the
+    # transition into ``enrolled`` is net-zero on the count — but we still
+    # re-assert in case someone bypassed the approve gate or quota was
+    # reduced after approve. Locking the offering row also serializes
+    # concurrent finalize calls.
+    await _assert_quota_or_bypass(
+        db,
+        profile,
+        admin,
+        bypass_quota=bool(data.get("bypass_quota", False)),
+        bypass_reason=data.get("bypass_reason"),
+        transition="finalize",
+    )
+
     # Path C / Arch-3: delegate to shared `_perform_enrollment_core` (NOT
     # `enroll_student`) so finalize owns its own bundle without
     # double-dispatching the enroll bundle. Core handles the locked fetch +
@@ -7053,6 +7332,26 @@ async def bulk_approve(
             if requires_fee and fee_status == "pending":
                 failed_ids.append(profile_id)
                 errors[profile_id] = "Lệ phí xét tuyển chưa được thanh toán"
+                continue
+
+            # ADM-026: per-item quota gate. Per-item bypass fields let admin
+            # selectively override the cap for some profiles in the batch
+            # while letting others fail-fast. Errors map to per-item
+            # ``errors[profile_id]`` so the batch keeps moving (matches
+            # existing bulk error shape used for state/version/fee gates).
+            try:
+                await _assert_quota_or_bypass(
+                    db,
+                    profile,
+                    approver,
+                    bypass_quota=bool(item.get("bypass_quota", False)),
+                    bypass_reason=item.get("bypass_reason"),
+                    transition="bulk_approve",
+                    source="bulk_api",
+                )
+            except (BusinessRuleViolation, PermissionDeniedError, ValidationError) as quota_err:
+                failed_ids.append(profile_id)
+                errors[profile_id] = str(quota_err)
                 continue
 
             # STATE CHANGE

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -316,12 +316,10 @@ async def _resolve_quota_context(
         ``None`` when the profile cannot be linked to an offering academic
         info row (legacy profile without offering_id, or seed/test data).
     """
-    from sqlalchemy import select as _select
-
     applied_rules = profile.applied_rules or {}
     academic_info_id = applied_rules.get("academic_info_id")
 
-    stmt = _select(models.OfferingAcademicInfo)
+    stmt = select(models.OfferingAcademicInfo)
     if academic_info_id:
         stmt = stmt.where(models.OfferingAcademicInfo.id == academic_info_id)
     else:
@@ -356,10 +354,8 @@ async def _count_quota_occupying_profiles(
     transition INTO a quota-occupying status doesn't double-count itself
     when the profile is mid-update.
     """
-    from sqlalchemy import select as _select, func as _func
-
     stmt = (
-        _select(_func.count(models.AdmissionProfile.id))
+        select(func.count(models.AdmissionProfile.id))
         .join(models.Lead, models.AdmissionProfile.lead_id == models.Lead.id)
         .where(
             models.Lead.offering_id == offering_id,
@@ -477,7 +473,32 @@ async def _assert_quota_or_bypass(
         )
 
     # Bypass path. Admin-only.
+    #
+    # ADM-026 review (Major #3): denied bypass attempts also generate an
+    # audit row so compliance can reconstruct WHO tried to overflow the
+    # cap, not just who succeeded. Because denial raises, the caller's
+    # transaction rolls back — we use a fresh AsyncSessionLocal()
+    # (separate connection, separate transaction) for the audit write so
+    # the row persists regardless of the outer rollback. Action codes:
+    #   * quota_bypass_denied_role    — non-admin tried bypass
+    #   * quota_bypass_denied_reason  — admin tried bypass without ≥20-char reason
+    #   * quota_bypassed              — admin success path (existing)
     if actor.role != UserRole.ADMIN:
+        await _audit_quota_bypass_denied(
+            entity_id=profile.id,
+            actor=actor,
+            denial_action="quota_bypass_denied_role",
+            denial_detail=f"role={actor.role}",
+            quota=quota,
+            count_before=count_before,
+            count_after=count_after,
+            academic_info_id=academic_info.id,
+            academic_year=profile.academic_year,
+            offering_id=offering_id,
+            transition=transition,
+            source=source,
+            attempted_reason=bypass_reason,
+        )
         raise PermissionDeniedError(
             "Chỉ Admin được phép ghi đè chỉ tiêu tuyển sinh (bypass_quota). "
             f"Role hiện tại: {actor.role}."
@@ -485,11 +506,26 @@ async def _assert_quota_or_bypass(
 
     reason = (bypass_reason or "").strip()
     if len(reason) < 20:
+        await _audit_quota_bypass_denied(
+            entity_id=profile.id,
+            actor=actor,
+            denial_action="quota_bypass_denied_reason",
+            denial_detail=f"reason_len={len(reason)}",
+            quota=quota,
+            count_before=count_before,
+            count_after=count_after,
+            academic_info_id=academic_info.id,
+            academic_year=profile.academic_year,
+            offering_id=offering_id,
+            transition=transition,
+            source=source,
+            attempted_reason=bypass_reason,
+        )
         raise ValidationError(
             "bypass_reason là bắt buộc và phải có ít nhất 20 ký tự khi bypass_quota=true."
         )
 
-    # Admin bypass authorized. Write durable audit log evidence.
+    # Admin bypass authorized. Write durable audit log evidence (success path).
     from ..services import audit_service
     await audit_service.log_audit(
         db,
@@ -519,6 +555,76 @@ async def _assert_quota_or_bypass(
         actor_id=actor.id,
         reason=reason[:80],
     )
+
+
+async def _audit_quota_bypass_denied(
+    *,
+    entity_id: int,
+    actor: models.User,
+    denial_action: str,
+    denial_detail: str,
+    quota: int,
+    count_before: int,
+    count_after: int,
+    academic_info_id: int,
+    academic_year: int,
+    offering_id: int,
+    transition: str,
+    source: str,
+    attempted_reason: Optional[str],
+) -> None:
+    """
+    ADM-026 review (Major #3): persist a denied bypass-attempt audit row.
+
+    Runs in its OWN session (``AsyncSessionLocal``) and commits
+    independently so the audit row survives the caller's rollback. The
+    caller is about to raise (PermissionDeniedError or ValidationError),
+    which will tear down the route's transaction frame; without an
+    independent session, the audit write would also rollback and the
+    attempt would leave no trace.
+
+    Best-effort: any exception here is logged but swallowed so we never
+    convert "bypass denied" into "bypass denied + 500 audit error".
+    """
+    from ..database import AsyncSessionLocal
+    from ..services import audit_service
+
+    try:
+        async with AsyncSessionLocal() as audit_db:
+            await audit_service.log_audit(
+                audit_db,
+                entity_type="AdmissionProfile",
+                entity_id=entity_id,
+                action=denial_action,
+                actor_user_id=actor.id,
+                changes={
+                    "denial_detail": {"old": None, "new": denial_detail},
+                    "quota": {"old": None, "new": quota},
+                    "enrolled_count_before": {"old": None, "new": count_before},
+                    "enrolled_count_after": {"old": None, "new": count_after},
+                    "academic_info_id": {"old": None, "new": academic_info_id},
+                    "academic_year": {"old": None, "new": academic_year},
+                    "offering_id": {"old": None, "new": offering_id},
+                    "transition": {"old": None, "new": transition},
+                    # Only store reason text when it had any content; admins'
+                    # short-reason attempts are still useful evidence.
+                    "attempted_reason": {
+                        "old": None,
+                        "new": (attempted_reason or "").strip()[:1000] or None,
+                    },
+                },
+                reason=denial_detail,
+                source=source,
+            )
+            await audit_db.commit()
+    except Exception as audit_err:  # noqa: BLE001 — best-effort, never block denial
+        log.error(
+            "ADM-026 audit write FAILED for denied bypass attempt",
+            entity_id=entity_id,
+            denial_action=denial_action,
+            actor_id=actor.id,
+            error=str(audit_err),
+        )
 
 
 async def check_enrollment_fee_eligibility(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -422,11 +422,23 @@ async def _assert_quota_or_bypass(
     """
     academic_info, quota = await _resolve_quota_context(db, profile, lock=True)
 
-    # No academic_info found OR quota=None → quota disabled / legacy data.
-    # Treat as unlimited (no enforcement). Log at debug for observability.
-    if academic_info is None or quota is None or quota <= 0:
+    # ADM-026 review (Round 2): three distinct quota states must be
+    # disambiguated. Conflating them was the original bug.
+    #   academic_info missing → unconfigured / legacy → SKIP (no enforcement)
+    #   quota IS NULL         → "unlimited"          → SKIP (no enforcement)
+    #   quota <= 0            → "offering closed"    → BLOCK ALL approves
+    #
+    # Schema currently allows annual_admission_quota = 0 (ge=0). Treating 0
+    # as unlimited would let admin/manager admit unbounded students into a
+    # deliberately closed cohort. Instead, 0 (or negative for safety) is a
+    # hard block — the only escape is admin bypass with the standard reason
+    # contract. This is the safe interpretation; if product wants a
+    # different model later (e.g. force schema to ge=1, or rename "0" to
+    # "frozen with admin override"), update both schema and this gate
+    # together.
+    if academic_info is None or quota is None:
         log.debug(
-            "Quota check skipped (unlimited / unconfigured)",
+            "Quota check skipped (unconfigured / unlimited)",
             profile_id=profile.id,
             transition=transition,
             academic_info_id=getattr(academic_info, "id", None),

--- a/Backend_FastAPI/tests/services/test_admission_quota.py
+++ b/Backend_FastAPI/tests/services/test_admission_quota.py
@@ -774,6 +774,210 @@ class TestQuotaConcurrentRace:
 
 
 # =========================================================================
+# ADM-026 review (Round 2): bulk autoflush-counted overflow
+# =========================================================================
+
+
+class TestQuotaBulkAutoflush:
+    """
+    Bulk approve must observe IN-BATCH inserts when checking the cap.
+    ``_assert_quota_or_bypass`` re-runs ``_count_quota_occupying_profiles``
+    for every item; that count must see the prior items' status updates
+    that were flushed earlier in the same batch (audit_service.log_audit
+    + sync_lead_from_admission both call ``db.flush()`` per item, even
+    though the sessionmaker has ``autoflush=False``).
+
+    Failure mode if this regresses: cap=2, 0 currently approved, batch
+    of 3 → all 3 approved (cap blown by 1). This test pins the contract
+    by asserting per-item outcomes AND by introspecting the per-item
+    error message to prove the count progression actually saw the
+    in-batch inserts.
+    """
+
+    async def test_bulk_overflow_detected_via_in_batch_autoflush(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        seeds = await _seed_offering_with_quota(
+            quota=2,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="autoflush",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER,
+            unit_id=seeds["unit_id"],
+            suffix="autoflush_mgr",
+        )
+        # Start clean: NO existing approved profiles. Items 1+2 must
+        # succeed (count goes 0→1→2 within the batch); item 3 must fail
+        # with the count_before reflecting items 1+2.
+        pids = []
+        for i in range(3):
+            pids.append(
+                await _seed_lead_and_profile(
+                    seeds=seeds,
+                    citizen_id=f"20000000040{i}",
+                    status="submitted",
+                )
+            )
+
+        async with AsyncSessionLocal() as session:
+            result, _cb = await admission_service.bulk_approve(
+                db=session,
+                items=[{"profile_id": pid, "version": 1} for pid in pids],
+                approver=manager,
+                notes="Autoflush contract test",
+            )
+            await session.commit()
+
+        # Items 1+2 succeed, item 3 fails because in-batch count saw
+        # items 1+2 already approved.
+        assert result["success_count"] == 2, (
+            f"Autoflush regression: expected 2 successes, got "
+            f"{result['success_count']}. Bulk likely missing per-item flush "
+            f"between items — item 3 saw count=0 instead of count=2."
+        )
+        assert result["failed_count"] == 1
+        assert pids[2] in result["failed_ids"]
+
+        # Stronger assertion: error message for item 3 mentions "2/2" so
+        # we can prove the count_before observed the in-batch inserts.
+        err_msg = result["errors"][pids[2]]
+        assert "2/2" in err_msg or "đã đầy" in err_msg.lower(), (
+            f"Item 3 error didn't reference cap-full state: {err_msg!r}"
+        )
+
+        # DB invariant: exactly 2 of the 3 profiles ended in 'approved'.
+        async with AsyncSessionLocal() as session:
+            approved = (
+                await session.execute(
+                    select(models.AdmissionProfile.id).where(
+                        models.AdmissionProfile.id.in_(pids),
+                        models.AdmissionProfile.status == "approved",
+                    )
+                )
+            ).scalars().all()
+            assert len(approved) == 2
+
+
+# =========================================================================
+# ADM-026 review (Round 2): quota=0 means "offering closed", not unlimited
+# =========================================================================
+
+
+class TestQuotaZeroBlocks:
+    """
+    Schema currently allows annual_admission_quota = 0 (ge=0). Conflating
+    that with quota = NULL (unlimited) would let staff admit unbounded
+    students into a deliberately closed cohort. ADM-026 round-2 fix:
+    quota=0 blocks ALL approves; only NULL means unlimited. Admin bypass
+    with valid reason still works as a documented escape hatch.
+    """
+
+    async def test_quota_zero_blocks_approve_without_bypass(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        seeds = await _seed_offering_with_quota(
+            quota=0,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="zero_block",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER,
+            unit_id=seeds["unit_id"],
+            suffix="zero_block_mgr",
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000600", status="submitted"
+        )
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                with pytest.raises(BusinessRuleViolation):
+                    await admission_service._assert_quota_or_bypass(
+                        session,
+                        profile,
+                        manager,
+                        bypass_quota=False,
+                        bypass_reason=None,
+                        transition="approve",
+                    )
+
+    async def test_quota_zero_admin_bypass_still_works(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """Admin bypass with valid reason is the documented escape."""
+        seeds = await _seed_offering_with_quota(
+            quota=0,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="zero_bypass",
+        )
+        admin = await _make_user(
+            role=UserRole.ADMIN,
+            unit_id=seeds["unit_id"],
+            suffix="zero_bypass_admin",
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000610", status="submitted"
+        )
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                # Should NOT raise — admin override on quota=0 cohort.
+                await admission_service._assert_quota_or_bypass(
+                    session,
+                    profile,
+                    admin,
+                    bypass_quota=True,
+                    bypass_reason=(
+                        "Cohort closed (quota=0) but admit per Hiệu Trưởng "
+                        "directive 2026-04-29."
+                    ),
+                    transition="approve",
+                )
+
+    async def test_quota_null_remains_unlimited(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """quota=None still means unlimited (no enforcement)."""
+        seeds = await _seed_offering_with_quota(
+            quota=None,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="null_unlimited",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER,
+            unit_id=seeds["unit_id"],
+            suffix="null_mgr",
+        )
+        # Even with several already approved, quota=None lets next pass.
+        for i in range(3):
+            await _seed_lead_and_profile(
+                seeds=seeds,
+                citizen_id=f"20000000062{i}",
+                status="approved",
+            )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000625", status="submitted"
+        )
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                # No raise — quota=None means unlimited.
+                await admission_service._assert_quota_or_bypass(
+                    session,
+                    profile,
+                    manager,
+                    bypass_quota=False,
+                    bypass_reason=None,
+                    transition="approve",
+                )
+
+
+# =========================================================================
 # ADM-026 review (Major #3): denied bypass attempts produce audit rows
 # =========================================================================
 

--- a/Backend_FastAPI/tests/services/test_admission_quota.py
+++ b/Backend_FastAPI/tests/services/test_admission_quota.py
@@ -1,0 +1,686 @@
+"""
+ADM-026: Quota enforcement tests.
+
+Validates ``_assert_quota_or_bypass`` semantics for approve / bulk_approve /
+finalize. Hits the real DB via ``AsyncSessionLocal`` (matches existing
+``test_admission_workflow.py`` pattern).
+
+Cases covered:
+1. Under-cap approve → passes silently.
+2. At-cap approve without bypass → ``BusinessRuleViolation``.
+3. At-cap approve with admin bypass + valid reason → passes + audit row.
+4. At-cap approve with manager bypass → ``PermissionDeniedError``.
+5. At-cap approve with admin bypass but short reason → ``ValidationError``.
+6. Bulk approve mixed: under-cap items succeed, over-cap third raises into
+   ``errors`` map without rolling back the batch.
+7. Finalize on already-approved profile → passes (already in count, net-zero).
+8. Quota=None (legacy / unconfigured) → enforcement skipped.
+9. Withdrawn profile does NOT count toward cap.
+"""
+
+import pytest
+from sqlalchemy import select
+
+from app import models
+from app.core.constants import UserRole
+from app.database import AsyncSessionLocal
+from app.services import admission_service
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    PermissionDeniedError,
+    ValidationError,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# =========================================================================
+# Test fixtures (reuse seed_lead_dependencies for unit + major)
+# =========================================================================
+
+
+async def _seed_offering_with_quota(
+    *,
+    quota: int | None,
+    seed_major_program_id: int,
+    seed_unit_id: int,
+    academic_year: int = 2026,
+    suffix: str = "",
+) -> dict:
+    """
+    Create a unique ProgramOffering + OfferingAcademicInfo for one test.
+    Reuses unit + major seeded by ``seed_lead_dependencies`` so each test
+    case isolates only on the offering+academic_info rows the quota helper
+    actually reads.
+    """
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            offering = models.ProgramOffering(
+                offering_type=f"ADM-026 Offering {suffix}",
+                program_id=seed_major_program_id,
+                is_active=True,
+            )
+            session.add(offering)
+            await session.flush()
+
+            academic_info = models.OfferingAcademicInfo(
+                academic_year=academic_year,
+                annual_admission_quota=quota,
+                offering_id=offering.id,
+                is_published=True,
+            )
+            session.add(academic_info)
+            await session.flush()
+
+            return {
+                "unit_id": seed_unit_id,
+                "offering_id": offering.id,
+                "academic_info_id": academic_info.id,
+                "academic_year": academic_year,
+            }
+
+
+async def _seed_lead_and_profile(
+    *,
+    seeds: dict,
+    citizen_id: str,
+    status: str,
+    assigned_officer_id: int | None = None,
+) -> int:
+    """Create a lead + profile in given status for a seeded offering. Returns profile_id."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            lead = models.Lead(
+                full_name=f"Quota Test {citizen_id}",
+                phone=f"09{citizen_id[-9:]}",
+                email=f"q{citizen_id}@test.com",
+                source="website",
+                unit_id=seeds["unit_id"],
+                offering_id=seeds["offering_id"],
+                assigned_officer_id=assigned_officer_id,
+            )
+            session.add(lead)
+            await session.flush()
+
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                status=status,
+                citizen_id=citizen_id,
+                academic_year=seeds["academic_year"],
+                version=1,
+                applied_rules={
+                    "academic_info_id": seeds["academic_info_id"],
+                    "min_gpa": 0,
+                    "mandatory_docs": [],
+                },
+            )
+            session.add(profile)
+            await session.flush()
+            return profile.id
+
+
+async def _make_user(
+    *,
+    role: str,
+    unit_id: int,
+    suffix: str,
+) -> models.User:
+    """Create a test user. Caller passes a unique ``suffix`` per case."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            user = models.User(
+                username=f"adm026_{suffix}",
+                email=f"adm026_{suffix}@test.com",
+                full_name=f"ADM-026 {suffix}",
+                password_hash="x",
+                role=role,
+                unit_id=unit_id,
+            )
+            session.add(user)
+            await session.flush()
+            # Detach so callers can use the instance after the session closes.
+            session.expunge(user)
+            return user
+
+
+async def _reload_profile(profile_id: int) -> models.AdmissionProfile:
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(models.AdmissionProfile)
+            .where(models.AdmissionProfile.id == profile_id)
+        )
+        return result.scalar_one()
+
+
+async def _profile_with_lead(session, profile_id: int) -> models.AdmissionProfile:
+    """Eager-load lead so the helper's offering-id fallback works."""
+    from sqlalchemy.orm import selectinload
+
+    result = await session.execute(
+        select(models.AdmissionProfile)
+        .where(models.AdmissionProfile.id == profile_id)
+        .options(selectinload(models.AdmissionProfile.lead))
+    )
+    return result.scalar_one()
+
+
+# =========================================================================
+# Tests
+# =========================================================================
+
+
+class TestQuotaHelper:
+    """Direct unit tests of ``_assert_quota_or_bypass``."""
+
+    async def test_under_cap_passes(self, setup_test_database, seed_lead_dependencies):
+        """Cap=2, currently 0 approved → next approve attempt allowed under cap."""
+        seeds = await _seed_offering_with_quota(
+            quota=2,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="under",
+        )
+        admin = await _make_user(
+            role=UserRole.ADMIN, unit_id=seeds["unit_id"], suffix="under_admin"
+        )
+        # Profile is in submitted (not yet occupying a seat).
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000001", status="submitted"
+        )
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                # No raise expected.
+                await admission_service._assert_quota_or_bypass(
+                    session,
+                    profile,
+                    admin,
+                    bypass_quota=False,
+                    bypass_reason=None,
+                    transition="approve",
+                )
+
+    async def test_at_cap_blocks_without_bypass(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """Cap=2, 2 already approved → 3rd approve raises BusinessRuleViolation."""
+        seeds = await _seed_offering_with_quota(
+            quota=2,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="atcap",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="atcap_mgr"
+        )
+        # Two already-approved profiles fill the quota.
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000010", status="approved"
+        )
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000011", status="approved"
+        )
+        # Third profile, still in submitted, attempting to approve.
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000012", status="submitted"
+        )
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                with pytest.raises(BusinessRuleViolation) as exc_info:
+                    await admission_service._assert_quota_or_bypass(
+                        session,
+                        profile,
+                        manager,
+                        bypass_quota=False,
+                        bypass_reason=None,
+                        transition="approve",
+                    )
+                assert "chỉ tiêu" in str(exc_info.value).lower()
+
+    async def test_admin_bypass_passes_and_writes_audit(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """Cap=1, 1 approved, admin bypass with valid reason → passes + audit row."""
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="bypass",
+        )
+        admin = await _make_user(
+            role=UserRole.ADMIN, unit_id=seeds["unit_id"], suffix="bypass_admin"
+        )
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000020", status="approved"
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000021", status="submitted"
+        )
+
+        reason = "Late transfer applicant approved by Tổng Giám Đốc per email 2026-04-28."
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                # Should NOT raise.
+                await admission_service._assert_quota_or_bypass(
+                    session,
+                    profile,
+                    admin,
+                    bypass_quota=True,
+                    bypass_reason=reason,
+                    transition="approve",
+                )
+
+        # Verify audit row landed in entity_audit_log.
+        async with AsyncSessionLocal() as session:
+            audit_rows = (
+                await session.execute(
+                    select(models.EntityAuditLog).where(
+                        models.EntityAuditLog.entity_type == "AdmissionProfile",
+                        models.EntityAuditLog.entity_id == pid,
+                        models.EntityAuditLog.action == "quota_bypassed",
+                    )
+                )
+            ).scalars().all()
+            assert len(audit_rows) == 1, f"expected 1 audit row, got {len(audit_rows)}"
+            row = audit_rows[0]
+            assert row.actor_user_id == admin.id
+            assert row.reason == reason
+            assert row.changes is not None
+            assert row.changes["quota"]["new"] == 1
+            assert row.changes["enrolled_count_before"]["new"] == 1
+            assert row.changes["enrolled_count_after"]["new"] == 2
+            assert row.changes["transition"]["new"] == "approve"
+
+    async def test_manager_bypass_rejected(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """Manager attempting bypass → PermissionDeniedError (admin-only per Q12 Option B)."""
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="mgrbypass",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="mgr_bypass"
+        )
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000030", status="approved"
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000031", status="submitted"
+        )
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                with pytest.raises(PermissionDeniedError) as exc_info:
+                    await admission_service._assert_quota_or_bypass(
+                        session,
+                        profile,
+                        manager,
+                        bypass_quota=True,
+                        bypass_reason="Manager attempting bypass with valid-looking reason that is long enough",
+                        transition="approve",
+                    )
+                assert "admin" in str(exc_info.value).lower()
+
+    async def test_admin_bypass_short_reason_rejected(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """Admin bypass with reason <20 chars → ValidationError at service layer."""
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="shortrsn",
+        )
+        admin = await _make_user(
+            role=UserRole.ADMIN, unit_id=seeds["unit_id"], suffix="short_admin"
+        )
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000040", status="approved"
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000041", status="submitted"
+        )
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                with pytest.raises(ValidationError) as exc_info:
+                    await admission_service._assert_quota_or_bypass(
+                        session,
+                        profile,
+                        admin,
+                        bypass_quota=True,
+                        bypass_reason="too short",
+                        transition="approve",
+                    )
+                assert "20" in str(exc_info.value)
+
+    async def test_quota_unconfigured_skipped(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """quota=None → enforcement skipped (treat as unlimited)."""
+        seeds = await _seed_offering_with_quota(
+            quota=None,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="nullq",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="nullq_mgr"
+        )
+        # Even with 5 approved profiles, no enforcement.
+        for i in range(5):
+            await _seed_lead_and_profile(
+                seeds=seeds, citizen_id=f"20000000005{i}", status="approved"
+            )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000059", status="submitted"
+        )
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                # No raise expected.
+                await admission_service._assert_quota_or_bypass(
+                    session,
+                    profile,
+                    manager,
+                    bypass_quota=False,
+                    bypass_reason=None,
+                    transition="approve",
+                )
+
+    async def test_withdrawn_does_not_count(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """Withdrawn profiles must NOT occupy a quota seat."""
+        seeds = await _seed_offering_with_quota(
+            quota=2,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="withdrawn",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="wdr_mgr"
+        )
+        # 1 approved + 5 withdrawn → only 1 occupies seat. Cap is 2 → next approve allowed.
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000060", status="approved"
+        )
+        for i in range(5):
+            await _seed_lead_and_profile(
+                seeds=seeds, citizen_id=f"20000000006{i + 1}", status="withdrawn"
+            )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000067", status="submitted"
+        )
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                # No raise: only 1 occupies seat, cap=2, +1 = 2 ≤ 2.
+                await admission_service._assert_quota_or_bypass(
+                    session,
+                    profile,
+                    manager,
+                    bypass_quota=False,
+                    bypass_reason=None,
+                    transition="approve",
+                )
+
+    async def test_finalize_on_already_approved_passes(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """
+        Profile already counted (status=overridden) → finalize transition is
+        net-zero, count stays within cap. Happy path for finalize gate.
+        """
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="finalok",
+        )
+        admin = await _make_user(
+            role=UserRole.ADMIN, unit_id=seeds["unit_id"], suffix="finalok_admin"
+        )
+        # Single overridden profile occupying the only seat. Finalize → enrolled.
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000070", status="overridden"
+        )
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                # No raise: profile already in count (excluded as self),
+                # count_before=0, count_after=count_before, within cap=1.
+                await admission_service._assert_quota_or_bypass(
+                    session,
+                    profile,
+                    admin,
+                    bypass_quota=False,
+                    bypass_reason=None,
+                    transition="finalize",
+                )
+
+
+class TestQuotaIntegrationApprove:
+    """End-to-end via ``approve_profile`` service entry."""
+
+    async def test_approve_blocked_at_cap(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """
+        Approve via service path: cap=1, 1 already approved → ``approve_profile``
+        propagates the BusinessRuleViolation up.
+        """
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="aprblk",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="aprblk_mgr"
+        )
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000090", status="approved"
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds,
+            citizen_id="200000000091",
+            status="submitted",
+            assigned_officer_id=None,
+        )
+
+        async with AsyncSessionLocal() as session:
+            with pytest.raises(BusinessRuleViolation):
+                await admission_service.approve_profile(
+                    db=session,
+                    profile_id=pid,
+                    approver=manager,
+                    data={"version": 1, "notes": None},
+                )
+
+    async def test_approve_admin_bypass_succeeds(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """Admin can override with bypass_quota+bypass_reason ≥20 chars."""
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="aprbypass",
+        )
+        admin = await _make_user(
+            role=UserRole.ADMIN, unit_id=seeds["unit_id"], suffix="aprbypass_admin"
+        )
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000100", status="approved"
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds,
+            citizen_id="200000000101",
+            status="submitted",
+            assigned_officer_id=None,
+        )
+
+        async with AsyncSessionLocal() as session:
+            profile, _cb = await admission_service.approve_profile(
+                db=session,
+                profile_id=pid,
+                approver=admin,
+                data={
+                    "version": 1,
+                    "notes": None,
+                    "bypass_quota": True,
+                    "bypass_reason": "Đặc cách theo công văn Tổng Giám Đốc 2026-04-28 cho thí sinh chuyển trường muộn",
+                },
+            )
+            await session.commit()
+
+        reloaded = await _reload_profile(pid)
+        assert reloaded.status == "approved"
+
+        async with AsyncSessionLocal() as session:
+            audit_rows = (
+                await session.execute(
+                    select(models.EntityAuditLog).where(
+                        models.EntityAuditLog.entity_type == "AdmissionProfile",
+                        models.EntityAuditLog.entity_id == pid,
+                        models.EntityAuditLog.action == "quota_bypassed",
+                    )
+                )
+            ).scalars().all()
+            assert len(audit_rows) == 1
+
+
+class TestQuotaIntegrationBulkApprove:
+    """End-to-end via ``bulk_approve``."""
+
+    async def test_bulk_partial_over_cap(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """
+        Cap=2, 0 approved. Bulk submit 3 profiles. First 2 succeed; 3rd
+        lands in errors map without rolling back the batch.
+        """
+        seeds = await _seed_offering_with_quota(
+            quota=2,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="bulkpartial",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="bulk_mgr"
+        )
+        pid1 = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000110", status="submitted"
+        )
+        pid2 = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000111", status="submitted"
+        )
+        pid3 = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000112", status="submitted"
+        )
+
+        async with AsyncSessionLocal() as session:
+            result, _cb = await admission_service.bulk_approve(
+                db=session,
+                items=[
+                    {"profile_id": pid1, "version": 1},
+                    {"profile_id": pid2, "version": 1},
+                    {"profile_id": pid3, "version": 1},
+                ],
+                approver=manager,
+                notes="Batch test",
+            )
+            await session.commit()
+
+        assert result["success_count"] == 2
+        assert result["failed_count"] == 1
+        assert pid3 in result["failed_ids"]
+        assert "chỉ tiêu" in result["errors"][pid3].lower()
+
+        # First two are approved, third still submitted.
+        for pid, expected_status in [
+            (pid1, "approved"),
+            (pid2, "approved"),
+            (pid3, "submitted"),
+        ]:
+            reloaded = await _reload_profile(pid)
+            assert reloaded.status == expected_status, (
+                f"profile {pid} expected {expected_status}, got {reloaded.status}"
+            )
+
+    async def test_bulk_per_item_admin_bypass_mixes_with_normal(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """
+        Cap=1, 1 already approved. Bulk submit 2 items: first without
+        bypass (fails), second with admin bypass (succeeds) → audit row
+        for second only.
+        """
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="bulkmixed",
+        )
+        admin = await _make_user(
+            role=UserRole.ADMIN, unit_id=seeds["unit_id"], suffix="bulkmix_admin"
+        )
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000120", status="approved"
+        )
+        pid_no_bypass = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000121", status="submitted"
+        )
+        pid_bypass = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000122", status="submitted"
+        )
+
+        async with AsyncSessionLocal() as session:
+            result, _cb = await admission_service.bulk_approve(
+                db=session,
+                items=[
+                    {"profile_id": pid_no_bypass, "version": 1},
+                    {
+                        "profile_id": pid_bypass,
+                        "version": 1,
+                        "bypass_quota": True,
+                        "bypass_reason": "Bulk override per email policy 2026-04-28 from Tổng Giám Đốc",
+                    },
+                ],
+                approver=admin,
+                notes=None,
+            )
+            await session.commit()
+
+        assert pid_no_bypass in result["failed_ids"]
+        assert pid_bypass not in result["failed_ids"]
+        no_bypass_profile = await _reload_profile(pid_no_bypass)
+        bypass_profile = await _reload_profile(pid_bypass)
+        assert no_bypass_profile.status == "submitted"
+        assert bypass_profile.status == "approved"
+
+        async with AsyncSessionLocal() as session:
+            audit_count = (
+                await session.execute(
+                    select(models.EntityAuditLog).where(
+                        models.EntityAuditLog.action == "quota_bypassed",
+                        models.EntityAuditLog.entity_id.in_([pid_no_bypass, pid_bypass]),
+                    )
+                )
+            ).scalars().all()
+            assert len(audit_count) == 1
+            assert audit_count[0].entity_id == pid_bypass

--- a/Backend_FastAPI/tests/services/test_admission_quota.py
+++ b/Backend_FastAPI/tests/services/test_admission_quota.py
@@ -684,3 +684,341 @@ class TestQuotaIntegrationBulkApprove:
             ).scalars().all()
             assert len(audit_count) == 1
             assert audit_count[0].entity_id == pid_bypass
+
+
+# =========================================================================
+# ADM-026 review (Major #2): concurrent-approve race
+# =========================================================================
+
+
+class TestQuotaConcurrentRace:
+    """
+    ADM-026 lock contract: ``with_for_update()`` on OfferingAcademicInfo
+    must serialize concurrent approves so the cap holds even when two
+    transactions race against the same offering at boundary.
+    """
+
+    async def test_concurrent_approves_at_cap_only_one_succeeds(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """
+        Cap=1, currently 0 approved. Two SEPARATE sessions each try to
+        approve their own profile in parallel via ``asyncio.gather``.
+        Without the FOR UPDATE row lock both would see ``count<quota`` and
+        succeed → cap blown by 1. With the lock, they serialize and the
+        second sees ``count=1`` and raises.
+        """
+        import asyncio
+
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="race",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="race_mgr"
+        )
+        pid_a = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000200", status="submitted"
+        )
+        pid_b = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000201", status="submitted"
+        )
+
+        # Each task runs in its OWN session/transaction — must not share
+        # AsyncSession across asyncio.gather (memory: async-session-gather).
+        async def _try_approve(pid: int) -> str:
+            try:
+                async with AsyncSessionLocal() as session:
+                    async with session.begin():
+                        profile = await _profile_with_lead(session, pid)
+                        await admission_service._assert_quota_or_bypass(
+                            session,
+                            profile,
+                            manager,
+                            bypass_quota=False,
+                            bypass_reason=None,
+                            transition="approve",
+                        )
+                        # Mimic the approve mutation by occupying a seat
+                        # within the same locked txn — the helper above
+                        # already locked OfferingAcademicInfo, so this
+                        # row update commits the seat consumption.
+                        profile.status = "approved"
+                        await session.flush()
+                return "ok"
+            except BusinessRuleViolation:
+                return "blocked"
+
+        result_a, result_b = await asyncio.gather(
+            _try_approve(pid_a), _try_approve(pid_b)
+        )
+        outcomes = sorted([result_a, result_b])
+        # Exactly one succeeds, exactly one is blocked.
+        assert outcomes == ["blocked", "ok"], (
+            f"Concurrency contract broken: outcomes={outcomes}"
+        )
+
+        # DB invariant: at most ONE of the two profiles ended in 'approved'.
+        async with AsyncSessionLocal() as session:
+            approved = (
+                await session.execute(
+                    select(models.AdmissionProfile.id).where(
+                        models.AdmissionProfile.id.in_([pid_a, pid_b]),
+                        models.AdmissionProfile.status == "approved",
+                    )
+                )
+            ).scalars().all()
+            assert len(approved) == 1
+
+
+# =========================================================================
+# ADM-026 review (Major #3): denied bypass attempts produce audit rows
+# =========================================================================
+
+
+class TestQuotaDeniedAudit:
+    """
+    Compliance contract: any attempt to override the cap — even a denied
+    one — must leave an entity_audit_log row. The denial path raises and
+    the caller's transaction rolls back, so the audit row is written via
+    a fresh session inside ``_audit_quota_bypass_denied``.
+    """
+
+    async def test_manager_denial_writes_audit_row(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="denied_role",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="denied_mgr"
+        )
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000300", status="approved"
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000301", status="submitted"
+        )
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                with pytest.raises(PermissionDeniedError):
+                    await admission_service._assert_quota_or_bypass(
+                        session,
+                        profile,
+                        manager,
+                        bypass_quota=True,
+                        bypass_reason=(
+                            "Trưởng phòng cần ghi đè cho kỳ này lý do hợp lệ"
+                        ),
+                        transition="approve",
+                    )
+
+        async with AsyncSessionLocal() as session:
+            rows = (
+                await session.execute(
+                    select(models.EntityAuditLog).where(
+                        models.EntityAuditLog.action == "quota_bypass_denied_role",
+                        models.EntityAuditLog.entity_id == pid,
+                    )
+                )
+            ).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].actor_user_id == manager.id
+
+    async def test_admin_short_reason_writes_audit_row(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="denied_reason",
+        )
+        admin = await _make_user(
+            role=UserRole.ADMIN, unit_id=seeds["unit_id"], suffix="denied_admin"
+        )
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000310", status="approved"
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000311", status="submitted"
+        )
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                with pytest.raises(ValidationError):
+                    await admission_service._assert_quota_or_bypass(
+                        session,
+                        profile,
+                        admin,
+                        bypass_quota=True,
+                        bypass_reason="ngắn",  # <20 chars
+                        transition="approve",
+                    )
+
+        async with AsyncSessionLocal() as session:
+            rows = (
+                await session.execute(
+                    select(models.EntityAuditLog).where(
+                        models.EntityAuditLog.action == "quota_bypass_denied_reason",
+                        models.EntityAuditLog.entity_id == pid,
+                    )
+                )
+            ).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].actor_user_id == admin.id
+
+
+# =========================================================================
+# Test-gap follow-ups: Pydantic 422, boundary 1/1+1, legacy fallback
+# =========================================================================
+
+
+class TestQuotaPydanticValidation:
+    """Schema-layer validation (Pydantic 422) for the bypass pair.
+
+    These are pure-sync schema checks. The module-level ``pytestmark =
+    pytest.mark.asyncio`` paints them with the asyncio marker, which
+    pytest-asyncio warns about for non-async functions. The warning is
+    cosmetic — tests still execute correctly because pytest-asyncio only
+    cares when the test body needs awaiting.
+    """
+
+    def test_bypass_quota_true_short_reason_raises_at_schema_level(self):
+        """ValueError at schema parse — FastAPI maps to 422 Unprocessable."""
+        from app.schemas.admission import ApproveRequest
+
+        with pytest.raises(ValueError) as exc_info:
+            ApproveRequest(
+                version=1,
+                bypass_quota=True,
+                bypass_reason="quá ngắn",
+            )
+        assert "20" in str(exc_info.value)
+
+    def test_bypass_quota_false_no_reason_ok(self):
+        """Bypass off → reason optional → schema accepts."""
+        from app.schemas.admission import ApproveRequest
+
+        req = ApproveRequest(version=1)
+        assert req.bypass_quota is False
+        assert req.bypass_reason is None
+
+    def test_bypass_quota_true_valid_reason_ok(self):
+        from app.schemas.admission import ApproveRequest
+
+        req = ApproveRequest(
+            version=1,
+            bypass_quota=True,
+            bypass_reason="Đặc cách tuyển sinh ngày 2026-04-29 do Hiệu Trưởng",
+        )
+        assert req.bypass_quota is True
+
+
+class TestQuotaBoundary:
+    """Edge boundary: occupied count exactly equals quota."""
+
+    async def test_one_of_one_blocks_next_attempt(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """Cap=1, count=1 → next approve raises (sharper than 2/2 case)."""
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="boundary11",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="boundary11_mgr"
+        )
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000400", status="approved"
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000401", status="submitted"
+        )
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                with pytest.raises(BusinessRuleViolation):
+                    await admission_service._assert_quota_or_bypass(
+                        session,
+                        profile,
+                        manager,
+                        bypass_quota=False,
+                        bypass_reason=None,
+                        transition="approve",
+                    )
+
+
+class TestQuotaLegacyFallback:
+    """Legacy profile path: applied_rules.academic_info_id missing."""
+
+    async def test_legacy_profile_falls_back_to_offering_academic_year(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """
+        Profile snapshotted before academic_info_id was added still gets
+        enforced by the (lead.offering_id, profile.academic_year) lookup.
+        """
+        seeds = await _seed_offering_with_quota(
+            quota=1,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="legacy",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="legacy_mgr"
+        )
+        await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000500", status="approved"
+        )
+        # Legacy profile: applied_rules has no academic_info_id field.
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                lead = models.Lead(
+                    full_name="Legacy applicant",
+                    phone="0900000501",
+                    email="legacy501@test.com",
+                    source="website",
+                    unit_id=seeds["unit_id"],
+                    offering_id=seeds["offering_id"],
+                )
+                session.add(lead)
+                await session.flush()
+                legacy = models.AdmissionProfile(
+                    lead_id=lead.id,
+                    status="submitted",
+                    citizen_id="200000000501",
+                    academic_year=seeds["academic_year"],
+                    version=1,
+                    applied_rules={
+                        "min_gpa": 0,
+                        "mandatory_docs": [],
+                        # No academic_info_id — legacy snapshot.
+                    },
+                )
+                session.add(legacy)
+                await session.flush()
+                pid = legacy.id
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                with pytest.raises(BusinessRuleViolation):
+                    await admission_service._assert_quota_or_bypass(
+                        session,
+                        profile,
+                        manager,
+                        bypass_quota=False,
+                        bypass_reason=None,
+                        transition="approve",
+                    )


### PR DESCRIPTION
## Summary
ADM-026 implements ``annual_admission_quota`` enforcement at the
``submitted/resubmitted → approved → confirmed/overridden → enrolled``
funnel. Hard cap with admin-only override (Q12 Option B). Includes 2
review rounds.

### Round 1 (commit 296c320b)
- New helper ``_assert_quota_or_bypass(db, profile, actor, bypass_quota,
  bypass_reason, transition)`` runs FOR UPDATE on
  OfferingAcademicInfo + counts seats currently in
  ``QUOTA_OCCUPYING_STATUSES = (approved, overridden, confirmed,
  enrolled)`` and either passes, blocks, or runs the admin bypass path.
- Wired into ``approve_profile``, ``finalize_profile``, ``bulk_approve``
  (per-item).
- Pydantic ``_QuotaBypassMixin`` shared by ``ApproveRequest``,
  ``BulkApproveItem``, ``FinalizeRequest`` enforces ``bypass_reason``
  ≥20 chars at schema level (422 if violated).
- Successful admin bypass writes ``action=quota_bypassed`` to
  ``entity_audit_log`` with full changeset (quota / count_before /
  count_after / academic_info_id / academic_year / offering_id /
  transition).

### Round 2 review fixes (commits 3032453d + c5d4714c)
- **quota=0 means "cohort closed"**, NOT "unlimited". Schema allows
  ``annual_admission_quota=0`` (ge=0); previous logic
  ``quota is None or quota <= 0: return`` conflated three states.
  Disambiguated:
  - ``academic_info`` missing → unconfigured → SKIP
  - ``quota IS NULL`` → unlimited → SKIP
  - ``quota <= 0`` → cohort closed → BLOCK ALL (admin bypass + ≥20-char
    reason remains the documented escape).
- **Single-source bypass admin gate + audit**: the original Round 1
  router pre-gate (``require_admin_for_quota_bypass`` in ``deps.py``)
  was removed because it raised PermissionDeniedError BEFORE the
  service ran, leaving manager bypass attempts via API without an
  audit trail. ``_assert_quota_or_bypass`` is now the single source
  for both admin gate and audit emission. Cost: a denied attempt
  acquires the FOR UPDATE lock + count query before bouncing — denial
  is rare so the trade is for compliance correctness.
- **Denied bypass audit codes** (written via separate
  ``AsyncSessionLocal()`` so they persist past the caller's rollback):
  - ``quota_bypass_denied_role`` — non-admin tried bypass via API or service.
  - ``quota_bypass_denied_reason`` — admin tried bypass with reason <20 chars
    (service-direct callers only — see audit scope below).
- **Stronger bulk autoflush test** — ``test_bulk_overflow_detected_via_in_batch_autoflush``
  pins the contract that ``_count_quota_occupying_profiles`` observes
  in-batch flushes from prior items in the same ``bulk_approve`` call.

## Audit scope (precise contract)
Successful admin bypass: always audited (``quota_bypassed``).

Denied bypass:
- **Manager / non-admin bypass via API** → audited
  (``quota_bypass_denied_role``). Schema accepts the body
  (``bypass_quota=true`` + ≥20-char reason); service catches the role
  check and writes the audit row before raising.
- **Schema-invalid bypass via API** (e.g. ``bypass_reason`` <20 chars)
  → fails at FastAPI/Pydantic 422 BEFORE the service runs. **Not
  audited** in this PR. Schema-invalid requests are surface-level
  validation failures, not bypass attempts in the compliance sense.
- **Direct service callers** (tests, internal flows, future Celery
  jobs) hitting either denial path → both ``quota_bypass_denied_role``
  AND ``quota_bypass_denied_reason`` written.

If the future requirement is "audit every API attempt regardless of
422", that's a separate piece of middleware (request audit log) and
out of scope for this PR.

## Test plan
- [x] ``pytest tests/services/test_admission_quota.py`` → **24/24 pass**
  - 12 round-1: helper unit tests, integration approve, bulk
  - 1 round-1 concurrent race (``asyncio.gather`` two approves at cap=1)
  - 2 round-1 denied audit (manager-role-deny, admin-short-reason-deny)
  - 3 round-1 Pydantic 422 schema tests
  - 1 round-1 boundary 1/1+1, 1 legacy fallback (no ``academic_info_id``)
  - 1 round-2 bulk autoflush regression guard
  - 3 round-2 quota=0 boundary cases (block / admin override / null still unlimited)
- [x] Backend imports clean; routers no longer call removed
  ``require_admin_for_quota_bypass``.
- [x] ``git merge-tree origin/main HEAD`` → clean.
- 3 cosmetic asyncio-mark warnings on the sync schema tests
  (pytest-asyncio painting non-async tests with the module-level
  marker). Harmless; tests run correctly.

## Deferred (not blocker)
- Observability counter for legacy ``offering_id IS NULL`` skip path
  (Round 1 nit, requires no product input).
- Schema-side ``ge=1`` migration to forbid ``quota=0`` entirely (if
  product wants the closed-cohort intent expressed at the column
  level rather than the helper).
- Audit-every-API-attempt middleware (would catch the 422 schema-fail
  case noted above).

## Related
- Lane A parallel: ``fix/admission-audit-w7-2-5-adm-031-documents-ui``
  (PR #160) — verified merge-clean against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)