### PR TITLE
ci+test(cleanup): unblock nightly Playwright CORS + unstale 2 tests + auth diagnostic + stale comment

### DIFF
--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -35,6 +35,26 @@ jobs:
       # TEST_USERNAME / TEST_PASSWORD env) login successfully.
       TEST_USERNAME: vothithuthuhien
       TEST_PASSWORD: Abc@123456789
+      # ROOT CAUSE FIX for nightly-regression P1 #39 — Playwright login
+      # succeeded server-side but browser stayed at /login because CORS
+      # blocked the response from reaching axios. The APP_ENV=test
+      # fallback in ``Backend_FastAPI/app/main.py:667-669`` populates::
+      #
+      #   _cors_origins = ["http://testserver", "http://localhost"]
+      #
+      # Per RFC 6454 + Fetch spec, origin = ``scheme://host:port``. With
+      # ``allow_credentials=True`` (auth cookie flow), Starlette CORSMiddleware
+      # enforces strict EXACT match — ``http://localhost`` (implicit port 80)
+      # ≠ ``http://localhost:3000``. Browser saw no matching
+      # Access-Control-Allow-Origin → blocked JS from reading the body →
+      # axios ``loginMutation.mutationFn`` rejected with Network Error →
+      # ``onSuccess`` never fired → ``router.push('/dashboard/officer')``
+      # never called. Backend logged "Authentication successful" × 3 because
+      # auth DID complete server-side; the response just never reached JS.
+      #
+      # Explicit env var here overrides the fallback so the dispatcher
+      # whitelists the exact origin Playwright reaches from.
+      CORS_ORIGINS: http://localhost:3000
 
     steps:
       - uses: actions/checkout@v4

--- a/Backend_FastAPI/tests/services/test_lead.py
+++ b/Backend_FastAPI/tests/services/test_lead.py
@@ -2431,13 +2431,22 @@ class TestLeadAdmissionEligibility:
         """Lead đã có admission profile → already_has_profile (priority over other checks)."""
         from app.services import admission_service
 
-        # Directly attach profile to model's __dict__ to simulate eager-loaded state
+        # Directly attach profile to model's __dict__ to simulate eager-loaded state.
+        #
+        # NOTE 2026-05-26: Wave 4 #15b (PR #224 / commit 966d5f5f) renamed the
+        # ORM relationship ``Lead.admission_profile`` (singular) →
+        # ``Lead.admission_profiles`` (collection, one-to-many). The eligibility
+        # check at ``admission_service.py:1244`` reads ``admission_profiles``
+        # (plural). Test previously wrote to the legacy singular key →
+        # ``__dict__.get("admission_profiles")`` returned empty → fall-through
+        # to "missing_offering" instead of "already_has_profile". Rename to
+        # the collection key to match the current contract.
         fake_profile = models.AdmissionProfile(
             lead_id=seeded_lead.id,
             status="draft",
             version=1,
         )
