### PR TITLE
hotfix(admission): ChoiceScoreCard setState-in-effect lint error blocking deploy

### DIFF
--- a/frontend/src/components/admissions/ChoiceScoreCard/ChoiceScoreCard.tsx
+++ b/frontend/src/components/admissions/ChoiceScoreCard/ChoiceScoreCard.tsx
@@ -23,7 +23,7 @@
  * settles in background. Local state diverges from props during edit
  * then re-syncs from server response onSettled.
  */
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { Info, Loader2 } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -86,17 +86,20 @@ export function ChoiceScoreCard({
   const [editedScores, setEditedScores] = useState<EditableScore[]>(() =>
     choice.scores.map(toEditable),
   )
+  // Track last-seen choice.scores reference so we re-sync local state when
+  // the parent re-fetches (server invalidates after another mutation /
+  // socket data_updated). React docs-blessed "reset state on prop change"
+  // pattern — setState during render avoids the useEffect cascade and the
+  // `react-you-might-not-need-an-effect` lint error.
+  // See https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes
+  const [lastChoiceScores, setLastChoiceScores] = useState(choice.scores)
+  if (lastChoiceScores !== choice.scores) {
+    setLastChoiceScores(choice.scores)
+    setEditedScores(choice.scores.map(toEditable))
+  }
   const [serverError, setServerError] = useState<string | null>(null)
 
   const mutation = useReplaceChoiceScores(profileId)
-
-  // Re-sync from props when the parent re-fetches (after another mutation
-  // succeeds or socket data_updated invalidates). Local edits in flight
-  // will be overwritten — acceptable per onBlur-save pattern (no long-lived
-  // unsaved drafts).
-  useEffect(() => {
-    setEditedScores(choice.scores.map(toEditable))
-  }, [choice.scores])
 
   const handleChange = (subjectId: number, raw: string) => {
     setEditedScores((prev) =>


### PR DESCRIPTION
## Summary

🚨 **Hotfix for deploy failure on main** (run `25783512328`, conclusion=FAILURE).

After PR #272 (FE Bundle 1) merged, deploy.yml's \"PR Gate — Contract Tests\" Frontend Lint step found:

> \`ChoiceScoreCard.tsx:98:5\` ESLint error: \`react-you-might-not-need-an-effect\` — Calling setState synchronously within an effect can trigger cascading renders.

215 problems = 1 error + 214 warnings. ESLint exit code 1 → \"PR Gate\" job FAILED → \"Deploy to VPS\" job SKIPPED.

## Root cause

Bundle 1 \`ChoiceScoreCard.tsx\` used \`useEffect\` to re-sync local \`editedScores\` state when parent's \`choice.scores\` prop changes (after another mutation or socket invalidation). Pattern was intentional but violates the React docs-blessed \"reset state on prop change\" guidance.

## Fix

Refactor to setState-during-render pattern per [React docs](https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes):

\`\`\`tsx
// Before — useEffect cascade
useEffect(() => {
  setEditedScores(choice.scores.map(toEditable))
}, [choice.scores])

// After — track ref, setState during render
const [lastChoiceScores, setLastChoiceScores] = useState(choice.scores)
if (lastChoiceScores !== choice.scores) {
  setLastChoiceScores(choice.scores)
  setEditedScores(choice.scores.map(toEditable))
}
\`\`\`

Identical externally-observable behavior, no useEffect cascade, lint clean.

## Verification

- [x] 7/7 ChoiceScoreCard vitest still PASS (no test change needed — same observable behavior)
- [x] \`eslint ChoiceScoreCard.tsx\` clean locally
- [ ] CI \"PR Gate — Contract Tests\" Frontend Lint passes → \"Deploy to VPS\" job runs

## Linked

- Bundle 1 PR: #272 (merged \`aa661961\`)
- Failed deploy run: 25783512328
- FE CI gap follow-up: task #126 (add PR-level FE workflow to catch lint BEFORE push to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)