### PR TITLE
fix(leads): close mobile detail drawer on bottom-nav tap + lead_created realtime pipeline sync

### DIFF
--- a/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useUIStore } from "@/lib/stores/ui.store";
 
 import { useLeads, useDeleteLead, useExportLeads, useImportLeads, useDownloadImportTemplate, leadsKeys } from "@/hooks/useLeads";
 import { leadsApi } from "@/lib/api/leads";
@@ -91,6 +92,11 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
 
   // Mobile detail sheet state
   const [mobileDetailOpen, setMobileDetailOpen] = useState(false);
+
+  // Global "close mobile overlays" signal (bumped by MobileBottomNav taps).
+  // The bottom nav is rendered above the modal sheet but can't reach this
+  // local state directly, so it broadcasts via the UI store instead.
+  const mobileOverlayCloseNonce = useUIStore((s) => s.mobileOverlayCloseNonce);
 
   // Selection & Dialog states
   const [selectedLeadId, setSelectedLeadId] = useState<number | null>(null);
@@ -160,9 +166,25 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
       const leadStillExists = filteredLeads.some((lead) => lead.id === selectedLeadId);
       if (!leadStillExists) {
         queueMicrotask(() => setSelectedLeadId(null));
+        // Also dismiss the mobile sheet — otherwise it lingers open showing
+        // an empty-state panel (e.g. when the open lead is deleted from
+        // another session via the `lead_deleted` socket event).
+        setMobileDetailOpen(false);
       }
     }
   }, [filteredLeads, selectedLeadId]);
+
+  // Close the mobile detail sheet when the bottom nav broadcasts a close
+  // request. Tapping a tab while the (modal) sheet is open should return the
+  // user to the list — the bottom nav can't toggle this local state directly,
+  // so it signals through the UI store nonce. Skip the initial mount (nonce 0)
+  // is implicit: the sheet is already closed then. We intentionally do NOT
+  // clear selectedLeadId here — closing the drawer is enough.
+  useEffect(() => {
+    if (mobileOverlayCloseNonce > 0) {
+      setMobileDetailOpen(false);
+    }
+  }, [mobileOverlayCloseNonce]);
 
   // ✅ Phase 1: Prefetch next page for instant pagination
   useEffect(() => {

--- a/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
@@ -165,11 +165,15 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
     if (selectedLeadId) {
       const leadStillExists = filteredLeads.some((lead) => lead.id === selectedLeadId);
       if (!leadStillExists) {
-        queueMicrotask(() => setSelectedLeadId(null));
+        // Defer both setState calls off the effect's synchronous path
+        // (queueMicrotask) to avoid cascading-render lint/runtime warnings.
         // Also dismiss the mobile sheet — otherwise it lingers open showing
         // an empty-state panel (e.g. when the open lead is deleted from
         // another session via the `lead_deleted` socket event).
-        setMobileDetailOpen(false);
+        queueMicrotask(() => {
+          setSelectedLeadId(null);
+          setMobileDetailOpen(false);
+        });
       }
     }
   }, [filteredLeads, selectedLeadId]);
@@ -182,7 +186,8 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
   // clear selectedLeadId here — closing the drawer is enough.
   useEffect(() => {
     if (mobileOverlayCloseNonce > 0) {
-      setMobileDetailOpen(false);
+      // Defer off the effect's synchronous path to avoid cascading renders.
+      queueMicrotask(() => setMobileDetailOpen(false));
     }
   }, [mobileOverlayCloseNonce]);
 

--- a/frontend/src/components/layouts/SocketHandler.test.tsx
+++ b/frontend/src/components/layouts/SocketHandler.test.tsx
@@ -370,6 +370,48 @@ describe("SocketHandler — admission event scoping (P2 anchor)", () => {
   })
 
   // =========================================================================
