### PR TITLE
chore(admissions): tech-debt bundle (hydration + canDecide + cache parity + socket-rooms + casbin keyMatch4)

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -49,7 +49,22 @@ jobs:
           #     at time of pinning. Re-evaluate on next pip-audit DB refresh.
           #   - PYSEC-2025-183: pyjwt weak-encryption DISPUTED by supplier
           #     (key length is application's responsibility, not library)
-          IGNORE_ARGS="--ignore-vuln CVE-2024-23342 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183"
+          #   - PYSEC-2026-161: starlette 0.49.1 Host header validation. Verified
+          #     NOT exploitable in QLTS by code audit 2026-05-23 (PR #324):
+          #       * 0 uses of str(request.url) / request.base_url / url_for() /
+          #         request.headers.get("host") in Backend_FastAPI/app/
+          #       * 18 uses of request.url.path are PATH-ONLY (from HTTP request
+          #         line, Host-independent)
+          #       * URL generation uses settings.FRONTEND_URL (deploy-time env)
+          #       * CSRF middleware uses Double-Submit Cookie (cookie + header),
+          #         not Host header
+          #       * frontend/src/ grep: 0 Host-dependent patterns
+          #     Defence-in-depth gap (nginx forwards Host unsanitized) + proper
+          #     fix (starlette 1.x requires coordinated fastapi 0.122+ upgrade)
+          #     tracked in memory entries:
+          #       - nginx-host-validation-gap-2026-05-23 (deadline 2026-05-30)
+          #       - starlette-fastapi-coordinated-upgrade-debt (deadline 2026-06-22)
+          IGNORE_ARGS="--ignore-vuln CVE-2024-23342 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183 --ignore-vuln PYSEC-2026-161"
           pip-audit -r requirements.txt --format json --output audit-results.json \
             $IGNORE_ARGS || true
 

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -49,15 +49,7 @@ jobs:
           #     at time of pinning. Re-evaluate on next pip-audit DB refresh.
           #   - PYSEC-2025-183: pyjwt weak-encryption DISPUTED by supplier
           #     (key length is application's responsibility, not library)
-          #   - PYSEC-2026-161: starlette 0.49.1 Host header validation — fix in
-          #     starlette 1.0.1, but starlette 1.x is a major bump that requires
-          #     a coordinated fastapi upgrade (we're on fastapi 0.121.0; 1.x
-          #     starlette compatibility starts at fastapi 0.122). Mitigation in
-          #     place: nginx reverse proxy validates Host header at the edge
-          #     (Documents/PRODUCTION_DEPLOY_GUIDE.md — nginx server_name
-          #     directive rejects unknown hosts before reaching app). Risk is
-          #     defence-in-depth, not primary. Track as dependency-upgrade PR.
-          IGNORE_ARGS="--ignore-vuln CVE-2024-23342 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183 --ignore-vuln PYSEC-2026-161"
+          IGNORE_ARGS="--ignore-vuln CVE-2024-23342 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183"
           pip-audit -r requirements.txt --format json --output audit-results.json \
             $IGNORE_ARGS || true
 

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -49,7 +49,15 @@ jobs:
           #     at time of pinning. Re-evaluate on next pip-audit DB refresh.
           #   - PYSEC-2025-183: pyjwt weak-encryption DISPUTED by supplier
           #     (key length is application's responsibility, not library)
-          IGNORE_ARGS="--ignore-vuln CVE-2024-23342 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183"
+          #   - PYSEC-2026-161: starlette 0.49.1 Host header validation — fix in
+          #     starlette 1.0.1, but starlette 1.x is a major bump that requires
+          #     a coordinated fastapi upgrade (we're on fastapi 0.121.0; 1.x
+          #     starlette compatibility starts at fastapi 0.122). Mitigation in
+          #     place: nginx reverse proxy validates Host header at the edge
+          #     (Documents/PRODUCTION_DEPLOY_GUIDE.md — nginx server_name
+          #     directive rejects unknown hosts before reaching app). Risk is
+          #     defence-in-depth, not primary. Track as dependency-upgrade PR.
+          IGNORE_ARGS="--ignore-vuln CVE-2024-23342 --ignore-vuln PYSEC-2026-89 --ignore-vuln PYSEC-2025-183 --ignore-vuln PYSEC-2026-161"
           pip-audit -r requirements.txt --format json --output audit-results.json \
             $IGNORE_ARGS || true
 

--- a/Backend_FastAPI/alembic/versions/qa20260522_tighten_lead_denies.py
+++ b/Backend_FastAPI/alembic/versions/qa20260522_tighten_lead_denies.py
@@ -1,0 +1,116 @@
+"""Tighten Casbin denies for 4 lead static routes — ACCOUNTANT ONLY.
+
+**Idempotent**: safe to re-run; each INSERT is guarded by NOT EXISTS.
+
+Casbin matcher `keyMatch4(r.obj, p.obj)` silently drops the `[regex]`
+constraint inside `{token}` (casbin/util/builtin_operators.py:22, 167 —
+`KEY_MATCH4_PATTERN = re.compile(r"{([^/]+)}")` then hard-replaces the
+captured token with `([^/]+)` regardless of the regex hint). The
+existing policy `/api/leads/{id}` therefore admits any 3-segment URL
+under `/api/leads/`, including the 4 static routes below. Both officer
+and accountant inherited de-facto access to:
+
+  * GET  /api/leads/export
+  * POST /api/leads/bulk-assign
+  * POST /api/leads/bulk-delete
+  * GET  /api/leads/distribution-preview
+
+`AUTHORIZATION_MATRIX.md` says only manager (and admin via wildcard)
+should reach these. This migration inserts 4 ACCOUNTANT DENY rows.
+
+Why NOT officer DENY: officer is an inheritance PARENT in the role
+tree (admin -> manager -> officer; accountant -> officer). A DENY at
+the officer subject propagates UP to manager + admin via Casbin's
+`g(r.sub, p.sub)` policy expansion AND DOWN to accountant. Verified
+empirically with `test_casbin_lead_static_route_collision.py`
+2026-05-23: officer DENY broke 11/16 matrix cells.
+
+Officer's de-facto access is mitigated at the FE layer
+(LeadDialog.tsx:285 `enabled: isAdmin || managerUsesDistribution`).
+A proper BE fix needs a custom matcher that respects `{token:[regex]}`
+constraints — tracked separately per memory
+`lead-keymatch4-collision-followup`.
+
+ACCOUNTANT is a LEAF role (only children, no descendants), so DENY at
+accountant is contained: accountant gets 403; manager/admin/officer
+are untouched. P2 prod audit (2026-05-22) confirmed 0 accountant
+traffic on these 4 routes — no user-facing breakage.
+
+Prod baseline verified 2026-05-22:
+  * 0 DENY rows for accountant × any of the 4 routes
+  * 0 ALLOW rows for accountant × any of the 4 routes
+  * Manager has 3 ALLOWs (export, bulk-assign, distribution-preview);
+    no /bulk-delete (admin-only by design)
+  * No exotic policy on these paths — clean insertion target
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "qa20260522_tighten_lead_denies"
+down_revision = "q9_07_e4f"
+branch_labels = None
+depends_on = None
+
+
+# (object, action) pairs locked for accountant only. Officer-side
+# tightening deferred — see module docstring above.
+ACCOUNTANT_DENY_TARGETS = (
+    ("/api/leads/export", "GET"),
+    ("/api/leads/bulk-assign", "POST"),
+    ("/api/leads/bulk-delete", "POST"),
+    ("/api/leads/distribution-preview", "GET"),
+)
+
+
+def upgrade() -> None:
+    """INSERT 4 accountant DENY rows, idempotent via NOT EXISTS per row.
+
+    Memory `casbin-insert-must-include-eft`: v3 ('deny') MUST be
+    present. NULL v3 → load_policy() crashes with "invalid policy
+    size" → every enforce() returns 500. The CAST AS VARCHAR on each
+    literal mirrors the qae2e01 pattern so asyncpg's bind-parameter
+    type inference doesn't surprise us.
+    """
+    for obj, act in ACCOUNTANT_DENY_TARGETS:
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO casbin_rule (ptype, v0, v1, v2, v3)
+                SELECT CAST('p' AS VARCHAR), CAST('role:accountant' AS VARCHAR),
+                       CAST(:v1 AS VARCHAR), CAST(:v2 AS VARCHAR),
+                       CAST('deny' AS VARCHAR)
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM casbin_rule
+                    WHERE ptype = 'p'
+                      AND v0 = 'role:accountant'
+                      AND v1 = :v1
+                      AND v2 = :v2
+                      AND v3 = 'deny'
+                )
+                """
+            ).bindparams(v1=obj, v2=act)
+        )
+
+
+def downgrade() -> None:
+    """Remove exactly the 4 DENY rows this migration would have inserted.
+
+    Narrow predicate (ptype + v0='role:accountant' + v1 + v2 + v3='deny')
+    so we don't accidentally delete an ALLOW row that someone added
+    later for the same (route, verb) tuple.
+    """
+    for obj, act in ACCOUNTANT_DENY_TARGETS:
+        op.execute(
+            sa.text(
+                """
+                DELETE FROM casbin_rule
+                WHERE ptype = 'p'
+                  AND v0 = 'role:accountant'
+                  AND v1 = :v1
+                  AND v2 = :v2
+                  AND v3 = 'deny'
+                """
+            ).bindparams(v1=obj, v2=act)
+        )

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -263,6 +263,21 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/payments/intents", "action": "POST"},  # Create payment intent (online)
         {"subject": "{role}", "object": "/api/payments/intents/{id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/payments/methods", "action": "GET"},
+        # NOTE (PR #324 Commit 5) — Officer DENY for /api/leads/export,
+        # /bulk-assign, /bulk-delete, /distribution-preview was DESIGNED
+        # here but NOT shipped. Reason: officer sits as an inheritance
+        # parent in the diamond (admin -> manager -> officer; accountant
+        # -> officer), so a DENY at the officer subject propagates UP
+        # to manager + admin AND DOWN to accountant via Casbin's
+        # `g(r.sub, p.sub)` policy expansion — verified empirically with
+        # `test_casbin_lead_static_route_collision.py` 2026-05-23 (test
+        # showed 11/16 cells flipped to DENY). The keyMatch4 collision
+        # bypass that exposes these 4 routes to officer is mitigated
+        # at the FE layer (`LeadDialog.tsx:285` enabled-gate). A proper
+        # BE fix needs a custom matcher (e.g., `keyMatchPriority` or
+        # `keyMatch4Numeric`) that respects the regex constraint inside
+        # `{token}` — tracked separately per memory
+        # `launch-readiness-over-creep` + `lead-keymatch4-collision-followup`.
     ]
 }
 
@@ -431,6 +446,16 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/leads/check-duplicate",     "action": "GET",  "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads/import",              "action": "POST", "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads/import/template",     "action": "GET",  "eft": "deny"},
+        # PR #324 Commit 5 — mirror OFFICER_TEMPLATE block above for the
+        # 4 lead static routes. Separation-of-duties: finance staff never
+        # operate the lead distribution / export / bulk-assign / bulk-delete
+        # paths. Inheritance via `g, role:accountant, role:officer` would
+        # otherwise let accountant flow through any future officer ALLOW
+        # added to these paths; explicit deny pins the contract.
+        {"subject": "{role}", "object": "/api/leads/export",               "action": "GET",  "eft": "deny"},
+        {"subject": "{role}", "object": "/api/leads/bulk-assign",          "action": "POST", "eft": "deny"},
+        {"subject": "{role}", "object": "/api/leads/bulk-delete",          "action": "POST", "eft": "deny"},
+        {"subject": "{role}", "object": "/api/leads/distribution-preview", "action": "GET",  "eft": "deny"},
     ]
 }
 

--- a/Backend_FastAPI/app/core/events.py
+++ b/Backend_FastAPI/app/core/events.py
@@ -368,7 +368,7 @@ class SystemEvents(str, Enum):
     sessions viewing the profile refresh. Privacy: payload carries
     field NAMES only; old/new values stay in the audit log behind RBAC.
     Rooms scope = role_admin + unit_<lead.unit_id> +
-    user_room_<lead.assigned_officer_id> via ``_rooms_for_admission``.
+    user_room_<lead.assigned_officer_id> via ``rooms_for_admission``.
     """
 
     # =========================================================================
@@ -528,7 +528,7 @@ class SystemEvents(str, Enum):
             "actor_id": int                   # The user that ran the calculation
         }
 
-    Recipients: scoped via ``_rooms_for_admission(profile)`` — admin
+    Recipients: scoped via ``rooms_for_admission(profile)`` — admin
     role + lead unit + assigned officer. No notification-channel fanout.
     """
 

--- a/Backend_FastAPI/app/routers/admin/users.py
+++ b/Backend_FastAPI/app/routers/admin/users.py
@@ -1044,7 +1044,7 @@ async def update_existing_user(
 
     # ✅ NOTIFICATION 2.0: Dispatch USER_ROLE_CHANGED if role or unit changed
     if "role" in changes or "unit_id" in changes:
-        from app.services.notification_dispatcher import safe_dispatch, _rooms_for_user
+        from app.services.notification_dispatcher import safe_dispatch, rooms_for_user
         from app.core.events import SystemEvents
 
         old_unit_str = changes.get("unit_id", {}).get("old") if "unit_id" in changes else None
@@ -1067,12 +1067,12 @@ async def update_existing_user(
                 "actor_id": _current_admin_id,
             },
             dedupe_key=f"user_role_changed:{_updated_user_id}:{_updated_role}:{_updated_unit_id}",
-            rooms=_rooms_for_user(_updated_user_id),
+            rooms=rooms_for_user(_updated_user_id),
         )
 
     # Dispatch USER_DEACTIVATED notification if status changed to inactive
     if "status" in changes and changes["status"]["new"] == "inactive":
