### PR TITLE
fix(fe+ci): DocumentsTab API_BASE_URL + Backfill Queue nav + Tier 2 allowlist (S2 batch)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -169,6 +169,7 @@ jobs:
           tests/unit/test_admission_state_service_event_mapping.py
           tests/unit/test_client_ip_helper.py
           tests/unit/test_admission_confirmation_cooldown.py
+          tests/unit/test_magic_link_rate_limit_key_hashing.py
           -q --tb=short
 
       # =====================================================================

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -95,6 +95,7 @@ import {
   isDocumentRequirementSatisfied,
   isDocumentPendingVerification,
 } from "@/lib/utils/admission-helpers"
+import { API_BASE_URL } from "@/lib/api/client"
 
 interface DocumentsTabProps {
   profile: AdmissionProfileResponse
@@ -866,7 +867,9 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
   const handleViewDocument = (filePath: string) => {
     if (!isSafeFilePath(filePath)) return
     const cleanPath = filePath.startsWith("/") ? filePath.slice(1) : filePath
-    const url = `${process.env.NEXT_PUBLIC_API_URL || ""}/${cleanPath}`
+    // Use canonical API_BASE_URL (Zod-validated in lib/config/env.ts) instead
+    // of raw process.env — single source of truth, fails fast on misconfig.
+    const url = `${API_BASE_URL}/${cleanPath}`
     window.open(url, "_blank", "noopener,noreferrer")
   }
 

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -359,6 +359,17 @@ export const navigationConfig: NavigationConfig = {
           roles: ["admin", "manager"], // Admin and Manager can restore deleted items
         },
         {
+          // Phase 3 PR-3D-B Bundle 3 (PR #275): admin queue for triaging
+          // backfill exceptions when migration cannot auto-map a legacy
+          // profile to the new multi-NV engine. Route deployed prod
+          // 2026-05-13 but was missing from the sidebar — admins had to
+          // remember the URL or rely on the recent-pages list.
+          label: "Backfill Queue",
+          href: "/admin/admission-backfill-queue",
+          icon: Database,
+          roles: ["admin"], // Admin-only — route is admin-gated via deps
+        },
+        {
           label: "Audit Logs",
           href: "/admin/audit-logs",
           icon: History,


### PR DESCRIPTION
## Summary

Sprint S2 hardening — three small fixes bundled in one PR per memory `solo-dev-batch-prs-to-reduce-ci-overhead` to amortize CI overhead across related changes.

| # | Commit | Change | File |
|---|---|---|---|
| 1 | `8e32b810` | DocumentsTab: replace raw `process.env.NEXT_PUBLIC_API_URL` with canonical `API_BASE_URL` import | `DocumentsTab.tsx` |
| 2 | `ad5b01b1` | AdminSidebar: expose `/admin/admission-backfill-queue` in System nav group | `navigation.ts` |
| 3 | `3c78656e` | Wire `test_magic_link_rate_limit_key_hashing.py` (from PR #290) into Tier 2 CI allowlist | `backend-test.yml` |

## 1. DocumentsTab API_BASE_URL fix (hard-review FU)

`DocumentsTab.handleViewDocument` built the document open URL via `${process.env.NEXT_PUBLIC_API_URL || \"\"}/${cleanPath}`. Two problems:
- Silent fallback to relative URL when env misconfigured (the `|| \"\"` turns the URL relative to FE origin → wrong host)
- Bypasses the Zod-validated `env.NEXT_PUBLIC_API_URL` (`lib/config/env.ts` + `lib/api/client.ts:API_BASE_URL`)

**Fix**: Import the canonical `API_BASE_URL`. Same value when env is correct; eliminates silent-failure when it isn't.

## 2. AdminSidebar Backfill Queue entry (Phase 3 UX gap)

PR #275 (Phase 3 PR-3D-B Bundle 3, deployed prod 2026-05-13) shipped `/admin/admission-backfill-queue` but did not add a sidebar entry. Admins had to remember the URL.

Adds a `Backfill Queue` link in the System nav group between *Deleted Items* and *Audit Logs* (semantic triage cluster). Role-gated `admin` only. Icon `Database`. Audit memory: `phase3-admin-backfill-queue-no-sidebar-entry`.

## 3. CI: wire magic_link_rate_limit anchor tests into Tier 2

PR #290 added 7 anchor tests covering the SHA-256-16hex Redis-key hashing of magic-link tokens + INCR/EXPIRE fail-closed paths. The selective `backend-test.yml` allowlist gating Tier 2 RBAC + security did not yet reference the file (per memory `ci-pytest-selective-allowlist-pattern` — explicit allowlist until full-suite restore).

Without this commit, drift back to plaintext keys would not be caught by CI. Adds the file under **Tier 2 — RBAC + security + CCCD lock** (per-token rate limit is a brute-force/impersonation defense surface).

## Hard-review FE audit verdict recap (memory `fe-thin-client-compliance-2026-05-14`)

| Finding | Verdict | This PR |
|---|---|---|
| DocumentsTab raw `process.env` | VALID | ✅ Fixed (commit 1) |
| SmartHeader `user?.role` checks | VALID but needs BE permission flag | ⏳ Deferred (out of scope) |
| BulkAssignDialog `user.role` filter | NOT a violation (defensive filter on returned list) | ⏭ No change |

Plus 2 Phase 3 close-out gaps discovered during 2026-05-14 prod smoke verify: sidebar entry (commit 2) + CI gate (commit 3).

## Test plan
- [x] Local diff review (3 commits, 13 net LOC)
- [ ] frontend-test.yml gate green (path filter triggers on `frontend/**`)
- [ ] backend-test.yml gate green — Tier 2 now executes the new anchor tests on this PR's CI run
- [ ] Dependency Audit green
- [ ] After merge — prod smoke:
  - Sidebar shows `System → Backfill Queue` for admin role → click goes to backfill queue page
  - Open a document from any admission profile's Documents tab → new tab resolves to API origin
  - CI Tier 2 step on next PR runs the hash anchor (drift detector active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)