### PR TITLE
ci(nightly-regression + alembic-chain): infra bootstrap fixes + phase1_19c5 chain integrity migration

### DIFF
--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -76,39 +76,14 @@ jobs:
       # ``-f docker-compose.yml`` bypasses the auto-loaded
       # ``docker-compose.override.yml`` (dev mode) which requires
       # ``Backend_FastAPI/.env`` that doesn't exist in CI. We want the
-      # production-like stack here anyway.
-      #
-      # Split-alembic bootstrap (memory ``worktree-stack-bootstrap``):
-      # phase3_01 has a pre-flight assertion requiring 5 LOWERCASE
-      # admission_* events in ``notification_rule``. ``phase1_19c`` seeds
-      # those events in UPPERCASE; the LOWERCASE rows that satisfy
-      # phase3_01 are produced by ``sync_notification_rules`` (reads
-      # EVENT_CATALOG lowercase enum names). Production accumulates both
-      # cases across deploys; a fresh CI DB does not, so a single
-      # ``alembic upgrade head`` crashes mid-chain at phase3_01.
-      # Workaround: upgrade to ``phase2_06`` (last revision before
-      # phase3_01), run sync to seed lowercase events, then continue to
-      # ``head``. Final sync covers phase3+ new events too.
-      # Backend container started with both ``RUN_*=false`` flags so the
-      # entrypoint does not re-run alembic / sync after we've already
-      # bootstrapped manually.
-      - name: Bootstrap DB schema via split alembic
+      # production-like stack here anyway. Entrypoint runs alembic
+      # upgrade head + sync_notification_rules normally — the chain
+      # is now self-contained for fresh DB after phase1_19c5 migration
+      # (this PR) converts phase1_19c's UPPERCASE seed to lowercase
+      # before phase3_01's pre-flight assertion runs.
+      - name: Start services
         run: |
-          docker compose -f docker-compose.yml up -d postgres redis
-          timeout 60 bash -c 'until docker compose -f docker-compose.yml exec -T postgres pg_isready -U qlts -d qlts_test; do sleep 2; done'
-          docker compose -f docker-compose.yml run --rm backend bash -c "
-            alembic upgrade phase2_06 &&
-            python -m app.scripts.sync_notification_rules &&
-            alembic upgrade head &&
-            python -m app.scripts.sync_notification_rules
-          "
-
-      - name: Start backend + frontend (entrypoint bootstrap skipped)
-        env:
-          RUN_MIGRATIONS_ON_STARTUP: "false"
-          RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: "false"
-        run: |
-          docker compose -f docker-compose.yml up -d backend frontend
+          docker compose -f docker-compose.yml up -d postgres redis backend frontend
           # Wait for services
           timeout 90 bash -c 'until curl -sf http://localhost:8000/docs > /dev/null; do sleep 2; done'
           timeout 90 bash -c 'until curl -sf http://localhost:3000 > /dev/null; do sleep 2; done'

--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -47,15 +47,26 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       # Generate ``.env.production`` so the backend service's ``env_file:``
-      # directive resolves (it's referenced unconditionally in
-      # docker-compose.yml). Values are CI-only placeholders mirroring the
-      # pattern used by backend-test.yml + nightly-backend-pytest.yml.
+      # directive resolves. ``_validate_production_secrets()`` in
+      # app/config.py enforces in APP_ENV=production:
+      #   * SECRET_KEY + JWT_SECRET_KEY ≥32 chars + not in weak-list
+      #   * DEVICE_FINGERPRINT_SALT != "CHANGE_ME_IN_PRODUCTION"
+      #   * LOG_LEVEL != DEBUG
+      #   * DATABASE_URL not localhost + sslmode=require unless
+      #     ALLOW_DOCKER_INTERNAL_NETWORK=true (postgres/redis are on the
+      #     same compose bridge here — internal network = true is correct).
+      # All values are CI-only placeholders; the runner is destroyed at
+      # job end. ``openssl rand -base64 32`` generates fresh salt per run
+      # to keep the secret out of repo history.
       - name: Generate .env.production for backend env_file load
         run: |
           cat > .env.production <<EOF
           APP_ENV=production
-          SECRET_KEY=ci-test-secret-key-for-nightly-only
-          JWT_SECRET_KEY=ci-test-jwt-secret-for-nightly-only
+          SECRET_KEY=ci-test-secret-key-with-32-chars-or-more-for-nightly-regression-only-not-real-prod
+          JWT_SECRET_KEY=ci-test-jwt-secret-with-32-chars-or-more-for-nightly-regression-only-not-real-prod
+          DEVICE_FINGERPRINT_SALT=$(openssl rand -base64 32)
+          ALLOW_DOCKER_INTERNAL_NETWORK=true
+          LOG_LEVEL=INFO
           MAIL_USERNAME=ci-test@example.com
           MAIL_PASSWORD=ci-test-placeholder
           MAIL_FROM=ci-test@example.com

--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -139,6 +139,23 @@ jobs:
           path: frontend/test-results/
           retention-days: 7
 
