### PR TITLE
[#184 Wave1] feat(schema): phase1_01 degree_level FK + phase1_02 bonus_rule

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase1_01_add_degree_level_fk_to_major_program.py
+++ b/Backend_FastAPI/alembic/versions/phase1_01_add_degree_level_fk_to_major_program.py
@@ -1,0 +1,103 @@
+"""phase1_01: add degree_level_id FK to major_program
+
+Revision ID: phase1_01
+Revises: phase1_19b
+Create Date: 2026-05-03
+
+#184 Wave 1 PR-1A — first additive migration of the Phase 1 Schema
+chain (PLAN §4 line 2616-2630). Adds the FK column
+``major_program.degree_level_id`` referencing the existing
+``config_degree_level`` table (seeded earlier by
+``l7m8n9o0p1q2_add_system_configuration_tables``). Backfills from
+the legacy ``major_program.degree_level`` text column via JOIN on
+``lower(trim(name))``; the per-row guard ``WHERE degree_level_id
+IS NULL`` keeps re-runs idempotent.
+
+The legacy ``degree_level`` text column STAYS for Phase 4 retire
+— consumers that still rely on the text shape keep working
+unchanged. New code paths read the FK; old code paths read the
+text column. Both columns sit on the row until the retire wave.
+
+Down-revision = ``phase1_19b`` (B1 Casbin deny-first backfill, the
+chronological head when this migration was authored). PLAN's
+nominal "phase0 → phase1_01" chain ordering is the *naming*
+intent; the actual Alembic linear chain follows ship order, so
+phase1_01 chains after phase1_19b (B1) which itself chained
+after phase1_19a (B2.2 outbox).
+
+Idempotency:
+* Re-running the migration body (`alembic upgrade phase1_01`
+  twice) is safe — Alembic gates on revision row, body never
+  re-executes.
+* Re-running just the backfill SQL (e.g. via psql for a partial
+  recovery) is safe via the ``WHERE degree_level_id IS NULL``
+  guard.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_01"
+down_revision: Union[str, None] = "phase1_19b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. ADD COLUMN — nullable, no server_default. Existing rows are
+    #    populated by the backfill SQL below; new rows stay honest
+    #    (NULL until the caller sets the FK explicitly).
+    op.add_column(
+        "major_program",
+        sa.Column(
+            "degree_level_id",
+            sa.Integer(),
+            sa.ForeignKey(
+                "config_degree_level.id",
+                ondelete="SET NULL",
+                name="fk_major_program_degree_level_id",
+            ),
+            nullable=True,
+            comment=(
+                "FK to config_degree_level. Canonical lookup for new code "
+                "paths; legacy degree_level text column stays for Phase 4 "
+                "retire."
+            ),
+        ),
+    )
+
+    # 2. Index — same shape as the existing ``ix_major_program_unit_id``
+    #    pattern; the planner needs a btree on the FK for join
+    #    queries against config_degree_level.
+    op.create_index(
+        "ix_major_program_degree_level_id",
+        "major_program",
+        ["degree_level_id"],
+    )
+
+    # 3. Backfill — JOIN on lower(trim(name)). Per-row idempotent
+    #    guard so a partial replay (e.g. crash mid-migration, restart)
+    #    skips rows already populated.
+    op.execute(
+        """
+        UPDATE major_program mp
+           SET degree_level_id = cdl.id
+          FROM config_degree_level cdl
+         WHERE mp.degree_level_id IS NULL
+           AND lower(trim(mp.degree_level)) = lower(trim(cdl.name));
+        """
+    )
+
+
+def downgrade() -> None:
+    # Inverse order: drop index → drop column. The FK constraint is
+    # implicit on the column drop; no explicit DROP CONSTRAINT needed
+    # because PostgreSQL cascades the constraint with the column.
+    op.drop_index(
+        "ix_major_program_degree_level_id",
+        table_name="major_program",
+    )
+    op.drop_column("major_program", "degree_level_id")

--- a/Backend_FastAPI/alembic/versions/phase1_02_add_bonus_rule_to_method_and_path.py
+++ b/Backend_FastAPI/alembic/versions/phase1_02_add_bonus_rule_to_method_and_path.py
@@ -1,0 +1,92 @@
+"""phase1_02: add bonus_rule JSONB to admission_method + admission_path
+
+Revision ID: phase1_02
+Revises: phase1_01
+Create Date: 2026-05-03
+
+#184 Wave 1 PR-1A — second migration in Phase 1 Schema chain
+(PLAN §4 line 2632-2634). Two nullable JSONB columns ship together:
+
+* ``admission_method.default_bonus_rule`` — method-level default
+  for area / subject bonus calculation. Schema (PLAN line 768-773)::
+
+      {
+          "apply_area_bonus": true,
+          "apply_subject_bonus": true,
+          "max_total_bonus": 2.75
+      }
+
+* ``admission_path.bonus_rule_override`` — path-level override
+  above the method default. Same JSONB shape; precedence per PLAN
+  line 787-789::
+
+      effective_bonus_rule =
+          path.bonus_rule_override
+          ?? path.admission_method.default_bonus_rule
+          ?? {"apply_area_bonus": false, "apply_subject_bonus": false}
+
+The two columns ship in the same migration because they are one
+semantic unit (method default + path override) and the PLAN file
+title spells them as a pair: ``add_bonus_rule_to_method_and_path``.
+
+No backfill — both columns are nullable from day one. Existing
+rows keep ``NULL`` (= bonus disabled per the precedence fallback).
+Admin UI populates them once the engine consumer is wired (later
+PR; this migration is pure schema additive).
+
+Down-revision chain: ``phase1_19b → phase1_01 → phase1_02``.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_02"
+down_revision: Union[str, None] = "phase1_01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. AdmissionMethod.default_bonus_rule — method-level default.
+    #    JSONB nullable; existing rows stay NULL (= bonus disabled
+    #    fallback per the precedence rule).
+    op.add_column(
+        "admission_method",
+        sa.Column(
+            "default_bonus_rule",
+            JSONB(),
+            nullable=True,
+            comment=(
+                'Method-level default bonus rule. Schema: '
+                '{"apply_area_bonus": bool, "apply_subject_bonus": bool, '
+                '"max_total_bonus": float}. NULL = bonus disabled fallback. '
+                'Path-level override via admission_path.bonus_rule_override.'
+            ),
+        ),
+    )
+
+    # 2. AdmissionPath.bonus_rule_override — path-level override.
+    #    Same JSONB shape; NULL = inherit from method default.
+    op.add_column(
+        "admission_path",
+        sa.Column(
+            "bonus_rule_override",
+            JSONB(),
+            nullable=True,
+            comment=(
+                "Path-level bonus rule override above the method default. "
+                "Same JSONB shape as admission_method.default_bonus_rule. "
+                "NULL = inherit from admission_method.default_bonus_rule."
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Inverse order — drop path override first, then method default.
+    op.drop_column("admission_path", "bonus_rule_override")
+    op.drop_column("admission_method", "default_bonus_rule")

--- a/Backend_FastAPI/app/models/admission_config/admission_path.py
+++ b/Backend_FastAPI/app/models/admission_config/admission_path.py
@@ -158,6 +158,20 @@ class AdmissionPath(Base):
         ),
     )
 
+    # phase1_02 (#184 Wave 1) — path-level bonus rule override above
+    # the method default. Same JSONB shape as
+    # AdmissionMethod.default_bonus_rule. NULL = inherit from method.
+    # Resolution precedence (PLAN line 787-789):
+    #   effective = path.bonus_rule_override
+    #               ?? method.default_bonus_rule
+    #               ?? {"apply_area_bonus": false, "apply_subject_bonus": false}
+    bonus_rule_override = Column(
+        JSONB,
+        nullable=True,
+        comment="Path-level bonus rule override above method default. "
+                "NULL = inherit from admission_method.default_bonus_rule."
+    )
+
     @property
     def requires_application_fee(self) -> bool:
         """Check if this admission path requires application fee payment."""

--- a/Backend_FastAPI/app/models/admission_config/method.py
+++ b/Backend_FastAPI/app/models/admission_config/method.py
@@ -9,6 +9,7 @@ Represents admission methods like:
 """
 
 from sqlalchemy import Column, Integer, String, Boolean, Text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
 from app.models.base import Base
@@ -66,6 +67,22 @@ class AdmissionMethod(Base):
         nullable=False,
         default=True,
         index=True
+    )
+
+    # phase1_02 (#184 Wave 1) — method-level default bonus rule.
+    # Schema: {"apply_area_bonus": bool, "apply_subject_bonus": bool,
+    # "max_total_bonus": float}. NULL = bonus disabled fallback.
+    # Path-level override via AdmissionPath.bonus_rule_override.
+    # Resolution rule (PLAN line 787-789):
+    #   effective = path.bonus_rule_override
+    #               ?? method.default_bonus_rule
+    #               ?? {"apply_area_bonus": false, "apply_subject_bonus": false}
+    default_bonus_rule = Column(
+        JSONB,
+        nullable=True,
+        comment="Method-level default bonus rule (JSONB). NULL = bonus "
+                "disabled fallback. Path-level override via "
+                "AdmissionPath.bonus_rule_override."
     )
 
     # Relationships

--- a/Backend_FastAPI/app/models/major_program.py
+++ b/Backend_FastAPI/app/models/major_program.py
@@ -36,7 +36,20 @@ class MajorProgram(Base):
     degree_level = Column(
         String(50),
         nullable=False,
-        comment="Trình độ (vd: 'Cao đẳng', 'Đại học')"
+        comment="Trình độ (vd: 'Cao đẳng', 'Đại học'). LEGACY text column "
+                "— stays for Phase 4 retire. New code paths use "
+                "degree_level_id FK below."
+    )
+    # phase1_01 (#184 Wave 1) — FK to config_degree_level. Canonical
+    # lookup for new code paths; legacy ``degree_level`` text column
+    # stays in parallel for Phase 4 retire.
+    degree_level_id = Column(
+        Integer,
+        ForeignKey("config_degree_level.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+        comment="FK to config_degree_level. Canonical lookup; "
+                "backfilled from legacy degree_level text column."
     )
     code = Column(
         String(50),

--- a/Backend_FastAPI/tests/unit/test_phase1_01_02_revision_chain.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_01_02_revision_chain.py
@@ -1,0 +1,260 @@
+"""Unit tests for #184 Wave 1 PR-1A migrations
+(``phase1_01_add_degree_level_fk_to_major_program`` +
+``phase1_02_add_bonus_rule_to_method_and_path``).
+
+Pure-text contract tests — locks the revision chain shape, the
+upgrade SQL contract, and the model field declarations so a
+regression in any of the three surfaces fails CI before the
+migration ever runs against a real DB.
+
+What lives here:
+1. Revision-row lock — `revision`, `down_revision` for both files.
+2. Linear chain shape — ``phase1_19b → phase1_01 → phase1_02``.
+3. Backfill SQL contract — phase1_01 must include the per-row
+   ``WHERE degree_level_id IS NULL`` idempotency guard, plus the
+   ``lower(trim(...))`` JOIN predicate the spec mandates.
+4. Bonus-rule shape — phase1_02 adds JSONB columns on both
+   ``admission_method`` and ``admission_path``.
+5. Model parity — the ORM declarations match the new columns so
+   downstream queries see the schema.
+
+What does NOT live here (covered separately):
+* End-to-end DDL apply — ``alembic upgrade head`` smoke runs in
+  the dev container; fixture-driven integration tests live under
+  ``tests/integration/`` and exercise actual data shape.
+* Backfill correctness on real data — the dev DB roundtrip
+  ``upgrade → downgrade → upgrade`` covers that manually pre-PR;
+  CI integration suite covers it post-merge.
+"""
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module loading — load each migration as a regular Python module so we can
+# pick out ``revision``, ``down_revision``, and inspect the upgrade body
+# source directly. Alembic's ``ScriptDirectory.walk_revisions`` is the
+# canonical way but it requires the live env; pytest unit scope skips it
+# in favor of plain importlib for speed + isolation.
+# ---------------------------------------------------------------------------
+
+
+_VERSIONS_DIR = (
+    Path(__file__).resolve().parents[2] / "alembic" / "versions"
+)
+
+
+def _load_migration(filename: str):
+    """Import an alembic migration file by stem. Returns the module."""
+    path = _VERSIONS_DIR / filename
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None, (
+        f"Cannot load migration {path}"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_01():
+    return _load_migration("phase1_01_add_degree_level_fk_to_major_program.py")
+
+
+@pytest.fixture
+def phase1_02():
+    return _load_migration("phase1_02_add_bonus_rule_to_method_and_path.py")
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision-row lock
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_01_revision_id(phase1_01) -> None:
+    assert phase1_01.revision == "phase1_01"
+
+
+def test_phase1_01_down_revision_chains_off_b1(phase1_01) -> None:
+    """phase1_01 chains off the chronological head when authored —
+    ``phase1_19b`` (B1 Casbin deny-first backfill). PLAN's nominal
+    ``phase0 → phase1_01`` ordering refers to *naming intent*; the
+    Alembic linear chain follows ship order.
+    """
+    assert phase1_01.down_revision == "phase1_19b"
+
+
+def test_phase1_02_revision_id(phase1_02) -> None:
+    assert phase1_02.revision == "phase1_02"
+
+
+def test_phase1_02_down_revision_chains_off_phase1_01(phase1_02) -> None:
+    """phase1_02 follows phase1_01 directly per PLAN line 2632."""
+    assert phase1_02.down_revision == "phase1_01"
+
+
+def test_neither_migration_has_branch_labels(phase1_01, phase1_02) -> None:
+    """Linear chain — no branching."""
+    assert phase1_01.branch_labels is None
+    assert phase1_02.branch_labels is None
+
+
+def test_neither_migration_has_extra_dependencies(phase1_01, phase1_02) -> None:
+    """``depends_on`` is for cross-branch dependencies; PR-1A is
+    plain linear so both stay None."""
+    assert phase1_01.depends_on is None
+    assert phase1_02.depends_on is None
+
+
+# ---------------------------------------------------------------------------
+# 2. phase1_01 backfill SQL contract
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_01_adds_degree_level_id_column(phase1_01) -> None:
+    """Source must include the ``add_column`` call for
+    ``degree_level_id`` — locks the column name + table."""
+    src = Path(_VERSIONS_DIR / "phase1_01_add_degree_level_fk_to_major_program.py").read_text()
+    assert 'add_column' in src
+    assert '"major_program"' in src
+    assert '"degree_level_id"' in src
+
+
+def test_phase1_01_creates_index_on_fk(phase1_01) -> None:
+    """FK column needs btree for join queries against
+    config_degree_level. Lock the index name + column."""
+    src = Path(_VERSIONS_DIR / "phase1_01_add_degree_level_fk_to_major_program.py").read_text()
+    assert "ix_major_program_degree_level_id" in src
+    assert 'create_index' in src
+
+
+def test_phase1_01_backfill_uses_lower_trim_join(phase1_01) -> None:
+    """Spec mandates JOIN on ``lower(trim(name)) = lower(trim(name))``
+    so cosmetic whitespace / casing differences in the legacy text
+    column don't drop the row from the backfill."""
+    src = Path(_VERSIONS_DIR / "phase1_01_add_degree_level_fk_to_major_program.py").read_text()
+    assert "lower(trim(mp.degree_level))" in src
+    assert "lower(trim(cdl.name))" in src
+
+
+def test_phase1_01_backfill_idempotency_guard(phase1_01) -> None:
+    """The ``WHERE degree_level_id IS NULL`` per-row guard makes the
+    backfill safe to re-run after a partial-replay (PLAN line 2630)."""
+    src = Path(_VERSIONS_DIR / "phase1_01_add_degree_level_fk_to_major_program.py").read_text()
+    assert "WHERE mp.degree_level_id IS NULL" in src
+
+
+def test_phase1_01_downgrade_drops_index_then_column(phase1_01) -> None:
+    """Inverse order — drop index first (FK constraint cascades on
+    column drop). Locks the symmetric DDL surface."""
+    src = Path(_VERSIONS_DIR / "phase1_01_add_degree_level_fk_to_major_program.py").read_text()
+    drop_idx_pos = src.index('drop_index(\n        "ix_major_program_degree_level_id"')
+    drop_col_pos = src.index('drop_column("major_program", "degree_level_id")')
+    assert drop_idx_pos < drop_col_pos, (
+        "drop_index must precede drop_column in downgrade"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. phase1_02 bonus_rule contract
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_02_adds_default_bonus_rule_to_method(phase1_02) -> None:
+    src = Path(_VERSIONS_DIR / "phase1_02_add_bonus_rule_to_method_and_path.py").read_text()
+    # Source must include both add_column calls — admission_method
+    # gets the default, admission_path gets the override.
+    assert '"admission_method"' in src
+    assert '"default_bonus_rule"' in src
+
+
+def test_phase1_02_adds_bonus_rule_override_to_path(phase1_02) -> None:
+    src = Path(_VERSIONS_DIR / "phase1_02_add_bonus_rule_to_method_and_path.py").read_text()
+    assert '"admission_path"' in src
+    assert '"bonus_rule_override"' in src
+
+
+def test_phase1_02_columns_use_jsonb_type(phase1_02) -> None:
+    """JSONB (not plain JSON) — needed for GIN index support + faster
+    containment queries the engine will issue downstream."""
+    src = Path(_VERSIONS_DIR / "phase1_02_add_bonus_rule_to_method_and_path.py").read_text()
+    assert "from sqlalchemy.dialects.postgresql import JSONB" in src
+    assert "JSONB()" in src
+
+
+def test_phase1_02_no_backfill(phase1_02) -> None:
+    """Pure additive — both columns nullable; existing rows keep
+    NULL = bonus disabled fallback per the precedence rule. No
+    backfill SQL should be in the body."""
+    src = Path(_VERSIONS_DIR / "phase1_02_add_bonus_rule_to_method_and_path.py").read_text()
+    # ``op.execute(`` is only used for raw SQL; phase1_02 should not
+    # have any. (op.add_column doesn't go through execute.)
+    assert "op.execute(" not in src
+
+
+def test_phase1_02_downgrade_drops_path_override_then_method_default(phase1_02) -> None:
+    """Inverse insertion order — path override drops before method
+    default. No FK between them so order is documentation only."""
+    src = Path(_VERSIONS_DIR / "phase1_02_add_bonus_rule_to_method_and_path.py").read_text()
+    drop_path_pos = src.index('drop_column("admission_path", "bonus_rule_override")')
+    drop_method_pos = src.index('drop_column("admission_method", "default_bonus_rule")')
+    assert drop_path_pos < drop_method_pos
+
+
+# ---------------------------------------------------------------------------
+# 4. ORM model parity
+# ---------------------------------------------------------------------------
+
+
+def test_major_program_model_declares_degree_level_id() -> None:
+    """ORM must know about the new FK; otherwise downstream queries
+    that try to filter / select ``degree_level_id`` get an
+    ``AttributeError`` at query construction time."""
+    from app.models.major_program import MajorProgram
+    assert hasattr(MajorProgram, "degree_level_id")
+    column = MajorProgram.__table__.columns["degree_level_id"]
+    assert column.nullable is True
+    assert column.foreign_keys, "degree_level_id must declare an FK"
+    fk = next(iter(column.foreign_keys))
+    assert fk.column.table.name == "config_degree_level"
+    assert fk.column.name == "id"
+
+
+def test_admission_method_model_declares_default_bonus_rule() -> None:
+    from app.models.admission_config.method import AdmissionMethod
+    assert hasattr(AdmissionMethod, "default_bonus_rule")
+    column = AdmissionMethod.__table__.columns["default_bonus_rule"]
+    assert column.nullable is True
+    # Type is JSONB — check via the sqlalchemy dialect class name.
+    type_repr = type(column.type).__name__
+    assert "JSON" in type_repr.upper(), (
+        f"default_bonus_rule type should be JSONB, got {type_repr}"
+    )
+
+
+def test_admission_path_model_declares_bonus_rule_override() -> None:
+    from app.models.admission_config.admission_path import AdmissionPath
+    assert hasattr(AdmissionPath, "bonus_rule_override")
+    column = AdmissionPath.__table__.columns["bonus_rule_override"]
+    assert column.nullable is True
+    type_repr = type(column.type).__name__
+    assert "JSON" in type_repr.upper()
+
+
+# ---------------------------------------------------------------------------
+# 5. Sanity — both migrations import cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_both_migrations_define_upgrade_and_downgrade(phase1_01, phase1_02) -> None:
+    """Alembic requires both functions to exist; absence is a
+    runtime error during ``alembic upgrade``. Lock the signature
+    early so a malformed copy-paste fails CI."""
+    for module in (phase1_01, phase1_02):
+        assert callable(getattr(module, "upgrade", None))
+        assert callable(getattr(module, "downgrade", None))

--- a/Documents/ADMISSION_DAILY_LOG.md
+++ b/Documents/ADMISSION_DAILY_LOG.md
@@ -94,12 +94,14 @@ Trade-off: smaller PRs (~2-3h each) vs more review cycles.
 
 **Pending user chốt before code starts:** ~~3-PR vs 4-PR split~~ → user chốt **4-PR split** 2026-05-03.
 
-### #184 Wave 1 PR-1A — phase1_01 + phase1_02 (CODE_DONE local, push pending)
+### #184 Wave 1 PR-1A — phase1_01 + phase1_02 (PR open, awaiting review/merge)
 
-**Branch / Commit:**
+**Branch / Commit / PR:**
 - Branch `feature/admission-184-pr-1a` off parent `2864df20` (preflight tracking).
+- PR [#205](https://github.com/favouritekid/QLTS/pull/205) opened 2026-05-03 base `feat/admission-full-cutover`.
+- Head SHA at PR open: `83d05150`.
 - 2 migrations + 3 model updates + 1 unit test file.
-- Squash title (when PR opens): `[#184 Wave1] feat(schema): phase1_01_degree_level + phase1_02_bonus_rule`.
+- Squash title: `[#184 Wave1] feat(schema): phase1_01 degree_level FK + phase1_02 bonus_rule`.
 
 **Migrations shipped:**
 1. `phase1_01_add_degree_level_fk_to_major_program.py`
@@ -127,8 +129,8 @@ Trade-off: smaller PRs (~2-3h each) vs more review cycles.
 - Live: AST lint 0 violations across 148 files; coverage script `--allow-deferred` exit 0 (no admission status / event surface touched in PR-1A).
 
 **Pending:**
-- Push approval từ user.
-- Sub-PR #205 open base `feat/admission-full-cutover`.
+- Reviewer review + squash merge PR [#205](https://github.com/favouritekid/QLTS/pull/205).
+- Post-merge: parent tracking commit citing squash SHA + start PR-1B' (path advanced + BE schema + service + FE Zod).
 
 ---
 

--- a/Documents/ADMISSION_DAILY_LOG.md
+++ b/Documents/ADMISSION_DAILY_LOG.md
@@ -92,9 +92,43 @@ KHÔNG được "defer to cutover" với bất kỳ lý do gì — cherry-pick h
 
 Trade-off: smaller PRs (~2-3h each) vs more review cycles.
 
-**Pending user chốt before code starts:**
-- 3-PR split (recommended) hay 4-PR split?
-- After split chốt: implementer preflight PR-1A → code → review cycle.
+**Pending user chốt before code starts:** ~~3-PR vs 4-PR split~~ → user chốt **4-PR split** 2026-05-03.
+
+### #184 Wave 1 PR-1A — phase1_01 + phase1_02 (CODE_DONE local, push pending)
+
+**Branch / Commit:**
+- Branch `feature/admission-184-pr-1a` off parent `2864df20` (preflight tracking).
+- 2 migrations + 3 model updates + 1 unit test file.
+- Squash title (when PR opens): `[#184 Wave1] feat(schema): phase1_01_degree_level + phase1_02_bonus_rule`.
+
+**Migrations shipped:**
+1. `phase1_01_add_degree_level_fk_to_major_program.py`
+   - `revision='phase1_01'`, `down_revision='phase1_19b'` (chronological chain).
+   - ADD COLUMN `major_program.degree_level_id INT NULL FK → config_degree_level.id ON DELETE SET NULL`.
+   - Index `ix_major_program_degree_level_id` on FK column.
+   - Backfill SQL: JOIN `lower(trim(name))` between legacy text + config table; per-row idempotent guard `WHERE degree_level_id IS NULL`.
+   - Legacy `major_program.degree_level` text column STAYS — Phase 4 retire later.
+2. `phase1_02_add_bonus_rule_to_method_and_path.py`
+   - `revision='phase1_02'`, `down_revision='phase1_01'`.
+   - ADD COLUMN `admission_method.default_bonus_rule JSONB NULL`.
+   - ADD COLUMN `admission_path.bonus_rule_override JSONB NULL`.
+   - Pure additive — no backfill. Existing rows keep NULL = bonus disabled fallback per the precedence rule (PLAN line 787-789).
+
+**Model updates** (ORM parity với schema):
+- `MajorProgram.degree_level_id` (FK) added; legacy `degree_level` text comment updated to mark Phase 4 retire candidate.
+- `AdmissionMethod.default_bonus_rule` (JSONB) added with precedence-rule comment.
+- `AdmissionPath.bonus_rule_override` (JSONB) added with precedence-rule comment.
+
+**Tested / Rehearsed:**
+- Live dev DB roundtrip on parent branch HEAD: `alembic upgrade head` `phase1_19b → phase1_01 → phase1_02` clean; both columns + FK + index verified via `information_schema.columns`.
+- Backfill verified: 12 "Cao đẳng" + 8 "Trung cấp" rows correctly mapped to FK ids (22, 21).
+- Downgrade roundtrip: `alembic downgrade phase1_19b` → 0 columns left → re-upgrade `head` → 3 columns back. Symmetric.
+- Unit test `tests/unit/test_phase1_01_02_revision_chain.py`: **20 passed (0.98s)** locks: revision id + down_revision chain + linear (no branch labels) + idempotency guard substring + JSONB type + ORM model parity (FK column, JSONB columns, nullable=True) + downgrade DDL order + sanity upgrade/downgrade callables.
+- Live: AST lint 0 violations across 148 files; coverage script `--allow-deferred` exit 0 (no admission status / event surface touched in PR-1A).
+
+**Pending:**
+- Push approval từ user.
+- Sub-PR #205 open base `feat/admission-full-cutover`.
 
 ---
 


### PR DESCRIPTION
## Summary

#184 **Phase 1 Schema Wave 1 — first sub-PR** (4-PR split per user chốt 2026-05-03). Two simple `add_column` migrations on the `major_program` / `admission_method` / `admission_path` trio — pure schema additive, no API / FE / service changes. PR-1B' / PR-1C' / PR-1D ship the rest of Wave 1 in subsequent PRs off this commit.

* **Base**: `feat/admission-full-cutover` @ `2864df20`
* **Head**: `feature/admission-184-pr-1a` @ `83d05150`
* **Issue**: #184 Phase 1 Schema (7 sub-tasks of `[Phase 1 Code]` thematic — this PR closes 2 migration rows: `M-1-01` + `M-1-02`)
* **Atomic 1-PR** for the 2 simple migrations; PR-1B' (path advanced + BE/FE) / PR-1C' (subject + document_group) / PR-1D (audit + profile + config) ship separately.

## Migrations shipped

### `phase1_01_add_degree_level_fk_to_major_program.py`

* `revision="phase1_01"`, `down_revision="phase1_19b"` (chronological chain — phase1_19b is the existing head from B1 Casbin backfill).
* ADD COLUMN `major_program.degree_level_id INT NULL FK → config_degree_level.id ON DELETE SET NULL`.
* Index `ix_major_program_degree_level_id` on the FK column for join queries against `config_degree_level`.
* Backfill via `JOIN ... ON lower(trim(name)) = lower(trim(name))` so cosmetic whitespace / casing differences in the legacy text column don't drop the row from the backfill.
* Per-row idempotency guard `WHERE degree_level_id IS NULL` makes the backfill safe to re-run after a partial replay (PLAN line 2630).
* Legacy `major_program.degree_level` text column **STAYS** for Phase 4 retire — consumers that still rely on the text shape keep working unchanged.

### `phase1_02_add_bonus_rule_to_method_and_path.py`

* `revision="phase1_02"`, `down_revision="phase1_01"`.
* ADD COLUMN `admission_method.default_bonus_rule JSONB NULL`.
* ADD COLUMN `admission_path.bonus_rule_override JSONB NULL`.
* Pure additive — no backfill. NULL = bonus disabled fallback per the resolution rule (PLAN line 787-789):

```
effective_bonus_rule =
    path.bonus_rule_override
    ?? method.default_bonus_rule
    ?? {"apply_area_bonus": false, "apply_subject_bonus": false}
```

## Live dev DB roundtrip (pre-PR verification)

| Step | Result |
|---|---|
| `alembic upgrade head` from `phase1_19b` | clean: `phase1_19b → phase1_01 → phase1_02` |
| Schema verified via `information_schema.columns` | 3 new columns present (degree_level_id integer nullable + 2 JSONB nullable) |
| Index verified | `ix_major_program_degree_level_id` present |
| Legacy column preserved | `major_program.degree_level` (text, NOT NULL) untouched |
| Backfill data verified | 12 "Cao đẳng" → FK 22, 8 "Trung cấp" → FK 21, **0 NULL** post-backfill |
| `alembic downgrade phase1_19b` | clean: 3 columns dropped → 0 columns left |
| `alembic upgrade head` (re-run) | clean: 3 columns back, symmetric |

## Live prod data audit (qlts.tnpc.edu.vn via SSH)

Pre-PR risk audit confirms backfill JOIN simulation matches **100% of prod data**:

| Audit | Prod state | Risk |
|---|---|---|
| `major_program` rows | 20 (12 Cao đẳng + 8 Trung cấp) | ✅ Tiny — UPDATE instant |
| Backfill JOIN match | **100% map** — 20/20 rows match FK id (22/21) cleanly | ✅ Zero leftover NULL |
| `config_degree_level` seed (FK target) | 5 rows present (Trung cấp, Cao đẳng, Đại học, Thạc sĩ, Tiến sĩ) | ✅ All possible degree_level text values covered |
| `admission_method` rows | 3 | ✅ ADD JSONB instant |
| `admission_path` rows | 52 | ✅ ADD JSONB instant (~ms) |
| Prod alembic head | `admstrict01` | ⏳ Cold cutover — full chain applied at cutover deploy per RUNBOOK §3.5 + §7.2; PR-1A's 2 migrations join the bundle |

## ORM model parity

* `MajorProgram.degree_level_id` (FK) added; legacy `degree_level` text comment updated to flag Phase 4 retire candidate.
* `AdmissionMethod` imports `JSONB` and adds `default_bonus_rule` with the precedence-rule comment.
* `AdmissionPath` adds `bonus_rule_override` (JSONB) with the same precedence-rule comment.

Without the ORM updates, downstream queries that filter / select the new columns get an `AttributeError` at query construction time. PR-1B' and downstream wave can now reference these fields.

## Tests

* `tests/unit/test_phase1_01_02_revision_chain.py` (new, 20 case) locks:
  * Revision id + `down_revision` linear chain (4 case)
  * No branch labels / extra deps (2 case)
  * `phase1_01` DDL contract: `add_column` for `degree_level_id`, `create_index`, `lower(trim)` JOIN, idempotency guard substring, downgrade DDL order (5 case)
  * `phase1_02` DDL contract: 2 JSONB columns on correct tables, JSONB type (not plain JSON), no `op.execute(` body (no backfill), downgrade DDL order (5 case)
  * ORM model parity: 3 columns, FK, JSONB, nullable=True (3 case)
  * Sanity upgrade/downgrade callables (1 case)

**Target test result: 20 passed (0.98s).**

## Verification summary

* Target test: `20 passed (0.98s)` — `tests/unit/test_phase1_01_02_revision_chain.py`.
* AST lint live: `0 violations across 148 files` (exit 0).
* Coverage script live with `--allow-deferred` set: exit 0 (no admission status / event surface touched in PR-1A).
* Live dev DB roundtrip: clean upgrade → verify → downgrade → re-upgrade (symmetric).
* Live prod data audit: 100% backfill JOIN match (20/20 rows).

## Out of scope

* `phase1_03` / `phase1_05` / `phase1_06` / `phase1_07b` / `phase1_08` / `phase1_13` — ship in **PR-1B'** (path advanced + BE/FE) / **PR-1C'** (subject + document_group) / **PR-1D** (audit + profile + config) per the 4-PR Wave 1 split.
* Wave 1 backfill scripts (BF-status-history etc.) — Wave 5.
* Phase 4 retire of legacy `major_program.degree_level` text column — separate retire wave; new code paths use the FK from this PR onward.
* Optional `config_degree_level.duration_default_semesters` column per PLAN line 2620-2621 — left out of PR-1A scope; can ship alongside whichever PR consumes it.

## Test plan

- [ ] CI green on this PR (the new admission-contract-check.yml workflow doesn't trigger here — PR-1A only touches `app/models/`, `alembic/versions/`, `tests/unit/`, none of which match the workflow `paths:` filter).
- [ ] Post-merge: parent tracking commit on `feat/admission-full-cutover` citing the squash SHA.
- [ ] After all 4 Wave 1 PRs (1A + 1B' + 1C' + 1D) ship: re-eval Wave 2 plan vs Q1 chốt.
- [ ] Pre-cutover: rehearse full Phase 1 chain (admstrict01 → ... → phase1_19b → phase1_01 → ... → phase1_18) on staging clone D12-D14 per Q5 chốt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
