### PR TITLE
feat(admission): PR-CO-2-BE PR-3E multi-action magic-link consume (P0, ~1.2d)

### DIFF
--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -46,6 +46,7 @@ from .routers import (
     admin_v2_system_config,  # ✅ #184 PR-1D / phase1_13: admin runtime config
     admin_backfill,  # ✅ #184 Phase 3 PR-3D-B BE-2: admin backfill exception queue (Q-P3-09)
     admissions,  # ✅ NEW: Admission Profile workflow
+    admissions_magic_link,  # ✅ PR-CO-2-BE / PR-3E: multi-action magic-link consume (4 actions)
     admissions_v2,  # ✅ #184 Phase 3 PR-3C Sub-3.3: multi-NV choice-engine endpoints (publish-result T6)
     auth,
     collaborators,  # ✅ CTV SYSTEM: Collaborator management + CTV self-service
@@ -783,6 +784,7 @@ fastapi_app.include_router(commissions.policy_router, prefix="/api")  # ✅ CTV 
 fastapi_app.include_router(commissions.record_router, prefix="/api")  # ✅ CTV P2: Commission records (Admin)
 fastapi_app.include_router(commissions.ctv_commission_router, prefix="/api")  # ✅ CTV P2: CTV commission view
 fastapi_app.include_router(admissions.router, prefix="/api")  # ✅ Admission Profile workflow
+fastapi_app.include_router(admissions_magic_link.router)  # ✅ PR-CO-2-BE / PR-3E: multi-action magic-link (router declares /api/v2/admissions/magic-link prefix)
 fastapi_app.include_router(admissions_v2.router)  # ✅ #184 Phase 3 PR-3C: multi-NV choice-engine v2 (router declares /api/v2 prefix)
 fastapi_app.include_router(admin_backfill.router)  # ✅ #184 Phase 3 PR-3D-B BE-2: admin backfill exception queue (router declares /api/v2/admin prefix)
 fastapi_app.include_router(admission_config.router, prefix="/api")  # ✅ PHASE 3: Admission Config + Scoring

--- a/Backend_FastAPI/app/middleware/csrf.py
+++ b/Backend_FastAPI/app/middleware/csrf.py
@@ -56,6 +56,7 @@ EXEMPT_PATHS: List[str] = [
     "/api/auth/verify-mfa",  # MFA verification before login completes (no csrf_token cookie yet)
     "/api/ctv-register",  # Public CTV registration (no auth, rate-limited, pending approval)
     "/api/admissions/confirm/",  # Public magic-link confirmation (no auth required)
+    "/api/v2/admissions/magic-link/",  # PR-CO-2-BE / PR-3E: multi-action magic-link (4 actions, no auth)
     "/api/public/",
     "/api/webhooks/",
     "/docs",

--- a/Backend_FastAPI/app/routers/admissions_magic_link.py
+++ b/Backend_FastAPI/app/routers/admissions_magic_link.py
@@ -1,0 +1,137 @@
+"""PR-CO-2-BE / PR-3E (Phase 3 close-out plan v2 LOCKED 2026-05-14):
+multi-action magic-link consume router.
+
+Sibling of the legacy single-action ``/api/admissions/confirm/{token}``
+endpoint (kept in ``admissions.py`` for backward compatibility). This
+v2 surface accepts a typed action enum in the path, routes to
+``magic_link_service.consume_token``, and returns a uniform response
+shape for the FE landing pages in PR-CO-2-FE.
+
+PUBLIC ENDPOINT — no authentication required. Security comes from:
+- 256-bit URL-safe token (impossible to guess)
+- CCCD verification (constant-time ``hmac.compare_digest``)
+- Per-token rate limit (5/60s, Redis ``mlt:{token}``, fail-closed)
+- ADM-023 CCCD brute-force cooldown ladder (preserved from legacy flow)
+- Global + per-IP slowapi limits (DATA_WRITE + 100/day per IP)
+- CSRF-exempt prefix (registered in ``middleware/csrf.py``)
+"""
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import database
+from ..core.rate_limits import limiter, RateLimits
+
+
+def get_client_ip(request: Request) -> str:
+    """Helper for slowapi per-IP key generation."""
+    return request.client.host if request.client else "unknown"
+from ..schemas.magic_link import (
+    MagicLinkAction,
+    MagicLinkConsumeRequest,
+    MagicLinkConsumeResponse,
+)
+from ..services import magic_link_service
+from ..utils.exceptions import BadRequest, ResourceNotFoundError
+
+log = structlog.get_logger(__name__)
+
+
+router = APIRouter(
+    prefix="/api/v2/admissions/magic-link",
+    tags=["admissions-v2-magic-link"],
+)
+
+
+@router.post(
+    "/{action}/{token}",
+    response_model=MagicLinkConsumeResponse,
+    summary="Consume a magic-link token (4-action: submit | resubmit | confirm | withdraw)",
+    description="""
+    Multi-action public magic-link consume endpoint. The ``{action}`` path
+    parameter MUST match the token row's ``action_type`` — mismatch
+    returns 404 (does not leak token existence).
+
+    **Workflow** (per action, infrastructure shared):
+      1. Per-token rate limit (5/60s, Redis ``mlt:{token}``, fail-closed)
+      2. ADM-013 profile-first 3-step row lock
+      3. Action enum match + freshness gates (expired/used/locked)
+      4. CCCD constant-time compare (last 4 digits)
+      5. Dispatch action handler (confirm wired; submit/resubmit/withdraw
+         currently 501 — FU PR-CO-2-BE-2)
+
+    **CSRF**: this endpoint is CSRF-exempt by allowlist
+    (``middleware/csrf.py``) since candidates do not hold a CSRF cookie.
+
+    **Wave A acceptance gate**: "Magic-link confirm consume atomic" — the
+    ADM-013 lock + ``confirmed_at IS NULL`` predicate at consume time
+    serialise concurrent consumes to a single winner.
+    """,
+)
+@limiter.limit(RateLimits.DATA_WRITE)
+@limiter.limit("100/day", key_func=get_client_ip)
+async def consume_magic_link_token(
+    request: Request,
+    action: MagicLinkAction,
+    token: str,
+    body: MagicLinkConsumeRequest,
+    db: AsyncSession = Depends(database.get_db),
+) -> MagicLinkConsumeResponse:
+    """Public endpoint — see route docstring for full behaviour."""
+    try:
+        profile, callback = await magic_link_service.consume_token(
+            db=db,
+            token_value=token,
+            cccd_last4=body.cccd,
+            action=action.value,
+        )
+
+        # Persist the consume + any state-machine mutations the action
+        # handler made (e.g. ``confirmed_at``, ``status`` transition).
+        await db.commit()
+        await db.refresh(profile)
+
+        # Post-commit notification fanout. The callback is the proven
+        # `verify_and_confirm` hand-off from the legacy confirm flow.
+        if callback is not None:
+            await callback()
+
+        return MagicLinkConsumeResponse(
+            message="Yêu cầu đã được xử lý thành công.",
+            profile_id=profile.id,
+            action=action,
+            status=profile.status,
+            consumed_at=(
+                profile.confirmed_at
+                if profile.confirmed_at is not None
+                else profile.updated_at
+            ),
+            next_url=None,  # FE picks destination per action
+        )
+
+    except ResourceNotFoundError as e:
+        # 404 covers both "token does not exist" and "action enum
+        # mismatch" — same response by design (no enumeration).
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(e)
+        )
+    except BadRequest as e:
+        # Commit any mutations the service applied before raising
+        # (cooldown ladder updates, lock_until, hard-lock audit row).
+        # Mirrors the legacy confirm router's pattern.
+        await db.commit()
+        post_commit = getattr(e, "post_commit_callback", None)
+        if post_commit is not None:
+            try:
+                await post_commit()
+            except Exception as cb_err:  # noqa: BLE001 — best-effort
+                log.error(
+                    "Magic-link post-commit callback failed (best-effort)",
+                    error=str(cb_err),
+                    token_prefix=token[:8],
+                    action=action.value,
+                )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        )

