### PR TITLE
[#184 Wave3-E] feat(schema): phase1_15a DROP UNIQUE(lead_id) → ADD UNIQUE(lead_id, academic_year) ⚠ ONE-WAY (final Wave 3)

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase1_15a_drop_lead_id_unique_to_composite.py
+++ b/Backend_FastAPI/alembic/versions/phase1_15a_drop_lead_id_unique_to_composite.py
@@ -1,0 +1,202 @@
+"""Wave 3-E / M-1-15a — DROP UNIQUE(lead_id) → ADD UNIQUE(lead_id, academic_year) ⚠ ONE-WAY.
+
+Final ⚠ ONE-WAY migration of Wave 3 — completes Phase 1 Schema 100%
+post-merge. Removes the legacy single-profile-per-lead constraint and
+replaces it with a composite ``(lead_id, academic_year)`` UNIQUE so a
+lead can apply for multiple academic years (one profile per year per
+lead) per PLAN line 3312-3346.
+
+Live DB naming convention (verified ``\\d admission_profile`` 2026-05-05)
+-----------------------------------------------------------------------
+
+The legacy UNIQUE constraint was created from ``unique=True +
+index=True`` on ``AdmissionProfile.lead_id``. SQLAlchemy emits this as
+ONE UNIQUE INDEX named ``ix_admission_profile_lead_id`` (``ix_*``
+prefix), NOT a separate ``_lead_id_key`` constraint. Verified live;
+migration uses the live name. Same correction pattern as Wave 3-D
+phase1_18 (PR #222 squash 958435cf).
+
+3-step DDL
+----------
+
+1. DROP legacy UNIQUE INDEX ``ix_admission_profile_lead_id`` —
+   removes the single-profile-per-lead enforcement.
+2. CREATE non-unique INDEX ``ix_admission_profile_lead_id`` ON
+   ``(lead_id)`` — preserves FK lookup performance. Same name reused
+   intentionally; the index transitions from UNIQUE to plain.
+3. ADD UNIQUE CONSTRAINT ``uq_admission_profile_lead_year`` ON
+   ``(lead_id, academic_year)`` — preserves business invariant: 1
+   lead → 1 profile / academic year.
+
+ONE-WAY downgrade contract
+--------------------------
+
+After this migration ships, the application (Wave 4 PR #15b) will
+flip ``Lead.admission_profile`` from singular ``uselist=False`` to
+plural ``admission_profiles`` and start letting leads accumulate
+profiles across years. Reverting requires:
+* application rolling back to single-profile-per-lead semantics, AND
+* DB having no lead with >1 profile.
+
+If any lead has >1 profile (post-Wave-4 multi-year data), recreating
+the legacy single UNIQUE on ``lead_id`` would FAIL at the ``CREATE``
+step. Defensive guard counts pre-existing offenders BEFORE drop —
+raises ``RuntimeError`` with snapshot-restore hint.
+
+Coupled deliverables in this PR
+-------------------------------
+
+* ``app/models/admission.py:44-58`` — ``AdmissionProfile.__table_args__``
+  carries the new composite UNIQUE so test DB
+  (``Base.metadata.create_all()``) stays in sync. Memory
+  ``test-db-schema-source`` flagged drift symptom previously; same-
+  commit update prevents.
+* ``lead_id`` column ``unique=True`` removed; relationship stays
+  singular (``uselist=False``) — flip to plural ships in Wave 4 PR
+  #15b paired with model + repository + service updates per PLAN
+  line 3320-3331. Wave 3-E is DDL-only; the application contract
+  remains 1-profile-per-lead until Wave 4.
+
+Live cold cutover rehearsal (dev DB w/ prod data 2026-05-05)
+------------------------------------------------------------
+
+Pre-flight verified live:
+* 9 admission_profile rows in dev DB (post prod-data import).
+* 0 lead_id duplicates: ``GROUP BY lead_id HAVING COUNT(*) > 1``
+  returns 0 rows.
+* 0 (lead_id, academic_year) duplicates: same query with composite
+  GROUP BY returns 0 rows.
+
+Zero conflict risk for both the UNIQUE swap and the defensive
+downgrade rebuild — every existing row satisfies both constraints.
+
+Solo cold cutover semantics — no inter-PR soak window
+-----------------------------------------------------
+
+PLAN line 3468-3473 specs a 1-week soak between phase1_15a (DDL drop)
+/ phase1_15b (model+service plural) / phase1_15c (FE migrate). Per
+memory ``solo-cutover-simple-data-import`` 2026-05-05 pivot, solo
+cold cutover ships the entire branch in 1 maintenance window — soak
+windows are team-style staged rollout semantic that doesn't apply
+when there's no concurrent traffic during the swap. Wave 4 PRs #15b
++ #15c ship sequentially without soak.
+
+Revision ID: phase1_15a
+Revises: phase1_18
+Create Date: 2026-05-05
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_15a"
+down_revision: Union[str, None] = "phase1_18"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE = "admission_profile"
+
+# Live DB naming convention — SQLAlchemy ``unique=True + index=True``
+# on the lead_id column produces ONE UNIQUE INDEX with the ``ix_*``
+# prefix. Verified via ``\d admission_profile`` 2026-05-05.
+LEAD_ID_INDEX = "ix_admission_profile_lead_id"
+
+# New composite UNIQUE — 1 profile per (lead, academic_year).
+COMPOSITE_UNIQUE_NAME = "uq_admission_profile_lead_year"
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    return index_name in {idx["name"] for idx in inspector.get_indexes(table_name)}
+
+
+def _is_index_unique(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    for idx in inspector.get_indexes(table_name):
+        if idx["name"] == index_name:
+            return bool(idx.get("unique", False))
+    return False
+
+
+def _constraint_exists(table_name: str, constraint_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    for c in inspector.get_unique_constraints(table_name):
+        if c["name"] == constraint_name:
+            return True
+    return False
+
+
+def upgrade() -> None:
+    """3-step UNIQUE swap.
+
+    Idempotency: each step inspects current state before executing.
+    Safe to re-run if half-applied state.
+    """
+    # Step 1: DROP legacy UNIQUE INDEX (only if it's still UNIQUE —
+    # if a prior run already converted it to plain, skip).
+    if _index_exists(TABLE, LEAD_ID_INDEX) and _is_index_unique(TABLE, LEAD_ID_INDEX):
+        op.drop_index(LEAD_ID_INDEX, table_name=TABLE)
+
+    # Step 2: RECREATE as plain (non-unique) index for FK lookup
+    # performance. Same name reused; the index transitions
+    # UNIQUE → plain.
+    if not _index_exists(TABLE, LEAD_ID_INDEX):
+        op.create_index(LEAD_ID_INDEX, TABLE, ["lead_id"])
+
+    # Step 3: ADD composite UNIQUE — 1 profile / lead / academic_year.
+    if not _constraint_exists(TABLE, COMPOSITE_UNIQUE_NAME):
+        op.create_unique_constraint(
+            COMPOSITE_UNIQUE_NAME,
+            TABLE,
+            ["lead_id", "academic_year"],
+        )
+
+
+def downgrade() -> None:
+    """⚠ ONE-WAY — defensive guard against multi-year-per-lead rows.
+
+    If any lead has >1 profile, recreating the legacy single UNIQUE
+    on ``lead_id`` would fail at CREATE (multiple rows violate the
+    new constraint). Surface the violation up-front instead of
+    failing mid-DDL.
+    """
+    bind = op.get_bind()
+    multi_profile_leads = bind.execute(
+        sa.text(
+            f"""
+            SELECT COUNT(*) FROM (
+                SELECT lead_id FROM {TABLE}
+                GROUP BY lead_id
+                HAVING COUNT(*) > 1
+            ) AS multi
+            """
+        )
+    ).scalar()
+    if multi_profile_leads and multi_profile_leads > 0:
+        raise RuntimeError(
+            f"Cannot downgrade phase1_15a: {multi_profile_leads} lead(s) in "
+            f"{TABLE} hold >1 profile (multi-year semantics already in "
+            f"flight). This is a ONE-WAY migration — restore from a "
+            f"pre-Wave-3 snapshot instead of running `alembic downgrade`. "
+            f"Manual cleanup playbook: collapse multi-year profiles per "
+            f"lead before re-running this downgrade."
+        )
+
+    # Reverse order: drop composite UNIQUE, recreate legacy UNIQUE
+    # INDEX on lead_id.
+    if _constraint_exists(TABLE, COMPOSITE_UNIQUE_NAME):
+        op.drop_constraint(COMPOSITE_UNIQUE_NAME, TABLE, type_="unique")
+
+    if _index_exists(TABLE, LEAD_ID_INDEX) and not _is_index_unique(TABLE, LEAD_ID_INDEX):
+        op.drop_index(LEAD_ID_INDEX, table_name=TABLE)
+
+    if not _index_exists(TABLE, LEAD_ID_INDEX):
+        op.create_index(LEAD_ID_INDEX, TABLE, ["lead_id"], unique=True)

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -44,6 +44,15 @@ class AdmissionProfile(Base):
     __table_args__ = (
         UniqueConstraint('citizen_id', 'academic_year', name='uq_citizen_academic_year'),
         Index('ix_admission_profile_citizen_year', 'citizen_id', 'academic_year'),
+        # Wave 3-E (M-1-15a) replaces the legacy single-profile-per-lead
+        # UNIQUE on ``lead_id`` with a composite ``(lead_id, academic_year)``
+        # UNIQUE so a lead can apply for multiple academic years (one
+        # profile per year per lead). Migration owner:
+        # ``alembic/versions/phase1_15a_drop_lead_id_unique_to_composite.py``.
+        # Test DB (``Base.metadata.create_all``) reads this declaration —
+        # keeping it in sync với migration prevents drift symptom per
+        # memory ``test-db-schema-source``.
+        UniqueConstraint('lead_id', 'academic_year', name='uq_admission_profile_lead_year'),
         # Wave 3-A (M-1-11) extends 10-state CHECK to 14-state, adding the
         # 4 choice-engine milestone states (reviewing / result_published /
         # admitted / waitlisted). Migration owner:
@@ -64,11 +73,17 @@ class AdmissionProfile(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
 
     # Foreign Key to Lead (One-to-One relationship)
+    # Wave 3-E (M-1-15a) DROPPED the single-profile-per-lead UNIQUE
+    # in favor of composite ``uq_admission_profile_lead_year`` declared
+    # above. Lead can now hold one profile PER academic_year. Wave 4
+    # PR #15b will flip ``Lead.admission_profile`` from
+    # ``uselist=False`` to plural ``admission_profiles`` paired with
+    # repository/service updates; until then the application contract
+    # remains 1-profile-per-lead via the composite constraint.
     lead_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("lead.id", ondelete="CASCADE"),
         nullable=False,
-        unique=True,  # One lead can only have one admission profile
         index=True,
         comment="Link to Lead (IDOR check point: lead.unit_id)"
     )

--- a/Backend_FastAPI/tests/unit/test_phase1_15a_unique_swap.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_15a_unique_swap.py
@@ -1,0 +1,240 @@
+"""Unit tests for #184 Wave 3-E migration ``phase1_15a_drop_lead_id_unique_to_composite``.
+
+Final ⚠ ONE-WAY migration of Wave 3 — completes Phase 1 Schema 100%
+post-merge. Swaps single-profile-per-lead UNIQUE for composite
+``(lead_id, academic_year)`` so a lead can apply across academic years.
+
+Tests cover:
+
+1. Revision row + chain (``phase1_15a`` → ``phase1_18``).
+2. Constants lock-in (TABLE + LEAD_ID_INDEX live name + COMPOSITE_UNIQUE_NAME).
+3. 3-step DDL ordering: drop legacy UNIQUE INDEX → recreate as plain →
+   add composite UNIQUE.
+4. Idempotent guards via inspector helpers (``_index_exists`` /
+   ``_is_index_unique`` / ``_constraint_exists``).
+5. Same-name index re-use: legacy index is UNIQUE, plain replacement
+   reuses the SAME name (transition UNIQUE → plain).
+6. Defensive ONE-WAY downgrade — counts leads with >1 profile BEFORE
+   drop, raises RuntimeError on any.
+7. Downgrade safe path: drop composite + drop plain index + recreate
+   UNIQUE on lead_id.
+8. ORM model parity — ``AdmissionProfile.__table_args__`` carries the
+   new composite UNIQUE; column ``unique=True`` removed.
+9. Module sanity (callable upgrade + downgrade).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_PHASE1_15A = _VERSIONS_DIR / "phase1_15a_drop_lead_id_unique_to_composite.py"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location(_PHASE1_15A.stem, _PHASE1_15A)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_15a():
+    return _load_migration()
+
+
+@pytest.fixture
+def src() -> str:
+    return _PHASE1_15A.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision row + chain
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_15a_revision_id(phase1_15a) -> None:
+    assert phase1_15a.revision == "phase1_15a"
+
+
+def test_phase1_15a_chains_off_phase1_18(phase1_15a) -> None:
+    """Wave 3 sequence final: 3-A (phase1_11) → 3-C (phase1_12 backfill)
+    → 3-D (phase1_18 token) → 3-E (this — UNIQUE swap, completes
+    Phase 1 Schema 100%)."""
+    assert phase1_15a.down_revision == "phase1_18"
+
+
+# ---------------------------------------------------------------------------
+# 2. Constants lock-in
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_15a_table_name_canonical(phase1_15a) -> None:
+    assert phase1_15a.TABLE == "admission_profile"
+
+
+def test_phase1_15a_lead_id_index_name_matches_live_db(phase1_15a) -> None:
+    """SQLAlchemy ``unique=True + index=True`` produces ONE UNIQUE
+    INDEX named with the ``ix_*`` prefix — verified live via
+    ``\\d admission_profile`` 2026-05-05. Same correction pattern as
+    Wave 3-D phase1_18 (``_lead_id_key`` constraint convention is the
+    PLAN draft style; live DB uses ``ix_*`` index convention)."""
+    assert phase1_15a.LEAD_ID_INDEX == "ix_admission_profile_lead_id"
+
+
+def test_phase1_15a_composite_unique_name_per_plan_line_3343(phase1_15a) -> None:
+    assert phase1_15a.COMPOSITE_UNIQUE_NAME == "uq_admission_profile_lead_year"
+
+
+# ---------------------------------------------------------------------------
+# 3. 3-step DDL ordering
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_15a_upgrade_steps_in_correct_order(src) -> None:
+    """Step 1 (drop legacy UNIQUE) → Step 2 (recreate as plain) →
+    Step 3 (add composite UNIQUE). Order matters: the recreated plain
+    index uses the SAME name as the dropped UNIQUE index; the
+    composite UNIQUE is independent but logically follows the lead_id
+    transition."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    drop_legacy_pos = upgrade_body.index("op.drop_index(LEAD_ID_INDEX")
+    create_plain_pos = upgrade_body.index("op.create_index(LEAD_ID_INDEX")
+    create_composite_pos = upgrade_body.index("op.create_unique_constraint(")
+    assert drop_legacy_pos < create_plain_pos < create_composite_pos
+
+
+def test_phase1_15a_recreated_index_is_plain_not_unique(src) -> None:
+    """Step 2 recreates the lead_id index as a PLAIN btree — not
+    UNIQUE. The UNIQUE flavor would conflict with the composite
+    UNIQUE at the application contract level."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    create_plain_block = upgrade_body[
+        upgrade_body.index("op.create_index(LEAD_ID_INDEX") :
+    ]
+    create_plain_block = create_plain_block[: create_plain_block.index(")") + 1]
+    # No ``unique=True`` argument on the recreate call.
+    assert "unique=True" not in create_plain_block
+
+
+def test_phase1_15a_composite_columns_lead_id_academic_year(src) -> None:
+    """Composite UNIQUE columns must be ``(lead_id, academic_year)`` in
+    that order — matches PLAN line 3343 spec."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    composite_block = upgrade_body[
+        upgrade_body.index("op.create_unique_constraint(") :
+    ]
+    assert '["lead_id", "academic_year"]' in composite_block
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotent helpers
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_15a_uses_inspector_idempotency_helpers(src) -> None:
+    """Helpers wrap inspector calls — same shape as Wave 5-D phase1_16
+    and Wave 3-D phase1_18."""
+    assert "_index_exists" in src
+    assert "_is_index_unique" in src
+    assert "_constraint_exists" in src
+    assert "from sqlalchemy import inspect" in src
+
+
+def test_phase1_15a_step_1_only_drops_if_index_is_unique(src) -> None:
+    """Idempotent — if a prior partial run already converted the
+    index to plain, skip the drop. ``_is_index_unique`` gates the
+    drop."""
+    upgrade_body = src[src.index("def upgrade()") : src.index("def downgrade()")]
+    # The drop_index call is guarded by AND clause on _is_index_unique.
+    assert "_is_index_unique(TABLE, LEAD_ID_INDEX)" in upgrade_body
+
+
+# ---------------------------------------------------------------------------
+# 5. Defensive ONE-WAY downgrade
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_15a_downgrade_counts_multi_profile_leads_first(src) -> None:
+    """COUNT must run BEFORE drop_constraint / drop_index — surface
+    the violation up-front instead of failing mid-DDL when CREATE
+    UNIQUE INDEX rejects multi-profile rows."""
+    downgrade_body = src[src.index("def downgrade()"):]
+    count_pos = downgrade_body.index("HAVING COUNT(*) > 1")
+    drop_pos = downgrade_body.index("op.drop_constraint(")
+    assert count_pos < drop_pos
+
+
+def test_phase1_15a_downgrade_raises_with_one_way_hint(src) -> None:
+    downgrade_body = src[src.index("def downgrade()"):]
+    assert "raise RuntimeError" in downgrade_body
+    assert "ONE-WAY" in downgrade_body
+    assert "snapshot" in downgrade_body
+    assert "Manual cleanup" in downgrade_body  # ops playbook hint
+
+
+def test_phase1_15a_downgrade_safe_path_recreates_unique_index(src) -> None:
+    """When safe (0 multi-profile leads), downgrade rebuilds the
+    legacy single UNIQUE on lead_id."""
+    downgrade_body = src[src.index("def downgrade()"):]
+    # The recreate call sets unique=True.
+    recreate_pos = downgrade_body.index("op.create_index(LEAD_ID_INDEX")
+    recreate_block = downgrade_body[recreate_pos : recreate_pos + 200]
+    assert "unique=True" in recreate_block
+
+
+# ---------------------------------------------------------------------------
+# 6. ORM model parity (cross-source consistency anchor)
+# ---------------------------------------------------------------------------
+
+
+def test_admission_profile_model_carries_composite_unique() -> None:
+    """``AdmissionProfile.__table_args__`` declares the composite
+    UNIQUE so test DB (``Base.metadata.create_all``) matches prod
+    schema. Drift here = test-vs-prod skew per memory
+    ``test-db-schema-source``."""
+    from sqlalchemy import UniqueConstraint
+
+    from app.models.admission import AdmissionProfile
+
+    composite = next(
+        (
+            c
+            for c in AdmissionProfile.__table_args__
+            if isinstance(c, UniqueConstraint)
+            and c.name == "uq_admission_profile_lead_year"
+        ),
+        None,
+    )
+    assert composite is not None, (
+        "AdmissionProfile.__table_args__ missing composite UniqueConstraint "
+        "'uq_admission_profile_lead_year' (lead_id, academic_year)"
+    )
+    column_names = {c.name for c in composite.columns}
+    assert column_names == {"lead_id", "academic_year"}
+
+
+def test_admission_profile_lead_id_no_longer_unique_at_column_level() -> None:
+    """``unique=True`` removed from the column declaration — the
+    composite UNIQUE in ``__table_args__`` is now the single source
+    of truth for lead-related uniqueness."""
+    from app.models.admission import AdmissionProfile
+
+    lead_id_col = AdmissionProfile.__table__.columns["lead_id"]
+    # Column-level unique=True would surface here as `unique=True` on
+    # the SQLAlchemy column — must be falsy after Wave 3-E swap.
+    assert lead_id_col.unique is None or lead_id_col.unique is False
+
+
+# ---------------------------------------------------------------------------
+# 7. Module sanity
+# ---------------------------------------------------------------------------
+
+
+def test_phase1_15a_callable_upgrade_and_downgrade(phase1_15a) -> None:
+    assert callable(getattr(phase1_15a, "upgrade", None))
+    assert callable(getattr(phase1_15a, "downgrade", None))


### PR DESCRIPTION
## Scope — Wave 3 final ⚠ ONE-WAY migration → Phase 1 Schema 100% post-merge

Removes legacy single-profile-per-lead constraint (UNIQUE on `lead_id`) and replaces với composite `(lead_id, academic_year)` UNIQUE so a lead can apply across academic years (one profile per year per lead) per PLAN §4 P1 #15 + line 3343.

## 3-step DDL design (preserves FK lookup performance)

1. DROP legacy UNIQUE INDEX `ix_admission_profile_lead_id`
2. CREATE plain (non-UNIQUE) INDEX `ix_admission_profile_lead_id` ON `(lead_id)` — keeps FK lookups fast
3. ADD UNIQUE CONSTRAINT `uq_admission_profile_lead_year` ON `(lead_id, academic_year)`

→ No index gap on `lead_id` giữa các steps. Smooth transition không degrade FK lookup performance.

## Schema name correction (memory `verify-schema-before-proposing`)

PLAN draft mentioned `_lead_id_key` (constraint convention), nhưng live DB uses `ix_admission_profile_lead_id` (SQLAlchemy `unique=True + index=True` index convention). Verified via `\d admission_profile`. Same correction pattern as Wave 3-D phase1_18 (PR #222 squash 958435cf). Test 4 anchor non-tautological locks live name.

## Defensive ONE-WAY downgrade với manual cleanup playbook

Counts leads với multi-profile via `GROUP BY lead_id HAVING COUNT(*) > 1`. If any → `RuntimeError` với clear ONE-WAY hint + actionable manual cleanup playbook (`"collapse multi-year profiles per lead before re-running this downgrade"`). Recovery semantic clear cho post-Wave-4 scenario when Lead 1-many model active.

## Coupled deliverables in this PR (DDL + model only — code in Wave 4)

- `app/models/admission.py:44-58` — `__table_args__` carries new composite `UniqueConstraint('lead_id', 'academic_year', name='uq_admission_profile_lead_year')` so test DB (`Base.metadata.create_all`) matches prod schema.
- `lead_id` column `unique=True` removed; relationship `Lead.admission_profile` STAYS `uselist=False` (singular). Wave 4 PR #15b ships the relationship + repository + service flip per memory `184-phase1-schema-wave-plan` line 47-49 split.

## Solo cold cutover — no inter-PR soak

PLAN line 3468-3473 specs 1-week soak between phase1_15a / 15b / 15c (team-style staged rollout). Per memory `solo-cutover-simple-data-import` 2026-05-05 pivot, solo cutover ships entire branch in 1 maintenance window — soak windows don't apply when there's no concurrent traffic during the swap. Wave 4 PRs #15b + #15c ship sequentially without soak.

## Test plan — 16/16 unit + live alembic verified

### Unit (16/16 PASS)
- [x] Revision chain (phase1_15a ← phase1_18)
- [x] Constants lock-in: TABLE + LEAD_ID_INDEX live name (`ix_*` not `_key`) + COMPOSITE_UNIQUE_NAME per PLAN line 3343
- [x] 3-step DDL ordering anchor (drop legacy → recreate plain → add composite)
- [x] Recreated index PLAIN (no `unique=True` on Step 2)
- [x] Composite columns `["lead_id", "academic_year"]` exact order
- [x] Inspector idempotency helpers (`_index_exists` / `_is_index_unique` / `_constraint_exists`)
- [x] Step 1 conditional drop (only if currently UNIQUE — partial state re-run safety)
- [x] Downgrade COUNT-before-drop_constraint
- [x] Downgrade raises RuntimeError với ONE-WAY + snapshot + Manual cleanup keywords
- [x] Downgrade safe-path recreates UNIQUE on lead_id when 0 multi-profile leads
- [x] **Cross-source anchor #1**: model `__table_args__` carries composite UniqueConstraint `uq_admission_profile_lead_year` on `(lead_id, academic_year)`
- [x] **Cross-source anchor #2**: lead_id column `unique=True` removed (column-level)
- [x] Module sanity

### Live alembic on dev DB w/ prod data ✅

Per memory `solo-cutover-simple-data-import` — Wave 3 strict standard maintained:

- ✅ **Pre-flight**: 0 lead_id duplicates (9 unique leads = 9 profiles, 1:1) + 0 (lead_id, academic_year) duplicates → ZERO conflict risk.
- ✅ Upgrade `phase1_18 → phase1_15a` clean. Live DB confirms:
  - `ix_admission_profile_lead_id` UNIQUE → `btree (lead_id)` (plain)
  - `uq_admission_profile_lead_year UNIQUE CONSTRAINT, btree (lead_id, academic_year)` (new composite)
- ✅ Downgrade safe path (0 multi-profile leads) — legacy UNIQUE INDEX restored, composite removed.
- ✅ Re-upgrade idempotent (alembic_version stays `phase1_15a` head).
- ✅ **Defensive ONE-WAY guard verified live**: INSERT 2nd profile lead_id=23 year=2027 (allowed by composite) → `alembic downgrade -1` raises:
  ```
  RuntimeError: Cannot downgrade phase1_15a: 1 lead(s) in admission_profile
  hold >1 profile (multi-year semantics already in flight). This is a
  ONE-WAY migration — restore from a pre-Wave-3 snapshot instead of
  running `alembic downgrade`. Manual cleanup playbook: collapse multi-
  year profiles per lead before re-running this downgrade.
  ```

## 🎯 Phase 1 Schema 100% completion milestone (post-merge)

| Wave | Migrations | Status |
|---|---|---|
| Wave 1 | 8 | ✅ COMPLETE |
| Wave 2 | 2 | ✅ COMPLETE |
| Wave 3 | 4 + 1 FE | ✅ **COMPLETE post-merge (this PR)** |
| Wave 5 | 5 | ✅ COMPLETE |
| **Total** | **19/19 active migrations** | 🎯 **PHASE 1 SCHEMA 100% COMPLETE** |

## Wave 3 progress (5/5 sub-PR — 4 merged + 1 OPEN final)

- ✅ 3-A `55f3eb41` phase1_11 status CHECK 10→14 ⚠ (PR #219)
- ✅ 3-B `efc1b4f7` FE Stage 3 strict 14-state z.enum (PR #220)
- ✅ 3-C `51b2c1ae` phase1_12 backfill ⚠ (PR #221)
- ✅ 3-D `958435cf` phase1_18 token multi-action ⚠ (PR #222)
- 🟡 **3-E THIS PR** phase1_15a UNIQUE swap ⚠ (final → 100%)

## References

- PLAN line 3312-3346 (3-step DDL spec + composite UNIQUE business rule)
- PLAN line 3468-3473 (Wave 4 split rationale — phase1_15a DDL only, code in #15b)
- Memory `audit-before-fix` (live `\d` DB query + 0 duplicates pre-flight)
- Memory `verify-schema-before-proposing` (live convention catch)
- Memory `migration-predicate-safety` (idempotent + manual cleanup playbook)
- Memory `pattern-change-impact-audit` (model + 2 cross-source anchor tests)
- Memory `solo-cutover-simple-data-import` (live alembic dev DB w/ prod data + no soak)

## Path filter no-checks fallback expected

Files: alembic + model + test. None match workflow paths → no-checks fallback đúng SOP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