+  // lead_created → list + pipeline + dashboard refresh (realtime gap fix)
+  // =========================================================================
+  describe("lead_created → invalidates lists + pipeline + dashboard", () => {
+    it("schedules a pipeline invalidation (so an open Pipeline Board refreshes)", async () => {
+      const { invalidateSpy, queryClient } = renderHandler()
+      await fireConnect()
+
+      act(() => {
+        socketStub.fire("lead_created", {
+          lead_id: 321,
+          lead_name: "Realtime New Lead",
+          lead_phone: "0900000000",
+          lead_email: "rt@example.com",
+          offering_name: "X",
+          unit_id: 1,
+          unit_name: "U",
+          created_by: "admin",
+          created_at: new Date().toISOString(),
+          assignment_status: "pending",
+          message: "m",
+        })
+      })
+
+      await flushDebounce()
+
+      // Pipeline must refresh — a brand-new lead enters the board at its
+      // initial stage. This is the gap this fix closes (previously only
+      // lists + dashboard were invalidated).
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ["pipeline"] }),
+      )
+      // List still refreshes too.
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: leadsKeys.lists() }),
+      )
+
+      invalidateSpy.mockRestore()
+      queryClient.clear()
+    })
+  })
+
+  // =========================================================================
   // Option-B Commit 8 — suspicious_login real-time banner bump
   // =========================================================================
   describe("suspicious_login event → banner bump + loginHistory invalidate", () => {

--- a/frontend/src/components/layouts/SocketHandler.tsx
+++ b/frontend/src/components/layouts/SocketHandler.tsx
@@ -453,6 +453,10 @@ export function SocketHandler() {
           break;
 
         case "lead":
+          // Forward-compatible branch: the backend does NOT currently emit
+          // `data_updated` for leads (it uses the dedicated `lead_*` events
+          // handled below). Kept so that if a future backend path ever falls
+          // back to the generic channel, lead lists still refresh.
           // ✅ PERFORMANCE FIX: Use debounced invalidation instead of immediate
           scheduleInvalidation({ leadsLists: true });
           break;
@@ -886,6 +890,11 @@ export function SocketHandler() {
       scheduleInvalidation({
         leadsLists: true,
         dashboard: true,
+        // A newly created lead enters the pipeline at its initial stage, so the
+        // Pipeline Board must refresh too — matches `lead_updated`/`lead_deleted`
+        // which already invalidate pipeline. Without this, a lead created in
+        // another tab/session never appears on an open Pipeline Board.
+        pipeline: true,
       });
       // ✅ NO TOAST - Per-user notification will show toast via "new_notification" event
     };

--- a/frontend/src/components/layouts/dashboard/MobileBottomNav.tsx
+++ b/frontend/src/components/layouts/dashboard/MobileBottomNav.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/lib/utils";
 import { User } from "lucide-react";
 import { useNotifications } from "@/hooks/useNotifications";
 import { useAppNavigation } from "@/hooks/useAppNavigation";
+import { useUIStore } from "@/lib/stores/ui.store";
 
 /**
  * Priority-ordered hrefs to show on mobile bottom nav.
@@ -36,6 +37,7 @@ const MOBILE_PRIORITY_HREFS = [
 export function MobileBottomNav() {
   const pathname = usePathname();
   const { navigation } = useAppNavigation();
+  const requestCloseMobileOverlays = useUIStore((s) => s.requestCloseMobileOverlays);
 
   // Fetch unread notification count for badge
   const { data: notificationsData } = useNotifications({
@@ -90,7 +92,11 @@ export function MobileBottomNav() {
     <nav
       className={cn(
         // Base styles
-        "fixed bottom-0 left-0 right-0 z-50",
+        // z-[60] + pointer-events-auto keep the bar tappable ABOVE an open
+        // Radix modal drawer (overlay/content sit at z-50 and set the rest of
+        // the page to pointer-events:none). Without this, tapping a tab while
+        // a mobile detail drawer is open does nothing — see LeadsClient sheet.
+        "fixed bottom-0 left-0 right-0 z-[60] pointer-events-auto",
         "bg-background border-t",
         "safe-area-pb", // For iPhone notch
         // Only show on mobile (hide on lg and up)
@@ -106,6 +112,10 @@ export function MobileBottomNav() {
             <Link
               key={item.href}
               href={item.href}
+              // Tapping any tab dismisses any open mobile drawer/sheet. This
+              // also covers re-tapping the already-active tab (same-route nav
+              // does NOT change pathname, so a route-based close never fires).
+              onClick={() => requestCloseMobileOverlays()}
               className={cn(
                 // Base styles - 44px touch target
                 "flex flex-col items-center justify-center",

--- a/frontend/src/lib/stores/ui.store.ts
+++ b/frontend/src/lib/stores/ui.store.ts
@@ -16,6 +16,16 @@ interface UIState {
   isSidebarCollapsed: boolean;
   setSidebarCollapsed: (collapsed: boolean) => void;
   toggleSidebar: () => void;
+
+  /**
+   * Monotonic counter bumped whenever a global "close all mobile overlays"
+   * request fires (e.g. tapping a MobileBottomNav tab). Pages that own a
+   * mobile drawer/sheet (Radix modal — which makes the bottom nav itself
+   * un-tappable) subscribe to this nonce and close their overlay on change.
+   * Runtime-only signal: excluded from persistence via `partialize`.
+   */
+  mobileOverlayCloseNonce: number;
+  requestCloseMobileOverlays: () => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -30,10 +40,19 @@ export const useUIStore = create<UIState>()(
       toggleSidebar: () => {
         set((state) => ({ isSidebarCollapsed: !state.isSidebarCollapsed }));
       },
+
+      mobileOverlayCloseNonce: 0,
+      requestCloseMobileOverlays: () => {
+        set((state) => ({ mobileOverlayCloseNonce: state.mobileOverlayCloseNonce + 1 }));
+      },
     }),
     {
       name: "ui-storage", // localStorage key
       version: STORAGE_VERSION,
+      // Only persist the sidebar preference. The overlay-close nonce is a
+      // transient runtime signal and must never be written to localStorage
+      // (a stale persisted value would fire a spurious close on rehydrate).
+      partialize: (state) => ({ isSidebarCollapsed: state.isSidebarCollapsed }),
       migrate: (persistedState, version) => {
         // If version mismatch, reset to defaults
         if (version !== STORAGE_VERSION) {


### PR DESCRIPTION
## Vấn đề
Trên mobile (<lg), drawer chi tiết lead (Radix `Sheet`, modal) không đóng khi tap tab "Lead" ở bottom nav. Root cause kép (verify runtime @375px):
1. Radix modal đặt cả `<body>` + `MobileBottomNav` thành `pointer-events:none` → tap không tới được link.
2. Tap "Lead" khi đang ở `/leads` là cùng-route → `pathname` không đổi → không có cơ chế đóng sheet.

Ngoài ra: `lead_created` socket handler thiếu invalidate `pipeline` → lead tạo từ tab/người khác không xuất hiện trên Pipeline Board.

## Thay đổi
- `ui.store.ts`: thêm `mobileOverlayCloseNonce` + `requestCloseMobileOverlays()`; `partialize` chỉ persist `isSidebarCollapsed` (nonce không rò localStorage).
- `MobileBottomNav.tsx`: nav `z-[60]` + `pointer-events-auto` (tap được trên modal); mỗi tab `onClick` bump nonce.
- `LeadsClient.tsx`: đóng sheet khi nonce đổi; đóng sheet khi lead đang mở biến mất khỏi list (vd bị xóa từ session khác).
- `SocketHandler.tsx`: `lead_created` invalidate thêm `pipeline`; chú thích nhánh `data_updated` case `lead` là forward-compatible (BE không emit).

## Kiểm thử
- Type-check ✅ · Vitest 19/19 ✅ (gồm anchor `lead_created`→pipeline).
- Chrome MCP smoke @375px 4/4 ✅: mở drawer / tap "Lead" (cùng route) đóng / tap tab khác đóng+điều hướng / desktop ≥1024 không hồi quy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)