### PR TITLE
hotfix(admission): Phase 3 PR-3C — SubjectGroup.subjects relation drift + 15 integration tests

### DIFF
--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -93,10 +93,13 @@ async def publish_admission_result(
             selectinload(models.AdmissionProfile.choices)
             .selectinload(models.AdmissionProfileChoice.admission_path)
             .selectinload(models.AdmissionPath.criteria),
+            # SubjectGroup uses subject_mappings (M2M) → SubjectGroupSubject.subject
+            # NOT direct `subjects` relation (em earlier drift, fixed).
             selectinload(models.AdmissionProfile.choices)
             .selectinload(models.AdmissionProfileChoice.path_subject_group_config)
             .selectinload(models.PathSubjectGroupConfig.subject_group)
-            .selectinload(models.SubjectGroup.subjects),
+            .selectinload(models.SubjectGroup.subject_mappings)
+            .selectinload(models.SubjectGroupSubject.subject),
             selectinload(models.AdmissionProfile.choices)
             .selectinload(models.AdmissionProfileChoice.scores)
             .selectinload(models.ProfileChoiceScore.subject),

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -221,6 +221,9 @@ def _resolve_allowed_subjects(choice: "AdmissionProfileChoice") -> List[str]:
     """Extract allowed subjects from choice.path_subject_group_config.
 
     Returns list of subject codes in deterministic order.
+
+    Schema: SubjectGroup has `subject_mappings` (M2M to SubjectGroupSubject)
+    NOT direct `subjects` relation. Navigate via mapping → subject chain.
     """
     config = getattr(choice, "path_subject_group_config", None)
     if config is None:
@@ -228,10 +231,12 @@ def _resolve_allowed_subjects(choice: "AdmissionProfileChoice") -> List[str]:
     group = getattr(config, "subject_group", None)
     if group is None:
         return []
-    subjects = getattr(group, "subjects", None) or []
+    # SubjectGroup.subject_mappings → SubjectGroupSubject.subject → Subject
+    mappings = getattr(group, "subject_mappings", None) or []
     codes: List[str] = []
-    for s in subjects:
-        code = getattr(s, "code", None)
+    for sgs in mappings:
+        subj = getattr(sgs, "subject", None)
+        code = getattr(subj, "code", None) if subj else None
         if code:
             codes.append(code)
     return codes

--- a/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
@@ -462,3 +462,99 @@ async def test_admin_rollback_reason_missing_422(
     assert response.status_code == 422, (
         f"missing reason must trigger 422; got {response.status_code}"
     )
+
+
+# ============================================================================
+# E. Phase C-3 extended — additional happy path + critical negatives (4 tests)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_waitlist_promote_happy_path_manager(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3c_seed_waitlisted: dict,
+):
+    """T10 happy path: manager + choice.decision=waitlisted + profile.status=
+    waitlisted → 200 với choice promoted to admitted + profile status=admitted.
+
+    Verifies TRANSITION_PAIR_TO_EVENT cascade end-to-end through router →
+    service → state machine → dispatch.
+    """
+    profile_id = pr3c_seed_waitlisted["profile_id"]
+    choice_id = pr3c_seed_waitlisted["choice_id_1"]
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/waitlist-promote",
+        headers=manager_token_headers,
+        json={"choice_id": choice_id, "reason": "Manager manual promote test"},
+    )
+    assert response.status_code == 200, (
+        f"Expected 200; got {response.status_code}: {response.text}"
+    )
+    body = response.json()
+    assert body["choice_id"] == choice_id
+    assert body["profile_id"] == profile_id
+    assert body["decision"] == "admitted"
+    assert body["profile_status"] == "admitted"
+
+    # Verify DB state mutation persisted
+    async with AsyncSessionLocal() as s:
+        choice = await s.get(models.AdmissionProfileChoice, choice_id)
+        profile = await s.get(models.AdmissionProfile, profile_id)
+        assert choice.decision == "admitted"
+        assert profile.status == "admitted"
+
+
+@pytest.mark.asyncio
+async def test_publish_result_profile_not_found_404(
+    client: AsyncClient,
+    manager_token_headers: dict,
+):
+    """T6 unknown profile_id → 404 (IDOR anti-enumeration via get_admission_for_manager)."""
+    response = await client.post(
+        "/api/v2/admissions/99999999/publish-result",
+        headers=manager_token_headers,
+    )
+    assert response.status_code == 404, (
+        f"Unknown profile_id must return 404 anti-enumeration; got {response.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_waitlist_promote_choice_id_mismatch_returns_404(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3c_seed_waitlisted: dict,
+):
+    """T10 IDOR ownership check: choice_id từ different profile → 404
+    (router defense-in-depth verifies choice.admission_profile_id matches
+    URL profile_id).
+    """
+    profile_id = pr3c_seed_waitlisted["profile_id"]
+    # choice_id 99999 doesn't belong to this profile
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/waitlist-promote",
+        headers=manager_token_headers,
+        json={"choice_id": 99999, "reason": None},
+    )
+    assert response.status_code == 404, (
+        f"choice_id mismatch must return 404; got {response.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_rollback_reason_too_long_422(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    pr3c_seed_choices: dict,
+):
+    """T17 schema: reason > 500 chars → Pydantic max_length 422."""
+    profile_id = pr3c_seed_choices["profile_id"]
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/admin-rollback",
+        headers=admin_token_headers,
+        json={"reason": "x" * 501},  # exceeds max_length=500
+    )
+    assert response.status_code == 422, (
+        f"reason > 500 chars must trigger Pydantic 422; got {response.status_code}"
+    )

