### PR TITLE
[#184 Wave5-B] feat(notification): phase1_19d marker + archive_outbox_dispatched_task beat

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase1_19d_register_celery_beat_archive_task.py
+++ b/Backend_FastAPI/alembic/versions/phase1_19d_register_celery_beat_archive_task.py
@@ -1,0 +1,83 @@
+"""Wave 5-B / M-1-19d — register weekly outbox archive task (B-i marker).
+
+Pattern B-i marker migration. Alembic does NOT manage the Celery beat
+schedule (per ``app/celery_app.py:118-255`` static-dict pattern — no
+DatabaseScheduler), so the actual change ships in two paired code edits:
+
+* ``app/celery_app.py`` adds ``"archive-outbox-dispatched"`` beat entry
+  pointed at ``archive_outbox_dispatched_task`` with a Sunday 02:00 VN
+  weekly schedule (low-traffic window per existing slot map at
+  ``app/celery_app.py:118-255`` — no conflict with KPI / cleanup /
+  reminder ticks).
+* ``app/tasks/notification_outbox_tasks.py`` adds the task body.
+
+This migration carries the **schema-side commitment** that the archive
+table from ``phase1_17`` (Wave 5-E PR #215 squash ``0b17f394``) is
+considered the canonical destination for the archive cron's MOVE
+operation. The body is a no-op because the DDL was already applied in
+``phase1_17``; this revision exists so the alembic history records the
+same version-control point that the paired Celery code change locks in.
+
+Cron semantic recap (PLAN line 168-178 — P1 fix #8 outbox 90-day archive)
+------------------------------------------------------------------------
+
+```sql
+WITH archived AS (
+    DELETE FROM notification_outbox
+    WHERE dispatched_at IS NOT NULL
+      AND dispatched_at < NOW() - INTERVAL '90 days'
+    RETURNING id, event_code, payload, idempotency_key, created_at,
+              dispatched_at, attempts, last_error, claimed_at, claimed_until
+)
+INSERT INTO _archived_notification_outbox (
+    id, event_code, payload, idempotency_key, created_at,
+    dispatched_at, attempts, last_error, claimed_at, claimed_until
+)
+SELECT * FROM archived;
+```
+
+Single-statement atomic move. The archive table's ``archived_at`` column
+auto-populates via the ``server_default=now()`` set in ``phase1_17``.
+``DELETE...RETURNING *`` snapshot feeds the INSERT in the same
+transaction — no second SELECT, no data-loss window.
+
+Idempotent guard
+----------------
+
+A marker-only migration has no idempotency surface to guard. Re-running
+``alembic upgrade head`` after the chain reaches this revision is a
+no-op (Alembic skips already-applied revisions). Re-running ``upgrade``
+explicitly (e.g. via ``alembic upgrade phase1_19d --sql``) emits the
+empty body with no DDL.
+
+Revision ID: phase1_19d
+Revises: phase1_17
+Create Date: 2026-05-05
+"""
+from typing import Sequence, Union
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_19d"
+down_revision: Union[str, None] = "phase1_17"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """B-i marker — paired Celery code in ``app/celery_app.py`` and
+    ``app/tasks/notification_outbox_tasks.py`` carries the actual change.
+
+    Schema commitment: ``phase1_17`` already created
+    ``_archived_notification_outbox``; this revision locks in the
+    version-control point for the archive cron beat registration that
+    the paired code change adds.
+    """
+    pass
+
+
+def downgrade() -> None:
+    """No-op — paired code change must be reverted in the application
+    repo separately. The archive table itself rolls back via
+    ``phase1_17``'s downgrade (drop_index + drop_table)."""
+    pass

--- a/Backend_FastAPI/app/celery_app.py
+++ b/Backend_FastAPI/app/celery_app.py
@@ -252,6 +252,18 @@ celery_app.conf.beat_schedule = {
         "schedule": 30.0,  # Every 30 seconds (per RUNBOOK §3.5 T0-4 acceptance)
         "options": {"queue": "default"},
     },
+
+    # --- Wave 5-B / M-1-19d: weekly outbox archive sweep (90-day retention) ---
+    # PLAN line 168-178 P1 fix #8: outbox table grows toward 60-180k rows over
+    # 5 years; worker SELECT FOR UPDATE SKIP LOCKED scan slows + coverage
+    # script DB query slows. Move dispatched rows older than 90d into
+    # `_archived_notification_outbox` (created by `phase1_17`). Sunday 02:00 VN
+    # — low-traffic window, no conflict with daily KPI / cleanup ticks above.
+    "archive-outbox-dispatched": {
+        "task": "archive_outbox_dispatched_task",
+        "schedule": crontab(hour=2, minute=0, day_of_week="sunday"),
+        "options": {"queue": "default"},
+    },
 }
 
 # =============================================================================

