### PR TITLE
feat(admission): #184 Phase 2 v8.2 PR-2A v2 — OfferingAdmissionRound year-level + RoundsManagementTab top-level

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase2_01_v2_create_offering_admission_round_year_level.py
+++ b/Backend_FastAPI/alembic/versions/phase2_01_v2_create_offering_admission_round_year_level.py
@@ -1,0 +1,195 @@
+"""phase2_01_v2: create offering_admission_round table at academic_year level.
+
+Revision ID: phase2_01_v2
+Revises: phase1_15a
+Create Date: 2026-05-09
+
+#184 Phase 2 PR-2A v2 (Option A schema redesign per plan v8.2 chốt
+2026-05-09). Round entity at academic_year level, NOT per-academic_info
+(superseded v6 schema từ tag ``phase2-pr-2a-v6-archived``).
+
+Plan
+----
+* Plan file ``C:\\Users\\Admin\\.claude\\plans\\noble-launching-cocoa.md``
+  v8.2 (8 audit rounds: v1 → v2 → v3 → v4 → v5 → v6 → v8 → v8.1 → v8.2).
+* Memory ``phase2-plan-locked`` v8.2.
+* PLAN Phần 9 "Phase 2 — Schema design pivot Option A (2026-05-09)".
+
+Schema delta vs v6 (PLAN §2.1 line 532-535)
+-------------------------------------------
+v6 (archived tag ``phase2-pr-2a-v6-archived``):
+    OfferingAdmissionRound.academic_info_id FK → per-academic_info nest
+    UNIQUE(academic_info_id, round_code)
+    Quota fields ON THIS TABLE (round_quota, admit_quota, submission_count)
+
+v8.2 Option A (this migration):
+    OfferingAdmissionRound.academic_year INT → year-level globally
+    UNIQUE(academic_year, round_code)
+    Quota fields MOVED to admission_path (PR-2B v2 phase2_02_v2)
+
+Rationale (PLAN Phần 9):
+    Round metadata replication problem trong v6 (extend/archive/notify
+    cost N atomic UPDATEs). Year-level: 1 đợt = 1 row, time-window edit
+    = single UPDATE.
+
+Decisions Q1-Q8 (LOCKED 2026-05-09)
+-----------------------------------
+* Q1: Schema = Option A (year-level)
+* Q3: Round metadata = time-window only Phase 2 (notification template
+  defer Phase 3)
+* Q7: admission_path.admission_round_id ON DELETE RESTRICT (PR-2B v2)
+* Q8: round_code = pure string + UI convention
+
+Final migration constraint: NO DROP TABLE prod path (v6 schema chưa vào
+prod, dev rollback only handled via separate downgrade).
+
+Backfill DOT_1 per distinct academic_year
+-----------------------------------------
+Pre-flight Phase A audit 2026-05-08 verified dev/prod 1:1 match — only
+distinct academic_year = 2026 → 1 DOT_1 row created globally cho cả
+trường năm 2026.
+
+Idempotent guards
+-----------------
+* ``CREATE TABLE`` raises ``DuplicateTable`` on re-run (alembic semantics)
+* Backfill INSERT uses ``ON CONFLICT (academic_year, round_code) DO
+  NOTHING`` — re-runnable safely.
+
+Concern β v5 carry forward — archive_expired_rounds_task cron DEFER
+Phase 3
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase2_01_v2"
+down_revision: Union[str, None] = "phase1_15a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE = "offering_admission_round"
+UNIQUE_NAME = "uq_offering_admission_round_year_code"
+
+
+def upgrade() -> None:
+    op.create_table(
+        TABLE,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "academic_year",
+            sa.Integer,
+            nullable=False,
+            index=True,
+            comment="Year-level grouping. UNIQUE per (academic_year, round_code).",
+        ),
+        sa.Column(
+            "round_code",
+            sa.String(20),
+            nullable=False,
+            comment="Round identifier: DOT_1 / DOT_2 / DOT_3 / BO_SUNG / DOT_1_VLVH (Q8 v8.2 — pure string)",
+        ),
+        sa.Column(
+            "round_name",
+            sa.String(100),
+            nullable=False,
+            comment='Localized display: "Đợt 1 - 2026"',
+        ),
+        sa.Column("start_date", sa.Date, nullable=True),
+        sa.Column("end_date", sa.Date, nullable=True),
+        sa.Column(
+            "is_active",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.true(),
+            comment="Toggle hide round khỏi storefront + path config dropdown",
+        ),
+        sa.Column(
+            "archived_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment=(
+                "Soft-archive marker — set by admin DELETE endpoint. "
+                "Phase 3 future: archive_expired_rounds_task cron will "
+                "move profiles to existing _archived_admission_profile "
+                "table (phase1_16) at end_date+6mo per PLAN §2.1.a Rule 3."
+            ),
+        ),
+        # SPEC §2.1.a Rule 2 — admin extend audit fields
+        sa.Column(
+            "extended_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Last admin end_date extension timestamp",
+        ),
+        sa.Column(
+            "extended_by_user_id",
+            sa.Integer,
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+            comment="Admin user who last extended end_date",
+        ),
+        sa.Column(
+            "extension_reason",
+            sa.Text,
+            nullable=True,
+            comment="Reason ≥10 chars mandatory for extend endpoint",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("academic_year", "round_code", name=UNIQUE_NAME),
+    )
+
+    # Backfill DOT_1 per distinct academic_year (Q1 v8.2 — year-level
+    # globally, NOT per academic_info). Idempotent ON CONFLICT.
+    # Pre-flight Phase A 2026-05-08: dev/prod has only academic_year=2026
+    # active → 1 DOT_1 row created.
+    op.execute(
+        """
+        INSERT INTO offering_admission_round
+            (academic_year, round_code, round_name,
+             start_date, end_date, is_active,
+             archived_at, extended_at, extended_by_user_id, extension_reason,
+             created_at, updated_at)
+        SELECT DISTINCT
+            oai.academic_year,
+            'DOT_1',
+            'Đợt 1 - ' || oai.academic_year::text,
+            NULL::date,
+            NULL::date,
+            true,
+            NULL::timestamptz,
+            NULL::timestamptz,
+            NULL::int,
+            NULL::text,
+            NOW(),
+            NOW()
+        FROM offering_academic_info oai
+        WHERE oai.is_deleted = false
+        ON CONFLICT (academic_year, round_code) DO NOTHING;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Reversible — drop table cascades all backfilled rounds.
+
+    Safe pre-Phase-2-prod-cutover. Post-cutover (PR-2C v2 ⚠ ONE-WAY ships
+    NOT NULL admission_round_id on admission_path), this downgrade would
+    break path FK invariants — handle via PR-2C downgrade playbook chain
+    (Documents/PHASE2_ROLLBACK_PLAYBOOK_V8.md).
+    """
+    op.drop_table(TABLE)

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -41,6 +41,7 @@ from .routers import (
     admission_config,  # ✅ PHASE 3: Admission Config + Scoring API
     admission_paths,  # ✅ PHASE 1: Admission Configuration Console
     admin_v2_casbin,  # ✅ T0-5 cold cutover: admin-only Casbin reload endpoint
+    admin_v2_admission_round,  # ✅ #184 Phase 2 v8.2 PR-2A v2: year-level rounds CRUD + bulk-create + extend
     admin_v2_system_config,  # ✅ #184 PR-1D / phase1_13: admin runtime config
     admissions,  # ✅ NEW: Admission Profile workflow
     auth,
@@ -783,6 +784,7 @@ fastapi_app.include_router(admission_config.router, prefix="/api")  # ✅ PHASE 
 fastapi_app.include_router(admission_paths.router, prefix="/api")  # ✅ PHASE 1: Admission Configuration Console
 fastapi_app.include_router(admin_v2_casbin.router)  # ✅ T0-5: POST /api/v2/admin/casbin/reload (router declares full prefix)
 fastapi_app.include_router(admin_v2_system_config.router)  # ✅ #184 PR-1D: GET/PATCH /api/v2/admin/system-config (router declares full prefix)
+fastapi_app.include_router(admin_v2_admission_round.router)  # ✅ #184 Phase 2 v8.2 PR-2A v2: year-level rounds (router declares full prefix)
 fastapi_app.include_router(document_groups.router, prefix="/api")  # ✅ PHASE A.3: DocumentGroup CRUD
 fastapi_app.include_router(config_data.router, prefix="/api") # ✅ NEW: Config Data
 fastapi_app.include_router(administrative.router, prefix="/api")  # ✅ PHASE 4: Administrative address nodes

--- a/Backend_FastAPI/app/models/__init__.py
+++ b/Backend_FastAPI/app/models/__init__.py
@@ -80,6 +80,7 @@ from .organization import OfferingDistributionConfig, OrganizationUnit
 from .major_program import MajorProgram  # Level 1
 from .program_offering import ProgramOffering  # Level 2
 from .offering_academic_info import OfferingAcademicInfo  # Level 3
+from .offering_admission_round import OfferingAdmissionRound  # Phase 2 v8.2 PR-2A v2 — year-level
 from .offering_semester_tuition import OfferingSemesterTuition  # PR 1 (ADR-002)
 
 # Tuition Discount Policy
@@ -196,6 +197,7 @@ __all__ = [
     "MajorProgram",
     "ProgramOffering",
     "OfferingAcademicInfo",
+    "OfferingAdmissionRound",
     "OfferingSemesterTuition",
     # Tuition Discount Policy
     "TuitionDiscountPolicy",

--- a/Backend_FastAPI/app/models/offering_admission_round.py
+++ b/Backend_FastAPI/app/models/offering_admission_round.py
@@ -1,0 +1,140 @@
+# app/models/offering_admission_round.py
+"""OfferingAdmissionRound — Phase 2 v8.2 Option A year-level entity.
+
+1 round = 1 row globally cho cả trường (Q1 v8.2). KHÔNG nest dưới
+academic_info nữa — đó là v6 archived schema (tag
+``phase2-pr-2a-v6-archived``).
+
+Quota fields (round_quota, admit_quota, submission_count) ship trên
+admission_path (PR-2B v2), KHÔNG trên này.
+
+PLAN refs: §2.1.a (Rule 1-4 lifecycle) + §4 line 540-547 (admit_quota
+semantic) + Phần 9 Phase 2 design pivot Option A.
+Migration: ``alembic/versions/phase2_01_v2_create_offering_admission_round_year_level.py``.
+"""
+
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import relationship
+
+from app.models.base import Base
+
+
+class OfferingAdmissionRound(Base):
+    """Đợt tuyển sinh year-level (1 row per đợt globally).
+
+    Examples (năm 2026):
+    * DOT_1: Đợt 1 chính thức (Mar-Jun)
+    * DOT_2: Đợt 2 bổ sung (Jul-Sep) — admin tạo khi DOT_1 chưa đủ chỉ tiêu
+    * DOT_3: Đợt 3 (Sep-Oct)
+    * BO_SUNG: Đợt vét tuyển cuối năm (Nov)
+    * DOT_1_VLVH: Đợt 1 hệ vừa làm vừa học (Q8 — pure string convention)
+
+    Lifecycle (per SPEC §2.1.a)
+    ---------------------------
+    * Rule 1 — Cutoff submit: candidate ``end_date < NOW()`` → 410 Gone
+    * Rule 2 — Admin extend: ``POST /rounds/{id}/extend`` writes
+      ``extended_at`` + ``extended_by_user_id`` + ``extension_reason``
+    * Rule 3 — 6-month archive: cron ``archive_expired_rounds_task``
+      (DEFER Phase 3) moves profiles to ``_archived_admission_profile``
+    * Rule 4 — Engine scope: profiles của round có ``is_active=true``
+      AND ``end_date >= NOW() - 30d``
+    """
+
+    __tablename__ = "offering_admission_round"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    academic_year = Column(
+        Integer,
+        nullable=False,
+        index=True,
+        comment="Year-level grouping. UNIQUE per (academic_year, round_code)",
+    )
+
+    round_code = Column(
+        String(20),
+        nullable=False,
+        comment="Pure string Phase 2 (Q8): DOT_1 / DOT_2 / DOT_3 / BO_SUNG / DOT_1_VLVH",
+    )
+    round_name = Column(
+        String(100),
+        nullable=False,
+        comment='Localized display: "Đợt 1 - 2026"',
+    )
+
+    start_date = Column(Date, nullable=True)
+    end_date = Column(Date, nullable=True)
+
+    is_active = Column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default="true",
+    )
+    archived_at = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment=(
+            "Soft-archive marker. Phase 3 future: cron will move profiles "
+            "to _archived_admission_profile (phase1_16) at end_date+6mo."
+        ),
+    )
+
+    # SPEC §2.1.a Rule 2 — admin extend audit fields
+    extended_at = Column(DateTime(timezone=True), nullable=True)
+    extended_by_user_id = Column(
+        Integer,
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    extension_reason = Column(Text, nullable=True)
+
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+
+    # Relationships
+    extended_by = relationship(
+        "User",
+        foreign_keys=[extended_by_user_id],
+    )
+    # admission_paths relationship will be added by PR-2B v2 when
+    # admission_path.admission_round_id FK ships.
+
+    __table_args__ = (
+        UniqueConstraint(
+            "academic_year",
+            "round_code",
+            name="uq_offering_admission_round_year_code",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<OfferingAdmissionRound id={self.id} "
+            f"year={self.academic_year} code={self.round_code!r} "
+            f"active={self.is_active}>"
+        )

--- a/Backend_FastAPI/app/repositories/admission_round_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_round_repository.py
@@ -1,0 +1,57 @@
+# app/repositories/admission_round_repository.py
+"""Repository for OfferingAdmissionRound year-level (Phase 2 v8.2 PR-2A v2)."""
+
+from typing import List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import OfferingAdmissionRound
+
+
+class AdmissionRoundRepository:
+    """Data access layer for admission rounds (year-level)."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_by_id(self, round_id: int) -> Optional[OfferingAdmissionRound]:
+        return await self.db.get(OfferingAdmissionRound, round_id)
+
+    async def list_by_year(
+        self, academic_year: int
+    ) -> List[OfferingAdmissionRound]:
+        """List all rounds for a given academic_year, ordered by round_code."""
+        result = await self.db.execute(
+            select(OfferingAdmissionRound)
+            .where(OfferingAdmissionRound.academic_year == academic_year)
+            .order_by(OfferingAdmissionRound.round_code)
+        )
+        return list(result.scalars().all())
+
+    async def get_default_dot1(
+        self, academic_year: int
+    ) -> Optional[OfferingAdmissionRound]:
+        """Service shim auto-resolve target — used by PR-2B v2
+        ``create_admission_path`` when caller omits round_id.
+
+        Q1 v8.2 year-level lookup: 1 DOT_1 row per academic_year (cho cả trường).
+        """
+        result = await self.db.execute(
+            select(OfferingAdmissionRound).where(
+                OfferingAdmissionRound.academic_year == academic_year,
+                OfferingAdmissionRound.round_code == "DOT_1",
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_year_and_code(
+        self, academic_year: int, round_code: str
+    ) -> Optional[OfferingAdmissionRound]:
+        result = await self.db.execute(
+            select(OfferingAdmissionRound).where(
+                OfferingAdmissionRound.academic_year == academic_year,
+                OfferingAdmissionRound.round_code == round_code,
+            )
+        )
+        return result.scalar_one_or_none()

--- a/Backend_FastAPI/app/routers/admin_v2_admission_round.py
+++ b/Backend_FastAPI/app/routers/admin_v2_admission_round.py
@@ -1,0 +1,273 @@
+# app/routers/admin_v2_admission_round.py
+"""Admin v2 — admission_round CRUD endpoints (Phase 2 v8.2 PR-2A v2).
+
+Year-level routes (Q1 v8.2). Mirrors ``admin_v2_system_config`` pattern:
+``/api/v2/admin`` prefix, ``Depends(require_admin)`` for read+write
+(Q P2-3 v8.1 — admin URL space implies admin-only), structlog audit.
+
+Endpoints
+---------
+* ``POST   /api/v2/admin/years/{academic_year}/rounds`` — create single
+* ``POST   /api/v2/admin/years/{academic_year}/rounds/bulk-create`` — atomic 4 đợt
+* ``GET    /api/v2/admin/years/{academic_year}/rounds`` — list per year
+* ``GET    /api/v2/admin/rounds/{round_id}`` — single
+* ``PATCH  /api/v2/admin/rounds/{round_id}`` — edit time-window/lifecycle
+* ``DELETE /api/v2/admin/rounds/{round_id}`` — soft-archive
+* ``POST   /api/v2/admin/rounds/{round_id}/extend`` — admin extend end_date
+"""
+
+import structlog
+from fastapi import APIRouter, Depends, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database, models
+from app.core.deps import require_admin
+from app.core.rate_limits import RateLimits, limiter
+from app.schemas.admission_round import (
+    AdmissionRoundBulkCreate,
+    AdmissionRoundBulkCreateResponse,
+    AdmissionRoundCreate,
+    AdmissionRoundExtend,
+    AdmissionRoundListResponse,
+    AdmissionRoundResponse,
+    AdmissionRoundUpdate,
+)
+from app.services import activity_service
+from app.services.admission_round_service import AdmissionRoundService
+
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(
+    prefix="/api/v2/admin",
+    tags=["Admin v2 - Admission Round"],
+)
+
+
+# =============================================================================
+# Year-level scoped endpoints
+# =============================================================================
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.post(
+    "/years/{academic_year}/rounds",
+    response_model=AdmissionRoundResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_round(
+    request: Request,
+    academic_year: int,
+    payload: AdmissionRoundCreate,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """Create new round under academic_year (Q1 v8.2 — year-level)."""
+    service = AdmissionRoundService(db)
+    round_obj = await service.create(academic_year, payload, current_admin)
+
+    await activity_service.log_activity(
+        db=db,
+        action="admission_round_create",
+        resource_type="offering_admission_round",
+        resource_id=round_obj.id,
+        actor_id=current_admin.id,
+        description=(
+            f"Round {payload.round_code!r} created cho năm {academic_year}"
+        ),
+        changes={
+            "academic_year": academic_year,
+            "round_code": payload.round_code,
+            "round_name": payload.round_name,
+        },
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    await db.commit()
+    await db.refresh(round_obj)
+    return AdmissionRoundResponse.model_validate(round_obj)
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.post(
+    "/years/{academic_year}/rounds/bulk-create",
+    response_model=AdmissionRoundBulkCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def bulk_create_rounds(
+    request: Request,
+    academic_year: int,
+    payload: AdmissionRoundBulkCreate,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """Bulk-create rounds (e.g., 4 đợt năm 2026 atomic).
+
+    Per Q1 v8.2 + PR-2A v2 plan: top-down workflow — admin tạo nhiều
+    rounds cùng lúc thay vì per-major bottom-up.
+    """
+    service = AdmissionRoundService(db)
+    created, skipped = await service.bulk_create(academic_year, payload, current_admin)
+
+    await activity_service.log_activity(
+        db=db,
+        action="admission_round_bulk_create",
+        resource_type="offering_admission_round",
+        actor_id=current_admin.id,
+        description=(
+            f"Bulk-created {len(created)} rounds cho năm {academic_year} "
+            f"({skipped} duplicates skipped)"
+        ),
+        changes={
+            "academic_year": academic_year,
+            "requested": len(payload.rounds),
+            "created": len(created),
+            "skipped": skipped,
+            "round_codes": [r.round_code for r in created],
+        },
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    await db.commit()
+    for r in created:
+        await db.refresh(r)
+
+    return AdmissionRoundBulkCreateResponse(
+        requested=len(payload.rounds),
+        created=len(created),
+        skipped_duplicates=skipped,
+        items=[AdmissionRoundResponse.model_validate(r) for r in created],
+    )
+
+
+@router.get(
+    "/years/{academic_year}/rounds",
+    response_model=AdmissionRoundListResponse,
+)
+async def list_rounds_by_year(
+    academic_year: int,
+    db: AsyncSession = Depends(database.get_db),
+    _admin: models.User = Depends(require_admin),
+):
+    """List rounds under academic_year, ordered by round_code."""
+    service = AdmissionRoundService(db)
+    rows = await service.list_by_year(academic_year)
+    return AdmissionRoundListResponse(
+        total=len(rows),
+        items=[AdmissionRoundResponse.model_validate(r) for r in rows],
+    )
+
+
+# =============================================================================
+# Direct round operations (by round_id)
+# =============================================================================
+
+
+@router.get("/rounds/{round_id}", response_model=AdmissionRoundResponse)
+async def get_round(
+    round_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    _admin: models.User = Depends(require_admin),
+):
+    """Fetch single round detail."""
+    service = AdmissionRoundService(db)
+    round_obj = await service.get_by_id(round_id)
+    return AdmissionRoundResponse.model_validate(round_obj)
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.patch("/rounds/{round_id}", response_model=AdmissionRoundResponse)
+async def update_round(
+    request: Request,
+    round_id: int,
+    payload: AdmissionRoundUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """Update round time-window/lifecycle (Phase 2 scope per Q3 v8.2)."""
+    service = AdmissionRoundService(db)
+    round_obj = await service.update(round_id, payload, current_admin)
+
+    await activity_service.log_activity(
+        db=db,
+        action="admission_round_update",
+        resource_type="offering_admission_round",
+        resource_id=round_id,
+        actor_id=current_admin.id,
+        description=f"Round {round_id} updated",
+        changes=payload.model_dump(exclude_unset=True),
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    await db.commit()
+    await db.refresh(round_obj)
+    return AdmissionRoundResponse.model_validate(round_obj)
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.delete("/rounds/{round_id}", response_model=AdmissionRoundResponse)
+async def soft_archive_round(
+    request: Request,
+    round_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """Soft-archive round (Concern γ v6 carry forward).
+
+    Phase 2: allow regardless of submission_count (admin discretion).
+    """
+    service = AdmissionRoundService(db)
+    round_obj = await service.soft_archive(round_id, current_admin)
+
+    await activity_service.log_activity(
+        db=db,
+        action="admission_round_soft_archive",
+        resource_type="offering_admission_round",
+        resource_id=round_id,
+        actor_id=current_admin.id,
+        description=f"Round {round_id} soft-archived",
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    await db.commit()
+    await db.refresh(round_obj)
+    return AdmissionRoundResponse.model_validate(round_obj)
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.post("/rounds/{round_id}/extend", response_model=AdmissionRoundResponse)
+async def extend_round(
+    request: Request,
+    round_id: int,
+    payload: AdmissionRoundExtend,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """Admin extend ``end_date`` per SPEC §2.1.a Rule 2."""
+    service = AdmissionRoundService(db)
+    round_obj = await service.extend(round_id, payload, current_admin)
+
+    await activity_service.log_activity(
+        db=db,
+        action="admission_round_extend",
+        resource_type="offering_admission_round",
+        resource_id=round_id,
+        actor_id=current_admin.id,
+        description=(
+            f"Round {round_id} end_date extended to {payload.end_date.isoformat()}"
+        ),
+        changes={
+            "new_end_date": payload.end_date.isoformat(),
+            "extension_reason": payload.extension_reason,
+        },
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    await db.commit()
+    await db.refresh(round_obj)
+    return AdmissionRoundResponse.model_validate(round_obj)

--- a/Backend_FastAPI/app/schemas/admission_round.py
+++ b/Backend_FastAPI/app/schemas/admission_round.py
@@ -1,0 +1,130 @@
+# app/schemas/admission_round.py
+"""Pydantic schemas for OfferingAdmissionRound (Phase 2 v8.2 PR-2A v2).
+
+Year-level round entity. Quota fields (round_quota, admit_quota,
+submission_count) ship trên admission_path (PR-2B v2), KHÔNG trên đây.
+"""
+
+from datetime import date, datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class AdmissionRoundBase(BaseModel):
+    """Common fields for create/update payloads."""
+
+    round_code: str = Field(
+        ...,
+        min_length=1,
+        max_length=20,
+        description="Pure string (Q8 v8.2): DOT_1 / DOT_2 / DOT_3 / BO_SUNG / DOT_1_VLVH",
+    )
+    round_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description='Localized display: "Đợt 1 - 2026"',
+    )
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    is_active: bool = True
+
+
+class AdmissionRoundCreate(AdmissionRoundBase):
+    """Payload for POST /api/v2/admin/years/{academic_year}/rounds."""
+
+    pass
+
+
+class AdmissionRoundUpdate(BaseModel):
+    """Partial update payload — all fields optional. Time-window/lifecycle
+    only Phase 2 (Q3 v8.2 — notification template defer Phase 3)."""
+
+    round_name: Optional[str] = Field(None, min_length=1, max_length=100)
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    is_active: Optional[bool] = None
+
+
+class AdmissionRoundExtend(BaseModel):
+    """Payload for POST /api/v2/admin/rounds/{id}/extend (SPEC §2.1.a Rule 2)."""
+
+    end_date: date = Field(..., description="New end_date — must be later than current")
+    extension_reason: str = Field(
+        ...,
+        min_length=10,
+        description="Reason ≥10 chars mandatory per SPEC §2.1.a",
+    )
+
+    @field_validator("extension_reason")
+    @classmethod
+    def _strip_reason(cls, v: str) -> str:
+        v = v.strip()
+        if len(v) < 10:
+            raise ValueError("extension_reason must be ≥10 chars after trimming")
+        return v
+
+
+class AdmissionRoundBulkCreateItem(BaseModel):
+    """Individual round in bulk-create payload."""
+
+    round_code: str = Field(..., min_length=1, max_length=20)
+    round_name: str = Field(..., min_length=1, max_length=100)
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+    is_active: bool = True
+
+
+class AdmissionRoundBulkCreate(BaseModel):
+    """Payload for POST /api/v2/admin/years/{academic_year}/rounds/bulk-create.
+
+    Atomic transaction: tạo nhiều rounds cho cùng 1 academic_year.
+    ON CONFLICT(academic_year, round_code) DO NOTHING — re-runnable safe.
+    """
+
+    rounds: List[AdmissionRoundBulkCreateItem] = Field(
+        ...,
+        min_length=1,
+        max_length=10,
+        description="List rounds to create atomically (e.g., 4 đợt năm 2026)",
+    )
+
+
+class AdmissionRoundResponse(BaseModel):
+    """Full round detail response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    academic_year: int
+    round_code: str
+    round_name: str
+    start_date: Optional[date]
+    end_date: Optional[date]
+    is_active: bool
+    archived_at: Optional[datetime]
+
+    # SPEC §2.1.a Rule 2 audit fields
+    extended_at: Optional[datetime]
+    extended_by_user_id: Optional[int]
+    extension_reason: Optional[str]
+
+    created_at: datetime
+    updated_at: datetime
+
+
+class AdmissionRoundListResponse(BaseModel):
+    """List wrapper for GET /years/{academic_year}/rounds."""
+
+    total: int
+    items: List[AdmissionRoundResponse]
+
+
+class AdmissionRoundBulkCreateResponse(BaseModel):
+    """Bulk-create result summary."""
+
+    requested: int
+    created: int
+    skipped_duplicates: int
+    items: List[AdmissionRoundResponse]

--- a/Backend_FastAPI/app/schemas/admission_round.py
+++ b/Backend_FastAPI/app/schemas/admission_round.py
@@ -79,8 +79,11 @@ class AdmissionRoundBulkCreateItem(BaseModel):
 class AdmissionRoundBulkCreate(BaseModel):
     """Payload for POST /api/v2/admin/years/{academic_year}/rounds/bulk-create.
 
-    Atomic transaction: tạo nhiều rounds cho cùng 1 academic_year.
-    ON CONFLICT(academic_year, round_code) DO NOTHING — re-runnable safe.
+    Idempotent transaction: skip duplicates by (academic_year, round_code),
+    create new rounds atomically. Re-runnable safely. Per-item duplicate
+    check + skip + continue; non-duplicate errors abort entire txn (router
+    db.commit() không chạy → rollback) — atomic-on-error, partial-success-
+    on-duplicate semantic (P2-3 v8.2 wording fix).
     """
 
     rounds: List[AdmissionRoundBulkCreateItem] = Field(

--- a/Backend_FastAPI/app/services/admission_round_service.py
+++ b/Backend_FastAPI/app/services/admission_round_service.py
@@ -1,0 +1,212 @@
+# app/services/admission_round_service.py
+"""Service layer for OfferingAdmissionRound year-level (Phase 2 v8.2 PR-2A v2).
+
+Implements:
+* Round CRUD year-level
+* Bulk-create (4 đợt atomic per academic_year)
+* SPEC §2.1.a Rule 2: extend endpoint với audit log
+* Soft-archive (Concern γ v6 — Phase 2 admin discretion regardless of
+  submission_count; per-path counter PR-2B v2 sẽ handle)
+
+Tier 1 chain logic (admit_quota per academic_info) MOVED to
+``admission_quota_service`` (PR-2B v2 ships sau khi quota fields trên
+admission_path). Round table không có quota fields nữa (Q1 Option A).
+"""
+
+from datetime import datetime, timezone
+from typing import List
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import OfferingAdmissionRound, User
+from app.repositories.admission_round_repository import AdmissionRoundRepository
+from app.schemas.admission_round import (
+    AdmissionRoundBulkCreate,
+    AdmissionRoundCreate,
+    AdmissionRoundExtend,
+    AdmissionRoundUpdate,
+)
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    DuplicateResourceError,
+    ResourceNotFoundError,
+)
+
+log = structlog.get_logger(__name__)
+
+
+class AdmissionRoundService:
+    """Business logic for admission rounds year-level."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = AdmissionRoundRepository(db)
+
+    async def create(
+        self, academic_year: int, payload: AdmissionRoundCreate, current_admin: User
+    ) -> OfferingAdmissionRound:
+        """Create new round under academic_year.
+
+        Guards:
+        * round_code UNIQUE per academic_year
+        """
+        existing = await self.repo.get_by_year_and_code(academic_year, payload.round_code)
+        if existing is not None:
+            raise DuplicateResourceError(
+                f"Round {payload.round_code!r} đã tồn tại cho năm {academic_year}"
+            )
+
+        round_obj = OfferingAdmissionRound(
+            academic_year=academic_year,
+            round_code=payload.round_code,
+            round_name=payload.round_name,
+            start_date=payload.start_date,
+            end_date=payload.end_date,
+            is_active=payload.is_active,
+        )
+        self.db.add(round_obj)
+        await self.db.flush()
+
+        log.info(
+            "admission_round_created",
+            round_id=round_obj.id,
+            academic_year=academic_year,
+            round_code=payload.round_code,
+            admin_id=current_admin.id,
+        )
+        return round_obj
+
+    async def bulk_create(
+        self, academic_year: int, payload: AdmissionRoundBulkCreate, current_admin: User
+    ) -> tuple[List[OfferingAdmissionRound], int]:
+        """Bulk-create rounds atomic per academic_year.
+
+        ON CONFLICT skip duplicates. Returns (created_rounds, skipped_count).
+        """
+        created: List[OfferingAdmissionRound] = []
+        skipped = 0
+
+        for item in payload.rounds:
+            existing = await self.repo.get_by_year_and_code(academic_year, item.round_code)
+            if existing is not None:
+                skipped += 1
+                continue
+
+            round_obj = OfferingAdmissionRound(
+                academic_year=academic_year,
+                round_code=item.round_code,
+                round_name=item.round_name,
+                start_date=item.start_date,
+                end_date=item.end_date,
+                is_active=item.is_active,
+            )
+            self.db.add(round_obj)
+            await self.db.flush()
+            created.append(round_obj)
+
+        log.info(
+            "admission_round_bulk_created",
+            academic_year=academic_year,
+            requested=len(payload.rounds),
+            created=len(created),
+            skipped_duplicates=skipped,
+            admin_id=current_admin.id,
+        )
+        return created, skipped
+
+    async def update(
+        self, round_id: int, payload: AdmissionRoundUpdate, current_admin: User
+    ) -> OfferingAdmissionRound:
+        """Update round time-window/lifecycle fields (Phase 2 scope per Q3)."""
+        round_obj = await self.repo.get_by_id(round_id)
+        if round_obj is None:
+            raise ResourceNotFoundError(f"Round {round_id} not found")
+
+        update_data = payload.model_dump(exclude_unset=True)
+
+        for field, value in update_data.items():
+            setattr(round_obj, field, value)
+
+        await self.db.flush()
+        log.info(
+            "admission_round_updated",
+            round_id=round_id,
+            fields=list(update_data.keys()),
+            admin_id=current_admin.id,
+        )
+        return round_obj
+
+    async def soft_archive(
+        self, round_id: int, current_admin: User
+    ) -> OfferingAdmissionRound:
+        """DELETE endpoint = soft-archive (Concern γ v6 carry forward).
+
+        Phase 2 behavior: allow regardless of submission_count (admin
+        discretion). is_active=false hides round khỏi storefront. Per-path
+        submission_count (PR-2B v2) preserved cho audit.
+        """
+        round_obj = await self.repo.get_by_id(round_id)
+        if round_obj is None:
+            raise ResourceNotFoundError(f"Round {round_id} not found")
+
+        if round_obj.archived_at is not None:
+            raise BusinessRuleViolation(
+                f"Round {round_id} already archived at {round_obj.archived_at}"
+            )
+
+        round_obj.archived_at = datetime.now(timezone.utc)
+        round_obj.is_active = False
+
+        await self.db.flush()
+        log.info(
+            "admission_round_soft_archived",
+            round_id=round_id,
+            admin_id=current_admin.id,
+        )
+        return round_obj
+
+    async def extend(
+        self, round_id: int, payload: AdmissionRoundExtend, current_admin: User
+    ) -> OfferingAdmissionRound:
+        """Admin extend end_date per SPEC §2.1.a Rule 2.
+
+        Audit fields ``extended_at``, ``extended_by_user_id``,
+        ``extension_reason`` written atomically. Reason ≥10 chars enforced
+        at schema layer.
+        """
+        round_obj = await self.repo.get_by_id(round_id)
+        if round_obj is None:
+            raise ResourceNotFoundError(f"Round {round_id} not found")
+
+        if round_obj.end_date is not None and payload.end_date <= round_obj.end_date:
+            raise BusinessRuleViolation(
+                f"New end_date ({payload.end_date}) phải sau current end_date "
+                f"({round_obj.end_date})"
+            )
+
+        round_obj.end_date = payload.end_date
+        round_obj.extended_at = datetime.now(timezone.utc)
+        round_obj.extended_by_user_id = current_admin.id
+        round_obj.extension_reason = payload.extension_reason
+
+        await self.db.flush()
+        log.info(
+            "admission_round_extended",
+            round_id=round_id,
+            new_end_date=payload.end_date.isoformat(),
+            admin_id=current_admin.id,
+            reason_len=len(payload.extension_reason),
+        )
+        return round_obj
+
+    async def list_by_year(
+        self, academic_year: int
+    ) -> List[OfferingAdmissionRound]:
+        return await self.repo.list_by_year(academic_year)
+
+    async def get_by_id(self, round_id: int) -> OfferingAdmissionRound:
+        round_obj = await self.repo.get_by_id(round_id)
+        if round_obj is None:
+            raise ResourceNotFoundError(f"Round {round_id} not found")
+        return round_obj

--- a/Backend_FastAPI/app/services/admission_round_service.py
+++ b/Backend_FastAPI/app/services/admission_round_service.py
@@ -80,10 +80,17 @@ class AdmissionRoundService:
     async def bulk_create(
         self, academic_year: int, payload: AdmissionRoundBulkCreate, current_admin: User
     ) -> tuple[List[OfferingAdmissionRound], int]:
-        """Bulk-create rounds atomic per academic_year.
+        """Bulk-create rounds idempotent per academic_year.
 
-        ON CONFLICT skip duplicates. Returns (created_rounds, skipped_count).
+        Per-item duplicate check + skip; non-duplicate DB errors abort
+        entire txn (router db.commit() không chạy → rollback). Returns
+        (created_rounds, skipped_count). P2-3 v8.2 semantic clarification.
+
+        Race-window mitigation (P2-4 v8.2): wrap IntegrityError trên flush
+        thành DuplicateResourceError friendly cho concurrent admin scenario.
         """
+        from sqlalchemy.exc import IntegrityError
+
         created: List[OfferingAdmissionRound] = []
         skipped = 0
 
@@ -102,7 +109,17 @@ class AdmissionRoundService:
                 is_active=item.is_active,
             )
             self.db.add(round_obj)
-            await self.db.flush()
+            try:
+                await self.db.flush()
+            except IntegrityError as exc:
+                # Race: 2 admins bulk-create same round_code concurrently.
+                # First commit, second hits UNIQUE → friendly 409 instead
+                # of raw 500.
+                await self.db.rollback()
+                raise DuplicateResourceError(
+                    f"Round {item.round_code!r} đã tồn tại cho năm {academic_year} "
+                    f"(race condition — admin khác vừa tạo cùng lúc)"
+                ) from exc
             created.append(round_obj)
 
         log.info(

--- a/Backend_FastAPI/tests/fixtures/builders.py
+++ b/Backend_FastAPI/tests/fixtures/builders.py
@@ -136,3 +136,52 @@ class SeedDependenciesBuilder:
             "status_a1_id": status_a1_id,
             "stage_id": stage_a_id,
         }
+
+
+# =============================================================================
+# Phase 2 v8.2 PR-2A v2 — AdmissionRoundBuilder year-level (Q1 Option A)
+# =============================================================================
+
+
+class AdmissionRoundBuilder:
+    """Builder for OfferingAdmissionRound test fixtures (year-level).
+
+    Q1 v8.2: round = 1 row globally per (academic_year, round_code), NOT
+    per academic_info (v6 archived).
+
+    Defaults: round_code='DOT_1', academic_year=2026, dates NULL,
+    is_active=True. No quota fields (moved to admission_path PR-2B v2).
+
+    Usage::
+
+        round_payload = AdmissionRoundBuilder.make(academic_year=2026)
+        round_obj = models.OfferingAdmissionRound(**round_payload)
+        session.add(round_obj)
+    """
+
+    @staticmethod
+    def make(
+        academic_year: int = 2026,
+        round_code: str = "DOT_1",
+        **overrides,
+    ) -> dict:
+        # Extract round number from code for display name (DOT_1 → "Đợt 1")
+        suffix = (
+            round_code.replace("DOT_", "")
+            if round_code.startswith("DOT_")
+            else round_code
+        )
+        defaults = {
+            "academic_year": academic_year,
+            "round_code": round_code,
+            "round_name": f"Đợt {suffix} - {academic_year}",
+            "start_date": None,
+            "end_date": None,
+            "is_active": True,
+            "archived_at": None,
+            "extended_at": None,
+            "extended_by_user_id": None,
+            "extension_reason": None,
+        }
+        defaults.update(overrides)
+        return defaults

--- a/Backend_FastAPI/tests/services/test_phase2_admission_round_service.py
+++ b/Backend_FastAPI/tests/services/test_phase2_admission_round_service.py
@@ -1,0 +1,459 @@
+"""Service-level tests for AdmissionRoundService year-level
+(Phase 2 v8.2 PR-2A v2 — Option A).
+
+Covers:
+* Year-level CRUD service guards
+* Bulk-create atomic per academic_year (Q1 v8.2)
+* Concern γ v6 — soft-archive admin discretion
+* Concern A v4 — extend writes audit fields
+* Repository ``get_default_dot1(academic_year)`` helper
+
+Anchor tests per memory pattern-change-impact-audit (P3-2 v8.2).
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.repositories.admission_round_repository import AdmissionRoundRepository
+from app.schemas.admission_round import (
+    AdmissionRoundBulkCreate,
+    AdmissionRoundBulkCreateItem,
+    AdmissionRoundCreate,
+    AdmissionRoundExtend,
+    AdmissionRoundUpdate,
+)
+from app.services.admission_round_service import AdmissionRoundService
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    DuplicateResourceError,
+    ResourceNotFoundError,
+)
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def round_test_seed(seed_lead_dependencies: dict) -> dict:
+    """Seed minimal admin user + return academic_year cho year-level tests.
+
+    Note: Year-level Option A KHÔNG cần academic_info seed (round độc lập
+    của academic_info). Chỉ cần admin user làm actor.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000)
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            from app.security import get_password_hash
+            admin = models.User(
+                username=f"admin_p2v2_{ts}",
+                email=f"admin_p2v2_{ts}@test.local",
+                full_name="Test Admin",
+                password_hash=get_password_hash("test"),
+                role="admin",
+                status="active",
+            )
+            s.add(admin)
+            await s.flush()
+
+    return {"academic_year": 2026, "admin_user_id": admin.id}
+
+
+async def _get_admin(db: AsyncSession, admin_id: int) -> models.User:
+    return await db.get(models.User, admin_id)
+
+
+# ---------------------------------------------------------------------------
+# Round create
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_create_unique_per_year_code(round_test_seed: dict) -> None:
+    """ANCHOR (P3-2 v8.2): Q1 v8.2 invariant — UNIQUE(academic_year, round_code).
+    Same round_code khác year cho phép; same year-code raise duplicate."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+
+        # Create DOT_1 năm 2026
+        await service.create(
+            2026,
+            AdmissionRoundCreate(round_code="DOT_1", round_name="Đợt 1 - 2026"),
+            admin,
+        )
+        await db.commit()
+
+    # Same year + code → reject
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        with pytest.raises(DuplicateResourceError):
+            await service.create(
+                2026,
+                AdmissionRoundCreate(round_code="DOT_1", round_name="dup"),
+                admin,
+            )
+
+    # Cross-year: same code OK năm 2027
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_2027 = await service.create(
+            2027,
+            AdmissionRoundCreate(round_code="DOT_1", round_name="Đợt 1 - 2027"),
+            admin,
+        )
+        await db.commit()
+        assert round_2027.academic_year == 2027
+
+
+@pytest.mark.asyncio
+async def test_round_create_minimal_payload(round_test_seed: dict) -> None:
+    """Create với time-window NULL (Q3 v8.2 — admin set qua extend sau)."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_obj = await service.create(
+            2026,
+            AdmissionRoundCreate(round_code="DOT_2", round_name="Đợt 2 - 2026"),
+            admin,
+        )
+        await db.commit()
+
+        assert round_obj.start_date is None
+        assert round_obj.end_date is None
+        assert round_obj.is_active is True
+        assert round_obj.archived_at is None
+
+
+# ---------------------------------------------------------------------------
+# Bulk-create (Q1 v8.2 top-down workflow)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_create_4_rounds_atomic(round_test_seed: dict) -> None:
+    """ANCHOR: Q1 v8.2 top-down — admin tạo 4 đợt cùng lúc cho 1 academic_year."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+
+        payload = AdmissionRoundBulkCreate(
+            rounds=[
+                AdmissionRoundBulkCreateItem(round_code="DOT_1", round_name="Đợt 1 - 2026"),
+                AdmissionRoundBulkCreateItem(round_code="DOT_2", round_name="Đợt 2 - 2026"),
+                AdmissionRoundBulkCreateItem(round_code="DOT_3", round_name="Đợt 3 - 2026"),
+                AdmissionRoundBulkCreateItem(round_code="BO_SUNG", round_name="Đợt bổ sung 2026"),
+            ]
+        )
+        created, skipped = await service.bulk_create(2026, payload, admin)
+        await db.commit()
+
+        assert len(created) == 4
+        assert skipped == 0
+        codes = {r.round_code for r in created}
+        assert codes == {"DOT_1", "DOT_2", "DOT_3", "BO_SUNG"}
+
+
+@pytest.mark.asyncio
+async def test_bulk_create_skips_duplicates(round_test_seed: dict) -> None:
+    """Bulk-create with existing rounds skips dup, creates rest."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+
+        # Pre-create DOT_1
+        await service.create(
+            2026,
+            AdmissionRoundCreate(round_code="DOT_1", round_name="Pre - 2026"),
+            admin,
+        )
+        await db.commit()
+
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+
+        # Bulk-create với DOT_1 dup + DOT_2 fresh
+        payload = AdmissionRoundBulkCreate(
+            rounds=[
+                AdmissionRoundBulkCreateItem(round_code="DOT_1", round_name="dup"),
+                AdmissionRoundBulkCreateItem(round_code="DOT_2", round_name="Đợt 2 - 2026"),
+            ]
+        )
+        created, skipped = await service.bulk_create(2026, payload, admin)
+        await db.commit()
+
+        assert len(created) == 1
+        assert skipped == 1
+        assert created[0].round_code == "DOT_2"
+
+
+# ---------------------------------------------------------------------------
+# Soft-archive (Concern γ v6 — Phase 2 admin discretion)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_soft_archive_sets_archived_at_and_is_active_false(
+    round_test_seed: dict,
+) -> None:
+    """ANCHOR: Concern γ v6 — soft-archive sets archived_at + is_active=false."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_obj = await service.create(
+            2026,
+            AdmissionRoundCreate(round_code="DOT_1", round_name="Đợt 1 - 2026"),
+            admin,
+        )
+        await db.commit()
+        round_id = round_obj.id
+
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        archived = await service.soft_archive(round_id, admin)
+        await db.commit()
+
+        assert archived.archived_at is not None
+        assert archived.is_active is False
+
+    # Row still exists (soft, not hard delete)
+    async with AsyncSessionLocal() as db:
+        row = await db.get(models.OfferingAdmissionRound, round_id)
+        assert row is not None
+        assert row.archived_at is not None
+
+
+@pytest.mark.asyncio
+async def test_double_archive_rejected(round_test_seed: dict) -> None:
+    """Double archive raise — already archived state guard."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_obj = await service.create(
+            2026,
+            AdmissionRoundCreate(round_code="DOT_1", round_name="Đợt 1 - 2026"),
+            admin,
+        )
+        await db.commit()
+        round_id = round_obj.id
+
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        await service.soft_archive(round_id, admin)
+        await db.commit()
+
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        with pytest.raises(BusinessRuleViolation, match="already archived"):
+            await service.soft_archive(round_id, admin)
+
+
+# ---------------------------------------------------------------------------
+# Extend — Concern A v4 audit fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_extend_writes_extended_at_user_id_reason(
+    round_test_seed: dict,
+) -> None:
+    """ANCHOR: Concern A v4 — SPEC §2.1.a Rule 2: extend writes 3 audit fields."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_obj = await service.create(
+            2026,
+            AdmissionRoundCreate(
+                round_code="DOT_1",
+                round_name="Đợt 1 - 2026",
+                end_date=date(2026, 6, 30),
+            ),
+            admin,
+        )
+        await db.commit()
+        round_id = round_obj.id
+
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        extended = await service.extend(
+            round_id,
+            AdmissionRoundExtend(
+                end_date=date(2026, 9, 30),
+                extension_reason="Kéo dài đợt do COVID resurgence",
+            ),
+            admin,
+        )
+        await db.commit()
+
+        assert extended.end_date == date(2026, 9, 30)
+        assert extended.extended_at is not None
+        assert extended.extended_by_user_id == round_test_seed["admin_user_id"]
+        assert "COVID" in extended.extension_reason
+
+
+@pytest.mark.asyncio
+async def test_round_extend_rejects_earlier_or_same_date(
+    round_test_seed: dict,
+) -> None:
+    """ANCHOR: SPEC §2.1.a Rule 2 — boundary check earlier AND same."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_obj = await service.create(
+            2026,
+            AdmissionRoundCreate(
+                round_code="DOT_1",
+                round_name="Đợt 1 - 2026",
+                end_date=date(2026, 6, 30),
+            ),
+            admin,
+        )
+        await db.commit()
+        round_id = round_obj.id
+
+    # Earlier
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        with pytest.raises(BusinessRuleViolation, match="phải sau current"):
+            await service.extend(
+                round_id,
+                AdmissionRoundExtend(
+                    end_date=date(2026, 5, 1),
+                    extension_reason="Test invalid earlier date",
+                ),
+                admin,
+            )
+
+    # Same date (== boundary)
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        with pytest.raises(BusinessRuleViolation, match="phải sau current"):
+            await service.extend(
+                round_id,
+                AdmissionRoundExtend(
+                    end_date=date(2026, 6, 30),
+                    extension_reason="Test invalid same date",
+                ),
+                admin,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Repository helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admission_round_repository_get_default_dot1(
+    round_test_seed: dict,
+) -> None:
+    """Service shim auto-resolve target — used by PR-2B v2
+    create_admission_path khi caller omits round_id (year-level lookup)."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        await service.create(
+            2026,
+            AdmissionRoundCreate(round_code="DOT_1", round_name="Đợt 1 - 2026"),
+            admin,
+        )
+        await service.create(
+            2026,
+            AdmissionRoundCreate(round_code="DOT_2", round_name="Đợt 2 - 2026"),
+            admin,
+        )
+        await db.commit()
+
+    async with AsyncSessionLocal() as db:
+        repo = AdmissionRoundRepository(db)
+        dot1 = await repo.get_default_dot1(academic_year=2026)
+        assert dot1 is not None
+        assert dot1.round_code == "DOT_1"
+        assert dot1.academic_year == 2026
+
+
+@pytest.mark.asyncio
+async def test_admission_round_repository_list_ordered_by_code(
+    round_test_seed: dict,
+) -> None:
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        for code in ["DOT_2", "DOT_1", "BO_SUNG"]:
+            await service.create(
+                2026,
+                AdmissionRoundCreate(round_code=code, round_name=f"{code} - 2026"),
+                admin,
+            )
+        await db.commit()
+
+    async with AsyncSessionLocal() as db:
+        service = AdmissionRoundService(db)
+        rows = await service.list_by_year(2026)
+        codes = [r.round_code for r in rows]
+        # alphabetical: BO_SUNG < DOT_1 < DOT_2
+        assert codes == ["BO_SUNG", "DOT_1", "DOT_2"]
+
+
+@pytest.mark.asyncio
+async def test_admission_round_service_get_by_id_raises_when_missing(
+    round_test_seed: dict,
+) -> None:
+    async with AsyncSessionLocal() as db:
+        service = AdmissionRoundService(db)
+        with pytest.raises(ResourceNotFoundError):
+            await service.get_by_id(99_999_999)
+
+
+# ---------------------------------------------------------------------------
+# Update (Phase 2 scope per Q3 v8.2 — time-window/lifecycle only)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_update_time_window_only(round_test_seed: dict) -> None:
+    """Q3 v8.2 — update accept time-window/lifecycle fields only.
+    Notification template defer Phase 3."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_obj = await service.create(
+            2026,
+            AdmissionRoundCreate(round_code="DOT_1", round_name="Đợt 1 - 2026"),
+            admin,
+        )
+        await db.commit()
+        round_id = round_obj.id
+
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        updated = await service.update(
+            round_id,
+            AdmissionRoundUpdate(
+                round_name="Đợt 1 (đã sửa)",
+                start_date=date(2026, 3, 1),
+                end_date=date(2026, 6, 30),
+                is_active=True,
+            ),
+            admin,
+        )
+        await db.commit()
+
+        assert updated.round_name == "Đợt 1 (đã sửa)"
+        assert updated.start_date == date(2026, 3, 1)
+        assert updated.end_date == date(2026, 6, 30)

--- a/Backend_FastAPI/tests/unit/test_phase2_admission_round.py
+++ b/Backend_FastAPI/tests/unit/test_phase2_admission_round.py
@@ -1,0 +1,220 @@
+"""Unit tests for OfferingAdmissionRound model + schema + builder
+(Phase 2 v8.2 PR-2A v2 — Option A year-level).
+
+Anchor tests per memory pattern-change-impact-audit (P3-2 v8.2 mandate).
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. Model schema shape (Q1 year-level anchor)
+# ---------------------------------------------------------------------------
+
+
+def test_offering_admission_round_unique_per_year_code() -> None:
+    """ANCHOR (P3-2 v8.2): Q1 v8.2 invariant — UNIQUE(academic_year, round_code)
+    confirms round is year-level entity globally, NOT per-academic_info.
+
+    v6 archived schema dùng UNIQUE(academic_info_id, round_code) — Option A
+    pivot moves to year-level."""
+    from app.models import OfferingAdmissionRound
+
+    table_args = OfferingAdmissionRound.__table_args__
+    unique_names = {
+        c.name for c in table_args
+        if hasattr(c, "name") and c.name and "uq_" in c.name
+    }
+    assert "uq_offering_admission_round_year_code" in unique_names
+
+    # Verify columns of UNIQUE constraint
+    for c in table_args:
+        if hasattr(c, "name") and c.name == "uq_offering_admission_round_year_code":
+            col_names = [col.name for col in c.columns]
+            assert col_names == ["academic_year", "round_code"]
+            return
+    pytest.fail("UNIQUE constraint not found on (academic_year, round_code)")
+
+
+def test_offering_admission_round_no_academic_info_id_column() -> None:
+    """ANCHOR: Q1 v8.2 — round table KHÔNG có academic_info_id (moved to year-level)."""
+    from app.models import OfferingAdmissionRound
+
+    cols = {c.name for c in OfferingAdmissionRound.__table__.columns}
+    assert "academic_info_id" not in cols, (
+        "academic_info_id removed in v8.2 Option A — round at year level"
+    )
+    assert "academic_year" in cols
+
+
+def test_offering_admission_round_no_quota_fields() -> None:
+    """ANCHOR: v8.2 — quota fields (round_quota, admit_quota, submission_count)
+    MOVED to admission_path (PR-2B v2). Round table chỉ giữ time-window/lifecycle."""
+    from app.models import OfferingAdmissionRound
+
+    cols = {c.name for c in OfferingAdmissionRound.__table__.columns}
+    assert "round_quota" not in cols
+    assert "admit_quota" not in cols
+    assert "submission_count" not in cols
+
+
+def test_offering_admission_round_columns_match_v8_spec() -> None:
+    from app.models import OfferingAdmissionRound
+
+    cols = {c.name for c in OfferingAdmissionRound.__table__.columns}
+    expected = {
+        "id", "academic_year",
+        "round_code", "round_name",
+        "start_date", "end_date",
+        "is_active", "archived_at",
+        # SPEC §2.1.a Rule 2 audit fields
+        "extended_at", "extended_by_user_id", "extension_reason",
+        "created_at", "updated_at",
+    }
+    assert expected.issubset(cols), f"Missing: {expected - cols}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Pydantic schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_create_schema_requires_round_code_and_name() -> None:
+    from pydantic import ValidationError
+
+    from app.schemas.admission_round import AdmissionRoundCreate
+
+    with pytest.raises(ValidationError):
+        AdmissionRoundCreate()  # missing required
+
+
+def test_create_schema_accepts_minimal_dot1_payload() -> None:
+    from app.schemas.admission_round import AdmissionRoundCreate
+
+    payload = AdmissionRoundCreate(
+        round_code="DOT_1", round_name="Đợt 1 - 2026"
+    )
+    assert payload.round_code == "DOT_1"
+    assert payload.round_name == "Đợt 1 - 2026"
+    assert payload.start_date is None
+    assert payload.end_date is None
+    assert payload.is_active is True
+
+
+def test_extend_schema_rejects_short_reason_under_10_chars() -> None:
+    from pydantic import ValidationError
+
+    from app.schemas.admission_round import AdmissionRoundExtend
+
+    with pytest.raises(ValidationError):
+        AdmissionRoundExtend(end_date=date(2026, 12, 31), extension_reason="short")
+
+
+def test_extend_schema_strips_whitespace_then_validates_length() -> None:
+    from pydantic import ValidationError
+
+    from app.schemas.admission_round import AdmissionRoundExtend
+
+    with pytest.raises(ValidationError):
+        AdmissionRoundExtend(
+            end_date=date(2026, 12, 31),
+            extension_reason="  9 chars  ",  # 9 visible chars after strip
+        )
+
+
+def test_extend_schema_accepts_10_char_reason() -> None:
+    from app.schemas.admission_round import AdmissionRoundExtend
+
+    payload = AdmissionRoundExtend(
+        end_date=date(2026, 12, 31),
+        extension_reason="exactly10c",
+    )
+    assert len(payload.extension_reason) == 10
+
+
+def test_response_schema_includes_extension_audit_fields() -> None:
+    from app.schemas.admission_round import AdmissionRoundResponse
+
+    schema_fields = AdmissionRoundResponse.model_fields.keys()
+    assert "academic_year" in schema_fields
+    assert "extended_at" in schema_fields
+    assert "extended_by_user_id" in schema_fields
+    assert "extension_reason" in schema_fields
+    assert "archived_at" in schema_fields
+    # No quota fields (moved to admission_path PR-2B v2)
+    assert "round_quota" not in schema_fields
+    assert "admit_quota" not in schema_fields
+    assert "submission_count" not in schema_fields
+
+
+def test_bulk_create_schema_min_max_constraints() -> None:
+    """Bulk-create accepts 1-10 rounds, atomic per academic_year."""
+    from pydantic import ValidationError
+
+    from app.schemas.admission_round import (
+        AdmissionRoundBulkCreate,
+        AdmissionRoundBulkCreateItem,
+    )
+
+    # Empty list rejected
+    with pytest.raises(ValidationError):
+        AdmissionRoundBulkCreate(rounds=[])
+
+    # Valid 4-round payload
+    payload = AdmissionRoundBulkCreate(
+        rounds=[
+            AdmissionRoundBulkCreateItem(round_code=code, round_name=f"Đợt {code} - 2026")
+            for code in ["DOT_1", "DOT_2", "DOT_3", "BO_SUNG"]
+        ]
+    )
+    assert len(payload.rounds) == 4
+
+
+# ---------------------------------------------------------------------------
+# 3. Builder factory defaults
+# ---------------------------------------------------------------------------
+
+
+def test_factory_admission_round_builder_year_level_defaults() -> None:
+    """Q4 v6 + Q1 v8.2 — extend tests/fixtures/builders.py với
+    AdmissionRoundBuilder year-level."""
+    from tests.fixtures.builders import AdmissionRoundBuilder
+
+    payload = AdmissionRoundBuilder.make(academic_year=2026)
+
+    assert payload["academic_year"] == 2026
+    assert payload["round_code"] == "DOT_1"
+    assert payload["round_name"] == "Đợt 1 - 2026"
+    assert payload["start_date"] is None
+    assert payload["end_date"] is None
+    assert payload["is_active"] is True
+    assert payload["archived_at"] is None
+    assert payload["extended_at"] is None
+    assert payload["extended_by_user_id"] is None
+    assert payload["extension_reason"] is None
+    # NO quota fields (moved to path)
+    assert "round_quota" not in payload
+    assert "admit_quota" not in payload
+    assert "submission_count" not in payload
+
+
+def test_factory_admission_round_builder_dot2_overrides() -> None:
+    from tests.fixtures.builders import AdmissionRoundBuilder
+
+    payload = AdmissionRoundBuilder.make(
+        academic_year=2026, round_code="DOT_2"
+    )
+    assert payload["round_code"] == "DOT_2"
+    assert payload["round_name"] == "Đợt 2 - 2026"
+
+
+def test_factory_admission_round_builder_year_2027() -> None:
+    """Cross-year override (P3-1 v8.2 — academic_year explicit)."""
+    from tests.fixtures.builders import AdmissionRoundBuilder
+
+    payload = AdmissionRoundBuilder.make(academic_year=2027, round_code="DOT_1")
+    assert payload["academic_year"] == 2027
+    assert payload["round_name"] == "Đợt 1 - 2027"

--- a/Documents/ADMISSION_DAILY_LOG.md
+++ b/Documents/ADMISSION_DAILY_LOG.md
@@ -56,6 +56,88 @@ KHÔNG được "defer to cutover" với bất kỳ lý do gì — cherry-pick h
 
 ## 2026-05-04
 
+## 2026-05-09 — Phase 2 PR-2A v6 ARCHIVED + design pivot Option A v8.2
+
+### Context — Pass 4 user review surfaces UX issue
+
+PR-2A v6 đã ship local (6 commits, 22 files, +2961 lines, browser smoke 8/8 PASS, BE pytest 26/26 + FE Vitest 25/25). Branch `feat/admission-phase2-01-rounds` chưa push. Trước khi push, user Pass 4 review (2026-05-09) flag:
+
+1. **UX issue tiếng Anh/Việt mix** trong RoundManagementPanel (Active/Inactive/Archived/Extended badges, "Override" label, "DOT_1" code leak)
+2. **Workflow inversion**: v6 schema `OfferingAdmissionRound.academic_info_id` FK forces admin vào từng ngành tạo đợt riêng (bottom-up). Nghiệp vụ thực = top-down (1 đợt cho cả trường, allocate quota per major)
+
+User confirm: "Như vậy nghiệp vụ vẫn là vào ngành thêm đợt tuyển sinh thì mới có đợt tuyển sinh đúng không?" → triggered design re-think.
+
+### Design pivot Option A (8-round audit thread)
+
+Em initial recommend Option B (giữ schema v6 + matrix UI top-level). User Pass 5 surface counter-argument: round metadata replication problem (extend/archive/notification template paid N-row coordination cost). Em flipped recommend Option A.
+
+**Walk-through 8 user stories + 4 edge cases** confirmed schema fit Option A. 4 NEW sub-decisions discovered (Q5-Q8): UNIQUE 3-col, clone deep-copy mandate (ADM-003 1:1 invariant), FK ON DELETE RESTRICT, round_code namespace.
+
+### 8 decisions chốt (Q1-Q8 LOCKED)
+
+| # | Decision | Choice |
+|---|---|---|
+| Q1 | Schema | Option A — round at academic_year level |
+| Q2 | Tier 1 chain root | admit_quota per academic_info |
+| Q3 | Round metadata Phase 2 | time-window only (defer notification template Phase 3) |
+| Q4 | Branch strategy | tag preserve v6 + new feat/admission-phase2-01-rounds-v2 |
+| Q5 | UNIQUE columns | 3-col (round_id, academic_info_id, method_id) |
+| Q6 | Clone strategy | hybrid modal + deep-copy criteria + criteria_subject_group + PSG config + items |
+| Q7 | FK ON DELETE | RESTRICT |
+| Q8 | round_code namespace | pure string + UI convention |
+
+### Plan v8 → v8.1 → v8.2 (3 P0 + 7 P2 + 5 P3 patches)
+
+**v8.1 P0 patches** (3 blockers Pass 5 review):
+- P0-1: `path.archived_at` không tồn tại — code dùng `status` enum (verified `admission_path.py:91-98`). Tier 1 filter chuyển `path.status != 'archived'`.
+- P0-2: DB trigger `enforce_applied_rules_immutability` (`b5c6d7e8f9a0_add_applied_rules_immutability_trigger.py:42-47`) chặn UPDATE applied_rules. PR-2B Task 3 wrap `DISABLE/ENABLE TRIGGER` try/finally per precedent `aa1i2j3k4l5m_pr6_allow_unverified_submission.py:65-92`.
+- P0-3: PR-2B Task 4 submission_count cast unsafe — CTE `safe_profiles` wrapper với regex + EXISTS guard parity Task 3.
+
+**v8.2 polish** (Pass 6 fresh-mindset audit, 7 P2 + 5 P3):
+- P2-1 helper naming consistent / P2-2 PR-2B v2 browser smoke / P2-3 rollback playbook scope / P2-4 multi-window 48h-24h / P2-5 A.0 approval note / P2-6 atomic submit tests / P2-7 deploy.sh pre-stage template
+- P3-1 URL `{academic_year}` consistent / P3-2 anchor test mandate matrix / P3-3 atomic increment shift mention / P3-4 admission_quota_service interface / P3-5 "120+ rows" wording
+
+### Task 10 execution 2026-05-09
+
+| Step | Action | Result |
+|---|---|---|
+| 1 | `git tag -a phase2-pr-2a-v6-archived feat/admission-phase2-01-rounds` | annotated tag `e95fa50b` → commit `59ba355a` |
+| 2 | `git push origin phase2-pr-2a-v6-archived` (em delegated approve) | tag pushed origin ✅ |
+| 3 | `docker compose exec backend alembic downgrade phase1_15a` (user approve test-run-approval-required) | head: phase2_01 → phase1_15a, table `offering_admission_round` dropped ✅ |
+| 4 | `\d offering_admission_round` verify | "table does not exist" ✅ |
+| 5-7 | git checkout main + pull + create v2 branch + delete v6 local | `feat/admission-phase2-01-rounds-v2` from main `7116794a` ✅ |
+
+### v6 → v8 PR breakdown delta
+
+| PR | v6 scope | v8.2 scope |
+|---|---|---|
+| PR-2A | round per-academic_info + drawer in AcademicInfoPanel | round at academic_year level + RoundsManagementTab top-level + bulk-create |
+| PR-2B | path.admission_round_id nullable + applied_rules backfill | + 3 quota fields (round_quota, admit_quota, submission_count) + 4-task backfill (DISABLE/ENABLE trigger + CTE safe_profiles) + admission_quota_service |
+| PR-2C | NOT NULL + 2-col UNIQUE swap | NOT NULL + 3-col UNIQUE swap (round_id, academic_info_id, method_id) |
+| PR-2D | PathSubjectGroupConfig + Item | + QuotaMatrix UI (2 tabs round/admit) + clone endpoint deep-copy |
+| PR-2E | Numeric(8,2) score precision | unchanged |
+| PR-2F | engine sweep ≥22 cases | refactored Tier 1/2/3 chain v8 + mandatory test_tier1_chain_per_academic_info_scope |
+
+### Tomorrow plan (Task 12)
+
+Implement PR-2A v2 trên branch `feat/admission-phase2-01-rounds-v2`:
+- Migration `phase2_01_v2_create_offering_admission_round_year_level.py` (down_revision phase1_15a)
+- Model `OfferingAdmissionRound` year-level (academic_year INT, round_code, UNIQUE(year, code))
+- Schema/Repo/Service/Router (`/api/v2/admin/years/{academic_year}/rounds`)
+- FE RoundsManagementTab top-level (Phase1Step `'rounds'` extension)
+- Bulk-create endpoint atomic (4 đợt)
+- Test infra extend builders.py với year-level AdmissionRoundBuilder
+- Anchor test mandate (P3-2 v8.2)
+- Browser smoke per `noble-launching-cocoa.md` plan
+
+### Notes / surprises
+
+- v6 PR-2A passed full verification gates (BE 26/26 + FE 25/25 + browser smoke 8/8 + service smoke 7/7) but failed user UX review → reminder em rằng technical correctness ≠ product fit
+- Pass 5 P0-2 (immutability trigger) là discovery em missed Pass 1-4 — memory `verify-schema-before-proposing` mandate violated. Future reviews phải grep DB trigger inventory trước khi propose UPDATE on applied_rules
+- 8-round audit history dài bất thường nhưng schema correctness Phase 2 sẽ pay dividend Phase 3+ cycle (multi-NV, choice engine, magic link multi-action)
+
+---
+
 ## 2026-05-08 — Post-cutover follow-up batch SHIPPED prod (combined deploy)
 
 ### #184 Routine deploy — FU batch + BE test-debt + FE test-debt atomic ship

--- a/Documents/ADMISSION_REFACTOR_PLAN.md
+++ b/Documents/ADMISSION_REFACTOR_PLAN.md
@@ -4546,3 +4546,78 @@ PLAN section §4 Phase 1 chain ordering uses placeholder revision IDs (`phase1_X
 Slot `phase1_14` left free as a future-reserve gap; `phase1_15a/15b/15c` reserved for Wave 4 lead-1-many sub-PR split (DDL drop + soak 1w + model+repo + soak 1w + FE migrate per PLAN line 3468-3473).
 
 Audit reference: `Documents/ADMISSION_DAILY_LOG.md` 2026-05-03 #184 preflight entry — 6-question matrix + Q1=C / Q2=A / Q3=phase1_13/16/17 / Q4=accept 3w / Q5=verify D12-D14 / Q6=start Wave 1 now.
+
+### Phase 2 — Schema design pivot Option A (2026-05-09, v8.2 plan locked)
+
+**MAJOR deviation from §2.1 line 532-535 + §4 Phase 2 line 3577-3608**.
+
+Plan v8.2 chốt 2026-05-09 sau 8 audit rounds. Plan file: `C:\Users\Admin\.claude\plans\noble-launching-cocoa.md`. v6 PR-2A archived qua tag `phase2-pr-2a-v6-archived` (push origin) — 6 commits + 22 files + 2961 lines + 8/8 browser smoke PASS retained for git history reference.
+
+#### Schema deviation — round entity location
+
+| Aspect | PLAN §2.1 spec (v6 plan) | v8.2 Option A final |
+|---|---|---|
+| Round entity | `OfferingAdmissionRound.academic_info_id` FK (per academic_info) | `OfferingAdmissionRound.academic_year` int + UNIQUE(academic_year, round_code) — year-level globally |
+| Storage | N rows per đợt (3 majors × 4 đợt = 12 rows replicate) | 1 row per đợt globally |
+| Quota fields | `round_quota`, `admit_quota`, `submission_count` on round table | MOVED to `admission_path` (per-path counter + caps) |
+| Round metadata sharing | Per academic_info (extend = N atomic UPDATEs) | Globally (extend = 1 UPDATE, paths inherit qua JOIN) |
+| Tier 1 chain root | `sum(round.round_quota in academic_info) ≤ annual_admission_quota` | `∑(path.admit_quota WHERE academic_info_id=X) ≤ academic_info[X].annual_admission_quota` |
+| AdmissionPath UNIQUE | swap to `(round_id, method_id)` [PR-2C v6] | swap to **3-col** `(round_id, academic_info_id, method_id)` [PR-2C v8.2 Q5] |
+| Atomic submit increment | `offering_admission_round.submission_count` per round | `admission_path.submission_count` per path (P3-3) |
+| Path FK | unspecified | `admission_path.admission_round_id` ON DELETE RESTRICT [Q7] |
+| Path clone | implicit | Mandatory deep-copy `AdmissionCriteria` + `CriteriaSubjectGroup` + `PathSubjectGroupConfig` + `PathSubjectGroupItem` per ADM-003 1:1 invariant [Q6] |
+| round_code namespace | implicit DOT_1/DOT_2 | Pure string + UI convention; program_type enum defer Phase 3 [Q8] |
+| Round metadata Phase 2 | time-window + notification template | Time-window only (extension audit + lifecycle); notification template defer Phase 3 [Q3] |
+
+#### Lý do deviation
+
+User Pass 4 review (2026-05-09) flag UX issue PR-2A v6: bottom-up workflow buộc admin vào từng ngành tạo đợt. Walk-through 8 stories + 4 edge cases reveal v6 schema sinh problem replication:
+
+1. Round metadata edit (extend/archive/notification template) → bulk update N rows atomic per academic_info
+2. Phase 3+ notification template per round = N rows duplicate
+3. Cross-major reporting "Đợt 1 status" = scan N rows GROUP BY
+4. Bulk-create solves CREATE only — EXTEND/ARCHIVE/EDIT vẫn pay N-row coordination cost
+
+Schema correctness Phase 2 trumps fast ship vì Phase 3+ cycle benefits multiply (multi-NV, choice engine, magic link multi-action depend on round metadata sharing).
+
+#### 8 decisions LOCKED Q1-Q8
+
+| # | Decision | Choice |
+|---|---|---|
+| Q1 | Schema | Option A (year-level round) |
+| Q2 | Tier 1 chain root | `admit_quota` per academic_info |
+| Q3 | Round metadata Phase 2 | time-window only |
+| Q4 | Branch strategy | tag preserve v6 + new `feat/admission-phase2-01-rounds-v2` |
+| Q5 | UNIQUE columns | 3-col `(round_id, academic_info_id, method_id)` |
+| Q6 | Clone strategy | hybrid modal + deep-copy criteria chain |
+| Q7 | FK ON DELETE | RESTRICT |
+| Q8 | round_code namespace | pure string + UI convention |
+
+#### Quota chain refactor v8.2 (Phần 5 update)
+
+- **Tier 1**: `∑(path.admit_quota WHERE academic_info_id=X AND path.status != 'archived' AND path.admit_quota IS NOT NULL) ≤ academic_info[X].annual_admission_quota`. Scope PER academic_info.
+- **Tier 2** (path-level invariant): `path.admit_quota ≤ path.round_quota` nếu cả 2 set.
+- **Tier 3** (PR-2D): `∑(group_quota in path) ≤ path.admit_quota`. KHÔNG fallback "round.admit_quota".
+
+#### Atomic increment SQL pattern shift
+
+PLAN §4.1 line 4100-4107 atomic increment original target: `offering_admission_round.submission_count`. v8.2 moves counter to `admission_path.submission_count` per-path semantic. Per-path semantic correct vì candidate submit destination = (path × round × major), KHÔNG global round.
+
+#### v8.1 P0 patches (3 blockers from Pass 5 review)
+
+1. **P0-1**: `admission_path.archived_at` column **không tồn tại** — `AdmissionPath.status` enum value `'archived'` (`app/models/admission_config/admission_path.py:91-98`). Tier 1 filter: `path.status != 'archived'`.
+2. **P0-2**: DB trigger `enforce_applied_rules_immutability` (`b5c6d7e8f9a0_add_applied_rules_immutability_trigger.py:42-47`) chặn UPDATE `applied_rules`. PR-2B Task 3 wrap `ALTER TABLE ... DISABLE/ENABLE TRIGGER` try/finally per precedent `aa1i2j3k4l5m_pr6_allow_unverified_submission.py:65-92`.
+3. **P0-3**: PR-2B Task 4 cast unsafe — CTE `safe_profiles` wrapper với regex `~ '^[0-9]+$'` + EXISTS guard parity Task 3.
+
+#### PR breakdown v8.2 (6 PRs ~10d)
+
+| PR | Scope |
+|---|---|
+| PR-2A v2 | phase2_01_v2 year-level OfferingAdmissionRound + RoundsManagementTab top-level + bulk-create endpoint |
+| PR-2B v2 | phase2_02_v2 admission_path 4 cols + 4-task backfill (DISABLE/ENABLE trigger + CTE safe_profiles) + service shim + Wave 6 #17 P2 storefront |
+| PR-2C v2 ⚠ | phase2_02b_v2 NOT NULL + 3-col UNIQUE swap + archive table + manual rollback playbook v8 |
+| PR-2D | phase2_03 PathSubjectGroupConfig + Item + QuotaMatrix UI + clone endpoint deep-copy |
+| PR-2E | phase2_04 Numeric(8,2) score precision |
+| PR-2F | engine sweep ≥22 cases + mandatory `test_tier1_chain_per_academic_info_scope` |
+
+Audit reference: `Documents/ADMISSION_DAILY_LOG.md` 2026-05-09 design pivot entry + memory `phase2-plan-locked` v8.2 + plan file `C:\Users\Admin\.claude\plans\noble-launching-cocoa.md`.

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/AdmissionConfigClient.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/AdmissionConfigClient.tsx
@@ -25,6 +25,7 @@ import { OfferingTypePanel } from "./Phase1Master/OfferingTypePanel";
 import { AdmissionMethodPanel } from "./Phase1Master/AdmissionMethodPanel";
 import { DocumentTypePanel } from "./Phase1Master/DocumentTypePanel";
 import { SubjectGroupPanel } from "./Phase1Master/SubjectGroupPanel";
+import { RoundsManagementTab } from "./Phase1Master/RoundsManagementTab";  // Phase 2 v8.2 PR-2A v2
 import { MajorProgramPanel } from "./Phase2Program/MajorProgramPanel";
 import { ProgramOfferingPanel } from "./Phase2Program/ProgramOfferingPanel";
 import { AcademicInfoPanel } from "./Phase2Program/AcademicInfoPanel";
@@ -174,6 +175,8 @@ function Phase1Content({ step }: { step: string }) {
       return <DocumentTypePanel />;
     case "subject-groups":
       return <SubjectGroupPanel />;
+    case "rounds":
+      return <RoundsManagementTab />;
     default:
       return (
         <div className="space-y-6">

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.test.tsx
@@ -85,12 +85,10 @@ describe("RoundsManagementTab year-level", () => {
     expect(screen.getByRole("button", { name: /Thêm đợt/i })).toBeTruthy()
   })
 
-  it("renders empty-state hint when no rounds for selected year", () => {
-    // Default current year ≠ 2026 (mock returns undefined for non-2026)
-    // Wait — current year is 2026 trong test environment
-    // mock returns 2 rounds when year === 2026
-    // To test empty-state, would need to override year via interaction
-    // Just verify mock baseline: 2 rounds visible (not empty-state path)
+  it("renders rounds list when data loaded", () => {
+    // Mock returns 2 rounds when year === 2026 (default current year).
+    // Empty-state path requires year selector interaction (Vitest JSDOM
+    // limitation với Radix Select portal — defer to Playwright e2e).
     render(wrap(<RoundsManagementTab />))
     // Both round codes visible
     expect(screen.getByText("DOT_1")).toBeTruthy()
@@ -118,9 +116,10 @@ describe("RoundsManagementTab year-level", () => {
     expect(extendButtons.length).toBe(2)
     expect(archiveButtons.length).toBe(2)
 
-    // Last row (DOT_2 archived) buttons should be disabled
-    expect(editButtons[1]).toHaveProperty("disabled", true)
-    expect(extendButtons[1]).toHaveProperty("disabled", true)
-    expect(archiveButtons[1]).toHaveProperty("disabled", true)
+    // Last row (DOT_2 archived) buttons should be disabled (P2-2 v8.2 —
+    // idiomatic jest-dom matcher).
+    expect(editButtons[1]).toBeDisabled()
+    expect(extendButtons[1]).toBeDisabled()
+    expect(archiveButtons[1]).toBeDisabled()
   })
 })

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Vitest tests for RoundsManagementTab year-level (Phase 2 v8.2 PR-2A v2).
+ *
+ * Top-level standalone tab (NOT drawer) — Q1 v8.2 workflow inversion.
+ * Anchor tests per memory pattern-change-impact-audit (P3-2 v8.2).
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { RoundsManagementTab } from "./RoundsManagementTab"
+
+vi.mock("@/hooks/admissions/useAdmissionRounds", () => ({
+  useAdmissionRounds: (year: number | null) => ({
+    data: year === 2026
+      ? {
+          total: 2,
+          items: [
+            {
+              id: 1,
+              academic_year: 2026,
+              round_code: "DOT_1",
+              round_name: "Đợt 1 - 2026",
+              start_date: "2026-03-01",
+              end_date: "2026-06-30",
+              is_active: true,
+              archived_at: null,
+              extended_at: null,
+              extended_by_user_id: null,
+              extension_reason: null,
+              created_at: "2026-05-09T00:00:00Z",
+              updated_at: "2026-05-09T00:00:00Z",
+            },
+            {
+              id: 2,
+              academic_year: 2026,
+              round_code: "DOT_2",
+              round_name: "Đợt 2 - 2026",
+              start_date: null,
+              end_date: null,
+              is_active: false,
+              archived_at: "2026-05-09T01:00:00Z",
+              extended_at: null,
+              extended_by_user_id: null,
+              extension_reason: null,
+              created_at: "2026-05-09T00:00:00Z",
+              updated_at: "2026-05-09T01:00:00Z",
+            },
+          ],
+        }
+      : undefined,
+    isLoading: false,
+  }),
+  useCreateRound: () => ({ mutateAsync: vi.fn() }),
+  useBulkCreateRounds: () => ({ mutateAsync: vi.fn() }),
+  useUpdateRound: () => ({ mutateAsync: vi.fn() }),
+  useSoftArchiveRound: () => ({ mutateAsync: vi.fn() }),
+  useExtendRound: () => ({ mutateAsync: vi.fn() }),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+}
+
+describe("RoundsManagementTab year-level", () => {
+  it("renders top-level tab với year selector + action buttons", () => {
+    render(wrap(<RoundsManagementTab />))
+    // Top-level heading
+    expect(screen.getByText("Đợt tuyển sinh")).toBeTruthy()
+    // Year selector label
+    expect(screen.getByText(/Năm học:/i)).toBeTruthy()
+    // Action buttons
+    expect(screen.getByRole("button", { name: /Tạo nhanh 4 đợt/i })).toBeTruthy()
+    expect(screen.getByRole("button", { name: /Thêm đợt/i })).toBeTruthy()
+  })
+
+  it("renders empty-state hint when no rounds for selected year", () => {
+    // Default current year ≠ 2026 (mock returns undefined for non-2026)
+    // Wait — current year is 2026 trong test environment
+    // mock returns 2 rounds when year === 2026
+    // To test empty-state, would need to override year via interaction
+    // Just verify mock baseline: 2 rounds visible (not empty-state path)
+    render(wrap(<RoundsManagementTab />))
+    // Both round codes visible
+    expect(screen.getByText("DOT_1")).toBeTruthy()
+    expect(screen.getByText("DOT_2")).toBeTruthy()
+  })
+
+  it("ANCHOR (P3-2 v8.2): renders Vietnamese status labels", () => {
+    render(wrap(<RoundsManagementTab />))
+    // DOT_1 active → "Đang hoạt động"
+    expect(screen.getByText("Đang hoạt động")).toBeTruthy()
+    // DOT_2 archived → "Đã lưu trữ"
+    expect(screen.getByText("Đã lưu trữ")).toBeTruthy()
+  })
+
+  it("disables action buttons on archived rounds", () => {
+    render(wrap(<RoundsManagementTab />))
+    // 3 action button types: Sửa đợt, Gia hạn đợt, Lưu trữ đợt per row
+    // DOT_2 archived → buttons disabled
+    const editButtons = screen.getAllByRole("button", { name: /Sửa đợt/i })
+    const extendButtons = screen.getAllByRole("button", { name: /Gia hạn đợt/i })
+    const archiveButtons = screen.getAllByRole("button", { name: /Lưu trữ đợt/i })
+
+    // 2 rows × 3 button types = 6 buttons, 3 disabled (archived row)
+    expect(editButtons.length).toBe(2)
+    expect(extendButtons.length).toBe(2)
+    expect(archiveButtons.length).toBe(2)
+
+    // Last row (DOT_2 archived) buttons should be disabled
+    expect(editButtons[1]).toHaveProperty("disabled", true)
+    expect(extendButtons[1]).toHaveProperty("disabled", true)
+    expect(archiveButtons[1]).toHaveProperty("disabled", true)
+  })
+})

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.tsx
@@ -1,0 +1,567 @@
+/**
+ * RoundsManagementTab — admin top-level UI cho OfferingAdmissionRound
+ * year-level (Phase 2 v8.2 PR-2A v2 — Q1 Option A workflow inversion fix).
+ *
+ * Per user Pass 4 review: chuyển từ bottom-up (vào từng ngành tạo đợt) sang
+ * top-down (admin tạo đợt 1 lần cho cả trường). Round là entity year-level
+ * (1 đợt = 1 row globally), KHÔNG nest dưới academic_info nữa.
+ *
+ * Capabilities:
+ * - Year selector dropdown (default: hiện tại)
+ * - List rounds per year (table với mã đợt, dates, trạng thái, hành động)
+ * - Tạo đợt mới (single)
+ * - Tạo nhanh 4 đợt (DOT_1/DOT_2/DOT_3/BO_SUNG atomic)
+ * - Sửa đợt (time-window/lifecycle only — Q3 v8.2)
+ * - Gia hạn end_date với lý do ≥10 ký tự (SPEC §2.1.a Rule 2)
+ * - Lưu trữ (soft-archive — Concern γ v6 admin discretion)
+ *
+ * Tiếng Việt nhất quán per user feedback.
+ */
+
+"use client"
+
+import {
+  Archive,
+  CalendarPlus,
+  Edit,
+  Layers,
+  Plus,
+  Trash2,
+} from "lucide-react"
+import { useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  useAdmissionRounds,
+  useBulkCreateRounds,
+  useCreateRound,
+  useExtendRound,
+  useSoftArchiveRound,
+  useUpdateRound,
+} from "@/hooks/admissions/useAdmissionRounds"
+import type { AdmissionRoundResponse } from "@/lib/zod/admission-rounds"
+
+interface FormState {
+  round_code: string
+  round_name: string
+  start_date: string
+  end_date: string
+  is_active: boolean
+}
+
+const EMPTY_FORM: FormState = {
+  round_code: "",
+  round_name: "",
+  start_date: "",
+  end_date: "",
+  is_active: true,
+}
+
+const DEFAULT_4_ROUNDS = [
+  { round_code: "DOT_1", round_name: "Đợt 1" },
+  { round_code: "DOT_2", round_name: "Đợt 2" },
+  { round_code: "DOT_3", round_name: "Đợt 3" },
+  { round_code: "BO_SUNG", round_name: "Đợt bổ sung" },
+]
+
+function formStateToCreatePayload(f: FormState) {
+  return {
+    round_code: f.round_code,
+    round_name: f.round_name,
+    start_date: f.start_date || null,
+    end_date: f.end_date || null,
+    is_active: f.is_active,
+  }
+}
+
+function formStateToUpdatePayload(f: FormState) {
+  return {
+    round_name: f.round_name,
+    start_date: f.start_date || null,
+    end_date: f.end_date || null,
+    is_active: f.is_active,
+  }
+}
+
+function roundToFormState(r: AdmissionRoundResponse): FormState {
+  return {
+    round_code: r.round_code,
+    round_name: r.round_name,
+    start_date: r.start_date ?? "",
+    end_date: r.end_date ?? "",
+    is_active: r.is_active,
+  }
+}
+
+function statusLabel(r: AdmissionRoundResponse): {
+  label: string
+  variant: "default" | "secondary" | "outline"
+} {
+  if (r.archived_at) return { label: "Đã lưu trữ", variant: "outline" }
+  if (r.is_active) return { label: "Đang hoạt động", variant: "default" }
+  return { label: "Tạm dừng", variant: "secondary" }
+}
+
+export function RoundsManagementTab() {
+  const currentYear = new Date().getFullYear()
+  const [academicYear, setAcademicYear] = useState<number>(currentYear)
+
+  const { data, isLoading } = useAdmissionRounds(academicYear)
+  const createMutation = useCreateRound(academicYear)
+  const bulkCreateMutation = useBulkCreateRounds(academicYear)
+  const updateMutation = useUpdateRound(academicYear)
+  const archiveMutation = useSoftArchiveRound(academicYear)
+  const extendMutation = useExtendRound(academicYear)
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [bulkCreateOpen, setBulkCreateOpen] = useState(false)
+  const [editTarget, setEditTarget] = useState<AdmissionRoundResponse | null>(null)
+  const [extendTarget, setExtendTarget] = useState<AdmissionRoundResponse | null>(null)
+  const [archiveTarget, setArchiveTarget] = useState<AdmissionRoundResponse | null>(null)
+
+  const [form, setForm] = useState<FormState>(EMPTY_FORM)
+  const [extendForm, setExtendForm] = useState({ end_date: "", extension_reason: "" })
+
+  const rounds = data?.items ?? []
+
+  // Year selector range — current ± 2 năm
+  const yearOptions = Array.from({ length: 5 }, (_, i) => currentYear - 1 + i)
+
+  const handleCreate = async () => {
+    await createMutation.mutateAsync(formStateToCreatePayload(form))
+    setCreateOpen(false)
+    setForm(EMPTY_FORM)
+  }
+
+  const handleBulkCreate = async () => {
+    await bulkCreateMutation.mutateAsync({
+      rounds: DEFAULT_4_ROUNDS.map((r) => ({
+        round_code: r.round_code,
+        round_name: `${r.round_name} - ${academicYear}`,
+        is_active: true,
+      })),
+    })
+    setBulkCreateOpen(false)
+  }
+
+  const handleUpdate = async () => {
+    if (!editTarget) return
+    await updateMutation.mutateAsync({
+      id: editTarget.id,
+      data: formStateToUpdatePayload(form),
+    })
+    setEditTarget(null)
+  }
+
+  const handleArchive = async () => {
+    if (!archiveTarget) return
+    await archiveMutation.mutateAsync(archiveTarget.id)
+    setArchiveTarget(null)
+  }
+
+  const handleExtend = async () => {
+    if (!extendTarget) return
+    await extendMutation.mutateAsync({
+      id: extendTarget.id,
+      data: extendForm,
+    })
+    setExtendTarget(null)
+    setExtendForm({ end_date: "", extension_reason: "" })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Đợt tuyển sinh</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Quản lý đợt tuyển sinh theo năm học (DOT_1 / DOT_2 / DOT_3 / Bổ sung)
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <Label htmlFor="year-select" className="text-sm whitespace-nowrap">
+              Năm học:
+            </Label>
+            <Select
+              value={academicYear.toString()}
+              onValueChange={(v) => setAcademicYear(parseInt(v, 10))}
+            >
+              <SelectTrigger id="year-select" className="w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {yearOptions.map((y) => (
+                  <SelectItem key={y} value={y.toString()}>
+                    {y}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button
+            variant="outline"
+            onClick={() => setBulkCreateOpen(true)}
+            disabled={rounds.length >= 4}
+          >
+            <Layers className="h-4 w-4 mr-2" />
+            Tạo nhanh 4 đợt
+          </Button>
+          <Button
+            onClick={() => {
+              setForm(EMPTY_FORM)
+              setCreateOpen(true)
+            }}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Thêm đợt
+          </Button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="text-sm text-muted-foreground p-4">Đang tải...</div>
+      ) : rounds.length === 0 ? (
+        <div className="border rounded-lg p-8 text-center space-y-3">
+          <p className="text-muted-foreground">
+            Chưa có đợt tuyển sinh nào năm {academicYear}.
+          </p>
+          <Button variant="outline" onClick={() => setBulkCreateOpen(true)}>
+            <Layers className="h-4 w-4 mr-2" />
+            Tạo nhanh 4 đợt mặc định
+          </Button>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Mã đợt</TableHead>
+              <TableHead>Tên hiển thị</TableHead>
+              <TableHead>Bắt đầu</TableHead>
+              <TableHead>Kết thúc</TableHead>
+              <TableHead>Trạng thái</TableHead>
+              <TableHead className="text-right">Hành động</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rounds.map((r) => {
+              const status = statusLabel(r)
+              return (
+                <TableRow key={r.id}>
+                  <TableCell className="font-mono">{r.round_code}</TableCell>
+                  <TableCell>{r.round_name}</TableCell>
+                  <TableCell>{r.start_date ?? "—"}</TableCell>
+                  <TableCell>
+                    {r.end_date ?? "—"}
+                    {r.extended_at && (
+                      <Badge variant="secondary" className="ml-2 text-xs">
+                        Đã gia hạn
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={status.variant}>{status.label}</Badge>
+                  </TableCell>
+                  <TableCell className="text-right space-x-1">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setForm(roundToFormState(r))
+                        setEditTarget(r)
+                      }}
+                      disabled={r.archived_at !== null}
+                      aria-label="Sửa đợt"
+                    >
+                      <Edit className="h-3 w-3" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setExtendForm({
+                          end_date: r.end_date ?? "",
+                          extension_reason: "",
+                        })
+                        setExtendTarget(r)
+                      }}
+                      disabled={r.archived_at !== null}
+                      aria-label="Gia hạn đợt"
+                    >
+                      <CalendarPlus className="h-3 w-3" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setArchiveTarget(r)}
+                      disabled={r.archived_at !== null}
+                      aria-label="Lưu trữ đợt"
+                    >
+                      <Archive className="h-3 w-3" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      )}
+
+      {/* Create Dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Tạo đợt tuyển sinh mới — Năm {academicYear}</DialogTitle>
+            <DialogDescription>
+              Mã đợt phải duy nhất trong năm học (vd: DOT_1, DOT_2, BO_SUNG).
+            </DialogDescription>
+          </DialogHeader>
+          <RoundForm form={form} setForm={setForm} mode="create" />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>
+              Huỷ
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!form.round_code || !form.round_name}
+            >
+              Tạo
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Bulk-create Dialog */}
+      <Dialog open={bulkCreateOpen} onOpenChange={setBulkCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Tạo nhanh 4 đợt — Năm {academicYear}</DialogTitle>
+            <DialogDescription>
+              Hệ thống sẽ tạo đồng thời 4 đợt mặc định: Đợt 1, Đợt 2, Đợt 3, Đợt
+              bổ sung. Đợt nào đã tồn tại sẽ được bỏ qua. Admin có thể sửa thời
+              gian từng đợt sau khi tạo.
+            </DialogDescription>
+          </DialogHeader>
+          <ul className="text-sm space-y-1 list-disc list-inside py-2">
+            {DEFAULT_4_ROUNDS.map((r) => (
+              <li key={r.round_code}>
+                <span className="font-mono">{r.round_code}</span> —{" "}
+                {r.round_name} - {academicYear}
+              </li>
+            ))}
+          </ul>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setBulkCreateOpen(false)}>
+              Huỷ
+            </Button>
+            <Button onClick={handleBulkCreate}>
+              <Layers className="h-4 w-4 mr-2" />
+              Tạo 4 đợt
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Dialog */}
+      <Dialog open={editTarget !== null} onOpenChange={(o) => !o && setEditTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Sửa đợt {editTarget?.round_code}</DialogTitle>
+            <DialogDescription>
+              Cập nhật tên hiển thị, ngày bắt đầu/kết thúc, trạng thái hoạt động.
+              Mã đợt không thể thay đổi sau khi tạo.
+            </DialogDescription>
+          </DialogHeader>
+          <RoundForm form={form} setForm={setForm} mode="edit" />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditTarget(null)}>
+              Huỷ
+            </Button>
+            <Button onClick={handleUpdate}>Lưu</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Extend Dialog */}
+      <Dialog
+        open={extendTarget !== null}
+        onOpenChange={(o) => !o && setExtendTarget(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Gia hạn đợt {extendTarget?.round_code}</DialogTitle>
+            <DialogDescription>
+              Lý do gia hạn bắt buộc tối thiểu 10 ký tự (lưu vào nhật ký kiểm tra).
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="extend_end_date">Ngày kết thúc mới</Label>
+              <Input
+                id="extend_end_date"
+                type="date"
+                value={extendForm.end_date}
+                onChange={(e) =>
+                  setExtendForm({ ...extendForm, end_date: e.target.value })
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="extend_reason">Lý do (≥10 ký tự)</Label>
+              <Textarea
+                id="extend_reason"
+                value={extendForm.extension_reason}
+                onChange={(e) =>
+                  setExtendForm({
+                    ...extendForm,
+                    extension_reason: e.target.value,
+                  })
+                }
+                placeholder="VD: Kéo dài đợt do bão lũ miền Trung"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setExtendTarget(null)}>
+              Huỷ
+            </Button>
+            <Button
+              onClick={handleExtend}
+              disabled={
+                !extendForm.end_date ||
+                extendForm.extension_reason.trim().length < 10
+              }
+            >
+              Gia hạn
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Archive Confirm Dialog */}
+      <Dialog
+        open={archiveTarget !== null}
+        onOpenChange={(o) => !o && setArchiveTarget(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Lưu trữ đợt {archiveTarget?.round_code}?</DialogTitle>
+            <DialogDescription>
+              Đợt sẽ ẩn khỏi danh sách công khai và không hiển thị trong cấu hình
+              đường tuyển sinh. Hồ sơ thí sinh đã đăng ký vẫn giữ liên kết với đợt
+              này (không bị xóa).
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setArchiveTarget(null)}>
+              Huỷ
+            </Button>
+            <Button variant="destructive" onClick={handleArchive}>
+              <Trash2 className="h-4 w-4 mr-2" />
+              Lưu trữ
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+// =============================================================================
+// Form sub-component (shared create/edit)
+// =============================================================================
+
+
+function RoundForm({
+  form,
+  setForm,
+  mode,
+}: {
+  form: FormState
+  setForm: (f: FormState) => void
+  mode: "create" | "edit"
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="round_code">Mã đợt</Label>
+          <Input
+            id="round_code"
+            value={form.round_code}
+            onChange={(e) => setForm({ ...form, round_code: e.target.value })}
+            placeholder="DOT_1"
+            disabled={mode === "edit"}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="round_name">Tên hiển thị</Label>
+          <Input
+            id="round_name"
+            value={form.round_name}
+            onChange={(e) => setForm({ ...form, round_name: e.target.value })}
+            placeholder="Đợt 1 - 2026"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="start_date">Ngày bắt đầu</Label>
+          <Input
+            id="start_date"
+            type="date"
+            value={form.start_date}
+            onChange={(e) => setForm({ ...form, start_date: e.target.value })}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="end_date">Ngày kết thúc</Label>
+          <Input
+            id="end_date"
+            type="date"
+            value={form.end_date}
+            onChange={(e) => setForm({ ...form, end_date: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="is_active"
+          checked={form.is_active}
+          onCheckedChange={(c) => setForm({ ...form, is_active: Boolean(c) })}
+        />
+        <Label htmlFor="is_active">Đang hoạt động</Label>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/PhaseNavigator.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/PhaseNavigator.tsx
@@ -49,6 +49,7 @@ const PHASE1_STEPS: StepConfig[] = [
   { id: "methods", label: "Phương thức Tuyển sinh" },
   { id: "document-types", label: "Loại Giấy tờ" },
   { id: "subject-groups", label: "Tổ hợp môn" },
+  { id: "rounds", label: "Đợt Tuyển sinh" },  // Phase 2 v8.2 PR-2A v2 — year-level
 ];
 
 const PHASE2_STEPS: StepConfig[] = [
@@ -185,13 +186,13 @@ export function PhaseNavigator({
           onClick={handlePhase3Click}
         >
           <BarChart3 className="h-4 w-4 mr-2" />
-          Đợt Tuyển sinh
+          Cấu hình Đường tuyển sinh
         </Button>
       </Card>
 
       {/* Help Text */}
       <div className="text-xs text-muted-foreground px-2">
-        <p>Hoàn thành Giai đoạn 1 và 2 trước khi cấu hình đợt tuyển sinh.</p>
+        <p>Hoàn thành Giai đoạn 1 và 2 trước khi cấu hình đường tuyển sinh.</p>
       </div>
     </div>
   );

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/shared/types.ts
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/shared/types.ts
@@ -125,7 +125,8 @@ export type Phase1Step =
   | 'offering-types'
   | 'methods'
   | 'document-types'
-  | 'subject-groups';
+  | 'subject-groups'
+  | 'rounds';  // Phase 2 v8.2 PR-2A v2 — đợt tuyển sinh year-level
 
 export type Phase2Step =
   | 'majors'

--- a/frontend/src/hooks/admissions/useAdmissionRounds.ts
+++ b/frontend/src/hooks/admissions/useAdmissionRounds.ts
@@ -1,0 +1,127 @@
+/**
+ * useAdmissionRounds — React Query hooks for OfferingAdmissionRound CRUD
+ * year-level (Phase 2 v8.2 PR-2A v2).
+ *
+ * Mirrors `useMasterData` toast + invalidation pattern.
+ * Vietnamese toasts (workflow inversion review feedback).
+ */
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+
+import * as roundsApi from "@/lib/api/admission-rounds"
+import type {
+  AdmissionRoundBulkCreate,
+  AdmissionRoundCreate,
+  AdmissionRoundExtend,
+  AdmissionRoundUpdate,
+} from "@/lib/zod/admission-rounds"
+
+interface ApiError {
+  response?: {
+    data?: {
+      detail?: string
+    }
+  }
+}
+
+const ROUNDS_KEY = "admission-rounds"
+
+export function useAdmissionRounds(academicYear: number | null) {
+  return useQuery({
+    queryKey: [ROUNDS_KEY, "by-year", academicYear],
+    queryFn: () => roundsApi.listRoundsByYear(academicYear as number),
+    enabled: academicYear !== null,
+  })
+}
+
+export function useCreateRound(academicYear: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: AdmissionRoundCreate) =>
+      roundsApi.createRound(academicYear, payload),
+    onSuccess: () => {
+      toast.success("Đã tạo đợt tuyển sinh")
+      queryClient.invalidateQueries({
+        queryKey: [ROUNDS_KEY, "by-year", academicYear],
+      })
+    },
+    onError: (error: ApiError) => {
+      toast.error(error.response?.data?.detail || "Không thể tạo đợt")
+    },
+  })
+}
+
+export function useBulkCreateRounds(academicYear: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: AdmissionRoundBulkCreate) =>
+      roundsApi.bulkCreateRounds(academicYear, payload),
+    onSuccess: (res) => {
+      if (res.skipped_duplicates > 0) {
+        toast.success(
+          `Đã tạo ${res.created} đợt mới (${res.skipped_duplicates} đã tồn tại)`,
+        )
+      } else {
+        toast.success(`Đã tạo ${res.created} đợt tuyển sinh`)
+      }
+      queryClient.invalidateQueries({
+        queryKey: [ROUNDS_KEY, "by-year", academicYear],
+      })
+    },
+    onError: (error: ApiError) => {
+      toast.error(error.response?.data?.detail || "Không thể tạo đợt hàng loạt")
+    },
+  })
+}
+
+export function useUpdateRound(academicYear: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: AdmissionRoundUpdate }) =>
+      roundsApi.updateRound(id, data),
+    onSuccess: () => {
+      toast.success("Đã cập nhật đợt tuyển sinh")
+      queryClient.invalidateQueries({
+        queryKey: [ROUNDS_KEY, "by-year", academicYear],
+      })
+    },
+    onError: (error: ApiError) => {
+      toast.error(error.response?.data?.detail || "Không thể cập nhật")
+    },
+  })
+}
+
+export function useSoftArchiveRound(academicYear: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: roundsApi.softArchiveRound,
+    onSuccess: () => {
+      toast.success("Đã lưu trữ đợt tuyển sinh")
+      queryClient.invalidateQueries({
+        queryKey: [ROUNDS_KEY, "by-year", academicYear],
+      })
+    },
+    onError: (error: ApiError) => {
+      toast.error(error.response?.data?.detail || "Không thể lưu trữ")
+    },
+  })
+}
+
+export function useExtendRound(academicYear: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: AdmissionRoundExtend }) =>
+      roundsApi.extendRound(id, data),
+    onSuccess: () => {
+      toast.success("Đã gia hạn đợt tuyển sinh")
+      queryClient.invalidateQueries({
+        queryKey: [ROUNDS_KEY, "by-year", academicYear],
+      })
+    },
+    onError: (error: ApiError) => {
+      toast.error(error.response?.data?.detail || "Không thể gia hạn")
+    },
+  })
+}

--- a/frontend/src/lib/api/admission-rounds.ts
+++ b/frontend/src/lib/api/admission-rounds.ts
@@ -1,0 +1,89 @@
+/**
+ * Admission Rounds API client year-level (Phase 2 v8.2 PR-2A v2).
+ *
+ * Mirrors backend `app/routers/admin_v2_admission_round.py`:
+ * - POST   /api/v2/admin/years/{academic_year}/rounds (create)
+ * - POST   /api/v2/admin/years/{academic_year}/rounds/bulk-create (atomic 4 đợt)
+ * - GET    /api/v2/admin/years/{academic_year}/rounds (list per year)
+ * - GET    /api/v2/admin/rounds/{id} (single)
+ * - PATCH  /api/v2/admin/rounds/{id} (update time-window/lifecycle)
+ * - DELETE /api/v2/admin/rounds/{id} (soft-archive)
+ * - POST   /api/v2/admin/rounds/{id}/extend (extend với reason ≥10 chars)
+ */
+import { api } from "@/lib/api/client"
+import type {
+  AdmissionRoundBulkCreate,
+  AdmissionRoundBulkCreateResponse,
+  AdmissionRoundCreate,
+  AdmissionRoundExtend,
+  AdmissionRoundListResponse,
+  AdmissionRoundResponse,
+  AdmissionRoundUpdate,
+} from "@/lib/zod/admission-rounds"
+
+const BASE = "/api/v2/admin"
+
+export async function listRoundsByYear(
+  academicYear: number
+): Promise<AdmissionRoundListResponse> {
+  const res = await api.get<AdmissionRoundListResponse>(
+    `${BASE}/years/${academicYear}/rounds`
+  )
+  return res.data
+}
+
+export async function createRound(
+  academicYear: number,
+  payload: AdmissionRoundCreate
+): Promise<AdmissionRoundResponse> {
+  const res = await api.post<AdmissionRoundResponse>(
+    `${BASE}/years/${academicYear}/rounds`,
+    payload
+  )
+  return res.data
+}
+
+export async function bulkCreateRounds(
+  academicYear: number,
+  payload: AdmissionRoundBulkCreate
+): Promise<AdmissionRoundBulkCreateResponse> {
+  const res = await api.post<AdmissionRoundBulkCreateResponse>(
+    `${BASE}/years/${academicYear}/rounds/bulk-create`,
+    payload
+  )
+  return res.data
+}
+
+export async function getRound(roundId: number): Promise<AdmissionRoundResponse> {
+  const res = await api.get<AdmissionRoundResponse>(`${BASE}/rounds/${roundId}`)
+  return res.data
+}
+
+export async function updateRound(
+  roundId: number,
+  payload: AdmissionRoundUpdate
+): Promise<AdmissionRoundResponse> {
+  const res = await api.patch<AdmissionRoundResponse>(
+    `${BASE}/rounds/${roundId}`,
+    payload
+  )
+  return res.data
+}
+
+export async function softArchiveRound(
+  roundId: number
+): Promise<AdmissionRoundResponse> {
+  const res = await api.delete<AdmissionRoundResponse>(`${BASE}/rounds/${roundId}`)
+  return res.data
+}
+
+export async function extendRound(
+  roundId: number,
+  payload: AdmissionRoundExtend
+): Promise<AdmissionRoundResponse> {
+  const res = await api.post<AdmissionRoundResponse>(
+    `${BASE}/rounds/${roundId}/extend`,
+    payload
+  )
+  return res.data
+}

--- a/frontend/src/lib/zod/admission-rounds.ts
+++ b/frontend/src/lib/zod/admission-rounds.ts
@@ -1,0 +1,80 @@
+/**
+ * Zod schemas for OfferingAdmissionRound year-level (Phase 2 v8.2 PR-2A v2).
+ *
+ * Mirrors backend Pydantic models in
+ * `Backend_FastAPI/app/schemas/admission_round.py`.
+ * Quota fields ship trên admission_path (PR-2B v2), KHÔNG trên đây.
+ */
+import { z } from "zod"
+
+export const AdmissionRoundCreateSchema = z.object({
+  round_code: z.string().min(1).max(20),
+  round_name: z.string().min(1).max(100),
+  start_date: z.string().nullable().optional(),
+  end_date: z.string().nullable().optional(),
+  is_active: z.boolean().default(true),
+})
+
+export const AdmissionRoundUpdateSchema = z.object({
+  round_name: z.string().min(1).max(100).optional(),
+  start_date: z.string().nullable().optional(),
+  end_date: z.string().nullable().optional(),
+  is_active: z.boolean().optional(),
+})
+
+export const AdmissionRoundExtendSchema = z.object({
+  end_date: z.string().min(1, "Vui lòng chọn ngày kết thúc mới"),
+  extension_reason: z
+    .string()
+    .min(10, "Lý do phải có ít nhất 10 ký tự")
+    .transform((s) => s.trim()),
+})
+
+export const AdmissionRoundBulkCreateItemSchema = z.object({
+  round_code: z.string().min(1).max(20),
+  round_name: z.string().min(1).max(100),
+  start_date: z.string().nullable().optional(),
+  end_date: z.string().nullable().optional(),
+  is_active: z.boolean().default(true),
+})
+
+export const AdmissionRoundBulkCreateSchema = z.object({
+  rounds: z.array(AdmissionRoundBulkCreateItemSchema).min(1).max(10),
+})
+
+export const AdmissionRoundResponseSchema = z.object({
+  id: z.number().int(),
+  academic_year: z.number().int(),
+  round_code: z.string(),
+  round_name: z.string(),
+  start_date: z.string().nullable(),
+  end_date: z.string().nullable(),
+  is_active: z.boolean(),
+  archived_at: z.string().nullable(),
+  extended_at: z.string().nullable(),
+  extended_by_user_id: z.number().int().nullable(),
+  extension_reason: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export const AdmissionRoundListResponseSchema = z.object({
+  total: z.number().int(),
+  items: z.array(AdmissionRoundResponseSchema),
+})
+
+export const AdmissionRoundBulkCreateResponseSchema = z.object({
+  requested: z.number().int(),
+  created: z.number().int(),
+  skipped_duplicates: z.number().int(),
+  items: z.array(AdmissionRoundResponseSchema),
+})
+
+export type AdmissionRoundCreate = z.infer<typeof AdmissionRoundCreateSchema>
+export type AdmissionRoundUpdate = z.infer<typeof AdmissionRoundUpdateSchema>
+export type AdmissionRoundExtend = z.infer<typeof AdmissionRoundExtendSchema>
+export type AdmissionRoundBulkCreateItem = z.infer<typeof AdmissionRoundBulkCreateItemSchema>
+export type AdmissionRoundBulkCreate = z.infer<typeof AdmissionRoundBulkCreateSchema>
+export type AdmissionRoundResponse = z.infer<typeof AdmissionRoundResponseSchema>
+export type AdmissionRoundListResponse = z.infer<typeof AdmissionRoundListResponseSchema>
+export type AdmissionRoundBulkCreateResponse = z.infer<typeof AdmissionRoundBulkCreateResponseSchema>


### PR DESCRIPTION
## Summary

**#184 Phase 2 PR-2A v2 — OfferingAdmissionRound year-level + RoundsManagementTab top-level**

Plan v8.2 Option A schema redesign per user Pass 4 review (workflow inversion). Round entity at academic_year level (1 row globally per đợt), KHÔNG nest dưới academic_info như v6 archived (tag `phase2-pr-2a-v6-archived`).

Quota fields (round_quota, admit_quota, submission_count) defer PR-2B v2 trên admission_path table.

## Pivot rationale (PLAN Phần 9 + DAILY_LOG 2026-05-09)

User Pass 4 review flag UX: v6 schema bottom-up (admin vào từng ngành tạo đợt). Walk-through 8 stories + 4 edges expose round metadata replication problem (30 majors × 4 đợt = 120 rows replicate; bulk extend/archive cost N atomic UPDATEs). Pivot to Option A: 1 đợt = 1 row globally, top-down workflow.

## 8 decisions LOCKED Q1-Q8 (2026-05-09)

| # | Decision | Choice |
|---|---|---|
| Q1 | Schema | Option A — round at academic_year level |
| Q2 | Tier 1 chain root | admit_quota per academic_info (PR-2B v2 implements) |
| Q3 | Round metadata Phase 2 | time-window only (notification defer Phase 3) |
| Q4 | Branch strategy | tag preserve v6 + new feat/admission-phase2-01-rounds-v2 |
| Q5 | UNIQUE columns | 3-col (round_id, academic_info_id, method_id) (PR-2C v2) |
| Q6 | Clone strategy | hybrid modal + deep-copy criteria chain (PR-2D) |
| Q7 | FK ON DELETE | RESTRICT (PR-2B v2) |
| Q8 | round_code namespace | pure string + UI convention |

## Scope

### Migration `phase2_01_v2_create_offering_admission_round_year_level.py`
- revision `phase2_01_v2`, down_revision `phase1_15a`
- Year-level table với UNIQUE(academic_year, round_code)
- 12 columns: id, academic_year, round_code, round_name, dates, is_active, archived_at, extended_* (3), timestamps
- NO academic_info_id FK (year-level globally)
- NO quota fields (defer PR-2B v2 on admission_path)
- Backfill 1 DOT_1 per distinct academic_year (verified prod = 1 row năm 2026)
- Idempotent ON CONFLICT (academic_year, round_code) DO NOTHING
- Explicit type casts NULL::timestamptz/int/text

### Backend
- Model `app/models/offering_admission_round.py` (top-level, year-level)
- Schema `app/schemas/admission_round.py` — Create/Update/Response/List/Extend + BulkCreate
- Repository `app/repositories/admission_round_repository.py` — `get_default_dot1(academic_year)` for PR-2B v2 service shim
- Service `app/services/admission_round_service.py` — CRUD + bulk-create idempotent (P2-3) + soft-archive (Concern γ v6) + extend (SPEC §2.1.a Rule 2) + IntegrityError race guard (P2-4)
- Router `app/routers/admin_v2_admission_round.py` — 7 endpoints `/api/v2/admin/years/{academic_year}/rounds*` + `/rounds/{id}/*` với require_admin gate (P2-3 v8.1) + ADMIN_WRITE rate limit + structlog audit + activity_service log

### Frontend
- Zod `frontend/src/lib/zod/admission-rounds.ts`
- API client `frontend/src/lib/api/admission-rounds.ts` (7 endpoints)
- React Query hooks `frontend/src/hooks/admissions/useAdmissionRounds.ts` với queryKey by year + Vietnamese toasts
- `Phase1Master/RoundsManagementTab.tsx` — top-level standalone tab (NOT drawer như v6 archived):
  - Year selector dropdown (current ± 2 năm)
  - List rounds table với "Đang hoạt động" / "Tạm dừng" / "Đã lưu trữ" / "Đã gia hạn" badges (Vietnamese consistent per user feedback)
  - "Tạo nhanh 4 đợt" button atomic (DOT_1/DOT_2/DOT_3/BO_SUNG)
  - Per-row actions: Sửa / Gia hạn / Lưu trữ
  - 5 dialogs (Create/BulkCreate/Edit/Extend/Archive Confirm)
- `shared/types.ts` — Phase1Step thêm `'rounds'` literal
- `PhaseNavigator.tsx` — Phase 1 nav entry "Đợt Tuyển sinh"; Phase 3 button rename "Cấu hình Đường tuyển sinh" để tránh label conflict
- `AdmissionConfigClient.tsx` — case `"rounds"` route render

### Tests
- BE pytest 14 unit + 12 service = 26/26 PASS
- FE Vitest 4/4 PASS RoundsManagementTab.test.tsx
- Anchor tests P3-2 v8.2 mandate (Q1 invariant: UNIQUE(academic_year, round_code) + no academic_info_id + no quota fields)

### Test infra
- `tests/fixtures/builders.py` extend với year-level `AdmissionRoundBuilder.make(academic_year, round_code)`

### Docs sync
- Memory `phase2-plan-locked` v6 → v8.2
- `Documents/ADMISSION_DAILY_LOG.md` entry 2026-05-09 design pivot
- `Documents/ADMISSION_REFACTOR_PLAN.md` Phần 9 MAJOR deviation entry "Phase 2 — Schema design pivot Option A"

## Audit history (8 rounds)

v1 → v2 (5 P0/P1) → v3 (10 drifts) → v4 (7 concerns) → v5 (6 micro-patches) → v6 (5 nano-patches + browser smoke 8/8) → v8 (Option A schema redesign) → v8.1 (3 P0 patches) → v8.2 (7 P2 + 5 P3 polish) → Pass 7 (4 P2 polish in this PR)

## Verification

- [x] BE pytest 26/26 PASS Phase 2 v8.2 (14 unit + 12 service)
- [x] Migration `phase1_15a → phase2_01_v2` apply + roundtrip downgrade clean
- [x] Backend container reload healthy post router include
- [x] FE type-check 0 errors
- [x] FE Vitest 4/4 PASS RoundsManagementTab
- [x] FE production build OK
- [x] FE ESLint 0 new warnings on changed files
- [x] Browser smoke (Chrome MCP) trên dev: navigate `/admin/admission-config?phase=1&step=rounds` → top-level tab loads → bulk-create 4 đợt → POST `/api/v2/admin/years/2026/rounds/bulk-create` 201 → toast "Đã tạo 3 đợt mới (1 đã tồn tại)" → table renders 4 rows với Vietnamese badges
- [x] Screenshot evidence `D:\QLTS\.smoke_phase2_v2_year_level_4_rounds.png`

## Pre-deploy state

- Pre-Phase-2 prod backup `prod_dump_pre_phase2_20260508_153443.dump` (1.3MB md5 `1a9eb966...`) ready
- prod alembic_version `phase1_15a` (this migration applies on first deploy after merge)
- v6 archived qua tag `phase2-pr-2a-v6-archived` (origin) preserves 6 commits + 22 files + 2961 lines + 8/8 browser smoke

## Strategy S1 per-PR ship rationale

Per user Pass 7 final audit:
- PR-2A v2 verified through 7 audit passes — ship now to clear queue
- PR-2B v2 risk surface higher (4 backfill tasks + DISABLE/ENABLE trigger + CTE safe_profiles + admission_quota_service + Wave 6 #17 P2 storefront) — should not bundle
- Phase 1 cutover lesson: bundling amplifies risk (19 migrations cutover required 6 rehearsals + 5 hotfixes)
- Memory `pattern-change-impact-audit`: pattern changes need observation; ship separately
- Storefront delay zero impact (PR-2B v2 storefront filter not yet wired — can defer)
- Production observation per PR enables clear regression attribution

## Refs

- #184 Phase 2 thematic issue #238 (subtask PR-2A v2 checkbox)
- v6 PR-2A archived: tag `phase2-pr-2a-v6-archived` on origin
- Plan file: `C:\Users\Admin\.claude\plans\noble-launching-cocoa.md` v8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
