### PR TITLE
feat(admissions-fe): badge lớp audience trong ConfigDocuments (FE Slice 1)

### DIFF
--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigDocuments.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigDocuments.tsx
@@ -12,9 +12,64 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 import { useUpdatePathDocuments, usePathDocuments } from "@/hooks/admissions/useAdmissionPaths";
 import { useDocumentTypes } from "@/hooks/admissions/useMasterData";
-import { AdmissionPathResponse } from "@/lib/zod/admission-path";
+import {
+  AdmissionPathResponse,
+  AUDIENCE_LABELS,
+  type ResolvedDocumentResponse,
+} from "@/lib/zod/admission-path";
 import type { DocumentType } from "../shared/types";
 import type { PydanticValidationError } from "@/types/api.types";
+
+/**
+ * Badge lớp giấy tờ resolve (feat/document-group-audience-merge ĐỢT A).
+ * Render `layer_kind` + `applicable_audience` BE trả → admin thấy mỗi giấy
+ * thuộc lớp nào (NỀN luôn gộp / theo đối tượng / override). Thin-client:
+ * KHÔNG suy luận, chỉ map enum → nhãn.
+ */
+function LayerBadge({ doc }: { doc: ResolvedDocumentResponse }) {
+  switch (doc.layer_kind) {
+    case "shared_base":
+      return (
+        <Badge variant="secondary" className="text-[10px] h-5">
+          NỀN
+        </Badge>
+      );
+    case "shared_audience":
+      return (
+        <span className="flex flex-wrap gap-1">
+          {(doc.applicable_audience ?? []).map((aud) => (
+            <Badge
+              key={aud}
+              variant="outline"
+              className="text-[10px] h-5 border-info-100 bg-info-50 text-info-700"
+            >
+              {AUDIENCE_LABELS[aud] ?? aud}
+            </Badge>
+          ))}
+        </span>
+      );
+    case "method_override":
+      return (
+        <Badge
+          variant="outline"
+          className="text-[10px] h-5 border-warning-200 bg-warning-50 text-warning-800"
+        >
+          Theo phương thức
+        </Badge>
+      );
+    case "path_override":
+      return (
+        <Badge
+          variant="outline"
+          className="text-[10px] h-5 border-warning-200 bg-warning-50 text-warning-800"
+        >
+          Riêng đợt này
+        </Badge>
+      );
+    default:
+      return null;
+  }
+}
 
 interface ConfigDocumentsProps {
   path: AdmissionPathResponse;
@@ -52,6 +107,16 @@ export function ConfigDocuments({ path, onFinish, onBack, embedded = false }: Co
       };
     });
     return initialMap;
+  }, [resolvedDocs]);
+
+  // Lookup resolved doc theo document_type_id → render LayerBadge (layer_kind
+  // + applicable_audience). Read-only annotation, KHÔNG đụng save semantics.
+  const resolvedByTypeId = useMemo(() => {
+    const map: Record<number, ResolvedDocumentResponse> = {};
+    resolvedDocs?.forEach((d) => {
+      map[d.document_type_id] = d;
+    });
+    return map;
   }, [resolvedDocs]);
 
   // Local modifications state - starts empty, merged with initial on save
