### PR TITLE
hotfix(ci): admission-contract-check.yml allow-deferred 4→1 names (PR-3B Sub-2 follow-up)

### DIFF
--- a/.github/workflows/admission-contract-check.yml
+++ b/.github/workflows/admission-contract-check.yml
@@ -101,14 +101,20 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run check_notification_event_coverage
-        # ``--allow-deferred`` permits the 4 ADMISSION_* events whose
-        # legacy writers haven't shipped yet (T6 / T8 / T10 / T17 —
-        # Phase 3 choice-engine). Locked by
+        # ``--allow-deferred`` permits ADMISSION_* events whose legacy
+        # writers haven't shipped yet. Locked by
         # ``state_service.DEFERRED_ADMISSION_EVENTS`` + the lock test
         # ``test_check_notification_event_coverage_deferred.py``.
-        # When Phase 3 wires the writers, drop the corresponding
-        # name(s) from this flag and the lock test fails until the
-        # Python set is updated to match.
+        #
+        # Phase 3 PR-3B Sub-2 (e2fa371f, merged 2026-05-12 via PR #264)
+        # wired T6/T8/T10 (RESULT_PUBLISHED / DECISION_WAITLISTED /
+        # WAITLIST_PROMOTED) via LEGACY_STATUS_TO_EVENT extension +
+        # TRANSITION_PAIR_TO_EVENT source-aware map → DEFERRED shrunk
+        # 4 → 1 (only T17 ADMISSION_ROLLED_BACK awaits PR-3C router).
+        # This file MUST stay in sync with deploy.yml + the lock test
+        # set. PR-3B Sub-2 missed this workflow file initially — this
+        # hotfix closes the gap (cross-file CI flag sync per memory
+        # `ci-workflow-flag-cross-file-sync`).
         run: |
           python -m app.scripts.check_notification_event_coverage \
-            --allow-deferred=ADMISSION_RESULT_PUBLISHED,ADMISSION_DECISION_WAITLISTED,ADMISSION_WAITLIST_PROMOTED,ADMISSION_ROLLED_BACK
+            --allow-deferred=ADMISSION_ROLLED_BACK


### PR DESCRIPTION
## Summary

PR-3B Sub-2 (e2fa371f, merged via PR #264) shrunk `DEFERRED_ADMISSION_EVENTS` frozenset 4→1 (only T17 `ADMISSION_ROLLED_BACK` awaits PR-3C router). Sub-2 updated `deploy.yml` `--allow-deferred` flag but **missed `admission-contract-check.yml`** carrying the same flag with 4 stale names. Workflow file drift caused CI `Coverage — every notification event fully wired` check to FAIL on PR #264 with `3 --allow-deferred misuse(s)`.

Future Phase 3 PRs (PR-3C/3D-A/3D-B/3E) would fail this check until synced.

## Change

Single 1-line fix: `admission-contract-check.yml:114` `--allow-deferred` list 4 names → 1 name (`ADMISSION_ROLLED_BACK`). Comment expanded with PR-3B Sub-2 context + cross-file sync rule reference.

## Verify

- `grep -r "--allow-deferred" .github/workflows/` → both `deploy.yml` + `admission-contract-check.yml` now match `=ADMISSION_ROLLED_BACK` only
- Coverage script local: 11 ADMISSION_* events `ok` + 1 `no-dispatch-site` (T17 expected)
- Lock test `test_check_notification_event_coverage_deferred.py` parity already locked (Sub-2 updated)

## Why it slipped

Path A1 mini-audit caught enum drift but didn't extend to `.github/workflows/` grep. Sub-2 verify only checked `deploy.yml:104` — missed sibling workflow.

Memory lesson (proposing post-merge save): `ci-workflow-flag-cross-file-sync` — khi update cross-workflow flag (`--allow-deferred`, similar), grep TẤT CẢ `.github/workflows/` cho cùng pattern trước commit. Tests pass ≠ CI infra synced.

## Memory refs

- `audit-before-fix` — em missed cross-workflow grep in Sub-2 verify
- `pattern-change-impact-audit` — DEFERRED shrink consumer audit incomplete (caught 2/2 code consumers, 1/2 workflow consumers)
- `notification-event-gate-required-locally` — coverage script gate honored locally, missed workflow-level CI gate cross-check

## Test plan

- [x] Local coverage script: PASS với 1-name `--allow-deferred`
- [ ] CI Coverage — every notification event fully wired: PASS
- [ ] CI AST lint + Python deps + Node deps: PASS
- [ ] Post-merge: PR-3C engine sẽ pass coverage gate on first try

🤖 Generated with [Claude Code](https://claude.com/claude-code)