--- a/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
@@ -1,0 +1,464 @@
+"""Phase 3 PR-3C Sub-3.7 Phase C-2/C-3 — Integration tests cho 3 routers.
+
+Real DB + AsyncClient + auth tokens. Extends `pr3a_seed` fixture pattern
+với AdmissionProfileChoice rows in various decisions.
+
+12 integration tests covering:
+- 3 happy paths (1 per router, end-to-end with real cascade/transition/dispatch)
+- 4 auth gate tests (officer/accountant DENY where expected, no-auth 401)
+- 3 pre-check failures (uses_choice_engine, choice decision mismatch, terminal state)
+- 2 schema validation (reason boundaries)
+
+Non-tautological per memory `pattern-change-impact-audit`: each test
+asserts SPECIFIC status code + response body + DB state mutation, NOT just
+"endpoint exists".
+
+Match PR-3B precedent — anchor + Casbin matrix shipped trong main PR-3C;
+this file is test-debt follow-up extending integration coverage.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from app import models
+from app.database import AsyncSessionLocal
+
+
+log = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Inlined pr3a_seed (fixture defined in tests/unit/ — NOT discoverable từ
+# tests/api/). Copies seed chain: lead → profile (uses_choice_engine) +
+# path + path_subject_group_config + subject_group_subject.
+# ============================================================================
+
+
+@pytest_asyncio.fixture
+async def pr3a_seed(seed_lead_dependencies: dict) -> dict:
+    """Seed full Phase 3 chain (inlined from tests/unit/test_phase3_pr3a)."""
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            offering = models.ProgramOffering(
+                program_id=seed_lead_dependencies["major_program_id"],
+                offering_type="full_time",
+                duration_semesters=8,
+            )
+            s.add(offering)
+            await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=offering.id,
+                academic_year=2026,
+                annual_admission_quota=20,
+                tuition_fee_per_year=1_000_000,
+            )
+            s.add(ai)
+            await s.flush()
+
+            from tests.fixtures.builders import AdmissionRoundBuilder
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                s, academic_year=2026,
+            )
+
+            method = models.AdmissionMethod(
+                code=f"M3C_{ts}",
+                name=f"PR-3C method {ts}",
+                requires_subject_scores=True,
+                is_active=True,
+            )
+            s.add(method)
+            await s.flush()
+
+            path = models.AdmissionPath(
+                academic_info_id=ai.id,
+                admission_method_id=method.id,
+                admission_round_id=round_id,
+                status="active",
+            )
+            s.add(path)
+            await s.flush()
+
+            sg = models.SubjectGroup(
+                code=f"SG3C{ts}"[:20],
+                name=f"SubjectGroup3C {ts}",
+            )
+            s.add(sg)
+            await s.flush()
+
+            subj = models.Subject(
+                code=f"SU3C{ts}"[:20],
+                name_vi=f"Subject3C {ts}",
+            )
+            s.add(subj)
+            await s.flush()
+
+            sgs = models.SubjectGroupSubject(
+                subject_group_id=sg.id,
+                subject_id=subj.id,
+                position=1,
+            )
+            s.add(sgs)
+            await s.flush()
+
+            config = models.PathSubjectGroupConfig(
+                admission_path_id=path.id,
+                subject_group_id=sg.id,
+                min_score=Decimal("18.00"),
+            )
+            s.add(config)
+            await s.flush()
+
+            lead = models.Lead(
+                full_name=f"PR-3C Lead {ts}",
+                phone=f"097{ts:07d}"[:10],
+                unit_id=seed_lead_dependencies["unit_id"],
+                pipeline_stage_id=seed_lead_dependencies["stage_id"],
+                source="walkin",
+            )
+            s.add(lead)
+            await s.flush()
+
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                citizen_id=f"7{ts:08d}1"[:12],
+                status="draft",
+                applied_rules={},
+                academic_year=2026,
+                uses_choice_engine=True,
+            )
+            s.add(profile)
+            await s.flush()
+
+            round_obj = await s.get(models.OfferingAdmissionRound, round_id)
+            round_obj.allow_multi_nv = True
+            await s.flush()
+
+            return {
+                "profile_id": profile.id,
+                "path_id": path.id,
+                "config_id": config.id,
+                "subject_id": subj.id,
+                "round_id": round_id,
+                "lead_id": lead.id,
+            }
+
+
+# ============================================================================
+# Extended seed fixture: pr3a_seed + AdmissionProfileChoice rows
+# ============================================================================
+
+
+@pytest_asyncio.fixture
+async def pr3c_seed_choices(pr3a_seed: dict) -> dict:
+    """Extend pr3a_seed with 2 AdmissionProfileChoice rows for cascade tests.
+
+    Choices added in display_order 1 + 2, decision='pending' default.
+    Profile starts in 'draft' status — tests may transition before HTTP call.
+    """
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            choice1 = models.AdmissionProfileChoice(
+                admission_profile_id=pr3a_seed["profile_id"],
+                admission_path_id=pr3a_seed["path_id"],
+                path_subject_group_config_id=pr3a_seed["config_id"],
+                display_order=1,
+                decision="pending",
+            )
+            s.add(choice1)
+            await s.flush()
+
+    return {**pr3a_seed, "choice_id_1": choice1.id}
+
+
+@pytest_asyncio.fixture
+async def pr3c_seed_reviewing(pr3c_seed_choices: dict) -> dict:
+    """Profile transitioned to 'reviewing' state (T6 pre-condition)."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            profile = await s.get(
+                models.AdmissionProfile, pr3c_seed_choices["profile_id"],
+            )
+            profile.status = "reviewing"
+            profile.version += 1
+    return pr3c_seed_choices
+
+
+@pytest_asyncio.fixture
+async def pr3c_seed_waitlisted(pr3c_seed_choices: dict) -> dict:
+    """Profile + choice in 'waitlisted' state (T10 pre-condition)."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            profile = await s.get(
+                models.AdmissionProfile, pr3c_seed_choices["profile_id"],
+            )
+            profile.status = "waitlisted"
+            profile.version += 1
+            choice = await s.get(
+                models.AdmissionProfileChoice, pr3c_seed_choices["choice_id_1"],
+            )
+            choice.decision = "waitlisted"
+    return pr3c_seed_choices
+
+
+# ============================================================================
+# A. Happy path E2E (3 tests, 1 per router)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_publish_result_happy_path_manager(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3c_seed_reviewing: dict,
+):
+    """T6 happy path: manager + uses_choice_engine + status=reviewing →
+    200 với CascadeResult per_choice_decisions.
+
+    Note: this happy path may produce decision=rejected (vì test seed
+    không có complete subject scores), but status code 200 + valid response
+    shape verifies router→service→state machine→dispatch chain works E2E.
+    """
+    profile_id = pr3c_seed_reviewing["profile_id"]
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/publish-result",
+        headers=manager_token_headers,
+    )
+    # 200 = happy E2E path traversed (cascade may admit or reject based on scores)
+    # 400 = pre-check fail (KHÔNG expected vì seed is correct state)
+    assert response.status_code == 200, (
+        f"Expected 200; got {response.status_code}: {response.text}"
+    )
+    body = response.json()
+    assert body["profile_id"] == profile_id
+    assert body["final_status"] in {"admitted", "rejected", "waitlisted"}
+    assert "per_choice_decisions" in body
+
+
+@pytest.mark.asyncio
+async def test_admin_rollback_happy_path_admin(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    pr3c_seed_choices: dict,
+):
+    """T17 happy path: admin + reason ≥10 chars → 200 status=draft + ROLLED_BACK
+    metadata. Profile starts draft (default seed), transitions to submitted first,
+    then admin rolls back to draft.
+    """
+    profile_id = pr3c_seed_choices["profile_id"]
+    # Transition profile to 'submitted' so rollback has meaningful source state
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            profile = await s.get(models.AdmissionProfile, profile_id)
+            profile.status = "submitted"
+            profile.version += 1
+
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/admin-rollback",
+        headers=admin_token_headers,
+        json={"reason": "Profile mis-submitted, candidate withdraw via CCCD verify"},
+    )
+    assert response.status_code == 200, (
+        f"Expected 200; got {response.status_code}: {response.text}"
+    )
+    body = response.json()
+    assert body["profile_id"] == profile_id
+    assert body["status"] == "draft"
+    assert body["rolled_back_from"] == "submitted"
+
+
+# ============================================================================
+# B. Auth gate enforcement (4 tests)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_publish_result_officer_denied(
+    client: AsyncClient,
+    officer_token_headers: dict,
+    pr3c_seed_reviewing: dict,
+):
+    """T6 officer DENIED — get_admission_for_manager IDOR rejects officer
+    role với 404 (anti-enumeration per `lead-active-user-casbin-pr4` memory).
+    IDOR runs BEFORE CasbinAuth → never reaches Casbin DENY → 404 returned.
+    """
+    profile_id = pr3c_seed_reviewing["profile_id"]
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/publish-result",
+        headers=officer_token_headers,
+    )
+    # 404 anti-enumeration via IDOR gate (NOT 403 — don't leak resource existence)
+    # 401 also acceptable nếu Casbin runs first
+    assert response.status_code in (403, 404), (
+        f"Officer must be denied (403/404); got {response.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_waitlist_promote_officer_denied(
+    client: AsyncClient,
+    officer_token_headers: dict,
+    pr3c_seed_waitlisted: dict,
+):
+    """T10 officer DENIED — IDOR via get_admission_for_manager returns 404."""
+    profile_id = pr3c_seed_waitlisted["profile_id"]
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/waitlist-promote",
+        headers=officer_token_headers,
+        json={"choice_id": pr3c_seed_waitlisted["choice_id_1"]},
+    )
+    assert response.status_code in (403, 404)
+
+
+@pytest.mark.asyncio
+async def test_admin_rollback_manager_denied(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3c_seed_choices: dict,
+):
+    """T17 manager DENIED — require_admin gate (NOT CasbinAuth). Even though
+    manager has Casbin reach to most routes, require_admin direct check rejects.
+    """
+    profile_id = pr3c_seed_choices["profile_id"]
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/admin-rollback",
+        headers=manager_token_headers,
+        json={"reason": "Test rollback reason 10+ chars"},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_rollback_no_auth_401(
+    client: AsyncClient,
+    pr3c_seed_choices: dict,
+):
+    """T17 unauthenticated request → 401."""
+    profile_id = pr3c_seed_choices["profile_id"]
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/admin-rollback",
+        json={"reason": "Test rollback reason 10+ chars"},
+    )
+    assert response.status_code == 401, (
+        f"No auth must return 401; got {response.status_code}"
+    )
+
+
+# ============================================================================
+# C. Pre-check failures (3 tests)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_publish_result_uses_choice_engine_false_blocked(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3c_seed_reviewing: dict,
+):
+    """T6 pre-check: uses_choice_engine=False profile rejected 400."""
+    # Flip flag
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            profile = await s.get(
+                models.AdmissionProfile, pr3c_seed_reviewing["profile_id"],
+            )
+            profile.uses_choice_engine = False
+
+    response = await client.post(
+        f"/api/v2/admissions/{pr3c_seed_reviewing['profile_id']}/publish-result",
+        headers=manager_token_headers,
+    )
+    assert response.status_code == 400, (
+        f"uses_choice_engine=False must block 400; got {response.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_waitlist_promote_choice_decision_mismatch_blocked(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3c_seed_choices: dict,
+):
+    """T10 pre-check: choice.decision='pending' (NOT waitlisted) → 400."""
+    profile_id = pr3c_seed_choices["profile_id"]
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/waitlist-promote",
+        headers=manager_token_headers,
+        json={"choice_id": pr3c_seed_choices["choice_id_1"]},
+    )
+    # 400 BusinessRuleViolation (decision != waitlisted)
+    assert response.status_code == 400, (
+        f"choice.decision='pending' must block 400; got {response.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_rollback_terminal_state_blocked(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    pr3c_seed_choices: dict,
+):
+    """T17 pre-check: profile in terminal state (enrolled) cannot rollback → 400."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            profile = await s.get(
+                models.AdmissionProfile, pr3c_seed_choices["profile_id"],
+            )
+            profile.status = "enrolled"
+            profile.version += 1
+
+    response = await client.post(
+        f"/api/v2/admissions/{pr3c_seed_choices['profile_id']}/admin-rollback",
+        headers=admin_token_headers,
+        json={"reason": "Valid rollback reason 10+ chars"},
+    )
+    assert response.status_code == 400, (
+        f"enrolled terminal state must block 400; got {response.status_code}"
+    )
+
+
+# ============================================================================
+# D. Schema validation (2 tests)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_admin_rollback_reason_too_short_422(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    pr3c_seed_choices: dict,
+):
+    """T17 schema: reason < 10 chars → Pydantic 422 (NOT 400 from service)."""
+    profile_id = pr3c_seed_choices["profile_id"]
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/admin-rollback",
+        headers=admin_token_headers,
+        json={"reason": "short"},  # 5 chars
+    )
+    assert response.status_code == 422, (
+        f"reason < 10 must trigger Pydantic 422; got {response.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_rollback_reason_missing_422(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    pr3c_seed_choices: dict,
+):
+    """T17 schema: missing reason field → 422 (required)."""
+    profile_id = pr3c_seed_choices["profile_id"]
+    response = await client.post(
+        f"/api/v2/admissions/{profile_id}/admin-rollback",
+        headers=admin_token_headers,
+        json={},  # No reason
+    )
+    assert response.status_code == 422, (
+        f"missing reason must trigger 422; got {response.status_code}"
+    )


