### PR TITLE
feat(q9-07/phase-e3): UT evidence verify/reject (officer write-path)

### DIFF
--- a/.github/workflows/admission-contract-check.yml
+++ b/.github/workflows/admission-contract-check.yml
@@ -101,16 +101,11 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run check_notification_event_coverage
-        # ``--allow-deferred`` permits ADMISSION_* + PRIORITY_* events
-        # whose dispatch sites haven't shipped yet. Locked by
-        # ``state_service.DEFERRED_ADMISSION_EVENTS`` + the lock test
-        # ``test_check_notification_event_coverage_deferred.py``.
-        #
-        # Q9 #07 Phase E Wave 1 (2026-05-19): 3 PRIORITY_* events seeded
-        # to catalog/seed_defaults; dispatch ships Wave 2 (override_kv)
-        # + Wave 3 (verify/reject evidence). Sync this flag with
-        # deploy.yml + backend-test.yml per memory
+        # Q9 #07 Phase E Wave 3 (2026-05-19): all 3 PRIORITY_* events
+        # fully wired via dispatch_event outbox (Wave 2 KV_OVERRIDDEN +
+        # Wave 3 OBJECT_VERIFIED/REJECTED). DEFERRED set back to empty;
+        # --allow-deferred flag no longer needed.
+        # Sync with backend-test.yml per memory
         # `ci-workflow-flag-cross-file-sync`.
         run: |
-          python -m app.scripts.check_notification_event_coverage \
-            --allow-deferred=PRIORITY_OBJECT_VERIFIED,PRIORITY_OBJECT_REJECTED
+          python -m app.scripts.check_notification_event_coverage

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -195,13 +195,12 @@ jobs:
 
       - name: pytest — Notification event coverage script
         working-directory: Backend_FastAPI
-        # Q9 #07 Phase E Wave 1 — 3 PRIORITY_* events seeded to catalog
-        # but dispatch ships Wave 2+3. Sync flag with
-        # admission-contract-check.yml + deploy.yml per memory
+        # Wave 3 (2026-05-19): all 3 PRIORITY_* events wired via outbox
+        # → no more --allow-deferred needed. Sync với
+        # admission-contract-check.yml per memory
         # `ci-workflow-flag-cross-file-sync`.
         run: |
-          python -m app.scripts.check_notification_event_coverage \
-            --allow-deferred=PRIORITY_OBJECT_VERIFIED,PRIORITY_OBJECT_REJECTED
+          python -m app.scripts.check_notification_event_coverage
 
       # =====================================================================
       # Tier 4: Admission + lead workflow contract (legacy deploy.yml subset)

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -975,3 +975,129 @@ async def override_priority_kv(
         db, reloaded, current_user=current_user
     )
     return reloaded
