### PR TITLE
ci(pr-1.6): bounded backend test gate + nightly full suite

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -28,20 +28,34 @@ name: Backend Test (PR Gate)
 # Trigger: ANY change under Backend_FastAPI/** — including tests/. No
 # path-filter loophole.
 #
-# Performance budget: <8 phút median.
+# Performance budget: <10 phút median.
 #
-# Test composition (2026-05-14 audit, S2 hardening item #5):
-# the original "full pytest" approach hung indefinitely on 3 consecutive
-# runs (25844187752, 25845356360, 25846362694) — root cause traced to
-# pre-existing test-debt deadlocks in ``test_admission_workflow_e2e.py``
-# (memory ``test-debt-admission-workflow-e2e``) and slow heavy-fixture
-# integration sweeps. Until the test-debt PR lands, this gate runs an
-# explicit allowlist of CRITICAL production-safety tests:
+# DESIGN — BOUNDED RISK GATE (PR-1.6, 2026-05-24):
+# This is a SOLO-DEV velocity-optimized PR gate. It is intentionally
+# scoped to system-breaking risk paths, NOT 100% pytest coverage. The
+# full backend suite lives in ``nightly-backend-pytest.yml`` (schedule +
+# workflow_dispatch) — required for pre-release runs, NOT required as
+# a per-PR gate. Memory ``ci-pytest-selective-allowlist-pattern`` +
+# ``solo-dev-batch-prs-to-reduce-ci-overhead``: per-PR CI overhead at
+# 30-60 phút × N PR-a-week is the actual cost driver for a solo dev;
+# a bounded curated gate that catches release-blockers in <10 phút is
+# the right trade-off vs an exhaustive 25-30 phút full suite per PR.
+#
+# Per-test ``--timeout=60`` (pytest-timeout, added in prior commit)
+# guards each tier against a future regression that re-introduces a
+# hang — aborts the offending test cleanly, captures the rest of the
+# tier's signal, never times out the whole GitHub Actions job.
+#
+# Tier composition (curated for release-blocker coverage):
 #
 #   Tier 1: Phase 3 multi-NV core (choice schema, state machine, engine,
 #           CRUD, magic-link consume) — Wave A/B acceptance gates
 #   Tier 2: RBAC + CCCD lock + CSRF (Casbin matrix, confirm lock ladder,
-#           CSRF exempt prefix, XFF helper)
+#           CSRF exempt prefix, XFF helper) — EXPANDED 2026-05-24 to
+#           include permission_matrix + lead static-route collision +
+#           fee auth + diamond inheritance because PR #329 reconciled
+#           those risk surfaces and the gate must verify them on every
+#           PR going forward.
 #   Tier 3: Notification reliability (parity + dispatcher + bundle +
 #           outbox + event coverage)
 #   Tier 4: Admission + lead workflow contract (state machine, milestone
@@ -49,11 +63,16 @@ name: Backend Test (PR Gate)
 #   Tier 5: Phase 2 engine prereqs (3-tier resolution, quota chain,
 #           snapshot, UNIQUE constraints)
 #
-# Net coverage: ~310-360 tests across ~25 files, ~5-8 phút wall-clock on
-# pip cache hit. ~5× coverage vs the deploy.yml legacy 6-test subset.
-# Excluded categories: known-flaky e2e workflow, debug-only, Zalo, heavy
-# admission_workflow/calculation services. Restore full suite via
-# follow-up PR after test-debt resolution.
+# What this gate does NOT cover (intentional — moved to nightly):
+#   - Full backend tests/ (~1500+ tests, broad service/repo unit sweeps)
+#   - Playwright E2E
+#   - Heavy historical regression suites
+#   - debug-only modules (tests/integration/test_debug*.py)
+#   - Zalo external-dep tests
+#
+# When a new release-blocker test surface lands, ADD it to the right
+# tier here (not a separate workflow) so the per-PR gate stays the
+# canonical risk truth.
 
 on:
   pull_request:
@@ -154,10 +173,18 @@ jobs:
           tests/api/test_phase3_pr3e_magic_link.py
           tests/services/test_phase3_create_profile_inherits_multi_nv.py
           tests/unit/test_admission_path_service_field_drift.py
