### PR TITLE
chore(p1): notification cleanup + CSV streaming + finance test drift bundle

### DIFF
--- a/Backend_FastAPI/alembic/versions/cleanup_uppercase_orphan_notification_rows.py
+++ b/Backend_FastAPI/alembic/versions/cleanup_uppercase_orphan_notification_rows.py
@@ -1,0 +1,122 @@
+"""cleanup phase1_19c UPPERCASE orphan notification rows (rule + action + template)
+
+Revision ID: cleanup_upper_notif
+Revises: qa20260522_tighten_lead_denies
+Create Date: 2026-05-23
+
+PR-1 Commit 2 — surgical cleanup of dead-weight rows seeded by
+``phase1_19c_seed_event_catalog_db_rows`` which used UPPERCASE event
+names (``"ADMISSION_PROFILE_SUBMITTED"`` etc., see that migration's
+``MILESTONE_EVENTS`` tuple lines 77-198) while ``SystemEvents.value`` —
+the dispatcher key — is lowercase. ``tasks/admission_tasks.py:348`` uses
+``WHERE event = event_value`` exact match → the 12 UPPERCASE rule rows +
+their child notification_action rows + the 12 ``TPL_ADMISSION_*`` upper
+template rows have never fired and never will. Harmless dead weight that
+clutters every diagnostic SELECT.
+
+Idempotent: each DELETE uses a strict predicate (``LIKE 'ADMISSION\\_%'``
+with explicit ``ESCAPE '\\'`` so the literal underscore is not the SQL
+wildcard, AND ``event != lower(event)`` to require at least one upper-
+case letter). Running upgrade twice DELETEs nothing on the second run.
+
+Scope (3 tables, in FK-safe order):
+
+  1. notification_action — child of notification_rule (rule_id FK).
+     The schema does NOT have ON DELETE CASCADE on that FK on prod;
+     delete children FIRST.
+  2. notification_rule — the 12 uppercase event rows.
+  3. notification_template — the 12 ``TPL_ADMISSION_*`` upper template
+     rows. No FK from notification_rule.template_id to template (per
+     phase1_19c insert which stores ``template_id=NULL``).
+
+downgrade is a no-op: the dead rows had no business meaning. To re-seed
+the lowercase variants (the live ones), re-run phase1_19c at upgrade
+head — its WHERE NOT EXISTS / ON CONFLICT guards keep that body
+idempotent.
+
+Per memory ``migration-predicate-safety``: strict predicate verified
+on dev DB before merge; SSH prod preflight queries the same predicate
+to confirm the orphan counts match expectations (12 rule, 12 template,
+~29 action per phase1_19c's 7 channels × subset of 12 events).
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "cleanup_upper_notif"
+down_revision: Union[str, None] = "qa20260522_tighten_lead_denies"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Predicates kept as module constants so the count-query, the delete,
+# and the test all reference one source of truth.
+_RULE_PREDICATE = (
+    "event LIKE 'ADMISSION\\_%' ESCAPE '\\' "
+    "AND event != lower(event)"
+)
+_TEMPLATE_PREDICATE = (
+    "template_code LIKE 'TPL\\_ADMISSION\\_%' ESCAPE '\\' "
+    "AND template_code != lower(template_code)"
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # --- Step 1: count what we are about to delete (logged in alembic output) ---
+    rule_count = conn.execute(
+        sa.text(f"SELECT COUNT(*) FROM notification_rule WHERE {_RULE_PREDICATE}")
+    ).scalar() or 0
+    template_count = conn.execute(
+        sa.text(f"SELECT COUNT(*) FROM notification_template WHERE {_TEMPLATE_PREDICATE}")
+    ).scalar() or 0
+
+    # --- Step 2: collect rule IDs so children can be deleted explicitly
+    # (FK does not declare ON DELETE CASCADE on prod schema) ---
+    rule_ids_rows = conn.execute(
+        sa.text(f"SELECT id FROM notification_rule WHERE {_RULE_PREDICATE}")
+    ).fetchall()
+    rule_ids = [row[0] for row in rule_ids_rows]
+
+    action_count = 0
+    if rule_ids:
+        # --- Step 3: delete notification_action children first (FK) ---
+        action_result = conn.execute(
+            sa.text(
+                "DELETE FROM notification_action WHERE rule_id = ANY(:ids)"
+            ),
+            {"ids": rule_ids},
+        )
+        action_count = action_result.rowcount or 0
+
+        # --- Step 4: delete notification_rule parents ---
+        conn.execute(
+            sa.text(f"DELETE FROM notification_rule WHERE {_RULE_PREDICATE}")
+        )
+
+    # --- Step 5: delete notification_template (no FK from rule.template_id) ---
+    if template_count:
+        conn.execute(
+            sa.text(f"DELETE FROM notification_template WHERE {_TEMPLATE_PREDICATE}")
+        )
+
+    print(
+        f"cleanup_uppercase_orphan_notification_rows: "
+        f"rule={rule_count} action={action_count} template={template_count}"
+    )
+
+
+def downgrade() -> None:
+    # Intentional no-op. The deleted rows were dead weight — never matched
+    # by the dispatcher (event-value comparison is case-sensitive lowercase)
+    # — and re-creating them only restores the noise. If someone genuinely
+    # needs the lowercase rows back, re-running phase1_19c at head is the
+    # canonical idempotent route (it skips already-present rows via its
+    # WHERE NOT EXISTS / ON CONFLICT guards).
+    pass

--- a/Backend_FastAPI/app/repositories/notification_delivery_repository.py
+++ b/Backend_FastAPI/app/repositories/notification_delivery_repository.py
@@ -459,21 +459,25 @@ class NotificationDeliveryRepository(BaseRepository[NotificationDelivery]):
     async def get_stale_sent_count(self, lag_minutes: int = 60) -> int:
         """Count deliveries sent > lag_minutes ago without webhook confirmation.
 