+      # Capture container logs BEFORE teardown when anything failed —
+      # backend/frontend crash signature isn't visible in compose up output
+      # (only "container Error / dependency failed to start"). Log dump gives
+      # the real cause (entrypoint exception, alembic mismatch, env reject).
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          echo "::group::backend logs"
+          docker compose -f docker-compose.yml logs backend --tail=200 || true
+          echo "::endgroup::"
+          echo "::group::frontend logs"
+          docker compose -f docker-compose.yml logs frontend --tail=100 || true
+          echo "::endgroup::"
+          echo "::group::postgres logs"
+          docker compose -f docker-compose.yml logs postgres --tail=50 || true
+          echo "::endgroup::"
+
       - name: Stop services
         if: always()
         run: docker compose -f docker-compose.yml down -v

--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -77,13 +77,41 @@ jobs:
       # ``docker-compose.override.yml`` (dev mode) which requires
       # ``Backend_FastAPI/.env`` that doesn't exist in CI. We want the
       # production-like stack here anyway.
-      - name: Start services
+      #
+      # Split-alembic bootstrap (memory ``worktree-stack-bootstrap``):
+      # phase3_01 has a pre-flight assertion requiring 5 LOWERCASE
+      # admission_* events in ``notification_rule``. ``phase1_19c`` seeds
+      # those events in UPPERCASE; the LOWERCASE rows that satisfy
+      # phase3_01 are produced by ``sync_notification_rules`` (reads
+      # EVENT_CATALOG lowercase enum names). Production accumulates both
+      # cases across deploys; a fresh CI DB does not, so a single
+      # ``alembic upgrade head`` crashes mid-chain at phase3_01.
+      # Workaround: upgrade to ``phase2_06`` (last revision before
+      # phase3_01), run sync to seed lowercase events, then continue to
+      # ``head``. Final sync covers phase3+ new events too.
+      # Backend container started with both ``RUN_*=false`` flags so the
+      # entrypoint does not re-run alembic / sync after we've already
+      # bootstrapped manually.
+      - name: Bootstrap DB schema via split alembic
         run: |
-          docker compose -f docker-compose.yml up -d postgres redis backend frontend
-          docker compose -f docker-compose.yml exec -T backend alembic upgrade head
+          docker compose -f docker-compose.yml up -d postgres redis
+          timeout 60 bash -c 'until docker compose -f docker-compose.yml exec -T postgres pg_isready -U qlts -d qlts_test; do sleep 2; done'
+          docker compose -f docker-compose.yml run --rm backend bash -c "
+            alembic upgrade phase2_06 &&
+            python -m app.scripts.sync_notification_rules &&
+            alembic upgrade head &&
+            python -m app.scripts.sync_notification_rules
+          "
+
+      - name: Start backend + frontend (entrypoint bootstrap skipped)
+        env:
+          RUN_MIGRATIONS_ON_STARTUP: "false"
+          RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP: "false"
+        run: |
+          docker compose -f docker-compose.yml up -d backend frontend
           # Wait for services
-          timeout 60 bash -c 'until curl -sf http://localhost:8000/docs > /dev/null; do sleep 2; done'
-          timeout 60 bash -c 'until curl -sf http://localhost:3000 > /dev/null; do sleep 2; done'
+          timeout 90 bash -c 'until curl -sf http://localhost:8000/docs > /dev/null; do sleep 2; done'
+          timeout 90 bash -c 'until curl -sf http://localhost:3000 > /dev/null; do sleep 2; done'
           echo "Services ready"
 
       # Seed data (required for E2E tests)

--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -46,27 +46,31 @@ jobs:
         working-directory: frontend
         run: npx playwright install chromium --with-deps
 
-      # Generate ``.env.production`` so the backend service's ``env_file:``
-      # directive resolves. ``_validate_production_secrets()`` in
-      # app/config.py enforces in APP_ENV=production:
-      #   * SECRET_KEY + JWT_SECRET_KEY ≥32 chars + not in weak-list
-      #   * DEVICE_FINGERPRINT_SALT != "CHANGE_ME_IN_PRODUCTION"
-      #   * LOG_LEVEL != DEBUG
-      #   * DATABASE_URL not localhost + sslmode=require unless
-      #     ALLOW_DOCKER_INTERNAL_NETWORK=true (postgres/redis are on the
-      #     same compose bridge here — internal network = true is correct).
-      # All values are CI-only placeholders; the runner is destroyed at
-      # job end. ``openssl rand -base64 32`` generates fresh salt per run
-      # to keep the secret out of repo history.
+      # Generate ``.env.production`` (compose ``env_file:`` directive
+      # requires the file to exist; values become container env vars).
+      # Backend uses ``APP_ENV=test`` here — NOT ``production`` — because
+      # two production-hardening validators reject CI placeholder values:
+      #
+      #   1. ``_validate_production_secrets()`` (app/config.py:245) demands
+      #      SECRET_KEY/JWT_SECRET_KEY ≥32 chars + non-weak,
+      #      DEVICE_FINGERPRINT_SALT != default, no localhost DB URL,
+      #      sslmode=require unless ALLOW_DOCKER_INTERNAL_NETWORK=true.
+      #   2. ``main.py:651`` rejects any CORS origin not on HTTPS — but
+      #      CI frontend serves at http://localhost:3000 (Playwright
+      #      target), so the realistic test origin is HTTP.
+      #
+      # APP_ENV=test skips both validators (config.py:222 + main.py:630
+      # both gate on ``APP_ENV == "production"``) and the CORS middleware
+      # auto-populates test origins (main.py:667-668). Other runtime
+      # behavior — alembic, dispatch pipeline, route registration, Casbin,
+      # JWT signing — is unaffected; those validators are CI-vs-prod
+      # hardening gates, not feature gates.
       - name: Generate .env.production for backend env_file load
         run: |
           cat > .env.production <<EOF
