### PR TITLE
feat(admission): PR-CO-2-FE — PR-3E multi-action magic-link FE landing pages

### DIFF
--- a/frontend/src/app/magic-link/[action]/[token]/page.tsx
+++ b/frontend/src/app/magic-link/[action]/[token]/page.tsx
@@ -1,0 +1,81 @@
+import { Suspense } from "react"
+import { notFound } from "next/navigation"
+import type { Metadata } from "next"
+
+import { MagicLinkConsumeForm } from "@/components/forms/MagicLinkConsumeForm"
+import {
+  magicLinkActionSchema,
+  type MagicLinkAction,
+} from "@/lib/zod/magic-link"
+
+// Per-action page <title>. Falls back to a neutral title if Next.js
+// renders the placeholder build route.
+const PAGE_TITLE: Record<MagicLinkAction, string> = {
+  confirm: "Xác nhận nhập học",
+  submit: "Gửi hồ sơ tuyển sinh",
+  resubmit: "Nộp lại hồ sơ",
+  withdraw: "Rút hồ sơ tuyển sinh",
+}
+
+const PAGE_DESCRIPTION: Record<MagicLinkAction, string> = {
+  confirm: "Xác nhận hồ sơ nhập học của bạn",
+  submit: "Gửi hồ sơ tuyển sinh của bạn",
+  resubmit: "Nộp lại hồ sơ sau khi đã chỉnh sửa",
+  withdraw: "Xác nhận rút hồ sơ tuyển sinh",
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ action: string; token: string }>
+}): Promise<Metadata> {
+  const { action } = await params
+  const parsed = magicLinkActionSchema.safeParse(action)
+  if (!parsed.success) {
+    return { title: "Liên kết không hợp lệ" }
+  }
+  return {
+    title: PAGE_TITLE[parsed.data],
+    description: PAGE_DESCRIPTION[parsed.data],
+  }
+}
+
+// Placeholder params for Next.js 16 cacheComponents build validation.
+// Real {action, token} pairs are resolved at request time; the
+// placeholder route triggers notFound() so no build-time API hit occurs.
+export function generateStaticParams() {
+  return [{ action: "__placeholder__", token: "__placeholder__" }]
+}
+
+export default async function MagicLinkConsumePage({
+  params,
+}: {
+  params: Promise<{ action: string; token: string }>
+}) {
+  const { action, token } = await params
+
+  if (action === "__placeholder__" || token === "__placeholder__") {
+    notFound()
+  }
+
+  // Validate the URL action enum at page boundary — anything outside the
+  // 4-value enum is a malformed link, fail closed with 404.
+  const parsed = magicLinkActionSchema.safeParse(action)
+  if (!parsed.success) {
+    notFound()
+  }
+
+  return (
+    <div className="bg-muted/40 flex min-h-screen items-center justify-center p-4">
+      <Suspense
+        fallback={
+          <div role="status" aria-live="polite" className="text-muted-foreground">
+            Đang tải…
+          </div>
+        }
+      >
+        <MagicLinkConsumeForm action={parsed.data} token={token} />
+      </Suspense>
+    </div>
+  )
+}

--- a/frontend/src/app/magic-link/[action]/[token]/page.tsx
+++ b/frontend/src/app/magic-link/[action]/[token]/page.tsx
@@ -24,6 +24,11 @@ const PAGE_DESCRIPTION: Record<MagicLinkAction, string> = {
   withdraw: "Xác nhận rút hồ sơ tuyển sinh",
 }
 
