### PR TITLE
test-debt(fe): fix 2 pre-existing FE test type-check errors blocking deploy CI

### DIFF
--- a/frontend/src/components/leads/AdmissionReadinessChecklist.wave4-15c.test.ts
+++ b/frontend/src/components/leads/AdmissionReadinessChecklist.wave4-15c.test.ts
@@ -52,12 +52,18 @@ describe("AdmissionReadinessChecklist — Wave 4 #15c plural migrate", () => {
 
 describe("Lead type — admission_profiles plural shape", () => {
   it("type allows plural list with legacy singular fallback", () => {
+    // Profile shape mirrors `AdmissionProfileShallow` interface
+    // (`types/lead.types.ts:340-345` + BE `app/schemas/lead.py:133-144`):
+    // {id, status, student_code?, created_at}. `lead_id` and
+    // `academic_year` are NOT in the shallow nested response — they
+    // live on the full `AdmissionProfileResponse`. Wave 4 #15c plural
+    // shape exposes the per-year list via `Lead.admission_profiles[]`
+    // but each item still uses the shallow projection.
     const profile_2026: AdmissionProfileShallow = {
       id: 100,
-      lead_id: 1,
       status: "draft",
-      academic_year: 2026,
-    } as AdmissionProfileShallow
+      created_at: "2026-01-01T00:00:00Z",
+    }
 
     const lead_with_plural: Pick<Lead, "id" | "admission_profiles" | "admission_profile"> = {
       id: 1,

--- a/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
+++ b/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
@@ -28,14 +28,21 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000
 const MOCK_PATH_ID = 42;
 
 /** A minimal AdmissionPathResponse to pre-seed the detail cache. */
-const mockAdmissionPathResponse: AdmissionPathResponse = {
+// Use ``satisfies`` instead of ``: AdmissionPathResponse`` annotation —
+// the explicit-annotation form triggered TS2739 "missing properties"
+// for the 3 phase1_03 fields (``applicable_to`` / ``method_quota`` /
+// ``bonus_rule_override``) even though they are present in the literal.
+// Symptom only manifests on CI runner; test-debt fix 2026-05-08 swap
+// to ``satisfies`` to widen literal-narrowing while still type-checking
+// the shape against ``AdmissionPathResponse``.
+const mockAdmissionPathResponse = {
   id: MOCK_PATH_ID,
   academic_info_id: 1,
   admission_method_id: 1,
-  status: "draft",
+  status: "draft" as const,
   display_name: "Test Path",
   display_order: 1,
-  visibility: "public",
+  visibility: "public" as const,
   activated_at: null,
   activated_by: null,
   created_at: "2025-06-01T00:00:00+00:00",
@@ -43,16 +50,16 @@ const mockAdmissionPathResponse: AdmissionPathResponse = {
   academic_info: null,
   admission_method: null,
   criteria: null,
-  available_actions: [],
+  available_actions: [] as string[],
   can_edit: true,
   can_activate: false,
-  validation_errors: [],
+  validation_errors: [] as string[],
   // PR #6: strict submit gate per path; default False in the fixture
   // mirrors the backend default for newly-created paths.
   allow_unverified_submission: false,
   // Minor-correction allowlist — empty by default for fresh paths
   // (admin opts in field-by-field after path creation).
-  minor_correction_allowed_fields: [],
+  minor_correction_allowed_fields: [] as string[],
   // phase1_03 (#184 Wave 1 PR-1B') — 3 new fields shipped in BE
   // PR #206 + Zod parse parity. Defaults mirror BE Create behavior:
   // null for all three (= legacy / no audience filter / no method
@@ -62,7 +69,7 @@ const mockAdmissionPathResponse: AdmissionPathResponse = {
   applicable_to: null,
   method_quota: null,
   bonus_rule_override: null,
-};
+} satisfies AdmissionPathResponse;
 
 /** The shape that PUT /paths/:id/documents returns. */
 const mockDocumentsResponse: ResolvedDocumentListResponse = {


### PR DESCRIPTION
## Summary

Fix 2 pre-existing FE test fixture type-check errors blocking deploy.yml CI Gate post-cutover follow-up wave.

Surfaced 2026-05-08 by deploy run #25531774137 (BE test-debt fixture fix `09b1538b` merge) — once BE gate unblocked, FE Type check exposed next failure in pipeline order.

Cutover ship 2026-05-07 cancelled the deploy.yml CI run before any of these test debt items could fire — they only become visible on the next non-cancelled main push.

## Fixes

### FE.1 — `AdmissionReadinessChecklist.wave4-15c.test.ts:55-60`

Test profile literal had `lead_id` + `academic_year` (NOT in `AdmissionProfileShallow` interface) and missing required `created_at`. TS2352 cast non-overlapping error.

```diff
-const profile_2026: AdmissionProfileShallow = {
-  id: 100,
-  lead_id: 1,           // not in shallow projection
-  status: "draft",
-  academic_year: 2026,  // not in shallow projection
-} as AdmissionProfileShallow
+const profile_2026: AdmissionProfileShallow = {
+  id: 100,
+  status: "draft",
+  created_at: "2026-01-01T00:00:00Z",  // required field
+}
```

Source-of-truth: `types/lead.types.ts:340-345` + BE `app/schemas/lead.py:133-144`. Shallow projection has 4 fields only — full lifecycle fields like `lead_id`/`academic_year` live on `AdmissionProfileResponse`.

### FE.2 — `useAdmissionPaths.test.tsx:31-65`

Test fixture had all 23 `admissionPathResponseSchema` fields but TS narrowed `[]` literals to `never[]` without context, then cascaded into "missing properties" false positive on `applicable_to` / `method_quota` / `bonus_rule_override` (which ARE in the literal).

```diff
-const mockAdmissionPathResponse: AdmissionPathResponse = {
+const mockAdmissionPathResponse = {
   id: MOCK_PATH_ID,
   ...
-  status: "draft",
+  status: "draft" as const,
-  visibility: "public",
+  visibility: "public" as const,
-  available_actions: [],
+  available_actions: [] as string[],
   ...
-  validation_errors: [],
+  validation_errors: [] as string[],
   ...
-  minor_correction_allowed_fields: [],
+  minor_correction_allowed_fields: [] as string[],
   applicable_to: null,
   method_quota: null,
   bonus_rule_override: null,
-};
+} satisfies AdmissionPathResponse;
```

Pattern: `: T` → `satisfies T` + `as const` / `as string[]` casts. Standard TS 4.9+ pattern for fixtures requiring literal precision while validating contract.

## Why both pre-existing

Both errors documented as carry-forward in memory:
* `184-phase1-schema-wave-plan` line 927 — useAdmissionPaths fixture drift from PR #207 (Wave 1 PR-1B'-FE)
* `test-debt-admission-workflow-e2e` — pre-existing test debt tracker

This PR closes 2 more items in the queue.

## Local verify limitation (transparent disclosure)

`docker compose run --rm` uses frozen image source (mtime 2026-04-26), KHÔNG see disk edits. CI runner uses fresh git checkout → fix logic should work CI-side.

Pattern (`satisfies` + literal narrowing) is canonical TS, low risk. CI gate verifies on fresh runtime.

## Test plan

- [x] FE.1 fix matches canonical `AdmissionProfileShallow` interface
- [x] FE.2 fix uses `satisfies` operator (TS 4.9+ pattern)
- [x] No runtime impact (type-only test changes)
- [ ] CI Frontend Type check PASS (CI verify)
- [ ] CI Frontend test suite PASS

## Deploy chain post-merge

This is the 3rd in a sequential test-debt chain post-cutover:
1. PR #234 FU-batch — BE bug fix + dep upgrade + Lead helper + docs (merged `d8554bca`)
2. PR #235 BE test-debt fixture fix — ENUM init order (merged `09b1538b`)
3. **This PR** — FE test type-check fix

Once merged + CI green + production env approved → routine deploy.yml auto-deploys ALL 3 changes atomic to prod.

## References

- Memory: `test-debt-admission-workflow-e2e`, `184-phase1-schema-wave-plan` (line 927), `audit-report-accuracy`
- Failed CI run #25531774137 at "Frontend — Type check" step
- Sister PRs #234 + #235 (BE side completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
