### PR TITLE
[#184 Wave3-D] feat(schema): phase1_18 extend confirmation_token multi-action (action_type + partial UNIQUE + 4-action CHECK) ⚠ ONE-WAY

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase1_18_extend_confirmation_token_for_multi_action.py
+++ b/Backend_FastAPI/alembic/versions/phase1_18_extend_confirmation_token_for_multi_action.py
@@ -1,0 +1,219 @@
+"""Wave 3-D / M-1-18 — extend ``admission_confirmation_token`` for multi-action ⚠ ONE-WAY.
+
+Promotes the magic-link token from single-purpose (only ``confirm``) to
+multi-action (``submit`` / ``resubmit`` / ``confirm`` / ``withdraw``) per
+PLAN §3.3.g + §4 P1 #18 + line 1880-1901. Each profile can now have ONE
+active token per action concurrently — e.g. a profile can hold an active
+``submit`` token AND an active ``confirm`` token simultaneously.
+
+5-step DDL
+----------
+
+1. ``ADD COLUMN action_type VARCHAR(20) NOT NULL DEFAULT 'confirm'``.
+   Backfills every existing row to ``'confirm'`` at ALTER time (PG fast
+   path), preserving the legacy single-action behavior.
+2. ``ADD CONSTRAINT ck_token_action_type`` CHECK action_type IN
+   ('submit', 'resubmit', 'confirm', 'withdraw'). Locks the enum at the
+   DB layer.
+3. Drop the existing single-token-per-profile UNIQUE INDEX
+   (``ix_admission_confirmation_token_profile_id``) — that index was
+   created from ``unique=True + index=True`` on the column; SQLAlchemy
+   names it with the ``ix_*`` prefix, NOT the ``_profile_id_key``
+   convention used in some PLAN draft examples (verified live via
+   ``\\d admission_confirmation_token`` on dev DB).
+4. ``CREATE UNIQUE INDEX uq_active_token_per_profile_action`` ON
+   ``(profile_id, action_type) WHERE confirmed_at IS NULL``. Partial
+   uniqueness keeps audit trail rows (already-confirmed tokens) free
+   from contention with newly-issued live tokens for the same
+   ``(profile, action)`` pair.
+5. ``CREATE INDEX ix_token_action_type`` ON ``(token, action_type)`` —
+   covers the ``get_profile_by_magic_link_token()`` lookup which
+   filters by both columns.
+
+ONE-WAY downgrade
+-----------------
+
+After this migration ships, the application will start writing rows
+with ``action_type ∈ {'submit','resubmit','withdraw'}``. Reverting the
+schema to the legacy single-action contract:
+* would break any caller that issued non-``confirm`` tokens, and
+* the pre-existing UNIQUE on ``profile_id`` cannot be re-added because
+  it would reject any profile that holds 2+ tokens with different
+  action types.
+
+Defensive guard: ``SELECT COUNT(*)`` for non-``confirm`` rows. If any
+exist, ``RuntimeError`` with snapshot-restore hint. If zero (only
+legacy ``confirm`` tokens), downgrade can rebuild the legacy shape.
+
+Idempotent guards
+-----------------
+
+* Column add via ``op.add_column`` is intrinsically idempotent on a
+  fresh DB; in a half-applied state, re-running raises a clean
+  ``DuplicateColumn`` (alembic surfaces it).
+* Index create/drop wrapped with ``IF NOT EXISTS`` / ``IF EXISTS`` via
+  inspector pattern — same shape as Wave 5-D phase1_16.
+* CHECK constraint ADD reuses the canonical name; PG raises if
+  duplicate.
+
+Live cold cutover rehearsal (dev DB w/ prod data 2026-05-05)
+------------------------------------------------------------
+
+Pre-flight verified live: 0 rows in ``admission_confirmation_token``
+on dev DB (post prod-data import). Zero break risk for any migration
+step — column add, CHECK, partial UNIQUE, and new index all operate
+on an empty table.
+
+Revision ID: phase1_18
+Revises: phase1_12
+Create Date: 2026-05-05
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_18"
+down_revision: Union[str, None] = "phase1_12"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE = "admission_confirmation_token"
+
+# Existing single-token-per-profile UNIQUE — created from
+# ``unique=True + index=True`` on the model column. Verified live via
+# ``\d admission_confirmation_token`` on dev DB 2026-05-05.
+LEGACY_UNIQUE_INDEX = "ix_admission_confirmation_token_profile_id"
+
+# 4-action enum lockdown — PLAN §3.3.g + §4 P1 #18 + line 1887.
+ACTION_TYPES: tuple[str, ...] = ("submit", "resubmit", "confirm", "withdraw")
+CHECK_NAME = "ck_token_action_type"
+
+# Partial UNIQUE — 1 active (un-confirmed) token per (profile, action).
+PARTIAL_UNIQUE_NAME = "uq_active_token_per_profile_action"
+
+# Lookup index for ``get_profile_by_magic_link_token(token, action)``.
+LOOKUP_INDEX_NAME = "ix_token_action_type"
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    return index_name in {idx["name"] for idx in inspector.get_indexes(table_name)}
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    return column_name in {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    # Step 1: ADD COLUMN action_type with default 'confirm' — backfills
+    # legacy rows at ALTER time (PG fast path).
+    if not _column_exists(TABLE, "action_type"):
+        op.add_column(
+            TABLE,
+            sa.Column(
+                "action_type",
+                sa.String(20),
+                nullable=False,
+                server_default=sa.text("'confirm'"),
+            ),
+        )
+
+    # Step 2: ADD CHECK constraint to lock the enum at DB layer.
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE {TABLE}
+                DROP CONSTRAINT IF EXISTS {CHECK_NAME};
+            """
+        )
+    )
+    quoted_actions = ", ".join(repr(a) for a in ACTION_TYPES)
+    op.create_check_constraint(
+        CHECK_NAME,
+        TABLE,
+        f"action_type IN ({quoted_actions})",
+    )
+
+    # Step 3: DROP legacy single-token-per-profile UNIQUE index.
+    if _index_exists(TABLE, LEGACY_UNIQUE_INDEX):
+        op.drop_index(LEGACY_UNIQUE_INDEX, table_name=TABLE)
+
+    # Step 4: CREATE partial UNIQUE — 1 active token per (profile,
+    # action). Audit-trail rows (already-confirmed) excluded by
+    # ``WHERE confirmed_at IS NULL``.
+    if not _index_exists(TABLE, PARTIAL_UNIQUE_NAME):
+        op.create_index(
+            PARTIAL_UNIQUE_NAME,
+            TABLE,
+            ["profile_id", "action_type"],
+            unique=True,
+            postgresql_where=sa.text("confirmed_at IS NULL"),
+        )
+
+    # Step 5: Lookup index for ``get_profile_by_magic_link_token()``.
+    if not _index_exists(TABLE, LOOKUP_INDEX_NAME):
+        op.create_index(
+            LOOKUP_INDEX_NAME,
+            TABLE,
+            ["token", "action_type"],
+        )
+
+
+def downgrade() -> None:
+    """⚠ ONE-WAY — defensive guard against multi-action token rows.
+
+    If any row has ``action_type != 'confirm'``, the application has
+    started using multi-action semantics. Reverting the schema would
+    break those callers AND fail to re-add the legacy single-
+    profile_id UNIQUE because of multi-token-per-profile rows.
+    """
+    bind = op.get_bind()
+    multi_action_count = bind.execute(
+        sa.text(
+            f"SELECT COUNT(*) FROM {TABLE} WHERE action_type != 'confirm'"
+        )
+    ).scalar()
+    if multi_action_count and multi_action_count > 0:
+        raise RuntimeError(
+            f"Cannot downgrade phase1_18: {multi_action_count} row(s) in "
+            f"{TABLE} hold non-'confirm' action_type values "
+            f"({', '.join(a for a in ACTION_TYPES if a != 'confirm')}). "
+            f"This is a ONE-WAY migration — restore from a pre-Wave-3 "
+            f"snapshot instead of running `alembic downgrade`."
+        )
+
+    # Reverse order: drop new indexes + CHECK, then re-add legacy
+    # UNIQUE + drop column.
+    if _index_exists(TABLE, LOOKUP_INDEX_NAME):
+        op.drop_index(LOOKUP_INDEX_NAME, table_name=TABLE)
+    if _index_exists(TABLE, PARTIAL_UNIQUE_NAME):
+        op.drop_index(PARTIAL_UNIQUE_NAME, table_name=TABLE)
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE {TABLE}
+                DROP CONSTRAINT IF EXISTS {CHECK_NAME};
+            """
+        )
+    )
+
+    # Recreate legacy UNIQUE on profile_id (only safe because the guard
+    # above ensured no profile holds >1 token after column drop).
+    if not _index_exists(TABLE, LEGACY_UNIQUE_INDEX):
+        op.create_index(
+            LEGACY_UNIQUE_INDEX,
+            TABLE,
+            ["profile_id"],
+            unique=True,
+        )
+
+    if _column_exists(TABLE, "action_type"):
+        op.drop_column(TABLE, "action_type")

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -16,7 +16,7 @@ Architecture:
 
 from datetime import date, datetime, timezone
 from typing import List, Optional
-from sqlalchemy import Boolean, CheckConstraint, Column, Date, Index, Integer, Numeric, SmallInteger, String, Text, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy import Boolean, CheckConstraint, Column, Date, Index, Integer, Numeric, SmallInteger, String, Text, DateTime, ForeignKey, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import ENUM, JSONB
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 
@@ -586,17 +586,55 @@ class AdmissionConfirmationToken(Base):
     """
     __tablename__ = "admission_confirmation_token"
 
