### PR TITLE
fix(zalo-bot): PR-Sec-1 — F-2/F-3/F-5/F-6 hardening + consent_history parity

### DIFF
--- a/Backend_FastAPI/app/routers/zalo_bot_link.py
+++ b/Backend_FastAPI/app/routers/zalo_bot_link.py
@@ -27,6 +27,7 @@ from app.database import (
     safe_redis_incr,
 )
 from app.utils.exceptions import BusinessRuleViolation
+from app.utils.inmemory_rate_limit import fallback_incr
 
 log = structlog.get_logger(__name__)
 router = APIRouter(prefix="/api/zalo-bot", tags=["Zalo Bot Link"])
@@ -41,16 +42,20 @@ _LINK_CODE_RL_WINDOW = 600  # seconds (10 min)
 async def _check_link_code_rate_limit(user_id: int) -> None:
     """Atomic INCR + EXPIRE — never use GET-then-SET (race window).
 
-    Raises ``BusinessRuleViolation`` (400) on overflow. Redis breaker
-    open returns ``None`` from INCR — we let the request through in
-    that case rather than failing closed; quota cap on the link service
-    side bounds total Redis writes either way.
+    Raises ``BusinessRuleViolation`` (400) on overflow.
+
+    F-2: when Redis is unavailable, fall back to a per-process
+    in-memory counter rather than failing OPEN. Without the fallback,
+    an authenticated attacker could spam ``/link-code`` during a Redis
+    outage and exhaust the link-code keyspace lookup work.
     """
     key = f"{_LINK_CODE_RL_PREFIX}{user_id}"
     new_val = await safe_redis_incr(key)
     if new_val == 1:
         await safe_redis_expire(key, _LINK_CODE_RL_WINDOW)
-    if new_val is not None and new_val > _LINK_CODE_RL_LIMIT:
+    if new_val is None:
+        new_val = fallback_incr(key, _LINK_CODE_RL_WINDOW)
+    if new_val > _LINK_CODE_RL_LIMIT:
         raise BusinessRuleViolation(
             "Quá nhiều yêu cầu. Vui lòng thử lại sau 10 phút."
         )

--- a/Backend_FastAPI/app/routers/zalo_bot_webhooks.py
+++ b/Backend_FastAPI/app/routers/zalo_bot_webhooks.py
@@ -33,6 +33,8 @@ from app.database import (
     safe_redis_incr,
     safe_redis_set,
 )
+from app.utils.inmemory_rate_limit import fallback_incr
+from app.utils.masking import mask_chat_id
 
 log = structlog.get_logger(__name__)
 router = APIRouter(prefix="/api/webhooks", tags=["Zalo Bot Webhooks"])
@@ -50,15 +52,15 @@ _WEBHOOK_RL_WINDOW = 60  # seconds
 # daily quota in minutes when a single chat is blasted with traffic.
 _WEBHOOK_RL_NOTIFIED_PREFIX = "zalo_bot:webhook_rl_notified:"
 
+# F-6: same once-per-window guard for the unknown-command help text.
+# Without it, every stray message (or stale /lienkit typo loop) burns a
+# send_message quota slot. Window matches the rate-limit window so a
+# user typing legit commands after exploring isn't silenced for an hour.
+_HELP_REPLY_PREFIX = "zalo_bot:help_throttle:"
+_HELP_REPLY_WINDOW = 60
+
 # 6-char uppercase alnum, exact length so attackers can't pad with spaces
 _LINK_CODE_RE = re.compile(r"^[A-Z0-9]{6}$")
-
-
-def _mask_chat_id(chat_id: str) -> str:
-    """First 8 chars + ``***`` so logs are greppable but not pivot-able."""
-    if not chat_id:
-        return ""
-    return chat_id[:8] + "***" if len(chat_id) > 8 else chat_id[:4] + "***"
 
 
 async def _send_reply(chat_id: str, text: str) -> None:
@@ -78,10 +80,36 @@ async def _send_reply(chat_id: str, text: str) -> None:
     if not result.success:
         log.warning(
             "zalo_bot reply send failed",
-            chat_id_prefix=_mask_chat_id(chat_id),
+            chat_id_prefix=mask_chat_id(chat_id),
             error_code=result.error_code,
             error_message=result.error_message,
         )
+
+
+async def _once_per_window(key: str, window_seconds: int) -> bool:
+    """Return True iff this is the first call for ``key`` within
+    ``window_seconds``. Used to throttle reply messages so spam can't
+    drain ``send_message`` quota.
+
+    Why custom: ``safe_redis_set`` re-raises on breaker open (unlike
+    ``safe_redis_incr`` which returns None), so a naive call here would
+    500 the webhook whenever Redis flapped. We catch the breaker
+    exceptions and fall back to the per-process counter (M1 fix);
+    ``count == 1`` is the in-memory equivalent of NX-set succeeding.
+    """
+    try:
+        notified = await safe_redis_set(
+            key, "1", ex=window_seconds, nx=True
+        )
+        return bool(notified)
+    except (ConnectionError, TimeoutError):
+        # Redis breaker open — degrade closed-but-bounded: use the
+        # in-memory counter, send the reply only on first hit per
+        # window per process. Multiple workers may each send once, but
+        # that's bounded (N workers × 1 reply/window) — far better
+        # than either 500ing the webhook or letting every spam message
+        # trigger a reply.
+        return fallback_incr(key, window_seconds) == 1
 
 
 async def _rate_limit_chat(chat_id: str) -> bool:
@@ -90,16 +118,19 @@ async def _rate_limit_chat(chat_id: str) -> bool:
     Atomic via INCR + EXPIRE — a GET-then-SET pattern would let two
     concurrent webhook deliveries both pass when both observe the
     pre-increment count.
