### PR TITLE
hotfix(casbin): backfill NULL v3 eft + patch qae2e01 INSERT (W4-1 BLOCKER)

### DIFF
--- a/Backend_FastAPI/alembic/versions/qae2e01_cleanup_dead_refunds_and_fix_leads_export_casbin.py
+++ b/Backend_FastAPI/alembic/versions/qae2e01_cleanup_dead_refunds_and_fix_leads_export_casbin.py
@@ -88,13 +88,19 @@ def upgrade() -> None:
             )
         )
 
-    # Insert correct entry (idempotent — skip if already exists)
+    # Insert correct entry (idempotent — skip if already exists).
+    # CRITICAL FIX 2026-05-16 (post-merge regression W4-1): include v3 column
+    # (eft = "allow") — Casbin model `p = sub, obj, act, eft` requires all 4
+    # fields. Missing v3 → NULL → load_policy() raises RuntimeError("invalid
+    # policy size") → 500 on every enforce() call → all admission endpoints
+    # crash. qae2e02 hotfix sweeps any NULL v3 rows already in DB.
     op.execute(
         sa.text(
             """
-            INSERT INTO casbin_rule (ptype, v0, v1, v2)
+            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3)
             SELECT CAST('p' AS VARCHAR), CAST('role:manager' AS VARCHAR),
-                   CAST('/api/leads/export' AS VARCHAR), CAST('GET' AS VARCHAR)
+                   CAST('/api/leads/export' AS VARCHAR), CAST('GET' AS VARCHAR),
+                   CAST('allow' AS VARCHAR)
             WHERE NOT EXISTS (
                 SELECT 1 FROM casbin_rule
                 WHERE ptype = 'p'
@@ -108,14 +114,15 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Re-insert dead refunds policies (idempotent)
+    # Re-insert dead refunds policies (idempotent, v3='allow')
     for obj, act in DEAD_REFUNDS:
         op.execute(
             sa.text(
                 """
-                INSERT INTO casbin_rule (ptype, v0, v1, v2)
+                INSERT INTO casbin_rule (ptype, v0, v1, v2, v3)
                 SELECT CAST('p' AS VARCHAR), CAST(:v0 AS VARCHAR),
-                       CAST(:v1 AS VARCHAR), CAST(:v2 AS VARCHAR)
+                       CAST(:v1 AS VARCHAR), CAST(:v2 AS VARCHAR),
+                       CAST('allow' AS VARCHAR)
                 WHERE NOT EXISTS (
                     SELECT 1 FROM casbin_rule
                     WHERE ptype = 'p' AND v0 = :v0 AND v1 = :v1 AND v2 = :v2
@@ -128,14 +135,16 @@ def downgrade() -> None:
             )
         )
 
-    # Restore wrong leads export paths + remove correct one
+    # Restore wrong leads export paths + remove correct one (downgrade
+    # also includes v3='allow' per Casbin policy contract).
     for obj, act in WRONG_LEADS_EXPORT:
         op.execute(
             sa.text(
                 """
-                INSERT INTO casbin_rule (ptype, v0, v1, v2)
+                INSERT INTO casbin_rule (ptype, v0, v1, v2, v3)
                 SELECT CAST('p' AS VARCHAR), CAST('role:manager' AS VARCHAR),
-                       CAST(:v1 AS VARCHAR), CAST(:v2 AS VARCHAR)
+                       CAST(:v1 AS VARCHAR), CAST(:v2 AS VARCHAR),
+                       CAST('allow' AS VARCHAR)
                 WHERE NOT EXISTS (
                     SELECT 1 FROM casbin_rule
                     WHERE ptype = 'p' AND v0 = 'role:manager'

--- a/Backend_FastAPI/alembic/versions/qae2e02_hotfix_null_eft_casbin_rules.py
+++ b/Backend_FastAPI/alembic/versions/qae2e02_hotfix_null_eft_casbin_rules.py
@@ -1,0 +1,82 @@
+"""Hotfix: Sweep ANY casbin_rule policy rows with NULL eft (v3).
+
+Revision ID: qae2e02
+Revises: qae2e01
+Create Date: 2026-05-16
+
+**Regression W4-1** (post-PR #297 deploy 2026-05-16): qae2e01 INSERT
+omitted v3 (eft) column → row 924 `role:manager /api/leads/export GET`
+NULL v3 → Casbin model `p = sub, obj, act, eft` raises RuntimeError
+"invalid policy size" trên load_policy() → ALL admission endpoints
+crash 500 (manifest qua "GET /api/admissions/{id} → 500" trên FE).
+
+User dev fix manual UPDATE row 924 v3='allow'. Prod chưa apply qae2e01
+(version=phase3_01 tại thời điểm hotfix) → cần migration đảm bảo cả 2
+guarantees:
+
+1. **qae2e01 source** đã được patch include v3 column → fresh
+   deploys/installs sẽ INSERT đúng.
+2. **qae2e02** (this) sweep ANY NULL v3 'p' rows (defense in depth):
+   - Dev: row 924 đã fix manual, NULL=0, no-op
+   - Prod: khi deploy chain qae2e01 → qae2e02 chạy ngay sau → guarantee
+     không còn NULL trước khi app khởi động Casbin reload
+   - Catches old migrations (bb2j3k4l5m6n, dd5m6n7o8p9q,
+     idor20260216001, etc.) cũng có pattern same bug nhưng prod chưa
+     surface (rows có thể được template re-seed cover trong bootstrap)
+
+Default `allow` chọn vì:
+- Tất cả NULL eft rows hiện được INSERT bởi migration "add allow policy",
+  không bao giờ deny (deny rules luôn explicit eft='deny' trong
+  policy_templates.py).
+- Casbin matcher fail-closed nếu no allow match → defensive default.
+
+Idempotent + safe re-run.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "qae2e02"
+down_revision: Union[str, None] = "qae2e01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Sweep NULL v3 (eft) policy rows → set to 'allow' default.
+    # CAST literal to VARCHAR to avoid asyncpg parameter type ambiguity
+    # (memory `migration-systemevents-value-case` lesson).
+    result = op.get_bind().execute(
+        sa.text(
+            """
+            UPDATE casbin_rule
+            SET v3 = CAST('allow' AS VARCHAR)
+            WHERE ptype = CAST('p' AS VARCHAR)
+              AND v3 IS NULL
+            """
+        )
+    )
+    # Log count for ops audit visibility — Alembic captures into deploy
+    # log so ops can verify how many rows hotfix touched.
+    op.execute(
+        sa.text(
+            f"""
+            DO $$
+            BEGIN
+                RAISE NOTICE 'qae2e02 hotfix: backfilled % NULL eft row(s) to allow',
+                    {result.rowcount};
+            END $$;
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # No-op: we can't reliably distinguish rows that were hotfixed from
+    # rows naturally 'allow'. Downgrading would require an audit log we
+    # don't have, and reverting would re-introduce the Casbin crash bug.
+    # Per memory `migration-predicate-safety`: only downgrade when safe.
+    pass

--- a/Backend_FastAPI/tests/integration/test_qa_e2e_casbin_path_alignment.py
+++ b/Backend_FastAPI/tests/integration/test_qa_e2e_casbin_path_alignment.py
@@ -19,10 +19,14 @@ test fail loudly.
 """
 from __future__ import annotations
 
+import pytest
+from sqlalchemy import text
+
 from app.casbin_config.policy_templates import (
     ACCOUNTANT_TEMPLATE,
     MANAGER_TEMPLATE,
 )
+from app.database import AsyncSessionLocal
 from app.main import fastapi_app
 
 
@@ -103,4 +107,44 @@ def test_leads_export_template_matches_actual_route():
         f"Orphan MANAGER_TEMPLATE entries pointing to non-existent paths "
         f"(/api/leads/export/csv|excel are 404; actual route uses "
         f"query param ?format=): {orphans}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_policy_rows_with_null_eft():
+    """W4-1 hotfix anchor: KHÔNG có 'p' (policy) row nào có v3 (eft) NULL.
+
+    Casbin model `p = sub, obj, act, eft` REQUIRE đầy đủ 4 fields. NULL v3
+    triggers `RuntimeError("invalid policy size")` trên load_policy() →
+    Casbin enforcer chết → all endpoints crash 500.
+
+    History (PR #297 deploy 2026-05-16):
+    - Migration qae2e01 INSERT thiếu cột v3 → row 924 NULL eft
+    - Manifest qua FE: GET /api/admissions/{id} → 500
+    - User fix manual UPDATE row 924 SET v3='allow'
+    - qae2e02 hotfix sweep + qae2e01 source patched include v3
+
+    Pattern bug từng xuất hiện trong nhiều migrations cũ
+    (bb2j3k4l5m6n, dd5m6n7o8p9q, idor20260216001) — đó là tại sao test
+    này là DB-runtime check, không chỉ template check.
+
+    Re-introducing INSERT thiếu v3 sẽ fail test này.
+    """
+    async with AsyncSessionLocal() as s:
+        result = await s.execute(
+            text(
+                """
+                SELECT id, v0, v1, v2, template_id
+                FROM casbin_rule
+                WHERE ptype = 'p' AND v3 IS NULL
+                ORDER BY id
+                LIMIT 20
+                """
+            )
+        )
+        rows = result.fetchall()
+    assert not rows, (
+        f"Found {len(rows)} policy rows with NULL eft — will crash Casbin "
+        f"load_policy(). Fix migration to include v3='allow' or 'deny'. "
+        f"Offending rows: {[(r.id, r.v0, r.v1, r.v2, r.template_id) for r in rows]}"
     )

--- a/Documents/QA_E2E_FINDINGS_2026-05-15.md
+++ b/Documents/QA_E2E_FINDINGS_2026-05-15.md
@@ -1,5 +1,51 @@
 # QA E2E FINDINGS — 2026-05-15 → 2026-05-16
 
+## 🔬 WAVE 4 — Chrome MCP runtime re-test (2026-05-16 ~15:30 UTC+7)
+
+### Browser-verified admission fixes
+
+| # | Test | Evidence (snapshot UID) | Status |
+|---|---|---|---|
+| F4 | Officer sidebar không có "Backfill Queue" | uid=27_3..27_27 — sidebar 7 nav items + 5 recent pages (Performance Dashboard/39/42/Create/410), không có Backfill Queue | ✅ |
+| F1+F2 | Profile 42 Step 4 → "Thêm nguyện vọng" dialog | uid=30_0 dialog "Thêm nguyện vọng NV4" + cascading dropdown "Ngành / Phương thức xét tuyển", KHÔNG còn error "Không xác định được đợt" | ✅ |
+| F2 list | "Danh sách nguyện vọng (3/5)" với NV1+NV2+NV3 render đầy đủ | uid=29_4..29_55 — 3 choices với drag handles + edit/delete buttons; NV2+NV3 scores hiển thị `math/physics/chemistry` 7.00/7.50/8.00 và `math/chemistry/english` 7.00/7.50/8.00 | ✅ |
+| W2-1 officer | "Gửi link rút hồ sơ" dialog mở với URL + Copy | uid=32_0 dialog "Liên kết rút hồ sơ tuyển sinh" + URL `http://localhost:3000/magic-link/withdraw/uXEM8R...` + Copy + Close. Expiry 23/5/2026 (7 ngày) | ✅ |
+| W2-1 admin | Admin profile 39 also có "Gửi link rút hồ sơ" button | uid=33_220 visible cho admin trên submitted profile | ✅ |
+| F6 | Admin trên profile 39 KHÔNG có Override button (status=submitted, only approved → overridden) | uid=33_215..219 chỉ có: Tiếp tục/Phê duyệt vượt điều kiện/Từ chối/Yêu cầu sửa/Nhận duyệt — không có Override (correct per state machine) | ✅ |
+| F7 | Admin profile 39 banner ⚠️ + "Phê duyệt (vượt điều kiện)" | uid=33_140-148 banner "⚠️ Hồ sơ này được nộp trong chế độ bỏ qua xét duyệt sơ bộ" + 7 lỗi count; uid=33_216 button "Phê duyệt (vượt điều kiện)" với haspopup="dialog" | ✅ |
+
+### 🟥 BLOCKER REGRESSION found + FIXED in Wave 4
+
+| # | Sev | Title | Root Cause | Fix |
+|---|---|---|---|---|
+| **W4-1** | 🟥 → ✅ | **ALL admission GET endpoints 500 "invalid policy size"** | Casbin row id=924 `role:manager / /api/leads/export / GET` có v3 (eft) NULL. Casbin model `p = sub, obj, act, eft` requires 4 fields; NULL eft raises RuntimeError ở matcher. Row được insert trong wave fix W2-3 (PR #297 qae2e01) nhưng INSERT chỉ 4 cột (ptype, v0, v1, v2) thiếu v3. | **Operational** (dev): `UPDATE casbin_rule SET v3='allow' WHERE id=924`; reload Casbin → 200 OK. **Source fix** (PR hotfix qae2e02): (1) Patch qae2e01 source INSERT include v3='allow' cho fresh installs; (2) qae2e02 migration sweep `UPDATE WHERE v3 IS NULL` defense-in-depth cho existing envs (prod chạy chain qae2e01→qae2e02 → guarantee 0 NULL trước Casbin reload); (3) Anchor test `test_no_policy_rows_with_null_eft` query live DB ngăn future regression; (4) Memory `casbin-insert-must-include-eft` lock pattern. |
+
+### Wave 4 execution log
+- **15:25** Login officer → sidebar verified clean (F4)
+- **15:26** Navigate `/admissions/42` → page CRASH với 500 error. Console: `API Error (500) ... <AdmissionDetailPageContent>` → ErrorBoundary catch
+- **15:27** Probe BE: ALL profiles (16/17/18/20/39/42) → 500. Logs reveal: `RuntimeError: invalid policy size`
+- **15:28** Audit casbin_rule: found row id=924 với v3 NULL (manager export endpoint, recent fix gone wrong).
+- **15:29** Fix v3='allow' + reload Casbin → all profiles 200
+- **15:30** Reload browser → profile 42 load OK; Step 4 → "(3/5)"; AddChoiceDialog NV4 mở OK; "Gửi link rút hồ sơ" dialog OK
+- **15:32** Admin login → profile 39 → F7 banner + warning button OK
+
+### Final admission status sau Wave 4
+
+| Layer | Status |
+|---|---|
+| All Wave 1-2 admission BE fixes (F1, F2, F3, F5, F6, F7, F8) | ✅ Runtime-verified browser |
+| Wave 3 user fix W2-1 (multi-action magic-link generate) | ✅ Runtime-verified browser (URL generated + copy dialog OK) |
+| Wave 4 regression W4-1 (Casbin v3 NULL) | ✅ Fixed in DB + reload |
+| **Admission module open bugs** | **0** |
+
+### Wave 4 cleanup notes
+
+- Row 924 trong casbin_rule có template_id=NULL (manual insert, không track template lineage). Cần verify `policy_templates.py` có entry tương ứng và sync proper format (`eft: "allow"`) khi seed lại từ template — nếu không sẽ tái xuất hiện sau lần reset Casbin tiếp theo.
+- Profile 16 vẫn ở state `withdrawn` (sau Wave 3 magic-link consume test). Restore nếu cần data fixture cũ.
+- Profile 42 hiện 3 choices (NV1 no-scores, NV2 A00, NV3 D07).
+
+---
+
 ## 🔁 WAVE 3 RE-TEST — Admission module sau user fix (2026-05-16 ~11:30 UTC+7)
 
 ### Kết quả


### PR DESCRIPTION
## 🟥 Severity: BLOCKER — prevents prod deploy of qae2e01

## Summary
W4-1 surfaced bởi Chrome MCP smoke 2026-05-16 sau PR #297 apply dev — ALL admission/lead/profile GET endpoints crash **500 \`RuntimeError: invalid policy size\`**. User fix dev manual; prod chưa apply qae2e01 (alembic=phase3_01) → **next deploy sẽ down prod toàn bộ admission/lead module**.

## Root cause
\`Backend_FastAPI/alembic/versions/qae2e01_*.py\` line 95-97:

\`\`\`sql
INSERT INTO casbin_rule (ptype, v0, v1, v2)  -- ❌ missing v3 (eft)
SELECT 'p', 'role:manager', '/api/leads/export', 'GET' ...
\`\`\`

Casbin model: \`p = sub, obj, act, eft\` (4 fields required). NULL v3 → \`enforcer.load_policy()\` raises RuntimeError → all Casbin-protected endpoints crash.

## Fix (3-layer defense)

1. **Patch qae2e01 source** — INSERT include \`v3='allow'\` (upgrade + downgrade). Fresh deploys/test DB recreate sẽ insert đúng.
2. **qae2e02 hotfix migration** (NEW) — \`UPDATE casbin_rule SET v3='allow' WHERE ptype='p' AND v3 IS NULL\` sweep cho existing envs. Prod chain: qae2e01 → qae2e02 → guarantee 0 NULL trước Casbin reload startup. Bonus: catches OLD migrations (bb2j3k4l5m6n, dd5m6n7o8p9q, idor20260216001) cũng có cùng pattern.
3. **Anchor test** \`test_no_policy_rows_with_null_eft\` — runtime DB query, fail loudly nếu future migration thiếu v3.

## Changes
- \`alembic/versions/qae2e01_*.py\` — patch INSERT include v3
- \`alembic/versions/qae2e02_hotfix_null_eft_casbin_rules.py\` — NEW sweep + ops audit RAISE NOTICE
- \`tests/integration/test_qa_e2e_casbin_path_alignment.py\` — anchor #3 NULL eft check
- \`Documents/QA_E2E_FINDINGS_2026-05-15.md\` — W4-1 source-fix detail

## Test plan
- [x] alembic upgrade head: clean
- [x] DB probe: 0 NULL v3 rows, row 924 v3='allow'
- [x] 3/3 anchor tests pass + 5/5 Casbin matrix regression
- [x] Live probe /api/leads/export + /api/admissions/42 → 401 (auth required, not 500)
- [ ] CI green
- [ ] Post-merge: deploy + verify prod Casbin reload không crash, monitor logs cho RuntimeError

## Memory
- New: \`casbin-insert-must-include-eft\` — lock pattern + ops rollback recipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)