### PR TITLE
chore: gitignore Claude Code session working-tree pollution

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -1,5 +1,13 @@
 name: Backend Test (PR Gate)
 
+# Touched 2026-05-14 alongside PR #288 (.gitignore session-pollution
+# cleanup) only to trigger this gate — branch protection ruleset 16381130
+# requires ``pytest`` to pass on every PR, but root-level config-only PRs
+# (.gitignore, README, etc.) do not match any path filter and would
+# otherwise sit at "expected, not run" forever. Future root-only PRs:
+# bundle a no-op workflow touch like this OR expand the path filter
+# below to include the affected root files explicitly.
+#
 # Sprint S2 hardening (memory `auto-merge-requires-full-ci-not-just-green`):
 # Closes the systemic gap surfaced by PR #283 orphan-merge. The existing
 # admission-contract-check.yml has a path filter (`services/admission*.py`,

--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,23 @@ qa_org_selector_verified.png
 2026-*-sn-sng.txt
 test-results/
 playwright-report/
+
+# Working tree pollution from Claude Code sessions (PR drafts, smoke
+# screenshots, debug logs, plan drafts). Saved per-session for context but
+# không phải canonical artifacts — canonical = memory + Documents/ + DAILY_LOG.
+.tmp_*
+.pr_body_*
+.backup_*
+.e2e_*
+.smoke_*
+.workflow_*.png
+.daily_log_*_draft.md
+.phase2_issue_body.md
+.plan_v82_*.md
+.pr_1b_*.png
+.pr_3d_b_*.png
+.claude_test_output/
+local_backup/
+# 2026-05-14 S2 hardening session additions
+.branch_protection_*.png
+.decision_badge_*.png


### PR DESCRIPTION
## Summary

Cleanup working-tree clutter from Claude Code session artifacts. Single `.gitignore` patch covers 15 patterns that accumulated across Phase 2 + Phase 3 + S1 + S2 hardening sessions:

```
.tmp_*                      # debug scratch files
.pr_body_*                  # PR body drafts
.backup_*                   # local data backups
.e2e_*                      # E2E test screenshots
.smoke_*                    # smoke verify screenshots
.workflow_*.png             # CI debug screenshots
.daily_log_*_draft.md       # log drafts
.phase2_issue_body.md       # one-off issue body draft
.plan_v82_*.md              # plan draft files
.pr_1b_*.png                # Phase 1 evidence screenshots
.pr_3d_b_*.png              # Phase 3 PR-3D-B evidence screenshots
.claude_test_output/        # Claude agent output dir
local_backup/               # local backup workspace
.branch_protection_*.png    # 2026-05-14 S2 ruleset config screenshot
.decision_badge_*.png       # Wave A FE component preview
```

## Why now

- S1 + S2 hardening shipped fully prod (PR #277-#287 all LIVE)
- Earlier user direction "defer toàn bộ sau S1+S2 close" — now unblocked
- 77+ untracked files → 14 remaining (Documents/scripts/dev tracked separately)
- Canonical artifacts unaffected: memory/, Documents/, DAILY_LOG, Backend_FastAPI/, frontend/src/

## What this does NOT do

- Does NOT add `Documents/PHASE3_*.md` (operational docs — defer to separate commit-or-gitignore decision)
- Does NOT add `scripts/phase3-*.{sh,py}` (Phase 3 ops scripts — same)
- Does NOT add `frontend/src/app/dev/` (dev pages dir — content review needed)

Those 14 remaining items are tracked as a follow-up review (commit OR gitignore per file).

## Test plan

- [x] `.gitignore` syntax valid (git ignores patterns as expected)
- [x] `git status --short | wc -l` drops from 77+ → 14 on local
- [ ] Post-merge: confirm new patterns active on `main` branch across all branches

## Memory references

- `solo-dev-batch-prs-to-reduce-ci-overhead` — single gitignore PR carries all session-accumulated patterns
- `solo-developer` — single dev workspace, no team review required for cosmetic cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)