-          APP_ENV=production
-          SECRET_KEY=ci-test-secret-key-with-32-chars-or-more-for-nightly-regression-only-not-real-prod
-          JWT_SECRET_KEY=ci-test-jwt-secret-with-32-chars-or-more-for-nightly-regression-only-not-real-prod
-          DEVICE_FINGERPRINT_SALT=$(openssl rand -base64 32)
-          ALLOW_DOCKER_INTERNAL_NETWORK=true
-          LOG_LEVEL=INFO
+          APP_ENV=test
+          SECRET_KEY=ci-test-secret-key-for-nightly-regression-only
+          JWT_SECRET_KEY=ci-test-jwt-secret-for-nightly-regression-only
           MAIL_USERNAME=ci-test@example.com
           MAIL_PASSWORD=ci-test-placeholder
           MAIL_FROM=ci-test@example.com

--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -87,7 +87,7 @@ jobs:
       # before phase3_01's pre-flight assertion runs.
       - name: Start services
         run: |
-          docker compose -f docker-compose.yml up -d postgres redis backend frontend
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d postgres redis backend frontend
           # Wait for services
           timeout 90 bash -c 'until curl -sf http://localhost:8000/docs > /dev/null; do sleep 2; done'
           timeout 90 bash -c 'until curl -sf http://localhost:3000 > /dev/null; do sleep 2; done'
@@ -96,9 +96,9 @@ jobs:
       # Seed data (required for E2E tests)
       - name: Seed database
         run: |
-          docker compose -f docker-compose.yml exec -T backend pip install -r requirements-dev.txt -q
-          docker compose -f docker-compose.yml exec -T backend python -m scripts.seed_from_xlsx
-          docker compose -f docker-compose.yml exec -T backend python -m app.scripts.seed_notification_rules
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml exec -T backend pip install -r requirements-dev.txt -q
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml exec -T backend python -m scripts.seed_from_xlsx
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml exec -T backend python -m app.scripts.seed_notification_rules
 
       # --- Regression Suites ---
       - name: E2E — Lead workflow
@@ -165,15 +165,15 @@ jobs:
         if: failure()
         run: |
           echo "::group::backend logs"
-          docker compose -f docker-compose.yml logs backend --tail=200 || true
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml logs backend --tail=200 || true
           echo "::endgroup::"
           echo "::group::frontend logs"
-          docker compose -f docker-compose.yml logs frontend --tail=100 || true
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml logs frontend --tail=100 || true
           echo "::endgroup::"
           echo "::group::postgres logs"
-          docker compose -f docker-compose.yml logs postgres --tail=50 || true
+          docker compose -f docker-compose.yml -f docker-compose.ci.yml logs postgres --tail=50 || true
           echo "::endgroup::"
 
       - name: Stop services
         if: always()
-        run: docker compose -f docker-compose.yml down -v
+        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml down -v

--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -17,6 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    # Inject all env vars referenced by ``docker-compose.yml`` interpolation
+    # (root cause of 10/10 fail runs through 2026-05-24 — see PR #332 body).
+    # CI test creds are intentionally unsafe placeholders; the stack only
+    # binds to localhost inside this runner and is torn down on job end.
+    env:
+      POSTGRES_USER: qlts
+      POSTGRES_PASSWORD: ci-test-postgres-pw
+      POSTGRES_DB: qlts_test
+      DOMAIN: localhost
+      NEXT_PUBLIC_API_URL: http://localhost:8000
+
     steps:
       - uses: actions/checkout@v4
 
@@ -35,11 +46,30 @@ jobs:
         working-directory: frontend
         run: npx playwright install chromium --with-deps
 
