### PR TITLE
fix(admission): parseApiError helper + useUpdatePathQuota cache parity (Bug #1 + #2)

### DIFF
--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ClonePathsDialog.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/ClonePathsDialog.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/components/ui/select"
 import { useAdmissionRounds } from "@/hooks/admissions/useAdmissionRounds"
 import { useClonePathsFromRound } from "@/hooks/admissions/useClonePathsFromRound"
+import { parseApiError } from "@/lib/utils/api-errors"
 
 interface AdmissionRound {
   id: number
@@ -77,10 +78,7 @@ export function ClonePathsDialog({ academicYear, onClose }: Props) {
       )
       onClose()
     } catch (e: unknown) {
-      const msg =
-        (e as { response?: { data?: { detail?: string } } }).response?.data?.detail ??
-        (e instanceof Error ? e.message : "Lỗi sao chép — kiểm tra dữ liệu và thử lại.")
-      toast.error(msg)
+      toast.error(parseApiError(e, "Lỗi sao chép — kiểm tra dữ liệu và thử lại."))
     }
   }
 

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
@@ -227,6 +227,32 @@ describe("PathDetailDrawer 5-tab", () => {
     },
   )
 
+  // Bug #1 anchor test (2026-05-11): khi BE return 400 với response.data.detail,
+  // toast phải hiển thị BE detail KHÔNG phải axios generic "Request failed
+  // with status code 400". parseApiError helper xử lý parse + fallback.
+  it("ANCHOR (Bug #1): toast hiển thị BE detail thay vì axios generic khi save quota fail", async () => {
+    const user = userEvent.setup()
+    hoisted.mockUpdateQuota.mockRejectedValueOnce({
+      response: { data: { detail: "Tier 1 chain violated: tổng admit_quota=80 vượt cap năm=70" } },
+    })
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    const submitInput = screen.getByLabelText(/Trần submit/) as HTMLInputElement
+    const admitInput = screen.getByLabelText(/Trần admit/) as HTMLInputElement
+    await user.clear(submitInput)
+    await user.type(submitInput, "100")
+    await user.clear(admitInput)
+    await user.type(admitInput, "80")
+
+    await user.click(screen.getByRole("button", { name: /Lưu chỉ tiêu/ }))
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        "Tier 1 chain violated: tổng admit_quota=80 vượt cap năm=70",
+      )
+    })
+  })
+
   it("ANCHOR (FM-2): click tab Quota (default) clears ?tab= URL param", async () => {
     const user = userEvent.setup()
     // Start from non-default tab để có tab=criteria trong URL trước click

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
@@ -61,6 +61,7 @@ import {
   quotaMatrixKeys,
   useUpdatePathQuota,
 } from "@/hooks/admissions/useQuotaMatrix"
+import { parseApiError } from "@/lib/utils/api-errors"
 import type { AdmissionPathResponse } from "@/lib/zod/admission-path"
 
 import { ConfigCriteria } from "../ConfigCriteria"
@@ -222,8 +223,7 @@ function QuotaTab({
       toast.success("Đã lưu chỉ tiêu")
       onClose()
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Lỗi lưu — kiểm tra mạng và thử lại."
-      toast.error(msg)
+      toast.error(parseApiError(e, "Lỗi lưu — kiểm tra mạng và thử lại."))
     }
   }
 
@@ -333,8 +333,7 @@ function IdentityTab({
       toast.success("Đã lưu định danh")
       onClose()
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Lỗi lưu — kiểm tra mạng và thử lại."
-      toast.error(msg)
+      toast.error(parseApiError(e, "Lỗi lưu — kiểm tra mạng và thử lại."))
     }
   }
 
@@ -487,8 +486,7 @@ function LifecycleTab({
       toast.success("Đã kích hoạt đường tuyển sinh")
       onClose()
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Lỗi kích hoạt — kiểm tra checklist và thử lại."
-      toast.error(msg)
+      toast.error(parseApiError(e, "Lỗi kích hoạt — kiểm tra checklist và thử lại."))
     }
   }
 
@@ -500,8 +498,7 @@ function LifecycleTab({
       toast.success("Đã vô hiệu hoá đường tuyển sinh")
       onClose()
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : "Lỗi vô hiệu hoá — thử lại sau."
-      toast.error(msg)
+      toast.error(parseApiError(e, "Lỗi vô hiệu hoá — thử lại sau."))
     }
   }
 

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/QuickCreatePathModal.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/QuickCreatePathModal.tsx
@@ -32,6 +32,8 @@ import {
 } from "@/components/ui/select"
 import { useCreateAdmissionPath } from "@/hooks/admissions/useAdmissionPaths"
 import { useAdmissionMethods } from "@/hooks/admissions/useMasterData"
+import { parseApiError } from "@/lib/utils/api-errors"
+
 import type { AdmissionMethod } from "../../shared/types"
 
 interface Props {
@@ -79,10 +81,7 @@ export function QuickCreatePathModal({
       toast.success("Đã tạo đường tuyển sinh. Mở chi tiết để cấu hình tiêu chí &amp; giấy tờ.")
       onCreated(created.id)
     } catch (e: unknown) {
-      const msg =
-        (e as { response?: { data?: { detail?: string } } }).response?.data?.detail ??
-        (e instanceof Error ? e.message : "Lỗi tạo — kiểm tra dữ liệu và thử lại.")
-      toast.error(msg)
+      toast.error(parseApiError(e, "Lỗi tạo — kiểm tra dữ liệu và thử lại."))
     }
   }
 

--- a/frontend/src/hooks/admissions/useQuotaMatrix.test.tsx
+++ b/frontend/src/hooks/admissions/useQuotaMatrix.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * Anchor test cho useUpdatePathQuota cache invalidation (Bug #2 fix).
+ *
+ * Verify mutation onSuccess invalidate cả admissionPathKeys.detail(pathId)
+ * VÀ quotaMatrixKeys.all — drawer reopen sau save không read stale cache.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/api/quota-matrix", () => ({
+  updatePathQuota: vi.fn(async () => ({ ok: true })),
+  getPathMatrixByMajor: vi.fn(),
+  getQuotaMatrix: vi.fn(),
+}))
+
+import { useUpdatePathQuota, quotaMatrixKeys } from "./useQuotaMatrix"
+import { admissionPathKeys } from "./useAdmissionPaths"
+
+function makeWrapper(qc: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  )
+}
+
+describe("useUpdatePathQuota", () => {
+  it("ANCHOR (Bug #2 cache parity): invalidates admissionPathKeys.detail(pathId) on success", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const invalidateSpy = vi.spyOn(qc, "invalidateQueries")
+
+    const { result } = renderHook(() => useUpdatePathQuota(), {
+      wrapper: makeWrapper(qc),
+    })
+
+    await result.current.mutateAsync({
+      pathId: 106,
+      data: { round_quota: 50, admit_quota: 30 },
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: admissionPathKeys.detail(106),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: quotaMatrixKeys.all,
+    })
+  })
+})