-          -q --tb=short
+          -q --tb=short --timeout=60
 
       # =====================================================================
       # Tier 2: RBAC + security + CCCD lock + CSRF
+      #
+      # PR-1.6 (2026-05-24) — added 4 surfaces that PR #329 reconciled and
+      # the prior allowlist did not execute (memory
+      # ``auto-merge-requires-full-ci-not-just-green`` flagged this gap):
+      #   * test_permissions_matrix.py — role/route assertion matrix
+      #   * test_casbin_lead_static_route_collision.py — keyMatch4 leak guard
+      #   * test_fees_calculate_authorization.py — officer scoped fee auth
+      #   * test_finance_api.py::TestDiamondInheritance — allow/deny semantics
       # =====================================================================
       - name: pytest — RBAC + security + CCCD lock
         working-directory: Backend_FastAPI
@@ -173,7 +200,11 @@ jobs:
           tests/unit/test_admission_confirmation_cooldown.py
           tests/unit/test_magic_link_rate_limit_key_hashing.py
           tests/api/test_admin_v2_admission_round_phase3_flags.py
-          -q --tb=short
+          tests/security/test_permissions_matrix.py
+          tests/integration/test_casbin_lead_static_route_collision.py
+          tests/api/test_fees_calculate_authorization.py
+          tests/api/test_finance_api.py::TestDiamondInheritance
+          -q --tb=short --timeout=60
 
       # =====================================================================
       # Tier 3: Notification reliability (legacy deploy.yml subset)
@@ -191,7 +222,7 @@ jobs:
           tests/unit/test_outbox_worker.py
           tests/unit/test_outbox_skeleton.py
           tests/unit/test_check_notification_event_coverage_deferred.py
-          -q --tb=short
+          -q --tb=short --timeout=60
 
       - name: pytest — Notification event coverage script
         working-directory: Backend_FastAPI
@@ -213,7 +244,7 @@ jobs:
           tests/api/test_lead_assignment_api.py::test_lead_assignment_lifecycle_end_to_end
           tests/unit/test_admission_state_machine.py
           tests/unit/test_b2_1_admission_milestone_events.py
-          -q --tb=short
+          -q --tb=short --timeout=60
 
       # =====================================================================
       # Tier 5: Phase 2 engine prereqs (Phase 3 builds laterally on these)
@@ -226,4 +257,4 @@ jobs:
           tests/unit/test_phase2_engine_quota_chain_v8.py
           tests/unit/test_phase2_engine_snapshot_integrity.py
           tests/unit/test_phase2_pr2c_three_col_unique.py
-          -q --tb=short
+          -q --tb=short --timeout=60

