### PR TITLE
[#184 PR-1C'] subject_kind + doc_group path FK + 3-tier resolution

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase1_05_add_subject_kind_and_score_bounds.py
+++ b/Backend_FastAPI/alembic/versions/phase1_05_add_subject_kind_and_score_bounds.py
@@ -1,0 +1,196 @@
+"""phase1_05: add subject_kind + score bounds + 6 virtual subject seed
+
+Revision ID: phase1_05
+Revises: phase1_03
+Create Date: 2026-05-04
+
+#184 Wave 1 PR-1C' — fifth migration in Phase 1 Schema chain
+(PLAN §4 line 2662-2666). Three additive columns on ``subject``
+plus a 6-row idempotent seed of virtual subjects (TERM_AVERAGE
+buckets, ABILITY_TEST scores, CERTIFICATE marks) needed by the
+multi-NV scoring engine that ships in Phase 3.
+
+Schema additions
+----------------
+* ``subject_kind`` ENUM type — 4 values per PLAN line 733-737:
+  ``ACADEMIC_SUBJECT`` (Toán/Lý/Hóa/Văn), ``TERM_AVERAGE``
+  (TB học kỳ/cả năm), ``ABILITY_TEST`` (DGNL/V-ACT), ``CERTIFICATE``
+  (IELTS/nghề). Created BEFORE the column add so the column type
+  resolves cleanly. Down migration drops AFTER column.
+
+* ``subject.subject_kind subject_kind NOT NULL DEFAULT
+  'ACADEMIC_SUBJECT'`` — server default backfills every existing
+  row at ALTER time (PG fast path on default, no row-by-row
+  UPDATE). Stays NOT NULL post-migration so the scoring engine
+  never has to handle a NULL kind.
+
+* ``subject.max_score`` Numeric(6,2) nullable. Stores the ceiling
+  for this subject's score (10 for academic, 150 for DGNL,
+  1200 for V-ACT, 9.0 for IELTS). NULL is legitimate for
+  legacy rows pre-seed; service should default to 10 when
+  reading a NULL ``max_score`` on an ACADEMIC_SUBJECT row.
+
+* ``subject.min_possible_score`` Numeric(6,2) nullable. Floor
+  for the subject score, NULL = 0. Used by the scoring engine
+  to clamp + percentage-normalize scores cross-kind.
+
+Seed
+----
+6 virtual subjects ON CONFLICT DO NOTHING (PLAN line 4174-4181
++ PLAN line 745 "TB_HK1_L12, TB_CN_L12, DGNL_DHQGHN, V_ACT, IELTS..."):
+
+* ``TB_HK1_L12`` — TERM_AVERAGE, max=10 — TB học kỳ 1 lớp 12
+* ``TB_HK2_L12`` — TERM_AVERAGE, max=10 — TB học kỳ 2 lớp 12
+* ``TB_CN_L12`` — TERM_AVERAGE, max=10 — TB cả năm lớp 12
+* ``DGNL_DHQGHN`` — ABILITY_TEST, max=150 — ĐGNL ĐHQG Hà Nội
+* ``V_ACT`` — ABILITY_TEST, max=1200 — V-ACT (ĐH Bách khoa HN)
+* ``IELTS`` — CERTIFICATE, max=9 — IELTS
+
+Idempotency: ``ON CONFLICT (code) DO NOTHING`` — re-applying
+upgrade after partial failure leaves existing rows untouched.
+The unique constraint on ``code`` (created by the initial
+migration) is what makes the conflict guard work; no need to
+add it here.
+
+Down-revision chain: ``phase1_03 → phase1_05``. Note: phase1_04
+is DEFERRED Q1/2027 (Q9 chốt 2026-05-01), so the chain skips it
+intentionally.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_05"
+down_revision: Union[str, None] = "phase1_03"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# ENUM values per PLAN line 733-737. Frozen here as the migration
+# is the source-of-truth for the type definition; SQLAlchemy
+# model mirrors via ``postgresql.ENUM(name=..., create_type=False)``.
+SUBJECT_KIND_VALUES: tuple[str, ...] = (
+    "ACADEMIC_SUBJECT",
+    "TERM_AVERAGE",
+    "ABILITY_TEST",
+    "CERTIFICATE",
+)
+
+
+def upgrade() -> None:
+    # 1. Create the subject_kind ENUM type. ``checkfirst=True`` makes
+    #    the call idempotent on partial-failure replay.
+    subject_kind_enum = postgresql.ENUM(
+        *SUBJECT_KIND_VALUES,
+        name="subject_kind",
+        create_type=False,
+    )
+    subject_kind_enum.create(op.get_bind(), checkfirst=True)
+
+    # 2. subject.subject_kind — NOT NULL with server default to
+    #    backfill every existing row (academic subjects only at
+    #    this point in time; the seed below adds the non-academic
+    #    virtual subjects under their proper kinds).
+    op.add_column(
+        "subject",
+        sa.Column(
+            "subject_kind",
+            subject_kind_enum,
+            nullable=False,
+            server_default=sa.text("'ACADEMIC_SUBJECT'::subject_kind"),
+            comment=(
+                "Subject category. ACADEMIC_SUBJECT for legacy rows; "
+                "TERM_AVERAGE / ABILITY_TEST / CERTIFICATE for virtual "
+                "subjects seeded by phase1_05."
+            ),
+        ),
+    )
+
+    # 3. subject.max_score — score ceiling. NULL for legacy rows;
+    #    seeded values explicit per-row.
+    op.add_column(
+        "subject",
+        sa.Column(
+            "max_score",
+            sa.Numeric(precision=6, scale=2),
+            nullable=True,
+            comment=(
+                "Score ceiling for this subject (10 for academic, "
+                "150 for DGNL, 1200 for V-ACT, 9 for IELTS). NULL = "
+                "service falls back to 10 for ACADEMIC_SUBJECT."
+            ),
+        ),
+    )
+
+    # 4. subject.min_possible_score — score floor. NULL = service
+    #    treats as 0.
+    op.add_column(
+        "subject",
+        sa.Column(
+            "min_possible_score",
+            sa.Numeric(precision=6, scale=2),
+            nullable=True,
+            comment=(
+                "Score floor for this subject. NULL = 0. Used by the "
+                "scoring engine to clamp + percentage-normalize."
+            ),
+        ),
+    )
+
+    # 5. Seed 6 virtual subjects. Idempotent via ON CONFLICT (code).
+    #    Names use Vietnamese display labels per PLAN line 4174-4181.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO subject (code, name_vi, subject_kind, max_score, display_order, is_active)
+            VALUES
+                ('TB_HK1_L12',  'TB học kỳ 1 lớp 12',      'TERM_AVERAGE', 10,   100, true),
+                ('TB_HK2_L12',  'TB học kỳ 2 lớp 12',      'TERM_AVERAGE', 10,   101, true),
+                ('TB_CN_L12',   'TB cả năm lớp 12',        'TERM_AVERAGE', 10,   102, true),
+                ('DGNL_DHQGHN', 'ĐGNL ĐHQG Hà Nội',        'ABILITY_TEST', 150,  200, true),
+                ('V_ACT',       'V-ACT (ĐH Bách khoa HN)', 'ABILITY_TEST', 1200, 201, true),
+                ('IELTS',       'IELTS',                   'CERTIFICATE',  9,    300, true)
+            ON CONFLICT (code) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # 1. Delete the seeded virtual subjects FIRST (before dropping the
+    #    enum, otherwise the rows hold a reference to the type and
+    #    the type drop fails). Strict predicate on ``code`` so admin-
+    #    edited rows with these codes (unlikely but possible) still
+    #    get removed cleanly — admin should be using the catalog UI
+    #    if they need to override seeded rows.
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM subject
+            WHERE code IN (
+                'TB_HK1_L12', 'TB_HK2_L12', 'TB_CN_L12',
+                'DGNL_DHQGHN', 'V_ACT', 'IELTS'
+            )
+            """
+        )
+    )
+
+    # 2. Drop columns in inverse order — score bounds before kind so
+    #    if the enum drop fails (e.g. another column we don't know
+    #    about references it) the column drop has already cleared.
+    op.drop_column("subject", "min_possible_score")
+    op.drop_column("subject", "max_score")
+    op.drop_column("subject", "subject_kind")
+
+    # 3. Drop the ENUM type LAST so PG doesn't error on type-still-
+    #    in-use. ``checkfirst=True`` keeps the downgrade re-runnable.
+    subject_kind_enum = postgresql.ENUM(
+        *SUBJECT_KIND_VALUES,
+        name="subject_kind",
+        create_type=False,
+    )
+    subject_kind_enum.drop(op.get_bind(), checkfirst=True)

