### PR TITLE
fix(security): W8-F.1 PUT user 500 + W8-A.3.1 Literal sort_by 5 routers (Wave 8)

### DIFF
--- a/Backend_FastAPI/app/routers/admin/users.py
+++ b/Backend_FastAPI/app/routers/admin/users.py
@@ -1004,28 +1004,43 @@ async def update_existing_user(
         assigned_by_user_id=current_admin.id  # ✅ PHASE 2: Track who made the assignment
     )
 
+    # W8-F.1 fix 2026-05-16: capture ALL needed attrs in plain Python vars
+    # BEFORE commit. `expire_on_commit=True` default expires attrs after
+    # commit; subsequent lazy access triggers connection ping path which
+    # fails in async middleware greenlet → MissingGreenlet 500. Plain-var
+    # capture decouples downstream notification/audit code from ORM state.
+    # Capture BOTH target user + current admin (both are ORM-tracked).
+    _updated_user_id = updated_user.id
+    _updated_username = updated_user.username
+    _updated_role = updated_user.role
+    _updated_unit_id = updated_user.unit_id
+    _current_admin_id = current_admin.id
+
     # ✅ TRANSACTION PATTERN: Commit and execute callback
     await db.commit()
     await callback()
 
-    # Best-effort audit log — business change already committed above
+    # Best-effort audit log — business change already committed above.
+    # W8-F.1 fix 2026-05-16: use captured plain-var IDs everywhere
+    # downstream so ORM session state (expired by commits + rollback)
+    # never triggers lazy load in middleware async context.
     try:
         _, log_callback = await log_admin_activity(
             db=db,
             request=request,
             action="update_user",
             resource_type="user",
-            actor_id=current_admin.id,
-            target_user_id=updated_user.id,
-            resource_id=updated_user.id,
-            description=f"Admin updated user: {updated_user.username}",
+            actor_id=_current_admin_id,
+            target_user_id=_updated_user_id,
+            resource_id=_updated_user_id,
+            description=f"Admin updated user: {_updated_username}",
             changes=changes if changes else None,
         )
         await db.commit()
         await log_callback()
     except Exception:
         await db.rollback()
-        log.error("Failed to persist audit log for update_user", user_id=updated_user.id, exc_info=True)
+        log.error("Failed to persist audit log for update_user", user_id=_updated_user_id, exc_info=True)
 
     # ✅ NOTIFICATION 2.0: Dispatch USER_ROLE_CHANGED if role or unit changed
     if "role" in changes or "unit_id" in changes:
@@ -1044,15 +1059,15 @@ async def update_existing_user(
             db=db,
             event=SystemEvents.USER_ROLE_CHANGED,
             payload={
-                "user_id": updated_user.id,
-                "old_role": changes.get("role", {}).get("old", updated_user.role),
-                "new_role": changes.get("role", {}).get("new", updated_user.role),
+                "user_id": _updated_user_id,
+                "old_role": changes.get("role", {}).get("old", _updated_role),
+                "new_role": changes.get("role", {}).get("new", _updated_role),
                 "old_unit_id": old_unit_id,
-                "new_unit_id": updated_user.unit_id,
-                "actor_id": current_admin.id,
+                "new_unit_id": _updated_unit_id,
+                "actor_id": _current_admin_id,
             },
-            dedupe_key=f"user_role_changed:{updated_user.id}:{updated_user.role}:{updated_user.unit_id}",
-            rooms=_rooms_for_user(updated_user.id),
+            dedupe_key=f"user_role_changed:{_updated_user_id}:{_updated_role}:{_updated_unit_id}",
+            rooms=_rooms_for_user(_updated_user_id),
         )
 
     # Dispatch USER_DEACTIVATED notification if status changed to inactive
@@ -1063,23 +1078,23 @@ async def update_existing_user(
             db=db,
             event=SystemEvents.USER_DEACTIVATED,
             payload={
-                "user_id": updated_user.id,
-                "username": updated_user.username,
+                "user_id": _updated_user_id,
+                "username": _updated_username,
                 "old_status": changes["status"]["old"],
                 "reason": "Account deactivated by administrator",
-                "actor_id": current_admin.id,
+                "actor_id": _current_admin_id,
             },
-            dedupe_key=f"user_deactivated:{updated_user.id}",
+            dedupe_key=f"user_deactivated:{_updated_user_id}",
             skip_preference_check=True,  # Critical notification
-            rooms=_rooms_for_user(updated_user.id),
+            rooms=_rooms_for_user(_updated_user_id),
         )
 
     # Send notification to user if admin updated their info