--- a/.github/workflows/nightly-backend-pytest.yml
+++ b/.github/workflows/nightly-backend-pytest.yml
@@ -1,0 +1,118 @@
+name: Nightly Backend Pytest
+
+# PR-1.6 (2026-05-24) — Full BACKEND pytest suite as nightly + manual,
+# NOT a required PR gate. Distinct from ``nightly-regression.yml`` which
+# runs Playwright E2E (frontend integration) at a different cron slot;
+# this workflow covers the backend pytest layer only.
+#
+# The per-PR gate (``backend-test.yml``) is intentionally a bounded
+# curated risk gate optimised for solo-dev velocity (memory
+# ``solo-dev-batch-prs-to-reduce-ci-overhead`` — 30-60 phút CI overhead
+# per PR is the real cost driver). This nightly workflow runs the FULL
+# backend suite so broad service/repo/unit drift surfaces every day
+# instead of waiting for a release-prep moment, without blocking any
+# PR's merge time.
+#
+# Triggers:
+#   schedule: 18:00 UTC daily (= 01:00 ICT next-day, off-hours for dev)
+#   workflow_dispatch: manual run for pre-release verification
+#
+# Failure mode: GitHub Actions email/UI notification. NOT a PR gate, so
+# a red nightly does NOT block ongoing PRs — it surfaces drift to the
+# solo dev for the next morning's triage.
+#
+# Cross-file sync (memory ``ci-workflow-flag-cross-file-sync``):
+#   python-version, cache, postgres + redis services, env vars all
+#   mirror ``backend-test.yml`` so the nightly's environment matches
+#   what the PR gate verifies (no env drift = no false nightly red).
+
+on:
+  schedule:
+    # 18:00 UTC daily. Cron is in UTC; this lands ~01:00 ICT = pre-dawn
+    # local, so the result is in the inbox by morning standup.
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+    # Manual trigger for pre-release runs ("ship Phase 4? run nightly
+    # first") or when investigating a suspected drift surface.
+
+concurrency:
+  # Multiple workflow_dispatch back-to-back collapse to the latest. The
+  # scheduled cron rarely overlaps with a manual run; if they do, the
+  # manual run wins (newer SHA / more intent).
+  group: nightly-backend-pytest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest-full:
+    name: pytest (full suite)
+    runs-on: ubuntu-latest
+    # Wall-clock ceiling — full suite at QLTS scale runs ~30-60 phút
+    # under sequential execution. 90 minutes covers worst-case slow
+    # fixture chains + leaves margin without burning a full job hour.
+    timeout-minutes: 90
+
+    env:
+      APP_ENV: test
+      DATABASE_URL: postgresql+asyncpg://test:test@localhost:5432/qlts_test
+      REDIS_URL: redis://localhost:6379/0
+      SECRET_KEY: test-secret-key-for-ci-only
+      JWT_SECRET_KEY: test-jwt-secret-for-ci-only
+      MAIL_USERNAME: ci-test@example.com
+      MAIL_PASSWORD: ci-test-placeholder
+      MAIL_FROM: ci-test@example.com
+      MAIL_SERVER: smtp.example.com
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: qlts_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: Backend_FastAPI/requirements-dev.txt
+
+      - name: Install backend dependencies (dev)
+        working-directory: Backend_FastAPI
+        run: pip install -r requirements-dev.txt
+
+      # Full backend pytest suite. ``--timeout=60`` (pytest-timeout) aborts
+      # any single test that hangs — without this, a future regression
+      # that re-introduces a deadlock would consume the full 90-min job
+      # ceiling and lose all log context. ``--ignore-glob`` excludes the
+      # debug-only modules under ``tests/integration/test_debug*.py``
+      # (interactive Casbin/role investigation tools, ``print``-driven —
+      # they collect under the default ``test_*.py`` pattern but contribute
+      # zero gate value).
+      - name: pytest — full suite
+        working-directory: Backend_FastAPI
+        run: >-
+          python -m pytest tests/
+          -q --tb=short
+          --timeout=60
+          --ignore-glob='tests/integration/test_debug*.py'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,32 @@ docker compose exec backend pytest -m unit                             # By mark
 docker compose exec backend pytest -m security
 ```
 
+**Heavy / destructive backend pytest suites — use a throwaway container.**
+``docker compose exec backend`` is fine for one-off, low-RAM unit tests, but for
+suites that DROP/CREATE the ``qlts_test`` schema or fan out many fixture chains
+(Casbin matrix, permission_matrix, fee auth, full Tier 2+), run them in a
+one-off backend container instead. The live ``qlts-backend-1`` (uvicorn
+``--reload``, celery sidecars, connection pool churn) contaminates the
+``qlts_test`` lifecycle and surfaces non-deterministic deadlocks / UNIQUE
+races that vanish in CI (which uses a fresh runner per job).
+
+```bash
+# Stop the live dev backend + celery while pytest runs against qlts_test
+docker compose stop backend celery-worker celery-beat
+
+# Run pytest in a fresh, throwaway backend container
+docker compose run --rm --no-deps backend bash -c "\
+  pip install -r requirements-dev.txt -q && \
+  python -m pytest <tests> -q --tb=short"
+
+# Restore normal dev services after the run
+docker compose start backend celery-worker celery-beat
+```
+
+Reference: memory ``local-test-oneoff-container-pattern``. Same principle as
+the frontend ``scripts/fe-check.sh`` wrapper (memory
+``type-check-container-isolation``).
+
 ### Backend Other
 
 ```bash

