### PR TITLE
fix(admissions): unify document policy and surface extra documents

### DIFF
--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -287,6 +287,18 @@ class DocumentItemSchema(BaseModel):
         default=None,
         description="Whether this document is mandatory for the admission path",
     )
+    is_extra: Optional[bool] = Field(
+        default=False,
+        description=(
+            "BR2 (2026-04-29): True when this row is a ProfileDocument that "
+            "exists in the DB but is NOT in the current "
+            "applied_rules.mandatory_docs snapshot — typically because the "
+            "AdmissionPath was edited after the profile was created. Extras "
+            "are read-only (all can_* flags false); the FE renders them in "
+            "a separate 'Tài liệu ngoài yêu cầu hiện tại' section so "
+            "officers see prior evidence isn't silently dropped."
+        ),
+    )
     requires_upload: Optional[bool] = Field(
         default=None,
         description="True if an online upload is required; False for paper-only docs",

--- a/Backend_FastAPI/app/services/admission_document_policy.py
+++ b/Backend_FastAPI/app/services/admission_document_policy.py
@@ -18,26 +18,45 @@ lifts the matrix into a small class both call sites consume.
 
 Why a class instead of a free function?
 ---------------------------------------
-The matrix needs five derived booleans (``is_admin``, ``is_owner``,
-``manager_in_scope``, ``reviewer_scope``, ``profile_editable``) that
-depend only on ``(profile, user)`` and never change between the five
-``authorize()`` calls a single response makes. Computing them once on
-construction avoids re-deriving on each ``authorize()`` invocation
-and keeps the per-call signature small (``action``, ``doc_status``,
-``requires_upload``).
+The matrix needs derived booleans (``is_admin``, ``is_owner``,
+``manager_in_scope``, ``reviewer_scope``, ``applicant_can_modify_docs``,
+``reviewer_can_modify_docs``) that depend only on ``(profile, user)``
+and never change between the five ``authorize()`` calls a single
+response makes. Computing them once on construction avoids re-deriving
+on each ``authorize()`` invocation and keeps the per-call signature
+small (``action``, ``doc_status``, ``requires_upload``).
+
+Profile-state contract (BR1, 2026-04-29)
+----------------------------------------
+- ``APPLICANT_DOC_MUTATION_STATES`` = the set in which an applicant or
+  the owning officer may upload a file or mark a paper receipt
+  (``draft / submitted / rejected / resubmitted / revision_requested``).
+  Includes ``submitted`` / ``resubmitted`` because real applicants do
+  add missing evidence after the initial submit before a manager rules
+  on it.
+- ``REVIEWER_DOC_MUTATION_BLOCKED_STATES`` = the set in which even a
+  reviewer (manager-in-scope or admin) is barred from verify / reject /
+  reset because the profile has crossed into student-record territory
+  (currently just ``enrolled``). After enrolment a Student +
+  StudentDocument exist and changing AdmissionProfile docs would drift
+  from the historical record.
 
 Allowed actions
 ---------------
 ``"upload"``: applicant/officer/manager-in-scope/admin uploads a file
-for an editable profile, document is missing or previously rejected.
+for a profile in ``APPLICANT_DOC_MUTATION_STATES``, document is
+missing or previously rejected.
 ``"paper_submitted"``: same actor, paper-only doc (``requires_upload
-== False``), document still missing.
+== False``), document still missing, profile in
+``APPLICANT_DOC_MUTATION_STATES``.
 ``"verify"``: reviewer (admin/manager-in-scope), status is
-``uploaded`` or ``paper_submitted``.
+``uploaded`` or ``paper_submitted``, profile NOT in
+``REVIEWER_DOC_MUTATION_BLOCKED_STATES``.
 ``"reject"``: reviewer, status is anything past ``missing`` except
