### PR TITLE
feat(admission): #184 Phase 2 v8.2 PR-2D.1 v2 — Quota Matrix overview Phase 3 (redesign)

### DIFF
--- a/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
+++ b/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
@@ -18,9 +18,15 @@ from app.schemas.path_subject_group import (
     PathSubjectGroupItemCreate,
     PathSubjectGroupItemResponse,
 )
+from app.schemas.admission_path import AdmissionPathQuotaUpdate, AdmissionPathResponse
+from app.schemas.quota_matrix import QuotaMatrixResponse
 from app.services import activity_service
+from app.services.admission_path_service import AdmissionPathService
 from app.services.path_clone_service import PathCloneService
 from app.services.path_subject_group_service import PathSubjectGroupService
+from app.services.quota_matrix_service import QuotaMatrixService
+from app.utils.exceptions import ResourceNotFoundError
+from sqlalchemy import select
 
 
 log = structlog.get_logger(__name__)
@@ -163,6 +169,76 @@ async def add_item(
     item = await service.add_item(config_id, payload)
     await db.commit()
     return item
+
+
+# =============================================================================
+# PR-2D.1 v2 — Quota Matrix overview + per-path quota PATCH
+# =============================================================================
+
+
+@router.get(
+    "/years/{academic_year}/quota-matrix",
+    response_model=QuotaMatrixResponse,
+)
+async def get_quota_matrix(
+    request: Request,
+    academic_year: int,
+    db: AsyncSession = Depends(database.get_db),
+    _admin: models.User = Depends(require_admin),
+):
+    """Phase 2 v8.2 PR-2D.1 v2 — admin tổng quan ALL ngành × ALL đợt năm filter.
+
+    Aggregation: rows = academic_info, cols = rounds, cells = ∑ admit_quota
+    across paths trong cùng (academic_info × round). Constraint visible:
+    ∑ row cells ≤ academic_info.annual_admission_quota.
+    """
+    service = QuotaMatrixService(db)
+    return await service.get_matrix(academic_year)
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.patch(
+    "/admission-paths/{admission_path_id}/quota",
+    response_model=AdmissionPathResponse,
+)
+async def update_path_quota(
+    request: Request,
+    admission_path_id: int,
+    payload: AdmissionPathQuotaUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """Phase 2 v8.2 PR-2D.1 — dedicated quota PATCH cho QuotaMatrix inline edit."""
+    stmt = select(models.AdmissionPath).where(
+        models.AdmissionPath.id == admission_path_id
+    )
+    path = (await db.execute(stmt)).scalar_one_or_none()
+    if path is None:
+        raise ResourceNotFoundError(f"AdmissionPath {admission_path_id} not found")
+
+    service = AdmissionPathService(db)
+    path = await service.update_quota(
+        path=path,
+        round_quota=payload.round_quota,
+        admit_quota=payload.admit_quota,
+        user=current_admin,
+    )
+    await db.commit()
+
+    await activity_service.log_activity(
+        db=db,
+        action="admission_path_quota_update",
+        resource_type="admission_path",
+        resource_id=path.id,
+        actor_id=current_admin.id,
+        description=(
+            f"Updated quota path={path.id} "
+            f"round_quota={payload.round_quota} admit_quota={payload.admit_quota}"
+        ),
+    )
+    from app.repositories.admission_path_repository import AdmissionPathRepository
+    path = await AdmissionPathRepository(db).get_by_id_with_relations(path.id)
+    return path
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -281,6 +281,20 @@ class AdmissionPathCreate(BaseModel):
     )(_validate_minor_correction_allowlist)
 
 
+class AdmissionPathQuotaUpdate(BaseModel):
+    """Phase 2 v8.2 PR-2D.1 — dedicated quota PATCH payload cho QuotaMatrix
+    inline edit. Allows admin update round_quota/admit_quota independently
+    với Tier 1+2 chain validation real-time per cell change."""
+    round_quota: Optional[int] = Field(
+        default=None, ge=0,
+        description="Per-path submission cap. NULL = unbounded; explicit None to clear.",
+    )
+    admit_quota: Optional[int] = Field(
+        default=None, ge=0,
+        description="Per-path admit cap. Triggers Tier 1 chain re-validation on change.",
+    )
+
+
 class AdmissionPathUpdate(BaseModel):
     """Request schema for updating an AdmissionPath."""
     display_name: Optional[str] = None

--- a/Backend_FastAPI/app/schemas/quota_matrix.py
+++ b/Backend_FastAPI/app/schemas/quota_matrix.py
@@ -1,0 +1,80 @@
+# app/schemas/quota_matrix.py
+"""Quota matrix overview schema (Phase 2 v8.2 PR-2D.1 v2 — Phase 3 view).
+
+Aggregated read-model cho admin tổng quan rải chỉ tiêu theo (ngành × đợt).
+Granularity: 1 row = 1 academic_info; 1 col = 1 round; cell = sum of
+admit_quota across paths trong cùng (academic_info × round).
+
+Constraint visible: ∑(row cells) ≤ academic_info.annual_admission_quota
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class QuotaMatrixRound(BaseModel):
+    """1 đợt cho năm filter (column header)."""
+    id: int
+    round_code: str
+    round_name: str
+    is_active: bool
+
+
+class QuotaMatrixCell(BaseModel):
+    """Sum aggregated cho (academic_info × round) cell."""
+    admission_round_id: int
+    round_code: str
+    total_admit_quota: int = Field(
+        default=0,
+        description="∑ admit_quota across paths trong cùng (academic_info × round). NULL paths counted as 0.",
+    )
+    total_round_quota: int = Field(
+        default=0,
+        description="∑ round_quota across paths.",
+    )
+    total_submission_count: int = Field(
+        default=0,
+        description="∑ submission_count actual filed.",
+    )
+    path_count: int = Field(
+        default=0,
+        description="Số paths trong cell (để admin biết granularity).",
+    )
+
+
+class QuotaMatrixRow(BaseModel):
+    """1 ngành (academic_info) × N rounds → 1 row matrix."""
+    academic_info_id: int
+    academic_year: int
+    program_name: str = Field(..., description="Tên ngành đào tạo")
+    program_code: Optional[str] = None
+    degree_level: Optional[str] = None
+    annual_admission_quota: Optional[int] = Field(
+        default=None,
+        description="Tổng chỉ tiêu cho năm. NULL = không giới hạn (unbounded).",
+    )
+    cells_by_round_id: dict[int, QuotaMatrixCell] = Field(
+        default_factory=dict,
+        description="Map round_id → cell. Empty cell nếu chưa có path",
+    )
+    sum_admit_allocated: int = Field(
+        default=0,
+        description="∑ tất cả cell.total_admit_quota — đã rải",
+    )
+    sum_remaining: Optional[int] = Field(
+        default=None,
+        description="annual - sum_allocated. NULL nếu annual NULL. Negative = vượt cap (warning)",
+    )
+
+
+class QuotaMatrixResponse(BaseModel):
+    """GET /api/v2/admin/years/{year}/quota-matrix response.
+
+    Admin tổng quan ALL ngành × ALL rounds cho năm filter.
+    """
+    model_config = ConfigDict(from_attributes=True)
+    academic_year: int
+    rounds: List[QuotaMatrixRound]
+    rows: List[QuotaMatrixRow]
+    total_rows: int

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -281,6 +281,43 @@ class AdmissionPathService:
 
         return path, _noop_callback
 
+    async def update_quota(
+        self,
+        path: AdmissionPath,
+        round_quota: int | None,
+        admit_quota: int | None,
+        user: User,
+    ) -> AdmissionPath:
+        """Phase 2 v8.2 PR-2D.1 — dedicated quota update với Tier 1+2 chain
+        validation per cell change cho QuotaMatrix UI inline edit."""
+        from app.services.admission_quota_service import AdmissionQuotaService
+
+        _check_lifecycle_guard(path, user)
+        quota_service = AdmissionQuotaService(self.db)
+
+        await quota_service.validate_tier2_path_invariant(
+            admit_quota=admit_quota, round_quota=round_quota,
+        )
+        if admit_quota != path.admit_quota:
+            await quota_service.validate_tier1_chain_on_path_quota_change(
+                academic_info_id=path.academic_info_id,
+                delta_admit_quota=(admit_quota or 0),
+                excluded_path_id=path.id,
+            )
+
+        path.round_quota = round_quota
+        path.admit_quota = admit_quota
+        await self.db.flush()
+
+        log.info(
+            "admission_path_quota_updated",
+            path_id=path.id,
+            round_quota=round_quota,
+            admit_quota=admit_quota,
+            actor_id=user.id,
+        )
+        return path
+
     async def update_path(
         self, path: AdmissionPath, data: AdmissionPathUpdate, user: User
     ) -> Tuple[AdmissionPath, PostCommitCallback]:

--- a/Backend_FastAPI/app/services/quota_matrix_service.py
+++ b/Backend_FastAPI/app/services/quota_matrix_service.py
@@ -1,0 +1,144 @@
+# app/services/quota_matrix_service.py
+"""Quota matrix overview service (Phase 2 v8.2 PR-2D.1 v2).
+
+Aggregation logic cho GET /api/v2/admin/years/{year}/quota-matrix endpoint.
+Returns matrix với rows = academic_info × academic_year, cols = rounds,
+cells = aggregated quota.
+"""
+
+from typing import List
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models import (
+    OfferingAcademicInfo,
+    OfferingAdmissionRound,
+    ProgramOffering,
+)
+from app.models.admission_config import AdmissionPath
+from app.models.major_program import MajorProgram
+from app.schemas.quota_matrix import (
+    QuotaMatrixCell,
+    QuotaMatrixResponse,
+    QuotaMatrixRound,
+    QuotaMatrixRow,
+)
+
+
+class QuotaMatrixService:
+    """Aggregation service cho quota matrix admin view."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_matrix(self, academic_year: int) -> QuotaMatrixResponse:
+        """Build matrix: rows = academic_info, cols = rounds, cells = sum quota.
+
+        Filter:
+        - academic_info.academic_year = year
+        - academic_info.is_deleted = false
+        - round.academic_year = year
+        - path.status != 'archived'
+        """
+        # 1. Rounds for the year (sorted by round_code asc cho stable column order)
+        rounds_stmt = (
+            select(OfferingAdmissionRound)
+            .where(OfferingAdmissionRound.academic_year == academic_year)
+            .order_by(OfferingAdmissionRound.round_code)
+        )
+        rounds = list((await self.db.execute(rounds_stmt)).scalars().all())
+
+        # 2. Academic infos for the year với eager-load offering → program
+        ai_stmt = (
+            select(OfferingAcademicInfo)
+            .where(
+                OfferingAcademicInfo.academic_year == academic_year,
+                OfferingAcademicInfo.is_deleted.is_(False),
+            )
+            .options(
+                selectinload(OfferingAcademicInfo.offering)
+                .selectinload(ProgramOffering.program)
+            )
+            .order_by(OfferingAcademicInfo.id)
+        )
+        academic_infos = list((await self.db.execute(ai_stmt)).scalars().all())
+
+        # 3. All paths for these academic_infos (excluding archived)
+        ai_ids = [ai.id for ai in academic_infos]
+        paths: List[AdmissionPath] = []
+        if ai_ids:
+            paths_stmt = select(AdmissionPath).where(
+                AdmissionPath.academic_info_id.in_(ai_ids),
+                AdmissionPath.status != "archived",
+            )
+            paths = list((await self.db.execute(paths_stmt)).scalars().all())
+
+        # 4. Aggregate paths into cells map: (ai_id, round_id) → cell
+        cell_map: dict[tuple[int, int], QuotaMatrixCell] = {}
+        for path in paths:
+            if path.admission_round_id is None:
+                continue  # defensive; PR-2C v2 swap NOT NULL nhưng safe
+            key = (path.academic_info_id, path.admission_round_id)
+            cell = cell_map.get(key)
+            if cell is None:
+                round_obj = next(
+                    (r for r in rounds if r.id == path.admission_round_id), None
+                )
+                if round_obj is None:
+                    # Path's round is from different year; skip
+                    continue
+                cell = QuotaMatrixCell(
+                    admission_round_id=path.admission_round_id,
+                    round_code=round_obj.round_code,
+                )
+                cell_map[key] = cell
+            cell.total_admit_quota += int(path.admit_quota or 0)
+            cell.total_round_quota += int(path.round_quota or 0)
+            cell.total_submission_count += int(path.submission_count or 0)
+            cell.path_count += 1
+
+        # 5. Build rows
+        rows: List[QuotaMatrixRow] = []
+        for ai in academic_infos:
+            offering = ai.offering
+            program = offering.program if offering else None
+            cells_by_round_id: dict[int, QuotaMatrixCell] = {}
+            for r in rounds:
+                cell = cell_map.get((ai.id, r.id))
+                if cell is not None:
+                    cells_by_round_id[r.id] = cell
+            sum_allocated = sum(c.total_admit_quota for c in cells_by_round_id.values())
+            remaining: int | None = None
+            if ai.annual_admission_quota is not None:
+                remaining = ai.annual_admission_quota - sum_allocated
+
+            rows.append(
+                QuotaMatrixRow(
+                    academic_info_id=ai.id,
+                    academic_year=ai.academic_year,
+                    program_name=program.name if program else "(không tên)",
+                    program_code=program.code if program else None,
+                    degree_level=program.degree_level if program else None,
+                    annual_admission_quota=ai.annual_admission_quota,
+                    cells_by_round_id=cells_by_round_id,
+                    sum_admit_allocated=sum_allocated,
+                    sum_remaining=remaining,
+                )
+            )
+
+        return QuotaMatrixResponse(
+            academic_year=academic_year,
+            rounds=[
+                QuotaMatrixRound(
+                    id=r.id,
+                    round_code=r.round_code,
+                    round_name=r.round_name,
+                    is_active=r.is_active,
+                )
+                for r in rounds
+            ],
+            rows=rows,
+            total_rows=len(rows),
+        )

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/AdmissionConfigClient.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/AdmissionConfigClient.tsx
@@ -32,6 +32,7 @@ import { AcademicInfoPanel } from "./Phase2Program/AcademicInfoPanel";
 import { ContextSelector } from "./Phase3Config/ContextSelector";
 import { PathsList } from "./Phase3Config/PathsList";
 import { CoverageMatrix } from "./Phase3Config/CoverageMatrix";
+import { QuotaMatrixOverview } from "./Phase3Config/QuotaMatrixOverview";  // Phase 2 v8.2 PR-2D.1 v2
 import { PathWizard } from "./Phase3Config/PathWizard";
 import { Button } from "@/components/ui/button";
 import {
@@ -151,6 +152,17 @@ export function AdmissionConfigClient() {
               context={currentState.context}
               view={currentState.view}
               navigate={navigate}
+            />
+          )}
+
+          {/* Phase 2 v8.2 PR-2D.1 v2 — Quota Matrix overview (no context) */}
+          {currentState.type === "quota-matrix-overview" && (
+            <QuotaMatrixOverview
+              academicYear={currentState.academicYear}
+              onYearChange={(year) =>
+                navigate({ type: "quota-matrix-overview", academicYear: year })
+              }
+              onBack={() => navigate({ type: "welcome" })}
             />
           )}
         </div>

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrixOverview.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrixOverview.tsx
@@ -1,0 +1,225 @@
+/**
+ * QuotaMatrixOverview — admin global quota allocation matrix (Phase 2 v8.2 PR-2D.1 v2).
+ *
+ * Phase 3 view, NO context filter. Shows ALL ngành × all rounds cho năm filter.
+ *
+ * UX:
+ * - Year selector (current ± 2 năm)
+ * - Table: rows = ngành (academic_info × academic_year), cols = rounds
+ * - Cells = ∑ admit_quota across paths trong cùng (academic_info × round)
+ * - Tổng quota | Đã rải | Còn lại columns
+ * - Cảnh báo đỏ nếu Còn lại < 0 (vượt cap)
+ *
+ * Tiếng Việt nhất quán per user feedback.
+ */
+"use client"
+
+import { AlertTriangle, ChevronLeft } from "lucide-react"
+import { useMemo, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useQuotaMatrix } from "@/hooks/admissions/useQuotaMatrix"
+
+const CURRENT_YEAR = new Date().getFullYear()
+const YEAR_OPTIONS = [CURRENT_YEAR - 1, CURRENT_YEAR, CURRENT_YEAR + 1, CURRENT_YEAR + 2]
+
+interface Props {
+  academicYear: number
+  onYearChange: (year: number) => void
+  onBack: () => void
+}
+
+export function QuotaMatrixOverview({ academicYear, onYearChange, onBack }: Props) {
+  const { data, isLoading, isError } = useQuotaMatrix(academicYear)
+  const [showAdmit, setShowAdmit] = useState(true)
+
+  const totalCols = useMemo(() => (data?.rounds.length ?? 0) + 4, [data?.rounds])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Quay lại
+        </Button>
+        <h2 className="text-xl font-semibold">Ma trận chỉ tiêu theo đợt</h2>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>Tổng quan rải chỉ tiêu năm {academicYear}</span>
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                variant={showAdmit ? "default" : "outline"}
+                onClick={() => setShowAdmit(true)}
+              >
+                Chỉ tiêu trúng tuyển
+              </Button>
+              <Button
+                size="sm"
+                variant={!showAdmit ? "default" : "outline"}
+                onClick={() => setShowAdmit(false)}
+              >
+                Chỉ tiêu nộp hồ sơ
+              </Button>
+            </div>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-4">
+            <div>
+              <label className="text-sm font-medium">Năm tuyển sinh:</label>
+              <Select
+                value={academicYear.toString()}
+                onValueChange={(v) => onYearChange(Number(v))}
+              >
+                <SelectTrigger className="w-32 ml-2 inline-flex">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {YEAR_OPTIONS.map((y) => (
+                    <SelectItem key={y} value={y.toString()}>
+                      {y}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {data && (
+              <Badge variant="outline">
+                {data.total_rows} ngành × {data.rounds.length} đợt
+              </Badge>
+            )}
+          </div>
+
+          {isLoading && <div className="text-sm text-muted-foreground">Đang tải...</div>}
+          {isError && (
+            <div className="text-sm text-destructive">
+              Lỗi tải dữ liệu. Vui lòng thử lại.
+            </div>
+          )}
+
+          {data && data.rows.length === 0 && (
+            <div className="text-sm text-muted-foreground">
+              Chưa có ngành nào được công bố cho năm {academicYear}.
+            </div>
+          )}
+
+          {data && data.rows.length > 0 && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Ngành</TableHead>
+                  <TableHead>Bậc</TableHead>
+                  <TableHead className="text-right">Tổng chỉ tiêu</TableHead>
+                  {data.rounds.map((r) => (
+                    <TableHead key={r.id} className="text-right">
+                      <div className="font-semibold">{r.round_code}</div>
+                      <div className="text-xs text-muted-foreground">{r.round_name}</div>
+                    </TableHead>
+                  ))}
+                  <TableHead className="text-right">Đã rải</TableHead>
+                  <TableHead className="text-right">Còn lại</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.rows.map((row) => {
+                  const isOver = row.sum_remaining !== null && row.sum_remaining < 0
+                  return (
+                    <TableRow key={row.academic_info_id} className={isOver ? "bg-red-50" : ""}>
+                      <TableCell className="font-medium">
+                        {row.program_name}
+                        {row.program_code && (
+                          <span className="ml-2 text-xs text-muted-foreground">
+                            ({row.program_code})
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className="text-xs">
+                          {row.degree_level ?? "—"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right font-medium">
+                        {row.annual_admission_quota ?? (
+                          <span className="text-muted-foreground italic">∞</span>
+                        )}
+                      </TableCell>
+                      {data.rounds.map((r) => {
+                        const cell = row.cells_by_round_id[r.id]
+                        const value = cell
+                          ? showAdmit
+                            ? cell.total_admit_quota
+                            : cell.total_round_quota
+                          : 0
+                        return (
+                          <TableCell key={r.id} className="text-right">
+                            {cell ? (
+                              <div>
+                                <div className="font-medium">{value}</div>
+                                {cell.path_count > 1 && (
+                                  <div className="text-xs text-muted-foreground">
+                                    ({cell.path_count} paths)
+                                  </div>
+                                )}
+                              </div>
+                            ) : (
+                              <span className="text-muted-foreground">—</span>
+                            )}
+                          </TableCell>
+                        )
+                      })}
+                      <TableCell className="text-right font-medium">
+                        {row.sum_admit_allocated}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {row.sum_remaining === null ? (
+                          <span className="text-muted-foreground italic">∞</span>
+                        ) : isOver ? (
+                          <span className="text-destructive font-semibold inline-flex items-center gap-1">
+                            <AlertTriangle className="h-4 w-4" />
+                            {row.sum_remaining}
+                          </span>
+                        ) : (
+                          <span className="font-medium">{row.sum_remaining}</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          )}
+
+          <div className="text-xs text-muted-foreground space-y-1 mt-4">
+            <p>• Cells = ∑ chỉ tiêu của tất cả đường tuyển sinh thuộc ngành đó cho đợt đó.</p>
+            <p>• Cảnh báo đỏ ⚠ nếu Đã rải vượt Tổng chỉ tiêu (Tier 1 chain violation).</p>
+            <p>
+              • Để chỉnh chỉ tiêu chi tiết per đường tuyển sinh, vào "Cấu hình Đường tuyển sinh"
+              chọn ngành cụ thể.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/PhaseNavigator.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/PhaseNavigator.tsx
@@ -71,6 +71,7 @@ export function PhaseNavigator({
   const isPhase1Active = currentState.type === "phase1";
   const isPhase2Active = currentState.type === "phase2";
   const isPhase3Active = currentState.type === "phase3" || currentState.type === "select-context";
+  const isQuotaMatrixActive = currentState.type === "quota-matrix-overview";
 
   const currentPhase1Step = isPhase1Active ? currentState.step : null;
   const currentPhase2Step = isPhase2Active ? currentState.step : null;
@@ -98,6 +99,13 @@ export function PhaseNavigator({
   const handlePhase3Click = () => {
     onNavigate({ type: "select-context" });
     // Close mobile sheet after navigation
+    onClose?.();
+  };
+
+  // Navigate to Quota Matrix overview (Phase 2 v8.2 PR-2D.1 v2)
+  const handleQuotaMatrixClick = () => {
+    const currentYear = new Date().getFullYear();
+    onNavigate({ type: "quota-matrix-overview", academicYear: currentYear });
     onClose?.();
   };
 
@@ -187,6 +195,15 @@ export function PhaseNavigator({
         >
           <BarChart3 className="h-4 w-4 mr-2" />
           Cấu hình Đường tuyển sinh
+        </Button>
+        <Button
+          variant={isQuotaMatrixActive ? "default" : "outline"}
+          size="sm"
+          className="w-full justify-start mt-2"
+          onClick={handleQuotaMatrixClick}
+        >
+          <BarChart3 className="h-4 w-4 mr-2" />
+          Ma trận Chỉ tiêu Theo Đợt
         </Button>
       </Card>
 

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/shared/types.ts
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/shared/types.ts
@@ -150,7 +150,10 @@ export type AdmissionConfigState =
   | { type: 'phase1'; step: Phase1Step }
   | { type: 'phase2'; step: Phase2Step }
   | { type: 'select-context' }
-  | { type: 'phase3'; context: SelectionContext; view: Phase3View };
+  | { type: 'phase3'; context: SelectionContext; view: Phase3View }
+  // Phase 2 v8.2 PR-2D.1 v2 — global quota matrix overview (ALL ngành × đợt)
+  // KHÔNG cần SelectionContext vì matrix tổng quan all academic_info
+  | { type: 'quota-matrix-overview'; academicYear: number };
 
 // ============================================
 // NAVIGATION TYPES

--- a/frontend/src/hooks/admissions/useAdmissionConfigState.ts
+++ b/frontend/src/hooks/admissions/useAdmissionConfigState.ts
@@ -116,6 +116,10 @@ function stateToUrl(state: AdmissionConfigState): string {
     return `${base}?phase=3`;
   }
 
+  if (state.type === "quota-matrix-overview") {
+    return `${base}?view=quota-matrix&year=${state.academicYear}`;
+  }
+
   if (state.type === "phase3") {
     const ctx = state.context;
     const params = new URLSearchParams({
@@ -184,6 +188,14 @@ export function useAdmissionConfigState() {
     // If Phase 2 URL param, show Phase 2
     if (phase === "2" && step) {
       return { type: "phase2", step: step as Phase2Step };
+    }
+
+    // Quota Matrix overview (Phase 2 v8.2 PR-2D.1 v2 — global view, no context)
+    const viewParam = searchParams.get("view");
+    if (viewParam === "quota-matrix") {
+      const yearStr = searchParams.get("year");
+      const year = yearStr ? parseInt(yearStr, 10) : new Date().getFullYear();
+      return { type: "quota-matrix-overview", academicYear: year };
     }
 
     // If Phase 3 URL param

--- a/frontend/src/hooks/admissions/useQuotaMatrix.ts
+++ b/frontend/src/hooks/admissions/useQuotaMatrix.ts
@@ -1,0 +1,40 @@
+// frontend/src/hooks/admissions/useQuotaMatrix.ts
+// Phase 2 v8.2 PR-2D.1 v2 — React Query hooks cho quota matrix.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import {
+  getQuotaMatrix,
+  updatePathQuota,
+  type AdmissionPathQuotaUpdate,
+} from "@/lib/api/quota-matrix"
+
+export const quotaMatrixKeys = {
+  all: ["quota-matrix"] as const,
+  byYear: (year: number) => [...quotaMatrixKeys.all, "year", year] as const,
+}
+
+export function useQuotaMatrix(academicYear: number | undefined) {
+  return useQuery({
+    queryKey: quotaMatrixKeys.byYear(academicYear ?? 0),
+    queryFn: () => getQuotaMatrix(academicYear!),
+    enabled: !!academicYear,
+    staleTime: 30 * 1000, // 30s
+  })
+}
+
+export function useUpdatePathQuota() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      pathId,
+      data,
+    }: {
+      pathId: number
+      data: AdmissionPathQuotaUpdate
+    }) => updatePathQuota(pathId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: quotaMatrixKeys.all })
+    },
+  })
+}

--- a/frontend/src/lib/api/quota-matrix.ts
+++ b/frontend/src/lib/api/quota-matrix.ts
@@ -1,0 +1,73 @@
+// frontend/src/lib/api/quota-matrix.ts
+// Phase 2 v8.2 PR-2D.1 v2 — Quota matrix overview API client.
+
+import { api } from "./client"
+
+export interface QuotaMatrixRound {
+  id: number
+  round_code: string
+  round_name: string
+  is_active: boolean
+}
+
+export interface QuotaMatrixCell {
+  admission_round_id: number
+  round_code: string
+  total_admit_quota: number
+  total_round_quota: number
+  total_submission_count: number
+  path_count: number
+}
+
+export interface QuotaMatrixRow {
+  academic_info_id: number
+  academic_year: number
+  program_name: string
+  program_code: string | null
+  degree_level: string | null
+  annual_admission_quota: number | null
+  cells_by_round_id: Record<number, QuotaMatrixCell>
+  sum_admit_allocated: number
+  sum_remaining: number | null
+}
+
+export interface QuotaMatrixResponse {
+  academic_year: number
+  rounds: QuotaMatrixRound[]
+  rows: QuotaMatrixRow[]
+  total_rows: number
+}
+
+export interface AdmissionPathQuotaUpdate {
+  round_quota: number | null
+  admit_quota: number | null
+}
+
+/**
+ * Get quota matrix overview cho năm tuyển sinh.
+ * Aggregation: rows = academic_info × academic_year, cols = rounds,
+ * cells = ∑ admit_quota across paths.
+ */
+export async function getQuotaMatrix(
+  academicYear: number,
+): Promise<QuotaMatrixResponse> {
+  const response = await api.get<QuotaMatrixResponse>(
+    `/api/v2/admin/years/${academicYear}/quota-matrix`,
+  )
+  return response.data
+}
+
+/**
+ * Update path quota cho QuotaMatrix drawer/inline edit.
+ * Tier 1+2 chain validated server-side.
+ */
+export async function updatePathQuota(
+  pathId: number,
+  data: AdmissionPathQuotaUpdate,
+): Promise<unknown> {
+  const response = await api.patch(
+    `/api/v2/admin/admission-paths/${pathId}/quota`,
+    data,
+  )
+  return response.data
+}


### PR DESCRIPTION
## Summary

Phase 2 v8.2 PR-2D.1 v2 — **REDESIGN** sau user feedback Pass 12 (PR #249 v1 closed).

### User feedback (2026-05-10)
- v1 design SAI: đặt 'Ma trận Chỉ tiêu' ở Phase 1 (Master data) là không hợp lý
- Logic đúng: **Ma trận = Phase 3 view**, hiển thị **TẤT CẢ ngành × đợt** trong 1 view tổng quan
- Constraint visible: ∑(quota cells của ngành theo đợt) ≤ annual_admission_quota của ngành

## Sidebar restructure

| Phase | Trước | Sau |
|---|---|---|
| **Phase 1** | Master data + 'Ma trận Chỉ tiêu' (sai vị trí) | Master data only |
| **Phase 3** | 1 button 'Cấu hình Đường tuyển sinh' | 2 buttons: 'Cấu hình Đường tuyển sinh' + 'Ma trận Chỉ tiêu Theo Đợt' |

## Components shipped

### Backend
- `quota_matrix.py` schema — QuotaMatrixResponse (rows × rounds × cells aggregated)
- `quota_matrix_service.py` — aggregation logic, eager-load programs, compute sum_remaining
- GET `/api/v2/admin/years/{year}/quota-matrix` endpoint require_admin
- PATCH `/api/v2/admin/admission-paths/{id}/quota` (preserved cho drawer Wave 2)

### Frontend
- AdmissionConfigState type extended với 'quota-matrix-overview' variant (NO context)
- URL sync: `?view=quota-matrix&year=YYYY`
- `QuotaMatrixOverview.tsx` Phase3Config:
  - Year selector (current ± 2)
  - Toggle: Chỉ tiêu trúng tuyển | Chỉ tiêu nộp hồ sơ
  - Table: rows=ngành, cols=đợt, cells=∑ admit_quota across paths
  - Cảnh báo đỏ row nếu Còn lại < 0 (Tier 1 chain violation visible)
  - Help text hướng dẫn chỉnh chi tiết qua Cấu hình Đường tuyển sinh

## Verification

- BE app loads OK (477 routes)
- FE type-check PASS
- **Browser smoke (Chrome MCP) end-to-end**:
  - Phase 1 sidebar không còn 'Ma trận Chỉ tiêu' ✅
  - Phase 3 hiển thị 2 buttons ✅
  - Click 'Ma trận Chỉ tiêu Theo Đợt' → render đúng matrix
  - 20 ngành × 1 đợt (DOT_1 2026) với prod data
  - Chăn nuôi thú y CĐ: 35 tổng, 30 rải DOT_1 (3 paths), còn 5 ✅
  - Y sỹ đa khoa CĐ: 70 tổng, 0 rải, còn 70

## Outstanding follow-up (Wave 2 defer)

- Drawer/modal click cell → drill-down per path (per method) breakdown + inline edit individual path quota
- Vitest interaction tests cho QuotaMatrixOverview
- Bulk save multi-cell

## Refs

- PR #249 v1 (closed unmerged) — feedback Pass 12 caught design error
- Plan: `noble-launching-cocoa.md` v8.2 PR-2D.1 split

🤖 Generated with [Claude Code](https://claude.com/claude-code)