-      # Start full stack via docker compose
+      # Generate ``.env.production`` so the backend service's ``env_file:``
+      # directive resolves (it's referenced unconditionally in
+      # docker-compose.yml). Values are CI-only placeholders mirroring the
+      # pattern used by backend-test.yml + nightly-backend-pytest.yml.
+      - name: Generate .env.production for backend env_file load
+        run: |
+          cat > .env.production <<EOF
+          APP_ENV=production
+          SECRET_KEY=ci-test-secret-key-for-nightly-only
+          JWT_SECRET_KEY=ci-test-jwt-secret-for-nightly-only
+          MAIL_USERNAME=ci-test@example.com
+          MAIL_PASSWORD=ci-test-placeholder
+          MAIL_FROM=ci-test@example.com
+          MAIL_SERVER=smtp.example.com
+          EOF
+
+      # ``-f docker-compose.yml`` bypasses the auto-loaded
+      # ``docker-compose.override.yml`` (dev mode) which requires
+      # ``Backend_FastAPI/.env`` that doesn't exist in CI. We want the
+      # production-like stack here anyway.
       - name: Start services
         run: |
-          docker compose up -d postgres redis backend frontend
-          docker compose exec -T backend alembic upgrade head
+          docker compose -f docker-compose.yml up -d postgres redis backend frontend
+          docker compose -f docker-compose.yml exec -T backend alembic upgrade head
           # Wait for services
           timeout 60 bash -c 'until curl -sf http://localhost:8000/docs > /dev/null; do sleep 2; done'
           timeout 60 bash -c 'until curl -sf http://localhost:3000 > /dev/null; do sleep 2; done'
@@ -48,9 +78,9 @@ jobs:
       # Seed data (required for E2E tests)
       - name: Seed database
         run: |
-          docker compose exec -T backend pip install -r requirements-dev.txt -q
-          docker compose exec -T backend python -m scripts.seed_from_xlsx
-          docker compose exec -T backend python -m app.scripts.seed_notification_rules
+          docker compose -f docker-compose.yml exec -T backend pip install -r requirements-dev.txt -q
+          docker compose -f docker-compose.yml exec -T backend python -m scripts.seed_from_xlsx
+          docker compose -f docker-compose.yml exec -T backend python -m app.scripts.seed_notification_rules
 
       # --- Regression Suites ---
       - name: E2E — Lead workflow
@@ -111,4 +141,4 @@ jobs:
 
       - name: Stop services
         if: always()
-        run: docker compose down -v
+        run: docker compose -f docker-compose.yml down -v

--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -27,6 +27,14 @@ jobs:
       POSTGRES_DB: qlts_test
       DOMAIN: localhost
       NEXT_PUBLIC_API_URL: http://localhost:8000
+      # Match credentials actually seeded by ``seed_from_xlsx.py`` (sheet
+      # ``2_TaiKhoan``). Doc default ``vothuhien``/``@Matkhau123!`` in
+      # ``Documents/TESTING_GUIDE.md`` + ``auth.setup.ts:27`` is stale —
+      # the xlsx workbook seeds ``vothithuthuhien`` / ``Abc@123456789``.
+      # Setting env here lets Playwright (auth.setup.ts:27-28 reads
+      # TEST_USERNAME / TEST_PASSWORD env) login successfully.
+      TEST_USERNAME: vothithuthuhien
+      TEST_PASSWORD: Abc@123456789
 
     steps:
       - uses: actions/checkout@v4

