### PR TITLE
feat(q9-07/phase-e2): manual KV override (officer/admin write-path)

### DIFF
--- a/.github/workflows/admission-contract-check.yml
+++ b/.github/workflows/admission-contract-check.yml
@@ -113,4 +113,4 @@ jobs:
         # `ci-workflow-flag-cross-file-sync`.
         run: |
           python -m app.scripts.check_notification_event_coverage \
-            --allow-deferred=PRIORITY_KV_OVERRIDDEN,PRIORITY_OBJECT_VERIFIED,PRIORITY_OBJECT_REJECTED
+            --allow-deferred=PRIORITY_OBJECT_VERIFIED,PRIORITY_OBJECT_REJECTED

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -201,7 +201,7 @@ jobs:
         # `ci-workflow-flag-cross-file-sync`.
         run: |
           python -m app.scripts.check_notification_event_coverage \
-            --allow-deferred=PRIORITY_KV_OVERRIDDEN,PRIORITY_OBJECT_VERIFIED,PRIORITY_OBJECT_REJECTED
+            --allow-deferred=PRIORITY_OBJECT_VERIFIED,PRIORITY_OBJECT_REJECTED
 
       # =====================================================================
       # Tier 4: Admission + lead workflow contract (legacy deploy.yml subset)

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -273,8 +273,14 @@ class AdmissionProfile(Base):
         server_default=text("'{}'::jsonb"),
         comment=(
             "Frozen KV resolution at submit T1 + re-frozen at engine T6. "
-            "Shape: {kv_resolved, rule_applied, pathway, breakdown, "
-            "frozen_at, frozen_at_status, manual_override_reason}. "
+            "Engine-set keys: {kv_resolved, rule_applied, pathway, breakdown, "
+            "frozen_at, frozen_at_status, resolved_by, requires_manual_override, "
+            "reason}. "
+            "Phase E.2 manual override extends với: {manual_override_by, "
+            "manual_override_at, manual_override_reason, evidence_file_id} — "
+            "OVERWRITTEN with LAST override per chain-of-override semantics "
+            "(Decision D1). Audit log preserves full chain history via "
+            "priority_audit_log table. "
             "Empty {} = draft state (service computes real-time preview)."
         )
     )

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -877,3 +877,101 @@ async def get_priority_object_catalog(
     )
     rows = (await db.execute(stmt)).scalars().all()
     return [schemas.PriorityObjectCatalogItem.model_validate(r) for r in rows]
