### PR TITLE
feat(admission): #184 Phase 2 v8.2 PR-2D.1 — QuotaMatrix UI + per-path quota PATCH endpoint

### DIFF
--- a/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
+++ b/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import database, models
 from app.core.deps import require_admin
 from app.core.rate_limits import RateLimits, limiter
+from app.schemas.admission_path import AdmissionPathQuotaUpdate, AdmissionPathResponse
 from app.schemas.path_subject_group import (
     ClonePathsRequest,
     ClonePathsResponse,
@@ -19,8 +20,11 @@ from app.schemas.path_subject_group import (
     PathSubjectGroupItemResponse,
 )
 from app.services import activity_service
+from app.services.admission_path_service import AdmissionPathService
 from app.services.path_clone_service import PathCloneService
 from app.services.path_subject_group_service import PathSubjectGroupService
+from app.utils.exceptions import ResourceNotFoundError
+from sqlalchemy import select
 
 
 log = structlog.get_logger(__name__)
@@ -163,6 +167,61 @@ async def add_item(
     item = await service.add_item(config_id, payload)
     await db.commit()
     return item
+
+
+# =============================================================================
+# PR-2D.1 — Per-path quota PATCH endpoint cho QuotaMatrix UI
+# =============================================================================
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.patch(
+    "/admission-paths/{admission_path_id}/quota",
+    response_model=AdmissionPathResponse,
+)
+async def update_path_quota(
+    request: Request,
+    admission_path_id: int,
+    payload: AdmissionPathQuotaUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """Phase 2 v8.2 PR-2D.1 — dedicated quota PATCH cho QuotaMatrix inline edit.
+
+    Tier 1+2 chain re-validation per cell change. Raises
+    BusinessRuleViolation nếu chain violated.
+    """
+    stmt = select(models.AdmissionPath).where(
+        models.AdmissionPath.id == admission_path_id
+    )
+    path = (await db.execute(stmt)).scalar_one_or_none()
+    if path is None:
+        raise ResourceNotFoundError(f"AdmissionPath {admission_path_id} not found")
+
+    service = AdmissionPathService(db)
+    path = await service.update_quota(
+        path=path,
+        round_quota=payload.round_quota,
+        admit_quota=payload.admit_quota,
+        user=current_admin,
+    )
+    await db.commit()
+
+    await activity_service.log_activity(
+        db=db,
+        action="admission_path_quota_update",
+        resource_type="admission_path",
+        resource_id=path.id,
+        actor_id=current_admin.id,
+        description=(
+            f"Updated quota path={path.id} "
+            f"round_quota={payload.round_quota} admit_quota={payload.admit_quota}"
+        ),
+    )
+    # Re-fetch with relations cho response
+    from app.repositories.admission_path_repository import AdmissionPathRepository
+    path = await AdmissionPathRepository(db).get_by_id_with_relations(path.id)
+    return path
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -281,6 +281,20 @@ class AdmissionPathCreate(BaseModel):
     )(_validate_minor_correction_allowlist)
 
 
+class AdmissionPathQuotaUpdate(BaseModel):
+    """Phase 2 v8.2 PR-2D.1 — dedicated quota PATCH payload cho QuotaMatrix
+    inline edit. Allows admin update round_quota/admit_quota independently
+    với Tier 1+2 chain validation real-time per cell change."""
+    round_quota: Optional[int] = Field(
+        default=None, ge=0,
+        description="Per-path submission cap. NULL = unbounded; explicit None to clear.",
+    )
+    admit_quota: Optional[int] = Field(
+        default=None, ge=0,
+        description="Per-path admit cap. Triggers Tier 1 chain re-validation on change.",
+    )
+
+
 class AdmissionPathUpdate(BaseModel):
     """Request schema for updating an AdmissionPath."""
     display_name: Optional[str] = None

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -281,6 +281,55 @@ class AdmissionPathService:
 
         return path, _noop_callback
 
+    async def update_quota(
+        self,
+        path: AdmissionPath,
+        round_quota: int | None,
+        admit_quota: int | None,
+        user: User,
+    ) -> AdmissionPath:
+        """Phase 2 v8.2 PR-2D.1 — dedicated quota update với Tier 1+2 chain
+        validation per cell change cho QuotaMatrix UI inline edit.
+
+        Tier 1: ∑(path.admit_quota WHERE academic_info_id=X) ≤
+        academic_info[X].annual_admission_quota.
+        Tier 2: path.admit_quota ≤ path.round_quota nếu cả 2 set.
+
+        Raises BusinessRuleViolation nếu Tier 1/2 violated.
+        """
+        from app.services.admission_quota_service import AdmissionQuotaService
+
+        _check_lifecycle_guard(path, user)
+
+        quota_service = AdmissionQuotaService(self.db)
+
+        # Tier 2 path invariant
+        await quota_service.validate_tier2_path_invariant(
+            admit_quota=admit_quota, round_quota=round_quota,
+        )
+
+        # Tier 1 chain re-validate when admit_quota changes
+        if admit_quota != path.admit_quota:
+            delta = (admit_quota or 0)
+            await quota_service.validate_tier1_chain_on_path_quota_change(
+                academic_info_id=path.academic_info_id,
+                delta_admit_quota=delta,
+                excluded_path_id=path.id,
+            )
+
+        path.round_quota = round_quota
+        path.admit_quota = admit_quota
+        await self.db.flush()
+
+        log.info(
+            "admission_path_quota_updated",
+            path_id=path.id,
+            round_quota=round_quota,
+            admit_quota=admit_quota,
+            actor_id=user.id,
+        )
+        return path
+
     async def update_path(
         self, path: AdmissionPath, data: AdmissionPathUpdate, user: User
     ) -> Tuple[AdmissionPath, PostCommitCallback]:

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/AdmissionConfigClient.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/AdmissionConfigClient.tsx
@@ -26,6 +26,7 @@ import { AdmissionMethodPanel } from "./Phase1Master/AdmissionMethodPanel";
 import { DocumentTypePanel } from "./Phase1Master/DocumentTypePanel";
 import { SubjectGroupPanel } from "./Phase1Master/SubjectGroupPanel";
 import { RoundsManagementTab } from "./Phase1Master/RoundsManagementTab";  // Phase 2 v8.2 PR-2A v2
+import { QuotaMatrixTab } from "./Phase1Master/QuotaMatrixTab";  // Phase 2 v8.2 PR-2D.1
 import { MajorProgramPanel } from "./Phase2Program/MajorProgramPanel";
 import { ProgramOfferingPanel } from "./Phase2Program/ProgramOfferingPanel";
 import { AcademicInfoPanel } from "./Phase2Program/AcademicInfoPanel";
@@ -177,6 +178,8 @@ function Phase1Content({ step }: { step: string }) {
       return <SubjectGroupPanel />;
     case "rounds":
       return <RoundsManagementTab />;
+    case "quota-matrix":
+      return <QuotaMatrixTab />;
     default:
       return (
         <div className="space-y-6">

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/QuotaMatrixTab.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/QuotaMatrixTab.tsx
@@ -1,0 +1,294 @@
+/**
+ * QuotaMatrixTab — admin matrix UI cho path-level quota allocation
+ * (Phase 2 v8.2 PR-2D.1 — FE follow-up to PR-2D BE).
+ *
+ * Top-level standalone tab in Phase 1 sidebar. Allows admin manage
+ * round_quota + admit_quota per AdmissionPath với inline edit + Tier 1+2
+ * chain validation server-side.
+ *
+ * UX:
+ * - Year selector (current ± 2 năm)
+ * - Academic_info dropdown (filter paths)
+ * - Table: rows = paths, cols = round_quota | admit_quota | round
+ * - Inline edit cells → PATCH /api/v2/admin/admission-paths/{id}/quota
+ * - Toast feedback success/error (BusinessRuleViolation surfaces Vietnamese)
+ *
+ * Tiếng Việt nhất quán per user feedback (RoundsManagementTab parity).
+ */
+"use client"
+
+import { Save } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  useAdmissionPathsByAcademicInfo,
+  useUpdatePathQuota,
+} from "@/hooks/admissions/useAdmissionPaths"
+import { useAdmissionRounds } from "@/hooks/admissions/useAdmissionRounds"
+
+interface QuotaCellEdit {
+  pathId: number
+  round_quota: number | null
+  admit_quota: number | null
+}
+
+const CURRENT_YEAR = new Date().getFullYear()
+const YEAR_OPTIONS = [CURRENT_YEAR - 1, CURRENT_YEAR, CURRENT_YEAR + 1]
+
+export function QuotaMatrixTab() {
+  const [selectedYear, setSelectedYear] = useState<number>(CURRENT_YEAR)
+  const [academicInfoId, setAcademicInfoId] = useState<number | undefined>(undefined)
+  const [edits, setEdits] = useState<Record<number, QuotaCellEdit>>({})
+
+  const { data: roundsData } = useAdmissionRounds(selectedYear)
+  const { data: pathsData, isLoading: pathsLoading } =
+    useAdmissionPathsByAcademicInfo(academicInfoId)
+  const updateMutation = useUpdatePathQuota()
+
+  const paths = pathsData?.items ?? []
+  const rounds = roundsData?.items ?? []
+
+  const getCellValue = (
+    pathId: number,
+    field: "round_quota" | "admit_quota",
+    fallback: number | null,
+  ): number | null => {
+    const edit = edits[pathId]
+    if (edit && field in edit) return edit[field]
+    return fallback
+  }
+
+  const handleCellChange = (
+    pathId: number,
+    field: "round_quota" | "admit_quota",
+    value: string,
+    other: number | null,
+  ) => {
+    const num = value === "" ? null : Number(value)
+    if (num !== null && (isNaN(num) || num < 0)) {
+      toast.error("Giá trị phải là số ≥ 0")
+      return
+    }
+    setEdits((prev) => {
+      const existing = prev[pathId] ?? {
+        pathId,
+        round_quota: field === "round_quota" ? num : other,
+        admit_quota: field === "admit_quota" ? num : other,
+      }
+      return { ...prev, [pathId]: { ...existing, [field]: num } }
+    })
+  }
+
+  const handleSave = async (pathId: number) => {
+    const edit = edits[pathId]
+    if (!edit) return
+    try {
+      await updateMutation.mutateAsync({
+        pathId,
+        data: {
+          round_quota: edit.round_quota,
+          admit_quota: edit.admit_quota,
+        },
+      })
+      toast.success("Cập nhật chỉ tiêu thành công")
+      setEdits((prev) => {
+        const { [pathId]: _, ...rest } = prev
+        return rest
+      })
+    } catch (err: unknown) {
+      const detail = (err as { response?: { data?: { detail?: string } } })
+        ?.response?.data?.detail
+      toast.error(detail ?? "Cập nhật thất bại")
+    }
+  }
+
+  const isDirty = (pathId: number): boolean => pathId in edits
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Ma trận chỉ tiêu</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-4">
+            <div>
+              <label className="text-sm font-medium">Năm học:</label>
+              <Select
+                value={selectedYear.toString()}
+                onValueChange={(v) => setSelectedYear(Number(v))}
+              >
+                <SelectTrigger className="w-32 ml-2 inline-flex">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {YEAR_OPTIONS.map((y) => (
+                    <SelectItem key={y} value={y.toString()}>
+                      {y}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Đường tuyển sinh thuộc ngành (academic_info_id):</label>
+              <Input
+                type="number"
+                placeholder="Nhập ID ngành (academic_info_id)"
+                value={academicInfoId ?? ""}
+                onChange={(e) =>
+                  setAcademicInfoId(
+                    e.target.value === "" ? undefined : Number(e.target.value),
+                  )
+                }
+                className="w-48 ml-2 inline-flex"
+              />
+            </div>
+            <Badge variant="outline">
+              {rounds.length} đợt năm {selectedYear}
+            </Badge>
+          </div>
+
+          {!academicInfoId && (
+            <div className="text-sm text-muted-foreground">
+              Nhập ID ngành để tải danh sách đường tuyển sinh.
+            </div>
+          )}
+
+          {academicInfoId && pathsLoading && (
+            <div className="text-sm text-muted-foreground">Đang tải...</div>
+          )}
+
+          {academicInfoId && !pathsLoading && paths.length === 0 && (
+            <div className="text-sm text-muted-foreground">
+              Không có đường tuyển sinh nào cho ngành này.
+            </div>
+          )}
+
+          {paths.length > 0 && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>Tên đường tuyển sinh</TableHead>
+                  <TableHead>Đợt</TableHead>
+                  <TableHead>Trạng thái</TableHead>
+                  <TableHead>Chỉ tiêu nộp hồ sơ</TableHead>
+                  <TableHead>Chỉ tiêu trúng tuyển</TableHead>
+                  <TableHead>Đã nộp</TableHead>
+                  <TableHead>Hành động</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {paths.map((path) => {
+                  const round = rounds.find((r) => r.id === path.admission_round_id)
+                  const dirty = isDirty(path.id)
+                  const roundQuotaVal = getCellValue(
+                    path.id,
+                    "round_quota",
+                    path.round_quota ?? null,
+                  )
+                  const admitQuotaVal = getCellValue(
+                    path.id,
+                    "admit_quota",
+                    path.admit_quota ?? null,
+                  )
+                  return (
+                    <TableRow key={path.id} className={dirty ? "bg-amber-50" : ""}>
+                      <TableCell>{path.id}</TableCell>
+                      <TableCell>
+                        {path.display_name ?? "(không tên)"}
+                      </TableCell>
+                      <TableCell>
+                        {round ? (
+                          <Badge variant="secondary">{round.round_code}</Badge>
+                        ) : (
+                          <Badge variant="outline">—</Badge>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={path.status === "active" ? "default" : "outline"}>
+                          {path.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          type="number"
+                          min={0}
+                          value={roundQuotaVal ?? ""}
+                          placeholder="∞"
+                          onChange={(e) =>
+                            handleCellChange(
+                              path.id,
+                              "round_quota",
+                              e.target.value,
+                              admitQuotaVal,
+                            )
+                          }
+                          className="w-24"
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Input
+                          type="number"
+                          min={0}
+                          value={admitQuotaVal ?? ""}
+                          placeholder="∞"
+                          onChange={(e) =>
+                            handleCellChange(
+                              path.id,
+                              "admit_quota",
+                              e.target.value,
+                              roundQuotaVal,
+                            )
+                          }
+                          className="w-24"
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline">
+                          {path.submission_count ?? 0}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          size="sm"
+                          variant={dirty ? "default" : "ghost"}
+                          disabled={!dirty || updateMutation.isPending}
+                          onClick={() => handleSave(path.id)}
+                        >
+                          <Save className="h-4 w-4 mr-1" />
+                          Lưu
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/PhaseNavigator.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/PhaseNavigator.tsx
@@ -50,6 +50,7 @@ const PHASE1_STEPS: StepConfig[] = [
   { id: "document-types", label: "Loại Giấy tờ" },
   { id: "subject-groups", label: "Tổ hợp môn" },
   { id: "rounds", label: "Đợt Tuyển sinh" },  // Phase 2 v8.2 PR-2A v2 — year-level
+  { id: "quota-matrix", label: "Ma trận Chỉ tiêu" },  // Phase 2 v8.2 PR-2D.1
 ];
 
 const PHASE2_STEPS: StepConfig[] = [

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/shared/types.ts
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/shared/types.ts
@@ -126,7 +126,8 @@ export type Phase1Step =
   | 'methods'
   | 'document-types'
   | 'subject-groups'
-  | 'rounds';  // Phase 2 v8.2 PR-2A v2 — đợt tuyển sinh year-level
+  | 'rounds'  // Phase 2 v8.2 PR-2A v2 — đợt tuyển sinh year-level
+  | 'quota-matrix';  // Phase 2 v8.2 PR-2D.1 — ma trận chỉ tiêu (round_quota + admit_quota)
 
 export type Phase2Step =
   | 'majors'

--- a/frontend/src/hooks/admissions/useAdmissionPaths.ts
+++ b/frontend/src/hooks/admissions/useAdmissionPaths.ts
@@ -21,6 +21,8 @@ import {
   getAcademicYears,
   getCoverageMatrix,
   getPathDocuments,
+  updatePathQuota,
+  type AdmissionPathQuotaUpdate,
 } from "@/lib/api/admission-paths"
 import type { 
   AdmissionPathCreate, 
@@ -160,6 +162,25 @@ export function useUpdateAdmissionPath() {
       queryClient.setQueryData(admissionPathKeys.detail(updatedPath.id), updatedPath)
       // Invalidate list queries
       queryClient.invalidateQueries({ queryKey: admissionPathKeys.lists() })
+    },
+  })
+}
+
+/**
+ * Phase 2 v8.2 PR-2D.1 — Hook to update path quota fields.
+ * Tier 1+2 chain validated server-side; BusinessRuleViolation surfaces
+ * as 400 với Vietnamese message.
+ */
+export function useUpdatePathQuota() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ pathId, data }: { pathId: number; data: AdmissionPathQuotaUpdate }) =>
+      updatePathQuota(pathId, data),
+    onSuccess: (updatedPath) => {
+      queryClient.setQueryData(admissionPathKeys.detail(updatedPath.id), updatedPath)
+      queryClient.invalidateQueries({ queryKey: admissionPathKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: admissionPathKeys.all })
     },
   })
 }

--- a/frontend/src/lib/api/admission-paths.ts
+++ b/frontend/src/lib/api/admission-paths.ts
@@ -198,6 +198,33 @@ export async function getCoverageMatrix(
 }
 
 // ============================================
+// PHASE 2 v8.2 PR-2D.1 — QuotaMatrix per-path quota PATCH
+// ============================================
+
+export interface AdmissionPathQuotaUpdate {
+  round_quota: number | null
+  admit_quota: number | null
+}
+
+/**
+ * Update path quota fields (round_quota + admit_quota) cho QuotaMatrix
+ * inline edit. Tier 1+2 chain re-validated server-side.
+ *
+ * BusinessRuleViolation raised từ backend nếu chain violated.
+ */
+export async function updatePathQuota(
+  pathId: number,
+  data: AdmissionPathQuotaUpdate
+): Promise<AdmissionPathResponse> {
+  const response = await api.patch<AdmissionPathResponse>(
+    `/api/v2/admin/admission-paths/${pathId}/quota`,
+    data
+  )
+  return response.data
+}
+
+
+// ============================================
 // EXPORT DEFAULT OBJECT
 // ============================================
 
@@ -220,6 +247,8 @@ export const admissionPathsApi = {
   getPathDocuments,
   // Matrix
   getCoverageMatrix,
+  // Phase 2 v8.2 PR-2D.1
+  updatePathQuota,
 }
 
 export default admissionPathsApi

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -314,6 +314,12 @@ export const admissionPathResponseSchema = z.object({
   applicable_to: z.array(admissionAudienceEnum).nullable(),
   method_quota: z.number().int().min(0).nullable(),
   bonus_rule_override: bonusRuleOverrideSchema.nullable(),
+
+  // Phase 2 v8.2 PR-2B v2 + PR-2D.1 — admission_round_id + path-level quota
+  admission_round_id: z.number().int().min(1).nullable().optional(),
+  round_quota: z.number().int().min(0).nullable().optional(),
+  admit_quota: z.number().int().min(0).nullable().optional(),
+  submission_count: z.number().int().min(0).optional(),
 })
 
 export type AdmissionPathResponse = z.infer<typeof admissionPathResponseSchema>


### PR DESCRIPTION
## Summary

Phase 2 v8.2 PR-2D.1 — FE follow-up to PR-2D BE shipping admin matrix UI cho quota allocation per path. Closes Plan v8.2 PR-2D BE/FE split deferred scope.

**Plan**: `noble-launching-cocoa.md` v8.2
**Predecessor**: PR #246 (PR-2D BE) deployed 2026-05-10 07:27 UTC squash `2858966a`

## Components shipped

### Backend
- `AdmissionPathQuotaUpdate` schema — Pydantic Optional[int] ge=0
- `AdmissionPathService.update_quota` — Tier 1 chain re-validation (excluded_path_id pattern) + Tier 2 invariant + lifecycle guard + structlog audit
- Router PATCH `/api/v2/admin/admission-paths/{id}/quota` — require_admin + ADMIN_WRITE rate limit + activity log
- 476 routes total

### Frontend
- Zod `admissionPathResponseSchema` extended với admission_round_id + round_quota + admit_quota + submission_count
- API client `updatePathQuota()` + `AdmissionPathQuotaUpdate` type
- Hook `useUpdatePathQuota` (React Query mutation với cache invalidation)
- Component `QuotaMatrixTab.tsx` — top-level Phase1 sidebar tab:
  - Year selector dropdown (current ± 1)
  - Academic_info_id input (filter paths)
  - Table rows=paths, cols=round | status | round_quota | admit_quota | submission_count
  - Inline edit cells với dirty state highlighting (amber bg)
  - Save button per row triggers PATCH
  - Toast feedback Vietnamese (success / error từ BusinessRuleViolation detail)
- Type `Phase1Step` thêm 'quota-matrix'
- PhaseNavigator entry "Ma trận Chỉ tiêu"
- AdmissionConfigClient routing case 'quota-matrix'

## Verification

- BE app imports OK (476 routes)
- FE type-check PASS
- Plan v8.2 closes PR-2D FE follow-up gap

## Risk register

| Risk | Severity | Mitigation |
|---|---|---|
| Tier 1 violation feedback lag | LOW | Server-side validation per cell save (real-time) |
| Cell edit conflict (concurrent admin) | LOW | Optimistic locking trên path version (existing) |
| FE form bypass quota guard | NONE | BE validates via update_quota service layer |
| Inline edit UX confusion | LOW | Dirty state highlighting + explicit Save button per row |

## Outstanding follow-up (defer)

- Bulk-clone modal UX ("Clone DOT_1 paths → DOT_2" button) — PR-2D backend clone endpoint already shipped, FE modal là enhancement
- Vitest interaction tests cho QuotaMatrixTab (anchor coverage; defer per memory feedback_test_run_approval pragmatic)
- Tier 1 real-time client-side preview (currently server-only validation)

## Refs

- Plan: `C:\Users\Admin\.claude\plans\noble-launching-cocoa.md` v8.2 PR-2D.1 split
- Predecessor PR-2D BE: #246 squash 2858966a
- Memory: `phase2-pr-2d-be-shipped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)