### PR TITLE
fix(utils): format_vn_date accepts plain date — unblocks 4 finance tests

### DIFF
--- a/Backend_FastAPI/app/utils/datetime_helpers.py
+++ b/Backend_FastAPI/app/utils/datetime_helpers.py
@@ -9,8 +9,8 @@ localises naive ``Consultation.scheduled_at`` with
 Used by notification payload builders when rendering into channels that
 require specific formats (e.g., Zalo ZNS DATE fields capped at 20 chars).
 """
-from datetime import datetime
-from typing import Optional
+from datetime import date, datetime
+from typing import Optional, Union
 from zoneinfo import ZoneInfo
 
 from app.config import settings
@@ -26,22 +26,38 @@ def _to_display(dt: datetime) -> datetime:
     return dt.astimezone(_VN_TZ)
 
 
-def format_vn_date(dt: Optional[datetime]) -> str:
+def format_vn_date(dt: Optional[Union[date, datetime]]) -> str:
     """Return ``DD/MM/YYYY`` (10 chars). Empty string if None.
 
-    Naive inputs treated as ``settings.TIMEZONE`` (app-local); aware
-    inputs converted to ``Asia/Ho_Chi_Minh`` for display.
+    Accepts both ``date`` and ``datetime``. ``Invoice.due_date`` and a
+    handful of other DB columns are typed ``Mapped[date]`` (no tzinfo,
+    just calendar day) — for those the timezone conversion is a no-op
+    and we format directly. ``datetime`` inputs go through
+    ``_to_display``: naive treated as ``settings.TIMEZONE``, aware
+    converted to ``Asia/Ho_Chi_Minh``.
+
+    Order of ``isinstance`` matters: ``datetime`` is a subclass of
+    ``date``, so check ``datetime`` first to avoid stripping tzinfo
+    from aware datetimes.
     """
     if dt is None:
         return ""
-    return _to_display(dt).strftime("%d/%m/%Y")
+    if isinstance(dt, datetime):
+        return _to_display(dt).strftime("%d/%m/%Y")
+    # Plain ``date``: no timezone semantics, format the calendar day
+    # as-is. Avoids the ``AttributeError: 'datetime.date' object has
+    # no attribute 'tzinfo'`` regression.
+    return dt.strftime("%d/%m/%Y")
 
 
 def format_vn_datetime(dt: Optional[datetime]) -> str:
     """Return ``DD/MM/YYYY HH:MM`` (16 chars). Empty string if None.
 
     Naive inputs treated as ``settings.TIMEZONE`` (app-local); aware
-    inputs converted to ``Asia/Ho_Chi_Minh`` for display.
+    inputs converted to ``Asia/Ho_Chi_Minh`` for display. Unlike
+    ``format_vn_date``, this requires a ``datetime`` because the
+    output renders a clock time — passing a plain ``date`` would
+    silently print ``00:00`` and hide the call-site bug.
     """
     if dt is None:
         return ""

--- a/Backend_FastAPI/tests/utils/test_datetime_helpers.py
+++ b/Backend_FastAPI/tests/utils/test_datetime_helpers.py
@@ -5,7 +5,7 @@ Semantic under test: naive datetimes are treated as app-local time (matching
 ``Asia/Ho_Chi_Minh`` (default), that means naive wall-clock is preserved
 through formatting — no unintended shift.
 """
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from zoneinfo import ZoneInfo
 
 from app.utils.datetime_helpers import format_vn_date, format_vn_datetime
@@ -33,6 +33,25 @@ class TestFormatVnDate:
     def test_length_within_zalo_date_limit(self):
         dt = datetime(2999, 12, 31, tzinfo=timezone.utc)
         assert len(format_vn_date(dt)) <= 20
