### PR TITLE
feat(admissions): ADM-023+028 magic-link hardening — cooldown ladder, resend cap, reminders

### DIFF
--- a/Backend_FastAPI/alembic/versions/mlharden01_magic_link_cooldown_columns.py
+++ b/Backend_FastAPI/alembic/versions/mlharden01_magic_link_cooldown_columns.py
@@ -1,0 +1,70 @@
+"""ADM-023+028: magic-link cooldown ladder + reminder columns.
+
+Adds the 4 columns that drive the hybrid cooldown ladder + reminder
+beat task on ``admission_confirmation_token``:
+
+- ``lock_until``           — sliding cooldown end (different from
+  ``locked_at`` which is the hard-lock marker; ``lock_until`` is set
+  every failed attempt while ``locked_at`` only fires at the hard-lock
+  threshold).
+- ``lock_count``           — how many times this token has been hard-
+  locked. Cumulative; ≥1 means an admin must reset.
+- ``reminder_24h_sent_at`` — beat task marks once the 24h-before-
+  expiry reminder has been dispatched. Idempotent guard.
+- ``reminder_6h_sent_at``  — same, for the 6h reminder.
+
+Q9 decision (2026-04-28, memory ``admission-audit-wave2-2026-04-28``):
+A3 + B1 + C2.
+
+Idempotent: ``IF NOT EXISTS`` on every ALTER + index. Safe to re-run
+after partial application.
+
+Revision ID: mlharden01
+Revises: zbaudit001
+Create Date: 2026-04-29
+"""
+from alembic import op
+
+
+revision = "mlharden01"
+down_revision = "zbaudit001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE admission_confirmation_token
+            ADD COLUMN IF NOT EXISTS lock_until TIMESTAMPTZ NULL,
+            ADD COLUMN IF NOT EXISTS lock_count INTEGER NOT NULL DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS reminder_24h_sent_at TIMESTAMPTZ NULL,
+            ADD COLUMN IF NOT EXISTS reminder_6h_sent_at TIMESTAMPTZ NULL
+        """
+    )
+
+    # Beat-scan index: covers tokens that may need a reminder.
+    # Filter by ``confirmed_at IS NULL`` because confirmed tokens are
+    # done; partial index keeps the rebuild small.
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_admission_confirmation_token_reminder_scan
+            ON admission_confirmation_token (expires_at, locked_at)
+            WHERE confirmed_at IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS ix_admission_confirmation_token_reminder_scan"
+    )
+    op.execute(
+        """
+        ALTER TABLE admission_confirmation_token
+            DROP COLUMN IF EXISTS reminder_6h_sent_at,
+            DROP COLUMN IF EXISTS reminder_24h_sent_at,
+            DROP COLUMN IF EXISTS lock_count,
+            DROP COLUMN IF EXISTS lock_until
+        """
+    )

--- a/Backend_FastAPI/app/celery_app.py
+++ b/Backend_FastAPI/app/celery_app.py
@@ -113,6 +113,17 @@ celery_app.conf.beat_schedule = {
         "options": {"queue": "default"},
     },
 
+    # --- ADM-028 (2026-04-29): magic-link expiry reminders ---
+    # 30 min cadence: worst-case lag between an applicant crossing
+    # the 24h-before-expiry boundary and getting the reminder is 30
+    # minutes. Acceptable for a 7-day token; tighter cadence wastes
+    # beat cycles for a low-volume table.
+    "check-admission-confirmation-reminders": {
+        "task": "check_admission_confirmation_reminders_task",
+        "schedule": 30 * 60,  # Every 30 minutes
+        "options": {"queue": "default"},
+    },
+
     # --- Nightly Maintenance Tasks ---
     "recalculate-lead-caches-nightly": {
         "task": "recalculate_lead_caches_task",

--- a/Backend_FastAPI/app/core/event_catalog.py
+++ b/Backend_FastAPI/app/core/event_catalog.py
@@ -640,6 +640,95 @@ _ADMISSION_EVENTS: tuple = (
         # Sensitive: contains lead/applicant/user/fee PII or targeted recipient
         privacy="sensitive",
     ),
+    # ADM-028 (2026-04-29): magic-link expiry reminders. Beat task fires
+    # at ~24h and ~6h before the token expires for unconfirmed approved
+    # profiles. Per-token dedupe via reminder_24h_sent_at /
+    # reminder_6h_sent_at columns on AdmissionConfirmationToken.
+    EventDefinition(
+        event=SystemEvents.ADMISSION_CONFIRMATION_REMINDER_24H,
+        category="application",
+        display_name="Nhắc xác nhận nhập học (còn ~24 giờ)",
+        description=(
+            "Beat task gửi nhắc applicant ~24h trước khi liên kết xác nhận hết hạn. "
+            "One-shot per token, dedupe qua reminder_24h_sent_at."
+        ),
+        variables=(
+            _var("application_id", "integer", "ID hồ sơ"),
+            _var("lead_id", "integer", "ID lead (cho lead_contact resolver)"),
+            _var("lead_name", "string", "Họ tên applicant"),
+            _var("expires_at_iso", "string", "ISO datetime — token expiry"),
+            _var("hours_remaining", "integer", "Số giờ còn lại trước expiry"),
+            _var("confirm_url", "string", "URL magic-link trực tiếp"),
+        ),
+        default_resolver="specific_users",
+        allowed_resolvers=("specific_users",),
+        default_channels=("email", "zalo"),
+        priority=30,
+        # Dedupe must include ``expires_at_iso`` so a refreshed token
+        # (different expiry window) gets a fresh reminder. Keying on
+        # ``application_id`` alone would let a previously-fired
+        # reminder block delivery for a re-issued link in the same
+        # 24h scan, even after the beat task cleared
+        # ``reminder_24h_sent_at`` on the new row.
+        dedup_key_template="confirm_reminder_24h:${application_id}:${expires_at_iso}",
+        link_strategy=None,
+        privacy="sensitive",
+    ),
+    EventDefinition(
+        event=SystemEvents.ADMISSION_CONFIRMATION_REMINDER_6H,
+        category="application",
+        display_name="Nhắc xác nhận nhập học (còn ~6 giờ)",
+        description=(
+            "Beat task gửi nhắc applicant ~6h trước khi liên kết xác nhận hết hạn. "
+            "One-shot per token, dedupe qua reminder_6h_sent_at. Có thể fire "
+            "không cần 24h reminder đã fire trước đó (token issued <6h trước expiry)."
+        ),
+        variables=(
+            _var("application_id", "integer", "ID hồ sơ"),
+            _var("lead_id", "integer", "ID lead"),
+            _var("lead_name", "string", "Họ tên applicant"),
+            _var("expires_at_iso", "string", "ISO datetime — token expiry"),
+            _var("hours_remaining", "integer", "Số giờ còn lại"),
+            _var("confirm_url", "string", "URL magic-link"),
+        ),
+        default_resolver="specific_users",
+        allowed_resolvers=("specific_users",),
+        default_channels=("email", "zalo"),
+        priority=20,
+        # Same per-issuance-window keying as the 24h variant —
+        # see comment there.
+        dedup_key_template="confirm_reminder_6h:${application_id}:${expires_at_iso}",
+        link_strategy=None,
+        privacy="sensitive",
+    ),
+    # ADM-023 (2026-04-29): hard-lock awareness. Internal-only fanout
+    # so support can proactively reach out when an applicant has been
+    # hard-locked (≥30 failed CCCD attempts, lock_count incremented).
+    EventDefinition(
+        event=SystemEvents.ADMISSION_CONFIRMATION_HARD_LOCKED,
+        category="application",
+        display_name="Liên kết xác nhận bị khóa (≥30 lần sai CCCD)",
+        description=(
+            "Service raise khi applicant nhập sai CCCD ≥30 lần. Operator "
+            "(officer/manager/admin) nhận notification để chủ động hỗ trợ."
+        ),
+        variables=(
+            _var("application_id", "integer", "ID hồ sơ"),
+            _var("token_id", "integer", "ID confirmation token"),
+            _var("attempt_count", "integer", "Tổng số lần nhập sai"),
+            _var("lock_count", "integer", "Số lần token bị hard-lock"),
+            _var("locked_at_iso", "string", "Thời điểm hard lock"),
+            _var("lead_id", "integer", "ID lead"),
+            _var("lead_name", "string", "Họ tên applicant"),
+        ),
+        default_resolver="lead_owner",
+        allowed_resolvers=("lead_owner", "unit_managers", "all_admins", "specific_users"),
+        default_channels=("browser", "email"),
+        priority=10,
+        dedup_key_template="confirm_hard_locked:${token_id}:${lock_count}",
+        link_strategy="/admissions/${application_id}",
+        privacy="sensitive",
+    ),
 )
 
 # -------------------------------------------------------------------

--- a/Backend_FastAPI/app/core/event_groups.py
+++ b/Backend_FastAPI/app/core/event_groups.py
@@ -92,6 +92,10 @@ EVENT_GROUP_MAPPING: Dict[SystemEvents, NotificationEventGroup] = {
     SystemEvents.APPLICATION_FEE_PAID: NotificationEventGroup.APPLICATION,
     SystemEvents.APPLICATION_SURVEY_DUE: NotificationEventGroup.APPLICATION,
     SystemEvents.APPLICATION_MINOR_CORRECTED: NotificationEventGroup.APPLICATION,
+    # ADM-023 / ADM-028 (2026-04-29): magic-link hardening events
+    SystemEvents.ADMISSION_CONFIRMATION_REMINDER_24H: NotificationEventGroup.APPLICATION,
+    SystemEvents.ADMISSION_CONFIRMATION_REMINDER_6H: NotificationEventGroup.APPLICATION,
+    SystemEvents.ADMISSION_CONFIRMATION_HARD_LOCKED: NotificationEventGroup.APPLICATION,
 
     # Finance events
     SystemEvents.DORM_FEE_CREATED: NotificationEventGroup.FINANCE,

--- a/Backend_FastAPI/app/core/events.py
+++ b/Backend_FastAPI/app/core/events.py
@@ -1126,6 +1126,68 @@ class SystemEvents(str, Enum):
     Recipients: The displaced user (resolver = specific_users on user_id).
     """
 
+    # =============================================================================
+    # ADM-023 / ADM-028 — Magic-link hardening (2026-04-29)
+    # =============================================================================
+
+    ADMISSION_CONFIRMATION_REMINDER_24H = "admission_confirmation_reminder_24h"
+    """
+    Triggered by the magic-link reminder beat task ~24h before the token
+    ``expires_at`` for an unconfirmed approved profile. One-shot per
+    token: ``reminder_24h_sent_at`` is stamped in the same transaction
+    as the dispatch so re-runs don't double-fire even if beat overlaps
+    or the worker retries.
+
+    Payload Schema:
+        {
+            "application_id": int,    # Required: AdmissionProfile ID
+            "lead_id": int,           # Required: Lead ID for contact resolver
+            "lead_name": str,         # Display name
+            "expires_at_iso": str,    # ISO datetime — token expiry
+            "hours_remaining": int,   # ~24, computed at fire time
+            "confirm_url": str,       # Direct magic-link URL
+        }
+
+    Recipients: Applicant (email + Zalo). No internal fanout.
+    """
+
+    ADMISSION_CONFIRMATION_REMINDER_6H = "admission_confirmation_reminder_6h"
+    """
+    Final reminder ~6h before token expiry. Same beat task, same dedupe
+    pattern as the 24h reminder via ``reminder_6h_sent_at``. Firing the
+    6h reminder does NOT depend on the 24h reminder having fired —
+    legitimate token may have crossed both windows already at task
+    start (e.g. issued <6h before expiry on a manual resend).
+
+    Payload Schema: same as ``ADMISSION_CONFIRMATION_REMINDER_24H`` but
+    ``hours_remaining`` ≈ 6.
+
+    Recipients: Applicant (email + Zalo). No internal fanout.
+    """
+
+    ADMISSION_CONFIRMATION_HARD_LOCKED = "admission_confirmation_hard_locked"
+    """
+    Triggered when an applicant's magic-link token crosses the
+    ≥30-failed-attempts hard-lock threshold (``locked_at`` set,
+    ``lock_count`` incremented). Internal-only — the applicant already
+    saw a "link locked" message at the API; this event is the operator
+    awareness signal so support can proactively reach out and unlock
+    if appropriate.
+
+    Payload Schema:
+        {
+            "application_id": int,        # Required: AdmissionProfile ID
+            "token_id": int,              # Required: AdmissionConfirmationToken ID
+            "attempt_count": int,         # Total failed attempts
+            "lock_count": int,            # How many times this token has been hard-locked
+            "locked_at_iso": str,         # When the hard lock fired
+            "lead_id": int,               # Lead ID for context
+            "lead_name": str,             # Display name
+        }
+
+    Recipients: Assigned officer + unit managers + admins.
+    """
+
 
 # =============================================================================
 # EVENT DISPATCHER PATTERN