-        seeded_lead.__dict__["admission_profile"] = fake_profile
+        seeded_lead.__dict__["admission_profiles"] = [fake_profile]
 
         result = await admission_service.check_lead_level_admission_eligibility(
             db, seeded_lead, admin_user

--- a/Backend_FastAPI/tests/unit/test_check_notification_event_coverage_namespace.py
+++ b/Backend_FastAPI/tests/unit/test_check_notification_event_coverage_namespace.py
@@ -207,28 +207,38 @@ async def other(db):
 # ---------------------------------------------------------------------------
 
 
-def test_live_scan_finds_submit_router_dual_dispatch() -> None:
-    """End-to-end: walks the actual codebase and confirms the
-    ``submit_admission_profile`` router (where #16 added the
-    ADMISSION_PROFILE_SUBMITTED dispatch alongside the existing
-    APPLICATION_STATUS_CHANGED bundle) shows up in the report.
+def test_live_scan_finds_submit_service_dual_dispatch() -> None:
+    """End-to-end: walks the actual codebase and confirms the submit
+    flow (where #16 added the ADMISSION_PROFILE_SUBMITTED dispatch
+    alongside the existing APPLICATION_STATUS_CHANGED bundle) shows up
+    in the report.
+
+    NOTE 2026-05-26: the magic-link refactor (commit 5fca4d4b, vintage
+    PR #279) extracted both ``safe_dispatch()`` calls from the router
+    ``submit_admission_profile`` (admissions.py:711-770 historical) into
+    a ``_post_commit_dispatch`` nested closure inside the service
+    ``submit_and_evaluate`` (admission_service.py:5126-5154 today). The
+    router now just calls the service + awaits the returned post_commit
+    callback — no ``SystemEvents.*`` reference left in the router body.
+    Scanner therefore attributes the pair to the SERVICE function name.
+    Test filter updated to match.
 
     This is the canonical Phase 1 cohabitation pair — the lint MUST
     keep finding it until Phase 4 retires the legacy bundle. If this
     test fails, either:
-    * the router stopped firing one of the two events (check what
-      changed in admissions.py); or
+    * the service stopped firing one of the two events (check what
+      changed in admission_service.py); or
     * the namespace detector regressed.
     """
     pairs = coverage._scan_dual_namespace_pairs()
-    # At least one pair exists post-#16 — the router-level submit
-    # flow that emits both bundles side-by-side.
+    # At least one pair exists post-#16 — the submit flow that emits
+    # both bundles side-by-side from the service-level closure.
     submit_pairs = [
         p for p in pairs
-        if "submit_admission_profile" in p.function
+        if "submit_and_evaluate" in p.function
     ]
     assert len(submit_pairs) >= 1, (
-        f"Expected at least one dual-namespace pair from submit router; "
+        f"Expected at least one dual-namespace pair from submit service; "
         f"got: {[p.function for p in pairs]}"
     )
     pair = submit_pairs[0]

--- a/frontend/src/components/layouts/DashboardLayout.tsx
+++ b/frontend/src/components/layouts/DashboardLayout.tsx
@@ -84,10 +84,17 @@ export function DashboardLayout({
   const { isSidebarCollapsed, setSidebarCollapsed } = useUIStore();
   const showSecurityBanner = useShouldShowSecurityBanner();
 
-  // ✅ SECURITY FIX: Removed client-side auth guard
-  // Authentication is now enforced by server-side middleware
+  // ✅ SECURITY FIX: Removed client-side auth guard.
+  // Authentication is enforced by:
+  //   1. Server Component fetches via ``lib/api/server.ts:174-176`` which
+  //      redirect to ``/login?force_login=true`` on 401 (the primary gate)
+  //   2. Axios interceptor in ``lib/api/client.ts:259`` which clears auth
+  //      store + redirects to /login on 401 for client-side requests
+  // (Earlier comment said "server-side middleware" — there is no
+  // ``frontend/middleware.ts``; the doc was stale. Updated 2026-05-26
+  // alongside nightly-regression CORS unblock.)
   // This prevents the security vulnerability where HTML/data was sent
-  // to the client before redirect
+  // to the client before redirect.
 
   useEffect(() => {
     const handleResize = () => {

--- a/frontend/src/test/e2e/auth.setup.ts
+++ b/frontend/src/test/e2e/auth.setup.ts
@@ -14,6 +14,35 @@ import path from "path";
 const authFile = path.join(__dirname, "..", ".auth", "user.json");
 
 setup("authenticate", async ({ page }) => {
+  // Self-diagnose listeners — when login fails the next time, the failure
+  // mode (CORS strip / 401 / 500 / cookie reject) shows up in the
+  // playwright-report immediately instead of only the timeout message.
+  // Lesson from 2026-05-25 nightly-regression debug cycle: original
+  // failure was CORS strip (P1 #39); without these listeners, multiple
+  // diagnostic rounds were needed to surface "Authentication successful"
+  // on server + Network Error on client. The listeners attach BEFORE any
+  // navigation so the first /login request is also captured.
+  page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      // eslint-disable-next-line no-console
+      console.log(`[browser ${msg.type()}]`, msg.text());
+    }
+  });
+  page.on("pageerror", (err) => {
+    // eslint-disable-next-line no-console
+    console.log("[browser pageerror]", err.message);
+  });
+  page.on("response", (resp) => {
+    const url = resp.url();
+    if (url.includes("/auth/login") || url.includes("/api/auth/")) {
+      const corsHeader = resp.headers()["access-control-allow-origin"] || "(none)";
+      // eslint-disable-next-line no-console
+      console.log(
+        `[auth ${resp.status()}] ${url} | CORS allow-origin: ${corsHeader}`,
+      );
+    }
+  });
+
   // Navigate to login page
   await page.goto("/login");
 


### PR DESCRIPTION
## Scope — 5 cleanup commits bundle 1 PR

Cùng theme "post-PR-#332-deploy cleanup" — close 4 backlog items với 1 CI cycle thay vì 4. File scope độc lập, zero conflict với Plan B (PR #338) đã merged.

| # | Commit | Closes |
|---|---|---|
| 1 | `7e9a9c38` ci(nightly-regression): unblock Playwright login (CORS) | task #39 P1 — nightly E2E coverage blocker |
| 2 | `25aa59c6` test(playwright): auth.setup diagnostic listeners | F2 self-diagnose — next failure narrates itself |
| 3 | `24f6102b` test(eligibility): unstale test_blocker_already_has_profile | task #43 test 1 — attribute rename post Wave 4 #15b |
| 4 | `f97c4974` test(notification): unstale dual-dispatch scan | task #43 test 2 — filter rename post magic-link refactor |
| 5 | `703d4c2d` chore(comment): fix stale DashboardLayout middleware comment | F3 cleanup — doc accuracy for future debug |

---

## Commit 1 — CORS_ORIGINS env (task #39, P1)

### Root cause (audited 2026-05-25)
APP_ENV=test CORS fallback `["http://testserver", "http://localhost"]` ở `main.py:667-669`. Per RFC 6454 origin = `scheme://host:port`. Với `allow_credentials=True`, Starlette strict EXACT match → `http://localhost` (port 80 implicit) ≠ `http://localhost:3000` (Chromium origin) → CORS strip response → axios Network Error → `loginMutation.onSuccess` không fire → `router.push` không gọi.

Backend log `Authentication successful` × 3 vì auth THỰC SỰ complete server-side; response chỉ không reach JS.

### Fix
1-line workflow env override: `CORS_ORIGINS: http://localhost:3000`. Whitelist exact origin Playwright reaches từ. APP_ENV=test vẫn skip production validators (cookie Secure, HTTPS check) — không touch production code.

### Hậu quả
Closes 13-day-old nightly E2E coverage gap (từ 2026-05-15).

---

## Commit 2 — Playwright self-diagnose listeners (F2)

### Background
Khi auth.setup fail, error message duy nhất là "33 × unexpected value localhost:3000/login" — không hint về layer nào fail (CORS / 401 / cookie / FE redirect).

Cost 3-5 diagnostic round + container log inspection để pinpoint CORS strip ở session 2026-05-25.

### Fix
Attach 3 listener BEFORE navigation:
- `page.on("console")` — axios CORS rejection log here
- `page.on("pageerror")` — uncaught JS exceptions
- `page.on("response")` — every `/auth/*` request với status + `Access-Control-Allow-Origin` header (smoking gun for CORS issues)

Output qua `console.log` → lands in per-test stdout của playwright-report. Zero cost happy path.

---

## Commit 3 — test_lead.py test 1 (task #43)

### Bug
Test assert `blocker_code == 'already_has_profile'` nhưng service trả `missing_offering`.

### Root cause
Wave 4 #15b refactor (PR #224 / commit 966d5f5f) đổi ORM relationship `Lead.admission_profile` (singular) → `Lead.admission_profiles` (collection, one-to-many). Service `admission_service.py:1244` đọc `admission_profiles` (plural). Test vẫn ghi singular key → `__dict__.get("admission_profiles")` empty → fall through → trip on `if not lead.offering_id` → returns `missing_offering`.

### Fix
1 line: `"admission_profile"` → `"admission_profiles" = [fake_profile]`.

Production code đúng — sibling test `test_precedence_missing_offering_wins_over_invalid_status:2555` đã document current precedence as intentional contract.

---

## Commit 4 — namespace dual-dispatch scan (task #43)

### Bug
`test_live_scan_finds_submit_router_dual_dispatch` filter `"submit_admission_profile" in p.function` returned 0 hits.

### Root cause
Magic-link refactor (commit 5fca4d4b) extracted 2 dispatches từ router `submit_admission_profile` (admissions.py:711-770) vào nested closure `_post_commit_dispatch` trong service `submit_and_evaluate` (admission_service.py:5126-5154). Scanner detect đúng 1 pair nhưng attribute tới SERVICE function name; test filter giờ point sai router.

### Fix
- Filter substring: `"submit_admission_profile"` → `"submit_and_evaluate"`
- Test function name rename for accuracy
- Docstring updated với pointer mới (admission_service.py)

Scanner contract unchanged + sibling unit tests at lines 144-202 still pass.

---

## Commit 5 — F3 stale comment

### Bug
`DashboardLayout.tsx:87-90` claims:
```
// Authentication is now enforced by server-side middleware
```

Realit: `frontend/middleware.ts` KHÔNG tồn tại. Auth enforcement qua:
1. SSR fetches `lib/api/server.ts:174-176` (redirect /login?force_login=true on 401)
2. Axios interceptor `lib/api/client.ts:259` (clear store + redirect on 401)

### Hậu quả
Stale wording cost 1 diagnostic round 2026-05-25 (auditor đi tìm middleware.ts không có). Comment-only fix, zero runtime impact.

---

## Verification

| Check | Strategy |
|---|---|
| BE pytest gate | CI sẽ run — anchor test `test_blocker_already_has_profile` should pass (fixed) + `test_live_scan_finds_submit_service_dual_dispatch` (renamed) should pass |
| FE type-check + vitest | CI Check (type+lint+test) — auth.setup.ts change is added listeners only, no API change |
| **Real E2E nightly-regression validation** | Sau merge: trigger workflow_dispatch nightly-regression với suite=smoke → expect Playwright login pass → URL redirect away from /login. Đây là proof of #39 fix |
| Diagnostic listener regression | Happy path: login pass + listeners log nothing destructive. Failure path: listeners narrate (verify khi next failure thật xảy ra) |

## Prod safety

| Item | Risk |
|---|---|
| Commit 1 (workflow env) | ZERO — chỉ CI YAML, không production runtime |
| Commit 2 (Playwright test util) | ZERO — test-only |
| Commit 3 (test fixture) | ZERO — test-only |
| Commit 4 (test fixture) | ZERO — test-only |
| Commit 5 (comment) | ZERO — comment only |

**Đây là PR thuần test/CI/comment** — không touch production code path. Safe ship.

## Closes tasks
- **#39** P1 FE auth cookie/redirect blocks Playwright nightly — via commit 1 (CORS root cause)
- **#43** P2 2 pre-existing test fail — via commits 3 + 4

## Test plan
- [ ] PR gate (backend-test.yml + frontend-test.yml + deps) passes
- [ ] Trigger workflow_dispatch nightly-regression với suite=smoke sau merge — confirm Playwright login pass + redirect /dashboard/officer
- [ ] Next failure (whenever) — Playwright listeners narrate fail mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
