### PR TITLE
feat(q9-07/phase-e4): PR-4 BE compliance — ut_evidence_warning_dismissed audit row + projection tests

### DIFF
--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4612,6 +4612,63 @@ async def submit_and_evaluate(
                 profile_id=profile_id,
             )
 
+        # Q9 #07 Phase E.4 Decision #2 — audit row when officer submits with
+        # UT codes ghi nhận nhưng chưa upload minh chứng. NOT eligibility
+        # gate (officer có quyền verify "Hồ sơ giấy"); just track cho post-
+        # hoc thanh tra audit trail. CHECK constraint extended in migration
+        # q9_07_e4b accepts action_type='ut_evidence_warning_dismissed'.
+        try:
+            from sqlalchemy import select as _sel
+            priority_codes = list(profile.priority_object_codes or [])
+            missing_codes: list[str] = []
+            if priority_codes:
+                # Query existing priority_evidence ProfileDocument rows.
+                docs_q = await db.execute(
+                    _sel(
+                        models.ProfileDocument.priority_sub_code,
+                    ).where(
+                        models.ProfileDocument.profile_id == profile_id,
+                        models.ProfileDocument.category == "priority_evidence",
+                        models.ProfileDocument.priority_sub_code.is_not(None),
+                    )
+                )
+                uploaded_codes = {row.priority_sub_code for row in docs_q}
+                missing_codes = sorted(set(priority_codes) - uploaded_codes)
+
+            if missing_codes:
+                db.add(
+                    models.PriorityAuditLog(
+                        profile_id=profile_id,
+                        action_type="ut_evidence_warning_dismissed",
+                        actor_id=current_user.id if current_user else None,
+                        old_value=None,
+                        new_value={"missing_codes": missing_codes},
+                        audit_metadata={
+                            "submit_status": "submitted",
+                            "missing_count": len(missing_codes),
+                            "actor_role": (
+                                current_user.role if current_user else "magic_link"
+                            ),
+                        },
+                    )
+                )
+                log.info(
+                    "submit_audit_warning_dismissed",
+                    profile_id=profile_id,
+                    missing_codes=missing_codes,
+                    actor_id=current_user.id if current_user else None,
+                )
+        except Exception as audit_exc:  # noqa: BLE001 — defensive: never block submit
+            log.warning(
+                "ut_evidence_warning_dismissed_audit_failed",
+                profile_id=profile_id,
+                error=str(audit_exc),
+                reason=(
+                    "Decision #2 audit row insert failed during submit; "
+                    "profile still submits but post-hoc audit gap exists."
+                ),
+            )
+
         await db.flush()
 
         log.info(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4195,6 +4195,82 @@ def _calculate_and_update_totals(profile: models.AdmissionProfile, scores: list 
     profile.snapshot_score = snapshot_score
 
 
+async def _audit_warning_dismissed_if_missing(
+    db: AsyncSession,
+    profile_id: int,
+    profile: models.AdmissionProfile,
+    current_user: Optional[models.User],
+) -> None:
+    """Q9 #07 Phase E.4 Decision #2 — audit row khi officer submit với UT
+    codes ghi nhận nhưng chưa upload minh chứng.
+
+    Computes missing_priority_evidence_codes inline (query ProfileDocument
+    cho category='priority_evidence' rows), then INSERTs PriorityAuditLog
+    với action_type='ut_evidence_warning_dismissed' nếu non-empty.
+
+    NOT eligibility gate (Decision #2): officer có quyền verify "Hồ sơ
+    giấy"; just track cho post-hoc thanh tra audit trail. CHECK constraint
+    ck_priority_audit_log_action_type extended in migration q9_07_e4b
+    accepts this action type.
+
+    Defensive try/except: failure không block submit (audit gap acceptable
+    vs profile submit blocked). Structlog warning cho ops monitoring.
+
+    Extracted from submit_and_evaluate cho unit test isolation (PR-4
+    audit cycle 2026-05-20).
+    """
+    try:
+        from sqlalchemy import select as _sel
+        priority_codes = list(profile.priority_object_codes or [])
+        missing_codes: list[str] = []
+        if priority_codes:
+            docs_q = await db.execute(
+                _sel(
+                    models.ProfileDocument.priority_sub_code,
+                ).where(
+                    models.ProfileDocument.profile_id == profile_id,
+                    models.ProfileDocument.category == "priority_evidence",
+                    models.ProfileDocument.priority_sub_code.is_not(None),
+                )
+            )
+            uploaded_codes = {row.priority_sub_code for row in docs_q}
+            missing_codes = sorted(set(priority_codes) - uploaded_codes)
+
+        if missing_codes:
+            db.add(
+                models.PriorityAuditLog(
+                    profile_id=profile_id,
+                    action_type="ut_evidence_warning_dismissed",
+                    actor_id=current_user.id if current_user else None,
+                    old_value=None,
+                    new_value={"missing_codes": missing_codes},
+                    audit_metadata={
+                        "submit_status": "submitted",
+                        "missing_count": len(missing_codes),
+                        "actor_role": (
+                            current_user.role if current_user else "magic_link"
+                        ),
+                    },
+                )
+            )
+            log.info(
+                "submit_audit_warning_dismissed",
+                profile_id=profile_id,
+                missing_codes=missing_codes,
+                actor_id=current_user.id if current_user else None,
+            )
+    except Exception as audit_exc:  # noqa: BLE001 — defensive: never block submit
+        log.warning(
+            "ut_evidence_warning_dismissed_audit_failed",
+            profile_id=profile_id,
+            error=str(audit_exc),
+            reason=(
+                "Decision #2 audit row insert failed during submit; "
+                "profile still submits but post-hoc audit gap exists."
+            ),
+        )
+
+
 async def submit_and_evaluate(
     db: AsyncSession,
     profile_id: int,
@@ -4612,62 +4688,10 @@ async def submit_and_evaluate(
                 profile_id=profile_id,
             )
 
-        # Q9 #07 Phase E.4 Decision #2 — audit row when officer submits with
-        # UT codes ghi nhận nhưng chưa upload minh chứng. NOT eligibility
-        # gate (officer có quyền verify "Hồ sơ giấy"); just track cho post-
-        # hoc thanh tra audit trail. CHECK constraint extended in migration
-        # q9_07_e4b accepts action_type='ut_evidence_warning_dismissed'.
-        try:
-            from sqlalchemy import select as _sel
-            priority_codes = list(profile.priority_object_codes or [])
-            missing_codes: list[str] = []
-            if priority_codes:
-                # Query existing priority_evidence ProfileDocument rows.
-                docs_q = await db.execute(
-                    _sel(
-                        models.ProfileDocument.priority_sub_code,
-                    ).where(
-                        models.ProfileDocument.profile_id == profile_id,
-                        models.ProfileDocument.category == "priority_evidence",
-                        models.ProfileDocument.priority_sub_code.is_not(None),
-                    )
-                )
-                uploaded_codes = {row.priority_sub_code for row in docs_q}
-                missing_codes = sorted(set(priority_codes) - uploaded_codes)
-
-            if missing_codes:
-                db.add(
-                    models.PriorityAuditLog(
-                        profile_id=profile_id,
-                        action_type="ut_evidence_warning_dismissed",
-                        actor_id=current_user.id if current_user else None,
-                        old_value=None,
-                        new_value={"missing_codes": missing_codes},
-                        audit_metadata={
-                            "submit_status": "submitted",
-                            "missing_count": len(missing_codes),
-                            "actor_role": (
-                                current_user.role if current_user else "magic_link"
-                            ),
-                        },
-                    )
-                )
-                log.info(
-                    "submit_audit_warning_dismissed",
-                    profile_id=profile_id,
-                    missing_codes=missing_codes,
-                    actor_id=current_user.id if current_user else None,
-                )
-        except Exception as audit_exc:  # noqa: BLE001 — defensive: never block submit
-            log.warning(
-                "ut_evidence_warning_dismissed_audit_failed",
-                profile_id=profile_id,
-                error=str(audit_exc),
-                reason=(
-                    "Decision #2 audit row insert failed during submit; "
-                    "profile still submits but post-hoc audit gap exists."
-                ),
-            )
+        # Q9 #07 Phase E.4 Decision #2 — audit row khi officer submit với
+        # UT codes ghi nhận nhưng chưa upload minh chứng. Extracted helper
+        # (audit_warning_dismissed_if_missing) cho unit test isolation.
+        await _audit_warning_dismissed_if_missing(db, profile_id, profile, current_user)
 
         await db.flush()
 

--- a/Backend_FastAPI/tests/unit/test_phase_e4_pr4_compliance.py
+++ b/Backend_FastAPI/tests/unit/test_phase_e4_pr4_compliance.py
@@ -257,3 +257,152 @@ def test_strip_display_fields_preserves_paper_only_verification() -> None:
     assert cleaned["04"]["paper_only_verification"] is True
     assert "verified_by_name" not in cleaned["04"]
     assert "document_file_path" not in cleaned["04"]
+
+
+# ---------------------------------------------------------------------------
+# Decision #2 audit row regression — P1 contract pinning
+# ---------------------------------------------------------------------------
+
+
+def _make_audit_db(uploaded_sub_codes: list[str]):
+    """Mock DB cho audit helper test — db.execute returns mapping rows với
+    .priority_sub_code attribute, simulating ProfileDocument query result."""
+    docs_result = MagicMock()
+
+    # Each row mimics ORM row attribute access (.priority_sub_code)
+    docs_result.__iter__ = lambda self: iter(
+        [SimpleNamespace(priority_sub_code=c) for c in uploaded_sub_codes]
+    )
+
+    async def _execute(stmt, *args, **kwargs):
+        return docs_result
+
+    db = MagicMock()
+    db.add = MagicMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+def _find_warning_audit_rows(db):
+    """Filter db.add() calls to PriorityAuditLog với action_type warning_dismissed."""
+    from app import models
+    return [
+        c[0][0]
+        for c in db.add.call_args_list
+        if isinstance(c[0][0], models.PriorityAuditLog)
+        and c[0][0].action_type == "ut_evidence_warning_dismissed"
+    ]
+
+
+async def test_audit_warning_dismissed_inserts_row_when_missing_codes() -> None:
+    """P1 Decision #2 contract: profile có UT codes ghi nhận nhưng chưa
+    upload minh chứng → INSERT priority_audit_log row với
+    action_type='ut_evidence_warning_dismissed' + new_value chứa
+    missing_codes + audit_metadata chứa missing_count + actor_role.
+    """
+    from app.services.admission_service import _audit_warning_dismissed_if_missing
+
+    actor = SimpleNamespace(id=7, role="officer")
+    profile = _make_profile(
+        codes=["04", "07", "08"],
+    )
+    # Only UT04 has uploaded doc → UT07 + UT08 missing
+    db = _make_audit_db(uploaded_sub_codes=["04"])
+
+    await _audit_warning_dismissed_if_missing(db, profile.id, profile, actor)
+
+    audit_rows = _find_warning_audit_rows(db)
+    assert len(audit_rows) == 1, "Exactly 1 warning_dismissed audit row expected"
+
+    row = audit_rows[0]
+    assert row.profile_id == profile.id
+    assert row.action_type == "ut_evidence_warning_dismissed"
+    assert row.actor_id == 7
+    assert row.new_value == {"missing_codes": ["07", "08"]}  # sorted
+    assert row.audit_metadata["submit_status"] == "submitted"
+    assert row.audit_metadata["missing_count"] == 2
+    assert row.audit_metadata["actor_role"] == "officer"
+
+
+async def test_audit_warning_dismissed_no_row_when_all_uploaded() -> None:
+    """All codes have uploaded files → NO audit row (officer hoàn thành
+    workflow trước submit, không trigger Decision #2 warning)."""
+    from app.services.admission_service import _audit_warning_dismissed_if_missing
+
+    actor = SimpleNamespace(id=7, role="officer")
+    profile = _make_profile(codes=["04", "07"])
+    db = _make_audit_db(uploaded_sub_codes=["04", "07"])
+
+    await _audit_warning_dismissed_if_missing(db, profile.id, profile, actor)
+
+    assert _find_warning_audit_rows(db) == []
+
+
+async def test_audit_warning_dismissed_no_row_when_no_priority_codes() -> None:
+    """Profile không có UT codes (e.g., candidate không thuộc diện ưu tiên)
+    → NO audit row, NO DB query needed."""
+    from app.services.admission_service import _audit_warning_dismissed_if_missing
+
+    actor = SimpleNamespace(id=7, role="officer")
+    profile = _make_profile(codes=[])
+    db = _make_audit_db(uploaded_sub_codes=[])
+
+    await _audit_warning_dismissed_if_missing(db, profile.id, profile, actor)
+
+    assert _find_warning_audit_rows(db) == []
+
+
+async def test_audit_warning_dismissed_magic_link_path_no_actor() -> None:
+    """Magic-link self-service path (current_user=None) → actor_id=None +
+    audit_metadata.actor_role='magic_link' (Decision #2 captures source
+    for thanh tra distinguishing officer vs candidate self-submit)."""
+    from app.services.admission_service import _audit_warning_dismissed_if_missing
+
+    profile = _make_profile(codes=["04"])
+    db = _make_audit_db(uploaded_sub_codes=[])
+
+    await _audit_warning_dismissed_if_missing(db, profile.id, profile, None)
+
+    rows = _find_warning_audit_rows(db)
+    assert len(rows) == 1
+    assert rows[0].actor_id is None
+    assert rows[0].audit_metadata["actor_role"] == "magic_link"
+
+
+async def test_audit_warning_dismissed_defensive_on_db_error() -> None:
+    """Decision #2 contract: audit insert failure MUST NOT block submit.
+    DB exception → swallow + warning log; no raise."""
+    from app.services.admission_service import _audit_warning_dismissed_if_missing
+
+    actor = SimpleNamespace(id=7, role="officer")
+    profile = _make_profile(codes=["04"])
+
+    # DB raises on execute
+    db = MagicMock()
+    db.add = MagicMock()
+    db.execute = AsyncMock(side_effect=Exception("simulated DB error"))
+
+    # MUST NOT raise — defensive try/except wraps entire audit block
+    await _audit_warning_dismissed_if_missing(db, profile.id, profile, actor)
+
+    # No audit row inserted (compute failed before db.add reached)
+    assert _find_warning_audit_rows(db) == []
+
+
+async def test_audit_warning_dismissed_missing_codes_sorted_in_audit() -> None:
+    """missing_codes trong audit.new_value MUST be sorted ascending
+    (consistent ordering cho thanh tra grep + comparison)."""
+    from app.services.admission_service import _audit_warning_dismissed_if_missing
+
+    actor = SimpleNamespace(id=7, role="admin")
+    # Profile codes in reverse order to verify sort happens
+    profile = _make_profile(codes=["08", "04", "07", "01"])
+    db = _make_audit_db(uploaded_sub_codes=[])  # all missing
+
+    await _audit_warning_dismissed_if_missing(db, profile.id, profile, actor)
+
+    rows = _find_warning_audit_rows(db)
+    assert len(rows) == 1
+    # Sorted ascending in audit row
+    assert rows[0].new_value["missing_codes"] == ["01", "04", "07", "08"]
+    assert rows[0].audit_metadata["actor_role"] == "admin"

--- a/Backend_FastAPI/tests/unit/test_phase_e4_pr4_compliance.py
+++ b/Backend_FastAPI/tests/unit/test_phase_e4_pr4_compliance.py
@@ -1,0 +1,259 @@
+"""Regression tests for Q9 #07 Phase E.4 PR-4 compliance gaps.
+
+Closes spec gaps surfaced post PR-3 review:
+
+1. ``_populate_priority_evidence_projections`` correctly computes 3 transient
+   attrs (display projection, missing_priority_evidence_codes, priority_
+   evidence_documents) — projection logic pure-function testable.
+
+2. ``submit_and_evaluate`` inserts ``priority_audit_log`` row với
+   ``action_type='ut_evidence_warning_dismissed'`` khi profile có codes
+   ghi nhận nhưng thiếu file (Decision #2 audit trail — NOT eligibility
+   gate, just post-hoc thanh tra track).
+
+Mock pattern mirrors tests/unit/test_phase_e4_pr2_priority_evidence.py.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_profile(
+    *,
+    id: int = 42,
+    academic_year: int = 2026,
+    codes: list = None,
+    evidence: dict = None,
+    documents: list = None,
+):
+    """SimpleNamespace mimicking AdmissionProfile + transient attrs."""
+    profile = SimpleNamespace(
+        id=id,
+        lead_id=100,
+        academic_year=academic_year,
+        priority_object_codes=codes or [],
+        priority_object_evidence=evidence or {},
+        documents=documents or [],
+        # Transient attrs set by _populate; pre-init None để assert sets them.
+        priority_object_evidence_display=None,
+        missing_priority_evidence_codes=None,
+        priority_evidence_documents=None,
+    )
+    return profile
+
+
+def _make_doc(
+    *,
+    id: int,
+    sub_code: str,
+    file_path: str = None,
+    category: str = "priority_evidence",
+):
+    return SimpleNamespace(
+        id=id,
+        category=category,
+        priority_sub_code=sub_code,
+        file_path=file_path or f"uploads/admissions/42/priority_{sub_code}.pdf",
+    )
+
+
+def _make_db(catalog_rows=None):
+    """Mock DB returning catalog rows cho PriorityObjectConfig query."""
+    catalog_result = MagicMock()
+    catalog_result.__iter__ = lambda self: iter(catalog_rows or [])
+
+    async def _execute(stmt, *args, **kwargs):
+        return catalog_result
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Projection helper tests — G2 + G4 regression
+# ---------------------------------------------------------------------------
+
+
+async def test_populate_priority_evidence_projections_missing_codes_transient() -> None:
+    """G4 regression: missing_priority_evidence_codes set as transient attr —
+    correctly computed from priority_object_codes minus uploaded documents."""
+    from app.services.admission_service import (
+        _populate_priority_evidence_projections,
+    )
+
+    profile = _make_profile(
+        codes=["04", "07", "08"],
+        documents=[
+            # Only UT04 has uploaded doc
+            _make_doc(id=99, sub_code="04"),
+        ],
+    )
+    catalog_rows = [
+        SimpleNamespace(sub_code="04", bonus_points=Decimal("1.00"),
+                        evidence_doc_type="Giấy chứng nhận con thương binh"),
+        SimpleNamespace(sub_code="07", bonus_points=Decimal("0.50"),
+                        evidence_doc_type="Giấy chứng nhận hộ nghèo"),
+        SimpleNamespace(sub_code="08", bonus_points=Decimal("0.50"),
+                        evidence_doc_type="Giấy xác nhận chất độc hóa học"),
+    ]
+    db = _make_db(catalog_rows=catalog_rows)
+
+    await _populate_priority_evidence_projections(db, profile, profile.documents)
+
+    # UT07 + UT08 missing files (only UT04 uploaded)
+    assert profile.missing_priority_evidence_codes == ["07", "08"]
+
+
+async def test_populate_priority_evidence_projections_no_codes_empty_lists() -> None:
+    """Empty priority_object_codes → empty projections (defensive)."""
+    from app.services.admission_service import (
+        _populate_priority_evidence_projections,
+    )
+
+    profile = _make_profile(codes=[])
+    db = _make_db()
+
+    await _populate_priority_evidence_projections(db, profile, [])
+
+    assert profile.missing_priority_evidence_codes == []
+    assert profile.priority_evidence_documents == []
+
+
+async def test_populate_priority_evidence_documents_projection_shape() -> None:
+    """G0a: priority_evidence_documents per-UT item correctly populated
+    với label, bonus, document_id, file_path, status, verification_status."""
+    from app.services.admission_service import (
+        _populate_priority_evidence_projections,
+    )
+
+    profile = _make_profile(
+        codes=["04", "07"],
+        evidence={
+            "04": {"status": "verified", "verified_by": 7},
+            "07": {"status": "pending"},
+        },
+        documents=[
+            _make_doc(
+                id=99, sub_code="04",
+                file_path="uploads/admissions/42/priority_04.pdf",
+            ),
+        ],
+    )
+    catalog_rows = [
+        SimpleNamespace(sub_code="04", bonus_points=Decimal("1.00"),
+                        evidence_doc_type="Con thương binh"),
+        SimpleNamespace(sub_code="07", bonus_points=Decimal("0.50"),
+                        evidence_doc_type="Hộ nghèo"),
+    ]
+    db = _make_db(catalog_rows=catalog_rows)
+
+    await _populate_priority_evidence_projections(db, profile, profile.documents)
+
+    items = profile.priority_evidence_documents
+    assert len(items) == 2
+
+    # UT04 — uploaded + verified
+    ut04 = next(i for i in items if i["sub_code"] == "04")
+    assert ut04["bonus_points"] == 1.0
+    assert ut04["label"] == "Con thương binh"
+    assert ut04["document_id"] == 99
+    assert ut04["document_file_path"] == "uploads/admissions/42/priority_04.pdf"
+    assert ut04["status"] == "uploaded"
+    assert ut04["verification_status"] == "verified"
+
+    # UT07 — no doc, pending
+    ut07 = next(i for i in items if i["sub_code"] == "07")
+    assert ut07["bonus_points"] == 0.5
+    assert ut07["label"] == "Hộ nghèo"
+    assert ut07["document_id"] is None
+    assert ut07["document_file_path"] is None
+    assert ut07["status"] == "missing"
+    assert ut07["verification_status"] == "pending"
+
+
+async def test_populate_priority_evidence_missing_codes_sorted() -> None:
+    """Sort contract — missing_priority_evidence_codes sorted ascending
+    (consistent FE rendering order)."""
+    from app.services.admission_service import (
+        _populate_priority_evidence_projections,
+    )
+
+    profile = _make_profile(
+        codes=["08", "04", "07", "01"],
+        documents=[],  # all missing
+    )
+    catalog_rows = [
+        SimpleNamespace(sub_code=c, bonus_points=Decimal("0.50"),
+                        evidence_doc_type=f"UT{c}")
+        for c in ["01", "04", "07", "08"]
+    ]
+    db = _make_db(catalog_rows=catalog_rows)
+
+    await _populate_priority_evidence_projections(db, profile, [])
+
+    # All 4 missing, returned sorted
+    assert profile.missing_priority_evidence_codes == ["01", "04", "07", "08"]
+
+
+async def test_populate_priority_evidence_filters_non_priority_evidence_docs() -> None:
+    """Documents với category='path' (NOT priority_evidence) MUST NOT
+    count toward uploaded codes set. Defensive filter check."""
+    from app.services.admission_service import (
+        _populate_priority_evidence_projections,
+    )
+
+    profile = _make_profile(
+        codes=["04"],
+        documents=[
+            # Path doc (CCCD) với same sub_code-like accident — must skip
+            _make_doc(
+                id=11, sub_code="04",
+                category="path",
+                file_path="uploads/admissions/42/cccd.pdf",
+            ),
+        ],
+    )
+    db = _make_db()
+
+    await _populate_priority_evidence_projections(db, profile, profile.documents)
+
+    # UT04 missing because the only doc was category='path'
+    assert profile.missing_priority_evidence_codes == ["04"]
+
+
+# ---------------------------------------------------------------------------
+# G3 cleaner regression (already in test_phase_e4_audit_fixes; light dup OK)
+# ---------------------------------------------------------------------------
+
+
+def test_strip_display_fields_preserves_paper_only_verification() -> None:
+    """Decision #3 persisted field must survive strip cleaner (only
+    verified_by_name + document_file_path are display-only)."""
+    from app.services.admission_service import _strip_display_fields_from_evidence
+
+    enriched = {
+        "04": {
+            "status": "verified",
+            "verified_by": 7,
+            "verified_by_name": "Trịnh Tố Uyên",  # display only
+            "document_file_path": "uploads/.../x.pdf",  # display only
+            "paper_only_verification": True,  # persisted
+        }
+    }
+    cleaned = _strip_display_fields_from_evidence(enriched)
+    assert cleaned["04"]["paper_only_verification"] is True
+    assert "verified_by_name" not in cleaned["04"]
+    assert "document_file_path" not in cleaned["04"]


### PR DESCRIPTION
## Summary

PR-4 closes Phase E.4 SPEC compliance gaps surfaced post PR-3 review (2026-05-20):

1. **P1 #1** — `ut_evidence_warning_dismissed` priority_audit_log row chưa được insert tại submit path; chỉ có CHECK constraint mở (q9_07_e4b migration đã ship trong PR-1) nhưng zero call site
2. **P1 #2** — Thiếu BE tests cho `missing_priority_evidence_codes` transient compute + `priority_evidence_documents` G0a projection

## Changes

### `admission_service.py::submit_and_evaluate`

Sau khi state_transition success draft→submitted + freeze_priority_snapshot + lead milestone consultation:

- Compute `missing_priority_evidence_codes` inline (query ProfileDocument cho category='priority_evidence' rows)
- Nếu non-empty → `db.add(PriorityAuditLog(action_type='ut_evidence_warning_dismissed', new_value={missing_codes}, audit_metadata={submit_status, missing_count, actor_role}))`
- Defensive try/except — audit failure không block submit (Decision #2 contract: audit gap acceptable vs profile submit blocked)
- Structlog warning cho ops monitoring

### `tests/unit/test_phase_e4_pr4_compliance.py` NEW

6 tests cover:
- `missing_priority_evidence_codes` transient compute (G4): sub_code in codes minus uploaded codes
- Empty codes → empty projections defensive
- `priority_evidence_documents` G0a projection shape (per-UT label/bonus/doc/status/verification_status)
- Missing codes sorted ascending (FE render consistency)
- Filter `category='priority_evidence'` only — path docs với accidental sub_code MUST NOT count
- G3 strip cleaner preserves `paper_only_verification` persisted field

## Test plan
- [x] 6 unit tests pass locally (1.31s)
- [x] Rebased onto main post #317 (idna + markdown + pyjwt dep upgrade merged)
- [ ] GitHub CI all checks pass
- [ ] PR-3 (#316) rebase onto new main + add FE P2 gaps (DocumentsTab summary footer + PriorityTab compose test + UploadCell contract test)
- [ ] Chrome MCP smoke 9 scenarios với surface đầy đủ

## Phase E.4 SPEC compliance status

After PR-4 merges:
- ✅ Decision #2 audit row implemented end-to-end
- ✅ G2 + G4 projection compute pinned by tests
- ⏳ FE P2 coverage gaps (PR-3 follow-up)
- ⏳ Chrome MCP 9-scenario smoke (post FE P2)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>