### PR TITLE
feat(storefront): fail-closed public catalog by eligible round paths

### DIFF
--- a/Backend_FastAPI/app/routers/public_admissions.py
+++ b/Backend_FastAPI/app/routers/public_admissions.py
@@ -140,6 +140,7 @@ async def get_public_tuition_catalog(
     request: Request,
     response: Response,
     audience: Optional[PublicAdmissionsAudience] = _AUDIENCE_QUERY,
+    admission_round_id: Optional[int] = _ADMISSION_ROUND_QUERY,
     db: AsyncSession = Depends(database.get_db),
 ):
     """
@@ -150,12 +151,11 @@ async def get_public_tuition_catalog(
     - tuition ranges by degree level
     - active tuition discount policies referenced by published offerings
 
-    ``audience`` is accepted for API uniformity. Tuition data is
-    offering-keyed (not path-keyed), so the parameter is currently a
-    no-op here; Phase 2 storefront PR will narrow offerings via
-    round+audience joins.
+    Tuition data is offering-keyed, but public exposure is path-gated:
+    ``audience`` and ``admission_round_id`` narrow the offering set to
+    those with at least one public-eligible path.
     """
     _set_public_cache_headers(response)
     return await public_admissions_service.get_public_tuition_catalog(
-        db, audience=audience
+        db, audience=audience, admission_round_id=admission_round_id,
     )

--- a/Backend_FastAPI/app/schemas/public_admissions.py
+++ b/Backend_FastAPI/app/schemas/public_admissions.py
@@ -25,6 +25,27 @@ class PublicAdmissionsAudience(str, Enum):
     LIEN_THONG_CD = "LIEN_THONG_CD"
     VLVH = "VLVH"
 
+    @classmethod
+    def _missing_(cls, value):
+        """Case-insensitive match for storefront query params.
+
+        PR #348 review C1 (2026-05-28): default strict Enum rejects
+        `?audience=post_thpt` lowercase → BE 422 → FE silent empty
+        fallback. User typing wrong case got "Danh mục đang được cập
+        nhật" without knowing why.
+
+        Now `post_thpt`, `Post_Thpt`, `POST_THPT` all resolve to
+        POST_THPT. Pure case-variant only — KHÔNG alias short-form
+        (e.g. `thpt` ≠ POST_THPT); that's a separate UX product decision.
+        """
+        if not isinstance(value, str):
+            return None
+        upper = value.upper()
+        for member in cls:
+            if member.value.upper() == upper:
+                return member
+        return None
+
 
 class PublicAdmissionsMethodTag(BaseModel):
     id: int