--- a/Backend_FastAPI/app/schemas/magic_link.py
+++ b/Backend_FastAPI/app/schemas/magic_link.py
@@ -1,0 +1,53 @@
+"""PR-CO-2-BE / PR-3E: Pydantic schemas for the multi-action magic-link
+consume endpoint.
+
+Action enum locked to 4 values matching the DB CHECK constraint at
+``AdmissionConfirmationToken.action_type`` (see
+``alembic/versions/phase1_18_extend_confirmation_token_for_multi_action.py``).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class MagicLinkAction(str, Enum):
+    """4-action enum locked by DB CHECK at admission_confirmation_token."""
+    SUBMIT = "submit"
+    RESUBMIT = "resubmit"
+    CONFIRM = "confirm"
+    WITHDRAW = "withdraw"
+
+
+class MagicLinkConsumeRequest(BaseModel):
+    """POST body for /api/v2/admissions/magic-link/{action}/{token}.
+
+    ``cccd`` is the last 4 digits of the candidate's CCCD (citizen ID).
+    The service constant-time compares it against
+    ``profile.citizen_id[-4:]`` via ``hmac.compare_digest``. Matches the
+    existing single-action /confirm/{token} contract — keeps the FE
+    keypad UX (4-digit) unchanged.
+    """
+    cccd: str = Field(
+        ...,
+        min_length=4,
+        max_length=4,
+        pattern=r"^\d{4}$",
+        description="Last 4 digits of citizen ID",
+    )
+
+
+class MagicLinkConsumeResponse(BaseModel):
+    """Response when a token is successfully consumed."""
+    message: str
+    profile_id: int
+    action: MagicLinkAction
+    status: str
+    consumed_at: datetime
+    next_url: Optional[str] = Field(
+        default=None,
+        description="Optional FE redirect target after success",
+    )

--- a/Backend_FastAPI/app/services/magic_link_rate_limit.py
+++ b/Backend_FastAPI/app/services/magic_link_rate_limit.py
@@ -1,0 +1,74 @@
+"""PR-CO-2-BE / PR-3E (Phase 3 close-out): per-token rate limit for the
+multi-action magic-link consume endpoint.
+
+Cap: ≤5 consume attempts per token in any trailing-edge 60s window.
+
+Defence-in-depth alongside the existing CCCD brute-force cooldown ladder
+(``admission_confirmation_cooldown``) and per-profile resend cap
+(``admission_confirmation_resend_limit``):
+
+  - Resend cap (per profile, 24h)        — stops free SMTP fanout
+  - Cooldown ladder (per token row, DB)  — stops CCCD brute force
+  - This module (per token VALUE, Redis) — stops endpoint hammering
+                                            from a single token URL
+
+Window shape: trailing-edge (TTL re-armed on every hit), identical to
+``admission_confirmation_resend_limit``. Burst then wait 60s
+quiet-period to reset. Matches plan v2 PR-CO-2-BE spec "Redis rate limit
+``mlt:{token}`` max 5/60s".
+
+Failure-mode policy: fail closed. When Redis is unavailable,
+``consume_attempt`` returns ``None`` and the caller MUST refuse the
+request. A brittle Redis is not an excuse to lift a rate cap — same
+reasoning as the resend cap.
+"""
+from __future__ import annotations
+
+import structlog
+from typing import Final, Optional
+
+from ..database import safe_redis_expire, safe_redis_incr
+
+log = structlog.get_logger(__name__)
+
+
+ATTEMPTS_CAP_PER_WINDOW: Final[int] = 5
+WINDOW_SECONDS: Final[int] = 60
+
+
+def _key(token_value: str) -> str:
+    # Token is 256-bit URL-safe random — safe to embed in the Redis key
+    # directly. Namespaced ``mlt:`` (magic-link token) per plan v2 spec.
+    return f"mlt:{token_value}"
+
+
+async def consume_attempt(token_value: str) -> Optional[int]:
+    """Atomically count + consume one attempt slot for ``token_value``.
+
+    Returns:
+        - Post-increment count when Redis is healthy. Caller checks
+          ``count <= ATTEMPTS_CAP_PER_WINDOW`` to decide whether to
+          proceed; ``count > cap`` means rate-limit lockout.
+        - ``None`` when the Redis breaker is open or EXPIRE arms fail.
+          Caller MUST fail closed (refuse the request).
+    """
+    key = _key(token_value)
+    count = await safe_redis_incr(key)
+    if count is None:
+        log.warning(
+            "Magic-link rate limit check failed: Redis INCR breaker open — failing closed",
+            token_prefix=token_value[:8],
+        )
+        return None
+
+    # Re-arm TTL every hit so the window is trailing-edge (60s of
+    # quiet required to clear). Mirrors the resend limit shape.
+    expire_ok = await safe_redis_expire(key, WINDOW_SECONDS)
+    if not expire_ok:
+        log.warning(
+            "Magic-link rate limit check failed: Redis EXPIRE returned falsy — failing closed",
+            token_prefix=token_value[:8],
+            count_after_incr=count,
+        )
+        return None
+    return count

--- a/Backend_FastAPI/app/services/magic_link_service.py
+++ b/Backend_FastAPI/app/services/magic_link_service.py
@@ -1,0 +1,221 @@
+"""PR-CO-2-BE / PR-3E (Phase 3 close-out plan v2 LOCKED 2026-05-14):
+multi-action magic-link consume service.
+
+Sits in front of the existing single-action confirm path
+(``admission_service.verify_and_confirm``) and the eventual
+submit/resubmit/withdraw handlers. Responsibilities:
+
+  1. Per-token rate limit (5/60s, Redis ``mlt:{token}``, fail-closed)
+  2. Action enum match between URL path and DB ``action_type``
+  3. CCCD constant-time compare (``hmac.compare_digest``)
+  4. Dispatch to the action-specific handler
+
+Wave A acceptance gate "Magic-link consume atomic" is satisfied by the
+existing ADM-013 3-step profile-first lock in
+``AdmissionRepository.get_token_for_confirm`` — the row lock + the
+``confirmed_at IS NULL`` predicate at consume time make concurrent
+consumes serialise to a single winner.
+
+This PR-CO-2-BE wires ``confirm`` only; submit/resubmit/withdraw stub
+out with 501 NOT_IMPLEMENTED and surface as follow-ups (FU PR-CO-2-BE-2).
+The infrastructure (router, rate limit, CSRF exempt, schemas, action
+enum match) ships fully so the candidate-facing FE landing pages in
+PR-CO-2-FE can integrate against a stable contract.
+"""
+from __future__ import annotations
+
+import hmac
+import secrets
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Optional, Tuple
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models
+from ..config import settings
+from ..utils.exceptions import (
+    BadRequest,
+    BusinessRuleViolation,
+    ResourceNotFoundError,
+)
+from . import admission_service
+from .magic_link_rate_limit import (
+    ATTEMPTS_CAP_PER_WINDOW,
+    consume_attempt,
+)
+from ..repositories import AdmissionRepository
+
+log = structlog.get_logger(__name__)
+
+
+PostCommitCallback = Optional[Callable[[], Awaitable[None]]]
+
+
+async def consume_token(
+    db: AsyncSession,
+    token_value: str,
+    cccd_last4: str,
+    action: str,
+) -> Tuple[models.AdmissionProfile, PostCommitCallback]:
+    """Consume a magic-link token for the specified action.
+
+    Args:
+        db: Async DB session.
+        token_value: URL-safe token string from URL path.
+        cccd_last4: Last 4 digits of citizen ID from request body.
+        action: One of ``submit | resubmit | confirm | withdraw``.
+
+    Returns:
+        Tuple of (profile, post_commit_callback). Caller (router)
+        commits the transaction and awaits the callback for the
+        notification fanout.
+
+    Raises:
+        ResourceNotFoundError: Token missing OR action_type mismatch
+            (both return 404 to avoid leaking token existence).
+        BadRequest: Rate limit hit, expired/used/locked, CCCD wrong.
+        BusinessRuleViolation: 501 for not-yet-wired actions.
+    """
+    # Step 1 — Per-token rate limit. Fail-closed when Redis breaker open.
+    count = await consume_attempt(token_value)
+    if count is None:
+        # Redis down; treat as rate-limited rather than open the door.
+        # Same defensive stance as resend cap (memory `zalo-bot-audit-gap`).
+        log.warning(
+            "Magic-link consume blocked: rate-limit service unavailable",
+            token_prefix=token_value[:8],
+            action=action,
+        )
+        raise BadRequest(
+            "Tạm thời không thể xử lý yêu cầu. Vui lòng thử lại sau ít phút."
+        )
+    if count > ATTEMPTS_CAP_PER_WINDOW:
+        log.warning(
+            "Magic-link consume blocked: per-token rate limit exceeded",
+            token_prefix=token_value[:8],
+            action=action,
+            count=count,
+            cap=ATTEMPTS_CAP_PER_WINDOW,
+        )
+        raise BadRequest(
+            f"Đã thử quá {ATTEMPTS_CAP_PER_WINDOW} lần trong 60 giây. "
+            "Vui lòng đợi và thử lại."
+        )
+
+    # Step 2 — Fetch token with the same ADM-013 3-step profile-first
+    # lock used by the existing /confirm/{token} flow. Locks the
+    # profile FIRST then the token, eliminating the race that the
+    # legacy single-statement lock left open.
+    repo = AdmissionRepository(db)
+    token_obj = await repo.get_token_for_confirm(token_value)
+    if token_obj is None:
+        # Generic not-found — do NOT distinguish "wrong token" from
+        # "wrong action" in the response (avoids enumeration).
+        raise ResourceNotFoundError("Invalid or expired confirmation link")
+
+    # Step 3 — Action enum match. URL action MUST match DB action_type.
+    # If a candidate edits the URL from /confirm/<t> to /submit/<t>
+    # we treat it as if the token does not exist for that action.
+    # Not constant-time critical: action_type values are public.
+    if token_obj.action_type != action:
+        log.warning(
+            "Magic-link action mismatch",
+            token_prefix=token_value[:8],
+            url_action=action,
+            token_action=token_obj.action_type,
+        )
+        raise ResourceNotFoundError("Invalid or expired confirmation link")
+
+    # Step 4 — Token freshness gates. Mirrors the existing confirm path
+    # so behaviour is identical regardless of which endpoint surface
+    # the candidate clicks through.
+    now = datetime.now(timezone.utc)
+
+    if token_obj.confirmed_at is not None:
+        raise BadRequest("This confirmation link has already been used")
+
+    if token_obj.locked_at is not None:
+        raise BadRequest(
+            "This confirmation link has been locked due to too many failed attempts. "
+            "Please contact support for assistance."
+        )
+
+    if token_obj.expires_at < now:
+        raise BadRequest(
+            "This confirmation link has expired. Please request a new link."
+        )
+
+    # Sliding cooldown (ADM-023). Distinct from ``locked_at`` — the
+    # cooldown clears itself by passage of time; ``locked_at`` only by
+    # an admin reset.
+    if token_obj.lock_until is not None and token_obj.lock_until > now:
+        retry_in_seconds = int((token_obj.lock_until - now).total_seconds())
+        raise BadRequest(
+            f"Quá nhiều lần nhập sai. Vui lòng thử lại sau {retry_in_seconds} giây."
+        )
+
+    # Step 5 — Profile / CCCD prerequisite.
+    profile = token_obj.profile
+    if not profile or not profile.citizen_id:
+        raise BadRequest("Profile data is incomplete. Please contact support.")
+
+    expected_digits = profile.citizen_id[-settings.ADMISSION_CONFIRM_CCCD_DIGITS:]
+
+    # Constant-time compare via ``hmac.compare_digest`` per plan v2
+    # RC2 mitigation (no timing leak). The decision to compare the
+    # last-4 digits — not the full CCCD — matches the existing
+    # /confirm/{token} contract and the candidate-facing 4-key UX.
+    if not hmac.compare_digest(cccd_last4, expected_digits):
+        # Delegate brute-force counter bookkeeping to the existing
+        # CCCD ladder logic in ``verify_and_confirm`` rather than
+        # duplicate ~70 lines of cooldown/hard-lock/dispatch. We
+        # invoke the legacy path with the same digits so the existing
+        # audit + dispatch + lock_count bookkeeping fires under the
+        # exact same row lock we are still holding.
+        # The legacy function raises ``BadRequest`` (or attaches a
+        # post-commit callback for the hard-lock case) — we propagate.
+        await admission_service.verify_and_confirm(
+            db=db,
+            token_value=token_value,
+            last_digits=cccd_last4,
+        )
+        # Unreachable: the legacy path raises BadRequest on CCCD
+        # mismatch. Defensive raise so the type checker can prove
+        # the function returns a tuple on every branch below.
+        raise BadRequest("CCCD verification failed")
+
+    # Step 6 — Dispatch the action handler. Each handler is responsible
+    # for the state mutation + dispatch + returning a post_commit
+    # callback that the router awaits after ``db.commit()``.
+    if action == "confirm":
+        # Delegate wholesale to the proven confirm flow. We re-enter
+        # ``verify_and_confirm`` with the correct CCCD — it will
+        # short-circuit the freshness gates (still satisfied), pass
+        # the CCCD check, atomic-update confirmed_at, dispatch the
+        # APPLICATION_CONFIRMED event, and hand back the callback.
+        # Cost: one extra ``get_token_for_confirm`` round-trip inside
+        # the legacy function. Acceptable for shipping infrastructure
+        # without duplicating 200 lines of state-machine code.
+        result_profile, callback = await admission_service.verify_and_confirm(
+            db=db,
+            token_value=token_value,
+            last_digits=cccd_last4,
+        )
+        return result_profile, callback
+
+    # PR-CO-2-BE follow-up scope (FU PR-CO-2-BE-2): wire submit /
+    # resubmit / withdraw handlers. Stubbed 501 here so the router
+    # surface ships intact for the FE landing pages; activating the
+    # remaining 3 actions is BE-only and can land without a new FE
+    # deploy. Tracked in plan v2 Day 5 follow-up.
+    log.warning(
+        "Magic-link action not yet wired",
+        action=action,
+        profile_id=profile.id,
+        token_prefix=token_value[:8],
+    )
+    raise BusinessRuleViolation(
+        f"Magic-link action '{action}' is not yet enabled. "
+        "Please use the in-app workflow for now."
+    )

--- a/Backend_FastAPI/tests/api/test_phase3_pr3e_magic_link.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3e_magic_link.py
@@ -1,0 +1,293 @@
+"""PR-CO-2-BE / PR-3E — Integration tests cho multi-action magic-link
+consume endpoint.
+
+Endpoint under test:
+- POST /api/v2/admissions/magic-link/{action}/{token}
+
+5 contract tests:
+1. Happy path confirm: valid token + correct CCCD last4 → 200, profile.status='confirmed'
+2. Action enum mismatch: URL action ≠ token row action_type → 404 (anti-enumeration)
+3. CCCD wrong: increments attempt_count + returns 400 + cooldown applied
+4. Expired token: expires_at in past → 400
+5. Not-yet-wired actions (submit/resubmit/withdraw): → 400 BusinessRuleViolation
+
+Race + per-token rate-limit tests deferred to FU PR-CO-2-BE-2 (need concurrent
+client harness + Redis mocking).
+
+Non-tautological per memory `pattern-change-impact-audit`: each test asserts
+SPECIFIC status code + response body shape OR DB state mutation.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+
+
+log = logging.getLogger(__name__)
+
+
+# ============================================================================
+# Seed: AdmissionProfile (approved + citizen_id) + AdmissionConfirmationToken
+# ============================================================================
+
+
+@pytest_asyncio.fixture
+async def magic_link_seed(seed_lead_dependencies: dict) -> dict:
+    """Seed an approved AdmissionProfile + a fresh ``confirm`` token.
+
+    Returns:
+        dict with profile_id, lead_id, token, citizen_id, last4.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    citizen_id = f"7{ts:08d}1"[:12]
+    last4 = citizen_id[-4:]
+    token_value = secrets.token_urlsafe(32)
+
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            lead = models.Lead(
+                full_name=f"PR-3E Lead {ts}",
+                phone=f"097{ts:07d}"[:10],
+                unit_id=seed_lead_dependencies["unit_id"],
+                pipeline_stage_id=seed_lead_dependencies["stage_id"],
+                source="walkin",
+            )
+            s.add(lead)
+            await s.flush()
+
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                citizen_id=citizen_id,
+                status="approved",
+                applied_rules={},
+                academic_year=2026,
+            )
+            s.add(profile)
+            await s.flush()
+
+            token = models.AdmissionConfirmationToken(
+                profile_id=profile.id,
+                action_type="confirm",
+                token=token_value,
+                expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+                confirmed_at=None,
+                attempt_count=0,
+            )
+            s.add(token)
+            await s.flush()
+
+            return {
+                "profile_id": profile.id,
+                "lead_id": lead.id,
+                "token": token_value,
+                "citizen_id": citizen_id,
+                "last4": last4,
+            }
+
+
+# ============================================================================
+# 1. Happy path: confirm action with correct CCCD last 4
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_consume_confirm_happy_path(
+    client: AsyncClient,
+    magic_link_seed: dict,
+):
+    """POST /magic-link/confirm/{token} with correct CCCD → 200 + status='confirmed'."""
+    response = await client.post(
+        f"/api/v2/admissions/magic-link/confirm/{magic_link_seed['token']}",
+        json={"cccd": magic_link_seed["last4"]},
+    )
+    assert response.status_code == 200, (
+        f"Expected 200; got {response.status_code}: {response.text}"
+    )
+    body = response.json()
+    assert body["profile_id"] == magic_link_seed["profile_id"]
+    assert body["action"] == "confirm"
+    assert body["status"] == "confirmed"
+    assert body["consumed_at"] is not None
+
+    # DB state mutation check
+    async with AsyncSessionLocal() as s:
+        profile = await s.get(models.AdmissionProfile, magic_link_seed["profile_id"])
+        assert profile.status == "confirmed"
+        assert profile.confirmed_at is not None
+
+        token_q = await s.execute(
+            select(models.AdmissionConfirmationToken).where(
+                models.AdmissionConfirmationToken.token == magic_link_seed["token"]
+            )
+        )
+        token = token_q.scalar_one()
+        assert token.confirmed_at is not None, "Token must be marked consumed"
+
+
+# ============================================================================
+# 2. Action enum mismatch: URL says 'submit' but token is 'confirm' → 404
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_consume_action_mismatch_returns_404(
+    client: AsyncClient,
+    magic_link_seed: dict,
+):
+    """URL action 'submit' on a 'confirm' token → 404 (anti-enumeration).
+
+    Same response shape as "token not found" — do not leak whether the token
+    exists for a different action_type.
+    """
+    response = await client.post(
+        f"/api/v2/admissions/magic-link/submit/{magic_link_seed['token']}",
+        json={"cccd": magic_link_seed["last4"]},
+    )
+    assert response.status_code == 404, (
+        f"Expected 404; got {response.status_code}: {response.text}"
+    )
+
+    # Token row should NOT have been mutated (no consume, no attempt bump)
+    async with AsyncSessionLocal() as s:
+        token_q = await s.execute(
+            select(models.AdmissionConfirmationToken).where(
+                models.AdmissionConfirmationToken.token == magic_link_seed["token"]
+            )
+        )
+        token = token_q.scalar_one()
+        assert token.confirmed_at is None, "Mismatched action must NOT consume token"
+        assert token.attempt_count == 0, "Mismatched action must NOT bump attempts"
+
+
+# ============================================================================
+# 3. CCCD wrong: attempt_count++ + 400 BadRequest
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_consume_cccd_wrong_returns_400_and_increments_attempts(
+    client: AsyncClient,
+    magic_link_seed: dict,
+):
+    """Wrong CCCD last4 → 400 + attempt_count incremented + token NOT consumed."""
+    response = await client.post(
+        f"/api/v2/admissions/magic-link/confirm/{magic_link_seed['token']}",
+        json={"cccd": "0000"},  # last 4 cannot start with 0000 in our fixture
+    )
+    assert response.status_code == 400, (
+        f"Expected 400; got {response.status_code}: {response.text}"
+    )
+
+    async with AsyncSessionLocal() as s:
+        token_q = await s.execute(
+            select(models.AdmissionConfirmationToken).where(
+                models.AdmissionConfirmationToken.token == magic_link_seed["token"]
+            )
+        )
+        token = token_q.scalar_one()
+        assert token.confirmed_at is None, "Wrong CCCD must NOT consume token"
+        assert token.attempt_count >= 1, "Wrong CCCD must bump attempt_count"
+
+
+# ============================================================================
+# 4. Expired token: 400 BadRequest
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_consume_expired_token_returns_400(
+    client: AsyncClient,
+    magic_link_seed: dict,
+):
+    """Token with expires_at in the past → 400 with 'expired' phrasing."""
+    # Backdate the token to be expired
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            token_q = await s.execute(
+                select(models.AdmissionConfirmationToken).where(
+                    models.AdmissionConfirmationToken.token == magic_link_seed["token"]
+                )
+            )
+            token = token_q.scalar_one()
+            token.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+
+    response = await client.post(
+        f"/api/v2/admissions/magic-link/confirm/{magic_link_seed['token']}",
+        json={"cccd": magic_link_seed["last4"]},
+    )
+    assert response.status_code == 400, (
+        f"Expected 400 for expired; got {response.status_code}: {response.text}"
+    )
+    assert "expired" in response.text.lower() or "hết hạn" in response.text.lower()
+
+
+# ============================================================================
+# 5. Not-yet-wired actions stub return 400 BusinessRuleViolation
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_consume_withdraw_action_returns_400_not_implemented(
+    client: AsyncClient,
+    seed_lead_dependencies: dict,
+):
+    """Token issued with action_type='withdraw' → 400 'not yet enabled'.
+
+    PR-CO-2-BE infrastructure ships the 4-action router surface but only
+    wires the confirm handler. submit/resubmit/withdraw are stubbed as
+    BusinessRuleViolation pending FU PR-CO-2-BE-2.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    citizen_id = f"7{ts:08d}2"[:12]
+    last4 = citizen_id[-4:]
+    token_value = secrets.token_urlsafe(32)
+
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            lead = models.Lead(
+                full_name=f"PR-3E Withdraw Lead {ts}",
+                phone=f"096{ts:07d}"[:10],
+                unit_id=seed_lead_dependencies["unit_id"],
+                pipeline_stage_id=seed_lead_dependencies["stage_id"],
+                source="walkin",
+            )
+            s.add(lead)
+            await s.flush()
+
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                citizen_id=citizen_id,
+                status="submitted",
+                applied_rules={},
+                academic_year=2026,
+            )
+            s.add(profile)
+            await s.flush()
+
+            token = models.AdmissionConfirmationToken(
+                profile_id=profile.id,
+                action_type="withdraw",
+                token=token_value,
+                expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+                confirmed_at=None,
+                attempt_count=0,
+            )
+            s.add(token)
+
+    response = await client.post(
+        f"/api/v2/admissions/magic-link/withdraw/{token_value}",
+        json={"cccd": last4},
+    )
+    assert response.status_code == 400, (
+        f"Expected 400 for not-yet-wired; got {response.status_code}: {response.text}"
+    )
+    assert "not yet enabled" in response.text.lower() or "withdraw" in response.text.lower()


