### PR TITLE
feat(admission): PR-CO-3 — DELETE choice audit log + reason + actor_id (FU #114)

### DIFF
--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -18,8 +18,10 @@ Endpoints (Sub-3.3-3.5b incremental ship):
 """
 from __future__ import annotations
 
+from typing import Optional
+
 import structlog
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Body, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database, models, schemas
@@ -370,6 +372,7 @@ async def delete_choice(
     db: AsyncSession = Depends(database.get_db),
     choice: models.AdmissionProfileChoice = Depends(get_choice_for_user),
     current_user: models.User = CasbinAuth,
+    body: Optional[schemas.ChoiceDeleteRequest] = Body(default=None),
 ):
     """DELETE /api/v2/admissions/{profile_id}/choices/{choice_id}.
 
@@ -383,6 +386,11 @@ async def delete_choice(
     (defense-in-depth — IDOR already narrows scope, this catches mismatched
     URL paths).
 
+    **Audit (PR-CO-3, FU #114)**: optional body ``{ "reason": "..." }`` is
+    captured to ``user_activity_log`` with the choice snapshot + scores
+    so DELETEs leave a forensic trace. Body is optional — a payload-less
+    DELETE still writes the audit row with a null reason.
+
     **Security**:
     - IDOR: ``get_choice_for_user`` (3-tier scope)
     - Casbin: officer/manager/admin allow; accountant DENY
@@ -394,7 +402,10 @@ async def delete_choice(
 
     service = AdmissionChoiceService(db)
     result, post_commit_cb = await service.delete_choice(
-        profile=choice.profile, choice=choice,
+        profile=choice.profile,
+        choice=choice,
+        actor_id=current_user.id,
+        reason=body.reason if body else None,
     )
 
     await db.commit()
@@ -406,6 +417,7 @@ async def delete_choice(
         profile_id=profile_id,
         choice_id=result["choice_id"],
         actor_id=current_user.id,
+        has_reason=bool(body and body.reason),
     )
 
     return schemas.ChoiceDeleteResponse(

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -219,6 +219,7 @@ from .admission_profile_choice import (
     # PR-3D-B BE-1 — Choice CRUD endpoint schemas
     ChoiceUpdateDisplayOrderRequest,
     ChoiceScoresReplaceRequest,
+    ChoiceDeleteRequest,
     ChoiceDeleteResponse,
 )
 

--- a/Backend_FastAPI/app/schemas/admission_profile_choice.py
+++ b/Backend_FastAPI/app/schemas/admission_profile_choice.py
@@ -254,6 +254,26 @@ class ChoiceScoresReplaceRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class ChoiceDeleteRequest(BaseModel):
+    """PR-CO-3 (FU #114) — optional audit body for DELETE choice.
+
+    Captured into ``user_activity_log.description`` + ``changes`` so a
+    candidate "where did NV 3 go?" complaint 3 months later has a
+    forensic trace (actor + reason + before-snapshot). Reason is
+    OPTIONAL — the audit row is still written without it; the body
+    itself is also optional on the wire so callers without a reason
+    can just ``DELETE`` with no payload.
+    """
+
+    reason: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description="Optional reason for deletion (audit trail)",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class ChoiceDeleteResponse(BaseModel):
     """DELETE /api/v2/admissions/{pid}/choices/{cid} response."""
 

--- a/Backend_FastAPI/app/services/admission_choice_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_service.py
@@ -40,6 +40,7 @@ from app.repositories.admission_profile_choice_repository import (
     AdmissionProfileChoiceRepository,
 )
 from app.repositories.admission_path_repository import AdmissionPathRepository
+from app.services.activity_service import log_activity
 from app.services.system_config_service import SystemConfigService
 from app.utils.exceptions import BusinessRuleViolation, ResourceNotFoundError
 
@@ -270,6 +271,8 @@ class AdmissionChoiceService:
         *,
         profile: AdmissionProfile,
         choice: AdmissionProfileChoice,
+        actor_id: Optional[int] = None,
+        reason: Optional[str] = None,
     ) -> Tuple[dict, Callable]:
         """Delete a choice + cascade scores via FK ON DELETE CASCADE.
 
@@ -280,14 +283,63 @@ class AdmissionChoiceService:
         Note: scope is INTENTIONALLY tight. Once a profile transitions to
         ``submitted`` or beyond, choices are immutable per state machine —
         admin uses T17 rollback to allow editing again.
+
+        **Audit (PR-CO-3, FU #114)**: snapshot the choice + dispatch a
+        ``log_activity`` row BEFORE the DB DELETE so the row is captured
+        even if the FK cascade subsequently nukes ``profile_choice_score``
+        children. Without an audit trail the narrow status whitelist
+        (draft / revision_requested) leaves no forensic record for a
+        "where did NV 3 go?" complaint months later.
         """
         self._assert_choice_editable(profile, action="xoá nguyện vọng")
+
+        # Snapshot the row + score children BEFORE the cascade delete so
+        # the audit log carries the full forensic state. Resolve the
+        # scores via the repository to avoid relying on a lazy attribute.
+        score_rows = await self.choice_repo.list_scores_by_choice(choice.id)
+        snapshot = {
+            "choice_id": choice.id,
+            "profile_id": choice.admission_profile_id,
+            "admission_path_id": choice.admission_path_id,
+            "path_subject_group_config_id": choice.path_subject_group_config_id,
+            "display_order": choice.display_order,
+            "decision": choice.decision,
+            "scores": [
+                {
+                    "subject_id": s.subject_id,
+                    "score": str(s.score) if s.score is not None else None,
+                }
+                for s in score_rows
+            ],
+        }
 
         deleted = await self.choice_repo.delete(choice.id)
         if not deleted:
             raise ResourceNotFoundError(
                 f"Nguyện vọng {choice.id} không tồn tại hoặc đã xoá."
             )
+
+        # Audit AFTER the DELETE succeeds — both the snapshot and the
+        # activity row land under the same transaction, so the router
+        # commit makes them visible atomically. Reason is stamped into
+        # the description so audit-log readers see it without unpacking
+        # the JSONB changes payload.
+        description = (
+            f"Xoá NV {snapshot['display_order']} (path_id="
+            f"{snapshot['admission_path_id']})"
+        )
+        if reason:
+            description = f"{description} — Lý do: {reason}"
+
+        await log_activity(
+            self.db,
+            action="delete_choice",
+            resource_type="admission_profile_choice",
+            actor_id=actor_id,
+            resource_id=choice.id,
+            description=description,
+            changes={"before": snapshot, "reason": reason},
+        )
 
         return ({"choice_id": choice.id, "profile_id": profile.id},
                 _noop_callback)

--- a/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
@@ -247,6 +247,114 @@ async def test_delete_choice_happy_manager(
         assert gone is None
 
 
+# ----------------------------------------------------------------------------
+# PR-CO-3 (FU #114) — DELETE choice audit-log anchor tests
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_choice_writes_audit_log_with_reason(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    manager_user_in_db: dict,
+    pr3d_b_seed_with_choice: dict,
+):
+    """PR-CO-3 (FU #114): DELETE with ``{ "reason": "..." }`` writes an
+    audit row to ``user_activity_log`` with:
+
+      - action = 'delete_choice'
+      - resource_type = 'admission_profile_choice'
+      - resource_id = the deleted choice_id
+      - actor_id = current_user.id from auth context
+      - description includes the reason verbatim
+      - changes.before snapshots display_order + admission_path_id
+      - changes.reason persists the raw reason string
+
+    Without this anchor a forensic complaint "candidate says NV 3 was
+    deleted but no record shows it" is unverifiable.
+    """
+    profile_id = pr3d_b_seed_with_choice["profile_id"]
+    choice_id = pr3d_b_seed_with_choice["choice_id"]
+    expected_display_order = 1  # seeded by ``pr3d_b_seed_with_choice``
+    expected_path_id = pr3d_b_seed_with_choice["path_id"]
+    actor_id = manager_user_in_db["id"]
+    reason = "Candidate yêu cầu xoá nhầm NV 3"
+
+    # httpx ``AsyncClient.delete`` does not expose a ``json`` kwarg, so the
+    # generic ``.request`` path is used to ship the optional body. Mirrors
+    # how a real FE client (axios / fetch) sends ``DELETE`` with payload.
+    response = await client.request(
+        "DELETE",
+        f"/api/v2/admissions/{profile_id}/choices/{choice_id}",
+        headers=manager_token_headers,
+        json={"reason": reason},
+    )
+    assert response.status_code == 200, response.text
+
+    # Verify the audit-log row reached the DB in the same transaction.
+    async with AsyncSessionLocal() as s:
+        result = await s.execute(
+            models.UserActivityLog.__table__.select().where(
+                models.UserActivityLog.action == "delete_choice",
+                models.UserActivityLog.resource_id == choice_id,
+            )
+        )
+        rows = list(result.mappings())
+        assert len(rows) == 1, (
+            f"Expected exactly 1 audit row for delete_choice; got {len(rows)}"
+        )
+        row = rows[0]
+        assert row["resource_type"] == "admission_profile_choice"
+        assert row["actor_id"] == actor_id
+        assert reason in row["description"], (
+            f"Reason missing from description: {row['description']!r}"
+        )
+        changes = row["changes"]
+        assert changes["reason"] == reason
+        assert changes["before"]["choice_id"] == choice_id
+        assert changes["before"]["display_order"] == expected_display_order
+        assert changes["before"]["admission_path_id"] == expected_path_id
+
+
+@pytest.mark.asyncio
+async def test_delete_choice_writes_audit_log_without_body(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    manager_user_in_db: dict,
+    pr3d_b_seed_with_choice: dict,
+):
+    """PR-CO-3 (FU #114): a payload-less DELETE still writes the audit row.
+
+    Reason becomes null, description omits the "Lý do: ..." suffix, and
+    ``changes.reason`` is explicitly null — the audit trail does not
+    disappear just because the operator didn't bother typing a reason.
+    """
+    profile_id = pr3d_b_seed_with_choice["profile_id"]
+    choice_id = pr3d_b_seed_with_choice["choice_id"]
+    actor_id = manager_user_in_db["id"]
+
+    response = await client.delete(
+        f"/api/v2/admissions/{profile_id}/choices/{choice_id}",
+        headers=manager_token_headers,
+        # No body — the typical "I just clicked delete" case.
+    )
+    assert response.status_code == 200, response.text
+
+    async with AsyncSessionLocal() as s:
+        result = await s.execute(
+            models.UserActivityLog.__table__.select().where(
+                models.UserActivityLog.action == "delete_choice",
+                models.UserActivityLog.resource_id == choice_id,
+            )
+        )
+        rows = list(result.mappings())
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["actor_id"] == actor_id
+        assert row["changes"]["reason"] is None
+        assert "Lý do:" not in row["description"]
+
+
 @pytest.mark.asyncio
 async def test_update_display_order_happy_manager(
     client: AsyncClient,


### PR DESCRIPTION
## Summary

Phase 3 close-out plan v2 **PR-CO-3** (~0.3d, P2 feat) — addresses memory `phase3-pr3d-b-backlog` **FU #114**:

> `admission_choice_service.delete_choice` previously took no actor_id, no reason, and wrote no audit row. The narrow status whitelist (`draft / revision_requested`) limits blast radius but leaves no forensic trace for a 3-months-later "where did NV 3 go?" complaint.

## Scope

- **`ChoiceDeleteRequest`** schema (OPTIONAL body) with `reason: Optional[str]` (max 500 chars). DELETE without body still works — operators who don't bother typing a reason still leave a null-reason audit row.
- **`delete_choice(*, profile, choice, actor_id, reason)`** signature change. Snapshots choice + score children BEFORE the cascade delete so the audit row carries the full state (display_order, admission_path_id, decision, per-subject scores).
- **`log_activity`** row: `action='delete_choice'`, `resource_type='admission_profile_choice'`, `resource_id=choice_id`, `actor_id`, `description="Xoá NV {order} (path_id={pid}) — Lý do: {reason}"` (suffix omitted when reason is null), `changes={"before": snapshot, "reason": reason}`.
- **Router** consumes `Body(default=None)` Optional, passes `current_user.id` + `body.reason` if present. httpx clients send body via `client.request("DELETE", ..., json=...)` (the `.delete()` shortcut does not accept `json=`).

## Test plan

- [x] Local: full file regression **16/16 PASS (1m54s)** — `tests/api/test_phase3_pr3d_b_choice_crud.py`
- [x] Two new anchor tests added (non-tautological per memory `pattern-change-impact-audit`):
  - `test_delete_choice_writes_audit_log_with_reason` — asserts audit row shape + reason in description + `changes.before` snapshot (display_order + admission_path_id + choice_id)
  - `test_delete_choice_writes_audit_log_without_body` — payload-less DELETE still writes audit row; `changes.reason` is null; description has no "Lý do:" suffix
- [ ] CI PR Gate (admission contract + notification coverage + parity + bundle + FE matrix)
- [ ] Post-merge prod smoke: existing UI DELETE button continues working (body is optional, no FE change required)

## Files (5)

| File | Change |
|---|---|
| `app/schemas/admission_profile_choice.py` | `ChoiceDeleteRequest` NEW (Optional reason, max 500) |
| `app/schemas/__init__.py` | export `ChoiceDeleteRequest` |
| `app/services/admission_choice_service.py` | `delete_choice` signature `(profile, choice, actor_id, reason)`; snapshot scores via `list_scores_by_choice`; `log_activity` import + call |
| `app/routers/admissions_v2.py` | accept `Body(default=None) Optional[ChoiceDeleteRequest]`; thread `current_user.id` + `body.reason` to service |
| `tests/api/test_phase3_pr3d_b_choice_crud.py` | +2 anchor tests |

## Architecture compliance

- ✅ **Service ↔ router contract**: service `flush`-only; router commits (mandatory rule per `Backend_FastAPI/CLAUDE.md`)
- ✅ **`log_activity` flush-only**: audit row lands in the same DB transaction as the cascade delete — router commit makes both visible atomically
- ✅ **Optional body** preserves existing client UX (DELETE without payload still works)
- ✅ **JSONB safety**: `changes` dict passed through `_json_safe` inside `log_activity` so Decimal/date types in score snapshots serialize correctly

## Memory references

- `pattern-change-impact-audit` — anchor tests assert **SPECIFIC** audit row shape (action + resource_id + description + changes.before), not just "row count > 0"
- `audit-before-fix` — verified existing `log_activity` signature + `list_scores_by_choice` repo method before implementing
- `verify-schema-before-proposing` — `self.db` AsyncSession + `models.UserActivityLog` verified before importing

🤖 Generated with [Claude Code](https://claude.com/claude-code)