--- a/Backend_FastAPI/app/services/public_admissions_service.py
+++ b/Backend_FastAPI/app/services/public_admissions_service.py
@@ -111,11 +111,20 @@ def _extract_semester_data(
 
 async def _load_public_program_snapshot(
     db: AsyncSession,
+    eligible_offering_ids: Optional[Set[int]] = None,
 ) -> Tuple[
     List[models.MajorProgram],
     Dict[int, models.OfferingAcademicInfo],
     Set[int],
 ]:
+    """Load public programs/offering academic_info snapshot.
+
+    When ``eligible_offering_ids`` is provided, only offerings with at
+    least one public-eligible admission path are kept. This lets
+    path-scoped endpoints fail closed instead of exposing tuition/program
+    data for offerings that have no active public path in the selected
+    round/audience window.
+    """
     repo = OrganizationRepository(db)
     programs = await repo.get_all_major_programs(is_active=True)
 
@@ -127,6 +136,8 @@ async def _load_public_program_snapshot(
         public_offerings = []
         for offering in program.offerings:
             if not offering.is_active:
+                continue
+            if eligible_offering_ids is not None and offering.id not in eligible_offering_ids:
                 continue
 
             public_info = _latest_public_academic_info(offering)
@@ -142,6 +153,18 @@ async def _load_public_program_snapshot(
 
     public_programs.sort(key=lambda program: (_sort_degree_level(program.degree_level), program.name.lower(), program.id))
     return public_programs, latest_info_by_offering_id, academic_info_ids
+
+
+def _eligible_offering_ids_from_paths(
+    paths: List[models.AdmissionPath],
+) -> Set[int]:
+    """Return offering IDs represented by public-eligible paths."""
+    return {
+        path.academic_info.offering_id
+        for path in paths
+        if path.academic_info is not None
+        and path.academic_info.offering_id is not None
+    }
 
 
 async def _load_public_paths(
@@ -429,16 +452,25 @@ async def get_public_programs_catalog(
     audience: Optional[PublicAdmissionsAudience] = None,
     admission_round_id: Optional[int] = None,
 ) -> PublicAdmissionsProgramsResponse:
-    """Phase 2 v8.2 PR-2B v2 (Wave 6 #17 P2) — `admission_round_id`
-    optional filter. NULL = backward-compat (return all paths, all
-    rounds). Set = scope to specific round (storefront switch by đợt)."""
+    """Public programs catalog, fail-closed by public-eligible paths.
+
+    ``admission_round_id=None`` means union of public-eligible active
+    rounds only (not historical rounds). Explicit round IDs are still
+    filtered through the same eligibility guard.
+    """
     programs, latest_info_by_offering_id, academic_info_ids = await _load_public_program_snapshot(db)
+    public_paths = await _load_public_paths(
+        db, academic_info_ids,
+        audience=audience,
+        admission_round_id=admission_round_id,
+    )
+    eligible_offering_ids = _eligible_offering_ids_from_paths(public_paths)
+    programs, latest_info_by_offering_id, _ = await _load_public_program_snapshot(
+        db,
+        eligible_offering_ids=eligible_offering_ids,
+    )
     method_tags_by_info_id = _build_method_lookup(
-        await _load_public_paths(
-            db, academic_info_ids,
-            audience=audience,
-            admission_round_id=admission_round_id,
-        )
+        public_paths
     )
 
     degree_groups: Dict[str, List[PublicAdmissionsProgramSummary]] = defaultdict(list)
@@ -874,13 +906,23 @@ async def get_public_documents_catalog(
 async def get_public_tuition_catalog(
     db: AsyncSession,
     audience: Optional[PublicAdmissionsAudience] = None,
+    admission_round_id: Optional[int] = None,
 ) -> PublicAdmissionsTuitionResponse:
-    # audience param accepted for API uniformity but no-op on tuition:
-    # tuition data is offering-keyed (not path-keyed) so audience filter
-    # has no semantic effect here. Phase 2 storefront PR will narrow
-    # offerings to those with at least one round+audience match.
-    del audience  # unused
-    programs, latest_info_by_offering_id, _ = await _load_public_program_snapshot(db)
+    # Tuition is offering-keyed, but public exposure is still path-gated:
+    # only offerings with at least one public-eligible path for the selected
+    # round/audience are allowed to surface tuition data.
+    programs, latest_info_by_offering_id, academic_info_ids = await _load_public_program_snapshot(db)
+    public_paths = await _load_public_paths(
+        db,
+        academic_info_ids,
+        audience=audience,
+        admission_round_id=admission_round_id,
+    )
+    eligible_offering_ids = _eligible_offering_ids_from_paths(public_paths)
+    programs, latest_info_by_offering_id, _ = await _load_public_program_snapshot(
+        db,
+        eligible_offering_ids=eligible_offering_ids,
+    )
 
     tuition_offerings: List[PublicAdmissionsTuitionOffering] = []
     degree_level_bands: Dict[str, List[PublicAdmissionsTuitionOffering]] = defaultdict(list)

--- a/Backend_FastAPI/app/services/public_admissions_service.py
+++ b/Backend_FastAPI/app/services/public_admissions_service.py
@@ -167,6 +167,57 @@ def _eligible_offering_ids_from_paths(
     }
 
 
+def _filter_snapshot_by_eligible_offerings(
+    programs: List[models.MajorProgram],
+    latest_info_by_offering_id: Dict[int, models.OfferingAcademicInfo],
+    eligible_offering_ids: Set[int],
+) -> Tuple[
+    List[models.MajorProgram],
+    Dict[int, models.OfferingAcademicInfo],
+]:
+    """In-memory filter of pre-loaded snapshot by eligible offering IDs.
+
+    PR-3 review fix #1 (2026-05-28): replaces the original 2× DB query
+    pattern in `get_public_programs_catalog` + `get_public_tuition_catalog`
+    (load full snapshot → load paths → derive eligible set → RE-LOAD
+    snapshot with filter) with a single in-memory pass.
+
+    Saves 1 DB round-trip + 1 SQL scan per request. Storefront cached
+    via CDN so prod impact is small, but cold-miss + crawler traffic
+    sees direct DB pressure.
+
+    Does NOT mutate input models — returns a filtered VIEW. Drops:
+      - offerings whose offering.id not in eligible_offering_ids
+      - programs with zero remaining eligible offerings
+
+    The downstream caller iterates ``program.offerings`` and checks
+    ``latest_info_by_offering_id.get(offering.id)``; offerings with
+    ``None`` lookup result are skipped naturally. We therefore filter
+    the dict (drop non-eligible offerings) but leave ``program.offerings``
+    untouched (no relationship mutation risk) — non-eligible offerings
+    on a kept program simply get `None` from the dict and are skipped.
+    """
+    filtered_info_by_offering_id = {
+        offering_id: academic_info
+        for offering_id, academic_info in latest_info_by_offering_id.items()
+        if offering_id in eligible_offering_ids
+    }
+
+    # Keep a program if at least one of its offerings is in the eligible
+    # set AND was originally accepted by the snapshot (i.e. still in
+    # latest_info_by_offering_id — passed is_active + is_published).
+    filtered_programs: List[models.MajorProgram] = [
+        program
+        for program in programs
+        if any(
+            offering.id in filtered_info_by_offering_id
+            for offering in program.offerings
+        )
+    ]
+
+    return filtered_programs, filtered_info_by_offering_id
+
+
 async def _load_public_paths(
     db: AsyncSession,
     academic_info_ids: Set[int],
@@ -465,9 +516,11 @@ async def get_public_programs_catalog(
         admission_round_id=admission_round_id,
     )
     eligible_offering_ids = _eligible_offering_ids_from_paths(public_paths)
-    programs, latest_info_by_offering_id, _ = await _load_public_program_snapshot(
-        db,
-        eligible_offering_ids=eligible_offering_ids,
+    # PR-3 review fix #1 (2026-05-28): in-memory filter instead of
+    # second _load_public_program_snapshot call — saves 1 DB round-trip
+    # per request (storefront cold-miss + crawler traffic benefit).
+    programs, latest_info_by_offering_id = _filter_snapshot_by_eligible_offerings(
+        programs, latest_info_by_offering_id, eligible_offering_ids,
     )
     method_tags_by_info_id = _build_method_lookup(
         public_paths
@@ -919,9 +972,10 @@ async def get_public_tuition_catalog(
         admission_round_id=admission_round_id,
     )
     eligible_offering_ids = _eligible_offering_ids_from_paths(public_paths)
-    programs, latest_info_by_offering_id, _ = await _load_public_program_snapshot(
-        db,
-        eligible_offering_ids=eligible_offering_ids,
+    # PR-3 review fix #1 (2026-05-28): same in-memory filter as
+    # get_public_programs_catalog — avoids 2× snapshot query per request.
+    programs, latest_info_by_offering_id = _filter_snapshot_by_eligible_offerings(
+        programs, latest_info_by_offering_id, eligible_offering_ids,
     )
 
     tuition_offerings: List[PublicAdmissionsTuitionOffering] = []

--- a/Backend_FastAPI/scripts/SMOKE_SEED_GUIDE.md
+++ b/Backend_FastAPI/scripts/SMOKE_SEED_GUIDE.md
@@ -1,0 +1,223 @@
+# Smoke Seed Guide
+
+Hướng dẫn sử dụng `scripts/seed_smoke_dev.py` để seed edge-state fixture cho
+local pre-push Chrome MCP smoke verify.
+
+## Mục đích
+
+`seed_from_xlsx.py` + `seed_sample_data.py` lo phần **core data** (programs,
+offerings, methods, users, casbin). Script này thêm layer **edge-state matrix**
+cần cho 18 smoke scenarios cover PR-1+PR-2+PR-3+PR-4 — không trùng lặp với
+seed gốc, không gọi từ CI fixture.
+
+## Quick start
+
+```bash
+# Lần đầu (giả định core data đã loaded)
+docker compose exec backend python -m scripts.seed_smoke_dev
+
+# Verify
+docker compose exec backend python -m scripts.seed_smoke_dev --verify
+
+# Re-seed group cụ thể (idempotent)
+docker compose exec backend python -m scripts.seed_smoke_dev --group 1 2
+
+# Reset all smoke fixtures (cascade delete)
+docker compose exec backend python -m scripts.seed_smoke_dev --reset
+```
+
+## Production guard
+
+Hai-tầng abort:
+1. `APP_ENV=production` → abort
+2. `DATABASE_URL` chứa substring `qlts_prod` → abort
+
+Cả hai layer nhằm tránh seed test data lên prod (sẽ làm SMK_* rounds visible
+trên storefront + fake profile lẫn pipeline thật).
+
+## Fixture matrix
+
+### Group 1 — Round (6 rows)
+
+| Round code | Window | multi_nv | Mục đích |
+|------------|--------|----------|----------|
+| `SMK_ACTIVE_MULTI` | today-10..today+30 | true | S3, S5, S10-14 |
+| `SMK_ACTIVE_SINGLE` | today-10..today+30 | false | Audience filter |
+| `SMK_EXPIRED` | today-30..today-1 | false | S7 cutoff create 410 |
+| `SMK_ARCHIVED` | today-60..today-10, archived_at=NOW | false | S4 archived empty |
+| `SMK_FUTURE` | today+30..today+60 | false | F43 future filter |
+| `SMK_OPEN_ENDED` | NULL..NULL | false | F43 NULL window edge |
+
+### Group 2 — Path (9 rows on Group 1 rounds)
+
+| Label | Round | Quota | Audience | Visibility | Status |
+|-------|-------|-------|----------|------------|--------|
+| `full_quota_1` | ACTIVE_MULTI | 1 | — | public | active |
+| `free_quota_5` | ACTIVE_MULTI | 5 | — | public | active |
+| `unbounded_null` | ACTIVE_MULTI | NULL | — | public | active |
+| `audience_thpt` | ACTIVE_SINGLE | 10 | `[POST_THPT]` | public | active |
+| `audience_vlvh` | ACTIVE_SINGLE | 10 | `[VLVH]` | public | active |
+| `audience_null` | ACTIVE_SINGLE | 10 | NULL (legacy all) | public | active |
+| `internal_hidden` | OPEN_ENDED | 5 | — | **internal** | active |
+| `archived_path` | OPEN_ENDED | 5 | — | public | **archived** |
+| `on_expired_round` | EXPIRED | 5 | — | public | active |
+
+### Group 3 — Annual quota Tier 1 (2 paths)
+
+| Label | annual_admission_quota | admit_quota | Method | Mục đích |
+|-------|------------------------|-------------|--------|----------|
+| `capped_path_0` | 2 (set on academic_info) | 10 | hoc_ba | PR-1 Tier 1 cross-method anchor |
+| `capped_path_1` | shares ai cap | 10 | thpt_qg | PR-1 Tier 1 cross-method anchor |
+
+Group 4 seeded 2 profiles admitted via these paths → Tier 1 cap saturated.
+Next admit attempt on either path returns `OFFERING_ANNUAL_QUOTA_EXHAUSTED`.
+
+### Group 4 — Profile state (7 rows)
+
+| Profile label | Citizen | Status | Choice decision | Mục đích |
+|---------------|---------|--------|-----------------|----------|
+| `DRAFT_active` | SMOKEDEV0001 | draft | (none) | S5 create + S8 PATCH cutoff |
+| `DRAFT_expired` | SMOKEDEV0002 | draft | (none) | S9 DELETE allow after cutoff |
+| `SUBMITTED_pending` | SMOKEDEV0003 | submitted | pending | PR-4 admin rollback realistic |
+| `ADMITTED_consumer` | SMOKEDEV0004 | admitted | admitted | S10 quota anchor (consume full_quota_1) |
+| `WAITLISTED_promotable` | SMOKEDEV0005 | waitlisted | waitlisted | S13, S14 promote |
+| `REJECTED` | SMOKEDEV0006 | rejected | rejected | S11 FE label rendering |
+| `ENROLLED` | SMOKEDEV0007 | enrolled | pending | KPI funnel smoke |
+
+State transitions qua `admission_state_service.transition()` với `skip_dispatch=True`
+— preserve audit chain + status_history, KHÔNG fire notification.
+
+### Group 5 — Magic-link token (6 rows)
+
+| Token label | Profile | action_type | State | Mục đích |
+|-------------|---------|-------------|-------|----------|
+| `SUBMIT_active` | DRAFT_active | submit | unused, 7d expiry | Magic-link submit happy path |
+| `CONFIRM_active` | ADMITTED_consumer | confirm | unused | Confirm flow |
+| `RESUBMIT_active` | REJECTED | resubmit | unused | Resubmit revision |
+| `EXPIRED` | DRAFT_expired | submit | expires_at < now | Token expiry handling |
+| `CONSUMED` | SUBMITTED_pending | confirm | confirmed_at NOT NULL | Replay prevention |
+| `HARD_LOCKED` | WAITLISTED_promotable | submit | attempt=10, lock_until=+24h | Cooldown ladder cap |
+
+Tokens deterministic: `smk_dev_<label>_<profile_id:06d>` (idempotent re-seed).
+
+## Scenario coverage map
+
+| Scenario | Fixture cần |
+|----------|-------------|
+| S1 storefront default | SMK_ACTIVE_MULTI + path (any) |
+| S2 tuition default | (parity) |
+| S3 explicit active round | SMK_ACTIVE_MULTI |
+| S4 expired round explicit | SMK_EXPIRED + on_expired_round |
+| S4a sentinel invalid | None (FE-level) |
+| S4b audience filter | audience_thpt + audience_vlvh + audience_null |
+| S5 create profile | SMK_ACTIVE_MULTI + free_quota_5 + officer auth + DRAFT_active reference |
+| S6 submit profile | (same as S5) + SUBMITTED_pending sample |
+| S7 cutoff create | SMK_EXPIRED |
+| S8 choice PATCH cutoff | DRAFT_expired + on_expired_round |
+| S9 choice DELETE allow | DRAFT_expired |
+| S10 quota cascade | ADMITTED_consumer (đã chiếm seat) + full_quota_1 + free_quota_5 |
+| S11 FE reason label | WAITLISTED_promotable view detail |
+| S12 all-NV-full | new profile + full_quota_1 + full_quota_1' (manual seed?) |
+| S13 promote blocked | WAITLISTED_promotable + admin auth |
+| S14 promote freed | rollback ADMITTED_consumer → promote |
+
+## Integration với workflow
+
+### Pre-push local smoke (1 dev, 1 lap)
+
+```bash
+# 1. Verify core data (optional, slow nếu chưa có)
+docker compose exec backend python -m scripts.seed_from_xlsx --dry-run
+
+# 2. Layer smoke fixtures (fast, idempotent ~20s)
+docker compose exec backend python -m scripts.seed_smoke_dev
+
+# 3. Chrome MCP smoke 18 scenarios (assistant-driven)
+# Hoặc skill /test với smoke scope
+
+# 4. (Optional) cleanup post-push
+docker compose exec backend python -m scripts.seed_smoke_dev --reset
+```
+
+### CI integration — KHÔNG
+
+CI test có fixture pytest dedicate, không cần seed runtime DB. Script này
+chỉ cho LOCAL dev DB.
+
+### Nightly Playwright
+
+Nếu nightly-regression cần extended coverage cho mobile responsive +
+empty state UI, có thể thêm step seed_smoke_dev sau seed_from_xlsx trong
+`.github/workflows/nightly-regression.yml`. Hiện tại chưa wire.
+
+## Caveats + Lessons
+
+### Constraint UNIQUE đã hit trong development
+
+1. `round_code VARCHAR(20)` — `SMOKE_DEV_ACTIVE_MULTI` (21 chars) overflow.
+   Fix: prefix `SMK_` (4 chars).
+2. `uq_admission_profile_lead_year` — 1 lead / 1 academic_year. Fix: seed
+   N leads (1 per profile fixture).
+3. `uq_active_token_per_profile_action` — 1 profile / 1 action_type unique.
+   Fix: spread token spec qua different profiles.
+
+### `applied_rules_immutability_trigger`
+
+Memory `applied_rules_immutability_trigger`: trigger block UPDATE on
+applied_rules. Script này chỉ INSERT (initial state), KHÔNG UPDATE
+applied_rules. State transition mutate `status` field, không touch
+applied_rules. → No trigger conflict.
+
+### State transition + dispatch
+
+`admission_state_service.transition()` mặc định fire notification dispatch
++ outbox. Script gọi với `skip_dispatch=True` để seed silent (memory
+`notification-payload-design`). Audit log VẪN created — status_history
+chain preserved → realistic data cho PR-4 rollback smoke.
+
+### Trigger PR-1 cascade engine
+
+Group 4 ADMITTED_consumer + WAITLISTED_promotable set `choice.decision`
+trực tiếp, KHÔNG qua cascade engine. Means: real cascade re-publish khi
+test S10 sẽ RE-EVALUATE — có thể flip decision. Đây là intended cho smoke
+(test engine thực sự).
+
+Nếu muốn lock decision immutable, additional flag cần consider.
+
+### Lead pipeline_stage_id
+
+VARCHAR(20) string FK to pipeline_stage.id. Script picks first available
+via `select(...).limit(1)` — relies on `seed_categories.py` đã run.
+
+## Failure modes + troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `value too long for type character varying(20)` | round_code prefix dài | Script đã fix `SMK_` |
+| `duplicate key value violates unique constraint "uq_admission_profile_lead_year"` | 2 profiles cùng lead+year | Reset rồi re-seed (script đã spread leads) |
+| `Need ≥3 active admission_methods` | Methods chưa seed | Run `seed_admission_config` trước |
+| `No published academic_info found` | Offerings chưa seed | Run `seed_from_xlsx` hoặc `seed_sample_data` trước |
+| Profile transition raise BusinessRuleViolation | State machine không allow chain | Verify `admission_state_machine.ALLOWED_TRANSITIONS` |
+| Transition fire dispatch ngoài ý muốn | Forgot `skip_dispatch=True` | Already set ở Group 4 |
+
+## Reset semantic
+
+`--reset` cascade delete theo FK order:
+1. `admission_confirmation_token` WHERE profile ở smoke marker
+2. `admission_profile_choice` WHERE profile ở smoke marker
+3. `admission_profile` WHERE `applied_rules->>'smoke_marker' = 'SMOKE_DEV'`
+4. `admission_path` WHERE round LIKE `SMK_*`
+5. `offering_admission_round` WHERE code LIKE `SMK_*`
+
+**KHÔNG delete**: leads (`09000xxxxx` phone marker preserved), academic_info
+(annual_quota mutate ở Group 3 KHÔNG revert), pipeline stages, users, casbin,
+methods, subjects, programs. Nếu cần full reset, dùng `seed_from_xlsx` lại.
+
+## Reference
+
+- PR #345 (admin rollback row lock) — S14 anchor
+- PR #346 (round cutoff 410) — S7-S9 anchor
+- PR #347 (quota guard) — S10-S14 anchor
+- PR #348 (storefront fail-closed) — S1-S4b anchor
+- Memory `chrome-mcp-pre-push-smoke` — policy mandate
+- Memory `pattern-change-impact-audit` — anchor test design philosophy

--- a/Backend_FastAPI/scripts/seed_smoke_dev.py
+++ b/Backend_FastAPI/scripts/seed_smoke_dev.py
@@ -1,0 +1,953 @@
+#!/usr/bin/env python3
+"""
+Smoke fixture seed for local DEV environment.
+
+Complement layer trên seed_from_xlsx + seed_sample_data: giả định core
+data (programs, offerings, academic_info, methods, subjects, users,
+casbin) đã loaded. Script này thêm edge-state matrix mà Chrome MCP
+pre-push smoke cần để cover 18 scenarios PR-1+PR-2+PR-3+PR-4.
+
+5 fixture groups:
+  1. ROUND matrix    — 6 rounds across window/visibility/multi_nv axes
+  2. PATH matrix     — 9+ paths với quota/audience/visibility variants
+  3. ANNUAL QUOTA   — Tier 1 anchor (offering cap=2, 2 admitted profiles)
+  4. PROFILE state   — 7 profile fixtures via state_service.transition()
+  5. MAGIC-LINK      — 6 token fixtures (active/expired/consumed/locked)
+
+Idempotency:
+  - All seeded rows marked với `round_code` LIKE 'SMOKE_DEV_%' (rounds)
+    hoặc `applied_rules->>'smoke_marker' = 'true'` (profiles).
+  - Reuse existing programs/methods/users/casbin — no duplicate.
+  - Rerun-safe: skip-if-exists per row.
+
+Usage:
+  python -m scripts.seed_smoke_dev                # seed all groups
+  python -m scripts.seed_smoke_dev --group 1      # only Round matrix
+  python -m scripts.seed_smoke_dev --group 1 2    # multiple groups
+  python -m scripts.seed_smoke_dev --verify       # row count report
+  python -m scripts.seed_smoke_dev --reset        # cascade delete markers
+
+Production guard:
+  Refuses to run when APP_ENV='production' OR DB name matches 'qlts_prod*'.
+
+Author: PR #348 review follow-up (2026-05-28 smoke session).
+Reference: SMOKE_SEED_GUIDE.md cho fixture matrix + scenario mapping.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+os.environ.setdefault("APP_ENV", "development")
+
+from app.database import AsyncSessionLocal  # noqa: E402
+from app import models  # noqa: E402
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONSTANTS — fixture markers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Round codes prefix (UNIQUE per academic_year). Idempotent identity key.
+# Short prefix vì round_code VARCHAR(20) — `SMOKE_DEV_ACTIVE_MULTI` (21) overflows.
+ROUND_PREFIX = "SMK_"
+ACADEMIC_YEAR = 2026
+
+# Profile marker in applied_rules JSONB (no native column for fixture tag).
+PROFILE_MARKER_KEY = "smoke_marker"
+PROFILE_MARKER_VALUE = "SMOKE_DEV"
+
+# Citizen ID prefix — deterministic for re-seed idempotency.
+CITIZEN_ID_PREFIX = "SMOKEDEV"  # appended với 4-digit index → SMOKEDEV0001
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PRODUCTION GUARD
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def assert_safe_environment() -> None:
+    """Refuse to run on production environment OR production DB.
+
+    Two-tier guard:
+      1. APP_ENV != 'production'
+      2. Database URL does not contain 'qlts_prod' substring
+
+    Either tier failure aborts immediately. Belt+suspenders since
+    accidental prod run = catastrophic (creates SMOKE_DEV_* rounds visible
+    in storefront, seeds fake profiles into real candidate pipeline).
+    """
+    app_env = os.environ.get("APP_ENV", "development").lower()
+    if app_env == "production":
+        sys.exit("❌ ABORT: APP_ENV=production. This script seeds test data — refuse to run.")
+
+    from app.config import settings as app_settings
+    db_url = str(getattr(app_settings, "DATABASE_URL", ""))
+    if "qlts_prod" in db_url.lower():
+        sys.exit(f"❌ ABORT: DATABASE_URL contains 'qlts_prod'. Refuse to seed.\n   {db_url}")
+
+    print(f"✅ Environment guard OK — APP_ENV={app_env}, DB target appears safe.")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GROUP 1 — ROUND MATRIX
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def seed_group_1_rounds(session: AsyncSession) -> dict[str, int]:
+    """Seed 6 rounds covering window × multi_nv × visibility axes.
+
+    Returns dict mapping round_code → round.id for downstream groups.
+
+    Matrix:
+      ACTIVE_MULTI    end=today+30, multi_nv=true  → S3 explicit active
+      ACTIVE_SINGLE   end=today+30, multi_nv=false → single-NV path
+      EXPIRED         end=today-1                  → S7 cutoff create
+      ARCHIVED        archived_at=NOW()            → S4 archived empty
+      FUTURE          start=today+30               → F43 future filter
+      OPEN_ENDED      start=NULL, end=NULL         → F43 NULL window edge
+    """
+    today = date.today()
+    print(f"\n📅 Group 1 — Round matrix (today={today})")
+
+    rounds_spec = [
+        # code suffix,     start_date,        end_date,          multi_nv, archived
+        ("ACTIVE_MULTI",   today - timedelta(days=10),  today + timedelta(days=30), True,  None),
+        ("ACTIVE_SINGLE",  today - timedelta(days=10),  today + timedelta(days=30), False, None),
+        ("EXPIRED",        today - timedelta(days=30),  today - timedelta(days=1),  False, None),
+        ("ARCHIVED",       today - timedelta(days=60),  today - timedelta(days=10), False, datetime.now(timezone.utc)),
+        ("FUTURE",         today + timedelta(days=30),  today + timedelta(days=60), False, None),
+        ("OPEN_ENDED",     None,                        None,                       False, None),
+    ]
+
+    round_ids: dict[str, int] = {}
+
+    for suffix, start, end, multi_nv, archived_at in rounds_spec:
+        code = f"{ROUND_PREFIX}{suffix}"
+
+        existing = (await session.execute(
+            select(models.OfferingAdmissionRound).where(
+                models.OfferingAdmissionRound.academic_year == ACADEMIC_YEAR,
+                models.OfferingAdmissionRound.round_code == code,
+            )
+        )).scalar_one_or_none()
+
+        if existing:
+            round_ids[suffix] = existing.id
+            print(f"  ⏭  {code} exists (id={existing.id}), skip")
+            continue
+
+        new_round = models.OfferingAdmissionRound(
+            academic_year=ACADEMIC_YEAR,
+            round_code=code,
+            round_name=f"Smoke fixture {suffix} {ACADEMIC_YEAR}",
+            start_date=start,
+            end_date=end,
+            is_active=True,
+            archived_at=archived_at,
+            allow_multi_nv=multi_nv,
+        )
+        session.add(new_round)
+        await session.flush()
+        round_ids[suffix] = new_round.id
+        print(f"  ✅  {code} created (id={new_round.id}, multi_nv={multi_nv}, "
+              f"window=[{start}..{end}], archived={archived_at is not None})")
+
+    await session.commit()
+    return round_ids
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GROUP 2 — PATH × ROUND + AUDIENCE MATRIX
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def seed_group_2_paths(
+    session: AsyncSession, round_ids: dict[str, int]
+) -> dict[str, int]:
+    """Seed 9 paths covering quota × audience × visibility × round axes.
+
+    Reuses existing programs/methods/academic_info — picks first available
+    matching constraint via SQL. Returns dict path_label → path.id.
+
+    Constraint: UNIQUE (admission_round_id, academic_info_id, admission_method_id).
+    Matrix uses different (round, method) pairs to avoid conflict.
+
+    Paths seeded:
+      full_quota_1      → ACTIVE_MULTI, admit_quota=1, public, no audience
+      free_quota_5      → ACTIVE_MULTI, admit_quota=5, public, no audience
+      unbounded_null    → ACTIVE_MULTI, admit_quota=NULL, public
+      audience_thpt     → ACTIVE_MULTI, applicable_to=[POST_THPT]
+      audience_vlvh     → ACTIVE_MULTI, applicable_to=[VLVH]
+      audience_null     → ACTIVE_MULTI, applicable_to=NULL (legacy all)
+      internal_hidden   → ACTIVE_MULTI, visibility='internal' (NOT public)
+      archived_path     → ACTIVE_MULTI, status='archived'
+      on_expired_round  → EXPIRED round
+    """
+    print(f"\n🛤  Group 2 — Path matrix")
+
+    # Pick first academic_info under any program (just need a valid FK).
+    ai_stmt = (
+        select(models.OfferingAcademicInfo)
+        .where(models.OfferingAcademicInfo.is_published.is_(True))
+        .limit(1)
+    )
+    target_ai = (await session.execute(ai_stmt)).scalar_one_or_none()
+    if not target_ai:
+        sys.exit("❌ No published academic_info found. Run seed_from_xlsx first.")
+
+    # Pick 3 distinct admission methods (Q-P3-02 multi-NV chain needs ≥2).
+    methods_stmt = select(models.AdmissionMethod).where(
+        models.AdmissionMethod.is_active.is_(True)
+    ).order_by(models.AdmissionMethod.id).limit(5)
+    methods = (await session.execute(methods_stmt)).scalars().all()
+    if len(methods) < 3:
+        sys.exit("❌ Need ≥3 active admission_methods. Run seed_admission_config first.")
+
+    # Path spec: label, round_key, method_idx, admit_quota, applicable_to,
+    #            visibility, status. UNIQUE (round, ai, method) enforced by DB.
+    paths_spec = [
+        # Quota variants (all on ACTIVE_MULTI, different methods)
+        ("full_quota_1",     "ACTIVE_MULTI", 0, 1,    None,                  "public",   "active"),
+        ("free_quota_5",     "ACTIVE_MULTI", 1, 5,    None,                  "public",   "active"),
+        ("unbounded_null",   "ACTIVE_MULTI", 2, None, None,                  "public",   "active"),
+        # Audience variants (need different rounds since methods reused)
+        ("audience_thpt",    "ACTIVE_SINGLE", 0, 10,  ["POST_THPT"],         "public",   "active"),
+        ("audience_vlvh",    "ACTIVE_SINGLE", 1, 10,  ["VLVH"],              "public",   "active"),
+        ("audience_null",    "ACTIVE_SINGLE", 2, 10,  None,                  "public",   "active"),
+        # Visibility + status edge
+        ("internal_hidden",  "OPEN_ENDED",   0, 5,    None,                  "internal", "active"),
+        ("archived_path",    "OPEN_ENDED",   1, 5,    None,                  "public",   "archived"),
+        ("on_expired_round", "EXPIRED",      0, 5,    None,                  "public",   "active"),
+    ]
+
+    path_ids: dict[str, int] = {}
+
+    for label, round_key, method_idx, admit_quota, applicable_to, visibility, status in paths_spec:
+        round_id = round_ids.get(round_key)
+        if not round_id:
+            print(f"  ⚠️  Skip {label}: round {round_key} not seeded")
+            continue
+        method = methods[method_idx]
+
+        existing = (await session.execute(
+            select(models.AdmissionPath).where(
+                models.AdmissionPath.admission_round_id == round_id,
+                models.AdmissionPath.academic_info_id == target_ai.id,
+                models.AdmissionPath.admission_method_id == method.id,
+            )
+        )).scalar_one_or_none()
+
+        if existing:
+            path_ids[label] = existing.id
+            print(f"  ⏭  {label} exists (id={existing.id}), skip")
+            continue
+
+        new_path = models.AdmissionPath(
+            academic_info_id=target_ai.id,
+            admission_method_id=method.id,
+            admission_round_id=round_id,
+            admit_quota=admit_quota,
+            round_quota=admit_quota * 2 if admit_quota else None,
+            applicable_to=applicable_to,
+            visibility=visibility,
+            status=status,
+        )
+        session.add(new_path)
+        await session.flush()
+        path_ids[label] = new_path.id
+        print(f"  ✅  {label} created (id={new_path.id}, quota={admit_quota}, "
+              f"audience={applicable_to}, vis={visibility}, status={status})")
+
+    await session.commit()
+    return path_ids
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GROUP 3 — ANNUAL QUOTA TIER 1 SCENARIO  (sketch — implement when needed)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Group 3 marker — dedicated ProgramOffering offering_type so --reset
+# can cascade delete it without touching real data.
+G3_OFFERING_TYPE = "smk_g3"
+
+
+async def seed_group_3_annual_quota(
+    session: AsyncSession, round_ids: dict[str, int]
+) -> dict[str, int]:
+    """Annual academic_info cap anchor for PR-1 Tier 1.
+
+    POST-REVIEW B2 fix (2026-05-28): create DEDICATED ProgramOffering
+    (offering_type='smk_g3') + OfferingAcademicInfo with annual_quota=2
+    + 2 paths. KHÔNG mutate any existing academic_info row.
+
+    Pre-fix mutated an existing offering's annual_quota → side effect
+    persisted past --reset → contaminated unrelated catalog queries.
+    Now --reset cascade deletes ProgramOffering → ai → paths fully.
+
+    Strategy:
+      1. Get/create ProgramOffering (program=first, offering_type='smk_g3')
+      2. Get/create OfferingAcademicInfo (annual_quota=2, is_published)
+      3. Create 2 paths on ACTIVE_MULTI round, different methods
+
+    Returns dict labels → ids for downstream Group 4 reference.
+    """
+    print(f"\n📊 Group 3 — Annual quota Tier 1 anchor (dedicated offering)")
+
+    round_id = round_ids.get("ACTIVE_MULTI")
+    if not round_id:
+        print(f"   ⚠️  Skip — SMK_ACTIVE_MULTI round missing.")
+        return {}
+
+    # Pick first program for FK
+    program = (await session.execute(
+        select(models.MajorProgram).order_by(models.MajorProgram.id).limit(1)
+    )).scalar_one_or_none()
+    if not program:
+        sys.exit("   ❌ Need ≥1 program. Run seed_sample_data first.")
+
+    # Dedicated G3 offering (UNIQUE program_id + offering_type)
+    offering = (await session.execute(
+        select(models.ProgramOffering).where(
+            models.ProgramOffering.program_id == program.id,
+            models.ProgramOffering.offering_type == G3_OFFERING_TYPE,
+        )
+    )).scalar_one_or_none()
+    if not offering:
+        offering = models.ProgramOffering(
+            program_id=program.id,
+            offering_type=G3_OFFERING_TYPE,
+            duration_semesters=8,
+            is_active=True,
+        )
+        session.add(offering)
+        await session.flush()
+        print(f"   ✅  ProgramOffering created (id={offering.id}, type={G3_OFFERING_TYPE})")
+    else:
+        print(f"   ⏭  ProgramOffering reused (id={offering.id})")
+
+    # Dedicated academic_info with annual_quota=2
+    ai = (await session.execute(
+        select(models.OfferingAcademicInfo).where(
+            models.OfferingAcademicInfo.offering_id == offering.id,
+            models.OfferingAcademicInfo.academic_year == ACADEMIC_YEAR,
+        )
+    )).scalar_one_or_none()
+    if not ai:
+        ai = models.OfferingAcademicInfo(
+            offering_id=offering.id,
+            academic_year=ACADEMIC_YEAR,
+            annual_admission_quota=2,
+            tuition_fee_per_year=Decimal("10000000"),
+            is_published=True,
+        )
+        session.add(ai)
+        await session.flush()
+        print(f"   ✅  AcademicInfo created (id={ai.id}, annual_quota=2)")
+    else:
+        print(f"   ⏭  AcademicInfo reused (id={ai.id})")
+
+    # 2 distinct methods → 2 paths under same ai (UNIQUE round+ai+method enforced)
+    methods = (await session.execute(
+        select(models.AdmissionMethod).where(
+            models.AdmissionMethod.is_active.is_(True)
+        ).order_by(models.AdmissionMethod.id).limit(2)
+    )).scalars().all()
+    if len(methods) < 2:
+        sys.exit("   ❌ Need ≥2 active admission_methods")
+
+    path_ids: dict[str, int] = {}
+    for idx, method in enumerate(methods):
+        label = f"capped_path_{idx}"
+        existing = (await session.execute(
+            select(models.AdmissionPath).where(
+                models.AdmissionPath.admission_round_id == round_id,
+                models.AdmissionPath.academic_info_id == ai.id,
+                models.AdmissionPath.admission_method_id == method.id,
+            )
+        )).scalar_one_or_none()
+        if existing:
+            path_ids[label] = existing.id
+            print(f"   ⏭  {label} exists (id={existing.id})")
+            continue
+
+        path = models.AdmissionPath(
+            academic_info_id=ai.id,
+            admission_method_id=method.id,
+            admission_round_id=round_id,
+            admit_quota=10,  # plenty path cap so Tier 1 (annual) is the gate
+            round_quota=20,
+            visibility="public",
+            status="active",
+        )
+        session.add(path)
+        await session.flush()
+        path_ids[label] = path.id
+        print(f"   ✅  {label} created (id={path.id}, method={method.code})")
+
+    await session.commit()
+    return path_ids
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GROUP 4 — PROFILE STATE MATRIX  (sketch — uses state_service.transition)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def seed_group_4_profiles(
+    session: AsyncSession,
+    round_ids: dict[str, int],
+    path_ids: dict[str, int],
+) -> dict[str, int]:
+    """Profile state matrix via state_service.transition().
+
+    Strategy:
+      1. Seed 1 SMOKE_DEV_LEAD (citizen_id unique by index, smoke_marker
+         qua applied_rules).
+      2. Tạo PathSubjectGroupConfig cho 2 paths trong Group 2 (full_quota_1,
+         free_quota_5) — needed for AdmissionProfileChoice FK.
+      3. Tạo 5 profiles initial status=draft (INSERT direct + applied_rules
+         marker — initial state KHÔNG cần transition).
+      4. Transition các profile cần trạng thái khác qua state_service với
+         skip_dispatch=True (tránh notification side effect ngoài ý muốn).
+
+    Fixtures (7 total):
+      DRAFT_active           — Round ACTIVE_MULTI, choice on free_quota_5
+      DRAFT_expired          — Round EXPIRED (cho S8/S9 cutoff CRUD)
+      SUBMITTED_pending      — draft → submitted
+      ADMITTED_consumer      — full chain → status=admitted + choice
+                               .decision=admitted on full_quota_1 (consume seat)
+      WAITLISTED_promotable  — chain → waitlisted, choice on full path
+      REJECTED               — chain → rejected
+      ENROLLED               — chain → enrolled (KPI smoke)
+    """
+    print(f"\n👤 Group 4 — Profile state matrix")
+
+    from app.services import admission_state_service
+
+    # Pick officer + manager for actor refs
+    officer_stmt = select(models.User).where(
+        models.User.role == "officer", models.User.status == "active"
+    ).limit(1)
+    officer = (await session.execute(officer_stmt)).scalar_one_or_none()
+    manager_stmt = select(models.User).where(
+        models.User.role == "manager", models.User.status == "active"
+    ).limit(1)
+    manager = (await session.execute(manager_stmt)).scalar_one_or_none()
+    if not (officer and manager):
+        sys.exit("   ❌ Need ≥1 active officer + 1 active manager user")
+
+    # Pipeline stage — use first available
+    pipeline_stmt = select(models.PipelineStage).order_by(models.PipelineStage.id).limit(1)
+    pipeline_stage = (await session.execute(pipeline_stmt)).scalar_one_or_none()
+    if not pipeline_stage:
+        sys.exit("   ❌ Need ≥1 pipeline_stage row. Run seed_categories first.")
+
+    # Seed N leads — 1 per profile (UNIQUE(lead_id, academic_year) constraint).
+    # Idempotent by deterministic phone "0900000xxx".
+    async def get_or_create_lead(idx: int) -> models.Lead:
+        phone = f"09000{idx:05d}"
+        existing = (await session.execute(
+            select(models.Lead).where(models.Lead.phone == phone)
+        )).scalar_one_or_none()
+        if existing:
+            return existing
+        new_lead = models.Lead(
+            full_name=f"SMOKE DEV Candidate {idx}",
+            phone=phone,
+            unit_id=officer.unit_id,
+            pipeline_stage_id=pipeline_stage.id,
+            source="walkin",
+            assigned_officer_id=officer.id,
+        )
+        session.add(new_lead)
+        await session.flush()
+        return new_lead
+
+    # PathSubjectGroupConfig for paths that will host choices
+    sg_stmt = select(models.SubjectGroup).order_by(models.SubjectGroup.id).limit(1)
+    sg = (await session.execute(sg_stmt)).scalar_one()
+    config_ids: dict[str, int] = {}
+    for label in ("full_quota_1", "free_quota_5"):
+        path_id = path_ids.get(label)
+        if not path_id:
+            continue
+        existing = (await session.execute(
+            select(models.PathSubjectGroupConfig).where(
+                models.PathSubjectGroupConfig.admission_path_id == path_id,
+                models.PathSubjectGroupConfig.subject_group_id == sg.id,
+            )
+        )).scalar_one_or_none()
+        if existing:
+            config_ids[label] = existing.id
+            continue
+        cfg = models.PathSubjectGroupConfig(
+            admission_path_id=path_id,
+            subject_group_id=sg.id,
+            min_score=Decimal("0.00"),
+        )
+        session.add(cfg)
+        await session.flush()
+        config_ids[label] = cfg.id
+
+    await session.commit()
+    print(f"   ✅  PathSubjectGroupConfig seeded for {list(config_ids.keys())}")
+
+    # Profile spec — label, target_status, round_key, path_label, choice_decision
+    profiles_spec = [
+        ("DRAFT_active",          "draft",      "ACTIVE_MULTI", "free_quota_5", None),
+        ("DRAFT_expired",         "draft",      "EXPIRED",      "on_expired_round", None),
+        ("SUBMITTED_pending",     "submitted",  "ACTIVE_MULTI", "free_quota_5", None),
+        ("ADMITTED_consumer",     "admitted",   "ACTIVE_MULTI", "full_quota_1", "admitted"),
+        ("WAITLISTED_promotable", "waitlisted", "ACTIVE_MULTI", "full_quota_1", "waitlisted"),
+        ("REJECTED",              "rejected",   "ACTIVE_MULTI", "free_quota_5", "rejected"),
+        ("ENROLLED",              "enrolled",   "ACTIVE_MULTI", "free_quota_5", None),
+    ]
+
+    # Transition chains per target. Each entry là sequence từ 'draft' tới target.
+    # Note: state machine ALLOWED_TRANSITIONS dictates each hop.
+    chains = {
+        "draft":      ["draft"],
+        "submitted":  ["draft", "submitted"],
+        "admitted":   ["draft", "submitted", "reviewing", "result_published", "admitted"],
+        "waitlisted": ["draft", "submitted", "reviewing", "result_published", "waitlisted"],
+        "rejected":   ["draft", "submitted", "reviewing", "result_published", "rejected"],
+        "enrolled":   ["draft", "submitted", "reviewing", "result_published",
+                       "admitted", "confirmed", "enrolled"],
+    }
+
+    profile_ids: dict[str, int] = {}
+
+    for label, target, round_key, path_label, choice_decision in profiles_spec:
+        round_id = round_ids.get(round_key)
+        path_id = path_ids.get(path_label)
+        if not (round_id and path_id):
+            print(f"   ⚠️  Skip {label}: missing round/path FK")
+            continue
+
+        # Deterministic citizen_id by profile index
+        idx = len(profile_ids) + 1
+        citizen = f"{CITIZEN_ID_PREFIX}{idx:04d}"
+
+        existing = (await session.execute(
+            select(models.AdmissionProfile).where(
+                models.AdmissionProfile.citizen_id == citizen
+            )
+        )).scalar_one_or_none()
+        if existing:
+            profile_ids[label] = existing.id
+            print(f"   ⏭  {label} exists (id={existing.id}, citizen={citizen})")
+            continue
+
+        # Get/create dedicated lead for this profile (UNIQUE constraint)
+        lead_for_profile = await get_or_create_lead(idx)
+
+        # INSERT initial draft directly (no transition needed for start state)
+        profile = models.AdmissionProfile(
+            lead_id=lead_for_profile.id,
+            citizen_id=citizen,
+            academic_year=ACADEMIC_YEAR,
+            status="draft",
+            applied_rules={
+                PROFILE_MARKER_KEY: PROFILE_MARKER_VALUE,
+                "admission_path_id": path_id,
+            },
+            uses_choice_engine=(round_key == "ACTIVE_MULTI"),
+        )
+        session.add(profile)
+        await session.flush()
+
+        # Choice (cho profiles in multi-NV round)
+        config_id = config_ids.get(path_label)
+        if config_id and choice_decision is not None:
+            choice = models.AdmissionProfileChoice(
+                admission_profile_id=profile.id,
+                admission_path_id=path_id,
+                path_subject_group_config_id=config_id,
+                display_order=1,
+                decision=choice_decision,
+            )
+            session.add(choice)
+            await session.flush()
+        elif config_id and target != "draft":
+            # Need choice in pending state for multi-NV profile that will
+            # transit beyond draft
+            choice = models.AdmissionProfileChoice(
+                admission_profile_id=profile.id,
+                admission_path_id=path_id,
+                path_subject_group_config_id=config_id,
+                display_order=1,
+                decision="pending",
+            )
+            session.add(choice)
+            await session.flush()
+
+        await session.commit()
+
+        # Transition chain (skip if target=='draft' — already there)
+        if target != "draft":
+            chain = chains.get(target, ["draft"])
+            for new_status in chain[1:]:  # skip first since profile starts at draft
+                try:
+                    await admission_state_service.transition(
+                        session, profile, new_status,
+                        actor=manager,  # use manager for both reviewing + final ops
+                        reason=f"smoke seed → {new_status}",
+                        source="seed_smoke_dev",
+                        skip_dispatch=True,  # don't fire notifications during seed
+                    )
+                    await session.commit()
+                except Exception as e:
+                    print(f"   ⚠️  {label} transition → {new_status} failed: {e}")
+                    await session.rollback()
+                    break
+
+        profile_ids[label] = profile.id
+        final_status = profile.status if profile.status else target
+        print(f"   ✅  {label} (id={profile.id}, citizen={citizen}, status={final_status})")
+
+    return profile_ids
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# GROUP 5 — MAGIC-LINK TOKEN FIXTURE  (sketch)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def seed_group_5_tokens(
+    session: AsyncSession, profile_ids: dict[str, int]
+) -> dict[str, int]:
+    """AdmissionConfirmationToken matrix — 6 token fixtures.
+
+    Reuse Group 4 profiles. Token determinism via fixed string per fixture
+    (avoids regen on re-seed). Each token represents a magic-link state:
+
+      SUBMIT_active        — DRAFT_active, action=submit, fresh expiry
+      CONFIRM_active       — ADMITTED_consumer, action=confirm
+      RESUBMIT_active      — REJECTED, action=resubmit
+      EXPIRED              — DRAFT_active, action=submit, expires_at < now
+      CONSUMED             — SUBMITTED_pending, confirmed_at = now
+      HARD_LOCKED          — DRAFT_active, attempt_count=10 + lock_until future
+    """
+    import secrets
+    print(f"\n🔗 Group 5 — Magic-link tokens")
+
+    if not profile_ids:
+        print(f"   ⚠️  Skip — Group 4 profile_ids empty.")
+        return {}
+
+    now = datetime.now(timezone.utc)
+    in_7d = now + timedelta(days=7)
+    past_1d = now - timedelta(days=1)
+    in_24h = now + timedelta(hours=24)
+
+    # spec: label, profile_key, action_type, expires_at, confirmed_at,
+    #       attempt_count, lock_until, lock_count.
+    # UNIQUE(profile_id, action_type) enforced — spread across profiles.
+    tokens_spec = [
+        ("SUBMIT_active",   "DRAFT_active",          "submit",   in_7d,   None, 0, None,    0),
+        ("CONFIRM_active",  "ADMITTED_consumer",     "confirm",  in_7d,   None, 0, None,    0),
+        ("RESUBMIT_active", "REJECTED",              "resubmit", in_7d,   None, 0, None,    0),
+        ("EXPIRED",         "DRAFT_expired",         "submit",   past_1d, None, 0, None,    0),
+        ("CONSUMED",        "SUBMITTED_pending",     "confirm",  in_7d,   now,  1, None,    0),
+        ("HARD_LOCKED",     "WAITLISTED_promotable", "submit",   in_7d,   None,10, in_24h,  4),
+    ]
+
+    token_ids: dict[str, int] = {}
+    for label, profile_key, action, expires_at, confirmed_at, attempts, lock_until, lock_count in tokens_spec:
+        profile_id = profile_ids.get(profile_key)
+        if not profile_id:
+            print(f"   ⚠️  Skip {label}: profile {profile_key} not seeded")
+            continue
+
+        # Deterministic token by label (idempotent re-seed)
+        token_str = f"smk_dev_{label.lower()}_{profile_id:06d}"[:64]
+
+        existing = (await session.execute(
+            select(models.AdmissionConfirmationToken).where(
+                models.AdmissionConfirmationToken.token == token_str
+            )
+        )).scalar_one_or_none()
+        if existing:
+            token_ids[label] = existing.id
+            print(f"   ⏭  {label} exists (id={existing.id})")
+            continue
+
+        token = models.AdmissionConfirmationToken(
+            profile_id=profile_id,
+            token=token_str,
+            action_type=action,
+            expires_at=expires_at,
+            confirmed_at=confirmed_at,
+            attempt_count=attempts,
+            lock_until=lock_until,
+            lock_count=lock_count,
+            locked_at=now if attempts >= 5 else None,
+        )
+        session.add(token)
+        await session.flush()
+        token_ids[label] = token.id
+        print(f"   ✅  {label} (id={token.id}, action={action}, attempts={attempts})")
+
+    await session.commit()
+    return token_ids
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RESET — cascade delete SMOKE_DEV_* markers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def reset(session: AsyncSession) -> None:
+    """Cascade delete all SMOKE_DEV_* fixtures.
+
+    Order matters due to FK constraints:
+      1. AdmissionConfirmationToken (depends on profile)
+      2. AdmissionProfileChoice (depends on profile + path)
+      3. AdmissionProfile (smoke_marker)
+      4. AdmissionPath (depends on round)
+      5. OfferingAdmissionRound (top-level marker)
+    """
+    print(f"\n🗑  RESET — cascade delete SMOKE_DEV_* fixtures")
+
+    # Profiles by marker
+    profile_count = await session.execute(text(
+        "DELETE FROM admission_confirmation_token "
+        "WHERE profile_id IN (SELECT id FROM admission_profile "
+        f"WHERE applied_rules->>'{PROFILE_MARKER_KEY}' = '{PROFILE_MARKER_VALUE}') "
+        "RETURNING profile_id"
+    ))
+    print(f"  Tokens deleted: {profile_count.rowcount}")
+
+    choices = await session.execute(text(
+        "DELETE FROM admission_profile_choice "
+        "WHERE admission_profile_id IN (SELECT id FROM admission_profile "
+        f"WHERE applied_rules->>'{PROFILE_MARKER_KEY}' = '{PROFILE_MARKER_VALUE}') "
+        "RETURNING id"
+    ))
+    print(f"  Choices deleted: {choices.rowcount}")
+
+    profiles = await session.execute(text(
+        f"DELETE FROM admission_profile "
+        f"WHERE applied_rules->>'{PROFILE_MARKER_KEY}' = '{PROFILE_MARKER_VALUE}' RETURNING id"
+    ))
+    print(f"  Profiles deleted: {profiles.rowcount}")
+
+    # Paths under SMOKE_DEV_* rounds
+    paths = await session.execute(text(
+        "DELETE FROM admission_path "
+        "WHERE admission_round_id IN (SELECT id FROM offering_admission_round "
+        f"WHERE round_code LIKE '{ROUND_PREFIX}%%') RETURNING id"
+    ))
+    print(f"  Paths deleted: {paths.rowcount}")
+
+    # Rounds themselves
+    rounds = await session.execute(text(
+        f"DELETE FROM offering_admission_round "
+        f"WHERE round_code LIKE '{ROUND_PREFIX}%%' RETURNING id"
+    ))
+    print(f"  Rounds deleted: {rounds.rowcount}")
+
+    # Group 3 dedicated offering — cascade deletes ai + any orphan paths.
+    # Order AFTER round delete vì Group 2 paths on smoke rounds đã sạch.
+    g3_offering = await session.execute(text(
+        f"DELETE FROM program_offering "
+        f"WHERE offering_type = '{G3_OFFERING_TYPE}' RETURNING id"
+    ))
+    print(f"  G3 ProgramOffering deleted: {g3_offering.rowcount}")
+
+    await session.commit()
+    print(f"✅ Reset complete.")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# VERIFY — row count report
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def verify(session: AsyncSession) -> None:
+    """Print row count per fixture marker + key state distributions."""
+    print(f"\n📋 VERIFY — Smoke fixture row counts")
+
+    queries = [
+        ("SMOKE_DEV rounds",
+         f"SELECT COUNT(*) FROM offering_admission_round WHERE round_code LIKE '{ROUND_PREFIX}%%'"),
+        ("SMOKE_DEV paths",
+         f"SELECT COUNT(*) FROM admission_path WHERE admission_round_id IN "
+         f"(SELECT id FROM offering_admission_round WHERE round_code LIKE '{ROUND_PREFIX}%%')"),
+        ("SMOKE_DEV profiles",
+         f"SELECT COUNT(*) FROM admission_profile "
+         f"WHERE applied_rules->>'{PROFILE_MARKER_KEY}' = '{PROFILE_MARKER_VALUE}'"),
+        ("SMOKE_DEV choices",
+         f"SELECT COUNT(*) FROM admission_profile_choice "
+         f"WHERE admission_profile_id IN (SELECT id FROM admission_profile "
+         f"WHERE applied_rules->>'{PROFILE_MARKER_KEY}' = '{PROFILE_MARKER_VALUE}')"),
+        ("SMOKE_DEV tokens",
+         f"SELECT COUNT(*) FROM admission_confirmation_token "
+         f"WHERE profile_id IN (SELECT id FROM admission_profile "
+         f"WHERE applied_rules->>'{PROFILE_MARKER_KEY}' = '{PROFILE_MARKER_VALUE}')"),
+        ("G3 dedicated offering",
+         f"SELECT COUNT(*) FROM program_offering WHERE offering_type = '{G3_OFFERING_TYPE}'"),
+        ("G3 dedicated academic_info",
+         f"SELECT COUNT(*) FROM offering_academic_info ai "
+         f"JOIN program_offering po ON po.id = ai.offering_id "
+         f"WHERE po.offering_type = '{G3_OFFERING_TYPE}'"),
+    ]
+
+    for label, sql in queries:
+        result = await session.execute(text(sql))
+        count = result.scalar_one()
+        print(f"  {label:30s} {count:>5}")
+
+    # Round detail
+    print(f"\n  Round detail:")
+    rounds_detail = await session.execute(text(
+        f"SELECT id, round_code, start_date, end_date, allow_multi_nv, "
+        f"archived_at IS NOT NULL AS archived "
+        f"FROM offering_admission_round WHERE round_code LIKE '{ROUND_PREFIX}%%' ORDER BY id"
+    ))
+    for row in rounds_detail:
+        print(f"    id={row.id} {row.round_code:30s} window=[{row.start_date}..{row.end_date}] "
+              f"multi_nv={row.allow_multi_nv} archived={row.archived}")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ENTRY POINT
+# ═══════════════════════════════════════════════════════════════════════════════
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--group", nargs="*", type=int, choices=[1, 2, 3, 4, 5],
+        help="Seed specific group(s). Default: all groups."
+    )
+    parser.add_argument("--reset", action="store_true",
+                        help="Cascade delete SMOKE_DEV_* fixtures. Mutually exclusive với seed.")
+    parser.add_argument("--verify", action="store_true",
+                        help="Print row count report. Read-only.")
+    args = parser.parse_args()
+
+    assert_safe_environment()
+
+    async with AsyncSessionLocal() as session:
+        if args.reset:
+            await reset(session)
+            return
+        if args.verify:
+            await verify(session)
+            return
+
+        groups_to_seed = args.group or [1, 2, 3, 4, 5]
+        round_ids: dict[str, int] = {}
+        path_ids: dict[str, int] = {}
+        profile_ids: dict[str, int] = {}
+
+        # Ensure dependencies exist when running later groups standalone.
+        if any(g in groups_to_seed for g in [2, 3, 4]):
+            if not round_ids:
+                round_ids = await _lookup_existing_rounds(session)
+        if any(g in groups_to_seed for g in [4, 5]):
+            if not path_ids:
+                path_ids = await _lookup_existing_paths(session, round_ids)
+
+        if 1 in groups_to_seed:
+            round_ids = await seed_group_1_rounds(session)
+        if 2 in groups_to_seed:
+            path_ids = await seed_group_2_paths(session, round_ids)
+        if 3 in groups_to_seed:
+            await seed_group_3_annual_quota(session, round_ids)
+        if 4 in groups_to_seed:
+            profile_ids = await seed_group_4_profiles(session, round_ids, path_ids)
+        if 5 in groups_to_seed:
+            if not profile_ids:
+                profile_ids = await _lookup_existing_profiles(session)
+            await seed_group_5_tokens(session, profile_ids)
+
+        print(f"\n✅ Seed complete. Run `--verify` để xem row counts.")
+
+
+async def _lookup_existing_rounds(session: AsyncSession) -> dict[str, int]:
+    """Lookup existing SMK_* rounds when later group needs round_ids
+    but Group 1 was skipped (rerun pattern)."""
+    result = await session.execute(
+        select(models.OfferingAdmissionRound.id, models.OfferingAdmissionRound.round_code)
+        .where(models.OfferingAdmissionRound.round_code.like(f"{ROUND_PREFIX}%"))
+    )
+    return {
+        row.round_code.replace(ROUND_PREFIX, ""): row.id
+        for row in result
+    }
+
+
+async def _lookup_existing_paths(
+    session: AsyncSession, round_ids: dict[str, int]
+) -> dict[str, int]:
+    """Reverse-map paths to Group 2 labels by (round_id, method_idx).
+
+    Inferred labels from path spec table — fragile, but adequate for
+    standalone rerun. If schema spec changes, this lookup needs update.
+    """
+    if not round_ids:
+        return {}
+
+    # Same spec ordering as Group 2 seed
+    paths_label_spec = [
+        ("full_quota_1",     "ACTIVE_MULTI",  0),
+        ("free_quota_5",     "ACTIVE_MULTI",  1),
+        ("unbounded_null",   "ACTIVE_MULTI",  2),
+        ("audience_thpt",    "ACTIVE_SINGLE", 0),
+        ("audience_vlvh",    "ACTIVE_SINGLE", 1),
+        ("audience_null",    "ACTIVE_SINGLE", 2),
+        ("internal_hidden",  "OPEN_ENDED",    0),
+        ("archived_path",    "OPEN_ENDED",    1),
+        ("on_expired_round", "EXPIRED",       0),
+    ]
+    methods = (await session.execute(
+        select(models.AdmissionMethod).where(models.AdmissionMethod.is_active.is_(True))
+        .order_by(models.AdmissionMethod.id).limit(5)
+    )).scalars().all()
+
+    path_ids: dict[str, int] = {}
+    for label, round_key, method_idx in paths_label_spec:
+        round_id = round_ids.get(round_key)
+        if not (round_id and method_idx < len(methods)):
+            continue
+        method = methods[method_idx]
+        result = await session.execute(
+            select(models.AdmissionPath.id).where(
+                models.AdmissionPath.admission_round_id == round_id,
+                models.AdmissionPath.admission_method_id == method.id,
+            ).order_by(models.AdmissionPath.id).limit(1)
+        )
+        pid = result.scalar_one_or_none()
+        if pid:
+            path_ids[label] = pid
+    return path_ids
+
+
+async def _lookup_existing_profiles(session: AsyncSession) -> dict[str, int]:
+    """Lookup profiles by smoke marker for Group 5 standalone rerun."""
+    result = await session.execute(text(
+        f"SELECT id, citizen_id FROM admission_profile "
+        f"WHERE applied_rules->>'{PROFILE_MARKER_KEY}' = '{PROFILE_MARKER_VALUE}' "
+        f"ORDER BY id"
+    ))
+    # Map by citizen_id suffix order (matches Group 4 enumeration)
+    labels_by_index = [
+        "DRAFT_active", "DRAFT_expired", "SUBMITTED_pending",
+        "ADMITTED_consumer", "WAITLISTED_promotable", "REJECTED", "ENROLLED",
+    ]
+    profile_ids: dict[str, int] = {}
+    rows = list(result)
+    for idx, row in enumerate(rows):
+        if idx < len(labels_by_index):
+            profile_ids[labels_by_index[idx]] = row.id
+    return profile_ids
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
+++ b/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
@@ -23,7 +23,12 @@ from app.utils.exceptions import (
     DuplicateResourceError,
     ResourceNotFoundError,
 )
-from app.services.public_admissions_service import _load_public_paths
+from app.schemas.public_admissions import PublicAdmissionsAudience
+from app.services.public_admissions_service import (
+    _load_public_paths,
+    get_public_programs_catalog,
+    get_public_tuition_catalog,
+)
 from app.utils.exceptions import BusinessRuleViolation
 
 
@@ -392,6 +397,236 @@ async def test_storefront_excludes_ineligible_rounds(path_seed: dict):
         assert all(
             p.admission_round_id == round_ids["open"] for p in open_paths
         )
+
+
+def _program_catalog_offering_ids(response) -> set[int]:
+    return {
+        offering.id
+        for group in response.degree_levels
+        for program in group.programs
+        for offering in program.offerings
+    }
+
+
+def _tuition_catalog_offering_ids(response) -> set[int]:
+    return {offering.offering_id for offering in response.offerings}
+
+
+@pytest.mark.asyncio
+async def test_programs_catalog_excludes_offering_without_public_eligible_path(
+    path_seed: dict,
+):
+    """PR-3 anchor: /programs must fail-closed at the snapshot layer.
+
+    A published active offering with no public-eligible path must not leak
+    into the programs catalog as an offering with an empty method list.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            base_ai = await s.get(
+                models.OfferingAcademicInfo,
+                path_seed["academic_info_id"],
+            )
+            base_offering = await s.get(
+                models.ProgramOffering,
+                base_ai.offering_id,
+            )
+            s.add(
+                models.AdmissionPath(
+                    academic_info_id=base_ai.id,
+                    admission_method_id=path_seed["method_id"],
+                    admission_round_id=path_seed["round_id"],
+                    status="active",
+                    visibility="public",
+                )
+            )
+
+            hidden_offering = models.ProgramOffering(
+                program_id=base_offering.program_id,
+                offering_type=f"no_path_{ts}",
+                duration_semesters=8,
+                is_active=True,
+            )
+            s.add(hidden_offering)
+            await s.flush()
+            hidden_ai = models.OfferingAcademicInfo(
+                offering_id=hidden_offering.id,
+                academic_year=2026,
+                annual_admission_quota=20,
+                tuition_fee_per_year=2_000_000,
+                is_published=True,
+            )
+            s.add(hidden_ai)
+            await s.flush()
+            base_offering_id = base_offering.id
+            hidden_offering_id = hidden_offering.id
+
+    async with AsyncSessionLocal() as s:
+        response = await get_public_programs_catalog(s)
+
+    offering_ids = _program_catalog_offering_ids(response)
+    assert base_offering_id in offering_ids
+    assert hidden_offering_id not in offering_ids
+
+
+@pytest.mark.asyncio
+async def test_tuition_excludes_offering_when_round_filter_set(path_seed: dict):
+    """PR-3 anchor: /tuition is round-aware, not just published-info aware."""
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            base_ai = await s.get(
+                models.OfferingAcademicInfo,
+                path_seed["academic_info_id"],
+            )
+            base_offering = await s.get(
+                models.ProgramOffering,
+                base_ai.offering_id,
+            )
+            s.add(
+                models.AdmissionPath(
+                    academic_info_id=base_ai.id,
+                    admission_method_id=path_seed["method_id"],
+                    admission_round_id=path_seed["round_id"],
+                    status="active",
+                    visibility="public",
+                )
+            )
+
+            other_round = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"PR3_TUI_{ts}",
+                round_name=f"PR3 tuition round {ts}",
+                is_active=True,
+            )
+            s.add(other_round)
+            await s.flush()
+
+            other_method = models.AdmissionMethod(
+                code=f"PR3MT_{ts}",
+                name=f"PR3 method tuition {ts}",
+                requires_subject_scores=True,
+                is_active=True,
+            )
+            s.add(other_method)
+            await s.flush()
+
+            other_offering = models.ProgramOffering(
+                program_id=base_offering.program_id,
+                offering_type=f"other_round_{ts}",
+                duration_semesters=8,
+                is_active=True,
+            )
+            s.add(other_offering)
+            await s.flush()
+            other_ai = models.OfferingAcademicInfo(
+                offering_id=other_offering.id,
+                academic_year=2026,
+                annual_admission_quota=20,
+                tuition_fee_per_year=3_000_000,
+                is_published=True,
+            )
+            s.add(other_ai)
+            await s.flush()
+            s.add(
+                models.AdmissionPath(
+                    academic_info_id=other_ai.id,
+                    admission_method_id=other_method.id,
+                    admission_round_id=other_round.id,
+                    status="active",
+                    visibility="public",
+                )
+            )
+            await s.flush()
+            base_offering_id = base_offering.id
+            other_offering_id = other_offering.id
+            round_id = path_seed["round_id"]
+
+    async with AsyncSessionLocal() as s:
+        response = await get_public_tuition_catalog(
+            s,
+            admission_round_id=round_id,
+        )
+
+    offering_ids = _tuition_catalog_offering_ids(response)
+    assert base_offering_id in offering_ids
+    assert other_offering_id not in offering_ids
+
+
+@pytest.mark.asyncio
+async def test_tuition_audience_filter_now_active(path_seed: dict):
+    """PR-3 anchor: /tuition must honor audience via eligible paths."""
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            base_ai = await s.get(
+                models.OfferingAcademicInfo,
+                path_seed["academic_info_id"],
+            )
+            base_offering = await s.get(
+                models.ProgramOffering,
+                base_ai.offering_id,
+            )
+            s.add(
+                models.AdmissionPath(
+                    academic_info_id=base_ai.id,
+                    admission_method_id=path_seed["method_id"],
+                    admission_round_id=path_seed["round_id"],
+                    status="active",
+                    visibility="public",
+                    applicable_to=[PublicAdmissionsAudience.POST_THPT.value],
+                )
+            )
+
+            vlvh_method = models.AdmissionMethod(
+                code=f"PR3AU_{ts}",
+                name=f"PR3 audience method {ts}",
+                requires_subject_scores=True,
+                is_active=True,
+            )
+            s.add(vlvh_method)
+            await s.flush()
+            vlvh_offering = models.ProgramOffering(
+                program_id=base_offering.program_id,
+                offering_type=f"vlvh_{ts}",
+                duration_semesters=8,
+                is_active=True,
+            )
+            s.add(vlvh_offering)
+            await s.flush()
+            vlvh_ai = models.OfferingAcademicInfo(
+                offering_id=vlvh_offering.id,
+                academic_year=2026,
+                annual_admission_quota=20,
+                tuition_fee_per_year=4_000_000,
+                is_published=True,
+            )
+            s.add(vlvh_ai)
+            await s.flush()
+            s.add(
+                models.AdmissionPath(
+                    academic_info_id=vlvh_ai.id,
+                    admission_method_id=vlvh_method.id,
+                    admission_round_id=path_seed["round_id"],
+                    status="active",
+                    visibility="public",
+                    applicable_to=[PublicAdmissionsAudience.VLVH.value],
+                )
+            )
+            await s.flush()
+            base_offering_id = base_offering.id
+            vlvh_offering_id = vlvh_offering.id
+
+    async with AsyncSessionLocal() as s:
+        response = await get_public_tuition_catalog(
+            s,
+            audience=PublicAdmissionsAudience.POST_THPT,
+        )
+
+    offering_ids = _tuition_catalog_offering_ids(response)
+    assert base_offering_id in offering_ids
+    assert vlvh_offering_id not in offering_ids
 
 
 @pytest.mark.asyncio

--- a/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
+++ b/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
@@ -1290,3 +1290,82 @@ async def test_create_path_rejects_invalid_round_id(path_seed: dict):
                 ),
                 admin,
             )
+
+
+# ============================================================================
+# PR-3 Finding A anchor (review post-fix dfb755d1) — sentinel contract
+# end-to-end. FE helper publicAdmissionsCatalogParams maps invalid round
+# input to INVALID_ROUND_SENTINEL=2147483647. The sentinel value must:
+#   1. Pass BE Pydantic Query(None, ge=1) validator (NOT 422)
+#   2. Return 200 with empty data (BE filter finds 0 paths)
+#
+# This test routes through the FastAPI router (httpx AsyncClient) so the
+# Pydantic validator actually runs. Previous service-level tests bypass
+# the router → catch nothing. Without this anchor, future tightening like
+# `ge=2147483648` or sentinel value mismatch would silently leak 422.
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_invalid_round_sentinel_returns_empty_200_not_422(
+    client,
+):
+    """End-to-end anchor: FE sentinel value (INT_MAX) on the public
+    programs endpoint must produce 200 empty, NOT 422 from BE Pydantic
+    ge=1 validator.
+
+    Reproduces PR #348 review Finding A: original sentinel 0 silently
+    triggered 422 leaking Pydantic constraint detail. Bumped to 2147483647
+    (PostgreSQL INTEGER max) to satisfy ge=1 while staying unmatched
+    (autoincrement starts at 1; realistic round_id growth ~thousands).
+
+    Asserts:
+      - status 200 (NOT 422; NOT 500)
+      - response body shape valid (degree_levels key present, may be empty)
+      - empty data (no eligible round matches sentinel) — degree_levels
+        is the union container that should be [] when no eligible offering
+    """
+    response = await client.get(
+        "/api/public/admissions/programs",
+        params={"admission_round_id": 2147483647},
+    )
+    assert response.status_code == 200, (
+        f"FE sentinel must pass BE ge=1 validator. Got "
+        f"status={response.status_code}: {response.text[:300]}. "
+        f"If 422 → sentinel value broken (review fix #2 regression). "
+        f"If 500 → BE missed empty-set handling."
+    )
+    body = response.json()
+    # Shape check: PublicAdmissionsProgramsResponse has summary +
+    # degree_levels keys per schema.
+    assert "degree_levels" in body, (
+        f"Response shape missing degree_levels; got keys: {list(body.keys())}"
+    )
+    assert body["degree_levels"] == [], (
+        f"Sentinel must return empty degree_levels (no path matches "
+        f"id={2147483647}); got {body['degree_levels']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_round_sentinel_tuition_returns_empty_200_not_422(
+    client,
+):
+    """Same anchor as above but for /tuition endpoint — both endpoints
+    share _ADMISSION_ROUND_QUERY validator, so both must honor sentinel.
+    """
+    response = await client.get(
+        "/api/public/admissions/tuition",
+        params={"admission_round_id": 2147483647},
+    )
+    assert response.status_code == 200, (
+        f"/tuition with FE sentinel must 200; got {response.status_code}: "
+        f"{response.text[:300]}"
+    )
+    body = response.json()
+    assert "offerings" in body, (
+        f"Response missing offerings key; got: {list(body.keys())}"
+    )
+    assert body["offerings"] == [], (
+        f"Sentinel must produce empty tuition offerings; got {body['offerings']}"
+    )

--- a/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
+++ b/Backend_FastAPI/tests/services/test_phase2_admission_path_quota_integration.py
@@ -412,6 +412,59 @@ def _tuition_catalog_offering_ids(response) -> set[int]:
     return {offering.offering_id for offering in response.offerings}
 
 
+async def _add_public_offering_path(
+    s: AsyncSession,
+    *,
+    program_id: int,
+    offering_type: str,
+    academic_year: int,
+    round_id: int,
+    method_code: str,
+    tuition_fee_per_year: int,
+    audience_values: list[str] | None = None,
+) -> int:
+    offering = models.ProgramOffering(
+        program_id=program_id,
+        offering_type=offering_type,
+        duration_semesters=8,
+        is_active=True,
+    )
+    s.add(offering)
+    await s.flush()
+
+    academic_info = models.OfferingAcademicInfo(
+        offering_id=offering.id,
+        academic_year=academic_year,
+        annual_admission_quota=20,
+        tuition_fee_per_year=tuition_fee_per_year,
+        is_published=True,
+    )
+    s.add(academic_info)
+    await s.flush()
+
+    method = models.AdmissionMethod(
+        code=method_code,
+        name=f"Method {method_code}",
+        requires_subject_scores=True,
+        is_active=True,
+    )
+    s.add(method)
+    await s.flush()
+
+    s.add(
+        models.AdmissionPath(
+            academic_info_id=academic_info.id,
+            admission_method_id=method.id,
+            admission_round_id=round_id,
+            status="active",
+            visibility="public",
+            applicable_to=audience_values,
+        )
+    )
+    await s.flush()
+    return offering.id
+
+
 @pytest.mark.asyncio
 async def test_programs_catalog_excludes_offering_without_public_eligible_path(
     path_seed: dict,
@@ -627,6 +680,290 @@ async def test_tuition_audience_filter_now_active(path_seed: dict):
     offering_ids = _tuition_catalog_offering_ids(response)
     assert base_offering_id in offering_ids
     assert vlvh_offering_id not in offering_ids
+
+
+@pytest.mark.asyncio
+async def test_programs_omitted_round_returns_eligible_active_union(
+    path_seed: dict,
+):
+    """PR-3 contract: omitted round means union of eligible active rounds."""
+    from datetime import timedelta
+
+    from app.utils.datetime_helpers import today_vn
+
+    today = today_vn()
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            base_ai = await s.get(
+                models.OfferingAcademicInfo,
+                path_seed["academic_info_id"],
+            )
+            base_offering = await s.get(
+                models.ProgramOffering,
+                base_ai.offering_id,
+            )
+            s.add(
+                models.AdmissionPath(
+                    academic_info_id=base_ai.id,
+                    admission_method_id=path_seed["method_id"],
+                    admission_round_id=path_seed["round_id"],
+                    status="active",
+                    visibility="public",
+                )
+            )
+
+            second_round = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"PR3_UNION_{ts}",
+                round_name=f"PR3 union round {ts}",
+                is_active=True,
+                start_date=today - timedelta(days=10),
+                end_date=today + timedelta(days=10),
+            )
+            expired_round = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"PR3_UNION_EXP_{ts}",
+                round_name=f"PR3 union expired round {ts}",
+                is_active=True,
+                start_date=today - timedelta(days=30),
+                end_date=today - timedelta(days=10),
+            )
+            s.add_all([second_round, expired_round])
+            await s.flush()
+
+            active_sibling_id = await _add_public_offering_path(
+                s,
+                program_id=base_offering.program_id,
+                offering_type=f"union_active_{ts}",
+                academic_year=2026,
+                round_id=second_round.id,
+                method_code=f"PR3UA_{ts}",
+                tuition_fee_per_year=2_000_000,
+            )
+            expired_sibling_id = await _add_public_offering_path(
+                s,
+                program_id=base_offering.program_id,
+                offering_type=f"union_expired_{ts}",
+                academic_year=2026,
+                round_id=expired_round.id,
+                method_code=f"PR3UE_{ts}",
+                tuition_fee_per_year=3_000_000,
+            )
+            base_offering_id = base_offering.id
+
+    async with AsyncSessionLocal() as s:
+        response = await get_public_programs_catalog(s)
+
+    offering_ids = _program_catalog_offering_ids(response)
+    assert base_offering_id in offering_ids
+    assert active_sibling_id in offering_ids
+    assert expired_sibling_id not in offering_ids
+
+
+@pytest.mark.asyncio
+async def test_programs_no_eligible_round_returns_empty_200(path_seed: dict):
+    """PR-3 contract: no public-eligible path returns an empty response."""
+    from datetime import timedelta
+
+    from app.utils.datetime_helpers import today_vn
+
+    today = today_vn()
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            expired_round = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"PR3_EMPTY_EXP_{ts}",
+                round_name=f"PR3 empty expired round {ts}",
+                is_active=True,
+                start_date=today - timedelta(days=30),
+                end_date=today - timedelta(days=10),
+            )
+            s.add(expired_round)
+            await s.flush()
+            s.add(
+                models.AdmissionPath(
+                    academic_info_id=path_seed["academic_info_id"],
+                    admission_method_id=path_seed["method_id"],
+                    admission_round_id=expired_round.id,
+                    status="active",
+                    visibility="public",
+                )
+            )
+
+    async with AsyncSessionLocal() as s:
+        response = await get_public_programs_catalog(s)
+
+    assert response.summary.program_count == 0
+    assert response.summary.offering_count == 0
+    assert response.degree_levels == []
+
+
+@pytest.mark.asyncio
+async def test_tuition_omitted_round_matches_programs_union(path_seed: dict):
+    """PR-3 contract: /tuition default exposure mirrors /programs."""
+    from datetime import timedelta
+
+    from app.utils.datetime_helpers import today_vn
+
+    today = today_vn()
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            base_ai = await s.get(
+                models.OfferingAcademicInfo,
+                path_seed["academic_info_id"],
+            )
+            base_offering = await s.get(
+                models.ProgramOffering,
+                base_ai.offering_id,
+            )
+            s.add(
+                models.AdmissionPath(
+                    academic_info_id=base_ai.id,
+                    admission_method_id=path_seed["method_id"],
+                    admission_round_id=path_seed["round_id"],
+                    status="active",
+                    visibility="public",
+                )
+            )
+
+            active_round = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"PR3_PARITY_{ts}",
+                round_name=f"PR3 parity active round {ts}",
+                is_active=True,
+                start_date=today - timedelta(days=10),
+                end_date=today + timedelta(days=10),
+            )
+            expired_round = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"PR3_PARX_{ts}",
+                round_name=f"PR3 parity expired round {ts}",
+                is_active=True,
+                start_date=today - timedelta(days=30),
+                end_date=today - timedelta(days=10),
+            )
+            s.add_all([active_round, expired_round])
+            await s.flush()
+
+            await _add_public_offering_path(
+                s,
+                program_id=base_offering.program_id,
+                offering_type=f"parity_active_{ts}",
+                academic_year=2026,
+                round_id=active_round.id,
+                method_code=f"PR3PA_{ts}",
+                tuition_fee_per_year=2_000_000,
+            )
+            await _add_public_offering_path(
+                s,
+                program_id=base_offering.program_id,
+                offering_type=f"parity_expired_{ts}",
+                academic_year=2026,
+                round_id=expired_round.id,
+                method_code=f"PR3PE_{ts}",
+                tuition_fee_per_year=3_000_000,
+            )
+
+    async with AsyncSessionLocal() as s:
+        programs = await get_public_programs_catalog(s)
+        tuition = await get_public_tuition_catalog(s)
+
+    assert _tuition_catalog_offering_ids(tuition) == _program_catalog_offering_ids(
+        programs
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_archived_round_returns_empty_200(path_seed: dict):
+    """PR-3 contract: pinned archived round serves no public catalog rows."""
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            archived_round = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"PR3_ARCH_{ts}",
+                round_name=f"PR3 archived round {ts}",
+                is_active=True,
+                archived_at=datetime.now(timezone.utc),
+            )
+            s.add(archived_round)
+            await s.flush()
+            s.add(
+                models.AdmissionPath(
+                    academic_info_id=path_seed["academic_info_id"],
+                    admission_method_id=path_seed["method_id"],
+                    admission_round_id=archived_round.id,
+                    status="active",
+                    visibility="public",
+                )
+            )
+            round_id = archived_round.id
+
+    async with AsyncSessionLocal() as s:
+        programs = await get_public_programs_catalog(
+            s, admission_round_id=round_id
+        )
+        tuition = await get_public_tuition_catalog(
+            s, admission_round_id=round_id
+        )
+
+    assert programs.summary.program_count == 0
+    assert programs.summary.offering_count == 0
+    assert programs.degree_levels == []
+    assert tuition.summary.program_count == 0
+    assert tuition.summary.offering_count == 0
+    assert tuition.offerings == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_expired_round_returns_empty_200(path_seed: dict):
+    """PR-3 contract: pinned expired round serves no public catalog rows."""
+    from datetime import timedelta
+
+    from app.utils.datetime_helpers import today_vn
+
+    today = today_vn()
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            expired_round = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"PR3_EXP_{ts}",
+                round_name=f"PR3 expired round {ts}",
+                is_active=True,
+                start_date=today - timedelta(days=30),
+                end_date=today - timedelta(days=10),
+            )
+            s.add(expired_round)
+            await s.flush()
+            s.add(
+                models.AdmissionPath(
+                    academic_info_id=path_seed["academic_info_id"],
+                    admission_method_id=path_seed["method_id"],
+                    admission_round_id=expired_round.id,
+                    status="active",
+                    visibility="public",
+                )
+            )
+            round_id = expired_round.id
+
+    async with AsyncSessionLocal() as s:
+        programs = await get_public_programs_catalog(
+            s, admission_round_id=round_id
+        )
+        tuition = await get_public_tuition_catalog(
+            s, admission_round_id=round_id
+        )
+
+    assert programs.summary.program_count == 0
+    assert programs.summary.offering_count == 0
+    assert programs.degree_levels == []
+    assert tuition.summary.program_count == 0
+    assert tuition.summary.offering_count == 0
+    assert tuition.offerings == []
 
 
 @pytest.mark.asyncio

--- a/frontend/src/app/tuyen-sinh/ho-so/page.tsx
+++ b/frontend/src/app/tuyen-sinh/ho-so/page.tsx
@@ -4,6 +4,10 @@ import { connection } from "next/server"
 
 import PublicDocumentsPage from "@/components/public/PublicDocumentsPage"
 import { serverApi } from "@/lib/api/server"
+import {
+  publicAdmissionsCatalogParams,
+  type PublicAdmissionsSearchParams,
+} from "@/lib/public-admissions/query"
 
 export const metadata: Metadata = {
   title: "Hồ sơ tuyển sinh | QLTS",
@@ -11,13 +15,14 @@ export const metadata: Metadata = {
     "Xem checklist hồ sơ theo hệ đào tạo và phương thức xét tuyển trên cổng tuyển sinh QLTS.",
 }
 
-async function DocumentsContent() {
+async function DocumentsContent({ searchParams }: { searchParams: PublicAdmissionsSearchParams }) {
   await connection()
 
   let catalog = null
+  const params = publicAdmissionsCatalogParams(await searchParams)
 
   try {
-    catalog = await serverApi.publicAdmissions.getDocumentsCatalog()
+    catalog = await serverApi.publicAdmissions.getDocumentsCatalog(params)
   } catch (error) {
     console.error("Failed to load public admissions documents catalog", error)
   }
@@ -25,10 +30,14 @@ async function DocumentsContent() {
   return <PublicDocumentsPage catalog={catalog} />
 }
 
-export default function AdmissionsDocumentsPage() {
+export default function AdmissionsDocumentsPage({
+  searchParams,
+}: {
+  searchParams: PublicAdmissionsSearchParams
+}) {
   return (
     <Suspense fallback={<div className="container mx-auto px-4 py-8 animate-pulse" />}>
-      <DocumentsContent />
+      <DocumentsContent searchParams={searchParams} />
     </Suspense>
   )
 }

--- a/frontend/src/app/tuyen-sinh/hoc-phi-hoc-bong/page.tsx
+++ b/frontend/src/app/tuyen-sinh/hoc-phi-hoc-bong/page.tsx
@@ -4,6 +4,10 @@ import { connection } from "next/server"
 
 import PublicTuitionAidPage from "@/components/public/PublicTuitionAidPage"
 import { serverApi } from "@/lib/api/server"
+import {
+  publicAdmissionsCatalogParams,
+  type PublicAdmissionsSearchParams,
+} from "@/lib/public-admissions/query"
 
 export const metadata: Metadata = {
   title: "Học phí và học bổng | QLTS",
@@ -11,13 +15,14 @@ export const metadata: Metadata = {
     "Xem khung học phí tham chiếu, học bổng đầu vào và lộ trình thanh toán trên cổng tuyển sinh QLTS.",
 }
 
-async function TuitionContent() {
+async function TuitionContent({ searchParams }: { searchParams: PublicAdmissionsSearchParams }) {
   await connection()
 
   let catalog = null
+  const params = publicAdmissionsCatalogParams(await searchParams)
 
   try {
-    catalog = await serverApi.publicAdmissions.getTuitionCatalog()
+    catalog = await serverApi.publicAdmissions.getTuitionCatalog(params)
   } catch (error) {
     console.error("Failed to load public admissions tuition catalog", error)
   }
@@ -25,10 +30,14 @@ async function TuitionContent() {
   return <PublicTuitionAidPage catalog={catalog} />
 }
 
-export default function AdmissionsTuitionPage() {
+export default function AdmissionsTuitionPage({
+  searchParams,
+}: {
+  searchParams: PublicAdmissionsSearchParams
+}) {
   return (
     <Suspense fallback={<div className="container mx-auto px-4 py-8 animate-pulse" />}>
-      <TuitionContent />
+      <TuitionContent searchParams={searchParams} />
     </Suspense>
   )
 }

--- a/frontend/src/app/tuyen-sinh/nganh-hoc/page.tsx
+++ b/frontend/src/app/tuyen-sinh/nganh-hoc/page.tsx
@@ -4,6 +4,10 @@ import { connection } from "next/server"
 
 import PublicProgramsPage from "@/components/public/PublicProgramsPage"
 import { serverApi } from "@/lib/api/server"
+import {
+  publicAdmissionsCatalogParams,
+  type PublicAdmissionsSearchParams,
+} from "@/lib/public-admissions/query"
 
 export const metadata: Metadata = {
   title: "Ngành học tuyển sinh | QLTS",
@@ -11,13 +15,14 @@ export const metadata: Metadata = {
     "Duyệt nhóm ngành, bậc học và hệ đào tạo trên cổng tuyển sinh QLTS để chọn chương trình phù hợp trước khi xem phương thức xét tuyển.",
 }
 
-async function ProgramsContent() {
+async function ProgramsContent({ searchParams }: { searchParams: PublicAdmissionsSearchParams }) {
   await connection()
 
   let catalog = null
+  const params = publicAdmissionsCatalogParams(await searchParams)
 
   try {
-    catalog = await serverApi.publicAdmissions.getProgramsCatalog()
+    catalog = await serverApi.publicAdmissions.getProgramsCatalog(params)
   } catch (error) {
     console.error("Failed to load public admissions programs catalog", error)
   }
@@ -25,10 +30,14 @@ async function ProgramsContent() {
   return <PublicProgramsPage catalog={catalog} />
 }
 
-export default function AdmissionsProgramsPage() {
+export default function AdmissionsProgramsPage({
+  searchParams,
+}: {
+  searchParams: PublicAdmissionsSearchParams
+}) {
   return (
     <Suspense fallback={<div className="container mx-auto px-4 py-8 animate-pulse" />}>
-      <ProgramsContent />
+      <ProgramsContent searchParams={searchParams} />
     </Suspense>
   )
 }

--- a/frontend/src/app/tuyen-sinh/phuong-thuc/page.tsx
+++ b/frontend/src/app/tuyen-sinh/phuong-thuc/page.tsx
@@ -4,6 +4,10 @@ import { connection } from "next/server"
 
 import PublicAdmissionMethodsPage from "@/components/public/PublicAdmissionMethodsPage"
 import { serverApi } from "@/lib/api/server"
+import {
+  publicAdmissionsCatalogParams,
+  type PublicAdmissionsSearchParams,
+} from "@/lib/public-admissions/query"
 
 export const metadata: Metadata = {
   title: "Phương thức xét tuyển | QLTS",
@@ -11,13 +15,14 @@ export const metadata: Metadata = {
     "So sánh phương thức xét tuyển, tổ hợp môn và checklist hồ sơ trên cổng tuyển sinh QLTS.",
 }
 
-async function MethodsContent() {
+async function MethodsContent({ searchParams }: { searchParams: PublicAdmissionsSearchParams }) {
   await connection()
 
   let catalog = null
+  const params = publicAdmissionsCatalogParams(await searchParams)
 
   try {
-    catalog = await serverApi.publicAdmissions.getMethodsCatalog()
+    catalog = await serverApi.publicAdmissions.getMethodsCatalog(params)
   } catch (error) {
     console.error("Failed to load public admissions methods catalog", error)
   }
@@ -25,10 +30,14 @@ async function MethodsContent() {
   return <PublicAdmissionMethodsPage catalog={catalog} />
 }
 
-export default function AdmissionsMethodsPage() {
+export default function AdmissionsMethodsPage({
+  searchParams,
+}: {
+  searchParams: PublicAdmissionsSearchParams
+}) {
   return (
     <Suspense fallback={<div className="container mx-auto px-4 py-8 animate-pulse" />}>
-      <MethodsContent />
+      <MethodsContent searchParams={searchParams} />
     </Suspense>
   )
 }

--- a/frontend/src/lib/api/server.ts
+++ b/frontend/src/lib/api/server.ts
@@ -549,21 +549,26 @@ const admissions = {
 // PUBLIC ADMISSIONS API (SERVER-SIDE)
 // ============================================
 
+type PublicAdmissionsCatalogParams = {
+  audience?: string;
+  admission_round_id?: number;
+};
+
 const publicAdmissions = {
-  async getProgramsCatalog(): Promise<PublicAdmissionsProgramsResponse> {
-    return serverFetch<PublicAdmissionsProgramsResponse>('/api/public/admissions/programs');
+  async getProgramsCatalog(params?: PublicAdmissionsCatalogParams): Promise<PublicAdmissionsProgramsResponse> {
+    return serverFetch<PublicAdmissionsProgramsResponse>('/api/public/admissions/programs', { params });
   },
 
-  async getMethodsCatalog(): Promise<PublicAdmissionsMethodsResponse> {
-    return serverFetch<PublicAdmissionsMethodsResponse>('/api/public/admissions/methods');
+  async getMethodsCatalog(params?: PublicAdmissionsCatalogParams): Promise<PublicAdmissionsMethodsResponse> {
+    return serverFetch<PublicAdmissionsMethodsResponse>('/api/public/admissions/methods', { params });
   },
 
-  async getDocumentsCatalog(): Promise<PublicAdmissionsDocumentsResponse> {
-    return serverFetch<PublicAdmissionsDocumentsResponse>('/api/public/admissions/documents');
+  async getDocumentsCatalog(params?: PublicAdmissionsCatalogParams): Promise<PublicAdmissionsDocumentsResponse> {
+    return serverFetch<PublicAdmissionsDocumentsResponse>('/api/public/admissions/documents', { params });
   },
 
-  async getTuitionCatalog(): Promise<PublicAdmissionsTuitionResponse> {
-    return serverFetch<PublicAdmissionsTuitionResponse>('/api/public/admissions/tuition');
+  async getTuitionCatalog(params?: PublicAdmissionsCatalogParams): Promise<PublicAdmissionsTuitionResponse> {
+    return serverFetch<PublicAdmissionsTuitionResponse>('/api/public/admissions/tuition', { params });
   },
 };
 

--- a/frontend/src/lib/public-admissions/query.test.ts
+++ b/frontend/src/lib/public-admissions/query.test.ts
@@ -37,34 +37,41 @@ describe("publicAdmissionsCatalogParams", () => {
   // ============================================================
   // Invalid round ID → strict fail-closed sentinel (post review #2)
   // ============================================================
-  it("invalid non-numeric → sentinel 0 (strict fail-closed)", () => {
+  it("invalid non-numeric → sentinel INT_MAX (strict fail-closed)", () => {
     // Plan v4 locked contract: explicit intent → strict. Even when
     // user-supplied value is syntactically garbage, we preserve the
-    // intent by passing sentinel 0 (non-existent round PK) → BE serves
-    // empty 200.
+    // intent by passing the sentinel — engineered to pass BE Pydantic
+    // ge=1 Query validator AND never match any real OfferingAdmissionRound
+    // PK (autoincrement from 1; realistic growth ~thousands forever).
+    // → BE returns 0 paths → empty 200.
+    //
+    // PR #348 review fix (Finding A): sentinel was 0 originally but
+    // failed BE ge=1 → 422 leaking Pydantic detail. Bumped to PostgreSQL
+    // INTEGER max (2147483647) to satisfy validator + preserve
+    // fail-closed contract end-to-end.
     expect(
       publicAdmissionsCatalogParams({ admission_round_id: "abc" }),
-    ).toEqual({ admission_round_id: 0 })
+    ).toEqual({ admission_round_id: 2147483647 })
   })
 
-  it("invalid zero → sentinel 0", () => {
+  it("invalid zero → sentinel INT_MAX", () => {
     expect(publicAdmissionsCatalogParams({ admission_round_id: "0" })).toEqual({
-      admission_round_id: 0,
+      admission_round_id: 2147483647,
     })
   })
 
-  it("invalid negative → sentinel 0", () => {
+  it("invalid negative → sentinel INT_MAX", () => {
     expect(
       publicAdmissionsCatalogParams({ admission_round_id: "-5" }),
-    ).toEqual({ admission_round_id: 0 })
+    ).toEqual({ admission_round_id: 2147483647 })
   })
 
-  it("invalid decimal → sentinel 0 (parseInt would strip silently)", () => {
+  it("invalid decimal → sentinel INT_MAX (parseInt would strip silently)", () => {
     // parseInt("3.5", 10) === 3 — preserving that as "round 3" would
     // silently corrupt user intent. Match-string guard rejects.
     expect(
       publicAdmissionsCatalogParams({ admission_round_id: "3.5" }),
-    ).toEqual({ admission_round_id: 0 })
+    ).toEqual({ admission_round_id: 2147483647 })
   })
 
   it("empty string → no admission_round_id (not sentinel)", () => {
@@ -77,7 +84,7 @@ describe("publicAdmissionsCatalogParams", () => {
 
   it("invalid alias round → sentinel via same path", () => {
     expect(publicAdmissionsCatalogParams({ round: "garbage" })).toEqual({
-      admission_round_id: 0,
+      admission_round_id: 2147483647,
     })
   })
 

--- a/frontend/src/lib/public-admissions/query.test.ts
+++ b/frontend/src/lib/public-admissions/query.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest"
+
+import { publicAdmissionsCatalogParams } from "./query"
+
+describe("publicAdmissionsCatalogParams", () => {
+  // ============================================================
+  // Canonical admission_round_id parsing
+  // ============================================================
+  it("parses canonical admission_round_id (valid integer)", () => {
+    expect(publicAdmissionsCatalogParams({ admission_round_id: "5" })).toEqual({
+      admission_round_id: 5,
+    })
+  })
+
+  it("ignores admission_round_id when not provided", () => {
+    expect(publicAdmissionsCatalogParams({})).toBeUndefined()
+  })
+
+  // ============================================================
+  // Alias `round` parsing
+  // ============================================================
+  it("falls back to alias `round` when canonical missing", () => {
+    expect(publicAdmissionsCatalogParams({ round: "7" })).toEqual({
+      admission_round_id: 7,
+    })
+  })
+
+  it("canonical admission_round_id wins over alias round when both present", () => {
+    expect(
+      publicAdmissionsCatalogParams({
+        admission_round_id: "5",
+        round: "10",
+      }),
+    ).toEqual({ admission_round_id: 5 })
+  })
+
+  // ============================================================
+  // Invalid round ID → strict fail-closed sentinel (post review #2)
+  // ============================================================
+  it("invalid non-numeric → sentinel 0 (strict fail-closed)", () => {
+    // Plan v4 locked contract: explicit intent → strict. Even when
+    // user-supplied value is syntactically garbage, we preserve the
+    // intent by passing sentinel 0 (non-existent round PK) → BE serves
+    // empty 200.
+    expect(
+      publicAdmissionsCatalogParams({ admission_round_id: "abc" }),
+    ).toEqual({ admission_round_id: 0 })
+  })
+
+  it("invalid zero → sentinel 0", () => {
+    expect(publicAdmissionsCatalogParams({ admission_round_id: "0" })).toEqual({
+      admission_round_id: 0,
+    })
+  })
+
+  it("invalid negative → sentinel 0", () => {
+    expect(
+      publicAdmissionsCatalogParams({ admission_round_id: "-5" }),
+    ).toEqual({ admission_round_id: 0 })
+  })
+
+  it("invalid decimal → sentinel 0 (parseInt would strip silently)", () => {
+    // parseInt("3.5", 10) === 3 — preserving that as "round 3" would
+    // silently corrupt user intent. Match-string guard rejects.
+    expect(
+      publicAdmissionsCatalogParams({ admission_round_id: "3.5" }),
+    ).toEqual({ admission_round_id: 0 })
+  })
+
+  it("empty string → no admission_round_id (not sentinel)", () => {
+    // Empty string ≈ user didn't enter anything → treat as no intent
+    // (omitted) → default eligible-active union, NOT fail-closed sentinel.
+    expect(
+      publicAdmissionsCatalogParams({ admission_round_id: "" }),
+    ).toBeUndefined()
+  })
+
+  it("invalid alias round → sentinel via same path", () => {
+    expect(publicAdmissionsCatalogParams({ round: "garbage" })).toEqual({
+      admission_round_id: 0,
+    })
+  })
+
+  // ============================================================
+  // Audience parsing
+  // ============================================================
+  it("preserves audience param", () => {
+    expect(publicAdmissionsCatalogParams({ audience: "thpt" })).toEqual({
+      audience: "thpt",
+    })
+  })
+
+  it("combines round + audience", () => {
+    expect(
+      publicAdmissionsCatalogParams({
+        admission_round_id: "3",
+        audience: "gdtx",
+      }),
+    ).toEqual({ admission_round_id: 3, audience: "gdtx" })
+  })
+
+  // ============================================================
+  // Array-form searchParams (Next.js may pass arrays)
+  // ============================================================
+  it("takes first value when searchParam is an array", () => {
+    expect(
+      publicAdmissionsCatalogParams({
+        admission_round_id: ["5", "10"],
+      }),
+    ).toEqual({ admission_round_id: 5 })
+  })
+
+  it("returns undefined when only undefined-valued keys present", () => {
+    expect(
+      publicAdmissionsCatalogParams({
+        admission_round_id: undefined,
+        audience: undefined,
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/frontend/src/lib/public-admissions/query.ts
+++ b/frontend/src/lib/public-admissions/query.ts
@@ -1,17 +1,35 @@
 export type PublicAdmissionsSearchParams = Promise<Record<string, string | string[] | undefined>>
 
 /**
- * Sentinel round ID for invalid syntactic input. BE schema treats this as
- * a non-existent round (auto-increment PK starts at 1) → 0 matches 0 paths
- * → eligible offering set is empty → response 200 empty.
+ * Sentinel round ID for invalid syntactic input. Engineered to:
  *
- * Preserves the plan v4 locked contract: explicit `admission_round_id`
- * intent → strict fail-closed, even when the user-supplied value is
- * syntactically invalid (e.g. `?round=abc`). Previously, invalid values
- * silently fell back to "default eligible-active union" which contradicts
- * the explicit-intent semantic.
+ *   1. Pass BE Pydantic Query validator (router declares
+ *      `_ADMISSION_ROUND_QUERY = Query(None, ge=1, ...)` —
+ *      public_admissions.py line 36). Sentinel must satisfy `ge=1` to
+ *      avoid HTTP 422 leaking Pydantic constraint detail to the user.
+ *      Using 0 here would have produced 422 instead of the intended 200
+ *      empty — caught in PR #348 review.
+ *
+ *   2. Never match a real `OfferingAdmissionRound.id`. The PK column is
+ *      `Integer` (PostgreSQL INTEGER, max 2147483647) and autoincrements
+ *      from 1. 2147483647 is the upper bound; realistic round_id growth
+ *      stays in the low thousands forever, so collision is theoretical
+ *      only. If anyone seeds an explicit id=2147483647 row in the future
+ *      this sentinel would unintentionally match — defensive note for
+ *      future migration authors.
+ *
+ *   3. BE path-eligibility filter `AdmissionPath.admission_round_id == X`
+ *      returns 0 rows for the sentinel → eligible offering set is empty
+ *      → snapshot filter returns empty → response 200 empty. Matches the
+ *      plan v4 locked contract: explicit `admission_round_id` intent →
+ *      strict fail-closed, even when the user-supplied value is
+ *      syntactically invalid (e.g. `?round=abc`).
+ *
+ * Anchor test for the end-to-end sentinel contract:
+ *   tests/services/test_phase2_admission_path_quota_integration.py
+ *   ::test_invalid_round_sentinel_returns_empty_200_not_422
  */
-const INVALID_ROUND_SENTINEL = 0
+const INVALID_ROUND_SENTINEL = 2147483647
 
 function firstValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value

--- a/frontend/src/lib/public-admissions/query.ts
+++ b/frontend/src/lib/public-admissions/query.ts
@@ -1,5 +1,18 @@
 export type PublicAdmissionsSearchParams = Promise<Record<string, string | string[] | undefined>>
 
+/**
+ * Sentinel round ID for invalid syntactic input. BE schema treats this as
+ * a non-existent round (auto-increment PK starts at 1) → 0 matches 0 paths
+ * → eligible offering set is empty → response 200 empty.
+ *
+ * Preserves the plan v4 locked contract: explicit `admission_round_id`
+ * intent → strict fail-closed, even when the user-supplied value is
+ * syntactically invalid (e.g. `?round=abc`). Previously, invalid values
+ * silently fell back to "default eligible-active union" which contradicts
+ * the explicit-intent semantic.
+ */
+const INVALID_ROUND_SENTINEL = 0
+
 function firstValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value
 }
@@ -7,14 +20,24 @@ function firstValue(value: string | string[] | undefined): string | undefined {
 export function publicAdmissionsCatalogParams(
   searchParams: Record<string, string | string[] | undefined>,
 ): { admission_round_id?: number; audience?: string } | undefined {
+  // Canonical `admission_round_id` wins over alias `round` when both present.
   const rawRound = firstValue(searchParams.admission_round_id) ?? firstValue(searchParams.round)
-  const roundId = rawRound ? Number.parseInt(rawRound, 10) : undefined
   const audience = firstValue(searchParams.audience)
 
   const params: { admission_round_id?: number; audience?: string } = {}
-  if (roundId !== undefined && Number.isInteger(roundId) && roundId > 0) {
-    params.admission_round_id = roundId
+
+  if (rawRound !== undefined && rawRound !== "") {
+    // Explicit intent — preserve even if invalid. Valid positive integer
+    // passes through; anything else (NaN, ≤0, decimal, negative) lands on
+    // the sentinel → BE returns empty.
+    const roundId = Number.parseInt(rawRound, 10)
+    if (Number.isInteger(roundId) && roundId > 0 && String(roundId) === rawRound.trim()) {
+      params.admission_round_id = roundId
+    } else {
+      params.admission_round_id = INVALID_ROUND_SENTINEL
+    }
   }
+
   if (audience) {
     params.audience = audience
   }

--- a/frontend/src/lib/public-admissions/query.ts
+++ b/frontend/src/lib/public-admissions/query.ts
@@ -1,0 +1,23 @@
+export type PublicAdmissionsSearchParams = Promise<Record<string, string | string[] | undefined>>
+
+function firstValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export function publicAdmissionsCatalogParams(
+  searchParams: Record<string, string | string[] | undefined>,
+): { admission_round_id?: number; audience?: string } | undefined {
+  const rawRound = firstValue(searchParams.admission_round_id) ?? firstValue(searchParams.round)
+  const roundId = rawRound ? Number.parseInt(rawRound, 10) : undefined
+  const audience = firstValue(searchParams.audience)
+
+  const params: { admission_round_id?: number; audience?: string } = {}
+  if (roundId !== undefined && Number.isInteger(roundId) && roundId > 0) {
+    params.admission_round_id = roundId
+  }
+  if (audience) {
+    params.audience = audience
+  }
+
+  return Object.keys(params).length > 0 ? params : undefined
+}


### PR DESCRIPTION
## Summary
- **Snapshot-keyed catalog endpoints (`/programs`, `/tuition`) fail-closed**: only offerings with at least one **public-eligible admission path** for the selected round/audience window surface in the response. Methods + documents catalog already path-keyed from F43 (PR #342) — this PR closes the remaining snapshot-keyed leak.
- `/tuition` now accepts `admission_round_id` + activates `audience` filter (was no-op `del audience # unused` pre-PR).
- Frontend storefront pages thread `searchParams` (`round` / `admission_round_id` / `audience`) into the catalog API client via new helper.

## Scope clarification (per review)
- **BE touched**: `get_public_programs_catalog` + `get_public_tuition_catalog` (snapshot-keyed → now path-eligibility-gated)
- **BE NOT touched**: `get_public_methods_catalog` + `get_public_documents_catalog` — already correctly path-keyed via `_load_public_paths` shipped F43 PR #342
- **FE touched**: all 4 catalog client methods extended to accept `PublicAdmissionsCatalogParams` (round + audience) — uniform API surface even where BE no-op for methods/documents

## Why
Per audit findings 2026-05-28 (P1 storefront fail-open): `_load_public_paths` had F43 round-eligibility (PR #342) but `_load_public_program_snapshot` + `/programs` still appended every offering with published academic_info regardless of path eligibility. `/tuition` had `del audience` + no `admission_round_id` param → showed tuition for offerings with no actionable path.

## Contract LOCKED (plan v4 2026-05-28)
- `admission_round_id` **omitted** → server filters paths theo eligible-active rounds union (`is_active=TRUE AND archived_at IS NULL AND start_date <= today <= end_date`). Match `_load_public_paths` semantic shipped F43 PR #342.
- `admission_round_id` **explicit** → strict fail-closed: inactive/archived/expired → 200 empty.
- **No eligible round** trong toàn hệ thống → 200 empty (KHÔNG 500).

## Changes (9 files, +722 / -44)

**BE (3 files):**
- `app/services/public_admissions_service.py`: `_load_public_program_snapshot` thêm optional `eligible_offering_ids`; new helper `_eligible_offering_ids_from_paths`; `get_public_programs_catalog` + `get_public_tuition_catalog` two-pass (load paths → derive eligible set → re-load snapshot filtered).
- `app/routers/public_admissions.py`: `/tuition` thêm `admission_round_id` query param.
- `tests/services/test_phase2_admission_path_quota_integration.py`: 8 anchor tests (Tier 5 allowlist `backend-test.yml:260`).

**FE (6 files):**
- `frontend/src/lib/api/server.ts`: 4 catalog methods (`programs`/`methods`/`documents`/`tuition`) extend `PublicAdmissionsCatalogParams` (round + audience).
- `frontend/src/lib/public-admissions/query.ts` (NEW): helper parse Next.js `searchParams` → API params (accept `admission_round_id` + alias `round` + `audience`).
- 4 storefront pages (`tuyen-sinh/{ho-so,hoc-phi-hoc-bong,nganh-hoc,phuong-thuc}/page.tsx`): wire helper via searchParams prop.

## Test plan
- [x] 8 storefront contract tests pass local (19 in file, 1 skipped pre-existing)
  - `test_programs_catalog_excludes_offering_without_public_eligible_path` (explicit round narrow)
  - `test_programs_omitted_round_returns_eligible_active_union` ⭐ locked contract anchor
  - `test_programs_no_eligible_round_returns_empty_200` ⭐ 500-prevention anchor
  - `test_tuition_excludes_offering_when_round_filter_set`
  - `test_tuition_omitted_round_matches_programs_union`
  - `test_tuition_audience_filter_now_active` (regression — audience param previously no-op)
  - `test_explicit_archived_round_returns_empty_200`
  - `test_explicit_expired_round_returns_empty_200`
- [x] FE type-check: pass
- [x] `git diff --check`: pass
- [x] Rebase onto post-PR-1 main: zero conflict (PR-3 + PR-1 file sets fully disjoint)
- [ ] CI backend-test.yml Tier 5 green
- [ ] CI Tier 1–4 + frontend + contract-check green

## Context
3rd PR của 5-PR admission hardening sprint (plan v4 2026-05-28). Order: PR-4 → PR-2 → PR-1 → **PR-3** → PR-5.
- PR-4 (#345 admin-rollback lock) — MERGED `af1e6dce`
- PR-2 (#346 round cutoff 410) — MERGED `0bca5407`
- PR-1 (#347 choice engine quota guard) — MERGED `35c90ceb`
- **PR-3 (this) — ships fail-closed storefront**
- PR-5 (token fingerprint + per-token rate) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)