### PR TITLE
chore(metrics): admission_quota_skip_total counter for missing-offering skip paths

### DIFF
--- a/Backend_FastAPI/app/admission_metrics.py
+++ b/Backend_FastAPI/app/admission_metrics.py
@@ -1,0 +1,20 @@
+# app/admission_metrics.py
+"""Prometheus metrics for admission workflows.
+
+Mirrors the per-domain pattern established in ``socket_metrics.py``.
+Exposed on ``GET /metrics`` (see ``app/main.py``).
+"""
+from prometheus_client import Counter
+
+# Quota enforcement skip counter — fires when ``_check_quota_for_offering``
+# bails out before counting seats. Read these labels alongside ADM-026
+# audit logs to spot data drift (e.g. a wave of profiles whose lead has
+# no offering_id, which would silently bypass the cap).
+#
+# Reasons currently emitted:
+#   * missing_offering_id  — profile.lead.offering_id IS NULL
+admission_quota_skip_total = Counter(
+    "admission_quota_skip_total",
+    "Admission quota enforcement skipped (count by reason)",
+    ["reason"],
+)

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -37,6 +37,7 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.orm.attributes import flag_modified
 
 from .. import models
+from ..admission_metrics import admission_quota_skip_total
 from ..core.events import SystemEvents
 from ..core.admission_correction_constants import (
     SAFE_MINOR_CORRECTION_FIELDS,
@@ -457,13 +458,41 @@ async def _assert_quota_or_bypass(
     # different model later (e.g. force schema to ge=1, or rename "0" to
     # "frozen with admin override"), update both schema and this gate
     # together.
-    if academic_info is None or quota is None:
+    # Disambiguate the two skip flavours so observability can tell them
+    # apart. ``_resolve_quota_context`` returns ``(None, None)`` for
+    # legacy profiles where neither ``applied_rules.academic_info_id``
+    # nor ``lead.offering_id`` is available — that is the SAME data-drift
+    # signal as a post-snapshot lead with offering_id stripped (handled
+    # below), so both branches tick ``missing_offering_id``. Only the
+    # ``quota IS NULL`` (unlimited) flavour stays at debug + no metric.
+    if academic_info is None:
+        lead_missing_offering = (
+            not profile.lead
+            or getattr(profile.lead, "offering_id", None) is None
+        )
+        if lead_missing_offering:
+            admission_quota_skip_total.labels(
+                reason="missing_offering_id"
+            ).inc()
+            log.warning(
+                "Quota check skipped: legacy profile + missing lead.offering_id",
+                profile_id=profile.id,
+                transition=transition,
+            )
+        else:
+            log.debug(
+                "Quota check skipped: academic_info row not found",
+                profile_id=profile.id,
+                transition=transition,
+            )
+        return
+
+    if quota is None:
         log.debug(
-            "Quota check skipped (unconfigured / unlimited)",
+            "Quota check skipped (unlimited)",
             profile_id=profile.id,
             transition=transition,
-            academic_info_id=getattr(academic_info, "id", None),
-            quota=quota,
+            academic_info_id=academic_info.id,
         )
         return
 
@@ -471,7 +500,10 @@ async def _assert_quota_or_bypass(
     # finalize on an already-approved profile doesn't double-count.
     offering_id = profile.lead.offering_id if profile.lead else None
     if offering_id is None:
-        # Cannot count without offering scope. Skip enforcement for safety.
+        # Snapshot resolved an academic_info row but ``lead.offering_id``
+        # was stripped post-snapshot. Same data-drift signal as the
+        # legacy branch above — count under the same reason.
+        admission_quota_skip_total.labels(reason="missing_offering_id").inc()
         log.warning(
             "Quota check skipped: profile has no lead.offering_id",
             profile_id=profile.id,

--- a/Backend_FastAPI/tests/services/test_admission_quota.py
+++ b/Backend_FastAPI/tests/services/test_admission_quota.py
@@ -399,6 +399,142 @@ class TestQuotaHelper:
                     transition="approve",
                 )
 
+    async def test_quota_skipped_when_offering_id_missing_increments_metric(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """``lead.offering_id IS NULL`` → quota check skipped + counter
+        ``admission_quota_skip_total{reason="missing_offering_id"}`` ticks.
+
+        ADM-026 follow-up (Lane C observability nit): the skip path is
+        a data-drift signal, not normal operation, so dashboards need
+        to count it.
+        """
+        from app.admission_metrics import admission_quota_skip_total
+
+        seeds = await _seed_offering_with_quota(
+            quota=2,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="missoff",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="missoff_mgr"
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000080", status="submitted"
+        )
+
+        # Force the skip path: clear offering_id on the seeded lead.
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                profile.lead.offering_id = None
+
+        before = (
+            admission_quota_skip_total
+            .labels(reason="missing_offering_id")
+            ._value.get()
+        )
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                # No raise expected — skip path returns early.
+                await admission_service._assert_quota_or_bypass(
+                    session,
+                    profile,
+                    manager,
+                    bypass_quota=False,
+                    bypass_reason=None,
+                    transition="approve",
+                )
+
+        after = (
+            admission_quota_skip_total
+            .labels(reason="missing_offering_id")
+            ._value.get()
+        )
+        assert after == before + 1, (
+            f"Counter did not tick on offering_id skip: {before} → {after}"
+        )
+
+    async def test_quota_skipped_when_legacy_profile_has_no_resolution_path_increments_metric(
+        self, setup_test_database, seed_lead_dependencies
+    ):
+        """Legacy profile (no ``applied_rules.academic_info_id``) + lead
+        without ``offering_id`` → ``_resolve_quota_context`` returns
+        ``(None, None)`` and ``_assert_quota_or_bypass`` returns early
+        WITHOUT counting seats. Counter must still tick under
+        ``missing_offering_id`` because this is the same data-drift
+        signal as the post-snapshot strip path.
+        """
+        from app.admission_metrics import admission_quota_skip_total
+
+        seeds = await _seed_offering_with_quota(
+            quota=2,
+            seed_unit_id=seed_lead_dependencies["unit_id"],
+            seed_major_program_id=seed_lead_dependencies["major_program_id"],
+            suffix="legacy",
+        )
+        manager = await _make_user(
+            role=UserRole.MANAGER, unit_id=seeds["unit_id"], suffix="legacy_mgr"
+        )
+        pid = await _seed_lead_and_profile(
+            seeds=seeds, citizen_id="200000000090", status="submitted"
+        )
+
+        # Force the legacy resolver path: drop the snapshot key AND
+        # clear lead.offering_id so the fallback at line ~349 also
+        # returns (None, None).
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                rules = dict(profile.applied_rules or {})
+                rules.pop("academic_info_id", None)
+                profile.applied_rules = rules
+                profile.lead.offering_id = None
+                from sqlalchemy.orm.attributes import flag_modified
+                flag_modified(profile, "applied_rules")
+
+        before = (
+            admission_quota_skip_total
+            .labels(reason="missing_offering_id")
+            ._value.get()
+        )
+
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                profile = await _profile_with_lead(session, pid)
+                # Sanity: resolver must return (None, None) for this
+                # profile shape — otherwise the test isn't exercising
+                # the legacy path.
+                ai, q = await admission_service._resolve_quota_context(
+                    session, profile, lock=False
+                )
+                assert ai is None and q is None, (
+                    f"Expected legacy resolver miss, got ({ai}, {q})"
+                )
+
+                # No raise expected — skip path returns early.
+                await admission_service._assert_quota_or_bypass(
+                    session,
+                    profile,
+                    manager,
+                    bypass_quota=False,
+                    bypass_reason=None,
+                    transition="approve",
+                )
+
+        after = (
+            admission_quota_skip_total
+            .labels(reason="missing_offering_id")
+            ._value.get()
+        )
+        assert after == before + 1, (
+            "Counter did not tick on legacy quota-context miss: "
+            f"{before} → {after}"
+        )
+
     async def test_withdrawn_does_not_count(
         self, setup_test_database, seed_lead_dependencies
     ):


### PR DESCRIPTION
## Summary

ADM-026 (PR #161) introduced ``_check_quota_for_offering`` with two
flavours of silent skip whose root cause is the same data-drift signal
("we cannot scope the cap to an offering"):

1. **Legacy resolver miss** — ``_resolve_quota_context`` returns
   ``(None, None)`` when the profile has no
   ``applied_rules.academic_info_id`` AND ``lead.offering_id`` is
   ``None`` (line ~349 fallback). Pre-fix this collapsed into the
   "unconfigured / unlimited" debug log alongside the
   ``quota IS NULL`` branch — undistinguishable on dashboards.
2. **Post-snapshot strip** — snapshot resolves an academic_info row but
   ``profile.lead.offering_id`` was cleared after profile creation
   (e.g. lead reassignment).

Both are anomalies, not normal operation. Add Prometheus counter
``admission_quota_skip_total{reason="missing_offering_id"}`` and tick
in BOTH branches so dashboards / alerts fire on either flavour.

## What changed

- ``app/admission_metrics.py`` (new) — Counter, mirrors the per-domain
  pattern in ``app/socket_metrics.py``
- ``app/services/admission_service.py``:
  - Split ``if academic_info is None or quota is None`` into two
    branches with distinct semantics
  - ``academic_info is None`` + lead missing offering_id → tick
    counter + WARN log
  - ``academic_info is None`` + lead has offering_id (academic_info
    row truly missing) → DEBUG only, no metric
  - ``quota is None`` (true unlimited/unconfigured) → DEBUG only, no
    metric (unchanged behaviour)
  - Post-snapshot strip branch keeps existing tick + WARN
- ``tests/services/test_admission_quota.py``:
  - ``test_quota_skipped_when_offering_id_missing_increments_metric``
    (post-snapshot strip)
  - ``test_quota_skipped_when_legacy_profile_has_no_resolution_path_increments_metric``
    (legacy resolver miss) — explicitly asserts
    ``_resolve_quota_context`` returns ``(None, None)`` so the test
    won't drift onto another path silently

## Behaviour preserved

- Skip path still returns early without enforcement (no rule change)
- Counter ticks BEFORE the warn log so the metric reflects every skip
  even if logging is filtered
- ``quota IS NULL`` path stays at ``debug`` and does NOT increment
- Counter exposed automatically on existing ``GET /metrics`` endpoint
  (``app/main.py``)

## Verified locally

- ``from app.admission_metrics import admission_quota_skip_total``
  → counter registered (HELP/TYPE present in ``generate_latest()``)
- 2 new metric tests PASS in 6.73s
- Full ``tests/services/test_admission_quota.py`` (26 tests) PASS in
  41.22s — was 24 baseline, +2 metric tests
- Live ``GET http://localhost:8000/metrics`` after backend restart
  exposes ``admission_quota_skip_total`` HELP/TYPE lines

## Test plan

- [ ] CI green
- [ ] ``docker compose exec backend python -m pytest tests/services/test_admission_quota.py -v``
- [ ] Optional post-deploy: scrape prod ``/metrics`` to confirm
  ``admission_quota_skip_total`` is exposed (counter starts at 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)