### PR TITLE
hotfix(nightly-regression): move CORS_ORIGINS to env_file (compose forward gap from PR #339)

### DIFF
--- a/.github/workflows/nightly-regression.yml
+++ b/.github/workflows/nightly-regression.yml
@@ -35,26 +35,14 @@ jobs:
       # TEST_USERNAME / TEST_PASSWORD env) login successfully.
       TEST_USERNAME: vothithuthuhien
       TEST_PASSWORD: Abc@123456789
-      # ROOT CAUSE FIX for nightly-regression P1 #39 — Playwright login
-      # succeeded server-side but browser stayed at /login because CORS
-      # blocked the response from reaching axios. The APP_ENV=test
-      # fallback in ``Backend_FastAPI/app/main.py:667-669`` populates::
-      #
-      #   _cors_origins = ["http://testserver", "http://localhost"]
-      #
-      # Per RFC 6454 + Fetch spec, origin = ``scheme://host:port``. With
-      # ``allow_credentials=True`` (auth cookie flow), Starlette CORSMiddleware
-      # enforces strict EXACT match — ``http://localhost`` (implicit port 80)
-      # ≠ ``http://localhost:3000``. Browser saw no matching
-      # Access-Control-Allow-Origin → blocked JS from reading the body →
-      # axios ``loginMutation.mutationFn`` rejected with Network Error →
-      # ``onSuccess`` never fired → ``router.push('/dashboard/officer')``
-      # never called. Backend logged "Authentication successful" × 3 because
-      # auth DID complete server-side; the response just never reached JS.
-      #
-      # Explicit env var here overrides the fallback so the dispatcher
-      # whitelists the exact origin Playwright reaches from.
-      CORS_ORIGINS: http://localhost:3000
+      # NOTE: CORS_ORIGINS moved to ``.env.production`` (Generate step
+      # below) per hotfix 2026-05-26 — docker-compose backend service
+      # ``environment:`` block does NOT forward arbitrary host env vars
+      # into the container (only keys explicitly listed there OR present
+      # in env_file). Setting CORS_ORIGINS here had no effect — backend
+      # used the APP_ENV=test fallback ``["http://testserver",
+      # "http://localhost"]`` which doesn't include port 3000 →
+      # axios got CORS Network Error → Playwright login fail.
 
     steps:
       - uses: actions/checkout@v4
@@ -103,6 +91,15 @@ jobs:
           MAIL_PASSWORD=ci-test-placeholder
           MAIL_FROM=ci-test@example.com
           MAIL_SERVER=smtp.example.com
+          # HOTFIX 2026-05-26 — CORS_ORIGINS phải có trong env_file (NOT chỉ
+          # workflow env block) vì docker-compose backend service
+          # ``environment:`` (docker-compose.yml:71-93) KHÔNG list
+          # CORS_ORIGINS → compose chỉ forward keys explicitly listed HOẶC
+          # present trong env_file. Workflow env CORS_ORIGINS chỉ sống ở
+          # runner host env, không reach backend container. Lesson nightly
+          # smoke run 26426142805 fail với "No 'Access-Control-Allow-Origin'
+          # header is present on the requested resource" (vs prior mismatch).
+          CORS_ORIGINS=http://localhost:3000
           EOF
 
       # ``-f docker-compose.yml`` bypasses the auto-loaded


### PR DESCRIPTION
## TL;DR

PR #339 set ``CORS_ORIGINS`` in workflow ``env:`` block but docker-compose backend service ``environment:`` block doesn't list it — so the var lived on the runner host only, never reached the backend container. Backend used APP_ENV=test fallback, browser got no matching ``Access-Control-Allow-Origin``, Playwright login fail same as pre-#339.

Move ``CORS_ORIGINS`` into the generated ``.env.production`` cat heredoc — compose ``env_file:`` directive forwards everything in that file into container env.

## Evidence

Nightly smoke run `26426142805` (validation post PR #339 ship) failed with:

```
[browser error] Access to XMLHttpRequest at 'http://localhost:8000/api/auth/login'
from origin 'http://localhost:3000' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

Note signature: header **missing** (different from pre-#339 mismatch).

## Diagnostic listener pay-off

The F2 diagnostic listeners shipped in PR #339 commit `25aa59c6` narrated this exactly — turned a 3-5 round diagnostic into 1 grep. This is the validation that F2 was the right add.

## Root cause documentation

`docker-compose.yml:87-90` (Hotfix #4 2026-05-07) literally documents this gap:

> compose only forwards keys explicitly listed here OR present in env_file

CORS_ORIGINS is not in `backend.environment:` list, was not in env_file → not forwarded.

## Fix

| Change | File |
|---|---|
| Remove `CORS_ORIGINS:` from workflow `env:` block + add note comment | `.github/workflows/nightly-regression.yml` |
| Add `CORS_ORIGINS=http://localhost:3000` line into `.env.production` cat heredoc | same file (Generate step) |

Net diff: 1 line moved + comment swap. No production code touched.

## Verification next

After merge + redeploy + trigger workflow_dispatch nightly-regression suites=smoke:

1. Backend log shows non-empty `settings.CORS_ORIGINS` (via `main.py:656` INFO log)
2. Browser diagnostic listener logs `[auth 200] http://localhost:8000/api/auth/login | CORS allow-origin: http://localhost:3000`
3. `expect(page).not.toHaveURL(/\/login/)` passes — redirect to /dashboard/officer

If still fails, Playwright listeners narrate next-layer issue (cookie / 401 / etc.).

## Closes
- Task #50 (this hotfix)
- Re-attempts closure of task #39 (Playwright nightly E2E coverage gap, originally targeted by PR #339)

🤖 Generated with [Claude Code](https://claude.com/claude-code)