### PR TITLE
feat(admissions): ADM-024 — flip allow_unverified_submission=false on all paths (PR #6 strict default)

### DIFF
--- a/Backend_FastAPI/alembic/versions/admstrict01_pr6_flip_paths_to_strict.py
+++ b/Backend_FastAPI/alembic/versions/admstrict01_pr6_flip_paths_to_strict.py
@@ -1,0 +1,79 @@
+"""ADM-024: flip allow_unverified_submission=false on all admission_path rows
+
+Revision ID: admstrict01
+Revises: mlharden01
+Create Date: 2026-04-30
+
+Realises PR #6's strict-mode default. Before this migration every
+``admission_path`` row carried ``allow_unverified_submission = true``
+(legacy compatibility set by ``aa1i2j3k4l5m``); the strict gate was
+opt-in per path and never flipped on prod.
+
+Pre-migration prod state (audit 2026-04-29 — see
+``Documents/ADM-024_AUDIT_2026-04-29.md``):
+
+- 52 ``admission_path`` rows, all ``allow_unverified_submission = true``
+- 4 paths in active use (ids 106, 109, 112, 115); 48 zero-traffic
+- 9 ``admission_profile`` rows, all ``applied_rules.schema_version = 1``
+- 0 docs verified, 0 docs paper-submitted across 54 ``profile_document``
+- All 9 in-flight profiles are officer-entered (no applicant
+  self-service traffic on prod yet)
+
+Decision (Q15a, 2026-04-30): flip every path to strict. Officer team
+handles verification training as normal ops; current profiles are
+officer-entered so workflow context already exists.
+
+Safety
+------
+The DB trigger ``enforce_applied_rules_immutability`` keeps every
+in-flight profile's snapshot intact. Submit-time validation reads
+``applied_rules.allow_unverified_submission`` from the snapshot, not
+from the path — so the 9 existing profiles continue to use legacy
+behaviour and remain submittable with ``uploaded`` docs. Only profiles
+*created after* this migration snapshot ``false`` (via
+``create_profile``) and require ``verified``/``paper_submitted`` docs.
+
+Idempotent
+----------
+Strict predicate ``WHERE allow_unverified_submission = TRUE`` makes
+this safe to re-run on a database where some or all rows are already
+flipped; matched rows = 0 on a re-run.
+
+Downgrade caveat
+----------------
+``downgrade()`` flips path rows back to ``true`` but does NOT rewrite
+profile snapshots. Profiles created during the strict window keep
+``applied_rules.allow_unverified_submission = false`` (immutable
+trigger) and continue to require verified docs even after downgrade.
+This matches the snapshot contract — historical profiles are bound
+to the rules that were in effect when they were created.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "admstrict01"
+down_revision: Union[str, None] = "mlharden01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE admission_path
+        SET allow_unverified_submission = FALSE
+        WHERE allow_unverified_submission = TRUE
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE admission_path
+        SET allow_unverified_submission = TRUE
+        WHERE allow_unverified_submission = FALSE
+        """
+    )

