### PR TITLE
fix(security+import): Wave 8 XSS + Wave 9 lead-import 3 blockers + rollback idempotent (5 findings)

### DIFF
--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -367,6 +367,7 @@ async def admin_rollback_admission(
     return schemas.AdmissionAdminRollbackResponse(
         profile_id=result["profile_id"],
         rolled_back_from=result["rolled_back_from"],
+        already_at_target=result.get("already_at_target", False),
     )
 
 

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -1504,6 +1504,12 @@ async def officer_import_leads(
         await callback()
 
         # ✅ NOTIFICATION: Dispatch LEAD_IMPORTED for officer import
+        # W9-N.1.3 fix 2026-05-16: `lead` variable never defined trong
+        # officer_import_leads scope (bulk endpoint imports N leads, no
+        # singular Lead). Was `NameError` → 500 sau commit thành công
+        # → DB had rows nhưng client thấy "Failed to import" → user
+        # retries → duplicate / dedupe confusion. Fix: build rooms from
+        # actor unit + role_admin (broadcast to admins + officer's unit).
         if result.successful_imports > 0:
             await safe_dispatch(
                 db=db,
@@ -1515,7 +1521,10 @@ async def officer_import_leads(
                     filename=file.filename or "unknown",
                     created_lead_ids=result.created_lead_ids,
                 ),
-                rooms=_rooms_for_lead(lead),
+                rooms=(
+                    ["role_admin", f"user_room_{current_user.id}"]
+                    + ([f"unit_{current_user.unit_id}"] if current_user.unit_id else [])
+                ),
             )
 
         return result

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1818,6 +1818,7 @@ class AdmissionAdminRollbackResponse(BaseModel):
     profile_id: int
     status: Literal["draft"] = "draft"
     rolled_back_from: str  # The status the profile was in BEFORE rollback
+    already_at_target: bool = False  # W9-J.7.idem 2026-05-16: True when no-op (profile already draft)
 
 
 __all__ = [

--- a/Backend_FastAPI/app/schemas/user.py
+++ b/Backend_FastAPI/app/schemas/user.py
@@ -156,6 +156,20 @@ class UserUpdate(BaseModel):
     skills: Optional[List[str]] = None
     unit_id: Optional[int] = None  # Organizational unit assignment
 
+    # W8-A.3.2 defense-in-depth 2026-05-16: HTML-escape user-supplied
+    # text fields. Frontend already escapes via React JSX, but server-
+    # side belt+suspenders prevents stored XSS if any downstream
+    # consumer (export CSV, PDF, email template, dangerouslySetInnerHTML
+    # leak) bypasses React escaping. Mirror pattern from admission
+    # schema (admission.py:70).
+    @field_validator("full_name", mode="before")
+    @classmethod
+    def _escape_full_name(cls, v):
+        if v is None or not isinstance(v, str):
+            return v
+        import html
+        return html.escape(v.strip())
+
 
 class UsersPage(BaseModel):
     total_count: int

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -665,6 +665,21 @@ async def admin_rollback_profile(
             "Lý do rollback bắt buộc, tối thiểu 10 ký tự"
         )
 
+    # W9-J.7.idem fix 2026-05-16: idempotent no-op khi đã ở 'draft'.
+    # Trước: state machine raise "Invalid transition: draft → draft"
+    # → 400 confusing UX ("not allowed"). Sau: 200 với
+    # `already_at_target=true` cho FE phân biệt no-op vs actual rollback.
+    if rolled_back_from == "draft":
+        return (
+            {
+                "profile_id": profile.id,
+                "status": "draft",
+                "rolled_back_from": "draft",
+                "already_at_target": True,
+            },
+            None,
+        )
+
     _, callback = await state_service.transition(
         db, profile, "draft",
         actor=actor,

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -3461,10 +3461,16 @@ async def import_leads_from_file_content(
         if not file_content:
             raise ValueError("Empty file uploaded.")
 
+        # W9-N.1.2 fix 2026-05-16: force `dtype=str` on read so pandas
+        # doesn't infer phone column as int64 → strip leading 0 →
+        # `0900000111` → `900000111` → 9 digits → fail VN phone regex
+        # `^0(3|5|7|8|9|2)\d{8,9}$` → 100% standard CSV exports rejected.
+        # Forcing string dtype keeps every column as-typed; Pydantic
+        # downstream coerces what needs coercing.
         if file_extension == "csv":
-            df = pd.read_csv(io.BytesIO(file_content))
+            df = pd.read_csv(io.BytesIO(file_content), dtype=str)
         else:  # xlsx
-            df = pd.read_excel(io.BytesIO(file_content), engine="openpyxl")
+            df = pd.read_excel(io.BytesIO(file_content), engine="openpyxl", dtype=str)
 
         log.info(f"Successfully read {len(df)} rows from {file_extension} file.")
 
@@ -3489,7 +3495,17 @@ async def import_leads_from_file_content(
         )
 
     # --- 3. Validate columns and process data ---
-    required_columns = {"full_name", "email", "phone", "source", "unit_id"}
+    # W9-N.1.1 fix 2026-05-16: unit_id chỉ REQUIRED khi caller không
+    # cung cấp `default_unit_id` (admin import). Officer flow override
+    # mọi row với current_user.unit_id (line ~3628) → unit_id column
+    # trong CSV bị ignore. Docstring router nói "auto-set từ officer"
+    # → contract đúng. Trước fix, officer CSV thiếu unit_id column →
+    # 400 "Missing required columns: unit_id" → user khó khăn tạo CSV.
+    base_required = {"full_name", "email", "phone", "source"}
+    if default_unit_id is None:
+        required_columns = base_required | {"unit_id"}
+    else:
+        required_columns = base_required
 
     # Normalize column names (lowercase, strip, replace spaces)
     df.columns = df.columns.str.lower().str.strip().str.replace(" ", "_")

--- a/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
@@ -1471,13 +1471,24 @@ async def test_admin_rollback_response_schema_locked(
     )
     assert response.status_code == 200
     body = response.json()
-    expected_keys = {"profile_id", "status", "rolled_back_from"}
+    # W9-J.7.idem 2026-05-16: shape expanded with optional `already_at_target`
+    # (default False). FE consumer ignoring extra keys is fine; required
+    # keys still locked. Anchor verifies (a) all required keys present
+    # (b) no UNEXPECTED keys beyond the documented allowlist.
+    required_keys = {"profile_id", "status", "rolled_back_from"}
+    allowed_keys = required_keys | {"already_at_target"}
     actual_keys = set(body.keys())
-    assert actual_keys == expected_keys, (
-        f"T17 response keys drift. Expected: {expected_keys}, got: {actual_keys}. "
-        f"BUG: shape change without API version bump breaks FE consumer."
+    assert required_keys <= actual_keys, (
+        f"T17 response missing required keys. Required: {required_keys}, "
+        f"got: {actual_keys}."
+    )
+    assert actual_keys <= allowed_keys, (
+        f"T17 response has unexpected keys. Allowed: {allowed_keys}, "
+        f"got: {actual_keys}. BUG: shape drift without API version bump."
     )
     # Specific value verify
     assert body["status"] == "draft"
     assert body["rolled_back_from"] == "submitted"
     assert body["profile_id"] == profile_id
+    # New idempotent marker default False (this rollback was real, not no-op)
+    assert body.get("already_at_target") is False

--- a/Backend_FastAPI/tests/api/test_qa_wave9_lead_import_and_w8a32.py
+++ b/Backend_FastAPI/tests/api/test_qa_wave9_lead_import_and_w8a32.py
@@ -1,0 +1,127 @@
+"""QA Wave 8-9 batch — lead import bugs + XSS defense + rollback idempotent.
+
+Wave 9 (2026-05-16):
+- W9-N.1.3 🟥 BLOCKER — `officer_import_leads` line 1518 NameError `lead`
+  not defined → 500 sau commit thành công → DB has rows, client thấy
+  "Failed to import" → user retries → duplicate.
+- W9-N.1.2 🟥 MAJOR — `pd.read_csv` thiếu `dtype=str` → leading 0 stripped
+  → 100% VN phone format rejected.
+- W9-N.1.1 🟧 — Officer import yêu cầu unit_id column nhưng docstring nói
+  auto-set → contract mismatch.
+- W9-J.7.idem 🟦 — Rollback already-draft → 400 "Invalid transition";
+  should be 200 no-op với `already_at_target=true`.
+
+Wave 8 remaining:
+- W8-A.3.2 🟦 — XSS payload stored raw in user.full_name → defense-in-depth
+  gap. Frontend escapes via React JSX OK but belt+suspenders prevents
+  stored XSS surfacing via export/email/dangerouslySetInnerHTML leak.
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# W9-N.1.2 + W9-N.1.3 + W9-N.1.1 — officer CSV import
+# ---------------------------------------------------------------------------
+
+OFFICER_CSV_NO_UNIT = (
+    b"full_name,email,phone,source\n"
+    b"W9 Anchor 1,w9anchor1@example.com,0900000901,walkin\n"
+    b"W9 Anchor 2,w9anchor2@example.com,0900000902,walkin\n"
+)
+
+
+async def test_w9_n13_officer_import_no_nameerror_codepath():
+    """W9-N.1.3 anchor: unit-level check that `lead` symbol no longer
+    referenced in officer_import_leads. Source-level guard cheaper than
+    full HTTP fixture (needs DB seed for pipeline stages + statuses).
+
+    Live HTTP repro already validated post-fix: officer import 2 rows
+    → 200 + 2 created_lead_ids + no 500 (dev env 2026-05-16).
+    """
+    import inspect
+    from app.routers import leads as leads_router
+
+    source = inspect.getsource(leads_router.officer_import_leads)
+    # Pre-fix bug: `rooms=_rooms_for_lead(lead)` — `lead` undefined
+    assert "_rooms_for_lead(lead)" not in source, (
+        "W9-N.1.3 regression: `_rooms_for_lead(lead)` references undefined "
+        "`lead` var in officer_import_leads scope (bulk endpoint, no "
+        "singular lead). Use captured user.unit_id + role_admin rooms instead."
+    )
+
+
+def test_w9_n12_csv_read_uses_dtype_str():
+    """W9-N.1.2 anchor: pd.read_csv must use dtype=str so VN phones with
+    leading 0 don't get pandas-inferred as int → stripped.
+    """
+    import inspect
+    from app.services import lead_service
+
+    source = inspect.getsource(lead_service.import_leads_from_file_content)
+    # Must contain dtype=str on read_csv
+    assert "pd.read_csv(io.BytesIO(file_content), dtype=str)" in source, (
+        "W9-N.1.2 regression: pd.read_csv missing dtype=str → pandas "
+        "strips leading 0 from phone column → 100% VN phone rejection."
+    )
+    assert "pd.read_excel(io.BytesIO(file_content), engine=\"openpyxl\", dtype=str)" in source, (
+        "Same fix needed for Excel path."
+    )
+
+
+def test_w9_n11_unit_id_not_required_when_default_unit_provided():
+    """W9-N.1.1 anchor: required_columns must conditionally exclude unit_id
+    when caller passes default_unit_id (officer flow). Docstring promise
+    matches code.
+    """
+    import inspect
+    from app.services import lead_service
+
+    source = inspect.getsource(lead_service.import_leads_from_file_content)
+    # Must have the conditional unit_id check
+    assert "default_unit_id is None" in source, (
+        "W9-N.1.1 regression: required_columns hardcodes unit_id, but "
+        "officer flow passes default_unit_id so column auto-overridden. "
+        "Conditional exclude expected."
+    )
+
+
+# ---------------------------------------------------------------------------
+# W8-A.3.2 — XSS escape on user.full_name
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_put_user_full_name_xss_escaped(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+):
+    """W8-A.3.2 defense-in-depth: HTML tags in full_name HTML-escaped server-
+    side. Pre-fix: stored raw, FE-only escape. Post-fix: `<script>...</script>`
+    → `&lt;script&gt;...&lt;/script&gt;` before DB write.
+    """
+    target_user_id = officer_user_in_db["id"]
+    response = await client.put(
+        f"/api/admin/users/{target_user_id}",
+        headers=admin_token_headers,
+        data={"full_name": "<script>alert(1)</script>Tester"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    # Stored value HTML-escaped
+    assert "&lt;script&gt;" in body["full_name"], (
+        f"Expected HTML escape; got {body['full_name']!r}"
+    )
+    assert "<script>" not in body["full_name"], "Raw <script> must NOT be in response"

--- a/Documents/QA_E2E_FINDINGS_2026-05-15.md
+++ b/Documents/QA_E2E_FINDINGS_2026-05-15.md
@@ -1,5 +1,225 @@
 # QA E2E FINDINGS — 2026-05-15 → 2026-05-16
 
+## 🚢 WAVE 9 — Multi-NV publish engine + Bulk import/export (2026-05-16 ~21:45 UTC+7)
+
+### Scope
+
+| Mini-wave | Coverage | Method |
+|---|---|---|
+| W9-J.1 Publish-result | §J.1: POST /api/v2/admissions/{id}/publish-result RBAC + state guard | curl 3-persona |
+| W9-J.5 Admin rollback (T17) | §J.5: rollback RBAC + reason validation + final-state guard | curl + DB inspect |
+| W9-J.7 Edge cases | §J.7: rollback non-final → 400 invalid transition, 404 nonexistent, idempotent rollback | curl |
+| W9-N.1 Lead import CSV | §N.1: missing cols, empty, malformed, SQLi cell, XSS cell, BOM, dup phone, mass-assign cols, cross-unit smuggle | curl multipart |
+| W9-N.2 Lead export | §N.2: officer/manager scope, status filter SQLi | curl |
+| W9-N.3 Bulk-assign | §N.4: RBAC admin-only? Manager/officer denied | curl |
+
+### Findings summary
+
+| # | Sev | Module | Title |
+|---|---|---|---|
+| **W9-N.1.3** | 🟥 → ✅ | Lead import | **FIXED 2026-05-16** — replaced `_rooms_for_lead(lead)` (undefined `lead` var) → broadcast rooms `["role_admin", f"user_room_{current_user.id}", f"unit_{unit_id}"]`. Live verify: officer import 2 rows → 200 + 2 created_lead_ids + no 500. |
+| **W9-N.1.2** | 🟥 → ✅ | Lead import | **FIXED 2026-05-16** — `pd.read_csv(..., dtype=str)` + `pd.read_excel(..., dtype=str)`. Leading 0 preserved. Live verify: VN phone `0900000901` round-trip OK. |
+| **W9-N.1.1** | 🟧 → ✅ | Lead import contract | **FIXED 2026-05-16** — `required_columns` excludes `unit_id` khi `default_unit_id is not None` (officer flow). Docstring promise giờ khớp code. |
+| **W9-J.7.idem** | 🟦 → ✅ | Admin rollback UX | **FIXED 2026-05-16** — rollback already-draft → 200 với `already_at_target=True` (no-op). Schema `AdmissionAdminRollbackResponse.already_at_target: bool=False` added; service short-circuit trước state machine. |
+| **W9-J.5** | ✅ | Admin rollback T17 | RBAC officer/manager 403, admin 200; reason min 10 chars enforced 422; final-state enrolled correctly rejected 400; 404 missing |
+| **W9-J.3** | ✅ | Waitlist promote | Officer→404 (Casbin DENY pattern), choice without waitlist decision → 404 |
+| **W9-N.2** | ✅ | Lead export | Officer scope (40 leads), manager scope (98 unit leads), status filter parameterized — SQLi neutralized |
+| **W9-N.3** | ✅ | Bulk-assign RBAC | Manager + officer cả 2 → 403 PERMISSION_DENIED (admin-only endpoint by design) |
+
+---
+
+### W9-N.1.3 🟥 BLOCKER — officer_import_leads NameError sau commit thành công
+
+**Endpoint**: `POST /api/leads/import`
+**Auth**: officer (id=16, unit 14)
+**Trigger**: ANY successful import row (`result.successful_imports > 0`)
+
+**Root cause** — `Backend_FastAPI/app/routers/leads.py:1518`:
+```python
+# ✅ NOTIFICATION: Dispatch LEAD_IMPORTED for officer import
+if result.successful_imports > 0:
+    await safe_dispatch(
+        db=db,
+        event=SystemEvents.LEAD_IMPORTED,
+        payload=EventPayload.for_lead_imported(...),
+        rooms=_rooms_for_lead(lead),   # ❌ NameError: name 'lead' is not defined
+    )
+```
+
+Variable `lead` chưa từng được define trong scope của `officer_import_leads`. Hàm import nhiều leads cùng lúc — không có 1 `lead` singular object để pass. Code 100% dead-path khi `successful_imports > 0`.
+
+**Live evidence** — DB lead 418 created OK (commit succeeded at line 1503), but request 500'd at line 1518:
+```sql
+SELECT id, full_name, email, phone, unit_id, assigned_officer_id, created_at FROM lead WHERE email='wi@example.com';
+418|Wave9 Intl|wi@example.com|0900000222|14|16|2026-05-16 14:40:58
+```
+
+```
+2026-05-16T14:41:09 ERROR:    Exception in ASGI application
+  File "/app/app/routers/leads.py", line 1518, in officer_import_leads
+    rooms=_rooms_for_lead(lead),
+NameError: name 'lead' is not defined
+172.18.0.1 - "POST /api/leads/import HTTP/1.1" 500
+```
+
+**Production risk**:
+1. **Commit succeeded** → DB has new leads
+2. **500 returned to client** → user sees "Failed to import" toast
+3. **User retries** → creates duplicates (or fails dedupe → confusion)
+4. **Silent notification miss** — `LEAD_IMPORTED` never fired → managers don't get notification badge
+5. **Bigger issue** — main branch + deployed prod. Officer cannot import leads end-to-end. Possible workaround: officer suspect failure even though data is in DB → manual SQL check.
+
+**Fix** (1-2 lines):
+- Option A (simplest): omit `rooms=` (broadcast to default rooms):
+  ```python
+  rooms=None,  # or just drop param if Optional
+  ```
+- Option B: build per-lead rooms list from `result.created_lead_ids`:
+  ```python
+  rooms=[room for lid in result.created_lead_ids for room in _rooms_for_lead_id(lid)]
+  ```
+- Option C: dispatch unit-broadcast room:
+  ```python
+  rooms=[f"unit:{current_user.unit_id}"]
+  ```
+
+**Anchor test**: `test_officer_import_succeeds_dispatches_without_nameerror()` — assert `result.successful_imports == N` AND HTTP 200.
+
+**Note**: Memory `solo-dev-aggressive-wave-ship` — should be hotfix bundled với W8 PR #304 nếu chưa merge. Bug đã LIVE trên main.
+
+---
+
+### W9-N.1.2 🟥 MAJOR — pandas strips leading zero from phone column
+
+**Endpoint**: `POST /api/leads/import` (CSV path)
+**Root cause** — `lead_service.py:3465`:
+```python
+df = pd.read_csv(io.BytesIO(file_content))   # ⚠️ no dtype=str
+```
+
+Pandas infers `phone` column dtype as int64 → strips leading zero → `0900000111` → `900000111` → 9 digits → fails VN phone regex `^0(3|5|7|8|9|2)\d{8,9}$` → row rejected.
+
+**Live evidence**:
+```
+Pre-import CSV row: phone="0900000111"
+Pydantic error: input_value='900000111'   ← leading 0 GONE
+Error: Số điện thoại không hợp lệ. Vui lòng nhập số điện thoại Việt Nam (VD: 0901234567)
+```
+
+3/3 rows in `happy.csv` failed identically. Workaround `+84900000111` succeeded (no leading 0 to strip + normalizer converts to `0900000222`) — but blocks W9-N.1.3 NameError → 500.
+
+**Risk**: **0% success rate** for standard CSV exports from Excel/CRM where phone shipped as `0900000111` literal. End users (officers) **cannot import any leads** via the documented column format. Combined with N.1.3, end-to-end import is fully broken.
+
+**Fix** (1 line):
+```python
+df = pd.read_csv(io.BytesIO(file_content), dtype=str)
+df = pd.read_excel(io.BytesIO(file_content), engine="openpyxl", dtype=str)
+```
+
+**Defensive add**: phone column-specific dtype `dtype={'phone': str, 'phone2': str}` to keep numeric inference on `gpa`, `lead_score` etc.
+
+**Memory**: Add `feedback_pandas_dtype_str_for_phone_id` — Pandas auto-inference strips leading zero on phone/postal/ID columns; always force `dtype=str` for these fields.
+
+---
+
+### W9-N.1.1 🟧 MAJOR — Lead import contract mismatch (unit_id docstring vs validator)
+
+**Docstring claim** (`leads.py:1462-1464`):
+> **Required columns:** full_name, email, phone, source
+> **Note:** unit_id sẽ được tự động set thành unit của officer.
+
+**Actual behavior**:
+```
+POST /api/leads/import without unit_id column:
+HTTP=400 {"detail":"File is missing required columns: unit_id"}
+```
+
+Validator (likely in `lead_service.import_leads_from_file_content`) checks `unit_id` as required column BEFORE service applies `default_unit_id=current_user.unit_id`.
+
+**Fix**:
+- Option A (preferred): drop `unit_id` from validator's required list; service-layer auto-fill survives
+- Option B: update docstring to say `unit_id` is required
+- Memory: lesson — keep docstring + validator + Zod schema in 3-way sync (similar pattern to `service-explicit-dict-field-drop-pattern`)
+
+---
+
+### W9-J.7.idem 🟦 INFO — Admin rollback already-draft UX
+
+`POST /api/v2/admissions/{id}/admin-rollback` khi profile ALREADY `status=draft`:
+```
+HTTP=400 {"detail":"Invalid transition: draft → draft. Allowed transitions from draft: submitted, withdrawn"}
+```
+
+Confusing UX for admin:
+1. Admin clicked "Rollback" → server should know admin WANTS draft → return 200 no-op
+2. OR clear message: "Hồ sơ đã ở trạng thái draft, không cần rollback"
+
+**Fix**: thêm pre-check ở `admin_rollback_profile` service: nếu `profile.status == 'draft'`, return idempotent success với message "Already at target state". State machine `validate_transition` chỉ fire khi source != target.
+
+---
+
+### W9-J.5 ✅ Admin rollback T17 — full matrix verified
+
+| Probe | Result |
+|---|---|
+| Officer → admin-rollback | 403 "Admin access required for this operation" ✓ |
+| Manager → admin-rollback | 403 (Casbin DENY at policy layer per memory) ✓ |
+| Admin → rollback approved profile 39 | 200 `{"rolled_back_from":"approved","status":"draft"}` ✓ |
+| Admin → rollback enrolled profile 22 | 400 "Hồ sơ ở trạng thái cuối ('enrolled') không thể rollback" ✓ |
+| Admin → rollback nonexistent 99999 | 404 "Hồ sơ 99999 không tồn tại" ✓ |
+| `{"reason":"short"}` (5 chars) | 422 "String should have at least 10 characters" ✓ |
+| `{"reason":""}` | 422 same as above ✓ |
+| `{}` (no reason) | 422 "Field required" ✓ |
+
+Reason min 10/max 500 chars enforced at Pydantic — service-layer defensive check matches.
+
+---
+
+### W9-N.2 ✅ Lead export
+
+| Probe | Result |
+|---|---|
+| Officer GET /api/leads/export?format=csv | 200, 40KB, 40 leads (assigned_officer_id=16 scope) |
+| Manager GET /api/leads/export?format=csv | 200, 98KB, 98 leads (full unit 14 scope) |
+| Admin status filter SQLi `status=qualified' OR 1=1--` | 200 with header row only (0 data rows) — payload treated as literal string, filter safely parameterized ✓ |
+
+CSV BOM (`﻿`) đầu file → Excel-compatible ✓.
+
+---
+
+### W9-N.3 ✅ Bulk-assign RBAC
+
+`POST /api/admin/users/leads/bulk-assign` payload `{lead_ids:[418,410,402],officer_id:16}`:
+- Officer (16): **403 PERMISSION_DENIED** ✓
+- Manager (manager_qa unit 14): **403 PERMISSION_DENIED** — by design (admin-only)
+
+Per memory `lead-bulk-assign-callbacks-pr6`, bulk_assign service contract supports manager scope, but Casbin policy gates only admin to this endpoint. If product wants manager bulk-assign within unit scope, need Casbin policy update + service unit-validation. Currently working as policy intends.
+
+---
+
+### Wave 9 success criteria recap
+
+- 🟥 **2 BLOCKER** in officer lead import path:
+  - W9-N.1.3: NameError 'lead' undefined → 500 after commit (data corruption risk)
+  - W9-N.1.2: pandas strips leading 0 → 0% phone validation pass rate
+- 🟧 1 MAJOR W9-N.1.1: docstring vs validator mismatch (unit_id required despite "auto-fill" claim)
+- 🟦 1 INFO W9-J.7.idem: rollback already-draft UX
+- ✅ Admin rollback T17 full matrix
+- ✅ Multi-NV waitlist promote (RBAC sane, no positive path tested — no `decision=waitlist` test data)
+- ✅ Lead export 3-tier scope + SQLi-safe
+- ✅ Bulk-assign RBAC
+
+### Suggested fix order
+
+1. **W9-N.1.3** (P0, prod-blocking) — 1-line fix `rooms=` param; bundle hotfix urgently. Confirm với git log nếu line 1518 mới recent ship.
+2. **W9-N.1.2** (P0, prod-blocking) — 1-line `dtype=str` ở pd.read_csv + pd.read_excel; anchor test for phone preservation.
+3. **W9-N.1.1** (P1) — Drop `unit_id` from required-columns validator; update docstring nếu retain required.
+4. **W9-J.7.idem** (P3) — Pre-check idempotent rollback in service.
+
+**Bundle recommendation**: W9-N.1.2 + W9-N.1.3 + W9-N.1.1 trong 1 hotfix PR "fix(lead-import): pandas dtype + officer dispatch NameError + unit_id column contract" — cùng file scope, < 10 LOC tổng, deploy chung.
+
+---
+
 ## 🛡️ WAVE 8 — Security adversarial + Data integrity race (2026-05-16 ~20:30 UTC+7)
 
 ### Scope
@@ -19,7 +239,7 @@
 |---|---|---|---|
 | **W8-F.1** | 🟥 → ✅ | Admin users API | **FIXED 2026-05-16** — MissingGreenlet sau `db.commit()` (expire_on_commit expire attrs → downstream lazy hit pool ping → no greenlet → 500). Fix: capture all needed IDs (`_updated_user_id` + `_updated_username` + `_updated_role` + `_updated_unit_id` + `_current_admin_id`) trong plain vars BEFORE commit + `db.refresh(updated_user)` trước return. 2 anchor tests. |
 | **W8-A.3.1** | 🟧 → ✅ | Multi router | **FIXED 2026-05-16** — applied Literal pattern (Q-INFO-1 PR #299) sang 5 routes còn lại: `leads.py` (×2), `officer.py` drilldowns consultations/transitions/cohorts (×3), `collaborators.py` (×1). Mỗi Literal mirror repo ALLOWED_SORT_FIELDS / sort_map keys → 422 literal_error thay vì 200 silent fallback. |
-| **W8-A.3.2** | 🟦 | Defense-in-depth | XSS payload `<script>` stored + returned RAW trong `full_name`; depend hoàn toàn FE escape (React JSX OK nhưng risky nếu dangerouslySetInnerHTML xuất hiện) |
+| **W8-A.3.2** | 🟦 → ✅ | Defense-in-depth | **FIXED 2026-05-16 (XSS escape part)** — UserUpdate `_escape_full_name` validator HTML-escape `<script>` → `&lt;script&gt;` server-side. Mirror pattern from admission_schema.py:70. Live verify: PUT user 20 với XSS payload → stored + returned escaped. **CSP audit**: prod CSP đã strict `script-src 'self'` (main.py:737); dev `unsafe-inline` ổn cho dev hot-reload. False alarm CSP part. |
 | **W8-A.1** | ✅ | Mass-assignment | PUT profile/lead/admission whitelist schema; sneak `role`/`unit_id`/`status`/`approved_at` đều bị Pydantic drop |
 | **W8-A.2** | ✅ | IDOR | 3-tier officer/manager scope returns 404 đúng spec; magic-link action mismatch → 404, brute-force CCCD lock sau 5 attempts |
 | **W8-A.4** | ✅ | JWT/session | alg=none / tamper sig / role escalate / expired ALL → 401 INVALID_TOKEN |


### PR DESCRIPTION
## Summary — 5 findings bundled per "gom commits 1 deploy"

### 🟥 W9-N.1.3 BLOCKER (LIVE prod) — officer_import_leads NameError 500
\`/api/leads/import\` line 1518 \`_rooms_for_lead(lead)\` — \`lead\` undefined. Commit succeeded → DB has new rows → client gets 500 → user retries → duplicate confusion. Fix: build broadcast rooms from current_user instead.

### 🟥 W9-N.1.2 BLOCKER (LIVE prod) — pandas strips leading 0 phones
\`pd.read_csv\` missing \`dtype=str\` → 100% VN phone format \`09xxxxxxxx\` rejected. Officers can't import. Fix: \`dtype=str\` on both CSV + Excel read paths.

### 🟧 W9-N.1.1 — Officer import contract mismatch
Docstring "unit_id auto-set" but service required column. Fix: conditional \`unit_id\` requirement based on \`default_unit_id\` param.

### 🟦 W9-J.7.idem — Rollback already-draft 400 → 200 no-op
Admin rollback profile đã ở draft → 400 "Invalid transition: draft → draft" confusing. Fix: short-circuit service + return 200 với \`already_at_target=True\` schema field.

### 🟦 W8-A.3.2 — XSS payload stored raw in user.full_name
Defense-in-depth gap. Frontend escapes via React JSX OK, but export/email/dangerouslySetInnerHTML could leak. Fix: \`UserUpdate._escape_full_name\` validator with \`html.escape()\`. CSP audit: prod already strict \`script-src 'self'\` — dev unsafe-inline OK.

## Verification

| # | Pre-fix | Post-fix |
|---|---|---|
| W9-N.1.3 officer import CSV 2 rows | 500 NameError | **200 + 2 created_lead_ids** |
| W9-N.1.2 phone \`0900000901\` | rejected ("9 digits") | **stored as \`0900000901\`** |
| W9-N.1.1 CSV no unit_id column | 400 "Missing required" | **200 (auto from officer)** |
| W9-J.7.idem rollback already-draft | 400 Invalid transition | **200 \`already_at_target=true\`** |
| W8-A.3.2 PUT \`<script>alert(1)\`</script> | stored raw | **\`&lt;script&gt;alert(1)&lt;/script&gt;\`** |

## Test plan
- [x] Live curl verify all 5 scenarios pass
- [x] 4/4 anchor tests pass
- [ ] CI green
- [ ] Post-deploy: re-verify W9-N.1.3 on prod (BLOCKER live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)