+// Token URL must not be indexed by search engines. Defense-in-depth —
+// the URL only ships via email, but a leaked screenshot / copy-paste
+// into a public channel must not show up in a crawler index.
+const NOINDEX_ROBOTS = { index: false, follow: false } as const
+
 export async function generateMetadata({
   params,
 }: {
@@ -32,13 +37,19 @@ export async function generateMetadata({
   const { action } = await params
   const parsed = magicLinkActionSchema.safeParse(action)
   if (!parsed.success) {
-    return { title: "Liên kết không hợp lệ" }
+    return { title: "Liên kết không hợp lệ", robots: NOINDEX_ROBOTS }
   }
   return {
     title: PAGE_TITLE[parsed.data],
     description: PAGE_DESCRIPTION[parsed.data],
+    robots: NOINDEX_ROBOTS,
   }
 }
+
+// Token URL pages must never be cached by Next.js / CDN / proxy: each
+// request must hit the BE consume endpoint at request time so the
+// freshness gates (used / locked / expired) reflect server state.
+export const dynamic = "force-dynamic"
 
 // Placeholder params for Next.js 16 cacheComponents build validation.
 // Real {action, token} pairs are resolved at request time; the

--- a/frontend/src/components/forms/MagicLinkConsumeForm.test.tsx
+++ b/frontend/src/components/forms/MagicLinkConsumeForm.test.tsx
@@ -168,6 +168,10 @@ describe("MagicLinkConsumeForm — validation", () => {
     await waitFor(() => {
       expect(mockConsumeMagicLinkToken).not.toHaveBeenCalled()
     })
+    // Strengthen non-tautological: assert the user-visible validation
+    // message renders, otherwise the test only proves react-hook-form's
+    // default-block behaviour rather than this schema's 4-digit rule.
+    expect(screen.getByText(/vui lòng nhập đúng 4 chữ số/i)).toBeInTheDocument()
   })
 })
 

--- a/frontend/src/components/forms/MagicLinkConsumeForm.test.tsx
+++ b/frontend/src/components/forms/MagicLinkConsumeForm.test.tsx
@@ -1,0 +1,278 @@
+// src/components/forms/MagicLinkConsumeForm.test.tsx
+/**
+ * MagicLinkConsumeForm UI Contract Tests (PR-CO-2-FE / PR-3E)
+ *
+ * Covers:
+ *   - per-action title + button label render for all 4 actions
+ *   - form validation (empty submit blocked, 4-digit regex enforced)
+ *   - happy path → success banner + success toast
+ *   - error path (BE 400) → handleApiError called, input reset, form stays mounted
+ *   - per-action mutation payload + URL action sent unchanged
+ *
+ * Non-tautological: API mock fn is asserted with exact (action, token, body)
+ * tuple per memory `pattern-change-impact-audit`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+
+import { createTestQueryClient } from "@/test/utils/test-utils"
+import type { MagicLinkAction } from "@/lib/zod/magic-link"
+
+// Mock InputOTP with a controlled single input — round-trip value only.
+vi.mock("@/components/ui/input-otp", () => ({
+  InputOTP: ({
+    value,
+    onChange,
+    disabled,
+  }: {
+    value: string
+    onChange: (v: string) => void
+    disabled?: boolean
+  }) => (
+    <input
+      data-testid="cccd-input"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+    />
+  ),
+  InputOTPGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  InputOTPSlot: () => null,
+}))
+
+// Mock sonner toast.
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+// Mock the API client function the hook delegates to. Capture
+// (action, token, body) for assertion.
+const mockConsumeMagicLinkToken = vi.fn()
+vi.mock("@/lib/api/magic-link", () => ({
+  consumeMagicLinkToken: (...args: unknown[]) =>
+    mockConsumeMagicLinkToken(...args),
+}))
+
+// Mock handleApiError so we don't render its toasts; just verify the
+// onError branch was reached.
+const mockHandleApiError = vi.fn()
+vi.mock("@/lib/error-handler", () => ({
+  handleApiError: (...args: unknown[]) => mockHandleApiError(...args),
+}))
+
+// Import AFTER mocks
+import { MagicLinkConsumeForm } from "./MagicLinkConsumeForm"
+import { toast } from "sonner"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function withProviders(ui: React.ReactElement, client?: QueryClient) {
+  const queryClient = client ?? createTestQueryClient()
+  return {
+    queryClient,
+    ...render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>),
+  }
+}
+
+function buildSuccessResponse(
+  action: MagicLinkAction,
+  status: string = "confirmed",
+) {
+  return {
+    message: "Yêu cầu đã được xử lý thành công.",
+    profile_id: 42,
+    action,
+    status,
+    consumed_at: "2026-05-14T10:00:00Z",
+    next_url: null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-action render tests
+// ---------------------------------------------------------------------------
+
+describe("MagicLinkConsumeForm — per-action render", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each([
+    ["confirm" as MagicLinkAction, /xác nhận nhập học/i, /xác nhận nhập học/i],
+    ["submit" as MagicLinkAction, /gửi hồ sơ tuyển sinh/i, /gửi hồ sơ/i],
+    ["resubmit" as MagicLinkAction, /nộp lại hồ sơ/i, /nộp lại/i],
+    ["withdraw" as MagicLinkAction, /rút hồ sơ tuyển sinh/i, /xác nhận rút hồ sơ/i],
+  ])(
+    "action=%s renders correct heading + button label",
+    (action, titleRegex, buttonRegex) => {
+      withProviders(<MagicLinkConsumeForm action={action} token="t1" />)
+
+      expect(
+        screen.getByRole("heading", { name: titleRegex }),
+      ).toBeInTheDocument()
+      // data-testid is stable across action labels — assert text on it
+      const submitBtn = screen.getByTestId("magic-link-submit")
+      expect(submitBtn).toBeInTheDocument()
+      expect(submitBtn).toHaveTextContent(buttonRegex)
+      expect(screen.getByTestId("cccd-input")).toBeInTheDocument()
+    },
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Form validation tests
+// ---------------------------------------------------------------------------
+
+describe("MagicLinkConsumeForm — validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("blocks submit when CCCD is empty (zod regex fails)", async () => {
+    withProviders(<MagicLinkConsumeForm action="confirm" token="t1" />)
+
+    fireEvent.click(screen.getByTestId("magic-link-submit"))
+
+    await waitFor(() => {
+      expect(mockConsumeMagicLinkToken).not.toHaveBeenCalled()
+    })
+    expect(screen.getByText(/vui lòng nhập đúng 4 chữ số/i)).toBeInTheDocument()
+  })
+
+  it("blocks submit when CCCD contains non-digits", async () => {
+    withProviders(<MagicLinkConsumeForm action="confirm" token="t1" />)
+
+    fireEvent.change(screen.getByTestId("cccd-input"), {
+      target: { value: "12ab" },
+    })
+    fireEvent.click(screen.getByTestId("magic-link-submit"))
+
+    await waitFor(() => {
+      expect(mockConsumeMagicLinkToken).not.toHaveBeenCalled()
+    })
+    expect(screen.getByText(/vui lòng nhập đúng 4 chữ số/i)).toBeInTheDocument()
+  })
+
+  it("blocks submit when CCCD is < 4 digits", async () => {
+    withProviders(<MagicLinkConsumeForm action="confirm" token="t1" />)
+
+    fireEvent.change(screen.getByTestId("cccd-input"), {
+      target: { value: "12" },
+    })
+    fireEvent.click(screen.getByTestId("magic-link-submit"))
+
+    await waitFor(() => {
+      expect(mockConsumeMagicLinkToken).not.toHaveBeenCalled()
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Happy path test
+// ---------------------------------------------------------------------------
+
+describe("MagicLinkConsumeForm — happy path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("submits (action, token, body) and renders success banner", async () => {
+    mockConsumeMagicLinkToken.mockResolvedValueOnce(
+      buildSuccessResponse("confirm"),
+    )
+
+    withProviders(<MagicLinkConsumeForm action="confirm" token="tok123" />)
+
+    fireEvent.change(screen.getByTestId("cccd-input"), {
+      target: { value: "1234" },
+    })
+    fireEvent.click(screen.getByTestId("magic-link-submit"))
+
+    await waitFor(() => {
+      expect(mockConsumeMagicLinkToken).toHaveBeenCalledWith(
+        "confirm",
+        "tok123",
+        { cccd: "1234" },
+      )
+    })
+
+    // Success banner replaces the form
+    expect(
+      await screen.findByText(/xác nhận nhập học thành công/i),
+    ).toBeInTheDocument()
+    expect(toast.success).toHaveBeenCalled()
+    // Form input is unmounted in the success state
+    expect(screen.queryByTestId("cccd-input")).not.toBeInTheDocument()
+  })
+
+  it("threads the URL action through to the API mock unchanged (submit)", async () => {
+    mockConsumeMagicLinkToken.mockResolvedValueOnce(
+      buildSuccessResponse("submit", "submitted"),
+    )
+
+    withProviders(<MagicLinkConsumeForm action="submit" token="tok-sub" />)
+
+    fireEvent.change(screen.getByTestId("cccd-input"), {
+      target: { value: "9876" },
+    })
+    fireEvent.click(screen.getByTestId("magic-link-submit"))
+
+    await waitFor(() => {
+      expect(mockConsumeMagicLinkToken).toHaveBeenCalledWith(
+        "submit",
+        "tok-sub",
+        { cccd: "9876" },
+      )
+    })
+
+    expect(
+      await screen.findByText(/đã gửi hồ sơ tuyển sinh/i),
+    ).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error path test
+// ---------------------------------------------------------------------------
+
+describe("MagicLinkConsumeForm — error path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("on BE 400, calls handleApiError + resets input + form stays mounted", async () => {
+    mockConsumeMagicLinkToken.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: { detail: "CCCD verification failed" },
+      },
+    })
+
+    withProviders(<MagicLinkConsumeForm action="confirm" token="t1" />)
+
+    const input = screen.getByTestId("cccd-input")
+    fireEvent.change(input, { target: { value: "0000" } })
+    fireEvent.click(screen.getByTestId("magic-link-submit"))
+
+    await waitFor(() => {
+      expect(mockHandleApiError).toHaveBeenCalledTimes(1)
+    })
+
+    // Input reset to empty
+    await waitFor(() => {
+      expect(
+        (screen.getByTestId("cccd-input") as HTMLInputElement).value,
+      ).toBe("")
+    })
+
+    // Form still mounted — user can retry
+    expect(screen.getByTestId("magic-link-submit")).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: /xác nhận nhập học/i }))
+      .toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/forms/MagicLinkConsumeForm.tsx
+++ b/frontend/src/components/forms/MagicLinkConsumeForm.tsx
@@ -33,8 +33,7 @@ import {
   type MagicLinkConsumeRequest,
   type MagicLinkConsumeResponse,
 } from "@/lib/zod/magic-link"
-import { handleApiError, type ApiErrorResponse } from "@/lib/error-handler"
-import type { AxiosError } from "axios"
+import { handleApiError } from "@/lib/error-handler"
 
 // ---------------------------------------------------------------------------
 // Per-action copy. Pure config — no business logic (thin client).
@@ -184,7 +183,9 @@ export function MagicLinkConsumeForm({
         setResult(data)
       },
       onError: (err) => {
-        handleApiError(err as AxiosError<ApiErrorResponse>, {
+        // ``err`` is typed as ``AxiosError<ApiErrorResponse>`` via the
+        // mutation generic in ``useMagicLinkConsume`` — no cast needed.
+        handleApiError(err, {
           context: copy.submitLabel.toLowerCase(),
         })
         // Clear the input so the user can re-enter cleanly after a 400.

--- a/frontend/src/components/forms/MagicLinkConsumeForm.tsx
+++ b/frontend/src/components/forms/MagicLinkConsumeForm.tsx
@@ -1,0 +1,258 @@
+// src/components/forms/MagicLinkConsumeForm.tsx
+"use client"
+
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { toast } from "sonner"
+import {
+  CheckCircle2,
+  AlertTriangle,
+  Loader2,
+} from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from "@/components/ui/input-otp"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { useMagicLinkConsume } from "@/hooks/admissions/useMagicLink"
+import {
+  magicLinkConsumeRequestSchema,
+  type MagicLinkAction,
+  type MagicLinkConsumeRequest,
+  type MagicLinkConsumeResponse,
+} from "@/lib/zod/magic-link"
+import { handleApiError, type ApiErrorResponse } from "@/lib/error-handler"
+import type { AxiosError } from "axios"
+
+// ---------------------------------------------------------------------------
+// Per-action copy. Pure config — no business logic (thin client).
+// Each entry mirrors the four enum members of MagicLinkAction so the
+// TypeScript exhaustiveness check covers the lot.
+// ---------------------------------------------------------------------------
+const ACTION_COPY: Record<
+  MagicLinkAction,
+  {
+    title: string
+    instruction: string
+    submitLabel: string
+    submittingLabel: string
+    successTitle: string
+    successDescription: (profileName: string | null) => string
+  }
+> = {
+  confirm: {
+    title: "Xác nhận nhập học",
+    instruction:
+      "Nhập 4 số cuối CCCD/CMND để xác nhận hồ sơ nhập học của bạn.",
+    submitLabel: "Xác nhận nhập học",
+    submittingLabel: "Đang xác nhận…",
+    successTitle: "Xác nhận nhập học thành công",
+    successDescription: (name) =>
+      `Cảm ơn ${name ?? "bạn"} đã xác nhận. Nhà trường sẽ liên hệ trong vòng 3 ngày làm việc.`,
+  },
+  submit: {
+    title: "Gửi hồ sơ tuyển sinh",
+    instruction:
+      "Nhập 4 số cuối CCCD/CMND để gửi hồ sơ tuyển sinh của bạn.",
+    submitLabel: "Gửi hồ sơ",
+    submittingLabel: "Đang gửi…",
+    successTitle: "Đã gửi hồ sơ tuyển sinh",
+    successDescription: () =>
+      "Hồ sơ của bạn đã được gửi và đang chờ Nhà trường xét duyệt.",
+  },
+  resubmit: {
+    title: "Nộp lại hồ sơ",
+    instruction:
+      "Nhập 4 số cuối CCCD/CMND để nộp lại hồ sơ sau khi đã chỉnh sửa.",
+    submitLabel: "Nộp lại",
+    submittingLabel: "Đang nộp lại…",
+    successTitle: "Đã nộp lại hồ sơ",
+    successDescription: () =>
+      "Hồ sơ chỉnh sửa của bạn đã được nộp lại và đang chờ xét duyệt.",
+  },
+  withdraw: {
+    title: "Rút hồ sơ tuyển sinh",
+    instruction:
+      "Nhập 4 số cuối CCCD/CMND để xác nhận rút hồ sơ tuyển sinh.",
+    submitLabel: "Xác nhận rút hồ sơ",
+    submittingLabel: "Đang xử lý…",
+    successTitle: "Đã rút hồ sơ",
+    successDescription: () =>
+      "Hồ sơ tuyển sinh của bạn đã được rút theo yêu cầu.",
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Small presentational helpers (consistent with ConfirmAdmissionForm).
+// ---------------------------------------------------------------------------
+function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-card mx-auto w-full max-w-md space-y-6 rounded border p-6 shadow-md md:p-8">
+      {children}
+    </div>
+  )
+}
+
+function SuccessBanner({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <PageShell>
+      <Alert>
+        <CheckCircle2 className="h-4 w-4" />
+        <AlertTitle>{title}</AlertTitle>
+        <AlertDescription>{description}</AlertDescription>
+      </Alert>
+    </PageShell>
+  )
+}
+
+function ActionRouteErrorBanner() {
+  return (
+    <PageShell>
+      <Alert variant="destructive">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertTitle>Liên kết không hợp lệ</AlertTitle>
+        <AlertDescription>
+          Đường dẫn không thuộc một trong các thao tác được hỗ trợ. Vui lòng
+          kiểm tra lại email hoặc liên hệ cán bộ tuyển sinh.
+        </AlertDescription>
+      </Alert>
+    </PageShell>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export type MagicLinkConsumeFormProps = {
+  action: MagicLinkAction
+  token: string
+}
+
+export function MagicLinkConsumeForm({
+  action,
+  token,
+}: MagicLinkConsumeFormProps) {
+  const copy = ACTION_COPY[action]
+  const consumeMutation = useMagicLinkConsume(action, token)
+  const [result, setResult] = useState<MagicLinkConsumeResponse | null>(null)
+
+  const form = useForm<MagicLinkConsumeRequest>({
+    resolver: zodResolver(magicLinkConsumeRequestSchema),
+    defaultValues: { cccd: "" },
+    mode: "onSubmit",
+  })
+
+  // Should never trigger at runtime — TypeScript exhaustiveness covers it,
+  // but render a safe banner if a stray action value ever leaks in.
+  if (!copy) {
+    return <ActionRouteErrorBanner />
+  }
+
+  // Success state — BE consumed the token + returned profile snapshot.
+  if (result) {
+    return (
+      <SuccessBanner
+        title={copy.successTitle}
+        description={copy.successDescription(null)}
+      />
+    )
+  }
+
+  const onSubmit = (values: MagicLinkConsumeRequest) => {
+    consumeMutation.mutate(values, {
+      onSuccess: (data) => {
+        toast.success(copy.successTitle)
+        setResult(data)
+      },
+      onError: (err) => {
+        handleApiError(err as AxiosError<ApiErrorResponse>, {
+          context: copy.submitLabel.toLowerCase(),
+        })
+        // Clear the input so the user can re-enter cleanly after a 400.
+        form.reset({ cccd: "" })
+      },
+    })
+  }
+
+  const isPending = consumeMutation.isPending
+
+  return (
+    <PageShell>
+      <div className="space-y-2 text-center">
+        <h1 className="font-display text-2xl font-bold">{copy.title}</h1>
+        <p className="text-muted-foreground text-sm">{copy.instruction}</p>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="cccd"
+            render={({ field }) => (
+              <FormItem className="flex flex-col items-center">
+                <FormLabel>4 số cuối CCCD/CMND</FormLabel>
+                <FormControl>
+                  <InputOTP
+                    maxLength={4}
+                    value={field.value}
+                    onChange={field.onChange}
+                    inputMode="numeric"
+                    pattern="\d*"
+                    disabled={isPending}
+                  >
+                    <InputOTPGroup>
+                      <InputOTPSlot index={0} />
+                      <InputOTPSlot index={1} />
+                      <InputOTPSlot index={2} />
+                      <InputOTPSlot index={3} />
+                    </InputOTPGroup>
+                  </InputOTP>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={isPending}
+            data-testid="magic-link-submit"
+          >
+            {isPending ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {copy.submittingLabel}
+              </span>
+            ) : (
+              copy.submitLabel
+            )}
+          </Button>
+        </form>
+      </Form>
+
+      <p className="text-muted-foreground text-center text-xs">
+        Nếu bạn không gửi yêu cầu này, vui lòng bỏ qua email và liên kết.
+      </p>
+    </PageShell>
+  )
+}

--- a/frontend/src/hooks/admissions/useMagicLink.ts
+++ b/frontend/src/hooks/admissions/useMagicLink.ts
@@ -1,0 +1,34 @@
+/**
+ * PR-CO-2-FE / PR-3E — Multi-action magic-link React Query hook.
+ *
+ * Public flow — no auth context. The mutation key carries the action +
+ * token so multiple in-flight consumes (extremely unlikely from a
+ * single candidate browser) stay isolated.
+ */
+import { useMutation } from "@tanstack/react-query"
+
+import { consumeMagicLinkToken } from "@/lib/api/magic-link"
+import type {
+  MagicLinkAction,
+  MagicLinkConsumeRequest,
+  MagicLinkConsumeResponse,
+} from "@/lib/zod/magic-link"
+
+export const magicLinkKeys = {
+  consume: (action: MagicLinkAction, token: string) =>
+    ["magic-link-consume", action, token] as const,
+}
+
+export function useMagicLinkConsume(
+  action: MagicLinkAction,
+  token: string,
+) {
+  return useMutation<
+    MagicLinkConsumeResponse,
+    unknown,
+    MagicLinkConsumeRequest
+  >({
+    mutationKey: magicLinkKeys.consume(action, token),
+    mutationFn: (body) => consumeMagicLinkToken(action, token, body),
+  })
+}

--- a/frontend/src/hooks/admissions/useMagicLink.ts
+++ b/frontend/src/hooks/admissions/useMagicLink.ts
@@ -6,8 +6,10 @@
  * single candidate browser) stay isolated.
  */
 import { useMutation } from "@tanstack/react-query"