--- a/Backend_FastAPI/tests/api/test_adm_024_strict_default_migration.py
+++ b/Backend_FastAPI/tests/api/test_adm_024_strict_default_migration.py
@@ -1,0 +1,433 @@
+"""ADM-024: validate the path-level strict-default migration.
+
+The migration ``admstrict01_pr6_flip_paths_to_strict.py`` flips
+``allow_unverified_submission`` from TRUE to FALSE on every existing
+``admission_path`` row, realising PR #6's strict default. This test
+file pins three behaviours that matter post-deploy:
+
+1. The migration's UPDATE flips legacy rows but leaves
+   already-strict rows alone (idempotent / non-destructive).
+2. In-flight profiles created before the migration retain their
+   snapshotted ``allow_unverified_submission = true`` and continue
+   to submit with uploaded-only docs (snapshot immutability).
+3. New profiles created on a flipped path snapshot
+   ``allow_unverified_submission = false``; submit blocks on
+   uploaded-only docs and unblocks once docs are verified.
+
+Test DB note
+------------
+Per memory ``reference_test_db_schema_source``, the test DB uses
+``Base.metadata.create_all()`` rather than alembic. We don't invoke
+alembic from pytest — we execute the migration's SQL directly via
+``MIGRATION_UPGRADE_SQL`` (kept in sync by hand). If the migration's
+SQL ever changes, update both files together.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app import models
+from app.database import AsyncSessionLocal
+from tests.fixtures.constants import AuthURLs, LeadsURLs
+
+
+ADMISSIONS = "/api/admissions"
+
+# Mirror of admstrict01_pr6_flip_paths_to_strict.upgrade(). Kept inline
+# so tests don't import the alembic module (which expects op.execute
+# context). If the migration SQL changes, update this string too.
+MIGRATION_UPGRADE_SQL = """
+    UPDATE admission_path
+    SET allow_unverified_submission = FALSE
+    WHERE allow_unverified_submission = TRUE
+"""
+
+
+async def _login(client: AsyncClient, username: str, password: str) -> dict:
+    r = await client.post(AuthURLs.LOGIN, data={"username": username, "password": password})
+    assert r.status_code == 200, f"Login {username}: {r.text}"
+    return {"Authorization": f"Bearer {r.cookies.get('access_token')}"}
+
+
+async def _seed_path(session, *, allow_unverified: bool, mpid: int, ts_suffix: str) -> dict:
+    """Seed a self-contained admission path with one mandatory document.
+
+    Returns the ids/codes the test needs to drive the API. Mirrors the
+    minimal scaffolding from ``test_admission_submit_requires_verified_docs``
+    so tests stay self-contained.
+    """
+    ot = models.ConfigOfferingType(code=f"tq_{ts_suffix}", name=f"TQ_{ts_suffix}", display_order=1)
+    session.add(ot)
+    await session.flush()
+    dt = models.ConfigDocumentType(code=f"tcc_{ts_suffix}", name=f"TCC_{ts_suffix}", display_order=1)
+    session.add(dt)
+    await session.flush()
+    po = models.ProgramOffering(
+        offering_type=f"TQ_{ts_suffix}",
+        program_id=mpid,
+        offering_type_id=ot.id,
+        is_active=True,
+        duration_semesters=6,
+    )
+    session.add(po)
+    await session.flush()
+    ai = models.OfferingAcademicInfo(
+        offering_id=po.id,
+        academic_year=2026,
+        tuition_fee_per_year=5000000,
+        annual_admission_quota=100,
+        is_published=True,
+    )
+    session.add(ai)
+    await session.flush()
+    am = models.AdmissionMethod(
+        code=f"hb_{ts_suffix}",
+        name=f"HB_{ts_suffix}",
+        requires_gpa=True,
+        requires_subject_scores=False,
+        is_active=True,
+    )
+    session.add(am)
+    await session.flush()
+    ac = models.AdmissionCriteria(
+        method_id=am.id,
+        code=f"TC_{ts_suffix}",
+        name=f"TC_{ts_suffix}",
+        min_gpa=0.0,
+        scoring_method="average",
+        subject_selection_mode="fixed",
+        policy_version="2026.1",
+        is_active=True,
+    )
+    session.add(ac)
+    await session.flush()
+    ap = models.AdmissionPath(
+        academic_info_id=ai.id,
+        admission_method_id=am.id,
+        criteria_id=ac.id,
+        status="active",
+        display_name=f"ADM024 {ts_suffix}",
+        display_order=0,
+        visibility="public",
+        allow_unverified_submission=allow_unverified,
+    )
+    session.add(ap)
+    await session.flush()
+    dg = models.DocumentGroup(
+        offering_type_id=ot.id,
+        admission_method_id=am.id,
+        code=f"dg_{ts_suffix}",
+        name=f"DG_{ts_suffix}",
+        is_active=True,
+    )
+    session.add(dg)
+    await session.flush()
+    dgi = models.DocumentGroupItem(
+        group_id=dg.id,
+        document_type_id=dt.id,
+        is_mandatory=True,
+        requires_upload=True,
+        submission_format="photo",
+        display_order=1,
+    )
+    session.add(dgi)
+    await session.flush()
+    return {
+        "offering_id": po.id,
+        "method_id": am.id,
+        "path_id": ap.id,
+        "doc_code": dt.code,
+    }
+
+
+@pytest_asyncio.fixture
+async def adm024_paths(seed_lead_dependencies: dict):
+    """Seed three paths simulating prod-like legacy state.
+
+    - Two paths with allow_unverified_submission=TRUE (legacy default)
+    - One path with allow_unverified_submission=FALSE (already strict)
+
+    Lets us assert the migration only touches legacy rows.
+    """
+    mpid = seed_lead_dependencies["major_program_id"]
+    ts = f"{int(datetime.now().timestamp() * 1000)}"
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            legacy_a = await _seed_path(s, allow_unverified=True, mpid=mpid, ts_suffix=f"a{ts}")
+            legacy_b = await _seed_path(s, allow_unverified=True, mpid=mpid, ts_suffix=f"b{ts}")
+            already_strict = await _seed_path(s, allow_unverified=False, mpid=mpid, ts_suffix=f"c{ts}")
+    return {
+        "unit_id": seed_lead_dependencies["unit_id"],
+        "legacy_a": legacy_a,
+        "legacy_b": legacy_b,
+        "already_strict": already_strict,
+    }
+
+
+async def _create_draft(client, admin_token_headers, officer_user_in_db, cfg, *, full_name: str):
+    from tests._lead_status_test_ids import INITIAL_LEAD_STATUS_ID
+
+    phone = f"0988{int(datetime.now().timestamp() * 1000) % 10**6:06d}"
+    lead_resp = await client.post(
+        LeadsURLs.LEADS,
+        json={
+            "full_name": full_name,
+            "phone": phone,
+            "source": "website",
+            "unit_id": cfg["unit_id"],
+            "assigned_officer_id": officer_user_in_db["id"],
+            "offering_id": cfg["path"]["offering_id"],
+        },
+        headers=admin_token_headers,
+    )
+    assert lead_resp.status_code in (200, 201), f"Lead create: {lead_resp.text}"
+    lead = lead_resp.json()
+    await client.post(
+        f"{LeadsURLs.LEADS}/{lead['id']}/consultations",
+        json={"status_id": INITIAL_LEAD_STATUS_ID, "method": "phone", "notes": "Pre-admission"},
+        headers=admin_token_headers,
+    )
+    prof_resp = await client.post(
+        ADMISSIONS,
+        json={"lead_id": lead["id"], "admission_method_id": cfg["path"]["method_id"]},
+        headers=admin_token_headers,
+    )
+    assert prof_resp.status_code in (200, 201), f"Create profile: {prof_resp.text}"
+    return prof_resp.json()
+
+
+async def _officer_upload(client, oh, pid, doc_code):
+    return await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{doc_code}/upload",
+        headers=oh,
+        files={"file": (f"{doc_code}.pdf", b"%PDF-1.4\n%%EOF", "application/pdf")},
+        data={"actual_submission_format": "photo"},
+    )
+
+
+async def _fill_personal(client, oh, pid):
+    ts_cccd = f"{int(datetime.now().timestamp()) % 10**12:012d}"
+    v = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()["version"]
+    await client.put(
+        f"{ADMISSIONS}/{pid}",
+        json={
+            "version": v,
+            "citizen_id": ts_cccd,
+            "gender": "male",
+            "dob": "2001-01-01",
+            "nationality": "Viet Nam",
+            "ethnicity": "Kinh",
+            "place_of_birth": "Test",
+            "family_info": [
+                {"relationship": "Cha", "full_name": "P", "phone": "0901111111", "is_primary_guardian": True}
+            ],
+            "academic_history": [
+                {"school_name": "THPT", "year_from": 2019, "year_to": 2022, "gpa": 8.0, "graduation_type": "THPT"}
+            ],
+            "admission_scores": {"gpa": 8.0, "subject_scores": {}},
+        },
+        headers=oh,
+    )
+
+
+async def _run_migration_upgrade() -> int:
+    """Execute the migration's UPDATE statement; returns affected row count."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            result = await s.execute(text(MIGRATION_UPGRADE_SQL))
+            return result.rowcount or 0
+
+
+@pytest.mark.asyncio
+async def test_migration_flips_legacy_paths_to_strict(adm024_paths: dict):
+    """Migration flips TRUE→FALSE only; idempotent on re-run."""
+    legacy_a = adm024_paths["legacy_a"]["path_id"]
+    legacy_b = adm024_paths["legacy_b"]["path_id"]
+    already_strict = adm024_paths["already_strict"]["path_id"]
+
+    # Pre-migration sanity — paths in the expected initial state.
+    async with AsyncSessionLocal() as s:
+        rows = (await s.execute(text(
+            "SELECT id, allow_unverified_submission FROM admission_path "
+            "WHERE id IN (:a, :b, :c) ORDER BY id"
+        ), {"a": legacy_a, "b": legacy_b, "c": already_strict})).all()
+    pre = {r[0]: r[1] for r in rows}
+    assert pre[legacy_a] is True
+    assert pre[legacy_b] is True
+    assert pre[already_strict] is False
+
+    # First run flips both legacy rows. Other already-strict rows in
+    # the DB (from this and prior tests) are not asserted on — we only
+    # care that our seeded legacy rows flipped.
+    affected_first = await _run_migration_upgrade()
+    assert affected_first >= 2, (
+        f"Expected at least the 2 seeded legacy rows to flip, got {affected_first}"
+    )
+
+    async with AsyncSessionLocal() as s:
+        rows = (await s.execute(text(
+            "SELECT id, allow_unverified_submission FROM admission_path "
+            "WHERE id IN (:a, :b, :c) ORDER BY id"
+        ), {"a": legacy_a, "b": legacy_b, "c": already_strict})).all()
+    post = {r[0]: r[1] for r in rows}
+    assert post[legacy_a] is False
+    assert post[legacy_b] is False
+    assert post[already_strict] is False, "Already-strict path must remain false"
+
+    # Idempotency: second run touches zero of the rows we seeded.
+    async with AsyncSessionLocal() as s:
+        rows_after = (await s.execute(text(
+            "SELECT COUNT(*) FROM admission_path "
+            "WHERE id IN (:a, :b, :c) AND allow_unverified_submission = TRUE"
+        ), {"a": legacy_a, "b": legacy_b, "c": already_strict})).scalar()
+    assert rows_after == 0, "All seeded paths must be strict after upgrade"
+
+    # Re-run migration; predicate matches nothing among our rows.
+    await _run_migration_upgrade()
+    async with AsyncSessionLocal() as s:
+        still_strict = (await s.execute(text(
+            "SELECT COUNT(*) FROM admission_path "
+            "WHERE id IN (:a, :b, :c) AND allow_unverified_submission = FALSE"
+        ), {"a": legacy_a, "b": legacy_b, "c": already_strict})).scalar()
+    assert still_strict == 3
+
+
+@pytest.mark.asyncio
+async def test_migration_preserves_inflight_profile_snapshots(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm024_paths: dict,
+):
+    """Pre-migration profile keeps legacy snapshot; submit grandfathers."""
+    cfg = {"unit_id": adm024_paths["unit_id"], "path": adm024_paths["legacy_a"]}
+
+    # Create the profile while the path is still legacy (allow=true).
+    prof = await _create_draft(client, admin_token_headers, officer_user_in_db, cfg, full_name="ADM024 Inflight")
+    pid = prof["id"]
+
+    # Force the snapshot to schema_version=1 + allow=true to mirror what
+    # ``aa1i2j3k4l5m`` backfilled on prod. Disabling the immutability
+    # trigger if present (test DB uses metadata.create_all and may not
+    # carry the trigger from alembic history).
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            trg_exists = (await s.execute(text(
+                "SELECT 1 FROM pg_trigger "
+                "WHERE tgrelid = 'admission_profile'::regclass "
+                "  AND tgname = 'enforce_applied_rules_immutability' "
+                "  AND NOT tgisinternal"
+            ))).scalar()
+            if trg_exists:
+                await s.execute(text(
+                    "ALTER TABLE admission_profile DISABLE TRIGGER "
+                    "enforce_applied_rules_immutability"
+                ))
+            try:
+                await s.execute(text(
+                    """
+                    UPDATE admission_profile
+                    SET applied_rules =
+                        COALESCE(applied_rules, '{}'::jsonb)
+                        || jsonb_build_object(
+                            'schema_version', 1,
+                            'allow_unverified_submission', TRUE
+                        )
+                    WHERE id = :pid
+                    """
+                ), {"pid": pid})
+            finally:
+                if trg_exists:
+                    await s.execute(text(
+                        "ALTER TABLE admission_profile ENABLE TRIGGER "
+                        "enforce_applied_rules_immutability"
+                    ))
+
+    # Now run the migration.
+    await _run_migration_upgrade()
+
+    # Profile snapshot unchanged.
+    async with AsyncSessionLocal() as s:
+        row = (await s.execute(text(
+            "SELECT applied_rules->>'schema_version', "
+            "       applied_rules->>'allow_unverified_submission' "
+            "FROM admission_profile WHERE id = :pid"
+        ), {"pid": pid})).first()
+    assert row[0] == "1", f"Snapshot schema_version drifted: {row[0]}"
+    assert row[1] == "true", f"Snapshot allow_unverified drifted: {row[1]}"
+
+    # Path is now strict.
+    async with AsyncSessionLocal() as s:
+        path_flag = (await s.execute(text(
+            "SELECT allow_unverified_submission FROM admission_path WHERE id = :pid"
+        ), {"pid": adm024_paths["legacy_a"]["path_id"]})).scalar()
+    assert path_flag is False
+
+    # Legacy profile still submits with uploaded-only docs (grandfathered).
+    oh = await _login(client, officer_user_in_db["username"], officer_user_in_db["password"])
+    await _fill_personal(client, oh, pid)
+    upload = await _officer_upload(client, oh, pid, adm024_paths["legacy_a"]["doc_code"])
+    assert upload.status_code in (200, 201), upload.text
+
+    v = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()["version"]
+    resp = await client.post(f"{ADMISSIONS}/{pid}/submit", json={"version": v}, headers=oh)
+    assert resp.status_code == 200, f"Legacy snapshot must still submit: {resp.text[:300]}"
+
+
+@pytest.mark.asyncio
+async def test_new_profile_post_migration_strict_with_verify_unblocks(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    adm024_paths: dict,
+):
+    """New profile on flipped path snapshots strict; verify unblocks submit."""
+    # Run the migration first — flips legacy_b to strict.
+    await _run_migration_upgrade()
+
+    cfg = {"unit_id": adm024_paths["unit_id"], "path": adm024_paths["legacy_b"]}
+    prof = await _create_draft(client, admin_token_headers, officer_user_in_db, cfg, full_name="ADM024 PostMig")
+    pid = prof["id"]
+
+    oh = await _login(client, officer_user_in_db["username"], officer_user_in_db["password"])
+    await _fill_personal(client, oh, pid)
+
+    # Snapshot must be schema_version=2 + allow=false (post-migration default).
+    detail = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
+    applied = detail.get("applied_rules") or {}
+    assert applied.get("schema_version") == 2, f"Expected schema_version=2, got {applied.get('schema_version')}"
+    assert applied.get("allow_unverified_submission") is False, (
+        f"Post-migration profile must snapshot strict, got {applied.get('allow_unverified_submission')}"
+    )
+
+    # Uploaded-only blocks submit (status stays draft, validation_errors set).
+    upload = await _officer_upload(client, oh, pid, adm024_paths["legacy_b"]["doc_code"])
+    assert upload.status_code in (200, 201), upload.text
+    v = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()["version"]
+    blocked = await client.post(f"{ADMISSIONS}/{pid}/submit", json={"version": v}, headers=oh)
+    assert blocked.status_code == 200, blocked.text
+    assert blocked.json()["status"] == "draft", (
+        f"Strict snapshot must block submit, got status={blocked.json()['status']}"
+    )
+
+    # Bonus per Q15a chốt: marking the doc verified unblocks submit.
+    admin = await _login(client, "testadmin", "AdminPassword!123")
+    verify_resp = await client.patch(
+        f"{ADMISSIONS}/{pid}/documents/{adm024_paths['legacy_b']['doc_code']}/verify-format",
+        json={"format": "photo"},
+        headers=admin,
+    )
+    assert verify_resp.status_code == 200, verify_resp.text
+
+    oh = await _login(client, officer_user_in_db["username"], officer_user_in_db["password"])
+    v = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()["version"]
+    ok = await client.post(f"{ADMISSIONS}/{pid}/submit", json={"version": v}, headers=oh)
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["status"] == "submitted", (
+        f"Verified docs must unblock submit, got {ok.json()['status']}"
+    )

