### PR TITLE
[#184 Wave4-15c] feat(fe): migrate admission_profile singular → admission_profiles plural

### DIFF
--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
@@ -116,6 +116,12 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
   const { data: insights } = useLeadInsights(leadId, { initialData: initialInsights });
   const { data: workflowContext } = useWorkflowContext(leadId);
 
+  // Wave 4 #15c — read from plural ``admission_profiles[0]`` (latest year
+  // per backend ``order_by=academic_year.desc()``). Falls back to legacy
+  // ``admission_profile`` while the backend still emits the dual response.
+  // Drop fallback in #15d once the legacy field is removed.
+  const currentProfile = lead?.admission_profiles?.[0] ?? lead?.admission_profile;
+
   // Delete mutation
   const deleteMutation = useDeleteLead();
 
@@ -308,11 +314,11 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
           {/* Right: Actions */}
           <div className="flex items-center gap-2">
             {lead.offering_id && (
-              lead.admission_profile ? (
+              currentProfile ? (
                 <Button
                   variant="default"
                   className="bg-indigo-600 hover:bg-indigo-700 rounded-xl shadow-lg shadow-indigo-200"
-                  onClick={() => router.push(`/admissions/${lead.admission_profile!.id}`)}
+                  onClick={() => router.push(`/admissions/${currentProfile.id}`)}
                 >
                   <FileText className="mr-1.5 h-4 w-4" />
                   Xem hồ sơ tuyển sinh
@@ -384,7 +390,7 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
               onAssign={() => setAssignDialogOpen(true)}
               onCreateProfile={() => router.push(`/admissions/create?lead_id=${leadId}`)}
               onViewProfile={() =>
-                lead.admission_profile && router.push(`/admissions/${lead.admission_profile.id}`)
+                currentProfile && router.push(`/admissions/${currentProfile.id}`)
               }
             />
 
@@ -400,7 +406,7 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
               lead={lead}
               onCreateProfile={() => router.push(`/admissions/create?lead_id=${leadId}`)}
               onViewProfile={() =>
-                lead.admission_profile && router.push(`/admissions/${lead.admission_profile.id}`)
+                currentProfile && router.push(`/admissions/${currentProfile.id}`)
               }
             />
           </div>

--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadInfoTabs.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadInfoTabs.tsx
@@ -476,30 +476,37 @@ export function LeadInfoTabs({
         {/* Profile Tab */}
         {activeTab === "profile" && (
           <div>
-            {lead.admission_profile ? (
+            {(() => {
+              // Wave 4 #15c — read from plural ``admission_profiles[0]``
+              // (latest year per backend ``order_by=academic_year.desc()``).
+              // Falls back to legacy ``admission_profile`` while the backend
+              // still emits the dual response. Drop fallback in #15d.
+              const profile =
+                lead.admission_profiles?.[0] ?? lead.admission_profile;
+              return profile ? (
               <div className="space-y-4">
                 {(() => {
-                  const profileStyle = getProfileStatusStyle(lead.admission_profile.status);
+                  const profileStyle = getProfileStatusStyle(profile.status);
                   return (
                     <div className={cn("p-4 border rounded-xl", profileStyle.bg, profileStyle.border)}>
                       <div className="flex items-center gap-2 mb-2">
                         <FileText className={cn("w-4 h-4", profileStyle.icon)} />
                         <span className={cn("text-sm font-semibold", profileStyle.value)}>
-                          Hồ sơ tuyển sinh #{lead.admission_profile.id}
+                          Hồ sơ tuyển sinh #{profile.id}
                         </span>
                       </div>
                       <div className="grid grid-cols-2 gap-2 text-sm">
                         <div>
                           <span className={profileStyle.label}>Trạng thái:</span>{" "}
                           <span className={cn("font-medium", profileStyle.value)}>
-                            {PROFILE_STATUS_LABELS[lead.admission_profile.status] ?? lead.admission_profile.status}
+                            {PROFILE_STATUS_LABELS[profile.status] ?? profile.status}
                           </span>
                         </div>
-                        {lead.admission_profile.student_code && (
+                        {profile.student_code && (
                           <div>
                             <span className={profileStyle.label}>Mã SV:</span>{" "}
                             <span className={cn("font-medium", profileStyle.value)}>
-                              {lead.admission_profile.student_code}
+                              {profile.student_code}
                             </span>
                           </div>
                         )}
@@ -528,7 +535,8 @@ export function LeadInfoTabs({
                   </Button>
                 )}
               </div>
-            )}
+            );
+            })()}
           </div>
         )}
 

--- a/frontend/src/components/leads/AdmissionReadinessChecklist.tsx
+++ b/frontend/src/components/leads/AdmissionReadinessChecklist.tsx
@@ -36,7 +36,10 @@ interface ChecklistItem {
 
 // Phase 1: Derive checklist from existing lead data
 function deriveAdmissionChecklist(lead: Lead): ChecklistItem[] {
-  const profile = lead.admission_profile;
+  // Wave 4 #15c — prefer plural list (latest year first) and fall back
+  // to legacy singular while the backend dual response still emits
+  // both. Drop fallback in #15d.
+  const profile = lead.admission_profiles?.[0] ?? lead.admission_profile;
   const profileStatus = profile?.status;
 
   return [
@@ -94,7 +97,7 @@ export function AdmissionReadinessChecklist({
   // Find next incomplete step
   const nextStep = checklist.find((item) => !item.completed);
 
-  const hasProfile = !!lead.admission_profile;
+  const hasProfile = !!(lead.admission_profiles?.[0] ?? lead.admission_profile);
   const hasOffering = !!lead.offering_id;
 
   return (

--- a/frontend/src/components/leads/AdmissionReadinessChecklist.wave4-15c.test.ts
+++ b/frontend/src/components/leads/AdmissionReadinessChecklist.wave4-15c.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for #184 Wave 4 PR #15c — FE migrate `admission_profile` →
+ * `admission_profiles` plural.
+ *
+ * The component reads the most-recent profile (latest year) from the
+ * plural list, falling back to the legacy singular field while the
+ * backend still emits the dual-response shape introduced by Wave 4
+ * PR #15b. Wave 4 PR #15d will remove the legacy field once all
+ * consumers migrate.
+ *
+ * Tests guard the dual-read pattern so a future regression that
+ * silently drops the plural read does not surface only after the
+ * backend removes the legacy field.
+ */
+import { describe, expect, it } from "vitest"
+
+import type { Lead, AdmissionProfileShallow } from "@/types/lead.types"
+
+// The pure derivation helper isn't exported, so we exercise it through
+// the component file's text. A non-tautological text-grep test is the
+// pragmatic way to catch a regression that re-introduces the singular
+// access pattern without paying the cost of mounting the React tree.
+import { readFileSync } from "fs"
+import path from "path"
+
+const COMPONENT_PATH = path.resolve(
+  __dirname,
+  "AdmissionReadinessChecklist.tsx",
+)
+const componentSource = readFileSync(COMPONENT_PATH, "utf-8")
+
+describe("AdmissionReadinessChecklist — Wave 4 #15c plural migrate", () => {
+  it("reads from admission_profiles plural with legacy fallback", () => {
+    // The dual-read pattern must keep both fields in scope. If a
+    // refactor drops the plural read, this guard surfaces it before
+    // the backend removes the singular field.
+    expect(componentSource).toContain("lead.admission_profiles?.[0]")
+    expect(componentSource).toContain("lead.admission_profile")
+    // Plural read MUST come first in the nullish-coalesce expression
+    // so the latest-year profile wins — legacy is fallback only.
+    const pluralIdx = componentSource.indexOf(
+      "lead.admission_profiles?.[0]",
+    )
+    const singularIdx = componentSource.indexOf(
+      "?? lead.admission_profile",
+    )
+    expect(pluralIdx).toBeGreaterThan(0)
+    expect(singularIdx).toBeGreaterThan(pluralIdx)
+  })
+})
+
+
+describe("Lead type — admission_profiles plural shape", () => {
+  it("type allows plural list with legacy singular fallback", () => {
+    const profile_2026: AdmissionProfileShallow = {
+      id: 100,
+      lead_id: 1,
+      status: "draft",
+      academic_year: 2026,
+    } as AdmissionProfileShallow
+
+    const lead_with_plural: Pick<Lead, "id" | "admission_profiles" | "admission_profile"> = {
+      id: 1,
+      admission_profiles: [profile_2026],
+    }
+    const lead_legacy_only: Pick<Lead, "id" | "admission_profiles" | "admission_profile"> = {
+      id: 1,
+      admission_profile: profile_2026,
+    }
+    const lead_both: Pick<Lead, "id" | "admission_profiles" | "admission_profile"> = {
+      id: 1,
+      admission_profiles: [profile_2026],
+      admission_profile: profile_2026,
+    }
+
+    // Type-check — runtime assertions are trivial; the ts compile
+    // catches the schema drift.
+    expect(lead_with_plural.admission_profiles?.[0]?.id).toBe(100)
+    expect(lead_legacy_only.admission_profile?.id).toBe(100)
+    expect(lead_both.admission_profiles?.[0]?.id).toBe(100)
+    expect(lead_both.admission_profile?.id).toBe(100)
+  })
+})

--- a/frontend/src/types/lead.types.ts
+++ b/frontend/src/types/lead.types.ts
@@ -126,6 +126,15 @@ export interface Lead {
   consultation_status?: ConsultationStatus | null;
   pipeline_stage?: PipelineStage | null;
   consultations?: Consultation[];
+  // Wave 4 #15c — multi-year list (post Wave 3-E composite UNIQUE swap).
+  // ``admission_profiles`` is the canonical plural shape; ordered most-recent
+  // first to match SQLAlchemy ``order_by=academic_year.desc()``. The legacy
+  // ``admission_profile`` singular field below is auto-populated from
+  // ``admission_profiles[0]`` by the backend ``LeadResponse`` validator —
+  // deprecated but kept during the FE migrate window. Wave 4 follow-up
+  // (#15d) removes the legacy field once all consumers read plural.
+  admission_profiles?: AdmissionProfileShallow[];
+  /** @deprecated Wave 4 #15c — read ``admission_profiles[0]`` instead. */
   admission_profile?: AdmissionProfileShallow | null;
 
   // Collaborator (CTV) fields


### PR DESCRIPTION
## Scope — Wave 4 second sub-PR (FE consumers migrate to plural)

Migrates 3 FE components reading từ `lead.admission_profile` (singular legacy) → `lead.admission_profiles[0]` (plural canonical) với fallback to legacy field while backend dual response từ Wave 4 #15b (squash `966d5f5f`) maintains backward compat.

## Dual-read pattern

```typescript
const profile = lead.admission_profiles?.[0] ?? lead.admission_profile;
```

- **Plural first** — forward-compat post-Wave-4-#15d when BE drops legacy field.
- **Legacy fallback** — backward-compat trong migration window (BE schema dual response từ #15b auto-populates singular).

3 components apply uniformly: `LeadDetailClient` + `LeadInfoTabs` + `AdmissionReadinessChecklist`.

## Type contract update

- `types/lead.types.ts`: `admission_profiles?: AdmissionProfileShallow[]` (plural canonical, comment narrates dual-response window + #15d removal trigger)
- `types/lead.types.ts`: `admission_profile` field marked `@deprecated` JSDoc — IDE warns devs reading legacy

## 5 file edits

| File | Pattern |
|---|---|
| `types/lead.types.ts` | Add plural field + @deprecated JSDoc on legacy |
| `LeadDetailClient.tsx` | Hoist `currentProfile` const → 4 callsites use it |
| `LeadInfoTabs.tsx` | IIFE wraps Profile tab conditional → 5 inline references via `profile` var |
| `AdmissionReadinessChecklist.tsx` | Inline dual-read at 2 sites (deriveAdmissionChecklist + hasProfile) |
| `AdmissionReadinessChecklist.wave4-15c.test.ts` (NEW) | 2 cases — drift guard text-grep + TS shape |

## Test

2/2 FE Vitest PASS:
- AdmissionReadinessChecklist drift guard (reads plural first với legacy fallback in correct order)
- Lead type shape (allows both plural list + legacy singular)

TS compile clean — only pre-existing `useAdmissionPaths.test.tsx:31` error (PR #207 root cause, **NOT** Wave 4 #15c).

## Wave 4 closure (post-merge)

| PR | Status | Squash |
|---|---|---|
| Wave 4 #15b BE Lead 1-many | ✅ MERGED | `966d5f5f` |
| Wave 4 #15c FE plural migrate | 🟡 THIS PR | TBD |

→ **Wave 4 COMPLETE** post-merge này. Phase 1 cutover prerequisites: Wave 1+2+3+5 ✅ + Wave 4 ✅ + Wave 6 (storefront) remaining.

Wave 4 #15d follow-up (post-soak): drop legacy `admission_profile` field từ BE schema dual response + types singular field. Possibly ship sau cutover.

## References

- PLAN line 3322-3331 (Lead 1-many FE consumer scope)
- Memory `solo-developer` (narrow scope, no soak per cold cutover)
- Memory `solo-cutover-simple-data-import` (legacy fallback preserved cho cutover safety — any deploy ordering works)
- Memory `pattern-change-impact-audit` (uniform dual-read pattern across 3 components)
- Memory `verify-schema-before-proposing` (BE LeadResponse validator confirmed shape)

## Path filter

Files: `types/*.ts` + `app/(dashboard)/leads/*.tsx` + `components/leads/*.tsx` + `*.test.ts` — none match workflow `admission-contract-check.yml` paths (services/admission* + notification* + events* + scripts/check_*). No-checks fallback expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