+
+
+# =============================================================================
+# Q9 #07 Phase E.3 — UT evidence verify/reject (officer write-path)
+# =============================================================================
+
+
+async def _evidence_response(
+    db: AsyncSession,
+    profile_id: int,
+    current_user: models.User,
+) -> models.AdmissionProfile:
+    """Shared reload + _populate_response_fields cho verify/reject responses."""
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+    from app.services import admission_service
+
+    stmt = (
+        select(models.AdmissionProfile)
+        .where(models.AdmissionProfile.id == profile_id)
+        .options(
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
+    )
+    reloaded = (await db.execute(stmt)).scalar_one()
+    await admission_service._populate_response_fields(
+        db, reloaded, current_user=current_user
+    )
+    return reloaded
+
+
+@router.patch(
+    "/{profile_id}/priority-objects/{sub_code}/verify",
+    response_model=schemas.AdmissionProfileResponse,
+    summary="Duyệt UT evidence (officer write-path — Phase E.3)",
+)
+async def verify_priority_object_evidence(
+    profile_id: int,
+    sub_code: str,
+    payload: schemas.VerifyObjectEvidenceRequest = Body(...),
+    db: AsyncSession = Depends(database.get_db),
+    profile: models.AdmissionProfile = Depends(get_admission_for_user),
+    current_user: models.User = CasbinAuth,
+):
+    """Officer marks ``priority_object_evidence[sub_code]`` as verified.
+
+    Bumps version + INSERTs audit log + recomputes
+    ``priority_resolution_snapshot.ut_verified_bucket`` (engine T6 actual
+    rate freeze). Dispatches PRIORITY_OBJECT_VERIFIED via outbox.
+
+    Security:
+    * IDOR: ``get_admission_for_user`` (3-tier scope)
+    * Casbin: ``q9_07_e0c`` seed (officer/manager/admin ALLOW, accountant DENY)
+
+    Per Decision D3 (plan v3): candidate uploads minh chứng qua existing
+    DocumentsTab (step 6); officer picks ``document_id`` từ
+    ``profile.documents`` tại verify time.
+    """
+    from app.services.priority_override_service import verify_object_evidence
+
+    _, post_commit_cb = await verify_object_evidence(
+        db,
+        profile,
+        sub_code=sub_code,
+        document_id=payload.document_id,
+        actor=current_user,
+        expected_version=payload.version,
+    )
+
+    await db.commit()
+    await post_commit_cb()
+
+    log.info(
+        "admissions_v2.verify_priority_object_evidence",
+        profile_id=profile_id,
+        sub_code=sub_code,
+        actor_id=current_user.id,
+    )
+    return await _evidence_response(db, profile_id, current_user)
+
+
+@router.patch(
+    "/{profile_id}/priority-objects/{sub_code}/reject",
+    response_model=schemas.AdmissionProfileResponse,
+    summary="Từ chối UT evidence (officer write-path — Phase E.3)",
+)
+async def reject_priority_object_evidence(
+    profile_id: int,
+    sub_code: str,
+    payload: schemas.RejectObjectEvidenceRequest = Body(...),
+    db: AsyncSession = Depends(database.get_db),
+    profile: models.AdmissionProfile = Depends(get_admission_for_user),
+    current_user: models.User = CasbinAuth,
+):
+    """Officer marks ``priority_object_evidence[sub_code]`` as rejected.
+
+    Reject reason 10-500 char mandatory. Recomputes ``ut_verified_bucket``
+    — if rejected code was the applied verified code, bucket falls back
+    to next-highest verified (or null if none remain).
+
+    Dispatches PRIORITY_OBJECT_REJECTED via outbox với reject_reason
+    trong payload.
+    """
+    from app.services.priority_override_service import reject_object_evidence
+
+    _, post_commit_cb = await reject_object_evidence(
+        db,
+        profile,
+        sub_code=sub_code,
+        reject_reason=payload.reject_reason,
+        actor=current_user,
+        expected_version=payload.version,
+    )
+
+    await db.commit()
+    await post_commit_cb()
+
+    log.info(
+        "admissions_v2.reject_priority_object_evidence",
+        profile_id=profile_id,
+        sub_code=sub_code,
+        actor_id=current_user.id,
+    )
+    return await _evidence_response(db, profile_id, current_user)

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -171,6 +171,9 @@ from .admission import (
     PriorityObjectCatalogItem,
     # Q9 #07 Phase E.2 — Manual KV override
     OverridePriorityKvRequest,
+    # Q9 #07 Phase E.3 — UT evidence verify/reject
+    VerifyObjectEvidenceRequest,
+    RejectObjectEvidenceRequest,
     EnrollStudentResponse,
     # Bulk action schemas
     BulkApproveRequest,

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -2204,6 +2204,58 @@ class OverridePriorityKvRequest(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
 
+# =============================================================================
+# Q9 #07 Phase E.3 — UT evidence verify/reject (officer write-path)
+# =============================================================================
+
+
+class VerifyObjectEvidenceRequest(BaseModel):
+    """Officer verifies one UT evidence (Phase E.3).
+
+    Marks ``priority_object_evidence[sub_code]`` as ``status='verified'``
+    + optional ``document_id`` reference. Per Decision D3 — candidate
+    uploads via DocumentsTab; officer picks document tại verify time.
+
+    Snapshot ``ut_verified_bucket`` recomputes after each verify (engine
+    T6 actual rate freeze: MAX bonus_points across verified codes).
+    """
+
+    version: int = Field(
+        ...,
+        description="Client-known profile.version for optimistic lock.",
+        ge=0,
+    )
+    document_id: Optional[int] = Field(
+        None,
+        description="Optional FK soft reference to supporting document.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class RejectObjectEvidenceRequest(BaseModel):
+    """Officer rejects one UT evidence với reason (Phase E.3).
+
+    Marks ``priority_object_evidence[sub_code]`` as ``status='rejected'``
+    + ``reject_reason``. If rejected code was the applied verified code,
+    ``ut_verified_bucket`` recomputes to next-highest verified or null.
+    """
+
+    version: int = Field(
+        ...,
+        description="Client-known profile.version for optimistic lock.",
+        ge=0,
+    )
+    reject_reason: str = Field(
+        ...,
+        min_length=10,
+        max_length=500,
+        description="Reason for rejection (10-500 chars).",
+    )
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+
 __all__ = [
     # Nested schemas
     "FamilyMemberSchema",
@@ -2256,4 +2308,7 @@ __all__ = [
     "PriorityObjectCatalogItem",
     # Q9 #07 Phase E.2 — Manual KV override
     "OverridePriorityKvRequest",
+    # Q9 #07 Phase E.3 — UT evidence verify/reject
+    "VerifyObjectEvidenceRequest",
+    "RejectObjectEvidenceRequest",
 ]

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1503,6 +1503,16 @@ def _compute_frontend_fields(
                 and status in ["submitted", "reviewing", "revision_requested"]
             )
         ),
+        # Q9 #07 Phase E.3 — UT evidence verify/reject (officer write-path).
+        # Used by FE UtEvidenceTab (Step 8 officer-only). Service-layer
+        # (priority_override_service._evidence_mutation_common_checks) refuses
+        # draft/withdrawn/dropped. Officer scope: assigned to profile;
+        # manager/admin via diamond/wildcard.
+        "verify_priority_object": (
+            is_admin
+            or is_manager
+            or (is_officer and is_owner)
+        ) and status not in ["draft", "withdrawn", "dropped"],
         "drop": status == "enrolled" and not _is_dropped and (is_manager or is_admin),
         "claim": (status in ["submitted", "resubmitted"] and (is_manager or is_admin)
                   and not profile.assigned_reviewer_id),

--- a/Backend_FastAPI/app/services/admission_state_service.py
+++ b/Backend_FastAPI/app/services/admission_state_service.py
@@ -269,12 +269,11 @@ TRANSITION_PAIR_TO_EVENT: Dict[Tuple[str, str], SystemEvents] = {
 # (Foundation seed) but dispatch sites ship Wave 2 (override_kv) + Wave 3
 # (verify/reject evidence). Track here until those waves merge — coverage
 # gate stays green via ``--allow-deferred`` in CI workflows.
-DEFERRED_ADMISSION_EVENTS: frozenset[str] = frozenset({
-    # Wave 2 (2026-05-19) wired PRIORITY_KV_OVERRIDDEN via dispatch_event
-    # outbox path → dropped from deferred set.
-    "PRIORITY_OBJECT_VERIFIED",   # Wave 3 (E.3 verify evidence)
-    "PRIORITY_OBJECT_REJECTED",   # Wave 3 (E.3 reject evidence)
-})
+# Wave 2 (2026-05-19) wired PRIORITY_KV_OVERRIDDEN via dispatch_event
+# outbox. Wave 3 (2026-05-19) wired PRIORITY_OBJECT_VERIFIED +
+# PRIORITY_OBJECT_REJECTED in verify_object_evidence + reject_object_evidence.
+# All 3 PRIORITY_* events fully wired → deferred set back to empty.
+DEFERRED_ADMISSION_EVENTS: frozenset[str] = frozenset()
 
 
 # ---------------------------------------------------------------------------

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -106,6 +106,19 @@ _HARD_DENIED_STATUS: frozenset[str] = frozenset({
 _MIN_REASON_LEN = 20
 _MAX_REASON_LEN = 500
 
+# UT evidence states & reject reason validation (Phase E.3)
+_EVIDENCE_STATUSES: frozenset[str] = frozenset({"pending", "verified", "rejected"})
+_MIN_REJECT_REASON_LEN = 10
+_MAX_REJECT_REASON_LEN = 500
+
+# Officer can verify/reject UT evidence in any status except hard-denied
+# (draft means candidate still editing — verify makes no sense).
+_EVIDENCE_DENIED_STATUS: frozenset[str] = frozenset({
+    "draft",
+    "withdrawn",
+    "dropped",
+})
+
 
 # ---------------------------------------------------------------------------
 # Public service entrypoint
@@ -338,3 +351,322 @@ async def override_kv(
         post_commit = _noop_callback
 
     return profile, post_commit
+
+
+# ---------------------------------------------------------------------------
+# UT evidence — verify + reject (Phase E.3)
+# ---------------------------------------------------------------------------
+
+
+async def _recompute_ut_verified_bucket(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+) -> dict[str, Any]:
+    """Recompute ``ut_verified_bucket`` snapshot field after verify/reject.
+
+    Engine T6 actual rate freeze (Phase E wireframe ut_verified_bucket key):
+    MAX bonus_points across codes với ``priority_object_evidence[code].status
+    == 'verified'``. If no verified codes, returns ``{applied_code: None,
+    applied_rate: 0}``.
+
+    Catalog rate lookup honors ``effective_from``/``effective_to`` window —
+    same query shape as ``admissions_v2.preview_priority_kv``.
+    """
+    from datetime import date as _date
+    from sqlalchemy import select as _sel
+    from app.models.priority_config import PriorityObjectConfig
+
+    evidence = profile.priority_object_evidence or {}
+    submitted_codes = list(profile.priority_object_codes or [])
+    verified_codes = [
+        c
+        for c in submitted_codes
+        if isinstance(evidence.get(c), dict)
+        and evidence[c].get("status") == "verified"
+    ]
+
+    if not verified_codes:
+        return {"applied_code": None, "applied_rate": 0}
+
+    # Academic year: fall back chain mirrors preview endpoint.
+    academic_year = profile.academic_year or 2026
+    today = _date.today()
+    stmt = (
+        _sel(PriorityObjectConfig.sub_code, PriorityObjectConfig.bonus_points)
+        .where(
+            PriorityObjectConfig.academic_year == academic_year,
+            PriorityObjectConfig.sub_code.in_(verified_codes),
+            PriorityObjectConfig.effective_from <= today,
+        )
+        .where(
+            (PriorityObjectConfig.effective_to.is_(None))
+            | (PriorityObjectConfig.effective_to > today)
+        )
+    )
+    rows = (await db.execute(stmt)).all()
+    if not rows:
+        return {"applied_code": None, "applied_rate": 0}
+
+    top = max(rows, key=lambda r: r[1])
+    return {"applied_code": top[0], "applied_rate": float(top[1])}
+
+
+async def _evidence_mutation_common_checks(
+    profile: models.AdmissionProfile,
+    sub_code: str,
+    actor: models.User,
+    expected_version: int,
+) -> None:
+    """Shared pre-mutation guard for verify + reject.
+
+    Raises ConflictError on version mismatch (FIRST per memory
+    `version-guard-before-state-machine`); BusinessRuleViolation on
+    hard-denied status, invalid sub_code, or sub_code not in profile's
+    submitted codes list.
+    """
+    if expected_version != profile.version:
+        raise ConflictError(
+            f"Profile was modified by another user. "
+            f"Expected version {expected_version}, "
+            f"but current version is {profile.version}. "
+            "Please refresh and try again."
+        )
+
+    if profile.status in _EVIDENCE_DENIED_STATUS:
+        raise BusinessRuleViolation(
+            f"Cannot verify/reject UT evidence in '{profile.status}' state."
+        )
+
+    if not sub_code or not isinstance(sub_code, str):
+        raise BusinessRuleViolation("sub_code is required and must be a string")
+
+    submitted = list(profile.priority_object_codes or [])
+    if sub_code not in submitted:
+        raise BusinessRuleViolation(
+            f"sub_code '{sub_code}' is not in profile's submitted codes "
+            f"({submitted}); candidate must select diện first."
+        )
+
+
+async def verify_object_evidence(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    *,
+    sub_code: str,
+    document_id: Optional[int],
+    actor: models.User,
+    expected_version: int,
+) -> Tuple[models.AdmissionProfile, Callable[[], Awaitable[None]]]:
+    """Officer verifies UT evidence cho 1 sub_code (Phase E.3).
+
+    Marks ``priority_object_evidence[sub_code]`` as ``status='verified'``
+    with verifier metadata + optional ``document_id`` reference (per
+    Decision D3 — candidate uploads via DocumentsTab, officer picks
+    document từ existing profile.documents).
+
+    Recomputes ``priority_resolution_snapshot.ut_verified_bucket`` (engine
+    T6 actual rate freeze). Bumps version + INSERTs audit log + dispatches
+    PRIORITY_OBJECT_VERIFIED event via outbox.
+
+    Raises:
+        ConflictError: version mismatch.
+        BusinessRuleViolation: sub_code not submitted / hard-denied status.
+    """
+    await _evidence_mutation_common_checks(
+        profile, sub_code, actor, expected_version
+    )
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    evidence = dict(profile.priority_object_evidence or {})
+    prev_entry = dict(evidence.get(sub_code) or {})
+
+    evidence[sub_code] = {
+        **prev_entry,
+        "status": "verified",
+        "verified_by": actor.id,
+        "verified_at": now_iso,
+        "document_id": document_id,
+        # Drop any stale reject_reason from prior reject cycle.
+        "reject_reason": None,
+    }
+    profile.priority_object_evidence = evidence
+
+    # Recompute UT verified bucket (engine T6 actual rate)
+    new_bucket = await _recompute_ut_verified_bucket(db, profile)
+    snapshot = dict(profile.priority_resolution_snapshot or {})
+    snapshot["ut_verified_bucket"] = new_bucket
+    profile.priority_resolution_snapshot = snapshot
+
+    audit_row = models.PriorityAuditLog(
+        profile_id=profile.id,
+        action_type="ut_evidence_verified",
+        actor_id=actor.id,
+        old_value={"sub_code": sub_code, "status": prev_entry.get("status")},
+        new_value={
+            "sub_code": sub_code,
+            "status": "verified",
+            "document_id": document_id,
+        },
+        audit_metadata={
+            "actor_role": actor.role,
+            "ut_verified_bucket": new_bucket,
+        },
+    )
+    db.add(audit_row)
+    profile.version += 1
+
+    from app.services.notification_dispatcher import dispatch_event
+
+    _payload = {
+        "application_id": profile.id,
+        "lead_id": profile.lead_id,
+        "actor_id": actor.id,
+        "actor_name": actor.full_name or actor.email,
+        "sub_code": sub_code,
+    }
+    _dedupe_key = (
+        f"priority:{profile.id}:ut_verified:{sub_code}:{actor.id}:"
+        f"{int(datetime.now(timezone.utc).timestamp())}"
+    )
+    post_commit = await dispatch_event(
+        db,
+        event=SystemEvents.PRIORITY_OBJECT_VERIFIED,
+        payload=_payload,
+        dedupe_key=_dedupe_key,
+    )
+
+    await db.flush()
+
+    log.info(
+        "priority_override_service.verify_object_evidence_success",
+        profile_id=profile.id,
+        actor_id=actor.id,
+        sub_code=sub_code,
+        applied_code=new_bucket.get("applied_code"),
+        applied_rate=new_bucket.get("applied_rate"),
+        version_after=profile.version,
+    )
+
+    async def _noop_callback() -> None:
+        return None
+
+    return profile, (post_commit or _noop_callback)
+
+
+async def reject_object_evidence(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    *,
+    sub_code: str,
+    reject_reason: str,
+    actor: models.User,
+    expected_version: int,
+) -> Tuple[models.AdmissionProfile, Callable[[], Awaitable[None]]]:
+    """Officer rejects UT evidence cho 1 sub_code (Phase E.3).
+
+    Marks ``priority_object_evidence[sub_code]`` as ``status='rejected'``
+    with ``reject_reason`` (min 10 / max 500 chars). Recomputes
+    ``ut_verified_bucket`` — if the rejected code was the current applied
+    verified code, the bucket recomputes to the next-highest verified
+    code (or null if none remain).
+
+    Per plan v3 Wave 3 spec line 245-247.
+
+    Raises:
+        ConflictError: version mismatch.
+        BusinessRuleViolation: sub_code not submitted / reason length /
+            hard-denied status.
+    """
+    await _evidence_mutation_common_checks(
+        profile, sub_code, actor, expected_version
+    )
+
+    reason_clean = (reject_reason or "").strip()
+    if len(reason_clean) < _MIN_REJECT_REASON_LEN:
+        raise BusinessRuleViolation(
+            f"Reject reason must be at least {_MIN_REJECT_REASON_LEN} "
+            f"characters (got {len(reason_clean)})"
+        )
+    if len(reason_clean) > _MAX_REJECT_REASON_LEN:
+        raise BusinessRuleViolation(
+            f"Reject reason must not exceed {_MAX_REJECT_REASON_LEN} "
+            f"characters (got {len(reason_clean)})"
+        )
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    evidence = dict(profile.priority_object_evidence or {})
+    prev_entry = dict(evidence.get(sub_code) or {})
+
+    evidence[sub_code] = {
+        **prev_entry,
+        "status": "rejected",
+        "verified_by": None,
+        "verified_at": None,
+        "reject_reason": reason_clean,
+        "rejected_by": actor.id,
+        "rejected_at": now_iso,
+    }
+    profile.priority_object_evidence = evidence
+
+    # Recompute UT verified bucket — if rejected code was applied verified,
+    # bucket falls back to next-highest verified (or null if no verified left).
+    new_bucket = await _recompute_ut_verified_bucket(db, profile)
+    snapshot = dict(profile.priority_resolution_snapshot or {})
+    snapshot["ut_verified_bucket"] = new_bucket
+    profile.priority_resolution_snapshot = snapshot
+
+    audit_row = models.PriorityAuditLog(
+        profile_id=profile.id,
+        action_type="ut_evidence_rejected",
+        actor_id=actor.id,
+        old_value={"sub_code": sub_code, "status": prev_entry.get("status")},
+        new_value={
+            "sub_code": sub_code,
+            "status": "rejected",
+            "reject_reason": reason_clean,
+        },
+        audit_metadata={
+            "actor_role": actor.role,
+            "ut_verified_bucket": new_bucket,
+        },
+    )
+    db.add(audit_row)
+    profile.version += 1
+
+    from app.services.notification_dispatcher import dispatch_event
+
+    _payload = {
+        "application_id": profile.id,
+        "lead_id": profile.lead_id,
+        "actor_id": actor.id,
+        "actor_name": actor.full_name or actor.email,
+        "sub_code": sub_code,
+        "reject_reason": reason_clean,
+    }
+    _dedupe_key = (
+        f"priority:{profile.id}:ut_rejected:{sub_code}:{actor.id}:"
+        f"{int(datetime.now(timezone.utc).timestamp())}"
+    )
+    post_commit = await dispatch_event(
+        db,
+        event=SystemEvents.PRIORITY_OBJECT_REJECTED,
+        payload=_payload,
+        dedupe_key=_dedupe_key,
+    )
+
+    await db.flush()
+
+    log.info(
+        "priority_override_service.reject_object_evidence_success",
+        profile_id=profile.id,
+        actor_id=actor.id,
+        sub_code=sub_code,
+        applied_code_after=new_bucket.get("applied_code"),
+        version_after=profile.version,
+        reason_len=len(reason_clean),
+    )
+
+    async def _noop_callback() -> None:
+        return None
+
+    return profile, (post_commit or _noop_callback)

--- a/Backend_FastAPI/tests/unit/test_admission_state_service_event_mapping.py
+++ b/Backend_FastAPI/tests/unit/test_admission_state_service_event_mapping.py
@@ -120,13 +120,11 @@ def test_approved_and_overridden_share_admitted_event() -> None:
 
 
 def test_deferred_admission_events_locked_set() -> None:
-    """Wave 2 (2026-05-19) wired PRIORITY_KV_OVERRIDDEN via outbox path;
-    2 UT evidence events remain deferred until Wave 3.
+    """Wave 3 (2026-05-19) wired both PRIORITY_OBJECT_VERIFIED +
+    PRIORITY_OBJECT_REJECTED via dispatch_event outbox. All 3 PRIORITY_*
+    events fully wired → deferred set back to empty.
     """
-    assert state_service.DEFERRED_ADMISSION_EVENTS == frozenset({
-        "PRIORITY_OBJECT_VERIFIED",
-        "PRIORITY_OBJECT_REJECTED",
-    })
+    assert state_service.DEFERRED_ADMISSION_EVENTS == frozenset()
 
 
 def test_deferred_set_is_frozenset() -> None:
@@ -157,26 +155,24 @@ def test_mapping_and_deferred_are_disjoint() -> None:
     assert overlap == set(), f"Events both mapped and deferred: {overlap!r}"
 
 
-def test_total_admission_events_is_15() -> None:
-    """Catalog ships 15 admission-tracked events post-Wave 2 (2026-05-19):
+def test_total_admission_events_is_13() -> None:
+    """Catalog ships 13 admission-tracked events post-Wave 3 (2026-05-19):
     - 10 distinct events via LEGACY_STATUS_TO_EVENT (target-keyed)
     - 2 source-aware via TRANSITION_PAIR_TO_EVENT (T10 PROMOTED + T11 WAITLIST_REJECTED)
     - 1 source-aware via TRANSITION_PAIR_TO_EVENT (T17 ROLLED_BACK)
-    - 2 deferred (PRIORITY_OBJECT_VERIFIED / _REJECTED, Wave 3 wire)
-
-    Wave 5 (Phase 3) added T11 ADMISSION_WAITLIST_REJECTED.
 
     Wave 1 (Q9 #07 Phase E) added 3 PRIORITY_* events to catalog seed.
-    Wave 2 wired PRIORITY_KV_OVERRIDDEN via outbox dispatch_event → moved
-    out of deferred set. PRIORITY_KV_OVERRIDDEN is not in
-    LEGACY_STATUS_TO_EVENT or TRANSITION_PAIR_TO_EVENT (event fires from
-    service layer, not state transition), so total is 15 events not 16.
+    Wave 2 wired PRIORITY_KV_OVERRIDDEN via outbox dispatch_event.
+    Wave 3 wired PRIORITY_OBJECT_VERIFIED + REJECTED via outbox dispatch_event.
+    None of the 3 PRIORITY events are in LEGACY_STATUS_TO_EVENT or
+    TRANSITION_PAIR_TO_EVENT (fire from service layer, not state transition),
+    so total = 10 mapped + 3 pair = 13.
     """
     mapped = {ev.name for ev in state_service.LEGACY_STATUS_TO_EVENT.values()}
     pair = {ev.name for ev in state_service.TRANSITION_PAIR_TO_EVENT.values()}
     deferred = set(state_service.DEFERRED_ADMISSION_EVENTS)
     total = len(mapped | pair | deferred)
-    assert total == 15
+    assert total == 13
 
 
 # ---------------------------------------------------------------------------

--- a/Backend_FastAPI/tests/unit/test_check_notification_event_coverage_deferred.py
+++ b/Backend_FastAPI/tests/unit/test_check_notification_event_coverage_deferred.py
@@ -67,12 +67,10 @@ def test_deferred_set_canonical_source_is_state_service() -> None:
     same set of names enumerated in
     ``state_service.DEFERRED_ADMISSION_EVENTS``. Without this, the
     coverage flag and the runtime mapping could drift silently."""
-    # Wave 2 (2026-05-19) wired PRIORITY_KV_OVERRIDDEN; only the 2 UT
-    # evidence events remain deferred until Wave 3 ships verify/reject.
-    assert DEFERRED_ADMISSION_EVENTS == frozenset({
-        "PRIORITY_OBJECT_VERIFIED",
-        "PRIORITY_OBJECT_REJECTED",
-    })
+    # Wave 3 (2026-05-19) wired both PRIORITY_OBJECT_VERIFIED +
+    # PRIORITY_OBJECT_REJECTED via dispatch_event outbox. All 3 PRIORITY_*
+    # events now fully wired → deferred set back to empty.
+    assert DEFERRED_ADMISSION_EVENTS == frozenset()
 
 
 def test_deferred_events_disjoint_from_mapped_events() -> None:
@@ -99,28 +97,19 @@ def _capture_stderr(callable_):
 
 
 def test_summarize_passes_when_deferred_events_match(capsys) -> None:
-    """Wave 2 (2026-05-19) shrunk DEFERRED set 3 → 2 (wired
-    PRIORITY_KV_OVERRIDDEN); 2 UT evidence events remain deferred
-    until Wave 3.
+    """Wave 3 (2026-05-19): DEFERRED_ADMISSION_EVENTS shrunk to empty
+    (all 3 PRIORITY_* events wired via dispatch_event outbox path).
+    Empty allow-list + no statuses → rc=0 clean output.
     """
-    # Build stand-in statuses with ONLY the single no-dispatch-site gap
-    # (allow-list only excuses that exact single gap).
-    statuses = [_status(name) for name in DEFERRED_ADMISSION_EVENTS]
-    assert len(statuses) == 2
-    for st in statuses:
-        assert st.gaps == ["no-dispatch-site"]
+    assert DEFERRED_ADMISSION_EVENTS == frozenset()
 
     rc, output = _capture_stderr(
-        lambda: coverage._summarize(
-            statuses,
-            allow_deferred=set(DEFERRED_ADMISSION_EVENTS),
-        )
+        lambda: coverage._summarize([], allow_deferred=set(DEFERRED_ADMISSION_EVENTS))
     )
 
     assert rc == 0
-    # No "with gaps:" failure block — only "Deferred (allow-listed)".
+    # No "with gaps:" failure block.
     assert "event(s) with gaps:" not in output
-    assert "Deferred (allow-listed)" in output
 
 
 def test_summarize_fails_when_deferred_event_actually_wired(capsys) -> None:

--- a/Backend_FastAPI/tests/unit/test_priority_evidence_service.py
+++ b/Backend_FastAPI/tests/unit/test_priority_evidence_service.py
@@ -1,0 +1,301 @@
+"""Unit tests for ``priority_override_service.verify_object_evidence`` +
+``reject_object_evidence`` (Q9 #07 Phase E.3).
+
+Stub AsyncSession + profile per ``test_priority_override_service`` style.
+Coverage:
+1. Version guard FIRST (per memory `version-guard-before-state-machine`).
+2. sub_code-not-in-codes → BusinessRuleViolation.
+3. Hard-denied status → BusinessRuleViolation.
+4. Reject reason length validation.
+5. Happy verify: evidence dict mutated, snapshot.ut_verified_bucket
+   recomputed, audit log INSERT, version bump.
+6. Happy reject: same shape + reject_reason persisted.
+7. Reject after verify: bucket recomputes (chain).
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.priority_override_service import (
+    reject_object_evidence,
+    verify_object_evidence,
+)
+from app.utils.exceptions import BusinessRuleViolation, ConflictError
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_profile(
+    *,
+    status: str = "submitted",
+    version: int = 5,
+    codes: list = None,
+    evidence: dict = None,
+):
+    return SimpleNamespace(
+        id=42,
+        lead_id=100,
+        status=status,
+        version=version,
+        academic_year=2026,
+        priority_object_codes=codes or ["04", "07"],
+        priority_object_evidence=evidence or {},
+        priority_resolution_snapshot={},
+    )
+
+
+def _make_actor(role: str = "officer", user_id: int = 7):
+    return SimpleNamespace(
+        id=user_id,
+        role=role,
+        full_name=f"User {user_id}",
+        email=f"user{user_id}@example.com",
+    )
+
+
+def _make_db(catalog_rows=None):
+    """Mock DB session — execute() returns catalog rows for UT bucket recompute."""
+    catalog_result = MagicMock()
+    catalog_result.all = MagicMock(return_value=catalog_rows or [])
+
+    async def _execute(stmt, *args, **kwargs):
+        return catalog_result
+
+    db = MagicMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+def _find_audit_rows(db):
+    from app import models
+    return [
+        c[0][0]
+        for c in db.add.call_args_list
+        if isinstance(c[0][0], models.PriorityAuditLog)
+    ]
+
+
+REJECT_REASON_VALID = "Document không hợp lệ (10+ chars)"
+
+
+# ---------------------------------------------------------------------------
+# Version guard
+# ---------------------------------------------------------------------------
+
+
+async def test_verify_version_conflict_raises() -> None:
+    profile = _make_profile(version=5)
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(ConflictError):
+        await verify_object_evidence(
+            db, profile, sub_code="04", document_id=None,
+            actor=actor, expected_version=99,
+        )
+    db.add.assert_not_called()
+
+
+async def test_reject_version_conflict_raises() -> None:
+    profile = _make_profile(version=5)
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(ConflictError):
+        await reject_object_evidence(
+            db, profile, sub_code="04", reject_reason=REJECT_REASON_VALID,
+            actor=actor, expected_version=99,
+        )
+
+
+# ---------------------------------------------------------------------------
+# sub_code-not-in-codes
+# ---------------------------------------------------------------------------
+
+
+async def test_verify_sub_code_not_submitted_raises() -> None:
+    profile = _make_profile(codes=["04"])
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match="not in profile's submitted"):
+        await verify_object_evidence(
+            db, profile, sub_code="99", document_id=None,
+            actor=actor, expected_version=5,
+        )
+
+
+async def test_reject_sub_code_not_submitted_raises() -> None:
+    profile = _make_profile(codes=["04"])
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match="not in profile's submitted"):
+        await reject_object_evidence(
+            db, profile, sub_code="99", reject_reason=REJECT_REASON_VALID,
+            actor=actor, expected_version=5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Hard-denied status (draft/withdrawn/dropped)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", ["draft", "withdrawn", "dropped"])
+async def test_verify_hard_denied_status(status: str) -> None:
+    profile = _make_profile(status=status)
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match=status):
+        await verify_object_evidence(
+            db, profile, sub_code="04", document_id=None,
+            actor=actor, expected_version=5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reject reason length
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_reason_too_short_raises() -> None:
+    profile = _make_profile()
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match="10 characters"):
+        await reject_object_evidence(
+            db, profile, sub_code="04", reject_reason="short",
+            actor=actor, expected_version=5,
+        )
+
+
+async def test_reject_reason_too_long_raises() -> None:
+    profile = _make_profile()
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match="500 characters"):
+        await reject_object_evidence(
+            db, profile, sub_code="04", reject_reason="x" * 501,
+            actor=actor, expected_version=5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Happy verify
+# ---------------------------------------------------------------------------
+
+
+async def test_verify_happy_path_mutates_evidence_and_audit() -> None:
+    profile = _make_profile()
+    actor = _make_actor("officer", user_id=7)
+    # Catalog returns UT04 bonus_points=1.00, UT07=0.50
+    db = _make_db(catalog_rows=[("04", Decimal("1.00"))])
+
+    updated, post_commit = await verify_object_evidence(
+        db, profile, sub_code="04", document_id=42,
+        actor=actor, expected_version=5,
+    )
+
+    # Evidence dict mutated
+    assert updated.priority_object_evidence["04"]["status"] == "verified"
+    assert updated.priority_object_evidence["04"]["verified_by"] == 7
+    assert updated.priority_object_evidence["04"]["document_id"] == 42
+
+    # Snapshot ut_verified_bucket recomputed
+    bucket = updated.priority_resolution_snapshot["ut_verified_bucket"]
+    assert bucket["applied_code"] == "04"
+    assert bucket["applied_rate"] == 1.0
+
+    # Version bumped
+    assert updated.version == 6
+
+    # Audit log row
+    audit_rows = _find_audit_rows(db)
+    assert len(audit_rows) == 1
+    audit = audit_rows[0]
+    assert audit.action_type == "ut_evidence_verified"
+    assert audit.actor_id == 7
+    assert audit.new_value["sub_code"] == "04"
+    assert audit.new_value["status"] == "verified"
+    assert audit.audit_metadata["ut_verified_bucket"]["applied_code"] == "04"
+
+    # Flushed not committed
+    db.flush.assert_awaited_once()
+    db.commit.assert_not_awaited()
+    assert callable(post_commit)
+
+
+# ---------------------------------------------------------------------------
+# Happy reject
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_happy_path_mutates_evidence() -> None:
+    profile = _make_profile()
+    actor = _make_actor("officer", user_id=7)
+    db = _make_db()
+
+    updated, _ = await reject_object_evidence(
+        db, profile, sub_code="04",
+        reject_reason="Minh chứng không khớp với hồ sơ",
+        actor=actor, expected_version=5,
+    )
+
+    entry = updated.priority_object_evidence["04"]
+    assert entry["status"] == "rejected"
+    assert entry["reject_reason"] == "Minh chứng không khớp với hồ sơ"
+    assert entry["rejected_by"] == 7
+
+    assert updated.version == 6
+
+    audit_rows = _find_audit_rows(db)
+    assert len(audit_rows) == 1
+    assert audit_rows[0].action_type == "ut_evidence_rejected"
+    assert audit_rows[0].new_value["reject_reason"] == "Minh chứng không khớp với hồ sơ"
+
+
+# ---------------------------------------------------------------------------
+# Bucket recompute — verify after reject (chain)
+# ---------------------------------------------------------------------------
+
+
+async def test_reject_after_verify_recomputes_bucket() -> None:
+    """If UT04 was verified (applied_code), then rejected, bucket falls
+    back to next-highest verified (or null if none).
+    """
+    profile = _make_profile(
+        codes=["04", "07"],
+        evidence={
+            "04": {"status": "verified", "verified_by": 7},
+            "07": {"status": "verified", "verified_by": 7},
+        },
+    )
+    actor = _make_actor("officer")
+    # Before reject, catalog has both verified. After rejecting "04",
+    # only "07" remains verified. Bucket recomputes to UT07=0.50.
+    db = _make_db(catalog_rows=[("07", Decimal("0.50"))])
+
+    updated, _ = await reject_object_evidence(
+        db, profile, sub_code="04",
+        reject_reason="Reject 04 to test bucket recompute",
+        actor=actor, expected_version=5,
+    )
+
+    bucket = updated.priority_resolution_snapshot["ut_verified_bucket"]
+    assert bucket["applied_code"] == "07"
+    assert bucket["applied_rate"] == 0.5
+
+    # 04 evidence now rejected
+    assert updated.priority_object_evidence["04"]["status"] == "rejected"

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.test.tsx
@@ -182,16 +182,16 @@ describe("AdmissionActions", () => {
     });
   });
 
-  // ===== STEP 8: SUBMIT (was step 7 before Phase D.2 priority tab insert) =====
+  // ===== STEP 9: SUBMIT (Wave 3 bump from 8 → 9 — step 8 now "Duyệt UT" officer) =====
 
-  describe("Step 8: Submit", () => {
+  describe("Step 9: Submit", () => {
     it("shows Check + Submit when submit=true and eligible", () => {
       const profile = buildProfile({
         status: "draft",
         permissions: { submit: true },
         eligibility_status: "eligible",
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.getByText("Kiểm tra toàn bộ")).toBeInTheDocument();
       expect(screen.getByText("Nộp hồ sơ")).toBeInTheDocument();
@@ -206,7 +206,7 @@ describe("AdmissionActions", () => {
         permissions: { submit: true },
         eligibility_status: "ineligible",
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       const submitBtn = screen.getByText("Nộp hồ sơ").closest("button");
       expect(submitBtn).toBeDisabled();
@@ -218,15 +218,15 @@ describe("AdmissionActions", () => {
         permissions: { submit: true },
         eligibility_status: "eligible",
       });
-      const spies = renderActions(profile, 8);
+      const spies = renderActions(profile, 9);
 
       fireEvent.click(screen.getByText("Nộp hồ sơ"));
       expect(spies.onSubmit).toHaveBeenCalled();
     });
 
-    it("hides step nav on step 8", () => {
+    it("hides step nav on step 9 (Finalize/Submit)", () => {
       const profile = buildProfile({ status: "draft", permissions: { submit: true } });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.queryByText("Tiếp tục")).not.toBeInTheDocument();
       expect(screen.queryByText("Quay lại")).not.toBeInTheDocument();
@@ -242,7 +242,7 @@ describe("AdmissionActions", () => {
         status: "rejected",
         permissions: { resubmit: true },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.getByText("Nộp lại hồ sơ")).toBeInTheDocument();
       expect(screen.getByText(getStatusConfig("rejected").label)).toBeInTheDocument();
@@ -253,7 +253,7 @@ describe("AdmissionActions", () => {
         status: "revision_requested",
         permissions: { resubmit: true },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.getByText("Nộp lại hồ sơ")).toBeInTheDocument();
       expect(screen.getByText(getStatusConfig("revision_requested").label)).toBeInTheDocument();
@@ -264,7 +264,7 @@ describe("AdmissionActions", () => {
         status: "rejected",
         permissions: { resubmit: true },
       });
-      const spies = renderActions(profile, 8);
+      const spies = renderActions(profile, 9);
 
       // With mocked AlertDialog, trigger + action both render.
       // "Nộp lại" is the dialog action text (AlertDialogAction).
@@ -282,7 +282,7 @@ describe("AdmissionActions", () => {
         status: "submitted",
         permissions: { approve: true, reject: true, claim: true },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.getByText("Phê duyệt")).toBeInTheDocument();
       // "Từ chối" appears as both reject button text AND may appear in dialog
@@ -297,7 +297,7 @@ describe("AdmissionActions", () => {
         status: "resubmitted",
         permissions: { approve: true, reject: true },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.getByText("Phê duyệt")).toBeInTheDocument();
       expect(screen.getByText(getStatusConfig("resubmitted").label)).toBeInTheDocument();
@@ -308,7 +308,7 @@ describe("AdmissionActions", () => {
         status: "submitted",
         permissions: { unclaim: true },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       // Trigger + dialog action both show "Bỏ nhận"
       expect(screen.getAllByText("Bỏ nhận").length).toBeGreaterThanOrEqual(1);
@@ -319,7 +319,7 @@ describe("AdmissionActions", () => {
         status: "submitted",
         permissions: { claim: true },
       });
-      const spies = renderActions(profile, 8);
+      const spies = renderActions(profile, 9);
 
       // Mocked AlertDialog renders trigger + action with same text "Nhận duyệt"
       const buttons = screen.getAllByText("Nhận duyệt");
@@ -332,7 +332,7 @@ describe("AdmissionActions", () => {
         status: "submitted",
         permissions: { unclaim: true },
       });
-      const spies = renderActions(profile, 8);
+      const spies = renderActions(profile, 9);
 
       const buttons = screen.getAllByText("Bỏ nhận");
       fireEvent.click(buttons[buttons.length - 1]); // last = dialog action
@@ -387,7 +387,7 @@ describe("AdmissionActions", () => {
         status: "confirmed",
         permissions: { enroll: true },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.getByText("Ghi danh")).toBeInTheDocument();
       expect(screen.getByText(getStatusConfig("confirmed").label)).toBeInTheDocument();
@@ -398,7 +398,7 @@ describe("AdmissionActions", () => {
         status: "overridden",
         permissions: { enroll: true },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.getByText("Ghi danh")).toBeInTheDocument();
       expect(screen.getByText(getStatusConfig("overridden").label)).toBeInTheDocument();
@@ -409,7 +409,7 @@ describe("AdmissionActions", () => {
         status: "confirmed",
         permissions: { enroll: true },
       });
-      const spies = renderActions(profile, 8);
+      const spies = renderActions(profile, 9);
 
       fireEvent.click(screen.getByText("Ghi danh"));
       expect(spies.onEnroll).toHaveBeenCalled();
@@ -423,7 +423,7 @@ describe("AdmissionActions", () => {
         status: "approved",
         permissions: { enroll: false, send_confirmation: true },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.queryByText("Ghi danh")).not.toBeInTheDocument();
     });
@@ -437,7 +437,7 @@ describe("AdmissionActions", () => {
         status: "approved",
         permissions: { send_confirmation: true },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       // Mocked child renders a stub button — see vi.mock at top of file.
       expect(screen.getByTestId("send-confirmation-button")).toBeInTheDocument();
@@ -449,7 +449,7 @@ describe("AdmissionActions", () => {
         status: "approved",
         permissions: { send_confirmation: false },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.queryByTestId("send-confirmation-button")).not.toBeInTheDocument();
     });
@@ -459,7 +459,7 @@ describe("AdmissionActions", () => {
         status: "confirmed",
         permissions: { send_confirmation: false, enroll: true },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.queryByTestId("send-confirmation-button")).not.toBeInTheDocument();
       // Sanity: Ghi danh DOES show at confirmed.
@@ -471,7 +471,7 @@ describe("AdmissionActions", () => {
         status: "submitted",
         permissions: { send_confirmation: false, approve: true },
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       expect(screen.queryByTestId("send-confirmation-button")).not.toBeInTheDocument();
     });
@@ -485,7 +485,7 @@ describe("AdmissionActions", () => {
         status: "enrolled",
         permissions: {},
       });
-      renderActions(profile, 8);
+      renderActions(profile, 9);
 
       // Badge — from real getStatusConfig, not hardcoded
       expect(screen.getByText(getStatusConfig("enrolled").label)).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
@@ -146,15 +146,17 @@ export function AdmissionActions({
             </AlertDialog>
           )}
 
-          {/* Back Button - always available for steps 2-6, independent of save permission */}
-          {currentStep > 1 && currentStep < 8 && (
+          {/* Back Button - always available for steps 2-8 (Phase E.3 bump
+              from <8 to <9 — step 8 "Duyệt UT" officer also needs back). */}
+          {currentStep > 1 && currentStep < 9 && (
             <Button variant="outline" onClick={() => onStepChange(currentStep - 1)}>
               <ArrowLeft className="w-4 h-4 mr-2" />
               Quay lại
             </Button>
           )}
 
-          {/* Save Changes - only when profile is editable */}
+          {/* Save Changes - only when profile is editable. Step 8 "Duyệt UT"
+              has individual verify/reject mutations — no form save needed. */}
           {currentStep < 8 && can('save') && (
             <Button variant="outline" onClick={onSave} disabled={isSaving}>
               {isSaving ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Save className="w-4 h-4 mr-2" />}
@@ -162,16 +164,17 @@ export function AdmissionActions({
             </Button>
           )}
 
-          {/* Next Step Button - always available for steps 1-6, independent of save permission */}
-          {currentStep < 8 && (
+          {/* Next Step Button - steps 1-8, advances to next (officer/admin
+              sees 1-8 incl. UT verify; candidate's step 8 filtered → 7→9). */}
+          {currentStep < 9 && (
             <Button onClick={() => onStepChange(currentStep + 1)}>
               Tiếp tục
               <ArrowRight className="w-4 h-4 ml-2" />
             </Button>
           )}
 
-          {/* Step 7 Only: Submit Actions */}
-          {currentStep === 8 && can('submit') && (
+          {/* Phase E.3 bump: Finalize step 8 → 9 */}
+          {currentStep === 9 && can('submit') && (
             <>
               {/* Check Condition */}
               <Button variant="outline" onClick={onCheckCondition}>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
@@ -68,6 +68,7 @@ import { PriorityTab } from "./tabs/PriorityTab"
 import { ScoresTab } from "./tabs/ScoresTab"
 import { DocumentsTab } from "./tabs/DocumentsTab"
 import { TuitionTab } from "./tabs/TuitionTab"
+import { UtEvidenceTab } from "./tabs/UtEvidenceTab"
 import { FinalizeTab } from "./tabs/FinalizeTab"
 
 interface AdmissionDetailClientProps {
@@ -484,7 +485,12 @@ export function AdmissionDetailClient({
           {currentStep === 5 && <ScoresTab form={form} isEditable={can('edit')} appliedRules={profile.applied_rules} profile={profile} />}
           {currentStep === 6 && <DocumentsTab profile={profile} isEditable={can('edit')} />}
           {currentStep === 7 && <TuitionTab profile={profile} />}
-          {currentStep === 8 && (
+          {/* Q9 #07 Phase E.3 — Step 8 officer-only "Duyệt UT" (Decision D2).
+              Candidate sees gap-skip 7→9 trong sidebar (filtered out). */}
+          {currentStep === 8 && profile.permissions?.verify_priority_object && (
+            <UtEvidenceTab profile={profile} />
+          )}
+          {currentStep === 9 && (
             <FinalizeTab
               profile={profile}
               isEligible={isEligible}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionLayout.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/AdmissionLayout.tsx
@@ -52,6 +52,9 @@ export function AdmissionLayout({
                 validationSummary={validationSummary}
                 groupedValidationErrors={groupedValidationErrors}
                 completionPercent={profile?.completion_percent ?? 0}
+                canVerifyPriorityObject={
+                  !!profile?.permissions?.verify_priority_object
+                }
              />
           </aside>
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/PipelineSidebar.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/PipelineSidebar.tsx
@@ -23,8 +23,17 @@ interface PipelineSidebarProps {
     scores?: { category: string; errors: string[]; count: number }
   } | null
   completionPercent: number
+  /**
+   * Q9 #07 Phase E.3 — show "Duyệt UT" step (id=8) for officer/admin.
+   * Falsy → candidate view, step 8 filtered out (gap-skip per Decision D2).
+   */
+  canVerifyPriorityObject?: boolean
 }
 
+// Q9 #07 Phase E.3 Wave 3 (Decision D2): step 8 = "Duyệt UT" (NEW
+// officer-only); step 9 = Finalize (bumped from 8). Officer gate qua
+// filter — candidate sees `1-2-3-4-5-6-7-9` gap-skip (per plan v3 line
+// 88-90); officer/admin sees full 9 steps.
 const STEPS = [
     { id: 1, label: "Thông tin cá nhân", icon: User },
     { id: 2, label: "Gia đình / Giám hộ", icon: Users },
@@ -33,20 +42,28 @@ const STEPS = [
     { id: 5, label: "Điểm & Điều kiện", icon: Calculator },
     { id: 6, label: "Tài liệu pháp lý", icon: FileText },
     { id: 7, label: "Học phí", icon: Wallet },
-    { id: 8, label: "Hoàn tất & Nộp", icon: CheckSquare },
+    { id: 8, label: "Duyệt UT", icon: Award, officerOnly: true },
+    { id: 9, label: "Hoàn tất & Nộp", icon: CheckSquare },
 ]
 
-export function PipelineSidebar({ 
-  currentStep, 
-  onStepChange, 
-  stepsStatus, 
-  validationErrors = [], 
-  validationSummary, 
+export function PipelineSidebar({
+  currentStep,
+  onStepChange,
+  stepsStatus,
+  validationErrors = [],
+  validationSummary,
   groupedValidationErrors,
-  completionPercent 
+  completionPercent,
+  canVerifyPriorityObject = false,
 }: PipelineSidebarProps) {
   const [isIssuesOpen, setIsIssuesOpen] = useState(false)
-  
+
+  // Q9 #07 Phase E.3 — filter officer-only steps for candidate view.
+  const visibleSteps = useMemo(
+    () => STEPS.filter((s) => !s.officerOnly || canVerifyPriorityObject),
+    [canVerifyPriorityObject],
+  )
+
   // Phase 4 Fix: Progressive Disclosure - Focus current ±1 steps
   const completedSteps = Object.values(stepsStatus).filter(status => status === "success").length
   // Removed local calculation to sync with Backend weighted score
@@ -90,7 +107,7 @@ export function PipelineSidebar({
       <div className="px-1">
         <div className="flex justify-between text-xs text-muted-foreground mb-2">
           <span className="font-medium">Tiến độ</span>
-          <span>{completedSteps}/{STEPS.length} ({completionPercent}%)</span>
+          <span>{completedSteps}/{visibleSteps.length} ({completionPercent}%)</span>
         </div>
         <Progress value={completionPercent} className="h-2" />
       </div>
@@ -98,7 +115,7 @@ export function PipelineSidebar({
       {/* Steps Navigation */}
       <nav className="space-y-3">
       <TooltipProvider>
-        {STEPS.map((step) => {
+        {visibleSteps.map((step) => {
           const status = stepsStatus[step.id] || "locked"
           const isActive = currentStep === step.id
           const isFocused = focusedSteps.includes(step.id)

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/UtEvidenceTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/UtEvidenceTab.tsx
@@ -1,0 +1,417 @@
+"use client"
+
+/**
+ * UtEvidenceTab — officer-side UT evidence verify/reject (Q9 #07 Phase E.3).
+ *
+ * **DISTINCT** từ candidate `UtEvidenceCard` (Wave 1 d599d16f): same UT
+ * domain, hai audiences khác. Candidate-side card cho phép multi-select
+ * + pending evidence. Officer-side tab cho phép verify/reject từng diện
+ * candidate đã submit.
+ *
+ * Layout per plan v3 Wave 3:
+ * - Iterate profile.priority_object_codes (candidate submitted)
+ * - Per row: code label + catalog description + status badge + verify/reject buttons
+ * - Reject sub-dialog: reason textarea min 10 chars
+ * - Permission gate via profile.permissions.verify_priority_object
+ *
+ * Decision D3: candidate uploads minh chứng qua existing DocumentsTab
+ * (step 6); officer picks document_id tại verify time. MVP defers document
+ * Select to Wave 5 polish — verify accepts null document_id (BE optional).
+ *
+ * Service-layer (priority_override_service):
+ * - Version guard FIRST per memory `version-guard-before-state-machine`
+ * - sub_code must be trong profile.priority_object_codes → 400
+ * - Recomputes snapshot.ut_verified_bucket (engine T6 actual rate freeze)
+ * - INSERT priority_audit_log + dispatch PRIORITY_OBJECT_{VERIFIED,REJECTED}
+ *   via outbox.
+ */
+import { useMemo, useState } from "react"
+import {
+  Award,
+  CheckCircle2,
+  Clock,
+  Loader2,
+  ShieldCheck,
+  ThumbsDown,
+  ThumbsUp,
+  XCircle,
+} from "lucide-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Label } from "@/components/ui/label"
+import {
+  ResponsiveDialog,
+  ResponsiveDialogContent,
+  ResponsiveDialogDescription,
+  ResponsiveDialogFooter,
+  ResponsiveDialogHeader,
+  ResponsiveDialogTitle,
+} from "@/components/ui/responsive-dialog"
+import { Textarea } from "@/components/ui/textarea"
+
+import { useUtCatalog } from "@/lib/hooks/use-priority-object-catalog"
+import {
+  useRejectObjectEvidence,
+  useVerifyObjectEvidence,
+} from "@/lib/hooks/use-priority-evidence"
+import type {
+  AdmissionProfileResponse,
+  PriorityObjectEvidenceEntry,
+} from "@/lib/zod/admissions"
+
+const MIN_REJECT_REASON = 10
+const MAX_REJECT_REASON = 500
+
+type EvidenceStatus = PriorityObjectEvidenceEntry["status"]
+
+interface UtEvidenceTabProps {
+  profile: AdmissionProfileResponse
+}
+
+function StatusBadge({ status }: { status: EvidenceStatus | "missing" }) {
+  if (status === "verified") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-800 border border-emerald-200">
+        <CheckCircle2 className="h-3 w-3" /> Đã duyệt
+      </span>
+    )
+  }
+  if (status === "rejected") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-800 border border-red-200">
+        <XCircle className="h-3 w-3" /> Bị từ chối
+      </span>
+    )
+  }
+  if (status === "missing") {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-800 border border-gray-200">
+        Chưa có dữ liệu
+      </span>
+    )
+  }
+  return (
+    <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 border border-amber-200">
+      <Clock className="h-3 w-3" /> Chờ duyệt
+    </span>
+  )
+}
+
+function RejectDialog({
+  open,
+  onOpenChange,
+  profileId,
+  profileVersion,
+  subCode,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  profileId: number
+  profileVersion: number
+  subCode: string
+}) {
+  const [reason, setReason] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const mutation = useRejectObjectEvidence(profileId, subCode)
+  const reasonLen = reason.trim().length
+  const valid = reasonLen >= MIN_REJECT_REASON && reasonLen <= MAX_REJECT_REASON
+
+  const handleClose = (next: boolean) => {
+    if (!next) {
+      setReason("")
+      setError(null)
+    }
+    onOpenChange(next)
+  }
+
+  const handleSubmit = async () => {
+    if (!valid || mutation.isPending) return
+    setError(null)
+    try {
+      await mutation.mutateAsync({
+        version: profileVersion,
+        reject_reason: reason.trim(),
+      })
+      toast.success(`Đã từ chối UT${subCode} thành công`)
+      handleClose(false)
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status
+      if (status === 409) {
+        toast.error("Hồ sơ vừa cập nhật, vui lòng refresh.")
+        setError("Phiên bản đã thay đổi — đóng dialog và mở lại.")
+      } else {
+        const detail =
+          (err as { response?: { data?: { detail?: string } } })?.response?.data
+            ?.detail
+        toast.error(detail || "Không thể từ chối. Vui lòng thử lại.")
+        setError(detail || "Lỗi server.")
+      }
+    }
+  }
+
+  return (
+    <ResponsiveDialog open={open} onOpenChange={handleClose}>
+      <ResponsiveDialogContent className="sm:max-w-[440px]">
+        <ResponsiveDialogHeader>
+          <ResponsiveDialogTitle className="flex items-center gap-2">
+            <ThumbsDown className="h-5 w-5 text-red-600" />
+            Từ chối UT{subCode}
+          </ResponsiveDialogTitle>
+          <ResponsiveDialogDescription>
+            Lý do từ chối sẽ được lưu vào audit log và hiển thị cho candidate.
+          </ResponsiveDialogDescription>
+        </ResponsiveDialogHeader>
+
+        <div className="grid gap-2 py-4">
+          <Label htmlFor={`reject-reason-${subCode}`}>
+            Lý do từ chối <span className="text-error-500">*</span>
+          </Label>
+          <Textarea
+            id={`reject-reason-${subCode}`}
+            data-testid={`ut-reject-reason-${subCode}`}
+            placeholder={`Nhập lý do từ chối (tối thiểu ${MIN_REJECT_REASON} ký tự)...`}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            rows={4}
+            maxLength={MAX_REJECT_REASON}
+          />
+          <p
+            className={`text-xs text-right ${
+              reasonLen < MIN_REJECT_REASON || reasonLen > MAX_REJECT_REASON
+                ? "text-error-500"
+                : "text-muted-foreground"
+            }`}
+          >
+            {reasonLen}/{MAX_REJECT_REASON} (tối thiểu {MIN_REJECT_REASON})
+          </p>
+          {error && (
+            <p
+              className="text-sm text-error-600"
+              data-testid={`ut-reject-error-${subCode}`}
+              role="alert"
+            >
+              {error}
+            </p>
+          )}
+        </div>
+
+        <ResponsiveDialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleClose(false)}
+            disabled={mutation.isPending}
+          >
+            Hủy
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleSubmit}
+            disabled={!valid || mutation.isPending}
+            data-testid={`ut-reject-submit-${subCode}`}
+          >
+            {mutation.isPending ? "Đang xử lý..." : "Từ chối"}
+          </Button>
+        </ResponsiveDialogFooter>
+      </ResponsiveDialogContent>
+    </ResponsiveDialog>
+  )
+}
+
+export function UtEvidenceTab({ profile }: UtEvidenceTabProps) {
+  const canVerify = !!profile.permissions?.verify_priority_object
+  const codes = useMemo(
+    () => profile.priority_object_codes ?? [],
+    [profile.priority_object_codes],
+  )
+  const evidence = (profile.priority_object_evidence ?? {}) as Record<
+    string,
+    PriorityObjectEvidenceEntry
+  >
+  const { data: catalog = [], isLoading } = useUtCatalog(
+    profile.academic_year ?? 2026,
+  )
+  const [rejectingCode, setRejectingCode] = useState<string | null>(null)
+
+  if (!canVerify) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-muted-foreground">
+          Bạn không có quyền duyệt UT trên hồ sơ này.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (codes.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Award className="h-5 w-5 text-purple-600" />
+            Duyệt đối tượng ưu tiên (UT)
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="py-8 text-center text-muted-foreground">
+          Candidate chưa khai diện UT nào. Không có gì để duyệt.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+            Duyệt đối tượng ưu tiên (UT)
+          </CardTitle>
+          <CardDescription>
+            Kiểm tra minh chứng từng diện candidate đã khai. Chỉ diện đã duyệt
+            mới được tính vào engine T6.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {isLoading && (
+            <div
+              className="flex items-center gap-2 text-sm text-muted-foreground py-4"
+              data-testid="ut-evidence-tab-loading"
+            >
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Đang tải danh mục...
+            </div>
+          )}
+          {!isLoading &&
+            codes.map((code) => {
+              const entry = evidence[code] ?? null
+              const status = entry?.status ?? ("missing" as const)
+              const catalogItem = catalog.find((c) => c.sub_code === code)
+              const label = `UT${code.padStart(2, "0")}`
+
+              return (
+                <UtRow
+                  key={code}
+                  code={code}
+                  label={label}
+                  description={catalogItem?.description ?? "(Không có trong catalog)"}
+                  status={status}
+                  entry={entry}
+                  profileId={profile.id}
+                  profileVersion={profile.version ?? 0}
+                  onReject={() => setRejectingCode(code)}
+                />
+              )
+            })}
+        </CardContent>
+      </Card>
+
+      {rejectingCode && (
+        <RejectDialog
+          open={!!rejectingCode}
+          onOpenChange={(open) => !open && setRejectingCode(null)}
+          profileId={profile.id}
+          profileVersion={profile.version ?? 0}
+          subCode={rejectingCode}
+        />
+      )}
+    </>
+  )
+}
+
+function UtRow({
+  code,
+  label,
+  description,
+  status,
+  entry,
+  profileId,
+  profileVersion,
+  onReject,
+}: {
+  code: string
+  label: string
+  description: string
+  status: EvidenceStatus | "missing"
+  entry: PriorityObjectEvidenceEntry | null
+  profileId: number
+  profileVersion: number
+  onReject: () => void
+}) {
+  const verifyMutation = useVerifyObjectEvidence(profileId, code)
+
+  const handleVerify = async () => {
+    if (verifyMutation.isPending) return
+    try {
+      await verifyMutation.mutateAsync({
+        version: profileVersion,
+        document_id: null,
+      })
+      toast.success(`Đã duyệt ${label}`)
+    } catch (err: unknown) {
+      const status = (err as { response?: { status?: number } })?.response?.status
+      if (status === 409) {
+        toast.error("Hồ sơ vừa cập nhật, vui lòng refresh.")
+      } else {
+        const detail =
+          (err as { response?: { data?: { detail?: string } } })?.response?.data
+            ?.detail
+        toast.error(detail || `Không thể duyệt ${label}. Vui lòng thử lại.`)
+      }
+    }
+  }
+
+  return (
+    <div
+      className="flex items-start gap-3 p-3 rounded-md border bg-background"
+      data-testid={`ut-officer-row-${code}`}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline gap-2 flex-wrap">
+          <span className="font-semibold text-sm">{label}</span>
+          <span className="text-sm text-foreground">{description}</span>
+        </div>
+        <div className="mt-1.5">
+          <StatusBadge status={status} />
+        </div>
+        {status === "rejected" && entry?.reject_reason && (
+          <p className="text-xs text-red-700 mt-1 italic">
+            Lý do từ chối: {entry.reject_reason}
+          </p>
+        )}
+      </div>
+
+      <div className="flex gap-1">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={handleVerify}
+          disabled={verifyMutation.isPending || status === "verified"}
+          data-testid={`ut-verify-${code}`}
+        >
+          <ThumbsUp className="h-3.5 w-3.5 mr-1" />
+          Duyệt
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={onReject}
+          disabled={status === "rejected"}
+          data-testid={`ut-reject-${code}`}
+        >
+          <ThumbsDown className="h-3.5 w-3.5 mr-1" />
+          Từ chối
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/api/priority-evidence.ts
+++ b/frontend/src/lib/api/priority-evidence.ts
@@ -1,0 +1,42 @@
+/**
+ * Q9 #07 Phase E.3 — UT evidence verify/reject API client.
+ *
+ * Wraps PATCH endpoints:
+ * * ``/api/v2/admissions/{id}/priority-objects/{sub_code}/verify``
+ * * ``/api/v2/admissions/{id}/priority-objects/{sub_code}/reject``
+ *
+ * BE service (priority_override_service) enforces version guard +
+ * sub_code-in-codes + status whitelist + reason validation + snapshot
+ * ut_verified_bucket recompute + audit log + outbox dispatch.
+ */
+import { api } from "@/lib/api/client"
+import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+import type {
+  RejectObjectEvidenceRequest,
+  VerifyObjectEvidenceRequest,
+} from "@/lib/zod/priority-evidence"
+
+export const priorityEvidenceApi = {
+  async verify(
+    profileId: number,
+    subCode: string,
+    body: VerifyObjectEvidenceRequest,
+  ): Promise<AdmissionProfileResponse> {
+    const { data } = await api.patch<AdmissionProfileResponse>(
+      `/api/v2/admissions/${profileId}/priority-objects/${subCode}/verify`,
+      body,
+    )
+    return data
+  },
+  async reject(
+    profileId: number,
+    subCode: string,
+    body: RejectObjectEvidenceRequest,
+  ): Promise<AdmissionProfileResponse> {
+    const { data } = await api.patch<AdmissionProfileResponse>(
+      `/api/v2/admissions/${profileId}/priority-objects/${subCode}/reject`,
+      body,
+    )
+    return data
+  },
+}

--- a/frontend/src/lib/hooks/use-priority-evidence.ts
+++ b/frontend/src/lib/hooks/use-priority-evidence.ts
@@ -1,0 +1,59 @@
+/**
+ * React Query mutation hooks — UT evidence verify/reject (Phase E.3).
+ *
+ * Cache parity per memory ``react-query-mutation-cache-parity``:
+ * onSuccess setQueryData + invalidateQueries cho admission detail key +
+ * preview-priority-kv sibling cache.
+ *
+ * Stale-version 409 handled by caller (UtEvidenceTab) — hook propagates
+ * error; toast + refresh prompt rendered trong dialog.
+ */
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { priorityEvidenceApi } from "@/lib/api/priority-evidence"
+import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+import type {
+  RejectObjectEvidenceRequest,
+  VerifyObjectEvidenceRequest,
+} from "@/lib/zod/priority-evidence"
+
+const admissionDetailKey = (id: number) => ["admission", id] as const
+
+function invalidateRelated(
+  queryClient: ReturnType<typeof useQueryClient>,
+  profileId: number,
+  updated: AdmissionProfileResponse,
+) {
+  queryClient.setQueryData(admissionDetailKey(profileId), updated)
+  queryClient.invalidateQueries({ queryKey: admissionDetailKey(profileId) })
+  queryClient.invalidateQueries({
+    predicate: (q) =>
+      Array.isArray(q.queryKey) &&
+      q.queryKey[0] === "preview-priority-kv" &&
+      q.queryKey[1] === profileId,
+  })
+}
+
+export function useVerifyObjectEvidence(profileId: number, subCode: string) {
+  const queryClient = useQueryClient()
+  return useMutation<
+    AdmissionProfileResponse,
+    Error,
+    VerifyObjectEvidenceRequest
+  >({
+    mutationFn: (body) => priorityEvidenceApi.verify(profileId, subCode, body),
+    onSuccess: (updated) => invalidateRelated(queryClient, profileId, updated),
+  })
+}
+
+export function useRejectObjectEvidence(profileId: number, subCode: string) {
+  const queryClient = useQueryClient()
+  return useMutation<
+    AdmissionProfileResponse,
+    Error,
+    RejectObjectEvidenceRequest
+  >({
+    mutationFn: (body) => priorityEvidenceApi.reject(profileId, subCode, body),
+    onSuccess: (updated) => invalidateRelated(queryClient, profileId, updated),
+  })
+}

--- a/frontend/src/lib/zod/priority-evidence.ts
+++ b/frontend/src/lib/zod/priority-evidence.ts
@@ -1,0 +1,36 @@
+/**
+ * Q9 #07 Phase E.3 — UT evidence verify/reject Zod schemas.
+ *
+ * Mirrors BE Pydantic ``VerifyObjectEvidenceRequest`` +
+ * ``RejectObjectEvidenceRequest`` trong
+ * ``Backend_FastAPI/app/schemas/admission.py`` — keep in sync.
+ *
+ * Service-layer guards (per memory ``version-guard-before-state-machine``):
+ * * Version check FIRST → 409 ConflictError trên mismatch.
+ * * sub_code must be trong profile.priority_object_codes → 400.
+ * * Status hard-deny {draft, withdrawn, dropped} → 400.
+ * * Reject reason 10-500 char mandatory.
+ */
+import { z } from "zod"
+
+export const verifyObjectEvidenceRequestSchema = z.object({
+  version: z.number().int().min(0),
+  document_id: z.number().int().positive().nullable().optional(),
+})
+
+export type VerifyObjectEvidenceRequest = z.infer<
+  typeof verifyObjectEvidenceRequestSchema
+>
+
+export const rejectObjectEvidenceRequestSchema = z.object({
+  version: z.number().int().min(0),
+  reject_reason: z
+    .string()
+    .trim()
+    .min(10, "Lý do từ chối phải có ít nhất 10 ký tự")
+    .max(500, "Lý do từ chối không được vượt quá 500 ký tự"),
+})
+
+export type RejectObjectEvidenceRequest = z.infer<
+  typeof rejectObjectEvidenceRequestSchema
+>


### PR DESCRIPTION
## Summary

Q9 #07 Phase E.3 — **Wave 3 of 5-wave plan v3 (Noble Sonnet)**.
Officer/admin verify hoặc reject candidate's UT (đối tượng ưu tiên)
evidence per code. Engine T6 actual rate freeze (``ut_verified_bucket``
snapshot field) recomputes after each verify/reject.

Builds on Wave 2 (PR #311 — CI pytest pending). Will rebase to main
sau khi Wave 2 merges.

## BE deliverables

**Service** (``priority_override_service.py`` +332):
* ``verify_object_evidence()`` — mark evidence[sub_code].status='verified'
  + document_id soft FK, recompute snapshot.ut_verified_bucket, audit
  log ``ut_evidence_verified``, dispatch PRIORITY_OBJECT_VERIFIED outbox.
* ``reject_object_evidence()`` — status='rejected' + reject_reason
  (10-500 char), recompute bucket (falls back to next-highest verified
  nếu rejected là applied), audit log ``ut_evidence_rejected``, dispatch
  PRIORITY_OBJECT_REJECTED outbox.
* ``_recompute_ut_verified_bucket()`` — MAX bonus_points across verified
  codes via catalog query (engine T6 actual freeze logic).
* ``_evidence_mutation_common_checks()`` — version guard FIRST per memory
  ``version-guard-before-state-machine`` + status whitelist
  {!draft, !withdrawn, !dropped} + sub_code-must-be-submitted.

**Endpoints** (admissions_v2.py +126):
* ``PATCH /api/v2/admissions/{profile_id}/priority-objects/{sub_code}/verify``
* ``PATCH /api/v2/admissions/{profile_id}/priority-objects/{sub_code}/reject``

IDOR via ``get_admission_for_user`` + ``CasbinAuth`` (Wave 1 seed).

**Permissions** ``admission_service.py``: ``verify_priority_object`` flag
= admin OR manager OR (officer && is_owner) AND status not hard-denied.

## FE deliverables

**UtEvidenceTab.tsx** +417 lines (**DISTINCT** from candidate
``UtEvidenceCard`` — same UT domain, 2 audiences khác):
* Per row: code label + catalog description + status badge +
  Duyệt/Từ chối buttons
* Reject sub-dialog: Textarea với 10/500 char counter + 409 handler
* Permission gate via ``profile.permissions.verify_priority_object``

**Decision D2 (plan v3 line 78-92)**: 9-step layout
* Step 8 = "Duyệt UT" (NEW officer-only)
* Step 9 = Finalize (bumped from 8)
* PipelineSidebar filters ``STEPS`` by ``canVerifyPriorityObject``
* Candidate sees gap-skip 7→9 (sidebar shows 1-7 + 9 với gap acceptable)
* Officer/admin sees full 9 steps

Touched 5 FE shell files: PipelineSidebar (STEPS register + filter),
AdmissionLayout (prop pass), AdmissionDetailClient (step 8→tab, step 9
→Finalize), AdmissionActions (bump `<8`→`<9` + `===8`→`===9`),
AdmissionActions.test.tsx (rename + bump 14 step refs).

**Decision D3 (deferred MVP)**: document Select cho verify modal defer
to Wave 5 — ``documents_checklist`` JSONB uses string ``code`` not
numeric id (Profile.documents soft-ref needs separate endpoint). MVP
verify accepts null document_id; engine T6 bonus calc unaffected.

## Tests

| Suite | Status |
|---|---|
| pytest ``test_priority_evidence_service.py`` | ✅ **12/12** |
| vitest admission detail (115 tests total) | ✅ **115/115** (incl. AdmissionActions Step 9 bump) |
| FE type-check | ✅ clean |

**pytest coverage**:
* Version conflict (verify + reject)
* sub_code-not-in-submitted-codes (verify + reject)
* Hard-denied status (3 × verify parametrized)
* Reject reason min 10 / max 500
* Happy verify: evidence mutation + snapshot ut_verified_bucket
  recompute + audit log + version bump
* Happy reject: status + reject_reason persisted
* **Chain semantics**: verify "04" then reject "04" → bucket falls
  back to "07" (next-highest verified)

## Smoke

Chrome MCP smoke for Wave 3 (verify/reject buttons on test profile)
deferred to post-Wave 2 merge — needs UT codes seeded on candidate
profile + Wave 2 dialog already verified end-to-end. Vitest covers
isolated component behaviour.

## Plan v3 status

* ✅ Wave 1 (PR #310 merged)
* ⏳ Wave 2 (PR #311 — CI pytest pending)
* ✅ **Wave 3 — this PR**
* ⬜ Wave 4: PR-F admin backfill (~3.2d)
* ⬜ Wave 5: UT catalog seed + final smoke + commune Combobox (~0.7d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)