### PR TITLE
fix(admission-round): service drops allow_multi_nv + confirm_expiry_hours on create

### DIFF
--- a/Backend_FastAPI/app/services/admission_round_service.py
+++ b/Backend_FastAPI/app/services/admission_round_service.py
@@ -78,6 +78,16 @@ class AdmissionRoundService:
             start_date=payload.start_date,
             end_date=payload.end_date,
             is_active=payload.is_active,
+            # Phase 3 Q-P3-02 / Q-P3-06 — pass-through the 2 round flags
+            # that PR #292 added to the Pydantic schema + FE form. Before
+            # this hotfix the service was dropping both fields on the
+            # floor — admin could check "Cho phép nhiều nguyện vọng"
+            # in the create dialog, see a "Đã tạo đợt tuyển sinh" toast,
+            # but the persisted row would always come back with
+            # allow_multi_nv=false (caught by Phase 1 prod smoke
+            # 2026-05-14 immediately after PR #293 deploy).
+            allow_multi_nv=payload.allow_multi_nv,
+            confirm_expiry_hours=payload.confirm_expiry_hours,
         )
         self.db.add(round_obj)
         await self.db.flush()
@@ -87,6 +97,8 @@ class AdmissionRoundService:
             round_id=round_obj.id,
             academic_year=academic_year,
             round_code=payload.round_code,
+            allow_multi_nv=payload.allow_multi_nv,
+            confirm_expiry_hours=payload.confirm_expiry_hours,
             admin_id=current_admin.id,
         )
         return round_obj
@@ -121,6 +133,13 @@ class AdmissionRoundService:
                 start_date=item.start_date,
                 end_date=item.end_date,
                 is_active=item.is_active,
+                # Phase 3 pass-through — same drift as create() above.
+                # ``AdmissionRoundBulkCreateItem`` ships the 2 round
+                # flags with defaults (False / 168) so existing
+                # "Tạo nhanh 4 đợt" callers keep their legacy behavior
+                # without touching the FE call site.
+                allow_multi_nv=item.allow_multi_nv,
+                confirm_expiry_hours=item.confirm_expiry_hours,
             )
             self.db.add(round_obj)
             try:

--- a/Backend_FastAPI/tests/api/test_admin_v2_admission_round_phase3_flags.py
+++ b/Backend_FastAPI/tests/api/test_admin_v2_admission_round_phase3_flags.py
@@ -173,3 +173,65 @@ async def test_patch_confirm_expiry_hours_rejects_out_of_range(
         )
         row = result.scalar_one()
         assert row.confirm_expiry_hours == 168
