### PR TITLE
fix(admissions-v2): admin-rollback row lock via get_admission_for_admin_locked

### DIFF
--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -57,6 +57,7 @@ __all__ = [
 
     # Admission State Machine IDOR (State Machine Implementation)
     "get_admission_for_manager",  # Manager approve/reject
+    "get_admission_for_admin_locked",  # Admin rollback — SELECT FOR UPDATE
     "get_admission_for_user",  # Officer resubmit
     "get_admission_for_user_read",  # Read-only fee-status / detail (no lock)
 
@@ -2239,6 +2240,49 @@ async def get_admission_for_manager(
                     assigned_officer_id=profile.lead.assigned_officer_id,
                 )
                 raise ResourceNotFoundError(detail=f"Admission profile {profile_id} not found")
+
+    return profile
+
+
+async def get_admission_for_admin_locked(
+    profile_id: int = Path(..., description="Admission Profile ID"),
+    current_admin: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(database.get_db),
+) -> models.AdmissionProfile:
+    """SELECT FOR UPDATE admin-scope dependency cho admin-rollback (T17).
+
+    Trước đây admissions_v2.py admin_rollback dùng ``db.get()`` không lock
+    → race với confirm/finalize/publish có thể tạo last-write-wins +
+    status_history sai thứ tự. Pattern mirror ``get_admission_for_manager``
+    (line 2166) nhưng KHÔNG có IDOR check vì admin có global scope (đã
+    enforce qua ``require_admin`` dep).
+
+    Eager-load (cùng shape với manager dep): lead.assigned_officer +
+    assigned_reviewer — _populate_response_fields() và post-commit
+    notification helper expect các relation này có sẵn.
+
+    Raises:
+        ResourceNotFoundError: profile_id không tồn tại (anti-enumeration
+        404 — KHÔNG 403 để khớp IDOR convention chung).
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    stmt = (
+        select(models.AdmissionProfile)
+        .where(models.AdmissionProfile.id == profile_id)
+        .options(
+            selectinload(models.AdmissionProfile.lead)
+            .selectinload(models.Lead.assigned_officer),
+            selectinload(models.AdmissionProfile.assigned_reviewer),
+        )
+        .with_for_update()
+    )
+    result = await db.execute(stmt)
+    profile = result.scalar_one_or_none()
+
+    if not profile:
+        raise ResourceNotFoundError(detail=f"Admission profile {profile_id} not found")
 
     return profile
 

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import database, models, schemas
 from app.core.deps import (
     CasbinAuth,
+    get_admission_for_admin_locked,
     get_admission_for_manager,
     get_admission_for_user,
     get_choice_for_user,
@@ -347,6 +348,7 @@ async def admin_rollback_admission(
     profile_id: int,
     payload: schemas.AdmissionAdminRollbackRequest,
     db: AsyncSession = Depends(database.get_db),
+    profile: models.AdmissionProfile = Depends(get_admission_for_admin_locked),
     current_admin: models.User = Depends(require_admin),
 ):
     """T17 admin rollback — force any non-final profile state → draft.
@@ -364,8 +366,11 @@ async def admin_rollback_admission(
       cannot rollback per state machine ALLOWED_TRANSITIONS (Sub-3.5 extension)
 
     **Security**:
-    - No IDOR gate — admin has global scope (require_admin dep enforces)
-    - `db.get(profile_id)` direct → 404 if not found (anti-enumeration)
+    - No IDOR gate — admin has global scope (require_admin dep enforces).
+    - ``get_admission_for_admin_locked`` SELECT FOR UPDATE serializes với
+      concurrent confirm/finalize/publish (PR-4 hardening 2026-05-28 —
+      replaced legacy db.get() race). Dependency also handles 404
+      anti-enumeration.
 
     **Dispatches** (via state_service.transition() + PAIR map):
     - ADMISSION_ROLLED_BACK (T17 source-aware via TRANSITION_PAIR_TO_EVENT
@@ -375,13 +380,9 @@ async def admin_rollback_admission(
     Returns AdmissionAdminRollbackResponse với `rolled_back_from` capture
     cho audit response.
     """
-    # Admin global scope — direct db.get (no IDOR gate needed)
-    profile = await db.get(models.AdmissionProfile, profile_id)
-    if profile is None:
-        raise ResourceNotFoundError(f"Hồ sơ {profile_id} không tồn tại")
-
     # Service helper (Sub-3.2) — pre-checks (terminal state, reason min 10)
-    # + state machine transition (source-aware PAIR → ROLLED_BACK)
+    # + state machine transition (source-aware PAIR → ROLLED_BACK).
+    # Profile is row-locked by get_admission_for_admin_locked dep above.
     result, post_commit_cb = await choice_engine.admin_rollback_profile(
         db,
         profile=profile,

--- a/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
@@ -18,6 +18,7 @@ this file is test-debt follow-up extending integration coverage.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -1492,3 +1493,170 @@ async def test_admin_rollback_response_schema_locked(
     assert body["profile_id"] == profile_id
     # New idempotent marker default False (this rollback was real, not no-op)
     assert body.get("already_at_target") is False
+
+
+# ============================================================================
+# PR-4 (2026-05-28) — Admin rollback row-lock anchors
+#
+# Trước: router dùng ``db.get(profile_id)`` không lock → race với confirm/
+# finalize/publish có thể tạo last-write-wins + status_history sai thứ tự.
+# Sau: dependency ``get_admission_for_admin_locked`` (deps.py) emit
+# SELECT ... FOR UPDATE serialize concurrent state-changing ops cùng
+# profile_id.
+#
+# Anchor tests dưới đây bảo vệ chống regression nếu ai accidentally:
+#   * Revert dep injection (router quay về db.get)
+#   * Bỏ ``.with_for_update()`` trong dep
+# Theo memory ``pattern-change-impact-audit``: anchor là business-reality,
+# KHÔNG mock SQL — concurrent test sẽ break audit/state chain nếu lock
+# bị bỏ, hệt như bulk_assign concurrency test (ADM-011).
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_admin_rollback_404_via_locked_dependency(
+    client: AsyncClient,
+    admin_token_headers: dict,
+):
+    """T17 + PR-4: non-existent profile_id → 404 từ dependency.
+
+    Anchor regression: ``get_admission_for_admin_locked`` raise
+    ResourceNotFoundError khi profile không tồn tại (anti-enumeration).
+    Trước PR-4, router dùng ``db.get()`` cũng trả 404, nhưng test này
+    đảm bảo path lock-dep cũng cover 404 case (không silently 500).
+    """
+    response = await client.post(
+        "/api/v2/admissions/999999999/admin-rollback",
+        headers=admin_token_headers,
+        json={"reason": "Test 404 path via locked dependency"},
+    )
+    assert response.status_code == 404, (
+        f"Non-existent profile via locked dep must 404 anti-enumeration; "
+        f"got {response.status_code}: {response.text[:200]}"
+    )
+
+
+async def _admin_rollback_in_own_session(
+    profile_id: int, admin_user_id: int, reason: str
+) -> dict:
+    """Helper: gọi service admin_rollback_profile() từ session độc lập,
+    qua REAL production dependency ``get_admission_for_admin_locked``.
+
+    QUAN TRỌNG (PR-4 review 2026-05-28): helper PHẢI dùng dep thật để
+    test concurrent là non-tautological. Nếu helper tự build
+    ``select(...).with_for_update()``, test sẽ pass kể cả khi production
+    dep bị revert (test kiểm tra lock của test, không phải của code).
+    Dùng dep trực tiếp đảm bảo: production lock biến mất → test break.
+
+    Mô phỏng request thực: dep emit SELECT FOR UPDATE → service
+    transition → commit. Dùng cho test concurrent (gather 2 caller cùng
+    profile_id).
+    """
+    from app.core.deps import get_admission_for_admin_locked
+    from app.services import admission_choice_engine_service as choice_engine
+
+    async with AsyncSessionLocal() as session:
+        try:
+            admin = await session.get(models.User, admin_user_id)
+            # Call production dep — same lock semantic as live request
+            profile = await get_admission_for_admin_locked(
+                profile_id=profile_id,
+                current_admin=admin,
+                db=session,
+            )
+            result, post_commit = await choice_engine.admin_rollback_profile(
+                db=session,
+                profile=profile,
+                reason=reason,
+                actor=admin,
+            )
+            await session.commit()
+            if post_commit:
+                await post_commit()
+            return result
+        except Exception:
+            await session.rollback()
+            raise
+
+
+@pytest.mark.asyncio
+async def test_admin_rollback_serializes_with_concurrent_attempts(
+    pr3c_seed_choices: dict,
+    admin_user_in_db: dict,
+):
+    """⭐ Concurrent anchor: 2 admin_rollback gọi đồng thời cùng profile_id
+    (start state='submitted') PHẢI serialize qua row lock (PR-4 fix).
+
+    With lock (PR-4 ship):
+      - Caller 1: 'submitted' → 'draft', rolled_back_from='submitted',
+        already_at_target=False
+      - Caller 2: blocks until 1 commits, then sees state='draft' →
+        no-op branch (choice_engine.admin_rollback_profile line 919) →
+        rolled_back_from='draft', already_at_target=True
+      - Cả 2 đều succeed (200/non-exception); business invariant: chỉ
+        1 transition entry trong status_history (real rollback)
+      - Profile final state='draft' deterministic
+
+    Without lock (regression):
+      - Cả 2 caller cùng đọc state='submitted', cùng transition →
+        BusinessRuleViolation cho caller chậm (state machine raise vì
+        version mismatch OR invalid 'draft'→'draft' transition không qua
+        idempotent guard), HOẶC 2 status_history entries từ cùng source
+        state (chain integrity broken)
+
+    Test asserts business reality (final state + at-most-1 real
+    transition), KHÔNG mock SQL — chain breaks naturally nếu lock removed.
+    Mirror pattern test_bulk_assign_locks_and_writes_accurate_audit_chain.
+    """
+    profile_id = pr3c_seed_choices["profile_id"]
+    admin_user_id = admin_user_in_db["id"]
+
+    # Setup: profile bắt đầu ở 'submitted' để rollback có meaningful source
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            profile = await s.get(models.AdmissionProfile, profile_id)
+            profile.status = "submitted"
+            profile.version += 1
+
+    # Gather 2 concurrent rollback. PostgreSQL FOR UPDATE serialise — caller 2
+    # block until caller 1 commits, rồi đọc state='draft' (no-op).
+    results = await asyncio.gather(
+        _admin_rollback_in_own_session(
+            profile_id, admin_user_id, "Concurrent rollback A — 10+ chars"
+        ),
+        _admin_rollback_in_own_session(
+            profile_id, admin_user_id, "Concurrent rollback B — 10+ chars"
+        ),
+        return_exceptions=True,
+    )
+
+    # Both calls must return (no exception). With lock: 1 real + 1 no-op.
+    # Without lock: caller B có thể raise BusinessRuleViolation từ state
+    # machine (transition 'draft'→'draft' không hợp lệ).
+    exceptions = [r for r in results if isinstance(r, Exception)]
+    assert not exceptions, (
+        f"Concurrent admin_rollback must serialize (no exceptions); "
+        f"got {len(exceptions)} exception(s). FIRST: {exceptions[0]!r}. "
+        f"This indicates the FOR UPDATE lock was bypassed (PR-4 regression)."
+    )
+
+    # Verify business reality: chỉ 1 real rollback happened (one
+    # already_at_target=True, one False), final state='draft'
+    successes = [r for r in results if not isinstance(r, Exception)]
+    assert len(successes) == 2, f"Expected 2 results; got {len(successes)}: {results}"
+
+    target_markers = sorted(
+        bool(r.get("already_at_target", False)) for r in successes
+    )
+    assert target_markers == [False, True], (
+        f"Lock invariant: exactly 1 real rollback + 1 no-op (already_at_target=True). "
+        f"Got markers={target_markers}, results={results}. Without lock both could "
+        f"transition from 'submitted' (both False) — that's the race PR-4 fixes."
+    )
+
+    # Final state deterministic
+    async with AsyncSessionLocal() as s:
+        profile_after = await s.get(models.AdmissionProfile, profile_id)
+        assert profile_after.status == "draft", (
+            f"Expected final state='draft'; got {profile_after.status}"
+        )

--- a/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub3_router_registration.py
+++ b/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub3_router_registration.py
@@ -26,7 +26,11 @@ import pytest
 from fastapi import params as fastapi_params
 from pydantic import ValidationError
 
-from app.core.deps import require_admin, get_admission_for_manager
+from app.core.deps import (
+    get_admission_for_admin_locked,
+    get_admission_for_manager,
+    require_admin,
+)
 from app.routers.admissions_v2 import router as v2_router
 from app.schemas.admission import (
     AdmissionAdminRollbackRequest,
@@ -166,6 +170,27 @@ def test_admin_rollback_uses_require_admin():
     # Anti-pattern guard: get_admission_for_manager NOT in deps (admin global scope)
     assert get_admission_for_manager not in dep_calls, (
         "admin-rollback should NOT use IDOR gate (admin global scope)"
+    )
+
+
+def test_admin_rollback_uses_admin_locked_dep():
+    """⭐ PR-4 (2026-05-28) anchor: T17 MUST depend on
+    ``get_admission_for_admin_locked`` (SELECT FOR UPDATE).
+
+    Catches regression nếu ai revert dep injection để dùng lại
+    ``db.get(profile_id)`` race-prone pattern, hoặc swap sang dep khác
+    không có ``.with_for_update()``. Production lock được enforce TẠI
+    dependency function, nên route-level wiring là single source of truth.
+
+    Inverse guard: KHÔNG dùng manager IDOR dep (admin global scope) và
+    KHÔNG dùng officer/user dep (sai scope).
+    """
+    route = _get_route("admin-rollback")
+    dep_calls = [d.call for d in _get_dependants(route)]
+    assert get_admission_for_admin_locked in dep_calls, (
+        "admin-rollback MUST depend on get_admission_for_admin_locked — "
+        "PR-4 fix for race với confirm/finalize/publish. Revert sẽ tạo "
+        "last-write-wins + status_history sai thứ tự."
     )
 
 


### PR DESCRIPTION
## Summary
- Replace race-prone `db.get()` with `SELECT FOR UPDATE` dependency to serialize admin rollback (T17) with concurrent confirm/finalize/publish on cùng profile.
- New dep `app.core.deps.get_admission_for_admin_locked`: admin-scope (require_admin), eager-loads lead.assigned_officer + assigned_reviewer chain mirror `get_admission_for_manager` pattern.
- Router `admissions_v2.admin_rollback_admission`: inject dep, remove legacy `db.get()` + 404 check (dep handles both).

## Why
Per audit findings 2026-05-28 (P1): admin rollback dùng `db.get()` không lock → race với confirm/finalize/publish có thể tạo last-write-wins + status_history sai thứ tự. Pattern đã chuẩn `get_admission_for_manager` với `.with_for_update()` (deps.py:2213) — PR này extend cùng pattern cho admin scope.

## Tests
3 tests, cả 2 file đã trong **Tier 1 allowlist** (`backend-test.yml:167,170`) → KHÔNG cần update workflow:

- `test_phase3_pr3c_sub3_router_registration.py::test_admin_rollback_uses_admin_locked_dep` — anchor route wiring (deterministic)
- `test_phase3_pr3c_routers_integration.py::test_admin_rollback_404_via_locked_dependency` — 404 regression via dep (deterministic)
- `test_phase3_pr3c_routers_integration.py::test_admin_rollback_serializes_with_concurrent_attempts` — concurrent asyncio.gather, helper gọi REAL production dep (non-tautological — production lock removal sẽ break test)

Local wall-clock: deterministic 12.54s, concurrent 7.24s on one-off container.

## Test plan
- [x] Deterministic tests pass local (`docker compose exec backend pytest`)
- [x] Concurrent test pass local one-off container (qlts_test, APP_ENV=test, 7.24s)
- [x] Main stack restored healthy after test run
- [ ] CI backend-test.yml Tier 1 green
- [ ] admission-contract-check.yml: KHÔNG trigger (chỉ chạm deps + router, không admission*.py service)

## Context
First PR của 5-PR admission hardening sprint per audit plan v4 2026-05-28. Production check: 1 round multi-NV active (DOT_2 2026) nhưng 0 pending publish → an toàn ship tuần tự PR-4 → PR-2 → PR-1 → PR-3 → PR-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)