### PR TITLE
test-debt(fixture): add explicit CREATE TYPE for 10 create_type=False ENUMs in test schema init + drift lock

### DIFF
--- a/Backend_FastAPI/tests/fixtures/database.py
+++ b/Backend_FastAPI/tests/fixtures/database.py
@@ -110,14 +110,96 @@ async def init_schema_once(settings, AppBase, CasbinBase=None):
             connect_args={"command_timeout": 60},
         )
         async with setup_engine.begin() as conn:
-            # Drop stale enum types
-            for enum_type in ("discount_type_enum", "outcometype", "statustype",
-                              "selectablemode", "triggertype", "administrativenodelevel"):
+            # Drop stale enum types (legacy + current names)
+            for enum_type in (
+                "discount_type_enum",
+                "outcometype", "statustype", "selectablemode", "triggertype",
+                "administrativenodelevel",
+                # cutover-introduced ENUMs (cleanup defensive)
+                "subject_kind",
+                "admission_audience",
+                "conduct_grade",
+                "transition_role_legacy",
+                "actor_actual_role",
+                "effective_transition_role",
+                "outcome_type_enum",
+                "status_type_enum",
+                "selectable_mode_enum",
+                "trigger_type_enum",
+            ):
                 await conn.execute(text(f"DROP TYPE IF EXISTS {enum_type} CASCADE"))
 
-            # Re-create migration-managed enums
+            # Re-create migration-managed enums BEFORE Base.metadata.create_all().
+            #
+            # All ENUMs here use ``create_type=False`` in the model column
+            # definition because their DDL is owned by Alembic migrations.
+            # Test DB uses ``Base.metadata.create_all()`` (NOT alembic) per
+            # ``tests/fixtures/database.py:123`` + memory
+            # ``test-db-schema-source`` — so SQLAlchemy SKIPs ENUM creation
+            # for ``create_type=False`` columns and the table CREATE fails
+            # with ``UndefinedObjectError: type "foo" does not exist``.
+            #
+            # Every ``create_type=False`` ENUM in app/models MUST be listed
+            # below. The lock test ``tests/unit/test_fixture_enum_coverage.
+            # py`` greps the codebase + asserts each name appears here —
+            # adding a new ``create_type=False`` ENUM without updating
+            # this fixture fails the lock test loudly.
+
+            # tuition_discount_policy.py — pre-cutover existing
             await conn.execute(text(
                 "CREATE TYPE discount_type_enum AS ENUM ('amount', 'percentage')"
+            ))
+
+            # phase1_03 (#184 Wave 1 PR-1B') — admission_path.applicable_to
+            await conn.execute(text(
+                "CREATE TYPE admission_audience AS ENUM "
+                "('POST_THCS', 'POST_THPT', 'LIEN_THONG_TC', "
+                "'LIEN_THONG_CD', 'VLVH')"
+            ))
+
+            # phase1_05 (#184 Wave 1 PR-1C') — subject.subject_kind
+            await conn.execute(text(
+                "CREATE TYPE subject_kind AS ENUM "
+                "('ACADEMIC_SUBJECT', 'TERM_AVERAGE', 'ABILITY_TEST', "
+                "'CERTIFICATE')"
+            ))
+
+            # phase1_09a (#184 Wave 2) — admission_profile.conduct_grade
+            await conn.execute(text(
+                "CREATE TYPE conduct_grade AS ENUM ('TB', 'KHA', 'TOT')"
+            ))
+
+            # phase1_10 (#184 Wave 2) — status_history 3-role triplet
+            await conn.execute(text(
+                "CREATE TYPE transition_role_legacy AS ENUM "
+                "('system', 'officer', 'admin', 'candidate')"
+            ))
+            await conn.execute(text(
+                "CREATE TYPE actor_actual_role AS ENUM "
+                "('candidate', 'officer', 'manager', 'accountant', "
+                "'admin', 'system')"
+            ))
+            await conn.execute(text(
+                "CREATE TYPE effective_transition_role AS ENUM "
+                "('candidate', 'officer', 'admin', 'system')"
+            ))
+
+            # pipeline.py — pre-cutover existing FSM enums
+            await conn.execute(text(
+                "CREATE TYPE outcome_type_enum AS ENUM "
+                "('positive', 'neutral', 'negative')"
+            ))
+            await conn.execute(text(
+                "CREATE TYPE status_type_enum AS ENUM "
+                "('transition', 'activity', 'system')"
+            ))
+            await conn.execute(text(
+                "CREATE TYPE selectable_mode_enum AS ENUM "
+                "('user', 'role', 'system')"
+            ))
+            await conn.execute(text(
+                "CREATE TYPE trigger_type_enum AS ENUM "
+                "('user', 'role', 'system', 'event')"
             ))
 
             await conn.run_sync(AppBase.metadata.create_all)

