### PR TITLE
[#184 Wave5-E] feat(schema): phase1_17 archived_outbox table

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase1_17_create_archived_outbox_table.py
+++ b/Backend_FastAPI/alembic/versions/phase1_17_create_archived_outbox_table.py
@@ -1,0 +1,179 @@
+"""PATCH-20 — create `_archived_notification_outbox` table for 90-day archive.
+
+Companion to ``phase1_16`` (Wave 5-D archive table for admission profile).
+PLAN line 168-178 (Phần 1 #08 fix) + cheat sheet line 3464-3468 + slot
+assignment §8 line 4492 ship 2 archive tables under PATCH-20:
+
+* ``_archived_admission_profile`` (phase1_16, Wave 5-D ✅ shipped PR #214)
+* ``_archived_notification_outbox`` (this migration, slot phase1_17, Wave 5-E)
+
+The cron ``archive_outbox_dispatched_task`` (NOT shipped here — paired with
+Wave 5-B ``phase1_19d`` Celery beat registration which depends on this table
+existing) runs weekly and MOVES rows whose ``dispatched_at`` is older than 90
+days from the live ``notification_outbox`` into this archive. Per PLAN line
+3464-3468 the archive holds BOTH dispatched and failed (DLQ) outbox rows
+post-90-days, NOT only failed.
+
+Cron semantic (PLAN line 170-176)
+---------------------------------
+
+```sql
+WITH archived AS (
+    DELETE FROM notification_outbox
+    WHERE dispatched_at IS NOT NULL
+      AND dispatched_at < NOW() - INTERVAL '90 days'
+    RETURNING *
+)
+INSERT INTO _archived_notification_outbox SELECT * FROM archived;
+```
+
+This is a MOVE (DELETE + INSERT), unlike Wave 5-D's COPY pattern where the
+source profile row is preserved. The cron's RETURNING-clause snapshot is
+enough to populate the archive INSERT — no second SELECT needed.
+
+Schema parity rules
+-------------------
+
+* Mirror the 10 columns of ``notification_outbox`` exactly (types +
+  nullability + server_default) so the cron CTE INSERT has perfect column
+  alignment.
+* + 1 archive-metadata column ``archived_at TIMESTAMPTZ NOT NULL DEFAULT
+  now()`` — set automatically when cron INSERTs the archive row.
+* NO foreign keys (the source notification_outbox has no FKs either).
+* NO unique constraints — the source ``idempotency_key`` UNIQUE is dropped
+  on the archive side. Reason: archived rows are by definition outside the
+  worker's dedupe window (they're 90+ days dispatched), so the live UNIQUE
+  contract no longer needs to extend across the archive table. Dropping it
+  also keeps the archive append-only even in the unlikely event a stale
+  worker re-INSERTs an idempotency_key that has since been archived.
+* NO check constraints — archive must round-trip historical rows even if
+  the live table contract evolves.
+* NO partial indexes — the source's ``ix_outbox_pending`` /
+  ``ix_outbox_claim`` are partial WHERE ``dispatched_at IS NULL`` filters
+  serving the worker's claim path. Every archived row has
+  ``dispatched_at IS NOT NULL`` (the cron's archive predicate), so the
+  partial filter would match zero rows on the archive side — the indexes
+  are useless here and we drop them.
+
+Archive index
+-------------
+
+``ix_archived_outbox_archived_at`` on ``archived_at`` — Option II chốt
+2026-05-05. PLAN does NOT mandate an archive-side index (line 168-178 + 3464
+silent), but the typical admin query against the archive is a time-range
+debug ("show me rows archived in window X-Y", weekly archive volume report,
+forensic lookup post-incident). Indexing ``archived_at`` keeps that query
+fast as the archive grows toward the 60-180k-row 5-year ceiling that
+motivated this archive policy in the first place. ``dispatched_at`` was
+considered (Option III) but rejected — every archived row has
+``dispatched_at < NOW() - 90 days`` by definition, so an index there has low
+selectivity for the typical admin query.
+
+Idempotent guards via SQLAlchemy ``inspector`` mirror the ``phase1_19a``
+template (PR #198) and ``phase1_16`` (PR #214):
+
+* table create skipped if ``_archived_notification_outbox`` already present;
+* named index skipped if already present;
+* downgrade short-circuits if the table is gone.
+
+Defer to follow-up (NOT in Wave 5-E D-i scope)
+----------------------------------------------
+
+* ORM class ``ArchivedNotificationOutbox`` — ship together with whichever
+  caller needs to query the archive (none today; deferred until forensic
+  query or DLQ-replay tooling lands).
+* ``archive_outbox_dispatched_task`` itself — ship in Wave 5-B
+  ``phase1_19d`` paired with the Celery beat registration (the marker
+  migration registers the schedule entry; the task body lives in
+  ``app/tasks/notification_outbox_tasks.py`` and references THIS table).
+
+Revision ID: phase1_17
+Revises: phase1_16
+Create Date: 2026-05-05
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_17"
+down_revision: Union[str, None] = "phase1_16"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE = "_archived_notification_outbox"
+INDEX_ARCHIVED_AT = "ix_archived_outbox_archived_at"
+
+
+def table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def index_exists(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    return index_name in {idx["name"] for idx in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not table_exists(TABLE):
+        op.create_table(
+            TABLE,
+            # ── Mirror notification_outbox columns (FK/UQ/CHECK omitted) ──
+            sa.Column(
+                "id",
+                sa.BigInteger(),
+                primary_key=True,
+                autoincrement=True,
+            ),
+            sa.Column("event_code", sa.String(64), nullable=False),
+            sa.Column("payload", postgresql.JSONB(), nullable=False),
+            sa.Column("idempotency_key", sa.String(128), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.Column("dispatched_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "attempts",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+            sa.Column("last_error", sa.Text(), nullable=True),
+            sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("claimed_until", sa.DateTime(timezone=True), nullable=True),
+            # ── Archive metadata (1 column only) ──
+            sa.Column(
+                "archived_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+        )
+
+    if not index_exists(TABLE, INDEX_ARCHIVED_AT):
+        op.create_index(
+            INDEX_ARCHIVED_AT,
+            TABLE,
+            ["archived_at"],
+        )
+
+
+def downgrade() -> None:
+    if not table_exists(TABLE):
+        return
+
+    if index_exists(TABLE, INDEX_ARCHIVED_AT):
+        op.drop_index(INDEX_ARCHIVED_AT, table_name=TABLE)
+
+    op.drop_table(TABLE)

--- a/Backend_FastAPI/tests/unit/test_phase1_17_archived_outbox.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_17_archived_outbox.py
@@ -1,0 +1,266 @@
+"""Unit tests for #184 Wave 5-E migration ``phase1_17_create_archived_outbox_table``.
+
+Companion test to ``test_phase1_16_archived_admission_profile.py``. Locks the
+revision chain, table name, the column-mirror invariant against the live
+``NotificationOutbox`` model, the archive metadata column, the
+``archived_at`` index per Option II chốt 2026-05-05, the dropped surface (UQ
+idempotency_key + 2 partial worker-only indexes), the no-FK/UQ/CHECK shape,
+and the idempotent guard surface.
+
+Live alembic roundtrip is DEFERRED to staging clone D12-D14 (same dev DB
+drift workaround as Wave 5-D — `alembic_version` stamped without upgrade
+body execution for Wave 2 artifacts).
+
+What lives here:
+1. Revision row + chain (``phase1_17`` → ``phase1_16``).
+2. Underscore-prefixed table name ``_archived_notification_outbox``.
+3. Mirror parity — every ``NotificationOutbox`` column name appears in the
+   migration source (re-derived, NOT hardcoded) — anchor non-tautological.
+4. Archive metadata column ``archived_at`` shape.
+5. ``ix_archived_outbox_archived_at`` single-column index per Option II.
+6. NO FK / UQ / CHECK constraints (archive must accept historical violators).
+7. UQ ``idempotency_key`` from source NOT mirrored (drop on archive).
+8. Source's worker-only partial indexes (``ix_outbox_pending`` /
+   ``ix_outbox_claim`` WHERE dispatched_at IS NULL) NOT mirrored.
+9. Idempotent guards (``table_exists`` + ``index_exists``) on both upgrade
+   and downgrade paths.
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_PHASE1_17 = _VERSIONS_DIR / "phase1_17_create_archived_outbox_table.py"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location(_PHASE1_17.stem, _PHASE1_17)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_17():
+    return _load_migration()
+
+
+@pytest.fixture
+def src() -> str:
+    return _PHASE1_17.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision row + chain
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_17_revision_id(phase1_17) -> None:
+    assert phase1_17.revision == "phase1_17"
+
+
+def test_phase1_17_chains_off_phase1_16(phase1_17) -> None:
+    """Wave 5 ship-order chốt 2026-05-05 Codex round 19: phase1_17 follows
+    phase1_16 (Wave 5-D), so phase1_19d (Wave 5-B archive task body) can
+    register knowing this table exists."""
+    assert phase1_17.down_revision == "phase1_16"
+
+
+# ---------------------------------------------------------------------------
+# 2. Table name + index name
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_17_uses_underscore_prefixed_table_name(phase1_17) -> None:
+    """PLAN line 176, 178, 3465, 3495 ALL use the leading-underscore
+    convention to mark this as an internal/archive table."""
+    assert phase1_17.TABLE == "_archived_notification_outbox"
+
+
+def test_phase1_17_index_name_matches_option_ii(phase1_17) -> None:
+    """Option II chốt 2026-05-05 — ``archived_at`` single-column index for
+    typical admin time-range queries."""
+    assert phase1_17.INDEX_ARCHIVED_AT == "ix_archived_outbox_archived_at"
+
+
+# ---------------------------------------------------------------------------
+# 3. Column mirror parity — re-derived from NotificationOutbox model
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_17_mirrors_every_notification_outbox_column(src) -> None:
+    """Re-derive the column list from the live ``NotificationOutbox`` model
+    instead of hardcoding it (memory ``verify-schema-before-proposing`` +
+    ``pattern-change-impact-audit``). A later schema rename to source must
+    not silently drift from the archive mirror."""
+    from app.models.notification_outbox import NotificationOutbox
+
+    source_columns = {c.name for c in NotificationOutbox.__table__.columns}
+
+    missing = []
+    for column_name in source_columns:
+        if f'"{column_name}"' not in src:
+            missing.append(column_name)
+
+    assert not missing, (
+        f"phase1_17 archive table missing NotificationOutbox columns: {missing}"
+    )
+
+
+def test_phase1_17_column_count_matches_source_plus_one(src) -> None:
+    """Archive table = source columns + exactly 1 archive-metadata column
+    (``archived_at``). No extra audit/discriminator columns."""
+    from app.models.notification_outbox import NotificationOutbox
+
+    source_count = len(NotificationOutbox.__table__.columns)
+    column_decls = re.findall(r'sa\.Column\(\s*"([a-z_]+)"', src)
+    unique = set(column_decls)
+    assert len(unique) == source_count + 1, (
+        f"Expected {source_count + 1} columns "
+        f"({source_count} source + 1 archived_at), got {len(unique)}: {unique}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Archive metadata column
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_17_archived_at_is_not_null_with_now_default(src) -> None:
+    """``archived_at`` is the cron's INSERT marker — NOT NULL with
+    ``DEFAULT now()`` so the cron INSERT does not need to set it
+    explicitly."""
+    pattern = re.compile(
+        r'sa\.Column\(\s*"archived_at"[^)]*?'
+        r'sa\.DateTime\(timezone=True\)[^)]*?'
+        r'nullable=False[^)]*?'
+        r'server_default=sa\.text\("now\(\)"\)',
+        re.DOTALL,
+    )
+    assert pattern.search(src), "archived_at column shape mismatch"
+
+
+# ---------------------------------------------------------------------------
+# 5. Index — Option II single column
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_17_creates_archived_at_index(src) -> None:
+    """Option II chốt — single-column index on ``archived_at`` for admin
+    time-range queries."""
+    assert "ix_archived_outbox_archived_at" in src
+    # Single column, not composite — verify only `archived_at` appears
+    # inside the create_index call's column list.
+    pattern = re.compile(
+        r'op\.create_index\(\s*INDEX_ARCHIVED_AT[^)]*?'
+        r'\[\s*"archived_at"\s*\]',
+        re.DOTALL,
+    )
+    assert pattern.search(src), (
+        "Index must be single-column on archived_at (Option II chốt)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. No FK / UQ / CHECK constraints
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_17_declares_no_foreign_keys(src) -> None:
+    """Source notification_outbox has no FKs either — symmetry preserved."""
+    assert "ForeignKey(" not in src
+
+
+def test_phase1_17_drops_idempotency_key_unique(src) -> None:
+    """Source has ``UniqueConstraint("idempotency_key", ...)`` (notification
+    _outbox.py:113-116). On the archive side this is dropped — archived rows
+    are outside the worker's dedupe window so the live UNIQUE contract no
+    longer needs to extend across the archive."""
+    # The idempotency_key column itself MUST appear (mirror parity) but
+    # NO UNIQUE constraint or `unique=True` flag may decorate it.
+    assert '"idempotency_key"' in src  # mirror present
+    assert "UniqueConstraint" not in src
+    assert "unique=True" not in src
+
+
+def test_phase1_17_declares_no_check_constraints(src) -> None:
+    """Archive must round-trip historical rows even if live contract
+    evolves."""
+    assert "CheckConstraint" not in src
+
+
+# ---------------------------------------------------------------------------
+# 7. No partial worker-only indexes
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_17_does_not_mirror_worker_partial_indexes(src) -> None:
+    """Source's ``ix_outbox_pending`` + ``ix_outbox_claim`` partial-WHERE
+    ``dispatched_at IS NULL`` filters serve the worker's claim path. Every
+    archived row has ``dispatched_at IS NOT NULL`` (cron's archive
+    predicate) — these partial indexes would match zero rows on the
+    archive.
+
+    Scope check to the executable body (between ``def upgrade():`` and
+    ``def downgrade():``) so the rationale text in the module docstring
+    can name the dropped indexes without the assertion misfiring."""
+    upgrade_body = src[
+        src.index("def upgrade()") : src.index("def downgrade()")
+    ]
+    assert "ix_outbox_pending" not in upgrade_body
+    assert "ix_outbox_claim" not in upgrade_body
+    assert "postgresql_where" not in upgrade_body
+
+
+# ---------------------------------------------------------------------------
+# 8. Idempotent guards
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_17_upgrade_guards_table_create(src) -> None:
+    """Idempotent re-run: a half-applied upgrade re-running must skip the
+    ``CREATE TABLE`` if the table already exists."""
+    assert "if not table_exists(TABLE):" in src
+
+
+def test_phase1_17_upgrade_guards_index_create(src) -> None:
+    assert "if not index_exists(TABLE, INDEX_ARCHIVED_AT):" in src
+
+
+def test_phase1_17_downgrade_short_circuits_when_table_missing(src) -> None:
+    """Per ``phase1_19a`` template — drop_index against a missing parent
+    table raises; downgrade returns early when the table is already gone."""
+    pattern = re.compile(
+        r"def downgrade\(\) -> None:\s*"
+        r"(?:#[^\n]*\n\s*)*"
+        r"if not table_exists\(TABLE\):\s*\n\s*return",
+        re.MULTILINE,
+    )
+    assert pattern.search(src), (
+        "downgrade() must short-circuit when the table is already gone"
+    )
+
+
+def test_phase1_17_downgrade_drops_index_before_table(src) -> None:
+    """Even though ``DROP TABLE`` cascades indexes, the explicit
+    ``drop_index`` call lets a half-applied downgrade resume safely."""
+    downgrade_block = src[src.index("def downgrade("):]
+    drop_index_pos = downgrade_block.index("op.drop_index(")
+    drop_table_pos = downgrade_block.index("op.drop_table(")
+    assert drop_index_pos < drop_table_pos
+
+
+# ---------------------------------------------------------------------------
+# 9. Module sanity
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_17_defines_upgrade_and_downgrade(phase1_17) -> None:
+    assert callable(getattr(phase1_17, "upgrade", None))
+    assert callable(getattr(phase1_17, "downgrade", None))


### PR DESCRIPTION
## Scope

PATCH-20 archive table #2/2 — creates `_archived_notification_outbox` mirroring 10 `notification_outbox` columns + 1 archive metadata (`archived_at`) + 1 archive index (`ix_archived_outbox_archived_at`). Empty table; cron `archive_outbox_dispatched_task` ships in Wave 5-B `phase1_19d` paired with Celery beat registration (needs THIS table to write to).

## Decisions

- **D-i scope** (Codex round 20 chốt 2026-05-05): migration only — no ORM, no service, no cron.
- **Archive index Option II chốt 2026-05-05**: `ix_archived_outbox_archived_at` on `archived_at` (single column). Option I (no index) rejected — first admin time-range query would seq-scan toward 60-180k row ceiling. Option III (`dispatched_at`) rejected — every archived row has `dispatched_at < NOW() - 90 days` by definition (low selectivity).
- **Wave 5 ship-order** (chốt 2026-05-05): `phase1_19c` (5-A ✅) → `phase1_16` (5-D ✅ #214) → **phase1_17 (5-E this PR)** → `phase1_19d` (5-B) → `phase1_19e` (5-C). Wave 5-D + 5-E ship before 5-B because 5-B archive task body references this table.

## Schema parity rules

- Mirror ALL 10 columns of `notification_outbox` exactly (types + nullability + server_default) so cron CTE INSERT has perfect column alignment with `DELETE...RETURNING *`.
- + 1 archive metadata: `archived_at TIMESTAMPTZ NOT NULL DEFAULT now()`.
- + 1 archive index: `ix_archived_outbox_archived_at` on `archived_at` (Option II).
- **NO foreign keys** — source notification_outbox has no FKs either.
- **NO unique constraints** — source `idempotency_key` UNIQUE dropped; archived rows are 90+ days dispatched, outside worker's dedupe window.
- **NO check constraints** — preserve historical violators if live contract evolves.
- **NO partial indexes** — source's `ix_outbox_pending` / `ix_outbox_claim` (partial WHERE `dispatched_at IS NULL`) match zero rows on the archive (every row has `dispatched_at IS NOT NULL` by cron predicate).

## Cron MOVE semantic (PLAN line 170-176) — different from Wave 5-D COPY

```sql
WITH archived AS (
    DELETE FROM notification_outbox
    WHERE dispatched_at IS NOT NULL
      AND dispatched_at < NOW() - INTERVAL '90 days'
    RETURNING *
)
INSERT INTO _archived_notification_outbox SELECT * FROM archived;
```

Atomic move — `DELETE...RETURNING *` snapshot populates the INSERT. Different from Wave 5-D admission profile archive (INSERT ... SELECT, source preserved per PLAN line 558-572).

## Test plan — 17/17 unit tests pass

- [x] Revision chain (`phase1_17` ← `phase1_16`)
- [x] Underscore-prefixed table name `_archived_notification_outbox`
- [x] Index name `ix_archived_outbox_archived_at` (Option II)
- [x] Mirror parity: every name in `NotificationOutbox.__table__.columns` appears in source (re-derived, NOT hardcoded — anchor non-tautological)
- [x] Column count = source + 1 (archive metadata only)
- [x] `archived_at TIMESTAMPTZ NOT NULL DEFAULT now()` shape
- [x] Single-column index on `archived_at` (NOT composite)
- [x] No `ForeignKey(`
- [x] `idempotency_key` column mirrored but NO `UniqueConstraint` / `unique=True`
- [x] No `CheckConstraint`
- [x] Worker-only partial-IX names not in upgrade() body (docstring rationale exception)
- [x] Upgrade idempotent guards (`if not table_exists`, `if not index_exists`)
- [x] Downgrade short-circuits when table missing
- [x] Downgrade drops index BEFORE table (half-applied resume safety)
- [x] `upgrade()` + `downgrade()` callable

## Live alembic roundtrip — DEFERRED to staging clone D12-D14

**Reason**: same dev DB drift workaround as Wave 5-D (PR #214). `alembic_version` stamped `phase1_19c` but Wave 2 schema artifacts (phase1_09a 4 columns + `conduct_grade` ENUM, phase1_10 status_history table) are missing. Wave 5-E inherits Option C per Codex round 20 risk evaluation.

**Mitigation**:
- 17 unit tests cover full migration contract with anchor non-tautological pattern.
- Template parity inherited from `phase1_19a` (PR #198 live ✅), `phase1_19c` (PR #213 live ✅), `phase1_16` (PR #214 unit-only same drift workaround).
- Production deploy will have proper Wave 2 schema → all column references resolve.
- Live alembic roundtrip will execute on staging clone D12-D14 per `Documents/ADMISSION_REHEARSAL_LOG.md` — extends Wave 1+2+5-A+5-D rehearsal window.

**Track**: dev DB drift fix as separate ops follow-up (DBA task — already opened with Wave 5-D).

## Defer to follow-up (NOT in Wave 5-E scope)

- ORM class `ArchivedNotificationOutbox` — ship with whichever caller needs forensic query / DLQ-replay tooling.
- `archive_outbox_dispatched_task` cron + Celery beat registration — Wave 5-B `phase1_19d` (now unblocked since this table will exist).

## References

- PLAN line 168-178 (Phần 1 #08 fix — outbox retention 90-day archive policy + cron SQL sample)
- PLAN line 3464-3468 (cheat sheet phase1_17 + "chứa cả dispatched + failed" clarification)
- PLAN line 4492 (slot phase1_17 chốt 2026-05-03 §8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