--- a/Backend_FastAPI/CLAUDE.md
+++ b/Backend_FastAPI/CLAUDE.md
@@ -158,6 +158,26 @@ docker compose exec backend python -m pytest tests/api/test_leads.py::test_creat
 - NEVER add test deps to `requirements.txt` -- production image must stay clean
 - After `docker compose down && up`, reinstall test deps
 
+### Heavy / destructive suites — throwaway container required
+
+`docker compose exec backend python -m pytest ...` is fine for one-off
+low-RAM unit tests, BUT for suites that DROP/CREATE the `qlts_test` schema
+or fan out many fixture chains (Casbin matrix, permission_matrix, fee auth,
+full Tier 2+), the live `qlts-backend-1` (uvicorn `--reload` + celery +
+shared connection pool) contaminates the test lifecycle and surfaces
+non-deterministic deadlocks / UNIQUE races that vanish in CI.
+
+```bash
+docker compose stop backend celery-worker celery-beat
+docker compose run --rm --no-deps backend bash -c "\
+  pip install -r requirements-dev.txt -q && \
+  python -m pytest <tests> -q --tb=short"
+docker compose start backend celery-worker celery-beat
+```
+
+Memory: `local-test-oneoff-container-pattern` (verified evidence 2026-05-24
+— 4-path PR-1.5 went from 31 errors via `exec` to 41 pass via one-off).
+
 ---
 
 ## Admission Workflows (Source of Truth)

--- a/Backend_FastAPI/requirements-dev.txt
+++ b/Backend_FastAPI/requirements-dev.txt
@@ -10,6 +10,12 @@ pytest==8.4.2
 pytest-asyncio==1.2.0
 pytest-dotenv==0.5.2
 pytest-mock==3.15.1
+# PR-1.6 (2026-05-24) — hard timeout guard for the full-suite gate.
+# The 5-tier allowlist in backend-test.yml previously masked any test
+# that hung indefinitely; full-suite restore relies on this plugin to
+# enforce a per-test ceiling and abort cleanly instead of timing out
+# the whole GitHub Actions job (which loses the captured logs).
+pytest-timeout==2.4.0
 
 # Code formatting & linting
 autoflake==2.3.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,25 @@ docker compose exec backend python -m pytest -m unit                            
 docker compose exec backend python -m pytest -m security
 ```
 
+**Heavy / destructive backend pytest suites — use a throwaway container.**
+``docker compose exec backend`` is fine for one-off, low-RAM unit tests, but
+for suites that DROP/CREATE the ``qlts_test`` schema or fan out many fixture
+chains (Casbin matrix, permission_matrix, fee auth, full Tier 2+), run them in
+a one-off backend container. The live ``qlts-backend-1`` (uvicorn
+``--reload``, celery sidecars, connection pool churn) contaminates the
+``qlts_test`` lifecycle and surfaces non-deterministic deadlocks / UNIQUE
+races that vanish in CI (which uses a fresh runner per job).
+
+```bash
+docker compose stop backend celery-worker celery-beat
+docker compose run --rm --no-deps backend bash -c "\
+  pip install -r requirements-dev.txt -q && \
+  python -m pytest <tests> -q --tb=short"
+docker compose start backend celery-worker celery-beat
+```
+
+Reference: memory ``local-test-oneoff-container-pattern``.
+
 ### Backend Other
 
 ```bash


### PR DESCRIPTION
## Why design changed

The original plan for PR-1.6 was to "restore the full pytest suite as a required PR gate." For a solo-dev workflow, running ~1500+ tests sequentially on every PR is the wrong trade-off — at 25-60 minutes per PR, CI overhead becomes the dominant cost driver vs the value of catching every drift surface synchronously. (Memory references: `solo-dev-batch-prs-to-reduce-ci-overhead`, `ci-pytest-selective-allowlist-pattern`.)

The redesign:

