### PR TITLE
[#184 Phase1-Hotfix-5] fix(deploy): docker-compose env passthrough for 3 cutover gate flags

### DIFF
--- a/Documents/ADMISSION_REHEARSAL_LOG.md
+++ b/Documents/ADMISSION_REHEARSAL_LOG.md
@@ -169,6 +169,109 @@ Before issuing GREEN verdict on rehearsal:
 
 ---
 
+## Rehearsal 5 — 2026-05-07 16:35 (UTC+7) — POST Hotfix #5 deploy env propagation fix
+
+**Trigger**: Post-Hotfix-4 code review (memory `audit-before-fix` + `pattern-change-impact-audit`) surfaced a 5th P0 bug — `deploy.sh` Step 8 `export RUN_*=false` does NOT propagate into backend / celery-worker / celery-beat containers because `docker-compose.yml` `environment:` blocks did NOT reference these 3 keys, and `.env.production` did NOT define them. Compose only forwards env keys that are explicitly listed in `environment:` block OR present in `env_file`. Result: `COLD_CUTOVER=true ./scripts/deploy.sh` would silently launch containers with default `:-true` semantics → entrypoint auto-runs `alembic upgrade head` + `sync_notification_rules` + Casbin lifespan policy load before operator can run RUNBOOK §7.2 manual sequence. Hotfix #5 adds 3 env passthrough keys with safe `:-true` defaults to all 3 services.
+
+**Branch / commit**: `feature/admission-184-deploy-env-propagation-fix` off `feat/admission-full-cutover @ 04a1f292`. PR pending push approval per memory `push-approval-required`.
+
+### R5.0 — Celery scope verify
+
+`Backend_FastAPI/Dockerfile`:
+```
+56  ENTRYPOINT ["/app/docker-entrypoint.sh"]
+63  CMD ["gunicorn", "app.main:app", "-c", "gunicorn.conf.py"]
+```
+
+Compose `command:` overrides ONLY CMD, NOT ENTRYPOINT. Therefore:
+* `backend` (CMD = gunicorn) → entrypoint runs 3 gates → exec gunicorn ✓
+* `celery-worker` (command override = celery worker) → entrypoint runs 3 gates → exec celery worker ✓
+* `celery-beat` (command override = celery beat) → entrypoint runs 3 gates → exec celery beat ✓
+
+→ All 3 services need the 3 cutover flags. Scope confirmed.
+
+`docker-entrypoint.sh` 3 gate lines verified:
+* `13  if [ "${RUN_MIGRATIONS_ON_STARTUP:-true}" != "false" ]; then ...`
+* `25  if [ "${RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP:-true}" != "false" ]; then ...`
+* `42  if [ "${RUN_CASBIN_LOAD_ON_STARTUP:-true}" != "false" ]; then ...`
+
+### R5.1 — Routine flow substitution (env unset → defaults to "true")
+
+```
+$ docker compose -f docker-compose.yml --profile production --env-file .env.production config | grep -E "RUN_(MIGRATIONS|SYNC_NOTIFICATION|CASBIN)" | sort
+
+RUN_CASBIN_LOAD_ON_STARTUP: "true"
+RUN_CASBIN_LOAD_ON_STARTUP: "true"
+RUN_CASBIN_LOAD_ON_STARTUP: "true"
+RUN_MIGRATIONS_ON_STARTUP: "true"
+RUN_MIGRATIONS_ON_STARTUP: "true"
+RUN_MIGRATIONS_ON_STARTUP: "true"
+RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: "true"
+RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: "true"
+RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: "true"
+```
+
+→ 9 lines = 3 flags × 3 services. ALL `"true"` ⇒ routine deploy unchanged. Existing pre-Hotfix-4 flow preserved.
+
+### R5.2 — Cutover flow substitution (deploy.sh exports `false`)
+
+```
+$ RUN_MIGRATIONS_ON_STARTUP=false RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP=false RUN_CASBIN_LOAD_ON_STARTUP=false \
+    docker compose -f docker-compose.yml --profile production --env-file .env.production config \
+    | grep -E "RUN_(MIGRATIONS|SYNC_NOTIFICATION|CASBIN)" | sort
+
+RUN_CASBIN_LOAD_ON_STARTUP: "false"
+RUN_CASBIN_LOAD_ON_STARTUP: "false"
+RUN_CASBIN_LOAD_ON_STARTUP: "false"
+RUN_MIGRATIONS_ON_STARTUP: "false"
+RUN_MIGRATIONS_ON_STARTUP: "false"
+RUN_MIGRATIONS_ON_STARTUP: "false"
+RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: "false"
+RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: "false"
+RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: "false"
+```
+
+→ 9 lines = 3 flags × 3 services. ALL `"false"` ⇒ entrypoint skips alembic + sync + Casbin. Operator runs RUNBOOK §7.2 manual sequence (T+1:30 / T+3:00 / T+3:15 / T+3:30) without race condition with auto-startup.
+
+### R5.3 — Pre-fix bug reproduction (negative test)
+
+Pre-Hotfix-5 state (no `RUN_*` keys in `environment:` blocks):
+```
+$ RUN_MIGRATIONS_ON_STARTUP=false ... docker compose ... config | grep RUN_
+(empty)
+```
+→ Confirmed: deploy.sh `export` had NO PATH into the container. Compose silently dropped them.
+
+Post-Hotfix-5 fix verified above (R5.2). Bug closed.
+
+### R5.4 — YAML syntax + diff scope
+
+* `docker-compose.yml` parses cleanly via `docker compose config` (no validation errors).
+* Diff scope: 3 services × `environment:` block += 3 keys + comment block. Total +33 lines added. No keys removed, no key types changed. `volumes`, `depends_on`, `command`, `restart`, `deploy.resources`, `healthcheck`, `logging` all untouched.
+
+### Verdict: GREEN — env propagation now works end-to-end
+
+| Gate | Result |
+|---|---|
+| Celery scope verify (entrypoint inheritance) | ✅ All 3 services share entrypoint |
+| Routine flow preserved (defaults to "true") | ✅ R5.1 — 9/9 instances `"true"` |
+| Cutover flow propagation (exports → containers) | ✅ R5.2 — 9/9 instances `"false"` |
+| Pre-fix negative test (bug reproducible) | ✅ R5.3 — pre-fix grep empty |
+| YAML parse + diff scope review | ✅ R5.4 — 33 lines additive only |
+
+### Action
+
+**Phase 7 Step B trigger** STILL gated on user explicit signal per memory `push-approval-required` + user explicit gate "không deploy mà không có approval của tôi". Hotfix #5 ships the missing piece for COLD_CUTOVER mode to actually function as RUNBOOK §7.2 designs — but the deploy itself is operator-triggered.
+
+Pending sign-off:
+* Hotfix #5 PR push approval (per `push-approval-required` memory)
+* Hotfix #5 PR CI green
+* Hotfix #5 PR merge approval
+
+Then Phase 7 Step A re-validate (re-read backup tags + image tags) → user GO signal → Phase 7 Step B (cutover execution per RUNBOOK §7.2).
+
+---
+
 ## Rehearsal 4 — 2026-05-07 15:25 (UTC+7) — POST 4-HOTFIX ARC integration verify + cutover closure
 
 **Trigger**: NO-GO verdict 2026-05-07 surfaced 4 P0 blockers (status_history skip_audit override gap, deploy.sh routine vs RUNBOOK §7.2, deploy.yml --allow-deferred missing, RUNBOOK §10 Go gate waiver drift). 4 hotfix arc shipped via PR #229/#230/#231 + cleanup commit `0ccdaa5a`. Rehearsal #4 verifies all 4 fixes integrated end-to-end before Phase 7 Step B trigger.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,21 @@ services:
       REDIS_URL: redis://redis:6379/1
       CELERY_BROKER_URL: redis://redis:6379/2
       CELERY_RESULT_BACKEND_URL: redis://redis:6379/3
+      # Cold cutover gates per RUNBOOK §7.2 (Phase1-Hotfix-5 / 2026-05-07).
+      # Default ``true`` keeps routine deploy unchanged — entrypoint runs
+      # alembic + sync_notification_rules + Casbin lifespan auto. When
+      # ``COLD_CUTOVER=true ./scripts/deploy.sh`` is invoked, the deploy
+      # script ``export``s these = ``false`` and the substitution below
+      # propagates them into the container env so docker-entrypoint.sh
+      # skips the gates and operator runs the steps manually per
+      # RUNBOOK §7.2 T+1:30 / T+3:00 / T+3:15 / T+3:30 sequence.
+      # Without these substitution lines, deploy.sh ``export`` had no
+      # path into the container (compose only forwards keys explicitly
+      # listed here OR present in env_file). Found via Hotfix #4
+      # post-merge code review 2026-05-07.
+      RUN_MIGRATIONS_ON_STARTUP: ${RUN_MIGRATIONS_ON_STARTUP:-true}
+      RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: ${RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP:-true}
+      RUN_CASBIN_LOAD_ON_STARTUP: ${RUN_CASBIN_LOAD_ON_STARTUP:-true}
     volumes:
       - backend_uploads:/app/uploads
       - backend_static_uploads:/app/app/static/uploads
@@ -112,6 +127,16 @@ services:
       REDIS_URL: redis://redis:6379/1
       CELERY_BROKER_URL: redis://redis:6379/2
       CELERY_RESULT_BACKEND_URL: redis://redis:6379/3
+      # Cold cutover gates per RUNBOOK §7.2 (Phase1-Hotfix-5).
+      # Celery worker shares Backend_FastAPI/Dockerfile so the same
+      # docker-entrypoint.sh runs (compose ``command:`` only overrides
+      # CMD, NOT ENTRYPOINT). Without these, celery container would
+      # auto-run alembic + sync at startup even when backend's gates
+      # are set to false → race condition với operator's manual
+      # cutover sequence.
+      RUN_MIGRATIONS_ON_STARTUP: ${RUN_MIGRATIONS_ON_STARTUP:-true}
+      RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: ${RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP:-true}
+      RUN_CASBIN_LOAD_ON_STARTUP: ${RUN_CASBIN_LOAD_ON_STARTUP:-true}
     volumes:
       - backend_static_uploads:/app/app/static/uploads
       - backend_uploads:/app/uploads
@@ -141,6 +166,16 @@ services:
       REDIS_URL: redis://redis:6379/1
       CELERY_BROKER_URL: redis://redis:6379/2
       CELERY_RESULT_BACKEND_URL: redis://redis:6379/3
+      # Cold cutover gates per RUNBOOK §7.2 (Phase1-Hotfix-5).
+      # Celery beat shares Backend_FastAPI/Dockerfile so the same
+      # docker-entrypoint.sh runs (compose ``command:`` only overrides
+      # CMD, NOT ENTRYPOINT). Beat container also evaluates the 3 gates
+      # before exec — without these flags it auto-runs alembic + sync
+      # at startup independently of backend, breaking RUNBOOK §7.2
+      # operator-controlled sequence.
+      RUN_MIGRATIONS_ON_STARTUP: ${RUN_MIGRATIONS_ON_STARTUP:-true}
+      RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: ${RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP:-true}
+      RUN_CASBIN_LOAD_ON_STARTUP: ${RUN_CASBIN_LOAD_ON_STARTUP:-true}
     volumes:
       - backend_static_uploads:/app/app/static/uploads
       - backend_uploads:/app/uploads


### PR DESCRIPTION
## Summary

Fixes **5th P0 bug** discovered post Hotfix #4 merge: `scripts/deploy.sh:201-203` `export RUN_*=false` had **no path** into the backend / celery-worker / celery-beat containers because `docker-compose.yml` `environment:` blocks did NOT reference the 3 cutover gate keys, AND `.env.production` did NOT define them. Result: `COLD_CUTOVER=true ./scripts/deploy.sh` would silently launch containers with default `:-true` semantics → entrypoint auto-runs alembic + sync_notification_rules + Casbin lifespan policy load **before** operator can run RUNBOOK §7.2 manual sequence.

This commit closes the gap by adding 3 env passthrough keys to all 3 services (backend + celery-worker + celery-beat) with safe `:-true` defaults so:

- **Routine deploy** (env unset) → defaults to `"true"` → entrypoint auto-runs alembic + sync + Casbin (existing pre-Hotfix-4 flow preserved, no regression)
- **Cold cutover deploy** (`COLD_CUTOVER=true`) → `deploy.sh` exports `"false"` → compose substitution propagates to containers → entrypoint skips the gates → operator runs manual sequence per RUNBOOK §7.2 (T+1:30 / T+3:00 / T+3:15 / T+3:30)

## Celery scope verified

`Backend_FastAPI/Dockerfile:56` sets `ENTRYPOINT = /app/docker-entrypoint.sh` which is inherited by **ALL** containers built from this image. Compose `command:` only overrides CMD, NOT ENTRYPOINT — so celery-worker (command = `celery worker`) and celery-beat (command = `celery beat`) BOTH run docker-entrypoint.sh gates before exec. Without flags on celery containers, beat would auto-run alembic at startup independently of backend, breaking the RUNBOOK §7.2 operator-controlled sequence.

## Verification

Rehearsal #5 + Rehearsal #6 GREEN — substitution validated both modes:

```
$ docker compose --profile production --env-file .env.production config | grep RUN_

# Routine (env unset → ":-true")
RUN_CASBIN_LOAD_ON_STARTUP: "true"             [×3 services]
RUN_MIGRATIONS_ON_STARTUP: "true"              [×3 services]
RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: "true" [×3 services]
                                                = 9/9 "true" ✓

# Cutover (export RUN_*=false)
RUN_CASBIN_LOAD_ON_STARTUP: "false"             [×3 services]
RUN_MIGRATIONS_ON_STARTUP: "false"              [×3 services]
RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: "false" [×3 services]
                                                = 9/9 "false" ✓
```

V3 runtime test re-run (Rehearsal #6, 2026-05-07) full coverage:

| Phase | Result |
|---|---|
| P1 Unit + parity suite | ✅ 59/59 PASS |
| P2 §A Schema invariants | ✅ 23/23 PASS |
| P3 §B Runtime workflow (live HTTP) | ✅ 6/7 PASS + 1 pre-existing P3 logged |
| P4 §C Storefront filter | ✅ Structure OK (data backfill by-design Phase 3) |
| P5 §D Multi-year | ✅ Single-year functional |
| P6 §E Outbox dispatcher | ✅ 4 outbox + 5 in-memory |
| P7 §F RBAC matrix | ✅ Role boundaries intact (24 checks) |
| P8 §G Frontend HTTP | ✅ All routes 200 |
| P9 Hotfix #5 substitution re-validate | ✅ 9/9 routine + 9/9 cutover |

**No regressions from Hotfix #5.**

## Pre-cutover gate verifications

- **F4/F5 schema drift**: Backend `RejectRequest.reason` + `OverrideRequest.reason` `min_length=10`; FE `rejectRequestSchema` mirror `min(10)`. V3 §F sent `"F4"`/`"F5"` (2 chars) → 422 = test artifact. NOT bug.
- **RUNBOOK §7.2 applicable_to backfill**: By design Phase 3 deferred per `ADMISSION_REFACTOR_PLAN.md:355` (NULL OR-branch contract). Phase 1 ships schema only.

## Test plan

- [x] `bash -n scripts/deploy.sh` syntax OK
- [x] `docker compose --profile production config` resolves env both modes
- [x] V3 P1-P9 GREEN (Rehearsal #6)
- [ ] CI gate (path filter — config file outside services/admission* may trigger no-checks fallback per `admission-cutover-subpr-sop` SOP)
- [ ] User merge approval

## Files changed

- `docker-compose.yml` (+33 lines): 3 services × `environment:` += 3 cutover flags + comment per service
- `Documents/ADMISSION_REHEARSAL_LOG.md` (+103 lines): Rehearsal #5 entry (R5.0 celery scope + R5.1/R5.2/R5.3 substitution proof + R5.4 syntax + verdict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
