### PR TITLE
feat(admissions): document-group audience resolution machinery (ĐỢT A)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -260,4 +260,6 @@ jobs:
           tests/unit/test_phase2_pr2c_three_col_unique.py
           tests/services/test_phase2_admission_path_quota_integration.py
           tests/unit/test_public_admissions_phase1_wave6.py
+          tests/unit/test_document_resolution_service.py
+          tests/integration/test_document_audience_reresolve.py
           -q --tb=short --timeout=60

--- a/Backend_FastAPI/alembic/versions/docgrp_audience_20260529_add_applicable_audience.py
+++ b/Backend_FastAPI/alembic/versions/docgrp_audience_20260529_add_applicable_audience.py
@@ -1,0 +1,82 @@
+"""feat/document-group-audience-merge — ĐỢT A: add document_group.applicable_audience + GIN
+
+Revision ID: docgrp_audience_20260529
+Revises: kv_add_successor_20260526
+Create Date: 2026-05-29
+
+ĐỢT A (inert, zero-regression):
+- Thêm cột ``document_group.applicable_audience`` ``admission_audience[]`` nullable.
+  NULL = lớp NỀN tier shared (luôn merge cho mọi thí sinh). ``[..]`` = lớp theo
+  đối tượng/trình độ, merge khi && audience_set của thí sinh.
+- GIN index ``ix_document_group_applicable_audience`` cho && overlap.
+  Query contract: ``WHERE applicable_audience IS NULL OR
+  applicable_audience && ARRAY[:aud]::admission_audience[]`` (NEVER = ANY).
+
+KHÔNG backfill ở đây (ĐỢT A inert): mọi row hiện hữu giữ applicable_audience=NULL
+→ vẫn là NỀN → resolve không đổi (profile mới vẫn lấy đủ doc như trước). Backfill
+split (§8.2) + lớp POST_THCS (§8.0) là migration RIÊNG ở ĐỢT B (owner-gated).
+
+ENUM ``admission_audience`` đã được tạo ở phase1_03 → ``create_type=False``,
+KHÔNG tạo lại.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "docgrp_audience_20260529"
+down_revision = "kv_add_successor_20260526"
+branch_labels = None
+depends_on = None
+
+
+ADMISSION_AUDIENCE_VALUES = (
+    "POST_THCS",
+    "POST_THPT",
+    "LIEN_THONG_TC",
+    "LIEN_THONG_CD",
+    "VLVH",
+)
+
+
+def upgrade() -> None:
+    # ENUM admission_audience đã tồn tại (phase1_03) → reference, KHÔNG tạo.
+    audience_enum = postgresql.ENUM(
+        *ADMISSION_AUDIENCE_VALUES,
+        name="admission_audience",
+        create_type=False,
+    )
+
+    # 1. Cột applicable_audience — NULL = lớp NỀN (mọi row hiện hữu = NỀN,
+    #    inert: resolve giữ nguyên).
+    op.add_column(
+        "document_group",
+        sa.Column(
+            "applicable_audience",
+            postgresql.ARRAY(audience_enum),
+            nullable=True,
+            comment=(
+                "Audience layer filter ARRAY admission_audience. "
+                "NULL = lớp NỀN (luôn merge). Chỉ dùng trong tier shared. "
+                "Query MUST use && overlap (NEVER = ANY) để hit GIN."
+            ),
+        ),
+    )
+
+    # 2. GIN index cho && overlap audience.
+    op.create_index(
+        "ix_document_group_applicable_audience",
+        "document_group",
+        ["applicable_audience"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_document_group_applicable_audience",
+        table_name="document_group",
+    )
+    op.drop_column("document_group", "applicable_audience")
+    # KHÔNG drop enum admission_audience — admission_path.applicable_to vẫn dùng.

--- a/Backend_FastAPI/app/models/admission_config/document_group.py
+++ b/Backend_FastAPI/app/models/admission_config/document_group.py
@@ -10,6 +10,7 @@ Tables:
 """
 
 from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, UniqueConstraint, Index
+from sqlalchemy.dialects.postgresql import ARRAY, ENUM
 from sqlalchemy.orm import relationship
 
 from app.models.base import Base
@@ -88,6 +89,30 @@ class DocumentGroup(Base):
         default=True,
         index=True
     )
+    # feat/document-group-audience-merge — audience layer filter.
+    # NULL = lớp NỀN tier shared (luôn merge cho mọi thí sinh).
+    # [..] = lớp theo đối tượng/trình độ, merge khi && audience_set của
+    # thí sinh (resolve qua document_resolution_service.filter_shared_by_audience).
+    # CHỈ có nghĩa trong tier shared (method/path override KHÔNG dùng audience).
+    # ENUM admission_audience tạo ở alembic phase1_03 (create_type=False
+    # mirrored). Query MUST dùng && overlap + cast ::admission_audience[],
+    # NEVER = ANY (không hit GIN ix_document_group_applicable_audience).
+    applicable_audience = Column(
+        ARRAY(
+            ENUM(
+                "POST_THCS",
+                "POST_THPT",
+                "LIEN_THONG_TC",
+                "LIEN_THONG_CD",
+                "VLVH",
+                name="admission_audience",
+                create_type=False,
+            )
+        ),
+        nullable=True,
+        comment="Audience layer filter ARRAY admission_audience. "
+                "NULL = lớp NỀN (luôn merge). Chỉ dùng trong tier shared.",
+    )
 
     # Relationships
     offering_type = relationship("ConfigOfferingType", back_populates="document_groups")
@@ -108,6 +133,12 @@ class DocumentGroup(Base):
         Index(
             "ix_document_group_offering_method",
             "offering_type_id", "admission_method_id"
+        ),
+        # GIN cho && overlap audience (feat/document-group-audience-merge).
+        Index(
+            "ix_document_group_applicable_audience",
+            "applicable_audience",
+            postgresql_using="gin",
         ),
     )
 

--- a/Backend_FastAPI/app/repositories/admission_path_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_path_repository.py
@@ -25,6 +25,7 @@ from app.models.admission_config import (
 )
 from app.models.offering_academic_info import OfferingAcademicInfo
 from app.models.program_offering import ProgramOffering
+from app.models.major_program import MajorProgram
 from app.repositories.base import BaseRepository
 
 
@@ -109,7 +110,37 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
         )
         result = await self.db.execute(query)
         return result.scalars().first()
