### PR TITLE
fix(seo-a11y): robots.txt + llms.txt + Progress aria-label (QA Wave 6 R-INFO-1)

### DIFF
--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -1,0 +1,18 @@
+# QLTS — Quản Lý Tuyển Sinh
+
+> Internal educational admission management system for Vietnamese institutions. Handles lead pipeline, admission profiles, multi-NV (multiple admission choices), document verification, fee/installment processing, KPI tracking, and notifications.
+
+QLTS is an authenticated staff/candidate application. Public crawling and LLM training data ingestion are not authorized — see robots.txt (`Disallow: /`). This file is published per [llmstxt.org](https://llmstxt.org/) convention so AI agents understand the boundary.
+
+## Tech stack
+
+- Backend: FastAPI (Python 3.12), SQLAlchemy 2.0 async, PostgreSQL 16, Redis, Celery
+- Frontend: Next.js 16 (App Router), React 19, TypeScript, Tailwind, Radix UI, React Query
+- Authorization: Casbin RBAC (admin/manager/officer/accountant/user)
+- Deployment: Docker Compose on VPS, Nginx reverse proxy with HTTPS
+
+## Out of scope for AI ingestion
+
+- User data (leads, admission profiles, candidate PII, payment records)
+- Configuration secrets, Casbin policies, JWT signing material
+- Operational logs, audit trails

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,7 @@
+# QLTS (Quản Lý Tuyển Sinh) — internal educational admission management system.
+# Not intended for public discovery or crawler indexing.
+# All staff/candidate access is auth-gated; surface routes have <meta name="robots" content="noindex">.
+User-agent: *
+Disallow: /
+
+# Sitemap intentionally omitted (no public content).

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -12,9 +12,21 @@ export interface ProgressProps extends React.ComponentPropsWithoutRef<typeof Pro
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   ProgressProps
->(({ className, value, indicatorClassName, ...props }, ref) => (
+>(({ className, value, indicatorClassName, ...props }, ref) => {
+  // Wave 6 R-INFO-1 (Lighthouse aria-progressbar-name): Radix Root
+  // renders role="progressbar" but without aria-label/labelledby, screen
+  // readers announce a generic "X percent". Default to a Vietnamese
+  // label that includes the current value; callers can override via
+  // aria-label prop when they have richer context (e.g. "Tiến trình
+  // hồ sơ"). Only apply default when caller did NOT supply either.
+  const ariaLabel =
+    props["aria-label"] ?? props["aria-labelledby"]
+      ? props["aria-label"]
+      : `Tiến trình ${value ?? 0}%`
+  return (
   <ProgressPrimitive.Root
     ref={ref}
+    aria-label={ariaLabel}
     className={cn(
       "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
       className
@@ -26,7 +38,8 @@ const Progress = React.forwardRef<
       style={{ transform: `translateX(-${100 - Math.min(100, Math.max(0, value || 0))}%)` }}
     />
   </ProgressPrimitive.Root>
-))
+  )
+})
 Progress.displayName = ProgressPrimitive.Root.displayName
 
 export { Progress }


### PR DESCRIPTION
## Summary
Batch E — Lighthouse SEO + a11y top 3 fails từ QA Wave 6.

**3 fixed**
- **robots.txt** — added \`Disallow: /\` for QLTS internal admin app
- **llms.txt** — added llmstxt.org-spec file marking user data + secrets ngoài scope LLM ingestion
- **Progress aria-label** — Radix Progress primitive defaulted to \`Tiến trình {value}%\`; fixes ALL 10+ usages across app (KPI, admission completion, payment progress) trong 1 edit

**Chrome MCP verify**
- /admissions/42 progressbar → aria="Tiến trình 28%" ✓

**Defer (4 remaining)**
button-name, color-contrast, label-content-name-mismatch, agent-accessibility-tree — Chrome MCP scan /admissions/42 cho 0 anonymous buttons → fails surface on other pages (login, dashboard, kpi-setup). Need broader sweep + per-page fixes.

## Test plan
- [x] FE type-check clean
- [x] Chrome MCP smoke progressbar aria-label verified
- [ ] CI green
- [ ] Post-deploy: re-run Lighthouse to confirm a11y +1pt (one less progressbar fail) + SEO recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)