--- a/frontend/src/hooks/admissions/useQuotaMatrix.ts
+++ b/frontend/src/hooks/admissions/useQuotaMatrix.ts
@@ -10,6 +10,8 @@ import {
   type AdmissionPathQuotaUpdate,
 } from "@/lib/api/quota-matrix"
 
+import { admissionPathKeys } from "./useAdmissionPaths"
+
 export const quotaMatrixKeys = {
   all: ["quota-matrix"] as const,
   byYear: (year: number) => [...quotaMatrixKeys.all, "year", year] as const,
@@ -45,7 +47,15 @@ export function useUpdatePathQuota() {
       pathId: number
       data: AdmissionPathQuotaUpdate
     }) => updatePathQuota(pathId, data),
-    onSuccess: () => {
+    onSuccess: (_result, variables) => {
+      // Invalidate path detail to refetch fresh quota — fixes drawer reopen
+      // showing stale empty inputs after save (parity với
+      // useUpdatePathDocuments:199-200 pattern; useUpdateAdmissionPath
+      // dùng setQueryData được vì BE return full path, ở đây response
+      // shape untyped nên invalidate an toàn hơn).
+      queryClient.invalidateQueries({
+        queryKey: admissionPathKeys.detail(variables.pathId),
+      })
       queryClient.invalidateQueries({ queryKey: quotaMatrixKeys.all })
     },
   })

--- a/frontend/src/lib/utils/api-errors.test.ts
+++ b/frontend/src/lib/utils/api-errors.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import { parseApiError } from "./api-errors"
+
+describe("parseApiError", () => {
+  it("returns Pydantic string detail when present", () => {
+    const e = { response: { data: { detail: "Tier 1 chain violated: vượt cap năm" } } }
+    expect(parseApiError(e, "fb")).toBe("Tier 1 chain violated: vượt cap năm")
+  })
+
+  it("joins Pydantic v2 array of validation errors via msg", () => {
+    const e = {
+      response: {
+        data: {
+          detail: [
+            { msg: "field required", loc: ["body", "round_quota"] },
+            { msg: "value must be positive", loc: ["body", "admit_quota"] },
+          ],
+        },
+      },
+    }
+    expect(parseApiError(e, "fb")).toBe("field required; value must be positive")
+  })
+
+  it("falls back to Error.message when no axios response shape", () => {
+    expect(parseApiError(new Error("Network Error"), "fb")).toBe("Network Error")
+  })
+
+  it("returns fallback when shape unknown", () => {
+    expect(parseApiError({}, "fallback msg")).toBe("fallback msg")
+    expect(parseApiError(null, "fallback msg")).toBe("fallback msg")
+    expect(parseApiError(undefined, "fallback msg")).toBe("fallback msg")
+  })
+
+  it("returns fallback when detail is empty string or invalid", () => {
+    expect(parseApiError({ response: { data: { detail: "" } } }, "fb")).toBe("fb")
+    expect(parseApiError({ response: { data: { detail: 123 } } }, "fb")).toBe("fb")
+  })
+
+  it("filters non-string msg entries in array", () => {
+    const e = {
+      response: { data: { detail: [{ msg: "ok" }, { msg: null }, { foo: "bar" }] } },
+    }
+    expect(parseApiError(e, "fb")).toBe("ok")
+  })
+})

