### PR TITLE
feat(phase3-closeout): new-profile inherits multi-NV from round + submit guard

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -152,6 +152,7 @@ jobs:
           tests/api/test_phase3_pr3d_b_choice_crud.py
           tests/api/test_phase3_pr3d_b_admin_backfill.py
           tests/api/test_phase3_pr3e_magic_link.py
+          tests/services/test_phase3_create_profile_inherits_multi_nv.py
           -q --tb=short
 
       # =====================================================================

--- a/Backend_FastAPI/app/repositories/admission_path_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_path_repository.py
@@ -147,6 +147,13 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
 
         ✅ FIX: Eager load admission_method to prevent MissingGreenlet error
         when service code accesses admission_path.admission_method.status.
+
+        Phase 3 close-out 2026-05-14: also eager-load ``admission_round`` so
+        ``admission_service.create_profile`` can read
+        ``admission_path.admission_round.allow_multi_nv`` without a separate
+        SELECT when deciding ``new_profile.uses_choice_engine``. Adds one
+        IN-clause query (selectinload), not a JOIN — keeps the existing
+        FOR UPDATE-friendly shape used by callers.
         """
         query = (
             select(AdmissionPath)
@@ -155,7 +162,8 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
                 AdmissionPath.admission_method_id == admission_method_id
             )
             .options(
-                selectinload(AdmissionPath.admission_method)  # ← FIX: Eager load
+                selectinload(AdmissionPath.admission_method),  # ← FIX: Eager load
+                selectinload(AdmissionPath.admission_round),   # Phase 3 close-out
             )
         )
         result = await self.db.execute(query)

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2880,6 +2880,22 @@ async def create_profile(
         if oac_row:
             offering_config_id = oac_row
 
+    # Phase 3 close-out 2026-05-14 — Q-P3-02 inherit multi-NV mode from
+    # the round on profile creation. The DB column was added by
+    # phase3_01 with server_default=false but no service path was
+    # writing the True branch, so every new profile defaulted to
+    # legacy single-NV regardless of round configuration. Round flag is
+    # eager-loaded on ``admission_path.admission_round`` via the path
+    # repository so no extra SELECT here.
+    #
+    # Fallback chain:
+    #   round present + flag True  → True (Phase 3 multi-NV mode)
+    #   round present + flag False → False (legacy preserved)
+    #   round missing (data drift) → False (safe default, matches DB)
+    inherit_multi_nv: bool = bool(
+        getattr(getattr(admission_path, "admission_round", None), "allow_multi_nv", False)
+    )
+
     # Step 15: Create AdmissionProfile
     new_profile = models.AdmissionProfile(
         lead_id=lead_id,
@@ -2889,6 +2905,7 @@ async def create_profile(
         family_info=[],
         academic_history=[],
         offering_admission_config_id=offering_config_id,
+        uses_choice_engine=inherit_multi_nv,
         # Pre-fill from Lead
         full_name=lead.full_name,
         phone=lead.phone,
@@ -3802,6 +3819,32 @@ async def submit_and_evaluate(
     # Initialize repository for document/citizen_id checks
     from app.repositories import AdmissionRepository
     admission_repo = AdmissionRepository(db)
+
+    # Phase 3 close-out 2026-05-14 — multi-NV profiles MUST carry at
+    # least one ``AdmissionProfileChoice`` before submit. Without this
+    # gate a candidate could submit an empty multi-NV profile, transition
+    # straight to ``reviewing``, then a manager's later publish-result
+    # call would invoke ``evaluate_cascade`` on an empty ``profile.choices``
+    # list — the for-loop iterates zero times and the engine silently
+    # returns ``CascadeResult(final_status='rejected')``, marking the
+    # candidate rejected without any human review.
+    #
+    # Counting via a scalar query (NOT loading the relation) keeps the
+    # FOR UPDATE lock semantics clean and avoids an eager-load that
+    # would otherwise require a relationship-aware lock variant.
+    if profile.uses_choice_engine:
+        from sqlalchemy import func as sa_func, select as sa_select
+        choice_count_result = await db.execute(
+            sa_select(sa_func.count(models.AdmissionProfileChoice.id)).where(
+                models.AdmissionProfileChoice.admission_profile_id == profile.id
+            )
+        )
+        choice_count = choice_count_result.scalar_one()
+        if choice_count == 0:
+            raise BadRequest(
+                "Hồ sơ đa nguyện vọng phải có ít nhất 1 nguyện vọng trước khi nộp. "
+                "Vui lòng thêm nguyện vọng tại bước Điểm & Điều kiện."
+            )
 
     # Must be in draft status
     if profile.status != "draft":

--- a/Backend_FastAPI/tests/services/test_phase3_create_profile_inherits_multi_nv.py
+++ b/Backend_FastAPI/tests/services/test_phase3_create_profile_inherits_multi_nv.py
@@ -63,8 +63,11 @@ async def seed_round_path_lead(admin_user_in_db):
     suffix = uuid.uuid4().hex[:8]
     async with AsyncSessionLocal() as s:
         async with s.begin():
-            # Org / unit
-            unit = (await s.execute(select(models.Unit).limit(1))).scalar_one()
+            # Org / unit — model class is ``OrganizationUnit`` (the field
+            # on Lead is ``unit_id``); fixture pulls any active unit.
+            unit = (
+                await s.execute(select(models.OrganizationUnit).limit(1))
+            ).scalar_one()
 
             # Offering chain
             offering_type_config = models.ConfigOfferingType(
@@ -75,7 +78,10 @@ async def seed_round_path_lead(admin_user_in_db):
             s.add(offering_type_config)
             await s.flush()
 
-            program = (await s.execute(select(models.Program).limit(1))).scalar_one()
+            # Program reference — model class is ``MajorProgram``.
+            program = (
+                await s.execute(select(models.MajorProgram).limit(1))
+            ).scalar_one()
 
             offering = models.ProgramOffering(
                 offering_type=f"p3_inh_{suffix}",
@@ -144,16 +150,16 @@ async def seed_round_path_lead(admin_user_in_db):
             s.add(lead)
             await s.flush()
 
-            # Consultation (create_profile precondition in service v3)
-            stage = (
-                await s.execute(select(models.PipelineStage).limit(1))
-            ).scalar_one()
+            # Consultation (create_profile precondition — service rejects
+            # leads with no_consultation / consultation_missing_status).
+            # ``sts06`` ("Dong y tu van") is seeded by conftest and is
+            # non-universal so it passes the universal-status gate.
             consult = models.Consultation(
                 lead_id=lead.id,
                 method="phone",
                 notes="P3 inherit setup",
                 officer_id=admin_user_in_db["id"],
-                consultation_status_id=stage.id if hasattr(stage, "id") else None,
+                consultation_status_id="sts06",
             )
             s.add(consult)
 

--- a/Backend_FastAPI/tests/services/test_phase3_create_profile_inherits_multi_nv.py
+++ b/Backend_FastAPI/tests/services/test_phase3_create_profile_inherits_multi_nv.py
@@ -34,7 +34,6 @@ import uuid
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import select
 
 from app import models
 from app.database import AsyncSessionLocal
@@ -53,22 +52,20 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest_asyncio.fixture
-async def seed_round_path_lead(admin_user_in_db):
+async def seed_round_path_lead(admin_user_in_db, seed_lead_dependencies):
     """Build the dependency chain create_profile / submit_and_evaluate need.
 