### PR DESCRIPTION
## Summary

**PR-CO-2-BE** (Phase 3 close-out plan v2 LOCKED 2026-05-14 — P0):

- POST `/api/v2/admissions/magic-link/{action}/{token}` — multi-action public consume endpoint
- 4-action enum at URL path + DB CHECK: `submit | resubmit | confirm | withdraw`
- Body: `{ cccd: str }` (last 4 digits, regex-locked)
- **confirm action wired** (delegates to proven `verify_and_confirm`); submit/resubmit/withdraw stub 400 "not yet enabled" — FU PR-CO-2-BE-2

**Wave A acceptance gate "Magic-link confirm consume atomic"**: satisfied by ADM-013 3-step profile-first lock — profile FOR UPDATE + token FOR UPDATE + `confirmed_at IS NULL` predicate serialises concurrent consumes to a single winner.

## Files (7)

| File | Status | Purpose |
|---|---|---|
| `services/magic_link_rate_limit.py` | NEW | Redis per-token 5/60s, fail-closed |
| `services/magic_link_service.py` | NEW | consume_token orchestrator (5 step) |
| `schemas/magic_link.py` | NEW | Pydantic enum + request/response |
| `routers/admissions_magic_link.py` | NEW | Public endpoint + slowapi limits |
| `middleware/csrf.py` | MOD | Exempt `/api/v2/admissions/magic-link/` |
| `main.py` | MOD | Include new router |
| `tests/api/test_phase3_pr3e_magic_link.py` | NEW | 5 contract tests |