+
+    def test_plain_date_input_does_not_raise(self):
+        """``Invoice.due_date`` is typed ``Mapped[date]`` — passing a
+        plain ``date`` to the formatter must not raise
+        ``AttributeError: 'datetime.date' object has no attribute
+        'tzinfo'``. Anchor for the bug surfaced by
+        TestPhase3Finance::test_step12_issue_invoice (memory:
+        ``project_test_debt_admission_workflow_e2e``).
+        """
+        d = date(2026, 4, 20)
+        assert format_vn_date(d) == "20/04/2026"
+
+    def test_plain_date_no_timezone_shift(self):
+        """A plain ``date`` carries no time-of-day, so the formatter
+        must NOT pretend it's midnight UTC and roll the date over —
+        that would silently misreport invoice due dates near midnight.
+        """
+        d = date(2026, 12, 31)
+        assert format_vn_date(d) == "31/12/2026"
 
 
 class TestFormatVnDatetime:


### PR DESCRIPTION
## Summary

Per memory ``project_test_debt_admission_workflow_e2e``, four tests
in ``test_admission_workflow_e2e.py`` (TestPhase3Finance step 12-14
+ TestMakerCheckerSeparation::test_accountant_cannot_self_verify)
fail with:

```
AttributeError: 'datetime.date' object has no attribute 'tzinfo'
File "app/utils/datetime_helpers.py", line 23, in _to_display
    if dt.tzinfo is None:
```

## Root cause

The original memory hypothesised a fixture-chain session sharing
deadlock, estimated 2-4h investigation. **Reproduction 2026-04-30
shows the AttributeError IS the bug** — not a symptom.

``Invoice.due_date`` is typed ``Mapped[date]`` in
``app/models/finance/invoice.py:130`` (calendar day, no time, no
tz). ``format_vn_date`` only handled ``datetime`` —
``invoice_service.generate_invoices_for_fee`` builds an
``InvoiceIssued`` payload calling
``format_vn_date(invoice.due_date)`` and crashes. Steps 13+14
cascade via ``self.test_step12_issue_invoice(...)`` so all three
explode at the same line.

The "deadlock" symptom in the original memory was misattributed —
single-test isolation reproduces the AttributeError reliably.

## Fix

``format_vn_date`` now branches on ``isinstance(dt, datetime)``:

- ``datetime`` (or its subclass): unchanged — naive treated as
  ``settings.TIMEZONE``, aware converted to ``Asia/Ho_Chi_Minh``
- plain ``date``: format directly as ``DD/MM/YYYY``. A calendar day
  has no time-of-day or timezone, so timezone conversion is
  meaningless for these inputs

``format_vn_datetime`` stays strict (requires ``datetime``) — a
``date`` would silently print ``00:00`` and mask call-site bugs.

Order of ``isinstance`` matters: ``datetime`` is a subclass of
``date``, so the ``datetime`` branch must come first to avoid
stripping tzinfo from aware datetimes.

## Tests

- ``tests/utils/test_datetime_helpers.py`` — 2 new anchor tests:
  - ``test_plain_date_input_does_not_raise`` — guards against
    AttributeError regression
  - ``test_plain_date_no_timezone_shift`` — pins that a calendar day
    near midnight does not silently roll over
- 12/12 datetime helper tests PASS in 0.42s

- Finance integration suite now PASSES end-to-end:
  - ``TestPhase3Finance::test_step11_accountant_calculates_fee`` ✓
  - ``TestPhase3Finance::test_step12_issue_invoice`` ✓
  - ``TestPhase3Finance::test_step13_accountant_records_payment`` ✓
  - ``TestPhase3Finance::test_step14_manager_verifies_payment`` ✓
  - ``TestMakerCheckerSeparation::test_accountant_cannot_self_verify`` ✓
- Combined regression 17/17 PASS in 47.82s

## Test plan

- [ ] CI green
- [ ] ``docker compose exec backend python -m pytest tests/utils/test_datetime_helpers.py tests/integration/test_admission_workflow_e2e.py::TestPhase3Finance tests/integration/test_admission_workflow_e2e.py::TestMakerCheckerSeparation -v``

🤖 Generated with [Claude Code](https://claude.com/claude-code)