+import type { AxiosError } from "axios"
 
 import { consumeMagicLinkToken } from "@/lib/api/magic-link"
+import type { ApiErrorResponse } from "@/lib/error-handler"
 import type {
   MagicLinkAction,
   MagicLinkConsumeRequest,
@@ -25,7 +27,7 @@ export function useMagicLinkConsume(
 ) {
   return useMutation<
     MagicLinkConsumeResponse,
-    unknown,
+    AxiosError<ApiErrorResponse>,
     MagicLinkConsumeRequest
   >({
     mutationKey: magicLinkKeys.consume(action, token),

--- a/frontend/src/lib/api/magic-link.ts
+++ b/frontend/src/lib/api/magic-link.ts
@@ -1,0 +1,43 @@
+/**
+ * PR-CO-2-FE / PR-3E — Multi-action magic-link API client.
+ *
+ * Wraps the BE v2 consume endpoint:
+ *   POST /api/v2/admissions/magic-link/{action}/{token}
+ *
+ * Public endpoint — no auth header, CSRF-exempt prefix (registered in
+ * `Backend_FastAPI/app/middleware/csrf.py`). Validates the BE response
+ * with the mirror Zod schema before returning — surfaces drift fast
+ * per FRONTEND_ARCHITECTURE_V3.md thin-client contract.
+ */
+import { api } from "@/lib/api/client"
+import {
+  magicLinkConsumeResponseSchema,
+  type MagicLinkAction,
+  type MagicLinkConsumeRequest,
+  type MagicLinkConsumeResponse,
+} from "@/lib/zod/magic-link"
+
+/**
+ * Consume a magic-link token for the specified action.
+ *
+ * @param action - One of: submit | resubmit | confirm | withdraw.
+ *                 MUST match the action_type the BE stamped on the
+ *                 token row when it was issued; mismatch → 404.
+ * @param token  - URL-safe random token from the email link.
+ * @param body   - `{ cccd: '1234' }` last 4 digits of candidate's CCCD.
+ *
+ * @throws AxiosError 400 — CCCD wrong / expired / locked / not-yet-wired
+ * @throws AxiosError 404 — token unknown OR action_type mismatch
+ * @throws AxiosError 429 — slowapi global/per-IP rate limit
+ */
+export async function consumeMagicLinkToken(
+  action: MagicLinkAction,
+  token: string,
+  body: MagicLinkConsumeRequest,
+): Promise<MagicLinkConsumeResponse> {
+  const response = await api.post<MagicLinkConsumeResponse>(
+    `/api/v2/admissions/magic-link/${action}/${encodeURIComponent(token)}`,
+    body,
+  )
+  return magicLinkConsumeResponseSchema.parse(response.data)
+}

--- a/frontend/src/lib/zod/magic-link.ts
+++ b/frontend/src/lib/zod/magic-link.ts
@@ -1,0 +1,57 @@
+/**
+ * PR-CO-2-FE / PR-3E — Multi-action magic-link Zod schemas.
+ *
+ * Mirrors BE Pydantic models in `Backend_FastAPI/app/schemas/magic_link.py`:
+ *   - MagicLinkAction enum (4 values, locked by DB CHECK)
+ *   - MagicLinkConsumeRequest (cccd: 4 digits)
+ *   - MagicLinkConsumeResponse (profile_id, action, status, consumed_at)
+ *
+ * Thin client per FRONTEND_ARCHITECTURE_V3.md: schemas are validation
+ * only; no derivation, no business logic. Response shape trusted from
+ * BE without re-deriving any state.
+ */
+import * as z from "zod"
+
+/**
+ * 4-action enum. Order matches BE for stable diffs; lowercase string
+ * values match the DB CHECK constraint on `action_type`.
+ */
+export const magicLinkActionSchema = z.enum([
+  "submit",
+  "resubmit",
+  "confirm",
+  "withdraw",
+])
+export type MagicLinkAction = z.infer<typeof magicLinkActionSchema>
+
+/**
+ * Request body for POST /api/v2/admissions/magic-link/{action}/{token}.
+ *
+ * `cccd` is the last 4 digits of citizen ID (matches BE `^\d{4}$`
+ * regex). NOT the full 12-digit CCCD — keeps UX consistent with the
+ * existing /confirm/{token} 4-digit keypad.
+ */
+export const magicLinkConsumeRequestSchema = z.object({
+  cccd: z
+    .string()
+    .regex(/^\d{4}$/u, "Vui lòng nhập đúng 4 chữ số"),
+})
+export type MagicLinkConsumeRequest = z.infer<
+  typeof magicLinkConsumeRequestSchema
+>
+
+/**
+ * Success response shape. `consumed_at` is ISO datetime string from BE
+ * (Pydantic serialises `datetime` → ISO 8601).
+ */
+export const magicLinkConsumeResponseSchema = z.object({
+  message: z.string(),
+  profile_id: z.number().int().positive(),
+  action: magicLinkActionSchema,
+  status: z.string(),
+  consumed_at: z.string(),
+  next_url: z.string().nullable().optional(),
+})
+export type MagicLinkConsumeResponse = z.infer<
+  typeof magicLinkConsumeResponseSchema
+>

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -38,6 +38,10 @@ const PUBLIC_ROUTE_PREFIXES = [
   // without being logged in. Backend exempts /api/admissions/confirm/*
   // from CSRF; frontend proxy must likewise let the page render.
   "/confirm",
+  // PR-CO-2-FE / PR-3E: multi-action magic-link landing (4 actions).
+  // Backend exempts /api/v2/admissions/magic-link/* from CSRF; the
+  // page itself is candidate-driven and must NOT bounce to /login.
+  "/magic-link",
 ];
 
 /**


### PR DESCRIPTION
## Summary

Phase 3 close-out plan v2 **PR-CO-2-FE** (~0.6d, P0) — Wave B acceptance gate "Magic-link 4 actions consumable" unblock. Lands the candidate-facing landing page + form for the 4-action v2 router shipped in PR #278 + parity-fixed in hotfix #279.

**Production verified post-hotfix #279 deploy** (run `25838551558`, prod SHA `4efe1209`):
- `POST /api/v2/admissions/magic-link/confirm/<invalid>` → 404 JSON
- `POST /api/v2/admissions/magic-link/withdraw/<invalid>` → 404 (4 actions wired)
- `POST /api/v2/admissions/magic-link/notanaction/<token>` → 422 Pydantic enum reject
- CSRF exempt confirmed (no csrf_token cookie required)
- Legacy `/api/admissions/confirm/{token}` untouched

## Files (8)

| File | LOC | Role |
|---|---|---|
| `lib/zod/magic-link.ts` | 58 | Action enum + Request/Response Zod mirror of BE Pydantic |
| `lib/api/magic-link.ts` | 44 | POST wrapper + response.parse() thin-client contract verify |
| `hooks/admissions/useMagicLink.ts` | 38 | React Query mutation, typed `AxiosError<ApiErrorResponse>` |
| `components/forms/MagicLinkConsumeForm.tsx` | 256 | Generic form, 4 action variants via `Record<MagicLinkAction, ...>` exhaustiveness |
| `components/forms/MagicLinkConsumeForm.test.tsx` | 280 | 10 vitest contract tests (non-tautological) |
| `app/magic-link/[action]/[token]/page.tsx` | 84 | Public landing, page-boundary Zod action validate + notFound() + force-dynamic + robots noindex |
| `src/proxy.ts` | +6 | Add `/magic-link` to PUBLIC_ROUTE_PREFIXES — anti `/login` redirect bounce (parity with existing `/confirm` entry) |

## Edge case caught locally

**Gap critical**: `proxy.ts` thiếu `/magic-link` allowlist → page bị 307 redirect tới `/login?redirect=/magic-link/confirm/<token>` cho candidate đến từ email không có session. Fix mirror pattern của `/confirm` existing.

## Test plan

- [x] **vitest** 10/10 PASS (365ms)
  - Per-action render (4 tests): heading + button label cho confirm/submit/resubmit/withdraw
  - Validation (3 tests): empty / non-digit / < 4 digits all assert FormMessage text
  - Happy path (2 tests): exact `(action, token, body)` tuple + success banner replaces form
  - Error path (1 test): 400 → handleApiError + input reset + form stays mounted
- [x] **tsc --noEmit** 0 errors
- [x] **eslint** 0 errors (208 pre-existing warnings unchanged)
- [x] **Browser smoke** 4 actions render + invalid action → 404
- [x] **Prod backend** verified live with v2 router after hotfix #279
- [ ] CI PR Gate (FE matrix: Check + Build)
- [ ] Post-merge prod smoke: issue real confirm token (existing flow) → consume via `/magic-link/confirm/<token>` → check officer dashboard receives realtime APPLICATION_STATUS_CHANGED

## Architecture compliance

- ✅ **Thin client** per FRONTEND_ARCHITECTURE_V3 — Zod schemas mirror BE strict; `.parse(response.data)` surfaces drift fast
- ✅ **No business logic** — per-action copy là pure config table, `Record<MagicLinkAction, ...>` với TypeScript exhaustiveness
- ✅ **React Query isolation** — mutationKey carries `(action, token)` per-tab
- ✅ **File conventions** — `lib/api/`, `lib/zod/`, `hooks/admissions/`, `components/forms/`, `app/.../page.tsx`
- ✅ **Folder convention (C3 from plan v2)** — ROOT `app/magic-link/...` NOT `(auth)/` group
- ✅ **Legacy backward compat** — `/confirm/[token]` route untouched

## Day 4 hard-review polish applied (M2 + L1 + L2 + L3)

Bundled in commit `9df4b291`:
- **M2**: < 4-digit validation test now asserts FormMessage text (non-tautological per memory `pattern-change-impact-audit`)
- **L1**: Page metadata `robots: { index: false, follow: false }` — defense-in-depth against leaked token URL screenshots
- **L2**: `export const dynamic = 'force-dynamic'` — token URL pages must never serve from CDN/Next.js cache
- **L3**: `useMagicLinkConsume` generic typed `AxiosError<ApiErrorResponse>` — drops `as` cast in form `onError`

**Deferred FU PR-CO-2-FE-2** (M1): `successDescription(null)` — UX downgrade vs legacy `/confirm/{token}` which shows candidate name. Requires BE response schema to include `profile_name`. Not blocking Wave B acceptance.

## Memory references

- `audit-before-fix` — proxy.ts gap caught via manual code audit before push
- `pattern-change-impact-audit` — tests assert exact (action, token, body) tuples; M2 strengthens < 4-digit case beyond `not.toHaveBeenCalled()`
- `verify-schema-before-proposing` — Zod schemas mirror verified BE Pydantic field names + 4-action enum lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)