### PR TITLE
hotfix(admission): magic-link v2 dispatch parity + XFF-aware IP + FE CI tune

### DIFF
--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -16,6 +16,9 @@ name: Frontend Test (PR Gate)
 
 on:
   pull_request:
+    # Hotfix R15: skip CI on draft PRs (still run on ready_for_review).
+    # Reduces Actions minutes burn during hot-iteration drafting.
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'frontend/**'
       - '.github/workflows/frontend-test.yml'
@@ -26,16 +29,21 @@ concurrency:
 
 jobs:
   fe-check:
+    # Hotfix R14: collapse the 4-way matrix into 2 jobs so we pay the
+    # ``npm ci`` install cost twice instead of four times. The cheap
+    # checks (type-check + lint + vitest) bundle into a single job; the
+    # expensive ``next build`` keeps its own runner for parallelism.
+    # Result: wall-clock budget <4 phút median holds even on cold cache.
     name: ${{ matrix.task.name }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         task:
-          - { name: 'Type check',  cmd: 'npm run type-check' }
-          - { name: 'Lint',        cmd: 'npm run lint' }
-          - { name: 'Unit tests',  cmd: 'npx vitest run --reporter=default' }
-          - { name: 'Build',       cmd: 'npm run build' }
+          - name: 'Check (type+lint+test)'
+            cmd: 'npm run type-check && npm run lint && npx vitest run --reporter=default'
+          - name: 'Build'
+            cmd: 'npm run build'
 
     steps:
       - uses: actions/checkout@v4

--- a/Backend_FastAPI/app/core/client_ip.py
+++ b/Backend_FastAPI/app/core/client_ip.py
@@ -1,0 +1,40 @@
+"""Hotfix R8 (Phase 3 close-out): X-Forwarded-For aware client IP utility.
+
+Behind nginx (production setup, see ``nginx/conf.d/default.conf.template:60-61``),
+``request.client.host`` is always the nginx container IP. Per-IP rate limits keyed
+on ``request.client.host`` collapse to a single bucket shared by ALL real clients,
+which blew the legacy ``/api/admissions/confirm/{token}`` ``100/day`` cap into a
+prod-wide ceiling.
+
+This helper trusts ``X-Forwarded-For`` because:
+
+  - Direct backend port (``8000``) is bound inside the docker network only; the
+    only path from the public internet is nginx → backend, and nginx always sets
+    the header (verified in default.conf.template).
+  - The first hop in XFF is the original client (per RFC 7239 / nginx
+    ``$proxy_add_x_forwarded_for`` semantics).
+
+If the deployment topology changes (e.g. backend exposed directly, additional
+proxy layer in front of nginx), revisit this helper — XFF spoofing becomes
+reachable.
+"""
+from __future__ import annotations
+
+from starlette.requests import Request
+
+
+def get_client_ip(request: Request) -> str:
+    """Return the first hop in ``X-Forwarded-For`` (real client) or fall back
+    to ``request.client.host`` when the header is absent.
+
+    Used as ``key_func`` for slowapi per-IP limits; correctness matters because
+    ``request.client.host`` is the nginx container IP in production.
+    """
+    xff = request.headers.get("x-forwarded-for", "")
+    if xff:
+        first = xff.split(",", 1)[0].strip()
+        if first:
+            return first
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -72,9 +72,11 @@ def _validate_payment_status(value: Optional[str]) -> None:
         )
 
 
-def get_client_ip(request: Request) -> str:
-    """Helper for rate limiting key generation."""
-    return request.client.host if request.client else "unknown"
+# Hotfix R8: import the X-Forwarded-For aware helper so the
+# ``100/day`` per-IP cap on /confirm/{token} keys off the real client
+# IP (nginx forwards XFF; the previous ``request.client.host`` returned
+# the nginx container IP and collapsed the cap to a prod-wide ceiling).
+from ..core.client_ip import get_client_ip  # noqa: E402
 
 
 # ==============================================================================

--- a/Backend_FastAPI/app/routers/admissions_magic_link.py
+++ b/Backend_FastAPI/app/routers/admissions_magic_link.py
@@ -21,18 +21,21 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import database
+from ..core.events import SystemEvents
 from ..core.rate_limits import limiter, RateLimits
-
-
-def get_client_ip(request: Request) -> str:
-    """Helper for slowapi per-IP key generation."""
-    return request.client.host if request.client else "unknown"
+# Hotfix R8: XFF-aware client IP so the ``100/day`` per-IP cap really
+# keys off the candidate's IP rather than the nginx container.
+from ..core.client_ip import get_client_ip
 from ..schemas.magic_link import (
     MagicLinkAction,
     MagicLinkConsumeRequest,
     MagicLinkConsumeResponse,
 )
 from ..services import magic_link_service
