### PR TITLE
feat(phase3-closeout): wire round flags + system-config admin UI

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -170,6 +170,7 @@ jobs:
           tests/unit/test_client_ip_helper.py
           tests/unit/test_admission_confirmation_cooldown.py
           tests/unit/test_magic_link_rate_limit_key_hashing.py
+          tests/api/test_admin_v2_admission_round_phase3_flags.py
           -q --tb=short
 
       # =====================================================================

--- a/Backend_FastAPI/app/schemas/admission_round.py
+++ b/Backend_FastAPI/app/schemas/admission_round.py
@@ -29,6 +29,17 @@ class AdmissionRoundBase(BaseModel):
     start_date: Optional[date] = None
     end_date: Optional[date] = None
     is_active: bool = True
+    # Phase 3 Q-P3-02 — per-round multi-NV gate. DB column ships with
+    # server_default false; surface here so admin can flip via UI.
+    allow_multi_nv: bool = False
+    # Phase 3 Q-P3-06 — per-round candidate-confirm token expiry. DB
+    # column ships server_default 168h (7 days). >0 enforced by model.
+    confirm_expiry_hours: int = Field(
+        168,
+        ge=1,
+        le=8760,  # 1 year ceiling — sanity guard, not business rule.
+        description="Magic-link confirm token expiry, hours. Default 168 (7d).",
+    )
 
 
 class AdmissionRoundCreate(AdmissionRoundBase):
@@ -38,13 +49,23 @@ class AdmissionRoundCreate(AdmissionRoundBase):
 
 
 class AdmissionRoundUpdate(BaseModel):
-    """Partial update payload — all fields optional. Time-window/lifecycle
-    only Phase 2 (Q3 v8.2 — notification template defer Phase 3)."""
+    """Partial update payload — all fields optional.
+
+    Phase 3 PATCH (post Q-P3-02 / Q-P3-06): in addition to the Phase 2
+    time-window/lifecycle fields, surface ``allow_multi_nv`` and
+    ``confirm_expiry_hours`` so admin can toggle multi-NV per round and
+    tune confirm expiry via the admin UI. The previous comment ("Time-
+    window/lifecycle only Phase 2 — notification template defer Phase 3")
+    is now stale: phase3_01 added the DB columns 2026-05-12; this PR
+    wires the schema + UI.
+    """
 
     round_name: Optional[str] = Field(None, min_length=1, max_length=100)
     start_date: Optional[date] = None
     end_date: Optional[date] = None
     is_active: Optional[bool] = None
+    allow_multi_nv: Optional[bool] = None
+    confirm_expiry_hours: Optional[int] = Field(None, ge=1, le=8760)
 
 
 class AdmissionRoundExtend(BaseModel):
@@ -74,6 +95,11 @@ class AdmissionRoundBulkCreateItem(BaseModel):
     start_date: Optional[date] = None
     end_date: Optional[date] = None
     is_active: bool = True
+    # Phase 3 Q-P3-02 / Q-P3-06 surfaced here so admin "Tạo nhanh 4 đợt"
+    # can pre-seed the multi-NV + confirm-expiry policy for all 4 rounds
+    # at once. Defaults match the per-round Pydantic Base above.
+    allow_multi_nv: bool = False
+    confirm_expiry_hours: int = Field(168, ge=1, le=8760)
 
 
 class AdmissionRoundBulkCreate(BaseModel):
@@ -112,6 +138,12 @@ class AdmissionRoundResponse(BaseModel):
     extended_at: Optional[datetime]
     extended_by_user_id: Optional[int]
     extension_reason: Optional[str]
+
+    # Phase 3 Q-P3-02 / Q-P3-06 (phase3_01 migration columns).
+    # Surfaced here so the FE round edit dialog can show + edit them
+    # and the engine + storefront can read them via the same payload.
+    allow_multi_nv: bool
+    confirm_expiry_hours: int
 
     created_at: datetime
     updated_at: datetime

