### PR TITLE
chore(scripts): fe-check wrapper to isolate frontend type-check / vitest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,13 +181,24 @@ docker compose logs celery-worker -f --tail=50
 
 ### Frontend
 
+**Use `scripts/fe-check.sh` (or `scripts\fe-check.cmd` on Windows)** for
+type-check / test / lint / build. The wrapper runs each command in a
+throw-away `docker compose run --rm --no-deps frontend ...` container
+so it cannot OOM-kill the live Next.js dev server (running `tsc` /
+`vitest` via `exec` has crashed PID 1 in the dev container, producing
+`err_empty_response` in the browser).
+
 ```bash
-docker compose exec frontend npm run test            # Vitest
-docker compose exec frontend npm run test:coverage    # Coverage
-docker compose exec frontend npm run type-check       # TypeScript
-docker compose exec frontend npm run lint             # ESLint
-docker compose exec frontend npm run build            # Production build
+./scripts/fe-check.sh type-check    # TypeScript (preferred)
+./scripts/fe-check.sh test          # Vitest
+./scripts/fe-check.sh test:coverage # Coverage
+./scripts/fe-check.sh lint          # ESLint
+./scripts/fe-check.sh build         # Production build
 ```
+
+Avoid `docker compose exec frontend npm run type-check` (and `test`,
+`build`) on a live dev container. `exec` is fine for one-off, low-RAM
+commands such as `npm install <pkg>`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,13 +181,24 @@ docker compose logs celery-worker -f --tail=50
 
 ### Frontend
 
+**Use `scripts/fe-check.sh` (or `scripts\fe-check.cmd` on Windows)** for
+type-check / test / lint / build. The wrapper runs each command in a
+throw-away `docker compose run --rm --no-deps frontend ...` container
+so it cannot OOM-kill the live Next.js dev server (running `tsc` /
+`vitest` via `exec` has crashed PID 1 in the dev container, producing
+`err_empty_response` in the browser).
+
 ```bash
-docker compose exec frontend npm run test            # Vitest
-docker compose exec frontend npm run test:coverage    # Coverage
-docker compose exec frontend npm run type-check       # TypeScript
-docker compose exec frontend npm run lint             # ESLint
-docker compose exec frontend npm run build            # Production build
+./scripts/fe-check.sh type-check    # TypeScript (preferred)
+./scripts/fe-check.sh test          # Vitest
+./scripts/fe-check.sh test:coverage # Coverage
+./scripts/fe-check.sh lint          # ESLint
+./scripts/fe-check.sh build         # Production build
 ```
+
+Avoid `docker compose exec frontend npm run type-check` (and `test`,
+`build`) on a live dev container. `exec` is fine for one-off, low-RAM
+commands such as `npm install <pkg>`.
 
 ---
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -78,16 +78,34 @@ const score = data.score; // Zod will fail if missing
 
 ## Common Commands (Docker)
 
-All commands run inside the frontend container via `docker compose exec`.
+For type-check / test / lint / build, **prefer the wrapper**
+`scripts/fe-check.sh` (Unix) or `scripts\fe-check.cmd` (Windows). The
+wrapper runs each command in a throw-away `docker compose run --rm
+--no-deps frontend ...` container so it cannot OOM-kill the live
+Next.js dev server. Running `tsc` or `vitest` via `docker compose
+exec` against the live container has crashed PID 1 (Next.js) in the
+past, producing `err_empty_response` in the browser.
+
+> **Run from the repository root.** The wrapper path is
+> `scripts/fe-check.sh` relative to repo root, and `docker compose`
+> needs `docker-compose.yml` in the working directory. If you are
+> currently inside `frontend/`, `cd ..` first (or use the absolute
+> path `bash D:/QLTS/scripts/fe-check.sh`).
+
+```bash
+# from repo root (e.g. D:/QLTS or ~/QLTS)
+./scripts/fe-check.sh type-check          # TypeScript
+./scripts/fe-check.sh test                # Vitest
+./scripts/fe-check.sh test:coverage       # Coverage
+./scripts/fe-check.sh lint                # ESLint
+./scripts/fe-check.sh lint:fix            # ESLint auto-fix
+./scripts/fe-check.sh build               # Production build
+```
+
+`docker compose exec` is still fine for low-RAM, in-container actions:
 
 ```bash
 docker compose exec frontend npm run dev             # Dev server (auto-started by override)
-docker compose exec frontend npm run build            # Production build
-docker compose exec frontend npm run type-check       # TypeScript checking
-docker compose exec frontend npm run lint             # ESLint check
-docker compose exec frontend npm run lint:fix         # ESLint auto-fix
-docker compose exec frontend npm run test             # Vitest
-docker compose exec frontend npm run test:coverage    # Coverage report
-docker compose exec frontend npm install [package]    # Install package
+docker compose exec frontend npm install [package]   # Install package
 ```
 