+    # Wave 3-D (M-1-18) extends single-action token to multi-action.
+    # Migration owner:
+    # ``alembic/versions/phase1_18_extend_confirmation_token_for_multi_action.py``.
+    # CheckConstraint locks the 4-action enum at the test DB layer
+    # (Base.metadata.create_all) so test rows that fail the contract
+    # surface here just like prod. Partial UNIQUE index keeps audit
+    # trail rows (already-confirmed) free from contention with newly-
+    # issued tokens for the same (profile_id, action_type) pair.
+    __table_args__ = (
+        CheckConstraint(
+            "action_type IN ('submit','resubmit','confirm','withdraw')",
+            name="ck_token_action_type",
+        ),
+        Index(
+            "uq_active_token_per_profile_action",
+            "profile_id",
+            "action_type",
+            unique=True,
+            postgresql_where=text("confirmed_at IS NULL"),
+        ),
+        Index("ix_token_action_type", "token", "action_type"),
+    )
+
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    
-    # Link to AdmissionProfile (one token per profile)
+
+    # Link to AdmissionProfile. Wave 3-D (PR Wave 3-D) DROPPED the
+    # single-token-per-profile UNIQUE in favor of the partial UNIQUE
+    # ``uq_active_token_per_profile_action`` declared above — every
+    # profile may now hold ONE active token PER action_type.
     profile_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("admission_profile.id", ondelete="CASCADE"),
         nullable=False,
