### PR TITLE
fix(admin): scope admin user response to public fields, drop password_hash leak

### DIFF
--- a/Backend_FastAPI/app/routers/admin/users.py
+++ b/Backend_FastAPI/app/routers/admin/users.py
@@ -41,7 +41,7 @@ from fastapi import (
     UploadFile,
     status as http_status,
 )
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import EmailStr, TypeAdapter, ValidationError
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -111,7 +111,11 @@ async def log_admin_activity(
 
 
 @limiter.limit(RateLimits.ADMIN_WRITE)  # 100/hour
-@router.post("", status_code=http_status.HTTP_201_CREATED)
+@router.post(
+    "",
+    status_code=http_status.HTTP_201_CREATED,
+    response_model=schemas.UserAdminResponse,
+)
 async def create_new_user(
     request: Request,
     db: AsyncSession = Depends(database.get_db),
@@ -125,15 +129,34 @@ async def create_new_user(
     avatar: Optional[UploadFile] = File(None),
 ):
     """(Admin only) Tạo một người dùng mới, có hỗ trợ upload avatar."""
-    user_in = schemas.AdminUserCreate(
-        username=username,
-        email=email,
-        password=password,
-        confirm_password=password,
-        full_name=full_name,
-        role=role,
-        status=status,
-    )
+    # Form() bypasses FastAPI's body validation, so we construct
+    # AdminUserCreate manually. Surface pydantic field errors as the
+    # 422 contract the rest of the admin/* tests expect — without this
+    # the inline error bubbles to the generic 500 handler.
+    try:
+        user_in = schemas.AdminUserCreate(
+            username=username,
+            email=email,
+            password=password,
+            confirm_password=password,
+            full_name=full_name,
+            role=role,
+            status=status,
+        )
+    except ValidationError as exc:
+        return JSONResponse(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+            content={
+                "detail": "Validation Error",
+                "errors": [
+                    {
+                        "field": ".".join(str(loc) for loc in err.get("loc", [])),
+                        "message": err.get("msg", ""),
+                    }
+                    for err in exc.errors()
+                ],
+            },
+        )
 
     # ✅ SECURITY: Prevent privilege escalation - users can only create roles below their own
     _role_hierarchy = {
@@ -243,7 +266,7 @@ async def get_all_users(
 
 
 @limiter.limit(RateLimits.ADMIN_READ)  # 300/hour
-@router.get("/list")
+@router.get("/list", response_model=List[schemas.UserAdminResponse])
 async def list_users(
     request: Request,
     unit_id: Optional[int] = Query(None, description="Filter by organization unit ID"),
@@ -772,7 +795,7 @@ async def get_user_statistics(
 # ============================================================================
 
 @limiter.limit(RateLimits.ADMIN_READ)  # 300/hour
-@router.get("/{user_id}")
+@router.get("/{user_id}", response_model=schemas.UserAdminResponse)
 async def get_user_details(
     request: Request,
     user_id: int,
@@ -802,7 +825,7 @@ async def get_user_details(
 
 
 @limiter.limit(RateLimits.ADMIN_WRITE)  # 100/hour
-@router.put("/{user_id}")
+@router.put("/{user_id}", response_model=schemas.UserAdminResponse)
 async def update_existing_user(
     request: Request,  # Required for rate limiter (must be first)
     user_id: int,

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -243,6 +243,7 @@ from .user import (
     Token,
     TokenData,
     User,
+    UserAdminResponse,
     UserBase,
     UserCreate,
     UserInDB,

--- a/Backend_FastAPI/app/schemas/user.py
+++ b/Backend_FastAPI/app/schemas/user.py
@@ -159,7 +159,7 @@ class UserUpdate(BaseModel):
 
 class UsersPage(BaseModel):
     total_count: int
-    users: List["User"]
+    users: List["UserAdminResponse"]
 
 
 class User(UserBase):
@@ -172,6 +172,46 @@ class User(UserBase):
     availability_status: Optional[str] = None
     password_reset_required: Optional[bool] = False  # Security: True when user needs to change password
     mfa_enabled: bool = False  # MFA: Whether TOTP MFA is enabled
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserAdminResponse(UserBase):
+    """Response schema for every ``/api/admin/users`` surface.
+
+    Whitelist-only: fields not listed here are stripped during
+    serialization. The four admin endpoints used to return the raw
+    SQLAlchemy ``models.User`` without a ``response_model``, leaking
+    every column — including ``password_hash``, ``totp_secret_encrypted``,
+    ``backup_codes_hashed``, ``active_jti``, and the ``search_vector``
+    tsvector. Pinning a Pydantic schema with
+    ``ConfigDict(from_attributes=True)`` makes the leak structurally
+    impossible: any new sensitive column added to the model stays
+    invisible to the API unless someone explicitly extends this list.
+
+    Used by all four admin user surfaces — paginated list
+    (``UsersPage.users``), unpaginated list (``GET /users/list``),
+    detail (``GET /users/{id}``), and mutation responses (``POST``,
+    ``PUT``) — so the FE can rely on a single shape across them.
+    ``max_capacity`` matters for cache reconciliation in
+    ``useAdminUpdateUser``; without it the optimistic update would
+    drop the field.
+
+    Distinct from ``User`` because admin contexts surface
+    ``max_capacity`` (lead-assignment capacity), which is not
+    appropriate to leak from ``/me``, ``/profile``, ``/auth/register``,
+    or ``/auth/reset-password``.
+    """
+    id: int
+    email: str  # Override EmailStr to tolerate placeholder/legacy DB values
+    avatar_url: Optional[str] = None
+    phone_number: Optional[str] = None
+    unit_id: Optional[int] = None
+    skills: Optional[List[str]] = None
+    availability_status: Optional[str] = None
+    max_capacity: Optional[int] = None
+    password_reset_required: Optional[bool] = False
+    mfa_enabled: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/Backend_FastAPI/tests/api/test_admin_users.py
+++ b/Backend_FastAPI/tests/api/test_admin_users.py
@@ -304,12 +304,15 @@ async def test_admin_create_user_weak_password(
     for error in error_data["errors"]:
         if error.get("field") == "password":
             found_error = True
-            # Kiểm tra message lỗi validation (có thể là độ dài hoặc độ phức tạp)
-            assert "String should have at least 8 characters" in error.get(
-                "message", ""
-            ) or "Password must contain" in error.get(
-                "message", ""
-            ), f"Unexpected validation message for weak password: {error.get('message')}"
+            # Validate either the length floor (currently 12 per
+            # OWASP ASVS 5.0 — see schemas/user.py PasswordStr) or
+            # the strength rules from validate_password_strength_logic.
+            message = error.get("message", "")
+            assert (
+                "at least" in message and "characters" in message
+            ) or "Password must contain" in message, (
+                f"Unexpected validation message for weak password: {message}"
+            )
             break
     assert found_error, "Validation error for 'password' field not found"
     log.info("Weak password correctly blocked (422) with detailed error.")
@@ -934,3 +937,81 @@ async def test_admin_update_user_avatar_file_too_large(
         )  # Thường là None hoặc giá trị gốc
         assert db_user.avatar_url is None
     log.info("Database state verified: No changes were made (transaction rolled back).")
+
+
+# ===============================================================
+# === ANCHOR: SENSITIVE FIELDS NEVER LEAK FROM ADMIN USER ENDPOINTS ===
+# ===============================================================
+# These fields live on the SQLAlchemy ``User`` model but must never be
+# surfaced over the API. The ``UserAdminResponse`` whitelist in
+# ``schemas/user.py`` is the structural enforcement; this test is the
+# behavioural anchor that fires if a future change widens the whitelist
+# (or omits ``response_model`` on a new endpoint) and re-introduces the
+# leak. Non-tautological: it asserts on the actual JSON response, not
+# on the schema definition itself, so a router-level slip past the
+# schema (e.g. raw ``return user_dict``) still fails the test.
+
+_SENSITIVE_USER_FIELDS = {
+    "password_hash",
+    "totp_secret_encrypted",
+    "backup_codes_hashed",
+    "active_jti",
+    "search_vector",
+}
+
+
+def _assert_no_sensitive_fields(payload, *, where: str) -> None:
+    """Assert no sensitive keys appear in ``payload`` (dict or list of dicts)."""
+    items = payload if isinstance(payload, list) else [payload]
+    for idx, item in enumerate(items):
+        assert isinstance(item, dict), (
+            f"{where}[{idx}] expected dict, got {type(item).__name__}: {item!r}"
+        )
+        leaked = _SENSITIVE_USER_FIELDS & set(item.keys())
+        assert not leaked, (
+            f"Sensitive field(s) leaked from {where}[{idx}]: {sorted(leaked)}. "
+            f"Full keys: {sorted(item.keys())}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_admin_users_list_does_not_leak_sensitive_fields(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    admin_user_in_db: dict,
+    regular_user_in_db: dict,
+):
+    """GET /api/admin/users/list returns whitelist shape — no password_hash etc.
+
+    PR fix anchor: ``/users/list`` previously had no ``response_model``
+    and serialised raw SQLAlchemy ``User`` rows, leaking the same
+    sensitive columns the POST/GET-detail/PUT endpoints leaked. The
+    list endpoint is the third surface for the same leak class.
+    """
+    log.info("--- Running: test_admin_users_list_does_not_leak_sensitive_fields ---")
+    response = await client.get(
+        f"{AdminURLs.USERS}/list",
+        headers=admin_token_headers,
+    )
+    assert response.status_code == 200, f"List Resp: {response.text}"
+    payload = response.json()
+    assert isinstance(payload, list), f"Expected list, got {type(payload).__name__}"
+    assert len(payload) >= 2, f"Expected at least 2 users, got {len(payload)}"
+    _assert_no_sensitive_fields(payload, where="/api/admin/users/list")
+
+
+@pytest.mark.asyncio
+async def test_admin_users_paginated_list_does_not_leak_sensitive_fields(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    admin_user_in_db: dict,
+    regular_user_in_db: dict,
+):
+    """GET /api/admin/users (paginated) anchor — UsersPage.users items
+    must also pass the same whitelist."""
+    log.info("--- Running: test_admin_users_paginated_list_does_not_leak ---")
+    response = await client.get(AdminURLs.USERS, headers=admin_token_headers)
+    assert response.status_code == 200, f"Paginated Resp: {response.text}"
+    payload = response.json()
+    assert "users" in payload and isinstance(payload["users"], list)
+    _assert_no_sensitive_fields(payload["users"], where="/api/admin/users.users")


### PR DESCRIPTION
## Summary

- Add ``UserAdminResponse`` Pydantic schema (whitelist) mirroring FE
  ``User`` shape (incl. ``max_capacity`` for ``useAdminUpdateUser``
  cache reconciliation)
- Apply ``response_model=schemas.UserAdminResponse`` on
  ``POST/GET /{id}/PUT /api/admin/users[/{id}]``
- Apply ``response_model=List[schemas.UserAdminResponse]`` on
  ``GET /api/admin/users/list``
- Switch ``UsersPage.users`` from ``List[User]`` →
  ``List[UserAdminResponse]`` so 5 admin surfaces share single shape
  (paginated list previously dropped ``max_capacity``)
- Stop leaking ``password_hash``, ``totp_secret_encrypted``,
  ``backup_codes_hashed``, ``active_jti``, ``search_vector`` etc.
  on every admin user surface
- Side fix: catch inline pydantic ``ValidationError`` in the
  ``POST`` route to return 422 with the standard
  ``detail`` + ``errors[].field`` shape (the ``Form()`` route
  bypasses FastAPI body validation, originally crashed with 500 on
  weak password)

## Why a new schema instead of reusing ``User``

FE ``User`` type includes ``max_capacity`` for
``useAdminUpdateUser`` cache reconciliation; BE ``User`` schema
doesn't. Adding ``max_capacity`` to ``User`` would also surface it
on ``/me``, ``/profile``, ``/auth/register``, ``/auth/reset-password``
— not appropriate. Separate schema decouples admin from
self-service contracts.

## Anchor tests (non-tautological)

``_SENSITIVE_USER_FIELDS = {password_hash, totp_secret_encrypted,
backup_codes_hashed, active_jti, search_vector}`` — assert this set
has empty intersection with response keys for both ``/users/list``
(raw list) and ``/users`` (paginated ``UsersPage.users``). Failures
fire on actual JSON, not schema definition, so a router-level slip
past the schema (e.g. raw ``return user_dict``) still trips them.

Sensitive list is verified complete (5/5) against ``models.User``
columns — no missing field.

## Test plan

- [x] 4 originally-failing tests now PASS
- [x] 2 new anchor tests PASS
- [x] 8/8 in-scope tests PASS (incl. existing list + pagination
  tests verifying no break from ``UsersPage.users`` schema swap)
- [x] Other 9 baseline failures in ``test_admin_users.py`` are
  pre-existing (URL drift on ``/bulk-action`` vs ``/bulk``,
  ``/set-password`` vs ``/password``, mock-arg shape on avatar
  tests) — verified via ``git stash`` baseline run, not introduced
  by this PR
- [x] Rebased onto current main (``03578066`` — includes PR #170 W1
  datetime fix)

## Test plan post-merge

- [ ] CI green
- [ ] Post-deploy SSH spot-check: ``GET /api/admin/users/list`` from
  admin session does NOT contain ``password_hash`` in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)