### PR TITLE
test-debt(admission): FM-2 click→URL anchor tests + AggregateDrawer mock parity

### DIFF
--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AggregateDrawer.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AggregateDrawer.test.tsx
@@ -11,12 +11,17 @@ import { describe, expect, it, vi } from "vitest"
 
 import { AggregateDrawer } from "./AggregateDrawer"
 
-// Test-debt fix 2026-05-11: drill-down test render nested PathDetailDrawer
-// dùng useRouter (FM-2 tab URL state). Mock next/navigation parity với
-// PathDetailDrawer.test.tsx tránh "invariant expected app router to be mounted".
+// Test-debt fix 2026-05-11 + follow-up parity 2026-05-11:
+// drill-down test render nested PathDetailDrawer dùng useRouter
+// (FM-2 tab URL state). Mock factory pattern parity với
+// PathDetailDrawer.test.tsx + ByMajorView.test.tsx — `searchParamsMock`
+// vi.fn cho phép future per-test override qua mockReturnValue nếu cần
+// initial tab/pathId state khác default.
+const aggregateReplaceMock = vi.fn()
+const searchParamsMock = vi.fn(() => new URLSearchParams())
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
-  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: aggregateReplaceMock, push: vi.fn() }),
+  useSearchParams: () => searchParamsMock(),
   usePathname: () => "/admin/admission-config",
 }))
 

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
@@ -192,4 +192,53 @@ describe("PathDetailDrawer 5-tab", () => {
     })
     expect(screen.queryByRole("button", { name: /Kích hoạt/ })).toBeNull()
   })
+
+  // FM-2 contract anchor: click tab updates ?tab= URL searchParam via
+  // router.replace. Trade-off cho 2 Lifecycle tests trên dùng pre-set
+  // ?tab=lifecycle (avoid mock router stateless click→URL gap) —
+  // anchor test này verify click→URL contract observable từ outside.
+  // 5-tab `it.each` cover toàn bộ FM-2 contract thay vì 1 tab anchor.
+  //
+  // Edge: tab "quota" là default → click "quota" KHÔNG add ?tab=quota
+  // (component xóa param khi value === default per FM-2 impl line 99).
+  // Test "quota" verify replaceMock called với URL KHÔNG chứa "tab=".
+  it.each([
+    ["identity", "Định danh"],
+    ["criteria", "Tiêu chí"],
+    ["documents", "Giấy tờ"],
+    ["lifecycle", "Vòng đời"],
+  ])(
+    "ANCHOR (FM-2): click tab %s updates ?tab=%s URL",
+    async (param, label) => {
+      const user = userEvent.setup()
+      render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+      // Click tab — Radix Tabs trigger button accessible qua role=tab.
+      // Tên trigger là Vietnamese label.
+      const tabTrigger = screen.getByRole("tab", {
+        name: new RegExp(label, "i"),
+      })
+      await user.click(tabTrigger)
+      // replaceMock được gọi với URL chứa `tab=<param>`. Format:
+      // `${pathname}?tab=<param>` hoặc query string variant.
+      expect(tabReplaceMock).toHaveBeenCalled()
+      const lastCall = tabReplaceMock.mock.calls.at(-1)
+      const url = lastCall?.[0] as string
+      expect(url).toContain(`tab=${param}`)
+    },
+  )
+
+  it("ANCHOR (FM-2): click tab Quota (default) clears ?tab= URL param", async () => {
+    const user = userEvent.setup()
+    // Start from non-default tab để có tab=criteria trong URL trước click
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=criteria"))
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+    const quotaTab = screen.getByRole("tab", { name: /Chỉ tiêu/i })
+    await user.click(quotaTab)
+    expect(tabReplaceMock).toHaveBeenCalled()
+    const lastCall = tabReplaceMock.mock.calls.at(-1)
+    const url = lastCall?.[0] as string
+    // Default tab "quota" xóa ?tab= param khỏi URL — FM-2 contract line 99
+    // `if (next === "quota") params.delete("tab")`.
+    expect(url).not.toContain("tab=")
+  })
 })


### PR DESCRIPTION
## Summary

Follow-up sau PR #255 test-debt batch. 2 commits atomic:

### Commit 1 — Item 2: AggregateDrawer mock factory parity (LOW)
- Refactor AggregateDrawer.test.tsx mock pattern align với PathDetailDrawer + ByMajorView (vi.fn factory thay inline arrow stateless)
- No behavior change; 5/5 tests vẫn PASS với default empty searchParams
- Cheap consistency improvement giảm cognitive load future readers

### Commit 2 — Item 1: FM-2 click→URL contract anchor tests (MEDIUM)
- Trade-off recovery: 2 Lifecycle tab tests (PR #255 line 154-194) pre-set `?tab=lifecycle` thay click → FM-2 contract không verify trong 2 test focus content
- New 5 anchor tests:
  - 4 `it.each` non-default tabs: click → `tab=<param>` trong URL
  - 1 default-clear: click Quota tab → URL không còn `tab=`
- Cover toàn FM-2 contract (5 tab labels + 2 contract branches: add param + clear default param)

## Verification

- [x] PathDetailDrawer tests: 5 → 10 (5 cũ + 4 it.each + 1 default-clear) PASS
- [x] AggregateDrawer tests: 5/5 PASS (no behavior change)
- [x] **Full admission-config suite: 88 → 93 PASS** (15 test files)

## Trade-off note

2 Lifecycle tab tests (`thin-client can_activate=false` + `status=active`) giữ pre-set `?tab=lifecycle` pattern — focus là Lifecycle tab CONTENT (Activate/Deactivate buttons + validation_errors), KHÔNG phải URL routing. New FM-2 contract tests cover routing fidelity riêng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)