### PR TITLE
chore(s2): Tier B batch — M2 Redis hash + M4 fixture scope + L3/B5 sweeps

### DIFF
--- a/Backend_FastAPI/app/services/magic_link_rate_limit.py
+++ b/Backend_FastAPI/app/services/magic_link_rate_limit.py
@@ -24,6 +24,7 @@ reasoning as the resend cap.
 """
 from __future__ import annotations
 
+import hashlib
 import structlog
 from typing import Final, Optional
 
@@ -37,9 +38,17 @@ WINDOW_SECONDS: Final[int] = 60
 
 
 def _key(token_value: str) -> str:
-    # Token is 256-bit URL-safe random — safe to embed in the Redis key
-    # directly. Namespaced ``mlt:`` (magic-link token) per plan v2 spec.
-    return f"mlt:{token_value}"
+    # Token is 256-bit URL-safe random — unguessable on the wire, but the
+    # plaintext form can still leak via Redis operational surfaces:
+    # ``redis-cli MONITOR`` (debug streaming), ``SLOWLOG`` snapshots, and
+    # RDB/AOF dumps all record the raw command incl. key name. Hashing
+    # truncates that exposure: the leak becomes a one-way hash, useless
+    # for impersonating the magic link inside the 60s rate window.
+    # SHA-256 hex truncated to 16 chars (64 bits) is plenty for collision
+    # resistance — Redis namespace ``mlt:`` already scopes per use case
+    # and the cardinality at any moment is bounded by live tokens.
+    h = hashlib.sha256(token_value.encode()).hexdigest()[:16]
+    return f"mlt:{h}"
 
 
 async def consume_attempt(token_value: str) -> Optional[int]:

--- a/Backend_FastAPI/tests/unit/test_casbin_phase3_routes.py
+++ b/Backend_FastAPI/tests/unit/test_casbin_phase3_routes.py
@@ -152,9 +152,16 @@ def _build_enforcer_from_templates(roles_to_seed):
     return enforcer
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def enforcer():
-    """Enforcer loaded with manager + officer + accountant templates."""
+    """Enforcer loaded with manager + officer + accountant templates.
+
+    Module-scoped because tests are read-only (.enforce() calls only, no
+    add_policy/remove_policy mutations — confirmed by grep). Building the
+    enforcer parses the model file + writes a tempfile policy + reloads —
+    not free at 49 matrix cells × per-function rebuilds. B3 M4 fixture
+    scope hardening (Tier B).
+    """
     roles = {
         "manager": MANAGER_TEMPLATE,
         "officer": OFFICER_TEMPLATE,
@@ -317,14 +324,14 @@ ROUTE_CHOICE_SCORES_PATCH = (
 )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def enforcer_with_admin_diamond():
     """Enforcer including ADMIN_TEMPLATE + full diamond inheritance.
 
     Distinct from the module-level ``enforcer`` fixture (manager+officer+
     accountant only) — choice CRUD matrix needs the admin diamond to
     verify FU #113 ``admin → accountant`` deny inheritance for all 4
