### PR TITLE
test-debt: partial cleanup — Casbin drift + dirty-state user fixture

### DIFF
--- a/Backend_FastAPI/tests/fixtures/users.py
+++ b/Backend_FastAPI/tests/fixtures/users.py
@@ -8,7 +8,8 @@ Standard return: dict with id, username, email, password.
 import logging
 from typing import Optional
 
-from sqlalchemy import insert
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 log = logging.getLogger(__name__)
 
@@ -42,16 +43,37 @@ async def create_user_with_role(
     user_info = {}
     async with session_factory() as session:
         async with session.begin():
-            user = models.User(
-                username=user_data["username"],
-                email=user_data["email"],
-                password_hash=get_password_hash(user_data["password"]),
-                role=user_data["role"],
-                status=user_data["status"],
-                unit_id=unit_id,
+            # Dirty-state safety: ``_truncate_all_tables`` occasionally
+            # leaves a row from the prior session (qlts_test cleanup
+            # races — see memory ``reference_test_db_schema_source``).
+            # Reuse the existing row instead of hitting
+            # ``ix_user_username`` UNIQUE.
+            existing = await session.execute(
+                select(models.User).where(
+                    models.User.username == user_data["username"]
+                )
             )
-            session.add(user)
-            await session.flush()
+            user = existing.scalar_one_or_none()
+            if user is None:
+                user = models.User(
+                    username=user_data["username"],
+                    email=user_data["email"],
+                    password_hash=get_password_hash(user_data["password"]),
+                    role=user_data["role"],
+                    status=user_data["status"],
+                    unit_id=unit_id,
+                )
+                session.add(user)
+                await session.flush()
+            else:
+                # Reset mutable fields so the recycled row matches what
+                # the test expects (login + RBAC).
+                user.email = user_data["email"]
+                user.password_hash = get_password_hash(user_data["password"])
+                user.role = user_data["role"]
+                user.status = user_data["status"]
+                user.unit_id = unit_id
+                await session.flush()
             db_user_id = user.id
             if not db_user_id:
                 raise Exception(
@@ -59,8 +81,15 @@ async def create_user_with_role(
                 )
 
             if CasbinRule:
-                casbin_policy = insert(CasbinRule).values(
-                    ptype="g", v0=f"user:{db_user_id}", v1=casbin_role
+                # Casbin grouping rule may also survive a failed
+                # truncate — ON CONFLICT DO NOTHING keeps the fixture
+                # idempotent on re-entry.
+                casbin_policy = (
+                    pg_insert(CasbinRule)
+                    .values(
+                        ptype="g", v0=f"user:{db_user_id}", v1=casbin_role
+                    )
+                    .on_conflict_do_nothing()
                 )
                 await session.execute(casbin_policy)
 

--- a/Backend_FastAPI/tests/integration/test_admission_workflow_e2e.py
+++ b/Backend_FastAPI/tests/integration/test_admission_workflow_e2e.py
@@ -1176,21 +1176,35 @@ class TestDiamondInheritancePermissions:
         assert ("/api/payments", "POST") not in manager_actions
         assert ("/api/fees/calculate", "POST") not in manager_actions
     
-    def test_officer_template_lacks_finance_operations(self):
-        """Officer should NOT have finance operation permissions."""
+    def test_officer_template_finance_scope(self):
+        """Officer must keep accountant-only finance writes off, but
+        retains the scoped operations they need to drive payment flow.
+
+        Per chat-thread decision ``admission-audit-decisions-2026-04-24``
+        ("officer scoped fee calc"), ``POST /api/fees/calculate`` is now
+        on the officer template — the officer needs it to compute the
+        fee for an approved/confirmed/enrolled profile before sending
+        the payment link. The earlier ``not in`` assertion no longer
+        matches the policy and was the test-debt fix flagged in the
+        ADM-007 audit arc.
+
+        Recording payments and issuing invoices remain accountant-only
+        — officer is still firewalled from those writes.
+        """
         from app.casbin_config.policy_templates import OFFICER_TEMPLATE
-        
+
         officer_actions = [
             (p["object"], p["action"])
             for p in OFFICER_TEMPLATE["policies"]
         ]
-        
-        # Officer should NOT have finance write operations
+
+        # Accountant-only writes — officer must NOT carry these.
         assert ("/api/payments", "POST") not in officer_actions
-        assert ("/api/fees/calculate", "POST") not in officer_actions
         assert ("/api/invoices/{id}/issue", "PUT") not in officer_actions
-        
-        # But CAN create payment intent (for online payment links)
+
+        # Officer-scoped writes — officer NEEDS these to drive payment
+        # flow without round-tripping through accountant.
+        assert ("/api/fees/calculate", "POST") in officer_actions
         assert ("/api/payments/intents", "POST") in officer_actions
 
 


### PR DESCRIPTION
## Summary

Partial test-debt cleanup. Fixes 2 of the 6 pre-existing failures
documented in memory ``project_test_debt_admission_workflow_e2e``.
**Does NOT claim full sweep clean** — see "Still deferred" below.

### Fix 1 — Casbin policy drift (1-line)
``test_officer_template_lacks_finance_operations`` asserted officer
LACKS ``/api/fees/calculate POST``. Decision
``admission-audit-decisions-2026-04-24`` chốt "officer scoped fee
calc" → ``OFFICER_TEMPLATE`` was updated (line 156, with PR #7 comment
explaining narrow scope to assigned profiles in
approved/confirmed/enrolled). Test renamed to
``test_officer_template_finance_scope`` and asserts the inclusion.

### Fix 2 — User fixture idempotent
``tests/fixtures/users.py::create_user_with_role`` now SELECTs by
username first; reuses + resets mutable fields if the row exists,
otherwise INSERT. Casbin grouping rule uses
``pg_insert(...).on_conflict_do_nothing()``. Removes the sporadic
``UniqueViolationError: ix_user_username (testadmin)`` failure that
hit ``test_admin_can_unclaim_anyone`` and friends when
``_truncate_all_tables`` left a row from the prior session (qlts_test
cleanup races — see memory ``reference_test_db_schema_source``).

Username remains ``TestUsers.ADMIN["username"]`` (login + RBAC
contracts depend on it) — uniquify-per-test was not a viable fix.

## Verified locally

- ``test_officer_template_finance_scope`` PASS (0.63s, isolation)
- ``TestClaimUnclaimWorkflow`` (8 tests) PASS 74.96s incl.
  ``test_admin_can_unclaim_anyone``
- Confirmed deferred failures are pre-existing on clean ``main``
  (stash + checkout + rerun)

## Still deferred (separate trackers)

This PR is **partial cleanup**, not full sweep clean:

- ``tests/api/test_admin_users.py`` — 4 cases failing with
  ``Password hash leaked in response`` (router/serializer issue, not
  fixture). Confirmed pre-existing on ``main``.
- ``test_admission_workflow_e2e.py::TestPhase3Finance`` — 4 deadlocks
  in ``test_step12``/``test_step13``/``test_step14`` +
  ``TestMakerCheckerSeparation::test_accountant_cannot_self_verify``.
  Root cause is fixture chain session sharing; needs 2-4h refactor.

Both groups remain documented in memory
``project_test_debt_admission_workflow_e2e`` for the next test-debt
sweep.

## Test plan

- [ ] CI green
- [ ] ``docker compose exec backend python -m pytest tests/integration/test_admission_workflow_e2e.py::TestDiamondInheritancePermissions tests/integration/test_admission_state_transitions.py::TestClaimUnclaimWorkflow -v``

🤖 Generated with [Claude Code](https://claude.com/claude-code)