### PR TITLE
fix(api): Literal sort_by/order validation (QA Wave 5 Q-INFO-1 + Q-BUG-1 closeout)

### DIFF
--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -19,7 +19,7 @@ Endpoints:
 """
 
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status, UploadFile, File, Form
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
@@ -99,8 +99,14 @@ async def list_admission_profiles(
     payment_status: str | None = Query(None, description="Filter by payment status (paid/unpaid/partial/no_fee)"),
     date_from: datetime | None = Query(None, description="Filter from date (created_at)"),
     date_to: datetime | None = Query(None, description="Filter to date (created_at)"),
-    sort_by: str = Query("created_at", description="Sort field (created_at, updated_at, full_name, status)"),
-    order: str = Query("desc", description="Sort order (asc, desc)"),
+    sort_by: Literal["created_at", "updated_at", "full_name", "status"] = Query(
+        "created_at",
+        description="Sort field — repo silently fell back to created_at for invalid values until 2026-05-16 (Q-INFO-1 fix). Mirror FE Zod `AdmissionListParams.sort_by`.",
+    ),
+    order: Literal["asc", "desc"] = Query(
+        "desc",
+        description="Sort order — repo defaulted to asc for any non-`desc` value until 2026-05-16. Mirror FE Zod `AdmissionListParams.order`.",
+    ),
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(20, ge=1, le=100, description="Items per page"),
     db: AsyncSession = Depends(database.get_db),

--- a/Backend_FastAPI/tests/api/test_admissions_list_query_validation.py
+++ b/Backend_FastAPI/tests/api/test_admissions_list_query_validation.py
@@ -1,0 +1,86 @@
+"""Q-INFO-1 anchor: /api/admissions list query param validation.
+
+Wave 5 (2026-05-16) adversarial bug hunting surfaced:
+- `sort_by=invalid_field` → 200 silent ignore (repo fallback to created_at)
+- `order=BAD` → 200 silent ignore (repo defaulted to asc for any non-`desc`)
+
+Both fixed by promoting Query type to Literal[...] enum in router so
+FastAPI/Pydantic auto-422 với clear "Input should be ..." message.
+
+Anchor verifies:
+1. Invalid sort_by → 422 với literal_error
+2. Invalid order → 422 với literal_error
+3. All 4 valid sort_by values accepted → 200
+4. Both valid order values accepted → 200
+
+Non-tautological: hits real route, not just schema introspection.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_list_admissions_sort_by_invalid_returns_422(
+    client: AsyncClient, admin_token_headers: dict
+):
+    """sort_by=invalid → 422 literal_error (Q-INFO-1 fix)."""
+    response = await client.get(
+        "/api/admissions?sort_by=invalid_field&page_size=1",
+        headers=admin_token_headers,
+    )
+    assert response.status_code == 422, response.text
+    body = response.json()
+    assert body["error_code"] == "VALIDATION_ERROR"
+    # Validate the literal_error type + sort_by location
+    errors = body["errors"]
+    sort_err = next((e for e in errors if e["loc"] == ["query", "sort_by"]), None)
+    assert sort_err is not None, f"No sort_by error in: {errors}"
+    assert sort_err["type"] == "literal_error"
+
+
+async def test_list_admissions_order_invalid_returns_422(
+    client: AsyncClient, admin_token_headers: dict
+):
+    """order=BAD → 422 literal_error (Q-INFO-1 fix)."""
+    response = await client.get(
+        "/api/admissions?order=BAD&page_size=1",
+        headers=admin_token_headers,
+    )
+    assert response.status_code == 422, response.text
+    errors = response.json()["errors"]
+    order_err = next((e for e in errors if e["loc"] == ["query", "order"]), None)
+    assert order_err is not None, f"No order error in: {errors}"
+    assert order_err["type"] == "literal_error"
+
+
+@pytest.mark.parametrize(
+    "sort_by", ["created_at", "updated_at", "full_name", "status"]
+)
+async def test_list_admissions_all_valid_sort_by_accepted(
+    client: AsyncClient, admin_token_headers: dict, sort_by: str
+):
+    """4 valid sort_by values from FE Zod AdmissionListParams accepted."""
+    response = await client.get(
+        f"/api/admissions?sort_by={sort_by}&page_size=1",
+        headers=admin_token_headers,
+    )
+    assert response.status_code == 200, (
+        f"Valid sort_by={sort_by!r} rejected: {response.text}"
+    )
+
+
+@pytest.mark.parametrize("order", ["asc", "desc"])
+async def test_list_admissions_both_order_values_accepted(
+    client: AsyncClient, admin_token_headers: dict, order: str
+):
+    """Both order values from FE Zod accepted."""
+    response = await client.get(
+        f"/api/admissions?order={order}&page_size=1",
+        headers=admin_token_headers,
+    )
+    assert response.status_code == 200, (
+        f"Valid order={order!r} rejected: {response.text}"
+    )

