### PR TITLE
chore(deps): bump ujson 5.12.1 — clear pip-audit CVE-2026-44660

### DIFF
--- a/Backend_FastAPI/requirements.txt
+++ b/Backend_FastAPI/requirements.txt
@@ -106,7 +106,7 @@ typing_extensions==4.15.0
 tzdata==2025.2
 ua-parser==1.0.1
 ua-parser-builtins==0.18.0.post1
-ujson==5.12.0
+ujson==5.12.1
 urllib3==2.7.0
 user-agents==2.2.0
 uvicorn==0.37.0


### PR DESCRIPTION
## Summary

CVE-2026-44660 (ujson 5.12.0 memory leak via `ujson.dump()`) disclosed mid-deploy 2026-05-13. Fix in ujson 5.12.1.

Pattern reuse: PR #257 PostCSS + PR #262 urllib3+next — em saved memory `outstanding-debt` pattern. New CVE recurring; bump dep standalone PR trước feature/hotfix rebase.

## Change

Single 1-line: `requirements.txt:109` `ujson==5.12.0` → `ujson==5.12.1`.

## Verify

- pip install clean
- python -c 'import ujson; print(ujson.__version__)' → 5.12.1
- Backend smoke imports OK

## Unblocks

Hotfix PR #267 (SubjectGroup relation drift) Python deps gate currently FAILING due to this CVE. Sequence: merge this PR first → rebase #267 → CI green → merge #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)