--- a/Backend_FastAPI/alembic/versions/phase1_16_create_archived_admission_profile_table.py
+++ b/Backend_FastAPI/alembic/versions/phase1_16_create_archived_admission_profile_table.py
@@ -67,7 +67,11 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "phase1_16"
-down_revision: Union[str, None] = "phase1_19c"
+# Chain link updated 2026-05-25: insert phase1_19c5 between phase1_19c
+# (UPPERCASE seed) and this migration so the lowercase conversion runs
+# before phase3_01's pre-flight check. See phase1_19c5 module docstring
+# for root cause + memory references.
+down_revision: Union[str, None] = "phase1_19c5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/Backend_FastAPI/alembic/versions/phase1_19c5_lowercase_admission_events.py
+++ b/Backend_FastAPI/alembic/versions/phase1_19c5_lowercase_admission_events.py
@@ -1,0 +1,96 @@
+"""phase1_19c5: lowercase ADMISSION_* notification_rule.event (chain integrity fix)
+
+Inserted 2026-05-25 between ``phase1_19c`` (UPPERCASE seed) and ``phase1_16``
+to close the recurring class of bugs documented in:
+
+* memory ``worktree-stack-bootstrap`` — fresh alembic fails phase3_01
+* memory ``migration-systemevents-value-case`` — enum case canon rule
+* PR #263 hotfix (2026-05-12) — phase3_01 prod deploy fail + auto-rollback
+* PR #330 nightly-regression CI failure cycle (2026-05-25)
+
+ROOT CAUSE
+----------
+``phase1_19c`` seeds 12 ADMISSION_* events into ``notification_rule`` with
+**UPPERCASE** enum NAMES (legacy convention). The modern canonical form is
+``SystemEvents.X.value`` lowercase (memory
+``migration-systemevents-value-case``). ``phase3_01`` (Phase 3 PR-3A) has
+a pre-flight assertion requiring 5 specific events in LOWERCASE and
+hard-aborts the migration if not found::
+
+    RuntimeError: Pre-flight fail: 0/5 system-critical events found
+    trong notification_rule.
+
+Production accumulated both cases over time because ``sync_notification_rules``
+(entrypoint, runs after alembic each deploy) inserts the lowercase variants
+on every startup. PR #263 hotfixed phase3_01 to expect LOWERCASE — but the
+ROOT CAUSE (chain has no step that produces lowercase before phase3_01
+runs from a fresh DB) was left unfixed. Result: prod deploys work after
+the first successful deploy (lowercase rows persist in DB across deploys),
+but **fresh DB scenarios remain broken**:
+
+* Fresh CI nightly-regression (this PR's verify runs #3 + #4)
+* Worktree bootstrap from clean alembic chain
+* Disaster recovery from backups predating the first successful phase3_01
+  run
+
+THIS MIGRATION
+--------------
+A single UPDATE that converts all ``notification_rule.event`` values
+matching ``'^ADMISSION_'`` (UPPERCASE) to lowercase. Idempotent — safe to
+run on prod (currently 0 UPPERCASE rows per SSH verify 2026-05-25
+``SELECT COUNT(*)... event != lower(event)`` = 0; UPDATE matches 0 rows).
+
+NOT touched (out of scope):
+* ``notification_template.template_code`` — prod has 0 ``tpl_admission%``
+  templates anyway (PR #327 cleanup deleted them); admin Config workflow
+  re-seeds via different mechanism.
+* ``notification_action.template_code`` — 2 orphan UPPERCASE rows exist
+  on prod (CONFIRMATION_REMINDER series) but reference templates that
+  no longer exist; that's an independent cleanup task, not in
+  phase3_01's pre-flight assertion.
+
+Per memory ``migration-predicate-safety``: predicate is strict
+(``event ~ '^ADMISSION_'`` — case-sensitive regex anchored to start) so
+this never touches non-target rows even if other event namespaces start
+with ``admission_``.
+
+DOWNGRADE
+---------
+Reverse to UPPERCASE for rollback. Idempotent — matches 0 rows on
+already-uppercase state.
+
+Revision ID: phase1_19c5
+Revises: phase1_19c
+Create Date: 2026-05-25
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "phase1_19c5"
+down_revision: Union[str, None] = "phase1_19c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE notification_rule
+        SET event = lower(event),
+            updated_at = NOW()
+        WHERE event ~ '^ADMISSION_'
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE notification_rule
+        SET event = upper(event),
+            updated_at = NOW()
+        WHERE event ~ '^admission_'
+        """
+    )

