### PR TITLE
test-debt(admission): fix 12 admission-config vitest fails sau Phase 2 PR-2D.1 v4a

### DIFF
--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.test.tsx
@@ -108,21 +108,27 @@ describe("RoundsManagementTab year-level", () => {
 
   it("disables action buttons on archived rounds", () => {
     render(wrap(<RoundsManagementTab />))
-    // 3 action button types: Sửa đợt, Gia hạn đợt, Lưu trữ đợt per row
-    // DOT_2 archived → buttons disabled
+    // CHECKPOINT 2 (2026-05-10): restore round feature thay Lưu trữ button
+    // bằng Khôi phục cho rows đã archive. Test-debt fix 2026-05-11:
+    // archive button count đổi 2 → 1 (chỉ row active còn Lưu trữ); thêm
+    // restoreButtons assertion cho row archived.
     const editButtons = screen.getAllByRole("button", { name: /Sửa đợt/i })
     const extendButtons = screen.getAllByRole("button", { name: /Gia hạn đợt/i })
     const archiveButtons = screen.getAllByRole("button", { name: /Lưu trữ đợt/i })
+    const restoreButtons = screen.getAllByRole("button", { name: /Khôi phục đợt/i })
 
-    // 2 rows × 3 button types = 6 buttons, 3 disabled (archived row)
+    // 2 rows total. Active row (DOT_1): Sửa + Gia hạn + Lưu trữ.
+    // Archived row (DOT_2): Sửa (disabled) + Gia hạn (disabled) + Khôi phục.
     expect(editButtons.length).toBe(2)
     expect(extendButtons.length).toBe(2)
-    expect(archiveButtons.length).toBe(2)
+    expect(archiveButtons.length).toBe(1)  // chỉ trên DOT_1 active
+    expect(restoreButtons.length).toBe(1)  // chỉ trên DOT_2 archived
 
-    // Last row (DOT_2 archived) buttons should be disabled (P2-2 v8.2 —
-    // idiomatic jest-dom matcher).
+    // Last row (DOT_2 archived) Sửa + Gia hạn buttons disabled
     expect(editButtons[1]).toBeDisabled()
     expect(extendButtons[1]).toBeDisabled()
-    expect(archiveButtons[1]).toBeDisabled()
+    // Restore button trên archived row KHÔNG bị disabled (admin có thể
+    // restore đợt đã archive bất kỳ lúc nào).
+    expect(restoreButtons[0]).not.toBeDisabled()
   })
 })

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AggregateDrawer.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AggregateDrawer.test.tsx
@@ -11,6 +11,15 @@ import { describe, expect, it, vi } from "vitest"
 
 import { AggregateDrawer } from "./AggregateDrawer"
 
+// Test-debt fix 2026-05-11: drill-down test render nested PathDetailDrawer
+// dùng useRouter (FM-2 tab URL state). Mock next/navigation parity với
+// PathDetailDrawer.test.tsx tránh "invariant expected app router to be mounted".
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/admin/admission-config",
+}))
+
 // Pass 2 hard-review F-2-2: PathDetailDrawer (nested) dùng useAdmissionPath
 // + useUpdatePathQuota; mock cả 2 module để drill-down render an toàn.
 vi.mock("@/hooks/admissions/useAdmissionPaths", () => ({

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ByMajorView.test.tsx
@@ -11,13 +11,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ByMajorView } from "./ByMajorView"
 
-// Pass 2 hard-review F-2-1 prerequisite: ByMajorView dùng Next.js navigation
-// hooks để sync ``?pathId`` URL param. Test mock cùng pattern với
-// ``useAdmissionsFilter.test.ts``.
+// Pass 2 hard-review F-2-1 + FM-3: ByMajorView dùng Next.js navigation
+// hooks để sync ``?pathId`` + ``?academicInfo`` URL params. Test mock
+// stateful qua searchParamsMock per-test override — auto-select ngành
+// effect (line 84-87 of component) gọi replace với academicInfo=N nhưng
+// mock router stateless không persist; mỗi test phải pre-set initial
+// searchParams nếu cần matrix loaded (test-debt fix 2026-05-11).
 const replaceMock = vi.fn()
+const searchParamsMock = vi.fn(() => new URLSearchParams("academicInfo=70"))
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => searchParamsMock(),
   usePathname: () => "/admin/admission-config",
 }))
 
