### PR TITLE
fix(q9-07/phase-e4): 2 BE P1 bugs from Chrome MCP smoke (G0a projection + validator NPE)

### DIFF
--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -996,25 +996,37 @@ def _validate_documents(
         allow_unverified = bool(applied_rules["allow_unverified_submission"])
 
     if documents is not None:
+        # Phase E.4 fix (smoke 2026-05-20): priority_evidence docs do NOT have
+        # a ``document_type_id`` FK (they map 1:1 with priority_object_codes
+        # via the ``priority_sub_code`` column, not the path's mandatory_docs
+        # ConfigDocumentType catalog). They MUST be filtered out before
+        # accessing ``doc.document_type.code`` or the validator crashes with
+        # ``AttributeError: 'NoneType' object has no attribute 'code'`` on
+        # the first priority evidence row.
+        path_docs = [
+            doc for doc in documents
+            if doc.document_type is not None
+            and getattr(doc, "category", None) != "priority_evidence"
+        ]
         if allow_unverified:
             # Legacy behaviour: uploaded (with file) / verified / paper-submitted
             # all count toward submission.
             uploaded_doc_codes = {
-                doc.document_type.code for doc in documents
+                doc.document_type.code for doc in path_docs
                 if doc.status in ("verified", "paper_submitted")
                 or (doc.file_path and doc.status == "uploaded")
             }
         else:
             # Strict mode: only verified or paper_submitted count.
             uploaded_doc_codes = {
-                doc.document_type.code for doc in documents
+                doc.document_type.code for doc in path_docs
                 if doc.status in ("verified", "paper_submitted")
             }
             # Track uploaded-with-file rows that strict mode rejected so
             # the UI can label them as "pending verify" rather than
             # "missing".
             pending_verify_codes = {
-                doc.document_type.code for doc in documents
+                doc.document_type.code for doc in path_docs
                 if doc.file_path and doc.status == "uploaded"
             }
 
@@ -3713,6 +3725,16 @@ async def get_profile(
     # (governance setting, not snapshotted) — keeps detail in lockstep
     # with list endpoint resolver above.
     await _resolve_minor_correction_state(db, profile, current_user)
+
+    # Q9 #07 Phase E.4 — projections on GET path (parity with mutation
+    # endpoints via ``_populate_response_fields``). Without these calls
+    # ``priority_evidence_documents`` returns [] even when the profile has
+    # ``priority_object_codes`` set, breaking DocumentsTab Priority section +
+    # PriorityWorkbench § 3 UT cards on every GET. Smoke 2026-05-20 caught
+    # this gap — projection logic existed (line 2264) but only fired from
+    # ``_populate_response_fields`` callers, leaving the read-side dark.
+    profile.priority_audit_log = await _load_priority_audit_log(db, profile.id)
+    await _populate_priority_evidence_projections(db, profile, documents)
 
     return profile
 

--- a/Backend_FastAPI/tests/unit/test_phase_e4_pr4_compliance.py
+++ b/Backend_FastAPI/tests/unit/test_phase_e4_pr4_compliance.py
@@ -406,3 +406,273 @@ async def test_audit_warning_dismissed_missing_codes_sorted_in_audit() -> None:
     # Sorted ascending in audit row
     assert rows[0].new_value["missing_codes"] == ["01", "04", "07", "08"]
     assert rows[0].audit_metadata["actor_role"] == "admin"
+
+
+# ===========================================================================
+# Smoke 2026-05-20 — GET path projection wiring (P1 read-side bug)
+# ===========================================================================
+# Smoke discovered that ``get_profile()`` skipped
+# ``_populate_priority_evidence_projections``, so the G0a contract
+# (DocumentsTab Priority section + § 3 UT cards) was dark on every GET.
+# Mutation endpoints wired through ``_populate_response_fields`` did populate
+# the projection, hiding the bug from frontend integration tests. Fix added
+# the call to ``get_profile`` directly. These tests pin both the projection
+# call site and the empty-fallback semantic so the bug doesn't drift back.
+
+
+async def test_get_profile_populates_priority_evidence_documents_when_codes_set(
+    monkeypatch,
+) -> None:
+    """GET path: codes=['07'] + no doc → projection row with status='missing'.
+
+    Mirrors the Chrome MCP smoke finding 2026-05-20: officer set
+    priority_object_codes=['07'] via PUT, response showed
+    priority_evidence_documents=[] (BUG). After fix, GET path itself populates
+    the projection.
+    """
+    from sqlalchemy import select as _sel
+    import app.services.admission_service as svc
+
+    captured_projection_calls: list = []
+
+    async def fake_populate_projection(db, profile, documents):
+        captured_projection_calls.append({
+            "profile_id": profile.id,
+            "codes": list(profile.priority_object_codes or []),
+            "doc_count": len(documents),
+        })
+        profile.priority_evidence_documents = [
+            {
+                "sub_code": "07",
+                "bonus_points": 0.5,
+                "label": "Quyết định cấp sổ hộ nghèo",
+                "document_id": None,
+                "document_file_path": None,
+                "status": "missing",
+                "verification_status": None,
+            }
+        ]
+        profile.priority_object_evidence_display = {}
+        profile.missing_priority_evidence_codes = ["07"]
+
+    async def fake_audit_log(db, profile_id):
+        return []
+
+    async def fake_repo_documents(profile_id):
+        return []
+
+    async def fake_resolver(db, docs):
+        return {}
+
+    async def fake_minor(db, profile, user):
+        return None
+
+    # Stub repository layer + helper functions
+    monkeypatch.setattr(svc, "_populate_priority_evidence_projections", fake_populate_projection)
+    monkeypatch.setattr(svc, "_load_priority_audit_log", fake_audit_log)
+    monkeypatch.setattr(svc, "_resolve_verifier_names", fake_resolver)
+    monkeypatch.setattr(svc, "_resolve_minor_correction_state", fake_minor)
+    monkeypatch.setattr(svc, "_compute_frontend_fields", lambda *a, **kw: None)
+    monkeypatch.setattr(svc, "_calculate_and_update_totals", lambda *a, **kw: None)
+    monkeypatch.setattr(svc, "_check_idor_access", lambda profile, user: None)
+
+    # Stub repository class — return a profile with codes=['07'], no docs
+    profile_stub = SimpleNamespace(
+        id=99,
+        status="draft",
+        academic_year=2026,
+        priority_object_codes=["07"],
+        priority_object_evidence={},
+        lead=SimpleNamespace(unit_id=1, assigned_officer=None),
+        assigned_reviewer=None,
+        priority_evidence_documents=None,
+        priority_object_evidence_display=None,
+        missing_priority_evidence_codes=None,
+        priority_audit_log=None,
+    )
+
+    class FakeRepo:
+        def __init__(self, db):
+            pass
+
+        async def get_profile_by_id_with_lead(self, profile_id):
+            return profile_stub
+
+        async def get_all_documents(self, profile_id):
+            return []
+
+        async def get_profile_scores(self, profile_id):
+            return []
+
+    monkeypatch.setattr("app.repositories.AdmissionRepository", FakeRepo)
+
+    db = MagicMock()
+    user = SimpleNamespace(id=7, role="officer", unit_id=1)
+
+    result = await svc.get_profile(db, 99, user)
+
+    # Pin contract: projection helper was called from GET path
+    assert len(captured_projection_calls) == 1
+    assert captured_projection_calls[0]["codes"] == ["07"]
+
+    # Pin contract: projection populated transient attrs visible to response
+    assert result.priority_evidence_documents == [
+        {
+            "sub_code": "07",
+            "bonus_points": 0.5,
+            "label": "Quyết định cấp sổ hộ nghèo",
+            "document_id": None,
+            "document_file_path": None,
+            "status": "missing",
+            "verification_status": None,
+        }
+    ]
+    assert result.missing_priority_evidence_codes == ["07"]
+
+
+async def test_get_profile_populates_audit_log_alongside_projection(
+    monkeypatch,
+) -> None:
+    """GET path also loads priority_audit_log — paired Phase E.4 contract.
+
+    These two attrs (audit log + projection) ship together via
+    ``_populate_response_fields`` for mutation endpoints; the GET fix mirrors
+    that pairing so workbench audit timeline does NOT regress.
+    """
+    import app.services.admission_service as svc
+
+    audit_call_recorded: dict = {}
+
+    async def fake_audit_log(db, profile_id):
+        audit_call_recorded["profile_id"] = profile_id
+        return [
+            SimpleNamespace(
+                id=1,
+                action_type="ut_evidence_verified",
+                actor_id=2,
+                timestamp=None,
+                old_value=None,
+                new_value={"sub_code": "07"},
+                audit_metadata={},
+            )
+        ]
+
+    async def fake_projection(db, profile, documents):
+        profile.priority_evidence_documents = []
+        profile.priority_object_evidence_display = {}
+        profile.missing_priority_evidence_codes = []
+
+    monkeypatch.setattr(svc, "_populate_priority_evidence_projections", fake_projection)
+    monkeypatch.setattr(svc, "_load_priority_audit_log", fake_audit_log)
+    monkeypatch.setattr(svc, "_resolve_verifier_names", AsyncMock(return_value={}))
+    monkeypatch.setattr(svc, "_resolve_minor_correction_state", AsyncMock(return_value=None))
+    monkeypatch.setattr(svc, "_compute_frontend_fields", lambda *a, **kw: None)
+    monkeypatch.setattr(svc, "_calculate_and_update_totals", lambda *a, **kw: None)
+    monkeypatch.setattr(svc, "_check_idor_access", lambda profile, user: None)
+
+    profile_stub = SimpleNamespace(
+        id=99,
+        status="draft",
+        academic_year=2026,
+        priority_object_codes=[],
+        priority_object_evidence={},
+        lead=SimpleNamespace(unit_id=1, assigned_officer=None),
+        assigned_reviewer=None,
+        priority_audit_log=None,
+        priority_evidence_documents=None,
+        priority_object_evidence_display=None,
+        missing_priority_evidence_codes=None,
+    )
+
+    class FakeRepo:
+        def __init__(self, db):
+            pass
+
+        async def get_profile_by_id_with_lead(self, profile_id):
+            return profile_stub
+
+        async def get_all_documents(self, profile_id):
+            return []
+
+        async def get_profile_scores(self, profile_id):
+            return []
+
+    monkeypatch.setattr("app.repositories.AdmissionRepository", FakeRepo)
+
+    db = MagicMock()
+    user = SimpleNamespace(id=7, role="officer", unit_id=1)
+
+    result = await svc.get_profile(db, 99, user)
+
+    # Pin contract: audit log loaded on GET path
+    assert audit_call_recorded["profile_id"] == 99
+    assert len(result.priority_audit_log) == 1
+    assert result.priority_audit_log[0].action_type == "ut_evidence_verified"
+
+
+async def test_get_profile_projection_empty_codes_still_populates_empty_list(
+    monkeypatch,
+) -> None:
+    """GET with empty codes: projection still sets [] (not None default).
+
+    Pydantic schema defaults priority_evidence_documents=[]. If the projection
+    helper is skipped entirely, the attribute stays at whatever __init__ set
+    (usually unset → schema default kicks in). The fix MUST call the helper
+    unconditionally so transient attrs are consistent — even empty.
+    """
+    import app.services.admission_service as svc
+
+    helper_called = {"count": 0}
+
+    async def fake_projection(db, profile, documents):
+        helper_called["count"] += 1
+        profile.priority_evidence_documents = []
+        profile.priority_object_evidence_display = {}
+        profile.missing_priority_evidence_codes = []
+
+    monkeypatch.setattr(svc, "_populate_priority_evidence_projections", fake_projection)
+    monkeypatch.setattr(svc, "_load_priority_audit_log", AsyncMock(return_value=[]))
+    monkeypatch.setattr(svc, "_resolve_verifier_names", AsyncMock(return_value={}))
+    monkeypatch.setattr(svc, "_resolve_minor_correction_state", AsyncMock(return_value=None))
+    monkeypatch.setattr(svc, "_compute_frontend_fields", lambda *a, **kw: None)
+    monkeypatch.setattr(svc, "_calculate_and_update_totals", lambda *a, **kw: None)
+    monkeypatch.setattr(svc, "_check_idor_access", lambda profile, user: None)
+
+    profile_stub = SimpleNamespace(
+        id=99,
+        status="draft",
+        academic_year=2026,
+        priority_object_codes=None,  # not set
+        priority_object_evidence={},
+        lead=SimpleNamespace(unit_id=1, assigned_officer=None),
+        assigned_reviewer=None,
+        priority_evidence_documents=None,
+        priority_object_evidence_display=None,
+        missing_priority_evidence_codes=None,
+        priority_audit_log=None,
+    )
+
+    class FakeRepo:
+        def __init__(self, db):
+            pass
+
+        async def get_profile_by_id_with_lead(self, profile_id):
+            return profile_stub
+
+        async def get_all_documents(self, profile_id):
+            return []
+
+        async def get_profile_scores(self, profile_id):
+            return []
+
+    monkeypatch.setattr("app.repositories.AdmissionRepository", FakeRepo)
+
+    db = MagicMock()
+    user = SimpleNamespace(id=7, role="officer", unit_id=1)
+
+    result = await svc.get_profile(db, 99, user)
+
+    # Pin contract: helper called even when no codes — keeps transient attrs
+    # consistent so response schema doesn't fall back to None defaults.
+    assert helper_called["count"] == 1
+    assert result.priority_evidence_documents == []


### PR DESCRIPTION
## Summary

Chrome MCP smoke matrix on profile 39 (real officer browser session) uncovered 2 P1 BE blockers on the GET → first-upload path that vitest + targeted pytest had missed.

## Bug 1 — G0a projection silent on GET path

`_populate_priority_evidence_projections` (`admission_service.py:2264`) builds the per-UT projection correctly, but it was only called from `_populate_response_fields`. `get_profile()` skipped that builder, so every GET returned `priority_evidence_documents: []` no matter what.

**Production effect:** officer opens profile via normal navigation → Step 6 DocumentsTab Priority section conditional render (`length > 0`) sees empty list and hides the upload UI entirely. § 3 UT cards also miss file/status data.

**Fix:** call `_load_priority_audit_log` + `_populate_priority_evidence_projections` at tail of `get_profile()`, mirroring `_populate_response_fields` ordering.

## Bug 2 — `_validate_documents` NPE on priority_evidence row

After Bug 1 fix, FE rendered the upload cell and the upload mutation fired → 500 from `_validate_documents`:

```
AttributeError: 'NoneType' object has no attribute 'code'
```

**Cause:** priority_evidence `profile_document` rows have `document_type_id=NULL` because they map 1:1 with `priority_object_codes` via the `priority_sub_code` column, **not** via the path's mandatory_docs `ConfigDocumentType` catalog. Three `doc.document_type.code` comprehensions assumed every doc has a FK.

**Fix:** filter `documents → path_docs` (skip rows where `document_type is None` OR `category == "priority_evidence"`) before the comprehensions. Semantic stays correct — priority evidence docs are NOT counted against path mandatory_docs.

## Regression tests (3 new in `test_phase_e4_pr4_compliance.py`)

- `test_get_profile_populates_priority_evidence_documents_when_codes_set` — GET with `priority_object_codes=['07']` + no doc → projection populated, `status='missing'`, `missing_priority_evidence_codes=['07']`. Pins GET wiring directly.
- `test_get_profile_populates_audit_log_alongside_projection` — audit-log loader paired with projection, prevents workbench timeline regression.
- `test_get_profile_projection_empty_codes_still_populates_empty_list` — helper always called even when codes empty, transient attrs consistent so Pydantic schema default doesn't kick in.

15/15 PASS local pytest run (`2.35s` in container).

## Smoke evidence (after both fixes applied)

Profile 39 walked end-to-end as officer `vothithuthuhien`:

- **KV-1** missing → banner "Thiếu thông tin trình độ"
- **KV-2** cultural set → ambiguous, "no_qualifying_entries"
- **KV-4** happy path với commune `SMOKE_DLK_01` → banner "🟢 KV đã xác định: KV1", citation disclosure expands to "TT 05/2021 Phụ lục 01 Mục 4"
- **UT-3 + UT-4** → Step 6 Priority section renders, real PDF upload via `POST /api/v2/admissions/39/priority-evidence/07/upload`, response carries `document_file_path`, cell switches to view mode + filename + "Xem PDF" + "Tải lại"
- **UT-10** untick with file → confirm dialog renders filename, default focus on "Huỷ", destructive button "Xoá file và bỏ chọn"
- **Eligibility footer dynamic**: "Ưu tiên: 0/1 docs uploaded · UT07 thiếu" → "Ưu tiên: 1/1 docs uploaded"

## Test plan

- [ ] CI: `pytest` + `Check (type+lint+test)` + `Build` + `Node/Python Dependencies` all PASS
- [ ] After merge: rebuild container, resume smoke UT-2/5/6/7/8/9/11 + KV-3/5/6 + KV-7 frozen (submit LAST) on profile 39
- [ ] Verify GET on any other profile with `priority_object_codes` no longer dark on Step 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)