--- a/scripts/fe-check.cmd
+++ b/scripts/fe-check.cmd
@@ -1,0 +1,26 @@
+@echo off
+REM Run frontend npm scripts (type-check, test, lint, build) in an
+REM isolated, throw-away container instead of `docker compose exec`.
+REM
+REM Why: `exec` shares the dev container's cgroup with the live Next.js
+REM dev server. Running tsc / vitest / eslint there has OOM-killed PID 1
+REM (Next.js) and produced err_empty_response in browser sessions.
+REM `run --rm --no-deps` spawns a fresh container, isolated memory, and
+REM auto-removes on exit.
+REM
+REM Usage:
+REM   scripts\fe-check.cmd type-check
+REM   scripts\fe-check.cmd test
+REM   scripts\fe-check.cmd test:coverage
+REM   scripts\fe-check.cmd lint
+REM   scripts\fe-check.cmd build
+REM
+REM Anything passed after the script name goes to `npm run <args...>`.
+
+if "%~1"=="" (
+  echo Usage: %~n0 ^<npm-script^> [args...]
+  echo Example: %~n0 type-check
+  exit /b 64
+)
+
+docker compose run --rm --no-deps frontend npm run %*

--- a/scripts/fe-check.sh
+++ b/scripts/fe-check.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Run frontend npm scripts (type-check, test, lint, build) in an
+# isolated, throw-away container instead of `docker compose exec`.
+#
+# Why: `exec` shares the dev container's cgroup with the live Next.js
+# dev server. Running tsc / vitest / eslint there has OOM-killed PID 1
+# (Next.js) and produced `err_empty_response` in browser sessions.
+# `run --rm --no-deps` spawns a fresh container, isolated memory, and
+# auto-removes on exit.
+#
+# Usage:
+#   scripts/fe-check.sh type-check
+#   scripts/fe-check.sh test
+#   scripts/fe-check.sh test:coverage
+#   scripts/fe-check.sh lint
+#   scripts/fe-check.sh build
+#
+# Anything passed after the script name goes to `npm run <args...>`.
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $(basename "$0") <npm-script> [args...]" >&2
+  echo "Example: $(basename "$0") type-check" >&2
+  exit 64
+fi
+
+exec docker compose run --rm --no-deps frontend npm run "$@"


### PR DESCRIPTION
## Summary

Add ``scripts/fe-check.{sh,cmd}`` so contributors run frontend
type-check / test / lint / build in a throw-away ``docker compose run
--rm --no-deps frontend`` container instead of ``docker compose exec``
against the live dev server.

**Why:** Running ``tsc`` or ``vitest`` via ``exec`` has OOM-killed PID 1
(Next.js) in the dev container, producing ``err_empty_response`` in
the browser. ``run --rm --no-deps`` spawns a fresh container with its
own cgroup, so a memory-heavy compile cannot reach the live process.
Memory ``feedback_type_check_container_isolation`` documents the
recovery path.

## What changed

- ``scripts/fe-check.sh`` (mode ``100755``) — Unix wrapper
- ``scripts/fe-check.cmd`` — Windows wrapper
- ``CLAUDE.md`` (root) — point ``Frontend`` block at the wrapper
- ``AGENTS.md`` (root) — same, for Codex / OpenAI agents
- ``frontend/CLAUDE.md`` — point block at the wrapper + add explicit
  "Run from repo root" callout (the script path and ``docker compose``
  both need repo root as cwd)

``docker compose exec`` remains the documented path for low-RAM,
in-container actions (``npm install``, dev server).

## Verified locally

- ``./scripts/fe-check.sh type-check`` → ``tsc`` clean exit, fresh
  container spun + auto-removed
- live ``frontend`` container stayed ``Up (healthy)``, HTTP 3000 still
  served the login redirect after the wrapper run
- ``git ls-tree HEAD scripts/fe-check.sh`` → ``100755`` (executable
  bit set in the index, confirmed after ``git update-index --chmod=+x``)

## Test plan

- [ ] CI green (no behavioral change to source — docs + scripts only)
- [ ] On a fresh checkout (Linux/WSL/macOS): ``./scripts/fe-check.sh
  type-check`` runs without ``Permission denied``

🤖 Generated with [Claude Code](https://claude.com/claude-code)