--- a/Backend_FastAPI/tests/api/test_admin_v2_admission_round_phase3_flags.py
+++ b/Backend_FastAPI/tests/api/test_admin_v2_admission_round_phase3_flags.py
@@ -1,0 +1,175 @@
+"""Phase 3 close-out 2026-05-14: anchor PATCH wiring tests for the two
+Phase 3 ``OfferingAdmissionRound`` columns surfaced via the admin
+``PATCH /api/v2/admin/rounds/{round_id}`` endpoint.
+
+``phase3_01`` migration deployed ``allow_multi_nv BOOLEAN DEFAULT false``
+and ``confirm_expiry_hours INT DEFAULT 168`` on 2026-05-12, but the
+Pydantic ``AdmissionRoundUpdate`` / ``AdmissionRoundResponse`` schemas
+were not wired at the same time. Without the schema wiring the columns
+were unreachable from the admin UI — admin had to mutate via direct
+SQL.
+
+Non-tautological anchor (memory ``pattern-change-impact-audit``):
+asserts (a) the PATCH persists the new value, (b) the same value comes
+back on the next GET, and (c) the value untouched by a PATCH that
+doesn't include the field stays at its previous value (no implicit
+default reset). A regression that strips the field from
+``AdmissionRoundUpdate`` would silently flip the assertion on (a).
+"""
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+
+
+log = logging.getLogger(__name__)
+
+
+@pytest_asyncio.fixture
+async def seeded_round() -> int:
+    """Create a fresh round and return its id.
+
+    Uses a randomised ``round_code`` so concurrent test runs don't
+    collide on the ``(academic_year, round_code)`` UNIQUE constraint.
+    """
+    # Keep year inside the 1900–2100 CHECK from Phase 1 #09a — derive from
+    # the current second-of-day so each test invocation gets a unique year
+    # without crossing the upper bound.
+    year = 2000 + (int(time.time()) % 100)
+    round_code = f"AT_{int(time.time() * 1000) % 1_000_000}"
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            r = models.OfferingAdmissionRound(
+                academic_year=year,
+                round_code=round_code,
+                round_name=f"Anchor round {round_code}",
+                is_active=True,
+                # DB defaults: allow_multi_nv=false, confirm_expiry_hours=168
+            )
+            s.add(r)
+            await s.flush()
+            return r.id
+
+
+# ---------------------------------------------------------------------
+# Anchor 1 — PATCH persists allow_multi_nv
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_allow_multi_nv_persists_and_round_trips(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    seeded_round: int,
+) -> None:
+    """Flipping ``allow_multi_nv`` via PATCH must survive a follow-up GET.
+
+    A regression that drops the field from ``AdmissionRoundUpdate`` would
+    silently strip it on payload validation, leaving the column at the
+    server_default ``false`` — the second GET assertion catches that.
+    """
+    patch_resp = await client.patch(
+        f"/api/v2/admin/rounds/{seeded_round}",
+        json={"allow_multi_nv": True},
+        headers=admin_token_headers,
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+    body = patch_resp.json()
+    assert body["allow_multi_nv"] is True, (
+        f"PATCH response should echo the new flag value, got {body!r}"
+    )
+
+    get_resp = await client.get(
+        f"/api/v2/admin/rounds/{seeded_round}",
+        headers=admin_token_headers,
+    )
+    assert get_resp.status_code == 200
+    fresh = get_resp.json()
+    assert fresh["allow_multi_nv"] is True
+    # Untouched column stays at server_default — drift detector for
+    # "PATCH bleeds defaults into untouched fields".
+    assert fresh["confirm_expiry_hours"] == 168
+
+
+# ---------------------------------------------------------------------
+# Anchor 2 — PATCH persists confirm_expiry_hours
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_confirm_expiry_hours_persists_and_round_trips(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    seeded_round: int,
+) -> None:
+    """Setting ``confirm_expiry_hours=24`` (shorter window) round-trips.
+
+    Combined with Anchor 1 this proves both new fields are independently
+    addressable — schema wiring did not regress either column.
+    """
+    patch_resp = await client.patch(
+        f"/api/v2/admin/rounds/{seeded_round}",
+        json={"confirm_expiry_hours": 24},
+        headers=admin_token_headers,
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+    assert patch_resp.json()["confirm_expiry_hours"] == 24
+
+    get_resp = await client.get(
+        f"/api/v2/admin/rounds/{seeded_round}",
+        headers=admin_token_headers,
+    )
+    assert get_resp.status_code == 200
+    fresh = get_resp.json()
+    assert fresh["confirm_expiry_hours"] == 24
+    # Sibling flag untouched stays at default.
+    assert fresh["allow_multi_nv"] is False
+
+
+# ---------------------------------------------------------------------
+# Anchor 3 — Bounds enforced by Pydantic
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_confirm_expiry_hours_rejects_out_of_range(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    seeded_round: int,
+) -> None:
+    """Reject 0 and >8760 (1 year ceiling).
+
+    Bounds documented in Pydantic + Zod schemas so the FE NumberInput's
+    max attribute stays aligned with the BE guard.
+    """
+    too_small = await client.patch(
+        f"/api/v2/admin/rounds/{seeded_round}",
+        json={"confirm_expiry_hours": 0},
+        headers=admin_token_headers,
+    )
+    assert too_small.status_code == 422
+
+    too_big = await client.patch(
+        f"/api/v2/admin/rounds/{seeded_round}",
+        json={"confirm_expiry_hours": 8761},
+        headers=admin_token_headers,
+    )
+    assert too_big.status_code == 422
+
+    # Verify nothing got mutated by the rejected payloads.
+    async with AsyncSessionLocal() as s:
+        result = await s.execute(
+            select(models.OfferingAdmissionRound).where(
+                models.OfferingAdmissionRound.id == seeded_round
+            )
+        )
+        row = result.scalar_one()
+        assert row.confirm_expiry_hours == 168

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.test.tsx
@@ -5,7 +5,7 @@
  * Anchor tests per memory pattern-change-impact-audit (P3-2 v8.2).
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { describe, expect, it, vi } from "vitest"
 
@@ -29,6 +29,12 @@ vi.mock("@/hooks/admissions/useAdmissionRounds", () => ({
               extended_at: null,
               extended_by_user_id: null,
               extension_reason: null,
+              // Phase 3 close-out 2026-05-14 — Q-P3-02 / Q-P3-06 fields
+              // surfaced via this PR. DOT_1 in this fixture is the
+              // "multi-NV enabled" round; DOT_2 below stays at server
+              // default (false / 168h) so the form can assert both paths.
+              allow_multi_nv: true,
+              confirm_expiry_hours: 72,
               created_at: "2026-05-09T00:00:00Z",
               updated_at: "2026-05-09T00:00:00Z",
             },
@@ -44,6 +50,8 @@ vi.mock("@/hooks/admissions/useAdmissionRounds", () => ({
               extended_at: null,
               extended_by_user_id: null,
               extension_reason: null,
+              allow_multi_nv: false,
+              confirm_expiry_hours: 168,
               created_at: "2026-05-09T00:00:00Z",
               updated_at: "2026-05-09T01:00:00Z",
             },
@@ -130,5 +138,33 @@ describe("RoundsManagementTab year-level", () => {
     // Restore button trên archived row KHÔNG bị disabled (admin có thể
     // restore đợt đã archive bất kỳ lúc nào).
     expect(restoreButtons[0]).not.toBeDisabled()
+  })
+
+  it("ANCHOR (Phase 3 close-out 2026-05-14): edit dialog seeds 2 Phase 3 fields from row", () => {
+    // Regression guard: if roundToFormState() ever drops the new Phase 3
+    // fields, the edit dialog will open with defaults (false / 168) for
+    // DOT_1 even though the row has (true / 72). The form would then
+    // silently overwrite the persisted multi-NV flag on next save —
+    // exactly the failure mode this anchor catches.
+    render(wrap(<RoundsManagementTab />))
+
+    // Open DOT_1 edit dialog. The fixture says DOT_1 has
+    // allow_multi_nv=true + confirm_expiry_hours=72.
+    const editButtons = screen.getAllByRole("button", { name: /Sửa đợt/i })
+    fireEvent.click(editButtons[0])
+
+    // Checkbox state mirrors the seeded value: TRUE for DOT_1.
+    const allowMultiNvCheckbox = screen.getByLabelText(
+      /Cho phép nhiều nguyện vọng/i
+    ) as HTMLInputElement
+    // Radix Checkbox reflects state via data-state="checked"; standard
+    // checked attribute also flips for accessibility.
+    expect(allowMultiNvCheckbox.getAttribute("data-state")).toBe("checked")
+
+    // NumberInput seeded with row.confirm_expiry_hours.
+    const expiryInput = screen.getByLabelText(
+      /Thời hạn xác nhận nhập học/i
+    ) as HTMLInputElement
+    expect(expiryInput.value).toBe("72")
   })
 })

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.tsx
@@ -77,6 +77,11 @@ interface FormState {
   start_date: string
   end_date: string
   is_active: boolean
+  // Phase 3 Q-P3-02 / Q-P3-06 surfaced via phase3_01 migration + this PR.
+  // Defaults mirror Pydantic AdmissionRoundBase to keep create + update + API
+  // contract aligned.
+  allow_multi_nv: boolean
+  confirm_expiry_hours: number
 }
 
 const EMPTY_FORM: FormState = {
@@ -85,6 +90,8 @@ const EMPTY_FORM: FormState = {
   start_date: "",
   end_date: "",
   is_active: true,
+  allow_multi_nv: false,
+  confirm_expiry_hours: 168,
 }
 
 const DEFAULT_4_ROUNDS = [
@@ -101,6 +108,8 @@ function formStateToCreatePayload(f: FormState) {
     start_date: f.start_date || null,
     end_date: f.end_date || null,
     is_active: f.is_active,
+    allow_multi_nv: f.allow_multi_nv,
+    confirm_expiry_hours: f.confirm_expiry_hours,
   }
 }
 
@@ -110,6 +119,8 @@ function formStateToUpdatePayload(f: FormState) {
     start_date: f.start_date || null,
     end_date: f.end_date || null,
     is_active: f.is_active,
+    allow_multi_nv: f.allow_multi_nv,
+    confirm_expiry_hours: f.confirm_expiry_hours,
   }
 }
 
@@ -120,6 +131,8 @@ function roundToFormState(r: AdmissionRoundResponse): FormState {
     start_date: r.start_date ?? "",
     end_date: r.end_date ?? "",
     is_active: r.is_active,
+    allow_multi_nv: r.allow_multi_nv,
+    confirm_expiry_hours: r.confirm_expiry_hours,
   }
 }
 
@@ -615,6 +628,52 @@ function RoundForm({
           onCheckedChange={(c) => setForm({ ...form, is_active: Boolean(c) })}
         />
         <Label htmlFor="is_active">Đang hoạt động</Label>
+      </div>
+
+      {/* Phase 3 Q-P3-02 — per-round multi-NV gate. Off by default; admin
+          flips on per round when the round should accept multi-choice
+          submissions. Engine + storefront read this same value. */}
+      <div className="flex items-start space-x-2">
+        <Checkbox
+          id="allow_multi_nv"
+          className="mt-1"
+          checked={form.allow_multi_nv}
+          onCheckedChange={(c) => setForm({ ...form, allow_multi_nv: Boolean(c) })}
+        />
+        <div className="space-y-1">
+          <Label htmlFor="allow_multi_nv">Cho phép nhiều nguyện vọng</Label>
+          <p className="text-xs text-muted-foreground">
+            Bật để thí sinh đăng ký nhiều ngành xếp thứ tự ưu tiên trong đợt
+            này. Tắt = mỗi hồ sơ chỉ 1 nguyện vọng (chế độ cũ).
+          </p>
+        </div>
+      </div>
+
+      {/* Phase 3 Q-P3-06 — per-round magic-link confirm expiry. Default
+          168h (7 ngày). Admin có thể rút ngắn (vd: 24h cho đợt gấp) hoặc
+          nới (vd: 336h=14d cho đợt dài). */}
+      <div className="space-y-2">
+        <Label htmlFor="confirm_expiry_hours">
+          Thời hạn xác nhận nhập học (giờ)
+        </Label>
+        <Input
+          id="confirm_expiry_hours"
+          type="number"
+          min={1}
+          max={8760}
+          value={form.confirm_expiry_hours}
+          onChange={(e) =>
+            setForm({
+              ...form,
+              confirm_expiry_hours: Number(e.target.value) || 0,
+            })
+          }
+        />
+        <p className="text-xs text-muted-foreground">
+          Sau khi trúng tuyển, thí sinh có {form.confirm_expiry_hours} giờ
+          (~{Math.round((form.confirm_expiry_hours / 24) * 10) / 10} ngày) để
+          xác nhận nhập học qua magic-link. Mặc định 168 giờ (7 ngày).
+        </p>
       </div>
     </div>
   )

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/RoundsManagementTab.tsx
@@ -184,6 +184,11 @@ export function RoundsManagementTab() {
         round_code: r.round_code,
         round_name: `${r.round_name} - ${academicYear}`,
         is_active: true,
+        // Phase 3 schema required these 2 fields; pre-seed defaults
+        // matching ``AdmissionRoundBase`` (multi-NV off, 7-day expiry).
+        // Admin can flip per-round via Sửa đợt after the bulk-create.
+        allow_multi_nv: false,
+        confirm_expiry_hours: 168,
       })),
     })
     setBulkCreateOpen(false)

