### PR TITLE
hardening(token): fingerprint logs + per-token rate on legacy confirm

### DIFF
--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -2099,6 +2099,15 @@ async def confirm_admission_by_token(
     # action magic-link consume namespace ``mlt:`` so a single token URL
     # used at both endpoints does NOT share quota — each surface gets its
     # own bucket. Fail-closed: Redis breaker → 503; cap exceeded → 429.
+    #
+    # STATUS-CODE NOTE (PR-5): 503/429 here are the semantically-correct
+    # codes — this router raises ``HTTPException`` directly. The v2
+    # magic-link consume path (``services/magic_link_service.py``) currently
+    # returns 400 for the SAME fail-closed conditions because it runs in the
+    # service layer (no ``HTTPException``) and lacks a 429/503 domain
+    # exception. That divergence is intentional and preserved for now;
+    # normalising magic-link to 429/503 is deferred to a dedicated
+    # domain-exception PR (with a magic-link wire test).
     count = await consume_attempt(token, key_namespace="cft:")
     if count is None:
         # Redis down → treat as rate-limited rather than open the door

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -34,6 +34,10 @@ from ..core.deps import (
     get_admission_for_user_read,
 )
 from ..services import admission_service
+from ..services.magic_link_rate_limit import (
+    ATTEMPTS_CAP_PER_WINDOW,
+    consume_attempt,
+)
 from ..services.notification_dispatcher import safe_dispatch, rooms_for_admission, rooms_for_lead
 from ..services.user_service import emit_data_updated as _emit_realtime_update
 from ..core.events import SystemEvents
@@ -45,6 +49,7 @@ from ..utils.exceptions import (
     ConflictError,
     ValidationError,
 )
+from ..utils.token_logging import token_fingerprint
 from ..core.constants import UserRole
 from ..utils.csv_helpers import sanitize_csv_row
 
@@ -2088,6 +2093,35 @@ async def confirm_admission_by_token(
     db: AsyncSession = Depends(database.get_db),
 ):
     """Confirm admission via magic link + CCCD verification."""
+    # PR-5 (2026-05-28): per-token Redis rate limit (5 attempts / 60s).
+    # Defence-in-depth alongside the existing global ``DATA_WRITE`` cap and
+    # per-IP 100/day cap. Namespace ``cft:`` is distinct from the multi-
+    # action magic-link consume namespace ``mlt:`` so a single token URL
+    # used at both endpoints does NOT share quota — each surface gets its
+    # own bucket. Fail-closed: Redis breaker → 503; cap exceeded → 429.
+    count = await consume_attempt(token, key_namespace="cft:")
+    if count is None:
+        # Redis down → treat as rate-limited rather than open the door
+        # (same defensive stance as the multi-action magic-link consume).
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Hệ thống đang quá tải, vui lòng thử lại sau ít phút.",
+        )
+    if count > ATTEMPTS_CAP_PER_WINDOW:
+        log.warning(
+            "Legacy confirm blocked: per-token rate limit exceeded",
+            token_fp=token_fingerprint(token),
+            count=count,
+            cap=ATTEMPTS_CAP_PER_WINDOW,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                f"Đã thử quá {ATTEMPTS_CAP_PER_WINDOW} lần trong 60 giây. "
+                "Vui lòng đợi và thử lại."
+            ),
+        )
+
     try:
         # 1. DELEGATE to Service
         profile, callback = await admission_service.verify_and_confirm(

--- a/Backend_FastAPI/app/routers/admissions_magic_link.py
+++ b/Backend_FastAPI/app/routers/admissions_magic_link.py
@@ -37,6 +37,7 @@ from ..services.notification_dispatcher import (
     safe_dispatch,
 )
 from ..utils.exceptions import BadRequest, ResourceNotFoundError
+from ..utils.token_logging import token_fingerprint
 
 log = structlog.get_logger(__name__)
 
@@ -156,7 +157,7 @@ async def consume_magic_link_token(
                 log.error(
                     "Magic-link post-commit callback failed (best-effort)",
                     error=str(cb_err),
-                    token_prefix=token[:8],
+                    token_fp=token_fingerprint(token),
                     action=action.value,
                 )
         raise HTTPException(

--- a/Backend_FastAPI/app/services/magic_link_rate_limit.py
+++ b/Backend_FastAPI/app/services/magic_link_rate_limit.py
@@ -24,11 +24,11 @@ reasoning as the resend cap.
 """
 from __future__ import annotations
 
-import hashlib
 import structlog
 from typing import Final, Optional
 
 from ..database import safe_redis_expire, safe_redis_incr
+from ..utils.token_logging import token_fingerprint
 
 log = structlog.get_logger(__name__)
 
@@ -37,22 +37,36 @@ ATTEMPTS_CAP_PER_WINDOW: Final[int] = 5
 WINDOW_SECONDS: Final[int] = 60
 
 
-def _key(token_value: str) -> str:
-    # Token is 256-bit URL-safe random — unguessable on the wire, but the
-    # plaintext form can still leak via Redis operational surfaces:
-    # ``redis-cli MONITOR`` (debug streaming), ``SLOWLOG`` snapshots, and
-    # RDB/AOF dumps all record the raw command incl. key name. Hashing
-    # truncates that exposure: the leak becomes a one-way hash, useless
-    # for impersonating the magic link inside the 60s rate window.
-    # SHA-256 hex truncated to 16 chars (64 bits) is plenty for collision
-    # resistance — Redis namespace ``mlt:`` already scopes per use case
-    # and the cardinality at any moment is bounded by live tokens.
-    h = hashlib.sha256(token_value.encode()).hexdigest()[:16]
-    return f"mlt:{h}"
+def _key(token_value: str, key_namespace: str = "mlt:") -> str:
+    """Build a hashed Redis key for ``token_value`` under ``key_namespace``.
+
+    Token is 256-bit URL-safe random — unguessable on the wire, but the
+    plaintext form can still leak via Redis operational surfaces:
+    ``redis-cli MONITOR`` (debug streaming), ``SLOWLOG`` snapshots, and
+    RDB/AOF dumps all record the raw command incl. key name. Hashing
+    truncates that exposure: the leak becomes a one-way hash, useless
+    for impersonating the magic link inside the 60s rate window.
+
+    Namespace strategy (PR-5 2026-05-28):
+      - ``mlt:`` — multi-action magic-link consume (default, original)
+      - ``cft:`` — legacy ``/api/admissions/confirm/{token}`` POST
+    Namespaces are mutually exclusive so a single token used across both
+    endpoints does NOT share quota — each surface gets its own 5/60s cap.
+    """
+    return f"{key_namespace}{token_fingerprint(token_value)}"
 
 
-async def consume_attempt(token_value: str) -> Optional[int]:
+async def consume_attempt(
+    token_value: str,
+    key_namespace: str = "mlt:",
+) -> Optional[int]:
     """Atomically count + consume one attempt slot for ``token_value``.
+
+    Args:
+        token_value: raw token from URL path / query.
+        key_namespace: Redis key prefix to scope the counter. Default
+            ``"mlt:"`` keeps the original magic-link behaviour. Pass
+            ``"cft:"`` for the legacy confirm endpoint (PR-5).
 
     Returns:
         - Post-increment count when Redis is healthy. Caller checks
@@ -61,12 +75,13 @@ async def consume_attempt(token_value: str) -> Optional[int]:
         - ``None`` when the Redis breaker is open or EXPIRE arms fail.
           Caller MUST fail closed (refuse the request).
     """
-    key = _key(token_value)
+    key = _key(token_value, key_namespace=key_namespace)
     count = await safe_redis_incr(key)
     if count is None:
         log.warning(
             "Magic-link rate limit check failed: Redis INCR breaker open — failing closed",
-            token_prefix=token_value[:8],
+            token_fp=token_fingerprint(token_value),
+            key_namespace=key_namespace,
         )
         return None
 
@@ -76,7 +91,8 @@ async def consume_attempt(token_value: str) -> Optional[int]:
     if not expire_ok:
         log.warning(
             "Magic-link rate limit check failed: Redis EXPIRE returned falsy — failing closed",
-            token_prefix=token_value[:8],
+            token_fp=token_fingerprint(token_value),
+            key_namespace=key_namespace,
             count_after_incr=count,
         )
         return None

--- a/Backend_FastAPI/app/services/magic_link_service.py
+++ b/Backend_FastAPI/app/services/magic_link_service.py
@@ -33,6 +33,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models
 from ..config import settings
+from ..utils.token_logging import token_fingerprint
 from ..utils.exceptions import (
     BadRequest,
     ResourceNotFoundError,
@@ -85,7 +86,7 @@ async def consume_token(
         # Same defensive stance as resend cap (memory `zalo-bot-audit-gap`).
         log.warning(
             "Magic-link consume blocked: rate-limit service unavailable",
-            token_prefix=token_value[:8],
+            token_fp=token_fingerprint(token_value),
             action=action,
         )
         raise BadRequest(
@@ -94,7 +95,7 @@ async def consume_token(
     if count > ATTEMPTS_CAP_PER_WINDOW:
         log.warning(
             "Magic-link consume blocked: per-token rate limit exceeded",
-            token_prefix=token_value[:8],
+            token_fp=token_fingerprint(token_value),
             action=action,
             count=count,
             cap=ATTEMPTS_CAP_PER_WINDOW,
@@ -122,7 +123,7 @@ async def consume_token(
     if token_obj.action_type != action:
         log.warning(
             "Magic-link action mismatch",
-            token_prefix=token_value[:8],
+            token_fp=token_fingerprint(token_value),
             url_action=action,
             token_action=token_obj.action_type,
         )

--- a/Backend_FastAPI/app/services/magic_link_service.py
+++ b/Backend_FastAPI/app/services/magic_link_service.py
@@ -80,6 +80,23 @@ async def consume_token(
             the right status.
     """
     # Step 1 — Per-token rate limit. Fail-closed when Redis breaker open.
+    #
+    # STATUS-CODE CONTRACT (PR-5 2026-05-28): the two fail-closed branches
+    # below raise ``BadRequest`` → HTTP 400. This is INTENTIONALLY different
+    # from the legacy router endpoint ``POST /api/admissions/confirm/{token}``
+    # (``routers/admissions.py::confirm_admission_by_token``) which returns
+    # 503 (Redis breaker) / 429 (cap exceeded). The router can raise
+    # ``HTTPException`` directly with the semantically-correct status; this
+    # service-layer path cannot (services must never raise ``HTTPException``)
+    # and there is no domain exception mapping to 429/503 yet.
+    #
+    # 400 is the PRESERVED PROD CONTRACT for this already-deployed endpoint,
+    # NOT a claim that 400 is the correct HTTP semantics — it is not (the
+    # client request is fine; the server is rate-limiting / temporarily
+    # unavailable). Normalising magic-link to 429/503 needs new 429/503
+    # domain exceptions + a wire test and is deferred to a dedicated
+    # domain-exception PR so this hardening PR does not change a deployed
+    # contract. See the matching note in confirm_admission_by_token.
     count = await consume_attempt(token_value)
     if count is None:
         # Redis down; treat as rate-limited rather than open the door.

--- a/Backend_FastAPI/app/services/user_service.py
+++ b/Backend_FastAPI/app/services/user_service.py
@@ -50,6 +50,7 @@ from ..security.hibp import check_password_breached
 from ..core.events import dispatcher, TransportEvents
 from ..socket_metrics import socket_emit_failures_total, socket_events_emitted_total
 from ..utils import file_helpers
+from ..utils.token_logging import token_fingerprint
 from . import activity_service
 
 # ✅ SỬA LỖI: Chuyển log sang đồng bộ (tương thích với main.py V5)
@@ -1091,13 +1092,13 @@ async def reset_password(
                       error=str(redis_err))
             raise InvalidToken(detail="Unable to process reset. Please try again.")
         if not claimed:
-            log.warning("Reset token reuse attempt blocked (SET NX)", token_prefix=token[:10])
+            log.warning("Reset token reuse attempt blocked (SET NX)", token_fp=token_fingerprint(token))
             raise InvalidToken(detail="This reset link has already been used")
 
         token_data = verify_password_reset_token(token)
         if not token_data:
             log.warning(
-                "Invalid reset token attempt", token_prefix=token[:10]
+                "Invalid reset token attempt", token_fp=token_fingerprint(token)
             )
             raise InvalidToken()
 

--- a/Backend_FastAPI/app/socket_manager.py
+++ b/Backend_FastAPI/app/socket_manager.py
@@ -151,8 +151,13 @@ async def check_rate_limit(client_ip: str) -> bool:
 
 
 # === ✅ CẢI TIẾN: Vấn đề #3 - Sanitize Token Log ===
+# PR-5 (2026-05-28): token[:8] leaked partial entropy into logs. Now use
+# SHA-256 fingerprint (one-way, stable for log correlation).
+from app.utils.token_logging import token_fingerprint  # noqa: E402
+
+
 def sanitize_token(token: str) -> str:
-    return f"{token[:8]}..." if token and len(token) > 8 else "None"
+    return token_fingerprint(token) if token else "None"
 
 
 # === ✅ SECURITY FIX: Parse cookies from Socket.io environ ===

--- a/Backend_FastAPI/app/socket_manager.py
+++ b/Backend_FastAPI/app/socket_manager.py
@@ -8,6 +8,7 @@ from . import models, security
 from .core.constants import UserRole
 from .config import settings
 from .database import AsyncSessionLocal, redis_client, safe_redis_get
+from .utils.token_logging import token_fingerprint
 # NOTE: user_service import moved inside function to avoid circular import
 from .socket_metrics import track_event_latency  # ✅ Thêm latency tracker
 from .socket_metrics import (
@@ -153,9 +154,8 @@ async def check_rate_limit(client_ip: str) -> bool:
 # === ✅ CẢI TIẾN: Vấn đề #3 - Sanitize Token Log ===
 # PR-5 (2026-05-28): token[:8] leaked partial entropy into logs. Now use
 # SHA-256 fingerprint (one-way, stable for log correlation).
-from app.utils.token_logging import token_fingerprint  # noqa: E402
-
-
+# token_fingerprint is imported at the module top (relative import) —
+# token_logging only depends on hashlib so there is no circular-import risk.
 def sanitize_token(token: str) -> str:
     return token_fingerprint(token) if token else "None"
 

--- a/Backend_FastAPI/app/utils/token_logging.py
+++ b/Backend_FastAPI/app/utils/token_logging.py
@@ -1,0 +1,31 @@
+"""Log-safe token identifier helper.
+
+PR-5 (2026-05-28) hardening: replaces the legacy ``token[:8]`` /
+``token[:10]`` substring patterns sprinkled across magic-link + confirm
++ socket logging. Substring leaks partial token entropy into structured
+log streams; SHA-256 fingerprint truncated to 16 hex characters is one-way
+(no entropy leak) but still stable per token value so log correlation /
+incident triage continues to work.
+
+Window choice: 16 hex characters = 64 bits, same width as the Redis key
+hash used by ``magic_link_rate_limit._key``. Collision probability at the
+scale of QLTS token cardinality (live tokens bounded by active
+candidates) is negligible.
+
+Stable across processes — search by fingerprint to follow a single token
+across services without ever recording the raw value.
+"""
+from __future__ import annotations
+
+import hashlib
+
+
+def token_fingerprint(token_value: str | None) -> str:
+    """Return a log-safe identifier for ``token_value``.
+
+    Returns ``"none"`` for empty / falsy input so callers do not need a
+    null check before emitting structured fields.
+    """
+    if not token_value:
+        return "none"
+    return hashlib.sha256(token_value.encode()).hexdigest()[:16]

--- a/Backend_FastAPI/tests/api/test_magic_link_3_actions_wire.py
+++ b/Backend_FastAPI/tests/api/test_magic_link_3_actions_wire.py
@@ -41,6 +41,10 @@ from sqlalchemy import select
 from app import models
 from app.database import AsyncSessionLocal
 from app.services import admission_service
+from tests.fixtures.builders import (
+    SUBMITTABLE_PERMANENT_ADDRESS,
+    ensure_submittable_ward,
+)
 
 
 log = logging.getLogger(__name__)
@@ -66,13 +70,53 @@ async def multi_nv_seed(admin_user_in_db, seed_lead_dependencies):
 
     async with AsyncSessionLocal() as s:
         async with s.begin():
-            offering_type = models.ConfigOfferingType(
-                code=f"mlw_{suffix}",
-                name=f"MagicLink wire {suffix}",
-                is_active=True,
-            )
-            s.add(offering_type)
-            await s.flush()
+            # PR-5 (2026-05-29): GDNN-valid offering type + degree level so
+            # Phase E.4 ``derive_target_level_and_type`` resolves
+            # (target_level, admission_type) from the chain. The legacy
+            # ``mlw_<suffix>`` offering-type code fell OUTSIDE the GDNN scope
+            # ({chinh_quy, lien_thong, ...}) and MAJOR_1 only sets the legacy
+            # ``degree_level`` text column (no ``degree_level_id`` FK), so the
+            # legacy single-NV submit raised CONFIG_GAP_TARGET_LEVEL — the
+            # pre-existing test-debt tracked by #337. get-or-create guards the
+            # UNIQUE(code) columns in case a future conftest seeds these rows.
+            offering_type = (
+                await s.execute(
+                    select(models.ConfigOfferingType).where(
+                        models.ConfigOfferingType.code == "chinh_quy"
+                    )
+                )
+            ).scalar_one_or_none()
+            if offering_type is None:
+                offering_type = models.ConfigOfferingType(
+                    code="chinh_quy",
+                    name=f"Chính quy {suffix}",
+                    is_active=True,
+                )
+                s.add(offering_type)
+                await s.flush()
+
+            degree_level = (
+                await s.execute(
+                    select(models.ConfigDegreeLevel).where(
+                        models.ConfigDegreeLevel.code == "cao_dang"
+                    )
+                )
+            ).scalar_one_or_none()
+            if degree_level is None:
+                degree_level = models.ConfigDegreeLevel(
+                    code="cao_dang",
+                    name=f"Cao đẳng {suffix}",
+                    display_order=2,
+                    is_active=True,
+                )
+                s.add(degree_level)
+                await s.flush()
+
+            # MajorProgram.degree_level_ref (FK) is what derive reads — the
+            # shared MAJOR_1 fixture only populates the legacy text column.
+            major = await s.get(models.MajorProgram, program_id)
+            if major is not None and major.degree_level_id is None:
+                major.degree_level_id = degree_level.id
 
             offering = models.ProgramOffering(
                 offering_type=f"mlw_{suffix}",
@@ -106,6 +150,44 @@ async def multi_nv_seed(admin_user_in_db, seed_lead_dependencies):
                 is_active=True,
             )
             s.add(criteria)
+            await s.flush()
+
+            # Junction row so the legacy (uses_choice_engine=False) submit path
+            # can resolve target level via the offering_admission_config chain.
+            # Test #6 sets profile.offering_admission_config_id to this id.
+            offering_admission_config = models.OfferingAdmissionConfig(
+                academic_info_id=academic_info.id,
+                criteria_id=criteria.id,
+                is_active=True,
+            )
+            s.add(offering_admission_config)
+            await s.flush()
+
+            # Phase E.4 KV catalog: a VnSchool + KV assignment so the engine's
+            # LICH_SU_THPT branch (cultural=graduated_thpt + target=cao_dang)
+            # resolves the academic_history THPT entry (level='THPT' +
+            # school_id) to a KV code. Without it submit aggregates
+            # KV_UNRESOLVED (insufficient_data) into validation_errors and
+            # stays 'draft' — the second layer of test-debt #337.
+            school = models.VnSchool(
+                moet_school_code=f"S{suffix}",
+                moet_province_code="001",
+                name=f"THPT Test {suffix}",
+                province="Hà Nội",
+                district="Ba Đình",
+                level="THPT",
+            )
+            s.add(school)
+            await s.flush()
+            s.add(
+                models.VnSchoolKvAssignment(
+                    school_id=school.id,
+                    kv_code="KV3",
+                    effective_from_year=2020,
+                    effective_to_year=2024,
+                    source="manual_admin",
+                )
+            )
             await s.flush()
 
             round_obj = models.OfferingAdmissionRound(
@@ -148,6 +230,8 @@ async def multi_nv_seed(admin_user_in_db, seed_lead_dependencies):
                 "academic_year": 2026,
                 "unit_id": unit_id,
                 "admin_user_id": admin_user_in_db["id"],
+                "offering_admission_config_id": offering_admission_config.id,
+                "school_id": school.id,
             }
 
 
@@ -443,8 +527,18 @@ async def test_officer_submit_returns_tuple_with_callback_post_option_b(
     exercise the (result, callback) unpack contract without seeding a
     full subject-score chain. Item A multi-NV guard is bypassed by
     ``uses_choice_engine=False`` (legacy single-NV path).
+
+    Phase E.4 note (#337 fix, 2026-05-29): the legacy path resolves the
+    target level from ``offering_admission_config_id`` → academic_info →
+    offering chain (multi_nv_seed now seeds a GDNN-valid config), and
+    ``cultural_education_level='graduated_thpt'`` satisfies CĐ-chính-quy
+    eligibility. Without these the submit raised CONFIG_GAP_TARGET_LEVEL.
     """
     ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+
+    # Gap #3 submit gate: seed a current-era WARD so permanent_commune_code
+    # validates. Helper opens its own session + commits (idempotent per test).
+    await ensure_submittable_ward()
 
     # Set lead.gpa so the gpa_only validation branch passes.
     async with AsyncSessionLocal() as s:
@@ -456,6 +550,18 @@ async def test_officer_submit_returns_tuple_with_callback_post_option_b(
                 lead_id=multi_nv_seed["lead_id"],
                 citizen_id=f"7{ts:08d}6"[:12],
                 status="draft",
+                # Gap #3: applicant identity + permanent address live on the
+                # profile (submit reads profile fields, NOT the lead).
+                full_name="Officer Submit Candidate",
+                phone="0901234567",
+                **SUBMITTABLE_PERMANENT_ADDRESS,
+                # Legacy single-NV path resolves target level via this config.
+                offering_admission_config_id=multi_nv_seed[
+                    "offering_admission_config_id"
+                ],
+                # CĐ chính quy eligibility: cultural ∈ THPT_KNOWLEDGE.
+                cultural_education_level="graduated_thpt",
+                vocational_qualification="none",
                 applied_rules={
                     "admission_path_id": multi_nv_seed["path_id"],
                     "method_type": "gpa_only",  # ← skip subject scoring
@@ -468,7 +574,19 @@ async def test_officer_submit_returns_tuple_with_callback_post_option_b(
                 version=1,
                 uses_choice_engine=False,  # legacy single-NV — bypass Item A guard
                 family_info=[{"relationship": "Cha", "full_name": "X", "phone": "0901234567"}],
-                academic_history=[{"school_name": "THPT X", "year_from": 2020, "year_to": 2024}],
+                # THPT entry with school_id + level so the KV engine resolves
+                # via vn_school_kv_assignment (seeded in multi_nv_seed). Years
+                # match the assignment's effective_from/to (2020-2024).
+                academic_history=[{
+                    "school_name": "THPT Test",
+                    "year_from": 2020,
+                    "year_to": 2024,
+                    "gpa": 8.0,
+                    "graduation_type": "THPT",
+                    "level": "THPT",
+                    "grade_to": 12,
+                    "school_id": multi_nv_seed["school_id"],
+                }],
             )
             s.add(profile)
             await s.flush()

--- a/Backend_FastAPI/tests/api/test_phase3_pr3e_magic_link.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3e_magic_link.py
@@ -618,3 +618,145 @@ async def test_magic_link_submit_410_when_round_closed(
         assert token.confirmed_at is None, (
             "Token must NOT be marked consumed when cutoff blocks submit"
         )
+
+
+# ============================================================================
+# PR-5 (2026-05-28) — Legacy /api/admissions/confirm/{token} per-token rate
+# limit anchors. consume_attempt(key_namespace='cft:') wired BEFORE the
+# verify_and_confirm service call. Fail-closed contract:
+#   - Redis breaker (consume_attempt returns None) → HTTP 503
+#   - count > ATTEMPTS_CAP_PER_WINDOW → HTTP 429
+#   - count within cap → proceeds to verify_and_confirm (404 here because
+#     no real token seeded — but proves rate gate was passed)
+# Each test patches consume_attempt at the routers.admissions import site
+# so we control the return value without standing up a Redis stub.
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_legacy_confirm_returns_503_when_redis_breaker_open(
+    client: AsyncClient,
+):
+    """⭐ PR-5: Redis breaker open (consume_attempt → None) MUST 503
+    BEFORE verify_and_confirm runs. Anchor against accidental
+    fail-open if someone treats ``None`` as ``0``.
+    """
+    with patch(
+        "app.routers.admissions.consume_attempt",
+        new=AsyncMock(return_value=None),
+    ), patch(
+        "app.routers.admissions.admission_service.verify_and_confirm",
+        new=AsyncMock(),
+    ) as fake_verify:
+        response = await client.post(
+            "/api/admissions/confirm/any-token-value-here",
+            json={"last_digits_citizen_id": "1234"},
+        )
+
+    assert response.status_code == 503, (
+        f"Redis breaker MUST 503 fail-closed; got {response.status_code}: "
+        f"{response.text[:200]}"
+    )
+    fake_verify.assert_not_called(), (
+        "verify_and_confirm MUST NOT be invoked when rate-limit pre-check "
+        "fails — would leak DB cycles + advance CCCD cooldown ladder."
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_confirm_returns_429_when_count_exceeds_cap(
+    client: AsyncClient,
+):
+    """⭐ PR-5: count > ATTEMPTS_CAP_PER_WINDOW MUST 429 with Vietnamese
+    error copy. verify_and_confirm MUST NOT be invoked.
+    """
+    from app.services.magic_link_rate_limit import ATTEMPTS_CAP_PER_WINDOW
+
+    with patch(
+        "app.routers.admissions.consume_attempt",
+        new=AsyncMock(return_value=ATTEMPTS_CAP_PER_WINDOW + 1),
+    ), patch(
+        "app.routers.admissions.admission_service.verify_and_confirm",
+        new=AsyncMock(),
+    ) as fake_verify:
+        response = await client.post(
+            "/api/admissions/confirm/spammed-token",
+            json={"last_digits_citizen_id": "1234"},
+        )
+
+    assert response.status_code == 429, (
+        f"Cap exceed MUST 429; got {response.status_code}: {response.text[:200]}"
+    )
+    body = response.json()
+    detail = (body.get("detail") or "")
+    assert "60 giây" in detail or "lần" in detail, (
+        f"429 detail should mention the 60s window or attempt count; got: {body}"
+    )
+    fake_verify.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_legacy_confirm_within_cap_proceeds_to_service(
+    client: AsyncClient,
+):
+    """⭐ PR-5: count within cap MUST NOT short-circuit; rate gate
+    passes through and verify_and_confirm is invoked. Token here is
+    bogus so the service raises ResourceNotFoundError → router maps
+    to 404. That 404 (NOT 429/503) is the proof.
+    """
+    from app.utils.exceptions import ResourceNotFoundError
+
+    with patch(
+        "app.routers.admissions.consume_attempt",
+        new=AsyncMock(return_value=1),
+    ), patch(
+        "app.routers.admissions.admission_service.verify_and_confirm",
+        new=AsyncMock(side_effect=ResourceNotFoundError("Token not found")),
+    ) as fake_verify:
+        response = await client.post(
+            "/api/admissions/confirm/within-cap-token",
+            json={"last_digits_citizen_id": "1234"},
+        )
+
+    assert response.status_code == 404, (
+        f"Within-cap MUST forward to service (404 from stub); got "
+        f"{response.status_code}: {response.text[:200]}"
+    )
+    fake_verify.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_legacy_confirm_uses_cft_namespace_not_mlt(
+    client: AsyncClient,
+):
+    """⭐ PR-5: legacy /confirm/{token} MUST consume with namespace
+    'cft:' so it shares NO quota with the multi-action magic-link
+    consume (namespace 'mlt:'). Captures the kwarg the router passed.
+    """
+    captured_kwargs: dict = {}
+
+    async def capture(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return 1
+
+    from app.utils.exceptions import ResourceNotFoundError
+
+    with patch(
+        "app.routers.admissions.consume_attempt",
+        new=AsyncMock(side_effect=capture),
+    ), patch(
+        "app.routers.admissions.admission_service.verify_and_confirm",
+        new=AsyncMock(side_effect=ResourceNotFoundError("stub")),
+    ):
+        # We don't care about the 404 after rate-check; we just want to
+        # capture the consume_attempt call kwargs.
+        await client.post(
+            "/api/admissions/confirm/ns-anchor",
+            json={"last_digits_citizen_id": "1234"},
+        )
+
+    assert captured_kwargs.get("key_namespace") == "cft:", (
+        f"Legacy /confirm MUST consume_attempt(key_namespace='cft:'); "
+        f"got kwargs={captured_kwargs}. Wrong namespace = shared quota "
+        f"with magic-link multi-action = defeats defence-in-depth."
+    )

--- a/Backend_FastAPI/tests/unit/test_magic_link_rate_limit_key_hashing.py
+++ b/Backend_FastAPI/tests/unit/test_magic_link_rate_limit_key_hashing.py
@@ -24,11 +24,13 @@ bug) trips (b).
 """
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from app.services import magic_link_rate_limit
+from app.utils.token_logging import token_fingerprint
 
 
 # ---------------------------------------------------------------------
@@ -132,3 +134,159 @@ async def test_consume_attempt_fails_closed_when_expire_arm_fails() -> None:
         result = await magic_link_rate_limit.consume_attempt("expire-fail-token")
 
     assert result is None
+
+
+# ---------------------------------------------------------------------
+# PR-5 (2026-05-28) — token_fingerprint helper + namespace isolation
+# ---------------------------------------------------------------------
+
+
+def test_token_fingerprint_deterministic() -> None:
+    """Same token MUST produce same fingerprint across calls so log
+    correlation by token_fp works across services + retries."""
+    token = "PR-5-determinism-anchor"
+    assert token_fingerprint(token) == token_fingerprint(token)
+
+
+def test_token_fingerprint_no_plaintext_leak() -> None:
+    """A leaked log line must NOT reveal the raw token. Fingerprint is
+    one-way hash truncated to 16 hex chars."""
+    token = "this-is-a-256-bit-magic-link-token-leak-guard"
+    fp = token_fingerprint(token)
+
+    assert token not in fp, (
+        f"token_fingerprint leaked the plaintext token into the output. "
+        f"fp={fp!r} contains token={token!r}"
+    )
+    assert len(fp) == 16, (
+        f"token_fingerprint output must be 16-char hex; got len={len(fp)} value={fp!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in fp), (
+        f"token_fingerprint output must be lowercase hex; got {fp!r}"
+    )
+
+
+def test_token_fingerprint_handles_empty_or_none() -> None:
+    """Helper must tolerate falsy input so call sites can skip null
+    guards before emitting structured fields."""
+    assert token_fingerprint("") == "none"
+    assert token_fingerprint(None) == "none"
+
+
+def test_key_namespace_isolated_mlt_vs_cft() -> None:
+    """⭐ PR-5: a single token used at BOTH endpoints (multi-action
+    magic-link + legacy confirm) MUST land on DIFFERENT Redis buckets.
+
+    Otherwise a spammer hitting one surface would lock the candidate
+    out of the other — defeats the defence-in-depth intent.
+    """
+    token = "shared-token-across-endpoints"
+    mlt_key = magic_link_rate_limit._key(token, key_namespace="mlt:")
+    cft_key = magic_link_rate_limit._key(token, key_namespace="cft:")
+
+    assert mlt_key != cft_key, (
+        f"Namespace isolation broken — same token landed on the same "
+        f"Redis key across mlt: and cft: buckets. "
+        f"mlt_key={mlt_key!r} cft_key={cft_key!r}"
+    )
+    assert mlt_key.startswith("mlt:")
+    assert cft_key.startswith("cft:")
+    # The hash suffix MUST be identical (deterministic) so the only
+    # difference is the namespace prefix.
+    assert mlt_key.split(":", 1)[1] == cft_key.split(":", 1)[1]
+
+
+def test_key_default_namespace_stays_mlt() -> None:
+    """Backward-compat anchor: existing magic-link callers do NOT pass
+    key_namespace; default MUST remain 'mlt:' so legacy buckets are
+    preserved."""
+    assert magic_link_rate_limit._key("legacy-token").startswith("mlt:")
+
+
+@pytest.mark.asyncio
+async def test_consume_attempt_uses_namespace_in_redis_key() -> None:
+    """consume_attempt MUST forward key_namespace into the Redis key
+    name so the legacy /confirm endpoint and multi-action magic-link
+    track separate buckets at the Redis layer (not just helper layer).
+    """
+    incr_calls: list[str] = []
+
+    async def fake_incr(key: str) -> int:
+        incr_calls.append(key)
+        return 1
+
+    with patch(
+        "app.services.magic_link_rate_limit.safe_redis_incr",
+        new=AsyncMock(side_effect=fake_incr),
+    ), patch(
+        "app.services.magic_link_rate_limit.safe_redis_expire",
+        new=AsyncMock(return_value=True),
+    ):
+        await magic_link_rate_limit.consume_attempt(
+            "ns-anchor-token", key_namespace="cft:"
+        )
+
+    assert len(incr_calls) == 1
+    assert incr_calls[0].startswith("cft:"), (
+        f"consume_attempt(key_namespace='cft:') wrote a Redis key without "
+        f"the cft: prefix. Actual key={incr_calls[0]!r}. The legacy "
+        f"confirm endpoint would silently share quota with magic-link."
+    )
+
+
+# ---------------------------------------------------------------------
+# PR-5 — static-source scan: no plaintext token prefix slices remain
+# ---------------------------------------------------------------------
+
+
+def test_no_residual_token_prefix_in_app_source() -> None:
+    """⭐ Anchor against regression: scan ``app/`` for the legacy
+    ``token[:8]`` / ``token[:10]`` / ``token_value[:8]`` patterns + the
+    ``token_prefix`` log field. PR-5 swept all real call sites; if a
+    future change re-introduces one, this test fails immediately.
+
+    Allowlist:
+      - ``app/utils/token_logging.py`` docstring references the legacy
+        pattern as historical context.
+      - ``app/socket_manager.py`` contains a comment referencing the
+        pattern in the PR-5 fix note.
+
+    Both files are inspected and only the docstring/comment lines may
+    contain the pattern; any source line elsewhere fails the test.
+    """
+    app_dir = Path(__file__).resolve().parents[2] / "app"
+    assert app_dir.is_dir(), f"Could not locate app/ at {app_dir}"
+
+    patterns = ("token[:8]", "token_value[:8]", "token[:10]", "token_prefix=")
+    allow_files = {
+        app_dir / "utils" / "token_logging.py",
+        app_dir / "socket_manager.py",
+    }
+
+    offenders: list[str] = []
+    for path in app_dir.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            stripped = line.strip()
+            if not any(p in stripped for p in patterns):
+                continue
+            # Comments + docstring lines are allowed in the allowlist
+            # files only.
+            if path in allow_files and (
+                stripped.startswith("#")
+                or stripped.startswith('"""')
+                or stripped.startswith("``")
+                or "``" in stripped
+            ):
+                continue
+            offenders.append(f"{path.relative_to(app_dir.parent)}:{lineno}: {stripped}")
+
+    assert not offenders, (
+        "Found residual plaintext token prefix usages in app/ — PR-5 "
+        "sweep regressed. Replace with token_fingerprint(token) and "
+        "rename the log field to token_fp.\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Tóm tắt

Hardening bảo mật cho luồng magic-link / confirm + xử lý test-debt liên quan.

### Commit 1 — `7e647f52` (logging + rate limit)
- **`token_logging.py` (mới)**: `token_fingerprint()` — SHA-256 → 16 hex (one-way), thay pattern `token[:8]`/`token[:10]` substring (rò rỉ entropy) ở magic-link, confirm, socket, password-reset.
- **Per-token Redis rate limit (5/60s)** trên legacy `POST /api/admissions/confirm/{token}` qua `consume_attempt(key_namespace="cft:")`, tách bucket khỏi magic-link (`mlt:`). Fail-closed: breaker → 503, vượt cap → 429.
- Generalize `_key()`/`consume_attempt()` nhận `key_namespace` (default `mlt:`, tương thích ngược). Hash suffix `mlt:` giữ nguyên → bucket in-flight không reset.

### Commit 2 — `ae964414` (review nits + test-debt #337)
- **Status-code (Option C)**: document lệch 503/429 (confirm router, đúng ngữ nghĩa) vs 400 (magic-link service, ràng buộc layer) là **cố ý**; normalize lên 429/503 defer sang PR domain-exception riêng (preserve deployed contract).
- **`socket_manager.py`**: đưa `token_fingerprint` import lên đầu file (relative, bỏ `noqa E402`).
- **Fix #337 test-debt** (`test_magic_link_3_actions_wire.py` only): `multi_nv_seed` seed chain GDNN-valid (ConfigDegreeLevel/OfferingType + OfferingAdmissionConfig + VnSchool/VnSchoolKvAssignment) + profile identity/address/KV → `test_officer_submit_..._post_option_b` đạt tới (result, callback) contract thay vì `CONFIG_GAP_TARGET_LEVEL`/`KV_UNRESOLVED`. Không đổi production logic.

## Test

Full PR-gate (5 tier) chạy local trong one-off container — **all green**:
- Tier 1: 205 passed · Tier 2: 192 passed +1 xfailed · Tier 3: 107 passed · Tier 4: 172 passed · Tier 5: 49 passed +3 skipped · notif coverage script ✓
- Affected suites: `test_phase3_pr3e_magic_link` 12 ✓ · `test_magic_link_3_actions_wire` 5 ✓ (gồm #337) · `test_magic_link_rate_limit_key_hashing` 14 ✓ (gồm static-scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)