-    
+
+    async def get_path_for_audience_reresolve(
+        self,
+        path_id: int,
+    ) -> Optional[AdmissionPath]:
+        """Load path với CHAIN DERIVE đầy đủ cho re-resolve audience (P1-A).
+
+        ``derive_target_level_and_type`` (priority_service) cần eager-load
+        ``academic_info→offering→program→degree_level_ref`` +
+        ``offering→offering_type_config``; thiếu → CONFIG_GAP → audience rớt
+        chiều loại hình (LIEN_THONG/VLVH). ``MajorProgram.degree_level_ref``
+        lazy="raise" nên BẮT BUỘC eager-load. Cũng load offering để lấy
+        ``offering_type_id``.
+        """
+        query = (
+            select(AdmissionPath)
+            .where(AdmissionPath.id == path_id)
+            .options(
+                selectinload(AdmissionPath.academic_info)
+                .selectinload(OfferingAcademicInfo.offering)
+                .selectinload(ProgramOffering.program)
+                .selectinload(MajorProgram.degree_level_ref),
+                selectinload(AdmissionPath.academic_info)
+                .selectinload(OfferingAcademicInfo.offering)
+                .selectinload(ProgramOffering.offering_type_config),
+                selectinload(AdmissionPath.admission_method),
+            )
+        )
+        result = await self.db.execute(query)
+        return result.scalars().first()
+
     async def get_paths_by_academic_info(
         self,
         academic_info_id: int

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -901,6 +901,67 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         await self.db.flush()  # Get IDs without committing
         return created_docs
 
+    async def add_path_documents_delta(
+        self,
+        profile_id: int,
+        document_type_codes: List[str],
+    ) -> List[models.ProfileDocument]:
+        """Idempotent DELTA INSERT cho re-resolve (feat audience — P0-B).
+
+        Khác ``initialize_documents_for_profile`` (add VÔ ĐIỀU KIỆN): chỉ tạo
+        ProfileDocument cho code CHƯA tồn tại trong tier ``category='path'``,
+        set ``category='path'`` tường minh → KHÔNG vi phạm partial-unique
+        ``uq_profile_document_path``. KHÔNG xóa / đụng row đã có upload.
+
+        Trả: list ProfileDocument mới tạo (rỗng nếu không có code thiếu).
+        """
+        if not document_type_codes:
+            return []
+
+        # Codes đã có (category='path') cho profile này.
+        existing_stmt = (
+            select(models.ConfigDocumentType.code)
+            .join(
+                models.ProfileDocument,
+                models.ProfileDocument.document_type_id
+                == models.ConfigDocumentType.id,
+            )
+            .where(
+                models.ProfileDocument.profile_id == profile_id,
+                models.ProfileDocument.category == "path",
+            )
+        )
+        existing_codes = set(
+            (await self.db.execute(existing_stmt)).scalars().all()
+        )
+
+        missing_codes = [
+            c for c in document_type_codes if c not in existing_codes
+        ]
+        if not missing_codes:
+            return []
+
+        dt_stmt = select(models.ConfigDocumentType).where(
+            models.ConfigDocumentType.code.in_(missing_codes)
+        )
+        doc_types = list((await self.db.execute(dt_stmt)).scalars().all())
+
+        created: List[models.ProfileDocument] = []
+        for dt in doc_types:
+            doc = models.ProfileDocument(
+                profile_id=profile_id,
+                document_type_id=dt.id,
+                category="path",
+                status="missing",
+                file_path=None,
+                uploaded_at=None,
+            )
+            self.db.add(doc)
+            created.append(doc)
+
+        await self.db.flush()
+        return created
+
     async def get_document_by_type(
         self,
         profile_id: int,

--- a/Backend_FastAPI/app/routers/admission_paths.py
+++ b/Backend_FastAPI/app/routers/admission_paths.py
@@ -12,7 +12,7 @@ MASTER_ARCHITECTURE.md Compliance:
 """
 
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query, Path as PathParam
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -38,6 +38,7 @@ from app.schemas.admission_path import (
     AdmissionCriteriaNested,
     SubjectGroupNested,
     CoverageMatrixResponse,
+    AdmissionAudience,
 )
 from app.services.admission_path_service import AdmissionPathService
 from app.repositories.admission_path_repository import AdmissionPathRepository
@@ -598,15 +599,23 @@ async def deactivate_admission_path(
     summary="Get resolved documents for path",
 )
 async def get_resolved_documents(
+    audience: Optional[AdmissionAudience] = Query(
+        None,
+        description=(
+            "Lọc bộ hồ sơ theo 1 diện thí sinh (POST_THPT, POST_THCS,...). "
+            "Bỏ trống → trả TẤT CẢ lớp (NỀN + mọi audience) cho view admin "
+            "(không co lại sau backfill audience)."
+        ),
+    ),
     path: models.AdmissionPath = Depends(get_admission_path_for_user),
     db: AsyncSession = Depends(database.get_db),
 ):
     """
     Get resolved document requirements for a path.
 
-    Override Rule:
-    - Shared docs (method_id = NULL) apply to all methods
-    - Method-specific docs override shared
+    3-tier override (path > method > shared). feat audience: trong tier shared,
+    ``?audience=`` lọc lớp theo diện thí sinh; bỏ trống → ALL layers (round-6 G2:
+    admin thấy đủ bộ, không co lại sau backfill audience).
 
     IDOR: Protected via get_admission_path_for_user dependency.
     """
@@ -614,9 +623,14 @@ async def get_resolved_documents(
     offering_type_id = path.academic_info.offering.offering_type_id
 
     service = AdmissionPathService(db)
-    documents, callback = await service.resolve_documents_for_path(
-        path, offering_type_id
-    )
+    if audience is None:
+        documents, callback = await service.resolve_documents_for_path(
+            path, offering_type_id, all_audiences=True
+        )
+    else:
+        documents, callback = await service.resolve_documents_for_path(
+            path, offering_type_id, audience_set={audience}
+        )
     await db.commit()
     await callback()
 

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -608,6 +608,17 @@ class ResolvedDocumentResponse(BaseModel):
     source: DocumentSource = Field(
         description="Where this doc requirement comes from: shared or method_override"
     )
+    # feat/document-group-audience-merge — KHÔNG overload source (round-2 P2).
+    applicable_audience: Optional[List[AdmissionAudience]] = Field(
+        default=None,
+        description="Audience của lớp giấy tờ ([POST_THPT,...]); None = lớp NỀN / override.",
+    )
+    layer_kind: Literal[
+        "shared_base", "shared_audience", "method_override", "path_override"
+    ] = Field(
+        default="shared_base",
+        description="Loại lớp: NỀN / theo audience / override method / override path.",
+    )
 
 
 class ResolvedDocumentListResponse(BaseModel):

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -35,6 +35,12 @@ from app.schemas.admission_path import (
     AdmissionPathDocumentUpsert,
     ResolvedDocumentResponse,
 )
+from app.services.document_resolution_service import (
+    compute_completed_doc_codes,
+    derive_audience_set,
+    filter_shared_by_audience,
+    mandatory_wins_merge,
+)
 from app.utils.exceptions import (
     ResourceNotFoundError,
     DuplicateResourceError,
@@ -656,8 +662,11 @@ class AdmissionPathService:
 
         await self.db.flush()
 
-        # Return resolved list
-        return await self.resolve_documents_for_path(path, offering_type_id)
+        # Return resolved list. round-6 G2: view admin no-audience → ALL layers
+        # (NỀN + mọi audience) để KHÔNG co lại sau backfill audience.
+        return await self.resolve_documents_for_path(
+            path, offering_type_id, all_audiences=True
+        )
 
     # =========================================================================
     # ACTIVATION LOGIC
@@ -868,31 +877,34 @@ class AdmissionPathService:
     # =========================================================================
 
     async def resolve_documents_for_path(
-        self, path: AdmissionPath, offering_type_id: int
+        self,
+        path: AdmissionPath,
+        offering_type_id: int,
+        *,
+        audience_set: Optional[set] = None,
+        all_audiences: bool = False,
+        completed_codes: Optional[set] = None,
     ) -> Tuple[List[ResolvedDocumentResponse], PostCommitCallback]:
         """
-        Resolve document requirements for a path.
+        Resolve document requirements for a path (3-tier + audience).
 
-        phase1_06 (#184 Wave 1 PR-1C') — 3-tier resolution rule
-        per PLAN line 619-623:
+        phase1_06 — 3-tier resolution (path > method > shared). Tier
+        precedence GIỮ NGUYÊN (fork không đụng audience). feat audience:
+        audience CHỈ áp trong tier shared (lớp NỀN + lớp khớp audience).
 
-        1. **Tier 1**: ``WHERE admission_path_id = path.id`` →
-           if any rows match, USE THIS TIER FULLY (ignore tier 2 + 3).
-        2. **Tier 2**: ``WHERE admission_method_id = path.method
-           AND admission_path_id IS NULL`` → if any rows match,
-           USE THIS TIER FULLY (ignore tier 3).
-        3. **Tier 3**: ``WHERE offering_type_id = X AND
-           admission_method_id IS NULL AND admission_path_id IS NULL``
-           → fallback shared bucket.
-
-        Within a tier, multiple groups merge with mandatory-wins
-        (existing precedence preserved). Source indicators on the
-        response surface which tier provided each document so the
-        FE / admin can debug drift.
+        Args:
+            audience_set: tập audience của thí sinh ({POST_THPT,...}). Trong tier
+                shared chỉ merge lớp NỀN + lớp ``&& audience_set``. ``None`` → CHỈ
+                NỀN (backward-compat: legacy / create chưa biết audience).
+            all_audiences: True → tier shared merge TẤT CẢ lớp (NỀN + mọi audience)
+                bất kể audience_set. Dùng cho view admin no-audience (round-6 G2 —
+                endpoint /paths/{id}/documents không ?audience= → thấy đủ bộ, KHÔNG
+                co lại sau backfill).
+            completed_codes: mã bằng TN LOẠI khỏi kết quả (cultural=completed_* §6).
 
         Returns:
-            List of resolved documents with source indicator
-            (``path_override`` / ``method_override`` / ``shared``).
+            (list resolved docs với source + layer_kind + applicable_audience,
+             noop callback).
         """
         path_groups, method_groups, shared_groups = (
             await self.repo.get_document_groups_for_path(
@@ -902,51 +914,77 @@ class AdmissionPathService:
             )
         )
 
-        # Build document map: document_type_id -> (item, source).
-        # Tier precedence: highest tier with non-empty groups wins
-        # FULLY; lower tiers are ignored (admin "deletes" default
-        # items by configuring a higher tier).
+        # doc_map: {document_type_id: (item, source, group_audience)}.
+        # Tier precedence: highest tier non-empty thắng FULLY (lower tiers
+        # ignored — admin "xóa" default item bằng cấu hình tier cao hơn).
         doc_map: dict = {}
-
         if path_groups:
-            # Tier 1 — path-specific (PR-1C' new). Mandatory-wins
-            # within the tier so two path groups can layer.
-            for group in path_groups:
-                for item in group.items:
-                    existing = doc_map.get(item.document_type_id)
-                    if existing is None:
-                        doc_map[item.document_type_id] = (item, "path_override")
-                    elif item.is_mandatory and not existing[0].is_mandatory:
-                        doc_map[item.document_type_id] = (item, "path_override")
+            mandatory_wins_merge(doc_map, path_groups, "path_override")
         elif method_groups:
-            # Tier 2 — method-specific. Existing legacy bucket;
-            # behavior unchanged from pre-PR-1C'.
-            for group in method_groups:
-                for item in group.items:
-                    existing = doc_map.get(item.document_type_id)
-                    if existing is None:
-                        doc_map[item.document_type_id] = (item, "method_override")
-                    elif item.is_mandatory and not existing[0].is_mandatory:
-                        doc_map[item.document_type_id] = (item, "method_override")
+            mandatory_wins_merge(doc_map, method_groups, "method_override")
         else:
-            # Tier 3 — shared offering-type fallback.
-            for group in shared_groups:
-                for item in group.items:
-                    existing = doc_map.get(item.document_type_id)
-                    if existing is None:
-                        doc_map[item.document_type_id] = (item, "shared")
-                    elif item.is_mandatory and not existing[0].is_mandatory:
-                        doc_map[item.document_type_id] = (item, "shared")
+            # Tier 3 — shared. Audience CHỈ áp ở đây.
+            layers = (
+                shared_groups
+                if all_audiences
+                else filter_shared_by_audience(shared_groups, audience_set)
+            )
+            mandatory_wins_merge(doc_map, layers, "shared")
 
-        # Step 3: Build response
+        resolved = self._build_resolved_response(doc_map, completed_codes)
+        return resolved, _noop_callback
+
+    async def resolve_documents_for_profile(
+        self,
+        profile,
+        path: AdmissionPath,
+        offering_type_id: int,
+    ) -> Tuple[List[ResolvedDocumentResponse], PostCommitCallback]:
+        """Resolve bộ hồ sơ THẬT của 1 thí sinh (audience suy từ profile).
+
+        Dùng cho create snapshot + re-resolve. ``derive_audience_set`` nuốt
+        CONFIG_GAP nội bộ → luôn ≥ tập văn hóa; ``compute_completed_doc_codes``
+        loại bằng TN khi cultural=completed_* (§6). Caller truyền ``path`` =
+        path primary để derive chiều loại hình (P1-A: chain phải eager-load).
+        """
+        audience_set = derive_audience_set(profile, path)
+        completed_codes = compute_completed_doc_codes(profile)
+        return await self.resolve_documents_for_path(
+            path,
+            offering_type_id,
+            audience_set=audience_set,
+            completed_codes=completed_codes,
+        )
+
+    @staticmethod
+    def _build_resolved_response(
+        doc_map: dict,
+        completed_codes: Optional[set] = None,
+    ) -> List[ResolvedDocumentResponse]:
+        """doc_map ``(item, source, group_audience)`` → list response.
+
+        Loại item có code ∈ ``completed_codes`` (cultural=completed_* → bỏ bằng TN).
+        ``layer_kind``: path_override / method_override / shared_audience / shared_base.
+        ``applicable_audience``: audience của group thắng (None cho NỀN/override).
+        """
+        completed = completed_codes or set()
         resolved: List[ResolvedDocumentResponse] = []
-        for doc_type_id, (item, source) in doc_map.items():
+        for _doc_type_id, (item, source, grp_aud) in doc_map.items():
+            code = item.document_type.code if item.document_type else ""
+            if code in completed:
+                continue
+            if source == "path_override":
+                layer_kind = "path_override"
+            elif source == "method_override":
+                layer_kind = "method_override"
+            elif grp_aud:
+                layer_kind = "shared_audience"
+            else:
+                layer_kind = "shared_base"
             resolved.append(
                 ResolvedDocumentResponse(
                     document_type_id=item.document_type_id,
-                    document_type_code=(
-                        item.document_type.code if item.document_type else ""
-                    ),
+                    document_type_code=code,
                     document_type_name=(
                         item.document_type.name if item.document_type else ""
                     ),
@@ -955,13 +993,12 @@ class AdmissionPathService:
                     submission_format=item.submission_format,
                     display_order=item.display_order,
                     source=source,
+                    applicable_audience=list(grp_aud) if grp_aud else None,
+                    layer_kind=layer_kind,
                 )
             )
-
-        # Sort by display_order
         resolved.sort(key=lambda x: x.display_order)
-
-        return resolved, _noop_callback
+        return resolved
 
     # =========================================================================
     # CONTROL FIELD COMPUTATION (for response)

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -3829,6 +3829,117 @@ async def get_profile(
     return profile
 
 
+async def _reresolve_documents_snapshot(
+    db: AsyncSession,
+    profile: "models.AdmissionProfile",
+    admission_repo,
+    current_user: Optional["models.User"],
+) -> None:
+    """Re-resolve doc snapshot khi cultural/vocational đổi (feat audience).
+
+    Bối cảnh (round-2 P0-A): submit check ``mandatory_docs`` từ SNAPSHOT, không
+    re-resolve; cultural set qua update_profile vốn không re-resolve. Nếu không
+    re-resolve khi cultural đổi → snapshot stale (thiếu học bạ/bằng TN theo
+    audience) → submit qua eligibility (cultural đã set) nhưng doc không bắt buộc
+    = REGRESSION. Hook này đóng lỗ đó.
+
+    - CHỈ editable states {draft, rejected, revision_requested} (ngoài đó gate
+      chặn → đóng băng, không cần block riêng).
+    - INSERT-only DELTA qua ``add_path_documents_delta`` (P0-B: không vi phạm
+      ``uq_profile_document_path``; không xóa upload).
+    - MERGE applied_rules PER-KEY (round-3 invariant): chỉ ghi đè
+      ``mandatory_docs``/``doc_configs``, GIỮ ``schema_version``/
+      ``allow_unverified_submission``/``admission_path_id``/scoring (submit
+      :4974-4978 raise nếu thiếu). KHÔNG bump schema_version (round-4 N1).
+    - CONFIG_GAP đã nuốt nội bộ trong ``derive_audience_set`` (round-3 BLOCKER)
+      → luôn ≥ tập văn hóa. Lỗi BẤT NGỜ (DB...) PROPAGATE (loud-fail) — KHÔNG
+      im lặng giữ snapshot NỀN-only.
+    - N5: ghi audit entry ``documents_reresolved`` (mutate snapshot không vào
+      ``updated_fields`` của update_profile).
+    """
+    if profile.status not in ("draft", "rejected", "revision_requested"):
+        return
+    applied = profile.applied_rules or {}
+    path_id = applied.get("admission_path_id")
+    if path_id is None:
+        return  # legacy / hồ sơ không có path snapshot → bỏ qua
+
+    from .admission_path_service import AdmissionPathService
+    from ..repositories.admission_path_repository import AdmissionPathRepository
+
+    path = await AdmissionPathRepository(db).get_path_for_audience_reresolve(
+        int(path_id)
+    )
+    if path is None or path.academic_info is None or path.academic_info.offering is None:
+        return
+    offering_type_id = path.academic_info.offering.offering_type_id
+    if offering_type_id is None:
+        return
+
+    resolved, _ = await AdmissionPathService(db).resolve_documents_for_profile(
+        profile, path, offering_type_id
+    )
+    new_mandatory = [d.document_type_code for d in resolved if d.is_mandatory]
+    new_doc_configs = {
+        d.document_type_code: {
+            "requires_upload": d.requires_upload,
+            "submission_format": d.submission_format,
+            "is_mandatory": d.is_mandatory,
+            "label": d.document_type_name,
+        }
+        for d in resolved
+    }
+
+    # Micro-opt: snapshot KHÔNG đổi (PATCH cultural set lại cùng giá trị, hoặc
+    # audience không đổi bộ hồ sơ) → skip write/delta/audit. resolved.sort theo
+    # display_order → list deterministic, so sánh list/dict an toàn.
+    if new_mandatory == (applied.get("mandatory_docs") or []) and (
+        new_doc_configs == (applied.get("doc_configs") or {})
+    ):
+        return
+
+    old_mandatory = set(applied.get("mandatory_docs") or [])
+
+    # MERGE per-key (giữ mọi key khác — KHÔNG gán dict mới).
+    applied["mandatory_docs"] = new_mandatory
+    applied["doc_configs"] = new_doc_configs
+    profile.applied_rules = applied
+    flag_modified(profile, "applied_rules")
+
+    # DELTA INSERT ProfileDocument cho code mới (idempotent, không xóa upload).
+    await admission_repo.add_path_documents_delta(profile.id, new_mandatory)
+
+    # N5 — audit entry cho mutate snapshot.
+    added = sorted(set(new_mandatory) - old_mandatory)
+    removed = sorted(old_mandatory - set(new_mandatory))
+    if added or removed:
+        from ..services import audit_service
+
+        await audit_service.log_changes(
+            db,
+            "AdmissionProfile",
+            profile.id,
+            "documents_reresolved",
+            changes={
+                "reason": "audience_change",
+                "cultural_education_level": getattr(
+                    profile, "cultural_education_level", None
+                ),
+                "docs_added": added,
+                "docs_removed": removed,
+            },
+            actor_user_id=current_user.id if current_user else None,
+            source="system",
+        )
+    log.info(
+        "documents_reresolved",
+        profile_id=profile.id,
+        mandatory_count=len(new_mandatory),
+        added=added,
+        removed=removed,
+    )
+
+
 async def update_profile(
     db: AsyncSession,
     profile_id: int,
@@ -4120,6 +4231,13 @@ async def update_profile(
             if profile.lead:
                 profile.lead.gpa = gpa_value
 
+
+    # feat/document-group-audience-merge — re-resolve doc snapshot khi
+    # cultural/vocational đổi (audience phụ thuộc 2 field này). Đặt sau khi
+    # set cultural (:4055-4058) + scores, trước flush. CONFIG_GAP nuốt nội bộ
+    # trong derive_audience_set → luôn ≥ tập văn hóa (round-3 BLOCKER).
+    if ("cultural_education_level" in data) or ("vocational_qualification" in data):
+        await _reresolve_documents_snapshot(db, profile, admission_repo, current_user)
 
     # Update timestamp and increment version
     profile.updated_at = datetime.now(timezone.utc)

--- a/Backend_FastAPI/app/services/document_resolution_service.py
+++ b/Backend_FastAPI/app/services/document_resolution_service.py
@@ -1,0 +1,162 @@
+# app/services/document_resolution_service.py
+"""
+Document Resolution Service — module chung resolve bộ hồ sơ đa chiều.
+
+feat/document-group-audience-merge. Tách helper merge + audience khỏi
+``admission_path_service`` + ``public_admissions_service`` để 1 NGUỒN merge
+duy nhất (tránh drift — round-6 G3).
+
+Bộ hồ sơ của 1 thí sinh = hợp các lớp giấy tờ khớp 3 chiều:
+- **Loại hình** (offering_type) — tier shared/method/path (đã có).
+- **Đối tượng/trình độ văn hóa** — ``DocumentGroup.applicable_audience`` (THÊM).
+- **Phương thức** (admission_method) — tier method (đã có).
+
+Precedence tier (path > method > shared) GIỮ NGUYÊN. Audience CHỈ merge trong
+tier shared (path/method override = fork, không đụng audience).
+
+Pure: chỉ import models + lazy ``priority_service`` (no FastAPI, no import cycle).
+"""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+
+# Nhãn tiếng Việt cho từng audience (FE render từ BE — thin-client).
+AUDIENCE_LABELS: Dict[str, str] = {
+    "POST_THCS": "Tốt nghiệp THCS",
+    "POST_THPT": "Tốt nghiệp THPT",
+    "LIEN_THONG_TC": "Liên thông Trung cấp",
+    "LIEN_THONG_CD": "Liên thông Cao đẳng",
+    "VLVH": "Vừa làm vừa học",
+}
+
+# cultural_education_level → audience VĂN HÓA (suy TRỰC TIẾP, KHÔNG qua derive).
+# Giá trị cultural: schemas/admission.py:732.
+_CULTURAL_TO_AUDIENCE: Dict[str, str] = {
+    "completed_thcs": "POST_THCS",
+    "graduated_thcs": "POST_THCS",
+    "completed_thpt": "POST_THPT",
+    "graduated_thpt": "POST_THPT",
+    "graduated_gdtx": "POST_THPT",
+}
+
+# cultural "completed_*" = hoàn thành chương trình nhưng CHƯA có bằng → mã bằng
+# TN cần LOẠI khỏi bộ hồ sơ (§6 GĐ1; doc type bằng TN tồn tại prod 2026-05-29).
+_COMPLETED_DIPLOMA_TO_REMOVE: Dict[str, str] = {
+    "completed_thpt": "bang_tot_nghiep_thpt",
+    "completed_thcs": "bang_tot_nghiep_thcs",
+}
+
+
+def mandatory_wins_merge(
+    doc_map: Dict[int, tuple],
+    groups: Iterable,
+    source: str,
+    *,
+    exclude_inactive: bool = False,
+) -> None:
+    """Merge items từ ``groups`` vào ``doc_map`` (mutate in-place), mandatory-wins.
+
+    ``doc_map``: ``{document_type_id: (DocumentGroupItem, source, group_audience)}``
+    — ``group_audience`` = ``group.applicable_audience`` của group thắng (None cho
+    NỀN/override) để response gắn ``applicable_audience`` + ``layer_kind``.
+    Item bắt buộc override item không bắt buộc CÙNG document_type.
+
+    ``exclude_inactive`` (round-6 G3 — 2 caller KHÁC hành vi):
+      - ``False`` (path/create snapshot): GIỮ item kể cả doc_type inactive
+        (hành vi ``admission_path_service.resolve_documents_for_path`` cũ).
+      - ``True`` (public/storefront): BỎ item có doc_type inactive
+        (giữ hardening #348 ``public_admissions_service``).
+    """
+    for group in groups:
+        grp_aud = getattr(group, "applicable_audience", None)
+        for item in group.items:
+            if exclude_inactive and (
+                item.document_type is None or not item.document_type.is_active
+            ):
+                continue
+            existing = doc_map.get(item.document_type_id)
+            if existing is None or (
+                item.is_mandatory and not existing[0].is_mandatory
+            ):
+                doc_map[item.document_type_id] = (item, source, grp_aud)
+
+
+def filter_shared_by_audience(
+    shared_groups: Iterable,
+    audience_set: Optional[Set[str]],
+) -> List:
+    """Lọc shared groups theo ``audience_set`` của thí sinh.
+
+    Trả: group NỀN (``applicable_audience`` NULL/rỗng — LUÔN merge cho mọi TS)
+         + group có ``applicable_audience && audience_set`` (overlap).
+
+    ``audience_set=None`` → CHỈ NỀN (backward-compat: legacy / admin no-audience /
+    create chưa biết audience). Public xử lý ALL layers riêng (§9).
+    """
+    result: List = []
+    for group in shared_groups:
+        aud = getattr(group, "applicable_audience", None)
+        if not aud:  # NULL hoặc [] → lớp NỀN
+            result.append(group)
+        elif audience_set is not None and (set(aud) & audience_set):
+            result.append(group)
+    return result
+
+
+def derive_audience_set(profile, path) -> Set[str]:
+    """Suy ``audience_set`` của hồ sơ từ 2 chiều.
+
+    - **Văn hóa**: TRỰC TIẾP từ ``profile.cultural_education_level`` (KHÔNG qua
+      derive → KHÔNG bao giờ rớt vì CONFIG_GAP).
+    - **Loại hình**: qua ``derive_target_level_and_type(path)`` — bọc try/except
+      QUANH RIÊNG call này → CONFIG_GAP/chain chưa load chỉ rớt chiều loại hình.
+
+    INVARIANT (round-3 BLOCKER): hàm NÀY **không bao giờ raise** và **luôn trả
+    ≥ tập văn hóa** → re-resolve luôn apply (chống P0-A tái sinh ở nhánh CONFIG_GAP).
+    """
+    audience: Set[str] = set()
+
+    cultural = getattr(profile, "cultural_education_level", None)
+    if cultural in _CULTURAL_TO_AUDIENCE:
+        audience.add(_CULTURAL_TO_AUDIENCE[cultural])
+
+    if path is not None:
+        try:
+            from .priority_service import derive_target_level_and_type
+
+            target_level, admission_type = derive_target_level_and_type(path)
+            if admission_type == "lien_thong":
+                if target_level == "trung_cap":
+                    audience.add("LIEN_THONG_TC")
+                elif target_level == "cao_dang":
+                    audience.add("LIEN_THONG_CD")
+            elif admission_type == "vua_lam_vua_hoc":
+                audience.add("VLVH")
+        except Exception as exc:  # noqa: BLE001 — fail-safe: chỉ rớt chiều loại hình
+            # log.warning (KHÔNG info) để bug code thật trong derive (vd
+            # AttributeError do typo) lộ ra thay vì âm thầm rớt chiều loại hình.
+            # CONFIG_GAP (chain chưa load) là ca hợp lệ duy nhất kỳ vọng ở đây.
+            log.warning(
+                "derive_audience_set_offering_type_dim_skipped",
+                reason=str(exc),
+                error_type=type(exc).__name__,
+                cultural_audience=sorted(audience),
+            )
+
+    return audience
+
+
+def compute_completed_doc_codes(profile) -> Set[str]:
+    """Mã bằng TN cần LOẠI khỏi bộ hồ sơ khi ``cultural='completed_*'``.
+
+    "completed" = hoàn thành chương trình nhưng CHƯA có bằng (§6 GĐ1) → không
+    yêu cầu nộp bằng TN tương ứng. "graduated_*" giữ bằng (đã có).
+    """
+    cultural = getattr(profile, "cultural_education_level", None)
+    code = _COMPLETED_DIPLOMA_TO_REMOVE.get(cultural)
+    return {code} if code else set()

--- a/Backend_FastAPI/tests/integration/test_document_audience_reresolve.py
+++ b/Backend_FastAPI/tests/integration/test_document_audience_reresolve.py
@@ -1,0 +1,372 @@
+"""Integration anchors — re-resolve doc snapshot theo audience (feat/document-group-audience-merge).
+
+Validate đường RE-RESOLVE FIRE end-to-end (create → PUT cultural → snapshot):
+- THCS↔THPT differentiation (nhu cầu gốc owner): cultural=graduated_thcs → bộ THCS;
+  graduated_thpt → bộ THPT (post-backfill group shape).
+- §6 completed_* → LOẠI bằng TN khỏi snapshot (finding round-8 #2: LIVE pre-backfill).
+- P0-B: re-resolve khi ProfileDocument đã tồn tại → add_path_documents_delta KHÔNG
+  vi phạm uq_profile_document_path; PUT lặp → short-circuit, không lỗi.
+- Round-3 invariant: merge per-key giữ schema_version=2 + admission_path_id.
+
+Dùng group shape POST-BACKFILL (NỀN base-only + lớp POST_THPT + lớp POST_THCS) để
+chứng minh machinery audience hoạt động NGAY (cái mà ĐỢT B backfill sẽ tạo).
+"""
+import random
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _get_or_create_doc_type(session, code: str, name: str) -> int:
+    existing = (
+        await session.execute(
+            select(models.ConfigDocumentType).where(
+                models.ConfigDocumentType.code == code
+            )
+        )
+    ).scalar_one_or_none()
+    if existing:
+        return existing.id
+    dt = models.ConfigDocumentType(code=code, name=name, is_active=True)
+    session.add(dt)
+    await session.flush()
+    return dt.id
+
+
+async def _setup_audience_data(major_id: int, unit_id: int, officer_id: int) -> dict:
+    """Tạo offering_type + path + lead + 3 DocumentGroup (NỀN/POST_THPT/POST_THCS).
+
+    Group shape = POST-BACKFILL: NỀN={cccd}; POST_THPT={hoc_ba_thpt,
+    bang_tot_nghiep_thpt}; POST_THCS={hoc_ba_thcs, bang_tot_nghiep_thcs}.
+    """
+    suffix = random.randint(10000, 99999)
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            ot = models.ConfigOfferingType(
+                code=f"aud_type_{suffix}",
+                name=f"Audience Test OT {suffix}",
+                is_active=True,
+            )
+            session.add(ot)
+            await session.flush()
+
+            offering = models.ProgramOffering(
+                offering_type=f"AudTest_{suffix}",
+                program_id=major_id,
+                offering_type_id=ot.id,
+            )
+            session.add(offering)
+            await session.flush()
+
+            academic_info = models.OfferingAcademicInfo(
+                offering_id=offering.id, academic_year=2025, is_published=True
+            )
+            session.add(academic_info)
+            await session.flush()
+
+            method = models.AdmissionMethod(
+                code=f"aud_method_{suffix}", name="Aud Method", is_active=True
+            )
+            session.add(method)
+            await session.flush()
+
+            criteria = models.AdmissionCriteria(
+                method_id=method.id,
+                code=f"aud_criteria_{suffix}",
+                name="Aud Criteria",
+                min_gpa=0,
+                is_active=True,
+            )
+            session.add(criteria)
+            await session.flush()
+
+            from tests.fixtures.builders import AdmissionRoundBuilder
+
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                session, academic_year=2025
+            )
+            path = models.AdmissionPath(
+                academic_info_id=academic_info.id,
+                admission_method_id=method.id,
+                admission_round_id=round_id,
+                criteria_id=criteria.id,
+                status="active",
+            )
+            session.add(path)
+            await session.flush()
+
+            # Doc types (get-or-create — bằng TN THCS có thể chưa có trong qlts_test).
+            cccd = await _get_or_create_doc_type(session, "cccd", "Căn cước công dân")
+            hb_thpt = await _get_or_create_doc_type(session, "hoc_ba_thpt", "Học bạ THPT")
+            bts_thpt = await _get_or_create_doc_type(
+                session, "bang_tot_nghiep_thpt", "Bằng tốt nghiệp THPT"
+            )
+            hb_thcs = await _get_or_create_doc_type(session, "hoc_ba_thcs", "Học bạ THCS")
+            bts_thcs = await _get_or_create_doc_type(
+                session, "bang_tot_nghiep_thcs", "Bằng tốt nghiệp THCS"
+            )
+
+            def _mk_group(code, audience, items):
+                g = models.DocumentGroup(
+                    offering_type_id=ot.id,
+                    admission_method_id=None,
+                    admission_path_id=None,
+                    code=code,
+                    name=code,
+                    is_active=True,
+                    applicable_audience=audience,
+                )
+                session.add(g)
+                return g
+
+            g_base = _mk_group(f"AUD_BASE_{suffix}", None, None)
+            g_thpt = _mk_group(f"AUD_THPT_{suffix}", ["POST_THPT"], None)
+            g_thcs = _mk_group(f"AUD_THCS_{suffix}", ["POST_THCS"], None)
+            await session.flush()
+
+            def _mk_item(group_id, dt_id, order):
+                session.add(
+                    models.DocumentGroupItem(
+                        group_id=group_id,
+                        document_type_id=dt_id,
+                        is_mandatory=True,
+                        requires_upload=True,
+                        submission_format="photo",
+                        display_order=order,
+                    )
+                )
+
+            _mk_item(g_base.id, cccd, 1)
+            _mk_item(g_thpt.id, hb_thpt, 2)
+            _mk_item(g_thpt.id, bts_thpt, 3)
+            _mk_item(g_thcs.id, hb_thcs, 2)
+            _mk_item(g_thcs.id, bts_thcs, 3)
+            await session.flush()
+
+            lead_uid = uuid.uuid4().hex[:12]
+            lead = models.Lead(
+                full_name=f"Aud Lead {lead_uid}",
+                phone=f"090{random.randint(1000000, 9999999)}",
+                email=f"aud_{lead_uid}@test.com",
+                source="website",
+                unit_id=unit_id,
+                assigned_officer_id=officer_id,
+                offering_id=offering.id,
+            )
+            session.add(lead)
+            await session.flush()
+            session.add(
+                models.Consultation(
+                    lead_id=lead.id,
+                    consultation_date=datetime.now(timezone.utc),
+                    method="phone",
+                    notes="aud",
+                    officer_id=officer_id,
+                    consultation_status_id="sts06",
+                )
+            )
+            await session.flush()
+
+            return {
+                "lead_id": lead.id,
+                "admission_method_id": method.id,
+                "admission_round_id": round_id,
+            }
+
+
+async def _auth(client: AsyncClient, user_info: dict) -> dict:
+    res = await client.post(
+        "/api/auth/login",
+        data={"username": user_info["username"], "password": user_info["password"]},
+    )
+    assert res.status_code == 200, res.text
+    token = res.cookies.get("access_token")
+    client.cookies.delete("access_token")
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _create_profile(client, headers, data) -> int:
+    res = await client.post(
+        "/api/admissions",
+        json={
+            "lead_id": data["lead_id"],
+            "admission_method_id": data["admission_method_id"],
+            "admission_round_id": data["admission_round_id"],
+            "academic_year": 2025,
+        },
+        headers=headers,
+    )
+    assert res.status_code == 201, f"create failed: {res.text}"
+    return res.json()["id"]
+
+
+async def _snapshot_mandatory(profile_id: int) -> set:
+    async with AsyncSessionLocal() as session:
+        p = (
+            await session.execute(
+                select(models.AdmissionProfile).where(
+                    models.AdmissionProfile.id == profile_id
+                )
+            )
+        ).scalar_one()
+        return set((p.applied_rules or {}).get("mandatory_docs") or [])
+
+
+async def _profile_doc_codes(profile_id: int) -> set:
+    async with AsyncSessionLocal() as session:
+        rows = (
+            await session.execute(
+                select(models.ConfigDocumentType.code)
+                .join(
+                    models.ProfileDocument,
+                    models.ProfileDocument.document_type_id
+                    == models.ConfigDocumentType.id,
+                )
+                .where(models.ProfileDocument.profile_id == profile_id)
+            )
+        ).scalars().all()
+        return set(rows)
+
+
+class TestReresolveAudience:
+    async def test_create_snapshot_is_base_only(
+        self, client, officer_user_in_db, seed_lead_dependencies
+    ):
+        data = await _setup_audience_data(
+            seed_lead_dependencies["major_program_id"],
+            seed_lead_dependencies["unit_id"],
+            officer_user_in_db["id"],
+        )
+        headers = await _auth(client, officer_user_in_db)
+        pid = await _create_profile(client, headers, data)
+        # create audience_set=None → CHỈ NỀN.
+        assert await _snapshot_mandatory(pid) == {"cccd"}
+
+    async def test_reresolve_thcs_loads_thcs_docs(
+        self, client, officer_user_in_db, seed_lead_dependencies
+    ):
+        """Nhu cầu gốc: TS tốt nghiệp THCS → bộ THCS, KHÔNG dính bộ THPT."""
+        data = await _setup_audience_data(
+            seed_lead_dependencies["major_program_id"],
+            seed_lead_dependencies["unit_id"],
+            officer_user_in_db["id"],
+        )
+        headers = await _auth(client, officer_user_in_db)
+        pid = await _create_profile(client, headers, data)
+        res = await client.put(
+            f"/api/admissions/{pid}",
+            json={"cultural_education_level": "graduated_thcs", "version": 1},
+            headers=headers,
+        )
+        assert res.status_code == 200, res.text
+        snap = await _snapshot_mandatory(pid)
+        assert snap == {"cccd", "hoc_ba_thcs", "bang_tot_nghiep_thcs"}
+        assert "hoc_ba_thpt" not in snap and "bang_tot_nghiep_thpt" not in snap
+
+    async def test_reresolve_thpt_loads_thpt_docs(
+        self, client, officer_user_in_db, seed_lead_dependencies
+    ):
+        data = await _setup_audience_data(
+            seed_lead_dependencies["major_program_id"],
+            seed_lead_dependencies["unit_id"],
+            officer_user_in_db["id"],
+        )
+        headers = await _auth(client, officer_user_in_db)
+        pid = await _create_profile(client, headers, data)
+        res = await client.put(
+            f"/api/admissions/{pid}",
+            json={"cultural_education_level": "graduated_thpt", "version": 1},
+            headers=headers,
+        )
+        assert res.status_code == 200, res.text
+        snap = await _snapshot_mandatory(pid)
+        assert snap == {"cccd", "hoc_ba_thpt", "bang_tot_nghiep_thpt"}
+        assert "hoc_ba_thcs" not in snap
+
+    async def test_reresolve_completed_thpt_drops_diploma(
+        self, client, officer_user_in_db, seed_lead_dependencies
+    ):
+        """§6 / finding round-8 #2: completed_thpt → LOẠI bằng TN khỏi snapshot."""
+        data = await _setup_audience_data(
+            seed_lead_dependencies["major_program_id"],
+            seed_lead_dependencies["unit_id"],
+            officer_user_in_db["id"],
+        )
+        headers = await _auth(client, officer_user_in_db)
+        pid = await _create_profile(client, headers, data)
+        res = await client.put(
+            f"/api/admissions/{pid}",
+            json={"cultural_education_level": "completed_thpt", "version": 1},
+            headers=headers,
+        )
+        assert res.status_code == 200, res.text
+        snap = await _snapshot_mandatory(pid)
+        assert "hoc_ba_thpt" in snap
+        assert "bang_tot_nghiep_thpt" not in snap  # completed → bỏ bằng TN
+
+    async def test_reresolve_delta_no_unique_violation_idempotent(
+        self, client, officer_user_in_db, seed_lead_dependencies
+    ):
+        """P0-B: re-resolve khi ProfileDocument (cccd) đã có → delta INSERT chỉ
+        code thiếu, KHÔNG vi phạm uq_profile_document_path; PUT lặp → OK."""
+        data = await _setup_audience_data(
+            seed_lead_dependencies["major_program_id"],
+            seed_lead_dependencies["unit_id"],
+            officer_user_in_db["id"],
+        )
+        headers = await _auth(client, officer_user_in_db)
+        pid = await _create_profile(client, headers, data)
+        # PUT 1 — re-resolve thêm thpt docs.
+        r1 = await client.put(
+            f"/api/admissions/{pid}",
+            json={"cultural_education_level": "graduated_thpt", "version": 1},
+            headers=headers,
+        )
+        assert r1.status_code == 200, r1.text
+        codes = await _profile_doc_codes(pid)
+        assert {"cccd", "hoc_ba_thpt", "bang_tot_nghiep_thpt"} <= codes
+        # PUT 2 — cùng cultural → short-circuit / delta idempotent, KHÔNG lỗi unique.
+        v2 = r1.json().get("version", 2)
+        r2 = await client.put(
+            f"/api/admissions/{pid}",
+            json={"cultural_education_level": "graduated_thpt", "version": v2},
+            headers=headers,
+        )
+        assert r2.status_code == 200, r2.text
+
+    async def test_reresolve_preserves_applied_rules_keys(
+        self, client, officer_user_in_db, seed_lead_dependencies
+    ):
+        """Round-3 invariant: merge per-key giữ schema_version + admission_path_id."""
+        data = await _setup_audience_data(
+            seed_lead_dependencies["major_program_id"],
+            seed_lead_dependencies["unit_id"],
+            officer_user_in_db["id"],
+        )
+        headers = await _auth(client, officer_user_in_db)
+        pid = await _create_profile(client, headers, data)
+        await client.put(
+            f"/api/admissions/{pid}",
+            json={"cultural_education_level": "graduated_thcs", "version": 1},
+            headers=headers,
+        )
+        async with AsyncSessionLocal() as session:
+            p = (
+                await session.execute(
+                    select(models.AdmissionProfile).where(
+                        models.AdmissionProfile.id == pid
+                    )
+                )
+            ).scalar_one()
+            ar = p.applied_rules or {}
+        assert ar.get("schema_version") == 2  # N1: không bump
+        assert ar.get("admission_path_id") is not None
+        assert "allow_unverified_submission" in ar

--- a/Backend_FastAPI/tests/unit/test_document_resolution_service.py
+++ b/Backend_FastAPI/tests/unit/test_document_resolution_service.py
@@ -1,0 +1,160 @@
+"""Unit tests cho document_resolution_service (feat/document-group-audience-merge).
+
+Pure logic, KHÔNG DB. Validate: derive_audience_set (cultural mapping + CONFIG_GAP
+nuốt nội bộ — round-3 BLOCKER), filter_shared_by_audience, mandatory_wins_merge
+(mandatory-wins + exclude_inactive G3), compute_completed_doc_codes (§6).
+"""
+import pytest
+from types import SimpleNamespace
+
+from app.services.document_resolution_service import (
+    AUDIENCE_LABELS,
+    compute_completed_doc_codes,
+    derive_audience_set,
+    filter_shared_by_audience,
+    mandatory_wins_merge,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _dt(code, *, is_active=True, name=None):
+    return SimpleNamespace(code=code, is_active=is_active, name=name or code)
+
+
+def _item(code, *, mandatory=True, active=True, order=1):
+    return SimpleNamespace(
+        document_type_id=hash(code) % 100000,
+        document_type=_dt(code, is_active=active),
+        is_mandatory=mandatory,
+        requires_upload=True,
+        submission_format="photo",
+        display_order=order,
+    )
+
+
+def _group(items, *, audience=None):
+    return SimpleNamespace(items=items, applicable_audience=audience)
+
+
+# =============================================================================
+# derive_audience_set — chiều văn hóa TRỰC TIẾP từ cultural
+# =============================================================================
+@pytest.mark.parametrize(
+    "cultural,expected",
+    [
+        ("graduated_thpt", {"POST_THPT"}),
+        ("completed_thpt", {"POST_THPT"}),
+        ("graduated_gdtx", {"POST_THPT"}),
+        ("graduated_thcs", {"POST_THCS"}),
+        ("completed_thcs", {"POST_THCS"}),
+        (None, set()),
+        ("garbage", set()),
+    ],
+)
+def test_derive_audience_cultural_dimension(cultural, expected):
+    profile = SimpleNamespace(cultural_education_level=cultural)
+    # path=None → chỉ chiều văn hóa.
+    assert derive_audience_set(profile, None) == expected
+
+
+def test_derive_audience_config_gap_swallowed_keeps_cultural():
+    """round-3 BLOCKER: derive_target_level_and_type raise CONFIG_GAP (path
+    chain chưa load) → KHÔNG raise ra ngoài, VẪN trả tập văn hóa."""
+    profile = SimpleNamespace(cultural_education_level="graduated_thpt")
+    # path không có chain eager-load → derive_target_level_and_type CONFIG_GAP.
+    bad_path = SimpleNamespace(__dict__={})  # academic_info=None → CONFIG_GAP
+    result = derive_audience_set(profile, bad_path)
+    assert result == {"POST_THPT"}  # cultural dimension survives
+
+
+def test_derive_audience_never_raises():
+    profile = SimpleNamespace(cultural_education_level=None)
+    bad_path = SimpleNamespace(__dict__={})
+    assert derive_audience_set(profile, bad_path) == set()  # không raise
+
+
+# =============================================================================
+# filter_shared_by_audience — NỀN luôn merge + overlap
+# =============================================================================
+def test_filter_shared_none_audience_only_base():
+    base = _group([_item("cccd")], audience=None)
+    thpt = _group([_item("hoc_ba_thpt")], audience=["POST_THPT"])
+    # audience_set=None (legacy/create) → CHỈ NỀN.
+    result = filter_shared_by_audience([base, thpt], None)
+    assert result == [base]
+
+
+def test_filter_shared_base_plus_overlap():
+    base = _group([_item("cccd")], audience=None)
+    thpt = _group([_item("hoc_ba_thpt")], audience=["POST_THPT"])
+    thcs = _group([_item("hoc_ba_thcs")], audience=["POST_THCS"])
+    result = filter_shared_by_audience([base, thpt, thcs], {"POST_THPT"})
+    assert base in result and thpt in result and thcs not in result
+
+
+def test_filter_shared_empty_audience_set_only_base():
+    base = _group([_item("cccd")], audience=None)
+    thpt = _group([_item("hoc_ba_thpt")], audience=["POST_THPT"])
+    # empty set && [POST_THPT] = false → chỉ NỀN.
+    assert filter_shared_by_audience([base, thpt], set()) == [base]
+
+
+# =============================================================================
+# mandatory_wins_merge — mandatory thắng + exclude_inactive (G3)
+# =============================================================================
+def test_merge_mandatory_wins():
+    optional_item = _item("x", mandatory=False)
+    mandatory_item = _item("x", mandatory=True)
+    # cùng document_type_id (code 'x') → mandatory override optional.
+    optional_item.document_type_id = mandatory_item.document_type_id = 42
+    doc_map = {}
+    mandatory_wins_merge(doc_map, [_group([optional_item])], "shared")
+    mandatory_wins_merge(doc_map, [_group([mandatory_item])], "shared")
+    assert doc_map[42][0].is_mandatory is True
+
+
+def test_merge_exclude_inactive_true_drops():
+    inactive = _item("old", active=False)
+    doc_map = {}
+    mandatory_wins_merge(doc_map, [_group([inactive])], "shared", exclude_inactive=True)
+    assert doc_map == {}
+
+
+def test_merge_exclude_inactive_false_keeps():
+    inactive = _item("old", active=False)
+    doc_map = {}
+    mandatory_wins_merge(doc_map, [_group([inactive])], "shared", exclude_inactive=False)
+    assert len(doc_map) == 1  # path/create giữ doc inactive
+
+
+def test_merge_stores_group_audience():
+    it = _item("hoc_ba_thpt")
+    doc_map = {}
+    mandatory_wins_merge(doc_map, [_group([it], audience=["POST_THPT"])], "shared")
+    _item_stored, source, grp_aud = doc_map[it.document_type_id]
+    assert source == "shared" and grp_aud == ["POST_THPT"]
+
+
+# =============================================================================
+# compute_completed_doc_codes — completed_* loại bằng TN (§6)
+# =============================================================================
+@pytest.mark.parametrize(
+    "cultural,expected",
+    [
+        ("completed_thpt", {"bang_tot_nghiep_thpt"}),
+        ("completed_thcs", {"bang_tot_nghiep_thcs"}),
+        ("graduated_thpt", set()),
+        ("graduated_thcs", set()),
+        (None, set()),
+    ],
+)
+def test_compute_completed_doc_codes(cultural, expected):
+    profile = SimpleNamespace(cultural_education_level=cultural)
+    assert compute_completed_doc_codes(profile) == expected
+
+
+def test_audience_labels_cover_all_five():
+    assert set(AUDIENCE_LABELS) == {
+        "POST_THCS", "POST_THPT", "LIEN_THONG_TC", "LIEN_THONG_CD", "VLVH",
+    }

--- a/Documents/DOCUMENT_GROUP_AUDIENCE_MERGE_PLAN.md
+++ b/Documents/DOCUMENT_GROUP_AUDIENCE_MERGE_PLAN.md
@@ -1,0 +1,210 @@
+# PLAN v9 — Bộ hồ sơ resolve đa chiều (Loại hình × Đối tượng/Trình độ × Phương thức)
+
+> **7 vòng paper-review + round-8 EMPIRICAL (§8.1 dry-run PROD đã chạy 2026-05-29).** round-7: H1/H2/H3 (P2 migration). **Round-8 data thật:** 🟢 doc type `hoc_ba_thcs`+`bang_tot_nghiep_thcs` ĐÃ TỒN TẠI → §8.0 không tạo doc type (H1 moot); 🟢 H2 moot (bang_diem_thpt đã xóa, lien_thong 0 path); 🔴 id drift prod 9/10/ot21-22 ≠ seed 1/2 → match code; 🎯 trọng tâm = group 9 chinh_quy (72 CĐ + 32 TC path), TC-từ-THCS = bug gốc owner. Chi tiết §8.1. round-1 (P0/P1/P2) **+ round-2** (2 P0+2 P1+2 P2) **+ round-3** (1 BLOCKER+1 citation+1 invariant) **+ round-4** (N1/N2 must-fix + N3-N7) **+ round-5** (4 polish) **+ round-6** (sweep data/caller thật: 3 gap material G1/G2/G3 + G4/G5). Branch: `feat/document-group-audience-merge`. Mọi quyết định kèm "đã verify file:line". **Lưu ý sửa từ v1: seed group thực tế là id 1/2 (KHÔNG phải 9/10).**
+
+> **OWNER SCOPE 2026-05-29:** GĐ1 = **machinery + cấu hình bộ THCS luôn** (không chỉ tách THPT). Thêm §8.0: tạo doc type `hoc_ba_thcs`/`bang_tot_nghiep_thcs` + seed lớp POST_THCS để THCS↔THPT khác bộ ngay. ⚠️ **Owner cần xác nhận danh mục giấy tờ THCS thực tế trước khi viết §8.0 migration.**
+
+> **Round-6 đóng (verify data+caller 2026-05-29):** **🔴 G1** = backfill §8.2 aspirational — đối chiếu seed thật chỉ POST_THPT(ot1) có data đầy đủ; ot2 không có hoc_ba; POST_THCS chưa có doc type → **§8.0 tạo bộ THCS (owner scope)**; LIEN_THONG_*/VLVH RỖNG ("bằng TC/CĐ"=vocational không phải doc, known-limitation) → §8.1 dry-run TRƯỚC, §8.2 theo output (§8). **🔴 G2** = `resolve_documents_for_path` có 3 caller (create :3216 + save :660 + admin endpoint :617); refactor no-audience=NỀN-only sẽ mất học bạ ở view admin sau backfill → default ALL layers + backward-compat (§10.6/§10.14). **🔴 G3** = 2 merge KHÁC is_active (path không filter :914-939 / public filter :466) → hàm chung tham số `exclude_inactive`, KHÔNG xóa-vì-trùng (§10.3). **🟡 G4** = upsert NỀN lookup theo code → 2 NỀN/ot (seed HS_CHINH_QUY vs SHARED_DOC_OT_{id}) → lookup (ot, audience IS NULL) (§10.8). **🟡 G5** = preview FE tự tính audience vi phạm thin-client → BE derive từ raw input (§10.14).
+
+> **Round-4 đóng (verify code 2026-05-29):** **🔴 N1** = KHÔNG bump schema_version (giữ =2; value 3 đỏ 2 test :209/:406 + zero runtime consumer) — §7/§10.7. **🔴 N2** = route GET document-groups KHÔNG Casbin-gated (auth qua `get_config_filter`→`get_current_active_user` deps.py:1886; 0 entry Casbin) → route mới mirror deps, KHÔNG cần casbin_rule — §10.13. **🟠 N3** = re-resolve derive dùng `profile.admission_path` primary; multi-NV nhất quán nhờ gate :4538 + 1 test — §7. **🟡 N4** = GIN cast `::admission_audience[]` — §10.1. **🟡 N5** = audit entry re-resolve (snapshot mutate không vào updated_fields :4172) — §7. **🟡 N6** = public ~6× group, P2 perf known-limitation — §9. **✅ N7** = magic-link sửa cultural cũng qua update_profile:4056 → re-resolve fire, không bypass.
+
+> **Round-2 đóng:** P0-A = re-resolve trigger PHẢI gồm `cultural_education_level`. P0-B = `add_path_documents_delta` (partial-unique `uq_profile_document_path`). P1-A = eager-load chain derive. P1-B = §8.3 backup + runbook one-way. P2 = code≤50 + alembic head verify.
+
+> **Round-3 đóng (verify code 2026-05-29):** **🔴 BLOCKER** = §5↔§7 mâu thuẫn CONFIG_GAP tái sinh P0-A → `derive_audience_set` **nuốt CONFIG_GAP nội bộ, luôn trả ≥ tập văn hóa** (§5); re-resolve **bỏ nhánh "giữ snapshot cũ"** (§7); anchor mạnh hóa "snapshot VẪN có học bạ" (§11). **🟠 Citation** = hard-gate cultural là `validate_eligibility` priority_service.py:1042/:1053 via `_validate_eligibility_all_choices` :4846 (raise unwrapped), KHÔNG phải KV path :5096 (do địa chỉ) — sửa §7. **🟡 Invariant** = re-resolve MERGE applied_rules per-key + flag_modified, KHÔNG gán dict mới (giữ allow_unverified_submission/path_id/round_id/scoring; submit :4974-4978 raise nếu thiếu) — §7.
+
+## 1. Mục tiêu
+Bộ hồ sơ của 1 thí sinh = hợp các lớp giấy tờ khớp theo 3 chiều: **Loại hình** (`offering_type_id`, đã có) × **Đối tượng/trình độ** (THÊM, suy từ `cultural_education_level` + `vocational_qualification` + loại hình) × **Phương thức** (`admission_method_id`, đã có).
+**Khác v1**: KHÔNG union toàn bộ. Precedence tier path/method override (fork) GIỮ NGUYÊN; audience chỉ MERGE trong tier shared (§4).
+
+## 2. Research đã verify (file:line)
+| # | Kết luận | Bằng chứng |
+|---|---|---|
+| R1 | Tier: highest có group → thắng TOÀN BỘ (if path / elif method / else shared) | admission_path_service.py:909-939; admission_path_repository.py:386-475 |
+| R2 | Snapshot `applied_rules.mandatory_docs`+`doc_configs`, schema_version=2 | admission_service.py:3221-3303, :3331 |
+| R3 | ProfileDocument CHỈ tạo từ mandatory_docs | admission_service.py:3472-3475; admission_repository.py:864-902 |
+| R4 | Action gate chặn doc ngoài mandatory_docs | admission_service.py:215-222 |
+| R5 | Checklist pass-1 lặp mandatory_docs; doc non-mandatory KHÔNG hiện | admission_service.py:1886, :2029-2100 |
+| R6 | Editable states = draft/rejected/revision_requested | admission_service.py:3892-3903; admission_state_machine.py:78-175 |
+| R7 | Cultural set qua update_profile, KHÔNG re-resolve docs | admission_service.py:4055-4058, :4124-4168 |
+| R8 | Seed FILE: group 1 (HS_CHINH_QUY ot1) + 2 (HS_LIEN_THONG ot2). **⚠️ PROD THẬT (§8.1 2026-05-29): group 9 (ot21 chinh_quy, 6 items) + 10 (ot22 lien_thong, 5 items); doc type THCS đã có** → match code/(ot,audience) KHÔNG id | seed:351-401 + dryrun PROD |
+| R9 | Enum admission_audience đã có (5 giá trị, không base), create_type=False | phase1_03:79-97; schemas/admission_path.py:61-67 |
+| R10 | upsert dùng `groups[0]` (bug multi-layer) | admission_config_service.py:474-490; document_group_repository.py:82-100 |
+| R11 | Public có merge RIÊNG; audience hiện lọc PATH (applicable_to), không lọc doc layer | public_admissions_service.py:456-470, :866-886, :262-272 |
+| R12 | Không import cycle (public không import path_service) → module chung an toàn | grep cross-import |
+| R13 | DocumentSource = shared/method_override/path_override; FE dùng để phát hiện fork | schemas/admission_path.py:48, :593-610 |
+| R14 | derive_target_level_and_type có thể raise CONFIG_GAP_TARGET_LEVEL | priority_service.py:905-992 |
+| R15 | FE key `["shared-document-group", offeringTypeId]`; route `/document-groups/shared/{ot}` | useMasterData.ts:409-431; admission_config.py:825-863 |
+| R16 | Alembic head — **VERIFY LẠI khi code** (P2): chạy `docker compose exec backend alembic heads` trên branch; nếu >1 head → tạo merge revision TRƯỚC; tuyệt đối KHÔNG tin head suy ra bằng tay (branch có 125+ migration) | alembic/versions |
+
+## 3. Schema: cột `DocumentGroup.applicable_audience`
+`ARRAY(admission_audience)` NULLABLE. NULL = lớp NỀN tier shared (luôn merge). `[..]` = merge khi `&& audience_set` (GIN index, dùng `&&` không `= ANY`). `code` unique → layer mới sinh code có hậu tố audience (**P2: hậu tố deterministic; assert `len(code) ≤ 50` — dài nhất `SHARED_DOC_OT_2_LIEN_THONG_CD` ~28 ký tự, dư**).
+
+## 4. Resolve mới (P0.1) — GIỮ tier precedence, audience CHỈ merge trong shared
+```
+if path_groups:    layers=path_groups;   src="path_override"   # fork nguyên cũ, KHÔNG đụng audience
+elif method_groups:layers=method_groups; src="method_override" # fork nguyên cũ
+else:              layers=filter_shared_by_audience(shared_groups, audience_set); src="shared"
+doc_map = mandatory_wins_merge(layers); remove completed-grad docs (§6)
+```
+`filter_shared_by_audience`: giữ group audience NULL (NỀN) + group `&& audience_set`. `audience_set=None` (legacy/admin preview) → chỉ NỀN (backward-compat); public xử lý riêng §9.
+**§4.2 Tombstone: DEFER** — audience chỉ merge trong shared tier, không trộn path/method → không có ca "path override loại giấy nền audience". Rebuild path sạch (owner cho xóa) là đủ. Mở phase 2 `layer_kind=tombstone` nếu sau cần.
+
+## 5. Mapping `derive_audience_set(profile, path) -> set[str]`
+- **Chiều văn hóa (suy TRỰC TIẾP từ `cultural_education_level`, KHÔNG qua derive):** completed/graduated_thcs→POST_THCS; completed/graduated_thpt, graduated_gdtx→POST_THPT; None→∅.
+- **Chiều loại hình (qua `derive_target_level_and_type` + vocational):** lien_thong+TC→LIEN_THONG_TC; lien_thong+CĐ→LIEN_THONG_CD; vlvh→VLVH; chinh_quy→∅.
+- **N1-VLVH known-limitation (GĐ1):** enum có VLVH nhưng §8.2 backfill KHÔNG tạo group VLVH (seed không có giấy đặc thù VLVH) → profile VLVH match NỀN+văn-hóa, KHÔNG có lớp VLVH riêng (chủ đích GĐ1). Admin tự upsert lớp VLVH qua panel nếu cần. Ghi rõ trong §8.2.
+- **Fail-safe CONFIG_GAP (R14) — NUỐT NỘI BỘ trong `derive_audience_set`:** chỉ `derive_target_level_and_type` (chiều loại hình) mới raise CONFIG_GAP. Bọc try/except QUANH RIÊNG call đó → rớt **chỉ chiều loại hình**, vẫn trả **đầy đủ chiều văn hóa** (POST_THPT/THCS vẫn còn vì suy trực tiếp từ cultural). Log warning. ⟹ `derive_audience_set` **không bao giờ raise CONFIG_GAP ra ngoài** và **luôn trả ≥ tập văn hóa** — đây là invariant chống P0-A tái sinh (xem §7 BLOCKER round-3).
+
+## 6. completed/graduated (P0.2) — LOẠI bằng TN khỏi set (KHÔNG optional)
+Verify R3-R5: hạ is_mandatory=False làm doc KHÔNG hiện/upload được (pipeline chỉ tạo+gate+render theo mandatory_docs). → **Quyết định GĐ1: `completed_*` → LOẠI document bằng TN khỏi resolved set** (không vào mandatory_docs/doc_configs/ProfileDocument). `derive` tính kèm `completed_doc_codes`; resolve bỏ item sau merge.
+**Phương án 2 (tách active_doc_codes vs required_doc_codes) DEFER GĐ2** — cần đổi pipeline 3 điểm (R3/R4/R5) + bump schema + grandfather; chỉ mở khi cần "giấy khuyến nghị nộp thêm".
+**N3-mã hằng số (verify code):** `compute_completed_doc_codes` hardcode mã bằng TN PHẢI khớp seed/catalog: `bang_tot_nghiep_thpt` ✅ verify seed (zq6w...:366,:395); **`bang_tot_nghiep_thcs` TẠO MỚI ở §8.0** (GĐ1 mở rộng owner scope) → completed_thcs sẽ loại đúng bằng TN THCS. Để hằng số trong `document_resolution_service` đồng bộ seed/§8.0, tránh removal âm thầm fail khi mã đổi.
+
+## 7. Re-resolve (P1) — TOÀN BỘ editable states, INSERT-only DELTA
+Verify R6/R7. **Trigger: `cultural_education_level` HOẶC `vocational_qualification` đổi (audience phụ thuộc 2 field này) + status ∈ {draft, rejected, revision_requested} + có admission_path_id.**
+
+**P0-A (verify code) — vì sao trigger PHẢI gồm cultural:** submit ĐÃ hard-gate cultural qua `_validate_eligibility_all_choices` (:4846) → `validate_eligibility` (priority_service.py:**1042** CĐ chính quy / :**1053** TC chính quy): `cultural=None` (hoặc sai bậc) ⇒ trả `False` ⇒ raise `BusinessRuleViolation` **UNWRAPPED** ⇒ submit abort TRƯỚC :5064/:5096. (Address hard-gate riêng :5115-5123. **KV-unresolved :5096 do địa chỉ/commune/school chi phối, KHÔNG do cultural** — citation v3 cũ sai cơ chế, đã sửa.) NHƯNG submit check `mandatory_docs` từ **SNAPSHOT** (:4852,:4965), KHÔNG re-resolve; cultural set qua update_profile vốn KHÔNG re-resolve (R7). ⟹ Nếu KHÔNG re-resolve khi cultural đổi: tạo hồ sơ cultural trống (snapshot=NỀN, thiếu học bạ/bằng TN) → set cultural sau → submit qua eligibility (cultural đã set) NHƯNG snapshot NỀN cũ ⇒ học bạ/bằng TN **âm thầm không bắt buộc = REGRESSION**. Re-resolve-on-cultural-change đóng đúng lỗ này (eligibility gate không cứu vì cultural đã set; chỉ doc snapshot stale).
+
+**P0-B (verify code) — INSERT-only = DELTA, KHÔNG reuse `initialize_documents_for_profile`:** ProfileDocument có partial-unique `uq_profile_document_path (profile_id, document_type_id) WHERE category='path'`, cột `category` default 'path' (profile_data.py:110-114,211-221). `initialize_documents_for_profile` (admission_repository.py:864-902) add **VÔ ĐIỀU KIỆN, không set category, không check tồn tại** ⇒ reuse khi re-resolve = UNIQUE violation ⇒ vỡ TOÀN BỘ update_profile (blast radius lớn). ⟹ Repo method MỚI `add_path_documents_delta(profile_id, codes)`: SELECT codes đã có (category='path') → INSERT chỉ code thiếu, set `category='path'` tường minh. KHÔNG xóa / đụng row có upload.
+
+**P1-A (verify code) — eager-load chain re-resolve:** chiều "loại hình" của audience dùng `derive_target_level_and_type`, fail-closed CONFIG_GAP nếu chain chưa eager-load (priority_service.py:929-936). Path re-resolve PHẢI eager-load `academic_info→offering→program→degree_level_ref + offering_type_config` (+ cột audience), nếu không §5 fallback chỉ-văn-hóa **âm thầm rớt layer LIEN_THONG/VLVH** (hồ sơ liên thông mất giấy đặc thù, không báo lỗi).
+
+**🔴 BLOCKER round-3 — CONFIG_GAP: KHÔNG được "giữ snapshot cũ":** `derive_audience_set` đã **nuốt CONFIG_GAP nội bộ** (§5) → luôn trả ≥ tập văn hóa → re-resolve **LUÔN apply** (POST_THPT vẫn ra học bạ/bằng TN). ⟹ Re-resolve **KHÔNG** có nhánh "CONFIG_GAP → giữ snapshot NỀN-only" (đó chính là failure mode tái sinh P0-A ở nhánh CONFIG_GAP). Outer try/except CHỈ cho exception **bất ngờ** (DB error...) và khi đó **propagate (loud-fail) — KHÔNG im lặng giữ snapshot NỀN-only**.
+
+**🟡 Invariant round-3 — MERGE applied_rules, KHÔNG replace:** submit raise nếu `schema_version!=1` mà thiếu `allow_unverified_submission` (:4974-4978). ⟹ re-resolve **update TỪNG key** (`mandatory_docs`, `doc_configs`) + `flag_modified(profile,"applied_rules")`, **TUYỆT ĐỐI KHÔNG gán dict mới** — phải giữ `allow_unverified_submission` + `admission_path_id` + `admission_round_id` + scoring config (min_gpa/allowed_subject_codes/...), nếu không submit vỡ :4975 + scoring vỡ.
+
+**🔴 N1 round-4 — KHÔNG bump schema_version:** create giữ `schema_version=2` (R2, :3331). Runtime gate chỉ phân biệt `==1`/`>=2` (:985,:4971) → value 3 KHÔNG có consumer + làm ĐỎ 2 test assert cứng `==2` (test_admission_submit_requires_verified_docs.py:209, test_adm_024_strict_default_migration.py:406). ⟹ re-resolve **KHÔNG đụng schema_version** (giữ nguyên 2) — chỉ merge mandatory_docs/doc_configs.
+
+`_reresolve_documents_snapshot`: derive_audience_set mới (chain eager-loaded §10.5, CONFIG_GAP nuốt nội bộ §5) → **merge per-key** mandatory_docs/doc_configs + flag_modified (giữ schema_version=2 + mọi key khác); `add_path_documents_delta` cho code thiếu (doc rớt → is_extra qua pass-2 read-only, KHÔNG xóa). **N5: ghi 1 audit entry re-resolve** (update_profile audit `updated_fields=data.keys()` :4172 KHÔNG bắt mutation snapshot → mất dấu "vì sao checklist đổi"). **N3: derive dùng `profile.admission_path` (path primary trong applied_rules.admission_path_id); multi-NV cùng target_level+admission_type được submit gate MULTI_NV_INCONSISTENT :4538 đảm bảo → audience nhất quán; thêm 1 test multi-NV re-resolve.** Đặt sau set cultural (:4058) trước flush (:4131). Status ngoài 3 trạng thái → gate chặn → đóng băng (không cần block riêng).
+
+## 8. Backfill (P1) — dry-run TRƯỚC, viết §8.2 theo data thật + rebuild path
+**8.1 DRY-RUN (BẮT BUỘC chạy TRƯỚC khi finalize §8.2, read-only)**: SQL `GROUP BY (offering_type_id, admission_method_id, admission_path_id, code)` đếm item. Script `scripts/dryrun_document_group_audience_2026.sql`. **§8.2 viết theo OUTPUT §8.1, KHÔNG aspirational.**
+
+**✅ §8.1 ĐÃ CHẠY PROD 2026-05-29 (round-8 empirical):**
+- **2 group shared, 0 method/path override**: group **9** `HS_CHINH_QUY` (ot **21** chinh_quy) + group **10** `HS_LIEN_THONG` (ot **22** lien_thong). ⚠️ **ID PROD = 9/10, ot 21/22 — KHÁC seed file (1/2)** → backfill match code/(ot,audience), KHÔNG hardcode id.
+- **Group 9 items (6)**: hoc_ba_thpt, bang_tot_nghiep_thpt, cccd, giay_khai_sinh, anh_3x4, giay_kham_suc_khoe (`giay_chung_nhan_uu_tien` ĐÃ XÓA — prod drift xác nhận).
+- **Group 10 items (5)**: bang_tot_nghiep_thpt, cccd, giay_khai_sinh, anh_3x4, giay_kham_suc_khoe (KHÔNG hoc_ba_thpt; `bang_diem_thpt` ĐÃ XÓA → **H2 moot**).
+- **config_document_type (8)**: 🟢 `hoc_ba_thcs` + `bang_tot_nghiep_thcs` **ĐÃ TỒN TẠI active** → §8.0 KHÔNG tạo doc type, chỉ wire vào layer.
+- **Path inventory (query 4)**: chinh_quy(ot21) = cao_dang **72 path** + trung_cap **32 path**; **lien_thong(ot22) = 0 path/0 offering** (group 10 UNUSED); vlvh/tu_xa/lien_ket = 0.
+- **🎯 KẾT LUẬN**: mục tiêu thật = **group 9 (chinh_quy ot21)**. TC chính quy (32 path) tuyển từ THCS (:1053) nhưng group 9 ép hoc_ba_thpt+bang_tot_nghiep_thpt cho MỌI hồ sơ = **bug gốc owner báo**. Group 10 unused → split tùy chọn (không tác động thực tế).
+
+**🔴 G1 round-6 — DATA THẬT: backfill chỉ đỡ được POST_THPT(ot1); 4/5 audience INERT.** Đối chiếu seed (zq6w...:351-401):
+- **ot1 (HS_CHINH_QUY)**: `hoc_ba_thpt`+`bang_tot_nghiep_thpt`+cccd+khai_sinh+anh+kham_SK+`giay_chung_nhan_uu_tien` → split POST_THPT = {hoc_ba_thpt, bang_tot_nghiep_thpt} ✅ REAL.
+- **ot2 (HS_LIEN_THONG)**: `bang_tot_nghiep_thpt`+cccd+khai_sinh+anh+kham_SK+`bang_diem_thpt` — **KHÔNG có hoc_ba_thpt**; split POST_THPT = {bang_tot_nghiep_thpt}. **🟠 H2 round-7: `bang_diem_thpt` (bảng điểm THPT) PHẢI vào POST_THPT(ot2), KHÔNG để NỀN** — ot2 phục vụ CẢ CĐ liên thông (yêu cầu THPT :1037) lẫn TC liên thông (yêu cầu THCS :1049); để NỀN sẽ ép TC-liên-thông-từ-THCS nộp bảng điểm THPT họ không có. **Điều kiện: §8.1 dry-run + path inventory xác nhận ot2 CÓ path TC liên thông; nếu ot2 chỉ CĐ liên thông → để NỀN cũng được.** (Lưu ý prod đã xóa bang_diem_thpt → §8.1 quyết định cuối.)
+- **LIEN_THONG_TC / LIEN_THONG_CD / VLVH**: **KHÔNG có doc nguồn trong seed** ("bằng TC/CĐ" là `vocational_qualification` :1037/:1049, KHÔNG phải document) → backfill RỖNG. **INERT tới khi admin upsert layer qua panel (known-limitation §5).**
+- **POST_THCS**: seed chưa có doc type THCS → **GĐ1 mở rộng (owner chốt 2026-05-29): TẠO doc type THCS + seed lớp POST_THCS** (xem §8.0 mới). KHÔNG còn inert.
+- ⚠️ **PROD drift**: `giay_chung_nhan_uu_tien` + `bang_diem_thpt` đã bị XÓA khỏi prod (MoET 2026-05-29) → §8.1 dry-run trên PROD ra tập khác seed → §8.2 phải dựa output đó.
+
+**Tuyên bố GĐ1:** POST_THPT(ot1) đầy đủ + POST_THPT(ot2) partial + **POST_THCS qua doc type mới (§8.0)** = nhu cầu gốc THCS↔THPT được phục vụ. LIEN_THONG_*/VLVH vẫn known-limitation (cần doc đặc thù sau).
+
+**8.0 (round-8 SIMPLIFIED) — Wire lớp POST_THCS dùng doc type CÓ SẴN:**
+- 🟢 **§8.1 xác nhận `hoc_ba_thcs` + `bang_tot_nghiep_thcs` ĐÃ TỒN TẠI active trong prod** → **KHÔNG tạo doc type** (H1 collision moot — nhưng TUYỆT ĐỐI không INSERT vì đụng cả code+name UNIQUE). Reference code có sẵn.
+- **Lớp POST_THCS**: tạo group `{POST_THCS}` cho **group shared ot21 (chinh_quy)** chứa 2 item `hoc_ba_thcs`+`bang_tot_nghiep_thcs`. Trọng tâm: 32 path trung_cap chinh_quy tuyển từ THCS. (Group 10 lien_thong unused → bỏ qua hoặc thêm sau.) CĐ chính quy vô hại (eligibility :1042 chặn cultural=graduated_thcs khỏi CĐ → lớp chỉ kích hoạt cho TC-từ-THCS).
+- Phụ thuộc §5: cultural `completed_thcs`/`graduated_thcs` → POST_THCS → resolve 2 doc THCS.
+- **Owner xác nhận**: 2 doc (hoc_ba_thcs + bang_tot_nghiep_thcs) có ĐỦ cho bộ hồ sơ THCS không, hay cần thêm.
+
+**8.2 Migration backfill** (idempotent, match code theo §8.1, KHÔNG hard-code id — **prod id 9/10 ≠ seed 1/2**): mỗi shared group (method+path NULL): giữ NỀN (audience NULL, item nền cccd/khai_sinh/anh/khám_SK); tách `hoc_ba_thpt`+`bang_tot_nghiep_thpt` (code TỒN TẠI) → group `{POST_THPT}` (code mới unique); **POST_THCS từ §8.0** (group 9 ot21). **Group 9 (chinh_quy ot21) = trọng tâm thật**; group 10 (lien_thong ot22) chỉ có bang_tot_nghiep_thpt để split + đang unused (0 path) → split để nhất quán nhưng không tác động. **KHÔNG tạo group rỗng cho LIEN_THONG_*/VLVH (known-limitation §5).** Profile cũ snapshot bất biến. **N4-idempotent: rerun skip cả bước MOVE (item đã ở group audience → bỏ qua), không chỉ skip tạo group** — guard "code chưa thuộc group audience". **🟡 H3 round-7: downgrade phải HOÀN NGUYÊN split THẬT** — xóa group POST_THPT/POST_THCS + move item về NỀN, KHÔNG chỉ drop cột applicable_audience (nếu chỉ drop cột mà để group tách → code cũ post-rollback merge TẤT CẢ shared group/ot → profile mới over-require cả THPT+THCS). KHÔNG drop enum, giữ doc type THCS (chỉ thêm, non-destructive).
+**8.3 Rebuild path sạch — ONE-WAY DOOR (P1-B)** (owner cho xóa prod): xóa path/method override group trộn lẫn → path fall-back shared đã split. **KHÔNG reversible: downgrade migration CHỈ gộp lại phần split §8.2, KHÔNG khôi phục group đã xóa.** Bắt buộc trước khi xóa: (a) **backup table** `document_group_backup_<date>` copy mọi row method/path-override (giữ ≥90 ngày — ref memory `migration-rollback-data-preservation-review`); (b) **runbook owner duyệt TỪNG path**; (c) **dry-run §8.1 chạy trên PROD data** (admin có thể đã upsert method/path group sau seed → phát hiện trước). KHÔNG tự động trong migration.
+
+## 9. Public documents (P1) — grouped by audience
+Verify R11. **Quyết định: không-audience → trả ALL layers GROUPED BY audience** (`audience_layers: [{audience, audience_label, documents}]`); giữ `shared_documents`=NỀN cho FE cũ. Caller truyền audience → NỀN + overlap. Tách merge dùng module §10.3.
+**N6 (P2, perf): sau backfill mỗi offering_type ≤6 group (NỀN+POST_THPT+POST_THCS+LIEN_THONG_TC/CD+VLVH) thay 1 → public catalog merge in-memory × ot × method × scope nặng hơn. Severity thấp (cached + bảng nhỏ) nhưng verify selectinload batching + TTL cache khi code. Known-limitation nếu chưa tối ưu.**
+
+## 10. File-by-file (code-ready)
+**Backend:**
+1. `models/admission_config/document_group.py` — cột applicable_audience + GIN index (reuse enum create_type=False). **N4: query phải CAST tham số `:set::admission_audience[]` (không phải text[], kẻo "operator does not exist" / bỏ index); filter chuẩn = `WHERE applicable_audience IS NULL OR applicable_audience && :set::admission_audience[]` (nhánh IS NULL = NỀN không vào GIN, seq-scan riêng OK vì bảng nhỏ; empty set `&& '{}'`=false → chỉ NỀN). EXPLAIN ANALYZE verify.**
+2. `alembic/versions/<rev>_add_applicable_audience...py` (down_revision = HEAD thực tế R16) — add column + GIN + **§8.0 (seed doc type `hoc_ba_thcs`/`bang_tot_nghiep_thcs` + lớp POST_THCS, owner-confirmed danh mục)** + backfill §8.2. Upgrade chỉ thêm (non-destructive); downgrade gộp split nhưng GIỮ doc type THCS.
+3. **`services/document_resolution_service.py` (MODULE MỚI)** — `mandatory_wins_merge`, `filter_shared_by_audience`, `AUDIENCE_LABELS`. Chỉ import models/schemas (no cycle R12). Cả path_service + public dùng chung. **🔴 G3 round-6: 2 merge KHÔNG đồng nhất — path (:914-939) KHÔNG filter is_active; public (:466) CÓ `not item.document_type.is_active: continue`. ⟹ hàm chung nhận tham số `exclude_inactive: bool`: path/create caller=`False` (giữ hành vi snapshot), public caller=`True` (giữ hardening storefront #348). KHÔNG xóa-vì-"trùng" (chúng KHÁC hành vi); test CẢ 2 caller.**
+4. `repositories/document_group_repository.py` — `get_shared_group_by_audience(ot, audience)`; get_shared_groups trả audience; get_filtered filter audience.
+4b. **`repositories/admission_repository.py` — `add_path_documents_delta(profile_id, codes)` MỚI (P0-B):** SELECT ProfileDocument codes đã có (category='path') → INSERT chỉ code thiếu, set `category='path'`. Idempotent, KHÔNG xóa upload, KHÔNG reuse `initialize_documents_for_profile`.
+5. `repositories/admission_path_repository.py` — selectinload thêm cột audience (không đổi chữ ký). **+ path query của re-resolve (trong admission_service update_profile) PHẢI eager-load chain derive `academic_info→offering→program→degree_level_ref+offering_type_config` (P1-A) cho `derive_target_level_and_type`.**
+6. `services/admission_path_service.py` — `derive_audience_set` + `compute_completed_doc_codes` + `resolve_documents_for_profile(...)`; refactor `resolve_documents_for_path`. **🔴 G2 round-6 — 3 CALLER (audit hidden caller TRƯỚC khi swap):** (a) create `admission_service.py:3216` (derive audience từ profile — đúng), (b) save-response `admission_path_service.py:660`, (c) **admin endpoint `routers/admission_paths.py:617` `get_resolved_documents`** (FE admin gọi KHÔNG audience). Nếu wrapper(audience_set=None)=NỀN-only → (b)(c) MẤT học bạ/bằng TN sau backfill (list co lại, lệch bộ hồ sơ thí sinh thật). ⟹ **default no-audience cho (b)(c) = trả ALL layers** (grouped như §9, superset — admin vẫn thấy học bạ → backward-compat FE); thêm `?audience=` để lọc 1 diện. Create (a) tự derive từ profile, không dùng default.
+7. `services/admission_service.py` — create snapshot audience_set=None, **schema_version GIỮ =2 (N1)**; update_profile `_reresolve_documents_snapshot` §7 INSERT-only delta + merge per-key + audit entry (N5).
+8. `services/admission_config_service.py` — sửa get/upsert_shared_document_group: lookup (ot, audience), bỏ groups[0] (R10), sinh code unique theo audience. **🟡 G4 round-6: lookup NỀN (audience IS NULL) phải match group seed THEO `(offering_type_id, applicable_audience IS NULL)`, KHÔNG theo code** — seed dùng `HS_CHINH_QUY`/`HS_LIEN_THONG` còn upsert sinh `SHARED_DOC_OT_{id}` (:502); nếu lookup theo code sẽ tạo group NỀN thứ 2 trùng ot → 2 NỀN/ot. Reuse group NỀN hiện hữu bất kể code.
+9. `services/public_admissions_service.py` — §9 audience_layers + dùng module §10.3.
+10. `schemas/document_group.py` + `schemas/admission_config.py` — thêm applicable_audience.
+11. `schemas/admission_path.py` — GIỮ DocumentSource nguyên nghĩa; THÊM field `applicable_audience` + `layer_kind` trên ResolvedDocumentResponse (KHÔNG overload source) — P2.
+12. `schemas/public_admissions.py` — `PublicAdmissionsAudienceDocumentLayer` + `audience_layers`.
+13. `routers/admission_config.py` — route `/document-groups/shared/{ot}/{audience}` (audience vào PATH cho cache key — P2). **N2 (verify code): route GET document-groups KHÔNG Casbin-gated — GET cũ `/document-groups/shared/{ot}` (:825-844) chỉ có deps `get_config_filter`+`get_db`; `get_config_filter` (deps.py:1886) đã `Depends(get_current_active_user)` ⇒ auth bằng current_user, KHÔNG check_permission/Casbin (grep casbin_config = 0 entry document-group). ⟹ route mới MIRROR đúng deps đó (`get_config_filter`+`get_db`) → kế thừa auth, KHÔNG cần casbin_rule migration, KHÔNG 403. TUYỆT ĐỐI không thêm check_permission.**
+14. `routers/admission_paths.py` — GET `/paths/{id}/documents` (route :617 hiện hữu): default no-audience → ALL layers (G2); thêm `?audience=` lọc 1 diện. **AN TOÀN Casbin: audience là query param, path KHÔNG đổi → policy :535 vẫn cover.** **🟡 G5 round-6 — preview thí sinh THIN-CLIENT:** dialog "Xem trước theo TS" (§5b) nhận **raw `cultural_education_level` + `vocational_qualification` (+ offering_type)** → BE `derive_audience_set` rồi resolve; KHÔNG để FE tự tính audience (vi phạm thin-client, memory `fe-thin-client-compliance`). `?audience=` chỉ dùng cho **bộ lọc lớp ở config panel** (admin chọn lớp để sửa — filter hợp lệ, KHÔNG phải business logic), KHÔNG dùng cho preview thí sinh.
+
+**Frontend:**
+15. `_components/shared/types.ts` — AdmissionAudience union; thêm applicable_audience + layer_kind.
+16. `lib/api/master-data.ts` + `hooks/admissions/useMasterData.ts` — audience vào path + queryKey `["shared-document-group", ot, audience]` (R15 P2).
+17. `Phase1Master/SharedDocumentConfigPanel.tsx` — Select Đối tượng (filter lớp để sửa) + (optional) Phương thức + nút Xem trước; reset modifications khi đổi audience. Bảng giấy tờ GIỮ NGUYÊN. **G5: nút "Xem trước theo TS" gửi raw cultural/vocational/offering_type cho BE derive — KHÔNG tự tính audience.**
+18. `Phase3Config/ConfigDocuments.tsx` — badge layer_kind + applicable_audience (render BE).
+
+## 5b. Wireframe FE (giữ từ v1)
+### HIỆN TẠI (1 chiều)
+```
+Loại hình: [ Chính quy ▼ ]
+[bảng giấy tờ: ☑ Học bạ THPT | ☑ Bằng TN THPT | ☑ CCCD ... | Bắt buộc | Up file | Thứ tự]  [💾 Lưu]
+```
+### SAU FEATURE (3 bộ lọc lớp + Xem trước, bảng GIỮ NGUYÊN)
+```
+Loại hình: [ Tất cả ▼ ]   Đối tượng: [ Sau THPT ▼ ]   Phương thức: [ Tất cả ▼ ]   [👁 Xem trước theo TS]
+LỚP: "Tất cả loại hình × Sau THPT"   ⓘ NỀN (Đối tượng=Tất cả) luôn gộp thêm cho mọi thí sinh.
+[bảng giấy tờ như cũ]  [💾 Lưu lớp]
+
+[Xem trước] → dialog: Loại hình + Trình độ VH + Phương thức → [Tính bộ hồ sơ]
+  → CCCD(NỀN), Khai sinh(NỀN), Ảnh/Khám SK(NỀN), Học bạ THPT(Lớp Sau THPT), Bằng TN THPT(Lớp Sau THPT)★
+  (★=bắt buộc khi tốt nghiệp; "completed" → LOẠI khỏi bộ hồ sơ)
+```
+Controls: Đối tượng (MỚI, enum BE), Phương thức (MỚI optional), Xem trước (MỚI, BE resolve). Thin-client: options+preview từ BE; badge dùng `layer_kind`/`applicable_audience` (KHÔNG overload source).
+
+## 11. Test
+- Unit derive_audience_set (5 cultural × 4 vocational × 3 type; CONFIG_GAP fallback); compute_completed_doc_codes (completed→loại bằng TN).
+- Resolve MERGE (mở rộng test_phase2_engine_3tier_resolution.py): NỀN-only=cũ; POST_THPT layer; **path_override KHÔNG bị audience trộn** (anti-regression P0.1); mandatory-wins; completed→bằng TN bị loại.
+- Integration (test_admission_documents_audience.py mới): create=NỀN; PATCH cultural ở 3 editable→re-resolve INSERT-only; doc rớt→is_extra; PATCH ở submitted→gate chặn.
+- **P0-A end-to-end (anchor regression):** create hồ sơ cultural trống (snapshot NỀN, KHÔNG có học bạ/bằng TN) → PATCH cultural=`completed_thpt` → assert snapshot mandatory_docs CÓ học bạ+bằng TN → submit assert 2 doc đó BẮT BUỘC (không submit được khi thiếu).
+- **P0-B (anchor):** re-resolve khi code đã tồn tại (vd CCCD nền) → `add_path_documents_delta` KHÔNG vi phạm `uq_profile_document_path`, update_profile thành công, upload cũ còn nguyên.
+- **P1-A + BLOCKER round-3 (anchor MẠNH):** re-resolve khi `derive_target_level_and_type` raise CONFIG_GAP (config NULL) + cultural=`graduated_thpt` → derive_audience_set nuốt CONFIG_GAP nội bộ, trả `{POST_THPT}` → **assert snapshot VẪN có học bạ + bằng TN** (KHÔNG chỉ "update_profile không vỡ" — anchor cũ không bắt được lỗ CONFIG_GAP). + assert applied_rules còn `allow_unverified_submission`/`admission_path_id` sau merge (invariant round-3) → submit KHÔNG raise :4975.
+- upsert 2 layer không đè (R10); backfill seed 1/2→split, idempotent, downgrade; public audience=None grouped.
+- **N1 (anchor):** create snapshot assert `schema_version==2` (KHÔNG bump 3) → 2 test :209/:406 vẫn xanh.
+- **N3 multi-NV (anchor):** hồ sơ uses_choice_engine 2 choice cùng offering_type → PATCH cultural → re-resolve dùng profile.admission_path → audience nhất quán, snapshot đúng.
+- **G2 admin endpoint (anchor):** GET `/paths/{id}/documents` KHÔNG audience SAU backfill → assert VẪN có học bạ/bằng TN (ALL layers, không co lại); `?audience=POST_THPT` → lọc đúng 1 diện.
+- **G3 is_active (anchor 2 caller):** merge chung với doc_type inactive → create/path (`exclude_inactive=False`) GIỮ doc inactive; public (`exclude_inactive=True`) BỎ doc inactive (storefront #348 không regression).
+- **G1 data thật (anchor):** backfill trên seed → POST_THPT(ot1) có hoc_ba+bằng TN; LIEN_THONG/VLVH RỖNG (assert không tạo group rỗng); profile cũ snapshot bất biến.
+- **§8.0 THCS (anchor):** sau §8.0 → hồ sơ cultural=`graduated_thcs` (TC từ THCS) resolve ra `hoc_ba_thcs`+`bang_tot_nghiep_thcs`; hồ sơ cultural=`graduated_thpt` KHÔNG dính doc THCS (đúng phân biệt THCS↔THPT — nhu cầu gốc).
+- CI: thêm test vào backend-test.yml Tier 4+5.
+
+## 12. Rollout
+**Chia 2 đợt co blast radius (round-1):** ĐỢT A = code + schema (cột applicable_audience + GIN), KHÔNG backfill. **⚠️ Framing chính xác (round-8 #2):** ĐỢT A inert cho cultural ∈ {graduated_*, None} (filter NỀN trả nguyên bộ → snapshot không đổi), NHƯNG **completed_*** ĐỔI hành vi NGAY: PATCH cultural=completed_thpt/thcs → re-resolve LOẠI bằng TN khỏi snapshot (§6 — TS hoàn thành chưa có bằng, không ép nộp). Đây là fix đúng, KHÔNG phải bug; nhưng KHÔNG phải "zero behavior change" tuyệt đối. Profile cũ snapshot bất biến (chỉ re-fire khi PATCH cultural/vocational). ĐỢT B (gated owner) = backfill §8.2 + §8.0 POST_THCS + rebuild path §8.3.
+Branch → CI xanh (gồm anchor N1/N3 + P0-A/P0-B/P1-A) → owner duyệt (re-resolve INSERT-only + dry-run output + public schema) → merge squash → deploy CÓ migration: cold cutover (RUN_MIGRATIONS_ON_STARTUP=false, alembic ĐỢT A, verify GIN EXPLAIN) → ĐỢT B: dry-run §8.1 trên PROD, backfill §8.2, verify split, rebuild path §8.3 (backup table + owner duyệt từng path). **KHÔNG có feature flag — cold cutover ship code+data theo 2 đợt; "bật flag" đã bỏ (không định nghĩa flag nào).** Enum đã có→không tạo. Ref runbook §3.5/§7.2.
+
+## 13. Risks
+1. Union phá fork → tier precedence giữ, audience chỉ shared (§4) + test anti-regression.
+2. completed=optional bất khả thi → loại khỏi set (§6).
+3. upsert single-group (R10) → lookup (ot,audience) + test.
+4. Backfill làm checklist profile mới co lại → chủ đích; profile cũ bất biến.
+5. CONFIG_GAP raise → **nuốt nội bộ trong derive_audience_set, luôn trả ≥ tập văn hóa** (§5); re-resolve KHÔNG giữ snapshot NỀN-only (BLOCKER round-3).
+6. GIN miss → dùng `&&` + **CAST `:set::admission_audience[]` (N4)**; query `IS NULL OR && :set::audience[]`; EXPLAIN ANALYZE.
+7. 2 nơi resolve drift → module chung document_resolution_service.
+8. FE cache đè → audience vào route+queryKey.
+9. Tombstone defer → known-limitation phase 2.
+10. code unique collision → hậu tố audience + check tồn tại + assert ≤50 (P2).
+11. **P0-A doc snapshot stale** (cultural set sau create không vào snapshot) → re-resolve trigger gồm cultural/vocational (§7) + test e2e anchor (§11).
+12. **P0-B UNIQUE violation re-resolve** (đụng uq_profile_document_path) → `add_path_documents_delta` delta INSERT (§7/§10.4b) + test anchor.
+13. **P1-A audience rớt layer liên thông** (derive CONFIG_GAP do thiếu eager-load) → eager-load chain (§10.5) + try/except fallback + test anchor.
+14. **P1-B rebuild path one-way** (downgrade không khôi phục group đã xóa) → backup table + runbook owner + dry-run PROD (§8.3).
+15. **BLOCKER round-3: §5↔§7 mâu thuẫn CONFIG_GAP** (giữ snapshot cũ tái sinh P0-A ở nhánh CONFIG_GAP) → derive_audience_set nuốt nội bộ + re-resolve luôn apply (§5/§7) + anchor mạnh §11.
+16. **Citation round-3: hard-gate cultural** thực ra ở `validate_eligibility` :1042/:1053 via :4846 (raise unwrapped), KHÔNG phải KV :5096 (do địa chỉ) → sửa §7.
+17. **Invariant round-3: replace applied_rules vỡ submit** (:4974-4978 + scoring) → MERGE per-key + flag_modified, KHÔNG gán dict mới (§7).
+18. **N1 round-4: schema_version=3 làm đỏ 2 test + zero benefit** (assert ==2 tại :209/:406; runtime chỉ ==1/>=2) → KHÔNG bump, giữ =2 (§7/§10.7).
+19. **N2 round-4: route {audience} 403** → verify route GET document-groups KHÔNG Casbin-gated (auth qua get_config_filter→current_user); mirror deps, KHÔNG thêm casbin_rule/check_permission (§10.13).
+20. **N3 round-4: multi-NV derive đa path** → re-resolve derive dùng profile.admission_path primary; submit gate MULTI_NV_INCONSISTENT :4538 đảm bảo nhất quán; +1 test multi-NV (§7).
+21. **N4 round-4: GIN trên ARRAY(enum)** → cast `::admission_audience[]` (xem risk 6).
+22. **N5 round-4: re-resolve mutate snapshot không vào audit** (updated_fields=data.keys() :4172) → thêm audit entry re-resolve (§7).
+23. **N6 round-4: public catalog ~6× group** → P2 perf, verify selectinload batching + TTL; known-limitation (§9).
+24. **P2 round-5: VLVH inert GĐ1** (enum có VLVH, backfill không tạo group) → known-limitation chủ đích; admin upsert nếu cần (§5/§8.2).
+25. **P2 round-5: "bật flag" mơ hồ** (không định nghĩa flag) → bỏ; cold cutover 2 đợt code+data (§12).
+26. **P2 round-5: compute_completed_doc_codes hardcode mã** → hằng số đồng bộ seed (`bang_tot_nghiep_thpt` ✅; `bang_tot_nghiep_thcs` verify catalog lúc code) (§6).
+27. **P2 round-5: idempotency bước MOVE** (rerun không được re-move item đã split) → guard "code chưa thuộc group audience" (§8.2).
+28. **🔴 G1 round-6: backfill §8.2 aspirational vs data thật** (4/5 audience không có doc nguồn trong seed; ot2 không có hoc_ba; "bằng TC/CĐ"=vocational không phải doc) → §8.1 dry-run TRƯỚC, §8.2 viết theo output; **owner chốt 2026-05-29: GĐ1 mở rộng TẠO doc type THCS + lớp POST_THCS (§8.0)** để phục vụ nhu cầu gốc; LIEN_THONG/VLVH vẫn known-limitation (§8).
+29. **🔴 G2 round-6: refactor resolve_documents_for_path regression view admin** (3 caller :3216/:660/:617; no-audience=NỀN-only mất học bạ sau backfill) → default no-audience trả ALL layers + backward-compat FE + liệt kê 3 caller (§10.6/§10.14).
+30. **🔴 G3 round-6: 2 merge khác is_active** (path không filter; public filter) → hàm chung tham số `exclude_inactive`, mỗi caller giữ hành vi; test cả 2 (§10.3).
+31. **🟡 G4 round-6: upsert NỀN lookup theo code → 2 NỀN/ot** (seed HS_CHINH_QUY vs upsert SHARED_DOC_OT_{id}) → lookup theo (ot, audience IS NULL) reuse group hiện hữu (§10.8).
+32. **🟡 G5 round-6: preview FE tự tính audience vi phạm thin-client** → preview nhận raw cultural/vocational, BE derive; `?audience=` chỉ cho filter panel (§10.14/§17).
+33. **🟠 H1 round-7: config_document_type.name UNIQUE** (:176) → §8.0 idempotent phải pre-check cả name, KHÔNG ON CONFLICT(code) đơn lẻ (§8.0).
+34. **🟠 H2 round-7: bang_diem_thpt(ot2) ép TC-liên-thông-từ-THCS** nếu để NỀN → đưa vào POST_THPT(ot2); §8.1 xác nhận ot2 có path TC liên thông (§8.2/G1).
+35. **🟡 H3 round-7: downgrade chỉ drop cột → over-require** (group split đứng yên, code cũ merge tất cả) → downgrade hoàn nguyên split thật (§8.2).


### PR DESCRIPTION
## Mục tiêu
Bộ hồ sơ resolve **đa chiều theo audience**: loại hình (offering_type) × **trình độ văn hóa / đối tượng** (THÊM) × phương thức. Giải quyết nhu cầu gốc: **TS tốt nghiệp THCS load bộ THCS, THPT load bộ THPT** — hiện group chính quy ép `hoc_ba_thpt`+`bang_tot_nghiep_thpt` cho MỌI hồ sơ kể cả TS chỉ tốt nghiệp THCS (32 path trung cấp prod).

**ĐỢT A = machinery + schema, KHÔNG backfill.** Inert cho cultural ∈ {graduated_*, None} (filter NỀN trả nguyên bộ → snapshot không đổi). `completed_*` ĐỔI hành vi ngay: loại bằng TN theo §6 (TS hoàn thành chưa có bằng → không ép nộp) — fix đúng, không phải bug.

## Thay đổi
- **Migration `docgrp_audience_20260529`**: cột `document_group.applicable_audience` (`admission_audience[]` nullable) + GIN. NULL = lớp NỀN (luôn merge). Enum reuse `create_type=False`. KHÔNG backfill (ĐỢT A inert).
- **`document_resolution_service.py`** (module chung path_service + public): `mandatory_wins_merge(exclude_inactive)` — G3 2 caller khác is_active; `filter_shared_by_audience`; `derive_audience_set` (nuốt CONFIG_GAP nội bộ → luôn ≥ tập văn hóa); `compute_completed_doc_codes`.
- **Repo**: `add_path_documents_delta` (P0-B: delta INSERT, set `category='path'`, KHÔNG reuse `initialize_documents_for_profile` → tránh vi phạm `uq_profile_document_path`); `get_path_for_audience_reresolve` (P1-A eager-load chain derive).
- **`admission_path_service`**: `resolve_documents_for_profile` + audience-aware `resolve_documents_for_path` (`all_audiences` cho admin view — G2) + `_build_resolved_response` (`layer_kind`).
- **`update_profile`**: `_reresolve_documents_snapshot` khi cultural/vocational đổi (editable states, MERGE per-key giữ `schema_version=2` — N1, delta INSERT, audit N5, CONFIG_GAP loud-fail, short-circuit no-op).
- **Schema** `ResolvedDocumentResponse`: `+applicable_audience` `+layer_kind` (giữ `source` — không overload). **Router** `/paths/{id}/documents`: `?audience=` optional + default ALL layers (G2, query-param Casbin-safe).

## Test
- **22 unit** (`test_document_resolution_service.py`) + **6 integration anchor** (`test_document_audience_reresolve.py`): create=NỀN; THCS→bộ THCS (không THPT); THPT→bộ THPT; completed_thpt→bỏ bằng TN; delta-no-unique idempotent (P0-B); merge-per-key giữ schema_version=2+path_id. **28 pass** trong one-off container.
- Regression suite cũ: 90 pass / 10 fail = **PRE-EXISTING** (clean-main đối chứng: 4 submit CONFIG_GAP #337 + 6 document_staging test-debt). **Zero regression.**
- Thêm 2 file test vào `backend-test.yml` Tier 5.

## Defer ĐỢT B (owner-gated)
backfill §8.2 (tách THPT khỏi NỀN) + §8.0 lớp POST_THCS (doc type `hoc_ba_thcs`+`bang_tot_nghiep_thcs` đã có sẵn prod) + rebuild §8.3 + FE panel/preview. Dry-run prod đã chạy — target = group 9 chinh_quy ot21.

Plan đầy đủ: `Documents/DOCUMENT_GROUP_AUDIENCE_MERGE_PLAN.md` (9 vòng review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)