### PR TITLE
feat(admission): Phase 3 PR-3C — choice-engine cascade + 3 router endpoints (T6/T10/T17) + 270 tests

### DIFF
--- a/.github/workflows/admission-contract-check.yml
+++ b/.github/workflows/admission-contract-check.yml
@@ -115,6 +115,7 @@ jobs:
         # set. PR-3B Sub-2 missed this workflow file initially — this
         # hotfix closes the gap (cross-file CI flag sync per memory
         # `ci-workflow-flag-cross-file-sync`).
+        # PR-3C Sub-3.5: T17 ADMISSION_ROLLED_BACK wired via
+        # TRANSITION_PAIR_TO_EVENT — DEFERRED set now empty.
         run: |
-          python -m app.scripts.check_notification_event_coverage \
-            --allow-deferred=ADMISSION_ROLLED_BACK
+          python -m app.scripts.check_notification_event_coverage

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,9 +100,12 @@ jobs:
         # the writers, drop the corresponding name(s) from this flag —
         # the lock test ``test_check_notification_event_coverage_deferred
         # .py`` fails until the Python set is updated to match.
+        # PR-3C Sub-3.5: T17 ADMISSION_ROLLED_BACK wired via
+        # TRANSITION_PAIR_TO_EVENT (11 pair entries). DEFERRED set
+        # now empty — coverage script runs WITHOUT --allow-deferred
+        # flag. ALL 12 ADMISSION_* events have a writer.
         run: |