### PR DESCRIPTION
## Summary

🚨 **Latent prod bug** caught while writing Phase C-2/C-3 integration tests for PR-3C #266.

Root cause: `SubjectGroup` model defines `subject_mappings` M2M relation to `SubjectGroupSubject`, NOT direct `subjects` attribute. PR-3C touched `SubjectGroup.subjects` (non-existent) in 2 locations → AttributeError 500 when manager triggers publish-result.

## Prod exposure

- alembic head: `phase3_01` ✓ (unchanged)
- Profile distribution: 9 draft + 1 submitted (NO profile in `reviewing` state)
- → **0 prod traffic yet** — bug latent, but ANY manager calling publish-result on real reviewing profile would FAIL với 500

## Fix (2 files)

1. **`admission_choice_engine_service.py:_resolve_allowed_subjects`** — navigate via `group.subject_mappings` → `SubjectGroupSubject.subject` chain instead of direct `group.subjects`
2. **`admissions_v2.py:publish_admission_result`** — eager-load chain `selectinload(SubjectGroup.subject_mappings).selectinload(SubjectGroupSubject.subject)` instead of broken `SubjectGroup.subjects`

## NEW 15 integration tests (`tests/api/test_phase3_pr3c_routers_integration.py`)

Phase C-2/C-3 from PR-3C deferred — match PR-3B precedent (anchor + integration suite).

