### PR TITLE
[T0-1] feat(admission): add entrypoint cutover gates

### DIFF
--- a/Backend_FastAPI/CLAUDE.md
+++ b/Backend_FastAPI/CLAUDE.md
@@ -210,6 +210,17 @@ docker compose exec backend alembic revision --autogenerate -m "description"
 docker compose exec backend alembic upgrade head
 docker compose exec backend alembic downgrade -1
 
+# Cutover only — 2 entrypoint gates skip auto migration + auto notification sync.
+# Routine deploy: cả 2 unset (hoặc =true) → entrypoint chạy alembic upgrade head + sync_notification_rules như cũ.
+# Cold cutover: set CẢ 2 = "false" trước deploy backend image mới:
+#   RUN_MIGRATIONS_ON_STARTUP=false                   # skip alembic
+#   RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP=false      # skip notification rule sync
+# Container start chỉ load code + uvicorn ready. Manual run alembic + backfill + sync_notification_rules
+# ngoài để stream log + time tracking + checkpoint mỗi step.
+# Sau cutover: switch CẢ 2 về true (hoặc unset) cho routine deploy.
+# Defensive default: chỉ exact lowercase "false" mới skip; mọi value khác (TRUE/FALSE/typo/...) chạy như cũ.
+# Ref: Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md §3.5 + §7.2.
+
 # Start server (dev mode -- auto-configured by docker-compose.override.yml)
 docker compose up -d
 

--- a/Backend_FastAPI/docker-entrypoint.sh
+++ b/Backend_FastAPI/docker-entrypoint.sh
@@ -1,11 +1,33 @@
 #!/bin/bash
 set -e
 
-echo "=== Running Alembic migrations ==="
-alembic upgrade head
+# Cold cutover gates — default behavior preserved cho routine deploy.
+# Cả 2 flag cùng họ pattern: exact lowercase "false" mới skip; mọi value khác
+# (unset/true/TRUE/typo/...) chạy như cũ. Defensive default: typo → run, không skip.
+# Cutover scenario set CẢ 2 flag = false trước deploy backend image mới, sau đó
+# manual run alembic + backfill + sync_notification_rules ngoài container start
+# để stream log + time tracking + checkpoint mỗi step.
+# Ref: Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md §3.5 T0-1 + §7.2.
 
-echo "=== Syncing notification rules ==="
-python -m app.scripts.sync_notification_rules
+# Gate 1: Alembic migrations
+if [ "${RUN_MIGRATIONS_ON_STARTUP:-true}" != "false" ]; then
+    echo "=== Running Alembic migrations ==="
+    alembic upgrade head
+else
+    echo "=== Skipping Alembic migrations (RUN_MIGRATIONS_ON_STARTUP=false) ==="
+fi
+
+# Gate 2: Notification rules sync
+# Cutover bundle scenario: B2 ship 12 ADMISSION_* events code; M-1-19b seed DB
+# notification_rule rows. Sync script reconcile EVENT_CATALOG ↔ DB. Pre-migration
+# (RUN_MIGRATIONS_ON_STARTUP=false) → notification_rule table có thể chưa tồn tại
+# hoặc chưa seed → sync sẽ fail/race. Manual run ở T+3:30 sau migration + DB seed.
+if [ "${RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP:-true}" != "false" ]; then
+    echo "=== Syncing notification rules ==="
+    python -m app.scripts.sync_notification_rules
+else
+    echo "=== Skipping notification rules sync (RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP=false) ==="
+fi
 
 echo "=== Startup complete. Starting application ==="
 exec "$@"

--- a/Documents/ADMISSION_DAILY_LOG.md
+++ b/Documents/ADMISSION_DAILY_LOG.md
@@ -19,7 +19,12 @@ Production critical hotfix trong window refactor:
 5. **Conflict touch admission core/state/lead/notification/RBAC** → **PAUSE refactor 0.5-1 ngày**, resolve conflict clean, re-test PASS rồi mới continue.
 6. KHÔNG defer hotfix vào cutover bundle. Lý do: cutover sẽ replace toàn bộ codebase từ feat branch — nếu hotfix chỉ ở main mà chưa cherry-pick → cutover sẽ overwrite hotfix → bug production tái xuất.
 