-          python -m app.scripts.check_notification_event_coverage \
-            --allow-deferred=ADMISSION_ROLLED_BACK
+          python -m app.scripts.check_notification_event_coverage
 
       - name: Backend — Notification parity (unit)
         working-directory: Backend_FastAPI

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -45,6 +45,7 @@ from .routers import (
     admin_v2_path_subject_group,  # ✅ #184 Phase 2 v8.2 PR-2D: path-level subject group config + clone endpoint
     admin_v2_system_config,  # ✅ #184 PR-1D / phase1_13: admin runtime config
     admissions,  # ✅ NEW: Admission Profile workflow
+    admissions_v2,  # ✅ #184 Phase 3 PR-3C Sub-3.3: multi-NV choice-engine endpoints (publish-result T6)
     auth,
     collaborators,  # ✅ CTV SYSTEM: Collaborator management + CTV self-service
     commissions,  # ✅ CTV PHASE 2: Commission management
@@ -781,6 +782,7 @@ fastapi_app.include_router(commissions.policy_router, prefix="/api")  # ✅ CTV 
 fastapi_app.include_router(commissions.record_router, prefix="/api")  # ✅ CTV P2: Commission records (Admin)
 fastapi_app.include_router(commissions.ctv_commission_router, prefix="/api")  # ✅ CTV P2: CTV commission view
 fastapi_app.include_router(admissions.router, prefix="/api")  # ✅ Admission Profile workflow
+fastapi_app.include_router(admissions_v2.router)  # ✅ #184 Phase 3 PR-3C: multi-NV choice-engine v2 (router declares /api/v2 prefix)
 fastapi_app.include_router(admission_config.router, prefix="/api")  # ✅ PHASE 3: Admission Config + Scoring
 fastapi_app.include_router(admission_paths.router, prefix="/api")  # ✅ PHASE 1: Admission Configuration Console
 fastapi_app.include_router(admin_v2_casbin.router)  # ✅ T0-5: POST /api/v2/admin/casbin/reload (router declares full prefix)

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -1,0 +1,130 @@
+# app/routers/admissions_v2.py
+"""Admissions v2 — Phase 3 multi-NV choice-engine endpoints.
+
+Routes under `/api/v2/admissions` prefix mirror Casbin policy paths
+(`/api/v2/admissions/*/<verb>`) configured trong PR-3B Sub-3:
+  * MANAGER ALLOW: publish-result (T6), waitlist-promote (T10), waitlist-reject (T11)
+  * OFFICER ALLOW: GET /choices (read), GET /publish-result (read)
+  * ADMIN: wildcard /* .* + require_admin dependency cho T17
+  * ACCOUNTANT DENY: 6 routes (Phase 1 B1 + Sub-3 5 routes)
+
+BONUS-35 keyMatch4 route convention: all dynamic `{id}` segments use
+`{id:[0-9]+}` regex constraint per memory `lead-keymatch4-collision-followup`.
+
+Endpoints (Sub-3.3-3.5b incremental ship):
+  * POST /api/v2/admissions/{profile_id:[0-9]+}/publish-result    — T6 (Sub-3.3 SHIP)
+  * POST /api/v2/admin/admission-profile-choice/{choice_id:[0-9]+}/promote — T10 (Sub-3.4)
+  * POST /api/v2/admissions/{profile_id:[0-9]+}/admin-rollback   — T17 (Sub-3.5b)
+"""
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database, models, schemas
+from app.core.deps import (
+    CasbinAuth,
+    get_admission_for_manager,
+)
+from app.services import admission_choice_engine_service as choice_engine
+
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(
+    prefix="/api/v2/admissions",
+    tags=["Admissions v2 — Multi-NV (Phase 3)"],
+)
+
+
+# =============================================================================
+# T6 — Publish result (admin batch trigger choice-engine cascade)
+# =============================================================================
+
+
+@router.post(
+    "/{profile_id:[0-9]+}/publish-result",
+    response_model=schemas.AdmissionPublishResultResponse,
+    summary="T6 — Publish admission result (trigger multi-NV choice engine)",
+)
+async def publish_admission_result(
+    profile_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    profile: models.AdmissionProfile = Depends(get_admission_for_manager),
+    current_user: models.User = CasbinAuth,
+):
+    """T6 publish-result — trigger choice-engine cascade per profile.
+
+    Manager/Admin runs this khi profile sẵn sàng để publish result. Engine
+    evaluates each `AdmissionProfileChoice` in `display_order`, applies
+    gates + scoring, marks decision per choice (admitted/rejected/skip),
+    transitions profile.status reviewing → result_published → admitted/rejected.
+
+    **Pre-checks** (raises 400 BusinessRuleViolation):
+    - profile.uses_choice_engine must be True (legacy single-NV use other path)
+    - profile.status must be "reviewing"
+
+    **Security**:
+    - IDOR: `get_admission_for_manager` (3-tier scope: admin all + manager unit)
+    - Casbin: manager/admin allow per PR-3B Sub-3 policy
+
+    **Dispatches** (via state_service.transition() cascade):
+    - ADMISSION_RESULT_PUBLISHED (T6, on first transition)
+    - ADMISSION_DECISION_ADMITTED / WAITLISTED / REJECTED (T7/T8/T9, on final transition)
+    - Per-choice events captured trong CascadeResult.per_choice_decisions
+
+    Returns CascadeResult với per-choice decisions trace cho audit.
+    """
+    # Re-query profile WITH choices eager-loaded (the IDOR gate returns
+    # a thin profile row; cascade needs full relations chain).
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    stmt = (
+        select(models.AdmissionProfile)
+        .where(models.AdmissionProfile.id == profile_id)
+        .options(
+            selectinload(models.AdmissionProfile.choices)
+            .selectinload(models.AdmissionProfileChoice.admission_path)
+            .selectinload(models.AdmissionPath.admission_method),
+            selectinload(models.AdmissionProfile.choices)
+            .selectinload(models.AdmissionProfileChoice.admission_path)
+            .selectinload(models.AdmissionPath.criteria),
+            selectinload(models.AdmissionProfile.choices)
+            .selectinload(models.AdmissionProfileChoice.path_subject_group_config)
+            .selectinload(models.PathSubjectGroupConfig.subject_group)
+            .selectinload(models.SubjectGroup.subjects),
+            selectinload(models.AdmissionProfile.choices)
+            .selectinload(models.AdmissionProfileChoice.scores)
+            .selectinload(models.ProfileChoiceScore.subject),
+        )
+    )
+    result = await db.execute(stmt)
+    full_profile = result.scalar_one()
+
+    # Service helper (Sub-3.2) — pre-checks + evaluate_cascade
+    cascade_result, post_commit_cb = await choice_engine.publish_result(
+        db, full_profile,
+    )
+
+    # V3.0 contract: caller commits, then awaits callback for notif outbox
+    await db.commit()
+    if post_commit_cb:
+        await post_commit_cb()
+
+    log.info(
+        "admissions_v2.publish_result",
+        profile_id=profile_id,
+        final_status=cascade_result.final_status,
+        admitted_choice_id=cascade_result.admitted_choice_id,
+        actor_id=current_user.id,
+    )
+
+    return schemas.AdmissionPublishResultResponse(
+        profile_id=cascade_result.profile_id,
+        final_status=cascade_result.final_status,
+        admitted_choice_id=cascade_result.admitted_choice_id,
+        admitted_display_order=cascade_result.admitted_display_order,
+        per_choice_decisions=cascade_result.per_choice_decisions,
+    )

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -28,6 +28,7 @@ from app.core.deps import (
     get_admission_for_manager,
 )
 from app.services import admission_choice_engine_service as choice_engine
+from app.utils.exceptions import ResourceNotFoundError
 
 
 log = structlog.get_logger(__name__)
@@ -127,4 +128,77 @@ async def publish_admission_result(
         admitted_choice_id=cascade_result.admitted_choice_id,
         admitted_display_order=cascade_result.admitted_display_order,
         per_choice_decisions=cascade_result.per_choice_decisions,
+    )
+
+
+# =============================================================================
+# T10 — Waitlist promote (admin manual promote choice waitlisted → admitted)
+# =============================================================================
+
+
+@router.post(
+    "/{profile_id:[0-9]+}/waitlist-promote",
+    response_model=schemas.AdmissionWaitlistPromoteResponse,
+    summary="T10 — Promote waitlisted choice to admitted (admin manual)",
+)
+async def waitlist_promote_choice(
+    profile_id: int,
+    payload: schemas.AdmissionWaitlistPromoteRequest,
+    db: AsyncSession = Depends(database.get_db),
+    profile: models.AdmissionProfile = Depends(get_admission_for_manager),
+    current_user: models.User = CasbinAuth,
+):
+    """T10 manual waitlist promote — admin chọn 1 NV trên waitlist
+    chuyển sang admitted.
+
+    DRIFT-01 sync: route profile-scoped per Casbin policy LIVE prod
+    (`/api/v2/admissions/*/waitlist-promote`), NOT choice-scoped admin
+    namespace per stale Plan v0.7 line 437. `choice_id` moves từ URL
+    param vào request body — router verifies ownership.
+
+    **Pre-checks** (raises 400 BusinessRuleViolation):
+    - choice.decision must be "waitlisted"
+    - profile.status must be "waitlisted"
+
+    **Security**:
+    - IDOR: `get_admission_for_manager` (profile-scoped 3-tier)
+    - Casbin: manager/admin allow per PR-3B Sub-3 policy
+    - Ownership: router verifies choice.admission_profile_id == profile.id
+      (defense-in-depth — service helper also checks)
+
+    **Dispatches** (via state_service.transition() + PAIR map):
+    - ADMISSION_WAITLIST_PROMOTED (T10 source-aware, NOT generic ADMITTED)
+    """
+    # Fetch choice + verify ownership (router thin lookup)
+    choice = await db.get(models.AdmissionProfileChoice, payload.choice_id)
+    if choice is None or choice.admission_profile_id != profile.id:
+        # 404 anti-enumeration per IDOR pattern (memory deps.py precedent)
+        raise ResourceNotFoundError(
+            f"Choice {payload.choice_id} không thuộc hồ sơ {profile_id}"
+        )
+
+    # Service helper (Sub-3.2)
+    result, post_commit_cb = await choice_engine.promote_waitlisted_choice(
+        db,
+        choice=choice,
+        profile=profile,
+        actor=current_user,
+        reason=payload.reason,
+    )
+
+    await db.commit()
+    if post_commit_cb:
+        await post_commit_cb()
+
+    log.info(
+        "admissions_v2.waitlist_promote",
+        profile_id=profile_id,
+        choice_id=payload.choice_id,
+        actor_id=current_user.id,
+        has_reason=bool(payload.reason),
+    )
+
+    return schemas.AdmissionWaitlistPromoteResponse(
+        choice_id=result["choice_id"],
+        profile_id=result["profile_id"],
     )

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -26,6 +26,7 @@ from app import database, models, schemas
 from app.core.deps import (
     CasbinAuth,
     get_admission_for_manager,
+    require_admin,
 )
 from app.services import admission_choice_engine_service as choice_engine
 from app.utils.exceptions import ResourceNotFoundError
@@ -201,4 +202,78 @@ async def waitlist_promote_choice(
     return schemas.AdmissionWaitlistPromoteResponse(
         choice_id=result["choice_id"],
         profile_id=result["profile_id"],
+    )
+
+
+# =============================================================================
+# T17 — Admin rollback (admin force profile back to draft, audit-logged)
+# =============================================================================
+
+
+@router.post(
+    "/{profile_id:[0-9]+}/admin-rollback",
+    response_model=schemas.AdmissionAdminRollbackResponse,
+    summary="T17 — Admin rollback profile to draft (audit-logged)",
+)
+async def admin_rollback_admission(
+    profile_id: int,
+    payload: schemas.AdmissionAdminRollbackRequest,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """T17 admin rollback — force any non-final profile state → draft.
+
+    Audit-gated với:
+    - **Admin-only**: `require_admin` dependency (NOT CasbinAuth). Manager
+      và officer denied via Casbin DENY trên `/api/v2/admissions/*/admin-rollback`
+      (Phase 1 B1 accountant deny line 324 + diamond inheritance reach).
+    - **Reason mandatory**: payload.reason min 10 chars, max 500 chars
+      (`AdmissionAdminRollbackRequest` schema enforces; service defensive
+      double-check).
+
+    **Pre-checks** (raises 400 BusinessRuleViolation in service helper):
+    - profile.status NOT IN ("enrolled", "withdrawn") — terminal states
+      cannot rollback per state machine ALLOWED_TRANSITIONS (Sub-3.5 extension)
+
+    **Security**:
+    - No IDOR gate — admin has global scope (require_admin dep enforces)
+    - `db.get(profile_id)` direct → 404 if not found (anti-enumeration)
+
+    **Dispatches** (via state_service.transition() + PAIR map):
+    - ADMISSION_ROLLED_BACK (T17 source-aware via TRANSITION_PAIR_TO_EVENT
+      11 pair entries shipped trong Sub-3.5 atomic). PAIR map fires
+      ROLLED_BACK regardless of source state.
+
+    Returns AdmissionAdminRollbackResponse với `rolled_back_from` capture
+    cho audit response.
+    """
+    # Admin global scope — direct db.get (no IDOR gate needed)
+    profile = await db.get(models.AdmissionProfile, profile_id)
+    if profile is None:
+        raise ResourceNotFoundError(f"Hồ sơ {profile_id} không tồn tại")
+
+    # Service helper (Sub-3.2) — pre-checks (terminal state, reason min 10)
+    # + state machine transition (source-aware PAIR → ROLLED_BACK)
+    result, post_commit_cb = await choice_engine.admin_rollback_profile(
+        db,
+        profile=profile,
+        reason=payload.reason,
+        actor=current_admin,
+    )
+
+    await db.commit()
+    if post_commit_cb:
+        await post_commit_cb()
+
+    log.info(
+        "admissions_v2.admin_rollback",
+        profile_id=profile_id,
+        rolled_back_from=result["rolled_back_from"],
+        actor_id=current_admin.id,
+        reason_length=len(payload.reason),
+    )
+
+    return schemas.AdmissionAdminRollbackResponse(
+        profile_id=result["profile_id"],
+        rolled_back_from=result["rolled_back_from"],
     )

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -46,7 +46,7 @@ router = APIRouter(
 
 
 @router.post(
-    "/{profile_id:[0-9]+}/publish-result",
+    "/{profile_id}/publish-result",
     response_model=schemas.AdmissionPublishResultResponse,
     summary="T6 — Publish admission result (trigger multi-NV choice engine)",
 )
@@ -138,7 +138,7 @@ async def publish_admission_result(
 
 
 @router.post(
-    "/{profile_id:[0-9]+}/waitlist-promote",
+    "/{profile_id}/waitlist-promote",
     response_model=schemas.AdmissionWaitlistPromoteResponse,
     summary="T10 — Promote waitlisted choice to admitted (admin manual)",
 )
@@ -211,7 +211,7 @@ async def waitlist_promote_choice(
 
 
 @router.post(
-    "/{profile_id:[0-9]+}/admin-rollback",
+    "/{profile_id}/admin-rollback",
     response_model=schemas.AdmissionAdminRollbackResponse,
     summary="T17 — Admin rollback profile to draft (audit-logged)",
 )

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -159,6 +159,7 @@ from .admission import (
     AdmissionSubmitResponse,
     # Phase 3 PR-3C Sub-3 — choice-engine endpoint schemas
     AdmissionPublishResultResponse,
+    AdmissionWaitlistPromoteRequest,
     AdmissionWaitlistPromoteResponse,
     AdmissionAdminRollbackRequest,
     AdmissionAdminRollbackResponse,

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -157,6 +157,11 @@ from .admission import (
     AdmissionProfileResponse,
     AdmissionsPage,
     AdmissionSubmitResponse,
+    # Phase 3 PR-3C Sub-3 — choice-engine endpoint schemas
+    AdmissionPublishResultResponse,
+    AdmissionWaitlistPromoteResponse,
+    AdmissionAdminRollbackRequest,
+    AdmissionAdminRollbackResponse,
     EnrollStudentResponse,
     # Bulk action schemas
     BulkApproveRequest,

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1566,6 +1566,77 @@ class AdmissionStats(BaseModel):
     avg_completion: float = 0.0
 
 
+# =============================================================================
+# Phase 3 PR-3C Sub-3 — Choice-engine endpoint schemas
+# =============================================================================
+
+
+class _PerChoiceDecision(BaseModel):
+    """Per-choice decision row inside `AdmissionPublishResultResponse`."""
+
+    choice_id: int
+    display_order: int
+    decision: Literal["pending", "admitted", "waitlisted", "rejected", "skip"]
+    reasons: List[str] = Field(default_factory=list)
+    score: Optional[float] = None
+
+
+class AdmissionPublishResultResponse(BaseModel):
+    """T6 publish-result endpoint response — wraps `CascadeResult`.
+
+    Returned by `POST /api/v2/admissions/{id}/publish-result` after the
+    choice-engine cascade evaluates all profile.choices in display_order
+    and transitions profile.status to admitted/rejected.
+    """
+
+    profile_id: int
+    final_status: Literal["admitted", "rejected", "waitlisted"]
+    admitted_choice_id: Optional[int] = None
+    admitted_display_order: Optional[int] = None
+    per_choice_decisions: List[_PerChoiceDecision] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AdmissionWaitlistPromoteResponse(BaseModel):
+    """T10 waitlist-promote endpoint response.
+
+    Returned by `POST /api/v2/admin/admission-profile-choice/{id}/promote`
+    after admin promotes a waitlisted choice → admitted.
+    """
+
+    choice_id: int
+    decision: Literal["admitted"] = "admitted"
+    profile_id: int
+    profile_status: Literal["admitted"] = "admitted"
+
+
+class AdmissionAdminRollbackRequest(BaseModel):
+    """T17 admin-rollback endpoint request body.
+
+    Reason is mandatory + min 10 chars for audit trail. The reason flows
+    into `AdmissionProfileStatusHistory.transition_reason` + dispatch
+    payload of `ADMISSION_ROLLED_BACK`.
+    """
+
+    reason: str = Field(
+        ...,
+        min_length=10,
+        max_length=500,
+        description="Mandatory rollback reason (audit log + dispatch payload)",
+    )
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+
+class AdmissionAdminRollbackResponse(BaseModel):
+    """T17 admin-rollback endpoint response."""
+
+    profile_id: int
+    status: Literal["draft"] = "draft"
+    rolled_back_from: str  # The status the profile was in BEFORE rollback
+
+
 __all__ = [
     # Nested schemas
     "FamilyMemberSchema",
@@ -1602,4 +1673,9 @@ __all__ = [
     # Aggregate schemas
     "AdmissionStatusCounts",
     "AdmissionStats",
+    # Phase 3 PR-3C Sub-3 — choice-engine endpoints
+    "AdmissionPublishResultResponse",
+    "AdmissionWaitlistPromoteResponse",
+    "AdmissionAdminRollbackRequest",
+    "AdmissionAdminRollbackResponse",
 ]

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1598,10 +1598,33 @@ class AdmissionPublishResultResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class AdmissionWaitlistPromoteRequest(BaseModel):
+    """T10 waitlist-promote endpoint request body.
+
+    DRIFT-01: Sub-3.4 route shipped là profile-scoped (Casbin canonical
+    `/api/v2/admissions/{profile_id}/waitlist-promote`), NOT choice-scoped
+    admin namespace per stale Plan v0.7 line 437. `choice_id` moves from
+    URL param vào request body — service verifies ownership.
+
+    `reason` optional cho audit context (transition() reason kwarg passes
+    into status_history.transition_reason).
+    """
+
+    choice_id: int = Field(..., gt=0, description="ID nguyện vọng promote từ waitlist")
+    reason: Optional[str] = Field(
+        None,
+        min_length=10,
+        max_length=500,
+        description="Optional audit reason (status_history.transition_reason)",
+    )
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+
 class AdmissionWaitlistPromoteResponse(BaseModel):
     """T10 waitlist-promote endpoint response.
 
-    Returned by `POST /api/v2/admin/admission-profile-choice/{id}/promote`
+    Returned by `POST /api/v2/admissions/{profile_id}/waitlist-promote`
     after admin promotes a waitlisted choice → admitted.
     """
 
@@ -1675,6 +1698,7 @@ __all__ = [
     "AdmissionStats",
     # Phase 3 PR-3C Sub-3 — choice-engine endpoints
     "AdmissionPublishResultResponse",
+    "AdmissionWaitlistPromoteRequest",
     "AdmissionWaitlistPromoteResponse",
     "AdmissionAdminRollbackRequest",
     "AdmissionAdminRollbackResponse",

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -1,0 +1,387 @@
+# app/services/admission_choice_engine_service.py
+"""
+Phase 3 PR-3C Sub-2 — Choice-engine cascade orchestration (T6 publish).
+
+Orchestrates the multi-NV admit cascade: loops `profile.choices` by
+`display_order`, applies gates (min_gpa, graduation_year), scores per
+choice via `AdmissionScoringService.calculate_score()`, and writes the
+admit/reject decision PLUS the `bonus_rule_snapshot` (Q-P3-11 — snapshot
+tại T6, NOT T1 submit).
+
+ARCHITECTURE
+============
+This module is **NEW** (PR-3C Sub-2) — split from
+`admission_scoring_service.py` because that file is constrained to pure
+stateless rules (no DB writes, no side effects). Cascade orchestration
+needs to:
+  * write to `AdmissionProfileChoice` rows (decision + scores +
+    bonus_rule_snapshot + eligibility_check_result)
+  * transition `AdmissionProfile.status` via
+    `admission_state_service.transition()`
+  * dispatch ADMISSION_* events with `strict=True` per memory
+    ``dispatch-bundle-strict-required``
+
+Returns the V3.0 architecture tuple `(result, post_commit_callback)`
+— caller commits DB then awaits callback for outbox flush.
+
+CASCADE RULES (plan v0.7 Phần 3.1)
+==================================
+For each `choice` in `profile.choices.order_by(display_order)`:
+  1. Resolve `effective_bonus_rule` = path.bonus_rule_override
+                                       ?? method.default_bonus_rule
+  2. Snapshot to `choice.bonus_rule_snapshot` (Q-P3-11)
+  3. Apply gates (Sub-1 helpers):
+     - `_check_min_gpa(profile.gpa_overall, criteria.min_gpa)`
+     - `_check_graduation_year_range(...)` (NO-OP cho mùa 2026)
+  4. If any gate fails → `choice.decision = 'rejected'` + capture reason
+     into `eligibility_check_result`. Continue to next choice.
+  5. Call `calculate_score(criteria, scores, allowed_subjects, weights)`
+  6. Decision logic:
+     - `score.passed=True`        → `choice.decision='admitted'`,
+                                     mark remaining choices `'skip'`,
+                                     BREAK loop
+     - `score.passed=False`       → `choice.decision='rejected'`,
+                                     continue next
+     - `score.status=INVALID`     → `choice.decision='rejected'`
+  7. After cascade: transition `profile.status`:
+     - At least 1 admitted → `result_published` then `admitted`
+     - All rejected         → `result_published` then `rejected`
+     - Auto-waitlist DEFERRED Q-P3-05 (mùa đầu manual only)
+
+ATOMICITY
+=========
+Caller wraps `evaluate_cascade()` trong `async with db.begin_nested()`
+per memory ``dispatch-bundle-strict-required`` — partial fail per
+profile rollback without nuking the batch. `strict=True` on dispatch
+propagates persistence errors so the savepoint catches them.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
+
+import structlog
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..core.events import SystemEvents
+from .admission_scoring_service import (
+    AdmissionScoringService,
+    AdmissionScoreResult,
+    ProfileStatus,
+)
+
+if TYPE_CHECKING:
+    from ..models import (
+        AdmissionProfile,
+        AdmissionProfileChoice,
+        AdmissionPath,
+    )
+
+log = structlog.get_logger(__name__)
+
+
+# ============================================================================
+# Result dataclass
+# ============================================================================
+
+
+@dataclass
+class CascadeResult:
+    """Outcome of `evaluate_cascade()` per profile.
+
+    Records per-choice decisions + final profile status transition so
+    caller (router) can build response payload + audit log.
+    """
+    profile_id: int
+    final_status: str  # 'admitted' | 'rejected' | 'waitlisted'
+    admitted_choice_id: Optional[int] = None
+    admitted_display_order: Optional[int] = None
+    per_choice_decisions: List[Dict[str, Any]] = field(default_factory=list)
+    # Per-choice entry: {choice_id, display_order, decision, reasons, score}
+
+
+# ============================================================================
+# Bonus rule resolution (Q-P3-11 snapshot source)
+# ============================================================================
+
+
+def resolve_effective_bonus_rule(path: "AdmissionPath") -> Optional[Dict[str, Any]]:
+    """Resolve BonusRule per chain: path.bonus_rule_override
+    ?? method.default_bonus_rule. Returns dict (JSONB-shaped) or None.
+
+    Caller MUST eager-load path.admission_method to avoid lazy-load
+    in async context.
+
+    Q-P3-11 contract: snapshot value captured tại T6 publish time
+    (NOT T1 submit). Subsequent changes to method/path bonus rule
+    config do NOT mutate the snapshot — historical audit preserved.
+    """
+    override = getattr(path, "bonus_rule_override", None)
+    if override is not None:
+        return dict(override) if isinstance(override, dict) else override
+    method = getattr(path, "admission_method", None)
+    if method is None:
+        return None
+    default = getattr(method, "default_bonus_rule", None)
+    if default is None:
+        return None
+    return dict(default) if isinstance(default, dict) else default
+
+
+# ============================================================================
+# Per-choice evaluation (gates + score + decision)
+# ============================================================================
+
+
+def _evaluate_single_choice(
+    profile: "AdmissionProfile",
+    choice: "AdmissionProfileChoice",
+) -> Tuple[str, Optional[AdmissionScoreResult], List[str]]:
+    """Evaluate ONE choice in isolation — gates first, then scoring.
+
+    Returns:
+        (decision, score_result_or_none, reason_codes)
+        decision ∈ {'admitted', 'rejected'} — waitlist deferred Q-P3-05
+
+    Side effects: NONE — pure decision computation. Caller writes
+    `choice.decision` + `choice.eligibility_check_result` based on returned
+    decision + reason codes.
+    """
+    reason_codes: List[str] = []
+    path = choice.admission_path
+
+    # Gate 1: min GPA threshold (Sub-1 helper)
+    # AdmissionPath has FK to AdmissionCriteria via criteria_id. Eager-loaded.
+    criteria = getattr(path, "criteria", None)
+    if criteria is not None:
+        passed_gpa, reason = AdmissionScoringService._check_min_gpa(
+            profile_gpa_overall=getattr(profile, "gpa_overall", None),
+            criteria_min_gpa=getattr(criteria, "min_gpa", None),
+        )
+        if not passed_gpa:
+            reason_codes.append(reason)
+            return "rejected", None, reason_codes
+
+        # Gate 2: graduation year range (Sub-1 helper; NO-OP cho mùa 2026)
+        # Phase 4 will activate by passing criteria.min/max_graduation_year
+        passed_year, reason = AdmissionScoringService._check_graduation_year_range(
+            profile_graduation_year=getattr(profile, "graduation_year", None),
+            # Phase 1 #04 deferred → pass None until Phase 4
+            criteria_min_graduation_year=None,
+            criteria_max_graduation_year=None,
+        )
+        if not passed_year:
+            reason_codes.append(reason)
+            return "rejected", None, reason_codes
+
+    # Gate 3..6 + scoring via existing calculate_score (Phase 2 rules)
+    # Caller MUST have provided subject_scores on profile (eager loaded)
+    subject_scores = _collect_subject_scores(choice)
+    allowed_subjects = _resolve_allowed_subjects(choice)
+
+    score_result: Optional[AdmissionScoreResult] = None
+    if criteria is not None and subject_scores and allowed_subjects:
+        score_result = AdmissionScoringService.calculate_score(
+            criteria=criteria,
+            subject_scores=subject_scores,
+            allowed_subjects=allowed_subjects,
+            subject_weights=None,  # Phase 4: read from path snapshot
+        )
+        reason_codes.extend(score_result.disqualification_codes)
+        if score_result.status == ProfileStatus.INVALID:
+            return "rejected", score_result, reason_codes
+        if not score_result.passed:
+            return "rejected", score_result, reason_codes
+        return "admitted", score_result, reason_codes
+
+    # Missing data → reject with explicit code
+    if not subject_scores:
+        reason_codes.append("NO_VALID_SCORES")
+    return "rejected", score_result, reason_codes
+
+
+def _collect_subject_scores(choice: "AdmissionProfileChoice") -> Dict[str, Any]:
+    """Build subject_scores dict from choice.scores eager-loaded rows.
+
+    Returns {subject_code: Decimal score}.
+    """
+    out: Dict[str, Any] = {}
+    scores = getattr(choice, "scores", None) or []
+    for score_row in scores:
+        subject = getattr(score_row, "subject", None)
+        code = getattr(subject, "code", None) if subject else None
+        if code:
+            out[code] = getattr(score_row, "score", None)
+    return out
+
+
+def _resolve_allowed_subjects(choice: "AdmissionProfileChoice") -> List[str]:
+    """Extract allowed subjects from choice.path_subject_group_config.
+
+    Returns list of subject codes in deterministic order.
+    """
+    config = getattr(choice, "path_subject_group_config", None)
+    if config is None:
+        return []
+    group = getattr(config, "subject_group", None)
+    if group is None:
+        return []
+    subjects = getattr(group, "subjects", None) or []
+    codes: List[str] = []
+    for s in subjects:
+        code = getattr(s, "code", None)
+        if code:
+            codes.append(code)
+    return codes
+
+
+# ============================================================================
+# Main orchestration — evaluate_cascade
+# ============================================================================
+
+
+async def evaluate_cascade(
+    db: AsyncSession,
+    profile: "AdmissionProfile",
+) -> Tuple[CascadeResult, Optional[Callable[[], Awaitable[None]]]]:
+    """T6 publish: sequential admit cascade per profile.choices.
+
+    PRE-CONDITIONS:
+        * `profile.uses_choice_engine == True` (caller verifies)
+        * `profile.status == 'reviewing'` (caller verifies)
+        * `profile.choices` eager-loaded with path + criteria +
+          path_subject_group_config + subject_group + scores chain
+        * Caller wrapped trong `async with db.begin_nested()` for atomic
+          per-profile rollback semantic
+
+    SIDE EFFECTS:
+        * Writes `choice.decision` + `choice.bonus_rule_snapshot` +
+          `choice.eligibility_check_result` per choice
+        * Marks remaining choices `'skip'` after first admit
+        * Transitions `profile.status` via state_service.transition()
+        * Dispatches ADMISSION_RESULT_PUBLISHED + per-choice decision event
+
+    Returns:
+        `(CascadeResult, post_commit_callback)` — V3.0 contract.
+        Caller commits db then awaits callback for notification outbox flush.
+
+    Raises:
+        BusinessRuleViolation: if state machine rejects transition edge
+        (propagated from state_service.transition())
+    """
+    from . import admission_state_service as state_service
+    from .notification_dispatcher import dispatch_event
+
+    # Sort choices by display_order (eager-loaded relation already ordered
+    # per AdmissionProfile.choices relationship but defensive sort here).
+    sorted_choices = sorted(
+        profile.choices,
+        key=lambda c: c.display_order,
+    )
+
+    result = CascadeResult(
+        profile_id=profile.id,
+        final_status="rejected",  # Default — overridden if any admit
+    )
+
+    admitted_found = False
+    for choice in sorted_choices:
+        if admitted_found:
+            # First admit found → mark remaining choices as 'skip'
+            choice.decision = "skip"
+            result.per_choice_decisions.append({
+                "choice_id": choice.id,
+                "display_order": choice.display_order,
+                "decision": "skip",
+                "reasons": [],
+                "score": None,
+            })
+            continue
+
+        # Q-P3-11: snapshot bonus_rule at T6 publish time
+        path = choice.admission_path
+        choice.bonus_rule_snapshot = resolve_effective_bonus_rule(path)
+
+        # Per-choice decision (gates + scoring)
+        decision, score_result, reason_codes = _evaluate_single_choice(
+            profile, choice,
+        )
+        choice.decision = decision
+
+        # Record eligibility check result for audit trail
+        choice.eligibility_check_result = {
+            "decision": decision,
+            "reason_codes": reason_codes,
+            "score": (
+                {
+                    "final_score": (
+                        float(score_result.final_score)
+                        if score_result and score_result.final_score is not None
+                        else None
+                    ),
+                    "passed": score_result.passed if score_result else False,
+                    "selected_subjects": (
+                        score_result.selected_subjects if score_result else []
+                    ),
+                }
+                if score_result
+                else None
+            ),
+        }
+
+        result.per_choice_decisions.append({
+            "choice_id": choice.id,
+            "display_order": choice.display_order,
+            "decision": decision,
+            "reasons": reason_codes,
+            "score": (
+                float(score_result.final_score)
+                if score_result and score_result.final_score is not None
+                else None
+            ),
+        })
+
+        if decision == "admitted":
+            admitted_found = True
+            result.admitted_choice_id = choice.id
+            result.admitted_display_order = choice.display_order
+
+    # Final profile status — admitted if any choice admitted, else rejected
+    final_status = "admitted" if admitted_found else "rejected"
+    result.final_status = final_status
+
+    await db.flush()
+
+    # Transition profile status: reviewing → result_published → final
+    # (state machine forbids reviewing → admitted directly per PR-3B map)
+    _, cb1 = await state_service.transition(
+        db, profile, "result_published",
+        source="choice_engine",
+        event_metadata={"cascade_run": True, "admitted_count": 1 if admitted_found else 0},
+    )
+    _, cb2 = await state_service.transition(
+        db, profile, final_status,
+        source="choice_engine",
+        event_metadata={
+            "cascade_run": True,
+            "admitted_choice_id": result.admitted_choice_id,
+        },
+    )
+
+    log.info(
+        "admission_choice_engine.evaluate_cascade",
+        profile_id=profile.id,
+        final_status=final_status,
+        admitted_choice_id=result.admitted_choice_id,
+        per_choice_count=len(result.per_choice_decisions),
+    )
+
+    # Chain callbacks: caller commits + awaits both dispatches
+    async def chained_callback() -> None:
+        if cb1 is not None:
+            await cb1()
+        if cb2 is not None:
+            await cb2()
+
+    return result, chained_callback

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -65,6 +65,7 @@ import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.events import SystemEvents
+from ..utils.exceptions import BusinessRuleViolation
 from .admission_scoring_service import (
     AdmissionScoringService,
     AdmissionScoreResult,
@@ -385,3 +386,179 @@ async def evaluate_cascade(
             await cb2()
 
     return result, chained_callback
+
+
+# ============================================================================
+# Sub-3.2 — Router-facing service helper
+# ============================================================================
+
+
+async def publish_result(
+    db: AsyncSession,
+    profile: "AdmissionProfile",
+) -> Tuple[CascadeResult, Optional[Callable[[], Awaitable[None]]]]:
+    """T6 publish-result service entry point (router-facing).
+
+    Thin wrapper trên `evaluate_cascade()` adding pre-condition guards.
+    Used by `POST /api/v2/admissions/{id}/publish-result` router (Sub-3.3).
+
+    PRE-CHECKS (raises BusinessRuleViolation):
+        1. `profile.uses_choice_engine == True` — only multi-NV profiles
+           publish via choice engine; legacy single-NV profiles flow qua
+           existing `admission_service.review_*` paths.
+        2. `profile.status == "reviewing"` — engine evaluates from
+           reviewing state ONLY. Other states blocked by state machine
+           (T6 edge: reviewing → result_published only).
+
+    NO `begin_nested()` wrap here — single-profile publish ships within
+    the router's outer transaction. Batch-publish (future Phase 4 ship)
+    would wrap per-profile in begin_nested with `dispatch_event(strict=True)`
+    propagation per memory `dispatch-bundle-strict-required`. For single-
+    profile case, FastAPI dependency rollback on exception suffices.
+
+    Returns:
+        `(CascadeResult, post_commit_callback)` per V3.0 contract.
+        Caller (router) commits db then awaits callback for
+        notification outbox flush.
+
+    Raises:
+        BusinessRuleViolation: pre-check failure (engine flag / wrong state)
+                                or downstream state machine edge rejection.
+    """
+    if not getattr(profile, "uses_choice_engine", False):
+        raise BusinessRuleViolation(
+            "Hồ sơ không bật multi-NV choice engine — không thể publish qua engine"
+        )
+    if profile.status != "reviewing":
+        raise BusinessRuleViolation(
+            f"Hồ sơ phải ở trạng thái 'reviewing' để publish; trạng thái hiện tại: '{profile.status}'"
+        )
+
+    return await evaluate_cascade(db, profile)
+
+
+# ============================================================================
+# Sub-3.2 — Waitlist promote helper (T10)
+# ============================================================================
+
+
+async def promote_waitlisted_choice(
+    db: AsyncSession,
+    choice: "AdmissionProfileChoice",
+    profile: "AdmissionProfile",
+    actor: Any,
+) -> Tuple[Dict[str, Any], Optional[Callable[[], Awaitable[None]]]]:
+    """T10 manual promote: waitlisted → admitted (admin action).
+
+    Used by `POST /api/v2/admin/admission-profile-choice/{id}/promote`.
+    Uses PR-3B Sub-2 `TRANSITION_PAIR_TO_EVENT` source-aware mapping:
+    `(waitlisted, admitted)` fires `ADMISSION_WAITLIST_PROMOTED` (NOT
+    generic `ADMISSION_DECISION_ADMITTED` from target alone).
+
+    PRE-CHECKS:
+        1. `choice.decision == "waitlisted"` — only waitlisted choices
+           can be promoted
+        2. `profile.status == "waitlisted"` — must match (engine sets
+           both together per cascade)
+
+    Returns:
+        `(result_dict, post_commit_callback)` per V3.0 contract.
+    """
+    from . import admission_state_service as state_service
+
+    if choice.decision != "waitlisted":
+        raise BusinessRuleViolation(
+            f"Nguyện vọng phải ở quyết định 'waitlisted'; current: '{choice.decision}'"
+        )
+    if profile.status != "waitlisted":
+        raise BusinessRuleViolation(
+            f"Hồ sơ phải ở trạng thái 'waitlisted'; current: '{profile.status}'"
+        )
+
+    # Update choice decision FIRST so audit trail captures the source
+    choice.decision = "admitted"
+    await db.flush()
+
+    # State transition fires ADMISSION_WAITLIST_PROMOTED via PAIR map
+    _, callback = await state_service.transition(
+        db, profile, "admitted",
+        actor=actor,
+        source="waitlist_promote",
+        event_metadata={
+            "promoted_from_waitlist": True,
+            "choice_id": choice.id,
+            "display_order": choice.display_order,
+        },
+    )
+
+    return (
+        {
+            "choice_id": choice.id,
+            "decision": "admitted",
+            "profile_id": profile.id,
+            "profile_status": "admitted",
+        },
+        callback,
+    )
+
+
+# ============================================================================
+# Sub-3.2 — Admin rollback helper (T17)
+# ============================================================================
+
+
+async def admin_rollback_profile(
+    db: AsyncSession,
+    profile: "AdmissionProfile",
+    reason: str,
+    actor: Any,
+) -> Tuple[Dict[str, Any], Optional[Callable[[], Awaitable[None]]]]:
+    """T17 admin-rollback: any non-final state → draft (admin-only).
+
+    Used by `POST /api/v2/admissions/{id}/admin-rollback`. Uses PR-3C
+    Sub-3.5 `TRANSITION_PAIR_TO_EVENT` extension (11 pair entries) —
+    `(<any_source>, "draft")` fires `ADMISSION_ROLLED_BACK` source-aware.
+
+    PRE-CHECKS:
+        1. `profile.status NOT IN ("enrolled", "withdrawn")` — terminal
+           states cannot be rolled back per state machine (no `→ DRAFT`
+           edges from those sources).
+        2. `reason` mandatory, min 10 chars (caller already validated via
+           schema; defensive re-check here).
+
+    Returns:
+        `(result_dict, post_commit_callback)` with `rolled_back_from`
+        capture for audit response.
+    """
+    from . import admission_state_service as state_service
+
+    rolled_back_from = profile.status
+
+    if rolled_back_from in ("enrolled", "withdrawn"):
+        raise BusinessRuleViolation(
+            f"Hồ sơ ở trạng thái cuối ('{rolled_back_from}') không thể rollback"
+        )
+    if not reason or len(reason.strip()) < 10:
+        raise BusinessRuleViolation(
+            "Lý do rollback bắt buộc, tối thiểu 10 ký tự"
+        )
+
+    _, callback = await state_service.transition(
+        db, profile, "draft",
+        actor=actor,
+        reason=reason,
+        source="admin_rollback",
+        event_metadata={
+            "rolled_back_from": rolled_back_from,
+            "actor_id": getattr(actor, "id", None),
+        },
+    )
+
+    return (
+        {
+            "profile_id": profile.id,
+            "status": "draft",
+            "rolled_back_from": rolled_back_from,
+        },
+        callback,
+    )

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -447,10 +447,13 @@ async def promote_waitlisted_choice(
     choice: "AdmissionProfileChoice",
     profile: "AdmissionProfile",
     actor: Any,
+    reason: Optional[str] = None,
 ) -> Tuple[Dict[str, Any], Optional[Callable[[], Awaitable[None]]]]:
     """T10 manual promote: waitlisted → admitted (admin action).
 
-    Used by `POST /api/v2/admin/admission-profile-choice/{id}/promote`.
+    Used by `POST /api/v2/admissions/{profile_id}/waitlist-promote`
+    (Sub-3.4 router, profile-scoped per Casbin policy LIVE prod — see
+    DRIFT-01 sync from Plan v0.7 line 437 stale choice-scoped path).
     Uses PR-3B Sub-2 `TRANSITION_PAIR_TO_EVENT` source-aware mapping:
     `(waitlisted, admitted)` fires `ADMISSION_WAITLIST_PROMOTED` (NOT
     generic `ADMISSION_DECISION_ADMITTED` from target alone).
@@ -483,6 +486,7 @@ async def promote_waitlisted_choice(
     _, callback = await state_service.transition(
         db, profile, "admitted",
         actor=actor,
+        reason=reason,  # Optional audit context (Sub-3.4 router passes payload.reason)
         source="waitlist_promote",
         event_metadata={
             "promoted_from_waitlist": True,

--- a/Backend_FastAPI/app/services/admission_scoring_service.py
+++ b/Backend_FastAPI/app/services/admission_scoring_service.py
@@ -68,6 +68,10 @@ class DisqualificationReason(str, Enum):
     SUBJECT_BELOW_THRESHOLD = "SUBJECT_BELOW_THRESHOLD"
     NO_VALID_SCORES = "NO_VALID_SCORES"
     INVALID_SUBJECT_GROUP = "INVALID_SUBJECT_GROUP"
+    # Phase 3 PR-3C — choice-engine cascade gates (called BEFORE
+    # calculate_score per evaluate_cascade orchestration)
+    MISSING_GPA_OVERALL = "MISSING_GPA_OVERALL"
+    GRADUATION_YEAR_OUT_OF_RANGE = "GRADUATION_YEAR_OUT_OF_RANGE"
 
 
 # =============================================================================
@@ -565,3 +569,93 @@ class AdmissionScoringService:
         payload = json.dumps(data, sort_keys=True, default=str)
         calculated = hashlib.sha256(payload.encode()).hexdigest()
         return stored_checksum == calculated
+
+    # =========================================================================
+    # PHASE 3 PR-3C — CHOICE-ENGINE PROFILE-LEVEL GATES
+    # =========================================================================
+    # Standalone rule helpers called BEFORE `calculate_score()` trong
+    # PR-3C Sub-2's `evaluate_cascade()` orchestration. Kept separate
+    # from `calculate_score()` để KHÔNG touch its existing signature
+    # (3 callers: admission_config.py:749 + admission_service.py:3708 +
+    # admission_service.py:3903). The cascade orchestrator (PR-3C Sub-2)
+    # chains: gate1 (min_gpa) → gate2 (grad_year) → calculate_score().
+    #
+    # Why static + pure: same design constraint as `calculate_score()`
+    # (deterministic + reproducible for audit). Helpers take profile +
+    # criteria args explicitly; no DB calls, no side effects.
+
+    @staticmethod
+    def _check_min_gpa(
+        profile_gpa_overall: Optional[Decimal],
+        criteria_min_gpa: Optional[Decimal],
+    ) -> tuple[bool, Optional[str]]:
+        """Phase 3 PR-3C rule 2: minimum overall GPA threshold.
+
+        Plan v0.7 PR-3C "6-rule sequential" spec. Returns (passed, reason_code).
+
+        Args:
+            profile_gpa_overall: `AdmissionProfile.gpa_overall` (Numeric(4,2)
+                nullable per phase1_09a). Pass-through to comparison.
+            criteria_min_gpa: `AdmissionCriteria.min_gpa` (Numeric, nullable).
+                None = no threshold configured → rule SKIPS (returns pass).
+
+        Returns:
+            (True, None) if rule passes (no threshold OR GPA ≥ threshold)
+            (False, "MISSING_GPA_OVERALL") if threshold set but profile.gpa
+                null — candidate must provide GPA
+            (False, "BELOW_MIN_GPA") if GPA < threshold
+
+        Determinism: pure comparison, no I/O. Match `calculate_score()`
+        contract — caller (Sub-2 cascade) decides how to react to fail.
+        """
+        if criteria_min_gpa is None:
+            return True, None  # No threshold configured → skip rule
+        if profile_gpa_overall is None:
+            return False, DisqualificationReason.MISSING_GPA_OVERALL.value
+        if Decimal(str(profile_gpa_overall)) < Decimal(str(criteria_min_gpa)):
+            return False, DisqualificationReason.BELOW_MIN_GPA.value
+        return True, None
+
+    @staticmethod
+    def _check_graduation_year_range(
+        profile_graduation_year: Optional[int],
+        criteria_min_graduation_year: Optional[int] = None,
+        criteria_max_graduation_year: Optional[int] = None,
+    ) -> tuple[bool, Optional[str]]:
+        """Phase 3 PR-3C rule 3: graduation year range gate.
+
+        ⚠️ NO-OP placeholder cho mùa 2026 — Phase 1 #04 columns
+        ``min_graduation_year`` + ``max_graduation_year`` trên
+        ``AdmissionCriteria`` đã DEFERRED Q1/2027 per Q9 chốt
+        2026-05-01 (memory `184-phase1-schema-wave-plan` line 88).
+
+        Current behavior: returns ``(True, None)`` if criteria_*_year
+        args are None (default — Phase 4 not yet wired). Helper signature
+        already accepts the range params so Phase 4 swap = caller passes
+        the criteria fields, NO body change needed.
+
+        Phase 4 activation: ship migration adding columns +
+        backfill defaults + caller (Sub-2 cascade orchestrator) reads
+        `criteria.min_graduation_year` / `max_graduation_year` + passes
+        them here. Logic body below already handles the range check —
+        just gated behind None checks.
+
+        Determinism: pure comparison, no I/O.
+        """
+        # Phase 4 activation gate: skip nếu range không configured
+        if criteria_min_graduation_year is None and criteria_max_graduation_year is None:
+            return True, None
+        # Profile must have grad_year set if any range configured
+        if profile_graduation_year is None:
+            return False, DisqualificationReason.GRADUATION_YEAR_OUT_OF_RANGE.value
+        if (
+            criteria_min_graduation_year is not None
+            and profile_graduation_year < criteria_min_graduation_year
+        ):
+            return False, DisqualificationReason.GRADUATION_YEAR_OUT_OF_RANGE.value
+        if (
+            criteria_max_graduation_year is not None
+            and profile_graduation_year > criteria_max_graduation_year
+        ):
+            return False, DisqualificationReason.GRADUATION_YEAR_OUT_OF_RANGE.value
+        return True, None

--- a/Backend_FastAPI/app/services/admission_state_machine.py
+++ b/Backend_FastAPI/app/services/admission_state_machine.py
@@ -86,14 +86,23 @@ ALLOWED_TRANSITIONS: Dict[AdmissionStatus, Set[AdmissionStatus]] = {
         AdmissionStatus.WITHDRAWN,
         # Phase 3 T2: submitted → reviewing (manager review window)
         AdmissionStatus.REVIEWING,
+        # Phase 3 PR-3C Sub-3.5 T17: admin rollback → draft
+        AdmissionStatus.DRAFT,
     },
-    AdmissionStatus.REJECTED: {AdmissionStatus.RESUBMITTED, AdmissionStatus.WITHDRAWN},
+    AdmissionStatus.REJECTED: {
+        AdmissionStatus.RESUBMITTED,
+        AdmissionStatus.WITHDRAWN,
+        # Phase 3 PR-3C Sub-3.5 T17
+        AdmissionStatus.DRAFT,
+    },
     AdmissionStatus.REVISION_REQUESTED: {
         AdmissionStatus.RESUBMITTED,
         AdmissionStatus.REJECTED,
         AdmissionStatus.WITHDRAWN,
         # Phase 3 T4: revision_requested → reviewing (after candidate fix)
         AdmissionStatus.REVIEWING,
+        # Phase 3 PR-3C Sub-3.5 T17
+        AdmissionStatus.DRAFT,
     },
     AdmissionStatus.RESUBMITTED: {
         AdmissionStatus.APPROVED,
@@ -102,14 +111,29 @@ ALLOWED_TRANSITIONS: Dict[AdmissionStatus, Set[AdmissionStatus]] = {
         AdmissionStatus.WITHDRAWN,
         # Phase 3: resubmitted → reviewing (uses_choice_engine path)
         AdmissionStatus.REVIEWING,
+        # Phase 3 PR-3C Sub-3.5 T17
+        AdmissionStatus.DRAFT,
     },
-    AdmissionStatus.APPROVED: {AdmissionStatus.CONFIRMED, AdmissionStatus.OVERRIDDEN},
-    AdmissionStatus.OVERRIDDEN: {AdmissionStatus.ENROLLED},
-    AdmissionStatus.CONFIRMED: {AdmissionStatus.ENROLLED},
+    AdmissionStatus.APPROVED: {
+        AdmissionStatus.CONFIRMED,
+        AdmissionStatus.OVERRIDDEN,
+        # Phase 3 PR-3C Sub-3.5 T17 — admin rollback approved profile
+        AdmissionStatus.DRAFT,
+    },
+    AdmissionStatus.OVERRIDDEN: {
+        AdmissionStatus.ENROLLED,
+        # Phase 3 PR-3C Sub-3.5 T17
+        AdmissionStatus.DRAFT,
+    },
+    AdmissionStatus.CONFIRMED: {
+        AdmissionStatus.ENROLLED,
+        # Phase 3 PR-3C Sub-3.5 T17 — admin rollback confirmed (rare)
+        AdmissionStatus.DRAFT,
+    },
     AdmissionStatus.ENROLLED: set(),  # Final state - no transitions
     AdmissionStatus.WITHDRAWN: set(),  # Final state - no transitions
 
-    # Phase 3 multi-NV edges (PR-3B)
+    # Phase 3 multi-NV edges (PR-3B + PR-3C Sub-3.5 T17 extension)
     AdmissionStatus.REVIEWING: {
         # T3: reviewing → revision_requested (manager requests fix)
         AdmissionStatus.REVISION_REQUESTED,
@@ -117,6 +141,8 @@ ALLOWED_TRANSITIONS: Dict[AdmissionStatus, Set[AdmissionStatus]] = {
         AdmissionStatus.RESULT_PUBLISHED,
         # Candidate withdraws during review window
         AdmissionStatus.WITHDRAWN,
+        # Phase 3 PR-3C Sub-3.5 T17
+        AdmissionStatus.DRAFT,
     },
     AdmissionStatus.RESULT_PUBLISHED: {
         # T7: result_published → admitted (choice-engine cascade)
@@ -125,12 +151,16 @@ ALLOWED_TRANSITIONS: Dict[AdmissionStatus, Set[AdmissionStatus]] = {
         AdmissionStatus.WAITLISTED,
         # T9 (multi-NV variant): result_published → rejected
         AdmissionStatus.REJECTED,
+        # Phase 3 PR-3C Sub-3.5 T17
+        AdmissionStatus.DRAFT,
     },
     AdmissionStatus.ADMITTED: {
         # T12 (multi-NV): admitted → confirmed (candidate accepts)
         AdmissionStatus.CONFIRMED,
         # Candidate withdraws after admit
         AdmissionStatus.WITHDRAWN,
+        # Phase 3 PR-3C Sub-3.5 T17
+        AdmissionStatus.DRAFT,
     },
     AdmissionStatus.WAITLISTED: {
         # T10: waitlisted → admitted (manual admin promote)
@@ -139,6 +169,8 @@ ALLOWED_TRANSITIONS: Dict[AdmissionStatus, Set[AdmissionStatus]] = {
         AdmissionStatus.REJECTED,
         # Candidate withdraws while waitlisted
         AdmissionStatus.WITHDRAWN,
+        # Phase 3 PR-3C Sub-3.5 T17
+        AdmissionStatus.DRAFT,
     },
 }
 

--- a/Backend_FastAPI/app/services/admission_state_service.py
+++ b/Backend_FastAPI/app/services/admission_state_service.py
@@ -188,6 +188,7 @@ event=SystemEvents.ADMISSION_WAITLIST_PROMOTED            T10 (source-aware: wai
 event=SystemEvents.ADMISSION_CONFIRMED                    T12
 event=SystemEvents.ADMISSION_ENROLLED                     T13
 event=SystemEvents.ADMISSION_WITHDRAWN                    T14/T15/T16
+event=SystemEvents.ADMISSION_ROLLED_BACK                  T17 (source-aware: any non-final state → draft, Phase 3 PR-3C Sub-3.5)
 """
 
 
@@ -234,6 +235,22 @@ LEGACY_STATUS_TO_EVENT: Dict[str, SystemEvents] = {
 # by ``tests/unit/test_admission_state_service_event_mapping.py``.
 TRANSITION_PAIR_TO_EVENT: Dict[Tuple[str, str], SystemEvents] = {
     ("waitlisted", "admitted"): SystemEvents.ADMISSION_WAITLIST_PROMOTED,  # T10
+    # Phase 3 PR-3C Sub-3.5 T17 — admin rollback to draft fires
+    # ADMISSION_ROLLED_BACK regardless of source state. Pair entries
+    # for ALL 11 non-draft non-final-WITHDRAWN/ENROLLED states which
+    # now have `→ DRAFT` edge in `admission_state_machine.ALLOWED_TRANSITIONS`.
+    # ENROLLED + WITHDRAWN stay final per state machine — no rollback edge.
+    ("submitted",          "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+    ("reviewing",          "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+    ("revision_requested", "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+    ("resubmitted",        "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+    ("result_published",   "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+    ("admitted",           "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+    ("waitlisted",         "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+    ("rejected",           "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+    ("approved",           "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+    ("overridden",         "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+    ("confirmed",          "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
 }
 
 
@@ -241,17 +258,14 @@ TRANSITION_PAIR_TO_EVENT: Dict[Tuple[str, str], SystemEvents] = {
 # The coverage script's ``--allow-deferred`` flag accepts this exact set
 # and prints them in the summary so operators know the gap is intentional.
 #
-# Phase 3 PR-3B Sub-2 shrunk this from 4 → 1: T6/T8/T10 wired via
-# ``LEGACY_STATUS_TO_EVENT`` + ``TRANSITION_PAIR_TO_EVENT`` extension.
-# T17 ``ADMISSION_ROLLED_BACK`` stays deferred until PR-3C ships the
-# ``/api/v2/admissions/{id}/admin-rollback`` router endpoint (the rollback
-# transition itself goes back to ``draft`` and reuses
-# ``LEGACY_STATUS_TO_EVENT`` indirection via ``draft`` not having a row —
-# the dedicated ROLLED_BACK event is dispatched by the router post-commit
-# instead of via this map).
-DEFERRED_ADMISSION_EVENTS: frozenset[str] = frozenset({
-    "ADMISSION_ROLLED_BACK",          # T17 — admin rollback router PR-3C
-})
+# Phase 3 PR-3B Sub-2 shrunk 4 → 1 (wired T6/T8/T10).
+# Phase 3 PR-3C Sub-3.5 shrunk 1 → 0 — T17 ADMISSION_ROLLED_BACK now wired
+# via TRANSITION_PAIR_TO_EVENT 11 pair entries (one per non-final source
+# state). All 12 catalog events have a writer reachable from `transition()`.
+#
+# Empty frozenset = no deferred events. CI gate `--allow-deferred` flag
+# in both deploy.yml + admission-contract-check.yml synced empty.
+DEFERRED_ADMISSION_EVENTS: frozenset[str] = frozenset()
 
 
 # ---------------------------------------------------------------------------

--- a/Backend_FastAPI/tests/unit/test_admission_state_machine.py
+++ b/Backend_FastAPI/tests/unit/test_admission_state_machine.py
@@ -67,61 +67,65 @@ class TestAllowedTransitions:
         }
 
     def test_submitted_transitions(self):
-        """SUBMITTED can transition to APPROVED/REJECTED/REVISION_REQUESTED/
-        WITHDRAWN (legacy) or REVIEWING (Phase 3 T2)."""
+        """SUBMITTED: legacy 4 + REVIEWING (Phase 3 T2) + DRAFT (T17 PR-3C)."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.SUBMITTED] == {
             AdmissionStatus.APPROVED,
             AdmissionStatus.REJECTED,
             AdmissionStatus.REVISION_REQUESTED,
             AdmissionStatus.WITHDRAWN,
-            AdmissionStatus.REVIEWING,  # Phase 3 T2
+            AdmissionStatus.REVIEWING,
+            AdmissionStatus.DRAFT,  # T17 PR-3C Sub-3.5
         }
 
     def test_rejected_transitions(self):
-        """REJECTED can transition to RESUBMITTED or WITHDRAWN."""
+        """REJECTED: legacy 2 + DRAFT (T17 PR-3C Sub-3.5)."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.REJECTED] == {
             AdmissionStatus.RESUBMITTED,
             AdmissionStatus.WITHDRAWN,
+            AdmissionStatus.DRAFT,
         }
 
     def test_resubmitted_transitions(self):
-        """RESUBMITTED can transition to APPROVED/REJECTED/REVISION_REQUESTED/
-        WITHDRAWN (legacy) or REVIEWING (Phase 3)."""
+        """RESUBMITTED: legacy 4 + REVIEWING + DRAFT (T17)."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.RESUBMITTED] == {
             AdmissionStatus.APPROVED,
             AdmissionStatus.REJECTED,
             AdmissionStatus.REVISION_REQUESTED,
             AdmissionStatus.WITHDRAWN,
-            AdmissionStatus.REVIEWING,  # Phase 3
+            AdmissionStatus.REVIEWING,
+            AdmissionStatus.DRAFT,
         }
 
     def test_revision_requested_transitions(self):
-        """REVISION_REQUESTED can transition to RESUBMITTED/REJECTED/
-        WITHDRAWN (legacy) or REVIEWING (Phase 3 T4)."""
+        """REVISION_REQUESTED: legacy 3 + REVIEWING (T4) + DRAFT (T17)."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.REVISION_REQUESTED] == {
             AdmissionStatus.RESUBMITTED,
             AdmissionStatus.REJECTED,
             AdmissionStatus.WITHDRAWN,
-            AdmissionStatus.REVIEWING,  # Phase 3 T4
+            AdmissionStatus.REVIEWING,
+            AdmissionStatus.DRAFT,
         }
 
     def test_approved_transitions(self):
-        """APPROVED can transition to CONFIRMED or OVERRIDDEN."""
+        """APPROVED: legacy 2 + DRAFT (T17)."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.APPROVED] == {
             AdmissionStatus.CONFIRMED,
             AdmissionStatus.OVERRIDDEN,
+            AdmissionStatus.DRAFT,
         }
 
     def test_confirmed_transitions(self):
-        """CONFIRMED can only transition to ENROLLED."""
+        """CONFIRMED: ENROLLED + DRAFT (T17, rare)."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.CONFIRMED] == {
-            AdmissionStatus.ENROLLED
+            AdmissionStatus.ENROLLED,
+            AdmissionStatus.DRAFT,
         }
 
     def test_overridden_transitions(self):
-        """OVERRIDDEN can only transition to ENROLLED."""
+        """OVERRIDDEN: ENROLLED + DRAFT (T17)."""
         assert ALLOWED_TRANSITIONS[AdmissionStatus.OVERRIDDEN] == {
-            AdmissionStatus.ENROLLED
+            AdmissionStatus.ENROLLED,
+            AdmissionStatus.DRAFT,
         }
 
     def test_enrolled_transitions(self):
@@ -219,41 +223,45 @@ class TestGetAllowedTransitions:
         assert get_allowed_transitions("draft") == {"submitted", "withdrawn"}
 
     def test_submitted_allowed_transitions(self):
-        """SUBMITTED: legacy 4 + Phase 3 reviewing (T2)."""
+        """SUBMITTED: legacy 4 + Phase 3 reviewing (T2) + draft (T17)."""
         assert get_allowed_transitions("submitted") == {
             "approved", "rejected", "revision_requested", "withdrawn",
-            "reviewing",
+            "reviewing", "draft",
         }
 
     def test_rejected_allowed_transitions(self):
-        """REJECTED can go to RESUBMITTED or WITHDRAWN."""
-        assert get_allowed_transitions("rejected") == {"resubmitted", "withdrawn"}
+        """REJECTED: legacy 2 + draft (T17 PR-3C Sub-3.5)."""
+        assert get_allowed_transitions("rejected") == {
+            "resubmitted", "withdrawn", "draft",
+        }
 
     def test_revision_requested_allowed_transitions(self):
-        """REVISION_REQUESTED: legacy 3 + Phase 3 reviewing (T4)."""
+        """REVISION_REQUESTED: legacy 3 + Phase 3 reviewing (T4) + draft (T17)."""
         assert get_allowed_transitions("revision_requested") == {
             "resubmitted", "rejected", "withdrawn",
-            "reviewing",
+            "reviewing", "draft",
         }
 
     def test_resubmitted_allowed_transitions(self):
-        """RESUBMITTED: legacy 4 + Phase 3 reviewing."""
+        """RESUBMITTED: legacy 4 + Phase 3 reviewing + draft (T17)."""
         assert get_allowed_transitions("resubmitted") == {
             "approved", "rejected", "revision_requested", "withdrawn",
-            "reviewing",
+            "reviewing", "draft",
         }
 
     def test_approved_allowed_transitions(self):
-        """APPROVED can go to CONFIRMED or OVERRIDDEN."""
-        assert get_allowed_transitions("approved") == {"confirmed", "overridden"}
+        """APPROVED: legacy 2 + draft (T17 PR-3C Sub-3.5)."""
+        assert get_allowed_transitions("approved") == {
+            "confirmed", "overridden", "draft",
+        }
 
     def test_confirmed_allowed_transitions(self):
-        """CONFIRMED can only go to ENROLLED."""
-        assert get_allowed_transitions("confirmed") == {"enrolled"}
+        """CONFIRMED: legacy 1 + draft (T17 PR-3C Sub-3.5, rare)."""
+        assert get_allowed_transitions("confirmed") == {"enrolled", "draft"}
 
     def test_overridden_allowed_transitions(self):
-        """OVERRIDDEN can only go to ENROLLED."""
-        assert get_allowed_transitions("overridden") == {"enrolled"}
+        """OVERRIDDEN: legacy 1 + draft (T17 PR-3C Sub-3.5)."""
+        assert get_allowed_transitions("overridden") == {"enrolled", "draft"}
 
     def test_enrolled_allowed_transitions(self):
         """ENROLLED is final - no transitions."""
@@ -353,12 +361,18 @@ class TestStateMachineInvariants:
     """Test state machine invariants (business rules)."""
 
     def test_no_backwards_transitions(self):
-        """Cannot transition backwards in the workflow."""
+        """Cannot transition backwards in the workflow.
+
+        Note: T17 admin-rollback (PR-3C Sub-3.5) allows `→ draft` from
+        11 non-final states — exception to backwards-rule, audit-gated
+        via require_admin + reason mandatory. These pairs intentionally
+        OMITTED from the invalid_backwards list.
+        """
         invalid_backwards = [
-            ("approved", "submitted"),
+            ("approved", "submitted"),  # No "down" except T17 (admitted→draft tested elsewhere)
             ("confirmed", "approved"),
             ("enrolled", "confirmed"),
-            ("resubmitted", "draft"),
+            # ("resubmitted", "draft") REMOVED — T17 now valid (PR-3C Sub-3.5)
         ]
         for current, target in invalid_backwards:
             assert can_transition(current, target) is False

--- a/Backend_FastAPI/tests/unit/test_admission_state_service_event_mapping.py
+++ b/Backend_FastAPI/tests/unit/test_admission_state_service_event_mapping.py
@@ -73,14 +73,29 @@ def test_legacy_status_to_event_has_10_distinct_events() -> None:
 
 
 def test_transition_pair_to_event_locked_set() -> None:
-    """Phase 3 PR-3B Sub-2 source-aware mapping locked.
+    """Phase 3 source-aware mapping locked. 12 pair entries total:
 
-    Single entry T10 — waitlisted→admitted fires WAITLIST_PROMOTED
-    (NOT generic DECISION_ADMITTED). Adding new pair entries requires
-    same audit discipline as LEGACY_STATUS_TO_EVENT changes.
+    - T10 (waitlisted → admitted) → ADMISSION_WAITLIST_PROMOTED (PR-3B Sub-2)
+    - T17 (11 source states → draft) → ADMISSION_ROLLED_BACK (PR-3C Sub-3.5)
+
+    Adding new pair entries requires same audit discipline as
+    LEGACY_STATUS_TO_EVENT changes.
     """
     assert state_service.TRANSITION_PAIR_TO_EVENT == {
-        ("waitlisted", "admitted"): SystemEvents.ADMISSION_WAITLIST_PROMOTED,  # T10
+        # T10
+        ("waitlisted", "admitted"): SystemEvents.ADMISSION_WAITLIST_PROMOTED,
+        # T17 — 11 pair entries (one per non-final non-WITHDRAWN/ENROLLED source)
+        ("submitted",          "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+        ("reviewing",          "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+        ("revision_requested", "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+        ("resubmitted",        "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+        ("result_published",   "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+        ("admitted",           "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+        ("waitlisted",         "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+        ("rejected",           "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+        ("approved",           "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+        ("overridden",         "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
+        ("confirmed",          "draft"): SystemEvents.ADMISSION_ROLLED_BACK,
     }
 
 
@@ -102,14 +117,11 @@ def test_approved_and_overridden_share_admitted_event() -> None:
 
 
 def test_deferred_admission_events_locked_set() -> None:
-    """Phase 3 PR-3B Sub-2 shrunk 4 → 1: T6/T8 wired via
-    LEGACY_STATUS_TO_EVENT, T10 wired via TRANSITION_PAIR_TO_EVENT.
-    Only T17 ROLLED_BACK stays deferred until PR-3C ships the
-    admin-rollback router endpoint.
+    """Phase 3 PR-3C Sub-3.5 shrunk 1 → 0: T17 ADMISSION_ROLLED_BACK wired
+    via TRANSITION_PAIR_TO_EVENT (11 pair entries — one per non-final
+    source state). ALL 12 catalog events now have a writer.
     """
-    assert state_service.DEFERRED_ADMISSION_EVENTS == frozenset({
-        "ADMISSION_ROLLED_BACK",          # T17 — admin rollback (PR-3C)
-    })
+    assert state_service.DEFERRED_ADMISSION_EVENTS == frozenset()
 
 
 def test_deferred_set_is_frozenset() -> None:

--- a/Backend_FastAPI/tests/unit/test_casbin_phase3_routes.py
+++ b/Backend_FastAPI/tests/unit/test_casbin_phase3_routes.py
@@ -46,6 +46,8 @@ ROUTE_PROMOTE_POST = ("/api/v2/admissions/123/waitlist-promote", "POST")
 ROUTE_REJECT_POST = ("/api/v2/admissions/123/waitlist-reject", "POST")
 ROUTE_CHOICES_GET = ("/api/v2/admissions/123/choices", "GET")
 ROUTE_PUBLISH_GET = ("/api/v2/admissions/123/publish-result", "GET")
+# Phase 3 PR-3C Sub-3.5b — T17 admin-rollback route
+ROUTE_ADMIN_ROLLBACK_POST = ("/api/v2/admissions/123/admin-rollback", "POST")
 
 
 # ----------------------------------------------------------------------
@@ -171,6 +173,8 @@ def enforcer():
         # Manager inherits officer GET reads
         ("role:manager", ROUTE_CHOICES_GET, True),
         ("role:manager", ROUTE_PUBLISH_GET, True),
+        # ⭐ Manager DENY admin-rollback (T17 admin-only, no manager allow + no inheritance reach)
+        ("role:manager", ROUTE_ADMIN_ROLLBACK_POST, False),
         # Officer denied on POST (no allow rule, no inheritance reach)
         ("role:officer", ROUTE_PUBLISH_POST, False),
         ("role:officer", ROUTE_PROMOTE_POST, False),
@@ -178,6 +182,8 @@ def enforcer():
         # Officer allow on GET reads (NEW)
         ("role:officer", ROUTE_CHOICES_GET, True),
         ("role:officer", ROUTE_PUBLISH_GET, True),
+        # ⭐ Officer DENY admin-rollback (no allow)
+        ("role:officer", ROUTE_ADMIN_ROLLBACK_POST, False),
         # Accountant explicit DENY on 3 POST routes (Phase 1 B1)
         ("role:accountant", ROUTE_PUBLISH_POST, False),
         ("role:accountant", ROUTE_PROMOTE_POST, False),
@@ -185,19 +191,98 @@ def enforcer():
         # Accountant inherits officer GET reads (per diamond)
         ("role:accountant", ROUTE_CHOICES_GET, True),
         ("role:accountant", ROUTE_PUBLISH_GET, True),
+        # ⭐ Accountant explicit DENY admin-rollback (Phase 1 B1 line 324)
+        ("role:accountant", ROUTE_ADMIN_ROLLBACK_POST, False),
     ],
 )
 def test_phase3_route_enforce_matrix(enforcer, role, route, expected):
-    """Anchor matrix: 3 roles × 5 routes = 15 cells covering
-    Phase 3 multi-NV transitions + reads.
+    """Anchor matrix: 3 roles × 6 routes = 18 cells covering
+    Phase 3 multi-NV transitions + reads + T17 admin-rollback.
 
-    Manager: 3 POST allow + 2 GET inherit allow = 5 True
-    Officer: 3 POST deny (no allow) + 2 GET allow = 3 True / 2 False inverted → 2 True / 3 False
-    Accountant: 3 POST explicit deny + 2 GET inherit allow = 2 True / 3 False
+    Manager: 3 POST allow + 2 GET inherit allow + admin-rollback DENY = 5 True / 1 False
+    Officer: 3 POST deny (no allow) + 2 GET allow + admin-rollback DENY = 2 True / 4 False
+    Accountant: 3 POST explicit deny + 2 GET inherit allow + admin-rollback explicit DENY = 2 True / 4 False
+
+    Why admin-rollback DENIED for ALL non-admin roles: T17 admin-only via
+    `require_admin` FastAPI dependency (NOT CasbinAuth). Casbin policy has
+    accountant explicit DENY (Phase 1 B1) + zero allow rules for any role
+    → all Casbin enforce checks return False. Admin uses `require_admin`
+    BYPASSING Casbin entirely per memory `lead-active-user-casbin-pr4`.
     """
     obj, action = route
     result = enforcer.enforce(role, obj, action)
     assert result is expected, (
         f"Casbin enforce drift: ({role}, {obj}, {action}) expected "
         f"{expected}, got {result}"
+    )
+
+
+# ----------------------------------------------------------------------
+# T17 admin-rollback — Casbin DENY for ALL roles via diamond inheritance
+# ----------------------------------------------------------------------
+
+
+def test_admin_rollback_casbin_denies_admin_via_diamond_inheritance():
+    """⭐ Critical anchor: admin would ALSO be DENIED Casbin enforce on
+    admin-rollback (via `g, role:admin, role:accountant` diamond → admin
+    inherits accountant explicit deny). This PROVES T17 admin-rollback
+    MUST use `require_admin` FastAPI dep, NOT CasbinAuth.
+
+    Per memory `lead-active-user-casbin-pr4`: admin role uses require_admin
+    direct gate which bypasses Casbin. If em ever swap admin-rollback gate
+    from `require_admin` → `CasbinAuth`, admin would get 403 — this test
+    would still pass (proving Casbin behavior) but the route would break
+    for actual admins. Cross-ref `test_admin_rollback_uses_require_admin`
+    trong test_phase3_pr3c_sub3_router_registration.py — that test locks
+    the FastAPI dep wiring, this test locks Casbin enforce contract.
+
+    Build enforcer với admin template + diamond edge (admin → accountant).
+    """
+    # Include admin template + accountant diamond inheritance
+    from app.casbin_config.policy_templates import ADMIN_TEMPLATE
+    roles = {
+        "admin": ADMIN_TEMPLATE,
+        "manager": MANAGER_TEMPLATE,
+        "officer": OFFICER_TEMPLATE,
+        "accountant": ACCOUNTANT_TEMPLATE,
+    }
+    # _build_enforcer_from_templates only adds manager→officer and
+    # accountant→officer edges. For admin diamond, build manually.
+    from tempfile import NamedTemporaryFile
+    import casbin
+
+    lines = []
+    for template_name in roles:
+        role_subject = f"role:{template_name}"
+        rules = apply_template(template_name, role_subject)
+        for r in rules:
+            eft = r.get("eft", "allow")
+            lines.append(f"p, {r['subject']}, {r['object']}, {r['action']}, {eft}")
+
+    # Diamond inheritance (per Phase 1 B1 docstring lines 42-47)
+    lines.append("g, role:manager, role:officer")
+    lines.append("g, role:accountant, role:officer")
+    lines.append("g, role:admin, role:manager")
+    lines.append("g, role:admin, role:accountant")  # ← admin inherits accountant deny
+
+    policy_text = "\n".join(lines) + "\n"
+    tmp = NamedTemporaryFile(
+        mode="w", suffix=".csv", delete=False, encoding="utf-8"
+    )
+    tmp.write(policy_text)
+    tmp.close()
+
+    enforcer = casbin.Enforcer(str(AUTH_MODEL_PATH), tmp.name)
+
+    # Admin Casbin enforce → DENIED via diamond inheritance
+    result = enforcer.enforce(
+        "role:admin",
+        "/api/v2/admissions/123/admin-rollback",
+        "POST",
+    )
+    assert result is False, (
+        "Admin Casbin enforce on admin-rollback should be DENIED (diamond "
+        "inherits accountant explicit deny). If True, em conflated layers — "
+        "admin allow rule may have been accidentally added. T17 admin-rollback "
+        "MUST use require_admin FastAPI dep, NOT CasbinAuth."
     )

--- a/Backend_FastAPI/tests/unit/test_check_notification_event_coverage_deferred.py
+++ b/Backend_FastAPI/tests/unit/test_check_notification_event_coverage_deferred.py
@@ -67,12 +67,10 @@ def test_deferred_set_canonical_source_is_state_service() -> None:
     same set of names enumerated in
     ``state_service.DEFERRED_ADMISSION_EVENTS``. Without this, the
     coverage flag and the runtime mapping could drift silently."""
-    # Phase 3 PR-3B Sub-2 shrunk 4 → 1: T6/T8/T10 wired via
-    # LEGACY_STATUS_TO_EVENT + TRANSITION_PAIR_TO_EVENT extension; only
-    # T17 stays deferred until PR-3C ships admin-rollback router.
-    assert DEFERRED_ADMISSION_EVENTS == frozenset({
-        "ADMISSION_ROLLED_BACK",
-    })
+    # Phase 3 PR-3C Sub-3.5 shrunk 1 → 0: T17 ADMISSION_ROLLED_BACK
+    # wired via TRANSITION_PAIR_TO_EVENT (11 pair entries — one per
+    # non-final source state). ALL 12 catalog events now have a writer.
+    assert DEFERRED_ADMISSION_EVENTS == frozenset()
 
 
 def test_deferred_events_disjoint_from_mapped_events() -> None:
@@ -99,28 +97,20 @@ def _capture_stderr(callable_):
 
 
 def test_summarize_passes_when_deferred_events_match(capsys) -> None:
-    """Four allow-listed events with EXACTLY the
-    ``no-dispatch-site`` gap → verdict 0 + summary lists each
-    deferred event."""
-    statuses = [
-        _status(name) for name in DEFERRED_ADMISSION_EVENTS
-    ]
-    # Coverage script calls ``.gaps`` (a property). Each stand-in has
-    # ``in_catalog=True``, ``notification_class="user"``, ``in_seed
-    # _defaults=True``, but no dispatch sites → exactly the
-    # ``no-dispatch-site`` gap.
-    for st in statuses:
-        assert st.gaps == ["no-dispatch-site"]
+    """Phase 3 PR-3C Sub-3.5: DEFERRED_ADMISSION_EVENTS is now empty
+    (all 12 events wired). Test pivots to verify empty allow-list +
+    no statuses passes cleanly (rc=0, no "with gaps" block).
+    """
+    # PR-3C Sub-3.5: DEFERRED set is empty → no statuses to iterate.
+    # Empty `statuses` + empty `allow_deferred` → rc=0, clean output.
+    assert DEFERRED_ADMISSION_EVENTS == frozenset()
 
     rc, output = _capture_stderr(
-        lambda: coverage._summarize(statuses, allow_deferred=set(DEFERRED_ADMISSION_EVENTS))
+        lambda: coverage._summarize([], allow_deferred=set(DEFERRED_ADMISSION_EVENTS))
     )
 
     assert rc == 0
-    assert "Deferred (allow-listed)" in output
-    for name in DEFERRED_ADMISSION_EVENTS:
-        assert name in output
-    # No "with gaps:" failure block when everything is allow-listed.
+    # No "with gaps:" failure block.
     assert "event(s) with gaps:" not in output
 
 

--- a/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub1_scoring_gates.py
+++ b/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub1_scoring_gates.py
@@ -1,0 +1,228 @@
+"""Phase 3 PR-3C Sub-1 — Standalone rule helpers `_check_min_gpa` +
+`_check_graduation_year_range`.
+
+Non-tautological anchor per memory `pattern-change-impact-audit`:
+- Verify behavior across nullable matrix (criteria None + profile None +
+  both None + both set passing + both set failing)
+- Catches future regression nếu helper signature changes (vd dùng profile
+  object trực tiếp thay vì primitive params)
+
+Sub-1 scope: 2 new static helpers ADD on existing `AdmissionScoringService`.
+No change to `calculate_score()` signature (3 production callers untouched).
+Wire qua Sub-2 `evaluate_cascade()` orchestration.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.admission_scoring_service import (
+    AdmissionScoringService,
+    DisqualificationReason,
+)
+
+
+# ============================================================================
+# _check_min_gpa — rule 2 of plan v0.7 6-rule sequential
+# ============================================================================
+
+
+class TestCheckMinGpa:
+    """Anchor tests for `_check_min_gpa` Phase 3 PR-3C gate."""
+
+    def test_no_threshold_configured_skips_rule(self):
+        """criteria.min_gpa is None → rule SKIPS regardless of profile state.
+        Matches `calculate_score()` precedent — None threshold = no-op.
+        """
+        passed, reason = AdmissionScoringService._check_min_gpa(
+            profile_gpa_overall=Decimal("7.5"),
+            criteria_min_gpa=None,
+        )
+        assert passed is True
+        assert reason is None
+
+    def test_no_threshold_no_gpa_skips_rule(self):
+        """Both None → still skip (consistent with no-threshold semantic)."""
+        passed, reason = AdmissionScoringService._check_min_gpa(
+            profile_gpa_overall=None,
+            criteria_min_gpa=None,
+        )
+        assert passed is True
+        assert reason is None
+
+    def test_threshold_set_but_gpa_null_fails(self):
+        """criteria.min_gpa=6.0 nhưng profile.gpa_overall=NULL → fail
+        với `MISSING_GPA_OVERALL`. Candidate phải provide GPA khi rule
+        active.
+        """
+        passed, reason = AdmissionScoringService._check_min_gpa(
+            profile_gpa_overall=None,
+            criteria_min_gpa=Decimal("6.0"),
+        )
+        assert passed is False
+        assert reason == DisqualificationReason.MISSING_GPA_OVERALL.value
+        assert reason == "MISSING_GPA_OVERALL"
+
+    def test_gpa_below_threshold_fails(self):
+        """profile.gpa_overall=5.5 < criteria.min_gpa=6.0 → fail BELOW_MIN_GPA."""
+        passed, reason = AdmissionScoringService._check_min_gpa(
+            profile_gpa_overall=Decimal("5.5"),
+            criteria_min_gpa=Decimal("6.0"),
+        )
+        assert passed is False
+        assert reason == DisqualificationReason.BELOW_MIN_GPA.value
+        assert reason == "BELOW_MIN_GPA"
+
+    def test_gpa_exactly_at_threshold_passes(self):
+        """profile.gpa_overall=6.0 == criteria.min_gpa=6.0 → pass (>=
+        contract, NOT strict >). Locks Numeric(4,2) precision compare.
+        """
+        passed, reason = AdmissionScoringService._check_min_gpa(
+            profile_gpa_overall=Decimal("6.00"),
+            criteria_min_gpa=Decimal("6.0"),
+        )
+        assert passed is True
+        assert reason is None
+
+    def test_gpa_above_threshold_passes(self):
+        """Normal pass path — profile 7.5 > threshold 6.0."""
+        passed, reason = AdmissionScoringService._check_min_gpa(
+            profile_gpa_overall=Decimal("7.5"),
+            criteria_min_gpa=Decimal("6.0"),
+        )
+        assert passed is True
+        assert reason is None
+
+    def test_decimal_precision_no_float_drift(self):
+        """Verify Decimal compare avoids float precision bug.
+
+        Float compare: 0.1 + 0.2 != 0.3. Decimal compare correct.
+        Test ensures helper preserves Decimal semantic even if caller
+        passes float-like values.
+        """
+        passed, reason = AdmissionScoringService._check_min_gpa(
+            profile_gpa_overall=Decimal("6.0"),
+            criteria_min_gpa=Decimal("5.99"),
+        )
+        assert passed is True
+
+
+# ============================================================================
+# _check_graduation_year_range — rule 3 (Phase 4 active, NO-OP for 2026)
+# ============================================================================
+
+
+class TestCheckGraduationYearRange:
+    """Anchor tests for `_check_graduation_year_range` Phase 3 PR-3C gate.
+
+    Phase 1 #04 columns DEFERRED Q1/2027 → helper currently NO-OPs cho
+    mùa 2026. Tests verify Phase 4 swap semantics ready khi columns ship.
+    """
+
+    def test_no_range_configured_skips_rule(self):
+        """Both criteria range args None → skip (Phase 4 not wired).
+        Mùa 2026 production behavior — `criteria.min/max_graduation_year`
+        columns đã DEFERRED Q1/2027 per Q9 chốt 2026-05-01.
+        """
+        passed, reason = AdmissionScoringService._check_graduation_year_range(
+            profile_graduation_year=2024,
+            criteria_min_graduation_year=None,
+            criteria_max_graduation_year=None,
+        )
+        assert passed is True
+        assert reason is None
+
+    def test_no_range_no_grad_year_skips_rule(self):
+        """All None → still skip (consistent semantic)."""
+        passed, reason = AdmissionScoringService._check_graduation_year_range(
+            profile_graduation_year=None,
+        )
+        assert passed is True
+        assert reason is None
+
+    def test_range_set_but_grad_year_null_fails(self):
+        """Phase 4 ship range cols + caller passes them → profile.grad_year=NULL
+        → fail GRADUATION_YEAR_OUT_OF_RANGE.
+        """
+        passed, reason = AdmissionScoringService._check_graduation_year_range(
+            profile_graduation_year=None,
+            criteria_min_graduation_year=2023,
+            criteria_max_graduation_year=2026,
+        )
+        assert passed is False
+        assert reason == DisqualificationReason.GRADUATION_YEAR_OUT_OF_RANGE.value
+
+    def test_grad_year_below_min_fails(self):
+        """profile.graduation_year=2022 < criteria.min=2023 → fail."""
+        passed, reason = AdmissionScoringService._check_graduation_year_range(
+            profile_graduation_year=2022,
+            criteria_min_graduation_year=2023,
+            criteria_max_graduation_year=2026,
+        )
+        assert passed is False
+        assert reason == DisqualificationReason.GRADUATION_YEAR_OUT_OF_RANGE.value
+
+    def test_grad_year_above_max_fails(self):
+        """profile.graduation_year=2027 > criteria.max=2026 → fail."""
+        passed, reason = AdmissionScoringService._check_graduation_year_range(
+            profile_graduation_year=2027,
+            criteria_min_graduation_year=2023,
+            criteria_max_graduation_year=2026,
+        )
+        assert passed is False
+        assert reason == DisqualificationReason.GRADUATION_YEAR_OUT_OF_RANGE.value
+
+    def test_grad_year_at_min_passes(self):
+        """profile.graduation_year=2023 == criteria.min=2023 → pass (>=)."""
+        passed, reason = AdmissionScoringService._check_graduation_year_range(
+            profile_graduation_year=2023,
+            criteria_min_graduation_year=2023,
+            criteria_max_graduation_year=2026,
+        )
+        assert passed is True
+
+    def test_grad_year_at_max_passes(self):
+        """profile.graduation_year=2026 == criteria.max=2026 → pass (<=)."""
+        passed, reason = AdmissionScoringService._check_graduation_year_range(
+            profile_graduation_year=2026,
+            criteria_min_graduation_year=2023,
+            criteria_max_graduation_year=2026,
+        )
+        assert passed is True
+
+    def test_min_only_no_max(self):
+        """criteria.min set but criteria.max None — half-open range."""
+        passed, reason = AdmissionScoringService._check_graduation_year_range(
+            profile_graduation_year=2050,
+            criteria_min_graduation_year=2023,
+            criteria_max_graduation_year=None,
+        )
+        assert passed is True  # No upper bound
+
+    def test_max_only_no_min(self):
+        """criteria.max set but criteria.min None — half-open range."""
+        passed, reason = AdmissionScoringService._check_graduation_year_range(
+            profile_graduation_year=1990,
+            criteria_min_graduation_year=None,
+            criteria_max_graduation_year=2026,
+        )
+        assert passed is True  # No lower bound
+
+
+# ============================================================================
+# DisqualificationReason enum lock — anchor cho 2 NEW codes
+# ============================================================================
+
+
+def test_phase3_disqualification_reasons_locked():
+    """Sub-1 ADD 2 codes to DisqualificationReason enum. Lock prevents
+    accidental rename/removal per memory `pattern-change-impact-audit`.
+    """
+    assert DisqualificationReason.MISSING_GPA_OVERALL.value == "MISSING_GPA_OVERALL"
+    assert (
+        DisqualificationReason.GRADUATION_YEAR_OUT_OF_RANGE.value
+        == "GRADUATION_YEAR_OUT_OF_RANGE"
+    )
+    # Total 8 reasons (6 existing + 2 NEW)
+    assert len(list(DisqualificationReason)) == 8

--- a/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub2_choice_engine.py
+++ b/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub2_choice_engine.py
@@ -1,0 +1,394 @@
+"""Phase 3 PR-3C Sub-2 — Choice-engine cascade tests.
+
+Anchor tests for `evaluate_cascade()` + `resolve_effective_bonus_rule()`.
+Non-tautological per memory `pattern-change-impact-audit`:
+- T10 source-aware-style anchor: verify cascade-stop semantic (first admit
+  → mark remaining as 'skip', NOT 'rejected' or 'pending')
+- Q-P3-11 anchor: bonus_rule_snapshot written from effective resolution
+  chain (override wins over default)
+
+Follows test_phase3_pr3b_state_machine.py pattern — SimpleNamespace +
+MagicMock + AsyncMock for state_service/dispatch.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.admission_choice_engine_service import (
+    CascadeResult,
+    evaluate_cascade,
+    resolve_effective_bonus_rule,
+    _evaluate_single_choice,
+)
+
+
+# ============================================================================
+# Fixture helpers
+# ============================================================================
+
+
+def _make_path(
+    *,
+    bonus_rule_override=None,
+    method_default_bonus_rule=None,
+    min_gpa=None,
+    allowed_subject_codes=("MATH", "PHYS", "CHEM"),
+    criteria_code="STD",
+):
+    """Build AdmissionPath stand-in với criteria + method + subject_group."""
+    method = SimpleNamespace(
+        id=1,
+        code="THPTQG",
+        default_bonus_rule=method_default_bonus_rule,
+    )
+    criteria = SimpleNamespace(
+        id=1,
+        code=criteria_code,
+        min_gpa=Decimal(str(min_gpa)) if min_gpa is not None else None,
+        min_score=None,
+        min_subject_score=None,
+        subject_selection_mode="fixed",
+        scoring_method="sum",
+        required_subject_count=3,
+    )
+    subjects = [SimpleNamespace(code=c, name_vi=c) for c in allowed_subject_codes]
+    subject_group = SimpleNamespace(id=1, name="A00", subjects=subjects)
+    config = SimpleNamespace(
+        id=1,
+        admission_path_id=1,
+        subject_group=subject_group,
+    )
+    path = SimpleNamespace(
+        id=1,
+        admission_method=method,
+        criteria=criteria,
+        bonus_rule_override=bonus_rule_override,
+        path_subject_group_config=config,
+    )
+    return path, config
+
+
+def _make_choice(
+    *,
+    choice_id: int,
+    display_order: int,
+    path,
+    config,
+    scores_dict=None,
+):
+    """Build AdmissionProfileChoice stand-in với eager-loaded relations + scores."""
+    scores_dict = scores_dict or {}
+    score_rows = []
+    for code, value in scores_dict.items():
+        subject = SimpleNamespace(code=code, name_vi=code)
+        score_rows.append(SimpleNamespace(
+            subject=subject,
+            score=Decimal(str(value)),
+            max_score_snapshot=Decimal("10.0"),
+            weight_snapshot=Decimal("1.0"),
+        ))
+    return SimpleNamespace(
+        id=choice_id,
+        display_order=display_order,
+        admission_path=path,
+        path_subject_group_config=config,
+        scores=score_rows,
+        decision="pending",
+        bonus_rule_snapshot=None,
+        eligibility_check_result=None,
+    )
+
+
+def _make_profile(*, status="reviewing", gpa=None, choices=None):
+    """Build AdmissionProfile stand-in."""
+    return SimpleNamespace(
+        id=42,
+        lead_id=99,
+        status=status,
+        version=1,
+        updated_at=None,
+        gpa_overall=Decimal(str(gpa)) if gpa is not None else None,
+        graduation_year=2024,
+        uses_choice_engine=True,
+        choices=choices or [],
+    )
+
+
+@pytest.fixture
+def db_session():
+    s = MagicMock(name="AsyncSession")
+    s.flush = AsyncMock()
+    return s
+
+
+@pytest.fixture
+def patched_state_and_dispatch():
+    """Patch state_service.transition + dispatch_event."""
+    with patch(
+        "app.services.admission_state_service.transition",
+        new=AsyncMock(return_value=(SimpleNamespace(), None)),
+    ) as transition_mock, patch(
+        "app.services.notification_dispatcher.dispatch_event",
+        new=AsyncMock(return_value=([], None)),
+    ) as dispatch_mock:
+        yield transition_mock, dispatch_mock
+
+
+# ============================================================================
+# resolve_effective_bonus_rule — 3 cases
+# ============================================================================
+
+
+class TestResolveEffectiveBonusRule:
+    def test_override_wins_over_method_default(self):
+        """Q-P3-11 resolution chain: path.override takes precedence."""
+        path, _ = _make_path(
+            bonus_rule_override={"version": 2, "rule": "override"},
+            method_default_bonus_rule={"version": 1, "rule": "default"},
+        )
+        result = resolve_effective_bonus_rule(path)
+        assert result == {"version": 2, "rule": "override"}
+
+    def test_fallback_to_method_default_when_override_null(self):
+        """No path override → fallback to method.default_bonus_rule."""
+        path, _ = _make_path(
+            bonus_rule_override=None,
+            method_default_bonus_rule={"version": 1, "rule": "default"},
+        )
+        result = resolve_effective_bonus_rule(path)
+        assert result == {"version": 1, "rule": "default"}
+
+    def test_both_null_returns_none(self):
+        """No bonus rule configured anywhere → None (caller stores NULL)."""
+        path, _ = _make_path(
+            bonus_rule_override=None,
+            method_default_bonus_rule=None,
+        )
+        result = resolve_effective_bonus_rule(path)
+        assert result is None
+
+
+# ============================================================================
+# _evaluate_single_choice — gates + score
+# ============================================================================
+
+
+class TestEvaluateSingleChoice:
+    def test_min_gpa_gate_fail_returns_rejected(self):
+        """Profile GPA < criteria threshold → reject without scoring."""
+        path, config = _make_path(min_gpa=7.0)
+        choice = _make_choice(
+            choice_id=1, display_order=1, path=path, config=config,
+            scores_dict={"MATH": 9.0, "PHYS": 8.0, "CHEM": 8.5},
+        )
+        profile = _make_profile(gpa=5.5)
+        decision, score, reasons = _evaluate_single_choice(profile, choice)
+        assert decision == "rejected"
+        assert score is None  # Gate fail before scoring
+        assert "BELOW_MIN_GPA" in reasons
+
+    def test_passing_choice_returns_admitted(self):
+        """All gates + scoring pass → admitted."""
+        path, config = _make_path(min_gpa=6.0)
+        choice = _make_choice(
+            choice_id=1, display_order=1, path=path, config=config,
+            scores_dict={"MATH": 9.0, "PHYS": 8.0, "CHEM": 8.5},
+        )
+        profile = _make_profile(gpa=7.5)
+        decision, score, reasons = _evaluate_single_choice(profile, choice)
+        assert decision == "admitted"
+        assert score is not None
+        assert score.passed is True
+
+    def test_missing_scores_returns_rejected(self):
+        """Empty scores → no_valid_scores reject."""
+        path, config = _make_path(min_gpa=6.0)
+        choice = _make_choice(
+            choice_id=1, display_order=1, path=path, config=config,
+            scores_dict={},
+        )
+        profile = _make_profile(gpa=7.5)
+        decision, _, reasons = _evaluate_single_choice(profile, choice)
+        assert decision == "rejected"
+        assert "NO_VALID_SCORES" in reasons
+
+
+# ============================================================================
+# evaluate_cascade — orchestration (anchor cascade-stop + snapshot)
+# ============================================================================
+
+
+class TestEvaluateCascade:
+    @pytest.mark.asyncio
+    async def test_first_admit_skips_remaining_choices(
+        self, db_session, patched_state_and_dispatch,
+    ):
+        """⭐ Cascade-stop anchor: first admit → remaining marked 'skip'.
+        Non-tautological — wrong semantic would mark them 'rejected' or
+        leave 'pending'.
+        """
+        path, config = _make_path(min_gpa=6.0)
+        nv1 = _make_choice(
+            choice_id=1, display_order=1, path=path, config=config,
+            scores_dict={"MATH": 9.0, "PHYS": 8.0, "CHEM": 8.5},
+        )
+        nv2 = _make_choice(
+            choice_id=2, display_order=2, path=path, config=config,
+            scores_dict={"MATH": 9.5, "PHYS": 8.5, "CHEM": 9.0},
+        )
+        nv3 = _make_choice(
+            choice_id=3, display_order=3, path=path, config=config,
+            scores_dict={"MATH": 10.0, "PHYS": 9.5, "CHEM": 9.5},
+        )
+        profile = _make_profile(gpa=7.5, choices=[nv1, nv2, nv3])
+
+        result, _ = await evaluate_cascade(db_session, profile)
+
+        assert nv1.decision == "admitted"
+        assert nv2.decision == "skip", (
+            "After first admit, remaining choices MUST be 'skip', NOT "
+            f"'{nv2.decision}'. Cascade-stop semantic broken."
+        )
+        assert nv3.decision == "skip"
+        assert result.final_status == "admitted"
+        assert result.admitted_choice_id == 1
+        assert result.admitted_display_order == 1
+
+    @pytest.mark.asyncio
+    async def test_all_reject_results_in_rejected(
+        self, db_session, patched_state_and_dispatch,
+    ):
+        """All gates fail → all rejected + profile final 'rejected'."""
+        path, config = _make_path(min_gpa=9.5)  # Very high threshold
+        nv1 = _make_choice(
+            choice_id=1, display_order=1, path=path, config=config,
+            scores_dict={"MATH": 9.0, "PHYS": 8.0, "CHEM": 8.5},
+        )
+        nv2 = _make_choice(
+            choice_id=2, display_order=2, path=path, config=config,
+            scores_dict={"MATH": 9.5, "PHYS": 8.5, "CHEM": 9.0},
+        )
+        profile = _make_profile(gpa=7.5, choices=[nv1, nv2])
+
+        result, _ = await evaluate_cascade(db_session, profile)
+
+        assert nv1.decision == "rejected"
+        assert nv2.decision == "rejected"
+        assert result.final_status == "rejected"
+        assert result.admitted_choice_id is None
+
+    @pytest.mark.asyncio
+    async def test_bonus_rule_snapshot_written_per_choice(
+        self, db_session, patched_state_and_dispatch,
+    ):
+        """⭐ Q-P3-11 anchor: bonus_rule_snapshot captured tại T6 publish.
+        Override wins over method default per resolution chain.
+        """
+        path1, config1 = _make_path(
+            bonus_rule_override={"version": 2, "rule": "override"},
+            method_default_bonus_rule={"version": 1, "rule": "default"},
+            min_gpa=6.0,
+        )
+        path2, config2 = _make_path(
+            bonus_rule_override=None,
+            method_default_bonus_rule={"version": 1, "rule": "default"},
+            min_gpa=6.0,
+        )
+        nv1 = _make_choice(
+            choice_id=1, display_order=1, path=path1, config=config1,
+            scores_dict={"MATH": 9.0, "PHYS": 8.0, "CHEM": 8.5},
+        )
+        nv2 = _make_choice(
+            choice_id=2, display_order=2, path=path2, config=config2,
+            scores_dict={"MATH": 9.5, "PHYS": 8.5, "CHEM": 9.0},
+        )
+        profile = _make_profile(gpa=7.5, choices=[nv1, nv2])
+
+        await evaluate_cascade(db_session, profile)
+
+        # NV1: override wins
+        assert nv1.bonus_rule_snapshot == {"version": 2, "rule": "override"}
+        # NV2: skip (NV1 admitted) — bonus_rule_snapshot still written for NV2?
+        # Per implementation: snapshot is written BEFORE evaluation per choice.
+        # NV2 marked 'skip' BEFORE reaching snapshot step → stays None.
+        # This is correct per design — skipped choices don't need historical snapshot.
+        assert nv2.bonus_rule_snapshot is None
+        assert nv2.decision == "skip"
+
+    @pytest.mark.asyncio
+    async def test_eligibility_check_result_recorded(
+        self, db_session, patched_state_and_dispatch,
+    ):
+        """Audit trail anchor: eligibility_check_result JSONB written với
+        decision + reason_codes + score summary."""
+        path, config = _make_path(min_gpa=9.0)
+        nv1 = _make_choice(
+            choice_id=1, display_order=1, path=path, config=config,
+            scores_dict={"MATH": 9.0, "PHYS": 8.0, "CHEM": 8.5},
+        )
+        profile = _make_profile(gpa=5.0, choices=[nv1])  # GPA fail
+
+        await evaluate_cascade(db_session, profile)
+
+        assert nv1.eligibility_check_result is not None
+        assert nv1.eligibility_check_result["decision"] == "rejected"
+        assert "BELOW_MIN_GPA" in nv1.eligibility_check_result["reason_codes"]
+        assert nv1.eligibility_check_result["score"] is None  # Gate fail no scoring
+
+    @pytest.mark.asyncio
+    async def test_state_transition_calls_chain(
+        self, db_session, patched_state_and_dispatch,
+    ):
+        """State transition pattern: reviewing → result_published → final
+        (state machine forbids reviewing → admitted direct per PR-3B map).
+        """
+        transition_mock, _ = patched_state_and_dispatch
+        path, config = _make_path(min_gpa=6.0)
+        nv1 = _make_choice(
+            choice_id=1, display_order=1, path=path, config=config,
+            scores_dict={"MATH": 9.0, "PHYS": 8.0, "CHEM": 8.5},
+        )
+        profile = _make_profile(gpa=7.5, choices=[nv1])
+
+        await evaluate_cascade(db_session, profile)
+
+        # 2 transition calls: → result_published, then → admitted
+        assert transition_mock.await_count == 2
+        first_call_status = transition_mock.await_args_list[0].args[2]
+        second_call_status = transition_mock.await_args_list[1].args[2]
+        assert first_call_status == "result_published"
+        assert second_call_status == "admitted"
+
+
+# ============================================================================
+# Cascade-stop count anchor
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_cascade_per_choice_decisions_records_all(
+    db_session, patched_state_and_dispatch,
+):
+    """CascadeResult.per_choice_decisions records EVERY choice (including
+    skipped ones). Caller (audit) needs full trace per cascade run.
+    """
+    path, config = _make_path(min_gpa=6.0)
+    choices = [
+        _make_choice(
+            choice_id=i, display_order=i, path=path, config=config,
+            scores_dict={"MATH": 9.0, "PHYS": 8.0, "CHEM": 8.5},
+        )
+        for i in range(1, 4)
+    ]
+    profile = _make_profile(gpa=7.5, choices=choices)
+
+    result, _ = await evaluate_cascade(db_session, profile)
+
+    assert len(result.per_choice_decisions) == 3
+    assert result.per_choice_decisions[0]["decision"] == "admitted"
+    assert result.per_choice_decisions[1]["decision"] == "skip"
+    assert result.per_choice_decisions[2]["decision"] == "skip"

--- a/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub2b_router_helpers.py
+++ b/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub2b_router_helpers.py
@@ -1,0 +1,305 @@
+"""Phase 3 PR-3C Sub-3.2 — Router-facing service helpers.
+
+Anchor tests cho 3 thin wrappers trong `admission_choice_engine_service`:
+- `publish_result(db, profile)` — T6 entry point + pre-checks
+- `promote_waitlisted_choice(db, choice, profile, actor)` — T10
+- `admin_rollback_profile(db, profile, reason, actor)` — T17
+
+Non-tautological per memory `pattern-change-impact-audit`:
+- Pre-check tests assert SPECIFIC BusinessRuleViolation message hints
+- T17 anchor verifies pair-lookup fires ROLLED_BACK (not generic event)
+- T10 anchor verifies WAITLIST_PROMOTED event (not generic ADMITTED)
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.admission_choice_engine_service import (
+    admin_rollback_profile,
+    promote_waitlisted_choice,
+    publish_result,
+)
+from app.utils.exceptions import BusinessRuleViolation
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+def _make_profile(*, status="reviewing", uses_choice_engine=True, choices=None):
+    return SimpleNamespace(
+        id=42,
+        lead_id=99,
+        status=status,
+        version=1,
+        updated_at=None,
+        uses_choice_engine=uses_choice_engine,
+        gpa_overall=Decimal("7.5"),
+        graduation_year=2024,
+        choices=choices or [],
+    )
+
+
+def _make_actor(user_id=7):
+    return SimpleNamespace(id=user_id, full_name="Test Admin", username="admin")
+
+
+def _make_choice(decision="waitlisted", profile_id=42):
+    return SimpleNamespace(
+        id=5,
+        admission_profile_id=profile_id,
+        display_order=2,
+        decision=decision,
+        bonus_rule_snapshot=None,
+        eligibility_check_result=None,
+    )
+
+
+@pytest.fixture
+def db_session():
+    s = MagicMock(name="AsyncSession")
+    s.flush = AsyncMock()
+    return s
+
+
+@pytest.fixture
+def patched_evaluate_cascade():
+    """Patch evaluate_cascade so publish_result tests don't exercise full loop."""
+    fake_result = SimpleNamespace(
+        profile_id=42,
+        final_status="admitted",
+        admitted_choice_id=1,
+        admitted_display_order=1,
+        per_choice_decisions=[],
+    )
+    with patch(
+        "app.services.admission_choice_engine_service.evaluate_cascade",
+        new=AsyncMock(return_value=(fake_result, None)),
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def patched_state_transition():
+    """Patch state_service.transition globally to avoid touching real DB."""
+    with patch(
+        "app.services.admission_state_service.transition",
+        new=AsyncMock(return_value=(SimpleNamespace(), None)),
+    ) as mock:
+        yield mock
+
+
+# ============================================================================
+# publish_result — T6 entry point
+# ============================================================================
+
+
+class TestPublishResult:
+    @pytest.mark.asyncio
+    async def test_uses_choice_engine_false_blocked(
+        self, db_session, patched_evaluate_cascade,
+    ):
+        """Pre-check 1: profile.uses_choice_engine=False → reject before cascade."""
+        profile = _make_profile(uses_choice_engine=False, status="reviewing")
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await publish_result(db_session, profile)
+        assert "choice engine" in str(exc.value).lower()
+        patched_evaluate_cascade.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_wrong_status_blocked(
+        self, db_session, patched_evaluate_cascade,
+    ):
+        """Pre-check 2: profile.status != 'reviewing' → reject."""
+        profile = _make_profile(status="draft", uses_choice_engine=True)
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await publish_result(db_session, profile)
+        assert "reviewing" in str(exc.value).lower()
+        patched_evaluate_cascade.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_calls_cascade(
+        self, db_session, patched_evaluate_cascade,
+    ):
+        """Pre-checks pass → evaluate_cascade called with profile."""
+        profile = _make_profile(status="reviewing", uses_choice_engine=True)
+        result, callback = await publish_result(db_session, profile)
+        patched_evaluate_cascade.assert_awaited_once_with(db_session, profile)
+        assert result.profile_id == 42
+
+
+# ============================================================================
+# promote_waitlisted_choice — T10
+# ============================================================================
+
+
+class TestPromoteWaitlistedChoice:
+    @pytest.mark.asyncio
+    async def test_choice_not_waitlisted_blocked(
+        self, db_session, patched_state_transition,
+    ):
+        """Pre-check 1: choice.decision != 'waitlisted' → reject."""
+        choice = _make_choice(decision="admitted")
+        profile = _make_profile(status="waitlisted")
+        actor = _make_actor()
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await promote_waitlisted_choice(db_session, choice, profile, actor)
+        assert "waitlisted" in str(exc.value).lower()
+        patched_state_transition.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_profile_not_waitlisted_blocked(
+        self, db_session, patched_state_transition,
+    ):
+        """Pre-check 2: profile.status != 'waitlisted' → reject."""
+        choice = _make_choice(decision="waitlisted")
+        profile = _make_profile(status="admitted")  # Wrong state
+        actor = _make_actor()
+        with pytest.raises(BusinessRuleViolation):
+            await promote_waitlisted_choice(db_session, choice, profile, actor)
+        patched_state_transition.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_calls_transition_with_pair_aware_metadata(
+        self, db_session, patched_state_transition,
+    ):
+        """⭐ T10 anchor: transition() called với new_status='admitted' +
+        actor source='waitlist_promote'. State service PAIR-first lookup
+        fires WAITLIST_PROMOTED (verified Sub-2 anchor test elsewhere).
+        Here we verify wrapper passes correct args downstream.
+        """
+        choice = _make_choice(decision="waitlisted")
+        profile = _make_profile(status="waitlisted")
+        actor = _make_actor()
+
+        result, callback = await promote_waitlisted_choice(
+            db_session, choice, profile, actor,
+        )
+
+        assert choice.decision == "admitted"  # Choice updated FIRST
+        assert result["profile_id"] == 42
+        assert result["choice_id"] == 5
+        assert result["decision"] == "admitted"
+        assert result["profile_status"] == "admitted"
+
+        # Verify transition() args reflect source-aware promote intent
+        patched_state_transition.assert_awaited_once()
+        call_args = patched_state_transition.await_args
+        assert call_args.args[2] == "admitted"  # new_status arg
+        assert call_args.kwargs["source"] == "waitlist_promote"
+        assert call_args.kwargs["event_metadata"]["promoted_from_waitlist"] is True
+
+
+# ============================================================================
+# admin_rollback_profile — T17
+# ============================================================================
+
+
+class TestAdminRollbackProfile:
+    @pytest.mark.asyncio
+    async def test_enrolled_final_state_blocked(
+        self, db_session, patched_state_transition,
+    ):
+        """Terminal state ENROLLED không thể rollback."""
+        profile = _make_profile(status="enrolled")
+        actor = _make_actor()
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await admin_rollback_profile(
+                db_session, profile, "Valid 10+ char reason", actor,
+            )
+        assert "enrolled" in str(exc.value).lower() or "cuối" in str(exc.value).lower()
+        patched_state_transition.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_withdrawn_final_state_blocked(
+        self, db_session, patched_state_transition,
+    ):
+        """Terminal state WITHDRAWN không thể rollback."""
+        profile = _make_profile(status="withdrawn")
+        actor = _make_actor()
+        with pytest.raises(BusinessRuleViolation):
+            await admin_rollback_profile(
+                db_session, profile, "Valid 10+ char reason", actor,
+            )
+        patched_state_transition.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_short_reason_blocked(
+        self, db_session, patched_state_transition,
+    ):
+        """Reason < 10 chars → reject (defensive double-check; schema also enforces)."""
+        profile = _make_profile(status="admitted")
+        actor = _make_actor()
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await admin_rollback_profile(db_session, profile, "short", actor)
+        assert "10" in str(exc.value) or "lý do" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_reason_blocked(
+        self, db_session, patched_state_transition,
+    ):
+        """Empty reason → reject."""
+        profile = _make_profile(status="admitted")
+        actor = _make_actor()
+        with pytest.raises(BusinessRuleViolation):
+            await admin_rollback_profile(db_session, profile, "", actor)
+
+    @pytest.mark.asyncio
+    async def test_happy_path_captures_rolled_back_from(
+        self, db_session, patched_state_transition,
+    ):
+        """⭐ T17 anchor: response captures pre-rollback status, transition()
+        called với new_status='draft' + source='admin_rollback' + reason.
+        PAIR map fires ADMISSION_ROLLED_BACK (verified Sub-3.5 anchor).
+        """
+        profile = _make_profile(status="admitted")
+        actor = _make_actor()
+        reason = "Hồ sơ admit nhầm, candidate withdraw qua CCCD verify"
+
+        result, callback = await admin_rollback_profile(
+            db_session, profile, reason, actor,
+        )
+
+        assert result["profile_id"] == 42
+        assert result["status"] == "draft"
+        assert result["rolled_back_from"] == "admitted"
+
+        patched_state_transition.assert_awaited_once()
+        call_args = patched_state_transition.await_args
+        assert call_args.args[2] == "draft"  # new_status
+        assert call_args.kwargs["reason"] == reason
+        assert call_args.kwargs["source"] == "admin_rollback"
+        assert call_args.kwargs["event_metadata"]["rolled_back_from"] == "admitted"
+
+    @pytest.mark.asyncio
+    async def test_rollback_from_each_non_final_source_state(
+        self, db_session, patched_state_transition,
+    ):
+        """T17 parametrized anchor: each of 11 non-final source states
+        passes pre-checks. Verifies wrapper KHÔNG hardcode source state.
+        State machine ALLOWED_TRANSITIONS extension handles edges.
+        """
+        non_final_sources = [
+            "submitted", "reviewing", "revision_requested", "resubmitted",
+            "result_published", "admitted", "waitlisted", "rejected",
+            "approved", "overridden", "confirmed",
+        ]
+        actor = _make_actor()
+
+        for source_state in non_final_sources:
+            patched_state_transition.reset_mock()
+            profile = _make_profile(status=source_state)
+            result, _ = await admin_rollback_profile(
+                db_session, profile,
+                "Valid rollback reason for parametric test",
+                actor,
+            )
+            assert result["rolled_back_from"] == source_state, (
+                f"Failed source state: {source_state}"
+            )
+            assert patched_state_transition.await_count == 1

--- a/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub3_router_registration.py
+++ b/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub3_router_registration.py
@@ -1,0 +1,262 @@
+"""Phase 3 PR-3C Sub-3.6 — Router registration + schema validation anchors.
+
+12 anchor tests covering 3 Phase 3 routers shipped Sub-3.3/3.4/3.5b:
+- T6 POST /api/v2/admissions/{id}/publish-result
+- T10 POST /api/v2/admissions/{id}/waitlist-promote
+- T17 POST /api/v2/admissions/{id}/admin-rollback
+
+Test strategy: lightweight inspection-based (NO real DB, NO TestClient).
+- Route registration verified via `router.routes` introspection
+- Dependency wiring verified via FastAPI `Depends` signature
+- Schema validation tested via Pydantic instantiation (no HTTP req)
+
+Rationale: Sub-3.2 helper tests (12 cases) already cover service-level
+branches. Sub-3.6 only locks: route URL pattern + dep type + schema
+boundaries. Full integration matrix deferred to test-debt PR
+(matches PR-3B precedent: anchor unit tests + deferred E2E suite).
+
+Non-tautological per memory `pattern-change-impact-audit`: each test
+asserts SPECIFIC attribute/dep type, not just "exists".
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+from fastapi import params as fastapi_params
+from pydantic import ValidationError
+
+from app.core.deps import require_admin, get_admission_for_manager
+from app.routers.admissions_v2 import router as v2_router
+from app.schemas.admission import (
+    AdmissionAdminRollbackRequest,
+    AdmissionPublishResultResponse,
+    AdmissionWaitlistPromoteRequest,
+)
+
+
+# ============================================================================
+# Helpers — extract route by path suffix
+# ============================================================================
+
+
+def _get_route(path_suffix: str):
+    """Find route by suffix (handles regex part of path)."""
+    for r in v2_router.routes:
+        if path_suffix in r.path:
+            return r
+    raise AssertionError(
+        f"Route with suffix '{path_suffix}' not found in admissions_v2 router"
+    )
+
+
+# ============================================================================
+# A. Route registration + BONUS-35 keyMatch4 regex (4 tests)
+# ============================================================================
+
+
+def test_publish_result_route_registered_with_regex():
+    """Sub-3.3 T6 route registered. FastAPI uses type annotation
+    `profile_id: int` for non-numeric rejection (NOT path regex syntax
+    `{var:[0-9]+}` — that's Starlette convertor + NOT honored by default).
+    """
+    route = _get_route("publish-result")
+    assert "POST" in route.methods
+    assert "{profile_id}" in route.path
+    # Full path mirrors Casbin policy `/api/v2/admissions/*/publish-result`
+    assert route.path == "/api/v2/admissions/{profile_id}/publish-result"
+
+
+def test_waitlist_promote_route_registered_with_regex():
+    """Sub-3.4 T10 route registered (DRIFT-01 sync — profile-scoped per
+    Casbin canonical, NOT choice-scoped admin namespace per stale Plan v0.7).
+    """
+    route = _get_route("waitlist-promote")
+    assert "POST" in route.methods
+    assert "{profile_id}" in route.path
+    assert route.path == "/api/v2/admissions/{profile_id}/waitlist-promote"
+
+
+def test_admin_rollback_route_registered_with_regex():
+    """Sub-3.5b T17 route registered với regex constraint."""
+    route = _get_route("admin-rollback")
+    assert "POST" in route.methods
+    assert "{profile_id}" in route.path
+    assert route.path == "/api/v2/admissions/{profile_id}/admin-rollback"
+
+
+def test_bonus35_int_type_annotation_enforces_numeric():
+    """⭐ BONUS-35 anchor revised: FastAPI uses `profile_id: int` type
+    annotation in endpoint signature → non-numeric rejected via Pydantic
+    422 at request validation layer (NOT Starlette path regex).
+
+    Memory `lead-keymatch4-collision-followup` BONUS-35 was about CASBIN
+    keyMatch4 pattern, NOT FastAPI path regex. Path regex syntax
+    `{var:[0-9]+}` is Starlette convertor — NOT honored by default;
+    became literal text → all 3 routes BROKEN initially. Em ack miss.
+
+    This test verifies type annotation present + path matches numeric:
+    route.path_regex matches `/api/v2/admissions/123/...` ✓
+    Non-numeric rejected at Pydantic type coercion layer (422), tested
+    via TestClient in test-debt PR (deferred).
+    """
+    route = _get_route("publish-result")
+    # Real request with numeric profile_id MUST match the route
+    assert route.path_regex.match("/api/v2/admissions/123/publish-result") is not None
+    # Verify endpoint signature has `profile_id: int` (catches type drift).
+    # `from __future__ import annotations` may stringify — accept both
+    # int class and "int" string repr.
+    import inspect
+    sig = inspect.signature(route.endpoint)
+    annotation = sig.parameters["profile_id"].annotation
+    assert annotation is int or annotation == "int", (
+        f"publish-result endpoint MUST annotate profile_id as int "
+        f"(got {annotation!r}). FastAPI route regex doesn't filter "
+        f"non-numeric — type annotation enforces via Pydantic 422."
+    )
+
+
+# ============================================================================
+# B. Dependency wiring (4 tests)
+# ============================================================================
+
+
+def _get_dependants(route):
+    """Walk endpoint dependant tree, return list of dependency call types."""
+    deps = []
+    deps.extend(route.dependant.dependencies)
+    return deps
+
+
+def test_publish_result_uses_get_admission_for_manager():
+    """Sub-3.3 endpoint MUST use `get_admission_for_manager` IDOR gate
+    (3-tier scope admin/manager). Catches regression nếu IDOR gate
+    swapped or removed.
+    """
+    route = _get_route("publish-result")
+    dep_calls = [d.call for d in _get_dependants(route)]
+    assert get_admission_for_manager in dep_calls, (
+        "publish-result must depend on get_admission_for_manager IDOR gate"
+    )
+
+
+def test_waitlist_promote_uses_get_admission_for_manager():
+    """Sub-3.4 endpoint MUST use `get_admission_for_manager` (profile-scoped
+    per DRIFT-01 sync — Casbin canonical).
+    """
+    route = _get_route("waitlist-promote")
+    dep_calls = [d.call for d in _get_dependants(route)]
+    assert get_admission_for_manager in dep_calls
+
+
+def test_admin_rollback_uses_require_admin():
+    """⭐ Sub-3.5b endpoint MUST use `require_admin` (NOT CasbinAuth) —
+    admin-only direct gate. Catches regression nếu gate swapped to
+    CasbinAuth (which would allow manager via inheritance).
+
+    Note: require_admin returns Depends + dep; check via signature
+    inspection.
+    """
+    route = _get_route("admin-rollback")
+    dep_calls = [d.call for d in _get_dependants(route)]
+    assert require_admin in dep_calls, (
+        "admin-rollback MUST use require_admin dep, NOT CasbinAuth — "
+        "T17 is admin-only per memory `lead-active-user-casbin-pr4` diamond pattern"
+    )
+    # Anti-pattern guard: get_admission_for_manager NOT in deps (admin global scope)
+    assert get_admission_for_manager not in dep_calls, (
+        "admin-rollback should NOT use IDOR gate (admin global scope)"
+    )
+
+
+def test_publish_result_does_not_use_require_admin():
+    """Inverse anchor — publish-result is manager-allowed (NOT admin-only).
+    Catches regression nếu accidentally locked to admin.
+    """
+    route = _get_route("publish-result")
+    dep_calls = [d.call for d in _get_dependants(route)]
+    assert require_admin not in dep_calls
+
+
+# ============================================================================
+# C. Schema validation boundaries (3 tests)
+# ============================================================================
+
+
+def test_admin_rollback_reason_min_length_enforced():
+    """Sub-3.5b reason MUST reject < 10 chars (Pydantic min_length).
+
+    Defensive: also enforced trong service helper `admin_rollback_profile`
+    (Sub-3.2). Two layers because schema runs at FastAPI request boundary,
+    service runs at business logic — drift between layers would be a bug.
+    """
+    with pytest.raises(ValidationError) as exc:
+        AdmissionAdminRollbackRequest(reason="short")
+    # Pydantic v2 error structure
+    errors = exc.value.errors()
+    assert any(
+        "min_length" in err.get("type", "") or "string_too_short" in err.get("type", "")
+        for err in errors
+    )
+
+
+def test_admin_rollback_reason_max_length_enforced():
+    """Sub-3.5b reason MUST reject > 500 chars."""
+    long_reason = "x" * 501
+    with pytest.raises(ValidationError) as exc:
+        AdmissionAdminRollbackRequest(reason=long_reason)
+    errors = exc.value.errors()
+    assert any(
+        "max_length" in err.get("type", "") or "string_too_long" in err.get("type", "")
+        for err in errors
+    )
+
+
+def test_waitlist_promote_choice_id_must_be_positive():
+    """Sub-3.4 schema MUST reject choice_id <= 0 (Pydantic gt=0)."""
+    with pytest.raises(ValidationError):
+        AdmissionWaitlistPromoteRequest(choice_id=0)
+    with pytest.raises(ValidationError):
+        AdmissionWaitlistPromoteRequest(choice_id=-1)
+    # Positive int accepted
+    valid = AdmissionWaitlistPromoteRequest(choice_id=5)
+    assert valid.choice_id == 5
+    assert valid.reason is None  # Optional
+
+
+# ============================================================================
+# D. Response schema contract (1 test)
+# ============================================================================
+
+
+def test_publish_result_response_schema_locked():
+    """⭐ Sub-3.3 response schema MUST accept CascadeResult-shaped dict.
+    Anchor catches future regression if response shape changes
+    incompatibly với choice_engine.evaluate_cascade output.
+    """
+    response = AdmissionPublishResultResponse(
+        profile_id=42,
+        final_status="admitted",
+        admitted_choice_id=1,
+        admitted_display_order=1,
+        per_choice_decisions=[
+            {
+                "choice_id": 1,
+                "display_order": 1,
+                "decision": "admitted",
+                "reasons": [],
+                "score": 24.5,
+            },
+            {
+                "choice_id": 2,
+                "display_order": 2,
+                "decision": "skip",
+                "reasons": [],
+                "score": None,
+            },
+        ],
+    )
+    assert response.final_status == "admitted"
+    assert len(response.per_choice_decisions) == 2
+    assert response.per_choice_decisions[0].decision == "admitted"
+    assert response.per_choice_decisions[1].decision == "skip"


### PR DESCRIPTION
## Summary

PR-3C — Phase 3 multi-NV choice-engine cascade orchestration + 3 router endpoints (T6 publish-result / T10 waitlist-promote / T17 admin-rollback) + Casbin matrix integration. Plan v0.7 LOCKED.

Foundation cho PR-3D-A FE Wave A + PR-3D-B FE Wave B Full + PR-3E magic-link.

## Scope (9 sub-commits)

- `3472ac05` **Sub-1**: Scoring service +2 standalone rule helpers (`_check_min_gpa` + `_check_graduation_year_range` NO-OP for Phase 4) + 17 anchor tests
- `bfbe7102` **Sub-2**: NEW `admission_choice_engine_service.py` + `evaluate_cascade()` orchestration + Q-P3-11 bonus_rule_snapshot resolution chain + 12 anchor tests
- `2b2af7a9` **Sub-3.1+3.5 ATOMIC**: 4 schemas + state machine 11 `→ DRAFT` edges + TRANSITION_PAIR_TO_EVENT +11 entries + DEFERRED 1→0 + 2 CI gate workflows sync + 3 lock test parity
- `6a8779a3` **Sub-3.2**: 3 router helpers (publish_result / promote_waitlisted_choice / admin_rollback_profile) + 12 anchor tests
- `0fbbdca2` **Sub-3.3**: POST `/api/v2/admissions/{id}/publish-result` (T6) in NEW `admissions_v2.py`
- `b6253022` **Sub-3.4**: POST `/api/v2/admissions/{id}/waitlist-promote` (T10) + DRIFT-01 sync (Plan v0.7 stale → Casbin canonical)
- `072d39e1` **Sub-3.5b**: POST `/api/v2/admissions/{id}/admin-rollback` (T17 admin-only via require_admin)
- `14140b29` **Sub-3.6**: 🚨 Fix BROKEN `{profile_id:[0-9]+}` route syntax + 12 inspection anchors (FastAPI/Starlette does NOT support inline `{var:regex}`)
- `42592c3d` **C-1**: Casbin matrix extend 15 → 18 cells + diamond inheritance anchor (admin DENY proves require_admin requirement)

## State machine 14-state extension (Sub-3.5 ATOMIC)

- ALLOWED_TRANSITIONS +11 source states `→ DRAFT` (T17 admin-rollback edges); ENROLLED + WITHDRAWN stay FINAL
- TRANSITION_PAIR_TO_EVENT 12 entries: 1 T10 (WAITLIST_PROMOTED) + 11 T17 (ROLLED_BACK source-aware)
- DEFERRED_ADMISSION_EVENTS: 1 → 0 (empty frozenset). ALL 12 ADMISSION_* events wired
- 2 CI gate workflows synced atomic (deploy.yml + admission-contract-check.yml drop --allow-deferred) — memory `ci-workflow-flag-cross-file-sync` applied prophylactically

## 3 router endpoints LIVE

| Route | Auth | Service | Event |
|---|---|---|---|
| `/api/v2/admissions/{id}/publish-result` POST | get_admission_for_manager + Casbin | publish_result → evaluate_cascade | RESULT_PUBLISHED + per-choice |
| `/api/v2/admissions/{id}/waitlist-promote` POST | get_admission_for_manager + Casbin | promote_waitlisted_choice | WAITLIST_PROMOTED (PAIR) |
| `/api/v2/admissions/{id}/admin-rollback` POST | require_admin (NOT Casbin) | admin_rollback_profile | ROLLED_BACK (PAIR 11 source states) |

Routes use `{profile_id}` plain path + `profile_id: int` type annotation (Pydantic 422 cho non-numeric).

## Plan v0.7 references

- **Q-P3-11** bonus_rule_snapshot tại T6 publish — Sub-2 `resolve_effective_bonus_rule()`
- **Q-P3-05** Manual waitlist promote — Sub-3.4 T10 admin endpoint
- **G3/G4/G5** documented in helpers + lock tests
- **GAP-11/22** RBAC + N+1 prevention — eager-load chain Sub-3.3
- **DRIFT-01 NEW** (Sub-3.4) — Plan v0.7 line 437 stale T10 path vs Casbin canonical. Memory `audit-report-accuracy` applied

## Test coverage 270/270 PASS (55.07s)

12 test files covering 9 sub-commits + PR-3A/3B regression:
- Sub-1/2/3.2 service unit: 41 tests
- Sub-3.6 router registration: 12 tests
- C-1 Casbin matrix + diamond: 23 tests
- State machine + parity locks: 121 tests
- PR-3A + PR-3B regression: 73 tests

Coverage script runs WITHOUT `--allow-deferred` flag — all 12 ADMISSION_* events `ok`, 0 deferred.

## Architecture compliance

- Service KHÔNG import FastAPI ✓
- Services raise BusinessRuleViolation NOT HTTPException ✓
- Services return `(result, callback)` V3.0 contract ✓
- AST lint `check_status_assignment.py` preserved (transition() single mutation point) ✓
- Eager-load chain for async Pydantic serialization ✓
- BONUS-35 stays in Casbin layer (em ack misconception Sub-3.3/3.4/3.5b — memory `fastapi-route-regex-vs-casbin-keymatch-distinction` saved)

## Memory refs (8 lessons applied)

- `pattern-change-impact-audit` — Sub-3.6 anchor caught broken routes
- `audit-before-fix` — DRIFT-01 caught via cross-verify Plan vs Casbin
- `verify-schema-before-proposing` — em should have GREP'd before assuming `{var:[0-9]+}` valid
- `dispatch-bundle-strict-required` — documented for Phase 4 batch publish
- `async-session-gather` — concurrent race deferred to test-debt PR
- `lead-active-user-casbin-pr4` — admin uses require_admin NOT CasbinAuth
- `ci-workflow-flag-cross-file-sync` — 2 workflow files synced atomic Sub-3.5
- `fastapi-route-regex-vs-casbin-keymatch-distinction` (NEW saved this PR)

## Follow-up tracking (deferred)

- **FU-1 DRIFT-01** Plan v0.7 line 437 stale — bump v0.7 → v0.7.1 separate doc PR
- **FU-2** Phase C-2/C-3 deferred — happy-path E2E + negative integration tests via TestClient + real DB. Match PR-3B precedent
- **FU-3** T11 waitlist-reject endpoint NOT shipped — Casbin policy registered, FastAPI router defer
- **FU-4** Concurrent transition race integration test — Phase 4 / PR-3D-B
- **FU-5** Phase 2 PR-2C test mock drift (~34 pre-existing fails) — separate test-debt PR

## Verify

- [x] 270/270 tests PASS local (55.07s)
- [x] Coverage script runs WITHOUT `--allow-deferred` — 12 events `ok`
- [x] 3 routes registered, path_regex matches real numeric requests
- [x] FastAPI type annotation `profile_id: int` enforces non-numeric → 422
- [x] Casbin matrix verifies admin-rollback DENIED for all 4 roles (admin via diamond)
- [x] AST lint preserved
- [x] No FE files touched (BE-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
