### PR TITLE
feat(q9-07/phase-c): KV resolution engine — fix silent 0đ bug (TT 05/2021 multi-school)

### DIFF
--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -358,7 +358,33 @@ async def evaluate_cascade(
         # (graceful for legacy 315 profiles without backfill).
         # Lazy import: priority_service imports app.models which would
         # create a circular dep at module load time of this engine file.
-        from app.services.priority_service import calculate_priority_bonus
+        from app.services.priority_service import (
+            calculate_priority_bonus,
+            freeze_priority_snapshot,
+        )
+
+        # Q9 #07 Phase C — Re-freeze priority_resolution_snapshot at T6 engine.
+        # T1 submit already froze with submit-time data; T6 re-freezes in
+        # case academic_history / cultural fields were edited during
+        # revision_requested cycle. Mirrors Q-P3-11 bonus_rule_snapshot
+        # double-freeze pattern. Best-effort: if KV resolution fails (eg
+        # missing commune data Phase B.2 pending), engine continues — the
+        # downstream calculate_priority_bonus reads snapshot.kv_resolved
+        # = None and returns 0đ gracefully.
+        try:
+            await freeze_priority_snapshot(
+                profile=profile,
+                db=db,
+                frozen_at_status="engine_T6",
+                resolved_by="system",
+            )
+        except Exception as kv_freeze_exc:  # noqa: BLE001
+            log.warning(
+                "priority_snapshot_freeze_failed_at_engine",
+                profile_id=getattr(profile, "id", None),
+                choice_id=getattr(choice, "id", None),
+                error=str(kv_freeze_exc),
+            )
 
         # Eager-load-safe access via __dict__.get (NOT getattr): plain
         # ``getattr(path, "admission_round", None)`` would trigger a

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4212,6 +4212,35 @@ async def submit_and_evaluate(
         # event. The single source of truth lives in our callback so
         # APPLICATION_STATUS_CHANGED + ADMISSION_PROFILE_SUBMITTED
         # always fire side-by-side AFTER ``db.commit()``.
+
+        # Q9 #07 Phase C — Freeze priority resolution snapshot at T1.
+        # Captures kv_resolved + breakdown immutably at submit time so
+        # subsequent admin edits to vn_school_kv_assignment / vn_commune_area_map
+        # don't mutate the candidate's resolved KV. T6 evaluate_cascade
+        # re-freezes with current rates per Q-P3-11 snapshot pattern.
+        # Lazy import: priority_service imports app.models which would
+        # create a circular dep at module load time.
+        from .priority_service import freeze_priority_snapshot as _freeze_kv
+
+        try:
+            await _freeze_kv(
+                profile=profile,
+                db=db,
+                frozen_at_status="submitted_T1",
+                resolved_by="system",
+            )
+        except Exception as freeze_exc:  # noqa: BLE001 — defensive: never block submit
+            log.warning(
+                "priority_snapshot_freeze_failed_at_submit",
+                profile_id=profile_id,
+                error=str(freeze_exc),
+                reason=(
+                    "KV resolution failed during submit T1; profile still "
+                    "submits but priority_resolution_snapshot stays empty. "
+                    "Engine T6 will retry freeze."
+                ),
+            )
+
         try:
             profile, _ = await state_transition(
                 db,

--- a/Backend_FastAPI/app/services/priority_service.py
+++ b/Backend_FastAPI/app/services/priority_service.py
@@ -261,3 +261,419 @@ def _today():
     from datetime import date
 
     return date.today()
+
+
+# =============================================================================
+# Phase C — KV Resolution (Q9 #07 PR5 v1.3)
+# =============================================================================
+#
+# Implements TT 05/2021/TT-BLĐTBXH Phụ lục 01 multi-school KV resolution:
+#   - "Nếu chuyển trường, thời gian học ở khu vực nào lâu hơn được hưởng
+#      ưu tiên theo khu vực đó."
+#   - "Khi mỗi năm học một trường thuộc các khu vực có mức ưu tiên khác
+#      nhau hoặc nửa thời gian học ở trường này, nửa thời gian học ở
+#      trường kia thì tốt nghiệp ở khu vực nào, hưởng ưu tiên theo khu
+#      vực đó."
+#
+# Branched by 2-field parallel (cultural_education_level, vocational_qualification)
+# per v1.3 redesign. See Documents/Q9_07_PR5_REDESIGN.md cho 6-row matrix
+# + 3 bypass cases (area_resolution_basis = permanent_address_special / manual_override
+# / NOT_RESOLVED).
+# =============================================================================
+
+
+def _derive_kv_basis_level(
+    cultural: Optional[str],
+    vocational: str,
+    area_resolution_basis: Optional[str] = None,
+) -> str:
+    """Map (cultural, vocational, area_basis) → KV resolution basis.
+
+    Returns one of:
+      'THPT'              — apply 3-year THPT multi-school rule (rows 1, 2)
+      'TC'                — apply TC time multi-school rule (rows 2-fallthrough, 4)
+      'COMMUNE_FALLBACK'  — THCS only / so_cap / completed_thpt+none (rows 3, 5, 6)
+      'COMMUNE_SPECIAL'   — 4 special cases bypass (row 8)
+      'MANUAL'            — admin override (row 9)
+      'NOT_RESOLVED'      — cultural chưa khai (row 7, draft)
+
+    See `Documents/Q9_07_PR5_REDESIGN.md` v1.3 Section "KV resolution basis
+    derivation matrix" cho 9 rows complete spec.
+    """
+    # Row 8/9: area_resolution_basis overrides matrix
+    if area_resolution_basis == "permanent_address_special":
+        return "COMMUNE_SPECIAL"
+    if area_resolution_basis == "manual_override":
+        return "MANUAL"
+
+    # Row 7: cultural not set (draft state)
+    if cultural is None:
+        return "NOT_RESOLVED"
+
+    # Rows 1, 2 (partial), 3: THPT-related cultural levels
+    if cultural in ("graduated_thpt", "graduated_gdtx", "completed_thpt"):
+        # Row 3 (completed_thpt + so_cap/none) → COMMUNE_FALLBACK
+        if cultural == "completed_thpt" and vocational in ("so_cap", "none"):
+            return "COMMUNE_FALLBACK"
+        return "THPT"  # Rows 1 + 2
+
+    # Rows 4, 5: graduated_thcs + vocational branching
+    if cultural == "graduated_thcs":
+        if vocational in ("trung_cap", "cao_dang"):
+            return "TC"  # Row 4
+        return "COMMUNE_FALLBACK"  # Row 5
+
+    # Row 6: completed_thcs (any vocational) → fallback
+    if cultural == "completed_thcs":
+        return "COMMUNE_FALLBACK"
+
+    # Defensive: unknown cultural (shouldn't happen due to CHECK enum)
+    return "NOT_RESOLVED"
+
+
+async def _lookup_commune_kv(
+    db: "AsyncSession", commune_code: str
+) -> Optional[str]:
+    """Lookup active KV for a commune_code from vn_commune_area_map.
+
+    Active row = effective_to IS NULL. Returns None if commune not in table
+    (graceful — Phase B.2 may not have full coverage yet).
+    """
+    from app.models.vn_locality import VnCommuneAreaMap
+
+    stmt = (
+        select(VnCommuneAreaMap.area_code)
+        .where(
+            VnCommuneAreaMap.commune_code == commune_code,
+            VnCommuneAreaMap.effective_to.is_(None),
+        )
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def lookup_kv_for_school_year(
+    db: "AsyncSession", school_id: int, year: int
+) -> Optional[str]:
+    """Lookup KV for a school at a given academic year (temporal).
+
+    Query pattern (per VnSchoolKvAssignment docstring):
+        SELECT kv_code FROM vn_school_kv_assignment
+        WHERE school_id = :sid
+          AND :year BETWEEN effective_from_year
+                       AND COALESCE(effective_to_year, 9999);
+    """
+    from app.models.vn_school import VnSchoolKvAssignment
+
+    stmt = (
+        select(VnSchoolKvAssignment.kv_code)
+        .where(
+            VnSchoolKvAssignment.school_id == school_id,
+            VnSchoolKvAssignment.effective_from_year <= year,
+            (VnSchoolKvAssignment.effective_to_year.is_(None))
+            | (VnSchoolKvAssignment.effective_to_year >= year),
+        )
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def resolve_kv_for_profile(
+    profile: "AdmissionProfile",
+    db: "AsyncSession",
+) -> tuple[Optional[str], dict[str, Any]]:
+    """Resolve KV for a profile per TT 05/2021 Phụ lục 01 multi-school rule.
+
+    Returns ``(kv_code, meta_dict)`` where ``meta_dict`` matches the shape
+    of ``priority_resolution_snapshot`` (without freeze metadata):
+
+        {
+            'rule_applied': str,   # longest_duration | tiebreak_graduation_school
+                                   # | commune_lookup | manual_override
+                                   # | ambiguous_requires_manual
+            'pathway': str,        # thpt_multi_school | tc_multi_school
+                                   # | commune_fallback | commune_special
+                                   # | manual | not_resolved
+            'breakdown': {...} | None,
+            'requires_manual_override': bool (optional),
+            'reason': str (optional)
+        }
+
+    NULL kv_code → engine ignores (legacy fallback 0đ).
+
+    See `Documents/Q9_07_PR5_REDESIGN.md` v1.3 Section "Resolution algorithm".
+    """
+    cultural = getattr(profile, "cultural_education_level", None)
+    vocational = getattr(profile, "vocational_qualification", "none") or "none"
+    area_basis = getattr(profile, "area_resolution_basis", None)
+
+    basis = _derive_kv_basis_level(cultural, vocational, area_basis)
+
+    # --- Row 8: 4 special cases bypass (PT DTNT / dự bị / quân nhân / xuất ngũ) ---
+    if basis == "COMMUNE_SPECIAL":
+        commune_code = getattr(profile, "permanent_commune_code", None)
+        if commune_code:
+            kv = await _lookup_commune_kv(db, commune_code)
+            return kv, {
+                "rule_applied": "commune_lookup",
+                "pathway": "commune_special",
+                "breakdown": {"commune_code_used": commune_code},
+            }
+        return None, {
+            "rule_applied": "ambiguous_requires_manual",
+            "pathway": "commune_special",
+            "requires_manual_override": True,
+            "reason": "special_case_no_commune",
+        }
+
+    # --- Row 9: admin/officer manual override ---
+    if basis == "MANUAL":
+        # Caller should have set kv_resolved in snapshot before calling;
+        # treat as no-op here (returns NULL → snapshot keeps existing).
+        return None, {
+            "rule_applied": "manual_override",
+            "pathway": "manual",
+            "requires_manual_override": False,
+            "reason": "admin_set_kv_directly",
+        }
+
+    # --- Row 7: cultural not set (draft) ---
+    if basis == "NOT_RESOLVED":
+        return None, {
+            "rule_applied": "ambiguous_requires_manual",
+            "pathway": "not_resolved",
+            "requires_manual_override": False,
+            "reason": "cultural_not_set",
+        }
+
+    # --- Rows 3, 5, 6: commune fallback (THCS only / so_cap / completed_thpt+none) ---
+    if basis == "COMMUNE_FALLBACK":
+        commune_code = getattr(profile, "permanent_commune_code", None)
+        if commune_code:
+            kv = await _lookup_commune_kv(db, commune_code)
+            return kv, {
+                "rule_applied": "commune_lookup",
+                "pathway": "commune_fallback",
+                "breakdown": {"commune_code_used": commune_code},
+            }
+        return None, {
+            "rule_applied": "ambiguous_requires_manual",
+            "pathway": "commune_fallback",
+            "requires_manual_override": True,
+            "reason": "fallback_no_commune",
+        }
+
+    # --- Rows 1, 2, 4: multi-school rule (THPT or TC) ---
+    history = getattr(profile, "academic_history", None) or []
+    basis_entries = [
+        e for e in history
+        if isinstance(e, dict)
+        and e.get("level") == basis
+        and e.get("school_id")
+    ]
+
+    pathway = "thpt_multi_school" if basis == "THPT" else "tc_multi_school"
+
+    if not basis_entries:
+        return None, {
+            "rule_applied": "ambiguous_requires_manual",
+            "pathway": pathway,
+            "requires_manual_override": True,
+            "reason": "no_qualifying_entries",
+            "breakdown": {"target_level": basis, "entries": []},
+        }
+
+    # Per-year KV duration map + breakdown per entry
+    kv_years: dict[str, int] = {}
+    breakdown_entries: list[dict[str, Any]] = []
+
+    for entry in basis_entries:
+        sid = entry["school_id"]
+        y_from = entry.get("year_from")
+        y_to = entry.get("year_to")
+        if y_from is None or y_to is None or y_to < y_from:
+            continue
+
+        entry_years_by_kv: list[dict[str, Any]] = []
+        for year in range(y_from, y_to + 1):
+            kv = await lookup_kv_for_school_year(db, sid, year)
+            if kv:
+                kv_years[kv] = kv_years.get(kv, 0) + 1
+                entry_years_by_kv.append({"year": year, "kv": kv})
+
+        breakdown_entries.append({
+            "school_id": sid,
+            "school_name_at_time": entry.get("school_name"),
+            "year_from": y_from,
+            "year_to": y_to,
+            "years_by_kv": entry_years_by_kv,
+        })
+
+    if not kv_years:
+        return None, {
+            "rule_applied": "ambiguous_requires_manual",
+            "pathway": pathway,
+            "requires_manual_override": True,
+            "reason": "no_kv_lookup_succeeded",
+            "breakdown": {
+                "target_level": basis,
+                "entries": breakdown_entries,
+                "kv_totals": {},
+            },
+        }
+
+    max_yrs = max(kv_years.values())
+    winners = [kv for kv, y in kv_years.items() if y == max_yrs]
+
+    breakdown_base = {
+        "target_level": basis,
+        "entries": breakdown_entries,
+        "kv_totals": kv_years,
+        "winner_years": max_yrs,
+    }
+
+    if len(winners) == 1:
+        return winners[0], {
+            "rule_applied": "longest_duration",
+            "pathway": pathway,
+            "breakdown": breakdown_base,
+        }
+
+    # Tiebreak: graduation school (highest year_to + grade_to, stable index).
+    # M1: detect ambiguous (2+ entries cùng year_to + grade_to) → require manual.
+    sorted_entries = sorted(
+        enumerate(basis_entries),
+        key=lambda pair: (
+            pair[1].get("year_to", 0),
+            pair[1].get("grade_to", 0),
+            -pair[0],  # stable: prefer earlier index when ties
+        ),
+        reverse=True,
+    )
+    if len(sorted_entries) >= 2:
+        top_entry = sorted_entries[0][1]
+        second_entry = sorted_entries[1][1]
+        if (
+            top_entry.get("year_to") == second_entry.get("year_to")
+            and top_entry.get("grade_to") == second_entry.get("grade_to")
+        ):
+            return None, {
+                "rule_applied": "ambiguous_requires_manual",
+                "pathway": pathway,
+                "requires_manual_override": True,
+                "reason": "tied_graduation_year_and_grade",
+                "breakdown": {
+                    **breakdown_base,
+                    "tied_kv": winners,
+                    "tied_entries": [
+                        top_entry["school_id"],
+                        second_entry["school_id"],
+                    ],
+                },
+            }
+
+    grad_entry = sorted_entries[0][1]
+    grad_kv = await lookup_kv_for_school_year(
+        db, grad_entry["school_id"], grad_entry["year_to"]
+    )
+    return grad_kv, {
+        "rule_applied": "tiebreak_graduation_school",
+        "pathway": pathway,
+        "breakdown": {
+            **breakdown_base,
+            "tied_kv": winners,
+            "graduation_school_id": grad_entry["school_id"],
+            "graduation_year": grad_entry["year_to"],
+        },
+    }
+
+
+async def freeze_priority_snapshot(
+    profile: "AdmissionProfile",
+    db: "AsyncSession",
+    frozen_at_status: str,
+    resolved_by: str = "system",
+    manual_override_reason: Optional[str] = None,
+) -> dict[str, Any]:
+    """Compute KV resolution + freeze into ``profile.priority_resolution_snapshot``.
+
+    Called from:
+      - submit_admission_profile (T1) → frozen_at_status='submitted_T1'
+      - evaluate_cascade (T6) → frozen_at_status='engine_T6'
+
+    Mutates ``profile.priority_resolution_snapshot`` directly. Caller is
+    responsible for ``await db.flush()`` (no commit — service layer rule).
+
+    ``frozen_at_status`` MUST be one of:
+      'draft_preview' | 'submitted_T1' | 'engine_T6'
+
+    Returns the snapshot dict (also written to profile column).
+    """
+    kv_resolved, meta = await resolve_kv_for_profile(profile, db)
+    snapshot: dict[str, Any] = {
+        "kv_resolved": kv_resolved,
+        "rule_applied": meta.get("rule_applied"),
+        "pathway": meta.get("pathway"),
+        "breakdown": meta.get("breakdown"),
+        "frozen_at": datetime.now(timezone.utc).isoformat(),
+        "frozen_at_status": frozen_at_status,
+        "resolved_by": resolved_by,
+    }
+    if manual_override_reason:
+        snapshot["manual_override_reason"] = manual_override_reason
+    if meta.get("requires_manual_override"):
+        snapshot["requires_manual_override"] = True
+    if meta.get("reason"):
+        snapshot["reason"] = meta["reason"]
+
+    profile.priority_resolution_snapshot = snapshot
+    return snapshot
+
+
+def validate_eligibility(
+    profile: "AdmissionProfile",
+    target_level: str,
+) -> tuple[bool, Optional[str]]:
+    """Validate candidate eligibility for target program level.
+
+    Per TT 05/2021 Phụ lục 01 + Luật GDNN 2014/2025:
+      - target_level='CD' (Cao đẳng): requires graduated_thpt OR graduated_gdtx
+        OR (completed_thpt + trung_cap) — path 2 cho liên thông
+      - target_level='TC' (Trung cấp): requires graduated_thcs trở lên
+      - target_level='SC' (Sơ cấp): no academic requirement
+
+    Returns ``(is_eligible, reason_if_not)``.
+    """
+    cultural = getattr(profile, "cultural_education_level", None)
+    vocational = getattr(profile, "vocational_qualification", "none") or "none"
+
+    if target_level in ("CD", "cao_dang"):
+        # Path 1: tốt nghiệp THPT/GDTX direct
+        if cultural in ("graduated_thpt", "graduated_gdtx"):
+            return True, None
+        # Path 2: liên thông — đủ kiến thức THPT + bằng TC nghề
+        if cultural == "completed_thpt" and vocational == "trung_cap":
+            return True, None
+        # Path 2 extended: graduated_thcs + cao_dang already done → re-enroll OK
+        if cultural == "graduated_thcs" and vocational == "cao_dang":
+            return True, None
+        return False, "cd_requires_thpt_or_thpt_kien_thuc_plus_trung_cap"
+
+    if target_level in ("TC", "trung_cap"):
+        # Per Luật GDNN: TC yêu cầu tốt nghiệp THCS trở lên
+        if cultural in (
+            "graduated_thcs",
+            "completed_thpt",
+            "graduated_thpt",
+            "graduated_gdtx",
+        ):
+            return True, None
+        return False, "tc_requires_graduated_thcs_or_higher"
+
+    if target_level in ("SC", "so_cap"):
+        return True, None  # SC không yêu cầu trình độ văn hóa
+
+    # Unknown target_level — defensive pass-through (caller validates)
+    return True, None

--- a/Backend_FastAPI/tests/unit/test_priority_kv_resolution.py
+++ b/Backend_FastAPI/tests/unit/test_priority_kv_resolution.py
@@ -1,0 +1,426 @@
+"""Phase C.5 anchor tests — KV resolution algorithm + eligibility validate.
+
+Tests the v1.3 multi-school KV resolution rule per TT 05/2021 Phụ lục 01
++ TT 06/2026/TT-BGDĐT Phụ lục I.
+
+Covers:
+- 6-row matrix `_derive_kv_basis_level()` (cultural × vocational)
+- 3 area_basis bypass (permanent_address_special / manual_override / NOT_RESOLVED)
+- M1 ambiguous tiebreak detection
+- validate_eligibility() for CĐ/TC/SC target levels
+
+Schema refs:
+- [[q9-07-pr5-phase-a-shipped-2026-05-18]]
+- `Documents/Q9_07_PR5_REDESIGN.md` v1.3
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.priority_service import (
+    _derive_kv_basis_level,
+    resolve_kv_for_profile,
+    validate_eligibility,
+)
+
+
+# =============================================================================
+# C.1 — `_derive_kv_basis_level()` 6-row matrix + 3 bypass
+# =============================================================================
+
+@pytest.mark.parametrize(
+    "cultural,vocational,area_basis,expected_basis",
+    [
+        # Row 1: graduated_thpt + any vocational → THPT
+        ("graduated_thpt", "none", None, "THPT"),
+        ("graduated_thpt", "trung_cap", None, "THPT"),
+        ("graduated_gdtx", "cao_dang", None, "THPT"),
+        # Row 2: completed_thpt + (trung_cap | cao_dang) → THPT
+        ("completed_thpt", "trung_cap", None, "THPT"),
+        ("completed_thpt", "cao_dang", None, "THPT"),
+        # Row 3: completed_thpt + (so_cap | none) → COMMUNE_FALLBACK
+        ("completed_thpt", "so_cap", None, "COMMUNE_FALLBACK"),
+        ("completed_thpt", "none", None, "COMMUNE_FALLBACK"),
+        # Row 4: graduated_thcs + (trung_cap | cao_dang) → TC
+        ("graduated_thcs", "trung_cap", None, "TC"),
+        ("graduated_thcs", "cao_dang", None, "TC"),
+        # Row 5: graduated_thcs + (so_cap | none) → COMMUNE_FALLBACK
+        ("graduated_thcs", "so_cap", None, "COMMUNE_FALLBACK"),
+        ("graduated_thcs", "none", None, "COMMUNE_FALLBACK"),
+        # Row 6: completed_thcs + any → COMMUNE_FALLBACK
+        ("completed_thcs", "none", None, "COMMUNE_FALLBACK"),
+        ("completed_thcs", "trung_cap", None, "COMMUNE_FALLBACK"),
+        # Row 7: cultural NULL → NOT_RESOLVED
+        (None, "none", None, "NOT_RESOLVED"),
+        (None, "trung_cap", None, "NOT_RESOLVED"),
+        # Row 8: area_basis bypass — special_case wins regardless of cultural
+        ("graduated_thpt", "none", "permanent_address_special", "COMMUNE_SPECIAL"),
+        ("graduated_thcs", "trung_cap", "permanent_address_special", "COMMUNE_SPECIAL"),
+        (None, "none", "permanent_address_special", "COMMUNE_SPECIAL"),
+        # Row 9: manual_override bypass
+        ("graduated_thpt", "none", "manual_override", "MANUAL"),
+        ("graduated_thcs", "cao_dang", "manual_override", "MANUAL"),
+    ],
+)
+def test_derive_kv_basis_level_full_matrix(
+    cultural, vocational, area_basis, expected_basis
+):
+    assert _derive_kv_basis_level(cultural, vocational, area_basis) == expected_basis
+
+
+def test_derive_kv_basis_level_unknown_cultural_defensive():
+    """Defensive: unknown cultural (CHECK should prevent, but defensive)."""
+    assert _derive_kv_basis_level("alien_value", "none", None) == "NOT_RESOLVED"
+
+
+# =============================================================================
+# C.2 — `resolve_kv_for_profile()` algorithm
+# =============================================================================
+
+def _mock_profile(**kwargs):
+    """Build a SimpleNamespace profile with defaults."""
+    defaults = {
+        "id": 1,
+        "cultural_education_level": None,
+        "vocational_qualification": "none",
+        "area_resolution_basis": None,
+        "permanent_commune_code": None,
+        "academic_history": [],
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class _Result:
+    """Plain Result mock — `scalar_one_or_none()` returns stored value."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+def _mock_db(commune_kv=None, school_kv_sequence=None):
+    """Build mock DB.
+
+    - `commune_kv`: single string returned for any vn_commune_area_map lookup
+    - `school_kv_sequence`: list of KV strings returned in call order for
+      vn_school_kv_assignment lookups (pop from front each call).
+    """
+    db = AsyncMock()
+    kv_iter = iter(school_kv_sequence or [])
+
+    async def execute(stmt):
+        stmt_str = str(stmt).lower()
+        if "vn_commune_area_map" in stmt_str:
+            return _Result(commune_kv)
+        if "vn_school_kv_assignment" in stmt_str:
+            try:
+                return _Result(next(kv_iter))
+            except StopIteration:
+                return _Result(None)
+        return _Result(None)
+
+    db.execute = execute
+    return db
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_special_case_with_commune():
+    """Row 8: area_resolution_basis='permanent_address_special' + commune set."""
+    profile = _mock_profile(
+        cultural_education_level="graduated_thcs",  # would normally be TC pathway
+        area_resolution_basis="permanent_address_special",
+        permanent_commune_code="66_24305",
+    )
+    db = _mock_db(commune_kv="KV1")
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    assert kv == "KV1"
+    assert meta["pathway"] == "commune_special"
+    assert meta["rule_applied"] == "commune_lookup"
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_special_case_no_commune_requires_manual():
+    profile = _mock_profile(
+        cultural_education_level="graduated_thpt",
+        area_resolution_basis="permanent_address_special",
+        permanent_commune_code=None,
+    )
+    db = _mock_db()
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    assert kv is None
+    assert meta["requires_manual_override"] is True
+    assert meta["pathway"] == "commune_special"
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_manual_override_returns_none():
+    """Row 9: manual_override — service returns None (admin populates snapshot directly)."""
+    profile = _mock_profile(
+        cultural_education_level="graduated_thpt",
+        area_resolution_basis="manual_override",
+    )
+    db = _mock_db()
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    assert kv is None
+    assert meta["rule_applied"] == "manual_override"
+    assert meta["pathway"] == "manual"
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_draft_cultural_not_set():
+    """Row 7: cultural NULL → NOT_RESOLVED + no manual override flag (draft state)."""
+    profile = _mock_profile(cultural_education_level=None)
+    db = _mock_db()
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    assert kv is None
+    assert meta["pathway"] == "not_resolved"
+    assert meta["reason"] == "cultural_not_set"
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_commune_fallback_thcs_only():
+    """Row 5: graduated_thcs + none → COMMUNE_FALLBACK."""
+    profile = _mock_profile(
+        cultural_education_level="graduated_thcs",
+        vocational_qualification="none",
+        permanent_commune_code="66_22255",
+    )
+    db = _mock_db(commune_kv="KV2-NT")
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    assert kv == "KV2-NT"
+    assert meta["pathway"] == "commune_fallback"
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_thpt_tied_then_tiebreak_graduation():
+    """Row 1: 2 schools tied 2 years each → tiebreak by graduation school."""
+    profile = _mock_profile(
+        cultural_education_level="graduated_thpt",
+        academic_history=[
+            {"school_id": 100, "level": "THPT", "year_from": 2020, "year_to": 2021, "grade_to": 11},
+            {"school_id": 200, "level": "THPT", "year_from": 2022, "year_to": 2023, "grade_to": 12},
+        ],
+    )
+    # 4 year lookups + 1 graduation lookup = 5 KV calls
+    db = _mock_db(school_kv_sequence=[
+        "KV1", "KV1",  # school 100 → 2 years KV1
+        "KV3", "KV3",  # school 200 → 2 years KV3
+        "KV3",         # graduation lookup (school 200, year 2023)
+    ])
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    # School 200 is graduation (year_to=2023 > 2021, grade_to=12 > 11)
+    assert kv == "KV3"
+    assert meta["pathway"] == "thpt_multi_school"
+    assert meta["rule_applied"] == "tiebreak_graduation_school"
+    assert meta["breakdown"]["graduation_school_id"] == 200
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_thpt_clear_longest_winner():
+    """Single KV dominates → longest_duration (no tiebreak)."""
+    profile = _mock_profile(
+        cultural_education_level="graduated_thpt",
+        academic_history=[
+            {"school_id": 100, "level": "THPT", "year_from": 2020, "year_to": 2022, "grade_to": 11},  # 3 years
+            {"school_id": 200, "level": "THPT", "year_from": 2023, "year_to": 2023, "grade_to": 12},  # 1 year
+        ],
+    )
+    db = _mock_db(school_kv_sequence=[
+        "KV1", "KV1", "KV1",  # school 100 → 3 years KV1
+        "KV3",                # school 200 → 1 year KV3
+    ])
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    assert kv == "KV1"
+    assert meta["rule_applied"] == "longest_duration"
+    assert meta["breakdown"]["winner_years"] == 3
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_m1_ambiguous_tied_graduation():
+    """M1 edge: 2 schools tied year_to + grade_to → require manual."""
+    profile = _mock_profile(
+        cultural_education_level="graduated_thpt",
+        academic_history=[
+            {"school_id": 100, "level": "THPT", "year_from": 2021, "year_to": 2023, "grade_to": 12},
+            {"school_id": 200, "level": "THPT", "year_from": 2021, "year_to": 2023, "grade_to": 12},
+        ],
+    )
+    db = _mock_db(school_kv_sequence=[
+        "KV1", "KV1", "KV1",  # school 100 → 3 years KV1
+        "KV3", "KV3", "KV3",  # school 200 → 3 years KV3
+    ])
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    assert kv is None
+    assert meta["rule_applied"] == "ambiguous_requires_manual"
+    assert meta["reason"] == "tied_graduation_year_and_grade"
+    assert meta["requires_manual_override"] is True
+    assert set(meta["breakdown"]["tied_entries"]) == {100, 200}
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_no_qualifying_entries():
+    """Cultural pathway THPT but no entries with level='THPT' in history."""
+    profile = _mock_profile(
+        cultural_education_level="graduated_thpt",
+        academic_history=[
+            # All level=THCS, no THPT
+            {"school_id": 50, "level": "THCS", "year_from": 2017, "year_to": 2019},
+        ],
+    )
+    db = _mock_db()
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    assert kv is None
+    assert meta["requires_manual_override"] is True
+    assert meta["reason"] == "no_qualifying_entries"
+
+
+# =============================================================================
+# C.4 — validate_eligibility()
+# =============================================================================
+
+@pytest.mark.parametrize(
+    "cultural,vocational,target,expected_ok",
+    [
+        # CĐ target — Path 1: tốt nghiệp THPT/GDTX
+        ("graduated_thpt", "none", "CD", True),
+        ("graduated_gdtx", "none", "CD", True),
+        # CĐ target — Path 2: liên thông (THPT kiến thức + TC)
+        ("completed_thpt", "trung_cap", "CD", True),
+        # CĐ target — fail cases
+        ("completed_thpt", "none", "CD", False),  # Chưa thi TN THPT + chưa TC → CD FAIL
+        ("graduated_thcs", "trung_cap", "CD", False),  # Chưa TN THPT → CD FAIL (path 2 strict)
+        ("graduated_thcs", "none", "CD", False),  # Chỉ TN THCS → CD FAIL
+        ("completed_thcs", "trung_cap", "CD", False),  # Chưa TN THCS → CD FAIL
+        (None, "none", "CD", False),  # Cultural draft → CD FAIL
+        # TC target — TN THCS trở lên OK
+        ("graduated_thcs", "none", "TC", True),
+        ("graduated_thpt", "none", "TC", True),
+        ("completed_thpt", "so_cap", "TC", True),
+        # TC target — fail
+        ("completed_thcs", "none", "TC", False),  # Chưa TN THCS
+        (None, "none", "TC", False),
+        # SC target — luôn pass
+        ("completed_thcs", "none", "SC", True),
+        (None, "none", "SC", True),
+    ],
+)
+def test_validate_eligibility_matrix(cultural, vocational, target, expected_ok):
+    profile = SimpleNamespace(
+        cultural_education_level=cultural,
+        vocational_qualification=vocational,
+    )
+    is_ok, reason = validate_eligibility(profile, target)
+    assert is_ok is expected_ok, (
+        f"({cultural}, {vocational}, {target}) → expected {expected_ok}, "
+        f"got {is_ok} ({reason})"
+    )
+    if not expected_ok:
+        assert reason is not None
+
+
+# =============================================================================
+# C.5b — Integration: temporal split data (depends on Phase B.1.b dedup)
+# =============================================================================
+#
+# Verifies engine `resolve_kv_for_profile()` correctly hits historical
+# vs current entries via vn_school_kv_assignment.effective_from/to_year.
+# Anchor for Phase B.1.b dedup pattern (memory
+# [[q9-07-pr5-phase-a-shipped-2026-05-18]]):
+# - Buôn Ma Thuột Mã 002 (KV1 2000-2024) + Mã 090 (KV2 2025-now)
+# - Lâm Đồng/Gia Lai dup pairs sau 04/6/2021 boundary
+#
+# Engine queries `WHERE :year BETWEEN effective_from_year AND COALESCE(
+# effective_to_year, 9999)` per VnSchoolKvAssignment docstring.
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_pre_2025_history_hits_before_entry():
+    """Candidate học 2020-2022 lớp 10→12 tại THPT Buôn Ma Thuột Mã 002 → KV1.
+
+    Simulates Buôn Ma Thuột Mã 002 (effective 2000-2024 KV1).
+    Engine lookup_kv_for_school_year(school_id=132, year=2020/2021/2022)
+    → all hit before-row → KV1 dominates.
+    """
+    profile = _mock_profile(
+        cultural_education_level="graduated_thpt",
+        academic_history=[
+            {
+                "school_id": 132,
+                "level": "THPT",
+                "year_from": 2020,
+                "year_to": 2022,
+                "grade_to": 12,
+            },
+        ],
+    )
+    db = _mock_db(school_kv_sequence=["KV1", "KV1", "KV1"])
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    assert kv == "KV1"
+    assert meta["pathway"] == "thpt_multi_school"
+    assert meta["breakdown"]["winner_years"] == 3
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_post_2025_history_hits_after_entry():
+    """Candidate học 2025-2027 tại THPT Buôn Ma Thuột Mã 090 → KV2.
+
+    Simulates Buôn Ma Thuột Mã 090 (effective 2025-now KV2).
+    """
+    profile = _mock_profile(
+        cultural_education_level="graduated_thpt",
+        academic_history=[
+            {
+                "school_id": 162,
+                "level": "THPT",
+                "year_from": 2025,
+                "year_to": 2027,
+                "grade_to": 12,
+            },
+        ],
+    )
+    db = _mock_db(school_kv_sequence=["KV2", "KV2", "KV2"])
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    assert kv == "KV2"
+    assert meta["breakdown"]["winner_years"] == 3
+
+
+@pytest.mark.asyncio
+async def test_resolve_kv_cross_period_max_duration_wins():
+    """TT 05/2021 rule: candidate học 2-trường cross-period 2023-2026.
+
+    2 năm pre-2025 KV1 + 2 năm post-2025 KV2 → tied → tiebreak graduation
+    school (year_to=2026 grade=12 wins).
+    """
+    profile = _mock_profile(
+        cultural_education_level="graduated_thpt",
+        academic_history=[
+            {
+                "school_id": 132,
+                "level": "THPT",
+                "year_from": 2023,
+                "year_to": 2024,
+                "grade_to": 11,
+            },
+            {
+                "school_id": 162,
+                "level": "THPT",
+                "year_from": 2025,
+                "year_to": 2026,
+                "grade_to": 12,
+            },
+        ],
+    )
+    # 2023, 2024 from school 132 → KV1
+    # 2025, 2026 from school 162 → KV2
+    # +1 graduation lookup for tiebreak (school 162, year 2026)
+    db = _mock_db(school_kv_sequence=["KV1", "KV1", "KV2", "KV2", "KV2"])
+    kv, meta = await resolve_kv_for_profile(profile, db)
+    assert kv == "KV2"
+    assert meta["rule_applied"] == "tiebreak_graduation_school"
+    assert meta["breakdown"]["graduation_school_id"] == 162


### PR DESCRIPTION
## Summary

Phase C — BE engine implementing KV resolution algorithm per TT 05/2021/TT-BLĐTBXH Phụ lục 01 multi-school rule. Fixes silent 0đ bonus bug shipped trong Phase A (PR #306) khi engine reads dropped `high_school_kv_resolved` column → fallback NULL.

**Depends on**: PR-B (#307 merged `e2be6c89`) — provides B.1.b temporal split data for `vn_school_kv_assignment.effective_from/to_year`.

## Sub-tasks

| # | Component | Lines |
|---|-----------|-------|
| C.1 | Helpers: `_derive_kv_basis_level()` matrix + `_lookup_commune_kv()` + `lookup_kv_for_school_year()` | 121 |
| C.2 | `resolve_kv_for_profile()` multi-school algorithm + M1 ambiguous tiebreak | 145 |
| C.3 | `freeze_priority_snapshot()` wired at T1 submit + T6 cascade | 60 (3 files) |
| C.4 | `validate_eligibility()` for CĐ/TC/SC target levels (TT 05/2021 path 1+2) | 35 |
| C.5 | Anchor tests: 45 base cases + 3 integration with B.1.b temporal data | 280 + 102 |

## Algorithm — TT 05/2021 Phụ lục 01 verbatim

3-rule pin (memory [[tt-05-2021-kv-rule-verbatim]]):

1. *"Thí sinh học liên tục và tốt nghiệp trung học tại khu vực nào thì hưởng ưu tiên theo khu vực đó."*
2. *"Nếu chuyển trường, **thời gian học ở khu vực nào lâu hơn được hưởng ưu tiên theo khu vực đó**."*
3. *"Khi mỗi năm học một trường thuộc các khu vực có mức ưu tiên khác nhau **hoặc nửa thời gian học ở trường này, nửa thời gian học ở trường kia** thì **tốt nghiệp ở khu vực nào, hưởng ưu tiên theo khu vực đó**."*

Engine implementation:
1. Filter academic_history theo target_level (CĐ→THPT, TC→THCS hoặc THPT)
2. Per entry: lookup KV per năm trong khoảng (year_from..year_to) qua `vn_school_kv_assignment`
3. Sum thời gian học theo KV
4. Pick KV có max duration (`longest_duration`)
5. Tiebreak: KV của entry có year_to + grade_to lớn nhất (`tiebreak_graduation_school`)
6. M1 detect: 2 entries cùng year_to + grade_to → `ambiguous_requires_manual`

## Bypass cases (4 case per TT Điều 7+11)

- PT DTNT, lớp dự bị, quân nhân tại ngũ, bộ đội xuất ngũ → dùng `permanent_commune_code` thay vì academic_history
- Engine returns `commune_special` pathway + `permanent_address_special` flag

## 6-row matrix `_derive_kv_basis_level()`

| Cultural | Vocational | → Basis |
|----------|------------|---------|
| graduated_thpt | any | THPT |
| graduated_gdtx | any | THPT |
| completed_thpt | trung_cap/cao_dang | THPT (liên thông path 2) |
| completed_thpt | so_cap/none | COMMUNE_FALLBACK |
| graduated_thcs | trung_cap/cao_dang | TC |
| graduated_thcs | so_cap/none | COMMUNE_FALLBACK |
| completed_thcs | any | COMMUNE_FALLBACK |
| NULL | any | NOT_RESOLVED (draft state) |
| (any) + permanent_address_special | — | COMMUNE_SPECIAL |
| (any) + manual_override | — | MANUAL |

## Integration tests verifying B.1.b temporal split

Verifies engine correctly hits historical vs current `vn_school_kv_assignment` entries:

- Pre-2025: candidate học 2020-2022 tại Mã 002 (KV1 2000-2024) → resolve KV1
- Post-2025: candidate học 2025-2027 tại Mã 090 (KV2 2025-now) → resolve KV2
- Cross-period 2023-2026: 2 năm KV1 + 2 năm KV2 → tied → tiebreak graduation school

## Test plan

- [x] `pytest test_priority_kv_resolution.py` → 48 PASS (45 base + 3 integration)
- [x] `pytest test_dedup_temporal_split.py` → 22 PASS (B.1.b helpers from PR-B merged)
- [x] Combined: 70/70 PASS post-rebase on main `e2be6c89`
- [ ] CI green (pending push)
- [ ] Local smoke: 1 Buôn Ma Thuột sample profile → submit T1 → snapshot kv_resolved correct + bonus > 0đ

## Critical state post-merge

After this merge, engine LIVE prod returns **real KV bonus** (not silent 0đ). Mùa 2026-08-01 candidate flow unblocked at BE layer. FE Phase D + Officer Phase E + Admin Phase F still needed for full UX.

## Follow-up

- Phase D: Candidate FE AcademicHistoryTab + PriorityTab (~3.5d)
- Phase E: Officer UT evidence verify UI + KV breakdown audit (~2d)
- Phase F: Admin backfill queue cho 10 prod profiles existing (~2d)
- TC school manual seed (Phase B.3): ~50-100 trường via admin manual entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)