-KHÔNG cherry-pick chỉ khi hotfix touch file mà refactor đang rewrite từ đầu (e.g., `admission_state_service.py` chưa tồn tại main, hotfix touch `admission_service.py` mà task #16 sẽ refactor toàn bộ). Trong case đó: ghi rõ trong DAILY_LOG entry "hotfix superseded by refactor — verify equivalent fix trong feat branch".
+**Equivalent-patch alternative** (khi cherry-pick không khả thi): hotfix touch file mà refactor đang rewrite từ đầu (e.g., `admission_service.py` mà task #16 sẽ refactor toàn bộ sang `admission_state_service.py`). Áp dụng equivalent-patch:
+- Verify hotfix logic đã được áp dụng tương đương trong refactor feat branch (cùng-day audit, KHÔNG defer).
+- Append DAILY_LOG entry: "hotfix equivalent-patched — main SHA → equivalent file:line trong feat branch + verification note".
+- Test cover behavior hotfix bằng test mới hoặc existing trong feat branch.
+
+KHÔNG được "defer to cutover" với bất kỳ lý do gì — cherry-pick hoặc equivalent-patch trong same-day, không có exception.
 
 ---
 
@@ -46,6 +51,53 @@ KHÔNG cherry-pick chỉ khi hotfix touch file mà refactor đang rewrite từ �
 **Notes / surprises:**
 - anything non-obvious worth remembering for post-mortem
 ```
+
+---
+
+## 2026-05-02
+
+**Merged hôm nay** (vào `feat/admission-full-cutover`):
+- _none merged yet — sub-branch `feature/admission-t0-1` pending push approval, sẽ open sub-PR sau push_
+
+**Local commits trên `feature/admission-t0-1` branch (HEAD ahead of `feat/admission-full-cutover` 2 commits):**
+
+1. **commit-docs**: `docs(admission): split T0-4 + lock hotfix same-day cherry-pick policy`
+   - C1: TRACKER Section 1 — T0-4 split → T0-4a (no-op skeleton, no dep) + T0-4b (real worker, dep B2 + M-1-19a). Section 12.3 production readiness checklist tương ứng.
+   - C2: DAILY_LOG header — hotfix policy explicit (same-day cherry-pick OR equivalent-patch mandatory; KHÔNG defer to cutover; pause 0.5-1d nếu conflict touch admission core/state/lead/notification/RBAC).
+
+2. **commit-t0-1**: `feat(admission): add 2 entrypoint env flag gates (T0-1)`
+   - `Backend_FastAPI/docker-entrypoint.sh`: 2 gate độc lập:
+     - Gate 1: `RUN_MIGRATIONS_ON_STARTUP` (default `true`) — skip `alembic upgrade head` khi `false`.
+     - Gate 2: `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP` (default `true`) — skip `sync_notification_rules` khi `false`.
+   - Default behavior preserved khi cả 2 unset (routine deploy chạy alembic + sync như cũ).
+   - Cutover scenario set CẢ 2 = `false` → container start chỉ uvicorn ready; manual run alembic + backfill + sync_notification_rules ngoài container ở T+1:30 / T+3:00 / T+3:30.
+   - `Backend_FastAPI/CLAUDE.md`: Common Commands note 2 flag cutover-only.
+   - `Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md` §3.5 + §7.2 + §9.3 update reflect 2 flag.
+   - `Documents/ADMISSION_IMPLEMENTATION_TRACKER.md`: T0-1 status TODO → CODE_DONE (local).
+
+**Tested / Rehearsed:**
+- T0-1 — `bash -n` syntax PASS. 14-case logic test PASS:
+  - 9-case matrix (3 RUN_MIGRATIONS × 3 RUN_SYNC):
+    - unset×unset / unset×true / unset×false / true×unset / true×true / true×false / false×unset / false×true / false×false → expected output match
+    - Cutover combo `false×false` → cả 2 skip ✓
+    - Default `unset×unset` → cả 2 run (current behavior preserved) ✓
+  - 5 defensive variant: TRUE / FALSE / typo / 0 / "False" capitalize → đều run (chỉ exact lowercase "false" skip) ✓
+
+**Blocked / decisions cần:**
+- Push approval cho sub-branch `feature/admission-t0-1` (2 commits: docs procedural + T0-1 code).
+
+**Tomorrow plan (sau push approval):**
+- Open sub-PR target `feat/admission-full-cutover` + link issue #181 sub-task 1.
+- Start T0-2 (`ADMISSION_FROZEN` middleware) — independent của T0-1, parallel.
+- Start T0-3 (Nginx admission block) — Ops owner, parallel.
+- Start T0-4a skeleton (no-op safe registration) — sau patch C1, đã unblock.
+- Start T0-5 (Casbin reload endpoint) — independent, parallel.
+
+**Notes:**
+- C3 patch áp dụng ngay sau khi user catch oversight: T0-1 ban đầu chỉ gate Alembic, vẫn auto chạy `sync_notification_rules` → cutover deploy backend `RUN_MIGRATIONS_ON_STARTUP=false` sẽ vẫn chạy sync rules trên empty schema → script fail/race. Add gate riêng cho sync.
+- T0-1 commit có thể bị amend (history rewrite trước push) — neutral wording dùng "commit-docs" + "commit-t0-1" thay vì raw SHA.
+- Test framework cho bash entrypoint: chỉ syntax check + logic test, không có integration framework. Manual smoke trong staging clone D12-D14 sẽ verify end-to-end (apply 2 flag, observe entrypoint output, smoke API ready).
+- Q11 closed (PLAN §3.3.g.1) → KHÔNG còn product decision blocker; D2 + D3 chỉ chặn cutover, không chặn dev start.
 
 ---
 

--- a/Documents/ADMISSION_DAILY_LOG.md
+++ b/Documents/ADMISSION_DAILY_LOG.md
@@ -56,16 +56,13 @@ KHÔNG được "defer to cutover" với bất kỳ lý do gì — cherry-pick h
 
 ## 2026-05-02
 
-**Merged hôm nay** (vào `feat/admission-full-cutover`):
-- _none merged yet — sub-branch `feature/admission-t0-1` pending push approval, sẽ open sub-PR sau push_
+**Pushed hôm nay** (origin/feature/admission-t0-1, sub-PR pending open → `feat/admission-full-cutover`):
 
-**Local commits trên `feature/admission-t0-1` branch (HEAD ahead of `feat/admission-full-cutover` 2 commits):**
-
-1. **commit-docs**: `docs(admission): split T0-4 + lock hotfix same-day cherry-pick policy`
+1. `74ed8b94` — `docs(admission): split T0-4 + lock hotfix same-day cherry-pick policy`
    - C1: TRACKER Section 1 — T0-4 split → T0-4a (no-op skeleton, no dep) + T0-4b (real worker, dep B2 + M-1-19a). Section 12.3 production readiness checklist tương ứng.
    - C2: DAILY_LOG header — hotfix policy explicit (same-day cherry-pick OR equivalent-patch mandatory; KHÔNG defer to cutover; pause 0.5-1d nếu conflict touch admission core/state/lead/notification/RBAC).
 
-2. **commit-t0-1**: `feat(admission): add 2 entrypoint env flag gates (T0-1)`
+2. `4c439a27` — `feat(admission): add 2 entrypoint env flag gates (T0-1)`
    - `Backend_FastAPI/docker-entrypoint.sh`: 2 gate độc lập:
      - Gate 1: `RUN_MIGRATIONS_ON_STARTUP` (default `true`) — skip `alembic upgrade head` khi `false`.
      - Gate 2: `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP` (default `true`) — skip `sync_notification_rules` khi `false`.
@@ -73,7 +70,7 @@ KHÔNG được "defer to cutover" với bất kỳ lý do gì — cherry-pick h
    - Cutover scenario set CẢ 2 = `false` → container start chỉ uvicorn ready; manual run alembic + backfill + sync_notification_rules ngoài container ở T+1:30 / T+3:00 / T+3:30.
    - `Backend_FastAPI/CLAUDE.md`: Common Commands note 2 flag cutover-only.
    - `Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md` §3.5 + §7.2 + §9.3 update reflect 2 flag.
-   - `Documents/ADMISSION_IMPLEMENTATION_TRACKER.md`: T0-1 status TODO → CODE_DONE (local).
+   - `Documents/ADMISSION_IMPLEMENTATION_TRACKER.md`: T0-1 status TODO → CODE_DONE (branch pushed).
 
 **Tested / Rehearsed:**
 - T0-1 — `bash -n` syntax PASS. 14-case logic test PASS:
@@ -84,9 +81,9 @@ KHÔNG được "defer to cutover" với bất kỳ lý do gì — cherry-pick h
   - 5 defensive variant: TRUE / FALSE / typo / 0 / "False" capitalize → đều run (chỉ exact lowercase "false" skip) ✓
 
 **Blocked / decisions cần:**
-- Push approval cho sub-branch `feature/admission-t0-1` (2 commits: docs procedural + T0-1 code).
+- Sub-PR creation approval (target `feat/admission-full-cutover` — solo dev self-review + merge).
 
-**Tomorrow plan (sau push approval):**
+**Tomorrow plan (sau sub-PR mở/merge):**
 - Open sub-PR target `feat/admission-full-cutover` + link issue #181 sub-task 1.
 - Start T0-2 (`ADMISSION_FROZEN` middleware) — independent của T0-1, parallel.
 - Start T0-3 (Nginx admission block) — Ops owner, parallel.
@@ -95,7 +92,7 @@ KHÔNG được "defer to cutover" với bất kỳ lý do gì — cherry-pick h
 
 **Notes:**
 - C3 patch áp dụng ngay sau khi user catch oversight: T0-1 ban đầu chỉ gate Alembic, vẫn auto chạy `sync_notification_rules` → cutover deploy backend `RUN_MIGRATIONS_ON_STARTUP=false` sẽ vẫn chạy sync rules trên empty schema → script fail/race. Add gate riêng cho sync.
-- T0-1 commit có thể bị amend (history rewrite trước push) — neutral wording dùng "commit-docs" + "commit-t0-1" thay vì raw SHA.
+- Branch đã push; KHÔNG rewrite history. Mọi cleanup setup docs sau push đi bằng commit bổ sung trên `feature/admission-t0-1`.
 - Test framework cho bash entrypoint: chỉ syntax check + logic test, không có integration framework. Manual smoke trong staging clone D12-D14 sẽ verify end-to-end (apply 2 flag, observe entrypoint output, smoke API ready).
 - Q11 closed (PLAN §3.3.g.1) → KHÔNG còn product decision blocker; D2 + D3 chỉ chặn cutover, không chặn dev start.
 
@@ -115,7 +112,7 @@ KHÔNG được "defer to cutover" với bất kỳ lý do gì — cherry-pick h
 - TRACKER section 0 reworded: D1 CLOSED, D2/D3 không chặn dev (chỉ chặn cutover/Go)
 
 **Tomorrow plan:**
-- Bắt đầu Task 0 prerequisites (T0-1..T0-5) per RUNBOOK §3.5
+- Bắt đầu Task 0 prerequisites (T0-1, T0-2, T0-3, T0-4a/4b, T0-5) per RUNBOOK §3.5
 - Q11 đã closed → Phase 0 hot-fix (P0c, M-P0a, M-P0b) có thể start parallel với T0
 
 **Notes:**

--- a/Documents/ADMISSION_DAILY_LOG.md
+++ b/Documents/ADMISSION_DAILY_LOG.md
@@ -8,6 +8,21 @@
 
 ---
 
+## Hotfix policy (chốt 2026-05-02 — bắt buộc)
+
+Production critical hotfix trong window refactor:
+
+1. **Hotfix branch off `main`** (KHÔNG off `feat/admission-full-cutover`).
+2. Implement + test + merge `main` → deploy production qua deploy gate.
+3. **SAME-DAY cherry-pick hoặc equivalent-patch** SHA hotfix sang `feat/admission-full-cutover`. KHÔNG được defer sang cutover.
+4. Append entry "Merged tới main (hotfix only)" với 3 SHA: main hotfix SHA → cherry-pick SHA → conflict notes (nếu có).
+5. **Conflict touch admission core/state/lead/notification/RBAC** → **PAUSE refactor 0.5-1 ngày**, resolve conflict clean, re-test PASS rồi mới continue.
+6. KHÔNG defer hotfix vào cutover bundle. Lý do: cutover sẽ replace toàn bộ codebase từ feat branch — nếu hotfix chỉ ở main mà chưa cherry-pick → cutover sẽ overwrite hotfix → bug production tái xuất.
+
+KHÔNG cherry-pick chỉ khi hotfix touch file mà refactor đang rewrite từ đầu (e.g., `admission_state_service.py` chưa tồn tại main, hotfix touch `admission_service.py` mà task #16 sẽ refactor toàn bộ). Trong case đó: ghi rõ trong DAILY_LOG entry "hotfix superseded by refactor — verify equivalent fix trong feat branch".
+
+---
+
 ## Entry template (copy-paste khi thêm entry mới)
 
 ```markdown

--- a/Documents/ADMISSION_IMPLEMENTATION_TRACKER.md
+++ b/Documents/ADMISSION_IMPLEMENTATION_TRACKER.md
@@ -6,7 +6,7 @@
 **Branch:** `feat/admission-full-cutover` (parent của sub-feature branches)
 
 **Last updated:** 2026-05-01 (round 22 cleanup: Q11 closed, Q9 defer 3 task, phase3_02/03 SUPERSEDED, sequencing fix #17/LS-map/FE Zod, blocker ID standardize, "9 → 11" direct sites, "Phase 3 = 2 → 1" align)
-**Current sprint focus:** Task 0 prerequisites (T0-1..T0-5) + maintenance window timing lock + 7 stakeholder sign-off
+**Current sprint focus:** Task 0 prerequisites (T0-1, T0-2, T0-3, T0-4a/4b, T0-5) + maintenance window timing lock + 7 stakeholder sign-off
 
 ---
 
@@ -42,7 +42,7 @@
 
 | ID | Task | Owner | Status | Branch/PR | Tests | Blocker | Plan ref |
 |---|---|---|---|---|---|---|---|
-| T0-1 | 2 entrypoint env flag gates: `RUN_MIGRATIONS_ON_STARTUP` + `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP` | BE | CODE_DONE (local) | feature/admission-t0-1 | U:✓ (14-case bash gate logic: 9 matrix + 5 defensive variants) | (chờ push approval + sub-PR) | RUNBOOK §3.5 |
+| T0-1 | 2 entrypoint env flag gates: `RUN_MIGRATIONS_ON_STARTUP` + `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP` | BE | CODE_DONE (branch pushed) | feature/admission-t0-1 | U:✓ (14-case bash gate logic: 9 matrix + 5 defensive variants) | (chờ sub-PR target `feat/admission-full-cutover`) | RUNBOOK §3.5 |
 | T0-2 | `ADMISSION_FROZEN` middleware + 4 method × 4 router matrix | BE | TODO | | U:- I:- | | RUNBOOK §3.5 |
 | T0-3 | Nginx admission block env-driven `NGINX_ADMISSION_FROZEN` | Ops | TODO | | U:- I:- | | RUNBOOK §3.5 |
 | T0-4a | Celery beat `dispatch_pending_outbox` **skeleton task** (no-op safe registration: function defined, beat schedule registered, log "outbox not yet active" + return early — KHÔNG insert/dispatch). Kịch bản: B2/M-1-19a chưa ship, beat task vẫn registered nhưng KHÔNG crash worker. | BE | TODO | | U:- I:- | (none — no dep, ship parallel với T0-1/2/3/5) | RUNBOOK §3.5 + PLAN §3.3.e |

--- a/Documents/ADMISSION_IMPLEMENTATION_TRACKER.md
+++ b/Documents/ADMISSION_IMPLEMENTATION_TRACKER.md
@@ -42,7 +42,7 @@
 
 | ID | Task | Owner | Status | Branch/PR | Tests | Blocker | Plan ref |
 |---|---|---|---|---|---|---|---|
-| T0-1 | `RUN_MIGRATIONS_ON_STARTUP` env flag entrypoint | BE | TODO | | U:- I:- | | RUNBOOK §3.5 |
+| T0-1 | 2 entrypoint env flag gates: `RUN_MIGRATIONS_ON_STARTUP` + `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP` | BE | CODE_DONE (local) | feature/admission-t0-1 | U:✓ (14-case bash gate logic: 9 matrix + 5 defensive variants) | (chờ push approval + sub-PR) | RUNBOOK §3.5 |
 | T0-2 | `ADMISSION_FROZEN` middleware + 4 method × 4 router matrix | BE | TODO | | U:- I:- | | RUNBOOK §3.5 |
 | T0-3 | Nginx admission block env-driven `NGINX_ADMISSION_FROZEN` | Ops | TODO | | U:- I:- | | RUNBOOK §3.5 |
 | T0-4a | Celery beat `dispatch_pending_outbox` **skeleton task** (no-op safe registration: function defined, beat schedule registered, log "outbox not yet active" + return early — KHÔNG insert/dispatch). Kịch bản: B2/M-1-19a chưa ship, beat task vẫn registered nhưng KHÔNG crash worker. | BE | TODO | | U:- I:- | (none — no dep, ship parallel với T0-1/2/3/5) | RUNBOOK §3.5 + PLAN §3.3.e |
@@ -226,7 +226,7 @@
 ### 12.3. Production readiness (Task 0 prerequisites)
 | Check | Status | Mapped task |
 |---|---|---|
-| T0-1 RUN_MIGRATIONS_ON_STARTUP shipped | TODO | T0-1 |
+| T0-1 2 entrypoint env flag gates shipped (RUN_MIGRATIONS_ON_STARTUP + RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP) | TODO | T0-1 |
 | T0-2 ADMISSION_FROZEN middleware shipped | TODO | T0-2 |
 | T0-3 Nginx admission block shipped | TODO | T0-3 |
 | T0-4a dispatch_pending_outbox skeleton (no-op safe) | TODO | T0-4a |

--- a/Documents/ADMISSION_IMPLEMENTATION_TRACKER.md
+++ b/Documents/ADMISSION_IMPLEMENTATION_TRACKER.md
@@ -45,7 +45,8 @@
 | T0-1 | `RUN_MIGRATIONS_ON_STARTUP` env flag entrypoint | BE | TODO | | U:- I:- | | RUNBOOK §3.5 |
 | T0-2 | `ADMISSION_FROZEN` middleware + 4 method × 4 router matrix | BE | TODO | | U:- I:- | | RUNBOOK §3.5 |
 | T0-3 | Nginx admission block env-driven `NGINX_ADMISSION_FROZEN` | Ops | TODO | | U:- I:- | | RUNBOOK §3.5 |
-| T0-4 | Celery beat `dispatch_pending_outbox` 30s + 3-step worker | BE | TODO | | U:- I:- R:- | T0 depends on B2 catalog ready | RUNBOOK §3.5 + PLAN §3.3.e |
+| T0-4a | Celery beat `dispatch_pending_outbox` **skeleton task** (no-op safe registration: function defined, beat schedule registered, log "outbox not yet active" + return early — KHÔNG insert/dispatch). Kịch bản: B2/M-1-19a chưa ship, beat task vẫn registered nhưng KHÔNG crash worker. | BE | TODO | | U:- I:- | (none — no dep, ship parallel với T0-1/2/3/5) | RUNBOOK §3.5 + PLAN §3.3.e |
+| T0-4b | Celery beat `dispatch_pending_outbox` **real worker wiring** (3-step claim/dispatch/finalize, query NotificationOutbox table, dispatch SystemEvents enum). Replace skeleton T0-4a. | BE | TODO | | U:- I:- R:- (concurrency + crash recovery rig) | **B2** + **M-1-19a** ship trước (NotificationOutbox model + table tồn tại) | RUNBOOK §3.5 + PLAN §3.3.e |
 | T0-5 | `POST /api/v2/admin/casbin/reload` admin endpoint | BE | TODO | | U:- I:- | | RUNBOOK §3.5 |
 
 ---
@@ -228,7 +229,8 @@
 | T0-1 RUN_MIGRATIONS_ON_STARTUP shipped | TODO | T0-1 |
 | T0-2 ADMISSION_FROZEN middleware shipped | TODO | T0-2 |
 | T0-3 Nginx admission block shipped | TODO | T0-3 |
-| T0-4 dispatch_pending_outbox beat shipped | TODO | T0-4 |
+| T0-4a dispatch_pending_outbox skeleton (no-op safe) | TODO | T0-4a |
+| T0-4b dispatch_pending_outbox real worker wiring (sau B2 + M-1-19a) | TODO | T0-4b |
 | T0-5 Casbin reload endpoint shipped | TODO | T0-5 |
 | ~~Q11 product decision chốt~~ | **CLOSED** | Resolved PLAN §3.3.g.1 |
 | Maintenance window communicated 7d trước | TODO | D2 |

--- a/Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md
+++ b/Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md
@@ -41,7 +41,7 @@ Runbook này KHÔNG:
 
 | Task 0 | Why | Codebase evidence (CHƯA CÓ) | Acceptance |
 |---|---|---|---|
-| **T0-1: `RUN_MIGRATIONS_ON_STARTUP` env flag** trong `Backend_FastAPI/docker-entrypoint.sh` | Cold cutover yêu cầu manual `alembic upgrade head` với log streaming + time tracking; entrypoint hiện auto-chạy | `docker-entrypoint.sh:4-5` `alembic upgrade head` không conditional | Entrypoint check `if [ "$RUN_MIGRATIONS_ON_STARTUP" != "false" ]; then alembic upgrade head; fi`. Default `true` cho routine deploy; cutover set `false`. |
+| **T0-1: 2 env flag gates** trong `Backend_FastAPI/docker-entrypoint.sh`: `RUN_MIGRATIONS_ON_STARTUP` + `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP` | Cold cutover yêu cầu manual `alembic upgrade head` + manual `sync_notification_rules` SAU migration + backfill (KHÔNG auto trên container start vì pre-migration state có thể chưa có notification_rule table hoặc chưa seed → script fail/race) | `docker-entrypoint.sh` auto chạy `alembic upgrade head` (line 4-5) + `python -m app.scripts.sync_notification_rules` (line 7-8), cả 2 không conditional | Entrypoint thêm 2 gate độc lập: `if [ "${RUN_MIGRATIONS_ON_STARTUP:-true}" != "false" ]; then alembic upgrade head; fi` + `if [ "${RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP:-true}" != "false" ]; then python -m app.scripts.sync_notification_rules; fi`. Default `true` cho routine deploy. Cutover set CẢ 2 = `false`. Defensive: chỉ exact lowercase `"false"` mới skip; mọi value khác (TRUE/FALSE/typo) chạy như cũ. |
 | **T0-2: `ADMISSION_FROZEN` middleware** | Freeze admission write endpoints khi maintenance window | Grep zero match `ADMISSION_FROZEN` trong `app/config.py`, `app/middleware/`, `app/routers/admissions.py` | Settings field + dependency/middleware raise 503 cho POST/PUT/DELETE/PATCH `/api/admissions/*` + `/api/admission-paths/*` + `/api/admission-configs/*` + `/api/public/admissions/*`. **Reload mechanism: env-based settings cần container restart** (Pydantic BaseSettings load 1 lần module-level) — runbook Phần 6.1 phải clarify restart container, KHÔNG hot-reload runtime. |
 | **T0-3: Nginx admission block config** | Defense-in-depth với T0-2 backend middleware | `nginx/conf.d/default.conf.template` chỉ generic `/api/` proxy, zero conditional admission block | Conditional `location ~ ^/api/(admissions|admission-paths|admission-configs|public/admissions)/.*$ { ... return 503 ...}` env-driven `${NGINX_ADMISSION_FROZEN}` template variable. |
 | **T0-4: `dispatch_pending_outbox` Celery beat task** | Worker drain outbox notification queue | `app/celery_app.py:108-150` zero match | Beat schedule entry 30s + 3-step claim/dispatch/finalize implementation per PLAN Phần 3.3.e. |
@@ -309,9 +309,14 @@ T+0:00   Communicate freeze (email + Slack + in-app banner)
 T+0:15   Set ADMISSION_FROZEN=true env + Nginx reload với NGINX_ADMISSION_FROZEN=1
          Verify: curl POST /api/admissions/... → 503
 T+0:30   Final pg_dump + uploads tar + config backup → upload S3 + integrity verify
-T+1:00   Deploy backend image MỚI với env RUN_MIGRATIONS_ON_STARTUP=false
-         (per RISK_REVIEW OG-1: tách Alembic khỏi container startup cho cutover)
-         Verify: container start → KHÔNG chạy alembic; sync_notification_rules + uvicorn ready
+T+1:00   Deploy backend image MỚI với 2 env flag = false:
+           RUN_MIGRATIONS_ON_STARTUP=false
+           RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP=false
+         (per RISK_REVIEW OG-1: tách Alembic + notification rule sync khỏi container startup cho cutover.
+          Lý do skip sync rules: pre-migration state có thể chưa có notification_rule table hoặc chưa seed
+          12 ADMISSION_* DB rows → script fail/race. Manual run ở T+3:30 sau migration + DB seed.)
+         Verify: container start → KHÔNG chạy alembic, KHÔNG chạy sync_notification_rules,
+                 chỉ uvicorn ready (log "Skipping..." cho cả 2 gate).
 T+1:30   Manual run Alembic chain:
            docker compose exec backend alembic upgrade head
          Stream log realtime; checkpoint mỗi migration step.
@@ -334,8 +339,10 @@ T+4:15   Smoke tests (Phần 7.3)
 T+4:45   Set ADMISSION_FROZEN=false + Nginx reload bỏ admission block
 T+5:00   Communicate unlock (email + Slack + in-app banner)
 T+5:15   Monitor handoff to oncall (Phần 9)
-T+24h    Switch backend env back RUN_MIGRATIONS_ON_STARTUP=true cho future routine deploys
-         (cutover behavior chỉ áp dụng 1 lần)
+T+24h    Switch backend env back CẢ 2 flag về true (hoặc unset) cho future routine deploy:
+           RUN_MIGRATIONS_ON_STARTUP=true (or unset)
+           RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP=true (or unset)
+         (cutover behavior chỉ áp dụng 1 lần; routine deploy phục hồi auto migration + auto sync như trước)
 ```
 
 ### 7.3. Smoke tests (T+4:15 — T+4:45)
@@ -463,7 +470,7 @@ Nếu cutover đã apply một trong 5 migration trên + phát hiện bug critic
 ### 9.3. Production readiness — Task 0 prerequisites (xem Phần 3.5)
 
 5 mục Task 0 BẮT BUỘC ship + tested trên staging trước Go decision:
-- [ ] **T0-1** `RUN_MIGRATIONS_ON_STARTUP` env flag trong `docker-entrypoint.sh` — tested với value `false` skip Alembic; default `true` chạy như cũ.
+- [ ] **T0-1** 2 env flag gates trong `docker-entrypoint.sh` — tested 9-case matrix (3 RUN_MIGRATIONS × 3 RUN_SYNC_NOTIFICATION_RULES) + 5 defensive variant (TRUE/FALSE/typo) PASS. Cutover combo `RUN_MIGRATIONS_ON_STARTUP=false` + `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP=false` skip cả 2; default unset/true chạy alembic + sync_notification_rules như cũ.
 - [ ] **T0-2** `ADMISSION_FROZEN` middleware shipped — 4 method × admission router prefix matrix tested (GET allowed, POST/PUT/DELETE/PATCH 503).
 - [ ] **T0-3** Nginx admission block config (env-driven `NGINX_ADMISSION_FROZEN`) tested với `nginx -t` syntax check + reload smoke.
 - [ ] **T0-4** `dispatch_pending_outbox` Celery beat task scheduled 30s + worker registered + 3-step claim/dispatch/finalize tested.

--- a/Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md
+++ b/Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md
@@ -37,17 +37,18 @@ Runbook này KHÔNG:
 
 ## 3.5. Task 0 — Pre-implementation Prerequisites (BẮT BUỘC ship TRƯỚC staging rehearsal)
 
-⚠️ **Runbook này giả định 5 infrastructure mục dưới đã được implement trong code.** Verified codebase 2026-05-01: tất cả CHƯA TỒN TẠI. Phải ship trong implementation phase (sub-PR riêng) TRƯỚC khi bắt đầu staging rehearsal Phần 7. KHÔNG assume.
+⚠️ **Runbook này giả định 5 infrastructure family dưới đã được implement trong code.** Verified codebase 2026-05-01: tất cả CHƯA TỒN TẠI. Phải ship trong implementation phase (sub-PR riêng) TRƯỚC khi bắt đầu staging rehearsal Phần 7. KHÔNG assume. T0-4 được tách thành 2 tracker row: T0-4a skeleton an toàn trước khi có outbox table, T0-4b worker thật sau B2 + M-1-19a.
 
 | Task 0 | Why | Codebase evidence (CHƯA CÓ) | Acceptance |
 |---|---|---|---|
 | **T0-1: 2 env flag gates** trong `Backend_FastAPI/docker-entrypoint.sh`: `RUN_MIGRATIONS_ON_STARTUP` + `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP` | Cold cutover yêu cầu manual `alembic upgrade head` + manual `sync_notification_rules` SAU migration + backfill (KHÔNG auto trên container start vì pre-migration state có thể chưa có notification_rule table hoặc chưa seed → script fail/race) | `docker-entrypoint.sh` auto chạy `alembic upgrade head` (line 4-5) + `python -m app.scripts.sync_notification_rules` (line 7-8), cả 2 không conditional | Entrypoint thêm 2 gate độc lập: `if [ "${RUN_MIGRATIONS_ON_STARTUP:-true}" != "false" ]; then alembic upgrade head; fi` + `if [ "${RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP:-true}" != "false" ]; then python -m app.scripts.sync_notification_rules; fi`. Default `true` cho routine deploy. Cutover set CẢ 2 = `false`. Defensive: chỉ exact lowercase `"false"` mới skip; mọi value khác (TRUE/FALSE/typo) chạy như cũ. |
 | **T0-2: `ADMISSION_FROZEN` middleware** | Freeze admission write endpoints khi maintenance window | Grep zero match `ADMISSION_FROZEN` trong `app/config.py`, `app/middleware/`, `app/routers/admissions.py` | Settings field + dependency/middleware raise 503 cho POST/PUT/DELETE/PATCH `/api/admissions/*` + `/api/admission-paths/*` + `/api/admission-configs/*` + `/api/public/admissions/*`. **Reload mechanism: env-based settings cần container restart** (Pydantic BaseSettings load 1 lần module-level) — runbook Phần 6.1 phải clarify restart container, KHÔNG hot-reload runtime. |
 | **T0-3: Nginx admission block config** | Defense-in-depth với T0-2 backend middleware | `nginx/conf.d/default.conf.template` chỉ generic `/api/` proxy, zero conditional admission block | Conditional `location ~ ^/api/(admissions|admission-paths|admission-configs|public/admissions)/.*$ { ... return 503 ...}` env-driven `${NGINX_ADMISSION_FROZEN}` template variable. |
-| **T0-4: `dispatch_pending_outbox` Celery beat task** | Worker drain outbox notification queue | `app/celery_app.py:108-150` zero match | Beat schedule entry 30s + 3-step claim/dispatch/finalize implementation per PLAN Phần 3.3.e. |
+| **T0-4a: `dispatch_pending_outbox` skeleton task** | Register Celery beat safely before outbox table/model exists | `app/celery_app.py:108-150` zero match | Beat schedule entry 30s + task function exists, logs "outbox not yet active", returns early, KHÔNG query/insert/dispatch `NotificationOutbox`. Safe to ship before B2 + M-1-19a. |
+| **T0-4b: `dispatch_pending_outbox` real worker wiring** | Worker drain outbox notification queue | `notification_outbox` table/model chưa tồn tại trước B2 + M-1-19a | Replace skeleton with 3-step claim/dispatch/finalize implementation per PLAN Phần 3.3.e. Gate: B2 + M-1-19a shipped first. |
 | **T0-5: `POST /api/v2/admin/casbin/reload` endpoint** | Cutover safety: reload Casbin policy sau seed deny rules direct DB | `admin/roles.py` chỉ side-effect trong CRUD endpoint, zero dedicated reload endpoint | Admin-only endpoint gọi `await enforcer.load_policy()` + return policy count + audit log. |
 
-**Gate**: Phần 9.3 production readiness checklist verify 5 mục trên shipped + tested trên staging trước Go decision.
+**Gate**: Phần 9.3 production readiness checklist verify 5 infrastructure family trên (6 tracker row vì T0-4 split) shipped + tested trên staging trước Go decision.
 
 ## 4. Environment Strategy
 
@@ -469,11 +470,12 @@ Nếu cutover đã apply một trong 5 migration trên + phát hiện bug critic
 
 ### 9.3. Production readiness — Task 0 prerequisites (xem Phần 3.5)
 
-5 mục Task 0 BẮT BUỘC ship + tested trên staging trước Go decision:
+5 infrastructure family Task 0 BẮT BUỘC ship + tested trên staging trước Go decision (6 tracker row vì T0-4 split):
 - [ ] **T0-1** 2 env flag gates trong `docker-entrypoint.sh` — tested 9-case matrix (3 RUN_MIGRATIONS × 3 RUN_SYNC_NOTIFICATION_RULES) + 5 defensive variant (TRUE/FALSE/typo) PASS. Cutover combo `RUN_MIGRATIONS_ON_STARTUP=false` + `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP=false` skip cả 2; default unset/true chạy alembic + sync_notification_rules như cũ.
 - [ ] **T0-2** `ADMISSION_FROZEN` middleware shipped — 4 method × admission router prefix matrix tested (GET allowed, POST/PUT/DELETE/PATCH 503).
 - [ ] **T0-3** Nginx admission block config (env-driven `NGINX_ADMISSION_FROZEN`) tested với `nginx -t` syntax check + reload smoke.
-- [ ] **T0-4** `dispatch_pending_outbox` Celery beat task scheduled 30s + worker registered + 3-step claim/dispatch/finalize tested.
+- [ ] **T0-4a** `dispatch_pending_outbox` skeleton scheduled 30s + worker registered + no-op safe before outbox table/model exists.
+- [ ] **T0-4b** `dispatch_pending_outbox` real worker wiring shipped after B2 + M-1-19a + 3-step claim/dispatch/finalize tested.
 - [ ] **T0-5** `POST /api/v2/admin/casbin/reload` endpoint shipped + admin-only Casbin guard + audit log.
 
 Misc readiness:
@@ -502,9 +504,9 @@ Misc readiness:
 | Legal/Compliance | __________ | __________ | __________ |
 
 **Sign-off scope per role:**
-- **Backend Lead**: full scope v2.13/v2.13.1 implementation + 27 migration + 14 code task + Task 0 prerequisites (Phần 3.5) + state service + outbox + multi-NV engine. Sign-off rằng code đã pass CI/test/lint trên `feat/admission-full-cutover` branch.
+- **Backend Lead**: full scope v2.13.1 implementation + 26 migration + 14 code task + Task 0 prerequisites (Phần 3.5) + state service + outbox + multi-NV engine. Sign-off rằng code đã pass CI/test/lint trên `feat/admission-full-cutover` branch.
 - **Frontend Lead**: i18n inline 25 keys + 14 status render + 5 component mới + multi-NV UX + typed `available_actions` contract. Sign-off rằng FE bundle production-ready.
-- **DBA / Ops Lead**: backup/restore plan + 27 migration chain review + one-way migration risk acceptance + maintenance window schedule + rollback playbook + monitoring dashboard + Nginx admission block config (T0-3).
+- **DBA / Ops Lead**: backup/restore plan + 26 migration chain review + one-way migration risk acceptance + maintenance window schedule + rollback playbook + monitoring dashboard + Nginx admission block config (T0-3).
 - **QA Lead**: E2E checklist + rehearsal protocol 2 lần + smoke test 8 critical journey sign-off + Casbin matrix 4×14 verified.
 - **Product Owner**: Q1-Q10 decisions chốt (Q11 resolved trong PLAN §3.3.g.1) + multi-NV launch user-facing + maintenance window 4-6h communication.
 - **Admission Ops** (vận hành admission daily): freeze window timing acceptable cho operational continuity + read-only allowed endpoints đáp ứng tham khảo officer trong window + post-cutover unlock procedure.

--- a/Documents/ADMISSION_REHEARSAL_LOG.md
+++ b/Documents/ADMISSION_REHEARSAL_LOG.md
@@ -81,7 +81,7 @@
 - [ ] Anonymized PII per company policy (if applicable)
 - [ ] Backend image build successful from feat branch HEAD
 - [ ] Alembic head trên feat branch verified (no missing migration)
-- [ ] T0-1..T0-5 prerequisites all shipped (per RUNBOOK §3.5)
+- [ ] Task 0 prerequisites all shipped (T0-1, T0-2, T0-3, T0-4a/4b, T0-5 per RUNBOOK §3.5)
 - [ ] Document expected backfill exception bounds (so unusual count flags issue)
 
 ---


### PR DESCRIPTION
## Summary

T0-1 prerequisite per RUNBOOK §3.5 + §7.2: tách Alembic migration + notification rule sync khỏi container startup để cold cutover scenario có manual control log streaming + time tracking + checkpoint mỗi step.

**2 entrypoint env flag gates** trong `Backend_FastAPI/docker-entrypoint.sh`:

- `RUN_MIGRATIONS_ON_STARTUP` (default `true`) — gate `alembic upgrade head`.
- `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP` (default `true`) — gate `python -m app.scripts.sync_notification_rules`.

**Lý do 2 gate (KHÔNG 1):** cutover sequence T+1:00 deploy backend image → T+1:30 manual alembic → T+3:00 manual backfill → T+3:30 manual sync_notification_rules. Pre-migration state có thể chưa có `notification_rule` table (M-1-19a tạo) hoặc chưa seed 12 ADMISSION_* DB rows (M-1-19b seed). Nếu container start auto chạy sync trên empty/stale schema → script fail/race. Phải gate riêng.

## Changes

| File | Change |
|---|---|
| `Backend_FastAPI/docker-entrypoint.sh` | 2 gate độc lập với defensive default (chỉ exact lowercase `"false"` skip) |
| `Backend_FastAPI/CLAUDE.md` | Common Commands note 2 flag cutover-only |
| `Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md` | §3.5 T0-1 acceptance updated to 2 flags + 14-case test matrix; §7.2 cutover sequence T+1:00 + T+24h reflect 2 flag; §9.3 readiness checklist update |
| `Documents/ADMISSION_IMPLEMENTATION_TRACKER.md` | T0-1 status TODO → CODE_DONE; Section 12.3 update; T0-4 split T0-4a/4b; current sprint focus list updated |
| `Documents/ADMISSION_DAILY_LOG.md` | 2026-05-02 entry với 3 SHA; hotfix policy explicit (cherry-pick OR equivalent-patch same-day mandatory; KHÔNG defer to cutover) |
| `Documents/ADMISSION_REHEARSAL_LOG.md` | Setup alignment with 2 flag |

## Test result

✅ `bash -n Backend_FastAPI/docker-entrypoint.sh` syntax PASS

✅ **14-case bash logic test PASS:**

**9-case matrix (3 RUN_MIGRATIONS × 3 RUN_SYNC):**

| RUN_MIGRATIONS | RUN_SYNC | Alembic | Sync | Scenario |
|---|---|---|---|---|
| unset | unset | run | run | **DEFAULT** — routine deploy, behavior preserved |
| unset | true | run | run | |
| unset | false | run | skip | |
| true | unset | run | run | |
| true | true | run | run | |
| true | false | run | skip | |
| false | unset | skip | run | |
| false | true | skip | run | |
| false | false | skip | skip | **CUTOVER** — manual run sau migration + backfill |

**5 defensive variant** (TRUE / FALSE / typo / 0 / "False" capitalize) → tất cả `run` (chỉ exact lowercase `"false"` mới skip).

## Behavior preservation

- Default behavior preserved khi cả 2 flag unset → routine deploy chạy alembic + sync như cũ.
- Reversible — switch flag về `true` (or unset) bất kỳ lúc nào.
- Defensive — typo/case variant KHÔNG tình cờ skip; chỉ exact lowercase `"false"`.
- Cold cutover: set CẢ 2 = `false` → container start chỉ uvicorn ready; manual alembic + backfill + sync ngoài container per RUNBOOK §7.2.

## Test plan staging clone

- [ ] Apply 2 flag value combinations trong staging clone, verify entrypoint output match expected log message.
- [ ] Smoke test API ready sau cutover combo (false/false): manual alembic + sync rồi curl health endpoint.

## Refs

- Issue #181 sub-task 1 (Task 0 prerequisite)
- RUNBOOK §3.5 T0-1 + §7.2 cutover sequence + §9.3 readiness
- TRACKER Section 1 row T0-1 + Section 12.3 production readiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)
