### PR TITLE
feat(q9-07/phase-e4): PR-2 priority evidence upload + untick + Casbin (sibling fn + P1 fixes)

### DIFF
--- a/Backend_FastAPI/alembic/versions/q9_07_e4d_seed_priority_evidence_casbin.py
+++ b/Backend_FastAPI/alembic/versions/q9_07_e4d_seed_priority_evidence_casbin.py
@@ -1,0 +1,115 @@
+"""q9_07_e4d: seed Casbin policies for Phase E.4 priority-evidence endpoints
+
+Revision ID: q9_07_e4d
+Revises: q9_07_e4c
+Create Date: 2026-05-20
+
+Q9 #07 Phase E.4 PR-2 — 2 NEW endpoints (upload + delete priority evidence)
+need Casbin seed. ``policy_templates.py`` được update tại cùng commit
+(officer ALLOW block + accountant DENY block) — script ``sync_casbin_policy``
+sẽ catch on next deploy boot, NHƯNG migration cũng seed để dev DB không cần
+manual restart pickup template change.
+
+8 rows seeded:
+* role:officer ALLOW × 2 (POST upload + DELETE untick — primary subject)
+* role:manager ALLOW × 2 (explicit grep audit, inherits officer)
+* role:admin ALLOW × 2 (explicit grep audit, wildcard catches)
+* role:accountant DENY × 2 (separation-of-duties — finance staff không
+  scan/manage UT minh chứng)
+
+Per memory ``casbin-insert-must-include-eft``: v3 (eft) MUST be included
+in INSERT — NULL → ``load_policy()`` crash → 500 every endpoint.
+
+Idempotent ``INSERT ... WHERE NOT EXISTS`` — safe re-run sau template sync.
+
+Note: role:user (candidate) KHÔNG có access — officer-driven paradigm
+(officer scan giấy từ candidate hồ sơ vật lý). Public portal không exist.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "q9_07_e4d"
+down_revision: Union[str, None] = "q9_07_e4c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# All 8 policy rows: (v0=subject, v1=object, v2=action, v3=eft)
+_PRIORITY_EVIDENCE_POLICIES = [
+    # role:officer — primary subject (officer write-path)
+    ("role:officer", "/api/v2/admissions/*/priority-evidence/*/upload", "POST", "allow"),
+    ("role:officer", "/api/v2/admissions/*/priority-evidence/*", "DELETE", "allow"),
+    # role:manager — explicit for grep audit (inherits officer via g-rule)
+    ("role:manager", "/api/v2/admissions/*/priority-evidence/*/upload", "POST", "allow"),
+    ("role:manager", "/api/v2/admissions/*/priority-evidence/*", "DELETE", "allow"),
+    # role:admin — explicit for grep audit (wildcard /*.*  handles)
+    ("role:admin", "/api/v2/admissions/*/priority-evidence/*/upload", "POST", "allow"),
+    ("role:admin", "/api/v2/admissions/*/priority-evidence/*", "DELETE", "allow"),
+    # role:accountant — DENY (separation-of-duties)
+    ("role:accountant", "/api/v2/admissions/*/priority-evidence/*/upload", "POST", "deny"),
+    ("role:accountant", "/api/v2/admissions/*/priority-evidence/*", "DELETE", "deny"),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    pre_count = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM casbin_rule "
+            "WHERE v1 LIKE '/api/v2/admissions/%priority-evidence%'"
+        )
+    ).scalar()
+    print(f"[q9_07_e4d] Pre-flight: existing priority-evidence policy rows={pre_count}")
+
+    inserted = 0
+    for v0, v1, v2, v3 in _PRIORITY_EVIDENCE_POLICIES:
+        result = conn.execute(
+            sa.text(
+                """
+                INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id, applied_at)
+                SELECT 'p',
+                       CAST(:v0 AS VARCHAR),
+                       CAST(:v1 AS VARCHAR),
+                       CAST(:v2 AS VARCHAR),
+                       CAST(:v3 AS VARCHAR),
+                       '_q9_07_e4d_priority_evidence_seed',
+                       NOW()
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM casbin_rule
+                    WHERE ptype='p'
+                      AND v0=CAST(:v0 AS VARCHAR)
+                      AND v1=CAST(:v1 AS VARCHAR)
+                      AND v2=CAST(:v2 AS VARCHAR)
+                      AND v3=CAST(:v3 AS VARCHAR)
+                )
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+        inserted += result.rowcount
+
+    print(f"[q9_07_e4d] Seeded {inserted} new policy row(s).")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    deleted = 0
+    for v0, v1, v2, v3 in _PRIORITY_EVIDENCE_POLICIES:
+        result = conn.execute(
+            sa.text(
+                """
+                DELETE FROM casbin_rule
+                WHERE ptype='p'
+                  AND v0=CAST(:v0 AS VARCHAR)
+                  AND v1=CAST(:v1 AS VARCHAR)
+                  AND v2=CAST(:v2 AS VARCHAR)
+                  AND v3=CAST(:v3 AS VARCHAR)
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+        deleted += result.rowcount
+    print(f"[q9_07_e4d] Removed {deleted} policy row(s).")

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -204,6 +204,12 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/v2/admissions/*/override-priority-kv",          "action": "POST"},
         {"subject": "{role}", "object": "/api/v2/admissions/*/priority-objects/*/verify",     "action": "PATCH"},
         {"subject": "{role}", "object": "/api/v2/admissions/*/priority-objects/*/reject",     "action": "PATCH"},
+        # Q9 #07 Phase E.4 PR-2 — Priority evidence upload + untick (officer
+        # ALLOW). Mirror verify/reject above; Casbin admits the route, service
+        # layer enforces version guard + sub_code-in-codes + status whitelist.
+        # Accountant DENY block đối ứng dưới.
+        {"subject": "{role}", "object": "/api/v2/admissions/*/priority-evidence/*/upload",    "action": "POST"},
+        {"subject": "{role}", "object": "/api/v2/admissions/*/priority-evidence/*",           "action": "DELETE"},
         # Wave 1 read endpoints — KV preview + UT catalog. Used by candidate
         # (BASIC_USER_TEMPLATE also has these) AND officer/manager/admin via
         # this template. Accountant DENY block below.
@@ -380,6 +386,12 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/v2/admissions/*/override-priority-kv",          "action": "POST",  "eft": "deny"},
         {"subject": "{role}", "object": "/api/v2/admissions/*/priority-objects/*/verify",     "action": "PATCH", "eft": "deny"},
         {"subject": "{role}", "object": "/api/v2/admissions/*/priority-objects/*/reject",     "action": "PATCH", "eft": "deny"},
+        # Q9 #07 Phase E.4 PR-2 — Priority evidence upload + untick (accountant
+        # DENY). Finance staff không scan/quản lý minh chứng UT; mirror officer
+        # ALLOW block above so accountant via inheritance (role:accountant →
+        # role:officer) bounces off deny effect.
+        {"subject": "{role}", "object": "/api/v2/admissions/*/priority-evidence/*/upload",    "action": "POST",  "eft": "deny"},
+        {"subject": "{role}", "object": "/api/v2/admissions/*/priority-evidence/*",           "action": "DELETE", "eft": "deny"},
         # Wave 1 read endpoints — accountant không cần xem priority data;
         # separation-of-duties giữ kế toán khỏi admission scoring info.
         {"subject": "{role}", "object": "/api/v2/admissions/*/preview-priority-kv",           "action": "POST",  "eft": "deny"},

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from typing import Optional
 
 import structlog
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, File, HTTPException, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database, models, schemas
@@ -35,7 +35,13 @@ from app.core.deps import (
 )
 from app.services import admission_choice_engine_service as choice_engine
 from app.services.admission_choice_service import AdmissionChoiceService
-from app.utils.exceptions import ResourceNotFoundError
+from app.utils.exceptions import (
+    BadRequest,
+    BusinessRuleViolation,
+    ConflictError,
+    PermissionDeniedError,
+    ResourceNotFoundError,
+)
 
 
 log = structlog.get_logger(__name__)
@@ -1107,3 +1113,143 @@ async def reject_priority_object_evidence(
         actor_id=current_user.id,
     )
     return await _evidence_response(db, profile_id, current_user)
+
+
+# =============================================================================
+# Q9 #07 Phase E.4 — Priority evidence upload + untick (PR-2)
+# =============================================================================
+
+
+@router.post(
+    "/{profile_id}/priority-evidence/{sub_code}/upload",
+    response_model=schemas.AdmissionProfileResponse,
+    summary="Upload UT evidence document (Phase E.4 PR-2)",
+    status_code=status.HTTP_200_OK,
+)
+async def upload_priority_evidence(
+    profile_id: int,
+    sub_code: str,
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    """Upload minh chứng UT cho 1 sub_code.
+
+    File constraints: PDF/JPG/PNG ≤10MB + magic-byte sniff. Profile MUST
+    be trong APPLICANT_DOC_MUTATION_STATES + sub_code MUST be in
+    ``profile.priority_object_codes`` + catalog year MUST có sub_code.
+
+    ADM-007 staging/finalize: file staged trước commit, promote post-commit.
+    Re-upload thay file cũ; doc_row status reset to 'uploaded' (officer
+    phải verify lại sau re-upload).
+
+    Security:
+    * IDOR: ``upload_priority_evidence_document`` calls ``get_profile``.
+    * Casbin: q9_07_e4 seed (officer/manager/admin ALLOW, accountant DENY).
+    """
+    from app.services import admission_service
+
+    try:
+        profile, finalize = await admission_service.upload_priority_evidence_document(
+            db=db,
+            profile_id=profile_id,
+            sub_code=sub_code,
+            file=file,
+            current_user=current_user,
+        )
+        try:
+            await db.commit()
+        except Exception:
+            await finalize(False)
+            raise
+        await finalize(True)
+        await db.refresh(profile)
+
+        log.info(
+            "admissions_v2.upload_priority_evidence",
+            profile_id=profile_id,
+            sub_code=sub_code,
+            actor_id=current_user.id,
+        )
+        return await _evidence_response(db, profile_id, current_user)
+
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except PermissionDeniedError:
+        # IDOR: 404 to prevent enumeration
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
+        )
+    except BusinessRuleViolation as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except BadRequest as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.delete(
+    "/{profile_id}/priority-evidence/{sub_code}",
+    response_model=schemas.AdmissionProfileResponse,
+    summary="Untick UT code + cascade delete evidence (Phase E.4 G1)",
+)
+async def untick_priority_object_evidence(
+    profile_id: int,
+    sub_code: str,
+    payload: schemas.UntickPriorityEvidenceRequest = Body(...),
+    db: AsyncSession = Depends(database.get_db),
+    profile: models.AdmissionProfile = Depends(get_admission_for_user),
+    current_user: models.User = CasbinAuth,
+):
+    """Officer unticks UT code → cascade hard delete file + JSONB cleanup.
+
+    Atomic 4-mutation contract (G1):
+    1. Remove sub_code từ priority_object_codes JSONB.
+    2. Remove sub_code entry từ priority_object_evidence JSONB.
+    3. DELETE profile_document row (category='priority_evidence',
+       priority_sub_code=sub_code).
+    4. INSERT priority_audit_log (action='ut_evidence_untick').
+    Plus recompute ut_verified_bucket if unticked code was applied verified.
+
+    File unlink via ADM-007 finalize callback (post-commit best-effort).
+
+    Decision #4 UI safety: FE shows confirm dialog BEFORE call. Service
+    assumes caller confirmed (no double-prompt). Soft delete defer Phase E.5.
+
+    Security:
+    * IDOR: ``get_admission_for_user`` (3-tier scope).
+    * Casbin: q9_07_e4 seed (officer/manager/admin ALLOW, accountant DENY).
+    """
+    from app.services.priority_override_service import untick_priority_evidence
+
+    try:
+        _, finalize_cb = await untick_priority_evidence(
+            db,
+            profile,
+            sub_code=sub_code,
+            actor=current_user,
+            expected_version=payload.version,
+        )
+        try:
+            await db.commit()
+        except Exception:
+            await finalize_cb(False)
+            raise
+        await finalize_cb(True)
+
+        log.info(
+            "admissions_v2.untick_priority_object_evidence",
+            profile_id=profile_id,
+            sub_code=sub_code,
+            actor_id=current_user.id,
+        )
+        return await _evidence_response(db, profile_id, current_user)
+
+    except ConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except BusinessRuleViolation as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except PermissionDeniedError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
+        )

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -174,6 +174,10 @@ from .admission import (
     # Q9 #07 Phase E.3 — UT evidence verify/reject
     VerifyObjectEvidenceRequest,
     RejectObjectEvidenceRequest,
+    # Q9 #07 Phase E.4 — Priority evidence schemas (PR-1 + PR-2)
+    PriorityObjectEvidenceDisplayEntry,
+    PriorityEvidenceDocumentItem,
+    UntickPriorityEvidenceRequest,
     EnrollStudentResponse,
     # Bulk action schemas
     BulkApproveRequest,

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -2389,6 +2389,26 @@ class RejectObjectEvidenceRequest(BaseModel):
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
 
 
+class UntickPriorityEvidenceRequest(BaseModel):
+    """Officer unticks UT code + cascade hard delete evidence (Phase E.4 G1).
+
+    Decision #4 UI guard: FE shows confirm dialog BEFORE call. Service-layer
+    assumes caller already confirmed (no double-prompt). Hard delete cascades:
+    JSONB cleanup + DELETE profile_document row + INSERT priority_audit_log
+    + S3 file unlink post-commit (ADM-007 finalize callback).
+
+    Soft delete (30d retention) defer Phase E.5 nếu officer report mất giấy.
+    """
+
+    version: int = Field(
+        ...,
+        description="Client-known profile.version for optimistic lock.",
+        ge=0,
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
 __all__ = [
     # Nested schemas
     "FamilyMemberSchema",
@@ -2444,4 +2464,8 @@ __all__ = [
     # Q9 #07 Phase E.3 — UT evidence verify/reject
     "VerifyObjectEvidenceRequest",
     "RejectObjectEvidenceRequest",
+    # Q9 #07 Phase E.4 — Priority evidence schemas (PR-1 + PR-2)
+    "PriorityObjectEvidenceDisplayEntry",
+    "PriorityEvidenceDocumentItem",
+    "UntickPriorityEvidenceRequest",
 ]

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -5041,6 +5041,353 @@ async def upload_document(
     return profile, finalize
 
 
+# =============================================================================
+# Q9 #07 Phase E.4 — Priority evidence document upload (PR-2 Item #1)
+# =============================================================================
+
+
+async def upload_priority_evidence_document(
+    db: AsyncSession,
+    profile_id: int,
+    sub_code: str,
+    file: Any,  # UploadFile
+    current_user: models.User,
+) -> tuple[models.AdmissionProfile, Callable]:
+    """Upload UT evidence document cho 1 sub_code (Phase E.4 PR-2).
+
+    Sibling function của upload_document (path docs). Reason for sibling
+    instead of extending: ADM-007 staging/finalize semantics + DocumentAction
+    Policy guards trên path docs khác với priority evidence (catalog-driven
+    không phải FK ConfigDocumentType).
+
+    Workflow:
+    1. Profile authz qua get_profile() (IDOR).
+    2. Profile status guard via APPLICANT_DOC_MUTATION_STATES.
+    3. sub_code MUST be in profile.priority_object_codes (officer ghi nhận
+       diện UT TRƯỚC khi scan giấy).
+    4. sub_code MUST exist trong PriorityObjectConfig catalog year.
+    5. File validation: PDF/JPG/PNG + ≤10MB + magic-byte sniff (mirror
+       upload_document).
+    6. Stage file to ``.staging.{uuid}.{ext}`` (ADM-007 — promote post-commit).
+    7. Find-or-create ProfileDocument row (category='priority_evidence',
+       priority_sub_code=sub_code, document_type_id=NULL).
+    8. Return (profile, finalize_callback) tuple. Router commits THEN calls
+       finalize(committed=True) to promote staging → final. Commit fail →
+       finalize(False) cleans staging.
+
+    Returns:
+        (AdmissionProfile, async finalize callback). See upload_document
+        docstring for finalize contract details.
+
+    Raises:
+        ResourceNotFoundError: profile IDOR fail.
+        BusinessRuleViolation: status guard / sub_code not in codes /
+            sub_code not in catalog.
+        BadRequest: file type / size / magic byte mismatch.
+    """
+    from app.repositories import AdmissionRepository
+    from .admission_document_policy import APPLICANT_DOC_MUTATION_STATES
+
+    admission_repo = AdmissionRepository(db)
+
+    profile = await get_profile(db, profile_id, current_user)
+
+    # Guard 1: profile must be in writeable state
+    if profile.status not in APPLICANT_DOC_MUTATION_STATES:
+        raise BusinessRuleViolation(
+            f"Cannot upload priority evidence trong status '{profile.status}'. "
+            f"Allowed: {sorted(APPLICANT_DOC_MUTATION_STATES)}."
+        )
+
+    # Guard 2: sub_code MUST be in profile.priority_object_codes
+    # Officer ghi nhận diện UT TRƯỚC qua AdmissionProfileUpdate, mới scan giấy.
+    priority_codes = list(profile.priority_object_codes or [])
+    if sub_code not in priority_codes:
+        raise BusinessRuleViolation(
+            f"Sub-code '{sub_code}' không có trong profile.priority_object_codes "
+            f"{priority_codes}. Officer phải ghi nhận diện UT trước khi upload "
+            f"minh chứng."
+        )
+
+    # Guard 3: sub_code MUST exist trong catalog year
+    catalog_check = await db.execute(
+        select(models.PriorityObjectConfig.id)
+        .where(
+            models.PriorityObjectConfig.academic_year == profile.academic_year,
+            models.PriorityObjectConfig.sub_code == sub_code,
+        )
+    )
+    if catalog_check.scalar_one_or_none() is None:
+        raise BusinessRuleViolation(
+            f"Sub-code '{sub_code}' không có trong PriorityObjectConfig "
+            f"catalog year {profile.academic_year}. Admin cần seed config."
+        )
+
+    # File validation (mirror upload_document)
+    ALLOWED_CONTENT_TYPES = ["application/pdf", "image/jpeg", "image/png"]
+    MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+
+    if file.content_type not in ALLOWED_CONTENT_TYPES:
+        raise BadRequest(
+            f"Invalid file type '{file.content_type}'. Allowed: PDF, JPG, PNG"
+        )
+
+    file.file.seek(0, 2)
+    file_size = file.file.tell()
+    file.file.seek(0)
+
+    if file_size > MAX_FILE_SIZE:
+        size_mb_exact = file_size / (1024 * 1024)
+        max_mb_exact = MAX_FILE_SIZE / (1024 * 1024)
+        raise BadRequest(
+            f"File too large: {file_size:,} bytes ({size_mb_exact:.3f}MB). "
+            f"Maximum allowed: {MAX_FILE_SIZE:,} bytes ({max_mb_exact:.0f}MB)."
+        )
+
+    sniffed_kind = _sniff_document_signature(file.file)
+    if sniffed_kind is None:
+        raise BadRequest(
+            "Tệp tải lên không phải PDF, JPG hoặc PNG hợp lệ (magic bytes không khớp)."
+        )
+    expected_content_type = {
+        "pdf": "application/pdf",
+        "jpeg": "image/jpeg",
+        "png": "image/png",
+    }[sniffed_kind]
+    if file.content_type != expected_content_type:
+        raise BadRequest(
+            f"Content-Type '{file.content_type}' không khớp nội dung thực tế "
+            f"({expected_content_type})."
+        )
+
+    # Find existing priority_evidence row (for re-upload scenario)
+    existing_doc_q = await db.execute(
+        select(models.ProfileDocument).where(
+            models.ProfileDocument.profile_id == profile_id,
+            models.ProfileDocument.category == "priority_evidence",
+            models.ProfileDocument.priority_sub_code == sub_code,
+        )
+    )
+    doc_row = existing_doc_q.scalar_one_or_none()
+
+    # File path setup (mirror upload_document ADM-007 staging pattern)
+    import os
+    import shutil
+    import uuid
+
+    upload_dir = f"uploads/admissions/{profile_id}"
+    os.makedirs(upload_dir, exist_ok=True)
+
+    old_file_path = doc_row.file_path if doc_row else None
+
+    extension_for_kind = {"pdf": ".pdf", "jpeg": ".jpg", "png": ".png"}
+    file_extension = extension_for_kind[sniffed_kind]
+
+    unique_id = uuid.uuid4().hex[:12]
+    unique_filename = f"priority_{sub_code}_{unique_id}{file_extension}"
+    final_path = f"{upload_dir}/{unique_filename}"
+    staging_path = f"{upload_dir}/.staging.{unique_id}{file_extension}"
+
+    # Stage file
+    try:
+        with open(staging_path, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+    except Exception as e:
+        log.error(
+            "Priority evidence file staging failed",
+            error=str(e),
+            profile_id=profile_id,
+            sub_code=sub_code,
+            staging_path=staging_path,
+        )
+        if os.path.exists(staging_path):
+            try:
+                os.remove(staging_path)
+            except OSError:
+                pass
+        raise BadRequest("Failed to save file")
+
+    # Post-staging: DB mutations wrapped in cleanup guard (mirror upload_document)
+    try:
+        uploaded_at_dt = datetime.now(timezone.utc)
+
+        if doc_row is None:
+            # Create new priority_evidence ProfileDocument row.
+            # document_type_id=NULL acceptable per Phase E.4 q9_07_e4a migration
+            # (ck_path_requires_doc_type fires only khi category='path').
+            doc_row = models.ProfileDocument(
+                profile_id=profile_id,
+                document_type_id=None,
+                category="priority_evidence",
+                priority_sub_code=sub_code,
+                status="uploaded",
+                file_path=final_path,
+                uploaded_at=uploaded_at_dt,
+            )
+            db.add(doc_row)
+        else:
+            # Re-upload: replace file. Reset status to 'uploaded' nếu was
+            # rejected/verified (officer phải verify lại sau re-upload).
+            doc_row.file_path = final_path
+            doc_row.status = "uploaded"
+            doc_row.uploaded_at = uploaded_at_dt
+            doc_row.verified_at = None
+            doc_row.verified_by = None
+            doc_row.rejected_at = None
+            doc_row.rejected_by = None
+            doc_row.rejection_reason = None
+
+            # P1 fix (audit cycle PR-2): re-upload MUST also reset evidence
+            # JSONB status. Engine reads bonus eligibility từ
+            # ``priority_object_evidence[code].status == 'verified'``
+            # (priority_override_service._recompute_ut_verified_bucket line 380
+            # + admissions_v2.preview_priority_kv line 795). Nếu chỉ reset
+            # document_row mà KHÔNG touch JSONB → file mới uploaded nhưng
+            # engine vẫn tính bonus theo verify cũ → stale bonus contract
+            # violation.
+            #
+            # Re-upload semantics: file changed → officer phải re-verify.
+            # Reset evidence entry về pending + clear verifier/rejecter
+            # metadata + clear paper_only_verification flag. Preserve
+            # requested_at (candidate claim timestamp unchanged).
+            evidence_dict = dict(profile.priority_object_evidence or {})
+            prev_entry = dict(evidence_dict.get(sub_code) or {})
+            prev_status = prev_entry.get("status")
+            if prev_status in ("verified", "rejected"):
+                evidence_dict[sub_code] = {
+                    "status": "pending",
+                    "document_id": None,
+                    "requested_at": prev_entry.get("requested_at"),
+                    "verified_by": None,
+                    "verified_at": None,
+                    "reject_reason": None,
+                    "paper_only_verification": False,
+                }
+                profile.priority_object_evidence = _strip_display_fields_from_evidence(
+                    evidence_dict
+                )
+
+                # Recompute ut_verified_bucket — if reset code was the applied
+                # verified, bucket falls back to next-highest verified (or null).
+                # Lazy import to avoid circular (priority_override_service
+                # imports from admission_service at top).
+                from app.services.priority_override_service import (
+                    _recompute_ut_verified_bucket,
+                )
+                new_bucket = await _recompute_ut_verified_bucket(db, profile)
+                snapshot = dict(profile.priority_resolution_snapshot or {})
+                snapshot["ut_verified_bucket"] = new_bucket
+                profile.priority_resolution_snapshot = snapshot
+
+                # Version bump — JSONB mutation requires optimistic lock advance
+                # so concurrent verify/reject sees stale token + retries.
+                profile.version += 1
+
+                log.info(
+                    "Priority evidence re-upload reset JSONB status",
+                    profile_id=profile_id,
+                    sub_code=sub_code,
+                    prev_status=prev_status,
+                    bucket_after=new_bucket.get("applied_code"),
+                    version_after=profile.version,
+                )
+
+        profile.updated_at = uploaded_at_dt
+        await db.flush()
+
+        # Populate response fields (transient projections)
+        documents = await admission_repo.get_all_documents(profile_id)
+        await _populate_response_fields(
+            db, profile, current_user, documents=documents
+        )
+    except Exception as exc:
+        log.error(
+            "Priority evidence upload service failed after staging write; "
+            "cleaning staging file before re-raising",
+            error=str(exc),
+            profile_id=profile_id,
+            sub_code=sub_code,
+            staging_path=staging_path,
+        )
+        if os.path.exists(staging_path):
+            try:
+                os.remove(staging_path)
+            except OSError as cleanup_error:
+                log.warning(
+                    "Failed to clean staging file after service error",
+                    staging_path=staging_path,
+                    cleanup_error=str(cleanup_error),
+                )
+        raise
+
+    log.info(
+        "Priority evidence staged (awaiting commit)",
+        profile_id=profile_id,
+        sub_code=sub_code,
+        staging_path=staging_path,
+        final_path=final_path,
+        user_id=current_user.id,
+    )
+
+    async def finalize(committed: bool) -> None:
+        """ADM-007 file-ops finalize callback for priority evidence upload."""
+        if not committed:
+            if os.path.exists(staging_path):
+                try:
+                    os.remove(staging_path)
+                    log.info(
+                        "Priority evidence staging file cleaned up after rollback",
+                        staging_path=staging_path,
+                    )
+                except OSError as e:
+                    log.warning(
+                        "Failed to clean priority evidence staging file after rollback",
+                        staging_path=staging_path,
+                        error=str(e),
+                    )
+            return
+
+        # committed=True: promote staging → final.
+        try:
+            if os.path.exists(staging_path):
+                os.replace(staging_path, final_path)
+                log.info(
+                    "Priority evidence file promoted from staging post-commit",
+                    final_path=final_path,
+                )
+            elif not os.path.exists(final_path):
+                raise OSError(
+                    f"ADM-007 finalize: neither staging nor final file "
+                    f"exists for profile={profile_id} sub_code={sub_code}"
+                )
+        except OSError as e:
+            log.error(
+                "Priority evidence finalize promote failed; old file kept intact",
+                staging_path=staging_path,
+                final_path=final_path,
+                old_file_path=old_file_path,
+                error=str(e),
+            )
+            raise
+
+        # Best-effort old file cleanup post-commit
+        if old_file_path and old_file_path != final_path and os.path.exists(old_file_path):
+            try:
+                os.remove(old_file_path)
+                log.info(
+                    "Old priority evidence file deleted post-commit",
+                    old_path=old_file_path,
+                )
+            except OSError as e:
+                log.warning(
+                    "Failed to delete old priority evidence file post-commit",
+                    old_path=old_file_path,
+                    error=str(e),
+                )
+
+    return profile, finalize
+
+
 async def confirm_document_format(
     db: AsyncSession,
     profile_id: int,

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -477,22 +477,69 @@ async def verify_object_evidence(
         profile, sub_code, actor, expected_version
     )
 
+    # Phase E.4 PR-2 P1 fix (audit cycle 2026-05-20) — server-side document
+    # binding. Spec: lookup ProfileDocument by (profile_id, category=
+    # 'priority_evidence', priority_sub_code=sub_code) INSTEAD of trusting
+    # client-supplied document_id blindly.
+    #
+    # Risk if KHÔNG fix: client gửi arbitrary document_id → audit ghi sai
+    # paper_only_verification; cross-profile reference (vd document_id của
+    # profile khác) → IDOR leak path metadata. FE currently hardcode
+    # document_id=null sau upload → mọi verify rơi vào "Hồ sơ giấy" path
+    # dù file đã scan vào hệ thống.
+    #
+    # 4 cases:
+    # 1. Client null + no row → paper_only=True, doc_id=None (true paper-only)
+    # 2. Client null + row exists → auto-bind doc_id=row.id, paper_only=False
+    # 3. Client int + row.id match → bind doc_id=row.id, paper_only=False
+    # 4. Client int + row.id mismatch (or no row) → BusinessRuleViolation
+    from sqlalchemy import select as _sel
+    doc_q = await db.execute(
+        _sel(models.ProfileDocument).where(
+            models.ProfileDocument.profile_id == profile.id,
+            models.ProfileDocument.category == "priority_evidence",
+            models.ProfileDocument.priority_sub_code == sub_code,
+        )
+    )
+    doc_row = doc_q.scalar_one_or_none()
+
+    if document_id is None:
+        if doc_row is not None:
+            # Case 2: auto-bind. FE chưa kịp re-fetch sau upload → server tự
+            # link evidence với file đã upload. Tone neutral cho officer
+            # workflow (không buộc client phải pass document_id explicit).
+            actual_document_id = doc_row.id
+            paper_only = False
+        else:
+            # Case 1: true paper-only — no file scanned yet. Officer verify
+            # dựa hồ sơ giấy candidate đem đến. Decision #3 default case.
+            actual_document_id = None
+            paper_only = True
+    else:
+        if doc_row is None or doc_row.id != document_id:
+            # Case 4: client lied or stale FE state. Refuse — server-side
+            # truth wins.
+            raise BusinessRuleViolation(
+                f"document_id {document_id} không match priority evidence "
+                f"row cho profile={profile.id} sub_code={sub_code} "
+                f"(server row id={getattr(doc_row, 'id', None)}). Officer "
+                f"phải verify đúng file đính kèm hoặc gửi null để verify "
+                f"hồ sơ giấy."
+            )
+        # Case 3: client + server match. Bind explicit.
+        actual_document_id = doc_row.id
+        paper_only = False
+
     now_iso = datetime.now(timezone.utc).isoformat()
     evidence = dict(profile.priority_object_evidence or {})
     prev_entry = dict(evidence.get(sub_code) or {})
-
-    # Phase E.4 Decision #3 — paper_only_verification flag. Officer verify
-    # UT cho hồ sơ giấy (document_id=None) là DEFAULT case trong nghiệp vụ
-    # VN, KHÔNG phải bypass. Persist flag để thanh tra truy được khi
-    # không có file scan. Tone neutral — UI badge "Hồ sơ giấy".
-    paper_only = document_id is None
 
     evidence[sub_code] = {
         **prev_entry,
         "status": "verified",
         "verified_by": actor.id,
         "verified_at": now_iso,
-        "document_id": document_id,
+        "document_id": actual_document_id,
         "paper_only_verification": paper_only,
         # Drop any stale reject_reason from prior reject cycle.
         "reject_reason": None,
@@ -516,7 +563,7 @@ async def verify_object_evidence(
         new_value={
             "sub_code": sub_code,
             "status": "verified",
-            "document_id": document_id,
+            "document_id": actual_document_id,
             "paper_only_verification": paper_only,
         },
         audit_metadata={
@@ -688,3 +735,161 @@ async def reject_object_evidence(
         return None
 
     return profile, (post_commit or _noop_callback)
+
+
+# =============================================================================
+# Q9 #07 Phase E.4 — Untick UT cascade (G1 atomic, PR-2 Item #2)
+# =============================================================================
+
+
+async def untick_priority_evidence(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    *,
+    sub_code: str,
+    actor: models.User,
+    expected_version: int,
+) -> Tuple[models.AdmissionProfile, Callable[[bool], Awaitable[None]]]:
+    """Untick UT code + cascade hard delete evidence file (Phase E.4 G1).
+
+    Atomic 4-mutation contract (all within single DB transaction):
+    1. JSONB update ``priority_object_codes`` — remove sub_code.
+    2. JSONB update ``priority_object_evidence`` — remove sub_code entry.
+       Uses ``_strip_display_fields_from_evidence`` defensive cleaner (G3).
+    3. DELETE ``profile_document`` row (category='priority_evidence',
+       priority_sub_code=sub_code) — if exists.
+    4. INSERT ``priority_audit_log`` row (action_type='ut_evidence_untick').
+    Plus: recompute ``ut_verified_bucket`` (bucket recompute matches reject
+    semantics — if unticked code was applied verified, bucket falls back).
+
+    S3 file cleanup is best-effort POST-commit via finalize callback (per
+    ADM-007 staging/finalize pattern). Commit fail → finalize(False) skips
+    delete → DB rollback restores doc row → S3 file still referenced.
+
+    Args:
+        db: AsyncSession.
+        profile: Pre-loaded AdmissionProfile (caller resolves IDOR).
+        sub_code: UT code to untick (must be in profile.priority_object_codes).
+        actor: Officer/admin performing untick.
+        expected_version: Optimistic-lock version (per memory
+            `version-guard-before-state-machine` — runs FIRST).
+
+    Returns:
+        (profile, finalize(committed: bool) async callback). Caller MUST
+        ``db.commit()`` then ``await finalize(True)`` to actually unlink S3
+        file. On commit fail call ``await finalize(False)`` — best-effort
+        cleanup with file still referenced (DB rollback safe).
+
+    Raises:
+        ConflictError: version mismatch.
+        BusinessRuleViolation: sub_code not submitted / hard-denied status.
+
+    Note: UI confirm dialog (Decision #4) is FE-side safety guard. Service
+    layer assumes caller already confirmed — no double-prompt.
+    """
+    import os
+    from sqlalchemy import select as _sel
+
+    # Version + status + sub_code guards (reuse common helper)
+    await _evidence_mutation_common_checks(
+        profile, sub_code, actor, expected_version
+    )
+
+    # Find ProfileDocument row to delete (if exists)
+    doc_q = await db.execute(
+        _sel(models.ProfileDocument).where(
+            models.ProfileDocument.profile_id == profile.id,
+            models.ProfileDocument.category == "priority_evidence",
+            models.ProfileDocument.priority_sub_code == sub_code,
+        )
+    )
+    doc_row = doc_q.scalar_one_or_none()
+    file_path_to_unlink: Optional[str] = doc_row.file_path if doc_row else None
+
+    # Capture old evidence entry for audit
+    prev_evidence = profile.priority_object_evidence or {}
+    prev_entry = dict(prev_evidence.get(sub_code) or {})
+    had_document_id = prev_entry.get("document_id")
+
+    # 1. Remove from priority_object_codes
+    codes = list(profile.priority_object_codes or [])
+    if sub_code in codes:
+        codes.remove(sub_code)
+    profile.priority_object_codes = codes
+
+    # 2. Remove from priority_object_evidence — strip display fields trước assign
+    evidence = dict(prev_evidence)
+    evidence.pop(sub_code, None)
+    profile.priority_object_evidence = _strip_display_fields_from_evidence(evidence)
+
+    # 3. DELETE profile_document row (if exists)
+    if doc_row is not None:
+        await db.delete(doc_row)
+
+    # Recompute UT verified bucket — if unticked was applied verified,
+    # bucket recomputes to next-highest (mirror reject semantics).
+    new_bucket = await _recompute_ut_verified_bucket(db, profile)
+    snapshot = dict(profile.priority_resolution_snapshot or {})
+    snapshot["ut_verified_bucket"] = new_bucket
+    profile.priority_resolution_snapshot = snapshot
+
+    # 4. INSERT priority_audit_log row
+    audit_row = models.PriorityAuditLog(
+        profile_id=profile.id,
+        action_type="ut_evidence_untick",
+        actor_id=actor.id,
+        old_value={
+            "sub_code": sub_code,
+            "status": prev_entry.get("status"),
+            "had_document": had_document_id is not None,
+        },
+        new_value={"sub_code": sub_code, "untick": True},
+        audit_metadata={
+            "actor_role": actor.role,
+            "file_unlinked": file_path_to_unlink is not None,
+            "ut_verified_bucket": new_bucket,
+        },
+    )
+    db.add(audit_row)
+    profile.version += 1
+
+    await db.flush()
+
+    log.info(
+        "priority_override_service.untick_priority_evidence_success",
+        profile_id=profile.id,
+        actor_id=actor.id,
+        sub_code=sub_code,
+        had_document=had_document_id is not None,
+        applied_code_after=new_bucket.get("applied_code"),
+        version_after=profile.version,
+    )
+
+    async def finalize(committed: bool) -> None:
+        """ADM-007 finalize callback — unlink S3 file post-commit.
+
+        - committed=True: best-effort unlink file_path_to_unlink. File
+          missing or unlink fail → log warning, không raise (the DB delete
+          already settled; orphan file = storage waste, not correctness).
+        - committed=False: skip. DB rollback restores doc_row → file still
+          referenced → leave file alone.
+        """
+        if not committed:
+            return
+        if not file_path_to_unlink:
+            return
+        if os.path.exists(file_path_to_unlink):
+            try:
+                os.remove(file_path_to_unlink)
+                log.info(
+                    "Priority evidence file deleted post-commit (untick cascade)",
+                    file_path=file_path_to_unlink,
+                )
+            except OSError as e:
+                log.warning(
+                    "Failed to unlink priority evidence file post-commit",
+                    file_path=file_path_to_unlink,
+                    error=str(e),
+                )
+
+    return profile, finalize

--- a/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
+++ b/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
@@ -462,6 +462,11 @@ async def test_accountant_deny_rows_seeded(setup_test_database):
             ("/api/v2/admissions/*/priority-objects/*/verify",     "PATCH"),
             ("/api/v2/admissions/*/priority-objects/*/reject",     "PATCH"),
             ("/api/v2/admissions/priority-objects/catalog",        "GET"),
+            # Q9 #07 Phase E.4 PR-2 — accountant DENY priority evidence
+            # mutations. Migration `q9_07_e4d` seeds these. Finance staff
+            # KHÔNG scan/manage UT minh chứng (separation-of-duties).
+            ("/api/v2/admissions/*/priority-evidence/*/upload",    "POST"),
+            ("/api/v2/admissions/*/priority-evidence/*",           "DELETE"),
         }
         assert observed == expected, (
             f"Accountant deny-row set drifted. "

--- a/Backend_FastAPI/tests/unit/test_phase_e4_audit_fixes.py
+++ b/Backend_FastAPI/tests/unit/test_phase_e4_audit_fixes.py
@@ -57,11 +57,20 @@ def _make_actor(role: str = "officer", user_id: int = 7):
     )
 
 
-def _make_db(catalog_rows=None):
+def _make_db(catalog_rows=None, doc_row=None):
+    """Mock DB. Phase E.4 PR-2 P1: verify_object_evidence now does server-side
+    ProfileDocument lookup. Smart dispatch by SQL target — ProfileDocument
+    select → doc_row, others → catalog (bucket recompute)."""
     catalog_result = MagicMock()
     catalog_result.all = MagicMock(return_value=catalog_rows or [])
 
+    doc_result = MagicMock()
+    doc_result.scalar_one_or_none = MagicMock(return_value=doc_row)
+
     async def _execute(stmt, *args, **kwargs):
+        stmt_str = str(stmt).lower()
+        if "profile_document" in stmt_str:
+            return doc_result
         return catalog_result
 
     db = MagicMock()
@@ -122,12 +131,20 @@ async def test_verify_paper_only_false_when_document_id_provided() -> None:
 
     Audit log ghi flag=False để analytics post-launch quantify ratio
     paper-only vs file-backed verify.
+
+    Phase E.4 PR-2 P1: server-side doc lookup — client document_id=42
+    matches doc_row.id=42 → bind successful, paper_only=False.
     """
     from app.services.priority_override_service import verify_object_evidence
+    from types import SimpleNamespace
 
     profile = _make_profile()
     actor = _make_actor("officer", user_id=7)
-    db = _make_db(catalog_rows=[("04", Decimal("1.00"))])
+    doc_row = SimpleNamespace(
+        id=42, category="priority_evidence", priority_sub_code="04",
+        file_path="uploads/admissions/42/priority_04_xyz.pdf",
+    )
+    db = _make_db(catalog_rows=[("04", Decimal("1.00"))], doc_row=doc_row)
 
     updated, _ = await verify_object_evidence(
         db, profile, sub_code="04", document_id=42,
@@ -141,6 +158,101 @@ async def test_verify_paper_only_false_when_document_id_provided() -> None:
     audit = _find_audit_rows(db)[0]
     assert audit.new_value["paper_only_verification"] is False
     assert audit.audit_metadata["paper_only_verification"] is False
+
+
+# ---------------------------------------------------------------------------
+# Test P1 fix audit cycle: verify server-side document binding
+# ---------------------------------------------------------------------------
+
+
+async def test_verify_auto_binds_doc_when_payload_null_and_row_exists() -> None:
+    """P1 fix contract: FE hardcodes document_id=null trong verify request.
+    Nếu profile has uploaded priority_evidence file → server auto-bind doc.id
+    + paper_only_verification=False (NOT paper-only, file IS attached).
+
+    Without server-side lookup: FE null → paper_only=True dù file đã scan.
+    Officer workflow đúng nhưng audit log sai → thanh tra không truy được file.
+    """
+    from app.services.priority_override_service import verify_object_evidence
+    from types import SimpleNamespace
+
+    profile = _make_profile()
+    actor = _make_actor("officer", user_id=7)
+    # Server-side row exists từ prior upload
+    doc_row = SimpleNamespace(
+        id=99, category="priority_evidence", priority_sub_code="04",
+        file_path="uploads/admissions/42/priority_04_uploaded.pdf",
+    )
+    db = _make_db(catalog_rows=[("04", Decimal("1.00"))], doc_row=doc_row)
+
+    # Client gửi null (FE chưa kịp re-fetch profile after upload)
+    updated, _ = await verify_object_evidence(
+        db, profile, sub_code="04", document_id=None,
+        actor=actor, expected_version=5,
+    )
+
+    entry = updated.priority_object_evidence["04"]
+    # Auto-bound to server doc row
+    assert entry["document_id"] == 99, (
+        "P1 server-side bind: client null + row exists → auto-bind doc.id"
+    )
+    # NOT paper-only — file actually attached
+    assert entry["paper_only_verification"] is False, (
+        "P1 contract: row exists → paper_only=False dù client gửi null"
+    )
+
+    # Audit reflects server truth, not client claim
+    audit = _find_audit_rows(db)[0]
+    assert audit.new_value["document_id"] == 99
+    assert audit.new_value["paper_only_verification"] is False
+
+
+async def test_verify_rejects_mismatched_document_id() -> None:
+    """P1 fix contract: client gửi document_id KHÔNG match server row → refuse.
+
+    Defense vs (a) client stale state sending old doc_id; (b) malicious client
+    trying to bind cross-profile document_id; (c) FE bug sending wrong id.
+    Server-side ownership truth wins.
+    """
+    from app.services.priority_override_service import verify_object_evidence
+    from app.utils.exceptions import BusinessRuleViolation
+    from types import SimpleNamespace
+
+    profile = _make_profile()
+    actor = _make_actor("officer", user_id=7)
+    # Server has row id=99 for UT04
+    doc_row = SimpleNamespace(
+        id=99, category="priority_evidence", priority_sub_code="04",
+        file_path="uploads/admissions/42/priority_04.pdf",
+    )
+    db = _make_db(catalog_rows=[("04", Decimal("1.00"))], doc_row=doc_row)
+
+    # Client gửi id=999 (lie / stale / cross-profile)
+    with pytest.raises(BusinessRuleViolation, match="không match"):
+        await verify_object_evidence(
+            db, profile, sub_code="04", document_id=999,
+            actor=actor, expected_version=5,
+        )
+
+
+async def test_verify_rejects_client_doc_id_when_no_server_row() -> None:
+    """P1 edge case: client gửi document_id nhưng server có NO row →
+    refuse (case 4 — mismatch, no doc row to bind).
+
+    Officer phải verify với null nếu muốn paper-only, hoặc upload file trước.
+    """
+    from app.services.priority_override_service import verify_object_evidence
+    from app.utils.exceptions import BusinessRuleViolation
+
+    profile = _make_profile()
+    actor = _make_actor("officer", user_id=7)
+    db = _make_db(catalog_rows=[("04", Decimal("1.00"))], doc_row=None)
+
+    with pytest.raises(BusinessRuleViolation, match="không match"):
+        await verify_object_evidence(
+            db, profile, sub_code="04", document_id=42,
+            actor=actor, expected_version=5,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/Backend_FastAPI/tests/unit/test_phase_e4_pr2_priority_evidence.py
+++ b/Backend_FastAPI/tests/unit/test_phase_e4_pr2_priority_evidence.py
@@ -1,0 +1,754 @@
+"""Unit tests for Q9 #07 Phase E.4 PR-2 priority evidence service contracts.
+
+Covers:
+* ``untick_priority_evidence`` (priority_override_service) — happy path,
+  version conflict, sub_code-not-in-codes, finalize callback unlink semantics.
+* ``upload_priority_evidence_document`` (admission_service) — guard checks
+  fire BEFORE file IO (status whitelist + sub_code-in-codes + catalog
+  lookup). Full filesystem happy-path defer to integration test.
+
+Mock pattern mirrors tests/unit/test_priority_evidence_service.py to keep
+test fixture style consistent across Phase E.3/E.4 unit suite.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_profile(
+    *,
+    status: str = "submitted",
+    version: int = 5,
+    codes: list = None,
+    evidence: dict = None,
+    academic_year: int = 2026,
+):
+    return SimpleNamespace(
+        id=42,
+        lead_id=100,
+        status=status,
+        version=version,
+        academic_year=academic_year,
+        priority_object_codes=codes or ["04", "07"],
+        priority_object_evidence=evidence or {},
+        priority_resolution_snapshot={},
+    )
+
+
+def _make_actor(role: str = "officer", user_id: int = 7):
+    return SimpleNamespace(
+        id=user_id,
+        role=role,
+        full_name=f"User {user_id}",
+        email=f"user{user_id}@example.com",
+    )
+
+
+def _make_db_for_untick(
+    doc_row=None,
+    catalog_rows=None,
+):
+    """Mock DB for untick: db.execute() resolves ProfileDocument lookup +
+    catalog query for bucket recompute.
+    """
+    profile_doc_result = MagicMock()
+    profile_doc_result.scalar_one_or_none = MagicMock(return_value=doc_row)
+
+    bucket_catalog_result = MagicMock()
+    bucket_catalog_result.all = MagicMock(return_value=catalog_rows or [])
+
+    call_state = {"count": 0}
+
+    async def _execute(stmt, *args, **kwargs):
+        # First call = ProfileDocument lookup. Subsequent = bucket recompute catalog.
+        call_state["count"] += 1
+        if call_state["count"] == 1:
+            return profile_doc_result
+        return bucket_catalog_result
+
+    db = MagicMock()
+    db.add = MagicMock()
+    db.delete = AsyncMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+def _find_audit_rows(db):
+    from app import models
+    return [
+        c[0][0]
+        for c in db.add.call_args_list
+        if isinstance(c[0][0], models.PriorityAuditLog)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Untick — happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_untick_happy_removes_codes_and_evidence_and_audits() -> None:
+    """Untick UT04 (no file) → cleanup JSONB + INSERT audit row + bump version."""
+    from app.services.priority_override_service import untick_priority_evidence
+
+    profile = _make_profile(
+        codes=["04", "07"],
+        evidence={
+            "04": {"status": "verified", "verified_by": 7, "document_id": None},
+            "07": {"status": "pending"},
+        },
+    )
+    actor = _make_actor("officer", user_id=7)
+    db = _make_db_for_untick(doc_row=None)  # no file attached
+
+    updated, finalize_cb = await untick_priority_evidence(
+        db, profile, sub_code="04", actor=actor, expected_version=5,
+    )
+
+    # JSONB updates: codes + evidence both lose '04'
+    assert updated.priority_object_codes == ["07"]
+    assert "04" not in updated.priority_object_evidence
+
+    # Audit row INSERTed
+    audit_rows = _find_audit_rows(db)
+    assert len(audit_rows) == 1
+    audit = audit_rows[0]
+    assert audit.action_type == "ut_evidence_untick"
+    assert audit.actor_id == 7
+    assert audit.old_value["sub_code"] == "04"
+    assert audit.old_value["had_document"] is False
+    assert audit.new_value["untick"] is True
+    assert audit.audit_metadata["file_unlinked"] is False
+
+    # Version bumped + flush (no commit)
+    assert updated.version == 6
+    db.flush.assert_awaited_once()
+    db.commit.assert_not_awaited()
+    db.delete.assert_not_awaited()  # no doc row to delete
+    assert callable(finalize_cb)
+
+
+async def test_untick_with_file_calls_db_delete() -> None:
+    """Untick UT07 với file đính kèm → db.delete(doc_row) called + audit
+    flags file_unlinked=True."""
+    from app.services.priority_override_service import untick_priority_evidence
+
+    doc_row = SimpleNamespace(
+        id=99,
+        file_path="uploads/admissions/42/priority_07_abc123.pdf",
+        priority_sub_code="07",
+        category="priority_evidence",
+    )
+    profile = _make_profile(
+        codes=["04", "07"],
+        evidence={"07": {"status": "verified", "verified_by": 7, "document_id": 99}},
+    )
+    actor = _make_actor("officer")
+    db = _make_db_for_untick(doc_row=doc_row)
+
+    updated, _ = await untick_priority_evidence(
+        db, profile, sub_code="07", actor=actor, expected_version=5,
+    )
+
+    # db.delete called với doc_row
+    db.delete.assert_awaited_once_with(doc_row)
+
+    # Audit captures file_unlinked + had_document
+    audit = _find_audit_rows(db)[0]
+    assert audit.old_value["had_document"] is True
+    assert audit.audit_metadata["file_unlinked"] is True
+
+    # Profile cleaned up
+    assert "07" not in updated.priority_object_evidence
+    assert "07" not in updated.priority_object_codes
+
+
+# ---------------------------------------------------------------------------
+# Untick — guards
+# ---------------------------------------------------------------------------
+
+
+async def test_untick_version_conflict_raises() -> None:
+    """Version mismatch FIRST (per memory version-guard-before-state-machine)."""
+    from app.services.priority_override_service import untick_priority_evidence
+    from app.utils.exceptions import ConflictError
+
+    profile = _make_profile(version=5)
+    actor = _make_actor("officer")
+    db = _make_db_for_untick()
+
+    with pytest.raises(ConflictError):
+        await untick_priority_evidence(
+            db, profile, sub_code="04", actor=actor, expected_version=4,
+        )
+
+
+async def test_untick_sub_code_not_in_codes_raises() -> None:
+    """sub_code MUST be in profile.priority_object_codes."""
+    from app.services.priority_override_service import untick_priority_evidence
+    from app.utils.exceptions import BusinessRuleViolation
+
+    profile = _make_profile(codes=["04"])  # 07 NOT in codes
+    actor = _make_actor("officer")
+    db = _make_db_for_untick()
+
+    with pytest.raises(BusinessRuleViolation):
+        await untick_priority_evidence(
+            db, profile, sub_code="07", actor=actor, expected_version=5,
+        )
+
+
+async def test_untick_hard_denied_status_raises() -> None:
+    """draft/withdrawn/dropped status → BusinessRuleViolation."""
+    from app.services.priority_override_service import untick_priority_evidence
+    from app.utils.exceptions import BusinessRuleViolation
+
+    profile = _make_profile(status="draft")
+    actor = _make_actor("officer")
+    db = _make_db_for_untick()
+
+    with pytest.raises(BusinessRuleViolation):
+        await untick_priority_evidence(
+            db, profile, sub_code="04", actor=actor, expected_version=5,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Untick — finalize callback (ADM-007 file unlink)
+# ---------------------------------------------------------------------------
+
+
+async def test_untick_finalize_commit_false_keeps_file() -> None:
+    """finalize(committed=False) MUST NOT delete file (DB rollback restores
+    doc_row → file still referenced).
+    """
+    from app.services.priority_override_service import untick_priority_evidence
+
+    # Create real tempfile so finalize callback có real path to NOT delete
+    fd, tmp_path = tempfile.mkstemp(suffix=".pdf")
+    os.close(fd)
+
+    try:
+        doc_row = SimpleNamespace(
+            id=99, file_path=tmp_path, priority_sub_code="07",
+            category="priority_evidence",
+        )
+        profile = _make_profile(codes=["07"], evidence={"07": {"status": "pending"}})
+        actor = _make_actor("officer")
+        db = _make_db_for_untick(doc_row=doc_row)
+
+        _, finalize_cb = await untick_priority_evidence(
+            db, profile, sub_code="07", actor=actor, expected_version=5,
+        )
+
+        # Simulate commit failure → finalize(False)
+        await finalize_cb(False)
+        # File MUST still exist (no unlink on rollback)
+        assert os.path.exists(tmp_path), (
+            "ADM-007 contract: commit fail → finalize(False) must NOT unlink"
+        )
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+async def test_untick_finalize_commit_true_unlinks_file() -> None:
+    """finalize(committed=True) MUST delete the staged file path."""
+    from app.services.priority_override_service import untick_priority_evidence
+
+    fd, tmp_path = tempfile.mkstemp(suffix=".pdf")
+    os.close(fd)
+
+    try:
+        doc_row = SimpleNamespace(
+            id=99, file_path=tmp_path, priority_sub_code="07",
+            category="priority_evidence",
+        )
+        profile = _make_profile(codes=["07"], evidence={"07": {"status": "pending"}})
+        actor = _make_actor("officer")
+        db = _make_db_for_untick(doc_row=doc_row)
+
+        _, finalize_cb = await untick_priority_evidence(
+            db, profile, sub_code="07", actor=actor, expected_version=5,
+        )
+
+        # Simulate commit success → finalize(True) unlinks
+        await finalize_cb(True)
+        assert not os.path.exists(tmp_path), (
+            "ADM-007 contract: commit success → finalize(True) unlinks file"
+        )
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+async def test_untick_finalize_handles_missing_file_silent() -> None:
+    """finalize(True) khi file đã missing (vd manual cleanup) → log warning,
+    NOT raise. DB delete already settled."""
+    from app.services.priority_override_service import untick_priority_evidence
+
+    doc_row = SimpleNamespace(
+        id=99,
+        file_path="/nonexistent/path/that/never/existed.pdf",
+        priority_sub_code="07",
+        category="priority_evidence",
+    )
+    profile = _make_profile(codes=["07"], evidence={"07": {"status": "pending"}})
+    actor = _make_actor("officer")
+    db = _make_db_for_untick(doc_row=doc_row)
+
+    _, finalize_cb = await untick_priority_evidence(
+        db, profile, sub_code="07", actor=actor, expected_version=5,
+    )
+
+    # Should not raise even though file doesn't exist
+    await finalize_cb(True)
+    # If we reach here, contract held
+
+
+# ---------------------------------------------------------------------------
+# Upload — guard checks (fail BEFORE file IO)
+# ---------------------------------------------------------------------------
+
+
+def _make_upload_db(catalog_has_sub_code: bool = True):
+    """Mock DB cho upload guard tests — catalog.scalar_one_or_none()
+    returns either id (sub_code in catalog) or None."""
+    catalog_result = MagicMock()
+    catalog_result.scalar_one_or_none = MagicMock(
+        return_value=1 if catalog_has_sub_code else None
+    )
+
+    async def _execute(stmt, *args, **kwargs):
+        return catalog_result
+
+    db = MagicMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+def _make_mock_upload_file():
+    """Minimal UploadFile mock — guards don't touch file IO."""
+    f = MagicMock()
+    f.content_type = "application/pdf"
+    f.filename = "test.pdf"
+    return f
+
+
+async def test_upload_wrong_status_raises() -> None:
+    """Upload trên profile status 'enrolled' → BusinessRuleViolation
+    (not in APPLICANT_DOC_MUTATION_STATES)."""
+    from app.services import admission_service
+    from app.utils.exceptions import BusinessRuleViolation
+
+    profile = _make_profile(status="enrolled", codes=["04"])
+    actor = _make_actor("officer")
+    db = _make_upload_db()
+
+    # Patch get_profile to return our SimpleNamespace
+    import app.services.admission_service as admission_service_mod
+    original = admission_service_mod.get_profile
+
+    async def mock_get_profile(db_, profile_id, current_user):
+        return profile
+
+    admission_service_mod.get_profile = mock_get_profile
+    try:
+        with pytest.raises(BusinessRuleViolation, match="enrolled"):
+            await admission_service.upload_priority_evidence_document(
+                db=db,
+                profile_id=42,
+                sub_code="04",
+                file=_make_mock_upload_file(),
+                current_user=actor,
+            )
+    finally:
+        admission_service_mod.get_profile = original
+
+
+async def test_upload_sub_code_not_in_codes_raises() -> None:
+    """sub_code MUST be in profile.priority_object_codes (officer ghi nhận
+    diện UT TRƯỚC khi upload)."""
+    from app.services import admission_service
+    from app.utils.exceptions import BusinessRuleViolation
+
+    profile = _make_profile(status="draft", codes=["04"])  # 07 NOT in codes
+    actor = _make_actor("officer")
+    db = _make_upload_db()
+
+    import app.services.admission_service as admission_service_mod
+    original = admission_service_mod.get_profile
+
+    async def mock_get_profile(db_, profile_id, current_user):
+        return profile
+
+    admission_service_mod.get_profile = mock_get_profile
+    try:
+        with pytest.raises(BusinessRuleViolation, match="priority_object_codes"):
+            await admission_service.upload_priority_evidence_document(
+                db=db,
+                profile_id=42,
+                sub_code="07",
+                file=_make_mock_upload_file(),
+                current_user=actor,
+            )
+    finally:
+        admission_service_mod.get_profile = original
+
+
+async def test_upload_sub_code_not_in_catalog_raises() -> None:
+    """sub_code MUST exist trong PriorityObjectConfig catalog cho academic_year."""
+    from app.services import admission_service
+    from app.utils.exceptions import BusinessRuleViolation
+
+    profile = _make_profile(status="draft", codes=["99"])  # 99 in codes but not catalog
+    actor = _make_actor("officer")
+    db = _make_upload_db(catalog_has_sub_code=False)  # catalog returns None
+
+    import app.services.admission_service as admission_service_mod
+    original = admission_service_mod.get_profile
+
+    async def mock_get_profile(db_, profile_id, current_user):
+        return profile
+
+    admission_service_mod.get_profile = mock_get_profile
+    try:
+        with pytest.raises(BusinessRuleViolation, match="catalog"):
+            await admission_service.upload_priority_evidence_document(
+                db=db,
+                profile_id=42,
+                sub_code="99",
+                file=_make_mock_upload_file(),
+                current_user=actor,
+            )
+    finally:
+        admission_service_mod.get_profile = original
+
+
+# ---------------------------------------------------------------------------
+# Upload — happy + re-upload (P1 contract) + finalize true/false
+# ---------------------------------------------------------------------------
+
+# Minimal valid PDF bytes — magic "%PDF" + padding để _sniff_document_signature
+# recognize without large fixture.
+_MINIMAL_PDF_BYTES = b"%PDF-1.4\n%\xff\xff\xff\xff\n" + b"x" * 200
+
+
+class _MockUploadFile:
+    """Minimal FastAPI UploadFile mock supporting .file.seek/.tell/.read +
+    .content_type + .filename."""
+
+    def __init__(self, content: bytes, content_type: str = "application/pdf",
+                 filename: str = "test.pdf"):
+        import io
+        self.content_type = content_type
+        self.filename = filename
+        self.file = io.BytesIO(content)
+
+
+def _make_upload_db_full(
+    *,
+    existing_doc=None,
+    catalog_has_sub_code: bool = True,
+    bucket_catalog_rows=None,
+):
+    """Multi-call DB mock. Order:
+    1. Catalog lookup (PriorityObjectConfig.id) — guard check
+    2. Existing ProfileDocument lookup
+    3. (Re-upload only) bucket recompute catalog rows
+    """
+    catalog_result = MagicMock()
+    catalog_result.scalar_one_or_none = MagicMock(
+        return_value=1 if catalog_has_sub_code else None
+    )
+    existing_doc_result = MagicMock()
+    existing_doc_result.scalar_one_or_none = MagicMock(return_value=existing_doc)
+    bucket_result = MagicMock()
+    bucket_result.all = MagicMock(return_value=bucket_catalog_rows or [])
+
+    call_state = {"count": 0}
+
+    async def _execute(stmt, *args, **kwargs):
+        call_state["count"] += 1
+        if call_state["count"] == 1:
+            return catalog_result
+        if call_state["count"] == 2:
+            return existing_doc_result
+        return bucket_result
+
+    db = MagicMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+def _setup_upload_mocks(monkeypatch, tmp_path, profile, documents=None):
+    """Patch get_profile + _sniff_document_signature + repo +
+    _populate_response_fields + cwd to tmp_path."""
+    import app.services.admission_service as svc
+
+    async def mock_get_profile(db_, pid, user):
+        return profile
+
+    def mock_sniff(file_obj):
+        pos = file_obj.tell()
+        file_obj.seek(0)
+        head = file_obj.read(4)
+        file_obj.seek(pos)
+        return "pdf" if head == b"%PDF" else None
+
+    async def mock_get_all_documents(self, pid):
+        return documents or []
+
+    async def mock_populate(db, p, u, documents=None):
+        return None
+
+    monkeypatch.setattr(svc, "get_profile", mock_get_profile)
+    monkeypatch.setattr(svc, "_sniff_document_signature", mock_sniff)
+    monkeypatch.setattr(svc, "_populate_response_fields", mock_populate)
+
+    from app.repositories.admission_repository import AdmissionRepository
+    monkeypatch.setattr(
+        AdmissionRepository, "get_all_documents", mock_get_all_documents
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+
+async def test_upload_happy_creates_new_doc_row(monkeypatch, tmp_path) -> None:
+    """Happy path: new sub_code upload → new ProfileDocument với
+    category='priority_evidence' + priority_sub_code + status='uploaded' +
+    document_type_id=None (critical: no FK to ConfigDocumentType)."""
+    from app.services import admission_service
+    from app import models
+
+    profile = _make_profile(status="draft", codes=["04"], evidence={})
+    actor = _make_actor("officer")
+    db = _make_upload_db_full(existing_doc=None)
+
+    _setup_upload_mocks(monkeypatch, tmp_path, profile)
+
+    file = _MockUploadFile(_MINIMAL_PDF_BYTES)
+
+    _, finalize = await admission_service.upload_priority_evidence_document(
+        db=db, profile_id=42, sub_code="04", file=file, current_user=actor,
+    )
+
+    added = [c[0][0] for c in db.add.call_args_list]
+    new_docs = [a for a in added if isinstance(a, models.ProfileDocument)]
+    assert len(new_docs) == 1
+    new_doc = new_docs[0]
+    assert new_doc.category == "priority_evidence"
+    assert new_doc.priority_sub_code == "04"
+    assert new_doc.document_type_id is None
+    assert new_doc.status == "uploaded"
+    assert new_doc.file_path.endswith(".pdf")
+    assert "priority_04_" in new_doc.file_path
+
+    assert callable(finalize)
+    db.flush.assert_awaited()
+
+
+async def test_reupload_verified_resets_jsonb_and_recomputes_bucket(
+    monkeypatch, tmp_path,
+) -> None:
+    """P1 fix contract: re-upload UT04 đang verified → evidence JSONB
+    reset về 'pending' + ut_verified_bucket recomputed + version bumped.
+
+    Without this fix engine reads stale status='verified' từ JSONB và
+    tiếp tục tính bonus dù file mới upload cần re-verify.
+    """
+    from app.services import admission_service
+
+    existing_doc = SimpleNamespace(
+        id=99,
+        category="priority_evidence",
+        priority_sub_code="04",
+        document_type_id=None,
+        file_path="uploads/admissions/42/priority_04_old.pdf",
+        status="verified",
+        uploaded_at=None,
+        verified_at="2026-05-20T08:00:00+00:00",
+        verified_by=7,
+        rejected_at=None,
+        rejected_by=None,
+        rejection_reason=None,
+    )
+    profile = _make_profile(
+        status="submitted", version=10, codes=["04"],
+        evidence={
+            "04": {
+                "status": "verified",
+                "verified_by": 7,
+                "verified_at": "2026-05-20T08:00:00+00:00",
+                "document_id": 99,
+                "paper_only_verification": False,
+                "requested_at": "2026-05-20T07:00:00+00:00",
+            }
+        },
+    )
+    profile.priority_resolution_snapshot = {
+        "kv_resolved": "KV1",
+        "ut_verified_bucket": {"applied_code": "04", "applied_rate": 1.0},
+    }
+    actor = _make_actor("officer")
+    # After reset → no verified codes → bucket falls back to None
+    db = _make_upload_db_full(existing_doc=existing_doc, bucket_catalog_rows=[])
+
+    _setup_upload_mocks(monkeypatch, tmp_path, profile, documents=[existing_doc])
+
+    file = _MockUploadFile(_MINIMAL_PDF_BYTES)
+
+    await admission_service.upload_priority_evidence_document(
+        db=db, profile_id=42, sub_code="04", file=file, current_user=actor,
+    )
+
+    # P1: evidence JSONB reset
+    entry = profile.priority_object_evidence["04"]
+    assert entry["status"] == "pending", (
+        "P1 fix: re-upload phải reset evidence status về pending — "
+        "engine reads bonus eligibility từ JSONB, không phải document row"
+    )
+    assert entry["verified_by"] is None
+    assert entry["verified_at"] is None
+    assert entry["document_id"] is None
+    assert entry["paper_only_verification"] is False
+    # requested_at preserved
+    assert entry["requested_at"] == "2026-05-20T07:00:00+00:00"
+
+    # Bucket recomputed → no verified codes left
+    bucket = profile.priority_resolution_snapshot["ut_verified_bucket"]
+    assert bucket["applied_code"] is None
+    assert bucket["applied_rate"] == 0
+
+    # Version bumped (JSONB mutation = optimistic-lock advance)
+    assert profile.version == 11
+
+    # Document row also updated
+    assert existing_doc.status == "uploaded"
+    assert existing_doc.verified_by is None
+
+
+async def test_reupload_pending_does_not_bump_version(
+    monkeypatch, tmp_path,
+) -> None:
+    """Re-upload trên evidence status='pending' (chưa verify): KHÔNG cần
+    reset JSONB (already pending) + KHÔNG bump version (chỉ document row
+    changes; evidence unchanged)."""
+    from app.services import admission_service
+
+    existing_doc = SimpleNamespace(
+        id=99, category="priority_evidence", priority_sub_code="04",
+        document_type_id=None,
+        file_path="uploads/admissions/42/priority_04_old.pdf",
+        status="uploaded",
+        uploaded_at=None, verified_at=None, verified_by=None,
+        rejected_at=None, rejected_by=None, rejection_reason=None,
+    )
+    profile = _make_profile(
+        status="submitted", version=5, codes=["04"],
+        evidence={"04": {"status": "pending"}},
+    )
+    actor = _make_actor("officer")
+    db = _make_upload_db_full(existing_doc=existing_doc)
+
+    _setup_upload_mocks(monkeypatch, tmp_path, profile, documents=[existing_doc])
+
+    file = _MockUploadFile(_MINIMAL_PDF_BYTES)
+
+    await admission_service.upload_priority_evidence_document(
+        db=db, profile_id=42, sub_code="04", file=file, current_user=actor,
+    )
+
+    assert profile.priority_object_evidence["04"]["status"] == "pending"
+    assert profile.version == 5
+
+
+async def test_upload_finalize_true_promotes_staging(
+    monkeypatch, tmp_path,
+) -> None:
+    """finalize(True) MUST os.replace staging file to final path."""
+    from app.services import admission_service
+
+    profile = _make_profile(status="draft", codes=["04"], evidence={})
+    actor = _make_actor("officer")
+    db = _make_upload_db_full(existing_doc=None)
+
+    _setup_upload_mocks(monkeypatch, tmp_path, profile)
+
+    file = _MockUploadFile(_MINIMAL_PDF_BYTES)
+
+    _, finalize = await admission_service.upload_priority_evidence_document(
+        db=db, profile_id=42, sub_code="04", file=file, current_user=actor,
+    )
+
+    upload_dir = tmp_path / "uploads" / "admissions" / "42"
+    staging_files = list(upload_dir.glob(".staging.*"))
+    final_files = [
+        f for f in upload_dir.glob("priority_04_*")
+        if not f.name.startswith(".staging.")
+    ]
+    assert len(staging_files) == 1, "staging file MUST exist pre-finalize"
+    assert len(final_files) == 0, "final file MUST NOT exist pre-finalize"
+
+    await finalize(True)
+
+    staging_files = list(upload_dir.glob(".staging.*"))
+    final_files = [
+        f for f in upload_dir.glob("priority_04_*")
+        if not f.name.startswith(".staging.")
+    ]
+    assert len(staging_files) == 0, "staging file MUST be promoted"
+    assert len(final_files) == 1, "final file MUST exist after finalize(True)"
+
+
+async def test_upload_finalize_false_cleans_staging(
+    monkeypatch, tmp_path,
+) -> None:
+    """finalize(False) MUST clean staging + NOT create final (rollback path)."""
+    from app.services import admission_service
+
+    profile = _make_profile(status="draft", codes=["04"], evidence={})
+    actor = _make_actor("officer")
+    db = _make_upload_db_full(existing_doc=None)
+
+    _setup_upload_mocks(monkeypatch, tmp_path, profile)
+
+    file = _MockUploadFile(_MINIMAL_PDF_BYTES)
+
+    _, finalize = await admission_service.upload_priority_evidence_document(
+        db=db, profile_id=42, sub_code="04", file=file, current_user=actor,
+    )
+
+    upload_dir = tmp_path / "uploads" / "admissions" / "42"
+    assert len(list(upload_dir.glob(".staging.*"))) == 1
+
+    await finalize(False)
+
+    staging_files = list(upload_dir.glob(".staging.*"))
+    final_files = [
+        f for f in upload_dir.glob("priority_04_*")
+        if not f.name.startswith(".staging.")
+    ]
+    assert len(staging_files) == 0, "staging cleaned on rollback"
+    assert len(final_files) == 0, "no final file on rollback"

--- a/Backend_FastAPI/tests/unit/test_priority_evidence_service.py
+++ b/Backend_FastAPI/tests/unit/test_priority_evidence_service.py
@@ -58,12 +58,35 @@ def _make_actor(role: str = "officer", user_id: int = 7):
     )
 
 
-def _make_db(catalog_rows=None):
-    """Mock DB session — execute() returns catalog rows for UT bucket recompute."""
+def _make_db(catalog_rows=None, doc_row=None):
+    """Mock DB session.
+
+    Phase E.4 PR-2 P1 fix: verify_object_evidence now does server-side
+    ProfileDocument lookup. Mock dispatches by statement target — queries
+    selecting ProfileDocument return ``doc_row``, others return catalog
+    rows (bucket recompute path). Reject path doesn't do doc lookup so
+    only catalog is hit.
+
+    Args:
+        catalog_rows: list of (sub_code, bonus_points) tuples for UT bucket
+            recompute (engine T6 actual rate freeze).
+        doc_row: SimpleNamespace or None — ProfileDocument lookup result
+            for the (profile_id, category='priority_evidence', sub_code)
+            query. None means "no file uploaded for this UT" → paper-only
+            verify path.
+    """
     catalog_result = MagicMock()
     catalog_result.all = MagicMock(return_value=catalog_rows or [])
 
+    doc_result = MagicMock()
+    doc_result.scalar_one_or_none = MagicMock(return_value=doc_row)
+
     async def _execute(stmt, *args, **kwargs):
+        # Inspect statement target. SELECT ProfileDocument → doc_result;
+        # everything else → catalog_result (bucket recompute path).
+        stmt_str = str(stmt).lower()
+        if "profile_document" in stmt_str:
+            return doc_result
         return catalog_result
 
     db = MagicMock()
@@ -200,8 +223,15 @@ async def test_reject_reason_too_long_raises() -> None:
 async def test_verify_happy_path_mutates_evidence_and_audit() -> None:
     profile = _make_profile()
     actor = _make_actor("officer", user_id=7)
-    # Catalog returns UT04 bonus_points=1.00, UT07=0.50
-    db = _make_db(catalog_rows=[("04", Decimal("1.00"))])
+    # Phase E.4 PR-2 P1 fix: verify now does server-side ProfileDocument
+    # lookup. Mock returns doc_row matching document_id=42 → client ↔ server
+    # ownership match → bind successful.
+    from types import SimpleNamespace
+    doc_row = SimpleNamespace(
+        id=42, category="priority_evidence", priority_sub_code="04",
+        file_path="uploads/admissions/42/priority_04_xyz.pdf",
+    )
+    db = _make_db(catalog_rows=[("04", Decimal("1.00"))], doc_row=doc_row)
 
     updated, post_commit = await verify_object_evidence(
         db, profile, sub_code="04", document_id=42,

--- a/Documents/PHASE_E4_PRIORITY_WORKBENCH_SPEC_V3_FINAL.md
+++ b/Documents/PHASE_E4_PRIORITY_WORKBENCH_SPEC_V3_FINAL.md
@@ -332,10 +332,10 @@ profile.priority_evidence_documents = [...]  # see G0a snippet
 | `schemas/admission.py` `PreviewPriorityKvResponse` | Add `rule_law_citation: Optional[str] = None` | +5 |
 | `services/priority_service.py` (engine — actual file name, KHÔNG phải `priority_resolution.py`) | Add `RULE_LAW_CITATION` map + `resolve_law_citation()` | +40 |
 | `services/admission_service.py` `_populate_response_fields` | **Set TRANSIENT attr** `profile.priority_object_evidence_display = enriched_dict` + `profile.missing_priority_evidence_codes = [...]` (NOT mutate columns). **Eager-load audit (G2 below):** add `selectinload(AdmissionProfile.documents)` vào các call sites chưa có | +60 |
-| `services/admission_service.py::upload_document` (existing line 4413) | **EXTEND existing function** — KHÔNG có file `services/document_service.py`. Add 2 optional params `category='path'` (default) + `priority_sub_code: Optional[str]=None`. Preserve **ADM-007 staging/finalize pattern**: tuple return `(profile, finalize(committed: bool))`. Khi `category='priority_evidence'`: validate sub_code ∈ catalog year + persist columns | +60 |
+| `services/admission_service.py::upload_priority_evidence_document` (NEW sibling, PR-2 decision drift) | **PR-2 audit cycle decision (2026-05-20):** thay vì EXTEND `upload_document` (line 4685, ~350 LOC complex với DocumentActionPolicy guards tied đến `mandatory_docs` + ConfigDocumentType FK), ship **NEW sibling function** `upload_priority_evidence_document`. Reason: (a) priority_evidence guards khác fundamental — sub_code in `priority_object_codes` + catalog lookup, NOT mandatory_docs; (b) ADM-007 staging/finalize tuple preserved identically; (c) lower regression risk vs threading new branch through path-doc flow. Casbin enforces route-level; service guards profile state + sub_code/catalog. **P1 contract (audit cycle 2):** re-upload trên evidence verified/rejected status PHẢI reset JSONB về 'pending' + recompute `ut_verified_bucket` + bump version — engine reads bonus từ JSONB, không phải document row. | +280 sibling |
 | `services/admission_service.py` `verify_object_evidence` (existing priority_override) | Lookup doc qua `(profile_id, category='priority_evidence', priority_sub_code=code)`; allow null doc + audit flag `paper_only_verification` (default case phần lớn hồ sơ) | +30 |
 | `services/admission_service.py` untick UT cascade | **NEW dedicated endpoint** — see Section VI G1 atomicity contract. Endpoint orchestrates JSONB update + DELETE doc + finalize callback trong 1 transaction | +50 |
-| **`routers/admissions_v2.py`** priority-evidence endpoints | **Canonical route group** — existing v2 router đã host priority-related endpoints (verify_priority_object_evidence line 1016, reject_priority_object_evidence line 1066). Add 2 NEW endpoints cùng nhóm cho consistency: `POST /api/v2/admissions/{id}/priority-evidence/{sub_code}/upload` + `DELETE /api/v2/admissions/{id}/priority-evidence/{sub_code}`. Cả 2 endpoint delegate vào `admission_service.upload_document` (extend) + `untick_priority_evidence` (new) | +70 |
+| **`routers/admissions_v2.py`** priority-evidence endpoints | **Canonical route group** — existing v2 router đã host priority-related endpoints (verify_priority_object_evidence line 1016, reject_priority_object_evidence line 1066). Add 2 NEW endpoints cùng nhóm cho consistency: `POST /api/v2/admissions/{id}/priority-evidence/{sub_code}/upload` + `DELETE /api/v2/admissions/{id}/priority-evidence/{sub_code}`. Cả 2 endpoint delegate vào `admission_service.upload_priority_evidence_document` (PR-2 sibling) + `priority_override_service.untick_priority_evidence` (new) | +70 |
 | `routers/admissions.py` upload endpoint (line 824) | Existing endpoint `POST /api/admissions/{id}/documents/{doc_code}/upload` — KHÔNG mở thêm path. Path docs route hiện hữu giữ nguyên. Priority evidence route hoàn toàn tách qua v2 group. | unchanged |
 | **`casbin_config/policy_templates.py`** | Add 2 new policy entries (mirror pattern verify/reject existing): `POST /api/v2/admissions/*/priority-evidence/*/upload` (officer/admin allow + accountant deny) + `DELETE /api/v2/admissions/*/priority-evidence/*` (officer/admin allow + accountant deny). Plus rerun `sync_notification_rules` không cần (đây là Casbin not notifications) | +20 |
 | **`services/admission_service.py`** step_status inline dicts (line 1126 trong `_compute_completion_percent` line 1082 + line 1768 trong `_compute_frontend_fields` line 1404) + step_weights inline (line 1136) | **CRITICAL renumber:** BE hiện compute 7-step inline model với Step 4=Scores, Step 5=Documents. Phase E.4 FE 8-step model với Step 4=Priority (new gộp KV+UT), Step 5=Scores, Step 6=Documents, Step 7=Tuition, Step 8=Finalize. Phải update inline step_status dict ở cả 2 chỗ + step_weights dict (rebalance 7→8 entries, total=100) + validation_summary mapping. Plus update PipelineSidebar `stepErrorCount` mapping line 82 (currently personal→1, gpa→4, documents→5 — sai sau renumber). KHÔNG có function `_calculate_step_status` riêng. | +60 |
@@ -1100,13 +1100,21 @@ Hour 0-3: BE foundation + schema
     + defensive try/except cho documents lazy-load (G2)
 
 Hour 3-5: BE upload extension + G2 eager-load audit
-  • admission_service.upload_document EXTEND với category + priority_sub_code
-    params, preserve ADM-007 staging/finalize tuple return (B2+B3)
+  • admission_service.upload_priority_evidence_document NEW SIBLING (PR-2
+    audit cycle decision 2026-05-20) — KHÔNG extend upload_document vì:
+    (a) priority_evidence guards khác fundamental (sub_code in
+    priority_object_codes + catalog lookup, NOT mandatory_docs);
+    (b) ADM-007 staging/finalize tuple preserved identically (sibling
+    reuses pattern); (c) lower regression risk vs threading new branch
+    through 350-LOC path-doc upload flow. P1 contract: re-upload trên
+    verified/rejected status PHẢI reset JSONB về 'pending' + recompute
+    ut_verified_bucket + bump version (engine reads bonus từ JSONB).
   • G2 audit: visit 15+ _populate_response_fields call sites (skip 7147 + 7716),
     add selectinload(AdmissionProfile.documents) hoặc documents= param
-  • Router POST /{id}/documents/{doc_code}/upload accept new params (B1)
-  • Router POST /{id}/priority-evidence/{sub_code}/upload shortcut
+  • Router POST /{id}/priority-evidence/{sub_code}/upload (NEW endpoint)
   • Router DELETE /{id}/priority-evidence/{sub_code} (G1 atomic endpoint)
+  • Path doc routes /{id}/documents/{doc_code}/upload giữ NGUYÊN — không
+    accept new params (sibling approach decouples 2 categories).
   • verify_object_evidence: lookup category + paper_only_verification flag
   • untick_priority_evidence: new service function với ADM-007 finalize callback
 


### PR DESCRIPTION
## Summary

PR-2 of Phase E.4 Priority Workbench. Builds on PR-1 #313 (merged main `735f5763`). Ships officer write-path cho priority evidence documents.

### Sibling function decision (PR-2 audit cycle 2026-05-20)
`upload_priority_evidence_document` is **NEW sibling** of `upload_document`, NOT extend. Reasons in spec V3 Section V + Section IX Hour 3-5 plan:
- priority_evidence guards khác fundamental (sub_code + catalog) vs path docs (mandatory_docs + ConfigDocumentType FK)
- ADM-007 staging/finalize pattern preserved identically
- Lower regression risk vs threading new branch through 350-LOC path-doc flow

## Changes

### Service layer
- **NEW** `upload_priority_evidence_document` (admission_service.py): full ADM-007 staging/finalize semantics; status guard, sub_code-in-codes guard, catalog lookup, file validation (PDF/JPG/PNG ≤10MB + magic bytes). **P1 contract**: re-upload trên verified/rejected evidence MUST reset JSONB status='pending' + recompute `ut_verified_bucket` + bump version (engine reads bonus từ JSONB, không phải document row)
- **NEW** `untick_priority_evidence` (priority_override_service.py): G1 atomic 4-mutation contract (codes/evidence JSONB cleanup + DELETE doc row + audit log) + ut_verified_bucket recompute + ADM-007 finalize callback S3 unlink
- **P1 fix** `verify_object_evidence` server-side document binding (audit cycle): replace `paper_only = document_id is None` (trust client) với server-side `(profile_id, category='priority_evidence', sub_code)` lookup. 4 cases: null+no row → paper-only, null+row → auto-bind, int+match → bind, int+mismatch → BusinessRuleViolation. Defense vs FE hardcode `document_id: null` + cross-profile leak

### Router (admissions_v2.py)
- POST `/api/v2/admissions/{profile_id}/priority-evidence/{sub_code}/upload`
- DELETE `/api/v2/admissions/{profile_id}/priority-evidence/{sub_code}` (with UntickPriorityEvidenceRequest body)

### Casbin (policy_templates.py + q9_07_e4d migration)
- 8 policy rows seeded: officer/manager/admin ALLOW × 2 endpoints, accountant DENY × 2
- Mirror existing verify/reject pattern
- role:user KHÔNG có access (officer-driven paradigm)

### Schemas
- NEW `UntickPriorityEvidenceRequest`
- `schemas/__init__.py` re-export 3 schemas

### Spec docs
- `PHASE_E4_PRIORITY_WORKBENCH_SPEC_V3_FINAL.md` Section V file plan + Section IX Hour 3-5: extend → sibling decision documented

## Tests

**76 Phase E.4 unit tests PASS** (vs 57 PR-1 baseline):
- `test_phase_e4_pr2_priority_evidence.py` NEW (16 tests): untick happy/guards/finalize × 8, upload guards × 3, upload happy/re-upload P1/re-upload pending/finalize true/finalize false × 5
- `test_phase_e4_audit_fixes.py` UPDATED: `_make_db` smart dispatch + 3 NEW P1 verify tests (auto-bind when null+row, reject mismatched doc_id, reject when no row)
- `test_priority_evidence_service.py` UPDATED: `_make_db` smart dispatch + happy test với doc_row mock

## Test plan
- [x] 76 unit tests PASS local
- [x] Migration q9_07_e4d applied dev DB (8 policy rows seeded)
- [x] Smoke: endpoints registered, schemas import clean, no circular imports
- [ ] GitHub CI pytest pass
- [ ] PR-3 FE workbench compose + Chrome MCP smoke

## Deferred PR-3
- G2 eager-load audit 15 `_populate_response_fields` call sites (defensive try/except mitigates lazy-load fails)
- Realtime emit `_emit_admission_doc_mutation` cho priority_evidence upload/untick (cross-tab cache invalidation)
- FE: zod schemas + 2 mutation hooks + 5 priority components + DocumentsTab refactor + Chrome MCP smoke 9 scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)