### PR TITLE
chore(ci): add backend pytest PR-level gate (S2 hardening #1)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,0 +1,98 @@
+name: Backend Test (PR Gate)
+
+# Sprint S2 hardening (memory `auto-merge-requires-full-ci-not-just-green`):
+# Closes the systemic gap surfaced by PR #283 orphan-merge. The existing
+# admission-contract-check.yml has a path filter (`services/admission*.py`,
+# `core/events*.py`, ...) that DOES NOT include `Backend_FastAPI/tests/**`.
+# Result: a test-only PR (e.g., #283 PR-CO-4) could auto-merge with only
+# Dependency Audit running — the actual pytest suite that the PR modified
+# never ran in CI. The M1 fix shipped post-merge as an orphan commit
+# (PR #284 cherry-pick repair). This workflow eliminates that gap.
+#
+# Cross-file sync (memory `ci-workflow-flag-cross-file-sync`):
+#   python-version '3.12'   — matches deploy.yml + dependency-audit.yml
+#   cache: 'pip'            — matches deploy.yml
+#   cache-dependency-path   — matches deploy.yml test job
+#   Postgres + Redis services + env vars — mirror deploy.yml test job
+#   exactly so PR gate semantics == post-merge deploy gate semantics
+#
+# Trigger: ANY change under Backend_FastAPI/** — including tests/. No
+# path-filter loophole.
+#
+# Performance budget: <8 phút median (full pytest suite ~400 tests).
+# Fallback if >10 phút sustained: split into matrix shards or adopt
+# pytest-testmon for test impact analysis.
+
+on:
+  pull_request:
+    # Skip draft PRs (mirror frontend-test.yml R15 pattern) to save
+    # Actions minutes during hot iteration.
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'Backend_FastAPI/**'
+      - '.github/workflows/backend-test.yml'
+
+concurrency:
+  group: be-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+
+    env:
+      APP_ENV: test
+      DATABASE_URL: postgresql+asyncpg://test:test@localhost:5432/qlts_test
+      REDIS_URL: redis://localhost:6379/0
+      SECRET_KEY: test-secret-key-for-ci-only
+      JWT_SECRET_KEY: test-jwt-secret-for-ci-only
+      # Mail settings — placeholders so app/config.py Settings() can instantiate.
+      # Tests must not actually send mail; smtp.example.com is unroutable on purpose.
+      MAIL_USERNAME: ci-test@example.com
+      MAIL_PASSWORD: ci-test-placeholder
+      MAIL_FROM: ci-test@example.com
+      MAIL_SERVER: smtp.example.com
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: qlts_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: Backend_FastAPI/requirements-dev.txt
+
+      - name: Install backend dependencies (dev)
+        working-directory: Backend_FastAPI
+        run: pip install -r requirements-dev.txt
+
+      - name: Run pytest (full suite)
+        working-directory: Backend_FastAPI
+        run: python -m pytest tests/ -v --tb=short -q


### PR DESCRIPTION
## Summary

Sprint S2 hardening item #1 — closes the systemic CI gap behind PR #283 orphan-merge + repair-PR #284 cycle.

## Production safety ✅

**Zero risk to running prod**:
- This PR adds ONE workflow file. No application code touched.
- Existing `deploy.yml` and `admission-contract-check.yml` unchanged.
- Gate is ADDITIVE — old gates continue running alongside.
- Workflow file changes still trigger `deploy.yml` per current paths-ignore policy (only `**.md`, `docs/**`, `.claude/**` excluded), so this PR's merge will run the normal post-merge deploy. No special handling needed.

## The systemic gap (incident write-up)

1. `admission-contract-check.yml` path filter = `services/admission*.py | core/events*.py | scripts/check_*.py | .contract-allowlist.yaml` — **excludes `tests/**`**
2. `deploy.yml` test job runs on `push:main` (post-merge), not on PR
3. A test-only PR (e.g., #283 PR-CO-4) only fires `dependency-audit.yml` in CI — actual pytest never runs before auto-merge
4. PR #283 hit exactly this scenario: M1 bug shipped → orphan repair PR #284 needed
5. Auto-merge eligibility = "no failing required checks". A workflow that didn't TRIGGER counts as "not failing" → vacuous green.

## Fix

New `.github/workflows/backend-test.yml`:
- Trigger: `pull_request` on `Backend_FastAPI/**` (no inverse filter — any change including `tests/` fires the gate)
- `types: [opened, synchronize, reopened, ready_for_review]` (skip drafts)
- `concurrency: be-pr-${{ github.ref }}` with `cancel-in-progress`
- Postgres 16 + Redis 7 service containers + env vars **exact mirror of `deploy.yml` test job** so PR-gate semantics == post-merge deploy-gate semantics
- Run: `pytest tests/ -v --tb=short -q` (full suite, ~400 tests)

## Cross-file sync (memory `ci-workflow-flag-cross-file-sync`)

| Setting | Aligned with |
|---|---|
| `python-version: '3.12'` | deploy.yml + dependency-audit.yml |
| `cache: 'pip'` | deploy.yml |
| `cache-dependency-path: Backend_FastAPI/requirements-dev.txt` | deploy.yml |
| Postgres + Redis services | deploy.yml exact mirror |
| env vars (APP_ENV, DATABASE_URL, REDIS_URL, SECRET_KEY, JWT, MAIL_*) | deploy.yml exact mirror |

## Verification on this PR

- This PR itself touches `.github/workflows/backend-test.yml` so the new gate SHOULD fire on its own first run (path filter includes `.github/workflows/backend-test.yml`) — implicit self-smoke
- Post-merge: any future PR touching `Backend_FastAPI/**` will run the gate

## Performance

Expected: <8 phút median for ~400-test suite. Monitor first week. Fallback if >10 phút sustained:
- `pytest --shard X/N` matrix split
- `pytest-testmon` test impact analysis (only run tests affected by changed code)

Out of scope here; track follow-up if needed.

## Follow-up (separate, S2 item #2)

Once branch protection includes `pytest` in required-checks, the test job inside `deploy.yml` becomes redundant (re-runs the same contract subset on the post-merge SHA). Removal will shave ~3-5 phút from every deploy.

## Memory references

- `auto-merge-requires-full-ci-not-just-green` — to be saved post-merge documenting the lesson
- `ci-workflow-flag-cross-file-sync` — Python version + cache + env vars aligned
- `phase3-pr3d-b-backlog` — FU R1 (PR-level BE CI gate) tracked since Day 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)