-        from app.services.notification_dispatcher import safe_dispatch, _rooms_for_user
+        from app.services.notification_dispatcher import safe_dispatch, rooms_for_user
         from app.core.events import SystemEvents
         await safe_dispatch(
             db=db,
@@ -1086,7 +1086,7 @@ async def update_existing_user(
             },
             dedupe_key=f"user_deactivated:{_updated_user_id}",
             skip_preference_check=True,  # Critical notification
-            rooms=_rooms_for_user(_updated_user_id),
+            rooms=rooms_for_user(_updated_user_id),
         )
 
     # Send notification to user if admin updated their info
@@ -1098,7 +1098,7 @@ async def update_existing_user(
             changes=list(changes.keys()),
         )
         change_description = ", ".join([f"{key}" for key in changes.keys()])
-        from app.services.notification_dispatcher import safe_dispatch, _rooms_for_user
+        from app.services.notification_dispatcher import safe_dispatch, rooms_for_user
         from app.core.events import SystemEvents
 
         await safe_dispatch(
@@ -1110,7 +1110,7 @@ async def update_existing_user(
                 "actor_id": _current_admin_id,
             },
             dedupe_key=f"user_profile_updated:{_updated_user_id}",
-            rooms=_rooms_for_user(_updated_user_id),
+            rooms=rooms_for_user(_updated_user_id),
         )
     else:
         log.debug(

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -34,7 +34,7 @@ from ..core.deps import (
     get_admission_for_user_read,
 )
 from ..services import admission_service
-from ..services.notification_dispatcher import safe_dispatch, _rooms_for_admission, _rooms_for_lead
+from ..services.notification_dispatcher import safe_dispatch, rooms_for_admission, rooms_for_lead
 from ..services.user_service import emit_data_updated as _emit_realtime_update
 from ..core.events import SystemEvents
 from ..utils.exceptions import (
@@ -329,7 +329,7 @@ async def create_admission_profile(
                 "actor_name": current_user.full_name or current_user.username,
             },
             dedupe_key=f"admission_profile_created:{profile.id}",
-            rooms=_rooms_for_admission(profile),
+            rooms=rooms_for_admission(profile),
         )
 
         return profile
@@ -1248,7 +1248,7 @@ async def delete_admission_profile(
                     "actor_name": current_user.full_name or current_user.username,
                 },
                 dedupe_key=f"admission_profile_deleted:{profile_id}",
-                rooms=_rooms_for_lead(_deleted_lead),
+                rooms=rooms_for_lead(_deleted_lead),
             )
 
         log.info(
@@ -1865,7 +1865,7 @@ async def override_admission(
                     "actor_name": current_user.full_name or current_user.username,
                 },
                 dedupe_key=f"admission_profile_overridden:{profile_id}",
-                rooms=_rooms_for_admission(result),
+                rooms=rooms_for_admission(result),
             )
 
         # 5. RETURN Pydantic Model
@@ -2121,7 +2121,7 @@ async def confirm_admission_by_token(
                     "actor_name": "Ứng viên xác nhận",
                 },
                 dedupe_key=f"admission_profile_confirmed:{profile.id}",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             )
 
         # 5. RETURN Response

--- a/Backend_FastAPI/app/routers/admissions_magic_link.py
+++ b/Backend_FastAPI/app/routers/admissions_magic_link.py
@@ -33,7 +33,7 @@ from ..schemas.magic_link import (
 )
 from ..services import magic_link_service
 from ..services.notification_dispatcher import (
-    _rooms_for_admission,
+    rooms_for_admission,
     safe_dispatch,
 )
 from ..utils.exceptions import BadRequest, ResourceNotFoundError
@@ -121,7 +121,7 @@ async def consume_magic_link_token(
                     "actor_name": "Ứng viên xác nhận",
                 },
                 dedupe_key=f"admission_profile_confirmed:{profile.id}",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             )
 
         return MagicLinkConsumeResponse(

--- a/Backend_FastAPI/app/routers/auth.py
+++ b/Backend_FastAPI/app/routers/auth.py
@@ -185,8 +185,8 @@ async def _complete_login_flow(
                 "actor_id": _notif_user_id,
             }
 
-            from ..services.notification_dispatcher import _rooms_for_user
-            _notif_rooms = _rooms_for_user(_notif_user_id)
+            from ..services.notification_dispatcher import rooms_for_user
+            _notif_rooms = rooms_for_user(_notif_user_id)
 
             async def _dispatch_suspicious_login():
                 try:

--- a/Backend_FastAPI/app/routers/collaborators.py
+++ b/Backend_FastAPI/app/routers/collaborators.py
@@ -46,7 +46,7 @@ from app.schemas.collaborator import (
 from app.core.events import SystemEvents
 from app.core.rate_limits import limiter, RateLimits
 from app.services import collaborator_service
-from app.services.notification_dispatcher import safe_dispatch, _rooms_for_user
+from app.services.notification_dispatcher import safe_dispatch, rooms_for_user
 from app.utils.exceptions import ResourceNotFoundError
 
 # ============================================================================
@@ -201,7 +201,7 @@ async def review_claim(
 
     # Dispatch notification to CTV
     ctv_user_id = claim.collaborator.user_id if claim.collaborator else None
-    _ctv_rooms = _rooms_for_user(ctv_user_id) if ctv_user_id else ["role_admin"]
+    _ctv_rooms = rooms_for_user(ctv_user_id) if ctv_user_id else ["role_admin"]
     if review_data.status == "approved":
         await safe_dispatch(
             db=db,
@@ -292,7 +292,7 @@ async def approve_collaborator_endpoint(
                 "actor_id": current_user.id,
             },
             dedupe_key=f"ctv_approved:{approved.id}",
-            rooms=_rooms_for_user(approved.user_id),
+            rooms=rooms_for_user(approved.user_id),
         )
 
     # Reload with relationships
@@ -347,7 +347,7 @@ async def suspend_collaborator_endpoint(
                 "actor_id": current_user.id,
             },
             dedupe_key=f"ctv_suspended:{collaborator.id}",
-            rooms=_rooms_for_user(collaborator.user_id),
+            rooms=rooms_for_user(collaborator.user_id),
         )
 
     repo = CollaboratorRepository(db)

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -13,7 +13,7 @@ from ..core.deps import CasbinAuth, LeadListFilter, get_lead_for_user, get_lead_
 from ..schemas.collaborator import LeadValidityUpdate
 from ..services import distribution_service, insights_service, lead_service
 from ..utils.csv_helpers import sanitize_csv_cell
-from ..services.notification_dispatcher import safe_dispatch, _rooms_for_lead  # ✅ NOTIFICATION 2.0 + scoped rooms
+from ..services.notification_dispatcher import safe_dispatch, rooms_for_lead  # ✅ NOTIFICATION 2.0 + scoped rooms
 from ..services.notification_payloads import EventPayload  # ✅ Phase 1
 from ..core.events import SystemEvents  # ✅ NOTIFICATION 2.0
 from ..core.constants import UserRole
@@ -675,7 +675,7 @@ async def update_existing_lead(
                 updated_fields=updated_fields,
             ),
             dedupe_key=f"lead_status_changed:{result.id}:{result.consultation_status_id}",
-            rooms=_rooms_for_lead(result),
+            rooms=rooms_for_lead(result),
         )
 
         # Commission check (Path 1)
@@ -696,7 +696,7 @@ async def update_existing_lead(
             status_changed=status_changed,
         ),
         dedupe_key=f"lead_updated:{result.id}:{int(datetime.now().timestamp())}",
-        rooms=_rooms_for_lead(result),
+        rooms=rooms_for_lead(result),
     )
 
     return result
@@ -751,7 +751,7 @@ async def delete_lead(
         event=SystemEvents.LEAD_DELETED,
         payload=EventPayload.for_lead_deleted(deleted_lead, current_user),
         dedupe_key=f"lead_deleted:{deleted_lead.id}",
-        rooms=_rooms_for_lead(lead),
+        rooms=rooms_for_lead(lead),
     )
 
     return None
@@ -798,7 +798,7 @@ async def restore_lead(
         event=SystemEvents.LEAD_RESTORED,
         payload=EventPayload.for_lead_restored(restored_lead, current_user),
         dedupe_key=EventPayload.dedupe_key("lead_restored", restored_lead.id),
-        rooms=_rooms_for_lead(lead),
+        rooms=rooms_for_lead(lead),
     )
 
     return restored_lead
@@ -835,7 +835,7 @@ async def add_new_consultation(
         event=SystemEvents.CONSULTATION_CREATED,
         payload=EventPayload.for_consultation_created(consultation, lead, current_user),
         dedupe_key=f"consultation_created:{consultation.id}",
-        rooms=_rooms_for_lead(lead),
+        rooms=rooms_for_lead(lead),
     )
 
     # Cascade: if consultation caused lead pipeline change, dispatch LEAD_STATUS_CHANGED
@@ -856,7 +856,7 @@ async def add_new_consultation(
                 "actor_name": current_user.full_name or current_user.username,
             },
             dedupe_key=f"lead_status_changed:{lead.id}:{lead.consultation_status_id}",
-            rooms=_rooms_for_lead(lead),
+            rooms=rooms_for_lead(lead),
         )
 
     return schemas.ConsultationCreateResult(
@@ -1047,7 +1047,7 @@ async def update_a_consultation(
             event=SystemEvents.CONSULTATION_UPDATED,
             payload=EventPayload.for_consultation_updated(result, lead, current_user, old_status_id=old_status_id),
             dedupe_key=f"consultation_updated:{result.id}:{result.consultation_status_id}",
-            rooms=_rooms_for_lead(result),
+            rooms=rooms_for_lead(result),
         )
 
         # Commission check (Path 3 - consultation update)
@@ -1077,7 +1077,7 @@ async def update_a_consultation(
                     "actor_name": current_user.full_name or current_user.username,
                 },
                 dedupe_key=f"lead_status_changed:{lead.id}:{lead.consultation_status_id}",
-                rooms=_rooms_for_lead(lead),
+                rooms=rooms_for_lead(lead),
             )
 
     return result
@@ -1115,7 +1115,7 @@ async def delete_a_consultation(
         event=SystemEvents.CONSULTATION_DELETED,
         payload=EventPayload.for_consultation_deleted(consultation_id, lead, current_user),
         dedupe_key=f"consultation_deleted:{consultation_id}",
-        rooms=_rooms_for_lead(lead),
+        rooms=rooms_for_lead(lead),
     )
 
     return None
@@ -1669,7 +1669,7 @@ async def update_lead_consultation_status(
             officer_name=lead.assigned_officer.full_name if lead.assigned_officer else "Unknown",
         ),
         dedupe_key=f"lead_status_changed:{lead.id}:{validated_status.id}",
-        rooms=_rooms_for_lead(lead),
+        rooms=rooms_for_lead(lead),
     )
 
     # Commission check (Path 2 - FSM)

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -52,7 +52,7 @@ from .notification_bundle import (
     compose_post_commit_callbacks,
     dispatch_bundle,
 )
