### PR TITLE
[#184 Wave3-A] feat(schema): phase1_11 extend profile status CHECK 10→14 state ⚠ ONE-WAY

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase1_11_extend_profile_status_check_constraint.py
+++ b/Backend_FastAPI/alembic/versions/phase1_11_extend_profile_status_check_constraint.py
@@ -1,0 +1,152 @@
+"""Wave 3-A / M-1-11 — extend ``admission_profile.status`` CHECK 10 → 14 state ⚠ ONE-WAY.
+
+Adds 4 milestone states to the existing CHECK constraint
+(``ck_admission_profile_status``):
+
+* ``reviewing``         — profile is under manager review (post-submit, pre-decision)
+* ``result_published``  — score published before per-candidate decision
+* ``admitted``          — choice-engine admit decision (replaces ``approved`` for
+                          choice-engine profiles per PLAN §3.3.b workflow remap)
+* ``waitlisted``        — choice-engine waitlist decision
+
+10 legacy states are preserved verbatim — additive only:
+``draft / submitted / approved / rejected / confirmed / enrolled /
+resubmitted / overridden / revision_requested / withdrawn``.
+
+ONE-WAY rationale + downgrade guard
+-----------------------------------
+
+After this migration ships, the application will start writing rows with the
+4 new state values via the choice-engine workflow. Reverting the CHECK to 10
+values would invalidate those rows — Postgres rejects ``ADD CHECK`` if any
+existing row violates the predicate, so the downgrade path defensively
+inspects current data:
+
+* If 0 rows hold a new-state value → safe rollback, recreate 10-state CHECK.
+* If ≥1 row holds a new-state value → ``RuntimeError`` with a clear message;
+  ops must restore from snapshot, not downgrade.
+
+Coupled deploy items (not in this migration; ship in Wave 3 atomic deploy)
+-------------------------------------------------------------------------
+
+* ``app/models/admission.py:48-50`` — ``CheckConstraint`` declaration string
+  must be updated to 14 states so test DB (``Base.metadata.create_all()``)
+  matches the prod schema. Updated in this PR (model + migration are the BE
+  half of "BE+FE Zod 14 state strict atomic deploy" per PLAN line 3471).
+* ``app/services/lead_admission_sync.py`` — already covers the 4 new states
+  per ``#15`` workflow remap (memory ``project_184_phase1_schema_wave_plan``
+  prerequisites).
+* FE Stage 3 strict Z.enum 14-state lock — separate sub-PR (3-B).
+
+Live prod baseline (dev DB post-import 2026-05-05)
+---------------------------------------------------
+
+Smoke verified 0 break risk: ``SELECT status, COUNT(*) FROM
+admission_profile GROUP BY status`` → ``draft=8, submitted=1`` (9 profiles
+total, none in any new-state). Upgrade is purely additive, downgrade is
+trivially safe today.
+
+Idempotent guards
+-----------------
+
+A CHECK constraint must be DROPPED + RECREATED in one statement pair
+(Postgres does not support ``ALTER CHECK``). Idempotency is achieved at the
+constraint level:
+
+* ``upgrade()`` — drop current constraint, recreate with 14 values. Safe to
+  re-run; the second run drops the (already-14) constraint and recreates
+  with the same 14.
+* ``downgrade()`` — defensive guard runs ``SELECT COUNT`` for new-state
+  rows. If safe, drop + recreate with 10 values.
+
+Revision ID: phase1_11
+Revises: phase1_19e
+Create Date: 2026-05-05
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_11"
+down_revision: Union[str, None] = "phase1_19e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+CONSTRAINT_NAME = "ck_admission_profile_status"
+TABLE = "admission_profile"
+
+# Existing 10-state baseline — verified live 2026-05-05 against prod-cloned
+# dev DB (constraint def + GROUP BY status both confirm).
+OLD_STATES: tuple[str, ...] = (
+    "draft",
+    "submitted",
+    "approved",
+    "rejected",
+    "confirmed",
+    "enrolled",
+    "resubmitted",
+    "overridden",
+    "revision_requested",
+    "withdrawn",
+)
+
+# 4 milestone states added in Wave 3 — choice-engine workflow per PLAN
+# §3.3.b workflow remap.
+NEW_STATES: tuple[str, ...] = (
+    "reviewing",
+    "result_published",
+    "admitted",
+    "waitlisted",
+)
+
+ALL_STATES: tuple[str, ...] = OLD_STATES + NEW_STATES  # 14
+
+
+def _check_predicate(states: tuple[str, ...]) -> str:
+    """Build the SQL CHECK predicate from a state tuple.
+
+    Quoted with ``repr`` so SQL injection via state name is impossible
+    (states come from this module's own constants, not user input — but
+    using ``repr`` is the principled shape regardless)."""
+    return "status IN (" + ", ".join(repr(s) for s in states) + ")"
+
+
+def upgrade() -> None:
+    """Replace 10-state CHECK with 14-state CHECK. Pure additive — every
+    row that satisfied the old CHECK still satisfies the new one."""
+    op.drop_constraint(CONSTRAINT_NAME, TABLE, type_="check")
+    op.create_check_constraint(
+        CONSTRAINT_NAME,
+        TABLE,
+        _check_predicate(ALL_STATES),
+    )
+
+
+def downgrade() -> None:
+    """⚠ ONE-WAY guard — reject downgrade if any row holds a new-state
+    value. Otherwise recreate 10-state CHECK."""
+    bind = op.get_bind()
+    new_state_count = bind.execute(
+        sa.text(
+            f"SELECT COUNT(*) FROM {TABLE} "
+            f"WHERE {_check_predicate(NEW_STATES)}"
+        )
+    ).scalar()
+    if new_state_count and new_state_count > 0:
+        raise RuntimeError(
+            f"Cannot downgrade phase1_11: {new_state_count} row(s) in "
+            f"{TABLE} hold a new-state value "
+            f"({', '.join(NEW_STATES)}). This is a ONE-WAY migration — "
+            f"restore from a pre-Wave-3 snapshot instead of running "
+            f"`alembic downgrade`."
+        )
+    op.drop_constraint(CONSTRAINT_NAME, TABLE, type_="check")
+    op.create_check_constraint(
+        CONSTRAINT_NAME,
+        TABLE,
+        _check_predicate(OLD_STATES),
+    )

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -44,8 +44,14 @@ class AdmissionProfile(Base):
     __table_args__ = (
         UniqueConstraint('citizen_id', 'academic_year', name='uq_citizen_academic_year'),
         Index('ix_admission_profile_citizen_year', 'citizen_id', 'academic_year'),
+        # Wave 3-A (M-1-11) extends 10-state CHECK to 14-state, adding the
+        # 4 choice-engine milestone states (reviewing / result_published /
+        # admitted / waitlisted). Migration owner:
+        # ``alembic/versions/phase1_11_extend_profile_status_check_constraint.py``.
+        # Test DB (``Base.metadata.create_all()``) reads this declaration —
+        # keeping it in sync with the migration prevents test-vs-prod drift.
         CheckConstraint(
-            "status IN ('draft','submitted','approved','rejected','confirmed','enrolled','resubmitted','overridden','revision_requested','withdrawn')",
+            "status IN ('draft','submitted','approved','rejected','confirmed','enrolled','resubmitted','overridden','revision_requested','withdrawn','reviewing','result_published','admitted','waitlisted')",
             name="ck_admission_profile_status"
         ),
         CheckConstraint(

--- a/Backend_FastAPI/tests/unit/test_phase1_11_status_check_extend.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_11_status_check_extend.py
@@ -1,0 +1,234 @@
+"""Unit tests for #184 Wave 3-A migration ``phase1_11_extend_profile_status_check_constraint``.
+
+Wave 3 ⚠ ONE-WAY first migration. Extends ``admission_profile.status`` CHECK
+constraint from 10 to 14 states. Tests cover:
+
+1. Revision row + chain (``phase1_11`` → ``phase1_19e``).
+2. Constraint name + table name canonical.
+3. ``OLD_STATES`` / ``NEW_STATES`` / ``ALL_STATES`` exact tuples.
+4. Upgrade body shape — drop + recreate with 14 values.
+5. Downgrade body shape — defensive guard against new-state rows + drop +
+   recreate with 10 values.
+6. Predicate helper produces SQL-safe quoting.
+7. Module sanity (``upgrade`` + ``downgrade`` callable).
+8. ORM model parity — ``AdmissionProfile.__table_args__`` ``CheckConstraint``
+   lists all 14 values (test DB reads this; drift = test-vs-prod skew).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_PHASE1_11 = (
+    _VERSIONS_DIR / "phase1_11_extend_profile_status_check_constraint.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location(_PHASE1_11.stem, _PHASE1_11)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_11():
+    return _load_migration()
+
+
+@pytest.fixture
+def src() -> str:
+    return _PHASE1_11.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision row + chain
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_11_revision_id(phase1_11) -> None:
+    assert phase1_11.revision == "phase1_11"
+
+
+def test_phase1_11_chains_off_phase1_19e(phase1_11) -> None:
+    """Wave 3 follows Wave 5 closure (``phase1_19e`` is the terminal Wave
+    5 marker). Wave 3-A unblocks the rest of Wave 3 sequence
+    (3-C/3-D/3-E)."""
+    assert phase1_11.down_revision == "phase1_19e"
+
+
+# ---------------------------------------------------------------------------
+# 2. Constraint + table name canonical
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_11_constraint_name_matches_model(phase1_11) -> None:
+    """Must match the name in ``AdmissionProfile.__table_args__`` so DROP
+    + ADD operates on the same constraint."""
+    assert phase1_11.CONSTRAINT_NAME == "ck_admission_profile_status"
+
+
+def test_phase1_11_table_name_admission_profile(phase1_11) -> None:
+    assert phase1_11.TABLE == "admission_profile"
+
+
+# ---------------------------------------------------------------------------
+# 3. State tuple lock-in
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_11_old_states_ten_values(phase1_11) -> None:
+    """Lock-in the 10-state baseline. A drift here would mean the migration
+    is operating on a different starting point than prod."""
+    assert phase1_11.OLD_STATES == (
+        "draft",
+        "submitted",
+        "approved",
+        "rejected",
+        "confirmed",
+        "enrolled",
+        "resubmitted",
+        "overridden",
+        "revision_requested",
+        "withdrawn",
+    )
+    assert len(phase1_11.OLD_STATES) == 10
+
+
+def test_phase1_11_new_states_four_values(phase1_11) -> None:
+    """Lock-in the 4 Wave-3 additions per PLAN §3.3.b workflow remap."""
+    assert phase1_11.NEW_STATES == (
+        "reviewing",
+        "result_published",
+        "admitted",
+        "waitlisted",
+    )
+    assert len(phase1_11.NEW_STATES) == 4
+
+
+def test_phase1_11_all_states_fourteen_values(phase1_11) -> None:
+    """``ALL_STATES`` = OLD + NEW; no overlap, no gap."""
+    assert phase1_11.ALL_STATES == phase1_11.OLD_STATES + phase1_11.NEW_STATES
+    assert len(phase1_11.ALL_STATES) == 14
+    # No accidental duplicates.
+    assert len(set(phase1_11.ALL_STATES)) == 14
+
+
+# ---------------------------------------------------------------------------
+# 4. Predicate helper
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_11_check_predicate_quotes_each_state(phase1_11) -> None:
+    """Predicate must quote each value individually — Postgres would reject
+    bare identifiers in IN(...). ``repr`` produces single-quoted Python
+    string literals which SQL accepts as character literals."""
+    pred = phase1_11._check_predicate(("alpha", "beta"))
+    assert pred == "status IN ('alpha', 'beta')"
+
+
+# ---------------------------------------------------------------------------
+# 5. Upgrade body — drop + recreate
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_11_upgrade_drops_then_creates(src) -> None:
+    """Postgres has no ``ALTER CHECK``; DROP + ADD is the canonical pair."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    drop_pos = upgrade_body.index("op.drop_constraint(")
+    create_pos = upgrade_body.index("op.create_check_constraint(")
+    assert drop_pos < create_pos
+
+
+def test_phase1_11_upgrade_uses_all_states_predicate(src) -> None:
+    """The recreated constraint must list all 14 states."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    assert "_check_predicate(ALL_STATES)" in upgrade_body
+
+
+# ---------------------------------------------------------------------------
+# 6. Downgrade defensive guard
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_11_downgrade_guards_with_count(src) -> None:
+    """Downgrade must run a COUNT against new-state rows BEFORE attempting
+    to recreate the 10-state CHECK — otherwise Postgres would raise a
+    constraint violation that is harder to recover from."""
+    downgrade_body = src[src.index("def downgrade()"):]
+    # Order: COUNT statement appears BEFORE drop_constraint.
+    select_pos = downgrade_body.index('SELECT COUNT(*)')
+    drop_pos = downgrade_body.index("op.drop_constraint(")
+    assert select_pos < drop_pos
+
+
+def test_phase1_11_downgrade_raises_on_new_state_rows(src) -> None:
+    """The guard must ``raise RuntimeError`` on a non-zero count — silent
+    skip would bury the data-loss risk."""
+    downgrade_body = src[src.index("def downgrade()"):]
+    assert "raise RuntimeError" in downgrade_body
+    assert "ONE-WAY" in downgrade_body
+
+
+def test_phase1_11_downgrade_uses_old_states_predicate_when_safe(src) -> None:
+    """When safe, downgrade recreates the original 10-state CHECK."""
+    downgrade_body = src[src.index("def downgrade()"):]
+    assert "_check_predicate(OLD_STATES)" in downgrade_body
+
+
+# ---------------------------------------------------------------------------
+# 7. Module sanity
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_11_callable_upgrade_and_downgrade(phase1_11) -> None:
+    assert callable(getattr(phase1_11, "upgrade", None))
+    assert callable(getattr(phase1_11, "downgrade", None))
+
+
+# ---------------------------------------------------------------------------
+# 8. ORM model parity — test DB reads this declaration
+# ---------------------------------------------------------------------------
+
+
+def test_admission_profile_check_constraint_lists_all_fourteen_states() -> None:
+    """``AdmissionProfile.__table_args__`` carries the 14-state CHECK so
+    test DB (``Base.metadata.create_all()``) can INSERT rows with the new
+    states. A drift here = test-vs-prod skew per memory
+    ``test-db-schema-source``."""
+    from sqlalchemy import CheckConstraint
+
+    from app.models.admission import AdmissionProfile
+
+    status_check = next(
+        c
+        for c in AdmissionProfile.__table_args__
+        if isinstance(c, CheckConstraint)
+        and c.name == "ck_admission_profile_status"
+    )
+    sql = str(status_check.sqltext)
+    for state in (
+        "draft",
+        "submitted",
+        "approved",
+        "rejected",
+        "confirmed",
+        "enrolled",
+        "resubmitted",
+        "overridden",
+        "revision_requested",
+        "withdrawn",
+        "reviewing",
+        "result_published",
+        "admitted",
+        "waitlisted",
+    ):
+        assert f"'{state}'" in sql, (
+            f"AdmissionProfile.__table_args__ status CheckConstraint missing "
+            f"value {state!r}"
+        )


### PR DESCRIPTION
## Scope — Wave 3 first ⚠ ONE-WAY migration

Extends `admission_profile.status` CHECK constraint from 10 to 14 states by adding 4 choice-engine milestone states per PLAN §3.3.b workflow remap:

- `reviewing`         — under manager review (post-submit, pre-decision)
- `result_published`  — score published before per-candidate decision
- `admitted`          — choice-engine admit decision
- `waitlisted`        — choice-engine waitlist decision

10 legacy states preserved verbatim — additive only.

## Decisions

- **Down_revision**: `phase1_19e` (post-Wave-5 head, terminal Phase 1 #19 chain)
- **Defensive downgrade**: `RuntimeError` if any row holds new-state value, with clear message + ONE-WAY hint pointing ops at snapshot restore
- **Cross-source consistency**: migration `ALL_STATES` tuple = model `__table_args__` `CheckConstraint` exact match (test 15 anchor non-tautological — catches silent drift)
- **Coupled deliverables**: model `__table_args__` updated same commit so test DB (`Base.metadata.create_all()`) stays in sync with prod schema

## Wave 3 prerequisites verified ✅

- B1 Casbin auth_model rewrite — PR #201 squash `6eac329e`
- #15 `is_admitted_like()` helper — used in 9+ files (fees, admission_service, phase_manager) — PR #202 squash `e3b09eaa`
- #16 workflow contract boundary — `check_status_assignment.py` AST lint live in CI — PR #203 squash `a7b6c5c9`
- LS-map 4 new state coverage — `lead_admission_sync.py:51,59,61,88-91,166-176`
- FE Stage 1 permissive Zod — PR #211 squash `d9631ad5`
- FE-badge + FE-tabs config 14 state — PR #212 squash `2c411306`

## Test plan — 15/15 unit tests + live alembic roundtrip pass

- [x] Revision row + chain (phase1_11 ← phase1_19e)
- [x] Constraint name + table name canonical
- [x] OLD_STATES (10) / NEW_STATES (4) / ALL_STATES (14) tuple lock-in
- [x] `_check_predicate()` SQL-safe quoting via `repr`
- [x] Upgrade body: drop_constraint BEFORE create_check_constraint with `_check_predicate(ALL_STATES)`
- [x] Downgrade body: SELECT COUNT BEFORE drop_constraint
- [x] Downgrade raises `RuntimeError` on new-state rows (with ONE-WAY hint)
- [x] Downgrade recreates `_check_predicate(OLD_STATES)` when safe
- [x] Module sanity (callable upgrade + downgrade)
- [x] Cross-source: `AdmissionProfile.__table_args__` `CheckConstraint` lists all 14 state literals

## Live alembic roundtrip ✅ (executed on dev DB with prod data)

Per memory `solo-cutover-simple-data-import` pivot 2026-05-05 — prod data imported into dev DB via `scripts/import-prod-to-dev.sh`:

- ✅ Upgrade `phase1_19e → phase1_11` clean; CHECK extended to 14 values verified via `pg_get_constraintdef`
- ✅ `INSERT INTO admission_profile (..., status='reviewing')` SUCCEEDS post upgrade (id=24 returned)
- ✅ `alembic downgrade -1` clean back to `phase1_19e` (10-state CHECK restored) when 0 new-state rows
- ✅ Re-upgrade idempotent
- ✅ **Defensive guard verified live**: with 1 row `INSERT ... status='admitted'` (id=25), downgrade raises:
  ```
  RuntimeError: Cannot downgrade phase1_11: 1 row(s) in admission_profile
  hold a new-state value (reviewing, result_published, admitted, waitlisted).
  This is a ONE-WAY migration — restore from a pre-Wave-3 snapshot instead
  of running `alembic downgrade`.
  ```

**Notable improvement vs Wave 5-D/E/B/C**: those used drift workaround "live roundtrip deferred D12-D14" because dev DB was stamp-only. Wave 3-A executes ACTUAL live alembic roundtrip với prod data on dev DB (post solo-cutover pivot).

## ONE-WAY downgrade rationale

Postgres `ADD CHECK` rejects creation if any existing row violates the predicate. Naively dropping + recreating the 10-state CHECK after the application has already written `admitted` rows would fail at the `ADD` step, leaving the table without a status CHECK at all (open window for arbitrary status values until manually re-added). The defensive guard runs `SELECT COUNT(*)` for new-state rows BEFORE the DROP — fails fast with a clear message pointing ops at snapshot restore.

## References

- PLAN §3.3.b workflow remap (4 new milestone states)
- PLAN line 3471 Wave 3-A scope ("BE+FE Zod 14 state strict atomic deploy")
- Memory `solo-cutover-simple-data-import` (2026-05-05 pivot)
- Memory `184-phase1-schema-wave-plan` line 41 (Wave 3 ONE-WAY scope)

## Path filter no-checks fallback expected

Files touched: alembic + model + test — không match workflow `admission-contract-check.yml` paths (services/admission* / notification* / events* / etc.). 0 check chạy → manual diff review trong PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
