### PR TITLE
chore(deps): override fast-uri + postcss to clear 4 npm audit vulns

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9812,9 +9812,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -12276,52 +12276,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -12865,9 +12819,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -125,5 +125,9 @@
     "*.{js,jsx,json,md,css}": [
       "prettier --write"
     ]
+  },
+  "overrides": {
+    "fast-uri": "^3.1.2",
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary

Add \`overrides\` block trong \`frontend/package.json\` để force vulnerable transitive deps lên patched versions. **All 4 npm audit vulns clear** (3 moderate + 1 high) — CI dependency-audit Node.js Dependencies sẽ chuyển từ FAILURE → SUCCESS sau merge.

## Vulns cleared

| Package | Severity | Advisory | Override |
|---|---|---|---|
| fast-uri ≤3.1.1 | 🔴 HIGH | GHSA-q3j6-qgpj-74h6 (path traversal) + GHSA-v39h-62p7-jpjc (host confusion) | `^3.1.2` |
| postcss <8.5.10 | 🟡 MODERATE | GHSA-qx2v-qp2m-jg93 (XSS unescaped \`</style>\`) | `^8.5.10` |
| next 9.3.4-c.0..16.3.0-c.5 | 🟡 MODERATE | Depends on vulnerable postcss | (auto-resolves via postcss override) |
| @sentry/nextjs | 🟡 MODERATE | Depends on vulnerable next | (auto-resolves) |

## Pre-check (verified)

- \`npm view next@latest\` → 16.2.6 vẫn pin postcss@8.4.31 — Next.js team chưa ship patch, override path required
- PostCSS 8.5.x semver minor backwards-compatible với 8.4.x
- Approach B (Next bump) KHÔNG khả thi: latest Next 16.2.6 chưa fix; tránh major bump (16→17) ngoài scope

## Test gate (all PASS)

- [x] \`npm audit\`: **found 0 vulnerabilities** (was \"4 vulnerabilities\")
- [x] FE type-check: 0 errors
- [x] FE lint: 0 errors / 207 warnings (pre-existing non-blocking)
- [x] FE vitest CI gate: **135/135 PASS** (93 admission-config + 42 CI 3 files)
- [x] Docker frontend build: clean
- [ ] Post-merge: CI Node.js Dependencies SUCCESS

## Risk assessment

- ⬇ LOW: fast-uri devdep-only chain (commitlint); zero runtime impact
- 🟡 MEDIUM-LOW: postcss override forces Next.js internal bump. Test gates all pass; runtime CSS pipeline được verify gián tiếp qua vitest (PostCSS chạy build-time). Post-merge browser smoke recommended để verify CSS rendering trong prod build.

## Outstanding

- Khi Next.js ship patch native với postcss>=8.5.10, có thể remove override (sẽ tự inherit qua next minor bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)