-    choice routes.
+    choice routes. Module-scoped (read-only enforcer) per B3 M4.
     """
     from app.casbin_config.policy_templates import ADMIN_TEMPLATE
 

--- a/Backend_FastAPI/tests/unit/test_magic_link_rate_limit_key_hashing.py
+++ b/Backend_FastAPI/tests/unit/test_magic_link_rate_limit_key_hashing.py
@@ -1,0 +1,134 @@
+"""B2 M2 hardening: ``magic_link_rate_limit._key`` must hash the token
+before embedding it in the Redis key.
+
+Why this anchor matters
+-----------------------
+The magic-link token is a 256-bit URL-safe random value used in CCCD-
+verified profile actions (confirm / submit / resubmit / withdraw).
+Pre-hardening the Redis key was ``mlt:{raw_token}``; an operator running
+``redis-cli MONITOR`` for diagnostic purposes — or a leaked RDB/AOF
+snapshot — would expose the token in plaintext. Inside the 60-second
+rate window a leaked token can still be used to impersonate the
+applicant, so we hash before namespacing.
+
+The hash anchor is intentionally **non-tautological**: it does not
+re-implement the hashing inside the assertion. Instead it asserts the
+two operational properties we care about:
+  (a) plaintext token MUST NOT appear in the Redis key, and
+  (b) two different tokens MUST produce different keys (collision
+      resistance at our cardinality).
+
+A drift to plaintext (e.g. someone reverts the hashing in a hot-fix)
+trips (a) immediately. A drift to a non-keyed hash (e.g. constant-key
+bug) trips (b).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import magic_link_rate_limit
+
+
+# ---------------------------------------------------------------------
+# _key() — hash anchor
+# ---------------------------------------------------------------------
+
+
+def test_key_does_not_embed_plaintext_token() -> None:
+    """A leaked Redis MONITOR / RDB dump must not reveal the raw token."""
+    token = "this-is-a-super-secret-magic-link-token-256bits"
+    key = magic_link_rate_limit._key(token)
+
+    assert token not in key, (
+        "Redis key still embeds the plaintext token — operator "
+        "MONITOR/SLOWLOG/RDB would leak the credential. "
+        f"key={key!r} contains token={token!r}"
+    )
+    assert key.startswith("mlt:"), (
+        f"Redis key lost its ``mlt:`` namespace prefix — operators "
+        f"can no longer identify magic-link entries: key={key!r}"
+    )
+
+
+def test_key_is_deterministic_for_same_token() -> None:
+    """INCR + EXPIRE on retries must land on the same bucket."""
+    token = "deterministic-anchor-token"
+    assert magic_link_rate_limit._key(token) == magic_link_rate_limit._key(token)
+
+
+def test_key_differs_across_tokens() -> None:
+    """Two distinct tokens must NOT share a rate-limit bucket
+    (otherwise an attacker spamming one token would lock out a
+    second legitimate user)."""
+    k1 = magic_link_rate_limit._key("token-alpha")
+    k2 = magic_link_rate_limit._key("token-bravo")
+    assert k1 != k2, (
+        f"_key collided across distinct tokens: both produced {k1!r}. "
+        "Rate limit would now lock unrelated users out."
+    )
+
+
+def test_key_shape_is_namespace_plus_short_hex() -> None:
+    """Anchor the post-hash key shape so a future drift (e.g. someone
+    base64-encodes instead of hex, blowing past 16 chars and creating
+    long Redis keys) trips the test."""
+    token = "shape-anchor"
+    key = magic_link_rate_limit._key(token)
+    prefix, _, suffix = key.partition(":")
+    assert prefix == "mlt"
+    # 16 hex chars = 64 bits, plenty for live-token cardinality.
+    assert len(suffix) == 16, f"key suffix should be 16-char hex, got {suffix!r}"
+    assert all(c in "0123456789abcdef" for c in suffix), (
+        f"key suffix should be lowercase hex, got {suffix!r}"
+    )
+
+
+# ---------------------------------------------------------------------
+# consume_attempt — fail-closed contract
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_consume_attempt_returns_count_on_healthy_redis() -> None:
+    with patch(
+        "app.services.magic_link_rate_limit.safe_redis_incr",
+        new=AsyncMock(return_value=2),
+    ), patch(
+        "app.services.magic_link_rate_limit.safe_redis_expire",
+        new=AsyncMock(return_value=True),
+    ):
+        result = await magic_link_rate_limit.consume_attempt("happy-path-token")
+
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_consume_attempt_fails_closed_when_incr_breaker_open() -> None:
+    """``safe_redis_incr`` returning ``None`` (breaker open) → contract
+    says caller must refuse. Verify the helper signals ``None`` rather
+    than fail-open with a synthetic count."""
+    with patch(
+        "app.services.magic_link_rate_limit.safe_redis_incr",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await magic_link_rate_limit.consume_attempt("breaker-token")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_consume_attempt_fails_closed_when_expire_arm_fails() -> None:
+    """INCR ok but EXPIRE returns falsy → still fail-closed (else a
+    counter could survive without a TTL and lock the token forever)."""
+    with patch(
+        "app.services.magic_link_rate_limit.safe_redis_incr",
+        new=AsyncMock(return_value=1),
+    ), patch(
+        "app.services.magic_link_rate_limit.safe_redis_expire",
+        new=AsyncMock(return_value=False),
+    ):
+        result = await magic_link_rate_limit.consume_attempt("expire-fail-token")
+
+    assert result is None


### PR DESCRIPTION
## Summary

Sprint S2 hardening **Tier B** follow-up to Phase 3 close-out Day 1-5 hard review pass 1. Three small independent improvements bundled per memory `solo-dev-batch-prs-to-reduce-ci-overhead`.

| Item | Severity | Change | Files |
|---|---|---|---|
| **M2** | Medium | SHA-256 hash token before `mlt:{}` Redis key — defense-in-depth vs MONITOR/SLOWLOG/RDB leak | `magic_link_rate_limit.py` + 7 anchor tests NEW |
| **M4** | Medium | Casbin enforcer fixtures → `scope="module"` (read-only, 65 rebuilds eliminated) | `test_casbin_phase3_routes.py` |
| **L3** | Low | i18n VI/EN sweep — **no fix needed**, 100% VI consistent | (documented in commit body) |
| **B5** | — | Hard-review pass 2 dispatch + IDOR sweep — **no violations found** | (documented in commit body) |

## M2 — Redis key hashing

Token was embedded plaintext in `mlt:{token}` Redis key. Token is 256-bit URL-safe random (unguessable on wire), but raw form still leaks via Redis operational surfaces (`MONITOR` debug stream, `SLOWLOG`, RDB/AOF dumps). Within the 60s rate window a leaked token can still be used to impersonate the applicant.

Fix: SHA-256 hex truncated to 16 chars (64 bits) before namespacing. Collision-resistant at live-token cardinality, identical INCR/EXPIRE semantics, ~µs overhead.

**Anchor tests** (`test_magic_link_rate_limit_key_hashing.py` NEW):
- `test_key_does_not_embed_plaintext_token` — non-tautological: asserts token string not present in key
- `test_key_is_deterministic_for_same_token` — INCR retries hit same bucket
- `test_key_differs_across_tokens` — collision sanity (no shared lockout)
- `test_key_shape_is_namespace_plus_short_hex` — drift detector (e.g. someone changes to base64)
- `test_consume_attempt_returns_count_on_healthy_redis` — happy path
- `test_consume_attempt_fails_closed_when_incr_breaker_open` — Redis down → caller refuses
- `test_consume_attempt_fails_closed_when_expire_arm_fails` — TTL miss → caller refuses (the previous bug shape)

## M4 — Casbin fixture scope

`enforcer` (used by 49 matrix cells) + `enforcer_with_admin_diamond` (16 choice CRUD cells) were function-scoped despite being read-only across tests (verified by grep: no `add_policy/remove_policy/delete_role/add_role` calls). Module scope cuts 65 redundant rebuilds.

## L3 — i18n sweep (no change)

Audited 7 Wave A/B FE component files:
- `MagicLinkConsumeForm` — 4 action ACTION_COPY entries
- `ChoiceListEditor` + `ChoiceScoreCard`
- `EligibilityResultViewer` + `AuditReasonDialog`
- `AdminBackfillQueue` + `BackfillResolveDialog`

All UI strings (titles, labels, placeholders, aria-labels, alerts) are 100% Vietnamese. English matches in JSDoc/comments/test strings only — no production drift.

## B5 — Hard-review pass 2 (no change)

Verified dispatch + IDOR contracts on PR-CO-2-BE / PR-CO-3:
- `magic_link_service.consume_token` — zero dispatch/begin_nested (deferred to router)
- `admission_choice_service.delete_choice` (PR-CO-3) — zero dispatch (log_activity only)
- `admissions_magic_link` router — `safe_dispatch` AFTER commit, no `begin_nested` wrap → no `strict=True` requirement per `dispatch-bundle-strict-required` memory
- IDOR: public endpoint by design, token IS the credential; anti-enumeration confirmed via existing test (action enum mismatch → 404)

## Test plan
- [x] Local file diff review
- [ ] backend-test.yml gate green (Tier 1 multi-NV + Tier 2 RBAC anchored)
- [ ] frontend-test.yml gate green (path filter triggers, no FE changes expected to pass)
- [ ] Dependency Audit green
- [ ] After merge: deploy auto-trigger + production smoke (no functional change, expect zero behaviour drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)