### PR TITLE
[#184 Phase1-Hotfix-4] fix(deploy): cold-cutover-aware deploy path — deploy.yml --allow-deferred + deploy.sh COLD_CUTOVER env-flag-gated manual mode (P0-2 + P0-3)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,18 @@ jobs:
       # ---------------------------------------------------------------------
       - name: Backend — Notification event coverage
         working-directory: Backend_FastAPI
-        run: python -m app.scripts.check_notification_event_coverage
+        # Phase1-Hotfix-4 (2026-05-07) — added --allow-deferred to mirror
+        # the policy already shipped in admission-contract-check.yml. The
+        # 4 deferred events have no current legacy writer and are tracked
+        # in ``state_service.DEFERRED_ADMISSION_EVENTS``; without the
+        # flag this gate exits 1 cho mọi cutover-branch deploy attempt
+        # (12 events declared, 4 không reachable). When Phase 3 wires
+        # the writers, drop the corresponding name(s) from this flag —
+        # the lock test ``test_check_notification_event_coverage_deferred
+        # .py`` fails until the Python set is updated to match.
+        run: |
+          python -m app.scripts.check_notification_event_coverage \
+            --allow-deferred=ADMISSION_RESULT_PUBLISHED,ADMISSION_DECISION_WAITLISTED,ADMISSION_WAITLIST_PROMOTED,ADMISSION_ROLLED_BACK
 
       - name: Backend — Notification parity (unit)
         working-directory: Backend_FastAPI

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,7 +2,30 @@
 # =============================================================================
 # QLTS Production Deployment Script
 # =============================================================================
-# Usage: ./scripts/deploy.sh
+# Usage:
+#   Routine deploy (default):
+#     ./scripts/deploy.sh
+#
+#   Cold cutover (Phase 1 ship per RUNBOOK §7.2):
+#     COLD_CUTOVER=true ./scripts/deploy.sh
+#
+# Cold cutover semantics (Phase1-Hotfix-4 / 2026-05-07):
+#   * Skip Step 6 auto ``alembic upgrade head`` — operator runs manually
+#     for stream-log + per-step checkpoint per RUNBOOK §7.2 T+1:30.
+#   * Inject 3 entrypoint gate flags = false (RUN_MIGRATIONS_ON_STARTUP,
+#     RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP, RUN_CASBIN_LOAD_ON_STARTUP)
+#     so backend container starts without auto-running migration / sync /
+#     Casbin policy load — those steps run manually post-deploy per
+#     RUNBOOK §7.2 T+1:30 / T+3:00 / T+3:15 / T+3:30.
+#   * Operator MUST follow RUNBOOK §7.2 sequence after this script
+#     finishes Step 8 (container running but admin endpoints frozen via
+#     ADMISSION_FROZEN + nginx block); script does NOT auto-execute the
+#     manual cutover steps.
+#   * Defensive default: only exact lowercase ``true`` triggers cutover
+#     mode; any other value (TRUE/typo/unset) runs the routine flow.
+#
+# Routine deploy (COLD_CUTOVER unset or != "true"):
+#   Flow unchanged from pre-Hotfix-4 — auto migration + sync + restart.
 # =============================================================================
 set -euo pipefail
 
@@ -22,6 +45,30 @@ NC='\033[0m'
 log() { echo -e "${GREEN}[DEPLOY]${NC} $1"; }
 warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
+cutover() { echo -e "${YELLOW}[CUTOVER]${NC} $1"; }
+
+# ============================================================================
+# Cold cutover mode detection (Phase1-Hotfix-4 / 2026-05-07)
+# ============================================================================
+# Defensive parse — only exact lowercase ``true`` enables cutover mode.
+# RUNBOOK §7.2 + memory ``solo-cutover-simple-data-import`` rationale.
+COLD_CUTOVER="${COLD_CUTOVER:-false}"
+if [ "${COLD_CUTOVER}" = "true" ]; then
+    IS_CUTOVER=1
+    cutover "============================================="
+    cutover "COLD CUTOVER MODE ENABLED (per RUNBOOK §7.2)"
+    cutover "============================================="
+    cutover "* Step 6 auto-alembic: SKIP (operator runs manual)"
+    cutover "* Step 8 container env: 3 cutover flags = false"
+    cutover "* Operator MUST follow RUNBOOK §7.2 post-deploy:"
+    cutover "  - T+1:30 manual ``alembic upgrade head``"
+    cutover "  - T+3:00 manual backfill verify"
+    cutover "  - T+3:15 restart backend (Casbin reload)"
+    cutover "  - T+3:30 manual ``sync_notification_rules``"
+    cutover "============================================="
+else
+    IS_CUTOVER=0
+fi
 
 # =============================================================================
 # Step 1: Pre-flight checks
@@ -97,26 +144,37 @@ fi
 # =============================================================================
 log "Step 6/8: Starting infrastructure & running migrations..."
 
-# Start infra services first
+# Start infra services first (always — postgres + redis needed both modes)
 docker compose -f docker-compose.yml --profile production --env-file .env.production up -d postgres redis
 log "Waiting for PostgreSQL to be healthy..."
 sleep 5
 
-# Run Alembic migrations
-docker compose -f docker-compose.yml --profile production --env-file .env.production run --rm backend \
-    alembic upgrade head \
-    && log "Migrations completed successfully" \
-    || {
-        warn "Migration failed! Rolling back..."
-        if [ -f "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql" ]; then
-            docker compose -f docker-compose.yml --env-file .env.production exec -T postgres psql \
-                -U "${POSTGRES_USER:-qlts}" \
-                "${POSTGRES_DB:-qlts_production}" \
-                < "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql"
-            error "Migration failed. Database restored from backup."
-        fi
-        error "Migration failed. No backup available to restore."
-    }
+if [ "${IS_CUTOVER}" -eq 1 ]; then
+    # Cold cutover: skip auto-alembic. Operator runs ``alembic upgrade head``
+    # manually post-deploy per RUNBOOK §7.2 T+1:30 to stream log per
+    # migration step + checkpoint mid-flow. Auto-rollback path also
+    # disabled here because cutover scenario uses snapshot-restore (not
+    # in-place SQL replay) per RUNBOOK §8.1.
+    cutover "Step 6: SKIP auto-alembic (cutover mode)"
+    cutover "Operator runs manually post-deploy:"
+    cutover "  docker compose --profile production exec backend alembic upgrade head"
+else
+    # Routine deploy: auto-migrate with built-in rollback on failure.
+    docker compose -f docker-compose.yml --profile production --env-file .env.production run --rm backend \
+        alembic upgrade head \
+        && log "Migrations completed successfully" \
+        || {
+            warn "Migration failed! Rolling back..."
+            if [ -f "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql" ]; then
+                docker compose -f docker-compose.yml --env-file .env.production exec -T postgres psql \
+                    -U "${POSTGRES_USER:-qlts}" \
+                    "${POSTGRES_DB:-qlts_production}" \
+                    < "$BACKUP_DIR/pre_deploy_${TIMESTAMP}.sql"
+                error "Migration failed. Database restored from backup."
+            fi
+            error "Migration failed. No backup available to restore."
+        }
+fi
 
 # =============================================================================
 # Step 7: Pre-deploy checks (Casbin policies)
@@ -133,7 +191,20 @@ docker compose -f docker-compose.yml --profile production --env-file .env.produc
 # =============================================================================
 log "Step 8/8: Rolling restart..."
 
-# Start backend + celery
+if [ "${IS_CUTOVER}" -eq 1 ]; then
+    # Cold cutover: inject 3 entrypoint gate flags = false so backend
+    # container starts without auto-running migration / sync / Casbin
+    # policy load. Operator runs those steps manually per RUNBOOK §7.2.
+    # Defensive: explicit ``false`` lowercase per docker-entrypoint.sh
+    # parse contract (any other value = run as usual).
+    cutover "Step 8: Backend env: 3 cutover flags = false (operator manual sequence)"
+    export RUN_MIGRATIONS_ON_STARTUP="false"
+    export RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP="false"
+    export RUN_CASBIN_LOAD_ON_STARTUP="false"
+fi
+
+# Start backend + celery (env flags propagate via process env when cutover mode;
+# routine mode = unset → entrypoint defaults to ``true`` = auto-run as before)
 docker compose -f docker-compose.yml --profile production --env-file .env.production up -d \
     backend celery-worker celery-beat
 


### PR DESCRIPTION
## Scope — P0-2 + P0-3 deploy blockers per Codex audit 2026-05-07

### P0-2: deploy.sh routine flow vs RUNBOOK §7.2 cold cutover

deploy.sh auto-runs alembic + sync + Casbin via container entrypoint defaults. Bypasses RUNBOOK §7.2 cutover semantics (3 entrypoint flags off + manual per-step checkpoint).

### P0-3: deploy.yml notification coverage gate

\`deploy.yml:92\` calls \`check_notification_event_coverage\` WITHOUT \`--allow-deferred\`. Exits 1 on 4 Phase 3 deferred events. Cutover branch deploy CI fails before SSH/deploy.sh execution.

## Fix

### \`.github/workflows/deploy.yml\` (+13/-3)

Mirror policy already shipped in \`admission-contract-check.yml\`:

\`\`\`yaml
run: |
  python -m app.scripts.check_notification_event_coverage \
    --allow-deferred=ADMISSION_RESULT_PUBLISHED,ADMISSION_DECISION_WAITLISTED,ADMISSION_WAITLIST_PROMOTED,ADMISSION_ROLLED_BACK
\`\`\`

When Phase 3 wires the writers, drop the corresponding name(s) — lock test \`test_check_notification_event_coverage_deferred.py\` fails until Python set updated to match.

### \`scripts/deploy.sh\` (+88/-16) — Option 3-B

Detect \`COLD_CUTOVER=true\` early (defensive: only exact lowercase \`true\` triggers).

When cutover mode:
* **Step 6**: SKIP auto \`alembic upgrade head\`. Operator runs manually per RUNBOOK §7.2 T+1:30 (stream log + checkpoint per step). Auto-rollback path also disabled (cutover uses snapshot-restore per RUNBOOK §8.1).
* **Step 8**: Inject 3 entrypoint gate flags = false:
  - \`RUN_MIGRATIONS_ON_STARTUP=false\`
  - \`RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP=false\`
  - \`RUN_CASBIN_LOAD_ON_STARTUP=false\`

Operator follows RUNBOOK §7.2 manual sequence:
1. T+1:30: \`docker compose exec backend alembic upgrade head\`
2. T+3:00: backfill verify
3. T+3:15: \`docker compose restart backend\` (Casbin reload)
4. T+3:30: \`docker compose exec backend python -m app.scripts.sync_notification_rules\`

**Backward compat preserved**: routine deploy flow unchanged when flag unset/false.

## Test plan

- [x] \`bash -n scripts/deploy.sh\` syntax OK
- [x] Defensive parse:
  - \`COLD_CUTOVER=true\` → IS_CUTOVER=1 ✓
  - \`COLD_CUTOVER=TRUE\` → IS_CUTOVER=0 (defensive) ✓
  - unset → IS_CUTOVER=0 ✓
- [x] \`deploy.yml\` YAML parse OK
- [x] **59/59 regression PASS** (status_history runtime 19 + parity 24 + state mapping 10 + coverage deferred lock 7)
- [ ] CI green
- [ ] Codex review

## Cutover usage post-merge

Routine deploy (no change):
\`\`\`bash
./scripts/deploy.sh
\`\`\`

Cold cutover (Phase 1 ship per RUNBOOK §7.2):
\`\`\`bash
COLD_CUTOVER=true ./scripts/deploy.sh
\`\`\`

## Cutover impact

P0-2 + P0-3 from NO-GO verdict resolved. Remaining cutover blocker:
* P0-4 RUNBOOK §10 Go gate vs DAILY_LOG waiver drift (cleanup commit, post-merge)

Then Phase 6 Rehearsal #4 → Phase 7 Step A re-validate → Phase 7 Step B trigger.

## References

* \`Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md\` §7.2 cutover sequence + §8.1 rollback procedure
* \`Backend_FastAPI/docker-entrypoint.sh\` 3 gate flags contract
* \`.github/workflows/admission-contract-check.yml\` --allow-deferred policy precedent
* Memory \`deploy-guidance\` + \`solo-cutover-simple-data-import\` rationale
* Codex 2026-05-07 NO-GO verdict P0-2 + P0-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)