### PR TITLE
[#184 Phase1-Hotfix-3] fix(admission): status_history runtime writer ALWAYS-WRITE — remove skip_audit gate per PLAN line 1098 mandate

### DIFF
--- a/Backend_FastAPI/app/services/admission_state_service.py
+++ b/Backend_FastAPI/app/services/admission_state_service.py
@@ -324,51 +324,60 @@ async def transition(
         for field_name, value in extra_fields.items():
             setattr(profile, field_name, value)
 
-    # 3.5. Status history audit row — Phase 1 PLAN line 1067 service
-    # contract: every status mutation MUST insert one row into
-    # ``admission_profile_status_history`` in the same transaction
-    # frame. This is independent of the legacy
-    # ``audit_service.log_status_change`` call below — that one
-    # writes generic ``entity_audit_log`` rows; this purpose-built
-    # table carries the 3-column role audit (legacy / actual /
-    # effective) Phase 3 RBAC trace consumes.
+    # 3.5. Status history audit row — Phase 1 PLAN line 1067 / 1098
+    # service contract: every status mutation MUST insert one row
+    # into ``admission_profile_status_history`` in the same
+    # transaction frame, with NO bypass. The override path's
+    # ``skip_audit=True`` semantics target the legacy
+    # ``entity_audit_log`` writer below (which would double-write
+    # alongside ``audit_service.log_changes``) — they do NOT
+    # extend to this purpose-built audit table.
     #
-    # Skipped only when ``skip_audit`` is set, mirroring the legacy
-    # audit's bypass semantics so callers that already record a
-    # richer status-change row (override path via
-    # ``audit_service.log_changes``) don't double-write.
-    if not skip_audit:
-        from ..models.admission_profile_status_history import (
-            AdmissionProfileStatusHistory,
-        )
+    # Phase1-Hotfix-3 (2026-05-07) — moved this writer outside
+    # ``if not skip_audit`` after ultrareview / Codex audit found
+    # that override transitions were silently skipping the row,
+    # leaving the 3-column role audit (legacy / actual / effective)
+    # incomplete for admin force-approve flows. The matching test
+    # ``test_transition_skip_audit_still_writes_status_history``
+    # locks this contract; ``override`` metadata flows through
+    # ``event_metadata`` so the row carries the override context.
+    from ..models.admission_profile_status_history import (
+        AdmissionProfileStatusHistory,
+    )
 
-        actor_fields = _resolve_status_history_actor(
-            actor=actor,
-            source=source,
-            profile_lead_id=profile.lead_id,
-        )
-        history_metadata: Dict[str, Any] = {"source": source}
-        if event_metadata:
-            # Caller-supplied audit context (e.g. ``override=True``,
-            # ``rejection_reason=…``). Stored separately from the
-            # ADMISSION_* dispatch payload so the audit row remains
-            # the single source of truth even if dispatch is skipped.
-            history_metadata.update(event_metadata)
+    actor_fields = _resolve_status_history_actor(
+        actor=actor,
+        source=source,
+        profile_lead_id=profile.lead_id,
+    )
+    history_metadata: Dict[str, Any] = {"source": source}
+    if event_metadata:
+        # Caller-supplied audit context (e.g. ``override=True``,
+        # ``rejection_reason=…``). Stored separately from the
+        # ADMISSION_* dispatch payload so the audit row remains the
+        # single source of truth even if dispatch is skipped or
+        # legacy entity_audit_log is bypassed via ``skip_audit``.
+        history_metadata.update(event_metadata)
 
-        db.add(
-            AdmissionProfileStatusHistory(
-                profile_id=profile.id,
-                from_status=old_status,
-                to_status=new_status,
-                transition_reason=reason,
-                occurred_at=now,
-                metadata_=history_metadata,
-                **actor_fields,
-            )
+    db.add(
+        AdmissionProfileStatusHistory(
+            profile_id=profile.id,
+            from_status=old_status,
+            to_status=new_status,
+            transition_reason=reason,
+            occurred_at=now,
+            metadata_=history_metadata,
+            **actor_fields,
         )
+    )
 
-    # 4. Audit log — single source of truth for status-change history,
-    # except when caller writes a richer log_changes row (override).
+    # 4. Audit log — legacy ``entity_audit_log`` sink. Override flows
+    # set ``skip_audit=True`` because ``audit_service.log_changes``
+    # already records a richer change-set row (status + version +
+    # override_reason + bypass_rules) and a second
+    # ``log_status_change`` would just be duplicate noise. The
+    # status_history writer above runs unconditionally per PLAN
+    # line 1098.
     if not skip_audit:
         from . import audit_service
         await audit_service.log_status_change(

--- a/Backend_FastAPI/tests/unit/test_status_history_runtime_writer.py
+++ b/Backend_FastAPI/tests/unit/test_status_history_runtime_writer.py
@@ -240,26 +240,77 @@ class TestTransitionWriterContract:
         assert history_row.effective_transition_role == "admin"
 
     @pytest.mark.asyncio
-    async def test_transition_skip_audit_skips_history_row(self):
-        """``skip_audit`` callers (e.g. override path that writes its
-        own ``audit_service.log_changes`` row) must NOT double-write
-        the status_history row either; otherwise the audit trail
-        contains both an ``override`` log_changes row and a generic
-        history row pointing at the same transition."""
+    async def test_transition_skip_audit_still_writes_status_history(self):
+        """Phase1-Hotfix-3 contract — ``skip_audit=True`` callers
+        (override path that already writes a richer
+        ``audit_service.log_changes`` row) MUST STILL stage the
+        purpose-built ``AdmissionProfileStatusHistory`` row per PLAN
+        line 1098 mandate ``"mọi endpoint đổi status MUST insert 1 row
+        vào status_history cùng transaction frame"``.
+
+        The override path's bypass intent targets ``entity_audit_log``
+        (legacy generic table) where a second log_status_change row
+        would duplicate the ``log_changes`` row. It does NOT extend
+        to the new 3-column role audit table — that table is the
+        single canonical source for transition-trail queries
+        regardless of which legacy sink the caller used.
+
+        Locks the corrected behavior; the previous test
+        ``test_transition_skip_audit_skips_history_row`` (deleted
+        2026-05-07) inverted this contract and would have allowed
+        admin override transitions to vanish from the new audit
+        table indefinitely."""
         db = _make_db()
-        profile = _profile()
+        profile = _profile(status="approved")
         await transition(
             db,
             profile,
-            "submitted",
+            "overridden",
             actor=_user(15, "admin"),
-            source="api",
+            reason="Admin force-approve",
+            source="override",
+            event_metadata={"override": True, "bypass_rules": True},
             skip_audit=True,
             skip_dispatch=True,
         )
-        # Zero ``db.add`` calls — neither history row nor anything
-        # else this code path stages.
-        assert db.add.call_count == 0
+        # Status_history row staged exactly once per transition,
+        # carrying the override context so admin audit queries can
+        # branch on it without joining the legacy log_changes row.
+        assert db.add.call_count == 1
+        history_row = db.add.call_args[0][0]
+        assert history_row.from_status == "approved"
+        assert history_row.to_status == "overridden"
+        assert history_row.transition_reason == "Admin force-approve"
+        assert history_row.metadata_["override"] is True
+        assert history_row.metadata_["bypass_rules"] is True
+        assert history_row.metadata_["source"] == "override"
+
+    @pytest.mark.asyncio
+    async def test_transition_skip_audit_skips_legacy_entity_audit(self):
+        """Companion to the above — ``skip_audit=True`` MUST still
+        bypass the legacy ``audit_service.log_status_change`` call
+        (which is the original bypass target). Status_history runs
+        regardless; entity_audit_log skips per the override path's
+        coordination with ``log_changes``."""
+        db = _make_db()
+        profile = _profile(status="approved")
+        with patch(
+            "app.services.audit_service.log_status_change",
+            new_callable=AsyncMock,
+        ) as mock_legacy:
+            await transition(
+                db,
+                profile,
+                "overridden",
+                actor=_user(15, "admin"),
+                source="override",
+                skip_audit=True,
+                skip_dispatch=True,
+            )
+        # Legacy entity_audit_log writer NOT called when skip_audit=True.
+        mock_legacy.assert_not_called()
+        # But status_history still staged (locked above).
+        assert db.add.call_count == 1
 
     @pytest.mark.asyncio
     async def test_transition_metadata_includes_source(self):


### PR DESCRIPTION
## Scope — P0 deploy blocker per Codex audit follow-up 2026-05-07

PLAN line 1098 mandate: \"mọi endpoint đổi AdmissionProfile.status MUST insert 1 row vào status_history cùng transaction frame\".

PR #228 hotfix shipped status_history writer wrapped in \`if not skip_audit:\` gate, sharing the same bypass with legacy \`audit_service.log_status_change\`. Override path (admin force-approve T7 via \`admission_service.py:6425\` \`state_transition(... skip_audit=True)\`) skipped BOTH writers, leaving the new 3-column role audit table empty for those transitions.

## Bug evidence

* \`admission_state_service.py:340\` (pre-hotfix): status_history INSERT inside \`if not skip_audit:\` block.
* \`admission_service.py:6425\`: override flow calls \`state_transition(... skip_audit=True)\`.
* Test \`test_transition_skip_audit_skips_history_row\` actively LOCKED the wrong contract — would have prevented future fix.
* PR #228 review missed this via memory \`audit-before-fix\` failure: did not trace all callers of pattern-changed function.

## Fix

### \`app/services/admission_state_service.py\` (-91/+91)

* Move \`db.add(AdmissionProfileStatusHistory(...))\` outside \`if not skip_audit:\` block.
* status_history runs unconditionally per PLAN line 1098.
* Legacy \`entity_audit_log\` writer remains caller-bypassable (avoids double-write với \`audit_service.log_changes\`).
* Comments updated to differentiate the 2 sinks và their respective bypass semantics.

### \`tests/unit/test_status_history_runtime_writer.py\` (-53/+75)

* DELETED \`test_transition_skip_audit_skips_history_row\` — locked inverted contract.
* ADDED \`test_transition_skip_audit_still_writes_status_history\` — locks corrected contract (override path stages row + carries metadata).
* ADDED \`test_transition_skip_audit_skips_legacy_entity_audit\` — companion lock confirming entity_audit_log IS still bypassed.

## Test plan

- [x] **19/19 unit tests PASS** (vs 17/17 pre-fix; net +2 correct contract locks)
- [x] **52/52 regression PASS** adjacent (status_history runtime 19 + state service event mapping 10 + parity 24)
- [x] **Live integration verify dev DB**:
  - Pre history count: 1
  - 3 transitions chain: draft → submitted → approved → overridden (skip_audit=True)
  - Post: 4 rows (delta +3 — every transition wrote a row including override)
  - Override row id=27: from='approved' to='overridden' role='admin' metadata=\`{override: true, bypass_rules: true}\`
  - Legacy entity_audit_log: 2 entries (override correctly skipped per skip_audit=True)
  - Rolled back; dev state restored
- [ ] CI green (admission-contract-check path filter triggers via \`services/admission*.py\`)
- [ ] Codex review approval

## Backward compat

* Override path's \`log_changes\` row continues recording richer change-set (status + version + override_reason + bypass_rules) — this hotfix does NOT touch that flow.
* Status_history row carries override metadata via \`event_metadata\` so consumers branch on \`metadata_->>'override' = 'true'\` without joining log_changes.
* No schema migration needed.

## Cutover impact

P0-1 from NO-GO verdict resolved. Remaining cutover blockers per closure plan:
* P0-2 deploy.sh routine vs RUNBOOK §7.2 cold cutover (next hotfix branch)
* P0-3 deploy.yml notification coverage --allow-deferred missing (bundled với P0-2)
* P0-4 RUNBOOK §10 Go gate vs DAILY_LOG waiver drift (cleanup commit)

## References

* PLAN line 1098 service contract verbatim mandate
* Codex audit 2026-05-07 NO-GO verdict P0-1
* Memory \`audit-before-fix\` + \`pattern-change-impact-audit\` lessons applied
* Live integration evidence dev DB profile 14 rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)