### PR TITLE
[#184 FU-batch] fix(admission): post-cutover follow-up batch — 5 items bundled (BUG_RESUBMIT + dep-audit + Lead helper + alembic doc + deploy.sh)

### DIFF
--- a/Backend_FastAPI/app/models/lead.py
+++ b/Backend_FastAPI/app/models/lead.py
@@ -321,6 +321,52 @@ class Lead(Base):
             None,
         )
 
+    @property
+    def last_terminal_admission_profile(self) -> "AdmissionProfile | None":
+        """Return the lead's most recent profile in a terminal state, or None.
+
+        Wave 4 #15b helper — companion to ``current_admission_profile(year)``.
+        Walks the in-memory ``admission_profiles`` collection and returns the
+        profile with the highest ``academic_year`` whose ``status`` is one of
+        the three truly terminal states from the candidate's perspective:
+
+        * ``enrolled`` — student row created, lifecycle complete
+        * ``rejected`` — final reject (NOTE: can transition to ``resubmitted``
+          but treated as terminal for "completed admissions" lookup until a
+          new submission cycle starts)
+        * ``withdrawn`` — candidate explicit cancellation
+
+        States like ``overridden`` and ``revision_requested`` are NOT
+        considered terminal because they imply an in-flight admin override
+        path or staff queue handoff that may transition further.
+
+        **Use cases**:
+        * Lead detail view — show "last admission outcome" badge
+        * Re-engagement / dedupe heuristic — if the lead has a terminal
+          ``enrolled`` profile, suppress new outreach
+        * KPI funnel — terminal counts for officer attribution
+
+        **Eager-load contract**: the caller MUST have eager-loaded
+        ``Lead.admission_profiles`` before invoking this helper — the scan
+        walks the in-memory collection without issuing a query. Mirror
+        ``current_admission_profile(year)`` contract.
+
+        **Archive fallback — TODO**: same caveat as
+        ``current_admission_profile`` — when ``archive_expired_rounds_task``
+        ships, extend this helper to UNION across active +
+        ``_archived_admission_profile`` so historical terminals stay
+        resolvable post-archive (PLAN line 124-131 P1 fix #6 v2.12).
+        Until then, archive table stays empty during the cutover window so
+        active-only is functionally equivalent.
+        """
+        terminal_states = {"enrolled", "rejected", "withdrawn"}
+        terminal_profiles = [
+            p for p in self.admission_profiles if p.status in terminal_states
+        ]
+        if not terminal_profiles:
+            return None
+        return max(terminal_profiles, key=lambda p: p.academic_year)
+
     def __repr__(self):
         return f"<Lead {self.id}: {self.full_name}>"
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -6264,7 +6264,7 @@ async def resubmit_profile(
         db=db,
         profile=profile,
         changed_by_user_id=officer.id,
-        reason=f"Profile resubmitted: {data.get('notes', 'No notes')[:50]}",
+        reason=f"Profile resubmitted: {(data.get('notes') or 'No notes')[:50]}",
     )
 
     await db.flush()

--- a/Backend_FastAPI/requirements.txt
+++ b/Backend_FastAPI/requirements.txt
@@ -49,7 +49,7 @@ idna==3.11
 Jinja2==3.1.6
 kombu==5.5.4
 limits==5.6.0
-Mako==1.3.10
+Mako==1.3.12
 Markdown==3.9
 MarkupSafe==3.0.3
 mergedeep==1.3.4
@@ -79,7 +79,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 python-engineio==4.12.3
 python-magic==0.4.27
-python-multipart==0.0.26
+python-multipart==0.0.27
 python-socketio==5.14.3
 pytokens==0.2.0
 pytz==2025.2