+
+    F-2: when Redis is unavailable (``safe_redis_incr`` returns None),
+    fall back to a per-process in-memory counter rather than failing
+    OPEN. With N workers an attacker still gets ``N × limit`` per
+    window, but that's bounded — fail-open let send_message quota be
+    drained whenever Redis flapped.
     """
     key = f"{_WEBHOOK_RL_PREFIX}{chat_id}"
     new_val = await safe_redis_incr(key)
     if new_val == 1:
         await safe_redis_expire(key, _WEBHOOK_RL_WINDOW)
     if new_val is None:
-        # Redis breaker open — let the request through rather than
-        # failing closed. The webhook itself isn't the attack surface
-        # for the link code (the 6-char Redis-stored code is).
-        return False
+        new_val = fallback_incr(key, _WEBHOOK_RL_WINDOW)
     return new_val > _WEBHOOK_RL_LIMIT
 
 
@@ -184,18 +215,13 @@ async def zalo_bot_webhook(
 
     # 3. Rate limit per chat_id.
     if await _rate_limit_chat(chat_id):
-        # Only reply once per window. ``SET NX EX`` returns truthy on
-        # first set inside the window, falsy on subsequent attempts —
-        # so the reply (and its send_message quota cost) fires exactly
-        # once per minute per chat regardless of attack volume. If
-        # Redis is unavailable, ``safe_redis_set`` returns None / False
-        # and we silently drop the reply, which is the right
-        # availability tradeoff (still log the rate_limited hit).
-        notified = await safe_redis_set(
+        # First-hit-only reply via ``_once_per_window`` — the SET NX EX
+        # plus in-memory fallback so a Redis flap doesn't 500 the webhook
+        # (M1 fix; ``safe_redis_set`` re-raises on breaker open unlike
+        # the rest of the safe_redis_* family).
+        notified = await _once_per_window(
             f"{_WEBHOOK_RL_NOTIFIED_PREFIX}{chat_id}",
-            "1",
-            ex=_WEBHOOK_RL_WINDOW,
-            nx=True,
+            _WEBHOOK_RL_WINDOW,
         )
         if notified:
             await _send_reply(
@@ -203,8 +229,8 @@ async def zalo_bot_webhook(
             )
         log.warning(
             "zalo_bot webhook rate_limited",
-            chat_id_prefix=_mask_chat_id(chat_id),
-            replied=bool(notified),
+            chat_id_prefix=mask_chat_id(chat_id),
+            replied=notified,
         )
         return {"status": "rate_limited"}
 
@@ -213,7 +239,7 @@ async def zalo_bot_webhook(
     #    latter as the message slot.
     log.info(
         "zalo_bot webhook event",
-        chat_id_prefix=_mask_chat_id(chat_id),
+        chat_id_prefix=mask_chat_id(chat_id),
         event_kind="text",
     )
 
@@ -247,7 +273,7 @@ async def zalo_bot_webhook(
             await db.rollback()
             log.exception(
                 "zalo_bot verify_and_link failed",
-                chat_id_prefix=_mask_chat_id(chat_id),
+                chat_id_prefix=mask_chat_id(chat_id),
             )
             await _send_reply(chat_id, "Lỗi hệ thống. Vui lòng thử lại sau.")
             return {"status": "ok", "mode": "service_error"}
@@ -264,7 +290,7 @@ async def zalo_bot_webhook(
                 # issue — the link itself is already committed.
                 log.exception(
                     "zalo_bot displacement post_commit failed",
-                    chat_id_prefix=_mask_chat_id(chat_id),
+                    chat_id_prefix=mask_chat_id(chat_id),
                 )
         return {"status": "ok", "mode": "verify_and_link", "linked": ok}
 
@@ -281,7 +307,7 @@ async def zalo_bot_webhook(
             await db.rollback()
             log.exception(
                 "zalo_bot unlink_by_chat_id failed",
-                chat_id_prefix=_mask_chat_id(chat_id),
+                chat_id_prefix=mask_chat_id(chat_id),
             )
             await _send_reply(chat_id, "Lỗi hệ thống. Vui lòng thử lại sau.")
             return {"status": "ok", "mode": "service_error"}
@@ -301,13 +327,22 @@ async def zalo_bot_webhook(
         return {"status": "ok", "mode": "status", "linked": bool(link)}
 
     # ---------------- help / unknown ----------------
-    await _send_reply(
-        chat_id,
-        (
-            "QLTS Bot:\n"
-            "/lienket <MA> — liên kết tài khoản\n"
-            "/huylienket — huỷ liên kết\n"
-            "/trangthai — kiểm tra trạng thái"
-        ),
+    # F-6: throttle the help reply per chat_id so an attacker spamming
+    # noise can't drain send_message quota by triggering one help reply
+    # per inbound text. Uses the same ``_once_per_window`` helper as the
+    # rate-limited reply above so a Redis breaker open path can't 500
+    # the webhook here either.
+    notified = await _once_per_window(
+        f"{_HELP_REPLY_PREFIX}{chat_id}", _HELP_REPLY_WINDOW
     )
-    return {"status": "ok", "mode": "help"}
+    if notified:
+        await _send_reply(
+            chat_id,
+            (
+                "QLTS Bot:\n"
+                "/lienket <MA> — liên kết tài khoản\n"
+                "/huylienket — huỷ liên kết\n"
+                "/trangthai — kiểm tra trạng thái"
+            ),
+        )
+    return {"status": "ok", "mode": "help", "replied": notified}

--- a/Backend_FastAPI/app/services/notification_channels/zalo_bot_channel.py
+++ b/Backend_FastAPI/app/services/notification_channels/zalo_bot_channel.py
@@ -121,7 +121,9 @@ class ZaloBotChannel(BaseChannel):
         # Logging: never echo the message body — it may carry PII via
         # template substitution. Mask the chat_id like the link service
         # does so log scraping doesn't leak the binding.
-        chat_prefix = (link.chat_id[:8] + "***") if link.chat_id else ""
+        from app.utils.masking import mask_chat_id
+
+        chat_prefix = mask_chat_id(link.chat_id)
 
         if result.success:
             log.info(

--- a/Backend_FastAPI/app/services/notification_consent_service.py
+++ b/Backend_FastAPI/app/services/notification_consent_service.py
@@ -143,6 +143,50 @@ async def grant_implied_zalo_consent(
         return False
 
 
+async def record_zalo_bot_consent(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    granted: bool,
+    source: str,
+    actor_id: Optional[int] = None,
+) -> None:
+    """Record consent state for a staff Zalo Bot binding.
+
+    Mirrors ``grant_implied_zalo_consent`` for the ``zalo_bot`` channel.
+    The bot binding is staff-internal (channel=``zalo_bot``,
+    source_type=``user``, source_id=user.id) — distinct from the
+    customer-facing ZNS channel (``zalo`` + ``lead``).
+
+    **Failure semantics**: this helper does NOT swallow exceptions.
+    ``upsert_consent`` flushes inline; an ``IntegrityError`` there
+    poisons the SQLAlchemy session and any subsequent
+    ``COMMIT TO SAVEPOINT`` raises ``PendingRollbackError`` — which
+    would kill the outer link transaction. Catching at this layer
+    cannot recover the savepoint state; only the SAVEPOINT's own
+    ``__aexit__`` rollback path can. So the contract is:
+
+    Caller MUST wrap the call in
+    ``try: async with db.begin_nested(): await record_zalo_bot_consent(...)
+    except Exception: log + continue`` so the SAVEPOINT rolls back
+    cleanly via the exception path before the catch sees it. The link
+    table remains source of truth for delivery gating; this is for
+    audit/compliance only.
+    """
+    await upsert_consent(
+        db,
+        data={
+            "channel": "zalo_bot",
+            "source_type": "user",
+            "source_id": user_id,
+            "consent_status": "granted" if granted else "revoked",
+            "consent_source": source,
+            "notes": f"zalo_bot {source}",
+        },
+        actor_id=actor_id,
+    )
+
+
 async def bulk_import_consents(
     db: AsyncSession,
     *,

--- a/Backend_FastAPI/app/services/zalo_bot_link_service.py
+++ b/Backend_FastAPI/app/services/zalo_bot_link_service.py
@@ -29,7 +29,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.repositories.staff_zalo_bot_link_repository import (
     StaffZaloBotLinkRepository,
 )
+from app.services import notification_consent_service
 from app.utils.exceptions import BusinessRuleViolation
+from app.utils.masking import mask_chat_id
 
 log = structlog.get_logger(__name__)
 
@@ -106,20 +108,6 @@ async def generate_link_code(
     raise BusinessRuleViolation("Không tạo được mã liên kết. Vui lòng thử lại.")
 
 
-def _audit_chat_id_prefix(chat_id: str) -> str:
-    """Mask chat_id for audit/log payload — first 4 + last 2 chars.
-
-    Tighter than the webhook-side ``_mask_chat_id`` (which exposes 8 chars)
-    so audit history doesn't leak more than necessary while still letting
-    operators correlate rows.
-    """
-    if not chat_id:
-        return ""
-    if len(chat_id) <= 6:
-        return chat_id[:2] + "***"
-    return chat_id[:4] + "***" + chat_id[-2:]
-
-
 async def verify_and_link(
     db: AsyncSession,
     code: str,
@@ -176,6 +164,28 @@ async def verify_and_link(
             reason=f"chat_id reassigned to user_id={user_id}",
             source=source,
         )
+        # Consent history parity: the displaced staff member loses delivery
+        # eligibility for the zalo_bot channel. Record a revoke row so the
+        # consent timeline shows the event alongside grant/unlink.
+        # SAVEPOINT + try/except: upsert_consent flushes; an IntegrityError
+        # would poison the session, but the SAVEPOINT __aexit__ rolls back
+        # cleanly when an exception bubbles, then the outer except logs +
+        # continues without blocking the link write.
+        try:
+            async with db.begin_nested():
+                await notification_consent_service.record_zalo_bot_consent(
+                    db,
+                    user_id=displaced_user_id,
+                    granted=False,
+                    source="displaced",
+                    actor_id=user_id,
+                )
+        except Exception:
+            log.warning(
+                "record_zalo_bot_consent (displaced) failed, link unblocked",
+                displaced_user_id=displaced_user_id,
+                exc_info=True,
+            )
 
     link = await repo.create_or_reactivate(user_id, chat_id, display_name)
     await _sync_preference(db, user_id, enabled=True, actor_user_id=user_id)
@@ -190,17 +200,36 @@ async def verify_and_link(
         actor_user_id=user_id,
         new_values={
             "user_id": user_id,
-            "chat_id_prefix": _audit_chat_id_prefix(chat_id),
+            "chat_id_prefix": mask_chat_id(chat_id),
             "display_name": display_name,
             "is_active": True,
         },
         source=source,
     )
 
+    # Consent history parity: a successful link grants zalo_bot consent
+    # for the new user. SAVEPOINT + try/except (see helper docstring) so
+    # an upsert IntegrityError can't poison the link transaction.
+    try:
+        async with db.begin_nested():
+            await notification_consent_service.record_zalo_bot_consent(
+                db,
+                user_id=user_id,
+                granted=True,
+                source="link",
+                actor_id=user_id,
+            )
+    except Exception:
+        log.warning(
+            "record_zalo_bot_consent (link) failed, link unblocked",
+            user_id=user_id,
+            exc_info=True,
+        )
+
     log.info(
         "Zalo Bot linked",
         user_id=user_id,
-        chat_id_prefix=_audit_chat_id_prefix(chat_id),
+        chat_id_prefix=mask_chat_id(chat_id),
         displaced_user_id=displaced_user_id,
     )
 
@@ -214,7 +243,7 @@ async def verify_and_link(
 
         _displaced_user_id = displaced_user_id
         _new_user_id = user_id
-        _chat_prefix = _audit_chat_id_prefix(chat_id)
+        _chat_prefix = mask_chat_id(chat_id)
 
         async def _post_commit() -> None:
             await safe_dispatch(
@@ -272,6 +301,27 @@ async def unlink(
         reason="user-initiated unlink",
         source=source,
     )
+
+    # Consent history parity: revoke row mirrors the unlink. ``source``
+    # propagates so audit trail can distinguish API unlink from webhook
+    # /huylienket unlink ("api" vs "zalo_bot_webhook"). SAVEPOINT +
+    # try/except (see helper docstring) so a flush failure can't poison
+    # the unlink transaction.
+    try:
+        async with db.begin_nested():
+            await notification_consent_service.record_zalo_bot_consent(
+                db,
+                user_id=user_id,
+                granted=False,
+                source=f"unlink:{source}",
+                actor_id=user_id,
+            )
+    except Exception:
+        log.warning(
+            "record_zalo_bot_consent (unlink) failed, unlink unblocked",
+            user_id=user_id,
+            exc_info=True,
+        )
 
     return True, "Đã huỷ liên kết.", None
 

--- a/Backend_FastAPI/app/utils/inmemory_rate_limit.py
+++ b/Backend_FastAPI/app/utils/inmemory_rate_limit.py
@@ -1,0 +1,120 @@
+"""Per-process in-memory rate limit fallback for Redis-down windows.
+
+Used by Zalo Bot webhook + link-code endpoints when ``safe_redis_incr``
+returns ``None`` (Redis circuit breaker open). Without this, those
+endpoints fail OPEN on Redis loss — letting an attacker DoS the bot's
+send_message quota or generate unbounded link codes.
+
+Properties:
+- Per-process counters (no cross-worker coordination). With N gunicorn
+  workers, an attacker effectively gets ``N × limit`` per window. Still
+  bounded — much better than fail-open.
+- ``time.monotonic()`` based windowing. Counter resets when the window
+  expires; no background sweep, evictions happen on next access.
+- Thread-safe via ``threading.Lock`` (gunicorn workers are processes,
+  but uvicorn inside them may dispatch on a thread pool).
+- Worker restart loses counters — acceptable, since the scope is
+  "Redis briefly down". Restart pattern is also a natural reset.
+
+NOT a replacement for Redis-backed limiting. Only kicks in when Redis
+is unavailable — Redis-backed counters are still the primary defense.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class _Bucket:
+    count: int
+    window_start: float
+
+
+# Soft cap on the bucket dict so an attacker rotating chat_ids during a
+# Redis outage can't blow up RSS. When exceeded, we sweep expired
+# buckets first; if still over after sweep, new keys fail-closed (return
+# limit+1 to signal "block"). 10k chat_ids per process is well above
+# normal usage but well below memory pressure.
+_MAX_BUCKETS = 10_000
+
+
+class InMemoryRateLimiter:
+    """Fixed-window per-key counter. Window resets on first request after
+    expiry, so behavior matches Redis ``INCR`` + ``EXPIRE`` semantics.
+    """
+
+    def __init__(self) -> None:
+        self._buckets: Dict[str, _Bucket] = {}
+        self._lock = threading.Lock()
+
+    def _sweep_expired(self, now: float, window_seconds: int) -> None:
+        """Drop buckets whose window has fully expired. Called only when
+        the dict hits the soft cap — sweeping every call would be O(N)
+        per request.
+        """
+        expired = [
+            k
+            for k, b in self._buckets.items()
+            if now - b.window_start >= window_seconds
+        ]
+        for k in expired:
+            self._buckets.pop(k, None)
+
+    def incr(self, key: str, window_seconds: int) -> int:
+        """Increment the counter for ``key`` and return the new value.
+
+        Resets the window if ``window_seconds`` have passed since the
+        bucket's window start. Caller compares the returned value to
+        the limit and decides whether to allow or block.
+
+        When the dict is at ``_MAX_BUCKETS``, expired buckets are swept;
+        if the dict is still full after the sweep, new keys return
+        ``window_seconds + 1`` (a sentinel guaranteed > any sane limit)
+        so they fail closed without inserting a new bucket.
+        """
+        now = time.monotonic()
+        with self._lock:
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                if len(self._buckets) >= _MAX_BUCKETS:
+                    self._sweep_expired(now, window_seconds)
+                    if len(self._buckets) >= _MAX_BUCKETS:
+                        # Memory pressure — fail closed for unknown keys.
+                        # Return a large sentinel so callers' ``> limit``
+                        # comparisons evaluate True regardless of limit.
+                        return _MAX_BUCKETS
+                bucket = _Bucket(count=1, window_start=now)
+                self._buckets[key] = bucket
+                return 1
+            if now - bucket.window_start >= window_seconds:
+                bucket.count = 1
+                bucket.window_start = now
+                return 1
+            bucket.count += 1
+            return bucket.count
+
+    def reset(self) -> None:
+        """Reset all buckets — test-only escape hatch."""
+        with self._lock:
+            self._buckets.clear()
+
+
+# Module-level singleton — one shared limiter per process.
+_limiter = InMemoryRateLimiter()
+
+
+def fallback_incr(key: str, window_seconds: int) -> int:
+    """Increment ``key`` in the per-process fallback limiter.
+
+    Returns the new count for the current window. Use this only when
+    Redis is unavailable (``safe_redis_incr`` returned None).
+    """
+    return _limiter.incr(key, window_seconds)
+
+
+def reset_for_tests() -> None:
+    """Reset the singleton — call from test setUp/teardown."""
+    _limiter.reset()