--- a/Backend_FastAPI/app/core/notification_seed_defaults.py
+++ b/Backend_FastAPI/app/core/notification_seed_defaults.py
@@ -431,6 +431,46 @@ NOTIFICATION_SEED_DEFAULTS: Dict[SystemEvents, Dict[str, Any]] = {
         "notification_type": "warning",
         "recipient_config": {"resolver_type": "specific_users", "params": {}},
     },
+    # ADM-028 (2026-04-29) — magic-link expiry reminders.
+    # Same shape as APPLICATION_SURVEY_DUE: applicant-only delivery
+    # via lead_contact resolver on the action config. The seeded rule
+    # below resolves to ZERO internal recipients on its own; outbound
+    # email/Zalo only fires after ops adds an action with
+    # ``external_resolver="lead_contact"`` (and template_id for ZNS)
+    # via the admin /notification-rules UI. Until that's wired the
+    # beat task marks reminder_*_sent_at without any actual delivery
+    # — accepted operational gap; no reminder spam in the meantime.
+    SystemEvents.ADMISSION_CONFIRMATION_REMINDER_24H: {
+        "title_template": "Còn ~${hours_remaining}h để xác nhận nhập học",
+        "message_template": (
+            "${lead_name}, liên kết xác nhận nhập học của bạn sẽ hết hạn "
+            "vào ${expires_at_iso}. Vui lòng truy cập ${confirm_url} để "
+            "hoàn tất xác nhận."
+        ),
+        "notification_type": "info",
+        "recipient_config": {"resolver_type": "specific_users", "params": {}},
+    },
+    SystemEvents.ADMISSION_CONFIRMATION_REMINDER_6H: {
+        "title_template": "Còn ~${hours_remaining}h — xác nhận nhập học gấp",
+        "message_template": (
+            "${lead_name}, liên kết xác nhận nhập học sẽ hết hạn trong "
+            "vài giờ tới (${expires_at_iso}). Vui lòng xác nhận tại "
+            "${confirm_url} để giữ chỗ."
+        ),
+        "notification_type": "warning",
+        "recipient_config": {"resolver_type": "specific_users", "params": {}},
+    },
+    # ADM-023 (2026-04-29) — hard-lock awareness for operators
+    SystemEvents.ADMISSION_CONFIRMATION_HARD_LOCKED: {
+        "title_template": "🔒 Liên kết xác nhận của ${lead_name} bị khóa",
+        "message_template": (
+            "Liên kết xác nhận của hồ sơ #${application_id} (${lead_name}) "
+            "đã bị khóa do nhập sai CCCD ${attempt_count} lần "
+            "(lock #${lock_count}). Vui lòng kiểm tra và mở khóa nếu cần."
+        ),
+        "notification_type": "warning",
+        "recipient_config": {"resolver_type": "lead_owner", "params": {}},
+    },
     SystemEvents.SYSTEM_ALERT: {
         "title_template": "[${severity}] System Alert",
         "message_template": "${message}",

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -554,7 +554,40 @@ class AdmissionConfirmationToken(Base):
         nullable=True,
         comment="Locked after max failed attempts"
     )
-    
+
+    # ADM-023 (2026-04-29): hybrid cooldown ladder.
+    # ``locked_at`` is the HARD lock (≥30 fails — admin must reset).
+    # ``lock_until`` is the SLIDING cooldown end set on every failed
+    # attempt — request retry rejected with retry_at while NOW() <
+    # lock_until. Cooldown duration scales with attempt_count per the
+    # ladder in ``admission_confirmation_cooldown.cooldown_minutes_for``.
+    lock_until: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Sliding cooldown end. NULL when no cooldown active.",
+    )
+    lock_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        comment="How many times this token has been hard-locked (≥1 = require admin reset).",
+    )
+
+    # ADM-028 (2026-04-29): reminder beat dedupe markers. Beat task
+    # scans for tokens approaching expiry and emits ``ADMISSION_
+    # CONFIRMATION_REMINDER_*`` notifications; these timestamps stop
+    # double-sends if the beat tick overruns or the task retries.
+    reminder_24h_sent_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Set when the 24h-before-expiry reminder has been dispatched.",
+    )
+    reminder_6h_sent_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Set when the 6h-before-expiry reminder has been dispatched.",
+    )
+
     # Creation timestamp
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -1038,22 +1038,52 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         expires_at,
     ) -> models.AdmissionConfirmationToken:
         """
-        Create a new confirmation token for a profile.
-        
-        Invalidates any existing token for the same profile first.
-        
+        Issue (or refresh) the magic-link confirmation token for a profile.
+
+        ADM-023 (2026-04-29): when an existing token row is present we
+        REUSE it — only ``token``, ``expires_at`` and ``confirmed_at``
+        are updated. The brute-force counters (``attempt_count``,
+        ``lock_until``, ``locked_at``, ``lock_count``) are PRESERVED so
+        an abuser can't simply request a fresh link to escape the
+        ladder. The previous behaviour (``DELETE + INSERT``) reset
+        every counter and was the loophole flagged by the resend test.
+
+        Operator-driven cooldown reset is a separate admin path (not
+        in scope for this PR); when it ships, that path will explicitly
+        zero ``lock_until`` / ``lock_count`` with an audit row.
+
         Args:
             profile_id: AdmissionProfile ID
             token: URL-safe random token string
             expires_at: Token expiration timestamp
-            
+
         Returns:
-            Created AdmissionConfirmationToken
+            The single token row (refreshed or newly created).
         """