--- a/Backend_FastAPI/tests/unit/test_lead_last_terminal_admission_profile.py
+++ b/Backend_FastAPI/tests/unit/test_lead_last_terminal_admission_profile.py
@@ -1,0 +1,146 @@
+"""Unit tests for ``Lead.last_terminal_admission_profile`` helper (FU.5).
+
+Covers PLAN line 903 contract:
+* Returns most recent profile in truly terminal states
+  (enrolled / rejected / withdrawn)
+* Returns None if no terminal profiles
+* Picks highest ``academic_year`` when multiple terminals
+* Excludes non-terminal states (draft / submitted / approved / overridden
+  / revision_requested / reviewing / result_published / admitted /
+  waitlisted / resubmitted / confirmed)
+* Walks in-memory list without issuing query (eager-load contract)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _profile(status: str, year: int):
+    """Lightweight stub matching the attributes the helper reads."""
+    return SimpleNamespace(status=status, academic_year=year)
+
+
+def _last_terminal(profiles):
+    """Invoke ``Lead.last_terminal_admission_profile`` against an in-memory
+    profile list via the unbound property descriptor — bypasses SQLAlchemy
+    instance state machinery while exercising the live function logic."""
+    from app.models.lead import Lead
+
+    stub = type("LeadStub", (), {"admission_profiles": profiles})()
+    return Lead.last_terminal_admission_profile.fget(stub)
+
+
+# --- truly-terminal returns ---
+
+
+def test_enrolled_profile_returned():
+    result = _last_terminal([_profile("enrolled", 2026)])
+    assert result is not None
+    assert result.status == "enrolled"
+    assert result.academic_year == 2026
+
+
+def test_rejected_profile_returned():
+    result = _last_terminal([_profile("rejected", 2026)])
+    assert result is not None
+    assert result.status == "rejected"
+
+
+def test_withdrawn_profile_returned():
+    result = _last_terminal([_profile("withdrawn", 2026)])
+    assert result is not None
+    assert result.status == "withdrawn"
+
+
+# --- non-terminal exclusions ---
+
+
+@pytest.mark.parametrize(
+    "non_terminal_state",
+    [
+        "draft",
+        "submitted",
+        "approved",
+        "overridden",
+        "revision_requested",
+        "resubmitted",
+        "reviewing",
+        "result_published",
+        "admitted",
+        "waitlisted",
+        "confirmed",
+    ],
+)
+def test_non_terminal_state_excluded(non_terminal_state):
+    """States that may still transition further must NOT be treated as
+    terminal — caller wants 'completed admission' lookup."""
+    result = _last_terminal([_profile(non_terminal_state, 2026)])
+    assert result is None
+
+
+# --- empty + None semantics ---
+
+
+def test_empty_profiles_returns_none():
+    assert _last_terminal([]) is None
+
+
+# --- year selection — highest wins ---
+
+
+def test_picks_highest_year_when_multiple_terminals():
+    result = _last_terminal([
+        _profile("rejected", 2025),
+        _profile("enrolled", 2027),
+        _profile("withdrawn", 2026),
+    ])
+    assert result is not None
+    assert result.academic_year == 2027
+    assert result.status == "enrolled"
+
+
+def test_skips_non_terminal_picks_terminal_even_if_lower_year():
+    """Non-terminal at higher year does NOT prevent picking terminal at
+    lower year."""
+    result = _last_terminal([
+        _profile("submitted", 2027),  # higher year, not terminal
+        _profile("enrolled", 2026),   # lower year, terminal — should win
+    ])
+    assert result is not None
+    assert result.academic_year == 2026
+    assert result.status == "enrolled"
+
+
+# --- mixed shape ---
+
+
+def test_mixed_terminal_and_non_terminal_picks_highest_terminal():
+    result = _last_terminal([
+        _profile("draft", 2027),       # excluded
+        _profile("rejected", 2025),    # terminal but lower year
+        _profile("approved", 2026),    # excluded
+        _profile("withdrawn", 2026),   # terminal, picked (highest terminal year)
+    ])
+    assert result is not None
+    assert result.academic_year == 2026
+    assert result.status == "withdrawn"
+
+
+# --- contract docstring lock ---
+
+
+def test_helper_contract_locked():
+    """Anchor — fail if someone refactors the terminal-state set."""
+    import inspect
+    from app.models.lead import Lead
+
+    src = inspect.getsource(Lead.last_terminal_admission_profile.fget)
+    # All 3 truly terminal states must be locked in the helper
+    for terminal in ("enrolled", "rejected", "withdrawn"):
+        assert f'"{terminal}"' in src, (
+            f"Terminal state {terminal!r} must remain in "
+            f"Lead.last_terminal_admission_profile — see PLAN line 903"
+        )

--- a/Backend_FastAPI/tests/unit/test_resubmit_notes_none_regression.py
+++ b/Backend_FastAPI/tests/unit/test_resubmit_notes_none_regression.py
@@ -1,0 +1,105 @@
+"""Regression lock — `BUG_RESUBMIT_NOTES_NONE` (admission_service.py:6267).
+
+Pre-existing P3 bug surfaced via V3 runtime test Rehearsal #6 (2026-05-07):
+when a client POSTs `/api/admissions/{id}/resubmit` without a ``notes`` field
+(or with ``notes: null``), Pydantic's ``Optional[str] = None`` default makes
+``data['notes']`` resolve to ``None``. The previous expression
+
+    data.get('notes', 'No notes')[:50]
+
+returned ``None`` (not the default — ``.get`` returns the actual stored
+value if the key exists, regardless of value) and ``None[:50]`` raised
+``TypeError: 'NoneType' object is not subscriptable``, propagating as a
+500 to the client.
+
+Atomicity stayed intact (the outer transaction rolled back fully — no
+profile mutation, no status_history row), but the user-visible 500 was
+the bug.
+
+The fix is the truthy-coalesce form
+
+    (data.get('notes') or 'No notes')[:50]
+
+which handles four input shapes correctly:
+
+* missing key  ``{}`` → 'No notes'
+* explicit ``None`` ``{'notes': None}`` → 'No notes'
+* empty string ``{'notes': ''}`` → 'No notes'
+* real string  ``{'notes': 'foo'}`` → 'foo'
+
+The test below reads the *live* expression from
+``admission_service.resubmit_profile``'s source via ``inspect`` and
+exercises it, so a regression to the buggy ``.get(key, default)`` form
+will fail loudly here before reaching production again.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+
+from app.services import admission_service
+
+
+def _extract_reason_template() -> str:
+    """Pull the ``reason=f"Profile resubmitted: ..."`` line from the live
+    ``resubmit_profile`` function source."""
+    src = inspect.getsource(admission_service.resubmit_profile)
+    match = re.search(
+        r'reason=f"Profile resubmitted:\s*(\{.*?\})"',
+        src,
+    )
+    assert match, (
+        "Expected reason f-string in resubmit_profile not found — has the "
+        "function been refactored? Update this regression lock to match the "
+        "new shape."
+    )
+    return match.group(1)
+
+
+def _evaluate(expression: str, data: dict) -> str:
+    """Evaluate ``f"Profile resubmitted: {<expression>}"`` against ``data``
+    and return the resulting reason string."""
+    return eval(  # noqa: S307 — controlled local eval, expression sourced from project file
+        f'f"Profile resubmitted: {expression}"',
+        {"data": data},
+    )
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    [
+        ({}, "Profile resubmitted: No notes"),
+        ({"notes": None}, "Profile resubmitted: No notes"),
+        ({"notes": ""}, "Profile resubmitted: No notes"),
+        ({"notes": "Real notes value"}, "Profile resubmitted: Real notes value"),
+        ({"notes": "x" * 80}, "Profile resubmitted: " + "x" * 50),
+    ],
+    ids=[
+        "missing_key",
+        "explicit_None_BUG_REGRESSION_GUARD",
+        "empty_string",
+        "real_value",
+        "truncated_to_50",
+    ],
+)
+def test_resubmit_reason_handles_all_notes_shapes(data, expected):
+    """Live-source expression must produce expected reason for all 5 shapes."""
+    expression = _extract_reason_template()
+    assert _evaluate(expression, data) == expected
+
+
+def test_resubmit_reason_template_does_not_use_dotget_default_anti_pattern():
+    """Anchor — fail if someone reverts to ``.get('notes', 'No notes')`` form
+    that triggers ``None[:50]`` ``TypeError`` on ``notes=None`` payload."""
+    expression = _extract_reason_template()
+    # Anti-pattern: .get('notes', 'No notes') returns None when key=None,
+    # then [:50] raises TypeError. Truthy-coalesce form (... or 'No notes')
+    # avoids this.
+    assert "or 'No notes'" in expression or 'or "No notes"' in expression, (
+        f"Resubmit reason template appears to use .get(default) anti-pattern: "
+        f"{expression!r}. Use ``(data.get('notes') or 'No notes')[:50]`` to "
+        f"handle ``notes=None`` payload — see V3 R6 BUG_RESUBMIT_NOTES_NONE."
+    )

