### PR TITLE
[#184 Wave4-15b-hotfix] fix(admission): create_profile race-safe check year-aware (multi-year regression)

### DIFF
--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2480,10 +2480,35 @@ async def create_profile(
         # IF we trust the session sync. 
         # Better: Re-query specifically for existence check to be safe.
         
-        # Fresh idempotency check inside lock (race-safe — DB query)
-        existing_profile = await admission_repo.get_profile_by_lead_id(lead_id)
+        # Fresh idempotency check inside lock (race-safe — DB query).
+        #
+        # Wave 4 #15b hotfix: Wave 3-E composite UNIQUE
+        # (lead_id, academic_year) is the new uniqueness rule, so this
+        # race-safe check must scope to the target year. Using the
+        # deprecated ``get_profile_by_lead_id`` (which returns the latest
+        # year regardless) would falsely block creating a profile for
+        # year N+1 when the lead has a profile for year N. Scope to the
+        # requested ``academic_year`` (or current_intake_year fallback,
+        # mirroring eligibility check at line 2497) so multi-year
+        # creates work as intended by the composite UNIQUE swap.
+        race_check_year = academic_year
+        if race_check_year is None:
+            from app.services.system_config_service import SystemConfigService
+
+            cfg_year = await SystemConfigService(db).get_value(
+                "current_intake_year", 2026
+            )
+            race_check_year = (
+                int(cfg_year) if isinstance(cfg_year, str) else cfg_year
+            )
+        existing_profile = await admission_repo.get_profile_by_lead_year(
+            lead_id, race_check_year
+        )
         if existing_profile:
-             raise ConflictError(f"Lead {lead_id} already has an admission profile")
+            raise ConflictError(
+                f"Lead {lead_id} already has an admission profile for "
+                f"academic year {race_check_year}"
+            )
 
     # Lead-level eligibility gate (SINGLE SOURCE OF TRUTH shared with GET /leads/{id}).
     # Checks: already_has_profile, invalid_lead_status, missing_offering,

--- a/Backend_FastAPI/tests/unit/test_wave4_15b_hotfix_multiyear_race_check.py
+++ b/Backend_FastAPI/tests/unit/test_wave4_15b_hotfix_multiyear_race_check.py
@@ -1,0 +1,130 @@
+"""Unit tests for #184 Wave 4 #15b hotfix — race-safe idempotency check
+in ``create_profile()`` must scope to the target ``academic_year``.
+
+Background
+----------
+
+Wave 3-E ``phase1_15a`` (PR #223 squash ``15f52c8e``) replaced the
+single-profile-per-lead UNIQUE with composite ``(lead_id, academic_year)``
+UNIQUE. Wave 4 PR #15b (squash ``966d5f5f``) flipped the model to
+plural and updated the eligibility check, but **left the secondary
+race-safe DB check inside the redis lock using the deprecated
+``get_profile_by_lead_id`` method** that returns the latest year
+regardless. That secondary check would incorrectly block a lead that
+already has a profile for, say, 2025 from creating one for 2026.
+
+Hotfix
+------
+
+The check now uses ``get_profile_by_lead_year(lead_id, academic_year)``
+with ``academic_year`` resolved from the explicit parameter or the
+``current_intake_year`` system config (mirroring the eligibility check
+fallback at the same call site).
+
+Tests target the source surface (text grep + behavior expectations)
+because the full ``create_profile`` flow has a long dependency chain
+(redis lock + offering + path lookup + ...) that would dwarf the
+narrow hotfix surface in setup/mock complexity.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. Race-safe check uses year-aware repository method
+# ---------------------------------------------------------------------------
+
+
+def test_race_safe_check_calls_get_profile_by_lead_year_not_lead_id() -> None:
+    """The secondary race-safe DB query must hit the composite-UNIQUE-
+    keyed lookup so multi-year creates are not falsely rejected."""
+    from app.services import admission_service
+
+    src = inspect.getsource(admission_service.create_profile)
+
+    # Find the redis-lock block — race-safe check lives inside it.
+    lock_idx = src.index("acquire_redis_lock")
+    eligibility_idx = src.index("check_lead_level_admission_eligibility(")
+    race_block = src[lock_idx:eligibility_idx]
+
+    # Inside the lock block, the new method must be called with both
+    # lead_id and the resolved year.
+    assert "get_profile_by_lead_year(" in race_block, (
+        "race-safe check must call get_profile_by_lead_year (composite-"
+        "UNIQUE-keyed) — not the deprecated get_profile_by_lead_id"
+    )
+    # And the deprecated method must NOT be reachable from the lock
+    # block. (The repository class still exposes get_profile_by_lead_id
+    # as a deprecated wrapper for legacy callers; create_profile must
+    # not be one of them.)
+    assert "get_profile_by_lead_id(" not in race_block, (
+        "create_profile race-safe check still references the deprecated "
+        "get_profile_by_lead_id — Wave 4 #15b hotfix incomplete"
+    )
+
+
+def test_race_safe_check_falls_back_to_current_intake_year_when_year_none() -> None:
+    """Mirrors the eligibility-check fallback at line 2497: when a
+    caller omits ``academic_year``, both checks resolve the same
+    year via ``SystemConfigService.get_value("current_intake_year",
+    2026)`` so the two gates agree on which year is being scoped."""
+    from app.services import admission_service
+
+    src = inspect.getsource(admission_service.create_profile)
+    lock_idx = src.index("acquire_redis_lock")
+    eligibility_idx = src.index("check_lead_level_admission_eligibility(")
+    race_block = src[lock_idx:eligibility_idx]
+
+    # The fallback signature mirrors lead_service._populate_lead_detail_
+    # fields: SystemConfigService(db).get_value("current_intake_year",
+    # 2026) + int(...) coercion when the value comes back as a string.
+    assert "SystemConfigService" in race_block
+    assert '"current_intake_year"' in race_block
+    assert "2026" in race_block
+
+
+# ---------------------------------------------------------------------------
+# 2. Error message scoped to the year (operator UX)
+# ---------------------------------------------------------------------------
+
+
+def test_race_safe_conflict_message_scoped_to_year(monkeypatch) -> None:
+    """The ``ConflictError`` raised when a duplicate is detected must
+    name the academic year — operators reading the prod log shouldn't
+    have to guess whether it's a multi-year edge case or a same-year
+    duplicate. Mirrors the year-aware message the Wave 4 #15b
+    eligibility check now emits."""
+    from app.services import admission_service
+
+    src = inspect.getsource(admission_service.create_profile)
+    lock_idx = src.index("acquire_redis_lock")
+    eligibility_idx = src.index("check_lead_level_admission_eligibility(")
+    race_block = src[lock_idx:eligibility_idx]
+
+    # Both ``academic year`` and a year placeholder must appear in the
+    # raise statement after ``get_profile_by_lead_year``.
+    raise_idx = race_block.index("ConflictError(")
+    raise_block = race_block[raise_idx : raise_idx + 400]
+    assert "academic year" in raise_block.lower()
+    assert "{race_check_year}" in raise_block or "{year}" in raise_block, (
+        "ConflictError message must f-string the resolved year so prod "
+        "logs disambiguate same-year vs cross-year duplicate cases"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Repository contract — both methods present (deprecated + new)
+# ---------------------------------------------------------------------------
+
+
+def test_repository_exposes_both_methods_during_migration_window() -> None:
+    """The deprecated ``get_profile_by_lead_id`` stays callable for any
+    pre-Wave-4 caller still in flight; the new
+    ``get_profile_by_lead_year`` is the create-profile race-safe path."""
+    from app.repositories.admission_repository import AdmissionRepository
+
+    assert callable(getattr(AdmissionRepository, "get_profile_by_lead_id", None))
+    assert callable(getattr(AdmissionRepository, "get_profile_by_lead_year", None))


### PR DESCRIPTION
## P0 Hotfix — multi-year regression in `create_profile()` race-safe check

Wave 4 #15b (PR #224 squash `966d5f5f`) updated the eligibility gate at `create_profile():2497` to be year-aware via the new `academic_year` keyword, BUT left the secondary race-safe DB check inside the redis lock at line 2484 calling the deprecated `get_profile_by_lead_id` — which returns the **latest year regardless**.

Net effect: Wave 3-E composite UNIQUE `(lead_id, academic_year)` allowed multi-year creates at the DB layer, but `create_profile` would falsely raise `ConflictError` if the lead had any profile in any prior year.

## Repro

Lead 23 has `admission_profile (id=18, academic_year=2026, status=draft)`. Attempt POST `/api/admissions` `lead_id=23, academic_year=2027`:

| State | Result |
|---|---|
| Pre-hotfix | ❌ `ConflictError("Lead 23 already has an admission profile")` raised by redis-lock race check |
| Post-hotfix | ✅ Succeeds; new profile for `academic_year=2027`, composite UNIQUE enforces per-year invariant at DB |

## Fix

Replace the race-safe lookup with the composite-UNIQUE-keyed `get_profile_by_lead_year(lead_id, academic_year)`. When `academic_year` is None (legacy callers), resolve from `SystemConfigService.get_value("current_intake_year", 2026)` — mirrors the eligibility-check fallback at the same call site so the two gates always agree on the year being scoped.

Defensive `int()` coercion handles JSON-stored config values (str → int).

Error message scoped to the year so prod logs disambiguate same-year vs cross-year duplicate cases.

## Tests — 4 hotfix + 15 Wave 4 #15b regression (19/19 PASS)

### Hotfix (4)
- [x] race-safe check calls `get_profile_by_lead_year` — not deprecated `get_profile_by_lead_id`
- [x] Fallback resolves `current_intake_year` via SystemConfigService với 2026 default
- [x] ConflictError message f-strings the resolved year (operator UX)
- [x] Repository contract: both methods callable during migration window (deprecated + new)

### Regression (15)
All Wave 4 #15b tests still pass: relationship + helper + repository + schema + eligibility surfaces unchanged.

## Scope (single-concern PR)

This hotfix ships ONLY the bug fix — `Lead.last_terminal_admission_profile()` helper (per PLAN line 892, 903) deferred to a separate post-Wave-4 follow-up PR to maintain single-concern review clarity. Tracked as `M-1-15-helper` in memory `outstanding-debt`.

## Path filter expected: triggers

Files: `services/admission_service.py` → workflow `admission-contract-check.yml` matches → AST lint + notification event coverage CI runs (same as PR #224). Should pass: no new SystemEvents, no direct `profile.status = '...'` writes.

## Memory references

- `audit-before-fix`: bug surfaced via deeper review; confirmed live by reading `admission_service.py:2484-2486` source pre-fix
- `migration-predicate-safety`: hotfix ships before any post-Wave-4 traffic exercises the multi-year path on production
- `solo-cutover-simple-data-import`: hotfix verifiable on dev DB with prod data — same year=N profile + INSERT year=N+1 succeeds at DB after fix
- `pattern-change-impact-audit`: deprecated method's call sites audited — only `create_profile` race check used it; eligibility check already updated in #15b

## Sequence after hotfix merge

1. ✅ Hotfix merge (this PR)
2. ⏳ PLAN patch v2.13.2 (formal soak waiver per `solo-cutover-simple-data-import` memory pivot) — ship BEFORE PR #225 merge để avoid retroactive amendment
3. ⏳ PR #225 (Wave 4 #15c FE plural migrate) review + merge
4. ⏳ Wave 4 closure tracking commit (M-1-15-model + M-1-15-fe TESTED + Wave 4 COMPLETE banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