-    Returns a dict with everything the tests reach for + a callback
-    that flips ``round.allow_multi_nv`` in a fresh session so we test
-    the round flag's effect at create_profile time, not at fixture time.
+    Depends on ``seed_lead_dependencies`` to ensure the conftest-seeded
+    OrganizationUnit + MajorProgram + ConsultationStatus rows exist —
+    pulling them via ``select().scalar_one()`` without the dependency
+    raises ``NoResultFound`` in a fresh test DB (conftest seeds these
+    inside the fixture, not at schema init time).
     """
     suffix = uuid.uuid4().hex[:8]
+    unit_id = seed_lead_dependencies["unit_id"]
+    program_id = seed_lead_dependencies["major_program_id"]
     async with AsyncSessionLocal() as s:
         async with s.begin():
-            # Org / unit — model class is ``OrganizationUnit`` (the field
-            # on Lead is ``unit_id``); fixture pulls any active unit.
-            unit = (
-                await s.execute(select(models.OrganizationUnit).limit(1))
-            ).scalar_one()
-
             # Offering chain
             offering_type_config = models.ConfigOfferingType(
                 code=f"p3_inh_{suffix}",
@@ -78,14 +75,9 @@ async def seed_round_path_lead(admin_user_in_db):
             s.add(offering_type_config)
             await s.flush()
 
-            # Program reference — model class is ``MajorProgram``.
-            program = (
-                await s.execute(select(models.MajorProgram).limit(1))
-            ).scalar_one()
-
             offering = models.ProgramOffering(
                 offering_type=f"p3_inh_{suffix}",
-                program_id=program.id,
+                program_id=program_id,
                 offering_type_id=offering_type_config.id,
             )
             s.add(offering)
@@ -144,7 +136,7 @@ async def seed_round_path_lead(admin_user_in_db):
                 phone=f"090{random.randint(1000000, 9999999)}",
                 email=f"p3_inh_{suffix}@test.com",
                 source="website",
-                unit_id=unit.id,
+                unit_id=unit_id,
                 offering_id=offering.id,
             )
             s.add(lead)

--- a/Backend_FastAPI/tests/services/test_phase3_create_profile_inherits_multi_nv.py
+++ b/Backend_FastAPI/tests/services/test_phase3_create_profile_inherits_multi_nv.py
@@ -1,0 +1,284 @@
+"""Phase 3 close-out 2026-05-14 — anchor tests for the new-profile
+multi-NV inheritance + the submit guard for empty multi-NV choices.
+
+Behavior under test
+-------------------
+``admission_service.create_profile()`` now sets
+``new_profile.uses_choice_engine`` to whatever
+``admission_path.admission_round.allow_multi_nv`` is at the moment of
+creation. Before this PR, the column always defaulted to ``false`` at
+the DB layer because no service path wrote the ``True`` branch — so
+even after Phase 3 schema landed, every new profile booted into legacy
+single-NV mode regardless of round configuration.
+
+``admission_service.submit_and_evaluate()`` now blocks submission of a
+multi-NV profile that carries zero ``AdmissionProfileChoice`` rows.
+Without that guard the profile would transition straight into
+``reviewing`` and a later ``publish-result`` call would iterate over
+an empty ``profile.choices`` list — ``evaluate_cascade()`` silently
+returns ``CascadeResult(final_status='rejected')``, the candidate is
+auto-rejected with no human review, and no observable error fires.
+
+Non-tautological anchors (memory ``pattern-change-impact-audit``):
+asserts the EXACT persisted flag value + the EXACT exception class +
+the EXACT message keyword. A regression that drops the inheritance
+read flips Anchor 1 to ``False``; a regression that flips the round
+flag default to ``True`` flips Anchor 2; a regression that strips
+the empty-choices guard surfaces on Anchor 3 with a ``ResourceNotFoundError``
+or no exception at all.
+"""
+from __future__ import annotations
+
+import random
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.services import admission_service
+from app.utils.exceptions import BadRequest
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------
+# Fixture: minimal admission chain seeded with a round + path + lead +
+# active user (for IDOR check inside create_profile). All knobs live on
+# the round so each test toggles ``allow_multi_nv`` independently.
+# ---------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def seed_round_path_lead(admin_user_in_db):
+    """Build the dependency chain create_profile / submit_and_evaluate need.
+
+    Returns a dict with everything the tests reach for + a callback
+    that flips ``round.allow_multi_nv`` in a fresh session so we test
+    the round flag's effect at create_profile time, not at fixture time.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            # Org / unit
+            unit = (await s.execute(select(models.Unit).limit(1))).scalar_one()
+
+            # Offering chain
+            offering_type_config = models.ConfigOfferingType(
+                code=f"p3_inh_{suffix}",
+                name=f"P3 inherit anchor {suffix}",
+                is_active=True,
+            )
+            s.add(offering_type_config)
+            await s.flush()
+
+            program = (await s.execute(select(models.Program).limit(1))).scalar_one()
+
+            offering = models.ProgramOffering(
+                offering_type=f"p3_inh_{suffix}",
+                program_id=program.id,
+                offering_type_id=offering_type_config.id,
+            )
+            s.add(offering)
+            await s.flush()
+
+            academic_info = models.OfferingAcademicInfo(
+                offering_id=offering.id,
+                academic_year=2026,
+                is_published=True,
+            )
+            s.add(academic_info)
+            await s.flush()
+
+            method = models.AdmissionMethod(
+                code=f"p3_method_{suffix}",
+                name="P3 inherit method",
+                is_active=True,
+            )
+            s.add(method)
+            await s.flush()
+
+            criteria = models.AdmissionCriteria(
+                method_id=method.id,
+                code=f"p3_crit_{suffix}",
+                name="P3 inherit criteria",
+                min_gpa=0,
+                is_active=True,
+            )
+            s.add(criteria)
+            await s.flush()
+
+            # Round: default allow_multi_nv=False; individual tests flip.
+            round_obj = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"P3I_{suffix}",
+                round_name=f"P3 inherit {suffix}",
+                is_active=True,
+                allow_multi_nv=False,
+            )
+            s.add(round_obj)
+            await s.flush()
+
+            path = models.AdmissionPath(
+                academic_info_id=academic_info.id,
+                admission_method_id=method.id,
+                admission_round_id=round_obj.id,
+                criteria_id=criteria.id,
+                status="active",
+            )
+            s.add(path)
+            await s.flush()
+
+            # Lead
+            lead = models.Lead(
+                full_name=f"P3 inherit lead {suffix}",
+                phone=f"090{random.randint(1000000, 9999999)}",
+                email=f"p3_inh_{suffix}@test.com",
+                source="website",
+                unit_id=unit.id,
+                offering_id=offering.id,
+            )
+            s.add(lead)
+            await s.flush()
+
+            # Consultation (create_profile precondition in service v3)
+            stage = (
+                await s.execute(select(models.PipelineStage).limit(1))
+            ).scalar_one()
+            consult = models.Consultation(
+                lead_id=lead.id,
+                method="phone",
+                notes="P3 inherit setup",
+                officer_id=admin_user_in_db["id"],
+                consultation_status_id=stage.id if hasattr(stage, "id") else None,
+            )
+            s.add(consult)
+
+            return {
+                "lead_id": lead.id,
+                "round_id": round_obj.id,
+                "admission_method_id": method.id,
+                "academic_year": 2026,
+                "admin_user_id": admin_user_in_db["id"],
+            }
+
+
+async def _set_round_flag(round_id: int, allow_multi_nv: bool) -> None:
+    """Flip the round flag in a fresh session so create_profile reads the
+    persisted value, not whatever the fixture session held in memory."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            r = await s.get(models.OfferingAdmissionRound, round_id)
+            r.allow_multi_nv = allow_multi_nv
+
+
+# ---------------------------------------------------------------------
+# Anchor 1 — Round allow_multi_nv=True → new profile uses_choice_engine=True
+# ---------------------------------------------------------------------
+
+
+async def test_create_profile_inherits_multi_nv_true_when_round_enabled(
+    seed_round_path_lead,
+) -> None:
+    """Round-level multi-NV flag must propagate into the new profile so the
+    Phase 3 engine becomes active for that profile from creation time."""
+    await _set_round_flag(seed_round_path_lead["round_id"], allow_multi_nv=True)
+
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, seed_round_path_lead["admin_user_id"])
+        profile = await admission_service.create_profile(
+            db=s,
+            lead_id=seed_round_path_lead["lead_id"],
+            admission_method_id=seed_round_path_lead["admission_method_id"],
+            current_user=admin,
+            academic_year=seed_round_path_lead["academic_year"],
+        )
+        await s.commit()
+
+        # Re-fetch from a fresh session so we exercise the persisted column,
+        # not the in-memory ORM instance.
+    async with AsyncSessionLocal() as s2:
+        persisted = await s2.get(models.AdmissionProfile, profile.id)
+        assert persisted.uses_choice_engine is True, (
+            "Profile should inherit uses_choice_engine=True when round "
+            f"allow_multi_nv=True; got {persisted.uses_choice_engine!r}"
+        )
+
+
+# ---------------------------------------------------------------------
+# Anchor 2 — Round allow_multi_nv=False → new profile uses_choice_engine=False
+# ---------------------------------------------------------------------
+
+
+async def test_create_profile_inherits_multi_nv_false_when_round_legacy(
+    seed_round_path_lead,
+) -> None:
+    """Legacy backward-compat: when the round has NOT been flipped, new
+    profiles must stay on legacy single-NV mode (the existing 10 prod
+    legacy profiles + future profiles in unconverted rounds rely on this)."""
+    # Round seeded with allow_multi_nv=False by the fixture; assert again
+    # explicitly to harden the test against future fixture drift.
+    await _set_round_flag(seed_round_path_lead["round_id"], allow_multi_nv=False)
+
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, seed_round_path_lead["admin_user_id"])
+        profile = await admission_service.create_profile(
+            db=s,
+            lead_id=seed_round_path_lead["lead_id"],
+            admission_method_id=seed_round_path_lead["admission_method_id"],
+            current_user=admin,
+            academic_year=seed_round_path_lead["academic_year"],
+        )
+        await s.commit()
+
+    async with AsyncSessionLocal() as s2:
+        persisted = await s2.get(models.AdmissionProfile, profile.id)
+        assert persisted.uses_choice_engine is False, (
+            "Profile should default to legacy single-NV when round "
+            f"allow_multi_nv=False; got {persisted.uses_choice_engine!r}"
+        )
+
+
+# ---------------------------------------------------------------------
+# Anchor 3 — Submit guard: multi-NV profile w/ zero choices → BadRequest
+# ---------------------------------------------------------------------
+
+
+async def test_submit_blocked_when_multi_nv_profile_has_no_choices(
+    seed_round_path_lead,
+) -> None:
+    """Without this guard ``evaluate_cascade`` would later iterate an empty
+    list and auto-reject the candidate. Anchor catches a regression that
+    drops the count(choices) check from ``submit_and_evaluate``."""
+    await _set_round_flag(seed_round_path_lead["round_id"], allow_multi_nv=True)
+
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, seed_round_path_lead["admin_user_id"])
+        profile = await admission_service.create_profile(
+            db=s,
+            lead_id=seed_round_path_lead["lead_id"],
+            admission_method_id=seed_round_path_lead["admission_method_id"],
+            current_user=admin,
+            academic_year=seed_round_path_lead["academic_year"],
+        )
+        await s.commit()
+        # Sanity: the new profile is multi-NV per Anchor 1's contract.
+        assert profile.uses_choice_engine is True
+
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, seed_round_path_lead["admin_user_id"])
+        with pytest.raises(BadRequest) as exc_info:
+            await admission_service.submit_and_evaluate(
+                db=s,
+                profile_id=profile.id,
+                current_user=admin,
+            )
+
+    # Message anchor: future readers should see WHY the submit was rejected.
+    assert "nguyện vọng" in str(exc_info.value).lower(), (
+        f"Submit guard message should mention 'nguyện vọng'; "
+        f"got: {exc_info.value!s}"
+    )


### PR DESCRIPTION
## Summary

Closes the **create-side gap** discovered post #292 prod audit. The `OfferingAdmissionRound.allow_multi_nv` column shipped 2026-05-12 (`phase3_01`) and admin can now flip it via the round edit dialog (#292), but no service path was wiring the True branch onto new profiles — every new profile inherited the DB server_default `false` → legacy single-NV regardless of round configuration. Multi-NV stayed dormant on prod even after the admin UI shipped.

## What lands

| File | Change | LOC |
|---|---|---|
| `app/repositories/admission_path_repository.py` | `selectinload(AdmissionPath.admission_round)` (zero extra SELECT) | +9 |
| `app/services/admission_service.py` | `create_profile` reads round flag → sets `uses_choice_engine` + `submit_and_evaluate` guard `count(choices) >= 1` cho multi-NV profile | +43 |
| `tests/services/test_phase3_create_profile_inherits_multi_nv.py` | 3 integration anchor tests | +284 NEW |
| `.github/workflows/backend-test.yml` | Tier 1 allowlist wire | +1 |

**Total**: 337 LOC, 4 files. Zero migration. Zero engine touch. Pure service + guard + tests.

## Behavior changes

### create_profile inherit
- Round `allow_multi_nv=true` → profile mới `uses_choice_engine=true` (Phase 3 multi-NV mode)
- Round `allow_multi_nv=false` → profile mới `uses_choice_engine=false` (legacy preserved)
- Round missing (data drift) → `uses_choice_engine=false` (safe fallback)

### submit_and_evaluate guard
Trước PR này: multi-NV profile với 0 choice có thể submit → transition vào `reviewing` → `publish-result` cascade iterate empty list → silent auto-reject CandidateResult(final_status='rejected') không có human review.

Sau PR này: `BadRequest` ở submit time với message "Hồ sơ đa nguyện vọng phải có ít nhất 1 nguyện vọng trước khi nộp. Vui lòng thêm nguyện vọng tại bước Điểm & Điều kiện."

## Anchor tests (non-tautological per memory `pattern-change-impact-audit`)

1. **Round=True → profile=True**: catches regression where service forgets to read round flag
2. **Round=False → profile=False**: backward-compat anchor cho 10 prod legacy profile + future rounds
3. **Submit multi-NV empty choices → 400 + message anchor**: catches regression strip guard hoặc reword message

## ⚠ Scope boundary

**Unblock create-side** multi-NV adoption nhưng KHÔNG unblock end-to-end self-service submit. Magic-link 3 actions submit/resubmit/withdraw vẫn 501 placeholder (PR #278 docstring). Officer-assist submit qua dashboard hoạt động đầy đủ với PR này.

Memory `phase3-multi-nv-partial-enablement-2026-05-14` documents:
- ✅ Create + officer-assist submit + manager publish + magic-link confirm hoạt động end-to-end
- ❌ Self-service candidate submit/resubmit/withdraw via magic-link vẫn block (separate PR scope)
- ⏳ Backfill 10 legacy profile defer (existing 10 stay legacy, safe fallback)

## Workflow sau khi PR merge + deploy

1. Admin bật `allow_multi_nv=true` cho DOT_2 qua UI (`Sửa đợt`)
2. Officer tạo profile mới → tự động `uses_choice_engine=true`
3. Candidate add ≥1 choice qua ChoiceListEditor (đã ship Bundle 1 PR #272)
4. Officer/candidate submit → guard pass (có choice), state machine transition OK
5. Manager publish-result → engine cascade evaluate
6. Candidate confirm enrollment qua magic-link confirm (đã ship PR #278)

## Test plan
- [x] Local diff review
- [ ] backend-test.yml Tier 1 chạy 3 new anchor tests
- [ ] frontend-test.yml gate green
- [ ] Dependency Audit green
- [ ] After merge — prod smoke:
  - Tạo round mới với `allow_multi_nv=true` (vd: DOT_TEST trong năm 2026)
  - Tạo profile mới qua dashboard cho lead trong round đó
  - Verify profile.uses_choice_engine=true qua DB hoặc admin GET
  - Test submit empty multi-NV profile → 400 với message Vietnamese
  - Add 1 choice + submit lại → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)