### PR TITLE
feat(admission): round contract hardening — create-profile + path-create REQUIRED round (plan v4 Gap #1)

### DIFF
--- a/Backend_FastAPI/app/repositories/admission_path_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_path_repository.py
@@ -176,39 +176,10 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
         result = await self.db.execute(query)
         return list(result.scalars().all())
     
-    async def get_path_by_offering_and_method(
-        self,
-        academic_info_id: int,
-        admission_method_id: int
-    ) -> Optional[AdmissionPath]:
-        """
-        Check if a path already exists for this offering + method combination.
-
-        Used for unique constraint validation and profile creation.
-
-        ✅ FIX: Eager load admission_method to prevent MissingGreenlet error
-        when service code accesses admission_path.admission_method.status.
-
-        Phase 3 close-out 2026-05-14: also eager-load ``admission_round`` so
-        ``admission_service.create_profile`` can read
-        ``admission_path.admission_round.allow_multi_nv`` without a separate
-        SELECT when deciding ``new_profile.uses_choice_engine``. Adds one
-        IN-clause query (selectinload), not a JOIN — keeps the existing
-        FOR UPDATE-friendly shape used by callers.
-        """
-        query = (
-            select(AdmissionPath)
-            .where(
-                AdmissionPath.academic_info_id == academic_info_id,
-                AdmissionPath.admission_method_id == admission_method_id
-            )
-            .options(
-                selectinload(AdmissionPath.admission_method),  # ← FIX: Eager load
-                selectinload(AdmissionPath.admission_round),   # Phase 3 close-out
-            )
-        )
-        result = await self.db.execute(query)
-        return result.scalars().first()
+    # get_path_by_offering_and_method (2-col) removed — round contract
+    # hardening (plan v4): create_profile now binds via the 3-col
+    # get_path_by_round_and_method below; the 2-col lookup + ``.first()``
+    # (which silently picked an arbitrary round) had no remaining caller.
 
     async def get_path_by_round_and_method(
         self,
@@ -227,8 +198,8 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
         reads ``admission_path.admission_round.allow_multi_nv`` for the
         ``uses_choice_engine`` decision without a lazy load (MissingGreenlet
         in async context) or a separate SELECT. Adds one IN-clause query
-        (selectinload), not a JOIN — mirrors the eager-load shape of
-        ``get_path_by_offering_and_method``.
+        (selectinload), not a JOIN — keeps the FOR UPDATE-friendly shape
+        used by callers.
         """
         query = (
             select(AdmissionPath)

--- a/Backend_FastAPI/app/repositories/admission_path_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_path_repository.py
@@ -96,6 +96,9 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
                 .selectinload(OfferingAcademicInfo.offering)
                 .selectinload(ProgramOffering.program),
                 selectinload(AdmissionPath.admission_method),
+                # Round contract hardening (plan v4 Section D) — flat round
+                # metadata in build_path_response.
+                selectinload(AdmissionPath.admission_round),
                 selectinload(AdmissionPath.activator),
                 selectinload(AdmissionPath.criteria).selectinload(
                     AdmissionCriteria.subject_group_mappings
@@ -125,6 +128,8 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
                 .selectinload(OfferingAcademicInfo.offering)
                 .selectinload(ProgramOffering.program),
                 selectinload(AdmissionPath.admission_method),
+                # Round contract hardening (plan v4 Section D).
+                selectinload(AdmissionPath.admission_round),
                 selectinload(AdmissionPath.activator),
                 selectinload(AdmissionPath.criteria).selectinload(
                     AdmissionCriteria.subject_group_mappings
@@ -159,6 +164,8 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
                 .selectinload(OfferingAcademicInfo.offering)
                 .selectinload(ProgramOffering.program),
                 selectinload(AdmissionPath.admission_method),
+                # Round contract hardening (plan v4 Section D).
+                selectinload(AdmissionPath.admission_round),
                 selectinload(AdmissionPath.activator),
                 selectinload(AdmissionPath.criteria).selectinload(
                     AdmissionCriteria.subject_group_mappings
@@ -214,6 +221,14 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
         Returns matching path under (round, academic_info, method) tuple
         per Q5 v8.2 UNIQUE constraint (PR-2C v2 swap). Eager loads
         admission_method để tránh MissingGreenlet downstream.
+
+        Round contract hardening (plan v4 Section A, 2026-05-25): also
+        eager-load ``admission_round`` so ``admission_service.create_profile``
+        reads ``admission_path.admission_round.allow_multi_nv`` for the
+        ``uses_choice_engine`` decision without a lazy load (MissingGreenlet
+        in async context) or a separate SELECT. Adds one IN-clause query
+        (selectinload), not a JOIN — mirrors the eager-load shape of
+        ``get_path_by_offering_and_method``.
         """
         query = (
             select(AdmissionPath)
@@ -222,7 +237,10 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
                 AdmissionPath.academic_info_id == academic_info_id,
                 AdmissionPath.admission_method_id == admission_method_id,
             )
-            .options(selectinload(AdmissionPath.admission_method))
+            .options(
+                selectinload(AdmissionPath.admission_method),
+                selectinload(AdmissionPath.admission_round),
+            )
         )
         result = await self.db.execute(query)
         return result.scalars().first()
@@ -358,6 +376,9 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
                 .selectinload(OfferingAcademicInfo.offering)
                 .selectinload(ProgramOffering.program),
                 selectinload(AdmissionPath.admission_method),
+                # Round contract hardening (plan v4 Section D) — round
+                # metadata drives the officer create-page round dropdown.
+                selectinload(AdmissionPath.admission_round),
                 # Eager load criteria with subject groups (for LeadApplicationForm)
                 selectinload(AdmissionPath.criteria).selectinload(
                     AdmissionCriteria.subject_group_mappings

--- a/Backend_FastAPI/app/repositories/admission_round_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_round_repository.py
@@ -29,21 +29,11 @@ class AdmissionRoundRepository:
         )
         return list(result.scalars().all())
 
-    async def get_default_dot1(
-        self, academic_year: int
-    ) -> Optional[OfferingAdmissionRound]:
-        """Service shim auto-resolve target — used by PR-2B v2
-        ``create_admission_path`` when caller omits round_id.
-
-        Q1 v8.2 year-level lookup: 1 DOT_1 row per academic_year (cho cả trường).
-        """
-        result = await self.db.execute(
-            select(OfferingAdmissionRound).where(
-                OfferingAdmissionRound.academic_year == academic_year,
-                OfferingAdmissionRound.round_code == "DOT_1",
-            )
-        )
-        return result.scalar_one_or_none()
+    # get_default_dot1() removed (round contract hardening, plan v4
+    # Section B, 2026-05-25). It only ever served the auto-resolve DOT_1
+    # shim in admission_path_service.create_path, which is now removed —
+    # admission_round_id is REQUIRED. Path-create always binds an explicit
+    # round. (seed_from_xlsx.py derives DOT_1 via its own raw SQL.)
 
     async def get_by_year_and_code(
         self, academic_year: int, round_code: str

--- a/Backend_FastAPI/app/routers/admission_paths.py
+++ b/Backend_FastAPI/app/routers/admission_paths.py
@@ -105,6 +105,20 @@ async def build_path_response(
     """
     response = AdmissionPathResponse.model_validate(path)
     response.criteria = build_criteria_nested(path)
+    # Round contract hardening (plan v4 Section D — Finding #3): populate
+    # flat round metadata from the eager-loaded ``admission_round``
+    # relationship. ``__dict__.get`` avoids triggering a lazy load
+    # (MissingGreenlet in async context) when a query didn't eager-load the
+    # relationship — the flat fields then stay None (schema default).
+    _round = path.__dict__.get("admission_round")
+    if _round is not None:
+        response.round_code = _round.round_code
+        response.round_name = _round.round_name
+        response.round_start_date = _round.start_date
+        response.round_end_date = _round.end_date
+        response.round_archived_at = _round.archived_at
+        response.round_is_active = _round.is_active
+        response.round_allow_multi_nv = _round.allow_multi_nv
     response.available_actions = service.compute_available_actions(path, current_user)
     response.can_edit = service.compute_can_edit(path, current_user)
     response.can_activate = await service.compute_can_activate(path, current_user)

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -285,12 +285,12 @@ async def create_admission_profile(
         profile = await admission_service.create_profile(
             db=db,
             lead_id=data.lead_id,
-            admission_method_id=data.admission_method_id,  # NEW: Required for AdmissionPath lookup
+            admission_method_id=data.admission_method_id,  # Required for AdmissionPath lookup
+            admission_round_id=data.admission_round_id,  # Round contract hardening (plan v4)
             current_user=current_user,
-            # ADM-017: forward optional academic_year. Service binds to
-            # the specific (offering, year) OfferingAcademicInfo when
-            # provided; falls back to first-published when omitted
-            # (legacy contract for backward-compat during FE rollout).
+            # Round contract hardening (plan v4): academic_year is now
+            # REQUIRED — the service validates the selected round belongs
+            # to this year (no first-published / current_intake fallback).
             academic_year=data.academic_year,
         )
 

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -417,23 +417,37 @@ class AdmissionProfileCreate(BaseModel):
         gt=0,
         description="Admission method ID (required for AdmissionPath lookup)"
     )
-    # ADM-017: client SHOULD pass academic_year so the service binds
-    # the profile to a specific OfferingAcademicInfo row deterministically.
-    # Optional in this BE phase for backward compatibility — if omitted,
-    # the service falls back to "first published academic_info for the
-    # offering" (legacy behaviour). A follow-up PR will add the FE field
-    # and flip this to required. See memory ``project_admission_audit_2026-04-27_wave_status``
-    # (Q8=b decision) and the ADM-017 ship note.
-    academic_year: Optional[int] = Field(
-        default=None,
+    # Round contract hardening (plan v4 Section A, 2026-05-25): the
+    # admission round is now REQUIRED. AdmissionPath is identified by the
+    # 3-col UNIQUE (admission_round_id, academic_info_id, admission_method_id),
+    # so binding the profile needs an explicit round — the old 2-col
+    # ``.first()`` lookup silently picked an arbitrary round (DOT_1 vs
+    # DOT_2) when both existed for the same (offering, year, method).
+    admission_round_id: int = Field(
+        ...,
+        gt=0,
+        description=(
+            "Admission round ID (REQUIRED). Binds the profile to the exact "
+            "(round, offering, method) AdmissionPath. Validated server-side: "
+            "must exist, match academic_year, be active and not archived."
+        ),
+    )
+    # Round contract hardening (plan v4): academic_year is now REQUIRED.
+    # The legacy "first published OfferingAcademicInfo" fallback and the
+    # ``current_intake_year`` race-check fallback have both been removed
+    # from ``create_profile``, so the year must be explicit to validate
+    # the selected round (round.academic_year == academic_year)
+    # deterministically. FE already always sends academic_year (ADM-017).
+    academic_year: int = Field(
+        ...,
         ge=2000,
         le=2100,
         description=(
-            "Academic year for the profile (e.g., 2026). Service "
-            "validates a published OfferingAcademicInfo row exists "
-            "for ``(lead.offering_id, academic_year)``; if omitted, "
-            "falls back to the offering's first published year."
-        )
+            "Academic year for the profile (e.g., 2026). Service validates "
+            "a published OfferingAcademicInfo row exists for "
+            "``(lead.offering_id, academic_year)`` AND that "
+            "admission_round_id belongs to this year."
+        ),
     )
 
     model_config = ConfigDict(str_strip_whitespace=True)

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -201,14 +201,20 @@ class AdmissionPathCreate(BaseModel):
     """Request schema for creating a new AdmissionPath."""
     academic_info_id: int
     admission_method_id: int
-    # Phase 2 v8.2 PR-2B v2 — optional admission_round_id; nếu None,
-    # service layer auto-resolve DOT_1 của academic_info's year (year-
-    # level lookup, Option A). NOT NULL post PR-2C v2 swap.
-    admission_round_id: Optional[int] = Field(
-        default=None,
+    # Round contract hardening (plan v4 Section B, 2026-05-25):
+    # admission_round_id is now REQUIRED. The auto-resolve DOT_1 shim is
+    # removed from the service, so omitting the round now 422s here rather
+    # than silently binding the path to DOT_1. The service still validates
+    # the explicit round (exists + same year + active + not archived).
+    admission_round_id: int = Field(
+        ...,
+        gt=0,
         description=(
-            "Round FK. NULL = auto-resolve DOT_1 của academic_info's "
-            "academic_year tại service layer."
+            "Round FK (REQUIRED). Path identity is the 3-col UNIQUE "
+            "(admission_round_id, academic_info_id, admission_method_id); "
+            "the service validates the round exists, matches academic_info's "
+            "year, is active and not archived. FE wizard/quick-create must "
+            "always send it."
         ),
     )
     round_quota: Optional[int] = Field(
@@ -434,6 +440,38 @@ class AdmissionPathResponse(BaseModel):
     submission_count: int = Field(
         default=0,
         description="Atomic submission counter; incremented on profile create.",
+    )
+
+    # Round contract hardening (plan v4 Section D — Finding #3): flat round
+    # metadata, eager-loaded via ``admission_round`` on the common response
+    # queries and populated in ``build_path_response``. FLAT (not a nested
+    # ``round`` object) + default None: ``model_validate(path)`` would touch
+    # an unloaded lazy relationship on endpoints that don't eager-load →
+    # MissingGreenlet; flat + default None is safe (Pydantic uses the
+    # default when the attribute is absent). The officer create page derives
+    # its round dropdown from these fields on the for-offering paths.
+    round_code: Optional[str] = Field(
+        default=None, description="Round code (e.g. DOT_1). NULL if not loaded."
+    )
+    round_name: Optional[str] = Field(
+        default=None, description="Round display name (e.g. 'Đợt 1 - 2026')."
+    )
+    round_start_date: Optional[date] = Field(
+        default=None, description="Round window start (date-only). NULL allowed."
+    )
+    round_end_date: Optional[date] = Field(
+        default=None, description="Round window end (date-only). NULL allowed."
+    )
+    round_archived_at: Optional[datetime] = Field(
+        default=None,
+        description="Round soft-archive marker (tz-aware). NULL = not archived.",
+    )
+    round_is_active: Optional[bool] = Field(
+        default=None, description="Round active flag. NULL if not loaded."
+    )
+    round_allow_multi_nv: Optional[bool] = Field(
+        default=None,
+        description="Round multi-NV (Phase 3 choice engine) flag.",
     )
 
     # Application Fee

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -148,20 +148,23 @@ class AdmissionPathService:
         """
         Create a new AdmissionPath.
 
-        Phase 2 v8.2 PR-2B v2: auto-resolve DOT_1 shim. If
-        ``data.admission_round_id`` is None, lookup DOT_1 của
-        academic_info's academic_year (year-level Option A). Validate
-        Tier 1 chain trên admit_quota change.
+        Round contract hardening (plan v4 Section B, 2026-05-25):
+        ``data.admission_round_id`` is REQUIRED (the auto-resolve DOT_1
+        shim is removed). The explicit round is validated: must exist,
+        match academic_info's academic_year, be active and not archived.
+        Tier 1/2 quota chain validated on admit_quota/round_quota change.
 
         Raises:
-            DuplicateResourceError: If path already exists for offering + method
-            BusinessRuleViolation: Tier 1 chain violated, Tier 2 invariant violated, or DOT_1 not found
+            ResourceNotFoundError: academic_info or round not found
+            DuplicateResourceError: path already exists for (round, acad, method)
+            BusinessRuleViolation: round archived/inactive/cross-year, or Tier 1/2 violated
         """
-        # Phase 2 v8.2 PR-2B v2 — auto-resolve admission_round_id.
-        # PR-2C v2 đã ship 3-col UNIQUE (round, acad, method); duplicate check
-        # bên dưới dùng 3-col helper tương ứng.
-        # Pass 2 hard-review BM-4: lookup academic_info upfront (cả 2 nhánh
-        # auto-resolve + explicit cần academic_year cho cross-check).
+        # Round contract hardening (plan v4 Section B) — admission_round_id
+        # is REQUIRED (schema enforces gt=0); always validate the explicit
+        # round. PR-2C v2 ships the 3-col UNIQUE (round, acad, method);
+        # duplicate check below uses the matching 3-col helper.
+        # Pass 2 hard-review BM-4: lookup academic_info upfront (need
+        # academic_year for the round cross-check).
         from app.models.offering_academic_info import OfferingAcademicInfo
 
         academic_info = await self.db.get(
@@ -173,68 +176,54 @@ class AdmissionPathService:
             )
 
         admission_round_id = data.admission_round_id
-        if admission_round_id is None:
-            from app.repositories.admission_round_repository import (
-                AdmissionRoundRepository,
+        # Pre-validate explicit round_id exists để tránh IntegrityError
+        # bùng FK constraint mid-INSERT (no response → CORS error ở FE).
+        from app.models.offering_admission_round import (
+            OfferingAdmissionRound,
+        )
+        round_obj = await self.db.get(
+            OfferingAdmissionRound, admission_round_id
+        )
+        if round_obj is None:
+            raise ResourceNotFoundError(
+                f"OfferingAdmissionRound {admission_round_id} not found"
             )
-            round_repo = AdmissionRoundRepository(self.db)
-            default_round = await round_repo.get_default_dot1(
-                academic_info.academic_year
+        # Pass 2 hard-review B-2-1: chặn tạo path trên round đã archive.
+        # Path tạo trên archived round = inert path (không activate được vì
+        # validate_activation cũng chặn) → wasted DB row + admin confusion.
+        # Catch sớm tại create để FE hiển thị error message thân thiện.
+        if round_obj.archived_at is not None:
+            raise BusinessRuleViolation(
+                f"Đợt tuyển sinh '{round_obj.round_code}' đã lưu trữ "
+                f"({round_obj.archived_at.date().isoformat()}); "
+                f"khôi phục đợt trước khi tạo đường tuyển sinh."
             )
-            if default_round is None:
-                raise BusinessRuleViolation(
-                    f"DOT_1 round không tồn tại cho năm "
-                    f"{academic_info.academic_year}; admin tạo round trước "
-                    f"hoặc truyền explicit admission_round_id."
-                )
-            admission_round_id = default_round.id
-            log.info(
-                "admission_path_create_auto_resolved_round",
-                academic_info_id=data.academic_info_id,
-                academic_year=academic_info.academic_year,
-                resolved_round_id=admission_round_id,
-                auto_resolved=True,
+        # Round contract hardening (plan v4 Section B): also block creating
+        # a path on an inactive round. Like archived rounds, an inactive
+        # round yields an inert path; reject early for a friendly message
+        # instead of letting an unusable path accumulate.
+        if not round_obj.is_active:
+            raise BusinessRuleViolation(
+                f"Đợt tuyển sinh '{round_obj.round_code}' đang tạm dừng "
+                f"(inactive); kích hoạt lại đợt trước khi tạo đường tuyển sinh."
             )
-        else:
-            # Pre-validate explicit round_id exists để tránh IntegrityError
-            # bùng FK constraint mid-INSERT (no response → CORS error ở FE).
-            from app.models.offering_admission_round import (
-                OfferingAdmissionRound,
+        # Pass 2 hard-review BM-4: cross-check academic_year giữa round
+        # và academic_info. Round là year-level (Q1 Option A); tạo path
+        # với round năm 2025 trên academic_info năm 2026 = cross-year
+        # configuration sai semantic, reporting "Đợt 1 năm X" sẽ confuse.
+        if round_obj.academic_year != academic_info.academic_year:
+            raise BusinessRuleViolation(
+                f"Đợt tuyển sinh '{round_obj.round_code}' thuộc năm "
+                f"{round_obj.academic_year}, không khớp năm "
+                f"{academic_info.academic_year} của ngành. Chọn đợt "
+                f"cùng năm với ngành."
             )
-            round_obj = await self.db.get(
-                OfferingAdmissionRound, admission_round_id
-            )
-            if round_obj is None:
-                raise ResourceNotFoundError(
-                    f"OfferingAdmissionRound {admission_round_id} not found"
-                )
-            # Pass 2 hard-review B-2-1: chặn tạo path trên round đã archive.
-            # Path tạo trên archived round = inert path (không activate được vì
-            # validate_activation cũng chặn) → wasted DB row + admin confusion.
-            # Catch sớm tại create để FE hiển thị error message thân thiện.
-            if round_obj.archived_at is not None:
-                raise BusinessRuleViolation(
-                    f"Đợt tuyển sinh '{round_obj.round_code}' đã lưu trữ "
-                    f"({round_obj.archived_at.date().isoformat()}); "
-                    f"khôi phục đợt trước khi tạo đường tuyển sinh."
-                )
-            # Pass 2 hard-review BM-4: cross-check academic_year giữa round
-            # và academic_info. Round là year-level (Q1 Option A); tạo path
-            # với round năm 2025 trên academic_info năm 2026 = cross-year
-            # configuration sai semantic, reporting "Đợt 1 năm X" sẽ confuse.
-            if round_obj.academic_year != academic_info.academic_year:
-                raise BusinessRuleViolation(
-                    f"Đợt tuyển sinh '{round_obj.round_code}' thuộc năm "
-                    f"{round_obj.academic_year}, không khớp năm "
-                    f"{academic_info.academic_year} của ngành. Chọn đợt "
-                    f"cùng năm với ngành."
-                )
-            log.debug(
-                "admission_path_create_explicit_round",
-                academic_info_id=data.academic_info_id,
-                round_id=admission_round_id,
-                auto_resolved=False,
-            )
+        log.debug(
+            "admission_path_create_explicit_round",
+            academic_info_id=data.academic_info_id,
+            round_id=admission_round_id,
+            auto_resolved=False,
+        )
 
         # Tier 1+2 chain validation — admit_quota Tier 1 chain check
         # if admit_quota provided; Tier 2 invariant check both fields.

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2855,9 +2855,10 @@ def _merge_subject_weights(admission_path) -> Dict[str, float]:
 async def create_profile(
     db: AsyncSession,
     lead_id: int,
-    admission_method_id: int,  # NEW: Required parameter for relational lookup
+    admission_method_id: int,  # Required for relational AdmissionPath lookup
+    admission_round_id: int,  # Round contract hardening (plan v4) — REQUIRED
     current_user: models.User,
-    academic_year: Optional[int] = None,
+    academic_year: int,  # Round contract hardening (plan v4) — REQUIRED
 ) -> models.AdmissionProfile:
     """
     Create new AdmissionProfile for a Lead.
@@ -2951,27 +2952,19 @@ async def create_profile(
         # race-safe check must scope to the target year. Using the
         # deprecated ``get_profile_by_lead_id`` (which returns the latest
         # year regardless) would falsely block creating a profile for
-        # year N+1 when the lead has a profile for year N. Scope to the
-        # requested ``academic_year`` (or current_intake_year fallback,
-        # mirroring eligibility check at line 2497) so multi-year
-        # creates work as intended by the composite UNIQUE swap.
-        race_check_year = academic_year
-        if race_check_year is None:
-            from app.services.system_config_service import SystemConfigService
-
-            cfg_year = await SystemConfigService(db).get_value(
-                "current_intake_year", 2026
-            )
-            race_check_year = (
-                int(cfg_year) if isinstance(cfg_year, str) else cfg_year
-            )
+        # year N+1 when the lead has a profile for year N.
+        #
+        # Round contract hardening (plan v4, 2026-05-25 — F30): academic_year
+        # is now a REQUIRED parameter, so the race-safe check scopes directly
+        # to it. The old ``current_intake_year`` SystemConfig fallback (used
+        # when academic_year was Optional/None) is removed.
         existing_profile = await admission_repo.get_profile_by_lead_year(
-            lead_id, race_check_year
+            lead_id, academic_year
         )
         if existing_profile:
             raise ConflictError(
                 f"Lead {lead_id} already has an admission profile for "
-                f"academic year {race_check_year}"
+                f"academic year {academic_year}"
             )
 
     # Lead-level eligibility gate (SINGLE SOURCE OF TRUTH shared with GET /leads/{id}).
@@ -3019,91 +3012,133 @@ async def create_profile(
             f"Program offering {lead.offering_id} not found"
         )
 
-    # Step 6: Get published OfferingAcademicInfo for this offering.
+    # Step 6: Get published OfferingAcademicInfo for the (offering, year).
     #
-    # ADM-017: when ``academic_year`` is provided, bind to the
-    # specific (offering, year) row and require it to be published.
-    # When omitted (legacy callers), fall back to "first published"
-    # — same behaviour as before, with a deprecation warning so we
-    # can track FE rollout. After all callers pass academic_year,
-    # a follow-up PR removes this fallback and flips the schema
-    # field to required.
+    # Round contract hardening (plan v4, 2026-05-25 — F30): academic_year
+    # is now REQUIRED, so we always bind to the specific (offering, year)
+    # row and require it to be published. The legacy "first published"
+    # fallback (the old ``else`` branch when academic_year was None) is
+    # removed — a deterministic year is needed to validate the selected
+    # round below (round.academic_year == academic_year).
     academic_info_list = await org_repo.get_academic_info_history(
         lead.offering_id,
         published_only=False,
     )
 
-    if academic_year is not None:
-        academic_info = next(
-            (
-                info
-                for info in academic_info_list
-                if info.academic_year == academic_year
-            ),
-            None,
-        )
-        if not academic_info:
-            log.warning(
-                "No academic info found for offering+academic_year",
-                offering_id=lead.offering_id,
-                academic_year=academic_year,
-            )
-            raise BadRequest(
-                f"Không tìm thấy năm học {academic_year} cho chương trình "
-                f"này (offering {lead.offering_id}). Vui lòng kiểm tra "
-                "cấu hình năm học hoặc chọn năm khác."
-            )
-        if not academic_info.is_published:
-            log.warning(
-                "academic_year requested but not published",
-                offering_id=lead.offering_id,
-                academic_year=academic_year,
-                academic_info_id=academic_info.id,
-            )
-            raise BadRequest(
-                f"Năm học {academic_year} của chương trình này chưa "
-                "được công bố tuyển sinh. Vui lòng chọn năm khác hoặc "
-                "liên hệ admin để công bố."
-            )
-    else:
-        # Legacy fallback — first published, else first row of history.
-        log.warning(
-            "create_profile called without academic_year (deprecated). "
-            "Falling back to first published OfferingAcademicInfo. "
-            "FE callers should migrate to passing academic_year.",
-            lead_id=lead_id,
-            offering_id=lead.offering_id,
-        )
-        academic_info = next(
-            (info for info in academic_info_list if info.is_published),
-            academic_info_list[0] if academic_info_list else None,
-        )
-
+    academic_info = next(
+        (
+            info
+            for info in academic_info_list
+            if info.academic_year == academic_year
+        ),
+        None,
+    )
     if not academic_info:
         log.warning(
-            "No academic info found for offering",
+            "No academic info found for offering+academic_year",
             offering_id=lead.offering_id,
+            academic_year=academic_year,
         )
         raise BadRequest(
-            f"No published academic info found for offering {lead.offering_id}. "
-            "Please configure academic year info before creating profiles."
+            f"Không tìm thấy năm học {academic_year} cho chương trình "
+            f"này (offering {lead.offering_id}). Vui lòng kiểm tra "
+            "cấu hình năm học hoặc chọn năm khác."
+        )
+    if not academic_info.is_published:
+        log.warning(
+            "academic_year requested but not published",
+            offering_id=lead.offering_id,
+            academic_year=academic_year,
+            academic_info_id=academic_info.id,
+        )
+        raise BadRequest(
+            f"Năm học {academic_year} của chương trình này chưa "
+            "được công bố tuyển sinh. Vui lòng chọn năm khác hoặc "
+            "liên hệ admin để công bố."
         )
 
-    # Step 7: Find AdmissionPath for this offering + method (NEW: Relational)
-    admission_path = await path_repo.get_path_by_offering_and_method(
+    # Step 6b: Validate the explicitly-selected admission round.
+    #
+    # Round contract hardening (plan v4 Section A): the round is now
+    # REQUIRED + validated up front, BEFORE building applied_rules, so the
+    # 3-col path lookup binds the profile to the exact (round, offering,
+    # method) tuple — no silent fallback to DOT_1 via ``.first()``.
+    # Validate (in order): exists → matches the requested academic_year →
+    # active → not archived. INSERT happens later so this runs before the
+    # applied_rules immutability trigger ever sees the row (F46 — safe).
+    from app.repositories.admission_round_repository import (
+        AdmissionRoundRepository,
+    )
+
+    round_repo = AdmissionRoundRepository(db)
+    admission_round = await round_repo.get_by_id(admission_round_id)
+    if admission_round is None:
+        log.warning(
+            "Admission round not found",
+            admission_round_id=admission_round_id,
+            lead_id=lead_id,
+        )
+        raise BadRequest(
+            f"Đợt tuyển sinh (round_id={admission_round_id}) không tồn tại."
+        )
+    if admission_round.academic_year != academic_year:
+        log.warning(
+            "Admission round academic_year mismatch",
+            admission_round_id=admission_round_id,
+            round_year=admission_round.academic_year,
+            requested_year=academic_year,
+        )
+        raise BadRequest(
+            f"Đợt tuyển sinh '{admission_round.round_code}' thuộc năm "
+            f"{admission_round.academic_year}, không khớp năm {academic_year} "
+            "đã chọn. Vui lòng chọn đợt đúng năm."
+        )
+    if not admission_round.is_active:
+        log.warning(
+            "Admission round is inactive",
+            admission_round_id=admission_round_id,
+        )
+        raise BadRequest(
+            f"Đợt tuyển sinh '{admission_round.round_code}' đang tạm dừng "
+            "(inactive). Vui lòng chọn đợt khác."
+        )
+    if admission_round.archived_at is not None:
+        log.warning(
+            "Admission round is archived",
+            admission_round_id=admission_round_id,
+            archived_at=str(admission_round.archived_at),
+        )
+        raise BadRequest(
+            f"Đợt tuyển sinh '{admission_round.round_code}' đã lưu trữ. "
+            "Vui lòng chọn đợt khác."
+        )
+
+    # Step 7: Find AdmissionPath for this (round, offering, method).
+    #
+    # Round contract hardening (plan v4 Section A): 3-col lookup replaces
+    # the old 2-col ``get_path_by_offering_and_method`` + ``.first()``,
+    # which silently picked an arbitrary round (DOT_1 vs DOT_2) when both
+    # existed for the same (offering, year, method). The helper eager-loads
+    # admission_round so ``uses_choice_engine`` below reads
+    # ``allow_multi_nv`` deterministically.
+    admission_path = await path_repo.get_path_by_round_and_method(
+        admission_round_id=admission_round_id,
         academic_info_id=academic_info.id,
-        admission_method_id=admission_method_id
+        admission_method_id=admission_method_id,
     )
 
     if not admission_path:
         log.warning(
-            "No admission path configured for offering + method",
+            "No admission path configured for round + offering + method",
+            admission_round_id=admission_round_id,
             academic_info_id=academic_info.id,
             admission_method_id=admission_method_id,
         )
         raise BadRequest(
-            f"No admission path configured for this offering and method (method_id={admission_method_id}). "
-            "Please configure admission paths in the Config Console before creating profiles."
+            f"Không có đường tuyển sinh (path) cấu hình cho đợt "
+            f"'{admission_round.round_code}', năm {academic_year}, "
+            f"phương thức (method_id={admission_method_id}). Vui lòng cấu "
+            "hình đường tuyển sinh ở Admission Config trước khi tạo hồ sơ."
         )
 
     # ✅ FIX Finding 1.2: Check if Admission Method is Active
@@ -3111,7 +3146,7 @@ async def create_profile(
     # Assuming path.admission_method is eager loaded in repository or exists
     # If not loaded, we rely on the repository ensuring it returns valid paths,
     # but explicit check is safer.
-    # Since get_path_by_offering_and_method likely joins admission_method, we check here.
+    # Since get_path_by_round_and_method eager-loads admission_method, we check here.
     if admission_path.admission_method and not admission_path.admission_method.is_active:
          log.warning(
             "Attempt to create profile with inactive admission method",

--- a/Backend_FastAPI/app/services/path_clone_service.py
+++ b/Backend_FastAPI/app/services/path_clone_service.py
@@ -93,6 +93,19 @@ class PathCloneService:
                 "source_round_id và target_round_id phải khác nhau"
             )
 
+        # Round contract hardening (plan v4 Section C — Finding #4): block
+        # cloning INTO an archived or inactive target round. Cloned paths
+        # would be inert (create_path + validate_activation also reject such
+        # rounds) and only confuse admins. The SOURCE round may be in any
+        # state — we copy its config forward — but the destination must be
+        # usable.
+        if target_round.archived_at is not None or not target_round.is_active:
+            raise BusinessRuleViolation(
+                f"Không thể clone đường tuyển sinh vào đợt "
+                f"'{target_round.round_code}' đã lưu trữ hoặc đang tạm dừng. "
+                "Chọn đợt đích đang hoạt động."
+            )
+
         # Eager-load source paths với criteria + criteria_subject_group +
         # path_subject_group_configs + items
         stmt = (

--- a/Backend_FastAPI/tests/api/test_admission_assign_officer_permission.py
+++ b/Backend_FastAPI/tests/api/test_admission_assign_officer_permission.py
@@ -68,7 +68,7 @@ async def adm_config(seed_lead_dependencies: dict):
                 status="active", display_name="Test", display_order=0, visibility="public",
             )
             s.add(ap); await s.flush()
-    return {"unit_id": uid, "offering_id": po.id, "method_id": am.id}
+    return {"unit_id": uid, "offering_id": po.id, "method_id": am.id, "round_id": round_id}
 
 
 async def _login(client: AsyncClient, username: str, password: str) -> dict:
@@ -121,6 +121,8 @@ async def test_assign_officer_action_role_matrix(
     prof = await client.post(ADMISSIONS, json={
         "lead_id": lead_id,
         "admission_method_id": adm_config["method_id"],
+        "admission_round_id": adm_config["round_id"],
+        "academic_year": 2026,
     }, headers=admin_token_headers)
     assert prof.status_code in (200, 201), prof.text
     pid = prof.json()["id"]
@@ -189,6 +191,8 @@ async def test_bulk_assign_rejects_non_officer_target(
     prof = (await client.post(ADMISSIONS, json={
         "lead_id": lead["id"],
         "admission_method_id": adm_config["method_id"],
+        "admission_round_id": adm_config["round_id"],
+        "academic_year": 2026,
     }, headers=admin_token_headers)).json()
 
     # Attempt to assign the manager (not an officer) → 400.

--- a/Backend_FastAPI/tests/api/test_admission_create_academic_year.py
+++ b/Backend_FastAPI/tests/api/test_admission_create_academic_year.py
@@ -2,15 +2,13 @@
 ``OfferingAcademicInfo`` row when client passes ``academic_year``.
 
 Q8=b decision (memory ``project_admission_audit_2026-04-27_wave_status``):
-client must pass academic_year on profile creation. This BE phase
-makes the field optional for backward compat — strict-required will
-flip in a follow-up after FE catches up — but **when passed it must
-be honoured strictly**: lookup the matching
-``(offering_id, academic_year)`` ``OfferingAcademicInfo`` row, reject
-if not found, reject if not published.
-
-When ``academic_year`` is omitted, fall back to "first published" so
-legacy FE callers don't break mid-rollout.
+client must pass academic_year on profile creation. Round contract
+hardening (plan v4 — F30) FLIPPED the field to strict-required and
+REMOVED the "first published" fallback: ``academic_year`` (and
+``admission_round_id``) are now mandatory. When passed they are honoured
+strictly — lookup the matching ``(offering_id, academic_year)``
+``OfferingAcademicInfo`` row, reject if not found / not published, and
+validate the round belongs to that year (active, not archived).
 """
 from __future__ import annotations
 
@@ -162,6 +160,10 @@ async def multi_year_offering(seed_lead_dependencies: dict):
         "academic_info_2025_id": ai_2025.id,
         "academic_info_2026_id": ai_2026.id,
         "academic_info_2027_id": ai_2027.id,
+        # Round contract hardening (plan v4): expose the per-year DOT_1
+        # rounds so create-profile can pass the now-required admission_round_id.
+        "round_2025_id": round_2025_id,
+        "round_2026_id": round_2026_id,
     }
 
 
@@ -201,10 +203,13 @@ async def _create_profile_request(
     lead_id: int,
     method_id: int,
     academic_year: Optional[int] = None,
+    admission_round_id: Optional[int] = None,
 ):
     body: dict = {"lead_id": lead_id, "admission_method_id": method_id}
     if academic_year is not None:
         body["academic_year"] = academic_year
+    if admission_round_id is not None:
+        body["admission_round_id"] = admission_round_id
     return await client.post(ADMISSIONS, json=body, headers=headers)
 
 
@@ -230,6 +235,7 @@ async def test_create_profile_binds_to_explicit_academic_year(
         lead_id,
         multi_year_offering["method_id"],
         academic_year=2025,
+        admission_round_id=multi_year_offering["round_2025_id"],
     )
     assert resp.status_code in (200, 201), resp.text
     body = resp.json()
@@ -267,6 +273,10 @@ async def test_create_profile_rejects_unknown_academic_year(
         lead_id,
         multi_year_offering["method_id"],
         academic_year=2099,
+        # Pass a valid round; the academic_info lookup for year 2099 fails
+        # FIRST (Step 6) with a 400 mentioning 2099, before the round
+        # validation (Step 6b) is ever reached.
+        admission_round_id=multi_year_offering["round_2025_id"],
     )
     assert resp.status_code == 400, resp.text
     body = resp.json()
@@ -293,6 +303,9 @@ async def test_create_profile_rejects_unpublished_academic_year(
         lead_id,
         multi_year_offering["method_id"],
         academic_year=2027,
+        # Valid round; the published-check on year 2027 (Step 6) fails
+        # before round validation (Step 6b).
+        admission_round_id=multi_year_offering["round_2025_id"],
     )
     assert resp.status_code == 400, resp.text
     body = resp.json()
@@ -303,33 +316,71 @@ async def test_create_profile_rejects_unpublished_academic_year(
 
 
 @pytest.mark.asyncio
-async def test_create_profile_legacy_callers_still_work_without_year(
+async def test_create_profile_requires_academic_year_and_round(
     client: AsyncClient,
     admin_token_headers: dict,
     officer_user_in_db: dict,
     multi_year_offering: dict,
 ):
-    """Backward compat: omitting ``academic_year`` falls back to the
-    first published OfferingAcademicInfo. FE callers that haven't
-    been updated yet must keep working — the strict-required flip
-    happens in a follow-up after FE catches up.
+    """Round contract hardening (plan v4 — F30): the legacy "omit
+    academic_year → first published" fallback is REMOVED. ``academic_year``
+    and ``admission_round_id`` are now both REQUIRED; a round whose year
+    doesn't match is rejected. The first three probes fail validation (no
+    profile written), so the happy path on the same lead still succeeds.
     """
     lead_id = await _seed_lead(
-        client, admin_token_headers, officer_user_in_db, multi_year_offering, "legacy"
+        client, admin_token_headers, officer_user_in_db, multi_year_offering, "strict"
     )
 
-    resp = await _create_profile_request(
+    # Missing academic_year → 422 (Pydantic required field; no fallback).
+    resp_no_year = await _create_profile_request(
         client,
         admin_token_headers,
         lead_id,
         multi_year_offering["method_id"],
-        academic_year=None,  # omitted
+        academic_year=None,
+        admission_round_id=multi_year_offering["round_2026_id"],
     )
-    assert resp.status_code in (200, 201), resp.text
-    body = resp.json()
-    # First published academic_info — order from get_academic_info_history
-    # is implementation-defined; we just assert the result is one of the
-    # two published years (2025 / 2026), NOT the unpublished 2027.
-    assert body["academic_year"] in (2025, 2026), (
-        f"Legacy fallback bound to unexpected year {body['academic_year']}"
+    assert resp_no_year.status_code == 422, resp_no_year.text
+
+    # Missing admission_round_id → 422.
+    resp_no_round = await _create_profile_request(
+        client,
+        admin_token_headers,
+        lead_id,
+        multi_year_offering["method_id"],
+        academic_year=2026,
+        admission_round_id=None,
+    )
+    assert resp_no_round.status_code == 422, resp_no_round.text
+
+    # Round whose year (2025) doesn't match academic_year (2026) → 400.
+    resp_mismatch = await _create_profile_request(
+        client,
+        admin_token_headers,
+        lead_id,
+        multi_year_offering["method_id"],
+        academic_year=2026,
+        admission_round_id=multi_year_offering["round_2025_id"],
+    )
+    assert resp_mismatch.status_code == 400, resp_mismatch.text
+    assert "không khớp" in resp_mismatch.json().get("detail", ""), resp_mismatch.text
+
+    # Both present + matching → 201, bound to the explicit (year, round).
+    resp_ok = await _create_profile_request(
+        client,
+        admin_token_headers,
+        lead_id,
+        multi_year_offering["method_id"],
+        academic_year=2026,
+        admission_round_id=multi_year_offering["round_2026_id"],
+    )
+    assert resp_ok.status_code in (200, 201), resp_ok.text
+    body = resp_ok.json()
+    assert body["academic_year"] == 2026
+    applied = body.get("applied_rules") or {}
+    assert applied.get("admission_round_id") == multi_year_offering["round_2026_id"], (
+        f"applied_rules.admission_round_id mismatch: got "
+        f"{applied.get('admission_round_id')}, expected "
+        f"{multi_year_offering['round_2026_id']}"
     )

--- a/Backend_FastAPI/tests/api/test_admission_doc_mutations_response_parity.py
+++ b/Backend_FastAPI/tests/api/test_admission_doc_mutations_response_parity.py
@@ -131,6 +131,8 @@ async def parity_config(seed_lead_dependencies: dict):
         "method_id": am.id,
         "upload_doc_code": dt_upload.code,
         "paper_doc_code": dt_paper.code,
+        # Round contract hardening (plan v4): now-required admission_round_id.
+        "round_id": round_id,
     }
 
 
@@ -153,6 +155,8 @@ async def _create_profile(client, admin_token_headers, officer_user_in_db, cfg, 
     prof = (await client.post(ADMISSIONS, json={
         "lead_id": lead["id"],
         "admission_method_id": cfg["method_id"],
+        "admission_round_id": cfg["round_id"],
+        "academic_year": 2026,
     }, headers=admin_token_headers)).json()
     return prof
 

--- a/Backend_FastAPI/tests/api/test_admission_doc_realtime_emit.py
+++ b/Backend_FastAPI/tests/api/test_admission_doc_realtime_emit.py
@@ -163,6 +163,8 @@ async def realtime_config(seed_lead_dependencies: dict):
         "method_id": am.id,
         "upload_doc_code": dt_upload.code,
         "paper_doc_code": dt_paper.code,
+        # Round contract hardening (plan v4): now-required admission_round_id.
+        "round_id": round_id,
     }
 
 
@@ -199,6 +201,8 @@ async def _create_profile(client, admin_token_headers, officer_user_in_db, cfg, 
             json={
                 "lead_id": lead["id"],
                 "admission_method_id": cfg["method_id"],
+                "admission_round_id": cfg["round_id"],
+                "academic_year": 2026,
             },
             headers=admin_token_headers,
         )

--- a/Backend_FastAPI/tests/api/test_admission_document_permissions.py
+++ b/Backend_FastAPI/tests/api/test_admission_document_permissions.py
@@ -94,7 +94,7 @@ async def doc_perm_config(seed_lead_dependencies: dict):
                 display_order=1,
             )
             s.add(dgi); await s.flush()
-    return {"unit_id": uid, "offering_id": po.id, "method_id": am.id}
+    return {"unit_id": uid, "offering_id": po.id, "method_id": am.id, "round_id": round_id}
 
 
 async def _create_profile(client, admin_token_headers, officer_user_in_db, cfg):
@@ -115,6 +115,8 @@ async def _create_profile(client, admin_token_headers, officer_user_in_db, cfg):
     prof = (await client.post(ADMISSIONS, json={
         "lead_id": lead["id"],
         "admission_method_id": cfg["method_id"],
+        "admission_round_id": cfg["round_id"],
+        "academic_year": 2026,
     }, headers=admin_token_headers)).json()
     return prof
 

--- a/Backend_FastAPI/tests/api/test_admission_submit_requires_verified_docs.py
+++ b/Backend_FastAPI/tests/api/test_admission_submit_requires_verified_docs.py
@@ -120,6 +120,9 @@ async def strict_path_config(seed_lead_dependencies: dict):
         "method_id": am.id,
         "path_id": ap.id,
         "doc_code": dt.code,
+        # Round contract hardening (plan v4): expose seeded round for the
+        # now-required admission_round_id on create-profile.
+        "round_id": round_id,
     }
 
 
@@ -148,6 +151,8 @@ async def _create_draft(client, admin_token_headers, officer_user_in_db, cfg, *,
     prof_resp = await client.post(ADMISSIONS, json={
         "lead_id": lead["id"],
         "admission_method_id": cfg["method_id"],
+        "admission_round_id": cfg["round_id"],
+        "academic_year": 2026,
     }, headers=admin_token_headers)
     assert prof_resp.status_code in (200, 201), (
         f"Create profile failed ({prof_resp.status_code}): {prof_resp.text}\n"

--- a/Backend_FastAPI/tests/api/test_admission_workflow_api.py
+++ b/Backend_FastAPI/tests/api/test_admission_workflow_api.py
@@ -73,6 +73,8 @@ async def _submit(
     lead_id: int,
     method_id: int,
     *,
+    admission_round_id: int,
+    academic_year: int = 2026,
     school_id: int | None = None,
 ) -> dict:
     """Add consultation + create profile + fill + upload docs + submit.
@@ -91,7 +93,12 @@ async def _submit(
         "status_id": status_id, "method": "phone", "notes": "Pre-admission consultation",
     }, headers=h)
 
-    r = await client.post(ADMISSIONS, json={"lead_id": lead_id, "admission_method_id": method_id}, headers=h)
+    r = await client.post(ADMISSIONS, json={
+        "lead_id": lead_id,
+        "admission_method_id": method_id,
+        "admission_round_id": admission_round_id,
+        "academic_year": academic_year,
+    }, headers=h)
     assert r.status_code in [200, 201], f"Create: {r.text}"
     p = r.json()
     pid, v = p["id"], p["version"]
@@ -313,6 +320,10 @@ async def adm_config(seed_lead_dependencies: dict):
         "offering_id": po.id,
         "method_id": am.id,
         "school_id": school_id,
+        # Round contract hardening (plan v4): create-profile now requires
+        # admission_round_id; expose the seeded DOT_1 round so _submit can
+        # thread it into the POST payload.
+        "round_id": round_id,
     }
 
 
@@ -335,7 +346,7 @@ async def adm_lead(client: AsyncClient, admin_token_headers: dict, officer_user_
 @pytest.mark.asyncio
 async def test_submit_approve_override_finalize_enrolled(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     assert p["status"] == "submitted"
     pid = p["id"]
 
@@ -358,7 +369,7 @@ async def test_submit_approve_override_finalize_enrolled(client, officer_user_in
 @pytest.mark.asyncio
 async def test_submit_reject_resubmit_revision_resubmit_approve(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     pid = p["id"]
 
     ah = await _admin(client); v = await _ver(client, ah, pid)
@@ -380,7 +391,7 @@ async def test_submit_reject_resubmit_revision_resubmit_approve(client, officer_
 @pytest.mark.asyncio
 async def test_finalize_from_approved_returns_400(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     pid = p["id"]
 
     ah = await _admin(client); v = await _ver(client, ah, pid)
@@ -396,7 +407,7 @@ async def test_finalize_from_approved_returns_400(client, officer_user_in_db, ad
 @pytest.mark.asyncio
 async def test_officer_cannot_approve(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     oh = await _officer(client, officer_user_in_db); v = await _ver(client, oh, p["id"])
     assert (await client.post(ACT(p["id"], "approve"), json={"notes": "No", "version": v}, headers=oh)).status_code == 403
 
@@ -404,7 +415,7 @@ async def test_officer_cannot_approve(client, officer_user_in_db, adm_lead, adm_
 @pytest.mark.asyncio
 async def test_officer_cannot_request_revision(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     oh = await _officer(client, officer_user_in_db); v = await _ver(client, oh, p["id"])
     assert (await client.post(ACT(p["id"], "request-revision"), json={"reason": "Officer trying revision test reason", "version": v}, headers=oh)).status_code == 403
 
@@ -412,7 +423,7 @@ async def test_officer_cannot_request_revision(client, officer_user_in_db, adm_l
 @pytest.mark.asyncio
 async def test_officer_cannot_override(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
     await client.post(ACT(p["id"], "approve"), json={"notes": "OK", "version": v}, headers=ah)
     oh = await _officer(client, officer_user_in_db); v = await _ver(client, oh, p["id"])
@@ -422,7 +433,7 @@ async def test_officer_cannot_override(client, officer_user_in_db, adm_lead, adm
 @pytest.mark.asyncio
 async def test_officer_cannot_finalize(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
     await client.post(ACT(p["id"], "approve"), json={"notes": "OK", "version": v}, headers=ah)
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
@@ -435,7 +446,7 @@ async def test_officer_cannot_finalize(client, officer_user_in_db, adm_lead, adm
 async def test_approve_stale_version(client, officer_user_in_db, adm_lead, adm_config):
     """Approve with stale version returns 409 (ConflictError)."""
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     ah = await _admin(client); stale = await _ver(client, ah, p["id"])
     # Reject to change version while keeping profile in a state where approve is valid later
     await client.post(ACT(p["id"], "reject"), json={"reason": "Reject to bump version for test", "version": stale}, headers=ah)
@@ -451,7 +462,7 @@ async def test_approve_stale_version(client, officer_user_in_db, adm_lead, adm_c
 @pytest.mark.asyncio
 async def test_request_revision_stale_version(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     # Get stale version at submitted state
     ah = await _admin(client); stale = await _ver(client, ah, p["id"])
     # Reject to change version (submitted → rejected is valid)
@@ -468,7 +479,7 @@ async def test_request_revision_stale_version(client, officer_user_in_db, adm_le
 @pytest.mark.asyncio
 async def test_resubmit_stale_version(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     # Reject first
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
     await client.post(ACT(p["id"], "reject"), json={"reason": "Documents insufficient for admission", "version": v}, headers=ah)
@@ -488,7 +499,7 @@ async def test_resubmit_stale_version(client, officer_user_in_db, adm_lead, adm_
 @pytest.mark.asyncio
 async def test_drop_stale_version(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     await _fast_enroll(client, p["id"])
     ah = await _admin(client); stale = await _ver(client, ah, p["id"])
     async with AsyncSessionLocal() as s:
@@ -503,7 +514,7 @@ async def test_drop_stale_version(client, officer_user_in_db, adm_lead, adm_conf
 @pytest.mark.asyncio
 async def test_drop_enrolled_sets_is_dropped(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     await _fast_enroll(client, p["id"])
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
     r = await client.post(ACT(p["id"], "drop"), json={"reason": "Student left for personal reasons text", "version": v}, headers=ah)
@@ -516,7 +527,7 @@ async def test_drop_enrolled_sets_is_dropped(client, officer_user_in_db, adm_lea
 @pytest.mark.asyncio
 async def test_drop_before_enrolled_returns_400(client, officer_user_in_db, adm_lead, adm_config):
     oh = await _officer(client, officer_user_in_db)
-    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], school_id=adm_config["school_id"])
+    p = await _submit(client, oh, adm_lead["id"], adm_config["method_id"], admission_round_id=adm_config["round_id"], school_id=adm_config["school_id"])
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
     await client.post(ACT(p["id"], "approve"), json={"notes": "OK", "version": v}, headers=ah)
     ah = await _admin(client); v = await _ver(client, ah, p["id"])

--- a/Backend_FastAPI/tests/api/test_admissions_minor_correction.py
+++ b/Backend_FastAPI/tests/api/test_admissions_minor_correction.py
@@ -91,6 +91,7 @@ async def adm_config(seed_lead_dependencies: dict):
         "offering_id": po.id,
         "method_id": am.id,
         "path_id": path_id,
+        "round_id": round_id,
     }
 
 
@@ -181,6 +182,8 @@ async def _create_seed_profile(
     prof = await client.post(ADMISSIONS, json={
         "lead_id": lead_id,
         "admission_method_id": adm_config["method_id"],
+        "admission_round_id": adm_config["round_id"],
+        "academic_year": 2026,
     }, headers=admin_token_headers)
     assert prof.status_code in (200, 201), prof.text
     return prof.json()["id"], lead_id
@@ -811,6 +814,12 @@ async def test_admission_path_create_persists_allowlist_for_admin(
                 requires_gpa=True, requires_subject_scores=False, is_active=True,
             )
             s.add(am); await s.flush()
+            # Round contract hardening (plan v4): path-create now requires
+            # admission_round_id (auto-DOT_1 shim removed).
+            from tests.fixtures.builders import AdmissionRoundBuilder
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                s, academic_year=2026
+            )
             ai_id = ai.id
             am_id = am.id
 
@@ -819,6 +828,7 @@ async def test_admission_path_create_persists_allowlist_for_admin(
         json={
             "academic_info_id": ai_id,
             "admission_method_id": am_id,
+            "admission_round_id": round_id,
             "display_name": "AllowlistOnCreate",
             "display_order": 1,
             "visibility": "internal",

--- a/Backend_FastAPI/tests/api/test_admissions_partial_update_invariants.py
+++ b/Backend_FastAPI/tests/api/test_admissions_partial_update_invariants.py
@@ -81,6 +81,7 @@ async def adm_config(seed_lead_dependencies: dict):
         "unit_id": uid,
         "offering_id": po.id,
         "method_id": am.id,
+        "round_id": round_id,
     }
 
 
@@ -119,6 +120,8 @@ async def _create_draft_profile(
     prof = await client.post(ADMISSIONS, json={
         "lead_id": lead_id,
         "admission_method_id": adm_config["method_id"],
+        "admission_round_id": adm_config["round_id"],
+        "academic_year": 2026,
     }, headers=admin_token_headers)
     assert prof.status_code in (200, 201), prof.text
     return prof.json()["id"]

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -162,6 +162,8 @@ async def fee_calc_config(seed_lead_dependencies: dict):
         "offering_id": po.id,
         "method_id": am.id,
         "school_id": school_id,
+        # Round contract hardening (plan v4): now-required admission_round_id.
+        "round_id": round_id,
     }
 
 
@@ -194,6 +196,8 @@ async def _create_approved_profile(
     prof = (await client.post(ADMISSIONS, json={
         "lead_id": lead["id"],
         "admission_method_id": cfg["method_id"],
+        "admission_round_id": cfg["round_id"],
+        "academic_year": 2026,
     }, headers=admin_headers)).json()
 
     # Minimal fill so submit passes validation (PR #6 lax mode → only docs).
@@ -315,6 +319,8 @@ async def test_calculate_fee_hidden_for_officer_on_draft(
     prof = (await client.post(ADMISSIONS, json={
         "lead_id": lead["id"],
         "admission_method_id": fee_calc_config["method_id"],
+        "admission_round_id": fee_calc_config["round_id"],
+        "academic_year": 2026,
     }, headers=admin_token_headers)).json()
 
     oh = await _login(client, officer_user_in_db["username"], officer_user_in_db["password"])

--- a/Backend_FastAPI/tests/integration/test_admission_audit.py
+++ b/Backend_FastAPI/tests/integration/test_admission_audit.py
@@ -334,6 +334,9 @@ async def setup_admission_api_data(
         "lead_id": lead.id,
         "admission_method_id": method.id,
         "offering_id": offering.id,
+        # Round contract hardening (plan v4): now-required round + year.
+        "admission_round_id": round_id,
+        "academic_year": academic_info.academic_year,
     }
 
 
@@ -370,6 +373,8 @@ class TestCreateProfileAudit:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )

--- a/Backend_FastAPI/tests/services/test_admission_service.py
+++ b/Backend_FastAPI/tests/services/test_admission_service.py
@@ -167,6 +167,10 @@ async def setup_admission_api_data(
         "offering_id": offering.id,
         "academic_info_id": academic_info.id,
         "criteria_id": criteria.id,
+        # Round contract hardening (plan v4): expose the seeded round + year
+        # so create-profile callers can pass the now-required fields.
+        "admission_round_id": round_id,
+        "academic_year": academic_info.academic_year,
     }
 
 
@@ -286,6 +290,8 @@ class TestCreateProfile:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )
@@ -296,15 +302,17 @@ class TestCreateProfile:
         # Verify academic_year was snapshotted
         assert result["academic_year"] == 2026, f"Expected 2026, got {result['academic_year']}"
 
-    async def test_create_profile_fallback_to_current_year(
+    async def test_create_profile_binds_to_current_year_when_passed(
         self,
         client: AsyncClient,
         officer_user_in_db: dict,
         seed_lead_dependencies: dict,
     ):
         """
-        When offering has no published academic info for future year,
-        academic_year should fallback to current year.
+        Round contract hardening (plan v4 — F30): the legacy "omit
+        academic_year → fallback to current year" behaviour is REMOVED.
+        Passing the current year explicitly binds the profile to it (no
+        implicit fallback).
         """
         unit_id = seed_lead_dependencies["unit_id"]
         major_id = seed_lead_dependencies["major_program_id"]
@@ -325,6 +333,8 @@ class TestCreateProfile:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )
@@ -360,6 +370,11 @@ class TestCreateProfile:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": 99999,  # Non-existent method
+                # Round contract hardening: pass valid round+year so the
+                # request clears Pydantic and the service runs → the method
+                # lookup fails with 400 (not a 422 masking the real path).
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )
@@ -408,7 +423,7 @@ class TestUpdateProfileCitizenId:
         # Create profile 1
         response1 = await client.post(
             "/api/admissions",
-            json={"lead_id": data1["lead_id"], "admission_method_id": data1["admission_method_id"]},
+            json={"lead_id": data1["lead_id"], "admission_method_id": data1["admission_method_id"], "admission_round_id": data1["admission_round_id"], "academic_year": data1["academic_year"]},
             headers=headers,
         )
         assert response1.status_code == 201, f"Create 1 failed: {response1.text}"
@@ -424,7 +439,7 @@ class TestUpdateProfileCitizenId:
         # Create profile 2
         response2 = await client.post(
             "/api/admissions",
-            json={"lead_id": data2["lead_id"], "admission_method_id": data2["admission_method_id"]},
+            json={"lead_id": data2["lead_id"], "admission_method_id": data2["admission_method_id"], "admission_round_id": data2["admission_round_id"], "academic_year": data2["academic_year"]},
             headers=headers,
         )
         assert response2.status_code == 201, f"Create 2 failed: {response2.text}"
@@ -491,6 +506,8 @@ class TestUpdateProfileLazyLoadRegression:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )
@@ -565,6 +582,8 @@ class TestUpdateProfileLazyLoadRegression:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )
@@ -633,6 +652,8 @@ class TestUpdateProfileDocumentsInResponse:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )
@@ -1108,6 +1129,8 @@ class TestAutoAssignOfficer:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )
@@ -1182,6 +1205,8 @@ async def _create_profile_with_state(
         json={
             "lead_id": data["lead_id"],
             "admission_method_id": data["admission_method_id"],
+            "admission_round_id": data["admission_round_id"],
+            "academic_year": data["academic_year"],
         },
         headers=headers,
     )
@@ -1676,6 +1701,8 @@ class TestCreateProfileResponseFields:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )
@@ -1711,6 +1738,8 @@ class TestCreateProfileResponseFields:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )

--- a/Backend_FastAPI/tests/services/test_admission_service_strict.py
+++ b/Backend_FastAPI/tests/services/test_admission_service_strict.py
@@ -118,6 +118,9 @@ async def setup_admission_api_data(
         "lead_id": lead.id,
         "admission_method_id": method.id,
         "offering_id": offering.id,
+        # Round contract hardening (plan v4): now-required round + year.
+        "admission_round_id": round_id,
+        "academic_year": academic_info.academic_year,
     }
 
 
@@ -154,6 +157,8 @@ class TestStrictAdmissionCompliance:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )
@@ -199,6 +204,8 @@ class TestStrictAdmissionCompliance:
             json={
                 "lead_id": data["lead_id"],
                 "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
             },
             headers=headers,
         )

--- a/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
+++ b/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
@@ -95,22 +95,20 @@ async def path_seed(seed_lead_dependencies: dict) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_create_path_auto_resolves_dot1_when_round_id_null(
+async def test_create_path_rejects_null_round_id(
     path_seed: dict,
 ):
-    """Service auto-resolve DOT_1 của academic_info's year khi
-    admission_round_id None (Option A year-level lookup)."""
-    async with AsyncSessionLocal() as s:
-        admin = await s.get(models.User, path_seed["admin_id"])
-        svc = AdmissionPathService(s)
-        data = AdmissionPathCreate(
+    """Round contract hardening (plan v4 Section B): the auto-resolve DOT_1
+    shim is removed — admission_round_id is REQUIRED, so omitting it (None)
+    is rejected by Pydantic at AdmissionPathCreate construction time."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        AdmissionPathCreate(
             academic_info_id=path_seed["academic_info_id"],
             admission_method_id=path_seed["method_id"],
-            admission_round_id=None,  # auto-resolve
+            admission_round_id=None,
         )
-        path, _cb = await svc.create_path(data, admin)
-        await s.commit()
-        assert path.admission_round_id == path_seed["round_id"]
 
 
 @pytest.mark.asyncio
@@ -132,62 +130,11 @@ async def test_create_path_uses_explicit_round_id_when_provided(
         assert path.admission_round_id == path_seed["round_id"]
 
 
-@pytest.mark.asyncio
-async def test_create_path_raises_when_no_dot1_for_year(
-    seed_lead_dependencies: dict,
-):
-    """Service raise BusinessRuleViolation nếu không có DOT_1 round
-    cho academic_info's year."""
-    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
-    async with AsyncSessionLocal() as s:
-        async with s.begin():
-            from app.security import get_password_hash
-            admin = models.User(
-                username=f"admin_no_{ts}",
-                email=f"admin_no_{ts}@test.local",
-                full_name="Test",
-                password_hash=get_password_hash("test"),
-                role="admin",
-                status="active",
-            )
-            s.add(admin)
-            await s.flush()
-            offering = models.ProgramOffering(
-                program_id=seed_lead_dependencies["major_program_id"],
-                offering_type="full_time",
-                duration_semesters=8,
-            )
-            s.add(offering)
-            await s.flush()
-            # Year 2099 — KHÔNG có DOT_1 seeded
-            ai = models.OfferingAcademicInfo(
-                offering_id=offering.id,
-                academic_year=2099,
-                annual_admission_quota=10,
-                tuition_fee_per_year=1_000_000,
-            )
-            s.add(ai)
-            await s.flush()
-            method = models.AdmissionMethod(
-                code=f"M_{ts}",
-                name=f"Method {ts}",
-                requires_subject_scores=True,
-                is_active=True,
-            )
-            s.add(method)
-            await s.flush()
-            ai_id, method_id, admin_id = ai.id, method.id, admin.id
-
-    async with AsyncSessionLocal() as s:
-        admin = await s.get(models.User, admin_id)
-        svc = AdmissionPathService(s)
-        data = AdmissionPathCreate(
-            academic_info_id=ai_id,
-            admission_method_id=method_id,
-            admission_round_id=None,
-        )
-        with pytest.raises(BusinessRuleViolation, match="DOT_1 round không tồn tại"):
-            await svc.create_path(data, admin)
+# test_create_path_raises_when_no_dot1_for_year removed — round contract
+# hardening (plan v4 Section B): the "no DOT_1 → auto-resolve fails" path is
+# gone (admission_round_id is REQUIRED, never auto-resolved). The explicit
+# non-existent-round → ResourceNotFoundError contract is covered by
+# test_create_path_raises_when_round_not_found below (BUG #6 anchor).
 
 
 @pytest.mark.asyncio
@@ -388,6 +335,7 @@ async def test_create_profile_snapshot_includes_admission_round_id(
                 db=s,
                 lead_id=lead_id,
                 admission_method_id=method_id,
+                admission_round_id=path_seed["round_id"],
                 current_user=admin,
                 academic_year=2026,
             )

--- a/Backend_FastAPI/tests/services/test_phase2_admission_round_service.py
+++ b/Backend_FastAPI/tests/services/test_phase2_admission_round_service.py
@@ -6,7 +6,6 @@ Covers:
 * Bulk-create atomic per academic_year (Q1 v8.2)
 * Concern γ v6 — soft-archive admin discretion
 * Concern A v4 — extend writes audit fields
-* Repository ``get_default_dot1(academic_year)`` helper
 
 Anchor tests per memory pattern-change-impact-audit (P3-2 v8.2).
 """
@@ -20,7 +19,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models
 from app.database import AsyncSessionLocal
-from app.repositories.admission_round_repository import AdmissionRoundRepository
 from app.schemas.admission_round import (
     AdmissionRoundBulkCreate,
     AdmissionRoundBulkCreateItem,
@@ -362,33 +360,9 @@ async def test_round_extend_rejects_earlier_or_same_date(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_admission_round_repository_get_default_dot1(
-    round_test_seed: dict,
-) -> None:
-    """Service shim auto-resolve target — used by PR-2B v2
-    create_admission_path khi caller omits round_id (year-level lookup)."""
-    async with AsyncSessionLocal() as db:
-        admin = await _get_admin(db, round_test_seed["admin_user_id"])
-        service = AdmissionRoundService(db)
-        await service.create(
-            2026,
-            AdmissionRoundCreate(round_code="DOT_1", round_name="Đợt 1 - 2026"),
-            admin,
-        )
-        await service.create(
-            2026,
-            AdmissionRoundCreate(round_code="DOT_2", round_name="Đợt 2 - 2026"),
-            admin,
-        )
-        await db.commit()
-
-    async with AsyncSessionLocal() as db:
-        repo = AdmissionRoundRepository(db)
-        dot1 = await repo.get_default_dot1(academic_year=2026)
-        assert dot1 is not None
-        assert dot1.round_code == "DOT_1"
-        assert dot1.academic_year == 2026
+# test_admission_round_repository_get_default_dot1 removed — round contract
+# hardening (plan v4 Section B): the get_default_dot1 helper is deleted along
+# with the create_path auto-resolve DOT_1 shim it was the only caller for.
 
 
 @pytest.mark.asyncio

--- a/Backend_FastAPI/tests/services/test_phase2_pr2d_path_clone_service.py
+++ b/Backend_FastAPI/tests/services/test_phase2_pr2d_path_clone_service.py
@@ -307,3 +307,75 @@ async def test_clone_skip_existing_does_not_corrupt_session(
         "Iter sau khi skip phải clone OK — nếu MissingGreenlet thì test fail "
         "với exception khác. Pre-check pattern không phá session state."
     )
+
+
+# ---------------------------------------------------------------------------
+# Round contract hardening (plan v4 Section C — Finding #4) — clone guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clone_rejects_archived_target_round(clone_seed: dict):
+    """ANCHOR F40: cloning INTO an archived round → BusinessRuleViolation.
+
+    Seeds a REAL archived target round (not a mock) and asserts the guard
+    fires before any path is copied — cloned paths would be inert (the round
+    can't activate them) so the destination must be usable.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            archived_round = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"AR{ts}"[:20],
+                round_name=f"Archived {ts}",
+                is_active=True,
+                archived_at=datetime.now(timezone.utc),
+            )
+            s.add(archived_round)
+            await s.flush()
+            archived_id = archived_round.id
+
+    async with AsyncSessionLocal() as s:
+        svc = PathCloneService(s)
+        with pytest.raises(
+            BusinessRuleViolation, match="lưu trữ hoặc đang tạm dừng"
+        ):
+            await svc.clone_paths_from_round(
+                target_round_id=archived_id,
+                source_round_id=clone_seed["source_round_id"],
+                payload=ClonePathsRequest(),
+            )
+
+
+@pytest.mark.asyncio
+async def test_clone_rejects_inactive_target_round(clone_seed: dict):
+    """ANCHOR F40: cloning INTO an inactive round → BusinessRuleViolation.
+
+    Companion to the archived-round anchor; covers the ``not is_active``
+    branch of the same guard.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            inactive_round = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"IR{ts}"[:20],
+                round_name=f"Inactive {ts}",
+                is_active=False,
+                archived_at=None,
+            )
+            s.add(inactive_round)
+            await s.flush()
+            inactive_id = inactive_round.id
+
+    async with AsyncSessionLocal() as s:
+        svc = PathCloneService(s)
+        with pytest.raises(
+            BusinessRuleViolation, match="lưu trữ hoặc đang tạm dừng"
+        ):
+            await svc.clone_paths_from_round(
+                target_round_id=inactive_id,
+                source_round_id=clone_seed["source_round_id"],
+                payload=ClonePathsRequest(),
+            )

--- a/Backend_FastAPI/tests/services/test_phase3_create_profile_inherits_multi_nv.py
+++ b/Backend_FastAPI/tests/services/test_phase3_create_profile_inherits_multi_nv.py
@@ -191,6 +191,7 @@ async def test_create_profile_inherits_multi_nv_true_when_round_enabled(
             db=s,
             lead_id=seed_round_path_lead["lead_id"],
             admission_method_id=seed_round_path_lead["admission_method_id"],
+            admission_round_id=seed_round_path_lead["round_id"],
             current_user=admin,
             academic_year=seed_round_path_lead["academic_year"],
         )
@@ -227,6 +228,7 @@ async def test_create_profile_inherits_multi_nv_false_when_round_legacy(
             db=s,
             lead_id=seed_round_path_lead["lead_id"],
             admission_method_id=seed_round_path_lead["admission_method_id"],
+            admission_round_id=seed_round_path_lead["round_id"],
             current_user=admin,
             academic_year=seed_round_path_lead["academic_year"],
         )
@@ -259,6 +261,7 @@ async def test_submit_blocked_when_multi_nv_profile_has_no_choices(
             db=s,
             lead_id=seed_round_path_lead["lead_id"],
             admission_method_id=seed_round_path_lead["admission_method_id"],
+            admission_round_id=seed_round_path_lead["round_id"],
             current_user=admin,
             academic_year=seed_round_path_lead["academic_year"],
         )

--- a/Backend_FastAPI/tests/services/test_phase3_create_profile_inherits_multi_nv.py
+++ b/Backend_FastAPI/tests/services/test_phase3_create_profile_inherits_multi_nv.py
@@ -283,3 +283,168 @@ async def test_submit_blocked_when_multi_nv_profile_has_no_choices(
         f"Submit guard message should mention 'nguyện vọng'; "
         f"got: {exc_info.value!s}"
     )
+
+
+# ---------------------------------------------------------------------
+# Anchor 4 — 3-col lookup binds to the EXACT round among two sharing
+# (offering, year, method). Round contract hardening (plan v4 Section A /
+# Blocker-2): the core bug was the 2-col ``.first()`` picking an arbitrary
+# round (DOT_1 vs DOT_2). This is the durable CI proof of the fix
+# (smoke E2E covered it manually; this keeps it regression-locked).
+# ---------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def seed_two_round_two_lead(admin_user_in_db, seed_lead_dependencies):
+    """One offering+method with TWO active paths in TWO rounds (DOT_1
+    allow_multi_nv=False, DOT_2 allow_multi_nv=True) + two leads. The two
+    paths share (academic_info, method) and differ only by round — exactly
+    the prod shape that broke the 2-col ``.first()`` lookup."""
+    suffix = uuid.uuid4().hex[:8]
+    unit_id = seed_lead_dependencies["unit_id"]
+    program_id = seed_lead_dependencies["major_program_id"]
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ot = models.ConfigOfferingType(
+                code=f"p3_2r_{suffix}", name=f"2round {suffix}", is_active=True
+            )
+            s.add(ot)
+            await s.flush()
+            offering = models.ProgramOffering(
+                offering_type=f"p3_2r_{suffix}",
+                program_id=program_id,
+                offering_type_id=ot.id,
+            )
+            s.add(offering)
+            await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=offering.id, academic_year=2026, is_published=True
+            )
+            s.add(ai)
+            await s.flush()
+            method = models.AdmissionMethod(
+                code=f"p3_2r_m_{suffix}", name="2round method", is_active=True
+            )
+            s.add(method)
+            await s.flush()
+            # ADM-003: AdmissionPath.criteria_id is UNIQUE → one criteria per path.
+            crit1 = models.AdmissionCriteria(
+                method_id=method.id, code=f"p3_2r_c1_{suffix}",
+                name="c1", min_gpa=0, is_active=True,
+            )
+            crit2 = models.AdmissionCriteria(
+                method_id=method.id, code=f"p3_2r_c2_{suffix}",
+                name="c2", min_gpa=0, is_active=True,
+            )
+            s.add_all([crit1, crit2])
+            await s.flush()
+            r1 = models.OfferingAdmissionRound(
+                academic_year=2026, round_code=f"D1_{suffix}",
+                round_name=f"Dot 1 {suffix}", is_active=True, allow_multi_nv=False,
+            )
+            r2 = models.OfferingAdmissionRound(
+                academic_year=2026, round_code=f"D2_{suffix}",
+                round_name=f"Dot 2 {suffix}", is_active=True, allow_multi_nv=True,
+            )
+            s.add_all([r1, r2])
+            await s.flush()
+            p1 = models.AdmissionPath(
+                academic_info_id=ai.id, admission_method_id=method.id,
+                admission_round_id=r1.id, criteria_id=crit1.id, status="active",
+            )
+            p2 = models.AdmissionPath(
+                academic_info_id=ai.id, admission_method_id=method.id,
+                admission_round_id=r2.id, criteria_id=crit2.id, status="active",
+            )
+            s.add_all([p1, p2])
+            await s.flush()
+            leads = []
+            for tag in ("A", "B"):
+                lead = models.Lead(
+                    full_name=f"2round {tag} {suffix}",
+                    phone=f"090{random.randint(1000000, 9999999)}",
+                    email=f"p3_2r_{tag}_{suffix}@test.com",
+                    source="website", unit_id=unit_id, offering_id=offering.id,
+                )
+                s.add(lead)
+                await s.flush()
+                s.add(models.Consultation(
+                    lead_id=lead.id, method="phone", notes="2round setup",
+                    officer_id=admin_user_in_db["id"], consultation_status_id="sts06",
+                ))
+                leads.append(lead.id)
+            return {
+                "lead_a_id": leads[0],
+                "lead_b_id": leads[1],
+                "round_dot1_id": r1.id,
+                "round_dot2_id": r2.id,
+                "admission_method_id": method.id,
+                "academic_year": 2026,
+                "admin_user_id": admin_user_in_db["id"],
+            }
+
+
+async def test_create_profile_3col_binds_to_exact_round_among_two(
+    seed_two_round_two_lead,
+) -> None:
+    """ANCHOR (plan v4 Blocker-2): with two active paths sharing (offering,
+    year, method) but different rounds, create_profile binds each profile to
+    the round its caller passed — NOT an arbitrary ``.first()``.
+
+    lead_A + DOT_1 → applied_rules.admission_round_id == DOT_1 + uses_choice_
+    engine False; lead_B + DOT_2 → DOT_2 + True. A regression reverting to the
+    2-col lookup would bind BOTH to the same (arbitrary) round → the distinct-
+    round assert (or one engine assert) fails. Re-fetched in a fresh session
+    so the assertion exercises the persisted column, not the in-memory object.
+    """
+    seed = seed_two_round_two_lead
+
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, seed["admin_user_id"])
+        prof_a = await admission_service.create_profile(
+            db=s,
+            lead_id=seed["lead_a_id"],
+            admission_method_id=seed["admission_method_id"],
+            admission_round_id=seed["round_dot1_id"],
+            current_user=admin,
+            academic_year=2026,
+        )
+        pid_a = prof_a.id
+        await s.commit()
+
+    async with AsyncSessionLocal() as s:
+        admin = await s.get(models.User, seed["admin_user_id"])
+        prof_b = await admission_service.create_profile(
+            db=s,
+            lead_id=seed["lead_b_id"],
+            admission_method_id=seed["admission_method_id"],
+            admission_round_id=seed["round_dot2_id"],
+            current_user=admin,
+            academic_year=2026,
+        )
+        pid_b = prof_b.id
+        await s.commit()
+
+    async with AsyncSessionLocal() as s:
+        pa = await s.get(models.AdmissionProfile, pid_a)
+        pb = await s.get(models.AdmissionProfile, pid_b)
+        assert pa.applied_rules["admission_round_id"] == seed["round_dot1_id"], (
+            f"lead_A bound to {pa.applied_rules.get('admission_round_id')}, "
+            f"expected DOT_1 {seed['round_dot1_id']}"
+        )
+        assert pb.applied_rules["admission_round_id"] == seed["round_dot2_id"], (
+            f"lead_B bound to {pb.applied_rules.get('admission_round_id')}, "
+            f"expected DOT_2 {seed['round_dot2_id']}"
+        )
+        assert pa.applied_rules["admission_round_id"] != pb.applied_rules["admission_round_id"], (
+            "two profiles must bind to DISTINCT rounds — 3-col disambiguation "
+            "(2-col .first() regression would collapse them to one round)"
+        )
+        assert pa.uses_choice_engine is False, (
+            f"DOT_1 allow_multi_nv=False → uses_choice_engine False, got "
+            f"{pa.uses_choice_engine!r}"
+        )
+        assert pb.uses_choice_engine is True, (
+            f"DOT_2 allow_multi_nv=True → uses_choice_engine True, got "
+            f"{pb.uses_choice_engine!r}"
+        )

--- a/Backend_FastAPI/tests/unit/test_admission_path_service_phase1_03_governance.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_service_phase1_03_governance.py
@@ -59,13 +59,14 @@ def _make_service():
     the persisted column dict.
 
     W11-T.2 fix (Q9 #07 PR1 bundle per memory test-fixture-drift-after-
-    policy-refactor): ``create_path`` Phase 2 PR-2B v2 now calls
-    ``self.db.get(OfferingAcademicInfo, ...)`` upfront to resolve
-    academic_year for the DOT_1 auto-resolution shim, AND calls
-    ``self.db.get(OfferingAdmissionRound, ...)`` when admission_round_id
-    is explicit. Both `db.get` calls must be AsyncMock or `await` raises
-    TypeError. Side-effect dispatches by model class so a single mock
-    handles both lookups.
+    policy-refactor), updated for round contract hardening (plan v4): the
+    DOT_1 auto-resolve shim is removed, so ``create_path`` now ALWAYS calls
+    ``self.db.get(OfferingAcademicInfo, ...)`` (resolve academic_year) AND
+    ``self.db.get(OfferingAdmissionRound, ...)`` (validate the explicit,
+    now-REQUIRED round). Both `db.get` calls must be AsyncMock or `await`
+    raises TypeError. Side-effect dispatches by model class so a single mock
+    handles both lookups; the round stub carries is_active / archived_at /
+    round_code so the new validation guards pass.
     """
     service = AdmissionPathService.__new__(AdmissionPathService)
     service.db = MagicMock()
@@ -80,17 +81,27 @@ def _make_service():
         if model_cls is OfferingAcademicInfo:
             return SimpleNamespace(id=obj_id, academic_year=2026)
         if model_cls is OfferingAdmissionRound:
-            return SimpleNamespace(id=obj_id, academic_year=2026)
+            # Round contract hardening (plan v4): create_path now reads
+            # round_code / is_active / archived_at for the explicit-round
+            # validation. academic_year=2026 matches academic_info so the
+            # cross-year guard passes.
+            return SimpleNamespace(
+                id=obj_id,
+                academic_year=2026,
+                round_code="DOT_1",
+                is_active=True,
+                archived_at=None,
+            )
         return None
 
     service.db.get = AsyncMock(side_effect=_fake_db_get)
 
-    # AdmissionRoundRepository.get_default_dot1 calls self.db.execute(...)
-    # then .scalar_one_or_none(). Mock returns a SimpleNamespace round so
-    # the auto-resolve branch in create_path doesn't BusinessRuleViolation.
-    _fake_round = SimpleNamespace(id=1, academic_year=2026, round_code="DOT_1")
+    # Round contract hardening (plan v4): create_path no longer calls
+    # db.execute for round resolution (the get_default_dot1 auto-resolve
+    # shim is removed — the round is explicit via db.get). Keep a harmless
+    # generic execute mock for any incidental query.
     _fake_result = MagicMock()
-    _fake_result.scalar_one_or_none = MagicMock(return_value=_fake_round)
+    _fake_result.scalar_one_or_none = MagicMock(return_value=None)
     service.db.execute = AsyncMock(return_value=_fake_result)
 
     service.repo = MagicMock()
@@ -131,6 +142,7 @@ def _admin_create_payload(**overrides) -> AdmissionPathCreate:
     base = {
         "academic_info_id": 1,
         "admission_method_id": 1,
+        "admission_round_id": 1,
         "applicable_to": ["POST_THPT", "LIEN_THONG_TC"],
         "method_quota": 50,
         "bonus_rule_override": {
@@ -183,6 +195,7 @@ class TestCreatePathAdminCanSetGovernance:
             {
                 "academic_info_id": 1,
                 "admission_method_id": 1,
+                "admission_round_id": 1,
             }
         )
         await service.create_path(payload, _user(UserRole.ADMIN))
@@ -219,6 +232,7 @@ class TestCreatePathManagerGovernanceGuard:
             {
                 "academic_info_id": 1,
                 "admission_method_id": 1,
+                "admission_round_id": 1,
                 **field_kwarg,
             }
         )
@@ -234,6 +248,7 @@ class TestCreatePathManagerGovernanceGuard:
             {
                 "academic_info_id": 1,
                 "admission_method_id": 1,
+                "admission_round_id": 1,
                 "minor_correction_allowed_fields": ["gender"],
             }
         )
@@ -248,6 +263,7 @@ class TestCreatePathManagerGovernanceGuard:
             {
                 "academic_info_id": 1,
                 "admission_method_id": 1,
+                "admission_round_id": 1,
                 "display_name": "Manager-created draft",
             }
         )

--- a/Backend_FastAPI/tests/unit/test_admission_path_service_phase1_03_governance.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_service_phase1_03_governance.py
@@ -105,10 +105,11 @@ def _make_service():
     service.db.execute = AsyncMock(return_value=_fake_result)
 
     service.repo = MagicMock()
-    service.repo.get_path_by_offering_and_method = AsyncMock(return_value=None)
-    service.repo.get_path_by_round_offering_method = AsyncMock(return_value=None)
     # Phase 2 PR-2C v2 duplicate check via 3-col UNIQUE — mock to return
     # None (no existing path) so create proceeds past the duplicate guard.
+    # (Dead mocks for the removed 2-col get_path_by_offering_and_method +
+    # a never-existent get_path_by_round_offering_method dropped — round
+    # contract hardening plan v4.)
     service.repo.get_path_by_round_and_method = AsyncMock(return_value=None)
 
     persisted: dict = {}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/PathBasicInfo.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/PathBasicInfo.tsx
@@ -11,6 +11,7 @@ import { Switch } from "@/components/ui/switch";
 import { Loader2, ArrowRight } from "lucide-react";
 import { toast } from "sonner";
 import { useCreateAdmissionPath, useUpdateAdmissionPath } from "@/hooks/admissions/useAdmissionPaths";
+import { useAdmissionRounds } from "@/hooks/admissions/useAdmissionRounds";
 import { useAuth } from "@/hooks/useAuth";
 import {
   AUDIENCE_LABELS_VI,
@@ -29,13 +30,30 @@ interface PathBasicInfoProps {
   path?: AdmissionPathResponse;
   methods: AdmissionMethod[];
   academicInfoId: number;
+  // Round contract hardening (plan v4 Section B-FE) — the wizard passes the
+  // context's academicYear so we can fetch this year's rounds for the
+  // (now REQUIRED) round dropdown on create.
+  academicYear: number;
   onFinish: (pathId: number) => void;
 }
 
-export function PathBasicInfo({ path, methods, academicInfoId, onFinish }: PathBasicInfoProps) {
+export function PathBasicInfo({ path, methods, academicInfoId, academicYear, onFinish }: PathBasicInfoProps) {
   // Initialize state directly from props (Key-based remount ensures fresh init)
   const [displayName, setDisplayName] = useState(path?.display_name || "");
   const [selectedMethodId, setSelectedMethodId] = useState<number | null>(path?.admission_method?.id || null);
+  // Round contract hardening (plan v4 Section B-FE) — REQUIRED on create.
+  // Edit mode pre-fills the existing round but renders it read-only
+  // (transfer-round is deferred). Only fetch rounds in create mode; in edit
+  // mode we display the path's already-loaded round metadata.
+  const [selectedRoundId, setSelectedRoundId] = useState<number | null>(
+    path?.admission_round_id ?? null
+  );
+  const { data: roundsData, isLoading: loadingRounds } = useAdmissionRounds(
+    path ? null : academicYear
+  );
+  const availableRounds = (roundsData?.items ?? []).filter(
+    (r) => r.is_active && r.archived_at == null
+  );
   const [displayOrder, setDisplayOrder] = useState(path?.display_order || 1);
   const [visibility, setVisibility] = useState<"public" | "internal">(path?.visibility || "internal");
   // PR #6 — path-level submit strictness. Default strict (false) for new paths;
@@ -222,10 +240,17 @@ export function PathBasicInfo({ path, methods, academicInfoId, onFinish }: PathB
         savedId = path.id;
         toast.success("Cập nhật thông tin cơ bản thành công");
       } else {
-        // Create new
+        // Create new — round is REQUIRED (round contract hardening, plan v4
+        // Section B). The BE auto-resolve DOT_1 shim is removed; omitting the
+        // round now 422s. Guard here narrows selectedRoundId to number.
+        if (selectedRoundId === null) {
+          toast.error("Vui lòng chọn đợt tuyển sinh");
+          return;
+        }
         const newPath = await createMutation.mutateAsync({
           academic_info_id: academicInfoId,
           admission_method_id: selectedMethodId,
+          admission_round_id: selectedRoundId,
           display_name: displayName || undefined,
           display_order: displayOrder,
           visibility: visibility,
@@ -288,6 +313,62 @@ export function PathBasicInfo({ path, methods, academicInfoId, onFinish }: PathB
               <p className="text-xs text-muted-foreground">
                 Không thể thay đổi phương thức sau khi tạo
               </p>
+            )}
+          </div>
+
+          {/* Round selection (round contract hardening, plan v4 Section B-FE).
+              Create: pick an active, non-archived round for this year — the BE
+              auto-DOT_1 shim is removed, so omitting it 422s. Edit: read-only
+              (transfer-round deferred). */}
+          <div className="space-y-2">
+            <Label htmlFor="admission-round">
+              Đợt tuyển sinh <span className="text-destructive">*</span>
+            </Label>
+            {path ? (
+              <>
+                <Input
+                  id="admission-round"
+                  value={
+                    path.round_name ??
+                    path.round_code ??
+                    `Đợt #${path.admission_round_id}`
+                  }
+                  disabled
+                  readOnly
+                />
+                <p className="text-xs text-muted-foreground">
+                  Không thể đổi đợt tuyển sinh sau khi tạo.
+                </p>
+              </>
+            ) : loadingRounds ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Đang tải đợt tuyển sinh...
+              </div>
+            ) : availableRounds.length === 0 ? (
+              <p className="text-sm text-destructive">
+                Năm {academicYear} chưa có đợt tuyển sinh khả dụng. Vui lòng tạo
+                đợt ở bước &quot;Đợt tuyển sinh&quot; trước.
+              </p>
+            ) : (
+              <Select
+                value={selectedRoundId?.toString() || ""}
+                onValueChange={(value) => setSelectedRoundId(parseInt(value))}
+              >
+                <SelectTrigger id="admission-round">
+                  <SelectValue placeholder="Chọn đợt tuyển sinh" />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableRounds.map((r) => (
+                    <SelectItem key={r.id} value={r.id.toString()}>
+                      {r.round_name}
+                      <span className="text-muted-foreground ml-2">
+                        ({r.round_code})
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             )}
           </div>
 

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/PathWizard.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/PathWizard.tsx
@@ -144,6 +144,7 @@ export function PathWizard({ context, pathId, onNavigate, initialStep = 1 }: Pat
             path={path}
             methods={methods}
             academicInfoId={context.academicInfoId}
+            academicYear={context.academicYear}
             onFinish={handleBasicInfoFinish}
           />
         )

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/QuickCreatePathModal.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/QuickCreatePathModal.tsx
@@ -38,7 +38,10 @@ import type { AdmissionMethod } from "../../shared/types"
 
 interface Props {
   academicInfoId: number
-  /** Preset round (cell vị trí). Optional — null → BE auto-resolve DOT_1 */
+  /** Preset round (cell vị trí). Round contract hardening (plan v4): the BE
+   *  auto-resolve DOT_1 shim is removed, so a null round can no longer be
+   *  quick-created here — submit is blocked and the admin is sent to the
+   *  step-by-step wizard (which has a round picker). */
   admissionRoundId?: number | null
   /** Preset method nếu cell là vị trí (method × round) cụ thể */
   admissionMethodId?: number | null
@@ -67,11 +70,21 @@ export function QuickCreatePathModal({
       toast.error("Vui lòng chọn phương thức trước khi tạo.")
       return
     }
+    // Round contract hardening (plan v4 Section B-FE): the round is REQUIRED
+    // and the BE auto-DOT_1 shim is removed. This minimal modal has no round
+    // picker, so when the cell didn't preset a round, block and route to the
+    // wizard. Guard also narrows admissionRoundId to number for the payload.
+    if (!admissionRoundId) {
+      toast.error(
+        "Thiếu đợt tuyển sinh — không thể tạo nhanh. Dùng trình tạo từng bước để chọn đợt.",
+      )
+      return
+    }
     try {
       const created = await createMutation.mutateAsync({
         academic_info_id: academicInfoId,
         admission_method_id: methodId,
-        admission_round_id: admissionRoundId ?? null,
+        admission_round_id: admissionRoundId,
         display_name: displayName.trim() || null,
         display_order: Number(displayOrder) || 1,
         visibility: "internal",
@@ -159,8 +172,9 @@ export function QuickCreatePathModal({
           </div>
 
           {!admissionRoundId && (
-            <div className="rounded-md border bg-muted/40 p-2 text-[11px] text-muted-foreground">
-              Đợt không chọn trước — máy chủ tự gán Đợt 1 của năm tương ứng.
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-2 text-[11px] text-destructive">
+              Chưa chọn đợt tuyển sinh — không thể tạo nhanh. Vui lòng dùng
+              trình tạo từng bước (wizard) để chọn đợt.
             </div>
           )}
         </div>
@@ -175,7 +189,7 @@ export function QuickCreatePathModal({
           </Button>
           <Button
             onClick={handleCreate}
-            disabled={createMutation.isPending}
+            disabled={createMutation.isPending || !admissionRoundId}
             aria-busy={createMutation.isPending}
           >
             {createMutation.isPending && (

--- a/frontend/src/app/(dashboard)/admissions/create/page.tsx
+++ b/frontend/src/app/(dashboard)/admissions/create/page.tsx
@@ -24,6 +24,7 @@ import { api } from "@/lib/api/client"
 import { getPathsForOffering } from "@/lib/api/admission-paths"
 import { toast } from "sonner"
 import { PageContainer } from "@/components/layouts/PageContainer"
+import { todayVN } from "@/lib/utils/vn-date"
 import type { LeadAdmissionBlocker } from "@/types/lead.types"
 
 // Blocker code → user-facing VN message. Source of truth lives in backend
@@ -58,6 +59,18 @@ interface AdmissionMethod {
 interface AdmissionMethodListResponse {
   methods: AdmissionMethod[]
   total: number
+}
+
+// Round contract hardening (plan v4): a distinct, usable admission round
+// derived from the offering's active paths (``round_*`` flat fields on the
+// for-offering response). ``isOpen`` = today within [start, end] in VN time.
+interface RoundOption {
+  id: number
+  code: string | null
+  name: string | null
+  startDate: string | null
+  endDate: string | null
+  isOpen: boolean
 }
 
 // Hook to fetch admission methods
@@ -103,6 +116,7 @@ export default function CreateAdmissionPage() {
   // would otherwise fire on a "useEffect → setState" auto-select
   // pattern.
   const [pickedYear, setPickedYear] = useState<number | null>(null)
+  const [pickedRoundId, setPickedRoundId] = useState<number | null>(null)
   const [pickedMethodId, setPickedMethodId] = useState<number | null>(null)
 
   const { data: lead, isLoading: isLoadingLead } = useLead(
@@ -163,15 +177,75 @@ export default function CreateAdmissionPage() {
   const academicYear: number | null =
     pickedYear ?? (eligibleYears.length === 1 ? eligibleYears[0] : null)
 
-  // Methods filtered by selected year's paths. ``useAdmissionMethods``
-  // still drives display name lookup; the gate is path-membership.
-  const methodsForYear: AdmissionMethod[] =
+  // Round contract hardening (plan v4): derive the usable round options for
+  // the selected year from the offering's active paths. Surface a distinct
+  // round per ``admission_round_id`` and FILTER OUT archived / explicitly
+  // inactive rounds (N4 — BE guard is final; FE just doesn't offer them).
+  // ``isOpen`` uses a VN-local YYYY-MM-DD string compare (F39 — never
+  // ``new Date("YYYY-MM-DD")``, which parses UTC midnight → off-by-one at
+  // GMT+7).
+  const today = todayVN()
+  const roundsForYear: RoundOption[] =
     academicYear === null
       ? []
       : (() => {
           const yearPaths = pathsByYear.get(academicYear) ?? []
-          const idsInYear = new Set(yearPaths.map((p) => p.admission_method_id))
-          return methods.filter((m) => m.is_active && idsInYear.has(m.id))
+          const byId = new Map<number, RoundOption>()
+          for (const p of yearPaths) {
+            if (p.round_archived_at != null) continue
+            if (p.round_is_active === false) continue
+            if (byId.has(p.admission_round_id)) continue
+            const startDate = p.round_start_date ?? null
+            const endDate = p.round_end_date ?? null
+            const isOpen =
+              startDate != null &&
+              endDate != null &&
+              startDate <= today &&
+              today <= endDate
+            byId.set(p.admission_round_id, {
+              id: p.admission_round_id,
+              code: p.round_code ?? null,
+              name: p.round_name ?? null,
+              startDate,
+              endDate,
+              isOpen,
+            })
+          }
+          return Array.from(byId.values()).sort((a, b) => {
+            if (a.isOpen !== b.isOpen) return a.isOpen ? -1 : 1
+            return (a.code ?? "").localeCompare(b.code ?? "")
+          })
+        })()
+
+  // Default round (derived): auto-select ONLY when exactly one round is
+  // currently open (today within its window). If multiple overlap (N7) or
+  // none is open, leave null so the officer picks explicitly.
+  const openRounds = roundsForYear.filter((r) => r.isOpen)
+  const defaultRoundId: number | null =
+    openRounds.length === 1 ? openRounds[0].id : null
+
+  // Effective round (derived) — invalidates a picked id that's no longer in
+  // the eligible set (e.g. after a year change). Mirrors the selectedMethodId
+  // pattern below; no setState-in-effect.
+  const selectedRoundId: number | null =
+    pickedRoundId !== null && roundsForYear.some((r) => r.id === pickedRoundId)
+      ? pickedRoundId
+      : defaultRoundId
+
+  // Methods filtered by the selected (year, round) paths.
+  // ``useAdmissionMethods`` still drives display name lookup; the gate is
+  // path-membership in the chosen round.
+  const methodsForYear: AdmissionMethod[] =
+    academicYear === null || selectedRoundId === null
+      ? []
+      : (() => {
+          const yearPaths = pathsByYear.get(academicYear) ?? []
+          const idsInRound = new Set(
+            yearPaths
+              .filter((p) => p.admission_round_id === selectedRoundId)
+              .map((p) => p.admission_method_id)
+          )
+          return methods.filter((m) => m.is_active && idsInRound.has(m.id))
         })()
 
   // Effective method (derived) — invalidates the picked id if the
@@ -186,15 +260,24 @@ export default function CreateAdmissionPage() {
   
   const handleCreate = async () => {
     // Submit guard mirrors the disabled state on the button below —
-    // both year and method are required. This double-check guards
+    // year, round and method are all required. This double-check guards
     // against a future change that loosens the disabled prop.
-    if (!leadId || !selectedMethodId || academicYear === null) return
+    if (
+      !leadId ||
+      !selectedMethodId ||
+      academicYear === null ||
+      selectedRoundId === null
+    )
+      return
 
     // Note: useCreateAdmission hook already handles success toast and navigation
     // Error is also handled via handleApiError() in the hook
     await createMutation.mutateAsync({
       lead_id: parseInt(leadId),
       admission_method_id: selectedMethodId,
+      // Round contract hardening (plan v4): bind to the explicit round so
+      // BE selects the exact (round, offering, method) AdmissionPath.
+      admission_round_id: selectedRoundId,
       // ADM-017: bind to the selected recruitment year so BE can
       // resolve the right ``OfferingAcademicInfo`` deterministically.
       academic_year: academicYear,
@@ -343,10 +426,85 @@ export default function CreateAdmissionPage() {
             </p>
           </div>
 
-          {/* Admission Method Selection — filtered by selected year's
-              active paths (review-fix). Dropdown is empty until a
-              year is chosen, so officer can't pick a method that has
-              no path for that year. */}
+          {/* Round selection (round contract hardening, plan v4). Options
+              derive from the offering's active paths for the selected year
+              (``round_*`` flat fields) — the SAME source the backend
+              validates at create_profile time. Archived / inactive rounds
+              are filtered out (N4). Auto-default only when exactly one round
+              is currently open; multiple overlapping open rounds (N7) require
+              a manual pick. Window badges are advisory only — the backend
+              does NOT hard-gate on dates (Hybrid). */}
+          <div className="space-y-2">
+            <Label htmlFor="admission-round">
+              Đợt tuyển sinh <span className="text-destructive">*</span>
+            </Label>
+            {academicYear === null ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <AlertCircle className="h-4 w-4" />
+                Chọn năm học trước để hiện danh sách đợt tuyển sinh.
+              </div>
+            ) : isLoadingPaths ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Đang tải đợt tuyển sinh...
+              </div>
+            ) : roundsForYear.length === 0 ? (
+              <div className="flex items-center gap-2 text-sm text-destructive">
+                <AlertCircle className="h-4 w-4" />
+                Năm {academicYear} chưa có đợt tuyển sinh khả dụng cho
+                chương trình này.
+              </div>
+            ) : (
+              <Select
+                value={selectedRoundId?.toString() ?? ""}
+                onValueChange={(value) =>
+                  setPickedRoundId(value ? parseInt(value, 10) : null)
+                }
+              >
+                <SelectTrigger id="admission-round">
+                  <SelectValue placeholder="Chọn đợt tuyển sinh" />
+                </SelectTrigger>
+                <SelectContent>
+                  {roundsForYear.map((r) => {
+                    const windowLabel =
+                      r.startDate == null || r.endDate == null
+                        ? null
+                        : today < r.startDate
+                          ? "Chưa mở"
+                          : today > r.endDate
+                            ? "Đã hết hạn"
+                            : null
+                    return (
+                      <SelectItem key={r.id} value={r.id.toString()}>
+                        <span className="flex items-center gap-2">
+                          <span>{r.name ?? r.code ?? `Đợt #${r.id}`}</span>
+                          {windowLabel && (
+                            <span className="text-xs text-muted-foreground">
+                              ({windowLabel})
+                            </span>
+                          )}
+                        </span>
+                      </SelectItem>
+                    )
+                  })}
+                </SelectContent>
+              </Select>
+            )}
+            {openRounds.length > 1 ? (
+              <p className="text-xs text-amber-600 dark:text-amber-500">
+                Có nhiều đợt đang mở — vui lòng chọn đợt thủ công.
+              </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Đợt tuyển sinh xác định chỉ tiêu, lệ phí và quy tắc xét của hồ sơ.
+              </p>
+            )}
+          </div>
+
+          {/* Admission Method Selection — filtered by the selected
+              (year, round) active paths. Dropdown is empty until a year
+              and round are chosen, so officer can't pick a method that has
+              no path for that round. */}
           <div className="space-y-2">
             <Label htmlFor="admission-method">
               Phương thức xét tuyển <span className="text-destructive">*</span>
@@ -355,6 +513,11 @@ export default function CreateAdmissionPage() {
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <AlertCircle className="h-4 w-4" />
                 Chọn năm học trước để hiện danh sách phương thức.
+              </div>
+            ) : selectedRoundId === null ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <AlertCircle className="h-4 w-4" />
+                Chọn đợt tuyển sinh trước để hiện danh sách phương thức.
               </div>
             ) : isLoadingMethods || isLoadingPaths ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -407,7 +570,8 @@ export default function CreateAdmissionPage() {
                 !lead ||
                 !canCreateAdmission ||
                 !selectedMethodId ||
-                academicYear === null
+                academicYear === null ||
+                selectedRoundId === null
               }
             >
               {createMutation.isPending ? (

--- a/frontend/src/lib/zod/admission-path.test.ts
+++ b/frontend/src/lib/zod/admission-path.test.ts
@@ -1,0 +1,70 @@
+// src/lib/zod/admission-path.test.ts
+import { describe, it, expect } from "vitest"
+
+import {
+  admissionPathCreateSchema,
+  admissionPathResponseSchema,
+} from "./admission-path"
+
+// Round contract hardening (plan v4): flat round_* metadata on the path
+// response (Section D) + required admission_round_id on create (Section B).
+describe("admissionPathResponseSchema — flat round metadata (plan v4 Section D)", () => {
+  const ROUND_FIELDS = [
+    "round_code",
+    "round_name",
+    "round_start_date",
+    "round_end_date",
+    "round_archived_at",
+    "round_is_active",
+    "round_allow_multi_nv",
+  ] as const
+
+  it("declares all 7 flat round_* fields", () => {
+    const shape = admissionPathResponseSchema.shape
+    for (const key of ROUND_FIELDS) {
+      expect(key in shape).toBe(true)
+    }
+  })
+
+  it("treats round fields as nullable + optional (None when not eager-loaded)", () => {
+    const shape = admissionPathResponseSchema.shape
+    // Each round field must accept both undefined (absent) and null (BE
+    // emitted null because the relationship wasn't eager-loaded).
+    for (const key of ROUND_FIELDS) {
+      expect(shape[key].safeParse(undefined).success).toBe(true)
+      expect(shape[key].safeParse(null).success).toBe(true)
+    }
+  })
+
+  it("parses concrete round values of the right types", () => {
+    const shape = admissionPathResponseSchema.shape
+    expect(shape.round_code.safeParse("DOT_2").success).toBe(true)
+    expect(shape.round_start_date.safeParse("2026-04-01").success).toBe(true)
+    expect(
+      shape.round_archived_at.safeParse("2026-05-14T00:00:00+07:00").success,
+    ).toBe(true)
+    expect(shape.round_is_active.safeParse(true).success).toBe(true)
+    expect(shape.round_allow_multi_nv.safeParse(false).success).toBe(true)
+  })
+})
+
+describe("admissionPathCreateSchema — admission_round_id REQUIRED (plan v4 Section B)", () => {
+  const base = { academic_info_id: 1, admission_method_id: 2, admission_round_id: 3 }
+
+  it("parses a payload with admission_round_id", () => {
+    const parsed = admissionPathCreateSchema.parse(base)
+    expect(parsed.admission_round_id).toBe(3)
+  })
+
+  it("rejects a payload missing admission_round_id (auto-DOT_1 shim removed)", () => {
+    const { admission_round_id: _omit, ...withoutRound } = base
+    void _omit
+    expect(() => admissionPathCreateSchema.parse(withoutRound)).toThrow()
+  })
+
+  it("rejects a non-positive admission_round_id", () => {
+    expect(() =>
+      admissionPathCreateSchema.parse({ ...base, admission_round_id: 0 }),
+    ).toThrow()
+  })
+})

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -174,8 +174,13 @@ export type AdmissionCriteriaNested = z.infer<typeof admissionCriteriaNestedSche
 export const admissionPathCreateSchema = z.object({
   academic_info_id: z.number().int().positive("Academic Info ID phải là số dương"),
   admission_method_id: z.number().int().positive("Admission Method ID phải là số dương"),
-  // Phase 2 v8.2 PR-2B v2 — optional; BE auto-resolves DOT_1 nếu null.
-  admission_round_id: z.number().int().positive().optional().nullable(),
+  // Round contract hardening (plan v4 Section B): REQUIRED. The BE
+  // auto-resolve DOT_1 shim is removed — wizard / quick-create must always
+  // send the round. Mirrors the BE Pydantic ``int = Field(..., gt=0)``.
+  admission_round_id: z
+    .number()
+    .int()
+    .positive("Đợt tuyển sinh phải là số dương"),
   // Phase 2 v8.2 PR-2B v2 — per-path quota fields (admit chain Tier 1, submit chain Tier 2).
   round_quota: z.number().int().min(0).optional().nullable(),
   admit_quota: z.number().int().min(0).optional().nullable(),
@@ -308,6 +313,20 @@ export const admissionPathResponseSchema = z.object({
   round_quota: z.number().nullable(),
   admit_quota: z.number().nullable(),
   submission_count: z.number().default(0),
+  // Round contract hardening (plan v4 Section D — Finding #3): flat round
+  // metadata, eager-loaded by the common response queries + populated in
+  // build_path_response. ``.nullable().optional()`` mirrors the BE
+  // ``Optional[...] = None`` defaults (None when a query didn't eager-load
+  // the relationship). The officer create page derives its round dropdown
+  // from these fields. date-only fields (start/end) come as YYYY-MM-DD
+  // strings; archived_at is a tz-aware ISO datetime.
+  round_code: z.string().nullable().optional(),
+  round_name: z.string().nullable().optional(),
+  round_start_date: z.string().nullable().optional(),
+  round_end_date: z.string().nullable().optional(),
+  round_archived_at: z.string().datetime({ offset: true }).nullable().optional(),
+  round_is_active: z.boolean().nullable().optional(),
+  round_allow_multi_nv: z.boolean().nullable().optional(),
   // Phase 2 v8.2 — application fee (VND).
   application_fee: z.number().nullable(),
   // BE Pydantic field default=False (admission_path.py:440), FE phải mirror.

--- a/frontend/src/lib/zod/admissions.test.ts
+++ b/frontend/src/lib/zod/admissions.test.ts
@@ -17,11 +17,45 @@
 import { describe, it, expect } from "vitest"
 
 import {
+  admissionProfileCreateSchema,
   admissionProfileUpdateSchema,
   appliedRulesSchema,
   priorityObjectEvidenceEntrySchema,
   subjectGroupSnapshotSchema,
 } from "./admissions"
+
+describe("admissionProfileCreateSchema — round contract hardening (plan v4)", () => {
+  const base = {
+    lead_id: 1,
+    admission_method_id: 2,
+    admission_round_id: 3,
+    academic_year: 2026,
+  }
+
+  it("parses a complete payload with admission_round_id + academic_year", () => {
+    const parsed = admissionProfileCreateSchema.parse(base)
+    expect(parsed.admission_round_id).toBe(3)
+    expect(parsed.academic_year).toBe(2026)
+  })
+
+  it("rejects a payload missing admission_round_id (now REQUIRED)", () => {
+    const { admission_round_id: _omit, ...withoutRound } = base
+    void _omit
+    expect(() => admissionProfileCreateSchema.parse(withoutRound)).toThrow()
+  })
+
+  it("rejects a payload missing academic_year (fallback removed, REQUIRED)", () => {
+    const { academic_year: _omit, ...withoutYear } = base
+    void _omit
+    expect(() => admissionProfileCreateSchema.parse(withoutYear)).toThrow()
+  })
+
+  it("rejects a non-positive admission_round_id", () => {
+    expect(() =>
+      admissionProfileCreateSchema.parse({ ...base, admission_round_id: 0 }),
+    ).toThrow()
+  })
+})
 
 describe("subjectGroupSnapshotSchema (nested weights)", () => {
   it("parses a group with weights", () => {

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -517,6 +517,13 @@ export const admissionProfileCreateSchema = z.object({
     .number()
     .int("Admission Method ID phải là số nguyên")
     .positive("Admission Method ID phải là số dương"),
+  // Round contract hardening (plan v4): REQUIRED. Binds the profile to the
+  // exact (round, offering, method) AdmissionPath; BE validates it exists,
+  // matches academic_year, is active and not archived.
+  admission_round_id: z
+    .number()
+    .int("Đợt tuyển sinh phải là số nguyên")
+    .positive("Đợt tuyển sinh phải là số dương"),
   academic_year: z
     .number()
     .int("Năm học phải là số nguyên")


### PR DESCRIPTION
## What
Closes **Gap #1** (round contract): both data-creation paths now **require an explicit admission round** and validate it, instead of the 2-col `.first()` lookup that silently bound profiles to an arbitrary round (DOT_1 vs DOT_2).

Plan v4 (`verdict-plan-splendid-cookie`). Sections:
- **A — create-profile**: `admission_round_id` + `academic_year` now REQUIRED; validate round (exists / academic_year match / active / not archived) before building `applied_rules`; drop the `current_intake_year` race-check + "first published" fallbacks (F30); switch to the 3-col `get_path_by_round_and_method` (eager-loads round → `uses_choice_engine` deterministic). Remove the now-dead 2-col `get_path_by_offering_and_method`.
- **B — path-create**: `AdmissionPathCreate.admission_round_id` REQUIRED; drop the auto-resolve DOT_1 shim + add `is_active` guard; remove `get_default_dot1`.
- **C — clone guard**: reject cloning into an archived/inactive target round.
- **D — round metadata**: `AdmissionPathResponse` gains 7 flat `round_*` fields; `build_path_response` populates them; `selectinload(admission_round)` added to the 4 common response queries.
- **FE**: officer create page Year→Round→Method selector (date-window default via `todayVN` F39, N7 multi-open manual pick, N4 filter archived/inactive); Config wizard `PathBasicInfo` round dropdown (edit read-only); `QuickCreatePathModal` blocks when round missing; zod schemas require round.

## ⚠ Breaking contract
`AdmissionProfileCreate.academic_year` Optional→REQUIRED, `admission_round_id` new REQUIRED; `AdmissionPathCreate.admission_round_id` Optional→REQUIRED. API clients omitting these now 422. FE already sends them.

## No migration
`admission_round_id` already NOT NULL since PR-2C v2. Rollback = redeploy prior image SHA (no DB rollback).

## Prod evidence (SSH read-only, 2026-05-25)
- `SELECT COUNT(*) FROM admission_path WHERE admission_round_id IS NULL` = **0** → no implicit data migration needed.
- 5 rounds for 2026 (DOT_1/DOT_2/DOT_3/DOT_4 active + TEST_MULTINV archived); 32 active paths each on DOT_1 (expired) + DOT_2 (open) → the `.first()` ambiguity was **real**.

## Verification
- **BE**: 180 passed (clean one-off, casbin loaded). New non-tautological anchors: clone archived/inactive target (F40); create-profile strict 422 + round-year mismatch 400; **2-round determinism** (`test_create_profile_3col_binds_to_exact_round_among_two`, in the pre-merge allowlist).
- **FE**: type-check + vitest 31 pass (zod round-required + response round fields).
- **Chrome MCP smoke (E2E)**: officer create → round dropdown auto-defaults DOT_2 (open) + DOT_1 "Đã hết hạn" badge + method gated → profile created → **BE bound `applied_rules.admission_round_id=DOT_2`, `uses_choice_engine=true`** (original bug fixed). Path-create contract: 422 without round / 201 with round.

## Pre-existing test-debt (NOT this PR)
8 submit-flow tests fail in the `create_all` test env with `CONFIG_GAP_TARGET_LEVEL` (incomplete Phase E.4 fixture seed). **Baseline-proven identical on origin/main** — not a regression here; not in the pre-merge allowlist. Tracked in #337.

## Deferred (per plan, by design — real gaps, out of scope)
F43 storefront expired-round leak (user-visible) · transfer-round · submit Gap #2 (magic-link sync) · Gap #3 (submit-completeness hard-gate) · DOT_1 data cleanup + orphan TEST_MULTINV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)