### PR TITLE
feat(admissions): choice engine quota guard

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -168,6 +168,7 @@ jobs:
           tests/unit/test_phase3_pr3c_sub2b_router_helpers.py
           tests/unit/test_phase3_pr3c_sub3_router_registration.py
           tests/api/test_phase3_pr3c_routers_integration.py
+          tests/integration/test_choice_engine_quota_concurrent.py
           tests/api/test_phase3_pr3d_b_choice_crud.py
           tests/api/test_phase3_pr3d_b_admin_backfill.py
           tests/api/test_phase3_pr3e_magic_link.py

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -697,6 +697,51 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def get_round_for_profile_cutoff(
+        self,
+        profile: models.AdmissionProfile,
+    ) -> Optional[models.OfferingAdmissionRound]:
+        """Resolve OfferingAdmissionRound từ ``profile.applied_rules`` snapshot.
+
+        Used by ``admission_service.submit_and_evaluate`` round-cutoff gate
+        (PR-2 ship 2026-05-28). Profile snapshot stores ``admission_path_id``
+        tại create-time → repo lookup path → round.
+
+        Returns None nếu:
+        - ``applied_rules`` rỗng hoặc thiếu ``admission_path_id`` (legacy
+          profile, pre-snapshot era — caller should log + skip gate)
+        - path không tồn tại (FK orphan; defensive, should not happen)
+
+        Caller responsibility:
+        - Handle None → skip cutoff gate + emit observability warning so ops
+          can find legacy profiles bypassing the round-cutoff fail-closed.
+        - Call ``assert_round_open(round)`` (utils.admission_round_guards)
+          on non-None return to enforce 410 Gone.
+
+        Extracted via PR #346 review nit #2: removes the inline 20-line
+        block in submit_and_evaluate + ugly ``sa_select_cutoff`` aliases
+        which existed to dodge top-level ``select``/``selectinload`` name
+        collisions inside the function-local scope.
+        """
+        applied_rules = profile.applied_rules or {}
+        path_id_raw = applied_rules.get("admission_path_id")
+        if path_id_raw is None:
+            return None
+        try:
+            path_id = int(path_id_raw)
+        except (TypeError, ValueError):
+            return None
+
+        stmt = (
+            select(AdmissionPath)
+            .where(AdmissionPath.id == path_id)
+            .options(selectinload(AdmissionPath.admission_round))
+        )
+        path = (await self.db.execute(stmt)).scalar_one_or_none()
+        if path is None:
+            return None
+        return path.admission_round
+
     async def reload_profile_with_lead(
         self,
         profile_id: int

--- a/Backend_FastAPI/app/routers/admissions_v2.py
+++ b/Backend_FastAPI/app/routers/admissions_v2.py
@@ -222,8 +222,22 @@ async def waitlist_promote_choice(
     **Dispatches** (via state_service.transition() + PAIR map):
     - ADMISSION_WAITLIST_PROMOTED (T10 source-aware, NOT generic ADMITTED)
     """
-    # Fetch choice + verify ownership (router thin lookup)
-    choice = await db.get(models.AdmissionProfileChoice, payload.choice_id)
+    # Fetch choice with eager-load chain for capacity check.
+    # PR-1 (2026-05-28): promote_waitlisted_choice now calls
+    # check_choice_admit_capacity which reads choice.admission_path.
+    # academic_info — without eager-load, lazy access in async context
+    # raises MissingGreenlet. Mirror engine cascade eager-load shape.
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+    choice_stmt = (
+        select(models.AdmissionProfileChoice)
+        .where(models.AdmissionProfileChoice.id == payload.choice_id)
+        .options(
+            selectinload(models.AdmissionProfileChoice.admission_path)
+            .selectinload(models.AdmissionPath.academic_info),
+        )
+    )
+    choice = (await db.execute(choice_stmt)).scalar_one_or_none()
     if choice is None or choice.admission_profile_id != profile.id:
         # 404 anti-enumeration per IDOR pattern (memory deps.py precedent)
         raise ResourceNotFoundError(

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -222,7 +222,16 @@ async def check_choice_admit_capacity(
     #       restricted to uses_choice_engine=FALSE to avoid double-counting
     #       with (a).
     academic_info = getattr(path, "academic_info", None)
-    if academic_info is not None and academic_info.annual_admission_quota is not None:
+    annual_cap_hint = (
+        getattr(academic_info, "annual_admission_quota", None)
+        if academic_info is not None
+        else None
+    )
+    admit_quota_hint = getattr(path, "admit_quota", None)
+    if annual_cap_hint is None and admit_quota_hint is None:
+        return CapacityCheck(allowed=True)
+
+    if academic_info is not None and annual_cap_hint is not None:
         ai_locked = (
             await db.execute(
                 select(models.OfferingAcademicInfo)

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -63,8 +63,10 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, TYPE_C
 from decimal import Decimal
 
 import structlog
+from sqlalchemy import Integer, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from .. import models
 from ..core.events import SystemEvents
 from ..utils.exceptions import BusinessRuleViolation
 from .admission_scoring_service import (
@@ -82,6 +84,222 @@ if TYPE_CHECKING:
     )
 
 log = structlog.get_logger(__name__)
+
+
+# ============================================================================
+# PR-1 (2026-05-28) — Capacity check helper for T6 cascade + T10 promote
+# ============================================================================
+#
+# Engine pre-PR-1: marked decision='admitted' purely from eligibility +
+# score, with NO check against admit_quota (per-path admit cap) or
+# annual_admission_quota (per-academic_info cap). Legacy single-NV approve
+# path enforced these via `_assert_quota_or_bypass` (admission_service.py)
+# but multi-NV cascade silently bypassed → over-admit risk if quota tight.
+#
+# This helper is the engine-internal counterpart. Differences vs the
+# legacy bypass-aware service helper:
+#   * No admin bypass contract — engine is a system trigger, not a human
+#     decision; falling back to waitlist is the right answer when capacity
+#     is exhausted (manager then makes a separate explicit override call).
+#   * Returns CapacityCheck instead of raising — caller threads the
+#     reason_code into `eligibility_check_result` so FE renders the
+#     waitlist explanation per choice.
+#   * Lock order: OfferingAcademicInfo FIRST (matches
+#     `admission_quota_service.py` Tier 1 pattern + admin update flow),
+#     AdmissionPath SECOND. Mismatched order vs the admin config flow
+#     would deadlock under concurrent edit + cascade.
+
+# Statuses that occupy a quota seat. Duplicated from
+# `admission_service.QUOTA_OCCUPYING_STATUSES` deliberately: importing
+# admission_service would create a circular dep (admission_service already
+# imports state_service which imports event mapping which imports engine
+# in some legacy call paths). Keep both lists in sync if either is
+# extended; the set has been stable since #15/#16 (admitted forward-compat).
+_QUOTA_OCCUPYING_STATUSES: tuple[str, ...] = (
+    "approved",
+    "overridden",
+    "admitted",
+    "confirmed",
+    "enrolled",
+)
+
+
+@dataclass(frozen=True)
+class CapacityCheck:
+    """Result of `check_choice_admit_capacity()` — capacity probe outcome.
+
+    Frozen so callers cannot mutate the verdict between check and act.
+
+    Fields:
+        allowed: True ⇒ admit safe; False ⇒ must waitlist/reject.
+        reason_code: Identifier matched by FE label map. One of
+            ``PATH_QUOTA_EXHAUSTED``, ``OFFERING_ANNUAL_QUOTA_EXHAUSTED``,
+            or ``None`` when allowed.
+        detail: Observability payload (path_id, current_count, cap) —
+            written to ``eligibility_check_result.capacity_detail`` so
+            FE/audit can show "X/Y seats taken". ``None`` when allowed.
+    """
+
+    allowed: bool
+    reason_code: Optional[str] = None
+    detail: Optional[Dict[str, Any]] = None
+
+
+async def check_choice_admit_capacity(
+    db: AsyncSession,
+    *,
+    path: "AdmissionPath",
+    admission_profile_id: int,
+) -> CapacityCheck:
+    """Probe whether ``admission_profile_id`` can still admit on ``path``.
+
+    Two-tier check (both must pass for ``allowed=True``):
+
+    **Tier 1 — Annual academic_info cap** (when configured):
+        Count profiles in ``_QUOTA_OCCUPYING_STATUSES`` for the same
+        (offering, academic_year) as ``path.academic_info``. Excludes
+        ``admission_profile_id`` itself so re-publishing the same profile
+        does not double-count.
+
+    **Tier 2 — Per-path admit cap** (when configured):
+        Count seats consumed on the path from TWO sources:
+          (a) Multi-NV via ``AdmissionProfileChoice.decision='admitted'``
+              with the same ``admission_path_id``, joined to profile
+              status in ``_QUOTA_OCCUPYING_STATUSES``.
+          (b) Legacy single-NV via ``AdmissionProfile.applied_rules
+              ->>'admission_path_id'`` filter, restricted to
+              ``uses_choice_engine = FALSE`` to avoid double-counting
+              with the choice rows above.
+
+    NULL ``admit_quota`` / ``annual_admission_quota`` → unbounded, skip
+    that tier (callers configure cap explicitly to opt-in to enforcement).
+
+    **Lock order (deadlock prevention)**:
+        1. ``SELECT ... FOR UPDATE`` on ``OfferingAcademicInfo`` first
+           (when annual cap configured). Matches the order
+           `admission_quota_service.validate_tier1_chain_on_path_quota_change`
+           uses for admin quota config edits — concurrent cascade +
+           admin update will not deadlock.
+        2. ``SELECT ... FOR UPDATE`` on ``AdmissionPath`` second. Path
+           row is the per-choice serialization point.
+
+    Args:
+        db: Active session. Caller wraps in ``begin_nested()`` per memory
+            `dispatch-bundle-strict-required` so per-profile rollback
+            does not nuke the batch.
+        path: Eager-loaded ``AdmissionPath`` (with ``academic_info`` for
+            Tier 1 lookup). Caller obtains via cascade choice eager-load
+            chain. Pass the in-memory row; helper re-fetches WITH lock
+            so the input ref is just a key carrier.
+        admission_profile_id: Profile being evaluated. Excluded from
+            counts so re-publishing the same profile is idempotent.
+
+    Returns:
+        CapacityCheck. On ``allowed=False`` the ``detail`` dict shape is:
+          - Tier 1: ``{"academic_info_id": int, "current_count": int,
+                       "cap": int}``
+          - Tier 2: ``{"path_id": int, "current_count": int, "cap": int}``
+
+    Raises:
+        Nothing under normal flow — capacity exhaustion is a valid
+        business outcome (→ waitlist), not an exception. SQLAlchemy DB
+        errors propagate (caller-savepoint catches).
+    """
+    # Tier 1 — annual academic_info cap (lock FIRST).
+    academic_info = getattr(path, "academic_info", None)
+    if academic_info is not None and academic_info.annual_admission_quota is not None:
+        ai_locked = (
+            await db.execute(
+                select(models.OfferingAcademicInfo)
+                .where(models.OfferingAcademicInfo.id == academic_info.id)
+                .with_for_update()
+            )
+        ).scalar_one()
+        annual_cap = ai_locked.annual_admission_quota
+        annual_count_stmt = (
+            select(func.count(models.AdmissionProfile.id))
+            .join(
+                models.Lead,
+                models.AdmissionProfile.lead_id == models.Lead.id,
+            )
+            .where(
+                models.Lead.offering_id == ai_locked.offering_id,
+                models.AdmissionProfile.academic_year == ai_locked.academic_year,
+                models.AdmissionProfile.status.in_(_QUOTA_OCCUPYING_STATUSES),
+                models.AdmissionProfile.id != admission_profile_id,
+            )
+        )
+        annual_count = int(
+            (await db.execute(annual_count_stmt)).scalar_one() or 0
+        )
+        if annual_count + 1 > annual_cap:
+            return CapacityCheck(
+                allowed=False,
+                reason_code="OFFERING_ANNUAL_QUOTA_EXHAUSTED",
+                detail={
+                    "academic_info_id": ai_locked.id,
+                    "current_count": annual_count,
+                    "cap": annual_cap,
+                },
+            )
+
+    # Tier 2 — per-path admit cap (lock SECOND).
+    path_locked = (
+        await db.execute(
+            select(models.AdmissionPath)
+            .where(models.AdmissionPath.id == path.id)
+            .with_for_update()
+        )
+    ).scalar_one()
+    admit_quota = path_locked.admit_quota
+    if admit_quota is None:
+        return CapacityCheck(allowed=True)
+
+    # (a) Multi-NV count via choice rows.
+    multi_nv_stmt = (
+        select(func.count(models.AdmissionProfileChoice.id))
+        .join(
+            models.AdmissionProfile,
+            models.AdmissionProfile.id
+            == models.AdmissionProfileChoice.admission_profile_id,
+        )
+        .where(
+            models.AdmissionProfileChoice.admission_path_id == path_locked.id,
+            models.AdmissionProfileChoice.decision == "admitted",
+            models.AdmissionProfile.status.in_(_QUOTA_OCCUPYING_STATUSES),
+            models.AdmissionProfile.id != admission_profile_id,
+        )
+    )
+    multi_nv_count = int((await db.execute(multi_nv_stmt)).scalar_one() or 0)
+
+    # (b) Legacy single-NV count via applied_rules snapshot. Restrict to
+    # uses_choice_engine=False so multi-NV profiles aren't double-counted
+    # (their seats are already in (a) via the choice row).
+    legacy_stmt = (
+        select(func.count(models.AdmissionProfile.id))
+        .where(
+            models.AdmissionProfile.uses_choice_engine.is_(False),
+            models.AdmissionProfile.status.in_(_QUOTA_OCCUPYING_STATUSES),
+            models.AdmissionProfile.applied_rules["admission_path_id"]
+            .astext.cast(Integer) == path_locked.id,
+            models.AdmissionProfile.id != admission_profile_id,
+        )
+    )
+    legacy_count = int((await db.execute(legacy_stmt)).scalar_one() or 0)
+
+    current_count = multi_nv_count + legacy_count
+    if current_count + 1 > admit_quota:
+        return CapacityCheck(
+            allowed=False,
+            reason_code="PATH_QUOTA_EXHAUSTED",
+            detail={
+                "path_id": path_locked.id,
+                "current_count": current_count,
+                "cap": admit_quota,
+            },
+        )
+
+    return CapacityCheck(allowed=True)
 
 
 # ============================================================================
@@ -511,12 +729,36 @@ async def evaluate_cascade(
         decision, score_result, reason_codes = _evaluate_single_choice(
             profile, choice, priority_bonus=priority_bonus_total,
         )
+
+        # PR-1 (2026-05-28) — Capacity gate per choice. Engine pre-PR-1
+        # never checked admit_quota / annual_admission_quota → silently
+        # over-admit on tight quotas. Now: if eligibility+score pass,
+        # re-check capacity. Capacity exhausted ⇒ degrade to 'waitlisted'
+        # + append reason_code to audit; fallthrough so the loop tries
+        # the next NV (lower priority). This matches plan v4 locked
+        # semantic: lower NV gets seat when higher NV's quota is full.
+        capacity_detail: Optional[Dict[str, Any]] = None
+        if decision == "admitted":
+            capacity = await check_choice_admit_capacity(
+                db,
+                path=choice.admission_path,
+                admission_profile_id=profile.id,
+            )
+            if not capacity.allowed:
+                decision = "waitlisted"
+                if capacity.reason_code:
+                    reason_codes.append(capacity.reason_code)
+                capacity_detail = capacity.detail
+
         choice.decision = decision
 
-        # Record eligibility check result for audit trail
+        # Record eligibility check result for audit trail. capacity_detail
+        # is additive (None when no capacity probe ran or capacity OK) so
+        # FE consumers ignoring the field stay forward-compat.
         choice.eligibility_check_result = {
             "decision": decision,
             "reason_codes": reason_codes,
+            "capacity_detail": capacity_detail,
             "score": (
                 {
                     "final_score": (
@@ -551,8 +793,17 @@ async def evaluate_cascade(
             result.admitted_choice_id = choice.id
             result.admitted_display_order = choice.display_order
 
-    # Final profile status — admitted if any choice admitted, else rejected
-    final_status = "admitted" if admitted_found else "rejected"
+    # Final profile status (PR-1 ship — 3-way decision):
+    #   any admit  → admitted (highest priority — first admit wins)
+    #   no admit but ≥1 waitlist (quota-induced) → waitlisted
+    #   all rejected (eligibility/score fail) → rejected
+    has_waitlist = any(c.decision == "waitlisted" for c in sorted_choices)
+    if admitted_found:
+        final_status = "admitted"
+    elif has_waitlist:
+        final_status = "waitlisted"
+    else:
+        final_status = "rejected"
     result.final_status = final_status
 
     await db.flush()
@@ -738,6 +989,27 @@ async def promote_waitlisted_choice(
     if profile.status != "waitlisted":
         raise BusinessRuleViolation(
             f"Hồ sơ phải ở trạng thái 'waitlisted'; current: '{profile.status}'"
+        )
+
+    # PR-1 (2026-05-28) — Re-check capacity AT promote-time. Cascade
+    # capacity gate only fires at T6; between T6 and T10 (admin click)
+    # other profiles may have admitted into the same path/academic_info
+    # and exhausted the quota. Without this gate, T10 silently
+    # over-admits beyond admit_quota / annual_admission_quota.
+    # Raise BusinessRuleViolation (NOT waitlist again) — admin must
+    # see the error, evaluate seat-freeing options (reject another
+    # admit, or wait for cancellation), then retry explicitly.
+    capacity = await check_choice_admit_capacity(
+        db,
+        path=choice.admission_path,
+        admission_profile_id=profile.id,
+    )
+    if not capacity.allowed:
+        raise BusinessRuleViolation(
+            f"Không thể promote — chỉ tiêu đã hết "
+            f"(reason={capacity.reason_code}, detail={capacity.detail}). "
+            f"Cần giải phóng ghế trước khi promote (reject hồ sơ khác "
+            f"hoặc đợi candidate cancel)."
         )
 
     # Update choice decision FIRST so audit trail captures the source

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -206,6 +206,21 @@ async def check_choice_admit_capacity(
         errors propagate (caller-savepoint catches).
     """
     # Tier 1 — annual academic_info cap (lock FIRST).
+    #
+    # Count attribution post-PR-1 review (BLOCKER #1 fix 2026-05-28):
+    # Multi-NV permits cross-offering choices (no constraint enforces
+    # same offering across NV). Lead.offering_id reflects ONLY the
+    # candidate's initial intent — they may admit via NV-N into a
+    # completely different academic_info. Counting via Lead.offering_id
+    # under-counts when admit target differs from intent → over-admit.
+    #
+    # Fix: count seats by what each profile is ACTUALLY admitted to:
+    #   (a) Multi-NV: AdmissionProfileChoice WHERE decision='admitted'
+    #       JOIN AdmissionPath WHERE academic_info_id = X
+    #   (b) Legacy single-NV: AdmissionProfile WHERE applied_rules
+    #       ->>admission_path_id ∈ {paths under academic_info X},
+    #       restricted to uses_choice_engine=FALSE to avoid double-counting
+    #       with (a).
     academic_info = getattr(path, "academic_info", None)
     if academic_info is not None and academic_info.annual_admission_quota is not None:
         ai_locked = (
@@ -216,22 +231,54 @@ async def check_choice_admit_capacity(
             )
         ).scalar_one()
         annual_cap = ai_locked.annual_admission_quota
-        annual_count_stmt = (
-            select(func.count(models.AdmissionProfile.id))
+
+        # (a) Multi-NV seats consumed in this academic_info.
+        annual_multi_nv_stmt = (
+            select(func.count(models.AdmissionProfileChoice.id))
             .join(
-                models.Lead,
-                models.AdmissionProfile.lead_id == models.Lead.id,
+                models.AdmissionProfile,
+                models.AdmissionProfile.id
+                == models.AdmissionProfileChoice.admission_profile_id,
+            )
+            .join(
+                models.AdmissionPath,
+                models.AdmissionPath.id
+                == models.AdmissionProfileChoice.admission_path_id,
             )
             .where(
-                models.Lead.offering_id == ai_locked.offering_id,
-                models.AdmissionProfile.academic_year == ai_locked.academic_year,
+                models.AdmissionPath.academic_info_id == ai_locked.id,
+                models.AdmissionProfileChoice.decision == "admitted",
                 models.AdmissionProfile.status.in_(_QUOTA_OCCUPYING_STATUSES),
                 models.AdmissionProfile.id != admission_profile_id,
             )
         )
-        annual_count = int(
-            (await db.execute(annual_count_stmt)).scalar_one() or 0
+        annual_multi_nv_count = int(
+            (await db.execute(annual_multi_nv_stmt)).scalar_one() or 0
         )
+
+        # (b) Legacy seats consumed (applied_rules.admission_path_id points
+        # into a path under this academic_info). Restrict to
+        # uses_choice_engine=FALSE so multi-NV profiles aren't double-counted.
+        annual_legacy_stmt = (
+            select(func.count(models.AdmissionProfile.id))
+            .where(
+                models.AdmissionProfile.uses_choice_engine.is_(False),
+                models.AdmissionProfile.status.in_(_QUOTA_OCCUPYING_STATUSES),
+                models.AdmissionProfile.id != admission_profile_id,
+                models.AdmissionProfile.applied_rules["admission_path_id"]
+                .astext.cast(Integer)
+                .in_(
+                    select(models.AdmissionPath.id).where(
+                        models.AdmissionPath.academic_info_id == ai_locked.id,
+                    )
+                ),
+            )
+        )
+        annual_legacy_count = int(
+            (await db.execute(annual_legacy_stmt)).scalar_one() or 0
+        )
+
+        annual_count = annual_multi_nv_count + annual_legacy_count
         if annual_count + 1 > annual_cap:
             return CapacityCheck(
                 allowed=False,

--- a/Backend_FastAPI/app/services/admission_choice_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_service.py
@@ -35,7 +35,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models import (
     AdmissionProfile,
     AdmissionProfileChoice,
-    OfferingAdmissionRound,
 )
 from app.repositories.admission_profile_choice_repository import (
     AdmissionProfileChoiceRepository,
@@ -43,35 +42,21 @@ from app.repositories.admission_profile_choice_repository import (
 from app.repositories.admission_path_repository import AdmissionPathRepository
 from app.services.activity_service import log_activity
 from app.services.system_config_service import SystemConfigService
-from app.utils.datetime_helpers import today_vn
+from app.utils.admission_round_guards import assert_round_open
 from app.utils.exceptions import (
     BusinessRuleViolation,
     DuplicateResourceError,
     ResourceNotFoundError,
-    RoundClosedError,
 )
 
 
 # Status whitelist cho add_choice retroactive (P1 fix #5 v2.12)
 ADD_CHOICE_ALLOWED_STATUSES = ("draft", "revision_requested")
 
-
-def _assert_round_open(round_obj: OfferingAdmissionRound) -> None:
-    """Raise RoundClosedError nếu round.end_date < today_vn().
-
-    PR-2 (2026-05-28) — strict cutoff enforcement cho modification ops
-    (POST/PATCH). KHÔNG gọi từ delete_choice — candidate retains right
-    to withdraw a NV sau round closed (no seat added → no risk).
-
-    Mirror helper trong admission_service.py:_assert_round_open. Local
-    copy ở đây để tránh circular import (admission_service → choice_service).
-    """
-    if round_obj.end_date is not None and round_obj.end_date < today_vn():
-        raise RoundClosedError(
-            f"Đợt tuyển sinh '{round_obj.round_code}' đã đóng "
-            f"(hạn cuối: {round_obj.end_date}). "
-            f"Không thể thêm/sửa nguyện vọng (rút NV vẫn cho phép)."
-        )
+# Context hint passed to assert_round_open for choice CRUD modification ops.
+# DELETE flow does NOT call assert_round_open (candidate retains withdraw right
+# per plan v4 locked decision — no seat added, no over-admit risk).
+_CHOICE_CRUD_HINT = "Không thể thêm/sửa nguyện vọng (rút NV vẫn cho phép)."
 
 
 async def _noop_callback() -> None:
@@ -154,7 +139,7 @@ class AdmissionChoiceService:
         # round.end_date. Per locked decision: POST + PATCH gate, DELETE
         # vẫn allow. Reuse round_obj đã load ngay trên cho allow_multi_nv
         # check — không thêm query.
-        _assert_round_open(round_obj)
+        assert_round_open(round_obj, context_hint=_CHOICE_CRUD_HINT)
 
         # First choice luôn cho phép (Wave A single-NV vẫn ship 1 choice
         # via this path). Chỉ block ADD-NV-2-trở-lên khi flag tắt.
@@ -420,7 +405,7 @@ class AdmissionChoiceService:
             choice.admission_path_id
         )
         if round_obj is not None:
-            _assert_round_open(round_obj)
+            assert_round_open(round_obj, context_hint=_CHOICE_CRUD_HINT)
 
         if new_display_order == choice.display_order:
             return choice, _noop_callback
@@ -480,7 +465,7 @@ class AdmissionChoiceService:
             choice.admission_path_id
         )
         if round_obj is not None:
-            _assert_round_open(round_obj)
+            assert_round_open(round_obj, context_hint=_CHOICE_CRUD_HINT)
 
         # Clear existing scores via direct delete (FK CASCADE would only fire
         # on choice delete, not score replace — use bulk delete here).

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -65,36 +65,12 @@ from ..utils.exceptions import (
     BusinessRuleViolation,
     PermissionDeniedError,
     ConflictError,
-    RoundClosedError,
     ValidationError,
 )
-from ..utils.datetime_helpers import today_vn
+from ..utils.admission_round_guards import assert_round_open
 from ..utils.masking import mask_citizen_id
 
 log = structlog.get_logger(__name__)
-
-
-def _assert_round_open(round_obj: "models.OfferingAdmissionRound") -> None:
-    """Raise RoundClosedError nếu round.end_date < today_vn().
-
-    PR-2 (2026-05-28) — strict fail-closed enforcement của
-    OfferingAdmissionRound SPEC §2.1.a Rule 1 (model docstring nói 410
-    Gone nhưng pre-PR-2 không enforce ở runtime).
-
-    NULL end_date → open-ended round, pass-through (admin có thể set
-    explicit end_date sau). Strict semantic — KHÔNG có grace period,
-    KHÔNG admin override ngầm (plan v4 locked decision: admin extends
-    qua POST /rounds/{id}/extend, KHÔNG bypass gate này).
-
-    Caller: create_profile, submit_and_evaluate, choice CRUD POST/PATCH.
-    NOT called from choice DELETE (candidate retains right to withdraw).
-    """
-    if round_obj.end_date is not None and round_obj.end_date < today_vn():
-        raise RoundClosedError(
-            f"Đợt tuyển sinh '{round_obj.round_code}' đã đóng "
-            f"(hạn cuối: {round_obj.end_date}). "
-            f"Liên hệ admin nếu cần extend đợt."
-        )
 
 
 # ADM-012: Safe domain exceptions whose ``str()`` is user-facing copy.
@@ -3141,9 +3117,11 @@ async def create_profile(
     # PR-2 (2026-05-28) — Round cutoff enforcement (SPEC §2.1.a Rule 1).
     # Block create_profile khi end_date đã qua. Raise RoundClosedError → 410
     # Gone. Strict: KHÔNG grace period, KHÔNG admin override ngầm; admin
-    # extends qua POST /rounds/{id}/extend (helper inline để readers thấy
-    # rõ semantic ngay tại site).
-    _assert_round_open(admission_round)
+    # extends qua POST /rounds/{id}/extend separate endpoint.
+    assert_round_open(
+        admission_round,
+        context_hint="Liên hệ admin nếu cần extend đợt.",
+    )
 
     # Step 7: Find AdmissionPath for this (round, offering, method).
     #
@@ -4824,29 +4802,34 @@ async def submit_and_evaluate(
     # PR-2 (2026-05-28) — Round cutoff enforcement (SPEC §2.1.a Rule 1).
     # Block submit khi round.end_date đã qua. create_profile() đã gate
     # tại create-time, nhưng candidate có thể create rồi đợi qua end_date
-    # mới submit → second gate ở đây bảo vệ. Load round qua applied_rules
-    # snapshot (path_id → path → round). Fail-fast trước eligibility/doc/
-    # score validation để tiết kiệm cycles + clear 410 error message.
-    applied_rules_for_cutoff = profile.applied_rules or {}
-    path_id_for_cutoff = applied_rules_for_cutoff.get("admission_path_id")
-    if path_id_for_cutoff is not None:
-        try:
-            path_id_int_cutoff = int(path_id_for_cutoff)
-        except (TypeError, ValueError):
-            path_id_int_cutoff = None
-        if path_id_int_cutoff is not None:
-            from sqlalchemy import select as sa_select_cutoff
-            from sqlalchemy.orm import selectinload as sa_selectinload_cutoff
-            cutoff_stmt = (
-                sa_select_cutoff(models.AdmissionPath)
-                .where(models.AdmissionPath.id == path_id_int_cutoff)
-                .options(
-                    sa_selectinload_cutoff(models.AdmissionPath.admission_round)
-                )
-            )
-            cutoff_path = (await db.execute(cutoff_stmt)).scalar_one_or_none()
-            if cutoff_path is not None and cutoff_path.admission_round is not None:
-                _assert_round_open(cutoff_path.admission_round)
+    # mới submit → second gate ở đây bảo vệ. Fail-fast trước eligibility/
+    # doc/score validation để tiết kiệm cycles + clear 410 error message.
+    #
+    # PR review nit #2: extracted inline 20-line lookup → admission_repo
+    # helper. Removes ugly sa_select_cutoff aliases (function-local name
+    # collision dodge against top-level select/selectinload imports).
+    #
+    # PR review nit #3: legacy profile mà applied_rules thiếu
+    # admission_path_id bypass gate (silent skip). Per memory
+    # phase3-multi-nv-partial-enablement-2026-05-14 còn ~10 legacy profile
+    # — log warning để ops grep + backfill manual nếu cần.
+    cutoff_round = await admission_repo.get_round_for_profile_cutoff(profile)
+    if cutoff_round is not None:
+        assert_round_open(
+            cutoff_round,
+            context_hint="Liên hệ admin nếu cần extend đợt.",
+        )
+    else:
+        log.warning(
+            "submit_cutoff_skipped_missing_path_in_applied_rules",
+            profile_id=profile.id,
+            applied_rules_keys=sorted((profile.applied_rules or {}).keys()),
+            reason=(
+                "applied_rules thiếu admission_path_id → cutoff gate skip "
+                "(legacy profile pre-snapshot era). Ops: grep log để backfill "
+                "manual nếu round đã đóng."
+            ),
+        )
 
     # Q9 #07 Phase E.4 — eligibility gate per yêu cầu nghiệp vụ #5: chặn TOÀN BỘ
     # hồ sơ submit không match cultural + vocational vs target_level/admission_type

--- a/Backend_FastAPI/app/utils/admission_round_guards.py
+++ b/Backend_FastAPI/app/utils/admission_round_guards.py
@@ -1,0 +1,70 @@
+"""Shared admission round guard helpers.
+
+Extracted from `admission_service.py` + `admission_choice_service.py` to
+eliminate the 2-copy drift risk flagged in PR #346 review (2026-05-28).
+
+Both services need to enforce ``OfferingAdmissionRound`` SPEC §2.1.a
+Rule 1 (round.end_date cutoff → 410 Gone), but historical co-evolution
+left them with slightly different error messages and risked drift on
+future i18n / grace-period / timezone changes.
+
+This module:
+* Contains the canonical ``_assert_round_open`` implementation.
+* Imports ONLY from `app.utils.*` + `app.models.*` to avoid circular
+  imports with either service.
+* Keeps message contracts in one place so caller-specific wording
+  (e.g. "Liên hệ admin" vs "rút NV vẫn cho phép") layers on top via
+  optional `context_hint` parameter.
+
+Reference: PR #346 review follow-up nit #1 (plan v4 2026-05-28 sprint).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from app.utils.datetime_helpers import today_vn
+from app.utils.exceptions import RoundClosedError
+
+if TYPE_CHECKING:  # pragma: no cover — import only for type hints
+    from app.models import OfferingAdmissionRound
+
+
+def assert_round_open(
+    round_obj: "OfferingAdmissionRound",
+    *,
+    context_hint: Optional[str] = None,
+) -> None:
+    """Raise RoundClosedError nếu round.end_date < today_vn().
+
+    PR-2 (2026-05-28) — strict cutoff enforcement của
+    OfferingAdmissionRound SPEC §2.1.a Rule 1.
+
+    NULL end_date → open-ended round, pass-through (admin có thể set
+    explicit end_date sau). Strict semantic — KHÔNG có grace period,
+    KHÔNG admin override ngầm (plan v4 locked decision: admin extends
+    qua POST /rounds/{id}/extend, KHÔNG bypass gate này).
+
+    Args:
+        round_obj: OfferingAdmissionRound đã load (callers thường đã có
+            qua eager-load của allow_multi_nv check hoặc explicit query).
+        context_hint: Optional Vietnamese clause append vào error message
+            để caller-side gợi ý hành động cho candidate/officer:
+            * Service create/submit: "Liên hệ admin nếu cần extend đợt."
+            * Service choice CRUD: "Không thể thêm/sửa nguyện vọng
+              (rút NV vẫn cho phép)."
+            Default None → message chỉ chứa round_code + end_date.
+
+    Raises:
+        RoundClosedError: end_date < today_vn(). HTTP 410 Gone tự pickup
+            via BaseAppException handler (main.py:398).
+    """
+    if round_obj.end_date is None or round_obj.end_date >= today_vn():
+        return
+
+    detail = (
+        f"Đợt tuyển sinh '{round_obj.round_code}' đã đóng "
+        f"(hạn cuối: {round_obj.end_date})."
+    )
+    if context_hint:
+        detail = f"{detail} {context_hint}"
+    raise RoundClosedError(detail)

--- a/Backend_FastAPI/tests/api/test_admission_workflow_api.py
+++ b/Backend_FastAPI/tests/api/test_admission_workflow_api.py
@@ -656,8 +656,9 @@ async def test_create_profile_410_when_round_end_date_passed(
         f"got {r.status_code}: {r.text[:200]}"
     )
     body = r.json()
-    assert "đã đóng" in (body.get("detail") or "").lower(), (
-        f"Detail phải mention 'đã đóng'; got: {body}"
+    # Assert via stable error_code (i18n-safe) per PR #346 review nit #4.
+    assert body.get("error_code") == "ROUND_CLOSED", (
+        f"Error code phải 'ROUND_CLOSED'; got: {body}"
     )
 
 

--- a/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
@@ -148,6 +148,11 @@ async def pr3a_seed(seed_lead_dependencies: dict) -> dict:
                 "subject_id": subj.id,
                 "round_id": round_id,
                 "lead_id": lead.id,
+                # PR-1 (2026-05-28): expose offering_id so quota helper tests
+                # can seed leads with matching offering_id for annual cap
+                # COUNT(*) JOIN on Lead.offering_id.
+                "offering_id": offering.id,
+                "academic_info_id": ai.id,
             }
 
 
@@ -1660,3 +1665,682 @@ async def test_admin_rollback_serializes_with_concurrent_attempts(
         assert profile_after.status == "draft", (
             f"Expected final state='draft'; got {profile_after.status}"
         )
+
+
+# ============================================================================
+# PR-1 (2026-05-28) — Choice engine quota guard tests
+#
+# Capacity helper (check_choice_admit_capacity) + cascade waitlist fallthrough
+# + T10 promote re-check. All real-DB (capacity helper queries
+# AdmissionProfileChoice + AdmissionProfile.applied_rules across rows —
+# pure mocks would be tautological).
+#
+# Test placement: same Tier 1 file (backend-test.yml:170) cùng với cascade
+# integration tests. Keeps allowlist single-source-of-truth.
+# ============================================================================
+
+
+@pytest_asyncio.fixture
+async def pr1_seed_with_quota(pr3a_seed: dict) -> dict:
+    """Extend pr3a_seed: set path.admit_quota=1, annual_admission_quota=2.
+
+    Tight quotas so capacity tests can exercise both Tier 1 (annual) and
+    Tier 2 (path) caps with minimal seed data.
+    """
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            path = await s.get(models.AdmissionPath, pr3a_seed["path_id"])
+            path.admit_quota = 1
+            path.round_quota = 5  # plenty for submit gate (not under test)
+            ai = await s.get(
+                models.OfferingAcademicInfo, path.academic_info_id
+            )
+            ai.annual_admission_quota = 2
+    return pr3a_seed
+
+
+async def _seed_admitted_choice_for_path(
+    path_id: int,
+    config_id: int,
+    unit_id: int,
+    pipeline_stage_id: int,
+    offering_id: int,
+) -> dict:
+    """Seed an extra profile + choice already in admitted state on the path.
+
+    Used to push path admit count up before testing capacity helper. Mimics
+    a previous successful cascade. Returns {profile_id, choice_id}.
+
+    Reuses the same path_subject_group_config_id (NOT NULL FK) across all
+    seed profiles — fine for capacity counting; uniqueness constraint is
+    on (profile_id, path_id, config_id) so different profiles can share.
+
+    `offering_id` MUST match the path's academic_info.offering_id so the
+    Tier 1 annual cap COUNT(*) JOIN on Lead.offering_id picks up the
+    seeded profile (annual count = COUNT WHERE Lead.offering_id matches
+    AND profile.academic_year matches AND status in occupying set).
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    # Add a small random offset to avoid collisions when called in tight loop
+    import random
+    ts = (ts + random.randint(0, 999)) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            lead = models.Lead(
+                full_name=f"Quota seed lead {ts}",
+                phone=f"099{ts:07d}"[:10],
+                unit_id=unit_id,
+                pipeline_stage_id=pipeline_stage_id,
+                source="walkin",
+                offering_id=offering_id,
+            )
+            s.add(lead); await s.flush()
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                citizen_id=f"7{ts:08d}9"[:12],
+                status="admitted",
+                applied_rules={"admission_path_id": path_id},
+                academic_year=2026,
+                uses_choice_engine=True,
+            )
+            s.add(profile); await s.flush()
+            choice = models.AdmissionProfileChoice(
+                admission_profile_id=profile.id,
+                admission_path_id=path_id,
+                path_subject_group_config_id=config_id,
+                display_order=1,
+                decision="admitted",
+            )
+            s.add(choice); await s.flush()
+            return {"profile_id": profile.id, "choice_id": choice.id}
+
+
+# --- 7 capacity helper unit-ish tests (real DB, isolated helper call) ---
+
+
+@pytest.mark.asyncio
+async def test_capacity_check_path_quota_allows_under_cap(
+    pr1_seed_with_quota: dict, seed_lead_dependencies: dict,
+):
+    """admit_quota=1, 0 admitted seats → allowed=True."""
+    from app.services.admission_choice_engine_service import (
+        check_choice_admit_capacity,
+    )
+    async with AsyncSessionLocal() as s:
+        from sqlalchemy import select as sa_select
+        from sqlalchemy.orm import selectinload as sa_sl
+        path = (await s.execute(
+            sa_select(models.AdmissionPath)
+            .where(models.AdmissionPath.id == pr1_seed_with_quota["path_id"])
+            .options(sa_sl(models.AdmissionPath.academic_info))
+        )).scalar_one()
+        check = await check_choice_admit_capacity(
+            s, path=path,
+            admission_profile_id=pr1_seed_with_quota["profile_id"],
+        )
+    assert check.allowed is True, f"Should allow under cap; got {check}"
+
+
+@pytest.mark.asyncio
+async def test_capacity_check_path_quota_blocks_at_cap(
+    pr1_seed_with_quota: dict, seed_lead_dependencies: dict,
+):
+    """admit_quota=1, 1 admitted seat already → allowed=False
+    PATH_QUOTA_EXHAUSTED. Annual cap=2 with 1 used → Tier 1 still OK,
+    so reason must be path-tier (NOT annual)."""
+    from app.services.admission_choice_engine_service import (
+        check_choice_admit_capacity,
+    )
+    await _seed_admitted_choice_for_path(
+        pr1_seed_with_quota["path_id"],
+        pr1_seed_with_quota["config_id"],
+        seed_lead_dependencies["unit_id"],
+        seed_lead_dependencies["stage_id"],
+        pr1_seed_with_quota["offering_id"],
+    )
+    async with AsyncSessionLocal() as s:
+        from sqlalchemy import select as sa_select
+        from sqlalchemy.orm import selectinload as sa_sl
+        path = (await s.execute(
+            sa_select(models.AdmissionPath)
+            .where(models.AdmissionPath.id == pr1_seed_with_quota["path_id"])
+            .options(sa_sl(models.AdmissionPath.academic_info))
+        )).scalar_one()
+        check = await check_choice_admit_capacity(
+            s, path=path,
+            admission_profile_id=pr1_seed_with_quota["profile_id"],
+        )
+    assert check.allowed is False
+    assert check.reason_code == "PATH_QUOTA_EXHAUSTED", (
+        f"Path quota fills first (1/1 vs annual 1/2); got {check.reason_code}"
+    )
+    assert check.detail["cap"] == 1 and check.detail["current_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_capacity_check_annual_quota_blocks_across_methods(
+    pr1_seed_with_quota: dict, seed_lead_dependencies: dict,
+):
+    """annual_admission_quota=2 reached via 2 admitted profiles on SAME
+    offering (even though path admit_quota itself only sees 1) →
+    OFFERING_ANNUAL_QUOTA_EXHAUSTED. Verify Tier 1 fires BEFORE Tier 2
+    when both would block — proves lock order + check order correct.
+    """
+    from app.services.admission_choice_engine_service import (
+        check_choice_admit_capacity,
+    )
+    # Bump path admit_quota high so Tier 2 doesn't fire first
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            path = await s.get(
+                models.AdmissionPath, pr1_seed_with_quota["path_id"]
+            )
+            path.admit_quota = 100
+
+    # Seed 2 admitted on this same offering/year → annual count = 2 = cap
+    for _ in range(2):
+        await _seed_admitted_choice_for_path(
+            pr1_seed_with_quota["path_id"],
+            pr1_seed_with_quota["config_id"],
+            seed_lead_dependencies["unit_id"],
+            seed_lead_dependencies["stage_id"],
+            pr1_seed_with_quota["offering_id"],
+        )
+
+    async with AsyncSessionLocal() as s:
+        from sqlalchemy import select as sa_select
+        from sqlalchemy.orm import selectinload as sa_sl
+        path = (await s.execute(
+            sa_select(models.AdmissionPath)
+            .where(models.AdmissionPath.id == pr1_seed_with_quota["path_id"])
+            .options(sa_sl(models.AdmissionPath.academic_info))
+        )).scalar_one()
+        check = await check_choice_admit_capacity(
+            s, path=path,
+            admission_profile_id=pr1_seed_with_quota["profile_id"],
+        )
+    assert check.allowed is False
+    assert check.reason_code == "OFFERING_ANNUAL_QUOTA_EXHAUSTED", (
+        f"Annual cap fires first (2/2); got {check.reason_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_capacity_check_excludes_self_profile(
+    pr1_seed_with_quota: dict, seed_lead_dependencies: dict,
+):
+    """Re-publishing the SAME profile (already admitted) must NOT
+    double-count itself → still allowed=True even when admit_quota=1.
+    Anchor: idempotent re-cascade does not exhaust own seat.
+    """
+    from app.services.admission_choice_engine_service import (
+        check_choice_admit_capacity,
+    )
+    # Make the seed profile itself admitted on the path so we test
+    # self-exclusion. Use applied_rules path so legacy-count branch hits.
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            p = await s.get(
+                models.AdmissionProfile, pr1_seed_with_quota["profile_id"]
+            )
+            p.status = "admitted"
+            p.uses_choice_engine = False
+            p.applied_rules = {
+                "admission_path_id": pr1_seed_with_quota["path_id"]
+            }
+
+    async with AsyncSessionLocal() as s:
+        from sqlalchemy import select as sa_select
+        from sqlalchemy.orm import selectinload as sa_sl
+        path = (await s.execute(
+            sa_select(models.AdmissionPath)
+            .where(models.AdmissionPath.id == pr1_seed_with_quota["path_id"])
+            .options(sa_sl(models.AdmissionPath.academic_info))
+        )).scalar_one()
+        check = await check_choice_admit_capacity(
+            s, path=path,
+            admission_profile_id=pr1_seed_with_quota["profile_id"],
+        )
+    assert check.allowed is True, (
+        f"Self must be excluded from count; got {check}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_capacity_check_mixes_multi_nv_and_legacy_counts(
+    pr1_seed_with_quota: dict, seed_lead_dependencies: dict,
+):
+    """admit_quota=2. Seed 1 admitted via multi-NV (choice row) + 1 via
+    legacy (applied_rules) → count = 2 → next admit blocked.
+    Anchor: count branches sum correctly (not one OR the other).
+    """
+    from app.services.admission_choice_engine_service import (
+        check_choice_admit_capacity,
+    )
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            path = await s.get(
+                models.AdmissionPath, pr1_seed_with_quota["path_id"]
+            )
+            path.admit_quota = 2
+            ai = await s.get(
+                models.OfferingAcademicInfo, path.academic_info_id
+            )
+            ai.annual_admission_quota = 100  # take Tier 1 out of equation
+
+    # Branch (a) — multi-NV admitted choice
+    await _seed_admitted_choice_for_path(
+        pr1_seed_with_quota["path_id"],
+        pr1_seed_with_quota["config_id"],
+        seed_lead_dependencies["unit_id"],
+        seed_lead_dependencies["stage_id"],
+        pr1_seed_with_quota["offering_id"],
+    )
+    # Branch (b) — legacy single-NV via applied_rules
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            lead = models.Lead(
+                full_name=f"Legacy quota lead {ts}",
+                phone=f"098{ts:07d}"[:10],
+                unit_id=seed_lead_dependencies["unit_id"],
+                pipeline_stage_id=seed_lead_dependencies["stage_id"],
+                source="walkin",
+            )
+            s.add(lead); await s.flush()
+            legacy = models.AdmissionProfile(
+                lead_id=lead.id,
+                citizen_id=f"7{ts:08d}5"[:12],
+                status="admitted",
+                uses_choice_engine=False,
+                applied_rules={
+                    "admission_path_id": pr1_seed_with_quota["path_id"]
+                },
+                academic_year=2026,
+            )
+            s.add(legacy); await s.flush()
+
+    async with AsyncSessionLocal() as s:
+        from sqlalchemy import select as sa_select
+        from sqlalchemy.orm import selectinload as sa_sl
+        path = (await s.execute(
+            sa_select(models.AdmissionPath)
+            .where(models.AdmissionPath.id == pr1_seed_with_quota["path_id"])
+            .options(sa_sl(models.AdmissionPath.academic_info))
+        )).scalar_one()
+        check = await check_choice_admit_capacity(
+            s, path=path,
+            admission_profile_id=pr1_seed_with_quota["profile_id"],
+        )
+    assert check.allowed is False, (
+        f"2 seats (1 multi-NV + 1 legacy) must reach cap; got {check}"
+    )
+    assert check.reason_code == "PATH_QUOTA_EXHAUSTED"
+    assert check.detail["current_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_capacity_check_null_admit_quota_pass_through(
+    pr3a_seed: dict, seed_lead_dependencies: dict,
+):
+    """admit_quota=NULL (unbounded) + annual cap NULL → always allowed.
+    Anchor: opt-in semantic — quotas only enforced when admin sets cap."""
+    from app.services.admission_choice_engine_service import (
+        check_choice_admit_capacity,
+    )
+    # Default seed already has admit_quota=NULL + annual_admission_quota=20.
+    # Drop annual cap too so we exercise the pure pass-through branch.
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            path = await s.get(models.AdmissionPath, pr3a_seed["path_id"])
+            path.admit_quota = None
+            ai = await s.get(
+                models.OfferingAcademicInfo, path.academic_info_id
+            )
+            ai.annual_admission_quota = None
+
+    # Seed 10 admitted — still allowed because no cap
+    for _ in range(3):
+        await _seed_admitted_choice_for_path(
+            pr3a_seed["path_id"],
+            pr3a_seed["config_id"],
+            seed_lead_dependencies["unit_id"],
+            seed_lead_dependencies["stage_id"],
+            pr3a_seed["offering_id"],
+        )
+
+    async with AsyncSessionLocal() as s:
+        from sqlalchemy import select as sa_select
+        from sqlalchemy.orm import selectinload as sa_sl
+        path = (await s.execute(
+            sa_select(models.AdmissionPath)
+            .where(models.AdmissionPath.id == pr3a_seed["path_id"])
+            .options(sa_sl(models.AdmissionPath.academic_info))
+        )).scalar_one()
+        check = await check_choice_admit_capacity(
+            s, path=path, admission_profile_id=pr3a_seed["profile_id"],
+        )
+    assert check.allowed is True, f"NULL caps → always allow; got {check}"
+
+
+@pytest.mark.asyncio
+async def test_capacity_check_null_annual_quota_pass_through(
+    pr1_seed_with_quota: dict, seed_lead_dependencies: dict,
+):
+    """annual_admission_quota=NULL but admit_quota set → only Tier 2 active.
+    Annual count above arbitrary number must not block."""
+    from app.services.admission_choice_engine_service import (
+        check_choice_admit_capacity,
+    )
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            path = await s.get(
+                models.AdmissionPath, pr1_seed_with_quota["path_id"]
+            )
+            path.admit_quota = 10  # plenty for this test
+            ai = await s.get(
+                models.OfferingAcademicInfo, path.academic_info_id
+            )
+            ai.annual_admission_quota = None  # disable Tier 1
+
+    # Seed 5 admitted — Tier 1 would block at 2, but it's NULL → ignored
+    for _ in range(5):
+        await _seed_admitted_choice_for_path(
+            pr1_seed_with_quota["path_id"],
+            pr1_seed_with_quota["config_id"],
+            seed_lead_dependencies["unit_id"],
+            seed_lead_dependencies["stage_id"],
+            pr1_seed_with_quota["offering_id"],
+        )
+
+    async with AsyncSessionLocal() as s:
+        from sqlalchemy import select as sa_select
+        from sqlalchemy.orm import selectinload as sa_sl
+        path = (await s.execute(
+            sa_select(models.AdmissionPath)
+            .where(models.AdmissionPath.id == pr1_seed_with_quota["path_id"])
+            .options(sa_sl(models.AdmissionPath.academic_info))
+        )).scalar_one()
+        check = await check_choice_admit_capacity(
+            s, path=path,
+            admission_profile_id=pr1_seed_with_quota["profile_id"],
+        )
+    assert check.allowed is True, (
+        f"NULL annual cap + plenty path cap → allow; got {check}"
+    )
+
+
+# --- 4 cascade/promote integration tests (HTTP-driven, full flow) ---
+
+
+@pytest_asyncio.fixture
+async def pr1_seed_multi_nv_two_choices_quota_one(
+    pr1_seed_with_quota: dict,
+) -> dict:
+    """pr1_seed_with_quota + 1 AdmissionProfileChoice on the path with
+    admit_quota=1. Profile starts 'reviewing' for direct publish_result T6
+    trigger. Single choice is enough to anchor the capacity-induced
+    waitlist outcome (UNIQUE(profile_id, path_id, config_id) blocks
+    seeding 2 NV on the same path+config in this minimal fixture).
+    """
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ch = models.AdmissionProfileChoice(
+                admission_profile_id=pr1_seed_with_quota["profile_id"],
+                admission_path_id=pr1_seed_with_quota["path_id"],
+                path_subject_group_config_id=pr1_seed_with_quota["config_id"],
+                display_order=1,
+                decision="pending",
+            )
+            s.add(ch)
+            profile = await s.get(
+                models.AdmissionProfile, pr1_seed_with_quota["profile_id"]
+            )
+            profile.status = "reviewing"
+            profile.version += 1
+    return pr1_seed_with_quota
+
+
+@pytest.mark.asyncio
+async def test_cascade_waitlist_when_path_quota_exhausted(
+    monkeypatch,
+    pr1_seed_multi_nv_two_choices_quota_one: dict,
+    seed_lead_dependencies: dict,
+):
+    """T6 cascade: admit_quota=1 + 1 prior admitted seat → capacity gate
+    must degrade decision='admitted' → 'waitlisted' với capacity_detail
+    captured.
+
+    Test isolates the PR-1 NEW behavior: monkeypatch the per-choice
+    eligibility/score eval so cascade always proposes 'admitted'. Only
+    the capacity gate then decides outcome. Without PR-1 quota guard:
+    engine would silently admit beyond cap.
+
+    Anchor: profile.status='waitlisted', choice.decision='waitlisted',
+    eligibility_check_result.capacity_detail.cap=1 +
+    PATH_QUOTA_EXHAUSTED in reason_codes.
+    """
+    from app.services import admission_choice_engine_service as engine_mod
+    seed = pr1_seed_multi_nv_two_choices_quota_one
+
+    # Push admit count to 1/1 (cap)
+    await _seed_admitted_choice_for_path(
+        seed["path_id"], seed["config_id"],
+        seed_lead_dependencies["unit_id"],
+        seed_lead_dependencies["stage_id"],
+        seed["offering_id"],
+    )
+
+    # Force every NV to evaluate as 'admitted' so only capacity gate decides
+    def _force_admit(profile, choice, priority_bonus=None):
+        return "admitted", None, []
+    monkeypatch.setattr(engine_mod, "_evaluate_single_choice", _force_admit)
+
+    # Load profile via direct service call (engine cascade) — eager-load
+    # chain mirror PR-3C router signature.
+    from sqlalchemy import select as sa_select
+    from sqlalchemy.orm import selectinload as sa_sl
+    async with AsyncSessionLocal() as s:
+        stmt = (
+            sa_select(models.AdmissionProfile)
+            .where(models.AdmissionProfile.id == seed["profile_id"])
+            .options(
+                sa_sl(models.AdmissionProfile.lead),
+                sa_sl(models.AdmissionProfile.choices)
+                .selectinload(models.AdmissionProfileChoice.admission_path)
+                .selectinload(models.AdmissionPath.academic_info),
+                sa_sl(models.AdmissionProfile.choices)
+                .selectinload(models.AdmissionProfileChoice.admission_path)
+                .selectinload(models.AdmissionPath.admission_method),
+                sa_sl(models.AdmissionProfile.choices)
+                .selectinload(models.AdmissionProfileChoice.admission_path)
+                .selectinload(models.AdmissionPath.admission_round),
+            )
+        )
+        profile = (await s.execute(stmt)).scalar_one()
+
+        result, _cb = await engine_mod.evaluate_cascade(s, profile)
+        await s.commit()
+
+    assert result.final_status == "waitlisted", (
+        f"Capacity-exhausted cascade must produce waitlisted final_status; "
+        f"got {result.final_status}; per_choice={result.per_choice_decisions}"
+    )
+
+    # DB invariant: profile + choice waitlisted + capacity_detail captured
+    async with AsyncSessionLocal() as s:
+        profile_after = await s.get(
+            models.AdmissionProfile, seed["profile_id"]
+        )
+        assert profile_after.status == "waitlisted"
+
+        choices = (await s.execute(
+            sa_select(models.AdmissionProfileChoice).where(
+                models.AdmissionProfileChoice.admission_profile_id
+                == seed["profile_id"]
+            )
+        )).scalars().all()
+        wl = [c for c in choices if c.decision == "waitlisted"]
+        assert wl, (
+            f"Choice must be waitlisted; got "
+            f"{[(c.display_order, c.decision) for c in choices]}"
+        )
+        elig = wl[0].eligibility_check_result or {}
+        assert elig.get("capacity_detail") is not None, (
+            f"capacity_detail must populate; got eligibility_check_result={elig}"
+        )
+        assert "PATH_QUOTA_EXHAUSTED" in (elig.get("reason_codes") or []), (
+            f"reason_codes must include PATH_QUOTA_EXHAUSTED; got "
+            f"{elig.get('reason_codes')}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_cascade_admits_when_no_quota_pressure(
+    monkeypatch,
+    pr1_seed_multi_nv_two_choices_quota_one: dict,
+):
+    """Inverse anchor: 1 choice + 0 prior seats + admit_quota=1 →
+    capacity gate ALLOWS, cascade transitions to admitted.
+
+    Proves capacity gate doesn't false-positive when seat is available,
+    just because the cap exists. Pairs with quota-exhausted test above.
+    """
+    from app.services import admission_choice_engine_service as engine_mod
+    seed = pr1_seed_multi_nv_two_choices_quota_one
+
+    def _force_admit(profile, choice, priority_bonus=None):
+        return "admitted", None, []
+    monkeypatch.setattr(engine_mod, "_evaluate_single_choice", _force_admit)
+
+    from sqlalchemy import select as sa_select
+    from sqlalchemy.orm import selectinload as sa_sl
+    async with AsyncSessionLocal() as s:
+        stmt = (
+            sa_select(models.AdmissionProfile)
+            .where(models.AdmissionProfile.id == seed["profile_id"])
+            .options(
+                sa_sl(models.AdmissionProfile.lead),
+                sa_sl(models.AdmissionProfile.choices)
+                .selectinload(models.AdmissionProfileChoice.admission_path)
+                .selectinload(models.AdmissionPath.academic_info),
+                sa_sl(models.AdmissionProfile.choices)
+                .selectinload(models.AdmissionProfileChoice.admission_path)
+                .selectinload(models.AdmissionPath.admission_method),
+                sa_sl(models.AdmissionProfile.choices)
+                .selectinload(models.AdmissionProfileChoice.admission_path)
+                .selectinload(models.AdmissionPath.admission_round),
+            )
+        )
+        profile = (await s.execute(stmt)).scalar_one()
+        result, _cb = await engine_mod.evaluate_cascade(s, profile)
+        await s.commit()
+
+    assert result.final_status == "admitted", (
+        f"With seat available + force-admit eval, cascade must admit; "
+        f"got {result.final_status}: {result.per_choice_decisions}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_promote_waitlist_blocked_when_quota_filled_after_engine(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr1_seed_with_quota: dict,
+    seed_lead_dependencies: dict,
+):
+    """T10 anchor: profile waitlisted via cascade earlier; admin tries to
+    promote, but in the meantime another admit consumed the seat → promote
+    must raise BusinessRuleViolation (400), NOT silently over-admit.
+
+    Without PR-1 promote guard: choice.decision='admitted' would be set
+    blindly, blowing the cap.
+    """
+    seed = pr1_seed_with_quota
+    # Setup: 1 choice waitlisted + 1 admitted seat already on path → cap = 1
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ch = models.AdmissionProfileChoice(
+                admission_profile_id=seed["profile_id"],
+                admission_path_id=seed["path_id"],
+                path_subject_group_config_id=seed["config_id"],
+                display_order=1,
+                decision="waitlisted",
+            )
+            s.add(ch); await s.flush()
+            choice_id = ch.id
+            profile = await s.get(models.AdmissionProfile, seed["profile_id"])
+            profile.status = "waitlisted"
+            profile.version += 1
+
+    await _seed_admitted_choice_for_path(
+        seed["path_id"], seed["config_id"],
+        seed_lead_dependencies["unit_id"],
+        seed_lead_dependencies["stage_id"],
+        seed["offering_id"],
+    )
+
+    response = await client.post(
+        f"/api/v2/admissions/{seed['profile_id']}/waitlist-promote",
+        headers=manager_token_headers,
+        json={"choice_id": choice_id, "reason": "Manual promote attempt"},
+    )
+    assert response.status_code == 400, (
+        f"Promote with no seat must 400 BusinessRuleViolation; "
+        f"got {response.status_code}: {response.text[:200]}"
+    )
+    body = response.json()
+    detail = (body.get("detail") or "").lower()
+    assert "chỉ tiêu" in detail or "quota" in detail, (
+        f"Detail must mention quota exhaustion; got: {body}"
+    )
+
+    # DB invariant: choice still waitlisted (no silent state mutation)
+    async with AsyncSessionLocal() as s:
+        ch_after = await s.get(models.AdmissionProfileChoice, choice_id)
+        assert ch_after.decision == "waitlisted", (
+            f"Choice must stay waitlisted after blocked promote; "
+            f"got {ch_after.decision}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_promote_waitlist_succeeds_when_seat_freed(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr1_seed_with_quota: dict,
+):
+    """Inverse anchor: profile waitlisted, NO competing admit on path →
+    promote must succeed (200). Proves T10 capacity check doesn't
+    false-positive when seat is actually available.
+    """
+    seed = pr1_seed_with_quota
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ch = models.AdmissionProfileChoice(
+                admission_profile_id=seed["profile_id"],
+                admission_path_id=seed["path_id"],
+                path_subject_group_config_id=seed["config_id"],
+                display_order=1,
+                decision="waitlisted",
+            )
+            s.add(ch); await s.flush()
+            choice_id = ch.id
+            profile = await s.get(models.AdmissionProfile, seed["profile_id"])
+            profile.status = "waitlisted"
+            profile.version += 1
+
+    response = await client.post(
+        f"/api/v2/admissions/{seed['profile_id']}/waitlist-promote",
+        headers=manager_token_headers,
+        json={"choice_id": choice_id, "reason": "Seat available — promote"},
+    )
+    assert response.status_code == 200, (
+        f"Promote with available seat must succeed; "
+        f"got {response.status_code}: {response.text[:200]}"
+    )
+    async with AsyncSessionLocal() as s:
+        ch_after = await s.get(models.AdmissionProfileChoice, choice_id)
+        assert ch_after.decision == "admitted"
+        profile_after = await s.get(models.AdmissionProfile, seed["profile_id"])
+        assert profile_after.status == "admitted"

--- a/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3c_routers_integration.py
@@ -2070,6 +2070,114 @@ async def test_capacity_check_null_annual_quota_pass_through(
     )
 
 
+@pytest.mark.asyncio
+async def test_capacity_check_annual_count_attributes_to_admitted_path_not_lead_intent(
+    pr1_seed_with_quota: dict, seed_lead_dependencies: dict,
+):
+    """⭐ BLOCKER #1 anchor (PR-1 review 2026-05-28): multi-NV admit on
+    path X must count toward academic_info(X) cap, NOT academic_info of
+    Lead.offering_id (which may be different intent).
+
+    Pre-fix bug: Tier 1 count JOINs ``Lead.offering_id`` which reflects
+    only initial intent. Candidate via NV-3 admits into a DIFFERENT
+    offering than Lead.offering_id → under-counts that offering's annual
+    cap → over-admit possible.
+
+    Scenario:
+      - academic_info A (capped 1) belongs to offering Y_A
+      - Lead L1 has offering_id = Y_B (DIFFERENT offering, picked
+        initially); profile P1 admitted via NV into path on A
+      - When evaluating new profile against A's annual cap: must count
+        P1 (consumes A's seat) regardless of L1's offering_id
+
+    Anchor: capacity_check returns allowed=False with
+    OFFERING_ANNUAL_QUOTA_EXHAUSTED. Pre-fix would silently allow
+    (count via Lead.offering_id=Y_B wouldn't match Y_A).
+    """
+    from app.services.admission_choice_engine_service import (
+        check_choice_admit_capacity,
+    )
+    # Setup A: set seed academic_info annual cap = 1; clear path admit_quota
+    # so only Tier 1 fires
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            path = await s.get(
+                models.AdmissionPath, pr1_seed_with_quota["path_id"]
+            )
+            path.admit_quota = None  # disable Tier 2
+            ai = await s.get(
+                models.OfferingAcademicInfo, path.academic_info_id
+            )
+            ai.annual_admission_quota = 1
+
+    # Seed a "different intent" offering Y_B → lead points there but
+    # profile admits via NV into path X (which belongs to Y_A = seed offering)
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            # Different offering (Y_B) — distinct offering_type to dodge
+            # UNIQUE(program_id, offering_type) from pr3a_seed
+            offering_b = models.ProgramOffering(
+                program_id=seed_lead_dependencies["major_program_id"],
+                offering_type=f"part_time_{ts}",
+                duration_semesters=8,
+                is_active=True,
+            )
+            s.add(offering_b); await s.flush()
+
+            lead = models.Lead(
+                full_name=f"Cross-offering intent lead {ts}",
+                phone=f"097{ts:07d}"[:10],
+                unit_id=seed_lead_dependencies["unit_id"],
+                pipeline_stage_id=seed_lead_dependencies["stage_id"],
+                source="walkin",
+                offering_id=offering_b.id,  # KEY: Lead.offering_id ≠ admit path's offering
+            )
+            s.add(lead); await s.flush()
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                citizen_id=f"7{ts:08d}3"[:12],
+                status="admitted",
+                applied_rules={"admission_path_id": pr1_seed_with_quota["path_id"]},
+                academic_year=2026,
+                uses_choice_engine=True,
+            )
+            s.add(profile); await s.flush()
+            # Admit choice into SEED path (academic_info A, offering Y_A)
+            s.add(models.AdmissionProfileChoice(
+                admission_profile_id=profile.id,
+                admission_path_id=pr1_seed_with_quota["path_id"],
+                path_subject_group_config_id=pr1_seed_with_quota["config_id"],
+                display_order=1,
+                decision="admitted",
+            )); await s.flush()
+
+    # Now check capacity for a NEW candidate trying to admit to same path.
+    # Annual cap=1 already consumed by cross-offering profile above →
+    # must block. Pre-fix (Lead.offering_id JOIN) would count 0 because
+    # Lead.offering_id = Y_B ≠ Y_A.
+    async with AsyncSessionLocal() as s:
+        from sqlalchemy import select as sa_select
+        from sqlalchemy.orm import selectinload as sa_sl
+        path = (await s.execute(
+            sa_select(models.AdmissionPath)
+            .where(models.AdmissionPath.id == pr1_seed_with_quota["path_id"])
+            .options(sa_sl(models.AdmissionPath.academic_info))
+        )).scalar_one()
+        check = await check_choice_admit_capacity(
+            s, path=path,
+            admission_profile_id=pr1_seed_with_quota["profile_id"],
+        )
+    assert check.allowed is False, (
+        f"BLOCKER #1: annual cap MUST count cross-offering admits via "
+        f"path.academic_info_id (not Lead.offering_id). Pre-fix bug would "
+        f"under-count → allow → over-admit. Got {check}"
+    )
+    assert check.reason_code == "OFFERING_ANNUAL_QUOTA_EXHAUSTED"
+    assert check.detail["current_count"] == 1
+    assert check.detail["cap"] == 1
+
+
 # --- 4 cascade/promote integration tests (HTTP-driven, full flow) ---
 
 

--- a/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
@@ -696,8 +696,10 @@ async def test_create_choice_410_when_round_closed(
         f"got {response.status_code}: {response.text[:200]}"
     )
     body = response.json()
-    assert "đã đóng" in (body.get("detail") or "").lower(), (
-        f"Detail phải mention 'đã đóng'; got: {body}"
+    # Assert via stable error_code (i18n-safe) per PR #346 review nit #4.
+    # Trước: substring "đã đóng" — fragile khi tinh chỉnh wording/i18n.
+    assert body.get("error_code") == "ROUND_CLOSED", (
+        f"Error code phải 'ROUND_CLOSED'; got: {body}"
     )
 
 

--- a/Backend_FastAPI/tests/api/test_phase3_pr3e_magic_link.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3e_magic_link.py
@@ -603,8 +603,9 @@ async def test_magic_link_submit_410_when_round_closed(
         f"got {response.status_code}: {response.text[:200]}"
     )
     body = response.json()
-    assert "đã đóng" in (body.get("detail") or "").lower(), (
-        f"Detail phải mention 'đã đóng'; got: {body}"
+    # Assert via stable error_code (i18n-safe) per PR #346 review nit #4.
+    assert body.get("error_code") == "ROUND_CLOSED", (
+        f"Error code phải 'ROUND_CLOSED'; got: {body}"
     )
 
     # Token must NOT be marked consumed (gate fired before _handle_submit body)

--- a/Backend_FastAPI/tests/integration/test_choice_engine_quota_concurrent.py
+++ b/Backend_FastAPI/tests/integration/test_choice_engine_quota_concurrent.py
@@ -1,0 +1,263 @@
+"""PR-1 (2026-05-28) — Choice engine quota guard concurrent serialization.
+
+Single concurrent anchor: two cascade publishes on the SAME path with
+admit_quota=1 must serialize via the SELECT FOR UPDATE locks inside
+`check_choice_admit_capacity` — exactly 1 admit, exactly 1 waitlist.
+
+Without PR-1 locks (Tier 1 OfferingAcademicInfo + Tier 2 AdmissionPath
+FOR UPDATE), two concurrent cascades both read count_before=0, both
+write decision='admitted' → over-admit by 1.
+
+Test calls `evaluate_cascade()` directly (NOT via HTTP) for two reasons:
+  1. asyncio.gather on HTTP would need 2 client tasks + serialized
+     session pool; direct service call is simpler and exercises the
+     same lock paths (the lock is in the helper, NOT the router).
+  2. Forces `_evaluate_single_choice` to return 'admitted' via
+     monkeypatch — isolates the capacity gate from scoring infra
+     (mirrors deterministic cascade tests in test_phase3_pr3c_routers_
+     integration.py).
+
+Mirror pattern: `tests/api/test_admission_bulk_assign_concurrency.py`
+`test_bulk_assign_locks_and_writes_accurate_audit_chain` — anchors
+business invariant (1 admit + 1 waitlist), NOT the SQL emitted. A
+future change that drops `.with_for_update()` would let both cascades
+admit → invariant breaks → test fails.
+
+Execution context per `local-test-oneoff-container-pattern` memory:
+heavy/destructive concurrent tests MUST run in a one-off backend
+container with explicit `-e DATABASE_URL=...qlts_test` override and
+main stack stopped. See plan v4 sprint test gate section.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+
+from app import models
+from app.database import AsyncSessionLocal
+
+
+pytestmark = pytest.mark.integration
+
+
+# ============================================================================
+# Seed helpers (inlined — fixture file pattern mirror test_phase3_pr3c_*)
+# ============================================================================
+
+
+@pytest_asyncio.fixture
+async def two_profiles_one_seat(seed_lead_dependencies: dict) -> dict:
+    """Seed scenario: 1 path admit_quota=1 + 2 reviewing profiles each with
+    1 choice on that path. Cascade publishes both concurrently → only 1
+    should land admit; the other must waitlist via the lock.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            offering = models.ProgramOffering(
+                program_id=seed_lead_dependencies["major_program_id"],
+                offering_type="full_time",
+                duration_semesters=8,
+                is_active=True,
+            )
+            s.add(offering); await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=offering.id,
+                academic_year=2026,
+                # Plenty so Tier 1 doesn't fire; Tier 2 path cap is the gate
+                annual_admission_quota=100,
+                tuition_fee_per_year=Decimal("1000000"),
+            )
+            s.add(ai); await s.flush()
+
+            from tests.fixtures.builders import AdmissionRoundBuilder
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                s, academic_year=2026,
+            )
+            method = models.AdmissionMethod(
+                code=f"PR1CC_{ts}",
+                name=f"PR-1 concurrent method {ts}",
+                requires_subject_scores=False,
+                requires_gpa=False,
+                is_active=True,
+            )
+            s.add(method); await s.flush()
+
+            path = models.AdmissionPath(
+                academic_info_id=ai.id,
+                admission_method_id=method.id,
+                admission_round_id=round_id,
+                status="active",
+                admit_quota=1,       # PR-1 gate setpoint
+                round_quota=10,
+            )
+            s.add(path); await s.flush()
+
+            sg = models.SubjectGroup(
+                code=f"GCC{ts}"[:20], name=f"Grp CC {ts}",
+            )
+            s.add(sg); await s.flush()
+            subj = models.Subject(
+                code=f"SCC{ts}"[:20], name_vi=f"Subj CC {ts}",
+                max_score=Decimal("10.00"),
+            )
+            s.add(subj); await s.flush()
+            s.add(models.SubjectGroupSubject(
+                subject_group_id=sg.id, subject_id=subj.id, position=1,
+            )); await s.flush()
+            config = models.PathSubjectGroupConfig(
+                admission_path_id=path.id,
+                subject_group_id=sg.id,
+                min_score=Decimal("0.0"),
+            )
+            s.add(config); await s.flush()
+
+            # Two profiles, each with offering_id matched for Tier 1 count
+            profile_ids = []
+            for idx in range(2):
+                lead = models.Lead(
+                    full_name=f"Concurrent lead {ts}_{idx}",
+                    phone=f"097{ts:07d}"[:10][:9] + str(idx),
+                    unit_id=seed_lead_dependencies["unit_id"],
+                    pipeline_stage_id=seed_lead_dependencies["stage_id"],
+                    source="walkin",
+                    offering_id=offering.id,
+                )
+                s.add(lead); await s.flush()
+                profile = models.AdmissionProfile(
+                    lead_id=lead.id,
+                    citizen_id=f"7{ts:08d}{idx}"[:12],
+                    status="reviewing",
+                    applied_rules={"admission_path_id": path.id},
+                    academic_year=2026,
+                    uses_choice_engine=True,
+                )
+                s.add(profile); await s.flush()
+                s.add(models.AdmissionProfileChoice(
+                    admission_profile_id=profile.id,
+                    admission_path_id=path.id,
+                    path_subject_group_config_id=config.id,
+                    display_order=1,
+                    decision="pending",
+                )); await s.flush()
+                profile_ids.append(profile.id)
+
+            return {
+                "path_id": path.id,
+                "config_id": config.id,
+                "offering_id": offering.id,
+                "academic_info_id": ai.id,
+                "profile_ids": profile_ids,
+            }
+
+
+async def _cascade_in_own_session(profile_id: int) -> str:
+    """Run evaluate_cascade in an isolated session and return final_status."""
+    from sqlalchemy import select as sa_select
+    from sqlalchemy.orm import selectinload as sa_sl
+    from app.services import admission_choice_engine_service as engine_mod
+
+    async with AsyncSessionLocal() as s:
+        try:
+            stmt = (
+                sa_select(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == profile_id)
+                .options(
+                    sa_sl(models.AdmissionProfile.lead),
+                    sa_sl(models.AdmissionProfile.choices)
+                    .selectinload(models.AdmissionProfileChoice.admission_path)
+                    .selectinload(models.AdmissionPath.academic_info),
+                    sa_sl(models.AdmissionProfile.choices)
+                    .selectinload(models.AdmissionProfileChoice.admission_path)
+                    .selectinload(models.AdmissionPath.admission_method),
+                    sa_sl(models.AdmissionProfile.choices)
+                    .selectinload(models.AdmissionProfileChoice.admission_path)
+                    .selectinload(models.AdmissionPath.admission_round),
+                )
+            )
+            profile = (await s.execute(stmt)).scalar_one()
+            result, _cb = await engine_mod.evaluate_cascade(s, profile)
+            await s.commit()
+            return result.final_status
+        except Exception:
+            await s.rollback()
+            raise
+
+
+@pytest.mark.asyncio
+async def test_cascade_concurrent_two_profiles_one_seat(
+    monkeypatch, two_profiles_one_seat: dict,
+):
+    """⭐ Concurrent anchor: 2 cascades on same path admit_quota=1 must
+    serialize via SELECT FOR UPDATE locks in check_choice_admit_capacity.
+
+    With PR-1 locks:
+      - Caller A acquires path lock first → counts 0 → admits → commits
+      - Caller B blocks on path lock → after A commits, counts 1 →
+        capacity blocks → waitlists → commits
+      - Final: exactly 1 admit + 1 waitlist (deterministic per-call
+        ordering OS-dependent, but invariant is the same)
+
+    Without locks (regression):
+      - Both callers count 0 → both write decision='admitted' → final
+        DB has 2 admitted choices on path → admit_quota=1 BLOWN
+      - The path admit count post-cascade would be 2 instead of 1,
+        breaking quota invariant
+
+    Force-admit via monkeypatch isolates the cascade's NEW PR-1 capacity
+    gate from scoring infrastructure. Mirror approach used by
+    deterministic cascade tests in
+    test_phase3_pr3c_routers_integration.py.
+    """
+    from app.services import admission_choice_engine_service as engine_mod
+
+    # Force every NV to evaluate as 'admitted' so only capacity gate decides
+    def _force_admit(profile, choice, priority_bonus=None):
+        return "admitted", None, []
+    monkeypatch.setattr(engine_mod, "_evaluate_single_choice", _force_admit)
+
+    seed = two_profiles_one_seat
+    p_a, p_b = seed["profile_ids"]
+
+    # Concurrent cascade — race for the single seat
+    results = await asyncio.gather(
+        _cascade_in_own_session(p_a),
+        _cascade_in_own_session(p_b),
+        return_exceptions=True,
+    )
+
+    # Both should return without exception (lock serializes; capacity
+    # gate produces waitlist for loser, not exception)
+    exceptions = [r for r in results if isinstance(r, Exception)]
+    assert not exceptions, (
+        f"Concurrent cascade must serialize without exception; "
+        f"got {len(exceptions)} exception(s). FIRST: {exceptions[0]!r}. "
+        f"This indicates the FOR UPDATE lock was bypassed (PR-1 regression)."
+    )
+
+    # Exactly 1 admit + 1 waitlist final_status
+    sorted_results = sorted(results)
+    assert sorted_results == ["admitted", "waitlisted"], (
+        f"Quota=1 + 2 cascades must produce exactly 1 admit + 1 waitlist; "
+        f"got {results}. Without lock both could admit (race), causing "
+        f"['admitted', 'admitted'] and blowing the cap."
+    )
+
+    # DB invariant: exactly 1 choice admitted on the path (the cap)
+    from sqlalchemy import func, select as sa_select
+    async with AsyncSessionLocal() as s:
+        admitted_count = int((await s.execute(
+            sa_select(func.count(models.AdmissionProfileChoice.id)).where(
+                models.AdmissionProfileChoice.admission_path_id == seed["path_id"],
+                models.AdmissionProfileChoice.decision == "admitted",
+            )
+        )).scalar_one() or 0)
+    assert admitted_count == 1, (
+        f"Path admit_quota=1 invariant: exactly 1 choice must be admitted; "
+        f"got {admitted_count}. >1 = lock bypassed; <1 = both waitlisted "
+        f"(unexpected deadlock or both lost race)."
+    )

--- a/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub2b_router_helpers.py
+++ b/Backend_FastAPI/tests/unit/test_phase3_pr3c_sub2b_router_helpers.py
@@ -55,11 +55,14 @@ def _make_actor(user_id=7):
 
 
 def _make_choice(decision="waitlisted", profile_id=42):
+    academic_info = SimpleNamespace(id=1, annual_admission_quota=None)
+    path = SimpleNamespace(id=1, admit_quota=None, academic_info=academic_info)
     return SimpleNamespace(
         id=5,
         admission_profile_id=profile_id,
         display_order=2,
         decision=decision,
+        admission_path=path,
         bonus_rule_snapshot=None,
         eligibility_check_result=None,
     )

--- a/frontend/src/lib/admission/eligibility.ts
+++ b/frontend/src/lib/admission/eligibility.ts
@@ -27,6 +27,12 @@ export type EligibilityReasonCode =
   | "NO_VALID_SCORES"
   | "INVALID_SUBJECT_GROUP"
   | "GRADUATION_YEAR_OUT_OF_RANGE"
+  // PR-1 (2026-05-28) — capacity gate codes appended bởi
+  // admission_choice_engine_service.check_choice_admit_capacity khi NV
+  // pass eligibility/score nhưng quota path/academic_info đã hết. Engine
+  // degrade decision='admitted' → 'waitlisted' và append code này.
+  | "PATH_QUOTA_EXHAUSTED"
+  | "OFFERING_ANNUAL_QUOTA_EXHAUSTED"
 
 export interface EligibilityScoreResult {
   final_score: number | null
@@ -34,9 +40,30 @@ export interface EligibilityScoreResult {
   selected_subjects: string[]
 }
 
+/**
+ * Capacity detail payload (PR-1 2026-05-28). Additive JSONB field —
+ * only present khi engine waitlist NV vì quota exhausted. Shape mirror
+ * BE CapacityCheck.detail:
+ *   - PATH_QUOTA_EXHAUSTED: { path_id, current_count, cap }
+ *   - OFFERING_ANNUAL_QUOTA_EXHAUSTED: { academic_info_id, current_count, cap }
+ */
+export interface EligibilityCapacityDetail {
+  path_id?: number
+  academic_info_id?: number
+  current_count: number
+  cap: number
+}
+
 export interface EligibilityCheckResult {
   decision: "admitted" | "waitlisted" | "rejected" | "skip" | "pending"
   reason_codes: string[]
+  /**
+   * PR-1 (2026-05-28) — Capacity probe detail. Only present when
+   * decision='waitlisted' due to quota exhaustion (reason_codes contains
+   * PATH_QUOTA_EXHAUSTED or OFFERING_ANNUAL_QUOTA_EXHAUSTED). Allows FE
+   * to render "X/Y seats taken" alongside the reason label.
+   */
+  capacity_detail?: EligibilityCapacityDetail | null
   score: EligibilityScoreResult | null
 }
 
@@ -53,6 +80,9 @@ export const REASON_CODE_LABELS: Record<EligibilityReasonCode, string> = {
   NO_VALID_SCORES: "Chưa có điểm xét tuyển hợp lệ",
   INVALID_SUBJECT_GROUP: "Tổ hợp môn không hợp lệ",
   GRADUATION_YEAR_OUT_OF_RANGE: "Năm tốt nghiệp ngoài phạm vi cho phép",
+  // PR-1 (2026-05-28) — capacity-gate codes (plan v4 locked decision #2).
+  PATH_QUOTA_EXHAUSTED: "Hết chỉ tiêu cho đường tuyển sinh",
+  OFFERING_ANNUAL_QUOTA_EXHAUSTED: "Hết chỉ tiêu năm học cho ngành",
 }
 
 export function getReasonLabel(code: string): string {


### PR DESCRIPTION
## Summary
- Add choice-engine quota capacity guard for T6 cascade and T10 waitlist promote.
- Enforce path `admit_quota` and offering/year `annual_admission_quota` without admin bypass; quota exhaustion degrades T6 choice to waitlisted and blocks T10 promote with a business error.
- Count both multi-NV admitted choices and legacy single-NV applied_rules seats, with current-profile self exclusion.
- Add FE Vietnamese reason labels for `PATH_QUOTA_EXHAUSTED` and `OFFERING_ANNUAL_QUOTA_EXHAUSTED`.
- Bundle PR #346 review nits: shared round cutoff guard, repository helper for submit cutoff lookup, stable error-code assertions, and missing applied_rules warning.

## Tests
- Backend deterministic PR-1 slice: 11 passed.
- One-off concurrent test: `tests/integration/test_choice_engine_quota_concurrent.py::test_cascade_concurrent_two_profiles_one_seat` passed in 5.31s.
- PR-2/PR-4 regression slice: 10 passed.
- `scripts\fe-check.cmd type-check`: pass.
- `python -m app.scripts.check_status_assignment`: pass.
- `python -m app.scripts.check_notification_event_coverage`: pass.