--- a/Documents/ADM-024_AUDIT_2026-04-29.md
+++ b/Documents/ADM-024_AUDIT_2026-04-29.md
@@ -1,0 +1,334 @@
+# ADM-024 — `schema_version` grandfather backfill audit (read-only)
+
+**Date**: 2026-04-29
+**Scope**: Read-only audit of prod state for ADM-024 (Wave 2 backlog).
+No code, no migration, no UI changes shipped from this audit.
+
+---
+
+## TL;DR
+
+PR #6's strict-mode (`allow_unverified_submission=false`) is **dead
+code on prod today**. All 52 paths are still in legacy mode (`true`),
+none have ever been edited via UI. Flipping all paths to `false`
+right now would break the 4 active paths (`106, 109, 112, 115`)
+because every submitted document is `uploaded` (zero `verified`).
+Need product input on the rollout strategy → **Q15** below.
+
+---
+
+## State of `admission_path` (52 rows)
+
+| Metric | Value |
+|---|---|
+| Total paths | **52** |
+| `status='active'` | 32 |
+| `status='draft'` | 20 |
+| `allow_unverified_submission='t'` | **52 (all)** |
+| `allow_unverified_submission='f'` | **0** |
+| `activated_at IS NOT NULL` | **0 (none)** |
+| `created_at == updated_at` (never edited) | **52 (all)** |
+| Created at | `2026-03-16 07:13:49+00` (single seed import) |
+
+**Implication**: every path is in the post-`aa1i2j3k4l5m` migration
+fallback bucket. The PR #6 strict gate has *never* run on prod
+traffic. No admin has touched the toggle via UI.
+
+### Path usage
+
+| Bucket | Paths |
+|---|---|
+| Has at least 1 profile | **4** — `106, 109, 112, 115` |
+| Has zero profiles | **48** |
+
+The 4 in-use paths:
+
+| ID | Status | Display name | Activated | `allow_unverified` |
+|---|---|---|---|---|
+| 106 | active | Y sỹ đa khoa 2026 – Chính quy – Học bạ | f | t |
+| 109 | active | Chăn nuôi thú y 2026 – Chính quy – Học bạ | f | t |
+| 112 | active | Điều dưỡng 2026 – Chính quy – Học bạ | f | t |
+| 115 | active | Công nghệ ô tô 2026 – Chính quy – Học bạ | f | t |
+
+---
+
+## State of `admission_profile` (9 rows)
+
+| Metric | Value |
+|---|---|
+| Total profiles | **9** |
+| `schema_version='1'` | **9 (all, backfilled by `aa1i2j3k4l5m`)** |
+| `schema_version='2'` (post-PR profile) | **0** |
+| `schema_version` missing key | **0** |
+| `applied_rules->>'allow_unverified_submission'='true'` | **9 (all)** |
+
+**Implication**: every profile created since deploy was either created
+before the migration (legacy) or carried legacy markers forward. We
+have **zero post-migration profiles** — meaning the migration's
+"new profiles get `schema_version=2`" branch is also untested in
+production.
+
+Wait, actually that needs verification — let me re-read. The
+migration backfilled profiles in `draft|submitted|rejected|
+revision_requested|resubmitted` with `{schema_version: 1,
+allow_unverified_submission: true}`. New profiles created AFTER
+deploy would use `create_profile` which snapshots
+`schema_version: 2` plus the path's current `allow_unverified`
+value (which is also `true` for every path → snapshot says `true`).
+So technically the 9 profiles below could be either:
+
+- pre-migration profiles backfilled (schema_version=1)
+- post-migration profiles created via `create_profile` after the
+  migration (schema_version=2)
+
+But the audit shows ALL 9 are `schema_version=1`, which means
+**every profile we have on prod predates `aa1i2j3k4l5m`**. We
+have not exercised `schema_version=2` snapshot logic on real
+traffic at all.
+
+### Profile breakdown by status × schema marker
+
+| `status` | `schema_version` | `allow_unverified` | Count |
+|---|---|---|---|
+| `draft` | 1 | true | 8 |
+| `submitted` | 1 | true | 1 |
+
+Created `2026-03-20` → `2026-04-23`.
+
+### Per-profile document inventory
+
+| profile_id | status | path_id | uploaded | verified | missing |
+|---|---|---|---|---|---|
+| 14 | draft | 106 | 0 | 0 | 6 |
+| 15 | draft | 115 | 5 | 0 | 1 |
+| 16 | draft | 112 | 5 | 0 | 1 |
+| 17 | draft | 115 | 4 | 0 | 2 |
+| 18 | draft | 115 | 5 | 0 | 1 |
+| 19 | draft | 115 | 5 | 0 | 1 |
+| 20 | draft | 109 | 3 | 0 | 3 |
+| **22** | **submitted** | 109 | **6** | **0** | 0 |
+| 23 | draft | 115 | 5 | 0 | 1 |
+
+**Critical observation**: profile **#22** is in `submitted` state
+with 6 uploaded docs and **0 verified**. This is exactly the case
+PR #6 strict mode was meant to block. Right now the path's legacy
+flag (`true`) lets it pass; if the path's flag had been `false`,
+profile #22 would have been rejected at `/submit`.
+
+---
+
+## State of `profile_document` (54 rows)
+
+| Status | Count |
+|---|---|
+| `uploaded` | **38** |
+| `missing` | **16** |
+| `verified` | **0** |
+| `paper_submitted` | **0** |
+
+**Zero docs have ever been verified or marked paper-submitted on
+prod.** Officers have not run the verification workflow yet (the
+8 draft profiles are still in applicant-pending state and the 1
+submitted profile has not yet hit officer review).
+
+---
+
+## Why this matters
+
+If we shipped a migration that flips
+`allow_unverified_submission=false` on every active path right now:
+
+- Profile #22 (submitted) — its applied_rules snapshot already says
+  `true` (immutable trigger blocks updates), so `_validate_documents`
+  would still allow legacy behaviour for THIS profile. **Safe.**
+- The 8 `draft` profiles — same snapshot says `true`. Submit-time
+  validator reads from the snapshot, not the path. **Safe.**
+- BUT new profiles created on those paths AFTER the flip would
+  snapshot `false` and require `verified` docs to submit. Officers
+  would need to verify each upload before applicants could submit
+  the resubmit/draft form. **Workflow change** — needs comms.
+
+The truly dangerous flavour is "flip the path AND retroactively
+rewrite snapshots" — that *would* break in-flight profiles. We are
+not proposing that.
+
+---
+
+## Q15 — Strategy options for product
+
+Pick one. Options listed lowest-blast-radius first.
+
+### Option A — **Opt-in per path, manual via admin UI** *(no migration)*
+
+- Ship: nothing. The state we have is the steady-state we want
+  pending product decision.
+- Product action: open `/admin/admission-paths/{id}/edit`, flip
+  `allow_unverified_submission` to `false` on each path when ready.
+- Pros: zero deploy risk, product owns rollout pace, in-flight
+  profiles untouched (snapshot is per-profile).
+- Cons: requires UI edit screen for `allow_unverified_submission`
+  to exist (need to verify current admin UI exposes this toggle).
+  Easy to forget paths.
+
+### Option B — **Opt-in per path, with a "default-strict" deploy switch**
+
+- Ship: small feature flag (env or settings) that flips the
+  *default* for new paths. Existing paths untouched.
+- Product action: same as A for existing paths, but new path
+  imports default to `false`.
+- Pros: catches the 48 unused paths the next time anyone imports
+  the xlsx. Existing 52 paths still need manual flip.
+- Cons: split contract — 2 sources of truth (DB column default vs
+  app-layer override).
+
+### Option C — **Opt-out per path, migration flips all to `false`** *(default)*
+
+- Ship: migration `admschemaver01` setting
+  `allow_unverified_submission=false` on every row. Existing
+  in-flight profile snapshots untouched (immutable).
+- Product action: visit each of the 4 in-use paths, decide
+  whether to keep strict (do nothing) or relax (flip back to
+  `true`). Train officers on the verify workflow.
+- Pros: makes strict mode the default — what PR #6 actually
+  intended. Forces a one-time decision per path.
+- Cons: applicants on the 4 in-use paths will need their docs
+  verified before resubmit/new profile creation. Need ops + admin
+  comms ahead of the deploy. Risk of officer queue backup if
+  they're not ready.
+
+### Option D — **Stage-gated**: default new paths strict, leave old paths alone
+
+- Ship: 2-step migration:
+  - Step 1: alter the column server_default from `false` to
+    `false` (already there) — no-op, just confirms.
+  - Step 2: never touch existing rows.
+- Product action: when an admin "creates a new path" they get
+  strict by default. Old paths stay legacy until manually flipped.
+- Pros: zero impact on current applicants. New paths get the right
+  default. Migration is a no-op.
+- Cons: today **all 52 paths are pre-migration legacy**, so this
+  is effectively "do nothing." Strict mode stays dead code on prod
+  until ops imports a new path or manually flips one.
+
+### Recommendation
+
+**Option A** if admin UI exposes the toggle (quickest, smallest
+risk, product-owned).
+
+**Option C** if product wants strict to be the safety default
+(PR #6's original intent).
+
+**Option D** is "punt" — ship nothing, document the gap, revisit
+when the next path import happens.
+
+**Option B** is the most engineering-heavy and probably not worth
+the split-contract complexity for a 52-row table.
+
+---
+
+## What we need from product (Q15) — ANSWERED 2026-04-30
+
+- [x] **Q15a → Option C**: flip every path to strict via migration.
+- [x] **Q15b → none opt back**: all 4 in-use paths (`106, 109, 112,
+  115`) flip to strict. Product reasoning: hồ sơ hiện tại đều
+  officer-nhập (có context, không phải applicant tự submit), 9
+  profiles total = blast radius nhỏ nhất sẽ có, training officer
+  team là normal ops không phải workflow shock.
+- [x] **Q15c → no extra UI work**: admin UI toggle đã exist tại
+  `frontend/src/app/(dashboard)/admin/admission-config/_components/
+  Phase3Config/PathBasicInfo.tsx:198-218`. Switch wired to
+  `useUpdateAdmissionPath`; create form already defaults to
+  strict (line 36-37, line 126 in zod schema). Path-by-path
+  exception future toggling supported out of the box.
+
+---
+
+## Decision (2026-04-30)
+
+**Option C — migration `admstrict01` flips every path to strict.**
+
+Implementation: `Backend_FastAPI/alembic/versions/admstrict01_pr6_flip_paths_to_strict.py`.
+
+Single statement, idempotent predicate:
+
+```sql
+UPDATE admission_path
+SET allow_unverified_submission = FALSE
+WHERE allow_unverified_submission = TRUE
+```
+
+### Why this is safe
+
+- Snapshot immutability (`enforce_applied_rules_immutability` trigger)
+  protects the 9 in-flight profiles. Their `applied_rules` snapshots
+  retain `allow_unverified_submission=true` and `schema_version=1`,
+  so submit-time validation continues using legacy (lax) behaviour.
+- New profiles created post-migration go through `create_profile`,
+  which snapshots the path's *current* flag. Now-strict paths produce
+  `schema_version=2` snapshots with `allow_unverified_submission=false`,
+  requiring `verified` or `paper_submitted` docs to submit.
+- Hồ sơ hiện tại đều officer-nhập → officer team có context để
+  switch sang verify workflow ngay; không cần cooldown phase.
+
+### Downgrade caveat (DO NOT skip in PR body)
+
+`downgrade()` flips path rows back to TRUE but **does NOT rewrite
+profile snapshots**. Profiles created during the strict window keep
+`applied_rules.allow_unverified_submission=false` (immutable trigger
+blocks updates by design) and continue to require verified docs even
+after rollback. This is the expected snapshot contract — historical
+profiles are bound to the rules in effect when they were created,
+not to the path's current flag.
+
+### Test coverage
+
+- `tests/api/test_adm_024_strict_default_migration.py` (new):
+  1. Migration flips legacy rows only; idempotent on re-run; already-
+     strict rows untouched.
+  2. Pre-migration profile snapshot survives migration; legacy
+     submit-with-uploaded still works.
+  3. New profile post-migration snapshots strict; uploaded-only
+     blocks submit; mark-verified unblocks (covers Q15a bonus check).
+- `tests/api/test_admission_submit_requires_verified_docs.py`
+  (existing PR #6 tests): regression coverage on strict submit gate.
+
+---
+
+## SQL ran for this audit (read-only)
+
+```sql
+-- Q1: path-level flag distribution
+SELECT allow_unverified_submission, COUNT(*) FROM admission_path GROUP BY 1;
+
+-- Q2: profile schema_version + flag combos
+SELECT applied_rules->>'schema_version', applied_rules->>'allow_unverified_submission',
+       COUNT(*)
+FROM admission_profile GROUP BY 1, 2;
+
+-- Q3: profile status × schema_version cross-tab
+SELECT status, applied_rules->>'schema_version',
+       applied_rules->>'allow_unverified_submission', COUNT(*)
+FROM admission_profile GROUP BY 1, 2, 3;
+
+-- Q4: path activation + status
+SELECT status, activated_at IS NOT NULL, COUNT(*) FROM admission_path GROUP BY 1, 2;
+
+-- Q5: paths with profiles attached
+SELECT applied_rules->>'admission_path_id', COUNT(*) FROM admission_profile
+GROUP BY 1 ORDER BY 2 DESC;
+
+-- Q6: profile timeline
+SELECT MIN(created_at)::date, MAX(created_at)::date, COUNT(*) FROM admission_profile;
+
+-- Q7: per-profile document inventory
+SELECT p.id, p.status, p.applied_rules->>'admission_path_id',
+       COUNT(d.id) FILTER (WHERE d.status='uploaded'),
+       COUNT(d.id) FILTER (WHERE d.status='verified'),
+       COUNT(d.id) FILTER (WHERE d.status='missing')
+FROM admission_profile p
+LEFT JOIN profile_document d ON d.profile_id = p.id
+GROUP BY 1, 2, 3 ORDER BY 1;
+
+-- Q8: document status distribution
+SELECT status, COUNT(*) FROM profile_document GROUP BY 1;
+```


### PR DESCRIPTION
## Summary
- ADM-024: realise PR #6 strict default by flipping every `admission_path` row from legacy `allow_unverified_submission=true` to `false`
- Per ADM-024 audit (`Documents/ADM-024_AUDIT_2026-04-29.md`), prod is in pristine state for this flip: 9 officer-entered profiles all legacy-snapshotted, 0 verified docs, 4 paths in active use (`106, 109, 112, 115`)
- Snapshot immutability (`enforce_applied_rules_immutability` trigger) protects all 9 in-flight profiles — they continue using legacy submit-with-uploaded behaviour. Only NEW profiles snapshot strict and require verified/paper_submitted docs

## Decision (Q15a → Option C)
Reasoning provided by product:
- Hồ sơ hiện tại đều officer-nhập → context có sẵn, không phải applicant tự submit
- 9 profiles total = blast radius nhỏ nhất sẽ có
- Officer training = normal ops, không phải workflow shock

Q15b: 0 paths opt back to legacy. All 4 in-use paths (106/109/112/115) flip to strict.
Q15c: admin UI toggle already shipped at `PathBasicInfo.tsx:198-218` — no FE work needed.

## Migration shape
```sql
UPDATE admission_path
SET allow_unverified_submission = FALSE
WHERE allow_unverified_submission = TRUE
```
Idempotent strict predicate. `downgrade()` flips back to TRUE with the symmetric predicate.

## Downgrade caveat (IMPORTANT — read before rolling back)
`downgrade()` flips path rows back to `true` but does **NOT** rewrite profile snapshots. Profiles created during the strict window keep `applied_rules.allow_unverified_submission=false` and continue to require verified docs even after rollback. This matches the snapshot contract — historical profiles are bound to the rules in effect when they were created, not to the path's current flag. **This is expected, not a bug.**

## Test plan
- [x] `alembic upgrade head` clean apply
- [x] `alembic downgrade -1` then `upgrade head` roundtrip clean
- [x] `alembic upgrade head` re-run is no-op (idempotent predicate)
- [x] `pytest tests/api/test_adm_024_strict_default_migration.py` — 3/3 PASS in 31s
- [x] `pytest tests/api/test_admission_submit_requires_verified_docs.py` — 3/3 PASS in 40s (regression)
- [x] `npm run type-check` clean (no FE change but sanity)
- [ ] Post-merge: deploy to prod, verify 52 paths flip; spot-check profile #22 still on legacy snapshot
- [ ] Post-deploy: ops/officer team comms — verify workflow now required for new profiles on the 4 in-use paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)