### PR TITLE
feat(admission): #184 Phase 2 PR-2D.1 v4a — Quota Matrix UI + 31 hard-review fixes

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase2_06_admit_quota_le_round_quota_check.py
+++ b/Backend_FastAPI/alembic/versions/phase2_06_admit_quota_le_round_quota_check.py
@@ -1,0 +1,68 @@
+"""Phase 2 hard-review pass 2 BM-2 — Tier 2 invariant CHECK constraint
+
+Add DB-level CHECK constraint backing service-layer Tier 2 invariant:
+``admit_quota <= round_quota`` khi cả 2 set. Service validator
+(``admission_quota_service.validate_tier2_path_invariant``) đã enforce,
+nhưng direct SQL bypass (admin migration / hand-edit script) có thể
+violate. CHECK constraint = defense-in-depth backup.
+
+Semantics:
+* CHECK passes nếu ``admit_quota IS NULL`` HOẶC ``round_quota IS NULL``
+  HOẶC ``admit_quota <= round_quota``
+* NULL-safe — không reject path chưa cấu hình quota
+
+Pre-flight check: audit existing rows, raise nếu vi phạm pre-deploy.
+
+Revision ID: phase2_06
+Revises: phase2_05
+Create Date: 2026-05-11
+"""
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+
+revision: str = "phase2_06"
+down_revision: Union[str, None] = "phase2_05"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Pre-flight audit: bất kỳ row nào violate sẽ block migration ngay
+    # (better than silent CHECK failure trên next INSERT/UPDATE).
+    conn = op.get_bind()
+    violations = conn.execute(
+        text(
+            """
+            SELECT COUNT(*) FROM admission_path
+            WHERE admit_quota IS NOT NULL
+              AND round_quota IS NOT NULL
+              AND admit_quota > round_quota
+            """
+        )
+    ).scalar()
+    if violations and int(violations) > 0:
+        raise RuntimeError(
+            f"Cannot add Tier 2 CHECK: {violations} rows already violate "
+            f"admit_quota <= round_quota. Fix data trước khi apply."
+        )
+
+    op.execute(
+        """
+        ALTER TABLE admission_path
+        ADD CONSTRAINT ck_admit_quota_le_round_quota
+        CHECK (
+            admit_quota IS NULL
+            OR round_quota IS NULL
+            OR admit_quota <= round_quota
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE admission_path DROP CONSTRAINT IF EXISTS ck_admit_quota_le_round_quota"
+    )

--- a/Backend_FastAPI/app/routers/admin_v2_admission_round.py
+++ b/Backend_FastAPI/app/routers/admin_v2_admission_round.py
@@ -250,7 +250,10 @@ async def restore_round(
 ):
     """Khôi phục đợt đã lưu trữ — inverse của soft_archive."""
     service = AdmissionRoundService(db)
-    round_obj = await service.restore(round_id, current_admin)
+    # Pass 2 hard-review B-2-2: service trả ``(round_obj, prior_state)`` —
+    # log delta old → new để audit reconstruction (restore-archive-restore
+    # loop preserve extension history).
+    round_obj, prior_state = await service.restore(round_id, current_admin)
 
     await activity_service.log_activity(
         db=db,
@@ -259,6 +262,11 @@ async def restore_round(
         resource_id=round_id,
         actor_id=current_admin.id,
         description=f"Round {round_id} restored từ archive",
+        changes={
+            **prior_state,
+            "new_archived_at": None,
+            "new_is_active": True,
+        },
         ip_address=request.client.host if request.client else None,
         user_agent=request.headers.get("user-agent"),
     )
@@ -279,7 +287,10 @@ async def extend_round(
 ):
     """Admin extend ``end_date`` per SPEC §2.1.a Rule 2."""
     service = AdmissionRoundService(db)
-    round_obj = await service.extend(round_id, payload, current_admin)
+    # Pass 2 hard-review B-2-2: service trả ``(round_obj, prior_state)`` —
+    # log delta old_end_date → new_end_date để audit reconstruction nếu
+    # admin extend nhiều lần liên tiếp.
+    round_obj, prior_state = await service.extend(round_id, payload, current_admin)
 
     await activity_service.log_activity(
         db=db,
@@ -291,6 +302,7 @@ async def extend_round(
             f"Round {round_id} end_date extended to {payload.end_date.isoformat()}"
         ),
         changes={
+            **prior_state,
             "new_end_date": payload.end_date.isoformat(),
             "extension_reason": payload.extension_reason,
         },

--- a/Backend_FastAPI/app/routers/admin_v2_admission_round.py
+++ b/Backend_FastAPI/app/routers/admin_v2_admission_round.py
@@ -197,7 +197,9 @@ async def update_round(
         resource_id=round_id,
         actor_id=current_admin.id,
         description=f"Round {round_id} updated",
-        changes=payload.model_dump(exclude_unset=True),
+        # mode="json" để serialize date → ISO string (JSON column không nhận
+        # datetime.date object → SQLAlchemy raise TypeError lúc INSERT).
+        changes=payload.model_dump(exclude_unset=True, mode="json"),
         ip_address=request.client.host if request.client else None,
         user_agent=request.headers.get("user-agent"),
     )
@@ -229,6 +231,34 @@ async def soft_archive_round(
         resource_id=round_id,
         actor_id=current_admin.id,
         description=f"Round {round_id} soft-archived",
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    await db.commit()
+    await db.refresh(round_obj)
+    return AdmissionRoundResponse.model_validate(round_obj)
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.post("/rounds/{round_id}/restore", response_model=AdmissionRoundResponse)
+async def restore_round(
+    request: Request,
+    round_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """Khôi phục đợt đã lưu trữ — inverse của soft_archive."""
+    service = AdmissionRoundService(db)
+    round_obj = await service.restore(round_id, current_admin)
+
+    await activity_service.log_activity(
+        db=db,
+        action="admission_round_restore",
+        resource_type="offering_admission_round",
+        resource_id=round_id,
+        actor_id=current_admin.id,
+        description=f"Round {round_id} restored từ archive",
         ip_address=request.client.host if request.client else None,
         user_agent=request.headers.get("user-agent"),
     )

--- a/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
+++ b/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
@@ -19,7 +19,7 @@ from app.schemas.path_subject_group import (
     PathSubjectGroupItemResponse,
 )
 from app.schemas.admission_path import AdmissionPathQuotaUpdate, AdmissionPathResponse
-from app.schemas.quota_matrix import QuotaMatrixResponse
+from app.schemas.quota_matrix import PathMatrixResponse, QuotaMatrixResponse
 from app.services import activity_service
 from app.services.admission_path_service import AdmissionPathService
 from app.services.path_clone_service import PathCloneService
@@ -194,6 +194,26 @@ async def get_quota_matrix(
     """
     service = QuotaMatrixService(db)
     return await service.get_matrix(academic_year)
+
+
+@router.get(
+    "/academic-infos/{academic_info_id}/path-matrix",
+    response_model=PathMatrixResponse,
+)
+async def get_path_matrix_by_major(
+    request: Request,
+    academic_info_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    _admin: models.User = Depends(require_admin),
+):
+    """Phase 2 v8.2 PR-2D.1 v3 — per-major view (Theo ngành) — daily ops mode.
+
+    Filter 1 ngành (academic_info) → matrix rows = methods, cols = rounds.
+    Cells = exact path identity (NOT aggregate). Empty cells = chưa tạo path.
+    Header context: cap năm, đã rải, còn lại.
+    """
+    service = QuotaMatrixService(db)
+    return await service.get_path_matrix_by_major(academic_info_id)
 
 
 @limiter.limit(RateLimits.ADMIN_WRITE)

--- a/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
+++ b/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
@@ -237,14 +237,21 @@ async def update_path_quota(
         raise ResourceNotFoundError(f"AdmissionPath {admission_path_id} not found")
 
     service = AdmissionPathService(db)
+    # Pass 2 hard-review BM-1: capture old quota TRƯỚC khi service mutate
+    # (cho activity log delta), sau đó update + log + commit cùng 1 txn frame.
+    old_round_quota = path.round_quota
+    old_admit_quota = path.admit_quota
     path = await service.update_quota(
         path=path,
         round_quota=payload.round_quota,
         admit_quota=payload.admit_quota,
         user=current_admin,
     )
-    await db.commit()
 
+    # Pass 2 hard-review BM-1: log_activity TRƯỚC db.commit() để cả 2 atomic.
+    # Trước fix: commit → log_activity → activity log fail = quota persists
+    # mà audit trail mất (silent drift). log_activity gọi db.add() = tham gia
+    # cùng transaction frame; nếu fail trước commit, full rollback.
     await activity_service.log_activity(
         db=db,
         action="admission_path_quota_update",
@@ -255,7 +262,17 @@ async def update_path_quota(
             f"Updated quota path={path.id} "
             f"round_quota={payload.round_quota} admit_quota={payload.admit_quota}"
         ),
+        changes={
+            "old_round_quota": old_round_quota,
+            "new_round_quota": payload.round_quota,
+            "old_admit_quota": old_admit_quota,
+            "new_admit_quota": payload.admit_quota,
+        },
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
     )
+    await db.commit()
+
     from app.repositories.admission_path_repository import AdmissionPathRepository
     path = await AdmissionPathRepository(db).get_by_id_with_relations(path.id)
     return path

--- a/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
+++ b/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
@@ -18,9 +18,15 @@ from app.schemas.path_subject_group import (
     PathSubjectGroupItemCreate,
     PathSubjectGroupItemResponse,
 )
+from app.schemas.admission_path import AdmissionPathQuotaUpdate, AdmissionPathResponse
+from app.schemas.quota_matrix import QuotaMatrixResponse
 from app.services import activity_service
+from app.services.admission_path_service import AdmissionPathService
 from app.services.path_clone_service import PathCloneService
 from app.services.path_subject_group_service import PathSubjectGroupService
+from app.services.quota_matrix_service import QuotaMatrixService
+from app.utils.exceptions import ResourceNotFoundError
+from sqlalchemy import select
 
 
 log = structlog.get_logger(__name__)
@@ -163,6 +169,76 @@ async def add_item(
     item = await service.add_item(config_id, payload)
     await db.commit()
     return item
+
+
+# =============================================================================
+# PR-2D.1 v2 — Quota Matrix overview + per-path quota PATCH
+# =============================================================================
+
+
+@router.get(
+    "/years/{academic_year}/quota-matrix",
+    response_model=QuotaMatrixResponse,
+)
+async def get_quota_matrix(
+    request: Request,
+    academic_year: int,
+    db: AsyncSession = Depends(database.get_db),
+    _admin: models.User = Depends(require_admin),
+):
+    """Phase 2 v8.2 PR-2D.1 v2 — admin tổng quan ALL ngành × ALL đợt năm filter.
+
+    Aggregation: rows = academic_info, cols = rounds, cells = ∑ admit_quota
+    across paths trong cùng (academic_info × round). Constraint visible:
+    ∑ row cells ≤ academic_info.annual_admission_quota.
+    """
+    service = QuotaMatrixService(db)
+    return await service.get_matrix(academic_year)
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.patch(
+    "/admission-paths/{admission_path_id}/quota",
+    response_model=AdmissionPathResponse,
+)
+async def update_path_quota(
+    request: Request,
+    admission_path_id: int,
+    payload: AdmissionPathQuotaUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """Phase 2 v8.2 PR-2D.1 — dedicated quota PATCH cho QuotaMatrix inline edit."""
+    stmt = select(models.AdmissionPath).where(
+        models.AdmissionPath.id == admission_path_id
+    )
+    path = (await db.execute(stmt)).scalar_one_or_none()
+    if path is None:
+        raise ResourceNotFoundError(f"AdmissionPath {admission_path_id} not found")
+
+    service = AdmissionPathService(db)
+    path = await service.update_quota(
+        path=path,
+        round_quota=payload.round_quota,
+        admit_quota=payload.admit_quota,
+        user=current_admin,
+    )
+    await db.commit()
+
+    await activity_service.log_activity(
+        db=db,
+        action="admission_path_quota_update",
+        resource_type="admission_path",
+        resource_id=path.id,
+        actor_id=current_admin.id,
+        description=(
+            f"Updated quota path={path.id} "
+            f"round_quota={payload.round_quota} admit_quota={payload.admit_quota}"
+        ),
+    )
+    from app.repositories.admission_path_repository import AdmissionPathRepository
+    path = await AdmissionPathRepository(db).get_by_id_with_relations(path.id)
+    return path
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -12,7 +12,7 @@ FRONTEND_ARCHITECTURE_V3.md Compliance:
 from datetime import datetime, date
 from decimal import Decimal
 from typing import List, Literal, Optional
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
 from app.core.admission_correction_constants import SAFE_MINOR_CORRECTION_FIELDS
 
@@ -441,6 +441,15 @@ class AdmissionPathResponse(BaseModel):
         default=False,
         description="True nếu lệ phí > 0, FE dùng để hiển thị flow thanh toán"
     )
+
+    # Pass 2 hard-review B-2-7: Pydantic v2 serializes ``Decimal`` thành str
+    # mặc định trong JSON output (preserve precision). FE Zod schema expect
+    # ``z.number().nullable()`` cho ``application_fee`` → parse fail trên path
+    # có lệ phí > 0. Force float emit cho on-the-wire JSON; DB column vẫn
+    # Numeric không mất precision (chỉ JSON layer convert).
+    @field_serializer("application_fee", when_used="json")
+    def _serialize_application_fee(self, v: Optional[Decimal]) -> Optional[float]:
+        return float(v) if v is not None else None
 
     # PR #6 — required in the response so FE Zod parse fails loudly
     # if backend forgot to emit the field, rather than silently

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -281,6 +281,20 @@ class AdmissionPathCreate(BaseModel):
     )(_validate_minor_correction_allowlist)
 
 
+class AdmissionPathQuotaUpdate(BaseModel):
+    """Phase 2 v8.2 PR-2D.1 — dedicated quota PATCH payload cho QuotaMatrix
+    inline edit. Allows admin update round_quota/admit_quota independently
+    với Tier 1+2 chain validation real-time per cell change."""
+    round_quota: Optional[int] = Field(
+        default=None, ge=0,
+        description="Per-path submission cap. NULL = unbounded; explicit None to clear.",
+    )
+    admit_quota: Optional[int] = Field(
+        default=None, ge=0,
+        description="Per-path admit cap. Triggers Tier 1 chain re-validation on change.",
+    )
+
+
 class AdmissionPathUpdate(BaseModel):
     """Request schema for updating an AdmissionPath."""
     display_name: Optional[str] = None

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -408,10 +408,29 @@ class AdmissionPathResponse(BaseModel):
     
     # Core fields
     id: int
+    academic_info_id: int
+    admission_method_id: int
     status: AdmissionPathStatus
     display_name: Optional[str] = None
     display_order: int
     visibility: VisibilityStatus
+
+    # Phase 2 v8.2 PR-2B v2 / PR-2C v2 — round + per-path quota fields.
+    admission_round_id: int = Field(
+        description="Round FK (NOT NULL post PR-2C v2 3-col UNIQUE swap)."
+    )
+    round_quota: Optional[int] = Field(
+        default=None,
+        description="Per-path submission cap. NULL = unbounded.",
+    )
+    admit_quota: Optional[int] = Field(
+        default=None,
+        description="Per-path admit cap. Tier 1 chain root (per academic_info).",
+    )
+    submission_count: int = Field(
+        default=0,
+        description="Atomic submission counter; incremented on profile create.",
+    )
 
     # Application Fee
     application_fee: Optional[Decimal] = Field(

--- a/Backend_FastAPI/app/schemas/quota_matrix.py
+++ b/Backend_FastAPI/app/schemas/quota_matrix.py
@@ -1,0 +1,80 @@
+# app/schemas/quota_matrix.py
+"""Quota matrix overview schema (Phase 2 v8.2 PR-2D.1 v2 — Phase 3 view).
+
+Aggregated read-model cho admin tổng quan rải chỉ tiêu theo (ngành × đợt).
+Granularity: 1 row = 1 academic_info; 1 col = 1 round; cell = sum of
+admit_quota across paths trong cùng (academic_info × round).
+
+Constraint visible: ∑(row cells) ≤ academic_info.annual_admission_quota
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class QuotaMatrixRound(BaseModel):
+    """1 đợt cho năm filter (column header)."""
+    id: int
+    round_code: str
+    round_name: str
+    is_active: bool
+
+
+class QuotaMatrixCell(BaseModel):
+    """Sum aggregated cho (academic_info × round) cell."""
+    admission_round_id: int
+    round_code: str
+    total_admit_quota: int = Field(
+        default=0,
+        description="∑ admit_quota across paths trong cùng (academic_info × round). NULL paths counted as 0.",
+    )
+    total_round_quota: int = Field(
+        default=0,
+        description="∑ round_quota across paths.",
+    )
+    total_submission_count: int = Field(
+        default=0,
+        description="∑ submission_count actual filed.",
+    )
+    path_count: int = Field(
+        default=0,
+        description="Số paths trong cell (để admin biết granularity).",
+    )
+
+
+class QuotaMatrixRow(BaseModel):
+    """1 ngành (academic_info) × N rounds → 1 row matrix."""
+    academic_info_id: int
+    academic_year: int
+    program_name: str = Field(..., description="Tên ngành đào tạo")
+    program_code: Optional[str] = None
+    degree_level: Optional[str] = None
+    annual_admission_quota: Optional[int] = Field(
+        default=None,
+        description="Tổng chỉ tiêu cho năm. NULL = không giới hạn (unbounded).",
+    )
+    cells_by_round_id: dict[int, QuotaMatrixCell] = Field(
+        default_factory=dict,
+        description="Map round_id → cell. Empty cell nếu chưa có path",
+    )
+    sum_admit_allocated: int = Field(
+        default=0,
+        description="∑ tất cả cell.total_admit_quota — đã rải",
+    )
+    sum_remaining: Optional[int] = Field(
+        default=None,
+        description="annual - sum_allocated. NULL nếu annual NULL. Negative = vượt cap (warning)",
+    )
+
+
+class QuotaMatrixResponse(BaseModel):
+    """GET /api/v2/admin/years/{year}/quota-matrix response.
+
+    Admin tổng quan ALL ngành × ALL rounds cho năm filter.
+    """
+    model_config = ConfigDict(from_attributes=True)
+    academic_year: int
+    rounds: List[QuotaMatrixRound]
+    rows: List[QuotaMatrixRow]
+    total_rows: int

--- a/Backend_FastAPI/app/schemas/quota_matrix.py
+++ b/Backend_FastAPI/app/schemas/quota_matrix.py
@@ -78,3 +78,58 @@ class QuotaMatrixResponse(BaseModel):
     rounds: List[QuotaMatrixRound]
     rows: List[QuotaMatrixRow]
     total_rows: int
+
+
+# ============================================================
+# Per-major view: paths × rounds (cells = exact path, NOT aggregate)
+# ============================================================
+
+
+class PathMatrixCell(BaseModel):
+    """1 cell trong per-major matrix = 1 exact AdmissionPath identity.
+
+    Vì filter theo (academic_info_id × method_id × round_id) = UNIQUE 3-col,
+    cell exact 1 path (or empty nếu chưa có).
+    """
+    path_id: int
+    admission_round_id: int
+    admission_method_id: int
+    round_quota: Optional[int]  # submit cap
+    admit_quota: Optional[int]
+    submission_count: int
+    status: str  # active|draft|inactive|archived
+    criteria_code: Optional[str] = None
+
+
+class PathMatrixMethodRow(BaseModel):
+    """1 row trong per-major matrix = 1 admission_method.
+
+    Cells map: round_id → cell (None nếu chưa có path cho cell này).
+    """
+    admission_method_id: int
+    method_code: str
+    method_name: str
+    cells_by_round_id: dict[int, Optional[PathMatrixCell]] = Field(
+        default_factory=dict,
+        description="Map round_id → cell (None = chưa tạo path cho cell này)",
+    )
+    sum_admit_quota: int = 0  # sum across rounds for this method
+
+
+class PathMatrixResponse(BaseModel):
+    """GET /api/v2/admin/academic-infos/{id}/path-matrix response.
+
+    Per-major view: rows = methods, cols = rounds, cells = exact path.
+    Admin chọn 1 ngành → render matrix method × đợt cho ngành đó.
+    """
+    model_config = ConfigDict(from_attributes=True)
+    academic_info_id: int
+    academic_year: int
+    program_name: str
+    program_code: Optional[str] = None
+    degree_level: Optional[str] = None
+    annual_admission_quota: Optional[int] = None
+    sum_admit_allocated: int = 0
+    sum_remaining: Optional[int] = None
+    rounds: List[QuotaMatrixRound]
+    methods: List[PathMatrixMethodRow]

--- a/Backend_FastAPI/app/services/activity_service.py
+++ b/Backend_FastAPI/app/services/activity_service.py
@@ -1,7 +1,7 @@
 # app/services/activity_service.py
 from datetime import date, datetime, timedelta
 from decimal import Decimal
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
 # ✅ PHASE 1: Removed FastAPI Request import (protocol-independent)
@@ -59,12 +59,19 @@ async def log_activity(
     changes: Optional[Dict[str, Any]] = None,
     ip_address: Optional[str] = None,
     user_agent: Optional[str] = None,
-) -> Tuple[models.UserActivityLog, Callable]:
+) -> models.UserActivityLog:
     """
     Create a new activity log entry.
 
     IMPORTANT: This function does NOT commit the transaction.
-    Router must call db.commit() and then execute the returned callback.
+    Router must call db.commit() — activity_log INSERT is part of the same
+    transaction frame, atomic với business mutation.
+
+    PR #251 review fix #2: signature trước đây trả ``Tuple[UserActivityLog,
+    Callable]`` nhưng all 17 callers discard tuple (verified). Post-commit
+    callback là no-op từ đầu. Simplify thành plain ``UserActivityLog`` để
+    contract khớp usage; nếu sau này cần post-commit logic, design riêng
+    qua dispatch pattern (memory ADR-001-remove-finance-events).
 
     Args:
         db: Database session
@@ -79,7 +86,7 @@ async def log_activity(
         user_agent: User agent string
 
     Returns:
-        Tuple of (activity_log, post_commit_callback)
+        The created UserActivityLog (flushed, refreshed; not yet committed).
     """
     activity_log = models.UserActivityLog(
         actor_id=actor_id,
@@ -96,16 +103,11 @@ async def log_activity(
 
     db.add(activity_log)
 
-    # ✅ TRANSACTION FIX: Flush instead of commit
+    # ✅ TRANSACTION FIX: Flush instead of commit — router commits.
     await db.flush()
     await db.refresh(activity_log)
 
-    # ✅ Create post-commit callback
-    async def _post_commit():
-        """Execute after router commits the transaction."""
-        pass  # No post-commit actions needed for activity logs
-
-    return activity_log, _post_commit
+    return activity_log
 
 
 # ✅ PHASE 1: Removed log_activity_from_request() - routers should extract IP/UA

--- a/Backend_FastAPI/app/services/activity_service.py
+++ b/Backend_FastAPI/app/services/activity_service.py
@@ -1,6 +1,8 @@
 # app/services/activity_service.py
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
+from decimal import Decimal
 from typing import Any, Callable, Dict, List, Optional, Tuple
+from uuid import UUID
 
 # ✅ PHASE 1: Removed FastAPI Request import (protocol-independent)
 from sqlalchemy import and_, desc, func, select
@@ -8,6 +10,32 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app import models, schemas
+
+
+def _json_safe(value: Any) -> Any:
+    """Recursive serialize cho JSON column (changes field).
+
+    JSON column raw INSERT raise TypeError với date/Decimal/UUID. Đây là
+    last-mile shim — caller có thể quên set ``mode="json"`` trên Pydantic
+    dump hoặc trộn raw model values vào dict.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):  # AFTER datetime (datetime kế thừa date)
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if hasattr(value, "value"):  # enum
+        return value.value
+    return str(value)
 
 
 async def log_activity(
@@ -50,7 +78,8 @@ async def log_activity(
         resource_type=resource_type,
         resource_id=resource_id,
         description=description,
-        changes=changes,
+        # JSON column safety: serialize date/Decimal/UUID inside dict.
+        changes=_json_safe(changes) if changes is not None else None,
         ip_address=ip_address,
         user_agent=user_agent,
     )

--- a/Backend_FastAPI/app/services/activity_service.py
+++ b/Backend_FastAPI/app/services/activity_service.py
@@ -12,12 +12,20 @@ from sqlalchemy.orm import selectinload
 from app import models, schemas
 
 
-def _json_safe(value: Any) -> Any:
+# Pass 2 hard-review BM-3: depth cap parity với audit_service._serialize_value.
+_MAX_JSON_SAFE_DEPTH = 10
+_DEPTH_SENTINEL = "[truncated: depth_exceeded]"
+
+
+def _json_safe(value: Any, _depth: int = 0) -> Any:
     """Recursive serialize cho JSON column (changes field).
 
     JSON column raw INSERT raise TypeError với date/Decimal/UUID. Đây là
     last-mile shim — caller có thể quên set ``mode="json"`` trên Pydantic
     dump hoặc trộn raw model values vào dict.
+
+    Pass 2 hard-review BM-3: depth cap _MAX_JSON_SAFE_DEPTH chống stack
+    overflow trên adversarial nested JSONB. Trả sentinel marker nếu vượt.
     """
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
@@ -29,10 +37,12 @@ def _json_safe(value: Any) -> Any:
         return float(value)
     if isinstance(value, UUID):
         return str(value)
+    if _depth >= _MAX_JSON_SAFE_DEPTH:
+        return _DEPTH_SENTINEL
     if isinstance(value, (list, tuple)):
-        return [_json_safe(v) for v in value]
+        return [_json_safe(v, _depth + 1) for v in value]
     if isinstance(value, dict):
-        return {k: _json_safe(v) for k, v in value.items()}
+        return {k: _json_safe(v, _depth + 1) for k, v in value.items()}
     if hasattr(value, "value"):  # enum
         return value.value
     return str(value)

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -181,6 +181,25 @@ class AdmissionPathService:
                 resolved_round_id=admission_round_id,
                 auto_resolved=True,
             )
+        else:
+            # Pre-validate explicit round_id exists để tránh IntegrityError
+            # bùng FK constraint mid-INSERT (no response → CORS error ở FE).
+            from app.models.offering_admission_round import (
+                OfferingAdmissionRound,
+            )
+            round_obj = await self.db.get(
+                OfferingAdmissionRound, admission_round_id
+            )
+            if round_obj is None:
+                raise ResourceNotFoundError(
+                    f"OfferingAdmissionRound {admission_round_id} not found"
+                )
+            log.debug(
+                "admission_path_create_explicit_round",
+                academic_info_id=data.academic_info_id,
+                round_id=admission_round_id,
+                auto_resolved=False,
+            )
 
         # Tier 1+2 chain validation — admit_quota Tier 1 chain check
         # if admit_quota provided; Tier 2 invariant check both fields.

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -666,6 +666,25 @@ class AdmissionPathService:
         if path.status not in ["draft", "inactive"]:
             errors.append(f"Cannot activate path with status '{path.status}'")
 
+        # Check 1b (BUG #C4 fix): admission_round phải đang hoạt động + chưa
+        # archive. Path active trên round archived = "active path on offline
+        # round" → confuse storefront. Cross-entity guard tại activation gate.
+        # Fetch via session.get để tránh MissingGreenlet (relationship không
+        # eager-loaded trong AdmissionPathRepository default queries).
+        from app.models.offering_admission_round import OfferingAdmissionRound
+        admission_round = await self.db.get(
+            OfferingAdmissionRound, path.admission_round_id
+        )
+        if admission_round is not None:
+            if admission_round.archived_at is not None:
+                errors.append(
+                    f"Đợt tuyển sinh '{admission_round.round_code}' đã lưu trữ"
+                )
+            elif not admission_round.is_active:
+                errors.append(
+                    f"Đợt tuyển sinh '{admission_round.round_code}' đang tắt (is_active=false)"
+                )
+
         # Check 2: academic_info + quota
         academic_info = path.academic_info
         if not academic_info:

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -194,6 +194,16 @@ class AdmissionPathService:
                 raise ResourceNotFoundError(
                     f"OfferingAdmissionRound {admission_round_id} not found"
                 )
+            # Pass 2 hard-review B-2-1: chặn tạo path trên round đã archive.
+            # Path tạo trên archived round = inert path (không activate được vì
+            # validate_activation cũng chặn) → wasted DB row + admin confusion.
+            # Catch sớm tại create để FE hiển thị error message thân thiện.
+            if round_obj.archived_at is not None:
+                raise BusinessRuleViolation(
+                    f"Đợt tuyển sinh '{round_obj.round_code}' đã lưu trữ "
+                    f"({round_obj.archived_at.date().isoformat()}); "
+                    f"khôi phục đợt trước khi tạo đường tuyển sinh."
+                )
             log.debug(
                 "admission_path_create_explicit_round",
                 academic_info_id=data.academic_info_id,
@@ -746,6 +756,38 @@ class AdmissionPathService:
 
         if not can_activate:
             raise BusinessRuleViolation(f"Cannot activate path: {'; '.join(errors)}")
+
+        # Pass 2 hard-review B-2-3: race window guard. validate_activation
+        # đọc round qua session.get (no lock); concurrent admin có thể
+        # soft_archive round giữa lúc validate xong và lúc UPDATE path
+        # ở dưới. Acquire SELECT FOR UPDATE trên round row để hold lock
+        # đến commit boundary — concurrent soft_archive UPDATE bị block,
+        # serialize 2 thao tác. Nếu lock release thấy round đã archive
+        # → fail-fast ngay đây.
+        from app.models.offering_admission_round import OfferingAdmissionRound
+
+        round_lock_stmt = (
+            select(OfferingAdmissionRound)
+            .where(OfferingAdmissionRound.id == path.admission_round_id)
+            .with_for_update()
+        )
+        round_locked = (
+            await self.db.execute(round_lock_stmt)
+        ).scalar_one_or_none()
+        if round_locked is None:
+            raise BusinessRuleViolation(
+                "Đợt tuyển sinh đã bị xoá; không thể kích hoạt"
+            )
+        if round_locked.archived_at is not None:
+            raise BusinessRuleViolation(
+                f"Đợt tuyển sinh '{round_locked.round_code}' đã lưu trữ "
+                f"trong khi xác thực; khôi phục đợt và thử lại."
+            )
+        if not round_locked.is_active:
+            raise BusinessRuleViolation(
+                f"Đợt tuyển sinh '{round_locked.round_code}' đã tắt "
+                f"trong khi xác thực; bật lại đợt và thử lại."
+            )
 
         # Activate
         path = await self.repo.update(

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -150,19 +150,23 @@ class AdmissionPathService:
         # Phase 2 v8.2 PR-2B v2 — auto-resolve admission_round_id.
         # PR-2C v2 đã ship 3-col UNIQUE (round, acad, method); duplicate check
         # bên dưới dùng 3-col helper tương ứng.
+        # Pass 2 hard-review BM-4: lookup academic_info upfront (cả 2 nhánh
+        # auto-resolve + explicit cần academic_year cho cross-check).
+        from app.models.offering_academic_info import OfferingAcademicInfo
+
+        academic_info = await self.db.get(
+            OfferingAcademicInfo, data.academic_info_id
+        )
+        if academic_info is None:
+            raise ResourceNotFoundError(
+                f"OfferingAcademicInfo {data.academic_info_id} not found"
+            )
+
         admission_round_id = data.admission_round_id
         if admission_round_id is None:
-            from app.models.offering_academic_info import OfferingAcademicInfo
             from app.repositories.admission_round_repository import (
                 AdmissionRoundRepository,
             )
-            academic_info = await self.db.get(
-                OfferingAcademicInfo, data.academic_info_id
-            )
-            if academic_info is None:
-                raise ResourceNotFoundError(
-                    f"OfferingAcademicInfo {data.academic_info_id} not found"
-                )
             round_repo = AdmissionRoundRepository(self.db)
             default_round = await round_repo.get_default_dot1(
                 academic_info.academic_year
@@ -203,6 +207,17 @@ class AdmissionPathService:
                     f"Đợt tuyển sinh '{round_obj.round_code}' đã lưu trữ "
                     f"({round_obj.archived_at.date().isoformat()}); "
                     f"khôi phục đợt trước khi tạo đường tuyển sinh."
+                )
+            # Pass 2 hard-review BM-4: cross-check academic_year giữa round
+            # và academic_info. Round là year-level (Q1 Option A); tạo path
+            # với round năm 2025 trên academic_info năm 2026 = cross-year
+            # configuration sai semantic, reporting "Đợt 1 năm X" sẽ confuse.
+            if round_obj.academic_year != academic_info.academic_year:
+                raise BusinessRuleViolation(
+                    f"Đợt tuyển sinh '{round_obj.round_code}' thuộc năm "
+                    f"{round_obj.academic_year}, không khớp năm "
+                    f"{academic_info.academic_year} của ngành. Chọn đợt "
+                    f"cùng năm với ngành."
                 )
             log.debug(
                 "admission_path_create_explicit_round",

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -148,9 +148,8 @@ class AdmissionPathService:
             BusinessRuleViolation: Tier 1 chain violated, Tier 2 invariant violated, or DOT_1 not found
         """
         # Phase 2 v8.2 PR-2B v2 — auto-resolve admission_round_id.
-        # Note: PR-2C v2 sẽ swap UNIQUE thành 3-col (round, acad, method).
-        # Phase 2 transition: vẫn dùng 2-col duplicate check tại đây
-        # (PR-2C v2 sẽ relax sang 3-col).
+        # PR-2C v2 đã ship 3-col UNIQUE (round, acad, method); duplicate check
+        # bên dưới dùng 3-col helper tương ứng.
         admission_round_id = data.admission_round_id
         if admission_round_id is None:
             from app.models.offering_academic_info import OfferingAcademicInfo
@@ -200,14 +199,18 @@ class AdmissionPathService:
                     delta_admit_quota=data.admit_quota,
                 )
 
-        # Check for duplicate
-        existing = await self.repo.get_path_by_offering_and_method(
-            data.academic_info_id, data.admission_method_id
+        # Phase 2 v8.2 PR-2C v2 — duplicate check theo 3-col UNIQUE
+        # (round, academic_info, method). 1 ngành có thể có nhiều path
+        # cùng method ở các đợt khác nhau (DOT_1 vs DOT_2).
+        existing = await self.repo.get_path_by_round_and_method(
+            admission_round_id=admission_round_id,
+            academic_info_id=data.academic_info_id,
+            admission_method_id=data.admission_method_id,
         )
         if existing:
             raise DuplicateResourceError(
-                f"AdmissionPath already exists for academic_info={data.academic_info_id}, "
-                f"method={data.admission_method_id}"
+                f"AdmissionPath already exists for round={admission_round_id}, "
+                f"academic_info={data.academic_info_id}, method={data.admission_method_id}"
             )
 
         # Governance guard: 4 fields are admin-only on create — the

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -281,6 +281,43 @@ class AdmissionPathService:
 
         return path, _noop_callback
 
+    async def update_quota(
+        self,
+        path: AdmissionPath,
+        round_quota: int | None,
+        admit_quota: int | None,
+        user: User,
+    ) -> AdmissionPath:
+        """Phase 2 v8.2 PR-2D.1 — dedicated quota update với Tier 1+2 chain
+        validation per cell change cho QuotaMatrix UI inline edit."""
+        from app.services.admission_quota_service import AdmissionQuotaService
+
+        _check_lifecycle_guard(path, user)
+        quota_service = AdmissionQuotaService(self.db)
+
+        await quota_service.validate_tier2_path_invariant(
+            admit_quota=admit_quota, round_quota=round_quota,
+        )
+        if admit_quota != path.admit_quota:
+            await quota_service.validate_tier1_chain_on_path_quota_change(
+                academic_info_id=path.academic_info_id,
+                delta_admit_quota=(admit_quota or 0),
+                excluded_path_id=path.id,
+            )
+
+        path.round_quota = round_quota
+        path.admit_quota = admit_quota
+        await self.db.flush()
+
+        log.info(
+            "admission_path_quota_updated",
+            path_id=path.id,
+            round_quota=round_quota,
+            admit_quota=admit_quota,
+            actor_id=user.id,
+        )
+        return path
+
     async def update_path(
         self, path: AdmissionPath, data: AdmissionPathUpdate, user: User
     ) -> Tuple[AdmissionPath, PostCommitCallback]:

--- a/Backend_FastAPI/app/services/admission_quota_service.py
+++ b/Backend_FastAPI/app/services/admission_quota_service.py
@@ -80,13 +80,23 @@ class AdmissionQuotaService:
         new_sum = current_sum + delta_admit_quota
 
         if new_sum > annual_cap:
+            # Pass 2 hard-review BM-5: structured metric_event + overflow
+            # gauge cho observability. Operator có thể grep
+            # ``metric_event=tier1_violation`` để build Prometheus counter
+            # qua promtail/loki, hoặc query Grafana log panel cho rate
+            # chain violations theo academic_info. Excluded_path_id giúp
+            # phân biệt CREATE vs UPDATE flow.
             log.warning(
                 "tier1_chain_violation",
+                metric_event="tier1_violation",
                 academic_info_id=academic_info_id,
                 annual_cap=annual_cap,
                 current_sum=current_sum,
                 delta=delta_admit_quota,
                 new_sum=new_sum,
+                overflow=new_sum - annual_cap,
+                excluded_path_id=excluded_path_id,
+                flow="update" if excluded_path_id is not None else "create",
             )
             raise BusinessRuleViolation(
                 f"Tier 1 chain violated: tổng admit_quota của ngành "
@@ -108,6 +118,15 @@ class AdmissionQuotaService:
         if admit_quota is None or round_quota is None:
             return
         if admit_quota > round_quota:
+            # Pass 2 hard-review BM-5: Tier 2 violation cũng có metric_event
+            # parity với Tier 1 cho dashboard panel chung.
+            log.warning(
+                "tier2_invariant_violation",
+                metric_event="tier2_violation",
+                admit_quota=admit_quota,
+                round_quota=round_quota,
+                overflow=admit_quota - round_quota,
+            )
             raise BusinessRuleViolation(
                 f"Tier 2 invariant violated: admit_quota={admit_quota} > "
                 f"round_quota={round_quota} trên cùng path"

--- a/Backend_FastAPI/app/services/admission_round_service.py
+++ b/Backend_FastAPI/app/services/admission_round_service.py
@@ -43,6 +43,17 @@ class AdmissionRoundService:
         self.db = db
         self.repo = AdmissionRoundRepository(db)
 
+    @staticmethod
+    def _validate_date_window(start, end) -> None:
+        """Cross-field invariant: start_date ≤ end_date nếu cả 2 set.
+
+        Apply chung create/update/extend để tránh drift logic giữa các path.
+        """
+        if start is not None and end is not None and start > end:
+            raise BusinessRuleViolation(
+                f"start_date ({start}) phải ≤ end_date ({end})"
+            )
+
     async def create(
         self, academic_year: int, payload: AdmissionRoundCreate, current_admin: User
     ) -> OfferingAdmissionRound:
@@ -50,7 +61,10 @@ class AdmissionRoundService:
 
         Guards:
         * round_code UNIQUE per academic_year
+        * start_date ≤ end_date nếu cả 2 set (BUG #C2 fix)
         """
+        self._validate_date_window(payload.start_date, payload.end_date)
+
         existing = await self.repo.get_by_year_and_code(academic_year, payload.round_code)
         if existing is not None:
             raise DuplicateResourceError(
@@ -145,16 +159,8 @@ class AdmissionRoundService:
         for field, value in update_data.items():
             setattr(round_obj, field, value)
 
-        # Validate time-window invariant: start_date ≤ end_date.
-        if (
-            round_obj.start_date is not None
-            and round_obj.end_date is not None
-            and round_obj.start_date > round_obj.end_date
-        ):
-            raise BusinessRuleViolation(
-                f"start_date ({round_obj.start_date}) phải ≤ end_date "
-                f"({round_obj.end_date})"
-            )
+        # Validate time-window invariant: start_date ≤ end_date (shared helper).
+        self._validate_date_window(round_obj.start_date, round_obj.end_date)
 
         await self.db.flush()
         log.info(
@@ -235,11 +241,23 @@ class AdmissionRoundService:
         if round_obj is None:
             raise ResourceNotFoundError(f"Round {round_id} not found")
 
+        # BUG #C1 fix: chặn extend khi đã archive — tránh corrupt audit trail
+        # (extended_at + archived_at cùng tồn tại). Admin phải restore trước
+        # nếu thật sự muốn extend.
+        if round_obj.archived_at is not None:
+            raise BusinessRuleViolation(
+                f"Round {round_id} đã lưu trữ ({round_obj.archived_at}); "
+                f"khôi phục trước khi gia hạn"
+            )
+
         if round_obj.end_date is not None and payload.end_date <= round_obj.end_date:
             raise BusinessRuleViolation(
                 f"New end_date ({payload.end_date}) phải sau current end_date "
                 f"({round_obj.end_date})"
             )
+
+        # Validate window after extend nếu start_date đã set.
+        self._validate_date_window(round_obj.start_date, payload.end_date)
 
         round_obj.end_date = payload.end_date
         round_obj.extended_at = datetime.now(timezone.utc)

--- a/Backend_FastAPI/app/services/admission_round_service.py
+++ b/Backend_FastAPI/app/services/admission_round_service.py
@@ -202,11 +202,16 @@ class AdmissionRoundService:
 
     async def restore(
         self, round_id: int, current_admin: User
-    ) -> OfferingAdmissionRound:
+    ) -> tuple[OfferingAdmissionRound, dict]:
         """Khôi phục đợt đã lưu trữ — clear archived_at, set is_active=true.
 
         Inverse của soft_archive. Chỉ admin discretion; đợt đã archive vẫn
         giữ nguyên end_date / extended_at để preserve audit trail.
+
+        Pass 2 hard-review B-2-2: trả tuple ``(round_obj, prior_state)`` để
+        router log_activity ghi delta old → new. Restore-archive-restore loop
+        không mất extension history vì ``extended_at`` / ``extension_reason``
+        được giữ nguyên + capture vào prior_state cho audit reconstruction.
         """
         round_obj = await self.repo.get_by_id(round_id)
         if round_obj is None:
@@ -217,6 +222,17 @@ class AdmissionRoundService:
                 f"Round {round_id} chưa lưu trữ — không cần khôi phục"
             )
 
+        prior_state = {
+            "old_archived_at": round_obj.archived_at.isoformat(),
+            "old_is_active": round_obj.is_active,
+            "old_extended_at": (
+                round_obj.extended_at.isoformat()
+                if round_obj.extended_at is not None
+                else None
+            ),
+            "old_extension_reason": round_obj.extension_reason,
+        }
+
         round_obj.archived_at = None
         round_obj.is_active = True
 
@@ -225,17 +241,23 @@ class AdmissionRoundService:
             "admission_round_restored",
             round_id=round_id,
             admin_id=current_admin.id,
+            **prior_state,
         )
-        return round_obj
+        return round_obj, prior_state
 
     async def extend(
         self, round_id: int, payload: AdmissionRoundExtend, current_admin: User
-    ) -> OfferingAdmissionRound:
+    ) -> tuple[OfferingAdmissionRound, dict]:
         """Admin extend end_date per SPEC §2.1.a Rule 2.
 
         Audit fields ``extended_at``, ``extended_by_user_id``,
         ``extension_reason`` written atomically. Reason ≥10 chars enforced
         at schema layer.
+
+        Pass 2 hard-review B-2-2: trả tuple ``(round_obj, prior_state)`` —
+        capture ``old_end_date`` + ``old_extended_at`` để router log delta.
+        Pre-extend value cần thiết cho audit reconstruction nếu admin
+        extend nhiều lần liên tiếp.
         """
         round_obj = await self.repo.get_by_id(round_id)
         if round_obj is None:
@@ -259,6 +281,20 @@ class AdmissionRoundService:
         # Validate window after extend nếu start_date đã set.
         self._validate_date_window(round_obj.start_date, payload.end_date)
 
+        prior_state = {
+            "old_end_date": (
+                round_obj.end_date.isoformat()
+                if round_obj.end_date is not None
+                else None
+            ),
+            "old_extended_at": (
+                round_obj.extended_at.isoformat()
+                if round_obj.extended_at is not None
+                else None
+            ),
+            "old_extension_reason": round_obj.extension_reason,
+        }
+
         round_obj.end_date = payload.end_date
         round_obj.extended_at = datetime.now(timezone.utc)
         round_obj.extended_by_user_id = current_admin.id
@@ -271,8 +307,9 @@ class AdmissionRoundService:
             new_end_date=payload.end_date.isoformat(),
             admin_id=current_admin.id,
             reason_len=len(payload.extension_reason),
+            **prior_state,
         )
-        return round_obj
+        return round_obj, prior_state
 
     async def list_by_year(
         self, academic_year: int

--- a/Backend_FastAPI/app/services/admission_round_service.py
+++ b/Backend_FastAPI/app/services/admission_round_service.py
@@ -145,6 +145,17 @@ class AdmissionRoundService:
         for field, value in update_data.items():
             setattr(round_obj, field, value)
 
+        # Validate time-window invariant: start_date ≤ end_date.
+        if (
+            round_obj.start_date is not None
+            and round_obj.end_date is not None
+            and round_obj.start_date > round_obj.end_date
+        ):
+            raise BusinessRuleViolation(
+                f"start_date ({round_obj.start_date}) phải ≤ end_date "
+                f"({round_obj.end_date})"
+            )
+
         await self.db.flush()
         log.info(
             "admission_round_updated",
@@ -178,6 +189,34 @@ class AdmissionRoundService:
         await self.db.flush()
         log.info(
             "admission_round_soft_archived",
+            round_id=round_id,
+            admin_id=current_admin.id,
+        )
+        return round_obj
+
+    async def restore(
+        self, round_id: int, current_admin: User
+    ) -> OfferingAdmissionRound:
+        """Khôi phục đợt đã lưu trữ — clear archived_at, set is_active=true.
+
+        Inverse của soft_archive. Chỉ admin discretion; đợt đã archive vẫn
+        giữ nguyên end_date / extended_at để preserve audit trail.
+        """
+        round_obj = await self.repo.get_by_id(round_id)
+        if round_obj is None:
+            raise ResourceNotFoundError(f"Round {round_id} not found")
+
+        if round_obj.archived_at is None:
+            raise BusinessRuleViolation(
+                f"Round {round_id} chưa lưu trữ — không cần khôi phục"
+            )
+
+        round_obj.archived_at = None
+        round_obj.is_active = True
+
+        await self.db.flush()
+        log.info(
+            "admission_round_restored",
             round_id=round_id,
             admin_id=current_admin.id,
         )

--- a/Backend_FastAPI/app/services/audit_service.py
+++ b/Backend_FastAPI/app/services/audit_service.py
@@ -42,7 +42,9 @@ Usage Examples:
         await audit_service.log_changes(db, "AdmissionProfile", profile.id, "updated", changes=changes, ...)
 """
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from uuid import UUID
 from typing import Any, Dict, List, Optional, Union
 
 import structlog
@@ -105,7 +107,8 @@ async def log_audit(
         field_name=field_name,
         old_value=_serialize_value(old_value),
         new_value=_serialize_value(new_value),
-        changes=changes,
+        # Recursive serialize để JSON column nhận date/Decimal/UUID inside dict.
+        changes=_serialize_value(changes) if changes is not None else None,
         reason=reason,
         source=source,
         ip_address=ip_address,
@@ -441,13 +444,24 @@ def _to_dict(obj: Any) -> Dict[str, Any]:
 
 
 def _serialize_value(value: Any) -> Any:
-    """Serialize a value for JSON storage."""
+    """Serialize a value for JSON storage.
+
+    Handles datetime, date, Decimal, UUID, enum, list/dict recursively.
+    JSON column raw INSERT raise TypeError với date/Decimal nếu skip.
+    """
     if value is None:
         return None
     if isinstance(value, (str, int, float, bool)):
         return value
     if isinstance(value, datetime):
         return value.isoformat()
+    # `date` MUST come AFTER `datetime` vì datetime là subclass của date.
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, UUID):
+        return str(value)
     if isinstance(value, (list, tuple)):
         return [_serialize_value(v) for v in value]
     if isinstance(value, dict):

--- a/Backend_FastAPI/app/services/audit_service.py
+++ b/Backend_FastAPI/app/services/audit_service.py
@@ -443,10 +443,20 @@ def _to_dict(obj: Any) -> Dict[str, Any]:
     return {}
 
 
-def _serialize_value(value: Any) -> Any:
+# Pass 2 hard-review BM-3: max recursion depth cho _serialize_value để
+# tránh stack overflow trên malformed JSONB payload (circular ref hoặc
+# deeply nested adversarial input). 10 levels đủ cho audit changes thực
+# tế (typical: 2-3 levels: changes → field → list); sentinel "[truncated:
+# depth_exceeded]" giúp admin debug nếu hit limit.
+_MAX_SERIALIZE_DEPTH = 10
+_DEPTH_SENTINEL = "[truncated: depth_exceeded]"
+
+
+def _serialize_value(value: Any, _depth: int = 0) -> Any:
     """Serialize a value for JSON storage.
 
-    Handles datetime, date, Decimal, UUID, enum, list/dict recursively.
+    Handles datetime, date, Decimal, UUID, enum, list/dict recursively
+    (with depth cap _MAX_SERIALIZE_DEPTH cho BM-3 stack safety).
     JSON column raw INSERT raise TypeError với date/Decimal nếu skip.
     """
     if value is None:
@@ -462,10 +472,14 @@ def _serialize_value(value: Any) -> Any:
         return float(value)
     if isinstance(value, UUID):
         return str(value)
+    if _depth >= _MAX_SERIALIZE_DEPTH:
+        # Truncate sentinel instead of recursing further. Audit log
+        # vẫn ghi được, admin debug bằng sentinel marker.
+        return _DEPTH_SENTINEL
     if isinstance(value, (list, tuple)):
-        return [_serialize_value(v) for v in value]
+        return [_serialize_value(v, _depth + 1) for v in value]
     if isinstance(value, dict):
-        return {k: _serialize_value(v) for k, v in value.items()}
+        return {k: _serialize_value(v, _depth + 1) for k, v in value.items()}
     # For enums and other types
     if hasattr(value, "value"):
         return value.value

--- a/Backend_FastAPI/app/services/path_clone_service.py
+++ b/Backend_FastAPI/app/services/path_clone_service.py
@@ -109,7 +109,25 @@ class PathCloneService:
         cloned_items: List[ClonePathsResponseItem] = []
         skipped = 0
 
+        # Pre-fetch tất cả existing (acad_info, method) trong target round —
+        # dùng làm lookup table cho ON CONFLICT skip mà KHÔNG cần catch
+        # IntegrityError (catch sẽ phá session state khi nested savepoint
+        # tương tác với expired attributes của remaining src_path instances).
+        existing_stmt = select(
+            AdmissionPath.academic_info_id,
+            AdmissionPath.admission_method_id,
+        ).where(AdmissionPath.admission_round_id == target_round_id)
+        existing_keys = {
+            (row.academic_info_id, row.admission_method_id)
+            for row in (await self.db.execute(existing_stmt)).all()
+        }
+
         for src_path in source_paths:
+            # Pre-check: skip nếu (acad, method) đã tồn tại trong target round
+            # — match logic ON CONFLICT 3-col UNIQUE.
+            if (src_path.academic_info_id, src_path.admission_method_id) in existing_keys:
+                skipped += 1
+                continue
             # Step 1: clone criteria nếu source có (ADM-003: 1:1 path-criteria)
             new_criteria_id: Optional[int] = None
             new_criteria_code: str = ""
@@ -190,16 +208,12 @@ class PathCloneService:
                 submission_count=0,
             )
             self.db.add(cloned_path)
-            try:
-                await self.db.flush()
-            except IntegrityError:
-                # ON CONFLICT 3-col UNIQUE skip — path already exists trong target round
-                await self.db.rollback()
-                skipped += 1
-                # Note: rollback nukes prior INSERTs trong this iteration too.
-                # Re-attach session for next iteration via fresh transaction.
-                # NOTE: caller wraps trong begin() — partial commit semantic.
-                continue
+            await self.db.flush()
+            # Track key as inserted để pre-check defend chống multiple
+            # source paths cùng (acad, method) trong source_round (edge case).
+            existing_keys.add(
+                (cloned_path.academic_info_id, cloned_path.admission_method_id)
+            )
 
             # Step 4: clone PathSubjectGroupConfig + items
             psgc_stmt = (

--- a/Backend_FastAPI/app/services/quota_matrix_service.py
+++ b/Backend_FastAPI/app/services/quota_matrix_service.py
@@ -1,0 +1,144 @@
+# app/services/quota_matrix_service.py
+"""Quota matrix overview service (Phase 2 v8.2 PR-2D.1 v2).
+
+Aggregation logic cho GET /api/v2/admin/years/{year}/quota-matrix endpoint.
+Returns matrix với rows = academic_info × academic_year, cols = rounds,
+cells = aggregated quota.
+"""
+
+from typing import List
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models import (
+    OfferingAcademicInfo,
+    OfferingAdmissionRound,
+    ProgramOffering,
+)
+from app.models.admission_config import AdmissionPath
+from app.models.major_program import MajorProgram
+from app.schemas.quota_matrix import (
+    QuotaMatrixCell,
+    QuotaMatrixResponse,
+    QuotaMatrixRound,
+    QuotaMatrixRow,
+)
+
+
+class QuotaMatrixService:
+    """Aggregation service cho quota matrix admin view."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_matrix(self, academic_year: int) -> QuotaMatrixResponse:
+        """Build matrix: rows = academic_info, cols = rounds, cells = sum quota.
+
+        Filter:
+        - academic_info.academic_year = year
+        - academic_info.is_deleted = false
+        - round.academic_year = year
+        - path.status != 'archived'
+        """
+        # 1. Rounds for the year (sorted by round_code asc cho stable column order)
+        rounds_stmt = (
+            select(OfferingAdmissionRound)
+            .where(OfferingAdmissionRound.academic_year == academic_year)
+            .order_by(OfferingAdmissionRound.round_code)
+        )
+        rounds = list((await self.db.execute(rounds_stmt)).scalars().all())
+
+        # 2. Academic infos for the year với eager-load offering → program
+        ai_stmt = (
+            select(OfferingAcademicInfo)
+            .where(
+                OfferingAcademicInfo.academic_year == academic_year,
+                OfferingAcademicInfo.is_deleted.is_(False),
+            )
+            .options(
+                selectinload(OfferingAcademicInfo.offering)
+                .selectinload(ProgramOffering.program)
+            )
+            .order_by(OfferingAcademicInfo.id)
+        )
+        academic_infos = list((await self.db.execute(ai_stmt)).scalars().all())
+
+        # 3. All paths for these academic_infos (excluding archived)
+        ai_ids = [ai.id for ai in academic_infos]
+        paths: List[AdmissionPath] = []
+        if ai_ids:
+            paths_stmt = select(AdmissionPath).where(
+                AdmissionPath.academic_info_id.in_(ai_ids),
+                AdmissionPath.status != "archived",
+            )
+            paths = list((await self.db.execute(paths_stmt)).scalars().all())
+
+        # 4. Aggregate paths into cells map: (ai_id, round_id) → cell
+        cell_map: dict[tuple[int, int], QuotaMatrixCell] = {}
+        for path in paths:
+            if path.admission_round_id is None:
+                continue  # defensive; PR-2C v2 swap NOT NULL nhưng safe
+            key = (path.academic_info_id, path.admission_round_id)
+            cell = cell_map.get(key)
+            if cell is None:
+                round_obj = next(
+                    (r for r in rounds if r.id == path.admission_round_id), None
+                )
+                if round_obj is None:
+                    # Path's round is from different year; skip
+                    continue
+                cell = QuotaMatrixCell(
+                    admission_round_id=path.admission_round_id,
+                    round_code=round_obj.round_code,
+                )
+                cell_map[key] = cell
+            cell.total_admit_quota += int(path.admit_quota or 0)
+            cell.total_round_quota += int(path.round_quota or 0)
+            cell.total_submission_count += int(path.submission_count or 0)
+            cell.path_count += 1
+
+        # 5. Build rows
+        rows: List[QuotaMatrixRow] = []
+        for ai in academic_infos:
+            offering = ai.offering
+            program = offering.program if offering else None
+            cells_by_round_id: dict[int, QuotaMatrixCell] = {}
+            for r in rounds:
+                cell = cell_map.get((ai.id, r.id))
+                if cell is not None:
+                    cells_by_round_id[r.id] = cell
+            sum_allocated = sum(c.total_admit_quota for c in cells_by_round_id.values())
+            remaining: int | None = None
+            if ai.annual_admission_quota is not None:
+                remaining = ai.annual_admission_quota - sum_allocated
+
+            rows.append(
+                QuotaMatrixRow(
+                    academic_info_id=ai.id,
+                    academic_year=ai.academic_year,
+                    program_name=program.name if program else "(không tên)",
+                    program_code=program.code if program else None,
+                    degree_level=program.degree_level if program else None,
+                    annual_admission_quota=ai.annual_admission_quota,
+                    cells_by_round_id=cells_by_round_id,
+                    sum_admit_allocated=sum_allocated,
+                    sum_remaining=remaining,
+                )
+            )
+
+        return QuotaMatrixResponse(
+            academic_year=academic_year,
+            rounds=[
+                QuotaMatrixRound(
+                    id=r.id,
+                    round_code=r.round_code,
+                    round_name=r.round_name,
+                    is_active=r.is_active,
+                )
+                for r in rounds
+            ],
+            rows=rows,
+            total_rows=len(rows),
+        )

--- a/Backend_FastAPI/app/services/quota_matrix_service.py
+++ b/Backend_FastAPI/app/services/quota_matrix_service.py
@@ -19,7 +19,11 @@ from app.models import (
 )
 from app.models.admission_config import AdmissionPath
 from app.models.major_program import MajorProgram
+from app.models.admission_config.method import AdmissionMethod
 from app.schemas.quota_matrix import (
+    PathMatrixCell,
+    PathMatrixMethodRow,
+    PathMatrixResponse,
     QuotaMatrixCell,
     QuotaMatrixResponse,
     QuotaMatrixRound,
@@ -141,4 +145,122 @@ class QuotaMatrixService:
             ],
             rows=rows,
             total_rows=len(rows),
+        )
+
+    async def get_path_matrix_by_major(
+        self, academic_info_id: int
+    ) -> PathMatrixResponse:
+        """Per-major view: rows = methods, cols = rounds, cells = exact path.
+
+        Filter:
+        - academic_info.id = id (single ngành × năm × hệ ĐT)
+        - rounds.academic_year = academic_info.academic_year
+        - paths.academic_info_id = id, status != 'archived'
+        - methods: ALL active methods (so admin có cells trống render '+ Tạo path')
+        """
+        ai_stmt = (
+            select(OfferingAcademicInfo)
+            .where(OfferingAcademicInfo.id == academic_info_id)
+            .options(
+                selectinload(OfferingAcademicInfo.offering)
+                .selectinload(ProgramOffering.program)
+            )
+        )
+        ai = (await self.db.execute(ai_stmt)).scalar_one_or_none()
+        if ai is None:
+            from app.utils.exceptions import ResourceNotFoundError
+            raise ResourceNotFoundError(
+                f"OfferingAcademicInfo {academic_info_id} not found"
+            )
+
+        # Rounds for the year
+        rounds_stmt = (
+            select(OfferingAdmissionRound)
+            .where(OfferingAdmissionRound.academic_year == ai.academic_year)
+            .order_by(OfferingAdmissionRound.round_code)
+        )
+        rounds = list((await self.db.execute(rounds_stmt)).scalars().all())
+
+        # All active methods
+        methods_stmt = (
+            select(AdmissionMethod)
+            .where(AdmissionMethod.is_active.is_(True))
+            .order_by(AdmissionMethod.display_order, AdmissionMethod.id)
+        )
+        methods = list((await self.db.execute(methods_stmt)).scalars().all())
+
+        # Paths for this academic_info (excluding archived)
+        paths_stmt = (
+            select(AdmissionPath)
+            .where(
+                AdmissionPath.academic_info_id == academic_info_id,
+                AdmissionPath.status != "archived",
+            )
+            .options(selectinload(AdmissionPath.criteria))
+        )
+        paths = list((await self.db.execute(paths_stmt)).scalars().all())
+
+        # Build cells map: (method_id, round_id) → path
+        path_map: dict[tuple[int, int], AdmissionPath] = {}
+        for p in paths:
+            if p.admission_round_id is None:
+                continue
+            path_map[(p.admission_method_id, p.admission_round_id)] = p
+
+        # Build method rows
+        method_rows: List[PathMatrixMethodRow] = []
+        for m in methods:
+            cells: dict[int, PathMatrixCell | None] = {}
+            sum_admit = 0
+            for r in rounds:
+                p = path_map.get((m.id, r.id))
+                if p is None:
+                    cells[r.id] = None
+                else:
+                    cells[r.id] = PathMatrixCell(
+                        path_id=p.id,
+                        admission_round_id=p.admission_round_id,
+                        admission_method_id=p.admission_method_id,
+                        round_quota=p.round_quota,
+                        admit_quota=p.admit_quota,
+                        submission_count=int(p.submission_count or 0),
+                        status=p.status,
+                        criteria_code=p.criteria.code if p.criteria else None,
+                    )
+                    sum_admit += int(p.admit_quota or 0)
+            method_rows.append(
+                PathMatrixMethodRow(
+                    admission_method_id=m.id,
+                    method_code=m.code,
+                    method_name=m.name,
+                    cells_by_round_id=cells,
+                    sum_admit_quota=sum_admit,
+                )
+            )
+
+        # Aggregate header
+        offering = ai.offering
+        program = offering.program if offering else None
+        sum_allocated = sum(mr.sum_admit_quota for mr in method_rows)
+        remaining: int | None = None
+        if ai.annual_admission_quota is not None:
+            remaining = ai.annual_admission_quota - sum_allocated
+
+        return PathMatrixResponse(
+            academic_info_id=ai.id,
+            academic_year=ai.academic_year,
+            program_name=program.name if program else "(không tên)",
+            program_code=program.code if program else None,
+            degree_level=program.degree_level if program else None,
+            annual_admission_quota=ai.annual_admission_quota,
+            sum_admit_allocated=sum_allocated,
+            sum_remaining=remaining,
+            rounds=[
+                QuotaMatrixRound(
+                    id=r.id, round_code=r.round_code,
+                    round_name=r.round_name, is_active=r.is_active,
+                )
+                for r in rounds
+            ],
+            methods=method_rows,
         )

--- a/Backend_FastAPI/tests/services/test_activity_service.py
+++ b/Backend_FastAPI/tests/services/test_activity_service.py
@@ -25,25 +25,23 @@ class TestLogActivity:
         return db
 
     @pytest.mark.asyncio
-    async def test_log_activity_returns_tuple(self, mock_db):
-        """Test that log_activity returns (log, callback) tuple."""
+    async def test_log_activity_returns_user_activity_log(self, mock_db):
+        """PR #251 review fix #2: log_activity trả plain UserActivityLog
+        (trước đây tuple với no-op callback; tất cả callers đều discard
+        tuple → simplify contract).
+        """
         result = await activity_service.log_activity(
             db=mock_db,
             action="test_action",
             resource_type="test",
         )
-        
-        assert isinstance(result, tuple)
-        assert len(result) == 2
-        # First element should be UserActivityLog
-        assert isinstance(result[0], models.UserActivityLog)
-        # Second element should be callable
-        assert callable(result[1])
+
+        assert isinstance(result, models.UserActivityLog)
 
     @pytest.mark.asyncio
     async def test_log_activity_creates_log_with_correct_data(self, mock_db):
         """Test that log_activity creates log with all provided data."""
-        log, callback = await activity_service.log_activity(
+        log = await activity_service.log_activity(
             db=mock_db,
             action="login",
             resource_type="user",
@@ -54,7 +52,7 @@ class TestLogActivity:
             ip_address="192.168.1.1",
             user_agent="Mozilla/5.0",
         )
-        
+
         assert log.action == "login"
         assert log.resource_type == "user"
         assert log.actor_id == 123
@@ -72,22 +70,10 @@ class TestLogActivity:
             action="test",
             resource_type="test",
         )
-        
+
         mock_db.add.assert_called_once()
         mock_db.flush.assert_awaited_once()
         mock_db.refresh.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_log_activity_callback_is_async(self, mock_db):
-        """Test that the callback is awaitable."""
-        log, callback = await activity_service.log_activity(
-            db=mock_db,
-            action="test",
-            resource_type="test",
-        )
-        
-        # Should not raise
-        await callback()
 
 
 class TestGetActivityLogs:

--- a/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
+++ b/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
@@ -19,6 +19,10 @@ from app import models
 from app.database import AsyncSessionLocal
 from app.schemas.admission_path import AdmissionPathCreate
 from app.services.admission_path_service import AdmissionPathService
+from app.utils.exceptions import (
+    DuplicateResourceError,
+    ResourceNotFoundError,
+)
 from app.services.public_admissions_service import _load_public_paths
 from app.utils.exceptions import BusinessRuleViolation
 
@@ -535,3 +539,119 @@ async def test_atomic_submit_blocks_when_round_quota_exhausted(
     # before quota). For ANCHOR atomic semantics, SQL test above sufficient.
     _ = profile_id  # used by full integration if validation seed expanded
     _ = path_seed
+
+
+# ---------------------------------------------------------------------------
+# BUG #1 fix — 3-col duplicate check (PR-2D.1 v4a+)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_path_allows_same_method_in_different_round(path_seed: dict):
+    """ANCHOR (BUG #1): same (acad, method) cho phép tạo path ở round khác.
+
+    Phase 2 v8.2 PR-2C v2 schema dùng 3-col UNIQUE (round, acad, method).
+    Trước fix: service vẫn check 2-col → block tạo path đợt thứ 2 → vô hiệu hoá
+    multi-round capability. Sau fix: 3-col check, allow duplicate (acad, method)
+    nếu round khác.
+    """
+    # Tạo round thứ 2 (DOT_2) cùng năm
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            r2 = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code="DOT_2",
+                round_name="Đợt 2 - 2026",
+                is_active=True,
+            )
+            s.add(r2)
+            await s.flush()
+            r2_id = r2.id
+
+    # Tạo path 1 ở DOT_1
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, path_seed["admin_id"])
+        svc = AdmissionPathService(s)
+        path1, _ = await svc.create_path(
+            AdmissionPathCreate(
+                academic_info_id=path_seed["academic_info_id"],
+                admission_method_id=path_seed["method_id"],
+                admission_round_id=path_seed["round_id"],
+            ),
+            admin,
+        )
+        await s.commit()
+
+    # Tạo path 2 cùng (acad, method) nhưng ở DOT_2 — phải pass
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, path_seed["admin_id"])
+        svc = AdmissionPathService(s)
+        path2, _ = await svc.create_path(
+            AdmissionPathCreate(
+                academic_info_id=path_seed["academic_info_id"],
+                admission_method_id=path_seed["method_id"],
+                admission_round_id=r2_id,
+            ),
+            admin,
+        )
+        await s.commit()
+
+        assert path2.id != path1.id
+        assert path2.admission_round_id == r2_id
+
+
+@pytest.mark.asyncio
+async def test_create_path_rejects_duplicate_3col(path_seed: dict):
+    """ANCHOR (BUG #1): same (round, acad, method) → 409 DuplicateResourceError."""
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, path_seed["admin_id"])
+        svc = AdmissionPathService(s)
+        await svc.create_path(
+            AdmissionPathCreate(
+                academic_info_id=path_seed["academic_info_id"],
+                admission_method_id=path_seed["method_id"],
+                admission_round_id=path_seed["round_id"],
+            ),
+            admin,
+        )
+        await s.commit()
+
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, path_seed["admin_id"])
+        svc = AdmissionPathService(s)
+        with pytest.raises(DuplicateResourceError, match="already exists"):
+            await svc.create_path(
+                AdmissionPathCreate(
+                    academic_info_id=path_seed["academic_info_id"],
+                    admission_method_id=path_seed["method_id"],
+                    admission_round_id=path_seed["round_id"],
+                ),
+                admin,
+            )
+
+
+# ---------------------------------------------------------------------------
+# BUG #6 fix — pre-validate explicit admission_round_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_path_rejects_invalid_round_id(path_seed: dict):
+    """ANCHOR (BUG #6): invalid admission_round_id raise ResourceNotFoundError
+    sớm thay vì SQLAlchemy IntegrityError mid-INSERT.
+
+    Trước fix: FK violation mid-INSERT → response 500 không có CORS header
+    → FE thấy 'Network Error'. Sau fix: pre-validate exists → 404.
+    """
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, path_seed["admin_id"])
+        svc = AdmissionPathService(s)
+        with pytest.raises(ResourceNotFoundError, match="OfferingAdmissionRound"):
+            await svc.create_path(
+                AdmissionPathCreate(
+                    academic_info_id=path_seed["academic_info_id"],
+                    admission_method_id=path_seed["method_id"],
+                    admission_round_id=999_999,  # not exists
+                ),
+                admin,
+            )