-        2026-04-22: ``zalo`` excluded from this filter — backend currently
-        does not consume the ``user_received_message`` ZBS Template Message
-        delivery webhook (header ``X-ZEvent-Server: ZNS``); the reconcile
-        task auto-marks ``sent → delivered`` after 60min instead, so a
-        ``sent`` zalo row older than 60min is the *expected* interim state,
-        not an alert condition. Re-add ``zalo`` once the webhook handler is
-        wired (separate follow-up). ``sms`` retained for when a future
-        SMS channel implementation lands; currently produces no rows.
+        2026-05-23: ``zalo`` re-included after ZBS Template Message webhook
+        handler shipped (commit ``d357c029`` — ``user_received_message``
+        events with ``X-ZEvent-Server: ZNS`` now route to
+        ``_handle_delivery_status`` and transition ``sent → delivered``
+        within ~3-10s of provider acknowledgement). A ``sent`` zalo row
+        older than ``lag_minutes`` is therefore a meaningful alert
+        condition: either the webhook delivery silently failed or the
+        provider never confirmed. Pairs with the reconcile task as a
+        defence-in-depth observability signal. See outstanding-debt P3-9.
+
+        ``sms`` retained for when a future SMS channel implementation
+        lands; currently produces no rows.
         """
         cutoff = datetime.now(timezone.utc) - timedelta(minutes=lag_minutes)
         q = (
             select(func.count()).select_from(NotificationDelivery)
             .where(
                 NotificationDelivery.status == "sent",
-                NotificationDelivery.channel.in_(["sms"]),
+                NotificationDelivery.channel.in_(["sms", "zalo"]),
                 NotificationDelivery.sent_at <= cutoff,
             )
         )

--- a/Backend_FastAPI/app/routers/admin_backfill.py
+++ b/Backend_FastAPI/app/routers/admin_backfill.py
@@ -223,6 +223,111 @@ async def bulk_resolve_exceptions(
 # =============================================================================
 
 
+_CSV_FIELDNAMES = (
+    "id",
+    "profile_id",
+    "exception_type",
+    "details",
+    "created_at",
+    "resolved_at",
+    "resolved_by_user_id",
+    "resolved_by_username",
+    "resolution_notes",
+)
+
+
+def _format_csv_header() -> bytes:
+    """Render the CSV header line.
+
+    Default csv.DictWriter quoting (csv.QUOTE_MINIMAL) preserves the
+    pre-PR-1 header shape ``id,profile_id,exception_type,...`` so
+    downstream tools that grep the header line continue to work.
+    """
+    buf = io.StringIO()
+    writer = csv.DictWriter(
+        buf, fieldnames=_CSV_FIELDNAMES, extrasaction="ignore"
+    )
+    writer.writeheader()
+    return buf.getvalue().encode("utf-8")
+
+
+def _format_csv_row(row: dict) -> bytes:
+    """Render one CSV data row using QUOTE_MINIMAL.
+
+    QUOTE_MINIMAL quotes only when the value contains the delimiter,
+    quotechar, or newline — same default as the pre-PR-1 router so
+    bytes-equality with the legacy materialised buffer (sans sanitiser
+    prefix) is preserved.
+    """
+    buf = io.StringIO()
+    writer = csv.DictWriter(
+        buf, fieldnames=_CSV_FIELDNAMES, extrasaction="ignore"
+    )
+    writer.writerow(row)
+    return buf.getvalue().encode("utf-8")
+
+
+async def _csv_export_stream(
+    db: AsyncSession,
+    *,
+    exception_type: Optional[str],
+    is_resolved: Optional[bool],
+    on_finish: Optional[callable] = None,
+):
+    """Per-row async generator for the admin backfill CSV export.
+
+    Lifted to a module-level coroutine generator so unit tests can drive
+    it directly with a mocked ``iter_csv_rows`` (httpx ASGITransport
+    buffers ``StreamingResponse`` end-to-end, so chunk-count assertions
+    have to come from the generator, not from the HTTP layer).
+
+    PR-1 Commit 3 (2026-05-23) — true async streaming. The pre-fix body
+    materialised every row into ``io.StringIO`` then wrapped
+    ``iter([buf.getvalue()])`` which defeated ``StreamingResponse``.
+    Now: header chunk first, then one CSV-line chunk per row, end of
+    stream when ``iter_csv_rows`` exhausts. ``on_finish`` is invoked
+    with the final ``row_count`` so the caller can write an audit log
+    line outside this generator's scope.
+
+    Sanitises user-controlled string columns via the shared
+    ``sanitize_csv_cell`` helper (``app/utils/csv_helpers.py``) to
+    prevent CSV/formula injection (OWASP CWE-1236). The shared helper
+    handles ``=``, ``+``, ``-``, ``@``, ``\\t``, ``\\r``, ``\\n``, ``|``
+    plus DDE pattern logging — narrower than a local FORMULA_PREFIX
+    denylist would be.
+    """
+    import json
+    from app.utils.csv_helpers import sanitize_csv_cell
+
+    yield _format_csv_header()
+
+    row_count = 0
+    async for row in backfill_service.iter_csv_rows(
+        db,
+        exception_type=exception_type,
+        is_resolved=is_resolved,
+    ):
+        # JSONB ``details`` → string, then sanitise the encoded JSON
+        # because untrusted user content can land inside it and Excel
+        # interprets leading ``=`` / ``+`` / ``-`` / ``@`` / control
+        # chars as a formula. Sanitise BEFORE csv.DictWriter so default
+        # QUOTE_MINIMAL quoting wraps any prepended single quote when
+        # the cell already contains a comma.
+        row["details"] = sanitize_csv_cell(
+            json.dumps(row["details"], ensure_ascii=False)
+        )
+        for k in ("resolved_by_username", "resolution_notes"):
+            v = row.get(k)
+            if isinstance(v, str):
+                row[k] = sanitize_csv_cell(v)
+
+        yield _format_csv_row(row)
+        row_count += 1
+
+    if on_finish is not None:
+        on_finish(row_count)
+
+
 @router.get(
     "/export.csv",
     response_class=StreamingResponse,
@@ -243,51 +348,38 @@ async def export_csv(
     ``details`` JSONB is dumped as raw JSON string into a single column —
     admin tooling parses downstream. Filename uses UTC timestamp for unique
     download names.
+
+    PR-1 Commit 3 (2026-05-23) — true async streaming via
+    ``_csv_export_stream`` module-level coroutine generator (testable
+    in isolation). Sanitises user-controlled string columns via shared
+    ``sanitize_csv_cell`` helper to prevent CSV/formula injection
+    (OWASP CWE-1236).
     """