--- a/Backend_FastAPI/app/utils/masking.py
+++ b/Backend_FastAPI/app/utils/masking.py
@@ -75,6 +75,26 @@ def mask_phone(phone: Optional[str], visible_digits: int = 4) -> Optional[str]:
     return "*" * masked_length + digits_only[-visible_digits:]
 
 
+def mask_chat_id(chat_id: Optional[str]) -> str:
+    """Mask a Zalo Bot chat_id for log/audit/dispatch payloads.
+
+    Returns ``"XXXX***YY"`` — first 4 + last 2 chars with ``***`` between.
+    Format is stable across the codebase (webhook logs, audit rows, and
+    notification dedup keys all rely on it) so do not change the
+    separator without coordinating an audit-row + dedup-key migration.
+
+    Why first-4 + last-2 (not first-8): Zalo chat_ids are ~20 hex chars,
+    and exposing 8/20 (40%) is enough to correlate IDs across logs if an
+    attacker gets a partial leak. 6/20 (30%) keeps logs greppable for
+    operators while reducing pivot value for an attacker.
+    """
+    if not chat_id:
+        return ""
+    if len(chat_id) <= 6:
+        return chat_id[:2] + "***"
+    return chat_id[:4] + "***" + chat_id[-2:]
+
+
 def mask_email(email: Optional[str]) -> Optional[str]:
     """
     Mask an email address for display.

--- a/Backend_FastAPI/tests/integration/test_zalo_bot_consent_history.py
+++ b/Backend_FastAPI/tests/integration/test_zalo_bot_consent_history.py
@@ -1,0 +1,272 @@
+"""Consent history parity for Zalo Bot link/unlink/displacement.
+
+PR-Sec-1 (Task 5). Mirrors PR-Audit-1 but for ``notification_consent``
++ ``notification_consent_history`` rows. Locks in:
+- Successful link writes a ``zalo_bot`` consent row with status=granted
+  and appends a history row.
+- Unlink (REST + webhook) flips the consent row to revoked and appends
+  another history row, with ``consent_source`` distinguishing the
+  trigger (``unlink:api`` vs ``unlink:zalo_bot_webhook``).
+- Displacement revokes consent for the displaced user (separate row
+  keyed by their user_id) without touching the new user's grant.
+- Failures inside ``record_zalo_bot_consent`` MUST NOT block the link
+  operation — link table remains source of truth.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification_consent import NotificationConsent
+from app.models.notification_consent_history import NotificationConsentHistory
+from app.services import zalo_bot_link_service
+
+
+pytestmark = pytest.mark.integration
+
+
+async def _consent_row(
+    db: AsyncSession, user_id: int
+) -> NotificationConsent | None:
+    q = select(NotificationConsent).where(
+        NotificationConsent.channel == "zalo_bot",
+        NotificationConsent.source_type == "user",
+        NotificationConsent.source_id == user_id,
+    )
+    return (await db.execute(q)).scalars().first()
+
+
+async def _history_rows(
+    db: AsyncSession, user_id: int
+) -> list[NotificationConsentHistory]:
+    q = (
+        select(NotificationConsentHistory)
+        .where(
+            NotificationConsentHistory.channel == "zalo_bot",
+            NotificationConsentHistory.source_type == "user",
+            NotificationConsentHistory.source_id == user_id,
+        )
+        .order_by(NotificationConsentHistory.id)
+    )
+    return list((await db.execute(q)).scalars().all())
+
+
+class TestLinkWritesGrantedConsent:
+    @pytest.mark.asyncio
+    async def test_first_link_writes_granted_consent_and_history(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            ok, _, _ = await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_consent_link", "Officer A"
+            )
+        assert ok is True
+        await db.commit()
+
+        consent = await _consent_row(db, user_id)
+        assert consent is not None
+        assert consent.consent_status == "granted"
+        assert consent.consent_source == "link"
+
+        history = await _history_rows(db, user_id)
+        assert len(history) == 1
+        assert history[0].action == "granted"
+        assert history[0].new_status == "granted"
+        assert history[0].old_status is None  # First write — no prior state.
+
+
+class TestUnlinkRevokesConsent:
+    @pytest.mark.asyncio
+    async def test_rest_unlink_revokes_with_api_source(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_unlink_consent", None
+            )
+            await db.commit()
+
+        ok, _, _ = await zalo_bot_link_service.unlink(db, user_id)
+        assert ok is True
+        await db.commit()
+
+        consent = await _consent_row(db, user_id)
+        assert consent is not None
+        assert consent.consent_status == "revoked"
+        assert consent.consent_source == "unlink:api"
+
+        history = await _history_rows(db, user_id)
+        # Two events: granted (link) → revoked (unlink).
+        actions = [h.action for h in history]
+        assert actions == ["granted", "revoked"]
+        assert history[1].old_status == "granted"
+        assert history[1].new_status == "revoked"
+
+    @pytest.mark.asyncio
+    async def test_webhook_unlink_revokes_with_webhook_source(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        user_id = officer_user_in_db["id"]
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_unlink_wh_consent", None
+            )
+            await db.commit()
+
+        ok, _, _ = await zalo_bot_link_service.unlink_by_chat_id(
+            db, "chat_unlink_wh_consent"
+        )
+        assert ok is True
+        await db.commit()
+
+        consent = await _consent_row(db, user_id)
+        assert consent.consent_status == "revoked"
+        assert consent.consent_source == "unlink:zalo_bot_webhook"
+
+
+class TestDisplacementRevokesDisplacedUser:
+    @pytest.mark.asyncio
+    async def test_displaced_user_consent_flipped_to_revoked(
+        self,
+        db: AsyncSession,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+    ):
+        user_a = officer_user_in_db["id"]
+        user_b = manager_user_in_db["id"]
+
+        # User A links chat_X first.
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_a)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_displaced", None
+            )
+            await db.commit()
+
+        # User B displaces A by linking the same chat_X.
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_b)),
+        ):
+            await zalo_bot_link_service.verify_and_link(
+                db, "DEF456", "chat_displaced", None
+            )
+            await db.commit()
+
+        # A's consent should be revoked with source=displaced.
+        consent_a = await _consent_row(db, user_a)
+        assert consent_a is not None
+        assert consent_a.consent_status == "revoked"
+        assert consent_a.consent_source == "displaced"
+
+        # B's consent should be granted (the displacement does not touch
+        # the new user's row — only the displaced one).
+        consent_b = await _consent_row(db, user_b)
+        assert consent_b is not None
+        assert consent_b.consent_status == "granted"
+        assert consent_b.consent_source == "link"
+
+        # A's timeline: granted (initial link) → revoked (displacement).
+        history_a = await _history_rows(db, user_a)
+        actions_a = [h.action for h in history_a]
+        assert actions_a == ["granted", "revoked"]
+
+
+class TestConsentFailureDoesNotBlockLink:
+    """Verifies the M2 contract: ``record_zalo_bot_consent`` re-raises;
+    caller wraps SAVEPOINT + try/except so the savepoint rollback path
+    runs cleanly (no PendingRollbackError) and the outer link
+    transaction survives.
+    """
+
+    @pytest.mark.asyncio
+    async def test_link_succeeds_when_consent_upsert_raises_runtime(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        """RuntimeError variant — exercises the "non-flush failure" path
+        (e.g. transient logic error before any SQL is sent). The
+        SAVEPOINT __aexit__ rolls back, caller's except logs, link
+        commits.
+        """
+        user_id = officer_user_in_db["id"]
+
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ), patch(
+            "app.services.notification_consent_service.upsert_consent",
+            new=AsyncMock(side_effect=RuntimeError("simulated transient")),
+        ):
+            ok, _, _ = await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_link_consent_fail_rt", None
+            )
+        assert ok is True, "link must commit even when consent insert raises"
+        await db.commit()
+
+        from app.repositories.staff_zalo_bot_link_repository import (
+            StaffZaloBotLinkRepository,
+        )
+
+        repo = StaffZaloBotLinkRepository(db)
+        link = await repo.get_active_by_chat_id("chat_link_consent_fail_rt")
+        assert link is not None
+        assert link.user_id == user_id
+
+    @pytest.mark.asyncio
+    async def test_link_succeeds_when_consent_upsert_raises_integrity(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        """IntegrityError variant — exercises the realistic path: the
+        upsert flushes, the DB returns a constraint error, and the
+        SAVEPOINT must clean up the poisoned session state before the
+        outer transaction tries to commit. Without proper SAVEPOINT
+        isolation this would manifest as PendingRollbackError on
+        ``db.commit()`` and the link write would be silently lost.
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        user_id = officer_user_in_db["id"]
+
+        with patch(
+            "app.database.safe_redis_getdel",
+            new=AsyncMock(return_value=str(user_id)),
+        ), patch(
+            "app.services.notification_consent_service.upsert_consent",
+            new=AsyncMock(
+                side_effect=IntegrityError(
+                    "INSERT", {}, Exception("simulated unique violation")
+                )
+            ),
+        ):
+            ok, _, _ = await zalo_bot_link_service.verify_and_link(
+                db, "ABC123", "chat_link_consent_fail_ie", None
+            )
+        assert ok is True, "link must survive consent IntegrityError"
+        # CRITICAL: outer commit must NOT raise PendingRollbackError —
+        # if it does, the SAVEPOINT contract is broken.
+        await db.commit()
+
+        from app.repositories.staff_zalo_bot_link_repository import (
+            StaffZaloBotLinkRepository,
+        )
+
+        repo = StaffZaloBotLinkRepository(db)
+        link = await repo.get_active_by_chat_id("chat_link_consent_fail_ie")
+        assert link is not None
+        assert link.user_id == user_id

--- a/Backend_FastAPI/tests/unit/test_inmemory_rate_limit.py
+++ b/Backend_FastAPI/tests/unit/test_inmemory_rate_limit.py
@@ -1,0 +1,102 @@
+"""F-2: in-memory fallback rate limiter unit tests.
+
+Validates the per-process counter used by Zalo Bot endpoints when Redis
+is unavailable. The fallback prevents fail-OPEN on Redis loss.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.utils.inmemory_rate_limit import (
+    InMemoryRateLimiter,
+    fallback_incr,
+    reset_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+class TestInMemoryRateLimiter:
+    def test_first_increment_returns_one(self):
+        rl = InMemoryRateLimiter()
+        assert rl.incr("k1", 60) == 1
+
+    def test_increments_within_window(self):
+        rl = InMemoryRateLimiter()
+        for expected in range(1, 6):
+            assert rl.incr("k1", 60) == expected
+
+    def test_separate_keys_have_independent_counters(self):
+        rl = InMemoryRateLimiter()
+        assert rl.incr("a", 60) == 1
+        assert rl.incr("b", 60) == 1
+        assert rl.incr("a", 60) == 2
+
+    def test_window_expiry_resets_counter(self, monkeypatch):
+        # Patch time.monotonic so we can simulate a window roll-over without
+        # sleeping. Use a list to allow mutation from the patch closure.
+        clock = [1000.0]
+        monkeypatch.setattr(
+            "app.utils.inmemory_rate_limit.time.monotonic", lambda: clock[0]
+        )
+        rl = InMemoryRateLimiter()
+        assert rl.incr("k", 60) == 1
+        assert rl.incr("k", 60) == 2
+        clock[0] += 60.1  # Window has rolled over.
+        assert rl.incr("k", 60) == 1, "should reset to 1 after window expiry"
+
+    def test_reset_clears_all_buckets(self):
+        rl = InMemoryRateLimiter()
+        rl.incr("a", 60)
+        rl.incr("b", 60)
+        rl.reset()
+        assert rl.incr("a", 60) == 1
+        assert rl.incr("b", 60) == 1
+
+    def test_soft_cap_sweeps_expired_then_fails_closed(self, monkeypatch):
+        """Attacker rotating chat_ids during Redis outage cannot blow
+        memory: dict caps at _MAX_BUCKETS, expired entries sweep first,
+        then new keys fail closed.
+        """
+        from app.utils import inmemory_rate_limit as ir
+
+        # Shrink the cap for the test so we don't have to insert 10k keys.
+        monkeypatch.setattr(ir, "_MAX_BUCKETS", 5)
+        clock = [1000.0]
+        monkeypatch.setattr(
+            "app.utils.inmemory_rate_limit.time.monotonic", lambda: clock[0]
+        )
+
+        rl = ir.InMemoryRateLimiter()
+        # Fill cap with non-expired entries.
+        for i in range(5):
+            assert rl.incr(f"k{i}", 60) == 1
+
+        # 6th unique key with all entries still fresh → fail closed
+        # (returns sentinel >= cap so callers' "> limit" evaluates True).
+        result = rl.incr("k_new", 60)
+        assert result >= 5, "new key beyond cap must fail closed"
+
+        # Roll the clock so half the original keys expire, then a new
+        # key should succeed (sweep clears expired entries first).
+        clock[0] += 60.1
+        # k0..k4 windows are now expired. New key triggers sweep.
+        assert rl.incr("k_after_sweep", 60) == 1
+
+
+class TestFallbackIncrSingleton:
+    def test_singleton_increments_across_calls(self):
+        assert fallback_incr("test:k", 60) == 1
+        assert fallback_incr("test:k", 60) == 2
+        assert fallback_incr("test:k", 60) == 3
+
+    def test_reset_for_tests_clears_singleton(self):
+        fallback_incr("test:k", 60)
+        fallback_incr("test:k", 60)
+        reset_for_tests()
+        assert fallback_incr("test:k", 60) == 1

--- a/Backend_FastAPI/tests/unit/test_masking.py
+++ b/Backend_FastAPI/tests/unit/test_masking.py
@@ -9,7 +9,12 @@ Tests the masking functions for sensitive PII data:
 """
 
 import pytest
-from app.utils.masking import mask_citizen_id, mask_phone, mask_email
+from app.utils.masking import (
+    mask_chat_id,
+    mask_citizen_id,
+    mask_email,
+    mask_phone,
+)
 
 
 class TestMaskCitizenId:
@@ -193,3 +198,39 @@ class TestMaskingIntegration:
         result3 = mask_citizen_id(cccd)
 
         assert result1 == result2 == result3
+
+
+class TestMaskChatId:
+    """F-5: Zalo Bot chat_id masking — first 4 + last 2."""
+
+    def test_long_chat_id_masks_middle(self):
+        result = mask_chat_id("12345678ABCDEFGHIJKL")
+        assert result == "1234***KL"
+
+    def test_returns_empty_string_for_none(self):
+        assert mask_chat_id(None) == ""
+
+    def test_returns_empty_string_for_empty(self):
+        assert mask_chat_id("") == ""
+
+    def test_short_chat_id_uses_two_char_prefix(self):
+        # <= 6 chars cannot show 4+2 without exposing everything; fall back
+        # to 2 + *** so we still hide enough to differentiate from raw value.
+        assert mask_chat_id("abc") == "ab***"
+        assert mask_chat_id("abcdef") == "ab***"
+
+    def test_seven_char_chat_id_masks_middle(self):
+        # Boundary: 7 chars -> first 4 + last 2 = "abcd***fg" (1 char hidden)
+        assert mask_chat_id("abcdefg") == "abcd***fg"
+
+    def test_only_exposes_six_of_twenty_chars(self):
+        # Confirm leak surface: 6/20 visible = 30% (vs old 8/20 = 40%).
+        masked = mask_chat_id("a" * 20)
+        # Count visible chars: prefix 4 + suffix 2 = 6.
+        visible = masked.replace("***", "")
+        assert len(visible) == 6
+
+    def test_format_uses_three_star_separator(self):
+        # Audit DB rows + notification dedup keys depend on the literal
+        # "***" separator; changing it would silently break dedup keys.
+        assert "***" in mask_chat_id("12345678ABCDEFGH")

--- a/Documents/RUNBOOK_zalo_bot_secret_rotation.md
+++ b/Documents/RUNBOOK_zalo_bot_secret_rotation.md
@@ -1,0 +1,183 @@
+# Runbook — Zalo Bot Webhook Secret Rotation
+
+**Last updated**: 2026-04-29
+**Owner**: Ops + Bot integration lead
+**Frequency**: Every 90 days (or immediately on suspected leak)
+**Estimated downtime**: 0 (rolling restart) — see Step 4 for grace-window strategy
+
+---
+
+## Why rotate?
+
+The Zalo Bot webhook is authenticated solely by the shared secret in
+the `X-Bot-Api-Secret-Token` header (compared timing-safe in
+`zalo_bot_webhooks.py`). There is no replay defense, no timestamp, no
+HMAC envelope. A leaked secret therefore allows arbitrary spoofed
+webhook deliveries until the secret changes.
+
+The `ZALO_BOT_WEBHOOK_SECRET` env var has no built-in expiry. Without
+a periodic rotation, a leak becomes **forever**. F-3 (OWASP review,
+2026-04-28) classified this as MEDIUM severity operational risk.
+
+---
+
+## When to rotate
+
+| Trigger | Urgency |
+|---|---|
+| Scheduled 90-day rotation | Within the same week |
+| Secret committed to git, slack, screenshot, etc. | Immediately |
+| Unexplained webhook traffic spike | Immediately |
+| Departure of staff with prod env access | Within 24h |
+
+---
+
+## Procedure
+
+### Step 1 — Generate the new secret
+
+```bash
+# 32 random URL-safe bytes (43 chars, ~256 bits entropy)
+python -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+Save the output to your password manager **immediately** under
+`zalo-bot-webhook-secret-NEW`. Do NOT paste into chat or commit.
+
+### Step 2 — Stage the new secret on the server
+
+> ⚠️ **READ THIS FIRST** — Dual-secret accept (`ZALO_BOT_WEBHOOK_SECRET_PREVIOUS`)
+> is **NOT shipped in code as of 2026-04-29**. Setting that env var
+> alone does nothing — the webhook only reads `ZALO_BOT_WEBHOOK_SECRET`.
+>
+> Pick one path:
+>
+> - **Path A — Brief downtime acceptable (default)**: skip the
+>   `_PREVIOUS` line below and edit only `ZALO_BOT_WEBHOOK_SECRET`.
+>   Plan for ~5–15s of 401 webhook responses while the Zalo OA console
+>   propagates. Zalo retries on non-2xx, but the secret check rejects
+>   401 retries — accept that a handful of inbound messages during the
+>   gap will be dropped (operationally trivial: 10 webhook events/min
+>   peak, retries clear in seconds).
+> - **Path B — True zero-downtime**: ship the Appendix A code change
+>   first (~1h PR), redeploy backend, then proceed with the
+>   `_PREVIOUS` line below as a real dual-accept window.
+
+```bash
+# On the prod host
+cd /opt/qlts
+sudo nano .env.production
+# Path A (dual-accept NOT yet shipped):
+#   Set ZALO_BOT_WEBHOOK_SECRET=<new_secret_value>
+# Path B (dual-accept already shipped per Appendix A):
+#   Set ZALO_BOT_WEBHOOK_SECRET_PREVIOUS=<old_secret_value>
+#   Set ZALO_BOT_WEBHOOK_SECRET=<new_secret_value>
+```
+
+### Step 3 — Update the Zalo OA console
+
+1. Log in to <https://oa.zalo.me/manage/menu/bot> with the bot owner account.
+2. Navigate to **Bot Settings → Webhook**.
+3. Replace the secret token with the new value.
+4. Save.
+
+The Zalo console sends a verification probe to the webhook URL — it
+must succeed under the new secret. If you applied Appendix A
+dual-secret support, success is guaranteed.
+
+### Step 4 — Restart backend (rolling)
+
+```bash
+# Apply the new env var into the running stack without dropping requests
+docker compose up -d --no-deps backend
+```
+
+The `--no-deps backend` recreates only the backend container and
+respects nginx upstream timeouts; in-flight requests complete on the
+old container before the new one takes over.
+
+### Step 5 — Verify
+
+```bash
+# 1. Should see no 401 webhook rejections in the last 5 minutes
+docker compose logs backend --tail=200 | grep -i "Invalid secret"
+
+# 2. Should see successful webhook events flowing
+docker compose logs backend --tail=200 | grep -i "zalo_bot webhook event"
+```
+
+If you see sustained 401s, roll the OA console secret back to the old
+value (Step 3 reversed) and investigate. The old secret is still
+listed under `ZALO_BOT_WEBHOOK_SECRET_PREVIOUS` so the webhook will
+keep accepting it during your roll-back.
+
+### Step 6 — Drop the old secret (after 1 hour)
+
+After 1 hour with no 401s and no operator complaints, remove the old
+secret from `.env.production`:
+
+```bash
+# On prod host
+cd /opt/qlts
+sudo nano .env.production
+# Delete the ZALO_BOT_WEBHOOK_SECRET_PREVIOUS line entirely
+docker compose up -d --no-deps backend
+```
+
+This finalises the rotation. The old secret is now revoked.
+
+### Step 7 — Update password manager + audit
+
+1. Move `zalo-bot-webhook-secret-NEW` → `zalo-bot-webhook-secret`.
+2. Move the previous-current value → `zalo-bot-webhook-secret-RETIRED-<YYYY-MM-DD>`.
+3. Add a Calendar reminder for 90 days from today: "Rotate Zalo Bot webhook secret".
+
+---
+
+## Rollback
+
+If anything goes wrong before Step 6:
+
+1. Revert `.env.production` to the prior commit (`git stash` or `git checkout`).
+2. Revert the OA console secret (Step 3).
+3. `docker compose up -d --no-deps backend`.
+4. Verify webhook traffic resumes (Step 5).
+
+The old secret is still valid until you delete it from `.env.production`,
+so rollback is non-destructive within the cut-over window.
+
+---
+
+## Appendix A — Optional dual-secret code support (recommended)
+
+To enable true zero-downtime rotation, extend `zalo_bot_webhooks.py`:
+
+```python
+configured_secret = settings.ZALO_BOT_WEBHOOK_SECRET or ""
+previous_secret = settings.ZALO_BOT_WEBHOOK_SECRET_PREVIOUS or ""
+if not configured_secret:
+    return Response(status_code=401, content="Webhook secret not configured")
+
+presented = request.headers.get("X-Bot-Api-Secret-Token", "") or ""
+if not (
+    hmac.compare_digest(presented, configured_secret)
+    or (previous_secret and hmac.compare_digest(presented, previous_secret))
+):
+    return Response(status_code=401, content="Invalid secret")
+```
+
+Add `ZALO_BOT_WEBHOOK_SECRET_PREVIOUS: str = ""` to `app/config.py`.
+The previous secret defaults to empty so the dual-accept branch is a
+no-op when not rotating. Leave the env var unset outside rotation
+windows.
+
+This change is NOT in scope for the F-3 runbook PR itself — the
+runbook ships first; the code change can follow as a one-line PR if
+ops decides they want truly zero-downtime rotation.
+
+---
+
+## Related findings
+
+- F-3 (MEDIUM, OWASP review 2026-04-28) — Webhook secret never rotates → leak is forever.
+- See also: `Backend_FastAPI/app/routers/zalo_bot_webhooks.py:117-128` for the secret-check implementation.


### PR DESCRIPTION
## Summary

Closes 4 OWASP findings from 2026-04-28 ``/owasp-security`` review (memory ``zalo-bot-audit-gap``) + 1 audit gap.

### F-2 MEDIUM — In-memory rate-limit fallback
- New ``app/utils/inmemory_rate_limit.py`` token-bucket fallback. Webhook + link endpoints no longer fail-OPEN on Redis breaker open.
- Soft cap ``_MAX_BUCKETS=10_000``: when full, sweep expired buckets first; if still full, return sentinel so new keys fail-closed (attacker rotating chat_ids during Redis outage can't blow RSS).

### F-3 MEDIUM (operational) — Webhook secret rotation runbook
- New ``Documents/RUNBOOK_zalo_bot_secret_rotation.md`` — 90-day rotation procedure.
- ⚠️ block at top: dual-secret accept (``ZALO_BOT_WEBHOOK_SECRET_PREVIOUS``) is NOT shipped 2026-04-29. Path A (brief downtime, default) vs Path B (Appendix A code change for zero-downtime) explicit.

### F-5 LOW — chat_id mask helper
- New ``app/utils/masking.py`` ``mask_chat_id`` helper. Reduces log leak from 8/20 → 6/20 hex chars (first 4 + last 2).
- Replaces all inline ``chat_id[:8] + '***'`` and ``_audit_chat_id_prefix`` callsites — grep returns zero remaining occurrences.

### F-6 LOW — Help-text reply throttle
- Bot reply for unknown text was unthrottled (one help reply per inbound message → drained ``send_message`` quota).
- New ``_once_per_window()`` helper in ``zalo_bot_webhooks.py`` wraps ``safe_redis_set`` with ``try/except (ConnectionError, TimeoutError)`` falling back to ``fallback_incr`` — ``count == 1`` is the in-memory equivalent of NX-set succeeding. Both F-1 reply branch + F-6 help branch share this helper.

### Audit parity — consent_history for zalo_bot channel
- Phase G ZNS shipped ``notification_consent_history`` for ``zalo`` channel; equivalent for ``zalo_bot`` was missing.
- New ``record_zalo_bot_consent`` helper in ``notification_consent_service.py``: writes ``notification_consent`` + ``notification_consent_history`` rows on link / displacement / unlink. Source field distinguishes ``link`` / ``displaced`` / ``unlink_*``.
- 3 callsites in ``zalo_bot_link_service.py`` wrap helper in ``try: async with db.begin_nested(): ... except Exception: log`` so an ``IntegrityError`` from ``upsert_consent`` flush triggers SAVEPOINT ``__aexit__`` rollback BEFORE the catch — never poisons the outer link transaction.

### Review fixes (post-pass-1)
After review found M1 (F-6 unhandled exception path) + M2 (SAVEPOINT contract fragile to IntegrityError) + 4 nits:
- **M1**: ``_once_per_window`` helper handles ``(ConnectionError, TimeoutError)`` re-raise from ``safe_redis_set`` — falls back to in-memory counter rather than 500ing the webhook.
- **M2**: ``record_zalo_bot_consent`` no longer swallows; raises propagate so SAVEPOINT rollback runs cleanly. New ``test_link_succeeds_when_consent_upsert_raises_integrity`` exercises the realistic IntegrityError path.
- **Nit 1**: ``_MAX_BUCKETS=10_000`` cap with sweep + fail-closed sentinel.
- **Nit 2**: comment update on ``_once_per_window`` callsites.
- **Nit 3**: hoist ``notification_consent_service`` import to module level (was 3 nested function-local imports).
- **Nit 4**: runbook ⚠️ block clarifies Appendix A code is NOT shipped; Path A vs Path B explicit.

## Test plan

### PR-Sec-1 suite — **50/50 PASS**
- ``tests/unit/test_inmemory_rate_limit.py`` (8) — increment, separate keys, window expiry, reset, soft cap sweep + fail-closed sentinel, singleton.
- ``tests/unit/test_masking.py`` (36) — None / empty / <6 chars / boundary at 7 / long / 30%-leak invariant / literal ``***`` separator + parametrized cases.
- ``tests/integration/test_zalo_bot_consent_history.py`` (6) — first link grants consent + history, REST unlink (api source), webhook unlink (webhook source), displacement flips old user to revoked, RuntimeError doesn't block link, **IntegrityError doesn't block link** (M2 contract).

### Notification CI gate (regression) — **91/91 PASS**
- ``test_notification_parity.py`` 29/29
- ``test_notification_contract.py`` 31/31
- ``test_condition_dispatch.py`` 4/4
- ``test_notification_dispatcher.py`` 7/7
- ``test_notification_core_v2.py`` 19/19

### Pre-deploy
- [x] Branch rebased on ``origin/main`` (= #163 Lane C). Merge-tree dry-run clean.
- [x] py_compile + module imports clean.
- [x] flake8 critical (E9/F63/F7/F82) — 0 errors.
- [x] No TODO/FIXME/HACK/print/console.log left in diff.
- [x] No SystemEvents added (notification event coverage script not required).
- [x] No alembic migration / no schema change / no env var / no FE files.
- [x] Lane C prod deploy stable (containers up 42+ min, /health 200).

## Operational checklist (post-merge)
- Schedule first 90-day rotation per runbook (~2026-07-29).
- Decide whether to ship Appendix A (dual-secret) before first rotation. Without it, rotation has 5-15s mis-auth gap.
- Post-deploy: install dev deps + run new test suites in container to lock in regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)