-    if current_admin.id != updated_user.id and changes:
+    if _current_admin_id != _updated_user_id and changes:
         log.info(
             "Admin updated user info, dispatching notification",
-            admin_id=current_admin.id,
-            target_user_id=updated_user.id,
+            admin_id=_current_admin_id,
+            target_user_id=_updated_user_id,
             changes=list(changes.keys()),
         )
         change_description = ", ".join([f"{key}" for key in changes.keys()])
@@ -1090,22 +1105,26 @@ async def update_existing_user(
             db=db,
             event=SystemEvents.USER_PROFILE_UPDATED,
             payload={
-                "user_id": updated_user.id,
+                "user_id": _updated_user_id,
                 "updated_fields": change_description,
-                "actor_id": current_admin.id,
+                "actor_id": _current_admin_id,
             },
-            dedupe_key=f"user_profile_updated:{updated_user.id}",
-            rooms=_rooms_for_user(updated_user.id),
+            dedupe_key=f"user_profile_updated:{_updated_user_id}",
+            rooms=_rooms_for_user(_updated_user_id),
         )
     else:
         log.debug(
             "Skipping notification",
-            admin_id=current_admin.id,
-            target_user_id=updated_user.id,
-            same_user=current_admin.id == updated_user.id,
+            admin_id=_current_admin_id,
+            target_user_id=_updated_user_id,
+            same_user=_current_admin_id == _updated_user_id,
             has_changes=bool(changes),
         )
 
+    # W8-F.1 fix: refresh ORM instance so FastAPI response serialization
+    # (UserAdminResponse `from_attributes=True`) doesn't hit lazy load
+    # on expired attrs in response middleware → MissingGreenlet.
+    await db.refresh(updated_user)
     return updated_user
 
 

