### PR TITLE
hotfix(migration): rename revision id ≤32 chars to fit alembic_version (prod deploy crash fix)

### DIFF
--- a/Backend_FastAPI/alembic/versions/null_orphan_tpl_admission_confirmation_reminder.py
+++ b/Backend_FastAPI/alembic/versions/null_orphan_tpl_admission_confirmation_reminder.py
@@ -42,16 +42,24 @@ Verified prod state 2026-05-25 via SSH read-only:
 Predicate is strict (full string match) per ``migration-predicate-safety``
 memory. Idempotent — re-run matches 0 rows.
 
-Revision ID: null_orphan_admission_reminder_tpl
+Revision ID: null_orphan_admin_reminder_tpl
 Revises: sl20260524_canonical
 Create Date: 2026-05-25
+
+⚠ HOTFIX 2026-05-25: revision id renamed từ
+``null_orphan_admission_reminder_tpl`` (34 chars) → ``null_orphan_admin_reminder_tpl``
+(30 chars) vì ``alembic_version.version_num`` là ``VARCHAR(32)`` →
+``StringDataRightTruncationError`` khi commit migration row. Deploy
+trước (PR #335 run 26396035967) đã auto-rollback từ Step 5 backup;
+prod alembic head giữ ở ``sl20260524_canonical``. Hotfix này rename
+revision + redeploy. Migration body unchanged.
 """
 from typing import Sequence, Union
 
 from alembic import op
 
 
-revision: str = "null_orphan_admission_reminder_tpl"
+revision: str = "null_orphan_admin_reminder_tpl"
 down_revision: Union[str, None] = "sl20260524_canonical"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/Backend_FastAPI/tests/unit/test_null_orphan_tpl_admission_reminder_migration.py
+++ b/Backend_FastAPI/tests/unit/test_null_orphan_tpl_admission_reminder_migration.py
@@ -29,8 +29,25 @@ def migration_source() -> str:
 
 def test_revision_id(migration_source: str) -> None:
     assert re.search(
-        r'^revision: str = "null_orphan_admission_reminder_tpl"',
+        r'^revision: str = "null_orphan_admin_reminder_tpl"',
         migration_source, re.M,
+    )
+
+
+def test_revision_id_within_alembic_version_column_limit(
+    migration_source: str,
+) -> None:
+    """``alembic_version.version_num`` is ``VARCHAR(32)`` — revision id
+    longer than 32 chars triggers ``StringDataRightTruncationError`` at
+    migration commit + auto-rollback. Lesson from prod deploy run
+    ``26396035967`` 2026-05-25: original id was 34 chars and crashed.
+    """
+    match = re.search(r'^revision: str = "([^"]+)"', migration_source, re.M)
+    assert match is not None, "revision id literal not found"
+    revision_value = match.group(1)
+    assert len(revision_value) <= 32, (
+        f"revision id {revision_value!r} is {len(revision_value)} chars; "
+        "alembic_version.version_num is VARCHAR(32)."
     )
 
 


### PR DESCRIPTION
## URGENT — prod state mismatch

PR #335 deploy run `26396035967` (2026-05-25 10:33 UTC) FAILED at Step 6 alembic upgrade head with::

  asyncpg.exceptions.StringDataRightTruncationError: value too long for type character varying(32)
  [SQL: UPDATE alembic_version SET version_num='null_orphan_admission_reminder_tpl' WHERE ...]

**Current prod state**:
- Code on disk: PR #335 merge SHA `ac3ea5c4`
- Containers: OLD PR #334 image (uptime 57 min, healthy)
- DB schema: rolled back to `sl20260524_canonical` (Step 6 auto-restore from Step 5 backup)
- **Risk**: next container restart (auto / manual / crash) triggers entrypoint `alembic upgrade head` → SAME crash → backend down

## Root cause

`alembic_version.version_num` is `VARCHAR(32)` (verified SSH `\d alembic_version` on prod 2026-05-25). Migration revision id `null_orphan_admission_reminder_tpl` = **34 chars** > 32.

The migration body itself (UPDATE 2 rows NULL template_code) succeeded — only the post-step `UPDATE alembic_version SET version_num=...` failed at the column constraint. Transaction rolled back, Step 6 auto-restored from `pre_deploy_TIMESTAMP.sql`.

## Fix

| Item | Change |
|---|---|
| `revision: str` | `null_orphan_admission_reminder_tpl` (34) → `null_orphan_admin_reminder_tpl` (30) |
| File name | unchanged (alembic doesn't care about file name length) |
| Migration body | unchanged (same UPDATE 2 rows NULL) |
| `down_revision` | unchanged (`sl20260524_canonical`) |
| Anchor test `test_revision_id` | updated to match new id |
| NEW anchor test `test_revision_id_within_alembic_version_column_limit` | asserts `len(revision) <= 32` — prevents repeat |

## Prod safety verified

- alembic head `sl20260524_canonical` ✅
- 8/8 containers Up healthy ✅
- /health 200 OK ✅
- SSH read-only confirmed VARCHAR(32) limit

## Deploy after merge

Migration body symmetric to prior attempt; only revision id renamed. Step 6 will:
1. Apply migration (same UPDATE 2 rows NULL)
2. Successfully commit `UPDATE alembic_version SET version_num='null_orphan_admin_reminder_tpl'` (30 chars fits)
3. Continue Step 7 + Step 8 rolling restart

If for any reason this fails again, same auto-rollback path exists (Step 5 backup).

## Test plan

- [ ] PR gate (backend-test.yml + frontend-test.yml + deps) passes
- [ ] Anchor tests (5 cases now, +1 length guard) green
- [ ] Admin merge URGENT — code/DB mismatch is timing bomb
- [ ] Approve env API → deploy runs Step 6 successfully
- [ ] Post-deploy: SSH verify `SELECT version_num FROM alembic_version` → `null_orphan_admin_reminder_tpl`
- [ ] Post-deploy: SSH verify `SELECT template_code FROM notification_action WHERE id IN (92, 94)` → both NULL

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>