--- a/Documents/QA_E2E_FINDINGS_2026-05-15.md
+++ b/Documents/QA_E2E_FINDINGS_2026-05-15.md
@@ -1,5 +1,141 @@
 # QA E2E FINDINGS — 2026-05-15 → 2026-05-16
 
+## 🎨 WAVE 6 — §R/§S/§T a11y + mobile + performance (2026-05-16 ~17:00 UTC+7)
+
+### Coverage matrix
+
+| Section | Test | Result |
+|---|---|---|
+| §R.1 Lighthouse a11y `/admissions/42` | desktop snapshot | **86/100** (7 failed audits) |
+| §R.2 Custom DOM probe | manual scan | 0 img/button/link issues; **2 orphan inputs** |
+| §R.2 Landmarks | main/nav/banner/skip-link | ✅ all present + `lang="vi"` |
+| §S.1 Mobile viewport 375×812 | emulated iPhone, no body overflow | ✅ |
+| §S.2 Touch targets | sidebar nav < 44×44 | **🟧 8+ targets 36×36** |
+| §S.2 Action bar mobile | sticky bottom w=549 > viewport 375 | **🟧 overflow ngang** |
+| §S.2 Sidebar collapse | hamburger present | ✅ |
+| §T.1 API timing 10 endpoints (5 runs each) | p50/p95 | mostly < 200ms ✅ |
+| §T.1 /api/officer/dashboard cold | first call | 🟧 433ms (then 210ms warm) |
+| §T.1 /api/admin/users cold | first call | 🟧 1.8s (then 44ms warm) |
+| §T.2 LCP profile detail | trace | ✅ 1352ms (good range) |
+| §T.2 CLS | trace | ✅ 0.04 (excellent <0.1) |
+| §T.2 TTFB | trace | 381ms — borderline |
+
+### NEW findings (6)
+
+| # | Sev | Module | Title | Detail |
+|---|---|---|---|---|
+| **R-BUG-1** | 🟧 | Admission (Step 1 Personal) | **2 input orphan không label** | PUT /admissions/{id} Step 1 personal-info có 2 textboxes thiếu label/aria-label: "Tổ dân phố / Thôn / Buôn / Ấp / Khóm / Khu phố" và "Số nhà, tên đường". Chỉ có placeholder. Screen reader user sẽ không biết field nào. Fix: add `<label>` hoặc `aria-label`. |
+| **R-INFO-1** | 🟦 | Frontend global | Lighthouse a11y 86/100 — 7 audit fails | Cần inspect HTML report tại `chrome-devtools-mcp-Qd8qsF/report.html` để biết chi tiết 7 fails (color contrast, ARIA roles, focus order...). |
+| **S-BUG-1** | 🟧 | Frontend layout | **Sticky action bar overflow ngang mobile** (375px viewport) | DIV `.flex items-center gap-3` w=549px > viewport 375px → users phải scroll ngang để thấy buttons. Trên iPhone SE/13 cũ unusable. Fix: action bar responsive (stack vertically <640px hoặc reduce button labels to icons). |
+| **S-BUG-2** | 🟧 | Frontend sidebar | **Touch targets 32-36×36 < 44×44 Apple HIG** | Sidebar nav links 36×36, logo 32×32. Mobile tap accuracy thấp, accidental taps frequent. Fix: increase padding sidebar items mobile, hoặc collapse to hamburger ở all mobile widths (hiện vẫn show ở >mobile widths). |
+| **T-INFO-1** | 🟨 | Backend | `/api/admin/users` cold path 1.8s | First call sau backend restart slow → cached subsequent calls 44ms (40x faster). Có thể do query không có index, Casbin re-init, hoặc lazy-loaded relationships. Phase 1 P2 audit recommended. |
+| **T-INFO-2** | 🟨 | Backend | `/api/officer/dashboard` p95 433ms cold | Aggregation query (lead stats + KPI). Acceptable nhưng > 300ms target. Consider materialized view hoặc Redis cache 30s. |
+
+### Strong scores
+
+| Metric | Value | Target | Status |
+|---|---|---|---|
+| Lighthouse Best Practices | 100 | ≥90 | ✅ |
+| Lighthouse a11y | 86 | ≥90 | 🟨 |
+| LCP profile detail | 1352ms | <2500ms good / <1200ms fast | ✅ good |
+| CLS profile detail | 0.04 | <0.1 | ✅ excellent |
+| TTFB | 381ms | <600ms | ✅ |
+| API list endpoints p95 | <115ms | <500ms | ✅ |
+| API detail endpoints p95 | <61ms | <200ms | ✅ |
+| API notifications | <25ms | <100ms | ✅ |
+| Body overflow X mobile 375 | 0px | 0 | ✅ |
+| Sidebar hamburger collapse | works | works | ✅ |
+| `lang="vi"` page declaration | present | present | ✅ |
+| Skip-link to main content | present | present | ✅ |
+
+### Wave 6 execution log
+- **16:50** Login officer + navigate /admissions/42 (after Wave 5 token expiry)
+- **16:52** Lighthouse desktop snapshot: 86 a11y / 100 BP / 80 SEO. 7 failed audits.
+- **16:53** Custom DOM probe: 0 img/button/link issues; 2 orphan inputs (address fields)
+- **16:55** Mobile emulate 375×812: no body overflow, but action bar 549px overflow + 8 small touch targets
+- **16:58** Performance API timing: 10 endpoints × 5 runs. Most <100ms. Outliers: dashboard 433ms cold, admin/users 1.8s cold.
+- **17:00** Performance trace profile detail: LCP 1352ms (TTFB 381 + render 971), CLS 0.04
+
+### Wave 6 follow-ups
+1. **R-BUG-1 orphan inputs** 🟧 — add `<label htmlFor="...">` hoặc `aria-label` cho 2 address fields Step 1.
+2. **S-BUG-1 action bar overflow mobile** 🟧 — responsive layout: icon-only mode <640px, hoặc 2-row stack.
+3. **S-BUG-2 touch targets** 🟧 — increase padding sidebar mobile (min-height: 44px).
+4. **T-INFO-1 admin/users cold 1.8s** 🟨 — profile query, add DB index nếu thiếu, hoặc warmup script.
+5. **T-INFO-2 officer/dashboard 433ms** 🟨 — Redis cache 30s cho aggregation widgets.
+6. **R-INFO-1 Lighthouse 7 fails** 🟦 — inspect HTML report cho detailed audit list.
+
+---
+
+## 🎯 WAVE 5 BUG HUNTING — §Q Adversarial (2026-05-16 ~16:00 UTC+7)
+
+### Coverage matrix
+33 scenarios across 4 categories. **32 mitigated · 1 minor bug · 1 minor leniency · 1 by-design info**.
+
+| Section | Run | Pass | Bugs |
+|---|---|---|---|
+| §Q.1.1 Mass-assignment (status/year/applied_rules/is_dropped) | 4 | 4 ✅ | 0 |
+| §Q.1.2 IDOR escalation (cross-officer PATCH/admin audit/role escalate) | 3 | 3 ✅ | 0 |
+| §Q.1.3 SQL injection (OR 1=1, DROP TABLE, UNION SELECT password_hash) | 3 | 3 ✅ | 0 |
+| §Q.1.5 JWT tamper (role officer→admin no re-sign) | 1 | 1 ✅ | 0 |
+| §Q.1.6 CSRF (POST no X-CSRF-Token) | 1 | 1 ✅ | 0 |
+| §Q.2.1 Field validation boundary | 8 | 6 ✅ + 1 ⚠️ + 1 🟧 | 1 |
+| §Q.2.3 Pagination edge | 5 | 4 ✅ + 1 🟨 | 1 |
+| §Q.2.4 Bulk schema discovery | 1 | 1 ✅ | 0 |
+| §Q.3 State machine invalid jump | 2 | 2 ✅ | 0 |
+| §Q.4.3 Audit log gap | 1 | 1 ✅ | 0 |
+| §Q.4.4 Bulk version locking | 1 | 1 ✅ | 0 |
+| §Q.4.5 Magic-link race (5 parallel) | 1 | 1 ✅ | 0 |
+| §Q.4.6 Webhook signature | 2 | 2 🟦 by-design | 0 |
+| §Q.5 Rate limit login spam | 1 | 1 ✅ (429 from req 3) | 0 |
+
+### NEW findings (3)
+
+| # | Sev | Module | Title | Detail |
+|---|---|---|---|---|
+| **Q-BUG-1** | 🟧 → ⚠️ | Admission | **NOT REPRODUCIBLE 2026-05-16** | Repro test (dev current HEAD post-W4-1 hotfix): PUT emoji+version → **200 OK**; PUT emoji+missing-version → **422 validation** (clear "Field required" message, KHÔNG phải 400 parse). Có thể QA hit transient state, hoặc đã fixed bởi unrelated change. Source FastAPI `routing.py:369` chỉ raise 400 khi `request.json()` fail (malformed JSON, not unicode content). |
+| Q-INFO-1 | 🟨 → ✅ | Admission | **FIXED 2026-05-16** `GET /api/admissions?sort_by=invalid_field` → 200 silent ignore + `order=BAD` silent ignore. Fix: promote `sort_by: str` + `order: str` → `Literal[4 valid] + Literal["asc","desc"]` trong admissions.py:102-103. FastAPI auto-422 với clear "Input should be ..." message. Anchor `test_admissions_list_query_validation.py` (8 tests) lock. Mirror FE Zod `AdmissionListParams.sort_by` (đã sẵn enum) — không phá FE. |
+| Q-INFO-2 | 🟦 | Notifications | Zalo webhook accept no-sig requests (BY DESIGN) | `zalo_webhooks.py:43-44`: Zalo OA spec không bắt buộc HMAC. Backend log `signature_present` cho observability. CAVEAT: nếu handler trigger state mutations, kẻ tấn công inject fake events được — audit handler logic riêng. |
+
+### Strong defenses verified (33 probes)
+
+| Attack vector | Mitigation |
+|---|---|
+| Mass-assignment | Pydantic schema whitelist — 4/4 extra fields silently ignored ✅ |
+| SQL injection 3 payloads | SQLAlchemy parameterized; DB intact (lead 392 rows post-test) ✅ |
+| JWT tamper role escalation | HMAC signature verification → 401 ✅ |
+| CSRF | X-CSRF-Token required → 403 ✅ |
+| IDOR cross-officer | 404 (NOT 403, per AUTHORIZATION_GUIDELINES) ✅ |
+| Self-elevate via PUT /users/me | 405 Method Not Allowed ✅ |
+| CCCD/phone/dob boundary | 422 validation ✅ |
+| Pagination DoS page_size=10000 | 422 (le=100 schema) ✅ |
+| Invalid state jump draft→enrolled/approved | 400 clean Vietnamese msg + allowed transitions ✅ |
+| Bulk version locking | Per-item `{profile_id, version}` schema; per-item conflict ✅ |
+| Magic-link double-consume race | ADM-013 lock + `confirmed_at` predicate → 1/5 success ✅ |
+| Login bruteforce 20 attempts | Rate limit 429 from req 3 ✅ |
+| Audit log | entity_audit_log: AdmissionProfile created/updated/status_changed với actor_user_id ✅ |
+
+### Wave 5 execution log
+- **15:45** Q.1.1 mass-assignment 4 fields → all silently ignored (verified post-GET)
+- **15:47** Q.1.2/1.5/1.6: 403/401/405/422 đúng
+- **15:50** Q.1.3 SQLi 3 payloads → 200 escaped, lead table intact
+- **15:53** Q.2.1 emoji discovery → 400 parse error (BUG)
+- **15:55** Q.2.4 bulk schema: `items: List[{profile_id, version}]` — W2-3 finding revisited
+- **15:58** Q.4.5 magic-link race 5 parallel → 1 success + 4 already-used (ADM-013 lock perfect)
+- **16:00** Q.4.6 webhook by-design per Zalo spec, downgrade HIGH→INFO
+- **16:02** Q.5 rate limit → 429 from req 3
+
+### Wave 5 test artifacts
+- Profile 20: `draft` → `withdrawn` via Q.4.5 race test (consume succeeded). Restore SQL nếu cần.
+- Profile 42: version bumped (3+ PUT), name="Nguyễn Văn Test" applied.
+- Lead 392 (was 391) — 1 lead added during Wave 4 session.
+
+### Wave 5 follow-ups (priority)
+1. **Q-BUG-1 emoji parse** 🟧 — find body parser/Pydantic validator restricting 4-byte UTF-8. Likely 1-2 line fix.
+2. **Q-INFO-1 sort_by** 🟨 — add `Literal["created_at","updated_at","status",...]` enum vào pagination schema (5-min).
+3. **Q-INFO-2 Zalo webhook handler** 🟦 — audit `zalo_webhook` handler nội bộ; nếu có state mutation, add allowlist sender/app_id check.
+
+---
+
 ## 🔬 WAVE 4 — Chrome MCP runtime re-test (2026-05-16 ~15:30 UTC+7)
 
 ### Browser-verified admission fixes