--- a/Backend_FastAPI/app/routers/collaborators.py
+++ b/Backend_FastAPI/app/routers/collaborators.py
@@ -6,7 +6,7 @@ Two separate routers:
 - admin_router: Admin/Manager endpoints for CTV management
 - ctv_router: CTV self-service endpoints
 """
-from typing import Optional
+from typing import Literal, Optional
 
 from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -64,8 +64,8 @@ async def list_collaborators(
     unit_id: Optional[int] = None,
     managed_by_officer_id: Optional[int] = None,
     search: Optional[str] = None,
-    sort_by: str = "created_at",
-    order: str = "desc",
+    sort_by: Literal["created_at", "updated_at", "full_name", "code", "status", "phone"] = "created_at",  # W8-A.3.1 fix 2026-05-16 — mirror ALLOWED_SORT_COLUMNS in collaborator_repository.py:19
+    order: Literal["asc", "desc"] = "desc",
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(check_permission),
 ):

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -233,8 +233,12 @@ async def get_all_leads(
     search: Optional[str] = Query(
         None, description="Search term for name, email, phone"
     ),
-    sort_by: str = Query("created_at", description="Field to sort by"),
-    order: str = Query("desc", description="Sort order (asc or desc)"),
+    sort_by: Literal[
+        "created_at", "updated_at", "full_name", "email", "phone",
+        "lead_score", "status", "source", "last_consultation_at",
+        "next_activity_at", "consultation_count", "cached_urgency_score",
+    ] = Query("created_at", description="Field to sort by — Literal enum mirror ALLOWED_SORT_FIELDS in lead_repository.py:402 (W8-A.3.1 fix 2026-05-16)"),
+    order: Literal["asc", "desc"] = Query("desc", description="Sort order"),
     # === PIPELINE STAGE FILTER ===
     pipeline_stage_id: Optional[str] = Query(
         None, description="Filter by pipeline stage ID(s) (comma-separated, e.g. 'stg01,stg02')"
@@ -336,8 +340,12 @@ async def export_leads(
     search: Optional[str] = Query(
         None, description="Search term for name, email, phone"
     ),
-    sort_by: str = Query("created_at", description="Field to sort by"),
-    order: str = Query("desc", description="Sort order (asc or desc)"),
+    sort_by: Literal[
+        "created_at", "updated_at", "full_name", "email", "phone",
+        "lead_score", "status", "source", "last_consultation_at",
+        "next_activity_at", "consultation_count", "cached_urgency_score",
+    ] = Query("created_at", description="Field to sort by — Literal enum mirror ALLOWED_SORT_FIELDS in lead_repository.py:402 (W8-A.3.1 fix 2026-05-16)"),
+    order: Literal["asc", "desc"] = Query("desc", description="Sort order"),
     pipeline_stage_id: Optional[str] = Query(
         None, description="Filter by pipeline stage ID(s) (comma-separated)"
     ),

--- a/Backend_FastAPI/app/routers/officer.py
+++ b/Backend_FastAPI/app/routers/officer.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Literal
 from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -341,8 +341,8 @@ async def drilldown_consultations(
     end_date: str = Query(None, alias="to"),
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
-    sort_by: str = Query("consultation_date"),
-    order: str = Query("desc"),
+    sort_by: Literal["consultation_date", "lead_name", "loss_reason_code", "status"] = Query("consultation_date"),  # W8-A.3.1
+    order: Literal["asc", "desc"] = Query("desc"),
     stage_id: str = Query(None),
     loss_reason_code: str = Query(None),
     consultation_kind: str = Query(None),
@@ -373,8 +373,8 @@ async def drilldown_transitions(
     end_date: str = Query(None, alias="to"),
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
-    sort_by: str = Query("changed_at"),
-    order: str = Query("desc"),
+    sort_by: Literal["changed_at", "lead_name", "old_stage_name", "new_stage_name", "outcome"] = Query("changed_at"),  # W8-A.3.1
+    order: Literal["asc", "desc"] = Query("desc"),
     stage_id: str = Query(None),
     outcome: str = Query(None, description="positive|negative"),
     final_only: bool = Query(False),
@@ -405,8 +405,8 @@ async def drilldown_cohorts(
     end_date: str = Query(None, alias="to"),
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
-    sort_by: str = Query("created_at"),
-    order: str = Query("desc"),
+    sort_by: Literal["created_at", "lead_name", "current_status"] = Query("created_at"),  # W8-A.3.1
+    order: Literal["asc", "desc"] = Query("desc"),
     cohort_result: str = Query(None, description="converted|lost|open"),
 ):
     """Cohorts drill-down: leads created in period with conversion result."""

--- a/Backend_FastAPI/tests/api/test_qa_wave8_user_update_greenlet.py
+++ b/Backend_FastAPI/tests/api/test_qa_wave8_user_update_greenlet.py
@@ -1,0 +1,82 @@
+"""W8-F.1 anchor — PUT /api/admin/users/{id} reliably 500 MissingGreenlet.
+
+QA Wave 8 (2026-05-16) — Admin không thể edit user qua chuẩn endpoint
+PUT /api/admin/users/{id} vì SQLAlchemy MissingGreenlet bombing trên
+ORM attribute access in middleware-level async context.
+
+Root cause: handler did `await db.commit()` → `expire_on_commit=True`
+expires all attrs on `updated_user` and `current_admin`. Subsequent
+lazy access (notification dispatch, audit log, response serialization)
+triggers SELECT-on-checkout that requires a greenlet not available in
+the response middleware path → MissingGreenlet → 500.
+
+Fix: capture ALL identifier attrs into plain Python vars BEFORE commit
+chain. Use captured vars throughout downstream notification + audit
+logic. `db.refresh(updated_user)` immediately before `return` so
+FastAPI response serialization (UserAdminResponse `from_attributes=True`)
+can read fresh attrs without lazy-fetch.
+
+Anchor verifies: PUT minimal field-only update → 200 OK + response body
+contains updated value. Pre-fix: 500 INTERNAL_ERROR. Multiple commits
++ multiple notifications all execute without raising MissingGreenlet.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_admin_put_user_full_name_returns_200_not_500(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+):
+    """PUT /api/admin/users/{id} với full_name update → 200 (was 500 W8-F.1).
+
+    Triggers commit + audit log + USER_PROFILE_UPDATED notification dispatch
+    chain. Pre-fix any of those steps lazy-loaded `updated_user.id` or
+    `current_admin.id` from expired session → MissingGreenlet → 500.
+    """
+    target_user_id = officer_user_in_db["id"]
+    # Form-data upload (not JSON) because endpoint uses Form() params
+    response = await client.put(
+        f"/api/admin/users/{target_user_id}",
+        headers=admin_token_headers,
+        data={"full_name": "W8-F.1 Anchor Test"},
+    )
+    assert response.status_code == 200, (
+        f"PUT user full_name expected 200 (W8-F.1 fix); "
+        f"got {response.status_code}: {response.text[:300]}"
+    )
+    body = response.json()
+    assert body["id"] == target_user_id
+    assert body["full_name"] == "W8-F.1 Anchor Test"
+
+
+async def test_admin_put_user_role_change_triggers_dispatch_no_500(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+):
+    """PUT với role change → 200, USER_ROLE_CHANGED dispatch fires
+    without MissingGreenlet. Tests the deeper code path that hits multiple
+    `safe_dispatch` calls + audit log all in same request.
+    """
+    target_user_id = officer_user_in_db["id"]
+    response = await client.put(
+        f"/api/admin/users/{target_user_id}",
+        headers=admin_token_headers,
+        data={
+            "full_name": "W8-F.1 Role Change Test",
+            "role": "manager",
+        },
+    )
+    assert response.status_code == 200, (
+        f"PUT user role-change expected 200; got {response.status_code}: "
+        f"{response.text[:300]}"
+    )
+    body = response.json()
+    assert body["id"] == target_user_id
+    assert body["role"] == "manager"

