### PR TITLE
fix(realtime+seed): quick wins batch — LEAD_RESTORED dispatch (2 paths) + seed schema drift + orphan TPL cleanup

### DIFF
--- a/Backend_FastAPI/alembic/versions/null_orphan_tpl_admission_confirmation_reminder.py
+++ b/Backend_FastAPI/alembic/versions/null_orphan_tpl_admission_confirmation_reminder.py
@@ -1,0 +1,94 @@
+"""null orphan TPL_ADMISSION_CONFIRMATION_REMINDER_*_V1 template_codes
+
+PR #327 ``cleanup_uppercase_orphan_notification_rows`` (2026-05-23) removed
+the UPPERCASE notification_template rows but left 2 ``notification_action``
+rows still referencing the now-non-existent template codes::
+
+    id=92, rule_id=51 (admission_confirmation_reminder_24h), channel=email,
+      template_code='TPL_ADMISSION_CONFIRMATION_REMINDER_24H_V1'
+
+    id=94, rule_id=52 (admission_confirmation_reminder_6h), channel=email,
+      template_code='TPL_ADMISSION_CONFIRMATION_REMINDER_6H_V1'
+
+Behavior pre-fix: when the celery-beat reminder scan fires (every night
+for profiles approaching their confirmation deadline), the dispatcher
+queries the missing template_code, logs::
+
+    "template_code not resolved, using rule defaults"
+
+and falls back to the rule's ``base_snapshot`` for title/body. Users still
+receive the reminder — just with the default rule snapshot content rather
+than the (intended-but-now-missing) tuned template. So the bug is
+
+* user-impact: low (notification still sent, content slightly less tuned)
+* log noise: medium (nightly warning spam during reminder window)
+
+This migration sets ``template_code = NULL`` on those 2 rows so the
+dispatcher silently uses the rule defaults without the warning log. If
+admin later wants tuned templates for these reminders, they can seed
+new templates + UPDATE action rows to reference them.
+
+Verified prod state 2026-05-25 via SSH read-only:
+
+    SELECT na.id, na.rule_id, na.channel, na.template_code, nr.event
+    FROM notification_action na
+    JOIN notification_rule nr ON na.rule_id = nr.id
+    WHERE na.template_code LIKE 'TPL_ADMISSION_CONFIRMATION_REMINDER%';
+
+    id | rule_id | channel | template_code                              | event
+    92 |      51 | email   | TPL_ADMISSION_CONFIRMATION_REMINDER_24H_V1 | admission_confirmation_reminder_24h
+    94 |      52 | email   | TPL_ADMISSION_CONFIRMATION_REMINDER_6H_V1  | admission_confirmation_reminder_6h
+
+Predicate is strict (full string match) per ``migration-predicate-safety``
+memory. Idempotent — re-run matches 0 rows.
+
+Revision ID: null_orphan_admission_reminder_tpl
+Revises: sl20260524_canonical
+Create Date: 2026-05-25
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "null_orphan_admission_reminder_tpl"
+down_revision: Union[str, None] = "sl20260524_canonical"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE notification_action
+        SET template_code = NULL,
+            updated_at = NOW()
+        WHERE template_code IN (
+            'TPL_ADMISSION_CONFIRMATION_REMINDER_24H_V1',
+            'TPL_ADMISSION_CONFIRMATION_REMINDER_6H_V1'
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    # Restore the exact rule_id → template_code mapping. If a future migration
+    # introduces new actions for these rules the restore could over-write —
+    # but at the time of this fix only the original 2 rows existed (verified
+    # prod 2026-05-25). Predicate uses rule_id + channel to scope.
+    op.execute(
+        """
+        UPDATE notification_action
+        SET template_code = 'TPL_ADMISSION_CONFIRMATION_REMINDER_24H_V1',
+            updated_at = NOW()
+        WHERE rule_id = 51 AND channel = 'email' AND template_code IS NULL
+        """
+    )
+    op.execute(
+        """
+        UPDATE notification_action
+        SET template_code = 'TPL_ADMISSION_CONFIRMATION_REMINDER_6H_V1',
+            updated_at = NOW()
+        WHERE rule_id = 52 AND channel = 'email' AND template_code IS NULL
+        """
+    )

--- a/Backend_FastAPI/app/routers/admin/deleted_items.py
+++ b/Backend_FastAPI/app/routers/admin/deleted_items.py
@@ -26,8 +26,11 @@ from sqlalchemy.orm import selectinload
 
 from app import database, models, schemas
 from app.core.deps import CasbinAuth, require_admin_or_manager
+from app.core.events import SystemEvents
 from app.core.rate_limits import limiter, RateLimits
 from app.services import lead_service
+from app.services.notification_dispatcher import rooms_for_lead, safe_dispatch
+from app.services.notification_payloads import EventPayload
 
 log = structlog.get_logger(__name__)
 
@@ -244,6 +247,20 @@ async def restore_deleted_lead(
         )
     )
     lead = result.scalar_one()
+
+    # ✅ NOTIFICATION: Dispatch LEAD_RESTORED — mirror leads.py:796 pattern.
+    # Without this, restoring via "Deleted Items" admin screen skips
+    # realtime/notification sync — other tabs viewing lead list never
+    # see the restored lead reappear until manual reload (UX inconsistency
+    # vs the /leads/{id}/restore path which does emit). Filed as task #42
+    # in 2026-05-25 session triage.
+    await safe_dispatch(
+        db=db,
+        event=SystemEvents.LEAD_RESTORED,
+        payload=EventPayload.for_lead_restored(lead, current_user),
+        dedupe_key=EventPayload.dedupe_key("lead_restored", lead.id),
+        rooms=rooms_for_lead(lead),
+    )
 
     log.info(
         "Lead restored via admin API",

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -798,7 +798,7 @@ async def restore_lead(
         event=SystemEvents.LEAD_RESTORED,
         payload=EventPayload.for_lead_restored(restored_lead, current_user),
         dedupe_key=EventPayload.dedupe_key("lead_restored", restored_lead.id),
-        rooms=rooms_for_lead(lead),
+        rooms=rooms_for_lead(restored_lead),
     )
 
     return restored_lead

--- a/Backend_FastAPI/scripts/seed_from_xlsx.py
+++ b/Backend_FastAPI/scripts/seed_from_xlsx.py
@@ -929,19 +929,23 @@ async def seed_16_duong_dan(db: AsyncSession, wb, dry_run: bool) -> int:
         # NOT NULL and changed the UNIQUE constraint from 2 columns to
         # ``(admission_round_id, academic_info_id, admission_method_id)``.
         # The xlsx workbook predates this change and has no admission_round_id
-        # column, so we derive it: pick the earliest round for the year
-        # (deterministic, matches the historical convention where DOT_1 is the
-        # first round of an academic year). Without this, INSERT fails twice:
+        # column, so we derive it: explicitly pick ``DOT_1`` to match the
+        # contract service auto-resolve convention (admission_path_service
+        # uses ``get_default_dot1``). Earlier draft used
+        # ``ORDER BY start_date ASC NULLS LAST`` but DOT_1's backfill row has
+        # ``start_date = NULL`` while DOT_2/DOT_3 have real dates, which
+        # would mis-route the seed into a non-default round in any DB with
+        # multiple rounds. Without this fix, INSERT fails twice:
         # (1) NOT NULL violation on admission_round_id, and (2) ON CONFLICT
         # references a constraint shape that no longer exists.
         round_row = (await db.execute(
             text('''SELECT id FROM offering_admission_round
-                 WHERE academic_year = :year
-                 ORDER BY start_date ASC NULLS LAST, id ASC LIMIT 1'''),
+                 WHERE academic_year = :year AND round_code = 'DOT_1'
+                 LIMIT 1'''),
             {"year": nam_hoc}
         )).fetchone()
         if not round_row:
-            # Year has no rounds seeded yet — skip this path (idempotent).
+            # Year has no DOT_1 round seeded yet — skip this path (idempotent).
             continue
         admission_round_id = round_row[0]
 

--- a/Backend_FastAPI/scripts/seed_from_xlsx.py
+++ b/Backend_FastAPI/scripts/seed_from_xlsx.py
@@ -925,6 +925,26 @@ async def seed_16_duong_dan(db: AsyncSession, wb, dry_run: bool) -> int:
         if not method_id:
             continue
 
+        # Phase 2 PR-2C v2 (2026-05-10) made ``admission_path.admission_round_id``
+        # NOT NULL and changed the UNIQUE constraint from 2 columns to
+        # ``(admission_round_id, academic_info_id, admission_method_id)``.
+        # The xlsx workbook predates this change and has no admission_round_id
+        # column, so we derive it: pick the earliest round for the year
+        # (deterministic, matches the historical convention where DOT_1 is the
+        # first round of an academic year). Without this, INSERT fails twice:
+        # (1) NOT NULL violation on admission_round_id, and (2) ON CONFLICT
+        # references a constraint shape that no longer exists.
+        round_row = (await db.execute(
+            text('''SELECT id FROM offering_admission_round
+                 WHERE academic_year = :year
+                 ORDER BY start_date ASC NULLS LAST, id ASC LIMIT 1'''),
+            {"year": nam_hoc}
+        )).fetchone()
+        if not round_row:
+            # Year has no rounds seeded yet — skip this path (idempotent).
+            continue
+        admission_round_id = round_row[0]
+
         # ADM-003: Insert path WITHOUT criteria_id first, then resolve
         # the effective criteria_id (possibly cloning) and UPDATE.
         # The xlsx data set deliberately has multiple paths referencing
@@ -938,11 +958,12 @@ async def seed_16_duong_dan(db: AsyncSession, wb, dry_run: bool) -> int:
         # alembic adm003path001 migration.
         result = await db.execute(
             text('''INSERT INTO admission_path
-                 (academic_info_id, admission_method_id, status,
+                 (admission_round_id, academic_info_id, admission_method_id, status,
                   display_name, display_order, visibility, application_fee, created_at, updated_at)
-                 VALUES (:aiid, :mid, :status, :dn, 0, :vis, :fee, NOW(), NOW())
-                 ON CONFLICT (academic_info_id, admission_method_id) DO NOTHING RETURNING id'''),
-            {"aiid": academic_info_id, "mid": method_id,
+                 VALUES (:rid, :aiid, :mid, :status, :dn, 0, :vis, :fee, NOW(), NOW())
+                 ON CONFLICT (admission_round_id, academic_info_id, admission_method_id)
+                     DO NOTHING RETURNING id'''),
+            {"rid": admission_round_id, "aiid": academic_info_id, "mid": method_id,
              "status": status, "dn": display_name, "vis": visibility, "fee": app_fee}
         )
         path_row = result.fetchone()

--- a/Backend_FastAPI/tests/unit/test_null_orphan_tpl_admission_reminder_migration.py
+++ b/Backend_FastAPI/tests/unit/test_null_orphan_tpl_admission_reminder_migration.py
@@ -1,0 +1,64 @@
+"""Anchor test for null_orphan_tpl_admission_confirmation_reminder migration.
+
+Locks the migration body so a future PR cannot accidentally:
+
+* widen the WHERE predicate to touch unrelated template_codes
+* drop the downgrade restore (rollback symmetry)
+* break the chain link off ``sl20260524_canonical``
+
+Pattern-based assertions (no DB needed) — same approach as
+``test_phase1_19c5_lowercase_migration.py``.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+ALEMBIC_VERSIONS = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+MIGRATION_FILE = ALEMBIC_VERSIONS / "null_orphan_tpl_admission_confirmation_reminder.py"
+
+
+@pytest.fixture(scope="module")
+def migration_source() -> str:
+    assert MIGRATION_FILE.exists(), f"migration file missing: {MIGRATION_FILE}"
+    return MIGRATION_FILE.read_text(encoding="utf-8")
+
+
+def test_revision_id(migration_source: str) -> None:
+    assert re.search(
+        r'^revision: str = "null_orphan_admission_reminder_tpl"',
+        migration_source, re.M,
+    )
+
+
+def test_down_revision_chains_off_sl20260524_canonical(migration_source: str) -> None:
+    assert re.search(
+        r'down_revision[^=]*=\s*"sl20260524_canonical"',
+        migration_source,
+    )
+
+
+def test_upgrade_targets_exact_two_template_codes(migration_source: str) -> None:
+    """Predicate must match exactly the 2 known orphan codes — nothing else."""
+    upgrade = migration_source.split("def upgrade()")[1].split("def downgrade()")[0]
+    assert "'TPL_ADMISSION_CONFIRMATION_REMINDER_24H_V1'" in upgrade
+    assert "'TPL_ADMISSION_CONFIRMATION_REMINDER_6H_V1'" in upgrade
+    assert "template_code = NULL" in upgrade
+    # Scope guard — must not touch other tables or wider patterns
+    forbidden = ("LIKE", "%", "notification_rule", "notification_template", "DELETE")
+    for token in forbidden:
+        assert token not in upgrade, f"upgrade unexpectedly contains {token!r}"
+
+
+def test_downgrade_restores_both_codes_with_rule_id_scope(migration_source: str) -> None:
+    """Downgrade must use rule_id + channel scope (not blanket UPDATE)."""
+    downgrade = migration_source.split("def downgrade()")[1]
+    assert "rule_id = 51" in downgrade
+    assert "rule_id = 52" in downgrade
+    assert "channel = 'email'" in downgrade
+    assert "template_code IS NULL" in downgrade  # restore only NULL rows
+    assert "TPL_ADMISSION_CONFIRMATION_REMINDER_24H_V1" in downgrade
+    assert "TPL_ADMISSION_CONFIRMATION_REMINDER_6H_V1" in downgrade


