### PR TITLE
fix(admission-path): service drops application_fee on create + drift parity anchor

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -153,6 +153,7 @@ jobs:
           tests/api/test_phase3_pr3d_b_admin_backfill.py
           tests/api/test_phase3_pr3e_magic_link.py
           tests/services/test_phase3_create_profile_inherits_multi_nv.py
+          tests/unit/test_admission_path_service_field_drift.py
           -q --tb=short
 
       # =====================================================================

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -286,45 +286,43 @@ class AdmissionPathService:
                     "cần thay đổi."
                 )
 
-        # Create path
-        path = await self.repo.create(
-            {
-                "academic_info_id": data.academic_info_id,
-                "admission_method_id": data.admission_method_id,
-                "admission_round_id": admission_round_id,
-                "round_quota": data.round_quota,
-                "admit_quota": data.admit_quota,
-                "display_name": data.display_name,
-                "display_order": data.display_order,
-                "visibility": data.visibility,
-                "status": "draft",  # Always start as draft
-                # PR #6 — strict-by-default; admin may flip to True on create.
-                "allow_unverified_submission": data.allow_unverified_submission,
-                # Per-path correction allowlist — empty by default, admin may
-                # seed a list at create time. Schema validator already
-                # filtered out non-SAFE entries before reaching here.
-                "minor_correction_allowed_fields": list(
-                    data.minor_correction_allowed_fields or []
-                ),
-                # phase1_03 (#184 Wave 1 PR-1B'-FE/BE micro-patch) — 3
-                # admin-only fields. Pydantic shape already validated
-                # the audience ENUM + method_quota ge=0 + BonusRuleOverride
-                # range; convert the typed shape back to a JSONB-friendly
-                # dict for the JSONB column. None passes through unchanged
-                # (= legacy / no method cap / inherit method bonus default).
-                "applicable_to": (
-                    list(data.applicable_to)
-                    if data.applicable_to is not None
-                    else None
-                ),
-                "method_quota": data.method_quota,
-                "bonus_rule_override": (
-                    data.bonus_rule_override.model_dump()
-                    if data.bonus_rule_override is not None
-                    else None
-                ),
-            }
+        # Create path — drift-immune pattern (2026-05-14 PR #295 lesson
+        # from PR #294 round-flag drift): build the row payload from
+        # ``data.model_dump()`` so every field the Pydantic schema accepts
+        # is forwarded by construction. When schema adds a field, the
+        # service does NOT have to be edited in lockstep — Pydantic-side
+        # validation is the single source of truth.
+        #
+        # Two carve-outs that DON'T come straight from the payload:
+        #   - ``admission_round_id`` may have been auto-resolved to DOT_1
+        #     above (the payload value can be None); we override with the
+        #     resolved id.
+        #   - ``status`` is server-controlled — every newly created path
+        #     starts in ``draft`` regardless of what the caller sent.
+        #
+        # Two field-level shape conversions stay explicit because the
+        # column is JSONB but the Pydantic field is a typed shape /
+        # iterable: ``applicable_to`` (typed enum list → plain list) +
+        # ``bonus_rule_override`` (BonusRuleOverride → dict). They mirror
+        # the same conversions ``update_path`` applies post-model_dump.
+        payload_data = data.model_dump(exclude_unset=False)
+        payload_data["admission_round_id"] = admission_round_id
+        payload_data["status"] = "draft"
+        # minor_correction_allowed_fields: coerce None → [] (schema default
+        # is empty list, but a stale caller could pass None). Keep list()
+        # wrap so the column receives a fresh list instance, not the
+        # validator's internal reference.
+        payload_data["minor_correction_allowed_fields"] = list(
+            payload_data.get("minor_correction_allowed_fields") or []
         )
+        if payload_data.get("applicable_to") is not None:
+            payload_data["applicable_to"] = list(payload_data["applicable_to"])
+        if payload_data.get("bonus_rule_override") is not None:
+            inner = payload_data["bonus_rule_override"]
+            if hasattr(inner, "model_dump"):
+                payload_data["bonus_rule_override"] = inner.model_dump()
+
+        path = await self.repo.create(payload_data)
 
         return path, _noop_callback
 

--- a/Backend_FastAPI/tests/unit/test_admission_path_service_field_drift.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_service_field_drift.py
@@ -1,0 +1,239 @@
+"""PR #295 — anchor tests against the service-explicit-dict field-drop
+drift class (memory ``service-explicit-dict-field-drop-pattern``).
+
+Two anchors:
+
+1. ``test_create_path_persists_application_fee`` — concrete repro of
+   the 2026-05-14 audit finding #2. Before PR #295, ``create_path``
+   built an explicit dict literal that left ``application_fee`` out;
+   admin set a non-zero fee in the FE form → service silently dropped
+   the field → DB row stored ``NULL`` → ``AdmissionPath.requires_
+   application_fee`` returned False → fee gate skipped → downstream
+   ``APPLICATION_FEE_PAID`` event never fired and consultation
+   sts13/sts10 ladders never advanced. Same pattern class as PR #294
+   (round flags) but on a different model.
+
+2. ``test_create_path_dict_payload_covers_every_schema_field`` —
+   generic parity test for the WHOLE schema. Introspects
+   ``AdmissionPathCreate.model_fields`` and the source of
+   ``AdmissionPathService.create_path``. Asserts each Pydantic field
+   is either:
+     a) referenced by name in the service source (positive forward),
+        OR
+     b) on the small ``SERVER_CONTROLLED_OR_RESOLVED`` allowlist
+        (e.g. ``admission_round_id`` is auto-resolved to DOT_1 if the
+        payload value is None; ``status`` is hardcoded to ``draft``).
+   A future PR that adds a field to ``AdmissionPathCreate`` and forgets
+   to plumb it through the service will fail this anchor immediately
+   in CI Tier 1 — catching the drift class structurally, not after a
+   prod symptom.
+
+Non-tautological per memory ``pattern-change-impact-audit``: the
+generic anchor asserts the EXACT field-name presence, not a count.
+A regression that adds 1 field + removes 1 field would still trip
+the assertion on the field that was dropped.
+"""
+from __future__ import annotations
+
+import inspect
+import random
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.schemas.admission_path import AdmissionPathCreate
+from app.services.admission_path_service import AdmissionPathService
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------
+# Fixture chain — minimal path prereqs.
+# ---------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def seed_path_chain(admin_user_in_db, seed_lead_dependencies):
+    """Build the chain ``create_path`` needs: offering + academic_info +
+    method + round. Returns ids + the admin user model for the service
+    call.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            program_id = seed_lead_dependencies["major_program_id"]
+
+            offering_type_config = models.ConfigOfferingType(
+                code=f"pdrift_{suffix}",
+                name=f"Path drift anchor {suffix}",
+                is_active=True,
+            )
+            s.add(offering_type_config)
+            await s.flush()
+
+            offering = models.ProgramOffering(
+                offering_type=f"pdrift_{suffix}",
+                program_id=program_id,
+                offering_type_id=offering_type_config.id,
+            )
+            s.add(offering)
+            await s.flush()
+
+            academic_info = models.OfferingAcademicInfo(
+                offering_id=offering.id,
+                academic_year=2026,
+                is_published=True,
+            )
+            s.add(academic_info)
+            await s.flush()
+
+            method = models.AdmissionMethod(
+                code=f"pdmethod_{suffix}",
+                name="Path drift method",
+                is_active=True,
+            )
+            s.add(method)
+            await s.flush()
+
+            round_obj = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"PD_{suffix}",
+                round_name=f"Path drift round {suffix}",
+                is_active=True,
+                allow_multi_nv=False,
+                confirm_expiry_hours=168,
+            )
+            s.add(round_obj)
+            await s.flush()
+
+            return {
+                "academic_info_id": academic_info.id,
+                "admission_method_id": method.id,
+                "admission_round_id": round_obj.id,
+                "admin_user_id": admin_user_in_db["id"],
+            }
+
+
+# ---------------------------------------------------------------------
+# Anchor 1 — concrete: application_fee persists after create_path
+# ---------------------------------------------------------------------
+
+
+async def test_create_path_persists_application_fee(seed_path_chain) -> None:
+    """Before PR #295: ``create_path`` dict literal omitted
+    ``application_fee`` → DB NULL regardless of payload value. Catches a
+    future regression that reverts the model_dump-based payload back to
+    an explicit dict that drops a field.
+    """
+    from decimal import Decimal
+
+    payload = AdmissionPathCreate(
+        academic_info_id=seed_path_chain["academic_info_id"],
+        admission_method_id=seed_path_chain["admission_method_id"],
+        admission_round_id=seed_path_chain["admission_round_id"],
+        display_name="Path drift anchor",
+        application_fee=Decimal("250000"),  # 250k VND — non-zero, non-default
+    )
+
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, seed_path_chain["admin_user_id"])
+        service = AdmissionPathService(s)
+        path, _cb = await service.create_path(payload, admin)
+        await s.commit()
+        created_id = path.id
+
+    async with AsyncSessionLocal() as s2:
+        persisted = await s2.get(models.AdmissionPath, created_id)
+        assert persisted is not None
+        assert persisted.application_fee is not None, (
+            "application_fee dropped on INSERT — same drift as PR #294 "
+            "round flags. Service must forward the payload field to the "
+            f"ORM column. Got NULL on path id={created_id}."
+        )
+        assert Decimal(persisted.application_fee) == Decimal("250000"), (
+            f"application_fee persisted but wrong value: "
+            f"{persisted.application_fee!r} (expected 250000)"
+        )
+        # Downstream property gate — proves the round-trip reaches the
+        # ``requires_application_fee`` consumer that the original bug
+        # silenced.
+        assert persisted.requires_application_fee is True
+
+
+# ---------------------------------------------------------------------
+# Anchor 2 — generic parity: every Pydantic field reaches the service
+# ---------------------------------------------------------------------
+
+
+# Fields the service intentionally controls / overrides; they will NOT
+# appear in the service source by their Pydantic name because they are
+# resolved/hardcoded server-side.
+SERVER_CONTROLLED_OR_RESOLVED: frozenset[str] = frozenset({
+    # Auto-resolved to DOT_1 if payload value is None; the service writes
+    # the resolved id into ``payload_data["admission_round_id"]`` after
+    # the dump, so the literal name appears in the source via the dict
+    # key — but if the model_dump-based refactor ever drops it, this
+    # carve-out makes the failure explicit. Keep in the allowlist.
+    "admission_round_id",
+})
+
+
+async def test_create_path_payload_covers_every_schema_field() -> None:
+    """Drift-class detector: the service must EITHER forward the payload
+    via ``model_dump()`` (drift-immune by construction) OR mention every
+    ``AdmissionPathCreate`` field by name (explicit forward).
+
+    Two acceptable patterns:
+      a) ``data.model_dump(...)`` / ``payload.model_dump(...)`` —
+         dynamic forward; every field Pydantic accepts auto-flows. PR
+         #295 refactor adopts this.
+      b) Explicit dict / kwarg list — must reference each field by name.
+         The pre-PR #295 ``create_path`` was this shape and dropped
+         ``application_fee``.
+
+    Server-controlled fields (e.g. ``status`` hardcoded ``draft``) bypass
+    both rules via the ``SERVER_CONTROLLED_OR_RESOLVED`` allowlist.
+
+    A regression that removes the ``model_dump()`` call AND fails to
+    list every field by name will fail this anchor — catching the
+    drift class structurally, not after a prod symptom.
+    """
+    import re
+    schema_fields = set(AdmissionPathCreate.model_fields.keys())
+    service_source = inspect.getsource(AdmissionPathService.create_path)
+
+    # Pattern (a) — model_dump call on the payload object.
+    uses_model_dump = bool(
+        re.search(r"\b(data|payload)\s*\.\s*model_dump\b", service_source)
+    )
+
+    if uses_model_dump:
+        # Drift-immune by construction. Anchor passes — the schema is
+        # forwarded as a whole. Future drift via explicit override on
+        # specific keys remains caught by the field-specific Anchor #1
+        # (test_create_path_persists_application_fee).
+        return
+
+    # Pattern (b) — explicit listing. Every field must appear by name.
+    missing: list[str] = []
+    for field in schema_fields:
+        if field in SERVER_CONTROLLED_OR_RESOLVED:
+            continue
+        if field not in service_source:
+            missing.append(field)
+
+    assert not missing, (
+        "Service uses explicit pattern but is missing schema fields: "
+        f"{sorted(missing)}\n\n"
+        "Either:\n"
+        "  - Refactor to ``data.model_dump()`` (drift-immune), OR\n"
+        "  - Add each missing field to the explicit dict / kwarg list, OR\n"
+        "  - Add intentionally server-controlled fields to "
+        "``SERVER_CONTROLLED_OR_RESOLVED`` with a justifying comment.\n\n"
+        "See PR #294 / PR #295 lessons + memory "
+        "``service-explicit-dict-field-drop-pattern``."
+    )


### PR DESCRIPTION
## Summary

🚨 **PATTERN INSTANCE #2** — caught by Path C sweep audit immediately after PR #294 deploy. Same drift class as PR #294 round flags but on a different model.

| Aspect | Detail |
|---|---|
| Bug | \`AdmissionPathService.create_path\` explicit dict literal MISSED \`application_fee\` field |
| Symptom | Admin sets fee qua FE → silent drop → DB stores NULL → fee gate skipped → revenue tracking broken |
| Dev DB audit | 54 paths NULL fee / 1 with fee (~98% NULL-heavy) |
| Drift class | Service-explicit-dict-field-drop-pattern (memory) |
| Fix pattern | Refactor sang \`data.model_dump()\` drift-immune by construction |

## Root cause + fix

\`AdmissionPathCreate\` Pydantic has 14 fields including \`application_fee: Optional[Decimal]\`. \`create_path\` built explicit dict with 13 keys — \`application_fee\` missing. \`update_path\` was OK because it uses dynamic \`payload.model_dump(exclude_unset=True)\`.

**Fix**: refactor \`create_path\` to model_dump pattern. Server-side overrides (\`admission_round_id\` auto-resolved, \`status='draft'\`) applied AFTER dump. JSONB shape conversions (\`applicable_to\`, \`bonus_rule_override\`) preserved.

## Downstream impact (silent bugs)

1. \`AdmissionPath.requires_application_fee\` property returns False when fee is NULL → fee gate skipped
2. \`admission_service.create_profile\` snapshots \`application_fee=0\` + \`fee_status='exempt'\` → candidate UI hiển thị miễn phí
3. \`APPLICATION_FEE_PAID\` event never fires → notification rule doesn't trigger → consultation sts13/sts10 ladders stay frozen

## Anchor tests (2 new)

**Anchor 1**: \`test_create_path_persists_application_fee\` — concrete repro. POST create with \`application_fee=250000\` → re-GET fresh session → assert column + \`requires_application_fee\` property.

**Anchor 2**: \`test_create_path_payload_covers_every_schema_field\` — generic drift parity. Introspects \`AdmissionPathCreate.model_fields\` vs \`inspect.getsource(AdmissionPathService.create_path)\`. Accepts either:
- Source mentions \`data.model_dump()\` (drift-immune), OR
- Source mentions every schema field by name (explicit), OR  
- Field in \`SERVER_CONTROLLED_OR_RESOLVED\` allowlist with comment

Template anchor — copy-pasteable cho next admin-create service touched (in memory).

**Local pytest: 2/2 PASS in 7.26s pre-push** (per \`test-before-push\` rule).

## Memory updates

- Renamed \`service-explicit-constructor-drift\` → \`service-explicit-dict-field-drop-pattern\` per audit recommendation
- Body lists 2 instances (PR #294 + PR #295) + generic anchor template + cost-benefit + architectural fix pattern

## Production remediation parallel

Admin should run (read-only, safe) immediately:

\`\`\`sql
SELECT id, display_name, academic_info_id, admission_method_id,
       application_fee, created_at
FROM admission_path
WHERE created_at >= '2026-01-01' AND application_fee IS NULL
ORDER BY created_at DESC;
\`\`\`

Then PATCH-fix per-row via UI (drift-immune \`update_path\` accepts \`application_fee\` correctly). Avoid bulk SQL UPDATE — intent varies per path.

## Test plan
- [x] Local pytest 2/2 PASS in 7.26s
- [ ] backend-test.yml Tier 1 anchor #1 + #2 PASS
- [ ] frontend-test.yml gate green
- [ ] Dependency Audit green
- [ ] After merge — prod smoke:
  - Tạo path mới với \`application_fee=100000\` qua admin UI
  - Re-GET path → verify \`application_fee\` persists
  - Run prod audit query → list NULL-fee paths created 2026 → admin PATCH-fix per row

🤖 Generated with [Claude Code](https://claude.com/claude-code)