-from .notification_dispatcher import _rooms_for_admission
+from .notification_dispatcher import rooms_for_admission
 from .admission_correction_helpers import (
     parse_and_normalize,
     post_parse_business_check,
@@ -5105,7 +5105,7 @@ async def submit_and_evaluate(
         # is the magic-link self-service path (Item Magic-Link FU).
         from .notification_dispatcher import (
             safe_dispatch as _safe_dispatch,
-            _rooms_for_lead as _rooms_for_lead_helper,
+            rooms_for_lead as rooms_for_lead_helper,
         )
 
         _capture_lead_id = profile.lead_id
@@ -5121,7 +5121,7 @@ async def submit_and_evaluate(
             if profile.updated_at
             else datetime.now(timezone.utc).isoformat()
         )
-        _capture_rooms = _rooms_for_lead_helper(_capture_lead)
+        _capture_rooms = rooms_for_lead_helper(_capture_lead)
 
         async def _post_commit_dispatch() -> None:
             await _safe_dispatch(
@@ -6721,7 +6721,7 @@ async def enroll_student(
                     "actor_name": current_user.full_name or current_user.username,
                 },
                 dedupe_key=f"student_enrolled:{result_dict['student_id']}",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
             NotificationIntent(
                 event=SystemEvents.LEAD_STATUS_CHANGED,
@@ -6734,7 +6734,7 @@ async def enroll_student(
                     "actor_name": current_user.full_name or current_user.username,
                 },
                 dedupe_key=f"lead_status_changed:{profile.lead_id}:sts11",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
         ]
         bundle = await dispatch_bundle(
@@ -6959,7 +6959,7 @@ async def approve_profile(
                     "actor_name": approver.full_name or approver.username,
                 },
                 dedupe_key=f"admission_profile_approved:{profile_id}",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
             NotificationIntent(
                 event=SystemEvents.LEAD_STATUS_CHANGED,
@@ -6972,7 +6972,7 @@ async def approve_profile(
                     "actor_name": approver.full_name or approver.username,
                 },
                 dedupe_key=f"lead_status_changed:{profile.lead_id}:sts09",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
         ]
         bundle = await dispatch_bundle(
@@ -7160,7 +7160,7 @@ async def reject_profile(
                     "actor_name": rejector.full_name or rejector.username,
                 },
                 dedupe_key=f"admission_profile_rejected:{profile_id}",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
             NotificationIntent(
                 event=SystemEvents.LEAD_STATUS_CHANGED,
@@ -7173,7 +7173,7 @@ async def reject_profile(
                     "actor_name": rejector.full_name or rejector.username,
                 },
                 dedupe_key=f"lead_status_changed:{profile.lead_id}:sts16",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
         ]
         bundle = await dispatch_bundle(
@@ -7361,7 +7361,7 @@ async def request_revision(
                     "actor_name": reviewer.full_name or reviewer.username,
                 },
                 dedupe_key=f"admission_profile_revision:{profile_id}",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
             NotificationIntent(
                 event=SystemEvents.LEAD_STATUS_CHANGED,
@@ -7374,7 +7374,7 @@ async def request_revision(
                     "actor_name": reviewer.full_name or reviewer.username,
                 },
                 dedupe_key=f"lead_status_changed:{profile.lead_id}:sts17",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
         ]
         bundle = await dispatch_bundle(
@@ -7547,7 +7547,7 @@ async def record_application_fee_payment(
         ),
     }
     _db = db
-    _rooms = _rooms_for_admission(profile)
+    _rooms = rooms_for_admission(profile)
 
     async def post_commit():
         from app.services.notification_dispatcher import safe_dispatch
@@ -7770,7 +7770,7 @@ async def resubmit_profile(
                     "actor_name": _actor_name,
                 },
                 dedupe_key=f"admission_profile_resubmitted:{profile_id}",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
             NotificationIntent(
                 event=SystemEvents.LEAD_STATUS_CHANGED,
@@ -7783,7 +7783,7 @@ async def resubmit_profile(
                     "actor_name": _actor_name,
                 },
                 dedupe_key=f"lead_status_changed:{profile.lead_id}:sts07",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
         ]
         bundle = await dispatch_bundle(
@@ -8272,7 +8272,7 @@ async def finalize_profile(
                     "actor_name": admin.full_name or admin.username,
                 },
                 dedupe_key=f"admission_profile_finalized:{profile_id}",
-                rooms=_rooms_for_admission(locked_profile),
+                rooms=rooms_for_admission(locked_profile),
             ),
             NotificationIntent(
                 event=SystemEvents.LEAD_STATUS_CHANGED,
@@ -8285,7 +8285,7 @@ async def finalize_profile(
                     "actor_name": admin.full_name or admin.username,
                 },
                 dedupe_key=f"lead_status_changed:{locked_profile.lead_id}:sts11",
-                rooms=_rooms_for_admission(locked_profile),
+                rooms=rooms_for_admission(locked_profile),
             ),
         ]
         bundle = await dispatch_bundle(
@@ -8583,7 +8583,7 @@ async def withdraw_profile(
                     "actor_name": _actor_name,
                 },
                 dedupe_key=f"admission_profile_withdrawn:{profile_id}",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
             NotificationIntent(
                 event=SystemEvents.LEAD_STATUS_CHANGED,
@@ -8596,7 +8596,7 @@ async def withdraw_profile(
                     "actor_name": _actor_name,
                 },
                 dedupe_key=f"lead_status_changed:{profile.lead_id}:sts08",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
         ]
         bundle = await dispatch_bundle(
@@ -8803,7 +8803,7 @@ async def apply_minor_correction(
         },
         # Required because catalog marks the event privacy="sensitive";
         # dispatcher fail-closed guard would block a no-rooms emit.
-        "rooms": _rooms_for_admission(profile),
+        "rooms": rooms_for_admission(profile),
     }
 
     # 10. Re-populate response fields. Pass documents=None — get_admission_for_user
@@ -8950,7 +8950,7 @@ async def mark_student_dropped(
                     "actor_name": actor.full_name or actor.username,
                 },
                 dedupe_key=f"admission_profile_dropped:{profile.id}",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
             NotificationIntent(
                 event=SystemEvents.LEAD_STATUS_CHANGED,
@@ -8963,7 +8963,7 @@ async def mark_student_dropped(
                     "actor_name": actor.full_name or actor.username,
                 },
                 dedupe_key=f"lead_status_changed:{profile.lead_id}:sts12",
-                rooms=_rooms_for_admission(profile),
+                rooms=rooms_for_admission(profile),
             ),
         ]
         bundle = await dispatch_bundle(
@@ -9478,7 +9478,7 @@ async def verify_and_confirm(
             # HTTP error — without this hand-off browser realtime +
             # email enqueue would never happen.
             from .notification_dispatcher import dispatch as _dispatch
-            from .notification_dispatcher import _rooms_for_admission
+            from .notification_dispatcher import rooms_for_admission
             hard_lock_cb = None
             try:
                 _, hard_lock_cb = await _dispatch(
@@ -9499,7 +9499,7 @@ async def verify_and_confirm(
                             else "Học viên"
                         ),
                     },
-                    rooms=_rooms_for_admission(profile),
+                    rooms=rooms_for_admission(profile),
                 )
             except Exception as dispatch_err:  # noqa: BLE001 — best-effort
                 # Dispatch failure must NOT block the hard-lock
@@ -9845,7 +9845,7 @@ async def bulk_approve(
                             "actor_name": approver.full_name or approver.username,
                         },
                         dedupe_key=f"admission_profile_approved:{profile.id}",
-                        rooms=_rooms_for_admission(profile),
+                        rooms=rooms_for_admission(profile),
                     ),
                     NotificationIntent(
                         event=SystemEvents.LEAD_STATUS_CHANGED,
@@ -9858,7 +9858,7 @@ async def bulk_approve(
                             "actor_name": approver.full_name or approver.username,
                         },
                         dedupe_key=f"lead_status_changed:{profile.lead_id}:sts09",
-                        rooms=_rooms_for_admission(profile),
+                        rooms=rooms_for_admission(profile),
                     ),
                 ]
                 bundle = await dispatch_bundle(
@@ -10067,7 +10067,7 @@ async def bulk_reject(
                             "actor_name": rejector.full_name or rejector.username,
                         },
                         dedupe_key=f"admission_profile_rejected:{profile.id}",
-                        rooms=_rooms_for_admission(profile),
+                        rooms=rooms_for_admission(profile),
                     ),
                     NotificationIntent(
                         event=SystemEvents.LEAD_STATUS_CHANGED,
@@ -10080,7 +10080,7 @@ async def bulk_reject(
                             "actor_name": rejector.full_name or rejector.username,
                         },
                         dedupe_key=f"lead_status_changed:{profile.lead_id}:sts16",
-                        rooms=_rooms_for_admission(profile),
+                        rooms=rooms_for_admission(profile),
                     ),
                 ]
                 bundle = await dispatch_bundle(

--- a/Backend_FastAPI/app/services/assignment_service.py
+++ b/Backend_FastAPI/app/services/assignment_service.py
@@ -158,13 +158,13 @@ async def automatically_assign_lead(
 
                     # ✅ REFACTOR: Dispatch notification for assignment failure
                     try:
-                        from app.services.notification_dispatcher import _rooms_for_lead
+                        from app.services.notification_dispatcher import rooms_for_lead
                         _, notif_cb = await dispatch(
                             db=db,
                             event=SystemEvents.LEAD_ASSIGNMENT_FAILED,
                             payload=EventPayload.for_lead_assignment_failed(lead, lead_unit_id, "No officers available"),
                             dedupe_key=f"lead_assignment_failed:{lead_id}:no_officers",
-                            rooms=_rooms_for_lead(lead),
+                            rooms=rooms_for_lead(lead),
                         )
                         if notif_cb:
                             _post_commit_callbacks.append(notif_cb)
@@ -255,13 +255,13 @@ async def automatically_assign_lead(
 
                     # ✅ REFACTOR: Dispatch notification for assignment failure
                     try:
-                        from app.services.notification_dispatcher import _rooms_for_lead
+                        from app.services.notification_dispatcher import rooms_for_lead
                         _, notif_cb = await dispatch(
                             db=db,
                             event=SystemEvents.LEAD_ASSIGNMENT_FAILED,
                             payload=EventPayload.for_lead_assignment_failed(lead, lead_unit_id, "All officers at full capacity"),
                             dedupe_key=f"lead_assignment_failed:{lead_id}:capacity",
-                            rooms=_rooms_for_lead(lead),
+                            rooms=rooms_for_lead(lead),
                         )
                         if notif_cb:
                             _post_commit_callbacks.append(notif_cb)
@@ -435,7 +435,7 @@ async def automatically_assign_lead(
                 offering_name = getattr(lead.offering, 'offering_type', 'N/A')
 
             # Dispatch notification (saves to DB via flush, caller commits)
-            from app.services.notification_dispatcher import _rooms_for_lead
+            from app.services.notification_dispatcher import rooms_for_lead
             _, notif_cb = await dispatch(
                 db=db,
                 event=SystemEvents.LEAD_ASSIGNED,
@@ -446,7 +446,7 @@ async def automatically_assign_lead(
                     assignment_method="automatic",
                 ),
                 dedupe_key=f"lead_assigned:{lead.id}:{chosen_one.id}",
-                rooms=_rooms_for_lead(lead),
+                rooms=rooms_for_lead(lead),
             )
             if notif_cb:
                 _post_commit_callbacks.append(notif_cb)

--- a/Backend_FastAPI/app/services/commission_service.py
+++ b/Backend_FastAPI/app/services/commission_service.py
@@ -153,7 +153,7 @@ async def check_and_create_commission(
     # Build notification callback
     async def _notify():
         from app.core.events import SystemEvents
-        from app.services.notification_dispatcher import safe_dispatch, _rooms_for_user
+        from app.services.notification_dispatcher import safe_dispatch, rooms_for_user
 
         for record in records:
             await safe_dispatch(
@@ -168,7 +168,7 @@ async def check_and_create_commission(
                     "actor_id": actor_id,
                 },
                 dedupe_key=f"ctv_commission_created:{record.id}",
-                rooms=_rooms_for_user(collaborator.user_id) if collaborator.user_id else ["role_admin"],
+                rooms=rooms_for_user(collaborator.user_id) if collaborator.user_id else ["role_admin"],
             )
 
     return records, _notify

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -307,8 +307,8 @@ class FeeCalculationService:
         # Pre-compute everything the closure needs while the session is
         # still attached; rooms must come from the admission helper since
         # the emit runs AFTER the router commits.
-        from app.services.notification_dispatcher import _rooms_for_admission
-        _rooms = _rooms_for_admission(profile)
+        from app.services.notification_dispatcher import rooms_for_admission
+        _rooms = rooms_for_admission(profile)
         _event_payload = {
             "admission_profile_id": admission_profile_id,
             "lead_id": getattr(_lead_obj, "id", None) if _lead_obj else None,

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -262,8 +262,8 @@ class InvoiceService:
             ]
             _db = self.db
             # Snapshot rooms pre-commit so post-commit callback doesn't lazy-fetch
-            from app.services.notification_dispatcher import _rooms_for_admission
-            _issued_rooms = _rooms_for_admission(_prof) if _prof is not None else ["role_admin"]
+            from app.services.notification_dispatcher import rooms_for_admission
+            _issued_rooms = rooms_for_admission(_prof) if _prof is not None else ["role_admin"]
 
             async def _post_commit_cb_fn():
                 from app.services.notification_dispatcher import safe_dispatch
@@ -471,8 +471,8 @@ class InvoiceService:
             degree_level=_degree_level,
         )
         _db = self.db
-        from app.services.notification_dispatcher import _rooms_for_admission
-        _invoice_rooms = _rooms_for_admission(_profile) if _profile is not None else ["role_admin"]
+        from app.services.notification_dispatcher import rooms_for_admission
+        _invoice_rooms = rooms_for_admission(_profile) if _profile is not None else ["role_admin"]
 
         async def post_commit():
             if not _invoice_payload.get("user_id"):
@@ -647,7 +647,7 @@ class InvoiceService:
             as_of_date=check_date,
         )
 
-        from app.services.notification_dispatcher import _rooms_for_admission
+        from app.services.notification_dispatcher import rooms_for_admission
 
         marked = []
         overdue_payloads = []
@@ -684,7 +684,7 @@ class InvoiceService:
                     _lead_id = _prof.lead_id
                     if getattr(_prof, "lead", None):
                         _officer_id = _prof.lead.assigned_officer_id
-                    _rooms_this = _rooms_for_admission(_prof)
+                    _rooms_this = rooms_for_admission(_prof)
 
             overdue_payloads.append({
                 "invoice_id": invoice.id,

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -1174,8 +1174,8 @@ async def create_lead(
 
         # Snapshot rooms for LEAD_* sensitive emits (fail-closed guard requires
         # non-empty rooms when SOCKET_SCOPED_EMIT=true).
-        from app.services.notification_dispatcher import _rooms_for_lead
-        _lead_rooms = _rooms_for_lead(db_lead)
+        from app.services.notification_dispatcher import rooms_for_lead
+        _lead_rooms = rooms_for_lead(db_lead)
 
         # ✅ Dispatch LEAD_CREATED notification in savepoint
         _lead_created_cb = None
@@ -1695,7 +1695,7 @@ async def update_lead(
         if reassignment_triggered:
             # Dispatch notification for lead reassignment in savepoint (safe for post-commit callback)
             try:
-                from app.services.notification_dispatcher import _rooms_for_lead
+                from app.services.notification_dispatcher import rooms_for_lead
                 async with db.begin_nested():
                     _, _reassign_cb = await dispatch(
                         db=db,
@@ -1710,7 +1710,7 @@ async def update_lead(
                             notify_user_ids=[old_officer_id] if old_officer_id else [],
                         ),
                         dedupe_key=f"lead_reassigned:{lead_id}",
-                        rooms=_rooms_for_lead(lead),
+                        rooms=rooms_for_lead(lead),
                     )
             except Exception as e:
                 log.error(
@@ -2158,7 +2158,7 @@ async def assign_lead_manually(
             else (lead.offering.offering_type if lead.offering else "N/A")
         )
 
-        from app.services.notification_dispatcher import _rooms_for_lead
+        from app.services.notification_dispatcher import rooms_for_lead
         async with db.begin_nested():
             _, _assign_cb = await dispatch(
                 db=db,
@@ -2168,7 +2168,7 @@ async def assign_lead_manually(
                     offering_name=offering_name,
                 ),
                 dedupe_key=f"lead_assigned:{lead.id}:{officer.id}",
-                rooms=_rooms_for_lead(lead),
+                rooms=rooms_for_lead(lead),
             )
     except Exception as e:
         log.error(

--- a/Backend_FastAPI/app/services/notification_bundle.py
+++ b/Backend_FastAPI/app/services/notification_bundle.py
@@ -67,8 +67,8 @@ class NotificationIntent:
            ``settings.SOCKET_SCOPED_EMIT=True`` — a sensitive intent without
            rooms will be blocked by the fail-closed guard in
            ``_emit_domain_event``. Build via
-           ``_rooms_for_admission(profile)`` / ``_rooms_for_lead(lead)`` /
-           ``_rooms_for_user(user_id)`` helpers at the call site.
+           ``rooms_for_admission(profile)`` / ``rooms_for_lead(lead)`` /
+           ``rooms_for_user(user_id)`` helpers at the call site.
     """
 
     event: SystemEvents

--- a/Backend_FastAPI/app/services/notification_dispatcher.py
+++ b/Backend_FastAPI/app/services/notification_dispatcher.py
@@ -348,12 +348,12 @@ async def _emit_domain_event(
 #   * `user_room_<lead.assigned_officer_id>`   — assigned officer across units
 #
 # Caller responsibility: eager-load `profile.lead` (selectinload) before
-# calling `_rooms_for_admission`. The helper returns `["role_admin"]` only
+# calling `rooms_for_admission`. The helper returns `["role_admin"]` only
 # if the lead relationship or its scoping fields are unavailable — in that
 # case admins still see the event while unit/officer targeting is skipped.
 
 
-def _rooms_for_admission(profile) -> List[str]:
+def rooms_for_admission(profile) -> List[str]:
     """Compute Socket.IO rooms for an admission-scoped event.
 
     Returns a list containing `role_admin` + (if available) the owning
@@ -371,10 +371,10 @@ def _rooms_for_admission(profile) -> List[str]:
     return rooms
 
 
-def _rooms_for_lead(lead) -> List[str]:
+def rooms_for_lead(lead) -> List[str]:
     """Compute Socket.IO rooms for a lead-scoped event.
 
-    Mirror of `_rooms_for_admission` for events that carry a Lead row
+    Mirror of `rooms_for_admission` for events that carry a Lead row
     directly (e.g. LEAD_CREATED, LEAD_ASSIGNED).
     """
     rooms: List[str] = ["role_admin"]
@@ -388,7 +388,7 @@ def _rooms_for_lead(lead) -> List[str]:
     return rooms
 
 
-def _rooms_for_user(user_id: Optional[int]) -> List[str]:
+def rooms_for_user(user_id: Optional[int]) -> List[str]:
     """Rooms for user-targeted sensitive events (USER_DEACTIVATED, USER_ROLE_CHANGED, SUSPICIOUS_LOGIN).
 
     Admin visibility + the target user's personal inbox. No unit scoping —
@@ -632,8 +632,8 @@ async def dispatch(
                Required for sensitive events (admission/lead/finance/user
                PII) when ``settings.SOCKET_SCOPED_EMIT=True``; public
                events (org/pipeline config) may pass None and broadcast.
-               Use ``_rooms_for_admission(profile)`` / ``_rooms_for_lead(lead)``
-               / ``_rooms_for_user(user_id)`` helpers at the call site.
+               Use ``rooms_for_admission(profile)`` / ``rooms_for_lead(lead)``
+               / ``rooms_for_user(user_id)`` helpers at the call site.
 
     Returns:
         Tuple of (notification_ids, post_commit_callback)
@@ -1729,7 +1729,7 @@ async def dispatch_to_user(
 
     Convenience wrapper that ensures the user_id is in the payload
     for SpecificUsersResolver. Default Socket.IO scope is the target
-    user's personal room + admins (``_rooms_for_user``) — callers may
+    user's personal room + admins (``rooms_for_user``) — callers may
     override via ``rooms=`` if the event needs broader/narrower targeting.
 
     Args:
@@ -1745,7 +1745,7 @@ async def dispatch_to_user(
         Caller is responsible for calling db.commit() then callback().
     """
     payload["user_id"] = user_id
-    effective_rooms = rooms if rooms is not None else _rooms_for_user(user_id)
+    effective_rooms = rooms if rooms is not None else rooms_for_user(user_id)
     return await dispatch(db, event, payload, dedupe_key, rooms=effective_rooms)
 
 

--- a/Backend_FastAPI/app/services/officer_service.py
+++ b/Backend_FastAPI/app/services/officer_service.py
@@ -237,7 +237,7 @@ async def update_officer_availability(
     # ✅ Dispatch notification in savepoint (records flushed with main transaction)
     _notif_cb = None
     try:
-        from app.services.notification_dispatcher import _rooms_for_user
+        from app.services.notification_dispatcher import rooms_for_user
         _notif_rooms = ["role_admin"]
         if user.unit_id:
             _notif_rooms.append(f"unit_{user.unit_id}")

--- a/Backend_FastAPI/app/services/payment_intent_service.py
+++ b/Backend_FastAPI/app/services/payment_intent_service.py
@@ -445,8 +445,8 @@ class PaymentIntentService:
             }
         _db = self.db
         # Snapshot rooms pre-commit for scoped domain emit.
-        from app.services.notification_dispatcher import _rooms_for_admission
-        _rooms = _rooms_for_admission(profile) if profile is not None else None
+        from app.services.notification_dispatcher import rooms_for_admission
+        _rooms = rooms_for_admission(profile) if profile is not None else None
 
         _fee_fully_paid_payload: Optional[Dict[str, Any]] = None
         if fee is not None and fee.is_fully_paid:

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -205,8 +205,8 @@ class PaymentService:
         _db = self.db
         # Snapshot rooms pre-commit: profile may be unloaded after session close,
         # and fail-closed guard requires non-empty rooms for sensitive events.
-        from app.services.notification_dispatcher import _rooms_for_admission
-        _rooms = _rooms_for_admission(profile) if fee and profile else None
+        from app.services.notification_dispatcher import rooms_for_admission
+        _rooms = rooms_for_admission(profile) if fee and profile else None
 
         async def post_commit():
             from app.services.notification_dispatcher import safe_dispatch
@@ -388,8 +388,8 @@ class PaymentService:
         }
         _db = self.db
         # Snapshot rooms pre-commit for scoped domain emit.
-        from app.services.notification_dispatcher import _rooms_for_admission
-        _rooms = _rooms_for_admission(profile) if profile else None
+        from app.services.notification_dispatcher import rooms_for_admission
+        _rooms = rooms_for_admission(profile) if profile else None
 
         _fee_fully_paid = fee_remaining <= 0
         _fee_fully_paid_payload = {
@@ -499,8 +499,8 @@ class PaymentService:
         }
         _db = self.db
         # Snapshot rooms pre-commit for scoped domain emit.
-        from app.services.notification_dispatcher import _rooms_for_admission
-        _rooms = _rooms_for_admission(_profile) if _profile else None
+        from app.services.notification_dispatcher import rooms_for_admission
+        _rooms = rooms_for_admission(_profile) if _profile else None
 
         async def post_commit():
             from app.services.notification_dispatcher import safe_dispatch
@@ -973,8 +973,8 @@ class RefundService:
         }
         _db = self.db
         # Snapshot rooms pre-commit for scoped domain emit.
-        from app.services.notification_dispatcher import _rooms_for_admission
-        _rooms = _rooms_for_admission(profile) if profile is not None else None
+        from app.services.notification_dispatcher import rooms_for_admission
+        _rooms = rooms_for_admission(profile) if profile is not None else None
 
         async def post_commit():
             from app.services.notification_dispatcher import safe_dispatch

--- a/Backend_FastAPI/app/tasks/admission_tasks.py
+++ b/Backend_FastAPI/app/tasks/admission_tasks.py
@@ -193,7 +193,7 @@ def check_admission_surveys_due_task(self):
                                 submitted_at=submitted_ref,
                                 tracking_id=tracking_id,
                             ),
-                            rooms=notification_dispatcher._rooms_for_admission(profile),
+                            rooms=notification_dispatcher.rooms_for_admission(profile),
                         )
                         if notif_cb:
                             post_commit_callbacks.append(notif_cb)
@@ -311,7 +311,7 @@ def check_admission_confirmation_reminders_task(self):
         from ..models.lead import Lead
         from ..models.admission import AdmissionProfile as _ProfileModel
         from ..services import notification_dispatcher
-        from ..services.notification_dispatcher import _rooms_for_admission
+        from ..services.notification_dispatcher import rooms_for_admission
 
         result = {
             "checked": 0,
@@ -437,7 +437,7 @@ def check_admission_confirmation_reminders_task(self):
                             f"{settings.FRONTEND_URL.rstrip('/')}"
                             f"/confirm/{token.token}"
                         )
-                        rooms = _rooms_for_admission(profile)
+                        rooms = rooms_for_admission(profile)
 
                         if (
                             not in_6h_window

--- a/Backend_FastAPI/app/tasks/collaborator_tasks.py
+++ b/Backend_FastAPI/app/tasks/collaborator_tasks.py
@@ -107,7 +107,7 @@ def check_ctv_attribution_expiry_task(self):
 
                         # Notify CTV
                         if row.user_id:
-                            from app.services.notification_dispatcher import _rooms_for_user
+                            from app.services.notification_dispatcher import rooms_for_user
                             await safe_dispatch(
                                 db=db,
                                 event=SystemEvents.CTV_ATTRIBUTION_EXPIRED,
@@ -118,7 +118,7 @@ def check_ctv_attribution_expiry_task(self):
                                     "actor_id": 0,
                                 },
                                 dedupe_key=f"ctv_attribution_expired:{row.lead_id}",
-                                rooms=_rooms_for_user(row.user_id),
+                                rooms=rooms_for_user(row.user_id),
                             )
 
                         expired_count += 1
@@ -127,7 +127,7 @@ def check_ctv_attribution_expiry_task(self):
                     # WARNING: Notify CTV about upcoming expiry
                     days_remaining = ATTRIBUTION_EXPIRE_DAYS - days_since_review
                     if row.user_id:
-                        from app.services.notification_dispatcher import _rooms_for_user
+                        from app.services.notification_dispatcher import rooms_for_user
                         await safe_dispatch(
                             db=db,
                             event=SystemEvents.CTV_ATTRIBUTION_EXPIRING,
@@ -139,7 +139,7 @@ def check_ctv_attribution_expiry_task(self):
                                 "actor_id": 0,
                             },
                             dedupe_key=f"ctv_attribution_expiring:{row.lead_id}:{days_remaining}",
-                            rooms=_rooms_for_user(row.user_id),
+                            rooms=rooms_for_user(row.user_id),
                         )
                     warned_count += 1
 
@@ -237,7 +237,7 @@ def send_ctv_weekly_summary_task(self):
                     "commission_amount_this_week": str(comm_stats["total"]),
                 }
 
-                from app.services.notification_dispatcher import _rooms_for_user
+                from app.services.notification_dispatcher import rooms_for_user
                 await safe_dispatch(
                     db=db,
                     event=SystemEvents.CTV_WEEKLY_SUMMARY,
@@ -248,7 +248,7 @@ def send_ctv_weekly_summary_task(self):
                         "actor_id": 0,
                     },
                     dedupe_key=f"ctv_weekly_summary:{collab.id}:{now.isocalendar()[1]}",
-                    rooms=_rooms_for_user(collab.user_id) if collab.user_id else ["role_admin"],
+                    rooms=rooms_for_user(collab.user_id) if collab.user_id else ["role_admin"],
                 )
                 sent_count += 1
 

--- a/Backend_FastAPI/app/tasks/notification_outbox_tasks.py
+++ b/Backend_FastAPI/app/tasks/notification_outbox_tasks.py
@@ -67,9 +67,9 @@ from ..celery_app import celery_app
 from ..core.event_catalog import get_event
 from ..core.events import SystemEvents
 from ..services.notification_dispatcher import (
-    _rooms_for_admission,
-    _rooms_for_lead,
-    _rooms_for_user,
+    rooms_for_admission,
+    rooms_for_lead,
+    rooms_for_user,
     dispatch,
 )
 from .utils import run_async_task, task_db_session
@@ -242,7 +242,7 @@ async def _resolve_rooms_for_event(
         (dispatcher sẽ fail-closed cho sensitive event — đúng contract).
         Public event không cần rooms (dispatcher broadcast global).
 
-    Note: helper safety — ``_rooms_for_admission(None)`` trả
+    Note: helper safety — ``rooms_for_admission(None)`` trả
     ``["role_admin"]`` thay vì crash, nên fallback luôn có admin
     visibility tối thiểu khi profile bị delete giữa outbox INSERT và
     worker drain.
@@ -260,18 +260,18 @@ async def _resolve_rooms_for_event(
         )
         result = await session.execute(stmt)
         profile = result.scalar_one_or_none()
-        return _rooms_for_admission(profile)
+        return rooms_for_admission(profile)
 
     # Lead-scoped events: payload chứa lead_id.
     lead_id = payload.get("lead_id")
     if isinstance(lead_id, int):
         lead = await session.get(models.Lead, lead_id)
-        return _rooms_for_lead(lead)
+        return rooms_for_lead(lead)
 
     # User-targeted events: payload chứa user_id / target_user_id.
     user_id = payload.get("user_id") or payload.get("target_user_id")
     if isinstance(user_id, int):
-        return _rooms_for_user(user_id)
+        return rooms_for_user(user_id)
 
     # Public event (organization_*, pipeline_config_*) — dispatcher tự
     # broadcast global, rooms=None là intended path.

--- a/Backend_FastAPI/app/tasks/notification_tasks.py
+++ b/Backend_FastAPI/app/tasks/notification_tasks.py
@@ -266,7 +266,7 @@ def check_consultation_reminders_task(self):
                             minutes_until=minutes_until,
                             major_name=major_name,
                         ),
-                        rooms=notification_dispatcher._rooms_for_lead(lead),
+                        rooms=notification_dispatcher.rooms_for_lead(lead),
                     )
                     if notif_cb:
                         post_commit_callbacks.append(notif_cb)

--- a/Backend_FastAPI/tests/api/test_qa_wave9_lead_import_and_w8a32.py
+++ b/Backend_FastAPI/tests/api/test_qa_wave9_lead_import_and_w8a32.py
@@ -55,9 +55,9 @@ async def test_w9_n13_officer_import_no_nameerror_codepath():
     from app.routers import leads as leads_router
 
     source = inspect.getsource(leads_router.officer_import_leads)
-    # Pre-fix bug: `rooms=_rooms_for_lead(lead)` — `lead` undefined
-    assert "_rooms_for_lead(lead)" not in source, (
-        "W9-N.1.3 regression: `_rooms_for_lead(lead)` references undefined "
+    # Pre-fix bug: `rooms=rooms_for_lead(lead)` — `lead` undefined
+    assert "rooms_for_lead(lead)" not in source, (
+        "W9-N.1.3 regression: `rooms_for_lead(lead)` references undefined "
         "`lead` var in officer_import_leads scope (bulk endpoint, no "
         "singular lead). Use captured user.unit_id + role_admin rooms instead."
     )

--- a/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
+++ b/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
@@ -393,7 +393,13 @@ async def test_accountant_deny_rows_seeded(setup_test_database):
       - Q9 #07 Phase E Wave 1 (2026-05-19) added 5 deny rows for
         priority bonus routes (preview/catalog + override/verify/reject).
         Separation-of-duties — finance không touch priority scoring data.
-      - Total NOW: 38 deny rows.
+      - PR #324 Commit 5 (2026-05-23) added 4 deny rows for the 4 lead
+        static routes (export / bulk-* / distribution-preview) as
+        defence-in-depth against keyMatch4 collision. Redundant under
+        the current matcher (existing `/api/leads/{id}` GET/PUT denies
+        already cover these via collision), but locks intent if matcher
+        is ever tightened.
+      - Total NOW: 42 deny rows.
     """
     db_url = os.environ["DATABASE_URL"]
     enforcer, engine = await _seed_test_db_and_load_enforcer(db_url)
@@ -467,6 +473,15 @@ async def test_accountant_deny_rows_seeded(setup_test_database):
             # KHÔNG scan/manage UT minh chứng (separation-of-duties).
             ("/api/v2/admissions/*/priority-evidence/*/upload",    "POST"),
             ("/api/v2/admissions/*/priority-evidence/*",           "DELETE"),
+            # PR #324 Commit 5 (2026-05-23) — defence-in-depth against
+            # keyMatch4 collision on `/api/leads/{id}` matching static
+            # routes. Officer-side fix deferred (officer is parent role;
+            # DENY would propagate). Migration
+            # `qa20260522_tighten_lead_denies` seeds these.
+            ("/api/leads/export",                                  "GET"),
+            ("/api/leads/bulk-assign",                             "POST"),
+            ("/api/leads/bulk-delete",                             "POST"),
+            ("/api/leads/distribution-preview",                    "GET"),
         }
         assert observed == expected, (
             f"Accountant deny-row set drifted. "

--- a/Backend_FastAPI/tests/integration/test_casbin_lead_static_route_collision.py
+++ b/Backend_FastAPI/tests/integration/test_casbin_lead_static_route_collision.py
@@ -1,0 +1,280 @@
+"""Lead static-route Casbin enforce matrix — PR #324 Commit 5.
+
+Pins the 4-route × 4-role × verb matrix for the 4 lead static
+endpoints. Without this anchor, a future template edit that drops a
+related DENY row (or relaxes keyMatch4 to a stricter matcher) would
+silently restore the bypass — first signal would be a downstream Lead
+UI bug or a security-team finding, too late.
+
+Architecture context:
+    casbin matcher: `m = g(r.sub, p.sub) && keyMatch4(r.obj, p.obj)
+                        && regexMatch(r.act, p.act)`
+    role tree:       admin -> manager -> officer -> user
+                     accountant -> officer
+
+    Key consequence: `g(manager, officer)` and `g(accountant, officer)`
+    are BOTH IS-A edges. A DENY at the officer subject would propagate
+    UP to manager + admin AND DOWN to accountant via policy expansion.
+    Verified empirically 2026-05-23 (officer DENY broke 11/16 cells).
+    Officer-level DENY therefore CANNOT be used. The keyMatch4 fix for
+    officer-side bypass needs a custom matcher
+    (`keyMatchPriority` / `keyMatch4Numeric`) that respects
+    `{token:[regex]}` constraints — tracked separately per memory
+    `lead-keymatch4-collision-followup`.
+
+Matrix expectations (4 routes × 4 roles = 16 cells):
+
+    admin   ALLOW all 4  (wildcard `/*.*`)
+    manager ALLOW 3 (export, bulk-assign, distribution-preview);
+            DENY 1 (bulk-delete — no manager allow, admin-only by
+            design)
+    accountant DENY all 4. GET routes (export, distribution-preview)
+            are denied via the EXISTING `/api/leads/{id} GET deny`
+            rule (line ~425 in ACCOUNTANT_TEMPLATE) that
+            keyMatch4-collides with the static path. The new explicit
+            DENY rows added by qa20260522_tighten_lead_denies are
+            defence-in-depth — redundant under the current matcher
+            but lock the intent if the matcher is ever tightened.
+            POST routes (bulk-*) are 403 by no-allow.
+    officer ALLOW 2 (export GET, distribution-preview GET — leaked via
+            officer's `/api/leads/{id}` GET ALLOW + keyMatch4
+            collision). DENY 2 (bulk-assign POST, bulk-delete POST —
+            no officer allow for /api/leads POST or /{id} POST).
+            KNOWN LIMITATION on the 2 leaks — FE LeadDialog.tsx:285
+            gates the UI surface; direct API call still works.
+
+Plus 1 regression test: officer GET /api/leads/123 must STILL succeed
+(non-collision numeric ID — verifies we didn't accidentally break the
+legitimate /{id} lookup path).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import casbin
+import pytest
+from casbin_async_sqlalchemy_adapter import Adapter
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.casbin_config.policy_templates import SYSTEM_ROLES, apply_template
+
+
+pytestmark = pytest.mark.asyncio
+
+REPO_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+AUTH_MODEL_PATH = REPO_BACKEND_ROOT / "auth_model.conf"
+
+
+# 4 lead static routes + verbs.
+ROUTES: tuple[tuple[str, str], ...] = (
+    ("/api/leads/export",               "GET"),
+    ("/api/leads/bulk-assign",          "POST"),
+    ("/api/leads/bulk-delete",          "POST"),
+    ("/api/leads/distribution-preview", "GET"),
+)
+
+
+# Expected matrix. True = allow, False = deny.
+# Index 0=export GET, 1=bulk-assign POST, 2=bulk-delete POST, 3=distribution-preview GET.
+EXPECTED: dict[str, list[bool]] = {
+    # Admin wildcard /*. * allows everything.
+    "role:admin":      [True,  True,  True,  True],
+    # Manager: explicit ALLOW for export/bulk-assign/distribution-preview
+    # (policy_templates.py:463-468). No allow for /bulk-delete (admin-only
+    # by matrix design) → False on that cell.
+    "role:manager":    [True,  True,  False, True],
+    # Accountant: ALL DENY.
+    #   - GET cells (0, 3): existing `/api/leads/{id} GET deny` rule
+    #     in ACCOUNTANT_TEMPLATE collides with /export and
+    #     /distribution-preview via keyMatch4 → DENY wins. Commit 5's
+    #     new explicit /export GET + /distribution-preview GET denies
+    #     are defence-in-depth (redundant under current matcher).
+    #   - POST cells (1, 2): no accountant or officer ALLOW for
+    #     /api/leads POST or /{id} POST → False by no-allow. Commit 5's
+    #     new explicit POST denies are belt-and-suspenders.
+    "role:accountant": [False, False, False, False],
+    # Officer: GET routes leak via keyMatch4 collision with `/api/leads/{id}`
+    # GET ALLOW (officer template line ~119). POST routes have no officer
+    # allow → 403 by no-allow.
+    # KNOWN LIMITATION — officer GETs /export + /distribution-preview
+    # leak; FE LeadDialog.tsx:285 gates the UI but a direct API call
+    # still works. Pending custom-matcher security PR.
+    "role:officer":    [True,  False, False, True],
+}
+
+
+async def _seed_test_db_and_load_enforcer(
+    db_url: str,
+    *,
+    skip_deny_route: tuple[str, str, str] | None = None,
+):
+    """Seed casbin_rule with full SYSTEM_ROLES templates + diamond g
+    rules, optionally skipping ONE deny row (for bite-verify).
+    """
+    async_url = db_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    engine = create_async_engine(async_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(
+                "CREATE TABLE IF NOT EXISTS casbin_rule ("
+                "id SERIAL PRIMARY KEY, ptype VARCHAR(255), "
+                "v0 VARCHAR(255), v1 VARCHAR(255), v2 VARCHAR(255), "
+                "v3 VARCHAR(255), v4 VARCHAR(255), v5 VARCHAR(255))"))
+            await conn.execute(text("TRUNCATE casbin_rule RESTART IDENTITY"))
+
+            for role_config in SYSTEM_ROLES:
+                template_id = role_config.get("template_id")
+                role_name = role_config["name"]
+                if not template_id:
+                    continue
+                rules = apply_template(template_id, role_name)
+                for r in rules:
+                    if (
+                        skip_deny_route is not None
+                        and r["eft"] == "deny"
+                        and (r["subject"], r["object"], r["action"])
+                        == skip_deny_route
+                    ):
+                        continue
+                    await conn.execute(
+                        text(
+                            """
+                            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3)
+                            VALUES (
+                                CAST('p' AS varchar),
+                                CAST(:v0 AS varchar),
+                                CAST(:v1 AS varchar),
+                                CAST(:v2 AS varchar),
+                                CAST(:v3 AS varchar)
+                            )
+                            """
+                        ),
+                        {
+                            "v0": r["subject"],
+                            "v1": r["object"],
+                            "v2": r["action"],
+                            "v3": r["eft"],
+                        },
+                    )
+
+            # Diamond g-tree (mirror app/main.py:378-383 — admin→accountant
+            # edge dropped 2026-05-15).
+            for child, parent in (
+                ("role:officer",    "role:user"),
+                ("role:accountant", "role:officer"),
+                ("role:manager",    "role:officer"),
+                ("role:admin",      "role:manager"),
+            ):
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO casbin_rule (ptype, v0, v1)
+                        VALUES (
+                            CAST('g' AS varchar),
+                            CAST(:child AS varchar),
+                            CAST(:parent AS varchar)
+                        )
+                        """
+                    ),
+                    {"child": child, "parent": parent},
+                )
+
+        adapter = Adapter(engine)
+        enforcer = casbin.AsyncEnforcer(str(AUTH_MODEL_PATH), adapter)
+        await enforcer.load_policy()
+        return enforcer, engine
+    except Exception:
+        await engine.dispose()
+        raise
+
+
+async def test_lead_static_routes_4role_x_4route_matrix(setup_test_database):
+    """16-cell matrix lock. Use ROLE constant order for stable diffs."""
+    db_url = os.environ["DATABASE_URL"]
+    enforcer, engine = await _seed_test_db_and_load_enforcer(db_url)
+    try:
+        misses: list[str] = []
+        for role, expected_row in EXPECTED.items():
+            for idx, (obj, act) in enumerate(ROUTES):
+                actual = enforcer.enforce(role, obj, act)
+                expected = expected_row[idx]
+                if actual != expected:
+                    misses.append(
+                        f"  {role:<18} {act:<6} {obj:<40} "
+                        f"expected={expected} actual={actual}"
+                    )
+        assert not misses, (
+            f"Lead static-route matrix has {len(misses)} mismatch(es):\n"
+            + "\n".join(misses)
+        )
+    finally:
+        await engine.dispose()
+
+
+async def test_officer_can_still_read_lead_by_numeric_id(setup_test_database):
+    """Regression guard: the legitimate /api/leads/{id} ALLOW for officer
+    must still work for numeric IDs. We only added DENY rows for the
+    4 static routes; the existing wildcard allow on `/{id}` is untouched.
+    """
+    db_url = os.environ["DATABASE_URL"]
+    enforcer, engine = await _seed_test_db_and_load_enforcer(db_url)
+    try:
+        assert enforcer.enforce("role:officer", "/api/leads/123", "GET"), (
+            "officer must still be able to GET /api/leads/123 (the legitimate "
+            "lead-detail path). If this fails, the DENY rows are over-broad."
+        )
+        assert enforcer.enforce("role:officer", "/api/leads/123", "PUT"), (
+            "officer must still be able to PUT /api/leads/123."
+        )
+    finally:
+        await engine.dispose()
+
+
+async def test_bite_verify_removing_existing_id_deny_breaks_accountant(
+    setup_test_database,
+):
+    """Bite-verify the load-bearing rule.
+
+    The NEW Commit 5 explicit DENYs on /api/leads/export (etc.) are
+    redundant under the current keyMatch4 matcher — the EXISTING
+    `/api/leads/{id} GET deny` rule in ACCOUNTANT_TEMPLATE is what
+    actually keeps accountant out of /export today (keyMatch4 collides
+    /{id} with /export and the deny matches). Pin THAT rule by
+    removing it from the seed and asserting accountant flips to ALLOW.
+
+    If a future refactor moves /{id} to a stricter matcher (or drops
+    the rule entirely) WITHOUT also adding an explicit accountant DENY
+    on /export, this test catches the regression.
+    """
+    db_url = os.environ["DATABASE_URL"]
+    target = ("role:accountant", "/api/leads/{id}", "GET")
+    enforcer, engine = await _seed_test_db_and_load_enforcer(
+        db_url, skip_deny_route=target
+    )
+    try:
+        # Removing accountant's /{id} GET deny → /export GET via
+        # keyMatch4 should also no longer be denied. The new explicit
+        # /export DENY (from Commit 5) keeps the cell False — proving
+        # Commit 5's defence-in-depth role.
+        assert not enforcer.enforce(
+            "role:accountant", "/api/leads/export", "GET"
+        ), (
+            "Belt-and-suspenders contract: the new explicit accountant "
+            "DENY on /api/leads/export GET must keep accountant out "
+            "even when the /{id} keyMatch4-colliding DENY is missing. "
+            "If this returns True, the defence-in-depth has regressed."
+        )
+        # The genuinely-removed cell (/{id} on a numeric ID) DOES flip
+        # to allow — accountant inherits officer's /{id} GET ALLOW.
+        assert enforcer.enforce(
+            "role:accountant", "/api/leads/123", "GET"
+        ), (
+            "Bite control: removing accountant's /{id} GET DENY must "
+            "let accountant through to /api/leads/123 via inherited "
+            "officer ALLOW. If this still denies, something else "
+            "blocks accountant (the test isn't probing what we think)."
+        )
+    finally:
+        await engine.dispose()

--- a/Backend_FastAPI/tests/integration/test_socket_scoping_contract.py
+++ b/Backend_FastAPI/tests/integration/test_socket_scoping_contract.py
@@ -187,6 +187,6 @@ def test_sensitive_events_always_dispatch_with_rooms():
             + detail
             + "\n\nEvery sensitive SystemEvents reference in dispatch() / "
             "safe_dispatch() / NotificationIntent(...) must pass `rooms=...` "
-            "(non-None). Use _rooms_for_admission / _rooms_for_lead / "
-            "_rooms_for_user from notification_dispatcher."
+            "(non-None). Use rooms_for_admission / rooms_for_lead / "
+            "rooms_for_user from notification_dispatcher."
         )

--- a/Backend_FastAPI/tests/unit/test_fee_calculated_event.py
+++ b/Backend_FastAPI/tests/unit/test_fee_calculated_event.py
@@ -40,7 +40,7 @@ async def test_calculate_fee_post_commit_emits_fee_calculated_with_lead_stage_ch
 
     profile = MagicMock()
     profile.id = 99
-    profile.__dict__["lead"] = lead  # _rooms_for_admission / getattr path
+    profile.__dict__["lead"] = lead  # rooms_for_admission / getattr path
 
     # --- Wire a service instance with mocked collaborators.
     # db.refresh is the step that populates fee.id in reality; fake it by
@@ -67,7 +67,7 @@ async def test_calculate_fee_post_commit_emits_fee_calculated_with_lead_stage_ch
         "app.services.lead_admission_sync.sync_lead_tuition_calculated",
         new=_fake_sync,
     ), patch(
-        "app.services.notification_dispatcher._rooms_for_admission",
+        "app.services.notification_dispatcher.rooms_for_admission",
         return_value=["role_admin", "unit_1", "user_room_42"],
     ), patch(
         "app.services.notification_dispatcher.safe_dispatch",
@@ -132,7 +132,7 @@ async def test_calculate_fee_reports_lead_stage_unchanged_when_sync_noop():
     svc._get_installment_plan = AsyncMock(return_value=None)
 
     with patch(
-        "app.services.notification_dispatcher._rooms_for_admission",
+        "app.services.notification_dispatcher.rooms_for_admission",
         return_value=["role_admin", "unit_1", "user_room_42"],
     ), patch(
         "app.services.notification_dispatcher.safe_dispatch",

--- a/Backend_FastAPI/tests/unit/test_outbox_worker.py
+++ b/Backend_FastAPI/tests/unit/test_outbox_worker.py
@@ -512,7 +512,7 @@ async def test_mixed_batch_marks_each_row_independently(setup_test_database):
 # --- 8. P2 anchor (2026-05-22) — rooms derivation from payload -------------
 
 
-async def test_worker_passes_rooms_for_admission_event(setup_test_database):
+async def test_worker_passesrooms_for_admission_event(setup_test_database):
     """Anchor: worker MUST resolve rooms từ payload và pass `rooms=`
     xuống `dispatch()`. Trước fix, sensitive event qua outbox bị
     `_emit_domain_event` fail-closed do `rooms=None` (notification_dispatcher.py:281).
@@ -594,3 +594,69 @@ async def test_worker_rooms_derivation_failure_falls_back_to_none(
     assert mock_dispatch.await_count == 1
     call_kwargs = mock_dispatch.call_args.kwargs
     assert call_kwargs.get("rooms") is None
+
+
+# ---------------------------------------------------------------------------
+# PR #324 Commit 4 — rooms_for_admission contract anchor (P1-2).
+#
+# notification_outbox_tasks + 26 other modules import this helper to build
+# the scoped `rooms=` list for sensitive events (admission mutations, lead
+# updates, finance transactions). It's now a public API; the contract that
+# admin always sees the event + unit/officer scoping only flows through the
+# lead relationship needs an explicit anchor so a refactor that flips the
+# return shape (e.g., admin scoping removed, or admin moved to fallback)
+# fails loudly here.
+# ---------------------------------------------------------------------------
+class _StubLead:
+    """Minimal duck-typed lead — the helper reads two attrs via getattr."""
+
+    def __init__(self, unit_id, assigned_officer_id):
+        self.unit_id = unit_id
+        self.assigned_officer_id = assigned_officer_id
+
+
+class _StubProfile:
+    """Profile wrapper that may or may not have a lead attached."""
+
+    def __init__(self, lead):
+        self.lead = lead
+
+
+def test_rooms_for_admission_returns_three_tuple_with_lead():
+    """Admin + unit + assigned officer when lead is fully populated."""
+    from app.services.notification_dispatcher import rooms_for_admission
+
+    profile = _StubProfile(_StubLead(unit_id=5, assigned_officer_id=42))
+    assert rooms_for_admission(profile) == [
+        "role_admin",
+        "unit_5",
+        "user_room_42",
+    ]
+
+
+def test_rooms_for_admission_returns_admin_only_when_lead_null():
+    """Profile without an eager-loaded lead still emits to role_admin only.
+
+    Caller-responsibility contract: selectinload(profile.lead) before
+    dispatch. The helper degrades gracefully — admins keep visibility,
+    unit/officer scoping is skipped silently. This is the fallback path
+    `notification_dispatcher.py:351` documents.
+    """
+    from app.services.notification_dispatcher import rooms_for_admission
+
+    profile = _StubProfile(lead=None)
+    assert rooms_for_admission(profile) == ["role_admin"]
+
+
+def test_rooms_for_admission_skips_officer_when_unassigned():
+    """Lead present + unit set + no assigned officer → admin + unit only.
+
+    Distinct from the lead-null case above: this covers freshly created
+    leads in the distribution-pending state where unit_id is set but
+    assigned_officer_id is still null. unit-room subscribers must still
+    receive the event (manager fanout); officer-room is rightly skipped.
+    """
+    from app.services.notification_dispatcher import rooms_for_admission
+
+    profile = _StubProfile(_StubLead(unit_id=5, assigned_officer_id=None))
+    assert rooms_for_admission(profile) == ["role_admin", "unit_5"]

--- a/Backend_FastAPI/tests/unit/test_outbox_worker.py
+++ b/Backend_FastAPI/tests/unit/test_outbox_worker.py
@@ -512,7 +512,7 @@ async def test_mixed_batch_marks_each_row_independently(setup_test_database):
 # --- 8. P2 anchor (2026-05-22) — rooms derivation from payload -------------
 
 
-async def test_worker_passesrooms_for_admission_event(setup_test_database):
+async def test_worker_passes_rooms_for_admission_event(setup_test_database):
     """Anchor: worker MUST resolve rooms từ payload và pass `rooms=`
     xuống `dispatch()`. Trước fix, sensitive event qua outbox bị
     `_emit_domain_event` fail-closed do `rooms=None` (notification_dispatcher.py:281).

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionActions.tsx
@@ -21,6 +21,7 @@ import { Badge } from "@/components/ui/badge"
 import { Loader2, Save, ClipboardCheck, ArrowRight, ArrowLeft } from "lucide-react"
 import { usePermissions } from "@/hooks/usePermissions"
 import { getStatusConfig } from "@/lib/status-config"
+import { canDecide } from "@/lib/utils/admission-permissions"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 import { SendConfirmationButton } from "./SendConfirmationButton"
 import { SendMagicLinkButton } from "./SendMagicLinkButton"
@@ -45,24 +46,12 @@ export function AdmissionActions({
   const { can } = usePermissions(profile)
   const statusConfig = getStatusConfig(profile.status)
 
-  // Code review 2026-05-22 — sticky 'Tiếp tục' gate cùng điều kiện
-  // PipelineSidebar (Step 8 unlock) để UX consistent. Ưu tiên BE-aggregated
-  // `permissions.has_decision` flag (admission_service.py ~1617); fallback
-  // OR-7-flags cho backward-compat với deploy chưa ship BE change.
-  const perms = profile.permissions
-  const canDecide = Boolean(
-    perms?.has_decision ??
-    (perms?.approve ||
-      perms?.reject ||
-      perms?.resubmit ||
-      perms?.submit ||
-      perms?.request_revision ||
-      perms?.publish_result ||
-      perms?.enroll)
-  )
+  // Sticky 'Tiếp tục' gate cùng điều kiện PipelineSidebar (Step 8 unlock).
+  // Helper trusts BE-aggregated `permissions.has_decision`, fallback OR-7.
+  const decide = canDecide(profile.permissions)
   // Hide Tiếp tục khi step 7 + no decision perm → user không advance qua
   // Step 8 disabled. Step 1-6 navigation vẫn cho phép.
-  const showNextButton = currentStep < 8 && !(currentStep === 7 && !canDecide)
+  const showNextButton = currentStep < 8 && !(currentStep === 7 && !decide)
 
   return (
     <div className="fixed bottom-0 left-0 right-0 border-t bg-background z-40 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)]">

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/PriorityOverrideDialog.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/PriorityOverrideDialog.tsx
@@ -223,7 +223,7 @@ export function PriorityOverrideDialog({
               onValueChange={(v) => setKvResolved(v as KvCode)}
             >
               <SelectTrigger id="override-kv" data-testid="override-kv-select">
-                <SelectValue placeholder="Chọn KV mới..." />
+                <SelectValue placeholder="Chọn KV mới…" />
               </SelectTrigger>
               <SelectContent>
                 {KV_CODES.map((code) => (

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/PipelineSidebar.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/layout/PipelineSidebar.tsx
@@ -7,6 +7,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { useMemo } from "react"
 import { IssueSummary } from "./IssueSummary"
 import { derivePriorityIssues } from "./priorityIssues"
+import { canDecide } from "@/lib/utils/admission-permissions"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
 interface PipelineSidebarProps {
@@ -112,23 +113,9 @@ export function PipelineSidebar({
           const status = stepsStatus[step.id] || "locked"
           const isActive = currentStep === step.id
           const isFocused = focusedSteps.includes(step.id)
-          // Code review 2026-05-22 — ưu tiên BE-aggregated `has_decision`
-          // flag (admission_service._compute_frontend_fields ~line 1617).
-          // Fallback OR-7-flags cho backward-compat với deploy chưa ship
-          // BE change. Khi flag stable → có thể clean fallback (memory:
-          // FE-BE additive forward-compat).
-          const perms = profile?.permissions
-          const canDecide = Boolean(
-            perms?.has_decision ??
-            (perms?.approve ||
-              perms?.reject ||
-              perms?.resubmit ||
-              perms?.submit ||
-              perms?.request_revision ||
-              perms?.publish_result ||
-              perms?.enroll)
-          )
-          const isStep8Override = step.id === 8 && canDecide
+          // Trust BE-aggregated `permissions.has_decision`, fallback OR-7.
+          const decide = canDecide(profile?.permissions)
+          const isStep8Override = step.id === 8 && decide
           const isLocked = !isStep8Override && status === "locked"
 
           const stepButton = (

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/priority/EngineResultCard.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/priority/EngineResultCard.tsx
@@ -164,15 +164,15 @@ export function EngineResultCard({
             <div className="mt-2 rounded-md border border-purple-200 bg-purple-50/60 p-2 text-xs">
               <p>
                 <span className="font-medium">Ấn định bởi:</span>{" "}
-                {/* Code review 2026-05-22 — ưu tiên denorm `manual_override_by_name`
+                {/* Prefer denorm `manual_override_by_name`
                     (priority_override_service.py:407). Legacy snapshot pre-deploy
-                    chưa có field → fallback `#{actor_id}`. */}
+                    chưa có field → fallback `#{actor_id}`. BE invariant guarantees
+                    at least `manual_override_by` present when state==='override'. */}
                 {(() => {
                   const name = snapshot.manual_override_by_name
                   if (typeof name === "string" && name) return name
                   const id = snapshot.manual_override_by
-                  if (id !== undefined && id !== null && id !== "") return `#${id}`
-                  return "—"
+                  return `#${id}`
                 })()}
                 {snapshot.manual_override_at && (
                   <span className="ml-2 opacity-70">
@@ -241,7 +241,7 @@ export function EngineResultCard({
       {state === "missing" && (
         <p className="text-sm text-muted-foreground">
           Vui lòng khai trình độ văn hóa ở phần trên + lịch sử học THPT ở tab
-          &quot;Học tập&quot; để hệ thống xác định KV.
+          “Học tập” để hệ thống xác định KV.
         </p>
       )}
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/priority/PrioritySummaryPanel.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/priority/PrioritySummaryPanel.test.tsx
@@ -13,7 +13,7 @@
 import { describe, expect, it } from "vitest"
 import type { PreviewPriorityKvResponse } from "@/lib/api/priority-kv"
 
-import { resolveSummaryDisplay } from "./PrioritySummaryPanel"
+import { resolveCap, resolveSummaryDisplay } from "./PrioritySummaryPanel"
 
 const HAPPY_PREVIEW: PreviewPriorityKvResponse = {
   kv_resolved: "KV1",
@@ -401,5 +401,68 @@ describe("PrioritySummaryPanel — cap display (Commit 3)", () => {
     expect(screen.getByTestId("priority-summary-cap")).toBeInTheDocument()
     expect(screen.queryByTestId("priority-summary-cap-badge")).not.toBeInTheDocument()
     expect(screen.getByTestId("priority-summary-applied")).toHaveTextContent("+1.75đ")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PR #324 Commit 2 — resolveCap direct unit tests (P1-4 follow-up review).
+// Indirect coverage existed via `PrioritySummaryPanel` cap-display tests
+// above, but the cap precedence (preview-wins-on-draft vs snapshot-wins-on-
+// post-draft) was implicit. Pin it explicitly so a refactor that drops the
+// `isPostDraft` branch fails loudly here, not in a downstream UI test.
+// ---------------------------------------------------------------------------
+describe("resolveCap — cap precedence", () => {
+  it("draft + preview.path_bonus_rule.max_total_bonus=2.0 + totalBonus=3.0 → preview wins, capped to 2.0", () => {
+    const profile = {
+      status: "draft" as const,
+      priority_resolution_snapshot: {},
+    }
+    const preview = { path_bonus_rule: { max_total_bonus: 2.0 } }
+    expect(resolveCap(profile, preview, 3.0)).toEqual({
+      maxTotalBonus: 2.0,
+      isCapped: true,
+      appliedBonus: 2.0,
+    })
+  })
+
+  it("post-draft + snapshot.path_bonus_rule.max_total_bonus=1.5 + totalBonus=2.0 → snapshot wins (preview ignored)", () => {
+    const profile = {
+      status: "submitted" as const,
+      priority_resolution_snapshot: {
+        path_bonus_rule: { max_total_bonus: 1.5 },
+      },
+    }
+    // Even when preview supplies a different cap, snapshot is authoritative
+    // post-draft (frozen contract mirrors `resolveSummaryDisplay` behaviour).
+    const preview = { path_bonus_rule: { max_total_bonus: 5.0 } }
+    expect(resolveCap(profile, preview, 2.0)).toEqual({
+      maxTotalBonus: 1.5,
+      isCapped: true,
+      appliedBonus: 1.5,
+    })
+  })
+
+  it("draft + preview=null + totalBonus=2.0 → no cap, applied = total", () => {
+    const profile = {
+      status: "draft" as const,
+      priority_resolution_snapshot: {},
+    }
+    expect(resolveCap(profile, null, 2.0)).toEqual({
+      maxTotalBonus: null,
+      isCapped: false,
+      appliedBonus: 2.0,
+    })
+  })
+
+  it("post-draft + snapshot có nhưng KHÔNG path_bonus_rule + totalBonus=2.0 → no cap", () => {
+    const profile = {
+      status: "submitted" as const,
+      priority_resolution_snapshot: { kv_resolved: "KV1" },
+    }
+    expect(resolveCap(profile, null, 2.0)).toEqual({
+      maxTotalBonus: null,
+      isCapped: false,
+      appliedBonus: 2.0,
+    })
   })
 })

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AdmissionScoresTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AdmissionScoresTab.tsx
@@ -277,7 +277,7 @@ export function AdmissionScoresTab({ form, isEditable, appliedRules }: Admission
                 >
                   <FormControl>
                     <SelectTrigger>
-                      <SelectValue placeholder="Chọn tổ hợp môn..." />
+                      <SelectValue placeholder="Chọn tổ hợp môn…" />
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PriorityTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PriorityTab.test.tsx
@@ -132,14 +132,6 @@ vi.mock("@/lib/hooks/use-preview-priority-kv", () => ({
   usePreviewPriorityKv: (...args: PreviewHookArgs) => previewHookSpy(...args),
 }))
 
-// P0-1 fix 2026-05-22 — auth.store mock no longer needed. PriorityTab swap
-// đọc mode từ `profile.override_priority_kv_mode` (server-derived) thay vì
-// user.role string. Keep no-op mock để tránh import resolution surprise
-// nếu PriorityTab re-add dependency tương lai.
-vi.mock("@/lib/stores/auth.store", () => ({
-  useAuthStore: () => null,
-}))
-
 // ---------------------------------------------------------------------------
 // Test harness: wraps PriorityTab with a real react-hook-form so form.watch
 // returns real values for the preview hook gate (per PR-3 P1 design — gate

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/DocumentChecklist.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/DocumentChecklist.tsx
@@ -406,7 +406,7 @@ function DocumentRow({
           <DialogHeader>
             <DialogTitle>Từ chối tài liệu</DialogTitle>
             <DialogDescription>
-              Nhập lý do từ chối tài liệu &quot;{doc.label}&quot;.
+              Nhập lý do từ chối tài liệu “{doc.label}”.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">

--- a/frontend/src/app/(dashboard)/admissions/_components/dialogs/BulkRejectDialog.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/dialogs/BulkRejectDialog.tsx
@@ -74,7 +74,7 @@ export function BulkRejectDialog({
             </Label>
             <Textarea
               id="reason"
-              placeholder="Nhập lý do từ chối (ít nhất 10 ký tự)..."
+              placeholder="Nhập lý do từ chối (ít nhất 10 ký tự)…"
               value={reason}
               onChange={(e) => {
                 setReason(e.target.value)

--- a/frontend/src/app/(dashboard)/dashboard/officer/_components/OfficerDashboardClient.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/officer/_components/OfficerDashboardClient.tsx
@@ -104,15 +104,23 @@ function DashboardContent({ initialStats }: { initialStats?: EnhancedOfficerStat
       : null;
   }, []);
 
-  const [scope, setScope] = useState<DashboardScope | null>(() => initialUrlScope ?? resolvedScope);
-    // Normalize legacy "team" → "unit"
+  // ⚠ HYDRATION-CRITICAL: useState init MUST be `null` (neutral default),
+  // not derived from Zustand persist store. Reading `resolvedScope` (which
+  // reads `useAuth().user.role`) at init time causes mismatch:
+  //   - SSR: localStorage undefined → user=null → resolvedScope=null → scope=null
+  //   - Client first render: Zustand persist rehydrate sync BEFORE React render
+  //     → user=persisted → resolvedScope="organization"/"unit"/"personal"
+  //     → scope=resolved → renders different element tree vs SSR
+  // The !scope skeleton guard below + useEffect resolution (rAF) below keep
+  // first client render identical to SSR; scope settles post-mount.
+  // Anchor: `auth.store.ts:79-87` onRehydrateStorage sync.
+  const [scope, setScope] = useState<DashboardScope | null>(null);
 
-  // Track whether scope was initialized from URL (stable across renders)
-
-  // Sync scope from role during render — only if URL didn't provide a scope
-  // and only when resolvedScope changes (i.e., user hydrates)
-
-  // Secondary filter states — initialized from URL
+  // Secondary filter states — initialized from URL.
+  // NOTE: getUrlParam() returns null on SSR (no window). Safe because the
+  // `!scope` skeleton guard below blocks rendering until useEffect resolves
+  // scope, and on SSR scope is also null. If that guard is removed, move
+  // these initializers to useEffect to avoid hydration mismatch.
   const [selectedUnitId, setSelectedUnitId] = useState<number | null>(() => {
     const raw = getUrlParam("unit");
     if (!raw) return null;
@@ -171,12 +179,16 @@ function DashboardContent({ initialStats }: { initialStats?: EnhancedOfficerStat
     window.history.replaceState({ ...window.history.state, _dashboardFilters: true }, "", newUrl);
   }, []);
 
+  // Post-mount scope resolution: URL param wins; fall back to role-derived
+  // default. Defers from useState init to keep first client render identical
+  // to SSR (skeleton). rAF schedules the state set after paint so React
+  // can finish hydrating before the dashboard tree mounts.
   useEffect(() => {
-    if (initialUrlScope !== null) return;
     if (scope !== null) return;
-    if (resolvedScope === null) return;
+    const next = initialUrlScope ?? resolvedScope;
+    if (next === null) return;
     const frame = window.requestAnimationFrame(() => {
-      setScope(resolvedScope);
+      setScope(next);
     });
     return () => window.cancelAnimationFrame(frame);
   }, [initialUrlScope, resolvedScope, scope]);

--- a/frontend/src/lib/hooks/use-priority-evidence.test.ts
+++ b/frontend/src/lib/hooks/use-priority-evidence.test.ts
@@ -95,7 +95,7 @@ function assertCacheParity(
   )
 
   // 3. sibling preview-priority-kv predicate must accept this profile's preview
-  const predicateCall = invalidateSpy.mock.calls.find(([opts]) => {
+  const predicateCall = invalidateSpy.mock.calls.find(([opts]: [unknown]) => {
     return typeof (opts as { predicate?: unknown })?.predicate === "function"
   })
   expect(predicateCall).toBeDefined()
@@ -168,7 +168,7 @@ describe("use-priority-evidence — mutation cache parity (P1-4)", () => {
       act(() => {
         result.current.mutate({
           version: 5,
-          reason: "Minh chứng không hợp lệ — quá hạn",
+          reject_reason: "Minh chứng không hợp lệ — quá hạn",
         })
       })
 

--- a/frontend/src/lib/hooks/use-priority-evidence.test.ts
+++ b/frontend/src/lib/hooks/use-priority-evidence.test.ts
@@ -1,0 +1,246 @@
+/**
+ * use-priority-evidence cache parity tests.
+ *
+ * PR #323 review P1-4 (memory `admission-review-followups-2026-05-22`) —
+ * 4 hooks share `invalidateRelated()` which performs:
+ *   1. setQueryData(admissionsKeys.detail(id)) — write fresh profile to cache
+ *   2. invalidateQueries(admissionsKeys.detail(id)) — refetch
+ *   3. invalidateQueries(predicate ["priority-kv-preview", id, ...]) — sibling
+ *
+ * Without these tests a refactor that drops one branch silently breaks
+ * the cache parity contract per memory `react-query-mutation-cache-parity`.
+ * Coverage previously existed only for choices (`useAdmissionChoices.test`).
+ *
+ * Real `QueryClient` (no `vi.fn()` tautology) + MSW intercept at fetch layer
+ * (no mock of `priorityEvidenceApi`) per memory `vitest-url-mock-tautological`.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { renderHook, waitFor, act } from "@testing-library/react"
+import { http, HttpResponse } from "msw"
+import { QueryClientProvider } from "@tanstack/react-query"
+import React from "react"
+
+import { server } from "@/test/mocks/server"
+import { createTestQueryClient } from "@/test/utils/test-utils"
+import { admissionsKeys } from "@/hooks/admissions/useAdmissions"
+import {
+  useVerifyObjectEvidence,
+  useRejectObjectEvidence,
+  useUploadPriorityEvidence,
+  useUntickPriorityEvidence,
+} from "./use-priority-evidence"
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}))
+
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || "http://localhost:8000"
+
+const PROFILE_ID = 42
+const SUB_CODE = "04"
+
+const SAMPLE_PROFILE_RESPONSE = {
+  id: PROFILE_ID,
+  status: "draft",
+  version: 5,
+  academic_year: 2026,
+  permissions: {},
+  available_actions: [],
+  validation_errors: [],
+  completion_percent: 80,
+  eligibility_status: "eligible",
+  priority_object_codes: ["04"],
+  priority_resolution_snapshot: {},
+  priority_audit_log: [],
+} as const
+
+function createWrapperWithClient() {
+  const queryClient = createTestQueryClient()
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children)
+  Wrapper.displayName = "TestQueryClientWrapper"
+  return { queryClient, Wrapper }
+}
+
+/**
+ * Assert the cache-parity contract that `invalidateRelated` is expected
+ * to satisfy. Run AFTER `result.current.isSuccess === true`.
+ *
+ *   1. setQueryData(detailKey, freshProfile) called — fresh write into cache
+ *   2. invalidateQueries(detailKey) called — triggers refetch
+ *   3. invalidateQueries(predicate) called — and the predicate matches
+ *      `["priority-kv-preview", PROFILE_ID, ...]` while rejecting unrelated
+ *      keys (defensive against an over-broad predicate that nukes the cache)
+ *
+ * We spy on `setQueryData` rather than reading `getQueryData()` because the
+ * test client uses `gcTime: 0`, which evicts the data immediately after
+ * `invalidateQueries` triggers a refetch with no observer.
+ */
+function assertCacheParity(
+  setDataSpy: ReturnType<typeof vi.spyOn>,
+  invalidateSpy: ReturnType<typeof vi.spyOn>,
+) {
+  // 1. setQueryData(detailKey, freshProfile)
+  expect(setDataSpy).toHaveBeenCalledWith(
+    admissionsKeys.detail(PROFILE_ID),
+    expect.objectContaining({ id: PROFILE_ID, version: 5 }),
+  )
+
+  // 2. invalidate detail key
+  expect(invalidateSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      queryKey: admissionsKeys.detail(PROFILE_ID),
+    }),
+  )
+
+  // 3. sibling preview-priority-kv predicate must accept this profile's preview
+  const predicateCall = invalidateSpy.mock.calls.find(([opts]) => {
+    return typeof (opts as { predicate?: unknown })?.predicate === "function"
+  })
+  expect(predicateCall).toBeDefined()
+  const predicate = (
+    predicateCall![0] as { predicate: (q: { queryKey: unknown[] }) => boolean }
+  ).predicate
+  expect(
+    predicate({ queryKey: ["priority-kv-preview", PROFILE_ID, "draft-input"] }),
+  ).toBe(true)
+  // Defensive: predicate must NOT match unrelated keys
+  expect(
+    predicate({ queryKey: ["priority-kv-preview", PROFILE_ID + 1] }),
+  ).toBe(false)
+  expect(predicate({ queryKey: ["admissions", "list"] })).toBe(false)
+}
+
+describe("use-priority-evidence — mutation cache parity (P1-4)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("useVerifyObjectEvidence", () => {
+    it("setQueryData detail + invalidateQueries detail + sibling preview predicate", async () => {
+      server.use(
+        http.patch(
+          `${API_BASE_URL}/api/v2/admissions/:id/priority-objects/:subCode/verify`,
+          () => HttpResponse.json(SAMPLE_PROFILE_RESPONSE),
+        ),
+      )
+
+      const { queryClient, Wrapper } = createWrapperWithClient()
+      const setDataSpy = vi.spyOn(queryClient, "setQueryData")
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+
+      const { result } = renderHook(
+        () => useVerifyObjectEvidence(PROFILE_ID, SUB_CODE),
+        { wrapper: Wrapper },
+      )
+
+      act(() => {
+        result.current.mutate({ version: 5 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      assertCacheParity(setDataSpy, invalidateSpy)
+      setDataSpy.mockRestore()
+      invalidateSpy.mockRestore()
+    })
+  })
+
+  describe("useRejectObjectEvidence", () => {
+    it("setQueryData detail + invalidateQueries detail + sibling preview predicate", async () => {
+      server.use(
+        http.patch(
+          `${API_BASE_URL}/api/v2/admissions/:id/priority-objects/:subCode/reject`,
+          () => HttpResponse.json(SAMPLE_PROFILE_RESPONSE),
+        ),
+      )
+
+      const { queryClient, Wrapper } = createWrapperWithClient()
+      const setDataSpy = vi.spyOn(queryClient, "setQueryData")
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+
+      const { result } = renderHook(
+        () => useRejectObjectEvidence(PROFILE_ID, SUB_CODE),
+        { wrapper: Wrapper },
+      )
+
+      act(() => {
+        result.current.mutate({
+          version: 5,
+          reason: "Minh chứng không hợp lệ — quá hạn",
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      assertCacheParity(setDataSpy, invalidateSpy)
+      setDataSpy.mockRestore()
+      invalidateSpy.mockRestore()
+    })
+  })
+
+  describe("useUploadPriorityEvidence", () => {
+    it("setQueryData detail + invalidateQueries detail + sibling preview predicate", async () => {
+      server.use(
+        http.post(
+          `${API_BASE_URL}/api/v2/admissions/:id/priority-evidence/:subCode/upload`,
+          () => HttpResponse.json(SAMPLE_PROFILE_RESPONSE),
+        ),
+      )
+
+      const { queryClient, Wrapper } = createWrapperWithClient()
+      const setDataSpy = vi.spyOn(queryClient, "setQueryData")
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+
+      const { result } = renderHook(
+        () => useUploadPriorityEvidence(PROFILE_ID, SUB_CODE),
+        { wrapper: Wrapper },
+      )
+
+      const file = new File(["fake-pdf-bytes"], "evidence.pdf", {
+        type: "application/pdf",
+      })
+
+      act(() => {
+        result.current.mutate({ file })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      assertCacheParity(setDataSpy, invalidateSpy)
+      setDataSpy.mockRestore()
+      invalidateSpy.mockRestore()
+    })
+  })
+
+  describe("useUntickPriorityEvidence", () => {
+    it("setQueryData detail + invalidateQueries detail + sibling preview predicate", async () => {
+      server.use(
+        http.delete(
+          `${API_BASE_URL}/api/v2/admissions/:id/priority-evidence/:subCode`,
+          () => HttpResponse.json(SAMPLE_PROFILE_RESPONSE),
+        ),
+      )
+
+      const { queryClient, Wrapper } = createWrapperWithClient()
+      const setDataSpy = vi.spyOn(queryClient, "setQueryData")
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+
+      const { result } = renderHook(
+        () => useUntickPriorityEvidence(PROFILE_ID, SUB_CODE),
+        { wrapper: Wrapper },
+      )
+
+      act(() => {
+        result.current.mutate({ version: 5 })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      assertCacheParity(setDataSpy, invalidateSpy)
+      setDataSpy.mockRestore()
+      invalidateSpy.mockRestore()
+    })
+  })
+})

--- a/frontend/src/lib/utils/admission-permissions.ts
+++ b/frontend/src/lib/utils/admission-permissions.ts
@@ -1,0 +1,28 @@
+/**
+ * Admission permission-flag helpers (FE thin client, BE = source of truth).
+ *
+ * BE `_compute_frontend_fields` in `admission_service.py` aggregates the
+ * decision-perm flags into `permissions.has_decision`. We trust that flag
+ * when present; otherwise fall back to the OR of the 7 individual flags
+ * for forward-compat with deployments that haven't shipped the aggregate
+ * yet. Once `has_decision` is universally present, the fallback can be
+ * dropped.
+ *
+ * Ref: PR #323 review P2-1 (memory `admission-review-followups-2026-05-22`).
+ */
+import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+
+type AdmissionPermissions = AdmissionProfileResponse["permissions"]
+
+export function canDecide(perms: AdmissionPermissions | undefined): boolean {
+  return Boolean(
+    perms?.has_decision ??
+      (perms?.approve ||
+        perms?.reject ||
+        perms?.resubmit ||
+        perms?.submit ||
+        perms?.request_revision ||
+        perms?.publish_result ||
+        perms?.enroll),
+  )
+}


### PR DESCRIPTION
## Summary

Bundle of 6 tech-debt fixes from PR #323 review follow-ups + 1 P0 runtime
hydration bug, gathered into a single PR to avoid 6 separate deploys
(memory `solo-dev-batch-prs-to-reduce-ci-overhead`).

| # | Commit | Subject | Risk |
|---|--------|---------|------|
| 1 | `f26edeee` | `fix(dashboard/officer)`: hydration mismatch — Zustand persist SSR drift | Low-Med |
| 2 | `19c25993` | `refactor(admissions)`: cosmetic FU bundle — canDecide helper + dead code + char polish | Zero |
| 3 | `459e66f0` | `test(priority-evidence)`: pin React Query cache parity for 4 mutation hooks | Zero (additive) |
| 4 | `05a9bbd6` | `refactor(socket-rooms)`: lift `_rooms_for_*` helpers to public API | Med (26 files) |
| 5 | `d5449a4a` | `fix(tests)`: restore underscore in `test_worker_passes_rooms_for_admission_event` | Trivial |
| 6 | `f867cf8d` | `fix(casbin)`: lock accountant out of 4 lead static routes (keyMatch4 collision) | Med (policy + migration) |

### Commit 1 — Officer dashboard hydration mismatch (P0 runtime)

`useState(() => initialUrlScope ?? resolvedScope)` derived from
`useAuth().user.role`, which is backed by a Zustand `persist` store
that rehydrates from localStorage synchronously BEFORE React hydrates.
SSR (no localStorage) saw `user=null → scope=null → skeleton`; client
first render saw persisted user → `scope=resolved → SmartHeader`.
Different trees at the same node → "Hydration failed" + visible
content jump.

Fix: `useState(null)` (neutral default that matches SSR). Existing
post-mount `useEffect` (rAF-scheduled) resolves scope after hydration.
`!scope` skeleton guard already covered the SSR branch; now it also
covers the client's first render.

Verified: `OfficerDashboardClient.test.tsx` 21/21 pass (test was
already `await waitFor`-wrapped). Chrome MCP smoke: admin + officer
role × 3 hard reloads + edge URLs (`?scope=unit`, `?scope=team` legacy
normalize) → 0 "Hydration failed" errors.

### Commit 2 — Cosmetic FU bundle (P2-1, P2-5, Gemini broader)

- `canDecide(perms)` helper extracted to `lib/utils/admission-permissions.ts`
  (was duplicated 11-line block in `AdmissionActions.tsx` +
  `layout/PipelineSidebar.tsx`)
- Drop dead `"—"` fallback in `EngineResultCard.tsx` (BE invariant
  guarantees `manual_override_by` present when `state === "override"`)
- Char polish: 2× `&quot;` → curly quotes; 3× `"..."` → `…` U+2026
- Drop dead `vi.mock("@/lib/stores/auth.store")` in `PriorityTab.test.tsx`
  (PR #323 P0-1 swap removed the dependency; mock unused since)
- Add 4-case direct `resolveCap` unit tests in `PrioritySummaryPanel.test.tsx`
  (precedence: preview-wins-on-draft vs snapshot-wins-on-post-draft)

Note: `resolveCap` was already exported (plan v1 nhầm assumption), so
no extract was needed — only tests added.

### Commit 3 — Priority evidence cache parity tests (P1-4)

4 hooks (`useVerifyObjectEvidence`, `useRejectObjectEvidence`,
`useUploadPriorityEvidence`, `useUntickPriorityEvidence`) share
`invalidateRelated()`, which performs:
1. `setQueryData(detailKey, updated)` — direct cache write
2. `invalidateQueries(detailKey)` — refetch trigger
3. `invalidateQueries(predicate)` — sibling `priority-kv-preview`

Coverage gap before this commit: only `useAdmissionChoices.test`
exercised the cache-parity pattern; the 4 priority-evidence hooks had
no anchor.

Pattern (per memories `react-query-mutation-cache-parity` and
`vitest-url-mock-tautological`): real `QueryClient` +
`createTestQueryClient`, MSW intercept at fetch layer (no
`vi.fn()` tautology), spy on `setQueryData` rather than reading
`getQueryData()` (test client has `gcTime: 0` which evicts
post-invalidate).

Verify: 4/4 tests pass.

### Commit 4 — Lift `_rooms_for_*` socket helpers to public API (P1-2)

`notification_outbox_tasks.py` imported `_rooms_for_admission`,
`_rooms_for_lead`, `_rooms_for_user` from `notification_dispatcher`.
The `_` prefix advertised them as module-private, yet cross-module
worker reached in anyway — if dispatcher renamed one, the worker
would silently break (and sensitive events would fail-closed at the
dispatcher with no rooms scoping).

Hard rename, no deprecation alias. Python import-time `NameError`
catches anything missed; pre-edit grep widened to f-strings, getattr,
importlib, monkeypatch.setattr, @patch — 0 dynamic-import sites found.

Sweep covered 26 files: 11 services, 4 tasks, 6 routers, 1 core,
4 tests. Post-edit grep `\b_rooms_for_*\b` → 0 stragglers.

Anchor tests added in `test_outbox_worker.py`:
- `rooms_for_admission` with full lead → `["role_admin", "unit_5", "user_room_42"]`
- `rooms_for_admission` with `lead=None` → `["role_admin"]` (graceful degradation)
- `rooms_for_admission` with lead but `assigned_officer_id=None` → `["role_admin", "unit_5"]`

### Commit 5 — Casbin keyMatch4 collision (partial)

Memory `lead-keymatch4-collision-followup`'s original plan was 8 DENY
rows (4 officer + 4 accountant). **Empirically broken** — test
`test_casbin_lead_static_route_collision.py` showed 11/16 cells
flipped to DENY because officer is an inheritance PARENT in the
diamond role tree (`admin → manager → officer; accountant → officer`)
and Casbin's `g(r.sub, p.sub)` policy expansion propagates DENY at
parent to all descendants.

Plan v2 (this PR): only add ACCOUNTANT DENY (4 rows). Accountant is a
LEAF role (no descendants), so DENY is contained.

Defence-in-depth (not strictly load-bearing under current matcher):
the existing ACCOUNTANT_TEMPLATE `/api/leads/{id} GET/PUT deny`
already catches the 4 static routes via keyMatch4 collision. The new
explicit DENYs lock the intent against future matcher tightening.

**Officer-side bypass NOT FIXED** (see Known Limitations below).

Migration `qa20260522_tighten_lead_denies` (down_revision `q9_07_e4f`):
4 INSERT rows, idempotent via `WHERE NOT EXISTS`, narrow DELETE
downgrade. New test `test_casbin_lead_static_route_collision.py`
(matrix + officer regression + bite-verify). Updated
`test_accountant_deny_rows_seeded` anchor (38 → 42 rows).

## Test plan

- [x] BE pytest groups (Commit 4 + 5): outbox_worker + fee_calculated_event
      + notification_parity + dispatcher + socket_scoping + casbin matrix
      + lead static collision + qa_wave9 → **65/66 pass**. The 1 fail
      (`test_sensitive_events_always_dispatch_with_rooms` flagging
      `zalo_bot_link_service.py:249`) is pre-existing on `main @ 2cd959bb`
      — verified by `git stash` and re-running on bare main. See Known
      Limitations #3.
- [x] Alembic round-trip: `upgrade head → downgrade -1 → upgrade head` clean
- [x] Post-upgrade row sanity: 4 accountant DENY rows
- [x] FE `fe-check.sh type-check` clean
- [x] FE vitest: 21 OfficerDashboardClient + 61 admission components + 4
      priority-evidence cache parity = 86+ tests pass
- [x] Chrome MCP smoke (Commit 1): admin + officer role × 3 hard reloads
      + 2 edge URLs (?scope=unit, ?scope=team) → 0 hydration errors
- [x] Post-edit grep `\b_rooms_for_*\b` (Commit 4) → 0 stragglers
- [ ] Manager-role Chrome MCP smoke — deferred (symmetric code path to
      admin/officer; can be exercised post-deploy on prod)

## Post-deploy ops

- [ ] Reload Casbin in-memory enforcer after deploy (in-memory cache stale
      otherwise):
  ```bash
  # Admin UI: POST /api/admin/roles/sync-all-from-templates
  # OR:
  docker compose exec backend python -c "from app.security import enforcer; \
    import asyncio; asyncio.run(enforcer.load_policy())"
  ```
- [ ] Smoke: officer + accountant tokens hit `/api/leads/export`:
  - admin → 200 (unchanged)
  - manager → 200 (unchanged)
  - **accountant → 403 (new behaviour)**
  - officer → 200 (unchanged, known limitation)
- [ ] Verify `/dashboard/officer` hydration on prod: admin + officer hard
      reload → 0 "Hydration failed" in DevTools Console

## Known limitations (documented, deferred)

1. **Officer-side keyMatch4 bypass** (Commit 5): officer GETs
   `/api/leads/export` + `/api/leads/distribution-preview` still leak via
   keyMatch4 collision. UI gated via FE (`LeadDialog.tsx:285`); direct
   API call by an authenticated officer succeeds. Proper fix needs
   custom matcher (`keyMatchPriority` or `keyMatch4Numeric`) —
   dedicated security PR. Tracked in memory
   `lead-keymatch4-collision-followup` (PARTIAL CLOSE status).

2. **Accountant/user role visiting `/dashboard/officer` manually**
   (Commit 1): pre-existing hydration mismatch (SSR skeleton vs
   client "Không có quyền" Alert). No nav entry leads there; not a
   regression introduced by this PR. Deferred fix uses `hasMounted`
   flag pattern.

3. **Pre-existing zalo_bot_link_service `ZALO_BOT_LINK_DISPLACED`
   missing `rooms=` kwarg** (uncovered by Commit 4's test pass):
   `test_sensitive_events_always_dispatch_with_rooms` flags
   `app/services/zalo_bot_link_service.py:249`. Same red on
   `main @ 2cd959bb` — NOT caused by this PR. Tracked separately.

## Memory updates included

- `lead-keymatch4-collision-followup` revised — PARTIAL CLOSE status,
  documents Plan v1 failure mode + Plan v2 ship + officer-side defer
- New: `casbin-deny-parent-role-propagates-to-children` — empirical
  lesson capturing the inheritance-DENY propagation gotcha
- 14 stale memory entries trimmed (memory/cleanup arc + CLOSED status
  trackers); MEMORY.md size 28247 → 25999 bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
