### PR TITLE
feat(q9-07/phase-e4): KV business resolution + UT permission hardening (17 commits)

### DIFF
--- a/Backend_FastAPI/alembic/versions/q9_07_e4e_seed_kv_business_resolution.py
+++ b/Backend_FastAPI/alembic/versions/q9_07_e4e_seed_kv_business_resolution.py
@@ -1,0 +1,223 @@
+"""q9_07_e4e: seed KV business resolution baseline (priority_area_config + default_bonus_rule)
+
+Revision ID: q9_07_e4e
+Revises: q9_07_e4d
+Create Date: 2026-05-21
+
+Q9 #07 Phase E.4 — engine KV chỉ hoạt động khi có 2 catalog seed này:
+
+1. ``priority_area_config`` (academic_year=2026): 4 hàng KV1/KV2-NT/KV2/KV3.
+   Không có hàng nào → ``_resolve_area_bonus()`` trả về None → mọi candidate
+   cộng 0đ KV bất kể engine resolve ra KV nào. Audit verified
+   (2026-05-21): ``SELECT count(*) FROM priority_area_config = 0``.
+
+2. ``admission_method.default_bonus_rule`` cho 3 method codes (hoc_ba,
+   thpt_qg, xet_tuyen_thang). Không có default → ``resolve_effective_bonus_rule()``
+   trả về None → engine treats as "no bonus" → 0đ. Audit verified
+   (2026-05-21): 0/3 methods có default; 52/55 admission_path có
+   ``bonus_rule_override`` NULL + 3/55 có jsonb `null` string. → mọi path
+   fall qua method default chain.
+
+Bonus rules đã chốt với product (Q4 trong báo cáo rà soát 2026-05-21):
+  hoc_ba          = area:true,  object:true,  max:2.75
+  thpt_qg         = area:true,  object:true,  max:2.75
+  xet_tuyen_thang = area:false, object:false, max:0.00  (tuyển thẳng không cộng ưu tiên)
+
+Per memory ``migration-predicate-safety``: idempotent guards (INSERT WHERE
+NOT EXISTS + UPDATE WHERE current_value matches pre-state) — safe re-run.
+
+Downgrade revert chỉ những giá trị engine seed (so sánh JSONB exact match);
+nếu admin đã chỉnh sau migration, downgrade KHÔNG ghi đè để bảo toàn ops change.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "q9_07_e4e"
+down_revision: Union[str, None] = "q9_07_e4d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# (area_code, area_name, bonus_points, description)
+_AREA_CONFIG_2026 = [
+    ("KV1", "Khu vực 1", 0.75, "Vùng miền núi, dân tộc thiểu số, biên giới, hải đảo (TT 05/2021 Phụ lục 01)"),
+    ("KV2-NT", "Khu vực 2 - Nông thôn", 0.50, "Nông thôn không thuộc KV1"),
+    ("KV2", "Khu vực 2", 0.25, "Thành phố thuộc tỉnh, phường ngoại thành TP trực thuộc TƯ"),
+    ("KV3", "Khu vực 3", 0.00, "Nội thành TP trực thuộc TƯ (không cộng ưu tiên)"),
+]
+
+# (method_code, default_bonus_rule JSONB)
+_METHOD_BONUS_RULES = [
+    (
+        "hoc_ba",
+        {
+            "apply_area_bonus": True,
+            "apply_object_bonus": True,
+            "max_total_bonus": 2.75,
+            "exception_codes": [],
+        },
+    ),
+    (
+        "thpt_qg",
+        {
+            "apply_area_bonus": True,
+            "apply_object_bonus": True,
+            "max_total_bonus": 2.75,
+            "exception_codes": [],
+        },
+    ),
+    (
+        "xet_tuyen_thang",
+        {
+            "apply_area_bonus": False,
+            "apply_object_bonus": False,
+            "max_total_bonus": 0.00,
+            "exception_codes": [],
+        },
+    ),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # ============================================================
+    # 1. Seed priority_area_config (academic_year=2026)
+    # ============================================================
+    pre_count = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM priority_area_config "
+            "WHERE academic_year = 2026 AND effective_to IS NULL"
+        )
+    ).scalar()
+    print(f"[q9_07_e4e] Pre-flight priority_area_config active 2026 rows={pre_count}")
+
+    area_inserted = 0
+    for area_code, area_name, bonus_points, description in _AREA_CONFIG_2026:
+        result = conn.execute(
+            sa.text(
+                """
+                INSERT INTO priority_area_config
+                    (academic_year, area_code, area_name, bonus_points,
+                     description, effective_from)
+                SELECT 2026,
+                       CAST(:area_code AS VARCHAR),
+                       CAST(:area_name AS VARCHAR),
+                       CAST(:bonus_points AS NUMERIC(4,2)),
+                       CAST(:description AS TEXT),
+                       DATE '2026-01-01'
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM priority_area_config
+                    WHERE academic_year = 2026
+                      AND area_code = CAST(:area_code AS VARCHAR)
+                      AND effective_to IS NULL
+                )
+                """
+            ),
+            {
+                "area_code": area_code,
+                "area_name": area_name,
+                "bonus_points": bonus_points,
+                "description": description,
+            },
+        )
+        area_inserted += result.rowcount
+
+    print(f"[q9_07_e4e] Seeded priority_area_config rows inserted={area_inserted}")
+
+    # ============================================================
+    # 2. Update admission_method.default_bonus_rule
+    # ============================================================
+    # Idempotent: chỉ UPDATE khi default_bonus_rule IS NULL (chưa được
+    # seed/admin chỉnh). Trường hợp admin đã set sau migration → giữ
+    # nguyên ops change, KHÔNG ghi đè.
+    method_updated = 0
+    for method_code, rule_dict in _METHOD_BONUS_RULES:
+        import json
+        rule_json = json.dumps(rule_dict)
+        result = conn.execute(
+            sa.text(
+                """
+                UPDATE admission_method
+                SET default_bonus_rule = CAST(:rule_json AS JSONB)
+                WHERE code = CAST(:method_code AS VARCHAR)
+                  AND default_bonus_rule IS NULL
+                """
+            ),
+            {"method_code": method_code, "rule_json": rule_json},
+        )
+        method_updated += result.rowcount
+
+    print(f"[q9_07_e4e] Updated admission_method.default_bonus_rule rows={method_updated}")
+
+    # ============================================================
+    # 3. Verification report
+    # ============================================================
+    post_areas = conn.execute(
+        sa.text(
+            "SELECT count(*) FROM priority_area_config "
+            "WHERE academic_year = 2026 AND effective_to IS NULL"
+        )
+    ).scalar()
+    post_methods = conn.execute(
+        sa.text(
+            "SELECT count(*) FROM admission_method "
+            "WHERE code IN ('hoc_ba', 'thpt_qg', 'xet_tuyen_thang') "
+            "  AND default_bonus_rule IS NOT NULL"
+        )
+    ).scalar()
+    print(
+        f"[q9_07_e4e] Post-state priority_area_config active 2026={post_areas} "
+        f"(expected 4), methods with default_bonus_rule={post_methods} (expected 3)"
+    )
+
+
+def downgrade() -> None:
+    """Revert seeded values ONLY if they still match seed shape.
+
+    Admin có thể đã chỉnh post-migration; downgrade KHÔNG ghi đè change đó.
+    Match logic:
+      - priority_area_config: match on (area_code, bonus_points)
+      - admission_method.default_bonus_rule: match exact JSONB shape
+    """
+    conn = op.get_bind()
+
+    # Revert priority_area_config — chỉ DELETE rows match seed value
+    area_deleted = 0
+    for area_code, _area_name, bonus_points, _description in _AREA_CONFIG_2026:
+        result = conn.execute(
+            sa.text(
+                """
+                DELETE FROM priority_area_config
+                WHERE academic_year = 2026
+                  AND area_code = CAST(:area_code AS VARCHAR)
+                  AND bonus_points = CAST(:bonus_points AS NUMERIC(4,2))
+                  AND effective_to IS NULL
+                """
+            ),
+            {"area_code": area_code, "bonus_points": bonus_points},
+        )
+        area_deleted += result.rowcount
+    print(f"[q9_07_e4e] Downgrade: deleted priority_area_config rows={area_deleted}")
+
+    # Revert admission_method.default_bonus_rule — match exact JSONB
+    method_reverted = 0
+    for method_code, rule_dict in _METHOD_BONUS_RULES:
+        import json
+        rule_json = json.dumps(rule_dict)
+        result = conn.execute(
+            sa.text(
+                """
+                UPDATE admission_method
+                SET default_bonus_rule = NULL
+                WHERE code = CAST(:method_code AS VARCHAR)
+                  AND default_bonus_rule = CAST(:rule_json AS JSONB)
+                """
+            ),
+            {"method_code": method_code, "rule_json": rule_json},
+        )
+        method_reverted += result.rowcount
+    print(f"[q9_07_e4e] Downgrade: reverted admission_method default_bonus_rule rows={method_reverted}")

--- a/Backend_FastAPI/alembic/versions/q9_07_e4f_remove_officer_override_kv_policy.py
+++ b/Backend_FastAPI/alembic/versions/q9_07_e4f_remove_officer_override_kv_policy.py
@@ -1,0 +1,106 @@
+"""q9_07_e4f: remove officer override-priority-kv policy (commit 7 hardening)
+
+Revision ID: q9_07_e4f
+Revises: q9_07_e4e
+Create Date: 2026-05-21
+
+Q9 #07 Phase E.4 commit 7 — KV override permission hardening per yêu cầu
+nghiệp vụ #10: officer KHÔNG được override KV. Chỉ admin/manager.
+
+Pre-commit 7 state (seeded ở q9_07_e0c):
+  - role:officer allow override-priority-kv POST
+  - role:manager allow override-priority-kv POST
+  - role:admin allow override-priority-kv POST
+  - role:accountant deny
+
+Post-commit 7 state:
+  - role:officer DELETED (hard-deny ở service layer + Casbin)
+  - role:manager allow (unchanged)
+  - role:admin allow (unchanged)
+  - role:accountant deny (unchanged)
+
+Service-level priority_override_service.override_kv() cũng raise
+BusinessRuleViolation cho actor.role=="officer" — defense-in-depth.
+
+Idempotent: DELETE WHERE (cụ thể 4-tuple) — safe re-run.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "q9_07_e4f"
+down_revision: Union[str, None] = "q9_07_e4e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Single row removal — officer override-priority-kv allow
+_OFFICER_OVERRIDE_KV_POLICY = (
+    "role:officer",
+    "/api/v2/admissions/*/override-priority-kv",
+    "POST",
+    "allow",
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    v0, v1, v2, v3 = _OFFICER_OVERRIDE_KV_POLICY
+
+    pre_count = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM casbin_rule "
+            "WHERE ptype='p' AND v0=:v0 AND v1=:v1 AND v2=:v2 AND v3=:v3"
+        ),
+        {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+    ).scalar()
+    print(
+        f"[q9_07_e4f] Pre-flight: existing officer override-priority-kv "
+        f"rows={pre_count} (expected 1 if q9_07_e0c applied)"
+    )
+
+    result = conn.execute(
+        sa.text(
+            "DELETE FROM casbin_rule "
+            "WHERE ptype='p' AND v0=:v0 AND v1=:v1 AND v2=:v2 AND v3=:v3"
+        ),
+        {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+    )
+    print(f"[q9_07_e4f] Removed {result.rowcount} officer override-priority-kv row(s).")
+
+
+def downgrade() -> None:
+    """Re-insert officer policy row (revert to pre-commit 7 state).
+
+    Note: service-layer hard-deny officer remains active even after downgrade
+    (code change in priority_override_service.override_kv). Downgrade is for
+    schema-level rollback only; full revert requires git revert of commit 7.
+    """
+    conn = op.get_bind()
+    v0, v1, v2, v3 = _OFFICER_OVERRIDE_KV_POLICY
+
+    result = conn.execute(
+        sa.text(
+            """
+            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id, applied_at)
+            SELECT 'p',
+                   CAST(:v0 AS VARCHAR),
+                   CAST(:v1 AS VARCHAR),
+                   CAST(:v2 AS VARCHAR),
+                   CAST(:v3 AS VARCHAR),
+                   '_q9_07_e4f_downgrade_restore',
+                   NOW()
+            WHERE NOT EXISTS (
+                SELECT 1 FROM casbin_rule
+                WHERE ptype='p' AND v0=CAST(:v0 AS VARCHAR)
+                  AND v1=CAST(:v1 AS VARCHAR)
+                  AND v2=CAST(:v2 AS VARCHAR)
+                  AND v3=CAST(:v3 AS VARCHAR)
+            )
+            """
+        ),
+        {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+    )
+    print(f"[q9_07_e4f] Downgrade: re-inserted {result.rowcount} officer policy row(s).")

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -196,12 +196,14 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/v2/admissions/*/choices/*",         "action": "DELETE"},
         {"subject": "{role}", "object": "/api/v2/admissions/*/choices/*",         "action": "PATCH"},
         {"subject": "{role}", "object": "/api/v2/admissions/*/choices/*/scores",  "action": "PATCH"},
-        # Q9 #07 Phase E — Priority bonus override + UT evidence verify/reject.
-        # Officer scope: must be assigned to profile (IDOR check trong service);
-        # manager + admin inherit via diamond. Accountant DENY block below.
-        # Service-layer additional gates: version guard (memory
-        # `version-guard-before-state-machine`) + status whitelist (officer mode).
-        {"subject": "{role}", "object": "/api/v2/admissions/*/override-priority-kv",          "action": "POST"},
+        # Q9 #07 Phase E — Priority bonus + UT evidence verify/reject.
+        # Officer scope: assigned to profile (IDOR check trong service);
+        # manager + admin inherit via diamond (verify/reject). Accountant
+        # DENY block below.
+        # Phase E.4 commit 7 hardening (yêu cầu nghiệp vụ #10): override-
+        # priority-kv MOVED TO MANAGER_TEMPLATE — officer KHÔNG được override
+        # KV. Service-layer priority_override_service hard-deny officer ngay
+        # đầu override_kv là defense-in-depth.
         {"subject": "{role}", "object": "/api/v2/admissions/*/priority-objects/*/verify",     "action": "PATCH"},
         {"subject": "{role}", "object": "/api/v2/admissions/*/priority-objects/*/reject",     "action": "PATCH"},
         # Q9 #07 Phase E.4 PR-2 — Priority evidence upload + untick (officer
@@ -469,6 +471,10 @@ MANAGER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/admissions/{id}/reject", "action": "POST"},  # Reject profile
         {"subject": "{role}", "object": "/api/admissions/{id}/request-revision", "action": "POST"},  # Request revision
         {"subject": "{role}", "object": "/api/admissions/{id}/override", "action": "POST"},  # Override decision
+        # Q9 #07 Phase E.4 commit 7 — Manual KV override (manager-explicit;
+        # officer hard-blocked at service level per nghiệp vụ #10). Admin
+        # inherits via wildcard `/*`.
+        {"subject": "{role}", "object": "/api/v2/admissions/*/override-priority-kv", "action": "POST"},
         # NOTE: /withdraw lives in OFFICER_TEMPLATE — manager inherits via diamond.
         {"subject": "{role}", "object": "/api/admissions/{id}/claim", "action": "POST"},  # Claim profile for review
         {"subject": "{role}", "object": "/api/admissions/{id}/unclaim", "action": "POST"},  # Unclaim profile

--- a/Backend_FastAPI/app/models/major_program.py
+++ b/Backend_FastAPI/app/models/major_program.py
@@ -51,6 +51,11 @@ class MajorProgram(Base):
         comment="FK to config_degree_level. Canonical lookup; "
                 "backfilled from legacy degree_level text column."
     )
+    # Phase E.4 (Q9 #07) — relationship cho derive_target_level_and_type()
+    # ở priority_service. Engine đọc ``degree_level_ref.code`` để map ra
+    # config_degree_level.code ("cao_dang"/"trung_cap"/"so_cap"). Eager-load
+    # bằng selectinload(MajorProgram.degree_level_ref) trong callers.
+    degree_level_ref = relationship("ConfigDegreeLevel", lazy="raise")
     code = Column(
         String(50),
         unique=True,

--- a/Backend_FastAPI/app/models/major_program.py
+++ b/Backend_FastAPI/app/models/major_program.py
@@ -55,6 +55,17 @@ class MajorProgram(Base):
     # ở priority_service. Engine đọc ``degree_level_ref.code`` để map ra
     # config_degree_level.code ("cao_dang"/"trung_cap"/"so_cap"). Eager-load
     # bằng selectinload(MajorProgram.degree_level_ref) trong callers.
+    #
+    # P2 deferred (post-launch FU): chain selectinload pattern (.academic_info
+    # → .offering → .program → .degree_level_ref + .offering_type_config) lặp
+    # ở 5 chỗ (admissions_v2.publish, admission_service._validate_eligibility_
+    # all_choices x2, priority_service.derive_profile_target_context x2). Root
+    # entity khác nhau (AdmissionProfile/AdmissionProfileChoice/Offering
+    # AdmissionConfig) nên extract chung helper sẽ có signature phức tạp +
+    # cross-module import. Anchor test (test_priority_config_models.py:
+    # test_major_program_degree_level_ref_uses_lazy_raise) đã pin contract
+    # lazy="raise"; nếu caller quên eager-load sẽ raise tại runtime — đủ net
+    # cho regression. Write-path low volume nên acceptable trade-off.
     degree_level_ref = relationship("ConfigDegreeLevel", lazy="raise")
     code = Column(
         String(50),

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -689,7 +689,10 @@ async def preview_priority_kv(
     - Casbin: standard read scope (any authenticated user with profile access)
     """
     from copy import copy
-    from app.services.priority_service import resolve_kv_for_profile
+    from app.services.priority_service import (
+        derive_profile_target_context,
+        resolve_kv_for_profile,
+    )
 
     # Build transient profile-like object: profile DB state + form overrides.
     # Shallow copy + override avoids SQLAlchemy session mutation persisting.
@@ -715,7 +718,20 @@ async def preview_priority_kv(
     if payload.priority_object_codes is not None:
         preview_profile.priority_object_codes = payload.priority_object_codes
 
-    kv, meta = await resolve_kv_for_profile(preview_profile, db)
+    # Phase E.4 commit 5 fix: preview phải pass target_level + admission_type
+    # vào resolve_kv_for_profile. Trước fix: preview rơi vào legacy matrix
+    # (target_level=None) → CĐ chính quy + completed_thpt được map sang
+    # THUONG_TRU thay vì LICH_SU_THPT → basis hiển thị FE sai trước submit.
+    # Sau fix: dùng derive_profile_target_context() trên profile DB state
+    # (NOT preview_profile, vì context derive từ path chain DB-side, KHÔNG
+    # phụ thuộc form overrides).
+    target_ctx = await derive_profile_target_context(profile, db)
+    kv, meta = await resolve_kv_for_profile(
+        preview_profile,
+        db,
+        target_level=target_ctx.get("target_level"),
+        admission_type=target_ctx.get("admission_type"),
+    )
 
     # Look up bonus rates — KV area_bonus + UT object_bonus (potential + verified)
     # academic_year derived từ profile.admission_path.admission_round nếu có

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -118,6 +118,23 @@ async def publish_admission_result(
             selectinload(models.AdmissionProfile.choices)
             .selectinload(models.AdmissionProfileChoice.admission_path)
             .selectinload(models.AdmissionPath.criteria),
+            # Q9 #07 Phase E.4 — choice-engine gate 0 (eligibility) needs
+            # derive_target_level_and_type(path), which reads:
+            #   path.academic_info.offering.program.degree_level_ref.code
+            #   path.academic_info.offering.offering_type_config.code
+            # Without this chain, gate 0 raises CONFIG_GAP_TARGET_LEVEL and
+            # every choice rejects silently. Mirrors the bonus_rule chain.
+            selectinload(models.AdmissionProfile.choices)
+            .selectinload(models.AdmissionProfileChoice.admission_path)
+            .selectinload(models.AdmissionPath.academic_info)
+            .selectinload(models.OfferingAcademicInfo.offering)
+            .selectinload(models.ProgramOffering.program)
+            .selectinload(models.MajorProgram.degree_level_ref),
+            selectinload(models.AdmissionProfile.choices)
+            .selectinload(models.AdmissionProfileChoice.admission_path)
+            .selectinload(models.AdmissionPath.academic_info)
+            .selectinload(models.OfferingAcademicInfo.offering)
+            .selectinload(models.ProgramOffering.offering_type_config),
             # SubjectGroup uses subject_mappings (M2M) → SubjectGroupSubject.subject
             # NOT direct `subjects` relation (em earlier drift, fixed).
             selectinload(models.AdmissionProfile.choices)

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -925,14 +925,15 @@ async def get_priority_object_catalog(
 
 
 # =============================================================================
-# Q9 #07 Phase E.2 — Manual KV override (officer/admin write-path)
+# Q9 #07 Phase E.2 + E.4 commit 7 hardening — Manual KV override
+# (admin + manager write-path; officer hard-denied per nghiệp vụ #10)
 # =============================================================================
 
 
 @router.post(
     "/{profile_id}/override-priority-kv",
     response_model=schemas.AdmissionProfileResponse,
-    summary="Override KV thủ công (officer/admin write-path — Phase E.2)",
+    summary="Override KV thủ công (admin/manager write-path — Phase E.4)",
 )
 async def override_priority_kv(
     profile_id: int,
@@ -941,27 +942,36 @@ async def override_priority_kv(
     profile: models.AdmissionProfile = Depends(get_admission_for_user),
     current_user: models.User = CasbinAuth,
 ):
-    """Officer/admin manually override profile's KV (Phase E.2 write-path).
+    """Admin/manager manually override profile's KV (Phase E.2 + E.4 commit 7).
+
+    Phase E.4 commit 7 hardening (yêu cầu nghiệp vụ #10): officer hard-denied
+    toàn diện. Chỉ admin/manager. Casbin migration q9_07_e4f đã remove
+    role:officer policy row; service-layer cũng raise BusinessRuleViolation
+    cho actor.role=="officer" là defense-in-depth.
 
     Service-layer ``priority_override_service.override_kv()`` enforces:
     * Version guard FIRST (memory `version-guard-before-state-machine`)
-    * Status whitelist (officer: submitted/reviewing/revision_requested;
-      admin bypass với ``acknowledge_post_publish=true`` for post-publish)
+    * Role gate: officer DENIED unconditionally (BusinessRuleViolation 400)
+    * Status whitelist (manager: submitted/reviewing/revision_requested +
+      draft khi engine signal unresolved; admin bypass với
+      ``acknowledge_post_publish=true`` for post-publish)
     * Reason 20-500 char validation
+    * Live engine recompute cho draft (verify still unresolved)
     * Snapshot mutation + audit log INSERT + version bump
 
     Snapshot keys overwritten on each override (Decision D1):
     * ``manual_override_by/at/reason`` + ``evidence_file_id``
-    * ``frozen_at_status='manual_override'`` + ``resolved_by`` (officer/admin)
+    * ``frozen_at_status='manual_override'`` + ``resolved_by`` (admin|manager)
 
     Audit log preserves full chain — query via composite index
     ``(profile_id, action_type, created_at DESC)``.
 
     Security:
-    * IDOR: ``get_admission_for_user`` (3-tier scope admin/manager/officer)
-    * Casbin: ``q9_07_e0c`` migration seeds policy
-      (officer/manager/admin ALLOW, accountant DENY).
-    * Service ``PermissionError`` (officer post-publish) → 403.
+    * IDOR: ``get_admission_for_user`` (3-tier scope admin/manager/officer
+      read; officer cannot reach mutation per Casbin q9_07_e4f).
+    * Casbin: ``q9_07_e0c`` seeds policy, ``q9_07_e4f`` removes officer row
+      (admin/manager ALLOW, officer NO POLICY, accountant DENY).
+    * Service ``PermissionError`` (manager post-publish) → 403.
 
     Dispatches ``PRIORITY_KV_OVERRIDDEN`` event post-commit (catalog seed
     Wave 1; payload: application_id, lead_id, actor_id, actor_name,

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -992,8 +992,11 @@ async def override_priority_kv(
             acknowledge_post_publish=payload.acknowledge_post_publish,
         )
     except PermissionError as exc:
-        # Officer attempted post-publish override; map to 403 per memory
-        # `version-guard-before-state-machine` adjacent pattern.
+        # Phase E.4 commit 7: officer hard-blocked ở service top (raises
+        # BusinessRuleViolation 400, NOT PermissionError). Branch này thực
+        # tế là manager attempted post-publish override (admin-only). Map
+        # to 403 per memory `version-guard-before-state-machine` adjacent
+        # pattern.
         raise HTTPException(status_code=403, detail=str(exc))
 
     await db.commit()

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -2288,20 +2288,29 @@ class PriorityObjectCatalogItem(BaseModel):
 
 
 # =============================================================================
-# Q9 #07 Phase E.2 — Manual KV override (officer/admin write-path)
+# Q9 #07 Phase E.2 + E.4 commit 7 — Manual KV override
+# (admin/manager write-path; officer hard-denied per nghiệp vụ #10)
 # =============================================================================
 
 
 class OverridePriorityKvRequest(BaseModel):
-    """Officer/admin override KV manually trên profile.
+    """Admin/manager override KV manually trên profile.
+
+    Phase E.4 commit 7 hardening: officer KHÔNG được override KV. Casbin
+    migration q9_07_e4f đã remove role:officer policy row; service-layer
+    raises BusinessRuleViolation cho actor.role=="officer".
 
     Service-layer (priority_override_service.override_kv) enforces:
     * Optimistic-lock via ``version`` body field (memory
       `version-guard-before-state-machine` — version guard runs FIRST,
       before status whitelist).
-    * Officer status whitelist {submitted, reviewing, revision_requested};
-      hard-deny {draft, withdrawn, dropped, rejected}; post-publish states
-      require admin role + ``acknowledge_post_publish=True``.
+    * Role gate: officer DENIED unconditionally; manager + admin allowed.
+    * Status whitelist:
+        - admin: any state (UI shows button; dialog handles post-publish ack)
+        - manager: submitted/reviewing/revision_requested + draft (engine
+          signal required, service verifies live recompute)
+        - withdrawn/dropped/rejected hard-deny (all roles)
+        - post-publish states require admin + ``acknowledge_post_publish=True``
     * Reason 20-500 char text (mandatory; persisted in
       ``profile.priority_resolution_snapshot.manual_override_reason``
       + ``priority_audit_log.new_value.reason``).

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -161,6 +161,40 @@ def _evaluate_single_choice(
     reason_codes: List[str] = []
     path = choice.admission_path
 
+    # Q9 #07 Phase E.4 — Gate 0: eligibility per target_level/admission_type
+    # TRƯỚC GPA gate (per priority_service pipeline). Fail-safe T6: nếu
+    # submit-time validate đã chạy thì pass-through; legacy magic-link
+    # paths chưa qua submit gate sẽ catch ở đây.
+    #
+    # Lazy import (cùng pattern với calculate_priority_bonus): priority_service
+    # imports app.models → circular dep nếu top-level import.
+    try:
+        from app.services.priority_service import (
+            derive_target_level_and_type,
+            validate_eligibility,
+        )
+
+        target_level, admission_type = derive_target_level_and_type(path)
+        passed_elig, elig_reason = validate_eligibility(
+            profile, target_level, admission_type
+        )
+        if not passed_elig:
+            reason_codes.append(f"ELIGIBILITY_FAIL:{elig_reason}")
+            return "rejected", None, reason_codes
+    except BusinessRuleViolation as gap_exc:
+        # CONFIG_GAP_TARGET_LEVEL — eager-load chain rỗng hoặc config missing.
+        # Mark reject với explicit code để admin debug. Engine KHÔNG fallback
+        # SC (per yêu cầu nghiệp vụ #5).
+        reason_codes.append(f"CONFIG_GAP_TARGET_LEVEL:{str(gap_exc)[:200]}")
+        log.warning(
+            "choice_eligibility_config_gap",
+            profile_id=getattr(profile, "id", None),
+            choice_id=getattr(choice, "id", None),
+            path_id=getattr(path, "id", None),
+            error=str(gap_exc),
+        )
+        return "rejected", None, reason_codes
+
     # Gate 1: min GPA threshold (Sub-1 helper)
     # AdmissionPath has FK to AdmissionCriteria via criteria_id. Eager-loaded.
     criteria = getattr(path, "criteria", None)

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -394,23 +394,48 @@ async def evaluate_cascade(
         # create a circular dep at module load time of this engine file.
         from app.services.priority_service import (
             calculate_priority_bonus,
+            derive_profile_target_context,
+            derive_target_level_and_type,
             freeze_priority_snapshot,
+            validate_eligibility,
         )
 
         # Q9 #07 Phase C — Re-freeze priority_resolution_snapshot at T6 engine.
         # T1 submit already froze with submit-time data; T6 re-freezes in
         # case academic_history / cultural fields were edited during
         # revision_requested cycle. Mirrors Q-P3-11 bonus_rule_snapshot
-        # double-freeze pattern. Best-effort: if KV resolution fails (eg
-        # missing commune data Phase B.2 pending), engine continues — the
-        # downstream calculate_priority_bonus reads snapshot.kv_resolved
-        # = None and returns 0đ gracefully.
+        # double-freeze pattern.
+        #
+        # Phase E.4 commit 5: T6 freeze bơm context từ choice hiện tại (eager-
+        # loaded path đầy đủ qua chain academic_info/offering/program). Cheaper
+        # than derive_profile_target_context() vì path đã ở memory.
         try:
+            t6_target_level: Optional[str] = None
+            t6_admission_type: Optional[str] = None
+            t6_eligibility: Optional[dict] = None
+            t6_bonus_rule: Optional[dict] = (
+                dict(choice.bonus_rule_snapshot) if choice.bonus_rule_snapshot else None
+            )
+            try:
+                t6_target_level, t6_admission_type = derive_target_level_and_type(path)
+                ok, reason = validate_eligibility(
+                    profile, t6_target_level, t6_admission_type
+                )
+                t6_eligibility = {"passed": ok, "reason": reason}
+            except Exception:  # noqa: BLE001
+                # Path chain missing → defer context, snapshot vẫn freeze với basis
+                # = INSUFFICIENT_DATA hoặc legacy matrix.
+                pass
+
             await freeze_priority_snapshot(
                 profile=profile,
                 db=db,
                 frozen_at_status="engine_T6",
                 resolved_by="system",
+                target_level=t6_target_level,
+                admission_type=t6_admission_type,
+                eligibility=t6_eligibility,
+                path_bonus_rule=t6_bonus_rule,
             )
         except Exception as kv_freeze_exc:  # noqa: BLE001
             log.warning(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1518,20 +1518,26 @@ def _compute_frontend_fields(
             )
             and (is_owner or is_manager or is_admin)
         ),
-        # Q9 #07 Phase E.2 — Manual KV override (officer/admin write-path).
-        # Service-layer (priority_override_service) enforces full whitelist
-        # + post-publish admin-only gate. UI uses this flag only to gate
-        # visibility of "Cán bộ ấn định thủ công" button trong PriorityTab.
-        # Officer must be assigned to profile via lead.assigned_officer_id;
-        # manager/admin scope handled by route's IDOR dep. Status whitelist
-        # here matches service-layer ``_OFFICER_ALLOWED_STATUS`` for officer
-        # path; admin bypasses (UI shows button regardless of status, dialog
-        # secondary checkbox for post-publish profiles).
+        # Q9 #07 Phase E.4 commit 7 hardening (yêu cầu nghiệp vụ #10):
+        # Officer KHÔNG được override KV. Chỉ admin + manager mới có quyền.
+        # Pre-fix-up: officer được override cho submitted/reviewing/
+        # revision_requested + ownership check. Hardening:
+        #   - admin: any state (UI shows button; dialog handles post-publish ack)
+        #   - manager: submitted/reviewing/revision_requested + draft (engine
+        #     signal required, service-layer gate verifies live recompute)
+        #   - officer / accountant / user: never (UI hide button)
+        # Service-layer (priority_override_service) cũng có hard-deny officer
+        # ngay đầu override_kv là defense-in-depth.
         "override_priority_kv": (
             is_admin
             or (
-                (is_manager or (is_officer and is_owner))
-                and status in ["submitted", "reviewing", "revision_requested"]
+                is_manager
+                and status in [
+                    "draft",
+                    "submitted",
+                    "reviewing",
+                    "revision_requested",
+                ]
             )
         ),
         # Q9 #07 Phase E.3 — UT evidence verify/reject (officer write-path).

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4240,15 +4240,18 @@ _KV_SUCCESS_RULE_APPLIED = frozenset({
 })
 
 
-def _assert_kv_resolved_for_submit(
+def _kv_unresolved_error_message(
     snapshot: Optional[dict],
     profile_id: int,
-) -> None:
-    """Raise BadRequest nếu snapshot không emit engine success signal.
+) -> Optional[str]:
+    """Return error message string nếu snapshot không emit engine success;
+    None khi snapshot resolve thành công.
 
-    Yêu cầu nghiệp vụ #7 + reviewer 2026-05-21 — engine fail-closed
-    DEFAULT-BLOCK pattern, KHÔNG defensive escape:
-      Pass CHỈ khi rule_applied ∈ whitelist success + kv_resolved != None.
+    Phase E.4 reviewer v4 2026-05-21 — KV unresolved giờ trả validation_error
+    (not raise) để submit flow giữ status=draft + commit snapshot unresolved.
+    Manager/admin sau đó có signal ``requires_manual_override=True`` trong
+    snapshot persisted để override draft (gỡ deadlock fail-closed vs draft
+    override gate).
 
     Pass paths (whitelist):
       - longest_duration / tiebreak_graduation_school / commune_lookup
@@ -4259,15 +4262,14 @@ def _assert_kv_resolved_for_submit(
       - address_not_normalized / catalog_gap_* / insufficient_data /
         ambiguous_requires_manual / not_resolved / unknown future rules
       - kv_resolved is None mà rule trong whitelist (race)
-      - Empty/None snapshot (freeze chưa chạy hoặc fail infra → fail-closed,
-        không cho submit khi không có bằng chứng KV đã resolve)
+      - Empty/None snapshot (freeze chưa chạy hoặc fail infra)
 
     Args:
         snapshot: profile.priority_resolution_snapshot (dict | None).
         profile_id: id cho log context.
 
-    Raises:
-        BadRequest: KV unresolved/missing, message tiếng Việt + rule + reason.
+    Returns:
+        Error message tiếng Việt nếu unresolved; None nếu pass.
     """
     snapshot = snapshot or {}
     rule_applied = snapshot.get("rule_applied")
@@ -4275,12 +4277,10 @@ def _assert_kv_resolved_for_submit(
 
     # Pass: rule trong success whitelist VÀ kv_resolved có giá trị.
     if rule_applied in _KV_SUCCESS_RULE_APPLIED and kv_resolved is not None:
-        return
+        return None
 
-    # Otherwise block — fail-closed default (KHÔNG defensive empty pass).
+    # Otherwise build error message — fail-closed default.
     if not snapshot:
-        # Empty/None — freeze chưa chạy hoặc fail. Submit-time block; ops sẽ
-        # thấy KV_RESOLUTION_FAILED hoặc KV_UNRESOLVED no_snapshot trong log.
         reason = "no_snapshot_present"
         log.info(
             "submit_blocked_kv_no_snapshot",
@@ -4300,13 +4300,28 @@ def _assert_kv_resolved_for_submit(
             kv_resolved=kv_resolved,
             reason=reason,
         )
-    raise BadRequest(
+    return (
         f"KV_UNRESOLVED ({rule_applied or 'no_rule_applied'}): engine không "
         f"xác định được khu vực ưu tiên cho hồ sơ này. Lý do: {reason}. "
         f"Vui lòng kiểm tra trình độ văn hóa, địa chỉ thường trú và lịch "
         f"sử học THPT, hoặc đề nghị quản lý ấn định KV thủ công trước "
         f"khi nộp."
     )
+
+
+def _assert_kv_resolved_for_submit(
+    snapshot: Optional[dict],
+    profile_id: int,
+) -> None:
+    """Raise BadRequest wrapper trên ``_kv_unresolved_error_message``.
+
+    Retained cho callers external (vd alternate flows). Submit-T1 path
+    KHÔNG dùng wrapper này nữa — giờ collect error vào validation_errors
+    list để commit snapshot unresolved (signal cho manager override draft).
+    """
+    err = _kv_unresolved_error_message(snapshot, profile_id)
+    if err:
+        raise BadRequest(err)
 
 
 async def _validate_eligibility_all_choices(
@@ -4817,6 +4832,62 @@ async def submit_and_evaluate(
     if not profile.academic_history:
         errors.append("Chưa nhập quá trình học tập (Academic History is empty)")
 
+    # Q9 #07 Phase E.4 reviewer v4 — KV freeze + assert chuyển từ "post if-errors
+    # transition prep" lên đây để errors collect cho cả KV failure. Nếu raise
+    # BadRequest trong transaction success path, router rollback snapshot →
+    # manager/admin draft override gate KHÔNG thấy engine signal → deadlock.
+    # Giải pháp: freeze runs unconditionally (collect signal vào snapshot),
+    # errors list aggregate KV unresolved/resolution_failed, then `if errors:`
+    # branch flushes snapshot + returns validation_errors. Snapshot persist
+    # vào DB qua router commit → override draft sees requires_manual_override.
+    #
+    # Lazy import: priority_service imports app.models would create circular
+    # dep at module load time of this service file.
+    from .priority_service import (
+        derive_profile_target_context,
+        freeze_priority_snapshot as _freeze_kv,
+    )
+
+    try:
+        target_ctx = await derive_profile_target_context(profile, db)
+        await _freeze_kv(
+            profile=profile,
+            db=db,
+            frozen_at_status="submitted_T1",
+            resolved_by="system",
+            target_level=target_ctx.get("target_level"),
+            admission_type=target_ctx.get("admission_type"),
+            eligibility=target_ctx.get("eligibility"),
+            path_bonus_rule=target_ctx.get("path_bonus_rule"),
+        )
+    except (BadRequest, BusinessRuleViolation):
+        # Domain errors từ helper (vd version conflict) → bubble lên router.
+        raise
+    except Exception as freeze_exc:  # noqa: BLE001
+        log.error(
+            "priority_snapshot_freeze_failed_at_submit",
+            profile_id=profile_id,
+            error=str(freeze_exc),
+            error_type=type(freeze_exc).__name__,
+        )
+        errors.append(
+            f"KV_RESOLUTION_FAILED: engine không hoàn tất resolve KV cho hồ "
+            f"sơ này do lỗi hệ thống ({type(freeze_exc).__name__}). Vui lòng "
+            f"thử lại; nếu lỗi tiếp diễn, báo admin kiểm tra catalog "
+            f"(vn_commune_area_map, vn_school_kv_assignment) và cấu hình "
+            f"path/method."
+        )
+
+    # KV unresolved check — collect message vào errors list (KHÔNG raise).
+    # Snapshot freeze ở trên đã ghi requires_manual_override=True khi engine
+    # cần manual; flush + commit ở `if errors:` branch persist signal đó cho
+    # admin/manager override draft.
+    kv_error = _kv_unresolved_error_message(
+        profile.priority_resolution_snapshot, profile_id
+    )
+    if kv_error:
+        errors.append(kv_error)
+
     # ✅ CRITICAL FIX #1: Submit should transition to SUBMITTED, not APPROVED/REJECTED
     # Per ADMISSION_STATE_MACHINE: draft → submitted (wait for Manager approval)
     # Validation errors should NOT change status - stay in draft for user to fix
@@ -4894,57 +4965,10 @@ async def submit_and_evaluate(
         # APPLICATION_STATUS_CHANGED + ADMISSION_PROFILE_SUBMITTED
         # always fire side-by-side AFTER ``db.commit()``.
 
-        # Q9 #07 Phase C — Freeze priority resolution snapshot at T1.
-        # Captures kv_resolved + breakdown immutably at submit time so
-        # subsequent admin edits to vn_school_kv_assignment / vn_commune_area_map
-        # don't mutate the candidate's resolved KV. T6 evaluate_cascade
-        # re-freezes with current rates per Q-P3-11 snapshot pattern.
-        # Lazy import: priority_service imports app.models which would
-        # create a circular dep at module load time.
-        from .priority_service import (
-            derive_profile_target_context,
-            freeze_priority_snapshot as _freeze_kv,
-        )
-
-        try:
-            # Phase E.4 commit 5 — bơm target_level + admission_type + bonus
-            # rule context vào snapshot để engine resolve đúng matrix mới.
-            # Multi-NV: lookup NV1 (display_order=1). Legacy: offering_admission_config.
-            target_ctx = await derive_profile_target_context(profile, db)
-            await _freeze_kv(
-                profile=profile,
-                db=db,
-                frozen_at_status="submitted_T1",
-                resolved_by="system",
-                target_level=target_ctx.get("target_level"),
-                admission_type=target_ctx.get("admission_type"),
-                eligibility=target_ctx.get("eligibility"),
-                path_bonus_rule=target_ctx.get("path_bonus_rule"),
-            )
-        except (BadRequest, BusinessRuleViolation):
-            # Domain errors từ helper (vd version conflict, validation) →
-            # bubble up nguyên trạng cho router.
-            raise
-        except Exception as freeze_exc:  # noqa: BLE001
-            # Phase E.4 reviewer 2026-05-21 fix-up — freeze infra failure
-            # phải block submit (fail-closed, KHÔNG pass-through). Pre-fix:
-            # catch + log warning + cho submit tiếp → vi phạm nghiệp vụ #7.
-            log.error(
-                "priority_snapshot_freeze_failed_at_submit",
-                profile_id=profile_id,
-                error=str(freeze_exc),
-                error_type=type(freeze_exc).__name__,
-            )
-            raise BadRequest(
-                f"KV_RESOLUTION_FAILED: engine không hoàn tất resolve KV cho "
-                f"hồ sơ này do lỗi hệ thống ({type(freeze_exc).__name__}). "
-                f"Vui lòng thử lại; nếu lỗi tiếp diễn, báo admin kiểm tra "
-                f"catalog (vn_commune_area_map, vn_school_kv_assignment) và "
-                f"cấu hình path/method."
-            ) from freeze_exc
-
-        # Q9 #07 Phase E.4 commit 5 fix-up — block submit khi KV unresolved.
-        _assert_kv_resolved_for_submit(profile.priority_resolution_snapshot, profile_id)
+        # Q9 #07 Phase E.4 reviewer v4 — freeze + KV check đã chạy ở bước
+        # validation phía trên. Nếu reach đây tức snapshot có rule_applied
+        # success + kv_resolved set (whitelist pass). Atomic increment +
+        # state transition chỉ fire khi đảm bảo no errors.
 
         try:
             profile, _ = await state_transition(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4506,21 +4506,26 @@ async def submit_and_evaluate(
                 "Vui lòng thêm nguyện vọng tại bước Điểm & Điều kiện."
             )
 
-        # Q9 #07 Phase E.4 — eligibility gate per choice trước khi freeze KV.
-        # Engine pipeline yêu cầu Eligibility → Exception → Auto basis → Resolve
-        # KV (xem priority_service docstring). Per yêu cầu nghiệp vụ #5:
-        #   - CĐ chính quy/liên thông: cultural mở rộng + (vocational nếu liên thông)
-        #   - TC chính quy/liên thông: cultural ≥ THCS + (vocational nếu liên thông)
-        #   - SC chính quy: không yêu cầu
-        # Tuyệt đối KHÔNG fallback "so_cap" khi thiếu target_level config.
-        await _validate_eligibility_all_choices(db, profile)
-
     # Must be in draft status
     if profile.status != "draft":
         raise BadRequest(
             f"Cannot submit profile with status '{profile.status}'. "
             "Only draft profiles can be submitted."
         )
+
+    # Q9 #07 Phase E.4 — eligibility gate per yêu cầu nghiệp vụ #5: chặn TOÀN BỘ
+    # hồ sơ submit không match cultural + vocational vs target_level/admission_type
+    # của path/config. Trước fix: gate đặt trong if uses_choice_engine → 9/11 dev
+    # profile legacy single-path bypass (reviewer finding 2026-05-21).
+    #
+    # Helper handle 2 flow:
+    #   - uses_choice_engine=True (multi-NV): loop choices.admission_path
+    #   - uses_choice_engine=False (legacy): profile.offering_admission_config chain
+    #
+    # Pipeline order: Eligibility → Exception → Auto basis → Resolve KV → Apply
+    # bonus → Snapshot (xem priority_service docstring). Tuyệt đối KHÔNG fallback
+    # "so_cap" khi thiếu target_level config — raise CONFIG_GAP_TARGET_LEVEL.
+    await _validate_eligibility_all_choices(db, profile)
 
     errors: List[str] = []
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4217,6 +4217,72 @@ def _calculate_and_update_totals(profile: models.AdmissionProfile, scores: list 
     profile.snapshot_score = snapshot_score
 
 
+# =============================================================================
+# Q9 #07 Phase E.4 commit 5 fix-up — submit-time guard cho KV unresolved
+# =============================================================================
+
+# Engine fail-closed rule_applied values khi KV không xác định được:
+#   - address_not_normalized      : profile thiếu permanent_commune_code
+#   - catalog_gap_commune         : commune không có trong vn_commune_area_map
+#   - catalog_gap_school          : tất cả vn_school_kv_assignment lookup miss
+#   - insufficient_data           : combo cultural/voc không match matrix
+#   - ambiguous_requires_manual   : tied graduation year + grade
+#   - not_resolved                : cultural NULL (eligibility cũng chặn)
+#
+# Submit pass-through CHỈ khi:
+#   - rule_applied = "manual_override" (manager/admin đã set KV trước submit)
+#   - rule_applied ∈ {longest_duration, tiebreak_graduation_school, commune_lookup}
+#     (engine resolve thành công, kv_resolved != None)
+_KV_UNRESOLVED_RULE_APPLIED = frozenset({
+    "address_not_normalized",
+    "catalog_gap_commune",
+    "catalog_gap_school",
+    "insufficient_data",
+    "ambiguous_requires_manual",
+    "not_resolved",
+})
+
+
+def _assert_kv_resolved_for_submit(
+    snapshot: Optional[dict],
+    profile_id: int,
+) -> None:
+    """Raise BadRequest nếu snapshot báo KV unresolved (engine fail-closed signal).
+
+    Yêu cầu nghiệp vụ #7 — engine fail-closed: KHÔNG cho submit khi KV mơ hồ.
+    Manager/admin có thể override KV trước submit qua POST override-priority-kv;
+    snapshot sau override mang rule_applied="manual_override" + kv_resolved
+    đã set → pass gate.
+
+    Args:
+        snapshot: profile.priority_resolution_snapshot (dict | None).
+        profile_id: id cho log context.
+
+    Raises:
+        BadRequest: KV unresolved, message tiếng Việt + rule_applied + reason.
+    """
+    snapshot = snapshot or {}
+    rule_applied = snapshot.get("rule_applied")
+    if (
+        snapshot.get("requires_manual_override")
+        and rule_applied in _KV_UNRESOLVED_RULE_APPLIED
+    ):
+        reason = snapshot.get("reason") or snapshot.get("basis_reason")
+        log.info(
+            "submit_blocked_kv_unresolved",
+            profile_id=profile_id,
+            rule_applied=rule_applied,
+            reason=reason,
+        )
+        raise BadRequest(
+            f"KV_UNRESOLVED ({rule_applied}): engine không xác định được khu "
+            f"vực ưu tiên cho hồ sơ này. Lý do: {reason or rule_applied}. "
+            f"Vui lòng kiểm tra trình độ văn hóa, địa chỉ thường trú và "
+            f"lịch sử học THPT, hoặc đề nghị quản lý ấn định KV thủ công "
+            f"trước khi nộp."
+        )
+
+
 async def _validate_eligibility_all_choices(
     db: AsyncSession,
     profile: models.AdmissionProfile,
@@ -4829,7 +4895,7 @@ async def submit_and_evaluate(
                 eligibility=target_ctx.get("eligibility"),
                 path_bonus_rule=target_ctx.get("path_bonus_rule"),
             )
-        except Exception as freeze_exc:  # noqa: BLE001 — defensive: never block submit
+        except Exception as freeze_exc:  # noqa: BLE001 — defensive: never block submit on infra fail
             log.warning(
                 "priority_snapshot_freeze_failed_at_submit",
                 profile_id=profile_id,
@@ -4840,6 +4906,9 @@ async def submit_and_evaluate(
                     "Engine T6 will retry freeze."
                 ),
             )
+
+        # Q9 #07 Phase E.4 commit 5 fix-up — block submit khi KV unresolved.
+        _assert_kv_resolved_for_submit(profile.priority_resolution_snapshot, profile_id)
 
         try:
             profile, _ = await state_transition(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4802,12 +4802,6 @@ async def submit_and_evaluate(
         # APPLICATION_STATUS_CHANGED + ADMISSION_PROFILE_SUBMITTED
         # always fire side-by-side AFTER ``db.commit()``.
 
-        # Q9 #07 Phase E.4 — eligibility cũng phải check cho legacy non-multi-NV
-        # profile (uses_choice_engine=False) qua chain offering_admission_config →
-        # academic_info → offering → program/offering_type. Helper handles both
-        # flows: nếu profile non-multi-NV, derive duy nhất 1 path từ
-        # offering_admission_config_id (legacy single-path snapshot pattern).
-
         # Q9 #07 Phase C — Freeze priority resolution snapshot at T1.
         # Captures kv_resolved + breakdown immutably at submit time so
         # subsequent admin edits to vn_school_kv_assignment / vn_commune_area_map
@@ -4815,14 +4809,25 @@ async def submit_and_evaluate(
         # re-freezes with current rates per Q-P3-11 snapshot pattern.
         # Lazy import: priority_service imports app.models which would
         # create a circular dep at module load time.
-        from .priority_service import freeze_priority_snapshot as _freeze_kv
+        from .priority_service import (
+            derive_profile_target_context,
+            freeze_priority_snapshot as _freeze_kv,
+        )
 
         try:
+            # Phase E.4 commit 5 — bơm target_level + admission_type + bonus
+            # rule context vào snapshot để engine resolve đúng matrix mới.
+            # Multi-NV: lookup NV1 (display_order=1). Legacy: offering_admission_config.
+            target_ctx = await derive_profile_target_context(profile, db)
             await _freeze_kv(
                 profile=profile,
                 db=db,
                 frozen_at_status="submitted_T1",
                 resolved_by="system",
+                target_level=target_ctx.get("target_level"),
+                admission_type=target_ctx.get("admission_type"),
+                eligibility=target_ctx.get("eligibility"),
+                path_bonus_rule=target_ctx.get("path_bonus_rule"),
             )
         except Exception as freeze_exc:  # noqa: BLE001 — defensive: never block submit
             log.warning(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4355,11 +4355,31 @@ async def _validate_eligibility_all_choices(
       - ``CONFIG_GAP_TARGET_LEVEL`` khi không derive được level/type
 
     Per yêu cầu nghiệp vụ #5: tuyệt đối KHÔNG fallback "so_cap" khi gap.
+
+    Error-handling contract — intentional contrast với choice engine
+    -----------------------------------------------------------------
+    Helper này (submit-time gate) raises ``BusinessRuleViolation`` UNWRAPPED:
+    bất kỳ ``derive_target_level_and_type`` CONFIG_GAP, validate_eligibility
+    fail, hoặc multi-NV inconsistency → bubble lên router → 400/422. Submit
+    fail-closed toàn bộ (Phase E.4 reviewer P0 fix — yêu cầu nghiệp vụ #5).
+
+    Đối lập với ``admission_choice_engine_service._evaluate_single_choice``
+    (engine T6 publish path) — chỗ đó WRAPS ``derive_target_level_and_type``
+    + ``validate_eligibility`` trong try/except ``BusinessRuleViolation`` và
+    convert thành per-choice ``reason_codes = ["CONFIG_GAP_TARGET_LEVEL:..."]``
+    / ``["ELIGIBILITY_FAIL:..."]`` + ``status="rejected"`` để engine vẫn
+    cascade qua các choice khác (1 choice rỗng config KHÔNG được block
+    publish 4 choice còn lại).
+
+    Tóm tắt:
+      submit-time   : fail-closed → raise → toàn hồ sơ vào draft + validation_errors
+      engine-T6     : per-choice  → reject reason_code → cascade tiếp choice sau
     """
     from sqlalchemy import select as _sel
     from sqlalchemy.orm import selectinload as _sel_in
 
     from .priority_service import (
+        _make_path_shim_from_academic_info,
         derive_target_level_and_type,
         validate_eligibility,
     )
@@ -4454,14 +4474,10 @@ async def _validate_eligibility_all_choices(
                 f"CONFIG_GAP_TARGET_LEVEL: offering_admission_config_id="
                 f"{config_id} không tồn tại."
             )
-        # Build pseudo-path stub để reuse derive_target_level_and_type (helper
-        # cần __dict__['academic_info'] nên dùng config trực tiếp work với
-        # `__dict__['academic_info']` của config object).
-        # Construct a tiny shim:
-        class _PathShim:
-            pass
-        shim = _PathShim()
-        shim.__dict__["academic_info"] = config.academic_info
+        # Build pseudo-path stub để reuse derive_target_level_and_type
+        # (helper đọc __dict__['academic_info']); shared helper centralize
+        # pattern (xem priority_service._make_path_shim_from_academic_info).
+        shim = _make_path_shim_from_academic_info(config.academic_info)
         target_level, admission_type = derive_target_level_and_type(shim)  # type: ignore[arg-type]
         ok, reason = validate_eligibility(profile, target_level, admission_type)
         if not ok:

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4221,25 +4221,22 @@ def _calculate_and_update_totals(profile: models.AdmissionProfile, scores: list 
 # Q9 #07 Phase E.4 commit 5 fix-up — submit-time guard cho KV unresolved
 # =============================================================================
 
-# Engine fail-closed rule_applied values khi KV không xác định được:
-#   - address_not_normalized      : profile thiếu permanent_commune_code
-#   - catalog_gap_commune         : commune không có trong vn_commune_area_map
-#   - catalog_gap_school          : tất cả vn_school_kv_assignment lookup miss
-#   - insufficient_data           : combo cultural/voc không match matrix
-#   - ambiguous_requires_manual   : tied graduation year + grade
-#   - not_resolved                : cultural NULL (eligibility cũng chặn)
+# Phase E.4 commit 5 fix-up — submit guard FLIP từ blacklist sang whitelist
+# success (reviewer P1: "nếu requires_manual_override is True thì block
+# mặc định, chỉ pass các rule thành công rõ ràng").
 #
-# Submit pass-through CHỈ khi:
-#   - rule_applied = "manual_override" (manager/admin đã set KV trước submit)
-#   - rule_applied ∈ {longest_duration, tiebreak_graduation_school, commune_lookup}
-#     (engine resolve thành công, kv_resolved != None)
-_KV_UNRESOLVED_RULE_APPLIED = frozenset({
-    "address_not_normalized",
-    "catalog_gap_commune",
-    "catalog_gap_school",
-    "insufficient_data",
-    "ambiguous_requires_manual",
-    "not_resolved",
+# Pass-through CHỈ khi:
+#   - rule_applied ∈ _KV_SUCCESS_RULE_APPLIED (engine resolve thành công)
+#   - VÀ kv_resolved != None (snapshot có giá trị KV thực)
+#
+# Empty/None snapshot → pass defensive (engine T1 freeze fail infra; warning
+# đã log ở freeze try/except). Mọi rule_applied khác / kv_resolved None →
+# block với BadRequest tiếng Việt + guidance.
+_KV_SUCCESS_RULE_APPLIED = frozenset({
+    "longest_duration",
+    "tiebreak_graduation_school",
+    "commune_lookup",
+    "manual_override",
 })
 
 
@@ -4247,12 +4244,25 @@ def _assert_kv_resolved_for_submit(
     snapshot: Optional[dict],
     profile_id: int,
 ) -> None:
-    """Raise BadRequest nếu snapshot báo KV unresolved (engine fail-closed signal).
+    """Raise BadRequest nếu snapshot không emit engine success signal.
 
-    Yêu cầu nghiệp vụ #7 — engine fail-closed: KHÔNG cho submit khi KV mơ hồ.
-    Manager/admin có thể override KV trước submit qua POST override-priority-kv;
-    snapshot sau override mang rule_applied="manual_override" + kv_resolved
-    đã set → pass gate.
+    Yêu cầu nghiệp vụ #7 + reviewer P1 2026-05-21 — engine fail-closed
+    DEFAULT-BLOCK pattern: chỉ pass khi rule_applied trong whitelist success
+    + kv_resolved có giá trị thực.
+
+    Pass paths:
+      - longest_duration / tiebreak_graduation_school / commune_lookup
+        (engine resolve qua LICH_SU_THPT hoặc THUONG_TRU/COMMUNE_SPECIAL)
+      - manual_override (admin/manager đã set KV thủ công pre-submit)
+
+    Block paths (fail-closed mọi case khác):
+      - address_not_normalized / catalog_gap_* / insufficient_data /
+        ambiguous_requires_manual / not_resolved / unknown future rules
+      - kv_resolved is None mà không phải success rule
+
+    Defensive escape:
+      - Empty/None snapshot → pass (freeze fail infra; warning đã log).
+        Không double-block lại vì failure mode khác.
 
     Args:
         snapshot: profile.priority_resolution_snapshot (dict | None).
@@ -4261,26 +4271,37 @@ def _assert_kv_resolved_for_submit(
     Raises:
         BadRequest: KV unresolved, message tiếng Việt + rule_applied + reason.
     """
-    snapshot = snapshot or {}
+    if not snapshot:
+        return  # Empty/None — freeze fail infra (đã log warning ở freeze).
+
     rule_applied = snapshot.get("rule_applied")
-    if (
-        snapshot.get("requires_manual_override")
-        and rule_applied in _KV_UNRESOLVED_RULE_APPLIED
-    ):
-        reason = snapshot.get("reason") or snapshot.get("basis_reason")
-        log.info(
-            "submit_blocked_kv_unresolved",
-            profile_id=profile_id,
-            rule_applied=rule_applied,
-            reason=reason,
-        )
-        raise BadRequest(
-            f"KV_UNRESOLVED ({rule_applied}): engine không xác định được khu "
-            f"vực ưu tiên cho hồ sơ này. Lý do: {reason or rule_applied}. "
-            f"Vui lòng kiểm tra trình độ văn hóa, địa chỉ thường trú và "
-            f"lịch sử học THPT, hoặc đề nghị quản lý ấn định KV thủ công "
-            f"trước khi nộp."
-        )
+    kv_resolved = snapshot.get("kv_resolved")
+
+    # Pass: rule trong success whitelist VÀ kv_resolved có giá trị.
+    if rule_applied in _KV_SUCCESS_RULE_APPLIED and kv_resolved is not None:
+        return
+
+    # Otherwise block — fail-closed default.
+    reason = (
+        snapshot.get("reason")
+        or snapshot.get("basis_reason")
+        or rule_applied
+        or "unknown"
+    )
+    log.info(
+        "submit_blocked_kv_unresolved",
+        profile_id=profile_id,
+        rule_applied=rule_applied,
+        kv_resolved=kv_resolved,
+        reason=reason,
+    )
+    raise BadRequest(
+        f"KV_UNRESOLVED ({rule_applied or 'no_rule_applied'}): engine không "
+        f"xác định được khu vực ưu tiên cho hồ sơ này. Lý do: {reason}. "
+        f"Vui lòng kiểm tra trình độ văn hóa, địa chỉ thường trú và lịch "
+        f"sử học THPT, hoặc đề nghị quản lý ấn định KV thủ công trước "
+        f"khi nộp."
+    )
 
 
 async def _validate_eligibility_all_choices(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4359,6 +4359,13 @@ async def _validate_eligibility_all_choices(
     )
 
     failures: list[str] = []
+    # Phase E.4 commit 6 — Multi-NV consistency guard (yêu cầu nghiệp vụ #12):
+    # collect target_level + admission_type per choice trong cùng loop. Sau
+    # loop, raise BusinessRuleViolation MULTI_NV_INCONSISTENT nếu khác nhau.
+    # MVP: block submit; per-choice KV snapshot defer Phase F.
+    targets_seen: set[str] = set()
+    types_seen: set[str] = set()
+    choices_summary: list[str] = []
 
     if profile.uses_choice_engine:
         # Load choices với eager chain cho derive_target_level_and_type
@@ -4386,12 +4393,33 @@ async def _validate_eligibility_all_choices(
         for choice in choices:
             path = choice.admission_path
             target_level, admission_type = derive_target_level_and_type(path)
+            targets_seen.add(target_level)
+            types_seen.add(admission_type)
+            choices_summary.append(
+                f"NV{choice.display_order}={target_level}/{admission_type}"
+            )
             ok, reason = validate_eligibility(profile, target_level, admission_type)
             if not ok:
                 failures.append(
                     f"NV{choice.display_order} ({target_level}/{admission_type}): "
                     f"{reason}"
                 )
+
+        # Phase E.4 commit 6 — Multi-NV consistency check (yêu cầu nghiệp vụ #12).
+        # KHI có > 1 choice và target/admission_type khác nhau → block submit
+        # với guidance tách hồ sơ. Snapshot KV freeze ở submit dùng NV1 làm
+        # primary (commit 5); per-choice snapshot defer Phase F — nên multi-NV
+        # khác basis tạo race conditions cho engine T6 + audit ambiguity.
+        if len(choices) >= 2 and (len(targets_seen) > 1 or len(types_seen) > 1):
+            raise BusinessRuleViolation(
+                "MULTI_NV_INCONSISTENT: hồ sơ đa nguyện vọng có các nguyện "
+                f"vọng KHÔNG đồng nhất bậc đào tạo hoặc hệ đào tạo "
+                f"({', '.join(choices_summary)}). Đợt MVP chỉ hỗ trợ các "
+                f"nguyện vọng cùng (target_level, admission_type) để engine "
+                f"tính khu vực ưu tiên + chính sách bonus thống nhất. Vui "
+                f"lòng tách thành nhiều hồ sơ riêng (mỗi hồ sơ 1 bậc/hệ) "
+                f"hoặc chọn lại các nguyện vọng đồng nhất."
+            )
     else:
         # Legacy non-multi-NV: lookup từ offering_admission_config chain.
         config_id = profile.offering_admission_config_id

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4217,6 +4217,123 @@ def _calculate_and_update_totals(profile: models.AdmissionProfile, scores: list 
     profile.snapshot_score = snapshot_score
 
 
+async def _validate_eligibility_all_choices(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+) -> None:
+    """Q9 #07 Phase E.4 — eligibility gate per yêu cầu nghiệp vụ #5.
+
+    Pipeline order (xem priority_service docstring): Eligibility → Exception
+    → Auto basis → Resolve KV → Apply path bonus → Snapshot. Eligibility chạy
+    TRƯỚC freeze để fail-fast khi cultural + vocational không match path
+    target_level/admission_type.
+
+    Behavior per flow:
+      - ``uses_choice_engine=True`` (multi-NV): query choices với eager-load
+        chain ``path → academic_info → offering → program``. Validate mỗi
+        choice. Bất kỳ choice nào fail → raise BusinessRuleViolation (caller
+        map sang BadRequest/422).
+      - ``uses_choice_engine=False`` (legacy single-path): derive target từ
+        ``profile.offering_admission_config_id`` chain. Nếu không có config →
+        raise CONFIG_GAP_TARGET_LEVEL (fail-closed per nghiệp vụ).
+
+    Reason codes (i18n key cho FE error display):
+      - ``ELIGIBILITY_FAIL_<reason>`` cho từng choice
+      - ``CONFIG_GAP_TARGET_LEVEL`` khi không derive được level/type
+
+    Per yêu cầu nghiệp vụ #5: tuyệt đối KHÔNG fallback "so_cap" khi gap.
+    """
+    from sqlalchemy import select as _sel
+    from sqlalchemy.orm import selectinload as _sel_in
+
+    from .priority_service import (
+        derive_target_level_and_type,
+        validate_eligibility,
+    )
+
+    failures: list[str] = []
+
+    if profile.uses_choice_engine:
+        # Load choices với eager chain cho derive_target_level_and_type
+        choices_stmt = (
+            _sel(models.AdmissionProfileChoice)
+            .where(
+                models.AdmissionProfileChoice.admission_profile_id == profile.id
+            )
+            .options(
+                _sel_in(models.AdmissionProfileChoice.admission_path)
+                .selectinload(models.AdmissionPath.academic_info)
+                .selectinload(models.OfferingAcademicInfo.offering)
+                .selectinload(models.ProgramOffering.program)
+                .selectinload(models.MajorProgram.degree_level_ref),
+                _sel_in(models.AdmissionProfileChoice.admission_path)
+                .selectinload(models.AdmissionPath.academic_info)
+                .selectinload(models.OfferingAcademicInfo.offering)
+                .selectinload(models.ProgramOffering.offering_type_config),
+            )
+            .order_by(models.AdmissionProfileChoice.display_order)
+        )
+        choices_result = await db.execute(choices_stmt)
+        choices = choices_result.scalars().all()
+
+        for choice in choices:
+            path = choice.admission_path
+            target_level, admission_type = derive_target_level_and_type(path)
+            ok, reason = validate_eligibility(profile, target_level, admission_type)
+            if not ok:
+                failures.append(
+                    f"NV{choice.display_order} ({target_level}/{admission_type}): "
+                    f"{reason}"
+                )
+    else:
+        # Legacy non-multi-NV: lookup từ offering_admission_config chain.
+        config_id = profile.offering_admission_config_id
+        if config_id is None:
+            raise BusinessRuleViolation(
+                "CONFIG_GAP_TARGET_LEVEL: hồ sơ không có offering_admission_config_id "
+                "và uses_choice_engine=False — không thể xác định bậc đào tạo. "
+                "Vui lòng cấu hình config trước khi submit."
+            )
+        config_stmt = (
+            _sel(models.OfferingAdmissionConfig)
+            .where(models.OfferingAdmissionConfig.id == config_id)
+            .options(
+                _sel_in(models.OfferingAdmissionConfig.academic_info)
+                .selectinload(models.OfferingAcademicInfo.offering)
+                .selectinload(models.ProgramOffering.program)
+                .selectinload(models.MajorProgram.degree_level_ref),
+                _sel_in(models.OfferingAdmissionConfig.academic_info)
+                .selectinload(models.OfferingAcademicInfo.offering)
+                .selectinload(models.ProgramOffering.offering_type_config),
+            )
+        )
+        config = (await db.execute(config_stmt)).scalar_one_or_none()
+        if config is None:
+            raise BusinessRuleViolation(
+                f"CONFIG_GAP_TARGET_LEVEL: offering_admission_config_id="
+                f"{config_id} không tồn tại."
+            )
+        # Build pseudo-path stub để reuse derive_target_level_and_type (helper
+        # cần __dict__['academic_info'] nên dùng config trực tiếp work với
+        # `__dict__['academic_info']` của config object).
+        # Construct a tiny shim:
+        class _PathShim:
+            pass
+        shim = _PathShim()
+        shim.__dict__["academic_info"] = config.academic_info
+        target_level, admission_type = derive_target_level_and_type(shim)  # type: ignore[arg-type]
+        ok, reason = validate_eligibility(profile, target_level, admission_type)
+        if not ok:
+            failures.append(
+                f"Legacy single-path ({target_level}/{admission_type}): {reason}"
+            )
+
+    if failures:
+        raise BusinessRuleViolation(
+            "ELIGIBILITY_FAIL: " + "; ".join(failures)
+        )
+
+
 async def _audit_warning_dismissed_if_missing(
     db: AsyncSession,
     profile_id: int,
@@ -4388,6 +4505,15 @@ async def submit_and_evaluate(
                 "Hồ sơ đa nguyện vọng phải có ít nhất 1 nguyện vọng trước khi nộp. "
                 "Vui lòng thêm nguyện vọng tại bước Điểm & Điều kiện."
             )
+
+        # Q9 #07 Phase E.4 — eligibility gate per choice trước khi freeze KV.
+        # Engine pipeline yêu cầu Eligibility → Exception → Auto basis → Resolve
+        # KV (xem priority_service docstring). Per yêu cầu nghiệp vụ #5:
+        #   - CĐ chính quy/liên thông: cultural mở rộng + (vocational nếu liên thông)
+        #   - TC chính quy/liên thông: cultural ≥ THCS + (vocational nếu liên thông)
+        #   - SC chính quy: không yêu cầu
+        # Tuyệt đối KHÔNG fallback "so_cap" khi thiếu target_level config.
+        await _validate_eligibility_all_choices(db, profile)
 
     # Must be in draft status
     if profile.status != "draft":
@@ -4670,6 +4796,12 @@ async def submit_and_evaluate(
         # event. The single source of truth lives in our callback so
         # APPLICATION_STATUS_CHANGED + ADMISSION_PROFILE_SUBMITTED
         # always fire side-by-side AFTER ``db.commit()``.
+
+        # Q9 #07 Phase E.4 — eligibility cũng phải check cho legacy non-multi-NV
+        # profile (uses_choice_engine=False) qua chain offering_admission_config →
+        # academic_info → offering → program/offering_type. Helper handles both
+        # flows: nếu profile non-multi-NV, derive duy nhất 1 path từ
+        # offering_admission_config_id (legacy single-path snapshot pattern).
 
         # Q9 #07 Phase C — Freeze priority resolution snapshot at T1.
         # Captures kv_resolved + breakdown immutably at submit time so

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4246,34 +4246,30 @@ def _assert_kv_resolved_for_submit(
 ) -> None:
     """Raise BadRequest nếu snapshot không emit engine success signal.
 
-    Yêu cầu nghiệp vụ #7 + reviewer P1 2026-05-21 — engine fail-closed
-    DEFAULT-BLOCK pattern: chỉ pass khi rule_applied trong whitelist success
-    + kv_resolved có giá trị thực.
+    Yêu cầu nghiệp vụ #7 + reviewer 2026-05-21 — engine fail-closed
+    DEFAULT-BLOCK pattern, KHÔNG defensive escape:
+      Pass CHỈ khi rule_applied ∈ whitelist success + kv_resolved != None.
 
-    Pass paths:
+    Pass paths (whitelist):
       - longest_duration / tiebreak_graduation_school / commune_lookup
         (engine resolve qua LICH_SU_THPT hoặc THUONG_TRU/COMMUNE_SPECIAL)
       - manual_override (admin/manager đã set KV thủ công pre-submit)
 
-    Block paths (fail-closed mọi case khác):
+    Block paths (fail-closed mọi case khác — KHÔNG có defensive escape):
       - address_not_normalized / catalog_gap_* / insufficient_data /
         ambiguous_requires_manual / not_resolved / unknown future rules
-      - kv_resolved is None mà không phải success rule
-
-    Defensive escape:
-      - Empty/None snapshot → pass (freeze fail infra; warning đã log).
-        Không double-block lại vì failure mode khác.
+      - kv_resolved is None mà rule trong whitelist (race)
+      - Empty/None snapshot (freeze chưa chạy hoặc fail infra → fail-closed,
+        không cho submit khi không có bằng chứng KV đã resolve)
 
     Args:
         snapshot: profile.priority_resolution_snapshot (dict | None).
         profile_id: id cho log context.
 
     Raises:
-        BadRequest: KV unresolved, message tiếng Việt + rule_applied + reason.
+        BadRequest: KV unresolved/missing, message tiếng Việt + rule + reason.
     """
-    if not snapshot:
-        return  # Empty/None — freeze fail infra (đã log warning ở freeze).
-
+    snapshot = snapshot or {}
     rule_applied = snapshot.get("rule_applied")
     kv_resolved = snapshot.get("kv_resolved")
 
@@ -4281,20 +4277,29 @@ def _assert_kv_resolved_for_submit(
     if rule_applied in _KV_SUCCESS_RULE_APPLIED and kv_resolved is not None:
         return
 
-    # Otherwise block — fail-closed default.
-    reason = (
-        snapshot.get("reason")
-        or snapshot.get("basis_reason")
-        or rule_applied
-        or "unknown"
-    )
-    log.info(
-        "submit_blocked_kv_unresolved",
-        profile_id=profile_id,
-        rule_applied=rule_applied,
-        kv_resolved=kv_resolved,
-        reason=reason,
-    )
+    # Otherwise block — fail-closed default (KHÔNG defensive empty pass).
+    if not snapshot:
+        # Empty/None — freeze chưa chạy hoặc fail. Submit-time block; ops sẽ
+        # thấy KV_RESOLUTION_FAILED hoặc KV_UNRESOLVED no_snapshot trong log.
+        reason = "no_snapshot_present"
+        log.info(
+            "submit_blocked_kv_no_snapshot",
+            profile_id=profile_id,
+        )
+    else:
+        reason = (
+            snapshot.get("reason")
+            or snapshot.get("basis_reason")
+            or rule_applied
+            or "unknown"
+        )
+        log.info(
+            "submit_blocked_kv_unresolved",
+            profile_id=profile_id,
+            rule_applied=rule_applied,
+            kv_resolved=kv_resolved,
+            reason=reason,
+        )
     raise BadRequest(
         f"KV_UNRESOLVED ({rule_applied or 'no_rule_applied'}): engine không "
         f"xác định được khu vực ưu tiên cho hồ sơ này. Lý do: {reason}. "
@@ -4916,17 +4921,27 @@ async def submit_and_evaluate(
                 eligibility=target_ctx.get("eligibility"),
                 path_bonus_rule=target_ctx.get("path_bonus_rule"),
             )
-        except Exception as freeze_exc:  # noqa: BLE001 — defensive: never block submit on infra fail
-            log.warning(
+        except (BadRequest, BusinessRuleViolation):
+            # Domain errors từ helper (vd version conflict, validation) →
+            # bubble up nguyên trạng cho router.
+            raise
+        except Exception as freeze_exc:  # noqa: BLE001
+            # Phase E.4 reviewer 2026-05-21 fix-up — freeze infra failure
+            # phải block submit (fail-closed, KHÔNG pass-through). Pre-fix:
+            # catch + log warning + cho submit tiếp → vi phạm nghiệp vụ #7.
+            log.error(
                 "priority_snapshot_freeze_failed_at_submit",
                 profile_id=profile_id,
                 error=str(freeze_exc),
-                reason=(
-                    "KV resolution failed during submit T1; profile still "
-                    "submits but priority_resolution_snapshot stays empty. "
-                    "Engine T6 will retry freeze."
-                ),
+                error_type=type(freeze_exc).__name__,
             )
+            raise BadRequest(
+                f"KV_RESOLUTION_FAILED: engine không hoàn tất resolve KV cho "
+                f"hồ sơ này do lỗi hệ thống ({type(freeze_exc).__name__}). "
+                f"Vui lòng thử lại; nếu lỗi tiếp diễn, báo admin kiểm tra "
+                f"catalog (vn_commune_area_map, vn_school_kv_assignment) và "
+                f"cấu hình path/method."
+            ) from freeze_exc
 
         # Q9 #07 Phase E.4 commit 5 fix-up — block submit khi KV unresolved.
         _assert_kv_resolved_for_submit(profile.priority_resolution_snapshot, profile_id)

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -276,7 +276,11 @@ async def override_kv(
     # admin/manager. Officer reach đây = bug router/permissions → raise.
     is_admin = actor.role == "admin"
     is_manager = actor.role == "manager"
-    is_officer_path = actor.role == "manager"  # only manager treated as officer path
+    # Phase E.4 commit 7 hardening: officer hard-deny ở top → "non-admin
+    # override path" giờ chỉ còn manager. Trước đây tên ``is_officer_path``
+    # vì cả officer + manager đều fall vào cùng whitelist; nay alias rõ
+    # tên hiện hành để reader khỏi hiểu lầm officer còn ở scope.
+    is_manager_override_path = actor.role == "manager"
     if actor.role == "officer":
         log.warning(
             "officer_override_kv_attempt_denied",
@@ -370,7 +374,7 @@ async def override_kv(
 
     if (
         not is_admin
-        and is_officer_path
+        and is_manager_override_path
         and profile.status not in _OFFICER_ALLOWED_STATUS
         and profile.status not in _POST_PUBLISH_STATUS
         and profile.status != "draft"  # draft handled by dedicated gate above

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -283,15 +283,46 @@ async def override_kv(
                 "Officer không được override KV ở trạng thái draft. "
                 "Vui lòng đề nghị quản lý / admin xử lý hồ sơ này."
             )
-        snapshot_now = profile.priority_resolution_snapshot or {}
-        if not snapshot_now.get("requires_manual_override"):
+
+        # Phase E.4 reviewer v5 2026-05-21 — RECOMPUTE LIVE thay vì trust snapshot
+        # stale. Pre-fix: kiểm tra ``snapshot.requires_manual_override`` từ DB.
+        # Edge case: officer sửa permanent_commune_code/cultural/history sau
+        # khi submit fail → snapshot vẫn cũ → manager override draft pass dù
+        # engine giờ resolve được. → sai nghiệp vụ (free-form override khi
+        # engine có đường tự xử).
+        # Fix: re-run resolve_kv_for_profile() với profile state hiện tại;
+        # CHỈ allow override draft khi engine vẫn emit unresolved signal.
+        # Lazy import (priority_service ↔ models circular dep at top-level).
+        from .priority_service import (
+            derive_profile_target_context,
+            resolve_kv_for_profile,
+        )
+
+        live_target_ctx = await derive_profile_target_context(profile, db)
+        _live_kv, live_meta = await resolve_kv_for_profile(
+            profile,
+            db,
+            target_level=live_target_ctx.get("target_level"),
+            admission_type=live_target_ctx.get("admission_type"),
+        )
+        if not live_meta.get("requires_manual_override"):
+            log.info(
+                "draft_override_refused_engine_resolved_live",
+                profile_id=profile.id,
+                actor_id=actor.id,
+                live_rule_applied=live_meta.get("rule_applied"),
+                live_basis=live_meta.get("basis"),
+                snapshot_rule_applied=(
+                    profile.priority_resolution_snapshot or {}
+                ).get("rule_applied"),
+            )
             raise BusinessRuleViolation(
-                "Hồ sơ draft chỉ được override KV khi engine không xác "
-                "định được (snapshot.requires_manual_override=True). "
-                "Vui lòng kiểm tra trình độ văn hóa, địa chỉ thường trú "
-                "và lịch sử học để engine resolve tự động trước, hoặc "
-                "submit để chuyển sang trạng thái cho phép override "
-                "thường lệ (submitted/reviewing/revision_requested)."
+                "Hồ sơ draft chỉ được override KV khi engine không xác định "
+                f"được với dữ liệu hiện tại. Engine vừa tính lại và resolve "
+                f"thành công (rule={live_meta.get('rule_applied')}, "
+                f"basis={live_meta.get('basis')}). Nếu muốn áp KV khác, "
+                f"submit hồ sơ trước (state submitted/reviewing/revision_requested "
+                f"cho phép override thường lệ)."
             )
 
     if profile.status in _POST_PUBLISH_STATUS:

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -353,11 +353,12 @@ async def override_kv(
 
     if profile.status in _POST_PUBLISH_STATUS:
         if not is_admin:
-            # Officer/manager refused post-publish; signal via
-            # PermissionError so router maps to 403.
+            # Phase E.4 commit 7: officer hard-blocked ở top; nhánh này thực
+            # tế là manager bị từ chối cho post-publish (admin-only).
+            # PermissionError → router maps to 403.
             raise PermissionError(
-                f"Officer cannot override KV on '{profile.status}' "
-                "profile — admin only for post-publish overrides."
+                f"Only admin can override KV on '{profile.status}' profile — "
+                "manager is refused for post-publish overrides."
             )
         # Admin path requires explicit acknowledgement flag.
         if not acknowledge_post_publish:

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -1,9 +1,14 @@
 # app/services/priority_override_service.py
-"""Q9 #07 Phase E.2 + E.3 — Priority bonus officer/admin write-path.
+"""Q9 #07 Phase E.2 + E.3 + E.4 — Priority bonus admin/manager (KV) +
+officer/admin/manager (UT) write-path.
 
-Service-layer functions cho manual KV override (Phase E.2) + UT evidence
-verify/reject (Phase E.3 — chưa ship Wave 2). Architectural rules
-(per CLAUDE.md PART 7):
+Service-layer functions cho:
+  - Manual KV override (Phase E.2; commit 7 hardening 2026-05-21):
+    ADMIN + MANAGER only. Officer hard-denied ngay đầu override_kv.
+  - UT evidence verify/reject (Phase E.3): officer + manager + admin
+    write-path; officer-scope via lead.assigned_officer_id IDOR check.
+
+Architectural rules (per CLAUDE.md PART 7):
 
 * No FastAPI imports — raise DomainExceptions, return (result, post_commit_cb)
 * Router commits; service flushes only
@@ -24,7 +29,7 @@ Snapshot mutation (override_kv):
       evidence_file_id: optional,
       frozen_at: now ISO (refresh on override),
       frozen_at_status: 'manual_override',
-      resolved_by: actor.role  # 'officer' | 'admin'
+      resolved_by: 'admin' | 'manager'  # Phase E.4 commit 7: officer denied
   }
   profile.area_resolution_basis ← 'manual_override'
   profile.version += 1
@@ -395,7 +400,11 @@ async def override_kv(
         "evidence_file_id": evidence_file_id,
         "frozen_at": now_iso,
         "frozen_at_status": "manual_override",
-        "resolved_by": "admin" if is_admin else "officer",
+        # Phase E.4 commit 7 fix-up — actor.role thực thay vì hardcode "officer".
+        # Officer đã hard-deny ở top → manager/admin là 2 role hợp lệ duy nhất.
+        # Allowlist explicit để fail-safe nếu future role được add (vd "auditor"
+        # với override permission) — chỉ admin/manager mới persist trong audit.
+        "resolved_by": "admin" if is_admin else "manager",
     }
     # Drop ambiguous engine-state keys that no longer apply post-override
     new_snapshot.pop("requires_manual_override", None)

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -261,10 +261,29 @@ async def override_kv(
             f"(got {len(reason_clean)})"
         )
 
-    # ---- Step 3: Status whitelist (role-aware)
+    # ---- Step 3: Role-level deny — Phase E.4 commit 7 hardening
+    # Yêu cầu nghiệp vụ #10 (chốt 2026-05-21): officer KHÔNG được override KV.
+    # Manager/admin pre-publish allowed với reason + audit; admin-only cho
+    # post-publish với acknowledge flag. Pre-commit 7: officer được override
+    # cho submitted/reviewing/revision_requested → cần block toàn diện.
+    # Service-level deny là defense-in-depth: Casbin migration q9_07_e4f cũng
+    # remove role:officer policy row; UI permissions flag cũng đổi sang chỉ
+    # admin/manager. Officer reach đây = bug router/permissions → raise.
     is_admin = actor.role == "admin"
     is_manager = actor.role == "manager"
-    is_officer_path = actor.role in ("officer", "manager")  # both treated as officer path
+    is_officer_path = actor.role == "manager"  # only manager treated as officer path
+    if actor.role == "officer":
+        log.warning(
+            "officer_override_kv_attempt_denied",
+            profile_id=profile.id,
+            actor_id=actor.id,
+            profile_status=profile.status,
+        )
+        raise BusinessRuleViolation(
+            "Officer không được override KV. Chỉ manager hoặc admin được "
+            "phép ấn định KV thủ công với lý do + audit. Vui lòng đề nghị "
+            "quản lý xử lý hồ sơ này."
+        )
 
     if profile.status in _HARD_DENIED_STATUS:
         raise BusinessRuleViolation(
@@ -279,9 +298,11 @@ async def override_kv(
     # đủ ở commit 7).
     if profile.status == "draft":
         if not (is_admin or is_manager):
+            # Officer đã được block ở top (commit 7). Branch này còn cover các
+            # role khác như accountant/user nếu Casbin lọt qua.
             raise BusinessRuleViolation(
-                "Officer không được override KV ở trạng thái draft. "
-                "Vui lòng đề nghị quản lý / admin xử lý hồ sơ này."
+                "Chỉ admin hoặc manager được phép override KV ở trạng thái "
+                "draft. Vui lòng đề nghị quản lý xử lý hồ sơ này."
             )
 
         # Phase E.4 reviewer v5 2026-05-21 — RECOMPUTE LIVE thay vì trust snapshot

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -96,9 +96,19 @@ _POST_PUBLISH_STATUS: frozenset[str] = frozenset({
     "waitlisted",
 })
 
-# Officer + admin BOTH refuse to override these (data inconsistency risk).
+# Phase E.4 commit 5 fix-up — KV override hard-deny matrix:
+# Pre-fix: ``draft`` đứng cùng withdrawn/dropped/rejected → block toàn bộ
+# override. Hậu quả: submit guard fail-closed (yêu cầu nghiệp vụ #7) raise
+# KV_UNRESOLVED + message "yêu cầu quản lý ấn định KV thủ công trước khi
+# nộp" → manager/admin KHÔNG có đường để fulfill yêu cầu đó vì profile
+# vẫn draft. Deadlock.
+#
+# Fix: tách ``draft`` khỏi hard-deny generic. Override trên draft được
+# allow CHỈ cho admin/manager + CHỈ khi engine đã emit signal unresolved
+# (snapshot.requires_manual_override=True). Officer giữ refused toàn diện
+# cho draft (kể cả engine signal) — hardening đầy đủ ở commit 7 (Casbin
+# + service guard).
 _HARD_DENIED_STATUS: frozenset[str] = frozenset({
-    "draft",
     "withdrawn",
     "dropped",
     "rejected",
@@ -253,14 +263,36 @@ async def override_kv(
 
     # ---- Step 3: Status whitelist (role-aware)
     is_admin = actor.role == "admin"
+    is_manager = actor.role == "manager"
     is_officer_path = actor.role in ("officer", "manager")  # both treated as officer path
 
     if profile.status in _HARD_DENIED_STATUS:
         raise BusinessRuleViolation(
             f"Cannot override KV in '{profile.status}' state — profile "
-            "is in draft/withdrawn/dropped/rejected and not eligible for "
+            "is in withdrawn/dropped/rejected and not eligible for "
             "manual KV intervention."
         )
+
+    # Phase E.4 commit 5 fix-up — draft gate riêng (gỡ deadlock với submit
+    # guard fail-closed). Cho admin/manager override draft CHỈ khi engine
+    # đã emit signal unresolved; officer giữ refused draft (hardening đầy
+    # đủ ở commit 7).
+    if profile.status == "draft":
+        if not (is_admin or is_manager):
+            raise BusinessRuleViolation(
+                "Officer không được override KV ở trạng thái draft. "
+                "Vui lòng đề nghị quản lý / admin xử lý hồ sơ này."
+            )
+        snapshot_now = profile.priority_resolution_snapshot or {}
+        if not snapshot_now.get("requires_manual_override"):
+            raise BusinessRuleViolation(
+                "Hồ sơ draft chỉ được override KV khi engine không xác "
+                "định được (snapshot.requires_manual_override=True). "
+                "Vui lòng kiểm tra trình độ văn hóa, địa chỉ thường trú "
+                "và lịch sử học để engine resolve tự động trước, hoặc "
+                "submit để chuyển sang trạng thái cho phép override "
+                "thường lệ (submitted/reviewing/revision_requested)."
+            )
 
     if profile.status in _POST_PUBLISH_STATUS:
         if not is_admin:
@@ -283,6 +315,7 @@ async def override_kv(
         and is_officer_path
         and profile.status not in _OFFICER_ALLOWED_STATUS
         and profile.status not in _POST_PUBLISH_STATUS
+        and profile.status != "draft"  # draft handled by dedicated gate above
     ):
         # Catch-all guard for unexpected statuses (vd new state machine
         # state not in either whitelist). Fail-closed for officer path.

--- a/Backend_FastAPI/app/services/priority_override_service.py
+++ b/Backend_FastAPI/app/services/priority_override_service.py
@@ -375,11 +375,15 @@ async def override_kv(
         and profile.status not in _POST_PUBLISH_STATUS
         and profile.status != "draft"  # draft handled by dedicated gate above
     ):
-        # Catch-all guard for unexpected statuses (vd new state machine
-        # state not in either whitelist). Fail-closed for officer path.
+        # Catch-all guard cho unexpected statuses (vd new state machine state
+        # không trong whitelist nào). Fail-closed cho non-admin path.
+        # Phase E.4 commit 7: officer đã hard-blocked ở top → branch này
+        # thực tế là manager bị từ chối cho status ngoài draft/submitted/
+        # reviewing/revision_requested.
         raise BusinessRuleViolation(
-            f"Cannot override KV in '{profile.status}' state — officer "
-            "allowed only for submitted/reviewing/revision_requested."
+            f"Cannot override KV in '{profile.status}' state — manager "
+            "allowed only for draft/submitted/reviewing/revision_requested; "
+            "admin required for post-publish overrides."
         )
 
     # ---- Step 4: Snapshot a deep copy of current state for audit log

--- a/Backend_FastAPI/app/services/priority_service.py
+++ b/Backend_FastAPI/app/services/priority_service.py
@@ -39,6 +39,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Optional
 
+import structlog
 from sqlalchemy import select
 
 if TYPE_CHECKING:
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
     from app.models.admission import AdmissionProfile
 
 
+log = structlog.get_logger(__name__)
 _ZERO = Decimal("0.00")
 
 
@@ -362,7 +364,7 @@ def _derive_kv_basis_level(
 
     voc = vocational or "none"
 
-    # 3. Backward-compat legacy branch (target_level chưa truyền — caller cũ).
+    # 4. Backward-compat legacy branch (target_level chưa truyền — caller cũ).
     #    Replicate matrix commit 4 để test legacy không break.
     if target_level is None:
         # Hồ sơ THPT-related → LICH_SU_THPT (trừ completed_thpt + so_cap/none → THUONG_TRU)
@@ -374,10 +376,10 @@ def _derive_kv_basis_level(
             return "THUONG_TRU", "legacy_thcs_pathway_uses_commune"
         return "NOT_RESOLVED", "legacy_unknown_cultural"
 
-    # 4. Phase E.4 matrix — target_level + admission_type drive basis.
+    # 5. Phase E.4 matrix — target_level + admission_type drive basis.
     atype = admission_type or "chinh_quy"
 
-    # 4a. Hybrid CĐ liên thông + completed_thpt + TC/CĐ (KHOI_LUONG_VH_THPT).
+    # 5a. Hybrid CĐ liên thông + completed_thpt + TC/CĐ (KHOI_LUONG_VH_THPT).
     # Per nghiệp vụ #6: có lịch sử THPT/GDTX hợp lệ → LICH_SU_THPT; không có
     # → THUONG_TRU; cả 2 thiếu → INSUFFICIENT_DATA (resolve step downgrade).
     if (
@@ -390,7 +392,7 @@ def _derive_kv_basis_level(
             return "LICH_SU_THPT", "cd_lien_thong_khoi_luong_with_thpt_history"
         return "THUONG_TRU", "cd_lien_thong_khoi_luong_no_thpt_history_fallback"
 
-    # 4b. CĐ (chính quy hoặc liên thông) với cultural graduated_thpt/gdtx/completed_thpt
+    # 5b. CĐ (chính quy hoặc liên thông) với cultural graduated_thpt/gdtx/completed_thpt
     # → LICH_SU_THPT. Matrix nghiệp vụ #6:
     #   - CĐ chính quy sau THPT/hoàn thành THPT → LICH_SU_THPT
     #   - CĐ chính quy diện hoàn thành THPT + TC → LICH_SU_THPT
@@ -405,7 +407,7 @@ def _derive_kv_basis_level(
         # Defensive: nếu reach here → cấu hình mismatch upstream.
         return "INSUFFICIENT_DATA", f"cd_{atype}_cultural_insufficient_for_kv_basis"
 
-    # 4c. TC matrix.
+    # 5c. TC matrix.
     if target_level == "trung_cap":
         if atype == "lien_thong":
             # TC liên thông từ SC/TC sau THCS → THUONG_TRU
@@ -424,12 +426,12 @@ def _derive_kv_basis_level(
             return "LICH_SU_THPT", "tc_chinh_quy_post_thpt_uses_school_history"
         return "INSUFFICIENT_DATA", "tc_chinh_quy_cultural_insufficient_for_kv_basis"
 
-    # 4d. SC chính quy — không yêu cầu cultural; default THUONG_TRU.
+    # 5d. SC chính quy — không yêu cầu cultural; default THUONG_TRU.
     # Engine sẽ check commune ở resolve step (ADDRESS_NOT_NORMALIZED nếu miss).
     if target_level == "so_cap":
         return "THUONG_TRU", "sc_uses_commune"
 
-    # 5. Defensive: target_level ngoài CD/TC/SC scope (eligibility gate đã chặn).
+    # 6. Defensive: target_level ngoài CD/TC/SC scope (eligibility gate đã chặn).
     return "INSUFFICIENT_DATA", f"unsupported_target_level:{target_level}"
 
 
@@ -794,13 +796,29 @@ async def freeze_priority_snapshot(
 
     Called from:
       - submit_admission_profile (T1) → frozen_at_status='submitted_T1'
-      - evaluate_cascade (T6) → frozen_at_status='engine_T6'
+      - evaluate_cascade (T6)         → frozen_at_status='engine_T6'
 
     Mutates ``profile.priority_resolution_snapshot`` directly. Caller is
     responsible for ``await db.flush()`` (no commit — service layer rule).
 
-    ``frozen_at_status`` MUST be one of:
-      'draft_preview' | 'submitted_T1' | 'engine_T6'
+    ``frozen_at_status`` values this helper writes:
+      'submitted_T1' | 'engine_T6'
+
+    Snapshot column ALSO sees ``'manual_override'`` — written directly by
+    ``priority_override_service.override_kv`` (NOT via this helper).
+
+    Phase E.4 semantics — ``frozen_at_status='submitted_T1'`` indicates the
+    snapshot was frozen DURING a submit attempt; it does NOT imply the
+    submit succeeded. Since commit ``dd108eb2`` (Phase E.4), submit
+    aggregates KV unresolved/resolution_failed into ``validation_errors``
+    instead of raising, so the snapshot persists (router still commits)
+    while ``profile.status`` stays ``'draft'``. This is required to
+    expose the engine signal (``requires_manual_override``) to the manager
+    /admin override-draft gate. To disambiguate ``submitted_T1`` snapshots,
+    callers MUST check ``profile.status``:
+      - ``status='draft'`` + ``submitted_T1``  → submit FAILED, snapshot
+        captures resolution attempt for override gate
+      - ``status='submitted'`` + ``submitted_T1`` → submit SUCCEEDED
 
     Phase E.4 (commit 5) additive fields (optional — backward-compat):
       target_level, admission_type, eligibility, basis, basis_reason,
@@ -846,6 +864,27 @@ async def freeze_priority_snapshot(
 
     profile.priority_resolution_snapshot = snapshot
     return snapshot
+
+
+def _make_path_shim_from_academic_info(academic_info: Any) -> Any:
+    """Build pseudo-AdmissionPath stub bọc academic_info đã eager-load.
+
+    ``derive_target_level_and_type`` đọc qua ``path.__dict__['academic_info']``
+    để mimic eager-load semantics; legacy callers (single-path / config
+    chain) không có thực thể AdmissionPath nên cần shim. Helper này centralize
+    pattern (trước đây duplicated 2 chỗ: admission_service._validate_*
+    + priority_service.derive_profile_target_context).
+
+    Trả về object với ``__dict__['academic_info']`` set + ``admission_method``
+    placeholder=None (legacy không có method chain — bonus_rule context fall
+    về admission_method default).
+    """
+    class _PathShim:
+        pass
+    shim = _PathShim()
+    shim.__dict__["academic_info"] = academic_info
+    shim.__dict__["admission_method"] = None
+    return shim
 
 
 def derive_target_level_and_type(path: "AdmissionPath") -> tuple[str, str]:
@@ -1143,12 +1182,7 @@ async def derive_profile_target_context(
             )
             config = (await db.execute(stmt)).scalar_one_or_none()
             if config is not None:
-                class _PathShim:
-                    pass
-                shim = _PathShim()
-                shim.__dict__["academic_info"] = config.academic_info
-                shim.__dict__["admission_method"] = None  # no path → no method
-                path = shim  # type: ignore[assignment]
+                path = _make_path_shim_from_academic_info(config.academic_info)
                 ctx["source"] = "legacy_offering_admission_config"
 
         if path is not None:
@@ -1156,8 +1190,17 @@ async def derive_profile_target_context(
                 target_level, admission_type = derive_target_level_and_type(path)
                 ctx["target_level"] = target_level
                 ctx["admission_type"] = admission_type
-            except Exception:  # noqa: BLE001 — defensive: missing chain
-                pass
+            except Exception as exc:  # noqa: BLE001 — defensive: missing chain
+                # Phase E.4 reviewer P5: log debug để trace context-derive
+                # failures (vd chain chưa eager-load đầy đủ). Vẫn không block
+                # freeze; snapshot ship null cho 2 field này, FE/audit degrade.
+                log.debug(
+                    "derive_target_level_context_failed",
+                    profile_id=getattr(profile, "id", None),
+                    source=ctx["source"],
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
 
             # path_bonus_rule snapshot: chain override → method.default.
             # Lazy import để tránh circular.
@@ -1167,8 +1210,14 @@ async def derive_profile_target_context(
                     rule = resolve_effective_bonus_rule(path)  # type: ignore[arg-type]
                     if rule is not None:
                         ctx["path_bonus_rule"] = dict(rule)
-            except Exception:  # noqa: BLE001
-                pass
+            except Exception as exc:  # noqa: BLE001
+                log.debug(
+                    "derive_path_bonus_rule_context_failed",
+                    profile_id=getattr(profile, "id", None),
+                    source=ctx["source"],
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
 
         # Eligibility check audit — chỉ compute khi cả 2 field có.
         if ctx["target_level"] and ctx["admission_type"]:
@@ -1177,8 +1226,13 @@ async def derive_profile_target_context(
             )
             ctx["eligibility"] = {"passed": ok, "reason": reason}
 
-    except Exception:  # noqa: BLE001 — defensive: never block freeze on context
-        pass
+    except Exception as exc:  # noqa: BLE001 — defensive: never block freeze on context
+        log.debug(
+            "derive_profile_target_context_failed",
+            profile_id=getattr(profile, "id", None),
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
 
     return ctx
 

--- a/Backend_FastAPI/app/services/priority_service.py
+++ b/Backend_FastAPI/app/services/priority_service.py
@@ -349,7 +349,14 @@ def _derive_kv_basis_level(
     if area_resolution_basis == "manual_override":
         return "MANUAL", "admin_set_kv_directly"
 
-    # 2. Draft state — cultural chưa khai.
+    # 2. SC chính quy carve-out (yêu cầu nghiệp vụ #5+#6): SC không yêu cầu
+    # văn hóa → cultural=None vẫn pass eligibility. KV resolve qua THUONG_TRU
+    # (commune lookup). Phải check TRƯỚC "cultural is None" early-return để
+    # không kẹt vào NOT_RESOLVED sai.
+    if target_level == "so_cap" and cultural is None:
+        return "THUONG_TRU", "sc_no_cultural_uses_commune"
+
+    # 3. Draft state — cultural chưa khai (mọi target_level khác SC đều block).
     if cultural is None:
         return "NOT_RESOLVED", "cultural_not_set"
 

--- a/Backend_FastAPI/app/services/priority_service.py
+++ b/Backend_FastAPI/app/services/priority_service.py
@@ -645,51 +645,180 @@ async def freeze_priority_snapshot(
     return snapshot
 
 
+def derive_target_level_and_type(path: "AdmissionPath") -> tuple[str, str]:
+    """Derive (target_level, admission_type) từ AdmissionPath chain.
+
+    Chain: AdmissionPath → OfferingAcademicInfo → ProgramOffering →
+    MajorProgram.degree_level_id + ProgramOffering.offering_type_id (FK
+    config_degree_level + config_offering_type).
+
+    Returns:
+        (target_level, admission_type) — cả 2 là `code` từ config table.
+        target_level ∈ {"cao_dang", "trung_cap", "so_cap"} (Phase E.4
+        scope GDNN; "dai_hoc"/"thac_si"/"tien_si" out-of-scope).
+        admission_type ∈ {"chinh_quy", "lien_thong", "vua_lam_vua_hoc",
+        "tu_xa", "lien_ket_quoc_te"}.
+
+    Raises:
+        BusinessRuleViolation("CONFIG_GAP_TARGET_LEVEL") khi không derive
+        được do:
+          - relation chain chưa eager-load (academic_info/offering/program/
+            degree_level/offering_type)
+          - degree_level_id/offering_type_id NULL trên major_program/
+            program_offering
+          - code không nằm trong GDNN scope (vd dai_hoc)
+        Per yêu cầu nghiệp vụ #5: tuyệt đối KHÔNG fallback "so_cap" — fail-closed.
+
+    Caller MUST eager-load chain trước khi gọi:
+        selectinload(AdmissionPath.academic_info)
+          .selectinload(OfferingAcademicInfo.offering)
+          .selectinload(ProgramOffering.program)
+          .selectinload(MajorProgram.degree_level_obj)  # FK config_degree_level
+        selectinload(AdmissionPath.academic_info)
+          .selectinload(OfferingAcademicInfo.offering)
+          .selectinload(ProgramOffering.offering_type_obj)  # FK config_offering_type
+    """
+    from ..utils.exceptions import BusinessRuleViolation
+
+    _GDNN_TARGET_LEVELS = frozenset({"cao_dang", "trung_cap", "so_cap"})
+
+    academic_info = path.__dict__.get("academic_info")
+    if academic_info is None:
+        raise BusinessRuleViolation(
+            "CONFIG_GAP_TARGET_LEVEL: AdmissionPath thiếu academic_info "
+            "(relation chưa eager-load hoặc DB không nhất quán)."
+        )
+    offering = academic_info.__dict__.get("offering")
+    if offering is None:
+        raise BusinessRuleViolation(
+            "CONFIG_GAP_TARGET_LEVEL: OfferingAcademicInfo thiếu offering."
+        )
+    program = offering.__dict__.get("program")
+    if program is None:
+        raise BusinessRuleViolation(
+            "CONFIG_GAP_TARGET_LEVEL: ProgramOffering thiếu program (MajorProgram)."
+        )
+
+    # degree_level — model relationship `MajorProgram.degree_level_ref` →
+    # ConfigDegreeLevel(.code). Eager-load via selectinload(program.degree_level_ref).
+    degree_level_obj = program.__dict__.get("degree_level_ref")
+    target_code: Optional[str] = (
+        getattr(degree_level_obj, "code", None) if degree_level_obj else None
+    )
+    if target_code is None:
+        raise BusinessRuleViolation(
+            "CONFIG_GAP_TARGET_LEVEL: MajorProgram chưa gán degree_level_id "
+            "(config_degree_level FK NULL). Vui lòng cấu hình bậc đào tạo "
+            "trước khi cho hồ sơ submit."
+        )
+    if target_code not in _GDNN_TARGET_LEVELS:
+        raise BusinessRuleViolation(
+            f"CONFIG_GAP_TARGET_LEVEL: bậc đào tạo '{target_code}' nằm ngoài "
+            f"phạm vi GDNN ({sorted(_GDNN_TARGET_LEVELS)}). Phase E.4 chỉ "
+            f"hỗ trợ CĐ/TC/SC."
+        )
+
+    # offering_type — model relationship `ProgramOffering.offering_type_config`
+    # → ConfigOfferingType(.code). Eager-load via
+    # selectinload(offering.offering_type_config).
+    offering_type_obj = offering.__dict__.get("offering_type_config")
+    admission_type: Optional[str] = (
+        getattr(offering_type_obj, "code", None) if offering_type_obj else None
+    )
+    if admission_type is None:
+        raise BusinessRuleViolation(
+            "CONFIG_GAP_TARGET_LEVEL: ProgramOffering chưa gán offering_type_id "
+            "(config_offering_type FK NULL). Vui lòng cấu hình hệ đào tạo "
+            "(chính quy / liên thông / VLVH...) trước khi cho hồ sơ submit."
+        )
+
+    return target_code, admission_type
+
+
 def validate_eligibility(
     profile: "AdmissionProfile",
     target_level: str,
+    admission_type: str = "chinh_quy",
 ) -> tuple[bool, Optional[str]]:
-    """Validate candidate eligibility for target program level.
+    """Validate candidate eligibility for target program level + type.
 
-    Per TT 05/2021 Phụ lục 01 + Luật GDNN 2014/2025:
-      - target_level='CD' (Cao đẳng): requires graduated_thpt OR graduated_gdtx
-        OR (completed_thpt + trung_cap) — path 2 cho liên thông
-      - target_level='TC' (Trung cấp): requires graduated_thcs trở lên
-      - target_level='SC' (Sơ cấp): no academic requirement
+    Per TT 05/2021 Phụ lục 01 + Luật GDNN 2014/2025 (chốt 2026-05-21):
+      - CĐ chính quy:     TN_THPT hoặc HOAN_THANH_THPT
+      - CĐ liên thông:    TN_THPT hoặc HOAN_THANH_THPT + bằng TC/CĐ
+      - TC chính quy:     TN_THCS trở lên
+      - TC liên thông:    TN_THCS trở lên + bằng SC/TC
+      - SC chính quy:     không yêu cầu văn hóa
 
-    Returns ``(is_eligible, reason_if_not)``.
+    Args:
+        profile: AdmissionProfile với cultural_education_level + vocational_qualification.
+        target_level: config_degree_level.code — "cao_dang" / "trung_cap" / "so_cap".
+        admission_type: config_offering_type.code — "chinh_quy" / "lien_thong" /
+            "vua_lam_vua_hoc" / "tu_xa" / "lien_ket_quoc_te". Default "chinh_quy"
+            cho backward-compat với callers cũ.
+
+    Returns:
+        (is_eligible, reason_code_if_not).
+        reason_code dùng làm i18n key cho FE error display.
+
+    Per yêu cầu nghiệp vụ #5: unknown target_level → block (fail-closed).
     """
     cultural = getattr(profile, "cultural_education_level", None)
     vocational = getattr(profile, "vocational_qualification", "none") or "none"
 
-    if target_level in ("CD", "cao_dang"):
-        # Path 1: tốt nghiệp THPT/GDTX direct
-        if cultural in ("graduated_thpt", "graduated_gdtx"):
-            return True, None
-        # Path 2: liên thông — đủ kiến thức THPT + bằng TC nghề
-        if cultural == "completed_thpt" and vocational == "trung_cap":
-            return True, None
-        # Path 2 extended: graduated_thcs + cao_dang already done → re-enroll OK
-        if cultural == "graduated_thcs" and vocational == "cao_dang":
-            return True, None
-        return False, "cd_requires_thpt_or_thpt_kien_thuc_plus_trung_cap"
+    _THPT_GRADUATED = ("graduated_thpt", "graduated_gdtx")
+    _THPT_KNOWLEDGE = ("completed_thpt", "graduated_thpt", "graduated_gdtx")
+    _THCS_OR_HIGHER = (
+        "graduated_thcs",
+        "completed_thpt",
+        "graduated_thpt",
+        "graduated_gdtx",
+    )
 
-    if target_level in ("TC", "trung_cap"):
-        # Per Luật GDNN: TC yêu cầu tốt nghiệp THCS trở lên
-        if cultural in (
-            "graduated_thcs",
-            "completed_thpt",
-            "graduated_thpt",
-            "graduated_gdtx",
-        ):
+    if target_level in ("cao_dang", "CD"):
+        if admission_type == "lien_thong":
+            # CĐ liên thông: kiến thức THPT (đã TN hoặc hoàn thành) + bằng TC/CĐ
+            if cultural in _THPT_KNOWLEDGE and vocational in ("trung_cap", "cao_dang"):
+                return True, None
+            return False, "cd_lien_thong_requires_thpt_knowledge_plus_tc_or_cd"
+        # CĐ chính quy + các hệ khác: TN_THPT hoặc HOAN_THANH_THPT (per spec mới
+        # 2026-05-21 — yêu cầu nghiệp vụ #5).
+        if cultural in _THPT_KNOWLEDGE:
+            return True, None
+        return False, "cd_chinh_quy_requires_thpt_or_completed_thpt"
+
+    if target_level in ("trung_cap", "TC"):
+        if admission_type == "lien_thong":
+            # TC liên thông: TN_THCS trở lên + bằng SC/TC
+            if cultural in _THCS_OR_HIGHER and vocational in ("so_cap", "trung_cap"):
+                return True, None
+            return False, "tc_lien_thong_requires_thcs_plus_sc_or_tc"
+        # TC chính quy: TN_THCS trở lên
+        if cultural in _THCS_OR_HIGHER:
             return True, None
         return False, "tc_requires_graduated_thcs_or_higher"
 
-    if target_level in ("SC", "so_cap"):
-        return True, None  # SC không yêu cầu trình độ văn hóa
+    if target_level in ("so_cap", "SC"):
+        # SC chính quy không yêu cầu văn hóa. Liên thông SC chưa định nghĩa
+        # nghiệp vụ — fail-closed.
+        if admission_type == "chinh_quy":
+            return True, None
+        return False, "sc_only_supports_chinh_quy_in_phase_e4"
 
-    # Unknown target_level — defensive pass-through (caller validates)
-    return True, None
+    # Yêu cầu nghiệp vụ #5: target_level ngoài CD/TC/SC scope → block.
+    return False, f"unsupported_target_level:{target_level}"
+
+
+# Legacy uppercase aliases for callers còn dùng "CD"/"TC"/"SC" tag.
+_LEGACY_TARGET_LEVEL_ALIAS = {
+    "CD": "cao_dang",
+    "TC": "trung_cap",
+    "SC": "so_cap",
+}
+
+
+def normalize_target_level(level: str) -> str:
+    """Map legacy "CD"/"TC"/"SC" → config code "cao_dang"/"trung_cap"/"so_cap"."""
+    return _LEGACY_TARGET_LEVEL_ALIAS.get(level, level)
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/services/priority_service.py
+++ b/Backend_FastAPI/app/services/priority_service.py
@@ -282,57 +282,148 @@ def _today():
 # =============================================================================
 
 
+def _has_thpt_history(academic_history: Optional[list]) -> bool:
+    """True khi profile có ít nhất 1 academic_history entry mức THPT/GDTX hợp lệ.
+
+    "Hợp lệ" = level ∈ {THPT, THCS_THPT, GDTX} + school_id + year_from/year_to
+    không null. Dùng cho hybrid rule CĐ liên thông KHOI_LUONG_VH_THPT + TC
+    (yêu cầu nghiệp vụ #6): có history → LICH_SU_THPT; không có → THUONG_TRU.
+    """
+    if not academic_history:
+        return False
+    return any(
+        isinstance(e, dict)
+        and e.get("level") in {"THPT", "THCS_THPT", "GDTX"}
+        and e.get("school_id")
+        and e.get("year_from") is not None
+        and e.get("year_to") is not None
+        for e in academic_history
+    )
+
+
 def _derive_kv_basis_level(
     cultural: Optional[str],
     vocational: str,
+    target_level: Optional[str] = None,
+    admission_type: Optional[str] = None,
+    academic_history: Optional[list] = None,
     area_resolution_basis: Optional[str] = None,
-) -> str:
-    """Map (cultural, vocational, area_basis) → KV resolution basis.
+) -> tuple[str, str]:
+    """Map profile context → KV resolution basis + reason code.
 
-    Returns one of:
-      'THPT'              — apply 3-year THPT multi-school rule (rows 1, 2)
-      'COMMUNE_FALLBACK'  — TN THCS bất kể vocational / so_cap / completed_thpt+none
-                            (rows 3, 4+5 merged, 6) — per nghiệp vụ trường 2026-05-18
-      'COMMUNE_SPECIAL'   — 4 special cases bypass (row 8)
-      'MANUAL'            — admin override (row 9)
-      'NOT_RESOLVED'      — cultural chưa khai (row 7, draft)
+    Phase E.4 (commit 5) refactor — signature mở rộng target_level +
+    admission_type + academic_history để khớp matrix nghiệp vụ #6:
 
-    See `Documents/Q9_07_PR5_REDESIGN.md` v1.3 Section "KV resolution basis
-    derivation matrix" cho 9 rows complete spec.
+      - TC sau THCS (target=trung_cap chính quy, cultural=graduated_thcs) → THUONG_TRU
+      - TC sau THPT/hoàn thành THPT → LICH_SU_THPT
+      - CĐ chính quy sau THPT/hoàn thành THPT → LICH_SU_THPT
+      - CĐ chính quy hoàn thành THPT + TC → LICH_SU_THPT (extended TT path)
+      - TC liên thông từ SC/TC sau THCS → THUONG_TRU
+      - TC liên thông có THPT/hoàn thành THPT → LICH_SU_THPT
+      - CĐ liên thông từ TC/CĐ có TN_THPT → LICH_SU_THPT
+      - CĐ liên thông KHOI_LUONG_VH_THPT + TC (completed_thpt + trung_cap/cao_dang):
+          có history THPT/GDTX hợp lệ → LICH_SU_THPT
+          không có history → THUONG_TRU
+          thiếu cả history lẫn commune → INSUFFICIENT_DATA (resolve step xử lý)
+
+    Returns ``(basis, basis_reason)``:
+      basis ∈ {
+        'LICH_SU_THPT'           — multi-school rule TT 05/2021 Mục 5.b
+        'THUONG_TRU'             — vn_commune_area_map lookup
+        'COMMUNE_SPECIAL'        — exception override (PT DTNT / ĐBKK 18+ tháng)
+        'MANUAL'                 — admin/manager override KV trực tiếp
+        'INSUFFICIENT_DATA'      — thiếu cultural/target/cấu hình quan trọng
+        'MANUAL_REVIEW_REQUIRED' — multi-school tied graduation
+        'NOT_RESOLVED'           — draft, cultural chưa khai
+      }
+      basis_reason — short snake_case key cho audit / FE display.
+
+    Backward compat: target_level/admission_type/academic_history mặc định None;
+    callers cũ chỉ truyền cultural + vocational + area_basis sẽ fall vào
+    "LEGACY" path (replicate hành vi commit 4) — KHÔNG break test cũ NGAY,
+    sẽ phase out khi resolve_kv_for_profile fully threaded.
     """
-    # Row 8/9: area_resolution_basis overrides matrix
+    # 1. Override paths — output bypass, áp trên mọi context.
     if area_resolution_basis == "permanent_address_special":
-        return "COMMUNE_SPECIAL"
+        return "COMMUNE_SPECIAL", "permanent_address_special_override"
     if area_resolution_basis == "manual_override":
-        return "MANUAL"
+        return "MANUAL", "admin_set_kv_directly"
 
-    # Row 7: cultural not set (draft state)
+    # 2. Draft state — cultural chưa khai.
     if cultural is None:
-        return "NOT_RESOLVED"
+        return "NOT_RESOLVED", "cultural_not_set"
 
-    # Rows 1, 2 (partial), 3: THPT-related cultural levels
-    if cultural in ("graduated_thpt", "graduated_gdtx", "completed_thpt"):
-        # Row 3 (completed_thpt + so_cap/none) → COMMUNE_FALLBACK
-        if cultural == "completed_thpt" and vocational in ("so_cap", "none"):
-            return "COMMUNE_FALLBACK"
-        return "THPT"  # Rows 1 + 2
+    voc = vocational or "none"
 
-    # Rows 4, 5: graduated_thcs → COMMUNE_FALLBACK regardless of vocational.
-    #
-    # Nghiệp vụ trường (user confirmed 2026-05-18): TN THCS bất kể đã có TC nghề
-    # hay chưa → KV theo nơi thường trú (hộ khẩu), KHÔNG theo trường TC nghề.
-    # Lý do: TT 05/2021 verbatim Mục 1 "tốt nghiệp trung học" — TN THCS chưa
-    # đủ "lịch sử trung học phổ thông" để tính KV theo trường. Override
-    # v1.3 design doc Row 4 (TC basis) — engine TC pathway = DEAD code path.
-    if cultural == "graduated_thcs":
-        return "COMMUNE_FALLBACK"  # Rows 4 + 5 merged
+    # 3. Backward-compat legacy branch (target_level chưa truyền — caller cũ).
+    #    Replicate matrix commit 4 để test legacy không break.
+    if target_level is None:
+        # Hồ sơ THPT-related → LICH_SU_THPT (trừ completed_thpt + so_cap/none → THUONG_TRU)
+        if cultural in ("graduated_thpt", "graduated_gdtx", "completed_thpt"):
+            if cultural == "completed_thpt" and voc in ("so_cap", "none"):
+                return "THUONG_TRU", "legacy_completed_thpt_no_vocational"
+            return "LICH_SU_THPT", "legacy_thpt_pathway"
+        if cultural in ("graduated_thcs", "completed_thcs"):
+            return "THUONG_TRU", "legacy_thcs_pathway_uses_commune"
+        return "NOT_RESOLVED", "legacy_unknown_cultural"
 
-    # Row 6: completed_thcs (any vocational) → fallback
-    if cultural == "completed_thcs":
-        return "COMMUNE_FALLBACK"
+    # 4. Phase E.4 matrix — target_level + admission_type drive basis.
+    atype = admission_type or "chinh_quy"
 
-    # Defensive: unknown cultural (shouldn't happen due to CHECK enum)
-    return "NOT_RESOLVED"
+    # 4a. Hybrid CĐ liên thông + completed_thpt + TC/CĐ (KHOI_LUONG_VH_THPT).
+    # Per nghiệp vụ #6: có lịch sử THPT/GDTX hợp lệ → LICH_SU_THPT; không có
+    # → THUONG_TRU; cả 2 thiếu → INSUFFICIENT_DATA (resolve step downgrade).
+    if (
+        target_level == "cao_dang"
+        and atype == "lien_thong"
+        and cultural == "completed_thpt"
+        and voc in ("trung_cap", "cao_dang")
+    ):
+        if _has_thpt_history(academic_history):
+            return "LICH_SU_THPT", "cd_lien_thong_khoi_luong_with_thpt_history"
+        return "THUONG_TRU", "cd_lien_thong_khoi_luong_no_thpt_history_fallback"
+
+    # 4b. CĐ (chính quy hoặc liên thông) với cultural graduated_thpt/gdtx/completed_thpt
+    # → LICH_SU_THPT. Matrix nghiệp vụ #6:
+    #   - CĐ chính quy sau THPT/hoàn thành THPT → LICH_SU_THPT
+    #   - CĐ chính quy diện hoàn thành THPT + TC → LICH_SU_THPT
+    #   - CĐ liên thông từ TC/CĐ có THPT → LICH_SU_THPT
+    if target_level == "cao_dang":
+        if cultural in ("graduated_thpt", "graduated_gdtx"):
+            return "LICH_SU_THPT", f"cd_{atype}_post_thpt_uses_school_history"
+        if cultural == "completed_thpt":
+            # CĐ chính quy + hoàn thành THPT đủ kiến thức → LICH_SU_THPT (nghiệp vụ #5)
+            return "LICH_SU_THPT", f"cd_{atype}_completed_thpt_uses_school_history"
+        # Eligibility gate đã chặn graduated_thcs/completed_thcs cho CĐ chính quy.
+        # Defensive: nếu reach here → cấu hình mismatch upstream.
+        return "INSUFFICIENT_DATA", f"cd_{atype}_cultural_insufficient_for_kv_basis"
+
+    # 4c. TC matrix.
+    if target_level == "trung_cap":
+        if atype == "lien_thong":
+            # TC liên thông từ SC/TC sau THCS → THUONG_TRU
+            if cultural == "graduated_thcs" and voc in ("so_cap", "trung_cap"):
+                return "THUONG_TRU", "tc_lien_thong_post_thcs_with_voc_uses_commune"
+            # TC liên thông có THPT/hoàn thành THPT → LICH_SU_THPT
+            if cultural in ("completed_thpt", "graduated_thpt", "graduated_gdtx"):
+                return "LICH_SU_THPT", "tc_lien_thong_post_thpt_uses_school_history"
+            return "INSUFFICIENT_DATA", "tc_lien_thong_cultural_insufficient_for_kv_basis"
+        # TC chính quy:
+        # - TN_THCS → THUONG_TRU
+        # - completed/graduated THPT/GDTX → LICH_SU_THPT
+        if cultural == "graduated_thcs":
+            return "THUONG_TRU", "tc_chinh_quy_post_thcs_uses_commune"
+        if cultural in ("completed_thpt", "graduated_thpt", "graduated_gdtx"):
+            return "LICH_SU_THPT", "tc_chinh_quy_post_thpt_uses_school_history"
+        return "INSUFFICIENT_DATA", "tc_chinh_quy_cultural_insufficient_for_kv_basis"
+
+    # 4d. SC chính quy — không yêu cầu cultural; default THUONG_TRU.
+    # Engine sẽ check commune ở resolve step (ADDRESS_NOT_NORMALIZED nếu miss).
+    if target_level == "so_cap":
+        return "THUONG_TRU", "sc_uses_commune"
+
+    # 5. Defensive: target_level ngoài CD/TC/SC scope (eligibility gate đã chặn).
+    return "INSUFFICIENT_DATA", f"unsupported_target_level:{target_level}"
 
 
 async def _lookup_commune_kv(
@@ -387,120 +478,176 @@ async def lookup_kv_for_school_year(
 async def resolve_kv_for_profile(
     profile: "AdmissionProfile",
     db: "AsyncSession",
+    *,
+    target_level: Optional[str] = None,
+    admission_type: Optional[str] = None,
 ) -> tuple[Optional[str], dict[str, Any]]:
-    """Resolve KV for a profile per TT 05/2021 Phụ lục 01 multi-school rule.
+    """Resolve KV cho profile per TT 05/2021 Phụ lục 01.
 
-    Returns ``(kv_code, meta_dict)`` where ``meta_dict`` matches the shape
-    of ``priority_resolution_snapshot`` (without freeze metadata):
+    Phase E.4 (commit 5) refactor — pipeline:
+       Eligibility (upstream gate) → Exception → Auto basis → Resolve KV
+       → Apply path bonus (caller) → Snapshot (freeze).
 
-        {
-            'rule_applied': str,   # longest_duration | tiebreak_graduation_school
-                                   # | commune_lookup | manual_override
-                                   # | ambiguous_requires_manual
-            'pathway': str,        # thpt_multi_school | tc_multi_school
-                                   # | commune_fallback | commune_special
-                                   # | manual | not_resolved
-            'breakdown': {...} | None,
-            'requires_manual_override': bool (optional),
-            'reason': str (optional)
-        }
+    Fail-closed: tuyệt đối KHÔNG silent 0đ. Khi catalog/data thiếu, trả
+    rule_applied đặc tả lỗi:
+      - "catalog_gap_school"      — vn_school_kv_assignment thiếu row
+      - "catalog_gap_commune"     — vn_commune_area_map thiếu commune_code
+      - "address_not_normalized"  — profile thiếu permanent_commune_code
+      - "ambiguous_requires_manual" — tied graduation
+      - "not_resolved"            — cultural NULL (draft)
+      - "insufficient_data"       — combo input không match matrix nào
 
-    NULL kv_code → engine ignores (legacy fallback 0đ).
+    Args:
+      profile: AdmissionProfile với cultural_education_level + vocational_qualification
+               + permanent_commune_code + academic_history + area_resolution_basis.
+      db: AsyncSession.
+      target_level: 'cao_dang' / 'trung_cap' / 'so_cap' từ path/config chain.
+                    Optional cho backward-compat (callers cũ); None → legacy
+                    matrix (cảnh báo: matrix giảm độ chính xác).
+      admission_type: 'chinh_quy' / 'lien_thong' / ... từ config_offering_type.
+                      Optional. Default 'chinh_quy' khi target_level đã set.
 
-    See `Documents/Q9_07_PR5_REDESIGN.md` v1.3 Section "Resolution algorithm".
+    Returns ``(kv_code, meta_dict)``:
+       kv_code: 'KV1' / 'KV2' / 'KV2-NT' / 'KV3' hoặc None khi unresolved.
+       meta_dict (matches priority_resolution_snapshot subset):
+         {
+             'rule_applied': str,
+             'pathway': str,            # legacy alias cho FE display
+             'basis': str,              # LICH_SU_THPT / THUONG_TRU / ...
+             'basis_reason': str,       # short reason code
+             'breakdown': {...} | None,
+             'requires_manual_override': bool (optional),
+             'reason': str (optional)
+         }
     """
     cultural = getattr(profile, "cultural_education_level", None)
     vocational = getattr(profile, "vocational_qualification", "none") or "none"
     area_basis = getattr(profile, "area_resolution_basis", None)
+    academic_history = getattr(profile, "academic_history", None) or []
 
-    basis = _derive_kv_basis_level(cultural, vocational, area_basis)
+    basis, basis_reason = _derive_kv_basis_level(
+        cultural=cultural,
+        vocational=vocational,
+        target_level=target_level,
+        admission_type=admission_type,
+        academic_history=academic_history,
+        area_resolution_basis=area_basis,
+    )
 
-    # --- Row 8: 4 special cases bypass (PT DTNT / dự bị / quân nhân / xuất ngũ) ---
+    # Common meta scaffold — basis + basis_reason luôn included.
+    def _meta_base(**extra) -> dict[str, Any]:
+        base = {"basis": basis, "basis_reason": basis_reason}
+        base.update(extra)
+        return base
+
+    # --- COMMUNE_SPECIAL: exception bypass (PT DTNT / ĐBKK 18+ tháng). ---
+    # Hôm nay chỉ wire 2 case (yêu cầu nghiệp vụ #11), 4 case full defer Phase F.
     if basis == "COMMUNE_SPECIAL":
         commune_code = getattr(profile, "permanent_commune_code", None)
-        if commune_code:
-            kv = await _lookup_commune_kv(db, commune_code)
-            return kv, {
-                "rule_applied": "commune_lookup",
-                "pathway": "commune_special",
-                "breakdown": {"commune_code_used": commune_code},
-            }
-        return None, {
-            "rule_applied": "ambiguous_requires_manual",
-            "pathway": "commune_special",
-            "requires_manual_override": True,
-            "reason": "special_case_no_commune",
-        }
+        if not commune_code:
+            return None, _meta_base(
+                rule_applied="address_not_normalized",
+                pathway="commune_special",
+                requires_manual_override=True,
+                reason="special_case_no_commune_code",
+            )
+        kv = await _lookup_commune_kv(db, commune_code)
+        if kv is None:
+            return None, _meta_base(
+                rule_applied="catalog_gap_commune",
+                pathway="commune_special",
+                requires_manual_override=True,
+                reason="commune_code_not_in_catalog",
+                breakdown={"commune_code_attempted": commune_code},
+            )
+        return kv, _meta_base(
+            rule_applied="commune_lookup",
+            pathway="commune_special",
+            breakdown={"commune_code_used": commune_code},
+        )
 
-    # --- Row 9: admin/officer manual override ---
+    # --- MANUAL: admin/manager override KV trực tiếp ---
     if basis == "MANUAL":
-        # Caller should have set kv_resolved in snapshot before calling;
-        # treat as no-op here (returns NULL → snapshot keeps existing).
-        return None, {
-            "rule_applied": "manual_override",
-            "pathway": "manual",
-            "requires_manual_override": False,
-            "reason": "admin_set_kv_directly",
-        }
+        # Caller phải đã set kv_resolved trong snapshot trước khi gọi engine;
+        # engine trả None để báo "không tự resolve, dùng existing kv_resolved".
+        return None, _meta_base(
+            rule_applied="manual_override",
+            pathway="manual",
+            requires_manual_override=False,
+            reason="admin_set_kv_directly",
+        )
 
-    # --- Row 7: cultural not set (draft) ---
+    # --- NOT_RESOLVED: cultural chưa khai (draft). ---
     if basis == "NOT_RESOLVED":
-        return None, {
-            "rule_applied": "ambiguous_requires_manual",
-            "pathway": "not_resolved",
-            "requires_manual_override": False,
-            "reason": "cultural_not_set",
-        }
+        return None, _meta_base(
+            rule_applied="not_resolved",
+            pathway="not_resolved",
+            requires_manual_override=False,
+            reason="cultural_not_set",
+        )
 
-    # --- Rows 3, 5, 6: commune fallback (THCS only / so_cap / completed_thpt+none) ---
-    if basis == "COMMUNE_FALLBACK":
+    # --- INSUFFICIENT_DATA: combo không match matrix nào (eligibility gate đã chặn upstream). ---
+    if basis == "INSUFFICIENT_DATA":
+        return None, _meta_base(
+            rule_applied="insufficient_data",
+            pathway="insufficient_data",
+            requires_manual_override=True,
+            reason=basis_reason,
+        )
+
+    # --- THUONG_TRU: vn_commune_area_map lookup theo permanent_commune_code. ---
+    if basis == "THUONG_TRU":
         commune_code = getattr(profile, "permanent_commune_code", None)
-        if commune_code:
-            kv = await _lookup_commune_kv(db, commune_code)
-            return kv, {
-                "rule_applied": "commune_lookup",
-                "pathway": "commune_fallback",
-                "breakdown": {"commune_code_used": commune_code},
-            }
-        return None, {
-            "rule_applied": "ambiguous_requires_manual",
-            "pathway": "commune_fallback",
-            "requires_manual_override": True,
-            "reason": "fallback_no_commune",
-        }
+        if not commune_code:
+            return None, _meta_base(
+                rule_applied="address_not_normalized",
+                pathway="thuong_tru",
+                requires_manual_override=True,
+                reason="profile_missing_permanent_commune_code",
+            )
+        kv = await _lookup_commune_kv(db, commune_code)
+        if kv is None:
+            return None, _meta_base(
+                rule_applied="catalog_gap_commune",
+                pathway="thuong_tru",
+                requires_manual_override=True,
+                reason="commune_code_not_in_catalog",
+                breakdown={"commune_code_attempted": commune_code},
+            )
+        return kv, _meta_base(
+            rule_applied="commune_lookup",
+            pathway="thuong_tru",
+            breakdown={"commune_code_used": commune_code},
+        )
 
-    # --- Rows 1, 2: THPT multi-school rule (per TT 05/2021 Mục 1+2+3) ---
-    # basis="THPT" matches standalone THPT + liên cấp THCS_THPT (candidate
-    # học liên cấp 2-3 + tốt nghiệp THPT). Memory note: vn_school.level enum
-    # = THCS/THPT/THCS_THPT/TRUNG_HOC_NGHE/OTHER per phase1_09; mirror trong
-    # AcademicRecordSchema Phase D.1 (Q9 #07).
-    #
-    # NOTE: Row 4 (graduated_thcs + TC) folded into COMMUNE_FALLBACK per
-    # nghiệp vụ trường 2026-05-18. TC basis code removed (was dead path).
-    accepted_levels = {"THPT", "THCS_THPT"}
+    # --- LICH_SU_THPT: multi-school rule TT 05/2021 Phụ lục 01 Mục 5.b. ---
+    # Aggregate duration per KV qua academic_history, longest duration wins,
+    # tie → graduation school (year_to + grade_to).
+    accepted_levels = {"THPT", "THCS_THPT", "GDTX"}
 
-    history = getattr(profile, "academic_history", None) or []
     basis_entries = [
-        e for e in history
+        e for e in academic_history
         if isinstance(e, dict)
         and e.get("level") in accepted_levels
         and e.get("school_id")
     ]
 
-    pathway = "thpt_multi_school"
+    pathway = "lich_su_thpt"
 
     if not basis_entries:
-        return None, {
-            "rule_applied": "ambiguous_requires_manual",
-            "pathway": pathway,
-            "requires_manual_override": True,
-            "reason": "no_qualifying_entries",
-            "breakdown": {"target_level": basis, "entries": []},
-        }
+        return None, _meta_base(
+            rule_applied="insufficient_data",
+            pathway=pathway,
+            requires_manual_override=True,
+            reason="no_qualifying_thpt_history_entries",
+            breakdown={"entries": []},
+        )
 
-    # Per-year KV duration map + breakdown per entry
+    # Per-year KV duration map + breakdown per entry. Track lookup failures
+    # explicit để fail-closed (catalog_gap_school).
     kv_years: dict[str, int] = {}
     breakdown_entries: list[dict[str, Any]] = []
+    missing_lookups: list[dict[str, Any]] = []
 
     for entry in basis_entries:
         sid = entry["school_id"]
@@ -515,6 +662,8 @@ async def resolve_kv_for_profile(
             if kv:
                 kv_years[kv] = kv_years.get(kv, 0) + 1
                 entry_years_by_kv.append({"year": year, "kv": kv})
+            else:
+                missing_lookups.append({"school_id": sid, "year": year})
 
         breakdown_entries.append({
             "school_id": sid,
@@ -525,34 +674,39 @@ async def resolve_kv_for_profile(
         })
 
     if not kv_years:
-        return None, {
-            "rule_applied": "ambiguous_requires_manual",
-            "pathway": pathway,
-            "requires_manual_override": True,
-            "reason": "no_kv_lookup_succeeded",
-            "breakdown": {
-                "target_level": basis,
+        # Tất cả lookup miss → vn_school_kv_assignment thiếu catalog cho 100%
+        # entries. Fail-closed: trả catalog_gap_school + KV=None.
+        return None, _meta_base(
+            rule_applied="catalog_gap_school",
+            pathway=pathway,
+            requires_manual_override=True,
+            reason="all_school_lookups_failed",
+            breakdown={
                 "entries": breakdown_entries,
                 "kv_totals": {},
+                "missing_lookups": missing_lookups,
             },
-        }
+        )
 
     max_yrs = max(kv_years.values())
     winners = [kv for kv, y in kv_years.items() if y == max_yrs]
 
     breakdown_base = {
-        "target_level": basis,
         "entries": breakdown_entries,
         "kv_totals": kv_years,
         "winner_years": max_yrs,
     }
+    if missing_lookups:
+        # Partial catalog gap — engine vẫn resolve theo entries có data,
+        # nhưng audit ghi lại để admin biết catalog cần seed.
+        breakdown_base["partial_catalog_missing"] = missing_lookups
 
     if len(winners) == 1:
-        return winners[0], {
-            "rule_applied": "longest_duration",
-            "pathway": pathway,
-            "breakdown": breakdown_base,
-        }
+        return winners[0], _meta_base(
+            rule_applied="longest_duration",
+            pathway=pathway,
+            breakdown=breakdown_base,
+        )
 
     # Tiebreak: graduation school (highest year_to + grade_to, stable index).
     # M1: detect ambiguous (2+ entries cùng year_to + grade_to) → require manual.
@@ -572,12 +726,12 @@ async def resolve_kv_for_profile(
             top_entry.get("year_to") == second_entry.get("year_to")
             and top_entry.get("grade_to") == second_entry.get("grade_to")
         ):
-            return None, {
-                "rule_applied": "ambiguous_requires_manual",
-                "pathway": pathway,
-                "requires_manual_override": True,
-                "reason": "tied_graduation_year_and_grade",
-                "breakdown": {
+            return None, _meta_base(
+                rule_applied="ambiguous_requires_manual",
+                pathway=pathway,
+                requires_manual_override=True,
+                reason="tied_graduation_year_and_grade",
+                breakdown={
                     **breakdown_base,
                     "tied_kv": winners,
                     "tied_entries": [
@@ -585,22 +739,36 @@ async def resolve_kv_for_profile(
                         second_entry["school_id"],
                     ],
                 },
-            }
+            )
 
     grad_entry = sorted_entries[0][1]
     grad_kv = await lookup_kv_for_school_year(
         db, grad_entry["school_id"], grad_entry["year_to"]
     )
-    return grad_kv, {
-        "rule_applied": "tiebreak_graduation_school",
-        "pathway": pathway,
-        "breakdown": {
+    if grad_kv is None:
+        # Graduation school year miss catalog → fail-closed.
+        return None, _meta_base(
+            rule_applied="catalog_gap_school",
+            pathway=pathway,
+            requires_manual_override=True,
+            reason="graduation_school_lookup_failed",
+            breakdown={
+                **breakdown_base,
+                "tied_kv": winners,
+                "graduation_school_id": grad_entry["school_id"],
+                "graduation_year": grad_entry["year_to"],
+            },
+        )
+    return grad_kv, _meta_base(
+        rule_applied="tiebreak_graduation_school",
+        pathway=pathway,
+        breakdown={
             **breakdown_base,
             "tied_kv": winners,
             "graduation_school_id": grad_entry["school_id"],
             "graduation_year": grad_entry["year_to"],
         },
-    }
+    )
 
 
 async def freeze_priority_snapshot(
@@ -609,6 +777,11 @@ async def freeze_priority_snapshot(
     frozen_at_status: str,
     resolved_by: str = "system",
     manual_override_reason: Optional[str] = None,
+    *,
+    target_level: Optional[str] = None,
+    admission_type: Optional[str] = None,
+    eligibility: Optional[dict] = None,
+    path_bonus_rule: Optional[dict] = None,
 ) -> dict[str, Any]:
     """Compute KV resolution + freeze into ``profile.priority_resolution_snapshot``.
 
@@ -622,18 +795,41 @@ async def freeze_priority_snapshot(
     ``frozen_at_status`` MUST be one of:
       'draft_preview' | 'submitted_T1' | 'engine_T6'
 
+    Phase E.4 (commit 5) additive fields (optional — backward-compat):
+      target_level, admission_type, eligibility, basis, basis_reason,
+      rule_law_citation, path_bonus_rule.
+
     Returns the snapshot dict (also written to profile column).
     """
-    kv_resolved, meta = await resolve_kv_for_profile(profile, db)
+    kv_resolved, meta = await resolve_kv_for_profile(
+        profile,
+        db,
+        target_level=target_level,
+        admission_type=admission_type,
+    )
+    rule_applied = meta.get("rule_applied")
     snapshot: dict[str, Any] = {
         "kv_resolved": kv_resolved,
-        "rule_applied": meta.get("rule_applied"),
+        "rule_applied": rule_applied,
         "pathway": meta.get("pathway"),
+        "basis": meta.get("basis"),
+        "basis_reason": meta.get("basis_reason"),
         "breakdown": meta.get("breakdown"),
+        "rule_law_citation": resolve_law_citation(rule_applied),
         "frozen_at": datetime.now(timezone.utc).isoformat(),
         "frozen_at_status": frozen_at_status,
         "resolved_by": resolved_by,
     }
+    # Phase E.4 additive snapshot context — KHÔNG bắt buộc; callers chưa
+    # eager-load path chain sẽ ship null, FE/audit log degrade gracefully.
+    if target_level is not None:
+        snapshot["target_level"] = target_level
+    if admission_type is not None:
+        snapshot["admission_type"] = admission_type
+    if eligibility is not None:
+        snapshot["eligibility"] = eligibility
+    if path_bonus_rule is not None:
+        snapshot["path_bonus_rule"] = path_bonus_rule
     if manual_override_reason:
         snapshot["manual_override_reason"] = manual_override_reason
     if meta.get("requires_manual_override"):
@@ -842,10 +1038,142 @@ RULE_LAW_CITATION: dict[str, Optional[str]] = {
     "commune_lookup": "TT 05/2021 Phụ lục 01 Mục 4",
     # Row 9: admin/officer ấn định KV thủ công
     "manual_override": "TT 05/2021 Phụ lục 01 Mục 6 (admin override)",
-    # Edge cases: cultural not set, no qualifying entries, no KV lookup, tied
-    # graduation year+grade — engine không quyết định được, không có citation.
+    # Phase E.4 commit 5 — fail-closed codes mới. Citation = None (engine
+    # không quyết định được; admin xử lý qua override hoặc catalog seed).
     "ambiguous_requires_manual": None,
+    "address_not_normalized": None,
+    "catalog_gap_commune": None,
+    "catalog_gap_school": None,
+    "insufficient_data": None,
+    "not_resolved": None,
 }
+
+
+async def derive_profile_target_context(
+    profile: "AdmissionProfile",
+    db: "AsyncSession",
+) -> dict[str, Any]:
+    """Derive context cho freeze_priority_snapshot từ profile chain.
+
+    Returns dict với keys:
+      - target_level: str | None
+      - admission_type: str | None
+      - path_bonus_rule: dict | None
+      - eligibility: {"passed": bool, "reason": str | None} | None
+      - source: 'multi_nv_first_choice' | 'legacy_offering_admission_config' | 'unknown'
+
+    Multi-NV: lookup choice với display_order=1; derive từ admission_path chain.
+    Legacy: lookup offering_admission_config_id; derive từ chain.
+
+    Fail-safe: nếu chain missing/incomplete, return None cho từng field;
+    snapshot vẫn freeze nhưng context fields = None (engine T6 re-freeze sẽ
+    cố retry khi caller eager-load đầy đủ).
+
+    Eligibility chỉ compute khi target_level + admission_type cả 2 đều có.
+    """
+    from sqlalchemy import select as _sel
+    from sqlalchemy.orm import selectinload as _sel_in
+
+    ctx: dict[str, Any] = {
+        "target_level": None,
+        "admission_type": None,
+        "path_bonus_rule": None,
+        "eligibility": None,
+        "source": "unknown",
+    }
+
+    try:
+        # Lazy import to avoid model circular dep at module load
+        from app import models
+
+        path = None
+        method = None
+
+        if profile.uses_choice_engine:
+            # Multi-NV: NV1 (display_order=1) làm primary cho snapshot context.
+            stmt = (
+                _sel(models.AdmissionProfileChoice)
+                .where(
+                    models.AdmissionProfileChoice.admission_profile_id == profile.id,
+                    models.AdmissionProfileChoice.display_order == 1,
+                )
+                .options(
+                    _sel_in(models.AdmissionProfileChoice.admission_path)
+                    .selectinload(models.AdmissionPath.admission_method),
+                    _sel_in(models.AdmissionProfileChoice.admission_path)
+                    .selectinload(models.AdmissionPath.academic_info)
+                    .selectinload(models.OfferingAcademicInfo.offering)
+                    .selectinload(models.ProgramOffering.program)
+                    .selectinload(models.MajorProgram.degree_level_ref),
+                    _sel_in(models.AdmissionProfileChoice.admission_path)
+                    .selectinload(models.AdmissionPath.academic_info)
+                    .selectinload(models.OfferingAcademicInfo.offering)
+                    .selectinload(models.ProgramOffering.offering_type_config),
+                )
+                .limit(1)
+            )
+            choice = (await db.execute(stmt)).scalar_one_or_none()
+            if choice is not None and choice.admission_path is not None:
+                path = choice.admission_path
+                method = path.__dict__.get("admission_method")
+                ctx["source"] = "multi_nv_first_choice"
+        elif profile.offering_admission_config_id is not None:
+            # Legacy single-path: derive từ offering_admission_config chain.
+            # KHÔNG có bonus_rule_override (chỉ AdmissionPath có) — bonus_rule
+            # context sẽ là None cho legacy; engine fallback admission_method default.
+            stmt = (
+                _sel(models.OfferingAdmissionConfig)
+                .where(models.OfferingAdmissionConfig.id == profile.offering_admission_config_id)
+                .options(
+                    _sel_in(models.OfferingAdmissionConfig.academic_info)
+                    .selectinload(models.OfferingAcademicInfo.offering)
+                    .selectinload(models.ProgramOffering.program)
+                    .selectinload(models.MajorProgram.degree_level_ref),
+                    _sel_in(models.OfferingAdmissionConfig.academic_info)
+                    .selectinload(models.OfferingAcademicInfo.offering)
+                    .selectinload(models.ProgramOffering.offering_type_config),
+                )
+            )
+            config = (await db.execute(stmt)).scalar_one_or_none()
+            if config is not None:
+                class _PathShim:
+                    pass
+                shim = _PathShim()
+                shim.__dict__["academic_info"] = config.academic_info
+                shim.__dict__["admission_method"] = None  # no path → no method
+                path = shim  # type: ignore[assignment]
+                ctx["source"] = "legacy_offering_admission_config"
+
+        if path is not None:
+            try:
+                target_level, admission_type = derive_target_level_and_type(path)
+                ctx["target_level"] = target_level
+                ctx["admission_type"] = admission_type
+            except Exception:  # noqa: BLE001 — defensive: missing chain
+                pass
+
+            # path_bonus_rule snapshot: chain override → method.default.
+            # Lazy import để tránh circular.
+            try:
+                from .admission_choice_engine_service import resolve_effective_bonus_rule
+                if hasattr(path, "bonus_rule_override") or method is not None:
+                    rule = resolve_effective_bonus_rule(path)  # type: ignore[arg-type]
+                    if rule is not None:
+                        ctx["path_bonus_rule"] = dict(rule)
+            except Exception:  # noqa: BLE001
+                pass
+
+        # Eligibility check audit — chỉ compute khi cả 2 field có.
+        if ctx["target_level"] and ctx["admission_type"]:
+            ok, reason = validate_eligibility(
+                profile, ctx["target_level"], ctx["admission_type"]
+            )
+            ctx["eligibility"] = {"passed": ok, "reason": reason}
+
+    except Exception:  # noqa: BLE001 — defensive: never block freeze on context
+        pass
+
+    return ctx
 
 
 def resolve_law_citation(rule_applied: Optional[str]) -> Optional[str]:

--- a/Backend_FastAPI/tests/api/test_admission_workflow_api.py
+++ b/Backend_FastAPI/tests/api/test_admission_workflow_api.py
@@ -67,8 +67,23 @@ async def _ver(client: AsyncClient, h: dict, pid: int) -> int:
     return (await client.get(ADM(pid), headers=h)).json()["version"]
 
 
-async def _submit(client: AsyncClient, h: dict, lead_id: int, method_id: int) -> dict:
-    """Add consultation + create profile + fill + upload docs + submit."""
+async def _submit(
+    client: AsyncClient,
+    h: dict,
+    lead_id: int,
+    method_id: int,
+    *,
+    school_id: int | None = None,
+) -> dict:
+    """Add consultation + create profile + fill + upload docs + submit.
+
+    Q9 #07 Phase E.4 contract: caller must pass ``school_id`` (from
+    ``adm_config["school_id"]``) so the academic_history entry resolves
+    through ``vn_school_kv_assignment`` and submit transitions to
+    ``submitted`` rather than aggregating ``KV_UNRESOLVED`` into
+    ``validation_errors``. Optional default kept for backward-compat with
+    fixtures that haven't been migrated yet.
+    """
     # Consultation required before admission (business rule)
     from tests._lead_status_test_ids import INITIAL_LEAD_STATUS_ID
     status_id = INITIAL_LEAD_STATUS_ID
@@ -82,12 +97,36 @@ async def _submit(client: AsyncClient, h: dict, lead_id: int, method_id: int) ->
     pid, v = p["id"], p["version"]
 
     cid = f"{int(datetime.now().timestamp()) % 10**12:012d}"
+    # Phase E.4: academic_history entry must include ``school_id`` + ``level``
+    # so the engine LICH_SU_THPT branch (cultural=graduated_thpt + target=
+    # cao_dang) hits a vn_school_kv_assignment row and resolves to a KV code.
+    academic_entry: dict = {
+        "school_name": "THPT",
+        "year_from": 2019,
+        "year_to": 2022,
+        "gpa": 8.0,
+        "graduation_type": "THPT",
+        "level": "THPT",
+        "grade_to": 12,
+    }
+    if school_id is not None:
+        academic_entry["school_id"] = school_id
+
     ur = await client.put(ADM(pid), json={
         "version": v, "citizen_id": cid, "gender": "male", "dob": "2001-01-01",
         "nationality": "Viet Nam", "ethnicity": "Kinh", "place_of_birth": "Test",
         "family_info": [{"relationship": "Cha", "full_name": "P", "phone": "0901111111", "is_primary_guardian": True}],
-        "academic_history": [{"school_name": "THPT", "year_from": 2019, "year_to": 2022, "gpa": 8.0, "graduation_type": "THPT"}],
+        "academic_history": [academic_entry],
         "admission_scores": {"gpa": 8.0, "subject_scores": {}},
+        # Q9 #07 Phase E.4 — submit gate eligibility: CD chính quy yêu cầu
+        # THPT knowledge (TN_THPT hoặc HOAN_THANH_THPT). Fixture adm_config
+        # seed MAJOR_1.degree_level_id → ConfigDegreeLevel("cao_dang") +
+        # ProgramOffering.offering_type_id → ConfigOfferingType("chinh_quy")
+        # → engine derive target_level="cao_dang"/admission_type="chinh_quy"
+        # → validate_eligibility(profile, "cao_dang", "chinh_quy") cần
+        # cultural in {"completed_thpt","graduated_thpt","graduated_gdtx"}.
+        "cultural_education_level": "graduated_thpt",
+        "vocational_qualification": "none",
     }, headers=h)
     if ur.status_code == 200:
         v = ur.json()["version"]
@@ -136,17 +175,87 @@ async def _fast_enroll(client: AsyncClient, pid: int):
 
 @pytest_asyncio.fixture
 async def adm_config(seed_lead_dependencies: dict):
-    """Seed admission config chain for tests."""
+    """Seed admission config chain for tests.
+
+    Phase E.4 (Q9 #07) — submit gate (admission_service._validate_eligibility_
+    all_choices legacy branch) requires the legacy single-path chain expose:
+      profile.offering_admission_config_id
+        → config.academic_info → offering → program.degree_level_ref.code
+                                          → offering_type_config.code
+
+    The chain must resolve to GDNN-scope codes ({"cao_dang"/"trung_cap"/
+    "so_cap"} for degree, any non-null for offering_type) and the profile
+    must declare cultural_education_level compatible with the target level,
+    or submit fail-closes with CONFIG_GAP_TARGET_LEVEL (yêu cầu nghiệp vụ #5).
+
+    Pre-Phase-E.4 this fixture seeded only ProgramOffering with timestamp-
+    suffixed ConfigOfferingType + a MajorProgram (MAJOR_1) with legacy text
+    ``degree_level`` and NULL ``degree_level_id``, plus NO OfferingAdmission
+    Config row. After Phase E.4 every submit raised CONFIG_GAP_TARGET_LEVEL.
+
+    Fix scope (tests only — no production logic change):
+      1. Get-or-create canonical ConfigDegreeLevel("cao_dang") and link
+         MAJOR_1 ``degree_level_id`` to it.
+      2. Use canonical ConfigOfferingType("chinh_quy") instead of ts-suffix
+         so admission_type is well-defined for validate_eligibility().
+      3. Seed OfferingAdmissionConfig(academic_info_id, criteria_id) so
+         admission_service.create_profile auto-populates
+         profile.offering_admission_config_id at step 14b.
+      The _submit() helper now sends cultural_education_level=
+      "graduated_thpt" + vocational_qualification="none" so submit-time
+      eligibility passes for the CD chính quy target.
+    """
     uid = seed_lead_dependencies["unit_id"]
     mpid = seed_lead_dependencies["major_program_id"]
     ts = f"{int(datetime.now().timestamp())}"
     async with AsyncSessionLocal() as s:
         async with s.begin():
-            ot = models.ConfigOfferingType(code=f"tq_{ts}", name=f"TQ_{ts}", display_order=1)
-            s.add(ot); await s.flush()
+            # Canonical ConfigDegreeLevel — code MUST be one of GDNN scope
+            # ("cao_dang"/"trung_cap"/"so_cap") for Phase E.4 derive helper.
+            # Get-or-create to tolerate cross-fixture seeding within the
+            # same test (DB truncates between tests, so within one test
+            # this row is only inserted once).
+            cdl = (await s.execute(
+                select(models.ConfigDegreeLevel).where(
+                    models.ConfigDegreeLevel.code == "cao_dang"
+                )
+            )).scalar_one_or_none()
+            if cdl is None:
+                cdl = models.ConfigDegreeLevel(
+                    code="cao_dang", name="Cao đẳng", display_order=1,
+                )
+                s.add(cdl); await s.flush()
+
+            # Canonical ConfigOfferingType "chinh_quy" — admission_type code
+            # read by derive_target_level_and_type. Get-or-create so that
+            # multiple test modules sharing the same DB-truncate cycle can
+            # both seed without UNIQUE-constraint collisions.
+            cot = (await s.execute(
+                select(models.ConfigOfferingType).where(
+                    models.ConfigOfferingType.code == "chinh_quy"
+                )
+            )).scalar_one_or_none()
+            if cot is None:
+                cot = models.ConfigOfferingType(
+                    code="chinh_quy", name="Chính quy", display_order=1,
+                )
+                s.add(cot); await s.flush()
+
+            # Backfill MAJOR_1.degree_level_id (seed_lead_dependencies seeds
+            # only the legacy text column). NULL → derive_target_level_and_
+            # _type raises CONFIG_GAP_TARGET_LEVEL pointing at MajorProgram.
+            major = (await s.execute(
+                select(models.MajorProgram).where(
+                    models.MajorProgram.id == mpid
+                )
+            )).scalar_one()
+            if major.degree_level_id is None:
+                major.degree_level_id = cdl.id
+                await s.flush()
+
             dt = models.ConfigDocumentType(code=f"tcc_{ts}", name=f"TCC_{ts}", display_order=1)
             s.add(dt); await s.flush()
-            po = models.ProgramOffering(offering_type=f"TQ_{ts}", program_id=mpid, offering_type_id=ot.id, is_active=True, duration_semesters=6)
+            po = models.ProgramOffering(offering_type=f"TQ_{ts}", program_id=mpid, offering_type_id=cot.id, is_active=True, duration_semesters=6)
             s.add(po); await s.flush()
             ai = models.OfferingAcademicInfo(offering_id=po.id, academic_year=2026, tuition_fee_per_year=5000000, annual_admission_quota=100, is_published=True)
             s.add(ai); await s.flush()
@@ -158,7 +267,53 @@ async def adm_config(seed_lead_dependencies: dict):
             round_id = await AdmissionRoundBuilder.get_or_create_default_round(s, academic_year=2026)
             ap = models.AdmissionPath(academic_info_id=ai.id, admission_method_id=am.id, admission_round_id=round_id, criteria_id=ac.id, status="active", display_name="Test", display_order=0, visibility="public")
             s.add(ap); await s.flush()
-    return {"unit_id": uid, "offering_id": po.id, "method_id": am.id}
+
+            # OfferingAdmissionConfig — link academic_info + criteria so that
+            # admission_service.create_profile step 14b auto-populates
+            # profile.offering_admission_config_id (lookup at lines 3294-3306).
+            # Without this row, profile.offering_admission_config_id stays
+            # NULL → submit gate fail-closed CONFIG_GAP_TARGET_LEVEL.
+            oac = models.OfferingAdmissionConfig(
+                academic_info_id=ai.id,
+                criteria_id=ac.id,
+                is_active=True,
+            )
+            s.add(oac); await s.flush()
+
+            # Phase E.4 KV resolution catalog — submit gate aggregates
+            # ``KV_UNRESOLVED`` into validation_errors when academic_history
+            # entries don't resolve to a KV via vn_school_kv_assignment OR
+            # commune lookup. For cultural="graduated_thpt" + target=cao_dang
+            # the engine routes LICH_SU_THPT (multi-school rule), so seed
+            # one VnSchool + KV assignment covering the candidate's THPT
+            # years and pass ``school_id`` into the academic_history entry
+            # via _submit() helper. Without this, submit returns status=
+            # "draft" + validation_errors=["KV_UNRESOLVED (insufficient_data)..."]
+            # rather than transitioning to "submitted".
+            sch = models.VnSchool(
+                moet_school_code=f"S{ts[-6:]}",
+                moet_province_code="001",
+                name=f"THPT Test {ts}",
+                province="Hà Nội",
+                district="Ba Đình",
+                level="THPT",
+            )
+            s.add(sch); await s.flush()
+            kva = models.VnSchoolKvAssignment(
+                school_id=sch.id,
+                kv_code="KV3",
+                effective_from_year=2019,
+                effective_to_year=2022,
+                source="manual_admin",
+            )
+            s.add(kva); await s.flush()
+            school_id = sch.id
+    return {
+        "unit_id": uid,
+        "offering_id": po.id,
+        "method_id": am.id,
+        "school_id": school_id,
+    }
 
 
 @pytest_asyncio.fixture
@@ -180,7 +335,7 @@ async def adm_lead(client: AsyncClient, admin_token_headers: dict, officer_user_
 @pytest.mark.asyncio
 async def test_submit_approve_override_finalize_enrolled(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     assert p["status"] == "submitted"
     pid = p["id"]
 
@@ -203,7 +358,7 @@ async def test_submit_approve_override_finalize_enrolled(client, officer_user_in
 @pytest.mark.asyncio
 async def test_submit_reject_resubmit_revision_resubmit_approve(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     pid = p["id"]
 
     ah = await _admin(client); v = await _ver(client, ah, pid)
@@ -225,7 +380,7 @@ async def test_submit_reject_resubmit_revision_resubmit_approve(client, officer_
 @pytest.mark.asyncio
 async def test_finalize_from_approved_returns_400(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     pid = p["id"]
 
     ah = await _admin(client); v = await _ver(client, ah, pid)
@@ -241,7 +396,7 @@ async def test_finalize_from_approved_returns_400(client, officer_user_in_db, ad
 @pytest.mark.asyncio
 async def test_officer_cannot_approve(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     oh = await _officer(client, officer_user_in_db); v = await _ver(client, oh, p["id"])
     assert (await client.post(ACT(p["id"], "approve"), json={"notes": "No", "version": v}, headers=oh)).status_code == 403
 
@@ -249,7 +404,7 @@ async def test_officer_cannot_approve(client, officer_user_in_db, adm_lead, adm_
 @pytest.mark.asyncio
 async def test_officer_cannot_request_revision(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     oh = await _officer(client, officer_user_in_db); v = await _ver(client, oh, p["id"])
     assert (await client.post(ACT(p["id"], "request-revision"), json={"reason": "Officer trying revision test reason", "version": v}, headers=oh)).status_code == 403
 
@@ -257,7 +412,7 @@ async def test_officer_cannot_request_revision(client, officer_user_in_db, adm_l
 @pytest.mark.asyncio
 async def test_officer_cannot_override(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
     await client.post(ACT(p["id"], "approve"), json={"notes": "OK", "version": v}, headers=ah)
     oh = await _officer(client, officer_user_in_db); v = await _ver(client, oh, p["id"])
@@ -267,7 +422,7 @@ async def test_officer_cannot_override(client, officer_user_in_db, adm_lead, adm
 @pytest.mark.asyncio
 async def test_officer_cannot_finalize(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
     await client.post(ACT(p["id"], "approve"), json={"notes": "OK", "version": v}, headers=ah)
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
@@ -280,7 +435,7 @@ async def test_officer_cannot_finalize(client, officer_user_in_db, adm_lead, adm
 async def test_approve_stale_version(client, officer_user_in_db, adm_lead, adm_config):
     """Approve with stale version returns 409 (ConflictError)."""
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     ah = await _admin(client); stale = await _ver(client, ah, p["id"])
     # Reject to change version while keeping profile in a state where approve is valid later
     await client.post(ACT(p["id"], "reject"), json={"reason": "Reject to bump version for test", "version": stale}, headers=ah)
@@ -296,7 +451,7 @@ async def test_approve_stale_version(client, officer_user_in_db, adm_lead, adm_c
 @pytest.mark.asyncio
 async def test_request_revision_stale_version(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     # Get stale version at submitted state
     ah = await _admin(client); stale = await _ver(client, ah, p["id"])
     # Reject to change version (submitted → rejected is valid)
@@ -313,7 +468,7 @@ async def test_request_revision_stale_version(client, officer_user_in_db, adm_le
 @pytest.mark.asyncio
 async def test_resubmit_stale_version(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     # Reject first
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
     await client.post(ACT(p["id"], "reject"), json={"reason": "Documents insufficient for admission", "version": v}, headers=ah)
@@ -333,7 +488,7 @@ async def test_resubmit_stale_version(client, officer_user_in_db, adm_lead, adm_
 @pytest.mark.asyncio
 async def test_drop_stale_version(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     await _fast_enroll(client, p["id"])
     ah = await _admin(client); stale = await _ver(client, ah, p["id"])
     async with AsyncSessionLocal() as s:
@@ -348,7 +503,7 @@ async def test_drop_stale_version(client, officer_user_in_db, adm_lead, adm_conf
 @pytest.mark.asyncio
 async def test_drop_enrolled_sets_is_dropped(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     await _fast_enroll(client, p["id"])
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
     r = await client.post(ACT(p["id"], "drop"), json={"reason": "Student left for personal reasons text", "version": v}, headers=ah)
@@ -361,7 +516,7 @@ async def test_drop_enrolled_sets_is_dropped(client, officer_user_in_db, adm_lea
 @pytest.mark.asyncio
 async def test_drop_before_enrolled_returns_400(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
     await client.post(ACT(p["id"], "approve"), json={"notes": "OK", "version": v}, headers=ah)
     ah = await _admin(client); v = await _ver(client, ah, p["id"])

--- a/Backend_FastAPI/tests/unit/test_kv_unresolved_error_message.py
+++ b/Backend_FastAPI/tests/unit/test_kv_unresolved_error_message.py
@@ -1,0 +1,111 @@
+"""Unit tests for ``_kv_unresolved_error_message`` helper (Phase E.4 v4 fix-up).
+
+Reviewer 2026-05-21 v4 deadlock: submit raise BadRequest → router rollback
+snapshot → manager/admin override draft KHÔNG thấy ``requires_manual_override``
+signal → deadlock với draft override gate.
+
+Fix v4: helper trả error message string (not raise) cho submit collect vào
+``validation_errors`` list. Submit return ``{status: 'draft', validation_errors}``
++ ``db.flush()`` snapshot → router commit → snapshot persist → admin/manager
+override draft sees real signal.
+
+Tests pin extract semantics: helper trả None khi pass, message string khi fail.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.admission_service import _kv_unresolved_error_message
+
+
+pytestmark = pytest.mark.unit
+
+
+# ===========================================================================
+# Pass paths — helper trả None
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "rule_applied",
+    [
+        "longest_duration",
+        "tiebreak_graduation_school",
+        "commune_lookup",
+        "manual_override",
+    ],
+)
+def test_success_rule_with_kv_resolved_returns_none(rule_applied: str) -> None:
+    snapshot = {
+        "rule_applied": rule_applied,
+        "kv_resolved": "KV1",
+        "basis": "LICH_SU_THPT",
+    }
+    assert _kv_unresolved_error_message(snapshot, profile_id=1) is None
+
+
+# ===========================================================================
+# Block paths — helper trả message string
+# ===========================================================================
+
+
+def test_empty_snapshot_returns_error_message() -> None:
+    msg = _kv_unresolved_error_message({}, profile_id=1)
+    assert msg is not None
+    assert "KV_UNRESOLVED" in msg
+    assert "no_snapshot_present" in msg
+
+
+def test_none_snapshot_returns_error_message() -> None:
+    msg = _kv_unresolved_error_message(None, profile_id=1)
+    assert msg is not None
+    assert "KV_UNRESOLVED" in msg
+    assert "no_snapshot_present" in msg
+
+
+@pytest.mark.parametrize(
+    "rule_applied,reason",
+    [
+        ("address_not_normalized", "profile_missing_permanent_commune_code"),
+        ("catalog_gap_commune", "commune_code_not_in_catalog"),
+        ("catalog_gap_school", "all_school_lookups_failed"),
+        ("insufficient_data", "no_qualifying_thpt_history_entries"),
+        ("ambiguous_requires_manual", "tied_graduation_year_and_grade"),
+        ("not_resolved", "cultural_not_set"),
+    ],
+)
+def test_unresolved_rule_returns_error_message(rule_applied: str, reason: str) -> None:
+    snapshot = {
+        "rule_applied": rule_applied,
+        "reason": reason,
+        "requires_manual_override": True,
+        "kv_resolved": None,
+    }
+    msg = _kv_unresolved_error_message(snapshot, profile_id=1)
+    assert msg is not None
+    assert "KV_UNRESOLVED" in msg
+    assert rule_applied in msg
+    assert reason in msg
+
+
+def test_success_rule_without_kv_resolved_returns_error_message() -> None:
+    """Race: rule trong success whitelist nhưng kv_resolved=None → block."""
+    snapshot = {
+        "rule_applied": "longest_duration",
+        "kv_resolved": None,
+    }
+    msg = _kv_unresolved_error_message(snapshot, profile_id=1)
+    assert msg is not None
+    assert "KV_UNRESOLVED" in msg
+
+
+def test_unknown_future_rule_returns_error_message() -> None:
+    """Fail-closed default: rule không trong whitelist → block."""
+    snapshot = {
+        "rule_applied": "future_new_rule",
+        "kv_resolved": "KV1",
+    }
+    msg = _kv_unresolved_error_message(snapshot, profile_id=1)
+    assert msg is not None
+    assert "KV_UNRESOLVED" in msg
+    assert "future_new_rule" in msg

--- a/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub2_choice_engine.py
+++ b/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub2_choice_engine.py
@@ -74,6 +74,21 @@ def _make_path(
         admission_path_id=1,
         subject_group=subject_group,
     )
+    # Q9 #07 Phase E.4 — _evaluate_single_choice Gate 0 calls
+    # derive_target_level_and_type(path) reading
+    # path.academic_info.offering.program.degree_level_ref.code
+    # + offering.offering_type_config.code. Without this eager-loaded chain
+    # stub, gate 0 raises CONFIG_GAP_TARGET_LEVEL → silently regresses every
+    # choice to 'rejected'. Mirror pattern from
+    # test_priority_bonus_decision_flip.py (Phase E.4 commit 5 fix).
+    program_stub = SimpleNamespace()
+    program_stub.__dict__["degree_level_ref"] = SimpleNamespace(code="cao_dang")
+    offering_stub = SimpleNamespace()
+    offering_stub.__dict__["program"] = program_stub
+    offering_stub.__dict__["offering_type_config"] = SimpleNamespace(code="chinh_quy")
+    academic_info_stub = SimpleNamespace()
+    academic_info_stub.__dict__["offering"] = offering_stub
+
     path = SimpleNamespace(
         id=1,
         admission_method=method,
@@ -81,6 +96,7 @@ def _make_path(
         bonus_rule_override=bonus_rule_override,
         path_subject_group_config=config,
     )
+    path.__dict__["academic_info"] = academic_info_stub
     return path, config
 
 
@@ -127,6 +143,13 @@ def _make_profile(*, status="reviewing", gpa=None, choices=None):
         graduation_year=2024,
         uses_choice_engine=True,
         choices=choices or [],
+        # Q9 #07 Phase E.4 — _evaluate_single_choice Gate 0 also calls
+        # validate_eligibility(profile, target, type) which reads
+        # cultural_education_level + vocational_qualification. CĐ chính quy
+        # (set in _make_path stub) yêu cầu THPT knowledge. Default safe value
+        # ``graduated_thpt`` để legacy tests không vướng eligibility fail.
+        cultural_education_level="graduated_thpt",
+        vocational_qualification="none",
     )
 
 

--- a/Backend_FastAPI/tests/unit/test_preview_priority_kv_path_aware.py
+++ b/Backend_FastAPI/tests/unit/test_preview_priority_kv_path_aware.py
@@ -1,0 +1,201 @@
+"""Unit tests for preview-priority-kv route path-aware behavior.
+
+Reviewer 2026-05-21: Trước fix-up, ``preview_priority_kv()`` gọi
+``resolve_kv_for_profile(preview_profile, db)`` KHÔNG truyền target_level/
+admission_type → engine fall vào legacy matrix (target_level=None branch)
+→ basis hiển thị FE sai cho một số combo (vd CĐ chính quy + completed_thpt
+→ THUONG_TRU legacy thay vì LICH_SU_THPT Phase E.4).
+
+Fix: route gọi ``derive_profile_target_context(profile, db)`` rồi pass
+target context vào engine. Test pin wiring đúng bằng cách mock 2 hàm và
+verify chúng được gọi với arguments đúng.
+
+KHÔNG dùng AsyncClient ở đây — route function gọi nhiều DB-bound helpers
+(bonus rate lookup) phức tạp; mock-direct test giữ slice nhỏ.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+# ===========================================================================
+# Test wiring: preview route → derive_profile_target_context → resolve_kv
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_preview_passes_target_context_to_engine_resolve() -> None:
+    """preview-priority-kv route phải pass target_level + admission_type
+    (từ derive_profile_target_context) vào resolve_kv_for_profile call.
+    """
+    # Lazy import để patch applied trước khi import route
+    from app.routers import admissions_v2
+    from app.schemas.admission import PreviewPriorityKvRequest
+
+    # Stub profile
+    profile = SimpleNamespace(
+        id=99,
+        cultural_education_level="graduated_thpt",
+        vocational_qualification="none",
+        area_resolution_basis=None,
+        permanent_commune_code=None,
+        academic_history=[],
+        priority_object_codes=[],
+        admission_path=None,
+        academic_year=2026,
+    )
+
+    captured = {}
+
+    async def fake_derive_context(profile_arg, db_arg):
+        captured["derive_called_with_profile_id"] = profile_arg.id
+        return {
+            "target_level": "cao_dang",
+            "admission_type": "chinh_quy",
+            "eligibility": {"passed": True, "reason": None},
+            "path_bonus_rule": None,
+            "source": "multi_nv_first_choice",
+        }
+
+    async def fake_resolve(profile_arg, db_arg, target_level=None, admission_type=None):
+        captured["resolve_target_level"] = target_level
+        captured["resolve_admission_type"] = admission_type
+        return ("KV1", {
+            "kv_resolved": "KV1",
+            "rule_applied": "longest_duration",
+            "pathway": "lich_su_thpt",
+            "basis": "LICH_SU_THPT",
+            "basis_reason": "cd_chinh_quy_post_thpt_uses_school_history",
+            "breakdown": {},
+        })
+
+    # Mock db.execute cho bonus rate lookup (PriorityAreaConfig + PriorityObjectConfig)
+    bonus_result = MagicMock()
+    bonus_result.scalar_one_or_none = MagicMock(return_value=None)  # no rate row
+    object_result = MagicMock()
+    object_result.all = MagicMock(return_value=[])
+
+    async def fake_execute(stmt, *args, **kwargs):
+        stmt_str = str(stmt)
+        if "priority_object_config" in stmt_str:
+            return object_result
+        return bonus_result
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=fake_execute)
+
+    with patch.object(
+        admissions_v2,
+        "log",
+        MagicMock(),
+    ):
+        # Replace priority_service exports in the namespace the route imports.
+        import app.services.priority_service as priority_module
+
+        with patch.object(
+            priority_module, "derive_profile_target_context", side_effect=fake_derive_context,
+        ), patch.object(
+            priority_module, "resolve_kv_for_profile", side_effect=fake_resolve,
+        ):
+            response = await admissions_v2.preview_priority_kv(
+                profile_id=99,
+                payload=PreviewPriorityKvRequest(),
+                db=db,
+                profile=profile,
+                current_user=SimpleNamespace(id=1, role="officer"),
+            )
+
+    # Wiring assertions:
+    assert captured["derive_called_with_profile_id"] == 99
+    # Phase E.4 fix Finding: target context phải reach engine
+    assert captured["resolve_target_level"] == "cao_dang"
+    assert captured["resolve_admission_type"] == "chinh_quy"
+    # Response carries kv + basis từ engine
+    assert response.kv_resolved == "KV1"
+
+
+@pytest.mark.asyncio
+async def test_preview_missing_target_context_still_calls_engine_with_none() -> None:
+    """Khi derive_profile_target_context không derive được (vd path chain
+    missing), engine vẫn được gọi với target_level=None — legacy matrix
+    branch fallback. Engine KHÔNG crash."""
+    from app.routers import admissions_v2
+    from app.schemas.admission import PreviewPriorityKvRequest
+
+    profile = SimpleNamespace(
+        id=100,
+        cultural_education_level="graduated_thcs",
+        vocational_qualification="none",
+        area_resolution_basis=None,
+        permanent_commune_code="66_22255",
+        academic_history=[],
+        priority_object_codes=[],
+        admission_path=None,
+        academic_year=2026,
+    )
+
+    captured = {}
+
+    async def fake_derive_context(profile_arg, db_arg):
+        # Simulate path chain missing → all fields None
+        return {
+            "target_level": None,
+            "admission_type": None,
+            "eligibility": None,
+            "path_bonus_rule": None,
+            "source": "unknown",
+        }
+
+    async def fake_resolve(profile_arg, db_arg, target_level=None, admission_type=None):
+        captured["resolve_target_level"] = target_level
+        captured["resolve_admission_type"] = admission_type
+        return ("KV2-NT", {
+            "kv_resolved": "KV2-NT",
+            "rule_applied": "commune_lookup",
+            "pathway": "thuong_tru",
+            "basis": "THUONG_TRU",
+            "basis_reason": "legacy_thcs_pathway_uses_commune",
+            "breakdown": {"commune_code_used": "66_22255"},
+        })
+
+    bonus_result = MagicMock()
+    bonus_result.scalar_one_or_none = MagicMock(return_value=None)
+    object_result = MagicMock()
+    object_result.all = MagicMock(return_value=[])
+
+    async def fake_execute(stmt, *args, **kwargs):
+        stmt_str = str(stmt)
+        if "priority_object_config" in stmt_str:
+            return object_result
+        return bonus_result
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=fake_execute)
+
+    import app.services.priority_service as priority_module
+
+    with patch.object(
+        admissions_v2, "log", MagicMock(),
+    ), patch.object(
+        priority_module, "derive_profile_target_context", side_effect=fake_derive_context,
+    ), patch.object(
+        priority_module, "resolve_kv_for_profile", side_effect=fake_resolve,
+    ):
+        response = await admissions_v2.preview_priority_kv(
+            profile_id=100,
+            payload=PreviewPriorityKvRequest(),
+            db=db,
+            profile=profile,
+            current_user=SimpleNamespace(id=1, role="officer"),
+        )
+
+    # Wiring assertions: engine nhận None (legacy matrix branch)
+    assert captured["resolve_target_level"] is None
+    assert captured["resolve_admission_type"] is None
+    assert response.kv_resolved == "KV2-NT"

--- a/Backend_FastAPI/tests/unit/test_priority_bonus_decision_flip.py
+++ b/Backend_FastAPI/tests/unit/test_priority_bonus_decision_flip.py
@@ -44,7 +44,22 @@ def _make_choice_with_scoring(
         selection_mode="fixed",
         required_count=3,
     )
+
+    # Q9 #07 Phase E.4 — _evaluate_single_choice gate 0 calls
+    # derive_target_level_and_type(path) → reads path.academic_info.offering
+    # .program.degree_level_ref.code + offering.offering_type_config.code.
+    # Without this eager-loaded chain stub, gate 0 raises CONFIG_GAP_TARGET_LEVEL
+    # và choice reject với code đó (silently regressed the bonus-flip behavior).
+    program_stub = SimpleNamespace()
+    program_stub.__dict__["degree_level_ref"] = SimpleNamespace(code="cao_dang")
+    offering_stub = SimpleNamespace()
+    offering_stub.__dict__["program"] = program_stub
+    offering_stub.__dict__["offering_type_config"] = SimpleNamespace(code="chinh_quy")
+    academic_info_stub = SimpleNamespace()
+    academic_info_stub.__dict__["offering"] = offering_stub
+
     path = SimpleNamespace(criteria=criteria)
+    path.__dict__["academic_info"] = academic_info_stub
     # Build scores so _collect_subject_scores returns something truthy;
     # the actual values don't matter because calculate_score is patched.
     score_row = SimpleNamespace(
@@ -65,9 +80,14 @@ def _make_choice_with_scoring(
         scores=[score_row, score_row, score_row],
         path_subject_group_config=config,
     )
+    # Q9 #07 Phase E.4 — profile needs cultural_education_level đủ pass
+    # eligibility gate 0. CĐ chính quy yêu cầu THPT knowledge (TN_THPT hoặc
+    # HOAN_THANH_THPT). Use graduated_thpt để không vướng vào gate 0.
     profile = SimpleNamespace(
         gpa_overall=Decimal("8.0"),
         graduation_year=None,
+        cultural_education_level="graduated_thpt",
+        vocational_qualification="none",
     )
 
     score_result = AdmissionScoreResult(

--- a/Backend_FastAPI/tests/unit/test_priority_config_models.py
+++ b/Backend_FastAPI/tests/unit/test_priority_config_models.py
@@ -132,3 +132,28 @@ def test_models_are_in_base_metadata() -> None:
         "vn_school_kv_assignment",
     ):
         assert tbl in table_names, f"{tbl} not registered in Base.metadata"
+
+
+def test_major_program_degree_level_ref_uses_lazy_raise() -> None:
+    """Phase E.4 (Q9 #07) anchor: MajorProgram.degree_level_ref MUST stay
+    lazy='raise'.
+
+    priority_service.derive_target_level_and_type() reads
+    ``program.degree_level_ref.code`` via __dict__ to mimic eager-load
+    semantics. Callers (admissions_v2, admission_service) selectinload
+    the full chain choices→admission_path→academic_info→offering→program
+    →degree_level_ref. If lazy mode regresses to 'select' (SQLAlchemy
+    default), a caller that forgets selectinload would silently issue
+    extra queries instead of crashing — making a future N+1 invisible
+    until prod load reveals it.
+    """
+    from sqlalchemy import inspect
+
+    from app.models.major_program import MajorProgram
+
+    rel = inspect(MajorProgram).relationships["degree_level_ref"]
+    assert rel.lazy == "raise", (
+        f"degree_level_ref.lazy regressed to {rel.lazy!r}. "
+        "Phase E.4 contract requires lazy='raise' (see "
+        "priority_service.derive_target_level_and_type)."
+    )

--- a/Backend_FastAPI/tests/unit/test_priority_eligibility.py
+++ b/Backend_FastAPI/tests/unit/test_priority_eligibility.py
@@ -1,0 +1,329 @@
+"""Unit tests for Phase E.4 eligibility + target_level derivation.
+
+Q9 #07 Phase E.4 — exercises:
+  - ``priority_service.derive_target_level_and_type(path)`` happy/gap paths
+  - ``priority_service.validate_eligibility(profile, target, type)`` cho 5
+    nghiệp vụ levels (CĐ/CĐ liên thông/TC/TC liên thông/SC) chốt 2026-05-21.
+
+Pure-logic tests dùng SimpleNamespace + stub objects. KHÔNG cần DB; gọi
+helpers trực tiếp.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.priority_service import (
+    derive_target_level_and_type,
+    normalize_target_level,
+    validate_eligibility,
+)
+from app.utils.exceptions import BusinessRuleViolation
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Builder helpers — build path/profile stubs
+# ---------------------------------------------------------------------------
+
+
+def _build_path(degree_level_code: str | None, offering_type_code: str | None):
+    """Build AdmissionPath stub với eager-loaded chain matching helper contract.
+
+    derive_target_level_and_type đọc qua ``__dict__`` để mimic SQLAlchemy
+    eager-load semantics (NOT lazy fetch). Builders mirror chain shape:
+        path.__dict__['academic_info'].__dict__['offering'].__dict__['program']
+            .__dict__['degree_level_ref'].code
+        path.__dict__['academic_info'].__dict__['offering']
+            .__dict__['offering_type_config'].code
+    """
+    degree_obj = SimpleNamespace(code=degree_level_code) if degree_level_code else None
+    program = SimpleNamespace()
+    program.__dict__["degree_level_ref"] = degree_obj
+
+    offering_type_obj = (
+        SimpleNamespace(code=offering_type_code) if offering_type_code else None
+    )
+    offering = SimpleNamespace()
+    offering.__dict__["program"] = program
+    offering.__dict__["offering_type_config"] = offering_type_obj
+
+    academic_info = SimpleNamespace()
+    academic_info.__dict__["offering"] = offering
+
+    path = SimpleNamespace()
+    path.__dict__["academic_info"] = academic_info
+    return path
+
+
+def _profile(cultural: str | None = None, vocational: str = "none"):
+    return SimpleNamespace(
+        cultural_education_level=cultural,
+        vocational_qualification=vocational,
+    )
+
+
+# ===========================================================================
+# derive_target_level_and_type — happy paths
+# ===========================================================================
+
+
+def test_derive_cao_dang_chinh_quy() -> None:
+    path = _build_path("cao_dang", "chinh_quy")
+    target, admission_type = derive_target_level_and_type(path)
+    assert target == "cao_dang"
+    assert admission_type == "chinh_quy"
+
+
+def test_derive_cao_dang_lien_thong() -> None:
+    path = _build_path("cao_dang", "lien_thong")
+    target, admission_type = derive_target_level_and_type(path)
+    assert target == "cao_dang"
+    assert admission_type == "lien_thong"
+
+
+def test_derive_trung_cap_chinh_quy() -> None:
+    path = _build_path("trung_cap", "chinh_quy")
+    assert derive_target_level_and_type(path) == ("trung_cap", "chinh_quy")
+
+
+def test_derive_trung_cap_lien_thong() -> None:
+    path = _build_path("trung_cap", "lien_thong")
+    assert derive_target_level_and_type(path) == ("trung_cap", "lien_thong")
+
+
+def test_derive_so_cap_chinh_quy() -> None:
+    path = _build_path("so_cap", "chinh_quy")
+    assert derive_target_level_and_type(path) == ("so_cap", "chinh_quy")
+
+
+# ===========================================================================
+# derive_target_level_and_type — CONFIG_GAP raises BusinessRuleViolation
+# ===========================================================================
+
+
+def test_derive_missing_degree_level_ref_raises() -> None:
+    path = _build_path(None, "chinh_quy")
+    with pytest.raises(BusinessRuleViolation) as exc:
+        derive_target_level_and_type(path)
+    assert "CONFIG_GAP_TARGET_LEVEL" in str(exc.value)
+    assert "degree_level_id" in str(exc.value)
+
+
+def test_derive_missing_offering_type_raises() -> None:
+    path = _build_path("cao_dang", None)
+    with pytest.raises(BusinessRuleViolation) as exc:
+        derive_target_level_and_type(path)
+    assert "CONFIG_GAP_TARGET_LEVEL" in str(exc.value)
+    assert "offering_type_id" in str(exc.value)
+
+
+def test_derive_out_of_gdnn_scope_raises_for_dai_hoc() -> None:
+    # GDNN scope: chỉ CĐ/TC/SC. dai_hoc/thac_si/tien_si không thuộc Phase E.4.
+    path = _build_path("dai_hoc", "chinh_quy")
+    with pytest.raises(BusinessRuleViolation) as exc:
+        derive_target_level_and_type(path)
+    assert "CONFIG_GAP_TARGET_LEVEL" in str(exc.value)
+    assert "GDNN" in str(exc.value) or "ngoài" in str(exc.value)
+
+
+def test_derive_no_academic_info_chain_raises() -> None:
+    # Eager-load chain missing (path bare) → raise.
+    bare_path = SimpleNamespace()
+    bare_path.__dict__["academic_info"] = None
+    with pytest.raises(BusinessRuleViolation) as exc:
+        derive_target_level_and_type(bare_path)
+    assert "CONFIG_GAP_TARGET_LEVEL" in str(exc.value)
+
+
+# ===========================================================================
+# validate_eligibility — CĐ chính quy
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "cultural",
+    [
+        "graduated_thpt",
+        "graduated_gdtx",
+        "completed_thpt",  # đủ kiến thức THPT theo nghiệp vụ #5 (HOAN_THANH_THPT)
+    ],
+)
+def test_cd_chinh_quy_pass(cultural: str) -> None:
+    profile = _profile(cultural=cultural)
+    ok, reason = validate_eligibility(profile, "cao_dang", "chinh_quy")
+    assert ok is True
+    assert reason is None
+
+
+@pytest.mark.parametrize(
+    "cultural",
+    [None, "graduated_thcs", "completed_thcs"],
+)
+def test_cd_chinh_quy_fail_without_thpt_knowledge(cultural: str | None) -> None:
+    profile = _profile(cultural=cultural)
+    ok, reason = validate_eligibility(profile, "cao_dang", "chinh_quy")
+    assert ok is False
+    assert reason == "cd_chinh_quy_requires_thpt_or_completed_thpt"
+
+
+# ===========================================================================
+# validate_eligibility — CĐ liên thông
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "cultural, vocational",
+    [
+        ("graduated_thpt", "trung_cap"),
+        ("graduated_thpt", "cao_dang"),
+        ("completed_thpt", "trung_cap"),  # HOAN_THANH_THPT + bằng TC
+        ("graduated_gdtx", "cao_dang"),
+    ],
+)
+def test_cd_lien_thong_pass(cultural: str, vocational: str) -> None:
+    profile = _profile(cultural=cultural, vocational=vocational)
+    ok, _ = validate_eligibility(profile, "cao_dang", "lien_thong")
+    assert ok is True
+
+
+@pytest.mark.parametrize(
+    "cultural, vocational",
+    [
+        ("graduated_thpt", "none"),  # thiếu bằng TC/CĐ
+        ("graduated_thpt", "so_cap"),  # SC không đủ cho CĐ liên thông
+        ("graduated_thcs", "trung_cap"),  # thiếu THPT knowledge
+        ("completed_thpt", "none"),
+    ],
+)
+def test_cd_lien_thong_fail(cultural: str, vocational: str) -> None:
+    profile = _profile(cultural=cultural, vocational=vocational)
+    ok, reason = validate_eligibility(profile, "cao_dang", "lien_thong")
+    assert ok is False
+    assert reason == "cd_lien_thong_requires_thpt_knowledge_plus_tc_or_cd"
+
+
+# ===========================================================================
+# validate_eligibility — TC chính quy
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "cultural",
+    [
+        "graduated_thcs",
+        "completed_thpt",
+        "graduated_thpt",
+        "graduated_gdtx",
+    ],
+)
+def test_tc_chinh_quy_pass(cultural: str) -> None:
+    profile = _profile(cultural=cultural)
+    ok, _ = validate_eligibility(profile, "trung_cap", "chinh_quy")
+    assert ok is True
+
+
+@pytest.mark.parametrize("cultural", [None, "completed_thcs"])
+def test_tc_chinh_quy_fail(cultural: str | None) -> None:
+    profile = _profile(cultural=cultural)
+    ok, reason = validate_eligibility(profile, "trung_cap", "chinh_quy")
+    assert ok is False
+    assert reason == "tc_requires_graduated_thcs_or_higher"
+
+
+# ===========================================================================
+# validate_eligibility — TC liên thông
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "cultural, vocational",
+    [
+        ("graduated_thcs", "so_cap"),
+        ("graduated_thcs", "trung_cap"),
+        ("graduated_thpt", "so_cap"),
+    ],
+)
+def test_tc_lien_thong_pass(cultural: str, vocational: str) -> None:
+    profile = _profile(cultural=cultural, vocational=vocational)
+    ok, _ = validate_eligibility(profile, "trung_cap", "lien_thong")
+    assert ok is True
+
+
+@pytest.mark.parametrize(
+    "cultural, vocational",
+    [
+        ("graduated_thcs", "none"),  # cần SC/TC
+        ("graduated_thcs", "cao_dang"),  # CĐ đã cao hơn TC — out of liên thông scope
+        ("completed_thcs", "trung_cap"),  # cần ≥ TN_THCS
+    ],
+)
+def test_tc_lien_thong_fail(cultural: str, vocational: str) -> None:
+    profile = _profile(cultural=cultural, vocational=vocational)
+    ok, reason = validate_eligibility(profile, "trung_cap", "lien_thong")
+    assert ok is False
+    assert reason == "tc_lien_thong_requires_thcs_plus_sc_or_tc"
+
+
+# ===========================================================================
+# validate_eligibility — SC chính quy + edge cases
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "cultural",
+    [None, "completed_thcs", "graduated_thcs", "graduated_thpt"],
+)
+def test_sc_chinh_quy_pass_any_cultural(cultural: str | None) -> None:
+    profile = _profile(cultural=cultural)
+    ok, _ = validate_eligibility(profile, "so_cap", "chinh_quy")
+    assert ok is True
+
+
+def test_sc_lien_thong_not_supported() -> None:
+    profile = _profile(cultural="graduated_thpt", vocational="trung_cap")
+    ok, reason = validate_eligibility(profile, "so_cap", "lien_thong")
+    assert ok is False
+    assert reason == "sc_only_supports_chinh_quy_in_phase_e4"
+
+
+def test_unsupported_target_level_blocks() -> None:
+    profile = _profile(cultural="graduated_thpt")
+    ok, reason = validate_eligibility(profile, "dai_hoc", "chinh_quy")
+    assert ok is False
+    assert "unsupported_target_level" in reason
+
+
+# ===========================================================================
+# normalize_target_level — legacy uppercase aliases
+# ===========================================================================
+
+
+def test_normalize_target_level_legacy_uppercase() -> None:
+    assert normalize_target_level("CD") == "cao_dang"
+    assert normalize_target_level("TC") == "trung_cap"
+    assert normalize_target_level("SC") == "so_cap"
+    # Already normalized → no change
+    assert normalize_target_level("cao_dang") == "cao_dang"
+    # Unknown → pass-through (caller validates)
+    assert normalize_target_level("xyz") == "xyz"
+
+
+# ===========================================================================
+# Backward-compat: legacy "CD"/"TC"/"SC" call signature still works
+# ===========================================================================
+
+
+def test_validate_eligibility_legacy_cd_alias_works() -> None:
+    profile = _profile(cultural="graduated_thpt")
+    ok, _ = validate_eligibility(profile, "CD")
+    assert ok is True
+
+
+def test_validate_eligibility_legacy_tc_alias_works() -> None:
+    profile = _profile(cultural="graduated_thcs")
+    ok, _ = validate_eligibility(profile, "TC")
+    assert ok is True

--- a/Backend_FastAPI/tests/unit/test_priority_kv_phase_e4_matrix.py
+++ b/Backend_FastAPI/tests/unit/test_priority_kv_phase_e4_matrix.py
@@ -115,7 +115,10 @@ def test_has_thpt_history_thpt_missing_year_returns_false() -> None:
         ("completed_thcs", "none", "trung_cap", "chinh_quy", "INSUFFICIENT_DATA", "tc_chinh_quy_cultural_insufficient"),
         # SC chính quy → THUONG_TRU
         ("graduated_thcs", "none", "so_cap", "chinh_quy", "THUONG_TRU", "sc_uses_commune"),
-        (None, "none", "so_cap", "chinh_quy", "NOT_RESOLVED", "cultural_not_set"),
+        # SC chính quy + cultural=None — yêu cầu nghiệp vụ #5: SC KHÔNG yêu
+        # cầu văn hóa. Engine phải vẫn THUONG_TRU (commune lookup), KHÔNG kẹt
+        # ở NOT_RESOLVED (reviewer fix-up 2026-05-21).
+        (None, "none", "so_cap", "chinh_quy", "THUONG_TRU", "sc_no_cultural_uses_commune"),
     ],
 )
 def test_phase_e4_matrix_basis_resolution(

--- a/Backend_FastAPI/tests/unit/test_priority_kv_phase_e4_matrix.py
+++ b/Backend_FastAPI/tests/unit/test_priority_kv_phase_e4_matrix.py
@@ -1,0 +1,393 @@
+"""Phase E.4 commit 5 — `_derive_kv_basis_level` + `resolve_kv_for_profile`
+mở rộng với target_level + admission_type + academic_history (yêu cầu nghiệp
+vụ #6) + fail-closed cho catalog gap (yêu cầu nghiệp vụ #7).
+
+Test boundaries:
+  - Phase E.4 matrix coverage (CD/TC/SC × chính_quy/liên_thông × cultural × voc)
+  - Hybrid CĐ liên thông KHOI_LUONG_VH_THPT + TC (3 sub-cases: history+/no/missing)
+  - Fail-closed codes: address_not_normalized, catalog_gap_commune, catalog_gap_school
+  - basis_reason short keys cho FE display
+
+Lưu ý: legacy 3-arg signature (target_level=None) đã được pin trong
+``test_priority_kv_resolution.py``; file này chỉ cover Phase E.4 signature
+mới (5-arg).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.priority_service import (
+    _derive_kv_basis_level,
+    _has_thpt_history,
+    resolve_kv_for_profile,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+# ===========================================================================
+# _has_thpt_history helper
+# ===========================================================================
+
+
+def test_has_thpt_history_empty() -> None:
+    assert _has_thpt_history(None) is False
+    assert _has_thpt_history([]) is False
+
+
+def test_has_thpt_history_thpt_entry() -> None:
+    history = [
+        {"school_id": 100, "level": "THPT", "year_from": 2020, "year_to": 2022},
+    ]
+    assert _has_thpt_history(history) is True
+
+
+def test_has_thpt_history_thcs_thpt_lien_cap() -> None:
+    history = [
+        {"school_id": 100, "level": "THCS_THPT", "year_from": 2019, "year_to": 2022},
+    ]
+    assert _has_thpt_history(history) is True
+
+
+def test_has_thpt_history_gdtx_entry() -> None:
+    history = [
+        {"school_id": 100, "level": "GDTX", "year_from": 2020, "year_to": 2022},
+    ]
+    assert _has_thpt_history(history) is True
+
+
+def test_has_thpt_history_only_thcs_returns_false() -> None:
+    history = [
+        {"school_id": 50, "level": "THCS", "year_from": 2017, "year_to": 2019},
+    ]
+    assert _has_thpt_history(history) is False
+
+
+def test_has_thpt_history_only_tc_nghe_returns_false() -> None:
+    history = [
+        {"school_id": 200, "level": "TRUNG_HOC_NGHE", "year_from": 2022, "year_to": 2024},
+    ]
+    assert _has_thpt_history(history) is False
+
+
+def test_has_thpt_history_thpt_missing_school_id_returns_false() -> None:
+    history = [{"level": "THPT", "year_from": 2020, "year_to": 2022}]
+    assert _has_thpt_history(history) is False
+
+
+def test_has_thpt_history_thpt_missing_year_returns_false() -> None:
+    history = [{"school_id": 100, "level": "THPT", "year_from": None, "year_to": 2022}]
+    assert _has_thpt_history(history) is False
+
+
+# ===========================================================================
+# Phase E.4 matrix — target_level + admission_type drive basis
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "cultural,vocational,target_level,admission_type,expected_basis,reason_contains",
+    [
+        # CĐ chính quy + cultural đủ THPT knowledge → LICH_SU_THPT
+        ("graduated_thpt", "none", "cao_dang", "chinh_quy", "LICH_SU_THPT", "cd_chinh_quy_post_thpt"),
+        ("graduated_gdtx", "none", "cao_dang", "chinh_quy", "LICH_SU_THPT", "cd_chinh_quy_post_thpt"),
+        ("completed_thpt", "none", "cao_dang", "chinh_quy", "LICH_SU_THPT", "cd_chinh_quy_completed_thpt"),
+        # CĐ chính quy + graduated_thcs → INSUFFICIENT_DATA (eligibility đã chặn upstream)
+        ("graduated_thcs", "none", "cao_dang", "chinh_quy", "INSUFFICIENT_DATA", "cd_chinh_quy_cultural_insufficient"),
+        # CĐ liên thông từ TC + cultural graduated_thpt → LICH_SU_THPT
+        ("graduated_thpt", "trung_cap", "cao_dang", "lien_thong", "LICH_SU_THPT", "cd_lien_thong_post_thpt"),
+        ("graduated_gdtx", "cao_dang", "cao_dang", "lien_thong", "LICH_SU_THPT", "cd_lien_thong_post_thpt"),
+        # TC chính quy + graduated_thcs → THUONG_TRU
+        ("graduated_thcs", "none", "trung_cap", "chinh_quy", "THUONG_TRU", "tc_chinh_quy_post_thcs"),
+        # TC chính quy + cultural đủ THPT → LICH_SU_THPT
+        ("graduated_thpt", "none", "trung_cap", "chinh_quy", "LICH_SU_THPT", "tc_chinh_quy_post_thpt"),
+        ("completed_thpt", "so_cap", "trung_cap", "chinh_quy", "LICH_SU_THPT", "tc_chinh_quy_post_thpt"),
+        # TC liên thông từ SC/TC + cultural graduated_thcs → THUONG_TRU
+        ("graduated_thcs", "so_cap", "trung_cap", "lien_thong", "THUONG_TRU", "tc_lien_thong_post_thcs_with_voc"),
+        ("graduated_thcs", "trung_cap", "trung_cap", "lien_thong", "THUONG_TRU", "tc_lien_thong_post_thcs_with_voc"),
+        # TC liên thông + cultural THPT → LICH_SU_THPT
+        ("graduated_thpt", "so_cap", "trung_cap", "lien_thong", "LICH_SU_THPT", "tc_lien_thong_post_thpt"),
+        # TC chính quy + completed_thcs → INSUFFICIENT_DATA
+        ("completed_thcs", "none", "trung_cap", "chinh_quy", "INSUFFICIENT_DATA", "tc_chinh_quy_cultural_insufficient"),
+        # SC chính quy → THUONG_TRU
+        ("graduated_thcs", "none", "so_cap", "chinh_quy", "THUONG_TRU", "sc_uses_commune"),
+        (None, "none", "so_cap", "chinh_quy", "NOT_RESOLVED", "cultural_not_set"),
+    ],
+)
+def test_phase_e4_matrix_basis_resolution(
+    cultural, vocational, target_level, admission_type, expected_basis, reason_contains,
+) -> None:
+    basis, reason = _derive_kv_basis_level(
+        cultural=cultural,
+        vocational=vocational,
+        target_level=target_level,
+        admission_type=admission_type,
+        academic_history=None,
+    )
+    assert basis == expected_basis, (
+        f"Combo ({cultural}/{vocational}/{target_level}/{admission_type}) "
+        f"expected basis={expected_basis} but got {basis} (reason={reason})"
+    )
+    assert reason_contains in reason
+
+
+# ===========================================================================
+# Hybrid: CĐ liên thông KHOI_LUONG_VH_THPT + TC (completed_thpt + trung_cap)
+# ===========================================================================
+
+
+def test_hybrid_cd_lien_thong_with_thpt_history_picks_lich_su_thpt() -> None:
+    """Có lịch sử học THPT/GDTX hợp lệ → LICH_SU_THPT (per nghiệp vụ #6)."""
+    history = [
+        {"school_id": 100, "level": "THPT", "year_from": 2018, "year_to": 2020},
+    ]
+    basis, reason = _derive_kv_basis_level(
+        cultural="completed_thpt",
+        vocational="trung_cap",
+        target_level="cao_dang",
+        admission_type="lien_thong",
+        academic_history=history,
+    )
+    assert basis == "LICH_SU_THPT"
+    assert "cd_lien_thong_khoi_luong_with_thpt_history" in reason
+
+
+def test_hybrid_cd_lien_thong_no_thpt_history_falls_to_thuong_tru() -> None:
+    """Không có lịch sử THPT → THUONG_TRU (fallback per nghiệp vụ #6)."""
+    history = [
+        {"school_id": 200, "level": "TRUNG_HOC_NGHE", "year_from": 2022, "year_to": 2024},
+    ]
+    basis, reason = _derive_kv_basis_level(
+        cultural="completed_thpt",
+        vocational="trung_cap",
+        target_level="cao_dang",
+        admission_type="lien_thong",
+        academic_history=history,
+    )
+    assert basis == "THUONG_TRU"
+    assert "cd_lien_thong_khoi_luong_no_thpt_history_fallback" in reason
+
+
+def test_hybrid_cd_lien_thong_no_history_at_all_falls_to_thuong_tru() -> None:
+    """Empty academic_history → fall to THUONG_TRU; engine sẽ check commune
+    ở resolve step → ADDRESS_NOT_NORMALIZED nếu cũng thiếu commune_code."""
+    basis, reason = _derive_kv_basis_level(
+        cultural="completed_thpt",
+        vocational="cao_dang",
+        target_level="cao_dang",
+        admission_type="lien_thong",
+        academic_history=[],
+    )
+    assert basis == "THUONG_TRU"
+    assert "no_thpt_history_fallback" in reason
+
+
+# ===========================================================================
+# Bypass paths — area_resolution_basis trumps Phase E.4 matrix
+# ===========================================================================
+
+
+def test_permanent_address_special_overrides_phase_e4_matrix() -> None:
+    basis, reason = _derive_kv_basis_level(
+        cultural="graduated_thpt",
+        vocational="none",
+        target_level="cao_dang",
+        admission_type="chinh_quy",
+        academic_history=None,
+        area_resolution_basis="permanent_address_special",
+    )
+    assert basis == "COMMUNE_SPECIAL"
+    assert reason == "permanent_address_special_override"
+
+
+def test_manual_override_trumps_everything() -> None:
+    basis, reason = _derive_kv_basis_level(
+        cultural=None,
+        vocational="none",
+        target_level=None,
+        admission_type=None,
+        academic_history=None,
+        area_resolution_basis="manual_override",
+    )
+    assert basis == "MANUAL"
+    assert reason == "admin_set_kv_directly"
+
+
+# ===========================================================================
+# resolve_kv_for_profile — fail-closed codes (yêu cầu nghiệp vụ #7)
+# ===========================================================================
+
+
+class _Result:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+def _mock_db(commune_kv=None, school_kv_sequence=None):
+    db = AsyncMock()
+    kv_iter = iter(school_kv_sequence or [])
+
+    async def execute(stmt):
+        stmt_str = str(stmt).lower()
+        if "vn_commune_area_map" in stmt_str:
+            return _Result(commune_kv)
+        if "vn_school_kv_assignment" in stmt_str:
+            try:
+                return _Result(next(kv_iter))
+            except StopIteration:
+                return _Result(None)
+        return _Result(None)
+
+    db.execute = execute
+    return db
+
+
+def _profile_stub(**kwargs):
+    defaults = {
+        "id": 1,
+        "cultural_education_level": "graduated_thpt",
+        "vocational_qualification": "none",
+        "area_resolution_basis": None,
+        "permanent_commune_code": None,
+        "academic_history": [],
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_resolve_thuong_tru_missing_commune_code_returns_address_not_normalized() -> None:
+    """TC chính quy + graduated_thcs + thiếu permanent_commune_code → fail-closed."""
+    profile = _profile_stub(
+        cultural_education_level="graduated_thcs",
+        permanent_commune_code=None,
+    )
+    db = _mock_db()
+    kv, meta = await resolve_kv_for_profile(
+        profile, db, target_level="trung_cap", admission_type="chinh_quy",
+    )
+    assert kv is None
+    assert meta["rule_applied"] == "address_not_normalized"
+    assert meta["pathway"] == "thuong_tru"
+    assert meta["basis"] == "THUONG_TRU"
+    assert meta["requires_manual_override"] is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_thuong_tru_commune_not_in_catalog_returns_catalog_gap_commune() -> None:
+    """commune_code có nhưng vn_commune_area_map miss → catalog_gap_commune."""
+    profile = _profile_stub(
+        cultural_education_level="graduated_thcs",
+        permanent_commune_code="UNKNOWN_CODE",
+    )
+    db = _mock_db(commune_kv=None)  # lookup miss
+    kv, meta = await resolve_kv_for_profile(
+        profile, db, target_level="trung_cap", admission_type="chinh_quy",
+    )
+    assert kv is None
+    assert meta["rule_applied"] == "catalog_gap_commune"
+    assert meta["pathway"] == "thuong_tru"
+    assert meta["breakdown"]["commune_code_attempted"] == "UNKNOWN_CODE"
+
+
+@pytest.mark.asyncio
+async def test_resolve_lich_su_thpt_all_school_lookups_miss_returns_catalog_gap_school() -> None:
+    """CĐ chính quy + history THPT nhưng vn_school_kv_assignment miss tất cả."""
+    profile = _profile_stub(
+        cultural_education_level="graduated_thpt",
+        academic_history=[
+            {"school_id": 100, "level": "THPT", "year_from": 2020, "year_to": 2022, "grade_to": 12},
+        ],
+    )
+    db = _mock_db(school_kv_sequence=[None, None, None])  # all 3 years miss
+    kv, meta = await resolve_kv_for_profile(
+        profile, db, target_level="cao_dang", admission_type="chinh_quy",
+    )
+    assert kv is None
+    assert meta["rule_applied"] == "catalog_gap_school"
+    assert meta["pathway"] == "lich_su_thpt"
+    assert meta["basis"] == "LICH_SU_THPT"
+
+
+@pytest.mark.asyncio
+async def test_resolve_commune_special_missing_code_returns_address_not_normalized() -> None:
+    """area_resolution_basis=permanent_address_special + thiếu commune_code."""
+    profile = _profile_stub(
+        cultural_education_level="graduated_thpt",
+        area_resolution_basis="permanent_address_special",
+        permanent_commune_code=None,
+    )
+    db = _mock_db()
+    kv, meta = await resolve_kv_for_profile(
+        profile, db, target_level="cao_dang", admission_type="chinh_quy",
+    )
+    assert kv is None
+    assert meta["rule_applied"] == "address_not_normalized"
+    assert meta["basis"] == "COMMUNE_SPECIAL"
+
+
+@pytest.mark.asyncio
+async def test_resolve_thuong_tru_happy_with_commune_in_catalog() -> None:
+    """TC chính quy + graduated_thcs + commune_code resolve OK."""
+    profile = _profile_stub(
+        cultural_education_level="graduated_thcs",
+        permanent_commune_code="66_22255",
+    )
+    db = _mock_db(commune_kv="KV2-NT")
+    kv, meta = await resolve_kv_for_profile(
+        profile, db, target_level="trung_cap", admission_type="chinh_quy",
+    )
+    assert kv == "KV2-NT"
+    assert meta["rule_applied"] == "commune_lookup"
+    assert meta["pathway"] == "thuong_tru"
+    assert meta["basis"] == "THUONG_TRU"
+    assert meta["breakdown"]["commune_code_used"] == "66_22255"
+
+
+@pytest.mark.asyncio
+async def test_resolve_insufficient_data_for_cd_lien_thong_no_history_no_commune() -> None:
+    """Hybrid: completed_thpt + trung_cap + no history + no commune → THUONG_TRU
+    basis nhưng resolve fail với ADDRESS_NOT_NORMALIZED (commune missing)."""
+    profile = _profile_stub(
+        cultural_education_level="completed_thpt",
+        vocational_qualification="trung_cap",
+        academic_history=[],
+        permanent_commune_code=None,
+    )
+    db = _mock_db()
+    kv, meta = await resolve_kv_for_profile(
+        profile, db, target_level="cao_dang", admission_type="lien_thong",
+    )
+    assert kv is None
+    assert meta["basis"] == "THUONG_TRU"
+    assert meta["rule_applied"] == "address_not_normalized"
+
+
+# ===========================================================================
+# Snapshot additive fields (target_level + admission_type bơm vào meta)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_resolve_carries_basis_and_reason_into_meta() -> None:
+    """Mọi resolve call phải emit basis + basis_reason trong meta (audit trail)."""
+    profile = _profile_stub(
+        cultural_education_level="graduated_thpt",
+        academic_history=[
+            {"school_id": 100, "level": "THPT", "year_from": 2020, "year_to": 2022, "grade_to": 12},
+        ],
+    )
+    db = _mock_db(school_kv_sequence=["KV1", "KV1", "KV1"])
+    kv, meta = await resolve_kv_for_profile(
+        profile, db, target_level="cao_dang", admission_type="chinh_quy",
+    )
+    assert kv == "KV1"
+    assert meta["basis"] == "LICH_SU_THPT"
+    assert "cd_chinh_quy_post_thpt" in meta["basis_reason"]

--- a/Backend_FastAPI/tests/unit/test_priority_kv_resolution.py
+++ b/Backend_FastAPI/tests/unit/test_priority_kv_resolution.py
@@ -350,8 +350,12 @@ async def test_resolve_kv_thcs_plus_tc_falls_to_commune():
         ("graduated_gdtx", "none", "CD", True),
         # CĐ target — Path 2: liên thông (THPT kiến thức + TC)
         ("completed_thpt", "trung_cap", "CD", True),
-        # CĐ target — fail cases
-        ("completed_thpt", "none", "CD", False),  # Chưa thi TN THPT + chưa TC → CD FAIL
+        # CĐ chính quy mới (Phase E.4 chốt 2026-05-21): TN_THPT hoặc
+        # HOAN_THANH_THPT — completed_thpt được phép vì "hoàn thành THPT"
+        # đủ cho CĐ chính quy. Trước commit này test expected False; sau
+        # commit eligibility wire mới, validate_eligibility(default admission_type
+        # = chinh_quy) PASS completed_thpt cho CĐ.
+        ("completed_thpt", "none", "CD", True),
         ("graduated_thcs", "trung_cap", "CD", False),  # Chưa TN THPT → CD FAIL (path 2 strict)
         ("graduated_thcs", "none", "CD", False),  # Chỉ TN THCS → CD FAIL
         ("completed_thcs", "trung_cap", "CD", False),  # Chưa TN THCS → CD FAIL

--- a/Backend_FastAPI/tests/unit/test_priority_kv_resolution.py
+++ b/Backend_FastAPI/tests/unit/test_priority_kv_resolution.py
@@ -34,35 +34,33 @@ from app.services.priority_service import (
 @pytest.mark.parametrize(
     "cultural,vocational,area_basis,expected_basis",
     [
-        # Row 1: graduated_thpt + any vocational → THPT
-        ("graduated_thpt", "none", None, "THPT"),
-        ("graduated_thpt", "trung_cap", None, "THPT"),
-        ("graduated_gdtx", "cao_dang", None, "THPT"),
-        # Row 2: completed_thpt + (trung_cap | cao_dang) → THPT
-        ("completed_thpt", "trung_cap", None, "THPT"),
-        ("completed_thpt", "cao_dang", None, "THPT"),
-        # Row 3: completed_thpt + (so_cap | none) → COMMUNE_FALLBACK
-        ("completed_thpt", "so_cap", None, "COMMUNE_FALLBACK"),
-        ("completed_thpt", "none", None, "COMMUNE_FALLBACK"),
-        # Rows 4+5 merged (per nghiệp vụ user 2026-05-18): graduated_thcs →
-        # COMMUNE_FALLBACK regardless of vocational. Original v1.3 design had
-        # Row 4 → TC basis cho liên thông TC pathway, NHƯNG user clarified:
-        # TN THCS bất kể có TC nghề → KV theo hộ khẩu (case 1 generic).
-        ("graduated_thcs", "trung_cap", None, "COMMUNE_FALLBACK"),
-        ("graduated_thcs", "cao_dang", None, "COMMUNE_FALLBACK"),
-        ("graduated_thcs", "so_cap", None, "COMMUNE_FALLBACK"),
-        ("graduated_thcs", "none", None, "COMMUNE_FALLBACK"),
-        # Row 6: completed_thcs + any → COMMUNE_FALLBACK
-        ("completed_thcs", "none", None, "COMMUNE_FALLBACK"),
-        ("completed_thcs", "trung_cap", None, "COMMUNE_FALLBACK"),
-        # Row 7: cultural NULL → NOT_RESOLVED
+        # Phase E.4 commit 5: _derive_kv_basis_level rename basis values:
+        #   "THPT" → "LICH_SU_THPT"
+        #   "COMMUNE_FALLBACK" → "THUONG_TRU"
+        # Legacy 3-arg signature (target_level=None) vẫn được hỗ trợ;
+        # callers cũ fall vào legacy matrix branch.
+        ("graduated_thpt", "none", None, "LICH_SU_THPT"),
+        ("graduated_thpt", "trung_cap", None, "LICH_SU_THPT"),
+        ("graduated_gdtx", "cao_dang", None, "LICH_SU_THPT"),
+        ("completed_thpt", "trung_cap", None, "LICH_SU_THPT"),
+        ("completed_thpt", "cao_dang", None, "LICH_SU_THPT"),
+        # completed_thpt + so_cap/none — legacy branch fall back commune
+        ("completed_thpt", "so_cap", None, "THUONG_TRU"),
+        ("completed_thpt", "none", None, "THUONG_TRU"),
+        # graduated_thcs all → THUONG_TRU (per nghiệp vụ 2026-05-18 user override)
+        ("graduated_thcs", "trung_cap", None, "THUONG_TRU"),
+        ("graduated_thcs", "cao_dang", None, "THUONG_TRU"),
+        ("graduated_thcs", "so_cap", None, "THUONG_TRU"),
+        ("graduated_thcs", "none", None, "THUONG_TRU"),
+        ("completed_thcs", "none", None, "THUONG_TRU"),
+        ("completed_thcs", "trung_cap", None, "THUONG_TRU"),
+        # Cultural NULL → NOT_RESOLVED
         (None, "none", None, "NOT_RESOLVED"),
         (None, "trung_cap", None, "NOT_RESOLVED"),
-        # Row 8: area_basis bypass — special_case wins regardless of cultural
+        # area_basis bypass — output overrides matrix
         ("graduated_thpt", "none", "permanent_address_special", "COMMUNE_SPECIAL"),
         ("graduated_thcs", "trung_cap", "permanent_address_special", "COMMUNE_SPECIAL"),
         (None, "none", "permanent_address_special", "COMMUNE_SPECIAL"),
-        # Row 9: manual_override bypass
         ("graduated_thpt", "none", "manual_override", "MANUAL"),
         ("graduated_thcs", "cao_dang", "manual_override", "MANUAL"),
     ],
@@ -70,12 +68,24 @@ from app.services.priority_service import (
 def test_derive_kv_basis_level_full_matrix(
     cultural, vocational, area_basis, expected_basis
 ):
-    assert _derive_kv_basis_level(cultural, vocational, area_basis) == expected_basis
+    # Phase E.4: returns tuple (basis, basis_reason). Test pin basis only;
+    # basis_reason coverage trong test_priority_eligibility_kv_matrix.py mới.
+    basis, _reason = _derive_kv_basis_level(
+        cultural=cultural,
+        vocational=vocational,
+        area_resolution_basis=area_basis,
+    )
+    assert basis == expected_basis
 
 
 def test_derive_kv_basis_level_unknown_cultural_defensive():
     """Defensive: unknown cultural (CHECK should prevent, but defensive)."""
-    assert _derive_kv_basis_level("alien_value", "none", None) == "NOT_RESOLVED"
+    basis, _reason = _derive_kv_basis_level(
+        cultural="alien_value",
+        vocational="none",
+        area_resolution_basis=None,
+    )
+    assert basis == "NOT_RESOLVED"
 
 
 # =============================================================================
@@ -196,7 +206,7 @@ async def test_resolve_kv_commune_fallback_thcs_only():
     db = _mock_db(commune_kv="KV2-NT")
     kv, meta = await resolve_kv_for_profile(profile, db)
     assert kv == "KV2-NT"
-    assert meta["pathway"] == "commune_fallback"
+    assert meta["pathway"] == "thuong_tru"
 
 
 @pytest.mark.asyncio
@@ -218,7 +228,7 @@ async def test_resolve_kv_thpt_tied_then_tiebreak_graduation():
     kv, meta = await resolve_kv_for_profile(profile, db)
     # School 200 is graduation (year_to=2023 > 2021, grade_to=12 > 11)
     assert kv == "KV3"
-    assert meta["pathway"] == "thpt_multi_school"
+    assert meta["pathway"] == "lich_su_thpt"
     assert meta["rule_applied"] == "tiebreak_graduation_school"
     assert meta["breakdown"]["graduation_school_id"] == 200
 
@@ -267,7 +277,10 @@ async def test_resolve_kv_m1_ambiguous_tied_graduation():
 
 @pytest.mark.asyncio
 async def test_resolve_kv_no_qualifying_entries():
-    """Cultural pathway THPT but no entries with level='THPT' in history."""
+    """Cultural pathway THPT but no entries with level='THPT' in history.
+
+    Phase E.4 commit 5: rule_applied = 'insufficient_data', reason rename.
+    """
     profile = _mock_profile(
         cultural_education_level="graduated_thpt",
         academic_history=[
@@ -279,7 +292,8 @@ async def test_resolve_kv_no_qualifying_entries():
     kv, meta = await resolve_kv_for_profile(profile, db)
     assert kv is None
     assert meta["requires_manual_override"] is True
-    assert meta["reason"] == "no_qualifying_entries"
+    assert meta["rule_applied"] == "insufficient_data"
+    assert meta["reason"] == "no_qualifying_thpt_history_entries"
 
 
 @pytest.mark.asyncio
@@ -305,7 +319,7 @@ async def test_resolve_kv_thpt_accepts_thcs_thpt_lien_cap():
     db = _mock_db(school_kv_sequence=["KV1", "KV1", "KV1"])
     kv, meta = await resolve_kv_for_profile(profile, db)
     assert kv == "KV1"
-    assert meta["pathway"] == "thpt_multi_school"
+    assert meta["pathway"] == "lich_su_thpt"
     assert meta["breakdown"]["winner_years"] == 3
 
 
@@ -334,7 +348,7 @@ async def test_resolve_kv_thcs_plus_tc_falls_to_commune():
     db = _mock_db(commune_kv="KV1")
     kv, meta = await resolve_kv_for_profile(profile, db)
     assert kv == "KV1"
-    assert meta["pathway"] == "commune_fallback"
+    assert meta["pathway"] == "thuong_tru"
     assert meta["rule_applied"] == "commune_lookup"
 
 
@@ -424,7 +438,7 @@ async def test_resolve_kv_pre_2025_history_hits_before_entry():
     db = _mock_db(school_kv_sequence=["KV1", "KV1", "KV1"])
     kv, meta = await resolve_kv_for_profile(profile, db)
     assert kv == "KV1"
-    assert meta["pathway"] == "thpt_multi_school"
+    assert meta["pathway"] == "lich_su_thpt"
     assert meta["breakdown"]["winner_years"] == 3
 
 

--- a/Backend_FastAPI/tests/unit/test_priority_override_service.py
+++ b/Backend_FastAPI/tests/unit/test_priority_override_service.py
@@ -545,9 +545,9 @@ async def test_manager_happy_path_mutates_snapshot_and_audit_log() -> None:
     assert snap["manual_override_reason"] == REASON_VALID
     assert snap["evidence_file_id"] == 42
     assert snap["frozen_at_status"] == "manual_override"
-    # Manager treated as officer-path (resolved_by="officer"); only admin emit
-    # resolved_by="admin". Behavior preserved from pre-commit 7.
-    assert snap["resolved_by"] == "officer"
+    # Phase E.4 commit 7 fix-up: resolved_by phản ánh actor.role thực.
+    # Manager override → "manager" (KHÔNG còn "officer" stale).
+    assert snap["resolved_by"] == "manager"
 
     # Engine-state keys dropped post-override
     assert "requires_manual_override" not in snap or not snap["requires_manual_override"]
@@ -643,7 +643,9 @@ async def test_second_override_overwrites_manual_keys() -> None:
     """First override sets manual_override_*; second overwrites with new
     actor + reason (snapshot LAST wins, audit log preserves chain).
     """
-    # Profile already had one override (e.g., from officer)
+    # Profile already had one override (e.g., legacy pre-commit-7 officer
+    # state, or manager first pass). Snapshot value retained để verify
+    # chain-of-override LAST wins semantics regardless of prior actor.
     profile = _make_profile(
         status="submitted",
         version=6,
@@ -653,11 +655,11 @@ async def test_second_override_overwrites_manual_keys() -> None:
             "rule_applied": "manual_override",
             "manual_override_by": 7,
             "manual_override_at": "2026-05-19T01:00:00Z",
-            "manual_override_reason": "Officer first pass override reason 20 chars+",
+            "manual_override_reason": "Manager first pass override reason 20 chars+",
             "evidence_file_id": 11,
             "frozen_at": "2026-05-19T01:00:00Z",
             "frozen_at_status": "manual_override",
-            "resolved_by": "officer",
+            "resolved_by": "manager",
         },
     )
     admin = _make_actor("admin", user_id=99)

--- a/Backend_FastAPI/tests/unit/test_priority_override_service.py
+++ b/Backend_FastAPI/tests/unit/test_priority_override_service.py
@@ -192,7 +192,7 @@ async def test_invalid_kv_value_raises() -> None:
 
 
 @pytest.mark.parametrize(
-    "status", ["draft", "withdrawn", "dropped", "rejected"]
+    "status", ["withdrawn", "dropped", "rejected"]
 )
 async def test_hard_denied_status_raises_for_officer(status: str) -> None:
     profile = _make_profile(status=status)
@@ -212,7 +212,7 @@ async def test_hard_denied_status_raises_for_officer(status: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "status", ["draft", "withdrawn", "dropped", "rejected"]
+    "status", ["withdrawn", "dropped", "rejected"]
 )
 async def test_hard_denied_status_raises_for_admin_too(status: str) -> None:
     """Admin also refused for hard-denied states (data integrity)."""
@@ -231,6 +231,105 @@ async def test_hard_denied_status_raises_for_admin_too(status: str) -> None:
             expected_version=5,
             acknowledge_post_publish=True,
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase E.4 commit 5 fix-up — draft gate (gỡ deadlock submit-guard fail-closed)
+# ---------------------------------------------------------------------------
+
+
+async def test_draft_override_refused_for_officer() -> None:
+    """Officer KHÔNG được override KV ở draft — kể cả engine signal unresolved.
+    Hardening đầy đủ ở commit 7."""
+    snapshot_with_engine_signal = {
+        "kv_resolved": None,
+        "rule_applied": "address_not_normalized",
+        "requires_manual_override": True,
+        "reason": "profile_missing_permanent_commune_code",
+    }
+    profile = _make_profile(
+        status="draft",
+        snapshot=snapshot_with_engine_signal,
+    )
+    actor = _make_actor("officer")
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match="Officer không được override KV"):
+        await override_kv(
+            db,
+            profile,
+            kv_resolved="KV1",
+            reason=REASON_VALID,
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=5,
+        )
+
+
+@pytest.mark.parametrize("role", ["admin", "manager"])
+async def test_draft_override_refused_without_engine_signal(role: str) -> None:
+    """Admin/manager cũng KHÔNG được override draft khi engine chưa emit
+    requires_manual_override — tránh free-form override khi candidate vẫn
+    edit form. Engine có thể resolve khi đủ data."""
+    snapshot_engine_resolve_ok = {
+        "kv_resolved": "KV1",
+        "rule_applied": "longest_duration",
+        "basis": "LICH_SU_THPT",
+        # Không có requires_manual_override
+    }
+    profile = _make_profile(
+        status="draft",
+        snapshot=snapshot_engine_resolve_ok,
+    )
+    actor = _make_actor(role)
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match="draft chỉ được override"):
+        await override_kv(
+            db,
+            profile,
+            kv_resolved="KV2",
+            reason=REASON_VALID,
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=5,
+        )
+
+
+@pytest.mark.parametrize("role", ["admin", "manager"])
+async def test_draft_override_allowed_for_admin_manager_with_engine_signal(role: str) -> None:
+    """Admin/manager được override draft KHI engine emit requires_manual_override
+    (vd: address_not_normalized, catalog_gap_*, ambiguous). Gỡ deadlock với
+    submit guard fail-closed."""
+    snapshot_with_engine_signal = {
+        "kv_resolved": None,
+        "rule_applied": "ambiguous_requires_manual",
+        "requires_manual_override": True,
+        "reason": "tied_graduation_year_and_grade",
+    }
+    profile = _make_profile(
+        status="draft",
+        snapshot=snapshot_with_engine_signal,
+    )
+    actor = _make_actor(role)
+    db = _make_db()
+
+    # Should not raise — override succeeds
+    updated, _cb = await override_kv(
+        db,
+        profile,
+        kv_resolved="KV1",
+        reason=REASON_VALID,
+        evidence_file_id=None,
+        actor=actor,
+        expected_version=5,
+    )
+    snap = updated.priority_resolution_snapshot
+    assert snap["kv_resolved"] == "KV1"
+    assert snap["rule_applied"] == "manual_override"
+    assert snap["manual_override_reason"] == REASON_VALID
+    # Engine signal flag dropped post-override
+    assert "requires_manual_override" not in snap
 
 
 @pytest.mark.parametrize(

--- a/Backend_FastAPI/tests/unit/test_priority_override_service.py
+++ b/Backend_FastAPI/tests/unit/test_priority_override_service.py
@@ -70,11 +70,25 @@ def _make_actor(role: str = "officer", user_id: int = 7):
 
 
 def _make_db():
-    """AsyncMock session — captures db.add() calls + db.flush() awaits."""
+    """AsyncMock session — captures db.add() calls + db.flush() awaits.
+
+    Phase E.4 v5 — override_kv draft gate now calls db.execute() qua
+    ``derive_profile_target_context`` + ``resolve_kv_for_profile``. Provide
+    a permissive execute mock returning empty results; tests that need
+    specific engine behavior patch the priority_service functions instead.
+    """
     db = MagicMock()
     db.add = MagicMock()
     db.flush = AsyncMock()
     db.commit = AsyncMock()
+
+    # Defensive execute mock: returns a result object with scalar_one_or_none()
+    # = None + scalar().all() = []. Tests patch priority_service functions để
+    # bypass execute entirely.
+    empty_result = MagicMock()
+    empty_result.scalar_one_or_none = MagicMock(return_value=None)
+    empty_result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+    db.execute = AsyncMock(return_value=empty_result)
     return db
 
 
@@ -266,28 +280,70 @@ async def test_draft_override_refused_for_officer() -> None:
         )
 
 
-@pytest.mark.parametrize("role", ["admin", "manager"])
-async def test_draft_override_refused_without_engine_signal(role: str) -> None:
-    """Admin/manager cũng KHÔNG được override draft khi engine chưa emit
-    requires_manual_override — tránh free-form override khi candidate vẫn
-    edit form. Engine có thể resolve khi đủ data."""
-    snapshot_engine_resolve_ok = {
-        "kv_resolved": "KV1",
-        "rule_applied": "longest_duration",
-        "basis": "LICH_SU_THPT",
-        # Không có requires_manual_override
+# Phase E.4 v5 — Draft override now uses LIVE engine recompute (not snapshot
+# stale). Helper monkeypatch để control resolve_kv_for_profile + derive
+# context output for these tests.
+async def _fake_derive_ctx(profile_arg, db_arg):
+    return {
+        "target_level": "trung_cap",
+        "admission_type": "chinh_quy",
+        "eligibility": {"passed": True, "reason": None},
+        "path_bonus_rule": None,
+        "source": "test_stub",
     }
-    profile = _make_profile(
-        status="draft",
-        snapshot=snapshot_engine_resolve_ok,
-    )
+
+
+def _fake_resolve_factory(returns_unresolved: bool, rule: str = "address_not_normalized"):
+    """Factory: build resolve_kv_for_profile mock returning unresolved or success meta."""
+    async def _fake_resolve(profile_arg, db_arg, target_level=None, admission_type=None):
+        if returns_unresolved:
+            return None, {
+                "rule_applied": rule,
+                "pathway": "thuong_tru",
+                "basis": "THUONG_TRU",
+                "basis_reason": "tc_chinh_quy_post_thcs_uses_commune",
+                "requires_manual_override": True,
+                "reason": "profile_missing_permanent_commune_code",
+            }
+        return "KV1", {
+            "rule_applied": "commune_lookup",
+            "pathway": "thuong_tru",
+            "basis": "THUONG_TRU",
+            "basis_reason": "tc_chinh_quy_post_thcs_uses_commune",
+            "breakdown": {"commune_code_used": "66_22255"},
+        }
+    return _fake_resolve
+
+
+@pytest.mark.parametrize("role", ["admin", "manager"])
+async def test_draft_override_refused_when_engine_recompute_resolves_live(
+    role: str, monkeypatch,
+) -> None:
+    """v5: Live engine recompute resolve OK với current profile data → refuse,
+    bất kể snapshot stale có signal hay không. Tránh free-form override khi
+    engine có đường tự xử."""
+    # Snapshot có thể là stale signal (officer mới sửa data) hoặc resolved OK
+    snapshot_any = {
+        "kv_resolved": None,
+        "rule_applied": "address_not_normalized",
+        "requires_manual_override": True,  # STALE signal
+        "reason": "profile_missing_permanent_commune_code",
+    }
+    profile = _make_profile(status="draft", snapshot=snapshot_any)
     actor = _make_actor(role)
     db = _make_db()
 
-    with pytest.raises(BusinessRuleViolation, match="draft chỉ được override"):
+    # Patch live recompute → return success (engine resolve OK)
+    import app.services.priority_service as priority_module
+    monkeypatch.setattr(priority_module, "derive_profile_target_context", _fake_derive_ctx)
+    monkeypatch.setattr(
+        priority_module, "resolve_kv_for_profile",
+        _fake_resolve_factory(returns_unresolved=False),
+    )
+
+    with pytest.raises(BusinessRuleViolation, match="Engine vừa tính lại và resolve thành công"):
         await override_kv(
-            db,
-            profile,
+            db, profile,
             kv_resolved="KV2",
             reason=REASON_VALID,
             evidence_file_id=None,
@@ -297,27 +353,33 @@ async def test_draft_override_refused_without_engine_signal(role: str) -> None:
 
 
 @pytest.mark.parametrize("role", ["admin", "manager"])
-async def test_draft_override_allowed_for_admin_manager_with_engine_signal(role: str) -> None:
-    """Admin/manager được override draft KHI engine emit requires_manual_override
-    (vd: address_not_normalized, catalog_gap_*, ambiguous). Gỡ deadlock với
-    submit guard fail-closed."""
+async def test_draft_override_allowed_when_engine_recompute_still_unresolved(
+    role: str, monkeypatch,
+) -> None:
+    """v5: Live engine recompute vẫn emit unresolved → allow (matches submit
+    guard fail-closed). Snapshot có thể đã có signal cũ hoặc không — không
+    quan trọng, live engine là nguồn quyết định."""
     snapshot_with_engine_signal = {
         "kv_resolved": None,
         "rule_applied": "ambiguous_requires_manual",
         "requires_manual_override": True,
         "reason": "tied_graduation_year_and_grade",
     }
-    profile = _make_profile(
-        status="draft",
-        snapshot=snapshot_with_engine_signal,
-    )
+    profile = _make_profile(status="draft", snapshot=snapshot_with_engine_signal)
     actor = _make_actor(role)
     db = _make_db()
 
+    # Patch live recompute → return unresolved (engine vẫn không xác định)
+    import app.services.priority_service as priority_module
+    monkeypatch.setattr(priority_module, "derive_profile_target_context", _fake_derive_ctx)
+    monkeypatch.setattr(
+        priority_module, "resolve_kv_for_profile",
+        _fake_resolve_factory(returns_unresolved=True, rule="address_not_normalized"),
+    )
+
     # Should not raise — override succeeds
     updated, _cb = await override_kv(
-        db,
-        profile,
+        db, profile,
         kv_resolved="KV1",
         reason=REASON_VALID,
         evidence_file_id=None,
@@ -330,6 +392,60 @@ async def test_draft_override_allowed_for_admin_manager_with_engine_signal(role:
     assert snap["manual_override_reason"] == REASON_VALID
     # Engine signal flag dropped post-override
     assert "requires_manual_override" not in snap
+
+
+async def test_draft_override_refused_with_stale_snapshot_signal_after_officer_fix(
+    monkeypatch,
+) -> None:
+    """Reviewer P0 2026-05-21 v5 — STALE SIGNAL bug regression.
+
+    Scenario:
+      1. Officer submit thiếu commune_code → snapshot persist với rule
+         address_not_normalized + requires_manual_override=True.
+      2. Officer sửa permanent_commune_code='66_22255' (qua update_profile);
+         snapshot KHÔNG được clear/recompute auto.
+      3. Manager mở override_kv draft.
+      4. Pre-fix v5: gate kiểm tra snapshot.requires_manual_override → True
+         (stale) → pass → free-form override với KV bất kỳ. SAI nghiệp vụ.
+      5. Post-fix v5: gate recompute live → engine giờ resolve OK (commune
+         có catalog) → refuse. Officer cần submit lại để engine refreeze.
+    """
+    # Stale snapshot from old submit (commune empty)
+    stale_snapshot = {
+        "kv_resolved": None,
+        "rule_applied": "address_not_normalized",
+        "pathway": "thuong_tru",
+        "basis": "THUONG_TRU",
+        "requires_manual_override": True,  # STALE
+        "reason": "profile_missing_permanent_commune_code",
+    }
+    profile = _make_profile(status="draft", snapshot=stale_snapshot)
+    # Officer đã sửa commune_code; profile.permanent_commune_code có giá trị.
+    # Trong test này SimpleNamespace stub không tracking field; quan trọng là
+    # live recompute fake return success → simulate "engine giờ resolve OK".
+    actor = _make_actor("manager")
+    db = _make_db()
+
+    import app.services.priority_service as priority_module
+    monkeypatch.setattr(priority_module, "derive_profile_target_context", _fake_derive_ctx)
+    monkeypatch.setattr(
+        priority_module, "resolve_kv_for_profile",
+        _fake_resolve_factory(returns_unresolved=False),  # Live = OK
+    )
+
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await override_kv(
+            db, profile,
+            kv_resolved="KV2",  # Manager intent override
+            reason=REASON_VALID,
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=5,
+        )
+    # Message phải nói rõ "engine vừa tính lại" để officer hiểu sửa data → resolve OK
+    assert "Engine vừa tính lại và resolve thành công" in str(exc.value)
+    # Snapshot KHÔNG bị mutate (override refused)
+    assert profile.priority_resolution_snapshot == stale_snapshot
 
 
 @pytest.mark.parametrize(

--- a/Backend_FastAPI/tests/unit/test_priority_override_service.py
+++ b/Backend_FastAPI/tests/unit/test_priority_override_service.py
@@ -205,15 +205,26 @@ async def test_invalid_kv_value_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
+# Phase E.4 commit 7 hardening: officer blocked at top — KHÔNG cần status-
+# specific test cho officer vì role gate fire trước status gate.
+# `test_officer_uniformly_blocked` (parametrized below) cover all states.
+
+
 @pytest.mark.parametrize(
-    "status", ["withdrawn", "dropped", "rejected"]
+    "status",
+    ["draft", "submitted", "reviewing", "revision_requested", "resubmitted",
+     "withdrawn", "dropped", "rejected", "enrolled", "approved",
+     "confirmed", "result_published"],
 )
-async def test_hard_denied_status_raises_for_officer(status: str) -> None:
+async def test_officer_uniformly_blocked_at_any_status(status: str) -> None:
+    """Phase E.4 commit 7 (yêu cầu nghiệp vụ #10): officer KHÔNG được override
+    KV bất kể profile status. Service-layer hard-deny role=='officer' ngay
+    sau version + reason validate, trước status whitelist."""
     profile = _make_profile(status=status)
     actor = _make_actor("officer")
     db = _make_db()
 
-    with pytest.raises(BusinessRuleViolation, match=status):
+    with pytest.raises(BusinessRuleViolation, match="Officer không được override KV"):
         await override_kv(
             db,
             profile,
@@ -448,15 +459,22 @@ async def test_draft_override_refused_with_stale_snapshot_signal_after_officer_f
     assert profile.priority_resolution_snapshot == stale_snapshot
 
 
+# Phase E.4 commit 7: ``test_officer_refused_post_publish_raises_permission_error``
+# REMOVED — officer giờ block ngay top với BusinessRuleViolation cho mọi status
+# (covered by ``test_officer_uniformly_blocked_at_any_status``). PermissionError
+# path còn lại chỉ cho manager attempting post-publish (treated as officer-path).
+
+
 @pytest.mark.parametrize(
     "status", ["enrolled", "approved", "confirmed", "result_published"]
 )
-async def test_officer_refused_post_publish_raises_permission_error(
+async def test_manager_refused_post_publish_raises_permission_error(
     status: str,
 ) -> None:
-    """Officer hits PermissionError for post-publish; router maps to 403."""
+    """Manager refused post-publish via PermissionError (router maps to 403).
+    Admin bypass với acknowledge_post_publish flag (separate test)."""
     profile = _make_profile(status=status)
-    actor = _make_actor("officer")
+    actor = _make_actor("manager")
     db = _make_db()
 
     with pytest.raises(PermissionError):
@@ -495,9 +513,13 @@ async def test_admin_post_publish_without_ack_raises() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_officer_happy_path_mutates_snapshot_and_audit_log() -> None:
+async def test_manager_happy_path_mutates_snapshot_and_audit_log() -> None:
+    """Phase E.4 commit 7: officer hard-blocked; happy path now belongs to
+    manager (admin happy path covered separately with post-publish ack).
+    Manager override pre-publish status (submitted) — same mechanics as
+    pre-commit 7 officer flow."""
     profile = _make_profile(status="submitted", version=5)
-    actor = _make_actor("officer", user_id=7)
+    actor = _make_actor("manager", user_id=7)
     db = _make_db()
 
     updated, post_commit = await override_kv(
@@ -523,6 +545,8 @@ async def test_officer_happy_path_mutates_snapshot_and_audit_log() -> None:
     assert snap["manual_override_reason"] == REASON_VALID
     assert snap["evidence_file_id"] == 42
     assert snap["frozen_at_status"] == "manual_override"
+    # Manager treated as officer-path (resolved_by="officer"); only admin emit
+    # resolved_by="admin". Behavior preserved from pre-commit 7.
     assert snap["resolved_by"] == "officer"
 
     # Engine-state keys dropped post-override
@@ -545,7 +569,7 @@ async def test_officer_happy_path_mutates_snapshot_and_audit_log() -> None:
     assert audit_row.old_value["kv_resolved"] == "KV3"
     assert audit_row.new_value["kv_resolved"] == "KV1"
     assert audit_row.new_value["reason"] == REASON_VALID
-    assert audit_row.audit_metadata["actor_role"] == "officer"
+    assert audit_row.audit_metadata["actor_role"] == "manager"
 
     # Flushed but NOT committed (router responsibility)
     db.flush.assert_awaited_once()
@@ -553,6 +577,31 @@ async def test_officer_happy_path_mutates_snapshot_and_audit_log() -> None:
 
     # post_commit callable returned
     assert callable(post_commit)
+
+
+async def test_officer_blocked_even_with_valid_state_and_inputs() -> None:
+    """Phase E.4 commit 7 negative regression — officer with completely valid
+    submitted-state inputs STILL blocked. Confirms role gate is unconditional."""
+    profile = _make_profile(status="submitted", version=5)
+    actor = _make_actor("officer", user_id=7)
+    db = _make_db()
+
+    with pytest.raises(BusinessRuleViolation, match="Officer không được override KV"):
+        await override_kv(
+            db,
+            profile,
+            kv_resolved="KV1",
+            reason=REASON_VALID,
+            evidence_file_id=42,
+            actor=actor,
+            expected_version=5,
+        )
+    # Snapshot KHÔNG bị mutate
+    assert profile.priority_resolution_snapshot.get("rule_applied") != "manual_override"
+    # Version KHÔNG bump
+    assert profile.version == 5
+    # Audit log KHÔNG có row được add
+    assert len(_find_audit_rows(db)) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/Backend_FastAPI/tests/unit/test_submit_kv_unresolved_guard.py
+++ b/Backend_FastAPI/tests/unit/test_submit_kv_unresolved_guard.py
@@ -1,21 +1,26 @@
 """Unit tests for ``_assert_kv_resolved_for_submit`` (Phase E.4 commit 5 fix-up).
 
-Reviewer 2026-05-21 — DEFAULT-BLOCK pattern (whitelist success rules + kv_resolved):
+Reviewer 2026-05-21 v3 — DEFAULT-BLOCK NO defensive escape.
 
-Pre-fix (commit 5 v1): block khi `requires_manual_override=True` + rule_applied
-∈ blacklist 6 codes. Sai hướng fail-closed: unknown future rule pass mặc định;
-`not_resolved` không có flag cũng pass.
+Pre-fix-up v1: blacklist block (block khi rule trong unresolved list) → unknown
+future rule + flag True pass sai hướng fail-closed.
 
-Post-fix (commit 5 v2): chỉ pass khi rule trong WHITELIST success
-{longest_duration, tiebreak_graduation_school, commune_lookup, manual_override}
-VÀ kv_resolved != None. Mọi case khác → block.
+Pre-fix-up v2: whitelist success + defensive escape empty/None pass. Vẫn fail-open
+khi freeze fail infra → snapshot stays empty/old + submit pass.
+
+Post-fix-up v3 (this): chỉ pass khi rule_applied ∈ {longest_duration,
+tiebreak_graduation_school, commune_lookup, manual_override} VÀ kv_resolved
+!= None. Empty/None snapshot, race state, unknown rule — TẤT CẢ block.
 
 Tests pin gate logic:
-  - 6 fail-closed rules block (address_not_normalized, catalog_gap_*, ...)
-  - manual_override với kv_resolved set → pass
-  - 3 happy paths (longest_duration, commune_lookup, ...) → pass
-  - Snapshot empty/None → pass defensive (engine T1 freeze fail infra)
-  - Default-block edge cases: unknown rule, kv_resolved None + success rule, etc.
+  - 6 unresolved rules → block
+  - manual_override + kv_resolved → pass
+  - 3 success rules với kv_resolved → pass
+  - Race: success rule + kv_resolved=None → block
+  - Race: unresolved rule + kv_resolved set → block
+  - Unknown future rule → block
+  - **Empty {} snapshot → block** (v3: NO defensive escape)
+  - **None snapshot → block** (v3: NO defensive escape)
 """
 from __future__ import annotations
 
@@ -140,15 +145,23 @@ def test_longest_duration_without_kv_resolved_blocks() -> None:
 # ===========================================================================
 
 
-def test_empty_snapshot_passes_defensive() -> None:
-    """Snapshot rỗng (vd engine T1 freeze fail do infra) → KHÔNG block submit.
-    Block path chỉ khi engine explicit signal unresolved; empty là failure
-    mode khác (đã log warning ở freeze try/except)."""
-    _assert_kv_resolved_for_submit({}, profile_id=1)
+def test_empty_snapshot_blocks_no_defensive_escape() -> None:
+    """v3 fix-up 2026-05-21: empty snapshot → BLOCK (KHÔNG defensive pass).
+    Freeze fail infra phải block submit, không pass-through. Freeze try/except
+    upstream giờ raise BadRequest('KV_RESOLUTION_FAILED') trực tiếp; nếu route
+    nào bỏ qua, guard này là defensive last-line block."""
+    with pytest.raises(BadRequest) as exc:
+        _assert_kv_resolved_for_submit({}, profile_id=1)
+    assert "KV_UNRESOLVED" in str(exc.value)
+    assert "no_snapshot_present" in str(exc.value)
 
 
-def test_none_snapshot_passes_defensive() -> None:
-    _assert_kv_resolved_for_submit(None, profile_id=1)
+def test_none_snapshot_blocks_no_defensive_escape() -> None:
+    """v3 fix-up — None snapshot cũng block (cùng lý do empty)."""
+    with pytest.raises(BadRequest) as exc:
+        _assert_kv_resolved_for_submit(None, profile_id=1)
+    assert "KV_UNRESOLVED" in str(exc.value)
+    assert "no_snapshot_present" in str(exc.value)
 
 
 # ===========================================================================

--- a/Backend_FastAPI/tests/unit/test_submit_kv_unresolved_guard.py
+++ b/Backend_FastAPI/tests/unit/test_submit_kv_unresolved_guard.py
@@ -1,0 +1,165 @@
+"""Unit tests for ``_assert_kv_resolved_for_submit`` (Phase E.4 commit 5 fix-up).
+
+Reviewer 2026-05-21: engine fail-closed signal (`address_not_normalized` /
+`catalog_gap_*` / `insufficient_data` / `ambiguous_requires_manual` /
+`not_resolved` + `requires_manual_override=True`) phải block submit; trước
+fix-up code chỉ log warning rồi vẫn cho submit qua (vi phạm nghiệp vụ #7).
+
+Tests pin gate logic:
+  - 6 unresolved rule_applied codes → raise BadRequest
+  - manual_override (admin pre-submit override) → pass
+  - happy paths (longest_duration, commune_lookup) → pass
+  - Snapshot empty/None → pass (defensive — không block khi engine chưa freeze)
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.admission_service import _assert_kv_resolved_for_submit
+from app.utils.exceptions import BadRequest
+
+
+pytestmark = pytest.mark.unit
+
+
+# ===========================================================================
+# 6 unresolved rule_applied codes → block
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "rule_applied,reason",
+    [
+        ("address_not_normalized", "profile_missing_permanent_commune_code"),
+        ("catalog_gap_commune", "commune_code_not_in_catalog"),
+        ("catalog_gap_school", "all_school_lookups_failed"),
+        ("insufficient_data", "no_qualifying_thpt_history_entries"),
+        ("ambiguous_requires_manual", "tied_graduation_year_and_grade"),
+        ("not_resolved", "cultural_not_set"),
+    ],
+)
+def test_blocks_when_unresolved_with_requires_manual_override(
+    rule_applied: str, reason: str,
+) -> None:
+    snapshot = {
+        "kv_resolved": None,
+        "rule_applied": rule_applied,
+        "reason": reason,
+        "requires_manual_override": True,
+    }
+    with pytest.raises(BadRequest) as exc:
+        _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+    assert "KV_UNRESOLVED" in str(exc.value)
+    assert rule_applied in str(exc.value)
+    assert reason in str(exc.value)
+
+
+# ===========================================================================
+# Manual override (admin pre-submit override KV) → pass
+# ===========================================================================
+
+
+def test_manual_override_passes() -> None:
+    """Admin/manager đã override KV trước submit → snapshot.kv_resolved set +
+    rule_applied='manual_override'. Submit phải pass."""
+    snapshot = {
+        "kv_resolved": "KV1",
+        "rule_applied": "manual_override",
+        "manual_override_reason": "Lớp tạo nguồn theo QĐ Bộ → KV1",
+        "manual_override_by": 42,
+        # MANUAL pathway từ engine cũng có requires_manual_override=False,
+        # nhưng admin override flow sét manual_override_reason → snapshot
+        # đại diện override hoàn tất.
+    }
+    # Should not raise
+    _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+
+
+def test_manual_override_with_requires_manual_override_false_passes() -> None:
+    """Engine MANUAL pathway (admin chưa override nhưng area_basis='manual_override'
+    được set, kv_resolved tồn tại). Không có requires_manual_override flag → pass."""
+    snapshot = {
+        "kv_resolved": "KV2",
+        "rule_applied": "manual_override",
+        "requires_manual_override": False,
+    }
+    _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+
+
+# ===========================================================================
+# Happy paths — engine resolve thành công
+# ===========================================================================
+
+
+def test_longest_duration_pass() -> None:
+    snapshot = {
+        "kv_resolved": "KV1",
+        "rule_applied": "longest_duration",
+        "basis": "LICH_SU_THPT",
+        # Happy path không có requires_manual_override flag
+    }
+    _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+
+
+def test_tiebreak_graduation_school_pass() -> None:
+    snapshot = {
+        "kv_resolved": "KV3",
+        "rule_applied": "tiebreak_graduation_school",
+        "basis": "LICH_SU_THPT",
+    }
+    _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+
+
+def test_commune_lookup_pass() -> None:
+    snapshot = {
+        "kv_resolved": "KV2-NT",
+        "rule_applied": "commune_lookup",
+        "basis": "THUONG_TRU",
+    }
+    _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+
+
+# ===========================================================================
+# Defensive: empty/None snapshot
+# ===========================================================================
+
+
+def test_empty_snapshot_passes_defensive() -> None:
+    """Snapshot rỗng (vd engine T1 freeze fail do infra) → KHÔNG block submit.
+    Block path chỉ khi engine explicit signal unresolved; empty là failure
+    mode khác (đã log warning ở freeze try/except)."""
+    _assert_kv_resolved_for_submit({}, profile_id=1)
+
+
+def test_none_snapshot_passes_defensive() -> None:
+    _assert_kv_resolved_for_submit(None, profile_id=1)
+
+
+# ===========================================================================
+# Edge: requires_manual_override=True nhưng rule_applied không match list
+# ===========================================================================
+
+
+def test_unknown_rule_with_manual_override_flag_passes_defensive() -> None:
+    """Defensive: rule_applied future-added chưa có trong unresolved list →
+    KHÔNG block (whitelist-based block, không blacklist). Avoid false-positive
+    block khi engine evolves."""
+    snapshot = {
+        "kv_resolved": "KV1",  # Có giá trị
+        "rule_applied": "future_new_rule",
+        "requires_manual_override": True,  # Engine flag (vẫn warn FE) nhưng
+        # block list không match → pass.
+    }
+    _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+
+
+def test_unresolved_rule_without_requires_manual_override_passes() -> None:
+    """Defensive: rule_applied match unresolved list NHƯNG không có flag
+    requires_manual_override → pass (treat as informational, not blocking).
+    Combination này không tự nhiên xảy ra từ engine nhưng phòng race."""
+    snapshot = {
+        "kv_resolved": "KV1",
+        "rule_applied": "address_not_normalized",
+        # requires_manual_override missing
+    }
+    _assert_kv_resolved_for_submit(snapshot, profile_id=1)

--- a/Backend_FastAPI/tests/unit/test_submit_kv_unresolved_guard.py
+++ b/Backend_FastAPI/tests/unit/test_submit_kv_unresolved_guard.py
@@ -1,15 +1,21 @@
 """Unit tests for ``_assert_kv_resolved_for_submit`` (Phase E.4 commit 5 fix-up).
 
-Reviewer 2026-05-21: engine fail-closed signal (`address_not_normalized` /
-`catalog_gap_*` / `insufficient_data` / `ambiguous_requires_manual` /
-`not_resolved` + `requires_manual_override=True`) phải block submit; trước
-fix-up code chỉ log warning rồi vẫn cho submit qua (vi phạm nghiệp vụ #7).
+Reviewer 2026-05-21 — DEFAULT-BLOCK pattern (whitelist success rules + kv_resolved):
+
+Pre-fix (commit 5 v1): block khi `requires_manual_override=True` + rule_applied
+∈ blacklist 6 codes. Sai hướng fail-closed: unknown future rule pass mặc định;
+`not_resolved` không có flag cũng pass.
+
+Post-fix (commit 5 v2): chỉ pass khi rule trong WHITELIST success
+{longest_duration, tiebreak_graduation_school, commune_lookup, manual_override}
+VÀ kv_resolved != None. Mọi case khác → block.
 
 Tests pin gate logic:
-  - 6 unresolved rule_applied codes → raise BadRequest
-  - manual_override (admin pre-submit override) → pass
-  - happy paths (longest_duration, commune_lookup) → pass
-  - Snapshot empty/None → pass (defensive — không block khi engine chưa freeze)
+  - 6 fail-closed rules block (address_not_normalized, catalog_gap_*, ...)
+  - manual_override với kv_resolved set → pass
+  - 3 happy paths (longest_duration, commune_lookup, ...) → pass
+  - Snapshot empty/None → pass defensive (engine T1 freeze fail infra)
+  - Default-block edge cases: unknown rule, kv_resolved None + success rule, etc.
 """
 from __future__ import annotations
 
@@ -59,7 +65,7 @@ def test_blocks_when_unresolved_with_requires_manual_override(
 # ===========================================================================
 
 
-def test_manual_override_passes() -> None:
+def test_manual_override_with_kv_resolved_passes() -> None:
     """Admin/manager đã override KV trước submit → snapshot.kv_resolved set +
     rule_applied='manual_override'. Submit phải pass."""
     snapshot = {
@@ -67,23 +73,22 @@ def test_manual_override_passes() -> None:
         "rule_applied": "manual_override",
         "manual_override_reason": "Lớp tạo nguồn theo QĐ Bộ → KV1",
         "manual_override_by": 42,
-        # MANUAL pathway từ engine cũng có requires_manual_override=False,
-        # nhưng admin override flow sét manual_override_reason → snapshot
-        # đại diện override hoàn tất.
     }
-    # Should not raise
     _assert_kv_resolved_for_submit(snapshot, profile_id=1)
 
 
-def test_manual_override_with_requires_manual_override_false_passes() -> None:
-    """Engine MANUAL pathway (admin chưa override nhưng area_basis='manual_override'
-    được set, kv_resolved tồn tại). Không có requires_manual_override flag → pass."""
+def test_manual_override_without_kv_resolved_blocks() -> None:
+    """Engine MANUAL pathway emit khi area_basis='manual_override' nhưng admin
+    chưa thực sự override KV → kv_resolved=None + rule_applied='manual_override'.
+    Fail-closed: block vì không có giá trị KV thực."""
     snapshot = {
-        "kv_resolved": "KV2",
+        "kv_resolved": None,
         "rule_applied": "manual_override",
         "requires_manual_override": False,
     }
-    _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+    with pytest.raises(BadRequest) as exc:
+        _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+    assert "KV_UNRESOLVED" in str(exc.value)
 
 
 # ===========================================================================
@@ -91,17 +96,16 @@ def test_manual_override_with_requires_manual_override_false_passes() -> None:
 # ===========================================================================
 
 
-def test_longest_duration_pass() -> None:
+def test_longest_duration_with_kv_resolved_passes() -> None:
     snapshot = {
         "kv_resolved": "KV1",
         "rule_applied": "longest_duration",
         "basis": "LICH_SU_THPT",
-        # Happy path không có requires_manual_override flag
     }
     _assert_kv_resolved_for_submit(snapshot, profile_id=1)
 
 
-def test_tiebreak_graduation_school_pass() -> None:
+def test_tiebreak_graduation_school_with_kv_resolved_passes() -> None:
     snapshot = {
         "kv_resolved": "KV3",
         "rule_applied": "tiebreak_graduation_school",
@@ -110,13 +114,25 @@ def test_tiebreak_graduation_school_pass() -> None:
     _assert_kv_resolved_for_submit(snapshot, profile_id=1)
 
 
-def test_commune_lookup_pass() -> None:
+def test_commune_lookup_with_kv_resolved_passes() -> None:
     snapshot = {
         "kv_resolved": "KV2-NT",
         "rule_applied": "commune_lookup",
         "basis": "THUONG_TRU",
     }
     _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+
+
+def test_longest_duration_without_kv_resolved_blocks() -> None:
+    """Defensive: rule success nhưng kv_resolved=None — fail-closed block."""
+    snapshot = {
+        "kv_resolved": None,
+        "rule_applied": "longest_duration",
+        "basis": "LICH_SU_THPT",
+    }
+    with pytest.raises(BadRequest) as exc:
+        _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+    assert "KV_UNRESOLVED" in str(exc.value)
 
 
 # ===========================================================================
@@ -140,26 +156,43 @@ def test_none_snapshot_passes_defensive() -> None:
 # ===========================================================================
 
 
-def test_unknown_rule_with_manual_override_flag_passes_defensive() -> None:
-    """Defensive: rule_applied future-added chưa có trong unresolved list →
-    KHÔNG block (whitelist-based block, không blacklist). Avoid false-positive
-    block khi engine evolves."""
+def test_unknown_rule_blocks_default_fail_closed() -> None:
+    """Reviewer P1 2026-05-21 fix-up — DEFAULT BLOCK fail-closed: rule_applied
+    không trong success whitelist → block, kể cả không có flag
+    requires_manual_override. Pre-fix-up code pass (blacklist) — flip now."""
     snapshot = {
-        "kv_resolved": "KV1",  # Có giá trị
+        "kv_resolved": "KV1",
         "rule_applied": "future_new_rule",
-        "requires_manual_override": True,  # Engine flag (vẫn warn FE) nhưng
-        # block list không match → pass.
+        # Không có requires_manual_override flag
     }
-    _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+    with pytest.raises(BadRequest) as exc:
+        _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+    assert "KV_UNRESOLVED" in str(exc.value)
 
 
-def test_unresolved_rule_without_requires_manual_override_passes() -> None:
-    """Defensive: rule_applied match unresolved list NHƯNG không có flag
-    requires_manual_override → pass (treat as informational, not blocking).
-    Combination này không tự nhiên xảy ra từ engine nhưng phòng race."""
+def test_not_resolved_without_flag_blocks() -> None:
+    """Reviewer P1 fix-up: rule_applied=not_resolved BLOCK kể cả không có flag
+    requires_manual_override. Pre-fix-up: pass khi flag false → vi phạm fail-closed."""
+    snapshot = {
+        "kv_resolved": None,
+        "rule_applied": "not_resolved",
+        "reason": "cultural_not_set",
+        # requires_manual_override KHÔNG có (engine emit False khi NOT_RESOLVED)
+    }
+    with pytest.raises(BadRequest) as exc:
+        _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+    assert "KV_UNRESOLVED" in str(exc.value)
+
+
+def test_address_not_normalized_with_kv_resolved_set_still_blocks() -> None:
+    """Edge: rule_applied = address_not_normalized nhưng kv_resolved có giá trị
+    (race state không tự nhiên xảy ra). Fail-closed: chỉ rule success whitelist
+    + kv_resolved set mới pass; address_not_normalized không trong list → block."""
     snapshot = {
         "kv_resolved": "KV1",
         "rule_applied": "address_not_normalized",
-        # requires_manual_override missing
+        # Force-set kv (race) — vẫn fail vì rule sai
     }
-    _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+    with pytest.raises(BadRequest) as exc:
+        _assert_kv_resolved_for_submit(snapshot, profile_id=1)
+    assert "KV_UNRESOLVED" in str(exc.value)

--- a/Backend_FastAPI/tests/unit/test_submit_override_draft_workflow.py
+++ b/Backend_FastAPI/tests/unit/test_submit_override_draft_workflow.py
@@ -1,0 +1,204 @@
+"""Regression test cho full workflow:
+   submit unresolved → snapshot persists with signal → override draft succeeds.
+
+Reviewer P0 2026-05-21 v4 — deadlock identification:
+   1. Officer submit draft → freeze runs → snapshot stays in object (in-memory)
+   2. ``_assert_kv_resolved_for_submit`` raise ``BadRequest`` (pre-fix-up v4)
+   3. Router ``admissions.py`` chỉ commit success path
+   4. ``except BadRequest`` raise HTTP 400, KHÔNG commit
+   5. Snapshot unresolved bị rollback / never persists
+   6. Manager/admin go to override draft → ``override_kv()`` reads
+      ``profile.priority_resolution_snapshot.requires_manual_override`` → False
+      (snapshot không persist) → refuse
+
+Fix v4: submit returns ``(result_dict, None)`` với ``status='draft'`` +
+``validation_errors`` thay vì raise. ``db.flush()`` trong errors branch persist
+snapshot. Router commit → snapshot lưu vào DB → override draft thấy signal.
+
+Pure-logic regression test (KHÔNG cần real DB):
+  - Helper ``_kv_unresolved_error_message()`` trả message non-None
+  - Helper ``override_kv()`` draft + snapshot signal → allow
+  - End-to-end: snapshot trước submit + signal-after-submit match
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.admission_service import _kv_unresolved_error_message
+from app.services.priority_override_service import override_kv
+
+
+pytestmark = pytest.mark.unit
+
+
+# ===========================================================================
+# Workflow test — submit unresolved leaves signal, override draft picks it up
+# ===========================================================================
+
+
+def _make_actor(role: str = "manager", user_id: int = 7):
+    return SimpleNamespace(id=user_id, role=role, full_name=f"Test {role}")
+
+
+async def test_submit_then_override_draft_no_deadlock() -> None:
+    """End-to-end: submit unresolved emits snapshot signal, override_kv on
+    draft consumes signal and succeeds."""
+    # Step 1: Simulate submit produces snapshot với engine fail-closed signal
+    # (vd address_not_normalized cho THUONG_TRU + missing commune_code).
+    submit_snapshot = {
+        "kv_resolved": None,
+        "rule_applied": "address_not_normalized",
+        "pathway": "thuong_tru",
+        "basis": "THUONG_TRU",
+        "basis_reason": "tc_chinh_quy_post_thcs_uses_commune",
+        "requires_manual_override": True,
+        "reason": "profile_missing_permanent_commune_code",
+        "frozen_at": "2026-05-21T03:00:00+00:00",
+        "frozen_at_status": "submitted_T1",
+        "resolved_by": "system",
+        "target_level": "trung_cap",
+        "admission_type": "chinh_quy",
+    }
+
+    # Submit helper trả error message (KHÔNG raise) cho submit append vào
+    # validation_errors. Snapshot stays in profile, sẽ flush+commit ở router.
+    submit_error = _kv_unresolved_error_message(submit_snapshot, profile_id=1)
+    assert submit_error is not None
+    assert "KV_UNRESOLVED" in submit_error
+    assert "address_not_normalized" in submit_error
+
+    # Step 2: Router commit → snapshot persists vào DB (simulated bằng cách
+    # gán snapshot vào profile object — KV ngữ nghĩa: snapshot persisted).
+    profile_after_submit = SimpleNamespace(
+        id=1,
+        lead_id=100,
+        status="draft",  # Submit returns status=draft (errors flow)
+        version=5,
+        priority_resolution_snapshot=submit_snapshot,  # PERSISTED — signal có
+        area_resolution_basis="school_history",
+    )
+
+    # Step 3: Manager attempts override_kv on draft profile.
+    # Gate check: status="draft" + role="manager" + snapshot signal True → allow.
+    actor = _make_actor(role="manager")
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock())
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+
+    updated_profile, callback = await override_kv(
+        db,
+        profile_after_submit,
+        kv_resolved="KV2-NT",
+        reason="Lớp tạo nguồn theo QĐ Bộ → KV2-NT (override draft sau submit fail)",
+        evidence_file_id=None,
+        actor=actor,
+        expected_version=5,
+    )
+
+    # Verify override succeeded — snapshot overwritten với manual_override.
+    new_snap = updated_profile.priority_resolution_snapshot
+    assert new_snap["kv_resolved"] == "KV2-NT"
+    assert new_snap["rule_applied"] == "manual_override"
+    assert new_snap["manual_override_by"] == actor.id
+    assert "Lớp tạo nguồn" in new_snap["manual_override_reason"]
+    # Engine signal dropped post-override (deadlock state cleared)
+    assert "requires_manual_override" not in new_snap
+
+    # Step 4: Officer re-submit. Snapshot rule_applied="manual_override" +
+    # kv_resolved="KV2-NT" → success whitelist + kv_resolved set → submit pass.
+    resubmit_error = _kv_unresolved_error_message(new_snap, profile_id=1)
+    assert resubmit_error is None  # Pass — no error
+
+
+async def test_admin_can_also_override_draft_after_submit_unresolved() -> None:
+    """Verify admin role cũng được override draft (mirror manager case)."""
+    submit_snapshot = {
+        "kv_resolved": None,
+        "rule_applied": "catalog_gap_school",
+        "requires_manual_override": True,
+        "reason": "all_school_lookups_failed",
+    }
+    profile = SimpleNamespace(
+        id=2, lead_id=101, status="draft", version=3,
+        priority_resolution_snapshot=submit_snapshot,
+        area_resolution_basis="school_history",
+    )
+    actor = _make_actor(role="admin")
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock())
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+
+    updated, _cb = await override_kv(
+        db, profile,
+        kv_resolved="KV1",
+        reason="THPT trong catalog gap; xác minh thủ công bằng giấy → KV1",
+        evidence_file_id=None,
+        actor=actor,
+        expected_version=3,
+    )
+    assert updated.priority_resolution_snapshot["kv_resolved"] == "KV1"
+    assert updated.priority_resolution_snapshot["rule_applied"] == "manual_override"
+
+
+async def test_officer_still_blocked_from_draft_override() -> None:
+    """Officer KHÔNG bypass deadlock — phải nhờ manager/admin (đúng nghiệp vụ #10)."""
+    from app.utils.exceptions import BusinessRuleViolation
+
+    submit_snapshot = {
+        "kv_resolved": None,
+        "rule_applied": "address_not_normalized",
+        "requires_manual_override": True,
+    }
+    profile = SimpleNamespace(
+        id=3, lead_id=102, status="draft", version=4,
+        priority_resolution_snapshot=submit_snapshot,
+        area_resolution_basis="school_history",
+    )
+    officer = _make_actor(role="officer")
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock())
+
+    with pytest.raises(BusinessRuleViolation, match="Officer không được override"):
+        await override_kv(
+            db, profile,
+            kv_resolved="KV1",
+            reason="Officer trying to override — should be refused per nghiệp vụ #10",
+            evidence_file_id=None,
+            actor=officer,
+            expected_version=4,
+        )
+
+
+async def test_manager_cannot_override_draft_without_engine_signal() -> None:
+    """Manager cũng KHÔNG bypass khi snapshot không có signal — engine resolve OK
+    nhưng manager muốn override draft → refuse (avoid free-form override)."""
+    from app.utils.exceptions import BusinessRuleViolation
+
+    happy_snapshot = {
+        "kv_resolved": "KV1",
+        "rule_applied": "longest_duration",
+        # KHÔNG có requires_manual_override
+    }
+    profile = SimpleNamespace(
+        id=4, lead_id=103, status="draft", version=2,
+        priority_resolution_snapshot=happy_snapshot,
+        area_resolution_basis="school_history",
+    )
+    actor = _make_actor(role="manager")
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=MagicMock())
+
+    with pytest.raises(BusinessRuleViolation, match="draft chỉ được override"):
+        await override_kv(
+            db, profile,
+            kv_resolved="KV2",
+            reason="Manager wants to override even though engine resolved fine",
+            evidence_file_id=None,
+            actor=actor,
+            expected_version=2,
+        )

--- a/Backend_FastAPI/tests/unit/test_submit_override_draft_workflow.py
+++ b/Backend_FastAPI/tests/unit/test_submit_override_draft_workflow.py
@@ -43,11 +43,41 @@ def _make_actor(role: str = "manager", user_id: int = 7):
     return SimpleNamespace(id=user_id, role=role, full_name=f"Test {role}")
 
 
-async def test_submit_then_override_draft_no_deadlock() -> None:
+# Phase E.4 v5 — draft override now uses LIVE recompute. Tests need patches.
+async def _fake_derive_ctx(profile_arg, db_arg):
+    return {
+        "target_level": "trung_cap",
+        "admission_type": "chinh_quy",
+        "eligibility": {"passed": True, "reason": None},
+        "path_bonus_rule": None,
+        "source": "test_stub",
+    }
+
+
+def _fake_resolve_factory(returns_unresolved: bool, rule: str = "address_not_normalized"):
+    async def _fake_resolve(profile_arg, db_arg, target_level=None, admission_type=None):
+        if returns_unresolved:
+            return None, {
+                "rule_applied": rule,
+                "pathway": "thuong_tru",
+                "basis": "THUONG_TRU",
+                "basis_reason": "tc_chinh_quy_post_thcs_uses_commune",
+                "requires_manual_override": True,
+                "reason": "profile_missing_permanent_commune_code",
+            }
+        return "KV1", {
+            "rule_applied": "commune_lookup",
+            "pathway": "thuong_tru",
+            "basis": "THUONG_TRU",
+            "basis_reason": "tc_chinh_quy_post_thcs_uses_commune",
+            "breakdown": {"commune_code_used": "66_22255"},
+        }
+    return _fake_resolve
+
+
+async def test_submit_then_override_draft_no_deadlock(monkeypatch) -> None:
     """End-to-end: submit unresolved emits snapshot signal, override_kv on
-    draft consumes signal and succeeds."""
-    # Step 1: Simulate submit produces snapshot với engine fail-closed signal
-    # (vd address_not_normalized cho THUONG_TRU + missing commune_code).
+    draft consumes signal AND verifies live engine still unresolved → allow."""
     submit_snapshot = {
         "kv_resolved": None,
         "rule_applied": "address_not_normalized",
@@ -63,31 +93,33 @@ async def test_submit_then_override_draft_no_deadlock() -> None:
         "admission_type": "chinh_quy",
     }
 
-    # Submit helper trả error message (KHÔNG raise) cho submit append vào
-    # validation_errors. Snapshot stays in profile, sẽ flush+commit ở router.
     submit_error = _kv_unresolved_error_message(submit_snapshot, profile_id=1)
     assert submit_error is not None
     assert "KV_UNRESOLVED" in submit_error
     assert "address_not_normalized" in submit_error
 
-    # Step 2: Router commit → snapshot persists vào DB (simulated bằng cách
-    # gán snapshot vào profile object — KV ngữ nghĩa: snapshot persisted).
     profile_after_submit = SimpleNamespace(
         id=1,
         lead_id=100,
-        status="draft",  # Submit returns status=draft (errors flow)
+        status="draft",
         version=5,
-        priority_resolution_snapshot=submit_snapshot,  # PERSISTED — signal có
+        priority_resolution_snapshot=submit_snapshot,
         area_resolution_basis="school_history",
     )
 
-    # Step 3: Manager attempts override_kv on draft profile.
-    # Gate check: status="draft" + role="manager" + snapshot signal True → allow.
     actor = _make_actor(role="manager")
     db = MagicMock()
     db.execute = AsyncMock(return_value=MagicMock())
     db.add = MagicMock()
     db.flush = AsyncMock()
+
+    # Phase E.4 v5: patch live recompute → vẫn unresolved (officer chưa fix data).
+    import app.services.priority_service as priority_module
+    monkeypatch.setattr(priority_module, "derive_profile_target_context", _fake_derive_ctx)
+    monkeypatch.setattr(
+        priority_module, "resolve_kv_for_profile",
+        _fake_resolve_factory(returns_unresolved=True),
+    )
 
     updated_profile, callback = await override_kv(
         db,
@@ -99,22 +131,18 @@ async def test_submit_then_override_draft_no_deadlock() -> None:
         expected_version=5,
     )
 
-    # Verify override succeeded — snapshot overwritten với manual_override.
     new_snap = updated_profile.priority_resolution_snapshot
     assert new_snap["kv_resolved"] == "KV2-NT"
     assert new_snap["rule_applied"] == "manual_override"
     assert new_snap["manual_override_by"] == actor.id
     assert "Lớp tạo nguồn" in new_snap["manual_override_reason"]
-    # Engine signal dropped post-override (deadlock state cleared)
     assert "requires_manual_override" not in new_snap
 
-    # Step 4: Officer re-submit. Snapshot rule_applied="manual_override" +
-    # kv_resolved="KV2-NT" → success whitelist + kv_resolved set → submit pass.
     resubmit_error = _kv_unresolved_error_message(new_snap, profile_id=1)
-    assert resubmit_error is None  # Pass — no error
+    assert resubmit_error is None
 
 
-async def test_admin_can_also_override_draft_after_submit_unresolved() -> None:
+async def test_admin_can_also_override_draft_after_submit_unresolved(monkeypatch) -> None:
     """Verify admin role cũng được override draft (mirror manager case)."""
     submit_snapshot = {
         "kv_resolved": None,
@@ -133,6 +161,14 @@ async def test_admin_can_also_override_draft_after_submit_unresolved() -> None:
     db.add = MagicMock()
     db.flush = AsyncMock()
 
+    # Patch live recompute return unresolved (catalog gap chưa khắc phục được)
+    import app.services.priority_service as priority_module
+    monkeypatch.setattr(priority_module, "derive_profile_target_context", _fake_derive_ctx)
+    monkeypatch.setattr(
+        priority_module, "resolve_kv_for_profile",
+        _fake_resolve_factory(returns_unresolved=True, rule="catalog_gap_school"),
+    )
+
     updated, _cb = await override_kv(
         db, profile,
         kv_resolved="KV1",
@@ -146,7 +182,10 @@ async def test_admin_can_also_override_draft_after_submit_unresolved() -> None:
 
 
 async def test_officer_still_blocked_from_draft_override() -> None:
-    """Officer KHÔNG bypass deadlock — phải nhờ manager/admin (đúng nghiệp vụ #10)."""
+    """Officer KHÔNG bypass deadlock — phải nhờ manager/admin (đúng nghiệp vụ #10).
+
+    Officer guard chạy TRƯỚC live recompute → KHÔNG cần patch resolve_kv_for_profile.
+    """
     from app.utils.exceptions import BusinessRuleViolation
 
     submit_snapshot = {
@@ -174,31 +213,47 @@ async def test_officer_still_blocked_from_draft_override() -> None:
         )
 
 
-async def test_manager_cannot_override_draft_without_engine_signal() -> None:
-    """Manager cũng KHÔNG bypass khi snapshot không có signal — engine resolve OK
-    nhưng manager muốn override draft → refuse (avoid free-form override)."""
+async def test_manager_cannot_override_draft_when_engine_recompute_resolves_live(
+    monkeypatch,
+) -> None:
+    """v5: Live engine recompute resolve OK → refuse (engine có đường tự xử).
+
+    Test này cover bug stale signal: snapshot stale có thể từng có signal,
+    nhưng nếu live engine resolve OK với dữ liệu hiện tại, override refused.
+    """
     from app.utils.exceptions import BusinessRuleViolation
 
-    happy_snapshot = {
-        "kv_resolved": "KV1",
-        "rule_applied": "longest_duration",
-        # KHÔNG có requires_manual_override
+    # Snapshot ban đầu có signal (vd: submit cũ thiếu commune)
+    stale_snapshot = {
+        "kv_resolved": None,
+        "rule_applied": "address_not_normalized",
+        "requires_manual_override": True,
     }
     profile = SimpleNamespace(
         id=4, lead_id=103, status="draft", version=2,
-        priority_resolution_snapshot=happy_snapshot,
+        priority_resolution_snapshot=stale_snapshot,
         area_resolution_basis="school_history",
     )
     actor = _make_actor(role="manager")
     db = MagicMock()
     db.execute = AsyncMock(return_value=MagicMock())
 
-    with pytest.raises(BusinessRuleViolation, match="draft chỉ được override"):
+    # Officer đã sửa data (commune_code=66_22255, etc) → live recompute resolve OK
+    import app.services.priority_service as priority_module
+    monkeypatch.setattr(priority_module, "derive_profile_target_context", _fake_derive_ctx)
+    monkeypatch.setattr(
+        priority_module, "resolve_kv_for_profile",
+        _fake_resolve_factory(returns_unresolved=False),  # Engine giờ resolve OK
+    )
+
+    with pytest.raises(BusinessRuleViolation, match="Engine vừa tính lại và resolve thành công"):
         await override_kv(
             db, profile,
             kv_resolved="KV2",
-            reason="Manager wants to override even though engine resolved fine",
+            reason="Manager wants to override after officer fixed data; engine giờ OK",
             evidence_file_id=None,
             actor=actor,
             expected_version=2,
         )
+    # Snapshot KHÔNG bị mutate
+    assert profile.priority_resolution_snapshot == stale_snapshot

--- a/Backend_FastAPI/tests/unit/test_validate_eligibility_all_choices.py
+++ b/Backend_FastAPI/tests/unit/test_validate_eligibility_all_choices.py
@@ -1,0 +1,307 @@
+"""Unit tests for ``_validate_eligibility_all_choices`` (Phase E.4 reviewer P0 fix).
+
+Reviewer 2026-05-21 đã chỉ ra: gate eligibility nằm trong nhánh
+``if profile.uses_choice_engine`` → 9/11 dev profile legacy single-path
+bypass. Fix: gate chạy unconditional sau status draft check; helper xử lý
+cả 2 flow.
+
+Tests verify:
+  - multi-NV (uses_choice_engine=True): loop choices, validate per choice
+  - legacy single-path (uses_choice_engine=False): derive từ
+    offering_admission_config_id, validate 1 chain
+  - Cả 2 raise BusinessRuleViolation với reason rõ ràng khi fail
+  - Cả 2 raise CONFIG_GAP_TARGET_LEVEL khi missing config
+
+Mock pattern: AsyncMock cho db.execute dispatching theo statement target.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.admission_service import _validate_eligibility_all_choices
+from app.utils.exceptions import BusinessRuleViolation
+
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _make_path(degree_code: str, offering_code: str):
+    """Build AdmissionPath stub với eager chain shape mà derive_target_level_and_type
+    đọc qua __dict__."""
+    degree_obj = SimpleNamespace(code=degree_code) if degree_code else None
+    program = SimpleNamespace()
+    program.__dict__["degree_level_ref"] = degree_obj
+
+    offering_type_obj = SimpleNamespace(code=offering_code) if offering_code else None
+    offering = SimpleNamespace()
+    offering.__dict__["program"] = program
+    offering.__dict__["offering_type_config"] = offering_type_obj
+
+    academic_info = SimpleNamespace()
+    academic_info.__dict__["offering"] = offering
+
+    path = SimpleNamespace()
+    path.__dict__["academic_info"] = academic_info
+    return path
+
+
+def _profile(
+    cultural: str | None,
+    vocational: str = "none",
+    uses_choice_engine: bool = True,
+    offering_admission_config_id: int | None = None,
+):
+    return SimpleNamespace(
+        id=1,
+        cultural_education_level=cultural,
+        vocational_qualification=vocational,
+        uses_choice_engine=uses_choice_engine,
+        offering_admission_config_id=offering_admission_config_id,
+    )
+
+
+def _make_db_multi_nv(choices: list[SimpleNamespace]):
+    """Mock db that returns choices for the multi-NV branch query."""
+    scalars_result = MagicMock()
+    scalars_result.all = MagicMock(return_value=choices)
+
+    result = MagicMock()
+    result.scalars = MagicMock(return_value=scalars_result)
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+def _make_db_legacy(config_stub: SimpleNamespace | None):
+    """Mock db that returns single OfferingAdmissionConfig stub for legacy branch."""
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=config_stub)
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+# ===========================================================================
+# multi-NV branch — pass + fail cases
+# ===========================================================================
+
+
+async def test_multi_nv_all_choices_pass() -> None:
+    profile = _profile(cultural="graduated_thpt", uses_choice_engine=True)
+    choices = [
+        SimpleNamespace(
+            admission_path=_make_path("cao_dang", "chinh_quy"),
+            display_order=1,
+        ),
+        SimpleNamespace(
+            admission_path=_make_path("trung_cap", "chinh_quy"),
+            display_order=2,
+        ),
+    ]
+    db = _make_db_multi_nv(choices)
+
+    # Should not raise
+    await _validate_eligibility_all_choices(db, profile)
+
+
+async def test_multi_nv_one_choice_fails_blocks_submit() -> None:
+    # cultural=graduated_thcs → CĐ chính quy fail, TC chính quy pass.
+    # Helper phải raise vì có ít nhất 1 choice fail.
+    profile = _profile(cultural="graduated_thcs", uses_choice_engine=True)
+    choices = [
+        SimpleNamespace(
+            admission_path=_make_path("cao_dang", "chinh_quy"),
+            display_order=1,
+        ),
+        SimpleNamespace(
+            admission_path=_make_path("trung_cap", "chinh_quy"),
+            display_order=2,
+        ),
+    ]
+    db = _make_db_multi_nv(choices)
+
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await _validate_eligibility_all_choices(db, profile)
+    assert "ELIGIBILITY_FAIL" in str(exc.value)
+    assert "NV1" in str(exc.value)
+    assert "cao_dang" in str(exc.value)
+
+
+async def test_multi_nv_config_gap_blocks() -> None:
+    # Path thiếu degree_level_ref → helper raise CONFIG_GAP_TARGET_LEVEL
+    profile = _profile(cultural="graduated_thpt", uses_choice_engine=True)
+    choices = [
+        SimpleNamespace(
+            admission_path=_make_path(None, "chinh_quy"),  # missing degree
+            display_order=1,
+        ),
+    ]
+    db = _make_db_multi_nv(choices)
+
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await _validate_eligibility_all_choices(db, profile)
+    assert "CONFIG_GAP_TARGET_LEVEL" in str(exc.value)
+
+
+# ===========================================================================
+# Legacy non-multi-NV branch (uses_choice_engine=False)
+# ===========================================================================
+
+
+async def test_legacy_no_config_id_raises_config_gap() -> None:
+    # Reviewer P0 finding: legacy profile chưa có offering_admission_config_id
+    # phải block CONFIG_GAP_TARGET_LEVEL (fail-closed, KHÔNG fallback SC).
+    profile = _profile(
+        cultural="graduated_thpt",
+        uses_choice_engine=False,
+        offering_admission_config_id=None,
+    )
+    db = _make_db_legacy(config_stub=None)
+
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await _validate_eligibility_all_choices(db, profile)
+    assert "CONFIG_GAP_TARGET_LEVEL" in str(exc.value)
+
+
+async def test_legacy_config_id_missing_in_db_raises() -> None:
+    profile = _profile(
+        cultural="graduated_thpt",
+        uses_choice_engine=False,
+        offering_admission_config_id=999,
+    )
+    db = _make_db_legacy(config_stub=None)  # query returns None
+
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await _validate_eligibility_all_choices(db, profile)
+    assert "CONFIG_GAP_TARGET_LEVEL" in str(exc.value)
+    assert "999" in str(exc.value)
+
+
+async def test_legacy_cd_chinh_quy_graduated_thcs_blocks() -> None:
+    # Reviewer regression: CD chính quy + cultural=graduated_thcs → block
+    profile = _profile(
+        cultural="graduated_thcs",
+        uses_choice_engine=False,
+        offering_admission_config_id=42,
+    )
+    # OfferingAdmissionConfig chain: academic_info → offering → program/offering_type
+    path = _make_path("cao_dang", "chinh_quy")
+    config_stub = SimpleNamespace()
+    config_stub.academic_info = path.__dict__["academic_info"]
+    db = _make_db_legacy(config_stub=config_stub)
+
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await _validate_eligibility_all_choices(db, profile)
+    assert "ELIGIBILITY_FAIL" in str(exc.value)
+    assert "Legacy single-path" in str(exc.value)
+    assert "cao_dang" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "cultural",
+    ["completed_thpt", "graduated_thpt", "graduated_gdtx"],
+)
+async def test_legacy_cd_chinh_quy_thpt_knowledge_passes(cultural: str) -> None:
+    # Reviewer regression: CD chính quy + cultural=completed_thpt/graduated_thpt
+    # → pass (nghiệp vụ #5: "TN_THPT hoặc HOAN_THANH_THPT").
+    profile = _profile(
+        cultural=cultural,
+        uses_choice_engine=False,
+        offering_admission_config_id=42,
+    )
+    path = _make_path("cao_dang", "chinh_quy")
+    config_stub = SimpleNamespace()
+    config_stub.academic_info = path.__dict__["academic_info"]
+    db = _make_db_legacy(config_stub=config_stub)
+
+    # Should not raise
+    await _validate_eligibility_all_choices(db, profile)
+
+
+async def test_legacy_tc_chinh_quy_graduated_thcs_passes() -> None:
+    profile = _profile(
+        cultural="graduated_thcs",
+        uses_choice_engine=False,
+        offering_admission_config_id=42,
+    )
+    path = _make_path("trung_cap", "chinh_quy")
+    config_stub = SimpleNamespace()
+    config_stub.academic_info = path.__dict__["academic_info"]
+    db = _make_db_legacy(config_stub=config_stub)
+
+    await _validate_eligibility_all_choices(db, profile)
+
+
+async def test_legacy_tc_chinh_quy_completed_thcs_blocks() -> None:
+    profile = _profile(
+        cultural="completed_thcs",
+        uses_choice_engine=False,
+        offering_admission_config_id=42,
+    )
+    path = _make_path("trung_cap", "chinh_quy")
+    config_stub = SimpleNamespace()
+    config_stub.academic_info = path.__dict__["academic_info"]
+    db = _make_db_legacy(config_stub=config_stub)
+
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await _validate_eligibility_all_choices(db, profile)
+    assert "ELIGIBILITY_FAIL" in str(exc.value)
+    assert "trung_cap" in str(exc.value)
+
+
+async def test_legacy_sc_chinh_quy_no_cultural_passes() -> None:
+    profile = _profile(
+        cultural=None,  # SC không yêu cầu văn hóa
+        uses_choice_engine=False,
+        offering_admission_config_id=42,
+    )
+    path = _make_path("so_cap", "chinh_quy")
+    config_stub = SimpleNamespace()
+    config_stub.academic_info = path.__dict__["academic_info"]
+    db = _make_db_legacy(config_stub=config_stub)
+
+    await _validate_eligibility_all_choices(db, profile)
+
+
+async def test_legacy_cd_lien_thong_requires_vocational() -> None:
+    # CĐ liên thông + graduated_thpt + vocational=none → block (cần TC/CĐ)
+    profile = _profile(
+        cultural="graduated_thpt",
+        vocational="none",
+        uses_choice_engine=False,
+        offering_admission_config_id=42,
+    )
+    path = _make_path("cao_dang", "lien_thong")
+    config_stub = SimpleNamespace()
+    config_stub.academic_info = path.__dict__["academic_info"]
+    db = _make_db_legacy(config_stub=config_stub)
+
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await _validate_eligibility_all_choices(db, profile)
+    assert "ELIGIBILITY_FAIL" in str(exc.value)
+    assert "lien_thong" in str(exc.value)
+
+
+async def test_legacy_cd_lien_thong_with_trung_cap_passes() -> None:
+    profile = _profile(
+        cultural="graduated_thpt",
+        vocational="trung_cap",
+        uses_choice_engine=False,
+        offering_admission_config_id=42,
+    )
+    path = _make_path("cao_dang", "lien_thong")
+    config_stub = SimpleNamespace()
+    config_stub.academic_info = path.__dict__["academic_info"]
+    db = _make_db_legacy(config_stub=config_stub)
+
+    await _validate_eligibility_all_choices(db, profile)

--- a/Backend_FastAPI/tests/unit/test_validate_eligibility_all_choices.py
+++ b/Backend_FastAPI/tests/unit/test_validate_eligibility_all_choices.py
@@ -96,7 +96,8 @@ def _make_db_legacy(config_stub: SimpleNamespace | None):
 # ===========================================================================
 
 
-async def test_multi_nv_all_choices_pass() -> None:
+async def test_multi_nv_all_choices_pass_same_target_type() -> None:
+    """Multi-NV cùng (cao_dang, chinh_quy) cho cả 2 NV → consistency pass."""
     profile = _profile(cultural="graduated_thpt", uses_choice_engine=True)
     choices = [
         SimpleNamespace(
@@ -104,7 +105,7 @@ async def test_multi_nv_all_choices_pass() -> None:
             display_order=1,
         ),
         SimpleNamespace(
-            admission_path=_make_path("trung_cap", "chinh_quy"),
+            admission_path=_make_path("cao_dang", "chinh_quy"),
             display_order=2,
         ),
     ]
@@ -115,9 +116,38 @@ async def test_multi_nv_all_choices_pass() -> None:
 
 
 async def test_multi_nv_one_choice_fails_blocks_submit() -> None:
-    # cultural=graduated_thcs → CĐ chính quy fail, TC chính quy pass.
-    # Helper phải raise vì có ít nhất 1 choice fail.
+    """cultural=graduated_thcs + cả 2 NV CĐ chính quy → CĐ fail eligibility
+    cho cả 2; raise ELIGIBILITY_FAIL (KHÔNG raise MULTI_NV vì consistency OK)."""
     profile = _profile(cultural="graduated_thcs", uses_choice_engine=True)
+    choices = [
+        SimpleNamespace(
+            admission_path=_make_path("cao_dang", "chinh_quy"),
+            display_order=1,
+        ),
+        SimpleNamespace(
+            admission_path=_make_path("cao_dang", "chinh_quy"),
+            display_order=2,
+        ),
+    ]
+    db = _make_db_multi_nv(choices)
+
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await _validate_eligibility_all_choices(db, profile)
+    assert "ELIGIBILITY_FAIL" in str(exc.value)
+    assert "NV1" in str(exc.value)
+    assert "cao_dang" in str(exc.value)
+
+
+# ===========================================================================
+# Phase E.4 commit 6 — Multi-NV consistency guard (yêu cầu nghiệp vụ #12)
+# ===========================================================================
+
+
+async def test_multi_nv_inconsistent_target_levels_blocks() -> None:
+    """2 NV với target_level khác nhau (CĐ vs TC) → MULTI_NV_INCONSISTENT.
+    Profile cultural OK cho cả 2 (graduated_thpt) — block hoàn toàn do
+    target/type mismatch, không phải eligibility data."""
+    profile = _profile(cultural="graduated_thpt", uses_choice_engine=True)
     choices = [
         SimpleNamespace(
             admission_path=_make_path("cao_dang", "chinh_quy"),
@@ -132,9 +162,116 @@ async def test_multi_nv_one_choice_fails_blocks_submit() -> None:
 
     with pytest.raises(BusinessRuleViolation) as exc:
         await _validate_eligibility_all_choices(db, profile)
-    assert "ELIGIBILITY_FAIL" in str(exc.value)
-    assert "NV1" in str(exc.value)
-    assert "cao_dang" in str(exc.value)
+    msg = str(exc.value)
+    assert "MULTI_NV_INCONSISTENT" in msg
+    assert "NV1=cao_dang/chinh_quy" in msg
+    assert "NV2=trung_cap/chinh_quy" in msg
+    assert "tách thành nhiều hồ sơ riêng" in msg
+
+
+async def test_multi_nv_inconsistent_admission_types_blocks() -> None:
+    """Cùng target_level (CĐ) nhưng admission_type khác (chính quy vs liên thông)
+    → MULTI_NV_INCONSISTENT."""
+    profile = _profile(
+        cultural="graduated_thpt", vocational="trung_cap", uses_choice_engine=True,
+    )
+    choices = [
+        SimpleNamespace(
+            admission_path=_make_path("cao_dang", "chinh_quy"),
+            display_order=1,
+        ),
+        SimpleNamespace(
+            admission_path=_make_path("cao_dang", "lien_thong"),
+            display_order=2,
+        ),
+    ]
+    db = _make_db_multi_nv(choices)
+
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await _validate_eligibility_all_choices(db, profile)
+    msg = str(exc.value)
+    assert "MULTI_NV_INCONSISTENT" in msg
+    assert "NV1=cao_dang/chinh_quy" in msg
+    assert "NV2=cao_dang/lien_thong" in msg
+
+
+async def test_multi_nv_same_target_and_type_passes() -> None:
+    """3 NV cùng CĐ chính quy (chỉ khác admission_method qua path config) →
+    consistency pass; eligibility check cho mỗi NV."""
+    profile = _profile(cultural="graduated_thpt", uses_choice_engine=True)
+    choices = [
+        SimpleNamespace(
+            admission_path=_make_path("cao_dang", "chinh_quy"),
+            display_order=1,
+        ),
+        SimpleNamespace(
+            admission_path=_make_path("cao_dang", "chinh_quy"),
+            display_order=2,
+        ),
+        SimpleNamespace(
+            admission_path=_make_path("cao_dang", "chinh_quy"),
+            display_order=3,
+        ),
+    ]
+    db = _make_db_multi_nv(choices)
+
+    # Should not raise
+    await _validate_eligibility_all_choices(db, profile)
+
+
+async def test_single_nv_no_consistency_check_needed() -> None:
+    """1 NV duy nhất → consistency check skip (chỉ fire khi len(choices) >= 2)."""
+    profile = _profile(cultural="graduated_thpt", uses_choice_engine=True)
+    choices = [
+        SimpleNamespace(
+            admission_path=_make_path("cao_dang", "chinh_quy"),
+            display_order=1,
+        ),
+    ]
+    db = _make_db_multi_nv(choices)
+
+    # Should not raise
+    await _validate_eligibility_all_choices(db, profile)
+
+
+async def test_multi_nv_inconsistent_with_eligibility_fail_prefers_consistency_msg() -> None:
+    """Khi cả 2 vấn đề tồn tại (multi-NV inconsistent + eligibility fail
+    cho ít nhất 1 NV), helper raise MULTI_NV_INCONSISTENT trước (architectural
+    error first; data error after split sẽ surface eligibility riêng cho mỗi
+    hồ sơ con)."""
+    profile = _profile(cultural="graduated_thcs", uses_choice_engine=True)
+    choices = [
+        SimpleNamespace(
+            admission_path=_make_path("cao_dang", "chinh_quy"),  # graduated_thcs fail CĐ
+            display_order=1,
+        ),
+        SimpleNamespace(
+            admission_path=_make_path("trung_cap", "chinh_quy"),  # graduated_thcs OK TC
+            display_order=2,
+        ),
+    ]
+    db = _make_db_multi_nv(choices)
+
+    with pytest.raises(BusinessRuleViolation) as exc:
+        await _validate_eligibility_all_choices(db, profile)
+    # Multi-NV raise BEFORE eligibility (loop collects both, raise MULTI first)
+    assert "MULTI_NV_INCONSISTENT" in str(exc.value)
+
+
+async def test_legacy_non_multi_nv_no_consistency_check() -> None:
+    """uses_choice_engine=False (legacy single-path) — không có multi-NV concept."""
+    profile = _profile(
+        cultural="graduated_thpt",
+        uses_choice_engine=False,
+        offering_admission_config_id=42,
+    )
+    path = _make_path("cao_dang", "chinh_quy")
+    config_stub = SimpleNamespace()
+    config_stub.academic_info = path.__dict__["academic_info"]
+    db = _make_db_legacy(config_stub=config_stub)
+
+    # Should not raise
+    await _validate_eligibility_all_choices(db, profile)
 
 
 async def test_multi_nv_config_gap_blocks() -> None:

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/priority/PriorityInputsSection.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/priority/PriorityInputsSection.test.tsx
@@ -1,19 +1,20 @@
 /**
  * Q9 #07 Phase E.4 — PriorityInputsSection render tests.
  *
- * Pins § 1 input section contract (officer-friendly UX refactor):
+ * v2 (2026-05-21) — officer KHÔNG chọn basis (auto resolve ở BE engine).
+ * Section chỉ render 2 dropdown trình độ + hint dòng derived basis.
+ *
+ * Pins:
  *   - Cultural + vocational dropdowns render với options
- *   - "Cách xác định khu vực" radio: "Theo trường học" | "Theo nơi thường trú"
- *   - "Theo trường học" maps to area_resolution_basis = null
- *   - "Theo nơi thường trú" maps to area_resolution_basis = "permanent_address_special"
- *     và reveals permanent_commune_code input
- *   - Main flow MUST NOT show "Bật trường hợp đặc biệt", PTDT, MOET, TT 05/2021 copy.
- *   - Disabled state propagates to all controls
+ *   - NO radio "Theo trường học / Theo nơi thường trú"
+ *   - NO commune_code input ở §1 (source-of-truth: tab Thông tin)
+ *   - Hint dòng đề cập "Hệ thống tự xác định"
+ *   - Main flow MUST NOT show "Bật trường hợp đặc biệt", PTDT, MOET copy.
+ *   - Disabled state propagates to all selects
  */
 import { describe, it, expect } from "vitest"
 import { useForm, FormProvider } from "react-hook-form"
-import { render, screen, fireEvent } from "@/test/utils/test-utils"
-import { useEffect } from "react"
+import { render, screen } from "@/test/utils/test-utils"
 
 import { PriorityInputsSection } from "./PriorityInputsSection"
 import type { AdmissionProfileUpdateInput } from "@/lib/zod/admissions"
@@ -21,11 +22,9 @@ import type { AdmissionProfileUpdateInput } from "@/lib/zod/admissions"
 function Wrapper({
   isEditable = true,
   defaultValues = {} as Partial<AdmissionProfileUpdateInput>,
-  onAreaBasisChange,
 }: {
   isEditable?: boolean
   defaultValues?: Partial<AdmissionProfileUpdateInput>
-  onAreaBasisChange?: (v: AdmissionProfileUpdateInput["area_resolution_basis"]) => void
 }) {
   const form = useForm<AdmissionProfileUpdateInput>({
     defaultValues: {
@@ -37,12 +36,6 @@ function Wrapper({
       ...defaultValues,
     },
   })
-  const watched = form.watch("area_resolution_basis")
-  // Surface the field value to the test via callback so we can assert
-  // the radio→BE mapping without inspecting form internals directly.
-  useEffect(() => {
-    onAreaBasisChange?.(watched)
-  }, [watched, onAreaBasisChange])
   return (
     <FormProvider {...form}>
       <PriorityInputsSection form={form} isEditable={isEditable} />
@@ -50,113 +43,57 @@ function Wrapper({
   )
 }
 
-describe("PriorityInputsSection — render", () => {
-  it("renders section heading + 2 dropdowns + radio group", () => {
+describe("PriorityInputsSection — render (v2 auto basis)", () => {
+  it("renders heading 'Trình độ' + 2 dropdowns", () => {
     render(<Wrapper />)
-    expect(screen.getByText(/Trình độ.*Khu vực/i)).toBeInTheDocument()
+    expect(screen.getByText(/^Trình độ$/i)).toBeInTheDocument()
     expect(screen.getByTestId("cultural-education-level-select")).toBeInTheDocument()
     expect(screen.getByTestId("vocational-qualification-select")).toBeInTheDocument()
-    expect(screen.getByTestId("area-resolution-basis-radio")).toBeInTheDocument()
-    expect(screen.getByTestId("area-basis-by-school")).toBeInTheDocument()
-    expect(screen.getByTestId("area-basis-by-permanent-address")).toBeInTheDocument()
   })
 
-  it("defaults to 'Theo trường học' when area_resolution_basis is null", () => {
-    render(<Wrapper defaultValues={{ area_resolution_basis: null }} />)
-    expect(screen.getByTestId("area-basis-by-school")).toHaveAttribute(
-      "aria-checked",
-      "true",
-    )
-    expect(screen.getByTestId("area-basis-by-permanent-address")).toHaveAttribute(
-      "aria-checked",
-      "false",
-    )
+  it("renders 'auto basis' hint informing officer engine resolves", () => {
+    render(<Wrapper />)
+    const hint = screen.getByTestId("auto-basis-hint")
+    expect(hint).toBeInTheDocument()
+    expect(hint).toHaveTextContent(/tự xác định/i)
+    expect(hint).toHaveTextContent(/khu vực ưu tiên/i)
   })
 
-  it("hides commune input when basis = 'Theo trường học'", () => {
+  it("does NOT render basis radio (v1 removed — auto-resolve ở BE engine)", () => {
+    render(<Wrapper />)
+    expect(screen.queryByTestId("area-resolution-basis-radio")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("area-basis-by-school")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("area-basis-by-permanent-address")).not.toBeInTheDocument()
+  })
+
+  it("does NOT render permanent_commune_code input ở §1 (source-of-truth ở tab Thông tin)", () => {
     render(<Wrapper />)
     expect(screen.queryByTestId("commune-code-field")).not.toBeInTheDocument()
-    expect(
-      screen.queryByTestId("permanent-commune-code-input"),
-    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId("permanent-commune-code-input")).not.toBeInTheDocument()
   })
 
-  it("reveals commune input when area_resolution_basis='permanent_address_special'", () => {
-    render(
-      <Wrapper
-        defaultValues={{
-          area_resolution_basis: "permanent_address_special",
-        }}
-      />,
-    )
-    expect(screen.getByTestId("commune-code-field")).toBeInTheDocument()
-    expect(screen.getByTestId("permanent-commune-code-input")).toBeInTheDocument()
-    expect(screen.getByTestId("area-basis-by-permanent-address")).toHaveAttribute(
-      "aria-checked",
-      "true",
-    )
-  })
-
-  it("commune helper text uses short officer-friendly copy (no MOET / no 'trường hợp đặc biệt')", () => {
-    render(
-      <Wrapper
-        defaultValues={{
-          area_resolution_basis: "permanent_address_special",
-        }}
-      />,
-    )
-    const field = screen.getByTestId("commune-code-field")
-    expect(field).toHaveTextContent(/Nhập mã xã\/phường/)
-    expect(field).not.toHaveTextContent(/MOET/i)
-    expect(field).not.toHaveTextContent(/893/)
-    expect(field).not.toHaveTextContent(/7,453|7\.453/)
-    expect(field).not.toHaveTextContent(/trường hợp đặc biệt/i)
-  })
-})
-
-describe("PriorityInputsSection — radio→BE mapping", () => {
-  it("selecting 'Theo nơi thường trú' writes area_resolution_basis = 'permanent_address_special'", () => {
-    const observed: Array<unknown> = []
-    render(
-      <Wrapper
-        onAreaBasisChange={(v) => observed.push(v)}
-      />,
-    )
-    fireEvent.click(screen.getByTestId("area-basis-by-permanent-address"))
-    expect(observed.at(-1)).toBe("permanent_address_special")
-  })
-
-  it("selecting 'Theo trường học' writes area_resolution_basis = null (NOT a sentinel string)", () => {
-    const observed: Array<unknown> = []
+  it("commune input NOT shown even when area_resolution_basis = 'permanent_address_special' (legacy field)", () => {
     render(
       <Wrapper
         defaultValues={{ area_resolution_basis: "permanent_address_special" }}
-        onAreaBasisChange={(v) => observed.push(v)}
       />,
     )
-    fireEvent.click(screen.getByTestId("area-basis-by-school"))
-    expect(observed.at(-1)).toBeNull()
+    expect(screen.queryByTestId("commune-code-field")).not.toBeInTheDocument()
   })
 })
 
 describe("PriorityInputsSection — main flow copy guards", () => {
-  it("does NOT render 'Bật trường hợp đặc biệt' text anywhere in section", () => {
+  it("does NOT render legacy basis copy ('Theo trường học' / 'Theo nơi thường trú')", () => {
+    render(<Wrapper />)
+    const section = screen.getByTestId("priority-inputs-section")
+    expect(section).not.toHaveTextContent(/Theo trường học/i)
+    expect(section).not.toHaveTextContent(/Theo nơi thường trú/i)
+  })
+
+  it("does NOT render 'Bật trường hợp đặc biệt' / PTDT / quân nhân copy", () => {
     render(<Wrapper />)
     const section = screen.getByTestId("priority-inputs-section")
     expect(section).not.toHaveTextContent(/Bật trường hợp đặc biệt/i)
-    // Old switch should be gone entirely.
-    expect(screen.queryByTestId("special-case-switch")).not.toBeInTheDocument()
-  })
-
-  it("does NOT render PTDT / quân nhân / dự bị ĐH / lớp tạo nguồn business copy in main flow", () => {
-    render(
-      <Wrapper
-        defaultValues={{
-          area_resolution_basis: "permanent_address_special",
-        }}
-      />,
-    )
-    const section = screen.getByTestId("priority-inputs-section")
     expect(section).not.toHaveTextContent(/PTDT/i)
     expect(section).not.toHaveTextContent(/quân nhân/i)
     expect(section).not.toHaveTextContent(/CAND/)
@@ -165,13 +102,7 @@ describe("PriorityInputsSection — main flow copy guards", () => {
   })
 
   it("does NOT render legal/data references (TT 05/2021, MOET) in main flow", () => {
-    render(
-      <Wrapper
-        defaultValues={{
-          area_resolution_basis: "permanent_address_special",
-        }}
-      />,
-    )
+    render(<Wrapper />)
     const section = screen.getByTestId("priority-inputs-section")
     expect(section).not.toHaveTextContent(/TT 05\/2021/)
     expect(section).not.toHaveTextContent(/MOET/i)
@@ -179,26 +110,9 @@ describe("PriorityInputsSection — main flow copy guards", () => {
 })
 
 describe("PriorityInputsSection — disabled state", () => {
-  it("disables all controls when isEditable=false", () => {
-    render(
-      <Wrapper
-        isEditable={false}
-        defaultValues={{
-          area_resolution_basis: "permanent_address_special",
-        }}
-      />,
-    )
-    const cultural = screen.getByTestId("cultural-education-level-select")
-    const vocational = screen.getByTestId("vocational-qualification-select")
-    const radioBySchool = screen.getByTestId("area-basis-by-school")
-    const radioByPerm = screen.getByTestId("area-basis-by-permanent-address")
-    const commune = screen.getByTestId("permanent-commune-code-input")
-    expect(cultural).toBeDisabled()
-    expect(vocational).toBeDisabled()
-    // Radix RadioGroupItem mirrors disabled via data-disabled + the underlying
-    // button attribute.
-    expect(radioBySchool).toBeDisabled()
-    expect(radioByPerm).toBeDisabled()
-    expect(commune).toBeDisabled()
+  it("disables 2 trình độ selects when isEditable=false", () => {
+    render(<Wrapper isEditable={false} />)
+    expect(screen.getByTestId("cultural-education-level-select")).toBeDisabled()
+    expect(screen.getByTestId("vocational-qualification-select")).toBeDisabled()
   })
 })

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/priority/PriorityInputsSection.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/priority/PriorityInputsSection.tsx
@@ -1,28 +1,25 @@
 /**
- * Q9 #07 Phase E.4 — § 1 Inputs section (officer-friendly UX refactor).
+ * Q9 #07 Phase E.4 — § 1 Inputs section.
  *
- * Linear 1-column layout:
- *   Trình độ:
- *     Văn hóa:  [select]      ← Tab 1
- *     Nghề:     [select]      ← Tab 2
- *   Cách xác định khu vực:
- *     ( ) Theo trường học           area_resolution_basis = null
- *     ( ) Theo nơi thường trú        area_resolution_basis = "permanent_address_special"
- *       ↳ Xã/phường thường trú: [input]  (conditional reveal)
+ * Officer chỉ nhập trình độ:
+ *   Văn hóa:  [select]      ← Tab 1
+ *   Nghề:     [select]      ← Tab 2
  *
- * UX rationale: replaces the previous "Bật trường hợp đặc biệt" switch +
- * raw commune-code input which read as bypass-control + jargon-heavy
- * helper text. The new radio framing surfaces the OFFICER DECISION
- * ("which basis are we using") instead of a binary edge-case toggle,
- * and the helper text on the commune field stays short — officers
- * tra cứu mã hành chính separately, không tự đoán.
+ * KV resolution basis là OUTPUT của engine (cultural + vocational + lịch sử
+ * học + permanent_commune_code từ tab Thông tin). Officer KHÔNG chọn basis
+ * — vi phạm thin-client + nghiệp vụ "hệ thống tự suy ra basis". Display
+ * basis derived hiển thị ở §2 EngineResultCard (state + reason + citation).
  *
- * Mapping to BE contract is UNCHANGED:
- *   - Theo trường học           → area_resolution_basis = null
- *   - Theo nơi thường trú        → area_resolution_basis = "permanent_address_special"
- *   - permanent_commune_code field shape unchanged
+ * Admin/manager override KV thực hiện qua PriorityOverrideDialog (output
+ * bypass), KHÔNG qua field area_resolution_basis ở §1.
  *
- * No business logic on FE — area resolution still computed by BE engine.
+ * History (audit cycle 2026-05-21):
+ *   - v0: switch "Bật trường hợp đặc biệt" + mã xã input — UX jargon-heavy.
+ *   - v1 (cycle 1): radio "Theo trường học / Theo nơi thường trú" + commune
+ *     input. Vẫn vi phạm thin-client: officer ÉP basis = bypass engine.
+ *   - v2 (THIS): officer chỉ khai trình độ; basis derive ở BE; commune
+ *     code source-of-truth ở tab Thông tin (PersonalInfoTab wire qua
+ *     AdaptiveAddressSelect).
  */
 "use client"
 
@@ -33,13 +30,7 @@ import {
   FormLabel,
   FormControl,
   FormMessage,
-  FormDescription,
 } from "@/components/ui/form"
-import { Input } from "@/components/ui/input"
-import {
-  RadioGroup,
-  RadioGroupItem,
-} from "@/components/ui/radio-group"
 import {
   Select,
   SelectContent,
@@ -65,12 +56,6 @@ const VOCATIONAL_OPTIONS = [
   { value: "cao_dang",   label: "Cao đẳng" },
 ]
 
-// Internal radio values — distinct from BE enum to avoid colliding với
-// the optional/nullable shape. ``null`` (school basis) is not a valid
-// HTML radio value, so we map UI strings ↔ BE field locally.
-const BASIS_BY_SCHOOL = "by_school"
-const BASIS_BY_PERMANENT_ADDRESS = "permanent_address_special"
-
 export interface PriorityInputsSectionProps {
   form: UseFormReturn<AdmissionProfileUpdateInput>
   isEditable: boolean
@@ -80,15 +65,12 @@ export function PriorityInputsSection({
   form,
   isEditable,
 }: PriorityInputsSectionProps) {
-  const areaBasis = form.watch("area_resolution_basis")
-  const isPermanentAddress = areaBasis === BASIS_BY_PERMANENT_ADDRESS
-
   return (
     <section
       data-testid="priority-inputs-section"
       className="space-y-4 rounded-lg border border-border bg-card p-4"
     >
-      <h3 className="text-base font-semibold">Trình độ &amp; Khu vực</h3>
+      <h3 className="text-base font-semibold">Trình độ</h3>
 
       {/* Trình độ — văn hóa + nghề */}
       <div className="grid gap-3 sm:grid-cols-2">
@@ -157,99 +139,15 @@ export function PriorityInputsSection({
         />
       </div>
 
-      {/* Cách xác định khu vực — replaces the prior "Bật trường hợp đặc biệt"
-          switch. Officer chooses the resolution basis explicitly. */}
-      <FormField
-        control={form.control}
-        name="area_resolution_basis"
-        render={({ field }) => {
-          const radioValue = isPermanentAddress
-            ? BASIS_BY_PERMANENT_ADDRESS
-            : BASIS_BY_SCHOOL
-          return (
-            <FormItem className="space-y-2 rounded-md border border-dashed border-border p-3">
-              <FormLabel className="text-sm font-medium">
-                Cách xác định khu vực
-              </FormLabel>
-              <FormControl>
-                <RadioGroup
-                  value={radioValue}
-                  onValueChange={(v) => {
-                    // Map UI → BE field: school basis writes null.
-                    field.onChange(
-                      v === BASIS_BY_PERMANENT_ADDRESS
-                        ? BASIS_BY_PERMANENT_ADDRESS
-                        : null,
-                    )
-                  }}
-                  disabled={!isEditable}
-                  className="gap-2"
-                  data-testid="area-resolution-basis-radio"
-                >
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem
-                      value={BASIS_BY_SCHOOL}
-                      id="area-basis-by-school"
-                      data-testid="area-basis-by-school"
-                    />
-                    <label
-                      htmlFor="area-basis-by-school"
-                      className="text-sm cursor-pointer"
-                    >
-                      Theo trường học
-                    </label>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem
-                      value={BASIS_BY_PERMANENT_ADDRESS}
-                      id="area-basis-by-permanent-address"
-                      data-testid="area-basis-by-permanent-address"
-                    />
-                    <label
-                      htmlFor="area-basis-by-permanent-address"
-                      className="text-sm cursor-pointer"
-                    >
-                      Theo nơi thường trú
-                    </label>
-                  </div>
-                </RadioGroup>
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )
-        }}
-      />
-
-      {/* Commune code (conditional reveal). Short helper text — no
-          MOET cardinality copy, no "trường hợp đặc biệt" wording. */}
-      {isPermanentAddress && (
-        <FormField
-          control={form.control}
-          name="permanent_commune_code"
-          render={({ field }) => (
-            <FormItem data-testid="commune-code-field">
-              <FormLabel htmlFor="permanent_commune_code">
-                Xã/phường thường trú
-              </FormLabel>
-              <FormControl>
-                <Input
-                  id="permanent_commune_code"
-                  data-testid="permanent-commune-code-input"
-                  placeholder="VD: 01_00025"
-                  value={field.value ?? ""}
-                  onChange={(e) => field.onChange(e.target.value || null)}
-                  disabled={!isEditable}
-                />
-              </FormControl>
-              <FormDescription className="text-xs">
-                Nhập mã xã/phường nếu hồ sơ thuộc diện tính khu vực theo
-                thường trú.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-      )}
+      {/* Thông báo derived basis — officer biết engine sẽ tự suy ra. */}
+      <p
+        data-testid="auto-basis-hint"
+        className="text-xs text-muted-foreground"
+      >
+        Hệ thống tự xác định cách tính khu vực ưu tiên dựa trên trình độ +
+        địa chỉ thường trú (tab Thông tin) + lịch sử học (tab Học tập).
+        Kết quả hiển thị bên dưới.
+      </p>
     </section>
   )
 }

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.test.tsx
@@ -10,7 +10,8 @@
 import { useState } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { useForm, FormProvider } from "react-hook-form";
+import { useForm, FormProvider, type UseFormReturn } from "react-hook-form";
+import { act } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { createTestQueryClient } from "@/test/utils/test-utils";
 import type { AdmissionProfileResponse, AdmissionProfileUpdateInput } from "@/lib/zod/admissions";
@@ -18,6 +19,14 @@ import type { AdmissionProfileResponse, AdmissionProfileUpdateInput } from "@/li
 // Mock useConfigData — all category lists return empty
 vi.mock("@/lib/hooks/useConfigData", () => ({
   useConfigData: () => ({ data: [], isLoading: false }),
+}));
+
+// Mock useAdministrative — place_of_birth combobox uses useProvinces("legacy");
+// no network calls allowed in test (would emit MSW-style XHR errors).
+vi.mock("@/lib/hooks/useAdministrative", () => ({
+  useProvinces: () => ({ data: [], isLoading: false }),
+  useDistricts: () => ({ data: [], isLoading: false }),
+  useWards: () => ({ data: [], isLoading: false }),
 }));
 
 // Mock AdaptiveAddressSelect — lightweight spy that exposes key props
@@ -114,6 +123,10 @@ const DEFAULT_VALUES: Partial<AdmissionProfileUpdateInput> = {
   permanent_ward: "",
 };
 
+// Module-level form spy lets tests reach into form state after rendering.
+// Cleared in beforeEach via capturedFormRef reassign.
+let capturedFormRef: UseFormReturn<AdmissionProfileUpdateInput> | null = null;
+
 /** Wrapper that provides FormProvider + renders PersonalInfoTab */
 function TestFormHost({
   profile,
@@ -129,8 +142,12 @@ function TestFormHost({
       permanent_province: profile.permanent_province || "",
       permanent_district: profile.permanent_district || "",
       permanent_ward: profile.permanent_ward || "",
+      permanent_commune_code:
+        (profile as unknown as { permanent_commune_code?: string | null })
+          .permanent_commune_code ?? null,
     } as AdmissionProfileUpdateInput,
   });
+  capturedFormRef = form;
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -149,6 +166,7 @@ describe("PersonalInfoTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedAddressProps = {};
+    capturedFormRef = null;
   });
 
   describe("addressMode derivation", () => {
@@ -218,6 +236,109 @@ describe("PersonalInfoTab", () => {
       render(<TestFormHost profile={profile} isEditable={true} />);
 
       expect(screen.getByTestId("address-disabled").textContent).toBe("false");
+    });
+  });
+
+  describe("Phase E.4 KV bridge — permanent_commune_code wiring", () => {
+    it("wires onWardCodeChange handler into AdaptiveAddressSelect", () => {
+      const profile = buildProfile({ version: 1 });
+      render(<TestFormHost profile={profile} />);
+
+      expect(typeof capturedAddressProps.onWardCodeChange).toBe("function");
+    });
+
+    it("onWardCodeChange sets permanent_commune_code form field", () => {
+      const profile = buildProfile({ version: 1 });
+      render(<TestFormHost profile={profile} />);
+
+      const onWardCodeChange =
+        capturedAddressProps.onWardCodeChange as (code: string | null) => void;
+      act(() => {
+        onWardCodeChange("66_002");
+      });
+
+      expect(capturedFormRef?.getValues("permanent_commune_code")).toBe("66_002");
+    });
+
+    it("onWardCodeChange(null) clears permanent_commune_code", () => {
+      const profile = buildProfile({
+        version: 1,
+      });
+      // Seed the form với code có sẵn để verify it gets cleared
+      render(<TestFormHost profile={profile} />);
+
+      const onWardCodeChange =
+        capturedAddressProps.onWardCodeChange as (code: string | null) => void;
+      act(() => {
+        onWardCodeChange("66_002");
+      });
+      expect(capturedFormRef?.getValues("permanent_commune_code")).toBe("66_002");
+
+      act(() => {
+        onWardCodeChange(null);
+      });
+      expect(capturedFormRef?.getValues("permanent_commune_code")).toBeNull();
+    });
+
+    it("changing province clears permanent_commune_code", () => {
+      const profile = buildProfile({ version: 1 });
+      render(<TestFormHost profile={profile} />);
+
+      // Seed code first
+      const onWardCodeChange =
+        capturedAddressProps.onWardCodeChange as (code: string | null) => void;
+      act(() => {
+        onWardCodeChange("66_002");
+      });
+
+      const onProvinceChange =
+        capturedAddressProps.onProvinceChange as (v: string) => void;
+      act(() => {
+        onProvinceChange("Hà Nội");
+      });
+
+      expect(capturedFormRef?.getValues("permanent_commune_code")).toBeNull();
+    });
+
+    it("changing district clears permanent_commune_code", () => {
+      const profile = buildProfile({
+        permanent_district: "Quận 1",
+        version: 1,
+      });
+      render(<TestFormHost profile={profile} />);
+
+      const onWardCodeChange =
+        capturedAddressProps.onWardCodeChange as (code: string | null) => void;
+      act(() => {
+        onWardCodeChange("01_001");
+      });
+
+      const onDistrictChange =
+        capturedAddressProps.onDistrictChange as (v: string | null) => void;
+      act(() => {
+        onDistrictChange("Quận 2");
+      });
+
+      expect(capturedFormRef?.getValues("permanent_commune_code")).toBeNull();
+    });
+
+    it("changing address mode clears permanent_commune_code", () => {
+      const profile = buildProfile({ version: 1 });
+      render(<TestFormHost profile={profile} />);
+
+      const onWardCodeChange =
+        capturedAddressProps.onWardCodeChange as (code: string | null) => void;
+      act(() => {
+        onWardCodeChange("66_002");
+      });
+
+      const onModeChange =
+        capturedAddressProps.onModeChange as (m: "current" | "legacy") => void;
+      act(() => {
+        onModeChange("legacy");
+      });
+
+      expect(capturedFormRef?.getValues("permanent_commune_code")).toBeNull();
     });
   });
 });

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
@@ -44,6 +44,7 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
   const permanentProvince = useWatch({ control: form.control, name: "permanent_province" }) || ""
   const permanentDistrict = useWatch({ control: form.control, name: "permanent_district" }) || null
   const permanentWard = useWatch({ control: form.control, name: "permanent_ward" }) || ""
+  const permanentCommuneCode = useWatch({ control: form.control, name: "permanent_commune_code" }) ?? null
   const permanentResidentialGroup = useWatch({ control: form.control, name: "permanent_residential_group" }) || ""
   const permanentStreetAddress = useWatch({ control: form.control, name: "permanent_street_address" }) || ""
 
@@ -251,6 +252,10 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
               provinceValue={permanentProvince}
               districtValue={permanentDistrict}
               wardValue={permanentWard}
+              // Phase E.4 KV bridge fix Finding 1: canonical code là primary
+              // key của combobox. Pass code thay vì để component lookup ngược
+              // từ name (tránh ambiguity 2 xã trùng tên 2 tỉnh).
+              wardCodeValue={permanentCommuneCode}
               residentialGroupValue={permanentResidentialGroup}
               streetAddressValue={permanentStreetAddress}
               onProvinceChange={(value) => {

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
@@ -253,13 +253,30 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
               wardValue={permanentWard}
               residentialGroupValue={permanentResidentialGroup}
               streetAddressValue={permanentStreetAddress}
-              onProvinceChange={(value) => form.setValue("permanent_province", value)}
-              onDistrictChange={(value) => form.setValue("permanent_district", value || "")}
-              onWardChange={(value) => form.setValue("permanent_ward", value)}
+              onProvinceChange={(value) => {
+                form.setValue("permanent_province", value, { shouldDirty: true })
+                // Province reset clears ward chain → mã xã canonical theo đó.
+                form.setValue("permanent_commune_code", null, { shouldDirty: true })
+              }}
+              onDistrictChange={(value) => {
+                form.setValue("permanent_district", value || "", { shouldDirty: true })
+                form.setValue("permanent_commune_code", null, { shouldDirty: true })
+              }}
+              onWardChange={(value) => form.setValue("permanent_ward", value, { shouldDirty: true })}
+              // Phase E.4 KV bridge — engine đọc permanent_commune_code chuẩn,
+              // KHÔNG đọc tên ward. PriorityTab hết phải hỏi officer gõ mã.
+              onWardCodeChange={(code) =>
+                form.setValue("permanent_commune_code", code, { shouldDirty: true })
+              }
               onResidentialGroupChange={(value) => form.setValue("permanent_residential_group", value)}
               onStreetAddressChange={(value) => form.setValue("permanent_street_address", value)}
               mode={addressMode}
-              onModeChange={setAddressMode}
+              onModeChange={(newMode) => {
+                setAddressMode(newMode)
+                // Mode switch resets cả tỉnh/quận/xã → mã xã cũng phải clear
+                // để tránh stale code orphan.
+                form.setValue("permanent_commune_code", null, { shouldDirty: true })
+              }}
               disabled={!isEditable}
             />
         </CardContent>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PriorityTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PriorityTab.tsx
@@ -60,11 +60,15 @@ export function PriorityTab({
   const [overrideDialogOpen, setOverrideDialogOpen] = useState(false)
   const userRole = useAuthStore((s) => s.user?.role)
 
-  // Form watches drive live preview query. Same fields as Phase E.3 PriorityTab —
-  // unchanged contract với usePreviewPriorityKv hook.
+  // Form watches drive live preview query. Same fields as Phase E.3 PriorityTab.
+  // Phase E.4 Finding 2 fix: KHÔNG watch + KHÔNG gửi `area_resolution_basis` vì
+  // engine giờ tự suy ra basis từ cultural + vocational + permanent_commune_code
+  // (yêu cầu nghiệp vụ #3 + #6). Field area_resolution_basis legacy có thể
+  // còn `manual_override` (đặt qua PriorityOverrideDialog OUTPUT bypass) hoặc
+  // `permanent_address_special` (legacy stale từ commit trước radio bị xoá);
+  // truyền nó vào preview = ép engine đi nhánh cũ → engine fail-closed sai.
   const cultural = form.watch("cultural_education_level")
   const vocational = form.watch("vocational_qualification")
-  const areaBasis = form.watch("area_resolution_basis")
   const communeCode = form.watch("permanent_commune_code")
   const academicHistory = form.watch("academic_history")
   const utCodes = form.watch("priority_object_codes")
@@ -79,7 +83,8 @@ export function PriorityTab({
     {
       cultural_education_level: cultural ?? null,
       vocational_qualification: vocational ?? null,
-      area_resolution_basis: areaBasis ?? null,
+      // area_resolution_basis intentionally omitted (null) — auto-basis ở BE
+      area_resolution_basis: null,
       permanent_commune_code: communeCode ?? null,
       academic_history:
         (academicHistory as PreviewPriorityKvRequest["academic_history"]) ?? null,

--- a/frontend/src/components/forms/AdaptiveAddressSelect.test.tsx
+++ b/frontend/src/components/forms/AdaptiveAddressSelect.test.tsx
@@ -81,6 +81,7 @@ interface Props {
   onProvinceChange?: (v: string) => void
   onDistrictChange?: (v: string | null) => void
   onWardChange?: (v: string) => void
+  onWardCodeChange?: (code: string | null) => void
   onModeChange?: (m: AddressMode) => void
 }
 
@@ -94,6 +95,7 @@ async function renderComponent(overrides: Props = {}) {
     onProvinceChange: vi.fn(),
     onDistrictChange: vi.fn(),
     onWardChange: vi.fn(),
+    onWardCodeChange: vi.fn(),
     onModeChange: vi.fn(),
     ...overrides,
   }
@@ -250,6 +252,112 @@ describe("AdaptiveAddressSelect", () => {
       expect(props.onProvinceChange).toHaveBeenCalledWith("Dak Lak")
       expect(props.onDistrictChange).toHaveBeenCalledWith(null)
       expect(props.onWardChange).toHaveBeenCalledWith("")
+    })
+  })
+
+  // -----------------------------------------------------------------
+  // Phase E.4 KV BRIDGE — ward code expose
+  // -----------------------------------------------------------------
+
+  it("selecting a ward fires onWardCodeChange with the canonical commune code", async () => {
+    mockUseWards.mockReturnValue({
+      data: [
+        { code: "66_001", name: "Phường Tân An", province_code: "66", district_code: null },
+        { code: "66_002", name: "Xã Ea Kao", province_code: "66", district_code: null },
+      ],
+      isLoading: false,
+    })
+
+    const { props } = await renderComponent({
+      mode: "current",
+      provinceValue: "Dak Lak",
+    })
+
+    fireEvent.change(screen.getByLabelText("Phường/Xã"), {
+      target: { value: "Xã Ea Kao" },
+    })
+
+    await waitFor(() => {
+      expect(props.onWardChange).toHaveBeenCalledWith("Xã Ea Kao")
+      expect(props.onWardCodeChange).toHaveBeenCalledWith("66_002")
+    })
+  })
+
+  it("ward selection cleared (empty string) emits null commune code", async () => {
+    mockUseWards.mockReturnValue({
+      data: [{ code: "66_001", name: "Phường Tân An", province_code: "66", district_code: null }],
+      isLoading: false,
+    })
+
+    const { props } = await renderComponent({
+      mode: "current",
+      provinceValue: "Dak Lak",
+      wardValue: "Phường Tân An",
+    })
+
+    fireEvent.change(screen.getByLabelText("Phường/Xã"), { target: { value: "" } })
+
+    await waitFor(() => {
+      expect(props.onWardChange).toHaveBeenCalledWith("")
+      expect(props.onWardCodeChange).toHaveBeenCalledWith(null)
+    })
+  })
+
+  it("ward name not present in catalog → onWardCodeChange(null)", async () => {
+    // Ward names list rỗng (province chưa load wards): pick any name → null code.
+    mockUseWards.mockReturnValue({ data: [], isLoading: false })
+
+    const { props } = await renderComponent({
+      mode: "current",
+      provinceValue: "Dak Lak",
+    })
+
+    fireEvent.change(screen.getByLabelText("Phường/Xã"), {
+      target: { value: "Phường Không Tồn Tại" },
+    })
+
+    await waitFor(() => {
+      expect(props.onWardCodeChange).toHaveBeenLastCalledWith(null)
+    })
+  })
+
+  it("province change clears commune code along with ward/district", async () => {
+    const { props } = await renderComponent({ mode: "current" })
+
+    fireEvent.change(screen.getByLabelText(/Tỉnh/), {
+      target: { value: "Dak Lak" },
+    })
+
+    await waitFor(() => {
+      expect(props.onWardCodeChange).toHaveBeenCalledWith(null)
+    })
+  })
+
+  it("mode switch clears commune code", async () => {
+    const { props } = await renderComponent({
+      mode: "current",
+      provinceValue: "Dak Lak",
+    })
+
+    fireEvent.click(screen.getByLabelText(/Hộ khẩu cũ/))
+
+    await waitFor(() => {
+      expect(props.onWardCodeChange).toHaveBeenCalledWith(null)
+    })
+  })
+
+  it("district change (legacy mode) clears commune code", async () => {
+    const { props } = await renderComponent({
+      mode: "legacy",
+      provinceValue: "Lao Cai",
+    })
+
+    fireEvent.change(screen.getByLabelText("Quận/Huyện"), {
+      target: { value: "Bat Xat" },
+    })
+
+    await waitFor(() => {
+      expect(props.onWardCodeChange).toHaveBeenCalledWith(null)
     })
   })
 })

--- a/frontend/src/components/forms/AdaptiveAddressSelect.test.tsx
+++ b/frontend/src/components/forms/AdaptiveAddressSelect.test.tsx
@@ -77,6 +77,7 @@ interface Props {
   provinceValue?: string
   districtValue?: string | null
   wardValue?: string
+  wardCodeValue?: string | null
   mode?: AddressMode
   onProvinceChange?: (v: string) => void
   onDistrictChange?: (v: string | null) => void
@@ -91,6 +92,7 @@ async function renderComponent(overrides: Props = {}) {
     provinceValue: "",
     districtValue: null,
     wardValue: "",
+    wardCodeValue: null as string | null,
     mode: "current" as AddressMode,
     onProvinceChange: vi.fn(),
     onDistrictChange: vi.fn(),
@@ -259,7 +261,27 @@ describe("AdaptiveAddressSelect", () => {
   // Phase E.4 KV BRIDGE — ward code expose
   // -----------------------------------------------------------------
 
-  it("selecting a ward fires onWardCodeChange with the canonical commune code", async () => {
+  it("ward combobox dùng ward.code làm option value (canonical key)", async () => {
+    mockUseWards.mockReturnValue({
+      data: [
+        { code: "66_001", name: "Phường Tân An", province_code: "66", district_code: null },
+        { code: "66_002", name: "Xã Ea Kao", province_code: "66", district_code: null },
+      ],
+      isLoading: false,
+    })
+
+    await renderComponent({ mode: "current", provinceValue: "Dak Lak" })
+
+    const wardSelect = screen.getByLabelText("Phường/Xã") as HTMLSelectElement
+    const optionValues = Array.from(wardSelect.options).map((o) => o.value)
+    expect(optionValues).toContain("66_001")
+    expect(optionValues).toContain("66_002")
+    // Không còn dùng ward.name làm value
+    expect(optionValues).not.toContain("Phường Tân An")
+    expect(optionValues).not.toContain("Xã Ea Kao")
+  })
+
+  it("selecting ward (by code) fires onWardChange(name) + onWardCodeChange(code)", async () => {
     mockUseWards.mockReturnValue({
       data: [
         { code: "66_001", name: "Phường Tân An", province_code: "66", district_code: null },
@@ -273,8 +295,9 @@ describe("AdaptiveAddressSelect", () => {
       provinceValue: "Dak Lak",
     })
 
+    // Combobox value đổi sang ward.code (canonical primary key)
     fireEvent.change(screen.getByLabelText("Phường/Xã"), {
-      target: { value: "Xã Ea Kao" },
+      target: { value: "66_002" },
     })
 
     await waitFor(() => {
@@ -283,7 +306,7 @@ describe("AdaptiveAddressSelect", () => {
     })
   })
 
-  it("ward selection cleared (empty string) emits null commune code", async () => {
+  it("ward selection cleared (empty string) emits empty name + null commune code", async () => {
     mockUseWards.mockReturnValue({
       data: [{ code: "66_001", name: "Phường Tân An", province_code: "66", district_code: null }],
       isLoading: false,
@@ -293,6 +316,7 @@ describe("AdaptiveAddressSelect", () => {
       mode: "current",
       provinceValue: "Dak Lak",
       wardValue: "Phường Tân An",
+      wardCodeValue: "66_001",
     })
 
     fireEvent.change(screen.getByLabelText("Phường/Xã"), { target: { value: "" } })
@@ -303,22 +327,45 @@ describe("AdaptiveAddressSelect", () => {
     })
   })
 
-  it("ward name not present in catalog → onWardCodeChange(null)", async () => {
-    // Ward names list rỗng (province chưa load wards): pick any name → null code.
-    mockUseWards.mockReturnValue({ data: [], isLoading: false })
+  it("wardCodeValue prop sets combobox internal selection (hydration)", async () => {
+    mockUseWards.mockReturnValue({
+      data: [
+        { code: "66_001", name: "Phường Tân An", province_code: "66", district_code: null },
+        { code: "66_002", name: "Xã Ea Kao", province_code: "66", district_code: null },
+      ],
+      isLoading: false,
+    })
 
-    const { props } = await renderComponent({
+    await renderComponent({
       mode: "current",
       provinceValue: "Dak Lak",
+      wardCodeValue: "66_002",
     })
 
-    fireEvent.change(screen.getByLabelText("Phường/Xã"), {
-      target: { value: "Phường Không Tồn Tại" },
+    expect((screen.getByLabelText("Phường/Xã") as HTMLSelectElement).value).toBe(
+      "66_002",
+    )
+  })
+
+  it("fallback hydration từ wardValue (name) khi wardCodeValue chưa có (legacy profile)", async () => {
+    mockUseWards.mockReturnValue({
+      data: [
+        { code: "66_001", name: "Phường Tân An", province_code: "66", district_code: null },
+      ],
+      isLoading: false,
     })
 
-    await waitFor(() => {
-      expect(props.onWardCodeChange).toHaveBeenLastCalledWith(null)
+    await renderComponent({
+      mode: "current",
+      provinceValue: "Dak Lak",
+      wardValue: "Phường Tân An",
+      // wardCodeValue undefined — legacy profile chỉ có name
     })
+
+    // Component lookup ngược name → code để select đúng option
+    expect((screen.getByLabelText("Phường/Xã") as HTMLSelectElement).value).toBe(
+      "66_001",
+    )
   })
 
   it("province change clears commune code along with ward/district", async () => {

--- a/frontend/src/components/forms/AdaptiveAddressSelect.tsx
+++ b/frontend/src/components/forms/AdaptiveAddressSelect.tsx
@@ -32,6 +32,15 @@ interface AdaptiveAddressSelectProps {
   onProvinceChange: (province: string) => void
   onDistrictChange: (district: string | null) => void
   onWardChange: (ward: string) => void
+  /**
+   * Phase E.4 KV bridge: canonical commune/ward code from administrative_nodes.
+   * Fires alongside `onWardChange` whenever the ward selection changes. Receives
+   * the ward `code` field from the administrative API (e.g. "01_00025") or
+   * `null` when ward is cleared / not found in the loaded list. Callers that
+   * track `permanent_commune_code` (PriorityTab KV resolution) wire this to
+   * form state; callers that don't simply omit the prop.
+   */
+  onWardCodeChange?: (wardCode: string | null) => void
   onResidentialGroupChange?: (residentialGroup: string) => void
   onStreetAddressChange?: (streetAddress: string) => void
   /** Address mode: "current" (2-level) or "legacy" (3-level) */
@@ -50,6 +59,7 @@ export function AdaptiveAddressSelect({
   onProvinceChange,
   onDistrictChange,
   onWardChange,
+  onWardCodeChange,
   onResidentialGroupChange,
   onStreetAddressChange,
   mode,
@@ -102,22 +112,42 @@ export function AdaptiveAddressSelect({
   )
 
   // ---- Handlers ----
+  // Phase E.4 KV bridge: every transition that changes the selected ward
+  // (mode switch, province/district reset, direct ward pick, or clear)
+  // must mirror the ward code so callers tracking `permanent_commune_code`
+  // never see a stale or orphaned code. `lookupWardCode` reads the loaded
+  // wards list; returns `null` when ward is empty or not present in the
+  // current province's ward set (e.g. mode switched mid-edit).
+  const lookupWardCode = (wardName: string): string | null => {
+    if (!wardName) return null
+    const ward = wards.find((w) => w.name === wardName)
+    return ward?.code ?? null
+  }
+
   const handleModeChange = (newMode: AddressMode) => {
     onModeChange(newMode)
     onProvinceChange("")
     onDistrictChange(null)
     onWardChange("")
+    onWardCodeChange?.(null)
   }
 
   const handleProvinceChange = (name: string) => {
     onProvinceChange(name)
     onDistrictChange(null)
     onWardChange("")
+    onWardCodeChange?.(null)
   }
 
   const handleDistrictChange = (name: string) => {
     onDistrictChange(name || null)
     onWardChange("")
+    onWardCodeChange?.(null)
+  }
+
+  const handleWardChange = (name: string) => {
+    onWardChange(name)
+    onWardCodeChange?.(lookupWardCode(name))
   }
 
   // ---- Render ----
@@ -189,7 +219,7 @@ export function AdaptiveAddressSelect({
         <div>
           <Combobox
             value={wardValue || ""}
-            onChange={onWardChange}
+            onChange={handleWardChange}
             options={wardOptions}
             placeholder="Phường/Xã"
             searchPlaceholder="Tìm phường/xã..."

--- a/frontend/src/components/forms/AdaptiveAddressSelect.tsx
+++ b/frontend/src/components/forms/AdaptiveAddressSelect.tsx
@@ -24,7 +24,20 @@ import { Input } from "@/components/ui/input"
 interface AdaptiveAddressSelectProps {
   provinceValue: string
   districtValue: string | null
+  /**
+   * Display name của xã/phường — fallback render khi `wardCodeValue` chưa
+   * có (vd hồ sơ legacy chỉ lưu tên). Callers cũ chỉ cần truyền `wardValue`.
+   */
   wardValue: string
+  /**
+   * Phase E.4 KV bridge: canonical commune/ward code (administrative_nodes.code,
+   * vd "01_00025"). Là **primary key** của combobox xã/phường sau commit fix
+   * Finding 1 — combobox `value` = code, options[].value = code, label = name.
+   * Khi prop này có giá trị, component lookup name từ code; nếu null/undefined,
+   * fall back lookup ngược từ `wardValue` (display name) để backward-compat
+   * với callers chưa wire code (vd hồ sơ cũ trước cải cách).
+   */
+  wardCodeValue?: string | null
   /** Tổ dân phố / Thôn / Buôn / Ấp / Khóm / Khu phố — community sub-unit, free-text. */
   residentialGroupValue?: string
   /** Số nhà, tên đường — street address line, free-text. */
@@ -54,6 +67,7 @@ export function AdaptiveAddressSelect({
   provinceValue,
   districtValue,
   wardValue,
+  wardCodeValue,
   residentialGroupValue,
   streetAddressValue,
   onProvinceChange,
@@ -106,23 +120,34 @@ export function AdaptiveAddressSelect({
     [districts],
   )
 
+  // Phase E.4 KV bridge fix Finding 1: options[].value = canonical ward.code
+  // (administrative_nodes.code), label = display name. Ward.code là primary
+  // key — tránh ambiguity khi 2 xã/phường trùng tên ở 2 tỉnh/quận khác.
   const wardOptions = useMemo(
-    () => wards.map((w) => ({ value: w.name, label: w.name })),
+    () => wards.map((w) => ({ value: w.code, label: w.name })),
     [wards],
   )
+
+  // Derive combobox internal value (= ward.code) từ 2 nguồn theo priority:
+  //   1. `wardCodeValue` prop (callers new — pass canonical code thẳng)
+  //   2. Fallback: lookup `wardValue` (display name) ngược ra code từ wards
+  //      list — backward-compat cho hồ sơ legacy chưa wire code.
+  // Khi cả 2 đều miss (vd wards list chưa load, hoặc name không match) →
+  // combobox shows placeholder; sẽ render đúng khi wards load và user re-pick.
+  const selectedWardCode = useMemo(() => {
+    if (wardCodeValue) return wardCodeValue
+    if (wardValue) {
+      const matched = wards.find((w) => w.name === wardValue)
+      return matched?.code ?? ""
+    }
+    return ""
+  }, [wardCodeValue, wardValue, wards])
 
   // ---- Handlers ----
   // Phase E.4 KV bridge: every transition that changes the selected ward
   // (mode switch, province/district reset, direct ward pick, or clear)
-  // must mirror the ward code so callers tracking `permanent_commune_code`
-  // never see a stale or orphaned code. `lookupWardCode` reads the loaded
-  // wards list; returns `null` when ward is empty or not present in the
-  // current province's ward set (e.g. mode switched mid-edit).
-  const lookupWardCode = (wardName: string): string | null => {
-    if (!wardName) return null
-    const ward = wards.find((w) => w.name === wardName)
-    return ward?.code ?? null
-  }
+  // must mirror cả name (display) lẫn code (canonical KV input) qua callbacks
+  // để callers tracking `permanent_commune_code` không có stale orphan code.
 
   const handleModeChange = (newMode: AddressMode) => {
     onModeChange(newMode)
@@ -145,9 +170,17 @@ export function AdaptiveAddressSelect({
     onWardCodeChange?.(null)
   }
 
-  const handleWardChange = (name: string) => {
-    onWardChange(name)
-    onWardCodeChange?.(lookupWardCode(name))
+  const handleWardChange = (code: string) => {
+    // Combobox onChange giờ truyền ward.code (canonical). Lookup ward record
+    // để fire onWardChange(display name) — keep public API caller cũ unchanged.
+    if (!code) {
+      onWardChange("")
+      onWardCodeChange?.(null)
+      return
+    }
+    const ward = wards.find((w) => w.code === code)
+    onWardChange(ward?.name ?? "")
+    onWardCodeChange?.(ward?.code ?? null)
   }
 
   // ---- Render ----
@@ -215,10 +248,12 @@ export function AdaptiveAddressSelect({
           </div>
         ) : null}
 
-        {/* Ward */}
+        {/* Ward — combobox dùng ward.code làm canonical key (Phase E.4 Finding 1).
+            `value` = ward.code, options[].value = ward.code. Display name resolve
+            qua options[].label. */}
         <div>
           <Combobox
-            value={wardValue || ""}
+            value={selectedWardCode}
             onChange={handleWardChange}
             options={wardOptions}
             placeholder="Phường/Xã"


### PR DESCRIPTION
## Summary

Complete Phase E.4 cutover branch — 17 commits ships engine KV business resolution + UT permission hardening end-to-end:

**Engine + service (BE):**
- Auto-basis matrix Phase E.4 (target_level + admission_type drive basis) + fail-closed signals (`address_not_normalized`, `catalog_gap_school/commune`, `insufficient_data`, `ambiguous_requires_manual`)
- Eligibility gate runs unconditional cho cả multi-NV + legacy single-path; never falls back to `so_cap`
- Submit fail-closed returns `status="draft" + validation_errors[KV_UNRESOLVED]` (gỡ deadlock với draft override)
- Override draft live recompute (gỡ stale signal khi officer fix data post-submit-fail)
- Multi-NV consistency guard: block submit khi mixed `target_level`/`admission_type`
- Officer hard-blocked from `override-priority-kv` (Casbin migration `q9_07_e4f` + service-level deny + permission flag false)
- `resolved_by` = `admin` | `manager` (no more stale `"officer"` post commit 7)

**Frontend:**
- AdaptiveAddressSelect: ward.code canonical primary key + `onWardCodeChange` bridge to `permanent_commune_code`
- PersonalInfoTab wires commune_code from administrative_nodes ward selection
- PriorityInputsSection: removed radio "Theo trường học/Theo nơi thường trú"; engine auto-derives basis
- PriorityTab: preview path-aware (target_level + admission_type) + UI gating via `permissions.override_priority_kv`

**Migrations:**
- `q9_07_e4e`: seed `priority_area_config 2026` (4 KV) + `admission_method.default_bonus_rule` (3 methods) — idempotent
- `q9_07_e4f`: remove `role:officer override-priority-kv` Casbin policy row — idempotent

## Verification

- Regression: **263 passed** across 12 priority/eligibility/override test files
- Backend engine smoke: **40/40** scenarios (Phase 2-5)
- UI Chrome MCP smoke: **12 scenarios end-to-end** (officer/manager/admin × PriorityTab/DocumentsTab/PersonalInfo/Submit fail-closed)
- No P0/P1 bugs found
- Casbin runtime verified: `admin allow`, `manager allow`, `accountant deny`, no `officer` row

## Test plan

- [x] Backend regression suite 263/263 pass
- [x] Engine logic smoke (auto-basis matrix, resolve, fail-closed paths, override permissions, multi-NV consistency, bonus rules, UT verify/reject/untick, max bucket, warning audit)
- [x] UI Chrome MCP smoke: officer no override button, manager override visible, admin post-publish ack flow, submit fail-closed validation_errors flow, PATCH PersonalInfo `permanent_commune_code` canonical
- [x] Migrations upgrade → idempotent → downgrade → re-upgrade clean cycle verified
- [ ] Manual production cutover smoke 5 phút (officer/manager/admin click-through pre-deploy)
- [ ] Post-cutover: restore dev passwords (4 users đã reset = `Smoke@2026` cho UI smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)