### PR TITLE
[#184 Wave4-15b] feat(admission): Lead one-to-many model + repository + service + 5 caller migrate

### DIFF
--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -2460,8 +2460,19 @@ async def validate_status_transition(
     if not to_status:
         raise ResourceNotFoundError(f"Status {to_status_id} not found")
     
-    # 3. Derive lead phase from admission_profile
-    lead_phase = derive_phase_from_admission(lead.admission_profile).value
+    # 3. Derive lead phase from current-year admission_profile.
+    # Wave 4 #15b: replaces ``lead.admission_profile`` (singular relationship,
+    # removed) with the per-year helper. ``current_intake_year`` from
+    # ``system_config`` defaults to 2026 if the row is missing — matches
+    # the storefront default seeded by phase1_13.
+    from ..services.system_config_service import SystemConfigService
+    current_year = await SystemConfigService(db).get_value(
+        "current_intake_year", 2026
+    )
+    if isinstance(current_year, str):
+        current_year = int(current_year)
+    current_profile = lead.current_admission_profile(current_year)
+    lead_phase = derive_phase_from_admission(current_profile).value
     
     # 4. ✅ RULE #12: Validate transition using FSM engine
     is_allowed = await is_transition_allowed(

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -76,10 +76,12 @@ class AdmissionProfile(Base):
     # Wave 3-E (M-1-15a) DROPPED the single-profile-per-lead UNIQUE
     # in favor of composite ``uq_admission_profile_lead_year`` declared
     # above. Lead can now hold one profile PER academic_year. Wave 4
-    # PR #15b will flip ``Lead.admission_profile`` from
-    # ``uselist=False`` to plural ``admission_profiles`` paired with
-    # repository/service updates; until then the application contract
-    # remains 1-profile-per-lead via the composite constraint.
+    # Wave 4 PR #15b (M-1-15-model) flipped ``Lead.admission_profile``
+    # (singular ``uselist=False``) to ``Lead.admission_profiles``
+    # (plural list) — leads now hold one profile PER academic_year via
+    # the composite UNIQUE ``uq_admission_profile_lead_year`` declared
+    # in ``__table_args__`` above. The application contract is
+    # multi-year per lead.
     lead_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("lead.id", ondelete="CASCADE"),
@@ -473,7 +475,7 @@ class AdmissionProfile(Base):
     # Relationships (Eager Loading to Prevent N+1 Queries)
     lead: Mapped["Lead"] = relationship(
         "Lead",
-        back_populates="admission_profile",
+        back_populates="admission_profiles",
         lazy="joined",  # Always load lead (for IDOR checks)
         foreign_keys=[lead_id]
     )

--- a/Backend_FastAPI/app/models/lead.py
+++ b/Backend_FastAPI/app/models/lead.py
@@ -249,11 +249,32 @@ class Lead(Base):
     consultations = relationship(
         "Consultation", back_populates="lead", cascade="all, delete-orphan"
     )
-    admission_profile = relationship(
+    # Wave 4 #15b (M-1-15-model) — Lead one-to-many migration. Phase
+    # 1 #15a (PR #223 squash 15f52c8e) replaced legacy single-profile-
+    # per-lead UNIQUE on ``admission_profile.lead_id`` with composite
+    # ``(lead_id, academic_year)`` UNIQUE so a lead can apply across
+    # academic years. The relationship now flips from singular
+    # (``uselist=False`` + ``cascade="all, delete-orphan"``) to plural
+    # list (``uselist=True`` + ``cascade="save-update, merge"``).
+    #
+    # cascade change rationale (drop ``delete-orphan``):
+    # * delete-orphan triggers profile deletion when a profile is
+    #   detached from the parent's collection (e.g.
+    #   ``lead.admission_profiles.remove(p)``). With multi-year
+    #   profiles, list mutation is a routine operation; auto-delete
+    #   would lose audit-grade application records. Removal is now
+    #   explicit (``db.delete(profile)``) and follows the archive
+    #   lifecycle owned by ``archive_expired_rounds_task`` (PLAN line
+    #   195/562-571 — code-phase post-cutover).
+    # * Hard-delete cascade on Lead deletion still propagates via
+    #   ``ondelete="CASCADE"`` on ``AdmissionProfile.lead_id``
+    #   (admission.py:62-68) — ORM-level ``cascade="save-update,
+    #   merge"`` only governs session ops, not DB-level FK action.
+    admission_profiles = relationship(
         "AdmissionProfile",
         back_populates="lead",
-        uselist=False,
-        cascade="all, delete-orphan",
+        cascade="save-update, merge",
+        order_by="AdmissionProfile.academic_year.desc()",
     )
     interactions = relationship(
         "CRMInteraction", back_populates="lead", cascade="all, delete-orphan"
@@ -268,6 +289,37 @@ class Lead(Base):
     # Collaborator system
     referrer = relationship("Collaborator", back_populates="leads_referred")
     claims = relationship("LeadClaim", back_populates="lead", cascade="all, delete-orphan")
+
+    def current_admission_profile(self, year: int) -> "AdmissionProfile | None":
+        """Return the lead's profile for ``year``, or None if none exists.
+
+        Wave 4 #15b helper — replaces the legacy ``lead.admission_profile``
+        singular access with explicit per-year resolution. Required after
+        the Wave 3-E composite UNIQUE swap (PR #223 squash ``15f52c8e``)
+        let leads carry one profile per academic year.
+
+        **Eager-load contract**: the caller MUST have eager-loaded
+        ``Lead.admission_profiles`` (e.g. ``selectinload(Lead.
+        admission_profiles)``) before invoking this helper — the
+        scan walks the in-memory collection without issuing a query.
+
+        **Archive fallback — TODO** (paired with ``ArchivedAdmissionProfile``
+        ORM + ``archive_expired_rounds_task`` cron):
+            PLAN line 124-131 P1 fix #6 v2.12 specs a 2-tier query
+            (active → archive fallback) so officers can resolve
+            historical profiles archived 6 months after round end_date.
+            Currently ``archive_expired_rounds_task`` is NOT shipped
+            (defer code-phase post-cutover per memory
+            ``notification-coverage-roadmap``); ``_archived_admission_
+            profile`` table stays empty during the cutover window, so
+            active-only return is functionally equivalent today. When
+            the cron + ORM ship, extend this helper with the archive
+            UNION query — signature already stable.
+        """
+        return next(
+            (p for p in self.admission_profiles if p.academic_year == year),
+            None,
+        )
 
     def __repr__(self):
         return f"<Lead {self.id}: {self.full_name}>"

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -12,9 +12,12 @@ Benefits:
 - Separates SQL from business logic
 """
 
+import logging
 from datetime import datetime
 from typing import List, Optional, Tuple
 import unicodedata
+
+log = logging.getLogger(__name__)
 
 from sqlalchemy import select, or_, and_, func, desc, asc, distinct
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -484,16 +487,77 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         lead_id: int
     ) -> Optional[models.AdmissionProfile]:
         """
-        Get admission profile by lead ID.
-        
+        DEPRECATED (Wave 4 #15b — Lead one-to-many migration).
+
+        Returns the lead's MOST RECENT profile (highest ``academic_year``)
+        for backward compatibility with callers that still expect a
+        single profile per lead. Wave 4 PR #15c FE migrate is on the
+        critical path to remove this method's call sites; new code MUST
+        use ``list_profiles_by_lead_id`` (multi-year) or
+        ``get_profile_by_lead_year`` (composite-UNIQUE-keyed lookup).
+
+        Logs a warning when the lead actually has >1 profile so the
+        ambiguity is visible during the migration window — silent
+        "return latest" would hide cases where the caller's expectation
+        of a single profile breaks.
+
         Args:
             lead_id: Lead ID
-            
+
         Returns:
-            AdmissionProfile or None
+            Latest AdmissionProfile by ``academic_year DESC`` (or None).
         """
-        stmt = select(models.AdmissionProfile).where(
-            models.AdmissionProfile.lead_id == lead_id
+        stmt = (
+            select(models.AdmissionProfile)
+            .where(models.AdmissionProfile.lead_id == lead_id)
+            .order_by(models.AdmissionProfile.academic_year.desc())
+        )
+        result = await self.db.execute(stmt)
+        rows = list(result.scalars().all())
+        if len(rows) > 1:
+            log.warning(
+                "get_profile_by_lead_id called on a lead with multiple "
+                "profiles; deprecated behavior returns the latest year. "
+                "Caller should migrate to list_profiles_by_lead_id or "
+                "get_profile_by_lead_year (Wave 4 #15b).",
+                extra={"lead_id": lead_id, "profile_count": len(rows)},
+            )
+        return rows[0] if rows else None
+
+    async def list_profiles_by_lead_id(
+        self,
+        lead_id: int,
+    ) -> list[models.AdmissionProfile]:
+        """Wave 4 #15b — multi-year list lookup.
+
+        Returns all profiles for a lead ordered ``academic_year DESC``
+        so the most recent year is first. Documents are eager-loaded
+        for callers that follow this query với fee/document checks.
+        """
+        stmt = (
+            select(models.AdmissionProfile)
+            .where(models.AdmissionProfile.lead_id == lead_id)
+            .order_by(models.AdmissionProfile.academic_year.desc())
+            .options(selectinload(models.AdmissionProfile.documents))
+        )
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_profile_by_lead_year(
+        self,
+        lead_id: int,
+        academic_year: int,
+    ) -> Optional[models.AdmissionProfile]:
+        """Wave 4 #15b — composite-UNIQUE-keyed single-profile lookup.
+
+        Hits the ``uq_admission_profile_lead_year`` UNIQUE shipped by
+        Wave 3-E ``phase1_15a`` (PR #223 squash 15f52c8e), so this
+        query returns at most one row by definition.
+        """
+        stmt = (
+            select(models.AdmissionProfile)
+            .where(models.AdmissionProfile.lead_id == lead_id)
+            .where(models.AdmissionProfile.academic_year == academic_year)
         )
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
@@ -518,7 +582,7 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             .where(models.Lead.id == lead_id)
             .options(
                 joinedload(models.Lead.offering),
-                selectinload(models.Lead.admission_profile),
+                selectinload(models.Lead.admission_profiles),
             )
         )
         result = await self.db.execute(stmt)

--- a/Backend_FastAPI/app/repositories/lead_repository.py
+++ b/Backend_FastAPI/app/repositories/lead_repository.py
@@ -86,7 +86,7 @@ class LeadRepository(BaseRepository[models.Lead]):
                 selectinload(models.Lead.assigned_officer),
                 selectinload(models.Lead.pipeline_stage),
                 selectinload(models.Lead.consultation_status).selectinload(models.ConsultationStatus.stage),
-                selectinload(models.Lead.admission_profile),
+                selectinload(models.Lead.admission_profiles),
                 # Collaborator referrer
                 selectinload(models.Lead.referrer),
                 # Collection relationships for timeline/insights
@@ -149,7 +149,7 @@ class LeadRepository(BaseRepository[models.Lead]):
                 selectinload(models.Lead.assigned_officer),
                 selectinload(models.Lead.pipeline_stage),
                 selectinload(models.Lead.consultation_status).selectinload(models.ConsultationStatus.stage),
-                selectinload(models.Lead.admission_profile),
+                selectinload(models.Lead.admission_profiles),
                 # Collaborator referrer
                 selectinload(models.Lead.referrer),
             )
@@ -457,7 +457,7 @@ class LeadRepository(BaseRepository[models.Lead]):
                 selectinload(models.Lead.unit),
                 selectinload(models.Lead.consultation_status).selectinload(models.ConsultationStatus.stage),
                 selectinload(models.Lead.pipeline_stage),
-                selectinload(models.Lead.admission_profile),
+                selectinload(models.Lead.admission_profiles),
                 # Collaborator referrer
                 selectinload(models.Lead.referrer),
             )

--- a/Backend_FastAPI/app/routers/admin/deleted_items.py
+++ b/Backend_FastAPI/app/routers/admin/deleted_items.py
@@ -240,7 +240,7 @@ async def restore_deleted_lead(
             selectinload(models.Lead.assigned_officer),
             selectinload(models.Lead.pipeline_stage),
             selectinload(models.Lead.consultation_status),
-            selectinload(models.Lead.admission_profile),
+            selectinload(models.Lead.admission_profiles),
         )
     )
     lead = result.scalar_one()

--- a/Backend_FastAPI/app/routers/pipeline.py
+++ b/Backend_FastAPI/app/routers/pipeline.py
@@ -124,14 +124,25 @@ async def get_allowed_next_statuses(
     lead_phase = "consultation"  # Default phase for new/consultation leads
 
     if lead_id:
-        # Get lead to derive phase
+        # Get lead to derive phase. Wave 4 #15b: relationship is plural
+        # (``admission_profiles``); resolve the current-intake-year profile
+        # via the helper before deriving phase.
+        from ..services.system_config_service import SystemConfigService
+
         lead = await db.get(
             models.Lead,
             lead_id,
-            options=[selectinload(models.Lead.admission_profile)]
+            options=[selectinload(models.Lead.admission_profiles)]
         )
-        if lead and lead.admission_profile:
-            lead_phase = derive_phase_from_admission(lead.admission_profile).value
+        if lead:
+            current_year = await SystemConfigService(db).get_value(
+                "current_intake_year", 2026
+            )
+            if isinstance(current_year, str):
+                current_year = int(current_year)
+            current_profile = lead.current_admission_profile(current_year)
+            if current_profile:
+                lead_phase = derive_phase_from_admission(current_profile).value
 
     # ✅ USE NEW FSM ENGINE (Spec v3.0 compliant)
     return await get_next_statuses_for_lead(

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -407,11 +407,44 @@ class Lead(LeadBase):
     assigned_officer: Optional[User] = None
     pipeline_stage: Optional[PipelineStage] = None
     consultation_status: Optional[ConsultationStatus] = None
-    admission_profile: Optional[AdmissionProfileShallow] = None
+    # Wave 4 #15b — multi-year list (post Wave 3-E composite UNIQUE swap).
+    # ``admission_profiles`` is the canonical plural shape; FE migrate
+    # consumes this in Wave 4 PR #15c. The legacy ``admission_profile``
+    # singular field below is auto-populated from the latest item for
+    # backward compatibility — deprecated, removed once FE migrate ships.
+    admission_profiles: List[AdmissionProfileShallow] = Field(
+        default_factory=list,
+        description=(
+            "Per-academic-year admission profiles, ordered most-recent "
+            "first. Wave 4 #15b plural shape."
+        ),
+    )
+    admission_profile: Optional[AdmissionProfileShallow] = Field(
+        default=None,
+        description=(
+            "DEPRECATED (Wave 4 #15b) — most-recent profile only. Kept "
+            "during the FE migrate window (Wave 4 PR #15c)."
+        ),
+    )
     # Collaborator referrer (nested)
     referrer: Optional[CollaboratorShallow] = None
 
     model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="after")
+    def _populate_legacy_admission_profile(self):
+        """Backward-compat: keep ``admission_profile`` (singular)
+        populated from the first item of ``admission_profiles`` so FE
+        clients that have not migrated to plural still see a profile.
+
+        Order is established by the SQLAlchemy relationship
+        ``order_by=academic_year.desc()`` so item 0 is the latest year.
+        FE migrate (Wave 4 PR #15c) will switch to consuming the plural
+        list directly; the legacy field is then removed.
+        """
+        if self.admission_profile is None and self.admission_profiles:
+            self.admission_profile = self.admission_profiles[0]
+        return self
 
 
 class LeadDetail(Lead):

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1149,6 +1149,7 @@ async def check_lead_level_admission_eligibility(
     current_user: models.User,
     *,
     check_role: bool = True,
+    academic_year: Optional[int] = None,
 ) -> LeadAdmissionEligibility:
     """Check 7 lead-level conditions for creating an admission profile.
 
@@ -1164,8 +1165,8 @@ async def check_lead_level_admission_eligibility(
       forbidden > already_has_profile > invalid_lead_status > missing_offering
       > no_consultation > consultation_missing_status > consultation_universal_status
 
-    Requires lead.admission_profile eager-loaded — uses __dict__.get() to avoid
-    lazy-load crash in async context.
+    Requires lead.admission_profiles eager-loaded (Wave 4 #15b plural) —
+    uses __dict__.get() to avoid lazy-load crash in async context.
     """
     # Role check (optional — skipped when caller already enforced IDOR at deps layer)
     if check_role:
@@ -1189,11 +1190,29 @@ async def check_lead_level_admission_eligibility(
     # matching the historical POST /admissions response.
 
     # 1. Already has profile (structural conflict)
-    if lead.__dict__.get("admission_profile") is not None:
+    #
+    # Wave 4 #15b — composite check: lead can hold one profile per
+    # academic_year (Wave 3-E composite UNIQUE), so blocking is now
+    # year-specific. Caller passes ``academic_year`` to scope the
+    # check; legacy callers (year=None) fall back to "any profile"
+    # semantic so the UX doesn't silently allow conflicting creates
+    # before the rest of the codebase is migrated.
+    profiles = lead.__dict__.get("admission_profiles") or []
+    has_conflict = (
+        any(p.academic_year == academic_year for p in profiles)
+        if academic_year is not None
+        else bool(profiles)
+    )
+    if has_conflict:
+        message = (
+            f"Lead này đã có hồ sơ tuyển sinh năm {academic_year}."
+            if academic_year is not None
+            else "Lead này đã có hồ sơ tuyển sinh."
+        )
         return LeadAdmissionEligibility(
             False,
             "already_has_profile",
-            "Lead này đã có hồ sơ tuyển sinh.",
+            message,
         )
 
     # 2. Missing offering (fixable first — historical precedence)
@@ -2470,8 +2489,13 @@ async def create_profile(
     # Checks: already_has_profile, invalid_lead_status, missing_offering,
     # no_consultation, consultation_missing_status, consultation_universal_status.
     # Role check skipped — IDOR enforced upstream by get_lead_for_user dep.
+    # Wave 4 #15b: pass academic_year so the composite (lead_id, academic_
+    # year) UNIQUE swap (PR #223 squash 15f52c8e) lets a lead create a new
+    # profile for a different year while still blocking duplicates within
+    # the same year. ``academic_year`` parameter on this function is
+    # Optional — None falls back to current_intake_year config below.
     eligibility = await check_lead_level_admission_eligibility(
-        db, lead, current_user, check_role=False
+        db, lead, current_user, check_role=False, academic_year=academic_year
     )
     if not eligibility.eligible:
         code = eligibility.blocker_code

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -4396,9 +4396,20 @@ async def _populate_lead_detail_fields(
 
     # Lazy import to avoid circular dependency (admission_service imports from lead indirectly)
     from app.services import admission_service
+    from app.services.system_config_service import SystemConfigService
+
+    # Wave 4 #15b: scope eligibility check to the current intake year so
+    # the UX hint matches the composite (lead_id, academic_year) UNIQUE
+    # rule. A lead with a profile for last year should still be allowed
+    # to create one for the current year.
+    current_year = await SystemConfigService(db).get_value(
+        "current_intake_year", 2026
+    )
+    if isinstance(current_year, str):
+        current_year = int(current_year)
 
     eligibility = await admission_service.check_lead_level_admission_eligibility(
-        db, lead, current_user, check_role=True
+        db, lead, current_user, check_role=True, academic_year=current_year
     )
 
     permissions = {"create_admission": eligibility.eligible}

--- a/Backend_FastAPI/tests/unit/test_wave4_15b_lead_one_to_many.py
+++ b/Backend_FastAPI/tests/unit/test_wave4_15b_lead_one_to_many.py
@@ -1,0 +1,269 @@
+"""Unit tests for #184 Wave 4 PR #15b — Lead one-to-many migration.
+
+Pure-text + import contract tests covering the model relationship flip,
+the helper, repository new methods, schema dual-response auto-populate,
+and the eligibility check composite-aware path.
+
+Live integration test (insert Lead + 2 profiles different years →
+both queryable + helper returns correct year + delete-orphan removed)
+is deferred to the staging clone D12-D14 batch.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. Lead model relationship flip
+# ---------------------------------------------------------------------------
+
+
+def test_lead_admission_profiles_relationship_is_plural() -> None:
+    """Wave 3-E composite UNIQUE shipped → relationship flipped to
+    plural list. The legacy ``admission_profile`` (singular) attribute
+    must not exist on the mapper."""
+    from app.models.lead import Lead
+
+    rels = set(Lead.__mapper__.relationships.keys())
+    assert "admission_profiles" in rels
+    assert "admission_profile" not in rels
+
+
+def test_lead_admission_profiles_uselist_true_no_delete_orphan() -> None:
+    """The relationship is plural (``uselist=True`` is implicit on a
+    list collection) and drops ``delete-orphan`` so removing an item
+    from the list does NOT auto-delete the profile row — Wave 4 spec
+    treats profile deletion as an explicit operation."""
+    from app.models.lead import Lead
+
+    rel = Lead.__mapper__.relationships["admission_profiles"]
+    assert rel.uselist is True
+    # ``rel.cascade`` is a CascadeOptions iterable of token strings.
+    cascade_set = set(rel.cascade)
+    assert "save-update" in cascade_set
+    assert "delete-orphan" not in cascade_set
+
+
+def test_lead_admission_profiles_ordered_by_academic_year_desc() -> None:
+    """Plural list is ordered most-recent first so deprecated callers
+    that read ``profiles[0]`` see the latest year — matches the
+    legacy "single profile = most recent" expectation."""
+    from app.models.lead import Lead
+
+    rel = Lead.__mapper__.relationships["admission_profiles"]
+    order_by_str = str(rel.order_by[0])
+    assert "academic_year" in order_by_str
+    assert "DESC" in order_by_str.upper()
+
+
+def test_admission_profile_back_populates_admission_profiles() -> None:
+    """Reverse relationship ``AdmissionProfile.lead`` must point at the
+    plural attribute; mismatch breaks SQLAlchemy session bookkeeping."""
+    from app.models.admission import AdmissionProfile
+
+    rel = AdmissionProfile.__mapper__.relationships["lead"]
+    assert rel.back_populates == "admission_profiles"
+
+
+# ---------------------------------------------------------------------------
+# 2. Lead.current_admission_profile() helper
+# ---------------------------------------------------------------------------
+
+
+def test_current_admission_profile_returns_match_when_year_present() -> None:
+    """Helper walks the in-memory ``admission_profiles`` collection
+    (caller eager-loads) and returns the one matching ``academic_year``."""
+    from app.models.lead import Lead
+
+    p2025 = SimpleNamespace(academic_year=2025, status="enrolled")
+    p2026 = SimpleNamespace(academic_year=2026, status="draft")
+    lead = Lead(id=1)
+    # Bypass SQLAlchemy collection setter (it expects ORM instances) — we
+    # only need the in-memory iteration semantic for the helper.
+    lead.__dict__["admission_profiles"] =[p2026, p2025]  # most-recent first per ORDER BY
+
+    assert lead.current_admission_profile(2025) is p2025
+    assert lead.current_admission_profile(2026) is p2026
+
+
+def test_current_admission_profile_returns_none_when_year_absent() -> None:
+    """No archive UNION fallback yet (TODO paired with
+    ``ArchivedAdmissionProfile`` ORM ship + cron). Active-only return
+    means a year not present in the loaded list yields None — caller
+    treats this as "no profile" until the cron starts archiving."""
+    from app.models.lead import Lead
+
+    p2025 = SimpleNamespace(academic_year=2025)
+    lead = Lead(id=1)
+    # Bypass SQLAlchemy collection setter (it expects ORM instances) — we
+    # only need the in-memory iteration semantic for the helper.
+    lead.__dict__["admission_profiles"] =[p2025]
+
+    assert lead.current_admission_profile(2026) is None
+
+
+def test_current_admission_profile_handles_empty_list() -> None:
+    from app.models.lead import Lead
+
+    lead = Lead(id=1)
+    # Bypass SQLAlchemy collection setter (it expects ORM instances) — we
+    # only need the in-memory iteration semantic for the helper.
+    lead.__dict__["admission_profiles"] =[]
+    assert lead.current_admission_profile(2026) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Repository new methods
+# ---------------------------------------------------------------------------
+
+
+def test_admission_repository_exposes_new_methods() -> None:
+    """New methods ship in Wave 4 #15b — older
+    ``get_profile_by_lead_id`` is deprecated but kept for migration."""
+    from app.repositories.admission_repository import AdmissionRepository
+
+    assert callable(getattr(AdmissionRepository, "list_profiles_by_lead_id", None))
+    assert callable(getattr(AdmissionRepository, "get_profile_by_lead_year", None))
+    # Legacy method still callable during deprecation window.
+    assert callable(getattr(AdmissionRepository, "get_profile_by_lead_id", None))
+
+
+def test_get_profile_by_lead_id_logs_warning_on_multiple_profiles() -> None:
+    """Deprecated method must surface a warning when a lead has >1
+    profile so the migration window's silent ambiguity is visible."""
+    import inspect
+
+    from app.repositories import admission_repository
+
+    src = inspect.getsource(admission_repository.AdmissionRepository.get_profile_by_lead_id)
+    assert "log.warning" in src
+    assert "list_profiles_by_lead_id" in src or "get_profile_by_lead_year" in src
+
+
+def test_get_profile_by_lead_year_uses_composite_unique_columns() -> None:
+    """Source must filter on both ``lead_id`` and ``academic_year``
+    so it hits the ``uq_admission_profile_lead_year`` UNIQUE shipped
+    by Wave 3-E ``phase1_15a``."""
+    import inspect
+
+    from app.repositories import admission_repository
+
+    src = inspect.getsource(admission_repository.AdmissionRepository.get_profile_by_lead_year)
+    assert "lead_id" in src
+    assert "academic_year" in src
+
+
+# ---------------------------------------------------------------------------
+# 4. Schema dual-response
+# ---------------------------------------------------------------------------
+
+
+def test_lead_schema_carries_both_singular_and_plural_fields() -> None:
+    """Backward compat: the FE may still consume ``admission_profile``
+    while migrating; both fields must serialize."""
+    from app.schemas.lead import Lead as LeadSchema
+
+    fields = LeadSchema.model_fields
+    assert "admission_profiles" in fields
+    assert "admission_profile" in fields
+
+
+def _minimal_lead_payload(**overrides) -> dict:
+    """Helper — build the minimum required fields for ``Lead`` schema
+    validation so the tests stay focused on the dual-response behavior
+    instead of stuffing irrelevant fields."""
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).isoformat()
+    payload = {
+        "id": 1,
+        "full_name": "Nguyễn Văn A",
+        "phone": "0900000000",
+        "source": "manual",
+        "status": "active",
+        "lead_score": 0,
+        "created_at": now,
+        "updated_at": now,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _minimal_profile_payload(**overrides) -> dict:
+    from datetime import datetime, timezone
+
+    payload = {
+        "id": 100,
+        "status": "draft",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "academic_year": 2026,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_lead_schema_validator_populates_legacy_singular_from_latest() -> None:
+    """The ``model_validator`` after-mode hook copies plural[0] into
+    the legacy singular field. Order matches SQLAlchemy
+    ``order_by=academic_year.desc()`` so plural[0] = most-recent year."""
+    from app.schemas.lead import Lead as LeadSchema
+
+    profile_2026 = _minimal_profile_payload(id=100, academic_year=2026)
+    profile_2025 = _minimal_profile_payload(
+        id=101, academic_year=2025, status="enrolled"
+    )
+
+    lead = LeadSchema.model_validate(
+        _minimal_lead_payload(admission_profiles=[profile_2026, profile_2025])
+    )
+    assert lead.admission_profile is not None
+    assert lead.admission_profile.id == 100
+
+
+def test_lead_schema_singular_stays_none_when_plural_empty() -> None:
+    from app.schemas.lead import Lead as LeadSchema
+
+    lead = LeadSchema.model_validate(
+        _minimal_lead_payload(admission_profiles=[])
+    )
+    assert lead.admission_profile is None
+    assert lead.admission_profiles == []
+
+
+# ---------------------------------------------------------------------------
+# 5. Eligibility check composite path
+# ---------------------------------------------------------------------------
+
+
+def test_eligibility_check_signature_accepts_optional_academic_year() -> None:
+    """The signature gained an ``academic_year`` keyword in Wave 4
+    #15b. Optional so legacy callers (no year) preserve the
+    "any profile = block" semantic."""
+    import inspect
+
+    from app.services.admission_service import (
+        check_lead_level_admission_eligibility,
+    )
+
+    sig = inspect.signature(check_lead_level_admission_eligibility)
+    assert "academic_year" in sig.parameters
+    assert sig.parameters["academic_year"].default is None
+
+
+def test_eligibility_check_uses_admission_profiles_plural() -> None:
+    """The body must read from ``admission_profiles`` (plural) — the
+    legacy ``admission_profile`` (singular) attribute is gone."""
+    import inspect
+
+    from app.services import admission_service
+
+    src = inspect.getsource(
+        admission_service.check_lead_level_admission_eligibility
+    )
+    assert "admission_profiles" in src
+    # Legacy access pattern must be removed (would always return None
+    # post-Wave-4 since the singular relationship is gone).
+    assert 'lead.__dict__.get("admission_profile")' not in src


### PR DESCRIPTION
## Scope — Wave 4 first sub-PR (no Alembic, builds on Wave 3-E `phase1_15a` UNIQUE swap)

Flips `Lead.admission_profile` (singular `uselist=False` + `cascade="all, delete-orphan"`) to `Lead.admission_profiles` (plural list + `cascade="save-update, merge"`) per PLAN line 3312-3346 + memory `184-phase1-schema-wave-plan` line 47-49 Wave 4 split.

Built on top of Phase 1 Schema 100% baseline (post-Wave-3-E `15f52c8e`) — composite UNIQUE `(lead_id, academic_year)` enforces business rule "1 profile per (lead, year)".

## Decisions

- **Narrow Option B chốt 2026-05-05**: `Lead.current_admission_profile(year)` helper ships **active-only query** + explicit TODO for archive UNION fallback. Pure functional equivalent during cutover window — `archive_expired_rounds_task` cron không shipped yet (defer code-phase post-cutover); `_archived_admission_profile` table empty → active-only return matches PLAN line 124-131 P1 fix #6 spec when archive empty.
- **Cascade `"all, delete-orphan"` → `"save-update, merge"`**: drops orphan auto-delete (multi-year profiles per lead → list mutation routine; auto-delete would lose audit-grade records). DB-level FK `ON DELETE CASCADE` still propagates Lead deletion. Explicit `db.delete(profile)` is the new contract.
- **Schema dual response**: legacy `admission_profile` (singular) auto-populated from `admission_profiles[0]` (latest year per ORDER BY) for FE backward compat — Wave 4 PR #15c removes legacy field after FE migrate ships.

## 11 file edits (paired migration boundary)

| Layer | Files |
|---|---|
| Model (2) | `lead.py` (relationship flip + helper + 19-line cascade rationale) + `admission.py` (back_populates plural) |
| Repository (2) | `admission_repository.py` (deprecate `get_profile_by_lead_id` + add `list_profiles_by_lead_id` + `get_profile_by_lead_year`) + `lead_repository.py` (3 selectinload renames) |
| Service (2) | `admission_service.py` (eligibility composite-aware `academic_year` keyword) + `lead_service.py` (current_year fetch via SystemConfig) |
| Schema (1) | `schemas/lead.py` (dual response + model_validator auto-populate legacy) |
| Callers (3) | `deps.py` (helper migrate) + `pipeline.py` (selectinload + helper migrate) + `admin/deleted_items.py` (selectinload rename) |
| Tests (1) | `test_wave4_15b_lead_one_to_many.py` (15 cases) |

## Test plan — 15/15 unit + 79/79 regression PASS

### Wave 4 #15b unit (15/15)
- [x] Lead model: relationship plural + uselist=True + cascade no delete-orphan + ORDER BY academic_year DESC
- [x] AdmissionProfile back_populates points to plural
- [x] Helper `current_admission_profile(year)`: returns match / None / handles empty list (3 cases)
- [x] Repository: new methods exposed + deprecation warning when >1 profile + composite UNIQUE columns
- [x] Schema dual response: both fields + validator populates legacy from plural[0] + None when empty
- [x] Eligibility check: signature gains `academic_year` keyword + body uses `admission_profiles` plural

### Regression — 79/79 (Wave 3 + Wave 4 combined)
All Wave 3 migration tests still pass: phase1_11 (15) + phase1_12 (15) + phase1_15a (16) + phase1_18 (18) + Wave 4 (15) = 79.

## Cascade change rationale (per Lead model line 254-272)

19-line comment documents:
- WHY drop `delete-orphan` (multi-year profiles → unintended cascade if list mutated)
- WHEN profile deletion still works (explicit `db.delete(profile)` + commit)
- WHAT preserves on Lead deletion (FK `ON DELETE CASCADE` at DB level via `admission.py:62-68`)

## Wave 4 progress (1/2 PRs)

- 🟡 **Wave 4 PR #15b THIS PR** — model + repo + service + 5 caller migrate
- ⏳ Wave 4 PR #15c — FE migrate `admission_profile` singular → `admission_profiles` plural
- ⏳ Wave 6 PR #17 — public storefront refactor

## References

- PLAN line 3312-3346 (Lead one-to-many spec + 3-step migration breakdown)
- PLAN line 124-131 P1 fix #6 v2.12 (helper UNION query — TODO defer)
- Memory `solo-developer` (narrow scope)
- Memory `solo-cutover-simple-data-import` (live test on dev DB w/ prod data)
- Memory `pattern-change-impact-audit` (cascade rationale + 5-caller migrate)
- Memory `184-phase1-schema-wave-plan` line 47-49 (Wave 4 split)

## Path filter

Files include `services/admission_service.py` + `services/lead_service.py` — workflow `admission-contract-check.yml` path filter likely **TRIGGERS** for these paths (not no-checks fallback). Will run AST lint + notification event coverage. Should pass since:
- No new SystemEvents added
- No direct `profile.status = '...'` writes added (composite check uses `admission_profiles` iteration, not direct status mutation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
