### PR TITLE
[#184 Wave2 PR-2A] feat(schema): phase1_09a eligibility scalars + phase1_10 status_history + 5 scattered audit migrate

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase1_09a_add_eligibility_scalars_and_backfill.py
+++ b/Backend_FastAPI/alembic/versions/phase1_09a_add_eligibility_scalars_and_backfill.py
@@ -1,0 +1,377 @@
+"""phase1_09a: add eligibility scalars + backfill gpa_overall + graduation_year
+
+Revision ID: phase1_09a
+Revises: phase1_13
+Create Date: 2026-05-04
+
+#184 Wave 2 PR-2A first migration. Add 4 nullable eligibility
+scalar columns on ``admission_profile`` + backfill 2 of them
+(``gpa_overall`` + ``graduation_year``) from
+``academic_history`` JSON. ``conduct`` + ``health_category`` stay
+NULL — no source in JSON, admin manual review qua UI Phase 1+2.
+
+PLAN refs
+---------
+* §4 P1 #09a (line 2699-2824) — column add + 2-field backfill body.
+* PLAN P2 fix #6 (line 398) — backfill scope = gpa + grad_year only.
+* PLAN P2 fix #10 (line 327) — cheat sheet wording fix; column adds
+  4 fields, backfill only 2.
+* PLAN line 818-820 — column types + lock-after-draft semantic.
+  Lock trigger ``phase1_09b`` is DEFERRED Q1/2027 per Q9 chốt
+  2026-05-01.
+
+Schema
+------
+
+* ``conduct_grade`` ENUM (3 values): ``TB`` (Trung bình), ``KHA``
+  (Khá), ``TOT`` (Tốt). Created BEFORE column add.
+
+* ``admission_profile.gpa_overall numeric(4,2) nullable`` — overall
+  GPA (0.00..10.00 scale). Backfilled from
+  ``academic_history`` JSON via LATERAL + WITH ORDINALITY.
+
+* ``admission_profile.conduct conduct_grade nullable`` — đạo đức.
+  STAYS NULL — no source in JSON. Admin reviews qua UI Phase 1+2.
+
+* ``admission_profile.health_category smallint nullable`` — phân
+  loại sức khỏe (1..4 — 1 tốt nhất). STAYS NULL — admin review UI.
+
+* ``admission_profile.graduation_year smallint nullable`` — năm tốt
+  nghiệp. Backfilled from MAX(year_to) of academic_history records.
+
+Backfill semantics
+------------------
+
+**gpa_overall**: pick GPA from the academic_history record with
+the HIGHEST ordinality (= latest year) that has a numeric GPA.
+NOT just the last record — last record may have NULL gpa but a
+prior record has a value. Length-bounded regex + range guard
+[0, 10] prevents overflow + clamps invalid data into the
+exception sink.
+
+**graduation_year**: pick MAX(year_to) from academic_history
+records where year_to is a 4-digit number in sane range
+(1900..2100 per PLAN line 2795). Out-of-range values land in
+``INVALID_GRADUATION_YEAR`` exception sink. Profile with
+``graduation_type`` set but malformed/missing year_to lands in
+``MISSING_GRADUATION_YEAR`` exception sink (PLAN line 2799-2811).
+
+**conduct + health_category**: stay NULL. NO backfill. Admin
+reviews via UI Phase 1+2 (Phase 4 admin maintenance flow with
+GUC bypass — see DEFERRED phase1_09b body).
+
+Idempotency
+-----------
+* All UPDATEs gated by ``WHERE <field> IS NULL`` per-row guard.
+* Exception inserts use ``ON CONFLICT (profile_id, exception_type)
+  DO NOTHING`` against ``_admission_backfill_exceptions``
+  (created in phase1_07b).
+* Re-running upgrade after partial failure leaves valid rows
+  alone + skips already-backfilled exceptions.
+
+Down-revision chain: ``phase1_13 → phase1_09a``. Note slot
+``phase1_09a`` (a) is intentional — phase1_09b (lock trigger) is
+DEFERRED so the chain runs straight to phase1_10 next.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_09a"
+down_revision: Union[str, None] = "phase1_13"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# ENUM values per PLAN line 818. Frozen here as the migration is
+# the source-of-truth; SQLAlchemy model mirrors via
+# ``postgresql.ENUM(name=..., create_type=False)``.
+CONDUCT_GRADE_VALUES: tuple[str, ...] = ("TB", "KHA", "TOT")
+
+
+def upgrade() -> None:
+    # 1. Create the conduct_grade ENUM type.
+    conduct_enum = postgresql.ENUM(
+        *CONDUCT_GRADE_VALUES,
+        name="conduct_grade",
+        create_type=False,
+    )
+    conduct_enum.create(op.get_bind(), checkfirst=True)
+
+    # 2. Add 4 nullable columns. All nullable so backfill can
+    #    populate selectively without violating constraints.
+    op.add_column(
+        "admission_profile",
+        sa.Column(
+            "gpa_overall",
+            sa.Numeric(precision=4, scale=2),
+            nullable=True,
+            comment="Overall GPA (0.00..10.00). Backfilled from academic_history JSON.",
+        ),
+    )
+    op.add_column(
+        "admission_profile",
+        sa.Column(
+            "conduct",
+            conduct_enum,
+            nullable=True,
+            comment=(
+                "Đạo đức (TB/KHA/TOT). STAYS NULL post-migration — no "
+                "source in academic_history JSON; admin reviews qua UI "
+                "Phase 1+2 (PLAN line 2813)."
+            ),
+        ),
+    )
+    op.add_column(
+        "admission_profile",
+        sa.Column(
+            "health_category",
+            sa.SmallInteger(),
+            nullable=True,
+            comment=(
+                "Phân loại sức khỏe (1..4 — 1 tốt nhất). STAYS NULL — "
+                "admin reviews qua UI Phase 1+2 (PLAN line 2814)."
+            ),
+        ),
+    )
+    op.add_column(
+        "admission_profile",
+        sa.Column(
+            "graduation_year",
+            sa.SmallInteger(),
+            nullable=True,
+            comment=(
+                "Năm tốt nghiệp (1900..2100). Backfilled from MAX(year_to) "
+                "of academic_history records."
+            ),
+        ),
+    )
+
+    # 3. Backfill gpa_overall — single statement with CTE chain.
+    #    Migration runs under ``isolation_level=AUTOCOMMIT`` (see
+    #    alembic env.py:57) so each ``op.execute`` opens a fresh
+    #    connection — TEMP TABLEs don't survive between calls.
+    #    Inline the staging via CTE so the parse + range filter +
+    #    DISTINCT ON pick run in ONE statement.
+    op.execute(
+        sa.text(
+            """
+            WITH staging AS (
+                SELECT
+                    p.id AS profile_id,
+                    rec.ord AS ord,
+                    rec.value->>'gpa' AS gpa_text,
+                    (rec.value->>'gpa')::numeric AS gpa_value_wide
+                FROM admission_profile p,
+                     LATERAL jsonb_array_elements(p.academic_history)
+                         WITH ORDINALITY AS rec(value, ord)
+                WHERE p.gpa_overall IS NULL
+                  AND p.academic_history IS NOT NULL
+                  AND rec.value->>'gpa' ~ '^[0-9]{1,3}(\\.[0-9]{1,4})?$'
+            ),
+            in_range AS (
+                SELECT profile_id, ord,
+                       gpa_value_wide::numeric(4,2) AS gpa_value
+                FROM staging
+                WHERE gpa_value_wide >= 0 AND gpa_value_wide <= 10
+            ),
+            picked AS (
+                SELECT DISTINCT ON (profile_id) profile_id, gpa_value
+                FROM in_range
+                ORDER BY profile_id, ord DESC
+            )
+            UPDATE admission_profile p
+            SET gpa_overall = picked.gpa_value
+            FROM picked
+            WHERE p.id = picked.profile_id
+              AND p.gpa_overall IS NULL
+            """
+        )
+    )
+
+    # INSERT exception sink for out-of-range GPA values — admin
+    # queue picks these up post-cutover. Re-runs the LATERAL parse
+    # (cheap on small dev DB; staging table not survivable across
+    # autocommit statements anyway).
+    op.execute(
+        sa.text(
+            """
+            WITH staging AS (
+                SELECT
+                    p.id AS profile_id,
+                    rec.value->>'gpa' AS gpa_text,
+                    (rec.value->>'gpa')::numeric AS gpa_value_wide
+                FROM admission_profile p,
+                     LATERAL jsonb_array_elements(p.academic_history)
+                         AS rec(value)
+                WHERE p.gpa_overall IS NULL
+                  AND p.academic_history IS NOT NULL
+                  AND rec.value->>'gpa' ~ '^[0-9]{1,3}(\\.[0-9]{1,4})?$'
+            )
+            INSERT INTO _admission_backfill_exceptions (profile_id, exception_type, details)
+            SELECT
+                profile_id,
+                'INVALID_GPA_VALUE',
+                jsonb_build_object(
+                    'gpa_text', MIN(gpa_text),
+                    'gpa_value_wide', MAX(gpa_value_wide)::text,
+                    'rule', 'gpa must be in [0, 10]'
+                )
+            FROM staging
+            WHERE gpa_value_wide < 0 OR gpa_value_wide > 10
+            GROUP BY profile_id
+            ON CONFLICT (profile_id, exception_type) DO NOTHING
+            """
+        )
+    )
+
+    # 4. Backfill graduation_year — MAX(year_to) where year_to is
+    #    a 4-digit number in sane range [1900, 2100] per PLAN line
+    #    2795. Tighter bounds (1990..2030) would reject legitimate
+    #    older graduations + future-dated international transfers.
+    op.execute(
+        sa.text(
+            """
+            WITH year_staging AS (
+                SELECT
+                    p.id AS profile_id,
+                    (rec.value->>'year_to')::int AS year_to_int
+                FROM admission_profile p,
+                     LATERAL jsonb_array_elements(p.academic_history)
+                         AS rec(value)
+                WHERE p.graduation_year IS NULL
+                  AND p.academic_history IS NOT NULL
+                  AND rec.value->>'year_to' ~ '^[0-9]{4}$'
+                  AND (rec.value->>'year_to')::int BETWEEN 1900 AND 2100
+            ),
+            picked AS (
+                SELECT profile_id, MAX(year_to_int) AS year_to_max
+                FROM year_staging
+                GROUP BY profile_id
+            )
+            UPDATE admission_profile p
+            SET graduation_year = picked.year_to_max
+            FROM picked
+            WHERE p.id = picked.profile_id
+              AND p.graduation_year IS NULL
+            """
+        )
+    )
+
+    # 4b. Exception sink for INVALID_GRADUATION_YEAR (PLAN line 2791-
+    #     2797) — year_to numeric but outside [1900, 2100]. Aggregates
+    #     all out-of-range years per profile so admin queue can
+    #     review the full set.
+    op.execute(
+        sa.text(
+            """
+            WITH year_staging AS (
+                SELECT
+                    p.id AS profile_id,
+                    (rec.value->>'year_to')::int AS year_to_int
+                FROM admission_profile p,
+                     LATERAL jsonb_array_elements(p.academic_history)
+                         AS rec(value)
+                WHERE p.graduation_year IS NULL
+                  AND p.academic_history IS NOT NULL
+                  AND rec.value->>'year_to' ~ '^[0-9]{4}$'
+            )
+            INSERT INTO _admission_backfill_exceptions (profile_id, exception_type, details)
+            SELECT
+                profile_id,
+                'INVALID_GRADUATION_YEAR',
+                jsonb_build_object(
+                    'out_of_range_years', array_agg(year_to_int),
+                    'rule', 'graduation_year must be in [1900, 2100]'
+                )
+            FROM year_staging
+            WHERE year_to_int NOT BETWEEN 1900 AND 2100
+            GROUP BY profile_id
+            ON CONFLICT (profile_id, exception_type) DO NOTHING
+            """
+        )
+    )
+
+    # 4c. Exception sink for MISSING_GRADUATION_YEAR (PLAN line 2801-
+    #     2811) — profile has at least one academic_history record
+    #     with ``graduation_type`` set, but no parseable ``year_to``,
+    #     so we can't backfill graduation_year. Admin queue picks
+    #     these up post-cutover for manual entry.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO _admission_backfill_exceptions (profile_id, exception_type, details)
+            SELECT
+                p.id,
+                'MISSING_GRADUATION_YEAR',
+                jsonb_build_object(
+                    'academic_history', p.academic_history,
+                    'rule', 'graduation_type set but year_to missing/malformed'
+                )
+            FROM admission_profile p
+            WHERE p.graduation_year IS NULL
+              AND p.academic_history IS NOT NULL
+              AND EXISTS (
+                  SELECT 1 FROM jsonb_array_elements(p.academic_history) AS rec(value)
+                  WHERE rec.value->>'graduation_type' IS NOT NULL
+              )
+            ON CONFLICT (profile_id, exception_type) DO NOTHING
+            """
+        )
+    )
+
+    # 5. Insert exception sink for profiles with NULL gpa_overall
+    #    after backfill (data nguồn lỗi). Only for status NOT IN
+    #    ('draft', 'revision_requested') — drafts haven't submitted
+    #    yet so missing data is expected and not actionable.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO _admission_backfill_exceptions (profile_id, exception_type, details)
+            SELECT
+                id,
+                'MISSING_GPA_OVERALL',
+                jsonb_build_object(
+                    'academic_history', academic_history,
+                    'rule', 'gpa_overall NULL after backfill on submitted+ profile'
+                )
+            FROM admission_profile
+            WHERE gpa_overall IS NULL
+              AND status NOT IN ('draft', 'revision_requested')
+            ON CONFLICT (profile_id, exception_type) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Inverse — drop exception rows scoped to this migration's
+    # exception_types FIRST (else CASCADE on profile won't fire),
+    # then columns, then ENUM type.
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM _admission_backfill_exceptions
+            WHERE exception_type IN (
+                'INVALID_GPA_VALUE', 'MISSING_GPA_OVERALL',
+                'INVALID_GRADUATION_YEAR', 'MISSING_GRADUATION_YEAR'
+            )
+            """
+        )
+    )
+
+    op.drop_column("admission_profile", "graduation_year")
+    op.drop_column("admission_profile", "health_category")
+    op.drop_column("admission_profile", "conduct")
+    op.drop_column("admission_profile", "gpa_overall")
+
+    conduct_enum = postgresql.ENUM(
+        *CONDUCT_GRADE_VALUES,
+        name="conduct_grade",
+        create_type=False,
+    )
+    conduct_enum.drop(op.get_bind(), checkfirst=True)

--- a/Backend_FastAPI/alembic/versions/phase1_10_create_status_history_table_and_backfill.py
+++ b/Backend_FastAPI/alembic/versions/phase1_10_create_status_history_table_and_backfill.py
@@ -1,0 +1,445 @@
+"""phase1_10: create admission_profile_status_history + backfill
+
+Revision ID: phase1_10
+Revises: phase1_09a
+Create Date: 2026-05-04
+
+#184 Wave 2 PR-2A second migration. Create the status history
+audit table per PLAN Phần 2.7 + backfill 1 row/profile (initial
+state) + 5 scattered scalar audit migrate blocks (approved,
+rejected, revision_requested, resubmitted, overridden).
+
+PLAN refs
+---------
+* §4 P1 #10 (line 2973-3039) — table create + 6 backfill blocks.
+* §2.7 (line 1018-1069) — table schema + CHECK constraint.
+* P1 fix #1 (line 182) + P1 fix #2 (line 201) — 3-column role
+  audit (deprecated transitioned_by_role + new actor_actual_role
+  + new effective_transition_role).
+* P2 fix #6 (line 409) — actor model split user_id + lead_id.
+
+Schema
+------
+
+* ``admission_profile_status_history``:
+  - ``id`` SERIAL PK
+  - ``profile_id`` integer FK → ``admission_profile(id)`` ON
+    DELETE CASCADE
+  - ``from_status`` varchar(20) nullable (NULL = profile creation)
+  - ``to_status`` varchar(20) NOT NULL
+  - ``transitioned_by_user_id`` integer FK → ``user(id)`` nullable
+  - ``transitioned_by_lead_id`` integer FK → ``lead(id)`` nullable
+  - ``transitioned_by_role`` ``transition_role_legacy`` ENUM
+    NOT NULL (deprecated 1 release; will drop Phase 4)
+  - ``actor_actual_role`` ``actor_actual_role`` ENUM NOT NULL
+  - ``effective_transition_role`` ``effective_transition_role``
+    ENUM NOT NULL
+  - ``transition_reason`` text nullable
+  - ``occurred_at`` timestamptz NOT NULL DEFAULT now()
+  - ``metadata`` JSONB nullable (default '{}')
+
+* Indexes:
+  - ``ix_status_history_profile_occurred`` (profile_id, occurred_at DESC)
+  - ``ix_status_history_to_status`` (to_status)
+
+* CHECK ``ck_status_history_actor_consistency``: per PLAN line 1058-1064.
+
+ENUM types
+----------
+Three ENUMs needed:
+
+* ``transition_role_legacy`` (4 values, deprecated): ``system``,
+  ``officer``, ``admin``, ``candidate``. Old column.
+* ``actor_actual_role`` (6 values): ``candidate``, ``officer``,
+  ``manager``, ``accountant``, ``admin``, ``system``.
+* ``effective_transition_role`` (4 values): ``candidate``,
+  ``officer``, ``admin``, ``system``.
+
+Backfill
+--------
+6 blocks per PLAN line 2975-3038:
+
+1. Initial state — 1 row/profile with from_status=NULL,
+   to_status=current. Idempotent: WHERE NOT EXISTS.
+2. Approved transitions — from scattered ``approved_at/by``.
+3. Rejected — from ``rejected_at/by``.
+4. Revision requested — from ``revision_requested_at/by``.
+5. Resubmitted — from ``resubmitted_at/by``.
+6. Overridden — from ``overridden_at/by``.
+
+Each scattered scalar block: idempotent via NOT EXISTS check on
+metadata.source = 'scattered_scalar_backfill' for the same
+(profile, transition).
+
+Down-revision chain: ``phase1_09a → phase1_10``.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_10"
+down_revision: Union[str, None] = "phase1_09a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# ENUM definitions (PLAN line 1032-1043 + role-actor consistency).
+TRANSITION_ROLE_LEGACY_VALUES: tuple[str, ...] = (
+    "system", "officer", "admin", "candidate",
+)
+ACTOR_ACTUAL_ROLE_VALUES: tuple[str, ...] = (
+    "candidate", "officer", "manager", "accountant", "admin", "system",
+)
+EFFECTIVE_TRANSITION_ROLE_VALUES: tuple[str, ...] = (
+    "candidate", "officer", "admin", "system",
+)
+
+
+def upgrade() -> None:
+    # 1. Create 3 ENUM types BEFORE table.
+    legacy_enum = postgresql.ENUM(
+        *TRANSITION_ROLE_LEGACY_VALUES,
+        name="transition_role_legacy",
+        create_type=False,
+    )
+    legacy_enum.create(op.get_bind(), checkfirst=True)
+
+    actor_actual_enum = postgresql.ENUM(
+        *ACTOR_ACTUAL_ROLE_VALUES,
+        name="actor_actual_role",
+        create_type=False,
+    )
+    actor_actual_enum.create(op.get_bind(), checkfirst=True)
+
+    effective_enum = postgresql.ENUM(
+        *EFFECTIVE_TRANSITION_ROLE_VALUES,
+        name="effective_transition_role",
+        create_type=False,
+    )
+    effective_enum.create(op.get_bind(), checkfirst=True)
+
+    # 2. Create table per PLAN Phần 2.7.
+    op.create_table(
+        "admission_profile_status_history",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "profile_id",
+            sa.Integer(),
+            sa.ForeignKey("admission_profile.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("from_status", sa.String(20), nullable=True),
+        sa.Column("to_status", sa.String(20), nullable=False),
+        sa.Column(
+            "transitioned_by_user_id",
+            sa.Integer(),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "transitioned_by_lead_id",
+            sa.Integer(),
+            sa.ForeignKey("lead.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("transitioned_by_role", legacy_enum, nullable=False),
+        sa.Column("actor_actual_role", actor_actual_enum, nullable=False),
+        sa.Column(
+            "effective_transition_role",
+            effective_enum,
+            nullable=False,
+        ),
+        sa.Column("transition_reason", sa.Text(), nullable=True),
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "metadata",
+            postgresql.JSONB(),
+            nullable=True,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        # PLAN line 1057-1064 actor-consistency invariant.
+        sa.CheckConstraint(
+            "(transitioned_by_role = 'system' "
+            "AND transitioned_by_user_id IS NULL "
+            "AND transitioned_by_lead_id IS NULL) "
+            "OR (transitioned_by_role IN ('officer', 'admin') "
+            "AND transitioned_by_user_id IS NOT NULL "
+            "AND transitioned_by_lead_id IS NULL) "
+            "OR (transitioned_by_role = 'candidate' "
+            "AND transitioned_by_lead_id IS NOT NULL "
+            "AND transitioned_by_user_id IS NULL)",
+            name="ck_status_history_actor_consistency",
+        ),
+    )
+
+    # 3. Indexes.
+    op.create_index(
+        "ix_status_history_profile_occurred",
+        "admission_profile_status_history",
+        ["profile_id", sa.text("occurred_at DESC")],
+    )
+    op.create_index(
+        "ix_status_history_to_status",
+        "admission_profile_status_history",
+        ["to_status"],
+    )
+
+    # 4. Backfill block 0 — Initial state (1 row/profile).
+    #    Idempotent via WHERE NOT EXISTS per-profile.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO admission_profile_status_history
+                (profile_id, from_status, to_status,
+                 transitioned_by_role, actor_actual_role,
+                 effective_transition_role,
+                 metadata, occurred_at)
+            SELECT
+                p.id, NULL, p.status,
+                'system',  -- legacy column
+                'system',  -- actor_actual_role
+                'system',  -- effective_transition_role
+                jsonb_build_object('backfill', true, 'source', 'phase1_10_initial'),
+                p.created_at
+            FROM admission_profile p
+            WHERE NOT EXISTS (
+                SELECT 1 FROM admission_profile_status_history h
+                WHERE h.profile_id = p.id
+            )
+            """
+        )
+    )
+
+    # NOTE — scattered scalar blocks 1-5 (Codex P1 catch on PR-2A):
+    # AdmissionProfile permits the audit-actor scalars
+    # (``approved_by_id`` / ``rejected_by_id`` / ``revision_requested_by_id``
+    # / ``resubmitted_by_id`` / ``overridden_by_id``) to be NULL while
+    # the corresponding ``*_at`` is non-NULL on legacy data
+    # (system auto-approval, migration-imported rows, etc.). The
+    # CHECK constraint ``ck_status_history_actor_consistency``
+    # requires ``transitioned_by_user_id NOT NULL`` when role is
+    # ``officer``/``admin``, so a naive backfill would violate the
+    # check on those rows.
+    #
+    # Fix: each block uses ``CASE WHEN p.<actor>_by_id IS NULL THEN
+    # 'system' ELSE '<role>'`` for all THREE role columns
+    # (transitioned_by_role legacy + actor_actual_role + effective_
+    # transition_role). When actor is NULL, the row classifies as
+    # system actor (CHECK first OR clause: role='system' AND
+    # user_id NULL AND lead_id NULL) and an ``actor_fallback`` flag
+    # in metadata records the substitution for admin queue review.
+
+    # 5. Backfill block 1 — Approved transitions.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO admission_profile_status_history
+                (profile_id, from_status, to_status,
+                 transitioned_by_user_id,
+                 transitioned_by_role, actor_actual_role,
+                 effective_transition_role,
+                 transition_reason, occurred_at, metadata)
+            SELECT
+                p.id, 'submitted', 'approved',
+                p.approved_by_id,
+                (CASE WHEN p.approved_by_id IS NULL THEN 'system' ELSE 'admin' END)::transition_role_legacy,
+                (CASE WHEN p.approved_by_id IS NULL THEN 'system' ELSE COALESCE(u.role::text, 'admin') END)::actor_actual_role,
+                (CASE WHEN p.approved_by_id IS NULL THEN 'system' ELSE 'admin' END)::effective_transition_role,
+                p.approval_notes,
+                p.approved_at,
+                jsonb_build_object(
+                    'source', 'scattered_scalar_backfill',
+                    'transition', 'approved',
+                    'actor_fallback', (p.approved_by_id IS NULL)
+                )
+            FROM admission_profile p
+            LEFT JOIN "user" u ON u.id = p.approved_by_id
+            WHERE p.approved_at IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM admission_profile_status_history h
+                  WHERE h.profile_id = p.id
+                    AND h.to_status = 'approved'
+                    AND h.metadata->>'source' = 'scattered_scalar_backfill'
+              )
+            """
+        )
+    )
+
+    # 6. Backfill block 2 — Rejected transitions.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO admission_profile_status_history
+                (profile_id, from_status, to_status,
+                 transitioned_by_user_id,
+                 transitioned_by_role, actor_actual_role,
+                 effective_transition_role,
+                 transition_reason, occurred_at, metadata)
+            SELECT
+                p.id, 'submitted', 'rejected',
+                p.rejected_by_id,
+                (CASE WHEN p.rejected_by_id IS NULL THEN 'system' ELSE 'admin' END)::transition_role_legacy,
+                (CASE WHEN p.rejected_by_id IS NULL THEN 'system' ELSE COALESCE(u.role::text, 'admin') END)::actor_actual_role,
+                (CASE WHEN p.rejected_by_id IS NULL THEN 'system' ELSE 'admin' END)::effective_transition_role,
+                p.rejection_reason,
+                p.rejected_at,
+                jsonb_build_object(
+                    'source', 'scattered_scalar_backfill',
+                    'transition', 'rejected',
+                    'actor_fallback', (p.rejected_by_id IS NULL)
+                )
+            FROM admission_profile p
+            LEFT JOIN "user" u ON u.id = p.rejected_by_id
+            WHERE p.rejected_at IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM admission_profile_status_history h
+                  WHERE h.profile_id = p.id
+                    AND h.to_status = 'rejected'
+                    AND h.metadata->>'source' = 'scattered_scalar_backfill'
+              )
+            """
+        )
+    )
+
+    # 7. Backfill block 3 — Revision requested transitions.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO admission_profile_status_history
+                (profile_id, from_status, to_status,
+                 transitioned_by_user_id,
+                 transitioned_by_role, actor_actual_role,
+                 effective_transition_role,
+                 transition_reason, occurred_at, metadata)
+            SELECT
+                p.id, 'submitted', 'revision_requested',
+                p.revision_requested_by_id,
+                (CASE WHEN p.revision_requested_by_id IS NULL THEN 'system' ELSE 'admin' END)::transition_role_legacy,
+                (CASE WHEN p.revision_requested_by_id IS NULL THEN 'system' ELSE COALESCE(u.role::text, 'admin') END)::actor_actual_role,
+                (CASE WHEN p.revision_requested_by_id IS NULL THEN 'system' ELSE 'admin' END)::effective_transition_role,
+                p.revision_reason,
+                p.revision_requested_at,
+                jsonb_build_object(
+                    'source', 'scattered_scalar_backfill',
+                    'transition', 'revision_requested',
+                    'actor_fallback', (p.revision_requested_by_id IS NULL)
+                )
+            FROM admission_profile p
+            LEFT JOIN "user" u ON u.id = p.revision_requested_by_id
+            WHERE p.revision_requested_at IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM admission_profile_status_history h
+                  WHERE h.profile_id = p.id
+                    AND h.to_status = 'revision_requested'
+                    AND h.metadata->>'source' = 'scattered_scalar_backfill'
+              )
+            """
+        )
+    )
+
+    # 8. Backfill block 4 — Resubmitted transitions. Officer is
+    #    the typical actor; system fallback when by_id NULL.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO admission_profile_status_history
+                (profile_id, from_status, to_status,
+                 transitioned_by_user_id,
+                 transitioned_by_role, actor_actual_role,
+                 effective_transition_role,
+                 transition_reason, occurred_at, metadata)
+            SELECT
+                p.id, 'revision_requested', 'resubmitted',
+                p.resubmitted_by_id,
+                (CASE WHEN p.resubmitted_by_id IS NULL THEN 'system' ELSE 'officer' END)::transition_role_legacy,
+                (CASE WHEN p.resubmitted_by_id IS NULL THEN 'system' ELSE COALESCE(u.role::text, 'officer') END)::actor_actual_role,
+                (CASE WHEN p.resubmitted_by_id IS NULL THEN 'system' ELSE 'officer' END)::effective_transition_role,
+                p.resubmit_notes,
+                p.resubmitted_at,
+                jsonb_build_object(
+                    'source', 'scattered_scalar_backfill',
+                    'transition', 'resubmitted',
+                    'actor_fallback', (p.resubmitted_by_id IS NULL)
+                )
+            FROM admission_profile p
+            LEFT JOIN "user" u ON u.id = p.resubmitted_by_id
+            WHERE p.resubmitted_at IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM admission_profile_status_history h
+                  WHERE h.profile_id = p.id
+                    AND h.to_status = 'resubmitted'
+                    AND h.metadata->>'source' = 'scattered_scalar_backfill'
+              )
+            """
+        )
+    )
+
+    # 9. Backfill block 5 — Overridden transitions. Admin only;
+    #    system fallback when by_id NULL.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO admission_profile_status_history
+                (profile_id, from_status, to_status,
+                 transitioned_by_user_id,
+                 transitioned_by_role, actor_actual_role,
+                 effective_transition_role,
+                 transition_reason, occurred_at, metadata)
+            SELECT
+                p.id, 'rejected', 'overridden',
+                p.overridden_by_id,
+                (CASE WHEN p.overridden_by_id IS NULL THEN 'system' ELSE 'admin' END)::transition_role_legacy,
+                (CASE WHEN p.overridden_by_id IS NULL THEN 'system' ELSE COALESCE(u.role::text, 'admin') END)::actor_actual_role,
+                (CASE WHEN p.overridden_by_id IS NULL THEN 'system' ELSE 'admin' END)::effective_transition_role,
+                NULL,  -- override reason not in scattered scalar; admin notes via UI later
+                p.overridden_at,
+                jsonb_build_object(
+                    'source', 'scattered_scalar_backfill',
+                    'transition', 'overridden',
+                    'actor_fallback', (p.overridden_by_id IS NULL)
+                )
+            FROM admission_profile p
+            LEFT JOIN "user" u ON u.id = p.overridden_by_id
+            WHERE p.overridden_at IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM admission_profile_status_history h
+                  WHERE h.profile_id = p.id
+                    AND h.to_status = 'overridden'
+                    AND h.metadata->>'source' = 'scattered_scalar_backfill'
+              )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Inverse — drop indexes, then table, then ENUMs in reverse
+    # creation order.
+    op.drop_index(
+        "ix_status_history_to_status",
+        table_name="admission_profile_status_history",
+    )
+    op.drop_index(
+        "ix_status_history_profile_occurred",
+        table_name="admission_profile_status_history",
+    )
+    op.drop_table("admission_profile_status_history")
+
+    for enum_values, name in [
+        (EFFECTIVE_TRANSITION_ROLE_VALUES, "effective_transition_role"),
+        (ACTOR_ACTUAL_ROLE_VALUES, "actor_actual_role"),
+        (TRANSITION_ROLE_LEGACY_VALUES, "transition_role_legacy"),
+    ]:
+        enum = postgresql.ENUM(
+            *enum_values, name=name, create_type=False,
+        )
+        enum.drop(op.get_bind(), checkfirst=True)

--- a/Backend_FastAPI/app/models/__init__.py
+++ b/Backend_FastAPI/app/models/__init__.py
@@ -35,6 +35,8 @@ from .lead_phone import LeadPhoneIdentity
 
 # Admission models (NEW: Replacement for Application)
 from .admission import AdmissionProfile, AdmissionConfirmationToken
+# phase1_10 (#184 Wave 2 PR-2A) — status transition audit trail.
+from .admission_profile_status_history import AdmissionProfileStatusHistory
 from .admission_survey_feedback import AdmissionSurveyFeedback
 from .student import Student, StudentDocument
 

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -16,8 +16,8 @@ Architecture:
 
 from datetime import date, datetime, timezone
 from typing import List, Optional
-from sqlalchemy import Boolean, CheckConstraint, Column, Date, Index, Integer, String, Text, DateTime, ForeignKey, UniqueConstraint
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import Boolean, CheckConstraint, Column, Date, Index, Integer, Numeric, SmallInteger, String, Text, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy.dialects.postgresql import ENUM, JSONB
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
 from .base import Base
@@ -394,6 +394,39 @@ class AdmissionProfile(Base):
     dropped_reason: Mapped[Optional[str]] = mapped_column(
         Text, nullable=True,
         comment="Reason for dropping out"
+    )
+
+    # phase1_09a (#184 Wave 2 PR-2A) — eligibility scalars. 4
+    # nullable columns. gpa_overall + graduation_year backfilled
+    # from academic_history JSON via LATERAL + range guard;
+    # conduct + health_category STAY NULL (no JSON source — admin
+    # reviews qua UI Phase 1+2 per PLAN line 2813-2814).
+    # Lock-after-draft trigger (phase1_09b) is DEFERRED Q1/2027
+    # per Q9 chốt 2026-05-01; service guard provides basic
+    # protection in 2026 cutover.
+    gpa_overall: Mapped[Optional[float]] = mapped_column(
+        Numeric(precision=4, scale=2),
+        nullable=True,
+        comment="Overall GPA (0.00..10.00). Backfilled from academic_history.",
+    )
+    conduct: Mapped[Optional[str]] = mapped_column(
+        ENUM(
+            "TB", "KHA", "TOT",
+            name="conduct_grade",
+            create_type=False,
+        ),
+        nullable=True,
+        comment="Đạo đức (TB/KHA/TOT). NULL post-migration; admin UI Phase 1+2.",
+    )
+    health_category: Mapped[Optional[int]] = mapped_column(
+        SmallInteger,
+        nullable=True,
+        comment="Phân loại sức khỏe (1..4 — 1 tốt nhất). NULL post-migration.",
+    )
+    graduation_year: Mapped[Optional[int]] = mapped_column(
+        SmallInteger,
+        nullable=True,
+        comment="Năm tốt nghiệp (1900..2100). Backfilled from MAX(year_to).",
     )
 
     # phase1_08 (#184 Wave 1 PR-1D) — multi-NV gate. Determines

--- a/Backend_FastAPI/app/models/admission_profile_status_history.py
+++ b/Backend_FastAPI/app/models/admission_profile_status_history.py
@@ -1,0 +1,179 @@
+# app/models/admission_profile_status_history.py
+"""AdmissionProfileStatusHistory model.
+
+phase1_10 (#184 Wave 2 PR-2A) — audit trail for every status
+transition on AdmissionProfile. Replaces the legacy scattered
+scalar columns (``approved_at/by``, ``rejected_at/by``, ...) which
+don't scale to the 17-state Phase 3 transition matrix.
+
+Per PLAN Phần 2.7 (line 1018-1069):
+
+* 3-column role audit chốt v2.9 (PLAN P1 fix #1 + #2):
+  - ``transitioned_by_role`` (deprecated, drop Phase 4) — kept
+    for 1-release backward compat with existing reports.
+  - ``actor_actual_role`` (NEW v2.9) — role THẬT của actor
+    (manager khi gọi T6/T10/T11 ghi 'manager'). Audit theo cột
+    này cho sự thật.
+  - ``effective_transition_role`` (NEW v2.9) — role sau khi
+    resolve qua effective_role_for_transition(). Manager → T6
+    'admin'; manager → T2 'officer'. Dùng cho RBAC trace +
+    matrix verification.
+
+* Actor model split (PLAN P2 fix #6):
+  - ``transitioned_by_user_id`` — nullable; SET khi actor =
+    officer/admin (có User row).
+  - ``transitioned_by_lead_id`` — nullable; SET khi actor =
+    candidate qua magic_link (no User row).
+
+Service contract (PLAN line 1067): mỗi endpoint đổi
+``AdmissionProfile.status`` MUST insert 1 row vào status_history
+cùng transaction frame. Không có row history → giả định bug,
+raise alert.
+"""
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import ENUM, JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+# ENUM values mirror alembic phase1_10 — frozen here as the
+# migration is the source-of-truth; ``create_type=False`` avoids
+# autogenerate redeclare.
+TRANSITION_ROLE_LEGACY_VALUES: tuple[str, ...] = (
+    "system", "officer", "admin", "candidate",
+)
+ACTOR_ACTUAL_ROLE_VALUES: tuple[str, ...] = (
+    "candidate", "officer", "manager", "accountant", "admin", "system",
+)
+EFFECTIVE_TRANSITION_ROLE_VALUES: tuple[str, ...] = (
+    "candidate", "officer", "admin", "system",
+)
+
+
+class AdmissionProfileStatusHistory(Base):
+    """One row per status transition (PLAN Phần 2.7 line 1021)."""
+
+    __tablename__ = "admission_profile_status_history"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    profile_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("admission_profile.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    from_status: Mapped[Optional[str]] = mapped_column(
+        String(20),
+        nullable=True,
+        comment="NULL = lần đầu tạo profile (initial state)",
+    )
+    to_status: Mapped[str] = mapped_column(String(20), nullable=False)
+
+    transitioned_by_user_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    transitioned_by_lead_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("lead.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    # Legacy column — drop Phase 4 after report migration.
+    transitioned_by_role: Mapped[str] = mapped_column(
+        ENUM(
+            *TRANSITION_ROLE_LEGACY_VALUES,
+            name="transition_role_legacy",
+            create_type=False,
+        ),
+        nullable=False,
+    )
+    actor_actual_role: Mapped[str] = mapped_column(
+        ENUM(
+            *ACTOR_ACTUAL_ROLE_VALUES,
+            name="actor_actual_role",
+            create_type=False,
+        ),
+        nullable=False,
+        comment="Role THẬT của actor (audit theo cột này cho sự thật).",
+    )
+    effective_transition_role: Mapped[str] = mapped_column(
+        ENUM(
+            *EFFECTIVE_TRANSITION_ROLE_VALUES,
+            name="effective_transition_role",
+            create_type=False,
+        ),
+        nullable=False,
+        comment="Role sau khi resolve qua effective_role_for_transition().",
+    )
+
+    transition_reason: Mapped[Optional[str]] = mapped_column(
+        Text,
+        nullable=True,
+        comment="Bắt buộc cho admin override + reject",
+    )
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default="now()",
+    )
+    # Renamed Python attribute to ``metadata_`` because ``metadata``
+    # collides with SQLAlchemy ``DeclarativeBase.metadata``. The
+    # ``"metadata"`` first arg pins the actual SQL column name.
+    metadata_: Mapped[Optional[Any]] = mapped_column(
+        "metadata",
+        JSONB,
+        nullable=True,
+        comment="Free-form audit payload (computed_total_score, decision_rule, ...)",
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "(transitioned_by_role = 'system' "
+            "AND transitioned_by_user_id IS NULL "
+            "AND transitioned_by_lead_id IS NULL) "
+            "OR (transitioned_by_role IN ('officer', 'admin') "
+            "AND transitioned_by_user_id IS NOT NULL "
+            "AND transitioned_by_lead_id IS NULL) "
+            "OR (transitioned_by_role = 'candidate' "
+            "AND transitioned_by_lead_id IS NOT NULL "
+            "AND transitioned_by_user_id IS NULL)",
+            name="ck_status_history_actor_consistency",
+        ),
+    )
+
+    # Relationships — lazy because the audit table is read-heavy
+    # (admin queue) but most callers only need (profile_id, status).
+    # No ``back_populates`` on AdmissionProfile side because the
+    # parent profile relationship doesn't need a bidirectional
+    # binding (audit reads run via direct queries).
+    profile = relationship(
+        "AdmissionProfile",
+        foreign_keys=[profile_id],
+    )
+    transitioned_by_user = relationship(
+        "User",
+        foreign_keys=[transitioned_by_user_id],
+    )
+    transitioned_by_lead = relationship(
+        "Lead",
+        foreign_keys=[transitioned_by_lead_id],
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<StatusHistory profile={self.profile_id} "
+            f"{self.from_status} → {self.to_status} "
+            f"actor={self.actor_actual_role} at {self.occurred_at}>"
+        )

--- a/Backend_FastAPI/tests/unit/test_phase1_09a_10_revision_chain.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_09a_10_revision_chain.py
@@ -1,0 +1,345 @@
+"""Unit tests for #184 Wave 2 PR-2A migrations
+(``phase1_09a_add_eligibility_scalars_and_backfill`` +
+``phase1_10_create_status_history_table_and_backfill``).
+
+Pure-text contract tests — locks the revision chain, ENUM values,
+column additions, backfill SQL contract, status_history table
+shape, scattered scalar audit migrate, and ORM model parity.
+
+What lives here:
+1. Revision chain (phase1_13 → phase1_09a → phase1_10).
+2. phase1_09a: 4 column add (gpa/conduct/health/grad_year),
+   conduct_grade ENUM 3 values, backfill scope locked to
+   gpa + grad_year, exception sink for out-of-range +
+   missing-after-backfill.
+3. phase1_10: status_history table + 3 ENUMs (legacy/actor_actual/
+   effective) + CHECK actor consistency + 6 backfill blocks
+   (initial + 5 scattered scalar).
+4. ORM model parity: AdmissionProfile 4 new columns +
+   AdmissionProfileStatusHistory module-level export.
+
+What does NOT live here:
+* End-to-end DDL apply — alembic upgrade smoke runs in dev container.
+* Backfill correctness on real data — covered by manual roundtrip
+  on dev DB pre-merge.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_PHASE1_09A = _VERSIONS_DIR / "phase1_09a_add_eligibility_scalars_and_backfill.py"
+_PHASE1_10 = _VERSIONS_DIR / "phase1_10_create_status_history_table_and_backfill.py"
+
+
+def _load_migration(filename: str):
+    path = _VERSIONS_DIR / filename
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_09a():
+    return _load_migration(_PHASE1_09A.name)
+
+
+@pytest.fixture
+def phase1_10():
+    return _load_migration(_PHASE1_10.name)
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision chain
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_09a_chains_off_phase1_13(phase1_09a) -> None:
+    assert phase1_09a.revision == "phase1_09a"
+    assert phase1_09a.down_revision == "phase1_13"
+
+
+def test_phase1_10_chains_off_phase1_09a(phase1_10) -> None:
+    assert phase1_10.revision == "phase1_10"
+    assert phase1_10.down_revision == "phase1_09a"
+
+
+# ---------------------------------------------------------------------------
+# 2. phase1_09a contract
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_09a_declares_3_conduct_grade_values(phase1_09a) -> None:
+    """conduct_grade ENUM per PLAN line 818. Adding a value =
+    update migration + Subject model + downstream consumer."""
+    assert phase1_09a.CONDUCT_GRADE_VALUES == ("TB", "KHA", "TOT")
+
+
+def test_phase1_09a_adds_4_columns() -> None:
+    src = _PHASE1_09A.read_text(encoding="utf-8")
+    for col in ("gpa_overall", "conduct", "health_category", "graduation_year"):
+        assert f'"{col}"' in src, f"column {col} missing from migration"
+
+
+def test_phase1_09a_columns_all_nullable() -> None:
+    src = _PHASE1_09A.read_text(encoding="utf-8")
+    # All 4 columns nullable so backfill can populate selectively.
+    # Check at least 4 occurrences of nullable=True (one per add_column).
+    assert src.count("nullable=True") >= 4
+
+
+def test_phase1_09a_backfill_uses_lateral_jsonb() -> None:
+    """gpa_overall backfill uses LATERAL jsonb_array_elements +
+    WITH ORDINALITY per PLAN line 2718. Anti-pattern (academic_history->-1)
+    explicitly rejected per PLAN line 4198."""
+    src = _PHASE1_09A.read_text(encoding="utf-8")
+    assert "LATERAL jsonb_array_elements" in src
+    assert "WITH ORDINALITY" in src
+
+
+def test_phase1_09a_gpa_backfill_uses_length_bounded_regex() -> None:
+    """Length-bounded regex prevents overflow on absurd values
+    (e.g. '999999999999' would pass simple format check but
+    overflow numeric(8,4))."""
+    src = _PHASE1_09A.read_text(encoding="utf-8")
+    # Regex is `^[0-9]{1,3}(\\.[0-9]{1,4})?$` (escaped backslash for Python).
+    assert "[0-9]{1,3}" in src
+
+
+def test_phase1_09a_backfill_scope_only_gpa_and_grad_year() -> None:
+    """Codex P2 contract — backfill ONLY 2 fields. conduct +
+    health_category stay NULL (no JSON source)."""
+    src = _PHASE1_09A.read_text(encoding="utf-8")
+    # gpa + graduation_year UPDATE blocks present.
+    assert "SET gpa_overall = " in src
+    assert "SET graduation_year = " in src
+    # No UPDATE for conduct or health_category.
+    assert "SET conduct = " not in src
+    assert "SET health_category = " not in src
+
+
+def test_phase1_09a_inserts_4_exception_sinks() -> None:
+    """4 exception sinks per PLAN line 2746 + 2791 + 2801 + 2815:
+    INVALID_GPA_VALUE (out-of-range numeric) +
+    MISSING_GPA_OVERALL (NULL after backfill on submitted+) +
+    INVALID_GRADUATION_YEAR (year_to outside [1900, 2100]) +
+    MISSING_GRADUATION_YEAR (graduation_type set but year_to
+    malformed/missing).
+
+    Codex P1 + P2 catches on PR-2A: GPA_OUT_OF_RANGE renamed to
+    INVALID_GPA_VALUE per PLAN; 2 graduation_year exception sinks
+    added (were missing in initial draft)."""
+    src = _PHASE1_09A.read_text(encoding="utf-8")
+    for exception_type in (
+        "INVALID_GPA_VALUE",
+        "MISSING_GPA_OVERALL",
+        "INVALID_GRADUATION_YEAR",
+        "MISSING_GRADUATION_YEAR",
+    ):
+        assert f"'{exception_type}'" in src, f"exception sink missing: {exception_type}"
+    assert "ON CONFLICT (profile_id, exception_type) DO NOTHING" in src
+
+
+def test_phase1_09a_graduation_year_range_1900_to_2100() -> None:
+    """PLAN line 2795 mandates [1900, 2100] — wider than naive
+    [1990, 2030] to allow legitimate older graduations + future-
+    dated international transfers. Codex P1 catch on PR-2A."""
+    src = _PHASE1_09A.read_text(encoding="utf-8")
+    assert "BETWEEN 1900 AND 2100" in src
+    # Anti-regression — narrower bounds rejected.
+    assert "BETWEEN 1990 AND 2030" not in src
+
+
+def test_phase1_09a_idempotent_per_row_guard() -> None:
+    """All UPDATEs gated by WHERE <field> IS NULL per-row guard
+    so re-runs leave valid rows alone."""
+    src = _PHASE1_09A.read_text(encoding="utf-8")
+    assert "p.gpa_overall IS NULL" in src
+    assert "p.graduation_year IS NULL" in src
+
+
+# ---------------------------------------------------------------------------
+# 3. phase1_10 contract
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_10_declares_3_enums(phase1_10) -> None:
+    """3 ENUMs per PLAN Phần 2.7: legacy (4 values), actor_actual
+    (6 values), effective (4 values)."""
+    assert phase1_10.TRANSITION_ROLE_LEGACY_VALUES == (
+        "system", "officer", "admin", "candidate",
+    )
+    assert phase1_10.ACTOR_ACTUAL_ROLE_VALUES == (
+        "candidate", "officer", "manager", "accountant", "admin", "system",
+    )
+    assert phase1_10.EFFECTIVE_TRANSITION_ROLE_VALUES == (
+        "candidate", "officer", "admin", "system",
+    )
+
+
+def test_phase1_10_creates_status_history_table() -> None:
+    src = _PHASE1_10.read_text(encoding="utf-8")
+    assert '"admission_profile_status_history"' in src
+
+
+def test_phase1_10_check_constraint_actor_consistency() -> None:
+    """CHECK constraint per PLAN line 1057-1064 — pin the 3-clause
+    actor consistency (system / officer-admin / candidate)."""
+    src = _PHASE1_10.read_text(encoding="utf-8")
+    assert "ck_status_history_actor_consistency" in src
+    # The 3 OR-clauses must all be present.
+    assert "transitioned_by_role = 'system'" in src
+    assert "transitioned_by_role IN ('officer', 'admin')" in src
+    assert "transitioned_by_role = 'candidate'" in src
+
+
+def test_phase1_10_creates_2_indexes() -> None:
+    src = _PHASE1_10.read_text(encoding="utf-8")
+    assert "ix_status_history_profile_occurred" in src
+    assert "ix_status_history_to_status" in src
+
+
+def test_phase1_10_backfill_initial_state_block() -> None:
+    """Block 0 — 1 row/profile, idempotent via NOT EXISTS."""
+    src = _PHASE1_10.read_text(encoding="utf-8")
+    assert "phase1_10_initial" in src
+    assert "WHERE NOT EXISTS" in src
+
+
+def test_phase1_10_backfill_5_scattered_scalar_blocks() -> None:
+    """5 transition blocks per PLAN line 2997-3038. Each block
+    sets metadata.source = 'scattered_scalar_backfill' for
+    idempotent re-run."""
+    src = _PHASE1_10.read_text(encoding="utf-8")
+    for transition in (
+        "approved", "rejected", "revision_requested",
+        "resubmitted", "overridden",
+    ):
+        # The backfill block tags the metadata transition value.
+        assert f"'transition', '{transition}'" in src, (
+            f"scattered scalar backfill block for {transition} missing"
+        )
+
+    # All 5 blocks share the source tag.
+    assert src.count("scattered_scalar_backfill") >= 5
+
+
+def test_phase1_10_overridden_block_fallback_admin() -> None:
+    """Override transition is admin-only per state machine matrix.
+    Backfill fallback role = 'admin' when User row exists but
+    role lookup misses (legacy data); 'system' fallback when
+    *_by_id IS NULL itself (Codex P1 catch on PR-2A — CHECK
+    ck_status_history_actor_consistency requires user_id NOT
+    NULL when role IN ('officer', 'admin')).
+    """
+    src = _PHASE1_10.read_text(encoding="utf-8")
+    idx = src.index("'transition', 'overridden'")
+    block_start = max(0, idx - 2000)
+    overridden_block = src[block_start:idx]
+    assert "COALESCE(u.role::text, 'admin')" in overridden_block
+
+
+def test_phase1_10_scattered_audit_falls_back_to_system_when_actor_null() -> None:
+    """Codex P1 catch on PR-2A — 5 scattered scalar backfill blocks
+    must classify ``*_by_id IS NULL`` as 'system' actor (CHECK
+    first OR clause: role='system' AND user_id NULL AND lead_id
+    NULL). Without the fallback, legacy rows with audit timestamp
+    but no actor cause the backfill INSERT to violate
+    ``ck_status_history_actor_consistency``.
+
+    Each block must contain a ``CASE WHEN p.<actor>_by_id IS NULL
+    THEN 'system'`` pattern."""
+    src = _PHASE1_10.read_text(encoding="utf-8")
+    # 5 blocks × 3 column assignments per block × CASE WHEN check
+    # — at minimum 5 ``actor_fallback`` metadata flags + 15 CASE
+    # WHEN ``IS NULL THEN 'system'`` patterns. Lock at lower bound
+    # to allow future formatting changes.
+    assert src.count("'actor_fallback'") == 5, (
+        "Each of the 5 scattered scalar blocks must record actor_fallback metadata"
+    )
+    # Pattern lock — at least 15 (= 5 blocks * 3 role columns) IS NULL fallbacks.
+    assert src.count("IS NULL THEN 'system'") >= 15, (
+        "Each scattered block needs CASE WHEN <actor_id> IS NULL THEN 'system' "
+        "for transitioned_by_role + actor_actual_role + effective_transition_role"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. ORM model parity
+# ---------------------------------------------------------------------------
+
+
+def test_admission_profile_model_declares_4_eligibility_scalars() -> None:
+    from app.models.admission import AdmissionProfile
+
+    for col in ("gpa_overall", "conduct", "health_category", "graduation_year"):
+        assert hasattr(AdmissionProfile, col), f"AdmissionProfile missing {col}"
+        column = AdmissionProfile.__table__.columns[col]
+        assert column.nullable is True, f"{col} must be nullable"
+
+
+def test_status_history_model_imports_cleanly() -> None:
+    from app.models import AdmissionProfileStatusHistory
+    from app.models.admission_profile_status_history import (
+        AdmissionProfileStatusHistory as DirectImport,
+    )
+
+    assert AdmissionProfileStatusHistory is DirectImport
+    assert AdmissionProfileStatusHistory.__tablename__ == "admission_profile_status_history"
+
+
+def test_status_history_model_declares_3_role_columns() -> None:
+    from app.models.admission_profile_status_history import (
+        AdmissionProfileStatusHistory,
+    )
+
+    for col in (
+        "transitioned_by_role",
+        "actor_actual_role",
+        "effective_transition_role",
+    ):
+        assert hasattr(AdmissionProfileStatusHistory, col), f"missing {col}"
+        column = AdmissionProfileStatusHistory.__table__.columns[col]
+        assert column.nullable is False, f"{col} must be NOT NULL"
+
+
+def test_status_history_model_declares_actor_consistency_check() -> None:
+    from app.models.admission_profile_status_history import (
+        AdmissionProfileStatusHistory,
+    )
+
+    constraint_names = {
+        c.name for c in AdmissionProfileStatusHistory.__table__.constraints
+    }
+    assert "ck_status_history_actor_consistency" in constraint_names
+
+
+def test_status_history_metadata_python_attr_renamed_to_avoid_collision() -> None:
+    """``metadata`` collides với SQLAlchemy DeclarativeBase.metadata —
+    Python attribute renamed to ``metadata_`` while SQL column stays
+    ``metadata``."""
+    from app.models.admission_profile_status_history import (
+        AdmissionProfileStatusHistory,
+    )
+
+    assert hasattr(AdmissionProfileStatusHistory, "metadata_")
+    assert "metadata" in AdmissionProfileStatusHistory.__table__.columns
+
+
+# ---------------------------------------------------------------------------
+# 5. Sanity — both migrations import cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_both_migrations_define_upgrade_and_downgrade(
+    phase1_09a, phase1_10
+) -> None:
+    for module in (phase1_09a, phase1_10):
+        assert callable(getattr(module, "upgrade", None))
+        assert callable(getattr(module, "downgrade", None))


### PR DESCRIPTION
## Summary

#184 Phase 1 Schema **Wave 2 PR-2A** — first Wave 2 sub-PR. Off remote parent `origin/feat/admission-full-cutover` = `5feb3c07` (post Wave 1 complete + B4 P0 closer).

Two pure-additive migrations + ORM wiring + status history audit trail:

| Migration | Scope |
|---|---|
| `phase1_09a_add_eligibility_scalars_and_backfill.py` | conduct_grade ENUM 3 values + 4 nullable cols + 2-field backfill (gpa_overall + graduation_year) via single-statement CTE chain + 4 exception sinks |
| `phase1_10_create_status_history_table_and_backfill.py` | 3 ENUMs (legacy/actor_actual/effective) + audit table + CHECK actor consistency + 2 indexes + 6 backfill blocks (initial + 5 scattered scalar audit migrate) |

## Codex P1+P2 fixes (round 12) before push

| # | Issue | Fix | PLAN ref |
|---|---|---|---|
| **P1** | Missing `INVALID_GRADUATION_YEAR` + `MISSING_GRADUATION_YEAR` exception sinks | Added 2 sinks in phase1_09a body | line 2791-2811 |
| **P1** | Year range `[1990, 2030]` quá hẹp (rejects legitimate older grads + future-dated transfers) | Fixed to `[1900, 2100]` (SQL + comment + model docstring) | line 2795 |
| **P1** | scattered scalar backfill vỡ CHECK khi `*_by_id IS NULL` (legacy data: audit timestamp set nhưng actor scalar NULL) | `CASE WHEN <actor>_by_id IS NULL THEN 'system'` fallback cho all 3 role columns + `actor_fallback` metadata flag | §2.7 line 1057-1064 CHECK |
| **P2** | exception_type `GPA_OUT_OF_RANGE` lệch SOT | Renamed `INVALID_GPA_VALUE` | line 354 + 2746 |
| **P2** | column comment + model docstring drift `1990..2030` vs SQL `1900..2100` | Synced both to `1900..2100` | live amend pre-push |

## Scope chốt 2026-05-04

- **Q chốt 09a**: 4 column add (gpa_overall, conduct, health_category, graduation_year all nullable) + **2-field backfill** only (gpa_overall + graduation_year). conduct + health_category **STAY NULL** — no source in `academic_history` JSON; admin reviews qua UI Phase 1+2 per PLAN line 2813-2814.
- **`phase1_09b` lock-after-draft trigger DEFERRED Q1/2027** per Q9 chốt 2026-05-01. Service guard provides basic protection in 2026 cutover.
- **DB/model only — FE Zod parse parity DEFERRED** per Codex Guard 4 (b). Will ship in dedicated FE-zod-eligibility PR **before M-1-11 CHECK extend** (Phase 3 deploy choreography requires FE Zod permissive enum BEFORE BE state extend).

## Files (6)

### Migrations (2)
- `alembic/versions/phase1_09a_add_eligibility_scalars_and_backfill.py` (NEW)
- `alembic/versions/phase1_10_create_status_history_table_and_backfill.py` (NEW)

### Backend (3)
- `app/models/admission.py` (MOD — 4 new columns)
- `app/models/admission_profile_status_history.py` (NEW — ORM với 3 ENUM mirror tuples + CheckConstraint + lazy relationships; Python attr `metadata_` rename)
- `app/models/__init__.py` (MOD — export)

### Tests (1 file, 25 case)
- `tests/unit/test_phase1_09a_10_revision_chain.py` (NEW)

## 4 exception sinks (post-fix)

| Sink type | Trigger | PLAN ref |
|---|---|---|
| `INVALID_GPA_VALUE` | gpa numeric value outside [0, 10] | line 2746 |
| `MISSING_GPA_OVERALL` | NULL after backfill on submitted+ profile (data nguồn lỗi) | line 2815-2822 |
| `INVALID_GRADUATION_YEAR` | year_to numeric but outside [1900, 2100] | line 2791-2797 |
| `MISSING_GRADUATION_YEAR` | graduation_type set but year_to malformed/missing | line 2801-2811 |

All sinks idempotent via `ON CONFLICT (profile_id, exception_type) DO NOTHING`.

## 5 scattered scalar audit migrate blocks

Per PLAN line 2997-3038. Each block includes Codex P1 fix:

```sql
(CASE WHEN p.<actor>_by_id IS NULL THEN 'system' ELSE '<role>' END)::transition_role_legacy,
(CASE WHEN p.<actor>_by_id IS NULL THEN 'system' ELSE COALESCE(u.role::text, '<role>') END)::actor_actual_role,
(CASE WHEN p.<actor>_by_id IS NULL THEN 'system' ELSE '<role>' END)::effective_transition_role,
...
jsonb_build_object(..., 'actor_fallback', (p.<actor>_by_id IS NULL))
```

→ Legacy rows with `*_at NOT NULL AND *_by_id NULL` (system auto-approval, migration-imported) classify as system actor (CHECK first OR clause). `actor_fallback` metadata flag surfaces the substitution for admin queue review.

## Test result

```
BE wide regression: 230/230 passed in 10.11s
  - 25 PR-2A new (incl. 2 new tests for actor_fallback + year range)
  - 33 PR-1D + 37 PR-1C' + 18 PR-1B'-FE + 117 phase1_03 + path/migration regression
```

Critical rerun pre-push: `tests/unit/test_phase1_09a_10_revision_chain.py` → 25 passed in 1.42s.

## Live alembic roundtrip on dev DB

- `alembic upgrade phase1_10` clean → 4 columns + ENUM + table + 6 backfill blocks all applied; `alembic_version = phase1_10`.
- `alembic downgrade phase1_13` clean → table dropped + columns dropped + 4 ENUM types dropped + 4 exception_types deleted.
- Re-upgrade idempotent.

## Catch + fix in-flight (live alembic smoke)

`alembic env.py:57` sets `isolation_level=AUTOCOMMIT` → TEMP TABLE not survivable across statements (each `op.execute` opens a fresh connection). Refactored gpa_overall backfill from 3-statement TEMP TABLE pattern to single-statement CTE chain (LATERAL + WITH ORDINALITY + length-bounded regex + range guard + DISTINCT ON inline).

## Down-revision chain

```
phase1_19a → phase1_19b → phase1_01 → phase1_02 → phase1_03 →
phase1_05 → phase1_06 → phase1_07b → phase1_08 → phase1_13 →
phase1_09a → phase1_10 (head)
```

`phase1_04` + `phase1_07` + `phase1_09b` DEFERRED Q1/2027 per Q9 chốt 2026-05-01.

## Test plan

- [x] BE wide regression 230/230 PASS
- [x] Live alembic upgrade/downgrade/re-upgrade idempotent
- [x] 4 exception sinks verified (INVALID_GPA_VALUE + MISSING_GPA_OVERALL + INVALID_GRADUATION_YEAR + MISSING_GRADUATION_YEAR)
- [x] CHECK ck_status_history_actor_consistency satisfied for `*_by_id IS NULL` legacy rows via system fallback
- [x] Year range [1900, 2100] consistent across SQL + column comment + model docstring (Codex P2 drift fix)
- [ ] **FE Zod parse parity** — DEFERRED to FE-zod-eligibility PR. **MUST ship BEFORE M-1-11 CHECK extend** (Phase 3 deploy choreography).
- [ ] Staging clone D12-D14 smoke (Wave 2 batch — gate Wave 3)
- [ ] Manual prod-state audit before staging rehearsal: `*_at IS NOT NULL AND *_by_id IS NULL` count → quantify how many rows hit the system fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)