### PR TITLE
fix(q9-07/phase-e4): UT verify/reject state allowlist (block post-publish drift)

### DIFF
--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -1048,15 +1048,22 @@ async def verify_priority_object_evidence(
     ``profile.documents`` tại verify time.
     """
     from app.services.priority_override_service import verify_object_evidence
+    from fastapi import HTTPException
 
-    _, post_commit_cb = await verify_object_evidence(
-        db,
-        profile,
-        sub_code=sub_code,
-        document_id=payload.document_id,
-        actor=current_user,
-        expected_version=payload.version,
-    )
+    try:
+        _, post_commit_cb = await verify_object_evidence(
+            db,
+            profile,
+            sub_code=sub_code,
+            document_id=payload.document_id,
+            actor=current_user,
+            expected_version=payload.version,
+            acknowledge_post_publish=payload.acknowledge_post_publish,
+        )
+    except PermissionError as exc:
+        # Officer/manager attempted post-publish verify; map to 403
+        # (parity với override_priority_kv handler above).
+        raise HTTPException(status_code=403, detail=str(exc))
 
     await db.commit()
     await post_commit_cb()
@@ -1093,15 +1100,20 @@ async def reject_priority_object_evidence(
     trong payload.
     """
     from app.services.priority_override_service import reject_object_evidence
+    from fastapi import HTTPException
 
-    _, post_commit_cb = await reject_object_evidence(
-        db,
-        profile,
-        sub_code=sub_code,
-        reject_reason=payload.reject_reason,
-        actor=current_user,
-        expected_version=payload.version,
-    )
+    try:
+        _, post_commit_cb = await reject_object_evidence(
+            db,
+            profile,
+            sub_code=sub_code,
+            reject_reason=payload.reject_reason,
+            actor=current_user,
+            expected_version=payload.version,
+            acknowledge_post_publish=payload.acknowledge_post_publish,
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc))
 
     await db.commit()
     await post_commit_cb()

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -2375,6 +2375,18 @@ class VerifyObjectEvidenceRequest(BaseModel):
         None,
         description="Optional FK soft reference to supporting document.",
     )
+    # Phase E.4 hotfix 3 (smoke 2026-05-21): post-publish guard. Officer/
+    # manager refused outright (403) on approved/confirmed/enrolled/
+    # result_published/admitted/waitlisted. Admin must opt in with this
+    # flag — mirrors KV override OverridePriorityKvRequest.
+    acknowledge_post_publish: bool = Field(
+        default=False,
+        description=(
+            "Admin-only escape hatch for verifying UT on a profile already "
+            "in a post-publish state. Officer/manager refused regardless. "
+            "Audit log records the flag."
+        ),
+    )
 
     model_config = ConfigDict(extra="forbid")
 
@@ -2397,6 +2409,15 @@ class RejectObjectEvidenceRequest(BaseModel):
         min_length=10,
         max_length=500,
         description="Reason for rejection (10-500 chars).",
