### PR TITLE
fix(leads): emit realtime events for bulk assign/stage/delete (cross-session sync)

### DIFF
--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -1359,13 +1359,16 @@ async def bulk_assign_leads(
     - Updates lead status to "assigned"
     - Updates officer's last_assigned_at timestamp
     """
-    result = await lead_service.bulk_assign_leads(
+    result, post_commit = await lead_service.bulk_assign_leads(
         db,
         lead_ids=bulk_assign_data.lead_ids,
         officer_id=officer_id,
         assigner=current_user
     )
     await db.commit()
+    # Fire the per-lead LEAD_ASSIGNED notifications/socket emits AFTER commit
+    # (mirrors single-assign). MUST NOT be skipped — else bulk assign is silent.
+    await post_commit()
     return result
 
 
@@ -1391,13 +1394,16 @@ async def bulk_update_leads_stage(
     {"lead_ids": [1, 2, 3], "pipeline_stage_id": "stage_2"}
     ```
     """
-    result = await lead_service.bulk_update_pipeline_stage(
+    result, post_commit = await lead_service.bulk_update_pipeline_stage(
         db,
         lead_ids=bulk_data.lead_ids,
         pipeline_stage_id=bulk_data.pipeline_stage_id,
         updated_by=current_user
     )
     await db.commit()
+    # Emit LEAD_UPDATED (broadcast_only) per updated lead so other sessions'
+    # list + pipeline refresh in realtime. No notification is sent.
+    await post_commit()
     return result
 
 
@@ -1423,17 +1429,39 @@ async def bulk_delete_leads(
     """
     deleted_count = 0
     skipped = []
+    # Snapshot the LEAD_DELETED payload + scoped rooms for each successful delete
+    # BEFORE commit, while the lead instance is still fresh. Dispatching after
+    # commit on an expired object would otherwise lazy-load and fail.
+    delete_events: list[tuple[dict, list, int]] = []
 
     for lead_id in bulk_data.lead_ids:
         try:
             deleted_lead = await lead_service.delete_lead(db, lead_id, deleted_by=current_user)
             if deleted_lead:
                 deleted_count += 1
+                delete_events.append((
+                    EventPayload.for_lead_deleted(deleted_lead, current_user),
+                    rooms_for_lead(deleted_lead),
+                    deleted_lead.id,
+                ))
         except Exception as e:
             log.warning(f"Failed to delete lead {lead_id}: {e}")
             skipped.append({"lead_id": lead_id, "reason": str(e)})
 
     await db.commit()
+
+    # Post-commit fanout — restores single-delete semantics for bulk: emit
+    # LEAD_DELETED per successfully deleted lead (socket realtime + whatever the
+    # current notification rule resolves, same as DELETE /leads/{id}).
+    for payload, rooms, lid in delete_events:
+        await safe_dispatch(
+            db=db,
+            event=SystemEvents.LEAD_DELETED,
+            payload=payload,
+            dedupe_key=f"lead_deleted:{lid}",
+            rooms=rooms,
+        )
+
     return {
         "message": f"Deleted {deleted_count} leads",
         "deleted_count": deleted_count,

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -1710,7 +1710,7 @@ async def update_lead(
                             notify_user_ids=[old_officer_id] if old_officer_id else [],
                         ),
                         dedupe_key=f"lead_reassigned:{lead_id}",
-                        rooms=rooms_for_lead(lead),
+                        rooms=rooms_for_lead(db_lead),
                     )
             except Exception as e:
                 log.error(

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -3850,7 +3850,7 @@ async def bulk_assign_leads(
     lead_ids: List[int],
     officer_id: int,
     assigner: models.User
-) -> dict:
+) -> Tuple[dict, Callable]:
     """
     Bulk assign multiple leads to a single officer (Admin/Manager only).
 
@@ -3861,13 +3861,16 @@ async def bulk_assign_leads(
         assigner: User performing the assignment
 
     Returns:
-        dict: {
+        Tuple[dict, Callable]: (result, post_commit)
+        result: {
             "total": int,
             "successful": int,
             "failed": int,
             "assigned_lead_ids": List[int],
             "errors": List[dict]
         }
+        post_commit: async callback the router MUST await AFTER db.commit() to
+        fire the gathered per-lead LEAD_ASSIGNED notifications/socket emits.
 
     Business Rules:
     - All leads must exist and not be deleted
@@ -3906,6 +3909,11 @@ async def bulk_assign_leads(
 
     assigned_lead_ids = []
     errors = []
+    # Collect the per-lead LEAD_ASSIGNED post-commit callbacks. The single-assign
+    # path (assign_lead_manually) returns one; bulk previously discarded them, so
+    # no socket emit / notification ever fired for bulk assignments. We gather the
+    # successful ones and await them AFTER the router commits (see post_commit).
+    assign_callbacks: List[Callable] = []
 
     for lead_id in lead_ids:
         try:
@@ -3918,6 +3926,9 @@ async def bulk_assign_leads(
             # Assign lead using existing service function
             lead, _cb = await assign_lead_manually(db, lead_id, officer_id, assigner)
             assigned_lead_ids.append(lead.id)
+            # Only collect callbacks for successful assignments (not skipped/failed).
+            if _cb:
+                assign_callbacks.append(_cb)
 
         except (ResourceNotFoundError, PermissionDeniedError, BadRequest) as e:
             errors.append({
@@ -3952,7 +3963,7 @@ async def bulk_assign_leads(
         assigner_id=assigner.id
     )
 
-    return {
+    result = {
         "total": len(lead_ids),
         "successful": len(assigned_lead_ids),
         "failed": len(errors),
@@ -3960,13 +3971,31 @@ async def bulk_assign_leads(
         "errors": errors
     }
 
+    async def _post_commit():
+        """Fire the gathered LEAD_ASSIGNED notifications/socket emits after the
+        router commits. Run sequentially; a single callback failure is logged but
+        does NOT roll back the already-committed assignments (mirrors single-assign
+        where the dispatch is best-effort post-commit)."""
+        for cb in assign_callbacks:
+            try:
+                await cb()
+            except Exception as e:  # noqa: BLE001 — best-effort post-commit fanout
+                log.error(
+                    "Bulk assign: notification callback failed (leads already committed)",
+                    officer_id=officer_id,
+                    error=str(e),
+                    exc_info=True,
+                )
+
+    return result, _post_commit
+
 
 async def bulk_update_pipeline_stage(
     db: AsyncSession,
     lead_ids: List[int],
     pipeline_stage_id: str,
     updated_by: models.User
-) -> dict:
+) -> Tuple[dict, Callable]:
     """
     Bulk update pipeline_stage_id for multiple leads (Admin only).
 
@@ -3980,11 +4009,14 @@ async def bulk_update_pipeline_stage(
         updated_by: User performing the update
 
     Returns:
-        dict: {
+        Tuple[dict, Callable]: (result, post_commit)
+        result: {
             "message": str,
             "updated_count": int,
             "skipped": [{"lead_id": int, "reason": str}, ...]
         }
+        post_commit: async callback the router MUST await AFTER db.commit() to
+        emit the LEAD_UPDATED (broadcast_only) realtime events per updated lead.
 
     Business Rules:
     - Only Admin can perform bulk updates
@@ -4017,10 +4049,70 @@ async def bulk_update_pipeline_stage(
         else:
             updatable_ids.append(lid)
 
+    # Capture each updatable lead's current (pre-update) stage now, while the
+    # ORM objects are fresh — the repo bulk UPDATE is raw SQL and does NOT sync
+    # the session, so found_leads[*].pipeline_stage_id stays at the old value.
+    old_stage_by_id: dict[int, object] = {
+        lid: found_leads[lid].pipeline_stage_id for lid in updatable_ids
+    }
+
     # Update only qualifying leads
     updated_count = 0
+    update_callbacks: List[Callable] = []
     if updatable_ids:
+        # FAIL-FAST GUARD: the realtime emit below calls dispatch() BEFORE the
+        # router commits. That is only safe because LEAD_UPDATED is a
+        # broadcast_only event — dispatch() returns the emit callback without
+        # resolving recipients or persisting a notification row. If LEAD_UPDATED
+        # is ever promoted to a user-class event, this path would dispatch on
+        # uncommitted data; assert so that change is caught loudly here instead
+        # of silently violating the dispatch-before-commit rule.
+        from app.core.event_catalog import get_event
+        _lu_def = get_event(SystemEvents.LEAD_UPDATED)
+        assert _lu_def is not None and _lu_def.notification_class == "broadcast_only", (
+            "LEAD_UPDATED must stay broadcast_only for pre-commit bulk dispatch; "
+            f"got notification_class={getattr(_lu_def, 'notification_class', None)}"
+        )
+
         updated_count = await repo.bulk_update_pipeline_stage(updatable_ids, pipeline_stage_id)
+
+        # Realtime sync (no notification spam): emit LEAD_UPDATED — a
+        # broadcast_only event — per updated lead so other tabs/sessions
+        # refresh their list + pipeline. We deliberately do NOT use
+        # LEAD_STATUS_CHANGED here: it is a user-class event (resolver
+        # lead_owner) and would push one inbox notification per lead to the
+        # owning officer — spam for an admin bulk action. status_changed=True
+        # makes the FE handler invalidate the pipeline board.
+        # Build payloads/rooms NOW (pre-commit, objects fresh) so the
+        # post-commit callbacks never lazy-load an expired instance.
+        from app.services.notification_dispatcher import rooms_for_lead
+        for lid in updatable_ids:
+            lead = found_leads.get(lid)
+            if lead is None:
+                continue
+            try:
+                _, _u_cb = await dispatch(
+                    db=db,
+                    event=SystemEvents.LEAD_UPDATED,
+                    payload=EventPayload.for_lead_updated(
+                        lead,
+                        updated_by,
+                        updated_fields=["pipeline_stage_id"],
+                        status_changed=True,
+                        updated_summary=f"pipeline_stage: {old_stage_by_id.get(lid)} → {pipeline_stage_id}",
+                    ),
+                    dedupe_key=f"lead_updated:{lead.id}:stage:{pipeline_stage_id}",
+                    rooms=rooms_for_lead(lead),
+                )
+                if _u_cb:
+                    update_callbacks.append(_u_cb)
+            except Exception as e:  # noqa: BLE001 — broadcast prep is best-effort
+                log.error(
+                    "Bulk stage update: failed to prepare realtime broadcast",
+                    lead_id=lid,
+                    error=str(e),
+                    exc_info=True,
+                )
 
     log.info(
         "Bulk pipeline stage update completed",
@@ -4031,11 +4123,27 @@ async def bulk_update_pipeline_stage(
         updated_by_id=updated_by.id
     )
 
-    return {
+    result = {
         "message": f"Updated {updated_count} leads",
         "updated_count": updated_count,
         "skipped": skipped,
     }
+
+    async def _post_commit():
+        """Fire the LEAD_UPDATED broadcasts after the router commits. Best-effort:
+        a failed emit is logged but never rolls back the committed stage changes."""
+        for cb in update_callbacks:
+            try:
+                await cb()
+            except Exception as e:  # noqa: BLE001 — best-effort post-commit fanout
+                log.error(
+                    "Bulk stage update: broadcast callback failed (leads already committed)",
+                    pipeline_stage_id=pipeline_stage_id,
+                    error=str(e),
+                    exc_info=True,
+                )
+
+    return result, _post_commit
 
 
 # =============================================================================

--- a/Backend_FastAPI/tests/api/test_leads_crud.py
+++ b/Backend_FastAPI/tests/api/test_leads_crud.py
@@ -7,7 +7,7 @@ from datetime import (  # <-- THÊM timedelta VÀO ĐÂY; Import datetime, timez
     timedelta,
     timezone,
 )
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models, schemas
 from app.config import settings
+from app.core.events import SystemEvents
 
 # Import app components
 from app.database import AsyncSessionLocal
@@ -533,3 +534,73 @@ async def test_get_lead_timeline_success(
 
     log.info(f"Get timeline successful. Found {len(data)} items with expected types.")
     log.info("--- Finished: test_get_lead_timeline_success ---")
+
+
+# =============================================================================
+# BULK DELETE — REALTIME DISPATCH (PR2 2C, router-level safe_dispatch)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_bulk_delete_dispatches_lead_deleted_per_deleted_lead(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    seed_lead_dependencies: dict,
+):
+    """POST /leads/bulk-delete must safe_dispatch LEAD_DELETED exactly once per
+    SUCCESSFULLY deleted lead, and never for a skipped (non-existent) id.
+
+    The dispatch lives in the router (post-commit fanout), so this API-level
+    test is the only thing that catches a regression there — the service-layer
+    bulk tests do not exercise it.
+    """
+    log.info("--- Running: test_bulk_delete_dispatches_lead_deleted_per_deleted_lead ---")
+    unit_id = seed_lead_dependencies["unit_id"]
+    initial = seed_lead_dependencies["initial_status_id"]
+    stage = seed_lead_dependencies["stage_id"]
+
+    # Seed 2 deletable leads (no admission profile attached → eligible).
+    lead_ids: list[int] = []
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            for i in range(2):
+                lead = models.Lead(
+                    full_name=f"Bulk Delete Lead {i}",
+                    phone=f"090111000{i}",
+                    email=f"bulk_delete_rt_{i}@test.com",
+                    source="test",
+                    unit_id=unit_id,
+                    status=initial,
+                    consultation_status_id=initial,
+                    pipeline_stage_id=stage,
+                )
+                session.add(lead)
+                await session.flush()
+                lead_ids.append(lead.id)
+
+    missing_id = 99_999_999  # non-existent → skipped, must NOT dispatch
+
+    # Patch the router's safe_dispatch so we can assert the post-commit fanout.
+    with patch(
+        "app.routers.leads.safe_dispatch", new_callable=AsyncMock
+    ) as mock_dispatch:
+        resp = await client.post(
+            f"{LeadsURLs.LEADS}/bulk-delete",
+            json={"lead_ids": lead_ids + [missing_id]},
+            headers=admin_token_headers,
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["deleted_count"] == 2, body
+    assert len(body["skipped"]) == 1, body
+
+    # One LEAD_DELETED dispatch per deleted lead; none for the skipped id.
+    assert mock_dispatch.call_count == 2, mock_dispatch.call_args_list
+    dispatched_ids = set()
+    for c in mock_dispatch.call_args_list:
+        assert c.kwargs["event"] == SystemEvents.LEAD_DELETED
+        dispatched_ids.add(c.kwargs["payload"]["lead_id"])
+    assert dispatched_ids == set(lead_ids)
+    assert missing_id not in dispatched_ids
+    log.info("--- Finished: test_bulk_delete_dispatches_lead_deleted_per_deleted_lead ---")

--- a/Backend_FastAPI/tests/services/test_lead.py
+++ b/Backend_FastAPI/tests/services/test_lead.py
@@ -1728,7 +1728,7 @@ class TestBulkAssign:
         
         # Act
         with patch("app.services.notification_dispatcher.dispatch", new_callable=AsyncMock, return_value=([], None)):
-            result = await lead_service.bulk_assign_leads(
+            result, _post_commit = await lead_service.bulk_assign_leads(
                 db, 
                 lead_ids, 
                 officer_user.id, 
@@ -1767,7 +1767,7 @@ class TestBulkAssign:
     ):
         """Test bulk_assign_leads with empty list returns zero results."""
         # Act
-        result = await lead_service.bulk_assign_leads(
+        result, _post_commit = await lead_service.bulk_assign_leads(
             db, [], officer_user.id, assigner=admin_user
         )
         
@@ -1788,7 +1788,7 @@ class TestBulkAssign:
         
         # Act
         with patch("app.services.notification_dispatcher.dispatch", new_callable=AsyncMock, return_value=([], None)):
-            result = await lead_service.bulk_assign_leads(
+            result, _post_commit = await lead_service.bulk_assign_leads(
                 db, lead_ids, officer_user.id, assigner=admin_user
             )
             await db.commit()
@@ -1828,6 +1828,89 @@ class TestBulkAssign:
             await lead_service.bulk_assign_leads(
                 db, lead_ids, inactive_officer.id, assigner=admin_user
             )
+
+    async def test_bulk_assign_returns_post_commit_and_fires_callbacks(
+        self,
+        db: AsyncSession,
+        multiple_leads: list,
+        officer_user: models.User,
+        admin_user: models.User,
+    ):
+        """Realtime fix: bulk assign must gather the per-lead LEAD_ASSIGNED
+        callbacks (single-assign returns one each) and expose a post_commit that
+        fires them. Previously the callbacks were dropped → bulk assign was
+        silent (no socket emit / notification for other sessions)."""
+        lead_ids = [lead.id for lead in multiple_leads[:3]]
+        fired: list[int] = []
+
+        async def _fake_cb():
+            fired.append(1)
+
+        # assign_lead_manually() calls dispatch() internally; stub it so each
+        # successful assignment yields our fake post-commit callback.
+        with patch(
+            "app.services.lead_service.dispatch",
+            new_callable=AsyncMock,
+            return_value=([], _fake_cb),
+        ):
+            result, post_commit = await lead_service.bulk_assign_leads(
+                db, lead_ids, officer_user.id, assigner=admin_user
+            )
+            await db.commit()
+
+            assert result["successful"] == 3
+            # Callbacks must NOT fire until the router runs post_commit.
+            assert fired == []
+            await post_commit()
+
+        assert len(fired) == 3
+
+
+# =============================================================================
+# BULK UPDATE PIPELINE STAGE — REALTIME (gap fix)
+# =============================================================================
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestBulkUpdatePipelineStageRealtime:
+    """POST /leads/bulk-update-stage realtime broadcast."""
+
+    async def test_emits_lead_updated_broadcast_per_updated_lead(
+        self,
+        db: AsyncSession,
+        multiple_leads: list,
+        admin_user: models.User,
+    ):
+        """Bulk stage update emits LEAD_UPDATED (broadcast_only) once per updated
+        lead — NEVER LEAD_STATUS_CHANGED, which is a user-class event that would
+        push one inbox notification per lead to the owning officer (spam)."""
+        from app.core.events import SystemEvents
+
+        lead_ids = [lead.id for lead in multiple_leads]  # all currently at stg01
+        captured_cb = AsyncMock()
+
+        with patch(
+            "app.services.lead_service.dispatch",
+            new_callable=AsyncMock,
+            return_value=([], captured_cb),
+        ) as mock_dispatch:
+            result, post_commit = await lead_service.bulk_update_pipeline_stage(
+                db,
+                lead_ids=lead_ids,
+                pipeline_stage_id="stg02",  # different from stg01 → all updatable
+                updated_by=admin_user,
+            )
+            await db.commit()
+            await post_commit()
+
+        assert result["updated_count"] == len(lead_ids)
+        # One broadcast per updated lead.
+        assert mock_dispatch.call_count == len(lead_ids)
+        events = [c.kwargs["event"] for c in mock_dispatch.call_args_list]
+        assert all(e == SystemEvents.LEAD_UPDATED for e in events)
+        assert SystemEvents.LEAD_STATUS_CHANGED not in events
+        # Broadcast callbacks fire only on post_commit (after the router commits).
+        assert captured_cb.await_count == len(lead_ids)
 
 
 # =============================================================================
@@ -2195,7 +2278,7 @@ class TestBulkAssignBugFixes:
         await db.refresh(unassigned_lead)
         
         # Act
-        result = await lead_service.bulk_assign_leads(
+        result, _post_commit = await lead_service.bulk_assign_leads(
             db, 
             lead_ids=[unassigned_lead.id], 
             officer_id=available_officer.id, 


### PR DESCRIPTION
## Vấn đề
3 bulk endpoint lead âm thầm bỏ side-effect realtime mà single-lead path vẫn phát → bulk op ở 1 session không refresh tab/session khác:
- `/bulk-assign`: callback `LEAD_ASSIGNED` của `assign_lead_manually` bị vứt (`_cb`).
- `/bulk-update-stage`: commit rồi return, không dispatch.
- `/bulk-delete`: loop gọi service (dispatch nằm ở router single nên bị bỏ).

## Thay đổi
- **bulk-assign**: `bulk_assign_leads` gom callback của lead thành công, return `(result, post_commit)`; router await sau commit. Giữ semantics single-assign (officer được notify per lead).
- **bulk-update-stage**: emit `LEAD_UPDATED` (**broadcast_only**, `status_changed=True`) per updated lead → realtime list+pipeline, **không** spam inbox. Cố ý KHÔNG dùng `LEAD_STATUS_CHANGED` (user-class, resolver `lead_owner` → N notification/lead). Guard fail-fast `assert notification_class == "broadcast_only"` vì path dispatch trước commit. `old_stage` capture pre-update (repo dùng raw SQL UPDATE không sync ORM).
- **bulk-delete**: snapshot payload+rooms pre-commit, `safe_dispatch(LEAD_DELETED)` post-commit per deleted lead — restores single-delete semantics.

## Kiểm thử (one-off container)
- 2A `bulk_assign_returns_post_commit_and_fires_callbacks` ✅
- 2B `emits_lead_updated_broadcast_per_updated_lead` (LEAD_UPDATED, không LEAD_STATUS_CHANGED) ✅
- 2C `bulk_delete_dispatches_lead_deleted_per_deleted_lead` (API-level: đúng số lead deleted, không gọi cho skipped) ✅
- 11 passed · notification suite 116 passed · `check_notification_event_coverage.py` exit 0, no gaps.
- 2 fail pre-existing (`test_blocker_already_has_profile`, `test_live_scan_finds_submit_router_dual_dispatch`) đã xác nhận trên baseline, ngoài scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)