--- a/frontend/src/app/(dashboard)/admin/system-config/page.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/system-config/page.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Vitest anchor tests for the system-config admin page (Phase 3
+ * close-out 2026-05-14). Verifies the table renders existing rows + the
+ * edit dialog round-trips a value mutation through the mocked hook.
+ *
+ * Non-tautological per memory ``pattern-change-impact-audit``: the
+ * mutation assertion checks the EXACT payload shape (``value`` parsed
+ * back from the JSON-aware textarea), not just "mutate was called".
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import SystemConfigPage from "./page"
+
+const mockMutateAsync = vi.fn()
+
+vi.mock("@/hooks/admin/useSystemConfig", () => ({
+  useSystemConfigList: () => ({
+    data: {
+      total: 2,
+      items: [
+        {
+          key: "max_choices_per_profile",
+          value: 5,
+          description: "Số nguyện vọng tối đa mỗi hồ sơ (Phase 3 Q-P3-01)",
+          updated_at: "2026-05-12T00:00:00Z",
+          updated_by_user_id: 1,
+        },
+        {
+          key: "current_intake_year",
+          value: 2026,
+          description: "Năm tuyển sinh hiện hành (storefront default)",
+          updated_at: "2026-05-09T00:00:00Z",
+          updated_by_user_id: 1,
+        },
+      ],
+    },
+    isLoading: false,
+  }),
+  useUpdateSystemConfig: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>
+}
+
+describe("/admin/system-config page", () => {
+  it("renders heading + the table of config rows", () => {
+    render(wrap(<SystemConfigPage />))
+    expect(screen.getByText("Cấu hình hệ thống")).toBeTruthy()
+    expect(screen.getByText("max_choices_per_profile")).toBeTruthy()
+    expect(screen.getByText("current_intake_year")).toBeTruthy()
+  })
+
+  it("ANCHOR (Phase 3 close-out): edit dialog seeds value + sends parsed JSON on save", async () => {
+    mockMutateAsync.mockReset()
+    render(wrap(<SystemConfigPage />))
+
+    // Open edit dialog for max_choices_per_profile.
+    const editBtn = screen.getByTestId("system-config-edit-max_choices_per_profile")
+    fireEvent.click(editBtn)
+
+    // Value textarea is seeded with the current value rendered as JSON
+    // (number ``5`` → ``"5"`` so JSON.parse will round-trip back to int).
+    const valueInput = screen.getByTestId(
+      "system-config-value-input"
+    ) as HTMLTextAreaElement
+    expect(valueInput.value).toBe("5")
+
+    // Admin edits to ``10``.
+    fireEvent.change(valueInput, { target: { value: "10" } })
+
+    // Submit and verify the mutation receives the parsed-int payload —
+    // NOT the literal string "10". This is the contract that keeps the
+    // BE engine reading an int via SystemConfigService.get_int.
+    fireEvent.click(screen.getByTestId("system-config-submit"))
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledTimes(1)
+    })
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      key: "max_choices_per_profile",
+      data: {
+        value: 10,
+        description: "Số nguyện vọng tối đa mỗi hồ sơ (Phase 3 Q-P3-01)",
+      },
+    })
+  })
+})

