### PR TITLE
feat(kv): resolve khu vực ưu tiên theo nơi thường trú — temporal engine + cross-era successor + FE resolve

### DIFF
--- a/Backend_FastAPI/alembic/versions/kv_add_successor_20260526.py
+++ b/Backend_FastAPI/alembic/versions/kv_add_successor_20260526.py
@@ -1,0 +1,59 @@
+"""kv: add successor_ward_code to administrative_nodes + identity backfill
+
+PR-2 cross-era lineage for legacy→current commune resolution. Adds a nullable
+``successor_ward_code`` on administrative_nodes = the CURRENT-era commune code a
+WARD resolves to.
+
+Identity backfill (deterministic, NO external data): any WARD whose own ``code``
+is still a current-era ward (valid_to IS NULL) → successor = own code. Covers
+all current wards + every legacy ward that kept its code through the merger.
+Merged-away legacy wards (code retired) stay NULL until the per-province
+merger-edge data is loaded (separate bulk import).
+
+Revision ID: kv_add_successor_20260526
+Revises: kv_smoke_cleanup_20260526
+Create Date: 2026-05-26
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "kv_add_successor_20260526"
+down_revision: Union[str, None] = "kv_smoke_cleanup_20260526"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "administrative_nodes",
+        sa.Column("successor_ward_code", sa.String(length=20), nullable=True),
+    )
+    op.create_index(
+        "idx_successor_ward_code",
+        "administrative_nodes",
+        ["successor_ward_code"],
+    )
+    # Identity backfill: WARD whose code is still a current-era ward → self.
+    op.get_bind().execute(
+        sa.text(
+            """
+            UPDATE administrative_nodes a
+            SET successor_ward_code = a.code
+            WHERE a.level = 'WARD'
+              AND EXISTS (
+                SELECT 1 FROM administrative_nodes c
+                WHERE c.level = 'WARD'
+                  AND c.valid_to IS NULL
+                  AND c.is_active = true
+                  AND c.code = a.code
+              )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_successor_ward_code", table_name="administrative_nodes")
+    op.drop_column("administrative_nodes", "successor_ward_code")

