### PR TITLE
[#184 Wave3-C] feat(schema): phase1_12 backfill_selected_subject_group_id (decision tree 3 rule + exception sinks) ⚠ ONE-WAY

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase1_12_backfill_selected_subject_group_id.py
+++ b/Backend_FastAPI/alembic/versions/phase1_12_backfill_selected_subject_group_id.py
@@ -1,0 +1,272 @@
+"""Wave 3-C / M-1-12 — backfill ``admission_profile.selected_subject_group_id`` ⚠ ONE-WAY.
+
+Backfills the column that Phase 0 (``admstrict01``) added but left NULL on
+all historical profiles. Phase 3 multi-NV needs a non-NULL value to know
+which subject group a candidate competed under so that
+``AdmissionProfileChoice`` can be created with the correct group reference.
+
+This migration ONLY backfills — it does NOT add the column. Phase 0 owns
+the DDL; running this migration before Phase 0 fails fast with a clear
+error pointing back at Phase 0.
+
+Decision tree (3 rules per PLAN line 394 + line 3122-3242 SQL spec)
+------------------------------------------------------------------
+
+* **Rule (a)** — auto-map: path has exactly 1 ``criteria_subject_group``
+  row → there is no ambiguity, every profile attached to that path
+  picks the sole group.
+
+* **Rule (b)** — infer from scores SCOPED to path: a profile may have
+  ``ProfileSubjectScore`` rows that complete exactly ONE of the path's
+  allowed groups. Match that group iff:
+  * profile has scores for EVERY subject in the candidate group, AND
+  * exactly ONE such complete group exists in the path's allowed set.
+
+  Both criteria are required. The "≥1 score in group" weak match would
+  flag every candidate with a single score that happens to share a
+  subject with multiple groups; "complete coverage" forces unambiguous
+  selection.
+
+* **Rule (c)** — exception report (no auto-create choice): two distinct
+  exception types so admin queue UX can route them to different fixes:
+  * ``AMBIGUOUS_SELECTED_GROUP`` — profile has data (path + scores) but
+    ≥2 complete groups match. Admin picks one via UI.
+  * ``INSUFFICIENT_DATA_FOR_BACKFILL`` — profile is active (status ∉
+    {draft, withdrawn}) but missing path id, or path id non-numeric, or
+    no scores at all. Admin fixes the upstream data first.
+
+  Both exception types skip ``draft`` / ``withdrawn`` profiles — those
+  are not on the choice-engine critical path; flooding the admin queue
+  with abandoned drafts dilutes the signal.
+
+ONE-WAY rationale + downgrade contract
+--------------------------------------
+
+Once Phase 3 multi-NV starts creating ``AdmissionProfileChoice`` rows
+keyed off ``selected_subject_group_id``, reverting the backfill (setting
+column back to NULL) breaks the FK reference inside choice rows. Even
+without Phase 3 yet, downgrading would force every backfilled profile to
+re-enter the "needs admin review" state — pure regression. Downgrade is
+intentionally a no-op with a clear message; restore from snapshot is the
+correct ops path.
+
+Idempotent
+----------
+
+* Each rule's UPDATE is guarded by ``WHERE selected_subject_group_id IS
+  NULL`` — re-running skips already-populated profiles.
+* Exception INSERTs use ``ON CONFLICT (profile_id, exception_type) DO
+  NOTHING`` — duplicates blocked by the unique constraint from
+  ``phase1_07b``.
+
+Live cold cutover rehearsal (dev DB w/ prod data 2026-05-05)
+------------------------------------------------------------
+
+Pre-flight verified: 9/9 admission_profile rows have NULL
+``selected_subject_group_id``; all 9 have ``admission_path_id`` in
+``applied_rules`` JSONB; 8/9 have ProfileSubjectScore rows; status
+distribution 8 draft + 1 submitted. Rule (c) scope (status NOT IN
+draft/withdrawn) means only 1 profile is candidate for exception
+reporting.
+
+Revision ID: phase1_12
+Revises: phase1_11
+Create Date: 2026-05-05
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_12"
+down_revision: Union[str, None] = "phase1_11"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Backfill ``selected_subject_group_id`` via 3-rule decision tree.
+
+    Pre-flight check: column must exist (Phase 0 ``admstrict01`` is the
+    DDL owner). Fail fast with hint if missing — running this migration
+    before Phase 0 is a chain misuse.
+    """
+    bind = op.get_bind()
+
+    # Pre-flight: column owned by Phase 0. If missing, the chain has been
+    # applied out of order — surface the hint instead of letting the
+    # backfill UPDATEs raise a cryptic "column does not exist".
+    column_exists = bind.execute(
+        sa.text(
+            """
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name = 'admission_profile'
+              AND column_name = 'selected_subject_group_id'
+            """
+        )
+    ).scalar()
+    if not column_exists:
+        raise RuntimeError(
+            "phase1_12 pre-flight: column "
+            "`admission_profile.selected_subject_group_id` not found. "
+            "Phase 0 migration `admstrict01` is the DDL owner — apply "
+            "the chain from base if the column is missing."
+        )
+
+    # Rule (a) — auto-map for paths with exactly 1 criteria_subject_group.
+    # CTE splits the eligible-profile filter (numeric guard + cast) from
+    # the path/group lookup so Postgres cannot reorder the cast before
+    # the regex predicate.
+    op.execute(
+        sa.text(
+            """
+            WITH eligible_profiles_a AS (
+                SELECT p.id AS profile_id,
+                       (p.applied_rules->>'admission_path_id')::int AS admission_path_id_int
+                FROM admission_profile p
+                WHERE p.selected_subject_group_id IS NULL
+                  AND p.applied_rules ? 'admission_path_id'
+                  AND (p.applied_rules->>'admission_path_id') ~ '^[0-9]+$'
+            ),
+            single_group_paths AS (
+                SELECT ap.id AS path_id, MAX(csg.subject_group_id) AS group_id
+                FROM admission_path ap
+                JOIN criteria_subject_group csg ON csg.criteria_id = ap.criteria_id
+                GROUP BY ap.id
+                HAVING COUNT(*) = 1
+            )
+            UPDATE admission_profile p
+            SET selected_subject_group_id = sgp.group_id
+            FROM eligible_profiles_a ep
+            JOIN single_group_paths sgp ON sgp.path_id = ep.admission_path_id_int
+            WHERE p.id = ep.profile_id
+              AND p.selected_subject_group_id IS NULL;
+            """
+        )
+    )
+
+    # Rule (b) — infer SCOPED to the path's allowed group set, gated by
+    # complete-coverage check (every subject in the candidate group has a
+    # ProfileSubjectScore row), and accept only when exactly ONE complete
+    # group remains.
+    op.execute(
+        sa.text(
+            """
+            WITH eligible_profiles AS (
+                SELECT p.id AS profile_id,
+                       (p.applied_rules->>'admission_path_id')::int AS admission_path_id_int
+                FROM admission_profile p
+                WHERE p.selected_subject_group_id IS NULL
+                  AND p.applied_rules ? 'admission_path_id'
+                  AND (p.applied_rules->>'admission_path_id') ~ '^[0-9]+$'
+            ),
+            path_allowed_groups AS (
+                SELECT ep.profile_id, csg.subject_group_id
+                FROM eligible_profiles ep
+                JOIN admission_path ap ON ap.id = ep.admission_path_id_int
+                JOIN criteria_subject_group csg ON csg.criteria_id = ap.criteria_id
+            ),
+            group_completeness AS (
+                SELECT pag.profile_id,
+                       pag.subject_group_id,
+                       (SELECT COUNT(*) FROM subject_group_subject sgs
+                        WHERE sgs.subject_group_id = pag.subject_group_id) AS required_count,
+                       (SELECT COUNT(*) FROM subject_group_subject sgs
+                        JOIN profile_subject_score pss
+                          ON pss.subject_id = sgs.subject_id
+                          AND pss.profile_id = pag.profile_id
+                        WHERE sgs.subject_group_id = pag.subject_group_id) AS matched_count
+                FROM path_allowed_groups pag
+            ),
+            complete_groups_per_profile AS (
+                SELECT profile_id, subject_group_id
+                FROM group_completeness
+                WHERE matched_count = required_count
+                  AND required_count > 0
+            ),
+            unique_complete_groups AS (
+                SELECT profile_id,
+                       MAX(subject_group_id) AS sole_group_id,
+                       COUNT(*) AS complete_group_count
+                FROM complete_groups_per_profile
+                GROUP BY profile_id
+                HAVING COUNT(*) = 1
+            )
+            UPDATE admission_profile p
+            SET selected_subject_group_id = ucg.sole_group_id
+            FROM unique_complete_groups ucg
+            WHERE ucg.profile_id = p.id
+              AND p.selected_subject_group_id IS NULL;
+            """
+        )
+    )
+
+    # Rule (c) — Exception 1: AMBIGUOUS — profile has full data but
+    # multiple complete groups satisfy. Admin picks one via UI.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO _admission_backfill_exceptions (profile_id, exception_type, details)
+            SELECT p.id, 'AMBIGUOUS_SELECTED_GROUP',
+                   jsonb_build_object(
+                       'applied_rules_groups', p.applied_rules->'subject_groups',
+                       'score_count', (SELECT count(*) FROM profile_subject_score WHERE profile_id = p.id)
+                   )
+            FROM admission_profile p
+            WHERE p.selected_subject_group_id IS NULL
+              AND p.status NOT IN ('draft', 'withdrawn')
+              AND p.applied_rules ? 'admission_path_id'
+              AND (p.applied_rules->>'admission_path_id') ~ '^[0-9]+$'
+              AND EXISTS (SELECT 1 FROM profile_subject_score WHERE profile_id = p.id)
+            ON CONFLICT (profile_id, exception_type) DO NOTHING;
+            """
+        )
+    )
+
+    # Rule (c) — Exception 2: INSUFFICIENT_DATA — profile is active but
+    # missing path id, non-numeric path id, or no scores. Different fix
+    # workflow than ambiguous, so different exception_type.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO _admission_backfill_exceptions (profile_id, exception_type, details)
+            SELECT p.id, 'INSUFFICIENT_DATA_FOR_BACKFILL',
+                   jsonb_build_object(
+                       'has_path_id', p.applied_rules ? 'admission_path_id',
+                       'has_scores', EXISTS (SELECT 1 FROM profile_subject_score WHERE profile_id = p.id),
+                       'status', p.status
+                   )
+            FROM admission_profile p
+            WHERE p.selected_subject_group_id IS NULL
+              AND p.status NOT IN ('draft', 'withdrawn')
+              AND (
+                  NOT (p.applied_rules ? 'admission_path_id')
+                  OR (p.applied_rules->>'admission_path_id') !~ '^[0-9]+$'
+                  OR NOT EXISTS (SELECT 1 FROM profile_subject_score WHERE profile_id = p.id)
+              )
+            ON CONFLICT (profile_id, exception_type) DO NOTHING;
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    """⚠ ONE-WAY — backfill is forward-only.
+
+    Phase 3 multi-NV (post-cutover) creates ``AdmissionProfileChoice``
+    rows keyed off ``selected_subject_group_id``. Setting the column
+    back to NULL would dangle Phase 3 FK references. Even pre-Phase-3,
+    the backfill represents an admin-decision-equivalent for each
+    profile — clearing it forces the queue to re-process every row.
+
+    Restore from a pre-Wave-3 snapshot if a real rollback is needed.
+    """
+    raise RuntimeError(
+        "Cannot downgrade phase1_12: backfill is ONE-WAY. Reverting "
+        "selected_subject_group_id to NULL would dangle Phase 3 "
+        "AdmissionProfileChoice FKs and force re-review of every "
+        "backfilled profile. Restore from a pre-Wave-3 snapshot if a "
+        "real rollback is required."
+    )

--- a/Backend_FastAPI/tests/unit/test_phase1_12_backfill_selected_subject_group.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_12_backfill_selected_subject_group.py
@@ -1,0 +1,215 @@
+"""Unit tests for #184 Wave 3-C migration ``phase1_12_backfill_selected_subject_group_id``.
+
+Wave 3 ⚠ ONE-WAY backfill. Tests cover:
+
+1. Revision row + chain (``phase1_12`` → ``phase1_11``).
+2. Pre-flight column-existence check raises clean error if Phase 0 not
+   applied.
+3. Rule (a) auto-map for single-group paths — SQL surface assertion.
+4. Rule (b) infer scoped + group-completeness — SQL surface assertion.
+5. Rule (c) exception INSERTs — both AMBIGUOUS and INSUFFICIENT_DATA
+   types emitted with correct scope (status NOT IN draft/withdrawn).
+6. ON CONFLICT (profile_id, exception_type) DO NOTHING — idempotent
+   exception inserts.
+7. Idempotent UPDATE guard (``WHERE selected_subject_group_id IS NULL``).
+8. Downgrade is ONE-WAY — raises RuntimeError with snapshot-restore
+   hint.
+9. Module sanity (callable upgrade + downgrade).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_PHASE1_12 = _VERSIONS_DIR / "phase1_12_backfill_selected_subject_group_id.py"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location(_PHASE1_12.stem, _PHASE1_12)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_12():
+    return _load_migration()
+
+
+@pytest.fixture
+def src() -> str:
+    return _PHASE1_12.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision row + chain
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_12_revision_id(phase1_12) -> None:
+    assert phase1_12.revision == "phase1_12"
+
+
+def test_phase1_12_chains_off_phase1_11(phase1_12) -> None:
+    """Wave 3 sequence: 3-A (phase1_11 status CHECK) → 3-B (FE Stage 3,
+    no migration) → 3-C (this — backfill). 3-C linear chain off 3-A."""
+    assert phase1_12.down_revision == "phase1_11"
+
+
+# ---------------------------------------------------------------------------
+# 2. Pre-flight column-existence check
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_12_preflight_checks_column_exists(src) -> None:
+    """Column ``selected_subject_group_id`` is owned by Phase 0
+    ``admstrict01``. If chain is applied out of order (this migration
+    runs before Phase 0), the backfill UPDATEs would fail with a
+    cryptic "column does not exist". The pre-flight surfaces a clear
+    hint instead."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    assert "information_schema.columns" in upgrade_body
+    assert "selected_subject_group_id" in upgrade_body
+    assert "RuntimeError" in upgrade_body
+    assert "Phase 0" in upgrade_body or "admstrict01" in upgrade_body
+
+
+# ---------------------------------------------------------------------------
+# 3. Rule (a) — auto-map single-group paths
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_12_rule_a_single_group_path_auto_map(src) -> None:
+    """Rule (a) HAVING COUNT(*) = 1 narrows to paths with exactly one
+    criteria_subject_group; the UPDATE then applies the sole group to
+    every profile attached to that path."""
+    assert "single_group_paths" in src
+    assert "HAVING COUNT(*) = 1" in src
+    assert "MAX(csg.subject_group_id) AS group_id" in src
+
+
+def test_phase1_12_rule_a_uses_cte_split_to_guard_cast(src) -> None:
+    """Eligible-profile filter (numeric guard via regex) is split into a
+    CTE so Postgres cannot reorder the int cast before the regex
+    predicate. Same defensive pattern as phase1_09a."""
+    assert "eligible_profiles_a" in src
+    assert "(p.applied_rules->>'admission_path_id') ~ '^[0-9]+$'" in src
+
+
+# ---------------------------------------------------------------------------
+# 4. Rule (b) — infer scoped + group-completeness
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_12_rule_b_scopes_to_path_allowed_groups(src) -> None:
+    """Group inference must be scoped to the path's allowed groups, not
+    global. Otherwise a profile with Toán-Lý-Hóa scores would match
+    A00 even if the path doesn't accept A00."""
+    assert "path_allowed_groups" in src
+    assert "criteria_subject_group" in src
+
+
+def test_phase1_12_rule_b_requires_group_completeness(src) -> None:
+    """Match group X iff profile has scores for EVERY subject in X.
+    Weak match ("≥1 score in group") would flag any profile with a
+    single shared subject."""
+    assert "group_completeness" in src
+    assert "matched_count = required_count" in src
+    assert "required_count > 0" in src
+
+
+def test_phase1_12_rule_b_accepts_only_unique_complete_groups(src) -> None:
+    """Even with completeness, if 2+ groups satisfy, do NOT auto-pick.
+    HAVING COUNT(*) = 1 enforces unambiguous selection; ambiguous
+    profiles fall through to Rule (c) AMBIGUOUS exception."""
+    assert "unique_complete_groups" in src
+    assert "complete_groups_per_profile" in src
+
+
+# ---------------------------------------------------------------------------
+# 5. Rule (c) — exception sinks
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_12_rule_c_emits_ambiguous_exception(src) -> None:
+    """Profile has data (path + scores) but multiple complete groups
+    satisfy. Admin picks one via UI."""
+    assert "'AMBIGUOUS_SELECTED_GROUP'" in src
+    assert "applied_rules_groups" in src
+    assert "score_count" in src
+
+
+def test_phase1_12_rule_c_emits_insufficient_data_exception(src) -> None:
+    """Profile is active but missing path id / non-numeric / no scores.
+    Different fix workflow than AMBIGUOUS."""
+    assert "'INSUFFICIENT_DATA_FOR_BACKFILL'" in src
+    assert "has_path_id" in src
+    assert "has_scores" in src
+
+
+def test_phase1_12_rule_c_skips_draft_and_withdrawn(src) -> None:
+    """Both exception types scope to ``status NOT IN ('draft',
+    'withdrawn')`` — abandoned drafts and withdrawn profiles do not
+    flood the admin queue."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    # Two occurrences (one per exception type's scope filter).
+    assert upgrade_body.count("status NOT IN ('draft', 'withdrawn')") == 2
+
+
+def test_phase1_12_exception_inserts_idempotent(src) -> None:
+    """``ON CONFLICT (profile_id, exception_type) DO NOTHING`` mirrors
+    the unique constraint from phase1_07b — re-running the migration
+    skips already-recorded exceptions."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    assert (
+        upgrade_body.count(
+            "ON CONFLICT (profile_id, exception_type) DO NOTHING"
+        )
+        == 2
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Idempotent UPDATE guards
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_12_updates_guard_null_column(src) -> None:
+    """Each backfill UPDATE filters
+    ``WHERE selected_subject_group_id IS NULL`` — re-running the
+    migration skips already-populated profiles."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    # Multiple occurrences across the rules + filter clauses.
+    assert (
+        upgrade_body.count("selected_subject_group_id IS NULL") >= 4
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Downgrade ONE-WAY
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_12_downgrade_raises_one_way(src) -> None:
+    """Downgrade is intentionally a no-op with a clear message —
+    reverting backfill would dangle Phase 3 AdmissionProfileChoice
+    FKs and force re-review of every profile."""
+    downgrade_body = src[src.index("def downgrade()"):]
+    assert "raise RuntimeError" in downgrade_body
+    assert "ONE-WAY" in downgrade_body
+    assert "snapshot" in downgrade_body
+
+
+# ---------------------------------------------------------------------------
+# 8. Module sanity
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_12_callable_upgrade_and_downgrade(phase1_12) -> None:
+    assert callable(getattr(phase1_12, "upgrade", None))
+    assert callable(getattr(phase1_12, "downgrade", None))


### PR DESCRIPTION
## Scope — Wave 3 third ⚠ ONE-WAY migration

Backfills `admission_profile.selected_subject_group_id` (column owned by Phase 0 `admstrict01`, currently NULL on all historical profiles) via 3-rule decision tree per PLAN line 394 + 3122-3242 SQL spec.

Phase 3 multi-NV needs non-NULL `selected_subject_group_id` to know which subject group a candidate competed under so `AdmissionProfileChoice` rows can be created with the correct group reference.

## Decision tree

- **Rule (a) auto-map**: path có exactly 1 `criteria_subject_group` → no ambiguity, auto-assign sole group.
- **Rule (b) scoped infer**: scope to path's allowed groups + complete-coverage check (every subject in candidate group has ProfileSubjectScore) + uniqueness (`HAVING COUNT(*) = 1`).
- **Rule (c) exception report** (no auto-create choice):
  - `AMBIGUOUS_SELECTED_GROUP` — has data but ≥2 complete groups match. Admin picks via UI.
  - `INSUFFICIENT_DATA_FOR_BACKFILL` — active profile but missing path id / non-numeric / no scores.
  - Scope guard: `status NOT IN ('draft', 'withdrawn')` — drafts không flood admin queue.

## Pre-flight + idempotent

- Pre-flight `information_schema.columns` check raises `RuntimeError` với hint pointing at Phase 0 `admstrict01` if column missing (chain misuse detection).
- Each backfill UPDATE guarded by `WHERE selected_subject_group_id IS NULL` — re-running skips populated profiles.
- Exception INSERTs use `ON CONFLICT (profile_id, exception_type) DO NOTHING` — duplicates blocked by unique constraint from `phase1_07b`.
- CTE split for cast guard: numeric regex predicate runs in CTE before int cast (Postgres không đảm bảo WHERE chạy trước CAST).

## ONE-WAY downgrade

Downgrade raises `RuntimeError` với clear message — reverting backfill to NULL would dangle Phase 3 `AdmissionProfileChoice` FKs and force re-review. Restore from a pre-Wave-3 snapshot if rollback needed.

## Test plan — 15/15 unit + live alembic verified

### Unit (15/15 PASS)
- [x] Revision chain (phase1_12 ← phase1_11)
- [x] Pre-flight column-existence check + Phase 0 hint
- [x] Rule (a) single-group path filter + MAX projection
- [x] Rule (a) CTE cast guard (regex before cast)
- [x] Rule (b) scopes to path's `criteria_subject_group`
- [x] Rule (b) requires complete coverage (`matched_count = required_count` + `> 0`)
- [x] Rule (b) accepts only unique complete groups (`HAVING COUNT(*) = 1`)
- [x] Rule (c) emits `AMBIGUOUS_SELECTED_GROUP`
- [x] Rule (c) emits `INSUFFICIENT_DATA_FOR_BACKFILL`
- [x] Rule (c) skips `draft`/`withdrawn` (2 occurrences scope filter)
- [x] Exception INSERTs idempotent (2 occurrences `ON CONFLICT`)
- [x] UPDATE guards NULL column only
- [x] Downgrade ONE-WAY raises
- [x] Module sanity

### Live alembic on dev DB w/ prod data ✅

Per memory `solo-cutover-simple-data-import` — Wave 3 strict standard maintained:

**Backfill outcome (9 prod profiles)**:
| Profile | Status | Group ID | Has scores |
|---|---|---|---|
| 14 | draft | 878 | ✓ |
| 15 | draft | 929 | ✓ |
| 16 | draft | 923 | ✓ |
| 17 | draft | 923 | ✓ |
| 18 | draft | 859 | ✓ |
| 19 | draft | 859 | ✓ |
| **20** | **draft** | **NULL** | ✗ — Rule (c) scope correctly skipped |
| 22 | submitted | 878 | ✓ |
| 23 | draft | 859 | ✓ |

**8/9 profiles backfilled** unambiguously via Rule (a) or (b). 1 profile (id=20, draft, no scores) correctly remained NULL — Rule (c) scope excludes drafts. **0 exceptions** generated (data clean).

- Re-upgrade idempotent (no double-backfill, alembic_version stays `phase1_12`).
- Defensive ONE-WAY downgrade verified live: `alembic downgrade -1` raises `RuntimeError: Cannot downgrade phase1_12: backfill is ONE-WAY. Reverting selected_subject_group_id to NULL would dangle Phase 3 AdmissionProfileChoice FKs and force re-review of every backfilled profile. Restore from a pre-Wave-3 snapshot if a real rollback is required.`

## Wave 3 progress (3/5 sub-PR shipped — 2 merged, 1 OPEN this PR)

- ✅ Wave 3-A `55f3eb41` phase1_11 status CHECK 10→14 ⚠ ONE-WAY (PR #219)
- ✅ Wave 3-B `efc1b4f7` FE Stage 3 strict 14-state z.enum (PR #220)
- 🟡 **Wave 3-C THIS PR** phase1_12 backfill_selected_subject_group_id ⚠ ONE-WAY
- ⏳ Wave 3-D phase1_18 confirmation_token multi-action ⚠ ONE-WAY
- ⏳ Wave 3-E phase1_15a DROP UNIQUE → composite ⚠ ONE-WAY

## Wave 3-B + 3-C tracking note

Wave 3-B SOP step 3+4 (TRACKER FE-zod-status row update + DAILY_LOG entry) deferred — sẽ batched với Wave 3-C 4-step SOP trong 1 doc commit post-merge (efficiency optimization per solo-dev workflow).

## References

- PLAN line 394 (decision tree 3 rule rationale)
- PLAN line 3122-3242 (SQL spec)
- PLAN line 3245 (Phase 3 backfill rule — only profiles với selected_subject_group_id IS NOT NULL)
- Memory `solo-cutover-simple-data-import` (live alembic on dev DB)
- Memory `migration-predicate-safety` (idempotent + ONE-WAY guard)

## Path filter no-checks fallback expected

Files: alembic + test only. None match workflow paths → no-checks fallback đúng SOP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