--- a/frontend/src/app/(dashboard)/admin/system-config/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/system-config/page.tsx
@@ -1,0 +1,272 @@
+/**
+ * Admin page — runtime system_config key-value editor.
+ *
+ * Phase 3 close-out 2026-05-14: phase3_01 migration seeded
+ * ``max_choices_per_profile=5`` (Q-P3-01) and Phase 1 PR-1D shipped the
+ * backend admin endpoints, but the FE consumer (admin UI) was never
+ * wired. Without this page admin can only mutate config via curl or
+ * direct SQL.
+ *
+ * Keys we expect to live here:
+ *   - ``max_choices_per_profile`` (int) — Phase 3 multi-NV cap
+ *   - ``current_intake_year`` (int) — storefront default year
+ *   - Future: ``zalo_template_approved`` / ``sms_template_approved``
+ *     gating flags (Q-P3-07 follow-up)
+ *
+ * Sensitive keys (secrets, tokens) MUST NOT be stored here — read path
+ * is permissive across active users. Backend service rejects writes for
+ * non-admin via ``require_admin``.
+ */
+"use client"
+
+import { useState } from "react"
+
+import { PageContainer } from "@/components/layouts/PageContainer"
+import { PageHeader } from "@/components/layouts/PageHeader"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Pencil, Loader2 } from "lucide-react"
+
+import {
+  useSystemConfigList,
+  useUpdateSystemConfig,
+} from "@/hooks/admin/useSystemConfig"
+import type { SystemConfigResponse } from "@/lib/zod/system-config"
+
+function formatValueForDisplay(value: unknown): string {
+  if (value === null || value === undefined) return "—"
+  if (typeof value === "string") return value
+  if (typeof value === "number" || typeof value === "boolean") return String(value)
+  // Compact JSON for nested shapes — multi-line view lives in the edit
+  // dialog, the table cell stays single-line readable.
+  return JSON.stringify(value)
+}
+
+function formatValueForEdit(value: unknown): string {
+  if (value === null || value === undefined) return "null"
+  if (typeof value === "string") return value
+  return JSON.stringify(value, null, 2)
+}
+
+/**
+ * Parse the textarea content back into the JSON shape the BE expects.
+ *
+ * BE stores heterogeneous JSONB so we accept:
+ *   - Bare strings (single line, no JSON wrapping)
+ *   - Numbers, booleans, null
+ *   - Arrays / nested objects (valid JSON)
+ *
+ * Order matters: try strict JSON first so ``"5"`` round-trips as a
+ * string and ``5`` parses as int. If JSON.parse fails the input is
+ * treated as a raw string.
+ */
+function parseEditedValue(raw: string): unknown {
+  const trimmed = raw.trim()
+  if (trimmed === "") return ""
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return trimmed
+  }
+}
+
+export default function SystemConfigPage() {
+  const { data, isLoading } = useSystemConfigList()
+  const updateMutation = useUpdateSystemConfig()
+
+  const [editTarget, setEditTarget] = useState<SystemConfigResponse | null>(null)
+  const [valueDraft, setValueDraft] = useState("")
+  const [descriptionDraft, setDescriptionDraft] = useState("")
+
+  const openEdit = (row: SystemConfigResponse) => {
+    setEditTarget(row)
+    setValueDraft(formatValueForEdit(row.value))
+    setDescriptionDraft(row.description ?? "")
+  }
+
+  const closeEdit = () => {
+    setEditTarget(null)
+    setValueDraft("")
+    setDescriptionDraft("")
+  }
+
+  const handleSubmit = async () => {
+    if (!editTarget) return
+    await updateMutation.mutateAsync({
+      key: editTarget.key,
+      data: {
+        value: parseEditedValue(valueDraft),
+        description: descriptionDraft.trim() === "" ? null : descriptionDraft,
+      },
+    })
+    closeEdit()
+  }
+
+  const rows = data?.items ?? []
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Cấu hình hệ thống"
+        description="Chỉnh sửa các tham số runtime của hệ thống (max nguyện vọng / năm tuyển sinh mặc định / cờ tính năng). Giá trị nhận JSON hợp lệ (số, chuỗi, mảng) hoặc text thuần."
+      />
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Các tham số runtime</CardTitle>
+          <CardDescription>
+            Sau khi sửa, giá trị có hiệu lực ngay với mọi request tiếp theo —
+            không cần restart backend. Phím nhạy cảm (secret, token) tuyệt
+            đối không được lưu ở đây.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="space-y-2" data-testid="system-config-loading">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          ) : rows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Chưa có tham số nào được khởi tạo.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Key</TableHead>
+                  <TableHead>Giá trị</TableHead>
+                  <TableHead>Mô tả</TableHead>
+                  <TableHead>Cập nhật gần nhất</TableHead>
+                  <TableHead className="text-right">Thao tác</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.key} data-testid={`system-config-row-${row.key}`}>
+                    <TableCell className="font-mono text-xs">{row.key}</TableCell>
+                    <TableCell className="max-w-xs truncate font-mono text-xs">
+                      {formatValueForDisplay(row.value)}
+                    </TableCell>
+                    <TableCell className="max-w-md text-xs text-muted-foreground">
+                      {row.description ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {new Date(row.updated_at).toLocaleString("vi-VN")}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => openEdit(row)}
+                        data-testid={`system-config-edit-${row.key}`}
+                      >
+                        <Pencil className="mr-1 h-3.5 w-3.5" />
+                        Sửa
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={editTarget !== null} onOpenChange={(o) => !o && closeEdit()}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              Sửa cấu hình: <code>{editTarget?.key}</code>
+            </DialogTitle>
+            <DialogDescription>
+              Giá trị mới được áp dụng ngay. Nhập JSON hợp lệ (số / chuỗi
+              JSON / mảng / object) hoặc plain string. Mọi thay đổi đều ghi
+              audit log.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <label
+                htmlFor="system-config-value"
+                className="text-sm font-medium"
+              >
+                Giá trị
+              </label>
+              <Textarea
+                id="system-config-value"
+                value={valueDraft}
+                onChange={(e) => setValueDraft(e.target.value)}
+                rows={6}
+                className="font-mono text-xs"
+                data-testid="system-config-value-input"
+              />
+              <p className="text-xs text-muted-foreground">
+                Hệ thống thử parse JSON trước; nếu không phải JSON hợp lệ sẽ
+                lưu nguyên dạng chuỗi.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <label
+                htmlFor="system-config-description"
+                className="text-sm font-medium"
+              >
+                Mô tả (tuỳ chọn)
+              </label>
+              <Input
+                id="system-config-description"
+                value={descriptionDraft}
+                onChange={(e) => setDescriptionDraft(e.target.value)}
+                placeholder="Mô tả khoá cấu hình, ghi chú quyết định..."
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={closeEdit}>
+              Huỷ
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={updateMutation.isPending}
+              data-testid="system-config-submit"
+            >
+              {updateMutation.isPending && (
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              )}
+              Lưu
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PageContainer>
+  )
+}