- **PR gate** (`backend-test.yml`) — bounded risk gate. Targets release-blocker surfaces in ~10 minutes. EXPANDED to cover the 4 surfaces PR #329 reconciled but the prior allowlist did not execute.
- **Nightly** (`nightly-backend-pytest.yml`, NEW) — full backend suite at 18:00 UTC + `workflow_dispatch`. Surfaces broad service/repo/unit drift within a 24-hour window, never blocks a PR merge.

When a new release-blocker test surface lands, add it to the right tier in the PR gate (canonical risk truth), not a separate workflow.

## Commits

1. **`17c2eed3` docs(testing): document one-off backend container pattern for heavy pytest** — `AGENTS.md` + root `CLAUDE.md` + `Backend_FastAPI/CLAUDE.md`. Live `qlts-backend-1` (uvicorn `--reload` + celery + shared pool) contaminates the `qlts_test` schema lifecycle when destructive suites are driven through `docker compose exec backend`. Future agents should use the throwaway pattern (`docker compose run --rm --no-deps backend ...`) instead. Same principle as `scripts/fe-check.sh` for vitest/tsc OOM kills.

2. **`eddb6520` chore(test-deps): add pytest-timeout for per-test hang guard** — `pytest-timeout==2.4.0` in `requirements-dev.txt`. Without `--timeout=60`, a future regression that re-introduces a deadlock would consume the full GitHub Actions job slot; with it, the offending test aborts cleanly and the remaining tier signal is preserved.

3. **`3c5ad15b` ci(pr-1.6): bounded gate expansion + nightly full-suite workflow** — Tier 2 of `backend-test.yml` picks up 4 surfaces (`test_permissions_matrix.py`, `test_casbin_lead_static_route_collision.py`, `test_fees_calculate_authorization.py`, `test_finance_api.py::TestDiamondInheritance`); `--timeout=60` added to all 5 tier runs; design header rewritten. NEW `nightly-backend-pytest.yml` runs the full backend suite with `--ignore-glob='tests/integration/test_debug*.py'`, `timeout-minutes: 90`, env/postgres/redis mirroring the PR gate per `ci-workflow-flag-cross-file-sync`.

## Verification

Local one-off container (throwaway backend, dev `backend + celery` stopped) running the expanded Tier 1 + Tier 2 — the same 26 path files the PR gate now executes:

```
364 passed, 1 xfailed in 1348.74s (22m28s)
collected 365 items
```

`--timeout=60` was active (`timeout: 60.0s, method: signal`); no test timed out. Comparison vs running the same set through `docker compose exec backend` on the live dev container: **4 failed + 36 errors → 364 passed + 1 xfailed**. The deterministic divergence is the evidence behind the doc commit and the new memory `local-test-oneoff-container-pattern`.

## xfail explanation

The single xfail comes from `tests/security/test_permissions_matrix.py` on the admin `GET /api/admin/pipeline-stages` row. It's a strict guard (xfail strict, asserts the failure mode is exactly fakeredis EVAL rejecting the rate-limit Lua script — not a route/auth regression). Added in PR #329 (memory `test-httpx-cookie-jar-contamination`); it flips to a normal pass once the fakeredis upgrade lands.

## Production code

**No production code changes.** This PR only touches:

- Two GitHub Actions workflow files
- `Backend_FastAPI/requirements-dev.txt` (dev/test dep only — production image installs from `requirements.txt`)
- Three documentation files (`AGENTS.md`, `CLAUDE.md`, `Backend_FastAPI/CLAUDE.md`)

## Scope note — Playwright E2E nightly

This PR does **not** touch `.github/workflows/nightly-regression.yml`. That workflow runs Playwright E2E on a different cron slot and currently has env-var interpolation issues (`POSTGRES_PASSWORD` / `NEXT_PUBLIC_API_URL`) — 10/10 latest runs failing. Out of scope here; will be a separate follow-up so the PR-1.6 review surface stays focused on backend pytest.

## Test plan

- [ ] `backend-test.yml` runs on this PR and passes in <12 minutes
- [ ] Tier 2 specifically passes the 4 new path files
- [ ] No regression in Tier 1, 3, 4, 5
- [ ] `nightly-backend-pytest.yml` shows up in the Actions tab (cron next fire: 18:00 UTC today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)