--- a/Documents/QA_E2E_PLAYBOOK_2026-05-15.md
+++ b/Documents/QA_E2E_PLAYBOOK_2026-05-15.md
@@ -1236,3 +1236,255 @@ Playbook xanh khi:
 ---
 
 *End of Wave 2 expansion.*
+
+---
+
+# WAVE 3 BUG-HUNTING — §Q (2026-05-16)
+
+Allow mutation mode. 4 nhóm scenarios.
+
+## §Q.1 ADVERSARIAL
+
+### Q.1.1 Mass-assignment tampering
+| # | Endpoint | Payload | Expected | Bug |
+|---|---|---|---|---|
+| Q.1.1a | PUT /api/admissions/42 | `{status:"approved",approved_by_id:15}` | 422/ignored | Flipped without /approve |
+| Q.1.1b | PUT /api/admissions/42 | `{academic_year:2030}` | 422/ignored | Year overwritten |
+| Q.1.1c | PUT /api/admissions/42 | `{applied_rules:{allow_unverified_submission:true}}` | 422/ignored | Bypass flag escalated |
+| Q.1.1d | PUT /api/admissions/42 | `{is_dropped:true}` | 422/ignored | Drop via PUT |
+| Q.1.1e | PATCH choices/14 | `{decision:"admitted",waitlist_rank:1}` | 422 | Officer admits manually |
+
+### Q.1.2 IDOR escalation
+| # | Test | Expected |
+|---|---|---|
+| Q.1.2a | Officer 16 PATCH /api/v2/admissions/39/choices/{any} | 404 |
+| Q.1.2c | Accountant DELETE /api/v2/admissions/42/choices/{cid} | 403 |
+| Q.1.2d | Officer GET /api/admin/audit-logs?actor_id=15 | 403 hoặc filtered |
+| Q.1.2e | Officer PUT /api/users/me `{role:"admin"}` | 422/ignored |
+
+### Q.1.3 SQL injection
+| # | Test | Expected |
+|---|---|---|
+| Q.1.3a | GET /api/admissions?search=' OR '1'='1 | 200 normal |
+| Q.1.3b | GET /api/leads?search=test'); DROP TABLE lead;-- | 200 escaped |
+| Q.1.3c | GET /api/admin/users?role=officer' UNION... | 200 normal, no leak |
+
+### Q.1.4 XSS
+| # | Test | Expected |
+|---|---|---|
+| Q.1.4a | PUT family_info name=`<script>alert(1)</script>` → re-GET | HTML escaped |
+| Q.1.4b | PUT notes/consultation với XSS payload | Sanitized |
+
+### Q.1.5 Token/session
+| # | Test | Expected |
+|---|---|---|
+| Q.1.5a | Use access_token sau logout | 401 |
+| Q.1.5b | JWT tamper role officer→admin | 401 sig invalid |
+| Q.1.5c | Reuse old refresh_token | 401 |
+
+### Q.1.6 CSRF
+| # | Test | Expected |
+|---|---|---|
+| Q.1.6a | POST mutate không X-CSRF-Token | 403 |
+| Q.1.6b | Stale CSRF | 403 |
+
+## §Q.2 EDGE CASES
+
+### Q.2.1 Field validation
+| # | Field | Values | Expected |
+|---|---|---|---|
+| Q.2.1a-d | CCCD | 3 chars / 15 chars / whitespace / unicode digits | 422 |
+| Q.2.1e-g | full_name | "" / 1000 chars / "🎓📚" | 422/422/200 |
+| Q.2.1h-j | phone | "0123" / 13 digits / "+84..." | 422 |
+| Q.2.1k-n | dob | 1900 / 2030 / 0001 / invalid date | 422 |
+
+### Q.2.2 Score boundary
+| # | Values | Expected |
+|---|---|---|
+| Q.2.2a-f | -1 / 10.01 / "abc" / null / [] / 100 items | 422 |
+
+### Q.2.3 Pagination
+| # | Test | Expected |
+|---|---|---|
+| Q.2.3a-e | page=0 / -1 / page_size=10000 / page=99999 / sort_by=invalid | 422 hoặc 200 empty |
+
+### Q.2.4 Bulk limits
+| # | profile_ids | Expected |
+|---|---|---|
+| Q.2.4a-d | [] / dup / 1000 items / non-existent | 422 / partial |
+
+### Q.2.5 File upload
+| # | Test | Expected |
+|---|---|---|
+| Q.2.5a-f | 0-byte / 10MB exact / +1 byte / MIME spoof / path traversal / unicode name | per spec |
+
+## §Q.3 STATE MACHINE
+
+### Q.3.1 Risky transitions
+| # | Transition | Expected |
+|---|---|---|
+| Q.3.1a | CONFIRMED→DRAFT (admin rollback) | 200 + audit + tokens invalidated |
+| Q.3.1b | APPROVED→DRAFT | 200 + audit |
+| Q.3.1c | ENROLLED→DRAFT | 400 (final) |
+| Q.3.1d | WITHDRAW from CONFIRMED | per business |
+
+### Q.3.2 Invalid jumps
+| From → To | Expected |
+|---|---|
+| draft→approved | 400 |
+| draft→enrolled | 400 |
+| submitted→enrolled | 400 |
+| approved→rejected | 400 |
+| rejected→approved | 400 |
+| withdrawn→any | 400 (final) |
+| enrolled→any | 400 (final) |
+
+### Q.3.3 Concurrent race
+| # | Test | Expected |
+|---|---|---|
+| Q.3.3a | 2 admins approve concurrent | 1 success + 1 409 |
+| Q.3.3b | Approve + reject race | 409 |
+| Q.3.3c | Magic-link confirm + admin override race | 1 wins |
+
+## §Q.4 DATA INTEGRITY
+
+### Q.4.1 N+1 audit
+- GET /api/admissions?page_size=50 timing — <500ms expected
+
+### Q.4.2 FK cascade
+- DELETE profile có choices → cascade or 409
+- DELETE lead có profile → cascade or 409
+
+### Q.4.3 Audit log gap
+| Action | Expected entry |
+|---|---|
+| Choice CRUD | entity_audit_log row |
+| Approve / Override | row với old/new |
+| Document upload | row |
+
+### Q.4.4 Optimistic locking matrix
+| Endpoint | version check? |
+|---|---|
+| POST /admissions/bulk/approve | **UNKNOWN — probe** |
+| PATCH /v2/admissions/{id}/choices/{cid} | **UNKNOWN — probe** |
+
+### Q.4.5 Magic-link race
+- 2 candidates click cùng token → 1 success + 1 400 already used
+- Token expired exact lúc consume → 410 Gone
+
+### Q.4.6 Webhook
+- POST Zalo webhook không signature → 401
+- Invalid HMAC → 401
+
+### Q.4.7 Celery idempotency
+- Enrollment task retry → 1 student record
+- Notification dispatch x2 same dedupe_key → single
+
+## §Q.5 RATE LIMIT
+- POST /api/auth/login spam 100 → 429
+- Magic-link generate spam → cooldown
+- Magic-link consume wrong CCCD spam → hard-lock
+
+## Success criteria
+- 0 BLOCKER mới
+- ≤ 3 MAJOR mới
+- Resolve 5 HIGH-RISK: webhook sig, CONFIRMED→DRAFT cleanup, bulk-approve version, N+1 list, Celery idempotency
+
+*End of §Q.*
+
+---
+
+# WAVE 6 — §R/§S/§T (a11y · mobile · performance) 2026-05-16
+
+## §R UI Accessibility
+
+### R.1 Lighthouse a11y audit (key pages)
+- `/login`, `/dashboard/officer`, `/admissions`, `/admissions/{id}`, `/leads/{id}`, `/admin/users`
+- Target: score ≥ 90/100. Detail trong `chrome-devtools-mcp-*/report.html`
+
+### R.2 Custom DOM probe per page
+- 0 images không `alt`
+- 0 buttons không text/aria-label
+- 0 inputs orphan (không label + không aria-label + không wrapped in label)
+- Heading hierarchy không skip (h1 → h2 → h3, not h1 → h4)
+- `<html lang="vi">` present
+- Landmarks: `<main>`, `<nav>`, `<header>` exist
+- Skip-link `<a href="#main-content">` present
+
+### R.3 Keyboard navigation
+- Tab through entire form → all inputs reachable, focus visible outline
+- Esc closes dialogs
+- Enter submits forms
+- Arrow keys navigate dropdowns + tabs
+
+### R.4 Color contrast
+- Text < 18px need contrast ≥ 4.5:1
+- Probe Lighthouse contrast audit + manual check status badges
+
+## §S Mobile Responsive
+
+### S.1 Viewport matrix
+| Device | Width × Height | DPR | Touch |
+|---|---|---|---|
+| iPhone SE | 375×667 | 2 | yes |
+| iPhone 13 | 390×844 | 3 | yes |
+| iPhone 13 Pro Max | 428×926 | 3 | yes |
+| iPad mini | 768×1024 | 2 | yes |
+| iPad Pro | 1024×1366 | 2 | yes |
+
+### S.2 Checks per viewport
+- Body không có horizontal scroll
+- Sticky bottom action bar fit trong width
+- Modal/Dialog fit (max-width responsive)
+- Touch targets ≥ 44×44 (Apple HIG)
+- Sidebar collapse to hamburger ở <768px
+- Form fields stack vertically (single-column)
+- Tab nav scroll horizontally khi quá nhiều tabs
+- Table không overflow (responsive table or card view)
+
+### S.3 Mobile-specific probes
+- Pull-to-refresh không trigger reload trang khi đang trong dialog
+- Keyboard pop-up không che submit button
+- Click-to-call link tel: + email link mailto:
+- Bottom safe area iPhone X+ (notch padding)
+
+## §T Performance
+
+### T.1 API timing matrix (5 runs each, report p50/p95)
+| Endpoint | Target p95 | Cold cache OK |
+|---|---|---|
+| GET /api/admissions list | < 200ms | < 500ms |
+| GET /api/admissions/{id} | < 100ms | < 200ms |
+| GET /api/leads list | < 200ms | < 500ms |
+| GET /api/notifications | < 50ms | < 100ms |
+| GET /api/officer/dashboard | < 300ms | < 800ms |
+| GET /api/admin/users | < 150ms | < 500ms |
+
+### T.2 Page load (Chrome MCP performance_start_trace)
+- LCP target: < 2500ms (good), < 1200ms (fast)
+- FID/INP: < 100ms
+- CLS: < 0.1
+- TTFB: < 600ms
+- Trace cho profile detail + admissions list + officer dashboard
+
+### T.3 Large payload stress
+- GET /api/admissions?page_size=100 ≥ 500 profiles → response time + memory
+- GET /api/leads?page_size=100 with 391 leads — gzip on?
+- File upload 10MB document — measure end-to-end
+
+### T.4 N+1 detection
+- GET /api/admissions với selectinload → single query
+- GET /api/leads với assigned_officer denormalized hoặc joined
+- Profile detail có lazy-load tab data → measure tab switch latency
+
+### T.5 Cache hit/miss
+- First call cold → measure cold timing
+- 4 subsequent calls → cache warm timing
+- Compare delta (>10x = cache effective)
+
+## Success criteria
+- A11y: ≥ 90/100 trên 5 key pages, 0 orphan input, 0 missing alt
+- Mobile: 0 horizontal scroll, ≥44px touch targets, modal fit
+- Performance: LCP < 2500ms, p95 < 500ms cho all read endpoints
+
+*End of Wave 6 §R/§S/§T*