## Security

- **CCCD**: `hmac.compare_digest` constant-time (RC2 timing-attack mitigation)
- **3-layer rate limits**:
  1. Redis per-token `mlt:{token}` 5/60s (this PR)
  2. slowapi DATA_WRITE 200/hour (global)
  3. slowapi 100/day per IP (brute-force)
- **CCCD brute force**: existing ADM-023 cooldown ladder + 30-fail hard-lock (delegated via `verify_and_confirm`)
- **404 anti-enumeration**: returned for both "wrong token" and "wrong action_type"
- **CSRF**: exempt prefix added — candidates have no CSRF cookie

## Test plan

Local: **5/5 PASSED in 19.09s**
- happy_path confirm → 200 + DB status='confirmed' + token.confirmed_at set
- action mismatch → 404 + NO mutation (token untouched)
- CCCD wrong → 400 + attempt_count incremented
- expired token → 400
- withdraw action stub → 400 "not yet enabled"

Regression: `test_admission_workflow_api.py` exit 0 (background-verified pre-push).

## Scope decisions

**1. confirm wired only**: this PR ships the 4-action ROUTER SURFACE complete + INFRASTRUCTURE (rate limit, CSRF exempt, atomic consume pattern, hmac compare, action enum match). The confirm handler delegates to proven `verify_and_confirm` (full ADM-023 cooldown + hard-lock + audit + dispatch). submit/resubmit/withdraw stub 400 — wires in FU PR-CO-2-BE-2 (BE-only, no FE blocker).