+
+
+# =============================================================================
+# Q9 #07 Phase E.2 — Manual KV override (officer/admin write-path)
+# =============================================================================
+
+
+@router.post(
+    "/{profile_id}/override-priority-kv",
+    response_model=schemas.AdmissionProfileResponse,
+    summary="Override KV thủ công (officer/admin write-path — Phase E.2)",
+)
+async def override_priority_kv(
+    profile_id: int,
+    payload: schemas.OverridePriorityKvRequest = Body(...),
+    db: AsyncSession = Depends(database.get_db),
+    profile: models.AdmissionProfile = Depends(get_admission_for_user),
+    current_user: models.User = CasbinAuth,
+):
+    """Officer/admin manually override profile's KV (Phase E.2 write-path).
+
+    Service-layer ``priority_override_service.override_kv()`` enforces:
+    * Version guard FIRST (memory `version-guard-before-state-machine`)
+    * Status whitelist (officer: submitted/reviewing/revision_requested;
+      admin bypass với ``acknowledge_post_publish=true`` for post-publish)
+    * Reason 20-500 char validation
+    * Snapshot mutation + audit log INSERT + version bump
+
+    Snapshot keys overwritten on each override (Decision D1):
+    * ``manual_override_by/at/reason`` + ``evidence_file_id``
+    * ``frozen_at_status='manual_override'`` + ``resolved_by`` (officer/admin)
+
+    Audit log preserves full chain — query via composite index
+    ``(profile_id, action_type, created_at DESC)``.
+
+    Security:
+    * IDOR: ``get_admission_for_user`` (3-tier scope admin/manager/officer)
+    * Casbin: ``q9_07_e0c`` migration seeds policy
+      (officer/manager/admin ALLOW, accountant DENY).
+    * Service ``PermissionError`` (officer post-publish) → 403.
+
+    Dispatches ``PRIORITY_KV_OVERRIDDEN`` event post-commit (catalog seed
+    Wave 1; payload: application_id, lead_id, actor_id, actor_name,
+    kv_resolved, override_reason).
+    """
+    from app.services.priority_override_service import override_kv as _override_kv
+    from fastapi import HTTPException
+
+    try:
+        updated_profile, post_commit_cb = await _override_kv(
+            db,
+            profile,
+            kv_resolved=payload.kv_resolved,
+            reason=payload.reason,
+            evidence_file_id=payload.evidence_file_id,
+            actor=current_user,
+            expected_version=payload.version,
+            acknowledge_post_publish=payload.acknowledge_post_publish,
+        )
+    except PermissionError as exc:
+        # Officer attempted post-publish override; map to 403 per memory
+        # `version-guard-before-state-machine` adjacent pattern.
+        raise HTTPException(status_code=403, detail=str(exc))
+
+    await db.commit()
+    await post_commit_cb()
+
+    log.info(
+        "admissions_v2.override_priority_kv",
+        profile_id=profile_id,
+        actor_id=current_user.id,
+        kv_resolved=payload.kv_resolved,
+    )
+
+    # Reload với eager-loaded relations for response (assigned_officer
+    # name + reviewer name + computed permissions).
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    stmt = (
+        select(models.AdmissionProfile)
+        .where(models.AdmissionProfile.id == profile_id)
+        .options(
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
+    )
+    reloaded = (await db.execute(stmt)).scalar_one()
+    # Populate computed fields cho mutation response per Backend CLAUDE.md
+    # "Mutation response contract" — _populate_response_fields() must run
+    # post-mutation to set permissions/available_actions/etc.
+    from app.services import admission_service
+
+    await admission_service._populate_response_fields(
+        reloaded, current_user=current_user
+    )
+    return reloaded

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -972,6 +972,6 @@ async def override_priority_kv(
     from app.services import admission_service
 
     await admission_service._populate_response_fields(
-        reloaded, current_user=current_user
+        db, reloaded, current_user=current_user
     )
     return reloaded

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -169,6 +169,8 @@ from .admission import (
     PreviewPriorityKvRequest,
     PreviewPriorityKvResponse,
     PriorityObjectCatalogItem,
+    # Q9 #07 Phase E.2 — Manual KV override
+    OverridePriorityKvRequest,
     EnrollStudentResponse,
     # Bulk action schemas
     BulkApproveRequest,

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -2141,6 +2141,69 @@ class PriorityObjectCatalogItem(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+# =============================================================================
+# Q9 #07 Phase E.2 — Manual KV override (officer/admin write-path)
+# =============================================================================
+
+
+class OverridePriorityKvRequest(BaseModel):
+    """Officer/admin override KV manually trên profile.
+
+    Service-layer (priority_override_service.override_kv) enforces:
+    * Optimistic-lock via ``version`` body field (memory
+      `version-guard-before-state-machine` — version guard runs FIRST,
+      before status whitelist).
+    * Officer status whitelist {submitted, reviewing, revision_requested};
+      hard-deny {draft, withdrawn, dropped, rejected}; post-publish states
+      require admin role + ``acknowledge_post_publish=True``.
+    * Reason 20-500 char text (mandatory; persisted in
+      ``profile.priority_resolution_snapshot.manual_override_reason``
+      + ``priority_audit_log.new_value.reason``).
+    * INSERT ``priority_audit_log`` row (action_type='kv_manual_override').
+    * Bump ``profile.version`` after mutation.
+
+    Snapshot keys written (overwritten on each override per Decision D1):
+    * ``manual_override_by`` — actor.id
+    * ``manual_override_at`` — ISO timestamp
+    * ``manual_override_reason`` — user-supplied
+    * ``evidence_file_id`` — optional FK soft reference
+    * ``frozen_at`` / ``frozen_at_status='manual_override'`` /
+      ``resolved_by``  — refreshed each override.
+
+    Chain-of-override history queryable via composite index
+    ``idx_priority_audit_log_profile_action_time`` on
+    ``(profile_id, action_type, created_at DESC)``.
+    """
+
+    version: int = Field(
+        ...,
+        description="Client-known profile.version for optimistic lock. "
+        "409 ConflictError if mismatch with DB state.",
+        ge=0,
+    )
+    kv_resolved: Literal["KV1", "KV2-NT", "KV2", "KV3"] = Field(
+        ...,
+        description="New KV code to assign manually.",
+    )
+    reason: str = Field(
+        ...,
+        min_length=20,
+        max_length=500,
+        description="Justification 20-500 char. Persisted to snapshot + audit log.",
+    )
+    evidence_file_id: Optional[int] = Field(
+        None,
+        description="Optional FK to supporting document (soft reference, no FK constraint).",
+    )
+    acknowledge_post_publish: bool = Field(
+        False,
+        description="Admin-only escape hatch for post-publish profile (enrolled/approved/confirmed/...). "
+        "Officer always refused for those states.",
+    )
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
 __all__ = [
     # Nested schemas
     "FamilyMemberSchema",
@@ -2191,4 +2254,6 @@ __all__ = [
     "PreviewPriorityKvRequest",
     "PreviewPriorityKvResponse",
     "PriorityObjectCatalogItem",
+    # Q9 #07 Phase E.2 — Manual KV override
+    "OverridePriorityKvRequest",
 ]

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1487,6 +1487,22 @@ def _compute_frontend_fields(
             )
             and (is_owner or is_manager or is_admin)
         ),
+        # Q9 #07 Phase E.2 — Manual KV override (officer/admin write-path).
+        # Service-layer (priority_override_service) enforces full whitelist
+        # + post-publish admin-only gate. UI uses this flag only to gate
+        # visibility of "Cán bộ ấn định thủ công" button trong PriorityTab.
+        # Officer must be assigned to profile via lead.assigned_officer_id;
+        # manager/admin scope handled by route's IDOR dep. Status whitelist
+        # here matches service-layer ``_OFFICER_ALLOWED_STATUS`` for officer
+        # path; admin bypasses (UI shows button regardless of status, dialog
+        # secondary checkbox for post-publish profiles).
+        "override_priority_kv": (
+            is_admin
+            or (
+                (is_manager or (is_officer and is_owner))
+                and status in ["submitted", "reviewing", "revision_requested"]
+            )
+        ),
         "drop": status == "enrolled" and not _is_dropped and (is_manager or is_admin),
         "claim": (status in ["submitted", "resubmitted"] and (is_manager or is_admin)
                   and not profile.assigned_reviewer_id),

--- a/Backend_FastAPI/app/services/admission_state_service.py
+++ b/Backend_FastAPI/app/services/admission_state_service.py
@@ -270,7 +270,8 @@ TRANSITION_PAIR_TO_EVENT: Dict[Tuple[str, str], SystemEvents] = {
 # (verify/reject evidence). Track here until those waves merge — coverage
 # gate stays green via ``--allow-deferred`` in CI workflows.
 DEFERRED_ADMISSION_EVENTS: frozenset[str] = frozenset({
-    "PRIORITY_KV_OVERRIDDEN",     # Wave 2 (E.2 override_kv)
+    # Wave 2 (2026-05-19) wired PRIORITY_KV_OVERRIDDEN via dispatch_event
+    # outbox path → dropped from deferred set.
     "PRIORITY_OBJECT_VERIFIED",   # Wave 3 (E.3 verify evidence)
     "PRIORITY_OBJECT_REJECTED",   # Wave 3 (E.3 reject evidence)
 })

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -288,6 +288,33 @@ async def override_kv(
     # ---- Step 7: Bump optimistic-lock version
     profile.version += 1
 
+    # ---- Step 8: Dispatch via outbox (catalog requires_outbox=True for
+    # PRIORITY_KV_OVERRIDDEN). dispatch_event INSERTs notification_outbox
+    # row inside caller's transaction; worker drains post-commit. Per
+    # B2.3 wrapper contract: this is the right primitive for outbox events
+    # — raw safe_dispatch() would trip the
+    # `raw-dispatch-of-outbox-event` coverage script gate.
+    from app.services.notification_dispatcher import dispatch_event
+
+    _payload = {
+        "application_id": profile.id,
+        "lead_id": profile.lead_id,
+        "actor_id": actor.id,
+        "actor_name": actor.full_name or actor.email,
+        "kv_resolved": kv_resolved,
+        "override_reason": reason_clean,
+    }
+    _dedupe_key = (
+        f"priority:{profile.id}:kv_overridden:{kv_resolved}:{actor.id}:"
+        f"{int(datetime.now(timezone.utc).timestamp())}"
+    )
+    post_commit = await dispatch_event(
+        db,
+        event=SystemEvents.PRIORITY_KV_OVERRIDDEN,
+        payload=_payload,
+        dedupe_key=_dedupe_key,
+    )
+
     await db.flush()
 
     log.info(
@@ -299,36 +326,15 @@ async def override_kv(
         new_kv=kv_resolved,
         version_after=profile.version,
         reason_len=len(reason_clean),
+        outbox_dispatched=True,
     )
 
-    # ---- Step 8: Build post_commit callback (safe_dispatch fires post-DB)
-    _profile_id = profile.id
-    _lead_id = profile.lead_id
-    _actor_id = actor.id
-    _actor_name = actor.full_name or actor.email
-    _kv = kv_resolved
-    _reason = reason_clean
+    # dispatch_event returns None for outbox events (router commits, worker
+    # processes async). Wrap None into noop callback for router uniformity.
+    async def _noop_callback() -> None:
+        return None
 
-    async def post_commit() -> None:
-        from app.services.notification_dispatcher import (
-            _rooms_for_admission,
-            safe_dispatch,
-        )
-
-        rooms = _rooms_for_admission(profile)
-
-        await safe_dispatch(
-            db=db,
-            event=SystemEvents.PRIORITY_KV_OVERRIDDEN,
-            payload={
-                "application_id": _profile_id,
-                "lead_id": _lead_id,
-                "actor_id": _actor_id,
-                "actor_name": _actor_name,
-                "kv_resolved": _kv,
-                "override_reason": _reason,
-            },
-            rooms=rooms,
-        )
+    if post_commit is None:
+        post_commit = _noop_callback
 
     return profile, post_commit

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -1,0 +1,334 @@
+# app/services/priority_override_service.py
+"""Q9 #07 Phase E.2 + E.3 — Priority bonus officer/admin write-path.
+
+Service-layer functions cho manual KV override (Phase E.2) + UT evidence
+verify/reject (Phase E.3 — chưa ship Wave 2). Architectural rules
+(per CLAUDE.md PART 7):
+
+* No FastAPI imports — raise DomainExceptions, return (result, post_commit_cb)
+* Router commits; service flushes only
+* Dispatch via safe_dispatch inside post_commit closure (NOT in service body)
+* Version guard FIRST (memory `version-guard-before-state-machine`)
+* Status whitelist enforced before mutation
+* Audit log INSERT row PER mutation (priority_audit_log table)
+
+Snapshot mutation (override_kv):
+
+  profile.priority_resolution_snapshot JSONB ← deep-merge {
+      kv_resolved: new_value,
+      pathway: 'manual',
+      rule_applied: 'manual_override',
+      manual_override_by: actor.id,
+      manual_override_at: now ISO,
+      manual_override_reason: reason,
+      evidence_file_id: optional,
+      frozen_at: now ISO (refresh on override),
+      frozen_at_status: 'manual_override',
+      resolved_by: actor.role  # 'officer' | 'admin'
+  }
+  profile.area_resolution_basis ← 'manual_override'
+  profile.version += 1
+
+Audit row (priority_audit_log):
+
+  action_type='kv_manual_override'
+  profile_id=profile.id
+  actor_id=actor.id
+  old_value={'kv_resolved': prev_kv, 'rule_applied': prev_rule}
+  new_value={'kv_resolved': new_kv, 'rule_applied': 'manual_override',
+             'reason': reason, 'evidence_file_id': evidence_file_id}
+  metadata={'pathway_before': prev_pathway}
+
+Chain-of-override semantics (Decision D1, plan v3):
+
+* Snapshot OVERWRITES with LAST override (manual_override_* keys reflect
+  the most recent actor + reason).
+* Audit log PRESERVES full history — query timeline via composite index
+  (profile_id, action_type, created_at DESC) for chain of N overrides.
+* UI BEFORE→AFTER preview reads snapshot.kv_resolved AS current; audit
+  log endpoint (Wave 5) surfaces full chain.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Literal, Optional, Tuple
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.core.events import SystemEvents
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    ConflictError,
+)
+
+
+log = structlog.get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+KvCode = Literal["KV1", "KV2-NT", "KV2", "KV3"]
+
+# Officer can override only in these intermediate states. Admin bypasses
+# whitelist but pays a confirmation tax for post-publish profiles
+# (`acknowledge_post_publish=True` required for enrolled/approved/confirmed).
+_OFFICER_ALLOWED_STATUS: frozenset[str] = frozenset({
+    "submitted",
+    "reviewing",
+    "revision_requested",
+})
+
+# Officer NEVER overrides in these terminal-ish states. Admin can with
+# `acknowledge_post_publish=True`.
+_POST_PUBLISH_STATUS: frozenset[str] = frozenset({
+    "approved",
+    "confirmed",
+    "enrolled",
+    "overridden",
+    "result_published",
+    "admitted",
+    "waitlisted",
+})
+
+# Officer + admin BOTH refuse to override these (data inconsistency risk).
+_HARD_DENIED_STATUS: frozenset[str] = frozenset({
+    "draft",
+    "withdrawn",
+    "dropped",
+    "rejected",
+})
+
+_MIN_REASON_LEN = 20
+_MAX_REASON_LEN = 500
+
+
+# ---------------------------------------------------------------------------
+# Public service entrypoint
+# ---------------------------------------------------------------------------
+
+
+async def override_kv(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    *,
+    kv_resolved: KvCode,
+    reason: str,
+    evidence_file_id: Optional[int],
+    actor: models.User,
+    expected_version: int,
+    acknowledge_post_publish: bool = False,
+) -> Tuple[models.AdmissionProfile, Callable[[], Awaitable[None]]]:
+    """Manual KV override by officer or admin.
+
+    Args:
+        db: Async session — caller (router) commits.
+        profile: AdmissionProfile (already IDOR-scoped via
+            ``get_admission_for_user``).
+        kv_resolved: New KV code one of ``{'KV1','KV2-NT','KV2','KV3'}``.
+        reason: 20-500 char free-text justification (mandatory; persisted
+            in snapshot + audit log).
+        evidence_file_id: Optional FK to uploaded document supporting the
+            override (no FK constraint in schema — soft reference).
+        actor: ``User`` performing override. Role drives status whitelist
+            enforcement (officer vs admin).
+        expected_version: Client-supplied optimistic-lock token.
+            Service raises ``ConflictError`` (router → 409) on mismatch.
+        acknowledge_post_publish: Admin-only escape hatch for overriding
+            post-publish profiles (enrolled/approved/confirmed/...).
+            Officer always refused for these states.
+
+    Returns:
+        Tuple ``(updated_profile, post_commit_cb)``. Router MUST await
+        ``post_commit_cb()`` AFTER ``db.commit()``.
+
+    Raises:
+        ConflictError (409): version mismatch.
+        BusinessRuleViolation (400): hard-denied state (draft/withdrawn/...),
+            invalid reason length, invalid kv_resolved value.
+        PermissionError → router → 403: officer attempts post-publish
+            override without admin role.
+    """
+    # ---- Step 1: Version guard FIRST (per memory `version-guard-before-state-machine`)
+    if expected_version != profile.version:
+        log.warning(
+            "priority_override_service.version_conflict",
+            profile_id=profile.id,
+            expected_version=expected_version,
+            current_version=profile.version,
+            actor_id=actor.id,
+        )
+        raise ConflictError(
+            f"Profile was modified by another user. "
+            f"Expected version {expected_version}, "
+            f"but current version is {profile.version}. "
+            "Please refresh and try again."
+        )
+
+    # ---- Step 2: Validate inputs
+    if kv_resolved not in ("KV1", "KV2-NT", "KV2", "KV3"):
+        raise BusinessRuleViolation(
+            f"Invalid kv_resolved '{kv_resolved}' — must be one of "
+            "KV1, KV2-NT, KV2, KV3"
+        )
+
+    reason_clean = (reason or "").strip()
+    if len(reason_clean) < _MIN_REASON_LEN:
+        raise BusinessRuleViolation(
+            f"Override reason must be at least {_MIN_REASON_LEN} characters "
+            f"(got {len(reason_clean)})"
+        )
+    if len(reason_clean) > _MAX_REASON_LEN:
+        raise BusinessRuleViolation(
+            f"Override reason must not exceed {_MAX_REASON_LEN} characters "
+            f"(got {len(reason_clean)})"
+        )
+
+    # ---- Step 3: Status whitelist (role-aware)
+    is_admin = actor.role == "admin"
+    is_officer_path = actor.role in ("officer", "manager")  # both treated as officer path
+
+    if profile.status in _HARD_DENIED_STATUS:
+        raise BusinessRuleViolation(
+            f"Cannot override KV in '{profile.status}' state — profile "
+            "is in draft/withdrawn/dropped/rejected and not eligible for "
+            "manual KV intervention."
+        )
+
+    if profile.status in _POST_PUBLISH_STATUS:
+        if not is_admin:
+            # Officer/manager refused post-publish; signal via
+            # PermissionError so router maps to 403.
+            raise PermissionError(
+                f"Officer cannot override KV on '{profile.status}' "
+                "profile — admin only for post-publish overrides."
+            )
+        # Admin path requires explicit acknowledgement flag.
+        if not acknowledge_post_publish:
+            raise BusinessRuleViolation(
+                f"Profile is in post-publish state '{profile.status}'. "
+                "Pass acknowledge_post_publish=true to confirm the "
+                "override; this will be recorded in the audit log."
+            )
+
+    if (
+        not is_admin
+        and is_officer_path
+        and profile.status not in _OFFICER_ALLOWED_STATUS
+        and profile.status not in _POST_PUBLISH_STATUS
+    ):
+        # Catch-all guard for unexpected statuses (vd new state machine
+        # state not in either whitelist). Fail-closed for officer path.
+        raise BusinessRuleViolation(
+            f"Cannot override KV in '{profile.status}' state — officer "
+            "allowed only for submitted/reviewing/revision_requested."
+        )
+
+    # ---- Step 4: Snapshot a deep copy of current state for audit log
+    prev_snapshot: dict[str, Any] = dict(profile.priority_resolution_snapshot or {})
+    prev_kv = prev_snapshot.get("kv_resolved")
+    prev_rule = prev_snapshot.get("rule_applied")
+    prev_pathway = prev_snapshot.get("pathway")
+
+    # ---- Step 5: Build new snapshot — overwrite with manual override metadata
+    now_iso = datetime.now(timezone.utc).isoformat()
+    new_snapshot: dict[str, Any] = {
+        **prev_snapshot,  # preserve fields not part of override (breakdown, etc.)
+        "kv_resolved": kv_resolved,
+        "pathway": "manual",
+        "rule_applied": "manual_override",
+        "manual_override_by": actor.id,
+        "manual_override_at": now_iso,
+        "manual_override_reason": reason_clean,
+        "evidence_file_id": evidence_file_id,
+        "frozen_at": now_iso,
+        "frozen_at_status": "manual_override",
+        "resolved_by": "admin" if is_admin else "officer",
+    }
+    # Drop ambiguous engine-state keys that no longer apply post-override
+    new_snapshot.pop("requires_manual_override", None)
+    new_snapshot.pop("reason", None)
+
+    profile.priority_resolution_snapshot = new_snapshot
+    profile.area_resolution_basis = "manual_override"
+
+    # ---- Step 6: INSERT audit log row
+    audit_row = models.PriorityAuditLog(
+        profile_id=profile.id,
+        action_type="kv_manual_override",
+        actor_id=actor.id,
+        old_value={
+            "kv_resolved": prev_kv,
+            "rule_applied": prev_rule,
+            "pathway": prev_pathway,
+        },
+        new_value={
+            "kv_resolved": kv_resolved,
+            "rule_applied": "manual_override",
+            "pathway": "manual",
+            "reason": reason_clean,
+            "evidence_file_id": evidence_file_id,
+        },
+        audit_metadata={
+            "actor_role": actor.role,
+            "profile_status": profile.status,
+            "acknowledged_post_publish": (
+                bool(acknowledge_post_publish)
+                if profile.status in _POST_PUBLISH_STATUS
+                else None
+            ),
+        },
+    )
+    db.add(audit_row)
+
+    # ---- Step 7: Bump optimistic-lock version
+    profile.version += 1
+
+    await db.flush()
+
+    log.info(
+        "priority_override_service.override_kv_success",
+        profile_id=profile.id,
+        actor_id=actor.id,
+        actor_role=actor.role,
+        prev_kv=prev_kv,
+        new_kv=kv_resolved,
+        version_after=profile.version,
+        reason_len=len(reason_clean),
+    )
+
+    # ---- Step 8: Build post_commit callback (safe_dispatch fires post-DB)
+    _profile_id = profile.id
+    _lead_id = profile.lead_id
+    _actor_id = actor.id
+    _actor_name = actor.full_name or actor.email
+    _kv = kv_resolved
+    _reason = reason_clean
+
+    async def post_commit() -> None:
+        from app.services.notification_dispatcher import (
+            _rooms_for_admission,
+            safe_dispatch,
+        )
+
+        rooms = _rooms_for_admission(profile)
+
+        await safe_dispatch(
+            db=db,
+            event=SystemEvents.PRIORITY_KV_OVERRIDDEN,
+            payload={
+                "application_id": _profile_id,
+                "lead_id": _lead_id,
+                "actor_id": _actor_id,
+                "actor_name": _actor_name,
+                "kv_resolved": _kv,
+                "override_reason": _reason,
+            },
+            rooms=rooms,
+        )
+
+    return profile, post_commit

--- a/Backend_FastAPI/tests/unit/test_admission_state_service_event_mapping.py
+++ b/Backend_FastAPI/tests/unit/test_admission_state_service_event_mapping.py
@@ -120,12 +120,10 @@ def test_approved_and_overridden_share_admitted_event() -> None:
 
 
 def test_deferred_admission_events_locked_set() -> None:
-    """Q9 #07 Phase E Wave 1 (2026-05-19) added 3 PRIORITY_* events to
-    catalog seed; dispatch sites ship Wave 2 (override_kv) + Wave 3
-    (verify/reject evidence). Tracked here until those waves merge.
+    """Wave 2 (2026-05-19) wired PRIORITY_KV_OVERRIDDEN via outbox path;
+    2 UT evidence events remain deferred until Wave 3.
     """
     assert state_service.DEFERRED_ADMISSION_EVENTS == frozenset({
-        "PRIORITY_KV_OVERRIDDEN",
         "PRIORITY_OBJECT_VERIFIED",
         "PRIORITY_OBJECT_REJECTED",
     })
@@ -159,25 +157,26 @@ def test_mapping_and_deferred_are_disjoint() -> None:
     assert overlap == set(), f"Events both mapped and deferred: {overlap!r}"
 
 
-def test_total_admission_events_is_16() -> None:
-    """Catalog ships 16 admission-tracked events post-Q9 #07 Phase E Wave 1:
+def test_total_admission_events_is_15() -> None:
+    """Catalog ships 15 admission-tracked events post-Wave 2 (2026-05-19):
     - 10 distinct events via LEGACY_STATUS_TO_EVENT (target-keyed)
     - 2 source-aware via TRANSITION_PAIR_TO_EVENT (T10 PROMOTED + T11 WAITLIST_REJECTED)
-    - 1 source-aware via TRANSITION_PAIR_TO_EVENT (T17 ROLLED_BACK — 11 pair entries
-      collapse to single event name)
-    - 3 Q9 #07 Phase E PRIORITY_* events deferred (dispatch ships Wave 2+3)
+    - 1 source-aware via TRANSITION_PAIR_TO_EVENT (T17 ROLLED_BACK)
+    - 2 deferred (PRIORITY_OBJECT_VERIFIED / _REJECTED, Wave 3 wire)
 
-    Wave 5 added T11 ADMISSION_WAITLIST_REJECTED to distinguish manual
-    waitlist rejection from generic engine cascade rejection.
+    Wave 5 (Phase 3) added T11 ADMISSION_WAITLIST_REJECTED.
 
-    Q9 #07 Phase E Wave 1 (2026-05-19) added 3 PRIORITY_* events:
-    PRIORITY_KV_OVERRIDDEN / PRIORITY_OBJECT_VERIFIED / PRIORITY_OBJECT_REJECTED.
+    Wave 1 (Q9 #07 Phase E) added 3 PRIORITY_* events to catalog seed.
+    Wave 2 wired PRIORITY_KV_OVERRIDDEN via outbox dispatch_event → moved
+    out of deferred set. PRIORITY_KV_OVERRIDDEN is not in
+    LEGACY_STATUS_TO_EVENT or TRANSITION_PAIR_TO_EVENT (event fires from
+    service layer, not state transition), so total is 15 events not 16.
     """
     mapped = {ev.name for ev in state_service.LEGACY_STATUS_TO_EVENT.values()}
     pair = {ev.name for ev in state_service.TRANSITION_PAIR_TO_EVENT.values()}
     deferred = set(state_service.DEFERRED_ADMISSION_EVENTS)
     total = len(mapped | pair | deferred)
-    assert total == 16
+    assert total == 15
 
 
 # ---------------------------------------------------------------------------

--- a/Backend_FastAPI/tests/unit/test_check_notification_event_coverage_deferred.py
+++ b/Backend_FastAPI/tests/unit/test_check_notification_event_coverage_deferred.py
@@ -67,11 +67,9 @@ def test_deferred_set_canonical_source_is_state_service() -> None:
     same set of names enumerated in
     ``state_service.DEFERRED_ADMISSION_EVENTS``. Without this, the
     coverage flag and the runtime mapping could drift silently."""
-    # Q9 #07 Phase E Wave 1 (2026-05-19) added 3 PRIORITY_* events to
-    # catalog seed; dispatch sites ship Wave 2 (override_kv) + Wave 3
-    # (verify/reject evidence). Tracked here until those waves merge.
+    # Wave 2 (2026-05-19) wired PRIORITY_KV_OVERRIDDEN; only the 2 UT
+    # evidence events remain deferred until Wave 3 ships verify/reject.
     assert DEFERRED_ADMISSION_EVENTS == frozenset({
-        "PRIORITY_KV_OVERRIDDEN",
         "PRIORITY_OBJECT_VERIFIED",
         "PRIORITY_OBJECT_REJECTED",
     })
@@ -101,14 +99,14 @@ def _capture_stderr(callable_):
 
 
 def test_summarize_passes_when_deferred_events_match(capsys) -> None:
-    """Q9 #07 Phase E Wave 1 (2026-05-19): DEFERRED set has 3 PRIORITY_*
-    events; verify passing the matching --allow-deferred list yields
-    rc=0 + "Deferred (allow-listed)" block.
+    """Wave 2 (2026-05-19) shrunk DEFERRED set 3 → 2 (wired
+    PRIORITY_KV_OVERRIDDEN); 2 UT evidence events remain deferred
+    until Wave 3.
     """
     # Build stand-in statuses with ONLY the single no-dispatch-site gap
     # (allow-list only excuses that exact single gap).
     statuses = [_status(name) for name in DEFERRED_ADMISSION_EVENTS]
-    assert len(statuses) == 3
+    assert len(statuses) == 2
     for st in statuses:
         assert st.gaps == ["no-dispatch-site"]
 

--- a/Backend_FastAPI/tests/unit/test_priority_override_service.py
+++ b/Backend_FastAPI/tests/unit/test_priority_override_service.py
@@ -1,0 +1,406 @@
+"""Unit tests for ``priority_override_service.override_kv``.
+
+Q9 #07 Phase E.2 — service-layer behaviour contract. Covers:
+
+1. Version guard FIRST (memory `version-guard-before-state-machine`).
+2. Reason length validation (20-500 char).
+3. KV value validation (4 codes only).
+4. Status whitelist enforcement per role:
+   * Officer: {submitted, reviewing, revision_requested} ALLOW
+   * Admin: same + bypass via acknowledge_post_publish for post-publish.
+   * Hard-deny {draft, withdrawn, dropped, rejected} for both.
+5. Snapshot mutation correctness (Decision D1 — LAST override wins).
+6. Audit log INSERT (action_type='kv_manual_override').
+7. Version bump (optimistic lock).
+8. post_commit callback closure (dispatch wiring).
+
+Tests mock the AsyncSession + profile so they stay independent of
+alembic + DB seed (pure-logic unit tests).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.priority_override_service import override_kv
+from app.utils.exceptions import BusinessRuleViolation, ConflictError
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_profile(
+    *,
+    status: str = "submitted",
+    version: int = 5,
+    snapshot: dict | None = None,
+):
+    """Build a SimpleNamespace profile stub with the fields override_kv reads."""
+    return SimpleNamespace(
+        id=42,
+        lead_id=100,
+        status=status,
+        version=version,
+        priority_resolution_snapshot=snapshot
+        if snapshot is not None
+        else {
+            "kv_resolved": "KV3",
+            "rule_applied": "thpt_multi_school_longest",
+            "pathway": "thpt_multi_school",
+            "frozen_at": "2026-05-19T00:00:00Z",
+        },
+        area_resolution_basis="school_history",
+    )
+
+
+def _make_actor(role: str = "officer", user_id: int = 7):
+    return SimpleNamespace(
+        id=user_id,
+        role=role,
+        full_name=f"User {user_id}",
+        email=f"user{user_id}@example.com",
+    )
+
+
+def _make_db():
+    """AsyncMock session — captures db.add() calls + db.flush() awaits."""
+    db = MagicMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    return db
+
+
+REASON_VALID = "Lý do override 20+ ký tự cho test smoke happy path"
+
+
+# ---------------------------------------------------------------------------
+# Version guard — FIRST per memory
+# ---------------------------------------------------------------------------
+
+
+async def test_version_conflict_raises_before_other_checks() -> None:
+    """Version mismatch must raise ConflictError BEFORE status / reason
+    validation — guarantees fast-fail trên concurrent writes.
+    """
+    profile = _make_profile(version=5)
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(ConflictError) as exc:
+        await override_kv(
+            db,
+            profile,
+            kv_resolved="KV1",
+            reason=REASON_VALID,
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=99,  # mismatch
+        )
+    assert "version" in str(exc.value).lower()
+    db.add.assert_not_called()
+    db.flush.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Reason validation
+# ---------------------------------------------------------------------------
+
+
+async def test_reason_too_short_raises() -> None:
+    profile = _make_profile()
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match="20 characters"):
+        await override_kv(
+            db,
+            profile,
+            kv_resolved="KV1",
+            reason="too short",  # 9 chars
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=5,
+        )
+
+
+async def test_reason_too_long_raises() -> None:
+    profile = _make_profile()
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match="500 characters"):
+        await override_kv(
+            db,
+            profile,
+            kv_resolved="KV1",
+            reason="x" * 501,
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# KV value validation
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_kv_value_raises() -> None:
+    profile = _make_profile()
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match="Invalid kv_resolved"):
+        await override_kv(
+            db,
+            profile,
+            kv_resolved="KV99",  # invalid
+            reason=REASON_VALID,
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Status whitelist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "status", ["draft", "withdrawn", "dropped", "rejected"]
+)
+async def test_hard_denied_status_raises_for_officer(status: str) -> None:
+    profile = _make_profile(status=status)
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match=status):
+        await override_kv(
+            db,
+            profile,
+            kv_resolved="KV1",
+            reason=REASON_VALID,
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=5,
+        )
+
+
+@pytest.mark.parametrize(
+    "status", ["draft", "withdrawn", "dropped", "rejected"]
+)
+async def test_hard_denied_status_raises_for_admin_too(status: str) -> None:
+    """Admin also refused for hard-denied states (data integrity)."""
+    profile = _make_profile(status=status)
+    actor = _make_actor("admin")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match=status):
+        await override_kv(
+            db,
+            profile,
+            kv_resolved="KV1",
+            reason=REASON_VALID,
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=5,
+            acknowledge_post_publish=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "status", ["enrolled", "approved", "confirmed", "result_published"]
+)
+async def test_officer_refused_post_publish_raises_permission_error(
+    status: str,
+) -> None:
+    """Officer hits PermissionError for post-publish; router maps to 403."""
+    profile = _make_profile(status=status)
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(PermissionError):
+        await override_kv(
+            db,
+            profile,
+            kv_resolved="KV1",
+            reason=REASON_VALID,
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=5,
+        )
+
+
+async def test_admin_post_publish_without_ack_raises() -> None:
+    """Admin requires acknowledge_post_publish=true for post-publish states."""
+    profile = _make_profile(status="enrolled")
+    actor = _make_actor("admin")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match="acknowledge_post_publish"):
+        await override_kv(
+            db,
+            profile,
+            kv_resolved="KV1",
+            reason=REASON_VALID,
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=5,
+            acknowledge_post_publish=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Happy path — officer
+# ---------------------------------------------------------------------------
+
+
+async def test_officer_happy_path_mutates_snapshot_and_audit_log() -> None:
+    profile = _make_profile(status="submitted", version=5)
+    actor = _make_actor("officer", user_id=7)
+    db = _make_db()
+
+    updated, post_commit = await override_kv(
+        db,
+        profile,
+        kv_resolved="KV1",
+        reason=REASON_VALID,
+        evidence_file_id=42,
+        actor=actor,
+        expected_version=5,
+    )
+
+    # Returned profile = same object mutated in-place
+    assert updated is profile
+
+    # Snapshot fully overwritten với manual override metadata
+    snap = profile.priority_resolution_snapshot
+    assert snap["kv_resolved"] == "KV1"
+    assert snap["pathway"] == "manual"
+    assert snap["rule_applied"] == "manual_override"
+    assert snap["manual_override_by"] == 7
+    assert snap["manual_override_at"]  # ISO timestamp set
+    assert snap["manual_override_reason"] == REASON_VALID
+    assert snap["evidence_file_id"] == 42
+    assert snap["frozen_at_status"] == "manual_override"
+    assert snap["resolved_by"] == "officer"
+
+    # Engine-state keys dropped post-override
+    assert "requires_manual_override" not in snap or not snap["requires_manual_override"]
+
+    # area_resolution_basis flipped to manual
+    assert profile.area_resolution_basis == "manual_override"
+
+    # Version bumped
+    assert profile.version == 6
+
+    # Audit log row queued for INSERT
+    assert db.add.call_count == 1
+    audit_row = db.add.call_args[0][0]
+    assert audit_row.profile_id == 42
+    assert audit_row.action_type == "kv_manual_override"
+    assert audit_row.actor_id == 7
+    assert audit_row.old_value["kv_resolved"] == "KV3"
+    assert audit_row.new_value["kv_resolved"] == "KV1"
+    assert audit_row.new_value["reason"] == REASON_VALID
+    assert audit_row.audit_metadata["actor_role"] == "officer"
+
+    # Flushed but NOT committed (router responsibility)
+    db.flush.assert_awaited_once()
+    db.commit.assert_not_awaited()
+
+    # post_commit callable returned
+    assert callable(post_commit)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — admin post-publish với ack
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_post_publish_with_ack_succeeds() -> None:
+    profile = _make_profile(status="enrolled", version=10)
+    actor = _make_actor("admin", user_id=1)
+    db = _make_db()
+
+    updated, _ = await override_kv(
+        db,
+        profile,
+        kv_resolved="KV2-NT",
+        reason=REASON_VALID,
+        evidence_file_id=None,
+        actor=actor,
+        expected_version=10,
+        acknowledge_post_publish=True,
+    )
+
+    assert updated.priority_resolution_snapshot["kv_resolved"] == "KV2-NT"
+    assert updated.priority_resolution_snapshot["resolved_by"] == "admin"
+    assert updated.version == 11
+
+    audit_row = db.add.call_args[0][0]
+    assert audit_row.audit_metadata["acknowledged_post_publish"] is True
+
+
+# ---------------------------------------------------------------------------
+# Chain-of-override semantics (Decision D1)
+# ---------------------------------------------------------------------------
+
+
+async def test_second_override_overwrites_manual_keys() -> None:
+    """First override sets manual_override_*; second overwrites with new
+    actor + reason (snapshot LAST wins, audit log preserves chain).
+    """
+    # Profile already had one override (e.g., from officer)
+    profile = _make_profile(
+        status="submitted",
+        version=6,
+        snapshot={
+            "kv_resolved": "KV1",
+            "pathway": "manual",
+            "rule_applied": "manual_override",
+            "manual_override_by": 7,
+            "manual_override_at": "2026-05-19T01:00:00Z",
+            "manual_override_reason": "Officer first pass override reason 20 chars+",
+            "evidence_file_id": 11,
+            "frozen_at": "2026-05-19T01:00:00Z",
+            "frozen_at_status": "manual_override",
+            "resolved_by": "officer",
+        },
+    )
+    admin = _make_actor("admin", user_id=99)
+    db = _make_db()
+
+    new_reason = "Admin re-override second pass with longer justification"
+
+    updated, _ = await override_kv(
+        db,
+        profile,
+        kv_resolved="KV2-NT",
+        reason=new_reason,
+        evidence_file_id=22,
+        actor=admin,
+        expected_version=6,
+    )
+
+    snap = updated.priority_resolution_snapshot
+    # New override metadata wins
+    assert snap["kv_resolved"] == "KV2-NT"
+    assert snap["manual_override_by"] == 99
+    assert snap["manual_override_reason"] == new_reason
+    assert snap["evidence_file_id"] == 22
+    assert snap["resolved_by"] == "admin"
+
+    # Audit log captures OLD = officer's last state, NEW = admin's
+    audit_row = db.add.call_args[0][0]
+    assert audit_row.old_value["kv_resolved"] == "KV1"
+    assert audit_row.new_value["kv_resolved"] == "KV2-NT"

--- a/Backend_FastAPI/tests/unit/test_priority_override_service.py
+++ b/Backend_FastAPI/tests/unit/test_priority_override_service.py
@@ -78,6 +78,22 @@ def _make_db():
     return db
 
 
+def _find_audit_rows(db):
+    """Filter db.add() calls down to PriorityAuditLog instances only.
+
+    Wave 2 dispatch_event() also adds a NotificationOutbox row inside
+    the caller's transaction (per B2.3 wrapper). Tests inspecting the
+    audit row must filter by type to skip the outbox sibling.
+    """
+    from app import models
+    rows = []
+    for call in db.add.call_args_list:
+        instance = call[0][0]
+        if isinstance(instance, models.PriorityAuditLog):
+            rows.append(instance)
+    return rows
+
+
 REASON_VALID = "Lý do override 20+ ký tự cho test smoke happy path"
 
 
@@ -303,9 +319,11 @@ async def test_officer_happy_path_mutates_snapshot_and_audit_log() -> None:
     # Version bumped
     assert profile.version == 6
 
-    # Audit log row queued for INSERT
-    assert db.add.call_count == 1
-    audit_row = db.add.call_args[0][0]
+    # Audit log row queued for INSERT (also NotificationOutbox row from
+    # dispatch_event — filter by type to avoid coupling).
+    audit_rows = _find_audit_rows(db)
+    assert len(audit_rows) == 1
+    audit_row = audit_rows[0]
     assert audit_row.profile_id == 42
     assert audit_row.action_type == "kv_manual_override"
     assert audit_row.actor_id == 7
@@ -347,8 +365,9 @@ async def test_admin_post_publish_with_ack_succeeds() -> None:
     assert updated.priority_resolution_snapshot["resolved_by"] == "admin"
     assert updated.version == 11
 
-    audit_row = db.add.call_args[0][0]
-    assert audit_row.audit_metadata["acknowledged_post_publish"] is True
+    audit_rows = _find_audit_rows(db)
+    assert len(audit_rows) == 1
+    assert audit_rows[0].audit_metadata["acknowledged_post_publish"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -401,6 +420,8 @@ async def test_second_override_overwrites_manual_keys() -> None:
     assert snap["resolved_by"] == "admin"
 
     # Audit log captures OLD = officer's last state, NEW = admin's
-    audit_row = db.add.call_args[0][0]
+    audit_rows = _find_audit_rows(db)
+    assert len(audit_rows) == 1
+    audit_row = audit_rows[0]
     assert audit_row.old_value["kv_resolved"] == "KV1"
     assert audit_row.new_value["kv_resolved"] == "KV2-NT"

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/PriorityOverrideDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/PriorityOverrideDialog.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * PriorityOverrideDialog — Vitest unit tests (Q9 #07 Phase E.2).
+ *
+ * Covers:
+ * - Render dialog with KV select + reason textarea + counter
+ * - BEFORE → AFTER preview reflects user-picked KV
+ * - Reason validation: min 20 chars enforced on submit
+ * - KV-changed gate: cannot submit same KV
+ * - Post-publish profile (admin): ack checkbox required
+ * - 409 ConflictError: surfaces refresh prompt via stateful mock
+ *
+ * Stateful mock per memory `vitest-url-mock-tautological` —
+ * useOverridePriorityKv hook is wrapped to allow per-test rejection.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import userEvent from "@testing-library/user-event"
+
+import { render, screen, waitFor } from "@/test/utils/test-utils"
+import { PriorityOverrideDialog } from "./PriorityOverrideDialog"
+
+// JSDOM doesn't support pointer capture (Radix Select uses it).
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = vi.fn(() => false)
+    Element.prototype.releasePointerCapture = vi.fn()
+  }
+})
+
+// useMediaQuery uses useSyncExternalStore + matchMedia; stub to always
+// desktop trong JSDOM tests (ResponsiveDialog uses this internally).
+vi.mock("@/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+  useIsMobile: () => false,
+  useIsTablet: () => false,
+  useIsDesktop: () => true,
+}))
+
+// Stateful mutation mock — toggled per-test by mutateImpl
+const mutateImpl = vi.fn()
+vi.mock("@/lib/hooks/use-priority-override", () => ({
+  useOverridePriorityKv: () => ({
+    mutateAsync: mutateImpl,
+    isPending: false,
+  }),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+function renderDialog(
+  overrides: Partial<React.ComponentProps<typeof PriorityOverrideDialog>> = {},
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  const onOpenChange = vi.fn()
+  const utils = render(
+    <QueryClientProvider client={client}>
+      <PriorityOverrideDialog
+        open
+        onOpenChange={onOpenChange}
+        profileId={42}
+        profileVersion={5}
+        profileStatus="submitted"
+        currentKv="KV3"
+        mode="officer"
+        {...overrides}
+      />
+    </QueryClientProvider>,
+  )
+  return { ...utils, onOpenChange, client }
+}
+
+describe("PriorityOverrideDialog", () => {
+  beforeEach(() => {
+    mutateImpl.mockReset()
+  })
+
+  it("renders header + KV select + reason input + counter", () => {
+    renderDialog()
+    expect(
+      screen.getByText(/Cán bộ ấn định KV thủ công/i),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("override-kv-select")).toBeInTheDocument()
+    expect(screen.getByTestId("override-reason-input")).toBeInTheDocument()
+    expect(screen.getByTestId("override-reason-counter")).toHaveTextContent(
+      /0\/500/,
+    )
+  })
+
+  it("shows BEFORE → AFTER preview với current KV", () => {
+    renderDialog({ currentKv: "KV3" })
+    expect(screen.getByTestId("override-before-kv")).toHaveTextContent(
+      /KV3/,
+    )
+    expect(screen.getByTestId("override-after-kv")).toHaveTextContent(/—/)
+  })
+
+  it("submit button disabled when reason < 20 chars", async () => {
+    const user = userEvent.setup()
+    renderDialog()
+    await user.type(
+      screen.getByTestId("override-reason-input"),
+      "Quá ngắn",
+    )
+    expect(screen.getByTestId("override-submit")).toBeDisabled()
+  })
+
+  it("submit button disabled when KV unchanged (same as currentKv)", async () => {
+    const user = userEvent.setup()
+    renderDialog({ currentKv: "KV1" })
+    // Reason valid
+    await user.type(
+      screen.getByTestId("override-reason-input"),
+      "Lý do override 20+ ký tự valid hợp lệ cho test",
+    )
+    // Without picking different KV, submit still disabled
+    expect(screen.getByTestId("override-submit")).toBeDisabled()
+  })
+
+  it("post-publish admin requires acknowledge checkbox", () => {
+    renderDialog({
+      mode: "admin",
+      profileStatus: "enrolled",
+    })
+    expect(
+      screen.getByTestId("override-post-publish-warning"),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("override-ack-checkbox")).toBeInTheDocument()
+  })
+
+  it("post-publish warning HIDDEN for non-post-publish status", () => {
+    renderDialog({
+      mode: "admin",
+      profileStatus: "submitted",
+    })
+    expect(
+      screen.queryByTestId("override-post-publish-warning"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("post-publish warning HIDDEN for officer mode (officer never overrides post-publish)", () => {
+    renderDialog({
+      mode: "officer",
+      profileStatus: "enrolled",
+    })
+    // BE PermissionError handled at service layer; UI doesn't show the
+    // admin-only ack checkbox.
+    expect(
+      screen.queryByTestId("override-post-publish-warning"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("409 ConflictError surfaces refresh prompt + cache invalidate handled by hook", async () => {
+    const user = userEvent.setup()
+    // Stateful mock: first call rejects với axios-style 409 shape
+    mutateImpl.mockRejectedValueOnce({
+      response: { status: 409, data: { detail: "Version mismatch" } },
+    })
+    renderDialog({ currentKv: "KV3" })
+
+    // Fill reason + change KV → submit enabled
+    await user.type(
+      screen.getByTestId("override-reason-input"),
+      "Lý do override 20+ ký tự valid cho test 409",
+    )
+    // Open select + pick KV1
+    await user.click(screen.getByTestId("override-kv-select"))
+    const kv1Option = await screen.findByRole("option", { name: /KV1/ })
+    await user.click(kv1Option)
+
+    await user.click(screen.getByTestId("override-submit"))
+
+    // Error message surfaces — phase E.2 stateful mock pattern per memory
+    // `vitest-url-mock-tautological` (real refetch happens in hook via
+    // queryClient.invalidateQueries, asserted indirectly via toast.error).
+    await waitFor(() => {
+      expect(screen.getByTestId("override-error")).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/PriorityOverrideDialog.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/PriorityOverrideDialog.tsx
@@ -28,7 +28,7 @@
  * * Snapshot mutation overwrites manual_override_* keys (Decision D1);
  *   audit log preserves chain.
  */
-import { useEffect, useState } from "react"
+import { useCallback, useState } from "react"
 import { AlertTriangle, ShieldCheck } from "lucide-react"
 import { toast } from "sonner"
 
@@ -102,15 +102,21 @@ export function PriorityOverrideDialog({
 
   const mutation = useOverridePriorityKv(profileId)
 
-  // Reset state khi dialog mở/đóng
-  useEffect(() => {
-    if (!open) {
-      setKvResolved("")
-      setReason("")
-      setAcknowledgePostPublish(false)
-      setError(null)
-    }
-  }, [open])
+  // Reset state khi dialog đóng — handled trong onOpenChange wrapper
+  // thay vì useEffect (avoids React 19 cascading setState rule + eliminates
+  // race when parent re-opens dialog ngay sau khi close).
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) {
+        setKvResolved("")
+        setReason("")
+        setAcknowledgePostPublish(false)
+        setError(null)
+      }
+      onOpenChange(next)
+    },
+    [onOpenChange],
+  )
 
   const isPostPublish = POST_PUBLISH_STATUS.has(profileStatus)
   const requiresAck = isPostPublish && mode === "admin"
@@ -135,7 +141,7 @@ export function PriorityOverrideDialog({
         acknowledge_post_publish: acknowledgePostPublish,
       })
       toast.success("Đã override KV thành công")
-      onOpenChange(false)
+      handleOpenChange(false)
     } catch (err: unknown) {
       const status = (err as { response?: { status?: number } })?.response?.status
       if (status === 409) {
@@ -168,7 +174,7 @@ export function PriorityOverrideDialog({
   const afterLabel = kvResolved ? KV_BADGE[kvResolved]?.label ?? kvResolved : "—"
 
   return (
-    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+    <ResponsiveDialog open={open} onOpenChange={handleOpenChange}>
       <ResponsiveDialogContent className="sm:max-w-[480px]">
         <ResponsiveDialogHeader>
           <ResponsiveDialogTitle className="flex items-center gap-2">

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/PriorityOverrideDialog.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/PriorityOverrideDialog.tsx
@@ -1,0 +1,316 @@
+"use client"
+
+/**
+ * PriorityOverrideDialog — Q9 #07 Phase E.2 (officer/admin write-path).
+ *
+ * Triggered từ PriorityTab "Cán bộ ấn định thủ công" button (gated by
+ * `profile.permissions.override_priority_kv`). Submits POST
+ * /api/v2/admissions/{id}/override-priority-kv với optimistic-lock
+ * version + 20-500 char reason.
+ *
+ * UX:
+ * * KV Select — 4 options (KV1 / KV2-NT / KV2 / KV3) sourced từ KV_BADGE
+ * * Reason Textarea — 20-500 chars với live counter
+ * * BEFORE → AFTER inline preview (current snapshot.kv_resolved → user-picked)
+ * * Submit gates: reason length OK + KV changed (no-op if same KV)
+ * * Admin escape hatch: secondary checkbox cho post-publish profile
+ *   (status enrolled/approved/confirmed/...) — required by BE service
+ *   layer's `acknowledge_post_publish` flag.
+ * * On 409 ConflictError → toast "Hồ sơ vừa cập nhật bởi người khác,
+ *   vui lòng refresh" + invalidate detail cache (handled inside the
+ *   mutation hook).
+ *
+ * BE service contract:
+ * * Version guard FIRST per memory `version-guard-before-state-machine`
+ * * Officer status whitelist {submitted, reviewing, revision_requested};
+ *   hard-deny {draft, withdrawn, dropped, rejected}; post-publish requires
+ *   admin + ack flag.
+ * * Snapshot mutation overwrites manual_override_* keys (Decision D1);
+ *   audit log preserves chain.
+ */
+import { useEffect, useState } from "react"
+import { AlertTriangle, ShieldCheck } from "lucide-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+
+import { KV_BADGE } from "@/components/admissions/kv-labels"
+import { useOverridePriorityKv } from "@/lib/hooks/use-priority-override"
+import {
+  KV_CODES,
+  type KvCode,
+} from "@/lib/zod/priority-override"
+
+const POST_PUBLISH_STATUS = new Set([
+  "approved",
+  "confirmed",
+  "enrolled",
+  "overridden",
+  "result_published",
+  "admitted",
+  "waitlisted",
+])
+
+const MIN_REASON = 20
+const MAX_REASON = 500
+
+export interface PriorityOverrideDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  profileId: number
+  profileVersion: number
+  profileStatus: string
+  currentKv: string | null | undefined
+  /**
+   * Caller's role. Service-layer enforces full rules; UI gates the
+   * "acknowledge post-publish" checkbox.
+   */
+  mode?: "officer" | "admin"
+}
+
+export function PriorityOverrideDialog({
+  open,
+  onOpenChange,
+  profileId,
+  profileVersion,
+  profileStatus,
+  currentKv,
+  mode = "officer",
+}: PriorityOverrideDialogProps) {
+  const [kvResolved, setKvResolved] = useState<KvCode | "">("")
+  const [reason, setReason] = useState("")
+  const [acknowledgePostPublish, setAcknowledgePostPublish] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const mutation = useOverridePriorityKv(profileId)
+
+  // Reset state khi dialog mở/đóng
+  useEffect(() => {
+    if (!open) {
+      setKvResolved("")
+      setReason("")
+      setAcknowledgePostPublish(false)
+      setError(null)
+    }
+  }, [open])
+
+  const isPostPublish = POST_PUBLISH_STATUS.has(profileStatus)
+  const requiresAck = isPostPublish && mode === "admin"
+  const reasonLen = reason.trim().length
+  const reasonValid = reasonLen >= MIN_REASON && reasonLen <= MAX_REASON
+  const kvChanged = kvResolved !== "" && kvResolved !== currentKv
+  const canSubmit =
+    kvChanged &&
+    reasonValid &&
+    (!requiresAck || acknowledgePostPublish) &&
+    !mutation.isPending
+
+  const handleSubmit = async () => {
+    if (!canSubmit || !kvResolved) return
+    setError(null)
+    try {
+      await mutation.mutateAsync({
+        version: profileVersion,
+        kv_resolved: kvResolved,
+        reason: reason.trim(),
+        evidence_file_id: null,
+        acknowledge_post_publish: acknowledgePostPublish,
+      })
+      toast.success("Đã override KV thành công")
+      onOpenChange(false)
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status
+      if (status === 409) {
+        toast.error(
+          "Hồ sơ vừa cập nhật bởi người khác. Vui lòng refresh và thử lại."
+        )
+        setError(
+          "Phiên bản hồ sơ đã thay đổi — cache đã refresh, vui lòng đóng dialog và mở lại."
+        )
+      } else if (status === 403) {
+        const detail =
+          (err as { response?: { data?: { detail?: string } } })?.response?.data
+            ?.detail
+        toast.error(detail || "Bạn không có quyền override KV trên hồ sơ này.")
+        setError(detail || "Không có quyền override.")
+      } else if (status === 400) {
+        const detail =
+          (err as { response?: { data?: { detail?: string } } })?.response?.data
+            ?.detail
+        toast.error(detail || "Yêu cầu không hợp lệ.")
+        setError(detail || "Yêu cầu không hợp lệ.")
+      } else {
+        toast.error("Không thể override KV. Vui lòng thử lại.")
+        setError("Lỗi server. Vui lòng thử lại sau.")
+      }
+    }
+  }
+
+  const beforeLabel = currentKv ? KV_BADGE[currentKv]?.label ?? currentKv : "—"
+  const afterLabel = kvResolved ? KV_BADGE[kvResolved]?.label ?? kvResolved : "—"
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={onOpenChange}>
+      <ResponsiveDialogContent className="sm:max-w-[480px]">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+            Cán bộ ấn định KV thủ công
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Override Khu vực ưu tiên trên hồ sơ này. Thay đổi sẽ được ghi vào
+            audit log với lý do bạn cung cấp.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        <div className="grid gap-4 py-4">
+          {/* BEFORE → AFTER preview */}
+          <div
+            className="rounded-md border border-border bg-muted/40 p-3 text-sm"
+            data-testid="priority-override-preview"
+          >
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-muted-foreground">Hiện tại:</span>
+              <span className="font-medium" data-testid="override-before-kv">
+                {beforeLabel}
+              </span>
+              <span className="text-muted-foreground">→</span>
+              <span className="text-muted-foreground">Sau:</span>
+              <span className="font-bold text-primary" data-testid="override-after-kv">
+                {afterLabel}
+              </span>
+            </div>
+          </div>
+
+          {/* KV Select */}
+          <div className="grid gap-2">
+            <Label htmlFor="override-kv">
+              KV mới <span className="text-error-500">*</span>
+            </Label>
+            <Select
+              value={kvResolved}
+              onValueChange={(v) => setKvResolved(v as KvCode)}
+            >
+              <SelectTrigger id="override-kv" data-testid="override-kv-select">
+                <SelectValue placeholder="Chọn KV mới..." />
+              </SelectTrigger>
+              <SelectContent>
+                {KV_CODES.map((code) => (
+                  <SelectItem key={code} value={code}>
+                    {KV_BADGE[code]?.label ?? code}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Reason textarea với counter */}
+          <div className="grid gap-2">
+            <Label htmlFor="override-reason">
+              Lý do override <span className="text-error-500">*</span>
+            </Label>
+            <Textarea
+              id="override-reason"
+              data-testid="override-reason-input"
+              placeholder={`Nhập lý do override (tối thiểu ${MIN_REASON} ký tự)...`}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={4}
+              maxLength={MAX_REASON}
+            />
+            <p
+              className={`text-xs text-right ${
+                reasonLen < MIN_REASON || reasonLen > MAX_REASON
+                  ? "text-error-500"
+                  : "text-muted-foreground"
+              }`}
+              data-testid="override-reason-counter"
+            >
+              {reasonLen}/{MAX_REASON} (tối thiểu {MIN_REASON})
+            </p>
+          </div>
+
+          {/* Admin escape hatch — post-publish profile */}
+          {requiresAck && (
+            <div
+              className="rounded-md border border-warning-300 bg-warning-50 p-3 text-sm flex items-start gap-2"
+              data-testid="override-post-publish-warning"
+            >
+              <AlertTriangle className="h-4 w-4 shrink-0 text-warning-700 mt-0.5" />
+              <div className="space-y-2 flex-1">
+                <p className="text-warning-900 font-medium">
+                  Hồ sơ đã ở trạng thái post-publish: {profileStatus}
+                </p>
+                <p className="text-warning-800 text-xs">
+                  Override KV sau khi hồ sơ đã được công bố kết quả là thao tác
+                  hiếm gặp. Hành động này sẽ được ghi vào audit log với metadata
+                  acknowledged_post_publish=true.
+                </p>
+                <div className="flex items-start gap-2">
+                  <Checkbox
+                    id="ack-post-publish"
+                    data-testid="override-ack-checkbox"
+                    checked={acknowledgePostPublish}
+                    onCheckedChange={(v) => setAcknowledgePostPublish(!!v)}
+                  />
+                  <Label
+                    htmlFor="ack-post-publish"
+                    className="text-warning-900 cursor-pointer"
+                  >
+                    Tôi xác nhận muốn override hồ sơ post-publish.
+                  </Label>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Server / validation error */}
+          {error && (
+            <p
+              className="text-sm text-error-600"
+              data-testid="override-error"
+              role="alert"
+            >
+              {error}
+            </p>
+          )}
+        </div>
+
+        <ResponsiveDialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={mutation.isPending}
+          >
+            Hủy
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            data-testid="override-submit"
+          >
+            {mutation.isPending ? "Đang lưu..." : "Override KV"}
+          </Button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PriorityTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PriorityTab.test.tsx
@@ -24,6 +24,16 @@ beforeAll(() => {
   }
 })
 
+// PriorityTab now embeds PriorityOverrideDialog → ResponsiveDialog →
+// useMediaQuery (useSyncExternalStore + matchMedia). Stub to desktop
+// trong JSDOM tests.
+vi.mock("@/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+  useIsMobile: () => false,
+  useIsTablet: () => false,
+  useIsDesktop: () => true,
+}))
+
 // Mock live preview hook — control returned data per test
 const mockPreview = vi.fn()
 vi.mock("@/lib/hooks/use-preview-priority-kv", () => ({

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PriorityTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PriorityTab.tsx
@@ -18,18 +18,21 @@
  *   3. Trình độ học vấn — 2 dropdowns cultural + vocational
  *   4. Trường hợp đặc biệt toggle (replaces dropdown — auto-detect basis)
  */
+import { useState } from "react"
 import { UseFormReturn } from "react-hook-form"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
+import { Button } from "@/components/ui/button"
 import { FormField, FormItem, FormLabel, FormControl, FormMessage, FormDescription } from "@/components/ui/form"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { ShieldCheck, Lightbulb } from "lucide-react"
+import { ShieldCheck, Lightbulb, ShieldAlert } from "lucide-react"
 import { usePreviewPriorityKv } from "@/lib/hooks/use-preview-priority-kv"
 import type { PreviewPriorityKvRequest } from "@/lib/api/priority-kv"
 import type { AdmissionProfileResponse, AdmissionProfileUpdateInput } from "@/lib/zod/admissions"
 import { PrioritySnapshotCard } from "@/components/admissions/PrioritySnapshotCard"
 import { UtEvidenceCard } from "@/components/admissions/UtEvidenceCard"
+import { PriorityOverrideDialog } from "../PriorityOverrideDialog"
 
 interface PriorityTabProps {
   form: UseFormReturn<AdmissionProfileUpdateInput>
@@ -56,6 +59,7 @@ const VOCATIONAL_OPTIONS = [
 // Reused by `KvBreakdownCard` + future `PriorityOverrideDialog` (E.2).
 
 export function PriorityTab({ form, profile, isEditable }: PriorityTabProps) {
+  const [overrideDialogOpen, setOverrideDialogOpen] = useState(false)
   const cultural = form.watch("cultural_education_level")
   const vocational = form.watch("vocational_qualification")
   const areaBasis = form.watch("area_resolution_basis")
@@ -160,8 +164,36 @@ export function PriorityTab({ form, profile, isEditable }: PriorityTabProps) {
         }
         manualOverrideAt={frozenSnapshot?.manual_override_at ?? null}
       />
-      {/* Phase E.2 (PriorityOverrideDialog) sẽ wire trigger button gated by
-          profile.permissions.override_priority_kv here — chưa ship */}
+      {/* Phase E.2 — manual KV override (officer/admin write-path).
+          Button gated by profile.permissions.override_priority_kv;
+          dialog enforces version guard + reason validation + 409 handler. */}
+      {profile.permissions?.override_priority_kv && (
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setOverrideDialogOpen(true)}
+            data-testid="priority-override-trigger"
+          >
+            <ShieldAlert className="h-4 w-4 mr-2" />
+            Cán bộ ấn định KV thủ công
+          </Button>
+        </div>
+      )}
+      <PriorityOverrideDialog
+        open={overrideDialogOpen}
+        onOpenChange={setOverrideDialogOpen}
+        profileId={profile.id}
+        profileVersion={profile.version ?? 0}
+        profileStatus={profile.status}
+        currentKv={
+          (frozenSnapshot?.kv_resolved as string | undefined) ??
+          preview?.kv_resolved ??
+          null
+        }
+        mode={profile.permissions?.override_priority_kv ? "admin" : "officer"}
+      />
 
       {/* ───────── 2. INTRO DISCLOSURE (1-line, collapsed by default) ───────── */}
       <details className="rounded-lg border border-info-200 bg-info-50/40 px-3 py-2 text-sm text-info-900/90">

--- a/frontend/src/lib/api/priority-override.ts
+++ b/frontend/src/lib/api/priority-override.ts
@@ -1,0 +1,33 @@
+/**
+ * Q9 #07 Phase E.2 — Manual KV override API client.
+ *
+ * Wraps `POST /api/v2/admissions/{profile_id}/override-priority-kv` —
+ * officer/admin write-path để override KV trên candidate's profile.
+ *
+ * Service-layer (Backend) enforces:
+ * * Version guard FIRST → 409 ConflictError
+ * * Status whitelist (officer: submitted/reviewing/revision_requested;
+ *   admin bypass với acknowledge_post_publish=true)
+ * * Reason 20-500 char validation
+ * * Snapshot mutation + priority_audit_log INSERT + version bump
+ *
+ * Response: full `AdmissionProfileResponse` shape (router calls
+ * `_populate_response_fields` after commit).
+ */
+import { api } from "@/lib/api/client"
+import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+
+import type { OverridePriorityKvRequest } from "@/lib/zod/priority-override"
+
+export const priorityOverrideApi = {
+  async overrideKv(
+    profileId: number,
+    body: OverridePriorityKvRequest,
+  ): Promise<AdmissionProfileResponse> {
+    const { data } = await api.post<AdmissionProfileResponse>(
+      `/api/v2/admissions/${profileId}/override-priority-kv`,
+      body,
+    )
+    return data
+  },
+}

--- a/frontend/src/lib/hooks/use-priority-override.ts
+++ b/frontend/src/lib/hooks/use-priority-override.ts
@@ -1,0 +1,57 @@
+/**
+ * React Query mutation hook — Manual KV override (Q9 #07 Phase E.2).
+ *
+ * Wraps `priorityOverrideApi.overrideKv()` with proper cache invalidation
+ * + 409 conflict handling per memory `react-query-mutation-cache-parity`.
+ *
+ * Cache parity requirements:
+ * * onSuccess MUST invalidate the detail query key — both pessimistic
+ *   `invalidateQueries(['admission', profileId])` AND
+ *   `setQueryData(['admission', profileId], updated)` to surface fresh
+ *   data immediately trong PriorityTab + sibling tabs reading the same
+ *   profile (DocumentsTab, PriorityFinanceTab, FinalizeTab).
+ * * onError với 409 should NOT clear cache — `react-query-mutation-cache-parity`
+ *   says invalidate detail key + display refresh toast (caller's
+ *   responsibility, hook just propagates the error).
+ *
+ * BE dispatches PRIORITY_KV_OVERRIDDEN event post-commit (Wave 1 catalog
+ * seed) → consumers receive notification + socket data_updated broadcast.
+ */
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { priorityOverrideApi } from "@/lib/api/priority-override"
+import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+import type { OverridePriorityKvRequest } from "@/lib/zod/priority-override"
+
+/** Cache keys mirror existing admission detail convention. */
+const admissionDetailKey = (id: number) => ["admission", id] as const
+
+export function useOverridePriorityKv(profileId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    AdmissionProfileResponse,
+    Error,
+    OverridePriorityKvRequest
+  >({
+    mutationFn: (body) => priorityOverrideApi.overrideKv(profileId, body),
+    onSuccess: async (updated) => {
+      // Cache parity per memory `react-query-mutation-cache-parity`:
+      // set fresh data to surface immediately + invalidate to refetch
+      // background (covers race với concurrent socket data_updated).
+      queryClient.setQueryData(admissionDetailKey(profileId), updated)
+      await queryClient.invalidateQueries({
+        queryKey: admissionDetailKey(profileId),
+      })
+      // Sibling caches that depend on snapshot also need refresh —
+      // e.g., PriorityTab live-preview query (preview-priority-kv).
+      // Use predicate match để avoid hardcoding every key.
+      await queryClient.invalidateQueries({
+        predicate: (query) =>
+          Array.isArray(query.queryKey) &&
+          query.queryKey[0] === "preview-priority-kv" &&
+          query.queryKey[1] === profileId,
+      })
+    },
+  })
+}

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -105,6 +105,55 @@ export type PriorityObjectEvidenceEntry = z.infer<
 >
 
 /**
+ * Priority Resolution Snapshot Schema
+ *
+ * BE column: ``admission_profile.priority_resolution_snapshot`` (JSONB).
+ * Set by ``priority_service.freeze_priority_snapshot()`` at T1/T6 +
+ * extended by ``priority_override_service.override_kv()`` (Phase E.2)
+ * với 4 manual override keys.
+ *
+ * All fields optional + ``passthrough()`` for forward-compat (engine
+ * may extend breakdown shape; nullable to handle pre-Phase-A profiles).
+ *
+ * Q9 #07 Phase E.2 (2026-05-19) adds 4 keys for chain-of-override
+ * semantics (Decision D1):
+ * * ``manual_override_by`` — actor user.id (overwritten on each override)
+ * * ``manual_override_at`` — ISO timestamp (refreshed each override)
+ * * ``manual_override_reason`` — 20-500 char user-supplied justification
+ * * ``evidence_file_id`` — optional FK soft reference to supporting doc
+ *
+ * Audit log preserves full chain via ``priority_audit_log`` table.
+ */
+export const prioritySnapshotSchema = z
+  .object({
+    // Engine-set keys (Phase C/D)
+    kv_resolved: z.string().nullable().optional(),
+    rule_applied: z.string().nullable().optional(),
+    pathway: z.string().nullable().optional(),
+    breakdown: z.record(z.string(), z.unknown()).nullable().optional(),
+    frozen_at: z.string().datetime({ offset: true }).nullable().optional(),
+    frozen_at_status: z.string().nullable().optional(),
+    resolved_by: z.string().nullable().optional(),
+    requires_manual_override: z.boolean().nullable().optional(),
+    reason: z.string().nullable().optional(),
+    // Phase E.2 manual override keys
+    manual_override_by: z
+      .union([z.number().int(), z.string()])
+      .nullable()
+      .optional(),
+    manual_override_at: z
+      .string()
+      .datetime({ offset: true })
+      .nullable()
+      .optional(),
+    manual_override_reason: z.string().nullable().optional(),
+    evidence_file_id: z.number().int().nullable().optional(),
+  })
+  .passthrough()
+
+export type PriorityResolutionSnapshot = z.infer<typeof prioritySnapshotSchema>
+
+/**
  * Academic Record Schema
  * Stored in admission_profile.academic_history JSONB array
  *
@@ -602,7 +651,7 @@ export const admissionProfileResponseSchema = z.object({
   priority_object_evidence: z
     .record(z.string(), priorityObjectEvidenceEntrySchema)
     .default({}),
-  priority_resolution_snapshot: z.record(z.string(), z.unknown()).default({}),
+  priority_resolution_snapshot: prioritySnapshotSchema.nullable().default(null),
 
   union_entry_date: z.string().datetime({ offset: true }).nullable(),
   party_entry_date: z.string().datetime({ offset: true }).nullable(),

--- a/frontend/src/lib/zod/priority-override.ts
+++ b/frontend/src/lib/zod/priority-override.ts
@@ -1,0 +1,42 @@
+/**
+ * Q9 #07 Phase E.2 — Manual KV override Zod schema.
+ *
+ * Mirrors BE Pydantic `OverridePriorityKvRequest` trong
+ * `Backend_FastAPI/app/schemas/admission.py` — keep in sync.
+ *
+ * Cross-field invariants enforced by BE service-layer:
+ * * Version guard FIRST → 409 ConflictError nếu mismatch
+ * * Status whitelist (officer: submitted/reviewing/revision_requested;
+ *   admin bypass với acknowledge_post_publish=true cho post-publish)
+ * * Reason 20-500 char mandatory (persisted in snapshot + audit log)
+ */
+import { z } from "zod"
+
+/** KV codes — matches `KV_BADGE` keys trong `kv-labels.ts`. */
+export const KV_CODES = ["KV1", "KV2-NT", "KV2", "KV3"] as const
+export type KvCode = (typeof KV_CODES)[number]
+
+export const overridePriorityKvRequestSchema = z.object({
+  /** Optimistic lock — must match profile.version. 409 on mismatch. */
+  version: z.number().int().min(0),
+  /** New KV code to assign manually. */
+  kv_resolved: z.enum(KV_CODES),
+  /** 20-500 char justification. Persisted in snapshot + audit log. */
+  reason: z
+    .string()
+    .trim()
+    .min(20, "Lý do override phải có ít nhất 20 ký tự")
+    .max(500, "Lý do override không được vượt quá 500 ký tự"),
+  /** Optional FK soft-reference to supporting evidence document. */
+  evidence_file_id: z.number().int().positive().nullable().optional(),
+  /**
+   * Admin-only escape hatch for post-publish profile (enrolled/approved/
+   * confirmed/...). Officer always refused for those states. UI gates
+   * via secondary checkbox trong PriorityOverrideDialog.
+   */
+  acknowledge_post_publish: z.boolean().default(false),
+})
+
+export type OverridePriorityKvRequest = z.infer<
+  typeof overridePriorityKvRequestSchema
+>


### PR DESCRIPTION
## Summary

Q9 #07 Phase E.2 — **Wave 2 of 5-wave plan v3 (Noble Sonnet)**.
Manual KV override service + endpoint + dialog. Officer/admin có thể override candidate's KV với mandatory 20-500 char reason + optimistic lock + audit log.

Builds on Wave 1 (PR #310 merged) Foundation + Casbin seed + wireframe Step 4 candidate FE.

## Architecture

**BE service** ``priority_override_service.override_kv()`` returns ``(profile, post_commit_cb)`` per Backend CLAUDE.md. Enforces:
* Version guard FIRST (memory ``version-guard-before-state-machine``)
* Status whitelist:
  * Officer ALLOW: ``{submitted, reviewing, revision_requested}``
  * Hard-deny BOTH: ``{draft, withdrawn, dropped, rejected}``
  * Post-publish (enrolled/approved/confirmed/...) → admin-only +
    ``acknowledge_post_publish=True`` per Decision D2
* Reason 20-500 char validation
* Snapshot overwrite với 4 ``manual_override_*`` keys (Decision D1 — LAST wins; chain-of-override history via ``priority_audit_log`` composite index)
* INSERT ``priority_audit_log`` (action_type=``kv_manual_override``)
* Bump ``profile.version`` (optimistic lock)
* Post-commit ``safe_dispatch(SystemEvents.PRIORITY_KV_OVERRIDDEN)``

**BE endpoint** ``POST /api/v2/admissions/{profile_id}/override-priority-kv``:
* IDOR ``get_admission_for_user`` + ``CasbinAuth`` (Wave 1 ``q9_07_e0c`` seed)
* Maps service ``PermissionError`` → 403 for officer post-publish
* Reloads profile với eager-loaded relations + ``_populate_response_fields`` per "Mutation response contract"

**FE Dialog** ``PriorityOverrideDialog`` (~316 lines):
* Radix ResponsiveDialog với KV Select + reason Textarea + char counter
* BEFORE→AFTER inline preview
* Admin escape hatch: secondary checkbox cho post-publish profile
* 409/403/400 error handlers + cache invalidate per memory ``react-query-mutation-cache-parity``

## Decisions

* **D1 (chain-of-override)**: snapshot OVERWRITES with LAST override (per plan v3 line 68-76); audit log PRESERVE full history queryable via composite index. UI BEFORE→AFTER reads ``snapshot.kv_resolved`` as current; audit timeline endpoint defer to Wave 5.

* **D2 (admin post-publish ack)**: admin can override profile in ``{enrolled, approved, confirmed, ...}`` post-publish states với ``acknowledge_post_publish=true`` body flag. Officer always 403 for those states (per plan v3 line 78-92).

## Tests

| Suite | Status |
|---|---|
| ``pytest tests/unit/test_priority_override_service.py`` | ✅ **20/20 PASS** |
| ``vitest PriorityOverrideDialog.test.tsx`` | ✅ **8/8 PASS** |

pytest covers: version conflict, reason validation (min 20, max 500), invalid KV, hard-denied status × officer + admin, officer post-publish → PermissionError, admin post-publish without ack → BusinessRuleViolation, officer happy path, admin post-publish with ack, chain-of-override semantics (Decision D1).

vitest covers: render dialog, BEFORE→AFTER preview, reason validation gate, KV-changed gate, admin post-publish ack required, officer mode hides ack, non-post-publish hides ack, 409 stateful mock error path.

## Files (14 changed, 1649+ / 6-)

**BE new** (430 lines):
* ``app/services/priority_override_service.py`` (~334)
* ``tests/unit/test_priority_override_service.py`` (~406, includes test data)

**BE edits** (180):
* ``app/routers/admissions_v2.py`` (+98 endpoint)
* ``app/schemas/admission.py`` (+65 OverridePriorityKvRequest + snapshot doc)
* ``app/schemas/__init__.py`` (+2 export)
* ``app/services/admission_service.py`` (+16 permissions)
* ``app/models/admission.py`` (+10 snapshot docstring)

**FE new** (487):
* ``app/(dashboard)/admissions/[id]/_components/PriorityOverrideDialog.tsx`` (~316)
* ``app/(dashboard)/admissions/[id]/_components/PriorityOverrideDialog.test.tsx`` (~187)
* ``lib/zod/priority-override.ts`` (~42)
* ``lib/api/priority-override.ts`` (~33)
* ``lib/hooks/use-priority-override.ts`` (~57)

**FE edits** (89):
* ``lib/zod/admissions.ts`` (+51 typed ``prioritySnapshotSchema``)
* ``app/(dashboard)/admissions/[id]/_components/tabs/PriorityTab.tsx`` (+38 trigger button wire)

## Smoke (deferred)

Chrome MCP smoke deferred — local FE container Tailwind/Turbopack cache wedged on stale ``admission-rounds.ts`` ENOENT after stash/rebase cycle (separate dev tooling issue, not Wave 2 regression). Workaround attempted: ``docker cp`` to sync files + container recreate — Tailwind cache still stuck.

Vitest 8/8 covers all Dialog state transitions (form validation, post-publish gating, 409 stateful mock); BE pytest 20/20 covers service correctness. CI will run type-check + vitest + build via FE workflow + pytest BE on push.

Will validate Chrome MCP smoke post-merge or after docker compose watch restart.

## Plan v3 status

* ✅ Wave 1: PR #310 merged (Foundation + E.1 + wireframe Step 4 candidate FE)
* ✅ **Wave 2: this PR** (manual KV override)
* ⬜ Wave 3: PR-E.3 UT officer verify/reject (~1.5d)
* ⬜ Wave 4: PR-F admin backfill (~3.2d)
* ⬜ Wave 5: UT catalog seed + final smoke (~0.7d)

Launch target 2026-05-29 buffer ~9 weeks before mùa 2026-08-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)