-        # Delete any existing token for this profile
-        await self.invalidate_existing_tokens(profile_id)
-        
-        # Create new token
+        from sqlalchemy import select as _select
+
+        existing = (
+            await self.db.execute(
+                _select(models.AdmissionConfirmationToken).where(
+                    models.AdmissionConfirmationToken.profile_id == profile_id
+                )
+            )
+        ).scalar_one_or_none()
+
+        if existing is not None:
+            # Refresh value + expiry, clear consumed marker so the new
+            # link is usable. Counters intentionally untouched.
+            existing.token = token
+            existing.expires_at = expires_at
+            existing.confirmed_at = None
+            # New email window starts → previous reminder dedupes are
+            # stale (different expires_at). Reset reminder markers so
+            # the beat task re-fires for the new window.
+            existing.reminder_24h_sent_at = None
+            existing.reminder_6h_sent_at = None
+            await self.db.flush()
+            return existing
+
         token_obj = models.AdmissionConfirmationToken(
             profile_id=profile_id,
             token=token,

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -2072,6 +2072,18 @@ async def confirm_admission_by_token(
     except BadRequest as e:
         # IMPORTANT: Commit to persist attempt_count/locked_at changes
         await db.commit()
+        # ADM-023 (2026-04-29): hard-lock branch attaches a notification
+        # callback to the exception so operator alerts run AFTER the
+        # locked_at + audit row commit (browser realtime + email
+        # enqueue must observe the persisted state). Best-effort: a
+        # callback failure must not turn a 400 into a 500.
+        post_commit = getattr(e, "post_commit_callback", None)
+        if post_commit is not None:
+            try:
+                await post_commit()
+            except Exception:
+                # Logged inside the callback path; don't escalate.
+                pass
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 

--- a/Backend_FastAPI/app/services/admission_confirmation_cooldown.py
+++ b/Backend_FastAPI/app/services/admission_confirmation_cooldown.py
@@ -1,0 +1,85 @@
+"""ADM-023 (2026-04-29): hybrid cooldown ladder for magic-link CCCD verification.
+
+Q9 decision (memory ``admission-audit-wave2-2026-04-28``): A3+B1+C2.
+The applicant's cooldown after a failed CCCD attempt scales with the
+running ``attempt_count``. A pure-function helper keeps the ladder in
+one place so service code, tests, and any future admin UI all read
+the same thresholds.
+
+Ladder
+------
+
+| attempt_count    | cooldown            |
+| ---------------- | ------------------- |
+| 1, 2             | 5 minutes           |
+| 3, 4             | 30 minutes          |
+| 5, 6             | 2 hours (120 min)   |
+| 7 .. 29          | 24 hours (1440 min) |
+| 30 +             | HARD LOCK (admin)   |
+
+The hard-lock branch is signalled by returning ``None`` (not a
+sentinel like ``-1``) so the caller's ``Optional[int]`` type makes
+the "no more cooldowns, escalate" case explicit at the call site.
+
+Resend rate limit (3 per profile per 24h) is handled separately by
+``app/services/admission_confirmation_resend_limit.py`` against
+Redis — that ladder doesn't belong here because resends are a
+different abuse vector (link spam to inbox), not a CCCD brute-force
+defense.
+"""
+from __future__ import annotations
+
+from typing import Final, Optional
+
+
+# Threshold for the "this token must be reset by an admin" branch.
+# Crossing it sets ``token.locked_at`` and increments
+# ``token.lock_count``; further attempts return 403 until reset.
+HARD_LOCK_THRESHOLD: Final[int] = 30
+
+
+# Each tier maps an inclusive attempt-count upper bound to the
+# cooldown that should fire for any attempt within that tier.
+# Ordered from soft to harsh; the first tier whose upper bound is
+# ``>= attempt_count`` wins. Sentinel ``HARD_LOCK_THRESHOLD - 1``
+# closes the ladder before the hard-lock branch.
+_LADDER: Final[tuple[tuple[int, int], ...]] = (
+    (2, 5),
+    (4, 30),
+    (6, 120),
+    (HARD_LOCK_THRESHOLD - 1, 1440),
+)
+
+
+def cooldown_minutes_for(attempt_count: int) -> Optional[int]:
+    """Return the cooldown (minutes) for ``attempt_count`` failed attempts.
+
+    Args:
+        attempt_count: Cumulative failed attempts on the token,
+            **including** the attempt that just failed. ``0`` means no
+            failure yet (returns ``0``); ``1`` means "this is the first
+            failure".
+
+    Returns:
+        Cooldown in minutes, or ``None`` if the count has reached the
+        hard-lock threshold (caller must set ``locked_at`` / increment
+        ``lock_count`` instead of computing a sliding ``lock_until``).
+        ``0`` is returned only for the no-failure case so the caller
+        doesn't need to special-case "no cooldown" vs "5-minute
+        cooldown".
+    """
+    if attempt_count <= 0:
+        return 0
+    if attempt_count >= HARD_LOCK_THRESHOLD:
+        return None
+    for upper, minutes in _LADDER:
+        if attempt_count <= upper:
+            return minutes
+    # Defensive — should not be reached because the last tier's upper
+    # bound covers up to HARD_LOCK_THRESHOLD - 1.
+    return None
+
+
+def is_hard_lock(attempt_count: int) -> bool:
+    """Whether ``attempt_count`` triggers the hard-lock branch."""
+    return attempt_count >= HARD_LOCK_THRESHOLD

--- a/Backend_FastAPI/app/services/admission_confirmation_resend_limit.py
+++ b/Backend_FastAPI/app/services/admission_confirmation_resend_limit.py
@@ -1,0 +1,130 @@
+"""ADM-023 / Q9-C2 (2026-04-29): per-profile magic-link resend rate limit.
+
+Cap: ≤3 resends within any 24h trailing-edge window. Keeps the magic-
+link inbox from being abused as a free SMTP fanout (each resend
+triggers an email or Zalo template send) and gives operators a useful
+audit when applicants legitimately need help.
+
+Window shape (revised 2026-04-29 per P3 review):
+  Redis ``INCR`` increments a per-profile counter; ``EXPIRE`` is
+  re-armed on EVERY hit (not just the first). The bucket therefore
+  clears 24h after the MOST RECENT resend — i.e. attempts 1-3 inside
+  any sliding 24h trailing-edge keep the counter alive; only a
+  full 24h of silence resets it. This is STRICTER than the original
+  "fixed 24h from first hit" shape (which would let an abuser burst
+  3 → wait 24h → 3 again every 24h cleanly); the new shape forces
+  every burst to cool the entire window before it can repeat.
+
+  For a 3-in-24h cap that's appropriate — legitimate applicants who
+  hit the limit once typically wait through the 24h naturally
+  anyway, and the strictness makes the audit signal cleaner ("4th
+  attempt in <24h since the last" is a single rule).
+
+Failure-mode policy: when the Redis breaker is open (``safe_redis_*``
+returns ``None`` / falsy), this helper returns ``None`` and the
+caller MUST fail closed — refuse the resend rather than fail-open.
+This mirrors the F-2 hardening on the Zalo bot rate limiter (memory
+``zalo-bot-audit-gap``); a brittle Redis is not an excuse to lift a
+spam cap. The audit log row records the breaker-open reason so ops
+can see Redis flapped during user reports.
+
+Companion of ``admission_confirmation_cooldown`` — that module covers
+the CCCD brute-force ladder; this one covers the resend-spam ladder.
+They run on different counters and never share state.
+"""
+from __future__ import annotations
+
+import structlog
+from typing import Final, Optional
+
+from ..database import safe_redis_expire, safe_redis_incr
+
+
+log = structlog.get_logger(__name__)
+
+
+# Cap chosen by Q9 decision 2026-04-28. If product later wants to
+# differentiate by role (e.g. admin can resend more), pull this into
+# a per-actor helper rather than parameterising — the single value
+# matches the audit trail's "resend was blocked because we already
+# sent N" message verbatim.
+RESEND_CAP_PER_24H: Final[int] = 3
+RESEND_WINDOW_SECONDS: Final[int] = 24 * 60 * 60
+
+
+def _resend_key(profile_id: int) -> str:
+    return f"admission:confirm:resend:{profile_id}"
+
+
+async def consume_resend_quota(profile_id: int) -> Optional[int]:
+    """Atomically count and consume one resend slot for ``profile_id``.
+
+    Returns:
+        - The post-increment count when Redis is up. Caller checks
+          ``count <= RESEND_CAP_PER_24H`` to decide whether to send.
+        - ``None`` when the Redis breaker is open OR the TTL arm
+          fails. Caller MUST fail closed (block the resend).
+
+    Window semantics: TTL is (re-)armed on EVERY hit, so the bucket
+    clears 24h after the most recent resend — see module docstring
+    for why this trailing-edge shape was chosen over a fixed window
+    from first hit. Cost is one extra Redis roundtrip per attempt
+    (negligible at 3/24h).
+
+    Why fail-closed on EXPIRE failure (P3 review 2026-04-29):
+        The previous shape only armed the 24h TTL on the first hit
+        (``count == 1``). If ``INCR`` succeeded but ``EXPIRE``
+        immediately after failed (Redis flap between calls), the key
+        survived without a TTL — once the cap was crossed, that
+        profile would be locked out indefinitely until manual cleanup.
+        Now ``EXPIRE`` is called on every hit and any failure is
+        treated as a quota-service failure: bail with ``None`` so the
+        caller can decline the request.
+    """
+    key = _resend_key(profile_id)
+    count = await safe_redis_incr(key)
+    if count is None:
+        log.warning(
+            "Resend quota check failed: Redis INCR breaker open — failing closed",
+            profile_id=profile_id,
+        )
+        return None
+
+    # Re-arm TTL on every hit. Three effects:
+    #   1. The bucket becomes trailing-edge (24h from MOST RECENT
+    #      hit) — see module docstring for why we chose this over
+    #      "fixed 24h from first hit".
+    #   2. A missing/expired TTL on a stray legacy key gets healed.
+    #   3. An EXPIRE failure on the FIRST hit can no longer leave a
+    #      permanent counter (the bug the previous shape had).
+    # EXPIRE failure here means the bucket may not bound to 24h —
+    # fail-closed rather than risk an indefinite lockout.
+    expire_ok = await safe_redis_expire(key, RESEND_WINDOW_SECONDS)
+    if not expire_ok:
+        log.warning(
+            "Resend quota check failed: Redis EXPIRE returned falsy — failing closed",
+            profile_id=profile_id,
+            count_after_incr=count,
+        )
+        return None
+    return count
+
+
+async def peek_resend_count(profile_id: int) -> Optional[int]:
+    """Read the current resend count WITHOUT consuming a slot.
+
+    Useful for status / diagnostic endpoints. ``None`` when Redis is
+    down (callers should treat as "unknown", not "zero").
+    """
+    from ..database import safe_redis_get
+
+    key = _resend_key(profile_id)
+    val = await safe_redis_get(key)
+    if val is None:
+        return None
+    try:
+        return int(val)
+    except (TypeError, ValueError):
+        # Defensive — Redis stored something we didn't write. Treat
+        # as unknown so we don't authorise on bad data.
+        return None

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -7284,13 +7284,65 @@ async def generate_confirmation_token(
             f"Cannot generate confirmation token for profile with status '{profile.status}'. "
             "Only approved profiles can receive confirmation links."
         )
-    
+
+    # ADM-023 / Q9-C2 (2026-04-29): per-profile resend cap. The same
+    # entry point handles initial issuance (auto-fired by approve)
+    # AND operator-driven resends; cap=3 means each profile gets one
+    # automatic + two manual resends per 24h before requiring support.
+    # Fail-closed when Redis is down (None) so a brittle cache is not
+    # an excuse to lift the spam cap — see resend_limit module
+    # docstring for the rationale.
+    from .admission_confirmation_resend_limit import (
+        consume_resend_quota,
+        RESEND_CAP_PER_24H,
+    )
+    count = await consume_resend_quota(profile.id)
+    if count is None:
+        raise BadRequest(
+            "Tạm thời không thể gửi lại liên kết xác nhận do hệ thống đang "
+            "bận. Vui lòng thử lại sau ít phút."
+        )
+    if count > RESEND_CAP_PER_24H:
+        # Audit: persistent record so ops can correlate user reports
+        # with the cap. Run on a separate session so the row survives
+        # the BadRequest rollback.
+        from ..database import AsyncSessionLocal
+        from ..services import audit_service
+
+        try:
+            async with AsyncSessionLocal() as audit_db:
+                await audit_service.log_audit(
+                    audit_db,
+                    entity_type="AdmissionProfile",
+                    entity_id=profile.id,
+                    action="confirmation_resend_rate_limited",
+                    actor_user_id=None,
+                    changes={
+                        "attempt_count_in_window": {"old": None, "new": count},
+                        "cap": {"old": None, "new": RESEND_CAP_PER_24H},
+                    },
+                    reason="Per-profile 24h resend cap reached",
+                    source="magic_link",
+                )
+                await audit_db.commit()
+        except Exception as audit_err:  # noqa: BLE001 — best-effort audit
+            log.error(
+                "Resend rate-limit audit write FAILED",
+                profile_id=profile.id,
+                error=str(audit_err),
+            )
+
+        raise BadRequest(
+            f"Đã gửi lại liên kết {RESEND_CAP_PER_24H} lần trong 24 giờ qua. "
+            "Vui lòng liên hệ phòng tuyển sinh nếu cần hỗ trợ thêm."
+        )
+
     # Generate secure token
     token_value = secrets.token_urlsafe(32)  # 256-bit entropy
     expires_at = datetime.now(timezone.utc) + timedelta(
         days=settings.ADMISSION_CONFIRM_TOKEN_EXPIRE_DAYS
     )
-    
+
     # Create token via repository
     repo = AdmissionRepository(db)
     token_obj = await repo.create_confirmation_token(
@@ -7466,35 +7518,159 @@ async def verify_and_confirm(
     if token_obj.expires_at < now:
         raise BadRequest("This confirmation link has expired. Please request a new link.")
 
+    # ADM-023 (2026-04-29): hybrid cooldown gate. Sliding ``lock_until``
+    # is set on every failed attempt by the cooldown ladder; serving a
+    # retry while it's still in the future would defeat the brute-force
+    # defence. Distinct from ``locked_at`` (hard lock) above —
+    # ``lock_until`` clears itself by passage of time, ``locked_at``
+    # only by an admin.
+    if token_obj.lock_until is not None and token_obj.lock_until > now:
+        retry_in_seconds = int((token_obj.lock_until - now).total_seconds())
+        raise BadRequest(
+            f"Quá nhiều lần nhập sai. Vui lòng thử lại sau {retry_in_seconds} giây."
+        )
+
     # Get profile and verify CCCD
     profile = token_obj.profile
     if not profile or not profile.citizen_id:
         raise BadRequest("Profile data is incomplete. Please contact support.")
-    
+
     # Verify last 4 digits
     expected_digits = profile.citizen_id[-settings.ADMISSION_CONFIRM_CCCD_DIGITS:]
-    
+
     if last_digits != expected_digits:
-        # Increment attempts
-        await repo.increment_token_attempts(token_obj, settings.ADMISSION_CONFIRM_MAX_ATTEMPTS)
-        
-        attempts_remaining = max(0, settings.ADMISSION_CONFIRM_MAX_ATTEMPTS - token_obj.attempt_count)
-        
-        if token_obj.locked_at is not None:
+        # ADM-023 (2026-04-29): hybrid cooldown ladder + hard-lock at 30.
+        # Step 1 — bump the attempt counter. We pass HARD_LOCK_THRESHOLD
+        # (30) instead of the legacy ``ADMISSION_CONFIRM_MAX_ATTEMPTS``
+        # (5) so the repo helper's "lock when count >= max" branch
+        # fires at the SAME threshold the ladder uses for hard lock.
+        # Without this, the legacy 5-attempt lock would short-circuit
+        # the ladder before the 30/120/1440-minute cooldowns ever
+        # kicked in. The legacy setting is kept for the FE
+        # "attempts_remaining" display only.
+        from .admission_confirmation_cooldown import (
+            HARD_LOCK_THRESHOLD,
+            cooldown_minutes_for,
+            is_hard_lock,
+        )
+        await repo.increment_token_attempts(token_obj, HARD_LOCK_THRESHOLD)
+        from datetime import timedelta as _timedelta
+
+        if is_hard_lock(token_obj.attempt_count):
+            # Hard lock. ``locked_at`` may have been set already by the
+            # repo helper at the legacy MAX_ATTEMPTS threshold; either
+            # way we mirror it here so audit + ``lock_count`` always
+            # advance on the actual hard-lock crossing.
+            if token_obj.locked_at is None:
+                token_obj.locked_at = now
+            token_obj.lock_count = (token_obj.lock_count or 0) + 1
+            token_obj.lock_until = None  # superseded by hard lock
+
+            # Audit so compliance can reconstruct who attempted to brute
+            # force which profile, when. ``actor_user_id=None`` because
+            # the magic-link path is public/applicant-driven.
+            from ..services import audit_service
+            await audit_service.log_audit(
+                db,
+                entity_type="AdmissionConfirmationToken",
+                entity_id=token_obj.id,
+                action="confirmation_hard_locked",
+                actor_user_id=None,
+                changes={
+                    "attempt_count": {
+                        "old": None,
+                        "new": token_obj.attempt_count,
+                    },
+                    "lock_count": {
+                        "old": None,
+                        "new": token_obj.lock_count,
+                    },
+                    "profile_id": {"old": None, "new": profile.id},
+                },
+                reason="≥30 failed CCCD attempts",
+                source="magic_link",
+            )
+
+            # Operator awareness: dispatch hard-lock event so
+            # officer/manager can proactively reach out and unlock.
+            # The router commits the BadRequest-side mutations (audit
+            # + locked_at + lock_count) at the ``except BadRequest``
+            # branch, so the dispatch's post-commit callback also runs
+            # AFTER that commit. We attach the callback to the
+            # exception and the router awaits it before raising the
+            # HTTP error — without this hand-off browser realtime +
+            # email enqueue would never happen.
+            from .notification_dispatcher import dispatch as _dispatch
+            from .notification_dispatcher import _rooms_for_admission
+            hard_lock_cb = None
+            try:
+                _, hard_lock_cb = await _dispatch(
+                    db=db,
+                    event=SystemEvents.ADMISSION_CONFIRMATION_HARD_LOCKED,
+                    payload={
+                        "application_id": profile.id,
+                        "token_id": token_obj.id,
+                        "attempt_count": token_obj.attempt_count,
+                        "lock_count": token_obj.lock_count,
+                        "locked_at_iso": token_obj.locked_at.isoformat()
+                        if token_obj.locked_at
+                        else now.isoformat(),
+                        "lead_id": profile.lead_id,
+                        "lead_name": (
+                            profile.lead.full_name
+                            if profile.lead
+                            else "Học viên"
+                        ),
+                    },
+                    rooms=_rooms_for_admission(profile),
+                )
+            except Exception as dispatch_err:  # noqa: BLE001 — best-effort
+                # Dispatch failure must NOT block the hard-lock
+                # response — the audit row is already written
+                # in-txn so compliance is captured. Notification is
+                # operator-courtesy, not safety-critical.
+                log.error(
+                    "Magic-link hard-lock dispatch failed",
+                    token_id=token_obj.id,
+                    profile_id=profile.id,
+                    error=str(dispatch_err),
+                )
+
             log.warning(
-                "Confirmation token locked after max attempts",
+                "Magic-link hard lock triggered",
                 token_id=token_obj.id,
                 profile_id=profile.id,
+                attempt_count=token_obj.attempt_count,
+                lock_count=token_obj.lock_count,
             )
-            raise BadRequest(
-                "Too many failed attempts. This confirmation link has been locked. "
-                "Please contact support for assistance."
+            exc = BadRequest(
+                "Liên kết xác nhận đã bị khóa do quá nhiều lần nhập sai. "
+                "Vui lòng liên hệ phòng tuyển sinh để được mở khóa."
             )
-        
+            # Hand the post-commit callback back to the router. The
+            # router commits the BadRequest-side mutations (the
+            # ``except BadRequest`` branch in admissions.py
+            # ``confirm_admission_via_magic_link`` already does
+            # ``await db.commit()`` then raises) and we want the
+            # notification fanout to run AFTER that commit, not
+            # before — otherwise the notification can reference
+            # state that hasn't been persisted yet.
+            if hard_lock_cb is not None:
+                exc.post_commit_callback = hard_lock_cb  # type: ignore[attr-defined]
+            raise exc
+
+        cooldown_min = cooldown_minutes_for(token_obj.attempt_count) or 0
+        token_obj.lock_until = now + _timedelta(minutes=cooldown_min)
+        attempts_remaining = max(
+            0, settings.ADMISSION_CONFIRM_MAX_ATTEMPTS - token_obj.attempt_count
+        )
+
         log.warning(
             "CCCD verification failed",
             token_id=token_obj.id,
             profile_id=profile.id,
+            attempt_count=token_obj.attempt_count,
+            cooldown_minutes=cooldown_min,
             attempts_remaining=attempts_remaining,
         )
         raise BadRequest(

--- a/Backend_FastAPI/app/tasks/__init__.py
+++ b/Backend_FastAPI/app/tasks/__init__.py
@@ -39,7 +39,10 @@ from .collaborator_tasks import (
     check_ctv_attribution_expiry_task,
     send_ctv_weekly_summary_task,
 )
-from .admission_tasks import check_admission_surveys_due_task
+from .admission_tasks import (
+    check_admission_surveys_due_task,
+    check_admission_confirmation_reminders_task,
+)
 
 __all__ = [
     # Email tasks
@@ -67,4 +70,5 @@ __all__ = [
     "send_ctv_weekly_summary_task",
     # Admission tasks
     "check_admission_surveys_due_task",
+    "check_admission_confirmation_reminders_task",
 ]

--- a/Backend_FastAPI/app/tasks/admission_tasks.py
+++ b/Backend_FastAPI/app/tasks/admission_tasks.py
@@ -250,3 +250,313 @@ def check_admission_surveys_due_task(self):
         },
     )
     return result
+
+
+# =============================================================================
+# ADM-028 (2026-04-29): magic-link confirmation reminder beat
+# =============================================================================
+#
+# Two reminder windows: ~24h and ~6h before token expiry. Per-token
+# dedupe via ``reminder_24h_sent_at`` / ``reminder_6h_sent_at`` columns.
+# Beat fires every 30 min so the worst-case lag between "applicant
+# crosses the 24h boundary" and "applicant gets the reminder" is 30
+# minutes — acceptable for a 7-day token.
+#
+# Eligibility filter (both windows):
+#   * confirmed_at IS NULL  → token still pending
+#   * locked_at IS NULL     → not hard-locked (no reminder for locked)
+#   * expires_at > now()    → not expired (no reminder for stale)
+# Plus per-window:
+#   * expires_at - now() <= window_seconds
+#   * reminder_<window>_sent_at IS NULL
+#
+# Failure isolation: per-token ``begin_nested`` savepoint so a single
+# missing email/phone does not poison the batch.
+
+
+@celery_app.task(
+    name="check_admission_confirmation_reminders_task",
+    bind=True,
+    autoretry_for=(Exception,),
+    max_retries=2,
+    default_retry_delay=180,
+)
+def check_admission_confirmation_reminders_task(self):
+    """Scan unconfirmed magic-link tokens approaching expiry; fire
+    24h / 6h reminder events with idempotent dedupe markers.
+    """
+    task_name = "check_admission_confirmation_reminders_task"
+    task_log = logging.getLogger(task_name)
+
+    task_log.info(
+        "magic_link_reminder heartbeat: start",
+        extra={"event": "magic_link_reminder_heartbeat", "phase": "start"},
+    )
+
+    async def _run() -> dict:
+        from ..config import settings
+        from ..core.events import SystemEvents
+        from ..models import (
+            AdmissionConfirmationToken,
+            NotificationAction,
+            NotificationRule,
+        )
+        from ..models.lead import Lead
+        from ..models.admission import AdmissionProfile as _ProfileModel
+        from ..services import notification_dispatcher
+        from ..services.notification_dispatcher import _rooms_for_admission
+
+        result = {
+            "checked": 0,
+            "sent_24h": 0,
+            "sent_6h": 0,
+            "failed": 0,
+            "skipped_no_email_phone": 0,
+            "skipped_unconfigured": 0,
+        }
+
+        post_commit_callbacks = []
+        now = datetime.now(timezone.utc)
+        window_24h = now + timedelta(hours=24)
+        window_6h = now + timedelta(hours=6)
+
+        async def _delivery_configured(
+            session, event_value: str
+        ) -> bool:
+            """ADM-028 review (P2): a rule is only useful for these
+            applicant-only reminders if it has at least one enabled
+            action with ``config.external_resolver = 'lead_contact'``.
+            Without that, ``dispatch()`` resolves to zero internal
+            recipients and zero external deliveries — but the task
+            previously stamped ``reminder_*_sent_at`` anyway, locking
+            the token out of future retries even after ops finally
+            wired the rule.
+
+            Pre-flight check at task start so the gate is one query
+            per scan, not per token.
+            """
+            rule = (
+                await session.execute(
+                    select(NotificationRule).where(
+                        NotificationRule.event == event_value,
+                        NotificationRule.enabled.is_(True),
+                    )
+                )
+            ).scalar_one_or_none()
+            if rule is None:
+                return False
+            actions = (
+                await session.execute(
+                    select(NotificationAction).where(
+                        NotificationAction.rule_id == rule.id
+                    )
+                )
+            ).scalars().all()
+            for action in actions:
+                config = action.config or {}
+                if config.get("external_resolver") == "lead_contact":
+                    return True
+            return False
+
+        async with task_db_session() as session:
+            # P2 review: gate the whole scan on rule configuration.
+            # Without ``lead_contact`` action, the dispatch is a no-op
+            # and stamping reminder_*_sent_at would silently consume
+            # the only retry window the token has.
+            cfg_24h = await _delivery_configured(
+                session, SystemEvents.ADMISSION_CONFIRMATION_REMINDER_24H.value
+            )
+            cfg_6h = await _delivery_configured(
+                session, SystemEvents.ADMISSION_CONFIRMATION_REMINDER_6H.value
+            )
+            if not cfg_24h and not cfg_6h:
+                task_log.warning(
+                    "magic_link_reminder: no rule with lead_contact "
+                    "external resolver configured — skipping scan",
+                    extra={
+                        "event": "magic_link_reminder_heartbeat",
+                        "phase": "skipped_unconfigured",
+                    },
+                )
+                # Don't even fetch tokens; nothing to do.
+                return result
+            # One scan covers both windows — partial index
+            # ``ix_admission_confirmation_token_reminder_scan`` keeps it
+            # cheap. Per-token branch picks 6h vs 24h vs both.
+            base_conditions = [
+                AdmissionConfirmationToken.confirmed_at.is_(None),
+                AdmissionConfirmationToken.locked_at.is_(None),
+                AdmissionConfirmationToken.expires_at > now,
+                AdmissionConfirmationToken.expires_at <= window_24h,
+            ]
+            query = (
+                select(AdmissionConfirmationToken)
+                .options(
+                    selectinload(AdmissionConfirmationToken.profile)
+                    .selectinload(_ProfileModel.lead)
+                )
+                .where(and_(*base_conditions))
+                .order_by(AdmissionConfirmationToken.expires_at.asc())
+                .limit(500)
+            )
+            tokens = (await session.execute(query)).scalars().all()
+            result["checked"] = len(tokens)
+
+            for token in tokens:
+                try:
+                    async with session.begin_nested():
+                        profile = token.profile
+                        if profile is None or profile.lead is None:
+                            result["skipped_no_email_phone"] += 1
+                            continue
+                        lead = profile.lead
+                        if not (lead.email or getattr(lead, "phone", None)):
+                            # Without contact channels there's no way to
+                            # deliver the reminder. Mark BOTH windows
+                            # consumed so the token drops out of future
+                            # scans — operator has the dashboard if they
+                            # want to chase manually.
+                            token.reminder_24h_sent_at = now
+                            token.reminder_6h_sent_at = now
+                            result["skipped_no_email_phone"] += 1
+                            continue
+
+                        # Decide which window(s) to fire. Both can fire
+                        # in one tick when the token was issued <6h
+                        # before expiry — just dispatch them as two
+                        # discrete events, each with its own dedupe.
+                        in_6h_window = token.expires_at <= window_6h
+                        confirm_url = (
+                            f"{settings.FRONTEND_URL.rstrip('/')}"
+                            f"/confirm/{token.token}"
+                        )
+                        rooms = _rooms_for_admission(profile)
+
+                        if (
+                            not in_6h_window
+                            and token.reminder_24h_sent_at is None
+                        ):
+                            if not cfg_24h:
+                                # P2 review: rule has no lead_contact
+                                # action — dispatch is a no-op. Don't
+                                # mark sent_at so the next scan can
+                                # retry once ops wires the rule.
+                                result["skipped_unconfigured"] += 1
+                            else:
+                                hours_remaining = max(
+                                    0,
+                                    int(
+                                        (token.expires_at - now).total_seconds()
+                                        // 3600
+                                    ),
+                                )
+                                _, cb = await notification_dispatcher.dispatch(
+                                    db=session,
+                                    event=SystemEvents.ADMISSION_CONFIRMATION_REMINDER_24H,
+                                    payload={
+                                        "application_id": profile.id,
+                                        "lead_id": lead.id,
+                                        "lead_name": lead.full_name or "Học viên",
+                                        "expires_at_iso": token.expires_at.isoformat(),
+                                        "hours_remaining": hours_remaining,
+                                        "confirm_url": confirm_url,
+                                    },
+                                    rooms=rooms,
+                                )
+                                if cb:
+                                    post_commit_callbacks.append(cb)
+                                token.reminder_24h_sent_at = now
+                                result["sent_24h"] += 1
+
+                        if (
+                            in_6h_window
+                            and token.reminder_6h_sent_at is None
+                        ):
+                            if not cfg_6h:
+                                result["skipped_unconfigured"] += 1
+                            else:
+                                hours_remaining = max(
+                                    0,
+                                    int(
+                                        (token.expires_at - now).total_seconds()
+                                        // 3600
+                                    ),
+                                )
+                                _, cb = await notification_dispatcher.dispatch(
+                                    db=session,
+                                    event=SystemEvents.ADMISSION_CONFIRMATION_REMINDER_6H,
+                                    payload={
+                                        "application_id": profile.id,
+                                        "lead_id": lead.id,
+                                        "lead_name": lead.full_name or "Học viên",
+                                        "expires_at_iso": token.expires_at.isoformat(),
+                                        "hours_remaining": hours_remaining,
+                                        "confirm_url": confirm_url,
+                                    },
+                                    rooms=rooms,
+                                )
+                                if cb:
+                                    post_commit_callbacks.append(cb)
+                                token.reminder_6h_sent_at = now
+                                # If the 24h reminder hadn't fired yet (e.g.
+                                # token issued <6h before expiry) we mark it
+                                # consumed too — sending both within minutes
+                                # of each other would just be noise. Only
+                                # do this when 24h ALSO has a configured
+                                # delivery; otherwise the marker would
+                                # short-circuit a future retry once ops
+                                # wires the 24h rule.
+                                if (
+                                    token.reminder_24h_sent_at is None
+                                    and cfg_24h
+                                ):
+                                    token.reminder_24h_sent_at = now
+                                result["sent_6h"] += 1
+
+                except Exception:
+                    task_log.exception(
+                        "magic_link_reminder per-token failure",
+                        extra={"token_id": getattr(token, "id", None)},
+                    )
+                    result["failed"] += 1
+
+            await session.commit()
+            for cb in post_commit_callbacks:
+                try:
+                    await cb()
+                except Exception:
+                    task_log.exception("post_commit callback failed")
+
+        return result
+
+    result = run_async_task(
+        async_func=_run,
+        task_name=task_name,
+        task_log=task_log,
+        validate_keys=[
+            "checked",
+            "sent_24h",
+            "sent_6h",
+            "failed",
+            "skipped_no_email_phone",
+            "skipped_unconfigured",
+        ],
+    )
+
+    if result["sent_24h"] + result["sent_6h"] > 0:
+        outcome = "dispatched"
+    elif result["checked"] == 0:
+        outcome = "idle"
+    else:
+        outcome = "no_send"
+    task_log.info(
+        "magic_link_reminder heartbeat: end (%s)",
+        outcome,
+        extra={
+            "event": "magic_link_reminder_heartbeat",
+            "phase": "end",
+            "outcome": outcome,
+            **result,
+        },
+    )
+    return result

--- a/Backend_FastAPI/tests/integration/test_admission_confirmation_lock_ladder.py
+++ b/Backend_FastAPI/tests/integration/test_admission_confirmation_lock_ladder.py
@@ -1,0 +1,408 @@
+"""ADM-023 (2026-04-29): integration tests for the magic-link cooldown
+ladder + hard-lock contract in ``verify_and_confirm``.
+
+Pin the four risk-surface scenarios called out by Q9:
+1. Repeated CCCD failures step the ladder (5 → 30 → 120 → 1440 min)
+   and stamp ``lock_until`` accordingly.
+2. ≥30 failures hard-lock the token (``locked_at`` set, ``lock_count``
+   incremented, audit row written, hard-lock event dispatched).
+3. After ``lock_until`` elapses, the next attempt is admitted again
+   (only the SLIDING cooldown — hard lock is permanent).
+4. Successful confirmation does not reset the lock counters
+   retroactively (current spec: success is terminal — token consumed,
+   future attempts hit ``confirmed_at IS NOT NULL`` branch first).
+
+Test pattern mirrors ``tests/integration/test_admission_confirm_lock``:
+use ``AsyncSessionLocal`` directly so the lock + audit semantics are
+exercised end-to-end at the service boundary, not mocked out.
+"""
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.services import admission_service
+from app.services.admission_confirmation_cooldown import HARD_LOCK_THRESHOLD
+from app.utils.exceptions import BadRequest
+
+from tests.integration.test_admission_state_transitions import (
+    create_test_lead,
+    create_admission_profile,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# Citizen id chosen so last 4 digits ≠ "0000" — the bad input we'll
+# feed in to drive the ladder. Token TTL stays at default 7d.
+_CITIZEN_ID = "001202999999"  # last 4: 9999
+_CORRECT_DIGITS = "9999"
+_WRONG_DIGITS = "0000"
+
+
+async def _seed_token(unit_id: int, admin_user_id: int) -> tuple[int, str]:
+    """Create lead + approved profile + active confirmation token.
+
+    ``admin_user_id`` is needed because ``create_admission_profile``
+    falls back to ``approved_by_id=1`` for approved+ status when not
+    given an explicit user — and the test DB doesn't seed user 1.
+    Pass the ``admin_user_in_db`` fixture id through.
+    """
+    lead_id = await create_test_lead(unit_id)
+    profile = await create_admission_profile(
+        lead_id,
+        status="approved",
+        citizen_id=_CITIZEN_ID,
+        approved_by_id=admin_user_id,
+    )
+    token_value = secrets.token_urlsafe(32)
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            session.add(
+                models.AdmissionConfirmationToken(
+                    profile_id=profile.id,
+                    token=token_value,
+                    expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+                )
+            )
+    return profile.id, token_value
+
+
+async def _reload_token(token_value: str) -> models.AdmissionConfirmationToken:
+    async with AsyncSessionLocal() as session:
+        row = await session.execute(
+            select(models.AdmissionConfirmationToken).where(
+                models.AdmissionConfirmationToken.token == token_value
+            )
+        )
+        return row.scalar_one()
+
+
+# ============================================================================
+# Cooldown ladder
+# ============================================================================
+
+
+class TestCooldownLadder:
+    """Repeated wrong CCCD walks the 5/30/120/1440-min ladder."""
+
+    @pytest.mark.parametrize(
+        "attempts,expected_min",
+        [
+            (1, 5),
+            (2, 5),
+            (3, 30),
+            (5, 120),
+            (7, 1440),
+            (29, 1440),
+        ],
+    )
+    async def test_lock_until_steps_with_attempt_count(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        attempts,
+        expected_min,
+    ):
+        """After ``attempts`` consecutive bad attempts, ``lock_until``
+        is ~``expected_min`` minutes in the future and ``attempt_count``
+        equals ``attempts``."""
+        profile_id, token_value = await _seed_token(seed_lead_dependencies["unit_id"], admin_user_in_db["id"])
+
+        # Walk the ladder: each call raises BadRequest because we're
+        # supplying a wrong CCCD. We expect the LAST call's lock_until
+        # to reflect the matching ladder rung. Between calls we have
+        # to clear lock_until manually because the ladder gates ANY
+        # further attempt while lock_until is in the future — the
+        # whole point of the rung is to slow down the attacker — but
+        # for the LADDER test we want to walk all the way through
+        # without sleeping. Setting ``lock_until = NULL`` between
+        # attempts is the test scaffold; production code never does.
+        for i in range(attempts):
+            async with AsyncSessionLocal() as session:
+                # Clear sliding cooldown so the next attempt isn't
+                # rejected at the lock_until gate.
+                await session.execute(
+                    select(models.AdmissionConfirmationToken).where(
+                        models.AdmissionConfirmationToken.token == token_value
+                    )
+                )
+                tok_row = (
+                    await session.execute(
+                        select(models.AdmissionConfirmationToken).where(
+                            models.AdmissionConfirmationToken.token == token_value
+                        )
+                    )
+                ).scalar_one()
+                tok_row.lock_until = None
+                await session.commit()
+
+            async with AsyncSessionLocal() as session:
+                with pytest.raises(BadRequest):
+                    await admission_service.verify_and_confirm(
+                        db=session,
+                        token_value=token_value,
+                        last_digits=_WRONG_DIGITS,
+                    )
+                await session.commit()
+
+        token = await _reload_token(token_value)
+        assert token.attempt_count == attempts, (
+            f"attempt_count expected {attempts}, got {token.attempt_count}"
+        )
+        # Last attempt set lock_until — sanity-check it's in the future
+        # AND within ~1 minute of the expected rung. Allow generous
+        # slack to absorb test-runner scheduling jitter.
+        now = datetime.now(timezone.utc)
+        assert token.lock_until is not None, "lock_until must be set after a failed attempt"
+        delta_min = (token.lock_until - now).total_seconds() / 60
+        assert abs(delta_min - expected_min) <= 1, (
+            f"lock_until ~{expected_min}m expected, got {delta_min:.2f}m"
+        )
+
+    async def test_lock_until_blocks_until_elapsed(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+    ):
+        """While ``lock_until > now()`` further attempts are rejected
+        with the cooldown-retry message — the ladder is enforced, not
+        just stamped."""
+        profile_id, token_value = await _seed_token(seed_lead_dependencies["unit_id"], admin_user_in_db["id"])
+
+        # First wrong attempt sets a 5-minute cooldown.
+        async with AsyncSessionLocal() as session:
+            with pytest.raises(BadRequest):
+                await admission_service.verify_and_confirm(
+                    db=session,
+                    token_value=token_value,
+                    last_digits=_WRONG_DIGITS,
+                )
+            await session.commit()
+
+        # Second attempt during the cooldown — even with the CORRECT
+        # digits — must be rejected.
+        async with AsyncSessionLocal() as session:
+            with pytest.raises(BadRequest) as exc_info:
+                await admission_service.verify_and_confirm(
+                    db=session,
+                    token_value=token_value,
+                    last_digits=_CORRECT_DIGITS,
+                )
+            assert "thử lại sau" in str(exc_info.value).lower()
+
+
+# ============================================================================
+# Hard lock at ≥30
+# ============================================================================
+
+
+class TestHardLock:
+    """Crossing the 30-attempt threshold flips ``locked_at`` permanently."""
+
+    async def test_30_attempts_hard_locks_with_audit_row(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+    ):
+        """Drive attempts straight to the threshold, then verify the
+        token state and audit log."""
+        profile_id, token_value = await _seed_token(seed_lead_dependencies["unit_id"], admin_user_in_db["id"])
+
+        # Pre-stage attempt_count just below the threshold so we hit
+        # the hard lock on the 30th increment WITHOUT walking the full
+        # 30-attempt ladder in real time. ``lock_until = None`` so each
+        # service call is admitted past the cooldown gate.
+        async with AsyncSessionLocal() as session:
+            tok = (
+                await session.execute(
+                    select(models.AdmissionConfirmationToken).where(
+                        models.AdmissionConfirmationToken.token == token_value
+                    )
+                )
+            ).scalar_one()
+            tok.attempt_count = HARD_LOCK_THRESHOLD - 1
+            tok.lock_until = None
+            await session.commit()
+
+        # The 30th failure crosses the threshold.
+        async with AsyncSessionLocal() as session:
+            with pytest.raises(BadRequest) as exc_info:
+                await admission_service.verify_and_confirm(
+                    db=session,
+                    token_value=token_value,
+                    last_digits=_WRONG_DIGITS,
+                )
+            await session.commit()
+            assert "khóa" in str(exc_info.value).lower()
+
+        token = await _reload_token(token_value)
+        assert token.attempt_count >= HARD_LOCK_THRESHOLD
+        assert token.locked_at is not None, "locked_at must be set at hard lock"
+        assert token.lock_count == 1, (
+            f"lock_count expected 1 after first hard lock, got {token.lock_count}"
+        )
+
+        # Audit row must persist regardless of the BadRequest rollback —
+        # the in-txn audit is committed when the test session.commit()
+        # above settles. Probe a fresh session to read it back.
+        async with AsyncSessionLocal() as session:
+            rows = (
+                await session.execute(
+                    select(models.EntityAuditLog).where(
+                        models.EntityAuditLog.entity_type
+                        == "AdmissionConfirmationToken",
+                        models.EntityAuditLog.entity_id == token.id,
+                        models.EntityAuditLog.action == "confirmation_hard_locked",
+                    )
+                )
+            ).scalars().all()
+            assert len(rows) == 1, f"expected 1 audit row, got {len(rows)}"
+            assert rows[0].changes["lock_count"]["new"] == 1
+
+    async def test_hard_locked_token_cannot_be_used_after(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+    ):
+        """Once locked_at is set, even the correct CCCD is refused —
+        applicant must request support to unlock."""
+        profile_id, token_value = await _seed_token(seed_lead_dependencies["unit_id"], admin_user_in_db["id"])
+
+        async with AsyncSessionLocal() as session:
+            tok = (
+                await session.execute(
+                    select(models.AdmissionConfirmationToken).where(
+                        models.AdmissionConfirmationToken.token == token_value
+                    )
+                )
+            ).scalar_one()
+            tok.locked_at = datetime.now(timezone.utc)
+            tok.lock_count = 1
+            await session.commit()
+
+        async with AsyncSessionLocal() as session:
+            with pytest.raises(BadRequest) as exc_info:
+                await admission_service.verify_and_confirm(
+                    db=session,
+                    token_value=token_value,
+                    last_digits=_CORRECT_DIGITS,
+                )
+            assert "locked" in str(exc_info.value).lower()
+
+
+# ============================================================================
+# Cooldown elapsed → next attempt admitted
+# ============================================================================
+
+
+class TestCooldownElapsed:
+    """After ``lock_until`` passes, the gate re-opens for the
+    sliding-cooldown branch (NOT the hard-lock branch)."""
+
+    async def test_lock_until_in_past_admits_next_attempt(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+    ):
+        """Manually backdate ``lock_until`` to simulate cooldown
+        elapsed, then a correct CCCD must succeed."""
+        profile_id, token_value = await _seed_token(seed_lead_dependencies["unit_id"], admin_user_in_db["id"])
+
+        # Stage a previously-failed token: attempts=2, cooldown
+        # already elapsed.
+        async with AsyncSessionLocal() as session:
+            tok = (
+                await session.execute(
+                    select(models.AdmissionConfirmationToken).where(
+                        models.AdmissionConfirmationToken.token == token_value
+                    )
+                )
+            ).scalar_one()
+            tok.attempt_count = 2
+            tok.lock_until = datetime.now(timezone.utc) - timedelta(minutes=1)
+            await session.commit()
+
+        # Correct digits must now succeed.
+        async with AsyncSessionLocal() as session:
+            profile, post_commit = await admission_service.verify_and_confirm(
+                db=session,
+                token_value=token_value,
+                last_digits=_CORRECT_DIGITS,
+            )
+            await session.commit()
+            assert profile.status == "confirmed"
+
+        token = await _reload_token(token_value)
+        assert token.confirmed_at is not None, (
+            "Successful confirm must stamp confirmed_at"
+        )
+
+
+# ============================================================================
+# Hard-lock notification callback survives BadRequest (P2 review fix)
+# ============================================================================
+
+
+class TestHardLockCallback:
+    """The hard-lock branch attaches a notification callback to the
+    raised BadRequest. The router commits the lock + audit mutations
+    on the BadRequest path, then must await the attached callback so
+    operator browser/email reaches them — without this, the
+    notification never enqueues and the dispatch becomes a no-op."""
+
+    async def test_badrequest_carries_post_commit_callback(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+    ):
+        profile_id, token_value = await _seed_token(
+            seed_lead_dependencies["unit_id"], admin_user_in_db["id"]
+        )
+
+        # Stage at threshold-1 so the next bad attempt hard-locks.
+        async with AsyncSessionLocal() as session:
+            tok = (
+                await session.execute(
+                    select(models.AdmissionConfirmationToken).where(
+                        models.AdmissionConfirmationToken.token == token_value
+                    )
+                )
+            ).scalar_one()
+            tok.attempt_count = HARD_LOCK_THRESHOLD - 1
+            tok.lock_until = None
+            await session.commit()
+
+        # The hard-lock branch raises — assert the exception carries
+        # the callback, and that awaiting it (router pattern) does not
+        # raise even when no rule is enabled (default seed state).
+        async with AsyncSessionLocal() as session:
+            with pytest.raises(BadRequest) as exc_info:
+                await admission_service.verify_and_confirm(
+                    db=session,
+                    token_value=token_value,
+                    last_digits=_WRONG_DIGITS,
+                )
+            await session.commit()  # router commits on BadRequest
+
+            callback = getattr(exc_info.value, "post_commit_callback", None)
+            assert callback is not None, (
+                "Hard-lock BadRequest must carry post_commit_callback "
+                "for the router to await after commit"
+            )
+
+            # Awaiting must not raise even when the rule is disabled
+            # (callback may be a no-op closure).
+            await callback()

--- a/Backend_FastAPI/tests/integration/test_admission_confirmation_reminder_task.py
+++ b/Backend_FastAPI/tests/integration/test_admission_confirmation_reminder_task.py
@@ -1,0 +1,593 @@
+"""ADM-028 (2026-04-29): magic-link reminder beat task tests.
+
+Pin the idempotency + filter contract so a flapping beat tick or
+worker retry can't double-send reminders, and so locked / expired /
+confirmed tokens are not pinged.
+
+The beat task runs the inner ``_run`` coroutine via ``run_async_task``
+which spawns its own asyncio loop. Tests invoke the registered Celery
+task synchronously (``.apply().get()``) to exercise the full code path
+without needing a running worker.
+"""
+from __future__ import annotations
+
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.tasks.admission_tasks import (
+    check_admission_confirmation_reminders_task,
+)
+
+from tests.integration.test_admission_state_transitions import (
+    create_test_lead,
+    create_admission_profile,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_lead_contact_rules() -> None:
+    """ADM-028 review (P2 2026-04-29): the reminder beat task is now
+    pre-flight gated on a NotificationRule with at least one
+    ``lead_contact`` external action being enabled. Most reminder tests
+    want to exercise the per-token filter logic AFTER that gate, so
+    they need both rules wired. Tests that explicitly want the
+    pre-flight skip path can call ``_clear_reminder_rules()`` first.
+    """
+    from sqlalchemy import delete as sa_delete
+    from app.services.notification_rule_loader import invalidate_rule_cache
+
+    events = [
+        "admission_confirmation_reminder_24h",
+        "admission_confirmation_reminder_6h",
+    ]
+    async with AsyncSessionLocal() as session:
+        for event in events:
+            await invalidate_rule_cache(event)
+            await session.execute(
+                sa_delete(models.NotificationRule).where(
+                    models.NotificationRule.event == event
+                )
+            )
+        await session.flush()
+        for event in events:
+            template = models.NotificationTemplate(
+                template_code=f"TPL_{event.upper()}",
+                name=f"Test {event}",
+                title_template="Reminder",
+                message_template="Body",
+                template_type="system",
+            )
+            session.add(template)
+            await session.flush()
+            rule = models.NotificationRule(
+                event=event,
+                template_id=template.id,
+                title_template=template.title_template,
+                message_template=template.message_template,
+                recipient_config={
+                    "resolver_type": "specific_users",
+                    "params": {},
+                },
+                enabled=True,
+            )
+            session.add(rule)
+            await session.flush()
+            session.add(
+                models.NotificationAction(
+                    rule_id=rule.id,
+                    step=1,
+                    channel="email",
+                    delay_minutes=0,
+                    config={"external_resolver": "lead_contact"},
+                )
+            )
+        await session.commit()
+
+
+@pytest.fixture
+async def lead_contact_rules_seeded():
+    """Auto-applied to every test in this module so the pre-flight
+    ``cfg_24h``/``cfg_6h`` gate inside the beat task evaluates to True
+    by default. Tests that want the unconfigured-skip path opt out by
+    not requesting this fixture and dropping the rules instead."""
+    await _seed_lead_contact_rules()
+
+
+async def _seed_token_with_expiry(
+    *,
+    unit_id: int,
+    admin_user_id: int,
+    expires_in: timedelta,
+    confirmed: bool = False,
+    locked: bool = False,
+    reminder_24h_sent: bool = False,
+    reminder_6h_sent: bool = False,
+    lead_email: str | None = "applicant@test.com",
+) -> int:
+    """Create lead + approved profile + token at a specific expiry.
+
+    Returns ``token.id`` for downstream introspection.
+    """
+    lead_id = await create_test_lead(unit_id)
+    if lead_email is not None:
+        # Override the helper's default email with whatever the test
+        # asked for (or set to null for the no-contact path).
+        async with AsyncSessionLocal() as s:
+            async with s.begin():
+                lead = (
+                    await s.execute(
+                        select(models.Lead).where(models.Lead.id == lead_id)
+                    )
+                ).scalar_one()
+                lead.email = lead_email
+    profile = await create_admission_profile(
+        lead_id,
+        status="approved",
+        citizen_id=f"00120{secrets.randbelow(10**7):07d}",
+        approved_by_id=admin_user_id,
+    )
+    expires_at = datetime.now(timezone.utc) + expires_in
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            tok = models.AdmissionConfirmationToken(
+                profile_id=profile.id,
+                token=secrets.token_urlsafe(32),
+                expires_at=expires_at,
+            )
+            if confirmed:
+                tok.confirmed_at = datetime.now(timezone.utc)
+            if locked:
+                tok.locked_at = datetime.now(timezone.utc)
+                tok.lock_count = 1
+            if reminder_24h_sent:
+                tok.reminder_24h_sent_at = datetime.now(timezone.utc)
+            if reminder_6h_sent:
+                tok.reminder_6h_sent_at = datetime.now(timezone.utc)
+            session.add(tok)
+            await session.flush()
+            return tok.id
+
+
+async def _reload_token(token_id: int) -> models.AdmissionConfirmationToken:
+    async with AsyncSessionLocal() as session:
+        return (
+            await session.execute(
+                select(models.AdmissionConfirmationToken).where(
+                    models.AdmissionConfirmationToken.id == token_id
+                )
+            )
+        ).scalar_one()
+
+
+def _run_task() -> dict:
+    """Invoke the Celery task synchronously and return its result dict."""
+    return check_admission_confirmation_reminders_task.apply().get()
+
+
+# ============================================================================
+# 24h window
+# ============================================================================
+
+
+class TestReminder24h:
+    async def test_token_in_24h_window_emits_once_and_marks_sent_at(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        lead_contact_rules_seeded,
+    ):
+        """Expiry ~20h away → 24h reminder fires + ``reminder_24h_sent_at``
+        is stamped. Re-running the task does not double-send."""
+        token_id = await _seed_token_with_expiry(
+            unit_id=seed_lead_dependencies["unit_id"],
+            admin_user_id=admin_user_in_db["id"],
+            expires_in=timedelta(hours=20),
+        )
+
+        result = _run_task()
+        assert result["sent_24h"] >= 1, result
+        assert result["sent_6h"] == 0, result
+
+        tok = await _reload_token(token_id)
+        assert tok.reminder_24h_sent_at is not None
+        assert tok.reminder_6h_sent_at is None
+
+        # Idempotency: second invocation must not re-send.
+        first_sent_at = tok.reminder_24h_sent_at
+        result_2 = _run_task()
+        assert result_2["sent_24h"] == 0, (
+            f"second run re-sent 24h reminder: {result_2}"
+        )
+
+        tok = await _reload_token(token_id)
+        assert tok.reminder_24h_sent_at == first_sent_at, (
+            "reminder_24h_sent_at must not be touched on re-run"
+        )
+
+
+# ============================================================================
+# 6h window
+# ============================================================================
+
+
+class TestReminder6h:
+    async def test_token_in_6h_window_emits_6h_only(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        lead_contact_rules_seeded,
+    ):
+        """Expiry ~3h away → only the 6h reminder fires; 24h is
+        suppressed because the window has already collapsed past it.
+
+        The task design also marks ``reminder_24h_sent_at`` on the same
+        run so a token issued <6h before expiry doesn't trigger a noisy
+        retroactive 24h reminder later."""
+        token_id = await _seed_token_with_expiry(
+            unit_id=seed_lead_dependencies["unit_id"],
+            admin_user_id=admin_user_in_db["id"],
+            expires_in=timedelta(hours=3),
+        )
+
+        result = _run_task()
+        assert result["sent_6h"] >= 1, result
+        assert result["sent_24h"] == 0, result
+
+        tok = await _reload_token(token_id)
+        assert tok.reminder_6h_sent_at is not None
+        # The task SHOULD also mark the 24h slot consumed in this case.
+        assert tok.reminder_24h_sent_at is not None
+
+    async def test_re_run_does_not_re_send_6h(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        lead_contact_rules_seeded,
+    ):
+        token_id = await _seed_token_with_expiry(
+            unit_id=seed_lead_dependencies["unit_id"],
+            admin_user_id=admin_user_in_db["id"],
+            expires_in=timedelta(hours=3),
+        )
+
+        _run_task()
+        tok_first = await _reload_token(token_id)
+
+        result_2 = _run_task()
+        assert result_2["sent_6h"] == 0
+        assert result_2["sent_24h"] == 0
+
+        tok_second = await _reload_token(token_id)
+        assert tok_second.reminder_6h_sent_at == tok_first.reminder_6h_sent_at
+
+
+# ============================================================================
+# Filter: ineligible tokens skipped
+# ============================================================================
+
+
+class TestSkipsIneligible:
+    """Locked / confirmed / expired / already-reminded tokens must
+    not be re-pinged."""
+
+    async def test_locked_token_skipped(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        lead_contact_rules_seeded,
+    ):
+        token_id = await _seed_token_with_expiry(
+            unit_id=seed_lead_dependencies["unit_id"],
+            admin_user_id=admin_user_in_db["id"],
+            expires_in=timedelta(hours=20),
+            locked=True,
+        )
+
+        result = _run_task()
+        assert result["sent_24h"] == 0, result
+
+        tok = await _reload_token(token_id)
+        assert tok.reminder_24h_sent_at is None
+
+    async def test_confirmed_token_skipped(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        lead_contact_rules_seeded,
+    ):
+        token_id = await _seed_token_with_expiry(
+            unit_id=seed_lead_dependencies["unit_id"],
+            admin_user_id=admin_user_in_db["id"],
+            expires_in=timedelta(hours=20),
+            confirmed=True,
+        )
+
+        result = _run_task()
+        assert result["sent_24h"] == 0
+        tok = await _reload_token(token_id)
+        assert tok.reminder_24h_sent_at is None
+
+    async def test_expired_token_skipped(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        lead_contact_rules_seeded,
+    ):
+        token_id = await _seed_token_with_expiry(
+            unit_id=seed_lead_dependencies["unit_id"],
+            admin_user_id=admin_user_in_db["id"],
+            expires_in=timedelta(hours=-1),  # already expired
+        )
+
+        result = _run_task()
+        assert result["sent_24h"] == 0
+        assert result["sent_6h"] == 0
+        tok = await _reload_token(token_id)
+        assert tok.reminder_24h_sent_at is None
+        assert tok.reminder_6h_sent_at is None
+
+    async def test_already_reminded_token_skipped(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        lead_contact_rules_seeded,
+    ):
+        token_id = await _seed_token_with_expiry(
+            unit_id=seed_lead_dependencies["unit_id"],
+            admin_user_id=admin_user_in_db["id"],
+            expires_in=timedelta(hours=20),
+            reminder_24h_sent=True,
+        )
+
+        result = _run_task()
+        assert result["sent_24h"] == 0
+
+
+# ============================================================================
+# No contact channel
+# ============================================================================
+
+
+class TestSkipsNoContact:
+    """Lead without email/phone → mark both windows consumed so the
+    token drops out of future scans (per task docstring)."""
+
+    async def test_external_delivery_via_lead_contact_creates_delivery_row(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        lead_contact_rules_seeded,
+    ):
+        """When a NotificationRule is wired with an action whose
+        ``config.external_resolver = "lead_contact"``, running the
+        reminder task must produce a ``NotificationDelivery`` row for
+        the applicant — proves the catalog ↔ rule ↔ task chain
+        actually delivers, not just stamps ``reminder_24h_sent_at``.
+
+        This pins the operational contract: ops can wire delivery
+        through the admin UI, the beat task fires, the dispatcher
+        picks up the rule, and ``notification_delivery`` rows accumulate.
+        """
+        from sqlalchemy import delete as sa_delete
+        from app.services.notification_rule_loader import invalidate_rule_cache
+
+        # Seed a rule + action with lead_contact external resolver for
+        # the 24h reminder event. Same shape as
+        # ``test_per_action_dispatch.py::_seed_rule_with_actions``.
+        async with AsyncSessionLocal() as session:
+            await invalidate_rule_cache(
+                "admission_confirmation_reminder_24h"
+            )
+            await session.execute(
+                sa_delete(models.NotificationRule).where(
+                    models.NotificationRule.event
+                    == "admission_confirmation_reminder_24h"
+                )
+            )
+            await session.flush()
+
+            template = models.NotificationTemplate(
+                template_code="TPL_TEST_CONFIRM_REMINDER_24H",
+                name="Test reminder 24h",
+                title_template="Còn ${hours_remaining}h",
+                message_template=(
+                    "${lead_name}, link xác nhận hết hạn ${expires_at_iso}"
+                ),
+                template_type="system",
+            )
+            session.add(template)
+            await session.flush()
+
+            rule = models.NotificationRule(
+                event="admission_confirmation_reminder_24h",
+                template_id=template.id,
+                title_template=template.title_template,
+                message_template=template.message_template,
+                # Internal recipients = none; external delivery via
+                # the action below.
+                recipient_config={"resolver_type": "specific_users", "params": {}},
+                enabled=True,
+            )
+            session.add(rule)
+            await session.flush()
+            session.add(
+                models.NotificationAction(
+                    rule_id=rule.id,
+                    step=1,
+                    channel="email",
+                    delay_minutes=0,
+                    config={"external_resolver": "lead_contact"},
+                )
+            )
+            await session.commit()
+
+        token_id = await _seed_token_with_expiry(
+            unit_id=seed_lead_dependencies["unit_id"],
+            admin_user_id=admin_user_in_db["id"],
+            expires_in=timedelta(hours=20),
+        )
+
+        result = _run_task()
+        assert result["sent_24h"] >= 1, result
+
+        # Delivery row must exist for the applicant via lead_contact.
+        async with AsyncSessionLocal() as session:
+            from app.models.notification_delivery import NotificationDelivery
+
+            tok = (
+                await session.execute(
+                    select(models.AdmissionConfirmationToken).where(
+                        models.AdmissionConfirmationToken.id == token_id
+                    )
+                )
+            ).scalar_one()
+            profile = (
+                await session.execute(
+                    select(models.AdmissionProfile).where(
+                        models.AdmissionProfile.id == tok.profile_id
+                    )
+                )
+            ).scalar_one()
+            lead = (
+                await session.execute(
+                    select(models.Lead).where(
+                        models.Lead.id == profile.lead_id
+                    )
+                )
+            ).scalar_one()
+
+            deliveries = (
+                await session.execute(
+                    select(NotificationDelivery).where(
+                        NotificationDelivery.event
+                        == "admission_confirmation_reminder_24h"
+                    )
+                )
+            ).scalars().all()
+            # At least one delivery row created.
+            assert len(deliveries) >= 1, (
+                f"expected ≥1 NotificationDelivery row for reminder, "
+                f"got {len(deliveries)}. lead.email={lead.email!r}"
+            )
+            # The delivery must target the applicant's email (not an
+            # internal user_id) — that's the lead_contact contract.
+            # NotificationDelivery.destination holds the normalized
+            # email/phone for external delivery.
+            applicant_delivery = next(
+                (d for d in deliveries if d.destination == lead.email),
+                None,
+            )
+            assert applicant_delivery is not None, (
+                f"expected delivery to destination={lead.email}, got "
+                f"destinations={[d.destination for d in deliveries]}"
+            )
+            assert applicant_delivery.channel == "email"
+
+    async def test_unconfigured_rule_skips_without_stamping_marker(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+    ):
+        """P2 review (2026-04-29): when no NotificationRule has an
+        action with ``external_resolver='lead_contact'``, the task
+        must NOT stamp ``reminder_*_sent_at`` — otherwise the token
+        burns its only retry window in the unconfigured deploy shape
+        and never re-fires once ops finally wires the rule.
+
+        Note: NO ``lead_contact_rules_seeded`` fixture — this test
+        deliberately exercises the unconfigured path.
+        """
+        token_id = await _seed_token_with_expiry(
+            unit_id=seed_lead_dependencies["unit_id"],
+            admin_user_id=admin_user_in_db["id"],
+            expires_in=timedelta(hours=20),
+        )
+
+        result = _run_task()
+        assert result["sent_24h"] == 0, result
+        assert result["sent_6h"] == 0, result
+
+        tok = await _reload_token(token_id)
+        # Critical: marker NOT stamped, so a future scan after ops
+        # configures the rule will retry this token.
+        assert tok.reminder_24h_sent_at is None, (
+            "reminder_24h_sent_at must remain NULL when no rule "
+            "is configured — otherwise the retry window is lost"
+        )
+        assert tok.reminder_6h_sent_at is None
+
+    async def test_no_contact_marks_both_windows_consumed(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        lead_contact_rules_seeded,
+    ):
+        token_id = await _seed_token_with_expiry(
+            unit_id=seed_lead_dependencies["unit_id"],
+            admin_user_id=admin_user_in_db["id"],
+            expires_in=timedelta(hours=20),
+            lead_email=None,
+        )
+        # Strip phone too — the helper sets a default phone.
+        async with AsyncSessionLocal() as s:
+            async with s.begin():
+                tok = (
+                    await s.execute(
+                        select(models.AdmissionConfirmationToken).where(
+                            models.AdmissionConfirmationToken.id == token_id
+                        )
+                    )
+                ).scalar_one()
+                lead = (
+                    await s.execute(
+                        select(models.Lead).where(
+                            models.Lead.id == tok.profile_id  # NB: profile.lead_id
+                        )
+                    )
+                ).scalar_one_or_none()
+                # The above lookup uses profile_id as a stand-in; fix
+                # by going via profile -> lead.
+                profile = (
+                    await s.execute(
+                        select(models.AdmissionProfile).where(
+                            models.AdmissionProfile.id == tok.profile_id
+                        )
+                    )
+                ).scalar_one()
+                lead = (
+                    await s.execute(
+                        select(models.Lead).where(
+                            models.Lead.id == profile.lead_id
+                        )
+                    )
+                ).scalar_one()
+                lead.phone = ""
+                lead.email = None
+
+        result = _run_task()
+        assert result["sent_24h"] == 0
+        assert result["sent_6h"] == 0
+        # Skipped row counter advanced.
+        assert result["skipped_no_email_phone"] >= 1
+
+        tok = await _reload_token(token_id)
+        # Both windows marked consumed so re-scans drop this token.
+        assert tok.reminder_24h_sent_at is not None
+        assert tok.reminder_6h_sent_at is not None

--- a/Backend_FastAPI/tests/integration/test_admission_confirmation_resend_limit.py
+++ b/Backend_FastAPI/tests/integration/test_admission_confirmation_resend_limit.py
@@ -1,0 +1,294 @@
+"""ADM-023 / Q9-C2 (2026-04-29): per-profile magic-link resend cap tests.
+
+Service-layer integration. Pin:
+1. 3 resends per 24h per profile pass; 4th raises BadRequest.
+2. Redis breaker open → fail-closed (BadRequest), NEVER bypass cap.
+3. Resending does NOT reset attempt_count / lock_until on prior token
+   — abusers can't simply request a fresh token to skip the cooldown.
+4. Audit row is written on the rate-limit denial (separate session
+   so it survives the request rollback).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from app import models
+from app.database import (
+    AsyncSessionLocal,
+    redis_client,
+    safe_redis_expire,
+)
+from app.services import admission_service
+from app.services.admission_confirmation_resend_limit import (
+    RESEND_CAP_PER_24H,
+    _resend_key,
+)
+from app.utils.exceptions import BadRequest
+
+from tests.integration.test_admission_state_transitions import (
+    create_test_lead,
+    create_admission_profile,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_approved_profile(unit_id: int, admin_user_id: int) -> int:
+    lead_id = await create_test_lead(unit_id)
+    profile = await create_admission_profile(
+        lead_id,
+        status="approved",
+        citizen_id="001202888888",
+        approved_by_id=admin_user_id,
+    )
+    return profile.id
+
+
+async def _clear_resend_quota(profile_id: int) -> None:
+    """Hygiene: tests should start with a clean Redis bucket."""
+    try:
+        await redis_client.delete(_resend_key(profile_id))
+    except Exception:
+        pass
+
+
+async def _resend(profile_id: int) -> None:
+    """Call generate_confirmation_token in its own session/txn so a
+    BadRequest rolls back cleanly without poisoning the shared session."""
+    async with AsyncSessionLocal() as session:
+        profile = (
+            await session.execute(
+                select(models.AdmissionProfile).where(
+                    models.AdmissionProfile.id == profile_id
+                )
+            )
+        ).scalar_one()
+        await admission_service.generate_confirmation_token(
+            db=session, profile=profile
+        )
+        await session.commit()
+
+
+# ============================================================================
+# Cap enforcement
+# ============================================================================
+
+
+class TestResendCap:
+    async def test_first_three_resends_pass_fourth_blocks(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+    ):
+        """24h sliding cap = 3. Calls 1-3 succeed, call 4 raises."""
+        profile_id = await _seed_approved_profile(
+            seed_lead_dependencies["unit_id"], admin_user_in_db["id"]
+        )
+        await _clear_resend_quota(profile_id)
+
+        for i in range(RESEND_CAP_PER_24H):
+            await _resend(profile_id)
+
+        # 4th must fail.
+        with pytest.raises(BadRequest) as exc_info:
+            await _resend(profile_id)
+        assert (
+            "Đã gửi lại liên kết" in str(exc_info.value)
+            or "24 giờ" in str(exc_info.value)
+        )
+
+    async def test_denied_resend_writes_audit_row(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+    ):
+        """Each denied resend must persist an audit row even though
+        the request transaction rolls back. Compliance contract: every
+        attempt to overflow the cap is reconstructable from
+        ``entity_audit_log``."""
+        profile_id = await _seed_approved_profile(
+            seed_lead_dependencies["unit_id"], admin_user_in_db["id"]
+        )
+        await _clear_resend_quota(profile_id)
+
+        # Burn the cap quickly.
+        for _ in range(RESEND_CAP_PER_24H):
+            await _resend(profile_id)
+
+        # Two denied attempts → expect 2 audit rows.
+        for _ in range(2):
+            with pytest.raises(BadRequest):
+                await _resend(profile_id)
+
+        async with AsyncSessionLocal() as session:
+            rows = (
+                await session.execute(
+                    select(models.EntityAuditLog).where(
+                        models.EntityAuditLog.entity_type == "AdmissionProfile",
+                        models.EntityAuditLog.entity_id == profile_id,
+                        models.EntityAuditLog.action
+                        == "confirmation_resend_rate_limited",
+                    )
+                )
+            ).scalars().all()
+            assert len(rows) == 2, (
+                f"expected 2 rate-limit audit rows, got {len(rows)}"
+            )
+            # Sanity-check shape — `attempt_count_in_window` is the
+            # post-increment count, which is 4 (= cap+1) for the first
+            # denied call.
+            assert rows[0].changes["cap"]["new"] == RESEND_CAP_PER_24H
+
+
+# ============================================================================
+# Redis fail-closed
+# ============================================================================
+
+
+class TestRedisFailClosed:
+    async def test_breaker_open_returns_bad_request_not_silent_pass(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        monkeypatch,
+    ):
+        """When ``safe_redis_incr`` returns None (breaker open / Redis
+        down), ``consume_resend_quota`` returns None and the service
+        MUST refuse the resend — fail-closed beats fail-open for a
+        spam cap."""
+        profile_id = await _seed_approved_profile(
+            seed_lead_dependencies["unit_id"], admin_user_in_db["id"]
+        )
+
+        # Force the Redis call to behave as if the breaker was open.
+        async def _stub_incr(*_args, **_kwargs):
+            return None
+
+        # Patch at the consumer module so the test doesn't have to
+        # touch the global circuit breaker state.
+        monkeypatch.setattr(
+            "app.services.admission_confirmation_resend_limit.safe_redis_incr",
+            _stub_incr,
+        )
+
+        with pytest.raises(BadRequest) as exc_info:
+            await _resend(profile_id)
+        assert (
+            "bận" in str(exc_info.value).lower()
+            or "thử lại" in str(exc_info.value).lower()
+        )
+
+    async def test_expire_failure_fails_closed_so_no_permanent_counter(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+        monkeypatch,
+    ):
+        """P3 review (2026-04-29): if ``INCR`` succeeds but ``EXPIRE``
+        fails on the first hit, the previous behaviour left the key
+        with no TTL — once the cap was crossed the profile was
+        locked indefinitely until manual cleanup. ``consume_resend_quota``
+        now treats EXPIRE failure as a service failure and returns
+        ``None`` so the caller fails closed."""
+        profile_id = await _seed_approved_profile(
+            seed_lead_dependencies["unit_id"], admin_user_in_db["id"]
+        )
+        await _clear_resend_quota(profile_id)
+
+        # Let INCR succeed but force EXPIRE to fail.
+        async def _stub_expire(*_args, **_kwargs):
+            return False
+
+        monkeypatch.setattr(
+            "app.services.admission_confirmation_resend_limit.safe_redis_expire",
+            _stub_expire,
+        )
+
+        with pytest.raises(BadRequest):
+            await _resend(profile_id)
+
+
+# ============================================================================
+# Resend cannot reset attempt_count / lock_until of prior token
+# ============================================================================
+
+
+class TestResendDoesNotResetCooldown:
+    async def test_resend_does_not_clear_prior_token_attempts(
+        self,
+        setup_test_database,
+        seed_lead_dependencies,
+        admin_user_in_db,
+    ):
+        """Generating a NEW confirmation token must not clear
+        ``attempt_count`` / ``lock_until`` on the previously-issued
+        token. Abuser pattern: fail CCCD a few times, request a new
+        link, retry — should still hit the same cooldown.
+
+        Implementation note: ``create_confirmation_token`` updates the
+        existing one-row-per-profile token in place rather than
+        creating a sibling, so the same row's counters must survive.
+        """
+        profile_id = await _seed_approved_profile(
+            seed_lead_dependencies["unit_id"], admin_user_in_db["id"]
+        )
+        await _clear_resend_quota(profile_id)
+
+        # Issue first token.
+        await _resend(profile_id)
+
+        async with AsyncSessionLocal() as session:
+            tok = (
+                await session.execute(
+                    select(models.AdmissionConfirmationToken).where(
+                        models.AdmissionConfirmationToken.profile_id
+                        == profile_id
+                    )
+                )
+            ).scalar_one()
+            tok.attempt_count = 5
+            tok.lock_until = datetime(
+                2099, 1, 1, tzinfo=timezone.utc
+            )  # far-future cooldown
+            first_token_id = tok.id
+            await session.commit()
+
+        # Resend (slot 2/3).
+        await _resend(profile_id)
+
+        async with AsyncSessionLocal() as session:
+            tok = (
+                await session.execute(
+                    select(models.AdmissionConfirmationToken).where(
+                        models.AdmissionConfirmationToken.profile_id
+                        == profile_id
+                    )
+                )
+            ).scalar_one()
+            assert tok.id == first_token_id, (
+                "Same row expected — one-token-per-profile contract."
+            )
+            # NOTE: the existing repo's ``create_confirmation_token``
+            # may legitimately reset attempt_count when it issues a
+            # fresh token (depends on the implementation's intent).
+            # The contract we PIN here is "lock_until on the prior
+            # row is NOT silently cleared" — abusers can't trivially
+            # bypass the brute-force defence by spamming resends.
+            #
+            # If the repo IS designed to reset the counters on a new
+            # token (legitimate operator-initiated reset), then this
+            # assertion will fail and the contract should be
+            # documented + a separate "reset cooldown" admin path
+            # introduced. Either outcome surfaces the design choice.
+            assert tok.lock_until is not None and tok.lock_until.year >= 2099, (
+                f"prior cooldown was cleared by resend — "
+                f"got lock_until={tok.lock_until}"
+            )

--- a/Backend_FastAPI/tests/unit/test_admission_confirmation_cooldown.py
+++ b/Backend_FastAPI/tests/unit/test_admission_confirmation_cooldown.py
@@ -1,0 +1,82 @@
+"""ADM-023 (2026-04-29): cooldown ladder unit tests.
+
+Pin the Q9 (A3) ladder so future tweaks to ``cooldown_minutes_for``
+either re-bless this table or break loudly. The matching service-layer
+behaviour (set ``lock_until`` vs hard lock) is exercised in
+``tests/services/test_admission_confirmation_lock.py`` (separate
+module to keep this one DB-free).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.admission_confirmation_cooldown import (
+    HARD_LOCK_THRESHOLD,
+    cooldown_minutes_for,
+    is_hard_lock,
+)
+
+
+class TestLadder:
+    """``attempt_count`` -> cooldown minutes table."""
+
+    def test_zero_returns_zero(self):
+        # No failure yet — caller should not set lock_until.
+        assert cooldown_minutes_for(0) == 0
+
+    @pytest.mark.parametrize("n", [1, 2])
+    def test_first_tier_is_5_minutes(self, n):
+        assert cooldown_minutes_for(n) == 5
+
+    @pytest.mark.parametrize("n", [3, 4])
+    def test_second_tier_is_30_minutes(self, n):
+        assert cooldown_minutes_for(n) == 30
+
+    @pytest.mark.parametrize("n", [5, 6])
+    def test_third_tier_is_120_minutes(self, n):
+        assert cooldown_minutes_for(n) == 120
+
+    @pytest.mark.parametrize("n", [7, 15, 29])
+    def test_fourth_tier_is_24h(self, n):
+        # 7 fails through 29 — sustained brute force, last cooldown
+        # before hard lock at 30.
+        assert cooldown_minutes_for(n) == 1440
+
+    @pytest.mark.parametrize("n", [30, 31, 100])
+    def test_hard_lock_returns_none(self, n):
+        # Sentinel: caller MUST handle None by setting locked_at +
+        # incrementing lock_count, not by computing a sliding cooldown.
+        assert cooldown_minutes_for(n) is None
+
+
+class TestHardLockPredicate:
+    """``is_hard_lock`` mirrors the ``cooldown_minutes_for`` boundary."""
+
+    @pytest.mark.parametrize("n", [0, 1, 5, 29])
+    def test_below_threshold_is_false(self, n):
+        assert is_hard_lock(n) is False
+
+    @pytest.mark.parametrize("n", [HARD_LOCK_THRESHOLD, 31, 100])
+    def test_at_or_above_threshold_is_true(self, n):
+        assert is_hard_lock(n) is True
+
+    def test_threshold_constant_is_30(self):
+        # Q9 decision (memory ``admission-audit-wave2-2026-04-28``).
+        # If product later wants a different threshold, change this
+        # constant + Q9 entry together — bumping silently breaks the
+        # audit story ("attempted to brute force ≥30 times" message).
+        assert HARD_LOCK_THRESHOLD == 30
+
+
+class TestLadderMonotonic:
+    """Cooldown never decreases as attempt_count rises."""
+
+    def test_monotonic_through_tier_boundaries(self):
+        ladder = [cooldown_minutes_for(n) for n in range(1, HARD_LOCK_THRESHOLD)]
+        for prev, curr in zip(ladder, ladder[1:]):
+            # ``curr`` is None only at the hard-lock boundary which
+            # this loop excludes via ``range(..., HARD_LOCK_THRESHOLD)``.
+            assert prev is not None and curr is not None
+            assert curr >= prev, (
+                f"Ladder regressed at boundary: {prev} -> {curr}"
+            )

--- a/Backend_FastAPI/tests/unit/test_notification_contract.py
+++ b/Backend_FastAPI/tests/unit/test_notification_contract.py
@@ -450,6 +450,15 @@ class TestUserEventsHaveDispatchCallers:
         # PR-Audit-1: dispatched from zalo_bot_link_service.verify_and_link
         # post_commit closure when chat_id displacement happens.
         "zalo_bot_link_displaced",
+        # ADM-023+028 (2026-04-29): magic-link hardening events.
+        # 24h/6h reminders fire from app/tasks/admission_tasks.py
+        # ``check_admission_confirmation_reminders_task``. hard_locked
+        # fires from app/services/admission_service.py
+        # ``verify_and_confirm`` when attempt_count crosses
+        # HARD_LOCK_THRESHOLD (=30).
+        "admission_confirmation_reminder_24h",
+        "admission_confirmation_reminder_6h",
+        "admission_confirmation_hard_locked",
     })
 
     def test_user_events_have_dispatch_in_codebase(self):


### PR DESCRIPTION
## Summary

Q9 (memory ``admission-audit-wave2-2026-04-28``) decision A3+B1+C2.

### ADM-023 — brute-force defence on the CCCD verification step
- Hybrid cooldown ladder (``admission_confirmation_cooldown.py``): attempts 1-2 → 5 min, 3-4 → 30 min, 5-6 → 120 min (2h), 7-29 → 1440 min (24h), ≥30 → hard lock (admin must reset).
- New ``AdmissionConfirmationToken`` columns: ``lock_until``, ``lock_count``, ``reminder_24h_sent_at``, ``reminder_6h_sent_at``.
- ``verify_and_confirm`` checks ``lock_until > now()`` before CCCD validation; on mismatch stamps the right rung. Repo helper now called with ``HARD_LOCK_THRESHOLD`` (30) so legacy + new gates agree.
- Hard lock writes audit row in-txn (``confirmation_hard_locked``) AND dispatches ``ADMISSION_CONFIRMATION_HARD_LOCKED``. Callback attached to the raised ``BadRequest`` so the router awaits it AFTER ``db.commit()`` — without the hand-off, the notification would never enqueue.

### ADM-023 — per-profile resend cap
- Redis ``INCR`` + ``EXPIRE``. ≤3 resends in any 24h trailing-edge window (TTL re-armed on every hit).
- Fail-closed when Redis breaker open OR ``EXPIRE`` falsy. The previous shape only armed TTL on the first hit; an EXPIRE flap would have left a permanent counter.
- ``generate_confirmation_token`` consumes a slot every call; denial writes ``confirmation_resend_rate_limited`` audit via separate session (survives BadRequest rollback).
- ``create_confirmation_token`` repo now UPDATES the existing token row in place rather than DELETE+INSERT, preserving brute-force counters on resend so abusers can't escape the ladder by spamming new links. Reminder markers ARE reset (new issuance window).

### ADM-028 — magic-link expiry reminders
- New SystemEvents: ``ADMISSION_CONFIRMATION_REMINDER_24H`` / ``REMINDER_6H`` / ``HARD_LOCKED``.
- Beat task ``check_admission_confirmation_reminders_task`` runs every 30 min. Per-window dedupe via ``reminder_*_sent_at`` markers. Skips locked / confirmed / expired / no-contact / already-reminded tokens.
- **Pre-flight gate**: queries for a ``NotificationRule`` with ``external_resolver='lead_contact'`` action BEFORE marking ``reminder_*_sent_at`` — without this, the unconfigured deploy shape would burn the only retry window. Counter ``skipped_unconfigured`` in heartbeat.
- Dedupe key includes ``${expires_at_iso}`` so a refreshed token gets a fresh reminder.

## Tests

### Automated (Lane C suite)
- ``test_admission_confirmation_cooldown.py`` (unit, **22**) — pure ladder pin: tier boundaries, hard-lock sentinel, monotonicity.
- ``test_admission_confirmation_lock_ladder.py`` (integration, **11**) — ``lock_until`` walks 5→30→120→1440 min, ``lock_until`` blocks until elapsed, ≥30 hard-locks with audit row, hard-locked refused even with correct CCCD, cooldown elapsed admits next, BadRequest carries ``post_commit_callback`` attribute.
- ``test_admission_confirmation_resend_limit.py`` (integration, **5**) — 3-pass-4th-block, denial audit, Redis INCR fail-closed, EXPIRE fail-closed, resend does not clear prior cooldown.
- ``test_admission_confirmation_reminder_task.py`` (integration, **10**) — 24h emit-once + idempotent, 6h emit + auto-mark 24h, locked/confirmed/expired/already-reminded skipped, no-contact marks both windows, unconfigured rule skip without stamping, ``lead_contact`` external delivery creates ``NotificationDelivery`` row at ``destination=lead.email``.

### Adjacent suites verified
- ``test_notification_contract.py`` 31/31 (3 new events added to ``_DISPATCHED_EVENTS``).
- ``test_per_action_dispatch.py`` 5/5.
- ``test_notification_parity.py`` 29/29.
- ``test_admission_confirm_lock.py`` (ADM-013 lock contract) 8/8.

**Total automated: 122/122 backend tests pass.**

### Runtime smoke (Chrome MCP + DB/Redis)
12/12 PASS:
1. Send link first time — token row created, attempt=0, expires +7d.
2. Resend cap 3/24h — 4th attempt HTTP 400; Redis DB 1 counter=4, TTL≈86359s; audit row.
3. Open magic-link form — CCCD form renders.
4. Wrong CCCD attempt 1 — attempt_count=1, lock_until=+5min, locked_at=null.
5. Cooldown blocks correct CCCD — "Quá nhiều lần nhập sai. Vui lòng thử lại sau 269 giây".
6. Confirm after cooldown — profile.status=confirmed, retry returns "Đã xác nhận trước đó".
7. Hard-lock 30 — attempt=30, locked_at set, lock_count=1, audit + 2 deliveries (browser=sent, email=lead_owner external).
8. Hard-locked rejects correct CCCD — form not rendered, profile stays approved.
9. Reminder unconfigured (no lead_contact action) — pre-flight skip, ``reminder_*_sent_at`` stays NULL.
10. Reminder configured — ``sent_24h=1``, marker stamped, 2 deliveries (email/zalo) via lead_contact, re-run idempotent.
11. Reminder 6h — ``sent_6h=1``, both markers stamped, no retroactive 24h.
12. Ineligible tokens (confirmed/locked/expired) — ``checked=0``, no markers stamped.

### Path snapshot smoke
7/7 PASS — Path master change vs profile snapshot independence + extras visibility:
1. Baseline checklist matches snapshot.
2. Path master change does not bleed into existing profiles (snapshot semantics).
3. New profile inherits new master config — verified by snapshot contract.
4. Sync-action mutation (``applied_rules.mandatory_docs``) → extras section appears.
5. Direct API on extras returns **404** for verify-format/reject/reset/paper-submitted.
6. New required doc renders with "Cần làm" + format/how-to.
7. Same-code-different-format shows mismatch warning ("Yêu cầu Chứng thực" vs "Đã ghi nhận Chụp/scan").

**Caveat**: new-profile-after-path-update is verified by the snapshot contract (test #2 above), not by full UI lead→profile E2E. Profile creation builds ``applied_rules`` from the path at create time; existing profiles' snapshots remain untouched until an explicit sync action.

## Migration

``mlharden01`` is current head. ``alembic check`` reports only cosmetic ``modify_comment`` drift on the table (codebase-wide pre-existing, not introduced here).

## Operational note

Reminder rules seed with ``specific_users`` recipient_config (resolves to zero internal users by design). Actual applicant delivery requires ops to add an action with ``config.external_resolver = 'lead_contact'`` (and ``zalo_template_id`` if Zalo) via ``/admin/notification-rules``. The beat task pre-flight gate prevents the reminder marker from being stamped until that wiring exists, so the retry window is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)