### PR TITLE
fix(fe-a11y): aria-label + 44x44 touch targets + mobile action bar scroll (QA Wave 6)

### DIFF
--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
@@ -104,17 +104,23 @@ export function AdmissionActions({
   
   return (
     <div className="fixed bottom-0 left-0 right-0 border-t bg-background z-40 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]">
-      <div className="container max-w-7xl mx-auto h-16 px-6 flex items-center justify-between">
+      {/* Mobile (<640px): allow horizontal scroll inside bar so wide
+          action sets (e.g. step 7 with 5 buttons) stay reachable without
+          forcing the user to scroll the whole page. Wave 6 S-BUG-1 fix
+          (action bar 549px overflow at 375px viewport). */}
+      <div className="container max-w-7xl mx-auto h-16 px-3 sm:px-6 flex items-center justify-between gap-2 overflow-x-auto">
         {/* Status Badge */}
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-4 flex-shrink-0">
           <span className="text-sm font-medium text-muted-foreground hidden sm:inline-block">
             Trạng thái:
           </span>
           <StatusBadge config={statusConfig} />
         </div>
 
-        {/* Action Buttons - Phase 2: Context-Based */}
-        <div className="flex items-center gap-3">
+        {/* Action Buttons - Phase 2: Context-Based.
+            flex-shrink-0 prevents buttons collapsing into ellipsis;
+            scroll lives on the outer container. */}
+        <div className="flex items-center gap-2 sm:gap-3 flex-shrink-0">
           {/* DELETE - Always available if can('delete') */}
           {can('delete') && onDelete && (
             <AlertDialog>

--- a/frontend/src/components/forms/AdaptiveAddressSelect.tsx
+++ b/frontend/src/components/forms/AdaptiveAddressSelect.tsx
@@ -215,6 +215,7 @@ export function AdaptiveAddressSelect({
                 value={residentialGroupValue ?? ""}
                 onChange={(e) => onResidentialGroupChange(e.target.value)}
                 placeholder="Tổ dân phố / Thôn / Buôn / Ấp / Khóm / Khu phố"
+                aria-label="Tổ dân phố / Thôn / Buôn / Ấp / Khóm / Khu phố"
                 disabled={disabled}
               />
             </div>
@@ -225,6 +226,7 @@ export function AdaptiveAddressSelect({
                 value={streetAddressValue ?? ""}
                 onChange={(e) => onStreetAddressChange(e.target.value)}
                 placeholder="Số nhà, tên đường"
+                aria-label="Số nhà, tên đường"
                 disabled={disabled}
               />
             </div>

--- a/frontend/src/components/layouts/dashboard/AppSidebar.tsx
+++ b/frontend/src/components/layouts/dashboard/AppSidebar.tsx
@@ -21,7 +21,7 @@ const AppTitle = ({ isCollapsed }: { isCollapsed: boolean }) => (
       {isCollapsed ? (
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" asChild className="flex-shrink-0" aria-label="QLTS - Trang chủ">
+            <Button variant="ghost" size="icon" asChild className="flex-shrink-0 h-11 w-11" aria-label="QLTS - Trang chủ">
               <Link href="/dashboard">
                 <BookMarked className="h-6 w-6" />
               </Link>

--- a/frontend/src/components/layouts/dashboard/NavItem.tsx
+++ b/frontend/src/components/layouts/dashboard/NavItem.tsx
@@ -74,7 +74,9 @@ export function NavItem({ link, isCollapsed }: NavItemProps) {
           <Link
             href={link.href}
             className={cn(
-              "text-muted-foreground hover:bg-muted hover:text-foreground flex h-9 w-9 items-center justify-center rounded-lg transition-colors",
+              // Wave 6 S-BUG-2: min 44×44 touch target (Apple HIG, WCAG 2.5.5).
+              // Was h-9 w-9 (36×36) — failed mobile tap accuracy criterion.
+              "text-muted-foreground hover:bg-muted hover:text-foreground flex h-11 w-11 items-center justify-center rounded-lg transition-colors",
               isActive &&
                 "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
             )}

--- a/frontend/src/components/layouts/dashboard/RecentPages.tsx
+++ b/frontend/src/components/layouts/dashboard/RecentPages.tsx
@@ -53,7 +53,7 @@ export function RecentPages({ isCollapsed }: RecentPagesProps) {
                 <TooltipTrigger asChild>
                   <Link
                     href={page.path}
-                    className="text-muted-foreground hover:bg-muted hover:text-foreground flex h-9 w-9 items-center justify-center rounded-lg transition-colors"
+                    className="text-muted-foreground hover:bg-muted hover:text-foreground flex h-11 w-11 items-center justify-center rounded-lg transition-colors"
                   >
                     <Clock className="h-4 w-4" />
                     <span className="sr-only">{page.label}</span>


### PR DESCRIPTION
## Summary
Batch B — Frontend a11y + mobile fixes từ QA E2E Wave 6 Chrome MCP smoke test 2026-05-16.

**R-BUG-1 FIXED** — 2 orphan inputs (Tổ dân phố / Số nhà) trong \`AdaptiveAddressSelect.tsx\` thiếu label/aria-label → screen reader user mất context. Add \`aria-label\` matching placeholder.

**S-BUG-1 FIXED** — Sticky action bar overflow 549px > 375px viewport mobile → user phải horizontal-scroll TOÀN PAGE. Fix: outer \`overflow-x-auto\` + \`gap-2 sm:gap-3\` + children \`flex-shrink-0\`. Scroll contained inside bar, body scrollX=0.

**S-BUG-2 FIXED** — Sidebar nav links 36x36 + logo 32x32 < Apple HIG 44x44 (WCAG 2.5.5). Mobile tap accuracy thấp. Fix: bump \`h-9 w-9\` → \`h-11 w-11\` across NavItem/RecentPages/AppSidebar logo.

## Chrome MCP smoke verify (memory \`chrome-mcp-pre-push-smoke\`)
- R-BUG-1: \`document.querySelector('input[placeholder*=Tổ dân]').getAttribute('aria-label')\` → matched placeholder text on both inputs ✅
- S-BUG-1: resize 500x814 → \`body.scrollWidth - body.clientWidth = 0\` (page không overflow) ✅
- S-BUG-2: measured 30 sidebar items → all 44x44 (was 32-36) ✅

## Changes
- \`frontend/src/components/forms/AdaptiveAddressSelect.tsx\` — 2× \`aria-label\`
- \`frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx\` — overflow-x-auto + responsive gap + flex-shrink-0
- \`frontend/src/components/layouts/dashboard/NavItem.tsx\` — h-11 w-11 (collapsed nav links)
- \`frontend/src/components/layouts/dashboard/RecentPages.tsx\` — h-11 w-11 (recent page links)
- \`frontend/src/components/layouts/dashboard/AppSidebar.tsx\` — logo Button override default h-11 w-11

## Test plan
- [x] FE type-check pass clean
- [x] FE lint 0 errors (208 warnings pre-existing, not introduced)
- [x] Chrome MCP smoke 3 verifications all pass
- [ ] CI green
- [ ] Doc Wave 6 R-BUG/S-BUG status update follow-up post #299 merge

## Followup
- Wave 6 doc entry status update sẽ commit sau khi #299 (Batch A) merge (Wave 5+6 sections sống trong #299).

🤖 Generated with [Claude Code](https://claude.com/claude-code)