--- a/Backend_FastAPI/app/tasks/notification_outbox_tasks.py
+++ b/Backend_FastAPI/app/tasks/notification_outbox_tasks.py
@@ -318,3 +318,94 @@ async def _finalize(session, results) -> None:
                     ),
                     {"id": row_id, "err": error},
                 )
+
+
+# ============================================================================
+# Wave 5-B / M-1-19d — weekly outbox archive sweep (90-day retention)
+# ============================================================================
+#
+# Beat fires ``archive_outbox_dispatched_task`` every Sunday 02:00 VN per the
+# entry in ``app/celery_app.py``. The task moves rows whose ``dispatched_at``
+# is older than 90 days from ``notification_outbox`` into
+# ``_archived_notification_outbox`` (created by ``phase1_17``, PR #215 squash
+# ``0b17f394``).
+#
+# This is a MOVE (DELETE source + INSERT archive in a single CTE) — different
+# from Wave 5-D admission profile archive which COPIES rows (source preserved
+# per PLAN line 558-572). The atomic CTE form follows PLAN line 170-176 P1 fix
+# #8 verbatim — ``DELETE...RETURNING *`` snapshot feeds the INSERT in the same
+# statement, so a crash mid-flight cannot leave a row in both tables nor lose
+# it.
+#
+# Memory ``async-session-gather`` (PR #105 lesson): the task uses ONE
+# ``task_db_session()`` for the whole sweep — no ``asyncio.gather`` over the
+# session.
+
+archive_log = logging.getLogger("archive_outbox_dispatched_task")
+
+# Discriminator in the result dict so ops can grep this task's ticks apart
+# from the worker tick.
+ARCHIVE_TASK_ID = "archive-outbox"
+
+# Retention window — sized to PLAN line 168-178. Surface as a constant so
+# ops can dial it from a single place (and tests can assert the value).
+ARCHIVE_RETENTION_DAYS = 90
+
+
+@celery_app.task(name="archive_outbox_dispatched_task")
+def archive_outbox_dispatched_task() -> dict:
+    """Move dispatched outbox rows older than ``ARCHIVE_RETENTION_DAYS``
+    into ``_archived_notification_outbox``.
+
+    Beat fires this with zero args (Sunday 02:00 VN). Returns a structured
+    result so monitoring can count archived rows per tick.
+    """
+    return run_async_task(
+        async_func=_archive_dispatched,
+        task_name="archive_outbox_dispatched_task",
+        task_log=archive_log,
+        validate_keys=["status", "archived_count", "task_id"],
+    )
+
+
+async def _archive_dispatched() -> dict:
+    """Async body — single-statement atomic move per PLAN line 170-176."""
+    async with task_db_session() as session:
+        async with session.begin():
+            result = await session.execute(
+                text(
+                    """
+                    WITH archived AS (
+                        DELETE FROM notification_outbox
+                        WHERE dispatched_at IS NOT NULL
+                          AND dispatched_at < NOW() - make_interval(days => :retention_days)
+                        RETURNING id, event_code, payload, idempotency_key,
+                                  created_at, dispatched_at, attempts,
+                                  last_error, claimed_at, claimed_until
+                    )
+                    INSERT INTO _archived_notification_outbox (
+                        id, event_code, payload, idempotency_key,
+                        created_at, dispatched_at, attempts, last_error,
+                        claimed_at, claimed_until
+                    )
+                    SELECT * FROM archived
+                    RETURNING id
+                    """
+                ),
+                {"retention_days": ARCHIVE_RETENTION_DAYS},
+            )
+            archived_ids = [row[0] for row in result.fetchall()]
+
+    archive_log.info(
+        "archive_outbox_dispatched_task: tick complete",
+        extra={
+            "task_id": ARCHIVE_TASK_ID,
+            "archived_count": len(archived_ids),
+            "retention_days": ARCHIVE_RETENTION_DAYS,
+        },
+    )
+    return {
+        "status": "ok",
+        "archived_count": len(archived_ids),
+        "task_id": ARCHIVE_TASK_ID,
+    }