--- a/frontend/src/hooks/admin/useSystemConfig.ts
+++ b/frontend/src/hooks/admin/useSystemConfig.ts
@@ -1,0 +1,60 @@
+/**
+ * React Query hooks for system_config admin CRUD.
+ */
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+
+import {
+  listSystemConfig,
+  updateSystemConfig,
+} from "@/lib/api/system-config"
+import type {
+  SystemConfigListResponse,
+  SystemConfigResponse,
+  SystemConfigUpdate,
+} from "@/lib/zod/system-config"
+import { handleApiError } from "@/lib/error-handler"
+
+const QK = {
+  list: () => ["system-config", "list"] as const,
+  detail: (key: string) => ["system-config", "detail", key] as const,
+}
+
+export function useSystemConfigList() {
+  return useQuery<SystemConfigListResponse>({
+    queryKey: QK.list(),
+    queryFn: listSystemConfig,
+  })
+}
+
+export function useUpdateSystemConfig() {
+  const qc = useQueryClient()
+  return useMutation<
+    SystemConfigResponse,
+    unknown,
+    { key: string; data: SystemConfigUpdate }
+  >({
+    mutationFn: ({ key, data }) => updateSystemConfig(key, data),
+    onSuccess: (updated) => {
+      // Surgical cache update keeps the list in sync without a network
+      // roundtrip; falling back to invalidate would also work but reflows
+      // the table.
+      qc.setQueryData<SystemConfigListResponse>(QK.list(), (prev) => {
+        if (!prev) return prev
+        return {
+          ...prev,
+          items: prev.items.map((row) =>
+            row.key === updated.key ? updated : row
+          ),
+        }
+      })
+      qc.setQueryData(QK.detail(updated.key), updated)
+      toast.success(`Đã cập nhật "${updated.key}"`)
+    },
+    onError: (err) => {
+      handleApiError(err, { context: "cập nhật cấu hình hệ thống" })
+    },
+  })
+}