+    )
+    # Phase E.4 hotfix 3 — same post-publish gate as verify above.
+    acknowledge_post_publish: bool = Field(
+        default=False,
+        description=(
+            "Admin-only escape hatch for rejecting UT on a profile already "
+            "in a post-publish state. Officer/manager refused regardless. "
+            "Audit log records the flag."
+        ),
     )
 
     model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -112,8 +112,57 @@ _EVIDENCE_STATUSES: frozenset[str] = frozenset({"pending", "verified", "rejected
 _MIN_REJECT_REASON_LEN = 10
 _MAX_REJECT_REASON_LEN = 500
 
-# Officer can verify/reject UT evidence in any status except hard-denied
-# (draft means candidate still editing — verify makes no sense).
+# Phase E.4 (smoke 2026-05-21) — UT verify/reject state guard.
+#
+# Original guard used a 3-state blocklist (draft / withdrawn / dropped),
+# which permitted verify/reject in approved / confirmed / enrolled /
+# result_published / admitted / waitlisted. Service recomputes
+# ``ut_verified_bucket`` + bumps version on every mutation, so a verify
+# late in the lifecycle silently shifts published UT bucket points after
+# results were already committed (parity with the documents-policy
+# concern blocking reviewer mutation post-enrolled at
+# ``admission_document_policy.py``).
+#
+# Pattern mirrors ``_OFFICER_ALLOWED_STATUS`` + ``_POST_PUBLISH_STATUS``
+# used by manual KV override above — same workflow shape (officer/admin
+# write-path, version-bump, audit log), so same gate.
+
+# Officer/manager/admin can verify/reject UT evidence in these
+# intermediate review states. Includes ``resubmitted`` because re-
+# submission flow legitimately reopens UT review.
+_EVIDENCE_OFFICER_ALLOWED_STATUS: frozenset[str] = frozenset({
+    "submitted",
+    "reviewing",
+    "revision_requested",
+    "resubmitted",
+})
+
+# Officer NEVER mutates UT evidence in these terminal/published states
+# because UT bucket is now part of a committed admission decision /
+# student record. Admin can bypass with explicit
+# ``acknowledge_post_publish=True`` (parity with KV override gate).
+_EVIDENCE_POST_PUBLISH_STATUS: frozenset[str] = frozenset({
+    "approved",
+    "confirmed",
+    "enrolled",
+    "overridden",
+    "result_published",
+    "admitted",
+    "waitlisted",
+})
+
+# Officer + admin BOTH refuse to verify/reject in these — there is no
+# coherent meaning (draft = candidate still editing, withdrawn/dropped/
+# rejected = no UT decision to record).
+_EVIDENCE_HARD_DENIED_STATUS: frozenset[str] = frozenset({
+    "draft",
+    "withdrawn",
+    "dropped",
+    "rejected",
+})
+
+# Legacy alias retained — referenced by external callers; matches the
+# original 3-state denial set.
 _EVIDENCE_DENIED_STATUS: frozenset[str] = frozenset({
     "draft",
     "withdrawn",
@@ -417,13 +466,20 @@ async def _evidence_mutation_common_checks(
     sub_code: str,
     actor: models.User,
     expected_version: int,
+    acknowledge_post_publish: bool = False,
 ) -> None:
-    """Shared pre-mutation guard for verify + reject.
+    """Shared pre-mutation guard for verify + reject (Phase E.4 hotfix 3).
 
     Raises ConflictError on version mismatch (FIRST per memory
     `version-guard-before-state-machine`); BusinessRuleViolation on
-    hard-denied status, invalid sub_code, or sub_code not in profile's
-    submitted codes list.
+    hard-denied status, post-publish without acknowledge, status outside
+    the officer allowlist, invalid sub_code, or sub_code not in
+    profile's submitted codes list. PermissionError when officer/manager
+    attempts post-publish mutation (router maps to 403).
+
+    State guard mirrors ``_OFFICER_ALLOWED_STATUS`` + ``_POST_PUBLISH_STATUS``
+    used by ``override_kv`` above — UT bucket mutation has the same
+    "snapshot-bumping post-decision" risk as a manual KV override.
     """
     if expected_version != profile.version:
         raise ConflictError(
@@ -433,9 +489,37 @@ async def _evidence_mutation_common_checks(
             "Please refresh and try again."
         )
 
-    if profile.status in _EVIDENCE_DENIED_STATUS:
+    # Hard-denied: nobody can verify/reject here. Fail-closed.
+    if profile.status in _EVIDENCE_HARD_DENIED_STATUS:
         raise BusinessRuleViolation(
             f"Cannot verify/reject UT evidence in '{profile.status}' state."
+        )
+
+    is_admin = getattr(actor, "role", None) == "admin"
+
+    # Post-publish: officer/manager refused outright (403 at router).
+    # Admin must opt in with explicit acknowledge_post_publish=True to
+    # leave a clear audit trail entry.
+    if profile.status in _EVIDENCE_POST_PUBLISH_STATUS:
+        if not is_admin:
+            raise PermissionError(
+                f"Officer cannot verify/reject UT evidence on "
+                f"'{profile.status}' profile — admin only for post-publish "
+                "mutations."
+            )
+        if not acknowledge_post_publish:
+            raise BusinessRuleViolation(
+                f"Profile is in post-publish state '{profile.status}'. "
+                "Pass acknowledge_post_publish=true to confirm the "
+                "verify/reject; this will be recorded in the audit log."
+            )
+
+    # Catch-all: officer path must be in the allow list. Admin already
+    # passed the post-publish gate above; here we only re-check officer.
+    elif profile.status not in _EVIDENCE_OFFICER_ALLOWED_STATUS:
+        raise BusinessRuleViolation(
+            f"Cannot verify/reject UT evidence in '{profile.status}' state — "
+            "allowed only for submitted/reviewing/revision_requested/resubmitted."
         )
 
     if not sub_code or not isinstance(sub_code, str):
@@ -457,6 +541,7 @@ async def verify_object_evidence(
     document_id: Optional[int],
     actor: models.User,
     expected_version: int,
+    acknowledge_post_publish: bool = False,
 ) -> Tuple[models.AdmissionProfile, Callable[[], Awaitable[None]]]:
     """Officer verifies UT evidence cho 1 sub_code (Phase E.3).
 
@@ -471,10 +556,14 @@ async def verify_object_evidence(
 
     Raises:
         ConflictError: version mismatch.
-        BusinessRuleViolation: sub_code not submitted / hard-denied status.
+        BusinessRuleViolation: sub_code not submitted / hard-denied status /
+            post-publish without acknowledge.
+        PermissionError: officer/manager attempts post-publish mutation
+            (router maps to 403).
     """
     await _evidence_mutation_common_checks(
-        profile, sub_code, actor, expected_version
+        profile, sub_code, actor, expected_version,
+        acknowledge_post_publish=acknowledge_post_publish,
     )
 
     # Phase E.4 PR-2 P1 fix (audit cycle 2026-05-20) — server-side document
@@ -621,6 +710,7 @@ async def reject_object_evidence(
     reject_reason: str,
     actor: models.User,
     expected_version: int,
+    acknowledge_post_publish: bool = False,
 ) -> Tuple[models.AdmissionProfile, Callable[[], Awaitable[None]]]:
     """Officer rejects UT evidence cho 1 sub_code (Phase E.3).
 
@@ -635,10 +725,13 @@ async def reject_object_evidence(
     Raises:
         ConflictError: version mismatch.
         BusinessRuleViolation: sub_code not submitted / reason length /
-            hard-denied status.
+            hard-denied status / post-publish without acknowledge.
+        PermissionError: officer/manager attempts post-publish mutation
+            (router maps to 403).
     """
     await _evidence_mutation_common_checks(
-        profile, sub_code, actor, expected_version
+        profile, sub_code, actor, expected_version,
+        acknowledge_post_publish=acknowledge_post_publish,
     )
 
     reason_clean = (reject_reason or "").strip()
@@ -749,6 +842,7 @@ async def untick_priority_evidence(
     sub_code: str,
     actor: models.User,
     expected_version: int,
+    acknowledge_post_publish: bool = False,
 ) -> Tuple[models.AdmissionProfile, Callable[[bool], Awaitable[None]]]:
     """Untick UT code + cascade hard delete evidence file (Phase E.4 G1).
 
@@ -792,7 +886,8 @@ async def untick_priority_evidence(
 
     # Version + status + sub_code guards (reuse common helper)
     await _evidence_mutation_common_checks(
-        profile, sub_code, actor, expected_version
+        profile, sub_code, actor, expected_version,
+        acknowledge_post_publish=acknowledge_post_publish,
     )
 
     # Find ProfileDocument row to delete (if exists)

--- a/Backend_FastAPI/tests/unit/test_phase_e4_pr4_compliance.py
+++ b/Backend_FastAPI/tests/unit/test_phase_e4_pr4_compliance.py
@@ -809,3 +809,158 @@ def test_priority_object_evidence_entry_verified_still_works_unchanged() -> None
     assert entry.document_id == 153
     assert entry.rejected_by is None
     assert entry.rejected_at is None
+
+
+# ===========================================================================
+# Smoke 2026-05-21 hotfix #3 — UT verify/reject post-publish state guard
+# ===========================================================================
+# User audit on hotfix-2 main caught that _evidence_mutation_common_checks
+# only blocked draft/withdrawn/dropped, permitting verify/reject on
+# approved/confirmed/enrolled/result_published/admitted/waitlisted —
+# every such call recomputes ut_verified_bucket + bumps version, silently
+# shifting published UT points after results were committed.
+#
+# Fix mirrors override_kv's pattern (priority_override_service.py:81-97):
+# allowlist [submitted, reviewing, revision_requested, resubmitted];
+# post-publish refused for officer/manager (PermissionError → 403),
+# admin needs explicit acknowledge_post_publish=True.
+
+
+def _ut_actor(role: str = "officer", actor_id: int = 7) -> SimpleNamespace:
+    return SimpleNamespace(id=actor_id, role=role)
+
+
+def _ut_profile(
+    status: str = "submitted",
+    version: int = 5,
+    codes: list[str] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=42,
+        status=status,
+        version=version,
+        priority_object_codes=codes if codes is not None else ["07"],
+        priority_object_evidence={"07": {"status": "pending"}},
+    )
+
+
+async def test_evidence_mutation_officer_refused_in_approved_state() -> None:
+    """Officer attempt to verify/reject on post-publish profile → PermissionError.
+
+    Pre-fix: this passed because approved wasn't in the 3-state denial list.
+    Post-fix: officer hits _EVIDENCE_POST_PUBLISH_STATUS branch, gets
+    PermissionError, router maps to 403.
+    """
+    from app.services.priority_override_service import (
+        _evidence_mutation_common_checks,
+    )
+
+    profile = _ut_profile(status="approved")
+    actor = _ut_actor(role="officer")
+
+    with pytest.raises(PermissionError, match="post-publish"):
+        await _evidence_mutation_common_checks(
+            profile, "07", actor, expected_version=5
+        )
+
+
+async def test_evidence_mutation_manager_refused_in_enrolled_state() -> None:
+    """Manager (non-admin) also refused on enrolled — Student record exists.
+
+    Manager has full review perms in submitted/reviewing, but enrolled
+    profile has materialized Student + StudentDocument. Mutating UT bucket
+    here would drift snapshot from the historical record.
+    """
+    from app.services.priority_override_service import (
+        _evidence_mutation_common_checks,
+    )
+
+    profile = _ut_profile(status="enrolled")
+    actor = _ut_actor(role="manager")
+
+    with pytest.raises(PermissionError, match="post-publish"):
+        await _evidence_mutation_common_checks(
+            profile, "07", actor, expected_version=5
+        )
+
+
+async def test_evidence_mutation_admin_blocked_without_acknowledge() -> None:
+    """Admin on post-publish requires explicit acknowledge_post_publish=True.
+
+    Without the flag, the gate raises BusinessRuleViolation telling admin
+    to confirm the override decision — same pattern as KV override.
+    """
+    from app.services.priority_override_service import (
+        _evidence_mutation_common_checks,
+    )
+    from app.utils.exceptions import BusinessRuleViolation
+
+    profile = _ut_profile(status="result_published")
+    actor = _ut_actor(role="admin")
+
+    with pytest.raises(BusinessRuleViolation, match="acknowledge_post_publish"):
+        await _evidence_mutation_common_checks(
+            profile, "07", actor, expected_version=5,
+            acknowledge_post_publish=False,
+        )
+
+
+async def test_evidence_mutation_admin_passes_with_acknowledge() -> None:
+    """Admin with acknowledge_post_publish=True on post-publish passes
+    the state guard.
+
+    Sub_code + version checks still apply; if all green, no raise.
+    """
+    from app.services.priority_override_service import (
+        _evidence_mutation_common_checks,
+    )
+
+    profile = _ut_profile(status="admitted")
+    actor = _ut_actor(role="admin")
+
+    # Should not raise
+    await _evidence_mutation_common_checks(
+        profile, "07", actor, expected_version=5,
+        acknowledge_post_publish=True,
+    )
+
+
+async def test_evidence_mutation_passes_in_allowed_states() -> None:
+    """Allowlist states pass without acknowledge for any actor role."""
+    from app.services.priority_override_service import (
+        _evidence_mutation_common_checks,
+    )
+
+    for status in ("submitted", "reviewing", "revision_requested", "resubmitted"):
+        profile = _ut_profile(status=status)
+        # Officer succeeds in each allowed state
+        await _evidence_mutation_common_checks(
+            profile, "07", _ut_actor(role="officer"), expected_version=5
+        )
+        # Admin also succeeds (no acknowledge needed in allowed states)
+        await _evidence_mutation_common_checks(
+            profile, "07", _ut_actor(role="admin"), expected_version=5
+        )
+
+
+async def test_evidence_mutation_hard_denied_states_block_everyone() -> None:
+    """draft / withdrawn / dropped / rejected hard-deny everyone including
+    admin. ``acknowledge_post_publish`` does NOT bypass this.
+
+    These states represent profiles where verify/reject has no coherent
+    meaning (draft = candidate editing, terminal states = no decision to
+    record).
+    """
+    from app.services.priority_override_service import (
+        _evidence_mutation_common_checks,
+    )
+    from app.utils.exceptions import BusinessRuleViolation
+
+    for status in ("draft", "withdrawn", "dropped", "rejected"):
+        profile = _ut_profile(status=status)
+        # Even admin with acknowledge=True can't bypass hard-denied
+        with pytest.raises(BusinessRuleViolation):
+            await _evidence_mutation_common_checks(
+                profile, "07", _ut_actor(role="admin"),
+                expected_version=5, acknowledge_post_publish=True,
+            )


### PR DESCRIPTION
## Summary

User audit on post hotfix-2 main caught that `_evidence_mutation_common_checks` only blocked `draft/withdrawn/dropped`, permitting officer/manager/admin to verify/reject UT evidence on profiles already in `approved/confirmed/enrolled/result_published/admitted/waitlisted`.

Each call recomputes `priority_resolution_snapshot.ut_verified_bucket` + bumps profile version (`priority_override_service.py:553` and `:678`) → silently shifts published UT bucket points after results were committed. Parity with documents-policy concern at `admission_document_policy.py:37` blocking reviewer mutation post-enrolled.

## Fix

Mirror manual KV override gate pattern (`_OFFICER_ALLOWED_STATUS` + `_POST_PUBLISH_STATUS` + `acknowledge_post_publish`):

- **`_EVIDENCE_OFFICER_ALLOWED_STATUS`** = `{submitted, reviewing, revision_requested, resubmitted}` — allowlist for normal review-phase verify/reject.
- **`_EVIDENCE_POST_PUBLISH_STATUS`** = same as KV override (`approved/confirmed/enrolled/overridden/result_published/admitted/waitlisted`). Officer/manager refused → `PermissionError` → router 403; admin must opt in with `acknowledge_post_publish=True`.
- **`_EVIDENCE_HARD_DENIED_STATUS`** extended with `rejected` — verify/reject has no coherent meaning on rejected admissions.
- Legacy `_EVIDENCE_DENIED_STATUS` alias retained (3-state set) for any external callers.

`verify_object_evidence`, `reject_object_evidence`, and `untick_priority_evidence` all accept `acknowledge_post_publish` kwarg and forward it. Request schemas `VerifyObjectEvidenceRequest` + `RejectObjectEvidenceRequest` add the same flag (default False, `extra='forbid'` preserved).

Routers wrap service calls in `PermissionError → HTTPException(403)` mapper (parity with `override_priority_kv` handler).

## Regression tests (6 new, total 24 in compliance suite)

- `test_evidence_mutation_officer_refused_in_approved_state` — pre-fix passed, post-fix raises PermissionError
- `test_evidence_mutation_manager_refused_in_enrolled_state` — manager also blocked post-Student record
- `test_evidence_mutation_admin_blocked_without_acknowledge` — admin needs explicit opt-in
- `test_evidence_mutation_admin_passes_with_acknowledge` — happy path for legitimate post-publish corrections
- `test_evidence_mutation_passes_in_allowed_states` — submitted/reviewing/revision_requested/resubmitted pass for both officer + admin
- `test_evidence_mutation_hard_denied_states_block_everyone` — draft/withdrawn/dropped/rejected block even admin with acknowledge=True

**24/24 PASS** `test_phase_e4_pr4_compliance.py`, **28/28 PASS** adjacent `test_phase_e4_pr2_priority_evidence.py` + `test_priority_evidence_service.py` → no regression.

## Smoke gate closure

This addresses the P1 from the user audit post `#320`. With this gate live:

- Officer cannot drift published UT bucket after approval/enrolment (would otherwise silently re-sum points on a profile that already has decision results sent).
- Admin can still correct legitimate post-publish errors with explicit `acknowledge_post_publish=true` — surfaces in the audit trail.

After merge + Chrome MCP re-verification, Phase E.4 SPEC complete declaration becomes appropriate.

## Test plan

- [ ] CI: pytest + Check (type+lint+test) + Build + Node/Python Dependencies all PASS
- [ ] After merge: verify officer call to verify/reject on profile 39 (status=submitted) still works (allowlist) — should pass
- [ ] Manual API probe: PATCH `.../priority-objects/07/verify` on a profile with status=approved as officer → expect 403

## Scope

Branch `fix/phase-e4-smoke-hotfix-3-ut-state-allowlist`, base on main `31c6fbcb`. Tracked diff = 4 files:

- `Backend_FastAPI/app/services/priority_override_service.py` (state guard refactor)
- `Backend_FastAPI/app/schemas/admission.py` (+ acknowledge_post_publish on 2 schemas)
- `Backend_FastAPI/app/routers/admissions_v2.py` (PermissionError → 403 wrapping)
- `Backend_FastAPI/tests/unit/test_phase_e4_pr4_compliance.py` (6 regression tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)