### PR TITLE
feat(schema+api): Q9 #07 priority bonus system — schema foundation v1.3 (multi-school KV + 2-field cultural/vocational)

### DIFF
--- a/Backend_FastAPI/alembic/versions/phase1_08a_rename_bonus_subject_to_object.py
+++ b/Backend_FastAPI/alembic/versions/phase1_08a_rename_bonus_subject_to_object.py
@@ -1,0 +1,118 @@
+"""phase1_08a: rename JSONB key apply_subject_bonus -> apply_object_bonus
+
+Revision ID: phase1_08a
+Revises: qae2e02
+Create Date: 2026-05-17
+
+#184 Q9 #07 Wave A — Foundation rename for Priority Bonus System.
+
+Background
+----------
+
+``BonusRuleOverride`` Pydantic schema (``app/schemas/admission_path.py``)
+shipped in phase1_02 with field ``apply_subject_bonus`` whose docstring
+already said "Apply per-subject bonus (priority objects 01..07)" — the
+intent was UT đối tượng (priority objects per Thông tư 05/2021-BLĐTBXH
+Phụ lục 01) but the field name said ``subject``. PR1 of Q9 #07 corrects
+this naming bug across the schema + JSONB key.
+
+Why a migration at all
+----------------------
+
+Verified via SSH on prod 2026-05-17:
+  - admission_method.default_bonus_rule:  0 rows non-null, 0 with old key
+  - admission_path.bonus_rule_override:   52 rows non-null but all are
+                                          JSON null literal — 0 with key
+
+So **this migration is a no-op on production today**. It ships anyway
+as a DEFENSIVE forward-compat shim: between when this PR merges and
+when prod deploys, an admin could conceivably set ``bonus_rule_override``
+via the path config UI using the old key. The migration runs at
+``alembic upgrade head`` during the deploy entrypoint and converts any
+such row before the Pydantic schema (extra="forbid") tries to load it.
+
+Idempotency
+-----------
+
+The WHERE clause ``... ? 'apply_subject_bonus'`` is the JSONB key-exists
+operator. Re-running the migration is a no-op once the key has been
+renamed, because the predicate no longer matches. Both upgrade and
+downgrade are guarded the same way.
+
+Down-revision chain: ``qae2e02 -> phase1_08a``.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_08a"
+down_revision: Union[str, None] = "qae2e02"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Rename JSONB key apply_subject_bonus -> apply_object_bonus on both
+    # tables that carry the BonusRule shape. The expression is:
+    #   (jsonb - 'old_key') || jsonb_build_object('new_key', jsonb->'old_key')
+    # which strips the old key and adds the new key with the same value
+    # in one atomic JSONB rebuild. The WHERE clause makes the operation
+    # idempotent and safe to re-run.
+    op.execute(
+        """
+        UPDATE admission_method
+        SET default_bonus_rule =
+            (default_bonus_rule - 'apply_subject_bonus')
+            || jsonb_build_object(
+                'apply_object_bonus',
+                default_bonus_rule -> 'apply_subject_bonus'
+            )
+        WHERE default_bonus_rule IS NOT NULL
+          AND default_bonus_rule ? 'apply_subject_bonus'
+        """
+    )
+    op.execute(
+        """
+        UPDATE admission_path
+        SET bonus_rule_override =
+            (bonus_rule_override - 'apply_subject_bonus')
+            || jsonb_build_object(
+                'apply_object_bonus',
+                bonus_rule_override -> 'apply_subject_bonus'
+            )
+        WHERE bonus_rule_override IS NOT NULL
+          AND bonus_rule_override ? 'apply_subject_bonus'
+        """
+    )
+
+
+def downgrade() -> None:
+    # Inverse rename — apply_object_bonus -> apply_subject_bonus.
+    op.execute(
+        """
+        UPDATE admission_method
+        SET default_bonus_rule =
+            (default_bonus_rule - 'apply_object_bonus')
+            || jsonb_build_object(
+                'apply_subject_bonus',
+                default_bonus_rule -> 'apply_object_bonus'
+            )
+        WHERE default_bonus_rule IS NOT NULL
+          AND default_bonus_rule ? 'apply_object_bonus'
+        """
+    )
+    op.execute(
+        """
+        UPDATE admission_path
+        SET bonus_rule_override =
+            (bonus_rule_override - 'apply_object_bonus')
+            || jsonb_build_object(
+                'apply_subject_bonus',
+                bonus_rule_override -> 'apply_object_bonus'
+            )
+        WHERE bonus_rule_override IS NOT NULL
+          AND bonus_rule_override ? 'apply_object_bonus'
+        """
+    )

--- a/Backend_FastAPI/alembic/versions/phase1_08b_priority_demographics_gdnn.py
+++ b/Backend_FastAPI/alembic/versions/phase1_08b_priority_demographics_gdnn.py
@@ -1,0 +1,513 @@
+"""phase1_08b: priority demographics (GDNN priority bonus system)
+
+Revision ID: phase1_08b
+Revises: phase1_08a
+Create Date: 2026-05-17
+
+#184 Q9 #07 Wave A — Foundation schema for Priority Bonus System per
+Thông tư 05/2021/TT-BLĐTBXH Phụ lục 01 (giáo dục nghề nghiệp).
+
+Pulls Q9 #07 forward from Q1/2027 (was deferred per phase1_07b
+docstring) so prod compliance with TT 05/2021 is in place before the
+next admission round. Future TT 2026/BGDĐT will be handled via
+admin-editable per-year rates in the same tables.
+
+Tables created
+--------------
+
+* ``priority_area_config`` (KV rates per academic_year)
+* ``priority_object_config`` (UT đối tượng rates per academic_year)
+* ``vn_commune_area_map`` (commune -> area_code dictionary)
+* ``vn_high_school`` (high school dictionary; PR1 ships empty,
+  PR4 imports MOET CSV)
+
+Columns added
+-------------
+
+* ``admission_profile``: 7 columns (high_school_id FK + KV resolved
+  snapshot + commune_code + resolution_basis + reason + UT codes JSONB +
+  UT evidence JSONB)
+* ``admission_profile_choice``: 3 snapshot columns (area bonus + object
+  bonus + frozen config JSONB at T6 publish, matching the existing
+  ``bonus_rule_snapshot`` Q-P3-11 pattern)
+
+Design decisions baked in
+-------------------------
+
+* **Temporal versioning** (effective_from + effective_to): supports
+  mid-year regulation changes and commune-merge events. Default
+  ``effective_from = CURRENT_DATE`` (= row creation date, no arbitrary
+  epoch). NULL ``effective_to`` = currently valid.
+
+* **Partial UNIQUE indexes** (WHERE effective_to IS NULL): enforces
+  "at most one currently active row per (year, code)" semantic while
+  allowing temporal history rows to coexist. Necessary because regular
+  UNIQUE(year, code) would block the "Bộ ra TT giữa năm" scenario.
+
+* **Soft-delete via ``is_active``** on ``vn_high_school``: admin "hides"
+  duplicate/closed schools without losing audit trail. FK from
+  ``admission_profile.high_school_id`` uses ``ondelete=RESTRICT`` so
+  hard DELETE is blocked while a profile references the row.
+
+* **CHECK regex on area_code / group_code / sub_code**: catches admin
+  typos (``"KV1_"``, ``"kv1"``, ``"KV-1"`` etc.) at DB layer while
+  still allowing future ``KV4``/``UT3`` extensions. Canonical form is
+  ``KV2-NT`` (hyphen) matching TT 05/2021 Phụ lục 01 text.
+
+* **No backfill / no seed**: rates seeded by admin via PR3 CRUD UI;
+  existing 315 profiles get NULL on new columns (engine treats as 0đ
+  graceful) and admin fills via PR7 backfill queue.
+
+Down-revision chain: ``phase1_08a -> phase1_08b``.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_08b"
+down_revision: Union[str, None] = "phase1_08a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    """Idempotency guard for op.add_column. Same pattern as
+    ``q4a1b2c3d4e5_add_academic_year_to_admission`` — protects against
+    partial-fail re-run where a previous attempt added some columns
+    before crashing on another."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    columns = [col["name"] for col in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1) priority_area_config — admin CRUD KV rates per academic_year
+    # ------------------------------------------------------------------
+    op.create_table(
+        "priority_area_config",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "academic_year",
+            sa.Integer,
+            nullable=False,
+            comment="Year-level grouping (vd 2026); matches offering_admission_round.academic_year pattern (plain Integer, no FK)",
+        ),
+        sa.Column(
+            "area_code",
+            sa.String(20),
+            nullable=False,
+            comment="Canonical: KV1 / KV2-NT / KV2 / KV3 (hyphen, per TT 05/2021)",
+        ),
+        sa.Column("area_name", sa.String(100), nullable=False),
+        sa.Column(
+            "bonus_points",
+            sa.Numeric(4, 2),
+            nullable=False,
+            server_default="0.00",
+        ),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column(
+            "effective_from",
+            sa.Date,
+            nullable=False,
+            server_default=sa.text("CURRENT_DATE"),
+        ),
+        sa.Column("effective_to", sa.Date, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "area_code ~ '^KV[1-9](-NT)?$'",
+            name="ck_priority_area_config_area_code_format",
+        ),
+    )
+    op.create_index(
+        "uq_priority_area_config_year_code_active",
+        "priority_area_config",
+        ["academic_year", "area_code"],
+        unique=True,
+        postgresql_where=sa.text("effective_to IS NULL"),
+    )
+
+    # ------------------------------------------------------------------
+    # 2) priority_object_config — admin CRUD UT rates per academic_year
+    # ------------------------------------------------------------------
+    op.create_table(
+        "priority_object_config",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "academic_year",
+            sa.Integer,
+            nullable=False,
+            comment="Year-level grouping (vd 2026); matches offering_admission_round.academic_year pattern (plain Integer, no FK)",
+        ),
+        sa.Column(
+            "group_code",
+            sa.String(10),
+            nullable=False,
+            comment="UT1 / UT2 (extensible UT3+ if Bộ thêm)",
+        ),
+        sa.Column(
+            "sub_code",
+            sa.String(10),
+            nullable=False,
+            comment="2-digit numeric: '01'..'07' per TT 05/2021 Phụ lục 01",
+        ),
+        sa.Column(
+            "description",
+            sa.Text,
+            nullable=False,
+            comment="vd 'Con liệt sĩ', 'Dân tộc thiểu số hộ khẩu KV1'",
+        ),
+        sa.Column(
+            "bonus_points",
+            sa.Numeric(4, 2),
+            nullable=False,
+            server_default="0.00",
+        ),
+        sa.Column(
+            "evidence_doc_type",
+            sa.String(100),
+            nullable=True,
+            comment="Gợi ý loại giấy tờ minh chứng cho thí sinh",
+        ),
+        sa.Column(
+            "effective_from",
+            sa.Date,
+            nullable=False,
+            server_default=sa.text("CURRENT_DATE"),
+        ),
+        sa.Column("effective_to", sa.Date, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "group_code ~ '^UT[1-9]$'",
+            name="ck_priority_object_config_group_code_format",
+        ),
+        sa.CheckConstraint(
+            "sub_code ~ '^[0-9]{2}$'",
+            name="ck_priority_object_config_sub_code_format",
+        ),
+    )
+    op.create_index(
+        "uq_priority_object_config_year_sub_active",
+        "priority_object_config",
+        ["academic_year", "sub_code"],
+        unique=True,
+        postgresql_where=sa.text("effective_to IS NULL"),
+    )
+
+    # ------------------------------------------------------------------
+    # 3) vn_commune_area_map — commune -> area_code dictionary
+    #    PR1 ships empty. PR4 imports BNV CSV (~11k communes).
+    # ------------------------------------------------------------------
+    op.create_table(
+        "vn_commune_area_map",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("commune_code", sa.String(20), nullable=False),
+        sa.Column("province", sa.String(100), nullable=False),
+        sa.Column("district", sa.String(100), nullable=False),
+        sa.Column("ward", sa.String(100), nullable=False),
+        sa.Column("area_code", sa.String(20), nullable=False),
+        sa.Column(
+            "effective_from",
+            sa.Date,
+            nullable=False,
+            server_default=sa.text("CURRENT_DATE"),
+        ),
+        sa.Column("effective_to", sa.Date, nullable=True),
+        sa.CheckConstraint(
+            "area_code ~ '^KV[1-9](-NT)?$'",
+            name="ck_vn_commune_area_map_area_code_format",
+        ),
+    )
+    op.create_index(
+        "ix_vn_commune_area_map_location",
+        "vn_commune_area_map",
+        ["province", "district", "ward"],
+    )
+    op.create_index(
+        "uq_vn_commune_area_map_code_active",
+        "vn_commune_area_map",
+        ["commune_code"],
+        unique=True,
+        postgresql_where=sa.text("effective_to IS NULL"),
+    )
+
+    # ------------------------------------------------------------------
+    # 4) vn_high_school — high school dictionary
+    #    PR1 ships empty. PR4 imports MOET CSV (~3k schools).
+    # ------------------------------------------------------------------
+    op.create_table(
+        "vn_high_school",
+        sa.Column("id", sa.BigInteger, primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("province", sa.String(100), nullable=True),
+        sa.Column("district", sa.String(100), nullable=True),
+        sa.Column("ward", sa.String(100), nullable=True),
+        sa.Column(
+            "kv_code",
+            sa.String(20),
+            nullable=True,
+            comment="Denormalized from vn_commune_area_map for fast lookup",
+        ),
+        sa.Column(
+            "is_active",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("true"),
+            comment=(
+                "Soft-delete flag; FK admission_profile.high_school_id "
+                "RESTRICT prevents hard DELETE while profiles reference row"
+            ),
+        ),
+        sa.Column(
+            "effective_from",
+            sa.Date,
+            nullable=False,
+            server_default=sa.text("CURRENT_DATE"),
+        ),
+        sa.Column("effective_to", sa.Date, nullable=True),
+        sa.CheckConstraint(
+            "kv_code IS NULL OR kv_code ~ '^KV[1-9](-NT)?$'",
+            name="ck_vn_high_school_kv_code_format",
+        ),
+    )
+    op.create_index(
+        "ix_vn_high_school_name",
+        "vn_high_school",
+        ["name"],
+    )
+    op.create_index(
+        "ix_vn_high_school_location_active",
+        "vn_high_school",
+        ["province", "district"],
+        postgresql_where=sa.text("is_active = true"),
+    )
+
+    # ------------------------------------------------------------------
+    # 5) admission_profile — 7 new columns
+    #    All nullable except priority_object_codes / _evidence (NOT NULL
+    #    with empty JSONB default so engine never gets NULL JSONB).
+    #    Wrapped in _column_exists guards for partial-fail re-run safety.
+    # ------------------------------------------------------------------
+    if not _column_exists("admission_profile", "high_school_id"):
+        op.add_column(
+            "admission_profile",
+            sa.Column(
+                "high_school_id",
+                sa.BigInteger,
+                sa.ForeignKey("vn_high_school.id", ondelete="RESTRICT"),
+                nullable=True,
+                comment=(
+                    "FK to vn_high_school. RESTRICT prevents hard delete; "
+                    "admin must use is_active=false for soft delete instead."
+                ),
+            ),
+        )
+    if not _column_exists("admission_profile", "high_school_kv_resolved"):
+        op.add_column(
+            "admission_profile",
+            sa.Column(
+                "high_school_kv_resolved",
+                sa.String(20),
+                nullable=True,
+                comment="KV snapshot at submit time, computed from high_school_id",
+            ),
+        )
+    if not _column_exists("admission_profile", "permanent_commune_code"):
+        op.add_column(
+            "admission_profile",
+            sa.Column(
+                "permanent_commune_code",
+                sa.String(20),
+                nullable=True,
+                comment="Loose ref to vn_commune_area_map.commune_code (no DB FK)",
+            ),
+        )
+    if not _column_exists("admission_profile", "area_resolution_basis"):
+        op.add_column(
+            "admission_profile",
+            sa.Column(
+                "area_resolution_basis",
+                sa.String(40),
+                nullable=True,
+                comment=(
+                    "How KV was resolved: 'high_school' | "
+                    "'permanent_address_special' | 'manual_override'"
+                ),
+            ),
+        )
+    if not _column_exists("admission_profile", "area_resolution_reason"):
+        op.add_column(
+            "admission_profile",
+            sa.Column(
+                "area_resolution_reason",
+                sa.Text,
+                nullable=True,
+                comment="Required when area_resolution_basis='manual_override'",
+            ),
+        )
+    if not _column_exists("admission_profile", "priority_object_codes"):
+        op.add_column(
+            "admission_profile",
+            sa.Column(
+                "priority_object_codes",
+                JSONB,
+                nullable=False,
+                server_default=sa.text("'[]'::jsonb"),
+                comment="Array of UT sub_codes thí sinh khai: ['04','06']",
+            ),
+        )
+    if not _column_exists("admission_profile", "priority_object_evidence"):
+        op.add_column(
+            "admission_profile",
+            sa.Column(
+                "priority_object_evidence",
+                JSONB,
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+                comment=(
+                    "{'04': {'document_id': 123, 'status': "
+                    "'pending|verified|rejected', 'verified_by': 45, "
+                    "'verified_at': '...', 'reject_reason': null}}"
+                ),
+            ),
+        )
+
+    # CHECK enum on area_resolution_basis — catches typos
+    # (vd: 'highschool' vs 'high_school') at DB layer instead of
+    # silently corrupting downstream engine resolution.
+    op.create_check_constraint(
+        "ck_admission_profile_area_resolution_basis",
+        "admission_profile",
+        (
+            "area_resolution_basis IS NULL OR area_resolution_basis IN "
+            "('high_school', 'permanent_address_special', 'manual_override')"
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # 6) admission_profile_choice — 3 snapshot columns at T6 publish
+    #    (matches existing Q-P3-11 bonus_rule_snapshot pattern)
+    # ------------------------------------------------------------------
+    if not _column_exists(
+        "admission_profile_choice", "priority_area_bonus_snapshot"
+    ):
+        op.add_column(
+            "admission_profile_choice",
+            sa.Column(
+                "priority_area_bonus_snapshot",
+                sa.Numeric(4, 2),
+                nullable=True,
+                comment="KV bonus applied at T6, snapshot from priority_area_config",
+            ),
+        )
+    if not _column_exists(
+        "admission_profile_choice", "priority_object_bonus_snapshot"
+    ):
+        op.add_column(
+            "admission_profile_choice",
+            sa.Column(
+                "priority_object_bonus_snapshot",
+                sa.Numeric(4, 2),
+                nullable=True,
+                comment=(
+                    "UT bonus applied at T6 (max of verified UT codes), snapshot "
+                    "from priority_object_config"
+                ),
+            ),
+        )
+    if not _column_exists(
+        "admission_profile_choice", "priority_config_snapshot"
+    ):
+        op.add_column(
+            "admission_profile_choice",
+            sa.Column(
+                "priority_config_snapshot",
+                JSONB,
+                nullable=True,
+                comment=(
+                    "Frozen rates + resolution_basis + resolved_at at T6 publish "
+                    "time for audit replay"
+                ),
+            ),
+        )
+
+
+def downgrade() -> None:
+    # Inverse order — drop additive columns first, then new tables.
+
+    # admission_profile_choice columns
+    op.drop_column("admission_profile_choice", "priority_config_snapshot")
+    op.drop_column("admission_profile_choice", "priority_object_bonus_snapshot")
+    op.drop_column("admission_profile_choice", "priority_area_bonus_snapshot")
+
+    # admission_profile CHECK constraint (drop before the column it guards)
+    op.drop_constraint(
+        "ck_admission_profile_area_resolution_basis",
+        "admission_profile",
+        type_="check",
+    )
+
+    # admission_profile columns
+    op.drop_column("admission_profile", "priority_object_evidence")
+    op.drop_column("admission_profile", "priority_object_codes")
+    op.drop_column("admission_profile", "area_resolution_reason")
+    op.drop_column("admission_profile", "area_resolution_basis")
+    op.drop_column("admission_profile", "permanent_commune_code")
+    op.drop_column("admission_profile", "high_school_kv_resolved")
+    op.drop_column("admission_profile", "high_school_id")
+
+    # New tables — indexes go with their tables in drop_table
+    op.drop_index("ix_vn_high_school_location_active", table_name="vn_high_school")
+    op.drop_index("ix_vn_high_school_name", table_name="vn_high_school")
+    op.drop_table("vn_high_school")
+
+    op.drop_index(
+        "uq_vn_commune_area_map_code_active",
+        table_name="vn_commune_area_map",
+    )
+    op.drop_index(
+        "ix_vn_commune_area_map_location",
+        table_name="vn_commune_area_map",
+    )
+    op.drop_table("vn_commune_area_map")
+
+    op.drop_index(
+        "uq_priority_object_config_year_sub_active",
+        table_name="priority_object_config",
+    )
+    op.drop_table("priority_object_config")
+
+    op.drop_index(
+        "uq_priority_area_config_year_code_active",
+        table_name="priority_area_config",
+    )
+    op.drop_table("priority_area_config")

--- a/Backend_FastAPI/alembic/versions/phase1_09_priority_kv_temporal.py
+++ b/Backend_FastAPI/alembic/versions/phase1_09_priority_kv_temporal.py
@@ -1,0 +1,537 @@
+"""phase1_09: Priority KV temporal multi-school redesign (Q9 #07 PR5 redesign)
+
+Revision ID: phase1_09
+Revises: phase1_08b
+Create Date: 2026-05-17
+
+#184 Q9 #07 Wave B — Redesign per TT 05/2021/TT-BLĐTBXH Phụ lục 01.
+
+Why redesign
+------------
+
+PR1 (phase1_08b) shipped với 1 ``high_school_id`` field duy nhất. Sau khi
+audit TT 05/2021 Phụ lục 01:
+
+    "Nếu trong 3 năm học trung học phổ thông có chuyển trường thì thời
+     gian học ở khu vực nào lâu hơn được hưởng ưu tiên theo khu vực đó."
+
+    "Khi mỗi năm học một trường thuộc các khu vực có mức ưu tiên khác
+     nhau hoặc nửa thời gian học ở trường này, nửa thời gian học ở
+     trường kia thì tốt nghiệp ở khu vực nào, hưởng ưu tiên theo khu
+     vực đó."
+
+→ KV resolution cần multi-school history với weighted resolution +
+graduation-school tiebreak. Single field không đủ.
+
+Plus slowly-changing dimensions:
+* Tên trường có thể đổi (sát nhập)
+* KV của trường có thể đổi qua năm (TT mới, sáp nhập xã)
+* Schema phải lookup KV THEO THỜI ĐIỂM HỌC (academic_year), không current
+
+Changes
+-------
+
+DROP (PR1 empty placeholders — 0 prod rows):
+* ``vn_high_school`` table
+* ``admission_profile.high_school_id``
+* ``admission_profile.high_school_kv_resolved``
+* ``admission_profile.area_resolution_reason`` (canonical moved to
+  ``priority_resolution_snapshot.manual_override_reason``)
+
+CREATE (new temporal schema):
+* ``vn_school`` — master directory (THCS / THPT / THCS_THPT liên cấp /
+  TRUNG_HOC_NGHE future / OTHER)
+* ``vn_school_name_history`` — slowly-changing tên trường
+* ``vn_school_kv_assignment`` — KV theo năm, support TT update mid-period
+
+ADD columns trên ``admission_profile``:
+
+* ``cultural_education_level`` VARCHAR(30) NULL — Trình độ văn hóa
+  candidate đã hoàn thành/tốt nghiệp. Values: ``completed_thcs`` |
+  ``graduated_thcs`` | ``completed_thpt`` | ``graduated_thpt`` |
+  ``graduated_gdtx``. CHECK constraint enforce enum.
+
+* ``vocational_qualification`` VARCHAR(30) NOT NULL DEFAULT 'none' —
+  Trình độ chuyên môn (nghề nghiệp) đã tốt nghiệp. Values: ``none`` |
+  ``so_cap`` | ``trung_cap`` | ``cao_dang``. CHECK enforce enum.
+
+* ``priority_resolution_snapshot`` JSONB: shape ``{kv_resolved,
+  rule_applied, pathway, breakdown, frozen_at, frozen_at_status,
+  manual_override_reason}``. Frozen at submit T1 + re-frozen at
+  engine T6 (per Q-P3-11 snapshot pattern).
+
+2-field parallel design (v1.3 2026-05-18) per VN admission convention
+(Luật GDNN 2014/2025 + TT 05/2021 Điều 4). Cultural = phổ thông,
+vocational = nghề nghiệp; both dimensions độc lập. KV basis derivation
+matrix dispatches on combination.
+
+KEEP (unchanged):
+* ``vn_commune_area_map`` — still needed for TC pathway B
+* ``admission_profile.permanent_commune_code``
+* ``admission_profile.area_resolution_basis``
+* ``admission_profile.priority_object_codes``
+* ``admission_profile.priority_object_evidence``
+* ``admission_profile_choice.priority_*_snapshot`` (3 cols)
+
+Data safety
+-----------
+
+PR1 schema deployed but 0 prod rows in any of the dropped tables/columns
+(verified 2026-05-17). Drop operations safe + reversible via downgrade.
+
+Down-revision chain: ``phase1_08b -> phase1_09``.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = "phase1_09"
+down_revision: Union[str, None] = "phase1_08b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _table_exists(table_name: str) -> bool:
+    """Idempotency guard — true if table already in DB."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    """Idempotency guard — true if column already on table.
+    Same pattern as phase1_08b._column_exists for partial-fail re-run."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return False
+    columns = [col["name"] for col in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1) Drop PR1 placeholder columns + table (empty, 0 prod rows)
+    # ------------------------------------------------------------------
+    if _column_exists("admission_profile", "high_school_id"):
+        # FK constraint on this column → SQLAlchemy auto-drops FK with column
+        op.drop_column("admission_profile", "high_school_id")
+    if _column_exists("admission_profile", "high_school_kv_resolved"):
+        op.drop_column("admission_profile", "high_school_kv_resolved")
+    if _column_exists("admission_profile", "area_resolution_reason"):
+        # Canonical reason now lives in priority_resolution_snapshot.manual_override_reason
+        op.drop_column("admission_profile", "area_resolution_reason")
+
+    if _table_exists("vn_high_school"):
+        # Drop indexes first (created by phase1_08b)
+        op.drop_index("ix_vn_high_school_location_active", table_name="vn_high_school")
+        op.drop_index("ix_vn_high_school_name", table_name="vn_high_school")
+        op.drop_table("vn_high_school")
+
+    # ------------------------------------------------------------------
+    # 2) vn_school — master directory (THCS + THPT + liên cấp + OTHER)
+    # ------------------------------------------------------------------
+    if not _table_exists("vn_school"):
+        op.create_table(
+            "vn_school",
+            sa.Column("id", sa.BigInteger, primary_key=True),
+            sa.Column(
+                "moet_school_code",
+                sa.String(10),
+                nullable=False,
+                comment="MOET school code (per Bộ GD-ĐT Apr 2025 directory)",
+            ),
+            sa.Column(
+                "moet_province_code",
+                sa.String(3),
+                nullable=False,
+                comment="MOET province code — composite unique với moet_school_code",
+            ),
+            sa.Column("moet_district_code", sa.String(5), nullable=True),
+            sa.Column(
+                "name",
+                sa.String(255),
+                nullable=False,
+                comment="Canonical current name; historical via vn_school_name_history",
+            ),
+            sa.Column("address", sa.Text, nullable=True),
+            sa.Column("province", sa.String(100), nullable=False),
+            sa.Column("district", sa.String(100), nullable=True),
+            sa.Column("ward", sa.String(100), nullable=True),
+            sa.Column(
+                "level",
+                sa.String(20),
+                nullable=False,
+                comment=(
+                    "THCS | THPT | THCS_THPT (liên cấp 2-3) | "
+                    "TRUNG_HOC_NGHE (dự thảo TT 2026) | OTHER"
+                ),
+            ),
+            sa.Column(
+                "is_dtnt",
+                sa.Boolean,
+                nullable=False,
+                server_default=sa.text("false"),
+                comment="Trường PT Dân tộc Nội trú — flag for special case bypass",
+            ),
+            sa.Column(
+                "is_active",
+                sa.Boolean,
+                nullable=False,
+                server_default=sa.text("true"),
+                comment=(
+                    "Soft-delete flag. Admin 'xoá' = is_active=false; "
+                    "FK from admission_profile uses RESTRICT to preserve audit."
+                ),
+            ),
+            sa.Column(
+                "merged_into_id",
+                sa.BigInteger,
+                sa.ForeignKey("vn_school.id"),
+                nullable=True,
+                comment="If school merged, points to surviving school. KV lookup vẫn theo school_id gốc + năm gốc.",
+            ),
+            sa.Column("merge_effective_date", sa.Date, nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.CheckConstraint(
+                "level IN ('THCS', 'THPT', 'THCS_THPT', 'TRUNG_HOC_NGHE', 'OTHER')",
+                name="ck_vn_school_level",
+            ),
+        )
+        # Composite unique per active row — handles "same MOET code but
+        # school inactive after sát nhập" by partial UNIQUE.
+        op.create_index(
+            "uq_vn_school_moet_code_active",
+            "vn_school",
+            ["moet_province_code", "moet_school_code"],
+            unique=True,
+            postgresql_where=sa.text("is_active = true"),
+        )
+        op.create_index(
+            "ix_vn_school_name",
+            "vn_school",
+            ["name"],
+        )
+        op.create_index(
+            "ix_vn_school_location",
+            "vn_school",
+            ["province", "district"],
+            postgresql_where=sa.text("is_active = true"),
+        )
+        op.create_index(
+            "ix_vn_school_level_active",
+            "vn_school",
+            ["level"],
+            postgresql_where=sa.text("is_active = true"),
+        )
+
+    # ------------------------------------------------------------------
+    # 3) vn_school_name_history — slowly-changing name tracking
+    # ------------------------------------------------------------------
+    if not _table_exists("vn_school_name_history"):
+        op.create_table(
+            "vn_school_name_history",
+            sa.Column("id", sa.BigInteger, primary_key=True),
+            sa.Column(
+                "school_id",
+                sa.BigInteger,
+                sa.ForeignKey("vn_school.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("name", sa.String(255), nullable=False),
+            sa.Column("effective_from", sa.Date, nullable=False),
+            sa.Column("effective_to", sa.Date, nullable=True),
+            sa.Column(
+                "notes",
+                sa.Text,
+                nullable=True,
+                comment="vd 'Sát nhập với Trường X' hoặc 'Đổi tên theo QĐ Y'",
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.UniqueConstraint(
+                "school_id", "effective_from",
+                name="uq_vn_school_name_history_school_effective",
+            ),
+        )
+        op.create_index(
+            "ix_vn_school_name_history_lookup",
+            "vn_school_name_history",
+            ["school_id", "effective_from"],
+        )
+
+    # ------------------------------------------------------------------
+    # 4) vn_school_kv_assignment — KV theo năm (temporal)
+    # ------------------------------------------------------------------
+    if not _table_exists("vn_school_kv_assignment"):
+        op.create_table(
+            "vn_school_kv_assignment",
+            sa.Column("id", sa.BigInteger, primary_key=True),
+            sa.Column(
+                "school_id",
+                sa.BigInteger,
+                sa.ForeignKey("vn_school.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "kv_code",
+                sa.String(20),
+                nullable=False,
+                comment="KV1 / KV2-NT / KV2 / KV3 (hyphen canonical per TT 05/2021)",
+            ),
+            sa.Column(
+                "effective_from_year",
+                sa.Integer,
+                nullable=False,
+                comment="Năm bắt đầu hiệu lực, vd 2025 = năm học 2025-2026",
+            ),
+            sa.Column(
+                "effective_to_year",
+                sa.Integer,
+                nullable=True,
+                comment="Năm kết thúc (inclusive). NULL = ongoing.",
+            ),
+            sa.Column(
+                "source",
+                sa.String(50),
+                nullable=False,
+                comment="moet_2024 | moet_2025 | qd_861 | manual_admin | qd_ubnd_<tinh>",
+            ),
+            sa.Column("notes", sa.Text, nullable=True),
+            sa.Column(
+                "created_by",
+                sa.Integer,
+                sa.ForeignKey("user.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.CheckConstraint(
+                "kv_code ~ '^KV[1-9](-NT)?$'",
+                name="ck_vn_school_kv_assignment_kv_code_format",
+            ),
+            sa.CheckConstraint(
+                "effective_to_year IS NULL OR effective_to_year >= effective_from_year",
+                name="ck_vn_school_kv_assignment_year_range_valid",
+            ),
+            # M3 review fix: NO EXCLUDE GiST constraint. Overlap check at
+            # service-layer (priority_service.add_kv_assignment) — simpler
+            # ORM compat + test DB create_all friendly per memory
+            # ``migration-predicate-safety``.
+        )
+        op.create_index(
+            "ix_vn_school_kv_lookup",
+            "vn_school_kv_assignment",
+            ["school_id", "effective_from_year"],
+            postgresql_using="btree",
+        )
+
+    # ------------------------------------------------------------------
+    # 5) admission_profile — Trình độ văn hóa + Trình độ chuyên môn (v1.3)
+    # 2-field parallel design per VN admission convention (Luật GDNN +
+    # TT 05/2021 Điều 4). Drives KV basis derivation matrix.
+    # ------------------------------------------------------------------
+    if not _column_exists("admission_profile", "cultural_education_level"):
+        op.add_column(
+            "admission_profile",
+            sa.Column(
+                "cultural_education_level",
+                sa.String(30),
+                nullable=True,
+                comment=(
+                    "Trình độ văn hóa (phổ thông): completed_thcs | "
+                    "graduated_thcs | completed_thpt | graduated_thpt | "
+                    "graduated_gdtx. Nullable cho draft state — candidate "
+                    "có thể chưa khai. Required tại submit T1."
+                ),
+            ),
+        )
+        # CHECK constraint enforce enum at DB layer
+        op.create_check_constraint(
+            "ck_admission_profile_cultural_education_level",
+            "admission_profile",
+            (
+                "cultural_education_level IS NULL OR "
+                "cultural_education_level IN ("
+                "'completed_thcs', 'graduated_thcs', "
+                "'completed_thpt', 'graduated_thpt', 'graduated_gdtx'"
+                ")"
+            ),
+        )
+
+    if not _column_exists("admission_profile", "vocational_qualification"):
+        op.add_column(
+            "admission_profile",
+            sa.Column(
+                "vocational_qualification",
+                sa.String(30),
+                nullable=False,
+                server_default=sa.text("'none'"),
+                comment=(
+                    "Trình độ chuyên môn (nghề nghiệp): none | so_cap | "
+                    "trung_cap | cao_dang. NOT NULL DEFAULT 'none' — auto "
+                    "fill cho legacy 315 + new profiles."
+                ),
+            ),
+        )
+        op.create_check_constraint(
+            "ck_admission_profile_vocational_qualification",
+            "admission_profile",
+            (
+                "vocational_qualification IN ("
+                "'none', 'so_cap', 'trung_cap', 'cao_dang'"
+                ")"
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # 6) admission_profile.priority_resolution_snapshot — NEW JSONB
+    # ------------------------------------------------------------------
+    if not _column_exists("admission_profile", "priority_resolution_snapshot"):
+        op.add_column(
+            "admission_profile",
+            sa.Column(
+                "priority_resolution_snapshot",
+                JSONB,
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+                comment=(
+                    "Frozen KV resolution at submit T1 + re-frozen at engine T6 "
+                    "(Q-P3-11 pattern). Shape: {kv_resolved, rule_applied, "
+                    "pathway, breakdown, frozen_at, frozen_at_status, "
+                    "manual_override_reason}. Empty dict {} = not resolved yet "
+                    "(draft state — service computes real-time)."
+                ),
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Reverse — drop new schema + restore PR1 placeholder columns.
+
+    Note: cannot restore PR1 vn_high_school content (was empty), so we
+    just recreate the empty table shape for chain compatibility. Same for
+    the 3 admission_profile columns — they were empty in prod when
+    phase1_09 ran.
+    """
+    # 1) Drop snapshot column + 2 cultural/vocational columns (v1.3)
+    if _column_exists("admission_profile", "priority_resolution_snapshot"):
+        op.drop_column("admission_profile", "priority_resolution_snapshot")
+
+    if _column_exists("admission_profile", "vocational_qualification"):
+        op.drop_constraint(
+            "ck_admission_profile_vocational_qualification",
+            "admission_profile",
+            type_="check",
+        )
+        op.drop_column("admission_profile", "vocational_qualification")
+
+    if _column_exists("admission_profile", "cultural_education_level"):
+        op.drop_constraint(
+            "ck_admission_profile_cultural_education_level",
+            "admission_profile",
+            type_="check",
+        )
+        op.drop_column("admission_profile", "cultural_education_level")
+
+    # 2) Drop new tables in reverse FK order
+    if _table_exists("vn_school_kv_assignment"):
+        op.drop_index("ix_vn_school_kv_lookup", table_name="vn_school_kv_assignment")
+        op.drop_table("vn_school_kv_assignment")
+
+    if _table_exists("vn_school_name_history"):
+        op.drop_index(
+            "ix_vn_school_name_history_lookup",
+            table_name="vn_school_name_history",
+        )
+        op.drop_table("vn_school_name_history")
+
+    if _table_exists("vn_school"):
+        op.drop_index("ix_vn_school_level_active", table_name="vn_school")
+        op.drop_index("ix_vn_school_location", table_name="vn_school")
+        op.drop_index("ix_vn_school_name", table_name="vn_school")
+        op.drop_index("uq_vn_school_moet_code_active", table_name="vn_school")
+        op.drop_table("vn_school")
+
+    # 3) Restore PR1 columns (empty shape for chain compat)
+    if not _column_exists("admission_profile", "area_resolution_reason"):
+        op.add_column(
+            "admission_profile",
+            sa.Column("area_resolution_reason", sa.Text, nullable=True),
+        )
+
+    # 4) Restore PR1 vn_high_school placeholder table
+    if not _table_exists("vn_high_school"):
+        op.create_table(
+            "vn_high_school",
+            sa.Column("id", sa.BigInteger, primary_key=True),
+            sa.Column("name", sa.String(255), nullable=False),
+            sa.Column("province", sa.String(100), nullable=True),
+            sa.Column("district", sa.String(100), nullable=True),
+            sa.Column("ward", sa.String(100), nullable=True),
+            sa.Column("kv_code", sa.String(20), nullable=True),
+            sa.Column(
+                "is_active",
+                sa.Boolean,
+                nullable=False,
+                server_default=sa.text("true"),
+            ),
+            sa.Column(
+                "effective_from",
+                sa.Date,
+                nullable=False,
+                server_default=sa.text("CURRENT_DATE"),
+            ),
+            sa.Column("effective_to", sa.Date, nullable=True),
+            sa.CheckConstraint(
+                "kv_code IS NULL OR kv_code ~ '^KV[1-9](-NT)?$'",
+                name="ck_vn_high_school_kv_code_format",
+            ),
+        )
+        op.create_index("ix_vn_high_school_name", "vn_high_school", ["name"])
+        op.create_index(
+            "ix_vn_high_school_location_active",
+            "vn_high_school",
+            ["province", "district"],
+            postgresql_where=sa.text("is_active = true"),
+        )
+
+    if not _column_exists("admission_profile", "high_school_id"):
+        op.add_column(
+            "admission_profile",
+            sa.Column(
+                "high_school_id",
+                sa.BigInteger,
+                sa.ForeignKey("vn_high_school.id", ondelete="RESTRICT"),
+                nullable=True,
+            ),
+        )
+    if not _column_exists("admission_profile", "high_school_kv_resolved"):
+        op.add_column(
+            "admission_profile",
+            sa.Column("high_school_kv_resolved", sa.String(20), nullable=True),
+        )

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -44,6 +44,7 @@ from .routers import (
     admin_v2_admission_round,  # ✅ #184 Phase 2 v8.2 PR-2A v2: year-level rounds CRUD + bulk-create + extend
     admin_v2_path_subject_group,  # ✅ #184 Phase 2 v8.2 PR-2D: path-level subject group config + clone endpoint
     admin_priority_config,  # ✅ Q9 #07 PR3: priority KV/UT bonus configs per year + clone + seed TT 05/2021
+    admin_vn_locality,  # ✅ Q9 #07 PR4: commune + high school CSV import + dropdown search
     admin_v2_system_config,  # ✅ #184 PR-1D / phase1_13: admin runtime config
     admin_backfill,  # ✅ #184 Phase 3 PR-3D-B BE-2: admin backfill exception queue (Q-P3-09)
     admissions,  # ✅ NEW: Admission Profile workflow
@@ -802,6 +803,8 @@ fastapi_app.include_router(admin_v2_system_config.router)  # ✅ #184 PR-1D: GET
 fastapi_app.include_router(admin_v2_admission_round.router)  # ✅ #184 Phase 2 v8.2 PR-2A v2: year-level rounds (router declares full prefix)
 fastapi_app.include_router(admin_v2_path_subject_group.router)  # ✅ #184 Phase 2 v8.2 PR-2D: path-level subject group config + clone
 fastapi_app.include_router(admin_priority_config.router)  # ✅ Q9 #07 PR3: priority KV/UT configs (router declares full prefix)
+fastapi_app.include_router(admin_vn_locality.admin_router)  # ✅ Q9 #07 PR4: admin CSV import for commune + high school
+fastapi_app.include_router(admin_vn_locality.public_router)  # ✅ Q9 #07 PR4: public HS search dropdown for candidate FE
 fastapi_app.include_router(document_groups.router, prefix="/api")  # ✅ PHASE A.3: DocumentGroup CRUD
 fastapi_app.include_router(config_data.router, prefix="/api") # ✅ NEW: Config Data
 fastapi_app.include_router(administrative.router, prefix="/api")  # ✅ PHASE 4: Administrative address nodes

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -803,8 +803,8 @@ fastapi_app.include_router(admin_v2_system_config.router)  # ✅ #184 PR-1D: GET
 fastapi_app.include_router(admin_v2_admission_round.router)  # ✅ #184 Phase 2 v8.2 PR-2A v2: year-level rounds (router declares full prefix)
 fastapi_app.include_router(admin_v2_path_subject_group.router)  # ✅ #184 Phase 2 v8.2 PR-2D: path-level subject group config + clone
 fastapi_app.include_router(admin_priority_config.router)  # ✅ Q9 #07 PR3: priority KV/UT configs (router declares full prefix)
-fastapi_app.include_router(admin_vn_locality.admin_router)  # ✅ Q9 #07 PR4: admin CSV import for commune + high school
-fastapi_app.include_router(admin_vn_locality.public_router)  # ✅ Q9 #07 PR4: public HS search dropdown for candidate FE
+fastapi_app.include_router(admin_vn_locality.admin_router)  # ✅ Q9 #07 PR4: admin commune CSV import
+# public_router DROPPED phase1_09 — HS search endpoint re-introduced in Phase D as /admin/vn-school/*
 fastapi_app.include_router(document_groups.router, prefix="/api")  # ✅ PHASE A.3: DocumentGroup CRUD
 fastapi_app.include_router(config_data.router, prefix="/api") # ✅ NEW: Config Data
 fastapi_app.include_router(administrative.router, prefix="/api")  # ✅ PHASE 4: Administrative address nodes

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -43,6 +43,7 @@ from .routers import (
     admin_v2_casbin,  # ✅ T0-5 cold cutover: admin-only Casbin reload endpoint
     admin_v2_admission_round,  # ✅ #184 Phase 2 v8.2 PR-2A v2: year-level rounds CRUD + bulk-create + extend
     admin_v2_path_subject_group,  # ✅ #184 Phase 2 v8.2 PR-2D: path-level subject group config + clone endpoint
+    admin_priority_config,  # ✅ Q9 #07 PR3: priority KV/UT bonus configs per year + clone + seed TT 05/2021
     admin_v2_system_config,  # ✅ #184 PR-1D / phase1_13: admin runtime config
     admin_backfill,  # ✅ #184 Phase 3 PR-3D-B BE-2: admin backfill exception queue (Q-P3-09)
     admissions,  # ✅ NEW: Admission Profile workflow
@@ -800,6 +801,7 @@ fastapi_app.include_router(admin_v2_casbin.router)  # ✅ T0-5: POST /api/v2/adm
 fastapi_app.include_router(admin_v2_system_config.router)  # ✅ #184 PR-1D: GET/PATCH /api/v2/admin/system-config (router declares full prefix)
 fastapi_app.include_router(admin_v2_admission_round.router)  # ✅ #184 Phase 2 v8.2 PR-2A v2: year-level rounds (router declares full prefix)
 fastapi_app.include_router(admin_v2_path_subject_group.router)  # ✅ #184 Phase 2 v8.2 PR-2D: path-level subject group config + clone
+fastapi_app.include_router(admin_priority_config.router)  # ✅ Q9 #07 PR3: priority KV/UT configs (router declares full prefix)
 fastapi_app.include_router(document_groups.router, prefix="/api")  # ✅ PHASE A.3: DocumentGroup CRUD
 fastapi_app.include_router(config_data.router, prefix="/api") # ✅ NEW: Config Data
 fastapi_app.include_router(administrative.router, prefix="/api")  # ✅ PHASE 4: Administrative address nodes

--- a/Backend_FastAPI/app/models/__init__.py
+++ b/Backend_FastAPI/app/models/__init__.py
@@ -116,7 +116,10 @@ from .administrative_node import AdministrativeNode, AdministrativeLevel
 
 # Q9 #07 PR1 — Priority bonus configs + VN locality dictionaries (phase1_08b)
 from .priority_config import PriorityAreaConfig, PriorityObjectConfig
-from .vn_locality import VnCommuneAreaMap, VnHighSchool
+from .vn_locality import VnCommuneAreaMap
+# Q9 #07 PR5 v1.3 (phase1_09) — VN school 3-table family + SCD
+# Replaces VnHighSchool (PR1 single-table placeholder, dropped phase1_09)
+from .vn_school import VnSchool, VnSchoolNameHistory, VnSchoolKvAssignment
 
 # Finance Module (Phase 0+1: Foundation)
 from .finance import (
@@ -236,7 +239,10 @@ __all__ = [
     "PriorityAreaConfig",
     "PriorityObjectConfig",
     "VnCommuneAreaMap",
-    "VnHighSchool",
+    # VnHighSchool removed in phase1_09 — see VnSchool family below
+    "VnSchool",
+    "VnSchoolNameHistory",
+    "VnSchoolKvAssignment",
     # Finance Module (Phase 0+1: Foundation)
     # Enums
     "FeeTypeEnum",

--- a/Backend_FastAPI/app/models/__init__.py
+++ b/Backend_FastAPI/app/models/__init__.py
@@ -114,6 +114,10 @@ from .entity_audit_log import EntityAuditLog  # Generic audit trail for any enti
 # Administrative Geography (Temporal Versioning)
 from .administrative_node import AdministrativeNode, AdministrativeLevel
 
+# Q9 #07 PR1 — Priority bonus configs + VN locality dictionaries (phase1_08b)
+from .priority_config import PriorityAreaConfig, PriorityObjectConfig
+from .vn_locality import VnCommuneAreaMap, VnHighSchool
+
 # Finance Module (Phase 0+1: Foundation)
 from .finance import (
     # Enums
@@ -228,6 +232,11 @@ __all__ = [
     # Administrative Geography
     "AdministrativeNode",
     "AdministrativeLevel",
+    # Q9 #07 PR1 — Priority bonus configs + VN locality dictionaries
+    "PriorityAreaConfig",
+    "PriorityObjectConfig",
+    "VnCommuneAreaMap",
+    "VnHighSchool",
     # Finance Module (Phase 0+1: Foundation)
     # Enums
     "FeeTypeEnum",

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -74,6 +74,20 @@ class AdmissionProfile(Base):
             "('high_school', 'permanent_address_special', 'manual_override')",
             name="ck_admission_profile_area_resolution_basis"
         ),
+        # Q9 #07 PR5 v1.3 (phase1_09) — Trình độ văn hóa enum CHECK.
+        # Mirror migration constraint for Base.metadata.create_all() test DB.
+        CheckConstraint(
+            "cultural_education_level IS NULL OR cultural_education_level IN "
+            "('completed_thcs', 'graduated_thcs', "
+            "'completed_thpt', 'graduated_thpt', 'graduated_gdtx')",
+            name="ck_admission_profile_cultural_education_level"
+        ),
+        # Q9 #07 PR5 v1.3 — Trình độ chuyên môn enum CHECK.
+        CheckConstraint(
+            "vocational_qualification IN "
+            "('none', 'so_cap', 'trung_cap', 'cao_dang')",
+            name="ck_admission_profile_vocational_qualification"
+        ),
     )
 
     # Primary Key
@@ -198,21 +212,32 @@ class AdmissionProfile(Base):
     )
 
     # =========================================================================
-    # Q9 #07 PR1 — Priority Bonus demographics (phase1_08b migration)
-    # See Backend_FastAPI/alembic/versions/phase1_08b_priority_demographics_gdnn.py
+    # Q9 #07 Priority Bonus demographics
+    # PR1 phase1_08b: initial cols (some dropped in phase1_09 — see below)
+    # PR5 phase1_09: 2-field parallel (cultural + vocational) + snapshot
+    # See Documents/Q9_07_PR5_REDESIGN.md v1.3 cho design rationale
     # =========================================================================
 
-    # High school resolution (PRIMARY KV basis per TT 05/2021 Điều 7+11)
-    high_school_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("vn_high_school.id", ondelete="RESTRICT"),
-        nullable=True,
-        comment="FK to vn_high_school. RESTRICT prevents hard delete; admin uses is_active=false instead."
+    # --- Trình độ văn hóa + chuyên môn (2-field parallel, v1.3 phase1_09) ---
+    cultural_education_level: Mapped[Optional[str]] = mapped_column(
+        String(30), nullable=True,
+        comment=(
+            "Trình độ văn hóa (phổ thông): completed_thcs | graduated_thcs | "
+            "completed_thpt | graduated_thpt | graduated_gdtx. Nullable cho "
+            "draft state; required tại submit T1."
+        )
     )
-    high_school_kv_resolved: Mapped[Optional[str]] = mapped_column(
-        String(20), nullable=True,
-        comment="KV snapshot at submit time, computed from high_school_id"
+    vocational_qualification: Mapped[str] = mapped_column(
+        String(30),
+        nullable=False,
+        default="none",
+        server_default=text("'none'"),
+        comment=(
+            "Trình độ chuyên môn (nghề nghiệp): none | so_cap | trung_cap | "
+            "cao_dang. NOT NULL DEFAULT 'none' — auto fill legacy + new."
+        )
     )
-    # Permanent address resolution (BACKUP basis for special case: PT DTNT, quân nhân, lớp dự bị)
+    # --- Permanent address resolution (BACKUP basis cho 4 special cases) ---
     permanent_commune_code: Mapped[Optional[str]] = mapped_column(
         String(20), nullable=True,
         comment="Loose ref to vn_commune_area_map.commune_code (no DB FK)"
@@ -221,11 +246,11 @@ class AdmissionProfile(Base):
         String(40), nullable=True,
         comment="'high_school' | 'permanent_address_special' | 'manual_override'"
     )
-    area_resolution_reason: Mapped[Optional[str]] = mapped_column(
-        Text, nullable=True,
-        comment="Required when area_resolution_basis='manual_override'"
-    )
-    # UT đối tượng codes + evidence (per TT 05/2021 Phụ lục 01 nhóm 01-07)
+    # NOTE: high_school_id + high_school_kv_resolved + area_resolution_reason
+    # DROPPED trong phase1_09. KV result giờ live in priority_resolution_snapshot;
+    # multi-school history live in academic_history JSONB.
+
+    # --- UT đối tượng codes + evidence (TT 05/2021 Phụ lục 01 nhóm 01-07) ---
     priority_object_codes: Mapped[list[str]] = mapped_column(
         JSONB,
         nullable=False,
@@ -239,6 +264,19 @@ class AdmissionProfile(Base):
         default=dict,
         server_default=text("'{}'::jsonb"),
         comment="{'04': {'document_id': 123, 'status': 'pending|verified|rejected', 'verified_by': 45, 'verified_at': '...', 'reject_reason': null}}"
+    )
+    # --- Priority resolution snapshot (v1.3 phase1_09 — Q-P3-11 pattern) ---
+    priority_resolution_snapshot: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=dict,
+        server_default=text("'{}'::jsonb"),
+        comment=(
+            "Frozen KV resolution at submit T1 + re-frozen at engine T6. "
+            "Shape: {kv_resolved, rule_applied, pathway, breakdown, "
+            "frozen_at, frozen_at_status, manual_override_reason}. "
+            "Empty {} = draft state (service computes real-time preview)."
+        )
     )
 
     place_of_birth: Mapped[str] = mapped_column(String(255), nullable=True)

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -15,7 +15,7 @@ Architecture:
 """
 
 from datetime import date, datetime, timezone
-from typing import List, Optional
+from typing import Any, List, Optional
 from sqlalchemy import Boolean, CheckConstraint, Column, Date, Index, Integer, Numeric, SmallInteger, String, Text, DateTime, ForeignKey, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import ENUM, JSONB
 from sqlalchemy.orm import relationship, Mapped, mapped_column
@@ -66,6 +66,13 @@ class AdmissionProfile(Base):
         CheckConstraint(
             "confirmed_via IN ('magic_link','admin_override','officer') OR confirmed_via IS NULL",
             name="ck_admission_profile_confirmed_via"
+        ),
+        # Q9 #07 PR1 — area_resolution_basis enum CHECK (mirror of phase1_08b).
+        # Catches typo 'highschool' vs 'high_school' at DB layer.
+        CheckConstraint(
+            "area_resolution_basis IS NULL OR area_resolution_basis IN "
+            "('high_school', 'permanent_address_special', 'manual_override')",
+            name="ck_admission_profile_area_resolution_basis"
         ),
     )
 
@@ -188,6 +195,50 @@ class AdmissionProfile(Base):
     permanent_street_address: Mapped[str] = mapped_column(
         String(255), nullable=True,
         comment="Số nhà, tên đường — street address line, free-text"
+    )
+
+    # =========================================================================
+    # Q9 #07 PR1 — Priority Bonus demographics (phase1_08b migration)
+    # See Backend_FastAPI/alembic/versions/phase1_08b_priority_demographics_gdnn.py
+    # =========================================================================
+
+    # High school resolution (PRIMARY KV basis per TT 05/2021 Điều 7+11)
+    high_school_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("vn_high_school.id", ondelete="RESTRICT"),
+        nullable=True,
+        comment="FK to vn_high_school. RESTRICT prevents hard delete; admin uses is_active=false instead."
+    )
+    high_school_kv_resolved: Mapped[Optional[str]] = mapped_column(
+        String(20), nullable=True,
+        comment="KV snapshot at submit time, computed from high_school_id"
+    )
+    # Permanent address resolution (BACKUP basis for special case: PT DTNT, quân nhân, lớp dự bị)
+    permanent_commune_code: Mapped[Optional[str]] = mapped_column(
+        String(20), nullable=True,
+        comment="Loose ref to vn_commune_area_map.commune_code (no DB FK)"
+    )
+    area_resolution_basis: Mapped[Optional[str]] = mapped_column(
+        String(40), nullable=True,
+        comment="'high_school' | 'permanent_address_special' | 'manual_override'"
+    )
+    area_resolution_reason: Mapped[Optional[str]] = mapped_column(
+        Text, nullable=True,
+        comment="Required when area_resolution_basis='manual_override'"
+    )
+    # UT đối tượng codes + evidence (per TT 05/2021 Phụ lục 01 nhóm 01-07)
+    priority_object_codes: Mapped[list[str]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default=text("'[]'::jsonb"),
+        comment="Array of UT sub_codes thí sinh khai: ['04','06']"
+    )
+    priority_object_evidence: Mapped[dict[str, dict[str, Any]]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=dict,
+        server_default=text("'{}'::jsonb"),
+        comment="{'04': {'document_id': 123, 'status': 'pending|verified|rejected', 'verified_by': 45, 'verified_at': '...', 'reject_reason': null}}"
     )
 
     place_of_birth: Mapped[str] = mapped_column(String(255), nullable=True)

--- a/Backend_FastAPI/app/models/admission_config/admission_path.py
+++ b/Backend_FastAPI/app/models/admission_config/admission_path.py
@@ -197,10 +197,11 @@ class AdmissionPath(Base):
     # phase1_02 (#184 Wave 1) — path-level bonus rule override above
     # the method default. Same JSONB shape as
     # AdmissionMethod.default_bonus_rule. NULL = inherit from method.
+    # (apply_subject_bonus renamed -> apply_object_bonus in phase1_08a / Q9 #07 PR1.)
     # Resolution precedence (PLAN line 787-789):
     #   effective = path.bonus_rule_override
     #               ?? method.default_bonus_rule
-    #               ?? {"apply_area_bonus": false, "apply_subject_bonus": false}
+    #               ?? {"apply_area_bonus": false, "apply_object_bonus": false}
     bonus_rule_override = Column(
         JSONB,
         nullable=True,

--- a/Backend_FastAPI/app/models/admission_config/method.py
+++ b/Backend_FastAPI/app/models/admission_config/method.py
@@ -70,13 +70,14 @@ class AdmissionMethod(Base):
     )
 
     # phase1_02 (#184 Wave 1) — method-level default bonus rule.
-    # Schema: {"apply_area_bonus": bool, "apply_subject_bonus": bool,
+    # Schema: {"apply_area_bonus": bool, "apply_object_bonus": bool,
     # "max_total_bonus": float}. NULL = bonus disabled fallback.
+    # (apply_subject_bonus renamed -> apply_object_bonus in phase1_08a / Q9 #07 PR1.)
     # Path-level override via AdmissionPath.bonus_rule_override.
     # Resolution rule (PLAN line 787-789):
     #   effective = path.bonus_rule_override
     #               ?? method.default_bonus_rule
-    #               ?? {"apply_area_bonus": false, "apply_subject_bonus": false}
+    #               ?? {"apply_area_bonus": false, "apply_object_bonus": false}
     default_bonus_rule = Column(
         JSONB,
         nullable=True,

--- a/Backend_FastAPI/app/models/admission_profile_choice.py
+++ b/Backend_FastAPI/app/models/admission_profile_choice.py
@@ -33,6 +33,7 @@ Service invariant (P1 fix #4 v1.3): ``path_subject_group_config.
 admission_path_id == admission_profile_choice.admission_path_id``.
 """
 from datetime import datetime
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Optional
 
 from sqlalchemy import (
@@ -147,6 +148,30 @@ class AdmissionProfileChoice(Base):
         JSONB,
         nullable=True,
         comment="Q-P3-11: BonusRule snapshot tại T6 publish (NOT T1)",
+    )
+
+    # Q9 #07 PR1 — Priority bonus snapshots at T6 publish (phase1_08b)
+    # See Backend_FastAPI/alembic/versions/phase1_08b_priority_demographics_gdnn.py
+    priority_area_bonus_snapshot: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(4, 2),
+        nullable=True,
+        comment="KV bonus applied at T6, snapshot from priority_area_config",
+    )
+    priority_object_bonus_snapshot: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(4, 2),
+        nullable=True,
+        comment=(
+            "UT bonus applied at T6 (max of verified UT codes), snapshot "
+            "from priority_object_config"
+        ),
+    )
+    priority_config_snapshot: Mapped[Optional[dict[str, Any]]] = mapped_column(
+        JSONB,
+        nullable=True,
+        comment=(
+            "Frozen rates + resolution_basis + resolved_at at T6 publish "
+            "time for audit replay"
+        ),
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/Backend_FastAPI/app/models/priority_config.py
+++ b/Backend_FastAPI/app/models/priority_config.py
@@ -1,0 +1,189 @@
+# app/models/priority_config.py
+"""ORM models for priority bonus configuration (Q9 #07 PR1).
+
+Two admin-editable, year-scoped tables that drive the priority bonus
+calculation in PR2's ``priority_service.py``:
+
+* ``PriorityAreaConfig`` — KV (khu vực) rates per academic_year.
+  Default seed in PR3 matches TT 05/2021 Phụ lục 01:
+  KV1=0.75 / KV2-NT=0.5 / KV2=0.25 / KV3=0.
+
+* ``PriorityObjectConfig`` — UT (đối tượng) rates per academic_year +
+  sub_code. Default seed in PR3 matches TT 05/2021 Phụ lục 01:
+  UT1 group (sub_codes 01-04) = 2.0, UT2 group (sub_codes 05-07) = 1.0.
+  Multi-UT calculation rule (max of verified codes) lives in PR2 engine.
+
+Temporal versioning
+-------------------
+
+Both tables carry ``effective_from`` / ``effective_to`` so a regulation
+change mid-year creates a new row instead of mutating the old one.
+Partial UNIQUE indexes (``WHERE effective_to IS NULL``) defined in
+``phase1_08b`` migration enforce "at most one active row per
+(year, code)" while allowing history rows to coexist.
+
+See ``alembic/versions/phase1_08b_priority_demographics_gdnn.py`` for
+DDL + CHECK constraints (area_code/group_code/sub_code regex).
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy import CheckConstraint, Date, DateTime, Integer, Numeric, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class PriorityAreaConfig(Base):
+    """KV (khu vực) bonus rate, scoped per academic_year.
+
+    Lookup pattern (PR2 engine):
+        SELECT bonus_points
+        FROM priority_area_config
+        WHERE academic_year = :year
+          AND area_code = :kv_code
+          AND effective_from <= CURRENT_DATE
+          AND (effective_to IS NULL OR effective_to > CURRENT_DATE)
+    """
+
+    __tablename__ = "priority_area_config"
+    __table_args__ = (
+        # Mirror of phase1_08b CHECK — catches typos at Base.metadata.create_all()
+        # test DB (which doesn't run alembic). Memory test-db-schema-source.
+        CheckConstraint(
+            "area_code ~ '^KV[1-9](-NT)?$'",
+            name="ck_priority_area_config_area_code_format",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    academic_year: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Year-level grouping (vd 2026)",
+    )
+    area_code: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        comment="Canonical: KV1 / KV2-NT / KV2 / KV3 (hyphen, per TT 05/2021)",
+    )
+    area_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    bonus_points: Mapped[Decimal] = mapped_column(
+        Numeric(4, 2),
+        nullable=False,
+        server_default="0.00",
+    )
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    effective_from: Mapped[date] = mapped_column(
+        Date,
+        nullable=False,
+        server_default=sa.text("CURRENT_DATE"),
+    )
+    effective_to: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<PriorityAreaConfig id={self.id} year={self.academic_year} "
+            f"code={self.area_code!r} pts={self.bonus_points}>"
+        )
+
+
+class PriorityObjectConfig(Base):
+    """UT (đối tượng) bonus rate, scoped per academic_year + sub_code.
+
+    Lookup pattern (PR2 engine, multi-UT max rule):
+        SELECT MAX(bonus_points)
+        FROM priority_object_config
+        WHERE academic_year = :year
+          AND sub_code = ANY(:verified_codes)
+          AND effective_from <= CURRENT_DATE
+          AND (effective_to IS NULL OR effective_to > CURRENT_DATE)
+    """
+
+    __tablename__ = "priority_object_config"
+    __table_args__ = (
+        # Mirror of phase1_08b CHECKs — see PriorityAreaConfig note.
+        CheckConstraint(
+            "group_code ~ '^UT[1-9]$'",
+            name="ck_priority_object_config_group_code_format",
+        ),
+        CheckConstraint(
+            "sub_code ~ '^[0-9]{2}$'",
+            name="ck_priority_object_config_sub_code_format",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    academic_year: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Year-level grouping (vd 2026)",
+    )
+    group_code: Mapped[str] = mapped_column(
+        String(10),
+        nullable=False,
+        comment="UT1 / UT2 (extensible UT3+ if Bộ thêm)",
+    )
+    sub_code: Mapped[str] = mapped_column(
+        String(10),
+        nullable=False,
+        comment="2-digit numeric: '01'..'07' per TT 05/2021 Phụ lục 01",
+    )
+    description: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        comment="vd 'Con liệt sĩ', 'Dân tộc thiểu số hộ khẩu KV1'",
+    )
+    bonus_points: Mapped[Decimal] = mapped_column(
+        Numeric(4, 2),
+        nullable=False,
+        server_default="0.00",
+    )
+    evidence_doc_type: Mapped[Optional[str]] = mapped_column(
+        String(100),
+        nullable=True,
+        comment="Gợi ý loại giấy tờ minh chứng cho thí sinh",
+    )
+
+    effective_from: Mapped[date] = mapped_column(
+        Date,
+        nullable=False,
+        server_default=sa.text("CURRENT_DATE"),
+    )
+    effective_to: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<PriorityObjectConfig id={self.id} year={self.academic_year} "
+            f"group={self.group_code} sub={self.sub_code!r} "
+            f"pts={self.bonus_points}>"
+        )

--- a/Backend_FastAPI/app/models/vn_locality.py
+++ b/Backend_FastAPI/app/models/vn_locality.py
@@ -42,7 +42,7 @@ from datetime import date
 from typing import Optional
 
 import sqlalchemy as sa
-from sqlalchemy import BigInteger, Boolean, CheckConstraint, Date, Integer, String
+from sqlalchemy import CheckConstraint, Date, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
@@ -98,57 +98,7 @@ class VnCommuneAreaMap(Base):
         )
 
 
-class VnHighSchool(Base):
-    """High school dictionary with denormalized KV for fast resolution.
-
-    Lookup pattern (PR5 candidate FE primary case, PR2 engine):
-        SELECT kv_code
-        FROM vn_high_school
-        WHERE id = :hs_id
-          AND is_active = true
-          AND effective_from <= CURRENT_DATE
-          AND (effective_to IS NULL OR effective_to > CURRENT_DATE)
-    """
-
-    __tablename__ = "vn_high_school"
-    __table_args__ = (
-        # Mirror of phase1_08b CHECK — kv_code is nullable but if set must match.
-        CheckConstraint(
-            "kv_code IS NULL OR kv_code ~ '^KV[1-9](-NT)?$'",
-            name="ck_vn_high_school_kv_code_format",
-        ),
-    )
-
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
-
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
-    province: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
-    district: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
-    ward: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
-    kv_code: Mapped[Optional[str]] = mapped_column(
-        String(20),
-        nullable=True,
-        comment="Denormalized from vn_commune_area_map for fast lookup",
-    )
-    is_active: Mapped[bool] = mapped_column(
-        Boolean,
-        nullable=False,
-        server_default=sa.text("true"),
-        comment=(
-            "Soft-delete flag; FK admission_profile.high_school_id RESTRICT "
-            "prevents hard DELETE while profiles reference row"
-        ),
-    )
-
-    effective_from: Mapped[date] = mapped_column(
-        Date,
-        nullable=False,
-        server_default=sa.text("CURRENT_DATE"),
-    )
-    effective_to: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
-
-    def __repr__(self) -> str:
-        return (
-            f"<VnHighSchool id={self.id} name={self.name!r} "
-            f"kv={self.kv_code} active={self.is_active}>"
-        )
+# VnHighSchool DROPPED in phase1_09 (Q9 #07 PR5 redesign 2026-05-18).
+# Replaced by 3-table family (VnSchool + VnSchoolNameHistory +
+# VnSchoolKvAssignment) in app.models.vn_school per multi-school + SCD
+# design. See Documents/Q9_07_PR5_REDESIGN.md v1.3 cho rationale.

--- a/Backend_FastAPI/app/models/vn_locality.py
+++ b/Backend_FastAPI/app/models/vn_locality.py
@@ -1,0 +1,154 @@
+# app/models/vn_locality.py
+"""ORM models for Vietnam locality dictionaries (Q9 #07 PR1).
+
+Two read-mostly reference tables imported in PR4:
+
+* ``VnCommuneAreaMap`` — maps a Vietnam commune (province + district +
+  ward) to its KV (khu vực) area_code. ~11k rows when imported.
+  Source: TT 06/2026/BNV (post commune-merge 2025).
+
+* ``VnHighSchool`` — dictionary of Vietnam high schools (~3k rows)
+  with denormalized ``kv_code`` for fast resolution in C2 hybrid flow.
+  Source: MOET public school list.
+
+Both ship empty in PR1. PR4 imports CSV. PR5 candidate FE uses these
+for searchable dropdowns. PR2 engine uses them for KV auto-resolve.
+
+Soft-delete pattern on ``VnHighSchool``
+---------------------------------------
+
+``vn_high_school.is_active`` enables admins to "hide" duplicate or
+closed-school rows without losing the audit trail. FK
+``admission_profile.high_school_id`` uses ``ondelete=RESTRICT`` so a
+hard DELETE is blocked while profiles reference the row; admins must
+use the soft-delete path instead. This matches the existing convention
+in 10+ QLTS models (offering_admission_round, major_program, etc.).
+
+Temporal versioning on both tables
+----------------------------------
+
+Both tables carry ``effective_from`` / ``effective_to`` so commune-merge
+and school-merge events create new rows instead of mutating. Partial
+UNIQUE on ``vn_commune_area_map.commune_code`` (WHERE effective_to IS
+NULL) defined in ``phase1_08b`` migration enforces "at most one active
+mapping per commune code".
+
+See ``alembic/versions/phase1_08b_priority_demographics_gdnn.py`` for
+DDL + CHECK constraints (area_code / kv_code regex).
+"""
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy import BigInteger, Boolean, CheckConstraint, Date, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class VnCommuneAreaMap(Base):
+    """Commune (province + district + ward) -> KV area_code mapping.
+
+    Lookup pattern (PR5 candidate FE backup case, PR2 engine):
+        SELECT area_code
+        FROM vn_commune_area_map
+        WHERE commune_code = :code
+          AND effective_from <= CURRENT_DATE
+          AND (effective_to IS NULL OR effective_to > CURRENT_DATE)
+    """
+
+    __tablename__ = "vn_commune_area_map"
+    __table_args__ = (
+        # Mirror of phase1_08b CHECK — see PriorityAreaConfig note.
+        CheckConstraint(
+            "area_code ~ '^KV[1-9](-NT)?$'",
+            name="ck_vn_commune_area_map_area_code_format",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    commune_code: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        comment="BNV commune code (partial UNIQUE WHERE effective_to IS NULL)",
+    )
+    province: Mapped[str] = mapped_column(String(100), nullable=False)
+    district: Mapped[str] = mapped_column(String(100), nullable=False)
+    ward: Mapped[str] = mapped_column(String(100), nullable=False)
+    area_code: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        comment="Canonical: KV1 / KV2-NT / KV2 / KV3 (hyphen, per TT 05/2021)",
+    )
+
+    effective_from: Mapped[date] = mapped_column(
+        Date,
+        nullable=False,
+        server_default=sa.text("CURRENT_DATE"),
+    )
+    effective_to: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"<VnCommuneAreaMap id={self.id} code={self.commune_code!r} "
+            f"area={self.area_code} ward={self.ward!r}>"
+        )
+
+
+class VnHighSchool(Base):
+    """High school dictionary with denormalized KV for fast resolution.
+
+    Lookup pattern (PR5 candidate FE primary case, PR2 engine):
+        SELECT kv_code
+        FROM vn_high_school
+        WHERE id = :hs_id
+          AND is_active = true
+          AND effective_from <= CURRENT_DATE
+          AND (effective_to IS NULL OR effective_to > CURRENT_DATE)
+    """
+
+    __tablename__ = "vn_high_school"
+    __table_args__ = (
+        # Mirror of phase1_08b CHECK — kv_code is nullable but if set must match.
+        CheckConstraint(
+            "kv_code IS NULL OR kv_code ~ '^KV[1-9](-NT)?$'",
+            name="ck_vn_high_school_kv_code_format",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    province: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    district: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    ward: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    kv_code: Mapped[Optional[str]] = mapped_column(
+        String(20),
+        nullable=True,
+        comment="Denormalized from vn_commune_area_map for fast lookup",
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=sa.text("true"),
+        comment=(
+            "Soft-delete flag; FK admission_profile.high_school_id RESTRICT "
+            "prevents hard DELETE while profiles reference row"
+        ),
+    )
+
+    effective_from: Mapped[date] = mapped_column(
+        Date,
+        nullable=False,
+        server_default=sa.text("CURRENT_DATE"),
+    )
+    effective_to: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"<VnHighSchool id={self.id} name={self.name!r} "
+            f"kv={self.kv_code} active={self.is_active}>"
+        )

--- a/Backend_FastAPI/app/models/vn_school.py
+++ b/Backend_FastAPI/app/models/vn_school.py
@@ -1,0 +1,275 @@
+# app/models/vn_school.py
+"""ORM models for Q9 #07 PR5 Redesign — Temporal multi-school KV resolution.
+
+Replaces ``VnHighSchool`` (PR1 single-school placeholder) với 3-table family
+that handles:
+
+* Multi-level support: THCS / THPT / THCS_THPT (liên cấp) /
+  TRUNG_HOC_NGHE (dự thảo TT 2026) / OTHER
+* Slowly-changing dimensions: school name history + KV reassignment over time
+* Per-year KV lookup theo TT 05/2021 Phụ lục 01 multi-school rule
+
+See ``Documents/Q9_07_PR5_REDESIGN.md`` v1.3 cho design rationale +
+``alembic/versions/phase1_09_priority_kv_temporal.py`` cho DDL.
+
+3 models trong file này:
+
+* ``VnSchool`` — master directory (PR4 imports MOET 2025 THPT list ~6,822 rows
+  + admin manual entry cho TC ~100 schools + THCS audit-only)
+* ``VnSchoolNameHistory`` — slowly-changing tên trường (sát nhập + đổi tên)
+* ``VnSchoolKvAssignment`` — temporal KV per (school_id, year_range)
+  với service-layer overlap check (M3 fix: dropped GiST EXCLUDE)
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+class VnSchool(Base):
+    """Vietnam school master directory — supports multi-level + SCD.
+
+    Lookup patterns (PR2 engine + PR5 candidate FE):
+    * Search by name (trigram) for candidate dropdown
+    * Lookup KV via ``vn_school_kv_assignment`` for academic_year
+
+    Soft-delete via ``is_active``; FK from ``admission_profile`` (if any)
+    uses RESTRICT to preserve audit trail.
+
+    Mergers tracked via ``merged_into_id`` self-FK; KV lookup vẫn dùng
+    ``school_id`` gốc + năm gốc (KHÔNG follow merger).
+    """
+
+    __tablename__ = "vn_school"
+    __table_args__ = (
+        # Mirror migration CHECK — Base.metadata.create_all() test DB
+        # parity per memory ``test-db-schema-source``.
+        CheckConstraint(
+            "level IN ('THCS', 'THPT', 'THCS_THPT', 'TRUNG_HOC_NGHE', 'OTHER')",
+            name="ck_vn_school_level",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    # MOET reference
+    moet_school_code: Mapped[str] = mapped_column(
+        String(10),
+        nullable=False,
+        comment="MOET school code (per Bộ GD-ĐT Apr 2025 directory)",
+    )
+    moet_province_code: Mapped[str] = mapped_column(
+        String(3),
+        nullable=False,
+        comment="MOET province code — composite unique với moet_school_code",
+    )
+    moet_district_code: Mapped[Optional[str]] = mapped_column(String(5), nullable=True)
+
+    # Canonical current info
+    name: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        comment="Canonical current name; historical via vn_school_name_history",
+    )
+    address: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    province: Mapped[str] = mapped_column(String(100), nullable=False)
+    district: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    ward: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+
+    # Level support (5 enum values)
+    level: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        comment="THCS | THPT | THCS_THPT (liên cấp) | TRUNG_HOC_NGHE (dự thảo TT 2026) | OTHER",
+    )
+
+    is_dtnt: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=sa.text("false"),
+        comment="Trường PT Dân tộc Nội trú — flag for special case bypass",
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default=sa.text("true"),
+        comment="Soft-delete flag; FK from admission_profile uses RESTRICT",
+    )
+
+    # Merger tracking
+    merged_into_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger,
+        ForeignKey("vn_school.id"),
+        nullable=True,
+        comment="If school merged, points to surviving school. KV lookup vẫn theo school_id gốc.",
+    )
+    merge_effective_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+    # Relationships
+    name_history: Mapped[list["VnSchoolNameHistory"]] = relationship(
+        back_populates="school",
+        cascade="all, delete-orphan",
+    )
+    kv_assignments: Mapped[list["VnSchoolKvAssignment"]] = relationship(
+        back_populates="school",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<VnSchool id={self.id} name={self.name!r} level={self.level} "
+            f"active={self.is_active}>"
+        )
+
+
+class VnSchoolNameHistory(Base):
+    """Slowly-changing name history per school.
+
+    Lookup pattern: tên trường tại thời điểm học (vd: candidate học 2018-2021
+    trước khi trường đổi tên 2023 → audit hiển thị tên cũ).
+
+    Query example:
+        SELECT name FROM vn_school_name_history
+        WHERE school_id = :sid
+          AND effective_from <= :date
+          AND (effective_to IS NULL OR effective_to >= :date)
+        ORDER BY effective_from DESC LIMIT 1;
+    """
+
+    __tablename__ = "vn_school_name_history"
+    __table_args__ = (
+        UniqueConstraint(
+            "school_id",
+            "effective_from",
+            name="uq_vn_school_name_history_school_effective",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    school_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("vn_school.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    effective_from: Mapped[date] = mapped_column(Date, nullable=False)
+    effective_to: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    notes: Mapped[Optional[str]] = mapped_column(
+        Text,
+        nullable=True,
+        comment="vd 'Sát nhập với Trường X' hoặc 'Đổi tên theo QĐ Y'",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+    school: Mapped["VnSchool"] = relationship(back_populates="name_history")
+
+    def __repr__(self) -> str:
+        return (
+            f"<VnSchoolNameHistory school_id={self.school_id} name={self.name!r} "
+            f"from={self.effective_from} to={self.effective_to}>"
+        )
+
+
+class VnSchoolKvAssignment(Base):
+    """Per-year KV classification per school (temporal lookup).
+
+    Service-layer overlap check (M3 fix per memory `migration-predicate-safety`):
+    inserts must verify no existing row overlaps `(school_id, year_range)`.
+    See ``app/services/priority_service.add_kv_assignment`` for guard.
+
+    Query pattern (canonical KV lookup at academic_year):
+        SELECT kv_code FROM vn_school_kv_assignment
+        WHERE school_id = :sid
+          AND :year BETWEEN effective_from_year AND COALESCE(effective_to_year, 9999)
+        LIMIT 1;
+    """
+
+    __tablename__ = "vn_school_kv_assignment"
+    __table_args__ = (
+        CheckConstraint(
+            "kv_code ~ '^KV[1-9](-NT)?$'",
+            name="ck_vn_school_kv_assignment_kv_code_format",
+        ),
+        CheckConstraint(
+            "effective_to_year IS NULL OR effective_to_year >= effective_from_year",
+            name="ck_vn_school_kv_assignment_year_range_valid",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    school_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("vn_school.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    kv_code: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        comment="KV1 | KV2-NT | KV2 | KV3 (hyphen canonical per TT 05/2021)",
+    )
+    effective_from_year: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        comment="Năm bắt đầu hiệu lực (vd 2025 = năm học 2025-2026)",
+    )
+    effective_to_year: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        nullable=True,
+        comment="Năm kết thúc (inclusive). NULL = ongoing.",
+    )
+    source: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        comment="moet_2024 | moet_2025 | qd_861 | manual_admin | qd_ubnd_<tinh>",
+    )
+    notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_by: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+
+    school: Mapped["VnSchool"] = relationship(back_populates="kv_assignments")
+
+    def __repr__(self) -> str:
+        return (
+            f"<VnSchoolKvAssignment school_id={self.school_id} kv={self.kv_code} "
+            f"year={self.effective_from_year}-{self.effective_to_year or 'now'}>"
+        )

--- a/Backend_FastAPI/app/repositories/priority_config_repository.py
+++ b/Backend_FastAPI/app/repositories/priority_config_repository.py
@@ -1,0 +1,132 @@
+# app/repositories/priority_config_repository.py
+"""Repository for priority_area_config + priority_object_config.
+
+Single repo handles both tables since they share the temporal + active-
+filter idiom; service layer (priority_config_service) provides the
+domain-level methods.
+"""
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.priority_config import PriorityAreaConfig, PriorityObjectConfig
+
+
+class PriorityConfigRepository:
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    # ----- Area -----
+
+    async def list_areas(
+        self, academic_year: int, active_only: bool = False
+    ) -> list[PriorityAreaConfig]:
+        stmt = select(PriorityAreaConfig).where(
+            PriorityAreaConfig.academic_year == academic_year
+        )
+        if active_only:
+            stmt = stmt.where(PriorityAreaConfig.effective_to.is_(None))
+        stmt = stmt.order_by(PriorityAreaConfig.area_code)
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_area(self, area_id: int) -> Optional[PriorityAreaConfig]:
+        return await self.db.get(PriorityAreaConfig, area_id)
+
+    async def get_active_area(
+        self, academic_year: int, area_code: str
+    ) -> Optional[PriorityAreaConfig]:
+        stmt = (
+            select(PriorityAreaConfig)
+            .where(
+                PriorityAreaConfig.academic_year == academic_year,
+                PriorityAreaConfig.area_code == area_code,
+                PriorityAreaConfig.effective_to.is_(None),
+            )
+            .limit(1)
+        )
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create_area(
+        self, data: dict
+    ) -> PriorityAreaConfig:
+        row = PriorityAreaConfig(**data)
+        self.db.add(row)
+        await self.db.flush()
+        return row
+
+    async def update_area(
+        self, row: PriorityAreaConfig, data: dict
+    ) -> PriorityAreaConfig:
+        for k, v in data.items():
+            setattr(row, k, v)
+        await self.db.flush()
+        return row
+
+    async def retire_area(
+        self, row: PriorityAreaConfig, effective_to: date
+    ) -> PriorityAreaConfig:
+        """Soft-delete via effective_to (temporal versioning)."""
+        row.effective_to = effective_to
+        await self.db.flush()
+        return row
+
+    # ----- Object -----
+
+    async def list_objects(
+        self, academic_year: int, active_only: bool = False
+    ) -> list[PriorityObjectConfig]:
+        stmt = select(PriorityObjectConfig).where(
+            PriorityObjectConfig.academic_year == academic_year
+        )
+        if active_only:
+            stmt = stmt.where(PriorityObjectConfig.effective_to.is_(None))
+        stmt = stmt.order_by(
+            PriorityObjectConfig.group_code, PriorityObjectConfig.sub_code
+        )
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def get_object(self, obj_id: int) -> Optional[PriorityObjectConfig]:
+        return await self.db.get(PriorityObjectConfig, obj_id)
+
+    async def get_active_object(
+        self, academic_year: int, sub_code: str
+    ) -> Optional[PriorityObjectConfig]:
+        stmt = (
+            select(PriorityObjectConfig)
+            .where(
+                PriorityObjectConfig.academic_year == academic_year,
+                PriorityObjectConfig.sub_code == sub_code,
+                PriorityObjectConfig.effective_to.is_(None),
+            )
+            .limit(1)
+        )
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def create_object(self, data: dict) -> PriorityObjectConfig:
+        row = PriorityObjectConfig(**data)
+        self.db.add(row)
+        await self.db.flush()
+        return row
+
+    async def update_object(
+        self, row: PriorityObjectConfig, data: dict
+    ) -> PriorityObjectConfig:
+        for k, v in data.items():
+            setattr(row, k, v)
+        await self.db.flush()
+        return row
+
+    async def retire_object(
+        self, row: PriorityObjectConfig, effective_to: date
+    ) -> PriorityObjectConfig:
+        row.effective_to = effective_to
+        await self.db.flush()
+        return row

--- a/Backend_FastAPI/app/routers/admin_priority_config.py
+++ b/Backend_FastAPI/app/routers/admin_priority_config.py
@@ -1,0 +1,285 @@
+# app/routers/admin_priority_config.py
+"""Admin priority_area_config + priority_object_config CRUD endpoints (Q9 #07 PR3).
+
+Year-scoped routes following the ``admin_v2_admission_round`` pattern:
+* ``/api/v2/admin/priority-config/years/{academic_year}/areas``
+* ``/api/v2/admin/priority-config/years/{academic_year}/objects``
+* ``/api/v2/admin/priority-config/areas/{area_id}`` (PATCH / DELETE)
+* ``/api/v2/admin/priority-config/objects/{object_id}`` (PATCH / DELETE)
+* ``/api/v2/admin/priority-config/clone`` (POST — copy active rows year→year)
+* ``/api/v2/admin/priority-config/seed-defaults`` (POST — TT 05/2021 baseline)
+
+All endpoints require ``require_admin`` — these are quy chế tuyển sinh
+parameters, not per-unit operational data.
+"""
+import structlog
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database
+from app.core.deps import require_admin
+from app.schemas.priority_config import (
+    PriorityAreaConfigCreate,
+    PriorityAreaConfigResponse,
+    PriorityAreaConfigUpdate,
+    PriorityConfigCloneRequest,
+    PriorityConfigCloneResponse,
+    PriorityConfigSeedDefaultsRequest,
+    PriorityConfigSeedDefaultsResponse,
+    PriorityObjectConfigCreate,
+    PriorityObjectConfigResponse,
+    PriorityObjectConfigUpdate,
+)
+from app.services.priority_config_service import PriorityConfigService
+
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(
+    prefix="/api/v2/admin/priority-config",
+    tags=["Admin v2 - Priority Config"],
+)
+
+
+# =============================================================================
+# Area endpoints
+# =============================================================================
+
+
+@router.get(
+    "/years/{academic_year}/areas",
+    response_model=list[PriorityAreaConfigResponse],
+)
+async def list_areas(
+    academic_year: int,
+    active_only: bool = True,
+    db: AsyncSession = Depends(database.get_db),
+    _user=Depends(require_admin),
+) -> list[PriorityAreaConfigResponse]:
+    service = PriorityConfigService(db)
+    rows = await service.list_areas(academic_year, active_only=active_only)
+    return [PriorityAreaConfigResponse.model_validate(r) for r in rows]
+
+
+@router.post(
+    "/years/{academic_year}/areas",
+    response_model=PriorityAreaConfigResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_area(
+    academic_year: int,
+    payload: PriorityAreaConfigCreate,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> PriorityAreaConfigResponse:
+    # Force consistency: path param wins over body to prevent admin
+    # accidentally posting to /years/2026 with year=2027 in payload.
+    data = payload.model_dump()
+    data["academic_year"] = academic_year
+    service = PriorityConfigService(db)
+    row, callback = await service.create_area(data)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "priority_area_config_created",
+        id=row.id, academic_year=academic_year, area_code=row.area_code,
+        bonus_points=str(row.bonus_points), actor=user.id,
+    )
+    return PriorityAreaConfigResponse.model_validate(row)
+
+
+@router.patch(
+    "/areas/{area_id}",
+    response_model=PriorityAreaConfigResponse,
+)
+async def update_area(
+    area_id: int,
+    payload: PriorityAreaConfigUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> PriorityAreaConfigResponse:
+    data = payload.model_dump(exclude_unset=True)
+    service = PriorityConfigService(db)
+    row, callback = await service.update_area(area_id, data)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "priority_area_config_updated",
+        id=row.id, changed_keys=list(data.keys()), actor=user.id,
+    )
+    return PriorityAreaConfigResponse.model_validate(row)
+
+
+@router.delete(
+    "/areas/{area_id}",
+    response_model=PriorityAreaConfigResponse,
+)
+async def retire_area(
+    area_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> PriorityAreaConfigResponse:
+    """Soft-delete via effective_to = today (temporal versioning)."""
+    service = PriorityConfigService(db)
+    row, callback = await service.retire_area(area_id)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "priority_area_config_retired",
+        id=row.id, effective_to=str(row.effective_to), actor=user.id,
+    )
+    return PriorityAreaConfigResponse.model_validate(row)
+
+
+# =============================================================================
+# Object endpoints
+# =============================================================================
+
+
+@router.get(
+    "/years/{academic_year}/objects",
+    response_model=list[PriorityObjectConfigResponse],
+)
+async def list_objects(
+    academic_year: int,
+    active_only: bool = True,
+    db: AsyncSession = Depends(database.get_db),
+    _user=Depends(require_admin),
+) -> list[PriorityObjectConfigResponse]:
+    service = PriorityConfigService(db)
+    rows = await service.list_objects(academic_year, active_only=active_only)
+    return [PriorityObjectConfigResponse.model_validate(r) for r in rows]
+
+
+@router.post(
+    "/years/{academic_year}/objects",
+    response_model=PriorityObjectConfigResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_object(
+    academic_year: int,
+    payload: PriorityObjectConfigCreate,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> PriorityObjectConfigResponse:
+    data = payload.model_dump()
+    data["academic_year"] = academic_year
+    service = PriorityConfigService(db)
+    row, callback = await service.create_object(data)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "priority_object_config_created",
+        id=row.id, academic_year=academic_year, sub_code=row.sub_code,
+        bonus_points=str(row.bonus_points), actor=user.id,
+    )
+    return PriorityObjectConfigResponse.model_validate(row)
+
+
+@router.patch(
+    "/objects/{object_id}",
+    response_model=PriorityObjectConfigResponse,
+)
+async def update_object(
+    object_id: int,
+    payload: PriorityObjectConfigUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> PriorityObjectConfigResponse:
+    data = payload.model_dump(exclude_unset=True)
+    service = PriorityConfigService(db)
+    row, callback = await service.update_object(object_id, data)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "priority_object_config_updated",
+        id=row.id, changed_keys=list(data.keys()), actor=user.id,
+    )
+    return PriorityObjectConfigResponse.model_validate(row)
+
+
+@router.delete(
+    "/objects/{object_id}",
+    response_model=PriorityObjectConfigResponse,
+)
+async def retire_object(
+    object_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> PriorityObjectConfigResponse:
+    service = PriorityConfigService(db)
+    row, callback = await service.retire_object(object_id)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "priority_object_config_retired",
+        id=row.id, effective_to=str(row.effective_to), actor=user.id,
+    )
+    return PriorityObjectConfigResponse.model_validate(row)
+
+
+# =============================================================================
+# Helpers: clone-from-year + seed-defaults
+# =============================================================================
+
+
+@router.post(
+    "/clone",
+    response_model=PriorityConfigCloneResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def clone_from_year(
+    payload: PriorityConfigCloneRequest,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> PriorityConfigCloneResponse:
+    """Copy all ACTIVE area + object rows from from_year to to_year.
+    Skips any (to_year, code) already active — re-run safe."""
+    service = PriorityConfigService(db)
+    result, callback = await service.clone_from_year(
+        from_year=payload.from_year, to_year=payload.to_year
+    )
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "priority_config_cloned",
+        from_year=payload.from_year, to_year=payload.to_year,
+        cloned_areas=result["cloned_areas"], cloned_objects=result["cloned_objects"],
+        actor=user.id,
+    )
+    return PriorityConfigCloneResponse(**result)
+
+
+@router.post(
+    "/seed-defaults",
+    response_model=PriorityConfigSeedDefaultsResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def seed_tt_05_2021_defaults(
+    payload: PriorityConfigSeedDefaultsRequest,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> PriorityConfigSeedDefaultsResponse:
+    """One-shot helper to bootstrap TT 05/2021 baseline rates for a
+    target year. Idempotent — skips if any active row already exists."""
+    service = PriorityConfigService(db)
+    result, callback = await service.seed_tt_05_2021_defaults(payload.academic_year)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "priority_config_seeded_tt_05_2021",
+        academic_year=payload.academic_year,
+        inserted_areas=result["inserted_areas"],
+        inserted_objects=result["inserted_objects"],
+        skipped_existing=result["skipped_existing"],
+        actor=user.id,
+    )
+    return PriorityConfigSeedDefaultsResponse(**result)

--- a/Backend_FastAPI/app/routers/admin_vn_locality.py
+++ b/Backend_FastAPI/app/routers/admin_vn_locality.py
@@ -1,25 +1,21 @@
 # app/routers/admin_vn_locality.py
-"""Admin CSV import + search endpoints for vn_commune_area_map +
-vn_high_school (Q9 #07 PR4).
+"""Admin CSV import endpoints for vn_commune_area_map (Q9 #07 PR4).
 
+Phase1_09 redesign (2026-05-18) removed VnHighSchool endpoints — see
+``Documents/Q9_07_PR5_REDESIGN.md`` v1.3. VnSchool family endpoints
+(THCS + THPT + TRUNG_HOC_NGHE) will live under /admin/vn-school/* in
+Phase B.1 import script + Phase D candidate FE.
+
+Current endpoints:
 * POST /api/v2/admin/vn-locality/communes/import — upload BNV CSV
-* POST /api/v2/admin/vn-locality/high-schools/import — upload MOET CSV
-* POST /api/v2/admin/vn-locality/high-schools/seed-sample — 5 demo rows
-  (admin one-shot bootstrap so FE dropdown has data pre-MOET CSV)
-* GET  /api/v2/vn-locality/high-schools/search?q=X — searchable dropdown
-  source for candidate FE (read; not admin-only)
 """
 import structlog
-from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database
-from app.core.deps import get_current_active_user, require_admin
-from app.core.rate_limits import RateLimits, limiter
-from app.schemas.vn_locality import (
-    CsvImportResponse,
-    VnHighSchoolResponse,
-)
+from app.core.deps import require_admin
+from app.schemas.vn_locality import CsvImportResponse
 from app.services.vn_locality_service import VnLocalityService
 
 
@@ -48,14 +44,13 @@ admin_router = APIRouter(
     tags=["Admin v2 - VN Locality Import"],
 )
 
-public_router = APIRouter(
-    prefix="/api/v2/vn-locality",
-    tags=["VN Locality - Public Read"],
-)
+# public_router DROPPED phase1_09 — was only used for /high-schools/search
+# (also DROPPED). Will be re-introduced trong Phase D candidate FE with
+# new prefix /api/v2/vn-school/* (VnSchool family).
 
 
 # =============================================================================
-# Admin: CSV imports + sample seed
+# Admin: CSV imports (commune only post-phase1_09)
 # =============================================================================
 
 
@@ -104,95 +99,18 @@ async def import_commune_csv(
     return CsvImportResponse(**result)
 
 
-@admin_router.post(
-    "/high-schools/import",
-    response_model=CsvImportResponse,
-    status_code=status.HTTP_201_CREATED,
-)
-async def import_high_school_csv(
-    file: UploadFile = File(...),
-    db: AsyncSession = Depends(database.get_db),
-    user=Depends(require_admin),
-) -> CsvImportResponse:
-    """Upload high school CSV (MOET format).
-
-    Expected columns: ``name,province,district,ward,kv_code``. Idempotent —
-    skips (name, province) already active."""
-    _require_csv_filename(file.filename)
-    if file.size is not None and file.size > MAX_CSV_SIZE_BYTES:
-        raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"CSV vượt {MAX_CSV_SIZE_BYTES // (1024 * 1024)}MB",
-        )
-    csv_bytes = await file.read()
-    if len(csv_bytes) > MAX_CSV_SIZE_BYTES:
-        raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"CSV vượt {MAX_CSV_SIZE_BYTES // (1024 * 1024)}MB",
-        )
-    service = VnLocalityService(db)
-    result, callback = await service.import_high_school_csv(csv_bytes)
-    await db.commit()
-    if callback:
-        await callback()
-    log.info(
-        "vn_high_school_csv_imported",
-        filename=file.filename,
-        inserted=result["inserted"],
-        skipped=result["skipped_existing"],
-        error_count=len(result["error_rows"]),
-        actor=user.id,
-    )
-    return CsvImportResponse(**result)
-
-
-@admin_router.post(
-    "/high-schools/seed-sample",
-    status_code=status.HTTP_201_CREATED,
-)
-async def seed_sample_high_schools(
-    db: AsyncSession = Depends(database.get_db),
-    user=Depends(require_admin),
-) -> dict:
-    """One-shot bootstrap of 5 demo high school rows so candidate FE
-    dropdown works before admin uploads the real MOET CSV. Idempotent —
-    skips already-existing rows by name+province."""
-    service = VnLocalityService(db)
-    result, callback = await service.seed_sample_high_schools()
-    await db.commit()
-    if callback:
-        await callback()
-    log.info(
-        "vn_high_school_sample_seeded",
-        inserted=result["inserted"],
-        total_in_seed=result["total_in_seed"],
-        actor=user.id,
-    )
-    return result
-
-
 # =============================================================================
-# Public: searchable dropdown source (used by candidate FE)
+# REMOVED phase1_09 (Q9 #07 PR5 redesign 2026-05-18)
 # =============================================================================
-
-
-@limiter.limit(RateLimits.DATA_READ)
-@public_router.get(
-    "/high-schools/search",
-    response_model=list[VnHighSchoolResponse],
-)
-async def search_high_schools(
-    request: Request,
-    q: str = Query(min_length=1, max_length=100),
-    limit: int = Query(20, ge=1, le=50),
-    db: AsyncSession = Depends(database.get_db),
-    _user=Depends(get_current_active_user),
-) -> list[VnHighSchoolResponse]:
-    """Case-insensitive prefix search for candidate dropdown.
-    Returns active rows only (is_active=true).
-
-    m-CR-4 fix: rate-limited via slowapi to prevent typing-fast spam.
-    CR-M3 fix: prefix match (not substring) — index-friendly + cleaner UX."""
-    service = VnLocalityService(db)
-    rows = await service.search_high_schools(q, limit=limit)
-    return [VnHighSchoolResponse.model_validate(r) for r in rows]
+# 3 endpoints below REMOVED — VnHighSchool table dropped, replaced by
+# VnSchool family (level='THPT'). New endpoints will be exposed under
+# /admin/vn-school/* trong Phase B.1 import script + Phase D candidate FE.
+#
+# Dropped endpoints:
+#   POST /admin/vn-locality/high-schools/import
+#   POST /admin/vn-locality/high-schools/seed-sample
+#   GET  /vn-locality/high-schools/search
+#
+# FE/clients should switch to /admin/vn-school/* (when ready). Pre-PR5
+# any cached call to these endpoints will now 404 (correct behavior —
+# better than 500 from NotImplementedError stub).

--- a/Backend_FastAPI/app/routers/admin_vn_locality.py
+++ b/Backend_FastAPI/app/routers/admin_vn_locality.py
@@ -1,0 +1,150 @@
+# app/routers/admin_vn_locality.py
+"""Admin CSV import + search endpoints for vn_commune_area_map +
+vn_high_school (Q9 #07 PR4).
+
+* POST /api/v2/admin/vn-locality/communes/import — upload BNV CSV
+* POST /api/v2/admin/vn-locality/high-schools/import — upload MOET CSV
+* POST /api/v2/admin/vn-locality/high-schools/seed-sample — 5 demo rows
+  (admin one-shot bootstrap so FE dropdown has data pre-MOET CSV)
+* GET  /api/v2/vn-locality/high-schools/search?q=X — searchable dropdown
+  source for candidate FE (read; not admin-only)
+"""
+import structlog
+from fastapi import APIRouter, Depends, File, Query, UploadFile, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database
+from app.core.deps import get_current_active_user, require_admin
+from app.schemas.vn_locality import (
+    CsvImportResponse,
+    VnHighSchoolResponse,
+)
+from app.services.vn_locality_service import VnLocalityService
+
+
+log = structlog.get_logger(__name__)
+
+admin_router = APIRouter(
+    prefix="/api/v2/admin/vn-locality",
+    tags=["Admin v2 - VN Locality Import"],
+)
+
+public_router = APIRouter(
+    prefix="/api/v2/vn-locality",
+    tags=["VN Locality - Public Read"],
+)
+
+
+# =============================================================================
+# Admin: CSV imports + sample seed
+# =============================================================================
+
+
+@admin_router.post(
+    "/communes/import",
+    response_model=CsvImportResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def import_commune_csv(
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> CsvImportResponse:
+    """Upload commune CSV (BNV TT 06/2026 format).
+
+    Expected columns: ``commune_code,province,district,ward,area_code``.
+    Idempotent — skips rows where (commune_code, active) already exists.
+    Malformed rows collected into ``error_rows`` for admin to fix."""
+    csv_bytes = await file.read()
+    service = VnLocalityService(db)
+    result, callback = await service.import_commune_csv(csv_bytes)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "vn_commune_csv_imported",
+        filename=file.filename,
+        inserted=result["inserted"],
+        skipped=result["skipped_existing"],
+        error_count=len(result["error_rows"]),
+        actor=user.id,
+    )
+    return CsvImportResponse(**result)
+
+
+@admin_router.post(
+    "/high-schools/import",
+    response_model=CsvImportResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def import_high_school_csv(
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> CsvImportResponse:
+    """Upload high school CSV (MOET format).
+
+    Expected columns: ``name,province,district,ward,kv_code``. Idempotent —
+    skips (name, province) already active."""
+    csv_bytes = await file.read()
+    service = VnLocalityService(db)
+    result, callback = await service.import_high_school_csv(csv_bytes)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "vn_high_school_csv_imported",
+        filename=file.filename,
+        inserted=result["inserted"],
+        skipped=result["skipped_existing"],
+        error_count=len(result["error_rows"]),
+        actor=user.id,
+    )
+    return CsvImportResponse(**result)
+
+
+@admin_router.post(
+    "/high-schools/seed-sample",
+    status_code=status.HTTP_201_CREATED,
+)
+async def seed_sample_high_schools(
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> dict:
+    """One-shot bootstrap of 5 demo high school rows so candidate FE
+    dropdown works before admin uploads the real MOET CSV. Idempotent —
+    skips already-existing rows by name+province."""
+    service = VnLocalityService(db)
+    result, callback = await service.seed_sample_high_schools()
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "vn_high_school_sample_seeded",
+        inserted=result["inserted"],
+        total_in_seed=result["total_in_seed"],
+        actor=user.id,
+    )
+    return result
+
+
+# =============================================================================
+# Public: searchable dropdown source (used by candidate FE)
+# =============================================================================
+
+
+@public_router.get(
+    "/high-schools/search",
+    response_model=list[VnHighSchoolResponse],
+)
+async def search_high_schools(
+    q: str = Query(min_length=1, max_length=100),
+    limit: int = Query(20, ge=1, le=50),
+    db: AsyncSession = Depends(database.get_db),
+    _user=Depends(get_current_active_user),
+) -> list[VnHighSchoolResponse]:
+    """Case-insensitive name search for candidate dropdown.
+    Returns active rows only (is_active=true)."""
+    service = VnLocalityService(db)
+    rows = await service.search_high_schools(q, limit=limit)
+    return [VnHighSchoolResponse.model_validate(r) for r in rows]

--- a/Backend_FastAPI/app/routers/admin_vn_locality.py
+++ b/Backend_FastAPI/app/routers/admin_vn_locality.py
@@ -29,6 +29,18 @@ from app.services.vn_locality_service import VnLocalityService
 MAX_CSV_SIZE_BYTES = 10 * 1024 * 1024
 
 
+def _require_csv_filename(filename: str | None) -> None:
+    """F.6 fix: reject non-CSV uploads at the router boundary so admin
+    sees an immediate 400 instead of "201 inserted=0" after the service
+    successfully decodes the file (a binary PDF/txt can decode as UTF-8
+    by accident, then DictReader reads junk header → 0 valid rows)."""
+    if not filename or not filename.lower().endswith(".csv"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File phải có đuôi .csv",
+        )
+
+
 log = structlog.get_logger(__name__)
 
 admin_router = APIRouter(
@@ -64,6 +76,7 @@ async def import_commune_csv(
     Malformed rows collected into ``error_rows`` for admin to fix."""
     # CR-M1: pre-read size check (Content-Length header). Post-read check
     # below catches the case where client lied about size.
+    _require_csv_filename(file.filename)
     if file.size is not None and file.size > MAX_CSV_SIZE_BYTES:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
@@ -105,6 +118,7 @@ async def import_high_school_csv(
 
     Expected columns: ``name,province,district,ward,kv_code``. Idempotent —
     skips (name, province) already active."""
+    _require_csv_filename(file.filename)
     if file.size is not None and file.size > MAX_CSV_SIZE_BYTES:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,

--- a/Backend_FastAPI/app/routers/admin_vn_locality.py
+++ b/Backend_FastAPI/app/routers/admin_vn_locality.py
@@ -10,16 +10,23 @@ vn_high_school (Q9 #07 PR4).
   source for candidate FE (read; not admin-only)
 """
 import structlog
-from fastapi import APIRouter, Depends, File, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database
 from app.core.deps import get_current_active_user, require_admin
+from app.core.rate_limits import RateLimits, limiter
 from app.schemas.vn_locality import (
     CsvImportResponse,
     VnHighSchoolResponse,
 )
 from app.services.vn_locality_service import VnLocalityService
+
+
+# CR-M1: cap CSV upload at 10MB to prevent OOM via accidental/malicious
+# huge file. Matches the QLTS lead-import precedent (lead-import-size-pr7
+# memory). Real BNV/MOET CSVs are well under 1MB (~11k rows max).
+MAX_CSV_SIZE_BYTES = 10 * 1024 * 1024
 
 
 log = structlog.get_logger(__name__)
@@ -55,7 +62,19 @@ async def import_commune_csv(
     Expected columns: ``commune_code,province,district,ward,area_code``.
     Idempotent — skips rows where (commune_code, active) already exists.
     Malformed rows collected into ``error_rows`` for admin to fix."""
+    # CR-M1: pre-read size check (Content-Length header). Post-read check
+    # below catches the case where client lied about size.
+    if file.size is not None and file.size > MAX_CSV_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"CSV vượt {MAX_CSV_SIZE_BYTES // (1024 * 1024)}MB",
+        )
     csv_bytes = await file.read()
+    if len(csv_bytes) > MAX_CSV_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"CSV vượt {MAX_CSV_SIZE_BYTES // (1024 * 1024)}MB",
+        )
     service = VnLocalityService(db)
     result, callback = await service.import_commune_csv(csv_bytes)
     await db.commit()
@@ -86,7 +105,17 @@ async def import_high_school_csv(
 
     Expected columns: ``name,province,district,ward,kv_code``. Idempotent —
     skips (name, province) already active."""
+    if file.size is not None and file.size > MAX_CSV_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"CSV vượt {MAX_CSV_SIZE_BYTES // (1024 * 1024)}MB",
+        )
     csv_bytes = await file.read()
+    if len(csv_bytes) > MAX_CSV_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"CSV vượt {MAX_CSV_SIZE_BYTES // (1024 * 1024)}MB",
+        )
     service = VnLocalityService(db)
     result, callback = await service.import_high_school_csv(csv_bytes)
     await db.commit()
@@ -133,18 +162,23 @@ async def seed_sample_high_schools(
 # =============================================================================
 
 
+@limiter.limit(RateLimits.DATA_READ)
 @public_router.get(
     "/high-schools/search",
     response_model=list[VnHighSchoolResponse],
 )
 async def search_high_schools(
+    request: Request,
     q: str = Query(min_length=1, max_length=100),
     limit: int = Query(20, ge=1, le=50),
     db: AsyncSession = Depends(database.get_db),
     _user=Depends(get_current_active_user),
 ) -> list[VnHighSchoolResponse]:
-    """Case-insensitive name search for candidate dropdown.
-    Returns active rows only (is_active=true)."""
+    """Case-insensitive prefix search for candidate dropdown.
+    Returns active rows only (is_active=true).
+
+    m-CR-4 fix: rate-limited via slowapi to prevent typing-fast spam.
+    CR-M3 fix: prefix match (not substring) — index-friendly + cleaner UX."""
     service = VnLocalityService(db)
     rows = await service.search_high_schools(q, limit=limit)
     return [VnHighSchoolResponse.model_validate(r) for r in rows]

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -100,6 +100,14 @@ async def publish_admission_result(
             selectinload(models.AdmissionProfile.choices)
             .selectinload(models.AdmissionProfileChoice.admission_path)
             .selectinload(models.AdmissionPath.admission_method),
+            # Q9 #07 review-3 fix: eager-load admission_round so the
+            # priority bonus engine (CR-P0) can read academic_year for
+            # priority_*_config lookup. Without this chain, the engine
+            # falls back to __dict__.get(...) → None → skip priority
+            # calc → 0đ bonus on every candidate (silent regression).
+            selectinload(models.AdmissionProfile.choices)
+            .selectinload(models.AdmissionProfileChoice.admission_path)
+            .selectinload(models.AdmissionPath.admission_round),
             selectinload(models.AdmissionProfile.choices)
             .selectinload(models.AdmissionProfileChoice.admission_path)
             .selectinload(models.AdmissionPath.criteria),

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -483,8 +483,52 @@ class AdmissionProfileUpdate(BaseModel):
         description="Admission scores (GPA or subject scores) for dynamic scoring"
     )
 
+    # =========================================================================
+    # Q9 #07 W11-BE.F.7 fix — priority bonus fields (phase1_08b migration)
+    # =========================================================================
+    # Candidate sets these during draft via PR5 FE. Without these on the
+    # Update schema, the PUT endpoint silently drops the 7 priority columns
+    # and the CR-P0 engine wire-up never sees real data.
+    high_school_id: Optional[int] = Field(
+        None,
+        description="FK to vn_high_school (PRIMARY KV basis per TT 05/2021)"
+    )
+    high_school_kv_resolved: Optional[str] = Field(
+        None,
+        pattern=r"^KV[1-9](-NT)?$",
+        description="KV snapshot 'KV1'/'KV2-NT'/'KV2'/'KV3' (hyphen canonical)"
+    )
+    permanent_commune_code: Optional[str] = Field(
+        None, max_length=20,
+        description="BNV commune code — BACKUP KV resolution for special case"
+    )
+    area_resolution_basis: Optional[str] = Field(
+        None,
+        pattern=r"^(high_school|permanent_address_special|manual_override)$",
+        description="How KV was resolved (enum — mirror of phase1_08b CHECK)"
+    )
+    area_resolution_reason: Optional[str] = Field(
+        None,
+        description="Required when basis='manual_override'"
+    )
+    priority_object_codes: Optional[List[str]] = Field(
+        None,
+        description="UT đối tượng codes thí sinh khai (vd: ['04','06'])"
+    )
+    priority_object_evidence: Optional[Dict[str, Dict[str, Any]]] = Field(
+        None,
+        description=(
+            "Evidence dict keyed by sub_code: "
+            "{'04': {'document_id': 123, 'status': 'pending|verified|rejected', ...}}"
+        )
+    )
+
     # Field validators to convert empty strings to None (for pattern fields)
-    @field_validator('phone', 'citizen_id', mode='before')
+    @field_validator(
+        'phone', 'citizen_id', 'high_school_kv_resolved', 'area_resolution_basis',
+        'permanent_commune_code',
+        mode='before',
+    )
     @classmethod
     def empty_str_to_none(cls, v):
         """Convert empty strings to None to bypass pattern validation."""
@@ -704,6 +748,17 @@ class AdmissionProfileResponse(BaseModel):
     permanent_street_address: Optional[str] = None
     place_of_birth: Optional[str] = None
     native_place: Optional[str] = None
+
+    # =========================================================================
+    # Q9 #07 W11-BE.F.7 — priority bonus fields (READ side)
+    # =========================================================================
+    high_school_id: Optional[int] = None
+    high_school_kv_resolved: Optional[str] = None
+    permanent_commune_code: Optional[str] = None
+    area_resolution_basis: Optional[str] = None
+    area_resolution_reason: Optional[str] = None
+    priority_object_codes: list[str] = Field(default_factory=list)
+    priority_object_evidence: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
 
     # Scores (Dynamic Calculation)
     admission_scores: Optional[AdmissionScoreSchema] = None

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -407,6 +407,57 @@ class AdmissionProfileCreate(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True)
 
 
+# =============================================================================
+# Q9 #07 W11-BE.F.7 — priority bonus support types (M1 + M2 review-2 fix)
+# =============================================================================
+
+# M1: per-item regex for priority_object_codes — mirror of phase1_08b
+# CHECK constraint ``sub_code ~ '^[0-9]{2}$'``. Without this annotation
+# Pydantic accepts any string and the engine silently sees no matches
+# (graceful 0đ but undiscoverable from API response).
+PrioritySubCode = Annotated[
+    str, StringConstraints(pattern=r"^[0-9]{2}$")
+]
+
+
+class PriorityObjectEvidenceEntry(BaseModel):
+    """M2: enforce shape of each evidence dict value.
+
+    Without this nested model, ``Dict[str, Dict[str, Any]]`` admitted any
+    inner dict (vd: ``{'random': 'stuff'}``) — engine read ``.get('status')``
+    and silently treated as unverified. Strict shape catches typos at the
+    Pydantic boundary so admin/candidate get a clear 422 instead of a
+    silent 0đ on calculation day.
+    """
+    status: Literal["pending", "verified", "rejected"] = Field(
+        ...,
+        description="Verification state. Engine only counts 'verified' for bonus."
+    )
+    document_id: Optional[int] = Field(
+        default=None,
+        description="FK to profile_document (the uploaded evidence file)"
+    )
+    verified_by: Optional[int] = Field(
+        default=None,
+        description="user.id who flipped status to verified/rejected"
+    )
+    verified_at: Optional[datetime] = Field(
+        default=None,
+        description="When officer recorded verify/reject decision"
+    )
+    reject_reason: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description="Required if status='rejected'"
+    )
+    requested_at: Optional[datetime] = Field(
+        default=None,
+        description="When candidate submitted the UT claim"
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class AdmissionProfileUpdate(BaseModel):
     """
     Schema for updating AdmissionProfile (only allowed when status = 'draft').
@@ -511,16 +562,27 @@ class AdmissionProfileUpdate(BaseModel):
         None,
         description="Required when basis='manual_override'"
     )
-    priority_object_codes: Optional[List[str]] = Field(
+    priority_object_codes: Optional[List[PrioritySubCode]] = Field(
         None,
-        description="UT đối tượng codes thí sinh khai (vd: ['04','06'])"
+        max_length=20,
+        description=(
+            "UT đối tượng codes thí sinh khai (vd: ['04','06']). "
+            "M1 review-2 fix: per-item regex ``^[0-9]{2}$`` mirrors phase1_08b "
+            "CHECK so garbage codes (vd: 'INVALID_99') fail at 422 instead of "
+            "silently scoring 0đ at T6."
+        ),
     )
-    priority_object_evidence: Optional[Dict[str, Dict[str, Any]]] = Field(
+    priority_object_evidence: Optional[
+        Dict[PrioritySubCode, PriorityObjectEvidenceEntry]
+    ] = Field(
         None,
         description=(
-            "Evidence dict keyed by sub_code: "
-            "{'04': {'document_id': 123, 'status': 'pending|verified|rejected', ...}}"
-        )
+            "Evidence dict keyed by sub_code → typed entry. "
+            "M2 review-2 fix: strict nested shape (status enum + optional "
+            "document_id / verified_by / verified_at / reject_reason) "
+            "catches typos at boundary instead of letting them pass through "
+            "to the engine as silently-unverified."
+        ),
     )
 
     # Field validators to convert empty strings to None (for pattern fields)
@@ -572,6 +634,54 @@ class AdmissionProfileUpdate(BaseModel):
         """
         from app.services.admission_invariants import validate_logical_dates
         validate_logical_dates(self.model_dump())
+        return self
+
+    @model_validator(mode='after')
+    def validate_priority_basis_invariants(self) -> 'AdmissionProfileUpdate':
+        """H1 review-2 fix: cross-field invariants for area_resolution_basis.
+
+        Each basis value implies a specific supporting field must be set:
+        * ``manual_override`` → area_resolution_reason (required for audit)
+        * ``high_school`` → high_school_id OR high_school_kv_resolved
+        * ``permanent_address_special`` → permanent_commune_code
+
+        Without this check, FE could submit basis='manual_override' without
+        a reason → engine still applies the calculated KV but the audit
+        trail has no explanation; or basis='high_school' without an HS id
+        → engine has nothing to look up → silent 0đ.
+
+        IMPORTANT caveat (same shape as ``validate_logical_dates`` above):
+        validator runs on PAYLOAD ONLY. A request that sends only ``basis``
+        relying on a DB-persisted supporting field will be REJECTED here —
+        which is intentional: the candidate FE PR5 sends the supporting
+        field in the same payload as ``basis`` since both come from the
+        same form section. Service-layer candidate-state check (in
+        ``update_profile``) handles the post-submit minor_correction case
+        if/when that path becomes available.
+        """
+        basis = self.area_resolution_basis
+        if basis is None:
+            return self  # not touching basis → invariant doesn't apply
+
+        if basis == "manual_override":
+            if not (self.area_resolution_reason and self.area_resolution_reason.strip()):
+                raise ValueError(
+                    "area_resolution_basis='manual_override' yêu cầu "
+                    "area_resolution_reason (lý do override)."
+                )
+        elif basis == "high_school":
+            if self.high_school_id is None and not self.high_school_kv_resolved:
+                raise ValueError(
+                    "area_resolution_basis='high_school' yêu cầu "
+                    "high_school_id hoặc high_school_kv_resolved."
+                )
+        elif basis == "permanent_address_special":
+            if not self.permanent_commune_code:
+                raise ValueError(
+                    "area_resolution_basis='permanent_address_special' yêu cầu "
+                    "permanent_commune_code."
+                )
+
         return self
 
 

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -457,6 +457,35 @@ class PriorityObjectEvidenceEntry(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    @model_validator(mode='after')
+    def validate_status_dependencies(self) -> 'PriorityObjectEvidenceEntry':
+        """m-RV2-1 polish: enforce audit trail completeness per status.
+
+        * status='rejected' → reject_reason required (non-empty after
+          strip). Without this, officer can reject a UT claim without
+          logging WHY — the candidate has no recourse and audit shows
+          a bare rejection.
+        * status='verified' → verified_by required (user.id of the
+          officer who approved). Without this, the engine snapshot
+          + bonus calculation has no chain of responsibility.
+
+        Note: ``pending`` (the initial candidate-submitted state) needs
+        neither — that's the whole point of a pending evidence row.
+        """
+        if self.status == "rejected":
+            if not (self.reject_reason and self.reject_reason.strip()):
+                raise ValueError(
+                    "status='rejected' yêu cầu reject_reason (officer "
+                    "phải ghi rõ lý do từ chối chứng cứ UT)."
+                )
+        elif self.status == "verified":
+            if self.verified_by is None:
+                raise ValueError(
+                    "status='verified' yêu cầu verified_by (user.id "
+                    "của officer xác minh)."
+                )
+        return self
+
 
 class AdmissionProfileUpdate(BaseModel):
     """

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -564,32 +564,37 @@ class AdmissionProfileUpdate(BaseModel):
     )
 
     # =========================================================================
-    # Q9 #07 W11-BE.F.7 fix — priority bonus fields (phase1_08b migration)
+    # Q9 #07 Priority bonus fields
+    # PR1 phase1_08b (legacy): high_school_id, high_school_kv_resolved,
+    #   area_resolution_reason — DROPPED in phase1_09 v1.3
+    # PR5 phase1_09 (current): cultural_education_level + vocational_qualification
+    #   + permanent_commune_code + area_resolution_basis (kept)
     # =========================================================================
-    # Candidate sets these during draft via PR5 FE. Without these on the
-    # Update schema, the PUT endpoint silently drops the 7 priority columns
-    # and the CR-P0 engine wire-up never sees real data.
-    high_school_id: Optional[int] = Field(
+    cultural_education_level: Optional[str] = Field(
         None,
-        description="FK to vn_high_school (PRIMARY KV basis per TT 05/2021)"
+        pattern=r"^(completed_thcs|graduated_thcs|completed_thpt|graduated_thpt|graduated_gdtx)$",
+        description=(
+            "Trình độ văn hóa: completed_thcs | graduated_thcs | "
+            "completed_thpt | graduated_thpt | graduated_gdtx. Nullable cho "
+            "draft; required tại submit T1."
+        ),
     )
-    high_school_kv_resolved: Optional[str] = Field(
+    vocational_qualification: Optional[str] = Field(
         None,
-        pattern=r"^KV[1-9](-NT)?$",
-        description="KV snapshot 'KV1'/'KV2-NT'/'KV2'/'KV3' (hyphen canonical)"
+        pattern=r"^(none|so_cap|trung_cap|cao_dang)$",
+        description=(
+            "Trình độ chuyên môn: none | so_cap | trung_cap | cao_dang. "
+            "DB default 'none' nếu omitted (NOT NULL constraint)."
+        ),
     )
     permanent_commune_code: Optional[str] = Field(
         None, max_length=20,
-        description="BNV commune code — BACKUP KV resolution for special case"
+        description="BNV commune code — BACKUP KV cho 4 special cases + commune_fallback"
     )
     area_resolution_basis: Optional[str] = Field(
         None,
         pattern=r"^(high_school|permanent_address_special|manual_override)$",
-        description="How KV was resolved (enum — mirror of phase1_08b CHECK)"
-    )
-    area_resolution_reason: Optional[str] = Field(
-        None,
-        description="Required when basis='manual_override'"
+        description="How KV was resolved (enum — mirror of CHECK constraint)"
     )
     priority_object_codes: Optional[List[PrioritySubCode]] = Field(
         None,
@@ -616,8 +621,8 @@ class AdmissionProfileUpdate(BaseModel):
 
     # Field validators to convert empty strings to None (for pattern fields)
     @field_validator(
-        'phone', 'citizen_id', 'high_school_kv_resolved', 'area_resolution_basis',
-        'permanent_commune_code',
+        'phone', 'citizen_id', 'area_resolution_basis',
+        'permanent_commune_code', 'cultural_education_level', 'vocational_qualification',
         mode='before',
     )
     @classmethod
@@ -667,49 +672,34 @@ class AdmissionProfileUpdate(BaseModel):
 
     @model_validator(mode='after')
     def validate_priority_basis_invariants(self) -> 'AdmissionProfileUpdate':
-        """H1 review-2 fix: cross-field invariants for area_resolution_basis.
+        """H1 cross-field invariants for area_resolution_basis (v1.3 phase1_09).
 
         Each basis value implies a specific supporting field must be set:
-        * ``manual_override`` → area_resolution_reason (required for audit)
-        * ``high_school`` → high_school_id OR high_school_kv_resolved
-        * ``permanent_address_special`` → permanent_commune_code
+        * ``permanent_address_special`` → permanent_commune_code (4 cases TT)
+        * ``manual_override`` → manual reason goes vào priority_resolution_snapshot
+          at engine time (no payload field — admin/officer fills via separate endpoint)
+        * ``high_school`` → academic_history với THPT/TC entries (multi-school rule)
+          Validated by service-layer after lookup vào academic_history.
 
-        Without this check, FE could submit basis='manual_override' without
-        a reason → engine still applies the calculated KV but the audit
-        trail has no explanation; or basis='high_school' without an HS id
-        → engine has nothing to look up → silent 0đ.
+        v1.3 changes: 'high_school' basis no longer references single field;
+        candidate khai trường qua academic_history JSONB. area_resolution_reason
+        column DROPPED — canonical reason lives in priority_resolution_snapshot.
 
-        IMPORTANT caveat (same shape as ``validate_logical_dates`` above):
-        validator runs on PAYLOAD ONLY. A request that sends only ``basis``
-        relying on a DB-persisted supporting field will be REJECTED here —
-        which is intentional: the candidate FE PR5 sends the supporting
-        field in the same payload as ``basis`` since both come from the
-        same form section. Service-layer candidate-state check (in
-        ``update_profile``) handles the post-submit minor_correction case
-        if/when that path becomes available.
+        IMPORTANT caveat: validator runs on PAYLOAD ONLY. Service-layer check
+        in ``update_profile`` handles cross-field with DB-persisted state.
         """
         basis = self.area_resolution_basis
         if basis is None:
             return self  # not touching basis → invariant doesn't apply
 
-        if basis == "manual_override":
-            if not (self.area_resolution_reason and self.area_resolution_reason.strip()):
-                raise ValueError(
-                    "area_resolution_basis='manual_override' yêu cầu "
-                    "area_resolution_reason (lý do override)."
-                )
-        elif basis == "high_school":
-            if self.high_school_id is None and not self.high_school_kv_resolved:
-                raise ValueError(
-                    "area_resolution_basis='high_school' yêu cầu "
-                    "high_school_id hoặc high_school_kv_resolved."
-                )
-        elif basis == "permanent_address_special":
+        if basis == "permanent_address_special":
             if not self.permanent_commune_code:
                 raise ValueError(
                     "area_resolution_basis='permanent_address_special' yêu cầu "
-                    "permanent_commune_code."
+                    "permanent_commune_code (4 trường hợp đặc biệt TT 05/2021)."
                 )
+        # 'high_school' + 'manual_override' validation moved to service-layer
+        # (need academic_history context not available in pure schema validator)
 
         return self
 
@@ -889,15 +879,15 @@ class AdmissionProfileResponse(BaseModel):
     native_place: Optional[str] = None
 
     # =========================================================================
-    # Q9 #07 W11-BE.F.7 — priority bonus fields (READ side)
+    # Q9 #07 Priority bonus fields (READ side) — v1.3 phase1_09
     # =========================================================================
-    high_school_id: Optional[int] = None
-    high_school_kv_resolved: Optional[str] = None
+    cultural_education_level: Optional[str] = None
+    vocational_qualification: Optional[str] = None
     permanent_commune_code: Optional[str] = None
     area_resolution_basis: Optional[str] = None
-    area_resolution_reason: Optional[str] = None
     priority_object_codes: list[str] = Field(default_factory=list)
     priority_object_evidence: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+    priority_resolution_snapshot: Dict[str, Any] = Field(default_factory=dict)
 
     # Scores (Dynamic Calculation)
     admission_scores: Optional[AdmissionScoreSchema] = None

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -90,14 +90,17 @@ class BonusRuleOverride(BaseModel):
 
     apply_area_bonus: bool = Field(
         description=(
-            "Apply the area bonus (KV1 / KV2_NT / KV2 / KV3) when "
-            "computing the effective score for this path."
+            "Apply KV bonus (KV1 / KV2-NT / KV2 / KV3) per TT 05/2021 "
+            "Phụ lục 01 — rates from priority_area_config per academic_year."
         ),
     )
-    apply_subject_bonus: bool = Field(
+    apply_object_bonus: bool = Field(
         description=(
-            "Apply per-subject bonus (priority objects 01..07) when "
-            "computing the effective score."
+            "Apply UT đối tượng bonus (nhóm UT1/UT2, sub_codes 01..07+) "
+            "per TT 05/2021 Phụ lục 01 — rates from priority_object_config "
+            "per academic_year. Multi-UT: chỉ tính diện cao nhất (max). "
+            "(Renamed from apply_subject_bonus in Q9 #07 PR1 to match the "
+            "actual intent — see phase1_08a migration.)"
         ),
     )
     max_total_bonus: Optional[float] = Field(
@@ -105,8 +108,9 @@ class BonusRuleOverride(BaseModel):
         ge=0,
         le=10,
         description=(
-            "Cap on the combined bonus (area + subject) in points. "
-            "NULL = no cap. Range 0..10 matches the GPA scale."
+            "Cap on the combined bonus (area + object) in points. "
+            "NULL = no cap (TT 05/2021 không cap; admin có thể set per quy "
+            "chế trường). Range 0..10 matches the GPA scale."
         ),
     )
 

--- a/Backend_FastAPI/app/schemas/priority_config.py
+++ b/Backend_FastAPI/app/schemas/priority_config.py
@@ -1,0 +1,129 @@
+# app/schemas/priority_config.py
+"""Pydantic schemas for priority_area_config + priority_object_config
+admin CRUD (Q9 #07 PR3).
+
+Mirrors the migration phase1_08b column set + the CHECK regex
+constraints (validated at Pydantic boundary so admin gets a 422 with
+a helpful message instead of a 500 from PG)."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ---------------------------------------------------------------------------
+# PriorityAreaConfig — KV rates per academic_year
+# ---------------------------------------------------------------------------
+
+
+class PriorityAreaConfigBase(BaseModel):
+    academic_year: int = Field(ge=2020, le=2100)
+    area_code: str = Field(
+        pattern=r"^KV[1-9](-NT)?$",
+        description="Canonical: KV1 / KV2-NT / KV2 / KV3 (hyphen)",
+    )
+    area_name: str = Field(min_length=1, max_length=100)
+    bonus_points: Decimal = Field(ge=0, le=99.99, decimal_places=2)
+    description: Optional[str] = None
+    effective_from: Optional[date] = Field(
+        default=None,
+        description="Defaults to CURRENT_DATE if omitted",
+    )
+    effective_to: Optional[date] = None
+
+
+class PriorityAreaConfigCreate(PriorityAreaConfigBase):
+    pass
+
+
+class PriorityAreaConfigUpdate(BaseModel):
+    """PATCH — all fields optional; service applies via model_dump(exclude_unset)."""
+    area_name: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    bonus_points: Optional[Decimal] = Field(
+        default=None, ge=0, le=99.99, decimal_places=2
+    )
+    description: Optional[str] = None
+    effective_to: Optional[date] = None
+
+
+class PriorityAreaConfigResponse(PriorityAreaConfigBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# PriorityObjectConfig — UT rates per academic_year + sub_code
+# ---------------------------------------------------------------------------
+
+
+class PriorityObjectConfigBase(BaseModel):
+    academic_year: int = Field(ge=2020, le=2100)
+    group_code: str = Field(
+        pattern=r"^UT[1-9]$",
+        description="Canonical: UT1 / UT2 (extensible UT3+ if Bộ thêm)",
+    )
+    sub_code: str = Field(
+        pattern=r"^[0-9]{2}$",
+        description="2-digit numeric per TT 05/2021 Phụ lục 01: '01'..'07'",
+    )
+    description: str = Field(min_length=1)
+    bonus_points: Decimal = Field(ge=0, le=99.99, decimal_places=2)
+    evidence_doc_type: Optional[str] = Field(default=None, max_length=100)
+    effective_from: Optional[date] = None
+    effective_to: Optional[date] = None
+
+
+class PriorityObjectConfigCreate(PriorityObjectConfigBase):
+    pass
+
+
+class PriorityObjectConfigUpdate(BaseModel):
+    description: Optional[str] = Field(default=None, min_length=1)
+    bonus_points: Optional[Decimal] = Field(
+        default=None, ge=0, le=99.99, decimal_places=2
+    )
+    evidence_doc_type: Optional[str] = Field(default=None, max_length=100)
+    effective_to: Optional[date] = None
+
+
+class PriorityObjectConfigResponse(PriorityObjectConfigBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Clone-from-year + seed-defaults requests
+# ---------------------------------------------------------------------------
+
+
+class PriorityConfigCloneRequest(BaseModel):
+    from_year: int = Field(ge=2020, le=2100)
+    to_year: int = Field(ge=2020, le=2100)
+
+
+class PriorityConfigCloneResponse(BaseModel):
+    cloned_areas: int
+    cloned_objects: int
+
+
+class PriorityConfigSeedDefaultsRequest(BaseModel):
+    """One-shot helper for admin to populate TT 05/2021 baseline rates
+    for a target year. Skips if any row already exists for the year
+    (idempotent — admin must explicitly delete + re-seed to override).
+    """
+    academic_year: int = Field(ge=2020, le=2100)
+
+
+class PriorityConfigSeedDefaultsResponse(BaseModel):
+    inserted_areas: int
+    inserted_objects: int
+    skipped_existing: bool

--- a/Backend_FastAPI/app/schemas/vn_locality.py
+++ b/Backend_FastAPI/app/schemas/vn_locality.py
@@ -1,0 +1,61 @@
+# app/schemas/vn_locality.py
+"""Pydantic schemas for vn_commune_area_map + vn_high_school admin
+CSV import (Q9 #07 PR4).
+
+Both shape mirror the migration phase1_08b column set. Read endpoints
+(searchable dropdowns) ship in PR5 candidate FE."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class VnCommuneAreaMapRow(BaseModel):
+    """Single CSV row payload for commune import (BNV format)."""
+    commune_code: str = Field(min_length=1, max_length=20)
+    province: str = Field(min_length=1, max_length=100)
+    district: str = Field(min_length=1, max_length=100)
+    ward: str = Field(min_length=1, max_length=100)
+    area_code: str = Field(pattern=r"^KV[1-9](-NT)?$")
+
+
+class VnCommuneAreaMapResponse(VnCommuneAreaMapRow):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    effective_from: date
+    effective_to: Optional[date] = None
+
+
+class VnHighSchoolRow(BaseModel):
+    """Single CSV row payload for high school import (MOET format)."""
+    name: str = Field(min_length=1, max_length=255)
+    province: Optional[str] = Field(default=None, max_length=100)
+    district: Optional[str] = Field(default=None, max_length=100)
+    ward: Optional[str] = Field(default=None, max_length=100)
+    kv_code: Optional[str] = Field(
+        default=None,
+        pattern=r"^KV[1-9](-NT)?$",
+        description="Denormalized from vn_commune_area_map; optional if unknown",
+    )
+
+
+class VnHighSchoolResponse(VnHighSchoolRow):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    is_active: bool
+    effective_from: date
+    effective_to: Optional[date] = None
+
+
+class CsvImportResponse(BaseModel):
+    """Standard shape for both import endpoints."""
+    inserted: int
+    skipped_existing: int
+    error_rows: list[dict] = Field(
+        default_factory=list,
+        description="Row-level validation errors {row_num, error}",
+    )

--- a/Backend_FastAPI/app/schemas/vn_locality.py
+++ b/Backend_FastAPI/app/schemas/vn_locality.py
@@ -29,26 +29,9 @@ class VnCommuneAreaMapResponse(VnCommuneAreaMapRow):
     effective_to: Optional[date] = None
 
 
-class VnHighSchoolRow(BaseModel):
-    """Single CSV row payload for high school import (MOET format)."""
-    name: str = Field(min_length=1, max_length=255)
-    province: Optional[str] = Field(default=None, max_length=100)
-    district: Optional[str] = Field(default=None, max_length=100)
-    ward: Optional[str] = Field(default=None, max_length=100)
-    kv_code: Optional[str] = Field(
-        default=None,
-        pattern=r"^KV[1-9](-NT)?$",
-        description="Denormalized from vn_commune_area_map; optional if unknown",
-    )
-
-
-class VnHighSchoolResponse(VnHighSchoolRow):
-    model_config = ConfigDict(from_attributes=True)
-
-    id: int
-    is_active: bool
-    effective_from: date
-    effective_to: Optional[date] = None
+# VnHighSchoolRow + VnHighSchoolResponse DROPPED phase1_09 (Q9 #07 PR5 v1.3).
+# Replaced by VnSchool family schemas (TBD in Phase B.1 import script
+# + Phase D candidate FE). See Documents/Q9_07_PR5_REDESIGN.md v1.3.
 
 
 class CsvImportResponse(BaseModel):

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -60,8 +60,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
 
-import structlog
+from decimal import Decimal
 
+import structlog
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..core.events import SystemEvents
@@ -69,6 +70,7 @@ from ..utils.exceptions import BusinessRuleViolation
 from .admission_scoring_service import (
     AdmissionScoringService,
     AdmissionScoreResult,
+    DisqualificationReason,
     ProfileStatus,
 )
 
@@ -138,16 +140,23 @@ def resolve_effective_bonus_rule(path: "AdmissionPath") -> Optional[Dict[str, An
 def _evaluate_single_choice(
     profile: "AdmissionProfile",
     choice: "AdmissionProfileChoice",
+    priority_bonus: Decimal = Decimal("0"),
 ) -> Tuple[str, Optional[AdmissionScoreResult], List[str]]:
     """Evaluate ONE choice in isolation — gates first, then scoring.
+
+    Q9 #07 CR-P0 fix: ``priority_bonus`` is added to ``final_score``
+    after the raw score is calculated, and the ``passed`` flag is
+    re-checked against ``min_score``. Without this addition the snapshot
+    columns are decorative — quy chế Bộ GDĐT bị vi phạm vì candidate
+    ưu tiên KHÔNG được hưởng quyền lợi cộng điểm.
 
     Returns:
         (decision, score_result_or_none, reason_codes)
         decision ∈ {'admitted', 'rejected'} — waitlist deferred Q-P3-05
 
-    Side effects: NONE — pure decision computation. Caller writes
-    `choice.decision` + `choice.eligibility_check_result` based on returned
-    decision + reason codes.
+    Side effects: mutates ``score_result.final_score`` / ``score_result.passed`` /
+    ``score_result.failure_reasons`` / ``score_result.disqualification_codes``
+    when priority bonus flips the pass/fail outcome.
     """
     reason_codes: List[str] = []
     path = choice.admission_path
@@ -189,6 +198,39 @@ def _evaluate_single_choice(
             allowed_subjects=allowed_subjects,
             subject_weights=None,  # Phase 4: read from path snapshot
         )
+
+        # Q9 #07 CR-P0: apply priority bonus to final_score + re-check
+        # passed flag against min_score threshold. This is the load-
+        # bearing line — without it the snapshot columns get written
+        # but the decision is computed from raw score only, silently
+        # rejecting candidates who qualify for the bonus.
+        if (
+            score_result.status == ProfileStatus.VALID
+            and score_result.final_score is not None
+            and priority_bonus > Decimal("0")
+        ):
+            boosted = score_result.final_score + priority_bonus
+            min_threshold = score_result.min_score_threshold
+            score_result.final_score = boosted
+            if min_threshold is None or boosted >= min_threshold:
+                # Bonus flipped fail → pass. Clean up the "below min"
+                # disqualification artifacts so audit shows what really
+                # happened (raw fail + bonus rescue).
+                was_failing_on_min = (
+                    DisqualificationReason.BELOW_MIN_SCORE.value
+                    in score_result.disqualification_codes
+                )
+                if was_failing_on_min:
+                    score_result.disqualification_codes = [
+                        c for c in score_result.disqualification_codes
+                        if c != DisqualificationReason.BELOW_MIN_SCORE.value
+                    ]
+                    score_result.failure_reasons = [
+                        r for r in score_result.failure_reasons
+                        if "điểm chuẩn" not in r.lower()
+                    ]
+                score_result.passed = True
+
         reason_codes.extend(score_result.disqualification_codes)
         if score_result.status == ProfileStatus.INVALID:
             return "rejected", score_result, reason_codes
@@ -314,6 +356,8 @@ async def evaluate_cascade(
         # admin edits to priority_*_config tables do NOT mutate the
         # snapshot. Engine treats NULL rule + missing rates as 0đ
         # (graceful for legacy 315 profiles without backfill).
+        # Lazy import: priority_service imports app.models which would
+        # create a circular dep at module load time of this engine file.
         from app.services.priority_service import calculate_priority_bonus
 
         round_obj = getattr(path, "admission_round", None)
@@ -332,9 +376,18 @@ async def evaluate_cascade(
                 academic_year=academic_year,
             )
 
-        # Per-choice decision (gates + scoring)
+        # Q9 #07 CR-P0: feed the priority bonus total into the decision
+        # so the snapshot columns actually affect admit/reject. Without
+        # this, ưu tiên candidates get the snapshot written but still
+        # bounced for raw-score < min_score (quy chế Bộ vi phạm).
+        priority_bonus_total = (
+            (choice.priority_area_bonus_snapshot or Decimal("0"))
+            + (choice.priority_object_bonus_snapshot or Decimal("0"))
+        )
+
+        # Per-choice decision (gates + scoring + priority bonus)
         decision, score_result, reason_codes = _evaluate_single_choice(
-            profile, choice,
+            profile, choice, priority_bonus=priority_bonus_total,
         )
         choice.decision = decision
 

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -371,6 +371,23 @@ async def evaluate_cascade(
         academic_year = (
             round_obj.__dict__.get("academic_year") if round_obj else None
         )
+        if academic_year is None:
+            # Review-3 MAJOR fix: observable defense-in-depth so a prod
+            # caller that forgot to eager-load admission_round surfaces
+            # in logs instead of silently scoring 0đ for every candidate.
+            # The router-side fix (selectinload AdmissionPath.admission_round)
+            # closes the current gap; this warning catches future regressions.
+            log.warning(
+                "priority_bonus_skipped_missing_academic_year",
+                profile_id=getattr(profile, "id", None),
+                choice_id=getattr(choice, "id", None),
+                path_id=getattr(path, "id", None),
+                reason=(
+                    "admission_round relation not eager-loaded (or NULL "
+                    "academic_year). Priority bonus will be 0đ for this "
+                    "choice — verify the caller's selectinload chain."
+                ),
+            )
         if academic_year is not None:
             (
                 choice.priority_area_bonus_snapshot,

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -309,6 +309,29 @@ async def evaluate_cascade(
         path = choice.admission_path
         choice.bonus_rule_snapshot = resolve_effective_bonus_rule(path)
 
+        # Q9 #07 PR2b: snapshot priority bonus (KV + UT) at T6 publish
+        # time alongside bonus_rule_snapshot. Same freeze semantic — later
+        # admin edits to priority_*_config tables do NOT mutate the
+        # snapshot. Engine treats NULL rule + missing rates as 0đ
+        # (graceful for legacy 315 profiles without backfill).
+        from app.services.priority_service import calculate_priority_bonus
+
+        round_obj = getattr(path, "admission_round", None)
+        academic_year = (
+            getattr(round_obj, "academic_year", None) if round_obj else None
+        )
+        if academic_year is not None:
+            (
+                choice.priority_area_bonus_snapshot,
+                choice.priority_object_bonus_snapshot,
+                choice.priority_config_snapshot,
+            ) = await calculate_priority_bonus(
+                db=db,
+                profile=profile,
+                rule=choice.bonus_rule_snapshot,
+                academic_year=academic_year,
+            )
+
         # Per-choice decision (gates + scoring)
         decision, score_result, reason_codes = _evaluate_single_choice(
             profile, choice,

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -360,9 +360,16 @@ async def evaluate_cascade(
         # create a circular dep at module load time of this engine file.
         from app.services.priority_service import calculate_priority_bonus
 
-        round_obj = getattr(path, "admission_round", None)
+        # Eager-load-safe access via __dict__.get (NOT getattr): plain
+        # ``getattr(path, "admission_round", None)`` would trigger a
+        # SQLAlchemy lazy-load in async context → MissingGreenlet on
+        # paths that don't pre-load the relation (existing Phase 3 API
+        # tests + legacy callers). __dict__.get returns None when the
+        # relation hasn't been eager-loaded, letting us skip the
+        # priority calc gracefully instead of crashing.
+        round_obj = path.__dict__.get("admission_round")
         academic_year = (
-            getattr(round_obj, "academic_year", None) if round_obj else None
+            round_obj.__dict__.get("academic_year") if round_obj else None
         )
         if academic_year is not None:
             (
@@ -380,9 +387,12 @@ async def evaluate_cascade(
         # so the snapshot columns actually affect admit/reject. Without
         # this, ưu tiên candidates get the snapshot written but still
         # bounced for raw-score < min_score (quy chế Bộ vi phạm).
+        # getattr-with-default keeps existing Phase 3 SimpleNamespace
+        # stubs working when academic_year is missing → snapshot fields
+        # never set → read would AttributeError on the stub.
         priority_bonus_total = (
-            (choice.priority_area_bonus_snapshot or Decimal("0"))
-            + (choice.priority_object_bonus_snapshot or Decimal("0"))
+            (getattr(choice, "priority_area_bonus_snapshot", None) or Decimal("0"))
+            + (getattr(choice, "priority_object_bonus_snapshot", None) or Decimal("0"))
         )
 
         # Per-choice decision (gates + scoring + priority bonus)

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -3593,6 +3593,28 @@ async def update_profile(
         profile.academic_history = data["academic_history"]
         flag_modified(profile, "academic_history")
 
+    # =========================================================================
+    # Q9 #07 W11-BE.F.7 fix — persist 7 priority bonus fields from payload.
+    # Without these set-statements the engine (CR-P0 wire-up) sees NULL
+    # and computes 0đ bonus for every profile — feature dormant.
+    # =========================================================================
+    if "high_school_id" in data:
+        profile.high_school_id = data["high_school_id"]
+    if "high_school_kv_resolved" in data:
+        profile.high_school_kv_resolved = data["high_school_kv_resolved"]
+    if "permanent_commune_code" in data:
+        profile.permanent_commune_code = data["permanent_commune_code"]
+    if "area_resolution_basis" in data:
+        profile.area_resolution_basis = data["area_resolution_basis"]
+    if "area_resolution_reason" in data:
+        profile.area_resolution_reason = data["area_resolution_reason"]
+    if "priority_object_codes" in data and data["priority_object_codes"] is not None:
+        profile.priority_object_codes = data["priority_object_codes"]
+        flag_modified(profile, "priority_object_codes")
+    if "priority_object_evidence" in data and data["priority_object_evidence"] is not None:
+        profile.priority_object_evidence = data["priority_object_evidence"]
+        flag_modified(profile, "priority_object_evidence")
+
     # ✅ Phase 6: Update Admission Scores
     if "admission_scores" in data and data["admission_scores"] is not None:
         # Extract subject scores map from Pydantic model dict

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -3599,7 +3599,22 @@ async def update_profile(
     # and computes 0đ bonus for every profile — feature dormant.
     # =========================================================================
     if "high_school_id" in data:
-        profile.high_school_id = data["high_school_id"]
+        # M3 review-2 fix: validate FK existence at the service boundary
+        # so admin gets a 422 with a friendly message instead of a 500
+        # IntegrityError when high_school_id points to a missing row.
+        new_hs_id = data["high_school_id"]
+        if new_hs_id is not None:
+            from app.models.vn_locality import VnHighSchool
+            existing_hs = await db.get(VnHighSchool, new_hs_id)
+            if existing_hs is None:
+                from app.utils.exceptions import (
+                    ValidationError as _ValidationError,
+                )
+                raise _ValidationError(
+                    f"Trường THPT id={new_hs_id} không tồn tại trong "
+                    "danh mục vn_high_school. Vui lòng chọn lại từ dropdown."
+                )
+        profile.high_school_id = new_hs_id
     if "high_school_kv_resolved" in data:
         profile.high_school_kv_resolved = data["high_school_kv_resolved"]
     if "permanent_commune_code" in data:

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -3594,41 +3594,26 @@ async def update_profile(
         flag_modified(profile, "academic_history")
 
     # =========================================================================
-    # Q9 #07 W11-BE.F.7 fix — persist 7 priority bonus fields from payload.
-    # Without these set-statements the engine (CR-P0 wire-up) sees NULL
-    # and computes 0đ bonus for every profile — feature dormant.
+    # Q9 #07 PR5 v1.3 phase1_09 — persist priority bonus fields from payload.
+    # 2-field parallel design: cultural_education_level + vocational_qualification.
+    # Legacy high_school_id / kv_resolved / area_resolution_reason DROPPED.
     # =========================================================================
-    if "high_school_id" in data:
-        # M3 review-2 fix: validate FK existence at the service boundary
-        # so admin gets a 422 with a friendly message instead of a 500
-        # IntegrityError when high_school_id points to a missing row.
-        new_hs_id = data["high_school_id"]
-        if new_hs_id is not None:
-            from app.models.vn_locality import VnHighSchool
-            existing_hs = await db.get(VnHighSchool, new_hs_id)
-            if existing_hs is None:
-                from app.utils.exceptions import (
-                    ValidationError as _ValidationError,
-                )
-                raise _ValidationError(
-                    f"Trường THPT id={new_hs_id} không tồn tại trong "
-                    "danh mục vn_high_school. Vui lòng chọn lại từ dropdown."
-                )
-        profile.high_school_id = new_hs_id
-    if "high_school_kv_resolved" in data:
-        profile.high_school_kv_resolved = data["high_school_kv_resolved"]
+    if "cultural_education_level" in data:
+        profile.cultural_education_level = data["cultural_education_level"]
+    if "vocational_qualification" in data and data["vocational_qualification"] is not None:
+        profile.vocational_qualification = data["vocational_qualification"]
     if "permanent_commune_code" in data:
         profile.permanent_commune_code = data["permanent_commune_code"]
     if "area_resolution_basis" in data:
         profile.area_resolution_basis = data["area_resolution_basis"]
-    if "area_resolution_reason" in data:
-        profile.area_resolution_reason = data["area_resolution_reason"]
     if "priority_object_codes" in data and data["priority_object_codes"] is not None:
         profile.priority_object_codes = data["priority_object_codes"]
         flag_modified(profile, "priority_object_codes")
     if "priority_object_evidence" in data and data["priority_object_evidence"] is not None:
         profile.priority_object_evidence = data["priority_object_evidence"]
         flag_modified(profile, "priority_object_evidence")
+    # Note: priority_resolution_snapshot KHÔNG set qua candidate payload —
+    # frozen at submit T1 + re-frozen at engine T6 (service-layer only).
 
     # ✅ Phase 6: Update Admission Scores
     if "admission_scores" in data and data["admission_scores"] is not None:

--- a/Backend_FastAPI/app/services/priority_config_service.py
+++ b/Backend_FastAPI/app/services/priority_config_service.py
@@ -1,0 +1,301 @@
+# app/services/priority_config_service.py
+"""Service layer for admin priority_area_config + priority_object_config CRUD.
+
+Domain logic (V3.0 contract):
+* Pure Python (no FastAPI imports — raises DomainExceptions).
+* Returns ``(result, post_commit_callback)`` tuples.
+* Clone-from-year + seed-defaults helpers for admin bootstrapping.
+
+Seed defaults follow TT 05/2021/TT-BLĐTBXH Phụ lục 01:
+  KV1 = 0.75, KV2-NT = 0.50, KV2 = 0.25, KV3 = 0.00
+  UT1 group: 01..04 = 2.00; UT2 group: 05..07 = 1.00
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Any, Awaitable, Callable, Optional, Tuple
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.priority_config import PriorityAreaConfig, PriorityObjectConfig
+from app.repositories.priority_config_repository import PriorityConfigRepository
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    DuplicateResourceError,
+    ResourceNotFoundError,
+)
+
+
+PostCommitCallback = Optional[Callable[[], Awaitable[None]]]
+
+
+async def _noop_callback() -> None:
+    return None
+
+
+# Default seed rates from TT 05/2021/TT-BLĐTBXH Phụ lục 01.
+# Keys are stable across years — admin may override per quy chế trường
+# via subsequent PATCH or new TT.
+TT_05_2021_AREA_DEFAULTS: list[dict[str, Any]] = [
+    {"area_code": "KV1", "area_name": "Khu vực 1", "bonus_points": Decimal("0.75")},
+    {"area_code": "KV2-NT", "area_name": "Khu vực 2 nông thôn", "bonus_points": Decimal("0.50")},
+    {"area_code": "KV2", "area_name": "Khu vực 2", "bonus_points": Decimal("0.25")},
+    {"area_code": "KV3", "area_name": "Khu vực 3", "bonus_points": Decimal("0.00")},
+]
+
+TT_05_2021_OBJECT_DEFAULTS: list[dict[str, Any]] = [
+    # UT1 group (2.00đ) — đối tượng 01..04 per Phụ lục 01
+    {
+        "group_code": "UT1", "sub_code": "01",
+        "description": "Công dân Việt Nam dân tộc thiểu số có hộ khẩu KV1",
+        "bonus_points": Decimal("2.00"),
+        "evidence_doc_type": "Giấy chứng nhận dân tộc + sổ hộ khẩu KV1",
+    },
+    {
+        "group_code": "UT1", "sub_code": "02",
+        "description": "Người lao động làm việc liên tục ≥5 năm, có ≥2 năm là chiến sĩ thi đua cấp tỉnh+",
+        "bonus_points": Decimal("2.00"),
+        "evidence_doc_type": "Quyết định khen thưởng + xác nhận đơn vị",
+    },
+    {
+        "group_code": "UT1", "sub_code": "03",
+        "description": "Thương binh, bệnh binh, quân nhân/công an phục vụ ≥12 tháng ở KV1 hoặc ≥18 tháng",
+        "bonus_points": Decimal("2.00"),
+        "evidence_doc_type": "Quyết định phục vụ + giấy xác nhận thương/bệnh binh",
+    },
+    {
+        "group_code": "UT1", "sub_code": "04",
+        "description": "Con liệt sĩ, con thương binh/bệnh binh suy giảm ≥81%, con Anh hùng",
+        "bonus_points": Decimal("2.00"),
+        "evidence_doc_type": "Giấy chứng nhận từ cơ quan BXH",
+    },
+    # UT2 group (1.00đ) — đối tượng 05..07
+    {
+        "group_code": "UT2", "sub_code": "05",
+        "description": "Thanh niên xung phong; quân nhân/công an phục vụ <18 tháng không KV1",
+        "bonus_points": Decimal("1.00"),
+        "evidence_doc_type": "Quyết định xuất ngũ / xác nhận đơn vị",
+    },
+    {
+        "group_code": "UT2", "sub_code": "06",
+        "description": "Dân tộc thiểu số ngoài KV1; con thương binh suy giảm <81%; con người hoạt động kháng chiến",
+        "bonus_points": Decimal("1.00"),
+        "evidence_doc_type": "Giấy chứng nhận dân tộc / giấy xác nhận BXH",
+    },
+    {
+        "group_code": "UT2", "sub_code": "07",
+        "description": "Người khuyết tật nặng; người lao động ưu tú là thợ giỏi/nghệ nhân; Y tá/dược tá/hộ lý ≥3 năm",
+        "bonus_points": Decimal("1.00"),
+        "evidence_doc_type": "Giấy xác nhận khuyết tật / quyết định công nhận",
+    },
+]
+
+
+class PriorityConfigService:
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+        self.repo = PriorityConfigRepository(db)
+
+    # =========================================================================
+    # Area CRUD
+    # =========================================================================
+
+    async def list_areas(
+        self, academic_year: int, active_only: bool = False
+    ) -> list[PriorityAreaConfig]:
+        return await self.repo.list_areas(academic_year, active_only=active_only)
+
+    async def create_area(
+        self, data: dict[str, Any]
+    ) -> Tuple[PriorityAreaConfig, PostCommitCallback]:
+        # Active-row guard mirrors the partial UNIQUE (year, code, NULL effective_to).
+        existing = await self.repo.get_active_area(
+            data["academic_year"], data["area_code"]
+        )
+        if existing is not None:
+            raise DuplicateResourceError(
+                f"Active KV rate for {data['area_code']!r} year "
+                f"{data['academic_year']} already exists — retire it first "
+                f"or PATCH the existing row."
+            )
+        # Drop nones so SQL gets server defaults (effective_from = CURRENT_DATE)
+        clean = {k: v for k, v in data.items() if v is not None}
+        row = await self.repo.create_area(clean)
+        return row, _noop_callback
+
+    async def update_area(
+        self, area_id: int, data: dict[str, Any]
+    ) -> Tuple[PriorityAreaConfig, PostCommitCallback]:
+        row = await self.repo.get_area(area_id)
+        if row is None:
+            raise ResourceNotFoundError(
+                f"PriorityAreaConfig {area_id} not found"
+            )
+        clean = {k: v for k, v in data.items() if v is not None or k == "effective_to"}
+        # Allow explicit effective_to=None passthrough (re-activate)
+        await self.repo.update_area(row, clean)
+        return row, _noop_callback
+
+    async def retire_area(
+        self, area_id: int, effective_to: Optional[date] = None
+    ) -> Tuple[PriorityAreaConfig, PostCommitCallback]:
+        row = await self.repo.get_area(area_id)
+        if row is None:
+            raise ResourceNotFoundError(
+                f"PriorityAreaConfig {area_id} not found"
+            )
+        if row.effective_to is not None:
+            raise BusinessRuleViolation(
+                f"PriorityAreaConfig {area_id} đã retire trước đó "
+                f"(effective_to={row.effective_to})"
+            )
+        target = effective_to or date.today()
+        await self.repo.retire_area(row, target)
+        return row, _noop_callback
+
+    # =========================================================================
+    # Object CRUD
+    # =========================================================================
+
+    async def list_objects(
+        self, academic_year: int, active_only: bool = False
+    ) -> list[PriorityObjectConfig]:
+        return await self.repo.list_objects(academic_year, active_only=active_only)
+
+    async def create_object(
+        self, data: dict[str, Any]
+    ) -> Tuple[PriorityObjectConfig, PostCommitCallback]:
+        existing = await self.repo.get_active_object(
+            data["academic_year"], data["sub_code"]
+        )
+        if existing is not None:
+            raise DuplicateResourceError(
+                f"Active UT rate for sub_code {data['sub_code']!r} year "
+                f"{data['academic_year']} already exists — retire it first "
+                f"or PATCH the existing row."
+            )
+        clean = {k: v for k, v in data.items() if v is not None}
+        row = await self.repo.create_object(clean)
+        return row, _noop_callback
+
+    async def update_object(
+        self, obj_id: int, data: dict[str, Any]
+    ) -> Tuple[PriorityObjectConfig, PostCommitCallback]:
+        row = await self.repo.get_object(obj_id)
+        if row is None:
+            raise ResourceNotFoundError(
+                f"PriorityObjectConfig {obj_id} not found"
+            )
+        clean = {k: v for k, v in data.items() if v is not None or k == "effective_to"}
+        await self.repo.update_object(row, clean)
+        return row, _noop_callback
+
+    async def retire_object(
+        self, obj_id: int, effective_to: Optional[date] = None
+    ) -> Tuple[PriorityObjectConfig, PostCommitCallback]:
+        row = await self.repo.get_object(obj_id)
+        if row is None:
+            raise ResourceNotFoundError(
+                f"PriorityObjectConfig {obj_id} not found"
+            )
+        if row.effective_to is not None:
+            raise BusinessRuleViolation(
+                f"PriorityObjectConfig {obj_id} đã retire trước đó "
+                f"(effective_to={row.effective_to})"
+            )
+        target = effective_to or date.today()
+        await self.repo.retire_object(row, target)
+        return row, _noop_callback
+
+    # =========================================================================
+    # Clone-from-year + Seed-defaults helpers
+    # =========================================================================
+
+    async def clone_from_year(
+        self, from_year: int, to_year: int
+    ) -> Tuple[dict[str, int], PostCommitCallback]:
+        """Copy all ACTIVE rows from from_year to to_year. Skips any
+        (year, code) already present in to_year — admin can run twice
+        safely. Validation: from_year != to_year."""
+        if from_year == to_year:
+            raise BusinessRuleViolation(
+                "from_year và to_year phải khác nhau"
+            )
+
+        source_areas = await self.repo.list_areas(from_year, active_only=True)
+        source_objects = await self.repo.list_objects(from_year, active_only=True)
+
+        cloned_areas = 0
+        for src in source_areas:
+            existing = await self.repo.get_active_area(to_year, src.area_code)
+            if existing is not None:
+                continue
+            await self.repo.create_area(
+                {
+                    "academic_year": to_year,
+                    "area_code": src.area_code,
+                    "area_name": src.area_name,
+                    "bonus_points": src.bonus_points,
+                    "description": src.description,
+                }
+            )
+            cloned_areas += 1
+
+        cloned_objects = 0
+        for src in source_objects:
+            existing = await self.repo.get_active_object(to_year, src.sub_code)
+            if existing is not None:
+                continue
+            await self.repo.create_object(
+                {
+                    "academic_year": to_year,
+                    "group_code": src.group_code,
+                    "sub_code": src.sub_code,
+                    "description": src.description,
+                    "bonus_points": src.bonus_points,
+                    "evidence_doc_type": src.evidence_doc_type,
+                }
+            )
+            cloned_objects += 1
+
+        return (
+            {"cloned_areas": cloned_areas, "cloned_objects": cloned_objects},
+            _noop_callback,
+        )
+
+    async def seed_tt_05_2021_defaults(
+        self, academic_year: int
+    ) -> Tuple[dict[str, Any], PostCommitCallback]:
+        """Idempotent seeder for TT 05/2021 baseline rates.
+
+        Skips entirely if ANY active row already exists for the year —
+        avoids partial-state where some rates seed and others don't.
+        Admin must explicitly retire existing rows + re-seed to refresh.
+        """
+        # Check for any existing active row (area or object) before seeding
+        existing_areas = await self.repo.list_areas(academic_year, active_only=True)
+        existing_objects = await self.repo.list_objects(academic_year, active_only=True)
+        if existing_areas or existing_objects:
+            return (
+                {
+                    "inserted_areas": 0,
+                    "inserted_objects": 0,
+                    "skipped_existing": True,
+                },
+                _noop_callback,
+            )
+
+        for area in TT_05_2021_AREA_DEFAULTS:
+            await self.repo.create_area({"academic_year": academic_year, **area})
+        for obj in TT_05_2021_OBJECT_DEFAULTS:
+            await self.repo.create_object({"academic_year": academic_year, **obj})
+
+        return (
+            {
+                "inserted_areas": len(TT_05_2021_AREA_DEFAULTS),
+                "inserted_objects": len(TT_05_2021_OBJECT_DEFAULTS),
+                "skipped_existing": False,
+            },
+            _noop_callback,
+        )

--- a/Backend_FastAPI/app/services/priority_service.py
+++ b/Backend_FastAPI/app/services/priority_service.py
@@ -1,0 +1,253 @@
+# app/services/priority_service.py
+"""Priority Bonus calculation service (Q9 #07 PR2).
+
+Pure Python (no FastAPI imports) — takes a profile + bonus rule snapshot
++ academic_year, returns ``(area_bonus, object_bonus, config_snapshot)``.
+
+Plug point: ``admission_choice_engine_service.evaluate_cascade()`` calls
+this for each choice at T6 publish time, right after capturing
+``bonus_rule_snapshot``. The 3 return values are written verbatim to
+``admission_profile_choice.priority_area_bonus_snapshot`` /
+``priority_object_bonus_snapshot`` / ``priority_config_snapshot``.
+
+Compliance source (TT 05/2021/TT-BLĐTBXH Phụ lục 01)
+----------------------------------------------------
+
+* KV (khu vực): max 4 codes per ``priority_area_config`` table; each
+  ``academic_year`` has its own row set so a mid-year regulation change
+  creates a new row instead of mutating the old one.
+
+* UT (đối tượng): N sub_codes per ``priority_object_config``; multi-UT
+  per profile applies the MAX (TT 05/2021 Phụ lục 01: "chỉ được hưởng
+  một diện ưu tiên cao nhất").
+
+* Evidence gate: UT bonus only counts for sub_codes whose
+  ``priority_object_evidence[sub_code].status == 'verified'``. Unverified
+  / rejected / missing → 0 contribution, regardless of admin / officer
+  later flipping it (snapshot freezes T6 state).
+
+* Cap: optional ``rule.max_total_bonus``; NULL = no cap (TT 05/2021
+  default; admin may set per quy chế trường).
+
+* Toggle: ``rule.apply_area_bonus`` / ``apply_object_bonus`` gate each
+  side independently. Both false → snapshot all zeros (engine still
+  records the config_snapshot for audit).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Optional
+
+from sqlalchemy import select
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.models.admission import AdmissionProfile
+
+
+_ZERO = Decimal("0.00")
+
+
+async def calculate_priority_bonus(
+    db: "AsyncSession",
+    profile: "AdmissionProfile",
+    rule: Optional[dict[str, Any]],
+    academic_year: int,
+) -> tuple[Decimal, Decimal, dict[str, Any]]:
+    """Compute KV + UT bonus for a profile at T6 publish.
+
+    Args:
+        db: active AsyncSession (engine already opens a savepoint).
+        profile: AdmissionProfile (eager-loaded; reads
+            ``high_school_kv_resolved`` + ``priority_object_codes`` +
+            ``priority_object_evidence`` + ``area_resolution_basis``).
+        rule: BonusRuleOverride snapshot dict from
+            ``resolve_effective_bonus_rule(path)``. NULL = bonus disabled
+            (legacy paths without explicit override or method default).
+        academic_year: year-level grouping (vd 2026) — looked up via
+            ``path.admission_round.academic_year``.
+
+    Returns:
+        ``(area_bonus, object_bonus, config_snapshot)``
+
+        * area_bonus: Decimal(4, 2) after toggle + cap
+        * object_bonus: Decimal(4, 2) after toggle + cap (max of verified)
+        * config_snapshot: JSONB-shaped dict for audit replay; always
+          populated (even when bonus disabled) so engine has a record
+          of "we considered priority for this choice but the rule said 0"
+    """
+    # Build config_snapshot upfront so every code path returns one.
+    snapshot: dict[str, Any] = {
+        "academic_year": academic_year,
+        "resolved_at": datetime.now(timezone.utc).isoformat(),
+        "rule": dict(rule) if rule else None,
+        "area_resolution_basis": getattr(profile, "area_resolution_basis", None),
+        "area_code": None,
+        "area_rate": None,
+        "object_max_code": None,
+        "object_rate": None,
+        "verified_codes": [],
+    }
+
+    if rule is None:
+        # Legacy path with no method default + no path override = bonus disabled.
+        return _ZERO, _ZERO, snapshot
+
+    apply_area = bool(rule.get("apply_area_bonus"))
+    apply_object = bool(rule.get("apply_object_bonus"))
+    max_total = rule.get("max_total_bonus")
+    max_total_dec = Decimal(str(max_total)) if max_total is not None else None
+
+    area_bonus = _ZERO
+    object_bonus = _ZERO
+
+    if apply_area:
+        area_bonus, area_meta = await _resolve_area_bonus(
+            db=db,
+            profile=profile,
+            academic_year=academic_year,
+        )
+        snapshot.update(area_meta)
+
+    if apply_object:
+        object_bonus, object_meta = await _resolve_object_bonus(
+            db=db,
+            profile=profile,
+            academic_year=academic_year,
+        )
+        snapshot.update(object_meta)
+
+    # Combined cap (TT 05/2021 không enforce; admin tùy chọn).
+    if max_total_dec is not None:
+        total = area_bonus + object_bonus
+        if total > max_total_dec:
+            # Proportional clip — keeps area/object ratio so the audit
+            # snapshot still reflects "this profile would have qualified
+            # for X but cap reduced to Y" without misattributing the cut.
+            if total > _ZERO:
+                ratio = max_total_dec / total
+                area_bonus = (area_bonus * ratio).quantize(Decimal("0.01"))
+                object_bonus = (object_bonus * ratio).quantize(Decimal("0.01"))
+            snapshot["cap_applied"] = str(max_total_dec)
+
+    return area_bonus, object_bonus, snapshot
+
+
+async def _resolve_area_bonus(
+    db: "AsyncSession",
+    profile: "AdmissionProfile",
+    academic_year: int,
+) -> tuple[Decimal, dict[str, Any]]:
+    """Lookup the KV rate for the profile's resolved area_code.
+
+    Per TT 05/2021 Điều 7+11: KV xác định theo trường THPT (PRIMARY)
+    hoặc hộ khẩu thường trú (special case). PR1 stores the resolved
+    code in ``profile.high_school_kv_resolved``; backfill PR7 fills
+    legacy rows. NULL → 0đ (graceful).
+
+    Returns ``(bonus_points, meta_dict)`` where meta is merged into the
+    config_snapshot for audit.
+    """
+    from app.models.priority_config import PriorityAreaConfig
+
+    area_code = getattr(profile, "high_school_kv_resolved", None)
+    meta: dict[str, Any] = {"area_code": area_code, "area_rate": None}
+    if not area_code:
+        return _ZERO, meta
+
+    stmt = (
+        select(PriorityAreaConfig.bonus_points)
+        .where(
+            PriorityAreaConfig.academic_year == academic_year,
+            PriorityAreaConfig.area_code == area_code,
+            PriorityAreaConfig.effective_from <= _today(),
+        )
+        .where(
+            (PriorityAreaConfig.effective_to.is_(None))
+            | (PriorityAreaConfig.effective_to > _today())
+        )
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    rate = result.scalar_one_or_none()
+    if rate is None:
+        # Admin chưa seed rate cho năm này → engine ghi 0đ (graceful);
+        # snapshot vẫn lưu area_code để audit thấy "candidate khai KV1
+        # nhưng rate chưa có config".
+        return _ZERO, meta
+
+    meta["area_rate"] = str(rate)
+    return Decimal(rate), meta
+
+
+async def _resolve_object_bonus(
+    db: "AsyncSession",
+    profile: "AdmissionProfile",
+    academic_year: int,
+) -> tuple[Decimal, dict[str, Any]]:
+    """Lookup MAX UT rate over verified evidence.
+
+    Per TT 05/2021 Phụ lục 01: "chỉ được hưởng một diện ưu tiên cao
+    nhất" — multi-UT đối tượng applies the highest bonus, not the sum.
+
+    Evidence gate: a sub_code only counts if
+    ``profile.priority_object_evidence[code].status == 'verified'``.
+    Missing key / 'pending' / 'rejected' → 0 contribution.
+
+    Returns ``(bonus_points, meta_dict)``.
+    """
+    from app.models.priority_config import PriorityObjectConfig
+
+    codes = getattr(profile, "priority_object_codes", None) or []
+    evidence = getattr(profile, "priority_object_evidence", None) or {}
+
+    verified_codes = [
+        c
+        for c in codes
+        if isinstance(evidence.get(c), dict)
+        and evidence[c].get("status") == "verified"
+    ]
+    meta: dict[str, Any] = {
+        "verified_codes": verified_codes,
+        "object_max_code": None,
+        "object_rate": None,
+    }
+    if not verified_codes:
+        return _ZERO, meta
+
+    stmt = (
+        select(
+            PriorityObjectConfig.sub_code,
+            PriorityObjectConfig.bonus_points,
+        )
+        .where(
+            PriorityObjectConfig.academic_year == academic_year,
+            PriorityObjectConfig.sub_code.in_(verified_codes),
+            PriorityObjectConfig.effective_from <= _today(),
+        )
+        .where(
+            (PriorityObjectConfig.effective_to.is_(None))
+            | (PriorityObjectConfig.effective_to > _today())
+        )
+    )
+    result = await db.execute(stmt)
+    rows = result.all()
+    if not rows:
+        return _ZERO, meta
+
+    # Pick max bonus + record which sub_code won (audit "candidate had
+    # UT1+UT2 verified, engine applied UT1 because higher rate").
+    best_code, best_rate = max(rows, key=lambda r: r[1])
+    meta["object_max_code"] = best_code
+    meta["object_rate"] = str(best_rate)
+    return Decimal(best_rate), meta
+
+
+def _today():
+    """date.today() — extracted so tests can monkeypatch a fixed value
+    without freezing the whole datetime module."""
+    from datetime import date
+
+    return date.today()

--- a/Backend_FastAPI/app/services/priority_service.py
+++ b/Backend_FastAPI/app/services/priority_service.py
@@ -142,17 +142,27 @@ async def _resolve_area_bonus(
 ) -> tuple[Decimal, dict[str, Any]]:
     """Lookup the KV rate for the profile's resolved area_code.
 
-    Per TT 05/2021 Điều 7+11: KV xác định theo trường THPT (PRIMARY)
-    hoặc hộ khẩu thường trú (special case). PR1 stores the resolved
-    code in ``profile.high_school_kv_resolved``; backfill PR7 fills
-    legacy rows. NULL → 0đ (graceful).
+    v1.3 phase1_09: KV resolved code lives in
+    ``profile.priority_resolution_snapshot.kv_resolved`` (frozen at T1
+    submit + re-frozen at T6 engine, per Q-P3-11 snapshot pattern).
+    Falls back to legacy ``profile.high_school_kv_resolved`` getattr
+    for backward-compat during cutover transition (column DROPPED in
+    phase1_09 so getattr returns None on real ORM, but kept for test
+    SimpleNamespace stubs).
+
+    NULL → 0đ (graceful — candidate chưa fill diploma info).
 
     Returns ``(bonus_points, meta_dict)`` where meta is merged into the
     config_snapshot for audit.
     """
     from app.models.priority_config import PriorityAreaConfig
 
-    area_code = getattr(profile, "high_school_kv_resolved", None)
+    # v1.3: read from snapshot.kv_resolved (canonical post-phase1_09)
+    snapshot = getattr(profile, "priority_resolution_snapshot", None) or {}
+    area_code = snapshot.get("kv_resolved") if isinstance(snapshot, dict) else None
+    # Backward-compat fallback for test stubs + legacy code paths
+    if not area_code:
+        area_code = getattr(profile, "high_school_kv_resolved", None)
     meta: dict[str, Any] = {"area_code": area_code, "area_rate": None}
     if not area_code:
         return _ZERO, meta

--- a/Backend_FastAPI/app/services/vn_locality_service.py
+++ b/Backend_FastAPI/app/services/vn_locality_service.py
@@ -42,6 +42,32 @@ def _decode_csv_bytes(csv_bytes: bytes) -> str:
         )
 
 
+# F.5 fix: required columns per CSV format. DictReader otherwise silently
+# parses any header into a dict; rows with wrong-named columns would
+# either silently pass with all-None fields (admin tưởng OK), or fail
+# Pydantic per-row (noisy). Upfront header check returns a clear 422.
+COMMUNE_CSV_REQUIRED_COLS = {
+    "commune_code", "province", "district", "ward", "area_code",
+}
+HIGH_SCHOOL_CSV_REQUIRED_COLS = {"name", "province"}  # district/ward/kv_code optional
+
+
+def _validate_csv_header(
+    reader: csv.DictReader, required_cols: set[str], format_name: str
+) -> None:
+    """Raise DomainValidationError if reader.fieldnames missing any
+    required column. Called before per-row parsing so admin gets a
+    single clear error instead of N row-level errors."""
+    header = set(reader.fieldnames or [])
+    missing = required_cols - header
+    if missing:
+        raise DomainValidationError(
+            f"CSV {format_name} thiếu cột bắt buộc: "
+            f"{', '.join(sorted(missing))}. "
+            f"Header phải có: {', '.join(sorted(required_cols))}."
+        )
+
+
 PostCommitCallback = Optional[Callable[[], Awaitable[None]]]
 
 
@@ -83,6 +109,7 @@ class VnLocalityService:
         Returns ``{inserted, skipped_existing, error_rows}``.
         """
         reader = csv.DictReader(io.StringIO(_decode_csv_bytes(csv_bytes)))
+        _validate_csv_header(reader, COMMUNE_CSV_REQUIRED_COLS, "commune")
         inserted = 0
         skipped = 0
         errors: list[dict] = []
@@ -136,8 +163,13 @@ class VnLocalityService:
         creates 2 distinct rows (correct — different schools).
 
         CR-M2: ``utf-8-sig`` decode strips Excel-exported BOM.
+        F.5: header validated upfront so admin sees one clear error
+        instead of N row-level errors when the wrong CSV is uploaded.
         """
         reader = csv.DictReader(io.StringIO(_decode_csv_bytes(csv_bytes)))
+        _validate_csv_header(
+            reader, HIGH_SCHOOL_CSV_REQUIRED_COLS, "high_school"
+        )
         inserted = 0
         skipped = 0
         errors: list[dict] = []

--- a/Backend_FastAPI/app/services/vn_locality_service.py
+++ b/Backend_FastAPI/app/services/vn_locality_service.py
@@ -25,6 +25,21 @@ from app.schemas.vn_locality import (
     VnCommuneAreaMapRow,
     VnHighSchoolRow,
 )
+from app.utils.exceptions import ValidationError as DomainValidationError
+
+
+def _decode_csv_bytes(csv_bytes: bytes) -> str:
+    """N2 fix: utf-8-sig handles Excel BOM, but CP1258 / latin1 / other
+    Excel-VN encodings raise UnicodeDecodeError → bubbles up as opaque
+    500. Catch + re-raise as domain ValidationError so router returns
+    422 with a clear "save as CSV UTF-8" hint."""
+    try:
+        return csv_bytes.decode("utf-8-sig", errors="strict")
+    except UnicodeDecodeError:
+        raise DomainValidationError(
+            "CSV phải encode UTF-8. Trong Excel chọn 'Save As → CSV UTF-8 "
+            "(Comma delimited) (*.csv)' rồi upload lại."
+        )
 
 
 PostCommitCallback = Optional[Callable[[], Awaitable[None]]]
@@ -67,7 +82,7 @@ class VnLocalityService:
 
         Returns ``{inserted, skipped_existing, error_rows}``.
         """
-        reader = csv.DictReader(io.StringIO(csv_bytes.decode("utf-8-sig", errors="strict")))
+        reader = csv.DictReader(io.StringIO(_decode_csv_bytes(csv_bytes)))
         inserted = 0
         skipped = 0
         errors: list[dict] = []
@@ -122,7 +137,7 @@ class VnLocalityService:
 
         CR-M2: ``utf-8-sig`` decode strips Excel-exported BOM.
         """
-        reader = csv.DictReader(io.StringIO(csv_bytes.decode("utf-8-sig", errors="strict")))
+        reader = csv.DictReader(io.StringIO(_decode_csv_bytes(csv_bytes)))
         inserted = 0
         skipped = 0
         errors: list[dict] = []

--- a/Backend_FastAPI/app/services/vn_locality_service.py
+++ b/Backend_FastAPI/app/services/vn_locality_service.py
@@ -60,9 +60,14 @@ class VnLocalityService:
         """Parse + upsert commune rows. Expected CSV columns:
         commune_code,province,district,ward,area_code
 
+        Idempotency key: ``commune_code`` (BNV's immutable identifier).
+        CR-M2: ``utf-8-sig`` decode strips the BOM that Excel-exported
+        CSVs commonly include — without this the first header column
+        parses as ``\\ufeffcommune_code`` and every row fails validation.
+
         Returns ``{inserted, skipped_existing, error_rows}``.
         """
-        reader = csv.DictReader(io.StringIO(csv_bytes.decode("utf-8")))
+        reader = csv.DictReader(io.StringIO(csv_bytes.decode("utf-8-sig", errors="strict")))
         inserted = 0
         skipped = 0
         errors: list[dict] = []
@@ -110,9 +115,14 @@ class VnLocalityService:
         """Parse + upsert high school rows. Expected CSV columns:
         name,province,district,ward,kv_code
 
-        Skips rows where (name, province) already active.
+        Idempotency key: ``(name, province)`` — MOET CSV has no stable
+        unique identifier across years; (name, province) is the
+        practical compromise. NOTE: same school name in 2 provinces
+        creates 2 distinct rows (correct — different schools).
+
+        CR-M2: ``utf-8-sig`` decode strips Excel-exported BOM.
         """
-        reader = csv.DictReader(io.StringIO(csv_bytes.decode("utf-8")))
+        reader = csv.DictReader(io.StringIO(csv_bytes.decode("utf-8-sig", errors="strict")))
         inserted = 0
         skipped = 0
         errors: list[dict] = []
@@ -189,12 +199,17 @@ class VnLocalityService:
     async def search_high_schools(
         self, query: str, limit: int = 20
     ) -> list[VnHighSchool]:
-        """Searchable dropdown source: case-insensitive prefix match on
-        name. Returns active rows only."""
+        """CR-M3 fix: prefix match (NOT substring) — index-friendly +
+        cleaner UX. Vietnamese school names canonically start with
+        'THPT' or 'Trường THPT' so candidate types the school's actual
+        name (vd 'Lê Quý Đôn') and we surface anything starting with
+        that string.
+
+        Returns active rows only (is_active=true)."""
         stmt = (
             select(VnHighSchool)
             .where(
-                VnHighSchool.name.ilike(f"%{query}%"),
+                VnHighSchool.name.ilike(f"{query}%"),
                 VnHighSchool.is_active.is_(True),
             )
             .order_by(VnHighSchool.name)

--- a/Backend_FastAPI/app/services/vn_locality_service.py
+++ b/Backend_FastAPI/app/services/vn_locality_service.py
@@ -20,12 +20,16 @@ from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.vn_locality import VnCommuneAreaMap, VnHighSchool
-from app.schemas.vn_locality import (
-    VnCommuneAreaMapRow,
-    VnHighSchoolRow,
-)
+from app.models.vn_locality import VnCommuneAreaMap
+from app.schemas.vn_locality import VnCommuneAreaMapRow
 from app.utils.exceptions import ValidationError as DomainValidationError
+
+# VnHighSchool DROPPED in phase1_09 — see app/models/vn_school.py for the
+# 3-table replacement family. Old methods (import_high_school_csv,
+# seed_sample_high_schools, search_high_schools) REMOVED from this service;
+# routes also removed from admin_vn_locality.py. Replacement will live in
+# Phase B.1 import script (app/scripts/import_moet_schools_2025.py) +
+# new VnSchool admin search service (Phase D candidate FE).
 
 
 def _decode_csv_bytes(csv_bytes: bytes) -> str:
@@ -49,7 +53,9 @@ def _decode_csv_bytes(csv_bytes: bytes) -> str:
 COMMUNE_CSV_REQUIRED_COLS = {
     "commune_code", "province", "district", "ward", "area_code",
 }
-HIGH_SCHOOL_CSV_REQUIRED_COLS = {"name", "province"}  # district/ward/kv_code optional
+# HIGH_SCHOOL_CSV_REQUIRED_COLS DROPPED phase1_09. New THPT import will live
+# in app/scripts/import_moet_schools_2025.py (Phase B.1) — uses MOET file
+# structure directly, không cần required_cols const ở service layer.
 
 
 def _validate_csv_header(
@@ -75,16 +81,8 @@ async def _noop_callback() -> None:
     return None
 
 
-# Demo seed (5 rows) so the candidate FE dropdown can render something
-# usable before the admin uploads the real MOET CSV. Rows are inserted
-# on first call only; subsequent calls skip existing names.
-SAMPLE_HIGH_SCHOOLS: list[dict[str, Any]] = [
-    {"name": "THPT Lê Quý Đôn", "province": "Hà Nội", "district": "Hà Đông", "kv_code": "KV3"},
-    {"name": "THPT Chu Văn An", "province": "Hà Nội", "district": "Tây Hồ", "kv_code": "KV3"},
-    {"name": "THPT Nguyễn Thị Minh Khai", "province": "Hồ Chí Minh", "district": "Quận 3", "kv_code": "KV3"},
-    {"name": "THPT chuyên Lê Hồng Phong", "province": "Hồ Chí Minh", "district": "Quận 5", "kv_code": "KV3"},
-    {"name": "THPT DTNT N'Trang Lơng", "province": "Đắk Lắk", "district": "Buôn Ma Thuột", "kv_code": "KV1"},
-]
+# SAMPLE_HIGH_SCHOOLS DROPPED phase1_09. Demo seed for VnSchool family
+# will live in app/scripts/import_moet_schools_2025.py (Phase B.1).
 
 
 class VnLocalityService:
@@ -148,122 +146,8 @@ class VnLocalityService:
         )
 
     # =========================================================================
-    # vn_high_school
+    # VnHighSchool methods DROPPED phase1_09 — see vn_school family (TBD service)
     # =========================================================================
-
-    async def import_high_school_csv(
-        self, csv_bytes: bytes
-    ) -> Tuple[dict[str, Any], PostCommitCallback]:
-        """Parse + upsert high school rows. Expected CSV columns:
-        name,province,district,ward,kv_code
-
-        Idempotency key: ``(name, province)`` — MOET CSV has no stable
-        unique identifier across years; (name, province) is the
-        practical compromise. NOTE: same school name in 2 provinces
-        creates 2 distinct rows (correct — different schools).
-
-        CR-M2: ``utf-8-sig`` decode strips Excel-exported BOM.
-        F.5: header validated upfront so admin sees one clear error
-        instead of N row-level errors when the wrong CSV is uploaded.
-        """
-        reader = csv.DictReader(io.StringIO(_decode_csv_bytes(csv_bytes)))
-        _validate_csv_header(
-            reader, HIGH_SCHOOL_CSV_REQUIRED_COLS, "high_school"
-        )
-        inserted = 0
-        skipped = 0
-        errors: list[dict] = []
-
-        for row_num, raw in enumerate(reader, start=2):
-            # csv.DictReader returns "" for blank cells; Pydantic regex
-            # pattern would reject "" — convert to None so optional fields
-            # stay optional (MOET CSV often omits kv_code / ward).
-            cleaned = {k: (v if v != "" else None) for k, v in raw.items()}
-            try:
-                row = VnHighSchoolRow.model_validate(cleaned)
-            except ValidationError as e:
-                errors.append({"row_num": row_num, "error": str(e)})
-                continue
-
-            existing = await self.db.execute(
-                select(VnHighSchool.id)
-                .where(
-                    VnHighSchool.name == row.name,
-                    VnHighSchool.province == row.province,
-                    VnHighSchool.is_active.is_(True),
-                )
-                .limit(1)
-            )
-            if existing.scalar_one_or_none() is not None:
-                skipped += 1
-                continue
-
-            self.db.add(VnHighSchool(**row.model_dump()))
-            inserted += 1
-
-        await self.db.flush()
-        return (
-            {
-                "inserted": inserted,
-                "skipped_existing": skipped,
-                "error_rows": errors,
-            },
-            _noop_callback,
-        )
-
-    async def seed_sample_high_schools(
-        self,
-    ) -> Tuple[dict[str, Any], PostCommitCallback]:
-        """Insert 5 demo rows (Q9 #07 hybrid C2: ship empty + free-text
-        fallback, but a handful of rows let candidate FE dropdown +
-        Chrome MCP smoke test work end-to-end without waiting on the
-        real MOET CSV)."""
-        inserted = 0
-        for row_data in SAMPLE_HIGH_SCHOOLS:
-            existing = await self.db.execute(
-                select(VnHighSchool.id)
-                .where(
-                    VnHighSchool.name == row_data["name"],
-                    VnHighSchool.province == row_data["province"],
-                    VnHighSchool.is_active.is_(True),
-                )
-                .limit(1)
-            )
-            if existing.scalar_one_or_none() is not None:
-                continue
-            self.db.add(VnHighSchool(**row_data))
-            inserted += 1
-        await self.db.flush()
-        return (
-            {"inserted": inserted, "total_in_seed": len(SAMPLE_HIGH_SCHOOLS)},
-            _noop_callback,
-        )
-
-    # =========================================================================
-    # Read endpoints (used by PR5 candidate FE)
-    # =========================================================================
-
-    async def search_high_schools(
-        self, query: str, limit: int = 20
-    ) -> list[VnHighSchool]:
-        """CR-M3 fix: prefix match (NOT substring) — index-friendly +
-        cleaner UX. Vietnamese school names canonically start with
-        'THPT' or 'Trường THPT' so candidate types the school's actual
-        name (vd 'Lê Quý Đôn') and we surface anything starting with
-        that string.
-
-        Returns active rows only (is_active=true)."""
-        stmt = (
-            select(VnHighSchool)
-            .where(
-                VnHighSchool.name.ilike(f"{query}%"),
-                VnHighSchool.is_active.is_(True),
-            )
-            .order_by(VnHighSchool.name)
-            .limit(limit)
-        )
-        result = await self.db.execute(stmt)
-        return list(result.scalars().all())
 
     async def lookup_commune_kv(
         self, commune_code: str

--- a/Backend_FastAPI/app/services/vn_locality_service.py
+++ b/Backend_FastAPI/app/services/vn_locality_service.py
@@ -1,0 +1,220 @@
+# app/services/vn_locality_service.py
+"""Admin CSV import service for vn_commune_area_map + vn_high_school
+(Q9 #07 PR4).
+
+Both imports are idempotent — re-running the same CSV is safe:
+* commune: skip rows where (commune_code, effective_to IS NULL) already exists
+* high_school: skip rows where (name, province) already exists active
+
+Validation strategy: row-level Pydantic parse + skip-on-error so a
+malformed line doesn't abort the whole import. Errors collected into
+``error_rows`` for admin to fix + re-upload.
+"""
+from __future__ import annotations
+
+import csv
+import io
+from typing import Any, Awaitable, Callable, Optional, Tuple
+
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.vn_locality import VnCommuneAreaMap, VnHighSchool
+from app.schemas.vn_locality import (
+    VnCommuneAreaMapRow,
+    VnHighSchoolRow,
+)
+
+
+PostCommitCallback = Optional[Callable[[], Awaitable[None]]]
+
+
+async def _noop_callback() -> None:
+    return None
+
+
+# Demo seed (5 rows) so the candidate FE dropdown can render something
+# usable before the admin uploads the real MOET CSV. Rows are inserted
+# on first call only; subsequent calls skip existing names.
+SAMPLE_HIGH_SCHOOLS: list[dict[str, Any]] = [
+    {"name": "THPT Lê Quý Đôn", "province": "Hà Nội", "district": "Hà Đông", "kv_code": "KV3"},
+    {"name": "THPT Chu Văn An", "province": "Hà Nội", "district": "Tây Hồ", "kv_code": "KV3"},
+    {"name": "THPT Nguyễn Thị Minh Khai", "province": "Hồ Chí Minh", "district": "Quận 3", "kv_code": "KV3"},
+    {"name": "THPT chuyên Lê Hồng Phong", "province": "Hồ Chí Minh", "district": "Quận 5", "kv_code": "KV3"},
+    {"name": "THPT DTNT N'Trang Lơng", "province": "Đắk Lắk", "district": "Buôn Ma Thuột", "kv_code": "KV1"},
+]
+
+
+class VnLocalityService:
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    # =========================================================================
+    # vn_commune_area_map
+    # =========================================================================
+
+    async def import_commune_csv(
+        self, csv_bytes: bytes
+    ) -> Tuple[dict[str, Any], PostCommitCallback]:
+        """Parse + upsert commune rows. Expected CSV columns:
+        commune_code,province,district,ward,area_code
+
+        Returns ``{inserted, skipped_existing, error_rows}``.
+        """
+        reader = csv.DictReader(io.StringIO(csv_bytes.decode("utf-8")))
+        inserted = 0
+        skipped = 0
+        errors: list[dict] = []
+
+        for row_num, raw in enumerate(reader, start=2):  # row 1 = header
+            try:
+                row = VnCommuneAreaMapRow.model_validate(raw)
+            except ValidationError as e:
+                errors.append({"row_num": row_num, "error": str(e)})
+                continue
+
+            # Skip if active row exists
+            existing = await self.db.execute(
+                select(VnCommuneAreaMap.id)
+                .where(
+                    VnCommuneAreaMap.commune_code == row.commune_code,
+                    VnCommuneAreaMap.effective_to.is_(None),
+                )
+                .limit(1)
+            )
+            if existing.scalar_one_or_none() is not None:
+                skipped += 1
+                continue
+
+            self.db.add(VnCommuneAreaMap(**row.model_dump()))
+            inserted += 1
+
+        await self.db.flush()
+        return (
+            {
+                "inserted": inserted,
+                "skipped_existing": skipped,
+                "error_rows": errors,
+            },
+            _noop_callback,
+        )
+
+    # =========================================================================
+    # vn_high_school
+    # =========================================================================
+
+    async def import_high_school_csv(
+        self, csv_bytes: bytes
+    ) -> Tuple[dict[str, Any], PostCommitCallback]:
+        """Parse + upsert high school rows. Expected CSV columns:
+        name,province,district,ward,kv_code
+
+        Skips rows where (name, province) already active.
+        """
+        reader = csv.DictReader(io.StringIO(csv_bytes.decode("utf-8")))
+        inserted = 0
+        skipped = 0
+        errors: list[dict] = []
+
+        for row_num, raw in enumerate(reader, start=2):
+            # csv.DictReader returns "" for blank cells; Pydantic regex
+            # pattern would reject "" — convert to None so optional fields
+            # stay optional (MOET CSV often omits kv_code / ward).
+            cleaned = {k: (v if v != "" else None) for k, v in raw.items()}
+            try:
+                row = VnHighSchoolRow.model_validate(cleaned)
+            except ValidationError as e:
+                errors.append({"row_num": row_num, "error": str(e)})
+                continue
+
+            existing = await self.db.execute(
+                select(VnHighSchool.id)
+                .where(
+                    VnHighSchool.name == row.name,
+                    VnHighSchool.province == row.province,
+                    VnHighSchool.is_active.is_(True),
+                )
+                .limit(1)
+            )
+            if existing.scalar_one_or_none() is not None:
+                skipped += 1
+                continue
+
+            self.db.add(VnHighSchool(**row.model_dump()))
+            inserted += 1
+
+        await self.db.flush()
+        return (
+            {
+                "inserted": inserted,
+                "skipped_existing": skipped,
+                "error_rows": errors,
+            },
+            _noop_callback,
+        )
+
+    async def seed_sample_high_schools(
+        self,
+    ) -> Tuple[dict[str, Any], PostCommitCallback]:
+        """Insert 5 demo rows (Q9 #07 hybrid C2: ship empty + free-text
+        fallback, but a handful of rows let candidate FE dropdown +
+        Chrome MCP smoke test work end-to-end without waiting on the
+        real MOET CSV)."""
+        inserted = 0
+        for row_data in SAMPLE_HIGH_SCHOOLS:
+            existing = await self.db.execute(
+                select(VnHighSchool.id)
+                .where(
+                    VnHighSchool.name == row_data["name"],
+                    VnHighSchool.province == row_data["province"],
+                    VnHighSchool.is_active.is_(True),
+                )
+                .limit(1)
+            )
+            if existing.scalar_one_or_none() is not None:
+                continue
+            self.db.add(VnHighSchool(**row_data))
+            inserted += 1
+        await self.db.flush()
+        return (
+            {"inserted": inserted, "total_in_seed": len(SAMPLE_HIGH_SCHOOLS)},
+            _noop_callback,
+        )
+
+    # =========================================================================
+    # Read endpoints (used by PR5 candidate FE)
+    # =========================================================================
+
+    async def search_high_schools(
+        self, query: str, limit: int = 20
+    ) -> list[VnHighSchool]:
+        """Searchable dropdown source: case-insensitive prefix match on
+        name. Returns active rows only."""
+        stmt = (
+            select(VnHighSchool)
+            .where(
+                VnHighSchool.name.ilike(f"%{query}%"),
+                VnHighSchool.is_active.is_(True),
+            )
+            .order_by(VnHighSchool.name)
+            .limit(limit)
+        )
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def lookup_commune_kv(
+        self, commune_code: str
+    ) -> Optional[str]:
+        """Backup KV resolution for special-case profiles (PT DTNT,
+        quân nhân) — looks up the ACTIVE commune row."""
+        stmt = (
+            select(VnCommuneAreaMap.area_code)
+            .where(
+                VnCommuneAreaMap.commune_code == commune_code,
+                VnCommuneAreaMap.effective_to.is_(None),
+            )
+            .limit(1)
+        )
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()

--- a/Backend_FastAPI/tests/unit/test_admission_choice_engine_priority_integration.py
+++ b/Backend_FastAPI/tests/unit/test_admission_choice_engine_priority_integration.py
@@ -1,0 +1,106 @@
+"""Anchor test for Q9 #07 PR2b — priority_service integration into
+``evaluate_cascade`` at T6 publish.
+
+Locks the contract that the engine wires the 3 snapshot columns
+(``priority_area_bonus_snapshot`` / ``priority_object_bonus_snapshot`` /
+``priority_config_snapshot``) at the same point it writes
+``bonus_rule_snapshot``. A regression here = silent zero-bonus on the
+next admission round, which is the failure mode Q9 #07 was supposed
+to prevent.
+"""
+from __future__ import annotations
+
+import inspect
+from decimal import Decimal
+from pathlib import Path
+
+
+_ENGINE_SRC = (
+    Path(__file__).resolve().parents[2]
+    / "app"
+    / "services"
+    / "admission_choice_engine_service.py"
+)
+
+
+def test_evaluate_cascade_imports_priority_service() -> None:
+    """Engine must import calculate_priority_bonus inside evaluate_cascade
+    (lazy import to avoid circular dependency at module load)."""
+    src = _ENGINE_SRC.read_text(encoding="utf-8")
+    assert (
+        "from app.services.priority_service import calculate_priority_bonus"
+        in src
+    )
+
+
+def test_evaluate_cascade_sets_three_snapshot_columns() -> None:
+    """Engine writes all 3 priority snapshot columns on each choice —
+    not just one or two. A missing column write = engine silently
+    omits the field and downstream scoring code sees NULL."""
+    src = _ENGINE_SRC.read_text(encoding="utf-8")
+    for col in (
+        "choice.priority_area_bonus_snapshot",
+        "choice.priority_object_bonus_snapshot",
+        "choice.priority_config_snapshot",
+    ):
+        assert col in src, f"Engine missing assignment to {col}"
+
+
+def test_engine_uses_academic_year_from_admission_round() -> None:
+    """The plain Integer academic_year is read via
+    ``path.admission_round.academic_year`` (NOT academic_year_id —
+    there is no academic_year FK table in the schema)."""
+    src = _ENGINE_SRC.read_text(encoding="utf-8")
+    assert 'getattr(round_obj, "academic_year", None)' in src
+    # And guard against the old assumption resurfacing
+    assert "academic_year_id" not in src.split(
+        "calculate_priority_bonus"
+    )[1][:500]
+
+
+def test_engine_passes_bonus_rule_snapshot_to_priority_service() -> None:
+    """Priority service receives the SAME snapshot dict the engine
+    just wrote to ``choice.bonus_rule_snapshot``. Mismatch = snapshot
+    drift between bonus_rule_snapshot and priority_config_snapshot."""
+    src = _ENGINE_SRC.read_text(encoding="utf-8")
+    # Locate the calculate_priority_bonus call
+    idx = src.index("calculate_priority_bonus(")
+    call_block = src[idx : idx + 400]
+    assert "rule=choice.bonus_rule_snapshot" in call_block
+
+
+def test_priority_service_returns_decimal_for_snapshot_columns() -> None:
+    """priority_area/object_bonus_snapshot are NUMERIC(4,2). Service
+    must return Decimal not float — runtime SQLAlchemy will coerce
+    but Decimal is the canonical type for currency-like precision."""
+    from app.services.priority_service import calculate_priority_bonus
+
+    sig = inspect.signature(calculate_priority_bonus)
+    # Service has 4 params (db, profile, rule, academic_year)
+    assert set(sig.parameters.keys()) == {
+        "db", "profile", "rule", "academic_year",
+    }
+
+
+def test_engine_skips_priority_if_academic_year_missing() -> None:
+    """If round_obj.academic_year is None (legacy / mis-eager-loaded),
+    engine must skip the priority calculation to avoid crashing the
+    whole cascade — defensive guard for prod safety."""
+    src = _ENGINE_SRC.read_text(encoding="utf-8")
+    assert "if academic_year is not None:" in src
+
+
+def test_snapshot_freeze_pattern_matches_bonus_rule_snapshot() -> None:
+    """Q-P3-11 freeze semantic: priority snapshot fires AFTER
+    bonus_rule_snapshot (so they capture the same atomic moment)
+    and BEFORE _evaluate_single_choice (so gates run on frozen data).
+    Order matters for replay determinism."""
+    src = _ENGINE_SRC.read_text(encoding="utf-8")
+
+    bonus_idx = src.index("choice.bonus_rule_snapshot = resolve_effective_bonus_rule")
+    priority_idx = src.index("calculate_priority_bonus(")
+    evaluate_idx = src.index("decision, score_result, reason_codes = _evaluate_single_choice")
+
+    assert bonus_idx < priority_idx < evaluate_idx, (
+        "Snapshot order violation: bonus_rule -> priority -> evaluate_single"
+    )

--- a/Backend_FastAPI/tests/unit/test_admission_choice_engine_priority_integration.py
+++ b/Backend_FastAPI/tests/unit/test_admission_choice_engine_priority_integration.py
@@ -49,9 +49,14 @@ def test_evaluate_cascade_sets_three_snapshot_columns() -> None:
 def test_engine_uses_academic_year_from_admission_round() -> None:
     """The plain Integer academic_year is read via
     ``path.admission_round.academic_year`` (NOT academic_year_id —
-    there is no academic_year FK table in the schema)."""
+    there is no academic_year FK table in the schema).
+
+    Review-3 update: access pattern switched to ``__dict__.get`` for
+    eager-load safety (avoid MissingGreenlet in async context). The
+    expectation remains "read academic_year from admission_round".
+    """
     src = _ENGINE_SRC.read_text(encoding="utf-8")
-    assert 'getattr(round_obj, "academic_year", None)' in src
+    assert 'round_obj.__dict__.get("academic_year")' in src
     # And guard against the old assumption resurfacing
     assert "academic_year_id" not in src.split(
         "calculate_priority_bonus"
@@ -104,3 +109,36 @@ def test_snapshot_freeze_pattern_matches_bonus_rule_snapshot() -> None:
     assert bonus_idx < priority_idx < evaluate_idx, (
         "Snapshot order violation: bonus_rule -> priority -> evaluate_single"
     )
+
+
+def test_publish_result_router_eager_loads_admission_round() -> None:
+    """Review-3 MAJOR fix lock: production publish_result router must
+    eager-load AdmissionPath.admission_round so the engine can read
+    academic_year for priority_*_config lookup.
+
+    Without this, the engine's defensive ``__dict__.get`` returns None,
+    priority calc is silently skipped, and every candidate gets 0đ
+    bonus — a regression of the CR-P0 fix that was caught in review-3.
+    """
+    router_src = (
+        _ENGINE_SRC.parent.parent
+        / "routers"
+        / "admissions_v2.py"
+    ).read_text(encoding="utf-8")
+
+    # The eager-load chain must include admission_round on the path
+    # used for cascade. We assert both the relation reference and the
+    # comment marker so reviewers know it's intentional, not orphan.
+    assert "AdmissionPath.admission_round" in router_src, (
+        "publish_result router missing selectinload(admission_round) — "
+        "priority bonus will silently be 0đ in prod."
+    )
+
+
+def test_engine_warns_on_skipped_priority() -> None:
+    """Review-3 MAJOR: defensive log.warning when priority calc is
+    skipped due to missing academic_year — so future eager-load
+    regressions surface in logs instead of silently scoring 0đ."""
+    src = _ENGINE_SRC.read_text(encoding="utf-8")
+    assert "priority_bonus_skipped_missing_academic_year" in src
+    assert "log.warning(" in src

--- a/Backend_FastAPI/tests/unit/test_admission_path_schema_bonus_rule_override.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_schema_bonus_rule_override.py
@@ -4,7 +4,7 @@ fields on ``AdmissionPathCreate`` / ``AdmissionPathUpdate`` /
 phase1_02).
 
 Codex P2 review on PR-1B' chốt: ``bonus_rule_override`` ships as a
-typed Pydantic shape (``apply_area_bonus`` / ``apply_subject_bonus``
+typed Pydantic shape (``apply_area_bonus`` / ``apply_object_bonus``
 / ``max_total_bonus``) instead of a raw JSONB blob. This file
 locks:
 
@@ -44,20 +44,20 @@ from app.schemas.admission_path import (
 def test_bonus_rule_override_accepts_all_three_fields() -> None:
     payload = {
         "apply_area_bonus": True,
-        "apply_subject_bonus": False,
+        "apply_object_bonus": False,
         "max_total_bonus": 2.75,
     }
     rule = BonusRuleOverride.model_validate(payload)
     assert rule.apply_area_bonus is True
-    assert rule.apply_subject_bonus is False
+    assert rule.apply_object_bonus is False
     assert rule.max_total_bonus == pytest.approx(2.75)
 
 
 def test_bonus_rule_override_max_total_bonus_optional_null() -> None:
     """``max_total_bonus`` is the only optional field — NULL = no
-    cap on the combined area + subject bonus."""
+    cap on the combined area + object bonus."""
     rule = BonusRuleOverride.model_validate(
-        {"apply_area_bonus": False, "apply_subject_bonus": False}
+        {"apply_area_bonus": False, "apply_object_bonus": False}
     )
     assert rule.max_total_bonus is None
 
@@ -67,11 +67,11 @@ def test_bonus_rule_override_requires_apply_area_bonus() -> None:
     boolean choice rather than implying False via omission."""
     with pytest.raises(ValidationError):
         BonusRuleOverride.model_validate(
-            {"apply_subject_bonus": True, "max_total_bonus": 1.0}
+            {"apply_object_bonus": True, "max_total_bonus": 1.0}
         )
 
 
-def test_bonus_rule_override_requires_apply_subject_bonus() -> None:
+def test_bonus_rule_override_requires_apply_object_bonus() -> None:
     with pytest.raises(ValidationError):
         BonusRuleOverride.model_validate(
             {"apply_area_bonus": True, "max_total_bonus": 1.0}
@@ -84,7 +84,7 @@ def test_bonus_rule_override_max_total_bonus_lower_bound() -> None:
         BonusRuleOverride.model_validate(
             {
                 "apply_area_bonus": True,
-                "apply_subject_bonus": True,
+                "apply_object_bonus": True,
                 "max_total_bonus": -0.1,
             }
         )
@@ -97,7 +97,7 @@ def test_bonus_rule_override_max_total_bonus_upper_bound() -> None:
         BonusRuleOverride.model_validate(
             {
                 "apply_area_bonus": True,
-                "apply_subject_bonus": True,
+                "apply_object_bonus": True,
                 "max_total_bonus": 10.01,
             }
         )
@@ -111,7 +111,7 @@ def test_bonus_rule_override_rejects_extra_keys() -> None:
         BonusRuleOverride.model_validate(
             {
                 "apply_area_bonus": True,
-                "apply_subject_bonus": True,
+                "apply_object_bonus": True,
                 "max_total_bonus": 1.0,
                 "stray_key": "ignored_silently?",
             }
@@ -173,7 +173,7 @@ def test_create_bonus_rule_override_passes_through_typed() -> None:
     payload = _create_baseline_payload() | {
         "bonus_rule_override": {
             "apply_area_bonus": True,
-            "apply_subject_bonus": True,
+            "apply_object_bonus": True,
             "max_total_bonus": 2.0,
         },
     }
@@ -220,7 +220,7 @@ def test_update_bonus_rule_override_typed() -> None:
         {
             "bonus_rule_override": {
                 "apply_area_bonus": False,
-                "apply_subject_bonus": True,
+                "apply_object_bonus": True,
                 "max_total_bonus": None,
             }
         }
@@ -235,9 +235,20 @@ def test_update_bonus_rule_override_typed() -> None:
 
 
 def _response_baseline_payload() -> dict:
-    """Minimum valid response payload mirroring what the BE emits."""
+    """Minimum valid response payload mirroring what the BE emits.
+
+    W11-T.1 fix (Q9 #07 PR1 bundle per memory test-fixture-drift-after-
+    policy-refactor): added 3 FK id fields that Phase 2 PR-2B v2 +
+    Phase 3 PR-3A made REQUIRED on AdmissionPathResponse
+    (``academic_info_id`` / ``admission_method_id`` /
+    ``admission_round_id``) — fixture had drifted since the schema bump.
+    """
     return {
         "id": 1,
+        # Phase 2 + Phase 3 required FK ids — drifted fixture, see W11-T.1.
+        "academic_info_id": 1,
+        "admission_method_id": 1,
+        "admission_round_id": 1,
         "status": "draft",
         "display_name": "CNTT 2026 — Xét học bạ",
         "display_order": 0,
@@ -296,7 +307,7 @@ def test_response_round_trips_typed_bonus_rule_override() -> None:
     payload = _response_baseline_payload() | {
         "bonus_rule_override": {
             "apply_area_bonus": True,
-            "apply_subject_bonus": True,
+            "apply_object_bonus": True,
             "max_total_bonus": 2.75,
         },
     }

--- a/Backend_FastAPI/tests/unit/test_admission_path_service_phase1_03_governance.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_service_phase1_03_governance.py
@@ -56,11 +56,49 @@ def _user(role: UserRole):
 def _make_service():
     """Service stub with mocked repo. Both ``create`` and ``update``
     echo their input back as the resulting path so we can inspect
-    the persisted column dict."""
+    the persisted column dict.
+
+    W11-T.2 fix (Q9 #07 PR1 bundle per memory test-fixture-drift-after-
+    policy-refactor): ``create_path`` Phase 2 PR-2B v2 now calls
+    ``self.db.get(OfferingAcademicInfo, ...)`` upfront to resolve
+    academic_year for the DOT_1 auto-resolution shim, AND calls
+    ``self.db.get(OfferingAdmissionRound, ...)`` when admission_round_id
+    is explicit. Both `db.get` calls must be AsyncMock or `await` raises
+    TypeError. Side-effect dispatches by model class so a single mock
+    handles both lookups.
+    """
     service = AdmissionPathService.__new__(AdmissionPathService)
     service.db = MagicMock()
+
+    async def _fake_db_get(model_cls, obj_id):
+        # Imported inline so the fixture stays independent of the
+        # service file's import order.
+        from app.models.offering_academic_info import OfferingAcademicInfo
+        from app.models.offering_admission_round import (
+            OfferingAdmissionRound,
+        )
+        if model_cls is OfferingAcademicInfo:
+            return SimpleNamespace(id=obj_id, academic_year=2026)
+        if model_cls is OfferingAdmissionRound:
+            return SimpleNamespace(id=obj_id, academic_year=2026)
+        return None
+
+    service.db.get = AsyncMock(side_effect=_fake_db_get)
+
+    # AdmissionRoundRepository.get_default_dot1 calls self.db.execute(...)
+    # then .scalar_one_or_none(). Mock returns a SimpleNamespace round so
+    # the auto-resolve branch in create_path doesn't BusinessRuleViolation.
+    _fake_round = SimpleNamespace(id=1, academic_year=2026, round_code="DOT_1")
+    _fake_result = MagicMock()
+    _fake_result.scalar_one_or_none = MagicMock(return_value=_fake_round)
+    service.db.execute = AsyncMock(return_value=_fake_result)
+
     service.repo = MagicMock()
     service.repo.get_path_by_offering_and_method = AsyncMock(return_value=None)
+    service.repo.get_path_by_round_offering_method = AsyncMock(return_value=None)
+    # Phase 2 PR-2C v2 duplicate check via 3-col UNIQUE — mock to return
+    # None (no existing path) so create proceeds past the duplicate guard.
+    service.repo.get_path_by_round_and_method = AsyncMock(return_value=None)
 
     persisted: dict = {}
 
@@ -97,7 +135,7 @@ def _admin_create_payload(**overrides) -> AdmissionPathCreate:
         "method_quota": 50,
         "bonus_rule_override": {
             "apply_area_bonus": True,
-            "apply_subject_bonus": False,
+            "apply_object_bonus": False,
             "max_total_bonus": 2.5,
         },
     }
@@ -131,7 +169,7 @@ class TestCreatePathAdminCanSetGovernance:
         # never sees a raw Pydantic instance on the model attribute.
         assert persisted["bonus_rule_override"] == {
             "apply_area_bonus": True,
-            "apply_subject_bonus": False,
+            "apply_object_bonus": False,
             "max_total_bonus": 2.5,
         }
         assert isinstance(path.bonus_rule_override, dict)
@@ -168,7 +206,7 @@ class TestCreatePathManagerGovernanceGuard:
                 {
                     "bonus_rule_override": {
                         "apply_area_bonus": True,
-                        "apply_subject_bonus": False,
+                        "apply_object_bonus": False,
                     }
                 }
             ),
@@ -245,7 +283,7 @@ class TestUpdatePathManagerGovernanceGuard:
                 {
                     "bonus_rule_override": {
                         "apply_area_bonus": True,
-                        "apply_subject_bonus": False,
+                        "apply_object_bonus": False,
                     }
                 }
             ),
@@ -307,7 +345,7 @@ class TestUpdatePathAdminPersistsPhase1_03Fields:
             {
                 "bonus_rule_override": {
                     "apply_area_bonus": False,
-                    "apply_subject_bonus": True,
+                    "apply_object_bonus": True,
                     "max_total_bonus": 1.0,
                 }
             }
@@ -315,7 +353,7 @@ class TestUpdatePathAdminPersistsPhase1_03Fields:
         await service.update_path(path, update, _user(UserRole.ADMIN))
         assert persisted["bonus_rule_override"] == {
             "apply_area_bonus": False,
-            "apply_subject_bonus": True,
+            "apply_object_bonus": True,
             "max_total_bonus": 1.0,
         }
 
@@ -328,7 +366,7 @@ class TestUpdatePathAdminPersistsPhase1_03Fields:
         path = _draft_path()
         path.bonus_rule_override = {
             "apply_area_bonus": True,
-            "apply_subject_bonus": True,
+            "apply_object_bonus": True,
             "max_total_bonus": None,
         }
         update = AdmissionPathUpdate.model_validate(

--- a/Backend_FastAPI/tests/unit/test_admission_profile_priority_columns.py
+++ b/Backend_FastAPI/tests/unit/test_admission_profile_priority_columns.py
@@ -1,0 +1,109 @@
+"""ORM smoke tests for Q9 #07 PR1 — verifies new columns are wired on
+``AdmissionProfile`` and ``AdmissionProfileChoice`` models.
+
+Catches "I added the alembic migration but forgot to update the ORM"
+regressions before they surface as runtime AttributeError in the
+service layer.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# AdmissionProfile — 7 new columns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "high_school_id",
+        "high_school_kv_resolved",
+        "permanent_commune_code",
+        "area_resolution_basis",
+        "area_resolution_reason",
+        "priority_object_codes",
+        "priority_object_evidence",
+    ],
+)
+def test_admission_profile_has_column(column: str) -> None:
+    from app.models import AdmissionProfile
+    assert column in AdmissionProfile.__table__.columns, (
+        f"AdmissionProfile missing column {column!r}"
+    )
+
+
+def test_high_school_id_is_fk_with_restrict() -> None:
+    """RESTRICT prevents hard DELETE on vn_high_school while a profile
+    references it — admin must use is_active=false soft-delete."""
+    from app.models import AdmissionProfile
+    col = AdmissionProfile.__table__.columns["high_school_id"]
+    fks = list(col.foreign_keys)
+    assert len(fks) == 1
+    fk = fks[0]
+    assert fk.column.table.name == "vn_high_school"
+    assert fk.ondelete == "RESTRICT"
+
+
+def test_priority_object_codes_is_not_null_with_empty_default() -> None:
+    """NOT NULL with empty JSONB default — engine never receives NULL,
+    legacy 315 profiles get [] which means "no UT claimed"."""
+    from app.models import AdmissionProfile
+    col = AdmissionProfile.__table__.columns["priority_object_codes"]
+    assert col.nullable is False
+
+
+def test_priority_object_evidence_is_not_null_with_empty_default() -> None:
+    from app.models import AdmissionProfile
+    col = AdmissionProfile.__table__.columns["priority_object_evidence"]
+    assert col.nullable is False
+
+
+def test_area_resolution_basis_is_nullable() -> None:
+    """Legacy 315 profiles have NULL basis until admin backfill PR7."""
+    from app.models import AdmissionProfile
+    col = AdmissionProfile.__table__.columns["area_resolution_basis"]
+    assert col.nullable is True
+
+
+# ---------------------------------------------------------------------------
+# AdmissionProfileChoice — 3 snapshot columns (Q-P3-11 pattern)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "priority_area_bonus_snapshot",
+        "priority_object_bonus_snapshot",
+        "priority_config_snapshot",
+    ],
+)
+def test_admission_profile_choice_has_snapshot_column(column: str) -> None:
+    from app.models import AdmissionProfileChoice
+    assert column in AdmissionProfileChoice.__table__.columns, (
+        f"AdmissionProfileChoice missing column {column!r}"
+    )
+
+
+def test_bonus_snapshot_columns_use_numeric_4_2() -> None:
+    """Match the existing Q-P3-11 bonus_rule_snapshot semantic — precision
+    (4, 2) matches priority_area_config / priority_object_config rates."""
+    from app.models import AdmissionProfileChoice
+    for col_name in (
+        "priority_area_bonus_snapshot",
+        "priority_object_bonus_snapshot",
+    ):
+        col = AdmissionProfileChoice.__table__.columns[col_name]
+        assert col.type.precision == 4
+        assert col.type.scale == 2
+        assert col.nullable is True
+
+
+def test_priority_config_snapshot_is_jsonb() -> None:
+    from app.models import AdmissionProfileChoice
+    from sqlalchemy.dialects.postgresql import JSONB
+    col = AdmissionProfileChoice.__table__.columns["priority_config_snapshot"]
+    assert isinstance(col.type, JSONB)
+    assert col.nullable is True

--- a/Backend_FastAPI/tests/unit/test_admission_profile_priority_columns.py
+++ b/Backend_FastAPI/tests/unit/test_admission_profile_priority_columns.py
@@ -1,9 +1,11 @@
-"""ORM smoke tests for Q9 #07 PR1 — verifies new columns are wired on
-``AdmissionProfile`` and ``AdmissionProfileChoice`` models.
+"""ORM smoke tests for Q9 #07 PR5 v1.3 priority columns on AdmissionProfile.
 
-Catches "I added the alembic migration but forgot to update the ORM"
-regressions before they surface as runtime AttributeError in the
-service layer.
+Replaces PR1 phase1_08b column tests (high_school_id / kv_resolved /
+area_resolution_reason — DROPPED in phase1_09). Locks the 2-field
+parallel design (cultural_education_level + vocational_qualification)
+plus priority_resolution_snapshot JSONB.
+
+See Documents/Q9_07_PR5_REDESIGN.md v1.3 cho rationale.
 """
 from __future__ import annotations
 
@@ -11,44 +13,77 @@ import pytest
 
 
 # ---------------------------------------------------------------------------
-# AdmissionProfile — 7 new columns
+# AdmissionProfile — phase1_09 columns
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
     "column",
     [
-        "high_school_id",
-        "high_school_kv_resolved",
+        # v1.3 phase1_09 — 2-field parallel
+        "cultural_education_level",
+        "vocational_qualification",
+        "priority_resolution_snapshot",
+        # Kept from PR1 (still valid)
         "permanent_commune_code",
         "area_resolution_basis",
-        "area_resolution_reason",
         "priority_object_codes",
         "priority_object_evidence",
     ],
 )
-def test_admission_profile_has_column(column: str) -> None:
+def test_admission_profile_has_priority_column(column: str) -> None:
     from app.models import AdmissionProfile
     assert column in AdmissionProfile.__table__.columns, (
         f"AdmissionProfile missing column {column!r}"
     )
 
 
-def test_high_school_id_is_fk_with_restrict() -> None:
-    """RESTRICT prevents hard DELETE on vn_high_school while a profile
-    references it — admin must use is_active=false soft-delete."""
+@pytest.mark.parametrize(
+    "dropped_column",
+    [
+        # phase1_09 DROPPED these PR1 placeholders (empty, no data)
+        "high_school_id",
+        "high_school_kv_resolved",
+        "area_resolution_reason",
+    ],
+)
+def test_admission_profile_dropped_columns_gone(dropped_column: str) -> None:
+    """phase1_09 dropped these columns — schema regression check."""
     from app.models import AdmissionProfile
-    col = AdmissionProfile.__table__.columns["high_school_id"]
-    fks = list(col.foreign_keys)
-    assert len(fks) == 1
-    fk = fks[0]
-    assert fk.column.table.name == "vn_high_school"
-    assert fk.ondelete == "RESTRICT"
+    assert dropped_column not in AdmissionProfile.__table__.columns, (
+        f"AdmissionProfile should NOT have column {dropped_column!r} "
+        f"(dropped in phase1_09 redesign)."
+    )
+
+
+def test_cultural_education_level_is_nullable() -> None:
+    """Nullable cho draft state; service-layer validation tại submit T1."""
+    from app.models import AdmissionProfile
+    col = AdmissionProfile.__table__.columns["cultural_education_level"]
+    assert col.nullable is True
+
+
+def test_vocational_qualification_not_null_with_default() -> None:
+    """NOT NULL DEFAULT 'none' — auto fill legacy + new profiles."""
+    from app.models import AdmissionProfile
+    col = AdmissionProfile.__table__.columns["vocational_qualification"]
+    assert col.nullable is False
+    # Server default 'none' present
+    assert col.server_default is not None
+
+
+def test_priority_resolution_snapshot_is_jsonb_not_null_with_default() -> None:
+    """Frozen KV resolution — NOT NULL DEFAULT '{}'::jsonb (Q-P3-11 pattern)."""
+    from sqlalchemy.dialects.postgresql import JSONB
+
+    from app.models import AdmissionProfile
+    col = AdmissionProfile.__table__.columns["priority_resolution_snapshot"]
+    assert col.nullable is False
+    assert isinstance(col.type, JSONB)
 
 
 def test_priority_object_codes_is_not_null_with_empty_default() -> None:
-    """NOT NULL with empty JSONB default — engine never receives NULL,
-    legacy 315 profiles get [] which means "no UT claimed"."""
+    """Kept from PR1 — engine never receives NULL JSONB."""
     from app.models import AdmissionProfile
     col = AdmissionProfile.__table__.columns["priority_object_codes"]
     assert col.nullable is False
@@ -61,14 +96,14 @@ def test_priority_object_evidence_is_not_null_with_empty_default() -> None:
 
 
 def test_area_resolution_basis_is_nullable() -> None:
-    """Legacy 315 profiles have NULL basis until admin backfill PR7."""
+    """Legacy 315 profiles + new draft state have NULL basis until set."""
     from app.models import AdmissionProfile
     col = AdmissionProfile.__table__.columns["area_resolution_basis"]
     assert col.nullable is True
 
 
 # ---------------------------------------------------------------------------
-# AdmissionProfileChoice — 3 snapshot columns (Q-P3-11 pattern)
+# AdmissionProfileChoice — snapshot columns (unchanged from PR1)
 # ---------------------------------------------------------------------------
 
 
@@ -88,8 +123,7 @@ def test_admission_profile_choice_has_snapshot_column(column: str) -> None:
 
 
 def test_bonus_snapshot_columns_use_numeric_4_2() -> None:
-    """Match the existing Q-P3-11 bonus_rule_snapshot semantic — precision
-    (4, 2) matches priority_area_config / priority_object_config rates."""
+    """Match Q-P3-11 bonus_rule_snapshot precision."""
     from app.models import AdmissionProfileChoice
     for col_name in (
         "priority_area_bonus_snapshot",
@@ -102,8 +136,53 @@ def test_bonus_snapshot_columns_use_numeric_4_2() -> None:
 
 
 def test_priority_config_snapshot_is_jsonb() -> None:
-    from app.models import AdmissionProfileChoice
     from sqlalchemy.dialects.postgresql import JSONB
+
+    from app.models import AdmissionProfileChoice
     col = AdmissionProfileChoice.__table__.columns["priority_config_snapshot"]
     assert isinstance(col.type, JSONB)
     assert col.nullable is True
+
+
+# ---------------------------------------------------------------------------
+# CHECK constraint mirror (M2 fix preserved + phase1_09 new CHECKs)
+# ---------------------------------------------------------------------------
+
+
+def test_admission_profile_has_cultural_check() -> None:
+    """phase1_09 CHECK enforces 5 cultural_education_level enum values."""
+    from sqlalchemy import CheckConstraint
+
+    from app.models import AdmissionProfile
+
+    checks = [
+        c for c in AdmissionProfile.__table__.constraints
+        if isinstance(c, CheckConstraint)
+        and c.name == "ck_admission_profile_cultural_education_level"
+    ]
+    assert len(checks) == 1, (
+        "Missing CHECK constraint ck_admission_profile_cultural_education_level"
+    )
+    sql = str(checks[0].sqltext)
+    for value in (
+        "completed_thcs", "graduated_thcs",
+        "completed_thpt", "graduated_thpt", "graduated_gdtx",
+    ):
+        assert value in sql, f"Enum value {value!r} missing from CHECK SQL"
+
+
+def test_admission_profile_has_vocational_check() -> None:
+    """phase1_09 CHECK enforces 4 vocational_qualification enum values."""
+    from sqlalchemy import CheckConstraint
+
+    from app.models import AdmissionProfile
+
+    checks = [
+        c for c in AdmissionProfile.__table__.constraints
+        if isinstance(c, CheckConstraint)
+        and c.name == "ck_admission_profile_vocational_qualification"
+    ]
+    assert len(checks) == 1
+    sql = str(checks[0].sqltext)
+    for value in ("none", "so_cap", "trung_cap", "cao_dang"):
+        assert value in sql, f"Enum value {value!r} missing from CHECK SQL"

--- a/Backend_FastAPI/tests/unit/test_admission_update_priority_fields.py
+++ b/Backend_FastAPI/tests/unit/test_admission_update_priority_fields.py
@@ -1,557 +1,290 @@
-"""Anchor test for W11-BE.F.7 BLOCKER fix.
+"""Tests cho Q9 #07 PR5 v1.3 PUT /api/admissions/{id} priority fields.
 
-PUT /api/admissions/{id} must persist the 7 priority bonus fields.
-Before this fix, AdmissionProfileUpdate schema didn't declare them →
-router silently dropped them → engine evaluate_cascade saw NULL → 0đ
-bonus on every profile → CR-P0 decision-flip logic dormant.
+Replaces PR1 phase1_08b tests (high_school_id / kv_resolved /
+area_resolution_reason — DROPPED in phase1_09). Locks 2-field parallel
+design (cultural_education_level + vocational_qualification).
 
-The test exercises the contract end-to-end through the actual PUT
-endpoint so a regression in either the schema OR the service set-
-statements is caught before deploy.
+Coverage:
+* Schema-level: Pydantic enum validation cho 2 new fields
+* H1 cross-field: basis='permanent_address_special' requires commune_code
+* Dropped fields: legacy field names no longer in schema
+* Field validator: empty_str_to_none for new fields
+* Realistic matrix combinations
 """
 from __future__ import annotations
 
-import random
-from datetime import datetime, timezone
-
 import pytest
-from httpx import AsyncClient
-
-from app import models
-from app.database import AsyncSessionLocal
 
 
-pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+pytestmark = pytest.mark.unit
 
 
-# Helpers — minimal copies from tests/services/test_admission_service_strict.py
-# kept inline so this anchor doesn't depend on relocations of shared test code.
-async def get_auth_headers(client: AsyncClient, user_info: dict) -> dict:
-    res = await client.post(
-        "/api/auth/login",
-        data={"username": user_info["username"], "password": user_info["password"]},
-    )
-    assert res.status_code == 200, f"Login failed: {res.text}"
-    access_token = res.cookies.get("access_token")
-    client.cookies.delete("access_token")
-    return {"Authorization": f"Bearer {access_token}"}
+# ---------------------------------------------------------------------------
+# Pydantic Update schema — cultural_education_level enum
+# ---------------------------------------------------------------------------
 
 
-async def setup_admission_api_data(
-    major_id: int, unit_id: int, officer_id: int, academic_year: int = 2026,
-) -> dict:
-    """Build minimal admission chain (offering → academic_info → method →
-    criteria → path → document_group → lead) so the POST endpoint can
-    create a draft profile against it."""
-    async with AsyncSessionLocal() as session:
-        async with session.begin():
-            ot = models.ConfigOfferingType(
-                code=f"f7_type_{random.randint(10000, 99999)}",
-                name="F7 Test", is_active=True,
-            )
-            session.add(ot)
-            await session.flush()
-            offering = models.ProgramOffering(
-                offering_type=f"F7_{random.randint(10000, 99999)}",
-                program_id=major_id, offering_type_id=ot.id,
-            )
-            session.add(offering)
-            await session.flush()
-            academic_info = models.OfferingAcademicInfo(
-                offering_id=offering.id, academic_year=academic_year,
-                is_published=True,
-            )
-            session.add(academic_info)
-            await session.flush()
-            method = models.AdmissionMethod(
-                code=f"f7_method_{random.randint(10000, 99999)}",
-                name="F7 Method", is_active=True,
-            )
-            session.add(method)
-            await session.flush()
-            criteria = models.AdmissionCriteria(
-                method_id=method.id,
-                code=f"f7_crit_{random.randint(10000, 99999)}",
-                name="F7 Crit", min_gpa=0, is_active=True,
-            )
-            session.add(criteria)
-            await session.flush()
-            from tests.fixtures.builders import AdmissionRoundBuilder
-            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
-                session, academic_year=academic_year,
-            )
-            path = models.AdmissionPath(
-                academic_info_id=academic_info.id,
-                admission_method_id=method.id,
-                admission_round_id=round_id,
-                criteria_id=criteria.id, status="active",
-            )
-            session.add(path)
-            await session.flush()
-            lead = models.Lead(
-                full_name="F7 Test Candidate",
-                phone=f"09{random.randint(10000000, 99999999)}",
-                email=f"f7_{random.randint(10000, 99999)}@test.local",
-                source="website",
-                unit_id=unit_id,
-                offering_id=offering.id,
-                assigned_officer_id=officer_id,
-            )
-            session.add(lead)
-            await session.flush()
-            consultation = models.Consultation(
-                lead_id=lead.id,
-                consultation_date=datetime.now(timezone.utc),
-                method="phone",
-                notes="F7 test consultation",
-                officer_id=officer_id,
-                consultation_status_id="sts06",
-            )
-            session.add(consultation)
-            await session.flush()
-            return {
-                "lead_id": lead.id,
-                "admission_method_id": method.id,
-                "academic_info_id": academic_info.id,
-            }
+@pytest.mark.parametrize(
+    "valid_value",
+    [
+        "completed_thcs",
+        "graduated_thcs",
+        "completed_thpt",
+        "graduated_thpt",
+        "graduated_gdtx",
+    ],
+)
+def test_cultural_education_level_accepts_5_canonical_values(valid_value: str) -> None:
+    """phase1_09 enum: 5 trình độ văn hóa values per Luật GDNN + TT 05/2021."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    obj = AdmissionProfileUpdate(version=1, cultural_education_level=valid_value)
+    assert obj.cultural_education_level == valid_value
 
 
-async def test_put_persists_all_seven_priority_fields(
-    client: AsyncClient,
-    officer_user_in_db: dict,
-    seed_lead_dependencies: dict,
-) -> None:
-    """PUT with the full priority field set — verify all 7 columns
-    persist (not silently dropped by schema)."""
-    unit_id = seed_lead_dependencies["unit_id"]
-    major_id = seed_lead_dependencies["major_program_id"]
-    data = await setup_admission_api_data(
-        major_id=major_id,
-        unit_id=unit_id,
-        officer_id=officer_user_in_db["id"],
-        academic_year=2026,
-    )
-    headers = await get_auth_headers(client, officer_user_in_db)
-
-    create_response = await client.post(
-        "/api/admissions",
-        json={
-            "lead_id": data["lead_id"],
-            "admission_method_id": data["admission_method_id"],
-        },
-        headers=headers,
-    )
-    assert create_response.status_code == 201, create_response.text
-    profile_id = create_response.json()["id"]
-
-    # PUT with the full priority field set
-    update_payload = {
-        "version": 1,
-        "high_school_kv_resolved": "KV1",
-        "permanent_commune_code": "00001",
-        "area_resolution_basis": "manual_override",
-        "area_resolution_reason": "Bố là quân nhân hộ khẩu KV1",
-        "priority_object_codes": ["04", "06"],
-        "priority_object_evidence": {
-            "04": {"document_id": 123, "status": "pending"},
-            "06": {"document_id": 456, "status": "pending"},
-        },
-    }
-    response = await client.put(
-        f"/api/admissions/{profile_id}",
-        json=update_payload,
-        headers=headers,
-    )
-    assert response.status_code == 200, (
-        f"PUT failed: {response.status_code} — {response.text}. "
-        f"If 422 about unknown fields, AdmissionProfileUpdate schema "
-        f"regressed (W11-BE.F.7)."
-    )
-
-    # Re-fetch profile and assert all 7 columns persisted
-    get_response = await client.get(
-        f"/api/admissions/{profile_id}", headers=headers,
-    )
-    assert get_response.status_code == 200
-    body = get_response.json()
-
-    assert body["high_school_kv_resolved"] == "KV1"
-    assert body["permanent_commune_code"] == "00001"
-    assert body["area_resolution_basis"] == "manual_override"
-    assert body["area_resolution_reason"] == "Bố là quân nhân hộ khẩu KV1"
-    assert body["priority_object_codes"] == ["04", "06"]
-    assert body["priority_object_evidence"]["04"]["document_id"] == 123
-    assert body["priority_object_evidence"]["06"]["status"] == "pending"
-
-
-async def test_put_omitted_priority_fields_preserve_existing(
-    client: AsyncClient,
-    officer_user_in_db: dict,
-    seed_lead_dependencies: dict,
-) -> None:
-    """Partial PUT: only some fields touched, others left as-is.
-    Pydantic's optional + service ``if key in data`` semantic means
-    omitted keys do NOT overwrite existing DB values."""
-    unit_id = seed_lead_dependencies["unit_id"]
-    major_id = seed_lead_dependencies["major_program_id"]
-    data = await setup_admission_api_data(
-        major_id=major_id,
-        unit_id=unit_id,
-        officer_id=officer_user_in_db["id"],
-        academic_year=2026,
-    )
-    headers = await get_auth_headers(client, officer_user_in_db)
-
-    create_response = await client.post(
-        "/api/admissions",
-        json={
-            "lead_id": data["lead_id"],
-            "admission_method_id": data["admission_method_id"],
-        },
-        headers=headers,
-    )
-    profile_id = create_response.json()["id"]
-
-    # First PUT: set KV + codes
-    await client.put(
-        f"/api/admissions/{profile_id}",
-        json={
-            "version": 1,
-            "high_school_kv_resolved": "KV1",
-            "priority_object_codes": ["04"],
-        },
-        headers=headers,
-    )
-
-    # Second PUT: change only the reason; KV + codes must stay
-    response = await client.put(
-        f"/api/admissions/{profile_id}",
-        json={
-            "version": 2,
-            "area_resolution_reason": "Updated reason",
-        },
-        headers=headers,
-    )
-    assert response.status_code == 200, response.text
-
-    body = (await client.get(
-        f"/api/admissions/{profile_id}", headers=headers,
-    )).json()
-    assert body["high_school_kv_resolved"] == "KV1"  # preserved
-    assert body["priority_object_codes"] == ["04"]   # preserved
-    assert body["area_resolution_reason"] == "Updated reason"  # changed
-
-
-async def test_put_rejects_invalid_kv_code_format(
-    client: AsyncClient,
-    officer_user_in_db: dict,
-    seed_lead_dependencies: dict,
-) -> None:
-    """Pydantic regex on high_school_kv_resolved rejects 'KV2_NT'
-    (underscore) — only canonical 'KV2-NT' (hyphen) per TT 05/2021."""
-    unit_id = seed_lead_dependencies["unit_id"]
-    major_id = seed_lead_dependencies["major_program_id"]
-    data = await setup_admission_api_data(
-        major_id=major_id,
-        unit_id=unit_id,
-        officer_id=officer_user_in_db["id"],
-        academic_year=2026,
-    )
-    headers = await get_auth_headers(client, officer_user_in_db)
-    create_response = await client.post(
-        "/api/admissions",
-        json={
-            "lead_id": data["lead_id"],
-            "admission_method_id": data["admission_method_id"],
-        },
-        headers=headers,
-    )
-    profile_id = create_response.json()["id"]
-
-    response = await client.put(
-        f"/api/admissions/{profile_id}",
-        json={"version": 1, "high_school_kv_resolved": "KV2_NT"},
-        headers=headers,
-    )
-    assert response.status_code == 422, response.text
-
-
-async def test_put_rejects_invalid_area_resolution_basis(
-    client: AsyncClient,
-    officer_user_in_db: dict,
-    seed_lead_dependencies: dict,
-) -> None:
-    """Pydantic enum-like regex on area_resolution_basis rejects
-    'highschool' typo. Only 3 canonical values accepted."""
-    unit_id = seed_lead_dependencies["unit_id"]
-    major_id = seed_lead_dependencies["major_program_id"]
-    data = await setup_admission_api_data(
-        major_id=major_id,
-        unit_id=unit_id,
-        officer_id=officer_user_in_db["id"],
-        academic_year=2026,
-    )
-    headers = await get_auth_headers(client, officer_user_in_db)
-    create_response = await client.post(
-        "/api/admissions",
-        json={
-            "lead_id": data["lead_id"],
-            "admission_method_id": data["admission_method_id"],
-        },
-        headers=headers,
-    )
-    profile_id = create_response.json()["id"]
-
-    response = await client.put(
-        f"/api/admissions/{profile_id}",
-        json={"version": 1, "area_resolution_basis": "highschool"},
-        headers=headers,
-    )
-    assert response.status_code == 422, response.text
-
-
-# =============================================================================
-# Review-2 hardening: H1 cross-field + M1 codes regex + M2 evidence shape
-# These tests probe the schema directly (no HTTP round-trip needed) since
-# they exercise Pydantic validation, not service/DB behavior.
-# =============================================================================
-
-
-def test_h1_basis_manual_override_requires_reason() -> None:
-    """H1: basis='manual_override' without reason → ValidationError."""
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        "tot_nghiep_thpt",  # wrong format (VN text instead of enum key)
+        "THPT",  # missing prefix
+        "completed_uni",  # not in enum
+    ],
+)
+def test_cultural_education_level_rejects_invalid(invalid_value: str) -> None:
+    """Pydantic regex pattern enforces 5-value enum."""
     from pydantic import ValidationError
+
     from app.schemas.admission import AdmissionProfileUpdate
 
-    with pytest.raises(ValidationError, match="manual_override"):
-        AdmissionProfileUpdate(version=1, area_resolution_basis="manual_override")
+    with pytest.raises(ValidationError):
+        AdmissionProfileUpdate(version=1, cultural_education_level=invalid_value)
 
 
-def test_h1_basis_manual_override_with_reason_passes() -> None:
-    """H1 happy path: reason present → accepted."""
+def test_empty_string_cultural_converted_to_none() -> None:
+    """Field validator: empty string → None to bypass enum pattern."""
     from app.schemas.admission import AdmissionProfileUpdate
 
-    obj = AdmissionProfileUpdate(
-        version=1,
-        area_resolution_basis="manual_override",
-        area_resolution_reason="Bố là quân nhân hộ khẩu KV1",
-    )
-    assert obj.area_resolution_basis == "manual_override"
+    obj = AdmissionProfileUpdate(version=1, cultural_education_level="")
+    assert obj.cultural_education_level is None
 
 
-def test_h1_basis_high_school_requires_id_or_kv() -> None:
-    """H1: basis='high_school' without high_school_id AND without
-    high_school_kv_resolved → ValidationError."""
+# ---------------------------------------------------------------------------
+# Pydantic Update schema — vocational_qualification enum
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "valid_value",
+    ["none", "so_cap", "trung_cap", "cao_dang"],
+)
+def test_vocational_qualification_accepts_4_canonical_values(valid_value: str) -> None:
+    """phase1_09 enum: 4 trình độ chuyên môn values."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    obj = AdmissionProfileUpdate(version=1, vocational_qualification=valid_value)
+    assert obj.vocational_qualification == valid_value
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        "trung_cap_nghe",  # extra suffix
+        "TRUNG_CAP",  # uppercase
+        "dai_hoc",  # not in enum (ĐH out of scope GDNN)
+    ],
+)
+def test_vocational_qualification_rejects_invalid(invalid_value: str) -> None:
     from pydantic import ValidationError
+
     from app.schemas.admission import AdmissionProfileUpdate
 
-    with pytest.raises(ValidationError, match="high_school"):
-        AdmissionProfileUpdate(version=1, area_resolution_basis="high_school")
+    with pytest.raises(ValidationError):
+        AdmissionProfileUpdate(version=1, vocational_qualification=invalid_value)
 
 
-def test_h1_basis_high_school_with_id_only_passes() -> None:
-    """H1: id alone is sufficient (kv_resolved server-derived later)."""
+def test_empty_string_vocational_converted_to_none() -> None:
     from app.schemas.admission import AdmissionProfileUpdate
 
-    obj = AdmissionProfileUpdate(
-        version=1, area_resolution_basis="high_school", high_school_id=42,
-    )
-    assert obj.high_school_id == 42
+    obj = AdmissionProfileUpdate(version=1, vocational_qualification="")
+    assert obj.vocational_qualification is None
 
 
-def test_h1_basis_permanent_address_special_requires_commune_code() -> None:
-    """H1: basis='permanent_address_special' (PT DTNT, quân nhân) requires
-    permanent_commune_code so engine knows which commune to look up."""
+# ---------------------------------------------------------------------------
+# H1 cross-field: basis='permanent_address_special' requires commune_code
+# ---------------------------------------------------------------------------
+
+
+def test_basis_permanent_address_special_requires_commune_code() -> None:
+    """H1 invariant: 4 special cases (PT DTNT / dự bị / quân nhân / xuất ngũ)
+    bypass diploma logic — phải khai permanent_commune_code."""
     from pydantic import ValidationError
+
     from app.schemas.admission import AdmissionProfileUpdate
 
     with pytest.raises(ValidationError, match="permanent_commune_code"):
         AdmissionProfileUpdate(
-            version=1, area_resolution_basis="permanent_address_special",
-        )
-
-
-def test_m1_priority_codes_per_item_regex_rejects_garbage() -> None:
-    """M1: garbage code 'INVALID_99' fails per-item regex ``^[0-9]{2}$``."""
-    from pydantic import ValidationError
-    from app.schemas.admission import AdmissionProfileUpdate
-
-    with pytest.raises(ValidationError):
-        AdmissionProfileUpdate(
-            version=1, priority_object_codes=["INVALID_99"],
-        )
-
-
-def test_m1_priority_codes_accepts_valid_2digit_codes() -> None:
-    """M1 happy path: valid 2-digit codes pass."""
-    from app.schemas.admission import AdmissionProfileUpdate
-
-    obj = AdmissionProfileUpdate(
-        version=1, priority_object_codes=["04", "06"],
-    )
-    assert obj.priority_object_codes == ["04", "06"]
-
-
-def test_m2_evidence_inner_shape_rejects_garbage_dict() -> None:
-    """M2: evidence inner dict without ``status`` key → ValidationError
-    (engine reads status; garbage dict was silently 0đ pre-fix)."""
-    from pydantic import ValidationError
-    from app.schemas.admission import AdmissionProfileUpdate
-
-    with pytest.raises(ValidationError):
-        AdmissionProfileUpdate(
             version=1,
-            priority_object_evidence={"04": {"random": "stuff"}},
+            area_resolution_basis="permanent_address_special",
         )
 
 
-def test_m2_evidence_status_must_be_canonical_enum() -> None:
-    """M2: status must be one of the 3 canonical values."""
-    from pydantic import ValidationError
-    from app.schemas.admission import AdmissionProfileUpdate
-
-    with pytest.raises(ValidationError):
-        AdmissionProfileUpdate(
-            version=1,
-            priority_object_evidence={
-                "04": {"status": "approved_typo"},
-            },
-        )
-
-
-def test_m2_evidence_canonical_shape_passes() -> None:
-    """M2 happy path: full canonical evidence dict accepted."""
+def test_basis_permanent_address_special_with_commune_passes() -> None:
+    """H1 happy path: commune_code present → accepted."""
     from app.schemas.admission import AdmissionProfileUpdate
 
     obj = AdmissionProfileUpdate(
         version=1,
-        priority_object_evidence={
-            "04": {
-                "status": "verified",
-                "document_id": 123,
-                "verified_by": 45,
-            },
-        },
+        area_resolution_basis="permanent_address_special",
+        permanent_commune_code="01001",
     )
-    assert obj.priority_object_evidence["04"].status == "verified"
-    assert obj.priority_object_evidence["04"].document_id == 123
+    assert obj.area_resolution_basis == "permanent_address_special"
+    assert obj.permanent_commune_code == "01001"
 
 
-def test_m_rv2_1_rejected_without_reason_fails() -> None:
-    """m-RV2-1: officer status='rejected' must provide reject_reason
-    so audit trail shows WHY the UT claim was denied."""
-    from pydantic import ValidationError
+def test_basis_high_school_no_payload_validator_check() -> None:
+    """v1.3 change: 'high_school' basis no longer validates supporting field
+    at schema-level (moved to service-layer — needs academic_history context)."""
     from app.schemas.admission import AdmissionProfileUpdate
 
-    with pytest.raises(ValidationError, match="reject_reason"):
-        AdmissionProfileUpdate(
-            version=1,
-            priority_object_evidence={
-                "04": {"status": "rejected"},
-            },
-        )
+    obj = AdmissionProfileUpdate(version=1, area_resolution_basis="high_school")
+    assert obj.area_resolution_basis == "high_school"
 
 
-def test_m_rv2_1_rejected_with_blank_reason_fails() -> None:
-    """m-RV2-1: whitespace-only reason fails (not just truly null)."""
-    from pydantic import ValidationError
+def test_basis_manual_override_no_payload_validator_check() -> None:
+    """v1.3 change: manual_override reason moved to priority_resolution_snapshot
+    (set by admin/officer via separate endpoint, NOT candidate payload)."""
     from app.schemas.admission import AdmissionProfileUpdate
 
-    with pytest.raises(ValidationError, match="reject_reason"):
-        AdmissionProfileUpdate(
-            version=1,
-            priority_object_evidence={
-                "04": {"status": "rejected", "reject_reason": "   "},
-            },
-        )
+    obj = AdmissionProfileUpdate(version=1, area_resolution_basis="manual_override")
+    assert obj.area_resolution_basis == "manual_override"
 
 
-def test_m_rv2_1_rejected_with_reason_passes() -> None:
-    """m-RV2-1 happy path: rejected with reason → accepted."""
+# ---------------------------------------------------------------------------
+# Dropped fields no longer in schema
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dropped_field",
+    [
+        "high_school_id",
+        "high_school_kv_resolved",
+        "area_resolution_reason",
+    ],
+)
+def test_dropped_legacy_fields_not_in_update_schema(dropped_field: str) -> None:
+    """phase1_09 dropped these — Pydantic schema regression check."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    assert dropped_field not in AdmissionProfileUpdate.model_fields, (
+        f"AdmissionProfileUpdate should NOT have field {dropped_field!r} "
+        f"(dropped in phase1_09 redesign)."
+    )
+
+
+@pytest.mark.parametrize(
+    "dropped_field",
+    [
+        "high_school_id",
+        "high_school_kv_resolved",
+        "area_resolution_reason",
+    ],
+)
+def test_dropped_legacy_fields_not_in_response_schema(dropped_field: str) -> None:
+    from app.schemas.admission import AdmissionProfileResponse
+
+    assert dropped_field not in AdmissionProfileResponse.model_fields
+
+
+@pytest.mark.parametrize(
+    "added_field",
+    [
+        "cultural_education_level",
+        "vocational_qualification",
+    ],
+)
+def test_v1_3_fields_in_update_schema(added_field: str) -> None:
+    """phase1_09 added these to Update schema."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    assert added_field in AdmissionProfileUpdate.model_fields
+
+
+@pytest.mark.parametrize(
+    "added_field",
+    [
+        "cultural_education_level",
+        "vocational_qualification",
+        "priority_resolution_snapshot",
+    ],
+)
+def test_v1_3_fields_in_response_schema(added_field: str) -> None:
+    """phase1_09 added these to Response schema.
+    Note: priority_resolution_snapshot in Response only (not Update — server-frozen)."""
+    from app.schemas.admission import AdmissionProfileResponse
+
+    assert added_field in AdmissionProfileResponse.model_fields
+
+
+def test_priority_resolution_snapshot_NOT_in_update_schema() -> None:
+    """Snapshot frozen by service (T1 + T6) — NOT mutable via candidate payload."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    assert "priority_resolution_snapshot" not in AdmissionProfileUpdate.model_fields
+
+
+# ---------------------------------------------------------------------------
+# Realistic combinations from matrix
+# ---------------------------------------------------------------------------
+
+
+def test_typical_cd_candidate_graduated_thpt_no_vocational() -> None:
+    """Row 1 matrix: graduated_thpt + none → THPT multi-school basis."""
     from app.schemas.admission import AdmissionProfileUpdate
 
     obj = AdmissionProfileUpdate(
         version=1,
-        priority_object_evidence={
-            "04": {
-                "status": "rejected",
-                "reject_reason": "Giấy tờ không khớp với hồ sơ gốc",
-                "verified_by": 45,
-            },
-        },
+        cultural_education_level="graduated_thpt",
+        vocational_qualification="none",
     )
-    assert obj.priority_object_evidence["04"].reject_reason
+    assert obj.cultural_education_level == "graduated_thpt"
+    assert obj.vocational_qualification == "none"
 
 
-def test_m_rv2_1_verified_without_verified_by_fails() -> None:
-    """m-RV2-1: officer status='verified' must record verified_by
-    (chain of responsibility for the bonus calculation)."""
-    from pydantic import ValidationError
-    from app.schemas.admission import AdmissionProfileUpdate
-
-    with pytest.raises(ValidationError, match="verified_by"):
-        AdmissionProfileUpdate(
-            version=1,
-            priority_object_evidence={
-                "04": {"status": "verified", "document_id": 123},
-            },
-        )
-
-
-def test_m_rv2_1_pending_allows_minimal_shape() -> None:
-    """m-RV2-1 negative: 'pending' is the initial candidate state and
-    needs neither reason nor verified_by — that's the point of pending."""
+def test_typical_cd_lien_thong_completed_thpt_with_tc() -> None:
+    """Row 2 matrix: completed_thpt + trung_cap → CĐ liên thông eligible."""
     from app.schemas.admission import AdmissionProfileUpdate
 
     obj = AdmissionProfileUpdate(
         version=1,
-        priority_object_evidence={
-            "04": {"status": "pending", "document_id": 123},
-        },
+        cultural_education_level="completed_thpt",
+        vocational_qualification="trung_cap",
     )
-    assert obj.priority_object_evidence["04"].status == "pending"
+    assert obj.cultural_education_level == "completed_thpt"
 
 
-async def test_m3_put_high_school_id_garbage_returns_friendly_400(
-    client: AsyncClient,
-    officer_user_in_db: dict,
-    seed_lead_dependencies: dict,
-) -> None:
-    """M3: garbage high_school_id (no such row) → 400 from service-side
-    FK lookup (QLTS ValidationError maps to 400, not FastAPI's 422)
-    instead of 500 IntegrityError at commit. Friendly message so
-    candidate / admin knows to pick from the dropdown."""
-    unit_id = seed_lead_dependencies["unit_id"]
-    major_id = seed_lead_dependencies["major_program_id"]
-    data = await setup_admission_api_data(
-        major_id=major_id,
-        unit_id=unit_id,
-        officer_id=officer_user_in_db["id"],
-        academic_year=2026,
-    )
-    headers = await get_auth_headers(client, officer_user_in_db)
-    create_response = await client.post(
-        "/api/admissions",
-        json={
-            "lead_id": data["lead_id"],
-            "admission_method_id": data["admission_method_id"],
-        },
-        headers=headers,
-    )
-    profile_id = create_response.json()["id"]
+def test_typical_tc_candidate_graduated_thcs_no_vocational() -> None:
+    """Row 5 matrix: graduated_thcs + none → commune_fallback (TC eligible)."""
+    from app.schemas.admission import AdmissionProfileUpdate
 
-    # Use a huge ID guaranteed to not exist in vn_high_school
-    response = await client.put(
-        f"/api/admissions/{profile_id}",
-        json={
-            "version": 1,
-            "high_school_id": 9999999999,
-            "area_resolution_basis": "high_school",
-            "high_school_kv_resolved": "KV1",  # satisfies H1 basis invariant
-        },
-        headers=headers,
+    obj = AdmissionProfileUpdate(
+        version=1,
+        cultural_education_level="graduated_thcs",
+        vocational_qualification="none",
     )
-    assert response.status_code == 400, (
-        f"Expected 400 for garbage FK (QLTS ValidationError convention), "
-        f"got {response.status_code}. Response: {response.text}"
+    assert obj.cultural_education_level == "graduated_thcs"
+
+
+def test_typical_special_case_dtnt_bypass() -> None:
+    """Row 8 matrix: special case bypass (DTNT) → commune_code path."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    obj = AdmissionProfileUpdate(
+        version=1,
+        cultural_education_level="graduated_thpt",
+        vocational_qualification="none",
+        area_resolution_basis="permanent_address_special",
+        permanent_commune_code="02HG01",  # PT DTNT N'Trang Lơng commune
     )
-    assert "không tồn tại" in response.text or "9999999999" in response.text
+    assert obj.area_resolution_basis == "permanent_address_special"
+    assert obj.permanent_commune_code == "02HG01"

--- a/Backend_FastAPI/tests/unit/test_admission_update_priority_fields.py
+++ b/Backend_FastAPI/tests/unit/test_admission_update_priority_fields.py
@@ -436,6 +436,81 @@ def test_m2_evidence_canonical_shape_passes() -> None:
     assert obj.priority_object_evidence["04"].document_id == 123
 
 
+def test_m_rv2_1_rejected_without_reason_fails() -> None:
+    """m-RV2-1: officer status='rejected' must provide reject_reason
+    so audit trail shows WHY the UT claim was denied."""
+    from pydantic import ValidationError
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    with pytest.raises(ValidationError, match="reject_reason"):
+        AdmissionProfileUpdate(
+            version=1,
+            priority_object_evidence={
+                "04": {"status": "rejected"},
+            },
+        )
+
+
+def test_m_rv2_1_rejected_with_blank_reason_fails() -> None:
+    """m-RV2-1: whitespace-only reason fails (not just truly null)."""
+    from pydantic import ValidationError
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    with pytest.raises(ValidationError, match="reject_reason"):
+        AdmissionProfileUpdate(
+            version=1,
+            priority_object_evidence={
+                "04": {"status": "rejected", "reject_reason": "   "},
+            },
+        )
+
+
+def test_m_rv2_1_rejected_with_reason_passes() -> None:
+    """m-RV2-1 happy path: rejected with reason → accepted."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    obj = AdmissionProfileUpdate(
+        version=1,
+        priority_object_evidence={
+            "04": {
+                "status": "rejected",
+                "reject_reason": "Giấy tờ không khớp với hồ sơ gốc",
+                "verified_by": 45,
+            },
+        },
+    )
+    assert obj.priority_object_evidence["04"].reject_reason
+
+
+def test_m_rv2_1_verified_without_verified_by_fails() -> None:
+    """m-RV2-1: officer status='verified' must record verified_by
+    (chain of responsibility for the bonus calculation)."""
+    from pydantic import ValidationError
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    with pytest.raises(ValidationError, match="verified_by"):
+        AdmissionProfileUpdate(
+            version=1,
+            priority_object_evidence={
+                "04": {"status": "verified", "document_id": 123},
+            },
+        )
+
+
+def test_m_rv2_1_pending_allows_minimal_shape() -> None:
+    """m-RV2-1 negative: 'pending' is the initial candidate state and
+    needs neither reason nor verified_by — that's the point of pending."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    obj = AdmissionProfileUpdate(
+        version=1,
+        priority_object_evidence={
+            "04": {"status": "pending", "document_id": 123},
+        },
+    )
+    assert obj.priority_object_evidence["04"].status == "pending"
+
+
 async def test_m3_put_high_school_id_garbage_returns_friendly_400(
     client: AsyncClient,
     officer_user_in_db: dict,

--- a/Backend_FastAPI/tests/unit/test_admission_update_priority_fields.py
+++ b/Backend_FastAPI/tests/unit/test_admission_update_priority_fields.py
@@ -1,0 +1,310 @@
+"""Anchor test for W11-BE.F.7 BLOCKER fix.
+
+PUT /api/admissions/{id} must persist the 7 priority bonus fields.
+Before this fix, AdmissionProfileUpdate schema didn't declare them →
+router silently dropped them → engine evaluate_cascade saw NULL → 0đ
+bonus on every profile → CR-P0 decision-flip logic dormant.
+
+The test exercises the contract end-to-end through the actual PUT
+endpoint so a regression in either the schema OR the service set-
+statements is caught before deploy.
+"""
+from __future__ import annotations
+
+import random
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+
+from app import models
+from app.database import AsyncSessionLocal
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+# Helpers — minimal copies from tests/services/test_admission_service_strict.py
+# kept inline so this anchor doesn't depend on relocations of shared test code.
+async def get_auth_headers(client: AsyncClient, user_info: dict) -> dict:
+    res = await client.post(
+        "/api/auth/login",
+        data={"username": user_info["username"], "password": user_info["password"]},
+    )
+    assert res.status_code == 200, f"Login failed: {res.text}"
+    access_token = res.cookies.get("access_token")
+    client.cookies.delete("access_token")
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+async def setup_admission_api_data(
+    major_id: int, unit_id: int, officer_id: int, academic_year: int = 2026,
+) -> dict:
+    """Build minimal admission chain (offering → academic_info → method →
+    criteria → path → document_group → lead) so the POST endpoint can
+    create a draft profile against it."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            ot = models.ConfigOfferingType(
+                code=f"f7_type_{random.randint(10000, 99999)}",
+                name="F7 Test", is_active=True,
+            )
+            session.add(ot)
+            await session.flush()
+            offering = models.ProgramOffering(
+                offering_type=f"F7_{random.randint(10000, 99999)}",
+                program_id=major_id, offering_type_id=ot.id,
+            )
+            session.add(offering)
+            await session.flush()
+            academic_info = models.OfferingAcademicInfo(
+                offering_id=offering.id, academic_year=academic_year,
+                is_published=True,
+            )
+            session.add(academic_info)
+            await session.flush()
+            method = models.AdmissionMethod(
+                code=f"f7_method_{random.randint(10000, 99999)}",
+                name="F7 Method", is_active=True,
+            )
+            session.add(method)
+            await session.flush()
+            criteria = models.AdmissionCriteria(
+                method_id=method.id,
+                code=f"f7_crit_{random.randint(10000, 99999)}",
+                name="F7 Crit", min_gpa=0, is_active=True,
+            )
+            session.add(criteria)
+            await session.flush()
+            from tests.fixtures.builders import AdmissionRoundBuilder
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                session, academic_year=academic_year,
+            )
+            path = models.AdmissionPath(
+                academic_info_id=academic_info.id,
+                admission_method_id=method.id,
+                admission_round_id=round_id,
+                criteria_id=criteria.id, status="active",
+            )
+            session.add(path)
+            await session.flush()
+            lead = models.Lead(
+                full_name="F7 Test Candidate",
+                phone=f"09{random.randint(10000000, 99999999)}",
+                email=f"f7_{random.randint(10000, 99999)}@test.local",
+                source="website",
+                unit_id=unit_id,
+                offering_id=offering.id,
+                assigned_officer_id=officer_id,
+            )
+            session.add(lead)
+            await session.flush()
+            consultation = models.Consultation(
+                lead_id=lead.id,
+                consultation_date=datetime.now(timezone.utc),
+                method="phone",
+                notes="F7 test consultation",
+                officer_id=officer_id,
+                consultation_status_id="sts06",
+            )
+            session.add(consultation)
+            await session.flush()
+            return {
+                "lead_id": lead.id,
+                "admission_method_id": method.id,
+                "academic_info_id": academic_info.id,
+            }
+
+
+async def test_put_persists_all_seven_priority_fields(
+    client: AsyncClient,
+    officer_user_in_db: dict,
+    seed_lead_dependencies: dict,
+) -> None:
+    """PUT with the full priority field set — verify all 7 columns
+    persist (not silently dropped by schema)."""
+    unit_id = seed_lead_dependencies["unit_id"]
+    major_id = seed_lead_dependencies["major_program_id"]
+    data = await setup_admission_api_data(
+        major_id=major_id,
+        unit_id=unit_id,
+        officer_id=officer_user_in_db["id"],
+        academic_year=2026,
+    )
+    headers = await get_auth_headers(client, officer_user_in_db)
+
+    create_response = await client.post(
+        "/api/admissions",
+        json={
+            "lead_id": data["lead_id"],
+            "admission_method_id": data["admission_method_id"],
+        },
+        headers=headers,
+    )
+    assert create_response.status_code == 201, create_response.text
+    profile_id = create_response.json()["id"]
+
+    # PUT with the full priority field set
+    update_payload = {
+        "version": 1,
+        "high_school_kv_resolved": "KV1",
+        "permanent_commune_code": "00001",
+        "area_resolution_basis": "manual_override",
+        "area_resolution_reason": "Bố là quân nhân hộ khẩu KV1",
+        "priority_object_codes": ["04", "06"],
+        "priority_object_evidence": {
+            "04": {"document_id": 123, "status": "pending"},
+            "06": {"document_id": 456, "status": "pending"},
+        },
+    }
+    response = await client.put(
+        f"/api/admissions/{profile_id}",
+        json=update_payload,
+        headers=headers,
+    )
+    assert response.status_code == 200, (
+        f"PUT failed: {response.status_code} — {response.text}. "
+        f"If 422 about unknown fields, AdmissionProfileUpdate schema "
+        f"regressed (W11-BE.F.7)."
+    )
+
+    # Re-fetch profile and assert all 7 columns persisted
+    get_response = await client.get(
+        f"/api/admissions/{profile_id}", headers=headers,
+    )
+    assert get_response.status_code == 200
+    body = get_response.json()
+
+    assert body["high_school_kv_resolved"] == "KV1"
+    assert body["permanent_commune_code"] == "00001"
+    assert body["area_resolution_basis"] == "manual_override"
+    assert body["area_resolution_reason"] == "Bố là quân nhân hộ khẩu KV1"
+    assert body["priority_object_codes"] == ["04", "06"]
+    assert body["priority_object_evidence"]["04"]["document_id"] == 123
+    assert body["priority_object_evidence"]["06"]["status"] == "pending"
+
+
+async def test_put_omitted_priority_fields_preserve_existing(
+    client: AsyncClient,
+    officer_user_in_db: dict,
+    seed_lead_dependencies: dict,
+) -> None:
+    """Partial PUT: only some fields touched, others left as-is.
+    Pydantic's optional + service ``if key in data`` semantic means
+    omitted keys do NOT overwrite existing DB values."""
+    unit_id = seed_lead_dependencies["unit_id"]
+    major_id = seed_lead_dependencies["major_program_id"]
+    data = await setup_admission_api_data(
+        major_id=major_id,
+        unit_id=unit_id,
+        officer_id=officer_user_in_db["id"],
+        academic_year=2026,
+    )
+    headers = await get_auth_headers(client, officer_user_in_db)
+
+    create_response = await client.post(
+        "/api/admissions",
+        json={
+            "lead_id": data["lead_id"],
+            "admission_method_id": data["admission_method_id"],
+        },
+        headers=headers,
+    )
+    profile_id = create_response.json()["id"]
+
+    # First PUT: set KV + codes
+    await client.put(
+        f"/api/admissions/{profile_id}",
+        json={
+            "version": 1,
+            "high_school_kv_resolved": "KV1",
+            "priority_object_codes": ["04"],
+        },
+        headers=headers,
+    )
+
+    # Second PUT: change only the reason; KV + codes must stay
+    response = await client.put(
+        f"/api/admissions/{profile_id}",
+        json={
+            "version": 2,
+            "area_resolution_reason": "Updated reason",
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+
+    body = (await client.get(
+        f"/api/admissions/{profile_id}", headers=headers,
+    )).json()
+    assert body["high_school_kv_resolved"] == "KV1"  # preserved
+    assert body["priority_object_codes"] == ["04"]   # preserved
+    assert body["area_resolution_reason"] == "Updated reason"  # changed
+
+
+async def test_put_rejects_invalid_kv_code_format(
+    client: AsyncClient,
+    officer_user_in_db: dict,
+    seed_lead_dependencies: dict,
+) -> None:
+    """Pydantic regex on high_school_kv_resolved rejects 'KV2_NT'
+    (underscore) — only canonical 'KV2-NT' (hyphen) per TT 05/2021."""
+    unit_id = seed_lead_dependencies["unit_id"]
+    major_id = seed_lead_dependencies["major_program_id"]
+    data = await setup_admission_api_data(
+        major_id=major_id,
+        unit_id=unit_id,
+        officer_id=officer_user_in_db["id"],
+        academic_year=2026,
+    )
+    headers = await get_auth_headers(client, officer_user_in_db)
+    create_response = await client.post(
+        "/api/admissions",
+        json={
+            "lead_id": data["lead_id"],
+            "admission_method_id": data["admission_method_id"],
+        },
+        headers=headers,
+    )
+    profile_id = create_response.json()["id"]
+
+    response = await client.put(
+        f"/api/admissions/{profile_id}",
+        json={"version": 1, "high_school_kv_resolved": "KV2_NT"},
+        headers=headers,
+    )
+    assert response.status_code == 422, response.text
+
+
+async def test_put_rejects_invalid_area_resolution_basis(
+    client: AsyncClient,
+    officer_user_in_db: dict,
+    seed_lead_dependencies: dict,
+) -> None:
+    """Pydantic enum-like regex on area_resolution_basis rejects
+    'highschool' typo. Only 3 canonical values accepted."""
+    unit_id = seed_lead_dependencies["unit_id"]
+    major_id = seed_lead_dependencies["major_program_id"]
+    data = await setup_admission_api_data(
+        major_id=major_id,
+        unit_id=unit_id,
+        officer_id=officer_user_in_db["id"],
+        academic_year=2026,
+    )
+    headers = await get_auth_headers(client, officer_user_in_db)
+    create_response = await client.post(
+        "/api/admissions",
+        json={
+            "lead_id": data["lead_id"],
+            "admission_method_id": data["admission_method_id"],
+        },
+        headers=headers,
+    )
+    profile_id = create_response.json()["id"]
+
+    response = await client.put(
+        f"/api/admissions/{profile_id}",
+        json={"version": 1, "area_resolution_basis": "highschool"},
+        headers=headers,
+    )
+    assert response.status_code == 422, response.text

--- a/Backend_FastAPI/tests/unit/test_admission_update_priority_fields.py
+++ b/Backend_FastAPI/tests/unit/test_admission_update_priority_fields.py
@@ -308,3 +308,175 @@ async def test_put_rejects_invalid_area_resolution_basis(
         headers=headers,
     )
     assert response.status_code == 422, response.text
+
+
+# =============================================================================
+# Review-2 hardening: H1 cross-field + M1 codes regex + M2 evidence shape
+# These tests probe the schema directly (no HTTP round-trip needed) since
+# they exercise Pydantic validation, not service/DB behavior.
+# =============================================================================
+
+
+def test_h1_basis_manual_override_requires_reason() -> None:
+    """H1: basis='manual_override' without reason → ValidationError."""
+    from pydantic import ValidationError
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    with pytest.raises(ValidationError, match="manual_override"):
+        AdmissionProfileUpdate(version=1, area_resolution_basis="manual_override")
+
+
+def test_h1_basis_manual_override_with_reason_passes() -> None:
+    """H1 happy path: reason present → accepted."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    obj = AdmissionProfileUpdate(
+        version=1,
+        area_resolution_basis="manual_override",
+        area_resolution_reason="Bố là quân nhân hộ khẩu KV1",
+    )
+    assert obj.area_resolution_basis == "manual_override"
+
+
+def test_h1_basis_high_school_requires_id_or_kv() -> None:
+    """H1: basis='high_school' without high_school_id AND without
+    high_school_kv_resolved → ValidationError."""
+    from pydantic import ValidationError
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    with pytest.raises(ValidationError, match="high_school"):
+        AdmissionProfileUpdate(version=1, area_resolution_basis="high_school")
+
+
+def test_h1_basis_high_school_with_id_only_passes() -> None:
+    """H1: id alone is sufficient (kv_resolved server-derived later)."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    obj = AdmissionProfileUpdate(
+        version=1, area_resolution_basis="high_school", high_school_id=42,
+    )
+    assert obj.high_school_id == 42
+
+
+def test_h1_basis_permanent_address_special_requires_commune_code() -> None:
+    """H1: basis='permanent_address_special' (PT DTNT, quân nhân) requires
+    permanent_commune_code so engine knows which commune to look up."""
+    from pydantic import ValidationError
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    with pytest.raises(ValidationError, match="permanent_commune_code"):
+        AdmissionProfileUpdate(
+            version=1, area_resolution_basis="permanent_address_special",
+        )
+
+
+def test_m1_priority_codes_per_item_regex_rejects_garbage() -> None:
+    """M1: garbage code 'INVALID_99' fails per-item regex ``^[0-9]{2}$``."""
+    from pydantic import ValidationError
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    with pytest.raises(ValidationError):
+        AdmissionProfileUpdate(
+            version=1, priority_object_codes=["INVALID_99"],
+        )
+
+
+def test_m1_priority_codes_accepts_valid_2digit_codes() -> None:
+    """M1 happy path: valid 2-digit codes pass."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    obj = AdmissionProfileUpdate(
+        version=1, priority_object_codes=["04", "06"],
+    )
+    assert obj.priority_object_codes == ["04", "06"]
+
+
+def test_m2_evidence_inner_shape_rejects_garbage_dict() -> None:
+    """M2: evidence inner dict without ``status`` key → ValidationError
+    (engine reads status; garbage dict was silently 0đ pre-fix)."""
+    from pydantic import ValidationError
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    with pytest.raises(ValidationError):
+        AdmissionProfileUpdate(
+            version=1,
+            priority_object_evidence={"04": {"random": "stuff"}},
+        )
+
+
+def test_m2_evidence_status_must_be_canonical_enum() -> None:
+    """M2: status must be one of the 3 canonical values."""
+    from pydantic import ValidationError
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    with pytest.raises(ValidationError):
+        AdmissionProfileUpdate(
+            version=1,
+            priority_object_evidence={
+                "04": {"status": "approved_typo"},
+            },
+        )
+
+
+def test_m2_evidence_canonical_shape_passes() -> None:
+    """M2 happy path: full canonical evidence dict accepted."""
+    from app.schemas.admission import AdmissionProfileUpdate
+
+    obj = AdmissionProfileUpdate(
+        version=1,
+        priority_object_evidence={
+            "04": {
+                "status": "verified",
+                "document_id": 123,
+                "verified_by": 45,
+            },
+        },
+    )
+    assert obj.priority_object_evidence["04"].status == "verified"
+    assert obj.priority_object_evidence["04"].document_id == 123
+
+
+async def test_m3_put_high_school_id_garbage_returns_friendly_400(
+    client: AsyncClient,
+    officer_user_in_db: dict,
+    seed_lead_dependencies: dict,
+) -> None:
+    """M3: garbage high_school_id (no such row) → 400 from service-side
+    FK lookup (QLTS ValidationError maps to 400, not FastAPI's 422)
+    instead of 500 IntegrityError at commit. Friendly message so
+    candidate / admin knows to pick from the dropdown."""
+    unit_id = seed_lead_dependencies["unit_id"]
+    major_id = seed_lead_dependencies["major_program_id"]
+    data = await setup_admission_api_data(
+        major_id=major_id,
+        unit_id=unit_id,
+        officer_id=officer_user_in_db["id"],
+        academic_year=2026,
+    )
+    headers = await get_auth_headers(client, officer_user_in_db)
+    create_response = await client.post(
+        "/api/admissions",
+        json={
+            "lead_id": data["lead_id"],
+            "admission_method_id": data["admission_method_id"],
+        },
+        headers=headers,
+    )
+    profile_id = create_response.json()["id"]
+
+    # Use a huge ID guaranteed to not exist in vn_high_school
+    response = await client.put(
+        f"/api/admissions/{profile_id}",
+        json={
+            "version": 1,
+            "high_school_id": 9999999999,
+            "area_resolution_basis": "high_school",
+            "high_school_kv_resolved": "KV1",  # satisfies H1 basis invariant
+        },
+        headers=headers,
+    )
+    assert response.status_code == 400, (
+        f"Expected 400 for garbage FK (QLTS ValidationError convention), "
+        f"got {response.status_code}. Response: {response.text}"
+    )
+    assert "không tồn tại" in response.text or "9999999999" in response.text

--- a/Backend_FastAPI/tests/unit/test_phase1_08a_rename_bonus.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_08a_rename_bonus.py
@@ -1,0 +1,107 @@
+"""Unit tests for ``phase1_08a_rename_bonus_subject_to_object`` migration.
+
+Q9 #07 PR1 — locks the JSONB key rename contract (defensive migration;
+verified 0 prod rows have the old key on 2026-05-17). Pure-text +
+revision-chain contract tests.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_PHASE1_08A = (
+    _VERSIONS_DIR / "phase1_08a_rename_bonus_subject_to_object.py"
+)
+
+
+def _load_migration(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_08a():
+    return _load_migration(_PHASE1_08A)
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision row + chain
+# ---------------------------------------------------------------------------
+
+
+def test_revision_id_is_phase1_08a(phase1_08a) -> None:
+    assert phase1_08a.revision == "phase1_08a"
+
+
+def test_chains_off_qae2e02(phase1_08a) -> None:
+    """qae2e02 is the current head as of 2026-05-17 (QA E2E migrations
+    appended after phase1_19e). PR1 picks up from there."""
+    assert phase1_08a.down_revision == "qae2e02"
+
+
+# ---------------------------------------------------------------------------
+# 2. Upgrade SQL surface — rename apply_subject_bonus -> apply_object_bonus
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_renames_key_on_admission_method() -> None:
+    src = _PHASE1_08A.read_text(encoding="utf-8")
+    # WHERE clause guards both NULL and missing-key (idempotent)
+    assert "UPDATE admission_method" in src
+    assert "default_bonus_rule IS NOT NULL" in src
+    assert "default_bonus_rule ? 'apply_subject_bonus'" in src
+
+
+def test_upgrade_renames_key_on_admission_path() -> None:
+    src = _PHASE1_08A.read_text(encoding="utf-8")
+    assert "UPDATE admission_path" in src
+    assert "bonus_rule_override IS NOT NULL" in src
+    assert "bonus_rule_override ? 'apply_subject_bonus'" in src
+
+
+def test_upgrade_uses_jsonb_subtract_and_build() -> None:
+    """The expression ``(jsonb - 'old') || jsonb_build_object('new', ...)``
+    is the canonical PG JSONB rename pattern — atomic single-statement
+    rewrite that preserves the value."""
+    src = _PHASE1_08A.read_text(encoding="utf-8")
+    assert "- 'apply_subject_bonus'" in src
+    assert "jsonb_build_object" in src
+    assert "'apply_object_bonus'" in src
+
+
+# ---------------------------------------------------------------------------
+# 3. Downgrade — inverse rename
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_reverses_key_on_both_tables() -> None:
+    src = _PHASE1_08A.read_text(encoding="utf-8")
+    # downgrade strips the new key and re-adds the old
+    assert "- 'apply_object_bonus'" in src
+    # The WHERE guard mirrors upgrade — idempotent
+    assert "? 'apply_object_bonus'" in src
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotency — re-running is a no-op once the key is renamed
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_predicate_is_idempotent_guard() -> None:
+    """The WHERE clause requires the OLD key to be present, so a
+    second upgrade run finds zero rows matching and silently no-ops.
+    Same for downgrade with the new key."""
+    src = _PHASE1_08A.read_text(encoding="utf-8")
+    # Two upgrade UPDATEs, both guarded
+    assert src.count("AND default_bonus_rule ? 'apply_subject_bonus'") == 1
+    assert src.count("AND bonus_rule_override ? 'apply_subject_bonus'") == 1
+    # Two downgrade UPDATEs, both guarded with the inverse predicate
+    assert src.count("AND default_bonus_rule ? 'apply_object_bonus'") == 1
+    assert src.count("AND bonus_rule_override ? 'apply_object_bonus'") == 1

--- a/Backend_FastAPI/tests/unit/test_phase1_08b_priority_schema.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_08b_priority_schema.py
@@ -1,0 +1,194 @@
+"""Unit tests for ``phase1_08b_priority_demographics_gdnn`` migration.
+
+Q9 #07 PR1 — locks the schema contract for 4 new tables + 7 new columns
+on admission_profile + 3 new snapshot columns on admission_profile_choice.
+
+Pure-text contract tests. End-to-end alembic upgrade smoke runs in the
+dev container as part of the verification step.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_PHASE1_08B = _VERSIONS_DIR / "phase1_08b_priority_demographics_gdnn.py"
+
+
+def _load_migration(path: Path):
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def phase1_08b():
+    return _load_migration(_PHASE1_08B)
+
+
+@pytest.fixture
+def src() -> str:
+    return _PHASE1_08B.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision row + chain
+# ---------------------------------------------------------------------------
+
+
+def test_revision_id_is_phase1_08b(phase1_08b) -> None:
+    assert phase1_08b.revision == "phase1_08b"
+
+
+def test_chains_off_phase1_08a(phase1_08b) -> None:
+    assert phase1_08b.down_revision == "phase1_08a"
+
+
+# ---------------------------------------------------------------------------
+# 2. Four new tables ship
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "table",
+    [
+        "priority_area_config",
+        "priority_object_config",
+        "vn_commune_area_map",
+        "vn_high_school",
+    ],
+)
+def test_creates_table(src: str, table: str) -> None:
+    assert f'create_table(\n        "{table}"' in src or f'"{table}"' in src
+    # Ensure drop_table in downgrade
+    assert f'drop_table("{table}")' in src
+
+
+# ---------------------------------------------------------------------------
+# 3. Partial UNIQUE indexes (B1 + M1 fix) — allow temporal history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "index_name",
+    [
+        "uq_priority_area_config_year_code_active",
+        "uq_priority_object_config_year_sub_active",
+        "uq_vn_commune_area_map_code_active",
+    ],
+)
+def test_partial_unique_index(src: str, index_name: str) -> None:
+    """Each "active row" UNIQUE is partial (WHERE effective_to IS NULL)
+    so history rows can coexist — required for mid-year regulation
+    changes and commune-merge events."""
+    assert index_name in src
+
+
+def test_partial_unique_uses_effective_to_null_predicate(src: str) -> None:
+    # Pattern repeated for 3 partial UNIQUEs above
+    assert src.count('postgresql_where=sa.text("effective_to IS NULL")') >= 3
+
+
+# ---------------------------------------------------------------------------
+# 4. CHECK regex (M2 fix) — catch typos at DB layer
+# ---------------------------------------------------------------------------
+
+
+def test_area_code_check_regex_uses_hyphen_canonical(src: str) -> None:
+    """Canonical KV2-NT (hyphen) per TT 05/2021 Phụ lục 01 text —
+    NOT KV2_NT (underscore). Regex must enforce hyphen form."""
+    assert "'^KV[1-9](-NT)?$'" in src
+    assert "ck_priority_area_config_area_code_format" in src
+    assert "ck_vn_commune_area_map_area_code_format" in src
+    assert "ck_vn_high_school_kv_code_format" in src
+
+
+def test_group_code_and_sub_code_regex(src: str) -> None:
+    assert "'^UT[1-9]$'" in src
+    assert "ck_priority_object_config_group_code_format" in src
+    assert "'^[0-9]{2}$'" in src
+    assert "ck_priority_object_config_sub_code_format" in src
+
+
+# ---------------------------------------------------------------------------
+# 5. Soft-delete pattern (M3 fix) on vn_high_school
+# ---------------------------------------------------------------------------
+
+
+def test_vn_high_school_has_is_active_default_true(src: str) -> None:
+    assert '"is_active"' in src
+    assert 'server_default=sa.text("true")' in src
+
+
+def test_high_school_id_fk_uses_restrict(src: str) -> None:
+    """RESTRICT prevents hard DELETE while a profile references the row
+    — admin must use is_active=false soft-delete instead. Preserves
+    audit trail for "trường nào cho KV1?" questions years later."""
+    assert 'ondelete="RESTRICT"' in src
+
+
+# ---------------------------------------------------------------------------
+# 6. effective_from default = CURRENT_DATE (M5 fix, not arbitrary epoch)
+# ---------------------------------------------------------------------------
+
+
+def test_effective_from_defaults_to_current_date(src: str) -> None:
+    """4 tables each have effective_from with CURRENT_DATE default."""
+    assert src.count('server_default=sa.text("CURRENT_DATE")') == 4
+
+
+# ---------------------------------------------------------------------------
+# 7. admission_profile — 7 new columns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "high_school_id",
+        "high_school_kv_resolved",
+        "permanent_commune_code",
+        "area_resolution_basis",
+        "area_resolution_reason",
+        "priority_object_codes",
+        "priority_object_evidence",
+    ],
+)
+def test_admission_profile_adds_column(src: str, column: str) -> None:
+    assert f'"{column}"' in src
+    # Downgrade drops each
+    assert f'drop_column("admission_profile", "{column}")' in src
+
+
+def test_priority_object_codes_and_evidence_are_not_null_with_default(
+    src: str,
+) -> None:
+    """m2 fix lock: these 2 cols are NOT NULL with empty JSONB default
+    so engine never receives NULL JSONB."""
+    assert "'[]'::jsonb" in src
+    assert "'{}'::jsonb" in src
+
+
+# ---------------------------------------------------------------------------
+# 8. admission_profile_choice — 3 snapshot columns (Q-P3-11 pattern)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        "priority_area_bonus_snapshot",
+        "priority_object_bonus_snapshot",
+        "priority_config_snapshot",
+    ],
+)
+def test_admission_profile_choice_adds_snapshot_column(
+    src: str, column: str
+) -> None:
+    assert f'"{column}"' in src
+    assert f'drop_column("admission_profile_choice", "{column}")' in src

--- a/Backend_FastAPI/tests/unit/test_priority_bonus_decision_flip.py
+++ b/Backend_FastAPI/tests/unit/test_priority_bonus_decision_flip.py
@@ -1,0 +1,258 @@
+"""CR-P0 anchor test: priority bonus must affect admission decision,
+not just decorate the snapshot columns.
+
+Without this test, future refactors could silently revert to "snapshot
+only" mode (compute the bonus, write the columns, but never feed it
+into _evaluate_single_choice) — which is exactly the bug Q9 #07 CR-P0
+identified in code review.
+
+The test uses a fake calculate_score result so it can construct the
+exact "raw fail / bonus rescue" scenario without needing a full DB
+fixture: raw final_score = 6.5, min_score = 7.0 → fails. Add
+priority_bonus = 2.75 → final_score = 9.25 → passes.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.admission_choice_engine_service import _evaluate_single_choice
+from app.services.admission_scoring_service import (
+    AdmissionScoreResult,
+    DisqualificationReason,
+    ProfileStatus,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_choice_with_scoring(
+    final_score: Decimal, min_score: Decimal, passed: bool
+):
+    """Build a stub choice + profile + monkeypatched calculate_score
+    that returns a deterministic AdmissionScoreResult so the test can
+    isolate the bonus-apply logic in _evaluate_single_choice."""
+    criteria = SimpleNamespace(
+        code="TEST",
+        min_gpa=None,
+        method="sum",
+        min_score=min_score,
+        min_subject_score=None,
+        selection_mode="fixed",
+        required_count=3,
+    )
+    path = SimpleNamespace(criteria=criteria)
+    # Build scores so _collect_subject_scores returns something truthy;
+    # the actual values don't matter because calculate_score is patched.
+    score_row = SimpleNamespace(
+        subject=SimpleNamespace(code="MATH"),
+        score=Decimal("6.5"),
+    )
+    config = SimpleNamespace(
+        subject_group=SimpleNamespace(
+            subject_mappings=[
+                SimpleNamespace(subject=SimpleNamespace(code="MATH")),
+                SimpleNamespace(subject=SimpleNamespace(code="PHYS")),
+                SimpleNamespace(subject=SimpleNamespace(code="CHEM")),
+            ]
+        ),
+    )
+    choice = SimpleNamespace(
+        admission_path=path,
+        scores=[score_row, score_row, score_row],
+        path_subject_group_config=config,
+    )
+    profile = SimpleNamespace(
+        gpa_overall=Decimal("8.0"),
+        graduation_year=None,
+    )
+
+    score_result = AdmissionScoreResult(
+        status=ProfileStatus.VALID,
+        passed=passed,
+        final_score=final_score,
+        selected_subjects=["MATH", "PHYS", "CHEM"],
+        subject_scores={"MATH": Decimal("6.5")},
+        min_score_threshold=min_score,
+        criteria_code="TEST",
+        failure_reasons=(
+            [f"Điểm {final_score} < điểm chuẩn {min_score}"]
+            if not passed else []
+        ),
+        disqualification_codes=(
+            [DisqualificationReason.BELOW_MIN_SCORE.value]
+            if not passed else []
+        ),
+    )
+    return profile, choice, score_result
+
+
+# ---------------------------------------------------------------------------
+# CR-P0 contract: priority bonus is added to final_score + flips passed
+# ---------------------------------------------------------------------------
+
+
+def test_priority_bonus_flips_decision_from_rejected_to_admitted(
+    monkeypatch,
+) -> None:
+    """Raw 6.5 + min_score 7.0 → would reject. With bonus 2.75 →
+    boosted 9.25 ≥ 7.0 → admit. This is THE test that protects against
+    the bug found in code review (snapshot decorative, decision unchanged)."""
+    profile, choice, fake_result = _make_choice_with_scoring(
+        final_score=Decimal("6.5"),
+        min_score=Decimal("7.0"),
+        passed=False,
+    )
+    monkeypatch.setattr(
+        "app.services.admission_choice_engine_service."
+        "AdmissionScoringService.calculate_score",
+        lambda **kwargs: fake_result,
+    )
+
+    decision, result, _ = _evaluate_single_choice(
+        profile, choice, priority_bonus=Decimal("2.75"),
+    )
+
+    assert decision == "admitted", (
+        "Priority bonus should flip the decision — without this fix the "
+        "Q9 #07 feature is decorative (snapshot writes, decision unchanged)."
+    )
+    assert result.final_score == Decimal("9.25")
+    assert result.passed is True
+
+
+def test_priority_bonus_zero_keeps_raw_decision(monkeypatch) -> None:
+    """When bonus is zero (legacy 315 profiles without backfill), engine
+    falls back to raw-score decision — no spurious admits."""
+    profile, choice, fake_result = _make_choice_with_scoring(
+        final_score=Decimal("6.5"),
+        min_score=Decimal("7.0"),
+        passed=False,
+    )
+    monkeypatch.setattr(
+        "app.services.admission_choice_engine_service."
+        "AdmissionScoringService.calculate_score",
+        lambda **kwargs: fake_result,
+    )
+
+    decision, result, _ = _evaluate_single_choice(
+        profile, choice, priority_bonus=Decimal("0"),
+    )
+
+    assert decision == "rejected"
+    assert result.final_score == Decimal("6.5")
+    assert result.passed is False
+
+
+def test_priority_bonus_still_below_min_keeps_rejected(monkeypatch) -> None:
+    """Raw 4.0 + min 7.0 + bonus 1.0 → boosted 5.0 still < 7.0.
+    Decision stays rejected; final_score updated to boosted value for
+    audit transparency."""
+    profile, choice, fake_result = _make_choice_with_scoring(
+        final_score=Decimal("4.0"),
+        min_score=Decimal("7.0"),
+        passed=False,
+    )
+    monkeypatch.setattr(
+        "app.services.admission_choice_engine_service."
+        "AdmissionScoringService.calculate_score",
+        lambda **kwargs: fake_result,
+    )
+
+    decision, result, _ = _evaluate_single_choice(
+        profile, choice, priority_bonus=Decimal("1.0"),
+    )
+
+    assert decision == "rejected"
+    assert result.final_score == Decimal("5.0")
+    assert result.passed is False
+    # BELOW_MIN_SCORE stays since boosted still fails
+    assert DisqualificationReason.BELOW_MIN_SCORE.value in result.disqualification_codes
+
+
+def test_priority_bonus_above_min_clears_disqualification_codes(
+    monkeypatch,
+) -> None:
+    """When bonus rescues a fail, the BELOW_MIN_SCORE disqualification
+    code + matching failure_reason are removed so the audit trail
+    accurately shows 'raw fail + bonus rescue', not 'fail then admit'."""
+    profile, choice, fake_result = _make_choice_with_scoring(
+        final_score=Decimal("6.5"),
+        min_score=Decimal("7.0"),
+        passed=False,
+    )
+    monkeypatch.setattr(
+        "app.services.admission_choice_engine_service."
+        "AdmissionScoringService.calculate_score",
+        lambda **kwargs: fake_result,
+    )
+
+    _, result, reason_codes = _evaluate_single_choice(
+        profile, choice, priority_bonus=Decimal("1.0"),
+    )
+
+    assert (
+        DisqualificationReason.BELOW_MIN_SCORE.value
+        not in result.disqualification_codes
+    )
+    assert not any("điểm chuẩn" in r.lower() for r in result.failure_reasons)
+
+
+def test_already_passing_with_bonus_increases_final_score(monkeypatch) -> None:
+    """Candidate passes WITHOUT bonus but still has priority codes —
+    bonus still gets added to final_score (audit transparency + ranking
+    fairness in waitlist scenarios)."""
+    profile, choice, fake_result = _make_choice_with_scoring(
+        final_score=Decimal("8.0"),
+        min_score=Decimal("7.0"),
+        passed=True,
+    )
+    monkeypatch.setattr(
+        "app.services.admission_choice_engine_service."
+        "AdmissionScoringService.calculate_score",
+        lambda **kwargs: fake_result,
+    )
+
+    decision, result, _ = _evaluate_single_choice(
+        profile, choice, priority_bonus=Decimal("0.75"),
+    )
+
+    assert decision == "admitted"
+    assert result.final_score == Decimal("8.75")
+    assert result.passed is True
+
+
+def test_invalid_status_bonus_not_applied(monkeypatch) -> None:
+    """If raw scoring returned INVALID (missing data, gate fail),
+    bonus is NOT applied — INVALID is a structural reject, not a
+    score threshold issue."""
+    profile, choice, _ = _make_choice_with_scoring(
+        final_score=Decimal("6.5"),
+        min_score=Decimal("7.0"),
+        passed=False,
+    )
+    invalid_result = AdmissionScoreResult(
+        status=ProfileStatus.INVALID,
+        passed=False,
+        final_score=None,  # INVALID never has a score
+        selected_subjects=[],
+        subject_scores={},
+        min_score_threshold=None,
+        criteria_code="TEST",
+    )
+    monkeypatch.setattr(
+        "app.services.admission_choice_engine_service."
+        "AdmissionScoringService.calculate_score",
+        lambda **kwargs: invalid_result,
+    )
+
+    decision, result, _ = _evaluate_single_choice(
+        profile, choice, priority_bonus=Decimal("2.75"),
+    )
+
+    assert decision == "rejected"
+    assert result.final_score is None
+    assert result.passed is False

--- a/Backend_FastAPI/tests/unit/test_priority_check_constraints.py
+++ b/Backend_FastAPI/tests/unit/test_priority_check_constraints.py
@@ -1,0 +1,110 @@
+"""ORM CHECK constraint mirror tests (Q9 #07 PR1 review fix M-CR-2).
+
+Test DB uses ``Base.metadata.create_all()`` (memory test-db-schema-source)
+and therefore picks up CHECK constraints declared in
+``__table_args__`` — NOT those declared only in alembic migrations.
+This file locks the parity so a future drift between migration CHECK
+and ORM CHECK surfaces here instead of leaking to prod.
+
+Each test inspects the model's __table__.constraints list and asserts
+the named CheckConstraint is present with the expected SQL text. Pure
+metadata inspection — no DB session required, so the test is cheap
+and deterministic.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+import pytest
+from sqlalchemy import CheckConstraint
+
+
+def _check_constraint_sql(table, name: str) -> str:
+    """Return the SQL text of a named CheckConstraint, or raise."""
+    matches = [
+        c for c in table.constraints
+        if isinstance(c, CheckConstraint) and c.name == name
+    ]
+    assert matches, f"CheckConstraint {name!r} not found on {table.name}"
+    return str(matches[0].sqltext)
+
+
+@pytest.mark.parametrize(
+    "model_name, constraint_name, expected_sql_fragment",
+    [
+        (
+            "PriorityAreaConfig",
+            "ck_priority_area_config_area_code_format",
+            "KV[1-9](-NT)?",
+        ),
+        (
+            "PriorityObjectConfig",
+            "ck_priority_object_config_group_code_format",
+            "UT[1-9]",
+        ),
+        (
+            "PriorityObjectConfig",
+            "ck_priority_object_config_sub_code_format",
+            "[0-9]{2}",
+        ),
+        (
+            "VnCommuneAreaMap",
+            "ck_vn_commune_area_map_area_code_format",
+            "KV[1-9](-NT)?",
+        ),
+        (
+            "VnHighSchool",
+            "ck_vn_high_school_kv_code_format",
+            "KV[1-9](-NT)?",
+        ),
+    ],
+)
+def test_orm_mirrors_migration_check(
+    model_name: str, constraint_name: str, expected_sql_fragment: str
+) -> None:
+    """The 5 CHECK regex defined in phase1_08b migration must be
+    mirrored in the ORM __table_args__ so test DB picks them up via
+    Base.metadata.create_all()."""
+    import app.models as m
+    model = getattr(m, model_name)
+    sql = _check_constraint_sql(model.__table__, constraint_name)
+    assert expected_sql_fragment in sql, (
+        f"{model_name}.{constraint_name} SQL missing fragment "
+        f"{expected_sql_fragment!r} — got: {sql!r}"
+    )
+
+
+def test_admission_profile_has_area_resolution_basis_check() -> None:
+    """m-CR-3 fix: enum-like CHECK on area_resolution_basis catches
+    typos at DB layer (vd: 'highschool' vs 'high_school')."""
+    from app.models import AdmissionProfile
+    sql = _check_constraint_sql(
+        AdmissionProfile.__table__,
+        "ck_admission_profile_area_resolution_basis",
+    )
+    # Verify all 3 enum values are listed
+    for value in ("high_school", "permanent_address_special", "manual_override"):
+        assert value in sql, f"enum value {value!r} missing from CHECK SQL"
+
+
+def test_kv_check_excludes_underscore_form() -> None:
+    """Canonical is KV2-NT (hyphen); underscore form 'KV2_NT' must be
+    rejected by the regex. Locks m6 canonical-form decision."""
+    from app.models import PriorityAreaConfig
+    import re
+    sql = _check_constraint_sql(
+        PriorityAreaConfig.__table__,
+        "ck_priority_area_config_area_code_format",
+    )
+    # Strip the SQL operator + quotes to extract just the regex pattern
+    # vd: "area_code ~ '^KV[1-9](-NT)?$'"
+    match = re.search(r"'(\^KV.+\$)'", sql)
+    assert match, f"Couldn't extract regex from SQL: {sql!r}"
+    pattern = match.group(1)
+    # Compile the PG regex (use Python re — slight dialect diff but
+    # core character class + anchor semantics match)
+    py_re = re.compile(pattern)
+    assert py_re.match("KV2-NT"), "Canonical KV2-NT must match"
+    assert not py_re.match("KV2_NT"), "Underscore KV2_NT must be rejected"
+    assert not py_re.match("kv1"), "Lowercase must be rejected"
+    assert not py_re.match("KV1 "), "Trailing space must be rejected"

--- a/Backend_FastAPI/tests/unit/test_priority_check_constraints.py
+++ b/Backend_FastAPI/tests/unit/test_priority_check_constraints.py
@@ -53,9 +53,9 @@ def _check_constraint_sql(table, name: str) -> str:
             "KV[1-9](-NT)?",
         ),
         (
-            "VnHighSchool",
-            "ck_vn_high_school_kv_code_format",
-            "KV[1-9](-NT)?",
+            "VnSchool",  # phase1_09: replaces VnHighSchool with level enum
+            "ck_vn_school_level",
+            "THCS",  # check level enum includes THCS
         ),
     ],
 )

--- a/Backend_FastAPI/tests/unit/test_priority_config_models.py
+++ b/Backend_FastAPI/tests/unit/test_priority_config_models.py
@@ -26,9 +26,12 @@ def test_vn_commune_area_map_model_is_importable() -> None:
     assert VnCommuneAreaMap.__tablename__ == "vn_commune_area_map"
 
 
-def test_vn_high_school_model_is_importable() -> None:
-    from app.models import VnHighSchool
-    assert VnHighSchool.__tablename__ == "vn_high_school"
+def test_vn_school_models_are_importable() -> None:
+    """phase1_09: VnHighSchool DROPPED, replaced by VnSchool family."""
+    from app.models import VnSchool, VnSchoolNameHistory, VnSchoolKvAssignment
+    assert VnSchool.__tablename__ == "vn_school"
+    assert VnSchoolNameHistory.__tablename__ == "vn_school_name_history"
+    assert VnSchoolKvAssignment.__tablename__ == "vn_school_kv_assignment"
 
 
 @pytest.mark.parametrize(
@@ -59,10 +62,28 @@ def test_vn_high_school_model_is_importable() -> None:
             },
         ),
         (
-            "VnHighSchool",
+            "VnSchool",
             {
-                "id", "name", "province", "district", "ward",
-                "kv_code", "is_active", "effective_from", "effective_to",
+                "id", "moet_school_code", "moet_province_code", "moet_district_code",
+                "name", "address", "province", "district", "ward",
+                "level", "is_dtnt", "is_active",
+                "merged_into_id", "merge_effective_date",
+                "created_at", "updated_at",
+            },
+        ),
+        (
+            "VnSchoolNameHistory",
+            {
+                "id", "school_id", "name",
+                "effective_from", "effective_to", "notes", "created_at",
+            },
+        ),
+        (
+            "VnSchoolKvAssignment",
+            {
+                "id", "school_id", "kv_code",
+                "effective_from_year", "effective_to_year",
+                "source", "notes", "created_by", "created_at",
             },
         ),
     ],
@@ -89,11 +110,10 @@ def test_bonus_points_uses_numeric_4_2() -> None:
         assert col.type.scale == 2
 
 
-def test_vn_high_school_is_active_defaults_true() -> None:
-    """Soft-delete flag default — admin "deletes" by flipping to false,
-    FK RESTRICT on admission_profile.high_school_id blocks hard DELETE."""
-    from app.models import VnHighSchool
-    col = VnHighSchool.__table__.columns["is_active"]
+def test_vn_school_is_active_defaults_true() -> None:
+    """phase1_09: VnSchool soft-delete flag is_active (replaces VnHighSchool)."""
+    from app.models import VnSchool
+    col = VnSchool.__table__.columns["is_active"]
     assert col.nullable is False
 
 
@@ -107,6 +127,8 @@ def test_models_are_in_base_metadata() -> None:
         "priority_area_config",
         "priority_object_config",
         "vn_commune_area_map",
-        "vn_high_school",
+        "vn_school",  # phase1_09: replaces vn_high_school
+        "vn_school_name_history",
+        "vn_school_kv_assignment",
     ):
         assert tbl in table_names, f"{tbl} not registered in Base.metadata"

--- a/Backend_FastAPI/tests/unit/test_priority_config_models.py
+++ b/Backend_FastAPI/tests/unit/test_priority_config_models.py
@@ -1,0 +1,112 @@
+"""ORM smoke tests for Q9 #07 PR1 priority config + VN locality models.
+
+Verifies model registration, __tablename__, column attribute presence,
+and Base metadata wiring — catches "I forgot to import the model in
+__init__.py" regressions before alembic autogenerate goes sideways.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+
+def test_priority_area_config_model_is_importable() -> None:
+    from app.models import PriorityAreaConfig
+    assert PriorityAreaConfig.__tablename__ == "priority_area_config"
+
+
+def test_priority_object_config_model_is_importable() -> None:
+    from app.models import PriorityObjectConfig
+    assert PriorityObjectConfig.__tablename__ == "priority_object_config"
+
+
+def test_vn_commune_area_map_model_is_importable() -> None:
+    from app.models import VnCommuneAreaMap
+    assert VnCommuneAreaMap.__tablename__ == "vn_commune_area_map"
+
+
+def test_vn_high_school_model_is_importable() -> None:
+    from app.models import VnHighSchool
+    assert VnHighSchool.__tablename__ == "vn_high_school"
+
+
+@pytest.mark.parametrize(
+    "model_name, expected_columns",
+    [
+        (
+            "PriorityAreaConfig",
+            {
+                "id", "academic_year", "area_code", "area_name",
+                "bonus_points", "description", "effective_from",
+                "effective_to", "created_at", "updated_at",
+            },
+        ),
+        (
+            "PriorityObjectConfig",
+            {
+                "id", "academic_year", "group_code", "sub_code",
+                "description", "bonus_points", "evidence_doc_type",
+                "effective_from", "effective_to", "created_at",
+                "updated_at",
+            },
+        ),
+        (
+            "VnCommuneAreaMap",
+            {
+                "id", "commune_code", "province", "district", "ward",
+                "area_code", "effective_from", "effective_to",
+            },
+        ),
+        (
+            "VnHighSchool",
+            {
+                "id", "name", "province", "district", "ward",
+                "kv_code", "is_active", "effective_from", "effective_to",
+            },
+        ),
+    ],
+)
+def test_model_has_expected_columns(model_name: str, expected_columns: set[str]) -> None:
+    """Lock the column set so renaming/removing a field surfaces here
+    instead of in a runtime SQLAlchemy error."""
+    import app.models as m
+    model = getattr(m, model_name)
+    actual = set(model.__table__.columns.keys())
+    assert expected_columns.issubset(actual), (
+        f"{model_name} missing columns: {expected_columns - actual}"
+    )
+
+
+def test_bonus_points_uses_numeric_4_2() -> None:
+    """Precision (4, 2) matches the migration — supports up to 99.99
+    points which is far above any plausible regulation cap (TT 05/2021
+    max conceivable is 2.75)."""
+    from app.models import PriorityAreaConfig, PriorityObjectConfig
+    for model in (PriorityAreaConfig, PriorityObjectConfig):
+        col = model.__table__.columns["bonus_points"]
+        assert col.type.precision == 4
+        assert col.type.scale == 2
+
+
+def test_vn_high_school_is_active_defaults_true() -> None:
+    """Soft-delete flag default — admin "deletes" by flipping to false,
+    FK RESTRICT on admission_profile.high_school_id blocks hard DELETE."""
+    from app.models import VnHighSchool
+    col = VnHighSchool.__table__.columns["is_active"]
+    assert col.nullable is False
+
+
+def test_models_are_in_base_metadata() -> None:
+    """Final wiring check: alembic autogenerate compares Base.metadata
+    against the live DB. If a model isn't reachable from Base, future
+    autogen runs would silently miss the table."""
+    from app.models import Base
+    table_names = set(Base.metadata.tables.keys())
+    for tbl in (
+        "priority_area_config",
+        "priority_object_config",
+        "vn_commune_area_map",
+        "vn_high_school",
+    ):
+        assert tbl in table_names, f"{tbl} not registered in Base.metadata"

--- a/Backend_FastAPI/tests/unit/test_priority_config_service.py
+++ b/Backend_FastAPI/tests/unit/test_priority_config_service.py
@@ -1,0 +1,288 @@
+"""Unit tests for PriorityConfigService (Q9 #07 PR3).
+
+CRUD + clone-from-year + seed-defaults TT 05/2021. Uses a real test
+DB session via the standard ``db`` fixture so the partial UNIQUE +
+CHECK constraints fire on bad inputs.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.exc import IntegrityError
+
+from app.database import AsyncSessionLocal
+from app.services.priority_config_service import (
+    TT_05_2021_AREA_DEFAULTS,
+    TT_05_2021_OBJECT_DEFAULTS,
+    PriorityConfigService,
+)
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    DuplicateResourceError,
+    ResourceNotFoundError,
+)
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def db(setup_test_database):
+    """Function-scoped async DB session bound to the test DB after the
+    standard ``setup_test_database`` fixture has initialized the schema
+    + truncated rows. Rollback teardown so any partial-state test
+    doesn't leak into next."""
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+        finally:
+            await session.rollback()
+            await session.close()
+
+
+# ---------------------------------------------------------------------------
+# Area CRUD
+# ---------------------------------------------------------------------------
+
+
+async def test_create_area_persists_with_defaults(db) -> None:
+    service = PriorityConfigService(db)
+    row, _cb = await service.create_area(
+        {
+            "academic_year": 2026,
+            "area_code": "KV1",
+            "area_name": "Khu vực 1",
+            "bonus_points": Decimal("0.75"),
+        }
+    )
+    await db.flush()
+    assert row.id is not None
+    assert row.area_code == "KV1"
+    assert row.bonus_points == Decimal("0.75")
+    # Server-side default for effective_from = CURRENT_DATE
+    assert row.effective_from is not None
+
+
+async def test_create_area_duplicate_active_raises(db) -> None:
+    service = PriorityConfigService(db)
+    await service.create_area(
+        {
+            "academic_year": 2026, "area_code": "KV1",
+            "area_name": "KV1", "bonus_points": Decimal("0.75"),
+        }
+    )
+    with pytest.raises(DuplicateResourceError):
+        await service.create_area(
+            {
+                "academic_year": 2026, "area_code": "KV1",
+                "area_name": "KV1 v2", "bonus_points": Decimal("0.50"),
+            }
+        )
+
+
+async def test_create_area_rejects_invalid_code_via_db_check(db) -> None:
+    """CHECK regex on area_code blocks 'KV2_NT' (underscore) — only
+    canonical 'KV2-NT' (hyphen) per TT 05/2021."""
+    service = PriorityConfigService(db)
+    with pytest.raises(IntegrityError):
+        await service.create_area(
+            {
+                "academic_year": 2026, "area_code": "KV2_NT",
+                "area_name": "Bad", "bonus_points": Decimal("0.50"),
+            }
+        )
+        await db.flush()
+
+
+async def test_update_area_patches_bonus_points(db) -> None:
+    service = PriorityConfigService(db)
+    row, _ = await service.create_area(
+        {
+            "academic_year": 2026, "area_code": "KV1",
+            "area_name": "KV1", "bonus_points": Decimal("0.75"),
+        }
+    )
+    updated, _ = await service.update_area(
+        row.id, {"bonus_points": Decimal("0.80")}
+    )
+    assert updated.bonus_points == Decimal("0.80")
+
+
+async def test_update_area_404_when_missing(db) -> None:
+    service = PriorityConfigService(db)
+    with pytest.raises(ResourceNotFoundError):
+        await service.update_area(99999, {"bonus_points": Decimal("0.50")})
+
+
+async def test_retire_area_sets_effective_to_today(db) -> None:
+    service = PriorityConfigService(db)
+    row, _ = await service.create_area(
+        {
+            "academic_year": 2026, "area_code": "KV1",
+            "area_name": "KV1", "bonus_points": Decimal("0.75"),
+        }
+    )
+    retired, _ = await service.retire_area(row.id)
+    assert retired.effective_to == date.today()
+
+
+async def test_retire_area_idempotency_blocks_double_retire(db) -> None:
+    service = PriorityConfigService(db)
+    row, _ = await service.create_area(
+        {
+            "academic_year": 2026, "area_code": "KV1",
+            "area_name": "KV1", "bonus_points": Decimal("0.75"),
+        }
+    )
+    await service.retire_area(row.id)
+    with pytest.raises(BusinessRuleViolation):
+        await service.retire_area(row.id)
+
+
+async def test_retire_area_then_recreate_succeeds(db) -> None:
+    """Partial UNIQUE WHERE effective_to IS NULL allows new active row
+    after old one is retired — supports mid-year rate change."""
+    service = PriorityConfigService(db)
+    old, _ = await service.create_area(
+        {
+            "academic_year": 2026, "area_code": "KV1",
+            "area_name": "KV1 v1", "bonus_points": Decimal("0.75"),
+        }
+    )
+    await service.retire_area(old.id)
+    new_row, _ = await service.create_area(
+        {
+            "academic_year": 2026, "area_code": "KV1",
+            "area_name": "KV1 v2 (TT mới)", "bonus_points": Decimal("0.50"),
+        }
+    )
+    assert new_row.id != old.id
+    assert new_row.bonus_points == Decimal("0.50")
+
+
+# ---------------------------------------------------------------------------
+# Object CRUD (same pattern, just spot-check)
+# ---------------------------------------------------------------------------
+
+
+async def test_create_object_persists(db) -> None:
+    service = PriorityConfigService(db)
+    row, _ = await service.create_object(
+        {
+            "academic_year": 2026, "group_code": "UT1", "sub_code": "04",
+            "description": "Con liệt sĩ", "bonus_points": Decimal("2.00"),
+        }
+    )
+    assert row.id is not None
+    assert row.sub_code == "04"
+
+
+async def test_create_object_rejects_invalid_sub_code_via_db_check(db) -> None:
+    service = PriorityConfigService(db)
+    with pytest.raises(IntegrityError):
+        await service.create_object(
+            {
+                "academic_year": 2026, "group_code": "UT1", "sub_code": "4",
+                "description": "Bad (need 2 digits)",
+                "bonus_points": Decimal("2.00"),
+            }
+        )
+        await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# Clone-from-year
+# ---------------------------------------------------------------------------
+
+
+async def test_clone_copies_active_rows_only(db) -> None:
+    service = PriorityConfigService(db)
+    # Seed 2 active + 1 retired in 2026
+    await service.create_area(
+        {"academic_year": 2026, "area_code": "KV1", "area_name": "KV1", "bonus_points": Decimal("0.75")}
+    )
+    retired, _ = await service.create_area(
+        {"academic_year": 2026, "area_code": "KV2", "area_name": "KV2", "bonus_points": Decimal("0.25")}
+    )
+    await service.retire_area(retired.id)
+    await service.create_area(
+        {"academic_year": 2026, "area_code": "KV2-NT", "area_name": "KV2-NT", "bonus_points": Decimal("0.50")}
+    )
+
+    result, _ = await service.clone_from_year(from_year=2026, to_year=2027)
+    # Only the 2 active rows cloned; retired KV2 row skipped
+    assert result["cloned_areas"] == 2
+
+
+async def test_clone_skips_existing_in_target_year(db) -> None:
+    service = PriorityConfigService(db)
+    await service.create_area(
+        {"academic_year": 2026, "area_code": "KV1", "area_name": "KV1", "bonus_points": Decimal("0.75")}
+    )
+    await service.create_area(
+        {"academic_year": 2027, "area_code": "KV1", "area_name": "Already there", "bonus_points": Decimal("0.80")}
+    )
+    result, _ = await service.clone_from_year(from_year=2026, to_year=2027)
+    # KV1 already in 2027 → skipped
+    assert result["cloned_areas"] == 0
+
+
+async def test_clone_same_year_raises(db) -> None:
+    service = PriorityConfigService(db)
+    with pytest.raises(BusinessRuleViolation):
+        await service.clone_from_year(from_year=2026, to_year=2026)
+
+
+# ---------------------------------------------------------------------------
+# Seed defaults TT 05/2021
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_inserts_all_baseline_rates_when_empty(db) -> None:
+    service = PriorityConfigService(db)
+    result, _ = await service.seed_tt_05_2021_defaults(2026)
+    assert result["inserted_areas"] == len(TT_05_2021_AREA_DEFAULTS) == 4
+    assert result["inserted_objects"] == len(TT_05_2021_OBJECT_DEFAULTS) == 7
+    assert result["skipped_existing"] is False
+
+
+async def test_seed_idempotent_skips_when_any_active_exists(db) -> None:
+    service = PriorityConfigService(db)
+    # Seed once
+    await service.seed_tt_05_2021_defaults(2026)
+    # Seed again — should skip entirely
+    result, _ = await service.seed_tt_05_2021_defaults(2026)
+    assert result["skipped_existing"] is True
+    assert result["inserted_areas"] == 0
+
+
+async def test_seed_kv_rates_match_tt_05_2021_phu_luc_01(db) -> None:
+    """Lock the exact rates the engine will see — regression here would
+    silently change scoring outcomes for the whole year."""
+    service = PriorityConfigService(db)
+    await service.seed_tt_05_2021_defaults(2026)
+    rows = await service.list_areas(2026, active_only=True)
+    by_code = {r.area_code: r.bonus_points for r in rows}
+    assert by_code == {
+        "KV1": Decimal("0.75"),
+        "KV2-NT": Decimal("0.50"),
+        "KV2": Decimal("0.25"),
+        "KV3": Decimal("0.00"),
+    }
+
+
+async def test_seed_ut_rates_match_tt_05_2021_phu_luc_01(db) -> None:
+    service = PriorityConfigService(db)
+    await service.seed_tt_05_2021_defaults(2026)
+    rows = await service.list_objects(2026, active_only=True)
+    ut1 = {r.sub_code: r.bonus_points for r in rows if r.group_code == "UT1"}
+    ut2 = {r.sub_code: r.bonus_points for r in rows if r.group_code == "UT2"}
+    # UT1: 4 codes (01-04) all 2.00
+    assert set(ut1.keys()) == {"01", "02", "03", "04"}
+    assert all(v == Decimal("2.00") for v in ut1.values())
+    # UT2: 3 codes (05-07) all 1.00
+    assert set(ut2.keys()) == {"05", "06", "07"}
+    assert all(v == Decimal("1.00") for v in ut2.values())

--- a/Backend_FastAPI/tests/unit/test_priority_service.py
+++ b/Backend_FastAPI/tests/unit/test_priority_service.py
@@ -1,0 +1,351 @@
+"""Unit tests for ``priority_service.calculate_priority_bonus``.
+
+Q9 #07 PR2a — pure-logic tests of the bonus calculation engine. Mocks
+the DB via AsyncMock so the test stays independent of alembic + seed.
+The 12 cases cover the contract that PR3 admin CRUD + PR5 candidate
+FE must respect.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.priority_service import calculate_priority_bonus
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# DB mock helpers — engine reads via 2 select() calls (area, object)
+# ---------------------------------------------------------------------------
+
+
+def _make_db(area_rate=None, object_rows=None):
+    """Return AsyncMock DB that dispatches by stmt text — so a test
+    where only one toggle fires still picks the right result regardless
+    of call order. Use None area_rate to simulate "missing config row"."""
+    area_result = MagicMock()
+    area_result.scalar_one_or_none = MagicMock(return_value=area_rate)
+
+    object_result = MagicMock()
+    object_result.all = MagicMock(return_value=object_rows or [])
+
+    async def _dispatch(stmt, *args, **kwargs):
+        sql_str = str(stmt)
+        if "priority_area_config" in sql_str:
+            return area_result
+        if "priority_object_config" in sql_str:
+            return object_result
+        raise AssertionError(f"Unexpected query to: {sql_str}")
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=_dispatch)
+    return db
+
+
+def _profile(**kwargs):
+    """Build a SimpleNamespace profile stub with the 3 fields the
+    engine reads."""
+    defaults = {
+        "high_school_kv_resolved": None,
+        "priority_object_codes": [],
+        "priority_object_evidence": {},
+        "area_resolution_basis": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+_RULE_BOTH_ON = {
+    "apply_area_bonus": True,
+    "apply_object_bonus": True,
+    "max_total_bonus": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. NULL rule → bonus disabled (legacy paths without method default)
+# ---------------------------------------------------------------------------
+
+
+async def test_null_rule_returns_zero_zero() -> None:
+    db = _make_db(area_rate=Decimal("0.75"))
+    profile = _profile(high_school_kv_resolved="KV1")
+    area, obj, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=None, academic_year=2026,
+    )
+    assert area == Decimal("0.00")
+    assert obj == Decimal("0.00")
+    assert snap["rule"] is None
+    # DB never queried when rule is None — early exit avoids round-trip.
+    db.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. Both toggles False → returns zero but still records snapshot
+# ---------------------------------------------------------------------------
+
+
+async def test_both_toggles_off_returns_zero_with_snapshot() -> None:
+    db = _make_db()
+    profile = _profile(high_school_kv_resolved="KV1")
+    rule = {
+        "apply_area_bonus": False,
+        "apply_object_bonus": False,
+        "max_total_bonus": None,
+    }
+    area, obj, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=rule, academic_year=2026,
+    )
+    assert area == Decimal("0.00")
+    assert obj == Decimal("0.00")
+    # Snapshot still records the rule for audit replay
+    assert snap["rule"] == rule
+    db.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3. Area: NULL kv_resolved → 0 (graceful for legacy 315 profiles)
+# ---------------------------------------------------------------------------
+
+
+async def test_area_null_kv_returns_zero() -> None:
+    db = _make_db(area_rate=Decimal("0.75"))
+    profile = _profile(high_school_kv_resolved=None)
+    area, _, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=_RULE_BOTH_ON, academic_year=2026,
+    )
+    assert area == Decimal("0.00")
+    assert snap["area_code"] is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Area: KV1 looked up + applied
+# ---------------------------------------------------------------------------
+
+
+async def test_area_kv1_resolves_rate() -> None:
+    db = _make_db(area_rate=Decimal("0.75"))
+    profile = _profile(high_school_kv_resolved="KV1")
+    area, _, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=_RULE_BOTH_ON, academic_year=2026,
+    )
+    assert area == Decimal("0.75")
+    assert snap["area_code"] == "KV1"
+    assert snap["area_rate"] == "0.75"
+
+
+# ---------------------------------------------------------------------------
+# 5. Area: KV2-NT canonical (hyphen) — make sure engine doesn't choke
+# ---------------------------------------------------------------------------
+
+
+async def test_area_kv2_nt_canonical_hyphen() -> None:
+    db = _make_db(area_rate=Decimal("0.50"))
+    profile = _profile(high_school_kv_resolved="KV2-NT")
+    area, _, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=_RULE_BOTH_ON, academic_year=2026,
+    )
+    assert area == Decimal("0.50")
+    assert snap["area_code"] == "KV2-NT"
+
+
+# ---------------------------------------------------------------------------
+# 6. Area: missing rate for year → 0 (admin chưa seed)
+# ---------------------------------------------------------------------------
+
+
+async def test_area_missing_rate_returns_zero() -> None:
+    db = _make_db(area_rate=None)
+    profile = _profile(high_school_kv_resolved="KV1")
+    area, _, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=_RULE_BOTH_ON, academic_year=2099,
+    )
+    assert area == Decimal("0.00")
+    # Snapshot records the code so audit shows "candidate khai KV1
+    # nhưng rate chưa config cho 2099"
+    assert snap["area_code"] == "KV1"
+    assert snap["area_rate"] is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Object: empty codes → 0
+# ---------------------------------------------------------------------------
+
+
+async def test_object_empty_codes_returns_zero() -> None:
+    db = _make_db(object_rows=[])
+    profile = _profile(priority_object_codes=[], priority_object_evidence={})
+    _, obj, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=_RULE_BOTH_ON, academic_year=2026,
+    )
+    assert obj == Decimal("0.00")
+    assert snap["verified_codes"] == []
+
+
+# ---------------------------------------------------------------------------
+# 8. Object: codes present but ALL unverified → 0 (evidence gate)
+# ---------------------------------------------------------------------------
+
+
+async def test_object_all_unverified_returns_zero() -> None:
+    db = _make_db(object_rows=[("04", Decimal("2.00"))])
+    profile = _profile(
+        priority_object_codes=["04", "06"],
+        priority_object_evidence={
+            "04": {"status": "pending"},
+            "06": {"status": "rejected"},
+        },
+    )
+    _, obj, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=_RULE_BOTH_ON, academic_year=2026,
+    )
+    assert obj == Decimal("0.00")
+    assert snap["verified_codes"] == []
+
+
+# ---------------------------------------------------------------------------
+# 9. Object: multi-UT verified → MAX wins (per TT 05/2021 "1 diện cao nhất")
+# ---------------------------------------------------------------------------
+
+
+async def test_object_multi_ut_picks_max() -> None:
+    db = _make_db(
+        object_rows=[
+            ("04", Decimal("2.00")),  # UT1
+            ("06", Decimal("1.00")),  # UT2
+        ]
+    )
+    profile = _profile(
+        priority_object_codes=["04", "06"],
+        priority_object_evidence={
+            "04": {"status": "verified", "verified_by": 5},
+            "06": {"status": "verified", "verified_by": 5},
+        },
+    )
+    _, obj, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=_RULE_BOTH_ON, academic_year=2026,
+    )
+    assert obj == Decimal("2.00")
+    assert snap["object_max_code"] == "04"
+    assert snap["object_rate"] == "2.00"
+    # Snapshot records BOTH verified codes for audit even though only
+    # the max was applied
+    assert sorted(snap["verified_codes"]) == ["04", "06"]
+
+
+# ---------------------------------------------------------------------------
+# 10. Object: only verified subset counts (partial verification)
+# ---------------------------------------------------------------------------
+
+
+async def test_object_partial_verified_counts_only_verified() -> None:
+    db = _make_db(
+        object_rows=[
+            ("06", Decimal("1.00")),  # only 06 returned since 04 not verified
+        ]
+    )
+    profile = _profile(
+        priority_object_codes=["04", "06"],
+        priority_object_evidence={
+            "04": {"status": "pending"},
+            "06": {"status": "verified", "verified_by": 5},
+        },
+    )
+    _, obj, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=_RULE_BOTH_ON, academic_year=2026,
+    )
+    assert obj == Decimal("1.00")
+    assert snap["verified_codes"] == ["06"]
+
+
+# ---------------------------------------------------------------------------
+# 11. Combined cap: area + object > max_total_bonus → proportional clip
+# ---------------------------------------------------------------------------
+
+
+async def test_cap_proportional_clip() -> None:
+    db = _make_db(
+        area_rate=Decimal("0.75"),
+        object_rows=[("04", Decimal("2.00"))],
+    )
+    profile = _profile(
+        high_school_kv_resolved="KV1",
+        priority_object_codes=["04"],
+        priority_object_evidence={"04": {"status": "verified"}},
+    )
+    rule = {
+        "apply_area_bonus": True,
+        "apply_object_bonus": True,
+        "max_total_bonus": 1.0,  # cap below 0.75+2.0=2.75
+    }
+    area, obj, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=rule, academic_year=2026,
+    )
+    # Proportional clip keeps the area/object ratio:
+    #   total=2.75, cap=1.0, ratio=1.0/2.75 ≈ 0.3636
+    #   area=0.75*ratio ≈ 0.27, object=2.00*ratio ≈ 0.73
+    assert area + obj <= Decimal("1.00")
+    assert snap["cap_applied"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# 12. Apply toggles independent: area on, object off → skip object lookup
+# ---------------------------------------------------------------------------
+
+
+async def test_apply_object_off_skips_object_lookup() -> None:
+    db = _make_db(area_rate=Decimal("0.75"))
+    profile = _profile(
+        high_school_kv_resolved="KV1",
+        priority_object_codes=["04"],
+        priority_object_evidence={"04": {"status": "verified"}},
+    )
+    rule = {
+        "apply_area_bonus": True,
+        "apply_object_bonus": False,
+        "max_total_bonus": None,
+    }
+    area, obj, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=rule, academic_year=2026,
+    )
+    assert area == Decimal("0.75")
+    assert obj == Decimal("0.00")
+    # Snapshot for object stays empty since lookup was skipped
+    assert snap["verified_codes"] == []
+    # Only the area select fired
+    assert db.execute.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 13. Apply area off, object on → skip area lookup
+# ---------------------------------------------------------------------------
+
+
+async def test_apply_area_off_skips_area_lookup() -> None:
+    db = _make_db(
+        area_rate=Decimal("0.75"),
+        object_rows=[("04", Decimal("2.00"))],
+    )
+    profile = _profile(
+        high_school_kv_resolved="KV1",
+        priority_object_codes=["04"],
+        priority_object_evidence={"04": {"status": "verified"}},
+    )
+    rule = {
+        "apply_area_bonus": False,
+        "apply_object_bonus": True,
+        "max_total_bonus": None,
+    }
+    area, obj, snap = await calculate_priority_bonus(
+        db=db, profile=profile, rule=rule, academic_year=2026,
+    )
+    assert area == Decimal("0.00")
+    assert obj == Decimal("2.00")
+    assert snap["area_code"] is None
+    # Only the object select fired
+    assert db.execute.await_count == 1

--- a/Backend_FastAPI/tests/unit/test_vn_locality_service.py
+++ b/Backend_FastAPI/tests/unit/test_vn_locality_service.py
@@ -135,17 +135,41 @@ async def test_seed_sample_idempotent(db) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_search_high_school_case_insensitive_partial(db) -> None:
-    """ilike does case-insensitive but NOT diacritic normalization —
-    candidate FE may send the user's exact typed string. Verify the
-    canonical-form search works (search by partial diacritic-matching
-    substring)."""
+async def test_search_high_school_prefix_match(db) -> None:
+    """CR-M3 fix: prefix ilike (not substring). Candidate types from
+    the start of the school name (canonical form 'THPT <name>'). Index-
+    friendly + cleaner UX vs substring 'L' matching everything with L."""
     service = VnLocalityService(db)
     await service.seed_sample_high_schools()
-    # Search by diacritic-matching substring (case-insensitive)
-    results = await service.search_high_schools("lê quý đôn", limit=10)
+    # Realistic flow: candidate types "THPT Lê" → dropdown filters
+    results = await service.search_high_schools("thpt lê", limit=10)
     assert len(results) >= 1
     assert any("Lê Quý Đôn" in r.name for r in results)
+
+
+async def test_search_high_school_prefix_does_not_match_midname(db) -> None:
+    """Lock the prefix-vs-substring change: 'Lê' alone (without THPT
+    prefix) should NOT match — old substring behavior would have."""
+    service = VnLocalityService(db)
+    await service.seed_sample_high_schools()
+    results = await service.search_high_schools("Lê Quý", limit=10)
+    # All seeded names start with "THPT", so "Lê Quý" prefix matches zero
+    assert results == []
+
+
+async def test_csv_decode_strips_utf8_bom(db) -> None:
+    """CR-M2 fix: Excel-exported CSVs often start with UTF-8 BOM
+    (\\xef\\xbb\\xbf). Without utf-8-sig decode, first header column
+    becomes '\\ufeffcommune_code' and every row fails Pydantic parse."""
+    csv_with_bom = (
+        b"\xef\xbb\xbf"  # UTF-8 BOM
+        b"commune_code,province,district,ward,area_code\n"
+        b"C001,Ha Noi,Ha Dong,Phuong A,KV3\n"
+    )
+    service = VnLocalityService(db)
+    result, _ = await service.import_commune_csv(csv_with_bom)
+    assert result["inserted"] == 1
+    assert result["error_rows"] == []
 
 
 async def test_search_respects_is_active(db) -> None:

--- a/Backend_FastAPI/tests/unit/test_vn_locality_service.py
+++ b/Backend_FastAPI/tests/unit/test_vn_locality_service.py
@@ -1,0 +1,186 @@
+"""Unit tests for VnLocalityService (Q9 #07 PR4).
+
+CSV import (commune + high_school) + sample seed + search dropdown.
+Idempotent behavior + malformed-row collection are the main contracts.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from app.database import AsyncSessionLocal
+from app.services.vn_locality_service import (
+    SAMPLE_HIGH_SCHOOLS,
+    VnLocalityService,
+)
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def db(setup_test_database):
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+        finally:
+            await session.rollback()
+            await session.close()
+
+
+# ---------------------------------------------------------------------------
+# Commune CSV import
+# ---------------------------------------------------------------------------
+
+
+async def test_commune_import_inserts_valid_rows(db) -> None:
+    csv = (
+        b"commune_code,province,district,ward,area_code\n"
+        b"C001,Ha Noi,Ha Dong,Phuong A,KV3\n"
+        b"C002,Dak Lak,Buon Ma Thuot,Phuong B,KV1\n"
+    )
+    service = VnLocalityService(db)
+    result, _ = await service.import_commune_csv(csv)
+    assert result["inserted"] == 2
+    assert result["skipped_existing"] == 0
+    assert result["error_rows"] == []
+
+
+async def test_commune_import_skips_duplicate_active_row(db) -> None:
+    csv = (
+        b"commune_code,province,district,ward,area_code\n"
+        b"C001,Ha Noi,Ha Dong,Phuong A,KV3\n"
+    )
+    service = VnLocalityService(db)
+    # First import — insert
+    r1, _ = await service.import_commune_csv(csv)
+    assert r1["inserted"] == 1
+    # Second import — skipped (idempotent)
+    r2, _ = await service.import_commune_csv(csv)
+    assert r2["inserted"] == 0
+    assert r2["skipped_existing"] == 1
+
+
+async def test_commune_import_collects_malformed_rows(db) -> None:
+    csv = (
+        b"commune_code,province,district,ward,area_code\n"
+        b"C001,Ha Noi,Ha Dong,Phuong A,KV3\n"          # OK
+        b"C002,Ha Noi,Ha Dong,Phuong B,KV2_NT\n"        # bad: underscore form
+        b"C003,Ha Noi,Ha Dong,Phuong C,INVALID\n"       # bad: not KV*
+    )
+    service = VnLocalityService(db)
+    result, _ = await service.import_commune_csv(csv)
+    assert result["inserted"] == 1
+    assert len(result["error_rows"]) == 2
+    # Each error carries row_num (1=header, so first data row = 2)
+    assert all("row_num" in e and "error" in e for e in result["error_rows"])
+
+
+# ---------------------------------------------------------------------------
+# High school CSV import
+# ---------------------------------------------------------------------------
+
+
+async def test_high_school_import_inserts_valid_rows(db) -> None:
+    csv = (
+        b"name,province,district,ward,kv_code\n"
+        b"THPT A,Ha Noi,Ha Dong,Phuong 1,KV3\n"
+        b"THPT B,Ha Noi,Cau Giay,Phuong 2,KV3\n"
+    )
+    service = VnLocalityService(db)
+    result, _ = await service.import_high_school_csv(csv)
+    assert result["inserted"] == 2
+
+
+async def test_high_school_import_skips_existing_by_name_province(db) -> None:
+    csv = b"name,province,district,ward,kv_code\nTHPT A,Ha Noi,Ha Dong,Phuong 1,KV3\n"
+    service = VnLocalityService(db)
+    await service.import_high_school_csv(csv)
+    r2, _ = await service.import_high_school_csv(csv)
+    assert r2["inserted"] == 0
+    assert r2["skipped_existing"] == 1
+
+
+async def test_high_school_kv_code_optional(db) -> None:
+    """MOET CSV may not always include kv_code — admin will fill later
+    via priority backfill UI. Should accept None."""
+    csv = b"name,province,district,ward,kv_code\nTHPT C,Ha Noi,,,\n"
+    service = VnLocalityService(db)
+    result, _ = await service.import_high_school_csv(csv)
+    assert result["inserted"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Sample seed
+# ---------------------------------------------------------------------------
+
+
+async def test_seed_sample_inserts_5_rows(db) -> None:
+    service = VnLocalityService(db)
+    result, _ = await service.seed_sample_high_schools()
+    assert result["inserted"] == 5
+    assert result["total_in_seed"] == len(SAMPLE_HIGH_SCHOOLS)
+
+
+async def test_seed_sample_idempotent(db) -> None:
+    service = VnLocalityService(db)
+    await service.seed_sample_high_schools()
+    r2, _ = await service.seed_sample_high_schools()
+    # Second run: all 5 already exist → 0 inserted
+    assert r2["inserted"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Search dropdown
+# ---------------------------------------------------------------------------
+
+
+async def test_search_high_school_case_insensitive_partial(db) -> None:
+    """ilike does case-insensitive but NOT diacritic normalization —
+    candidate FE may send the user's exact typed string. Verify the
+    canonical-form search works (search by partial diacritic-matching
+    substring)."""
+    service = VnLocalityService(db)
+    await service.seed_sample_high_schools()
+    # Search by diacritic-matching substring (case-insensitive)
+    results = await service.search_high_schools("lê quý đôn", limit=10)
+    assert len(results) >= 1
+    assert any("Lê Quý Đôn" in r.name for r in results)
+
+
+async def test_search_respects_is_active(db) -> None:
+    """Soft-deleted rows (is_active=false) must NOT appear in search."""
+    service = VnLocalityService(db)
+    await service.seed_sample_high_schools()
+    # Soft-delete one row
+    from sqlalchemy import update
+
+    from app.models.vn_locality import VnHighSchool
+
+    await db.execute(
+        update(VnHighSchool)
+        .where(VnHighSchool.name == "THPT Lê Quý Đôn")
+        .values(is_active=False)
+    )
+    await db.flush()
+    results = await service.search_high_schools("Lê Quý Đôn", limit=10)
+    assert not any(r.name == "THPT Lê Quý Đôn" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Commune lookup (PR5 special-case KV resolution)
+# ---------------------------------------------------------------------------
+
+
+async def test_lookup_commune_kv_returns_area_code(db) -> None:
+    csv = b"commune_code,province,district,ward,area_code\nC001,DL,BMT,W1,KV1\n"
+    service = VnLocalityService(db)
+    await service.import_commune_csv(csv)
+    kv = await service.lookup_commune_kv("C001")
+    assert kv == "KV1"
+
+
+async def test_lookup_commune_kv_missing_returns_none(db) -> None:
+    service = VnLocalityService(db)
+    kv = await service.lookup_commune_kv("NONEXISTENT")
+    assert kv is None

--- a/Backend_FastAPI/tests/unit/test_vn_locality_service.py
+++ b/Backend_FastAPI/tests/unit/test_vn_locality_service.py
@@ -157,6 +157,19 @@ async def test_search_high_school_prefix_does_not_match_midname(db) -> None:
     assert results == []
 
 
+async def test_csv_decode_non_utf8_raises_friendly_validation_error(db) -> None:
+    """N2 fix: bytes that can't decode as UTF-8 (vd: CP1258 Excel-VN
+    export) must raise a domain ValidationError with admin-friendly
+    hint instead of opaque 500 from UnicodeDecodeError."""
+    from app.utils.exceptions import ValidationError as DomainValidationError
+
+    # Bytes 0xE9 (é in latin1/cp1258) is invalid as UTF-8 lead byte
+    bad_csv = b"commune_code,province,district,ward,area_code\nC1,H\xe9 Noi,X,Y,KV3\n"
+    service = VnLocalityService(db)
+    with pytest.raises(DomainValidationError, match="UTF-8"):
+        await service.import_commune_csv(bad_csv)
+
+
 async def test_csv_decode_strips_utf8_bom(db) -> None:
     """CR-M2 fix: Excel-exported CSVs often start with UTF-8 BOM
     (\\xef\\xbb\\xbf). Without utf-8-sig decode, first header column

--- a/Backend_FastAPI/tests/unit/test_vn_locality_service.py
+++ b/Backend_FastAPI/tests/unit/test_vn_locality_service.py
@@ -1,7 +1,10 @@
-"""Unit tests for VnLocalityService (Q9 #07 PR4).
+"""Unit tests for VnLocalityService (Q9 #07 PR4 — commune CSV import only).
 
-CSV import (commune + high_school) + sample seed + search dropdown.
-Idempotent behavior + malformed-row collection are the main contracts.
+Scope updated 2026-05-18 (phase1_09 v1.3 redesign):
+* VnHighSchool tests REMOVED (table dropped, replaced by VnSchool family
+  with Phase B.1 import script ``app/scripts/import_moet_schools_2025.py``)
+* Kept: commune CSV import (idempotent + malformed-row collection +
+  F.5 header validation + N2 UTF-8 fallback + CR-M2 BOM strip)
 """
 from __future__ import annotations
 
@@ -9,10 +12,7 @@ import pytest
 import pytest_asyncio
 
 from app.database import AsyncSessionLocal
-from app.services.vn_locality_service import (
-    SAMPLE_HIGH_SCHOOLS,
-    VnLocalityService,
-)
+from app.services.vn_locality_service import VnLocalityService
 
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
@@ -77,84 +77,8 @@ async def test_commune_import_collects_malformed_rows(db) -> None:
 
 
 # ---------------------------------------------------------------------------
-# High school CSV import
+# CSV validation
 # ---------------------------------------------------------------------------
-
-
-async def test_high_school_import_inserts_valid_rows(db) -> None:
-    csv = (
-        b"name,province,district,ward,kv_code\n"
-        b"THPT A,Ha Noi,Ha Dong,Phuong 1,KV3\n"
-        b"THPT B,Ha Noi,Cau Giay,Phuong 2,KV3\n"
-    )
-    service = VnLocalityService(db)
-    result, _ = await service.import_high_school_csv(csv)
-    assert result["inserted"] == 2
-
-
-async def test_high_school_import_skips_existing_by_name_province(db) -> None:
-    csv = b"name,province,district,ward,kv_code\nTHPT A,Ha Noi,Ha Dong,Phuong 1,KV3\n"
-    service = VnLocalityService(db)
-    await service.import_high_school_csv(csv)
-    r2, _ = await service.import_high_school_csv(csv)
-    assert r2["inserted"] == 0
-    assert r2["skipped_existing"] == 1
-
-
-async def test_high_school_kv_code_optional(db) -> None:
-    """MOET CSV may not always include kv_code — admin will fill later
-    via priority backfill UI. Should accept None."""
-    csv = b"name,province,district,ward,kv_code\nTHPT C,Ha Noi,,,\n"
-    service = VnLocalityService(db)
-    result, _ = await service.import_high_school_csv(csv)
-    assert result["inserted"] == 1
-
-
-# ---------------------------------------------------------------------------
-# Sample seed
-# ---------------------------------------------------------------------------
-
-
-async def test_seed_sample_inserts_5_rows(db) -> None:
-    service = VnLocalityService(db)
-    result, _ = await service.seed_sample_high_schools()
-    assert result["inserted"] == 5
-    assert result["total_in_seed"] == len(SAMPLE_HIGH_SCHOOLS)
-
-
-async def test_seed_sample_idempotent(db) -> None:
-    service = VnLocalityService(db)
-    await service.seed_sample_high_schools()
-    r2, _ = await service.seed_sample_high_schools()
-    # Second run: all 5 already exist → 0 inserted
-    assert r2["inserted"] == 0
-
-
-# ---------------------------------------------------------------------------
-# Search dropdown
-# ---------------------------------------------------------------------------
-
-
-async def test_search_high_school_prefix_match(db) -> None:
-    """CR-M3 fix: prefix ilike (not substring). Candidate types from
-    the start of the school name (canonical form 'THPT <name>'). Index-
-    friendly + cleaner UX vs substring 'L' matching everything with L."""
-    service = VnLocalityService(db)
-    await service.seed_sample_high_schools()
-    # Realistic flow: candidate types "THPT Lê" → dropdown filters
-    results = await service.search_high_schools("thpt lê", limit=10)
-    assert len(results) >= 1
-    assert any("Lê Quý Đôn" in r.name for r in results)
-
-
-async def test_search_high_school_prefix_does_not_match_midname(db) -> None:
-    """Lock the prefix-vs-substring change: 'Lê' alone (without THPT
-    prefix) should NOT match — old substring behavior would have."""
-    service = VnLocalityService(db)
-    await service.seed_sample_high_schools()
-    results = await service.search_high_schools("Lê Quý", limit=10)
-    # All seeded names start with "THPT", so "Lê Quý" prefix matches zero
-    assert results == []
 
 
 async def test_commune_csv_missing_header_column_raises_validation(db) -> None:
@@ -171,17 +95,6 @@ async def test_commune_csv_missing_header_column_raises_validation(db) -> None:
     service = VnLocalityService(db)
     with pytest.raises(DomainValidationError, match="area_code"):
         await service.import_commune_csv(bad_csv)
-
-
-async def test_high_school_csv_missing_header_column_raises_validation(db) -> None:
-    """F.5 fix: same upfront-header-check for HS import."""
-    from app.utils.exceptions import ValidationError as DomainValidationError
-
-    # Header missing 'name' (required) — kv_code/district/ward are optional
-    bad_csv = b"province,district,ward,kv_code\nHa Noi,Ha Dong,Phuong 1,KV3\n"
-    service = VnLocalityService(db)
-    with pytest.raises(DomainValidationError, match="name"):
-        await service.import_high_school_csv(bad_csv)
 
 
 async def test_csv_decode_non_utf8_raises_friendly_validation_error(db) -> None:
@@ -212,39 +125,22 @@ async def test_csv_decode_strips_utf8_bom(db) -> None:
     assert result["error_rows"] == []
 
 
-async def test_search_respects_is_active(db) -> None:
-    """Soft-deleted rows (is_active=false) must NOT appear in search."""
-    service = VnLocalityService(db)
-    await service.seed_sample_high_schools()
-    # Soft-delete one row
-    from sqlalchemy import update
-
-    from app.models.vn_locality import VnHighSchool
-
-    await db.execute(
-        update(VnHighSchool)
-        .where(VnHighSchool.name == "THPT Lê Quý Đôn")
-        .values(is_active=False)
-    )
-    await db.flush()
-    results = await service.search_high_schools("Lê Quý Đôn", limit=10)
-    assert not any(r.name == "THPT Lê Quý Đôn" for r in results)
-
-
 # ---------------------------------------------------------------------------
-# Commune lookup (PR5 special-case KV resolution)
+# lookup_commune_kv (used by priority_service for 4 special cases + fallback)
 # ---------------------------------------------------------------------------
 
 
-async def test_lookup_commune_kv_returns_area_code(db) -> None:
-    csv = b"commune_code,province,district,ward,area_code\nC001,DL,BMT,W1,KV1\n"
+async def test_lookup_commune_kv_returns_active_row(db) -> None:
+    """Service uses this for permanent_address_special bypass + TC commune_fallback."""
+    csv = b"commune_code,province,district,ward,area_code\nKV1_TEST,Dak Lak,Buon Ma Thuot,X,KV1\n"
     service = VnLocalityService(db)
     await service.import_commune_csv(csv)
-    kv = await service.lookup_commune_kv("C001")
+    kv = await service.lookup_commune_kv("KV1_TEST")
     assert kv == "KV1"
 
 
-async def test_lookup_commune_kv_missing_returns_none(db) -> None:
+async def test_lookup_commune_kv_returns_none_for_missing(db) -> None:
+    """Missing commune → None (caller falls back to manual_override)."""
     service = VnLocalityService(db)
     kv = await service.lookup_commune_kv("NONEXISTENT")
     assert kv is None

--- a/Backend_FastAPI/tests/unit/test_vn_locality_service.py
+++ b/Backend_FastAPI/tests/unit/test_vn_locality_service.py
@@ -157,6 +157,33 @@ async def test_search_high_school_prefix_does_not_match_midname(db) -> None:
     assert results == []
 
 
+async def test_commune_csv_missing_header_column_raises_validation(db) -> None:
+    """F.5 fix: CSV with header missing a required column must raise
+    a single clear DomainValidationError up-front instead of silently
+    inserting 0 rows with N per-row Pydantic errors (admin tưởng OK)."""
+    from app.utils.exceptions import ValidationError as DomainValidationError
+
+    # Header missing 'area_code'
+    bad_csv = (
+        b"commune_code,province,district,ward\n"
+        b"C001,Ha Noi,Ha Dong,Phuong A\n"
+    )
+    service = VnLocalityService(db)
+    with pytest.raises(DomainValidationError, match="area_code"):
+        await service.import_commune_csv(bad_csv)
+
+
+async def test_high_school_csv_missing_header_column_raises_validation(db) -> None:
+    """F.5 fix: same upfront-header-check for HS import."""
+    from app.utils.exceptions import ValidationError as DomainValidationError
+
+    # Header missing 'name' (required) — kv_code/district/ward are optional
+    bad_csv = b"province,district,ward,kv_code\nHa Noi,Ha Dong,Phuong 1,KV3\n"
+    service = VnLocalityService(db)
+    with pytest.raises(DomainValidationError, match="name"):
+        await service.import_high_school_csv(bad_csv)
+
+
 async def test_csv_decode_non_utf8_raises_friendly_validation_error(db) -> None:
     """N2 fix: bytes that can't decode as UTF-8 (vd: CP1258 Excel-VN
     export) must raise a domain ValidationError with admin-friendly

--- a/Documents/Q9_07_PR5_REDESIGN.md
+++ b/Documents/Q9_07_PR5_REDESIGN.md
@@ -1,0 +1,823 @@
+# Q9 #07 PR5 Redesign — Temporal Multi-School KV Resolution
+
+**Status**: DRAFT v1.3 2026-05-18 — 2-field parallel (cultural + vocational) correction per VN admission convention (supersedes v1.2 single `diploma_submitted` enum); supersedes PR5 candidate FE commit `a58d2eb2` (reset)
+**Owner**: solo dev
+**Replaces**: PR1 single `high_school_id` design + PR4 single-table import + PR5 single-field PriorityTab
+
+---
+
+## Why redesign
+
+PR5 candidate FE (commit `a58d2eb2`) đã viết `PriorityTab.tsx` với **1 field `high_school_id` duy nhất**. Sau khi audit TT 05/2021/TT-BLĐTBXH Phụ lục 01 + user feedback, phát hiện 3 vấn đề:
+
+### 1. TT 05/2021 yêu cầu rule "thời gian học dài nhất"
+
+Verbatim TT Phụ lục 01:
+> "Nếu chuyển trường, **thời gian học ở khu vực nào lâu hơn được hưởng ưu tiên theo khu vực đó**."
+>
+> "Khi mỗi năm học một trường thuộc các khu vực có mức ưu tiên khác nhau hoặc nửa thời gian học ở trường này, nửa thời gian học ở trường kia thì **tốt nghiệp ở khu vực nào, hưởng ưu tiên theo khu vực đó**."
+
+→ Không thể derive KV từ 1 trường. Cần multi-school history với weighted resolution.
+
+### 2. Pathway theo **2 field PARALLEL** — Trình độ văn hóa + Trình độ chuyên môn
+
+**Correction 2026-05-18 v1.3**: Theo VN admission convention (Luật GDNN 2014/2025 + TT 05/2021 Điều 4), candidate khai 2 dimension **độc lập song song**, KHÔNG phải 1 enum diploma:
+
+#### **Trình độ văn hóa** (`cultural_education_level`) — required
+Cấp giáo dục PHỔ THÔNG candidate đã hoàn thành/tốt nghiệp:
+- `completed_thcs` — Hoàn thành THCS (đã học lớp 9 nhưng CHƯA được cấp bằng — rare case: dropout giữa năm hoặc chuyển TC trước thi tốt nghiệp; N2 verified per VN reality hiếm gặp)
+- `graduated_thcs` — **Tốt nghiệp THCS** (có bằng — common case)
+- `completed_thpt` — Hoàn thành THPT (đủ kiến thức văn hóa, chưa thi tốt nghiệp — TT 05/2021 Điều 4 lối 2 cho CĐ liên thông yêu cầu giấy CN này)
+- `graduated_thpt` — **Tốt nghiệp THPT** (có bằng — common)
+- `graduated_gdtx` — Tốt nghiệp GDTX (tương đương Tốt nghiệp THPT theo Luật GDNN)
+
+#### **Trình độ chuyên môn** (`vocational_qualification`) — optional, default `none`
+Cấp NGHỀ NGHIỆP candidate đã tốt nghiệp (nếu có):
+- `none` — Chưa có (default)
+- `so_cap` — Tốt nghiệp Sơ cấp (3-12 tháng)
+- `trung_cap` — Tốt nghiệp Trung cấp (1-2 năm)
+- `cao_dang` — Tốt nghiệp Cao đẳng (2-3 năm)
+
+#### Cấp mới future-proof: Trung học nghề
+Dự thảo TT 2026 BGDĐT thêm cấp "Trung học nghề" (THPT + TC nghề combined). Schema `vn_school.level` enum + academic_history `level` field add value `'TRUNG_HOC_NGHE'`.
+
+#### Multi-school rule (TT 05/2021 Phụ lục 01 verbatim)
+> "Nếu trong **3 năm học trung học phổ thông (hoặc trong thời gian học trung cấp)** có chuyển trường thì thời gian học ở khu vực nào lâu hơn được hưởng ưu tiên"
+
+→ Rule áp dụng cho **THPT** (3 năm) HOẶC **TC** (thời gian học), KHÔNG có rule THCS-multi-school.
+
+#### KV resolution basis derivation matrix (COMPLETE — v1.3 C3 fix)
+
+| # | Cultural | Vocational | Basis | Pathway | Eligibility |
+|---|---|---|---|---|---|
+| 1 | `graduated_thpt` / `graduated_gdtx` | any | **THPT** | `thpt_multi_school` | CĐ + TC both OK |
+| 2 | `completed_thpt` | `trung_cap` / `cao_dang` | **THPT** (if history) ELSE **TC** | `thpt_multi_school` OR `tc_multi_school` | CĐ liên thông OK (TT path 2) |
+| 3 | `completed_thpt` | `so_cap` / `none` | **COMMUNE_FALLBACK** | `commune_fallback` | TC eligible (THPT kiến thức = equiv); CĐ FAIL eligibility |
+| 4 | `graduated_thcs` | `trung_cap` / `cao_dang` | **TC** | `tc_multi_school` | TC OK; CĐ FAIL (cần văn hóa THPT) |
+| 5 | `graduated_thcs` | `so_cap` / `none` | **COMMUNE_FALLBACK** | `commune_fallback` | TC OK; CĐ FAIL |
+| 6 | `completed_thcs` | any | **COMMUNE_FALLBACK** | `commune_fallback` | TC FAIL (cần Tốt nghiệp THCS); CĐ FAIL |
+| 7 | `None` (chưa khai) | any | **NOT_RESOLVED** | `not_resolved` | N/A — draft state |
+| 8 | (any) + `area_resolution_basis='permanent_address_special'` | bypass | **COMMUNE_SPECIAL** | `commune_special` | 4 cases TT 05/2021 |
+| 9 | (any) + `area_resolution_basis='manual_override'` | bypass | **MANUAL** | `manual_override` | Admin/officer fill |
+
+**Note**: Matrix rows 3, 4, 5, 6 có thể trigger KV resolve nhưng FAIL eligibility tại submit T1. KV resolution và eligibility là **2 concern độc lập** (xem decoupling note dưới).
+
+#### Helper `_derive_kv_basis_level()` — C1 fix
+
+```python
+from typing import Optional
+
+def _derive_kv_basis_level(
+    cultural: Optional[str],
+    vocational: str,
+    area_resolution_basis: Optional[str] = None,
+) -> str:
+    """
+    Map (cultural, vocational, area_basis) → KV resolution basis per
+    TT 05/2021 Phụ lục 01 multi-school rules.
+
+    Returns one of:
+      'THPT'              — apply 3-year THPT multi-school rule (rows 1, 2)
+      'TC'                — apply TC time multi-school rule (rows 2 fallthrough, 4)
+      'COMMUNE_FALLBACK'  — THCS only / so_cap / completed_thpt+none (rows 3, 5, 6)
+      'COMMUNE_SPECIAL'   — 4 special cases bypass (row 8)
+      'MANUAL'            — admin override (row 9)
+      'NOT_RESOLVED'      — cultural chưa khai (row 7, draft)
+    """
+    # Row 8/9: area_resolution_basis overrides matrix
+    if area_resolution_basis == 'permanent_address_special':
+        return 'COMMUNE_SPECIAL'
+    if area_resolution_basis == 'manual_override':
+        return 'MANUAL'
+
+    # Row 7: cultural not set (draft state)
+    if cultural is None:
+        return 'NOT_RESOLVED'
+
+    # Rows 1, 2 (partial): THPT pathway
+    if cultural in ('graduated_thpt', 'graduated_gdtx', 'completed_thpt'):
+        # Row 1 + Row 2 if THPT history sufficient → THPT
+        # Row 2 fallthrough if no THPT history → TC handled by caller
+        # Row 3 (completed_thpt + so_cap/none) → COMMUNE_FALLBACK
+        if cultural == 'completed_thpt' and vocational in ('so_cap', 'none'):
+            return 'COMMUNE_FALLBACK'  # Row 3
+        return 'THPT'  # Rows 1, 2
+
+    # Rows 4, 5: graduated_thcs + vocational branching
+    if cultural == 'graduated_thcs':
+        if vocational in ('trung_cap', 'cao_dang'):
+            return 'TC'  # Row 4
+        return 'COMMUNE_FALLBACK'  # Row 5
+
+    # Row 6: completed_thcs (any vocational) → fallback
+    if cultural == 'completed_thcs':
+        return 'COMMUNE_FALLBACK'
+
+    # Defensive: unknown cultural (shouldn't happen due to CHECK enum)
+    return 'NOT_RESOLVED'
+```
+
+#### Decoupling note — C2 fix
+
+**KV resolution và eligibility check là 2 concern độc lập**:
+
+- `resolve_kv_for_profile(profile)`: tính KV theo combination hiện tại của profile (draft/submitted/T6)
+- `validate_eligibility(profile, target_level)`: gate profile submit/approval based on target program
+
+Flow:
+1. **Draft state**: candidate edit form → KV resolve real-time hiển thị preview (ngay cả khi combo fail eligibility — show "Sẽ KHÔNG đủ điều kiện CĐ" warning)
+2. **Submit T1**: eligibility check chạy TRƯỚC KV freeze. Nếu fail → reject submit (HTTP 422); KV snapshot KHÔNG fire.
+3. **Engine T6**: chỉ chạy cho profile đã submit thành công → eligibility đã pass.
+
+→ KV resolution KHÔNG cần guard `_passes_eligibility()` because flow guarantee: invalid combos KHÔNG bao giờ reach T6 freeze.
+
+Tuy nhiên, FE PriorityTab nên show eligibility warning kết hợp KV preview để candidate sửa trước khi submit (UX defense).
+
+**4 special cases bypass** (TT 05/2021): PT DTNT / lớp dự bị / quân nhân / xuất ngũ → `permanent_commune_code`.
+
+#### Eligibility validation (NEW v1.3)
+
+System validate target program against (cultural, vocational):
+
+```python
+def validate_eligibility(profile, target_level):
+    """target_level: 'so_cap' | 'trung_cap' | 'cao_dang' | 'trung_hoc_nghe'"""
+    cultural = profile.cultural_education_level
+    vocational = profile.vocational_qualification
+
+    if target_level == 'cao_dang':
+        # Lối 1: Tốt nghiệp THPT
+        if cultural in ('graduated_thpt', 'graduated_gdtx'):
+            return None
+        # Lối 2: TC + chứng nhận văn hóa THPT (per TT 05/2021)
+        if vocational == 'trung_cap' and cultural in ('completed_thpt', 'graduated_thpt'):
+            return None
+        return "Cao đẳng yêu cầu Tốt nghiệp THPT HOẶC Tốt nghiệp TC + chứng nhận văn hóa THPT"
+
+    if target_level == 'trung_cap':
+        # Tốt nghiệp THCS và tương đương trở lên
+        if cultural in ('graduated_thcs', 'completed_thpt', 'graduated_thpt', 'graduated_gdtx'):
+            return None
+        return "Trung cấp yêu cầu tối thiểu Tốt nghiệp THCS"
+
+    # so_cap + trung_hoc_nghe: accept all (theo dự thảo TT 2026, chưa có quy định cụ thể)
+    return None
+```
+
+#### THCS KV strategy (giữ nguyên v1.2)
+- `vn_school` table chứa cả THCS + THPT + TRUNG_HOC_NGHE entries
+- THCS school KV derive at import time từ school's `ward_code` → `vn_commune_area_map` → KV (QĐ 861 chain)
+- Frozen snapshot pattern (xem Phase B.3)
+
+### 3. Trường THPT có "slowly-changing dimensions"
+
+- **Tên trường** có thể đổi (vd sát nhập 2 trường thành 1)
+- **KV của trường** có thể đổi qua các năm (TT mới, thay đổi địa giới hành chính)
+- **Trường có thể bị sát nhập / giải thể**
+
+→ Schema phải lookup KV **theo thời điểm học** (academic_year), không phải theo state hiện tại.
+
+---
+
+## Schema design
+
+### Table: `vn_school` (master directory)
+
+Replace existing `vn_high_school` (empty, deployed nhưng chưa dùng).
+
+```sql
+CREATE TABLE vn_school (
+    id BIGSERIAL PRIMARY KEY,
+
+    -- MOET reference (Bộ GD-ĐT 21/4/2025)
+    moet_school_code VARCHAR(10) NOT NULL,
+    moet_province_code VARCHAR(3) NOT NULL,
+    moet_district_code VARCHAR(5),
+
+    -- Canonical / current info (slowly-changing → see vn_school_name_history)
+    name VARCHAR(255) NOT NULL,
+    address TEXT,
+    province VARCHAR(100) NOT NULL,
+    district VARCHAR(100),
+    ward VARCHAR(100),
+
+    -- Level support: cả THCS + THPT + Trung học nghề (dự thảo TT 2026)
+    level VARCHAR(20) NOT NULL,  -- 'THCS' | 'THPT' | 'THCS_THPT' | 'TRUNG_HOC_NGHE' | 'OTHER'
+    is_dtnt BOOLEAN NOT NULL DEFAULT false,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+
+    -- Merger / dissolution tracking
+    merged_into_id BIGINT REFERENCES vn_school(id),
+    merge_effective_date DATE,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CHECK (level IN ('THCS', 'THPT', 'THCS_THPT', 'TRUNG_HOC_NGHE', 'OTHER'))
+);
+
+-- Active records: unique per province + MOET code
+CREATE UNIQUE INDEX uq_vn_school_moet_code_active
+    ON vn_school(moet_province_code, moet_school_code)
+    WHERE is_active = true;
+
+-- Fuzzy name search (PR4 candidate FE dropdown)
+CREATE INDEX ix_vn_school_name_trgm
+    ON vn_school USING gin (name gin_trgm_ops);
+```
+
+### Table: `vn_school_name_history` (đổi tên)
+
+```sql
+CREATE TABLE vn_school_name_history (
+    id BIGSERIAL PRIMARY KEY,
+    school_id BIGINT NOT NULL REFERENCES vn_school(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    effective_from DATE NOT NULL,
+    effective_to DATE,
+    notes TEXT,
+
+    UNIQUE(school_id, effective_from)
+);
+
+-- Lookup: tên trường tại 1 năm cụ thể
+CREATE INDEX ix_vn_school_name_history_lookup
+    ON vn_school_name_history(school_id, effective_from);
+```
+
+Query pattern:
+```sql
+SELECT name FROM vn_school_name_history
+WHERE school_id = :sid
+  AND effective_from <= :date
+  AND (effective_to IS NULL OR effective_to >= :date)
+ORDER BY effective_from DESC LIMIT 1;
+```
+
+### Table: `vn_school_kv_assignment` (KV theo năm)
+
+Trọng tâm của redesign — temporal lookup table.
+
+```sql
+CREATE TABLE vn_school_kv_assignment (
+    id BIGSERIAL PRIMARY KEY,
+    school_id BIGINT NOT NULL REFERENCES vn_school(id) ON DELETE CASCADE,
+
+    -- KV applicable trong khoảng năm này
+    kv_code VARCHAR(20) NOT NULL,
+    effective_from_year INTEGER NOT NULL,  -- vd 2023 = năm học 2023-2024
+    effective_to_year INTEGER,              -- NULL = ongoing
+
+    source VARCHAR(50) NOT NULL,  -- 'moet_2024' | 'moet_2025' | 'manual_admin'
+    notes TEXT,
+    created_by INTEGER REFERENCES "user"(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CHECK (kv_code ~ '^KV[1-9](-NT)?$'),
+    CHECK (effective_to_year IS NULL OR effective_to_year >= effective_from_year),
+
+    -- M3 simplification: drop EXCLUDE GiST constraint (btree_gist
+    -- extension dependency + ORM mirror complexity + test DB
+    -- create_all incompatibility). Replace với index + service-layer
+    -- overlap check.
+);
+
+CREATE INDEX ix_vn_school_kv_lookup
+    ON vn_school_kv_assignment(school_id, effective_from_year DESC);
+```
+
+**Service-layer overlap check** (replaces EXCLUDE constraint per M3 review fix):
+```python
+async def add_kv_assignment(db, school_id, kv_code, effective_from_year, effective_to_year=None):
+    """Reject if overlaps existing assignment for same school."""
+    overlapping = await db.execute(
+        select(VnSchoolKvAssignment)
+        .where(
+            VnSchoolKvAssignment.school_id == school_id,
+            VnSchoolKvAssignment.effective_from_year <= (effective_to_year or 9999),
+            or_(
+                VnSchoolKvAssignment.effective_to_year.is_(None),
+                VnSchoolKvAssignment.effective_to_year >= effective_from_year,
+            ),
+        )
+        .limit(1)
+    )
+    if overlapping.first():
+        raise ValidationError(
+            f"KV assignment overlap cho school_id={school_id} năm {effective_from_year}"
+        )
+    db.add(VnSchoolKvAssignment(...))
+```
+
+Trade-off accepted: lose DB-level guarantee, gain ORM compat + test DB compat + memory `migration-predicate-safety` alignment. Admin write path 100% via service → guarded.
+
+Query pattern (canonical KV lookup):
+```sql
+SELECT kv_code
+FROM vn_school_kv_assignment
+WHERE school_id = :school_id
+  AND :academic_year BETWEEN effective_from_year
+      AND COALESCE(effective_to_year, 9999)
+LIMIT 1;
+```
+
+### `admission_profile.academic_history` JSONB shape (mở rộng existing)
+
+```typescript
+{
+  // Existing fields (giữ nguyên backward compat)
+  school_name: string,        // Free-text snapshot at submit time
+  year_from: number,          // Năm bắt đầu (vd 2022)
+  year_to: number,            // Năm kết thúc (vd 2025)
+  gpa: number | null,
+  graduation_type: string | null,
+
+  // NEW fields cho KV resolution (Q9 #07 PR5 redesign)
+  school_id: number | null,           // FK to vn_school.id (null = manual entry chưa match)
+  level: 'THCS' | 'THPT' | 'OTHER',   // Cấp học
+  grade_from: number,                 // Lớp bắt đầu (6/7/8/9 hoặc 10/11/12)
+  grade_to: number,                   // Lớp kết thúc
+
+  // Snapshot at profile-submit time (audit-safe, frozen)
+  kv_at_attendance_snapshot?: {
+    by_year: Record<number, string>,  // { 2022: 'KV1', 2023: 'KV1', ... }
+    school_name_at_time: string,      // Tên trường tại thời điểm học
+    resolved_at: string,              // ISO datetime
+  } | null
+}
+```
+
+### Drop columns trên `admission_profile`
+
+```sql
+ALTER TABLE admission_profile
+    DROP COLUMN high_school_id,            -- PR1 phase1_08b — empty, no candidate data
+    DROP COLUMN high_school_kv_resolved,   -- PR1 phase1_08b — empty
+    DROP COLUMN area_resolution_reason;    -- canonical moved to priority_resolution_snapshot.manual_override_reason
+```
+
+Lý do: KV không còn là 1 field flat. Đã thay bằng:
+- `academic_history[].school_id` (multi-entry)
+- Snapshot computed result vào `priority_resolution_snapshot` JSONB column (xem dưới)
+
+### Note: `area_resolution_basis` column status (N4 fix)
+
+**KEEP existing column** từ PR1 phase1_08b — KHÔNG drop. Vẫn dùng cho:
+- Default value: `'high_school'` — KV auto-derive từ academic_history
+- Value `'permanent_address_special'` — trigger 4 special cases bypass (row 8 matrix)
+- Value `'manual_override'` — trigger admin/officer override (row 9 matrix)
+
+Algorithm `resolve_kv_for_profile` reads `area_resolution_basis` ở step 1 (xem helper `_derive_kv_basis_level`).
+
+Drop chỉ `area_resolution_reason` (text) — canonical moved vào `priority_resolution_snapshot.manual_override_reason`.
+
+### Add columns trên `admission_profile` (v1.3 — 2-field parallel)
+
+```sql
+ALTER TABLE admission_profile
+    ADD COLUMN cultural_education_level VARCHAR(30),
+    ADD COLUMN vocational_qualification VARCHAR(30) NOT NULL DEFAULT 'none';
+
+-- CHECK constraints (mirror phase1_09 migration)
+ALTER TABLE admission_profile
+    ADD CONSTRAINT ck_cultural_education_level CHECK (
+        cultural_education_level IS NULL OR cultural_education_level IN (
+            'completed_thcs', 'graduated_thcs',
+            'completed_thpt', 'graduated_thpt', 'graduated_gdtx'
+        )
+    ),
+    ADD CONSTRAINT ck_vocational_qualification CHECK (
+        vocational_qualification IN ('none', 'so_cap', 'trung_cap', 'cao_dang')
+    );
+```
+
+- `cultural_education_level` nullable — candidate có thể chưa chọn ở draft state
+- `vocational_qualification` NOT NULL DEFAULT `'none'` — auto fill cho 315 legacy + new profiles
+- Both fields read on submit → eligibility validation + KV basis derivation
+
+### NEW column: `admission_profile.priority_resolution_snapshot`
+
+Frozen kết quả compute KV tại submit time + breakdown for audit.
+
+```sql
+ALTER TABLE admission_profile
+    ADD COLUMN priority_resolution_snapshot JSONB DEFAULT '{}'::jsonb;
+```
+
+Shape (N3 standardized 2026-05-18 — separate `rule_applied` HOW vs `pathway` WHICH branch):
+```typescript
+{
+  kv_resolved: 'KV1' | 'KV2' | 'KV2-NT' | 'KV3' | null,
+  // rule_applied = HOW final value was decided
+  rule_applied:
+    | 'longest_duration'           // single KV winner by max years
+    | 'tiebreak_graduation_school' // tied → graduation school KV wins
+    | 'commune_lookup'             // fallback to permanent_commune_code
+    | 'manual_override'            // admin/officer fill
+    | 'ambiguous_requires_manual', // M1 edge: 2 graduation schools tied
+  // pathway = WHICH matrix branch fired (audit which row of matrix)
+  pathway:
+    | 'thpt_multi_school'    // Rows 1, 2 (full THPT history)
+    | 'tc_multi_school'      // Rows 2-fallthrough, 4 (TC time)
+    | 'commune_fallback'     // Rows 3, 5, 6 (THCS only / so_cap / completed_thpt+none)
+    | 'commune_special'      // Row 8 (4 special cases)
+    | 'manual'               // Row 9 (admin override)
+    | 'not_resolved',        // Row 7 (cultural chưa khai - draft)
+  breakdown: {
+    target_level: 'THPT' | 'TC' | 'COMMUNE',
+    entries: Array<{
+      school_id: number,
+      school_name_at_time: string,
+      year_from: number,
+      year_to: number,
+      years_by_kv: Array<{ year: number, kv: string }>
+    }>,
+    kv_totals: Record<string, number>,  // { 'KV1': 2, 'KV3': 1 }
+    winner_years: number,
+    tied_kv?: string[],
+    graduation_school_id?: number,
+    graduation_year?: number,
+    tied_entries?: number[],  // M1: 2 schools cùng year_to + grade_to → manual required
+    commune_code_used?: string  // TC pathway B
+  },
+  // M2 snapshot timing: tracked per freeze event
+  frozen_at: string,  // ISO datetime
+  frozen_at_status: 'draft_preview' | 'submitted_T1' | 'engine_T6',
+  resolved_by: 'system' | 'manual_admin',
+  manual_override_reason?: string  // Canonical — drops admission_profile.area_resolution_reason column
+}
+```
+
+### Snapshot timing spec (M2 review fix)
+
+| Profile lifecycle | Snapshot behavior | Purpose |
+|---|---|---|
+| `draft` / `revision_requested` | Computed real-time mỗi GET (Redis cache 5p); KHÔNG persist | UI preview while editing academic_history |
+| Submit T1 → `submitted` | **Freeze** at first submit; persisted vào JSONB column with `frozen_at_status='submitted_T1'` | Audit immutability post-submit |
+| Engine `evaluate_cascade` T6 → publish | **Re-freeze** với rates tại T6 (match Q-P3-11 `bonus_rule_snapshot` pattern); `frozen_at_status='engine_T6'` | Quy chế compliance — rates apply theo thời điểm xét tuyển |
+| Final states (`enrolled`/`rejected`/`withdrawn`) | Frozen, immutable | Audit history |
+
+Implementation: service `freeze_priority_snapshot(profile, status_at_freeze)` called from `submit_admission_profile` (T1) + `evaluate_cascade` (T6).
+
+---
+
+## Resolution algorithm (BE service)
+
+```python
+def resolve_kv_for_profile(
+    profile: AdmissionProfile,
+    db: AsyncSession
+) -> tuple[str | None, dict]:
+    """
+    TT 05/2021 Phụ lục 01 — KV resolution per academic history.
+
+    Branched by (cultural_education_level, vocational_qualification) — v1.3 2-field:
+
+    | Cultural | Vocational | Basis filter | Rule |
+    |---|---|---|---|
+    | graduated_thpt / graduated_gdtx | any | level='THPT' | thpt_multi_school |
+    | completed_thpt | trung_cap / cao_dang | level='THPT' (3-yr if exist) | thpt_multi_school |
+    | graduated_thcs | trung_cap / cao_dang | level='TC' | tc_multi_school |
+    | graduated_thcs | none / so_cap | (none) | commune_fallback |
+    | completed_thcs | any | (none) | commune_fallback |
+    | (any) + special_case basis | bypass | (none) | commune_special |
+
+    Steps:
+    1. Check special case bypass → commune lookup
+    2. Derive basis_level từ (cultural, vocational) per matrix
+    3. Filter basis_entries: history entries với level == basis_level + school_id
+    4. Per entry: lookup KV cho từng năm trong khoảng (year_from..year_to)
+       - THPT entries: KV từ vn_school_kv_assignment direct (MOET pre-compute)
+       - TC entries: KV derived từ school.ward → vn_commune_area_map (QĐ 861 chain)
+    5. Sum thời gian theo KV
+    6. Pick KV với max duration
+    7. Tiebreak: KV của trường tốt nghiệp
+    8. M1 edge: nếu tiebreak ambiguous (2 entries cùng year_to+grade_to) → require manual
+    """
+    cultural = getattr(profile, 'cultural_education_level', None)
+    vocational = getattr(profile, 'vocational_qualification', 'none')
+
+    # Special cases bypass (4 case TT 05/2021): PT DTNT / dự bị / quân nhân / xuất ngũ
+    if profile.area_resolution_basis == 'permanent_address_special':
+        if profile.permanent_commune_code:
+            kv = await _lookup_commune_kv(db, profile.permanent_commune_code)
+            return kv, {
+                'rule': 'permanent_commune_special_case',
+                'pathway': 'commune_special',
+                'commune_code_used': profile.permanent_commune_code,
+            }
+        return None, {'reason': 'special_case_no_commune', 'requires_manual_override': True}
+
+    # Derive basis_level from (cultural, vocational) matrix
+    basis_level = _derive_kv_basis_level(cultural, vocational)
+    # Returns: 'THPT' | 'TC' | 'COMMUNE_FALLBACK' | None
+
+    if basis_level == 'COMMUNE_FALLBACK':
+        if profile.permanent_commune_code:
+            kv = await _lookup_commune_kv(db, profile.permanent_commune_code)
+            return kv, {
+                'rule': 'commune_fallback_thcs_or_so_cap',
+                'pathway': 'commune_fallback',
+                'commune_code_used': profile.permanent_commune_code,
+            }
+        return None, {'reason': 'thcs_no_commune', 'requires_manual_override': True}
+
+    if basis_level is None:
+        return None, {'reason': 'cultural_not_set', 'requires_manual_override': True}
+
+    # Multi-school rule applies (THPT or TC)
+    history = profile.academic_history or []
+    basis_entries = [
+        e for e in history
+        if e.get('level') == basis_level and e.get('school_id')
+    ]
+
+    if not basis_entries:
+        return None, {'reason': 'no_qualifying_entries', 'requires_manual_override': True}
+
+    # Per-year KV duration map
+    kv_years: dict[str, int] = {}
+    breakdown_per_entry = []
+
+    for entry in basis_entries:
+        sid = entry['school_id']
+        y_from = entry['year_from']
+        y_to = entry['year_to']
+
+        entry_years_by_kv = []
+        for year in range(y_from, y_to + 1):
+            kv = await lookup_kv_for_school_year(db, sid, year)
+            if kv:
+                kv_years[kv] = kv_years.get(kv, 0) + 1
+                entry_years_by_kv.append({'year': year, 'kv': kv})
+
+        breakdown_per_entry.append({
+            'school_id': sid,
+            'school_name_at_time': entry.get('school_name'),
+            'year_from': y_from,
+            'year_to': y_to,
+            'years_by_kv': entry_years_by_kv,
+        })
+
+    if not kv_years:
+        return None, {'reason': 'no_kv_lookup_succeeded'}
+
+    max_yrs = max(kv_years.values())
+    winners = [kv for kv, y in kv_years.items() if y == max_yrs]
+
+    if len(winners) == 1:
+        return winners[0], {
+            'rule': 'longest_duration',
+            'winner_years': max_yrs,
+            'breakdown': breakdown_per_entry,
+            'kv_totals': kv_years,
+        }
+
+    # Tiebreak: KV của trường tốt nghiệp
+    # M1 review fix: stable sort + detect ambiguous (2 entries cùng year_to+grade_to)
+    candidates = sorted(
+        enumerate(basis_entries),
+        key=lambda pair: (pair[1]['year_to'], pair[1].get('grade_to', 0), pair[0]),
+        reverse=True,
+    )
+    if len(candidates) >= 2:
+        top, second = candidates[0][1], candidates[1][1]
+        if (top['year_to'] == second['year_to']
+            and top.get('grade_to') == second.get('grade_to')):
+            return None, {
+                'rule': 'ambiguous_requires_manual',
+                'reason': 'tied_graduation_year_and_grade',
+                'tied_entries': [top['school_id'], second['school_id']],
+                'requires_manual_override': True,
+                'breakdown': breakdown_per_entry,
+                'kv_totals': kv_years,
+            }
+
+    grad_entry = candidates[0][1]
+    grad_kv = await lookup_kv_for_school_year(
+        db, grad_entry['school_id'], grad_entry['year_to']
+    )
+
+    return grad_kv, {
+        'rule': 'thpt_tiebreak_graduation_school',
+        'tied_kv': winners,
+        'graduation_school_id': grad_entry['school_id'],
+        'graduation_year': grad_entry['year_to'],
+        'breakdown': breakdown_per_entry,
+        'kv_totals': kv_years,
+    }
+```
+
+### Special cases bypass
+
+4 trường hợp đặc biệt TT 05/2021 (PT DTNT/lớp dự bị/quân nhân/xuất ngũ) skip rule trên, dùng `permanent_commune_code` → `vn_commune_area_map`. Existing PR1 schema giữ nguyên.
+
+---
+
+## Migration strategy
+
+### Phase A: Schema cutover (new migration `phase1_09`)
+
+PR1 `phase1_08b` đã deployed nhưng các bảng `vn_high_school` + columns `high_school_id`/`high_school_kv_resolved` chưa có data thực (315 profiles existing có values NULL all).
+
+```python
+# phase1_09_priority_kv_temporal.py
+
+def upgrade():
+    # 1. Drop PR1 empty placeholder
+    op.drop_table('vn_high_school')  # 0 rows
+    op.drop_column('admission_profile', 'high_school_id')
+    op.drop_column('admission_profile', 'high_school_kv_resolved')
+
+    # 2. Create vn_school + history + kv_assignment
+    op.create_table('vn_school', ...)
+    op.create_table('vn_school_name_history', ...)
+    op.create_table('vn_school_kv_assignment', ...)
+
+    # 3. Add resolution snapshot column
+    op.add_column('admission_profile',
+        sa.Column('priority_resolution_snapshot', JSONB,
+                  server_default=sa.text("'{}'::jsonb"), nullable=False))
+
+def downgrade():
+    op.drop_column('admission_profile', 'priority_resolution_snapshot')
+    op.drop_table('vn_school_kv_assignment')
+    op.drop_table('vn_school_name_history')
+    op.drop_table('vn_school')
+    # Restore PR1 columns (best effort)
+    op.add_column('admission_profile',
+        sa.Column('high_school_id', sa.BigInteger, nullable=True))
+    op.add_column('admission_profile',
+        sa.Column('high_school_kv_resolved', sa.String(20), nullable=True))
+    op.create_table('vn_high_school', ...)  # original PR1 shape
+```
+
+### Phase B: MOET school + BNV commune data import
+
+**B.1 — MOET THPT school import** (replaces original PR4):
+
+Script `app/scripts/import_moet_schools_2025.py`:
+
+1. Read MOET file `3. Danh sach trường THPT 21.4.2025.xls` (~6,822 rows)
+2. Verify column structure trước implement (m3 review polish — open MOET file + audit format)
+3. For each row → upsert `vn_school` với `level='THPT'` (matched by `moet_province_code` + `moet_school_code`)
+4. For each row → insert `vn_school_kv_assignment` với `effective_from_year=2025`, `source='moet_2025'`
+5. (Optional) read older MOET dumps for retro KV assignments
+
+**B.2 — VN commune KV map import** (NEW — required cho 4 special cases + **THCS school KV derive** + TC ward fallback):
+
+Script `app/scripts/import_commune_kv_map.py`:
+
+Data source chain (no single canonical file — Stage 1 hybrid strategy):
+
+1. **Stage 1 (ship NGAY)**: Parse QĐ 861/QĐ-TTg PDF (4/6/2021) extract ~3,434 xã KV I/II/III DTTS → map sang KV1 tuyển sinh. Reuse `administrative_nodes` existing (memory `admin-nodes-gso-alignment`) cho province/district/ward lookup. Default mapping cho commune NOT in DTTS list: KV3 if phường thành phố TƯ, KV2 if phường tỉnh hoặc xã thành phố TƯ, KV2-NT otherwise.
+
+2. **Stage 2 (parallel)**: Scrape thuvienphapluat.vn / FPT / HNUE bảng tra cứu để reconcile + identify gaps.
+
+3. **Stage 3 (long-term post mùa 2026)**: Track 63 QĐ UBND tỉnh ban hành giai đoạn 2026-2030 (theo memo Luật Việt Nam 01/07/2025 phân quyền).
+
+**KV mapping rule** (Bộ GD-ĐT vs Ủy ban Dân tộc):
+
+⚠️ **Critical correction 2026-05-17**: QĐ 861 KV I/II/III (vùng DTTS classification gradients) **ALL** map → TT KV1 tuyển sinh (0.75đ). KHÔNG phải 1→KV1, 2→KV2, 3→KV3. KV I/II/III của QĐ 861 chỉ là internal disadvantaged-level gradient trong DTTS context — TT 06/2026 + TT 05/2021 KV1 tuyển sinh là tập union rộng hơn.
+
+- **KV1 tuyển sinh** = (xã KV I/II/III vùng DTTS theo QĐ 861) ∪ xã biên giới ∪ xã hải đảo ∪ xã đặc khu ∪ xã bãi ngang ven biển (QĐ 353/2022)
+- **KV2-NT** = xã ngoài KV1 (rural default, fallback)
+- **KV2** = phường tỉnh + xã thành phố TƯ ngoài KV1
+- **KV3** = phường thành phố TƯ ngoài KV1
+
+**Data source verified** (research 2026-05-17): repo đã có `Documents/Seeding data/data province/`:
+- `wards.sql` — **3,321 commune** post-sáp nhập 1/7/2025 với BNV 5-digit codes
+- `provinces.sql` — **34 provinces** mới
+- `ward_mappings.sql` — **10,039 old→new code mappings** (resolve pre-2025 names trong QĐ 861)
+
+**Primary external source**: [luatvietnam.vn QĐ 861 HTML tables](https://luatvietnam.vn/chinh-sach/quyet-dinh-861-qd-ttg-danh-sach-cac-xa-khu-vuc-iii-ii-i-2021-2025-203245-d1.html) — verified WebFetch-accessible (chinhphu.vn blocked).
+
+**Realistic Stage 1 effort**: ~6-7h (WebFetch chunks 3h + fuzzy match legacy 2h + QA 30min + script 1h).
+
+**B.3 — TC school KV (N1 revised 2026-05-18)** — manual admin entry preferred:
+
+V1.2 đề xuất ward-derive THCS KV. V1.3 dropped THCS multi-school rule per TT (chỉ THPT + TC có multi-school rule). Refocus B.3 vào **TC school KV**:
+
+Script `app/scripts/seed_tc_schools_initial.py`:
+
+1. **TC schools nation-wide ~100-200 schools** (per Bộ LĐTBXH statistics) — feasible cho manual admin entry
+2. **N1 revised**: KHÔNG ward-derive (risk mismatch — TC schools thường ở khu công nghiệp với KV khác địa chỉ trường). Admin explicit manual entry per TC school + `vn_school_kv_assignment` row với `source='manual_admin'`
+3. Bootstrap data: top 50 TC schools by enrollment volume (admin pre-seed before mùa 2026-08-01)
+4. Long-term: locate Bộ LĐTBXH TC school registry nếu publish (Stage 3)
+
+**THCS schools**: schema support `level='THCS'` trong `vn_school` cho audit log purposes (candidate khai academic_history THCS entry → store free-text school name). KHÔNG cần KV assignment vì THCS không có multi-school rule.
+
+Effort: ~0.3d (Stage 1 manual seed 50 TC schools + 0.2d hook admin form vn_school).
+
+**Phase B total**: ~1.8d (1d MOET THPT B.1 + 0.5d commune KV map B.2 + 0.3d TC manual seed B.3).
+
+### Phase C: BE engine (replaces PR2 KV portion)
+
+- `priority_service.resolve_kv_for_profile()` per algorithm above
+- Snapshot to `priority_resolution_snapshot` at submit time
+- Engine bonus computation reads `priority_resolution_snapshot.kv_resolved`
+
+### Phase D: FE candidate UI (replaces PR5 PriorityTab)
+
+**AcademicHistoryTab** (upgrade existing): mỗi row có:
+- Dropdown chọn trường (search `vn_school` API) → sets `school_id`
+- Auto-detect level từ chosen school's `level` field, allow manual override
+- Grade range input (lớp X → lớp Y) → BE computes year range based on entry year
+- Display "KV năm Y: KV1" inline (lookup `vn_school_kv_assignment` qua API)
+
+**PriorityTab** (rewrite từ đầu):
+```
+┌────────────────────────────────────────────────┐
+│ 📊 Khu vực ưu tiên (tự động xác định)         │
+├────────────────────────────────────────────────┤
+│ Cơ sở: Lịch sử học tập (hệ Cao đẳng → THPT)   │
+│                                                │
+│ • THPT Lê Quý Đôn (KV1): 2 năm (2022-2024)    │
+│ • THPT Trần Đại Nghĩa (KV3): 1 năm (2024-2025)│
+│   ↳ Trường tốt nghiệp                          │
+│                                                │
+│ → KV1 (theo thời gian học lâu hơn)            │
+│   Quy chế TT 05/2021 Phụ lục 01                │
+│                                                │
+│ [✏ Ghi đè thủ công]   [✓ Đồng ý]              │
+└────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────┐
+│ 🏅 Đối tượng ưu tiên (UT)                     │
+│ ... (same as PR5 original) ...                 │
+└────────────────────────────────────────────────┘
+```
+
+### Phase E: Officer FE (PR6)
+
+- Verify evidence cho UT codes (Q9 #07 PR6 scope)
+- Review KV breakdown trong audit log
+
+### Phase F: Admin backfill (PR7)
+
+- Tool fill `school_id` cho 315 existing profiles từ `school_name` (fuzzy match)
+- Manual `vn_school_kv_assignment` cho năm cũ nếu chưa import
+
+---
+
+## Edge cases handled
+
+| Case | Handling |
+|---|---|
+| Trường sát nhập | `vn_school.merged_into_id` chain; KV lookup vẫn dùng `school_id` gốc + năm gốc (không follow merger) |
+| Trường đổi tên | `vn_school_name_history` track; UI show tên hiện tại với note "(Tên cũ: X)" |
+| KV của trường đổi giữa năm học | Granularity = năm học (academic_year), không tháng. Acceptable per TT |
+| Học sinh học liên thông TC→CĐ | (cultural=completed/graduated_thpt, vocational=trung_cap) → THPT multi-school nếu có history, else TC rule |
+| Học sinh chuyển hệ giữa chừng | `level` per-entry; basis_entries filter theo derived basis_level từ (cultural, vocational) |
+| 4 case đặc biệt (PT DTNT/dự bị/quân nhân/xuất ngũ) | Bypass logic, dùng `permanent_commune_code` (existing PR1 logic) |
+| Học sinh học ở nước ngoài | MOET file có sẵn entry mã `800` mỗi tỉnh = KV3 (cultural=graduated_thpt only) |
+| Tốt nghiệp THCS đi làm 5 năm → thi TC | (cultural=graduated_thcs, vocational=none) → commune_fallback (TC chưa nhập học) |
+| Đã có Sơ cấp, muốn lên TC | (cultural=graduated_thcs, vocational=so_cap) → commune_fallback (Sơ cấp không qualify cho TC multi-school) |
+| TC tốt nghiệp + thi CĐ liên thông | (cultural=completed_thpt, vocational=trung_cap) → THPT rule (nếu có) hoặc TC rule fallback |
+| Trung học nghề (dự thảo 2026) | Future: cấp mới `level='TRUNG_HOC_NGHE'` — schema ready, rule TBD khi TT ban hành chính thức |
+
+---
+
+## Open questions
+
+1. ~~**Backfill 315 hồ sơ existing**~~: **RESOLVED 2026-05-17** — 315 KHÔNG phải prod data, chỉ là test fixtures. Backfill workflow chỉ cần cover real candidates post-deploy mùa 2026-08-01.
+
+2. **Năm học cross-format**: TT 05/2021 không define rõ "năm" = năm dương lịch hay năm học. Implementation hiện đề xuất dùng năm dương lịch (vd 2024 = năm học 2024-2025 hoặc 2023-2024 depending on context). Cần confirm với admin nghiệp vụ.
+
+3. **TT mới có thể đổi rule**: TT 2026 BGDĐT đang dự thảo. Có cần rule pluggable (config per academic_year) không? Hay vẫn hardcode TT 05/2021 và refactor khi TT mới ban hành?
+
+4. **Hệ liên thông TC→CĐ**: KV xác định theo THPT hay theo cấp đã tốt nghiệp (TC)? TT 05/2021 không nói rõ. Default: theo cấp gần nhất đã tốt nghiệp.
+
+5. **Trường THPT chuyên / trường quốc tế** (chưa có trong MOET list): manual_override basis với reason text.
+
+6. ~~**THCS school dictionary cho hệ TC**~~: **REVISED 2026-05-18 v1.3** — Per Luật GDNN + TT 05/2021 verbatim, multi-school rule chỉ apply cho **THPT (3 năm)** HOẶC **TC (thời gian học)**, KHÔNG có rule THCS-multi-school. THCS-only candidates fall back to `permanent_commune_code`. Schema vẫn support `level='THCS'` entries trong `academic_history` cho audit log (candidate khai school name historical) nhưng KHÔNG dùng cho KV multi-school resolution. THCS school KV derive in `vn_school` table reserve cho future use case (vd: dự thảo TT 2026 Trung học nghề).
+
+7. ~~**Diploma conflict handling**~~: **RESOLVED 2026-05-18 v1.3** — Split thành 2 field parallel (cultural + vocational). KHÔNG còn conflict vì candidate khai cả 2 dimension độc lập. Validation: eligibility check ở `validate_eligibility(profile, target_level)` đảm bảo combination hợp lệ theo TT 05/2021 Điều 4.
+
+---
+
+## Effort estimate (v1.3 — 2-field parallel 2026-05-18)
+
+| Phase | Description | v1.2 | v1.3 | Δ |
+|---|---|---|---|---|
+| A | Migration phase1_09 (drop legacy + create vn_school + 2 cultural/vocational columns) | 1.75d | 2d | +0.25d (2 columns + CHECK + eligibility validator unit tests) |
+| B | MOET THPT + commune KV map (+ THCS schema-only) | 2.5d | 2d | -0.5d (THCS no multi-school rule → defer B.3 scaffold) |
+| C | BE resolve_kv (2-field matrix) + eligibility validator + tests | 2.5d | 3d | +0.5d (matrix derivation + eligibility validator + edge case tests) |
+| D | FE AcademicHistoryTab + PriorityTab + 2 dropdown (cultural + vocational) | 3.5d | 3.5d | — |
+| E | Officer FE verify (PR6 scope) | 2d | 2d | — |
+| F | Admin backfill (PR7 scope) | 2d | 2d | — |
+| **Total** | | **~14.25d** | **~14.5d** | +0.25d (net) |
+
+vs original plan (PR1 schema + PR2 engine + PR4 import + PR5 single FE + PR6 + PR7): **~14d** equivalent. 2-field design more accurate per VN convention + Luật GDNN, KHÔNG cần derive logic phức tạp.
+
+---
+
+## Open follow-ups (track separately)
+
+- TT 2026 BGDĐT công bố → adapter cho phép switch rule per academic_year
+- ~~File 2 (districts) + File 3 (KK communes) import~~ → **Required NOW** cho 4 special cases + THCS school KV derive. Moved vào Phase B.2.
+- ~~THCS school list (separate MOET file?)~~ → **REVISED 2026-05-17**: needed cho diploma=THCS candidates; resolution = manual scaffold + ward-derive KV (Phase B.3) — không cần canonical MOET file.
+- 63 QĐ UBND tỉnh 2026-2030: track + automate update khi tỉnh ban hành (Stage 3 long-term)
+- Verify MOET THPT file `(moet_province_code, moet_school_code)` composite unique assumption
+- TC liên thông từ TC sang CĐ: diploma=TC pathway covered (sub-case A2); verify TC school KV derivation accuracy
+- Diploma derivation logic: rule để derive `diploma_submitted` từ `academic_history` (highest `graduation_type`) — handle conflict cases (vd khai THPT + TC cùng lúc, candidate đã tốt nghiệp 2 cấp)

--- a/Documents/research_qd861_data_source.md
+++ b/Documents/research_qd861_data_source.md
@@ -1,0 +1,193 @@
+# QĐ 861 / TT 05/2021 → KV Commune Mapping — Data Source Research
+
+**Date**: 2026-05-17
+**Owner**: solo dev
+**Audience**: Q9 #07 PR4 (CSV import for `vn_commune_area_map`)
+
+---
+
+## Critical finding — DON'T rebuild what's already shipped
+
+Repo đã có **3,321 wards post-sáp nhập 1/7/2025** + **34 provinces mới** seeded sẵn:
+
+| File | Rows | Schema |
+|------|------|--------|
+| `Documents/Seeding data/data province/wards.sql` | 3,321 | `(ward_code VARCHAR(6), name, province_code VARCHAR(2))` — codes from BNV (vd `00025` = Phường Giảng Võ) |
+| `Documents/Seeding data/data province/provinces.sql` | 34 | Hà Nội/HCM/Huế/Đà Nẵng/Hải Phòng/Cần Thơ + 28 tỉnh — đã apply Nghị quyết UBTVQH 16/6/2025 |
+| `Documents/Seeding data/data province/ward_mappings.sql` | 10,039 | Old→new code mappings (pre→post sáp nhập) |
+
+**Schema mismatch warning**: `wards.sql` dùng `(province_code, ward_code)` 2-tier (no district level vì sáp nhập đã xóa cấp huyện), trong khi `VnCommuneAreaMap` model dùng `(commune_code, province, district, ward)` 4-field text — PR4 sẽ cần map. District field có thể null hoặc derive từ ward_mappings old_district.
+
+→ **Step 1 dataset = JOIN wards.sql với KV classification từ QĐ 861/698**, KHÔNG cần tải lại admin division.
+
+---
+
+## Sources by Priority
+
+### P1 — QĐ 861/QĐ-TTg (2021) — primary KV I/II/III source
+
+- **Source PDF**: <https://vanban.chinhphu.vn/?pageid=27160&docid=203373> (WebFetch denied — robots/auth)
+- **Best alternate mirror**: <https://luatvietnam.vn/chinh-sach/quyet-dinh-861-qd-ttg-danh-sach-cac-xa-khu-vuc-iii-ii-i-2021-2025-203245-d1.html> — **HTML table inline, parseable** (verified 50 rows extracted, sample below)
+- **Backup**: <https://thuvienphapluat.vn/van-ban/Van-hoa-Xa-hoi/Quyet-dinh-861-QD-TTg-2021-danh-sach-cac-xa-III-II-I-vung-dong-bao-dan-toc-thieu-so-mien-nui-476885.aspx> — also has HTML tables
+- **Coverage**: 3,434 xã ở 51 tỉnh (cũ — pre-sáp nhập 2021), 1,673 KV I + 210 KV II + 1,551 KV III
+- **Caveat**: Districts/wards là **tên cũ** trước sáp nhập 2025 → phải fuzzy-match với `wards.sql` (post-sáp nhập tên mới) qua `ward_mappings.sql` (old→new code) — đây là lý do `ward_mappings.sql` 10k rows tồn tại trong repo
+
+### P2 — QĐ 698/QĐ-TTg (19/7/2024) — amendment
+
+- **Source**: <https://vanban.chinhphu.vn/?pageid=27160&docid=210708>
+- **Alternate**: <https://thuvienphapluat.vn/van-ban/Van-hoa-Xa-hoi/Quyet-dinh-698-QD-TTg-2024-dieu-chinh-danh-sach-xa-khu-vuc-III-vung-dan-toc-thieu-so-mien-nui-618054.aspx>
+- **Changes**: Add 2 thị trấn vào KV I (TT Yên Sơn-Tuyên Quang, TT Quân Chu-Thái Nguyên) + xã Mường Báng (Tủa Chùa, Điện Biên) KV II → KV III + 2 deletions from KV I. Diff << 1% — apply as patch sau base import QĐ 861.
+
+### P3 — QĐ 353/QĐ-TTg (15/3/2022) — coastal/island disadvantaged
+
+- **Source**: <https://thuvienphapluat.vn/van-ban/Van-hoa-Xa-hoi/Quyet-dinh-353-QD-TTg-2022-phe-duyet-Danh-sach-huyen-ngheo-vung-bai-ngang-ven-bien-506772.aspx>
+- **Coverage**: 74 huyện nghèo + 54 xã đặc biệt khó khăn vùng bãi ngang ven biển hải đảo ở 12 tỉnh — bổ sung KV1 cho tuyển sinh
+- **Status**: ~54 rows extra, low priority Stage 1
+
+### P4 — TT 06/2026/TT-BGDĐT — 2026 university admission regulation
+
+- **Source**: <https://baochinhphu.vn/bo-gddt-chot-quy-dinh-tuyen-sinh-dai-hoc-2026-102260505095923563.htm>
+- **Issued**: 15/02/2026
+- **Confirms**: KV1=0.75, KV2-NT=0.50, KV2=0.25, KV3=0 (đã match seed plan trong `phase1_08b`)
+- **CRITICAL**: Phụ lục I định nghĩa criteria, NHƯNG **không list xã cụ thể** → vẫn phải reference QĐ 861/698 + QĐ 353 + danh sách phường nội thành TP TW
+- **Post-01/07/2025 phân quyền UBND tỉnh ban hành QĐ riêng giai đoạn 2026-2030** → roadmap vẫn pending province-level revisions
+
+### P5 — Open-data fallbacks
+
+- <https://danhmuchanhchinh.gso.gov.vn/> — GSO catalog, có "Xuất Excel" button (lookup district/ward, NO KV classification)
+- <https://github.com/ThangLeQuoc/vietnamese-provinces-database> — v3.0.2 (20/7/2025), post-merger, has `code`, **KHÔNG có KV** field — confirmed via WebFetch
+- <https://github.com/daohoangson/dvhcvn> — 3-level admin JSON, **KHÔNG có KV** — confirmed
+
+→ **Không có dataset open-source nào pre-joined KV + commune.** Phải tự build.
+
+---
+
+## Sample data — verified extraction từ luatvietnam.vn (50 rows)
+
+```csv
+province,district,ward,area_code,source
+An Giang,Tri Tôn,Thị trấn Tri Tôn,KV1,QĐ861
+An Giang,Tri Tôn,Xã An Tức,KV1,QĐ861
+An Giang,Tri Tôn,Xã Ô Lâm,KV1,QĐ861
+An Giang,Tri Tôn,Xã Cô Tô,KV1,QĐ861
+An Giang,Tri Tôn,Xã Châu Lăng,KV1,QĐ861
+An Giang,Tri Tôn,Xã Lương Phi,KV1,QĐ861
+An Giang,Tri Tôn,Xã Lê Tri,KV1,QĐ861
+An Giang,Tri Tôn,Xã Núi Tô,KV1,QĐ861
+An Giang,Tịnh Biên,Xã An Cư,KV1,QĐ861
+An Giang,Tịnh Biên,Xã Văn Giáo,KV1,QĐ861
+An Giang,Tịnh Biên,Xã An Hảo,KV1,QĐ861
+An Giang,Tịnh Biên,Xã Tân Lợi,KV1,QĐ861
+An Giang,Tịnh Biên,Xã Vĩnh Trung,KV1,QĐ861
+An Giang,An Phú,Xã Nhơn Hội,KV1,QĐ861
+An Giang,Tân Châu,Xã Châu Phong,KV1,QĐ861
+An Giang,Thoại Sơn,Thị trấn Óc Eo,KV1,QĐ861
+Bắc Giang,Lạng Giang,Xã Hương Sơn,KV1,QĐ861
+Bắc Giang,Lạng Giang,Xã Yên Mỹ,KV1,QĐ861
+Bắc Giang,Lạng Giang,Xã Hương Lạc,KV1,QĐ861
+Bắc Giang,Sơn Động,Thị trấn An Châu,KV1,QĐ861
+```
+
+> NOTE: TT 06/2026 KV I/II/III của QĐ 861 đều = **KV1 tuyển sinh** (đều thuộc "vùng đồng bào dân tộc thiểu số và miền núi"). Không phải mapping I→KV1, II→KV2, III→KV3 — đây là common confusion. KV1 = ưu tiên cao nhất bonus 0.75.
+
+---
+
+## Mapping rules — QĐ 861 KV → TT 06/2026 KV tuyển sinh
+
+| QĐ 861 zone | Meaning | TT 06/2026 area_code | Bonus |
+|-------------|---------|---------------------|-------|
+| KV I (an toàn) | Xã miền núi DTTS bước đầu phát triển | **KV1** | 0.75 |
+| KV II (khó khăn) | Xã miền núi DTTS còn khó khăn | **KV1** | 0.75 |
+| KV III (đặc biệt khó khăn) | Xã miền núi DTTS đặc biệt khó khăn | **KV1** | 0.75 |
+| QĐ 353 xã bãi ngang | Đặc biệt khó khăn coastal | **KV1** | 0.75 |
+| Phường nội thành TP TW (HN, HCM, HP, ĐN, Cần Thơ, Huế) | Inner-city | **KV3** | 0 |
+| Phường thuộc TX/TP trực thuộc tỉnh + xã ngoại thành TP TW | Thị xã/TP cấp tỉnh | **KV2** | 0.25 |
+| Tất cả xã còn lại | Nông thôn không-KV1 | **KV2-NT** | 0.50 |
+
+→ Algorithm: default `KV2-NT` cho mọi xã không-classification, sau đó override theo 3 list (QĐ 861 → KV1, QĐ 353 → KV1, phường nội thành TP TW → KV3, phường khác/xã ngoại thành TP TW → KV2).
+
+---
+
+## Recommended approach (Top-1)
+
+**Approach A — Hybrid join** (recommended):
+
+1. **Base** = `wards.sql` 3,321 rows post-merger 2025 (already in repo)
+2. **Default** all wards → `area_code = 'KV2-NT'`
+3. **Extract** QĐ 861 + 698 (~3,434 rows) từ luatvietnam.vn HTML (continue WebFetch in 50-row chunks)
+4. **Extract** QĐ 353 ~54 xã bãi ngang
+5. **Override** phường nội thành 5-6 TP TW → `KV3` (Hà Nội, HCM, Hải Phòng, Đà Nẵng, Cần Thơ, Huế — derive từ province_code + name LIKE 'Phường%')
+6. **Override** phường/xã thuộc TP cấp tỉnh → `KV2`
+7. **Fuzzy-match** pre-2025 xã names trong QĐ 861 với post-2025 ward_code via `ward_mappings.sql` old→new mapping. Confidence threshold + manual review queue
+8. **Output**: CSV `commune_code, province, district, ward, area_code, effective_from_year, source` ready for PR4 import
+
+**Effort estimate**:
+- Extract QĐ 861 từ HTML (3,434 rows, ~70 chunks × 50 rows): ~3h scripted WebFetch
+- Extract QĐ 353 (~54 rows): ~15 min
+- Build default + TP TW override: ~30 min SQL
+- Fuzzy match old→new commune via ward_mappings: ~2h (Levenshtein/trigram, manual review ~5% edge cases)
+- QA verification sample 50 rows: ~30 min
+- **Total Stage 1: 6-7 hours actual work, ship within 1 day**
+
+**Fallback if WebFetch rate-limited**:
+- Manual paste full HTML tables of QĐ 861 từ luatvietnam.vn vào file local (đã verified inline table format)
+- Or screenshot+OCR (lower confidence, NOT recommended)
+
+---
+
+## Top-10 priority provinces (data-entry fallback)
+
+Nếu Approach A blocked, manual entry theo volume:
+
+| Rank | Province | Reason | Est commune count |
+|------|----------|--------|-------------------|
+| 1 | Hà Nội | Capital, TP TW, big enrollment | 526 |
+| 2 | HCM | TP TW, largest enrollment | 273 |
+| 3 | Hải Phòng | TP TW | 167 |
+| 4 | Đà Nẵng | TP TW | 94 |
+| 5 | Cần Thơ | TP TW | 103 |
+| 6 | Huế | TP TW (mới 2026) | 133 |
+| 7 | Thanh Hóa | Province, large DTTS + bãi ngang | 166 |
+| 8 | Nghệ An | Largest geographic + DTTS | 130 |
+| 9 | Đồng Nai | Bordering HCM, high migration | 95 |
+| 10 | Hà Tĩnh | DTTS + bãi ngang | 69 |
+
+→ TP TW (1-6) = ~1,296 communes, mostly KV2/KV3 → can be done quickly (default → KV3 cho phường, KV2 cho xã). 7-10 = ~460 communes mix → manual review.
+
+---
+
+## Schema verification — MOET school code format
+
+**Question**: `(moet_province_code, moet_school_code)` composite unique?
+
+**Answer**: **YES, confirmed via Q9_07_PR5_REDESIGN.md** line 84-87:
+
+```sql
+CREATE UNIQUE INDEX uq_vn_school_moet_code_active
+    ON vn_school(moet_province_code, moet_school_code)
+    WHERE is_active = true;
+```
+
+MOET issues mỗi tỉnh 1 namespace school code → tuple unique GLOBAL. Format: province (3 chars) + school (variable, typically 5-7 chars numeric). Reference file `3. Danh sach trường THPT 21.4.2025.xls` mentioned in Q9_07 plan as canonical seed; need separate import script (NOT in scope this research). Sample provincial files may be available via MOET portal nhưng KHÔNG có public Excel download URL surface trong search — likely needs phone request to Sở GD&ĐT.
+
+---
+
+## Next actions
+
+1. ✅ Research done — sources identified, samples verified
+2. 🟡 PR4-prep: Write Python script in `Backend_FastAPI/scripts/build_kv_dataset.py` that:
+   - Loads `wards.sql` (3,321 rows)
+   - Loads `ward_mappings.sql` (old→new mapping)
+   - Fetches luatvietnam.vn HTML in chunks (50 rows × 70 = 3,500 total target)
+   - Parses + fuzzy-matches old commune name → new ward_code
+   - Outputs `Backend_FastAPI/app/seed/vn_commune_kv.csv` for PR4 import
+3. 🟡 Manual review queue: ~5% edge cases (split/merge ambiguities) → admin spreadsheet
+4. 🔴 Stage 2 deferred: per-province UBND QĐ giai đoạn 2026-2030 (rolling out 2026-2027) — handle via admin CRUD UI in PR5 onwards
+
+---
+
+## Open questions for user
+
+1. Tách-rời commune codes của xã/phường mới sau sáp nhập 2025 dùng BNV-issued 5-digit ward_code (`00025`, `00070`) hay dùng tên tỉnh+ward concatenation cho `commune_code` trong `VnCommuneAreaMap`? Schema cho `commune_code VARCHAR(20)` — recommend dùng BNV 5-digit prefix với province để có 7-digit canonical key (vd `01_00025`).
+2. Default value `KV2-NT` cho mọi commune không có classification — accept? (Conservative: candidate KHÔNG được bonus error-of-favor; risk: mới sinh sống TP nhưng schema chưa override KV3 sẽ được +0.5đ sai)
+3. PR4 import có cần admin manual review queue front-load không, hay accept fuzzy-match confidence ≥ 0.9 auto-apply + < 0.9 hold queue?

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/PathBasicInfo.payload.test.ts
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/PathBasicInfo.payload.test.ts
@@ -42,7 +42,7 @@ function buildMethodQuotaPayload(methodQuotaInput: string): number | null {
 function buildBonusOverridePayload(args: {
   enabled: boolean
   applyAreaBonus: boolean
-  applySubjectBonus: boolean
+  applyObjectBonus: boolean
   maxTotalBonusInput: string
 }): BonusRuleOverride | null {
   if (!args.enabled) return null
@@ -60,7 +60,7 @@ function buildBonusOverridePayload(args: {
   }
   return {
     apply_area_bonus: args.applyAreaBonus,
-    apply_subject_bonus: args.applySubjectBonus,
+    apply_object_bonus: args.applyObjectBonus,
     max_total_bonus: maxTotal,
   }
 }
@@ -160,7 +160,7 @@ describe("buildBonusOverridePayload", () => {
       buildBonusOverridePayload({
         enabled: false,
         applyAreaBonus: true,
-        applySubjectBonus: true,
+        applyObjectBonus: true,
         maxTotalBonusInput: "2.5",
       }),
     ).toBeNull()
@@ -171,12 +171,12 @@ describe("buildBonusOverridePayload", () => {
       buildBonusOverridePayload({
         enabled: true,
         applyAreaBonus: true,
-        applySubjectBonus: false,
+        applyObjectBonus: false,
         maxTotalBonusInput: "2.75",
       }),
     ).toEqual({
       apply_area_bonus: true,
-      apply_subject_bonus: false,
+      apply_object_bonus: false,
       max_total_bonus: 2.75,
     })
   })
@@ -189,12 +189,12 @@ describe("buildBonusOverridePayload", () => {
       buildBonusOverridePayload({
         enabled: true,
         applyAreaBonus: true,
-        applySubjectBonus: true,
+        applyObjectBonus: true,
         maxTotalBonusInput: "",
       }),
     ).toEqual({
       apply_area_bonus: true,
-      apply_subject_bonus: true,
+      apply_object_bonus: true,
       max_total_bonus: null,
     })
   })
@@ -209,12 +209,12 @@ describe("buildBonusOverridePayload", () => {
       buildBonusOverridePayload({
         enabled: true,
         applyAreaBonus: false,
-        applySubjectBonus: false,
+        applyObjectBonus: false,
         maxTotalBonusInput: "0",
       }),
     ).toEqual({
       apply_area_bonus: false,
-      apply_subject_bonus: false,
+      apply_object_bonus: false,
       max_total_bonus: 0,
     })
   })
@@ -224,12 +224,12 @@ describe("buildBonusOverridePayload", () => {
       buildBonusOverridePayload({
         enabled: true,
         applyAreaBonus: true,
-        applySubjectBonus: true,
+        applyObjectBonus: true,
         maxTotalBonusInput: "abc",
       }),
     ).toEqual({
       apply_area_bonus: true,
-      apply_subject_bonus: true,
+      apply_object_bonus: true,
       max_total_bonus: null,
     })
   })
@@ -243,12 +243,12 @@ describe("buildBonusOverridePayload", () => {
       buildBonusOverridePayload({
         enabled: true,
         applyAreaBonus: true,
-        applySubjectBonus: true,
+        applyObjectBonus: true,
         maxTotalBonusInput: "11.5",
       }),
     ).toEqual({
       apply_area_bonus: true,
-      apply_subject_bonus: true,
+      apply_object_bonus: true,
       max_total_bonus: 10,
     })
   })
@@ -258,12 +258,12 @@ describe("buildBonusOverridePayload", () => {
       buildBonusOverridePayload({
         enabled: true,
         applyAreaBonus: true,
-        applySubjectBonus: true,
+        applyObjectBonus: true,
         maxTotalBonusInput: "-2.0",
       }),
     ).toEqual({
       apply_area_bonus: true,
-      apply_subject_bonus: true,
+      apply_object_bonus: true,
       max_total_bonus: 0,
     })
   })
@@ -273,12 +273,12 @@ describe("buildBonusOverridePayload", () => {
       buildBonusOverridePayload({
         enabled: true,
         applyAreaBonus: true,
-        applySubjectBonus: true,
+        applyObjectBonus: true,
         maxTotalBonusInput: "10",
       }),
     ).toEqual({
       apply_area_bonus: true,
-      apply_subject_bonus: true,
+      apply_object_bonus: true,
       max_total_bonus: 10,
     })
   })

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/PathBasicInfo.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/PathBasicInfo.tsx
@@ -76,8 +76,8 @@ export function PathBasicInfo({ path, methods, academicInfoId, onFinish }: PathB
   const [applyAreaBonus, setApplyAreaBonus] = useState<boolean>(
     path?.bonus_rule_override?.apply_area_bonus ?? false
   );
-  const [applySubjectBonus, setApplySubjectBonus] = useState<boolean>(
-    path?.bonus_rule_override?.apply_subject_bonus ?? false
+  const [applyObjectBonus, setApplyObjectBonus] = useState<boolean>(
+    path?.bonus_rule_override?.apply_object_bonus ?? false
   );
   const [maxTotalBonusInput, setMaxTotalBonusInput] = useState<string>(
     path?.bonus_rule_override?.max_total_bonus != null
@@ -175,7 +175,7 @@ export function PathBasicInfo({ path, methods, academicInfoId, onFinish }: PathB
     }
     return {
       apply_area_bonus: applyAreaBonus,
-      apply_subject_bonus: applySubjectBonus,
+      apply_object_bonus: applyObjectBonus,
       max_total_bonus: maxTotal,
     };
   }
@@ -518,19 +518,19 @@ export function PathBasicInfo({ path, methods, academicInfoId, onFinish }: PathB
                     htmlFor="apply-area-bonus"
                     className="text-sm cursor-pointer"
                   >
-                    Cộng điểm khu vực (KV1 / KV2_NT / KV2 / KV3)
+                    Cộng điểm khu vực (KV1 / KV2-NT / KV2 / KV3)
                   </Label>
                 </div>
                 <div className="flex items-center gap-2">
                   <Checkbox
-                    id="apply-subject-bonus"
-                    checked={applySubjectBonus}
-                    onCheckedChange={(v) => setApplySubjectBonus(v === true)}
+                    id="apply-object-bonus"
+                    checked={applyObjectBonus}
+                    onCheckedChange={(v) => setApplyObjectBonus(v === true)}
                     disabled={!isAdmin}
-                    aria-label="Cộng điểm môn ưu tiên"
+                    aria-label="Cộng điểm đối tượng ưu tiên"
                   />
                   <Label
-                    htmlFor="apply-subject-bonus"
+                    htmlFor="apply-object-bonus"
                     className="text-sm cursor-pointer"
                   >
                     Cộng điểm đối tượng ưu tiên (mã 01..07)

--- a/frontend/src/app/(dashboard)/admin/priority-config/_components/AreaTable.tsx
+++ b/frontend/src/app/(dashboard)/admin/priority-config/_components/AreaTable.tsx
@@ -1,0 +1,384 @@
+/**
+ * AreaTable — KV (Khu vực) bonus rates per academic_year.
+ *
+ * Q9 #07 PR3 admin FE — TT 05/2021 priority area config CRUD.
+ *
+ * Renders the active KV rows for the selected year. Each row supports
+ * inline edit (bonus_points + area_name + description), retire
+ * (effective_to = today), and a "Thêm mới" dialog for new codes.
+ *
+ * The component trusts BE to return only currently-active rows when
+ * `activeOnly=true` (default) — no client-side filter.
+ */
+
+"use client"
+
+import { useState } from "react"
+import { Pencil, Plus, Trash2 } from "lucide-react"
+import { toast } from "sonner"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Textarea } from "@/components/ui/textarea"
+
+import {
+  useCreatePriorityArea,
+  usePriorityAreas,
+  useRetirePriorityArea,
+  useUpdatePriorityArea,
+} from "@/lib/hooks/usePriorityConfig"
+import {
+  priorityAreaConfigCreateSchema,
+  priorityAreaConfigUpdateSchema,
+  type PriorityAreaConfigResponse,
+} from "@/lib/zod/priority-config"
+
+interface AreaTableProps {
+  academicYear: number
+}
+
+interface AreaFormState {
+  area_code: string
+  area_name: string
+  bonus_points: string
+  description: string
+}
+
+const EMPTY_FORM: AreaFormState = {
+  area_code: "",
+  area_name: "",
+  bonus_points: "0",
+  description: "",
+}
+
+export function AreaTable({ academicYear }: AreaTableProps) {
+  const { data: rows, isLoading } = usePriorityAreas(academicYear)
+  const createMutation = useCreatePriorityArea(academicYear)
+  const updateMutation = useUpdatePriorityArea()
+  const retireMutation = useRetirePriorityArea()
+
+  // Dialog state
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [form, setForm] = useState<AreaFormState>(EMPTY_FORM)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  // Retire confirm
+  const [retireTarget, setRetireTarget] = useState<PriorityAreaConfigResponse | null>(
+    null,
+  )
+
+  const openCreate = () => {
+    setEditingId(null)
+    setForm(EMPTY_FORM)
+    setFormError(null)
+    setDialogOpen(true)
+  }
+
+  const openEdit = (row: PriorityAreaConfigResponse) => {
+    setEditingId(row.id)
+    setForm({
+      area_code: row.area_code,
+      area_name: row.area_name,
+      bonus_points: String(row.bonus_points),
+      description: row.description ?? "",
+    })
+    setFormError(null)
+    setDialogOpen(true)
+  }
+
+  const handleSubmit = async () => {
+    setFormError(null)
+    const bonus = Number(form.bonus_points)
+    if (Number.isNaN(bonus)) {
+      setFormError("Điểm cộng phải là số")
+      return
+    }
+
+    try {
+      if (editingId == null) {
+        const parsed = priorityAreaConfigCreateSchema.safeParse({
+          academic_year: academicYear,
+          area_code: form.area_code.trim(),
+          area_name: form.area_name.trim(),
+          bonus_points: bonus,
+          description: form.description.trim() || null,
+        })
+        if (!parsed.success) {
+          setFormError(parsed.error.issues[0]?.message ?? "Dữ liệu không hợp lệ")
+          return
+        }
+        await createMutation.mutateAsync(parsed.data)
+        toast.success(`Đã tạo ${parsed.data.area_code}`)
+      } else {
+        const parsed = priorityAreaConfigUpdateSchema.safeParse({
+          area_name: form.area_name.trim(),
+          bonus_points: bonus,
+          description: form.description.trim() || null,
+        })
+        if (!parsed.success) {
+          setFormError(parsed.error.issues[0]?.message ?? "Dữ liệu không hợp lệ")
+          return
+        }
+        await updateMutation.mutateAsync({ areaId: editingId, data: parsed.data })
+        toast.success(`Đã cập nhật KV #${editingId}`)
+      }
+      setDialogOpen(false)
+    } catch (error) {
+      const msg =
+        (error as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? "Thao tác thất bại"
+      setFormError(typeof msg === "string" ? msg : "Thao tác thất bại")
+    }
+  }
+
+  const handleRetireConfirm = async () => {
+    if (!retireTarget) return
+    try {
+      await retireMutation.mutateAsync(retireTarget.id)
+      toast.success(`Đã ngưng ${retireTarget.area_code}`)
+    } catch (error) {
+      const msg =
+        (error as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? "Ngưng KV thất bại"
+      toast.error(typeof msg === "string" ? msg : "Ngưng KV thất bại")
+    } finally {
+      setRetireTarget(null)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold">Khu vực (KV)</h3>
+          <p className="text-muted-foreground text-sm">
+            Cộng điểm theo khu vực trường THPT (TT 05/2021 Phụ lục 01)
+          </p>
+        </div>
+        <Button size="sm" onClick={openCreate} data-testid="area-add-btn">
+          <Plus className="mr-1 h-4 w-4" />
+          Thêm KV
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : !rows || rows.length === 0 ? (
+        <div className="text-muted-foreground rounded-md border py-8 text-center text-sm">
+          Chưa có khu vực nào cho năm {academicYear}. Bấm &quot;Seed
+          Defaults&quot; để khởi tạo TT 05/2021.
+        </div>
+      ) : (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[110px]">Mã KV</TableHead>
+                <TableHead>Tên</TableHead>
+                <TableHead className="w-[120px] text-right">Điểm cộng</TableHead>
+                <TableHead>Mô tả</TableHead>
+                <TableHead className="w-[100px] text-right">Thao tác</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.id} data-testid={`area-row-${row.area_code}`}>
+                  <TableCell>
+                    <Badge variant="secondary" className="font-mono">
+                      {row.area_code}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>{row.area_name}</TableCell>
+                  <TableCell className="text-right font-mono">
+                    {Number(row.bonus_points).toFixed(2)}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground max-w-[300px] truncate">
+                    {row.description ?? "—"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => openEdit(row)}
+                        aria-label={`Sửa ${row.area_code}`}
+                        data-testid={`area-edit-${row.area_code}`}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setRetireTarget(row)}
+                        aria-label={`Ngưng ${row.area_code}`}
+                        data-testid={`area-retire-${row.area_code}`}
+                      >
+                        <Trash2 className="text-destructive h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      {/* Create / Edit dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {editingId == null ? "Thêm khu vực" : `Sửa KV #${editingId}`}
+            </DialogTitle>
+            <DialogDescription>
+              Năm học {academicYear}. Mã KV theo TT 05/2021: KV1, KV2-NT, KV2, KV3.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="grid gap-2">
+              <Label htmlFor="area-code">Mã KV</Label>
+              <Input
+                id="area-code"
+                value={form.area_code}
+                disabled={editingId != null}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, area_code: e.target.value }))
+                }
+                placeholder="KV1 / KV2-NT / KV2 / KV3"
+                data-testid="area-form-code"
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="area-name">Tên</Label>
+              <Input
+                id="area-name"
+                value={form.area_name}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, area_name: e.target.value }))
+                }
+                placeholder="Khu vực 1"
+                data-testid="area-form-name"
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="area-bonus">Điểm cộng</Label>
+              <Input
+                id="area-bonus"
+                type="number"
+                step="0.25"
+                min="0"
+                max="99.99"
+                value={form.bonus_points}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, bonus_points: e.target.value }))
+                }
+                data-testid="area-form-bonus"
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="area-desc">Mô tả</Label>
+              <Textarea
+                id="area-desc"
+                value={form.description}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, description: e.target.value }))
+                }
+                placeholder="Tuỳ chọn"
+                rows={2}
+                data-testid="area-form-desc"
+              />
+            </div>
+
+            {formError && (
+              <p className="text-destructive text-sm" role="alert">
+                {formError}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDialogOpen(false)}
+              disabled={createMutation.isPending || updateMutation.isPending}
+            >
+              Hủy
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={createMutation.isPending || updateMutation.isPending}
+              data-testid="area-form-submit"
+            >
+              {editingId == null ? "Tạo" : "Lưu"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Retire confirm */}
+      <AlertDialog
+        open={!!retireTarget}
+        onOpenChange={(open) => !open && setRetireTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Xác nhận ngưng KV</AlertDialogTitle>
+            <AlertDialogDescription>
+              Ngưng {retireTarget?.area_code} ({retireTarget?.area_name})? Hồ sơ
+              đã snapshot sẽ không bị ảnh hưởng — chỉ ngừng áp dụng cho hồ sơ
+              mới.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Hủy</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleRetireConfirm}
+            >
+              Ngưng
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/priority-config/_components/CloneFromYearDialog.tsx
+++ b/frontend/src/app/(dashboard)/admin/priority-config/_components/CloneFromYearDialog.tsx
@@ -1,0 +1,150 @@
+/**
+ * CloneFromYearDialog — copy ACTIVE KV/UT rows year→year.
+ *
+ * BE is idempotent: rows that already exist active in `to_year` are
+ * skipped silently, so admin can re-run after a partial seed without
+ * harm. Toast surfaces the actual `cloned_areas` + `cloned_objects`
+ * counts.
+ */
+
+"use client"
+
+import { useState } from "react"
+import { Copy } from "lucide-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+import { useClonePriorityConfig } from "@/lib/hooks/usePriorityConfig"
+import { priorityConfigCloneRequestSchema } from "@/lib/zod/priority-config"
+
+interface CloneFromYearDialogProps {
+  defaultToYear: number
+}
+
+export function CloneFromYearDialog({ defaultToYear }: CloneFromYearDialogProps) {
+  const cloneMutation = useClonePriorityConfig()
+  const [open, setOpen] = useState(false)
+  const [fromYear, setFromYear] = useState<string>(String(defaultToYear - 1))
+  const [toYear, setToYear] = useState<string>(String(defaultToYear))
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    setError(null)
+    const parsed = priorityConfigCloneRequestSchema.safeParse({
+      from_year: Number(fromYear),
+      to_year: Number(toYear),
+    })
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? "Dữ liệu không hợp lệ")
+      return
+    }
+
+    try {
+      const result = await cloneMutation.mutateAsync(parsed.data)
+      toast.success(
+        `Đã sao chép từ ${parsed.data.from_year} sang ${parsed.data.to_year}`,
+        {
+          description: `${result.cloned_areas} KV + ${result.cloned_objects} UT`,
+        },
+      )
+      setOpen(false)
+    } catch (err) {
+      const msg =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? "Sao chép thất bại"
+      setError(typeof msg === "string" ? msg : "Sao chép thất bại")
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          setFromYear(String(defaultToYear - 1))
+          setToYear(String(defaultToYear))
+          setError(null)
+          setOpen(true)
+        }}
+        data-testid="clone-from-year-btn"
+      >
+        <Copy className="mr-1 h-4 w-4" />
+        Sao chép từ năm khác
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Sao chép cấu hình ưu tiên</DialogTitle>
+            <DialogDescription>
+              Copy toàn bộ KV/UT đang hoạt động từ một năm sang năm khác. Mã
+              nào đã tồn tại ở năm đích sẽ được giữ nguyên (không ghi đè).
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="grid gap-2">
+              <Label htmlFor="clone-from">Từ năm</Label>
+              <Input
+                id="clone-from"
+                type="number"
+                min="2020"
+                max="2100"
+                value={fromYear}
+                onChange={(e) => setFromYear(e.target.value)}
+                data-testid="clone-from-input"
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="clone-to">Sang năm</Label>
+              <Input
+                id="clone-to"
+                type="number"
+                min="2020"
+                max="2100"
+                value={toYear}
+                onChange={(e) => setToYear(e.target.value)}
+                data-testid="clone-to-input"
+              />
+            </div>
+          </div>
+
+          {error && (
+            <p className="text-destructive text-sm" role="alert">
+              {error}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setOpen(false)}
+              disabled={cloneMutation.isPending}
+            >
+              Hủy
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={cloneMutation.isPending}
+              data-testid="clone-submit-btn"
+            >
+              Sao chép
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/priority-config/_components/ObjectTable.tsx
+++ b/frontend/src/app/(dashboard)/admin/priority-config/_components/ObjectTable.tsx
@@ -1,0 +1,404 @@
+/**
+ * ObjectTable — UT (đối tượng) bonus rates per academic_year.
+ *
+ * Q9 #07 PR3 admin FE — TT 05/2021 priority object config CRUD.
+ *
+ * UT row identifier is the composite (group_code, sub_code) — e.g.
+ * UT1/04, UT2/06. The BE enforces uniqueness per (year, sub_code) so
+ * we keep group_code as a small input that defaults to UT1.
+ */
+
+"use client"
+
+import { useState } from "react"
+import { Pencil, Plus, Trash2 } from "lucide-react"
+import { toast } from "sonner"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Textarea } from "@/components/ui/textarea"
+
+import {
+  useCreatePriorityObject,
+  usePriorityObjects,
+  useRetirePriorityObject,
+  useUpdatePriorityObject,
+} from "@/lib/hooks/usePriorityConfig"
+import {
+  priorityObjectConfigCreateSchema,
+  priorityObjectConfigUpdateSchema,
+  type PriorityObjectConfigResponse,
+} from "@/lib/zod/priority-config"
+
+interface ObjectTableProps {
+  academicYear: number
+}
+
+interface ObjectFormState {
+  group_code: string
+  sub_code: string
+  description: string
+  bonus_points: string
+  evidence_doc_type: string
+}
+
+const EMPTY_FORM: ObjectFormState = {
+  group_code: "UT1",
+  sub_code: "",
+  description: "",
+  bonus_points: "0",
+  evidence_doc_type: "",
+}
+
+export function ObjectTable({ academicYear }: ObjectTableProps) {
+  const { data: rows, isLoading } = usePriorityObjects(academicYear)
+  const createMutation = useCreatePriorityObject(academicYear)
+  const updateMutation = useUpdatePriorityObject()
+  const retireMutation = useRetirePriorityObject()
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [form, setForm] = useState<ObjectFormState>(EMPTY_FORM)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [retireTarget, setRetireTarget] = useState<PriorityObjectConfigResponse | null>(
+    null,
+  )
+
+  const openCreate = () => {
+    setEditingId(null)
+    setForm(EMPTY_FORM)
+    setFormError(null)
+    setDialogOpen(true)
+  }
+
+  const openEdit = (row: PriorityObjectConfigResponse) => {
+    setEditingId(row.id)
+    setForm({
+      group_code: row.group_code,
+      sub_code: row.sub_code,
+      description: row.description,
+      bonus_points: String(row.bonus_points),
+      evidence_doc_type: row.evidence_doc_type ?? "",
+    })
+    setFormError(null)
+    setDialogOpen(true)
+  }
+
+  const handleSubmit = async () => {
+    setFormError(null)
+    const bonus = Number(form.bonus_points)
+    if (Number.isNaN(bonus)) {
+      setFormError("Điểm cộng phải là số")
+      return
+    }
+
+    try {
+      if (editingId == null) {
+        const parsed = priorityObjectConfigCreateSchema.safeParse({
+          academic_year: academicYear,
+          group_code: form.group_code.trim(),
+          sub_code: form.sub_code.trim(),
+          description: form.description.trim(),
+          bonus_points: bonus,
+          evidence_doc_type: form.evidence_doc_type.trim() || null,
+        })
+        if (!parsed.success) {
+          setFormError(parsed.error.issues[0]?.message ?? "Dữ liệu không hợp lệ")
+          return
+        }
+        await createMutation.mutateAsync(parsed.data)
+        toast.success(`Đã tạo ${parsed.data.group_code}/${parsed.data.sub_code}`)
+      } else {
+        const parsed = priorityObjectConfigUpdateSchema.safeParse({
+          description: form.description.trim(),
+          bonus_points: bonus,
+          evidence_doc_type: form.evidence_doc_type.trim() || null,
+        })
+        if (!parsed.success) {
+          setFormError(parsed.error.issues[0]?.message ?? "Dữ liệu không hợp lệ")
+          return
+        }
+        await updateMutation.mutateAsync({
+          objectId: editingId,
+          data: parsed.data,
+        })
+        toast.success(`Đã cập nhật UT #${editingId}`)
+      }
+      setDialogOpen(false)
+    } catch (error) {
+      const msg =
+        (error as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? "Thao tác thất bại"
+      setFormError(typeof msg === "string" ? msg : "Thao tác thất bại")
+    }
+  }
+
+  const handleRetireConfirm = async () => {
+    if (!retireTarget) return
+    try {
+      await retireMutation.mutateAsync(retireTarget.id)
+      toast.success(`Đã ngưng ${retireTarget.group_code}/${retireTarget.sub_code}`)
+    } catch (error) {
+      const msg =
+        (error as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? "Ngưng UT thất bại"
+      toast.error(typeof msg === "string" ? msg : "Ngưng UT thất bại")
+    } finally {
+      setRetireTarget(null)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold">Đối tượng (UT)</h3>
+          <p className="text-muted-foreground text-sm">
+            Cộng điểm theo đối tượng ưu tiên (TT 05/2021 Phụ lục 01)
+          </p>
+        </div>
+        <Button size="sm" onClick={openCreate} data-testid="object-add-btn">
+          <Plus className="mr-1 h-4 w-4" />
+          Thêm UT
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : !rows || rows.length === 0 ? (
+        <div className="text-muted-foreground rounded-md border py-8 text-center text-sm">
+          Chưa có đối tượng nào cho năm {academicYear}. Bấm &quot;Seed
+          Defaults&quot; để khởi tạo TT 05/2021.
+        </div>
+      ) : (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[100px]">Nhóm</TableHead>
+                <TableHead className="w-[80px]">Mã</TableHead>
+                <TableHead>Mô tả</TableHead>
+                <TableHead className="w-[120px] text-right">Điểm cộng</TableHead>
+                <TableHead className="w-[100px] text-right">Thao tác</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-testid={`object-row-${row.group_code}-${row.sub_code}`}
+                >
+                  <TableCell>
+                    <Badge variant="secondary" className="font-mono">
+                      {row.group_code}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="font-mono">{row.sub_code}</TableCell>
+                  <TableCell className="max-w-[400px] truncate">
+                    {row.description}
+                  </TableCell>
+                  <TableCell className="text-right font-mono">
+                    {Number(row.bonus_points).toFixed(2)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => openEdit(row)}
+                        aria-label={`Sửa ${row.group_code}/${row.sub_code}`}
+                        data-testid={`object-edit-${row.group_code}-${row.sub_code}`}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setRetireTarget(row)}
+                        aria-label={`Ngưng ${row.group_code}/${row.sub_code}`}
+                        data-testid={`object-retire-${row.group_code}-${row.sub_code}`}
+                      >
+                        <Trash2 className="text-destructive h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {editingId == null ? "Thêm đối tượng" : `Sửa UT #${editingId}`}
+            </DialogTitle>
+            <DialogDescription>
+              Năm học {academicYear}. group_code: UT1/UT2; sub_code: 2 chữ số
+              (VD: 01, 04, 07).
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="grid gap-2">
+                <Label htmlFor="object-group">Nhóm</Label>
+                <Input
+                  id="object-group"
+                  value={form.group_code}
+                  disabled={editingId != null}
+                  onChange={(e) =>
+                    setForm((s) => ({ ...s, group_code: e.target.value }))
+                  }
+                  placeholder="UT1"
+                  data-testid="object-form-group"
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="object-sub">Mã (2 chữ số)</Label>
+                <Input
+                  id="object-sub"
+                  value={form.sub_code}
+                  disabled={editingId != null}
+                  onChange={(e) =>
+                    setForm((s) => ({ ...s, sub_code: e.target.value }))
+                  }
+                  placeholder="04"
+                  maxLength={2}
+                  data-testid="object-form-sub"
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="object-desc">Mô tả</Label>
+              <Textarea
+                id="object-desc"
+                value={form.description}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, description: e.target.value }))
+                }
+                placeholder="Anh hùng LLVTND, anh hùng lao động..."
+                rows={2}
+                data-testid="object-form-desc"
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="object-bonus">Điểm cộng</Label>
+              <Input
+                id="object-bonus"
+                type="number"
+                step="0.25"
+                min="0"
+                max="99.99"
+                value={form.bonus_points}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, bonus_points: e.target.value }))
+                }
+                data-testid="object-form-bonus"
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="object-evidence">Loại chứng từ (tùy chọn)</Label>
+              <Input
+                id="object-evidence"
+                value={form.evidence_doc_type}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, evidence_doc_type: e.target.value }))
+                }
+                placeholder="VD: anh_hung_certificate"
+                maxLength={100}
+                data-testid="object-form-evidence"
+              />
+            </div>
+
+            {formError && (
+              <p className="text-destructive text-sm" role="alert">
+                {formError}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDialogOpen(false)}
+              disabled={createMutation.isPending || updateMutation.isPending}
+            >
+              Hủy
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              disabled={createMutation.isPending || updateMutation.isPending}
+              data-testid="object-form-submit"
+            >
+              {editingId == null ? "Tạo" : "Lưu"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={!!retireTarget}
+        onOpenChange={(open) => !open && setRetireTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Xác nhận ngưng UT</AlertDialogTitle>
+            <AlertDialogDescription>
+              Ngưng {retireTarget?.group_code}/{retireTarget?.sub_code}? Hồ sơ
+              đã snapshot sẽ không bị ảnh hưởng — chỉ ngừng áp dụng cho hồ sơ
+              mới.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Hủy</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleRetireConfirm}
+            >
+              Ngưng
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/priority-config/_components/PriorityConfigClient.tsx
+++ b/frontend/src/app/(dashboard)/admin/priority-config/_components/PriorityConfigClient.tsx
@@ -1,0 +1,109 @@
+/**
+ * PriorityConfigClient — orchestrator for /admin/priority-config.
+ *
+ * Layout:
+ *   ┌────────────────────────────────────────────────────────┐
+ *   │ Header: title + year selector + clone + seed-defaults  │
+ *   ├────────────────────────────────────────────────────────┤
+ *   │ AreaTable                  │ ObjectTable               │
+ *   │ (KV)                       │ (UT)                      │
+ *   └────────────────────────────────────────────────────────┘
+ *
+ * Year selector is client-side state — list 5 years centred on
+ * current year (2024..2028 in 2026). Selecting a year reloads both
+ * tables via React Query.
+ */
+
+"use client"
+
+import { useState } from "react"
+
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+import { AreaTable } from "./AreaTable"
+import { CloneFromYearDialog } from "./CloneFromYearDialog"
+import { ObjectTable } from "./ObjectTable"
+import { SeedDefaultsButton } from "./SeedDefaultsButton"
+
+// Range: 2 years back, current, 3 years forward. Keep the window
+// small — admin rarely needs to edit rates more than a year out.
+function buildYearOptions(): number[] {
+  const current = new Date().getFullYear()
+  const start = current - 2
+  return Array.from({ length: 6 }, (_, i) => start + i)
+}
+
+export function PriorityConfigClient() {
+  const yearOptions = buildYearOptions()
+  const [academicYear, setAcademicYear] = useState<number>(
+    new Date().getFullYear(),
+  )
+
+  return (
+    <div className="container mx-auto space-y-6 p-6">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Cấu hình Ưu tiên</h1>
+          <p className="text-muted-foreground text-sm">
+            Quản lý điểm cộng Khu vực (KV) + Đối tượng (UT) theo TT
+            05/2021-BLĐTBXH. Hồ sơ đã snapshot không bị ảnh hưởng khi bạn sửa
+            tỉ lệ — chỉ áp dụng cho hồ sơ mới.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="year-select"
+              className="text-muted-foreground text-xs"
+            >
+              Năm học
+            </label>
+            <Select
+              value={String(academicYear)}
+              onValueChange={(v) => setAcademicYear(Number(v))}
+            >
+              <SelectTrigger
+                id="year-select"
+                className="w-[120px]"
+                data-testid="year-select"
+              >
+                <SelectValue placeholder="Năm" />
+              </SelectTrigger>
+              <SelectContent>
+                {yearOptions.map((y) => (
+                  <SelectItem key={y} value={String(y)}>
+                    {y}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <SeedDefaultsButton academicYear={academicYear} />
+          <CloneFromYearDialog defaultToYear={academicYear} />
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardContent className="pt-6">
+            <AreaTable academicYear={academicYear} />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <ObjectTable academicYear={academicYear} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/priority-config/_components/SeedDefaultsButton.tsx
+++ b/frontend/src/app/(dashboard)/admin/priority-config/_components/SeedDefaultsButton.tsx
@@ -1,0 +1,93 @@
+/**
+ * SeedDefaultsButton — populate TT 05/2021 baseline rates for a year.
+ *
+ * Idempotent on the BE side: if any active row already exists for the
+ * year, the call returns skipped_existing=true and inserts nothing.
+ * We surface that distinction in the toast so admin knows whether to
+ * delete-then-re-seed.
+ */
+
+"use client"
+
+import { useState } from "react"
+import { Sparkles } from "lucide-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+import { useSeedPriorityDefaults } from "@/lib/hooks/usePriorityConfig"
+
+interface SeedDefaultsButtonProps {
+  academicYear: number
+}
+
+export function SeedDefaultsButton({ academicYear }: SeedDefaultsButtonProps) {
+  const seedMutation = useSeedPriorityDefaults()
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
+  const handleConfirm = async () => {
+    try {
+      const result = await seedMutation.mutateAsync({ academic_year: academicYear })
+      if (result.skipped_existing) {
+        toast.info(`Năm ${academicYear} đã có cấu hình`, {
+          description: "Bỏ qua seed vì đã tồn tại KV/UT đang hoạt động.",
+        })
+      } else {
+        toast.success(`Đã khởi tạo TT 05/2021 cho năm ${academicYear}`, {
+          description: `${result.inserted_areas} KV + ${result.inserted_objects} UT`,
+        })
+      }
+    } catch (err) {
+      const msg =
+        (err as { response?: { data?: { detail?: string } } })?.response?.data
+          ?.detail ?? "Seed thất bại"
+      toast.error(typeof msg === "string" ? msg : "Seed thất bại")
+    } finally {
+      setConfirmOpen(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="default"
+        size="sm"
+        onClick={() => setConfirmOpen(true)}
+        disabled={seedMutation.isPending}
+        data-testid="seed-defaults-btn"
+      >
+        <Sparkles className="mr-1 h-4 w-4" />
+        Khởi tạo TT 05/2021
+      </Button>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Khởi tạo cấu hình ưu tiên?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Tạo bộ KV/UT mặc định theo TT 05/2021-BLĐTBXH cho năm{" "}
+              {academicYear} (4 KV + 7 UT). Nếu năm đã có cấu hình, thao tác
+              này sẽ tự động bỏ qua.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Hủy</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirm}>
+              Khởi tạo
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/priority-config/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/priority-config/page.tsx
@@ -1,0 +1,30 @@
+/**
+ * /admin/priority-config — Q9 #07 PR3 admin FE entry point.
+ *
+ * Admin-only quy chế config. Backend require_admin enforces auth so
+ * the page itself stays a thin wrapper around the client orchestrator.
+ */
+
+import { Suspense } from "react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+
+import { PriorityConfigClient } from "./_components/PriorityConfigClient"
+
+export default function PriorityConfigPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="container mx-auto space-y-4 p-6">
+          <Skeleton className="h-10 w-1/3" />
+          <div className="grid gap-6 lg:grid-cols-2">
+            <Skeleton className="h-[400px]" />
+            <Skeleton className="h-[400px]" />
+          </div>
+        </div>
+      }
+    >
+      <PriorityConfigClient />
+    </Suspense>
+  )
+}

--- a/frontend/src/lib/api/priority-config.ts
+++ b/frontend/src/lib/api/priority-config.ts
@@ -1,0 +1,159 @@
+/**
+ * Priority Config API Client — admin CRUD for KV/UT bonus rates.
+ *
+ * Mirrors `Backend_FastAPI/app/routers/admin_priority_config.py`. All
+ * endpoints sit behind `require_admin` so a non-admin user hitting any
+ * function will see a 403 from the backend.
+ *
+ * Endpoint base: `/api/v2/admin/priority-config`
+ */
+
+import { api } from "@/lib/api/client"
+
+import type {
+  PriorityAreaConfigCreate,
+  PriorityAreaConfigResponse,
+  PriorityAreaConfigUpdate,
+  PriorityConfigCloneRequest,
+  PriorityConfigCloneResponse,
+  PriorityConfigSeedDefaultsRequest,
+  PriorityConfigSeedDefaultsResponse,
+  PriorityObjectConfigCreate,
+  PriorityObjectConfigResponse,
+  PriorityObjectConfigUpdate,
+} from "@/lib/zod/priority-config"
+
+const BASE = "/api/v2/admin/priority-config"
+
+// ============================================
+// AREAS (KV)
+// ============================================
+
+export async function listAreas(
+  academicYear: number,
+  activeOnly: boolean = true,
+): Promise<PriorityAreaConfigResponse[]> {
+  const response = await api.get<PriorityAreaConfigResponse[]>(
+    `${BASE}/years/${academicYear}/areas`,
+    { params: { active_only: activeOnly } },
+  )
+  return response.data
+}
+
+export async function createArea(
+  academicYear: number,
+  payload: PriorityAreaConfigCreate,
+): Promise<PriorityAreaConfigResponse> {
+  // BE forces academic_year = path param (router strips body value),
+  // but we still post the full shape for Pydantic validation parity.
+  const response = await api.post<PriorityAreaConfigResponse>(
+    `${BASE}/years/${academicYear}/areas`,
+    payload,
+  )
+  return response.data
+}
+
+export async function updateArea(
+  areaId: number,
+  payload: PriorityAreaConfigUpdate,
+): Promise<PriorityAreaConfigResponse> {
+  const response = await api.patch<PriorityAreaConfigResponse>(
+    `${BASE}/areas/${areaId}`,
+    payload,
+  )
+  return response.data
+}
+
+export async function retireArea(
+  areaId: number,
+): Promise<PriorityAreaConfigResponse> {
+  const response = await api.delete<PriorityAreaConfigResponse>(
+    `${BASE}/areas/${areaId}`,
+  )
+  return response.data
+}
+
+// ============================================
+// OBJECTS (UT)
+// ============================================
+
+export async function listObjects(
+  academicYear: number,
+  activeOnly: boolean = true,
+): Promise<PriorityObjectConfigResponse[]> {
+  const response = await api.get<PriorityObjectConfigResponse[]>(
+    `${BASE}/years/${academicYear}/objects`,
+    { params: { active_only: activeOnly } },
+  )
+  return response.data
+}
+
+export async function createObject(
+  academicYear: number,
+  payload: PriorityObjectConfigCreate,
+): Promise<PriorityObjectConfigResponse> {
+  const response = await api.post<PriorityObjectConfigResponse>(
+    `${BASE}/years/${academicYear}/objects`,
+    payload,
+  )
+  return response.data
+}
+
+export async function updateObject(
+  objectId: number,
+  payload: PriorityObjectConfigUpdate,
+): Promise<PriorityObjectConfigResponse> {
+  const response = await api.patch<PriorityObjectConfigResponse>(
+    `${BASE}/objects/${objectId}`,
+    payload,
+  )
+  return response.data
+}
+
+export async function retireObject(
+  objectId: number,
+): Promise<PriorityObjectConfigResponse> {
+  const response = await api.delete<PriorityObjectConfigResponse>(
+    `${BASE}/objects/${objectId}`,
+  )
+  return response.data
+}
+
+// ============================================
+// CLONE + SEED HELPERS
+// ============================================
+
+export async function cloneFromYear(
+  payload: PriorityConfigCloneRequest,
+): Promise<PriorityConfigCloneResponse> {
+  const response = await api.post<PriorityConfigCloneResponse>(
+    `${BASE}/clone`,
+    payload,
+  )
+  return response.data
+}
+
+export async function seedTt052021Defaults(
+  payload: PriorityConfigSeedDefaultsRequest,
+): Promise<PriorityConfigSeedDefaultsResponse> {
+  const response = await api.post<PriorityConfigSeedDefaultsResponse>(
+    `${BASE}/seed-defaults`,
+    payload,
+  )
+  return response.data
+}
+
+export const priorityConfigApi = {
+  listAreas,
+  createArea,
+  updateArea,
+  retireArea,
+  listObjects,
+  createObject,
+  updateObject,
+  retireObject,
+  cloneFromYear,
+  seedTt052021Defaults,
+}
+
+export default priorityConfigApi

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -232,6 +232,15 @@ export const navigationConfig: NavigationConfig = {
           roles: ["admin", "manager"],
         },
         {
+          // Q9 #07 PR3 — KV/UT bonus rates per TT 05/2021. Admin-only
+          // (BE enforces require_admin on every endpoint) so manager
+          // is excluded from the sidebar entry as well.
+          label: "Cấu hình Ưu tiên",
+          href: "/admin/priority-config",
+          icon: Calculator,
+          roles: ["admin"],
+        },
+        {
           label: "Organization Tree",
           href: "/admin/organization-tree",
           icon: FolderTree,

--- a/frontend/src/lib/hooks/usePriorityConfig.ts
+++ b/frontend/src/lib/hooks/usePriorityConfig.ts
@@ -1,0 +1,181 @@
+/**
+ * React Query hooks for priority_area_config + priority_object_config
+ * admin CRUD (Q9 #07 PR3 admin FE).
+ *
+ * One query key family per year scope so an edit in 2026 doesn't
+ * flush 2025/2027 caches. Mutations invalidate the relevant year +
+ * the root key for the cross-cutting clone/seed buttons.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import {
+  cloneFromYear,
+  createArea,
+  createObject,
+  listAreas,
+  listObjects,
+  retireArea,
+  retireObject,
+  seedTt052021Defaults,
+  updateArea,
+  updateObject,
+} from "@/lib/api/priority-config"
+import type {
+  PriorityAreaConfigCreate,
+  PriorityAreaConfigUpdate,
+  PriorityConfigCloneRequest,
+  PriorityConfigSeedDefaultsRequest,
+  PriorityObjectConfigCreate,
+  PriorityObjectConfigUpdate,
+} from "@/lib/zod/priority-config"
+
+// ============================================
+// QUERY KEYS
+// ============================================
+
+export const priorityConfigKeys = {
+  all: ["priority-config"] as const,
+  areas: () => [...priorityConfigKeys.all, "areas"] as const,
+  areasByYear: (year: number, activeOnly: boolean) =>
+    [...priorityConfigKeys.areas(), year, activeOnly] as const,
+  objects: () => [...priorityConfigKeys.all, "objects"] as const,
+  objectsByYear: (year: number, activeOnly: boolean) =>
+    [...priorityConfigKeys.objects(), year, activeOnly] as const,
+}
+
+// ============================================
+// READ HOOKS
+// ============================================
+
+export function usePriorityAreas(
+  academicYear: number | undefined,
+  activeOnly: boolean = true,
+) {
+  return useQuery({
+    queryKey: priorityConfigKeys.areasByYear(academicYear ?? 0, activeOnly),
+    queryFn: () => listAreas(academicYear!, activeOnly),
+    enabled: !!academicYear,
+    staleTime: 30 * 1000,
+  })
+}
+
+export function usePriorityObjects(
+  academicYear: number | undefined,
+  activeOnly: boolean = true,
+) {
+  return useQuery({
+    queryKey: priorityConfigKeys.objectsByYear(academicYear ?? 0, activeOnly),
+    queryFn: () => listObjects(academicYear!, activeOnly),
+    enabled: !!academicYear,
+    staleTime: 30 * 1000,
+  })
+}
+
+// ============================================
+// AREA MUTATIONS
+// ============================================
+
+export function useCreatePriorityArea(academicYear: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: PriorityAreaConfigCreate) => createArea(academicYear, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: priorityConfigKeys.areas() })
+    },
+  })
+}
+
+export function useUpdatePriorityArea() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      areaId,
+      data,
+    }: {
+      areaId: number
+      data: PriorityAreaConfigUpdate
+    }) => updateArea(areaId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: priorityConfigKeys.areas() })
+    },
+  })
+}
+
+export function useRetirePriorityArea() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (areaId: number) => retireArea(areaId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: priorityConfigKeys.areas() })
+    },
+  })
+}
+
+// ============================================
+// OBJECT MUTATIONS
+// ============================================
+
+export function useCreatePriorityObject(academicYear: number) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (data: PriorityObjectConfigCreate) =>
+      createObject(academicYear, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: priorityConfigKeys.objects() })
+    },
+  })
+}
+
+export function useUpdatePriorityObject() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      objectId,
+      data,
+    }: {
+      objectId: number
+      data: PriorityObjectConfigUpdate
+    }) => updateObject(objectId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: priorityConfigKeys.objects() })
+    },
+  })
+}
+
+export function useRetirePriorityObject() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (objectId: number) => retireObject(objectId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: priorityConfigKeys.objects() })
+    },
+  })
+}
+
+// ============================================
+// CLONE + SEED
+// ============================================
+
+export function useClonePriorityConfig() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: PriorityConfigCloneRequest) => cloneFromYear(payload),
+    onSuccess: () => {
+      // Clone hits a year that's not the currently-selected one, so
+      // invalidate the whole tree (areas + objects across years).
+      queryClient.invalidateQueries({ queryKey: priorityConfigKeys.all })
+    },
+  })
+}
+
+export function useSeedPriorityDefaults() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (payload: PriorityConfigSeedDefaultsRequest) =>
+      seedTt052021Defaults(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: priorityConfigKeys.all })
+    },
+  })
+}

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -60,7 +60,7 @@ export type AdmissionAudience = z.infer<typeof admissionAudienceEnum>
 export const bonusRuleOverrideSchema = z
   .object({
     apply_area_bonus: z.boolean(),
-    apply_subject_bonus: z.boolean(),
+    apply_object_bonus: z.boolean(),
     max_total_bonus: z.number().min(0).max(10).nullable().optional(),
   })
   .strict()

--- a/frontend/src/lib/zod/admissions.test.ts
+++ b/frontend/src/lib/zod/admissions.test.ts
@@ -16,7 +16,11 @@
 
 import { describe, it, expect } from "vitest"
 
-import { appliedRulesSchema, subjectGroupSnapshotSchema } from "./admissions"
+import {
+  admissionProfileUpdateSchema,
+  appliedRulesSchema,
+  subjectGroupSnapshotSchema,
+} from "./admissions"
 
 describe("subjectGroupSnapshotSchema (nested weights)", () => {
   it("parses a group with weights", () => {
@@ -126,5 +130,108 @@ describe("appliedRulesSchema (top-level subject_weights)", () => {
         method_type: "subject_based" as const,
       }),
     ).toThrow()
+  })
+})
+
+
+// =============================================================================
+// Q9 #07 PR5/A — Priority bonus Zod schemas (review-3 m-FE-3 fix)
+// =============================================================================
+//
+// Lock the FE Zod parity with BE Pydantic for the 7 priority fields.
+// Without these tests, a future refactor could silently relax / drop
+// validation and the FE would accept garbage that BE then 400s on,
+// degrading UX to "click submit then see red".
+
+describe("admissionProfileUpdateSchema priority fields (Q9 #07)", () => {
+  const baseline = { version: 1 }
+
+  it("accepts canonical sub_codes + verified evidence", () => {
+    const parsed = admissionProfileUpdateSchema.parse({
+      ...baseline,
+      priority_object_codes: ["04", "06"],
+      priority_object_evidence: {
+        "04": { status: "verified" },
+        "06": { status: "pending", document_id: 123 },
+      },
+    })
+    expect(parsed.priority_object_codes).toEqual(["04", "06"])
+    expect(parsed.priority_object_evidence?.["04"].status).toBe("verified")
+  })
+
+  it("rejects garbage UT code (per-item regex from prioritySubCodeSchema)", () => {
+    expect(() =>
+      admissionProfileUpdateSchema.parse({
+        ...baseline,
+        priority_object_codes: ["INVALID_99"],
+      }),
+    ).toThrow()
+  })
+
+  it("rejects evidence with bad status enum", () => {
+    expect(() =>
+      admissionProfileUpdateSchema.parse({
+        ...baseline,
+        priority_object_evidence: {
+          "04": { status: "approved_typo" },
+        },
+      }),
+    ).toThrow()
+  })
+
+  it("rejects evidence with extra unknown keys (.strict mirror of BE extra=forbid)", () => {
+    expect(() =>
+      admissionProfileUpdateSchema.parse({
+        ...baseline,
+        priority_object_evidence: {
+          "04": { status: "verified", random_extra: "x" },
+        },
+      }),
+    ).toThrow()
+  })
+
+  it("rejects evidence dict keyed by non-canonical sub_code", () => {
+    expect(() =>
+      admissionProfileUpdateSchema.parse({
+        ...baseline,
+        priority_object_evidence: {
+          "INVALID_KEY": { status: "verified" },
+        },
+      }),
+    ).toThrow()
+  })
+
+  it("rejects KV2_NT (underscore) — only KV2-NT (hyphen) canonical", () => {
+    expect(() =>
+      admissionProfileUpdateSchema.parse({
+        ...baseline,
+        high_school_kv_resolved: "KV2_NT",
+      }),
+    ).toThrow()
+  })
+
+  it("accepts KV2-NT (hyphen canonical form)", () => {
+    const parsed = admissionProfileUpdateSchema.parse({
+      ...baseline,
+      high_school_kv_resolved: "KV2-NT",
+    })
+    expect(parsed.high_school_kv_resolved).toBe("KV2-NT")
+  })
+
+  it("rejects invalid area_resolution_basis enum value", () => {
+    expect(() =>
+      admissionProfileUpdateSchema.parse({
+        ...baseline,
+        area_resolution_basis: "highschool",
+      }),
+    ).toThrow()
+  })
+
+  it("preprocess empty string high_school_kv_resolved -> null", () => {
+    const parsed = admissionProfileUpdateSchema.parse({
+      ...baseline,
+      high_school_kv_resolved: "",
+    })
+    expect(parsed.high_school_kv_resolved).toBeNull()
   })
 })

--- a/frontend/src/lib/zod/admissions.test.ts
+++ b/frontend/src/lib/zod/admissions.test.ts
@@ -201,23 +201,6 @@ describe("admissionProfileUpdateSchema priority fields (Q9 #07)", () => {
     ).toThrow()
   })
 
-  it("rejects KV2_NT (underscore) — only KV2-NT (hyphen) canonical", () => {
-    expect(() =>
-      admissionProfileUpdateSchema.parse({
-        ...baseline,
-        high_school_kv_resolved: "KV2_NT",
-      }),
-    ).toThrow()
-  })
-
-  it("accepts KV2-NT (hyphen canonical form)", () => {
-    const parsed = admissionProfileUpdateSchema.parse({
-      ...baseline,
-      high_school_kv_resolved: "KV2-NT",
-    })
-    expect(parsed.high_school_kv_resolved).toBe("KV2-NT")
-  })
-
   it("rejects invalid area_resolution_basis enum value", () => {
     expect(() =>
       admissionProfileUpdateSchema.parse({
@@ -227,11 +210,76 @@ describe("admissionProfileUpdateSchema priority fields (Q9 #07)", () => {
     ).toThrow()
   })
 
-  it("preprocess empty string high_school_kv_resolved -> null", () => {
+  // ==========================================================================
+  // Q9 #07 PR5 v1.3 phase1_09 — cultural + vocational 2-field parallel
+  // ==========================================================================
+
+  it("accepts cultural_education_level enum values (5 options)", () => {
+    const values = [
+      "completed_thcs", "graduated_thcs",
+      "completed_thpt", "graduated_thpt", "graduated_gdtx",
+    ]
+    for (const v of values) {
+      const parsed = admissionProfileUpdateSchema.parse({
+        ...baseline,
+        cultural_education_level: v,
+      })
+      expect(parsed.cultural_education_level).toBe(v)
+    }
+  })
+
+  it("rejects invalid cultural_education_level value", () => {
+    expect(() =>
+      admissionProfileUpdateSchema.parse({
+        ...baseline,
+        cultural_education_level: "tot_nghiep_thpt",  // wrong format
+      }),
+    ).toThrow()
+  })
+
+  it("accepts vocational_qualification enum values (4 options)", () => {
+    const values = ["none", "so_cap", "trung_cap", "cao_dang"]
+    for (const v of values) {
+      const parsed = admissionProfileUpdateSchema.parse({
+        ...baseline,
+        vocational_qualification: v,
+      })
+      expect(parsed.vocational_qualification).toBe(v)
+    }
+  })
+
+  it("rejects invalid vocational_qualification value", () => {
+    expect(() =>
+      admissionProfileUpdateSchema.parse({
+        ...baseline,
+        vocational_qualification: "trung_cap_nghe",  // wrong key
+      }),
+    ).toThrow()
+  })
+
+  it("accepts both fields parallel (Tốt nghiệp THPT + TC)", () => {
     const parsed = admissionProfileUpdateSchema.parse({
       ...baseline,
-      high_school_kv_resolved: "",
+      cultural_education_level: "graduated_thpt",
+      vocational_qualification: "trung_cap",
     })
-    expect(parsed.high_school_kv_resolved).toBeNull()
+    expect(parsed.cultural_education_level).toBe("graduated_thpt")
+    expect(parsed.vocational_qualification).toBe("trung_cap")
+  })
+
+  it("dropped fields no longer in schema (high_school_id, kv_resolved, reason)", () => {
+    // Strict schema would reject extras, but admissionProfileUpdateSchema
+    // uses default Zod behavior (strip unknown). Verify by checking parsed
+    // shape doesn't contain dropped fields.
+    const probePayload: Record<string, unknown> = {
+      ...baseline,
+      high_school_id: 42,  // dropped in phase1_09
+      high_school_kv_resolved: "KV1",  // dropped
+      area_resolution_reason: "Legacy reason",  // dropped
+    }
+    const parsed = admissionProfileUpdateSchema.parse(probePayload)
+    expect("high_school_id" in parsed).toBe(false)
+    expect("high_school_kv_resolved" in parsed).toBe(false)
+    expect("area_resolution_reason" in parsed).toBe(false)
   })
 })

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -390,13 +390,14 @@ export const admissionProfileUpdateSchema = z.object({
   // UT (đối tượng): priority_object_codes + per-code evidence dict.
   // =========================================================================
   high_school_id: z.number().int().nullable().optional(),
-  high_school_kv_resolved: z
-    .string()
-    .regex(/^KV[1-9](-NT)?$/, "Mã KV phải là KV1/KV2-NT/KV2/KV3")
-    .nullable()
-    .optional()
-    .or(z.literal(""))
-    .transform(v => v === "" ? null : v),
+  high_school_kv_resolved: z.preprocess(
+    v => (v === "" ? null : v),
+    z
+      .string()
+      .regex(/^KV[1-9](-NT)?$/, "Mã KV phải là KV1/KV2-NT/KV2/KV3")
+      .nullable()
+      .optional(),
+  ),
   permanent_commune_code: nullableString(20),
   area_resolution_basis: z
     .enum(["high_school", "permanent_address_special", "manual_override"])

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -390,14 +390,18 @@ export const admissionProfileUpdateSchema = z.object({
   // UT (đối tượng): priority_object_codes + per-code evidence dict.
   // =========================================================================
   high_school_id: z.number().int().nullable().optional(),
-  high_school_kv_resolved: z.preprocess(
-    v => (v === "" ? null : v),
-    z
-      .string()
-      .regex(/^KV[1-9](-NT)?$/, "Mã KV phải là KV1/KV2-NT/KV2/KV3")
-      .nullable()
-      .optional(),
-  ),
+  // m-FE-2 (review-3 INFO) revert: z.preprocess infers input as `unknown`
+  // which breaks react-hook-form's UseFormReturn type inference downstream
+  // (TS2719 in AdmissionDetailClient.tsx). Verbose chain is more cognitive
+  // overhead but preserves the string input type so the form types stay
+  // narrow. Keep the chain.
+  high_school_kv_resolved: z
+    .string()
+    .regex(/^KV[1-9](-NT)?$/, "Mã KV phải là KV1/KV2-NT/KV2/KV3")
+    .nullable()
+    .optional()
+    .or(z.literal(""))
+    .transform(v => v === "" ? null : v),
   permanent_commune_code: nullableString(20),
   area_resolution_basis: z
     .enum(["high_school", "permanent_address_special", "manual_override"])

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -383,31 +383,35 @@ export const admissionProfileUpdateSchema = z.object({
   documents_checklist: z.array(documentItemSchema).optional().nullable(),
 
   // =========================================================================
-  // Q9 #07 — Priority bonus fields (mirror of BE AdmissionProfileUpdate).
-  // KV (khu vực) PRIMARY basis: high_school_id → server-derived kv_resolved.
+  // Q9 #07 PR5 v1.3 (phase1_09) — Priority bonus fields (2-field parallel).
+  // Trình độ văn hóa: 5 options (Hoàn thành THCS / Tốt nghiệp THCS / Hoàn thành
+  //   THPT / Tốt nghiệp THPT / Tốt nghiệp GDTX) — per Luật GDNN 2014/2025.
+  // Trình độ chuyên môn: 4 options (Chưa có / Sơ cấp / Trung cấp / Cao đẳng).
   // KV BACKUP for special case (PT DTNT / quân nhân): permanent_commune_code.
-  // KV manual override: high_school_kv_resolved + area_resolution_reason.
   // UT (đối tượng): priority_object_codes + per-code evidence dict.
+  // Multi-school history live in academic_history JSONB array (NOT single field).
+  // Legacy (PR1 phase1_08b) high_school_id / kv_resolved / area_resolution_reason
+  //   DROPPED in phase1_09.
   // =========================================================================
-  high_school_id: z.number().int().nullable().optional(),
-  // m-FE-2 (review-3 INFO) revert: z.preprocess infers input as `unknown`
-  // which breaks react-hook-form's UseFormReturn type inference downstream
-  // (TS2719 in AdmissionDetailClient.tsx). Verbose chain is more cognitive
-  // overhead but preserves the string input type so the form types stay
-  // narrow. Keep the chain.
-  high_school_kv_resolved: z
-    .string()
-    .regex(/^KV[1-9](-NT)?$/, "Mã KV phải là KV1/KV2-NT/KV2/KV3")
+  cultural_education_level: z
+    .enum([
+      "completed_thcs",
+      "graduated_thcs",
+      "completed_thpt",
+      "graduated_thpt",
+      "graduated_gdtx",
+    ])
     .nullable()
-    .optional()
-    .or(z.literal(""))
-    .transform(v => v === "" ? null : v),
+    .optional(),
+  vocational_qualification: z
+    .enum(["none", "so_cap", "trung_cap", "cao_dang"])
+    .nullable()
+    .optional(),
   permanent_commune_code: nullableString(20),
   area_resolution_basis: z
     .enum(["high_school", "permanent_address_special", "manual_override"])
     .nullable()
     .optional(),
-  area_resolution_reason: z.string().nullable().optional(),
   priority_object_codes: z.array(prioritySubCodeSchema).max(20).nullable().optional(),
   priority_object_evidence: z
     .record(prioritySubCodeSchema, priorityObjectEvidenceEntrySchema)
@@ -561,17 +565,18 @@ export const admissionProfileResponseSchema = z.object({
   place_of_birth: z.string().nullable(),
   native_place: z.string().nullable(),
 
-  // Q9 #07 priority bonus — READ side (mirror of BE AdmissionProfileResponse).
+  // Q9 #07 v1.3 priority bonus — READ side (mirror of BE AdmissionProfileResponse).
+  // 2-field parallel design (phase1_09): cultural + vocational.
   // Defaults match BE: list/dict default-factory, scalars nullable.
-  high_school_id: z.number().int().nullable().optional(),
-  high_school_kv_resolved: z.string().nullable().optional(),
+  cultural_education_level: z.string().nullable().optional(),
+  vocational_qualification: z.string().nullable().optional(),
   permanent_commune_code: z.string().nullable().optional(),
   area_resolution_basis: z.string().nullable().optional(),
-  area_resolution_reason: z.string().nullable().optional(),
   priority_object_codes: z.array(z.string()).default([]),
   priority_object_evidence: z
     .record(z.string(), priorityObjectEvidenceEntrySchema)
     .default({}),
+  priority_resolution_snapshot: z.record(z.string(), z.unknown()).default({}),
 
   union_entry_date: z.string().datetime({ offset: true }).nullable(),
   party_entry_date: z.string().datetime({ offset: true }).nullable(),

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -71,6 +71,40 @@ export const familyMemberSchema = z.object({
 export type FamilyMember = z.infer<typeof familyMemberSchema>
 
 /**
+ * Priority Bonus — UT đối tượng sub_code regex (Q9 #07 PR1/PR5).
+ *
+ * Mirror of phase1_08b CHECK ``sub_code ~ '^[0-9]{2}$'`` + Pydantic
+ * PrioritySubCode in BE schemas/admission.py. 2-digit numeric like
+ * "01".."07+" per TT 05/2021 Phụ lục 01.
+ */
+export const prioritySubCodeSchema = z
+  .string()
+  .regex(/^[0-9]{2}$/, "Mã UT phải là 2 chữ số (vd: '04')")
+
+/**
+ * Priority Object Evidence Entry — nested shape for each evidence dict
+ * value in priority_object_evidence JSONB. Mirror of BE
+ * PriorityObjectEvidenceEntry (Q9 #07 review-2 + m-RV2-1).
+ *
+ * Status enum gates the engine bonus calc — only "verified" contributes.
+ * Cross-field invariants on BE (rejected → reject_reason, verified →
+ * verified_by) surface as 400 ValidationError from PUT; FE form should
+ * pre-validate to give a faster red-state.
+ */
+export const priorityObjectEvidenceEntrySchema = z.object({
+  status: z.enum(["pending", "verified", "rejected"]),
+  document_id: z.number().int().nullable().optional(),
+  verified_by: z.number().int().nullable().optional(),
+  verified_at: z.string().datetime({ offset: true }).nullable().optional(),
+  reject_reason: z.string().max(500).nullable().optional(),
+  requested_at: z.string().datetime({ offset: true }).nullable().optional(),
+}).strict()
+
+export type PriorityObjectEvidenceEntry = z.infer<
+  typeof priorityObjectEvidenceEntrySchema
+>
+
+/**
  * Academic Record Schema
  * Stored in admission_profile.academic_history JSONB array
  */
@@ -347,6 +381,33 @@ export const admissionProfileUpdateSchema = z.object({
   academic_history: z.array(academicRecordSchema).optional().nullable(),
   admission_scores: admissionScoreSchema.optional().nullable(),
   documents_checklist: z.array(documentItemSchema).optional().nullable(),
+
+  // =========================================================================
+  // Q9 #07 — Priority bonus fields (mirror of BE AdmissionProfileUpdate).
+  // KV (khu vực) PRIMARY basis: high_school_id → server-derived kv_resolved.
+  // KV BACKUP for special case (PT DTNT / quân nhân): permanent_commune_code.
+  // KV manual override: high_school_kv_resolved + area_resolution_reason.
+  // UT (đối tượng): priority_object_codes + per-code evidence dict.
+  // =========================================================================
+  high_school_id: z.number().int().nullable().optional(),
+  high_school_kv_resolved: z
+    .string()
+    .regex(/^KV[1-9](-NT)?$/, "Mã KV phải là KV1/KV2-NT/KV2/KV3")
+    .nullable()
+    .optional()
+    .or(z.literal(""))
+    .transform(v => v === "" ? null : v),
+  permanent_commune_code: nullableString(20),
+  area_resolution_basis: z
+    .enum(["high_school", "permanent_address_special", "manual_override"])
+    .nullable()
+    .optional(),
+  area_resolution_reason: z.string().nullable().optional(),
+  priority_object_codes: z.array(prioritySubCodeSchema).max(20).nullable().optional(),
+  priority_object_evidence: z
+    .record(prioritySubCodeSchema, priorityObjectEvidenceEntrySchema)
+    .nullable()
+    .optional(),
 })
 
 export type AdmissionProfileUpdateInput = z.input<
@@ -494,6 +555,19 @@ export const admissionProfileResponseSchema = z.object({
   permanent_street_address: z.string().nullable(),
   place_of_birth: z.string().nullable(),
   native_place: z.string().nullable(),
+
+  // Q9 #07 priority bonus — READ side (mirror of BE AdmissionProfileResponse).
+  // Defaults match BE: list/dict default-factory, scalars nullable.
+  high_school_id: z.number().int().nullable().optional(),
+  high_school_kv_resolved: z.string().nullable().optional(),
+  permanent_commune_code: z.string().nullable().optional(),
+  area_resolution_basis: z.string().nullable().optional(),
+  area_resolution_reason: z.string().nullable().optional(),
+  priority_object_codes: z.array(z.string()).default([]),
+  priority_object_evidence: z
+    .record(z.string(), priorityObjectEvidenceEntrySchema)
+    .default({}),
+
   union_entry_date: z.string().datetime({ offset: true }).nullable(),
   party_entry_date: z.string().datetime({ offset: true }).nullable(),
   party_official_entry_date: z.string().datetime({ offset: true }).nullable(),

--- a/frontend/src/lib/zod/priority-config.test.ts
+++ b/frontend/src/lib/zod/priority-config.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Zod contract tests for priority-config schemas — Q9 #07 PR3.
+ *
+ * Pins FE parity with the BE Pydantic schema + PG CHECK regex in
+ * `phase1_08b_priority_demographics_gdnn`. If admin types a typo in
+ * the area_code field ("KV2_NT" with an underscore, or lowercase
+ * "kv1"), Zod must reject BEFORE the round-trip so the user never
+ * sees a 500 from PostgreSQL.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import {
+  AREA_CODE_REGEX,
+  GROUP_CODE_REGEX,
+  SUB_CODE_REGEX,
+  priorityAreaConfigCreateSchema,
+  priorityAreaConfigUpdateSchema,
+  priorityConfigCloneRequestSchema,
+  priorityConfigSeedDefaultsRequestSchema,
+  priorityObjectConfigCreateSchema,
+  priorityObjectConfigUpdateSchema,
+} from "./priority-config"
+
+// ============================================================================
+// Regex sanity (pinned to TT 05/2021 Phụ lục 01 canonical code shape)
+// ============================================================================
+
+describe("AREA_CODE_REGEX", () => {
+  it.each(["KV1", "KV2", "KV3", "KV2-NT", "KV9"])("accepts %s", (code) => {
+    expect(AREA_CODE_REGEX.test(code)).toBe(true)
+  })
+
+  it.each([
+    "KV2_NT", // underscore — common typo, must fail
+    "kv1", // lowercase
+    "KV2-nt", // lowercase suffix
+    "KV1NT", // missing hyphen
+    "KV-1", // hyphen in wrong place
+    "KV0", // zero is not allowed
+    "KV10", // two digits not allowed
+    "", // empty
+  ])("rejects %s", (code) => {
+    expect(AREA_CODE_REGEX.test(code)).toBe(false)
+  })
+})
+
+describe("GROUP_CODE_REGEX", () => {
+  it.each(["UT1", "UT2", "UT9"])("accepts %s", (code) => {
+    expect(GROUP_CODE_REGEX.test(code)).toBe(true)
+  })
+
+  it.each(["UT", "UT0", "UT10", "ut1", "U1", "V1", "UT1-A"])(
+    "rejects %s",
+    (code) => {
+      expect(GROUP_CODE_REGEX.test(code)).toBe(false)
+    },
+  )
+})
+
+describe("SUB_CODE_REGEX", () => {
+  it.each(["01", "04", "07", "99", "00"])("accepts %s", (code) => {
+    expect(SUB_CODE_REGEX.test(code)).toBe(true)
+  })
+
+  it.each(["1", "100", "0A", "", "AB"])("rejects %s", (code) => {
+    expect(SUB_CODE_REGEX.test(code)).toBe(false)
+  })
+})
+
+// ============================================================================
+// PriorityAreaConfigCreate — happy path + typical typos
+// ============================================================================
+
+describe("priorityAreaConfigCreateSchema", () => {
+  it("parses a valid TT 05/2021 KV1 row", () => {
+    const parsed = priorityAreaConfigCreateSchema.parse({
+      academic_year: 2026,
+      area_code: "KV1",
+      area_name: "Khu vực 1",
+      bonus_points: 0.75,
+      description: "Vùng đặc biệt khó khăn",
+    })
+    expect(parsed.area_code).toBe("KV1")
+    expect(parsed.bonus_points).toBe(0.75)
+  })
+
+  it("rejects the canonical underscore typo (KV2_NT)", () => {
+    const result = priorityAreaConfigCreateSchema.safeParse({
+      academic_year: 2026,
+      area_code: "KV2_NT",
+      area_name: "Khu vực 2 nông thôn",
+      bonus_points: 0.5,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const codeIssue = result.error.issues.find((i) =>
+        i.path.includes("area_code"),
+      )
+      expect(codeIssue).toBeDefined()
+    }
+  })
+
+  it("rejects bonus_points > 99.99", () => {
+    const result = priorityAreaConfigCreateSchema.safeParse({
+      academic_year: 2026,
+      area_code: "KV1",
+      area_name: "Khu vực 1",
+      bonus_points: 100,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects bonus_points with > 2 decimal places", () => {
+    const result = priorityAreaConfigCreateSchema.safeParse({
+      academic_year: 2026,
+      area_code: "KV1",
+      area_name: "Khu vực 1",
+      bonus_points: 0.123,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects academic_year < 2020", () => {
+    const result = priorityAreaConfigCreateSchema.safeParse({
+      academic_year: 2019,
+      area_code: "KV1",
+      area_name: "Khu vực 1",
+      bonus_points: 0.75,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("accepts integer bonus_points (0)", () => {
+    const result = priorityAreaConfigCreateSchema.safeParse({
+      academic_year: 2026,
+      area_code: "KV3",
+      area_name: "Khu vực 3",
+      bonus_points: 0,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects malformed date string", () => {
+    const result = priorityAreaConfigCreateSchema.safeParse({
+      academic_year: 2026,
+      area_code: "KV1",
+      area_name: "Khu vực 1",
+      bonus_points: 0.75,
+      effective_from: "2026/01/01", // slashes not allowed
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("priorityAreaConfigUpdateSchema", () => {
+  it("accepts empty body (no-op update)", () => {
+    const result = priorityAreaConfigUpdateSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts partial body — bonus_points only", () => {
+    const result = priorityAreaConfigUpdateSchema.safeParse({
+      bonus_points: 1.0,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("does not allow area_code on update (immutable identity)", () => {
+    // Update schema deliberately omits area_code — extra keys are
+    // stripped by default, not rejected. Confirm the parsed output
+    // is empty when only area_code is sent.
+    const result = priorityAreaConfigUpdateSchema.safeParse({
+      area_code: "KV9",
+    } as Record<string, unknown>)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).area_code).toBeUndefined()
+    }
+  })
+})
+
+// ============================================================================
+// PriorityObjectConfigCreate
+// ============================================================================
+
+describe("priorityObjectConfigCreateSchema", () => {
+  it("parses a valid TT 05/2021 UT1/04 row", () => {
+    const parsed = priorityObjectConfigCreateSchema.parse({
+      academic_year: 2026,
+      group_code: "UT1",
+      sub_code: "04",
+      description: "Con liệt sĩ",
+      bonus_points: 2.0,
+    })
+    expect(parsed.sub_code).toBe("04")
+    expect(parsed.bonus_points).toBe(2.0)
+  })
+
+  it("rejects single-digit sub_code (must be 2 digits)", () => {
+    const result = priorityObjectConfigCreateSchema.safeParse({
+      academic_year: 2026,
+      group_code: "UT1",
+      sub_code: "4",
+      description: "Con liệt sĩ",
+      bonus_points: 2.0,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects 3-digit sub_code", () => {
+    const result = priorityObjectConfigCreateSchema.safeParse({
+      academic_year: 2026,
+      group_code: "UT1",
+      sub_code: "004",
+      description: "Anh hùng",
+      bonus_points: 2.0,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects empty description", () => {
+    const result = priorityObjectConfigCreateSchema.safeParse({
+      academic_year: 2026,
+      group_code: "UT1",
+      sub_code: "04",
+      description: "",
+      bonus_points: 2.0,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("rejects lowercase group_code", () => {
+    const result = priorityObjectConfigCreateSchema.safeParse({
+      academic_year: 2026,
+      group_code: "ut1",
+      sub_code: "04",
+      description: "Con liệt sĩ",
+      bonus_points: 2.0,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("priorityObjectConfigUpdateSchema", () => {
+  it("accepts partial body — bonus_points + description only", () => {
+    const result = priorityObjectConfigUpdateSchema.safeParse({
+      bonus_points: 1.5,
+      description: "Mô tả mới",
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts evidence_doc_type=null (clear field)", () => {
+    const result = priorityObjectConfigUpdateSchema.safeParse({
+      evidence_doc_type: null,
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+// ============================================================================
+// Clone + seed requests
+// ============================================================================
+
+describe("priorityConfigCloneRequestSchema", () => {
+  it("accepts from_year != to_year", () => {
+    const parsed = priorityConfigCloneRequestSchema.parse({
+      from_year: 2026,
+      to_year: 2027,
+    })
+    expect(parsed.to_year).toBe(2027)
+  })
+
+  it("rejects from_year === to_year", () => {
+    const result = priorityConfigCloneRequestSchema.safeParse({
+      from_year: 2026,
+      to_year: 2026,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      // Refine attaches the error to to_year per schema config.
+      const issue = result.error.issues.find((i) => i.path.includes("to_year"))
+      expect(issue).toBeDefined()
+    }
+  })
+
+  it("rejects year < 2020", () => {
+    const result = priorityConfigCloneRequestSchema.safeParse({
+      from_year: 2019,
+      to_year: 2026,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe("priorityConfigSeedDefaultsRequestSchema", () => {
+  it("accepts year in range", () => {
+    const parsed = priorityConfigSeedDefaultsRequestSchema.parse({
+      academic_year: 2026,
+    })
+    expect(parsed.academic_year).toBe(2026)
+  })
+
+  it("rejects year > 2100", () => {
+    const result = priorityConfigSeedDefaultsRequestSchema.safeParse({
+      academic_year: 2101,
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/frontend/src/lib/zod/priority-config.ts
+++ b/frontend/src/lib/zod/priority-config.ts
@@ -1,0 +1,176 @@
+/**
+ * Zod schemas for priority_area_config + priority_object_config
+ * admin CRUD (Q9 #07 PR3 admin FE).
+ *
+ * Mirrors `Backend_FastAPI/app/schemas/priority_config.py` Pydantic
+ * shapes + the migration phase1_08b CHECK regex constraints so a typo
+ * fails Zod BEFORE the round-trip and never hits a PG 500.
+ *
+ * Code values (TT 05/2021-BLĐTBXH Phụ lục 01):
+ * - area_code: KV1 / KV2-NT / KV2 / KV3 (HYPHEN, not underscore)
+ * - group_code: UT1 / UT2 (extensible UT3+)
+ * - sub_code:   2-digit numeric '01'..'07' (extensible)
+ *
+ * NB: `bonus_points` arrives as a `Decimal` JSON encoding from the BE
+ * — Pydantic serialises Numeric(4,2) as a number; FE keeps it as
+ * `number` (Zod will fail loudly if the BE ever emits a string).
+ */
+import { z } from "zod"
+
+// ==============================================================================
+// CODE REGEX CONSTANTS — single source of truth for FE validation
+// ==============================================================================
+
+export const AREA_CODE_REGEX = /^KV[1-9](-NT)?$/
+export const GROUP_CODE_REGEX = /^UT[1-9]$/
+export const SUB_CODE_REGEX = /^[0-9]{2}$/
+
+// ==============================================================================
+// PRIORITY AREA CONFIG
+// ==============================================================================
+
+const academicYearField = z
+  .number()
+  .int()
+  .min(2020, "Năm học tối thiểu 2020")
+  .max(2100, "Năm học tối đa 2100")
+
+const bonusPointsField = z
+  .number()
+  .min(0, "Điểm cộng không âm")
+  .max(99.99, "Điểm cộng tối đa 99.99")
+  // Mirror Pydantic decimal_places=2: enforce ≤ 2 fractional digits on
+  // the wire. Multiplying by 100 + rounding catches floating-point
+  // garbage like 0.123 without false positives on 0.75 / 1.5 / 2.
+  .refine((v) => Math.round(v * 100) === v * 100, {
+    message: "Tối đa 2 chữ số thập phân",
+  })
+
+const dateField = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Định dạng phải là YYYY-MM-DD")
+
+export const priorityAreaConfigBaseSchema = z.object({
+  academic_year: academicYearField,
+  area_code: z
+    .string()
+    .regex(AREA_CODE_REGEX, "Mã KV không hợp lệ (VD: KV1, KV2-NT, KV3)"),
+  area_name: z.string().min(1, "Tên KV bắt buộc").max(100),
+  bonus_points: bonusPointsField,
+  description: z.string().nullable().optional(),
+  effective_from: dateField.nullable().optional(),
+  effective_to: dateField.nullable().optional(),
+})
+
+export type PriorityAreaConfigBase = z.infer<typeof priorityAreaConfigBaseSchema>
+
+/** Create payload — same shape as base. */
+export const priorityAreaConfigCreateSchema = priorityAreaConfigBaseSchema
+
+export type PriorityAreaConfigCreate = z.infer<typeof priorityAreaConfigCreateSchema>
+
+/**
+ * PATCH payload — all fields optional. BE applies via
+ * `model_dump(exclude_unset=True)` so omitted keys leave the column
+ * untouched.
+ */
+export const priorityAreaConfigUpdateSchema = z.object({
+  area_name: z.string().min(1).max(100).optional(),
+  bonus_points: bonusPointsField.optional(),
+  description: z.string().nullable().optional(),
+  effective_to: dateField.nullable().optional(),
+})
+
+export type PriorityAreaConfigUpdate = z.infer<typeof priorityAreaConfigUpdateSchema>
+
+/** Response — server-side fields included. */
+export const priorityAreaConfigResponseSchema = priorityAreaConfigBaseSchema.extend({
+  id: z.number().int().positive(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export type PriorityAreaConfigResponse = z.infer<typeof priorityAreaConfigResponseSchema>
+
+// ==============================================================================
+// PRIORITY OBJECT CONFIG (UT đối tượng — group_code + sub_code)
+// ==============================================================================
+
+export const priorityObjectConfigBaseSchema = z.object({
+  academic_year: academicYearField,
+  group_code: z
+    .string()
+    .regex(GROUP_CODE_REGEX, "Mã nhóm UT không hợp lệ (VD: UT1, UT2)"),
+  sub_code: z
+    .string()
+    .regex(SUB_CODE_REGEX, "sub_code phải là 2 chữ số (VD: 01, 04, 07)"),
+  description: z.string().min(1, "Mô tả bắt buộc"),
+  bonus_points: bonusPointsField,
+  evidence_doc_type: z.string().max(100).nullable().optional(),
+  effective_from: dateField.nullable().optional(),
+  effective_to: dateField.nullable().optional(),
+})
+
+export type PriorityObjectConfigBase = z.infer<typeof priorityObjectConfigBaseSchema>
+
+export const priorityObjectConfigCreateSchema = priorityObjectConfigBaseSchema
+
+export type PriorityObjectConfigCreate = z.infer<typeof priorityObjectConfigCreateSchema>
+
+export const priorityObjectConfigUpdateSchema = z.object({
+  description: z.string().min(1).optional(),
+  bonus_points: bonusPointsField.optional(),
+  evidence_doc_type: z.string().max(100).nullable().optional(),
+  effective_to: dateField.nullable().optional(),
+})
+
+export type PriorityObjectConfigUpdate = z.infer<typeof priorityObjectConfigUpdateSchema>
+
+export const priorityObjectConfigResponseSchema = priorityObjectConfigBaseSchema.extend({
+  id: z.number().int().positive(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export type PriorityObjectConfigResponse = z.infer<typeof priorityObjectConfigResponseSchema>
+
+// ==============================================================================
+// CLONE + SEED REQUESTS
+// ==============================================================================
+
+export const priorityConfigCloneRequestSchema = z
+  .object({
+    from_year: academicYearField,
+    to_year: academicYearField,
+  })
+  .refine((d) => d.from_year !== d.to_year, {
+    message: "from_year và to_year phải khác nhau",
+    path: ["to_year"],
+  })
+
+export type PriorityConfigCloneRequest = z.infer<typeof priorityConfigCloneRequestSchema>
+
+export const priorityConfigCloneResponseSchema = z.object({
+  cloned_areas: z.number().int().min(0),
+  cloned_objects: z.number().int().min(0),
+})
+
+export type PriorityConfigCloneResponse = z.infer<typeof priorityConfigCloneResponseSchema>
+
+export const priorityConfigSeedDefaultsRequestSchema = z.object({
+  academic_year: academicYearField,
+})
+
+export type PriorityConfigSeedDefaultsRequest = z.infer<
+  typeof priorityConfigSeedDefaultsRequestSchema
+>
+
+export const priorityConfigSeedDefaultsResponseSchema = z.object({
+  inserted_areas: z.number().int().min(0),
+  inserted_objects: z.number().int().min(0),
+  skipped_existing: z.boolean(),
+})
+
+export type PriorityConfigSeedDefaultsResponse = z.infer<
+  typeof priorityConfigSeedDefaultsResponseSchema
+>


### PR DESCRIPTION
## Summary

Q9 #07 Priority Bonus System **schema foundation** ship — 13 commits squashed.

**Evolution**: PR1-4 đã ship single-school placeholder (`high_school_id`); Track B redesign (commit `138e530d`) SUPERSEDES với multi-school 2-field design per TT 05/2021/TT-BLĐTBXH Phụ lục 01 + Luật GDNN 2014/2025.

## Final state (post-merge)

### Schema (phase1_09 migration)

**admission_profile columns**:
- ADD `cultural_education_level` (5 enum: completed_thcs / graduated_thcs / completed_thpt / graduated_thpt / graduated_gdtx)
- ADD `vocational_qualification` (4 enum: none / so_cap / trung_cap / cao_dang)
- ADD `priority_resolution_snapshot` JSONB (Q-P3-11 frozen pattern)
- DROP `high_school_id`, `high_school_kv_resolved`, `area_resolution_reason` (PR1 placeholders, 0 prod rows)
- KEEP `permanent_commune_code`, `area_resolution_basis`, `priority_object_codes`, `priority_object_evidence`

**New tables** (temporal SCD):
- `vn_school` (THCS / THPT / THCS_THPT / TRUNG_HOC_NGHE / OTHER + soft-delete)
- `vn_school_name_history` (slowly-changing name)
- `vn_school_kv_assignment` (KV theo năm học)

**Dropped tables**: `vn_high_school` (PR1 placeholder)

### Other shipped in this PR

- PR3 admin priority-config CRUD (8 endpoints) + FE sidebar entry + TT 05/2021 seed
- FE Zod schemas (cultural + vocational enums + dropped fields proof)
- Engine integration (CR-P0 wire priority bonus → admission decision)
- CSV import (commune only — HS endpoints dropped phase1_09)
- Review fixes: F.5/F.6/F.7/H1/M1-3/N2/CR-P0/CR-M1-3/m-FE-4/m-RV2-1
- Documentation `Documents/Q9_07_PR5_REDESIGN.md` v1.3

### Test coverage

- BE: 116 priority anchor tests pass
- FE: 18 Zod tests pass
- App: 506 routes clean (was 509, dropped 3 HS endpoints expected)
- Migration roundtrip verified clean (upgrade → downgrade → re-upgrade)

## ⚠️ Important post-merge state

**Engine sẽ ship LIVE với bonus=0đ silently cho mọi candidate** vì:
- `priority_service.calculate_priority_bonus()` reads `profile.high_school_kv_resolved` (dropped) → fallback None → 0đ graceful
- Candidate FE chưa có PriorityTab → không có UX khai cultural/vocational
- Phase B-F (data ingestion + engine refactor + candidate FE + officer verify + admin backfill) ship trong subsequent PRs

**Defensive degrade — KHÔNG phải bug**. Mùa 2026-08-01 còn 2.5 tháng buffer cho Phase B-F.

## Remaining work (subsequent PRs)

- Phase B: MOET THPT import + VN commune KV map + TC manual seed (~3-4d)
- Phase C: BE engine resolve_kv_for_profile() + eligibility validator (~3d)
- Phase D: Candidate FE PriorityTab + AcademicHistoryTab upgrade (~3.5d)
- Phase E: Officer FE UT evidence verify + KV breakdown audit (~2d)
- Phase F: Admin backfill UI (~2d)

## Test plan

- [x] BE pytest CI (17m12s green)
- [x] FE Build + Check (type+lint+test) CI green
- [x] AST lint + Coverage + Dependencies CI green
- [x] Migration roundtrip verified locally
- [ ] Post-merge: monitor deploy.yml auto-deploy to prod VPS
- [ ] Post-merge: smoke test `/api/admissions` POST + PUT with v1.3 fields

Refs:
- Documents/Q9_07_PR5_REDESIGN.md v1.3
- Documents/research_qd861_data_source.md
- TT 05/2021/TT-BLĐTBXH Phụ lục 01
- QĐ 861/QĐ-TTg
- Dự thảo TT 2026/TT-BGDĐT GDNN

🤖 Generated with [Claude Code](https://claude.com/claude-code)