### PR TITLE
chore(deps): bump axios 1.15.2 → 1.16.1 (fix GHSA-pjwm-pj3p-43mv high)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,7 +35,7 @@
         "@tanstack/react-query": "^5.90.5",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.13",
-        "axios": "^1.13.1",
+        "axios": "^1.16.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -7525,13 +7525,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,7 @@
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.13",
-    "axios": "^1.13.1",
+    "axios": "^1.16.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
## Vì sao
`dependency-audit.yml` → **Node.js Dependencies** (npm audit) đỏ trên CẢ main do **axios high-severity vuln mới công bố** (~5 ngày qua, sau lần main pass 2026-05-25):
- **GHSA-pjwm-pj3p-43mv** (high): NO_PROXY bypass — incomplete fix CVE-2025-62718
- GHSA-898c-q2cr-xwhg + GHSA-654m-c8p4-x5fp: prototype-pollution header injection

axios 1.15.2 ∈ vulnerable range `1.0.0 - 1.15.2`. Fix = **1.16.1** (latest 1.x, `fixAvailable: true`).

## Thay đổi
- `frontend/package.json`: axios `^1.13.1` → `^1.16.1`.
- `frontend/package-lock.json`: axios 1.15.2 → 1.16.1 (regenerate `--package-lock-only`).
- **Minor bump trong major 1.x → non-breaking semver.** Diff surgical: CHỈ axios (1 version line), không mass re-resolve.

## Verify
- `npm ci` cài axios 1.16.1 ✅
- **type-check `tsc --noEmit` xanh** với 1.16.1 (0 lỗi) ✅
- CI sẽ chạy: `dependency-audit` (npm audit → 0 high) + `frontend-test` (build + vitest + type-check).

Mở khoá merge [#350](https://github.com/favouritekid/QLTS/pull/350) (backend feature đang bị block bởi audit gate này). Khớp pattern `chore(deps)` của repo (idna/markdown/starlette gần đây).

🤖 Generated with [Claude Code](https://claude.com/claude-code)