--- a/Backend_FastAPI/tests/unit/test_fixture_enum_coverage.py
+++ b/Backend_FastAPI/tests/unit/test_fixture_enum_coverage.py
@@ -1,0 +1,131 @@
+"""Lock test — fixture ``init_schema_once`` ENUM coverage anchor.
+
+Every ENUM in ``app/models`` declared with ``create_type=False`` (DDL
+owned by Alembic migration) MUST be explicitly created in
+``tests/fixtures/database.py:init_schema_once`` BEFORE
+``Base.metadata.create_all()`` is called — otherwise SQLAlchemy skips
+the ENUM creation (per the ``create_type=False`` flag) and the column
+CREATE fails with::
+
+    asyncpg.exceptions.UndefinedObjectError: type "foo" does not exist
+
+This test greps every ``create_type=False`` ENUM name from the model
+source files and asserts each name appears as a ``CREATE TYPE foo AS
+ENUM (...)`` statement in the fixture. Adding a new
+``create_type=False`` ENUM without updating the fixture fails this
+test loudly before the change can land.
+
+Root cause incident: 2026-05-08 post-cutover follow-up batch CI gate
+"PR Gate — Contract Tests" failed at
+``test_lead_assignment_lifecycle_end_to_end`` with
+``UndefinedObjectError: type "subject_kind" does not exist`` —
+``subject_kind`` ENUM was added in Phase 1 Wave 1 PR-1C' (phase1_05)
+with ``create_type=False`` but the test fixture was never updated.
+This regression slipped through because cutover ship 2026-05-07
+cancelled the deploy.yml CI run before "PR Gate" could fire on the
+post-merge branch — the test debt only became visible on the next
+non-cancelled main push.
+
+Fix shipped 2026-05-08 in PR `test-debt/admission-workflow-e2e-
+fixture-fix` adds 10 explicit ``CREATE TYPE`` statements covering all
+``create_type=False`` ENUMs across the codebase. This anchor test
+prevents the same regression class from recurring.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODELS_DIR = REPO_ROOT / "app" / "models"
+FIXTURE_FILE = REPO_ROOT / "tests" / "fixtures" / "database.py"
+
+
+def _collect_create_type_false_enum_names() -> set[str]:
+    """Walk ``app/models`` and extract every ENUM ``name="foo"``
+    paired with ``create_type=False``."""
+    names: set[str] = set()
+    # Match patterns:
+    #   name="foo",
+    #   ...
+    #   create_type=False,
+    # OR same-line:
+    #   Enum(X, name="foo", create_type=False)
+    # We allow up to ~500 chars between name= and create_type=False to
+    # handle multi-line column definitions (typical in models).
+    pattern = re.compile(
+        r'name\s*=\s*["\']([a-z_]+)["\'][^)]{0,500}?create_type\s*=\s*False',
+        re.DOTALL,
+    )
+    for py_file in MODELS_DIR.rglob("*.py"):
+        src = py_file.read_text(encoding="utf-8")
+        for match in pattern.finditer(src):
+            names.add(match.group(1))
+    return names
+
+
+def _collect_fixture_create_type_names() -> set[str]:
+    """Extract every ``CREATE TYPE foo AS ENUM (...)`` name from the
+    fixture file."""
+    src = FIXTURE_FILE.read_text(encoding="utf-8")
+    pattern = re.compile(r'CREATE TYPE\s+([a-z_]+)\s+AS ENUM', re.IGNORECASE)
+    return set(pattern.findall(src))
+
+
+def test_every_create_type_false_enum_is_in_fixture():
+    """Each ENUM declared with ``create_type=False`` in the codebase
+    must have a matching ``CREATE TYPE`` line in the test fixture."""
+    model_enums = _collect_create_type_false_enum_names()
+    fixture_enums = _collect_fixture_create_type_names()
+
+    assert model_enums, (
+        "Failed to discover any ``create_type=False`` ENUMs in app/models — "
+        "regex pattern probably broke after a refactor; fix this test."
+    )
+
+    missing = model_enums - fixture_enums
+    assert not missing, (
+        f"\n\n🚨 ENUM coverage drift in test fixture:\n\n"
+        f"Models declare {sorted(missing)} with ``create_type=False``\n"
+        f"but ``tests/fixtures/database.py:init_schema_once`` does NOT\n"
+        f"emit a ``CREATE TYPE ... AS ENUM (...)`` statement for them.\n\n"
+        f"Without the explicit CREATE TYPE, ``Base.metadata.create_all()``\n"
+        f"will fail with ``UndefinedObjectError: type \"foo\" does not\n"
+        f"exist`` because ``create_type=False`` tells SQLAlchemy to skip\n"
+        f"ENUM creation (DDL owned by Alembic migration, not test\n"
+        f"fixture).\n\n"
+        f"Fix: add ``CREATE TYPE {{name}} AS ENUM (...)`` for each missing\n"
+        f"name in ``tests/fixtures/database.py:init_schema_once`` BEFORE\n"
+        f"the ``await conn.run_sync(AppBase.metadata.create_all)`` call.\n"
+        f"Mirror the pattern used for existing ENUMs (e.g.\n"
+        f"``subject_kind``, ``admission_audience``).\n\n"
+        f"All known model ENUMs: {sorted(model_enums)}\n"
+        f"All fixture-created:   {sorted(fixture_enums)}\n"
+    )
+
+
+def test_fixture_does_not_create_orphan_enums():
+    """Sanity check — fixture should not have CREATE TYPE for ENUMs
+    that no model uses (would indicate stale fixture or model deletion
+    without fixture cleanup)."""
+    model_enums = _collect_create_type_false_enum_names()
+    fixture_enums = _collect_fixture_create_type_names()
+
+    # ``discount_type_enum`` historically created here even though
+    # the model uses ``values_callable``; allow as legacy carrying.
+    legacy_allowed: set[str] = set()
+
+    orphan = fixture_enums - model_enums - legacy_allowed
+    if orphan:
+        # Soft warning via plain assert message — not a hard fail
+        # because some fixtures may keep a CREATE TYPE for legacy
+        # back-compat. If this triggers, audit each orphan and either
+        # remove it from fixture OR add to ``legacy_allowed``.
+        assert not orphan, (
+            f"\n\nFixture creates orphan ENUMs (no matching model "
+            f"declaration): {sorted(orphan)}\n"
+            f"Audit each — remove from fixture OR add to "
+            f"``legacy_allowed`` set in this test.\n"
+        )


### PR DESCRIPTION
## Summary

Closes pre-existing test debt per memory `test-debt-admission-workflow-e2e`. Surfaced 2026-05-08 by FU batch (#234) merge — CI run #25530761329 failed at `test_lead_assignment_lifecycle_end_to_end` setup with:

```
asyncpg.exceptions.UndefinedObjectError: type "subject_kind" does not exist
```

## Root cause

* Test DB uses `Base.metadata.create_all()` (NOT alembic) per memory `test-db-schema-source` + `tests/fixtures/database.py:123`
* Models with `create_type=False` ENUM columns tell SQLAlchemy "DDL owned by alembic migration, don't redeclare" — so `create_all()` SKIPS the ENUM creation
* Without explicit `CREATE TYPE foo AS ENUM (...)` in the fixture, the table CREATE statement fails because the ENUM type doesn't exist
* Worked previously because pre-cutover models didn't use `create_type=False` heavily; Phase 1 schema added 7 new `create_type=False` ENUMs

Cutover ship 2026-05-07 cancelled the deploy.yml CI run (`gh run cancel 25503559533`) before "PR Gate" could fire — the test debt only became visible on the next non-cancelled main push (FU batch merge `d8554bca` → run #25530761329 → failure).

## Fix

`tests/fixtures/database.py:init_schema_once` — add explicit `CREATE TYPE foo AS ENUM (...)` for all 11 `create_type=False` ENUMs (10 cutover + 1 legacy `discount_type_enum`) BEFORE `Base.metadata.create_all()`. Also extend defensive `DROP TYPE IF EXISTS` cleanup to match new names.

## ENUMs added

| ENUM | Migration | Used by |
|---|---|---|
| `admission_audience` | phase1_03 | `admission_path.applicable_to` |
| `subject_kind` | phase1_05 | `subject.subject_kind` |
| `conduct_grade` | phase1_09a | `admission_profile.conduct_grade` |
| `transition_role_legacy` | phase1_10 | `status_history.transitioned_by_role` |
| `actor_actual_role` | phase1_10 | `status_history.actor_actual_role` |
| `effective_transition_role` | phase1_10 | `status_history.effective_transition_role` |
| `outcome_type_enum` | pre-cutover | pipeline FSM |
| `status_type_enum` | pre-cutover | pipeline FSM |
| `selectable_mode_enum` | pre-cutover | pipeline FSM |
| `trigger_type_enum` | pre-cutover | pipeline FSM |
| `discount_type_enum` | pre-cutover | tuition_discount_policy (legacy) |

## Drift prevention

New lock test `tests/unit/test_fixture_enum_coverage.py`:

* `test_every_create_type_false_enum_is_in_fixture` — greps every `create_type=False` ENUM name from `app/models` + asserts each name appears as `CREATE TYPE foo AS ENUM` in fixture. Fails loudly on next ENUM addition without fixture update.
* `test_fixture_does_not_create_orphan_enums` — sanity check no stale fixture CREATE TYPE for ENUMs without model declaration.

## Verification (local)

| Suite | Result |
|---|---|
| `tests/unit/test_fixture_enum_coverage.py` (new lock) | 2/2 PASS |
| `test_lead_assignment_lifecycle_end_to_end` (previously failing CI) | ✅ PASS (17.22s, fresh `qlts_test` DB) |
| Full `deploy.yml` PR Gate suite (8 test files) | 91/91 PASS in 6:07 |
| Unit + parity (FU batch + Phase 1 baseline) | 86/86 PASS in 5.47s |

## Test plan

- [x] New lock test PASS — drift prevention anchor
- [x] Previously failing CI test PASS post-fix
- [x] Full deploy.yml PR Gate suite PASS locally
- [x] No regression on existing unit/parity tests
- [ ] CI gate — full PR Gate suite trên GitHub runner
- [ ] Merge → CI auto-deploy fires (deploys FU batch #234 + this fix together)

## Companion to

PR #234 (`[#184 FU-batch]`) — once this test-debt fix merges, the deploy.yml workflow will succeed on next main push and auto-deploy the FU batch (Mako/python-multipart upgrade + BUG_RESUBMIT_NOTES_NONE fix + Lead helper) to prod.

## References

- Memory: `test-debt-admission-workflow-e2e`, `test-db-schema-source`, `pattern-change-impact-audit`
- `Documents/ADMISSION_DAILY_LOG.md` 2026-05-07 cutover entry
- `Backend_FastAPI/CLAUDE.md` test deps install procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
