### PR TITLE
chore(deps): bump idna 3.11 → 3.15 (CVE-2026-45409)

### DIFF
--- a/Backend_FastAPI/requirements.txt
+++ b/Backend_FastAPI/requirements.txt
@@ -45,7 +45,7 @@ h11==0.16.0
 httpcore==1.0.9
 httptools==0.7.1
 httpx==0.28.1
-idna==3.11
+idna==3.15
 Jinja2==3.1.6
 kombu==5.5.4
 limits==5.6.0


### PR DESCRIPTION
## Summary

Pre-existing main vuln blocking PR #313 (Phase E.4 BE foundation). Bump `idna` 3.11 → 3.15 to clear `CVE-2026-45409`.

## CVE detail

- **Package:** `idna` 3.11
- **CVE:** CVE-2026-45409 (DoS via crafted input — incomplete fix of CVE-2024-3651)
- **Fix version:** 3.15
- **Impact:** Specially crafted argument to `idna.encode()` consumes significant CPU. Domain name max length (253 chars) typically blocks the exploit but `idna` được dùng làm building block trong higher-level apps không validate input trước.

Per memory `outstanding-debt`: dep-audit vulns pre-existing trên main đã ghi nhận — đây là upgrade PR đối ứng.

## Verification

```
$ pip-audit -r requirements.txt --ignore-vuln CVE-2024-23342
No known vulnerabilities found
```

- `idna 3.15` install clean, no API breakage (encode/decode behavior unchanged)
- FastAPI app imports OK với version mới
- Single-file change: `Backend_FastAPI/requirements.txt` line 48 only

## Unblocks

- PR #313 Phase E.4 BE foundation (6/7 checks pass; chỉ Python Dependencies fail trên main vuln này)

## Test plan
- [x] pip-audit clean trên local
- [x] idna 3.15 install smoke (encode/decode + FastAPI app import)
- [ ] GitHub CI Python Dependencies check PASS
- [ ] No regression trong backend pytest

🤖 Generated with [Claude Code](https://claude.com/claude-code)