-    import json
-
-    rows = []
-    async for row in backfill_service.iter_csv_rows(
-        db,
-        exception_type=exception_type,
-        is_resolved=is_resolved,
-    ):
-        # JSON-encode the dict column for CSV cell safety
-        row["details"] = json.dumps(row["details"], ensure_ascii=False)
-        rows.append(row)
-
-    buf = io.StringIO()
-    fieldnames = [
-        "id",
-        "profile_id",
-        "exception_type",
-        "details",
-        "created_at",
-        "resolved_at",
-        "resolved_by_user_id",
-        "resolved_by_username",
-        "resolution_notes",
-    ]
-    writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
-    writer.writeheader()
-    for r in rows:
-        writer.writerow(r)
-    buf.seek(0)
-
     from datetime import timezone as _tz
     ts = datetime.now(_tz.utc).strftime("%Y%m%dT%H%M%SZ")
     filename = f"backfill_exceptions_{ts}.csv"
 
     log.info(
-        "admin_backfill.export_csv",
+        "admin_backfill.export_csv.start",
         actor_id=current_admin.id,
-        row_count=len(rows),
         exception_type=exception_type,
         is_resolved=is_resolved,
     )
 
+    def _log_finish(row_count: int) -> None:
+        log.info(
+            "admin_backfill.export_csv.finish",
+            actor_id=current_admin.id,
+            row_count=row_count,
+        )
+
     return StreamingResponse(
-        iter([buf.getvalue()]),
+        _csv_export_stream(
+            db,
+            exception_type=exception_type,
+            is_resolved=is_resolved,
+            on_finish=_log_finish,
+        ),
         media_type="text/csv",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )

--- a/Backend_FastAPI/tests/api/test_finance_api.py
+++ b/Backend_FastAPI/tests/api/test_finance_api.py
@@ -695,8 +695,26 @@ class TestFinanceRolePermissions:
         # Should have PUT /api/payments/{id}/verify
         assert ("/api/payments/{id}/verify", "PUT") in accountant_actions
 
-    def test_officer_cannot_calculate_fee(self):
-        """Officer policy should NOT include calculate fee permission."""
+    def test_officer_can_calculate_fee_scoped(self):
+        """Officer template INCLUDES /api/fees/calculate POST (scoped).
+
+        Decision reference: memory ``admission-audit-decisions-2026-04-24``
+        chốt officer scoped fee calc — officer initiates fee calculation
+        on their assigned profile within the approved/confirmed/enrolled
+        status whitelist. The service layer ``_fee_calc_authorized``
+        enforces ownership + status guard at runtime; the Casbin gate
+        only opens the route.
+
+        Recording payments (``/api/payments`` POST) and issuing invoices
+        (``/api/invoices/{id}/issue`` PUT) remain accountant-only per
+        separation of duties — asserted here as symmetry guard so a
+        future template drift that grants officer those writes fails
+        loud at unit-test time.
+
+        Pre-PR-1 this test was ``test_officer_cannot_calculate_fee`` —
+        flipped 2026-05-23 to match the policy reality shipped
+        2026-04-24 (memory ``test-debt-admission-workflow-e2e``).
+        """
         from app.casbin_config.policy_templates import OFFICER_TEMPLATE
 
         officer_actions = [
@@ -704,8 +722,22 @@ class TestFinanceRolePermissions:
             for p in OFFICER_TEMPLATE["policies"]
         ]
 
