### PR TITLE
chore(ci): gate VPS deploy on production environment approval

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,6 +156,7 @@ jobs:
     name: Deploy to VPS
     needs: test
     runs-on: ubuntu-latest
+    environment: production
     if: github.ref == 'refs/heads/main'
     concurrency:
       group: deploy-production


### PR DESCRIPTION
## Summary

- Adds `environment: production` to the deploy job in `.github/workflows/deploy.yml`
- Production deploys now require manual approval via the GitHub Environment protection rule (required reviewer = `favouritekid`) configured for the repo
- Test job still runs unconditionally on every `main` push — only the SSH deploy step is gated

## Why now

Locks accidental auto-deploy during the upcoming admission full-cutover refactor window. During the window, sub-PRs land on `feat/admission-full-cutover` (not `main`), so accidents come from main-targeted PRs that should pause for review before SSH-ing to the VPS. Hotfix flow remains unchanged: hotfix → main → click "Review deployments → Approve" in Actions tab → SSH deploy runs.

## Audit

- Repo workflows: only `deploy.yml` deploys (verified via grep on `.github/workflows/`); `dependency-audit.yml` and `nightly-regression.yml` do not SSH
- VPS-side: no cron / systemd timer auto-pulls or runs `deploy.sh` (verified on `qlts.tnpc.edu.vn`)
- → Gate is end-to-end

## Test plan

- [ ] Merge this PR → main push triggers workflow
- [ ] Verify `test` job runs and passes
- [ ] Verify `deploy` job pauses with "Waiting for review" status
- [ ] Click Approve in Actions tab → SSH deploy runs and completes successfully
- [ ] Run a no-op smoke (e.g., `curl https://qlts.tnpc.edu.vn/api/health`) to confirm post-deploy state

🤖 Generated with [Claude Code](https://claude.com/claude-code)