-the rejected/missing terminal states (= ``uploaded`` / ``paper_submitted`` /
-``verified``).
-``"reset"``: reviewer, anything except ``missing``.
+the rejected/missing terminal states (= ``uploaded`` /
+``paper_submitted`` / ``verified``), profile NOT blocked.
+``"reset"``: reviewer, anything except ``missing``, profile NOT
+blocked.
 """
 from __future__ import annotations
 
@@ -57,6 +76,32 @@ DocumentAction = Literal[
 ]
 
 
+# BR1 (2026-04-29): profile-state set in which an applicant/officer may
+# add or replace evidence. Real-world workflow: applicant submits, a
+# missing certificate arrives in the post a day later, officer uploads
+# it before the manager begins review. Excluding ``submitted`` /
+# ``resubmitted`` from this set (the previous "profile_editable" did)
+# made the FE hide the upload button and the BE service guard reject
+# the call — a real bug for that workflow.
+APPLICANT_DOC_MUTATION_STATES: frozenset[str] = frozenset(
+    {
+        "draft",
+        "submitted",
+        "rejected",
+        "resubmitted",
+        "revision_requested",
+    }
+)
+
+# BR1 (2026-04-29): profile states in which even a reviewer (admin /
+# manager-in-scope) is barred from verify / reject / reset. After
+# ``enrolled`` the system has materialised a Student + StudentDocument;
+# mutating AdmissionProfile docs from this point would silently drift
+# from the historical student record. Withdrawn is also terminal but
+# pre-Student so we leave reviewer access open for evidence cleanup.
+REVIEWER_DOC_MUTATION_BLOCKED_STATES: frozenset[str] = frozenset({"enrolled"})
+
+
 # Cached derived flags — computed once per (profile, user) pair so the
 # five authorize() calls a single response makes don't re-derive them.
 @dataclass(frozen=True)
@@ -65,7 +110,8 @@ class _UserProfileContext:
     is_owner: bool
     manager_in_scope: bool
     reviewer_scope: bool
-    profile_editable: bool
+    applicant_can_modify_docs: bool
+    reviewer_can_modify_docs: bool
 
 
 def _build_context(
@@ -95,17 +141,17 @@ def _build_context(
         and lead.unit_id == user.unit_id
     )
     reviewer_scope = is_admin or manager_in_scope
-    profile_editable = profile.status in (
-        "draft",
-        "rejected",
-        "revision_requested",
+    applicant_can_modify_docs = profile.status in APPLICANT_DOC_MUTATION_STATES
+    reviewer_can_modify_docs = (
+        profile.status not in REVIEWER_DOC_MUTATION_BLOCKED_STATES
     )
     return _UserProfileContext(
         is_admin=is_admin,
         is_owner=is_owner,
         manager_in_scope=manager_in_scope,
         reviewer_scope=reviewer_scope,
-        profile_editable=profile_editable,
+        applicant_can_modify_docs=applicant_can_modify_docs,
+        reviewer_can_modify_docs=reviewer_can_modify_docs,
     )
 
 
@@ -167,30 +213,35 @@ class DocumentActionPolicy:
         if action == "upload":
             return (
                 requires_upload
-                and ctx.profile_editable
+                and ctx.applicant_can_modify_docs
                 and (ctx.is_owner or ctx.is_admin or ctx.manager_in_scope)
                 and doc_status in ("missing", "rejected")
             )
         if action == "paper_submitted":
             return (
                 (not requires_upload)
-                and ctx.profile_editable
+                and ctx.applicant_can_modify_docs
                 and (ctx.is_owner or ctx.is_admin or ctx.manager_in_scope)
                 and doc_status == "missing"
             )
         if action == "verify":
-            return ctx.reviewer_scope and doc_status in (
-                "uploaded",
-                "paper_submitted",
+            return (
+                ctx.reviewer_scope
+                and ctx.reviewer_can_modify_docs
+                and doc_status in ("uploaded", "paper_submitted")
             )
         if action == "reject":
-            return ctx.reviewer_scope and doc_status in (
-                "uploaded",
-                "paper_submitted",
-                "verified",
+            return (
+                ctx.reviewer_scope
+                and ctx.reviewer_can_modify_docs
+                and doc_status in ("uploaded", "paper_submitted", "verified")
             )
         if action == "reset":
-            return ctx.reviewer_scope and doc_status != "missing"
+            return (
+                ctx.reviewer_scope
+                and ctx.reviewer_can_modify_docs
+                and doc_status != "missing"
+            )
 
         # Unknown action — treat as deny so a typo in calling code
         # never grants access. Service guard surfaces the bug as a

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -196,6 +196,27 @@ def _authorize_document_action(
     config = doc_configs.get(doc_code, {}) or {}
     requires_upload = bool(config.get("requires_upload", True))
 
+    # BR2 (2026-04-29): the document is "extra" — exists in the DB but
+    # is no longer in the current applied_rules.mandatory_docs snapshot
+    # (typically because the AdmissionPath was edited after the profile
+    # was created). The response marks these rows with ``is_extra=True``
+    # and clamps every ``can_*`` flag to False so the FE row renders
+    # read-only. The service-side gate must mirror that contract,
+    # otherwise a direct call to ``verify-format`` / ``reject`` /
+    # ``reset`` / ``upload`` / ``paper-submitted`` bypasses the
+    # read-only promise (the policy alone never sees ``is_extra``).
+    # Treat missing ``mandatory_docs`` as ``[]`` for safety: a profile
+    # without a snapshot can't tell which docs are "active" so every
+    # request is necessarily on extras.
+    mandatory_docs = applied_rules.get("mandatory_docs") or []
+    if doc_code not in mandatory_docs:
+        raise PermissionDeniedError(
+            f"Document '{doc_code}' is no longer in the current admission "
+            f"path's mandatory list (treated as extra / evidence-only). "
+            f"Direct '{action}' actions are blocked until an explicit "
+            f"sync-path action ships."
+        )
+
     policy = DocumentActionPolicy.for_(profile, current_user)
     if not policy.authorize(action, doc_status, requires_upload):
         # 404 per IDOR convention — router translates.
@@ -1748,8 +1769,21 @@ def _compute_frontend_fields(
             ),
         }
 
-    # Build documents_checklist
+    # Build documents_checklist.
+    # Two passes:
+    #   (1) snapshot-driven mandatory docs from ``applied_rules.mandatory_docs``
+    #       — flagged ``is_mandatory=True``, ``is_extra=False``.
+    #   (2) BR2 (2026-04-29): ProfileDocument rows whose code is NOT in
+    #       the snapshot — flagged ``is_extra=True``, all ``can_*``
+    #       forced false (extras are evidence/audit, never silently
+    #       dropped, but no actions surface in the UI). Happens when the
+    #       AdmissionPath was edited after the profile was created and
+    #       previously-uploaded docs are no longer in the current
+    #       mandatory list. Sync action that would refresh the snapshot
+    #       is intentionally out of scope for this PR.
     documents_checklist = []
+    _mandatory_set = set(all_mandatory_docs)
+
     for i, doc_code in enumerate(all_mandatory_docs):
         config = doc_configs.get(doc_code, {})
         uploaded_doc = doc_by_code.get(doc_code, {})
@@ -1761,6 +1795,7 @@ def _compute_frontend_fields(
             "code": doc_code,
             "label": config.get("label") or uploaded_doc.get("label_from_db") or doc_code,
             "is_mandatory": True,
+            "is_extra": False,
             "requires_upload": _requires_upload,
             "submission_format": config.get("submission_format"),
             # ADM-031 round 4: pass through the officer-declared and
@@ -1780,6 +1815,46 @@ def _compute_frontend_fields(
             "rejection_reason": uploaded_doc.get("rejection_reason"),
             "submission_format_confirmed": uploaded_doc.get("submission_format_confirmed", False),
             **_perms,
+        })
+
+    # Pass (2): extra ProfileDocument rows. Stable sort by code so
+    # repeated GETs render in a consistent order.
+    for extra_code in sorted(c for c in doc_by_code.keys() if c not in _mandatory_set):
+        uploaded_doc = doc_by_code[extra_code]
+        _doc_status = uploaded_doc.get("status", "missing")
+        # No live config for extras (path changed). Infer
+        # requires_upload from the artifact: a file_path means an
+        # upload happened, otherwise treat as paper-only.
+        _requires_upload = bool(uploaded_doc.get("file_path"))
+
+        documents_checklist.append({
+            "code": extra_code,
+            "label": uploaded_doc.get("label_from_db") or extra_code,
+            "is_mandatory": False,
+            "is_extra": True,
+            "requires_upload": _requires_upload,
+            "submission_format": None,
+            "actual_submission_format": uploaded_doc.get("actual_submission_format"),
+            "verified_format": uploaded_doc.get("verified_format"),
+            "status": _doc_status,
+            "file_path": uploaded_doc.get("file_path"),
+            "uploaded_at": uploaded_doc.get("uploaded_at"),
+            "paper_submitted_at": uploaded_doc.get("paper_submitted_at"),
+            "verified_at": uploaded_doc.get("verified_at"),
+            "verified_by": uploaded_doc.get("verified_by"),
+            "verified_by_name": uploaded_doc.get("verified_by_name"),
+            "rejection_reason": uploaded_doc.get("rejection_reason"),
+            "submission_format_confirmed": uploaded_doc.get(
+                "submission_format_confirmed", False
+            ),
+            # Extras are read-only: row visible for evidence + audit,
+            # but no action buttons. A future sync-path action will own
+            # the cleanup workflow.
+            "can_upload": False,
+            "can_verify": False,
+            "can_reject": False,
+            "can_reset": False,
+            "can_mark_paper_submitted": False,
         })
 
     profile.documents_checklist = documents_checklist
@@ -3853,9 +3928,13 @@ async def upload_document(
 
     profile = await get_profile(db, profile_id, current_user)
 
-    # State Locking
-    if profile.status not in ["draft", "rejected", "revision_requested"]:
-        raise BadRequest(f"Cannot upload documents for profile with status '{profile.status}'")
+    # BR1 (2026-04-29): the profile-state guard now lives inside
+    # ``DocumentActionPolicy`` (see ``APPLICANT_DOC_MUTATION_STATES``)
+    # so the FE flag and BE gate stay in lockstep automatically.
+    # The previous hand-rolled ``profile.status not in [draft, rejected,
+    # revision_requested]`` check would also reject ``submitted`` /
+    # ``resubmitted`` — a real workflow bug since applicants do post
+    # missing evidence between submit and the manager's first review.
 
     # Find document record early — needed for doc_status-based guard check.
     doc_record = await admission_repo.get_document_by_type(profile_id, doc_code)
@@ -4260,18 +4339,20 @@ async def mark_paper_submitted(
     # Get profile for access check
     profile = await get_profile(db, profile_id, current_user)
 
-    # Status guard: only allow document operations in editable states
-    if profile.status not in ["draft", "submitted", "rejected", "resubmitted"]:
-        raise BadRequest(
-            f"Cannot modify documents when profile status is '{profile.status}'"
-        )
+    # BR1 (2026-04-29): profile-state guard delegated to
+    # ``DocumentActionPolicy`` (see ``APPLICANT_DOC_MUTATION_STATES``).
+    # The previous hand-rolled set ``[draft, submitted, rejected,
+    # resubmitted]`` was a different shape from the policy's
+    # ``[draft, rejected, revision_requested]`` — a dead-code mismatch
+    # that this unification closes.
 
     # Get document to capture old status
     doc_before = await admission_repo.get_document_by_type(profile_id, doc_code)
     old_status = doc_before.status if doc_before else "missing"
 
-    # PR #5 guard — matches can_mark_paper_submitted (requires_upload=false,
-    # status=missing, owning officer in scope).
+    # Single source of truth — same matrix as can_mark_paper_submitted
+    # on the response (requires_upload=false, status=missing, owning
+    # officer in scope, profile in APPLICANT_DOC_MUTATION_STATES).
     _authorize_document_action(
         action="paper_submitted",
         profile=profile,
@@ -4358,16 +4439,14 @@ async def reject_document(
     # Get profile for access check
     profile = await get_profile(db, profile_id, current_user)
 
-    # Status guard: cannot reject documents for enrolled profiles
-    if profile.status == "enrolled":
-        raise BadRequest("Cannot reject documents for enrolled profile")
+    # BR1 (2026-04-29): enrolled-state block delegated to
+    # ``DocumentActionPolicy`` (see ``REVIEWER_DOC_MUTATION_BLOCKED_STATES``).
+    # Single source of truth — same matrix as can_reject on the response.
 
     # Get document to capture old status
     doc_before = await admission_repo.get_document_by_type(profile_id, doc_code)
     old_status = doc_before.status if doc_before else "unknown"
 
-    # PR #5 guard — matches can_reject (reviewer scope + doc status
-    # in uploaded/paper_submitted/verified).
     _authorize_document_action(
         action="reject",
         profile=profile,
@@ -4467,16 +4546,15 @@ async def reset_document(
     # Get profile for access check
     profile = await get_profile(db, profile_id, current_user)
 
-    # State Locking: Cannot reset documents for enrolled profiles
-    if profile.status == "enrolled":
-        raise BadRequest("Cannot reset documents for enrolled profiles")
+    # BR1 (2026-04-29): enrolled-state block delegated to
+    # ``DocumentActionPolicy`` (see ``REVIEWER_DOC_MUTATION_BLOCKED_STATES``).
+    # Single source of truth — same matrix as can_reset on the response.
 
     # Get document to capture old status and file path before reset
     doc_before = await admission_repo.get_document_by_type(profile_id, doc_code)
     old_status = doc_before.status if doc_before else "unknown"
     old_file_path = doc_before.file_path if doc_before else None
 
-    # PR #5 guard — matches can_reset (reviewer scope + non-missing status).
     _authorize_document_action(
         action="reset",
         profile=profile,

--- a/Backend_FastAPI/tests/api/test_admission_document_permissions.py
+++ b/Backend_FastAPI/tests/api/test_admission_document_permissions.py
@@ -259,3 +259,144 @@ async def test_admin_has_reviewer_actions_after_upload(
     # Admin is not the lead's assigned officer → can_upload should flip off
     # once status is no longer missing/rejected.
     assert uploaded_row["can_upload"] is False
+
+
+@pytest.mark.asyncio
+async def test_extras_are_locked_at_service_layer_not_just_in_response(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    doc_perm_config: dict,
+):
+    """BR2 (2026-04-29): documents whose code is no longer in the
+    profile's ``applied_rules.mandatory_docs`` snapshot are
+    evidence-only — every direct API mutation must be rejected, not
+    just hidden in the UI.
+
+    Set up: create a profile (which seeds ``mandatory_docs`` from the
+    path), upload its mandatory doc, then mutate the snapshot in DB so
+    that doc becomes "extra". Re-fetch and confirm the response marks
+    it ``is_extra=True`` with all ``can_*`` false. Then call every
+    document-mutation endpoint directly and assert each one is
+    rejected — proves the service guard, not just the response shape,
+    enforces the read-only contract.
+    """
+    from sqlalchemy.orm.attributes import flag_modified
+    from sqlalchemy import select
+    from tests.fixtures.constants import TestUsers
+
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, doc_perm_config
+    )
+    pid = prof["id"]
+
+    # Officer uploads so the doc has artifact state to "freeze" as evidence.
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    checklist = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()[
+        "documents_checklist"
+    ]
+    target = next(d for d in checklist if d.get("requires_upload"))
+    upload = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{target['code']}/upload",
+        headers=oh,
+        files={
+            "file": (f"{target['code']}.pdf", b"%PDF-1.4\n%%EOF", "application/pdf")
+        },
+        data={"actual_submission_format": "photo"},
+    )
+    assert upload.status_code in (200, 201), upload.text
+
+    # Mutate the snapshot so target becomes "extra". This simulates the
+    # AdmissionPath being edited after profile creation; the service
+    # under test must observe applied_rules.mandatory_docs as the
+    # source of truth and reject mutations on the now-stale doc.
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            row = await s.execute(
+                select(models.AdmissionProfile).where(
+                    models.AdmissionProfile.id == pid
+                )
+            )
+            db_profile = row.scalar_one()
+            new_rules = dict(db_profile.applied_rules or {})
+            new_rules["mandatory_docs"] = []
+            db_profile.applied_rules = new_rules
+            flag_modified(db_profile, "applied_rules")
+
+    admin_headers = await _login(
+        client, TestUsers.ADMIN["username"], TestUsers.ADMIN["password"]
+    )
+
+    # Response shape: row marked is_extra + all can_* false.
+    refreshed = (
+        await client.get(f"{ADMISSIONS}/{pid}", headers=admin_headers)
+    ).json()
+    extra = next(
+        d for d in refreshed["documents_checklist"] if d["code"] == target["code"]
+    )
+    assert extra["is_extra"] is True, extra
+    for flag in (
+        "can_upload",
+        "can_verify",
+        "can_reject",
+        "can_reset",
+        "can_mark_paper_submitted",
+    ):
+        assert extra[flag] is False, f"extras must clamp {flag}=False, got {extra}"
+
+    # Service guard: every direct mutation endpoint must reject.
+    # Includes both reviewer-side (verify/reject/reset) and
+    # applicant-side (upload/paper-submitted) — the read-only contract
+    # is symmetric.
+    code = target["code"]
+    rejection_routes = [
+        (
+            f"{ADMISSIONS}/{pid}/documents/{code}/verify-format",
+            "PATCH",
+            {"format": "photo"},
+            None,
+        ),
+        (
+            f"{ADMISSIONS}/{pid}/documents/{code}/reject",
+            "POST",
+            {"reason": "extras lock contract test"},
+            None,
+        ),
+        (
+            f"{ADMISSIONS}/{pid}/documents/{code}/reset",
+            "POST",
+            {},
+            None,
+        ),
+        (
+            f"{ADMISSIONS}/{pid}/documents/{code}/paper-submitted",
+            "POST",
+            # Include actual_submission_format so the request passes the
+            # Pydantic schema validation gate and reaches the service
+            # guard — without it the endpoint would 422 on the body
+            # shape, which doesn't prove the BR2 lock.
+            {"actual_submission_format": "photo"},
+            None,
+        ),
+    ]
+    for route, method, body, _ in rejection_routes:
+        resp = await client.request(method, route, headers=admin_headers, json=body)
+        assert resp.status_code in (403, 404), (
+            f"{method} {route} on extra doc: expected 403/404, "
+            f"got {resp.status_code}: {resp.text[:200]}"
+        )
+
+    # Upload endpoint takes multipart, not JSON — exercise it separately
+    # so the service guard is hit before the file-handling path.
+    upload_again = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{code}/upload",
+        headers=admin_headers,
+        files={"file": (f"{code}.pdf", b"%PDF-1.4\n%%EOF", "application/pdf")},
+        data={"actual_submission_format": "photo"},
+    )
+    assert upload_again.status_code in (403, 404), (
+        f"POST upload on extra doc: expected 403/404, "
+        f"got {upload_again.status_code}: {upload_again.text[:200]}"
+    )

--- a/Backend_FastAPI/tests/unit/test_admission_document_policy.py
+++ b/Backend_FastAPI/tests/unit/test_admission_document_policy.py
@@ -324,3 +324,118 @@ def test_missing_lead_blocks_owner_actions(officer_owner):
     assert not policy.authorize(
         "paper_submitted", "missing", requires_upload=False
     )
+
+
+# ---------------------------------------------------------------------------
+# BR1 (2026-04-29): profile-state matrix
+# ---------------------------------------------------------------------------
+#
+# Pin the contract from the business-rule note:
+#   APPLICANT_DOC_MUTATION_STATES =
+#     {draft, submitted, rejected, resubmitted, revision_requested}
+#   REVIEWER_DOC_MUTATION_BLOCKED_STATES = {enrolled}
+#
+# These are the per-state cells the previous "profile_editable" set
+# (``draft, rejected, revision_requested``) didn't cover; they are the
+# regression surface that motivated unifying service guards into the
+# policy.
+
+
+@pytest.mark.parametrize(
+    "profile_status",
+    ["draft", "submitted", "rejected", "resubmitted", "revision_requested"],
+)
+def test_applicant_states_allow_upload_and_paper_submitted(
+    profile_status, officer_owner
+):
+    """Five states where applicant/officer may add evidence."""
+    profile = _StubProfile(
+        status=profile_status,
+        lead=_StubLead(unit_id=42, assigned_officer_id=20),
+    )
+    policy = DocumentActionPolicy.for_(profile, officer_owner)
+    assert policy.authorize("upload", "missing", requires_upload=True)
+    assert policy.authorize(
+        "paper_submitted", "missing", requires_upload=False
+    )
+
+
+@pytest.mark.parametrize(
+    "profile_status",
+    ["approved", "confirmed", "overridden", "enrolled", "withdrawn"],
+)
+def test_post_decision_states_block_upload_and_paper_submitted(
+    profile_status, officer_owner
+):
+    """After a manager decision (approved+) or terminal (withdrawn),
+    the applicant path is closed; further evidence requires the manager
+    to re-open via revision_requested."""
+    profile = _StubProfile(
+        status=profile_status,
+        lead=_StubLead(unit_id=42, assigned_officer_id=20),
+    )
+    policy = DocumentActionPolicy.for_(profile, officer_owner)
+    assert not policy.authorize("upload", "missing", requires_upload=True)
+    assert not policy.authorize(
+        "paper_submitted", "missing", requires_upload=False
+    )
+
+
+@pytest.mark.parametrize(
+    "profile_status",
+    [
+        "draft",
+        "submitted",
+        "approved",
+        "rejected",
+        "revision_requested",
+        "resubmitted",
+        "confirmed",
+        "overridden",
+        "withdrawn",
+    ],
+)
+@pytest.mark.parametrize("action", ["verify", "reject", "reset"])
+def test_reviewer_actions_allowed_pre_enrolled(
+    profile_status, action, manager_in_scope
+):
+    """Manager-in-scope/admin may verify/reject/reset until enrolled."""
+    profile = _StubProfile(
+        status=profile_status,
+        lead=_StubLead(unit_id=42, assigned_officer_id=20),
+    )
+    policy = DocumentActionPolicy.for_(profile, manager_in_scope)
+    # Use a doc_status compatible with each action.
+    doc_status = "uploaded" if action != "reset" else "verified"
+    assert policy.authorize(action, doc_status, requires_upload=True)
+
+
+@pytest.mark.parametrize("action", ["verify", "reject", "reset"])
+def test_enrolled_blocks_all_reviewer_actions(action, manager_in_scope, admin):
+    """After enrolment, AdmissionProfile docs are frozen — even admin
+    can't flip them. Compliance contract: don't drift from the Student
+    record materialised at enrolment."""
+    profile = _StubProfile(
+        status="enrolled",
+        lead=_StubLead(unit_id=42, assigned_officer_id=20),
+    )
+    doc_status = "uploaded" if action != "reset" else "verified"
+    for actor in (manager_in_scope, admin):
+        policy = DocumentActionPolicy.for_(profile, actor)
+        assert not policy.authorize(action, doc_status, requires_upload=True)
+
+
+def test_enrolled_blocks_applicant_paths_too(officer_owner):
+    """Belt-and-braces: applicant-side actions also can't reach an
+    enrolled profile. APPLICANT_DOC_MUTATION_STATES does not include
+    enrolled, so this is implied — pin it explicitly so an accidental
+    set expansion later trips the test."""
+    profile = _StubProfile(
+        status="enrolled",
+        lead=_StubLead(unit_id=42, assigned_officer_id=20),
+    )
+    policy = DocumentActionPolicy.for_(profile, officer_owner)
+    assert not policy.authorize("upload", "missing", requires_upload=True)
+    assert not policy.authorize(
+        "paper_submitted", "missing", requires_upload=False
+    )

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -714,21 +714,37 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
     ? uploadConfig.allowed_extensions.map((ext) => `.${ext}`).join(",")
     : ""
 
+  // BR2 (2026-04-29): split rows into the active checklist (snapshot
+  // mandatory) and extras (ProfileDocument rows whose code is no
+  // longer in the current applied_rules.mandatory_docs — backend now
+  // surfaces them with is_extra=true instead of silently dropping).
+  // KPI counts and the work-queue sort run on activeDocs only —
+  // extras are evidence-only and would muddy the "what's left to do"
+  // signal if mixed in.
+  const activeDocs = useMemo(
+    () => documents.filter((d) => !d.is_extra),
+    [documents],
+  )
+  const extraDocs = useMemo(
+    () => documents.filter((d) => d.is_extra),
+    [documents],
+  )
+
   // Sort docs by work-queue priority — only resort when documents change.
-  const sortedDocs = useMemo(() => sortByWorkQueue(documents), [documents])
+  const sortedDocs = useMemo(() => sortByWorkQueue(activeDocs), [activeDocs])
 
   // KPI counts. Keep on the unsorted array — totals don't depend on order.
-  const total = documents.length
-  const recordedCount = documents.filter((d) =>
+  const total = activeDocs.length
+  const recordedCount = activeDocs.filter((d) =>
     isDocumentRecorded(d.status ?? ""),
   ).length
-  const satisfiedCount = documents.filter((d) =>
+  const satisfiedCount = activeDocs.filter((d) =>
     isDocumentRequirementSatisfied(d.status ?? ""),
   ).length
-  const pendingCount = documents.filter((d) =>
+  const pendingCount = activeDocs.filter((d) =>
     isDocumentPendingVerification(d.status ?? ""),
   ).length
-  const mandatoryDocs = documents.filter((d) => d.is_mandatory)
+  const mandatoryDocs = activeDocs.filter((d) => d.is_mandatory)
   const mandatorySatisfiedCount = mandatoryDocs.filter((d) =>
     isDocumentRequirementSatisfied(d.status ?? ""),
   ).length
@@ -1405,6 +1421,74 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
           aria-describedby="documents-upload-rules"
         />
       </Card>
+
+      {/*
+        BR2 (2026-04-29): extras section.
+        ProfileDocument rows that exist in the DB but are no longer in
+        the path's mandatory_docs snapshot — usually because the path
+        was edited after the profile was created. Backend marks them
+        is_extra=true; we surface them so officers see prior evidence
+        wasn't silently dropped, but render read-only (action buttons
+        suppressed via backend can_* = false). A future explicit
+        "Đồng bộ yêu cầu tài liệu" action will own cleanup.
+      */}
+      {extraDocs.length > 0 && (
+        <Card className="mt-4">
+          <CardHeader>
+            <CardTitle className="text-base">
+              Tài liệu ngoài yêu cầu hiện tại
+            </CardTitle>
+            <CardDescription>
+              Đây là các tài liệu thí sinh đã nộp ở phương thức tuyển sinh
+              trước đó. Hiện không còn nằm trong yêu cầu hồ sơ. Giữ lại để
+              lưu vết hồ sơ; không thể chỉnh trực tiếp ở đây.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {extraDocs.map((doc, i) => {
+                const state = computeRowState(doc)
+                const StatusIcon = state.statusConfig.icon
+                return (
+                  <li
+                    key={doc.code || `extra-${i}`}
+                    className="rounded-md border bg-muted/30 p-3 flex items-start gap-3"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div
+                        className="font-medium break-words"
+                        title={`Mã: ${doc.code}`}
+                      >
+                        {doc.label}
+                      </div>
+                      <div className="text-xs text-muted-foreground mt-1">
+                        {state.recordedFormatLabel
+                          ? `${state.recordedFormatLabel}`
+                          : "—"}
+                        {state.recordedAtFormatted && (
+                          <span className="tabular-nums">
+                            {" · "}
+                            {state.recordedAtFormatted}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <Badge
+                      className={`${state.statusConfig.color} gap-1 shrink-0`}
+                    >
+                      <StatusIcon
+                        className="h-3 w-3 shrink-0"
+                        aria-hidden="true"
+                      />
+                      {state.statusConfig.label}
+                    </Badge>
+                  </li>
+                )
+              })}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Submission Format Selection Dialog */}
       <Dialog

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -170,6 +170,15 @@ export const documentItemSchema = z.object({
     .max(255, "Tên tài liệu không được quá 255 ký tự")
     .trim(),
   is_mandatory: z.boolean().optional(),
+  /**
+   * BR2 (2026-04-29): true when this row is a ProfileDocument that
+   * exists in the DB but is NOT in the current
+   * applied_rules.mandatory_docs snapshot — typically because the
+   * AdmissionPath was edited after the profile was created. Extras are
+   * read-only (all can_* flags false); UI renders them in a separate
+   * "Tài liệu ngoài yêu cầu hiện tại" section.
+   */
+  is_extra: z.boolean().optional(),
   // Phase 0.9: New document config fields (all optional for form/response compatibility)
   requires_upload: z.boolean().optional(),
   submission_format: z.enum(["photo", "certified_copy", "original"]).nullable().optional(),


### PR DESCRIPTION
## Summary
Two business rules chốt 2026-04-29 by user:

### BR1 — Document workflow + single-source policy
- Applicants/officers may add evidence in ``draft / submitted / rejected / resubmitted / revision_requested``. ``submitted`` and ``resubmitted`` were previously rejected by the policy and (separately) some service guards — but applicants do post missing scans between submit and the manager's first review, so the previous matrix was a real workflow bug.
- Reviewers (admin / manager-in-scope) may verify / reject / reset in any state EXCEPT ``enrolled`` (the system has materialised a Student + StudentDocument at enrolment; mutating AdmissionProfile docs from there would silently drift from the historical record).
- ``DocumentActionPolicy`` is now the SOLE source of truth for the per-action × per-state × per-role matrix. The four hand-rolled service-layer ``profile.status`` guards in ``upload_document`` / ``mark_paper_submitted`` / ``reject_document`` / ``reset_document`` are removed. ``confirm_document_format`` (verify) was missing a state guard entirely — now picks up the lock via the same policy.

### BR2 — Surface (don't drop) ProfileDocuments outside the snapshot
- When an AdmissionPath is edited after a profile is created, some ProfileDocument rows can fall out of ``applied_rules.mandatory_docs``. The previous loop iterated only ``mandatory_docs`` and silently hid those rows, leaving uploaded files un-renderable.
- ``_compute_frontend_fields`` now does a second pass: any ProfileDocument whose code is not in the snapshot is appended to ``documents_checklist`` with ``is_extra=True`` and every ``can_*`` flag forced to False (read-only).
- ``_authorize_document_action`` enforces the read-only contract at the service boundary too — direct API calls to verify-format / reject / reset / upload / paper-submitted on an extra doc raise ``PermissionDeniedError``. Without this, the response would lie about what's callable. ``mandatory_docs`` missing is treated as ``[]`` so legacy profiles without a snapshot can't slip through either.
- Cleanup workflow ("Đồng bộ yêu cầu tài liệu" — preview added / removed / changed + admin confirm + audit) is intentionally OUT of scope and remains a future PR.

## Frontend
- ``DocumentsTab`` splits docs into ``activeDocs`` (snapshot) and ``extraDocs`` (is_extra=true). KPI tiles + work-queue sort run on active only. New "Tài liệu ngoài yêu cầu hiện tại" Card renders extras as a flat list with status badge, no actions.
- Zod ``documentItemSchema`` mirrors the new ``is_extra`` field.

## Tests
- ``tests/unit/test_admission_document_policy.py`` — 41 new cases pinning the BR1 matrix: applicant states allow upload/paper, post-decision states block, reviewer actions allowed pre-enrolled, enrolled blocks ALL actions for ALL roles, applicant paths can't reach an enrolled profile.
- ``tests/api/test_admission_document_permissions.py`` — new ``test_extras_are_locked_at_service_layer_not_just_in_response`` exercises the full lifecycle: create profile, officer upload, mutate ``applied_rules.mandatory_docs = []`` to make the doc \"extra\", re-fetch and assert ``is_extra=True`` + all ``can_*=False``, then call all 5 mutation endpoints directly and assert each returns 403/404. Proves the BR2 lock is enforced by the service guard, not just hidden in the UI.

## Test plan
- [x] **125/125 backend admission tests pass** (75 policy unit + 5 API permission + 13 admission workflow API + 24 quota + 8 admission workflow service).
- [x] **77/77 frontend tests pass** (3 CI vitest gate + 35 DocumentsTab).
- [x] ``tsc --noEmit`` clean.
- [x] Backend imports clean; ``_authorize_document_action`` extras gate verified.

## Deferred (separate PRs)
- "Đồng bộ yêu cầu tài liệu" sync action (BR2.4 — preview + admin confirm + audit).
- Frontend test for extras section render (low priority — backend contract pinned by API test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)