--- a/Backend_FastAPI/tests/services/test_phase2_admission_round_service.py
+++ b/Backend_FastAPI/tests/services/test_phase2_admission_round_service.py
@@ -287,7 +287,8 @@ async def test_round_extend_writes_extended_at_user_id_reason(
     async with AsyncSessionLocal() as db:
         admin = await _get_admin(db, round_test_seed["admin_user_id"])
         service = AdmissionRoundService(db)
-        extended = await service.extend(
+        # Pass 2 hard-review B-2-2: service.extend trả tuple cho audit log delta.
+        extended, prior_state = await service.extend(
             round_id,
             AdmissionRoundExtend(
                 end_date=date(2026, 9, 30),
@@ -301,6 +302,10 @@ async def test_round_extend_writes_extended_at_user_id_reason(
         assert extended.extended_at is not None
         assert extended.extended_by_user_id == round_test_seed["admin_user_id"]
         assert "COVID" in extended.extension_reason
+        # Prior state captured cho audit reconstruction.
+        assert prior_state["old_end_date"] == "2026-06-30"
+        assert prior_state["old_extended_at"] is None  # first extend
+        assert prior_state["old_extension_reason"] is None
 
 
 @pytest.mark.asyncio
@@ -484,11 +489,15 @@ async def test_round_restore_clears_archived_at_and_sets_active(
     async with AsyncSessionLocal() as db:
         admin = await _get_admin(db, round_test_seed["admin_user_id"])
         service = AdmissionRoundService(db)
-        restored = await service.restore(round_id, admin)
+        # Pass 2 hard-review B-2-2: service.restore trả tuple cho audit log delta.
+        restored, prior_state = await service.restore(round_id, admin)
         await db.commit()
 
         assert restored.archived_at is None
         assert restored.is_active is True
+        # Prior state captured: archived_at non-null pre-restore.
+        assert prior_state["old_archived_at"] is not None
+        assert prior_state["old_is_active"] is False
 
 
 @pytest.mark.asyncio

--- a/Backend_FastAPI/tests/services/test_phase2_admission_round_service.py
+++ b/Backend_FastAPI/tests/services/test_phase2_admission_round_service.py
@@ -457,3 +457,133 @@ async def test_round_update_time_window_only(round_test_seed: dict) -> None:
         assert updated.round_name == "Đợt 1 (đã sửa)"
         assert updated.start_date == date(2026, 3, 1)
         assert updated.end_date == date(2026, 6, 30)
+
+
+# ---------------------------------------------------------------------------
+# Restore (un-archive) — PR-2D.1 v4a+ NEW
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_restore_clears_archived_at_and_sets_active(
+    round_test_seed: dict,
+) -> None:
+    """ANCHOR: restore inverse của soft_archive — archived_at=None, is_active=True."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_obj = await service.create(
+            2026,
+            AdmissionRoundCreate(round_code="DOT_1", round_name="Đợt 1"),
+            admin,
+        )
+        await service.soft_archive(round_obj.id, admin)
+        await db.commit()
+        round_id = round_obj.id
+
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        restored = await service.restore(round_id, admin)
+        await db.commit()
+
+        assert restored.archived_at is None
+        assert restored.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_round_restore_idempotent_guard_when_not_archived(
+    round_test_seed: dict,
+) -> None:
+    """ANCHOR: restore raise BusinessRuleViolation khi round chưa archive."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_obj = await service.create(
+            2026,
+            AdmissionRoundCreate(round_code="DOT_1", round_name="Đợt 1"),
+            admin,
+        )
+        await db.commit()
+        round_id = round_obj.id
+
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        with pytest.raises(BusinessRuleViolation, match="chưa lưu trữ"):
+            await service.restore(round_id, admin)
+
+
+# ---------------------------------------------------------------------------
+# Update invariant: start_date ≤ end_date — PR-2D.1 v4a+ BUG #5 fix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_update_rejects_end_before_start(round_test_seed: dict) -> None:
+    """ANCHOR (BUG #5): PATCH với end_date < start_date raise 400.
+
+    Trước fix: server lưu invalid time-window. Sau fix: validate post-merge.
+    """
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_obj = await service.create(
+            2026,
+            AdmissionRoundCreate(
+                round_code="DOT_1",
+                round_name="Đợt 1",
+                start_date=date(2026, 1, 1),
+                end_date=date(2026, 3, 31),
+            ),
+            admin,
+        )
+        await db.commit()
+        round_id = round_obj.id
+
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        with pytest.raises(BusinessRuleViolation, match="phải ≤ end_date"):
+            await service.update(
+                round_id,
+                AdmissionRoundUpdate(
+                    start_date=date(2026, 6, 1),
+                    end_date=date(2026, 1, 1),
+                ),
+                admin,
+            )
+
+
+@pytest.mark.asyncio
+async def test_round_update_partial_start_against_existing_end(
+    round_test_seed: dict,
+) -> None:
+    """ANCHOR (BUG #5 partial): PATCH chỉ start_date phải validate against
+    end_date đang có trong DB (cross-field invariant)."""
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_obj = await service.create(
+            2026,
+            AdmissionRoundCreate(
+                round_code="DOT_1",
+                round_name="Đợt 1",
+                start_date=date(2026, 1, 1),
+                end_date=date(2026, 3, 31),
+            ),
+            admin,
+        )
+        await db.commit()
+        round_id = round_obj.id
+
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        # PATCH chỉ start_date sang sau end_date hiện tại → violation
+        with pytest.raises(BusinessRuleViolation, match="phải ≤ end_date"):
+            await service.update(
+                round_id,
+                AdmissionRoundUpdate(start_date=date(2026, 12, 31)),
+                admin,
+            )

--- a/Backend_FastAPI/tests/services/test_phase2_admission_round_service.py
+++ b/Backend_FastAPI/tests/services/test_phase2_admission_round_service.py
@@ -556,6 +556,67 @@ async def test_round_update_rejects_end_before_start(round_test_seed: dict) -> N
 
 
 @pytest.mark.asyncio
+async def test_round_create_rejects_end_before_start(round_test_seed: dict) -> None:
+    """ANCHOR (BUG #C2): create round với end_date < start_date raise 400.
+
+    Trước fix: chỉ update() validate, create() bỏ qua → admin tạo round
+    với window invalid.
+    """
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        with pytest.raises(BusinessRuleViolation, match="phải ≤ end_date"):
+            await service.create(
+                2026,
+                AdmissionRoundCreate(
+                    round_code="DOT_X",
+                    round_name="Đợt invalid",
+                    start_date=date(2026, 6, 1),
+                    end_date=date(2026, 1, 1),
+                ),
+                admin,
+            )
+
+
+@pytest.mark.asyncio
+async def test_round_extend_blocks_archived(round_test_seed: dict) -> None:
+    """ANCHOR (BUG #C1): extend round đã archive raise 400.
+
+    Trước fix: extended_at + archived_at cùng tồn tại → audit trail ambiguous.
+    Sau fix: phải restore trước khi extend.
+    """
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        round_obj = await service.create(
+            2026,
+            AdmissionRoundCreate(
+                round_code="DOT_1",
+                round_name="Đợt 1",
+                start_date=date(2026, 1, 1),
+                end_date=date(2026, 3, 31),
+            ),
+            admin,
+        )
+        await service.soft_archive(round_obj.id, admin)
+        await db.commit()
+        round_id = round_obj.id
+
+    async with AsyncSessionLocal() as db:
+        admin = await _get_admin(db, round_test_seed["admin_user_id"])
+        service = AdmissionRoundService(db)
+        with pytest.raises(BusinessRuleViolation, match="đã lưu trữ"):
+            await service.extend(
+                round_id,
+                AdmissionRoundExtend(
+                    end_date=date(2026, 6, 30),
+                    extension_reason="Cố gắng gia hạn round archived",
+                ),
+                admin,
+            )
+
+
+@pytest.mark.asyncio
 async def test_round_update_partial_start_against_existing_end(
     round_test_seed: dict,
 ) -> None:

--- a/Backend_FastAPI/tests/services/test_phase2_pr2d_path_clone_service.py
+++ b/Backend_FastAPI/tests/services/test_phase2_pr2d_path_clone_service.py
@@ -222,3 +222,88 @@ async def test_clone_filtered_by_academic_info_ids(clone_seed: dict, seed_lead_d
 
     assert response.cloned_count == 1  # Chỉ matching academic_info_id #1
     assert response.items[0].source_path_id == clone_seed["source_path_id"]
+
+
+# ---------------------------------------------------------------------------
+# BUG #3 fix — pre-check skip pattern (savepoint không phá session state)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clone_skip_existing_does_not_corrupt_session(
+    clone_seed: dict, seed_lead_dependencies: dict
+):
+    """ANCHOR (BUG #3): clone với 1 source path đã tồn tại trong target +
+    1 source path mới → 1 skipped + 1 cloned, KHÔNG MissingGreenlet.
+
+    Trước fix: rollback() trong loop expire instances của remaining src_paths
+    → access criteria_id ở iter sau crash MissingGreenlet.
+    Sau fix: pre-fetch existing keys (acad, method) làm lookup table, skip
+    in-memory mà KHÔNG cần catch IntegrityError → session intact.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            # Pre-create path trong target_round với cùng (acad, method) như source
+            # để force ON CONFLICT skip iter đầu.
+            existing_criteria = models.AdmissionCriteria(
+                method_id=clone_seed["method_id"],
+                code=f"E{ts}"[:20], name=f"Existing {ts}",
+                min_score=Decimal("16.00"),
+                policy_version="2026.1", is_active=True,
+            )
+            s.add(existing_criteria); await s.flush()
+            existing_path = models.AdmissionPath(
+                academic_info_id=clone_seed["academic_info_id"],
+                admission_method_id=clone_seed["method_id"],
+                admission_round_id=clone_seed["target_round_id"],
+                criteria_id=existing_criteria.id,
+                status="draft",
+            )
+            s.add(existing_path); await s.flush()
+
+            # Add source path #2 cho academic_info khác (sẽ clone OK)
+            offering2 = models.ProgramOffering(
+                program_id=seed_lead_dependencies["major_program_id"],
+                offering_type="part_time",
+                duration_semesters=8,
+            )
+            s.add(offering2); await s.flush()
+            ai2 = models.OfferingAcademicInfo(
+                offering_id=offering2.id,
+                academic_year=2026,
+                annual_admission_quota=10,
+                tuition_fee_per_year=1_000_000,
+            )
+            s.add(ai2); await s.flush()
+            criteria2 = models.AdmissionCriteria(
+                method_id=clone_seed["method_id"],
+                code=f"S2_{ts}"[:20], name=f"Source2 {ts}",
+                min_score=Decimal("15.00"),
+                policy_version="2026.1", is_active=True,
+            )
+            s.add(criteria2); await s.flush()
+            path2 = models.AdmissionPath(
+                academic_info_id=ai2.id,
+                admission_method_id=clone_seed["method_id"],
+                admission_round_id=clone_seed["source_round_id"],
+                criteria_id=criteria2.id,
+                status="active",
+            )
+            s.add(path2); await s.flush()
+
+    # Clone — expect skip 1 (acad #1 đã có), cloned 1 (acad #2 mới)
+    async with AsyncSessionLocal() as s:
+        svc = PathCloneService(s)
+        response = await svc.clone_paths_from_round(
+            target_round_id=clone_seed["target_round_id"],
+            source_round_id=clone_seed["source_round_id"],
+            payload=ClonePathsRequest(),
+        )
+        await s.commit()
+
+    assert response.skipped_count == 1
+    assert response.cloned_count == 1, (
+        "Iter sau khi skip phải clone OK — nếu MissingGreenlet thì test fail "
+        "với exception khác. Pre-check pattern không phá session state."
+    )

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/AdmissionConfigClient.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/AdmissionConfigClient.tsx
@@ -32,6 +32,7 @@ import { AcademicInfoPanel } from "./Phase2Program/AcademicInfoPanel";
 import { ContextSelector } from "./Phase3Config/ContextSelector";
 import { PathsList } from "./Phase3Config/PathsList";
 import { CoverageMatrix } from "./Phase3Config/CoverageMatrix";
+import { QuotaMatrixOverview } from "./Phase3Config/QuotaMatrixOverview";  // Phase 2 v8.2 PR-2D.1 v2
 import { PathWizard } from "./Phase3Config/PathWizard";
 import { Button } from "@/components/ui/button";
 import {
@@ -151,6 +152,17 @@ export function AdmissionConfigClient() {
               context={currentState.context}
               view={currentState.view}
               navigate={navigate}
+            />
+          )}
+
+          {/* Phase 2 v8.2 PR-2D.1 v2 — Quota Matrix overview (no context) */}
+          {currentState.type === "quota-matrix-overview" && (
+            <QuotaMatrixOverview
+              academicYear={currentState.academicYear}
+              onYearChange={(year) =>
+                navigate({ type: "quota-matrix-overview", academicYear: year })
+              }
+              onBack={() => navigate({ type: "welcome" })}
             />
           )}
         </div>

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.tsx
@@ -22,6 +22,7 @@
 
 import {
   Archive,
+  ArchiveRestore,
   CalendarPlus,
   Edit,
   Layers,
@@ -64,6 +65,7 @@ import {
   useBulkCreateRounds,
   useCreateRound,
   useExtendRound,
+  useRestoreRound,
   useSoftArchiveRound,
   useUpdateRound,
 } from "@/hooks/admissions/useAdmissionRounds"
@@ -139,6 +141,7 @@ export function RoundsManagementTab() {
   const bulkCreateMutation = useBulkCreateRounds(academicYear)
   const updateMutation = useUpdateRound(academicYear)
   const archiveMutation = useSoftArchiveRound(academicYear)
+  const restoreMutation = useRestoreRound(academicYear)
   const extendMutation = useExtendRound(academicYear)
 
   const [createOpen, setCreateOpen] = useState(false)
@@ -318,15 +321,27 @@ export function RoundsManagementTab() {
                     >
                       <CalendarPlus className="h-3 w-3" />
                     </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => setArchiveTarget(r)}
-                      disabled={r.archived_at !== null}
-                      aria-label="Lưu trữ đợt"
-                    >
-                      <Archive className="h-3 w-3" />
-                    </Button>
+                    {r.archived_at === null ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => setArchiveTarget(r)}
+                        aria-label="Lưu trữ đợt"
+                      >
+                        <Archive className="h-3 w-3" aria-hidden="true" />
+                      </Button>
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => restoreMutation.mutate(r.id)}
+                        disabled={restoreMutation.isPending}
+                        aria-label="Khôi phục đợt"
+                        aria-busy={restoreMutation.isPending}
+                      >
+                        <ArchiveRestore className="h-3 w-3" aria-hidden="true" />
+                      </Button>
+                    )}
                   </TableCell>
                 </TableRow>
               )

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.tsx
@@ -149,6 +149,7 @@ export function RoundsManagementTab() {
   const [editTarget, setEditTarget] = useState<AdmissionRoundResponse | null>(null)
   const [extendTarget, setExtendTarget] = useState<AdmissionRoundResponse | null>(null)
   const [archiveTarget, setArchiveTarget] = useState<AdmissionRoundResponse | null>(null)
+  const [restoreTarget, setRestoreTarget] = useState<AdmissionRoundResponse | null>(null)
 
   const [form, setForm] = useState<FormState>(EMPTY_FORM)
   const [extendForm, setExtendForm] = useState({ end_date: "", extension_reason: "" })
@@ -188,6 +189,12 @@ export function RoundsManagementTab() {
     if (!archiveTarget) return
     await archiveMutation.mutateAsync(archiveTarget.id)
     setArchiveTarget(null)
+  }
+
+  const handleRestore = async () => {
+    if (!restoreTarget) return
+    await restoreMutation.mutateAsync(restoreTarget.id)
+    setRestoreTarget(null)
   }
 
   const handleExtend = async () => {
@@ -334,10 +341,8 @@ export function RoundsManagementTab() {
                       <Button
                         size="sm"
                         variant="outline"
-                        onClick={() => restoreMutation.mutate(r.id)}
-                        disabled={restoreMutation.isPending}
+                        onClick={() => setRestoreTarget(r)}
                         aria-label="Khôi phục đợt"
-                        aria-busy={restoreMutation.isPending}
                       >
                         <ArchiveRestore className="h-3 w-3" aria-hidden="true" />
                       </Button>
@@ -499,9 +504,43 @@ export function RoundsManagementTab() {
             <Button variant="outline" onClick={() => setArchiveTarget(null)}>
               Huỷ
             </Button>
-            <Button variant="destructive" onClick={handleArchive}>
-              <Trash2 className="h-4 w-4 mr-2" />
+            <Button
+              variant="destructive"
+              onClick={handleArchive}
+              disabled={archiveMutation.isPending}
+              aria-busy={archiveMutation.isPending}
+            >
+              <Trash2 className="h-4 w-4 mr-2" aria-hidden="true" />
               Lưu trữ
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Restore Confirm Dialog */}
+      <Dialog
+        open={restoreTarget !== null}
+        onOpenChange={(o) => !o && setRestoreTarget(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Khôi phục đợt {restoreTarget?.round_code}?</DialogTitle>
+            <DialogDescription>
+              Đợt sẽ hiện lại trên storefront và xuất hiện trong danh sách cấu
+              hình đường tuyển sinh. Trạng thái Đang hoạt động sẽ được bật lại.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRestoreTarget(null)}>
+              Huỷ
+            </Button>
+            <Button
+              onClick={handleRestore}
+              disabled={restoreMutation.isPending}
+              aria-busy={restoreMutation.isPending}
+            >
+              <ArchiveRestore className="h-4 w-4 mr-2" aria-hidden="true" />
+              Khôi phục
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigCriteria.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigCriteria.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -51,26 +51,35 @@ export function ConfigCriteria({ path, onNext, onBack, embedded = false }: Confi
   // Search state for filtering subject groups
   const [searchQuery, setSearchQuery] = useState<string>("");
 
+  // Pass 2 hard-review FM-4: debounce search input để tránh filter 281
+  // subject groups + re-render checkbox grid mỗi keystroke. 200ms = ngắn
+  // đủ feel responsive, đủ skip rapid typing.
+  const [debouncedSearch, setDebouncedSearch] = useState<string>("");
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedSearch(searchQuery), 200);
+    return () => clearTimeout(handle);
+  }, [searchQuery]);
+
   // Sync form state when path data loads
   const currentPathId = path.id;
-   
+
   // REMOVED useEffect sync - relying on key-based remount from parent (PathWizard)
   // to re-initialize these states when path/criteria changes.
-  
+
   // Handlers
 
-  // Filter subject groups based on search query
-  // Filter subject groups based on search query
-  const filteredGroups = Array.isArray(subjectGroups) 
-    ? subjectGroups.filter((group: SubjectGroup) => {
-        if (!searchQuery) return true;
-        const query = searchQuery.toLowerCase();
-        return (
-          (group.code?.toLowerCase() || "").includes(query) ||
-          (group.name?.toLowerCase() || "").includes(query)
-        );
-      })
-    : [];
+  // Filter subject groups based on debounced search query.
+  // Wrap trong useMemo để re-compute chỉ khi groups hoặc query thay đổi
+  // (không re-compute trên mỗi state change khác trong component).
+  const filteredGroups = useMemo(() => {
+    if (!Array.isArray(subjectGroups)) return [] as SubjectGroup[];
+    if (!debouncedSearch) return subjectGroups;
+    const query = debouncedSearch.toLowerCase();
+    return subjectGroups.filter((group: SubjectGroup) =>
+      (group.code?.toLowerCase() || "").includes(query) ||
+      (group.name?.toLowerCase() || "").includes(query)
+    );
+  }, [subjectGroups, debouncedSearch]);
 
   // Get selected group details for chip display
   const selectedGroupsDetails = subjectGroups.filter((group: SubjectGroup) =>

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigCriteria.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigCriteria.tsx
@@ -97,9 +97,15 @@ export function ConfigCriteria({ path, onNext, onBack, embedded = false }: Confi
       return;
     }
 
-    if (effectiveFrom && effectiveTo && effectiveFrom > effectiveTo) {
-      toast.warning("Ngày bắt đầu hiệu lực không được lớn hơn ngày kết thúc");
-      return;
+    if (effectiveFrom && effectiveTo) {
+      // Parse ISO date string ('YYYY-MM-DD') to Date trước khi compare —
+      // string compare lexical sai cho format không zero-pad consistent.
+      const fromTs = Date.parse(effectiveFrom);
+      const toTs = Date.parse(effectiveTo);
+      if (!isNaN(fromTs) && !isNaN(toTs) && fromTs > toTs) {
+        toast.warning("Ngày bắt đầu hiệu lực không được lớn hơn ngày kết thúc");
+        return;
+      }
     }
 
     try {
@@ -171,8 +177,6 @@ export function ConfigCriteria({ path, onNext, onBack, embedded = false }: Confi
         effective_to: effectiveTo || null,
       };
 
-      console.log("Sending criteria payload:", payload);
-
       await updateMutation.mutateAsync({
         pathId: path.id,
         data: payload
@@ -181,9 +185,11 @@ export function ConfigCriteria({ path, onNext, onBack, embedded = false }: Confi
       // Move to next step after successful save
       onNext();
     } catch (error: unknown) {
-      console.error("Failed to save criteria:", error);
       const apiError = error as { response?: { data?: { detail?: unknown } } };
-      console.error("Error response:", apiError?.response?.data);
+      if (process.env.NODE_ENV === "development") {
+        // eslint-disable-next-line no-console
+        console.error("ConfigCriteria save error:", error, apiError?.response?.data);
+      }
 
       // Extract validation error details
       const errorDetail = apiError?.response?.data?.detail;

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigCriteria.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigCriteria.tsx
@@ -22,9 +22,12 @@ interface ConfigCriteriaProps {
   path: AdmissionPathResponse;
   onNext: () => void;
   onBack: () => void;
+  /** Khi true: render footer "Đóng" + "Lưu tiêu chí" (drawer mode) thay vì
+   * "Quay lại" + "Lưu & Tiếp tục" (wizard mode). */
+  embedded?: boolean;
 }
 
-export function ConfigCriteria({ path, onNext, onBack }: ConfigCriteriaProps) {
+export function ConfigCriteria({ path, onNext, onBack, embedded = false }: ConfigCriteriaProps) {
   const { data: subjectGroups = [], isLoading: loadingGroups } = useSubjectGroups();
   const updateMutation = useUpdateCriteria();
 
@@ -397,20 +400,27 @@ export function ConfigCriteria({ path, onNext, onBack }: ConfigCriteriaProps) {
 
           {/* Search Input */}
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Search
+              className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none"
+              aria-hidden="true"
+            />
             <Input
-              placeholder="Tìm kiếm tổ hợp môn (mã hoặc tên môn)..."
+              placeholder="Tìm kiếm tổ hợp môn (mã hoặc tên môn)…"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9"
+              autoComplete="off"
+              spellCheck={false}
+              className={searchQuery ? "pl-9 pr-9" : "pl-9"}
+              aria-label="Tìm kiếm tổ hợp môn"
             />
             {searchQuery && (
               <button
                 type="button"
                 onClick={() => setSearchQuery("")}
-                className="absolute right-3 top-1/2 transform -translate-y-1/2 hover:bg-muted rounded-full p-1"
+                aria-label="Xoá từ khoá tìm kiếm"
+                className="absolute right-2 top-1/2 transform -translate-y-1/2 hover:bg-muted rounded-full p-1"
               >
-                <X className="h-4 w-4 text-muted-foreground" />
+                <X className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
               </button>
             )}
           </div>
@@ -452,19 +462,19 @@ export function ConfigCriteria({ path, onNext, onBack }: ConfigCriteriaProps) {
         </div>
 
         {/* Actions */}
-        <div className="flex justify-between pt-4">
+        <div className="flex justify-end gap-2 pt-4 border-t">
           <Button variant="outline" onClick={onBack} disabled={isSaving}>
-            <ArrowLeft className="h-4 w-4 mr-2" />
-            Quay lại
+            {!embedded && <ArrowLeft className="h-4 w-4 mr-2" aria-hidden="true" />}
+            {embedded ? "Đóng" : "Quay lại"}
           </Button>
-          <Button onClick={handleSave} disabled={isSaving}>
+          <Button onClick={handleSave} disabled={isSaving} aria-busy={isSaving}>
             {isSaving ? (
-              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
             ) : (
-              <Save className="h-4 w-4 mr-2" />
+              <Save className="h-4 w-4 mr-2" aria-hidden="true" />
             )}
-            Lưu & Tiếp tục
-            <ArrowRight className="h-4 w-4 ml-2" />
+            {embedded ? "Lưu tiêu chí" : "Lưu & Tiếp tục"}
+            {!embedded && <ArrowRight className="h-4 w-4 ml-2" aria-hidden="true" />}
           </Button>
         </div>
 

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigDocuments.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigDocuments.tsx
@@ -20,6 +20,8 @@ interface ConfigDocumentsProps {
   path: AdmissionPathResponse;
   onFinish: () => void;
   onBack: () => void;
+  /** Khi true: render footer "Đóng" + "Lưu giấy tờ" (drawer mode). */
+  embedded?: boolean;
 }
 
 interface DocSelection {
@@ -30,7 +32,7 @@ interface DocSelection {
   display_order: number;
 }
 
-export function ConfigDocuments({ path, onFinish, onBack }: ConfigDocumentsProps) {
+export function ConfigDocuments({ path, onFinish, onBack, embedded = false }: ConfigDocumentsProps) {
   // Queries
   const { data: allDocTypes = [], isLoading: loadingTypes } = useDocumentTypes();
   const { data: resolvedDocs, isLoading: loadingResolved } = usePathDocuments(path.id);
@@ -263,18 +265,18 @@ export function ConfigDocuments({ path, onFinish, onBack }: ConfigDocumentsProps
             </div>
 
             {/* Actions */}
-            <div className="flex justify-between pt-4">
+            <div className="flex justify-end gap-2 pt-4 border-t">
               <Button variant="outline" onClick={onBack} disabled={isSaving}>
-                <ArrowLeft className="h-4 w-4 mr-2" />
-                Quay lại
+                {!embedded && <ArrowLeft className="h-4 w-4 mr-2" aria-hidden="true" />}
+                {embedded ? "Đóng" : "Quay lại"}
               </Button>
-              <Button onClick={handleSave} disabled={isSaving}>
+              <Button onClick={handleSave} disabled={isSaving} aria-busy={isSaving}>
                 {isSaving ? (
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
                 ) : (
-                  <Archive className="h-4 w-4 mr-2" />
+                  <Archive className="h-4 w-4 mr-2" aria-hidden="true" />
                 )}
-                Lưu & Tiếp tục
+                {embedded ? "Lưu giấy tờ" : "Lưu & Tiếp tục"}
               </Button>
             </div>
           </div>

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigDocuments.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigDocuments.tsx
@@ -124,7 +124,6 @@ export function ConfigDocuments({ path, onFinish, onBack, embedded = false }: Co
 
     try {
       const payload = Object.values(selections);
-      console.log("ConfigDocuments: Saving payload:", payload);
 
       await updateMutation.mutateAsync({
         pathId: path.id,
@@ -135,9 +134,11 @@ export function ConfigDocuments({ path, onFinish, onBack, embedded = false }: Co
       // Move to review step after successful save
       onFinish();
     } catch (error: unknown) {
-      console.error("ConfigDocuments: Save error:", error);
       const apiError = error as { response?: { data?: { detail?: unknown } } };
-      console.error("ConfigDocuments: Error response:", apiError?.response?.data);
+      if (process.env.NODE_ENV === "development") {
+        // eslint-disable-next-line no-console
+        console.error("ConfigDocuments save error:", error, apiError?.response?.data);
+      }
 
       // Extract validation error details
       const errorDetail = apiError?.response?.data?.detail;

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AggregateDrawer.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AggregateDrawer.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Vitest tests cho AggregateDrawer (Phase 2 v8.2 PR-2D.1 v3).
+ *
+ * Anchor: drawer chỉ filter cells thuộc round được click (NOT all rounds).
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { AggregateDrawer } from "./AggregateDrawer"
+
+vi.mock("@/hooks/admissions/useQuotaMatrix", () => ({
+  usePathMatrixByMajor: () => ({
+    data: {
+      academic_info_id: 70,
+      academic_year: 2026,
+      program_name: "Công nghệ thông tin",
+      program_code: "CNTT",
+      degree_level: "DH",
+      annual_admission_quota: 100,
+      sum_admit_allocated: 80,
+      sum_remaining: 20,
+      rounds: [
+        { id: 1, round_code: "DOT_1", round_name: "Đợt 1", is_active: true },
+        { id: 2, round_code: "DOT_2", round_name: "Đợt 2", is_active: true },
+      ],
+      methods: [
+        {
+          admission_method_id: 1,
+          method_code: "HB",
+          method_name: "Học bạ",
+          sum_admit_quota: 50,
+          cells_by_round_id: {
+            1: {
+              path_id: 106,
+              admission_round_id: 1,
+              admission_method_id: 1,
+              round_quota: 50,
+              admit_quota: 30,
+              submission_count: 5,
+              status: "active",
+              criteria_code: "HB_DOT_1",
+            },
+            2: {
+              path_id: 107,
+              admission_round_id: 2,
+              admission_method_id: 1,
+              round_quota: 40,
+              admit_quota: 20,
+              submission_count: 0,
+              status: "draft",
+              criteria_code: "HB_DOT_2",
+            },
+          },
+        },
+        {
+          admission_method_id: 3,
+          method_code: "THPT",
+          method_name: "THPT",
+          sum_admit_quota: 30,
+          cells_by_round_id: {
+            1: {
+              path_id: 108,
+              admission_round_id: 1,
+              admission_method_id: 3,
+              round_quota: 60,
+              admit_quota: 30,
+              submission_count: 2,
+              status: "active",
+              criteria_code: "THPT_DOT_1",
+            },
+            2: null,
+          },
+        },
+      ],
+    },
+    isLoading: false,
+  }),
+}))
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+}
+
+describe("AggregateDrawer", () => {
+  it("renders header với program_name + đợt selected", () => {
+    render(
+      wrap(
+        <AggregateDrawer
+          academicInfoId={70}
+          roundId={1}
+          programName="Công nghệ thông tin"
+          roundCode="DOT_1"
+          onClose={() => {}}
+        />,
+      ),
+    )
+    expect(screen.getByText("Công nghệ thông tin")).toBeTruthy()
+    expect(screen.getByText(/Đợt/)).toBeTruthy()
+    expect(screen.getByText("DOT_1")).toBeTruthy()
+  })
+
+  it("ANCHOR (round filter): DOT_1 lists 2 methods (HB + THPT)", () => {
+    render(
+      wrap(
+        <AggregateDrawer
+          academicInfoId={70}
+          roundId={1}
+          programName="CNTT"
+          roundCode="DOT_1"
+          onClose={() => {}}
+        />,
+      ),
+    )
+    expect(screen.getByText("Học bạ")).toBeTruthy()
+    // method_name + method_code đều là "THPT" → 2 occurrences
+    expect(screen.getAllByText("THPT").length).toBeGreaterThan(0)
+    expect(screen.getByText(/2 phương thức/)).toBeTruthy()
+  })
+
+  it("ANCHOR (filter DOT_2): method có cell null ở DOT_2 KHÔNG xuất hiện", () => {
+    render(
+      wrap(
+        <AggregateDrawer
+          academicInfoId={70}
+          roundId={2}
+          programName="CNTT"
+          roundCode="DOT_2"
+          onClose={() => {}}
+        />,
+      ),
+    )
+    // DOT_2: HB có cell nhưng THPT cell=null → THPT method row không render
+    expect(screen.getByText("Học bạ")).toBeTruthy()
+    expect(screen.queryByText("THPT")).toBeNull()
+    // 1 method only
+    expect(screen.getByText(/1 phương thức/)).toBeTruthy()
+  })
+
+  it("renders summary box với cap năm + sum_admit_allocated + còn lại", () => {
+    render(
+      wrap(
+        <AggregateDrawer
+          academicInfoId={70}
+          roundId={1}
+          programName="CNTT"
+          roundCode="DOT_1"
+          onClose={() => {}}
+        />,
+      ),
+    )
+    expect(screen.getByText(/Cap năm:/)).toBeTruthy()
+    expect(screen.getByText(/Đã rải toàn ngành:/)).toBeTruthy()
+    expect(screen.getByText("100")).toBeTruthy()
+    expect(screen.getByText("80")).toBeTruthy()
+  })
+})

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AggregateDrawer.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AggregateDrawer.test.tsx
@@ -4,11 +4,21 @@
  * Anchor: drawer chỉ filter cells thuộc round được click (NOT all rounds).
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 
 import { AggregateDrawer } from "./AggregateDrawer"
+
+// Pass 2 hard-review F-2-2: PathDetailDrawer (nested) dùng useAdmissionPath
+// + useUpdatePathQuota; mock cả 2 module để drill-down render an toàn.
+vi.mock("@/hooks/admissions/useAdmissionPaths", () => ({
+  useAdmissionPath: () => ({ data: undefined, isLoading: true }),
+  useUpdateAdmissionPath: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useActivateAdmissionPath: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useDeactivateAdmissionPath: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}))
 
 vi.mock("@/hooks/admissions/useQuotaMatrix", () => ({
   usePathMatrixByMajor: () => ({
@@ -155,5 +165,31 @@ describe("AggregateDrawer", () => {
     expect(screen.getByText(/Đã rải toàn ngành:/)).toBeTruthy()
     expect(screen.getByText("100")).toBeTruthy()
     expect(screen.getByText("80")).toBeTruthy()
+  })
+
+  // Pass 2 hard-review F-2-2: ChevronRight click → PathDetailDrawer nested
+  // mở với pathId đúng. Verify drill-down flow + tránh regression khi
+  // refactor button-to-drawer dispatch trong AggregateDrawer.
+  it("ANCHOR (drill-down): ChevronRight click → PathDetailDrawer nested", async () => {
+    const user = userEvent.setup()
+    render(
+      wrap(
+        <AggregateDrawer
+          academicInfoId={70}
+          roundId={1}
+          programName="CNTT"
+          roundCode="DOT_1"
+          onClose={() => {}}
+        />,
+      ),
+    )
+    // ChevronRight button có aria-label "Mở chi tiết đường <method_name>".
+    const drillBtn = screen.getByLabelText(/Mở chi tiết đường Học bạ/)
+    await user.click(drillBtn)
+    // PathDetailDrawer hiển thị fallback title "Đường tuyển sinh #<pathId>"
+    // khi data chưa load (mocked isLoading=true) — pathId=106 cho HB DOT_1.
+    await waitFor(() => {
+      expect(screen.getByText(/Đường tuyển sinh #106/)).toBeTruthy()
+    })
   })
 })

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AggregateDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AggregateDrawer.tsx
@@ -1,0 +1,193 @@
+/**
+ * AggregateDrawer — drill-down 1 cell aggregate (ngành × đợt) trong Ma trận toàn cảnh.
+ *
+ * Phase 2 v8.2 PR-2D.1 v3.
+ * Cell aggregate = N paths (1 path / method). Drawer = list paths + each path
+ * → click open PathDetailDrawer (nested) cho edit deep.
+ */
+"use client"
+
+import { ChevronRight, Loader2 } from "lucide-react"
+import { useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { usePathMatrixByMajor } from "@/hooks/admissions/useQuotaMatrix"
+
+import { PathDetailDrawer } from "./PathDetailDrawer"
+import { pathStatusLabel } from "./labels"
+
+interface Props {
+  academicInfoId: number
+  roundId: number
+  programName: string
+  roundCode: string
+  onClose: () => void
+}
+
+export function AggregateDrawer({
+  academicInfoId,
+  roundId,
+  programName,
+  roundCode,
+  onClose,
+}: Props) {
+  const { data, isLoading } = usePathMatrixByMajor(academicInfoId)
+  const [openPathId, setOpenPathId] = useState<number | null>(null)
+
+  // Filter cells thuộc round này
+  const rowsInRound = data?.methods
+    .map((m) => ({
+      method: m,
+      cell: m.cells_by_round_id[roundId],
+    }))
+    .filter((x) => x.cell !== null && x.cell !== undefined)
+
+  return (
+    <Sheet open onOpenChange={(o) => { if (!o) onClose() }}>
+      <SheetContent className="sm:max-w-2xl w-full flex flex-col overflow-hidden">
+        <SheetHeader className="pr-8">
+          <SheetTitle className="text-pretty">{programName}</SheetTitle>
+          <SheetDescription className="sr-only">
+            Tổng hợp đường tuyển sinh theo phương thức cho ngành &amp; đợt đã chọn.
+          </SheetDescription>
+          <div className="text-xs text-muted-foreground">
+            Đợt <span translate="no">{roundCode}</span>
+            <span aria-hidden="true"> · </span>
+            {rowsInRound?.length ?? 0} phương thức
+          </div>
+        </SheetHeader>
+
+        <div className="flex-1 min-h-0 overflow-y-auto py-4">
+          {isLoading && (
+            <div className="flex items-center justify-center py-8" aria-live="polite">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-hidden="true" />
+              <span className="sr-only">Đang tải tổng hợp đường tuyển sinh…</span>
+            </div>
+          )}
+
+          {data && rowsInRound && rowsInRound.length === 0 && (
+            <div className="text-sm text-muted-foreground py-4">
+              Chưa có đường tuyển sinh nào cho ngành &amp; đợt này.
+            </div>
+          )}
+
+          {data && rowsInRound && rowsInRound.length > 0 && (
+            <>
+              <div className="rounded-md border bg-muted/40 p-3 text-xs space-y-1 mb-4">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Cap năm:</span>
+                  <span className="font-medium tabular-nums">
+                    {data.annual_admission_quota ?? "∞"}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Đã rải toàn ngành:</span>
+                  <span className="font-medium tabular-nums">{data.sum_admit_allocated}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Còn lại:</span>
+                  <span
+                    className={
+                      data.sum_remaining !== null && data.sum_remaining < 0
+                        ? "font-semibold text-destructive tabular-nums"
+                        : "font-medium text-emerald-600 tabular-nums"
+                    }
+                  >
+                    {data.sum_remaining ?? "∞"}
+                  </span>
+                </div>
+              </div>
+
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Phương thức</TableHead>
+                    <TableHead className="text-right">Trần submit</TableHead>
+                    <TableHead className="text-right">Trần admit</TableHead>
+                    <TableHead className="text-right">Đã nộp</TableHead>
+                    <TableHead className="text-center">Trạng thái</TableHead>
+                    <TableHead>
+                      <span className="sr-only">Mở chi tiết</span>
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rowsInRound.map(({ method, cell }) => (
+                    <TableRow key={method.admission_method_id}>
+                      <TableCell>
+                        <div className="font-medium">{method.method_name}</div>
+                        <div className="text-xs text-muted-foreground" translate="no">
+                          {method.method_code}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {cell!.round_quota ?? "—"}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {cell!.admit_quota ?? "—"}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {cell!.submission_count}
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <Badge
+                          variant={cell!.status === "active" ? "default" : "outline"}
+                          className="text-xs"
+                        >
+                          {pathStatusLabel(cell!.status)}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right p-1">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setOpenPathId(cell!.path_id)}
+                          aria-label={`Mở chi tiết đường ${method.method_name}`}
+                        >
+                          <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+
+              <p className="text-[11px] text-muted-foreground mt-3">
+                Click → mở chi tiết path để chỉnh quota.
+              </p>
+            </>
+          )}
+        </div>
+
+        <div className="flex justify-end border-t pt-3">
+          <Button variant="outline" onClick={onClose}>
+            Đóng
+          </Button>
+        </div>
+      </SheetContent>
+
+      {openPathId !== null && (
+        <PathDetailDrawer
+          pathId={openPathId}
+          onClose={() => setOpenPathId(null)}
+        />
+      )}
+    </Sheet>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Vitest tests cho ByMajorView (Phase 2 v8.2 PR-2D.1 v3).
+ *
+ * Anchor: cell = exact path (NOT aggregate) — read-only with status badge.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ByMajorView } from "./ByMajorView"
+
+vi.mock("@/hooks/admissions/useQuotaMatrix", () => ({
+  useQuotaMatrix: () => ({
+    data: {
+      academic_year: 2026,
+      total_rows: 1,
+      rounds: [{ id: 1, round_code: "DOT_1", round_name: "Đợt 1", is_active: true }],
+      rows: [
+        {
+          academic_info_id: 70,
+          academic_year: 2026,
+          program_name: "Công nghệ thông tin",
+          program_code: "CNTT",
+          degree_level: "DH",
+          annual_admission_quota: 100,
+          sum_admit_allocated: 30,
+          sum_remaining: 70,
+          cells_by_round_id: {},
+        },
+      ],
+    },
+  }),
+  usePathMatrixByMajor: (academicInfoId: number | undefined) => ({
+    data: academicInfoId === 70
+      ? {
+          academic_info_id: 70,
+          academic_year: 2026,
+          program_name: "Công nghệ thông tin",
+          program_code: "CNTT",
+          degree_level: "DH",
+          annual_admission_quota: 100,
+          sum_admit_allocated: 30,
+          sum_remaining: 70,
+          rounds: [
+            { id: 1, round_code: "DOT_1", round_name: "Đợt 1", is_active: true },
+          ],
+          methods: [
+            {
+              admission_method_id: 1,
+              method_code: "HB",
+              method_name: "Học bạ",
+              sum_admit_quota: 30,
+              cells_by_round_id: {
+                1: {
+                  path_id: 106,
+                  admission_round_id: 1,
+                  admission_method_id: 1,
+                  round_quota: 50,
+                  admit_quota: 30,
+                  submission_count: 5,
+                  status: "active",
+                  criteria_code: "HB2026_CNTT_DOT_1",
+                },
+              },
+            },
+          ],
+        }
+      : undefined,
+    isLoading: false,
+  }),
+}))
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+}
+
+describe("ByMajorView", () => {
+  it("renders title + auto-select first ngành + load matrix", () => {
+    render(wrap(<ByMajorView academicYear={2026} onYearChange={() => {}} />))
+    expect(screen.getByText(/Cấu hình theo ngành/)).toBeTruthy()
+    expect(screen.getByText("Học bạ")).toBeTruthy()
+  })
+
+  it("renders cell with 3-line contract: admit/annual + Submit + status badge", () => {
+    render(wrap(<ByMajorView academicYear={2026} onYearChange={() => {}} />))
+    expect(screen.getByText(/30 \/ 100/)).toBeTruthy()
+    expect(screen.getByText(/Submit 50/)).toBeTruthy()
+    expect(screen.getByText(/Đang hoạt động/)).toBeTruthy()
+  })
+
+  it("ANCHOR (per-major header): shows cap năm + đã rải + còn lại", () => {
+    render(wrap(<ByMajorView academicYear={2026} onYearChange={() => {}} />))
+    expect(screen.getByText(/Cap năm:/)).toBeTruthy()
+    expect(screen.getByText(/Đã rải:/)).toBeTruthy()
+    expect(screen.getByText(/Còn:/)).toBeTruthy()
+  })
+
+  it("ANCHOR (read-only): cells rendered as button (no inline input)", () => {
+    const { container } = render(
+      wrap(<ByMajorView academicYear={2026} onYearChange={() => {}} />),
+    )
+    expect(container.querySelectorAll("input[type='number']").length).toBe(0)
+  })
+})

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.test.tsx
@@ -5,10 +5,21 @@
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ByMajorView } from "./ByMajorView"
+
+// Pass 2 hard-review F-2-1 prerequisite: ByMajorView dùng Next.js navigation
+// hooks để sync ``?pathId`` URL param. Test mock cùng pattern với
+// ``useAdmissionsFilter.test.ts``.
+const replaceMock = vi.fn()
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/admin/admission-config",
+}))
 
 vi.mock("@/hooks/admissions/useQuotaMatrix", () => ({
   useQuotaMatrix: () => ({
@@ -77,6 +88,10 @@ function wrap(ui: ReactNode) {
 }
 
 describe("ByMajorView", () => {
+  beforeEach(() => {
+    replaceMock.mockClear()
+  })
+
   it("renders title + auto-select first ngành + load matrix", () => {
     render(wrap(<ByMajorView academicYear={2026} onYearChange={() => {}} />))
     expect(screen.getByText(/Cấu hình theo ngành/)).toBeTruthy()
@@ -102,5 +117,29 @@ describe("ByMajorView", () => {
       wrap(<ByMajorView academicYear={2026} onYearChange={() => {}} />),
     )
     expect(container.querySelectorAll("input[type='number']").length).toBe(0)
+  })
+
+  // Pass 2 hard-review F-2-2: regression cho ngành dropdown — đảm bảo
+  // dropdown trigger render với ngành option khả dụng. Test ngành change
+  // → matrix re-fetch không thực hiện được vì hook mock tĩnh, nhưng test
+  // dropdown options có ngành đúng tránh regression khi refactor data flow.
+  it("ANCHOR (ngành dropdown): trigger render + ngành option có sẵn", () => {
+    render(wrap(<ByMajorView academicYear={2026} onYearChange={() => {}} />))
+    expect(screen.getByText(/Ngành:/)).toBeTruthy()
+    // SelectTrigger hiển thị ngành đã auto-select.
+    expect(screen.getAllByText("Công nghệ thông tin").length).toBeGreaterThan(0)
+  })
+
+  // Pass 2 hard-review F-2-2: cell click → setOpenPathId qua URL replace.
+  // Verify router.replace gọi với ?pathId=N khi user click cell active.
+  it("ANCHOR (cell click → URL sync): click cell active emit replace với ?pathId", async () => {
+    const user = userEvent.setup()
+    render(wrap(<ByMajorView academicYear={2026} onYearChange={() => {}} />))
+    // Cell button có aria-label chứa method_name + đợt — pick by partial match.
+    const cellButton = screen.getByLabelText(/Mở chi tiết Học bạ/)
+    await user.click(cellButton)
+    expect(replaceMock).toHaveBeenCalled()
+    const callArg = replaceMock.mock.calls[0][0] as string
+    expect(callArg).toContain("pathId=106")
   })
 })

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.tsx
@@ -1,0 +1,243 @@
+/**
+ * ByMajorView — Theo ngành (default daily ops mode).
+ *
+ * Pick 1 ngành → matrix [method × đợt] cho ngành đó.
+ * Cell = exact path (NOT aggregate) vì filter (academic_info × method × round)
+ * = UNIQUE 3-col. Click cell → PathDetailDrawer trực tiếp (1-step).
+ */
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import { useEffect, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useQuotaMatrix, usePathMatrixByMajor } from "@/hooks/admissions/useQuotaMatrix"
+
+import { PathDetailDrawer } from "./PathDetailDrawer"
+import { QuickCreatePathModal } from "./QuickCreatePathModal"
+import { pathStatusLabel } from "./labels"
+
+const CURRENT_YEAR = new Date().getFullYear()
+const YEAR_OPTIONS = [CURRENT_YEAR - 1, CURRENT_YEAR, CURRENT_YEAR + 1, CURRENT_YEAR + 2]
+
+interface Props {
+  academicYear: number
+  onYearChange: (year: number) => void
+}
+
+export function ByMajorView({ academicYear, onYearChange }: Props) {
+  // Reuse global quota-matrix endpoint to populate ngành dropdown options
+  const { data: globalData } = useQuotaMatrix(academicYear)
+  const [selectedAcademicInfoId, setSelectedAcademicInfoId] = useState<number | undefined>(undefined)
+  const { data: matrix, isLoading } = usePathMatrixByMajor(selectedAcademicInfoId)
+  const [openPathId, setOpenPathId] = useState<number | null>(null)
+  const [createCell, setCreateCell] = useState<{
+    methodId: number
+    methodName: string
+    roundId: number
+    roundCode: string
+  } | null>(null)
+
+  // Auto-select first ngành on year change
+  useEffect(() => {
+    if (globalData && globalData.rows.length > 0 && selectedAcademicInfoId === undefined) {
+      setSelectedAcademicInfoId(globalData.rows[0].academic_info_id)
+    }
+  }, [globalData, selectedAcademicInfoId])
+
+  const isOver = matrix?.sum_remaining !== null && matrix !== undefined && matrix.sum_remaining! < 0
+
+  return (
+    <Card>
+      <CardHeader className="space-y-3 pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base">Cấu hình theo ngành — daily ops</CardTitle>
+          <Select value={academicYear.toString()} onValueChange={(v) => onYearChange(Number(v))}>
+            <SelectTrigger className="w-32"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {YEAR_OPTIONS.map((y) => (
+                <SelectItem key={y} value={y.toString()}>{y}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center gap-3 flex-wrap">
+          <label className="text-sm font-medium">Ngành:</label>
+          <Select
+            value={selectedAcademicInfoId?.toString() ?? ""}
+            onValueChange={(v) => setSelectedAcademicInfoId(Number(v))}
+          >
+            <SelectTrigger className="w-72">
+              <SelectValue placeholder="Chọn ngành…" />
+            </SelectTrigger>
+            <SelectContent>
+              {globalData?.rows.map((r) => (
+                <SelectItem key={r.academic_info_id} value={r.academic_info_id.toString()}>
+                  {r.program_name}
+                  {r.degree_level && (
+                    <span className="text-muted-foreground"> ({r.degree_level})</span>
+                  )}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {matrix && (
+            <div className="flex items-center gap-2 text-sm ml-auto">
+              <span className="text-muted-foreground">Cap năm:</span>
+              <span className="font-medium">{matrix.annual_admission_quota ?? "∞"}</span>
+              <span className="text-muted-foreground">·</span>
+              <span className="text-muted-foreground">Đã rải:</span>
+              <span className="font-medium">{matrix.sum_admit_allocated}</span>
+              <span className="text-muted-foreground">·</span>
+              <span className="text-muted-foreground">Còn:</span>
+              {matrix.sum_remaining === null ? (
+                <span className="font-medium italic">∞</span>
+              ) : isOver ? (
+                <span className="font-semibold text-destructive inline-flex items-center gap-1">
+                  <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+                  {matrix.sum_remaining}
+                </span>
+              ) : (
+                <span className="font-medium text-emerald-600">{matrix.sum_remaining}</span>
+              )}
+            </div>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {!selectedAcademicInfoId && (
+          <div className="text-sm text-muted-foreground py-4">
+            Chọn ngành để xem cấu hình.
+          </div>
+        )}
+        {selectedAcademicInfoId && isLoading && (
+          <div className="text-sm text-muted-foreground py-4">Đang tải...</div>
+        )}
+        {matrix && (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Phương thức</TableHead>
+                {matrix.rounds.map((r) => (
+                  <TableHead key={r.id} className="text-center min-w-[120px]" translate="no">
+                    {r.round_code}
+                  </TableHead>
+                ))}
+                <TableHead className="text-right">Tổng phương thức</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {matrix.methods.map((m) => (
+                <TableRow key={m.admission_method_id}>
+                  <TableCell>
+                    <div className="font-medium">{m.method_name}</div>
+                    <div className="text-xs text-muted-foreground" translate="no">
+                      {m.method_code}
+                    </div>
+                  </TableCell>
+                  {matrix.rounds.map((r) => {
+                    const cell = m.cells_by_round_id[r.id]
+                    if (!cell) {
+                      return (
+                        <TableCell key={r.id} className="p-1 text-center">
+                          <button
+                            onClick={() =>
+                              setCreateCell({
+                                methodId: m.admission_method_id,
+                                methodName: m.method_name,
+                                roundId: r.id,
+                                roundCode: r.round_code,
+                              })
+                            }
+                            className="text-xs text-muted-foreground hover:text-foreground hover:bg-muted rounded px-2 py-1.5 w-full transition-colors"
+                            aria-label={`Tạo đường tuyển sinh ${m.method_name} đợt ${r.round_code}`}
+                          >
+                            + Tạo
+                          </button>
+                        </TableCell>
+                      )
+                    }
+                    return (
+                      <TableCell key={r.id} className="p-1">
+                        <button
+                          onClick={() => setOpenPathId(cell.path_id)}
+                          className="w-full text-left bg-blue-50 dark:bg-blue-950/40 hover:bg-blue-100 dark:hover:bg-blue-900/50 border border-blue-200 dark:border-blue-800 rounded-md px-2 py-1.5 transition-colors"
+                          aria-label={`Mở chi tiết ${m.method_name} đợt ${r.round_code}: trần admit ${cell.admit_quota ?? "chưa đặt"} trên cap năm ${matrix.annual_admission_quota ?? "không giới hạn"}, trạng thái ${pathStatusLabel(cell.status)}`}
+                        >
+                          <div className="text-xs font-semibold tabular-nums">
+                            {cell.admit_quota ?? "—"} / {matrix.annual_admission_quota ?? "∞"}
+                          </div>
+                          <div className="text-[11px] text-muted-foreground tabular-nums">
+                            Submit {cell.round_quota ?? "—"}
+                          </div>
+                          <div className="text-[11px]">
+                            <Badge
+                              variant={cell.status === "active" ? "default" : "outline"}
+                              className="text-[10px] h-4 px-1"
+                            >
+                              {pathStatusLabel(cell.status)}
+                            </Badge>
+                          </div>
+                        </button>
+                      </TableCell>
+                    )
+                  })}
+                  <TableCell className="text-right font-medium tabular-nums">
+                    {m.sum_admit_quota}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+
+        {matrix && (
+          <div className="mt-4 text-xs text-muted-foreground space-y-0.5">
+            <p>Mỗi ô gồm 3 dòng: trần admit / cap năm · trần submit · trạng thái. Bấm ô để xem chi tiết &amp; chỉnh chỉ tiêu.</p>
+            <p>Dấu "—" = chưa có đường tuyển sinh cho (phương thức × đợt).</p>
+          </div>
+        )}
+      </CardContent>
+
+      {openPathId !== null && (
+        <PathDetailDrawer
+          pathId={openPathId}
+          onClose={() => setOpenPathId(null)}
+        />
+      )}
+
+      {createCell && selectedAcademicInfoId && (
+        <QuickCreatePathModal
+          academicInfoId={selectedAcademicInfoId}
+          admissionRoundId={createCell.roundId}
+          admissionMethodId={createCell.methodId}
+          contextLabel={`${matrix?.program_name ?? ""} × ${createCell.roundCode} × ${createCell.methodName}`}
+          onClose={() => setCreateCell(null)}
+          onCreated={(newPathId) => {
+            setCreateCell(null)
+            setOpenPathId(newPathId)
+          }}
+        />
+      )}
+    </Card>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.tsx
@@ -9,7 +9,7 @@
 
 import { AlertTriangle } from "lucide-react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { memo, useCallback, useEffect, useMemo, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -45,13 +45,10 @@ interface Props {
 export function ByMajorView({ academicYear, onYearChange }: Props) {
   // Reuse global quota-matrix endpoint to populate ngành dropdown options
   const { data: globalData } = useQuotaMatrix(academicYear)
-  const [selectedAcademicInfoId, setSelectedAcademicInfoId] = useState<number | undefined>(undefined)
-  const { data: matrix, isLoading } = usePathMatrixByMajor(selectedAcademicInfoId)
 
-  // Pass 2 hard-review F-2-1: URL state sync cho openPathId.
-  // Drawer state là URL state theo Frontend CLAUDE.md ("URL State: Filters,
-  // pagination") — admin share link mở thẳng path detail, browser
-  // back/forward navigate giữa các drawer mở/đóng.
+  // Pass 2 hard-review F-2-1 + FM-3: URL state sync cho openPathId +
+  // selectedAcademicInfoId. Share link reproduce đúng ngành + drawer
+  // path detail; browser back/forward navigate giữa các view.
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -61,16 +58,32 @@ export function ByMajorView({ academicYear, onYearChange }: Props) {
     const n = Number(raw)
     return Number.isFinite(n) && n > 0 ? n : null
   }, [searchParams])
-  const setOpenPathId = useCallback(
-    (id: number | null) => {
+  const selectedAcademicInfoId = useMemo<number | undefined>(() => {
+    const raw = searchParams.get("academicInfo")
+    if (!raw) return undefined
+    const n = Number(raw)
+    return Number.isFinite(n) && n > 0 ? n : undefined
+  }, [searchParams])
+  const updateSearchParam = useCallback(
+    (key: string, value: string | null) => {
       const params = new URLSearchParams(searchParams.toString())
-      if (id === null) params.delete("pathId")
-      else params.set("pathId", id.toString())
+      if (value === null) params.delete(key)
+      else params.set(key, value)
       const qs = params.toString()
       router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
     },
     [pathname, router, searchParams],
   )
+  const setOpenPathId = useCallback(
+    (id: number | null) => updateSearchParam("pathId", id === null ? null : id.toString()),
+    [updateSearchParam],
+  )
+  const setSelectedAcademicInfoId = useCallback(
+    (id: number) => updateSearchParam("academicInfo", id.toString()),
+    [updateSearchParam],
+  )
+
+  const { data: matrix, isLoading } = usePathMatrixByMajor(selectedAcademicInfoId)
 
   const [createCell, setCreateCell] = useState<{
     methodId: number
@@ -79,12 +92,12 @@ export function ByMajorView({ academicYear, onYearChange }: Props) {
     roundCode: string
   } | null>(null)
 
-  // Auto-select first ngành on year change
+  // Auto-select first ngành on year change — only if URL has no academicInfo.
   useEffect(() => {
     if (globalData && globalData.rows.length > 0 && selectedAcademicInfoId === undefined) {
       setSelectedAcademicInfoId(globalData.rows[0].academic_info_id)
     }
-  }, [globalData, selectedAcademicInfoId])
+  }, [globalData, selectedAcademicInfoId, setSelectedAcademicInfoId])
 
   const isOver = matrix?.sum_remaining !== null && matrix !== undefined && matrix.sum_remaining! < 0
 
@@ -183,47 +196,28 @@ export function ByMajorView({ academicYear, onYearChange }: Props) {
                     const cell = m.cells_by_round_id[r.id]
                     if (!cell) {
                       return (
-                        <TableCell key={r.id} className="p-1 text-center">
-                          <button
-                            onClick={() =>
-                              setCreateCell({
-                                methodId: m.admission_method_id,
-                                methodName: m.method_name,
-                                roundId: r.id,
-                                roundCode: r.round_code,
-                              })
-                            }
-                            className="text-xs text-muted-foreground hover:text-foreground hover:bg-muted rounded px-2 py-1.5 w-full transition-colors"
-                            aria-label={`Tạo đường tuyển sinh ${m.method_name} đợt ${r.round_code}`}
-                          >
-                            + Tạo
-                          </button>
-                        </TableCell>
+                        <EmptyCellButton
+                          key={r.id}
+                          methodId={m.admission_method_id}
+                          methodName={m.method_name}
+                          roundId={r.id}
+                          roundCode={r.round_code}
+                          onCreate={setCreateCell}
+                        />
                       )
                     }
                     return (
-                      <TableCell key={r.id} className="p-1">
-                        <button
-                          onClick={() => setOpenPathId(cell.path_id)}
-                          className="w-full text-left bg-blue-50 dark:bg-blue-950/40 hover:bg-blue-100 dark:hover:bg-blue-900/50 border border-blue-200 dark:border-blue-800 rounded-md px-2 py-1.5 transition-colors"
-                          aria-label={`Mở chi tiết ${m.method_name} đợt ${r.round_code}: trần admit ${cell.admit_quota ?? "chưa đặt"} trên cap năm ${matrix.annual_admission_quota ?? "không giới hạn"}, trạng thái ${pathStatusLabel(cell.status)}`}
-                        >
-                          <div className="text-xs font-semibold tabular-nums">
-                            {cell.admit_quota ?? "—"} / {matrix.annual_admission_quota ?? "∞"}
-                          </div>
-                          <div className="text-[11px] text-muted-foreground tabular-nums">
-                            Submit {cell.round_quota ?? "—"}
-                          </div>
-                          <div className="text-[11px]">
-                            <Badge
-                              variant={cell.status === "active" ? "default" : "outline"}
-                              className="text-[10px] h-4 px-1"
-                            >
-                              {pathStatusLabel(cell.status)}
-                            </Badge>
-                          </div>
-                        </button>
-                      </TableCell>
+                      <PathCellButton
+                        key={r.id}
+                        pathId={cell.path_id}
+                        admitQuota={cell.admit_quota}
+                        roundQuota={cell.round_quota}
+                        status={cell.status}
+                        methodName={m.method_name}
+                        roundCode={r.round_code}
+                        annualCap={matrix.annual_admission_quota}
+                        onOpen={setOpenPathId}
+                      />
                     )
                   })}
                   <TableCell className="text-right font-medium tabular-nums">
@@ -266,3 +260,91 @@ export function ByMajorView({ academicYear, onYearChange }: Props) {
     </Card>
   )
 }
+
+// ============================================================================
+// Pass 2 hard-review FM-5: memoize cell buttons để tránh re-create closures +
+// re-render toàn matrix khi 1 cell update (vd user edit cell A, all other
+// cells re-render mặc dù props không đổi). React.memo + stable callback từ
+// parent (setOpenPathId / setCreateCell stable qua useCallback) skip re-render.
+// ============================================================================
+
+interface PathCellProps {
+  pathId: number
+  admitQuota: number | null | undefined
+  roundQuota: number | null | undefined
+  status: "draft" | "active" | "inactive" | "archived"
+  methodName: string
+  roundCode: string
+  annualCap: number | null | undefined
+  onOpen: (id: number) => void
+}
+
+const PathCellButton = memo(function PathCellButton({
+  pathId,
+  admitQuota,
+  roundQuota,
+  status,
+  methodName,
+  roundCode,
+  annualCap,
+  onOpen,
+}: PathCellProps) {
+  const handleClick = useCallback(() => onOpen(pathId), [onOpen, pathId])
+  return (
+    <TableCell className="p-1">
+      <button
+        onClick={handleClick}
+        className="w-full text-left bg-blue-50 dark:bg-blue-950/40 hover:bg-blue-100 dark:hover:bg-blue-900/50 border border-blue-200 dark:border-blue-800 rounded-md px-2 py-1.5 transition-colors"
+        aria-label={`Mở chi tiết ${methodName} đợt ${roundCode}: trần admit ${admitQuota ?? "chưa đặt"} trên cap năm ${annualCap ?? "không giới hạn"}, trạng thái ${pathStatusLabel(status)}`}
+      >
+        <div className="text-xs font-semibold tabular-nums">
+          {admitQuota ?? "—"} / {annualCap ?? "∞"}
+        </div>
+        <div className="text-[11px] text-muted-foreground tabular-nums">
+          Submit {roundQuota ?? "—"}
+        </div>
+        <div className="text-[11px]">
+          <Badge
+            variant={status === "active" ? "default" : "outline"}
+            className="text-[10px] h-4 px-1"
+          >
+            {pathStatusLabel(status)}
+          </Badge>
+        </div>
+      </button>
+    </TableCell>
+  )
+})
+
+interface EmptyCellProps {
+  methodId: number
+  methodName: string
+  roundId: number
+  roundCode: string
+  onCreate: (cell: { methodId: number; methodName: string; roundId: number; roundCode: string }) => void
+}
+
+const EmptyCellButton = memo(function EmptyCellButton({
+  methodId,
+  methodName,
+  roundId,
+  roundCode,
+  onCreate,
+}: EmptyCellProps) {
+  const handleClick = useCallback(
+    () => onCreate({ methodId, methodName, roundId, roundCode }),
+    [onCreate, methodId, methodName, roundId, roundCode],
+  )
+  return (
+    <TableCell className="p-1 text-center">
+      <button
+        onClick={handleClick}
+        className="text-xs text-muted-foreground hover:text-foreground hover:bg-muted rounded px-2 py-1.5 w-full transition-colors"
+        aria-label={`Tạo đường tuyển sinh ${methodName} đợt ${roundCode}`}
+      >
+        + Tạo
+      </button>
+    </TableCell>
+  )
+})
+

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.tsx
@@ -8,7 +8,8 @@
 "use client"
 
 import { AlertTriangle } from "lucide-react"
-import { useEffect, useState } from "react"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -46,7 +47,31 @@ export function ByMajorView({ academicYear, onYearChange }: Props) {
   const { data: globalData } = useQuotaMatrix(academicYear)
   const [selectedAcademicInfoId, setSelectedAcademicInfoId] = useState<number | undefined>(undefined)
   const { data: matrix, isLoading } = usePathMatrixByMajor(selectedAcademicInfoId)
-  const [openPathId, setOpenPathId] = useState<number | null>(null)
+
+  // Pass 2 hard-review F-2-1: URL state sync cho openPathId.
+  // Drawer state là URL state theo Frontend CLAUDE.md ("URL State: Filters,
+  // pagination") — admin share link mở thẳng path detail, browser
+  // back/forward navigate giữa các drawer mở/đóng.
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const openPathId = useMemo(() => {
+    const raw = searchParams.get("pathId")
+    if (!raw) return null
+    const n = Number(raw)
+    return Number.isFinite(n) && n > 0 ? n : null
+  }, [searchParams])
+  const setOpenPathId = useCallback(
+    (id: number | null) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (id === null) params.delete("pathId")
+      else params.set("pathId", id.toString())
+      const qs = params.toString()
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+    },
+    [pathname, router, searchParams],
+  )
+
   const [createCell, setCreateCell] = useState<{
     methodId: number
     methodName: string

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ClonePathsDialog.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ClonePathsDialog.tsx
@@ -1,0 +1,203 @@
+/**
+ * ClonePathsDialog — bulk clone paths source_round → target_round (Q6 deep-copy).
+ *
+ * Phase 2 v8.2 PR-2D.1 v4a — wrap BE endpoint
+ * POST /api/v2/admin/rounds/{target}/clone-paths-from/{source}.
+ *
+ * Atomic transaction server-side: deep-copy criteria + criteria_subject_group
+ * + admission_path + path_subject_group_config + items. ON CONFLICT skip.
+ */
+"use client"
+
+import { CheckCircle2, Loader2 } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useAdmissionRounds } from "@/hooks/admissions/useAdmissionRounds"
+import { useClonePathsFromRound } from "@/hooks/admissions/useClonePathsFromRound"
+
+interface AdmissionRound {
+  id: number
+  round_code: string
+  round_name: string
+}
+
+interface Props {
+  academicYear: number
+  onClose: () => void
+}
+
+export function ClonePathsDialog({ academicYear, onClose }: Props) {
+  const { data: roundsData, isLoading: loadingRounds } = useAdmissionRounds(academicYear)
+  const [sourceRoundId, setSourceRoundId] = useState<number | null>(null)
+  const [targetRoundId, setTargetRoundId] = useState<number | null>(null)
+  const [template, setTemplate] = useState("{source_code}_{round_code}")
+  const cloneMutation = useClonePathsFromRound()
+
+  const rounds: AdmissionRound[] = roundsData?.items ?? []
+
+  const handleClone = async () => {
+    if (!sourceRoundId || !targetRoundId) {
+      toast.error("Vui lòng chọn cả đợt nguồn và đợt đích.")
+      return
+    }
+    if (sourceRoundId === targetRoundId) {
+      toast.error("Đợt nguồn và đợt đích phải khác nhau.")
+      return
+    }
+    try {
+      const result = await cloneMutation.mutateAsync({
+        targetRoundId,
+        sourceRoundId,
+        payload: {
+          academic_info_ids: null,
+          criteria_code_template: template.trim() || null,
+        },
+      })
+      toast.success(
+        `Đã sao chép ${result.cloned_count} đường (bỏ qua ${result.skipped_count} đường đã tồn tại).`,
+      )
+      onClose()
+    } catch (e: unknown) {
+      const msg =
+        (e as { response?: { data?: { detail?: string } } }).response?.data?.detail ??
+        (e instanceof Error ? e.message : "Lỗi sao chép — kiểm tra dữ liệu và thử lại.")
+      toast.error(msg)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-pretty">Sao chép đường tuyển sinh giữa các đợt</DialogTitle>
+          <DialogDescription>
+            Sao chép sâu toàn bộ đường tuyển sinh từ đợt nguồn sang đợt đích cùng năm {academicYear}.
+            Đường đã tồn tại ở đợt đích sẽ tự động bỏ qua (ràng buộc 3-cột duy nhất).
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="source-round">
+              Đợt nguồn{" "}
+              <span className="text-destructive" aria-hidden="true">*</span>
+              <span className="sr-only"> (bắt buộc)</span>
+            </Label>
+            <Select
+              value={sourceRoundId?.toString() ?? ""}
+              onValueChange={(v) => setSourceRoundId(Number(v))}
+              disabled={loadingRounds}
+            >
+              <SelectTrigger id="source-round">
+                <SelectValue placeholder="Chọn đợt nguồn…" />
+              </SelectTrigger>
+              <SelectContent>
+                {rounds.map((r) => (
+                  <SelectItem key={r.id} value={r.id.toString()}>
+                    <span translate="no">{r.round_code}</span> — {r.round_name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="target-round">
+              Đợt đích{" "}
+              <span className="text-destructive" aria-hidden="true">*</span>
+              <span className="sr-only"> (bắt buộc)</span>
+            </Label>
+            <Select
+              value={targetRoundId?.toString() ?? ""}
+              onValueChange={(v) => setTargetRoundId(Number(v))}
+              disabled={loadingRounds}
+            >
+              <SelectTrigger id="target-round">
+                <SelectValue placeholder="Chọn đợt đích…" />
+              </SelectTrigger>
+              <SelectContent>
+                {rounds
+                  .filter((r) => r.id !== sourceRoundId)
+                  .map((r) => (
+                    <SelectItem key={r.id} value={r.id.toString()}>
+                      <span translate="no">{r.round_code}</span> — {r.round_name}
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="template">Mẫu mã tiêu chí</Label>
+            <Input
+              id="template"
+              name="criteria_code_template"
+              value={template}
+              onChange={(e) => setTemplate(e.target.value)}
+              placeholder="{source_code}_{round_code}"
+              className="font-mono text-xs"
+              autoComplete="off"
+              spellCheck={false}
+              translate="no"
+            />
+            <p className="text-[11px] text-muted-foreground">
+              Biến thay thế:{" "}
+              <code translate="no">{`{source_code}`}</code>,{" "}
+              <code translate="no">{`{round_code}`}</code>. Bỏ trống = dùng mẫu mặc định.
+            </p>
+          </div>
+
+          <div className="rounded-md border bg-emerald-500/5 border-emerald-500/30 p-3 text-xs flex gap-2">
+            <CheckCircle2 className="h-4 w-4 text-emerald-600 shrink-0 mt-0.5" aria-hidden="true" />
+            <div>
+              <div className="font-medium">Sao chép sâu, nguyên vẹn</div>
+              <p className="text-muted-foreground mt-0.5">
+                Máy chủ sao chép đầy đủ: tiêu chí, tổ hợp môn, cấu hình đường tuyển sinh.
+                Chỉ tiêu (trần submit/admit) reset rỗng — admin tự đặt lại trên ma trận.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={cloneMutation.isPending}
+          >
+            Huỷ
+          </Button>
+          <Button
+            onClick={handleClone}
+            disabled={cloneMutation.isPending}
+            aria-busy={cloneMutation.isPending}
+          >
+            {cloneMutation.isPending && (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+            )}
+            Sao chép
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/GlobalMatrixView.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/GlobalMatrixView.test.tsx
@@ -4,11 +4,13 @@
  * Anchor tests per memory pattern-change-impact-audit.
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { render, screen } from "@testing-library/react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 
 import { GlobalMatrixView } from "./GlobalMatrixView"
+
 
 vi.mock("@/hooks/admissions/useQuotaMatrix", () => ({
   useQuotaMatrix: () => ({
@@ -43,6 +45,12 @@ vi.mock("@/hooks/admissions/useQuotaMatrix", () => ({
     },
     isLoading: false,
     isError: false,
+  }),
+  // Pass 2 hard-review F-2-2: AggregateDrawer (nested) dùng cùng module —
+  // mock minimal shape để drawer render khi user click cell mở tổng hợp.
+  usePathMatrixByMajor: () => ({
+    data: undefined,
+    isLoading: true,
   }),
 }))
 
@@ -91,5 +99,23 @@ describe("GlobalMatrixView", () => {
     )
     expect(hasCellButton).toBe(true)
     expect(container.querySelectorAll("input[type='number']").length).toBe(0)
+  })
+
+  // Pass 2 hard-review F-2-2: cell click → AggregateDrawer mở với context
+  // đúng (academicInfoId + roundId + programName + roundCode). Tránh
+  // regression khi refactor cell-to-drawer dispatch.
+  it("ANCHOR (cell click → AggregateDrawer): mở drawer với context ngành+đợt", async () => {
+    const user = userEvent.setup()
+    render(
+      wrap(<GlobalMatrixView academicYear={2026} onYearChange={() => {}} />),
+    )
+    // Click aggregate cell — aria-label chứa "Mở tổng hợp" + program_name + đợt.
+    const cellButton = screen.getByLabelText(/Mở tổng hợp Công nghệ thông tin đợt DOT_1/)
+    await user.click(cellButton)
+    // AggregateDrawer hiển thị header với program_name + roundCode.
+    await waitFor(() => {
+      // Drawer header chứa "Đợt" + program_name + DOT_1.
+      expect(screen.getAllByText(/DOT_1/).length).toBeGreaterThan(0)
+    })
   })
 })

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/GlobalMatrixView.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/GlobalMatrixView.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Vitest tests cho GlobalMatrixView (Phase 2 v8.2 PR-2D.1 v3).
+ *
+ * Anchor tests per memory pattern-change-impact-audit.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { GlobalMatrixView } from "./GlobalMatrixView"
+
+vi.mock("@/hooks/admissions/useQuotaMatrix", () => ({
+  useQuotaMatrix: () => ({
+    data: {
+      academic_year: 2026,
+      total_rows: 1,
+      rounds: [
+        { id: 1, round_code: "DOT_1", round_name: "Đợt 1", is_active: true },
+      ],
+      rows: [
+        {
+          academic_info_id: 70,
+          academic_year: 2026,
+          program_name: "Công nghệ thông tin",
+          program_code: "CNTT",
+          degree_level: "DH",
+          annual_admission_quota: 100,
+          sum_admit_allocated: 30,
+          sum_remaining: 70,
+          cells_by_round_id: {
+            1: {
+              admission_round_id: 1,
+              round_code: "DOT_1",
+              total_admit_quota: 30,
+              total_round_quota: 50,
+              total_submission_count: 5,
+              path_count: 2,
+            },
+          },
+        },
+      ],
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}))
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+}
+
+describe("GlobalMatrixView", () => {
+  it("renders matrix title + year + total badge", () => {
+    render(
+      wrap(<GlobalMatrixView academicYear={2026} onYearChange={() => {}} />),
+    )
+    expect(screen.getByText(/Ma trận toàn cảnh năm 2026/)).toBeTruthy()
+    expect(screen.getByText(/1 ngành × 1 đợt/)).toBeTruthy()
+  })
+
+  it("renders aggregate cell theo contract 3-line: Admit/Annual + Submit + path_count", () => {
+    render(
+      wrap(<GlobalMatrixView academicYear={2026} onYearChange={() => {}} />),
+    )
+    // Cell aggregate dòng 1: total_admit_quota / annual_admission_quota
+    expect(screen.getByText(/30 \/ 100/)).toBeTruthy()
+    // Cell aggregate dòng 2: Submit cap
+    expect(screen.getByText(/Submit 50/)).toBeTruthy()
+    // Cell aggregate dòng 3: path_count
+    expect(screen.getByText(/2 đường/)).toBeTruthy()
+  })
+
+  it("ANCHOR: shows ngành column với program_code", () => {
+    render(
+      wrap(<GlobalMatrixView academicYear={2026} onYearChange={() => {}} />),
+    )
+    expect(screen.getByText("Công nghệ thông tin")).toBeTruthy()
+    expect(screen.getByText("CNTT")).toBeTruthy()
+  })
+
+  it("ANCHOR (cell read-only): cell rendered as button (not input/select)", () => {
+    const { container } = render(
+      wrap(<GlobalMatrixView academicYear={2026} onYearChange={() => {}} />),
+    )
+    // Cell phải render như button drill-down — không có input cho inline edit
+    const cellButtons = container.querySelectorAll("button")
+    const hasCellButton = Array.from(cellButtons).some((b) =>
+      b.textContent?.includes("Submit"),
+    )
+    expect(hasCellButton).toBe(true)
+    expect(container.querySelectorAll("input[type='number']").length).toBe(0)
+  })
+})

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/GlobalMatrixView.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/GlobalMatrixView.tsx
@@ -1,0 +1,223 @@
+/**
+ * GlobalMatrixView — Ma trận toàn cảnh (power mode).
+ *
+ * Rows = academic_info × academic_year, cols = rounds, cells = aggregate.
+ * Cell read-only, click → AggregateDrawer.
+ */
+"use client"
+
+import { AlertTriangle } from "lucide-react"
+import { useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { useQuotaMatrix } from "@/hooks/admissions/useQuotaMatrix"
+
+import { AggregateDrawer } from "./AggregateDrawer"
+
+const CURRENT_YEAR = new Date().getFullYear()
+const YEAR_OPTIONS = [CURRENT_YEAR - 1, CURRENT_YEAR, CURRENT_YEAR + 1, CURRENT_YEAR + 2]
+
+interface Props {
+  academicYear: number
+  onYearChange: (year: number) => void
+}
+
+export function GlobalMatrixView({ academicYear, onYearChange }: Props) {
+  const { data, isLoading, isError } = useQuotaMatrix(academicYear)
+  const [openCell, setOpenCell] = useState<{
+    academicInfoId: number
+    roundId: number
+    programName: string
+    roundCode: string
+  } | null>(null)
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
+        <div>
+          <CardTitle className="text-base text-pretty">
+            Ma trận toàn cảnh năm {academicYear}
+          </CardTitle>
+          <p className="text-xs text-muted-foreground mt-1">
+            Tổng quan chỉ đọc · bấm ô để xem chi tiết &amp; chỉnh chỉ tiêu.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select value={academicYear.toString()} onValueChange={(v) => onYearChange(Number(v))}>
+            <SelectTrigger className="w-32"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {YEAR_OPTIONS.map((y) => (
+                <SelectItem key={y} value={y.toString()}>{y}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {data && (
+            <Badge variant="outline">
+              {data.total_rows} ngành × {data.rounds.length} đợt
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="text-sm text-muted-foreground" aria-live="polite">
+            Đang tải…
+          </div>
+        )}
+        {isError && (
+          <div className="text-sm text-destructive">Lỗi tải dữ liệu.</div>
+        )}
+        {data && data.rows.length === 0 && (
+          <div className="text-sm text-muted-foreground">
+            Chưa có ngành nào được công bố cho năm {academicYear}.
+          </div>
+        )}
+        {data && data.rows.length > 0 && (
+          <TooltipProvider delayDuration={200}>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Ngành</TableHead>
+                    <TableHead className="text-center">Bậc</TableHead>
+                    <TableHead className="text-right">Cap năm</TableHead>
+                    <TableHead className="text-right">Đã rải</TableHead>
+                    <TableHead className="text-right">Còn lại</TableHead>
+                    {data.rounds.map((r) => (
+                      <TableHead key={r.id} className="text-center min-w-[120px]" translate="no">
+                        {r.round_code}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.rows.map((row) => {
+                    const isOver = row.sum_remaining !== null && row.sum_remaining < 0
+                    return (
+                      <TableRow
+                        key={row.academic_info_id}
+                        className={isOver ? "bg-destructive/5" : ""}
+                      >
+                        <TableCell>
+                          <div className="font-medium">{row.program_name}</div>
+                          {row.program_code && (
+                            <div className="text-xs text-muted-foreground">{row.program_code}</div>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <Badge variant="outline" className="text-xs">
+                            {row.degree_level ?? "—"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right font-medium">
+                          {row.annual_admission_quota ?? (
+                            <span className="text-muted-foreground italic">∞</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right">{row.sum_admit_allocated}</TableCell>
+                        <TableCell className="text-right">
+                          {row.sum_remaining === null ? (
+                            <span className="text-muted-foreground italic">∞</span>
+                          ) : isOver ? (
+                            <span className="text-destructive font-semibold inline-flex items-center gap-1">
+                              <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+                              {row.sum_remaining}
+                            </span>
+                          ) : (
+                            <span className="text-emerald-600 font-medium">{row.sum_remaining}</span>
+                          )}
+                        </TableCell>
+                        {data.rounds.map((r) => {
+                          const cell = row.cells_by_round_id[r.id]
+                          if (!cell) {
+                            return (
+                              <TableCell key={r.id} className="text-center text-xs text-muted-foreground">
+                                —
+                              </TableCell>
+                            )
+                          }
+                          return (
+                            <TableCell key={r.id} className="p-1">
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <button
+                                    onClick={() =>
+                                      setOpenCell({
+                                        academicInfoId: row.academic_info_id,
+                                        roundId: r.id,
+                                        programName: row.program_name,
+                                        roundCode: r.round_code,
+                                      })
+                                    }
+                                    className="w-full text-left bg-blue-50 dark:bg-blue-950/40 hover:bg-blue-100 dark:hover:bg-blue-900/50 border border-blue-200 dark:border-blue-800 rounded-md px-2 py-1.5 transition-colors"
+                                    aria-label={`Mở tổng hợp ${row.program_name} đợt ${r.round_code}: tổng admit ${cell.total_admit_quota}, tổng submit ${cell.total_round_quota}, ${cell.path_count} đường tuyển sinh`}
+                                  >
+                                    <div className="text-xs font-semibold tabular-nums">
+                                      {cell.total_admit_quota} / {row.annual_admission_quota ?? "∞"}
+                                    </div>
+                                    <div className="text-[11px] text-muted-foreground tabular-nums">
+                                      Submit {cell.total_round_quota}
+                                    </div>
+                                    <div className="text-[11px] text-muted-foreground">
+                                      {cell.path_count} đường
+                                    </div>
+                                  </button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                  <div className="text-xs">
+                                    <div className="font-medium mb-1">
+                                      {row.program_name}
+                                      <span aria-hidden="true"> × </span>
+                                      <span translate="no">{r.round_code}</span>
+                                    </div>
+                                    <div>Bấm để xem &amp; chỉnh chi tiết theo phương thức.</div>
+                                  </div>
+                                </TooltipContent>
+                              </Tooltip>
+                            </TableCell>
+                          )
+                        })}
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          </TooltipProvider>
+        )}
+      </CardContent>
+
+      {openCell && (
+        <AggregateDrawer
+          academicInfoId={openCell.academicInfoId}
+          roundId={openCell.roundId}
+          programName={openCell.programName}
+          roundCode={openCell.roundCode}
+          onClose={() => setOpenCell(null)}
+        />
+      )}
+    </Card>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/GlobalMatrixView.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/GlobalMatrixView.tsx
@@ -3,6 +3,12 @@
  *
  * Rows = academic_info × academic_year, cols = rounds, cells = aggregate.
  * Cell read-only, click → AggregateDrawer.
+ *
+ * FM-5 follow-up: memoize cell button pending. Tooltip wrapper (Radix)
+ * trigger asChild render-prop khiến memoization phức tạp hơn ByMajorView;
+ * cần đo perf trên schema thực (20 ngành × 4 đợt = 80 cells) trước khi
+ * extract component. ByMajorView (240 cells / 1 method × round) đã memoize
+ * trong CHECKPOINT 6.
  */
 "use client"
 

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Vitest tests cho PathDetailDrawer 5-tab (Phase 2 v8.2 PR-2D.1 v4a).
+ *
+ * Anchor:
+ * - 5 tabs render
+ * - Quota tab client guard (admit ≤ round)
+ * - Identity tab can_edit gate
+ * - Lifecycle tab can_activate gate (thin-client)
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ReactNode } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const hoisted = vi.hoisted(() => {
+  const defaultPath = {
+    id: 109,
+    display_name: "CNTT - Học bạ",
+    status: "draft",
+    can_edit: true,
+    can_activate: false,
+    validation_errors: [] as string[],
+    round_quota: 50,
+    admit_quota: 30,
+    submission_count: 5,
+    display_order: 1,
+    visibility: "public",
+    application_fee: null,
+    allow_unverified_submission: false,
+    criteria: { id: 200, code: "HB2026_CNTT" },
+    admission_method: { id: 1, code: "hoc_ba" },
+    admission_method_id: 1,
+  }
+  return {
+    defaultPath,
+    mockUseAdmissionPath: vi.fn(() => ({ data: defaultPath, isLoading: false })),
+    mockUpdateQuota: vi.fn(),
+    mockUpdatePath: vi.fn(),
+    mockActivate: vi.fn(),
+    mockDeactivate: vi.fn(),
+  }
+})
+
+vi.mock("@/hooks/admissions/useAdmissionPaths", () => ({
+  admissionPathKeys: { all: ["admission-paths"] },
+  useAdmissionPath: hoisted.mockUseAdmissionPath,
+  useUpdateAdmissionPath: () => ({ mutateAsync: hoisted.mockUpdatePath, isPending: false }),
+  useActivateAdmissionPath: () => ({ mutateAsync: hoisted.mockActivate, isPending: false }),
+  useDeactivateAdmissionPath: () => ({ mutateAsync: hoisted.mockDeactivate, isPending: false }),
+}))
+
+vi.mock("@/hooks/admissions/useQuotaMatrix", () => ({
+  quotaMatrixKeys: { all: ["quota-matrix"] },
+  useUpdatePathQuota: () => ({ mutateAsync: hoisted.mockUpdateQuota, isPending: false }),
+}))
+
+vi.mock("../ConfigCriteria", () => ({
+  ConfigCriteria: () => <div data-testid="config-criteria-stub">criteria form</div>,
+}))
+vi.mock("../ConfigDocuments", () => ({
+  ConfigDocuments: () => <div data-testid="config-documents-stub">documents form</div>,
+}))
+
+const toastError = vi.fn()
+const toastSuccess = vi.fn()
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+  },
+}))
+
+import { PathDetailDrawer } from "./PathDetailDrawer"
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+}
+
+beforeEach(() => {
+  hoisted.mockUpdateQuota.mockReset()
+  hoisted.mockUpdatePath.mockReset()
+  hoisted.mockActivate.mockReset()
+  hoisted.mockDeactivate.mockReset()
+  toastError.mockReset()
+  toastSuccess.mockReset()
+  // Reset path mock to default; per-test override với mockReturnValue if needed
+  hoisted.mockUseAdmissionPath.mockReturnValue({
+    data: hoisted.defaultPath,
+    isLoading: false,
+  })
+})
+
+describe("PathDetailDrawer 5-tab", () => {
+  it("renders 5 tabs + path display_name in header", () => {
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+    expect(screen.getByText("CNTT - Học bạ")).toBeTruthy()
+    expect(screen.getByRole("tab", { name: /Chỉ tiêu/ })).toBeTruthy()
+    expect(screen.getByRole("tab", { name: /Định danh/ })).toBeTruthy()
+    expect(screen.getByRole("tab", { name: /Tiêu chí/ })).toBeTruthy()
+    expect(screen.getByRole("tab", { name: /Giấy tờ/ })).toBeTruthy()
+    expect(screen.getByRole("tab", { name: /Vòng đời/ })).toBeTruthy()
+  })
+
+  it("ANCHOR (Quota tab client guard): blocks save khi admit > round", async () => {
+    const user = userEvent.setup()
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    const submitInput = screen.getByLabelText(/Trần submit/) as HTMLInputElement
+    const admitInput = screen.getByLabelText(/Trần admit/) as HTMLInputElement
+
+    await user.clear(submitInput)
+    await user.type(submitInput, "10")
+    await user.clear(admitInput)
+    await user.type(admitInput, "50")
+
+    await user.click(screen.getByRole("button", { name: /Lưu chỉ tiêu/ }))
+    expect(toastError).toHaveBeenCalledWith(
+      "Trần admit phải ≤ trần submit. Giảm trần admit hoặc tăng trần submit.",
+    )
+    expect(hoisted.mockUpdateQuota).not.toHaveBeenCalled()
+  })
+
+  it("ANCHOR (thin-client can_edit=false): Quota inputs disabled, save button disabled", () => {
+    hoisted.mockUseAdmissionPath.mockReturnValue({
+      data: { ...hoisted.defaultPath, can_edit: false },
+      isLoading: false,
+    })
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    const submitInput = screen.getByLabelText(/Trần submit/) as HTMLInputElement
+    expect(submitInput.disabled).toBe(true)
+    const saveBtn = screen.getByRole("button", { name: /Lưu chỉ tiêu/ }) as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+  })
+
+  it("ANCHOR (thin-client can_activate=false): Activate button disabled, validation_errors render từ API", async () => {
+    hoisted.mockUseAdmissionPath.mockReturnValue({
+      data: {
+        ...hoisted.defaultPath,
+        status: "draft",
+        can_activate: false,
+        validation_errors: ["Missing criteria"],
+      },
+      isLoading: false,
+    })
+    const user = userEvent.setup()
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    await user.click(screen.getByRole("tab", { name: /Vòng đời/ }))
+
+    await waitFor(() => {
+      const activateBtn = screen.getByRole("button", {
+        name: /Kích hoạt/,
+      }) as HTMLButtonElement
+      expect(activateBtn.disabled).toBe(true)
+    })
+    expect(screen.getByText(/Missing criteria/)).toBeTruthy()
+  })
+
+  it("ANCHOR (status=active): shows Deactivate button, NOT Activate", async () => {
+    hoisted.mockUseAdmissionPath.mockReturnValue({
+      data: {
+        ...hoisted.defaultPath,
+        status: "active",
+        can_activate: true,
+      },
+      isLoading: false,
+    })
+    const user = userEvent.setup()
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    await user.click(screen.getByRole("tab", { name: /Vòng đời/ }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Vô hiệu hoá/ })).toBeTruthy()
+    })
+    expect(screen.queryByRole("button", { name: /Kích hoạt/ })).toBeNull()
+  })
+})

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
@@ -1,0 +1,566 @@
+/**
+ * PathDetailDrawer — chi tiết 1 path với 5 tabs configurator.
+ *
+ * Phase 2 v8.2 PR-2D.1 v4a — Option A merge: gộp wizard cũ vào drawer.
+ * Tabs: Chỉ tiêu / Định danh / Tiêu chí / Giấy tờ / Vòng đời.
+ *
+ * Thin-client: button visibility = path.can_edit / path.can_activate /
+ * path.available_actions từ API; KHÔNG check role; KHÔNG infer state.
+ */
+"use client"
+
+import { useQueryClient } from "@tanstack/react-query"
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Loader2,
+  Power,
+  PowerOff,
+  Save,
+  XCircle,
+} from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  useActivateAdmissionPath,
+  useAdmissionPath,
+  useDeactivateAdmissionPath,
+  useUpdateAdmissionPath,
+} from "@/hooks/admissions/useAdmissionPaths"
+import {
+  quotaMatrixKeys,
+  useUpdatePathQuota,
+} from "@/hooks/admissions/useQuotaMatrix"
+import type { AdmissionPathResponse } from "@/lib/zod/admission-path"
+
+import { ConfigCriteria } from "../ConfigCriteria"
+import { ConfigDocuments } from "../ConfigDocuments"
+import { pathStatusLabel } from "./labels"
+
+type PathLike = AdmissionPathResponse
+
+interface Props {
+  pathId: number
+  onClose: () => void
+}
+
+export function PathDetailDrawer({ pathId, onClose }: Props) {
+  const { data: path, isLoading } = useAdmissionPath(pathId)
+  const [tab, setTab] = useState<string>("quota")
+
+  return (
+    <Sheet open onOpenChange={(o) => { if (!o) onClose() }}>
+      <SheetContent className="sm:max-w-3xl w-full flex flex-col overflow-hidden">
+        <SheetHeader className="pr-8">
+          <SheetTitle className="text-pretty">
+            {path?.display_name || `Đường tuyển sinh #${pathId}`}
+          </SheetTitle>
+          <SheetDescription className="sr-only">
+            Cấu hình chi tiết đường tuyển sinh: chỉ tiêu, định danh, tiêu chí, giấy tờ, vòng đời.
+          </SheetDescription>
+          {path && (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span translate="no">
+                {path.admission_method?.code ?? `method ${path.admission_method_id}`}
+              </span>
+              <span aria-hidden="true">·</span>
+              <Badge
+                variant={path.status === "active" ? "default" : "outline"}
+                className="text-[10px] h-4 px-1"
+              >
+                {pathStatusLabel(path.status)}
+              </Badge>
+            </div>
+          )}
+        </SheetHeader>
+
+        {isLoading && (
+          <div className="flex items-center justify-center py-8" aria-live="polite">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-hidden="true" />
+            <span className="sr-only">Đang tải chi tiết đường tuyển sinh…</span>
+          </div>
+        )}
+
+        {path && (
+          <Tabs value={tab} onValueChange={setTab} className="flex-1 flex flex-col min-h-0">
+            <TabsList className="grid grid-cols-5 shrink-0">
+              <TabsTrigger value="quota">Chỉ tiêu</TabsTrigger>
+              <TabsTrigger value="identity">Định danh</TabsTrigger>
+              <TabsTrigger value="criteria">Tiêu chí</TabsTrigger>
+              <TabsTrigger value="documents">Giấy tờ</TabsTrigger>
+              <TabsTrigger value="lifecycle">Vòng đời</TabsTrigger>
+            </TabsList>
+
+            <div className="flex-1 min-h-0 overflow-y-auto py-4">
+              <TabsContent value="quota">
+                <QuotaTab path={path} pathId={pathId} onClose={onClose} />
+              </TabsContent>
+              <TabsContent value="identity">
+                <IdentityTab path={path} pathId={pathId} onClose={onClose} />
+              </TabsContent>
+              <TabsContent value="criteria">
+                <ConfigCriteria
+                  path={path}
+                  onNext={onClose}
+                  onBack={onClose}
+                  embedded
+                />
+              </TabsContent>
+              <TabsContent value="documents">
+                <ConfigDocuments
+                  path={path}
+                  onFinish={onClose}
+                  onBack={onClose}
+                  embedded
+                />
+              </TabsContent>
+              <TabsContent value="lifecycle">
+                <LifecycleTab path={path} pathId={pathId} onClose={onClose} />
+              </TabsContent>
+            </div>
+          </Tabs>
+        )}
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+// ============================================================================
+// Tab: Chỉ tiêu (Quota)
+// ============================================================================
+
+function QuotaTab({
+  path,
+  pathId,
+  onClose,
+}: {
+  path: PathLike
+  pathId: number
+  onClose: () => void
+}) {
+  const [roundQuota, setRoundQuota] = useState(path.round_quota?.toString() ?? "")
+  const [admitQuota, setAdmitQuota] = useState(path.admit_quota?.toString() ?? "")
+  const updateMutation = useUpdatePathQuota()
+
+  const handleSave = async () => {
+    const rq = roundQuota.trim() === "" ? null : Number(roundQuota)
+    const aq = admitQuota.trim() === "" ? null : Number(admitQuota)
+    if (rq !== null && aq !== null && aq > rq) {
+      toast.error("Trần admit phải ≤ trần submit. Giảm trần admit hoặc tăng trần submit.")
+      return
+    }
+    try {
+      await updateMutation.mutateAsync({
+        pathId,
+        data: { round_quota: rq, admit_quota: aq },
+      })
+      toast.success("Đã lưu chỉ tiêu")
+      onClose()
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Lỗi lưu — kiểm tra mạng và thử lại."
+      toast.error(msg)
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="round-quota">Trần submit (số hồ sơ tối đa)</Label>
+          <Input
+            id="round-quota"
+            name="round_quota"
+            type="number"
+            inputMode="numeric"
+            min="0"
+            value={roundQuota}
+            onChange={(e) => setRoundQuota(e.target.value)}
+            placeholder="∞"
+            autoComplete="off"
+            disabled={!path.can_edit}
+          />
+          <p className="text-[11px] text-muted-foreground">
+            Bỏ trống = không giới hạn số hồ sơ nộp.
+          </p>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="admit-quota">Trần admit (số trúng tuyển tối đa)</Label>
+          <Input
+            id="admit-quota"
+            name="admit_quota"
+            type="number"
+            inputMode="numeric"
+            min="0"
+            value={admitQuota}
+            onChange={(e) => setAdmitQuota(e.target.value)}
+            placeholder="—"
+            autoComplete="off"
+            disabled={!path.can_edit}
+          />
+          <p className="text-[11px] text-muted-foreground">
+            Tier 1 ràng buộc với cap năm của ngành.
+          </p>
+        </div>
+      </div>
+      <div className="rounded-md border bg-muted/40 p-3 text-xs space-y-1">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Đã nộp:</span>
+          <span className="font-medium tabular-nums">{path.submission_count}</span>
+        </div>
+        <div className="text-muted-foreground">
+          Tier 1 (admit ≤ cap năm) &amp; Tier 2 (admit ≤ submit) sẽ kiểm tra ở máy chủ.
+        </div>
+      </div>
+      <div className="flex justify-end gap-2 border-t pt-3">
+        <Button variant="outline" onClick={onClose}>Đóng</Button>
+        <Button
+          onClick={handleSave}
+          disabled={!path.can_edit || updateMutation.isPending}
+          aria-busy={updateMutation.isPending}
+        >
+          {updateMutation.isPending ? (
+            <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+          ) : (
+            <Save className="h-4 w-4 mr-1" aria-hidden="true" />
+          )}
+          Lưu chỉ tiêu
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Tab: Định danh (Identity)
+// ============================================================================
+
+function IdentityTab({
+  path,
+  pathId,
+  onClose,
+}: {
+  path: PathLike
+  pathId: number
+  onClose: () => void
+}) {
+  const [displayName, setDisplayName] = useState(path.display_name ?? "")
+  const [displayOrder, setDisplayOrder] = useState(path.display_order.toString())
+  const [visibility, setVisibility] = useState<string>(path.visibility)
+  const [applicationFee, setApplicationFee] = useState(
+    path.application_fee?.toString() ?? "",
+  )
+  const [allowUnverified, setAllowUnverified] = useState(path.allow_unverified_submission)
+  const updateMutation = useUpdateAdmissionPath()
+
+  const handleSave = async () => {
+    try {
+      await updateMutation.mutateAsync({
+        pathId,
+        data: {
+          display_name: displayName.trim() || null,
+          display_order: Number(displayOrder),
+          visibility: visibility as "public" | "internal",
+          application_fee:
+            applicationFee.trim() === "" ? null : Number(applicationFee),
+          allow_unverified_submission: allowUnverified,
+        },
+      })
+      toast.success("Đã lưu định danh")
+      onClose()
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Lỗi lưu — kiểm tra mạng và thử lại."
+      toast.error(msg)
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-1.5">
+        <Label htmlFor="display-name">Tên hiển thị</Label>
+        <Input
+          id="display-name"
+          name="display_name"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          autoComplete="off"
+          spellCheck={false}
+          disabled={!path.can_edit}
+          placeholder="VD: CNTT 2026 — Học bạ…"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="display-order">Thứ tự hiển thị</Label>
+          <Input
+            id="display-order"
+            name="display_order"
+            type="number"
+            inputMode="numeric"
+            min="0"
+            value={displayOrder}
+            onChange={(e) => setDisplayOrder(e.target.value)}
+            autoComplete="off"
+            disabled={!path.can_edit}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="visibility">Phạm vi hiển thị</Label>
+          <Select
+            value={visibility}
+            onValueChange={setVisibility}
+            disabled={!path.can_edit}
+          >
+            <SelectTrigger id="visibility"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="public">Công khai (storefront)</SelectItem>
+              <SelectItem value="internal">Nội bộ (chỉ admin)</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="app-fee">Lệ phí xét tuyển (VND)</Label>
+        <Input
+          id="app-fee"
+          name="application_fee"
+          type="number"
+          inputMode="numeric"
+          min="0"
+          value={applicationFee}
+          onChange={(e) => setApplicationFee(e.target.value)}
+          placeholder="0 hoặc bỏ trống = miễn phí…"
+          autoComplete="off"
+          disabled={!path.can_edit}
+        />
+      </div>
+
+      <div className="flex items-start gap-2 rounded-md border p-3">
+        <Checkbox
+          id="allow-unverified"
+          checked={allowUnverified}
+          onCheckedChange={(checked) => setAllowUnverified(checked === true)}
+          disabled={!path.can_edit}
+          className="mt-0.5"
+        />
+        <div className="flex-1">
+          <Label htmlFor="allow-unverified" className="cursor-pointer">
+            Cho phép nộp khi chưa xác minh giấy tờ
+          </Label>
+          <p className="text-[11px] text-muted-foreground mt-0.5">
+            Chế độ legacy. Tắt = bắt buộc xác minh trước khi nộp.
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-md border bg-muted/40 p-3 text-xs space-y-1">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Phương thức:</span>
+          <span className="font-medium" translate="no">
+            {path.admission_method?.code ?? `#${path.admission_method_id}`}
+          </span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">Mã tiêu chí:</span>
+          <span className="font-medium font-mono text-[11px]" translate="no">
+            {path.criteria?.code ?? "—"}
+          </span>
+        </div>
+        <p className="text-muted-foreground mt-1">
+          Phương thức &amp; tiêu chí khoá sau khi tạo (3-col UNIQUE + invariant ADM-003).
+        </p>
+      </div>
+
+      <div className="flex justify-end gap-2 border-t pt-3">
+        <Button variant="outline" onClick={onClose}>Đóng</Button>
+        <Button
+          onClick={handleSave}
+          disabled={!path.can_edit || updateMutation.isPending}
+          aria-busy={updateMutation.isPending}
+        >
+          {updateMutation.isPending ? (
+            <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+          ) : (
+            <Save className="h-4 w-4 mr-1" aria-hidden="true" />
+          )}
+          Lưu định danh
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Tab: Vòng đời (Lifecycle)
+// ============================================================================
+
+function LifecycleTab({
+  path,
+  pathId,
+  onClose,
+}: {
+  path: PathLike
+  pathId: number
+  onClose: () => void
+}) {
+  const queryClient = useQueryClient()
+  const activateMutation = useActivateAdmissionPath()
+  const deactivateMutation = useDeactivateAdmissionPath()
+
+  const hasCriteria = path.criteria !== null
+  const hasQuota = path.admit_quota !== null && path.admit_quota > 0
+  const errors = path.validation_errors ?? []
+
+  const handleActivate = async () => {
+    try {
+      await activateMutation.mutateAsync(pathId)
+      queryClient.invalidateQueries({ queryKey: quotaMatrixKeys.all })
+      toast.success("Đã kích hoạt đường tuyển sinh")
+      onClose()
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Lỗi kích hoạt — kiểm tra checklist và thử lại."
+      toast.error(msg)
+    }
+  }
+
+  const handleDeactivate = async () => {
+    if (!confirm("Vô hiệu hoá đường tuyển sinh này? Storefront sẽ ẩn ngay.")) return
+    try {
+      await deactivateMutation.mutateAsync(pathId)
+      queryClient.invalidateQueries({ queryKey: quotaMatrixKeys.all })
+      toast.success("Đã vô hiệu hoá đường tuyển sinh")
+      onClose()
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Lỗi vô hiệu hoá — thử lại sau."
+      toast.error(msg)
+    }
+  }
+
+  const isActive = path.status === "active"
+  const isPending = activateMutation.isPending || deactivateMutation.isPending
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-2">
+        <Label className="text-xs text-muted-foreground">Trạng thái hiện tại</Label>
+        <div>
+          <Badge variant={isActive ? "default" : "outline"} className="text-sm">
+            {pathStatusLabel(path.status)}
+          </Badge>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-xs text-muted-foreground">
+          Checklist sẵn sàng kích hoạt
+        </Label>
+        <ul className="space-y-1.5 text-sm">
+          <ChecklistRow
+            ok={hasCriteria}
+            label="Đã cấu hình tiêu chí (tổ hợp môn + điểm sàn)"
+          />
+          <ChecklistRow
+            ok={hasQuota}
+            label={`Đã đặt trần admit (hiện tại: ${path.admit_quota ?? "—"})`}
+          />
+          {errors.length === 0 ? (
+            <ChecklistRow ok label="Không có lỗi xác thực từ máy chủ" />
+          ) : (
+            <li className="flex items-start gap-2 text-destructive">
+              <XCircle className="h-4 w-4 mt-0.5 shrink-0" aria-hidden="true" />
+              <div>
+                <div className="font-medium">Lỗi xác thực từ máy chủ</div>
+                <ul className="text-xs mt-0.5 space-y-0.5 ml-1">
+                  {errors.map((err, i) => (
+                    <li key={i}>• {err}</li>
+                  ))}
+                </ul>
+              </div>
+            </li>
+          )}
+        </ul>
+      </div>
+
+      {!path.can_activate && !isActive && (
+        <div className="rounded-md border border-amber-500/50 bg-amber-500/5 p-3 text-xs flex gap-2">
+          <AlertTriangle className="h-4 w-4 text-amber-600 shrink-0 mt-0.5" aria-hidden="true" />
+          <div>
+            <div className="font-medium text-amber-900 dark:text-amber-200">
+              Chưa thể kích hoạt
+            </div>
+            <p className="text-muted-foreground mt-0.5">
+              Hoàn tất checklist phía trên trước khi kích hoạt.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2 border-t pt-3">
+        <Button variant="outline" onClick={onClose}>Đóng</Button>
+        {isActive ? (
+          <Button
+            variant="destructive"
+            onClick={handleDeactivate}
+            disabled={isPending}
+            aria-busy={isPending}
+          >
+            {isPending ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+            ) : (
+              <PowerOff className="h-4 w-4 mr-1" aria-hidden="true" />
+            )}
+            Vô hiệu hoá
+          </Button>
+        ) : (
+          <Button
+            onClick={handleActivate}
+            disabled={!path.can_activate || isPending}
+            aria-busy={isPending}
+          >
+            {isPending ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+            ) : (
+              <Power className="h-4 w-4 mr-1" aria-hidden="true" />
+            )}
+            Kích hoạt
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function ChecklistRow({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <li className="flex items-start gap-2">
+      {ok ? (
+        <CheckCircle2 className="h-4 w-4 text-emerald-600 shrink-0 mt-0.5" aria-hidden="true" />
+      ) : (
+        <XCircle className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" aria-hidden="true" />
+      )}
+      <span className={ok ? "" : "text-muted-foreground"}>{label}</span>
+    </li>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
@@ -493,8 +493,8 @@ function LifecycleTab({
               <div>
                 <div className="font-medium">Lỗi xác thực từ máy chủ</div>
                 <ul className="text-xs mt-0.5 space-y-0.5 ml-1">
-                  {errors.map((err, i) => (
-                    <li key={i}>• {err}</li>
+                  {errors.map((err) => (
+                    <li key={err}>• {err}</li>
                   ))}
                 </ul>
               </div>

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
@@ -19,12 +19,21 @@ import {
   Save,
   XCircle,
 } from "lucide-react"
-import { useState } from "react"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useCallback, useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -65,9 +74,34 @@ interface Props {
   onClose: () => void
 }
 
+const VALID_TABS = ["quota", "identity", "criteria", "documents", "lifecycle"] as const
+type TabId = (typeof VALID_TABS)[number]
+
 export function PathDetailDrawer({ pathId, onClose }: Props) {
   const { data: path, isLoading } = useAdmissionPath(pathId)
-  const [tab, setTab] = useState<string>("quota")
+
+  // Pass 2 hard-review FM-2: tab active sync với ?tab= URL param.
+  // Reload page giữ tab user đang xem; share link mở thẳng tab cụ thể.
+  // Default = "quota" nếu URL không có hoặc invalid value.
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const tab: TabId = useMemo(() => {
+    const raw = searchParams.get("tab")
+    return (VALID_TABS as readonly string[]).includes(raw ?? "")
+      ? (raw as TabId)
+      : "quota"
+  }, [searchParams])
+  const setTab = useCallback(
+    (next: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (next === "quota") params.delete("tab")
+      else params.set("tab", next)
+      const qs = params.toString()
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
+    },
+    [pathname, router, searchParams],
+  )
 
   return (
     <Sheet open onOpenChange={(o) => { if (!o) onClose() }}>
@@ -438,6 +472,9 @@ function LifecycleTab({
   const queryClient = useQueryClient()
   const activateMutation = useActivateAdmissionPath()
   const deactivateMutation = useDeactivateAdmissionPath()
+  // Pass 2 hard-review FM-1: custom Dialog confirm thay JS confirm()
+  // (mobile UX kém + a11y kém — không có focus trap, không styled).
+  const [confirmDeactivate, setConfirmDeactivate] = useState(false)
 
   const hasCriteria = path.criteria !== null
   const hasQuota = path.admit_quota !== null && path.admit_quota > 0
@@ -455,8 +492,8 @@ function LifecycleTab({
     }
   }
 
-  const handleDeactivate = async () => {
-    if (!confirm("Vô hiệu hoá đường tuyển sinh này? Storefront sẽ ẩn ngay.")) return
+  const performDeactivate = async () => {
+    setConfirmDeactivate(false)
     try {
       await deactivateMutation.mutateAsync(pathId)
       queryClient.invalidateQueries({ queryKey: quotaMatrixKeys.all })
@@ -532,7 +569,7 @@ function LifecycleTab({
         {isActive ? (
           <Button
             variant="destructive"
-            onClick={handleDeactivate}
+            onClick={() => setConfirmDeactivate(true)}
             disabled={isPending}
             aria-busy={isPending}
           >
@@ -558,6 +595,38 @@ function LifecycleTab({
           </Button>
         )}
       </div>
+
+      {/* Pass 2 hard-review FM-1: custom Dialog confirm thay JS confirm() —
+          focus trap + styled + a11y-friendly trên mobile. */}
+      <Dialog open={confirmDeactivate} onOpenChange={setConfirmDeactivate}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Vô hiệu hoá đường tuyển sinh?</DialogTitle>
+            <DialogDescription>
+              Storefront sẽ ẩn ngay đường tuyển sinh này. Người dùng đã
+              nộp hồ sơ vẫn giữ snapshot path; chỉ submission mới bị chặn.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDeactivate(false)}>
+              Huỷ
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={performDeactivate}
+              disabled={isPending}
+              aria-busy={isPending}
+            >
+              {isPending ? (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+              ) : (
+                <PowerOff className="h-4 w-4 mr-1" aria-hidden="true" />
+              )}
+              Vô hiệu hoá
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
@@ -103,7 +103,17 @@ export function PathDetailDrawer({ pathId, onClose }: Props) {
         )}
 
         {path && (
-          <Tabs value={tab} onValueChange={setTab} className="flex-1 flex flex-col min-h-0">
+          // Pass 2 hard-review F-2-3: ``key={pathId}`` ép Tabs subtree remount
+          // khi parent giữ drawer mở rồi swap path khác (vd drill-down từ
+          // AggregateDrawer sang path khác). Nếu không có key, QuotaTab /
+          // IdentityTab / LifecycleTab giữ ``useState`` initial value của
+          // path cũ → user save = ghi đè path mới với data path cũ.
+          <Tabs
+            key={pathId}
+            value={tab}
+            onValueChange={setTab}
+            className="flex-1 flex flex-col min-h-0"
+          >
             <TabsList className="grid grid-cols-5 shrink-0">
               <TabsTrigger value="quota">Chỉ tiêu</TabsTrigger>
               <TabsTrigger value="identity">Định danh</TabsTrigger>

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/QuickCreatePathModal.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/QuickCreatePathModal.tsx
@@ -1,0 +1,191 @@
+/**
+ * QuickCreatePathModal — tạo path trống tối thiểu cho cell empty `—`.
+ *
+ * Phase 2 v8.2 PR-2D.1 v4a — quick create flow.
+ * Preset (round_id, academic_info_id, method_id) từ vị trí cell. Admin
+ * vẫn có thể edit method nếu cần (case Theo ngành click "+ Tạo path mới").
+ * Sau create → admin tiếp tục cấu hình tiêu chí/giấy tờ qua PathDetailDrawer.
+ */
+"use client"
+
+import { Loader2 } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { useCreateAdmissionPath } from "@/hooks/admissions/useAdmissionPaths"
+import { useAdmissionMethods } from "@/hooks/admissions/useMasterData"
+import type { AdmissionMethod } from "../../shared/types"
+
+interface Props {
+  academicInfoId: number
+  /** Preset round (cell vị trí). Optional — null → BE auto-resolve DOT_1 */
+  admissionRoundId?: number | null
+  /** Preset method nếu cell là vị trí (method × round) cụ thể */
+  admissionMethodId?: number | null
+  /** Title hiển thị context (vd "CNTT × DOT_1 × Học bạ") */
+  contextLabel?: string
+  onClose: () => void
+  onCreated: (pathId: number) => void
+}
+
+export function QuickCreatePathModal({
+  academicInfoId,
+  admissionRoundId,
+  admissionMethodId,
+  contextLabel,
+  onClose,
+  onCreated,
+}: Props) {
+  const { data: methods = [], isLoading: loadingMethods } = useAdmissionMethods()
+  const [methodId, setMethodId] = useState<number | null>(admissionMethodId ?? null)
+  const [displayName, setDisplayName] = useState("")
+  const [displayOrder, setDisplayOrder] = useState("1")
+  const createMutation = useCreateAdmissionPath()
+
+  const handleCreate = async () => {
+    if (!methodId) {
+      toast.error("Vui lòng chọn phương thức trước khi tạo.")
+      return
+    }
+    try {
+      const created = await createMutation.mutateAsync({
+        academic_info_id: academicInfoId,
+        admission_method_id: methodId,
+        admission_round_id: admissionRoundId ?? null,
+        display_name: displayName.trim() || null,
+        display_order: Number(displayOrder) || 1,
+        visibility: "internal",
+        allow_unverified_submission: false,
+        minor_correction_allowed_fields: [],
+      })
+      toast.success("Đã tạo đường tuyển sinh. Mở chi tiết để cấu hình tiêu chí &amp; giấy tờ.")
+      onCreated(created.id)
+    } catch (e: unknown) {
+      const msg =
+        (e as { response?: { data?: { detail?: string } } }).response?.data?.detail ??
+        (e instanceof Error ? e.message : "Lỗi tạo — kiểm tra dữ liệu và thử lại.")
+      toast.error(msg)
+    }
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-pretty">Tạo đường tuyển sinh mới</DialogTitle>
+          <DialogDescription>
+            {contextLabel ?? "Tạo tối thiểu — cấu hình chi tiết sau ở trang chi tiết."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="method">
+              Phương thức{" "}
+              <span className="text-destructive" aria-hidden="true">*</span>
+              <span className="sr-only"> (bắt buộc)</span>
+            </Label>
+            <Select
+              value={methodId?.toString() ?? ""}
+              onValueChange={(v) => setMethodId(Number(v))}
+              disabled={!!admissionMethodId || loadingMethods}
+            >
+              <SelectTrigger id="method">
+                <SelectValue placeholder="Chọn phương thức…" />
+              </SelectTrigger>
+              <SelectContent>
+                {methods.map((m: AdmissionMethod) => (
+                  <SelectItem key={m.id} value={m.id.toString()}>
+                    {m.name}{" "}
+                    <span className="text-muted-foreground" translate="no">
+                      ({m.code})
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {admissionMethodId && (
+              <p className="text-[11px] text-muted-foreground">
+                Phương thức đã chọn theo vị trí ô — không đổi được.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="display-name">Tên hiển thị (tuỳ chọn)</Label>
+            <Input
+              id="display-name"
+              name="display_name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="VD: CNTT 2026 — Học bạ…"
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <p className="text-[11px] text-muted-foreground">
+              Bỏ trống = hệ thống tự sinh từ tên ngành &amp; phương thức.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="order">Thứ tự hiển thị</Label>
+            <Input
+              id="order"
+              name="display_order"
+              type="number"
+              inputMode="numeric"
+              min="0"
+              value={displayOrder}
+              onChange={(e) => setDisplayOrder(e.target.value)}
+              autoComplete="off"
+            />
+          </div>
+
+          {!admissionRoundId && (
+            <div className="rounded-md border bg-muted/40 p-2 text-[11px] text-muted-foreground">
+              Đợt không chọn trước — máy chủ tự gán Đợt 1 của năm tương ứng.
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={createMutation.isPending}
+          >
+            Huỷ
+          </Button>
+          <Button
+            onClick={handleCreate}
+            disabled={createMutation.isPending}
+            aria-busy={createMutation.isPending}
+          >
+            {createMutation.isPending && (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+            )}
+            Tạo đường tuyển sinh
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/labels.ts
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/labels.ts
@@ -1,0 +1,21 @@
+/**
+ * Bảng nhãn tiếng Việt cho admission path trong matrix UI.
+ * Phase 2 v8.2 PR-2D.1 v4a — i18n shim cho status/visibility raw từ API.
+ */
+
+export const PATH_STATUS_LABEL: Record<string, string> = {
+  draft: "Bản nháp",
+  active: "Đang hoạt động",
+  inactive: "Đã ngưng",
+  archived: "Đã lưu trữ",
+}
+
+export function pathStatusLabel(s: string | null | undefined): string {
+  if (!s) return "—"
+  return PATH_STATUS_LABEL[s] ?? s
+}
+
+export const VISIBILITY_LABEL: Record<string, string> = {
+  public: "Công khai (storefront)",
+  internal: "Nội bộ (chỉ admin)",
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrixOverview.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrixOverview.tsx
@@ -1,44 +1,28 @@
 /**
- * QuotaMatrixOverview — admin global quota allocation matrix (Phase 2 v8.2 PR-2D.1 v2).
+ * QuotaMatrixOverview — Phase 3 hub cấu hình quota (Phase 2 v8.2 PR-2D.1 v3).
  *
- * Phase 3 view, NO context filter. Shows ALL ngành × all rounds cho năm filter.
+ * Architecture (locked design Pass 14):
+ *   Toggle [Theo ngành (default)] | [Ma trận toàn cảnh]
+ *     ├─ ByMajorView    : 1 ngành chọn → matrix [method × đợt], cell = path exact
+ *     └─ GlobalMatrixView: all ngành × đợt, cell = aggregate
  *
- * UX:
- * - Year selector (current ± 2 năm)
- * - Table: rows = ngành (academic_info × academic_year), cols = rounds
- * - Cells = ∑ admit_quota across paths trong cùng (academic_info × round)
- * - Tổng quota | Đã rải | Còn lại columns
- * - Cảnh báo đỏ nếu Còn lại < 0 (vượt cap)
+ *   Click cell → Drawer (read-only matrix, edit ở drawer):
+ *     ├─ Ma trận toàn cảnh: cell → AggregateDrawer → PathDetailDrawer
+ *     └─ Theo ngành: cell → PathDetailDrawer (1-step skip aggregate)
  *
- * Tiếng Việt nhất quán per user feedback.
+ * Cell tiết chế (3 dòng): "Admit/Annual" + "Submit cap" + "Status"
+ * KHÔNG inline edit. Drawer là configurator.
  */
 "use client"
 
-import { AlertTriangle, ChevronLeft } from "lucide-react"
-import { useMemo, useState } from "react"
+import { ChevronLeft, Copy, LayoutGrid, List } from "lucide-react"
+import { useState } from "react"
 
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
-import { useQuotaMatrix } from "@/hooks/admissions/useQuotaMatrix"
 
-const CURRENT_YEAR = new Date().getFullYear()
-const YEAR_OPTIONS = [CURRENT_YEAR - 1, CURRENT_YEAR, CURRENT_YEAR + 1, CURRENT_YEAR + 2]
+import { ByMajorView } from "./QuotaMatrix/ByMajorView"
+import { ClonePathsDialog } from "./QuotaMatrix/ClonePathsDialog"
+import { GlobalMatrixView } from "./QuotaMatrix/GlobalMatrixView"
 
 interface Props {
   academicYear: number
@@ -46,180 +30,73 @@ interface Props {
   onBack: () => void
 }
 
-export function QuotaMatrixOverview({ academicYear, onYearChange, onBack }: Props) {
-  const { data, isLoading, isError } = useQuotaMatrix(academicYear)
-  const [showAdmit, setShowAdmit] = useState(true)
+type ViewMode = "by-major" | "global"
 
-  const totalCols = useMemo(() => (data?.rounds.length ?? 0) + 4, [data?.rounds])
+export function QuotaMatrixOverview({ academicYear, onYearChange, onBack }: Props) {
+  const [viewMode, setViewMode] = useState<ViewMode>("by-major")
+  const [cloneOpen, setCloneOpen] = useState(false)
 
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2">
         <Button variant="ghost" size="sm" onClick={onBack}>
-          <ChevronLeft className="h-4 w-4 mr-1" />
+          <ChevronLeft className="h-4 w-4 mr-1" aria-hidden="true" />
           Quay lại
         </Button>
-        <h2 className="text-xl font-semibold">Ma trận chỉ tiêu theo đợt</h2>
+        <h2 className="text-xl font-semibold font-display text-pretty">
+          Cấu hình chỉ tiêu tuyển sinh
+        </h2>
+        <Button
+          variant="outline"
+          size="sm"
+          className="ml-auto"
+          onClick={() => setCloneOpen(true)}
+        >
+          <Copy className="h-4 w-4 mr-1.5" aria-hidden="true" />
+          Sao chép đợt
+        </Button>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center justify-between">
-            <span>Tổng quan rải chỉ tiêu năm {academicYear}</span>
-            <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                variant={showAdmit ? "default" : "outline"}
-                onClick={() => setShowAdmit(true)}
-              >
-                Chỉ tiêu trúng tuyển
-              </Button>
-              <Button
-                size="sm"
-                variant={!showAdmit ? "default" : "outline"}
-                onClick={() => setShowAdmit(false)}
-              >
-                Chỉ tiêu nộp hồ sơ
-              </Button>
-            </div>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex items-center gap-4">
-            <div>
-              <label className="text-sm font-medium">Năm tuyển sinh:</label>
-              <Select
-                value={academicYear.toString()}
-                onValueChange={(v) => onYearChange(Number(v))}
-              >
-                <SelectTrigger className="w-32 ml-2 inline-flex">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {YEAR_OPTIONS.map((y) => (
-                    <SelectItem key={y} value={y.toString()}>
-                      {y}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {data && (
-              <Badge variant="outline">
-                {data.total_rows} ngành × {data.rounds.length} đợt
-              </Badge>
-            )}
-          </div>
+      {/* Toggle */}
+      <div
+        role="tablist"
+        aria-label="Chế độ xem ma trận"
+        className="flex items-center gap-1 bg-muted rounded-lg p-1 w-fit"
+      >
+        <Button
+          role="tab"
+          aria-selected={viewMode === "by-major"}
+          variant={viewMode === "by-major" ? "default" : "ghost"}
+          size="sm"
+          onClick={() => setViewMode("by-major")}
+        >
+          <List className="h-4 w-4 mr-1.5" aria-hidden="true" />
+          Theo ngành
+        </Button>
+        <Button
+          role="tab"
+          aria-selected={viewMode === "global"}
+          variant={viewMode === "global" ? "default" : "ghost"}
+          size="sm"
+          onClick={() => setViewMode("global")}
+        >
+          <LayoutGrid className="h-4 w-4 mr-1.5" aria-hidden="true" />
+          Ma trận toàn cảnh
+        </Button>
+      </div>
 
-          {isLoading && <div className="text-sm text-muted-foreground">Đang tải...</div>}
-          {isError && (
-            <div className="text-sm text-destructive">
-              Lỗi tải dữ liệu. Vui lòng thử lại.
-            </div>
-          )}
+      {cloneOpen && (
+        <ClonePathsDialog
+          academicYear={academicYear}
+          onClose={() => setCloneOpen(false)}
+        />
+      )}
 
-          {data && data.rows.length === 0 && (
-            <div className="text-sm text-muted-foreground">
-              Chưa có ngành nào được công bố cho năm {academicYear}.
-            </div>
-          )}
-
-          {data && data.rows.length > 0 && (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Ngành</TableHead>
-                  <TableHead>Bậc</TableHead>
-                  <TableHead className="text-right">Tổng chỉ tiêu</TableHead>
-                  {data.rounds.map((r) => (
-                    <TableHead key={r.id} className="text-right">
-                      <div className="font-semibold">{r.round_code}</div>
-                      <div className="text-xs text-muted-foreground">{r.round_name}</div>
-                    </TableHead>
-                  ))}
-                  <TableHead className="text-right">Đã rải</TableHead>
-                  <TableHead className="text-right">Còn lại</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {data.rows.map((row) => {
-                  const isOver = row.sum_remaining !== null && row.sum_remaining < 0
-                  return (
-                    <TableRow key={row.academic_info_id} className={isOver ? "bg-red-50" : ""}>
-                      <TableCell className="font-medium">
-                        {row.program_name}
-                        {row.program_code && (
-                          <span className="ml-2 text-xs text-muted-foreground">
-                            ({row.program_code})
-                          </span>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="outline" className="text-xs">
-                          {row.degree_level ?? "—"}
-                        </Badge>
-                      </TableCell>
-                      <TableCell className="text-right font-medium">
-                        {row.annual_admission_quota ?? (
-                          <span className="text-muted-foreground italic">∞</span>
-                        )}
-                      </TableCell>
-                      {data.rounds.map((r) => {
-                        const cell = row.cells_by_round_id[r.id]
-                        const value = cell
-                          ? showAdmit
-                            ? cell.total_admit_quota
-                            : cell.total_round_quota
-                          : 0
-                        return (
-                          <TableCell key={r.id} className="text-right">
-                            {cell ? (
-                              <div>
-                                <div className="font-medium">{value}</div>
-                                {cell.path_count > 1 && (
-                                  <div className="text-xs text-muted-foreground">
-                                    ({cell.path_count} paths)
-                                  </div>
-                                )}
-                              </div>
-                            ) : (
-                              <span className="text-muted-foreground">—</span>
-                            )}
-                          </TableCell>
-                        )
-                      })}
-                      <TableCell className="text-right font-medium">
-                        {row.sum_admit_allocated}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {row.sum_remaining === null ? (
-                          <span className="text-muted-foreground italic">∞</span>
-                        ) : isOver ? (
-                          <span className="text-destructive font-semibold inline-flex items-center gap-1">
-                            <AlertTriangle className="h-4 w-4" />
-                            {row.sum_remaining}
-                          </span>
-                        ) : (
-                          <span className="font-medium">{row.sum_remaining}</span>
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-              </TableBody>
-            </Table>
-          )}
-
-          <div className="text-xs text-muted-foreground space-y-1 mt-4">
-            <p>• Cells = ∑ chỉ tiêu của tất cả đường tuyển sinh thuộc ngành đó cho đợt đó.</p>
-            <p>• Cảnh báo đỏ ⚠ nếu Đã rải vượt Tổng chỉ tiêu (Tier 1 chain violation).</p>
-            <p>
-              • Để chỉnh chỉ tiêu chi tiết per đường tuyển sinh, vào "Cấu hình Đường tuyển sinh"
-              chọn ngành cụ thể.
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+      {viewMode === "by-major" ? (
+        <ByMajorView academicYear={academicYear} onYearChange={onYearChange} />
+      ) : (
+        <GlobalMatrixView academicYear={academicYear} onYearChange={onYearChange} />
+      )}
     </div>
   )
 }

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrixOverview.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrixOverview.tsx
@@ -1,0 +1,225 @@
+/**
+ * QuotaMatrixOverview — admin global quota allocation matrix (Phase 2 v8.2 PR-2D.1 v2).
+ *
+ * Phase 3 view, NO context filter. Shows ALL ngành × all rounds cho năm filter.
+ *
+ * UX:
+ * - Year selector (current ± 2 năm)
+ * - Table: rows = ngành (academic_info × academic_year), cols = rounds
+ * - Cells = ∑ admit_quota across paths trong cùng (academic_info × round)
+ * - Tổng quota | Đã rải | Còn lại columns
+ * - Cảnh báo đỏ nếu Còn lại < 0 (vượt cap)
+ *
+ * Tiếng Việt nhất quán per user feedback.
+ */
+"use client"
+
+import { AlertTriangle, ChevronLeft } from "lucide-react"
+import { useMemo, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useQuotaMatrix } from "@/hooks/admissions/useQuotaMatrix"
+
+const CURRENT_YEAR = new Date().getFullYear()
+const YEAR_OPTIONS = [CURRENT_YEAR - 1, CURRENT_YEAR, CURRENT_YEAR + 1, CURRENT_YEAR + 2]
+
+interface Props {
+  academicYear: number
+  onYearChange: (year: number) => void
+  onBack: () => void
+}
+
+export function QuotaMatrixOverview({ academicYear, onYearChange, onBack }: Props) {
+  const { data, isLoading, isError } = useQuotaMatrix(academicYear)
+  const [showAdmit, setShowAdmit] = useState(true)
+
+  const totalCols = useMemo(() => (data?.rounds.length ?? 0) + 4, [data?.rounds])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          <ChevronLeft className="h-4 w-4 mr-1" />
+          Quay lại
+        </Button>
+        <h2 className="text-xl font-semibold">Ma trận chỉ tiêu theo đợt</h2>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>Tổng quan rải chỉ tiêu năm {academicYear}</span>
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                variant={showAdmit ? "default" : "outline"}
+                onClick={() => setShowAdmit(true)}
+              >
+                Chỉ tiêu trúng tuyển
+              </Button>
+              <Button
+                size="sm"
+                variant={!showAdmit ? "default" : "outline"}
+                onClick={() => setShowAdmit(false)}
+              >
+                Chỉ tiêu nộp hồ sơ
+              </Button>
+            </div>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-4">
+            <div>
+              <label className="text-sm font-medium">Năm tuyển sinh:</label>
+              <Select
+                value={academicYear.toString()}
+                onValueChange={(v) => onYearChange(Number(v))}
+              >
+                <SelectTrigger className="w-32 ml-2 inline-flex">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {YEAR_OPTIONS.map((y) => (
+                    <SelectItem key={y} value={y.toString()}>
+                      {y}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {data && (
+              <Badge variant="outline">
+                {data.total_rows} ngành × {data.rounds.length} đợt
+              </Badge>
+            )}
+          </div>
+
+          {isLoading && <div className="text-sm text-muted-foreground">Đang tải...</div>}
+          {isError && (
+            <div className="text-sm text-destructive">
+              Lỗi tải dữ liệu. Vui lòng thử lại.
+            </div>
+          )}
+
+          {data && data.rows.length === 0 && (
+            <div className="text-sm text-muted-foreground">
+              Chưa có ngành nào được công bố cho năm {academicYear}.
+            </div>
+          )}
+
+          {data && data.rows.length > 0 && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Ngành</TableHead>
+                  <TableHead>Bậc</TableHead>
+                  <TableHead className="text-right">Tổng chỉ tiêu</TableHead>
+                  {data.rounds.map((r) => (
+                    <TableHead key={r.id} className="text-right">
+                      <div className="font-semibold">{r.round_code}</div>
+                      <div className="text-xs text-muted-foreground">{r.round_name}</div>
+                    </TableHead>
+                  ))}
+                  <TableHead className="text-right">Đã rải</TableHead>
+                  <TableHead className="text-right">Còn lại</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.rows.map((row) => {
+                  const isOver = row.sum_remaining !== null && row.sum_remaining < 0
+                  return (
+                    <TableRow key={row.academic_info_id} className={isOver ? "bg-red-50" : ""}>
+                      <TableCell className="font-medium">
+                        {row.program_name}
+                        {row.program_code && (
+                          <span className="ml-2 text-xs text-muted-foreground">
+                            ({row.program_code})
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className="text-xs">
+                          {row.degree_level ?? "—"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right font-medium">
+                        {row.annual_admission_quota ?? (
+                          <span className="text-muted-foreground italic">∞</span>
+                        )}
+                      </TableCell>
+                      {data.rounds.map((r) => {
+                        const cell = row.cells_by_round_id[r.id]
+                        const value = cell
+                          ? showAdmit
+                            ? cell.total_admit_quota
+                            : cell.total_round_quota
+                          : 0
+                        return (
+                          <TableCell key={r.id} className="text-right">
+                            {cell ? (
+                              <div>
+                                <div className="font-medium">{value}</div>
+                                {cell.path_count > 1 && (
+                                  <div className="text-xs text-muted-foreground">
+                                    ({cell.path_count} paths)
+                                  </div>
+                                )}
+                              </div>
+                            ) : (
+                              <span className="text-muted-foreground">—</span>
+                            )}
+                          </TableCell>
+                        )
+                      })}
+                      <TableCell className="text-right font-medium">
+                        {row.sum_admit_allocated}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {row.sum_remaining === null ? (
+                          <span className="text-muted-foreground italic">∞</span>
+                        ) : isOver ? (
+                          <span className="text-destructive font-semibold inline-flex items-center gap-1">
+                            <AlertTriangle className="h-4 w-4" />
+                            {row.sum_remaining}
+                          </span>
+                        ) : (
+                          <span className="font-medium">{row.sum_remaining}</span>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          )}
+
+          <div className="text-xs text-muted-foreground space-y-1 mt-4">
+            <p>• Cells = ∑ chỉ tiêu của tất cả đường tuyển sinh thuộc ngành đó cho đợt đó.</p>
+            <p>• Cảnh báo đỏ ⚠ nếu Đã rải vượt Tổng chỉ tiêu (Tier 1 chain violation).</p>
+            <p>
+              • Để chỉnh chỉ tiêu chi tiết per đường tuyển sinh, vào "Cấu hình Đường tuyển sinh"
+              chọn ngành cụ thể.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/PhaseNavigator.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/PhaseNavigator.tsx
@@ -71,6 +71,7 @@ export function PhaseNavigator({
   const isPhase1Active = currentState.type === "phase1";
   const isPhase2Active = currentState.type === "phase2";
   const isPhase3Active = currentState.type === "phase3" || currentState.type === "select-context";
+  const isQuotaMatrixActive = currentState.type === "quota-matrix-overview";
 
   const currentPhase1Step = isPhase1Active ? currentState.step : null;
   const currentPhase2Step = isPhase2Active ? currentState.step : null;
@@ -98,6 +99,13 @@ export function PhaseNavigator({
   const handlePhase3Click = () => {
     onNavigate({ type: "select-context" });
     // Close mobile sheet after navigation
+    onClose?.();
+  };
+
+  // Navigate to Quota Matrix overview (Phase 2 v8.2 PR-2D.1 v2)
+  const handleQuotaMatrixClick = () => {
+    const currentYear = new Date().getFullYear();
+    onNavigate({ type: "quota-matrix-overview", academicYear: currentYear });
     onClose?.();
   };
 
@@ -187,6 +195,15 @@ export function PhaseNavigator({
         >
           <BarChart3 className="h-4 w-4 mr-2" />
           Cấu hình Đường tuyển sinh
+        </Button>
+        <Button
+          variant={isQuotaMatrixActive ? "default" : "outline"}
+          size="sm"
+          className="w-full justify-start mt-2"
+          onClick={handleQuotaMatrixClick}
+        >
+          <BarChart3 className="h-4 w-4 mr-2" />
+          Ma trận Chỉ tiêu Theo Đợt
         </Button>
       </Card>
 

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/shared/types.ts
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/shared/types.ts
@@ -150,7 +150,10 @@ export type AdmissionConfigState =
   | { type: 'phase1'; step: Phase1Step }
   | { type: 'phase2'; step: Phase2Step }
   | { type: 'select-context' }
-  | { type: 'phase3'; context: SelectionContext; view: Phase3View };
+  | { type: 'phase3'; context: SelectionContext; view: Phase3View }
+  // Phase 2 v8.2 PR-2D.1 v2 — global quota matrix overview (ALL ngành × đợt)
+  // KHÔNG cần SelectionContext vì matrix tổng quan all academic_info
+  | { type: 'quota-matrix-overview'; academicYear: number };
 
 // ============================================
 // NAVIGATION TYPES

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -3,10 +3,24 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, onWheel, ...props }, ref) => {
+    // type="number" mặc định ăn wheel event để tăng/giảm giá trị khi đang focus
+    // → page không cuộn được khi cursor hover input số. Blur input để wheel bubble
+    // lên page scroll; user refocus bằng click nếu cần chỉnh tiếp.
+    const handleWheel = React.useCallback(
+      (e: React.WheelEvent<HTMLInputElement>) => {
+        onWheel?.(e)
+        if (type === "number" && e.currentTarget === document.activeElement) {
+          e.currentTarget.blur()
+        }
+      },
+      [type, onWheel],
+    )
+
     return (
       <input
         type={type}
+        onWheel={handleWheel}
         className={cn(
           "flex w-full rounded-md border border-input bg-transparent px-3 shadow-sm transition-colors",
           // Mobile: taller input (44px touch target), 16px font to prevent iOS zoom

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -65,8 +65,8 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <X className="h-4 w-4" aria-hidden="true" />
+        <span className="sr-only">Đóng</span>
       </SheetPrimitive.Close>
       {children}
     </SheetPrimitive.Content>

--- a/frontend/src/hooks/admissions/useAdmissionConfigState.ts
+++ b/frontend/src/hooks/admissions/useAdmissionConfigState.ts
@@ -116,6 +116,10 @@ function stateToUrl(state: AdmissionConfigState): string {
     return `${base}?phase=3`;
   }
 
+  if (state.type === "quota-matrix-overview") {
+    return `${base}?view=quota-matrix&year=${state.academicYear}`;
+  }
+
   if (state.type === "phase3") {
     const ctx = state.context;
     const params = new URLSearchParams({
@@ -184,6 +188,14 @@ export function useAdmissionConfigState() {
     // If Phase 2 URL param, show Phase 2
     if (phase === "2" && step) {
       return { type: "phase2", step: step as Phase2Step };
+    }
+
+    // Quota Matrix overview (Phase 2 v8.2 PR-2D.1 v2 — global view, no context)
+    const viewParam = searchParams.get("view");
+    if (viewParam === "quota-matrix") {
+      const yearStr = searchParams.get("year");
+      const year = yearStr ? parseInt(yearStr, 10) : new Date().getFullYear();
+      return { type: "quota-matrix-overview", academicYear: year };
     }
 
     // If Phase 3 URL param

--- a/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
+++ b/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
@@ -44,7 +44,11 @@ const mockAdmissionPathResponse = {
   display_order: 1,
   visibility: "public" as const,
   activated_at: null,
-  activated_by: null,
+  // Mirror BE Pydantic UserNested shape (admission_path.py:499). FE Zod
+  // schema yêu cầu nested object, không phải scalar id.
+  activator: null,
+  // Phase 2 v8.2 — derived flag từ application_fee > 0.
+  requires_application_fee: false,
   created_at: "2025-06-01T00:00:00+00:00",
   updated_at: "2025-06-01T00:00:00+00:00",
   academic_info: null,

--- a/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
+++ b/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
@@ -69,6 +69,12 @@ const mockAdmissionPathResponse = {
   applicable_to: null,
   method_quota: null,
   bonus_rule_override: null,
+  // Phase 2 v8.2 PR-2B/2C — quota fields + admission_round_id (NOT NULL).
+  admission_round_id: 1,
+  round_quota: null,
+  admit_quota: null,
+  submission_count: 0,
+  application_fee: null,
 } satisfies AdmissionPathResponse;
 
 /** The shape that PUT /paths/:id/documents returns. */

--- a/frontend/src/hooks/admissions/useAdmissionRounds.ts
+++ b/frontend/src/hooks/admissions/useAdmissionRounds.ts
@@ -109,6 +109,22 @@ export function useSoftArchiveRound(academicYear: number) {
   })
 }
 
+export function useRestoreRound(academicYear: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: roundsApi.restoreRound,
+    onSuccess: () => {
+      toast.success("Đã khôi phục đợt tuyển sinh")
+      queryClient.invalidateQueries({
+        queryKey: [ROUNDS_KEY, "by-year", academicYear],
+      })
+    },
+    onError: (error: ApiError) => {
+      toast.error(error.response?.data?.detail || "Không thể khôi phục")
+    },
+  })
+}
+
 export function useExtendRound(academicYear: number) {
   const queryClient = useQueryClient()
   return useMutation({

--- a/frontend/src/hooks/admissions/useClonePathsFromRound.ts
+++ b/frontend/src/hooks/admissions/useClonePathsFromRound.ts
@@ -1,0 +1,34 @@
+/**
+ * Hook bulk clone admission paths theo Q6 deep-copy.
+ *
+ * Invalidate cả admission-paths + quota-matrix sau success vì 2 surface
+ * cùng đọc admission_path data, drift = stale UI.
+ */
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import {
+  clonePathsFromRound,
+  type ClonePathsRequest,
+} from "@/lib/api/admission-path-clone"
+
+import { admissionPathKeys } from "./useAdmissionPaths"
+import { quotaMatrixKeys } from "./useQuotaMatrix"
+
+interface MutationVars {
+  targetRoundId: number
+  sourceRoundId: number
+  payload: ClonePathsRequest
+}
+
+export function useClonePathsFromRound() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ targetRoundId, sourceRoundId, payload }: MutationVars) =>
+      clonePathsFromRound(targetRoundId, sourceRoundId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: admissionPathKeys.all })
+      queryClient.invalidateQueries({ queryKey: quotaMatrixKeys.all })
+    },
+  })
+}

--- a/frontend/src/hooks/admissions/useQuotaMatrix.ts
+++ b/frontend/src/hooks/admissions/useQuotaMatrix.ts
@@ -1,0 +1,40 @@
+// frontend/src/hooks/admissions/useQuotaMatrix.ts
+// Phase 2 v8.2 PR-2D.1 v2 — React Query hooks cho quota matrix.
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import {
+  getQuotaMatrix,
+  updatePathQuota,
+  type AdmissionPathQuotaUpdate,
+} from "@/lib/api/quota-matrix"
+
+export const quotaMatrixKeys = {
+  all: ["quota-matrix"] as const,
+  byYear: (year: number) => [...quotaMatrixKeys.all, "year", year] as const,
+}
+
+export function useQuotaMatrix(academicYear: number | undefined) {
+  return useQuery({
+    queryKey: quotaMatrixKeys.byYear(academicYear ?? 0),
+    queryFn: () => getQuotaMatrix(academicYear!),
+    enabled: !!academicYear,
+    staleTime: 30 * 1000, // 30s
+  })
+}
+
+export function useUpdatePathQuota() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      pathId,
+      data,
+    }: {
+      pathId: number
+      data: AdmissionPathQuotaUpdate
+    }) => updatePathQuota(pathId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: quotaMatrixKeys.all })
+    },
+  })
+}

--- a/frontend/src/hooks/admissions/useQuotaMatrix.ts
+++ b/frontend/src/hooks/admissions/useQuotaMatrix.ts
@@ -4,6 +4,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
 import {
+  getPathMatrixByMajor,
   getQuotaMatrix,
   updatePathQuota,
   type AdmissionPathQuotaUpdate,
@@ -12,6 +13,17 @@ import {
 export const quotaMatrixKeys = {
   all: ["quota-matrix"] as const,
   byYear: (year: number) => [...quotaMatrixKeys.all, "year", year] as const,
+  byMajor: (academicInfoId: number) =>
+    [...quotaMatrixKeys.all, "major", academicInfoId] as const,
+}
+
+export function usePathMatrixByMajor(academicInfoId: number | undefined) {
+  return useQuery({
+    queryKey: quotaMatrixKeys.byMajor(academicInfoId ?? 0),
+    queryFn: () => getPathMatrixByMajor(academicInfoId!),
+    enabled: !!academicInfoId,
+    staleTime: 30 * 1000,
+  })
 }
 
 export function useQuotaMatrix(academicYear: number | undefined) {

--- a/frontend/src/lib/api/admission-path-clone.ts
+++ b/frontend/src/lib/api/admission-path-clone.ts
@@ -1,0 +1,43 @@
+/**
+ * Bulk clone admission paths Q6 deep-copy (Phase 2 v8.2 PR-2D BE).
+ *
+ * Endpoint: POST /api/v2/admin/rounds/{target_round_id}/clone-paths-from/{source_round_id}
+ * BE schema source: app/schemas/path_subject_group.py:78-111.
+ */
+
+import { api } from "./client"
+
+export interface ClonePathsRequest {
+  /** Filter — clone chỉ paths thuộc các academic_info này. NULL = clone all. */
+  academic_info_ids?: number[] | null
+  /** Template cho cloned criteria.code, e.g. "{source_code}_{round_code}". NULL = auto fallback. */
+  criteria_code_template?: string | null
+}
+
+export interface ClonePathsResponseItem {
+  source_path_id: number
+  cloned_path_id: number
+  source_criteria_code: string
+  cloned_criteria_code: string
+}
+
+export interface ClonePathsResponse {
+  source_round_id: number
+  target_round_id: number
+  cloned_count: number
+  /** Paths skipped (already exist trong target round per 3-col UNIQUE). */
+  skipped_count: number
+  items: ClonePathsResponseItem[]
+}
+
+export async function clonePathsFromRound(
+  targetRoundId: number,
+  sourceRoundId: number,
+  payload: ClonePathsRequest,
+): Promise<ClonePathsResponse> {
+  const response = await api.post<ClonePathsResponse>(
+    `/api/v2/admin/rounds/${targetRoundId}/clone-paths-from/${sourceRoundId}`,
+    payload,
+  )
+  return response.data
+}

--- a/frontend/src/lib/api/admission-rounds.ts
+++ b/frontend/src/lib/api/admission-rounds.ts
@@ -77,6 +77,15 @@ export async function softArchiveRound(
   return res.data
 }
 
+export async function restoreRound(
+  roundId: number
+): Promise<AdmissionRoundResponse> {
+  const res = await api.post<AdmissionRoundResponse>(
+    `${BASE}/rounds/${roundId}/restore`,
+  )
+  return res.data
+}
+
 export async function extendRound(
   roundId: number,
   payload: AdmissionRoundExtend

--- a/frontend/src/lib/api/quota-matrix.ts
+++ b/frontend/src/lib/api/quota-matrix.ts
@@ -43,6 +43,48 @@ export interface AdmissionPathQuotaUpdate {
   admit_quota: number | null
 }
 
+// Phase 2 v8.2 PR-2D.1 v3 — per-major view types
+export interface PathMatrixCell {
+  path_id: number
+  admission_round_id: number
+  admission_method_id: number
+  round_quota: number | null
+  admit_quota: number | null
+  submission_count: number
+  status: string
+  criteria_code: string | null
+}
+
+export interface PathMatrixMethodRow {
+  admission_method_id: number
+  method_code: string
+  method_name: string
+  cells_by_round_id: Record<number, PathMatrixCell | null>
+  sum_admit_quota: number
+}
+
+export interface PathMatrixResponse {
+  academic_info_id: number
+  academic_year: number
+  program_name: string
+  program_code: string | null
+  degree_level: string | null
+  annual_admission_quota: number | null
+  sum_admit_allocated: number
+  sum_remaining: number | null
+  rounds: QuotaMatrixRound[]
+  methods: PathMatrixMethodRow[]
+}
+
+export async function getPathMatrixByMajor(
+  academicInfoId: number,
+): Promise<PathMatrixResponse> {
+  const response = await api.get<PathMatrixResponse>(
+    `/api/v2/admin/academic-infos/${academicInfoId}/path-matrix`,
+  )
+  return response.data
+}
+
 /**
  * Get quota matrix overview cho năm tuyển sinh.
  * Aggregation: rows = academic_info × academic_year, cols = rounds,

--- a/frontend/src/lib/api/quota-matrix.ts
+++ b/frontend/src/lib/api/quota-matrix.ts
@@ -1,0 +1,73 @@
+// frontend/src/lib/api/quota-matrix.ts
+// Phase 2 v8.2 PR-2D.1 v2 — Quota matrix overview API client.
+
+import { api } from "./client"
+
+export interface QuotaMatrixRound {
+  id: number
+  round_code: string
+  round_name: string
+  is_active: boolean
+}
+
+export interface QuotaMatrixCell {
+  admission_round_id: number
+  round_code: string
+  total_admit_quota: number
+  total_round_quota: number
+  total_submission_count: number
+  path_count: number
+}
+
+export interface QuotaMatrixRow {
+  academic_info_id: number
+  academic_year: number
+  program_name: string
+  program_code: string | null
+  degree_level: string | null
+  annual_admission_quota: number | null
+  cells_by_round_id: Record<number, QuotaMatrixCell>
+  sum_admit_allocated: number
+  sum_remaining: number | null
+}
+
+export interface QuotaMatrixResponse {
+  academic_year: number
+  rounds: QuotaMatrixRound[]
+  rows: QuotaMatrixRow[]
+  total_rows: number
+}
+
+export interface AdmissionPathQuotaUpdate {
+  round_quota: number | null
+  admit_quota: number | null
+}
+
+/**
+ * Get quota matrix overview cho năm tuyển sinh.
+ * Aggregation: rows = academic_info × academic_year, cols = rounds,
+ * cells = ∑ admit_quota across paths.
+ */
+export async function getQuotaMatrix(
+  academicYear: number,
+): Promise<QuotaMatrixResponse> {
+  const response = await api.get<QuotaMatrixResponse>(
+    `/api/v2/admin/years/${academicYear}/quota-matrix`,
+  )
+  return response.data
+}
+
+/**
+ * Update path quota cho QuotaMatrix drawer/inline edit.
+ * Tier 1+2 chain validated server-side.
+ */
+export async function updatePathQuota(
+  pathId: number,
+  data: AdmissionPathQuotaUpdate,
+): Promise<unknown> {
+  const response = await api.patch(
+    `/api/v2/admin/admission-paths/${pathId}/quota`,
+    data,
+  )
+  return response.data
+}

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -105,6 +105,18 @@ export const admissionMethodNestedSchema = z.object({
 export type AdmissionMethodNested = z.infer<typeof admissionMethodNestedSchema>
 
 /**
+ * User (nested - used for activator field).
+ * Mirror BE UserNested mini-schema.
+ */
+export const userNestedSchema = z.object({
+  id: z.number(),
+  username: z.string(),
+  full_name: z.string().nullable(),
+})
+
+export type UserNested = z.infer<typeof userNestedSchema>
+
+/**
  * Subject Group (nested in criteria)
  * Used for LeadApplicationForm score initialization
  */
@@ -135,7 +147,10 @@ export const admissionCriteriaNestedSchema = z.object({
   // Rule Engine config
   required_subject_count: z.number().nullable(),
   subject_selection_mode: z.string().default("fixed"),
-  scoring_method: z.string().default("sum"),
+  // BE Pydantic Literal["sum", "average", "weighted"] (admission_path.py:373).
+  // FE phải mirror đúng — trước đây dùng "avg" sai chính tả + thiếu "weighted"
+  // → criteria có scoring_method="average"/"weighted" parse fail.
+  scoring_method: z.enum(["sum", "average", "weighted"]).default("sum"),
   
   // Validity
   policy_version: z.string().nullable().optional(),
@@ -291,12 +306,17 @@ export const admissionPathResponseSchema = z.object({
   submission_count: z.number().default(0),
   // Phase 2 v8.2 — application fee (VND).
   application_fee: z.number().nullable(),
+  // BE Pydantic field default=False (admission_path.py:440), FE phải mirror.
+  // FE dùng để hiển thị flow thanh toán — không suy luận từ application_fee > 0.
+  requires_application_fee: z.boolean().default(false),
   status: admissionPathStatusEnum,
   display_name: z.string().nullable(),
   display_order: z.number(),
   visibility: z.enum(["public", "internal"]),
   activated_at: z.string().datetime({ offset: true }).nullable(),
-  activated_by: z.number().nullable(),
+  // BE Pydantic trả nested ``activator: Optional[UserNested]`` (admission_path.py:499).
+  // Trước đây FE viết ``activated_by: number`` → Zod parse fail khi BE trả object.
+  activator: userNestedSchema.nullable().optional(),
   created_at: z.string().datetime({ offset: true }),
   updated_at: z.string().datetime({ offset: true }),
   

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -260,7 +260,11 @@ export const admissionCriteriaCreateSchema = z.object({
   conditions: z.string().nullable().optional(),
   required_subject_count: z.number().int().min(1).nullable().optional(),
   subject_selection_mode: z.enum(["fixed", "best_n", "any_n"]).default("fixed"),
-  scoring_method: z.enum(["sum", "avg"]).default("sum"),
+  // PR #251 review fix #1: parity với BE Pydantic Literal["sum", "average",
+  // "weighted"] (admission_path.py:373). Trước đây Create schema còn "avg"
+  // typo (Response schema đã fix CHECKPOINT 4); payload Create với
+  // scoring_method="average" parse fail.
+  scoring_method: z.enum(["sum", "average", "weighted"]).default("sum"),
   subject_groups: z.array(z.number().int()).default([]), // List of IDs
   
   // Validity

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -159,6 +159,13 @@ export type AdmissionCriteriaNested = z.infer<typeof admissionCriteriaNestedSche
 export const admissionPathCreateSchema = z.object({
   academic_info_id: z.number().int().positive("Academic Info ID phải là số dương"),
   admission_method_id: z.number().int().positive("Admission Method ID phải là số dương"),
+  // Phase 2 v8.2 PR-2B v2 — optional; BE auto-resolves DOT_1 nếu null.
+  admission_round_id: z.number().int().positive().optional().nullable(),
+  // Phase 2 v8.2 PR-2B v2 — per-path quota fields (admit chain Tier 1, submit chain Tier 2).
+  round_quota: z.number().int().min(0).optional().nullable(),
+  admit_quota: z.number().int().min(0).optional().nullable(),
+  // Phase 2 v8.2 — application fee (VND). 0/null = miễn phí.
+  application_fee: z.number().min(0).optional().nullable(),
   display_name: z.string().max(255).optional().nullable(),
   display_order: z.number().int().min(0).optional().nullable(),
   visibility: z.enum(["public", "internal"]).optional(),
@@ -197,6 +204,8 @@ export const admissionPathUpdateSchema = z.object({
   display_name: z.string().max(255).optional().nullable(),
   display_order: z.number().int().min(0).optional().nullable(),
   visibility: z.enum(["public", "internal"]).optional(),
+  // Phase 2 v8.2 — application fee (VND). 0/null = miễn phí.
+  application_fee: z.number().min(0).optional().nullable(),
   // Optional on update — callers that don't want to flip the flag omit
   // it entirely and the backend leaves the current value untouched.
   allow_unverified_submission: z.boolean().optional(),
@@ -274,6 +283,14 @@ export const admissionPathResponseSchema = z.object({
   id: z.number(),
   academic_info_id: z.number(),
   admission_method_id: z.number(),
+  // Phase 2 v8.2 PR-2C v2 — NOT NULL post 3-col UNIQUE swap.
+  admission_round_id: z.number(),
+  // Phase 2 v8.2 PR-2B v2 — per-path quota fields.
+  round_quota: z.number().nullable(),
+  admit_quota: z.number().nullable(),
+  submission_count: z.number().default(0),
+  // Phase 2 v8.2 — application fee (VND).
+  application_fee: z.number().nullable(),
   status: admissionPathStatusEnum,
   display_name: z.string().nullable(),
   display_order: z.number(),


### PR DESCRIPTION
## Summary

Phase 2 v8.2 PR-2D.1 ship Quota Matrix admin UI cho admission config + 31 hard-review fixes qua 2 audit passes (Critical/High/Medium).

## Scope

### Feature work (CHECKPOINT 1-3)
- **5-tab PathDetailDrawer**: Chỉ tiêu / Định danh / Tiêu chí / Giấy tờ / Vòng đời — unified config flow thay wizard cũ
- **ByMajorView** (default daily ops): chọn ngành → matrix [phương thức × đợt] với click-to-detail
- **GlobalMatrixView** (overview): ma trận toàn cảnh ngành × đợt + drill-down qua AggregateDrawer → PathDetailDrawer
- **QuickCreatePathModal**: tạo path tối thiểu cho cell trống `+ Tạo`
- **ClonePathsDialog**: deep-copy paths giữa rounds (Q6 v8.2)
- **Restore round** endpoint + UI confirm dialog (un-archive)

### Hard-review pass 1 (CHECKPOINT 4 — 14 fixes)
- BE: 3-col duplicate check fix, 6 schema drift fields, clone session corrupt fix, activity log date serialize, round update date validation, FK pre-validate, audit serialize date/Decimal/UUID, restore endpoint, archived round extend block, date helper extraction, activate_path round cross-check, 8 anchor pytest tests
- FE: 5 Zod schema critical fixes, date compare, console.log strip, validation key fix, test fixture sync, Input wheel handler, drawer overflow fix, Việt hoá + a11y, ConfigCriteria/Documents embedded mode, restore confirm dialog

### Hard-review pass 2 (CHECKPOINT 5-6 — 7 high + 10 medium + 4 false positives verified)

**Critical/High (CHECKPOINT 5):**
- B-2-1: block create_path on archived round
- B-2-2: restore + extend return prior_state cho audit delta
- B-2-3: SELECT FOR UPDATE round trong activate_path (race window guard)
- B-2-7: application_fee Decimal → float JSON serializer
- F-2-1: openPathId URL state sync (Frontend CLAUDE.md compliance)
- F-2-3: Tabs key={pathId} ép remount khi swap path
- F-2-2: 4 anchor tests mới (ngành dropdown, cell click URL, AggregateDrawer mở, PathDetailDrawer drill-down)

**Medium (CHECKPOINT 6):**
- BM-1: update_path_quota log_activity trước commit (atomic)
- BM-2: DB CHECK constraint Tier2 invariant (migration phase2_06)
- BM-3: _serialize_value depth limit 10 + sentinel
- BM-4: create_path year mismatch round vs academic_info
- BM-5: structured metric_event cho Tier1/Tier2 violations
- FM-1: replace JS confirm() bằng shadcn Dialog
- FM-2: tab active URL state (?tab=)
- FM-3: selectedAcademicInfoId URL state (?academicInfo=)
- FM-4: ConfigCriteria search debounce 200ms + useMemo
- FM-5: ByMajorView memoize PathCellButton + EmptyCellButton

**False positives verified** (atomicity preserved bởi router commit boundary + FOR UPDATE lock duration):
- B-2-4 clone atomicity, B-2-5 bulk_create rollback, B-2-6 Tier1 lock, F-2-4 mutation callback

## Migration

`phase2_06_admit_quota_le_round_quota_check` — DB CHECK constraint backing Tier 2 invariant `admit_quota <= round_quota`. NULL-safe; pre-flight audit blocks migration nếu data vi phạm.

## Test plan

- [x] BE pytest 41/41 PASS (Phase 2 service + integration suite, 1 pre-existing skip)
- [x] FE type-check 0 errors
- [x] FE vitest 26/26 PASS (5 test files: ByMajorView, GlobalMatrixView, AggregateDrawer, PathDetailDrawer, useAdmissionPaths)
- [x] Alembic migration phase2_06 apply clean trên dev DB
- [x] Browser smoke Chrome MCP: 5-tab drawer + quick create + restore round
- [x] CRUD audit sweep + 2 hard-review audit passes (BE + FE Explore agents)
- [ ] Post-merge: prod deploy + 48h soak (Tier 2 CHECK + restore round flow)

## Deferred follow-ups

- B-C3 Tier1 SERIALIZABLE race (cần design decision)
- GlobalMatrixView memoize parity FM-5
- 7 Low aria polish pass 1
- React Query narrow invalidation tuning

🤖 Generated with [Claude Code](https://claude.com/claude-code)