--- a/Backend_FastAPI/alembic/versions/phase1_06_add_path_id_to_document_group.py
+++ b/Backend_FastAPI/alembic/versions/phase1_06_add_path_id_to_document_group.py
@@ -1,0 +1,112 @@
+"""phase1_06: add admission_path_id FK + partial index to document_group
+
+Revision ID: phase1_06
+Revises: phase1_05
+Create Date: 2026-05-04
+
+#184 Wave 1 PR-1C' — sixth migration in Phase 1 Schema chain
+(PLAN §4 line 2668-2683). One nullable FK column + one partial
+index. Pure additive — existing 2-tier resolution
+(method-specific override + shared) keeps working unchanged
+because legacy document_group rows have ``admission_path_id IS
+NULL``.
+
+Schema additions
+----------------
+* ``document_group.admission_path_id`` integer nullable FK to
+  ``admission_path(id)`` ON DELETE SET NULL. NULL semantic:
+  - With ``admission_method_id`` non-null + path NULL → legacy
+    method-specific override (existing tier 2).
+  - With ``admission_method_id`` NULL + path NULL → legacy
+    shared / offering_type default (existing tier 3).
+  - With ``admission_path_id`` non-null → NEW path-specific
+    override (tier 1) — wins over both legacy tiers when the
+    profile's path matches.
+
+* ``ix_doc_group_path`` partial btree index on
+  ``admission_path_id`` WHERE ``admission_path_id IS NOT NULL``.
+  Partial because most rows are legacy (method or shared) →
+  index only the path-specific rows for a smaller / hotter
+  index; the resolution rule's tier-1 query
+  ``WHERE admission_path_id = X`` is the only consumer.
+
+Service-layer invariant (NOT enforced by DB)
+--------------------------------------------
+Per PLAN line 2671-2682, when admin creates / updates a
+DocumentGroup with ``admission_path_id`` set, the service must
+validate:
+
+* ``DocumentGroup.offering_type_id == path.academic_info.offering.offering_type_id``
+* ``DocumentGroup.admission_method_id`` is None OR equals
+  ``path.admission_method_id``
+
+Mismatch → ``BusinessRuleViolation``. Reason: the resolution
+rule chooses path-level groups BEFORE checking offering_type /
+method, so an inconsistent group would silently leak into a
+profile that doesn't match the path's offering.
+
+The invariant lives in ``DocumentGroupService.create`` /
+``update`` — see PR-1C' BE diff. Migration owns the schema only.
+
+Down-revision chain: ``phase1_03 → phase1_05 → phase1_06``.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_06"
+down_revision: Union[str, None] = "phase1_05"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Add admission_path_id nullable FK. ON DELETE SET NULL means
+    #    deleting a path doesn't cascade-kill its document groups —
+    #    they fall back to the method / shared tier automatically.
+    op.add_column(
+        "document_group",
+        sa.Column(
+            "admission_path_id",
+            sa.Integer(),
+            nullable=True,
+            comment=(
+                "Path-level override (tier 1 of 3-tier resolution). "
+                "NULL = legacy method/shared override. ON DELETE SET "
+                "NULL so path delete falls back to lower tiers."
+            ),
+        ),
+    )
+    op.create_foreign_key(
+        "fk_document_group_admission_path",
+        "document_group",
+        "admission_path",
+        ["admission_path_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # 2. Partial btree index on the FK column. Tier-1 query is
+    #    ``WHERE admission_path_id = X`` so a btree on the column
+    #    is the right shape; partial keeps it small (most rows are
+    #    legacy = NULL).
+    op.create_index(
+        "ix_doc_group_path",
+        "document_group",
+        ["admission_path_id"],
+        postgresql_where=sa.text("admission_path_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    # Inverse order — index → FK → column.
+    op.drop_index("ix_doc_group_path", table_name="document_group")
+    op.drop_constraint(
+        "fk_document_group_admission_path",
+        "document_group",
+        type_="foreignkey",
+    )
+    op.drop_column("document_group", "admission_path_id")

--- a/Backend_FastAPI/app/models/admission_config/document_group.py
+++ b/Backend_FastAPI/app/models/admission_config/document_group.py
@@ -49,6 +49,23 @@ class DocumentGroup(Base):
         index=True,
         comment="NULL = all methods, non-NULL = method-specific override"
     )
+    # phase1_06 (#184 Wave 1 PR-1C') — path-level override (tier 1
+    # of 3-tier resolution). NULL = legacy method/shared override.
+    # ON DELETE SET NULL so deleting a path doesn't cascade-kill
+    # its document groups; they fall back to the lower tiers.
+    # Service-layer invariant (NOT enforced by DB) — when this is
+    # set, the row's offering_type_id + admission_method_id MUST
+    # match the path's; ``DocumentGroupService.create``/``update``
+    # raise BusinessRuleViolation on drift.
+    admission_path_id = Column(
+        Integer,
+        ForeignKey("admission_path.id", ondelete="SET NULL"),
+        nullable=True,
+        comment=(
+            "Path-level override (tier 1). NULL = legacy "
+            "method/shared override."
+        ),
+    )
     code = Column(
         String(50),
         nullable=False,
@@ -75,6 +92,10 @@ class DocumentGroup(Base):
     # Relationships
     offering_type = relationship("ConfigOfferingType", back_populates="document_groups")
     admission_method = relationship("AdmissionMethod", back_populates="document_groups")
+    admission_path = relationship(
+        "AdmissionPath",
+        foreign_keys=[admission_path_id],
+    )
     items = relationship(
         "DocumentGroupItem",
         back_populates="document_group",

--- a/Backend_FastAPI/app/models/admission_config/subject.py
+++ b/Backend_FastAPI/app/models/admission_config/subject.py
@@ -10,10 +10,23 @@ Tables:
 
 from decimal import Decimal
 
-from sqlalchemy import Column, Integer, Numeric, String, Boolean, ForeignKey, UniqueConstraint
+from sqlalchemy import Column, Integer, Numeric, String, Boolean, ForeignKey, UniqueConstraint, text
+from sqlalchemy.dialects.postgresql import ENUM
 from sqlalchemy.orm import relationship
 
 from app.models.base import Base
+
+
+# phase1_05 (#184 Wave 1 PR-1C') — subject_kind ENUM mirror.
+# ``create_type=False`` because the migration owns the DDL.
+# Adding a new value requires migration ALTER TYPE + this tuple
+# in lockstep — no silent extension via direct DB access.
+SUBJECT_KIND_VALUES: tuple[str, ...] = (
+    "ACADEMIC_SUBJECT",
+    "TERM_AVERAGE",
+    "ABILITY_TEST",
+    "CERTIFICATE",
+)
 
 
 class Subject(Base):
@@ -51,6 +64,46 @@ class Subject(Base):
         nullable=False,
         default=True,
         index=True
+    )
+
+    # phase1_05 (#184 Wave 1 PR-1C') — subject category. Backfilled
+    # to ``ACADEMIC_SUBJECT`` for all legacy rows via server default
+    # at ALTER TIME; seeded virtual subjects (TB_HK1_L12 / DGNL /
+    # IELTS / V_ACT / ...) carry the proper non-academic kind. Service
+    # uses this to gate routing: ``ACADEMIC_SUBJECT`` flows through
+    # legacy single-NV ProfileSubjectScore (CHECK 0..10), non-academic
+    # MUST go through Phase 3 multi-NV choice engine (no CHECK).
+    subject_kind = Column(
+        ENUM(
+            *SUBJECT_KIND_VALUES,
+            name="subject_kind",
+            create_type=False,
+        ),
+        nullable=False,
+        server_default=text("'ACADEMIC_SUBJECT'::subject_kind"),
+        comment=(
+            "Subject category. ACADEMIC_SUBJECT for legacy / Toán / "
+            "Lý / Hóa; TERM_AVERAGE / ABILITY_TEST / CERTIFICATE for "
+            "virtual subjects."
+        ),
+    )
+
+    # phase1_05 — score ceiling. NULL = service falls back to 10
+    # for ACADEMIC_SUBJECT. Seeded values: 10 (academic), 150
+    # (DGNL_DHQGHN), 1200 (V_ACT), 9 (IELTS).
+    max_score = Column(
+        Numeric(precision=6, scale=2),
+        nullable=True,
+        comment=(
+            "Score ceiling. NULL = service default 10 for ACADEMIC_SUBJECT."
+        ),
+    )
+
+    # phase1_05 — score floor. NULL = service treats as 0.
+    min_possible_score = Column(
+        Numeric(precision=6, scale=2),
+        nullable=True,
+        comment="Score floor. NULL = 0.",
     )
 
     # Relationships

--- a/Backend_FastAPI/app/repositories/admission_path_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_path_repository.py
@@ -328,22 +328,60 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
     async def get_document_groups_for_path(
         self,
         offering_type_id: int,
-        admission_method_id: int
-    ) -> Tuple[List[DocumentGroup], List[DocumentGroup]]:
+        admission_method_id: int,
+        admission_path_id: int | None = None,
+    ) -> Tuple[List[DocumentGroup], List[DocumentGroup], List[DocumentGroup]]:
         """