--- a/Backend_FastAPI/tests/unit/test_phase1_19d_archive_beat_task.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_19d_archive_beat_task.py
@@ -1,0 +1,251 @@
+"""Unit tests for #184 Wave 5-B migration ``phase1_19d_register_celery_beat_archive_task``
+plus the paired Celery code edits (``app/celery_app.py`` beat entry +
+``app/tasks/notification_outbox_tasks.py`` task body).
+
+Pattern B-i: the alembic migration is a marker (``upgrade`` /
+``downgrade`` are no-ops); the actual change is the Celery beat
+registration + task body. Tests cover all three surfaces:
+
+1. Migration revision chain + body=pass marker.
+2. Beat schedule entry shape (key + task name + Sunday 02:00 crontab +
+   queue).
+3. Task body contract: name, callable, zero-arg, retention constant,
+   single-statement atomic CTE (text grep), correct column projection
+   for archive INSERT (no ``archived_at`` — relies on
+   ``server_default=now()`` from ``phase1_17``).
+4. Task name registers under the celery app after ``app.tasks`` import.
+5. Result-dict validation keys honored (`status`, `archived_count`,
+   `task_id`).
+
+What does NOT live here:
+
+* End-to-end SQL execution against a real DB — defer to staging clone
+  D12-D14 alongside the rest of Wave 5 live alembic roundtrip.
+* Worker pattern coverage of ``dispatch_pending_outbox`` —
+  ``test_outbox_worker.py`` owns that.
+"""
+from __future__ import annotations
+
+import importlib.util
+import inspect
+from pathlib import Path
+
+import pytest
+from celery.schedules import crontab
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_PHASE1_19D = (
+    _VERSIONS_DIR / "phase1_19d_register_celery_beat_archive_task.py"
+)
+_TASKS_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "app"
+    / "tasks"
+    / "notification_outbox_tasks.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location(_PHASE1_19D.stem, _PHASE1_19D)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_19d():
+    return _load_migration()
+
+
+# ---------------------------------------------------------------------------
+# 1. Migration revision row + chain
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_19d_revision_id(phase1_19d) -> None:
+    assert phase1_19d.revision == "phase1_19d"
+
+
+def test_phase1_19d_chains_off_phase1_17(phase1_19d) -> None:
+    """Wave 5-B runs after Wave 5-E so the archive table that the task
+    body writes to (``_archived_notification_outbox``) already exists."""
+    assert phase1_19d.down_revision == "phase1_17"
+
+
+# ---------------------------------------------------------------------------
+# 2. Migration is B-i marker (no-op)
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_19d_upgrade_body_is_marker(phase1_19d) -> None:
+    """B-i pattern — paired Celery code carries the actual change. The
+    migration must NOT call any ``op.*`` DDL helper."""
+    src = _PHASE1_19D.read_text(encoding="utf-8")
+    # The string ``op.`` must not appear inside the upgrade() / downgrade()
+    # function bodies (the docstring above does NOT contain ``op.``).
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    downgrade_body = src[src.index("def downgrade()"):]
+    assert "op." not in upgrade_body
+    assert "op." not in downgrade_body
+
+
+def test_phase1_19d_callable_upgrade_and_downgrade(phase1_19d) -> None:
+    assert callable(getattr(phase1_19d, "upgrade", None))
+    assert callable(getattr(phase1_19d, "downgrade", None))
+
+
+# ---------------------------------------------------------------------------
+# 3. Beat schedule entry
+# ---------------------------------------------------------------------------
+
+
+def test_beat_schedule_registers_archive_outbox_dispatched():
+    """Sunday 02:00 VN weekly per PLAN line 168-178 P1 fix #8 — low-traffic
+    slot, no conflict with daily KPI / cleanup ticks at 00:05 / 01:00 /
+    02:00 day-1 / 02:30 / 03:00 / 03:15 / 04:00 / 05:00 / 07:00 / 09:00."""
+    from app.celery_app import celery_app
+
+    schedule = celery_app.conf.beat_schedule
+    assert "archive-outbox-dispatched" in schedule, (
+        "beat entry `archive-outbox-dispatched` is missing — "
+        "Wave 5-B M-1-19d depends on this weekly cadence"
+    )
+
+    entry = schedule["archive-outbox-dispatched"]
+    assert entry["task"] == "archive_outbox_dispatched_task"
+    assert entry["options"] == {"queue": "default"}
+
+
+def test_beat_schedule_archive_runs_sunday_two_am():
+    """The schedule object is a ``celery.schedules.crontab`` set to
+    ``hour=2, minute=0, day_of_week='sunday'``. We verify each field via
+    the public crontab attributes rather than the repr."""
+    from app.celery_app import celery_app
+
+    sched = celery_app.conf.beat_schedule["archive-outbox-dispatched"]["schedule"]
+    assert isinstance(sched, crontab), (
+        f"archive sweep must be a crontab schedule; got {type(sched).__name__}"
+    )
+    assert sched.hour == {2}
+    assert sched.minute == {0}
+    # ``day_of_week='sunday'`` parses to the sunday set ({0}).
+    assert sched.day_of_week == {0}
+
+
+# ---------------------------------------------------------------------------
+# 4. Task module contract
+# ---------------------------------------------------------------------------
+
+
+def test_archive_task_callable_zero_arg():
+    """Beat fires the task with no args — its signature must accept zero
+    positional args."""
+    from app.tasks.notification_outbox_tasks import archive_outbox_dispatched_task
+
+    sig = inspect.signature(archive_outbox_dispatched_task)
+    required = [
+        p
+        for p in sig.parameters.values()
+        if p.default is inspect.Parameter.empty
+        and p.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    assert required == [], (
+        f"archive_outbox_dispatched_task must accept zero required args; "
+        f"got {required}"
+    )
+
+
+def test_archive_task_name_registered_under_celery_app():
+    """After ``import app.tasks``, the task name string must resolve in
+    ``celery_app.tasks`` so beat dispatch does not silently drop messages."""
+    import app.tasks  # noqa: F401 — registers tasks on the celery app
+
+    from app.celery_app import celery_app
+
+    assert "archive_outbox_dispatched_task" in celery_app.tasks, (
+        "archive_outbox_dispatched_task is not registered — "
+        "beat will fire with no consumer"
+    )
+
+
+def test_archive_retention_constant_is_ninety_days():
+    """PLAN line 168 mandates 90-day retention. Surface as a constant so
+    tests + ops can reason about it without grepping a magic number."""
+    from app.tasks.notification_outbox_tasks import ARCHIVE_RETENTION_DAYS
+
+    assert ARCHIVE_RETENTION_DAYS == 90
+
+
+# ---------------------------------------------------------------------------
+# 5. SQL contract (text grep — execution defers to D12-D14 staging clone)
+# ---------------------------------------------------------------------------
+
+
+def test_archive_task_uses_single_statement_cte_move():
+    """PLAN line 170-176 specifies a single CTE: DELETE...RETURNING *
+    feeds INSERT INTO archive. Splitting into two statements (DELETE
+    then INSERT) opens a data-loss window if the worker crashes in
+    between. This text grep guards against the split."""
+    src = _TASKS_FILE.read_text(encoding="utf-8")
+    # The CTE must wrap the DELETE so RETURNING flows into the INSERT.
+    assert "WITH archived AS (" in src
+    assert "DELETE FROM notification_outbox" in src
+    assert "RETURNING id, event_code" in src
+    assert "INSERT INTO _archived_notification_outbox" in src
+    assert "SELECT * FROM archived" in src
+
+
+def test_archive_task_uses_retention_parameter_not_hardcoded():
+    """The retention window is parameterized (``:retention_days``) so the
+    constant ``ARCHIVE_RETENTION_DAYS`` is the single source of truth.
+    Hardcoding ``INTERVAL '90 days'`` would let the constant drift from
+    the SQL silently."""
+    src = _TASKS_FILE.read_text(encoding="utf-8")
+    assert "make_interval(days => :retention_days)" in src
+    assert "INTERVAL '90 days'" not in src
+
+
+def test_archive_task_does_not_explicit_archived_at_in_insert():
+    """``phase1_17`` ships ``archived_at`` with ``server_default=now()``
+    — the cron INSERT must NOT specify it explicitly, so the default
+    fires automatically. Specifying it would couple the cron to the
+    archive table's metadata column shape."""
+    src = _TASKS_FILE.read_text(encoding="utf-8")
+    insert_block = src[src.index("INSERT INTO _archived_notification_outbox") :]
+    insert_columns = insert_block[: insert_block.index(")")]
+    # The 10-column projection must exclude ``archived_at``.
+    assert '"archived_at"' not in insert_columns
+    assert " archived_at" not in insert_columns
+
+
+def test_archive_task_filters_only_dispatched_rows():
+    """``dispatched_at IS NOT NULL`` AND ``dispatched_at < NOW() -
+    make_interval(...)`` filter — pending rows (still IS NULL) MUST be
+    preserved. Dropping the IS NOT NULL guard would archive pending
+    rows."""
+    src = _TASKS_FILE.read_text(encoding="utf-8")
+    where_block = src[src.index("DELETE FROM notification_outbox") :]
+    where_block = where_block[: where_block.index("RETURNING")]
+    assert "dispatched_at IS NOT NULL" in where_block
+    assert "dispatched_at < NOW() - make_interval(days => :retention_days)" in where_block
+
+
+# ---------------------------------------------------------------------------
+# 6. Result dict shape
+# ---------------------------------------------------------------------------
+
+
+def test_archive_task_validate_keys_match_documented_shape():
+    """``run_async_task(validate_keys=...)`` enforces the result-dict
+    shape. Ops monitoring + alerting depend on the exact keys."""
+    src = _TASKS_FILE.read_text(encoding="utf-8")
+    # The validate_keys list is on a single line: lock its content.
+    assert (
+        'validate_keys=["status", "archived_count", "task_id"]' in src
+    ), "validate_keys must be exactly status + archived_count + task_id"


### PR DESCRIPTION
## Scope

Wave 5-B B-i marker migration + paired Celery code that registers the weekly outbox archive sweep. Alembic does NOT manage Celery beat schedule (per `app/celery_app.py:118-255` static-dict pattern — no DatabaseScheduler), so the marker migration carries the version-control point and the actual change ships in 2 paired code edits:

- `app/celery_app.py`: adds `"archive-outbox-dispatched"` beat entry → crontab Sunday 02:00 VN weekly.
- `app/tasks/notification_outbox_tasks.py`: adds `archive_outbox_dispatched_task` body using existing `task_db_session()` + `run_async_task()` helpers (mirrors `dispatch_pending_outbox` T0-4b pattern).

## Decisions

- **B-i pattern** (Codex round 19 chốt): static-dict beat schedule, no DatabaseScheduler. Marker migration body=pass; paired code carries actual change.
- **Sunday 02:00 VN weekly**: low-traffic slot, no conflict with daily KPI / cleanup ticks (00:05 / 01:00 / 02:00 day-1 / 02:30 / 03:00 / 03:15 / 04:00 / 05:00 / 07:00 / 09:00 Mon).
- **Single-CTE atomic MOVE** (PLAN line 170-176): `DELETE...RETURNING *` snapshot feeds INSERT in same statement — crash-safe, no data-loss window.
- **Retention parameterized**: `make_interval(days => :retention_days)` from `ARCHIVE_RETENTION_DAYS = 90` constant — single source of truth.
- **`archived_at` auto-populates**: cron INSERT does NOT specify the column; relies on `server_default=now()` from phase1_17 (PR #215).

## Cron MOVE semantic (PLAN line 170-176)

```sql
WITH archived AS (
    DELETE FROM notification_outbox
    WHERE dispatched_at IS NOT NULL
      AND dispatched_at < NOW() - make_interval(days => :retention_days)
    RETURNING id, event_code, payload, idempotency_key,
              created_at, dispatched_at, attempts, last_error,
              claimed_at, claimed_until
)
INSERT INTO _archived_notification_outbox (
    id, event_code, payload, idempotency_key, created_at,
    dispatched_at, attempts, last_error, claimed_at, claimed_until
)
SELECT * FROM archived
RETURNING id;
```

Atomic single-statement → cannot leave a row in both tables nor lose it.

## Memory gates

- ✅ `audit-before-fix`: pre-flight grep done (beat schedule pattern + task helpers + crontab import).
- ✅ `verify-schema-before-proposing`: re-grep `notification_outbox.py` 10-col mirror.
- ✅ `migration-predicate-safety`: marker body=pass.
- ✅ `async-session-gather` (PR #105 lesson): single `task_db_session()` — no `asyncio.gather`.
- ✅ `notification-event-gate-required-locally`: targeted regression run — 53/53 PASS new + non-DB outbox/notification suite. 10 errors in `test_outbox_worker.py` are pre-existing test DB drift (subject_kind ENUM type missing per memory `test-db-schema-source`) — not caused by this PR.

## Test plan — 14/14 unit tests pass

- [x] phase1_19d revision chain (← phase1_17)
- [x] Migration upgrade/downgrade body marker (no `op.*` DDL)
- [x] Module sanity (callable upgrade + downgrade)
- [x] Beat schedule entry registered (`archive-outbox-dispatched`)
- [x] Beat schedule task name (`archive_outbox_dispatched_task`)
- [x] Beat schedule queue (`default`)
- [x] Beat schedule crontab Sunday 02:00 (hour={2}, minute={0}, day_of_week={0})
- [x] Task callable zero-arg signature
- [x] Task name registered under `celery_app.tasks` after `import app.tasks`
- [x] `ARCHIVE_RETENTION_DAYS = 90` constant
- [x] SQL single-statement CTE (`WITH archived AS (DELETE...) INSERT...SELECT * FROM archived`)
- [x] Retention parameterized (`make_interval(days => :retention_days)`) — not hardcoded
- [x] Archive INSERT excludes `archived_at` column (relies on server_default)
- [x] DELETE filter `dispatched_at IS NOT NULL AND dispatched_at < NOW() - make_interval(...)` — pending rows preserved
- [x] `validate_keys=["status", "archived_count", "task_id"]` lock-in

## Live DB execution — DEFERRED to staging clone D12-D14

10 pre-existing `test_outbox_worker.py` errors confirm test DB drift independently of this PR (`subject_kind` ENUM created by phase1_05 not in `Base.metadata.create_all()` schema init per memory `test-db-schema-source`). Live SQL execution of the new archive task deferred to D12-D14 alongside Wave 5-D + 5-E roundtrip.

## Wave 5 progress (4/5 sub-PR shipped — 3 merged, 1 OPEN this PR)

- ✅ Wave 5-A `9af7510b` phase1_19c (PR #213)
- ✅ Wave 5-D `1989bd03` phase1_16 (PR #214)
- ✅ Wave 5-E `0b17f394` phase1_17 (PR #215)
- 🟡 **Wave 5-B THIS PR** phase1_19d marker + paired beat task
- ⏳ Wave 5-C M-1-19e phase1_19e notification rules (last)

## References

- PLAN line 168-178 (P1 fix #8 outbox 90-day archive)
- PLAN line 170-176 (cron CTE SQL sample)
- PLAN line 3464-3468 (cheat sheet phase1_19d)
- PLAN line 3500-3501 (Wave 5-B scope: dispatch + archive task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