--- a/Backend_FastAPI/alembic/versions/kv_smoke_cleanup_20260526.py
+++ b/Backend_FastAPI/alembic/versions/kv_smoke_cleanup_20260526.py
@@ -1,0 +1,49 @@
+"""kv: cleanup SMOKE_* placeholder rows from vn_commune_area_map
+
+The 3-province commune-KV PoC left 32 ``SMOKE_DLK_*`` placeholder rows in
+``vn_commune_area_map`` (fake commune_code, not real GSO codes). They must NOT
+flow into a prod import or pollute KV lookups. This migration deletes every
+``commune_code LIKE 'SMOKE%'`` row and asserts zero remain.
+
+Idempotent: re-running deletes nothing once clean. Safe on prod (where the
+table had no SMOKE rows) — a no-op DELETE.
+
+Revision ID: kv_smoke_cleanup_20260526
+Revises: null_orphan_admin_reminder_tpl
+Create Date: 2026-05-26
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "kv_smoke_cleanup_20260526"
+down_revision: Union[str, None] = "null_orphan_admin_reminder_tpl"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_SMOKE_PREDICATE = "commune_code LIKE 'SMOKE%'"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(f"DELETE FROM vn_commune_area_map WHERE {_SMOKE_PREDICATE}")
+    )
+    # Fail-closed assertion: no SMOKE rows may survive cleanup.
+    remaining = conn.execute(
+        sa.text(
+            f"SELECT count(*) FROM vn_commune_area_map WHERE {_SMOKE_PREDICATE}"
+        )
+    ).scalar()
+    if remaining:
+        raise RuntimeError(
+            f"SMOKE cleanup failed: {remaining} SMOKE_* rows still present "
+            "in vn_commune_area_map"
+        )
+
+
+def downgrade() -> None:
+    # Irreversible: SMOKE_* rows were throwaway PoC placeholders with fake
+    # commune_code — nothing meaningful to restore.
+    pass

--- a/Backend_FastAPI/app/models/administrative_node.py
+++ b/Backend_FastAPI/app/models/administrative_node.py
@@ -26,7 +26,13 @@ class AdministrativeNode(Base):
     province_code = Column(String(20), nullable=False)
     district_code = Column(String(20), nullable=True)
     ward_code = Column(String(20), nullable=True)
-    
+
+    # PR-2 cross-era lineage: for a WARD node, the CURRENT-era commune code it
+    # resolves to. Current/survived wards → own code (identity); legacy wards
+    # merged into a new commune → the new commune code; NULL = unresolved (the
+    # resolver fail-closes so the officer must re-pick the current commune).
+    successor_ward_code = Column(String(20), nullable=True)
+
     valid_from = Column(Date, nullable=False)
     valid_to = Column(Date, nullable=True)
     
@@ -41,4 +47,5 @@ class AdministrativeNode(Base):
         Index("idx_province", "province_code"),
         Index("idx_district", "district_code"),
         Index("idx_valid_time", "valid_from", "valid_to"),
+        Index("idx_successor_ward_code", "successor_ward_code"),
     )

--- a/Backend_FastAPI/app/repositories/administrative_repository.py
+++ b/Backend_FastAPI/app/repositories/administrative_repository.py
@@ -152,6 +152,25 @@ class AdministrativeRepository(BaseRepository[AdministrativeNode]):
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def get_current_ward_name(self, code: str) -> Optional[str]:
+        """Name of a CURRENT-era (valid_to IS NULL) ward by code — for the
+        resolve-ward endpoint to display the canonical commune to the officer."""
+        code = (code or "").strip()
+        if not code:
+            return None
+        stmt = (
+            select(AdministrativeNode.name)
+            .where(
+                AdministrativeNode.code == code,
+                AdministrativeNode.level == AdministrativeLevel.WARD,
+                AdministrativeNode.valid_to.is_(None),
+                AdministrativeNode.is_active == True,
+            )
+            .limit(1)
+        )
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()
+
     # ------------------------------------------------------------------
     # GENERIC FILTERED (admin panel)
     # ------------------------------------------------------------------

--- a/Backend_FastAPI/app/repositories/administrative_repository.py
+++ b/Backend_FastAPI/app/repositories/administrative_repository.py
@@ -126,6 +126,32 @@ class AdministrativeRepository(BaseRepository[AdministrativeNode]):
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def resolve_current_ward_code(self, ward_code: str) -> Optional[str]:
+        """Resolve ANY ward code (current or legacy) to its CURRENT-era commune
+        code via ``successor_ward_code`` (PR-2 cross-era lineage).
+
+        * current / survived ward → its own code (identity backfill)
+        * legacy ward merged into a new commune → the new commune code
+        * unknown code, or legacy ward with no successor mapped yet → ``None``
+
+        Caller fail-closes on ``None`` (officer re-picks current commune), so a
+        profile never persists a stale legacy code.
+        """
+        code = (ward_code or "").strip()
+        if not code:
+            return None
+        stmt = (
+            select(AdministrativeNode.successor_ward_code)
+            .where(
+                AdministrativeNode.code == code,
+                AdministrativeNode.level == AdministrativeLevel.WARD,
+                AdministrativeNode.successor_ward_code.isnot(None),
+            )
+            .limit(1)
+        )
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()
+
     # ------------------------------------------------------------------
     # GENERIC FILTERED (admin panel)
     # ------------------------------------------------------------------

--- a/Backend_FastAPI/app/routers/administrative.py
+++ b/Backend_FastAPI/app/routers/administrative.py
@@ -19,6 +19,7 @@ from app.repositories.administrative_repository import AdministrativeRepository
 from app.schemas.administrative import (
     ProvinceResponse,
     DistrictResponse,
+    ResolveWardResponse,
     WardResponse,
 )
 
@@ -107,3 +108,30 @@ async def get_wards(
         )
         for w in wards
     ]
+
+
+@router.get("/resolve-ward", response_model=ResolveWardResponse)
+async def resolve_ward(
+    code: str = Query(..., description="Ward code (current or legacy) to canonicalize"),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(deps.get_current_active_user),
+):
+    """PR-3: resolve a ward code (current OR legacy 3-tier) to its canonical
+    CURRENT-era commune (code + name).
+
+    The FE calls this when an officer picks an address — esp. from an old
+    (3-tier) document — so the profile stores the current commune code and the
+    UI can show "→ Xã X (hiện hành)". ``resolved=false`` → officer must pick a
+    current-mode commune (the submit gate also fail-closes).
+    """
+    repo = AdministrativeRepository(db)
+    current_code = await repo.resolve_current_ward_code(code)
+    current_name = (
+        await repo.get_current_ward_name(current_code) if current_code else None
+    )
+    return ResolveWardResponse(
+        input_code=code,
+        current_code=current_code,
+        current_name=current_name,
+        resolved=current_code is not None,
+    )

--- a/Backend_FastAPI/app/schemas/administrative.py
+++ b/Backend_FastAPI/app/schemas/administrative.py
@@ -37,3 +37,15 @@ class WardDetailResponse(WardResponse):
     valid_from: date
     valid_to: Optional[date] = None
     old_district_name: Optional[str] = None
+
+
+class ResolveWardResponse(BaseModel):
+    """PR-3: resolve any ward code (current or legacy) → canonical current commune.
+
+    ``resolved=False`` (current_code=None) means the input couldn't be mapped to a
+    current-era commune → FE keeps the officer on a current-mode pick (submit gate
+    also fail-closes)."""
+    input_code: str
+    current_code: Optional[str] = None
+    current_name: Optional[str] = None
+    resolved: bool

--- a/Backend_FastAPI/app/schemas/vn_locality.py
+++ b/Backend_FastAPI/app/schemas/vn_locality.py
@@ -16,7 +16,10 @@ class VnCommuneAreaMapRow(BaseModel):
     """Single CSV row payload for commune import (BNV format)."""
     commune_code: str = Field(min_length=1, max_length=20)
     province: str = Field(min_length=1, max_length=100)
-    district: str = Field(min_length=1, max_length=100)
+    # district allows empty: the post-2025 2-tier model (Tỉnh → Xã) drops the
+    # district level, so current-era commune rows carry district="". The DB
+    # column is NOT NULL but accepts ''. (Legacy 3-tier rows still populate it.)
+    district: str = Field(default="", max_length=100)
     ward: str = Field(min_length=1, max_length=100)
     area_code: str = Field(pattern=r"^KV[1-9](-NT)?$")
 

--- a/Backend_FastAPI/app/scripts/build_qd861_kv_dataset.py
+++ b/Backend_FastAPI/app/scripts/build_qd861_kv_dataset.py
@@ -15,8 +15,13 @@ Output:
 CSV columns match vn_locality_service.import_commune_csv:
     commune_code, province, district, ward, area_code
 
-Convention (locked 2026-05-18, [[q9-07-pr5-phase-a-shipped-2026-05-18]]):
-- commune_code = "{province_code}_{ward_code}"  e.g. "01_00025"
+Convention (revised 2026-05-26 — see commune_code note):
+- commune_code = ward.code (raw, e.g. "00025"). administrative_nodes.code is
+  nationally-unique for current-era wards, and the FE stores that raw code in
+  profile.permanent_commune_code. The earlier "{province_code}_{ward_code}"
+  composed form was dropped because the province prefix only desynced the KV
+  catalog key from the FE-stored code (commune KV never resolved). Engine
+  lookup is opaque equality, so raw is safe everywhere.
 - district = ""  (post-sáp nhập 2025 không còn cấp huyện)
 - area_code regex `^KV[1-9](-NT)?$` (CHECK constraint phase1_08b)
 
@@ -184,7 +189,7 @@ def build_rows(
             )
         rows.append(
             {
-                "commune_code": f"{p.code}_{w.code}",
+                "commune_code": w.code,  # raw ward.code (matches FE permanent_commune_code)
                 "province": p.name,
                 "district": "",
                 "ward": w.name,

--- a/Backend_FastAPI/app/scripts/load_successor_edges.py
+++ b/Backend_FastAPI/app/scripts/load_successor_edges.py
@@ -1,0 +1,88 @@
+"""Load successor merger edges (legacy_code → current_code) into
+``administrative_nodes.successor_ward_code``.
+
+PR-2 cross-era lineage: the migration ``kv_add_successor_20260526`` backfills
+the IDENTITY edges (wards whose code survived). This script loads the explicit
+MERGED-AWAY edges (legacy code → the new commune code), per-province batch,
+from a CSV produced off the province KV file.
+
+CSV columns: ``legacy_code,current_code[,audit_old_to_new]``
+
+Idempotent (re-running re-sets the same successor). Fail-soft per row:
+* validates ``current_code`` IS a current-era ward (valid_to IS NULL) — else
+  the row is rejected (would create a dangling successor).
+* updates only LEGACY ward rows (valid_to IS NOT NULL) for ``legacy_code``.
+
+Usage (inside backend container, CSV bind-mounted):
+
+    docker compose run --rm --no-deps backend \\
+        python -m app.scripts.load_successor_edges --csv /path/successor_edges.csv
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+
+from sqlalchemy import text
+
+from app.database import AsyncSessionLocal
+
+
+async def load_edges(csv_path: str) -> dict:
+    with open(csv_path, encoding="utf-8-sig", newline="") as f:
+        rows = list(csv.DictReader(f))
+
+    applied = 0
+    rejected_no_current = 0
+    no_legacy_row = 0
+    async with AsyncSessionLocal() as s:
+        for r in rows:
+            legacy_code = (r.get("legacy_code") or "").strip()
+            current_code = (r.get("current_code") or "").strip()
+            if not legacy_code or not current_code:
+                continue
+            valid_current = (await s.execute(
+                text(
+                    "SELECT 1 FROM administrative_nodes WHERE code=:c "
+                    "AND level='WARD' AND valid_to IS NULL AND is_active=true LIMIT 1"
+                ),
+                {"c": current_code},
+            )).first()
+            if not valid_current:
+                rejected_no_current += 1
+                continue
+            res = await s.execute(
+                text(
+                    "UPDATE administrative_nodes SET successor_ward_code=:cc "
+                    "WHERE code=:lc AND level='WARD' AND valid_to IS NOT NULL"
+                ),
+                {"cc": current_code, "lc": legacy_code},
+            )
+            if res.rowcount:
+                applied += res.rowcount
+            else:
+                no_legacy_row += 1
+        await s.commit()
+
+    return {
+        "rows": len(rows),
+        "applied": applied,
+        "rejected_no_current_ward": rejected_no_current,
+        "no_legacy_row_matched": no_legacy_row,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Load successor merger edges")
+    ap.add_argument("--csv", required=True, help="Path to successor_edges CSV")
+    args = ap.parse_args()
+    result = asyncio.run(load_edges(args.csv))
+    print(
+        "Successor edges loaded: applied=%(applied)d rejected_no_current_ward=%(rejected_no_current_ward)d "
+        "no_legacy_row_matched=%(no_legacy_row_matched)d (rows=%(rows)d)" % result
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4641,6 +4641,36 @@ async def _audit_warning_dismissed_if_missing(
         )
 
 
+async def _is_current_era_ward(db: AsyncSession, commune_code: Optional[str]) -> bool:
+    """True iff ``commune_code`` is a CURRENT-era (2-tier, ``valid_to IS NULL``)
+    ward node in ``administrative_nodes``.
+
+    Gap #3 submit gate uses this: a legacy / stale / missing code → False, so
+    submit fail-closes and forces re-selecting the post-2025 commune. This
+    guarantees the stored ``permanent_commune_code`` is the canonical current
+    code KV resolution + records rely on (never a deprecated 3-tier code).
+    """
+    code = (commune_code or "").strip()
+    if not code:
+        return False
+    from sqlalchemy import select as _sel
+    from app.models.administrative_node import (
+        AdministrativeLevel,
+        AdministrativeNode,
+    )
+    result = await db.execute(
+        _sel(AdministrativeNode.id)
+        .where(
+            AdministrativeNode.code == code,
+            AdministrativeNode.level == AdministrativeLevel.WARD,
+            AdministrativeNode.valid_to.is_(None),
+            AdministrativeNode.is_active.is_(True),
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
 async def submit_and_evaluate(
     db: AsyncSession,
     profile_id: int,
@@ -5011,6 +5041,29 @@ async def submit_and_evaluate(
     )
     if kv_error:
         errors.append(kv_error)
+
+    # Gap #3 — applicant identity + permanent-address completeness (production
+    # scope, locked 2026-05-26). Submit already gates citizen_id / family_info /
+    # academic_history / docs / scores / KV but NOT name / phone / permanent
+    # address. Scope: full_name + phone + permanent_province + permanent_ward.
+    # NOT district (the 2025 2-tier reform dropped the district level — FE mode
+    # "current" doesn't collect it, prod rows leave it empty). The ward must be a
+    # CURRENT-era commune node (administrative_nodes valid_to IS NULL), not merely
+    # present: a legacy-era code can't resolve KV and is a deprecated address, so
+    # submit fail-closes and forces re-selecting the current commune.
+    if not (profile.full_name or "").strip():
+        errors.append("Chưa nhập họ tên thí sinh (full_name)")
+    if not (profile.phone or "").strip():
+        errors.append("Chưa nhập số điện thoại (phone)")
+    if not (profile.permanent_province or "").strip():
+        errors.append("Thiếu địa chỉ thường trú: Tỉnh/Thành phố")
+    if not (profile.permanent_ward or "").strip():
+        errors.append("Thiếu địa chỉ thường trú: Phường/Xã")
+    elif not await _is_current_era_ward(db, profile.permanent_commune_code):
+        errors.append(
+            "Phường/Xã thường trú phải theo địa giới hiện hành (2 cấp, sau "
+            "01/07/2025). Vui lòng chọn lại Phường/Xã hiện tại."
+        )
 
     # ✅ CRITICAL FIX #1: Submit should transition to SUBMITTED, not APPROVED/REJECTED
     # Per ADMISSION_STATE_MACHINE: draft → submitted (wait for Manager approval)

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4047,7 +4047,22 @@ async def update_profile(
     if "vocational_qualification" in data and data["vocational_qualification"] is not None:
         profile.vocational_qualification = data["vocational_qualification"]
     if "permanent_commune_code" in data:
-        profile.permanent_commune_code = data["permanent_commune_code"]
+        _raw_cc = data["permanent_commune_code"]
+        if _raw_cc:
+            # PR-3: canonicalize to the CURRENT commune code. An officer may
+            # enter an old (3-tier) code from a legacy document; store the
+            # resolved current code so KV + records always use the canonical
+            # commune. Unresolvable → keep raw (submit gate fail-closes on a
+            # non-current code, forcing a current-mode re-pick).
+            from app.repositories.administrative_repository import (
+                AdministrativeRepository,
+            )
+            _resolved_cc = await AdministrativeRepository(db).resolve_current_ward_code(
+                _raw_cc
+            )
+            profile.permanent_commune_code = _resolved_cc or _raw_cc
+        else:
+            profile.permanent_commune_code = _raw_cc
     if "area_resolution_basis" in data:
         profile.area_resolution_basis = data["area_resolution_basis"]
     if "priority_object_codes" in data and data["priority_object_codes"] is not None:

--- a/Backend_FastAPI/app/services/priority_service.py
+++ b/Backend_FastAPI/app/services/priority_service.py
@@ -35,7 +35,7 @@ Compliance source (TT 05/2021/TT-BLĐTBXH Phụ lục 01)
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -436,21 +436,31 @@ def _derive_kv_basis_level(
 
 
 async def _lookup_commune_kv(
-    db: "AsyncSession", commune_code: str
+    db: "AsyncSession", commune_code: str, year: int
 ) -> Optional[str]:
-    """Lookup active KV for a commune_code from vn_commune_area_map.
+    """Lookup KV for a commune_code from vn_commune_area_map, AS-OF the given
+    academic year (temporal — mirrors ``lookup_kv_for_school_year`` semantics).
 
-    Active row = effective_to IS NULL. Returns None if commune not in table
-    (graceful — Phase B.2 may not have full coverage yet).
+    A KV row is effective for ``year`` when it is the active policy at the end
+    of that academic year (half-open interval): ``effective_from <= Dec-31-year``
+    AND ``effective_to`` is NULL or strictly after Dec-31-year. So a mid-year KV
+    reclassification (xã hết khó khăn → KV đổi), recorded as expire-old +
+    insert-new, resolves to the correct row per year instead of always taking
+    the "now" row — which would silently mis-score historical/future cycles.
+    Returns None if commune not in table (graceful — coverage may be partial).
     """
     from app.models.vn_locality import VnCommuneAreaMap
 
+    as_of = date(year, 12, 31)
     stmt = (
         select(VnCommuneAreaMap.area_code)
         .where(
             VnCommuneAreaMap.commune_code == commune_code,
-            VnCommuneAreaMap.effective_to.is_(None),
+            VnCommuneAreaMap.effective_from <= as_of,
+            (VnCommuneAreaMap.effective_to.is_(None))
+            | (VnCommuneAreaMap.effective_to > as_of),
         )
+        .order_by(VnCommuneAreaMap.effective_from.desc())
         .limit(1)
     )
     result = await db.execute(stmt)
@@ -533,6 +543,11 @@ async def resolve_kv_for_profile(
     vocational = getattr(profile, "vocational_qualification", "none") or "none"
     area_basis = getattr(profile, "area_resolution_basis", None)
     academic_history = getattr(profile, "academic_history", None) or []
+    # Temporal KV: resolve commune KV as-of the profile's admission year so a
+    # mid-year KV reclassification doesn't silently mis-score. Mirrors the
+    # academic_year semantics of lookup_kv_for_school_year. Fallback to current
+    # year for drafts without academic_year set.
+    kv_year = getattr(profile, "academic_year", None) or date.today().year
 
     basis, basis_reason = _derive_kv_basis_level(
         cultural=cultural,
@@ -560,7 +575,7 @@ async def resolve_kv_for_profile(
                 requires_manual_override=True,
                 reason="special_case_no_commune_code",
             )
-        kv = await _lookup_commune_kv(db, commune_code)
+        kv = await _lookup_commune_kv(db, commune_code, kv_year)
         if kv is None:
             return None, _meta_base(
                 rule_applied="catalog_gap_commune",
@@ -614,7 +629,7 @@ async def resolve_kv_for_profile(
                 requires_manual_override=True,
                 reason="profile_missing_permanent_commune_code",
             )
-        kv = await _lookup_commune_kv(db, commune_code)
+        kv = await _lookup_commune_kv(db, commune_code, kv_year)
         if kv is None:
             return None, _meta_base(
                 rule_applied="catalog_gap_commune",

--- a/Backend_FastAPI/scripts/seeds/seed_administrative_nodes.py
+++ b/Backend_FastAPI/scripts/seeds/seed_administrative_nodes.py
@@ -233,7 +233,12 @@ def build_trees(records: list[dict], mapping: dict) -> tuple:
             if rec["old_ward_code"]:
                 wards = tree_old[old_norm]["districts"][dist_name]["wards"]
                 if not any(w["code"] == rec["old_ward_code"] for w in wards):
-                    wards.append({"code": rec["old_ward_code"], "name": rec["old_ward_name"]})
+                    # PR-2: carry the authoritative successor (new_ward_code) so
+                    # the legacy ward node resolves cross-era to its current commune.
+                    wards.append({
+                        "code": rec["old_ward_code"], "name": rec["old_ward_name"],
+                        "successor": rec["new_ward_code"] or None,
+                    })
         else:
             unmapped.add(old_prov_raw)
         
@@ -326,6 +331,8 @@ async def seed_wards_3level(db: AsyncSession, tree_old: dict, dist_map: dict) ->
                     parent_id=dist_id, path=path,
                     province_code=prov_code, district_code=dist_code, ward_code=ward["code"],
                     valid_from=LEGACY_VALID_FROM, valid_to=LEGACY_VALID_TO, is_active=True,
+                    # PR-2 cross-era lineage: legacy ward → current commune code.
+                    successor_ward_code=ward.get("successor"),
                 )
                 db.add(node)
                 count += 1
@@ -386,6 +393,8 @@ async def seed_wards_2level(db: AsyncSession, tree_new: dict, prov_map: dict) ->
                 parent_id=prov_id, path=path,
                 province_code=prov_code, district_code=None, ward_code=ward["code"],
                 valid_from=NEW_VALID_FROM, valid_to=None, is_active=True,
+                # PR-2: current ward → itself (identity).
+                successor_ward_code=ward["code"],
             )
             db.add(node)
             count += 1

--- a/Backend_FastAPI/tests/api/test_admission_workflow_api.py
+++ b/Backend_FastAPI/tests/api/test_admission_workflow_api.py
@@ -24,6 +24,10 @@ from sqlalchemy import select
 
 from app import models
 from app.database import AsyncSessionLocal
+from tests.fixtures.builders import (
+    SUBMITTABLE_PERMANENT_ADDRESS,
+    ensure_submittable_ward,
+)
 
 try:
     from tests.fixtures.constants import AuthURLs, LeadsURLs, TestUsers
@@ -119,8 +123,11 @@ async def _submit(
     if school_id is not None:
         academic_entry["school_id"] = school_id
 
+    # Gap #3 submit gate: seed current-era ward + fill permanent address.
+    await ensure_submittable_ward()
     ur = await client.put(ADM(pid), json={
         "version": v, "citizen_id": cid, "gender": "male", "dob": "2001-01-01",
+        **SUBMITTABLE_PERMANENT_ADDRESS,
         "nationality": "Viet Nam", "ethnicity": "Kinh", "place_of_birth": "Test",
         "family_info": [{"relationship": "Cha", "full_name": "P", "phone": "0901111111", "is_primary_guardian": True}],
         "academic_history": [academic_entry],
@@ -342,6 +349,52 @@ async def adm_lead(client: AsyncClient, admin_token_headers: dict, officer_user_
 # =============================================================================
 # TESTS
 # =============================================================================
+
+@pytest.mark.asyncio
+async def test_submit_without_permanent_address_stays_draft_gap3(client, officer_user_in_db, adm_lead, adm_config):
+    """Gap #3 INTEGRATION anchor (KV PR): a config-complete, eligible profile
+    missing the permanent address must NOT submit — submit returns 200 with
+    status='draft' + the 'Thiếu địa chỉ thường trú' validation errors. This
+    locks the full submit→Gap#3 wiring (the regression this PR's fixtures fix),
+    beyond the direct unit test of ``_is_current_era_ward``.
+    """
+    oh = await _officer(client, officer_user_in_db)
+    lead_id = adm_lead["id"]
+    from tests._lead_status_test_ids import INITIAL_LEAD_STATUS_ID
+    await client.post(f"{LeadsURLs.LEADS}/{lead_id}/consultations", json={
+        "status_id": INITIAL_LEAD_STATUS_ID, "method": "phone", "notes": "pre-admission",
+    }, headers=oh)
+    r = await client.post(ADMISSIONS, json={
+        "lead_id": lead_id, "admission_method_id": adm_config["method_id"],
+        "admission_round_id": adm_config["round_id"], "academic_year": 2026,
+    }, headers=oh)
+    assert r.status_code in (200, 201), r.text
+    pid, v = r.json()["id"], r.json()["version"]
+    cid = f"{int(datetime.now().timestamp()) % 10**12:012d}"
+    # Fill everything EXCEPT permanent address (passes CONFIG_GAP, reaches Gap #3).
+    await client.put(ADM(pid), json={
+        "version": v, "citizen_id": cid, "gender": "male", "dob": "2001-01-01",
+        "nationality": "Viet Nam", "ethnicity": "Kinh", "place_of_birth": "Test",
+        "family_info": [{"relationship": "Cha", "full_name": "P", "phone": "0901111111", "is_primary_guardian": True}],
+        "academic_history": [{"school_name": "THPT", "year_from": 2019, "year_to": 2022,
+            "gpa": 8.0, "graduation_type": "THPT", "level": "THPT", "grade_to": 12,
+            "school_id": adm_config["school_id"]}],
+        "admission_scores": {"gpa": 8.0, "subject_scores": {}},
+        "cultural_education_level": "graduated_thpt", "vocational_qualification": "none",
+    }, headers=oh)
+    fresh = (await client.get(ADM(pid), headers=oh)).json()
+    for doc in fresh.get("documents_checklist", []):
+        if doc.get("is_mandatory") and doc.get("status") == "missing":
+            await client.post(f"{ADM(pid)}/documents/{doc['code']}/upload", headers=oh,
+                files={"file": (f"{doc['code']}.pdf", b"%PDF-1.4\n%%EOF", "application/pdf")},
+                data={"actual_submission_format": "photo"})
+    v = (await client.get(ADM(pid), headers=oh)).json()["version"]
+    sr = await client.post(ACT(pid, "submit"), json={"version": v}, headers=oh)
+    assert sr.status_code == 200, sr.text
+    body = sr.json()
+    assert body["status"] == "draft", body
+    assert "thường trú" in " ".join(body.get("validation_errors") or []), body
+
 
 @pytest.mark.asyncio
 async def test_submit_approve_override_finalize_enrolled(client, officer_user_in_db, adm_lead, adm_config):

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -25,6 +25,10 @@ from sqlalchemy import select
 from app import models
 from app.database import AsyncSessionLocal
 from tests.fixtures.constants import AuthURLs, LeadsURLs
+from tests.fixtures.builders import (
+    SUBMITTABLE_PERMANENT_ADDRESS,
+    ensure_submittable_ward,
+)
 
 
 ADMISSIONS = "/api/admissions"
@@ -210,8 +214,12 @@ async def _create_approved_profile(
     #     CĐ chính quy eligibility gate (priority_service.validate_eligibility)
     #   * academic_history entry carries level + grade_to + school_id so the
     #     LICH_SU_THPT branch resolves a KV via vn_school_kv_assignment
+    # Gap #3 submit gate: seed a current-era ward + fill permanent address so
+    # submit transitions to 'submitted' (not draft with "Thiếu địa chỉ thường trú").
+    await ensure_submittable_ward()
     await client.put(f"{ADMISSIONS}/{prof['id']}", json={
         "version": v,
+        **SUBMITTABLE_PERMANENT_ADDRESS,
         "citizen_id": cccd,
         "gender": "male",
         "dob": "2001-01-01",

--- a/Backend_FastAPI/tests/api/test_kv_pr1_submit_gate.py
+++ b/Backend_FastAPI/tests/api/test_kv_pr1_submit_gate.py
@@ -1,0 +1,58 @@
+"""PR-1 anchor: Gap #3 current-era ward gate logic.
+
+The submit gate's novel decision — "permanent_ward must be a CURRENT-era node,
+not merely present" — is extracted into ``_is_current_era_ward`` and unit-tested
+directly here. A full submit_and_evaluate integration (reach the gate + assert
+status='draft') additionally needs a config-complete profile to pass the
+upstream CONFIG_GAP_TARGET_LEVEL eligibility gate (the pre-existing #337
+fixture-seed debt) — tracked as a follow-up.
+
+NOTE: the gate WIRING (full_name / phone / permanent_province / permanent_ward
+presence + this current-era check) is in submit_and_evaluate just before
+``if errors:``; presence checks are trivial string-empty guards.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+import pytest_asyncio
+
+from app.database import AsyncSessionLocal
+from app.models.administrative_node import AdministrativeLevel, AdministrativeNode
+from app.services.admission_service import _is_current_era_ward
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def db(setup_test_database):
+    async with AsyncSessionLocal() as s:
+        try:
+            yield s
+        finally:
+            await s.rollback()
+            await s.close()
+
+
+async def test_is_current_era_ward_gate(db) -> None:
+    """current-era ward → True; legacy / missing / empty / None → False
+    (Gap #3 fail-closed: chỉ chấp nhận xã địa giới hiện hành)."""
+    db.add(AdministrativeNode(
+        code="CUR01", name="Phường Hiện Hành", level=AdministrativeLevel.WARD,
+        path="99/CUR01", province_code="99", ward_code="CUR01",
+        valid_from=date(2025, 7, 1), valid_to=None, is_active=True,
+    ))
+    db.add(AdministrativeNode(
+        code="LEG01", name="Xã Cũ", level=AdministrativeLevel.WARD,
+        path="99/99_001/LEG01", province_code="99", district_code="99_001",
+        ward_code="LEG01", valid_from=date(2010, 1, 1),
+        valid_to=date(2025, 7, 1), is_active=True,  # valid_to set = legacy
+    ))
+    await db.flush()
+
+    assert await _is_current_era_ward(db, "CUR01") is True   # current → pass
+    assert await _is_current_era_ward(db, "LEG01") is False  # legacy → reject
+    assert await _is_current_era_ward(db, "NOPE") is False   # missing → reject
+    assert await _is_current_era_ward(db, "") is False       # empty → reject
+    assert await _is_current_era_ward(db, None) is False     # None → reject

--- a/Backend_FastAPI/tests/api/test_kv_pr3_resolve_and_canonicalize.py
+++ b/Backend_FastAPI/tests/api/test_kv_pr3_resolve_and_canonicalize.py
@@ -1,0 +1,293 @@
+# -*- coding: utf-8 -*-
+"""PR-3 anchors: /resolve-ward endpoint + update_profile canonicalization.
+
+Two untested-before-this paths (review P1 #1):
+
+1. ``GET /api/administrative/resolve-ward`` — resolve any ward code (current or
+   legacy 3-tier) to its canonical CURRENT-era commune via
+   ``successor_ward_code``. Current/survived → self; legacy merged → new code
+   (cross-era); unmapped legacy / unknown → ``resolved=false`` (fail-closed).
+
+2. ``PUT /api/admissions/{id}`` canonicalizes ``permanent_commune_code`` on save:
+   a legacy merged code is stored as the CURRENT code; an unresolvable code is
+   kept raw (so the submit gate fail-closes on it later, forcing a re-pick).
+
+Seed nodes use raw SQL (mirrors test_administrative.py) to avoid ORM session
+conflicts with the test client.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app import models
+from app.database import AsyncSessionLocal
+from tests.fixtures.constants import LeadsURLs
+
+
+ADMISSIONS = "/api/admissions"
+
+# Distinct codes (94/95 era pair) so they can't collide with other admin-node
+# test seeds running in the same module session.
+CURRENT_CODE = "KVC01"
+CURRENT_NAME = "Phường Hiện Hành KV"
+LEGACY_MERGED_CODE = "KVL01"   # merged away → successor = CURRENT_CODE
+LEGACY_UNMAPPED_CODE = "KVL02"  # legacy, no successor mapped yet → fail-closed
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _seed_kv_nodes(setup_test_database):
+    """Seed a current ward + two legacy wards (one merged-away with a successor,
+    one unmapped) into the truncated test DB before each test."""
+    # Inline literals (trusted test constants) — mirrors test_administrative.py.
+    # Bind params can't be reused across a string-concat (text) AND a varchar
+    # column in one asyncpg prepared statement (AmbiguousParameterError).
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            await session.execute(
+                text(
+                    f"""
+                    INSERT INTO administrative_nodes
+                        (code, name, level, path, province_code, district_code,
+                         ward_code, valid_from, valid_to, is_active,
+                         successor_ward_code)
+                    VALUES
+                        -- current ward (2-level): identity successor = self
+                        ('{CURRENT_CODE}', '{CURRENT_NAME}', 'WARD',
+                         '95/{CURRENT_CODE}', '95', NULL,
+                         '{CURRENT_CODE}', '2025-07-01', NULL, true, '{CURRENT_CODE}'),
+                        -- legacy ward merged into the current commune
+                        ('{LEGACY_MERGED_CODE}', 'Xã Cũ Gộp', 'WARD',
+                         '94/94_001/{LEGACY_MERGED_CODE}', '94', '94_001',
+                         '{LEGACY_MERGED_CODE}', '2010-01-01', '2025-06-30', true,
+                         '{CURRENT_CODE}'),
+                        -- legacy ward with NO successor mapped yet (fail-closed)
+                        ('{LEGACY_UNMAPPED_CODE}', 'Xã Cũ Chưa Map', 'WARD',
+                         '94/94_001/{LEGACY_UNMAPPED_CODE}', '94', '94_001',
+                         '{LEGACY_UNMAPPED_CODE}', '2010-01-01', '2025-06-30', true,
+                         NULL)
+                    """
+                )
+            )
+
+
+# ===========================================================================
+# 1. GET /resolve-ward
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_resolve_ward_current_returns_self(
+    client: AsyncClient, regular_user_token_headers: dict
+):
+    """Current-era code → resolves to itself with its current name."""
+    resp = await client.get(
+        "/api/administrative/resolve-ward",
+        params={"code": CURRENT_CODE},
+        headers=regular_user_token_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "input_code": CURRENT_CODE,
+        "current_code": CURRENT_CODE,
+        "current_name": CURRENT_NAME,
+        "resolved": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_ward_legacy_merged_returns_current(
+    client: AsyncClient, regular_user_token_headers: dict
+):
+    """Cross-era: a legacy merged-away code resolves to the CURRENT commune
+    (different code, current name) — the core PR-3 behavior."""
+    resp = await client.get(
+        "/api/administrative/resolve-ward",
+        params={"code": LEGACY_MERGED_CODE},
+        headers=regular_user_token_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["input_code"] == LEGACY_MERGED_CODE
+    assert body["current_code"] == CURRENT_CODE        # ← cross-era resolve
+    assert body["current_name"] == CURRENT_NAME
+    assert body["resolved"] is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_ward_unmapped_legacy_fails_closed(
+    client: AsyncClient, regular_user_token_headers: dict
+):
+    """Legacy code with no successor mapped → resolved=false (fail-closed)."""
+    resp = await client.get(
+        "/api/administrative/resolve-ward",
+        params={"code": LEGACY_UNMAPPED_CODE},
+        headers=regular_user_token_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "input_code": LEGACY_UNMAPPED_CODE,
+        "current_code": None,
+        "current_name": None,
+        "resolved": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_ward_unknown_code_fails_closed(
+    client: AsyncClient, regular_user_token_headers: dict
+):
+    """Completely unknown code → resolved=false."""
+    resp = await client.get(
+        "/api/administrative/resolve-ward",
+        params={"code": "NOPE_99999"},
+        headers=regular_user_token_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["current_code"] is None
+    assert body["resolved"] is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_ward_requires_auth(client: AsyncClient):
+    """Endpoint is gated by get_current_active_user — unauthenticated → 401."""
+    resp = await client.get(
+        "/api/administrative/resolve-ward", params={"code": CURRENT_CODE}
+    )
+    assert resp.status_code == 401, resp.text
+
+
+# ===========================================================================
+# 2. PUT /admissions/{id} canonicalizes permanent_commune_code
+# ===========================================================================
+
+@pytest_asyncio.fixture
+async def adm_config(seed_lead_dependencies: dict):
+    """Seed offering chain + path (same shape as
+    test_admissions_partial_update_invariants.adm_config)."""
+    uid = seed_lead_dependencies["unit_id"]
+    mpid = seed_lead_dependencies["major_program_id"]
+    ts = f"{int(datetime.now().timestamp() * 1000)}"
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ot = models.ConfigOfferingType(code=f"kv_{ts}", name=f"KV_{ts}", display_order=1)
+            s.add(ot); await s.flush()
+            po = models.ProgramOffering(
+                offering_type=f"KV_{ts}", program_id=mpid, offering_type_id=ot.id,
+                is_active=True, duration_semesters=6,
+            )
+            s.add(po); await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=po.id, academic_year=2026,
+                tuition_fee_per_year=5000000, annual_admission_quota=100, is_published=True,
+            )
+            s.add(ai); await s.flush()
+            am = models.AdmissionMethod(
+                code=f"kvm_{ts}", name=f"KVM_{ts}",
+                requires_gpa=True, requires_subject_scores=False, is_active=True,
+            )
+            s.add(am); await s.flush()
+            ac = models.AdmissionCriteria(
+                method_id=am.id, code=f"KVTC_{ts}", name=f"KVTC_{ts}",
+                min_gpa=6.0, scoring_method="average", subject_selection_mode="fixed",
+                policy_version="2026.1", is_active=True,
+            )
+            s.add(ac); await s.flush()
+            from tests.fixtures.builders import AdmissionRoundBuilder
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(s, academic_year=2026)
+            ap = models.AdmissionPath(
+                academic_info_id=ai.id, admission_method_id=am.id,
+                admission_round_id=round_id, criteria_id=ac.id,
+                status="active", display_name="KV Test", display_order=0, visibility="public",
+            )
+            s.add(ap); await s.flush()
+    return {
+        "unit_id": uid,
+        "offering_id": po.id,
+        "method_id": am.id,
+        "round_id": round_id,
+    }
+
+
+async def _create_draft_profile(
+    client: AsyncClient, admin_token_headers: dict, adm_config: dict,
+    officer_id: int, full_name: str,
+) -> int:
+    """Seed lead + consultation + draft admission profile under admin token."""
+    lead_resp = await client.post(LeadsURLs.LEADS, json={
+        "full_name": full_name,
+        "phone": f"097{int(datetime.now().timestamp()) % 10_000_000:07d}",
+        "source": "website",
+        "unit_id": adm_config["unit_id"],
+        "assigned_officer_id": officer_id,
+        "offering_id": adm_config["offering_id"],
+    }, headers=admin_token_headers)
+    assert lead_resp.status_code in (200, 201), lead_resp.text
+    lead_id = lead_resp.json()["id"]
+
+    from tests._lead_status_test_ids import INITIAL_LEAD_STATUS_ID
+    cons = await client.post(
+        f"{LeadsURLs.LEADS}/{lead_id}/consultations",
+        json={"status_id": INITIAL_LEAD_STATUS_ID, "method": "phone", "notes": "pre-admission"},
+        headers=admin_token_headers,
+    )
+    assert cons.status_code in (200, 201), cons.text
+
+    prof = await client.post(ADMISSIONS, json={
+        "lead_id": lead_id,
+        "admission_method_id": adm_config["method_id"],
+        "admission_round_id": adm_config["round_id"],
+        "academic_year": 2026,
+    }, headers=admin_token_headers)
+    assert prof.status_code in (200, 201), prof.text
+    return prof.json()["id"]
+
+
+async def _read_commune_code(profile_id: int) -> str | None:
+    async with AsyncSessionLocal() as s:
+        prof = await s.get(models.AdmissionProfile, profile_id)
+        return prof.permanent_commune_code
+
+
+@pytest.mark.asyncio
+async def test_update_canonicalizes_legacy_merged_to_current(
+    client: AsyncClient, admin_token_headers: dict,
+    officer_user_in_db: dict, adm_config: dict,
+):
+    """PUT with a legacy merged code stores the CURRENT code (canonicalized),
+    never the legacy code."""
+    pid = await _create_draft_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "KV Canonicalize Cross-Era",
+    )
+    r = await client.put(
+        f"{ADMISSIONS}/{pid}",
+        json={"version": 1, "permanent_commune_code": LEGACY_MERGED_CODE},
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert await _read_commune_code(pid) == CURRENT_CODE  # stored canonical, not legacy
+
+
+@pytest.mark.asyncio
+async def test_update_keeps_unresolvable_code_raw(
+    client: AsyncClient, admin_token_headers: dict,
+    officer_user_in_db: dict, adm_config: dict,
+):
+    """PUT with an unresolvable code keeps it raw (submit gate fail-closes
+    later) — canonicalization must not blank out an unknown code."""
+    pid = await _create_draft_profile(
+        client, admin_token_headers, adm_config,
+        officer_user_in_db["id"], "KV Canonicalize Fallback",
+    )
+    r = await client.put(
+        f"{ADMISSIONS}/{pid}",
+        json={"version": 1, "permanent_commune_code": LEGACY_UNMAPPED_CODE},
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert await _read_commune_code(pid) == LEGACY_UNMAPPED_CODE  # kept raw

--- a/Backend_FastAPI/tests/fixtures/builders.py
+++ b/Backend_FastAPI/tests/fixtures/builders.py
@@ -27,6 +27,69 @@ def reset_id_counter(start: int = 10000):
     _id_counter = start
 
 
+# ---------------------------------------------------------------------------
+# Gap #3 submit gate (KV PR) — permanent address + current-era ward.
+# ``submit_and_evaluate`` now requires full_name + phone + permanent_province +
+# permanent_ward AND ``permanent_commune_code`` to be a CURRENT-era WARD
+# (administrative_nodes valid_to IS NULL). Any test that submits a profile for
+# SUCCESS must (1) seed this ward via ``ensure_submittable_ward()`` and (2) fill
+# ``**SUBMITTABLE_PERMANENT_ADDRESS`` in the profile update payload.
+# ---------------------------------------------------------------------------
+SUBMITTABLE_WARD_CODE = "99TESTKV"
+SUBMITTABLE_PERMANENT_ADDRESS = {
+    "permanent_province": "Tỉnh Test KV",
+    "permanent_ward": "Phường Test KV",
+    "permanent_commune_code": SUBMITTABLE_WARD_CODE,
+}
+
+
+async def ensure_submittable_ward() -> str:
+    """Idempotently seed one CURRENT-era WARD node so the Gap #3 submit gate
+    (`_is_current_era_ward`) accepts ``SUBMITTABLE_PERMANENT_ADDRESS``.
+
+    Returns the ward code. Safe to call repeatedly (per-test) — re-running on an
+    already-seeded DB is a no-op.
+    """
+    from datetime import date
+
+    from sqlalchemy import select
+
+    from app.database import AsyncSessionLocal
+    from app.models.administrative_node import (
+        AdministrativeLevel,
+        AdministrativeNode,
+    )
+
+    async with AsyncSessionLocal() as s:
+        exists = (
+            await s.execute(
+                select(AdministrativeNode.id)
+                .where(
+                    AdministrativeNode.code == SUBMITTABLE_WARD_CODE,
+                    AdministrativeNode.level == AdministrativeLevel.WARD,
+                    AdministrativeNode.valid_to.is_(None),
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if exists is None:
+            s.add(
+                AdministrativeNode(
+                    code=SUBMITTABLE_WARD_CODE,
+                    name="Phường Test KV",
+                    level=AdministrativeLevel.WARD,
+                    path=f"99/{SUBMITTABLE_WARD_CODE}",
+                    province_code="99",
+                    ward_code=SUBMITTABLE_WARD_CODE,
+                    valid_from=date(2025, 7, 1),
+                    valid_to=None,
+                    is_active=True,
+                )
+            )
+            await s.commit()
+    return SUBMITTABLE_WARD_CODE
+
+
 class SeedDependenciesBuilder:
     """
     Builder for seeding unit/stage/status dependencies.

--- a/Backend_FastAPI/tests/unit/test_build_qd861_kv_dataset.py
+++ b/Backend_FastAPI/tests/unit/test_build_qd861_kv_dataset.py
@@ -112,9 +112,10 @@ def test_build_rows_full_pipeline(seed_files):
 
     by_code = {r["commune_code"]: r for r in rows}
 
-    # commune_code = {province_code}_{ward_code}
-    assert "01_00004" in by_code
-    assert "68_24829" in by_code
+    # commune_code = raw ward.code (revised 2026-05-26 — dropped province prefix;
+    # ward.code is nationally-unique + matches FE permanent_commune_code)
+    assert "00004" in by_code
+    assert "24829" in by_code
 
     # district always empty (post-sáp nhập 2025)
     assert all(r["district"] == "" for r in rows)
@@ -124,14 +125,14 @@ def test_build_rows_full_pipeline(seed_files):
     assert all(re.match(r"^KV[1-9](-NT)?$", r["area_code"]) for r in rows)
 
     # KV mapping spot checks
-    assert by_code["01_00004"]["area_code"] == "KV3"  # HN Phường
-    assert by_code["01_00376"]["area_code"] == "KV2"  # HN Xã
-    assert by_code["01_06994"]["area_code"] == "KV1"  # Đặc khu (any province)
-    assert by_code["68_24829"]["area_code"] == "KV2"  # Lâm Đồng Phường
-    assert by_code["68_24934"]["area_code"] == "KV2-NT"  # Lâm Đồng Xã
+    assert by_code["00004"]["area_code"] == "KV3"  # HN Phường
+    assert by_code["00376"]["area_code"] == "KV2"  # HN Xã
+    assert by_code["06994"]["area_code"] == "KV1"  # Đặc khu (any province)
+    assert by_code["24829"]["area_code"] == "KV2"  # Lâm Đồng Phường
+    assert by_code["24934"]["area_code"] == "KV2-NT"  # Lâm Đồng Xã
 
     # Apostrophe preserved end-to-end
-    assert by_code["68_24829"]["ward"] == "Phường B'Lao"
+    assert by_code["24829"]["ward"] == "Phường B'Lao"
 
 
 def test_build_rows_rejects_unknown_province(tmp_path):

--- a/Backend_FastAPI/tests/unit/test_kv_pr1_temporal_and_cleanup.py
+++ b/Backend_FastAPI/tests/unit/test_kv_pr1_temporal_and_cleanup.py
@@ -1,0 +1,79 @@
+"""PR-1 anchors: temporal commune-KV (as-of academic_year) + SMOKE cleanup.
+
+Covers:
+* _lookup_commune_kv resolves the KV row effective for the given year (a
+  mid-year reclassification, recorded as expire-old + insert-new, must NOT
+  bleed across years) — the prod blocker the user flagged.
+* SMOKE_* placeholder cleanup predicate removes all + leaves real rows.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.database import AsyncSessionLocal
+from app.models.vn_locality import VnCommuneAreaMap
+from app.services.priority_service import _lookup_commune_kv
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def db(setup_test_database):
+    async with AsyncSessionLocal() as s:
+        try:
+            yield s
+        finally:
+            await s.rollback()
+            await s.close()
+
+
+async def test_lookup_commune_kv_resolves_by_year(db) -> None:
+    """Xã 99001 đổi KV giữa 2026: KV1 đến 01/06/2026, KV2 sau đó.
+    Lookup phải trả KV ĐÚNG THEO NĂM tuyển sinh (không lấy mù 'now')."""
+    db.add(VnCommuneAreaMap(
+        commune_code="99001", province="P", district="", ward="W",
+        area_code="KV1", effective_from=date(2024, 1, 1),
+        effective_to=date(2026, 6, 1),
+    ))
+    db.add(VnCommuneAreaMap(
+        commune_code="99001", province="P", district="", ward="W",
+        area_code="KV2", effective_from=date(2026, 6, 1), effective_to=None,
+    ))
+    await db.flush()
+
+    assert await _lookup_commune_kv(db, "99001", 2025) == "KV1"
+    assert await _lookup_commune_kv(db, "99001", 2026) == "KV2"
+    assert await _lookup_commune_kv(db, "99001", 2027) == "KV2"
+    # commune not in catalog → graceful None
+    assert await _lookup_commune_kv(db, "00000", 2026) is None
+
+
+async def test_smoke_cleanup_predicate_removes_all_and_keeps_real(db) -> None:
+    """Predicate của migration kv_smoke_cleanup_20260526 xóa hết SMOKE_*,
+    giữ nguyên dòng thật, và assert còn 0 SMOKE."""
+    db.add(VnCommuneAreaMap(
+        commune_code="SMOKE_DLK_01", province="P", district="D", ward="W",
+        area_code="KV1", effective_from=date(2026, 1, 1),
+    ))
+    db.add(VnCommuneAreaMap(
+        commune_code="21609", province="Tỉnh Gia Lai", district="", ward="Xã An Lão",
+        area_code="KV1", effective_from=date(2026, 1, 1),
+    ))
+    await db.flush()
+
+    await db.execute(text(
+        "DELETE FROM vn_commune_area_map WHERE commune_code LIKE 'SMOKE%'"
+    ))
+    n_smoke = (await db.execute(text(
+        "SELECT count(*) FROM vn_commune_area_map WHERE commune_code LIKE 'SMOKE%'"
+    ))).scalar()
+    n_real = (await db.execute(text(
+        "SELECT count(*) FROM vn_commune_area_map WHERE commune_code='21609'"
+    ))).scalar()
+
+    assert n_smoke == 0, "migration phải xóa hết SMOKE_*"
+    assert n_real == 1, "dòng thật KHÔNG được đụng"

--- a/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
+++ b/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
@@ -85,3 +85,16 @@ async def test_identity_backfill_predicate(db) -> None:
     assert by[("C", True)] == "C"    # current C → self
     assert by[("C", False)] == "C"   # legacy survived → C
     assert by[("M", False)] is None  # merged away → still NULL (needs merger CSV)
+
+
+async def test_get_current_ward_name(db) -> None:
+    """PR-3 resolve endpoint helper: name of a CURRENT-era ward by code;
+    legacy/unknown → None."""
+    db.add(_ward("CURX", current=True, successor="CURX"))
+    db.add(_ward("LEGX", current=False, successor="CURX", dist="99_1"))
+    await db.flush()
+    repo = AdministrativeRepository(db)
+    assert await repo.get_current_ward_name("CURX") == "Ward CURX"
+    assert await repo.get_current_ward_name("LEGX") is None  # legacy, not current
+    assert await repo.get_current_ward_name("NOPE") is None
+    assert await repo.get_current_ward_name("") is None

--- a/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
+++ b/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
@@ -1,0 +1,87 @@
+"""PR-2 anchors: cross-era successor resolution + identity backfill.
+
+* resolve_current_ward_code: legacy merged code → current code (and a profile
+  therefore never persists the legacy code); current/survived → self; unmapped
+  legacy / unknown / empty → None (fail-closed).
+* identity backfill predicate (the migration's deterministic UPDATE): a ward
+  whose code is still a current-era ward gets successor=self; a merged-away
+  code (no current equivalent) stays NULL.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.database import AsyncSessionLocal
+from app.models.administrative_node import AdministrativeLevel, AdministrativeNode
+from app.repositories.administrative_repository import AdministrativeRepository
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def db(setup_test_database):
+    async with AsyncSessionLocal() as s:
+        try:
+            yield s
+        finally:
+            await s.rollback()
+            await s.close()
+
+
+def _ward(code, *, current, successor, dist=None):
+    return AdministrativeNode(
+        code=code, name=f"Ward {code}", level=AdministrativeLevel.WARD,
+        path=f"99/{code}", province_code="99", district_code=dist, ward_code=code,
+        valid_from=date(2025, 7, 1) if current else date(2010, 1, 1),
+        valid_to=None if current else date(2025, 7, 1),
+        is_active=True, successor_ward_code=successor,
+    )
+
+
+async def test_resolve_current_ward_code(db) -> None:
+    db.add(_ward("CUR1", current=True, successor="CUR1"))                  # current identity
+    db.add(_ward("LEGSAME", current=False, successor="LEGSAME"))           # legacy survived
+    db.add(_ward("LEGMERG", current=False, successor="CUR1", dist="99_1")) # legacy merged → CUR1
+    db.add(_ward("LEGNULL", current=False, successor=None, dist="99_1"))   # legacy unmapped
+    await db.flush()
+    repo = AdministrativeRepository(db)
+
+    assert await repo.resolve_current_ward_code("CUR1") == "CUR1"      # current → self
+    assert await repo.resolve_current_ward_code("LEGSAME") == "LEGSAME"  # survived → self
+    # merged-away legacy → CURRENT code (caller stores this, never the legacy code)
+    assert await repo.resolve_current_ward_code("LEGMERG") == "CUR1"
+    assert await repo.resolve_current_ward_code("LEGNULL") is None     # unmapped → fail-closed
+    assert await repo.resolve_current_ward_code("NOPE") is None        # unknown
+    assert await repo.resolve_current_ward_code("") is None            # empty
+    assert await repo.resolve_current_ward_code(None) is None          # None
+
+
+async def test_identity_backfill_predicate(db) -> None:
+    """Migration's identity UPDATE: code still current → successor=self;
+    merged-away code (no current equivalent) → stays NULL."""
+    db.add(_ward("C", current=True, successor=None))                 # current C
+    db.add(_ward("C", current=False, successor=None, dist="99_1"))   # legacy same code (survived)
+    db.add(_ward("M", current=False, successor=None, dist="99_1"))   # merged away (no current M)
+    await db.flush()
+
+    await db.execute(text(
+        """
+        UPDATE administrative_nodes a SET successor_ward_code = a.code
+        WHERE a.level='WARD' AND EXISTS (
+            SELECT 1 FROM administrative_nodes c
+            WHERE c.level='WARD' AND c.valid_to IS NULL AND c.is_active=true AND c.code=a.code)
+        """
+    ))
+
+    rows = (await db.execute(text(
+        "SELECT code, (valid_to IS NULL) AS cur, successor_ward_code "
+        "FROM administrative_nodes WHERE code IN ('C','M')"
+    ))).all()
+    by = {(r[0], r[1]): r[2] for r in rows}
+    assert by[("C", True)] == "C"    # current C → self
+    assert by[("C", False)] == "C"   # legacy survived → C
+    assert by[("M", False)] is None  # merged away → still NULL (needs merger CSV)

--- a/Backend_FastAPI/tests/unit/test_vn_locality_service.py
+++ b/Backend_FastAPI/tests/unit/test_vn_locality_service.py
@@ -46,6 +46,24 @@ async def test_commune_import_inserts_valid_rows(db) -> None:
     assert result["error_rows"] == []
 
 
+async def test_commune_import_accepts_empty_district_2tier(db) -> None:
+    """2-tier model (post-2025 sáp nhập): current-era communes have NO
+    district, so the importer MUST accept district="". This was rejected by
+    a stale ``min_length=1`` on ``VnCommuneAreaMapRow.district`` which blocked
+    100% of real rows (anchor for the 2026-05-26 relax). commune_code = raw
+    ward.code (e.g. '21609') — matches FE ``permanent_commune_code``."""
+    csv = (
+        b"commune_code,province,district,ward,area_code\n"
+        b"21609,Tinh Gia Lai,,Xa An Lao,KV1\n"
+    )
+    service = VnLocalityService(db)
+    result, _ = await service.import_commune_csv(csv)
+    assert result["inserted"] == 1, result["error_rows"]
+    assert result["error_rows"] == []
+    # raw commune_code resolves through the same opaque-equality lookup
+    assert await service.lookup_commune_kv("21609") == "KV1"
+
+
 async def test_commune_import_skips_duplicate_active_row(db) -> None:
     csv = (
         b"commune_code,province,district,ward,area_code\n"

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Combobox } from "@/components/ui/combobox"
 
 import { useMemo, useState } from "react"
-import type { AddressMode } from "@/lib/api/administrative"
+import { administrativeApi, type AddressMode, type ResolvedWard } from "@/lib/api/administrative"
 import { AdaptiveAddressSelect } from "@/components/forms/AdaptiveAddressSelect"
 import type { AdmissionProfileResponse, AdmissionProfileUpdateInput } from "@/lib/zod/admissions"
 import { useConfigData } from "@/lib/hooks/useConfigData"
@@ -47,6 +47,22 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
   const permanentCommuneCode = useWatch({ control: form.control, name: "permanent_commune_code" }) ?? null
   const permanentResidentialGroup = useWatch({ control: form.control, name: "permanent_residential_group" }) || ""
   const permanentStreetAddress = useWatch({ control: form.control, name: "permanent_street_address" }) || ""
+
+  // PR-3: resolved CURRENT commune for the picked ward (display badge). The BE
+  // canonicalizes permanent_commune_code → current on save, so this is UX only:
+  // officer sees which current commune an old/legacy ward maps to (+ a warning
+  // when it can't be resolved → must pick a current-mode commune).
+  const [resolvedWard, setResolvedWard] = useState<ResolvedWard | null>(null)
+  const resolvePermanentWard = (code: string | null) => {
+    if (!code) {
+      setResolvedWard(null)
+      return
+    }
+    administrativeApi
+      .resolveWard(code)
+      .then(setResolvedWard)
+      .catch(() => setResolvedWard(null))
+  }
 
   // Address mode: local state, re-derived when profile.version changes.
   // Uses React's "adjusting state during render" pattern — no useEffect.
@@ -263,17 +279,21 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
                 form.setValue("permanent_province", value, { shouldDirty: true })
                 // Province reset clears ward chain → mã xã canonical theo đó.
                 form.setValue("permanent_commune_code", null, { shouldDirty: true })
+                setResolvedWard(null)
               }}
               onDistrictChange={(value) => {
                 form.setValue("permanent_district", value || "", { shouldDirty: true })
                 form.setValue("permanent_commune_code", null, { shouldDirty: true })
+                setResolvedWard(null)
               }}
               onWardChange={(value) => form.setValue("permanent_ward", value, { shouldDirty: true })}
               // Phase E.4 KV bridge — engine đọc permanent_commune_code chuẩn,
               // KHÔNG đọc tên ward. PriorityTab hết phải hỏi officer gõ mã.
-              onWardCodeChange={(code) =>
+              // PR-3: resolve picked code → current commune for the badge.
+              onWardCodeChange={(code) => {
                 form.setValue("permanent_commune_code", code, { shouldDirty: true })
-              }
+                resolvePermanentWard(code)
+              }}
               onResidentialGroupChange={(value) => form.setValue("permanent_residential_group", value)}
               onStreetAddressChange={(value) => form.setValue("permanent_street_address", value)}
               mode={addressMode}
@@ -282,14 +302,33 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
                 // Mode switch resets cả tỉnh/quận/xã → mã xã cũng phải clear
                 // để tránh stale code orphan.
                 form.setValue("permanent_commune_code", null, { shouldDirty: true })
+                setResolvedWard(null)
               }}
               disabled={!isEditable}
             />
 
-            {/* Commit 5 — Address normalized indicator. BE engine resolve
-                KV qua permanent_commune_code (canonical). Officer cần thấy
-                trạng thái rõ thay vì chờ fail ở Submit/Priority. */}
-            {permanentCommuneCode ? (
+            {/* Commit 5 + PR-3 — Address normalized indicator. BE engine resolve
+                KV qua permanent_commune_code (canonical, đã quy về xã hiện hành).
+                Officer cần thấy trạng thái rõ thay vì chờ fail ở Submit/Priority. */}
+            {resolvedWard?.resolved && resolvedWard.current_name ? (
+              <p
+                className="text-xs text-success-700 flex items-center gap-1"
+                data-testid="address-resolved-current"
+              >
+                <span aria-hidden="true">✓</span>
+                Tương ứng xã/phường hiện hành: {resolvedWard.current_name} — KV tự xác định
+              </p>
+            ) : resolvedWard && !resolvedWard.resolved ? (
+              <p
+                className="text-xs text-warning-700 flex items-center gap-1"
+                data-testid="address-resolve-warning"
+                role="alert"
+              >
+                <span aria-hidden="true">⚠</span>
+                Xã/phường đã chọn không khớp địa giới hiện hành — vui lòng chọn lại
+                xã/phường hiện tại.
+              </p>
+            ) : permanentCommuneCode ? (
               <p
                 className="text-xs text-success-700 flex items-center gap-1"
                 data-testid="address-normalized-ok"

--- a/frontend/src/lib/api/administrative.ts
+++ b/frontend/src/lib/api/administrative.ts
@@ -29,6 +29,13 @@ export interface Ward {
   district_code: string | null
 }
 
+export interface ResolvedWard {
+  input_code: string
+  current_code: string | null
+  current_name: string | null
+  resolved: boolean
+}
+
 export const administrativeApi = {
   getProvinces: async (mode: AddressMode = "current"): Promise<Province[]> => {
     const { data } = await api.get<Province[]>("/api/administrative/provinces", {
@@ -58,6 +65,19 @@ export const administrativeApi = {
       params.district_code = districtCode
     }
     const { data } = await api.get<Ward[]>("/api/administrative/wards", { params })
+    return data
+  },
+
+  /**
+   * PR-3: resolve any ward code (current or legacy 3-tier) → canonical CURRENT
+   * commune. Used when an officer picks an address (esp. from an old document)
+   * so the UI can show the current commune; the BE also canonicalizes on save.
+   */
+  resolveWard: async (code: string): Promise<ResolvedWard> => {
+    const { data } = await api.get<ResolvedWard>(
+      "/api/administrative/resolve-ward",
+      { params: { code } },
+    )
     return data
   },
 }


### PR DESCRIPTION
## Mục tiêu
Hoàn thiện **tính khu vực ưu tiên (KV) theo nơi thường trú**, an toàn cho cải cách hành chính 2025 (3 cấp → 2 cấp). Officer nhập địa chỉ cũ (3 cấp) → hệ thống tự quy đổi sang xã/phường hiện hành để engine resolve KV đúng. Gom 3 phần gắn kết vào **1 PR** (solo dev, batch để giảm overhead; 1 branch linear → migration apply đúng thứ tự, không rủi ro merge-order).

## Nội dung (5 commit, theo thứ tự logic)
- **PR-1 — engine/gate/cleanup** (`66ae67d9`, `abd7dd11`)
  - Importer chấp nhận `district=""` (mô hình 2 cấp); `commune_code = raw ward.code` (bỏ prefix tỉnh → khớp mã FE lưu + catalog).
  - `_lookup_commune_kv` **temporal as-of năm học** (half-open interval) → KV reclassification giữa năm không mis-score.
  - **Gap #3 submit gate**: bắt buộc `full_name + phone + permanent_province + permanent_ward`, và xã phải là **node hiện hành** (`valid_to IS NULL`) — fail-closed buộc chọn lại xã hiện hành.
  - Migration `kv_smoke_cleanup_20260526`: xoá 32 SMOKE row + assert 0 (idempotent).
- **PR-2 — cross-era lineage** (`5420388d`)
  - Cột `administrative_nodes.successor_ward_code` + index + migration identity backfill (ward hiện hành → chính nó); loader CSV merger-edge.
- **PR-3 — FE resolve + canonicalize** (`c523ff1d`, `583e729c`)
  - Endpoint `GET /api/administrative/resolve-ward` (current/legacy → current commune).
  - `update_profile` canonicalize `permanent_commune_code` về mã hiện hành khi save (không resolve được → giữ raw, submit gate fail-closed).
  - FE badge trên PersonalInfoTab + 7 anchor test (endpoint + canonicalize).

## Migrations (2, đã verify reversible)
`null_orphan_admin_reminder_tpl → kv_smoke_cleanup_20260526 → kv_add_successor_20260526`. Roundtrip up→down→up trên DB thật: column drop/re-add sạch, backfill idempotent, single head.

## Đã kiểm chứng (hard gate, local)
- Alembic: origin/main single head `null_orphan`; KV extend linear → single head sau merge.
- **42 test KV xanh** (PR-1+2+3 + regression `test_administrative`) trên `qlts_test` sạch.
- FE `tsc --noEmit` sạch.
- Chrome MCP smoke cả 2 path (identity + cross-era legacy→current badge).
- **Engine end-to-end trên data KV thật**: An Lão(21609)→KV1→0.75đ · Quy Nhơn Bắc(21553)→KV2→0.25đ · 3 năm trường KV1→longest_duration→KV1 · xã ngoài catalog→KV=None+manual override+0đ (fail-closed, không sai âm thầm).

## Test coverage (allowlist KHÔNG đổi — cố ý)
6 file test KV là unit/contract của logic mới, không thuộc đường system-breaking → **chủ ý không thêm vào allowlist `backend-test.yml`** (gate bounded-by-design cho release-blocker, không phải full coverage). Chúng **chạy đầy đủ ở `nightly-backend-pytest.yml`** (`pytest tests/`) + đã hard-gate local (42 xanh trên `qlts_test` sạch). Nếu sau này muốn chốt cứng đường *submit-blocking*: gỡ nợ fixture #337 → viết integration test submit chạm Gap #3 → đưa vào Tier 4 (follow-up riêng).

## Deploy checklist (sau merge)
- [ ] Backfill `permanent_commune_code` ~10 hồ sơ legacy qua resolver (tránh fail-closed khi re-submit).
- [ ] Load dữ liệu KV còn lại: 31 tỉnh commune + ~6.400 trường THPT (hiện mới 3 tỉnh/361 xã + 438 trường; vùng thiếu data fail-closed an toàn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