**2. Last-4 CCCD compare (not full 12-digit)**: matches existing `/confirm/{token}` legacy contract + 4-key candidate UX. Stronger hmac.compare_digest constant-time still applied. Future-compat: schema validator can extend to 12-digit if product wants.

**3. Backward compat**: legacy `/api/admissions/confirm/{token}` untouched. FE consolidation in PR-CO-2-FE.

## Follow-ups (FU PR-CO-2-BE-2)

- Wire submit handler → delegate to `admission_service.submit_profile` with `actor=None + source='magic_link'`
- Wire resubmit handler → same pattern for `resubmit_profile`
- Wire withdraw handler → `withdraw_profile` already anticipates `actor=None` at line 7074
- Race test (concurrent consume harness) + per-token rate-limit test (Redis mock)

## Memory references

- `audit-before-fix` — verified ADM-013 lock + phase1_18 migration in place
- `verify-schema-before-proposing` — citizen_id + action_type 4-enum + partial UNIQUE
- `pattern-change-impact-audit` — delegate to verify_and_confirm (no logic duplication)
- `solo-dev-aggressive-wave-ship` — auto-monitor CI + auto-merge per close-out wave

## Next: PR-CO-2-FE

After this PR merges, PR-CO-2-FE delivers 4 magic-link landing pages at `app/magic-link/[action]/[token]/page.tsx` (ROOT, NOT in `(auth)/` group per plan v2 C3 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)