+
+
+# ---------------------------------------------------------------------
+# Anchor 4 — POST create endpoint persists Phase 3 flags
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_create_round_persists_phase3_flags(
+    client: AsyncClient,
+    admin_token_headers: dict,
+) -> None:
+    """Service drift caught by prod smoke 2026-05-14 immediately after
+    PR #293 deploy: admin checked ``Cho phép nhiều nguyện vọng`` in the
+    create dialog, the toast confirmed "Đã tạo đợt tuyển sinh", but the
+    persisted row came back with ``allow_multi_nv=false``.
+
+    Root cause: ``AdmissionRoundService.create`` (and ``bulk_create``)
+    instantiated ``OfferingAdmissionRound(...)`` with an explicit kwarg
+    list that did NOT include the 2 Phase 3 fields shipped via PR #292
+    Pydantic. Pydantic accepted the field on input, the service silently
+    dropped it before the INSERT. The PATCH anchors above passed because
+    ``update()`` uses ``setattr(round_obj, field, value)`` dynamically,
+    so the bug was confined to the explicit constructor sites.
+
+    Drift detector: if a future refactor reintroduces the explicit kwarg
+    list without the 2 flags, this anchor catches the regression at CI
+    Tier 2 before another prod surprise.
+    """
+    import time
+    suffix = int(time.time() * 1000) % 1_000_000
+    year = 2000 + (int(time.time()) % 100)
+    payload = {
+        "round_code": f"AT_C_{suffix}",
+        "round_name": f"Anchor create persist {suffix}",
+        "is_active": True,
+        "allow_multi_nv": True,
+        "confirm_expiry_hours": 72,
+    }
+    resp = await client.post(
+        f"/api/v2/admin/years/{year}/rounds",
+        json=payload,
+        headers=admin_token_headers,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["allow_multi_nv"] is True, (
+        "Service dropped allow_multi_nv on INSERT — same drift as the "
+        f"2026-05-14 prod smoke incident. Response body: {body!r}"
+    )
+    assert body["confirm_expiry_hours"] == 72
+
+    # Round-trip via fresh GET against the DB-backed handler to prove the
+    # value actually persisted (not just echoed by the create response).
+    get_resp = await client.get(
+        f"/api/v2/admin/rounds/{body['id']}",
+        headers=admin_token_headers,
+    )
+    assert get_resp.status_code == 200
+    fresh = get_resp.json()
+    assert fresh["allow_multi_nv"] is True
+    assert fresh["confirm_expiry_hours"] == 72


### PR DESCRIPTION
## Summary

🚨 **Hotfix for service-layer drift caught by Phase 1 prod smoke 2026-05-14 within minutes of PR #293 deploy.**

**Bug reproduction**:
1. Admin opens \`Cấu hình Tuyển sinh → Đợt Tuyển sinh → Thêm đợt\`
2. Fills form, **checks** \`Cho phép nhiều nguyện vọng\`, click \`Tạo\`
3. Toast: \`Đã tạo đợt tuyển sinh\` ✓
4. Reopens row → checkbox **unchecked**
5. Direct API \`GET /api/v2/admin/rounds/{id}\` returns \`allow_multi_nv: false\`

## Root cause

\`AdmissionRoundService.create\` + \`bulk_create\` instantiated \`OfferingAdmissionRound(...)\` with an **explicit kwarg list** that did NOT include the 2 Phase 3 fields shipped via PR #292 Pydantic + FE form:

\`\`\`python
# BEFORE (admission_round_service.py:74-81)
round_obj = OfferingAdmissionRound(
    academic_year=academic_year,
    round_code=payload.round_code,
    round_name=payload.round_name,
    start_date=payload.start_date,
    end_date=payload.end_date,
    is_active=payload.is_active,
    # ❌ MISSING: allow_multi_nv, confirm_expiry_hours
)
\`\`\`

Router validated payload OK (Pydantic accepted), service silently dropped fields before INSERT, hence persisted row defaulted to \`false / 168\` regardless of admin input.

**Why PATCH worked but POST didn't**: \`update()\` uses \`setattr(round_obj, field, value)\` over \`model_dump(exclude_unset=True)\` which dynamically forwards every Pydantic field. \`create()\` + \`bulk_create()\` are explicit constructor sites that the PR #292 wiring missed.

## Fix

Add 2 lines to each explicit constructor site forwarding both fields. \`bulk_create\` preserves \"Tạo nhanh 4 đợt\" defaults (False / 168) — admin flips per round via Sửa đợt after.

## Test

Adds **Anchor #4** \`test_post_create_round_persists_phase3_flags\`:
- POST with \`allow_multi_nv=true + confirm_expiry_hours=72\`
- Assert 201 response body echoes both fields
- Re-GET via detail endpoint to prove DB persistence

**Local pytest: 4/4 PASS in 31.11s** pre-push (per memory \`test-before-push\`).

## Lessons

| Memory | Reinforced by |
|---|---|
| \`chrome-mcp-pre-push-smoke\` | PR #292 shipped without smoke verify create flow (only PATCH covered). This bug would have been caught immediately if create dialog had been smoke-tested before push. |
| \`pattern-change-impact-audit\` | When adding fields to schema, audit ALL constructor sites — not just the update path. Setattr-based update is forward-compatible, explicit constructor is not. |
| \`test-before-push\` | Local pytest 31s vs prod smoke catch → confirmed 10x faster + cheaper than waiting for prod observation. |

## Production state

Currently 1 prod row affected: \`TEST_MULTINV\` created during Phase 1 smoke. Will fix manually via PATCH (\`update()\` works correctly) after this PR deploys. No other rounds touched.

## Test plan
- [x] Local pytest 4/4 PASS in 31.11s
- [ ] backend-test.yml Tier 2 anchor #4 PASS
- [ ] frontend-test.yml gate green
- [ ] Dependency Audit green
- [ ] After merge — prod smoke: create new test round with \`allow_multi_nv=true\` → verify GET returns \`allow_multi_nv: true\` (replicate exact Phase 1 smoke that caught this bug)
- [ ] Fix existing TEST_MULTINV row via PATCH or recreate

🤖 Generated with [Claude Code](https://claude.com/claude-code)