-        # Officer should NOT have POST /api/fees/calculate
-        assert ("/api/fees/calculate", "POST") not in officer_actions
+        # Officer HAS /api/fees/calculate POST (scoped to assigned profile,
+        # service-layer ownership + status whitelist enforced).
+        assert ("/api/fees/calculate", "POST") in officer_actions, (
+            "OFFICER_TEMPLATE must include /api/fees/calculate POST per "
+            "decision admission-audit-decisions-2026-04-24."
+        )
+
+        # Officer LACKS accountant-only finance writes (symmetry drift guard).
+        assert ("/api/payments", "POST") not in officer_actions, (
+            "Officer must NOT have /api/payments POST — accountant-only "
+            "(separation of duties)."
+        )
+        assert ("/api/invoices/{id}/issue", "PUT") not in officer_actions, (
+            "Officer must NOT have /api/invoices/{id}/issue PUT — "
+            "accountant-only (separation of duties)."
+        )
 
     def test_accountant_can_calculate_fee(self):
         """Accountant policy should include calculate fee permission."""

--- a/Backend_FastAPI/tests/api/test_phase3_pr3d_b_admin_backfill.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3d_b_admin_backfill.py
@@ -341,6 +341,179 @@ async def test_list_filter_is_resolved_false_excludes_closed(
 
 
 # ============================================================================
+# PR-1 Commit 3 (2026-05-23) — CSV export streaming + injection sanitize
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_csv_export_stream_yields_one_chunk_per_row(backfill_seed: dict):
+    """Per-row streaming contract — drive the generator directly.
+
+    ``httpx.ASGITransport`` (in-process test transport) buffers the full
+    ``StreamingResponse`` body before yielding to ``client.stream``, so
+    chunk-count assertions can NOT be made through the HTTP layer.
+    Instead, exercise ``_csv_export_stream`` directly + count yields.
+
+    Before PR-1 Commit 3 the router materialised every row into a single
+    ``io.StringIO`` then wrapped ``iter([buf.getvalue()])`` —
+    ``StreamingResponse`` only ever saw one chunk. After the fix the
+    body is an async generator: header chunk first, then one chunk per
+    row, then end-of-stream. Pin: with 3 seeded rows we expect 4
+    chunks (1 header + 3 data).
+    """
+    from app.routers.admin_backfill import _csv_export_stream
+
+    async with AsyncSessionLocal() as s:
+        chunks: list[bytes] = []
+        finish_calls: list[int] = []
+
+        async for chunk in _csv_export_stream(
+            s,
+            exception_type=None,
+            is_resolved=None,
+            on_finish=lambda count: finish_calls.append(count),
+        ):
+            chunks.append(chunk)
+
+    # 1 header + ≥3 seeded rows. The seed fixture writes exactly 3 rows
+    # for this profile but other tests in the suite may seed more, so the
+    # assertion is "> 1 chunk" — pre-fix behaviour was exactly 1.
+    assert len(chunks) > 1, (
+        f"Expected per-row streaming (> 1 chunk) but got {len(chunks)}. "
+        f"Router may have regressed to ``iter([buf.getvalue()])``."
+    )
+    # ``on_finish`` callback must fire exactly once with the row count
+    # (rows yielded, not including the header chunk).
+    assert len(finish_calls) == 1
+    assert finish_calls[0] == len(chunks) - 1, (
+        f"on_finish row_count {finish_calls[0]} should equal data chunks "
+        f"{len(chunks) - 1} (chunks minus header)."
+    )
+
+    # First chunk MUST be the header line (preserves pre-PR-1 unquoted
+    # header shape so downstream grep continues to work).
+    header = chunks[0].decode("utf-8")
+    assert header.startswith("id,profile_id,exception_type"), (
+        f"First chunk must be header line; got: {header!r}"
+    )
+
+    # All seeded ids present somewhere in the data chunks.
+    body = b"".join(chunks).decode("utf-8")
+    for ex_id in backfill_seed["exception_ids"]:
+        assert str(ex_id) in body, f"Seeded row id={ex_id} missing from CSV body"
+
+
+@pytest.mark.asyncio
+async def test_csv_export_sanitizes_formula_injection_in_resolution_notes(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    seed_lead_dependencies: dict,
+):
+    """User-controlled ``resolution_notes`` cells with formula-trigger
+    prefix MUST be sanitised via ``sanitize_csv_cell`` before CSV emit.
+
+    OWASP CWE-1236. The shared helper at ``app/utils/csv_helpers.py:55``
+    prepends a single quote so Excel treats the cell as text, not as a
+    formula. PR-1 Commit 3 wires this into the streaming generator —
+    regression here would re-open the formula-injection vector.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            lead = models.Lead(
+                full_name=f"Sanitize seed lead {ts}",
+                phone=f"097{ts:07d}"[:10],
+                unit_id=seed_lead_dependencies["unit_id"],
+                pipeline_stage_id=seed_lead_dependencies["stage_id"],
+                source="walkin",
+            )
+            s.add(lead)
+            await s.flush()
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                citizen_id=f"5{ts:08d}2"[:12],
+                status="draft",
+                applied_rules={},
+                academic_year=2026,
+                uses_choice_engine=False,
+            )
+            s.add(profile)
+            await s.flush()
+            ex = models.AdmissionBackfillException(
+                profile_id=profile.id,
+                exception_type="selected_subject_group_ambiguous",
+                details={"matches": [1, 2]},
+            )
+            s.add(ex)
+            await s.flush()
+            ex_id = ex.id
+
+    # Resolve with a dangerous-prefix notes string. Avoid characters that
+    # csv would auto-quote (comma / quote / newline) so we can assert on
+    # the raw cell content without quoting-layer interference.
+    malicious = "=DANGEROUS_FORMULA()"
+    resolve = await client.patch(
+        f"/api/v2/admin/admission-backfill-exceptions/{ex_id}/resolve",
+        headers=admin_token_headers,
+        json={"resolution_notes": malicious},
+    )
+    assert resolve.status_code == 200, resolve.text
+
+    response = await client.get(
+        "/api/v2/admin/admission-backfill-exceptions/export.csv",
+        headers=admin_token_headers,
+        params={"exception_type": "selected_subject_group_ambiguous"},
+    )
+    assert response.status_code == 200
+    text = response.text
+
+    # Sanitised: cell content starts with a literal single quote followed
+    # by the original formula. resolution_notes is the LAST column so it
+    # is preceded by a comma and terminated by CR/LF.
+    sanitised_cell = f",'{malicious}\r\n"
+    assert sanitised_cell in text, (
+        f"Expected sanitised cell {sanitised_cell!r} in CSV body; "
+        f"first 600 chars:\n{text[:600]!r}"
+    )
+    # And the raw, unsanitised form (no leading single quote) MUST NOT
+    # appear as a cell — that would mean sanitize_csv_cell was bypassed.
+    raw_cell = f",{malicious}\r\n"
+    assert raw_cell not in text, (
+        f"CSV contains malicious formula unprefixed — sanitiser bypass. "
+        f"CWE-1236 regression."
+    )
+
+
+@pytest.mark.asyncio
+async def test_csv_export_handles_empty_result(
+    client: AsyncClient,
+    admin_token_headers: dict,
+):
+    """Zero matching rows still emits the header line + 200 status.
+
+    Defensive: a filter combo that matches nothing must not raise — the
+    async generator yields only the header chunk.
+    """
+    response = await client.get(
+        "/api/v2/admin/admission-backfill-exceptions/export.csv",
+        headers=admin_token_headers,
+        params={"exception_type": "__nonexistent_type__"},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    text = response.text
+    # Header line emitted (unquoted shape, preserves pre-PR-1 contract)
+    assert text.startswith("id,profile_id,exception_type"), (
+        f"Expected header line as sole chunk; got: {text[:200]!r}"
+    )
+    # No data rows — only the header line
+    lines = [line for line in text.split("\n") if line.strip()]
+    assert len(lines) == 1, (
+        f"Empty-result CSV should have exactly 1 line (header); got {len(lines)} lines"
+    )
+
+
+# ============================================================================
 # PR-CO-4 (FU #118) — Bulk-resolve atomicity anchor
 # ============================================================================
 

--- a/Backend_FastAPI/tests/integration/test_notification_delivery_stale_sent_filter.py
+++ b/Backend_FastAPI/tests/integration/test_notification_delivery_stale_sent_filter.py
@@ -1,0 +1,101 @@
+# tests/integration/test_notification_delivery_stale_sent_filter.py
+"""Anchor test for NotificationDeliveryRepository.get_stale_sent_count.
+
+PR-1 Commit 1 (2026-05-23) — re-add ``zalo`` to the stale-sent channel
+filter after the ZBS Template Message webhook handler shipped (commit
+``d357c029``). Before that commit zalo was excluded because a "sent zalo
+row older than 60min" was the expected interim state. Post-d357c029 the
+webhook transitions ``sent → delivered`` in ~3-10s, so a stale ``sent``
+row IS now a meaningful alert.
+
+Anchor pins:
+  - Both ``sms`` AND ``zalo`` channels above the lag window count
+  - ``email`` / ``browser`` are NOT counted (handler-confirmed channels
+    have their own delivery webhooks; zalo/sms are the "provider
+    callback uncertain" cohort)
+  - Rows inside the lag window do not count
+
+Reference: memory ``outstanding-debt`` P3-9 + ``project_zns_uid_findings``.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.notification_delivery_repository import (
+    NotificationDeliveryRepository,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestGetStaleSentCount:
+    """Pin the stale-sent filter post-d357c029 webhook handler."""
+
+    async def _seed_sent(
+        self,
+        db: AsyncSession,
+        *,
+        channel: str,
+        minutes_ago: int,
+        user_id: int,
+    ) -> int:
+        """Seed a ``status='sent'`` row at ``now - minutes_ago``. Returns id."""
+        repo = NotificationDeliveryRepository(db)
+        sent_at = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+        delivery = await repo.create_delivery(
+            event="test_stale_filter_anchor",
+            channel=channel,
+            recipient_kind="internal",
+            user_id=user_id,
+            status="sent",
+            sent_at=sent_at,
+        )
+        return delivery.id
+
+    async def test_counts_both_sms_and_zalo_above_lag_window(
+        self, db: AsyncSession, admin_user
+    ):
+        """Both sms AND zalo rows older than lag count as stale."""
+        await self._seed_sent(db, channel="sms", minutes_ago=90, user_id=admin_user.id)
+        await self._seed_sent(db, channel="zalo", minutes_ago=90, user_id=admin_user.id)
+
+        repo = NotificationDeliveryRepository(db)
+        count = await repo.get_stale_sent_count(lag_minutes=60)
+
+        assert count == 2, (
+            f"Expected both sms+zalo to be flagged stale, got count={count}. "
+            f"Post-d357c029 ZBS webhook handler shipped → zalo MUST be in filter."
+        )
+
+    async def test_zalo_within_lag_window_not_counted(
+        self, db: AsyncSession, admin_user
+    ):
+        """Zalo row sent recently (within lag) is NOT a stale alert."""
+        await self._seed_sent(db, channel="zalo", minutes_ago=30, user_id=admin_user.id)
+
+        repo = NotificationDeliveryRepository(db)
+        count = await repo.get_stale_sent_count(lag_minutes=60)
+
+        assert count == 0, (
+            f"Recent zalo (30min old < 60min lag) should NOT be flagged. "
+            f"Got count={count} — filter may have flipped window comparator."
+        )
+
+    async def test_browser_and_email_channels_not_counted(
+        self, db: AsyncSession, admin_user
+    ):
+        """browser + email have their own provider webhooks and are NOT in
+        the stale-sent cohort. Only sms+zalo (provider-callback uncertain
+        channels) are flagged when stuck in ``sent`` past the lag.
+        """
+        await self._seed_sent(db, channel="browser", minutes_ago=90, user_id=admin_user.id)
+        await self._seed_sent(db, channel="email", minutes_ago=90, user_id=admin_user.id)
+
+        repo = NotificationDeliveryRepository(db)
+        count = await repo.get_stale_sent_count(lag_minutes=60)
+
+        assert count == 0, (
+            f"browser+email channels must not be in stale-sent filter. "
+            f"Got count={count}."
+        )

--- a/Backend_FastAPI/tests/unit/test_migration_cleanup_uppercase.py
+++ b/Backend_FastAPI/tests/unit/test_migration_cleanup_uppercase.py
@@ -1,0 +1,157 @@
+"""Unit tests for ``cleanup_uppercase_orphan_notification_rows`` migration.
+
+PR-1 Commit 2 (2026-05-23) — verify the cleanup migration:
+1. Loads with the expected revision chain identifiers.
+2. Declares both required predicates (rule + template).
+3. Touches all three tables in the correct FK-safe order
+   (notification_action child first, then notification_rule parent,
+   then notification_template — which has no FK back into rule).
+4. ``downgrade()`` is a no-op (the deleted rows had no business meaning).
+
+Pattern follows ``test_phase1_01_02_revision_chain.py`` — importlib-load
+the migration as a plain module, contract-assert revision / body
+predicates / SQL ordering. The real upgrade/downgrade run lives in the
+dev-DB roundtrip pre-PR + the CI integration sweep post-merge.
+"""
+from __future__ import annotations
+
+import importlib.util
+import inspect
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = (
+    Path(__file__).resolve().parents[2] / "alembic" / "versions"
+)
+
+
+@pytest.fixture
+def migration():
+    path = _VERSIONS_DIR / "cleanup_uppercase_orphan_notification_rows.py"
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None, (
+        f"Cannot load migration {path}"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision chain lock
+# ---------------------------------------------------------------------------
+
+
+def test_revision_id(migration):
+    assert migration.revision == "cleanup_upper_notif", (
+        "Revision ID is part of the alembic chain — renaming breaks any "
+        "downstream migration that lists this as down_revision."
+    )
+
+
+def test_down_revision_chains_off_qa20260522(migration):
+    """Migration revises off the prior head ``qa20260522_tighten_lead_denies``.
+
+    If a NEW migration lands between this commit and merge, that migration
+    would also need to bump its down_revision to point to ``cleanup_upper_notif``
+    OR this revision must be rebased to chain off the new head.
+    """
+    assert migration.down_revision == "qa20260522_tighten_lead_denies"
+
+
+# ---------------------------------------------------------------------------
+# 2. Predicate constants — single source of truth for delete + count
+# ---------------------------------------------------------------------------
+
+
+def test_rule_predicate_uses_escape_clause(migration):
+    """SQL LIKE ``ADMISSION_%`` without ESCAPE matches single-char underscore
+    wildcard → false positives on patterns like ``ADMISSIONX``. Migration
+    MUST use explicit ESCAPE so the literal underscore is matched.
+    """
+    pred = migration._RULE_PREDICATE
+    assert "ESCAPE '\\'" in pred, (
+        "Rule predicate must escape the literal underscore in LIKE."
+    )
+    assert "event != lower(event)" in pred, (
+        "Rule predicate must require at least one uppercase character "
+        "to avoid deleting lowercase (live) rows."
+    )
+    assert pred.startswith("event LIKE 'ADMISSION\\_%'"), (
+        "Rule predicate target — uppercase ADMISSION_* event names — "
+        "must be the LIKE pattern."
+    )
+
+
+def test_template_predicate_uses_escape_clause(migration):
+    pred = migration._TEMPLATE_PREDICATE
+    assert "ESCAPE '\\'" in pred
+    assert "template_code != lower(template_code)" in pred
+    assert pred.startswith("template_code LIKE 'TPL\\_ADMISSION\\_%'"), (
+        "Template predicate target — uppercase TPL_ADMISSION_* template "
+        "codes (per phase1_19c _template_code helper) — must be the "
+        "LIKE pattern."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Upgrade body — FK-safe ordering + 3 table coverage
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_body_covers_three_tables_in_fk_safe_order(migration):
+    """Upgrade body MUST:
+      - DELETE from notification_action BEFORE notification_rule (FK).
+      - DELETE notification_template independently (no FK from rule).
+      - Use the predicate constants (no inline string drift).
+    """
+    src = inspect.getsource(migration.upgrade)
+
+    action_idx = src.find("DELETE FROM notification_action")
+    rule_idx = src.find("DELETE FROM notification_rule")
+    template_idx = src.find("DELETE FROM notification_template")
+
+    assert action_idx >= 0, "Missing DELETE FROM notification_action"
+    assert rule_idx >= 0, "Missing DELETE FROM notification_rule"
+    assert template_idx >= 0, "Missing DELETE FROM notification_template"
+
+    assert action_idx < rule_idx, (
+        "FK order violation: notification_action (child) must be deleted "
+        "BEFORE notification_rule (parent). Schema has no ON DELETE CASCADE."
+    )
+
+    # Predicate constants must be referenced (no inline string drift).
+    assert "_RULE_PREDICATE" in src
+    assert "_TEMPLATE_PREDICATE" in src
+
+
+def test_upgrade_logs_counts(migration):
+    """Upgrade should print rule/action/template counts so the alembic
+    output trail captures the row impact (per memory ``migration-predicate-safety``
+    audit trail requirement).
+    """
+    src = inspect.getsource(migration.upgrade)
+    assert "print(" in src, "Upgrade body should log row counts"
+    for key in ("rule=", "action=", "template="):
+        assert key in src, f"Expected count log key {key!r} in upgrade output"
+
+
+# ---------------------------------------------------------------------------
+# 4. Downgrade no-op contract
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_is_noop(migration):
+    """Downgrade docstring + body must encode "no-op" intent — the deleted
+    rows were dead weight, re-creating them would only restore the noise.
+    """
+    src = inspect.getsource(migration.downgrade)
+    # Body must NOT execute any DELETE / INSERT / op.execute call.
+    for forbidden in ("op.execute", "INSERT INTO", "DELETE FROM", "UPDATE "):
+        assert forbidden not in src, (
+            f"downgrade() must be a no-op; found forbidden token {forbidden!r}"
+        )
+    # ``pass`` (the no-op statement) MUST be present.
+    assert "pass" in src


### PR DESCRIPTION
## Summary

PR-1 of the 3-PR plan (plan: `ng-2-pr-sorted-floyd.md`). Bundles 4 low-risk, independent
commits across notification reliability, notification-rule cleanup, admin-backfill CSV
streaming + injection sanitize, and a single finance template-assertion drift fix.

### Commits (in landed order)

1. `7b273617 fix(notification): re-add zalo to get_stale_sent_count filter`
   - `notification_delivery_repository.py:476` filter `["sms"]` → `["sms", "zalo"]`
   - Rationale: ZBS Template Message webhook handler shipped `d357c029` (~3-10s
     `sent → delivered` transition) so stale `sent` zalo rows are now meaningful alerts.
2. `5d7a9001 chore(migrations): cleanup phase1_19c UPPERCASE orphan notification rows`
   - New alembic `cleanup_upper_notif` revises off `qa20260522_tighten_lead_denies`.
   - FK-safe DELETE order: `notification_action` (child) → `notification_rule` (parent)
     → `notification_template` (independent).
   - Predicate `LIKE 'ADMISSION\_%' ESCAPE '\\' AND event != lower(event)` so the
     literal underscore is matched and lowercase live rows untouched.
   - Idempotent; `downgrade()` is a deliberate no-op.
3. `c7145f69 perf(admin-backfill): true async CSV streaming + reuse sanitize_csv_cell`
   - Lifted `_csv_export_stream` to a module-level coroutine generator so unit tests
     drive it directly (httpx ASGITransport buffers `StreamingResponse` end-to-end).
   - Reuses `app/utils/csv_helpers.py:55` `sanitize_csv_cell` for CSV/formula injection
     (OWASP CWE-1236) on `details`, `resolved_by_username`, `resolution_notes`.
   - Header chunk keeps unquoted shape (csv default QUOTE_MINIMAL) so downstream tooling
     greps still pass.
4. `f89db82f test-debt(finance): flip officer fee calc assertion to match policy reality`
   - `test_officer_cannot_calculate_fee` → `test_officer_can_calculate_fee_scoped`.
   - Flips `not in` → `in` per decision `admission-audit-decisions-2026-04-24` (officer
     scoped fee calc shipped 2026-04-24; OFFICER_TEMPLATE has had the rule since).
   - Adds two symmetry assertions so a future drift granting officer the accountant-only
     finance writes fails loud at unit-test time.

---

## Verification matrix

All commands run locally inside the backend Docker container (`docker compose exec -T backend python -m pytest ...`).

| Scope | Result |
|---|---|
| Commit 1 anchor: `tests/integration/test_notification_delivery_stale_sent_filter.py` | **3/3 PASS** |
| Commit 2 unit contract: `tests/unit/test_migration_cleanup_uppercase.py` | **7/7 PASS** |
| Commit 2 `alembic upgrade head` on dev DB | **PASS** (rule=12 action=29 template=14 deleted); idempotent (2nd run no-op) |
| Commit 3 file: `tests/api/test_phase3_pr3d_b_admin_backfill.py` (3 new + 12 existing + 1 atomicity) | **16/16 PASS** isolated |
| Commit 4 class: `tests/api/test_finance_api.py::TestFinanceRolePermissions` | **11/11 PASS** |
| Full notification CI suite (7 files per plan section "PR-1 Verification") | **92/92 PASS** isolated |

---

## SSH prod preflight (read-only)

```
Prod DB: qlts_production

 rule_count | template_count | action_count
------------+----------------+--------------
          0 |             14 |            0
```

**Findings**:
- Prod has **0** orphan `notification_rule` rows (memory `outstanding-debt P3-E` expected
  12 based on dev baseline; prod state has diverged — likely never fully seeded due to
  cutover gate `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP=false` or manual cleanup that
  missed the `notification_template` rows).
- Prod has **0** orphan `notification_action` rows (consistent with rule=0; FK
  cascade-empty).
- Prod has **14** orphan `notification_template` rows of the `TPL_ADMISSION_*`
  uppercase pattern — these are the dead weight this migration removes.

**Prod migration impact (verified safe)**:
- Step 1 logs `rule=0 template=14`.
- Step 2 collects `rule_ids = []`.
- Step 3 `DELETE notification_action` — **skipped** (empty rule_ids list).
- Step 4 `DELETE notification_rule` — **0 rows** (predicate matches 0).
- Step 5 `DELETE notification_template` — **14 rows deleted**.
- Idempotent: second `alembic upgrade head` no-ops.

Memory `outstanding-debt P3-E` description needs updating post-merge to reflect actual
prod row counts (handled in plan section "Memory updates checklist", not in this PR).

---

## Residuals — handed off to PR-1.5

Documented in plan section "PR-1 residual evidence after Commit 4". **All pre-existing on
main, NOT regressions from PR-1** — do not block this PR's targeted gate per user
decision 2026-05-23.

1. **`tests/api/test_finance_api.py` 2 failures (Casbin template-shape drift)**:
   - `TestDiamondInheritance::test_accountant_does_not_have_user_management`
   - `TestDiamondInheritance::test_separation_of_duties_summary`
   - Root cause: tests enumerate ALL `ACCOUNTANT_TEMPLATE["policies"]` rows without
     distinguishing `eft="deny"` vs `eft="allow"`. After B1 deny-first design
     (memory `casbin-deny-parent-role-propagates-to-children`) the template carries
     both shapes; the deny rows trip the negative assertions.
   - Fix candidate: `if p.get("eft", "allow") == "allow"` filter.
   - Fits PR-1.5 trigger condition #1 (not pure expected-status drift).

2. **`tests/api/test_fees_calculate_authorization.py` 3/5 failures (fixture config gap)**:
   - 3 tests fail at `submit.status_code == 200` (`tests/api/test_fees_calculate_authorization.py:147`)
     with body `CONFIG_GAP_TARGET_LEVEL: hồ sơ không có offering_admission_config_id và uses_choice_engine=False`.
   - Fixture submit never reaches `/api/fees/calculate` → authorization evidence
     unclean.
   - Root cause: fixture predates Phase 3 multi-NV / choice-engine changes; needs to
     seed `offering_admission_config_id` or route through a valid admission_path config.
   - Fits PR-1.5 trigger condition #2 (requires service-layer understanding).

3. **Parallel pytest + testadmin fixture race**:
   - Running two pytest invocations concurrently against the same backend container
     causes the admin-token fixture to race (auth 401 / UniqueViolation on testadmin),
     producing ~20-25 spurious `ERROR`s in whichever invocation lost the race.
   - Isolated reruns produce 0 errors (verified for both admin-backfill and notification
     CI suite).
   - Already tracked in memory `test-debt-admission-workflow-e2e`. Fits PR-1.5 trigger
     condition #3 (fixture issue requiring multi-callsite reasoning).

---

## Files touched (PR-1 scope only — verified no overlap with other plans)

```
 Backend_FastAPI/app/repositories/notification_delivery_repository.py | docstring + filter
 Backend_FastAPI/app/routers/admin_backfill.py                        | streaming + sanitize reuse
 Backend_FastAPI/alembic/versions/cleanup_uppercase_orphan_notification_rows.py | NEW
 Backend_FastAPI/tests/api/test_finance_api.py                        | flip officer fee calc test
 Backend_FastAPI/tests/api/test_phase3_pr3d_b_admin_backfill.py       | +3 anchor tests
 Backend_FastAPI/tests/integration/test_notification_delivery_stale_sent_filter.py | NEW
 Backend_FastAPI/tests/unit/test_migration_cleanup_uppercase.py       | NEW
```

7 files total. No suspicious-login files touched (`login_history_service.py`,
`login_history_repository.py`, `auth.py`, `useAuth.ts`, `SecurityBanner.tsx`,
`SocketHandler.tsx`, `SecurityClient.tsx`, `api.types.ts` all untouched).

---

## Test plan

- [x] Local anchor tests per commit pass
- [x] Local full notification CI suite (7 files) pass isolated
- [x] Alembic upgrade idempotent on dev DB
- [x] SSH prod preflight verifies migration impact (deletes only 14 orphan templates; rule/action no-op)
- [ ] CI green on push (backend-test workflow gate)
- [ ] Post-merge: alembic upgrade runs on prod via entrypoint, confirm 14 templates cleaned + no regression
- [ ] Post-merge: update memory entries per plan section "Memory updates checklist" (NOT in this PR's scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
