### PR TITLE
[#184 FE-zod-eligibility] feat(zod): Stage 1 permissive status + 4 eligibility fields

### DIFF
--- a/frontend/src/lib/zod/admissions.eligibility.test.ts
+++ b/frontend/src/lib/zod/admissions.eligibility.test.ts
@@ -1,0 +1,327 @@
+/**
+ * FE Zod tests for the M-1-11 deploy-choreography Stage 1
+ * permissive parse + #184 Wave 2 PR-2A 4 eligibility scalar
+ * fields (FE-zod-eligibility / phase1_09a wiring).
+ *
+ * Locks the runtime contract:
+ *
+ * 1. Permissive status parse — BE deploys M-1-11 (status CHECK
+ *    extend 10 → 14) BEFORE the FE container build catches up.
+ *    Profile responses with ``status="reviewing"`` /
+ *    ``status="admitted"`` MUST parse without throwing so the FE
+ *    renders generic gray badge (status-badge.config.ts:380
+ *    DEFAULT_BADGE_CONFIG fallback) instead of crashing.
+ *
+ * 2. Legacy 14 status all still parse strict — Stage 1 widens the
+ *    accepted set; doesn't narrow.
+ *
+ * 3. 4 eligibility scalar fields — gpa_overall, conduct,
+ *    health_category, graduation_year. All nullable + optional so
+ *    legacy responses (pre-phase1_09a) still parse.
+ *
+ * 4. Range guards mirror BE Pydantic + alembic migration:
+ *    - gpa_overall [0, 10]
+ *    - conduct enum {TB, KHA, TOT}
+ *    - health_category int [1, 4]
+ *    - graduation_year int [1900, 2100]
+ */
+import { describe, expect, it } from "vitest"
+
+import { admissionProfileResponseSchema } from "./admissions"
+
+
+/**
+ * Minimum profile shape that satisfies all REQUIRED fields in
+ * admissionProfileResponseSchema. Each test layers eligibility
+ * fields on top of this baseline.
+ */
+function _baselineProfile(): Record<string, unknown> {
+  // The schema declares many ``z.string().nullable()`` fields
+  // (NOT optional) — they need an explicit ``null`` rather than
+  // being omitted. List them all so each test can override only
+  // the field it cares about.
+  const isoDate = "2026-05-04T00:00:00Z"
+  return {
+    id: 1,
+    lead_id: 100,
+    full_name: null,
+    dob: null,
+    gender: null,
+    email: null,
+    phone: null,
+    social_insurance_number: null,
+    nationality: null,
+    ethnicity: null,
+    religion: null,
+    disability_type: null,
+    permanent_province: null,
+    permanent_district: null,
+    permanent_ward: null,
+    permanent_residential_group: null,
+    permanent_street_address: null,
+    place_of_birth: null,
+    native_place: null,
+    union_entry_date: null,
+    party_entry_date: null,
+    party_official_entry_date: null,
+    status: "draft",
+    applied_rules: {
+      schema_version: 1,
+      mandatory_docs: [],
+      method_type: "gpa_only",
+    },
+    family_info: [],
+    academic_history: [],
+    admission_scores: null,
+    documents_checklist: [],
+    created_at: isoDate,
+    updated_at: isoDate,
+    permissions: {},
+    minor_correction_fields: [],
+  }
+}
+
+
+// =============================================================================
+// 1. Permissive status — Stage 1 deploy choreography
+// =============================================================================
+
+
+describe("admissionProfileResponseSchema — permissive status parse", () => {
+  it("parses all 10 legacy status values strict", () => {
+    const legacy = [
+      "draft",
+      "submitted",
+      "resubmitted",
+      "approved",
+      "rejected",
+      "revision_requested",
+      "confirmed",
+      "overridden",
+      "enrolled",
+      "withdrawn",
+    ]
+    for (const status of legacy) {
+      const result = admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        status,
+      })
+      expect(result.success, `legacy status ${status} should parse`).toBe(true)
+    }
+  })
+
+  it("parses unknown status 'reviewing' (M-1-11 future state)", () => {
+    // M-1-11 extends the BE CHECK to 14 states. FE permissive
+    // catchall lets `reviewing` through during the deploy window.
+    const result = admissionProfileResponseSchema.safeParse({
+      ..._baselineProfile(),
+      status: "reviewing",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.status).toBe("reviewing")
+    }
+  })
+
+  it("parses unknown status 'admitted' (M-1-11 future state)", () => {
+    const result = admissionProfileResponseSchema.safeParse({
+      ..._baselineProfile(),
+      status: "admitted",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.status).toBe("admitted")
+    }
+  })
+
+  it("parses arbitrary unknown status string without crashing", () => {
+    // Defense — even if BE accidentally emits a typo or a state
+    // we haven't planned for, FE must not crash. StatusBadge
+    // fallback renders the raw string with neutral styling.
+    const result = admissionProfileResponseSchema.safeParse({
+      ..._baselineProfile(),
+      status: "future_state_x",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects non-string status (number / object / null)", () => {
+    // Permissive only widens to ANY STRING; type itself stays
+    // string. A number or null is still a contract violation.
+    for (const bad of [42, { state: "draft" }, null, undefined]) {
+      const result = admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        status: bad,
+      })
+      expect(result.success, `non-string ${typeof bad} should fail`).toBe(false)
+    }
+  })
+})
+
+
+// =============================================================================
+// 2. 4 eligibility scalar fields
+// =============================================================================
+
+
+describe("admissionProfileResponseSchema — gpa_overall", () => {
+  it("accepts numeric in range [0, 10]", () => {
+    for (const value of [0, 0.5, 5.25, 9.99, 10]) {
+      const result = admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        gpa_overall: value,
+      })
+      expect(result.success, `gpa ${value} should parse`).toBe(true)
+    }
+  })
+
+  it("coerces string-numeric (BE Pydantic Numeric → JSON string)", () => {
+    const result = admissionProfileResponseSchema.safeParse({
+      ..._baselineProfile(),
+      gpa_overall: "8.5",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.gpa_overall).toBe(8.5)
+    }
+  })
+
+  it("rejects out-of-range gpa", () => {
+    for (const value of [-0.1, 10.1, 100]) {
+      const result = admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        gpa_overall: value,
+      })
+      expect(result.success, `gpa ${value} should fail`).toBe(false)
+    }
+  })
+
+  it("accepts null + omitted (legacy response)", () => {
+    expect(
+      admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        gpa_overall: null,
+      }).success,
+    ).toBe(true)
+    // Omit entirely.
+    expect(admissionProfileResponseSchema.safeParse(_baselineProfile()).success).toBe(true)
+  })
+})
+
+
+describe("admissionProfileResponseSchema — conduct", () => {
+  it("accepts the 3 enum values", () => {
+    for (const value of ["TB", "KHA", "TOT"]) {
+      const result = admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        conduct: value,
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it("rejects unknown enum value", () => {
+    // Conduct is enum-strict (BE CHECK constraint enforces it
+    // too); permissive only applies to status field.
+    const result = admissionProfileResponseSchema.safeParse({
+      ..._baselineProfile(),
+      conduct: "EXCELLENT",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("accepts null + omitted (admin UI hasn't filled yet)", () => {
+    expect(
+      admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        conduct: null,
+      }).success,
+    ).toBe(true)
+  })
+})
+
+
+describe("admissionProfileResponseSchema — health_category", () => {
+  it("accepts integers 1..4", () => {
+    for (const value of [1, 2, 3, 4]) {
+      const result = admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        health_category: value,
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it("rejects out-of-range + non-integer", () => {
+    for (const value of [0, 5, 3.5, -1]) {
+      const result = admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        health_category: value,
+      })
+      expect(result.success, `health_category ${value} should fail`).toBe(false)
+    }
+  })
+})
+
+
+describe("admissionProfileResponseSchema — graduation_year", () => {
+  it("accepts years in [1900, 2100]", () => {
+    for (const value of [1900, 1950, 2026, 2100]) {
+      const result = admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        graduation_year: value,
+      })
+      expect(result.success, `year ${value} should parse`).toBe(true)
+    }
+  })
+
+  it("rejects years outside the range", () => {
+    for (const value of [1899, 2101, 0]) {
+      const result = admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        graduation_year: value,
+      })
+      expect(result.success, `year ${value} should fail`).toBe(false)
+    }
+  })
+
+  it("accepts null + omitted", () => {
+    expect(
+      admissionProfileResponseSchema.safeParse({
+        ..._baselineProfile(),
+        graduation_year: null,
+      }).success,
+    ).toBe(true)
+    expect(admissionProfileResponseSchema.safeParse(_baselineProfile()).success).toBe(true)
+  })
+})
+
+
+// =============================================================================
+// 3. Combined — eligibility fields + permissive status interplay
+// =============================================================================
+
+
+describe("admissionProfileResponseSchema — combined Wave 2 + M-1-11 deploy", () => {
+  it("parses a profile with all 4 eligibility fields + future status", () => {
+    // The realistic post-Wave-2-pre-Wave-3 response shape: BE
+    // emits the new eligibility fields (Wave 2 shipped) + a new
+    // status (Wave 3 ships next). FE Zod must accept both.
+    const result = admissionProfileResponseSchema.safeParse({
+      ..._baselineProfile(),
+      status: "reviewing",
+      gpa_overall: 8.75,
+      conduct: "TOT",
+      health_category: 1,
+      graduation_year: 2026,
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.status).toBe("reviewing")
+      expect(result.data.gpa_overall).toBe(8.75)
+      expect(result.data.conduct).toBe("TOT")
+      expect(result.data.health_category).toBe(1)
+      expect(result.data.graduation_year).toBe(2026)
+    }
+  })
+})

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -491,8 +491,30 @@ export const admissionProfileResponseSchema = z.object({
   union_entry_date: z.string().datetime({ offset: true }).nullable(),
   party_entry_date: z.string().datetime({ offset: true }).nullable(),
   party_official_entry_date: z.string().datetime({ offset: true }).nullable(),
-  // Status (extended for async-first workflow)
-  status: z.enum(["draft", "submitted", "resubmitted", "approved", "rejected", "revision_requested", "confirmed", "overridden", "enrolled", "withdrawn"]),
+  // Status (extended for async-first workflow).
+  //
+  // PERMISSIVE PARSE per PLAN line 3049-3055 — Stage 1 of the
+  // 3-stage deploy choreography for M-1-11 (status CHECK extend
+  // 10 → 14 state). FE Zod must accept any string so the response
+  // doesn't crash when BE deploys the migration + service starts
+  // emitting ``reviewing`` / ``admitted`` / new states BEFORE the
+  // FE container build catches up. Legacy strict enum is the
+  // documentation; the union catchall is what runtime parses.
+  //
+  // Status badge fallback (StatusBadge.tsx:166 + status-badge.config.ts:380):
+  // unknown status renders raw string with neutral/outline styling
+  // — generic gray badge per PLAN line 3052.
+  //
+  // After Wave 3 ship (M-1-11 + 14 status badge config + i18n):
+  // Stage 3 deploy choreography flips this back to strict enum
+  // with all 14 states.
+  status: z.union([
+    z.enum([
+      "draft", "submitted", "resubmitted", "approved", "rejected",
+      "revision_requested", "confirmed", "overridden", "enrolled", "withdrawn",
+    ]),
+    z.string(),
+  ]),
   version: z.number().int().optional(), // Optimistic locking
   academic_year: z.number().int().optional(), // Academic year
   applied_rules: appliedRulesSchema, // ✅ NEW: Properly typed with 18 fields
@@ -557,6 +579,52 @@ export const admissionProfileResponseSchema = z.object({
   
   // Profile completion percentage (0-100)
   completion_percent: z.number().int().min(0).max(100).default(0),
+
+  // =========================================================================
+  // phase1_09a (#184 Wave 2 PR-2A wired in FE-zod-eligibility) —
+  // 4 eligibility scalar fields. BE migration ships 4 nullable
+  // columns + backfills 2 (gpa_overall + graduation_year via
+  // academic_history JSON). conduct + health_category STAY NULL
+  // post-migration — admin reviews via UI Phase 1+2.
+  // =========================================================================
+  //
+  // FE Zod parse parity per Codex Guard 4 — DB shipped in PR-2A
+  // (squash 2d8b52f1) but FE Zod was deferred to this PR per the
+  // Phase 3 deploy choreography Stage 1 contract (FE permissive
+  // BEFORE BE M-1-11 status CHECK extend). All 4 nullable +
+  // optional so legacy responses without the fields still parse.
+  //
+  // Range guards mirror PLAN + alembic migration:
+  // * gpa_overall: 0..10 (numeric(4,2) on the wire — string-or-
+  //   number depending on BE serializer). Coerce because Pydantic
+  //   `Numeric` typically serializes as string in JSON.
+  // * conduct: enum TB/KHA/TOT (PLAN line 818).
+  // * health_category: smallint 1..4, where 1 = best (PLAN line 819).
+  // * graduation_year: smallint 1900..2100 (PLAN line 2795).
+  gpa_overall: z.coerce
+    .number()
+    .min(0)
+    .max(10)
+    .nullable()
+    .optional(),
+  conduct: z
+    .enum(["TB", "KHA", "TOT"])
+    .nullable()
+    .optional(),
+  health_category: z
+    .number()
+    .int()
+    .min(1)
+    .max(4)
+    .nullable()
+    .optional(),
+  graduation_year: z
+    .number()
+    .int()
+    .min(1900)
+    .max(2100)
+    .nullable()
+    .optional(),
   
   // Phase 0.9: Validation Summary (Grouped Errors for UX)
   validation_summary: z.object({


### PR DESCRIPTION
## Summary

**Stage 1 permissive parse only** — FE-only PR, no BE change. Off remote parent `origin/feat/admission-full-cutover` = `e46cf5fc` (post Wave 2 PR-2A complete).

⚠ **NOT a full closure of FE-zod-status / FE-badge / FE-tabs** — those (Stage 3 strict 14-state lock + 14 status badge config + i18n keys) ship trong Wave 3 wave bundle với BE migration `M-1-11`. This PR satisfies Codex Guard 4 contract: ship FE Zod permissive parse **BEFORE** M-1-11 BE deploy (Phase 3 deploy choreography Stage 1).

## PLAN ref

§3 deploy choreography Stage 1 (PLAN line 3049-3055):

> Stage 1 (Day 1) — FE Zod permissive deploy ONLY:
> - FE Zod đổi enum strict thành catchall: `z.union([z.enum([...legacy_states]), z.string()])` — passthrough state lạ.
> - Status badge fallback render generic gray badge cho state lạ.
> - KHÔNG đổi BE.

→ Window 1-3 phút giữa BE migration apply và FE container build → strict Zod parse fail → user crash. Stage 1 prevents the window.

## Scope

### Frontend Zod (1 file)

`lib/zod/admissions.ts`:

- **Status parse — permissive**: `z.union([z.enum([...10 legacy states]), z.string()])`. Legacy strict enum kept inline as documentation; the catchall is what runtime uses.
- **4 eligibility fields** (Wave 2 PR-2A `2d8b52f1` parity, deferred per Codex Guard 4):
  - `gpa_overall`: `z.coerce.number().min(0).max(10).nullable().optional()` — coerce because Pydantic Numeric typically serializes as JSON string.
  - `conduct`: `z.enum(["TB", "KHA", "TOT"]).nullable().optional()` — strict enum (BE CHECK constraint enforces).
  - `health_category`: `z.number().int().min(1).max(4).nullable().optional()` — 1 = best.
  - `graduation_year`: `z.number().int().min(1900).max(2100).nullable().optional()` — mirrors PLAN line 2795.

All 4 nullable + optional → legacy responses (pre-phase1_09a) still parse.

### Status badge fallback — already exists

| File | Behavior |
|---|---|
| `components/common/status/StatusBadge.tsx:166` | `getStatusConfig` returns `{ label: status, variant: "neutral" }` for unknown |
| `lib/ui-config/status-badge.config.ts:380` | `getStatusBadgeConfig` returns `{ ...DEFAULT_BADGE_CONFIG, label: status }` for unknown — neutral/outline styling + `AlertCircle` icon |

→ No new fallback code needed. Unknown status renders raw string với generic gray badge per PLAN line 3052.

## Tests (18 case)

`lib/zod/admissions.eligibility.test.ts`:

| Group | Cases |
|---|---|
| Permissive status | 10 legacy strict + 3 unknown (reviewing/admitted/future_state_x) + non-string reject |
| `gpa_overall` | 5 in-range + string coerce + 3 out-of-range reject + null/omit accept |
| `conduct` | 3 enum accept + unknown reject + null/omit accept |
| `health_category` | 4 int accept + 4 invalid reject |
| `graduation_year` | 4 in-range accept + 3 out-of-range reject + null/omit accept |
| Combined Wave 2 + M-1-11 | profile với 4 eligibility + future status "reviewing" parse cleanly |

```
FE targeted suite (bind-mount): 18 passed in 1.80s
FE tsc --noEmit: 0 error
FE lint: 0 error (206 pre-existing warnings, none in scope)
```

## NOT shipped in this PR (defer to Wave 3 wave bundle)

| Tracker row | Status |
|---|---|
| `FE-zod-status` (Zod 14 status enum re-strict) | DEFERRED (Stage 3 — sau khi BE M-1-11 ship) |
| `FE-badge` (`STATUS_BADGE_CONFIG` extend 14 status + i18n inline 25 keys) | DEFERRED (Wave 3 bundle) |
| `FE-tabs` (`AdmissionsClient.tsx STATUS_TABS` extend 14 status filter) | DEFERRED (Wave 3 bundle) |

These 3 must ship CÙNG hoặc TRƯỚC M-1-11 final flip per PLAN line 3041-3060 deploy choreography.

## Test plan

- [x] FE targeted suite 18/18 PASS
- [x] FE tsc 0 error
- [x] FE lint 0 error in scope
- [x] Status badge fallback for unknown status verified (existing code)
- [ ] Manual smoke: render profile với status="reviewing" → expect generic gray badge with raw "reviewing" text (defer pre-cutover Chrome MCP)
- [ ] Wave 3 bundle PR (FE-zod-status strict re-tighten + FE-badge + FE-tabs) — ship CÙNG/TRƯỚC M-1-11

🤖 Generated with [Claude Code](https://claude.com/claude-code)