--- a/Backend_FastAPI/tests/unit/test_phase1_19c5_lowercase_migration.py
+++ b/Backend_FastAPI/tests/unit/test_phase1_19c5_lowercase_migration.py
@@ -1,0 +1,102 @@
+"""Anchor test for phase1_19c5 lowercase ADMISSION_* events migration.
+
+Guards the chain integrity fix shipped 2026-05-25. The migration converts
+``notification_rule.event`` from UPPERCASE (legacy phase1_19c seed) to
+lowercase BEFORE phase3_01's pre-flight assertion runs. Without this
+migration in chain, fresh DB scenarios (CI, worktree bootstrap, DR)
+crash with::
+
+    RuntimeError: Pre-flight fail: 0/5 system-critical events found
+    trong notification_rule.
+
+These tests assert the migration body has the required SQL patterns
+without requiring an actual DB connection (pattern-based, fast). They
+catch regression if a future PR accidentally:
+
+* changes the predicate to not match UPPERCASE rows (e.g., removes the
+  regex anchor)
+* drops the downgrade reverse UPDATE
+* breaks the chain link by changing phase1_16.down_revision back to
+  phase1_19c (bypassing phase1_19c5)
+
+Companion to PR #263 anchor
+``test_phase3_01_c1_preflight_event_strings_match_canonical_lowercase``
+(asserts phase3_01 checks LOWERCASE strings). Together they lock both
+ends of the case-canon contract.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+ALEMBIC_VERSIONS = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+MIGRATION_FILE = ALEMBIC_VERSIONS / "phase1_19c5_lowercase_admission_events.py"
+PHASE1_16_FILE = ALEMBIC_VERSIONS / "phase1_16_create_archived_admission_profile_table.py"
+
+
+@pytest.fixture(scope="module")
+def migration_source() -> str:
+    assert MIGRATION_FILE.exists(), f"migration file missing: {MIGRATION_FILE}"
+    return MIGRATION_FILE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def phase1_16_source() -> str:
+    assert PHASE1_16_FILE.exists(), f"phase1_16 file missing: {PHASE1_16_FILE}"
+    return PHASE1_16_FILE.read_text(encoding="utf-8")
+
+
+def test_migration_revision_id(migration_source: str) -> None:
+    """Revision string must be exactly ``phase1_19c5``."""
+    assert re.search(r'^revision: str = "phase1_19c5"', migration_source, re.M), \
+        "phase1_19c5 must declare revision='phase1_19c5'"
+
+
+def test_migration_down_revision_is_phase1_19c(migration_source: str) -> None:
+    """down_revision must chain back to phase1_19c (UPPERCASE seed)."""
+    assert re.search(r'down_revision[^=]*=\s*"phase1_19c"', migration_source), \
+        "phase1_19c5 must chain off phase1_19c (the UPPERCASE seed migration)"
+
+
+def test_phase1_16_chains_through_phase1_19c5(phase1_16_source: str) -> None:
+    """phase1_16 must point to phase1_19c5, not directly back to phase1_19c.
+
+    If a future PR reverts this to ``phase1_19c``, the lowercase
+    conversion bypasses and phase3_01 will fail again on fresh DB.
+    """
+    assert re.search(r'down_revision[^=]*=\s*"phase1_19c5"', phase1_16_source), \
+        "phase1_16 must chain through phase1_19c5 — see module docstring"
+
+
+def test_upgrade_converts_uppercase_to_lowercase(migration_source: str) -> None:
+    """UPDATE must use lower(event) with regex anchored predicate ``^ADMISSION_``."""
+    assert "lower(event)" in migration_source, \
+        "upgrade must contain SET event = lower(event)"
+    # Case-sensitive regex anchor — matches UPPERCASE only, never collides with
+    # lowercase admission_* events that already exist on prod.
+    assert re.search(r"WHERE event ~ '\^ADMISSION_'", migration_source), \
+        "upgrade WHERE predicate must be case-sensitive regex ^ADMISSION_"
+
+
+def test_downgrade_reverses_to_uppercase(migration_source: str) -> None:
+    """downgrade must restore UPPERCASE for rollback symmetry."""
+    assert "upper(event)" in migration_source, \
+        "downgrade must contain SET event = upper(event)"
+    assert re.search(r"WHERE event ~ '\^admission_'", migration_source), \
+        "downgrade WHERE predicate must match lowercase ^admission_"
+
+
+def test_only_touches_notification_rule_table(migration_source: str) -> None:
+    """Scope guard: migration MUST NOT touch notification_template /
+    notification_action / other tables — those are independent cleanup
+    (per phase1_19c5 module docstring scope note).
+    """
+    upgrade_block = migration_source.split("def upgrade()")[1].split("def downgrade()")[0]
+    assert "notification_rule" in upgrade_block
+    for forbidden in ("notification_template", "notification_action", "lead", "user_account"):
+        assert forbidden not in upgrade_block, (
+            f"upgrade unexpectedly touches {forbidden!r} — out of scope"
+        )

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,30 @@
+# =============================================================================
+# QLTS CI Override (nightly-regression workflow only)
+# =============================================================================
+# Production ``docker-compose.yml`` does NOT bind backend / frontend ports to
+# the host — nginx (production profile) is the canonical ingress and proxies
+# 80/443 to backend:8000 / frontend:3000 over the internal compose network.
+# Dev ``docker-compose.override.yml`` adds the bindings + dev tooling
+# (uvicorn --reload, ``Backend_FastAPI/.env`` env_file, bind mounts) — but
+# the CI workflow explicitly bypasses the override via ``-f docker-compose.yml``
+# because the override demands ``Backend_FastAPI/.env`` which CI has no
+# secret store path to populate.
+#
+# This file fills the narrow gap: bind only the ports Playwright + the
+# health-wait curl loop need to reach from the GitHub Actions runner, without
+# pulling in any dev-only side effects.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d ...
+#
+# Memory reference: ``worktree-stack-bootstrap`` — same port-conflict reality
+# applies when running multiple stacks side-by-side.
+# =============================================================================
+
+services:
+  backend:
+    ports:
+      - "8000:8000"
+  frontend:
+    ports:
+      - "3000:3000"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -126,11 +126,22 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests */
+  /* Run your local dev server before starting the tests.
+   *
+   * ``reuseExistingServer: true`` always — the prior ``!process.env.CI``
+   * setting forced Playwright to start its own ``npm run dev`` on CI,
+   * which conflicts with the Docker frontend container that
+   * nightly-regression.yml binds to ``localhost:3000`` via
+   * docker-compose.ci.yml. The semantics of ``true`` are correct for
+   * BOTH local + CI: probe the URL first, reuse if reachable, otherwise
+   * run the command — covers local dev (Docker frontend running),
+   * nightly-regression (Docker frontend running), and a hypothetical
+   * vacuum CI (no Docker, command starts dev server).
+   */
   webServer: {
     command: 'npm run dev',
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: true,
     timeout: 120 * 1000,
   },
 })


### PR DESCRIPTION
## Honest scope

This PR fixes **7 layered CI infrastructure issues** + **1 recurring alembic chain bug** that blocked the Playwright nightly regression workflow for 13 days. After this PR merges:

- Backend container boots cleanly on fresh CI DB (alembic chain self-contained)
- Frontend container reachable from runner host (port binding)
- Playwright authenticates successfully against the seeded test user (correct credentials)
- **Nightly E2E will STILL fail** at the auth-redirect step — see follow-up section below

**This is NOT "restore Playwright nightly".** It is "make the infra layer sound so the remaining bug is clearly visible". The remaining bug is a class-different FE/BE auth flow issue that warrants its own focused PR.

---

## What this PR ships

### A. CI infra fixes (7 layered, 1 per round of diagnosis)

| Round | Bug | Fix |
|---|---|---|
| 1 | `docker compose up` interpolation failed — POSTGRES_PASSWORD / NEXT_PUBLIC_API_URL / DOMAIN missing | Job-level `env:` block with CI placeholders |
| 2 | (debug aid) | Add `if: failure()` step that dumps backend/frontend/postgres logs before teardown |
| 3 | `_validate_production_secrets()` (config.py:245, PR #328) rejected placeholder DEVICE_FINGERPRINT_SALT | Generate `.env.production` with APP_ENV=test to bypass production-hardening validators (also covers CORS HTTPS validator in round 5) |
| 5 | `main.py:651` rejected `http://localhost:5173` CORS origin in production mode | Same fix as round 3 (APP_ENV=test) |
| 6 | Production `docker-compose.yml` does not bind backend:8000 / frontend:3000 to host (nginx is the canonical ingress in prod profile, but workflow does not use nginx) | NEW `docker-compose.ci.yml` override that ONLY adds port bindings (no dev-only side effects); workflow loads both files via `-f -f` |
| 7 | `playwright.config.ts:133` had `reuseExistingServer: !process.env.CI` — CI=true flipped to false, Playwright tried to spawn its own `npm run dev` and conflicted with Docker frontend on :3000 | Change to `reuseExistingServer: true` always (probes URL first, reuses if reachable, otherwise runs command — correct semantic for both local + CI) |
| 9 | `auth.setup.ts:27-28` defaults `vothuhien` / `@Matkhau123!` are stale — actual seed in `seed_data_template.xlsx` sheet `2_TaiKhoan` uses `vothithuthuhien` / `Abc@123456789` | Inject correct creds via `TEST_USERNAME` / `TEST_PASSWORD` env vars at job level (doc + auth.setup defaults still stale, separate broader-scope fix) |

### B. Alembic chain integrity fix — phase1_19c5 (recurring class bug, 3 incidents in 13 days)

Recurring bug closed:

- 2026-05-12 PR #263 hotfix — prod deploy of phase3_01 failed; auto-restored from backup; phase3_01 flipped to LOWERCASE check
- 2026-05-23 PR #327 — cleanup_uppercase_orphan deleted prod leftover UPPERCASE rows
- 2026-05-25 (this PR diagnostic runs #3 + #4) — fresh CI hit the same crash

Root cause (memory `worktree-stack-bootstrap`):

```
phase1_19c        seeds 12 ADMISSION_* events in UPPERCASE
     ↓
(no chain step converts case)
     ↓
phase3_01         pre-flight asserts 5 events in LOWERCASE
                  → 0/5 found → RuntimeError → migration aborts
```

Production accumulated both cases via `sync_notification_rules` (entrypoint) over deploys — fresh DB scenarios (CI / worktree bootstrap / DR from pre-phase3_01 backup) crash every time.

Fix — NEW migration `phase1_19c5_lowercase_admission_events.py` inserted between `phase1_19c` and `phase1_16`:

```sql
UPDATE notification_rule
SET event = lower(event), updated_at = NOW()
WHERE event ~ '^ADMISSION_'
```

- Predicate case-sensitive anchored regex per `migration-predicate-safety` memory
- Idempotent (matches 0 rows on already-lowercase state)
- **Prod safe**: verified 2026-05-25 via SSH read-only — `SELECT COUNT(*)... event != lower(event)` = 0 rows → no-op on prod
- `phase1_16.down_revision` updated `phase1_19c` → `phase1_19c5`
- Anchor test `test_phase1_19c5_lowercase_migration.py` (7 cases) locks chain links + SQL shape + scope guard

---

## What this PR does NOT fix (intentional defer)

### Residual blocker — FE auth cookie / redirect (P1, separate PR)

Run #9 (`26384493889`) proved the infra layer is sound: Start services SUCCESS, Seed database SUCCESS, Playwright reached login form. The remaining failure is NOT a CI workflow issue:

Evidence from run #9 backend log:

```
{"username":"vothithuthuhien","event":"Authentication successful"} × 3 attempts
{"event":"Login attempts counter reset after successful login"} × 3 attempts
```

Evidence from Playwright auth.setup:

```
Error: expect(page).not.toHaveURL failed
  - Expect "not toHaveURL" with timeout 30000ms
  - 33 × unexpected value "http://localhost:3000/login"
> 40 | await expect(page).not.toHaveURL(/\/login/, { timeout: 30000 });
```

Backend authenticates successfully + JWT issued + cookie set, but browser never navigates away from /login. Likely cause: cookie `Secure` flag rejected on HTTP localhost CI, OR `SameSite` mismatch, OR FE auth store not pickup cookie. **Needs FE/BE cookie config debug — class-different from CI workflow YAML scope** (filed as follow-up task).

### Pre-existing seed bug — admission_path ON CONFLICT (P3, separate)

Run #9 seed log surfaced this pre-existing bug (not introduced by this PR):

```
FAIL    16 admission_path  (sqlalchemy.dialects.postgresql.asyncpg.ProgrammingError)
        <class 'asyncpg.exceptions.InvalidColumnReferenceError'>:
        there is no unique or exclusion constraint matching the ON CONFLICT specification
```

Likely `admission_path` UNIQUE constraint shape changed (Phase 2 PR-2C v2 shipped 3-col UNIQUE 2026-05-10) but `seed_from_xlsx.py` still uses old-shape `ON CONFLICT` clause. Filed as follow-up task.

### Other deferred (2 from cross-audit agent)

- P2 — orphan `TPL_ADMISSION_CONFIRMATION_REMINDER_{24H,6H}_V1` template_codes on notification_action rules 51/52
- P3 — drop `_archived_notification_rule_uppercase_20260508` backup table after ~90-day soak (target 2026-08-06+)

---

## Verification

### Local anchor test (memory `local-test-oneoff-container-pattern`)

```
$ docker compose stop backend celery-worker celery-beat
$ docker compose run --rm --no-deps backend bash -c "..."
tests/unit/test_phase1_19c5_lowercase_migration.py  6 passed
tests/unit/test_phase3_pr3a_choice_and_score.py
  ::test_phase3_01_c1_preflight_event_strings_match_canonical_lowercase  1 passed
============================== 7 passed in 6.45s ==============================
```

### CI run history (this branch, workflow_dispatch)

| Run | Round | Outcome | Layer surfaced |
|---|---|---|---|
| #1 26376343053 | 1 | fail | env var (no fix yet at trigger) |
| #2 26377664571 | 2 | fail | (debug only — same env) |
| #3 26379742654 | 3 | fail | _validate_production_secrets |
| #4 26380640871 | 4 | fail | phase3_01 (workaround stale) |
| #5 26382615868 | 5 | fail | CORS HTTPS validator |
| #6 26383243859 | 6 | fail | port binding |
| #7 26383662374 | 7 | fail | Playwright config |
| #8 26383885784 | 8 | fail | test creds mismatch |
| **#9 26384493889** | 9 | fail | **Auth redirect (residual P1, this PR scope ends here)** |

### Cross-audit (1500-word agent report run this session)

Verified `phase1_19c5` is scope-correct and no other case-leak sources:

- `notification_outbox.event_code` empty (lowercase by contract)
- `notification_delivery.event` empty (lowercase by contract)
- `notification_template.allowed_events` 0 uppercase JSONB matches
- No service hardcodes UPPERCASE event literal
- All 5 other admission-event migrations already lowercase
- PR #327 `cleanup_upper_notif` predicate strict (case-sensitive + lowercase check) — no risk of deleting lowercase after phase1_19c5 runs
- FE socket subscriber lowercase-only
- Redis notification_rule cache keyed by `.value` lowercase
- No `SystemEvents.X.name` (uppercase) callsite

### Prod safety pre-flight (SSH read-only 2026-05-25)

```sql
SELECT COUNT(*) FROM admission_path WHERE admission_round_id IS NULL;  -- 0
SELECT COUNT(*) FROM notification_rule WHERE event ~ '^ADMISSION_';     -- 0
SELECT version_num FROM alembic_version;                                -- sl20260524_canonical
```

---

## Test plan

- [ ] PR gate (backend-test.yml + frontend-test.yml + deps) passes
- [ ] Anchor test `tests/unit/test_phase1_19c5_lowercase_migration.py` (7 cases) green in CI
- [ ] After merge: prod deploy executes `phase1_19c5` (no-op on prod, 0 rows UPDATE)
- [ ] After merge: file follow-up P1 issue for FE auth cookie/redirect blocker
- [ ] Nightly cron 2026-05-26 02:00 UTC runs with infra fixes — expected: same auth-redirect failure (NOT a regression), but Start services + Seed database GREEN this time

## Commits (9, kept atomic for bisect)

```
6335be27 ci(nightly-regression): inject correct seed credentials for Playwright auth.setup
699042cc ci(playwright): always reuseExistingServer to coexist with Docker frontend
62539652 ci(nightly-regression): bind backend/frontend ports via docker-compose.ci.yml
90ec0db6 ci(nightly-regression): switch APP_ENV=test to bypass production-hardening validators
67131818 fix(migration): chain phase1_19c5 lowercase ADMISSION_* events before phase3_01
e65a61c8 ci(nightly-regression): split alembic to seed lowercase events between phase2_06 and phase3_01
6208a2d6 ci(nightly-regression): satisfy _validate_production_secrets() — backend crash fix
717ada41 ci(nightly-regression): dump container logs on failure for diagnosis
26a2215d ci(nightly-regression): fix env var injection for docker compose (10/10 fail since 2026-05-15)
```

Note: commit `e65a61c8` (split-alembic workaround) is preserved in history for bisect lineage even though commit `67131818` superseded it with the real fix. Workflow no longer references the workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