-        unique=True,  # One active token per profile
-        index=True
+        index=True,
     )
-    
+
+    # Wave 3-D (M-1-18) — multi-action token. 4 values locked by the
+    # ``ck_token_action_type`` CHECK declared in ``__table_args__``
+    # above. Default ``'confirm'`` preserves legacy single-action
+    # behavior on legacy rows; new code paths set ``submit`` /
+    # ``resubmit`` / ``withdraw`` explicitly.
+    action_type: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default="confirm",
+        server_default=text("'confirm'"),
+        comment="Token action: submit | resubmit | confirm | withdraw",
+    )
+
     # The actual token value (sent in email link)
     token: Mapped[str] = mapped_column(
         String(64),

--- a/Backend_FastAPI/tests/unit/test_phase1_18_token_multi_action.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_18_token_multi_action.py
@@ -1,0 +1,243 @@
+"""Unit tests for #184 Wave 3-D migration ``phase1_18_extend_confirmation_token_for_multi_action``.
+
+Wave 3 ⚠ ONE-WAY token schema extend. Tests cover:
+
+1. Revision row + chain (``phase1_18`` → ``phase1_12``).
+2. Constants lock-in (table name + 4-action enum + index/constraint
+   names match PLAN spec).
+3. 5 DDL steps in correct order: column add → CHECK → drop legacy
+   UNIQUE → partial UNIQUE → lookup index.
+4. Column add: NOT NULL + server_default 'confirm' (PG fast-path
+   backfill of legacy rows).
+5. CHECK constraint locks 4 action enum at DB layer.
+6. Partial UNIQUE shape: ``(profile_id, action_type) WHERE
+   confirmed_at IS NULL``.
+7. Idempotent guards: ``_column_exists`` / ``_index_exists``.
+8. Defensive ONE-WAY downgrade: count non-confirm rows BEFORE drop +
+   raise RuntimeError on >0.
+9. Module sanity (``upgrade`` + ``downgrade`` callable).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_PHASE1_18 = (
+    _VERSIONS_DIR / "phase1_18_extend_confirmation_token_for_multi_action.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location(_PHASE1_18.stem, _PHASE1_18)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_18():
+    return _load_migration()
+
+
+@pytest.fixture
+def src() -> str:
+    return _PHASE1_18.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision row + chain
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_18_revision_id(phase1_18) -> None:
+    assert phase1_18.revision == "phase1_18"
+
+
+def test_phase1_18_chains_off_phase1_12(phase1_18) -> None:
+    """Wave 3 sequence: 3-A (phase1_11) → 3-B (FE Stage 3) → 3-C
+    (phase1_12 backfill) → 3-D (this — token multi-action). Linear
+    chain off Wave 3-C."""
+    assert phase1_18.down_revision == "phase1_12"
+
+
+# ---------------------------------------------------------------------------
+# 2. Constants lock-in
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_18_table_name_canonical(phase1_18) -> None:
+    assert phase1_18.TABLE == "admission_confirmation_token"
+
+
+def test_phase1_18_action_types_lock_four_values(phase1_18) -> None:
+    """PLAN §3.3.g + line 1887 — 4 action values exact. Drift here =
+    schema-vs-app contract divergence."""
+    assert phase1_18.ACTION_TYPES == (
+        "submit",
+        "resubmit",
+        "confirm",
+        "withdraw",
+    )
+    assert len(phase1_18.ACTION_TYPES) == 4
+
+
+def test_phase1_18_legacy_unique_index_name_matches_live(phase1_18) -> None:
+    """SQLAlchemy ``unique=True + index=True`` produces the ``ix_*``
+    prefix — verified live on dev DB 2026-05-05 via
+    ``\\d admission_confirmation_token``. PLAN draft mentioned
+    ``_profile_id_key`` which is the constraint convention; the live
+    DB uses the index convention."""
+    assert phase1_18.LEGACY_UNIQUE_INDEX == "ix_admission_confirmation_token_profile_id"
+
+
+def test_phase1_18_partial_unique_name(phase1_18) -> None:
+    assert phase1_18.PARTIAL_UNIQUE_NAME == "uq_active_token_per_profile_action"
+
+
+def test_phase1_18_lookup_index_name(phase1_18) -> None:
+    assert phase1_18.LOOKUP_INDEX_NAME == "ix_token_action_type"
+
+
+def test_phase1_18_check_constraint_name(phase1_18) -> None:
+    assert phase1_18.CHECK_NAME == "ck_token_action_type"
+
+
+# ---------------------------------------------------------------------------
+# 3. 5-step DDL order
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_18_upgrade_steps_in_correct_order(src) -> None:
+    """Step 1 (add column) → Step 2 (CHECK) → Step 3 (drop legacy
+    UNIQUE) → Step 4 (partial UNIQUE) → Step 5 (lookup index). Steps
+    must run in this order: the partial UNIQUE references action_type
+    which doesn't exist before Step 1; the legacy UNIQUE drop must
+    happen before the partial UNIQUE creation to avoid contention."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    add_col_pos = upgrade_body.index('op.add_column(')
+    check_create_pos = upgrade_body.index("op.create_check_constraint(")
+    drop_legacy_pos = upgrade_body.index('op.drop_index(LEGACY_UNIQUE_INDEX')
+    partial_create_pos = upgrade_body.index("PARTIAL_UNIQUE_NAME")
+    lookup_create_pos = upgrade_body.index("LOOKUP_INDEX_NAME")
+    assert (
+        add_col_pos
+        < check_create_pos
+        < drop_legacy_pos
+        < partial_create_pos
+        < lookup_create_pos
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Column add shape
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_18_action_type_column_not_null_default_confirm(src) -> None:
+    """NOT NULL + server_default 'confirm' = PG fast-path backfill of
+    every legacy row to the legacy single-action behavior at ALTER
+    time, no follow-up UPDATE needed."""
+    assert '"action_type"' in src
+    assert "sa.String(20)" in src
+    assert "nullable=False" in src
+    assert "server_default=sa.text(\"'confirm'\")" in src
+
+
+# ---------------------------------------------------------------------------
+# 5. CHECK constraint locks the enum
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_18_check_constraint_uses_quoted_action_list(src) -> None:
+    """Predicate built via repr to quote each action_type literal —
+    SQL injection-safe (states come from tuple constant, but quoting
+    is the principled shape)."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    assert "create_check_constraint" in upgrade_body
+    assert 'CHECK_NAME' in upgrade_body
+    assert "f\"action_type IN ({quoted_actions})\"" in upgrade_body
+
+
+# ---------------------------------------------------------------------------
+# 6. Partial UNIQUE shape per PLAN line 1893-1897
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_18_partial_unique_predicate_confirmed_at_null(src) -> None:
+    """``WHERE confirmed_at IS NULL`` keeps audit-trail rows
+    (already-confirmed tokens) free from contention with newly-
+    issued live tokens for the same (profile, action) pair."""
+    pattern = "postgresql_where=sa.text(\"confirmed_at IS NULL\")"
+    assert pattern in src
+
+
+def test_phase1_18_partial_unique_columns_profile_id_action_type(src) -> None:
+    """Composite UNIQUE on ``(profile_id, action_type)`` — same profile
+    can hold ONE active token per action concurrently."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    # Look for the create_index call with PARTIAL_UNIQUE_NAME and the
+    # column list ``["profile_id", "action_type"]``.
+    pu_idx = upgrade_body.index("PARTIAL_UNIQUE_NAME")
+    pu_block = upgrade_body[pu_idx : pu_idx + 400]
+    assert '["profile_id", "action_type"]' in pu_block
+    assert "unique=True" in pu_block
+
+
+# ---------------------------------------------------------------------------
+# 7. Idempotent guards
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_18_uses_inspector_idempotency_helpers(src) -> None:
+    assert "_column_exists" in src
+    assert "_index_exists" in src
+    # Helpers wrap inspector — same shape as Wave 5-D phase1_16.
+    assert "from sqlalchemy import inspect" in src
+
+
+# ---------------------------------------------------------------------------
+# 8. Downgrade defensive guard
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_18_downgrade_counts_non_confirm_rows_first(src) -> None:
+    """COUNT must run BEFORE drop_index / drop_column — otherwise the
+    guard would already have torn down the schema by the time we
+    notice the violation."""
+    downgrade_body = src[src.index("def downgrade()"):]
+    count_pos = downgrade_body.index("WHERE action_type != 'confirm'")
+    drop_pos = downgrade_body.index("op.drop_index(")
+    assert count_pos < drop_pos
+
+
+def test_phase1_18_downgrade_raises_on_multi_action_rows(src) -> None:
+    """Non-zero count must raise — silent skip would let Phase 3
+    callers continue writing rows the migration just attempted to
+    revert."""
+    downgrade_body = src[src.index("def downgrade()"):]
+    assert "raise RuntimeError" in downgrade_body
+    assert "ONE-WAY" in downgrade_body
+    assert "snapshot" in downgrade_body
+
+
+def test_phase1_18_downgrade_recreates_legacy_unique_only_if_safe(src) -> None:
+    """When safe (0 multi-action rows), downgrade rebuilds the legacy
+    single-token-per-profile UNIQUE."""
+    downgrade_body = src[src.index("def downgrade()"):]
+    assert "LEGACY_UNIQUE_INDEX" in downgrade_body
+    assert 'unique=True' in downgrade_body
+
+
+# ---------------------------------------------------------------------------
+# 9. Module sanity
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_18_callable_upgrade_and_downgrade(phase1_18) -> None:
+    assert callable(getattr(phase1_18, "upgrade", None))
+    assert callable(getattr(phase1_18, "downgrade", None))


### PR DESCRIPTION
## Scope — Wave 3 fourth ⚠ ONE-WAY migration

Promotes `admission_confirmation_token` từ single-purpose (`confirm` only) → multi-action (`submit` / `resubmit` / `confirm` / `withdraw`) per PLAN §3.3.g + §4 P1 #18 + line 1880-1901. Each profile có thể giữ ONE active token PER action concurrently.

## 5-step DDL (ordered, idempotent)

1. `ADD COLUMN action_type VARCHAR(20) NOT NULL DEFAULT 'confirm'` — backfills existing rows safely tại ALTER time (PG fast path).
2. `ADD CONSTRAINT ck_token_action_type CHECK action_type IN ('submit', 'resubmit', 'confirm', 'withdraw')` — locks enum at DB layer.
3. DROP legacy UNIQUE index `ix_admission_confirmation_token_profile_id` (replaced by partial UNIQUE).
4. `CREATE UNIQUE INDEX uq_active_token_per_profile_action` ON `(profile_id, action_type)` `WHERE confirmed_at IS NULL` — audit-trail rows excluded.
5. `CREATE INDEX ix_token_action_type` ON `(token, action_type)` — fast token+action lookup.

## Schema name correction (memory `verify-schema-before-proposing`)

PLAN draft mentioned `_profile_id_key` (constraint convention), nhưng live DB uses `ix_admission_confirmation_token_profile_id` (SQLAlchemy `unique=True + index=True` index convention). Verified via `\d` on dev DB, migration uses live name. Test 5 anchor non-tautological catches future spec drift.

## ONE-WAY downgrade

Counts rows với `action_type != 'confirm'`. If any → `RuntimeError` với snapshot-restore hint listing all non-'confirm' values. Safe path (0 multi-action rows): drop new artifacts + recreate legacy UNIQUE.

## Coupled deliverables in this PR

- `app/models/admission.py:587-660` — `AdmissionConfirmationToken` model:
  - Removed `unique=True` from `profile_id` (no longer enforces single-token-per-profile).
  - Added `action_type` column (String(20), NOT NULL, default 'confirm', server_default text "'confirm'").
  - Added `__table_args__` carrying `CheckConstraint` (4-action enum), partial UNIQUE Index (`uq_active_token_per_profile_action` WHERE `confirmed_at IS NULL`), and lookup Index (`ix_token_action_type`).
  - Imported `text` from sqlalchemy for `postgresql_where`.
- Test DB (`Base.metadata.create_all()`) reads model — keeping in sync với migration prevents test-vs-prod drift per memory `test-db-schema-source`.

## Test plan — 18/18 unit pass + live alembic round-trip

### Unit (18/18)
- [x] Revision chain (phase1_18 ← phase1_12)
- [x] Constants lock-in: TABLE name + 4 ACTION_TYPES + LEGACY_UNIQUE_INDEX (live name `ix_*` not `_key`) + PARTIAL_UNIQUE_NAME + LOOKUP_INDEX_NAME + CHECK_NAME
- [x] 5-step DDL ordering anchor (column add → CHECK → drop legacy UNIQUE → partial UNIQUE → lookup index)
- [x] Column add NOT NULL + server_default 'confirm'
- [x] CHECK uses quoted action list via `repr`
- [x] Partial UNIQUE predicate `WHERE confirmed_at IS NULL`
- [x] Partial UNIQUE columns `["profile_id", "action_type"]` + unique=True
- [x] Inspector idempotent helpers
- [x] Downgrade COUNT BEFORE drop_index
- [x] Downgrade raises RuntimeError với ONE-WAY + snapshot keywords
- [x] Downgrade recreates LEGACY_UNIQUE_INDEX với unique=True when safe
- [x] Module sanity

### Live alembic on dev DB w/ prod data ✅

Per memory `solo-cutover-simple-data-import` — Wave 3 strict standard maintained:

- ✅ Upgrade `phase1_12 → phase1_18` clean. Schema verified post-upgrade: action_type col + ck_token_action_type CHECK (4 values) + uq_active_token_per_profile_action partial UNIQUE + ix_token_action_type lookup. Legacy `ix_admission_confirmation_token_profile_id` UNIQUE dropped.
- ✅ **Partial UNIQUE behavior verified live**:
  - INSERT (profile_id=14, action='submit') → SUCCESS (id=3)
  - INSERT (profile_id=14, action='confirm') → SUCCESS (id=4) — different action allowed
  - INSERT (profile_id=14, action='submit') again → REJECTED `duplicate key value violates unique constraint "uq_active_token_per_profile_action"`
- ✅ Downgrade safe path (0 rows) clean — schema fully reverted, legacy UNIQUE re-added.
- ✅ Re-upgrade idempotent (alembic_version stays phase1_18 head).
- ✅ **Defensive ONE-WAY guard verified live**: INSERT (action='withdraw') → `alembic downgrade -1` raises:
  ```
  RuntimeError: Cannot downgrade phase1_18: 1 row(s) in admission_confirmation_token
  hold non-'confirm' action_type values (submit, resubmit, withdraw). This is a
  ONE-WAY migration — restore from a pre-Wave-3 snapshot instead of running
  `alembic downgrade`.
  ```

## Wave 3 progress (4/5 sub-PR shipped — 3 merged, 1 OPEN this PR)

- ✅ Wave 3-A `55f3eb41` phase1_11 status CHECK 10→14 ⚠ (PR #219)
- ✅ Wave 3-B `efc1b4f7` FE Stage 3 strict 14-state (PR #220)
- ✅ Wave 3-C `51b2c1ae` phase1_12 backfill ⚠ (PR #221)
- 🟡 **Wave 3-D THIS PR** phase1_18 confirmation_token multi-action ⚠
- ⏳ Wave 3-E phase1_15a DROP UNIQUE → composite ⚠

## References

- PLAN §3.3.g (token multi-action lifecycle)
- PLAN §4 P1 #18 + line 1880-1901 (5-step DDL spec)
- Memory `audit-before-fix` (live `\d` DB query pre-draft + corrected naming)
- Memory `verify-schema-before-proposing` (live convention vs PLAN draft drift)
- Memory `migration-predicate-safety` (5-step idempotent + defensive guard)
- Memory `pattern-change-impact-audit` (model __table_args__ updated same commit)
- Memory `solo-cutover-simple-data-import` (Wave 3 strict standard — live alembic)

## Path filter no-checks fallback expected

Files: alembic + model + test only. Không match workflow paths → no-checks fallback đúng SOP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
