### PR TITLE
fix(mobile): lead detail + intake selectors responsive @375px (12 findings)

### DIFF
--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
@@ -284,7 +284,7 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-6 w-6 p-0 text-muted-foreground hover:text-muted-foreground shrink-0"
+                  className="h-11 w-11 sm:h-6 sm:w-6 p-0 text-muted-foreground hover:text-muted-foreground shrink-0"
                   onClick={() => handleCopyPhone(lead.phone)}
                   aria-label={phoneCopied ? "Đã sao chép" : "Sao chép số điện thoại"}
                 >

--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadInfoTabs.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadInfoTabs.tsx
@@ -353,7 +353,7 @@ export function LeadInfoTabs({
                     <Button
                       variant="outline"
                       size="sm"
-                      className="h-7 text-xs"
+                      className="h-11 sm:h-7 text-xs"
                       onClick={onAssign}
                     >
                       <UserPlus className="mr-1 h-3 w-3" />

--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadSidebar.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadSidebar.tsx
@@ -218,7 +218,7 @@ export function LeadSidebar({ lead, timeline, onAssign, hideHeader, compact }: L
           <Button
             variant="ghost"
             size="sm"
-            className="h-6 px-2 text-xs text-info-600 hover:bg-info-50"
+            className="h-11 sm:h-6 px-2 text-xs text-info-600 hover:bg-info-50"
             onClick={() => window.open(`tel:${lead.phone}`, "_blank")}
           >
             Gọi
@@ -318,20 +318,20 @@ export function LeadSidebar({ lead, timeline, onAssign, hideHeader, compact }: L
           <div className="bg-background rounded-md p-2 border">
             <div className="flex items-center gap-1 text-muted-foreground mb-0.5">
               <Clock className="h-3 w-3" />
-              <span className="text-[10px]">Trong pipeline</span>
+              <span className="text-xs">Trong pipeline</span>
             </div>
             <div className="font-semibold text-sm" suppressHydrationWarning>{daysInPipeline ?? "..."} ngày</div>
           </div>
           <div className="bg-background rounded-md p-2 border">
             <div className="flex items-center gap-1 text-muted-foreground mb-0.5">
               <History className="h-3 w-3" />
-              <span className="text-[10px]">Số lần tư vấn</span>
+              <span className="text-xs">Số lần tư vấn</span>
             </div>
             <div className="font-semibold text-sm">{lead.consultation_count}</div>
           </div>
         </div>
 
-        <div className="text-[10px] text-muted-foreground flex items-center gap-1 pt-1" suppressHydrationWarning>
+        <div className="text-xs text-muted-foreground flex items-center gap-1 pt-1" suppressHydrationWarning>
           <Calendar className="h-3 w-3" />
           Ngày tạo: {new Date(lead.created_at).toLocaleDateString("vi-VN")}
         </div>

--- a/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
@@ -568,7 +568,7 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
 
       {/* Mobile: Detail Panel Sheet */}
       <Sheet open={mobileDetailOpen} onOpenChange={setMobileDetailOpen}>
-        <SheetContent side="right" className="w-[85vw] sm:w-[400px] sm:max-w-md p-0">
+        <SheetContent side="right" className="w-[calc(100vw-1rem)] sm:w-[400px] sm:max-w-md p-0">
           <SheetHeader className="sr-only">
             <SheetTitle>Chi tiết Lead</SheetTitle>
           </SheetHeader>

--- a/frontend/src/components/common/selectors/MultiOfferingSelector.tsx
+++ b/frontend/src/components/common/selectors/MultiOfferingSelector.tsx
@@ -206,17 +206,17 @@ export function MultiOfferingSelector({
     <div className={cn("space-y-2", className)}>
       {/* Search Input */}
       <div className="relative">
-        <Search className="text-muted-foreground absolute top-2 left-2 h-4 w-4" />
+        <Search className="text-muted-foreground absolute top-1/2 left-2 h-4 w-4 -translate-y-1/2" />
         <Input
           placeholder="Tìm chương trình..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="h-8 pl-8 pr-8 text-sm"
+          className="h-11 sm:h-8 pl-8 pr-8 text-base sm:text-sm"
         />
         {searchQuery && (
           <button
             onClick={() => setSearchQuery("")}
-            className="text-muted-foreground hover:text-foreground absolute top-2 right-2"
+            className="text-muted-foreground hover:text-foreground absolute top-1/2 right-1 -translate-y-1/2 flex h-9 w-9 items-center justify-center sm:right-2 sm:h-auto sm:w-auto"
           >
             <X className="h-4 w-4" />
           </button>
@@ -236,7 +236,7 @@ export function MultiOfferingSelector({
               <button
                 type="button"
                 onClick={() => toggleGroup(degreeLevel)}
-                className="hover:bg-muted/50 flex w-full items-center justify-between px-2 py-1.5 text-left transition-colors"
+                className="hover:bg-muted/50 flex min-h-11 sm:min-h-0 w-full items-center justify-between px-2 py-1.5 text-left transition-colors"
               >
                 <div className="flex items-center gap-1.5">
                   {isCollapsed ? (
@@ -248,11 +248,11 @@ export function MultiOfferingSelector({
                 </div>
                 <div className="flex items-center gap-2">
                   {selectedCount > 0 && (
-                    <span className="bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 text-[10px]">
+                    <span className="bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 text-xs">
                       {selectedCount}
                     </span>
                   )}
-                  <span className="text-muted-foreground text-[10px]">
+                  <span className="text-muted-foreground text-xs">
                     {levelOfferings.length}
                   </span>
                 </div>

--- a/frontend/src/components/common/selectors/SmartConsultationStatusSelector.tsx
+++ b/frontend/src/components/common/selectors/SmartConsultationStatusSelector.tsx
@@ -362,30 +362,36 @@ function ComboboxVariant({
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[350px] p-0" align="start">
+      <PopoverContent className="w-[calc(100vw-2rem)] max-w-[350px] sm:w-[350px] p-0" align="start">
         <Command>
           <CommandInput placeholder="Tim kiem trang thai..." />
           <CommandEmpty>Khong tim thay trang thai nao.</CommandEmpty>
-          {Array.from(groupedStatuses.entries()).map(([stageName, stageStatuses]) => (
-            <CommandGroup key={stageName} heading={stageName}>
-              {stageStatuses.map((status) => (
-                <CommandItem
-                  key={status.id}
-                  value={`${status.name} ${status.stageName}`}
-                  onSelect={() => {
-                    onChange(status.id);
-                    setOpen(false);
-                  }}
-                >
-                  <StatusItem
-                    status={status}
-                    showOutcomeType={showOutcomeType}
-                    isSelected={value === status.id}
-                  />
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          ))}
+          <div
+            className="max-h-[300px] overflow-y-auto overscroll-contain"
+            onTouchMove={(e) => e.stopPropagation()}
+            onWheel={(e) => e.stopPropagation()}
+          >
+            {Array.from(groupedStatuses.entries()).map(([stageName, stageStatuses]) => (
+              <CommandGroup key={stageName} heading={stageName}>
+                {stageStatuses.map((status) => (
+                  <CommandItem
+                    key={status.id}
+                    value={`${status.name} ${status.stageName}`}
+                    onSelect={() => {
+                      onChange(status.id);
+                      setOpen(false);
+                    }}
+                  >
+                    <StatusItem
+                      status={status}
+                      showOutcomeType={showOutcomeType}
+                      isSelected={value === status.id}
+                    />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
+          </div>
         </Command>
       </PopoverContent>
     </Popover>

--- a/frontend/src/components/common/selectors/SmartOfferingSelector.tsx
+++ b/frontend/src/components/common/selectors/SmartOfferingSelector.tsx
@@ -336,14 +336,27 @@ function ComboboxVariant({
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[420px] p-0" align="start">
+      {/* Mobile: fit viewport (avoid 420px overflow on 375px screens).
+          Desktop (sm+): keep the 420px design width. */}
+      <PopoverContent className="w-[calc(100vw-2rem)] max-w-[420px] sm:w-[420px] p-0" align="start">
         <Command shouldFilter={false}>
           <CommandInput
             placeholder="Tìm kiếm ngành, loại hình..."
             value={searchQuery}
             onValueChange={setSearchQuery}
           />
-          <div className="max-h-[350px] overflow-y-auto">
+          {/* onTouchMove/onWheel stopPropagation: when this combobox renders
+              inside a Radix Dialog (e.g. LeadDialog), the Dialog's
+              react-remove-scroll attaches a bubble-phase document touchmove
+              listener that preventDefault()s scroll on this portaled popover
+              (it lives outside the dialog's scroll-lock shard). Stopping
+              propagation here keeps the event from reaching that listener so
+              native touch scroll works on mobile. Verified @375px. */}
+          <div
+            className="max-h-[350px] overflow-y-auto overscroll-contain"
+            onTouchMove={(e) => e.stopPropagation()}
+            onWheel={(e) => e.stopPropagation()}
+          >
             <CommandEmpty>Không tìm thấy chương trình nào.</CommandEmpty>
             {allowAll && (
               <CommandGroup>

--- a/frontend/src/components/common/selectors/SmartUnitSelector.tsx
+++ b/frontend/src/components/common/selectors/SmartUnitSelector.tsx
@@ -275,11 +275,19 @@ function ComboboxVariant({
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[400px] p-0" align="start">
+      {/* Mobile: fit viewport instead of fixed 400px (overflow on 375px). */}
+      <PopoverContent className="w-[calc(100vw-2rem)] max-w-[400px] sm:w-[400px] p-0" align="start">
         <Command>
           <CommandInput placeholder="Tim kiem don vi..." />
           <CommandEmpty>Khong tim thay don vi nao.</CommandEmpty>
-          <CommandGroup className="max-h-[300px] overflow-auto">
+          {/* onTouchMove/onWheel stopPropagation: see SmartOfferingSelector —
+              defeats Radix Dialog react-remove-scroll touch-lock so the
+              portaled popover list scrolls on mobile. */}
+          <CommandGroup
+            className="max-h-[300px] overflow-auto overscroll-contain"
+            onTouchMove={(e) => e.stopPropagation()}
+            onWheel={(e) => e.stopPropagation()}
+          >
             {allowNone && (
               <CommandItem
                 value="none"

--- a/frontend/src/components/leads/AdmissionReadinessChecklist.tsx
+++ b/frontend/src/components/leads/AdmissionReadinessChecklist.tsx
@@ -183,7 +183,7 @@ export function AdmissionReadinessChecklist({
               <Button
                 size="sm"
                 variant="default"
-                className="h-7 text-xs"
+                className="h-11 sm:h-7 text-xs"
                 onClick={onCreateProfile}
               >
                 Tạo hồ sơ
@@ -193,7 +193,7 @@ export function AdmissionReadinessChecklist({
               <Button
                 size="sm"
                 variant="outline"
-                className="h-7 text-xs"
+                className="h-11 sm:h-7 text-xs"
                 onClick={onViewProfile}
               >
                 Xem hồ sơ

--- a/frontend/src/components/leads/InsightsHelperDrawer.tsx
+++ b/frontend/src/components/leads/InsightsHelperDrawer.tsx
@@ -161,7 +161,7 @@ export function InsightsHelperDrawer({ trigger }: InsightsHelperDrawerProps) {
           </Button>
         )}
       </SheetTrigger>
-      <SheetContent side="right" className="w-[420px] sm:w-[520px] overflow-y-auto">
+      <SheetContent side="right" className="w-[calc(100vw-1rem)] sm:w-[520px] overflow-y-auto">
         <SheetHeader className="mb-6">
           <SheetTitle className="flex items-center gap-2 text-lg">
             <HelpCircle aria-hidden="true" className="h-5 w-5 text-primary" />

--- a/frontend/src/components/leads/LeadKanbanCard.tsx
+++ b/frontend/src/components/leads/LeadKanbanCard.tsx
@@ -124,7 +124,7 @@ export function LeadKanbanCard({ lead, isDragging = false }: LeadKanbanCardProps
             <Button
               variant="ghost"
               size="sm"
-              className="h-6 w-6 p-0"
+              className="h-11 w-11 sm:h-6 sm:w-6 p-0"
               asChild
               onClick={(e) => e.stopPropagation()}
               aria-label="Xem chi tiết lead"

--- a/frontend/src/components/leads/LeadScoringCollapsible.tsx
+++ b/frontend/src/components/leads/LeadScoringCollapsible.tsx
@@ -49,7 +49,7 @@ function ScoreBadge({
         <Icon className="h-3.5 w-3.5" />
       </div>
       <div className="min-w-0">
-        <p className="text-[10px] text-muted-foreground uppercase tracking-wide truncate">
+        <p className="text-xs text-muted-foreground uppercase tracking-wide truncate">
           {label}
         </p>
         <p className={cn("text-sm font-bold", isNull ? "text-muted-foreground" : colorClass.split(" ")[0])}>
@@ -101,7 +101,7 @@ export function LeadScoringCollapsible({
             >
               <TrendingUp className="h-3 w-3" />
               {overallScore}
-              <span className="text-[10px] font-normal opacity-80">
+              <span className="text-xs font-normal opacity-80">
                 ({getLeadScoreLabelShort(overallScore)})
               </span>
             </div>

--- a/frontend/src/components/leads/LeadTimelineTab.tsx
+++ b/frontend/src/components/leads/LeadTimelineTab.tsx
@@ -586,7 +586,7 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
                                 <Button
                                   variant="ghost"
                                   size="sm"
-                                  className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                                  className="h-11 w-11 sm:h-7 sm:w-7 p-0 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
                                 >
                                   <MoreVertical className="h-4 w-4 text-muted-foreground" />
                                 </Button>

--- a/frontend/src/components/leads/QuickConsultationSectionV2.tsx
+++ b/frontend/src/components/leads/QuickConsultationSectionV2.tsx
@@ -443,7 +443,7 @@ export function QuickConsultationSectionV2({
     const isPending = pendingStatus?.id === status.id;
 
     const base =
-      "relative flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors";
+      "relative flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors min-h-11 sm:min-h-0";
 
     if (isPending) {
       return cn(base, "ring-2 ring-primary ring-offset-1 scale-[1.02]", getOutcomeBg(status.outcome_type));
@@ -589,7 +589,7 @@ export function QuickConsultationSectionV2({
                 value={opt.value}
                 size="sm"
                 className={cn(
-                  "h-8 gap-1.5 px-2.5 text-xs",
+                  "h-11 sm:h-8 gap-1.5 px-2.5 text-xs",
                   "data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
                 )}
               >
@@ -615,7 +615,7 @@ export function QuickConsultationSectionV2({
         <div>
           <button
             type="button"
-            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors min-h-11 sm:min-h-0 py-2 sm:py-0"
             onClick={() => setScheduleOpen((prev) => !prev)}
           >
             <CalendarClock className="h-3.5 w-3.5" />
@@ -649,35 +649,35 @@ export function QuickConsultationSectionV2({
                 <ToggleGroupItem
                   value="none"
                   size="sm"
-                  className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-7 px-2.5 text-xs"
+                  className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-11 sm:h-7 px-2.5 text-xs"
                 >
                   Không
                 </ToggleGroupItem>
                 <ToggleGroupItem
                   value="30m"
                   size="sm"
-                  className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-7 px-2.5 text-xs"
+                  className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-11 sm:h-7 px-2.5 text-xs"
                 >
                   30p
                 </ToggleGroupItem>
                 <ToggleGroupItem
                   value="1h"
                   size="sm"
-                  className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-7 px-2.5 text-xs"
+                  className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-11 sm:h-7 px-2.5 text-xs"
                 >
                   1h
                 </ToggleGroupItem>
                 <ToggleGroupItem
                   value="tomorrow"
                   size="sm"
-                  className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-7 px-2.5 text-xs"
+                  className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-11 sm:h-7 px-2.5 text-xs"
                 >
                   Ngày mai
                 </ToggleGroupItem>
                 <ToggleGroupItem
                   value="custom"
                   size="sm"
-                  className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-7 px-2.5 text-xs"
+                  className="data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-11 sm:h-7 px-2.5 text-xs"
                 >
                   <CalendarClock className="mr-1 h-3 w-3" />
                   Tùy chọn
@@ -691,7 +691,7 @@ export function QuickConsultationSectionV2({
                     onChange={(date) => setCustomDateTime(date)}
                     placeholder="Chọn ngày giờ"
                     minDate={new Date()}
-                    className="h-8 text-xs"
+                    className="h-11 sm:h-8 text-xs"
                     open={isDatePickerOpen}
                     onOpenChange={setIsDatePickerOpen}
                     hideTrigger
@@ -739,7 +739,7 @@ export function QuickConsultationSectionV2({
                   key={status.id}
                   type="button"
                   className={cn(
-                    "flex items-center gap-1.5 rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-100",
+                    "flex items-center gap-1.5 rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-100 min-h-11 sm:min-h-0",
                     pendingStatus?.id === status.id &&
                       "ring-2 ring-primary ring-offset-1"
                   )}

--- a/frontend/src/components/leads/QuickConsultationSectionV2.tsx
+++ b/frontend/src/components/leads/QuickConsultationSectionV2.tsx
@@ -579,7 +579,7 @@ export function QuickConsultationSectionV2({
           onValueChange={(value) =>
             value && setMethod(value as ConsultationMethod)
           }
-          className="flex justify-start gap-1"
+          className="flex flex-wrap justify-start gap-1"
         >
           {methodOptions.map((opt) => {
             const Icon = opt.icon;

--- a/frontend/src/components/leads/QuickConsultationSectionV2.tsx
+++ b/frontend/src/components/leads/QuickConsultationSectionV2.tsx
@@ -557,7 +557,7 @@ export function QuickConsultationSectionV2({
             </span>
           </div>
           {lead.pipeline_stage && (
-            <Badge variant="outline" className="ml-auto text-[10px] font-normal">
+            <Badge variant="outline" className="ml-auto text-xs font-normal">
               {lead.pipeline_stage.name}
             </Badge>
           )}
@@ -721,7 +721,7 @@ export function QuickConsultationSectionV2({
             Bước 2: Kết quả tư vấn
           </Label>
           {!pendingStatus && (
-            <span className="text-[11px] text-amber-600">
+            <span className="text-xs text-amber-600">
               Chọn một kết quả bên dưới để lưu
             </span>
           )}
@@ -730,7 +730,7 @@ export function QuickConsultationSectionV2({
         {/* ── Không liên hệ được ── */}
         {groupedStatuses.universal.length > 0 && (
           <div className="space-y-1.5">
-            <Label className="text-muted-foreground text-[11px]">
+            <Label className="text-muted-foreground text-xs">
               Không liên hệ được
             </Label>
             <div className="flex flex-wrap gap-1.5">
@@ -762,7 +762,7 @@ export function QuickConsultationSectionV2({
         {/* ── Liên hệ được ── */}
         {groupedStatuses.sameStage.length > 0 && (
           <div className="space-y-1.5">
-            <Label className="text-muted-foreground text-[11px]">
+            <Label className="text-muted-foreground text-xs">
               Liên hệ được
             </Label>
             {renderStatusGrid(groupedStatuses.sameStage, "same")}
@@ -772,7 +772,7 @@ export function QuickConsultationSectionV2({
         {/* Next stage */}
         {groupedStatuses.nextStage.length > 0 && (
           <div className="space-y-1.5">
-            <Label className="text-muted-foreground text-[11px]">
+            <Label className="text-muted-foreground text-xs">
               Tiến tới →
             </Label>
             {renderStatusGrid(groupedStatuses.nextStage, "next")}

--- a/frontend/src/components/leads/QuickConsultationSectionV2.tsx
+++ b/frontend/src/components/leads/QuickConsultationSectionV2.tsx
@@ -627,7 +627,7 @@ export function QuickConsultationSectionV2({
               )}
             />
             {scheduleOption !== "none" && !scheduleOpen && (
-              <Badge variant="secondary" className="ml-1 h-4 px-1.5 text-[10px]">
+              <Badge variant="secondary" className="ml-1 h-4 px-1.5 text-xs">
                 {getSchedulePreviewText(scheduleOption, customDateTime)}
               </Badge>
             )}
@@ -784,7 +784,7 @@ export function QuickConsultationSectionV2({
           <div>
             <button
               type="button"
-              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors min-h-11 sm:min-h-0 py-2 sm:py-0"
               onClick={() => setShowPreviousStage((prev) => !prev)}
             >
               <ChevronDown
@@ -843,7 +843,7 @@ export function QuickConsultationSectionV2({
                   type="button"
                   variant="ghost"
                   size="sm"
-                  className="h-7 px-2 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                  className="h-11 sm:h-7 px-2 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
                   onClick={cancelPending}
                 >
                   Hoàn tác
@@ -852,7 +852,7 @@ export function QuickConsultationSectionV2({
                   type="button"
                   variant="default"
                   size="sm"
-                  className="h-7 px-3 text-xs"
+                  className="h-11 sm:h-7 px-3 text-xs"
                   onClick={() => commitSave(pendingStatus)}
                   disabled={addConsultation.isPending}
                   title="Ctrl+Enter để lưu nhanh"

--- a/frontend/src/components/leads/command-center/BulkActionsBar.tsx
+++ b/frontend/src/components/leads/command-center/BulkActionsBar.tsx
@@ -58,7 +58,8 @@ export function BulkActionsBar({
         "fixed bottom-6 left-1/2 z-50 -translate-x-1/2",
         "animate-in slide-in-from-bottom-4 fade-in-0 duration-200",
         "bg-background/95 supports-[backdrop-filter]:bg-background/80 backdrop-blur",
-        "flex items-center gap-3 rounded-lg border px-4 py-3 shadow-lg"
+        "flex flex-wrap items-center justify-center gap-3 rounded-lg border px-4 py-3 shadow-lg",
+        "max-w-[calc(100vw-1rem)]"
       )}
     >
       {/* Selection count */}
@@ -71,7 +72,7 @@ export function BulkActionsBar({
           variant="ghost"
           size="sm"
           onClick={onClearSelection}
-          className="h-6 w-6 p-0"
+          className="h-11 w-11 sm:h-6 sm:w-6 p-0"
           aria-label="Bỏ chọn tất cả"
         >
           <X className="h-4 w-4" />
@@ -87,7 +88,7 @@ export function BulkActionsBar({
           variant="ghost"
           size="sm"
           onClick={() => onBulkAssign(selectedLeads)}
-          className="h-8 gap-1.5"
+          className="h-11 sm:h-8 gap-1.5"
         >
           <UserPlus className="h-4 w-4" />
           Gán cán bộ
@@ -96,7 +97,7 @@ export function BulkActionsBar({
           variant="ghost"
           size="sm"
           onClick={() => onBulkChangeStage(selectedLeads)}
-          className="h-8 gap-1.5"
+          className="h-11 sm:h-8 gap-1.5"
         >
           <Layers className="h-4 w-4" />
           Đổi giai đoạn
@@ -105,7 +106,7 @@ export function BulkActionsBar({
           variant="ghost"
           size="sm"
           onClick={() => onBulkExport(selectedLeads)}
-          className="h-8 gap-1.5"
+          className="h-11 sm:h-8 gap-1.5"
         >
           <Download className="h-4 w-4" />
           Xuất
@@ -114,7 +115,7 @@ export function BulkActionsBar({
           variant="ghost"
           size="sm"
           onClick={() => onBulkDelete(selectedLeads)}
-          className="h-8 gap-1.5 text-error-600 hover:text-error-700"
+          className="h-11 sm:h-8 gap-1.5 text-error-600 hover:text-error-700"
         >
           <Trash2 className="h-4 w-4" />
           Xóa

--- a/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
@@ -235,7 +235,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
         {/* Row 3: Action Buttons - space between */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1.5">
-            <Button variant="outline" size="sm" className="h-7 px-2 text-xs" asChild>
+            <Button variant="outline" size="sm" className="h-11 sm:h-7 px-2 text-xs" asChild>
               <Link href={`/leads/${lead.id}`}>
                 <ExternalLink className="h-3.5 w-3.5 mr-1" />
                 Xem
@@ -244,7 +244,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
             <Button
               variant="outline"
               size="sm"
-              className="h-7 px-2 text-xs"
+              className="h-11 sm:h-7 px-2 text-xs"
               onClick={() => window.open(`tel:${lead.phone}`, "_blank")}
             >
               <Phone className="h-3.5 w-3.5 mr-1" />
@@ -253,7 +253,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
             <Button
               variant="outline"
               size="sm"
-              className="h-7 px-2 text-xs"
+              className="h-11 sm:h-7 px-2 text-xs"
               onClick={() => window.open(`https://zalo.me/${lead.phone?.replace(/\D/g, '')}`, "_blank")}
             >
               <span className="font-bold mr-1">Z</span>
@@ -267,7 +267,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
               <Button
                 variant="ghost"
                 size="sm"
-                className="h-7 w-7 p-0"
+                className="h-11 w-11 sm:h-7 sm:w-7 p-0"
                 onClick={() => setActionSheetOpen(true)}
                 aria-label="Mở menu thao tác"
               >
@@ -349,7 +349,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
           ) : (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="h-7 w-7 p-0" aria-label="Mở menu thao tác">
+                <Button variant="ghost" size="sm" className="h-11 w-11 sm:h-7 sm:w-7 p-0" aria-label="Mở menu thao tác">
                   <MoreVertical className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
@@ -468,7 +468,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
                     <Button
                       size="sm"
                       variant="outline"
-                      className="h-5 px-2 text-[10px] border-amber-300 text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300"
+                      className="h-11 sm:h-5 px-2 text-xs sm:text-[10px] border-amber-300 text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300"
                       onClick={() => window.open(`tel:${lead.phone}`, "_blank")}
                     >
                       Gọi ngay

--- a/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
+++ b/frontend/src/components/leads/command-center/LeadDetailPanel.tsx
@@ -196,7 +196,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
           {lead.assignment_status && (
             <Badge
               variant="outline"
-              className={cn("text-[10px] shrink-0", getAssignmentStatusColor(lead.assignment_status))}
+              className={cn("text-xs shrink-0", getAssignmentStatusColor(lead.assignment_status))}
             >
               {getAssignmentStatusLabel(lead.assignment_status)}
             </Badge>
@@ -212,7 +212,7 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
             return (
               <Badge
                 variant="outline"
-                className={cn("border-0 font-medium text-[10px]", stageColor && "text-white")}
+                className={cn("border-0 font-medium text-xs", stageColor && "text-white")}
                 style={{ backgroundColor: stageColor || undefined }}
               >
                 {lead.pipeline_stage.name}
@@ -409,12 +409,12 @@ export function LeadDetailPanel({ leadId, onEdit, onDelete, onAssign }: LeadDeta
                 <User className="h-4 w-4 text-primary shrink-0" />
                 <span>Thông tin</span>
                 {lead.is_hot_lead && (
-                  <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-5 bg-orange-50 text-orange-600 border-orange-200 dark:bg-orange-950/50 dark:text-orange-400 dark:border-orange-800">
+                  <Badge variant="outline" className="text-xs px-1.5 py-0 h-5 bg-orange-50 text-orange-600 border-orange-200 dark:bg-orange-950/50 dark:text-orange-400 dark:border-orange-800">
                     🔥 Hot
                   </Badge>
                 )}
                 {lead.is_overdue && (
-                  <Badge variant="destructive" className="text-[10px] px-1.5 py-0 h-5">
+                  <Badge variant="destructive" className="text-xs px-1.5 py-0 h-5">
                     Quá hạn
                   </Badge>
                 )}

--- a/frontend/src/components/leads/command-center/LeadFilterBar.tsx
+++ b/frontend/src/components/leads/command-center/LeadFilterBar.tsx
@@ -113,7 +113,7 @@ function FilterDropdown({ label, count, children }: FilterDropdownProps) {
           variant="outline"
           size="sm"
           className={cn(
-            "h-9 md:h-8 gap-1 transition-colors duration-200",
+            "h-11 md:h-8 gap-1 transition-colors duration-200",
             count > 0 && "border-primary bg-primary/5"
           )}
         >
@@ -609,7 +609,7 @@ export function LeadFilterBar({
                   placeholder="Tìm cán bộ…"
                   value={officerSearch}
                   onChange={(e) => handleOfficerSearchChange(e.target.value)}
-                  className="h-7 text-xs"
+                  className="h-11 text-base sm:h-7 sm:text-xs"
                 />
                 <div className="max-h-48 space-y-2 overflow-y-auto">
                   {officers.map((officer) => (
@@ -892,7 +892,7 @@ export function LeadFilterBar({
                     placeholder="Tìm cán bộ…"
                     value={officerSearch}
                     onChange={(e) => handleOfficerSearchChange(e.target.value)}
-                    className="h-7 text-xs"
+                    className="h-11 text-base sm:h-7 sm:text-xs"
                   />
                   <div className="max-h-48 space-y-2 overflow-y-auto">
                     {officers.map((officer) => (
@@ -993,7 +993,7 @@ export function LeadFilterBar({
             {!isFiltersExpanded && hiddenCount > 0 && (
               <Badge
                 variant="outline"
-                className="h-6 cursor-pointer gap-1 px-2 text-xs transition-colors hover:bg-primary/10"
+                className="h-9 sm:h-6 cursor-pointer gap-1 px-2 text-xs transition-colors hover:bg-primary/10"
                 onClick={() => setIsFiltersExpanded(true)}
               >
                 +{hiddenCount} more
@@ -1005,7 +1005,7 @@ export function LeadFilterBar({
             {isFiltersExpanded && allPills.length > MAX_VISIBLE_PILLS && (
               <Badge
                 variant="outline"
-                className="h-6 cursor-pointer gap-1 px-2 text-xs transition-colors hover:bg-primary/10"
+                className="h-9 sm:h-6 cursor-pointer gap-1 px-2 text-xs transition-colors hover:bg-primary/10"
                 onClick={() => setIsFiltersExpanded(false)}
               >
                 Thu gọn

--- a/frontend/src/components/leads/command-center/LeadFilterBar.tsx
+++ b/frontend/src/components/leads/command-center/LeadFilterBar.tsx
@@ -410,7 +410,7 @@ export function LeadFilterBar({
             placeholder="Tìm kiếm..."
             value={localSearch}
             onChange={(e) => handleSearchInputChange(e.target.value)}
-            className="h-9 pl-9 pr-8 text-sm md:h-8"
+            className="h-11 pl-9 pr-8 text-base sm:text-sm md:h-8"
           />
           {localSearch && (
             <button
@@ -419,7 +419,7 @@ export function LeadFilterBar({
                 if (debounceRef.current) clearTimeout(debounceRef.current);
                 onSearchChange("");
               }}
-              className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+              className="text-muted-foreground hover:text-foreground absolute top-1/2 right-1 -translate-y-1/2 flex h-9 w-9 items-center justify-center sm:h-auto sm:w-auto sm:right-2"
               aria-label="Xóa tìm kiếm"
             >
               <X className="h-4 w-4" />
@@ -431,7 +431,7 @@ export function LeadFilterBar({
         <Button
           variant="outline"
           size="sm"
-          className="h-9 gap-1.5 md:hidden"
+          className="h-11 gap-1.5 md:hidden"
           onClick={() => setMobileFiltersOpen(!mobileFiltersOpen)}
         >
           <ChevronDown className={cn("h-4 w-4 transition-transform", mobileFiltersOpen && "rotate-180")} />
@@ -444,7 +444,7 @@ export function LeadFilterBar({
         </Button>
 
         {/* Mobile: Add Lead button */}
-        <Button size="sm" onClick={onAddLead} className="h-9 gap-1.5 md:hidden">
+        <Button size="sm" onClick={onAddLead} className="h-11 gap-1.5 md:hidden">
           <Plus className="h-4 w-4" />
           <span className="sr-only sm:not-sr-only">Thêm</span>
         </Button>
@@ -782,7 +782,7 @@ export function LeadFilterBar({
                     variant="outline"
                     size="sm"
                     className={cn(
-                      "h-9 gap-1",
+                      "h-11 md:h-8 gap-1",
                       unitId && "border-primary bg-primary/5"
                     )}
                   >
@@ -928,7 +928,7 @@ export function LeadFilterBar({
                 variant="ghost"
                 size="sm"
                 onClick={() => { onReset(); setMobileFiltersOpen(false); }}
-                className="h-9 text-xs"
+                className="h-11 text-xs"
               >
                 <RotateCcw className="mr-1 h-3.5 w-3.5" />
                 Đặt lại

--- a/frontend/src/components/leads/command-center/LeadsTable.tsx
+++ b/frontend/src/components/leads/command-center/LeadsTable.tsx
@@ -810,7 +810,7 @@ export function LeadsTable({
               size="sm"
               onClick={() => onPageChange?.(page - 1)}
               disabled={page <= 1}
-              className="h-8 w-8 p-0"
+              className="h-11 w-11 md:h-8 md:w-8 p-0"
             >
               <ChevronLeft className="h-4 w-4" />
             </Button>
@@ -822,7 +822,7 @@ export function LeadsTable({
               size="sm"
               onClick={() => onPageChange?.(page + 1)}
               disabled={page >= totalPages}
-              className="h-8 w-8 p-0"
+              className="h-11 w-11 md:h-8 md:w-8 p-0"
             >
               <ChevronRight className="h-4 w-4" />
             </Button>

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -133,8 +133,9 @@ export function MobileLeadCard({
         <Button
           variant="ghost"
           size="icon"
-          className="h-10 w-10"
+          className="h-11 w-11"
           onClick={() => setActionSheetOpen(true)}
+          aria-label="Mở menu hành động"
         >
           <MoreVertical className="h-4 w-4" />
         </Button>

--- a/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
+++ b/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
@@ -29,6 +29,17 @@ const offering = read("../common/selectors/SmartOfferingSelector.tsx");
 const unit = read("../common/selectors/SmartUnitSelector.tsx");
 const sheet = read("../ui/sheet.tsx");
 
+// Round 2 — lead-list + direct-detail audit (#7-#9)
+const leadsClient = read("../../app/(dashboard)/leads/_components/LeadsClient.tsx");
+const insightsDrawer = read("./InsightsHelperDrawer.tsx");
+const statusSelector = read("../common/selectors/SmartConsultationStatusSelector.tsx");
+const bulkBar = read("./command-center/BulkActionsBar.tsx");
+const filterBar = read("./command-center/LeadFilterBar.tsx");
+const mobileCard = read("./command-center/MobileLeadCard.tsx");
+const detailClient = read("../../app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx");
+const infoTabs = read("../../app/(dashboard)/leads/[id]/_components/LeadInfoTabs.tsx");
+const sidebar = read("../../app/(dashboard)/leads/[id]/_components/LeadSidebar.tsx");
+
 describe("Bug #2 — consultation method toggle wraps on mobile", () => {
   it("method ToggleGroup uses flex-wrap (no horizontal overflow @375px)", () => {
     // The method selector row must wrap; pre-fix it was `flex justify-start
@@ -74,5 +85,62 @@ describe("Touch targets — 44px on mobile, compact on desktop", () => {
     expect(v2).toMatch(/h-11 sm:h-8/);     // method chips
     expect(v2).toMatch(/h-11 sm:h-7/);     // outcome chips
     expect(v2).toMatch(/min-h-11 sm:min-h-0/); // status pills / disclosure
+  });
+});
+
+describe("Round 2 #7 — drawer / popover width overflow @375px", () => {
+  it("LeadsClient mobile detail Sheet uses viewport-relative width", () => {
+    expect(leadsClient).toMatch(/w-\[calc\(100vw-1rem\)\] sm:w-\[400px\]/);
+    expect(leadsClient).not.toMatch(/w-\[85vw\] sm:w-\[400px\]/); // old 318px clip
+  });
+
+  it("InsightsHelperDrawer base width no longer fixed 420px", () => {
+    expect(insightsDrawer).toMatch(/w-\[calc\(100vw-1rem\)\] sm:w-\[520px\]/);
+    expect(insightsDrawer).not.toMatch(/w-\[420px\] sm:w-\[520px\]/);
+  });
+
+  it("SmartConsultationStatusSelector: responsive width + touch-scroll shim", () => {
+    // parity with Offering/Unit — defeats Dialog react-remove-scroll touch-lock
+    expect(statusSelector).toMatch(/w-\[calc\(100vw-2rem\)\][^"]*sm:w-\[350px\]/);
+    expect(statusSelector).not.toMatch(/className="w-\[350px\] p-0"/);
+    expect(statusSelector).toMatch(/onTouchMove=\{\(e\)\s*=>\s*e\.stopPropagation\(\)\}/);
+    expect(statusSelector).toContain("overscroll-contain");
+  });
+});
+
+describe("Round 2 #8 — command-center touch targets + bulk-bar overflow", () => {
+  it("BulkActionsBar wraps + caps width + 44px targets", () => {
+    expect(bulkBar).toContain("flex-wrap");
+    expect(bulkBar).toMatch(/max-w-\[calc\(100vw-1rem\)\]/);
+    expect(bulkBar).toMatch(/h-11 sm:h-8/);             // 4 action buttons
+    expect(bulkBar).toMatch(/h-11 w-11 sm:h-6 sm:w-6/); // clear button
+  });
+
+  it("LeadFilterBar bumps trigger + officer inputs + collapse pills", () => {
+    expect(filterBar).toMatch(/h-11 md:h-8/);                      // filter trigger
+    expect(filterBar).toMatch(/h-11 text-base sm:h-7 sm:text-xs/); // officer search (text-base = no iOS zoom)
+    expect(filterBar).toMatch(/h-9 sm:h-6 cursor-pointer/);        // +X-more / Thu-gon
+    expect(filterBar).not.toMatch(/"h-9 md:h-8 gap-1/);            // old trigger gone
+  });
+
+  it("MobileLeadCard action button 44px + labelled", () => {
+    expect(mobileCard).toMatch(/h-11 w-11/);
+    expect(mobileCard).toMatch(/aria-label="Mở menu hành động"/);
+    expect(mobileCard).not.toMatch(/className="h-10 w-10"/);
+  });
+});
+
+describe("Round 2 #9 — direct /leads/[id] detail", () => {
+  it("LeadDetailClient copy-phone is 44px on mobile", () => {
+    expect(detailClient).toMatch(/h-11 w-11 sm:h-6 sm:w-6/);
+  });
+
+  it("LeadInfoTabs assign button 44px on mobile", () => {
+    expect(infoTabs).toMatch(/h-11 sm:h-7 text-xs/);
+  });
+
+  it("LeadSidebar call button 44px + stats off micro-px token", () => {
+    expect(sidebar).toMatch(/h-11 sm:h-6 px-2 text-xs/);
+    expect(sidebar).not.toMatch(/text-\[10px\]/); // normalized to text-xs token
   });
 });

--- a/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
+++ b/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
@@ -40,6 +40,14 @@ const detailClient = read("../../app/(dashboard)/leads/[id]/_components/LeadDeta
 const infoTabs = read("../../app/(dashboard)/leads/[id]/_components/LeadInfoTabs.tsx");
 const sidebar = read("../../app/(dashboard)/leads/[id]/_components/LeadSidebar.tsx");
 
+// Round 3 — broader /leads mobile sweep (#10-#12)
+const leadsTable = read("./command-center/LeadsTable.tsx");
+const kanbanCard = read("./LeadKanbanCard.tsx");
+const multiOffering = read("../common/selectors/MultiOfferingSelector.tsx");
+const readinessChecklist = read("./AdmissionReadinessChecklist.tsx");
+const timelineTab = read("./LeadTimelineTab.tsx");
+const scoringCollapsible = read("./LeadScoringCollapsible.tsx");
+
 describe("Bug #2 — consultation method toggle wraps on mobile", () => {
   it("method ToggleGroup uses flex-wrap (no horizontal overflow @375px)", () => {
     // The method selector row must wrap; pre-fix it was `flex justify-start
@@ -142,5 +150,48 @@ describe("Round 2 #9 — direct /leads/[id] detail", () => {
   it("LeadSidebar call button 44px + stats off micro-px token", () => {
     expect(sidebar).toMatch(/h-11 sm:h-6 px-2 text-xs/);
     expect(sidebar).not.toMatch(/text-\[10px\]/); // normalized to text-xs token
+  });
+});
+
+describe("Round 3 #10 — /leads list + pipeline touch targets", () => {
+  it("LeadsTable mobile pagination prev/next are 44px on mobile", () => {
+    const hits = leadsTable.match(/h-11 w-11 md:h-8 md:w-8/g) ?? [];
+    expect(hits.length).toBeGreaterThanOrEqual(2); // prev + next
+  });
+
+  it("LeadKanbanCard detail button is 44px on mobile", () => {
+    expect(kanbanCard).toMatch(/h-11 w-11 sm:h-6 sm:w-6/);
+  });
+});
+
+describe("Round 3 #11 — filter bar + multi-offering selector mobile controls", () => {
+  it("LeadFilterBar mobile controls bump to 44px (compact on md+)", () => {
+    expect(filterBar).toMatch(/h-11 pl-9 pr-8 text-base sm:text-sm md:h-8/); // search
+    expect(filterBar).toMatch(/h-11 gap-1\.5 md:hidden/);                    // filter toggle / add-lead
+    expect(filterBar).toMatch(/h-11 md:h-8 gap-1/);                          // unit trigger
+  });
+
+  it("MultiOfferingSelector mobile search + header + badges", () => {
+    expect(multiOffering).toMatch(/h-11 sm:h-8 pl-8 pr-8 text-base sm:text-sm/);
+    expect(multiOffering).toMatch(/min-h-11 sm:min-h-0/);   // group header tap area
+    expect(multiOffering).not.toMatch(/text-\[10px\]/);     // badges normalized
+  });
+});
+
+describe("Round 3 #12 — lead-detail readiness CTA + timeline menu + scoring", () => {
+  it("AdmissionReadinessChecklist both CTAs 44px on mobile", () => {
+    const hits = readinessChecklist.match(/h-11 sm:h-7 text-xs/g) ?? [];
+    expect(hits.length).toBeGreaterThanOrEqual(2); // Tạo hồ sơ + Xem hồ sơ
+  });
+
+  it("LeadTimelineTab action menu visible on touch + 44px", () => {
+    // was opacity-0 hover-only (undiscoverable on touch) + sub-44px
+    expect(timelineTab).toMatch(/opacity-100 sm:opacity-0 sm:group-hover:opacity-100/);
+    expect(timelineTab).toMatch(/h-11 w-11 sm:h-7 sm:w-7/);
+    expect(timelineTab).not.toMatch(/h-7 w-7 p-0 opacity-0 group-hover/); // old hover-only chip gone
+  });
+
+  it("LeadScoringCollapsible off micro-px token", () => {
+    expect(scoringCollapsible).not.toMatch(/text-\[10px\]/);
   });
 });

--- a/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
+++ b/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Mobile responsive anchors — lead detail + intake selectors.
+ *
+ * Source-contract tests (no DOM render): they read the component source
+ * and assert the responsive class patterns that the 2026-05-24 mobile
+ * audit fixes introduced. Render-based tests for these components need
+ * the full React Query + hooks provider tree and would mostly assert
+ * the mocks; a source contract is the cheapest durable guard against a
+ * refactor silently reintroducing the bugs verified in-browser @375px.
+ *
+ * Covers:
+ *  - Bug #2: consultation method ToggleGroup wraps (flex-wrap).
+ *  - Bug #1: offering/unit combobox scroll containers stop touchmove
+ *    propagation (defeats Radix Dialog react-remove-scroll touch-lock)
+ *    + use responsive width instead of a fixed px that overflows mobile.
+ *  - Touch targets: Sheet close button is a 44px hit area; lead-detail
+ *    chips/buttons use `h-11 sm:*` (mobile 44, desktop compact).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string) => readFileSync(resolve(__dirname, rel), "utf-8");
+
+const v2 = read("./QuickConsultationSectionV2.tsx");
+const offering = read("../common/selectors/SmartOfferingSelector.tsx");
+const unit = read("../common/selectors/SmartUnitSelector.tsx");
+const sheet = read("../ui/sheet.tsx");
+
+describe("Bug #2 — consultation method toggle wraps on mobile", () => {
+  it("method ToggleGroup uses flex-wrap (no horizontal overflow @375px)", () => {
+    // The method selector row must wrap; pre-fix it was `flex justify-start
+    // gap-1` (no wrap) and the "Gặp mặt" chip overflowed the 319px drawer.
+    expect(v2).toMatch(/value=\{method\}[\s\S]{0,200}?className="flex flex-wrap justify-start gap-1"/);
+  });
+
+  it("sibling toggle rows also wrap (consistency guard)", () => {
+    const wrapCount = (v2.match(/flex flex-wrap (?:justify-start )?gap-1(?:\.5)?/g) ?? []).length;
+    expect(wrapCount).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("Bug #1 — combobox selectors scroll on touch inside a Dialog", () => {
+  it("SmartOfferingSelector scroll container stops touchmove propagation", () => {
+    // Defeats the Dialog's react-remove-scroll bubble-phase document
+    // touchmove listener so native scroll works on mobile.
+    expect(offering).toMatch(/onTouchMove=\{\(e\)\s*=>\s*e\.stopPropagation\(\)\}/);
+    expect(offering).toContain("overscroll-contain");
+  });
+
+  it("SmartOfferingSelector popover width is responsive (no 420px overflow @375px)", () => {
+    expect(offering).toMatch(/w-\[calc\(100vw-2rem\)\][^"]*sm:w-\[420px\]/);
+    // the old hardcoded fixed width must be gone
+    expect(offering).not.toMatch(/className="w-\[420px\] p-0"/);
+  });
+
+  it("SmartUnitSelector has the same touch-scroll shim + responsive width", () => {
+    expect(unit).toMatch(/onTouchMove=\{\(e\)\s*=>\s*e\.stopPropagation\(\)\}/);
+    expect(unit).toMatch(/w-\[calc\(100vw-2rem\)\][^"]*sm:w-\[400px\]/);
+    expect(unit).not.toMatch(/className="w-\[400px\] p-0"/);
+  });
+});
+
+describe("Touch targets — 44px on mobile, compact on desktop", () => {
+  it("Sheet close button is a 44px hit area (shared primitive)", () => {
+    // X icon stays 16px but the SheetPrimitive.Close hit area is 44px.
+    expect(sheet).toMatch(/SheetPrimitive\.Close[\s\S]{0,160}?h-11 w-11/);
+  });
+
+  it("lead-detail chips/buttons bump to 44px on mobile via h-11 sm:*", () => {
+    // method chip, outcome chips, quick-action buttons all gated h-11 sm:*
+    expect(v2).toMatch(/h-11 sm:h-8/);     // method chips
+    expect(v2).toMatch(/h-11 sm:h-7/);     // outcome chips
+    expect(v2).toMatch(/min-h-11 sm:min-h-0/); // status pills / disclosure
+  });
+});

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -64,7 +64,11 @@ const SheetContent = React.forwardRef<
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      {/* 44px touch target (Apple HIG) — the icon stays 16px but the hit
+          area is padded out so it's tappable on mobile. inline-flex
+          centers the icon; -m-2 keeps the visual position aligned with
+          the original right-4/top-4 inset. */}
+      <SheetPrimitive.Close className="absolute right-4 top-4 -m-2 inline-flex h-11 w-11 items-center justify-center rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" aria-hidden="true" />
         <span className="sr-only">Đóng</span>
       </SheetPrimitive.Close>


### PR DESCRIPTION
## Summary

Mobile responsive sweep cho toàn bộ lead surfaces @375px (iPhone SE), gom 12 finding vào 1 PR (14 commit). Khởi đầu từ 2 bug user-reported, mở rộng qua smoke toàn bộ lead detail + command-center + direct `/leads/[id]`.

### Bugs gốc
1. **SmartOfferingSelector không cuộn được trên mobile trong Dialog** — Radix Dialog `react-remove-scroll` gắn document `touchmove` listener bubble-phase chặn scroll trên Popover portaled ra body. Fix: `onTouchMove stopPropagation` + `overscroll-contain` trên scroll container → native scroll hoạt động. Áp dụng cho cả SmartUnitSelector + SmartConsultationStatusSelector (parity).
2. **Method toggle row tràn ngang** — thêm `flex-wrap`.

### Touch targets → 44px mobile (compact `sm:`/`md:` desktop)
- **Lead detail**: method/outcome chips, status pill, quick actions (Gọi/Zalo), DateTimePicker, disclosure, Hoàn tác/Lưu ngay, Sheet close (global `ui/sheet.tsx`)
- **Command-center**: BulkActionsBar (flex-wrap + max-w + 44px), LeadFilterBar (search/Lọc/Thêm/unit/officer/reset/pills), MobileLeadCard action btn + aria-label, LeadsTable pagination, MultiOfferingSelector
- **Direct `/leads/[id]`**: copy-phone, assign, call button, AdmissionReadinessChecklist CTA, LeadKanbanCard detail btn
- **LeadTimelineTab**: action menu hover-only → visible on touch (`opacity-100 sm:opacity-0 sm:group-hover:opacity-100`)

### Drawer/popover width
- Detail Sheet `w-[85vw]`(318px)→`w-[calc(100vw-1rem)]`(359px); InsightsHelperDrawer `w-[420px]`→responsive; selectors responsive width

### Typography
- Normalize off-token `text-[10px]`/`text-[11px]` → `text-xs` design token (LeadSidebar, LeadScoringCollapsible, MultiOfferingSelector, LeadDetailPanel)

### Out of scope (deferred)
- `/leads` mobile shell horizontal overflow: `DashboardLayout.tsx:194` content wrapper thiếu `min-w-0` → clip Lọc/Thêm + stats @375px. **Shared app-shell, ảnh hưởng mọi route dashboard** → tách PR riêng (cần cross-route verify). Lead-module content đã handle width đúng.
- 5-star rating row + broader `text-[10px]` (bottom-nav, badges) defer.

## Test plan
- [x] type-check: 0 lỗi
- [x] vitest anchor `mobile-lead-detail-responsive.test.ts`: **23/23** (source-contract, non-tautological: assert pattern mới + pattern cũ biến mất)
- [x] Browser smoke @375px (Chrome MCP, worktree): filter controls 44px + no page h-scroll · MultiOfferingSelector popover scroll/fit · pagination 44px · detail sheet 359px + 0 overflow nội bộ · consultation sheet touch targets 44px + method wrap · direct detail copy-phone/readiness CTA 44px
- [ ] Static-only (low-risk, cần lead có lịch sử tư vấn / form khác): timeline menu, ConsultationStatusSelector combobox, BulkActionsBar wrap, kanban detail btn

🤖 Generated with [Claude Code](https://claude.com/claude-code)