### PR DESCRIPTION
## Summary
Batch A — Backend quick wins từ QA E2E Wave 5 adversarial bug hunting.

**Q-INFO-1 FIXED** — \`/api/admissions\` list endpoint silently fell back \`sort_by\` + \`order\` cho invalid values. Promote to \`Literal[...]\` enum → 422 với clear "Input should be ..." message. Mirror FE Zod \`AdmissionListParams\` đã sẵn enum 4 values, không phá callers.

**Q-BUG-1 NOT REPRODUCIBLE** — QA reported PUT emoji full_name → 400 parse error. Local repro post-W4-1 deploy: emoji+version → 200 OK; emoji+missing-version → 422 validation (clear "Field required"). Source FastAPI \`routing.py:369\` chỉ raise 400 khi JSON malformed, NOT unicode content. Đánh dấu FALSE ALARM, no code change.

## Changes
- \`app/routers/admissions.py\` — Literal enum on sort_by + order
- \`tests/api/test_admissions_list_query_validation.py\` — 8 anchor tests
- \`Documents/QA_E2E_FINDINGS_2026-05-15.md\` — Q-INFO-1 FIXED + Q-BUG-1 false alarm
- \`Documents/QA_E2E_PLAYBOOK_2026-05-15.md\` — Wave 6 §R/§S/§T test scripts append

## Test plan
- [x] 8/8 anchor tests pass local (69s)
- [x] Live probe \`?sort_by=invalid\` → 422, \`?order=BAD\` → 422, valid combos → 200
- [ ] CI green

## Findings status post-merge
- ✅ Wave 5: Q-BUG-1 (false alarm), Q-INFO-1 (fixed)
- 🟦 Wave 5: Q-INFO-2 (by-design, Zalo OA spec)
- Remaining open (separate PRs): Wave 6 R-BUG-1 (a11y), S-BUG-1/2 (mobile), T-INFO-1/2 (perf); F10 (validation order refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)