@@ -90,6 +94,11 @@ function wrap(ui: ReactNode) {
 describe("ByMajorView", () => {
   beforeEach(() => {
     replaceMock.mockClear()
+    // Reset to default initial: pre-selected academicInfo=70 để matrix
+    // load (auto-select effect không trigger trong mock router stateless).
+    searchParamsMock.mockImplementation(
+      () => new URLSearchParams("academicInfo=70"),
+    )
   })
 
   it("renders title + auto-select first ngành + load matrix", () => {

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
@@ -13,6 +13,18 @@ import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+// Test-debt fix 2026-05-11: FM-2 added useRouter cho tab URL state sync.
+// Mock per-test override `useSearchParams` để test active tab Vòng đời
+// (Lifecycle) cần pre-set `?tab=lifecycle` initial state — Tabs component
+// dùng `value={tab}` controlled (URL-derived), không phải `defaultValue`.
+const tabReplaceMock = vi.fn()
+const searchParamsMock = vi.fn(() => new URLSearchParams())
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: tabReplaceMock, push: vi.fn() }),
+  useSearchParams: () => searchParamsMock(),
+  usePathname: () => "/admin/admission-config",
+}))
+
 const hoisted = vi.hoisted(() => {
   const defaultPath = {
     id: 109,
@@ -85,6 +97,10 @@ beforeEach(() => {
   hoisted.mockDeactivate.mockReset()
   toastError.mockReset()
   toastSuccess.mockReset()
+  tabReplaceMock.mockReset()
+  // Reset URL search params về default empty cho mỗi test; test có thể
+  // override qua searchParamsMock.mockReturnValue(...) inside test body.
+  searchParamsMock.mockImplementation(() => new URLSearchParams())
   // Reset path mock to default; per-test override với mockReturnValue if needed
   hoisted.mockUseAdmissionPath.mockReturnValue({
     data: hoisted.defaultPath,
@@ -145,10 +161,10 @@ describe("PathDetailDrawer 5-tab", () => {
       },
       isLoading: false,
     })
-    const user = userEvent.setup()
+    // Pre-set ?tab=lifecycle vì Tabs component controlled bởi URL (FM-2).
+    // Click tab Vòng đời trong test không persist vì mock router stateless.
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=lifecycle"))
     render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
-
-    await user.click(screen.getByRole("tab", { name: /Vòng đời/ }))
 
     await waitFor(() => {
       const activateBtn = screen.getByRole("button", {
@@ -168,10 +184,8 @@ describe("PathDetailDrawer 5-tab", () => {
       },
       isLoading: false,
     })
-    const user = userEvent.setup()
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=lifecycle"))
     render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
-
-    await user.click(screen.getByRole("tab", { name: /Vòng đời/ }))
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /Vô hiệu hoá/ })).toBeTruthy()


### PR DESCRIPTION
## Summary

12 admission-config vitest tests fail post Phase 2 PR-2D.1 v4a (PR #251) do feature changes drift test fixtures. Đã defer post-Phase-2 closure; PR này bundle 4 file fix → 88/88 PASS.

## Root cause

| Component | Fails | Root cause |
|---|---|---|
| PathDetailDrawer | 5 | FM-2 useRouter cho tab URL state — mock thiếu next/navigation |
| ByMajorView | 5 | FM-3 selectedAcademicInfoId URL-driven — auto-select effect via router.replace stateless trong mock |
| AggregateDrawer | 1 | Nested PathDetailDrawer dùng useRouter → same FM-2 trap |
| RoundsManagementTab | 1 | CHECKPOINT 2 restore round thay button label trên archived rows |

## Fixes

1. **PathDetailDrawer.test.tsx**: add `vi.mock("next/navigation")` + `searchParamsMock` factory per-test override; 2 Lifecycle tab tests pre-set `?tab=lifecycle` vì Tabs controlled by URL (click trong mock router stateless không persist).

2. **ByMajorView.test.tsx**: refactor mock dùng `searchParamsMock` factory với default `"academicInfo=70"` để matrix load (auto-select effect → router.replace stateless không update URL).

3. **AggregateDrawer.test.tsx**: add `vi.mock("next/navigation")` cho nested PathDetailDrawer drill-down test.

4. **RoundsManagementTab.test.tsx**: archive button count 2→1 + thêm restore button count assertion + verify restore button NOT disabled trên archived row.

## Verification

- [x] All 15 admission-config test files **88/88 PASS**
- [x] No production code touch (test fixtures only)
- [ ] Post-merge: CI gate verify (deploy.yml `paths-ignore: **.md` không loại test files; deploy SẼ trigger nhưng tests-only diff không impact prod)

## Process learnings

- Mock URL state: dùng `vi.fn(() => new URLSearchParams("..."))` thay inline factory để per-test override
- Tabs controlled bởi URL: tests pre-set initial searchParams thay vì click tab
- Feature add/replace button: test fixture phải update assertion count + verify new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)