### PR TITLE
feat(admissions): ADM-017 FE — add academic_year input to create profile form

### DIFF
--- a/frontend/src/app/(dashboard)/admissions/create/page.tsx
+++ b/frontend/src/app/(dashboard)/admissions/create/page.tsx
@@ -78,6 +78,15 @@ export default function CreateAdmissionPage() {
   
   // State for selected admission method
   const [selectedMethodId, setSelectedMethodId] = useState<number | null>(null)
+  // ADM-017: state for academic year selection. Default = current
+  // calendar year — officer can adjust if creating a profile for a
+  // different recruitment year. Backend strictly validates that the
+  // (offering_id, academic_year) ``OfferingAcademicInfo`` row exists
+  // and is published; mismatch surfaces as a 400 with a Vietnamese
+  // message that we let the mutation hook's ``handleApiError`` render.
+  const [academicYear, setAcademicYear] = useState<number>(
+    new Date().getFullYear()
+  )
   
   const { data: lead, isLoading: isLoadingLead } = useLead(
     leadId ? parseInt(leadId) : 0,
@@ -107,12 +116,15 @@ export default function CreateAdmissionPage() {
   
   const handleCreate = async () => {
     if (!leadId || !selectedMethodId) return
-    
+
     // Note: useCreateAdmission hook already handles success toast and navigation
     // Error is also handled via handleApiError() in the hook
     await createMutation.mutateAsync({
       lead_id: parseInt(leadId),
       admission_method_id: selectedMethodId,
+      // ADM-017: bind to the selected recruitment year so BE can
+      // resolve the right ``OfferingAcademicInfo`` deterministically.
+      academic_year: academicYear,
     })
   }
   
@@ -212,6 +224,36 @@ export default function CreateAdmissionPage() {
             </div>
           )}
           
+          {/* ADM-017: Academic year input — required by backend
+              ``admissionProfileCreateSchema``. Backend validates the
+              (offering_id, academic_year) ``OfferingAcademicInfo``
+              row exists + is published; mismatch surfaces as a 400
+              with a Vietnamese message. Default = current calendar
+              year (officer adjusts when creating profile for a
+              different recruitment year). */}
+          <div className="space-y-2">
+            <Label htmlFor="academic-year">
+              Năm học <span className="text-destructive">*</span>
+            </Label>
+            <input
+              id="academic-year"
+              type="number"
+              min={2000}
+              max={2100}
+              value={academicYear}
+              onChange={(e) => {
+                const v = parseInt(e.target.value, 10);
+                if (!Number.isNaN(v)) setAcademicYear(v);
+              }}
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-describedby="academic-year-hint"
+            />
+            <p id="academic-year-hint" className="text-xs text-muted-foreground">
+              Năm tuyển sinh hồ sơ thuộc về (vd. 2026). Backend xác minh
+              năm có cấu hình tuyển sinh đã công bố cho chương trình này.
+            </p>
+          </div>
+
           {/* Admission Method Selection - NEW */}
           <div className="space-y-2">
             <Label htmlFor="admission-method">

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -258,6 +258,15 @@ export type DocumentItem = z.infer<typeof documentItemSchema>
  * Create Admission Profile Schema
  * Used for POST /api/admissions
  * REFACTORED (Phase 2): Now requires admission_method_id for AdmissionPath lookup
+ *
+ * ADM-017: ``academic_year`` lets the caller bind the profile to a
+ * specific (offering, year) ``OfferingAcademicInfo`` row. Pre-fix
+ * BE picked "newest published year" implicitly — broken when an
+ * offering had multiple published years simultaneously (transition
+ * windows). BE phase merged in PR #176; this FE schema makes the
+ * field required client-side. Backend still tolerates it being
+ * omitted (legacy fallback) until the strict-required follow-up
+ * ships.
  */
 export const admissionProfileCreateSchema = z.object({
   lead_id: z
@@ -268,6 +277,11 @@ export const admissionProfileCreateSchema = z.object({
     .number()
     .int("Admission Method ID phải là số nguyên")
     .positive("Admission Method ID phải là số dương"),
+  academic_year: z
+    .number()
+    .int("Năm học phải là số nguyên")
+    .min(2000, "Năm học không hợp lệ")
+    .max(2100, "Năm học không hợp lệ"),
 })
 
 export type AdmissionProfileCreate = z.infer<


### PR DESCRIPTION
## Summary

Follow-up to PR #176 (BE phase). Adds the FE side of the ADM-017
contract: officer explicitly chooses the recruitment year when
creating a profile, instead of relying on the BE legacy fallback
("newest published year") which was implicit and broke during
multi-year transition windows.

## Changes

- ``lib/zod/admissions.ts``: ``admissionProfileCreateSchema`` now
  requires ``academic_year`` (``int``, ``min(2000), max(2100)``) —
  matches the BE Pydantic ``ge=2000, le=2100`` bounds.
- ``app/(dashboard)/admissions/create/page.tsx``:
  - ``academicYear`` state defaults to ``new Date().getFullYear()``
    (current calendar year — sensible for the typical case where
    officer creates a profile for the current recruitment cycle)
  - New "Năm học *" input field above the existing "Phương thức
    xét tuyển" dropdown
  - ``handleCreate`` forwards ``academic_year`` in the POST body

BE strictly validates the (offering_id, academic_year) row exists
+ is published; mismatch returns 400 with a Vietnamese message
which the existing ``handleApiError()`` in ``useCreateAdmission``
hook surfaces as a toast.

## Verified locally (qlts-w2 stack)

- ``./scripts/fe-check.sh type-check`` — clean
- ``./scripts/fe-check.sh lint`` — 0 errors, 206 pre-existing
  warnings (none introduced by this commit)

## Out of scope

- **Strict-required flip on BE** (drop ``Optional`` + legacy
  fallback) — separate PR after this FE deploys + warn-log shows
  zero "missing academic_year" calls.
- Dropdown sourced from offering's published academic_info history
  (instead of free-form input). Future UX enhancement; current
  free-form is acceptable because BE validates.

## Test plan

- [ ] CI green
- [ ] Post-deploy: open ``/admissions/create?lead_id=X``, verify
  "Năm học" input present + defaults to current year
- [ ] Create profile with valid year → success
- [ ] Create profile with year having no published academic_info →
  toast Vietnamese error

🤖 Generated with [Claude Code](https://claude.com/claude-code)