--- a/frontend/src/hooks/admin/useSystemConfig.ts
+++ b/frontend/src/hooks/admin/useSystemConfig.ts
@@ -16,8 +16,11 @@ import type {
   SystemConfigResponse,
   SystemConfigUpdate,
 } from "@/lib/zod/system-config"
-import type { ApiErrorResponse } from "@/types/api.types"
-import { handleApiError } from "@/lib/error-handler"
+// Import ApiErrorResponse from error-handler so the mutation generic
+// matches the handleApiError parameter type. Two ApiErrorResponse defs
+// exist in this repo (types/api.types vs lib/error-handler) — pairing
+// with handleApiError requires the error-handler one.
+import { handleApiError, type ApiErrorResponse } from "@/lib/error-handler"
 
 const QK = {
   list: () => ["system-config", "list"] as const,

--- a/frontend/src/hooks/admin/useSystemConfig.ts
+++ b/frontend/src/hooks/admin/useSystemConfig.ts
@@ -4,6 +4,7 @@
 "use client"
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import type { AxiosError } from "axios"
 import { toast } from "sonner"
 
 import {
@@ -15,6 +16,7 @@ import type {
   SystemConfigResponse,
   SystemConfigUpdate,
 } from "@/lib/zod/system-config"
+import type { ApiErrorResponse } from "@/types/api.types"
 import { handleApiError } from "@/lib/error-handler"
 
 const QK = {
@@ -33,7 +35,7 @@ export function useUpdateSystemConfig() {
   const qc = useQueryClient()
   return useMutation<
     SystemConfigResponse,
-    unknown,
+    AxiosError<ApiErrorResponse>,
     { key: string; data: SystemConfigUpdate }
   >({
     mutationFn: ({ key, data }) => updateSystemConfig(key, data),

--- a/frontend/src/lib/api/system-config.ts
+++ b/frontend/src/lib/api/system-config.ts
@@ -1,0 +1,40 @@
+/**
+ * System Config API client (Phase 1 PR-1D / phase1_13).
+ *
+ * Mirrors backend ``app/routers/admin_v2_system_config.py``:
+ *   GET    /api/v2/admin/system-config
+ *   GET    /api/v2/admin/system-config/{key}
+ *   PATCH  /api/v2/admin/system-config/{key}
+ *
+ * Sensitive keys MUST NOT live here (env / secrets). Service guard
+ * allows read for any active user but write requires admin.
+ */
+import { api } from "@/lib/api/client"
+import type {
+  SystemConfigListResponse,
+  SystemConfigResponse,
+  SystemConfigUpdate,
+} from "@/lib/zod/system-config"
+
+const BASE = "/api/v2/admin/system-config"
+
+export async function listSystemConfig(): Promise<SystemConfigListResponse> {
+  const res = await api.get<SystemConfigListResponse>(BASE)
+  return res.data
+}
+
+export async function getSystemConfig(key: string): Promise<SystemConfigResponse> {
+  const res = await api.get<SystemConfigResponse>(`${BASE}/${encodeURIComponent(key)}`)
+  return res.data
+}
+
+export async function updateSystemConfig(
+  key: string,
+  payload: SystemConfigUpdate
+): Promise<SystemConfigResponse> {
+  const res = await api.patch<SystemConfigResponse>(
+    `${BASE}/${encodeURIComponent(key)}`,
+    payload
+  )
+  return res.data
+}

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -347,6 +347,16 @@ export const navigationConfig: NavigationConfig = {
           roles: ["admin"], // Only admin can access system configuration
         },
         {
+          // Phase 3 close-out 2026-05-14: runtime key-value system_config
+          // editor (max_choices_per_profile, current_intake_year, future
+          // gating flags). BE shipped phase1_13 PR-1D, FE was the missing
+          // piece — admin previously had to curl/SQL to mutate.
+          label: "Cấu hình hệ thống",
+          href: "/admin/system-config",
+          icon: Cog,
+          roles: ["admin"],
+        },
+        {
           label: "Monitoring",
           href: "/admin/monitoring",
           icon: Activity,

--- a/frontend/src/lib/zod/admission-rounds.ts
+++ b/frontend/src/lib/zod/admission-rounds.ts
@@ -7,12 +7,25 @@
  */
 import { z } from "zod"
 
+// Phase 3 round flags surfaced via phase3_01 migration columns + this PR's
+// Pydantic + FE wiring (Q-P3-02 allow_multi_nv, Q-P3-06 confirm_expiry_hours).
+// Keep validation bounds consistent with Backend_FastAPI/app/schemas/admission_round.py.
+const CONFIRM_EXPIRY_HOURS_MIN = 1
+const CONFIRM_EXPIRY_HOURS_MAX = 8760 // 1 year ceiling, sanity guard.
+
 export const AdmissionRoundCreateSchema = z.object({
   round_code: z.string().min(1).max(20),
   round_name: z.string().min(1).max(100),
   start_date: z.string().nullable().optional(),
   end_date: z.string().nullable().optional(),
   is_active: z.boolean().default(true),
+  allow_multi_nv: z.boolean().default(false),
+  confirm_expiry_hours: z
+    .number()
+    .int()
+    .min(CONFIRM_EXPIRY_HOURS_MIN)
+    .max(CONFIRM_EXPIRY_HOURS_MAX)
+    .default(168),
 })
 
 export const AdmissionRoundUpdateSchema = z.object({
@@ -20,6 +33,13 @@ export const AdmissionRoundUpdateSchema = z.object({
   start_date: z.string().nullable().optional(),
   end_date: z.string().nullable().optional(),
   is_active: z.boolean().optional(),
+  allow_multi_nv: z.boolean().optional(),
+  confirm_expiry_hours: z
+    .number()
+    .int()
+    .min(CONFIRM_EXPIRY_HOURS_MIN)
+    .max(CONFIRM_EXPIRY_HOURS_MAX)
+    .optional(),
 })
 
 export const AdmissionRoundExtendSchema = z.object({
@@ -36,6 +56,13 @@ export const AdmissionRoundBulkCreateItemSchema = z.object({
   start_date: z.string().nullable().optional(),
   end_date: z.string().nullable().optional(),
   is_active: z.boolean().default(true),
+  allow_multi_nv: z.boolean().default(false),
+  confirm_expiry_hours: z
+    .number()
+    .int()
+    .min(CONFIRM_EXPIRY_HOURS_MIN)
+    .max(CONFIRM_EXPIRY_HOURS_MAX)
+    .default(168),
 })
 
 export const AdmissionRoundBulkCreateSchema = z.object({
@@ -54,6 +81,8 @@ export const AdmissionRoundResponseSchema = z.object({
   extended_at: z.string().nullable(),
   extended_by_user_id: z.number().int().nullable(),
   extension_reason: z.string().nullable(),
+  allow_multi_nv: z.boolean(),
+  confirm_expiry_hours: z.number().int(),
   created_at: z.string(),
   updated_at: z.string(),
 })

--- a/frontend/src/lib/zod/system-config.ts
+++ b/frontend/src/lib/zod/system-config.ts
@@ -1,0 +1,41 @@
+/**
+ * Zod schemas for system_config admin surface.
+ *
+ * Mirrors backend ``Backend_FastAPI/app/schemas/system_config.py`` —
+ * ``value`` is intentionally untyped (``z.unknown()``) because the
+ * table stores heterogeneous JSONB shapes (bool / int / string /
+ * list / nested object). The admin UI renders + edits the raw JSON;
+ * shape validation belongs at the consumer site (engine reads
+ * ``max_choices_per_profile`` as int, storefront reads
+ * ``current_intake_year`` as int, etc.).
+ *
+ * Endpoints:
+ *   GET    /api/v2/admin/system-config
+ *   GET    /api/v2/admin/system-config/{key}
+ *   PATCH  /api/v2/admin/system-config/{key}   (admin-only)
+ */
+import { z } from "zod"
+
+export const SystemConfigResponseSchema = z.object({
+  key: z.string(),
+  value: z.unknown(),
+  description: z.string().nullable(),
+  updated_at: z.string(),
+  updated_by_user_id: z.number().int().nullable(),
+})
+
+export const SystemConfigUpdateSchema = z.object({
+  // ``value`` REQUIRED per BE contract — to "clear" admin sends explicit
+  // null/false/0/"" rather than DELETE row. Keep audit + description intact.
+  value: z.unknown(),
+  description: z.string().nullable().optional(),
+})
+
+export const SystemConfigListResponseSchema = z.object({
+  total: z.number().int(),
+  items: z.array(SystemConfigResponseSchema),
+})
+
+export type SystemConfigResponse = z.infer<typeof SystemConfigResponseSchema>
+export type SystemConfigUpdate = z.infer<typeof SystemConfigUpdateSchema>
+export type SystemConfigListResponse = z.infer<typeof SystemConfigListResponseSchema>


### PR DESCRIPTION
## Summary

Closes the **schema-gap** discovered during 2026-05-14 production audit of mùa T05/2026 (đợt 2): the `phase3_01` migration shipped DB columns on 2026-05-12 but never wired the admin schema/UI, so admin had to mutate via direct SQL/curl. Production currently shows DOT_1 ACTIVE with 10 legacy profiles still on single-NV — admin cannot bật multi-NV without this PR.

## What lands

| Layer | Change | Δ LOC |
|---|---|---|
| BE Pydantic | `AdmissionRoundBase` + `Update` + `Response` + `BulkCreateItem` thêm `allow_multi_nv` + `confirm_expiry_hours` | ~33 |
| FE Zod | 4 schemas mirror BE bounds | ~29 |
| FE Form | RoundsManagementTab edit dialog: Checkbox + NumberInput với caption | ~59 |
| FE NEW | `/admin/system-config` page + Zod + API client + hook | ~412 |
| FE Sidebar | "Cấu hình hệ thống" entry trong System group | ~10 |
| Tests | BE anchor PATCH + FE form anchor + FE system-config anchor | ~316 |
| CI | backend-test.yml Tier 2 wire new BE test | +1 |

**Net**: 12 files, +862 LOC. Zero migration. Zero engine touch. Pure schema + UI wiring.

## Bối cảnh nghiệp vụ

Sau audit 2026-05-14:
- 4 đợt/năm: T01-03, **T04-06 (đang trong)**, T07-09, T10-12
- Kênh nộp: kết hợp officer assist + self-service candidate
- Mô hình NV: **nhiều nguyện vọng xếp thứ tự ưu tiên** (giống ĐH/CĐ)
- 10 hồ sơ legacy single-NV LIVE (`uses_choice_engine=false`)
- Admin chưa bật multi-NV được do UI thiếu fields

PR này wire **bước 1/N** trong P0 list:
- ✅ Cấu hình 4 đợt + flags qua UI (PR này)
- ⏳ Wire magic-link 3 actions submit/resubmit/withdraw (separate PR — currently 501 placeholder)
- ⏳ Backfill 10 legacy profile → multi-NV (data migration — separate PR sau khi flag bật)
- ⏳ Enable `uses_choice_engine=true` default cho profile mới khi round có `allow_multi_nv=true` (separate PR BE service)

## Anchor tests (non-tautological per memory `pattern-change-impact-audit`)

**BE** (`tests/api/test_admin_v2_admission_round_phase3_flags.py`):
1. PATCH `allow_multi_nv` persists + round-trips qua GET + sibling field untouched
2. Symmetric anchor cho `confirm_expiry_hours`
3. Out-of-range 0/8761 → 422 + DB row không bị mutate

**FE Round form** (`RoundsManagementTab.test.tsx`):
- Fixture mock seed DOT_1 với `allow_multi_nv=true, confirm_expiry_hours=72`
- Anchor: edit dialog seeds form inputs từ row state (catches `roundToFormState` drift)

**FE System Config** (`system-config/page.test.tsx`):
- Anchor: edit `max_choices_per_profile`, type "10", submit → mutation receives `value: 10` (parsed int) NOT `value: "10"` (string drift catcher)

## Test plan
- [x] Local diff review
- [ ] backend-test.yml Tier 2 RBAC + security chạy 3 new anchor tests
- [ ] frontend-test.yml gate green (path filter triggers on `frontend/**`)
- [ ] Dependency Audit green
- [ ] After merge — prod smoke:
  - Mở `/admin/admission-config?phase=1&step=rounds` → click "Sửa đợt" DOT_1 → 2 fields mới hiển thị + edit + save persist
  - Mở `/admin/system-config` từ sidebar → table show `max_choices_per_profile` + `current_intake_year` → edit `max_choices_per_profile=6` (test) → verify persist
  - Bật `allow_multi_nv=true` cho DOT_1 → tạo profile mới → step 4 "Điểm & Điều kiện" hiển thị ChoiceListEditor (multi-NV mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)