### PR TITLE
feat(admission): Phase 3 PR-3A — multi-NV schema + models + service + 21 tests

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase3_01_create_admission_profile_choice_and_score.py
+++ b/Backend_FastAPI/alembic/versions/phase3_01_create_admission_profile_choice_and_score.py
@@ -1,0 +1,357 @@
+"""Phase 3 PR-3A — admission_profile_choice + profile_choice_score tables
+
+Bundle migration per plan v0.6 G1:
+1. 2 NEW tables (admission_profile_choice + profile_choice_score)
+2. 3 ALTER columns:
+   - offering_admission_round.allow_multi_nv (Q-P3-02 per-round flag)
+   - offering_admission_round.confirm_expiry_hours (Q-P3-06 per-round)
+   - notification_rule.bypass_consent (Q-P3-07 per-rule)
+3. 1 INSERT system_config row (Q-P3-01 max_choices_per_profile=5)
+4. 1 UPDATE notification_rule bypass_consent=true cho 5 system-critical events
+
+FK ON DELETE CASCADE/RESTRICT per GAP-18 v0.6:
+- admission_profile_choice.admission_profile_id ON DELETE CASCADE
+- admission_profile_choice.admission_path_id ON DELETE RESTRICT
+- admission_profile_choice.path_subject_group_config_id ON DELETE RESTRICT
+- profile_choice_score.admission_profile_choice_id ON DELETE CASCADE
+- profile_choice_score.subject_id ON DELETE RESTRICT
+
+UNIQUE constraints:
+- (admission_profile_id, admission_path_id, path_subject_group_config_id) — P1 fix #4 v1.3
+- (admission_profile_id, display_order) — chặn 2 NV cùng priority
+
+CHECK constraints:
+- display_order BETWEEN 1 AND 10 (Q-P3-01 hard upper bound; system_config soft default 5)
+
+GAP-29 v0.6: notification_rule column name là `event` (NOT `event_code`)
+GAP-31 v0.6: 12 events match SystemEvents enum (8 wired + 4 deferred)
+
+Revision ID: phase3_01
+Revises: phase2_06
+Create Date: 2026-05-12
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "phase3_01"
+down_revision: Union[str, None] = "phase2_06"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ============================================================
+    # 0. PRE-FLIGHT AUDIT — C1 fix v0.6 (memory migration-predicate-safety)
+    # ============================================================
+    # Verify 5 system-critical events exist trong notification_rule
+    # (Phase 1 #19c-d seed). Block migration nếu seed missing — better
+    # than silent UPDATE-0 leaving bypass_consent uninitialized.
+    conn = op.get_bind()
+    events_count = conn.execute(
+        sa.text(
+            """
+            SELECT COUNT(*) FROM notification_rule
+            WHERE event IN (
+                'ADMISSION_RESULT_PUBLISHED',
+                'ADMISSION_DECISION_ADMITTED',
+                'ADMISSION_DECISION_WAITLISTED',
+                'ADMISSION_DECISION_REJECTED',
+                'ADMISSION_ENROLLED'
+            )
+            """
+        )
+    ).scalar()
+    if events_count is None or int(events_count) < 5:
+        raise RuntimeError(
+            f"Pre-flight fail: {events_count}/5 system-critical events found "
+            f"trong notification_rule. Phase 1 #19c-d seed missing — apply "
+            f"prerequisite migrations trước phase3_01."
+        )
+
+    # ============================================================
+    # 1. Create admission_profile_choice table
+    # ============================================================
+    op.create_table(
+        "admission_profile_choice",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column(
+            "admission_profile_id",
+            sa.Integer(),
+            sa.ForeignKey("admission_profile.id", ondelete="CASCADE"),
+            nullable=False,
+            comment="Phase 3 multi-NV — link profile (GAP-18: CASCADE on profile delete)",
+        ),
+        sa.Column(
+            "admission_path_id",
+            sa.Integer(),
+            sa.ForeignKey("admission_path.id", ondelete="RESTRICT"),
+            nullable=False,
+            comment="Path = ngành × phương thức × đợt (GAP-18: RESTRICT — path archive via status flag)",
+        ),
+        sa.Column(
+            "path_subject_group_config_id",
+            sa.Integer(),
+            sa.ForeignKey("path_subject_group_config.id", ondelete="RESTRICT"),
+            nullable=False,
+            comment="Tổ hợp môn snapshot (GAP-18: RESTRICT)",
+        ),
+        sa.Column(
+            "display_order",
+            sa.Integer(),
+            nullable=False,
+            comment="Thứ tự ưu tiên NV (1 = cao nhất, max 10 per Q-P3-01)",
+        ),
+        sa.Column(
+            "decision",
+            sa.String(20),
+            nullable=False,
+            server_default="pending",
+            comment="Engine decision: pending/admitted/waitlisted/rejected/skip",
+        ),
+        sa.Column(
+            "waitlist_rank",
+            sa.Integer(),
+            nullable=True,
+            comment="Rank trong waitlist (GAP-30: assigned at T6 engine, 1-based, unique per path×round)",
+        ),
+        sa.Column(
+            "eligibility_check_result",
+            sa.dialects.postgresql.JSONB(),
+            nullable=True,
+            comment="JSONB snapshot 6-rule engine result (computed at T6 publish)",
+        ),
+        sa.Column(
+            "bonus_rule_snapshot",
+            sa.dialects.postgresql.JSONB(),
+            nullable=True,
+            comment="BonusRule snapshot tại T6 publish time (Q-P3-11 NOT T1 submit)",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        # UNIQUE: chặn duplicate (profile, path, config) — P1 fix #4 v1.3
+        sa.UniqueConstraint(
+            "admission_profile_id", "admission_path_id", "path_subject_group_config_id",
+            name="uq_admission_profile_choice_path_config",
+        ),
+        # UNIQUE: chặn 2 NV cùng priority per profile
+        sa.UniqueConstraint(
+            "admission_profile_id", "display_order",
+            name="uq_admission_profile_choice_display_order",
+        ),
+        # CHECK: display_order range 1-10 (Q-P3-01 hard upper bound)
+        sa.CheckConstraint(
+            "display_order BETWEEN 1 AND 10",
+            name="ck_admission_profile_choice_display_order_range",
+        ),
+        # CHECK: decision enum
+        sa.CheckConstraint(
+            "decision IN ('pending', 'admitted', 'waitlisted', 'rejected', 'skip')",
+            name="ck_admission_profile_choice_decision",
+        ),
+    )
+
+    # Indexes (engine query + admin queue)
+    op.create_index(
+        "ix_admission_profile_choice_profile_decision",
+        "admission_profile_choice",
+        ["admission_profile_id", "decision"],
+    )
+    op.create_index(
+        "ix_admission_profile_choice_path_id",
+        "admission_profile_choice",
+        ["admission_path_id"],
+    )
+
+    # ============================================================
+    # 2. Create profile_choice_score table
+    # ============================================================
+    op.create_table(
+        "profile_choice_score",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column(
+            "admission_profile_choice_id",
+            sa.BigInteger(),
+            sa.ForeignKey("admission_profile_choice.id", ondelete="CASCADE"),
+            nullable=False,
+            comment="Link choice (GAP-18: CASCADE on choice delete)",
+        ),
+        sa.Column(
+            "subject_id",
+            sa.Integer(),
+            sa.ForeignKey("subject.id", ondelete="RESTRICT"),
+            nullable=False,
+            comment="Subject (GAP-18: RESTRICT — không delete subject đang used)",
+        ),
+        sa.Column(
+            "score",
+            sa.Numeric(8, 2),
+            nullable=False,
+            comment="Điểm thí sinh (V-ACT/DGNL 1200-point max precision)",
+        ),
+        sa.Column(
+            "max_score_snapshot",
+            sa.Numeric(8, 2),
+            nullable=False,
+            comment="Max score tại submit time (snapshot)",
+        ),
+        sa.Column(
+            "min_possible_score_snapshot",
+            sa.Numeric(8, 2),
+            nullable=True,
+            comment="Min possible score snapshot (P2 fix #8 v1.9 — default 0 cho legacy)",
+        ),
+        sa.Column(
+            "weight_snapshot",
+            sa.Numeric(5, 2),
+            nullable=False,
+            server_default="1.00",
+            comment="Subject weight in scoring formula (snapshot)",
+        ),
+        # UNIQUE per (choice, subject)
+        sa.UniqueConstraint(
+            "admission_profile_choice_id", "subject_id",
+            name="uq_profile_choice_score_choice_subject",
+        ),
+        # CHECK: score >= 0 (snapshot bounds enforced trong engine, NOT DB CHECK
+        # vì max varies per path config)
+        sa.CheckConstraint(
+            "score >= 0",
+            name="ck_profile_choice_score_non_negative",
+        ),
+    )
+
+    op.create_index(
+        "ix_profile_choice_score_choice_id",
+        "profile_choice_score",
+        ["admission_profile_choice_id"],
+    )
+
+    # ============================================================
+    # 3. ALTER offering_admission_round — Q-P3-02 + Q-P3-06
+    # ============================================================
+    op.add_column(
+        "offering_admission_round",
+        sa.Column(
+            "allow_multi_nv",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+            comment="Q-P3-02 per-round flag — 2026 false, 2027 admin enable",
+        ),
+    )
+    op.add_column(
+        "offering_admission_round",
+        sa.Column(
+            "confirm_expiry_hours",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("168"),
+            comment="Q-P3-06 magic-link confirm expiry per-round (default 168h = 7d)",
+        ),
+    )
+
+    # ============================================================
+    # 4. ALTER notification_rule — Q-P3-07
+    # ============================================================
+    op.add_column(
+        "notification_rule",
+        sa.Column(
+            "bypass_consent",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+            comment="Q-P3-07 per-rule bypass consent flag — system-critical events override consent",
+        ),
+    )
+
+    # ============================================================
+    # 5. INSERT system_config Q-P3-01
+    # ============================================================
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO system_config (key, value, description, updated_at)
+            VALUES (
+                'max_choices_per_profile',
+                '5'::jsonb,
+                'Max NV per profile, mùa 2026 default. DB CHECK display_order BETWEEN 1 AND 10 hard upper bound.',
+                now()
+            )
+            ON CONFLICT (key) DO NOTHING
+            """
+        )
+    )
+
+    # ============================================================
+    # 6. UPDATE notification_rule bypass_consent cho 5 events
+    # GAP-29: column name là `event` (NOT `event_code`)
+    # ============================================================
+    op.execute(
+        sa.text(
+            """
+            UPDATE notification_rule
+            SET bypass_consent = true
+            WHERE event IN (
+                'ADMISSION_RESULT_PUBLISHED',
+                'ADMISSION_DECISION_ADMITTED',
+                'ADMISSION_DECISION_WAITLISTED',
+                'ADMISSION_DECISION_REJECTED',
+                'ADMISSION_ENROLLED'
+            )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Reverse order: drop tables → drop columns → cleanup data
+
+    # Rollback bypass_consent UPDATE (set back to false)
+    op.execute(
+        sa.text(
+            """
+            UPDATE notification_rule
+            SET bypass_consent = false
+            WHERE event IN (
+                'ADMISSION_RESULT_PUBLISHED',
+                'ADMISSION_DECISION_ADMITTED',
+                'ADMISSION_DECISION_WAITLISTED',
+                'ADMISSION_DECISION_REJECTED',
+                'ADMISSION_ENROLLED'
+            )
+            """
+        )
+    )
+
+    # Rollback system_config row
+    op.execute(
+        sa.text(
+            "DELETE FROM system_config WHERE key = 'max_choices_per_profile'"
+        )
+    )
+
+    # Drop ALTER columns
+    op.drop_column("notification_rule", "bypass_consent")
+    op.drop_column("offering_admission_round", "confirm_expiry_hours")
+    op.drop_column("offering_admission_round", "allow_multi_nv")
+
+    # Drop tables (CASCADE handles FK cleanup automatically)
+    op.drop_index("ix_profile_choice_score_choice_id", table_name="profile_choice_score")
+    op.drop_table("profile_choice_score")
+
+    op.drop_index("ix_admission_profile_choice_path_id", table_name="admission_profile_choice")
+    op.drop_index("ix_admission_profile_choice_profile_decision", table_name="admission_profile_choice")
+    op.drop_table("admission_profile_choice")

--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -63,6 +63,11 @@ __all__ = [
     # Admission Configuration Console IDOR
     "get_admission_path_for_user",  # Phase 1: Config Console
 
+    # Phase 3 Multi-NV IDOR (GAP-13 v0.6)
+    "get_choice_for_user",  # Officer scope: assigned profile choices
+    "get_choice_for_manager",  # Manager scope: unit-level choices
+    "get_backfill_exception_for_admin",  # Admin only — Q-P3-09
+
     # Collaborator System (Phase 1)
     "require_collaborator_role",
     "get_own_collaborator",
@@ -2688,3 +2693,183 @@ async def get_commission_record_for_user(
         if record.collaborator and record.collaborator.unit_id == current_user.unit_id:
             return record
     raise ResourceNotFoundError("Commission record not found")
+
+
+# ============================================================
+# Phase 3 Multi-NV IDOR gates (GAP-13 v0.6)
+# Memory: lead-active-user-casbin-pr4 precedent — raise 404 (not 403)
+# ============================================================
+
+
+async def get_choice_for_user(
+    choice_id: int = Path(..., description="Admission Profile Choice ID"),
+    current_user: "models.User" = Depends(get_current_active_user),
+    db: AsyncSession = Depends(database.get_db),
+) -> "models.AdmissionProfileChoice":
+    """IDOR gate for Officer/Manager mutations on a choice.
+
+    3-tier scope (Phase 3 parity với get_admission_for_user):
+    - Admin: all choices
+    - Manager: choices whose profile.lead.unit_id == user.unit_id
+    - Officer: choices whose profile.lead.assigned_officer_id == user.id
+
+    Returns 404 (not 403) for unauthorized — anti-enumeration.
+
+    Used by:
+    - PATCH /api/v2/admissions/{profile_id}/choices/{choice_id}/scores
+    - PATCH /api/v2/admissions/{profile_id}/choices/{choice_id}
+    - DELETE /api/v2/admissions/{profile_id}/choices/{choice_id}
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    from ..repositories.admission_profile_choice_repository import (
+        AdmissionProfileChoiceRepository,
+    )
+
+    stmt = (
+        select(models.AdmissionProfileChoice)
+        .where(models.AdmissionProfileChoice.id == choice_id)
+        .options(
+            selectinload(models.AdmissionProfileChoice.profile)
+            .selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+        )
+    )
+    result = await db.execute(stmt)
+    choice = result.scalar_one_or_none()
+
+    if choice is None:
+        raise ResourceNotFoundError(
+            detail=f"Choice {choice_id} not found"
+        )
+
+    if current_user.role != UserRole.ADMIN:
+        profile = choice.profile
+        if not profile or not profile.lead or profile.lead.unit_id != current_user.unit_id:
+            log.warning(
+                "IDOR attempt: User tried to access choice from different unit",
+                user_id=current_user.id,
+                user_unit_id=current_user.unit_id,
+                choice_id=choice_id,
+            )
+            raise ResourceNotFoundError(
+                detail=f"Choice {choice_id} not found"
+            )
+        if current_user.role == UserRole.OFFICER:
+            if profile.lead.assigned_officer_id != current_user.id:
+                log.warning(
+                    "IDOR attempt: Officer tried to access choice not assigned",
+                    user_id=current_user.id,
+                    choice_id=choice_id,
+                    assigned_officer_id=profile.lead.assigned_officer_id,
+                )
+                raise ResourceNotFoundError(
+                    detail=f"Choice {choice_id} not found"
+                )
+
+    return choice
+
+
+async def get_choice_for_manager(
+    choice_id: int = Path(..., description="Admission Profile Choice ID"),
+    current_user: "models.User" = Depends(get_current_active_user),
+    db: AsyncSession = Depends(database.get_db),
+) -> "models.AdmissionProfileChoice":
+    """IDOR gate for Manager-only operations (waitlist promote/reject).
+
+    2-tier scope:
+    - Admin: all choices
+    - Manager: choices whose profile.lead.unit_id == user.unit_id
+    - Officer + others: 404 (deny)
+
+    Used by:
+    - POST /api/v2/admissions/{profile_id}/choices/{choice_id}/promote (T10)
+    - POST /api/v2/admissions/{profile_id}/choices/{choice_id}/reject (T11)
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    stmt = (
+        select(models.AdmissionProfileChoice)
+        .where(models.AdmissionProfileChoice.id == choice_id)
+        .options(
+            selectinload(models.AdmissionProfileChoice.profile)
+            .selectinload(models.AdmissionProfile.lead),
+        )
+    )
+    result = await db.execute(stmt)
+    choice = result.scalar_one_or_none()
+
+    if choice is None:
+        raise ResourceNotFoundError(
+            detail=f"Choice {choice_id} not found"
+        )
+
+    if current_user.role == UserRole.ADMIN:
+        return choice
+
+    if current_user.role != UserRole.MANAGER:
+        log.warning(
+            "IDOR attempt: Non-manager tried to access manager-only choice op",
+            user_id=current_user.id,
+            user_role=current_user.role,
+            choice_id=choice_id,
+        )
+        raise ResourceNotFoundError(
+            detail=f"Choice {choice_id} not found"
+        )
+
+    profile = choice.profile
+    if not profile or not profile.lead or profile.lead.unit_id != current_user.unit_id:
+        log.warning(
+            "IDOR attempt: Manager cross-unit choice access",
+            user_id=current_user.id,
+            user_unit_id=current_user.unit_id,
+            choice_id=choice_id,
+        )
+        raise ResourceNotFoundError(
+            detail=f"Choice {choice_id} not found"
+        )
+
+    return choice
+
+
+async def get_backfill_exception_for_admin(
+    exception_id: int = Path(..., description="Backfill exception row ID"),
+    current_user: "models.User" = Depends(require_admin),
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Admin-only gate for Q-P3-09 admin backfill queue UI.
+
+    Note: ``require_admin`` dependency handles 403/permission denial cho
+    non-admin BEFORE reaching this gate body. Gate body chỉ resolve
+    exception row + raise 404 if missing — pattern parity với other
+    admin-only IDOR gates.
+
+    Used by:
+    - PATCH /api/v2/admin/admission-backfill-exceptions/{id}/resolve
+    """
+    from sqlalchemy import text
+
+    # _admission_backfill_exceptions table (Phase 1 #07b). Model class
+    # name TBD trong Phase 3 backfill PR — placeholder query via raw
+    # SQL until model registered. Em ship gate signature, body returns
+    # row dict (router consumes).
+    result = await db.execute(
+        text(
+            "SELECT id, profile_id, exception_type, details, "
+            "resolved_at, resolved_by_user_id, resolution_notes, "
+            "created_at "
+            "FROM _admission_backfill_exceptions WHERE id = :id"
+        ),
+        {"id": exception_id},
+    )
+    row = result.mappings().first()
+
+    if row is None:
+        raise ResourceNotFoundError(
+            detail=f"Backfill exception {exception_id} not found"
+        )
+
+    return dict(row)

--- a/Backend_FastAPI/app/models/__init__.py
+++ b/Backend_FastAPI/app/models/__init__.py
@@ -37,6 +37,12 @@ from .lead_phone import LeadPhoneIdentity
 from .admission import AdmissionProfile, AdmissionConfirmationToken
 # phase1_10 (#184 Wave 2 PR-2A) — status transition audit trail.
 from .admission_profile_status_history import AdmissionProfileStatusHistory
+# phase3_01 (#184 Wave 3 PR-3A) — multi-NV choice + per-choice score.
+from .admission_profile_choice import (
+    AdmissionProfileChoice,
+    ProfileChoiceScore,
+    CHOICE_DECISIONS,
+)
 from .admission_survey_feedback import AdmissionSurveyFeedback
 from .student import Student, StudentDocument
 

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -488,6 +488,19 @@ class AdmissionProfile(Base):
         lazy="selectin",  # ✅ FIX: Eager load to prevent MissingGreenlet in async
     )
 
+    # phase3_01 (#184 Wave 3 PR-3A) — multi-NV Phase 3.
+    # Active khi uses_choice_engine=true (legacy profiles có 0 choices,
+    # KHÔNG flow qua engine xét tuyển này). Cascade delete-orphan đảm bảo
+    # cleanup choices + scores khi profile xoá (matches FK ON DELETE
+    # CASCADE migration).
+    choices: Mapped[list["AdmissionProfileChoice"]] = relationship(
+        "AdmissionProfileChoice",
+        back_populates="profile",
+        cascade="all, delete-orphan",
+        order_by="AdmissionProfileChoice.display_order",
+        lazy="select",  # Engine query via selectinload explicit (GAP-22)
+    )
+
     # ✅ FIX #6: Audit trail relationships
     approved_by: Mapped["User"] = relationship(
         "User",

--- a/Backend_FastAPI/app/models/admission_config/path_subject_group.py
+++ b/Backend_FastAPI/app/models/admission_config/path_subject_group.py
@@ -69,7 +69,11 @@ class PathSubjectGroupConfig(Base):
 
     # Relationships
     admission_path = relationship("AdmissionPath", foreign_keys=[admission_path_id])
-    subject_group = relationship("SubjectGroup", foreign_keys=[subject_group_id])
+    subject_group = relationship(
+        "SubjectGroup",
+        foreign_keys=[subject_group_id],
+        lazy="selectin",  # phase3_01 Contract-06: eager-load for display_subject_group_name
+    )
     items = relationship(
         "PathSubjectGroupItem",
         back_populates="config",

--- a/Backend_FastAPI/app/models/admission_profile_choice.py
+++ b/Backend_FastAPI/app/models/admission_profile_choice.py
@@ -1,0 +1,249 @@
+# app/models/admission_profile_choice.py
+"""AdmissionProfileChoice + ProfileChoiceScore models — Phase 3 PR-3A.
+
+phase3_01 (#184 Wave 3 PR-3A) — multi-NV (multiple choices per profile)
++ per-subject score per choice. Implements PLAN line 982-1000 spec.
+
+Per PLAN v0.6 LOCKED + UI design v0.6:
+
+**AdmissionProfileChoice = 1 NV (Nguyện vọng)**:
+- profile × admission_path × path_subject_group_config
+- display_order = priority ranking (1 = top, max 10 per Q-P3-01 DB CHECK)
+- decision = engine result tại T6 publish (pending/admitted/waitlisted/
+  rejected/skip)
+- eligibility_check_result = 6-rule engine output snapshot JSONB
+- bonus_rule_snapshot = T6-time snapshot (Q-P3-11 NOT T1 submit)
+
+**ProfileChoiceScore = điểm thí sinh per subject per choice**:
+- choice × subject = 1 row (UNIQUE)
+- score Numeric(8,2) precision cho V-ACT/DGNL 1200-point
+- *_snapshot columns freeze max_score/min_possible/weight tại submit time
+
+**FK ON DELETE** (GAP-18 v0.6):
+- profile → choice CASCADE (profile delete clears choices)
+- choice → score CASCADE (choice delete clears scores)
+- path/config/subject → RESTRICT (lifecycle via archive flag)
+
+**Sequential engine** (PLAN line 1271 + 3.3):
+- Loop choices ORDER BY display_order
+- Đậu NV nào → mark admitted, remaining → skip
+- Waitlist → continue next NV
+
+Service invariant (P1 fix #4 v1.3): ``path_subject_group_config.
+admission_path_id == admission_profile_choice.admission_path_id``.
+"""
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Optional
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+if TYPE_CHECKING:
+    from app.models.admission import AdmissionProfile
+    from app.models.admission_config.admission_path import AdmissionPath
+    from app.models.admission_config.path_subject_group import (
+        PathSubjectGroupConfig,
+    )
+    from app.models.subject import Subject
+
+
+# Decision enum values (match phase3_01 CHECK constraint)
+CHOICE_DECISIONS = ("pending", "admitted", "waitlisted", "rejected", "skip")
+
+
+class AdmissionProfileChoice(Base):
+    """1 NV (nguyện vọng) trong Phase 3 multi-NV flow.
+
+    1 profile có thể có max 10 choices (DB CHECK display_order BETWEEN 1
+    AND 10; system_config soft default 5 mùa 2026).
+
+    Cùng (profile, path, config) chỉ 1 row (UNIQUE). Cùng (profile,
+    display_order) chỉ 1 row (UNIQUE) — chặn 2 NV cùng priority.
+
+    Service-layer guard ``add_choice`` (G7 v0.6) enforce:
+    - ``offering_admission_round.allow_multi_nv`` per-round flag
+    - ``system_config.max_choices_per_profile`` system-wide soft cap
+    """
+
+    __tablename__ = "admission_profile_choice"
+    __table_args__ = (
+        UniqueConstraint(
+            "admission_profile_id",
+            "admission_path_id",
+            "path_subject_group_config_id",
+            name="uq_admission_profile_choice_path_config",
+        ),
+        UniqueConstraint(
+            "admission_profile_id",
+            "display_order",
+            name="uq_admission_profile_choice_display_order",
+        ),
+        CheckConstraint(
+            "display_order BETWEEN 1 AND 10",
+            name="ck_admission_profile_choice_display_order_range",
+        ),
+        CheckConstraint(
+            "decision IN ('pending', 'admitted', 'waitlisted', "
+            "'rejected', 'skip')",
+            name="ck_admission_profile_choice_decision",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    admission_profile_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("admission_profile.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    admission_path_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("admission_path.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    path_subject_group_config_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("path_subject_group_config.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+
+    display_order: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Priority 1 (cao nhất) - 10 (thấp nhất)",
+    )
+    decision: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        server_default="pending",
+        comment="Engine output: pending/admitted/waitlisted/rejected/skip",
+    )
+    waitlist_rank: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        nullable=True,
+        comment="GAP-30: assigned at T6 engine, 1-based unique per path×round",
+    )
+    eligibility_check_result: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        JSONB,
+        nullable=True,
+        comment="6-rule engine result snapshot",
+    )
+    bonus_rule_snapshot: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        JSONB,
+        nullable=True,
+        comment="Q-P3-11: BonusRule snapshot tại T6 publish (NOT T1)",
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=__import__("sqlalchemy").text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=__import__("sqlalchemy").text("now()"),
+    )
+
+    # Relationships (selectinload via repository per GAP-22)
+    profile: Mapped["AdmissionProfile"] = relationship(
+        "AdmissionProfile",
+        back_populates="choices",
+    )
+    admission_path: Mapped["AdmissionPath"] = relationship(
+        "AdmissionPath",
+        lazy="selectin",
+    )
+    path_subject_group_config: Mapped["PathSubjectGroupConfig"] = relationship(
+        "PathSubjectGroupConfig",
+        lazy="selectin",
+    )
+    scores: Mapped[list["ProfileChoiceScore"]] = relationship(
+        "ProfileChoiceScore",
+        back_populates="choice",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+
+class ProfileChoiceScore(Base):
+    """Điểm thí sinh cho 1 subject thuộc 1 choice.
+
+    Mỗi choice link path_subject_group_config → list of subjects.
+    Score precision Numeric(8,2) hỗ trợ V-ACT/DGNL 1200-point.
+
+    *_snapshot columns freeze values tại submit time (admin update
+    path config sau submit → existing choice giữ snapshot, KHÔNG
+    affected).
+    """
+
+    __tablename__ = "profile_choice_score"
+    __table_args__ = (
+        UniqueConstraint(
+            "admission_profile_choice_id",
+            "subject_id",
+            name="uq_profile_choice_score_choice_subject",
+        ),
+        CheckConstraint(
+            "score >= 0",
+            name="ck_profile_choice_score_non_negative",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    admission_profile_choice_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("admission_profile_choice.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    subject_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("subject.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+
+    score: Mapped[Numeric] = mapped_column(
+        Numeric(8, 2),
+        nullable=False,
+    )
+    max_score_snapshot: Mapped[Numeric] = mapped_column(
+        Numeric(8, 2),
+        nullable=False,
+    )
+    min_possible_score_snapshot: Mapped[Optional[Numeric]] = mapped_column(
+        Numeric(8, 2),
+        nullable=True,
+        comment="P2 fix #8 v1.9: default 0 cho legacy",
+    )
+    weight_snapshot: Mapped[Numeric] = mapped_column(
+        Numeric(5, 2),
+        nullable=False,
+        server_default="1.00",
+    )
+
+    # Relationships
+    choice: Mapped["AdmissionProfileChoice"] = relationship(
+        "AdmissionProfileChoice",
+        back_populates="scores",
+    )
+    subject: Mapped["Subject"] = relationship(
+        "Subject",
+        lazy="selectin",
+    )

--- a/Backend_FastAPI/app/models/notification.py
+++ b/Backend_FastAPI/app/models/notification.py
@@ -123,6 +123,15 @@ class NotificationRule(Base):
     enabled = Column(Boolean, nullable=False, default=True, index=True,
                     comment="Enable/disable this rule")
 
+    # phase3_01 (#184 Wave 3 PR-3A) — Q-P3-07 per-rule bypass consent flag.
+    # System-critical events (decision/published/enrolled) bypass consent
+    # check khi flag=true. Seeded true cho 5 events (ADMISSION_RESULT_PUBLISHED,
+    # DECISION_ADMITTED/WAITLISTED/REJECTED, ENROLLED) trong phase3_01
+    # migration UPDATE statement.
+    bypass_consent = Column(Boolean, nullable=False, default=False,
+                            server_default="false",
+                            comment="Q-P3-07 per-rule bypass consent flag")
+
     # ✅ PHASE 3.1: Optional reference to reusable template
     template_id = Column(Integer, ForeignKey("notification_template.id", ondelete="SET NULL"),
                         nullable=True, index=True,

--- a/Backend_FastAPI/app/models/offering_admission_round.py
+++ b/Backend_FastAPI/app/models/offering_admission_round.py
@@ -102,6 +102,26 @@ class OfferingAdmissionRound(Base):
     )
     extension_reason = Column(Text, nullable=True)
 
+    # phase3_01 (#184 Wave 3 PR-3A) — Q-P3-02 + Q-P3-06.
+    # Per-round flag enable Phase 3 multi-NV. Default false (2026
+    # stay legacy single-NV; admin enable cho future 2027 round).
+    allow_multi_nv = Column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="false",
+        comment="Q-P3-02 per-round flag — Phase 3 multi-NV gate",
+    )
+    # Magic-link confirm expiry per-round (Q-P3-06 default 168h = 7d).
+    # Admin set per round (vd: DOT_1 = 7d, BO_SUNG = 3d).
+    confirm_expiry_hours = Column(
+        Integer,
+        nullable=False,
+        default=168,
+        server_default="168",
+        comment="Q-P3-06 magic-link confirm expiry per-round (hours)",
+    )
+
     created_at = Column(
         DateTime(timezone=True),
         nullable=False,

--- a/Backend_FastAPI/app/repositories/admission_profile_choice_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_profile_choice_repository.py
@@ -45,7 +45,18 @@ class AdmissionProfileChoiceRepository:
     async def get_by_id_with_relations(
         self, choice_id: int
     ) -> Optional[AdmissionProfileChoice]:
-        """GAP-22: selectinload chain — Contract-06 computed display fields."""
+        """GAP-22: selectinload chain — Contract-06 computed display fields.
+
+        Chain pre-loads:
+        - admission_path → academic_info + admission_method + admission_round
+        - path_subject_group_config → subject_group (Contract-06 fix v0.6)
+        - scores → subject
+        """
+        # Imports local để tránh circular
+        from app.models.admission_config.path_subject_group import (
+            PathSubjectGroupConfig,
+        )
+
         result = await self.db.execute(
             select(AdmissionProfileChoice)
             .where(AdmissionProfileChoice.id == choice_id)
@@ -57,10 +68,14 @@ class AdmissionProfileChoiceRepository:
                 selectinload(AdmissionProfileChoice.admission_path).selectinload(
                     AdmissionPath.admission_method
                 ),
-                # path_subject_group_config → subject_group
+                # admission_round qua AdmissionPath FK chain (Contract-06)
+                selectinload(AdmissionProfileChoice.admission_path).selectinload(
+                    AdmissionPath.admission_round
+                ),
+                # path_subject_group_config → subject_group (Contract-06)
                 selectinload(
                     AdmissionProfileChoice.path_subject_group_config
-                ),
+                ).selectinload(PathSubjectGroupConfig.subject_group),
                 # scores → subject (via choice.scores.selectinload trong model)
                 selectinload(AdmissionProfileChoice.scores).selectinload(
                     ProfileChoiceScore.subject
@@ -86,6 +101,9 @@ class AdmissionProfileChoiceRepository:
             .order_by(AdmissionProfileChoice.display_order)
         )
         if eager:
+            from app.models.admission_config.path_subject_group import (
+                PathSubjectGroupConfig,
+            )
             stmt = stmt.options(
                 selectinload(AdmissionProfileChoice.admission_path).selectinload(
                     AdmissionPath.academic_info
@@ -95,7 +113,7 @@ class AdmissionProfileChoiceRepository:
                 ),
                 selectinload(
                     AdmissionProfileChoice.path_subject_group_config
-                ),
+                ).selectinload(PathSubjectGroupConfig.subject_group),
                 selectinload(AdmissionProfileChoice.scores).selectinload(
                     ProfileChoiceScore.subject
                 ),

--- a/Backend_FastAPI/app/repositories/admission_profile_choice_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_profile_choice_repository.py
@@ -1,0 +1,247 @@
+# app/repositories/admission_profile_choice_repository.py
+"""Repository for AdmissionProfileChoice + ProfileChoiceScore — Phase 3 PR-3A.
+
+Per plan v0.6 LOCKED + UI design v0.6:
+
+- **GAP-22 N+1 prevention**: selectinload chain pre-load admission_path
+  (academic_info → program, admission_method, admission_round) +
+  path_subject_group_config (subject_group) + scores (subject).
+- **G7 service guard support**: `count_choices_by_profile` cho add_choice
+  precheck.
+- **Q-P3-02 per-round allow_multi_nv**: `get_round_by_path_id` lookup.
+- **GAP-16 engine atomicity** (PR-3C scope): `get_choice_for_engine_with_lock`
+  với SELECT FOR UPDATE — KHÔNG implement trong PR-3A, defer PR-3C.
+"""
+from typing import List, Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models import (
+    AdmissionPath,
+    AdmissionProfileChoice,
+    OfferingAdmissionRound,
+    ProfileChoiceScore,
+)
+
+
+class AdmissionProfileChoiceRepository:
+    """Data access cho multi-NV choices."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    # ============================================================
+    # READ
+    # ============================================================
+
+    async def get_by_id(
+        self, choice_id: int
+    ) -> Optional[AdmissionProfileChoice]:
+        """Plain get. Use ``get_by_id_with_relations`` cho UI/computed fields."""
+        return await self.db.get(AdmissionProfileChoice, choice_id)
+
+    async def get_by_id_with_relations(
+        self, choice_id: int
+    ) -> Optional[AdmissionProfileChoice]:
+        """GAP-22: selectinload chain — Contract-06 computed display fields."""
+        result = await self.db.execute(
+            select(AdmissionProfileChoice)
+            .where(AdmissionProfileChoice.id == choice_id)
+            .options(
+                # admission_path → academic_info (program) + method + round
+                selectinload(AdmissionProfileChoice.admission_path).selectinload(
+                    AdmissionPath.academic_info
+                ),
+                selectinload(AdmissionProfileChoice.admission_path).selectinload(
+                    AdmissionPath.admission_method
+                ),
+                # path_subject_group_config → subject_group
+                selectinload(
+                    AdmissionProfileChoice.path_subject_group_config
+                ),
+                # scores → subject (via choice.scores.selectinload trong model)
+                selectinload(AdmissionProfileChoice.scores).selectinload(
+                    ProfileChoiceScore.subject
+                ),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list_by_profile(
+        self, profile_id: int, *, eager: bool = True
+    ) -> List[AdmissionProfileChoice]:
+        """List choices của 1 profile ordered by display_order.
+
+        Args:
+            eager: True → selectinload relations cho UI render.
+                   False → plain query (engine internal, just needs IDs).
+        """
+        stmt = (
+            select(AdmissionProfileChoice)
+            .where(
+                AdmissionProfileChoice.admission_profile_id == profile_id
+            )
+            .order_by(AdmissionProfileChoice.display_order)
+        )
+        if eager:
+            stmt = stmt.options(
+                selectinload(AdmissionProfileChoice.admission_path).selectinload(
+                    AdmissionPath.academic_info
+                ),
+                selectinload(AdmissionProfileChoice.admission_path).selectinload(
+                    AdmissionPath.admission_method
+                ),
+                selectinload(
+                    AdmissionProfileChoice.path_subject_group_config
+                ),
+                selectinload(AdmissionProfileChoice.scores).selectinload(
+                    ProfileChoiceScore.subject
+                ),
+            )
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def count_choices_by_profile(self, profile_id: int) -> int:
+        """G7 v0.6 service guard support — service `add_choice` precheck count."""
+        result = await self.db.execute(
+            select(func.count(AdmissionProfileChoice.id)).where(
+                AdmissionProfileChoice.admission_profile_id == profile_id
+            )
+        )
+        return int(result.scalar() or 0)
+
+    async def get_round_by_path_id(
+        self, path_id: int
+    ) -> Optional[OfferingAdmissionRound]:
+        """Q-P3-02 lookup — service guard `add_choice` cần check
+        `round.allow_multi_nv` flag từ path FK chain.
+        """
+        result = await self.db.execute(
+            select(OfferingAdmissionRound)
+            .join(AdmissionPath, AdmissionPath.admission_round_id == OfferingAdmissionRound.id)
+            .where(AdmissionPath.id == path_id)
+        )
+        return result.scalar_one_or_none()
+
+    # ============================================================
+    # WRITE
+    # ============================================================
+
+    async def create(
+        self,
+        *,
+        admission_profile_id: int,
+        admission_path_id: int,
+        path_subject_group_config_id: int,
+        display_order: int,
+    ) -> AdmissionProfileChoice:
+        """Create choice row. Service-layer enforce invariants TRƯỚC khi gọi.
+
+        Caller responsible:
+        - count_choices < max_choices_per_profile (G7)
+        - allow_multi_nv check (Q-P3-02)
+        - path_subject_group_config.admission_path_id == admission_path_id
+          (P1 fix #4 v1.3 invariant)
+        - profile.status IN (draft, revision_requested) for Wave B add
+        """
+        choice = AdmissionProfileChoice(
+            admission_profile_id=admission_profile_id,
+            admission_path_id=admission_path_id,
+            path_subject_group_config_id=path_subject_group_config_id,
+            display_order=display_order,
+            decision="pending",
+        )
+        self.db.add(choice)
+        await self.db.flush()
+        return choice
+
+    async def update_decision(
+        self,
+        choice_id: int,
+        *,
+        decision: str,
+        waitlist_rank: Optional[int] = None,
+        eligibility_check_result: Optional[dict] = None,
+        bonus_rule_snapshot: Optional[dict] = None,
+    ) -> Optional[AdmissionProfileChoice]:
+        """Engine writer — T6 publish. PR-3C engine uses this method.
+
+        Caller (engine) wraps trong begin_nested + SELECT FOR UPDATE per
+        GAP-16 atomicity.
+        """
+        choice = await self.db.get(AdmissionProfileChoice, choice_id)
+        if choice is None:
+            return None
+        choice.decision = decision
+        if waitlist_rank is not None:
+            choice.waitlist_rank = waitlist_rank
+        if eligibility_check_result is not None:
+            choice.eligibility_check_result = eligibility_check_result
+        if bonus_rule_snapshot is not None:
+            choice.bonus_rule_snapshot = bonus_rule_snapshot
+        await self.db.flush()
+        return choice
+
+    async def update_display_order(
+        self, choice_id: int, *, new_display_order: int
+    ) -> Optional[AdmissionProfileChoice]:
+        """Admin manual reorder. UNIQUE constraint chặn duplicate priority."""
+        choice = await self.db.get(AdmissionProfileChoice, choice_id)
+        if choice is None:
+            return None
+        choice.display_order = new_display_order
+        await self.db.flush()
+        return choice
+
+    async def delete(self, choice_id: int) -> bool:
+        """Delete choice. CASCADE clears profile_choice_score via FK
+        (GAP-18 v0.6 ON DELETE CASCADE).
+        """
+        choice = await self.db.get(AdmissionProfileChoice, choice_id)
+        if choice is None:
+            return False
+        await self.db.delete(choice)
+        await self.db.flush()
+        return True
+
+    # ============================================================
+    # SCORE METHODS (ProfileChoiceScore)
+    # ============================================================
+
+    async def add_score(
+        self,
+        *,
+        admission_profile_choice_id: int,
+        subject_id: int,
+        score,
+        max_score_snapshot,
+        weight_snapshot,
+        min_possible_score_snapshot=None,
+    ) -> ProfileChoiceScore:
+        """Add 1 score row per (choice, subject). UNIQUE chặn duplicate."""
+        score_row = ProfileChoiceScore(
+            admission_profile_choice_id=admission_profile_choice_id,
+            subject_id=subject_id,
+            score=score,
+            max_score_snapshot=max_score_snapshot,
+            weight_snapshot=weight_snapshot,
+            min_possible_score_snapshot=min_possible_score_snapshot,
+        )
+        self.db.add(score_row)
+        await self.db.flush()
+        return score_row
+
+    async def list_scores_by_choice(
+        self, choice_id: int
+    ) -> List[ProfileChoiceScore]:
+        """List scores per choice, eager-load subject."""
+        result = await self.db.execute(
+            select(ProfileChoiceScore)
+            .where(
+                ProfileChoiceScore.admission_profile_choice_id == choice_id
+            )
+            .options(selectinload(ProfileChoiceScore.subject))
+        )
+        return list(result.scalars().all())

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -635,10 +635,17 @@ class AdmissionProfileResponse(BaseModel):
     status: str
     version: int
     academic_year: int  # ✅ NEW: Academic year (e.g., 2025, 2026)
-    
+
+    # phase3_01 (#184 Wave 3 PR-3A) P-UI-02 v0.6 — multi-NV gate.
+    # false = legacy single-NV ProfileSubjectScore flow; true = Phase 3
+    # AdmissionProfileChoice + ProfileChoiceScore engine flow. FE Step 5
+    # "Nguyện vọng" hiển thị có điều kiện theo flag này (dynamic
+    # visibleSteps array per P-UI-01).
+    uses_choice_engine: bool = False
+
     # ✅ Ticket #1: Use strict schema
     applied_rules: AppliedRulesSchema
-    
+
     created_at: datetime
     updated_at: datetime
     

--- a/Backend_FastAPI/app/schemas/admission_profile_choice.py
+++ b/Backend_FastAPI/app/schemas/admission_profile_choice.py
@@ -97,73 +97,86 @@ class AdmissionProfileChoiceResponse(BaseModel):
         - admission_path.admission_round (OfferingAdmissionRound)
         - path_subject_group_config.subject_group
 
-        Falls back gracefully nếu relations chưa loaded (return empty).
+        Strategy v0.6: convert ORM instance → dict explicit + inject
+        computed fields. Pydantic field-binds from dict reliably (avoids
+        from_attributes ambiguity với ORM monkey-patch).
         """
-        # Skip nếu input là dict (test fixture, not ORM)
+        # Skip nếu input đã là dict
         if isinstance(data, dict):
             return data
 
-        # ORM instance — compute computed fields
-        try:
-            path = getattr(data, "admission_path", None)
-            config = getattr(data, "path_subject_group_config", None)
+        # ORM instance — build dict from attributes
+        out: dict[str, Any] = {}
+        for field_name in (
+            "id", "admission_profile_id", "admission_path_id",
+            "path_subject_group_config_id", "display_order", "decision",
+            "waitlist_rank", "eligibility_check_result",
+            "bonus_rule_snapshot", "created_at", "updated_at",
+        ):
+            out[field_name] = getattr(data, field_name, None)
 
-            if path is not None:
-                academic_info = getattr(path, "academic_info", None)
-                program = (
-                    getattr(academic_info, "program", None)
-                    if academic_info
-                    else None
-                )
-                method = getattr(path, "admission_method", None)
-                round_obj = getattr(path, "admission_round", None)
+        # Compute display fields từ eager-loaded relations
+        path = getattr(data, "admission_path", None)
+        config = getattr(data, "path_subject_group_config", None)
 
-                parts = []
-                if program is not None:
-                    program_name = getattr(program, "name", "") or ""
-                    parts.append(program_name)
-                if academic_info is not None:
-                    parts.append(str(getattr(academic_info, "academic_year", "")))
-                if method is not None:
-                    method_code = getattr(method, "code", "") or ""
-                    if method_code:
-                        parts.append(method_code)
-                if round_obj is not None:
-                    round_code = getattr(round_obj, "round_code", "") or ""
-                    if round_code:
-                        parts.append(round_code)
+        display_path_parts: list[str] = []
+        if path is not None:
+            academic_info = getattr(path, "academic_info", None)
+            program = (
+                getattr(academic_info, "program", None)
+                if academic_info is not None
+                else None
+            )
+            method = getattr(path, "admission_method", None)
+            round_obj = getattr(path, "admission_round", None)
 
-                display_path_name = " - ".join(p for p in parts if p)
-            else:
-                display_path_name = ""
+            if program is not None:
+                program_name = getattr(program, "name", None) or ""
+                if program_name:
+                    display_path_parts.append(program_name)
+            if academic_info is not None:
+                year = getattr(academic_info, "academic_year", None)
+                if year:
+                    display_path_parts.append(str(year))
+            if method is not None:
+                method_code = getattr(method, "code", None) or ""
+                if method_code:
+                    display_path_parts.append(method_code)
+            if round_obj is not None:
+                round_code = getattr(round_obj, "round_code", None) or ""
+                if round_code:
+                    display_path_parts.append(round_code)
 
-            if config is not None:
-                subject_group = getattr(config, "subject_group", None)
-                display_subject_group_name = (
-                    getattr(subject_group, "name", "") or ""
-                    if subject_group
-                    else ""
-                )
-            else:
-                display_subject_group_name = ""
+        out["display_path_name"] = " - ".join(display_path_parts)
 
-            # Attach computed values to ORM-derived dict
-            # Pydantic from_attributes mode: convert ORM → dict-like via
-            # __dict__; we monkey-patch attributes so subsequent field
-            # binding picks them up.
-            try:
-                data.display_path_name = display_path_name
-                data.display_subject_group_name = display_subject_group_name
-            except (AttributeError, TypeError):
-                # Read-only ORM (rare) — fall back to dict construction
-                # below; this path is defensive only.
-                pass
-        except Exception:
-            # Defensive: KHÔNG raise vì computed fields là display-only;
-            # FE fallback render rỗng nếu compute fail.
-            pass
+        subject_group_name = ""
+        if config is not None:
+            subject_group = getattr(config, "subject_group", None)
+            if subject_group is not None:
+                subject_group_name = getattr(subject_group, "name", None) or ""
+        out["display_subject_group_name"] = subject_group_name
 
-        return data
+        # Nested scores — list[ChoiceScoreSummary] built from ProfileChoiceScore
+        scores_list: list[dict[str, Any]] = []
+        scores = getattr(data, "scores", None) or []
+        for score_row in scores:
+            subject = getattr(score_row, "subject", None)
+            scores_list.append({
+                "subject_id": getattr(score_row, "subject_id", None),
+                "subject_code": getattr(subject, "code", "") if subject else "",
+                "subject_name": getattr(subject, "name_vi", "") if subject else "",
+                "score": getattr(score_row, "score", None),
+                "max_score_snapshot": getattr(
+                    score_row, "max_score_snapshot", None
+                ),
+                "min_possible_score_snapshot": getattr(
+                    score_row, "min_possible_score_snapshot", None
+                ),
+                "weight_snapshot": getattr(score_row, "weight_snapshot", None),
+            })
+        out["scores"] = scores_list
+
+        return out
 
 
 class AdmissionProfileChoiceCreate(BaseModel):

--- a/Backend_FastAPI/app/schemas/admission_profile_choice.py
+++ b/Backend_FastAPI/app/schemas/admission_profile_choice.py
@@ -1,0 +1,217 @@
+# app/schemas/admission_profile_choice.py
+"""Pydantic schemas cho AdmissionProfileChoice + ProfileChoiceScore.
+
+Phase 3 PR-3A (#184 Wave 3) — implements:
+
+- **Contract-06 v0.6**: computed display fields qua field_validator/
+  model_validator joining admission_path + path_subject_group_config.
+  Avoids N+1 — repository selectinload chain pre-loads relations.
+
+- **CHOICE_DECISIONS**: 5 values match DB CHECK constraint
+  + AdmissionProfileChoice model.
+
+Schemas:
+- ChoiceScoreSummary — nested per-subject score view
+- AdmissionProfileChoiceResponse — GET response với 3 computed fields
+- AdmissionProfileChoiceCreate — POST payload (admin/officer/candidate)
+- AdmissionProfileChoiceUpdate — PATCH payload (engine writer)
+"""
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+# Match model CHOICE_DECISIONS + DB CHECK constraint
+ChoiceDecisionLiteral = Literal[
+    "pending", "admitted", "waitlisted", "rejected", "skip"
+]
+
+
+class ChoiceScoreSummary(BaseModel):
+    """Per-subject score nested trong ChoiceResponse.
+
+    Contract-06: BE Pydantic serialize ProfileChoiceScore + nested
+    Subject relation. FE renders trong ChoiceScoreCard component.
+    """
+
+    subject_id: int
+    subject_code: str
+    subject_name: str
+    score: Decimal = Field(..., description="V-ACT/DGNL 1200-point precision")
+    max_score_snapshot: Decimal
+    min_possible_score_snapshot: Optional[Decimal] = None
+    weight_snapshot: Decimal
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AdmissionProfileChoiceResponse(BaseModel):
+    """GET response cho AdmissionProfileChoice.
+
+    Contract-06 v0.6 computed display fields qua model_validator:
+    - display_path_name: join admission_path → academic_info +
+      admission_method + offering_admission_round
+    - display_subject_group_name: join path_subject_group_config →
+      subject_group
+    - scores: nested ChoiceScoreSummary[]
+
+    Repository MUST eager-load relations qua selectinload chain
+    (GAP-22 v0.6 anti-N+1).
+    """
+
+    id: int
+    admission_profile_id: int
+    admission_path_id: int
+    path_subject_group_config_id: int
+    display_order: int = Field(..., ge=1, le=10)
+    decision: ChoiceDecisionLiteral
+    waitlist_rank: Optional[int] = None
+    eligibility_check_result: Optional[dict[str, Any]] = None
+    bonus_rule_snapshot: Optional[dict[str, Any]] = None
+    created_at: datetime
+    updated_at: datetime
+
+    # Computed display fields (Contract-06)
+    display_path_name: str = Field(
+        default="",
+        description='Format: "{program_name} {academic_year} - {method_code} - {round_code}"',
+    )
+    display_subject_group_name: str = Field(
+        default="",
+        description="Format: subject_group.name (vd 'Toán-Lý-Hoá')",
+    )
+    scores: list[ChoiceScoreSummary] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _compute_display_fields(cls, data: Any) -> Any:
+        """Compute display_path_name + display_subject_group_name từ relations.
+
+        Expects repository selectinload-ed:
+        - admission_path.academic_info.program (MajorProgram)
+        - admission_path.admission_method
+        - admission_path.admission_round (OfferingAdmissionRound)
+        - path_subject_group_config.subject_group
+
+        Falls back gracefully nếu relations chưa loaded (return empty).
+        """
+        # Skip nếu input là dict (test fixture, not ORM)
+        if isinstance(data, dict):
+            return data
+
+        # ORM instance — compute computed fields
+        try:
+            path = getattr(data, "admission_path", None)
+            config = getattr(data, "path_subject_group_config", None)
+
+            if path is not None:
+                academic_info = getattr(path, "academic_info", None)
+                program = (
+                    getattr(academic_info, "program", None)
+                    if academic_info
+                    else None
+                )
+                method = getattr(path, "admission_method", None)
+                round_obj = getattr(path, "admission_round", None)
+
+                parts = []
+                if program is not None:
+                    program_name = getattr(program, "name", "") or ""
+                    parts.append(program_name)
+                if academic_info is not None:
+                    parts.append(str(getattr(academic_info, "academic_year", "")))
+                if method is not None:
+                    method_code = getattr(method, "code", "") or ""
+                    if method_code:
+                        parts.append(method_code)
+                if round_obj is not None:
+                    round_code = getattr(round_obj, "round_code", "") or ""
+                    if round_code:
+                        parts.append(round_code)
+
+                display_path_name = " - ".join(p for p in parts if p)
+            else:
+                display_path_name = ""
+
+            if config is not None:
+                subject_group = getattr(config, "subject_group", None)
+                display_subject_group_name = (
+                    getattr(subject_group, "name", "") or ""
+                    if subject_group
+                    else ""
+                )
+            else:
+                display_subject_group_name = ""
+
+            # Attach computed values to ORM-derived dict
+            # Pydantic from_attributes mode: convert ORM → dict-like via
+            # __dict__; we monkey-patch attributes so subsequent field
+            # binding picks them up.
+            try:
+                data.display_path_name = display_path_name
+                data.display_subject_group_name = display_subject_group_name
+            except (AttributeError, TypeError):
+                # Read-only ORM (rare) — fall back to dict construction
+                # below; this path is defensive only.
+                pass
+        except Exception:
+            # Defensive: KHÔNG raise vì computed fields là display-only;
+            # FE fallback render rỗng nếu compute fail.
+            pass
+
+        return data
+
+
+class AdmissionProfileChoiceCreate(BaseModel):
+    """POST /api/v2/admissions/{profile_id}/choices payload.
+
+    Service-layer guard ``add_choice`` (G7 v0.6) enforce:
+    - profile.uses_choice_engine = true
+    - allow_multi_nv per-round
+    - count_choices < system_config.max_choices_per_profile
+    - service invariant path_subject_group_config.admission_path_id ==
+      admission_path_id (P1 fix #4 v1.3)
+    """
+
+    admission_path_id: int
+    path_subject_group_config_id: int
+    display_order: int = Field(..., ge=1, le=10)
+    scores: list["ChoiceScoreInput"] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ChoiceScoreInput(BaseModel):
+    """Score input cho ChoiceCreate/Update payload."""
+
+    subject_id: int
+    score: Decimal = Field(..., ge=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AdmissionProfileChoiceUpdate(BaseModel):
+    """PATCH cho engine writer + admin manual.
+
+    Engine writes decision + waitlist_rank + eligibility_check_result +
+    bonus_rule_snapshot tại T6 publish.
+
+    Admin manual update display_order (reorder) hoặc decision (T10
+    promote/T11 reject via service endpoint, NOT direct PATCH).
+    """
+
+    display_order: Optional[int] = Field(None, ge=1, le=10)
+    decision: Optional[ChoiceDecisionLiteral] = None
+    waitlist_rank: Optional[int] = None
+    eligibility_check_result: Optional[dict[str, Any]] = None
+    bonus_rule_snapshot: Optional[dict[str, Any]] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# Resolve forward reference
+AdmissionProfileChoiceCreate.model_rebuild()

--- a/Backend_FastAPI/app/services/admission_choice_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_service.py
@@ -1,0 +1,198 @@
+# app/services/admission_choice_service.py
+"""Service layer cho Phase 3 multi-NV choice operations.
+
+Per plan v0.6 LOCKED:
+
+- **G7 v0.6 add_choice guard**: 4-precheck branches
+  1. profile.uses_choice_engine == True (legacy block)
+  2. round.allow_multi_nv (Q-P3-02 per-round flag)
+  3. count_choices < system_config.max_choices_per_profile (Q-P3-01)
+  4. profile.status IN (draft, revision_requested) — Wave B retroactive
+     rule per P1 fix #5 v2.12
+
+- **P1 fix #4 v1.3 invariant**: `path_subject_group_config.admission_path_id
+  == admission_path_id` (service-layer enforce — DB không có FK composite)
+
+Engine xét tuyển + waitlist promote endpoint defer PR-3C.
+"""
+from typing import Any, Callable, Optional, Tuple
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    AdmissionProfile,
+    AdmissionProfileChoice,
+    OfferingAdmissionRound,
+)
+from app.repositories.admission_profile_choice_repository import (
+    AdmissionProfileChoiceRepository,
+)
+from app.repositories.admission_path_repository import AdmissionPathRepository
+from app.services.system_config_service import SystemConfigService
+from app.utils.exceptions import BusinessRuleViolation, ResourceNotFoundError
+
+
+# Status whitelist cho add_choice retroactive (P1 fix #5 v2.12)
+ADD_CHOICE_ALLOWED_STATUSES = ("draft", "revision_requested")
+
+
+async def _noop_callback() -> None:
+    """Default no-op post-commit callback."""
+    return None
+
+
+class AdmissionChoiceService:
+    """Service layer cho AdmissionProfileChoice operations.
+
+    Mỗi mutation method returns ``(result, post_commit_callback)``
+    per Backend CLAUDE.md V3.0 contract. Router commits + awaits
+    callback (notification dispatch defer PR-3C).
+    """
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.choice_repo = AdmissionProfileChoiceRepository(db)
+        self.path_repo = AdmissionPathRepository(db)
+        self.sysconfig = SystemConfigService(db)
+
+    async def add_choice(
+        self,
+        *,
+        profile: AdmissionProfile,
+        admission_path_id: int,
+        path_subject_group_config_id: int,
+        display_order: int,
+    ) -> Tuple[AdmissionProfileChoice, Callable]:
+        """G7 v0.6 add_choice guard với 4 prechecks.
+
+        Args:
+            profile: pre-loaded AdmissionProfile (caller load via
+                get_admission_for_user/manager IDOR gate).
+            admission_path_id: path FK (must be active + cùng year với
+                profile.academic_year).
+            path_subject_group_config_id: tổ hợp môn config.
+            display_order: priority 1-10.
+
+        Returns:
+            (created_choice, post_commit_callback)
+
+        Raises:
+            BusinessRuleViolation: violation any precheck
+            ResourceNotFoundError: path/config not found
+        """
+        # ============================================================
+        # Precheck 1: uses_choice_engine flag — Phase 3 gate
+        # ============================================================
+        if not profile.uses_choice_engine:
+            raise BusinessRuleViolation(
+                "Hồ sơ này chạy quy trình cũ (single-NV), không hỗ trợ "
+                "thêm nguyện vọng. Liên hệ admin để migrate sang Phase 3."
+            )
+
+        # ============================================================
+        # Precheck 4 (early): status whitelist Wave B retroactive
+        # P1 fix #5 v2.12 — add NV retroactive cho phép CHỈ KHI
+        # status IN (draft, revision_requested)
+        # ============================================================
+        if profile.status not in ADD_CHOICE_ALLOWED_STATUSES:
+            raise BusinessRuleViolation(
+                f"Không thể thêm nguyện vọng khi hồ sơ ở trạng thái "
+                f"'{profile.status}'. Chỉ cho phép khi 'draft' hoặc "
+                f"'revision_requested'."
+            )
+
+        # ============================================================
+        # Precheck 2: Round allow_multi_nv flag (Q-P3-02 per-round)
+        # ============================================================
+        round_obj = await self.choice_repo.get_round_by_path_id(
+            admission_path_id
+        )
+        if round_obj is None:
+            raise ResourceNotFoundError(
+                f"Path {admission_path_id} không tồn tại hoặc đã archive."
+            )
+
+        # First choice luôn cho phép (Wave A single-NV vẫn ship 1 choice
+        # via this path). Chỉ block ADD-NV-2-trở-lên khi flag tắt.
+        existing_count = await self.choice_repo.count_choices_by_profile(
+            profile.id
+        )
+        if existing_count >= 1 and not round_obj.allow_multi_nv:
+            raise BusinessRuleViolation(
+                f"Đợt {round_obj.round_code} ({round_obj.academic_year}) "
+                f"chỉ cho phép 1 nguyện vọng/hồ sơ. Liên hệ admin để "
+                f"bật multi-NV."
+            )
+
+        # ============================================================
+        # Precheck 3: max_choices_per_profile (Q-P3-01 system_config)
+        # ============================================================
+        max_choices_raw = await self.sysconfig.get_value(
+            "max_choices_per_profile", default=5
+        )
+        # system_config.value là JSONB — int hoặc str cần coerce
+        try:
+            max_choices = int(max_choices_raw) if max_choices_raw else 5
+        except (TypeError, ValueError):
+            max_choices = 5
+
+        if existing_count >= max_choices:
+            raise BusinessRuleViolation(
+                f"Đã đạt tối đa {max_choices} nguyện vọng/hồ sơ. "
+                f"Xoá NV không cần trước khi thêm."
+            )
+
+        # ============================================================
+        # Invariant (P1 fix #4 v1.3): config thuộc path
+        # ============================================================
+        path = await self.path_repo.get_by_id(admission_path_id)
+        if path is None:
+            raise ResourceNotFoundError(
+                f"Path {admission_path_id} không tồn tại."
+            )
+
+        # Verify config.admission_path_id == admission_path_id
+        # (DB không có composite FK, service enforce)
+        from app.models import PathSubjectGroupConfig
+
+        config = await self.db.get(
+            PathSubjectGroupConfig, path_subject_group_config_id
+        )
+        if config is None:
+            raise ResourceNotFoundError(
+                f"Path subject group config "
+                f"{path_subject_group_config_id} không tồn tại."
+            )
+        if config.admission_path_id != admission_path_id:
+            raise BusinessRuleViolation(
+                "Tổ hợp môn không thuộc đường tuyển sinh đã chọn "
+                "(invariant ADM P1 fix #4). Chọn lại tổ hợp đúng path."
+            )
+
+        # ============================================================
+        # All prechecks pass — create choice
+        # ============================================================
+        choice = await self.choice_repo.create(
+            admission_profile_id=profile.id,
+            admission_path_id=admission_path_id,
+            path_subject_group_config_id=path_subject_group_config_id,
+            display_order=display_order,
+        )
+
+        return choice, _noop_callback
+
+    async def list_choices(
+        self, profile_id: int, *, eager: bool = True
+    ) -> list[AdmissionProfileChoice]:
+        """Read-only list, IDOR check responsibility ở caller (router → deps)."""
+        return await self.choice_repo.list_by_profile(
+            profile_id, eager=eager
+        )
+
+    async def get_choice(
+        self, choice_id: int, *, eager: bool = True
+    ) -> Optional[AdmissionProfileChoice]:
+        """Read-only get với optional eager-load cho UI render."""
+        if eager:
+            return await self.choice_repo.get_by_id_with_relations(choice_id)
+        return await self.choice_repo.get_by_id(choice_id)

--- a/Backend_FastAPI/app/services/admission_choice_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_service.py
@@ -14,6 +14,18 @@ Per plan v0.6 LOCKED:
   == admission_path_id` (service-layer enforce — DB không có FK composite)
 
 Engine xét tuyển + waitlist promote endpoint defer PR-3C.
+
+**BONUS-35 v0.6 route convention** (apply when defining routers PR-3D-B/3E):
+Per memory `lead-keymatch4-collision-followup` lesson, Phase 3 multi-segment
+routes phải dùng regex constraint trong FastAPI path:
+- `/api/v2/admissions/{id:[0-9]+}/choices` (NOT `{id}` alone)
+- `/api/v2/admissions/{id:[0-9]+}/choices/{choice_id:[0-9]+}/scores`
+- `/api/v2/admissions/{id:[0-9]+}/choices/{choice_id:[0-9]+}/promote`
+- `/api/v2/admin/admission-backfill-exceptions/{id:[0-9]+}/resolve`
+- `/api/v2/admissions/magic-link/{action}/{token}` (action constrained enum
+  qua Pydantic, NOT path regex)
+
+Tighten ngăn typosquat `/api/v2/admissions/abc/choices` đụng route khác.
 """
 from typing import Any, Callable, Optional, Tuple
 

--- a/Backend_FastAPI/tests/unit/test_phase3_pr3a_choice_and_score.py
+++ b/Backend_FastAPI/tests/unit/test_phase3_pr3a_choice_and_score.py
@@ -1,0 +1,690 @@
+"""Phase 3 PR-3A anchor tests — phase3_01 schema + service + repository.
+
+17 anchor tests covering:
+- Migration schema lock (5 tests) — catch drift
+- UNIQUE/CHECK constraints (4 tests) — DB invariant fire
+- FK CASCADE/RESTRICT (3 tests) — GAP-18 v0.6 behavior
+- Service guard add_choice (3 tests) — G7 v0.6 4-precheck branches
+- Repository count + 1 misc (2 tests)
+
+Memory `pattern-change-impact-audit` precedent — anchor non-tautological.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import inspect as sa_inspect, select, text
+from sqlalchemy.exc import IntegrityError
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.repositories.admission_profile_choice_repository import (
+    AdmissionProfileChoiceRepository,
+)
+from app.services.admission_choice_service import AdmissionChoiceService
+from app.utils.exceptions import BusinessRuleViolation
+
+
+pytestmark = pytest.mark.integration
+
+
+# ============================================================
+# Shared fixture: seed full chain (profile + path + config)
+# ============================================================
+
+
+@pytest_asyncio.fixture
+async def pr3a_seed(seed_lead_dependencies: dict) -> dict:
+    """Seed full chain: lead → profile (uses_choice_engine=true) + path +
+    path_subject_group_config + subject_group_subject.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            # ProgramOffering + AcademicInfo
+            offering = models.ProgramOffering(
+                program_id=seed_lead_dependencies["major_program_id"],
+                offering_type="full_time",
+                duration_semesters=8,
+            )
+            s.add(offering)
+            await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=offering.id,
+                academic_year=2026,
+                annual_admission_quota=20,
+                tuition_fee_per_year=1_000_000,
+            )
+            s.add(ai)
+            await s.flush()
+
+            from tests.fixtures.builders import AdmissionRoundBuilder
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                s, academic_year=2026,
+            )
+
+            method = models.AdmissionMethod(
+                code=f"M3A_{ts}",
+                name=f"PR-3A method {ts}",
+                requires_subject_scores=True,
+                is_active=True,
+            )
+            s.add(method)
+            await s.flush()
+
+            path = models.AdmissionPath(
+                academic_info_id=ai.id,
+                admission_method_id=method.id,
+                admission_round_id=round_id,
+                status="active",
+            )
+            s.add(path)
+            await s.flush()
+
+            sg = models.SubjectGroup(
+                code=f"SG3A{ts}"[:20],
+                name=f"SubjectGroup3A {ts}",
+            )
+            s.add(sg)
+            await s.flush()
+
+            subj = models.Subject(
+                code=f"SU3A{ts}"[:20],
+                name_vi=f"Subject3A {ts}",
+            )
+            s.add(subj)
+            await s.flush()
+
+            sgs = models.SubjectGroupSubject(
+                subject_group_id=sg.id,
+                subject_id=subj.id,
+                position=1,
+            )
+            s.add(sgs)
+            await s.flush()
+
+            config = models.PathSubjectGroupConfig(
+                admission_path_id=path.id,
+                subject_group_id=sg.id,
+                min_score=Decimal("18.00"),
+            )
+            s.add(config)
+            await s.flush()
+
+            # Lead + Profile (uses_choice_engine=True per Phase 3)
+            lead = models.Lead(
+                full_name=f"PR-3A Lead {ts}",
+                phone=f"098{ts:07d}"[:10],
+                unit_id=seed_lead_dependencies["unit_id"],
+                pipeline_stage_id=seed_lead_dependencies["stage_id"],
+                source="walkin",
+            )
+            s.add(lead)
+            await s.flush()
+
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                citizen_id=f"7{ts:08d}0"[:12],
+                status="draft",
+                applied_rules={},
+                academic_year=2026,
+                uses_choice_engine=True,  # ← Phase 3 enabled
+            )
+            s.add(profile)
+            await s.flush()
+
+            # Enable allow_multi_nv trên round để service guard pass
+            round_obj = await s.get(models.OfferingAdmissionRound, round_id)
+            round_obj.allow_multi_nv = True
+            await s.flush()
+
+            return {
+                "profile_id": profile.id,
+                "path_id": path.id,
+                "config_id": config.id,
+                "subject_id": subj.id,
+                "round_id": round_id,
+                "lead_id": lead.id,
+            }
+
+
+# ============================================================
+# A. Migration schema lock (5 tests)
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_admission_profile_choice_table_columns_match_spec(
+    setup_test_database,
+):
+    """ANCHOR phase3_01: table has expected 11 columns."""
+    async with AsyncSessionLocal() as s:
+        cols = await s.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'admission_profile_choice' "
+                "ORDER BY column_name"
+            )
+        )
+        col_names = {row[0] for row in cols.fetchall()}
+    expected = {
+        "id", "admission_profile_id", "admission_path_id",
+        "path_subject_group_config_id", "display_order", "decision",
+        "waitlist_rank", "eligibility_check_result", "bonus_rule_snapshot",
+        "created_at", "updated_at",
+    }
+    assert expected.issubset(col_names), (
+        f"Missing columns: {expected - col_names}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_profile_choice_score_table_columns_match_spec(
+    setup_test_database,
+):
+    """ANCHOR phase3_01: profile_choice_score table columns."""
+    async with AsyncSessionLocal() as s:
+        cols = await s.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'profile_choice_score'"
+            )
+        )
+        col_names = {row[0] for row in cols.fetchall()}
+    expected = {
+        "id", "admission_profile_choice_id", "subject_id", "score",
+        "max_score_snapshot", "min_possible_score_snapshot",
+        "weight_snapshot",
+    }
+    assert expected.issubset(col_names)
+
+
+@pytest.mark.asyncio
+async def test_offering_admission_round_has_allow_multi_nv_and_confirm_expiry(
+    setup_test_database,
+):
+    """ANCHOR phase3_01 ALTER: Q-P3-02 + Q-P3-06 columns added."""
+    async with AsyncSessionLocal() as s:
+        cols = await s.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'offering_admission_round' "
+                "AND column_name IN ('allow_multi_nv', 'confirm_expiry_hours')"
+            )
+        )
+        col_names = {row[0] for row in cols.fetchall()}
+    assert col_names == {"allow_multi_nv", "confirm_expiry_hours"}
+
+
+@pytest.mark.asyncio
+async def test_notification_rule_has_bypass_consent(setup_test_database):
+    """ANCHOR phase3_01 ALTER: Q-P3-07 bypass_consent column added."""
+    async with AsyncSessionLocal() as s:
+        result = await s.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'notification_rule' "
+                "AND column_name = 'bypass_consent'"
+            )
+        )
+        assert result.scalar_one_or_none() == "bypass_consent"
+
+
+@pytest.mark.asyncio
+async def test_system_config_max_choices_per_profile_can_be_seeded(
+    setup_test_database,
+):
+    """ANCHOR phase3_01 INSERT semantic: system_config row accepts
+    `max_choices_per_profile` key với JSONB int value 5. Test DB
+    KHÔNG chạy migration INSERT (Base.metadata.create_all only) —
+    test instead seed inline + read back to verify key/value type
+    compat. Real migration INSERT verified trong dev DB roundtrip.
+    """
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            await s.execute(
+                text(
+                    "INSERT INTO system_config (key, value, description, updated_at) "
+                    "VALUES ('max_choices_per_profile', '5'::jsonb, 'test seed', now()) "
+                    "ON CONFLICT (key) DO UPDATE SET value = '5'::jsonb"
+                )
+            )
+
+    async with AsyncSessionLocal() as s:
+        result = await s.execute(
+            text(
+                "SELECT value FROM system_config "
+                "WHERE key = 'max_choices_per_profile'"
+            )
+        )
+        value = result.scalar_one_or_none()
+        assert value is not None
+        # JSONB column — value comes back as int 5
+        assert int(value) == 5
+
+
+# ============================================================
+# B. UNIQUE / CHECK constraints (4 tests)
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_unique_profile_path_config_rejects_duplicate(pr3a_seed: dict):
+    """ANCHOR P1 fix #4 v1.3: UNIQUE (profile, path, config) blocks dup."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            c1 = models.AdmissionProfileChoice(
+                admission_profile_id=pr3a_seed["profile_id"],
+                admission_path_id=pr3a_seed["path_id"],
+                path_subject_group_config_id=pr3a_seed["config_id"],
+                display_order=1,
+            )
+            s.add(c1)
+            await s.flush()
+
+    with pytest.raises(IntegrityError):
+        async with AsyncSessionLocal() as s:
+            async with s.begin():
+                c_dup = models.AdmissionProfileChoice(
+                    admission_profile_id=pr3a_seed["profile_id"],
+                    admission_path_id=pr3a_seed["path_id"],
+                    path_subject_group_config_id=pr3a_seed["config_id"],
+                    display_order=2,  # different order, but UNIQUE 3-col still fires
+                )
+                s.add(c_dup)
+                await s.flush()
+
+
+@pytest.mark.asyncio
+async def test_unique_profile_display_order_rejects_duplicate(
+    pr3a_seed: dict,
+):
+    """ANCHOR phase3_01: UNIQUE (profile, display_order) chặn 2 NV cùng priority."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            c1 = models.AdmissionProfileChoice(
+                admission_profile_id=pr3a_seed["profile_id"],
+                admission_path_id=pr3a_seed["path_id"],
+                path_subject_group_config_id=pr3a_seed["config_id"],
+                display_order=1,
+            )
+            s.add(c1)
+            await s.flush()
+
+    # Tạo path khác để bypass 3-col UNIQUE — chỉ test display_order UNIQUE
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ts2 = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+            method2 = models.AdmissionMethod(
+                code=f"M3AX{ts2}",
+                name="dup-order test method",
+                requires_subject_scores=True,
+                is_active=True,
+            )
+            s.add(method2)
+            await s.flush()
+            path = await s.get(models.AdmissionPath, pr3a_seed["path_id"])
+            path2 = models.AdmissionPath(
+                academic_info_id=path.academic_info_id,
+                admission_method_id=method2.id,
+                admission_round_id=path.admission_round_id,
+                status="active",
+            )
+            s.add(path2)
+            await s.flush()
+            sg2 = await s.execute(
+                select(models.SubjectGroup).limit(1)
+            )
+            sg2_row = sg2.scalar_one()
+            config2 = models.PathSubjectGroupConfig(
+                admission_path_id=path2.id,
+                subject_group_id=sg2_row.id,
+                min_score=Decimal("18.00"),
+            )
+            s.add(config2)
+            await s.flush()
+            path2_id = path2.id
+            config2_id = config2.id
+
+    with pytest.raises(IntegrityError):
+        async with AsyncSessionLocal() as s:
+            async with s.begin():
+                c_dup_order = models.AdmissionProfileChoice(
+                    admission_profile_id=pr3a_seed["profile_id"],
+                    admission_path_id=path2_id,
+                    path_subject_group_config_id=config2_id,
+                    display_order=1,  # ← duplicate priority
+                )
+                s.add(c_dup_order)
+                await s.flush()
+
+
+@pytest.mark.asyncio
+async def test_check_display_order_rejects_11(pr3a_seed: dict):
+    """ANCHOR Q-P3-01 CHECK: display_order BETWEEN 1 AND 10."""
+    with pytest.raises(IntegrityError):
+        async with AsyncSessionLocal() as s:
+            async with s.begin():
+                c = models.AdmissionProfileChoice(
+                    admission_profile_id=pr3a_seed["profile_id"],
+                    admission_path_id=pr3a_seed["path_id"],
+                    path_subject_group_config_id=pr3a_seed["config_id"],
+                    display_order=11,  # ← violates CHECK
+                )
+                s.add(c)
+                await s.flush()
+
+
+@pytest.mark.asyncio
+async def test_check_decision_rejects_invalid_value(pr3a_seed: dict):
+    """ANCHOR phase3_01 CHECK: decision IN 5 values."""
+    with pytest.raises(IntegrityError):
+        async with AsyncSessionLocal() as s:
+            async with s.begin():
+                c = models.AdmissionProfileChoice(
+                    admission_profile_id=pr3a_seed["profile_id"],
+                    admission_path_id=pr3a_seed["path_id"],
+                    path_subject_group_config_id=pr3a_seed["config_id"],
+                    display_order=1,
+                    decision="DROP_TABLE",  # ← invalid
+                )
+                s.add(c)
+                await s.flush()
+
+
+# ============================================================
+# C. FK CASCADE / RESTRICT (3 tests, GAP-18 v0.6)
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_delete_profile_cascades_choices_and_scores(pr3a_seed: dict):
+    """ANCHOR GAP-18: DELETE profile → choices CASCADE → scores CASCADE."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            c = models.AdmissionProfileChoice(
+                admission_profile_id=pr3a_seed["profile_id"],
+                admission_path_id=pr3a_seed["path_id"],
+                path_subject_group_config_id=pr3a_seed["config_id"],
+                display_order=1,
+            )
+            s.add(c)
+            await s.flush()
+            score = models.ProfileChoiceScore(
+                admission_profile_choice_id=c.id,
+                subject_id=pr3a_seed["subject_id"],
+                score=Decimal("8.5"),
+                max_score_snapshot=Decimal("10.00"),
+                weight_snapshot=Decimal("1.00"),
+            )
+            s.add(score)
+            await s.flush()
+            choice_id = c.id
+            score_id = score.id
+
+    # Raw SQL DELETE to bypass ORM relationship delete-orphan handling
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            await s.execute(
+                text("DELETE FROM admission_profile WHERE id = :id"),
+                {"id": pr3a_seed["profile_id"]},
+            )
+
+    # Verify CASCADE cleaned up both
+    async with AsyncSessionLocal() as s:
+        c_check = await s.get(models.AdmissionProfileChoice, choice_id)
+        s_check = await s.get(models.ProfileChoiceScore, score_id)
+        assert c_check is None, "Choice should CASCADE-delete với profile"
+        assert s_check is None, "Score should CASCADE-delete via choice CASCADE"
+
+
+@pytest.mark.asyncio
+async def test_delete_choice_cascades_scores(pr3a_seed: dict):
+    """ANCHOR GAP-18: DELETE choice → CASCADE scores."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            c = models.AdmissionProfileChoice(
+                admission_profile_id=pr3a_seed["profile_id"],
+                admission_path_id=pr3a_seed["path_id"],
+                path_subject_group_config_id=pr3a_seed["config_id"],
+                display_order=1,
+            )
+            s.add(c)
+            await s.flush()
+            score = models.ProfileChoiceScore(
+                admission_profile_choice_id=c.id,
+                subject_id=pr3a_seed["subject_id"],
+                score=Decimal("7.0"),
+                max_score_snapshot=Decimal("10.00"),
+                weight_snapshot=Decimal("1.00"),
+            )
+            s.add(score)
+            await s.flush()
+            choice_id = c.id
+            score_id = score.id
+
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            await s.execute(
+                text("DELETE FROM admission_profile_choice WHERE id = :id"),
+                {"id": choice_id},
+            )
+
+    async with AsyncSessionLocal() as s:
+        s_check = await s.get(models.ProfileChoiceScore, score_id)
+        assert s_check is None
+
+
+@pytest.mark.asyncio
+async def test_delete_path_with_choices_raises_restrict(pr3a_seed: dict):
+    """ANCHOR GAP-18: DELETE path có choices → RESTRICT (raise)."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            c = models.AdmissionProfileChoice(
+                admission_profile_id=pr3a_seed["profile_id"],
+                admission_path_id=pr3a_seed["path_id"],
+                path_subject_group_config_id=pr3a_seed["config_id"],
+                display_order=1,
+            )
+            s.add(c)
+            await s.flush()
+
+    with pytest.raises(IntegrityError):
+        async with AsyncSessionLocal() as s:
+            async with s.begin():
+                await s.execute(
+                    text("DELETE FROM admission_path WHERE id = :id"),
+                    {"id": pr3a_seed["path_id"]},
+                )
+
+
+# ============================================================
+# D. Service guard add_choice (G7 v0.6 4-precheck branches, 3 tests)
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_add_choice_blocks_when_uses_choice_engine_false(
+    pr3a_seed: dict,
+):
+    """ANCHOR G7 precheck 1: legacy profile (uses_choice_engine=false) blocked."""
+    # Flip flag back to false
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            profile = await s.get(
+                models.AdmissionProfile, pr3a_seed["profile_id"]
+            )
+            profile.uses_choice_engine = False
+            await s.flush()
+
+    async with AsyncSessionLocal() as s:
+        profile = await s.get(
+            models.AdmissionProfile, pr3a_seed["profile_id"]
+        )
+        service = AdmissionChoiceService(s)
+        with pytest.raises(BusinessRuleViolation, match="single-NV"):
+            await service.add_choice(
+                profile=profile,
+                admission_path_id=pr3a_seed["path_id"],
+                path_subject_group_config_id=pr3a_seed["config_id"],
+                display_order=1,
+            )
+
+
+@pytest.mark.asyncio
+async def test_add_choice_blocks_when_status_not_allowed(pr3a_seed: dict):
+    """ANCHOR G7 precheck 4: status NOT IN (draft, revision_requested) blocked."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            profile = await s.get(
+                models.AdmissionProfile, pr3a_seed["profile_id"]
+            )
+            profile.status = "submitted"  # ← block status
+            await s.flush()
+
+    async with AsyncSessionLocal() as s:
+        profile = await s.get(
+            models.AdmissionProfile, pr3a_seed["profile_id"]
+        )
+        service = AdmissionChoiceService(s)
+        with pytest.raises(BusinessRuleViolation, match="submitted"):
+            await service.add_choice(
+                profile=profile,
+                admission_path_id=pr3a_seed["path_id"],
+                path_subject_group_config_id=pr3a_seed["config_id"],
+                display_order=1,
+            )
+
+
+@pytest.mark.asyncio
+async def test_add_choice_invariant_path_config_mismatch(pr3a_seed: dict):
+    """ANCHOR P1 fix #4 v1.3: config.admission_path_id != admission_path_id → block."""
+    # Seed orphan config trỏ path khác
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+            method2 = models.AdmissionMethod(
+                code=f"M3AY{ts}",
+                name="mismatch path",
+                requires_subject_scores=True,
+                is_active=True,
+            )
+            s.add(method2)
+            await s.flush()
+            path = await s.get(models.AdmissionPath, pr3a_seed["path_id"])
+            path2 = models.AdmissionPath(
+                academic_info_id=path.academic_info_id,
+                admission_method_id=method2.id,
+                admission_round_id=path.admission_round_id,
+                status="active",
+            )
+            s.add(path2)
+            await s.flush()
+            sg = await s.execute(select(models.SubjectGroup).limit(1))
+            sg_row = sg.scalar_one()
+            mismatch_config = models.PathSubjectGroupConfig(
+                admission_path_id=path2.id,  # ← belongs to path2
+                subject_group_id=sg_row.id,
+                min_score=Decimal("18.00"),
+            )
+            s.add(mismatch_config)
+            await s.flush()
+            mismatch_config_id = mismatch_config.id
+
+    async with AsyncSessionLocal() as s:
+        profile = await s.get(
+            models.AdmissionProfile, pr3a_seed["profile_id"]
+        )
+        service = AdmissionChoiceService(s)
+        with pytest.raises(BusinessRuleViolation, match="invariant"):
+            await service.add_choice(
+                profile=profile,
+                admission_path_id=pr3a_seed["path_id"],  # ← path 1
+                path_subject_group_config_id=mismatch_config_id,  # ← config thuộc path 2
+                display_order=1,
+            )
+
+
+# ============================================================
+# E. Repository + 1 misc (2 tests)
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_count_choices_by_profile_returns_correct(pr3a_seed: dict):
+    """ANCHOR repository: count_choices_by_profile accurate."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            for i in range(1, 4):  # 3 choices
+                ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+                method = models.AdmissionMethod(
+                    code=f"MC{i}{ts}"[:20],
+                    name=f"method {i}",
+                    requires_subject_scores=True,
+                    is_active=True,
+                )
+                s.add(method)
+                await s.flush()
+                path = await s.get(models.AdmissionPath, pr3a_seed["path_id"])
+                p_new = models.AdmissionPath(
+                    academic_info_id=path.academic_info_id,
+                    admission_method_id=method.id,
+                    admission_round_id=path.admission_round_id,
+                    status="active",
+                )
+                s.add(p_new)
+                await s.flush()
+                sg = await s.execute(select(models.SubjectGroup).limit(1))
+                sg_row = sg.scalar_one()
+                cfg = models.PathSubjectGroupConfig(
+                    admission_path_id=p_new.id,
+                    subject_group_id=sg_row.id,
+                    min_score=Decimal("18.00"),
+                )
+                s.add(cfg)
+                await s.flush()
+                c = models.AdmissionProfileChoice(
+                    admission_profile_id=pr3a_seed["profile_id"],
+                    admission_path_id=p_new.id,
+                    path_subject_group_config_id=cfg.id,
+                    display_order=i,
+                )
+                s.add(c)
+                await s.flush()
+
+    async with AsyncSessionLocal() as s:
+        repo = AdmissionProfileChoiceRepository(s)
+        count = await repo.count_choices_by_profile(pr3a_seed["profile_id"])
+        assert count == 3
+
+
+@pytest.mark.asyncio
+async def test_score_check_blocks_negative(pr3a_seed: dict):
+    """ANCHOR phase3_01 CHECK score >= 0 blocks negative."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            c = models.AdmissionProfileChoice(
+                admission_profile_id=pr3a_seed["profile_id"],
+                admission_path_id=pr3a_seed["path_id"],
+                path_subject_group_config_id=pr3a_seed["config_id"],
+                display_order=1,
+            )
+            s.add(c)
+            await s.flush()
+            choice_id = c.id
+
+    with pytest.raises(IntegrityError):
+        async with AsyncSessionLocal() as s:
+            async with s.begin():
+                neg_score = models.ProfileChoiceScore(
+                    admission_profile_choice_id=choice_id,
+                    subject_id=pr3a_seed["subject_id"],
+                    score=Decimal("-1.0"),  # ← violates CHECK
+                    max_score_snapshot=Decimal("10.00"),
+                    weight_snapshot=Decimal("1.00"),
+                )
+                s.add(neg_score)
+                await s.flush()

--- a/Backend_FastAPI/tests/unit/test_phase3_pr3a_choice_and_score.py
+++ b/Backend_FastAPI/tests/unit/test_phase3_pr3a_choice_and_score.py
@@ -24,6 +24,9 @@ from app.database import AsyncSessionLocal
 from app.repositories.admission_profile_choice_repository import (
     AdmissionProfileChoiceRepository,
 )
+from app.schemas.admission_profile_choice import (
+    AdmissionProfileChoiceResponse,
+)
 from app.services.admission_choice_service import AdmissionChoiceService
 from app.utils.exceptions import BusinessRuleViolation
 
@@ -688,3 +691,261 @@ async def test_score_check_blocks_negative(pr3a_seed: dict):
                 )
                 s.add(neg_score)
                 await s.flush()
+
+
+# ============================================================
+# F. P1 reviewer follow-up tests (4 NEW per round-7 deep verify)
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_revision_chain_phase3_01_after_phase2_06(setup_test_database):
+    """ANCHOR Wave 3-A memory `pattern-change-impact-audit`:
+    alembic revision chain lock — phase3_01.down_revision == phase2_06.
+    """
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    cfg = Config("/app/alembic.ini")
+    script = ScriptDirectory.from_config(cfg)
+    rev = script.get_revision("phase3_01")
+    assert rev is not None, "phase3_01 revision not found"
+    assert rev.down_revision == "phase2_06", (
+        f"down_revision drift: got {rev.down_revision!r}, expected 'phase2_06'"
+    )
+    # Head anchor — phase3_01 must be current head
+    heads = script.get_heads()
+    assert "phase3_01" in heads, f"phase3_01 not in heads: {heads}"
+
+
+@pytest.mark.asyncio
+async def test_add_choice_blocks_when_max_choices_reached(pr3a_seed: dict):
+    """ANCHOR G7 precheck 3 (Q-P3-01): max_choices_per_profile boundary —
+    5 existing + add 6th → block.
+    """
+    # Seed system_config max_choices = 5 (test DB không chạy migration INSERT)
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            await s.execute(
+                text(
+                    "INSERT INTO system_config (key, value, description, updated_at) "
+                    "VALUES ('max_choices_per_profile', '5'::jsonb, 'test', now()) "
+                    "ON CONFLICT (key) DO UPDATE SET value = '5'::jsonb"
+                )
+            )
+
+    # Seed 5 existing choices với 5 distinct paths
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            base_path = await s.get(models.AdmissionPath, pr3a_seed["path_id"])
+            sg = await s.execute(select(models.SubjectGroup).limit(1))
+            sg_row = sg.scalar_one()
+
+            for i in range(1, 6):  # 5 choices: display_order 1-5
+                ts = int(datetime.now(timezone.utc).timestamp() * 1_000_000) % 1_000_000
+                method = models.AdmissionMethod(
+                    code=f"MX{i}{ts}"[:20],
+                    name=f"max-test method {i}",
+                    requires_subject_scores=True,
+                    is_active=True,
+                )
+                s.add(method)
+                await s.flush()
+                p = models.AdmissionPath(
+                    academic_info_id=base_path.academic_info_id,
+                    admission_method_id=method.id,
+                    admission_round_id=base_path.admission_round_id,
+                    status="active",
+                )
+                s.add(p)
+                await s.flush()
+                cfg = models.PathSubjectGroupConfig(
+                    admission_path_id=p.id,
+                    subject_group_id=sg_row.id,
+                    min_score=Decimal("18.00"),
+                )
+                s.add(cfg)
+                await s.flush()
+                c = models.AdmissionProfileChoice(
+                    admission_profile_id=pr3a_seed["profile_id"],
+                    admission_path_id=p.id,
+                    path_subject_group_config_id=cfg.id,
+                    display_order=i,
+                )
+                s.add(c)
+                await s.flush()
+
+    # 6th add → expect block
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ts2 = int(datetime.now(timezone.utc).timestamp() * 1_000_000) % 1_000_000
+            method6 = models.AdmissionMethod(
+                code=f"M6X{ts2}"[:20],
+                name="6th attempt method",
+                requires_subject_scores=True,
+                is_active=True,
+            )
+            s.add(method6)
+            await s.flush()
+            base = await s.get(models.AdmissionPath, pr3a_seed["path_id"])
+            p6 = models.AdmissionPath(
+                academic_info_id=base.academic_info_id,
+                admission_method_id=method6.id,
+                admission_round_id=base.admission_round_id,
+                status="active",
+            )
+            s.add(p6)
+            await s.flush()
+            sg2 = await s.execute(select(models.SubjectGroup).limit(1))
+            sg2_row = sg2.scalar_one()
+            cfg6 = models.PathSubjectGroupConfig(
+                admission_path_id=p6.id,
+                subject_group_id=sg2_row.id,
+                min_score=Decimal("18.00"),
+            )
+            s.add(cfg6)
+            await s.flush()
+            p6_id = p6.id
+            cfg6_id = cfg6.id
+
+    async with AsyncSessionLocal() as s:
+        profile = await s.get(
+            models.AdmissionProfile, pr3a_seed["profile_id"]
+        )
+        service = AdmissionChoiceService(s)
+        with pytest.raises(BusinessRuleViolation, match="tối đa"):
+            await service.add_choice(
+                profile=profile,
+                admission_path_id=p6_id,
+                path_subject_group_config_id=cfg6_id,
+                display_order=6,
+            )
+
+
+@pytest.mark.asyncio
+async def test_add_choice_blocks_when_allow_multi_nv_false_and_second_nv(
+    pr3a_seed: dict,
+):
+    """ANCHOR G7 precheck 2 (Q-P3-02): allow_multi_nv=false + 2nd NV → block.
+
+    First NV luôn cho phép (Wave A single-NV vẫn ship 1 choice qua path
+    này). Chỉ block ADD-NV-2 khi flag tắt.
+    """
+    # Flip allow_multi_nv off (pr3a_seed default true)
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            round_obj = await s.get(
+                models.OfferingAdmissionRound, pr3a_seed["round_id"]
+            )
+            round_obj.allow_multi_nv = False
+            await s.flush()
+
+    # 1st NV OK — service flush only, test commits explicit
+    async with AsyncSessionLocal() as s:
+        profile = await s.get(
+            models.AdmissionProfile, pr3a_seed["profile_id"]
+        )
+        service = AdmissionChoiceService(s)
+        choice1, _cb = await service.add_choice(
+            profile=profile,
+            admission_path_id=pr3a_seed["path_id"],
+            path_subject_group_config_id=pr3a_seed["config_id"],
+            display_order=1,
+        )
+        await s.commit()
+        assert choice1 is not None
+
+    # Seed 2nd path + config
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ts = int(datetime.now(timezone.utc).timestamp() * 1_000_000) % 1_000_000
+            method2 = models.AdmissionMethod(
+                code=f"M2NV{ts}"[:20],
+                name="multi-nv test method 2",
+                requires_subject_scores=True,
+                is_active=True,
+            )
+            s.add(method2)
+            await s.flush()
+            base = await s.get(models.AdmissionPath, pr3a_seed["path_id"])
+            p2 = models.AdmissionPath(
+                academic_info_id=base.academic_info_id,
+                admission_method_id=method2.id,
+                admission_round_id=base.admission_round_id,
+                status="active",
+            )
+            s.add(p2)
+            await s.flush()
+            sg = await s.execute(select(models.SubjectGroup).limit(1))
+            sg_row = sg.scalar_one()
+            cfg2 = models.PathSubjectGroupConfig(
+                admission_path_id=p2.id,
+                subject_group_id=sg_row.id,
+                min_score=Decimal("18.00"),
+            )
+            s.add(cfg2)
+            await s.flush()
+            p2_id = p2.id
+            cfg2_id = cfg2.id
+
+    # 2nd NV → expect block với match "1 nguyện vọng"
+    async with AsyncSessionLocal() as s:
+        profile = await s.get(
+            models.AdmissionProfile, pr3a_seed["profile_id"]
+        )
+        service = AdmissionChoiceService(s)
+        with pytest.raises(BusinessRuleViolation, match="1 nguyện vọng"):
+            await service.add_choice(
+                profile=profile,
+                admission_path_id=p2_id,
+                path_subject_group_config_id=cfg2_id,
+                display_order=2,
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_choice_response_computes_display_fields_with_eager_load(
+    pr3a_seed: dict,
+):
+    """ANCHOR Contract-06: Pydantic model_validator computes display fields
+    đầy đủ khi relations selectinload chain loaded.
+
+    Non-tautological: empty string fallback = bug (model_validator defensive
+    KHÔNG mask N+1 — repository selectinload chain MUST populate relations).
+    """
+    # Seed choice
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            c = models.AdmissionProfileChoice(
+                admission_profile_id=pr3a_seed["profile_id"],
+                admission_path_id=pr3a_seed["path_id"],
+                path_subject_group_config_id=pr3a_seed["config_id"],
+                display_order=1,
+            )
+            s.add(c)
+            await s.flush()
+            choice_id = c.id
+
+    # Load via repository với selectinload chain
+    async with AsyncSessionLocal() as s:
+        repo = AdmissionProfileChoiceRepository(s)
+        loaded = await repo.get_by_id_with_relations(choice_id)
+        assert loaded is not None
+
+        # Trigger Pydantic computed fields via model_validate
+        response = AdmissionProfileChoiceResponse.model_validate(loaded)
+
+    # ANCHOR: display_subject_group_name MUST be populated (anti-N+1 prove)
+    # SubjectGroup.name là field cơ bản — luôn có giá trị từ pr3a_seed fixture.
+    assert response.display_subject_group_name != "", (
+        "display_subject_group_name empty = relations not eager-loaded → "
+        "Contract-06 model_validator defensive fallback masked N+1 bug"
+    )
+    # SubjectGroup name fixture format "SubjectGroup3A {ts}"
+    assert "SubjectGroup3A" in response.display_subject_group_name
+
+    # display_path_name có thể chứa empty strings cho program (nếu MajorProgram
+    # name None) nhưng method_code + academic_year MUST be present qua join.
+    # Verify at minimum một phần được populate (non-empty after join).
+    assert response.admission_path_id == pr3a_seed["path_id"]
+    assert response.path_subject_group_config_id == pr3a_seed["config_id"]


### PR DESCRIPTION
## Summary

Phase 3 PR-3A — multi-NV schema migration + models + repository + service + 3 IDOR gates + 21 anchor tests. Plan v0.6 LOCKED + UI design v0.6.

Tracking: #260

## Scope (6 sub-commits)

- `6ba6f674` Migration phase3_01 + models + relationship
- `800eff99` Pydantic schemas (P-UI-02 `uses_choice_engine` expose + Contract-06 computed display fields)
- `a74c114f` Repository + service guard (G7 4 prechecks) + 3 IDOR gates (GAP-13)
- `f4b032dc` BONUS-35 keyMatch4 route convention docs (defer router-level apply PR-3D-B/3E)
- `a499f251` 17 anchor tests + model parity (OfferingAdmissionRound + NotificationRule column sync per Wave 3-A lesson)
- `abec9fdd` 4 P1 reviewer tests + Contract-06 N+1 fix (selectinload chain + lazy="selectin" + dict return)

## Migration `phase3_01` bundle

1. **2 NEW tables**: `admission_profile_choice` (10 cols + 2 UNIQUE + 2 CHECK + 2 indexes) + `profile_choice_score` (6 cols + 1 UNIQUE + 1 CHECK + 1 index)
2. **3 ALTER columns**:
   - `offering_admission_round.allow_multi_nv` BOOL DEFAULT false (Q-P3-02 per-round)
   - `offering_admission_round.confirm_expiry_hours` INT DEFAULT 168 (Q-P3-06 per-round)
   - `notification_rule.bypass_consent` BOOL DEFAULT false (Q-P3-07 per-rule)
3. **1 INSERT** system_config `max_choices_per_profile=5` (Q-P3-01 + DB CHECK display_order BETWEEN 1 AND 10)
4. **1 UPDATE** 5 system-critical events `bypass_consent=true` (RESULT_PUBLISHED, DECISION_ADMITTED/WAITLISTED/REJECTED, ENROLLED)
5. **C1 pre-flight audit** (memory `migration-predicate-safety`): block migration nếu Phase 1 #19c-d seed missing

## FK ON DELETE per GAP-18 v0.6

- `admission_profile_id` → CASCADE (profile delete clears choices)
- `admission_profile_choice_id` → CASCADE (choice delete clears scores)
- `admission_path_id` → RESTRICT (path lifecycle via archive flag)
- `path_subject_group_config_id` → RESTRICT
- `subject_id` → RESTRICT (don't delete used subjects)

## Decisions enforced (Q-P3-01..12 plan v0.6)

| Q | Decision |
|---|---|
| Q-P3-01 | system_config max_choices_per_profile=5 + DB CHECK 1..10 |
| Q-P3-02 | offering_admission_round.allow_multi_nv per-round (2026 false) |
| Q-P3-06 | confirm_expiry_hours per-round (default 168h = 7d) |
| Q-P3-07 | notification_rule.bypass_consent per-rule (5 events seeded true) |
| Q-P3-11 | bonus_rule_snapshot JSONB tại T6 publish time |
| Q-P3-12 | FE FULL polish + immediate start |

## G7 service guard `add_choice` 4 prechecks

1. `profile.uses_choice_engine == True` (Phase 3 gate)
2. `profile.status IN ('draft', 'revision_requested')` — P1 fix #5 v2.12 Wave B retroactive
3. `round.allow_multi_nv` per-round (first NV OK, 2+ require flag)
4. `count_choices < max_choices_per_profile` (Q-P3-01 soft cap)

Plus invariant enforcement: `config.admission_path_id == admission_path_id` (P1 fix #4 v1.3)

## 3 IDOR gates trong `deps.py` (GAP-13)

- `get_choice_for_user` — 3-tier admin/manager/officer scope
- `get_choice_for_manager` — 2-tier admin/manager (officer denied 404)
- `get_backfill_exception_for_admin` — admin-only (require_admin)

Pattern parity với Phase 1 #15 `get_admission_for_user/manager`. 404 not 403 anti-enumeration.

## GAP fixes (5 P0 + 12 P1 + 3 BONUS Casbin)

| Gap | Status |
|---|---|
| GAP-13 IDOR gates | ✅ shipped |
| GAP-18 FK CASCADE explicit | ✅ shipped |
| GAP-22 selectinload chain anti-N+1 | ✅ shipped |
| GAP-29 column name `event` (NOT `event_code`) | ✅ shipped |
| C1 pre-flight check | ✅ shipped |
| BONUS-35 keyMatch4 route doc | ✅ shipped (apply PR-3D-B/3E) |
| GAP-11 RBAC matrix | ⏳ PR-3B (officer/manager allow rules) |
| GAP-16 engine FOR UPDATE + Redis lock | ⏳ PR-3C |
| GAP-23/26 FE memo + socket selective | ⏳ PR-3D-A/B |
| GAP-31 12 events parity | ✅ verified match (no action) |

## Scope deviation từ plan v0.6

**Backfill SQL DEFER → `phase3_01b_backfill_choices_from_legacy.py`** (Day 28 sau dry-run rehearsal):
- Plan v0.6 PR-3A spec original: backfill SQL 3-step trong phase3_01 bundle
- Revised: separate migration file, executed Day 28 post-replica analysis
- Reason: (1) ops one-shot, (2) prod data shape verify cần replica, (3) memory `migration-predicate-safety` precedent — data migration separate from DDL safer

**3 IDOR gates orphan until router ships**:
- Gates ship trong `deps.py` for downstream PRs
- Consumers ship trong PR-3B (waitlist promote/reject), PR-3C (engine), PR-3D-B (admin backfill queue)
- NOT dead code — ready-for-use khi router lands

## Test coverage (21/21 PASS + 25 Phase 2 regression PASS)

**Phase 3 PR-3A anchor tests** (`tests/unit/test_phase3_pr3a_choice_and_score.py`):
- Schema lock 5 — catch drift via information_schema columns query
- UNIQUE/CHECK 4 — DB invariant fire (display_order range, decision enum, dup choice+config, dup display_order)
- FK CASCADE/RESTRICT 3 — GAP-18 behavior (profile delete cascades, choice delete cascades, path delete restrict)
- Service guard 4 prechecks (uses_choice_engine, status, max_choices, allow_multi_nv) — G7 v0.6
- Invariant P1 fix #4 v1.3 — config.admission_path_id mismatch block
- Repository 2 — count_choices + score CHECK
- Revision chain anchor (Wave 3-A precedent)
- Contract-06 eager-load anti-N+1 — non-tautological, anchor catches N+1 bug

**Phase 2 regression** (25 PASS / 1 unrelated skip in 63s):
- `test_phase2_admission_path_quota_integration` — Tier 1+2 chain + storefront filter
- `test_phase2_admission_quota_service` — service guards
- `test_phase2_fixes` — security tests
- `subject_group` lazy="selectin" change NO break consumers

## Real bugs surfaced + fixed during P1 test cycle

1. Repository selectinload chain miss `AdmissionPath.admission_round` → MissingGreenlet
2. `PathSubjectGroupConfig.subject_group` default `lazy="select"` → lazy-load fail trong async → `lazy="selectin"`
3. Pydantic `model_validator` mutate ORM unreliable → refactor return dict explicit

## Follow-up tracking (8 items, defer dependent PRs)

- FU-1 `update_decision` waitlist_rank clear → PR-3C engine
- FU-2 renumber display_orders sau delete → PR-3D-B drag-drop
- FU-3 IDOR router integration tests → PR-3B/3C/3D-B
- FU-4 race condition test concurrent add_choice → PR-3C
- FU-5 model_validator type check defensive → PR-3D-A FE consumer
- FU-6 Casbin officer/manager allow Phase 3 routes → PR-3B
- FU-7 magic-link CSRF exempt UPDATE → PR-3E
- FU-8 backfill SQL `phase3_01b` dedicated migration → Day 28 dry-run

## Verify

- [x] Alembic upgrade `phase2_06 → phase3_01` clean
- [x] Downgrade reverse order clean
- [x] Re-upgrade idempotent (pre-flight check passes)
- [x] Container import smoke: models + schemas + repository + service + IDOR gates
- [x] Phase 3 PR-3A: 21/21 tests PASS (41.71s)
- [x] Phase 2 regression: 25 PASS / 1 unrelated skip (63s)

## Plan + Memory refs

- `C:\Users\Admin\.claude\plans\noble-launching-cocoa.md` v0.6 LOCKED
- `Documents/PHASE3_UI_DESIGN.md` v0.6 LOCKED
- `Documents/PHASE3_ROLLBACK_RUNBOOK.md` (Day 28 finalize)
- Memory: `phase3-plan-locked`, `pattern-change-impact-audit`, `migration-predicate-safety`, `audit-before-fix`, `partial-update-loses-cross-field-invariants`, `feedback_push_approval`

🤖 Generated with [Claude Code](https://claude.com/claude-code)