--- a/Documents/QA_E2E_FINDINGS_2026-05-15.md
+++ b/Documents/QA_E2E_FINDINGS_2026-05-15.md
@@ -1,5 +1,205 @@
 # QA E2E FINDINGS — 2026-05-15 → 2026-05-16
 
+## 🛡️ WAVE 8 — Security adversarial + Data integrity race (2026-05-16 ~20:30 UTC+7)
+
+### Scope
+
+| Mini-wave | Coverage | Method |
+|---|---|---|
+| W8-A.1 Mass-assignment | §Q.1.1: PUT profile/lead/admission sneak `role`/`unit_id`/`assigned_*`/`approved_*` | curl JSON + form |
+| W8-A.2 IDOR escalation | §Q.1.2: officer→cross-officer lead/profile; magic-link action mismatch + CCCD brute-force | curl |
+| W8-A.3 SQLi + XSS | §Q.1.3/4: `or '1'='1`, `pg_sleep`, UNION SELECT, sort_by injection, stored XSS in lead full_name | curl |
+| W8-A.4 JWT + Rate limit | §Q.1.5/Q.5: alg=none, sig tamper, role escalate, expired, login 5/min, magic-link cooldown | curl + jwt.encode |
+| W8-B.1 Race | §Q.3.3 + §Q.4.5: bulk-approve race blocked (account lockout), magic-link 3-step ADM-013 lock audit | code review + DB inventory |
+| W8-B.2 Audit + Dedupe | §Q.4.3/Q.4.7: entity_audit_log coverage, notification_delivery dedupe_key uniqueness | psql |
+
+### Findings summary
+
+| # | Sev | Module | Title |
+|---|---|---|---|
+| **W8-F.1** | 🟥 → ✅ | Admin users API | **FIXED 2026-05-16** — MissingGreenlet sau `db.commit()` (expire_on_commit expire attrs → downstream lazy hit pool ping → no greenlet → 500). Fix: capture all needed IDs (`_updated_user_id` + `_updated_username` + `_updated_role` + `_updated_unit_id` + `_current_admin_id`) trong plain vars BEFORE commit + `db.refresh(updated_user)` trước return. 2 anchor tests. |
+| **W8-A.3.1** | 🟧 → ✅ | Multi router | **FIXED 2026-05-16** — applied Literal pattern (Q-INFO-1 PR #299) sang 5 routes còn lại: `leads.py` (×2), `officer.py` drilldowns consultations/transitions/cohorts (×3), `collaborators.py` (×1). Mỗi Literal mirror repo ALLOWED_SORT_FIELDS / sort_map keys → 422 literal_error thay vì 200 silent fallback. |
+| **W8-A.3.2** | 🟦 | Defense-in-depth | XSS payload `<script>` stored + returned RAW trong `full_name`; depend hoàn toàn FE escape (React JSX OK nhưng risky nếu dangerouslySetInnerHTML xuất hiện) |
+| **W8-A.1** | ✅ | Mass-assignment | PUT profile/lead/admission whitelist schema; sneak `role`/`unit_id`/`status`/`approved_at` đều bị Pydantic drop |
+| **W8-A.2** | ✅ | IDOR | 3-tier officer/manager scope returns 404 đúng spec; magic-link action mismatch → 404, brute-force CCCD lock sau 5 attempts |
+| **W8-A.4** | ✅ | JWT/session | alg=none / tamper sig / role escalate / expired ALL → 401 INVALID_TOKEN |
+| **Q.5** | ✅ | Rate limit | Login spam 5/min, attempt 6 → 429 "5 per 1 minute"; persistent account lock 14p sau threshold |
+| **W8-B.1** | ✅ | Magic-link race | ADM-013 3-step lock pattern (profile → token → re-validate FK) verified ở `admission_repository.py:1232-1290` |
+| **W8-B.2.audit** | ✅ | Audit log | `entity_audit_log` records correctly với entity_type PascalCase (`AdmissionProfile`/`Lead`); 1896 rows tổng, recent mutations all captured |
+| **W8-B.2.dedupe** | ✅ | Celery dedupe | dedupe_key + channel + user_id triple correctly de-dupes; broadcast pattern (same key, multiple users) là EXPECTED không phải bug |
+
+---
+
+### W8-F.1 🟥 MAJOR — Admin PUT users 500 MissingGreenlet
+
+**Endpoint**: `PUT /api/admin/users/{id}`
+**Auth**: admin (id=15, role=admin)
+**Payload**: `{"full_name":"any value"}`
+**Expected**: 200 OK với updated user
+**Actual**: **500 INTERNAL_ERROR** reproducible mỗi lần
+
+**Backend log evidence**:
+```
+sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here.
+  File ".../sqlalchemy/orm/loading.py:1674" in load_scalar_attributes
+  File ".../sqlalchemy/pool/base.py:1301" in _checkout result = pool._dialect._do_ping_w_event(dbapi_connection)
+  File ".../asyncpg.py:1160" in do_ping dbapi_connection.ping()
+  File ".../asyncpg.py:816" in ping _ = self.await_(self._async_ping())
+```
+
+**Root cause hypothesis**: Sau commit `0f1c2368` "perf(admin/users): drop eager-load User.sessions", có thể PUT path còn lazy-load attribute (sessions / login_history / role relationships) khi async context không spawn greenlet đúng. Stack trace cho thấy connection pool `do_ping` trigger trong `load_scalar_attributes` — implies expired-attribute refresh fires **after** async session unwound.
+
+**Risk**: **Admin cannot update ANY user** via standard PUT endpoint. Affects user profile edits, role changes, status activation/deactivation từ `/admin/users` page.
+
+**Investigation pointers**:
+- `app/routers/admin/users.py:857` (PUT handler) — kiểm tra eager-load pattern từ GET list query đã apply cho PUT response chưa
+- `UserAdminResponse` serialization có reference attribute expired sau `await db.commit()` không
+- Memory `feedback_async_session_gather` — similar AsyncSession race
+
+**Fix direction**:
+1. `await db.refresh(user, attribute_names=[...])` trước khi service return
+2. `selectinload(User.sessions)` (hoặc lazy attr triggering ping) trong update flow query
+3. Capture User → dict trước khi async session unwind
+
+---
+
+### W8-A.3.1 🟧 MAJOR — Q-INFO-1 sort_by Literal fix INCOMPLETE
+
+**Background**: Commit `23bf4324` ("Literal sort_by/order validation") chỉ patch `admissions.py:102`. 5 routers khác còn `sort_by: str` silent fallback.
+
+**Evidence**:
+```bash
+curl "http://localhost:8000/api/leads?sort_by=password&page_size=1"  → 200 (silent fallback)
+curl "http://localhost:8000/api/leads?sort_by=id;DROP&page_size=1"   → 200 (silent fallback)
+curl "http://localhost:8000/api/leads?sort_by=secret_field"          → 200 (silent fallback)
+```
+
+**Grep audit**:
+```
+admissions.py:102        sort_by: Literal[...]                       ✅ FIXED
+leads.py:236             sort_by: str = Query("created_at")          ❌ MISSED
+leads.py:339             sort_by: str = Query("created_at")          ❌ MISSED
+officer.py:344           sort_by: str = Query("consultation_date")   ❌ MISSED
+officer.py:376           sort_by: str = Query("changed_at")          ❌ MISSED
+officer.py:408           sort_by: str = Query("created_at")          ❌ MISSED
+collaborators.py:67      sort_by: str = "created_at"                 ❌ MISSED
+```
+
+**Memory lesson**: `ci-workflow-flag-cross-file-sync` — pattern lặp lại; khi swap pattern, grep ALL files trước commit. Q-INFO-1 patch missed 5 routers.
+
+**Fix**: Promote 5 routers → `Literal[allowed_fields]`; anchor test sweep `assert sort_by=invalid_xxx → 422`.
+
+---
+
+### W8-A.3.2 🟦 INFO — Stored XSS payload accepted raw
+
+`PUT /api/leads/410 {"full_name":"<script>alert(1)</script>"}` → 200; GET returns literal `<script>alert(1)</script>`. React 19 JSX auto-escape mitigates, NHƯNG:
+
+- **CSP header observed** ở W8-A.4: `script-src 'self' 'unsafe-inline' 'unsafe-eval'` — inline scripts ALLOWED ❗ — stored XSS exploitable nếu FE miss escape ở 1 chỗ
+- Defense-in-depth recommend: Pydantic validator regex hoặc `bleach.clean()` ở service layer
+- CSP tighten: drop `'unsafe-inline'` từ `script-src` (cần audit Next.js inline script usage trước)
+
+---
+
+### W8-A.1 ✅ Mass-assignment PROTECTED
+
+| Endpoint | Probe | Result |
+|---|---|---|
+| `PUT /api/profile` form sneak `role=admin&unit_id=1` | Officer | 200, role/unit_id IGNORED ✓ |
+| `PUT /api/leads/410` JSON `assigned_officer_id=15,unit_id=1,created_by=15,pipeline_stage=enrolled` | Officer | 200, extras dropped ✓ |
+| `PUT /api/admissions/42` JSON `status=enrolled,approved_at=...,approved_by=15,lead_id=24` | Officer | 200, extras dropped ✓ |
+| `PUT /api/admin/users/16` Officer self-escalate | Officer→admin | 403 Casbin DENY ✓ |
+| `PUT /api/admin/users/15` Officer demote admin | Officer→admin | 403 Casbin DENY ✓ |
+
+---
+
+### W8-A.2 ✅ IDOR 3-tier enforcement
+
+**Officer 16, unit 14** GET cross-officer in same unit (leads 38/133/24/209/156 owned bởi officer 18/23/25/26) → **all 404** ✓ (per memory `admission-profile-3-tier-idor`: 404 not 403).
+
+Officer GET admissions 14/22/39 (lead owned by officer 18) → 404 ✓
+Officer GET admissions 16/19/20/23 (lead owned by self) → 200 ✓
+
+**Magic-link**: action mismatch `/withdraw/{confirm_token}` → 404 (doesn't leak), CCCD brute 5 attempts → 400 cooldown ✓
+
+---
+
+### W8-A.4 ✅ JWT/session attacks rejected
+
+| Attack | Result |
+|---|---|
+| `alg=none` JWT admin claims | 401 INVALID_TOKEN |
+| Tampered sig (modified payload, kept sig) | 401 INVALID_TOKEN |
+| Officer token `role:admin` payload mod | 401 INVALID_TOKEN |
+| Expired HS256 token (exp=now-3600) | 401 INVALID_TOKEN |
+
+---
+
+### Q.5 ✅ Rate limit + account lockout
+
+```
+20 wrong logins in 12s:
+  1-5: 401 (wrong password)
+  6+:  429 "5 per 1 minute"
+Post-test legit login: 429 "Tài khoản tạm thời bị khóa... thử lại sau 14 phút" (retry-after=803s)
+```
+
+✅ Triple protection: rate limit / account lockout / CCCD length validator.
+
+---
+
+### W8-B.1 ✅ Magic-link 3-step lock (ADM-013) — design verified
+
+`admission_repository.py:1232-1290` `get_token_for_confirm`:
+1. Resolve `profile_id` from token
+2. `SELECT AdmissionProfile FOR UPDATE` for `profile_id`
+3. `SELECT AdmissionConfirmationToken FOR UPDATE` by token
+4. Re-validate FK
+
+Identical lock ordering across confirm/override/finalize → no deadlock. Caller idempotency: `confirmed_at IS NULL` predicate.
+
+**Live race test data-gap**: chỉ 1 unused token (id=25 profile 42 status=draft) thiếu `citizen_id`. Recommend seed fixture `magic_link_race_test.sql` cho future regression.
+
+---
+
+### W8-B.2 ✅ Audit log + dedupe semantics
+
+**Audit log** — recent mutations recorded với entity_type PascalCase:
+```
+1896|Lead|410|updated|13:43:42|actor 15
+1894|AdmissionProfile|42|updated|13:38:57|actor 16
+1892|AdmissionProfile|39|status_changed|13:09:11|actor 34 (manager loser từ W7-A.1 race)
+1891|AdmissionProfile|39|status_changed|11:54:30|actor 15 (admin race winner)
+```
+
+Wave 7 W7-A.1 race winner+loser cả 2 đều captured. ✅
+
+**Dedupe**:
+- 4649 deliveries, 1881 với dedupe_key, 1870 unique → 11 duplicate keys
+- Tất cả 11 duplicates: same key + same channel browser + DIFFERENT user_id (broadcast pattern)
+- Dispatcher `find_existing_user_ids_by_dedupe(user_ids, dedupe_key, channel)` correctly de-dupes per-user → ✅
+
+---
+
+### Wave 8 success criteria recap
+
+- ✅ 0 SQL injection, 0 IDOR escalation, 0 JWT forge
+- ✅ Rate limit + account lockout
+- ✅ Mass-assignment whitelist
+- ✅ Race lock + dedupe design verified
+- 🟥 1 MAJOR W8-F.1: Admin PUT users 500
+- 🟧 1 MAJOR W8-A.3.1: Q-INFO-1 fix incomplete (5 routers)
+- 🟦 1 INFO W8-A.3.2: XSS defense-in-depth + CSP unsafe-inline
+
+### Suggested fix order
+
+1. **W8-F.1** (P0, prod-blocking) — Diagnose MissingGreenlet, likely 1-file fix trong `admin/users.py:857` PUT handler
+2. **W8-A.3.1** (P1) — Promote 5 routers `sort_by: str` → `Literal[...]` + anchor test sweep
+3. **W8-A.3.2** (P2) — `bleach.clean()` hoặc Pydantic regex + audit CSP `unsafe-inline` removal
+4. Magic-link race seed fixture (test-debt FU)
+
+---
+
 ## 🌊 WAVE 7 — State race + File upload edge + Notification delivery (2026-05-16 ~19:00 UTC+7)
 
 ### Scope


### PR DESCRIPTION
## Summary
Wave 8 audit 2 actionable findings closed.

### 🟥 W8-F.1 BLOCKER — PUT /api/admin/users/{id} reliably 500
**Live on prod**. Admin không thể edit user qua endpoint chuẩn.

Root cause: \`db.commit()\` expires ORM attrs → downstream lazy access (audit log + 3× notification dispatch + response serialization) hit pool ping path → no greenlet in middleware → MissingGreenlet → 500.

Fix: capture ALL needed ID attrs (target user + current admin) trong plain Python vars BEFORE commit chain. Use captured vars throughout. \`db.refresh(updated_user)\` trước return cho FastAPI serialize.

### 🟧 W8-A.3.1 MAJOR — Q-INFO-1 Literal fix INCOMPLETE
PR #299 patched admissions.py nhưng grep audit Wave 8 phát hiện 5 endpoints khác còn \`sort_by: str\` silent fallback:
- leads.py (×2) + officer.py drilldowns consultations/transitions/cohorts (×3) + collaborators.py (×1)

Fix: apply Literal pattern uniformly. Each Literal mirrors actual repo ALLOWED_SORT_FIELDS / sort_map keys.

## Verification
| # | Pre-fix | Post-fix |
|---|---|---|
| W8-F.1 PUT user | 500 INTERNAL_ERROR | **200 OK** + updated body |
| W8-A.3.1 leads sort_by=invalid | 200 silent fallback | **422 literal_error** |

## Anchors
- 2 W8-F.1 anchors (PUT user + PUT user role change)
- Live curl verify W8-A.3.1 across 6 endpoints

## Defer (Wave 8)
- W8-A.3.2 XSS + CSP unsafe-inline — defense-in-depth, FE escapes via React JSX. Separate PR for CSP nonce + input sanitization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)