### PR TITLE
[#184 Wave1 PR-1B'-BE] feat(schema): phase1_03 applicable_to + method_quota + GIN

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase1_03_add_applicable_to_method_quota_to_path.py
+++ b/Backend_FastAPI/alembic/versions/phase1_03_add_applicable_to_method_quota_to_path.py
@@ -1,0 +1,161 @@
+"""phase1_03: add applicable_to + method_quota to admission_path
+
+Revision ID: phase1_03
+Revises: phase1_02
+Create Date: 2026-05-04
+
+#184 Wave 1 PR-1B' — third migration in Phase 1 Schema chain
+(PLAN §4 line 2636-2657). Two columns + one PostgreSQL ENUM type
++ one GIN index ship together because the two columns are one
+semantic unit (audience filter + per-method quota tier) and the
+PLAN file title spells them as a pair:
+``add_applicable_to_method_quota_to_path``.
+
+Schema additions
+----------------
+* ``admission_audience`` ENUM type — 5 candidate-education-level
+  buckets per PLAN line 605-606: ``POST_THCS``, ``POST_THPT``,
+  ``LIEN_THONG_TC``, ``LIEN_THONG_CD``, ``VLVH``. Created BEFORE
+  the column add so the array element type resolves cleanly. Down
+  migration drops the type AFTER the column to satisfy FK/dep
+  ordering.
+
+* ``admission_path.applicable_to`` ``admission_audience[]`` nullable.
+  Audience filter for storefront / admin path-list query. NULL =
+  legacy path applicable to every audience (Phase 1+2 contract):
+  query MUST preserve NULL via
+  ``WHERE (applicable_to IS NULL OR applicable_to @> ARRAY[:audience]::admission_audience[])``
+  per PLAN line 2649-2655. Phase 3 enables strict filter only after
+  validator gate "X path null applicable_to → admin set trước".
+
+* ``admission_path.method_quota`` integer nullable. Per-method
+  quota tier between annual `admission_round` quota (Phase 2) and
+  per-criteria `group_quota` (existing). NULL = no method-level
+  cap; service derives effective quota from round/group fallback.
+
+* ``ix_admission_path_applicable_to`` GIN index on
+  ``applicable_to``. REQUIRED because the query contract (PLAN
+  line 2646-2657) is ``@>`` containment and ``&&`` overlap. The
+  ANTI-PATTERN ``WHERE :audience = ANY(applicable_to)`` produces
+  correct results but the Postgres planner cannot pick GIN for
+  ``= ANY(arr)`` → seq-scan on every storefront audience filter.
+  Smoke test (staging clone D12-D14): ``EXPLAIN ANALYZE`` must
+  show ``Bitmap Index Scan on ix_admission_path_applicable_to``
+  for the audience-filter endpoint; ``Seq Scan`` means the
+  repository is using the wrong operator.
+
+Idempotency
+-----------
+Pure additive — no backfill statements, no UPDATE/DELETE/INSERT
+gated WHERE clauses needed. Re-applying upgrade after partial
+failure: the ``IF NOT EXISTS`` guards on the ENUM type creation
+catch the early failure mode where the type was created but the
+column add raised; the column add itself raises a clear
+``DuplicateColumn`` if already present (alembic operator does
+not silently no-op, but that signal is the cleanest way to flag
+the partial-state bug for ops to bisect).
+
+Down-revision chain: ``phase1_19b → phase1_01 → phase1_02 →
+phase1_03``.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_03"
+down_revision: Union[str, None] = "phase1_02"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# ENUM values per PLAN line 605-606. Frozen here as the migration
+# is the source-of-truth for the type definition; the SQLAlchemy
+# model mirrors these values via ``postgresql.ENUM(name=...,
+# create_type=False)`` so model drift can't silently extend the type.
+ADMISSION_AUDIENCE_VALUES: tuple[str, ...] = (
+    "POST_THCS",
+    "POST_THPT",
+    "LIEN_THONG_TC",
+    "LIEN_THONG_CD",
+    "VLVH",
+)
+
+
+def upgrade() -> None:
+    # 1. Create the admission_audience ENUM type. ``checkfirst=True``
+    #    (alembic default for ENUM ``create``) makes the call
+    #    idempotent on partial-failure replay.
+    audience_enum = postgresql.ENUM(
+        *ADMISSION_AUDIENCE_VALUES,
+        name="admission_audience",
+        create_type=False,
+    )
+    audience_enum.create(op.get_bind(), checkfirst=True)
+
+    # 2. admission_path.applicable_to — array of admission_audience.
+    #    NULL = legacy path / no audience filter (Phase 1+2 query
+    #    contract preserves NULL via OR branch).
+    op.add_column(
+        "admission_path",
+        sa.Column(
+            "applicable_to",
+            postgresql.ARRAY(audience_enum),
+            nullable=True,
+            comment=(
+                "Audience filter ARRAY of admission_audience enum. "
+                "NULL = applicable to every audience (legacy path / "
+                "Phase 1+2 contract). Query MUST use @> containment "
+                "or && overlap (NEVER = ANY) to hit the GIN index."
+            ),
+        ),
+    )
+
+    # 3. admission_path.method_quota — per-method quota tier.
+    #    NULL = no method-level cap (round/group fallback).
+    op.add_column(
+        "admission_path",
+        sa.Column(
+            "method_quota",
+            sa.Integer(),
+            nullable=True,
+            comment=(
+                "Per-method admission quota. NULL = inherit from "
+                "round.admit_quota (Phase 2). Service-layer guard "
+                "(Phase 2 line 3973): sum(method_quota for path in "
+                "round.paths) <= round.admit_quota."
+            ),
+        ),
+    )
+
+    # 4. GIN index for the @>/&& query contract. Required for the
+    #    storefront audience filter endpoint to hit an index path.
+    op.create_index(
+        "ix_admission_path_applicable_to",
+        "admission_path",
+        ["applicable_to"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    # Inverse order — index → column → enum type.
+    op.drop_index(
+        "ix_admission_path_applicable_to",
+        table_name="admission_path",
+    )
+    op.drop_column("admission_path", "method_quota")
+    op.drop_column("admission_path", "applicable_to")
+
+    # Drop the ENUM type LAST so PG doesn't error on type-still-in-use
+    # (the ARRAY column referenced it). ``checkfirst=True`` keeps the
+    # downgrade re-runnable.
+    audience_enum = postgresql.ENUM(
+        *ADMISSION_AUDIENCE_VALUES,
+        name="admission_audience",
+        create_type=False,
+    )
+    audience_enum.drop(op.get_bind(), checkfirst=True)

--- a/Backend_FastAPI/app/models/admission_config/admission_path.py
+++ b/Backend_FastAPI/app/models/admission_config/admission_path.py
@@ -13,7 +13,7 @@ This is the CENTRAL ENTITY for:
 
 import sqlalchemy as sa
 from sqlalchemy import CheckConstraint, Column, Integer, String, Boolean, ForeignKey, DateTime, UniqueConstraint, Numeric
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, ENUM, JSONB
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
@@ -156,6 +156,42 @@ class AdmissionPath(Base):
             "Effective = SAFE_MINOR_CORRECTION_FIELDS ∩ this list. "
             "Live config (not snapshotted to applied_rules)."
         ),
+    )
+
+    # phase1_03 (#184 Wave 1 PR-1B') — audience filter ARRAY of
+    # admission_audience enum. NULL = legacy / applicable to every
+    # audience (Phase 1+2 query contract preserves NULL via OR
+    # branch). Query MUST use @> containment / && overlap; NEVER
+    # = ANY(arr) (would not hit the ix_admission_path_applicable_to
+    # GIN index — see PLAN line 2646-2657).
+    # ENUM type is created in alembic phase1_03 with create_type=False
+    # mirrored here so model autogenerate doesn't try to redeclare it.
+    applicable_to = Column(
+        ARRAY(
+            ENUM(
+                "POST_THCS",
+                "POST_THPT",
+                "LIEN_THONG_TC",
+                "LIEN_THONG_CD",
+                "VLVH",
+                name="admission_audience",
+                create_type=False,
+            )
+        ),
+        nullable=True,
+        comment="Audience filter ARRAY of admission_audience enum. "
+                "NULL = applicable to every audience.",
+    )
+
+    # phase1_03 (#184 Wave 1 PR-1B') — per-method quota tier. NULL =
+    # no method-level cap; effective quota falls back to round
+    # (Phase 2) / group_quota. Service-layer guard tier-3 (PLAN
+    # line 3973) sum(method_quota) <= round.admit_quota.
+    method_quota = Column(
+        Integer,
+        nullable=True,
+        comment="Per-method admission quota. NULL = inherit from "
+                "round.admit_quota fallback.",
     )
 
     # phase1_02 (#184 Wave 1) — path-level bonus rule override above

--- a/Backend_FastAPI/app/repositories/admission_path_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_path_repository.py
@@ -8,8 +8,9 @@ Provides data access for AdmissionPath entities with:
 - No business logic (pure data access)
 """
 
-from typing import Iterable, List, Optional, Tuple
-from sqlalchemy import select, func, distinct
+from typing import Iterable, List, Optional, Sequence, Tuple
+from sqlalchemy import select, func, distinct, or_, cast
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -25,6 +26,24 @@ from app.models.admission_config import (
 from app.models.offering_academic_info import OfferingAcademicInfo
 from app.models.program_offering import ProgramOffering
 from app.repositories.base import BaseRepository
+
+
+# phase1_03 (#184 Wave 1 PR-1B') — typed array element for ``@>`` /
+# ``&&`` casts. ``create_type=False`` because the migration owns the
+# DDL. ``literal_column("admission_audience")`` was the first cut but
+# fails compile (AttributeError on ``_variant_mapping`` per Codex
+# review on PR-1B'); the real type expression is needed for SQLA to
+# render the proper ``CAST(... AS admission_audience[])``.
+_AUDIENCE_ENUM_TYPE = postgresql.ENUM(
+    "POST_THCS",
+    "POST_THPT",
+    "LIEN_THONG_TC",
+    "LIEN_THONG_CD",
+    "VLVH",
+    name="admission_audience",
+    create_type=False,
+)
+_AUDIENCE_ARRAY_TYPE = postgresql.ARRAY(_AUDIENCE_ENUM_TYPE)
 
 
 class AdmissionPathRepository(BaseRepository[AdmissionPath]):
@@ -141,6 +160,112 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
         )
         result = await self.db.execute(query)
         return result.scalars().first()
+
+    async def list_paths_by_audience(
+        self,
+        audience: str,
+        *,
+        academic_info_id: Optional[int] = None,
+        include_legacy_null: bool = True,
+    ) -> List[AdmissionPath]:
+        """List active paths visible to a single ``admission_audience``.
+
+        phase1_03 (#184 Wave 1 PR-1B') — uses PostgreSQL containment
+        operator ``@>`` so the query hits the
+        ``ix_admission_path_applicable_to`` GIN index. NEVER rewrite
+        this as ``WHERE :audience = ANY(applicable_to)`` — that
+        operator yields the same logical result but the planner
+        cannot pick a GIN index for ``= ANY(arr)``, so the storefront
+        endpoint would seq-scan the entire ``admission_path`` table
+        (PLAN line 2646-2657 anti-pattern).
+
+        ``include_legacy_null=True`` (default) ORs in paths whose
+        ``applicable_to`` is NULL — required for Phase 1+2 because
+        legacy / not-yet-backfilled paths must remain visible.
+        Phase 3 flips this to ``False`` after the validator gate
+        ("X path null applicable_to → admin set trước") completes.
+        """
+        # CAST([:audience] AS admission_audience[]) — typed PG ENUM
+        # array so the @> operator hits the GIN index. Using
+        # ``literal_column("admission_audience")`` for the inner type
+        # fails compile on SQLAlchemy 2.x; the real type expression
+        # ``postgresql.ARRAY(postgresql.ENUM(...))`` is required.
+        audience_array = cast([audience], _AUDIENCE_ARRAY_TYPE)
+        contains = AdmissionPath.applicable_to.op("@>")(audience_array)
+
+        if include_legacy_null:
+            audience_filter = or_(
+                AdmissionPath.applicable_to.is_(None),
+                contains,
+            )
+        else:
+            audience_filter = contains
+
+        query = (
+            select(AdmissionPath)
+            .where(audience_filter)
+            .options(
+                selectinload(AdmissionPath.admission_method),
+                selectinload(AdmissionPath.academic_info)
+                .selectinload(OfferingAcademicInfo.offering)
+                .selectinload(ProgramOffering.program),
+            )
+            .order_by(AdmissionPath.display_order, AdmissionPath.id)
+        )
+        if academic_info_id is not None:
+            query = query.where(AdmissionPath.academic_info_id == academic_info_id)
+
+        result = await self.db.execute(query)
+        return list(result.scalars().all())
+
+    async def list_paths_by_audiences_overlap(
+        self,
+        audiences: Sequence[str],
+        *,
+        academic_info_id: Optional[int] = None,
+        include_legacy_null: bool = True,
+    ) -> List[AdmissionPath]:
+        """List active paths whose audience overlaps any of ``audiences``.
+
+        phase1_03 (#184 Wave 1 PR-1B') — uses PostgreSQL overlap
+        operator ``&&`` so the query hits the GIN index. Same
+        anti-pattern guard as ``list_paths_by_audience``: NEVER use
+        ``= ANY()`` (planner can't pick GIN).
+
+        Empty input → returns no paths (matches "audience filter
+        active but caller passed no buckets" semantic). Caller
+        wanting "all audiences" should not invoke this method.
+        """
+        if not audiences:
+            return []
+
+        audience_array = cast(list(audiences), _AUDIENCE_ARRAY_TYPE)
+        overlaps = AdmissionPath.applicable_to.op("&&")(audience_array)
+
+        if include_legacy_null:
+            audience_filter = or_(
+                AdmissionPath.applicable_to.is_(None),
+                overlaps,
+            )
+        else:
+            audience_filter = overlaps
+
+        query = (
+            select(AdmissionPath)
+            .where(audience_filter)
+            .options(
+                selectinload(AdmissionPath.admission_method),
+                selectinload(AdmissionPath.academic_info)
+                .selectinload(OfferingAcademicInfo.offering)
+                .selectinload(ProgramOffering.program),
+            )
+            .order_by(AdmissionPath.display_order, AdmissionPath.id)
+        )
+        if academic_info_id is not None:
+            query = query.where(AdmissionPath.academic_info_id == academic_info_id)
+
+        result = await self.db.execute(query)
+        return list(result.scalars().all())
     
     async def get_active_paths_by_offering_id(
         self,

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -49,6 +49,69 @@ DocumentSource = Literal["shared", "method_override"]
 
 
 # =============================================================================
+# AUDIENCE ENUM (phase1_03 / #184 Wave 1 PR-1B')
+# =============================================================================
+
+# admission_audience PG ENUM. Values mirror alembic phase1_03 +
+# PLAN line 605-606. Frozen here as a Literal so Pydantic rejects
+# unknown values at the API boundary, and so the FE Zod can pin the
+# same union shape via a generated type. Adding a new audience =
+# update both this Literal AND the alembic migration AND the FE
+# Zod schema in lockstep (no silent extension via direct DB ALTER).
+AdmissionAudience = Literal[
+    "POST_THCS",
+    "POST_THPT",
+    "LIEN_THONG_TC",
+    "LIEN_THONG_CD",
+    "VLVH",
+]
+
+
+# =============================================================================
+# BONUS RULE OVERRIDE SHAPE (phase1_02 wired in PR-1B' per Codex P2)
+# =============================================================================
+
+
+class BonusRuleOverride(BaseModel):
+    """Path-level / method-default bonus rule shape.
+
+    PLAN line 768-789. Shape is shared by
+    ``AdmissionMethod.default_bonus_rule`` and
+    ``AdmissionPath.bonus_rule_override`` (path takes precedence).
+
+    Per Codex P2 review on PR-1B': we ship a structured Pydantic
+    shape rather than a raw JSONB blob so the admin UI can render
+    a typed form (3 fields) and the API rejects malformed payload
+    at the boundary instead of letting bad shapes reach the
+    scoring engine.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    apply_area_bonus: bool = Field(
+        description=(
+            "Apply the area bonus (KV1 / KV2_NT / KV2 / KV3) when "
+            "computing the effective score for this path."
+        ),
+    )
+    apply_subject_bonus: bool = Field(
+        description=(
+            "Apply per-subject bonus (priority objects 01..07) when "
+            "computing the effective score."
+        ),
+    )
+    max_total_bonus: Optional[float] = Field(
+        default=None,
+        ge=0,
+        le=10,
+        description=(
+            "Cap on the combined bonus (area + subject) in points. "
+            "NULL = no cap. Range 0..10 matches the GPA scale."
+        ),
+    )
+
+
+# =============================================================================
 # NESTED SCHEMAS (for response)
 # =============================================================================
 
@@ -166,6 +229,35 @@ class AdmissionPathCreate(BaseModel):
         ),
     )
 
+    # phase1_03 (#184 Wave 1 PR-1B') — audience filter. Optional on
+    # create; admin sets later via update once the storefront Phase
+    # 3 validator gate is enabled. NULL = legacy / applicable to
+    # every audience (Phase 1+2 query contract preserves NULL).
+    applicable_to: Optional[List[AdmissionAudience]] = Field(
+        default=None,
+        description=(
+            "Audience filter list. NULL = applicable to every audience. "
+            "Phase 3 enables strict filter only after admin sets this."
+        ),
+    )
+    method_quota: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Per-method admission quota. NULL = no method-level cap; "
+            "round.admit_quota / group_quota provide fallback."
+        ),
+    )
+    # phase1_02 wired in PR-1B' — typed shape (NOT raw JSONB) per
+    # Codex P2. NULL = inherit from admission_method.default_bonus_rule.
+    bonus_rule_override: Optional[BonusRuleOverride] = Field(
+        default=None,
+        description=(
+            "Path-level override above admission_method.default_bonus_rule. "
+            "NULL = inherit from method default."
+        ),
+    )
+
     _v_minor_correction_allowlist = field_validator(
         "minor_correction_allowed_fields"
     )(_validate_minor_correction_allowlist)
@@ -200,6 +292,35 @@ class AdmissionPathUpdate(BaseModel):
             "Replace the per-path correction allowlist. Admin-only — "
             "service raises BusinessRuleViolation for non-admin callers. "
             "Pass `[]` to clear; omit to leave unchanged."
+        ),
+    )
+
+    # phase1_03 — Optional on update so partial PATCH-style updates
+    # don't accidentally clear the audience filter / quota. Pass an
+    # explicit empty list to ``applicable_to`` to clear, or pass
+    # ``None`` to leave unchanged. Same pattern for ``method_quota``
+    # and ``bonus_rule_override`` — None means "do not touch", which
+    # the service distinguishes via ``model_dump(exclude_unset=True)``.
+    applicable_to: Optional[List[AdmissionAudience]] = Field(
+        default=None,
+        description=(
+            "Replace the audience filter. Pass `[]` to clear (NULL "
+            "= every audience), or omit to leave unchanged."
+        ),
+    )
+    method_quota: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Replace per-method quota. Pass 0 to mark exhausted, "
+            "or omit to leave unchanged."
+        ),
+    )
+    bonus_rule_override: Optional[BonusRuleOverride] = Field(
+        default=None,
+        description=(
+            "Replace path-level bonus override. Pass `null` to fall "
+            "back to method default, or omit to leave unchanged."
         ),
     )
 
@@ -289,6 +410,29 @@ class AdmissionPathResponse(BaseModel):
         description=(
             "Per-path allowlist for post-approval minor corrections. "
             "Subset of SAFE_MINOR_CORRECTION_FIELDS."
+        ),
+    )
+
+    # phase1_03 — REQUIRED in the response (non-default) so Zod parse
+    # on FE side fails loudly when the BE forgets to emit the field
+    # rather than silently rendering an empty audience filter / NULL
+    # quota. Following the same pattern as
+    # ``allow_unverified_submission`` / ``minor_correction_allowed_fields``.
+    applicable_to: Optional[List[AdmissionAudience]] = Field(
+        description=(
+            "Audience filter list, or NULL = applicable to every "
+            "audience (Phase 1+2 legacy)."
+        ),
+    )
+    method_quota: Optional[int] = Field(
+        description=(
+            "Per-method admission quota, or NULL if no cap configured."
+        ),
+    )
+    bonus_rule_override: Optional[BonusRuleOverride] = Field(
+        description=(
+            "Path-level bonus override, or NULL if inherited from "
+            "admission_method.default_bonus_rule."
         ),
     )
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2770,6 +2770,24 @@ async def create_profile(
         "allow_unverified_submission": bool(
             getattr(admission_path, "allow_unverified_submission", False)
         ),
+
+        # =====================================================================
+        # GROUP 8: phase1_03 / phase1_02 wired (#184 Wave 1 PR-1B')
+        # =====================================================================
+        # Snapshot the audience filter + per-method quota + bonus rule
+        # override at profile creation so later admin changes to the path
+        # don't retroactively re-classify or re-cap profiles already in
+        # flight. Read sites: scoring engine (bonus_rule_override
+        # precedence), quota guard (method_quota tier-3 — Phase 2),
+        # storefront audience filter (applicable_to legacy NULL fallback).
+        # NULL passes through as None so consumers can rely on the
+        # ``getattr`` / ``.get()`` is-None contract instead of probing
+        # presence.
+        "applicable_to": list(admission_path.applicable_to)
+        if getattr(admission_path, "applicable_to", None)
+        else None,
+        "method_quota": getattr(admission_path, "method_quota", None),
+        "bonus_rule_override": getattr(admission_path, "bonus_rule_override", None),
     }
 
 

--- a/Backend_FastAPI/tests/unit/test_admission_path_repository_audience.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_repository_audience.py
@@ -1,0 +1,242 @@
+"""Unit tests for ``AdmissionPathRepository`` audience filter
+methods (#184 Wave 1 PR-1B' / phase1_03).
+
+Operator-contract guard tests — the production semantic
+``WHERE :audience = ANY(applicable_to)`` is logically equivalent
+to ``applicable_to @> ARRAY[:audience]`` BUT the Postgres planner
+cannot pick a GIN index for ``= ANY(arr)``, so the storefront
+audience filter would seq-scan the entire ``admission_path``
+table. PLAN line 2646-2657 mandates ``@>`` / ``&&`` operators.
+
+This file inspects the repository source text + the rendered SQL
+of the two new methods to lock the operator contract:
+
+* ``list_paths_by_audience`` MUST emit ``@>`` containment.
+* ``list_paths_by_audiences_overlap`` MUST emit ``&&`` overlap.
+* Neither method may use ``.any(`` (SQLAlchemy operator that
+  compiles to ``= ANY(arr)``).
+
+What does NOT live here:
+* End-to-end SQL execution + EXPLAIN plan — staging clone D12-D14
+  smoke per PLAN line 2656.
+* DB migration shape — see ``test_phase1_03_revision_chain.py``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.repositories import admission_path_repository as repo_module
+from app.repositories.admission_path_repository import AdmissionPathRepository
+
+
+_REPO_FILE = Path(repo_module.__file__).resolve()
+
+
+# ---------------------------------------------------------------------------
+# 1. Anti-pattern guard — operator source contract
+# ---------------------------------------------------------------------------
+
+
+def test_repository_does_not_use_any_operator() -> None:
+    """``.any(`` would compile to ``WHERE val = ANY(arr)`` which
+    cannot use the GIN index. Anti-pattern per PLAN line 2657.
+
+    The grep is intentionally broad — anywhere in the file. Any
+    future audience-filter method that introduces ``.any(`` would
+    silently degrade the storefront query to a seq-scan; this
+    static guard catches it pre-merge."""
+    src = _REPO_FILE.read_text()
+    assert ".any(" not in src, (
+        "Found ``.any(`` in admission_path_repository.py — this is the "
+        "= ANY(arr) anti-pattern per PLAN line 2657. Use @> containment "
+        "(applicable_to.op('@>')(...)) or && overlap instead so the "
+        "ix_admission_path_applicable_to GIN index is reachable."
+    )
+
+
+def test_repository_uses_containment_operator() -> None:
+    """The ``@>`` operator is the canonical containment for the
+    single-audience filter contract per PLAN line 2647."""
+    src = _REPO_FILE.read_text()
+    assert ".op(\"@>\")" in src, (
+        "list_paths_by_audience must use applicable_to.op('@>')(...)"
+    )
+
+
+def test_repository_uses_overlap_operator() -> None:
+    """The ``&&`` operator is the canonical overlap for the
+    multi-audience filter contract per PLAN line 2648."""
+    src = _REPO_FILE.read_text()
+    assert ".op(\"&&\")" in src, (
+        "list_paths_by_audiences_overlap must use applicable_to.op('&&')(...)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Method existence + signature
+# ---------------------------------------------------------------------------
+
+
+def test_list_paths_by_audience_exists() -> None:
+    assert hasattr(AdmissionPathRepository, "list_paths_by_audience")
+    assert callable(AdmissionPathRepository.list_paths_by_audience)
+
+
+def test_list_paths_by_audiences_overlap_exists() -> None:
+    assert hasattr(AdmissionPathRepository, "list_paths_by_audiences_overlap")
+    assert callable(AdmissionPathRepository.list_paths_by_audiences_overlap)
+
+
+def test_list_paths_by_audience_signature_includes_legacy_null_flag() -> None:
+    """``include_legacy_null`` is the Phase-3 cutover knob — when
+    flipped to False, the OR NULL branch drops out of the WHERE
+    clause and the storefront only returns paths with explicit
+    audience set. Phase 1+2 contract: default True."""
+    import inspect
+
+    sig = inspect.signature(AdmissionPathRepository.list_paths_by_audience)
+    params = sig.parameters
+    assert "include_legacy_null" in params
+    assert params["include_legacy_null"].default is True
+
+
+def test_list_paths_by_audiences_overlap_signature_includes_legacy_null_flag() -> None:
+    import inspect
+
+    sig = inspect.signature(
+        AdmissionPathRepository.list_paths_by_audiences_overlap
+    )
+    params = sig.parameters
+    assert "include_legacy_null" in params
+    assert params["include_legacy_null"].default is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty-input contract — overlap with no audiences = no rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_overlap_with_empty_input_returns_empty_list() -> None:
+    """Empty ``audiences`` argument = "filter active but caller passed
+    no buckets" — should return [] without hitting the DB. Caller
+    wanting "all audiences" should not invoke this method."""
+    # No DB session needed — the method short-circuits.
+    repo = AdmissionPathRepository.__new__(AdmissionPathRepository)
+    result = await repo.list_paths_by_audiences_overlap([])
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Source contract — preserve NULL via OR branch when flag True
+# ---------------------------------------------------------------------------
+
+
+def test_repository_preserves_null_via_or_branch() -> None:
+    """Phase 1+2 query contract (PLAN line 2649-2655) — legacy paths
+    with ``applicable_to IS NULL`` must remain visible. Static check
+    that the OR NULL branch lives in the source; runtime smoke
+    against staging clone covers the planner behavior."""
+    src = _REPO_FILE.read_text()
+    # The two methods both use ``or_(AdmissionPath.applicable_to.is_(None), ...)``
+    assert "or_(" in src
+    assert "AdmissionPath.applicable_to.is_(None)" in src
+
+
+# ---------------------------------------------------------------------------
+# 5. Compile-dialect contract — runtime SQL must render correctly
+# ---------------------------------------------------------------------------
+#
+# Codex P1 catch on PR-1B' first cut: the source-grep tests above all
+# passed even though the original ``literal_column("admission_audience")``
+# cast failed compile with ``AttributeError: ... '_variant_mapping'``.
+# Source grep is necessary but not sufficient — we also need to
+# materialize the SQL via the postgresql dialect so a future cast-
+# style change can't pass tests while breaking runtime.
+
+
+def _compile_select_with_filter(method_name: str, *args, **kwargs) -> str:
+    """Run the repository method body up to the SQL-compile step.
+
+    Both methods build the same shape: ``select(AdmissionPath).where(<filter>)``.
+    We use SQLAlchemy's postgresql dialect compile directly to render
+    the final SQL string with literal_binds so the rendered output
+    can be substring-checked for the operator + cast contract.
+    """
+    from sqlalchemy import select
+    from sqlalchemy.dialects import postgresql
+    from sqlalchemy import cast as sql_cast, or_
+
+    from app.models.admission_config.admission_path import AdmissionPath
+    from app.repositories.admission_path_repository import _AUDIENCE_ARRAY_TYPE
+
+    if method_name == "contains":
+        audience = args[0]
+        cond = AdmissionPath.applicable_to.op("@>")(
+            sql_cast([audience], _AUDIENCE_ARRAY_TYPE)
+        )
+    elif method_name == "overlap":
+        audiences = args[0]
+        cond = AdmissionPath.applicable_to.op("&&")(
+            sql_cast(list(audiences), _AUDIENCE_ARRAY_TYPE)
+        )
+    else:
+        raise AssertionError(f"unknown method {method_name}")
+
+    if kwargs.get("include_legacy_null", True):
+        where_clause = or_(AdmissionPath.applicable_to.is_(None), cond)
+    else:
+        where_clause = cond
+
+    stmt = select(AdmissionPath.id).where(where_clause)
+    return str(
+        stmt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def test_contains_compiles_with_typed_array_cast() -> None:
+    """``list_paths_by_audience`` must render
+    ``CAST(ARRAY[...] AS admission_audience[])`` with the @> operator.
+    Bare ``literal_column`` (the first-cut bug) raises AttributeError
+    on ``_variant_mapping`` — this test catches that regression."""
+    sql = _compile_select_with_filter("contains", "POST_THPT")
+    assert "@>" in sql
+    assert "CAST(ARRAY[" in sql
+    assert "AS admission_audience[]" in sql
+    # Anti-pattern: ``= ANY(arr)`` would pass a logically-equivalent
+    # query but cannot use the GIN index.
+    assert " ANY(" not in sql.upper()
+
+
+def test_overlap_compiles_with_typed_array_cast() -> None:
+    """``list_paths_by_audiences_overlap`` must render
+    ``CAST(ARRAY[...] AS admission_audience[])`` with the && operator."""
+    sql = _compile_select_with_filter("overlap", ["POST_THPT", "LIEN_THONG_TC"])
+    assert "&&" in sql
+    assert "CAST(ARRAY[" in sql
+    assert "AS admission_audience[]" in sql
+    assert " ANY(" not in sql.upper()
+
+
+def test_contains_preserves_legacy_null_in_compiled_sql() -> None:
+    """Phase 1+2 contract (PLAN line 2649-2655) — when
+    ``include_legacy_null=True`` (default), the rendered SQL must OR
+    in the NULL branch so paths not yet backfilled stay visible."""
+    sql = _compile_select_with_filter("contains", "POST_THPT")
+    assert "applicable_to IS NULL" in sql
+
+
+def test_contains_drops_null_branch_when_strict_filter_enabled() -> None:
+    """Phase 3 cutover knob — when ``include_legacy_null=False``, the
+    NULL branch is gone. Storefront after the validator gate uses
+    this mode."""
+    sql = _compile_select_with_filter(
+        "contains", "POST_THPT", include_legacy_null=False
+    )
+    assert "applicable_to IS NULL" not in sql
+    assert "@>" in sql

--- a/Backend_FastAPI/tests/unit/test_admission_path_schema_bonus_rule_override.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_schema_bonus_rule_override.py
@@ -1,0 +1,327 @@
+"""Unit tests for ``BonusRuleOverride`` Pydantic shape + the 3 new
+fields on ``AdmissionPathCreate`` / ``AdmissionPathUpdate`` /
+``AdmissionPathResponse`` (#184 Wave 1 PR-1B' / phase1_03 + wired
+phase1_02).
+
+Codex P2 review on PR-1B' chốt: ``bonus_rule_override`` ships as a
+typed Pydantic shape (``apply_area_bonus`` / ``apply_subject_bonus``
+/ ``max_total_bonus``) instead of a raw JSONB blob. This file
+locks:
+
+* The 3-field shape — exact field set, types, defaults, range guards.
+* ``extra="forbid"`` — Pydantic rejects unknown keys at the
+  boundary so the admin UI can't silently round-trip stray fields
+  the scoring engine ignores.
+* The Create / Update / Response wiring — the 3 new fields
+  (``applicable_to`` / ``method_quota`` / ``bonus_rule_override``)
+  are present, with the correct optional / required semantic.
+
+What does NOT live here:
+* DB migration shape — see ``test_phase1_03_revision_chain.py``.
+* Repository operator (@>/&&) — see
+  ``test_admission_path_repository_audience.py``.
+* applied_rules snapshot — see ``test_admission_service_applied_rules_phase1_03.py``.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.admission_path import (
+    AdmissionAudience,
+    AdmissionPathCreate,
+    AdmissionPathResponse,
+    AdmissionPathUpdate,
+    BonusRuleOverride,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. BonusRuleOverride — shape + validation
+# ---------------------------------------------------------------------------
+
+
+def test_bonus_rule_override_accepts_all_three_fields() -> None:
+    payload = {
+        "apply_area_bonus": True,
+        "apply_subject_bonus": False,
+        "max_total_bonus": 2.75,
+    }
+    rule = BonusRuleOverride.model_validate(payload)
+    assert rule.apply_area_bonus is True
+    assert rule.apply_subject_bonus is False
+    assert rule.max_total_bonus == pytest.approx(2.75)
+
+
+def test_bonus_rule_override_max_total_bonus_optional_null() -> None:
+    """``max_total_bonus`` is the only optional field — NULL = no
+    cap on the combined area + subject bonus."""
+    rule = BonusRuleOverride.model_validate(
+        {"apply_area_bonus": False, "apply_subject_bonus": False}
+    )
+    assert rule.max_total_bonus is None
+
+
+def test_bonus_rule_override_requires_apply_area_bonus() -> None:
+    """``apply_area_bonus`` is required — admin form must commit a
+    boolean choice rather than implying False via omission."""
+    with pytest.raises(ValidationError):
+        BonusRuleOverride.model_validate(
+            {"apply_subject_bonus": True, "max_total_bonus": 1.0}
+        )
+
+
+def test_bonus_rule_override_requires_apply_subject_bonus() -> None:
+    with pytest.raises(ValidationError):
+        BonusRuleOverride.model_validate(
+            {"apply_area_bonus": True, "max_total_bonus": 1.0}
+        )
+
+
+def test_bonus_rule_override_max_total_bonus_lower_bound() -> None:
+    """Lower bound 0 — bonus is additive; negative makes no sense."""
+    with pytest.raises(ValidationError):
+        BonusRuleOverride.model_validate(
+            {
+                "apply_area_bonus": True,
+                "apply_subject_bonus": True,
+                "max_total_bonus": -0.1,
+            }
+        )
+
+
+def test_bonus_rule_override_max_total_bonus_upper_bound() -> None:
+    """Upper bound 10 — matches the GPA scale; > 10 means the rule
+    is effectively unbounded and admin should pass NULL instead."""
+    with pytest.raises(ValidationError):
+        BonusRuleOverride.model_validate(
+            {
+                "apply_area_bonus": True,
+                "apply_subject_bonus": True,
+                "max_total_bonus": 10.01,
+            }
+        )
+
+
+def test_bonus_rule_override_rejects_extra_keys() -> None:
+    """``extra="forbid"`` (Codex P2 rationale) — admin form must
+    not silently round-trip stray fields. Any key the scoring
+    engine doesn't read is a bug, not a feature."""
+    with pytest.raises(ValidationError):
+        BonusRuleOverride.model_validate(
+            {
+                "apply_area_bonus": True,
+                "apply_subject_bonus": True,
+                "max_total_bonus": 1.0,
+                "stray_key": "ignored_silently?",
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. AdmissionPathCreate — 3 new fields wired
+# ---------------------------------------------------------------------------
+
+
+def _create_baseline_payload() -> dict:
+    """Minimum valid Create payload — extracted so each test focuses
+    on the field under inspection without re-stating the boilerplate."""
+    return {
+        "academic_info_id": 1,
+        "admission_method_id": 1,
+    }
+
+
+def test_create_accepts_applicable_to_audience_list() -> None:
+    payload = _create_baseline_payload() | {
+        "applicable_to": ["POST_THPT", "LIEN_THONG_TC"],
+    }
+    obj = AdmissionPathCreate.model_validate(payload)
+    assert obj.applicable_to == ["POST_THPT", "LIEN_THONG_TC"]
+
+
+def test_create_rejects_unknown_audience() -> None:
+    """Unknown audience = enum drift; FE must update lockstep with BE."""
+    payload = _create_baseline_payload() | {
+        "applicable_to": ["NOT_A_REAL_AUDIENCE"],
+    }
+    with pytest.raises(ValidationError):
+        AdmissionPathCreate.model_validate(payload)
+
+
+def test_create_applicable_to_defaults_to_none() -> None:
+    """NULL on the wire = applicable to every audience (Phase 1+2
+    contract). Optional on Create — admin sets via update later."""
+    obj = AdmissionPathCreate.model_validate(_create_baseline_payload())
+    assert obj.applicable_to is None
+
+
+def test_create_method_quota_accepts_zero() -> None:
+    """0 is a legitimate value (admin marks the method exhausted)."""
+    payload = _create_baseline_payload() | {"method_quota": 0}
+    obj = AdmissionPathCreate.model_validate(payload)
+    assert obj.method_quota == 0
+
+
+def test_create_method_quota_rejects_negative() -> None:
+    payload = _create_baseline_payload() | {"method_quota": -1}
+    with pytest.raises(ValidationError):
+        AdmissionPathCreate.model_validate(payload)
+
+
+def test_create_bonus_rule_override_passes_through_typed() -> None:
+    payload = _create_baseline_payload() | {
+        "bonus_rule_override": {
+            "apply_area_bonus": True,
+            "apply_subject_bonus": True,
+            "max_total_bonus": 2.0,
+        },
+    }
+    obj = AdmissionPathCreate.model_validate(payload)
+    assert isinstance(obj.bonus_rule_override, BonusRuleOverride)
+    assert obj.bonus_rule_override.max_total_bonus == 2.0
+
+
+def test_create_bonus_rule_override_rejects_raw_blob() -> None:
+    """Raw JSONB blob (no shape) must be rejected — Codex P2."""
+    payload = _create_baseline_payload() | {
+        "bonus_rule_override": {"random_blob": "no_shape"},
+    }
+    with pytest.raises(ValidationError):
+        AdmissionPathCreate.model_validate(payload)
+
+
+# ---------------------------------------------------------------------------
+# 3. AdmissionPathUpdate — partial PATCH semantic
+# ---------------------------------------------------------------------------
+
+
+def test_update_all_three_fields_optional() -> None:
+    """Update with empty body = leave everything unchanged. Service
+    distinguishes "key absent" vs "key=null" via
+    model_dump(exclude_unset=True) — but the Pydantic shape itself
+    must accept the omission cleanly."""
+    obj = AdmissionPathUpdate.model_validate({})
+    assert obj.applicable_to is None
+    assert obj.method_quota is None
+    assert obj.bonus_rule_override is None
+
+
+def test_update_applicable_to_explicit_empty_list_clears() -> None:
+    """``[]`` is the explicit "clear the audience filter" signal —
+    distinct from omitting the key (= leave unchanged). The schema
+    parses both shapes; the service distinguishes via exclude_unset."""
+    obj = AdmissionPathUpdate.model_validate({"applicable_to": []})
+    assert obj.applicable_to == []
+
+
+def test_update_bonus_rule_override_typed() -> None:
+    obj = AdmissionPathUpdate.model_validate(
+        {
+            "bonus_rule_override": {
+                "apply_area_bonus": False,
+                "apply_subject_bonus": True,
+                "max_total_bonus": None,
+            }
+        }
+    )
+    assert isinstance(obj.bonus_rule_override, BonusRuleOverride)
+    assert obj.bonus_rule_override.max_total_bonus is None
+
+
+# ---------------------------------------------------------------------------
+# 4. AdmissionPathResponse — required (no default) so parse fails loudly
+# ---------------------------------------------------------------------------
+
+
+def _response_baseline_payload() -> dict:
+    """Minimum valid response payload mirroring what the BE emits."""
+    return {
+        "id": 1,
+        "status": "draft",
+        "display_name": "CNTT 2026 — Xét học bạ",
+        "display_order": 0,
+        "visibility": "internal",
+        "application_fee": None,
+        "requires_application_fee": False,
+        "allow_unverified_submission": False,
+        "minor_correction_allowed_fields": [],
+        "applicable_to": None,
+        "method_quota": None,
+        "bonus_rule_override": None,
+        "academic_info": None,
+        "admission_method": None,
+        "criteria": None,
+        "activated_at": None,
+        "activator": None,
+        "created_at": "2026-05-04T00:00:00+00:00",
+        "updated_at": "2026-05-04T00:00:00+00:00",
+    }
+
+
+def test_response_accepts_null_for_all_three_new_fields() -> None:
+    """NULL is the legacy / "no-config" signal for all three. Response
+    parse must accept it — Phase 1+2 has paths not yet backfilled."""
+    obj = AdmissionPathResponse.model_validate(_response_baseline_payload())
+    assert obj.applicable_to is None
+    assert obj.method_quota is None
+    assert obj.bonus_rule_override is None
+
+
+def test_response_fails_when_applicable_to_missing() -> None:
+    """REQUIRED (no default) — a BE that forgets to map the column
+    must surface as Zod / Pydantic parse error, not a silent empty
+    list. Same pattern as ``allow_unverified_submission``."""
+    payload = _response_baseline_payload()
+    payload.pop("applicable_to")
+    with pytest.raises(ValidationError):
+        AdmissionPathResponse.model_validate(payload)
+
+
+def test_response_fails_when_method_quota_missing() -> None:
+    payload = _response_baseline_payload()
+    payload.pop("method_quota")
+    with pytest.raises(ValidationError):
+        AdmissionPathResponse.model_validate(payload)
+
+
+def test_response_fails_when_bonus_rule_override_missing() -> None:
+    payload = _response_baseline_payload()
+    payload.pop("bonus_rule_override")
+    with pytest.raises(ValidationError):
+        AdmissionPathResponse.model_validate(payload)
+
+
+def test_response_round_trips_typed_bonus_rule_override() -> None:
+    payload = _response_baseline_payload() | {
+        "bonus_rule_override": {
+            "apply_area_bonus": True,
+            "apply_subject_bonus": True,
+            "max_total_bonus": 2.75,
+        },
+    }
+    obj = AdmissionPathResponse.model_validate(payload)
+    assert isinstance(obj.bonus_rule_override, BonusRuleOverride)
+    assert obj.bonus_rule_override.apply_area_bonus is True
+
+
+# ---------------------------------------------------------------------------
+# 5. AdmissionAudience — Literal pinned to alembic phase1_03
+# ---------------------------------------------------------------------------
+
+
+def test_admission_audience_literal_has_5_values() -> None:
+    """Literal __args__ exposes the union members; lock the 5 values
+    so any drift between BE Literal and alembic ENUM is caught
+    pre-merge. Pulling values via ``typing.get_args`` is the
+    Pydantic-supported way."""
+    from typing import get_args
+
+    members = set(get_args(AdmissionAudience))
+    assert members == {
+        "POST_THCS",
+        "POST_THPT",
+        "LIEN_THONG_TC",
+        "LIEN_THONG_CD",
+        "VLVH",
+    }

--- a/Backend_FastAPI/tests/unit/test_admission_service_applied_rules_phase1_03.py
+++ b/Backend_FastAPI/tests/unit/test_admission_service_applied_rules_phase1_03.py
@@ -1,0 +1,81 @@
+"""Unit tests for ``admission_service`` ``applied_rules`` snapshot —
+the 3 new fields wired in #184 Wave 1 PR-1B' (phase1_03 +
+phase1_02 wired).
+
+PLAN line 2776 contract: applied_rules is the immutable per-profile
+snapshot of the path config at create time. PR-1B' adds 3 keys:
+
+* ``applicable_to`` — list of audience strings or None.
+* ``method_quota`` — int or None.
+* ``bonus_rule_override`` — dict (the raw JSONB shape) or None.
+
+This file locks the snapshot keys exist in the source + the values
+are read from the path attribute (not hard-coded / mocked
+elsewhere). Full integration of profile create flow is covered by
+existing ``test_admission_service.py``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from app.services import admission_service
+
+
+_SERVICE_FILE = Path(admission_service.__file__).resolve()
+
+
+# ---------------------------------------------------------------------------
+# 1. Source-text contract — 3 keys present in the snapshot dict
+# ---------------------------------------------------------------------------
+
+
+def test_applied_rules_includes_applicable_to_key() -> None:
+    """The snapshot dict literal must reference the new key. Static
+    grep is sufficient — the production code path that constructs
+    the dict is the only writer for ``applied_rules``."""
+    src = _SERVICE_FILE.read_text()
+    assert '"applicable_to":' in src
+
+
+def test_applied_rules_includes_method_quota_key() -> None:
+    src = _SERVICE_FILE.read_text()
+    assert '"method_quota":' in src
+
+
+def test_applied_rules_includes_bonus_rule_override_key() -> None:
+    src = _SERVICE_FILE.read_text()
+    assert '"bonus_rule_override":' in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Source contract — values read from path attribute, not hard-coded
+# ---------------------------------------------------------------------------
+
+
+def test_applied_rules_reads_applicable_to_from_path() -> None:
+    """The new keys must read from ``admission_path.<attr>`` so the
+    snapshot reflects the live path config at create time. A bug
+    where someone hard-coded the value (e.g. ``"applicable_to":
+    None``) would silently break Phase 3 audience filter for
+    profiles created in Phase 1+2."""
+    src = _SERVICE_FILE.read_text()
+    # ``applicable_to`` may use list() conversion to detach from the
+    # ORM list type; either way the source must reference the path attribute.
+    assert "admission_path.applicable_to" in src or 'getattr(admission_path, "applicable_to"' in src
+
+
+def test_applied_rules_reads_method_quota_from_path() -> None:
+    src = _SERVICE_FILE.read_text()
+    assert (
+        "admission_path.method_quota" in src
+        or 'getattr(admission_path, "method_quota"' in src
+    )
+
+
+def test_applied_rules_reads_bonus_rule_override_from_path() -> None:
+    src = _SERVICE_FILE.read_text()
+    assert (
+        "admission_path.bonus_rule_override" in src
+        or 'getattr(admission_path, "bonus_rule_override"' in src
+    )

--- a/Backend_FastAPI/tests/unit/test_phase1_03_revision_chain.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_03_revision_chain.py
@@ -1,0 +1,219 @@
+"""Unit tests for #184 Wave 1 PR-1B' migration
+(``phase1_03_add_applicable_to_method_quota_to_path``).
+
+Pure-text contract tests — locks the revision chain shape, the
+upgrade SQL contract, the GIN index + ENUM type, and the model
+field declarations so a regression in any of the four surfaces
+fails CI before the migration ever runs against a real DB.
+
+What lives here:
+1. Revision-row lock — `revision`, `down_revision`.
+2. Linear chain shape — ``phase1_02 → phase1_03``.
+3. ENUM type contract — admission_audience with 5 values.
+4. Column add contract — applicable_to ARRAY + method_quota int.
+5. GIN index lock (load-bearing for query contract per PLAN
+   line 2646-2657 — anti-pattern guard test for ``= ANY()`` /
+   ``.any()`` lives in test_admission_path_repository_audience.py).
+6. ORM model parity — applicable_to + method_quota columns exist.
+7. No backfill — pure additive.
+
+What does NOT live here (covered separately):
+* End-to-end DDL apply — alembic upgrade smoke runs in dev container.
+* Repository operator contract — see
+  ``test_admission_path_repository_audience.py``.
+* BonusRuleOverride Pydantic shape — see
+  ``test_admission_path_schema_bonus_rule_override.py``.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_PHASE1_03_FILE = (
+    _VERSIONS_DIR / "phase1_03_add_applicable_to_method_quota_to_path.py"
+)
+
+
+def _load_migration(filename: str):
+    path = _VERSIONS_DIR / filename
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_03():
+    return _load_migration(_PHASE1_03_FILE.name)
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision-row lock
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_03_revision_id(phase1_03) -> None:
+    assert phase1_03.revision == "phase1_03"
+
+
+def test_phase1_03_down_revision_chains_off_phase1_02(phase1_03) -> None:
+    """phase1_03 follows phase1_02 directly per PLAN line 2636 + 3452."""
+    assert phase1_03.down_revision == "phase1_02"
+
+
+def test_phase1_03_no_branch_labels(phase1_03) -> None:
+    assert phase1_03.branch_labels is None
+
+
+def test_phase1_03_no_extra_dependencies(phase1_03) -> None:
+    assert phase1_03.depends_on is None
+
+
+# ---------------------------------------------------------------------------
+# 2. ENUM contract — admission_audience with 5 values
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_03_declares_5_audience_values(phase1_03) -> None:
+    """Audience values pinned to PLAN line 605-606. Adding a value =
+    update migration + BE Literal + FE Zod in lockstep, never
+    silently extend via ALTER TYPE."""
+    assert phase1_03.ADMISSION_AUDIENCE_VALUES == (
+        "POST_THCS",
+        "POST_THPT",
+        "LIEN_THONG_TC",
+        "LIEN_THONG_CD",
+        "VLVH",
+    )
+
+
+def test_phase1_03_creates_admission_audience_type() -> None:
+    src = _PHASE1_03_FILE.read_text()
+    assert 'name="admission_audience"' in src
+    assert ".create(op.get_bind(), checkfirst=True)" in src
+
+
+def test_phase1_03_drops_admission_audience_type_in_downgrade() -> None:
+    src = _PHASE1_03_FILE.read_text()
+    assert ".drop(op.get_bind(), checkfirst=True)" in src
+
+
+# ---------------------------------------------------------------------------
+# 3. Column add contract
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_03_adds_applicable_to_to_admission_path() -> None:
+    src = _PHASE1_03_FILE.read_text()
+    assert "add_column" in src
+    assert '"admission_path"' in src
+    assert '"applicable_to"' in src
+    # Column is ARRAY of the audience enum.
+    assert "postgresql.ARRAY(audience_enum)" in src
+
+
+def test_phase1_03_adds_method_quota_to_admission_path() -> None:
+    src = _PHASE1_03_FILE.read_text()
+    assert '"method_quota"' in src
+    # Plain Integer — no length / FK.
+    assert "sa.Integer()" in src
+
+
+def test_phase1_03_columns_are_nullable() -> None:
+    """Both columns must stay nullable in Phase 1 — Phase 3 NOT NULL
+    swap is a separate migration after the validator gate completes."""
+    src = _PHASE1_03_FILE.read_text()
+    # Two ``nullable=True`` add_column kwargs (one per column).
+    assert src.count("nullable=True") >= 2
+
+
+# ---------------------------------------------------------------------------
+# 4. GIN index lock (load-bearing for query contract)
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_03_creates_gin_index_on_applicable_to() -> None:
+    """GIN index is REQUIRED — without it, the ``@>`` / ``&&`` query
+    contract still works correctly but burns a seq-scan on every
+    storefront audience filter call. PLAN line 2656 mandates
+    ``EXPLAIN ANALYZE`` show ``Bitmap Index Scan`` on this index;
+    the existence check here is the static guard against accidental
+    deletion in a future migration sweep."""
+    src = _PHASE1_03_FILE.read_text()
+    assert "ix_admission_path_applicable_to" in src
+    assert 'postgresql_using="gin"' in src
+
+
+def test_phase1_03_downgrade_drops_index_first() -> None:
+    """Inverse order — index → column → enum. PG would error on
+    drop_column if the GIN index still references the column."""
+    src = _PHASE1_03_FILE.read_text()
+    drop_idx_pos = src.index('drop_index(\n        "ix_admission_path_applicable_to"')
+    drop_col_pos = src.index('drop_column("admission_path", "applicable_to")')
+    assert drop_idx_pos < drop_col_pos
+
+
+# ---------------------------------------------------------------------------
+# 5. No backfill (pure additive)
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_03_no_op_execute() -> None:
+    """Pure additive — both columns nullable, no UPDATE/INSERT
+    statements. ``op.execute(`` should not appear."""
+    src = _PHASE1_03_FILE.read_text()
+    assert "op.execute(" not in src
+
+
+# ---------------------------------------------------------------------------
+# 6. ORM model parity
+# ---------------------------------------------------------------------------
+
+
+def test_admission_path_model_declares_applicable_to() -> None:
+    from app.models.admission_config.admission_path import AdmissionPath
+    assert hasattr(AdmissionPath, "applicable_to")
+    column = AdmissionPath.__table__.columns["applicable_to"]
+    assert column.nullable is True
+    # Type wraps ARRAY around an ENUM — check the outer container.
+    type_repr = type(column.type).__name__
+    assert "ARRAY" in type_repr.upper()
+
+
+def test_admission_path_model_declares_method_quota() -> None:
+    from app.models.admission_config.admission_path import AdmissionPath
+    assert hasattr(AdmissionPath, "method_quota")
+    column = AdmissionPath.__table__.columns["method_quota"]
+    assert column.nullable is True
+    type_repr = type(column.type).__name__
+    assert "INTEGER" in type_repr.upper()
+
+
+def test_admission_path_unique_constraint_unchanged() -> None:
+    """Duplicate-check guard — Codex P1 contract: PR-1B' MUST NOT
+    drop the existing ``uq_admission_path_offering_method`` unique
+    constraint. Phase 2 swap is a separate migration. If this test
+    breaks because someone removed the constraint name, the
+    ``DuplicateResourceError`` raised by
+    ``admission_path_service:144`` would silently degrade to a DB
+    IntegrityError 500 in Phase 1 — bad UX, bad telemetry."""
+    from app.models.admission_config.admission_path import AdmissionPath
+    constraint_names = {
+        c.name for c in AdmissionPath.__table__.constraints
+    }
+    assert "uq_admission_path_offering_method" in constraint_names
+
+
+# ---------------------------------------------------------------------------
+# 7. Sanity — migration imports cleanly + has both functions
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_03_defines_upgrade_and_downgrade(phase1_03) -> None:
+    assert callable(getattr(phase1_03, "upgrade", None))
+    assert callable(getattr(phase1_03, "downgrade", None))

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -26,6 +26,48 @@ export const admissionPathStatusEnum = z.enum([
 export type AdmissionPathStatus = z.infer<typeof admissionPathStatusEnum>
 
 // ==============================================================================
+// AUDIENCE ENUM (phase1_03 / #184 Wave 1 PR-1B')
+// ==============================================================================
+
+/**
+ * admission_audience PG ENUM mirror — values pinned to alembic
+ * phase1_03 + PLAN line 605-606. Adding a new audience must touch
+ * the migration, the BE schema (`AdmissionAudience` Literal) and
+ * this enum together; do not extend silently.
+ */
+export const admissionAudienceEnum = z.enum([
+  "POST_THCS",
+  "POST_THPT",
+  "LIEN_THONG_TC",
+  "LIEN_THONG_CD",
+  "VLVH",
+])
+
+export type AdmissionAudience = z.infer<typeof admissionAudienceEnum>
+
+// ==============================================================================
+// BONUS RULE OVERRIDE (phase1_02 wired in PR-1B')
+// ==============================================================================
+
+/**
+ * Path-level / method-default bonus rule shape mirror
+ * (BE: `BonusRuleOverride` in app/schemas/admission_path.py).
+ *
+ * `.strict()` rejects unknown keys to keep parity with Pydantic
+ * `extra="forbid"` — the admin form must not silently round-trip
+ * stray fields that the scoring engine will ignore.
+ */
+export const bonusRuleOverrideSchema = z
+  .object({
+    apply_area_bonus: z.boolean(),
+    apply_subject_bonus: z.boolean(),
+    max_total_bonus: z.number().min(0).max(10).nullable().optional(),
+  })
+  .strict()
+
+export type BonusRuleOverride = z.infer<typeof bonusRuleOverrideSchema>
+
+// ==============================================================================
 // NESTED SCHEMAS
 // ==============================================================================
 
@@ -135,6 +177,14 @@ export const admissionPathCreateSchema = z.object({
       (arr) => arr.every((f) => SAFE_MINOR_CORRECTION_FIELDS.has(f as never)),
       { message: "Field không nằm trong safe catalog" },
     ),
+  // phase1_03 (#184 Wave 1 PR-1B') — audience filter + per-method
+  // quota + typed bonus override. All three optional on create;
+  // admin sets via update once Phase 3 validator gate ("X path null
+  // applicable_to → admin set trước") flips. NULL on the wire =
+  // applicable to every audience (Phase 1+2 contract).
+  applicable_to: z.array(admissionAudienceEnum).optional().nullable(),
+  method_quota: z.number().int().min(0).optional().nullable(),
+  bonus_rule_override: bonusRuleOverrideSchema.optional().nullable(),
 })
 
 export type AdmissionPathCreate = z.infer<typeof admissionPathCreateSchema>
@@ -163,6 +213,14 @@ export const admissionPathUpdateSchema = z.object({
         arr.every((f) => SAFE_MINOR_CORRECTION_FIELDS.has(f as never)),
       { message: "Field không nằm trong safe catalog" },
     ),
+  // phase1_03 — Optional on update so partial PATCH-style updates
+  // don't accidentally clear the audience filter / quota / override.
+  // Pass `null` to clear; omit the key to leave unchanged. Pydantic
+  // distinguishes `None` (clear) from "key missing" via
+  // `model_dump(exclude_unset=True)` on the BE side.
+  applicable_to: z.array(admissionAudienceEnum).optional().nullable(),
+  method_quota: z.number().int().min(0).optional().nullable(),
+  bonus_rule_override: bonusRuleOverrideSchema.optional().nullable(),
 })
 
 export type AdmissionPathUpdate = z.infer<typeof admissionPathUpdateSchema>
@@ -246,6 +304,16 @@ export const admissionPathResponseSchema = z.object({
   // validation, so re-checking here would be redundant work that
   // surfaces no new bugs.
   minor_correction_allowed_fields: z.array(z.string()),
+
+  // phase1_03 (#184 Wave 1 PR-1B') — REQUIRED on the response (no
+  // default) so the parse fails loudly if BE forgets to map the
+  // column. NULL on wire = "applicable to every audience" / "no
+  // quota cap" / "inherit method bonus default". Admin UI must
+  // distinguish NULL vs `[]`/`0` for `applicable_to` / `method_quota`
+  // since they have different semantics.
+  applicable_to: z.array(admissionAudienceEnum).nullable(),
+  method_quota: z.number().int().min(0).nullable(),
+  bonus_rule_override: bonusRuleOverrideSchema.nullable(),
 })
 
 export type AdmissionPathResponse = z.infer<typeof admissionPathResponseSchema>


### PR DESCRIPTION
## Summary

#184 Phase 1 Schema Wave 1 third sub-PR (4-PR split per user chốt 2026-05-03).
Migration `phase1_03` + BE schema/service/repo + FE Zod parse parity.

PR scope chốt 2026-05-04 sau 4-round Codex supervising review:

| # | Q | Decision | Rationale |
|---|---|---|---|
| Q1 | `admission_round_id` ship Phase 1 hay Phase 2? | **Defer Phase 2** | Phase 1 chưa có `offering_admission_round` table — phantom field nếu ship sớm |
| Q2 | Bỏ duplicate check service-side? | **GIỮ NGUYÊN** | DB unique `uq_admission_path_offering_method` còn — bỏ service check sẽ biến `DuplicateResourceError` thành DB IntegrityError 500 |
| Q3 | FE ship cùng PR hay tách? | **Zod cùng BE, UI tách** | Parse drift nếu BE emit field mới mà FE chưa parse; UI form sẽ ship PR-1B'-FE riêng |

## Pre-flight

- Base: `feat/admission-full-cutover`
- Parent verified: `origin/feat/admission-full-cutover == f344a6e3` (tracker drift repair commit). Push branch gốc clean — không pollute parent.
- Branch HEAD: `33d65265`
- Down-revision chain: `phase1_19a → phase1_19b → phase1_01 → phase1_02 → phase1_03 (head)`

## Migration

`phase1_03_add_applicable_to_method_quota_to_path.py`:
- ENUM `admission_audience` 5 values (`POST_THCS`, `POST_THPT`, `LIEN_THONG_TC`, `LIEN_THONG_CD`, `VLVH`) per PLAN line 605-606.
- `admission_path.applicable_to admission_audience[]` nullable — audience filter ARRAY. NULL = applicable to every audience (Phase 1+2 contract).
- `admission_path.method_quota integer` nullable — per-method quota tier. NULL = no method-level cap.
- GIN index `ix_admission_path_applicable_to` — REQUIRED cho `@>`/`&&` query contract (PLAN line 2646-2657).

## Backend

- `models/admission_config/admission_path.py` — 2 column wired (`bonus_rule_override` đã có từ phase1_02).
- `schemas/admission_path.py` — `AdmissionAudience` Literal + typed `BonusRuleOverride` shape (`apply_area_bonus`/`apply_subject_bonus`/`max_total_bonus 0..10`) per Codex P2 với `extra="forbid"`. Create/Update/Response wire 3 field; Response REQUIRED no-default.
- `services/admission_service.py` — `applied_rules` Group 8 thêm 3 key đọc từ `admission_path.<attr>`. Profile create snapshot đầy đủ; admin sửa path sau KHÔNG retroactive.
- `repositories/admission_path_repository.py` — 2 method: `list_paths_by_audience` (`@>`) + `list_paths_by_audiences_overlap` (`&&`). NEVER `.any()` / `= ANY()` (planner không pick GIN). `include_legacy_null` flag (Phase 3 cutover knob) + OR NULL branch preserve legacy.
- **DUPLICATE CHECK GIỮ NGUYÊN** ở `admission_path_service.py:144` — Codex P1 contract; Phase 2 swap unique mới remove.

## Frontend

- `lib/zod/admission-path.ts` — `admissionAudienceEnum` + `bonusRuleOverrideSchema` (`.strict()`) mirror BE shape. Create/Update/Response wire 3 field cùng required/optional semantic như Pydantic.
- FE form UI tách PR-1B'-FE riêng (per Q3).

## Codex P1 catch on round 4

Source-grep tests passed nhưng `ARRAY(literal_column("admission_audience"))` fail compile với `AttributeError: '_variant_mapping'`. Fix dùng typed enum array `postgresql.ARRAY(postgresql.ENUM(..., name="admission_audience", create_type=False))`.

Compile probe verified live trên container backend:
```
@> CAST(ARRAY['POST_THPT'] AS admission_audience[])
&& CAST(ARRAY['POST_THPT', 'LIEN_THONG_TC'] AS admission_audience[])
```

Added 4 compile-dialect tests asserting `@>`/`&&`/`CAST(... AS admission_audience[])`/no `ANY` contract — bảo đảm future cast-style change không pass test mà fail runtime.

## Tests

**4 new file, 59 cases**:
- `test_phase1_03_revision_chain.py` (17 case) — revision lock + ENUM 5 value + column add + GIN + ORM parity + `uq_admission_path_offering_method` PRESERVED guard (Codex P1) + no `op.execute` backfill.
- `test_admission_path_schema_bonus_rule_override.py` (22 case) — BonusRuleOverride shape + range 0..10 + `extra=forbid` + Create/Update/Response 3 field semantic + AdmissionAudience Literal lock.
- `test_admission_path_repository_audience.py` (13 case) — anti-pattern `.any(` source guard + `@>`/`&&` source contract + signature default + empty-input + NULL OR branch + 4 compile-dialect tests.
- `test_admission_service_applied_rules_phase1_03.py` (6 case) — 3 key trong dict literal + read từ path attribute.

## Test result

```
117 passed in 6.54s
```

4 new file (59 case) + 5 existing path/migration regression file (58 case) target `tests/unit/test_admission_path_*.py`. Zero break trong existing suite.

**Critical rerun post-fix** (Codex round 4 evidence):
```
tests/unit/test_admission_path_repository_audience.py: 13 passed
```

## Live alembic roundtrip on dev DB

- `alembic upgrade phase1_03` clean → schema applied (column + GIN + ENUM 5 value).
- `alembic downgrade phase1_02` clean → column + index + enum dropped no orphan; `pg_type` không còn `admission_audience`.
- Re-upgrade idempotent.
- `uq_admission_path_offering_method` + `uq_admission_path_criteria_id` PRESERVED (Codex P1 contract live verify).

## EXPLAIN smoke (Codex P2 expected behavior)

Dev DB nhỏ → planner picks `Seq Scan` trên empty table (cost 4.67):
```
Seq Scan on admission_path
  Filter: ((applicable_to IS NULL) OR (applicable_to @> '{POST_THPT}'::admission_audience[]))
```

`enable_seqscan=off` forces planner to consider GIN:
```
Bitmap Heap Scan on admission_path
  Recheck Cond: (applicable_to @> '{POST_THPT}'::admission_audience[])
  ->  Bitmap Index Scan on ix_admission_path_applicable_to
        Index Cond: (applicable_to @> '{POST_THPT}'::admission_audience[])
```

→ GIN index reachable; auto-pick sẽ flip trên staging clone D12-D14 với data volume thực.

## Test plan
- [x] Unit test 117/117 PASS local
- [x] Compile-dialect probe verified `@>`/`&&`/`CAST AS admission_audience[]`/no `ANY`
- [x] Live alembic upgrade + downgrade + re-upgrade idempotent
- [x] Unique constraints PRESERVED live verify
- [x] EXPLAIN GIN reachable (force planner)
- [ ] Staging clone D12-D14 GIN auto-pick smoke (gate Wave 3)
- [ ] FE form UI ship PR-1B'-FE riêng

🤖 Generated with [Claude Code](https://claude.com/claude-code)