### PR DESCRIPTION
## Scope — 5 fix nhỏ độc lập gom 1 PR, cùng họ "cleanup tech debt"

Bốn fix realtime dispatch + 1 fix seed schema drift. Cùng "cleanup tech debt" surface từ 2026-05-25 session triage (post combined deploy PR #332+#333+#334). 5 commits atomic, bisect-friendly.

| # | Commit | Item | Severity | Closes |
|---|---|---|---|---|
| 1 | `874790f3` | LEAD_RESTORED dispatch inconsistent (admin path) | P2 | task #42 |
| 2 | `79a596f1` | seed_from_xlsx admission_path 3-col schema drift | P2 | task #40 |
| 3 | `28fbc0ae` | NULL orphan TPL_ADMISSION_CONFIRMATION_REMINDER template_codes | P2 | task #37 |
| 4 | `35edeadf` | leads.py:801 NameError (lead → restored_lead) — sister of f14c4013 | **P1** (reviewer found) | latent crash on /leads/{id}/restore endpoint |
| 5 | `79001801` | seed round resolver pin to DOT_1 explicitly | P2 (reviewer found) | bug latent — earlier draft used start_date sort that picks DOT_2 wrongly |

---

## Commit 1 — `LEAD_RESTORED` dispatch (task #42)

### Bug
Hai API path restore soft-deleted lead nhưng chỉ 1 path emit realtime event:

| Path | Endpoint | Emit `LEAD_RESTORED`? |
|---|---|---|
| Detail page | `POST /leads/{id}/restore` (`leads.py:796`) | ✅ (sau commit 4 fix NameError) |
| Admin "Deleted Items" | `POST /admin/deleted-items/leads/{id}/restore` (`deleted_items.py:230`) | ❌ pre-fix |

### Hậu quả
Officer A có tab lead list mở. Manager B vào "Deleted Items" screen restore lead → Officer A không thấy lead xuất hiện lại đến khi reload page. UX inconsistency.

### Fix
Mirror exact pattern `leads.py:796-802` vào `deleted_items.py:230` ngay sau re-fetch lead row. Dùng `safe_dispatch` (post-commit) — match Backend `CLAUDE.md` notification dispatch convention.

---

## Commit 2 — `seed_from_xlsx` admission_path schema drift (task #40)

### Bug
Phase 2 PR-2C v2 (2026-05-10) đổi schema `admission_path`:
- `admission_round_id` → **NOT NULL**
- UNIQUE constraint: 2 cột → **3 cột** `(admission_round_id, academic_info_id, admission_method_id)`

Xlsx workbook sheet `16_DuongDanTuyenSinh` predates schema change. Headers verified 2026-05-25:
```
ma_nganh, hinh_thuc, nam_hoc, admission_method_code, criteria_code,
status, display_name, visibility, application_fee
```

Pre-fix INSERT fail 2 cách:
1. `NOT NULL violation on admission_round_id`
2. `ON CONFLICT (academic_info_id, admission_method_id)` → `InvalidColumnReferenceError`

### Hậu quả
- nightly-regression CI seed step fail (PR #332 verify rounds #5-#6)
- worktree bootstrap mới: same fail
- **Prod KHÔNG bị ảnh hưởng** (script seed không chạy prod)

### Fix (xem thêm Commit 5 cho round resolver fix)
Derive `admission_round_id` từ `nam_hoc`. INSERT bao gồm `admission_round_id`, ON CONFLICT đổi sang 3-col.

---

## Commit 3 — NULL orphan `TPL_ADMISSION_CONFIRMATION_REMINDER_*` (task #37)

### Bug
PR #327 cleanup_uppercase_orphan (2026-05-23) xóa UPPERCASE `notification_template` rows nhưng để lại 2 `notification_action` rows reference deleted codes.

Verified prod 2026-05-25 via SSH read-only:
```
id | rule_id | channel | template_code                              | event
92 |      51 | email   | TPL_ADMISSION_CONFIRMATION_REMINDER_24H_V1 | admission_confirmation_reminder_24h
94 |      52 | email   | TPL_ADMISSION_CONFIRMATION_REMINDER_6H_V1  | admission_confirmation_reminder_6h
```

### Hậu quả
Mỗi đêm celery-beat scan → dispatcher tìm template_code missing → log warning `"template_code not resolved, using rule defaults"` → fall back `base_snapshot`.

- User-facing: **LOW** (notification still sent)
- Log noise: **MEDIUM** (nightly warning spam)

### Fix
Migration `null_orphan_admission_reminder_tpl` (chains off `sl20260524_canonical`) NULL out `template_code` ở 2 rows. Predicate strict literal IN-list. Idempotent. Downgrade scoped restore.

Anchor test `test_null_orphan_tpl_admission_reminder_migration.py` (4 cases) lock revision id, chain link, exact 2-code scope, downgrade restore semantics.

---

## Commit 4 — leads.py:801 NameError (reviewer found, **P1**)

### Bug
Same NameError class như fix `f14c4013` ở PR #334 cho `lead_service.py:1713` — khác surface, cùng pattern swallow/crash.

Location: `app/routers/leads.py:801` trong endpoint `POST /leads/{id}/restore` (route handler line 786).

```python
rooms=rooms_for_lead(lead),
                     ^^^^
NameError: name 'lead' is not defined.
```

Endpoint signature có `lead_id: int` (Path), KHÔNG có `lead` object. Restored row bound là `restored_lead` từ `lead_service.restore_lead(...)`.

### Hậu quả
Khác với case `lead_service.py:1713` (bên trong `try/except` swallow), call này ở top-level endpoint body → real restore request **500 SAU `await db.commit()`** line 787, nghĩa là **DB row đã restored** nhưng response là error + LEAD_RESTORED event không emit. User-visible: confusing 500 + missing cross-session sync.

**Latent từ khi dispatch được add** — path này hiếm khi được exercise (restore qua admin "Deleted Items" path mà trước đó cũng không dispatch — fix ở commit 1 của batch này). Reviewer found 2026-05-25.

### Fix
`rooms_for_lead(lead)` → `rooms_for_lead(restored_lead)`. 1 line.

---

## Commit 5 — seed round resolver pin DOT_1 (reviewer found, **P2**)

### Bug (earlier draft của commit 2)
Earlier draft dùng:
```sql
SELECT id FROM offering_admission_round
WHERE academic_year = :year
ORDER BY start_date ASC NULLS LAST, id ASC LIMIT 1
```

**KHÔNG robust** với actual prod data shape:
- DOT_1 backfill row có `start_date = NULL`
- DOT_2 / DOT_3 có real `start_date`

`NULLS LAST` đẩy DOT_1 xuống CUỐI sort → trên DB có nhiều round, seed pick **DOT_2 thay vì DOT_1** → seeded `admission_path` rows attach sai round → mis-resolve `offering_admission_config` downstream.

### Fix (per reviewer)
Match contract layer `admission_path_service.get_default_dot1` convention — pin theo `round_code='DOT_1'`:
```sql
SELECT id FROM offering_admission_round
WHERE academic_year = :year AND round_code = 'DOT_1'
LIMIT 1
```

Nếu year chưa có DOT_1 → skip path (idempotent, giữ contract). Future round seeding (DOT_2/DOT_3) = admin workflow, không phải seed-script concern.

---

## Verification (đã chạy local theo user review)

| Check | Result |
|---|---|
| `git diff --check main...HEAD` | pass |
| `pytest tests/unit/test_null_orphan_tpl_admission_reminder_migration.py tests/integration/test_socket_scoping_contract.py -q` | **7 passed** |
| `pytest tests/unit/test_phase2_pr2c_three_col_unique.py -q` | 3 passed, 1 skipped |
| `pytest tests/unit/test_notification_payloads.py::TestLeadRestored -q` | 1 passed |
| `alembic heads` | `null_orphan_admission_reminder_tpl (head)` |
| Local SQL rollback dry-run | matched exactly rows 92, 94 |

PR gate sẽ verify đầy đủ (backend-test.yml + frontend-test.yml + deps).

---

## Prod safety

| Item | Risk |
|---|---|
| Commit 1 (admin LEAD_RESTORED) | LOW — additive realtime emit |
| Commit 2 (seed schema) | ZERO — script không chạy prod |
| Commit 3 (migration NULL 2 rows) | LOW — match exact 2 rows, idempotent, downgrade scoped |
| Commit 4 (leads.py NameError) | LOW — fix endpoint hiện đang 500 sau commit DB |
| Commit 5 (seed DOT_1) | ZERO — script không chạy prod |

### Rollback
- Commits 1, 4: revert → endpoint emit hành vi cũ. Risk ZERO.
- Commits 2, 5: revert → seed lại fail like before. Risk ZERO.
- Commit 3: `alembic downgrade -1` → restore 2 codes scoped. Risk LOW.

---

## Test plan
- [ ] PR gate (backend-test.yml + frontend-test.yml + deps) passes
- [ ] Anchor test `test_null_orphan_tpl_admission_reminder_migration.py` (4 cases) green in CI
- [ ] After merge: prod deploy executes migration (UPDATE 2 rows NULL)
- [ ] Post-deploy: SSH verify `SELECT template_code FROM notification_action WHERE id IN (92, 94)` → both NULL
- [ ] Post-deploy: monitor celery-beat log ~24h — confirm warning stops appearing
- [ ] After merge: nightly-regression next cron run seed step passes (admission_path INSERT works)
- [ ] After merge: `/leads/{id}/restore` endpoint smoke (manual hoặc Playwright) — confirm không 500

## Closes tasks
- #37 (orphan TPL templates) — via commit 3
- #40 (seed admission_path ON CONFLICT) — via commits 2 + 5
- #42 (LEAD_RESTORED inconsistent) — via commit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