**A. Happy path E2E (3 tests)**:
- publish-result happy: manager + uses_choice_engine + status=reviewing → 200 cascade
- waitlist-promote happy: manager + choice.waitlisted + profile.waitlisted → 200 admitted + DB state verified
- admin-rollback happy: admin + reason ≥10 → 200 status=draft + rolled_back_from

**B. Auth gate (4)**:
- publish-result officer denied (IDOR 404 anti-enumeration)
- waitlist-promote officer denied
- admin-rollback manager denied (require_admin direct gate)
- admin-rollback no auth → 401

**C. IDOR (2)**:
- publish-result unknown profile_id → 404
- waitlist-promote choice_id mismatch profile → 404

**D. Pre-check (3)**:
- publish-result uses_choice_engine=False → 400
- waitlist-promote choice.decision=pending → 400
- admin-rollback profile in enrolled terminal state → 400

**E. Schema validation (3)**:
- admin-rollback reason < 10 → 422
- admin-rollback reason missing → 422
- admin-rollback reason > 500 → 422

## Test pattern

- Inlined `pr3a_seed` fixture (tests/unit fixture KHÔNG discoverable từ tests/api)
- Extended với `pr3c_seed_choices`, `pr3c_seed_reviewing`, `pr3c_seed_waitlisted`
- Real DB seed end-to-end qua TestClient + admin/manager/officer token fixtures
- Non-tautological per memory `pattern-change-impact-audit` — happy tests verify DB state mutation persisted

## Em ack 4th significant miss in PR-3C arc

| # | Miss | Caught by |
|---|---|---|
| 1 | Path regex syntax `{var:[0-9]+}` (Sub-3.3/3.4/3.5b) | Sub-3.6 anchor (`14140b29`) |
| 2 | Cross-file CI flag sync (PR-3B Sub-2) | User post-merge hotfix #265 |
| 3 | Casbin path drift assumed Plan vs shipped policy (PR-3B Sub-3) | Sub-3.4 DRIFT-01 sync |
| 4 | **`SubjectGroup.subjects` relation drift (PR-3C Sub-2/3.3)** | **Integration tests** |

Memory lesson reinforced: **integration tests catch bugs unit tests miss** (53 PR-3C unit tests all mocked `SubjectGroup.subjects` accessor — silent breakage).

## Verify

- [x] 15/15 integration tests PASS (107.39s)
- [x] 270 pre-existing unit tests still PASS (no regression)
- [x] Real DB seed chain verified end-to-end via TestClient
- [x] DB state mutation persisted post-request (no silent success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)