--- a/Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md
+++ b/Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md
@@ -310,6 +310,30 @@ KHÔNG khóa: Lead module (CRUD), Finance (payment view), Dashboard, KPI reports
 
 ### 7.2. Cutover steps (target window 4-6h)
 
+> **🚨 Self-update caveat — pre-stage `deploy.sh` before invoking** (lesson
+> from 2026-05-07 cutover ship):
+>
+> When `scripts/deploy.sh` changes ship via main, invoking
+> `./scripts/deploy.sh` directly on prod runs the **OLD** logic — bash
+> loads the script into memory at invocation, then Step 2 `git pull
+> origin main` updates the file on disk but the in-memory copy stays
+> OLD. Any new flag (e.g. `COLD_CUTOVER` detection added in Hotfix #4)
+> only takes effect from the **SECOND** invocation onwards.
+>
+> **Mitigation**: pre-stage updated script before invoking:
+>
+> ```bash
+> ssh prod && cd /opt/qlts
+> git fetch origin && git checkout main && git pull --ff-only origin main
+> cp scripts/deploy.sh /tmp/deploy_NEW.sh && chmod +x /tmp/deploy_NEW.sh
+> COLD_CUTOVER=true /tmp/deploy_NEW.sh
+> ```
+>
+> The `/tmp` copy is loaded into bash memory; Step 2's git pull updates
+> the on-disk script but our running invocation already loaded the NEW
+> logic. See `scripts/deploy.sh` Self-update caveat header for full
+> rationale.
+
 ```
 T+0:00   Communicate freeze (email + Slack + in-app banner)
 T+0:15   Edit .env.production: ADMISSION_FROZEN=true + NGINX_ADMISSION_FROZEN=true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,6 +26,52 @@
 #
 # Routine deploy (COLD_CUTOVER unset or != "true"):
 #   Flow unchanged from pre-Hotfix-4 — auto migration + sync + restart.
+#
+# =============================================================================
+# 🚨 SELF-UPDATE CAVEAT (Phase1-Hotfix-7 / 2026-05-08, lesson from cutover
+# ship 2026-05-07 22:18 UTC+7):
+# =============================================================================
+# When this script changes (e.g. new flag, new step, new env var) and the
+# changes ship via main, invoking ``./scripts/deploy.sh`` directly on prod
+# will run the OLD logic — bash loads the script into memory at invocation,
+# then Step 2 ``git pull origin main`` updates the file ON DISK but the
+# in-memory copy stays the OLD version. Result: any new flag/branch logic
+# added in the latest commit will NOT execute on the FIRST deploy after
+# merge. It only takes effect from the SECOND invocation onwards.
+#
+# This bit us during the admission cutover ship: ``COLD_CUTOVER=true ./
+# scripts/deploy.sh`` ran the OLD pre-Hotfix-4 deploy.sh in memory which
+# had no COLD_CUTOVER detection, so the routine flow auto-ran alembic +
+# sync + Casbin instead of the operator-controlled sequence per RUNBOOK
+# §7.2. End state was correct because all migrations + backfills are
+# idempotent + apply cleanly, but the safety net (operator pause) was
+# never engaged.
+#
+# **Mitigation for next cutover** — pre-stage the updated script BEFORE
+# invoking, so bash loads the NEW version directly:
+#
+#   ssh prod
+#   cd /opt/qlts
+#   git fetch origin && git checkout main && git pull --ff-only origin main
+#   # Copy NEW deploy.sh out of repo so future ``git pull`` (Step 2) cannot
+#   # mutate the in-memory script:
+#   cp scripts/deploy.sh /tmp/deploy_NEW.sh
+#   chmod +x /tmp/deploy_NEW.sh
+#   COLD_CUTOVER=true /tmp/deploy_NEW.sh
+#
+# The ``/tmp`` copy is loaded into bash memory; Step 2's git pull updates
+# ``/opt/qlts/scripts/deploy.sh`` but our running invocation reads from
+# ``/tmp/deploy_NEW.sh`` which we already loaded. Subsequent routine
+# deploys (post-cutover) call ``./scripts/deploy.sh`` directly as usual
+# because the on-disk and in-memory copies converge after the cutover
+# merge propagates.
+#
+# Alternative: invoke via stdin to bypass the file-on-disk → memory race:
+#   COLD_CUTOVER=true bash < scripts/deploy.sh
+# (Less robust because positional args/relative paths break. Prefer cp.)
+#
+# Reference: ``Documents/ADMISSION_DAILY_LOG.md`` 2026-05-07 cutover entry +
+# memory ``admission-cutover-shipped-2026-05-07``.
 # =============================================================================
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Post-cutover follow-up batch — 5 items bundled per memory `admission-cutover-shipped-2026-05-07`. Closes 3 P3 latent + 1 dep-audit upgrade + 1 cosmetic doc.

## Items shipped

### FU.1 — `BUG_RESUBMIT_NOTES_NONE` fix

`Backend_FastAPI/app/services/admission_service.py:6267`

```diff
-reason=f"Profile resubmitted: {data.get('notes', 'No notes')[:50]}",
+reason=f"Profile resubmitted: {(data.get('notes') or 'No notes')[:50]}",
```

Pre-existing P3: Pydantic `Optional[str] = None` default → `data['notes']=None` → `.get(key, default)` returns the actual value (None) NOT the default → `None[:50]` raises `TypeError` → 500. Atomicity intact (transaction rollback) but visible 500 was the bug. Truthy-coalesce form handles 4 input shapes: missing key / explicit None / empty string / real value.

Lock test: `tests/unit/test_resubmit_notes_none_regression.py` — 6 cases (5 shapes parametrized + 1 anti-pattern anchor via `inspect`).

### FU.2 — dep-audit upgrade (2 CVE pre-existing)

`Backend_FastAPI/requirements.txt`:

| Package | Old | New | CVE |
|---|---|---|---|
| `Mako` | 1.3.10 | 1.3.12 | CVE-2026-44307 (Windows path traversal) |
| `python-multipart` | 0.0.26 | 0.0.27 | CVE-2026-42561 (DoS multipart header parsing) |

Both pre-existing on main + cutover branch. Verified `python -m pip_audit -r requirements.txt --ignore-vuln CVE-2024-23342` returns "No known vulnerabilities found" post-upgrade.

### FU.5 — `Lead.last_terminal_admission_profile` helper (PLAN line 903)

`Backend_FastAPI/app/models/lead.py:325`

`@property` walks in-memory `admission_profiles` list, filters to truly terminal states (enrolled / rejected / withdrawn), returns highest `academic_year` match or None.

Excludes non-terminal: draft / submitted / approved / overridden / revision_requested / resubmitted / reviewing / result_published / admitted / waitlisted / confirmed.

Eager-load contract mirrors `current_admission_profile(year)` — caller MUST `selectinload(Lead.admission_profiles)` before invoke.

Lock test: `tests/unit/test_lead_last_terminal_admission_profile.py` — 19 cases (3 terminal returns + 11 non-terminal exclusions parametrized + 1 empty + 3 year-selection + 1 contract anchor).

### FU.6 — alembic_version multi-head investigation (NO CODE CHANGE)

Suspected drift turned out to be **FALSE ALARM**. Chain layout LINEAR (NOT multi-head):

```
... phase1_10 → phase1_19c → phase1_16 → phase1_17 → phase1_19d → phase1_19e
            → phase1_11 → phase1_12 → phase1_18 → phase1_15a (head)
```

Wave 5 migrations chained INLINE between phase1_10 and phase1_11. Single head `phase1_15a` (Wave 3-E final) is correct per terminal Phase 1 chain. No action required.

### FU.7 — `deploy.sh` self-update prevention pattern

Lesson from 2026-05-07 cutover ship: bash loads script into memory at invocation; Step 2 `git pull origin main` updates file ON DISK but in-memory copy stays OLD. New flag in latest commit only takes effect from SECOND invocation.

Mitigation recipe added to:
* `scripts/deploy.sh` header — 🚨 SELF-UPDATE CAVEAT block with `cp scripts/deploy.sh /tmp/deploy_NEW.sh && /tmp/deploy_NEW.sh` recipe
* `Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md` §7.2 preface — pre-stage script blockquote with cross-ref

## Test verification

```
tests/unit/test_resubmit_notes_none_regression.py            6/6 PASS
tests/unit/test_lead_last_terminal_admission_profile.py     19/19 PASS
tests/unit/test_status_history_runtime_writer.py            19/19 PASS
tests/unit/test_admission_dispatch_payload_template_parity.py 24/24 PASS
tests/unit/test_admission_state_service_event_mapping.py    10/10 PASS
tests/unit/test_check_notification_event_coverage_deferred.py 7/7 PASS
                                                          ───────────
                                                          84/84 PASS
                                                          in 5.01s
```

## Deferred (not in this PR)

* **FU.3 prod SQL DELETE** — 12 UPPERCASE orphan `notification_rule` rows (`event ~ '^ADMISSION_[A-Z]'`). Direct prod DB execution với explicit GO per memory `push-approval-required` (data mutation prod ≠ code change).
* **FU.4 Wave 4 #15d** — drop legacy `admission_profile` singular field từ BE schema dual response + FE types + 5 FE fallback sites. BE+FE coordinated deploy + external consumer audit needed → standalone PR future session.

## Test plan

- [x] 6 FU.1 + 19 FU.5 unit tests new
- [x] 59 Phase 1 baseline regression tests intact
- [x] `pip_audit` post dep upgrade passes
- [x] `bash -n scripts/deploy.sh` syntax OK
- [ ] CI gate — admission-contract-check + dep-audit + AST lint + Notification coverage
- [ ] User merge approval

## References

- Memory: `admission-cutover-shipped-2026-05-07`, `resubmit-notes-none-bug`, `outstanding-debt`
- `Documents/ADMISSION_DAILY_LOG.md` 2026-05-07 cutover entry
- `Documents/ADMISSION_PRODUCTION_REPLACEMENT_RUNBOOK.md` §7.2 + §10
- `Documents/ADMISSION_REFACTOR_PLAN.md` v2.13.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
