### PR TITLE
feat(admissions): round cutoff enforcement (RoundClosedError 410)

### DIFF
--- a/Backend_FastAPI/app/services/admission_choice_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_service.py
@@ -43,15 +43,35 @@ from app.repositories.admission_profile_choice_repository import (
 from app.repositories.admission_path_repository import AdmissionPathRepository
 from app.services.activity_service import log_activity
 from app.services.system_config_service import SystemConfigService
+from app.utils.datetime_helpers import today_vn
 from app.utils.exceptions import (
     BusinessRuleViolation,
     DuplicateResourceError,
     ResourceNotFoundError,
+    RoundClosedError,
 )
 
 
 # Status whitelist cho add_choice retroactive (P1 fix #5 v2.12)
 ADD_CHOICE_ALLOWED_STATUSES = ("draft", "revision_requested")
+
+
+def _assert_round_open(round_obj: OfferingAdmissionRound) -> None:
+    """Raise RoundClosedError nếu round.end_date < today_vn().
+
+    PR-2 (2026-05-28) — strict cutoff enforcement cho modification ops
+    (POST/PATCH). KHÔNG gọi từ delete_choice — candidate retains right
+    to withdraw a NV sau round closed (no seat added → no risk).
+
+    Mirror helper trong admission_service.py:_assert_round_open. Local
+    copy ở đây để tránh circular import (admission_service → choice_service).
+    """
+    if round_obj.end_date is not None and round_obj.end_date < today_vn():
+        raise RoundClosedError(
+            f"Đợt tuyển sinh '{round_obj.round_code}' đã đóng "
+            f"(hạn cuối: {round_obj.end_date}). "
+            f"Không thể thêm/sửa nguyện vọng (rút NV vẫn cho phép)."
+        )
 
 
 async def _noop_callback() -> None:
@@ -129,6 +149,12 @@ class AdmissionChoiceService:
             raise ResourceNotFoundError(
                 f"Path {admission_path_id} không tồn tại hoặc đã archive."
             )
+
+        # PR-2 (2026-05-28) — Round cutoff: block add_choice (POST) sau
+        # round.end_date. Per locked decision: POST + PATCH gate, DELETE
+        # vẫn allow. Reuse round_obj đã load ngay trên cho allow_multi_nv
+        # check — không thêm query.
+        _assert_round_open(round_obj)
 
         # First choice luôn cho phép (Wave A single-NV vẫn ship 1 choice
         # via this path). Chỉ block ADD-NV-2-trở-lên khi flag tắt.
@@ -384,8 +410,17 @@ class AdmissionChoiceService:
         - new_display_order != current (no-op short-circuit)
         - new_display_order ≤ system_config.max_choices_per_profile (Q-P3-01
           allows ≤10 by DB CHECK, but service narrows per system_config)
+        - PR-2 (2026-05-28): round.end_date not in the past (RoundClosedError
+          410). Load round qua choice.admission_path_id (lazy add — single
+          extra query, paths này low-traffic vs add_choice).
         """
         self._assert_choice_editable(profile, action="đổi thứ tự nguyện vọng")
+
+        round_obj = await self.choice_repo.get_round_by_path_id(
+            choice.admission_path_id
+        )
+        if round_obj is not None:
+            _assert_round_open(round_obj)
 
         if new_display_order == choice.display_order:
             return choice, _noop_callback
@@ -434,8 +469,18 @@ class AdmissionChoiceService:
 
         Note: empty scores list is a valid "clear all" intent — DB UNIQUE
         constraint allows zero rows per choice.
+
+        PR-2 (2026-05-28): round.end_date enforcement same pattern as
+        update_choice_display_order — load round qua admission_path_id
+        + assert open. RoundClosedError → 410.
         """
         self._assert_choice_editable(profile, action="cập nhật điểm nguyện vọng")
+
+        round_obj = await self.choice_repo.get_round_by_path_id(
+            choice.admission_path_id
+        )
+        if round_obj is not None:
+            _assert_round_open(round_obj)
 
         # Clear existing scores via direct delete (FK CASCADE would only fire
         # on choice delete, not score replace — use bulk delete here).

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -65,11 +65,36 @@ from ..utils.exceptions import (
     BusinessRuleViolation,
     PermissionDeniedError,
     ConflictError,
+    RoundClosedError,
     ValidationError,
 )
+from ..utils.datetime_helpers import today_vn
 from ..utils.masking import mask_citizen_id
 
 log = structlog.get_logger(__name__)
+
+
+def _assert_round_open(round_obj: "models.OfferingAdmissionRound") -> None:
+    """Raise RoundClosedError nếu round.end_date < today_vn().
+
+    PR-2 (2026-05-28) — strict fail-closed enforcement của
+    OfferingAdmissionRound SPEC §2.1.a Rule 1 (model docstring nói 410
+    Gone nhưng pre-PR-2 không enforce ở runtime).
+
+    NULL end_date → open-ended round, pass-through (admin có thể set
+    explicit end_date sau). Strict semantic — KHÔNG có grace period,
+    KHÔNG admin override ngầm (plan v4 locked decision: admin extends
+    qua POST /rounds/{id}/extend, KHÔNG bypass gate này).
+
+    Caller: create_profile, submit_and_evaluate, choice CRUD POST/PATCH.
+    NOT called from choice DELETE (candidate retains right to withdraw).
+    """
+    if round_obj.end_date is not None and round_obj.end_date < today_vn():
+        raise RoundClosedError(
+            f"Đợt tuyển sinh '{round_obj.round_code}' đã đóng "
+            f"(hạn cuối: {round_obj.end_date}). "
+            f"Liên hệ admin nếu cần extend đợt."
+        )
 
 
 # ADM-012: Safe domain exceptions whose ``str()`` is user-facing copy.
@@ -3113,6 +3138,13 @@ async def create_profile(
             "Vui lòng chọn đợt khác."
         )
 
+    # PR-2 (2026-05-28) — Round cutoff enforcement (SPEC §2.1.a Rule 1).
+    # Block create_profile khi end_date đã qua. Raise RoundClosedError → 410
+    # Gone. Strict: KHÔNG grace period, KHÔNG admin override ngầm; admin
+    # extends qua POST /rounds/{id}/extend (helper inline để readers thấy
+    # rõ semantic ngay tại site).
+    _assert_round_open(admission_round)
+
     # Step 7: Find AdmissionPath for this (round, offering, method).
     #
     # Round contract hardening (plan v4 Section A): 3-col lookup replaces
@@ -4788,6 +4820,33 @@ async def submit_and_evaluate(
             f"Cannot submit profile with status '{profile.status}'. "
             "Only draft profiles can be submitted."
         )
+
+    # PR-2 (2026-05-28) — Round cutoff enforcement (SPEC §2.1.a Rule 1).
+    # Block submit khi round.end_date đã qua. create_profile() đã gate
+    # tại create-time, nhưng candidate có thể create rồi đợi qua end_date
+    # mới submit → second gate ở đây bảo vệ. Load round qua applied_rules
+    # snapshot (path_id → path → round). Fail-fast trước eligibility/doc/
+    # score validation để tiết kiệm cycles + clear 410 error message.
+    applied_rules_for_cutoff = profile.applied_rules or {}
+    path_id_for_cutoff = applied_rules_for_cutoff.get("admission_path_id")
+    if path_id_for_cutoff is not None:
+        try:
+            path_id_int_cutoff = int(path_id_for_cutoff)
+        except (TypeError, ValueError):
+            path_id_int_cutoff = None
+        if path_id_int_cutoff is not None:
+            from sqlalchemy import select as sa_select_cutoff
+            from sqlalchemy.orm import selectinload as sa_selectinload_cutoff
+            cutoff_stmt = (
+                sa_select_cutoff(models.AdmissionPath)
+                .where(models.AdmissionPath.id == path_id_int_cutoff)
+                .options(
+                    sa_selectinload_cutoff(models.AdmissionPath.admission_round)
+                )
+            )
+            cutoff_path = (await db.execute(cutoff_stmt)).scalar_one_or_none()
+            if cutoff_path is not None and cutoff_path.admission_round is not None:
+                _assert_round_open(cutoff_path.admission_round)
 
     # Q9 #07 Phase E.4 — eligibility gate per yêu cầu nghiệp vụ #5: chặn TOÀN BỘ
     # hồ sơ submit không match cultural + vocational vs target_level/admission_type

--- a/Backend_FastAPI/app/utils/exceptions.py
+++ b/Backend_FastAPI/app/utils/exceptions.py
@@ -159,6 +159,43 @@ class ConflictError(BaseAppException):
 
 
 # ============================================================================
+# GONE / CLOSED RESOURCES (410)
+# ============================================================================
+
+
+class GoneError(BaseAppException):
+    """Resource is no longer available (HTTP 410).
+
+    Used for hard-deadline cutoffs: round closed, archived offers, etc.
+    Subclass BaseAppException directly (NOT ValidationError) so the
+    global ``base_app_exception_handler`` (middleware/exception_handlers.py)
+    picks up ``status_code=410`` correctly. Subclassing ValidationError
+    would map to 400 via the inheritance chain.
+
+    Strict fail-closed semantic — no implicit override. Admin extends
+    a closed round via a separate explicit endpoint, NOT by bypassing
+    this gate (per plan v4 locked decision 2026-05-28).
+    """
+
+    status_code = status.HTTP_410_GONE
+    detail = "This resource is no longer available."
+    error_code = "GONE"
+
+
+class RoundClosedError(GoneError):
+    """Admission round end_date has passed.
+
+    Raised by create_profile, submit_and_evaluate, and choice CRUD
+    modification endpoints (POST/PATCH; DELETE intentionally allowed
+    per plan v4 — candidate retains right to withdraw a choice after
+    the round closes, but cannot create/modify).
+    """
+
+    detail = "Đợt tuyển sinh đã đóng."
+    error_code = "ROUND_CLOSED"
+
+
+# ============================================================================
 # VALIDATION EXCEPTIONS (400)
 # ============================================================================
 
@@ -422,6 +459,9 @@ EXCEPTION_HTTP_STATUS_MAP = {
     # 409 Conflict
     DuplicateResourceError: 409,
     ConflictError: 409,
+    # 410 Gone
+    GoneError: 410,
+    RoundClosedError: 410,
     # 500 Internal Server Error
     BaseAppException: 500,
     ServiceError: 500,

--- a/Backend_FastAPI/tests/api/test_admission_workflow_api.py
+++ b/Backend_FastAPI/tests/api/test_admission_workflow_api.py
@@ -585,3 +585,173 @@ async def test_drop_before_enrolled_returns_400(client, officer_user_in_db, adm_
     await client.post(ACT(p["id"], "approve"), json={"notes": "OK", "version": v}, headers=ah)
     ah = await _admin(client); v = await _ver(client, ah, p["id"])
     assert (await client.post(ACT(p["id"], "drop"), json={"reason": "Should fail not enrolled reason", "version": v}, headers=ah)).status_code == 400
+
+
+# =============================================================================
+# PR-2 (2026-05-28) — Round cutoff enforcement (RoundClosedError 410)
+#
+# admission_service:
+#   * create_profile() — gate ngay sau archived_at check (line ~3140)
+#   * submit_and_evaluate() — gate trước eligibility/doc validation
+#     (load round qua applied_rules.admission_path_id snapshot)
+# Magic-link submit tự dính qua submit_and_evaluate (test riêng trong
+# test_phase3_pr3e_magic_link.py).
+#
+# Strict semantic: KHÔNG grace, KHÔNG admin override ngầm. Admin extend
+# round qua POST /rounds/{id}/extend (kiểm dưới qua re-open flow).
+# =============================================================================
+
+
+async def _close_round(round_id: int) -> None:
+    """Helper: set round.end_date to yesterday."""
+    from datetime import date, timedelta
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            r = await s.get(models.OfferingAdmissionRound, round_id)
+            r.end_date = date.today() - timedelta(days=1)
+
+
+async def _extend_round(round_id: int, *, days_forward: int = 30) -> None:
+    """Helper: simulate admin extend by setting end_date forward."""
+    from datetime import date, timedelta
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            r = await s.get(models.OfferingAdmissionRound, round_id)
+            r.end_date = date.today() + timedelta(days=days_forward)
+
+
+@pytest.mark.asyncio
+async def test_create_profile_410_when_round_end_date_passed(
+    client, officer_user_in_db, adm_lead, adm_config
+):
+    """POST /api/admissions MUST return 410 khi admission_round.end_date < today.
+
+    Anchor PR-2 gate trong admission_service.create_profile (sau archived_at
+    check). Strict — admin extends qua endpoint riêng, KHÔNG bypass gate này.
+    """
+    oh = await _officer(client, officer_user_in_db)
+    # Close the round BEFORE create attempt
+    await _close_round(adm_config["round_id"])
+
+    # Consultation prerequisite (business rule preserved)
+    from tests._lead_status_test_ids import INITIAL_LEAD_STATUS_ID
+    await client.post(
+        f"{LeadsURLs.LEADS}/{adm_lead['id']}/consultations",
+        json={"status_id": INITIAL_LEAD_STATUS_ID, "method": "phone", "notes": "pre"},
+        headers=oh,
+    )
+
+    r = await client.post(
+        ADMISSIONS,
+        json={
+            "lead_id": adm_lead["id"],
+            "admission_method_id": adm_config["method_id"],
+            "admission_round_id": adm_config["round_id"],
+            "academic_year": 2026,
+        },
+        headers=oh,
+    )
+    assert r.status_code == 410, (
+        f"POST /admissions sau round closed phải 410 Gone; "
+        f"got {r.status_code}: {r.text[:200]}"
+    )
+    body = r.json()
+    assert "đã đóng" in (body.get("detail") or "").lower(), (
+        f"Detail phải mention 'đã đóng'; got: {body}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_submit_410_when_round_closed_after_create(
+    client, officer_user_in_db, adm_lead, adm_config
+):
+    """Profile created khi round mở, sau đó round close trước khi submit →
+    submit phải 410. Anchor cho gate ở submit_and_evaluate.
+
+    Realistic scenario: candidate fills form ngày 30/6, hệ thống đóng đợt
+    đêm 30/6 (end_date=30/6), candidate click submit sáng 1/7 → 410.
+    """
+    oh = await _officer(client, officer_user_in_db)
+
+    # Step 1: create + fill + submit while round OPEN (use helper)
+    p = await _submit(
+        client, oh, adm_lead["id"], adm_config["method_id"],
+        admission_round_id=adm_config["round_id"],
+        school_id=adm_config["school_id"],
+    )
+    # _submit() ends with profile in 'submitted' state — rollback to 'draft'
+    # to retry submit sau khi close round. Reuse admin-rollback (T17 admin only).
+    ah = await _admin(client); v = await _ver(client, ah, p["id"])
+    # NOTE: legacy admission router doesn't have direct draft revert; instead
+    # we directly mutate DB to draft for this test (admin-rollback only on
+    # v2 multi-NV path). This isolates the cutoff gate semantic.
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            prof = await s.get(models.AdmissionProfile, p["id"])
+            prof.status = "draft"
+            prof.version += 1
+
+    # Step 2: close round
+    await _close_round(adm_config["round_id"])
+
+    # Step 3: re-submit must 410
+    v = (await client.get(ADM(p["id"]), headers=oh)).json()["version"]
+    sr = await client.post(ACT(p["id"], "submit"), json={"version": v}, headers=oh)
+    assert sr.status_code == 410, (
+        f"Re-submit sau round closed phải 410; "
+        f"got {sr.status_code}: {sr.text[:200]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_round_extension_re_opens_submit_to_new_end_date(
+    client, officer_user_in_db, adm_lead, adm_config
+):
+    """Admin extend end_date forward → submit phải pass lại.
+
+    Anchor cho path EXTEND: gate KHÔNG cứng vĩnh viễn — admin có cơ chế
+    extend qua POST /rounds/{id}/extend (test direct DB mutation tương
+    đương). Sau extend, end_date >= today → submit lại OK.
+    """
+    oh = await _officer(client, officer_user_in_db)
+
+    # Step 1: create profile while round OPEN
+    from tests._lead_status_test_ids import INITIAL_LEAD_STATUS_ID
+    await client.post(
+        f"{LeadsURLs.LEADS}/{adm_lead['id']}/consultations",
+        json={"status_id": INITIAL_LEAD_STATUS_ID, "method": "phone", "notes": "pre"},
+        headers=oh,
+    )
+    r = await client.post(
+        ADMISSIONS,
+        json={
+            "lead_id": adm_lead["id"],
+            "admission_method_id": adm_config["method_id"],
+            "admission_round_id": adm_config["round_id"],
+            "academic_year": 2026,
+        },
+        headers=oh,
+    )
+    assert r.status_code in (200, 201), r.text
+    pid = r.json()["id"]
+
+    # Step 2: close round → verify submit attempt blocked (sanity check)
+    await _close_round(adm_config["round_id"])
+    v = (await client.get(ADM(pid), headers=oh)).json()["version"]
+    sr_closed = await client.post(ACT(pid, "submit"), json={"version": v}, headers=oh)
+    assert sr_closed.status_code == 410, (
+        f"Sanity: submit khi closed phải 410; got {sr_closed.status_code}"
+    )
+
+    # Step 3: admin extends round end_date 30 ngày tới
+    await _extend_round(adm_config["round_id"], days_forward=30)
+
+    # Step 4: submit lại — KHÔNG còn block ở cutoff gate (có thể fail validation
+    # khác như missing docs/permanent address vì test này không fill full —
+    # chỉ verify status code KHÔNG phải 410)
+    v = (await client.get(ADM(pid), headers=oh)).json()["version"]
+    sr_extended = await client.post(ACT(pid, "submit"), json={"version": v}, headers=oh)
+    assert sr_extended.status_code != 410, (
+        f"Sau extend, submit KHÔNG được trả 410 nữa; "
+        f"got {sr_extended.status_code}: {sr_extended.text[:200]}"
+    )

--- a/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
@@ -647,3 +647,140 @@ async def test_update_display_order_extra_fields_rejected_422(
         json={"display_order": 2, "decision": "admitted"},  # decision NOT allowed
     )
     assert response.status_code == 422, response.text
+
+
+# ============================================================================
+# PR-2 (2026-05-28) — Round cutoff enforcement: 410 Gone for POST/PATCH;
+# DELETE intentionally allowed (candidate retains withdraw right per locked
+# decision). Tests close the round's end_date by direct DB update — admin
+# extend endpoint is out of scope here (tested separately at workflow level).
+# ============================================================================
+
+
+async def _close_round(round_id: int) -> None:
+    """Helper: set round.end_date to yesterday (closes the round)."""
+    from datetime import date, timedelta
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            round_obj = await s.get(models.OfferingAdmissionRound, round_id)
+            round_obj.end_date = date.today() - timedelta(days=1)
+
+
+@pytest.mark.asyncio
+async def test_create_choice_410_when_round_closed(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3a_seed: dict,
+):
+    """POST /choices MUST return 410 RoundClosedError khi round.end_date đã qua.
+
+    Anchor cho PR-2 gate trong admission_choice_service.add_choice
+    (line 157). Strict — KHÔNG admin override ngầm.
+    """
+    await _close_round(pr3a_seed["round_id"])
+
+    response = await client.post(
+        f"/api/v2/admissions/{pr3a_seed['profile_id']}/choices",
+        headers=manager_token_headers,
+        json={
+            "admission_path_id": pr3a_seed["path_id"],
+            "path_subject_group_config_id": pr3a_seed["config_id"],
+            "display_order": 1,
+            "scores": [
+                {"subject_id": pr3a_seed["subject_id"], "score": "8.50"}
+            ],
+        },
+    )
+    assert response.status_code == 410, (
+        f"POST /choices sau round closed phải 410 Gone; "
+        f"got {response.status_code}: {response.text[:200]}"
+    )
+    body = response.json()
+    assert "đã đóng" in (body.get("detail") or "").lower(), (
+        f"Detail phải mention 'đã đóng'; got: {body}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_patch_choice_410_when_round_closed(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3d_b_seed_with_choice: dict,
+):
+    """PATCH /choices/{cid} (display_order) MUST return 410 khi round closed.
+
+    Anchor cho gate trong update_choice_display_order (choice_service:423).
+    """
+    await _close_round(pr3d_b_seed_with_choice["round_id"])
+
+    response = await client.patch(
+        f"/api/v2/admissions/{pr3d_b_seed_with_choice['profile_id']}/choices/{pr3d_b_seed_with_choice['choice_id']}",
+        headers=manager_token_headers,
+        json={"display_order": 2},
+    )
+    assert response.status_code == 410, (
+        f"PATCH /choices/{{cid}} sau round closed phải 410; "
+        f"got {response.status_code}: {response.text[:200]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_patch_choice_scores_410_when_round_closed(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3d_b_seed_with_choice: dict,
+):
+    """PATCH /choices/{cid}/scores MUST return 410 khi round closed.
+
+    Anchor cho gate trong replace_choice_scores (choice_service:483).
+    """
+    await _close_round(pr3d_b_seed_with_choice["round_id"])
+
+    response = await client.patch(
+        f"/api/v2/admissions/{pr3d_b_seed_with_choice['profile_id']}/choices/{pr3d_b_seed_with_choice['choice_id']}/scores",
+        headers=manager_token_headers,
+        json={
+            "scores": [
+                {"subject_id": pr3d_b_seed_with_choice["subject_id"], "score": "9.00"}
+            ]
+        },
+    )
+    assert response.status_code == 410, (
+        f"PATCH /scores sau round closed phải 410; "
+        f"got {response.status_code}: {response.text[:200]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_choice_allowed_when_round_closed(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3d_b_seed_with_choice: dict,
+):
+    """⭐ DELETE /choices/{cid} MUST succeed (200) khi round closed.
+
+    Per plan v4 locked decision #3 (2026-05-28): candidate retains right
+    to withdraw a NV sau round closed — không thêm seat, không tăng risk
+    over-admit. Anchor: nếu ai accidentally thêm cutoff gate vào
+    delete_choice() service helper, test này break.
+
+    Inverse anchor cho 3 tests cutoff-410 trên — proves DELETE intentionally
+    KHÔNG gate, không phải miss.
+    """
+    await _close_round(pr3d_b_seed_with_choice["round_id"])
+
+    response = await client.delete(
+        f"/api/v2/admissions/{pr3d_b_seed_with_choice['profile_id']}/choices/{pr3d_b_seed_with_choice['choice_id']}",
+        headers=manager_token_headers,
+    )
+    assert response.status_code == 200, (
+        f"DELETE /choices sau round closed PHẢI 200 (candidate withdraw right); "
+        f"got {response.status_code}: {response.text[:200]}. "
+        f"Nếu got 410 → cutoff gate đã accidentally add vào delete_choice — revert."
+    )
+    # Verify DB state: choice gone
+    async with AsyncSessionLocal() as s:
+        gone = await s.get(
+            models.AdmissionProfileChoice, pr3d_b_seed_with_choice["choice_id"]
+        )
+        assert gone is None, "Choice phải bị xoá khỏi DB sau DELETE thành công"

--- a/Backend_FastAPI/tests/api/test_phase3_pr3e_magic_link.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3e_magic_link.py
@@ -468,3 +468,152 @@ async def test_consume_confirm_dispatches_status_changed_event(
     assert payload["new_status"] == "confirmed"
     assert payload["old_status"] == "approved"
     assert kwargs["dedupe_key"] == f"admission_profile_confirmed:{magic_link_seed['profile_id']}"
+
+
+# ============================================================================
+# PR-2 (2026-05-28) — Magic-link submit round cutoff enforcement
+#
+# magic_link_service._handle_submit() delegates to
+# admission_service.submit_and_evaluate(current_user=None) → cutoff gate
+# trong submit_and_evaluate (PR-2 Step 3) tự fire cho magic-link path.
+# Anchor end-to-end through magic-link router để khẳng định gate KHÔNG bị
+# bypass khi candidate self-service submit qua link.
+# ============================================================================
+
+
+@pytest_asyncio.fixture
+async def magic_link_submit_seed_closed_round(seed_lead_dependencies: dict) -> dict:
+    """Profile draft + submit-action token + round đã đóng (end_date yesterday).
+
+    Mô phỏng candidate fill form trong ngày cuối, click submit hôm sau —
+    middleware không re-check round trước khi route, gate phải fire ở
+    submit_and_evaluate.
+    """
+    from datetime import date, timedelta
+    from decimal import Decimal
+
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    citizen_id = f"7{ts:08d}1"[:12]
+    last4 = citizen_id[-4:]
+    token_value = secrets.token_urlsafe(32)
+
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            # Seed minimal admission config chain so applied_rules.admission_path_id
+            # resolves to a real path → round (gate load path).
+            offering = models.ProgramOffering(
+                program_id=seed_lead_dependencies["major_program_id"],
+                offering_type="full_time",
+                duration_semesters=8,
+                is_active=True,
+            )
+            s.add(offering); await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=offering.id,
+                academic_year=2026,
+                annual_admission_quota=20,
+                tuition_fee_per_year=Decimal("1000000"),
+                is_published=True,
+            )
+            s.add(ai); await s.flush()
+
+            from tests.fixtures.builders import AdmissionRoundBuilder
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                s, academic_year=2026,
+            )
+
+            method = models.AdmissionMethod(
+                code=f"PR2ML_{ts}",
+                name=f"PR2 ML method {ts}",
+                requires_subject_scores=False,
+                requires_gpa=False,
+                is_active=True,
+            )
+            s.add(method); await s.flush()
+
+            path = models.AdmissionPath(
+                academic_info_id=ai.id,
+                admission_method_id=method.id,
+                admission_round_id=round_id,
+                status="active",
+            )
+            s.add(path); await s.flush()
+
+            # Close the round AFTER path setup so all FKs resolve cleanly
+            round_obj = await s.get(models.OfferingAdmissionRound, round_id)
+            round_obj.end_date = date.today() - timedelta(days=1)
+            await s.flush()
+
+            lead = models.Lead(
+                full_name=f"PR-2 ML Lead {ts}",
+                phone=f"097{ts:07d}"[:10],
+                unit_id=seed_lead_dependencies["unit_id"],
+                pipeline_stage_id=seed_lead_dependencies["stage_id"],
+                source="walkin",
+            )
+            s.add(lead); await s.flush()
+
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                citizen_id=citizen_id,
+                status="draft",
+                applied_rules={"admission_path_id": path.id},
+                academic_year=2026,
+            )
+            s.add(profile); await s.flush()
+
+            token = models.AdmissionConfirmationToken(
+                profile_id=profile.id,
+                action_type="submit",
+                token=token_value,
+                expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+                confirmed_at=None,
+                attempt_count=0,
+            )
+            s.add(token); await s.flush()
+
+            return {
+                "profile_id": profile.id,
+                "lead_id": lead.id,
+                "token": token_value,
+                "last4": last4,
+                "round_id": round_id,
+                "path_id": path.id,
+            }
+
+
+@pytest.mark.asyncio
+async def test_magic_link_submit_410_when_round_closed(
+    client: AsyncClient,
+    magic_link_submit_seed_closed_round: dict,
+):
+    """Candidate self-service magic-link submit sau round closed → 410.
+
+    Anchor PR-2 cutoff gate fire qua magic_link_service._handle_submit
+    → admission_service.submit_and_evaluate. Verify candidate KHÔNG bypass
+    được cutoff qua link path (sự cố tiềm tàng nếu gate chỉ ở officer
+    UI route).
+    """
+    response = await client.post(
+        f"/api/v2/admissions/magic-link/submit/{magic_link_submit_seed_closed_round['token']}",
+        json={"cccd": magic_link_submit_seed_closed_round["last4"]},
+    )
+    assert response.status_code == 410, (
+        f"Magic-link submit sau round closed phải 410 Gone; "
+        f"got {response.status_code}: {response.text[:200]}"
+    )
+    body = response.json()
+    assert "đã đóng" in (body.get("detail") or "").lower(), (
+        f"Detail phải mention 'đã đóng'; got: {body}"
+    )
+
+    # Token must NOT be marked consumed (gate fired before _handle_submit body)
+    async with AsyncSessionLocal() as s:
+        token = (await s.execute(
+            select(models.AdmissionConfirmationToken).where(
+                models.AdmissionConfirmationToken.token == magic_link_submit_seed_closed_round["token"]
+            )
+        )).scalar_one()
+        assert token.confirmed_at is None, (
+            "Token must NOT be marked consumed when cutoff blocks submit"
+        )


### PR DESCRIPTION
## Summary
- Enforce `OfferingAdmissionRound` SPEC §2.1.a Rule 1 — block create/submit profile + add/modify choices sau `round.end_date < today_vn()`.
- New exception `GoneError(BaseAppException, status_code=410)` + subclass `RoundClosedError`; `BaseAppException` global handler auto-picks status_code (no custom handler).
- Strict fail-closed: no grace period, no admin override; admin extends qua `POST /rounds/{id}/extend` (NOT bypass gate).

## Why
Per audit findings 2026-05-28 (P1): model docstring `OfferingAdmissionRound.py:45` ghi 410 Gone fail-closed nhưng `create_profile` (admission_service.py:3060-3114) + `submit_and_evaluate` không enforce → production có thể nhận hồ sơ sau hạn nếu admin quên tắt round.

## Locked decisions (plan v4 2026-05-28)
- **POST + PATCH gate**: create_profile, submit_and_evaluate, add_choice, update_choice_display_order, replace_choice_scores
- **DELETE allowed**: `delete_choice` intentionally NOT gated — candidate retains right to withdraw NV sau round closed (không thêm seat, không tăng over-admit risk)
- **Magic-link**: `magic_link_service._handle_submit` delegates qua `admission_service.submit_and_evaluate` → gate tự fire, no duplicate

## Changes (6 files, +600 lines)

**Runtime:**
- `app/utils/exceptions.py`: `GoneError` + `RoundClosedError` + `EXCEPTION_HTTP_STATUS_MAP` entries
- `app/services/admission_service.py`: `_assert_round_open` helper + 2 gates
- `app/services/admission_choice_service.py`: local `_assert_round_open` (avoid circular) + 3 gates

**Tests (8, all extend Tier 1/4 allowlist files — KHÔNG cần update workflow):**
- `tests/api/test_admission_workflow_api.py` (Tier 4): create 410, submit 410, extend re-opens (3)
- `tests/api/test_phase3_pr3d_b_choice_crud.py` (Tier 1): POST 410, PATCH 410, PATCH /scores 410, DELETE allowed inverse anchor (4)
- `tests/api/test_phase3_pr3e_magic_link.py` (Tier 1): magic-link submit 410 (1)

## Test plan
- [x] Compile sweep 6 files: pass
- [x] Import smoke (exceptions + admission_service + admission_choice_service): pass
- [x] 8 deterministic tests pass local: 71.59s
- [x] `check_status_assignment`: pass (no new direct status writes)
- [x] `check_notification_event_coverage`: pass (no new events)
- [x] `git diff --check`: pass
- [ ] CI backend-test.yml Tier 1/4 green
- [ ] CI admission-contract-check.yml green

## Context
PR-2 của 5-PR admission hardening sprint (plan v4 2026-05-28). Order: PR-4 → **PR-2** → PR-1 → PR-3 → PR-5.

Builds on PR #345 (PR-4 admin-rollback row lock) — PR-2 base branch là main, không depend trực tiếp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)