### PR TITLE
hotfix(admission): drop incompatible `export const dynamic` from magic-link page

### DIFF
--- a/frontend/src/app/magic-link/[action]/[token]/page.tsx
+++ b/frontend/src/app/magic-link/[action]/[token]/page.tsx
@@ -46,10 +46,12 @@ export async function generateMetadata({
   }
 }
 
-// Token URL pages must never be cached by Next.js / CDN / proxy: each
-// request must hit the BE consume endpoint at request time so the
-// freshness gates (used / locked / expired) reflect server state.
-export const dynamic = "force-dynamic"
+// No explicit ``export const dynamic`` declaration: Next.js 16 with
+// ``cacheComponents: true`` (next.config.ts) is incompatible with that
+// route segment config. Pages opt INTO caching via the ``"use cache"``
+// directive; this page does not, so each request is dynamic by default
+// — the BE consume endpoint is hit at request time and the freshness
+// gates (used / locked / expired) reflect server state.
 
 // Placeholder params for Next.js 16 cacheComponents build validation.
 // Real {action, token} pairs are resolved at request time; the


### PR DESCRIPTION
## Summary

PR #280 squash-merge landed the broken L2 polish on main (``export const dynamic = \"force-dynamic\"`` in `frontend/src/app/magic-link/[action]/[token]/page.tsx`) **without** the follow-up revert commit ``104ad3bb`` from the PR-CO-2-FE branch. The auto-merge fired before the second push could be evaluated and the FE ``Build`` check is not in the branch-protection required-checks set, so a failing Build never blocked the merge.

This hotfix lands the revert directly on main so the next prod deploy does not hit the Turbopack failure during ``next build`` inside the frontend Docker stage.

## Verification

- ``./scripts/fe-check.sh build`` PASS locally on this branch
- Cancelled deploy run ``25840722511`` (SHA ``23142d51`` broken) before approving env so no half-finished deploy hit prod

## Memory

``nextjs16-cachecomponents-incompatible-with-dynamic`` saved 2026-05-14 — when QLTS has ``cacheComponents: true`` (verified next.config.ts:36), pages are dynamic-by-default; the ``"use cache"`` directive is the opt-in mechanism. Route-segment config ``dynamic`` is rejected at build time.

## Branch protection follow-up (separate)

Build job should be added to required checks alongside ``Check (type+lint+test)``. Otherwise this gap recurs. Tracking as FU memo — out of scope for this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)