@@ -235,8 +300,8 @@ export function ConfigDocuments({ path, onFinish, onBack, embedded = false }: Co
                           </Label>
                           <span className="text-xs text-muted-foreground">{type.code}</span>
                         </div>
-                        {isSelected && resolvedDocs?.find(d => d.document_type_id === type.id)?.source === 'shared' && (
-                          <Badge variant="secondary" className="text-[10px] h-5">Mặc định</Badge>
+                        {isSelected && resolvedByTypeId[type.id] && (
+                          <LayerBadge doc={resolvedByTypeId[type.id]} />
                         )}
                       </div>
 

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigDocuments.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/ConfigDocuments.tsx
@@ -242,7 +242,7 @@ export function ConfigDocuments({ path, onFinish, onBack, embedded = false }: Co
         {!isLoading && (
           <div className="mb-4">
             {isDetached ? (
-              <Alert className="bg-info-50 text-info-900 border-info-200">
+              <Alert className="bg-info-50 text-info-700 border-info-100">
                 <Info className="h-4 w-4" />
                 <AlertTitle>Cấu hình riêng biệt (Forked)</AlertTitle>
                 <AlertDescription>
@@ -250,7 +250,7 @@ export function ConfigDocuments({ path, onFinish, onBack, embedded = false }: Co
                 </AlertDescription>
               </Alert>
             ) : (
-              <Alert className="bg-warning-50 text-warning-900 border-warning-200">
+              <Alert className="bg-warning-50 text-warning-800 border-warning-200">
                 <AlertTriangle className="h-4 w-4" />
                 <AlertTitle>Chú ý: Ghi đè cấu hình chung</AlertTitle>
                 <AlertDescription>

--- a/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
+++ b/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
@@ -96,6 +96,8 @@ const mockDocumentsResponse: ResolvedDocumentListResponse = {
       submission_format: null,
       display_order: 1,
       source: "shared",
+      applicable_audience: null,
+      layer_kind: "shared_base",
     },
   ],
 };

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -45,6 +45,20 @@ export const admissionAudienceEnum = z.enum([
 
 export type AdmissionAudience = z.infer<typeof admissionAudienceEnum>
 
+/**
+ * Nhãn tiếng Việt cho từng audience — mirror BE
+ * `document_resolution_service.AUDIENCE_LABELS`. Dùng để render badge
+ * lớp giấy tờ (display-only formatting của enum, KHÔNG phải business
+ * logic — như `STATUS_CONFIG` labels). Đổi nhãn phải sync BE.
+ */
+export const AUDIENCE_LABELS: Record<AdmissionAudience, string> = {
+  POST_THCS: "Tốt nghiệp THCS",
+  POST_THPT: "Tốt nghiệp THPT",
+  LIEN_THONG_TC: "Liên thông Trung cấp",
+  LIEN_THONG_CD: "Liên thông Cao đẳng",
+  VLVH: "Vừa làm vừa học",
+}
+
 // ==============================================================================
 // BONUS RULE OVERRIDE (phase1_02 wired in PR-1B')
 // ==============================================================================
@@ -432,6 +446,17 @@ export const resolvedDocumentResponseSchema = z.object({
   submission_format: z.string().nullable(),
   display_order: z.number(),
   source: z.enum(["shared", "method_override", "path_override"]),
+  // feat/document-group-audience-merge (ĐỢT A) — audience layer metadata.
+  // applicable_audience: [POST_THPT,...] = lớp theo đối tượng/trình độ;
+  //   null = lớp NỀN (luôn gộp) hoặc override (method/path).
+  // layer_kind: phân loại lớp để render badge — KHÔNG overload `source`.
+  applicable_audience: admissionAudienceEnum.array().nullable(),
+  layer_kind: z.enum([
+    "shared_base",
+    "shared_audience",
+    "method_override",
+    "path_override",
+  ]),
 })
 
 export type ResolvedDocumentResponse = z.infer<typeof resolvedDocumentResponseSchema>


### PR DESCRIPTION
## Mục tiêu
FE consume metadata audience từ resolved document response (BE **ĐỢT A** đã ship + live prod): mỗi giấy tờ trong ConfigDocuments hiện **badge lớp** nó thuộc về → admin nhìn rõ giấy nào là NỀN (luôn gộp), giấy nào theo đối tượng (Tốt nghiệp THPT/THCS), giấy nào override. Phần consume-API của plan §10.15 + §10.18.

## Thay đổi
- **Zod** `resolvedDocumentResponseSchema` (`lib/zod/admission-path.ts`): thêm `applicable_audience` (`admissionAudienceEnum[]` nullable) + `layer_kind` (`shared_base`/`shared_audience`/`method_override`/`path_override`) — mirror strict BE `ResolvedDocumentResponse` (FastAPI không exclude defaults → field luôn có). Type `ResolvedDocumentResponse` (z.infer) tự cập nhật. Fixture test thêm 2 field.
- **`AUDIENCE_LABELS`** const — mirror BE `document_resolution_service.AUDIENCE_LABELS` (display-only enum→nhãn, thin-client như `STATUS_CONFIG`).
- **`ConfigDocuments.tsx`**: `LayerBadge` (switch `layer_kind` → NỀN / nhãn audience / Theo phương thức / Riêng đợt này; guard `?? []` + `default` runtime-safe) + memo `resolvedByTypeId`. Thay badge "Mặc định" (chỉ `source==='shared'`) bằng `LayerBadge` đầy đủ.

## Token cleanup (review Codex)
- LayerBadge ban đầu dùng shade tailwind KHÔNG có trong theme (`info-200`/`info-900`/`warning-900`) → sửa về token thật (`border-info-100 bg-info-50 text-info-700`, `text-warning-800`).
- Commit riêng: 2 Alert detachment pre-existing (`ConfigDocuments:245/253`) dính cùng lỗi token → đồng bộ luôn.

## Thin-client
Render đúng BE trả, KHÔNG suy luận audience ở FE. Badge là **annotation read-only** — KHÔNG đụng `handleSave`/`selections`/`modifications` (save vẫn build payload từ all-layers, không co hẹp).

## Verify
- type-check clean · vitest 5 pass (`useAdmissionPaths`) · eslint 0 error.
- **Runtime smoke** (Chrome, authed prod-shape data): API `/paths/106/documents` trả `layer_kind`+`applicable_audience` đúng (hoc_ba_thpt→`[POST_THPT]`, hoc_ba_thcs→`[POST_THCS]`, cccd→`shared_base`/null) → zod parse OK, 0 console error.
- **Codex review**: no P0/P1; contract khớp, badge read-only, không phá save semantics; token fix đã apply.

## Defer (cần BE companion — KHÔNG thiếu sót)
- §10.17 SharedDocumentConfigPanel audience CRUD — cần §10.8 upsert-by-audience (fix R10) + §10.13 route `/document-groups/shared/{ot}/{audience}`.
- Dialog "Xem trước theo TS" (§5b/G5) — cần preview endpoint BE derive raw cultural/vocational.
- §10.16 `usePathDocuments(audience)` filter + public §9 `audience_layers` FE.

Plan: `Documents/DOCUMENT_GROUP_AUDIENCE_MERGE_PLAN.md` §10.15/§10.18/§5b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)