### PR TITLE
fix(storefront): F43 — public catalog only serves public-eligible rounds

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -257,4 +257,6 @@ jobs:
           tests/unit/test_phase2_engine_quota_chain_v8.py
           tests/unit/test_phase2_engine_snapshot_integrity.py
           tests/unit/test_phase2_pr2c_three_col_unique.py
+          tests/services/test_phase2_admission_path_quota_integration.py
+          tests/unit/test_public_admissions_phase1_wave6.py
           -q --tb=short --timeout=60

--- a/Backend_FastAPI/app/routers/public_admissions.py
+++ b/Backend_FastAPI/app/routers/public_admissions.py
@@ -39,7 +39,10 @@ _ADMISSION_ROUND_QUERY = Query(
     description=(
         "Phase 2 v8.2 PR-2B v2 (Wave 6 #17 P2) — optional admission_round_id "
         "filter. Khi set, chỉ trả về paths thuộc round đó (storefront switch "
-        "by đợt). NULL = backward-compat: return all paths across all rounds."
+        "by đợt). NULL = trả paths của TẤT CẢ round public-eligible "
+        "(active + chưa archive + trong cửa sổ start/end). F43: round hết "
+        "hạn/archived/tương lai luôn bị loại, kể cả khi set admission_round_id "
+        "trỏ vào nó."
     ),
 )
 _AUDIENCE_QUERY = Query(

--- a/Backend_FastAPI/app/services/public_admissions_service.py
+++ b/Backend_FastAPI/app/services/public_admissions_service.py
@@ -38,6 +38,7 @@ from app.schemas.public_admissions import (
     PublicAdmissionsTuitionOffering,
     PublicAdmissionsTuitionResponse,
 )
+from app.utils.datetime_helpers import today_vn
 
 
 # Tier source precedence for #17 Wave 6 (Phase 1 portion). Higher index =
@@ -152,14 +153,34 @@ async def _load_public_paths(
     if not academic_info_ids:
         return []
 
+    today = today_vn()
     conditions = [
         models.AdmissionPath.academic_info_id.in_(sorted(academic_info_ids)),
         models.AdmissionPath.status == PUBLIC_PATH_STATUS,
         models.AdmissionPath.visibility == PUBLIC_PATH_VISIBILITY,
+        # F43 — storefront only serves paths whose round is *public-eligible*.
+        # We ALWAYS join + filter OfferingAdmissionRound, even when the
+        # caller passes no admission_round_id. Public-eligible round =
+        # active + not soft-archived + within its [start_date, end_date]
+        # window (NULL bound = open-ended). This closes the leak where an
+        # expired round (e.g. DOT_1 past its end_date) kept serving its
+        # active+public paths alongside the open round under round=None.
+        # admission_round_id is NOT NULL on AdmissionPath (PR-2C v2), so
+        # the inner join never drops a legitimate path.
+        models.OfferingAdmissionRound.is_active.is_(True),
+        models.OfferingAdmissionRound.archived_at.is_(None),
+        or_(
+            models.OfferingAdmissionRound.start_date.is_(None),
+            models.OfferingAdmissionRound.start_date <= today,
+        ),
+        or_(
+            models.OfferingAdmissionRound.end_date.is_(None),
+            models.OfferingAdmissionRound.end_date >= today,
+        ),
     ]
-    # Phase 2 v8.2 PR-2B v2 (Wave 6 #17 P2) — storefront round filter.
-    # Khi caller specify admission_round_id, only paths thuộc round đó
-    # được serve. NULL filter = backward-compat (return all paths).
+    # When the caller pins a specific round we still apply the
+    # public-eligible guard above — an explicit expired/archived/future
+    # admission_round_id therefore returns zero paths (no stale data).
     if admission_round_id is not None:
         conditions.append(
             models.AdmissionPath.admission_round_id == admission_round_id
@@ -180,6 +201,11 @@ async def _load_public_paths(
 
     query = (
         select(models.AdmissionPath)
+        .join(
+            models.OfferingAdmissionRound,
+            models.AdmissionPath.admission_round_id
+            == models.OfferingAdmissionRound.id,
+        )
         .where(*conditions)
         .options(
             selectinload(models.AdmissionPath.academic_info)

--- a/Backend_FastAPI/app/utils/datetime_helpers.py
+++ b/Backend_FastAPI/app/utils/datetime_helpers.py
@@ -26,6 +26,18 @@ def _to_display(dt: datetime) -> datetime:
     return dt.astimezone(_VN_TZ)
 
 
+def today_vn() -> date:
+    """Current calendar day in ``Asia/Ho_Chi_Minh``.
+
+    Use when comparing against ``Date`` columns (admission-round windows,
+    due dates) so the day boundary doesn't drift by one around UTC
+    midnight on a container running in UTC. ``date.today()`` reads the
+    container clock (UTC in prod) and would flip a day early/late near
+    midnight VN time. See the public-admissions round-eligibility filter.
+    """
+    return datetime.now(_VN_TZ).date()
+
+
 def format_vn_date(dt: Optional[Union[date, datetime]]) -> str:
     """Return ``DD/MM/YYYY`` (10 chars). Empty string if None.
 

--- a/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
+++ b/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
@@ -280,6 +280,121 @@ async def test_storefront_round_filter_returns_only_paths_in_round(
 
 
 @pytest.mark.asyncio
+async def test_storefront_excludes_ineligible_rounds(path_seed: dict):
+    """F43 anchor: ``_load_public_paths`` serves only paths whose round is
+    *public-eligible* — is_active + archived_at IS NULL + within the
+    [start_date, end_date] window (NULL bound = open-ended).
+
+    Must-haves:
+    * round=None excludes expired / future / archived / inactive rounds
+      (the storefront leak: an expired round kept serving its active+public
+      paths alongside the open round).
+    * an explicit ``admission_round_id`` pointing at an ineligible round
+      returns ``[]`` (no stale single-round serve either).
+
+    Non-tautological: builds real rounds with concrete windows relative to
+    today_vn() and asserts the SQL filter result, not a mock.
+    """
+    from datetime import timedelta
+
+    from app.utils.datetime_helpers import today_vn
+
+    today = today_vn()
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    ai_id = path_seed["academic_info_id"]
+
+    # Wide ±10/20/40/60-day margins so the UTC-container vs VN-tz day
+    # boundary (≤7h skew) can never flip an assertion near midnight.
+    specs = {
+        "open": dict(
+            start=today - timedelta(days=10), end=today + timedelta(days=20),
+            active=True, archived=None,
+        ),
+        "expired": dict(
+            start=today - timedelta(days=60), end=today - timedelta(days=10),
+            active=True, archived=None,
+        ),
+        "future": dict(
+            start=today + timedelta(days=10), end=today + timedelta(days=40),
+            active=True, archived=None,
+        ),
+        "archived": dict(
+            start=None, end=None,
+            active=True, archived=datetime.now(timezone.utc),
+        ),
+        "inactive": dict(
+            start=None, end=None,
+            active=False, archived=None,
+        ),
+    }
+    round_ids: dict[str, int] = {}
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            # One method reused across rounds — the 3-col UNIQUE
+            # (round, academic_info, method) is satisfied because each
+            # path lands in a distinct round.
+            method = models.AdmissionMethod(
+                code=f"MF43_{ts}",
+                name=f"MethodF43 {ts}",
+                requires_subject_scores=True,
+                is_active=True,
+            )
+            s.add(method)
+            await s.flush()
+            for key, sp in specs.items():
+                rnd = models.OfferingAdmissionRound(
+                    academic_year=2026,
+                    round_code=f"F43_{key[:3].upper()}_{ts}",
+                    round_name=f"F43 {key} {ts}",
+                    is_active=sp["active"],
+                    archived_at=sp["archived"],
+                    start_date=sp["start"],
+                    end_date=sp["end"],
+                )
+                s.add(rnd)
+                await s.flush()
+                round_ids[key] = rnd.id
+                s.add(
+                    models.AdmissionPath(
+                        academic_info_id=ai_id,
+                        admission_method_id=method.id,
+                        admission_round_id=rnd.id,
+                        status="active",
+                        visibility="public",
+                    )
+                )
+            await s.flush()
+
+    async with AsyncSessionLocal() as s:
+        # round=None → only the OPEN round's path among our specs
+        got = {
+            p.admission_round_id
+            for p in await _load_public_paths(s, {ai_id})
+        }
+        assert round_ids["open"] in got
+        for key in ("expired", "future", "archived", "inactive"):
+            assert round_ids[key] not in got, (
+                f"{key} round leaked into round=None storefront"
+            )
+
+        # explicit ineligible round → empty (no single-round stale serve)
+        for key in ("expired", "future", "archived", "inactive"):
+            pinned = await _load_public_paths(
+                s, {ai_id}, admission_round_id=round_ids[key]
+            )
+            assert pinned == [], f"{key} round must serve zero paths"
+
+        # explicit OPEN round → its path only
+        open_paths = await _load_public_paths(
+            s, {ai_id}, admission_round_id=round_ids["open"]
+        )
+        assert open_paths
+        assert all(
+            p.admission_round_id == round_ids["open"] for p in open_paths
+        )
+
+
+@pytest.mark.asyncio
 async def test_create_profile_snapshot_includes_admission_round_id(
     path_seed: dict, seed_lead_dependencies: dict
 ):

--- a/Backend_FastAPI/tests/unit/test_public_admissions_phase1_wave6.py
+++ b/Backend_FastAPI/tests/unit/test_public_admissions_phase1_wave6.py
@@ -136,7 +136,7 @@ class TestAudienceFilterPropagation:
         async def fake_snapshot(db):
             return [], {}, set()
 
-        async def fake_load_paths(db, ids, audience=None):
+        async def fake_load_paths(db, ids, audience=None, admission_round_id=None):
             captured["audience"] = audience
             return []
 
@@ -166,7 +166,7 @@ class TestAudienceFilterPropagation:
         async def fake_snapshot(db):
             return [], {}, set()
 
-        async def fake_load_paths(db, ids, audience=None):
+        async def fake_load_paths(db, ids, audience=None, admission_round_id=None):
             captured["audience"] = audience
             return []
 
@@ -196,7 +196,7 @@ class TestAudienceFilterPropagation:
         async def fake_snapshot(db):
             return [], {}, set()
 
-        async def fake_load_paths(db, ids, audience=None):
+        async def fake_load_paths(db, ids, audience=None, admission_round_id=None):
             captured["audience"] = audience
             return []
 
@@ -289,7 +289,7 @@ class TestDocumentsCatalogTierAggregation:
         offering_type_models,
         method_models,
     ) -> PublicAdmissionsDocumentsResponse:
-        async def fake_load_paths(db, ids, audience=None):
+        async def fake_load_paths(db, ids, audience=None, admission_round_id=None):
             return paths
 
         async def fake_load_tiers(db, _paths):


### PR DESCRIPTION
## F43 — storefront chỉ serve round public-eligible

Fixes the storefront leak (deferred gap **F43** from the round-contract audit): the public catalog served paths from **expired rounds** alongside the open one.

### Vấn đề (prod 2026-05-26)
`_load_public_paths(round=None)` chỉ lọc `status=active` + `visibility=public`, **không** lọc trạng thái round. Snapshot prod:

| round | window | active+public paths | trạng thái |
|---|---|---|---|
| DOT_1 | 01/01→**31/03** | **32** | hết hạn ~2 tháng, chưa archive |
| DOT_2 | 01/04→30/06 | 32 | open |

→ visitor gọi storefront không truyền round thấy **lẫn phương thức/lệ phí DOT_1 đã đóng** với DOT_2.

### Fix (1a — path-keyed: programs / methods / documents)
- `_load_public_paths` **luôn** join + filter `OfferingAdmissionRound`: public-eligible = `is_active` + `archived_at IS NULL` + trong cửa sổ `[start_date, end_date]` (NULL bound = open-ended).
- `round=None` đổi nghĩa: **all public-eligible rounds** (không còn "all rounds"). Pin explicit vào round expired/archived/**future** → trả `[]`.
- `today_vn()` helper mới (`Asia/Ho_Chi_Minh`) thay `date.today()` → tránh lệch ngày UTC-container quanh midnight.
- Router doc cập nhật theo nghĩa mới.

### Out of scope (fast-follow riêng)
- **1b /tuition**: offering-keyed (`_load_public_program_snapshot`), chưa bao giờ round-aware → không phải regression; round-eligibility cho tuition là PR riêng (derive offering từ eligible public paths).
- transfer-round, submit Gap #3, DOT_1 data cleanup: tracked riêng.

### Tests
- **F43 anchor** `test_storefront_excludes_ineligible_rounds`: expired/future/archived/inactive bị loại cả ở `round=None` lẫn pin explicit; open round vẫn serve. Non-tautological (real rounds + SQL filter, không mock).
- Allowlist **Tier 5** thêm `test_phase2_admission_path_quota_integration.py` + `test_public_admissions_phase1_wave6.py` → CI gate bề mặt này. Local Tier 5 đầy đủ: **39 passed, 3 skipped**.
- Dọn test-debt pre-existing: 4 `fake_load_paths` ở wave6 thiếu `admission_round_id` kwarg (out-of-date từ PR-2B v2). **Baseline-proven** identical fail trên `origin/main` → không do PR này gây ra.

### Ghi chú reviewer
**Độc lập với PR #341** (Playwright/Casbin hotfix) — file scope khác nhau, không kỳ vọng conflict. Ready cho merge sequence sau khi #341 ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