--- a/frontend/src/lib/utils/api-errors.ts
+++ b/frontend/src/lib/utils/api-errors.ts
@@ -1,0 +1,29 @@
+/**
+ * Parse axios/fetch error and extract user-readable message.
+ *
+ * Priority:
+ * 1. Pydantic/FastAPI `response.data.detail` (string OR array of validation
+ *    errors with `msg`)
+ * 2. JS `Error.message` (network, timeout, etc.)
+ * 3. Caller-provided fallback
+ */
+export function parseApiError(e: unknown, fallback: string): string {
+  const detail = (e as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail
+
+  if (typeof detail === "string" && detail.length > 0) {
+    return detail
+  }
+
+  if (Array.isArray(detail)) {
+    const msgs = detail
+      .map((d) => (d as { msg?: unknown })?.msg)
+      .filter((m): m is string => typeof m === "string" && m.length > 0)
+    if (msgs.length > 0) return msgs.join("; ")
+  }
+
+  if (e instanceof Error && e.message.length > 0) {
+    return e.message
+  }
+
+  return fallback
+}


### PR DESCRIPTION
## Summary

Fix 2 bugs phát hiện trong E2E browser round 2 Quota Matrix UI (post Phase 2 sprint CLOSED 2026-05-11).

- **Bug #1** (HIGH): 4 callsites `PathDetailDrawer.tsx` hiển thị toast `"Request failed with status code 400"` thay vì BE detail (Tier 1 chain violation, UNIQUE conflict, etc.). User mất context tại sao save fail.
- **Bug #2** (HIGH): Reopen drawer sau save quota → inputs RỖNG mặc dù data persist. Root cause: `useUpdatePathQuota.onSuccess` chỉ invalidate `quotaMatrixKeys.all`, KHÔNG đụng `admissionPathKeys.detail(pathId)` → stale cache.

## Changes

- **NEW** `frontend/src/lib/utils/api-errors.ts`: `parseApiError(e, fallback)` helper xử lý Pydantic string detail + array of validation errors + Error.message fallback. 6 anchor tests cover all branches.
- `useQuotaMatrix.ts` `useUpdatePathQuota.onSuccess`: thêm `invalidateQueries(admissionPathKeys.detail(variables.pathId))` parity với `useUpdatePathDocuments:199-200`. KHÔNG dùng setQueryData vì `updatePathQuota` API response type `unknown`. Anchor test verify 2 keys invalidated.
- `PathDetailDrawer.tsx` 4 callsites (QuotaTab/IdentityTab/Activate/Deactivate): replace inline narrow bằng `parseApiError()` call.
- `QuickCreatePathModal.tsx` + `ClonePathsDialog.tsx`: refactor 2 inline duplicates dùng helper (consistency).
- `PathDetailDrawer.test.tsx`: anchor test verify toast hiển thị BE detail thay vì generic.

## Out of scope (follow-up)

44 files khác trong codebase có inline error parse variants (Notifications, Finance, Hooks) — tách follow-up "fe-tech-debt/api-error-helper-rollout" sau.

Bug #3 (FM-2 tab URL không update runtime) defer sang PR B (runtime debug + lift state).

## Test plan

- [x] type-check PASS
- [x] Vitest 18/18 (api-errors 6 + useQuotaMatrix 1 + PathDetailDrawer 11)
- [x] Lint 0 errors
- [x] Browser smoke Bug #1: toast hiển thị `"Tier 1 chain violated: tổng admit_quota của ngành academic_info_id=69 sẽ là 80 (current 20 + delta 60), vượt annual_admission_quota=70"`
- [x] Browser smoke Bug #2: reopen drawer hiển thị value 30/50 server canonical
- [ ] Prod smoke post-deploy: reproduce 2 fixes trên `/admin/admission-config?view=quota-matrix`

Note: `status-config.test.ts:50` fail là pre-existing baseline main HEAD (verified bằng git stash → test trên main → same fail), không liên quan PR này.

🤖 Generated with [Claude Code](https://claude.com/claude-code)