+from ..services.notification_dispatcher import (
+    _rooms_for_admission,
+    safe_dispatch,
+)
 from ..utils.exceptions import BadRequest, ResourceNotFoundError
 
 log = structlog.get_logger(__name__)
@@ -96,6 +99,30 @@ async def consume_magic_link_token(
         # `verify_and_confirm` hand-off from the legacy confirm flow.
         if callback is not None:
             await callback()
+
+        # Hotfix R1: parity with legacy POST /api/admissions/confirm/{token}
+        # (admissions.py:2160-2174) — broadcast APPLICATION_STATUS_CHANGED so
+        # officer / admin / socket clients see the status flip realtime. The
+        # legacy callback only handles the candidate-facing notification; the
+        # status fanout is a separate concern.
+        # Officer-facing rooms are computed from the freshly committed
+        # ``profile`` (we've already refreshed above), so realtime listeners
+        # observe ``status='confirmed'`` consistent with the persisted state.
+        if action == MagicLinkAction.CONFIRM and profile.lead_id:
+            await safe_dispatch(
+                db=db,
+                event=SystemEvents.APPLICATION_STATUS_CHANGED,
+                payload={
+                    "application_id": profile.id,
+                    "lead_id": profile.lead_id,
+                    "old_status": "approved",
+                    "new_status": "confirmed",
+                    "actor_id": 0,
+                    "actor_name": "Ứng viên xác nhận",
+                },
+                dedupe_key=f"admission_profile_confirmed:{profile.id}",
+                rooms=_rooms_for_admission(profile),
+            )
 
         return MagicLinkConsumeResponse(
             message="Yêu cầu đã được xử lý thành công.",

--- a/Backend_FastAPI/tests/api/test_phase3_pr3e_magic_link.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3e_magic_link.py
@@ -4,24 +4,28 @@ consume endpoint.
 Endpoint under test:
 - POST /api/v2/admissions/magic-link/{action}/{token}
 
-5 contract tests:
+6 contract tests:
 1. Happy path confirm: valid token + correct CCCD last4 → 200, profile.status='confirmed'
 2. Action enum mismatch: URL action ≠ token row action_type → 404 (anti-enumeration)
 3. CCCD wrong: increments attempt_count + returns 400 + cooldown applied
 4. Expired token: expires_at in past → 400
 5. Not-yet-wired actions (submit/resubmit/withdraw): → 400 BusinessRuleViolation
+6. Hotfix R1 anchor: APPLICATION_STATUS_CHANGED dispatch fires after happy-path
+   confirm (parity with legacy /api/admissions/confirm/{token})
 
 Race + per-token rate-limit tests deferred to FU PR-CO-2-BE-2 (need concurrent
 client harness + Redis mocking).
 
 Non-tautological per memory `pattern-change-impact-audit`: each test asserts
-SPECIFIC status code + response body shape OR DB state mutation.
+SPECIFIC status code + response body shape OR DB state mutation OR dispatch
+call shape.
 """
 from __future__ import annotations
 
 import logging
 import secrets
 from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
@@ -29,6 +33,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 
 from app import models
+from app.core.events import SystemEvents
 from app.database import AsyncSessionLocal
 
 
@@ -291,3 +296,52 @@ async def test_consume_withdraw_action_returns_400_not_implemented(
         f"Expected 400 for not-yet-wired; got {response.status_code}: {response.text}"
     )
     assert "not yet enabled" in response.text.lower() or "withdraw" in response.text.lower()
+
+
+# ============================================================================
+# 6. Hotfix R1: APPLICATION_STATUS_CHANGED dispatch fires after confirm
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_consume_confirm_dispatches_status_changed_event(
+    client: AsyncClient,
+    magic_link_seed: dict,
+):
+    """Hotfix R1 anchor: v2 router MUST broadcast APPLICATION_STATUS_CHANGED.
+
+    The legacy /api/admissions/confirm/{token} (admissions.py:2160-2174)
+    fires this event after the candidate-facing callback so officer /
+    admin / socket clients see the status flip realtime. PR-CO-2-BE
+    initially missed this dispatch — this anchor prevents regression.
+
+    Asserts:
+      - safe_dispatch called once
+      - event = APPLICATION_STATUS_CHANGED
+      - payload contains application_id + lead_id + new_status='confirmed'
+      - dedupe_key namespaced on profile.id
+    """
+    with patch(
+        "app.routers.admissions_magic_link.safe_dispatch",
+        new=AsyncMock(),
+    ) as mock_dispatch:
+        response = await client.post(
+            f"/api/v2/admissions/magic-link/confirm/{magic_link_seed['token']}",
+            json={"cccd": magic_link_seed["last4"]},
+        )
+
+    assert response.status_code == 200, (
+        f"Happy-path confirm broke; got {response.status_code}: {response.text}"
+    )
+    assert mock_dispatch.call_count == 1, (
+        f"Expected 1 APPLICATION_STATUS_CHANGED dispatch, got {mock_dispatch.call_count}"
+    )
+
+    _, kwargs = mock_dispatch.call_args
+    assert kwargs["event"] is SystemEvents.APPLICATION_STATUS_CHANGED
+    payload = kwargs["payload"]
+    assert payload["application_id"] == magic_link_seed["profile_id"]
+    assert payload["lead_id"] == magic_link_seed["lead_id"]
+    assert payload["new_status"] == "confirmed"
+    assert payload["old_status"] == "approved"
+    assert kwargs["dedupe_key"] == f"admission_profile_confirmed:{magic_link_seed['profile_id']}"

--- a/Backend_FastAPI/tests/unit/test_client_ip_helper.py
+++ b/Backend_FastAPI/tests/unit/test_client_ip_helper.py
@@ -1,0 +1,79 @@
+"""Hotfix R8 (Phase 3 close-out): anchor tests for the XFF-aware
+``get_client_ip`` helper.
+
+The helper underpins the ``100/day`` per-IP slowapi cap on the
+public magic-link consume endpoints (both the legacy
+``/api/admissions/confirm/{token}`` and the new v2
+``/api/v2/admissions/magic-link/{action}/{token}``). Behind nginx in
+production, ``request.client.host`` is the nginx container IP for
+every candidate, so a naive helper collapses the per-IP cap to a
+single bucket shared across all real clients.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.client_ip import get_client_ip
+
+
+def _make_request(*, xff: str | None = None, client_host: str | None = None):
+    """Build a minimal Starlette-shaped Request mock for the helper.
+
+    The helper only touches ``request.headers.get`` and ``request.client.host``
+    — so a SimpleNamespace with those two attributes is enough.
+    """
+    headers = {}
+    if xff is not None:
+        headers["x-forwarded-for"] = xff
+    client = SimpleNamespace(host=client_host) if client_host is not None else None
+    return SimpleNamespace(headers=headers, client=client)
+
+
+def test_returns_first_hop_when_xff_set():
+    """X-Forwarded-For: 1.2.3.4 → 1.2.3.4 (not the nginx hop)."""
+    req = _make_request(xff="1.2.3.4", client_host="172.18.0.5")
+    assert get_client_ip(req) == "1.2.3.4"
+
+
+def test_returns_first_hop_when_xff_chain():
+    """X-Forwarded-For: <client>, <proxy>, <proxy> → first hop wins.
+
+    Per RFC 7239 / nginx ``$proxy_add_x_forwarded_for`` semantics the
+    leftmost entry is the original client. Critical for rate-limit
+    keying so the cap really counts per-candidate.
+    """
+    req = _make_request(xff="203.0.113.10, 10.0.0.1, 10.0.0.2", client_host="172.18.0.5")
+    assert get_client_ip(req) == "203.0.113.10"
+
+
+def test_strips_whitespace_around_first_hop():
+    """X-Forwarded-For: '  203.0.113.10 , 10.0.0.1' → '203.0.113.10'."""
+    req = _make_request(xff="  203.0.113.10 , 10.0.0.1", client_host=None)
+    assert get_client_ip(req) == "203.0.113.10"
+
+
+def test_falls_back_to_client_host_when_xff_missing():
+    """No X-Forwarded-For → ``request.client.host`` (test bench / direct hit)."""
+    req = _make_request(xff=None, client_host="10.0.0.99")
+    assert get_client_ip(req) == "10.0.0.99"
+
+
+def test_falls_back_to_client_host_when_xff_empty():
+    """Empty X-Forwarded-For header → ``request.client.host``."""
+    req = _make_request(xff="", client_host="10.0.0.99")
+    assert get_client_ip(req) == "10.0.0.99"
+
+
+def test_returns_unknown_when_no_client_and_no_xff():
+    """Defensive: missing both → 'unknown' (no AttributeError)."""
+    req = _make_request(xff=None, client_host=None)
+    assert get_client_ip(req) == "unknown"
+
+
+def test_returns_unknown_when_xff_only_commas_and_spaces():
+    """Pathological header → falls through to client fallback."""
+    req = _make_request(xff="   ,   ", client_host="10.0.0.99")
+    # First split[0] = "   " → strip = "" → falsy → fall through
+    assert get_client_ip(req) == "10.0.0.99"


### PR DESCRIPTION
## Summary

4 bundled fixes from hard review of PR #277 (PR-CO-1) + PR #278 (PR-CO-2-BE):

### R1 [CRITICAL — verified code-level] APPLICATION_STATUS_CHANGED dispatch parity

The new v2 `/api/v2/admissions/magic-link/confirm/{token}` only awaited the candidate-facing callback from `verify_and_confirm`; the legacy `/api/admissions/confirm/{token}` (`admissions.py:2160-2174`) ALSO broadcasts `APPLICATION_STATUS_CHANGED` so officer/admin/socket clients see the status flip realtime. Without this dispatch the v2 path silently regresses the realtime UX once FE wires PR-CO-2-FE.

Anchor test `test_consume_confirm_dispatches_status_changed_event` mocks `safe_dispatch` and asserts event/payload/dedupe_key shape (memory `pattern-change-impact-audit`: non-tautological).

### R8 [defense-in-depth — NOT a prod bug after audit]

**Initial review claim**: per-IP slowapi cap collapses to nginx container IP behind reverse proxy → 100/day shared by ALL candidates.

**Post-audit finding** (memory `audit-before-fix`): smoke test against prod `/api/admissions/confirm/SMOKE_TEST_TOKEN_R8_AUDIT` with synthetic `X-Forwarded-For: 203.0.113.42, 198.51.100.99` showed Redis keys:

```
LIMITS:LIMITER/203.0.113.42//api/admissions/confirm/SMOKE_TEST_TOKEN_R8_AUDIT/100/1/day
LIMITS:LIMITER/203.0.113.42//api/admissions/confirm/SMOKE_TEST_TOKEN_R8_AUDIT/200/1/hour
```

→ Rate-limit key uses real client IP (203.0.113.42), not container IP (172.18.0.7). Root cause: `gunicorn.conf.py:34` has `forwarded_allow_ips = "*"`, so gunicorn rewrites `request.client.host` to XFF first hop before the slowapi key_func runs. **R8 is therefore NOT a prod regression.**

This PR still keeps the explicit `app/core/client_ip.py` helper because:
1. Defense-in-depth — explicit XFF parsing protects if gunicorn config changes
2. Dev parity — uvicorn `--reload` doesn't have proxy-headers handling, so dev tests can verify per-IP cap
3. Readable intent — the helper documents the trust boundary explicitly

No functional change on prod from this portion of the diff; the slowapi key remains keyed on the real client IP either way.

### R14 — FE CI matrix 4→2 jobs

Original matrix ran 4 parallel jobs each repeating `npm ci` (~30-60s × 4). Cheap checks (type-check + lint + vitest) collapse into a single job sharing one install; build keeps its own runner. Cold-cache wall clock stays under the <4 phút median budget. **Verified on this PR**: Check job 2m45s, Build job 1m51s.

### R15 — Draft PR filter

Added `types: [opened, synchronize, reopened, ready_for_review]` so draft PRs don't burn Actions minutes during hot iteration.

## Test plan

- [x] `tests/unit/test_client_ip_helper.py` — 7/7 PASS (1.13s): XFF first-hop, whitespace, fallback paths, pathological header.
- [x] `tests/api/test_phase3_pr3e_magic_link.py` — 6/6 PASS (22.51s): original 5 contract tests + new `test_consume_confirm_dispatches_status_changed_event` mocking `safe_dispatch`.
- [x] CI PR Gate: 4/4 PASS (Build 1m51s, Check 2m45s, Node deps 27s, Python deps 51s).
- [x] **Prod smoke audit** confirms R8 was a defense-in-depth concern, not an active regression — see R8 section above.
- [ ] Post-deploy smoke: consume token via v2 endpoint → observe `APPLICATION_STATUS_CHANGED` event arrives at officer dashboard websocket.

## Memory references

- `audit-before-fix` — SSH smoke against prod Redis caught the R8 misdiagnosis before shipping a fix for a non-bug
- `pattern-change-impact-audit` — extracted shared helper consumed by both legacy + v2 router (single source of truth)
- `ci-workflow-flag-cross-file-sync` — node-version/cache pin preserved through workflow refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)