-        Get document groups for resolution.
-        
-        Returns:
-            Tuple of (shared_groups, method_specific_groups)
-            - shared_groups: admission_method_id IS NULL
-            - method_specific_groups: admission_method_id = given method
+        Get document groups for 3-tier resolution
+        (phase1_06 / #184 Wave 1 PR-1C').
+
+        Returns a triple ordered from highest to lowest precedence:
+            (path_groups, method_specific_groups, shared_groups)
+
+        * **Tier 1** — ``admission_path_id = X`` (when caller passes
+          ``admission_path_id``). Path-specific override; wins over
+          everything else when present. Empty list when caller passes
+          ``None`` (legacy callers, e.g. profile creation pre-PR-1C').
+        * **Tier 2** — ``admission_path_id IS NULL`` AND
+          ``admission_method_id = Y``. Existing legacy method-specific
+          override; preserved for backward-compat with shared/method
+          configs not yet migrated to path-level.
+        * **Tier 3** — ``admission_path_id IS NULL`` AND
+          ``admission_method_id IS NULL`` AND ``offering_type_id = Z``.
+          Default offering-type-wide shared bucket.
+
+        The caller (``admission_path_service.resolve_documents_for_path``)
+        applies the precedence: tier 1 wins fully if present; else
+        tier 2 wins fully; else tier 3.
         """
-        # Shared groups (applies to all methods)
+        # Tier 1 — path-specific (only when caller passes a path id;
+        # legacy callers send None and skip this query entirely).
+        path_groups: List[DocumentGroup] = []
+        if admission_path_id is not None:
+            path_query = (
+                select(DocumentGroup)
+                .where(
+                    DocumentGroup.admission_path_id == admission_path_id,
+                    DocumentGroup.is_active == True,
+                )
+                .options(
+                    selectinload(DocumentGroup.items).selectinload(
+                        DocumentGroupItem.document_type
+                    )
+                )
+            )
+            path_result = await self.db.execute(path_query)
+            path_groups = list(path_result.scalars().all())
+
+        # Tier 3 — shared (applies to all methods of the offering type).
+        # Note: admission_path_id IS NULL filter required to keep
+        # path-level rows out of the shared bucket once they exist.
         shared_query = (
             select(DocumentGroup)
             .where(
                 DocumentGroup.offering_type_id == offering_type_id,
                 DocumentGroup.admission_method_id == None,  # noqa: E711
+                DocumentGroup.admission_path_id == None,  # noqa: E711
                 DocumentGroup.is_active == True
             )
             .options(
@@ -352,13 +390,14 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
                 )
             )
         )
-        
-        # Method-specific groups (override)
+
+        # Tier 2 — method-specific, NOT path-specific.
         method_query = (
             select(DocumentGroup)
             .where(
                 DocumentGroup.offering_type_id == offering_type_id,
                 DocumentGroup.admission_method_id == admission_method_id,
+                DocumentGroup.admission_path_id == None,  # noqa: E711
                 DocumentGroup.is_active == True
             )
             .options(
@@ -367,13 +406,14 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
                 )
             )
         )
-        
+
         shared_result = await self.db.execute(shared_query)
         method_result = await self.db.execute(method_query)
-        
+
         return (
+            path_groups,
+            list(method_result.scalars().all()),
             list(shared_result.scalars().all()),
-            list(method_result.scalars().all())
         )
     
     # =========================================================================

--- a/Backend_FastAPI/app/repositories/document_group_repository.py
+++ b/Backend_FastAPI/app/repositories/document_group_repository.py
@@ -131,12 +131,14 @@ class DocumentGroupRepository(BaseRepository[DocumentGroup]):
         name: str,
         description: str | None = None,
         admission_method_id: int | None = None,
+        admission_path_id: int | None = None,
         is_active: bool = True,
     ) -> DocumentGroup:
         """Create new document group."""
         group = DocumentGroup(
             offering_type_id=offering_type_id,
             admission_method_id=admission_method_id,
+            admission_path_id=admission_path_id,
             code=code,
             name=name,
             description=description,
@@ -152,12 +154,16 @@ class DocumentGroupRepository(BaseRepository[DocumentGroup]):
         **updates
     ) -> DocumentGroup:
         """Update existing document group."""
-        allowed_fields = {"name", "description", "is_active"}
-        
+        # phase1_06 (#184 Wave 1 PR-1C') — admission_path_id editable
+        # so admin can re-target a group between path / method / shared
+        # tiers. Service layer is responsible for the invariant check
+        # before this method runs.
+        allowed_fields = {"name", "description", "is_active", "admission_path_id"}
+
         for field, value in updates.items():
             if field in allowed_fields:
                 setattr(group, field, value)
-        
+
         await self.db.flush()
         return group
 

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -45,7 +45,7 @@ def _validate_minor_correction_allowlist(
 
 AdmissionPathStatus = Literal["draft", "active", "inactive", "archived"]
 VisibilityStatus = Literal["internal", "public"]
-DocumentSource = Literal["shared", "method_override"]
+DocumentSource = Literal["shared", "method_override", "path_override"]
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/schemas/document_group.py
+++ b/Backend_FastAPI/app/schemas/document_group.py
@@ -67,11 +67,16 @@ class DocumentGroupCreate(BaseModel):
     """Request schema for creating a document group."""
     offering_type_id: int
     admission_method_id: Optional[int] = None  # NULL = shared
+    # phase1_06 (#184 Wave 1 PR-1C') — path-level override (tier 1
+    # of 3-tier resolution). NULL = legacy method/shared override.
+    # Service raises BusinessRuleViolation if set + offering_type
+    # / method don't match the path.
+    admission_path_id: Optional[int] = None
     code: str
     name: str
     description: Optional[str] = None
     is_active: Optional[bool] = True
-    
+
     # Items to add
     items: Optional[List[DocumentGroupItemCreate]] = None
 
@@ -81,7 +86,12 @@ class DocumentGroupUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     is_active: Optional[bool] = None
-    
+    # phase1_06 — admin can re-target a group to a different path
+    # (or clear it back to method/shared with explicit ``null``).
+    # ``model_dump(exclude_unset=True)`` distinguishes "key absent"
+    # (= leave unchanged) from "key=null" (= clear path FK).
+    admission_path_id: Optional[int] = None
+
     # Replace all items
     items: Optional[List[DocumentGroupItemCreate]] = None
 
@@ -89,18 +99,21 @@ class DocumentGroupUpdate(BaseModel):
 class DocumentGroupResponse(BaseModel):
     """Response schema for document group."""
     model_config = ConfigDict(from_attributes=True)
-    
+
     id: int
     offering_type_id: int
     admission_method_id: Optional[int] = None
+    # phase1_06 — REQUIRED in response (no default) so Pydantic /
+    # FE Zod parse fails loudly when BE forgets to map the column.
+    admission_path_id: Optional[int]
     code: str
     name: str
     description: Optional[str] = None
     is_active: bool
-    
+
     # Nested method (for display)
     admission_method: Optional[AdmissionMethodNested] = None
-    
+
     # Items
     items: List[DocumentGroupItemResponse] = []
 

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -679,24 +679,54 @@ class AdmissionPathService:
         """
         Resolve document requirements for a path.
 
-        Override Resolution Rule:
-        1. Load shared groups (admission_method_id = NULL)
-        2. Load method-specific groups (admission_method_id = path.method)
-        3. Merge: method-specific OVERRIDES shared for same document_type
+        phase1_06 (#184 Wave 1 PR-1C') — 3-tier resolution rule
+        per PLAN line 619-623:
+
+        1. **Tier 1**: ``WHERE admission_path_id = path.id`` →
+           if any rows match, USE THIS TIER FULLY (ignore tier 2 + 3).
+        2. **Tier 2**: ``WHERE admission_method_id = path.method
+           AND admission_path_id IS NULL`` → if any rows match,
+           USE THIS TIER FULLY (ignore tier 3).
+        3. **Tier 3**: ``WHERE offering_type_id = X AND
+           admission_method_id IS NULL AND admission_path_id IS NULL``
+           → fallback shared bucket.
+
+        Within a tier, multiple groups merge with mandatory-wins
+        (existing precedence preserved). Source indicators on the
+        response surface which tier provided each document so the
+        FE / admin can debug drift.
 
         Returns:
             List of resolved documents with source indicator
+            (``path_override`` / ``method_override`` / ``shared``).
         """
-        shared_groups, method_groups = await self.repo.get_document_groups_for_path(
-            offering_type_id, path.admission_method_id
+        path_groups, method_groups, shared_groups = (
+            await self.repo.get_document_groups_for_path(
+                offering_type_id,
+                path.admission_method_id,
+                admission_path_id=path.id,
+            )
         )
 
-        # Build document map: document_type_id -> (item, source)
+        # Build document map: document_type_id -> (item, source).
+        # Tier precedence: highest tier with non-empty groups wins
+        # FULLY; lower tiers are ignored (admin "deletes" default
+        # items by configuring a higher tier).
         doc_map: dict = {}
 
-        if method_groups:
-            # Case 1: Method-specific config exists -> FULL OVERRIDE
-            # We ignore shared groups completely to allow "deleting" default items
+        if path_groups:
+            # Tier 1 — path-specific (PR-1C' new). Mandatory-wins
+            # within the tier so two path groups can layer.
+            for group in path_groups:
+                for item in group.items:
+                    existing = doc_map.get(item.document_type_id)
+                    if existing is None:
+                        doc_map[item.document_type_id] = (item, "path_override")
+                    elif item.is_mandatory and not existing[0].is_mandatory:
+                        doc_map[item.document_type_id] = (item, "path_override")
+        elif method_groups:
+            # Tier 2 — method-specific. Existing legacy bucket;
+            # behavior unchanged from pre-PR-1C'.
             for group in method_groups:
                 for item in group.items:
                     existing = doc_map.get(item.document_type_id)
@@ -705,7 +735,7 @@ class AdmissionPathService:
                     elif item.is_mandatory and not existing[0].is_mandatory:
                         doc_map[item.document_type_id] = (item, "method_override")
         else:
-            # Case 2: No specific config -> Use Shared Defaults
+            # Tier 3 — shared offering-type fallback.
             for group in shared_groups:
                 for item in group.items:
                     existing = doc_map.get(item.document_type_id)

--- a/Backend_FastAPI/app/services/document_group_service.py
+++ b/Backend_FastAPI/app/services/document_group_service.py
@@ -12,9 +12,13 @@ Follows MASTER_ARCHITECTURE.md:
 from typing import Callable, Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models import User
 from app.models.admission_config import DocumentGroup
+from app.models.admission_config.admission_path import AdmissionPath
+from app.models.offering_academic_info import OfferingAcademicInfo
+from app.models.program_offering import ProgramOffering
 from app.repositories.document_group_repository import DocumentGroupRepository
 from app.schemas.document_group import (
     DocumentGroupCreate,
@@ -23,12 +27,79 @@ from app.schemas.document_group import (
 from app.utils.exceptions import (
     ResourceNotFoundError,
     DuplicateResourceError,
+    BusinessRuleViolation,
 )
 
 
 async def _noop_callback():
     """No-op callback for operations without side effects."""
     pass
+
+
+async def _validate_path_invariant(
+    db: AsyncSession,
+    *,
+    admission_path_id: int,
+    offering_type_id: int,
+    admission_method_id: int | None,
+) -> None:
+    """phase1_06 (#184 Wave 1 PR-1C') invariant — when a DocumentGroup
+    references a path, its offering_type + method MUST be consistent
+    with the path's. PLAN line 2671-2682.
+
+    The 3-tier resolution rule chooses path-level groups BEFORE
+    looking at offering_type or method, so an inconsistent group
+    would silently leak into a profile that doesn't match. Cheaper
+    to catch here than to silently corrupt resolution.
+
+    Raises:
+        ResourceNotFoundError: ``admission_path_id`` doesn't exist.
+        BusinessRuleViolation: offering_type or method drift detected.
+    """
+    # Eager-load the chain path → academic_info → offering so the
+    # offering_type comparison runs without a per-attribute round trip.
+    from sqlalchemy import select
+
+    query = (
+        select(AdmissionPath)
+        .where(AdmissionPath.id == admission_path_id)
+        .options(
+            selectinload(AdmissionPath.academic_info)
+            .selectinload(OfferingAcademicInfo.offering)
+        )
+    )
+    result = await db.execute(query)
+    path = result.scalars().first()
+
+    if path is None:
+        raise ResourceNotFoundError(
+            f"AdmissionPath id={admission_path_id} không tồn tại"
+        )
+
+    # offering_type comparison — path's offering_type comes from the
+    # ProgramOffering linked through OfferingAcademicInfo.
+    path_offering_type_id = (
+        path.academic_info.offering.offering_type_id
+        if path.academic_info and path.academic_info.offering
+        else None
+    )
+    if path_offering_type_id != offering_type_id:
+        raise BusinessRuleViolation(
+            f"DocumentGroup.offering_type_id={offering_type_id} lệch path "
+            f"(path offering_type_id={path_offering_type_id})"
+        )
+
+    # admission_method comparison — DocumentGroup may have method
+    # NULL (= applies to all methods of the path) or a specific method
+    # MATCHING the path's method. Anything else is drift.
+    if (
+        admission_method_id is not None
+        and admission_method_id != path.admission_method_id
+    ):
+        raise BusinessRuleViolation(
+            f"DocumentGroup.admission_method_id={admission_method_id} lệch "
+            f"path (path method_id={path.admission_method_id})"
+        )
 
 
 class DocumentGroupService:
@@ -69,6 +140,17 @@ class DocumentGroupService:
         if existing:
             raise DuplicateResourceError(f"DocumentGroup with code '{data.code}' already exists")
 
+        # phase1_06 invariant — when admin opts into path-level tier,
+        # offering_type + method MUST be consistent with the path's.
+        # Skip when path is NULL (legacy method/shared override).
+        if data.admission_path_id is not None:
+            await _validate_path_invariant(
+                self.db,
+                admission_path_id=data.admission_path_id,
+                offering_type_id=data.offering_type_id,
+                admission_method_id=data.admission_method_id,
+            )
+
         # Create group
         group = await self.repo.create_group(
             offering_type_id=data.offering_type_id,
@@ -76,6 +158,7 @@ class DocumentGroupService:
             name=data.name,
             description=data.description,
             admission_method_id=data.admission_method_id,
+            admission_path_id=data.admission_path_id,
             is_active=data.is_active if data.is_active is not None else True,
         )
 
@@ -107,15 +190,37 @@ class DocumentGroupService:
         Returns:
             Tuple of (updated group, callback)
         """
-        # Build update dict
+        # phase1_06 — distinguish "key absent" (= leave path
+        # unchanged) from "key=null" (= clear path FK). Schema
+        # ``model_dump(exclude_unset=True)`` is the canonical way;
+        # use it once and bind into ``updates``.
+        update_data = data.model_dump(exclude_unset=True)
+
+        # Build update dict — only the explicitly-set keys flow through.
         updates = {}
-        
+
         if data.name is not None:
             updates["name"] = data.name
         if data.description is not None:
             updates["description"] = data.description
         if data.is_active is not None:
             updates["is_active"] = data.is_active
+
+        # phase1_06 — admin re-targets group to a different path
+        # (or clears with explicit ``null``). Validate invariant
+        # against the EFFECTIVE state (new path id + existing
+        # offering_type + admission_method since those are immutable
+        # post-create per repo allowlist).
+        if "admission_path_id" in update_data:
+            new_path_id = update_data["admission_path_id"]
+            updates["admission_path_id"] = new_path_id
+            if new_path_id is not None:
+                await _validate_path_invariant(
+                    self.db,
+                    admission_path_id=new_path_id,
+                    offering_type_id=group.offering_type_id,
+                    admission_method_id=group.admission_method_id,
+                )
 
         # Apply updates
         if updates:

--- a/Backend_FastAPI/tests/unit/test_admission_path_resolution_3tier.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_resolution_3tier.py
@@ -1,0 +1,191 @@
+"""3-tier resolution rule tests for
+``AdmissionPathService.resolve_documents_for_path`` (#184 Wave 1
+PR-1C' / phase1_06).
+
+PLAN line 619-623 + line 2683 contract — when resolving the
+document checklist for an admission path:
+
+1. **Tier 1**: any DocumentGroup with ``admission_path_id =
+   path.id`` wins fully (ignore tier 2 + 3).
+2. **Tier 2**: else any DocumentGroup with
+   ``admission_path_id IS NULL`` AND ``admission_method_id =
+   path.method`` wins fully (ignore tier 3).
+3. **Tier 3**: else fall back to shared
+   (``admission_path_id IS NULL`` AND ``admission_method_id IS
+   NULL``).
+
+Within a tier, mandatory-wins on duplicate document_type. Source
+indicators on the response surface which tier provided each
+document so admin can debug drift via FE.
+
+What does NOT live here:
+* Migration / schema shape — see
+  ``test_phase1_05_06_revision_chain.py``.
+* DocumentGroup invariant on path FK — see
+  ``test_document_group_service_phase1_06_invariant.py``.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.admission_path_service import AdmissionPathService
+
+
+pytestmark = pytest.mark.unit
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+def _doc_type(code: str, name: str = "doc"):
+    return SimpleNamespace(code=code, name=name)
+
+
+def _item(doc_type_code: str, *, is_mandatory=True, display_order=0):
+    return SimpleNamespace(
+        document_type_id=hash(doc_type_code) % 10_000,
+        document_type=_doc_type(doc_type_code),
+        is_mandatory=is_mandatory,
+        requires_upload=True,
+        submission_format=None,
+        display_order=display_order,
+    )
+
+
+def _group(*items):
+    return SimpleNamespace(items=list(items))
+
+
+def _path(*, path_id=42, admission_method_id=10):
+    return SimpleNamespace(id=path_id, admission_method_id=admission_method_id)
+
+
+def _make_service(*, path_groups, method_groups, shared_groups):
+    """Service stub whose repo returns the (path, method, shared)
+    triple per the new repository contract."""
+    service = AdmissionPathService.__new__(AdmissionPathService)
+    service.db = MagicMock()
+    service.repo = MagicMock()
+    service.repo.get_document_groups_for_path = AsyncMock(
+        return_value=(path_groups, method_groups, shared_groups)
+    )
+    return service
+
+
+# =============================================================================
+# Tier precedence
+# =============================================================================
+
+
+class TestThreeTierPrecedence:
+    @pytest.mark.asyncio
+    async def test_tier1_path_wins_fully_over_tier2_and_tier3(self):
+        """Path-level group present → tier 1 wins fully; tier 2 +
+        tier 3 are ignored even if they would contribute different
+        documents."""
+        service = _make_service(
+            path_groups=[_group(_item("CCCD", display_order=1))],
+            method_groups=[_group(_item("HOC_BA", display_order=2))],
+            shared_groups=[_group(_item("ANH3X4", display_order=3))],
+        )
+        resolved, _ = await service.resolve_documents_for_path(
+            _path(), offering_type_id=5
+        )
+        codes = [doc.document_type_code for doc in resolved]
+        assert codes == ["CCCD"]
+        assert all(doc.source == "path_override" for doc in resolved)
+
+    @pytest.mark.asyncio
+    async def test_tier2_method_wins_when_no_path_groups(self):
+        """No path-level groups → fall through to tier 2 (method)
+        and ignore tier 3."""
+        service = _make_service(
+            path_groups=[],
+            method_groups=[_group(_item("HOC_BA", display_order=2))],
+            shared_groups=[_group(_item("ANH3X4", display_order=3))],
+        )
+        resolved, _ = await service.resolve_documents_for_path(
+            _path(), offering_type_id=5
+        )
+        codes = [doc.document_type_code for doc in resolved]
+        assert codes == ["HOC_BA"]
+        assert all(doc.source == "method_override" for doc in resolved)
+
+    @pytest.mark.asyncio
+    async def test_tier3_shared_wins_when_no_path_no_method(self):
+        """No path-level + no method-specific → fall through to
+        shared tier."""
+        service = _make_service(
+            path_groups=[],
+            method_groups=[],
+            shared_groups=[_group(_item("ANH3X4", display_order=3))],
+        )
+        resolved, _ = await service.resolve_documents_for_path(
+            _path(), offering_type_id=5
+        )
+        codes = [doc.document_type_code for doc in resolved]
+        assert codes == ["ANH3X4"]
+        assert all(doc.source == "shared" for doc in resolved)
+
+    @pytest.mark.asyncio
+    async def test_no_groups_at_any_tier_returns_empty_list(self):
+        service = _make_service(
+            path_groups=[], method_groups=[], shared_groups=[]
+        )
+        resolved, _ = await service.resolve_documents_for_path(
+            _path(), offering_type_id=5
+        )
+        assert resolved == []
+
+
+# =============================================================================
+# Within-tier precedence — mandatory wins
+# =============================================================================
+
+
+class TestWithinTierMandatoryWins:
+    @pytest.mark.asyncio
+    async def test_path_tier_mandatory_overrides_optional(self):
+        """Two path-level groups touch the same document_type — the
+        mandatory item wins, mirroring legacy tier-2/tier-3 logic."""
+        # Same document_type_code → same hash bucket.
+        optional_first = _item("HOC_BA", is_mandatory=False, display_order=1)
+        mandatory_second = _item("HOC_BA", is_mandatory=True, display_order=2)
+        service = _make_service(
+            path_groups=[_group(optional_first), _group(mandatory_second)],
+            method_groups=[],
+            shared_groups=[],
+        )
+        resolved, _ = await service.resolve_documents_for_path(
+            _path(), offering_type_id=5
+        )
+        # One item only (same document_type), mandatory.
+        assert len(resolved) == 1
+        assert resolved[0].is_mandatory is True
+        assert resolved[0].source == "path_override"
+
+
+# =============================================================================
+# Repository contract — caller passes path id only when path tier exists
+# =============================================================================
+
+
+class TestRepoContract:
+    @pytest.mark.asyncio
+    async def test_repo_receives_path_id_argument(self):
+        """The service MUST pass ``path.id`` to the repo so tier-1
+        query runs. A regression that drops the kwarg silently
+        degrades the new feature back to 2-tier resolution."""
+        service = _make_service(
+            path_groups=[], method_groups=[], shared_groups=[]
+        )
+        await service.resolve_documents_for_path(
+            _path(path_id=99), offering_type_id=5
+        )
+        kwargs = service.repo.get_document_groups_for_path.call_args.kwargs
+        assert kwargs.get("admission_path_id") == 99

--- a/Backend_FastAPI/tests/unit/test_document_group_service_phase1_06_invariant.py
+++ b/Backend_FastAPI/tests/unit/test_document_group_service_phase1_06_invariant.py
@@ -1,0 +1,333 @@
+"""Service invariant tests for the phase1_06 DocumentGroup
+``admission_path_id`` field (#184 Wave 1 PR-1C').
+
+PLAN line 2671-2682 contract — when admin creates / updates a
+DocumentGroup with ``admission_path_id`` set, the service must
+validate:
+
+* ``DocumentGroup.offering_type_id == path.academic_info.offering.offering_type_id``
+* ``DocumentGroup.admission_method_id`` is None OR equals
+  ``path.admission_method_id``
+
+Mismatch → ``BusinessRuleViolation``. Reason: the 3-tier
+resolution rule chooses path-level groups BEFORE checking
+offering_type / method, so an inconsistent group would silently
+leak into a profile that doesn't match the path's offering.
+
+This file locks the invariant on both create + update paths,
+plus the path-NULL passthrough (legacy method/shared groups
+keep working unchanged).
+
+What does NOT live here:
+* Migration shape — see ``test_phase1_05_06_revision_chain.py``.
+* 3-tier resolution rule (which tier wins) — see
+  ``test_admission_path_resolution_3tier.py``.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.document_group import (
+    DocumentGroupCreate,
+    DocumentGroupUpdate,
+)
+from app.services.document_group_service import (
+    DocumentGroupService,
+    _validate_path_invariant,
+)
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    ResourceNotFoundError,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+def _path(*, path_id=42, offering_type_id=1, admission_method_id=10):
+    """Path stub with eager-loaded academic_info → offering chain so
+    ``_validate_path_invariant`` can read offering_type without a
+    real DB."""
+    offering = SimpleNamespace(offering_type_id=offering_type_id)
+    academic_info = SimpleNamespace(offering=offering)
+    return SimpleNamespace(
+        id=path_id,
+        admission_method_id=admission_method_id,
+        academic_info=academic_info,
+    )
+
+
+def _make_db_with_path(path):
+    """AsyncSession stub whose ``execute`` returns ``path`` from
+    ``scalars().first()``."""
+    db = MagicMock()
+
+    async def _execute(query):
+        result = MagicMock()
+        scalars = MagicMock()
+        scalars.first = MagicMock(return_value=path)
+        result.scalars = MagicMock(return_value=scalars)
+        return result
+
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+def _make_db_with_no_path():
+    db = MagicMock()
+
+    async def _execute(query):
+        result = MagicMock()
+        scalars = MagicMock()
+        scalars.first = MagicMock(return_value=None)
+        result.scalars = MagicMock(return_value=scalars)
+        return result
+
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+def _make_service(db):
+    """Construct a DocumentGroupService with a stubbed repo."""
+    service = DocumentGroupService.__new__(DocumentGroupService)
+    service.db = db
+
+    repo = MagicMock()
+    repo.get_by_code = AsyncMock(return_value=None)
+    repo.create_group = AsyncMock(side_effect=lambda **kwargs: SimpleNamespace(
+        id=1, **kwargs
+    ))
+
+    async def _fake_update(group, **updates):
+        for k, v in updates.items():
+            setattr(group, k, v)
+        return group
+
+    repo.update_group = AsyncMock(side_effect=_fake_update)
+    repo.add_item_to_group = AsyncMock()
+    service.repo = repo
+    return service
+
+
+def _user():
+    return SimpleNamespace(id=1, role="admin")
+
+
+# =============================================================================
+# 1. _validate_path_invariant — direct unit tests
+# =============================================================================
+
+
+class TestValidatePathInvariant:
+    @pytest.mark.asyncio
+    async def test_matches_offering_and_method_passes(self):
+        path = _path(offering_type_id=5, admission_method_id=10)
+        db = _make_db_with_path(path)
+        # No raise — invariant satisfied.
+        await _validate_path_invariant(
+            db,
+            admission_path_id=42,
+            offering_type_id=5,
+            admission_method_id=10,
+        )
+
+    @pytest.mark.asyncio
+    async def test_method_null_with_matching_offering_passes(self):
+        """DocumentGroup with method=NULL is the "applies to any
+        method" semantic. PR-1C' spec allows this — invariant
+        only blocks mismatched non-null methods."""
+        path = _path(offering_type_id=5, admission_method_id=10)
+        db = _make_db_with_path(path)
+        await _validate_path_invariant(
+            db,
+            admission_path_id=42,
+            offering_type_id=5,
+            admission_method_id=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_offering_type_drift_raises(self):
+        path = _path(offering_type_id=5, admission_method_id=10)
+        db = _make_db_with_path(path)
+        with pytest.raises(BusinessRuleViolation, match="offering_type"):
+            await _validate_path_invariant(
+                db,
+                admission_path_id=42,
+                offering_type_id=99,
+                admission_method_id=10,
+            )
+
+    @pytest.mark.asyncio
+    async def test_method_drift_raises(self):
+        path = _path(offering_type_id=5, admission_method_id=10)
+        db = _make_db_with_path(path)
+        with pytest.raises(BusinessRuleViolation, match="method"):
+            await _validate_path_invariant(
+                db,
+                admission_path_id=42,
+                offering_type_id=5,
+                admission_method_id=99,
+            )
+
+    @pytest.mark.asyncio
+    async def test_path_not_found_raises_resource_not_found(self):
+        db = _make_db_with_no_path()
+        with pytest.raises(ResourceNotFoundError, match="AdmissionPath"):
+            await _validate_path_invariant(
+                db,
+                admission_path_id=42,
+                offering_type_id=5,
+                admission_method_id=10,
+            )
+
+
+# =============================================================================
+# 2. create_group — invariant integration
+# =============================================================================
+
+
+class TestCreateGroupPathInvariant:
+    @pytest.mark.asyncio
+    async def test_create_with_matching_path_persists(self):
+        path = _path(offering_type_id=5, admission_method_id=10)
+        service = _make_service(_make_db_with_path(path))
+
+        data = DocumentGroupCreate.model_validate(
+            {
+                "offering_type_id": 5,
+                "admission_method_id": 10,
+                "admission_path_id": 42,
+                "code": "HS_PATH_42",
+                "name": "Hồ sơ path 42",
+            }
+        )
+        group, _ = await service.create_group(data, _user())
+        assert group.admission_path_id == 42
+        # Repo received the path id.
+        service.repo.create_group.assert_called_once()
+        kwargs = service.repo.create_group.call_args.kwargs
+        assert kwargs["admission_path_id"] == 42
+
+    @pytest.mark.asyncio
+    async def test_create_with_offering_drift_raises(self):
+        path = _path(offering_type_id=5, admission_method_id=10)
+        service = _make_service(_make_db_with_path(path))
+
+        data = DocumentGroupCreate.model_validate(
+            {
+                "offering_type_id": 99,  # drift
+                "admission_method_id": 10,
+                "admission_path_id": 42,
+                "code": "HS_DRIFT",
+                "name": "Lệch offering",
+            }
+        )
+        with pytest.raises(BusinessRuleViolation, match="offering_type"):
+            await service.create_group(data, _user())
+        # Repo never reached because invariant failed first.
+        service.repo.create_group.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_with_path_null_skips_invariant(self):
+        """Legacy method/shared groups (path NULL) MUST keep working
+        without the invariant query. Otherwise PR-1C' would break
+        every existing legacy create path."""
+        # No path → no validation; the db.execute should never run.
+        db = MagicMock()
+        db.execute = AsyncMock()
+        service = _make_service(db)
+
+        data = DocumentGroupCreate.model_validate(
+            {
+                "offering_type_id": 5,
+                "admission_method_id": 10,
+                "code": "HS_LEGACY_METHOD",
+                "name": "Legacy method-specific",
+            }
+        )
+        group, _ = await service.create_group(data, _user())
+        assert group.admission_path_id is None
+        db.execute.assert_not_awaited()
+
+
+# =============================================================================
+# 3. update_group — invariant on path re-target
+# =============================================================================
+
+
+def _existing_group(*, group_id=7, offering_type_id=5, admission_method_id=10,
+                    admission_path_id=None):
+    """Stand-in for an already-persisted DocumentGroup row that
+    update_group operates on."""
+    return SimpleNamespace(
+        id=group_id,
+        offering_type_id=offering_type_id,
+        admission_method_id=admission_method_id,
+        admission_path_id=admission_path_id,
+        name="Existing",
+        description=None,
+        is_active=True,
+    )
+
+
+class TestUpdateGroupPathInvariant:
+    @pytest.mark.asyncio
+    async def test_update_re_target_to_matching_path_persists(self):
+        path = _path(path_id=42, offering_type_id=5, admission_method_id=10)
+        service = _make_service(_make_db_with_path(path))
+        group = _existing_group(offering_type_id=5, admission_method_id=10)
+
+        data = DocumentGroupUpdate.model_validate({"admission_path_id": 42})
+        updated, _ = await service.update_group(group, data, _user())
+        assert updated.admission_path_id == 42
+
+    @pytest.mark.asyncio
+    async def test_update_clear_path_to_null_skips_invariant(self):
+        """Admin can clear the path FK back to NULL (= fall back to
+        method/shared tier). No invariant query needed because the
+        target state has no path constraint."""
+        db = MagicMock()
+        db.execute = AsyncMock()
+        service = _make_service(db)
+        group = _existing_group(admission_path_id=42)
+
+        data = DocumentGroupUpdate.model_validate({"admission_path_id": None})
+        updated, _ = await service.update_group(group, data, _user())
+        assert updated.admission_path_id is None
+        db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_re_target_to_drifted_path_raises(self):
+        path = _path(offering_type_id=99, admission_method_id=10)
+        service = _make_service(_make_db_with_path(path))
+        group = _existing_group(offering_type_id=5, admission_method_id=10)
+
+        data = DocumentGroupUpdate.model_validate({"admission_path_id": 42})
+        with pytest.raises(BusinessRuleViolation, match="offering_type"):
+            await service.update_group(group, data, _user())
+        # Repo update never ran because invariant failed first.
+        service.repo.update_group.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_omitted_path_key_left_unchanged(self):
+        """exclude_unset semantic — admin omitting the key means
+        "leave path unchanged"; invariant must not run."""
+        db = MagicMock()
+        db.execute = AsyncMock()
+        service = _make_service(db)
+        group = _existing_group(admission_path_id=42)
+
+        data = DocumentGroupUpdate.model_validate({"name": "Renamed"})
+        updated, _ = await service.update_group(group, data, _user())
+        # Path unchanged because the key wasn't in the payload.
+        assert updated.admission_path_id == 42
+        assert updated.name == "Renamed"
+        db.execute.assert_not_awaited()

--- a/Backend_FastAPI/tests/unit/test_phase1_05_06_revision_chain.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_05_06_revision_chain.py
@@ -1,0 +1,257 @@
+"""Unit tests for #184 Wave 1 PR-1C' migrations
+(``phase1_05_add_subject_kind_and_score_bounds`` +
+``phase1_06_add_path_id_to_document_group``).
+
+Pure-text contract tests — locks the revision chain, the upgrade
+SQL surface, the ENUM type values, the seed semantics, the
+partial index predicate, and the ORM model parity. A regression
+in any surface fails CI before the migration runs against a real
+DB.
+
+What lives here:
+1. Revision row + linear chain (phase1_03 → phase1_05 → phase1_06).
+2. phase1_05 ENUM 4 values + 3 column add + 6 seed rows.
+3. phase1_06 FK column + partial index predicate.
+4. Subject ORM model declares 3 new fields with correct types.
+5. DocumentGroup ORM model declares ``admission_path_id`` FK.
+
+What does NOT live here:
+* End-to-end DDL apply — ``alembic upgrade head`` smoke runs in
+  the dev container.
+* Service invariant for DocumentGroup path FK — see
+  ``test_document_group_service_phase1_06_invariant.py``.
+* 3-tier resolution rule — see
+  ``test_admission_path_resolution_3tier.py``.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_PHASE1_05_FILE = _VERSIONS_DIR / "phase1_05_add_subject_kind_and_score_bounds.py"
+_PHASE1_06_FILE = _VERSIONS_DIR / "phase1_06_add_path_id_to_document_group.py"
+
+
+def _load_migration(filename: str):
+    path = _VERSIONS_DIR / filename
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_05():
+    return _load_migration(_PHASE1_05_FILE.name)
+
+
+@pytest.fixture
+def phase1_06():
+    return _load_migration(_PHASE1_06_FILE.name)
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision row + linear chain
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_05_revision_id(phase1_05) -> None:
+    assert phase1_05.revision == "phase1_05"
+
+
+def test_phase1_05_chains_off_phase1_03(phase1_05) -> None:
+    """phase1_04 is DEFERRED Q1/2027 (Q9 chốt 2026-05-01) so the
+    chain skips it intentionally — phase1_05 → phase1_03 directly.
+    """
+    assert phase1_05.down_revision == "phase1_03"
+
+
+def test_phase1_06_revision_id(phase1_06) -> None:
+    assert phase1_06.revision == "phase1_06"
+
+
+def test_phase1_06_chains_off_phase1_05(phase1_06) -> None:
+    assert phase1_06.down_revision == "phase1_05"
+
+
+def test_neither_has_branch_labels(phase1_05, phase1_06) -> None:
+    assert phase1_05.branch_labels is None
+    assert phase1_06.branch_labels is None
+
+
+# ---------------------------------------------------------------------------
+# 2. phase1_05 ENUM contract
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_05_declares_4_subject_kind_values(phase1_05) -> None:
+    """4-value ENUM per PLAN line 733-737. Adding a value = update
+    migration + Subject model SUBJECT_KIND_VALUES + downstream
+    consumer in lockstep."""
+    assert phase1_05.SUBJECT_KIND_VALUES == (
+        "ACADEMIC_SUBJECT",
+        "TERM_AVERAGE",
+        "ABILITY_TEST",
+        "CERTIFICATE",
+    )
+
+
+def test_phase1_05_creates_subject_kind_enum() -> None:
+    src = _PHASE1_05_FILE.read_text(encoding="utf-8")
+    assert 'name="subject_kind"' in src
+    assert ".create(op.get_bind(), checkfirst=True)" in src
+
+
+def test_phase1_05_drops_subject_kind_enum_in_downgrade() -> None:
+    src = _PHASE1_05_FILE.read_text(encoding="utf-8")
+    assert ".drop(op.get_bind(), checkfirst=True)" in src
+
+
+# ---------------------------------------------------------------------------
+# 3. phase1_05 column add contract
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_05_adds_subject_kind_with_server_default() -> None:
+    """Server default backfills every existing row at ALTER time
+    (no row-by-row UPDATE). NOT NULL post-migration so the scoring
+    engine never has to handle NULL kind."""
+    src = _PHASE1_05_FILE.read_text(encoding="utf-8")
+    assert '"subject_kind"' in src
+    # Server default cast clause locks the type-aware backfill
+    # so a future careless edit can't drop the cast.
+    assert "'ACADEMIC_SUBJECT'::subject_kind" in src
+    assert "nullable=False" in src
+
+
+def test_phase1_05_adds_max_and_min_possible_score_nullable() -> None:
+    src = _PHASE1_05_FILE.read_text(encoding="utf-8")
+    assert '"max_score"' in src
+    assert '"min_possible_score"' in src
+    # Both are Numeric(precision=6, scale=2) and nullable.
+    assert "Numeric(precision=6, scale=2)" in src
+
+
+# ---------------------------------------------------------------------------
+# 4. phase1_05 seed contract
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_05_seeds_6_virtual_subjects() -> None:
+    """Six virtual subjects per PLAN line 745 + 4174-4181. ON
+    CONFLICT (code) DO NOTHING keeps the seed idempotent."""
+    src = _PHASE1_05_FILE.read_text(encoding="utf-8")
+    for code in (
+        "TB_HK1_L12",
+        "TB_HK2_L12",
+        "TB_CN_L12",
+        "DGNL_DHQGHN",
+        "V_ACT",
+        "IELTS",
+    ):
+        assert f"'{code}'" in src, f"seed row missing: {code}"
+
+    assert "ON CONFLICT (code) DO NOTHING" in src
+
+
+def test_phase1_05_downgrade_deletes_seeded_rows_before_dropping_enum() -> None:
+    """Inverse order — DELETE rows BEFORE dropping the enum, else
+    PG errors on type-still-in-use."""
+    src = _PHASE1_05_FILE.read_text(encoding="utf-8")
+    delete_pos = src.index("DELETE FROM subject")
+    drop_enum_pos = src.index(".drop(op.get_bind(), checkfirst=True)")
+    assert delete_pos < drop_enum_pos
+
+
+# ---------------------------------------------------------------------------
+# 5. phase1_06 FK + partial index contract
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_06_adds_admission_path_id_fk() -> None:
+    src = _PHASE1_06_FILE.read_text(encoding="utf-8")
+    assert '"admission_path_id"' in src
+    assert "create_foreign_key" in src
+    assert '"fk_document_group_admission_path"' in src
+    # ON DELETE SET NULL — deleting a path doesn't cascade-kill its
+    # document groups; they fall back to the lower tiers.
+    assert 'ondelete="SET NULL"' in src
+
+
+def test_phase1_06_creates_partial_index_with_correct_predicate() -> None:
+    """Partial index on admission_path_id WHERE NOT NULL keeps the
+    index small (most rows are legacy = NULL); tier-1 query
+    ``WHERE admission_path_id = X`` is the only consumer."""
+    src = _PHASE1_06_FILE.read_text(encoding="utf-8")
+    assert '"ix_doc_group_path"' in src
+    assert "admission_path_id IS NOT NULL" in src
+    assert "postgresql_where" in src
+
+
+def test_phase1_06_downgrade_drops_index_then_fk_then_column() -> None:
+    src = _PHASE1_06_FILE.read_text(encoding="utf-8")
+    drop_idx = src.index('drop_index("ix_doc_group_path"')
+    drop_fk = src.index('drop_constraint(\n        "fk_document_group_admission_path"')
+    drop_col = src.index('drop_column("document_group", "admission_path_id")')
+    assert drop_idx < drop_fk < drop_col
+
+
+# ---------------------------------------------------------------------------
+# 6. ORM model parity
+# ---------------------------------------------------------------------------
+
+
+def test_subject_model_declares_subject_kind() -> None:
+    from app.models.admission_config.subject import Subject, SUBJECT_KIND_VALUES
+
+    assert hasattr(Subject, "subject_kind")
+    column = Subject.__table__.columns["subject_kind"]
+    assert column.nullable is False
+    # 4 enum values mirror the migration constant.
+    assert SUBJECT_KIND_VALUES == (
+        "ACADEMIC_SUBJECT",
+        "TERM_AVERAGE",
+        "ABILITY_TEST",
+        "CERTIFICATE",
+    )
+
+
+def test_subject_model_declares_score_bounds() -> None:
+    from app.models.admission_config.subject import Subject
+
+    assert hasattr(Subject, "max_score")
+    assert hasattr(Subject, "min_possible_score")
+    max_col = Subject.__table__.columns["max_score"]
+    min_col = Subject.__table__.columns["min_possible_score"]
+    assert max_col.nullable is True
+    assert min_col.nullable is True
+    # Numeric(6, 2) — precision 6 / scale 2 (e.g. 1200.00 fits).
+    assert "NUMERIC" in type(max_col.type).__name__.upper()
+
+
+def test_document_group_model_declares_admission_path_id() -> None:
+    from app.models.admission_config.document_group import DocumentGroup
+
+    assert hasattr(DocumentGroup, "admission_path_id")
+    column = DocumentGroup.__table__.columns["admission_path_id"]
+    assert column.nullable is True
+    assert column.foreign_keys, "admission_path_id must declare an FK"
+    fk = next(iter(column.foreign_keys))
+    assert fk.column.table.name == "admission_path"
+    assert fk.column.name == "id"
+
+
+# ---------------------------------------------------------------------------
+# 7. Sanity — both migrations import cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_both_migrations_define_upgrade_and_downgrade(phase1_05, phase1_06) -> None:
+    for module in (phase1_05, phase1_06):
+        assert callable(getattr(module, "upgrade", None))
+        assert callable(getattr(module, "downgrade", None))

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -350,10 +350,18 @@ export type AcademicYearListResponse = z.infer<typeof academicYearListResponseSc
 /**
  * Resolved Document Response
  * Used for GET /api/admission-config/paths/{id}/documents
- * 
- * The `source` field indicates whether document config comes from:
- * - "shared": Applies to all methods (admission_method_id = NULL)
- * - "method_override": Method-specific config that overrides shared
+ *
+ * The `source` field indicates which tier of the 3-tier resolution
+ * (phase1_06 / #184 Wave 1 PR-1C') provided the document config:
+ * - "path_override": Tier 1 — path-specific group (admission_path_id = X)
+ * - "method_override": Tier 2 — method-specific override
+ *   (admission_path_id NULL, admission_method_id = path.method)
+ * - "shared": Tier 3 — shared offering-type fallback
+ *   (admission_path_id NULL, admission_method_id NULL)
+ *
+ * Precedence: tier 1 fully wins if present; else tier 2 fully
+ * wins; else tier 3. Within a tier, mandatory-wins on duplicate
+ * document_type.
  */
 export const resolvedDocumentResponseSchema = z.object({
   document_type_id: z.number(),
@@ -363,7 +371,7 @@ export const resolvedDocumentResponseSchema = z.object({
   requires_upload: z.boolean(),
   submission_format: z.string().nullable(),
   display_order: z.number(),
-  source: z.enum(["shared", "method_override"]),
+  source: z.enum(["shared", "method_override", "path_override"]),
 })
 
 export type ResolvedDocumentResponse = z.infer<typeof resolvedDocumentResponseSchema>


### PR DESCRIPTION
## Summary

Wave 1 PR-1C' — bốn sub-PR cuối của #184 Phase 1 Schema. 2 pure-additive migrations (`phase1_05`, `phase1_06`) + ORM/schema/service wiring + service invariant cho path-level governance + 3-tier document resolution (path → method → shared).

- **Branch off**: `aff47d61` (post PR-1B'-FE merge + tracking docs commit `7aaed879`/`c65c79d9`)
- **HEAD**: `fd4f8f38` — 1 commit, 14 files
- **PLAN refs**: §4 P1 #05 (subject_kind), §4 P1 #06 (doc_group path FK + 3-tier), §4 P1 fix #6 (precedence chốt)

## Key callouts

1. **Branch off `aff47d61`** (KHÔNG phải `efb64ec8`) — daily log drift đã ghi chú trong commit body, sẽ correct ở post-merge tracking commit.
2. **`phase1_04` intentionally skipped** — DEFERRED Q1/2027 per Q9 chốt 2026-05-01. Down-revision chain hiện tại: `phase1_03 → phase1_05 → phase1_06`.
3. **3-tier resolution precedence**: tier 1 path FULL OVERRIDE → tier 2 method FULL OVERRIDE → tier 3 shared. Within-tier `mandatory-wins` behaviour preserved từ pre-PR-1C'.
4. **Alembic roundtrip evidence**: tôi đã chạy upgrade `phase1_05`+`phase1_06` + downgrade về `phase1_03` + re-upgrade idempotent trên dev DB trước push. Reviewer chạy read-only — không cần rerun migration trên CI/local của reviewer.

## File scope (14)

**Backend (10)**
- `alembic/versions/phase1_05_add_subject_kind_and_score_bounds.py` (NEW) — ENUM `subject_kind` 4 values + `subject.subject_kind NOT NULL DEFAULT 'ACADEMIC_SUBJECT'` + `max_score`/`min_possible_score` Numeric(6,2) nullable + 6 seed `ON CONFLICT DO NOTHING` (display_order ≥ 100 tránh va legacy)
- `alembic/versions/phase1_06_add_path_id_to_document_group.py` (NEW) — `document_group.admission_path_id` integer nullable FK ON DELETE SET NULL + partial btree `WHERE admission_path_id IS NOT NULL`
- `app/models/admission_config/subject.py` — 3 cột mới + `SUBJECT_KIND_VALUES` tuple lockstep migration
- `app/models/admission_config/document_group.py` — FK column + relationship
- `app/schemas/document_group.py` — Create/Update/Response thêm `admission_path_id`; Response REQUIRED no-default (parse drift guard)
- `app/schemas/admission_path.py` — `DocumentSource` literal extend `path_override`
- `app/services/document_group_service.py` — `_validate_path_invariant` helper + tích hợp create/update; mismatch → `BusinessRuleViolation`
- `app/services/admission_path_service.py` — `resolve_documents_for_path` rewrite consume 3-tuple + 3-tier precedence
- `app/repositories/document_group_repository.py` — create/update accept `admission_path_id`; update allowlist extend
- `app/repositories/admission_path_repository.py` — `get_document_groups_for_path` rewrite return triple

**Frontend (1)**
- `frontend/src/lib/zod/admission-path.ts` — `ResolvedDocumentResponse.source` enum extend `path_override` + inline doc precedence

**Tests (3 files, 37 cases)**
- `tests/unit/test_phase1_05_06_revision_chain.py` (17): revision lock + ENUM contract + nullable semantic + seed lock + downgrade ordering + ORM parity
- `tests/unit/test_document_group_service_phase1_06_invariant.py` (12): invariant unit + create/update integration
- `tests/unit/test_admission_path_resolution_3tier.py` (8): tier-1 wins / tier-2 fallback / tier-3 fallback / within-tier mandatory / repo contract

## Test evidence (pre-push)

- BE targeted regression: **172/172 passed in 7.23s** (37 PR-1C' new + 18 PR-1B'-FE governance + 117 phase1_03 + path/migration regression). Tóm tắt subset re-verified: **114 passed in 7.02s**.
- FE `tsc --noEmit`: clean (chạy trong throwaway `docker compose run --rm --no-deps frontend` workspace, không stale `.next`).
- `git diff --check origin/feat/admission-full-cutover..HEAD`: clean.
- Alembic upgrade/downgrade/re-upgrade: clean trên dev DB.

## Test plan

- [ ] CI green (BE + FE + lint)
- [ ] Reviewer cross-check 3-tier precedence ngữ nghĩa (tier 1 PATH override → tier 2 METHOD override → tier 3 SHARED; within-tier mandatory-wins)
- [ ] Reviewer cross-check `phase1_04` deferral — down_revision chain skip không leave dangling head
- [ ] Reviewer cross-check service invariant: path NULL skip OK, path non-null mismatch raise `BusinessRuleViolation`
- [ ] Manual: log post-merge tracking entry để correct daily log drift `efb64ec8` → `aff47d61`

🤖 Generated with [Claude Code](https://claude.com/claude-code)