### PR TITLE
fix(admissions): hotfix — replace setState-in-effect with derived state on create form

### DIFF
--- a/frontend/src/app/(dashboard)/admissions/create/page.tsx
+++ b/frontend/src/app/(dashboard)/admissions/create/page.tsx
@@ -95,18 +95,15 @@ export default function CreateAdmissionPage() {
   const searchParams = useSearchParams()
   const leadId = searchParams.get("lead_id")
   
-  // ADM-017 review-fix: NO calendar-year default. The original FE
-  // PR defaulted to ``new Date().getFullYear()`` — during a year
-  // transition (vd: cuối 2026 ↔ đầu 2027 với cả 2 năm vẫn published)
-  // an officer creating a profile for a 2027 cohort could click
-  // submit without touching the field and silently bind to 2026.
-  // This recreates the original implicit-selection bug the BE
-  // phase tried to remove. Now the year is derived from the
-  // offering's active paths and either:
-  //   - auto-selected when only ONE eligible year exists, OR
-  //   - left empty (officer must pick) when multiple years exist.
-  const [academicYear, setAcademicYear] = useState<number | null>(null)
-  const [selectedMethodId, setSelectedMethodId] = useState<number | null>(null)
+  // ADM-017 review-fix: NO calendar-year default. State only holds
+  // the OFFICER'S EXPLICIT PICK; the effective ``academicYear`` /
+  // ``selectedMethodId`` rendered in the UI are *derived* below
+  // from picked-state + eligible options. This shape avoids the
+  // ``react-hooks/set-state-in-effect`` lint rule (CI-strict) that
+  // would otherwise fire on a "useEffect → setState" auto-select
+  // pattern.
+  const [pickedYear, setPickedYear] = useState<number | null>(null)
+  const [pickedMethodId, setPickedMethodId] = useState<number | null>(null)
 
   const { data: lead, isLoading: isLoadingLead } = useLead(
     leadId ? parseInt(leadId) : 0,
@@ -156,29 +153,36 @@ export default function CreateAdmissionPage() {
   }
   const eligibleYears = Array.from(pathsByYear.keys()).sort((a, b) => b - a)
 
-  // Auto-select when there's only one eligible year (saves a click;
-  // doesn't reintroduce the silent-default bug because there's no
-  // ambiguity to silence).
-  useEffect(() => {
-    if (eligibleYears.length === 1 && academicYear === null) {
-      setAcademicYear(eligibleYears[0])
-    }
-  }, [eligibleYears, academicYear])
-
-  // Reset method when year changes — a method that was valid for
-  // year A might have no path for year B.
-  useEffect(() => {
-    setSelectedMethodId(null)
-  }, [academicYear])
+  // Effective year (derived) — fall through:
+  //   1. officer's explicit pick → use it
+  //   2. exactly 1 eligible year → auto-select (no ambiguity to silence)
+  //   3. otherwise → null (officer must pick)
+  // Auto-selecting only when ``eligibleYears.length === 1`` keeps
+  // the original anti-implicit-selection guarantee from the prior
+  // review fix.
+  const academicYear: number | null =
+    pickedYear ?? (eligibleYears.length === 1 ? eligibleYears[0] : null)
 
   // Methods filtered by selected year's paths. ``useAdmissionMethods``
   // still drives display name lookup; the gate is path-membership.
-  const methodsForYear: AdmissionMethod[] = (() => {
-    if (academicYear === null) return []
-    const yearPaths = pathsByYear.get(academicYear) ?? []
-    const idsInYear = new Set(yearPaths.map((p) => p.admission_method_id))
-    return methods.filter((m) => m.is_active && idsInYear.has(m.id))
-  })()
+  const methodsForYear: AdmissionMethod[] =
+    academicYear === null
+      ? []
+      : (() => {
+          const yearPaths = pathsByYear.get(academicYear) ?? []
+          const idsInYear = new Set(yearPaths.map((p) => p.admission_method_id))
+          return methods.filter((m) => m.is_active && idsInYear.has(m.id))
+        })()
+
+  // Effective method (derived) — invalidates the picked id if the
+  // year change rendered it ineligible for that year. Replaces the
+  // prior ``useEffect(() => setSelectedMethodId(null), [academicYear])``
+  // cascade reset; same behaviour, no setState-in-effect.
+  const selectedMethodId: number | null =
+    pickedMethodId !== null &&
+    methodsForYear.some((m) => m.id === pickedMethodId)
+      ? pickedMethodId
+      : null
   
   const handleCreate = async () => {
     // Submit guard mirrors the disabled state on the button below —
@@ -318,7 +322,7 @@ export default function CreateAdmissionPage() {
               <Select
                 value={academicYear?.toString() ?? ""}
                 onValueChange={(value) =>
-                  setAcademicYear(value ? parseInt(value, 10) : null)
+                  setPickedYear(value ? parseInt(value, 10) : null)
                 }
               >
                 <SelectTrigger id="academic-year">
@@ -367,7 +371,7 @@ export default function CreateAdmissionPage() {
               <Select
                 value={selectedMethodId?.toString() ?? ""}
                 onValueChange={(value) =>
-                  setSelectedMethodId(value ? parseInt(value, 10) : null)
+                  setPickedMethodId(value ? parseInt(value, 10) : null)
                 }
               >
                 <SelectTrigger id="admission-method">


### PR DESCRIPTION
## Hotfix — main CI broken

PR #178 (ADM-017 FE path-driven dropdowns) shipped 2 ``useEffect``
blocks that call ``setState`` synchronously. The strict
``eslint-plugin-react-hooks 7.0.1`` ``set-state-in-effect`` rule
fires on this pattern. Local lint inside the pre-built
``qlts-w2`` Docker image did NOT register the rule (stale
``node_modules`` minor version mismatch); GitHub Actions runs
``npm ci`` fresh and DID register it → PR Gate failed → Deploy
skipped → **main broken on CI**.

## Fix — derived state, no ``useEffect``

State now holds only the officer's explicit pick. Effective values
are derived in the render pass — preserves all prior UX semantics
without the lint violation.

```ts
// Pick state
const [pickedYear, setPickedYear] = useState<number | null>(null)
const [pickedMethodId, setPickedMethodId] = useState<number | null>(null)

// Effective year — pick OR auto-single OR null
const academicYear =
  pickedYear ?? (eligibleYears.length === 1 ? eligibleYears[0] : null)

// Effective method — invalidate automatically if year change
// renders the picked id ineligible (replaces cascade-reset effect)
const selectedMethodId =
  pickedMethodId !== null && methodsForYear.some(m => m.id === pickedMethodId)
    ? pickedMethodId
    : null
```

## Behaviours preserved

- No calendar-year default
- Auto-select only when exactly 1 eligible year
- Method dropdown filtered by selected year's active paths
- Cascade reset of method when year changes
- Submit button disabled until both year + method chosen

## Verified locally

- ``useEffect`` in file: **1** (navigation guard only — no
  ``setState``)
- ``setState`` callsites: **2**, both in ``Select onValueChange``
  event handlers (not effects)
- ``./scripts/fe-check.sh type-check`` clean
- ``./scripts/fe-check.sh lint`` 206/0 errors (pre-existing
  warnings only)
- ``--no-cache`` lint run also clean

CI verification expected to pass — rule fires structurally on
``setX(...)`` inside ``useEffect``, which the new code path does
not contain.

## Test plan

- [ ] CI green (the gate that broke main)
- [ ] Post-merge deploy success
- [ ] Manual smoke ``/admissions/create?lead_id=X``: year dropdown
  + method dropdown still behave per PR #178 spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)