### PR TITLE
feat(admissions): document-group audience backfill — split lớp (ĐỢT B)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -262,4 +262,5 @@ jobs:
           tests/unit/test_public_admissions_phase1_wave6.py
           tests/unit/test_document_resolution_service.py
           tests/integration/test_document_audience_reresolve.py
+          tests/unit/test_docgrp_audience_backfill_migration.py
           -q --tb=short --timeout=60

--- a/Backend_FastAPI/alembic/versions/docgrp_audience_bf_20260530_backfill_split_layers.py
+++ b/Backend_FastAPI/alembic/versions/docgrp_audience_bf_20260530_backfill_split_layers.py
@@ -1,0 +1,284 @@
+"""feat/document-group-audience-merge — ĐỢT B: backfill split lớp audience
+
+Revision ID: docgrp_audience_bf_20260530
+Revises: docgrp_audience_20260529
+Create Date: 2026-05-30
+
+ĐỢT B (data migration, owner-gated) — tách bộ hồ sơ NỀN thành các lớp theo
+``applicable_audience`` để TS tốt nghiệp THCS / THPT nhận đúng bộ giấy tờ.
+
+Bối cảnh (plan §8): group shared (``admission_method_id`` + ``admission_path_id``
+NULL, ``applicable_audience`` NULL = lớp NỀN) hiện gộp HỌC BẠ + BẰNG TN THPT cho
+MỌI hồ sơ — kể cả TS chỉ tốt nghiệp THCS (32 path trung cấp chính quy). Đây là
+bug gốc owner báo.
+
+Migration làm 2 việc, GENERIC + DATA-DRIVEN (match theo CODE, KHÔNG hard-code
+id — prod id 9/10 ≠ seed 1/2; §8.1 dry-run xác nhận drift) cho TỪNG group NỀN:
+
+§8.2 — SPLIT POST_THPT (MOVE):
+  Item có doc code ∈ {hoc_ba_thpt, bang_tot_nghiep_thpt, bang_diem_thpt}
+  → CHUYỂN sang group anh em ``{code}_POST_THPT`` (applicable_audience=[POST_THPT]).
+  Resolve gộp NỀN + lớp khớp audience → TS THPT vẫn nhận đủ; TS THCS KHÔNG bị ép.
+
+§8.0 — WIRE POST_THCS (INSERT, CHỈ offering type ``chinh_quy``):
+  Tạo group ``{code}_POST_THCS`` (applicable_audience=[POST_THCS]) +
+  thêm item hoc_ba_thcs + bang_tot_nghiep_thcs (doc type ĐÃ TỒN TẠI prod —
+  §8.1 round-8; KHÔNG tạo doc type). Phục vụ 32 path trung cấp chính quy
+  tuyển từ THCS. CĐ chính quy vô hại (eligibility chặn graduated_thcs khỏi CĐ).
+
+KHÔNG đụng (chủ đích):
+- Group method/path-override (audience chỉ có nghĩa ở tier shared). §8.1 prod = 0
+  override group → §8.3 "rebuild path" MOOT (không có gì để xóa).
+- LIEN_THONG_*/VLVH: seed không có doc nguồn ("bằng TC/CĐ" = vocational_qualification,
+  KHÔNG phải document) → known-limitation §5; admin upsert qua panel nếu cần.
+- POST_THCS cho offering type ≠ chinh_quy (lien_thong ot22 unused 0 path).
+- Snapshot ``applied_rules`` của hồ sơ cũ (bất biến — chỉ re-fire khi PATCH
+  cultural/vocational qua update_profile, đã ship ĐỢT A).
+
+Idempotent (N4): rerun bỏ qua CẢ tạo group LẪN move (item đã rời NỀN → query
+rỗng; group audience đã tồn tại → reuse theo code). An toàn chạy lại nhiều lần.
+
+Downgrade (H3): HOÀN NGUYÊN split THẬT — move item POST_THPT VỀ NỀN + xóa group
+POST_THPT (rỗng) + xóa group POST_THCS (cascade item). KHÔNG drop doc type
+(non-destructive). Bắt buộc reverse thật: nếu chỉ drop cột (ĐỢT A) mà để group
+tách đứng yên → code resolve cũ post-rollback merge TẤT CẢ shared group/ot →
+hồ sơ mới over-require cả THPT lẫn THCS.
+"""
+from typing import Optional, Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+
+# revision identifiers, used by Alembic.
+revision: str = "docgrp_audience_bf_20260530"
+down_revision: Union[str, None] = "docgrp_audience_20260529"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# --- Phân loại doc code → lớp audience (quyết định backfill, §8.0/§8.2/H2) ---
+# THPT-level (học bạ / bằng TN / bảng điểm THPT). bang_diem_thpt vào POST_THPT
+# (H2): KHÔNG để NỀN, tránh ép TC-liên-thông-từ-THCS nộp bảng điểm THPT.
+POST_THPT_DOC_CODES = ("hoc_ba_thpt", "bang_tot_nghiep_thpt", "bang_diem_thpt")
+# THCS-level — INSERT cho lớp POST_THCS (doc type có sẵn prod §8.1).
+POST_THCS_DOC_CODES = ("hoc_ba_thcs", "bang_tot_nghiep_thcs")
+# Lớp POST_THCS CHỈ wire cho offering type chính quy (§8.0 owner scope).
+CHINH_QUY_OT_CODE = "chinh_quy"
+
+# Nhãn group (mirror document_resolution_service.AUDIENCE_LABELS — migration
+# tự chứa, KHÔNG import app code).
+_AUDIENCE_LABELS = {
+    "POST_THPT": "Tốt nghiệp THPT",
+    "POST_THCS": "Tốt nghiệp THCS",
+}
+
+# Mặc định item THCS mới — mirror item THPT hiện hữu (is_mandatory=t,
+# requires_upload=t, submission_format=certified_copy — verify dev 2026-05-30).
+_THCS_ITEM_SUBMISSION_FORMAT = "certified_copy"
+
+
+def _audience_group_code(nen_code: str, audience: str) -> str:
+    """Code group lớp = ``{nen_code}_{audience}`` (deterministic → idempotent +
+    downgrade khớp đúng group migration tạo, KHÔNG đụng group admin upsert qua
+    panel — panel sinh ``SHARED_DOC_OT_{id}*`` khác scheme)."""
+    code = f"{nen_code}_{audience}"
+    # §3/P2: code UNIQUE VARCHAR(50). Fail-loud nếu vượt (seed thực ~23 ký tự).
+    assert len(code) <= 50, (
+        f"audience group code '{code}' ({len(code)} ký tự) > 50 — "
+        f"đổi scheme hậu tố cho group NỀN code dài '{nen_code}'"
+    )
+    return code
+
+
+def _ensure_audience_group(
+    bind, nen_id: int, nen_code: str, nen_name: str, offering_type_id: int,
+    audience: str,
+) -> int:
+    """Tạo (hoặc reuse nếu đã có — idempotent) group shared lớp ``audience``.
+
+    Group anh em cùng offering_type, method+path NULL, applicable_audience=[audience].
+    """
+    code = _audience_group_code(nen_code, audience)
+    existing = bind.execute(
+        text("SELECT id FROM document_group WHERE code = :code"),
+        {"code": code},
+    ).scalar()
+    if existing is not None:
+        return existing
+
+    label = _AUDIENCE_LABELS[audience]
+    new_id = bind.execute(
+        text(
+            """
+            INSERT INTO document_group (
+                offering_type_id, admission_method_id, admission_path_id,
+                code, name, description, is_active, applicable_audience
+            )
+            VALUES (
+                :ot, NULL, NULL,
+                :code, :name, :descr, TRUE,
+                ARRAY[:aud]::admission_audience[]
+            )
+            RETURNING id
+            """
+        ),
+        {
+            "ot": offering_type_id,
+            "code": code,
+            "name": f"{nen_name} — {label}",
+            "descr": f"Lớp giấy tờ theo đối tượng: {label} (tách từ {nen_code}).",
+            "aud": audience,
+        },
+    ).scalar()
+    return new_id
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # Mọi group NỀN tier shared (method+path NULL, audience NULL).
+    nen_groups = bind.execute(
+        text(
+            """
+            SELECT dg.id, dg.code, dg.name, dg.offering_type_id, ot.code AS ot_code
+            FROM document_group dg
+            JOIN config_offering_type ot ON ot.id = dg.offering_type_id
+            WHERE dg.admission_method_id IS NULL
+              AND dg.admission_path_id IS NULL
+              AND dg.applicable_audience IS NULL
+            ORDER BY dg.id
+            """
+        )
+    ).fetchall()
+
+    for grp in nen_groups:
+        # ---- §8.2 — MOVE item THPT-level sang lớp POST_THPT ----
+        thpt_items = bind.execute(
+            text(
+                """
+                SELECT dgi.id
+                FROM document_group_item dgi
+                JOIN config_document_type dt ON dt.id = dgi.document_type_id
+                WHERE dgi.group_id = :gid
+                  AND dt.code = ANY(:codes)
+                """
+            ),
+            {"gid": grp.id, "codes": list(POST_THPT_DOC_CODES)},
+        ).fetchall()
+
+        if thpt_items:  # KHÔNG tạo group rỗng (§8.2)
+            thpt_gid = _ensure_audience_group(
+                bind, grp.id, grp.code, grp.name, grp.offering_type_id, "POST_THPT"
+            )
+            for (item_id,) in thpt_items:
+                # MOVE: group anh em mới → KHÔNG đụng uq_document_group_item
+                # (group_id, document_type_id) vì target group khác.
+                bind.execute(
+                    text(
+                        "UPDATE document_group_item SET group_id = :ng WHERE id = :iid"
+                    ),
+                    {"ng": thpt_gid, "iid": item_id},
+                )
+
+        # ---- §8.0 — INSERT lớp POST_THCS (chỉ chinh_quy) ----
+        if grp.ot_code == CHINH_QUY_OT_CODE:
+            # Doc type THCS phải tồn tại (§8.1: có sẵn prod). Trên DB thiếu
+            # (test/fresh) → bỏ qua, KHÔNG tạo group rỗng.
+            thcs_types = bind.execute(
+                text(
+                    """
+                    SELECT id, code FROM config_document_type
+                    WHERE code = ANY(:codes)
+                    ORDER BY array_position(:codes, code)
+                    """
+                ),
+                {"codes": list(POST_THCS_DOC_CODES)},
+            ).fetchall()
+
+            if thcs_types:
+                thcs_gid = _ensure_audience_group(
+                    bind, grp.id, grp.code, grp.name, grp.offering_type_id,
+                    "POST_THCS",
+                )
+                for order, (dt_id, _code) in enumerate(thcs_types, start=1):
+                    # Idempotent: chỉ INSERT nếu (group, doc_type) chưa có.
+                    exists = bind.execute(
+                        text(
+                            """
+                            SELECT 1 FROM document_group_item
+                            WHERE group_id = :g AND document_type_id = :d
+                            """
+                        ),
+                        {"g": thcs_gid, "d": dt_id},
+                    ).scalar()
+                    if exists:
+                        continue
+                    bind.execute(
+                        text(
+                            """
+                            INSERT INTO document_group_item (
+                                group_id, document_type_id, is_mandatory,
+                                requires_upload, submission_format, display_order
+                            )
+                            VALUES (:g, :d, TRUE, TRUE, :fmt, :ord)
+                            """
+                        ),
+                        {
+                            "g": thcs_gid,
+                            "d": dt_id,
+                            "fmt": _THCS_ITEM_SUBMISSION_FORMAT,
+                            "ord": order,
+                        },
+                    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    # Reverse THẬT cho từng group NỀN (H3). Match group lớp theo code
+    # deterministic ``{nen_code}_POST_*`` → chỉ đụng group migration tạo.
+    nen_groups = bind.execute(
+        text(
+            """
+            SELECT id, code FROM document_group
+            WHERE admission_method_id IS NULL
+              AND admission_path_id IS NULL
+              AND applicable_audience IS NULL
+            ORDER BY id
+            """
+        )
+    ).fetchall()
+
+    for grp in nen_groups:
+        # POST_THPT: MOVE item VỀ NỀN rồi xóa group (rỗng).
+        thpt_code = f"{grp.code}_POST_THPT"
+        thpt_gid: Optional[int] = bind.execute(
+            text("SELECT id FROM document_group WHERE code = :c"),
+            {"c": thpt_code},
+        ).scalar()
+        if thpt_gid is not None:
+            bind.execute(
+                text(
+                    "UPDATE document_group_item SET group_id = :nen WHERE group_id = :thpt"
+                ),
+                {"nen": grp.id, "thpt": thpt_gid},
+            )
+            bind.execute(
+                text("DELETE FROM document_group WHERE id = :id"),
+                {"id": thpt_gid},
+            )
+
+        # POST_THCS: xóa group → item cascade (item THCS được INSERT, KHÔNG
+        # có ở NỀN trước đó nên KHÔNG move về).
+        thcs_code = f"{grp.code}_POST_THCS"
+        thcs_gid: Optional[int] = bind.execute(
+            text("SELECT id FROM document_group WHERE code = :c"),
+            {"c": thcs_code},
+        ).scalar()
+        if thcs_gid is not None:
+            bind.execute(
+                text("DELETE FROM document_group WHERE id = :id"),
+                {"id": thcs_gid},
+            )
+    # KHÔNG drop doc type hoc_ba_thcs/bang_tot_nghiep_thcs (non-destructive).

--- a/Backend_FastAPI/tests/unit/test_docgrp_audience_backfill_migration.py
+++ b/Backend_FastAPI/tests/unit/test_docgrp_audience_backfill_migration.py
@@ -1,0 +1,212 @@
+"""Contract tests for ``docgrp_audience_bf_20260530`` backfill migration (ĐỢT B).
+
+feat/document-group-audience-merge ĐỢT B — split bộ hồ sơ NỀN thành lớp
+``applicable_audience`` (POST_THPT / POST_THCS). Verify migration:
+1. Khoá revision chain (down_revision = ĐỢT A ``docgrp_audience_20260529``).
+2. Phân loại doc code đúng (bang_diem_thpt ∈ POST_THPT — H2; POST_THCS = 2 mã;
+   gate chinh_quy — §8.0).
+3. Upgrade: MOVE item THPT (UPDATE group_id), tạo group lớp với cast
+   ``::admission_audience[]``, INSERT item THCS gated chinh_quy, KHÔNG tạo
+   group rỗng.
+4. Idempotency: reuse group theo code + SELECT-trước-INSERT item THCS.
+5. Downgrade HOÀN NGUYÊN split THẬT (H3): move THPT VỀ NỀN + xóa group POST_*;
+   non-destructive (KHÔNG DROP TYPE, KHÔNG xóa config_document_type).
+6. Guard code ≤ 50 (P2 — UNIQUE VARCHAR(50)).
+
+Pattern theo ``test_migration_cleanup_uppercase.py`` — importlib-load module,
+contract-assert revision + constants + SQL body. Run thật ở dev-DB roundtrip
+pre-PR + CI integration sweep post-merge.
+"""
+from __future__ import annotations
+
+import importlib.util
+import inspect
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_MIGRATION_FILE = "docgrp_audience_bf_20260530_backfill_split_layers.py"
+
+
+@pytest.fixture
+def migration():
+    path = _VERSIONS_DIR / _MIGRATION_FILE
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None, f"Cannot load {path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def module_src(migration):
+    return inspect.getsource(migration)
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision chain lock
+# ---------------------------------------------------------------------------
+
+
+def test_revision_id(migration):
+    assert migration.revision == "docgrp_audience_bf_20260530"
+
+
+def test_down_revision_chains_off_dot_a(migration):
+    """Backfill (ĐỢT B) PHẢI revise off schema migration (ĐỢT A). Nếu migration
+    khác land giữa commit này và merge → migration đó bump down_revision sang
+    ``docgrp_audience_bf_20260530`` HOẶC rebase revision này lên head mới."""
+    assert migration.down_revision == "docgrp_audience_20260529"
+
+
+# ---------------------------------------------------------------------------
+# 2. Phân loại doc code → lớp audience
+# ---------------------------------------------------------------------------
+
+
+def test_post_thpt_codes_include_bang_diem_thpt(migration):
+    """H2: bang_diem_thpt PHẢI vào POST_THPT (KHÔNG để NỀN) — tránh ép
+    TC-liên-thông-từ-THCS nộp bảng điểm THPT họ không có."""
+    assert set(migration.POST_THPT_DOC_CODES) == {
+        "hoc_ba_thpt",
+        "bang_tot_nghiep_thpt",
+        "bang_diem_thpt",
+    }
+
+
+def test_post_thcs_codes_are_the_two_existing_doc_types(migration):
+    """§8.0: lớp POST_THCS dùng 2 doc type ĐÃ TỒN TẠI prod (§8.1 round-8)."""
+    assert tuple(migration.POST_THCS_DOC_CODES) == (
+        "hoc_ba_thcs",
+        "bang_tot_nghiep_thcs",
+    )
+
+
+def test_post_thcs_gated_to_chinh_quy(migration):
+    """§8.0: lớp POST_THCS CHỈ wire cho offering type chinh_quy (TC từ THCS).
+    lien_thong/vlvh/... = known-limitation, admin upsert qua panel."""
+    assert migration.CHINH_QUY_OT_CODE == "chinh_quy"
+    src = inspect.getsource(migration.upgrade)
+    assert "CHINH_QUY_OT_CODE" in src, (
+        "Upgrade phải gate INSERT POST_THCS sau ot_code == CHINH_QUY_OT_CODE"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Upgrade body — MOVE THPT + tạo group lớp + INSERT THCS, không group rỗng
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_moves_thpt_items_via_update_group_id(migration):
+    """§8.2 SPLIT = MOVE: item THPT UPDATE sang group anh em (KHÔNG copy → tránh
+    luôn bắt buộc; KHÔNG đụng uq_document_group_item vì target group khác)."""
+    src = inspect.getsource(migration.upgrade)
+    assert "UPDATE document_group_item SET group_id" in src, (
+        "Split POST_THPT phải MOVE item qua UPDATE group_id."
+    )
+
+
+def test_upgrade_does_not_create_empty_thpt_group(migration):
+    """§8.2: KHÔNG tạo group POST_THPT rỗng — chỉ tạo khi có item THPT để move."""
+    src = inspect.getsource(migration.upgrade)
+    assert "if thpt_items:" in src, (
+        "Tạo group POST_THPT phải gated 'if thpt_items' (không tạo group rỗng)."
+    )
+
+
+def test_audience_group_insert_casts_enum_array(module_src):
+    """Cột applicable_audience = ARRAY(admission_audience); INSERT PHẢI cast
+    ``::admission_audience[]`` (N4) kẻo 'operator does not exist' / sai type."""
+    assert "::admission_audience[]" in module_src, (
+        "INSERT group lớp phải cast ARRAY[:aud]::admission_audience[]."
+    )
+
+
+def test_thcs_item_insert_present(module_src):
+    """§8.0: INSERT item vào document_group_item cho lớp POST_THCS."""
+    assert "INSERT INTO document_group_item" in module_src
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotency (N4) — reuse theo code + SELECT-trước-INSERT
+# ---------------------------------------------------------------------------
+
+
+def test_audience_group_reused_by_code(migration):
+    """Rerun: group lớp đã tồn tại → reuse theo code (KHÔNG INSERT trùng →
+    UNIQUE violation)."""
+    src = inspect.getsource(migration._ensure_audience_group)
+    assert "SELECT id FROM document_group WHERE code" in src
+    assert "if existing is not None" in src, (
+        "_ensure_audience_group phải reuse khi code đã tồn tại."
+    )
+
+
+def test_thcs_item_insert_guarded(migration):
+    """Rerun: item THCS đã có (group, doc_type) → bỏ qua (idempotent)."""
+    src = inspect.getsource(migration.upgrade)
+    assert "FROM document_group_item" in src and "if exists:" in src, (
+        "INSERT item THCS phải SELECT-trước (idempotent guard)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Downgrade — hoàn nguyên split THẬT (H3) + non-destructive
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_moves_thpt_back_to_nen(migration):
+    """H3: downgrade PHẢI move item POST_THPT VỀ NỀN (UPDATE group_id = NỀN),
+    KHÔNG chỉ drop cột — nếu để group tách đứng yên, code resolve cũ
+    post-rollback merge TẤT CẢ shared group → hồ sơ mới over-require."""
+    src = inspect.getsource(migration.downgrade)
+    assert "UPDATE document_group_item SET group_id = :nen" in src, (
+        "Downgrade phải move item POST_THPT về group NỀN."
+    )
+    assert "_POST_THPT" in src and "_POST_THCS" in src, (
+        "Downgrade match group lớp theo code deterministic {nen}_POST_*."
+    )
+
+
+def test_downgrade_deletes_audience_groups(migration):
+    src = inspect.getsource(migration.downgrade)
+    assert "DELETE FROM document_group WHERE id" in src
+
+
+def test_downgrade_is_non_destructive_to_doc_types(migration):
+    """Non-destructive: downgrade KHÔNG drop enum admission_audience (ĐỢT A
+    quản) cũng KHÔNG xóa config_document_type THCS (chỉ thêm, giữ lại)."""
+    src = inspect.getsource(migration.downgrade)
+    for forbidden in ("DROP TYPE", "config_document_type", "DROP COLUMN"):
+        assert forbidden not in src, (
+            f"Downgrade ĐỢT B phải non-destructive — token cấm {forbidden!r}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Code length guard (P2)
+# ---------------------------------------------------------------------------
+
+
+def test_audience_group_code_asserts_max_50(migration):
+    """code group UNIQUE VARCHAR(50) → guard fail-loud khi vượt."""
+    src = inspect.getsource(migration._audience_group_code)
+    assert "<= 50" in src or "len(code)" in src, (
+        "_audience_group_code phải assert độ dài ≤ 50."
+    )
+    # Smoke: code seed thực ngắn (≤ ~23) — không raise.
+    assert migration._audience_group_code("HS_CHINH_QUY", "POST_THPT") == (
+        "HS_CHINH_QUY_POST_THPT"
+    )
+    assert migration._audience_group_code("HS_LIEN_THONG", "POST_THCS") == (
+        "HS_LIEN_THONG_POST_THCS"
+    )
+
+
+def test_audience_group_code_raises_when_too_long(migration):
+    """Guard thực sự raise khi nen_code dài → code > 50."""
+    long_code = "X" * 45  # 45 + len('_POST_THPT')=10 = 55 > 50
+    with pytest.raises(AssertionError):
+        migration._audience_group_code(long_code, "POST_THPT")


### PR DESCRIPTION
## Mục tiêu
**ĐỢT B = data migration** tách bộ hồ sơ NỀN thành các lớp theo `applicable_audience` (machinery + schema đã ship ĐỢT A [#350](https://github.com/favouritekid/QLTS/pull/350)). Fix **bug gốc**: group chính quy ép `hoc_ba_thpt`+`bang_tot_nghiep_thpt` cho MỌI hồ sơ — kể cả TS chỉ tốt nghiệp THCS (**32 path trung cấp chính quy** tuyển từ THCS).

## Thay đổi
Migration `docgrp_audience_bf_20260530` (down_rev = ĐỢT A `docgrp_audience_20260529`), **GENERIC + data-driven, match-by-code** (prod id 9/10 ≠ seed 1/2 — §8.1 dry-run xác nhận drift):

- **§8.2 SPLIT POST_THPT (MOVE)**: item doc ∈ {`hoc_ba_thpt`, `bang_tot_nghiep_thpt`, `bang_diem_thpt`} → group anh em `{code}_POST_THPT` (`applicable_audience=[POST_THPT]`). `bang_diem_thpt` vào POST_THPT (H2), KHÔNG để NỀN.
- **§8.0 WIRE POST_THCS (INSERT, chỉ offering type `chinh_quy`)**: group `{code}_POST_THCS` + item `hoc_ba_thcs`+`bang_tot_nghiep_thcs` (doc type ĐÃ TỒN TẠI prod §8.1 — KHÔNG tạo doc type). Phục vụ 32 path TC chính quy.

**Kết quả resolve** (gộp NỀN + lớp khớp audience): TS THCS → `base + bộ THCS` (KHÔNG THPT); TS THPT → `base + bộ THPT`. Delivers qua re-resolve khi PATCH cultural (`_reresolve_documents_snapshot`, ĐỢT A); create cultural-trống = NỀN-only (`AdmissionProfileCreate` không nhận cultural → không gap).

## KHÔNG đụng (chủ đích)
- Group method/path-override — §8.1 prod **0 override** → **§8.3 rebuild path MOOT**.
- `LIEN_THONG_*`/`VLVH` — known-limitation §5 (seed không có doc nguồn; admin upsert qua panel).
- POST_THCS cho offering type ≠ chinh_quy (lien_thong ot22 unused 0 path).
- Snapshot `applied_rules` hồ sơ cũ — bất biến (chỉ re-fire khi PATCH cultural/vocational).

## An toàn
- **Idempotent (N4)**: reuse group theo code + SELECT-trước-INSERT → rerun không vỡ.
- **Downgrade (H3)**: hoàn nguyên split THẬT — move POST_THPT về NỀN + xóa group POST_* + non-destructive (giữ doc type + enum).
- **Real-DB roundtrip dev verified**: up→split (5 group)→down→restore (2 group, 13 item bảo toàn)→up idempotent. Sau verify revert dev về head ĐỢT A.

## Test
- **16 contract test** (`test_docgrp_audience_backfill_migration.py`): revision chain, phân loại doc (bang_diem_thpt∈POST_THPT, POST_THCS gate chinh_quy), MOVE/INSERT body, idempotency guard, downgrade reverse-thật + non-destructive, code≤50 guard. Thêm vào `backend-test.yml` Tier 5.
- Migration KHÔNG chạy trong CI test DB (`Base.metadata.create_all()` không alembic) → run thật = dev-roundtrip pre-PR (✅) + CI integration sweep post-merge.

## Deploy
Routine `deploy.sh` auto `alembic upgrade head` chạy backfill (idempotent + pg_dump backup Step 5 + auto-rollback). **Owner-gated** — chờ duyệt trước merge.

Plan: `Documents/DOCUMENT_GROUP_AUDIENCE_MERGE_PLAN.md` §8.0/§8.2/§8.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)