### PR TITLE
feat(admissions): audience config-panel (CRUD lớp + preview) + fix R10 prod bug

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -263,4 +263,5 @@ jobs:
           tests/unit/test_document_resolution_service.py
           tests/integration/test_document_audience_reresolve.py
           tests/unit/test_docgrp_audience_backfill_migration.py
+          tests/integration/test_document_audience_config_panel.py
           -q --tb=short --timeout=60

--- a/Backend_FastAPI/app/repositories/document_group_repository.py
+++ b/Backend_FastAPI/app/repositories/document_group_repository.py
@@ -138,14 +138,12 @@ class DocumentGroupRepository(BaseRepository[DocumentGroup]):
           2 NỀN/ot).
         - ``audience=<X>`` → group có X trong ``applicable_audience``.
 
-        Filter trong Python trên ``get_shared_groups`` (≤6 group/ot, low-freq
-        config) → tránh SQL enum-array ``&&`` + tự lọc ``path IS NULL`` mà
-        KHÔNG đụng query resolve. Deterministic nhờ ORDER BY id.
+        Filter audience trong Python trên ``get_shared_groups`` (≤6 group/ot,
+        low-freq config) → tránh SQL enum-array ``&&``. ``get_shared_groups`` đã
+        lọc tier shared (method + path đều NULL) + ORDER BY id ⇒ deterministic.
         """
         groups = await self.get_shared_groups(offering_type_id)
         for group in groups:
-            if group.admission_path_id is not None:
-                continue  # path-override KHÔNG phải tier shared thuần
             aud = group.applicable_audience
             if audience is None:
                 if not aud:  # NULL hoặc [] = lớp NỀN

--- a/Backend_FastAPI/app/repositories/document_group_repository.py
+++ b/Backend_FastAPI/app/repositories/document_group_repository.py
@@ -31,7 +31,14 @@ class DocumentGroupRepository(BaseRepository[DocumentGroup]):
         self,
         group_id: int
     ) -> Optional[DocumentGroup]:
-        """Get group by ID with items and document types loaded."""
+        """Get group by ID with items and document types loaded.
+
+        ``populate_existing`` (feat/document-group-audience-merge): upsert
+        làm bulk DELETE items + add → object trong identity map còn giữ
+        collection ``.items`` CŨ (bulk delete KHÔNG sync ORM). Refetch phải
+        OVERWRITE state cũ bằng DB truth, nếu không response trả item stale
+        (bug pre-existing: upsert refetch hiện old+new).
+        """
         query = (
             select(DocumentGroup)
             .where(DocumentGroup.id == group_id)
@@ -41,6 +48,7 @@ class DocumentGroupRepository(BaseRepository[DocumentGroup]):
                 selectinload(DocumentGroup.items)
                 .selectinload(DocumentGroupItem.document_type),
             )
+            .execution_options(populate_existing=True)
         )
         result = await self.db.execute(query)
         return result.scalars().first()
@@ -95,9 +103,62 @@ class DocumentGroupRepository(BaseRepository[DocumentGroup]):
                 selectinload(DocumentGroup.items)
                 .selectinload(DocumentGroupItem.document_type),
             )
+            # Deterministic order (feat/document-group-audience-merge config
+            # panel): sau ĐỢT B mỗi offering_type có nhiều shared group (NỀN +
+            # lớp audience). Resolve merge order-independent, nhưng config
+            # lookup/list cần thứ tự ổn định — id ASC ⇒ group NỀN (tạo trước)
+            # luôn đứng đầu. KHÔNG đổi tập trả về (resolve giữ nguyên).
+            .order_by(DocumentGroup.id)
         )
         result = await self.db.execute(query)
         return list(result.scalars().all())
+
+    async def get_shared_group_by_audience(
+        self,
+        offering_type_id: int,
+        audience: Optional[str],
+    ) -> Optional[DocumentGroup]:
+        """Lookup CHÍNH XÁC 1 shared group theo (offering_type, audience).
+
+        feat/document-group-audience-merge §10.8 (fix R10 ``groups[0]`` +
+        G4 NỀN-theo-code). Tier shared = ``admission_method_id`` +
+        ``admission_path_id`` đều NULL.
+
+        - ``audience=None`` → group NỀN (``applicable_audience`` NULL/rỗng).
+          G4: match THEO ``(ot, audience IS NULL)``, KHÔNG theo code (seed dùng
+          ``HS_CHINH_QUY`` còn upsert sinh ``SHARED_DOC_OT_{id}`` → tránh tạo
+          2 NỀN/ot).
+        - ``audience=<X>`` → group có X trong ``applicable_audience``.
+
+        Filter trong Python trên ``get_shared_groups`` (≤6 group/ot, low-freq
+        config) → tránh SQL enum-array ``&&`` + tự lọc ``path IS NULL`` mà
+        KHÔNG đụng query resolve. Deterministic nhờ ORDER BY id.
+        """
+        groups = await self.get_shared_groups(offering_type_id)
+        for group in groups:
+            if group.admission_path_id is not None:
+                continue  # path-override KHÔNG phải tier shared thuần
+            aud = group.applicable_audience
+            if audience is None:
+                if not aud:  # NULL hoặc [] = lớp NỀN
+                    return group
+            elif aud and audience in aud:
+                return group
+        return None
+
+    async def get_offering_type_code(
+        self,
+        offering_type_id: int,
+    ) -> Optional[str]:
+        """Lấy ``code`` của offering type (cho preview chiều VLVH §5b)."""
+        from app.models.config import ConfigOfferingType
+
+        result = await self.db.execute(
+            select(ConfigOfferingType.code).where(
+                ConfigOfferingType.id == offering_type_id
+            )
+        )
+        return result.scalar_one_or_none()
 
     async def get_method_specific_group(
         self,
@@ -133,8 +194,13 @@ class DocumentGroupRepository(BaseRepository[DocumentGroup]):
         admission_method_id: int | None = None,
         admission_path_id: int | None = None,
         is_active: bool = True,
+        applicable_audience: list[str] | None = None,
     ) -> DocumentGroup:
-        """Create new document group."""
+        """Create new document group.
+
+        ``applicable_audience`` (feat/document-group-audience-merge): NULL = lớp
+        NỀN tier shared; ``[..]`` = lớp theo đối tượng/trình độ.
+        """
         group = DocumentGroup(
             offering_type_id=offering_type_id,
             admission_method_id=admission_method_id,
@@ -143,6 +209,7 @@ class DocumentGroupRepository(BaseRepository[DocumentGroup]):
             name=name,
             description=description,
             is_active=is_active,
+            applicable_audience=applicable_audience,
         )
         self.db.add(group)
         await self.db.flush()

--- a/Backend_FastAPI/app/repositories/document_group_repository.py
+++ b/Backend_FastAPI/app/repositories/document_group_repository.py
@@ -91,12 +91,20 @@ class DocumentGroupRepository(BaseRepository[DocumentGroup]):
         self,
         offering_type_id: int
     ) -> List[DocumentGroup]:
-        """Get shared groups (admission_method_id = NULL)."""
+        """Get shared groups (tier shared = method + path đều NULL).
+
+        ``admission_path_id IS NULL`` (review P1): path-level override group
+        ĐƯỢC PHÉP có ``admission_method_id=NULL`` (invariant document_group_
+        service) → nếu thiếu filter này, path-override lẫn vào "shared" layer
+        (list/preview/can-activate hiển thị/merge nhầm). Khớp canonical resolver
+        ``admission_path_repository`` shared query.
+        """
         query = (
             select(DocumentGroup)
             .where(
                 DocumentGroup.offering_type_id == offering_type_id,
                 DocumentGroup.admission_method_id.is_(None),
+                DocumentGroup.admission_path_id.is_(None),
                 DocumentGroup.is_active == True,
             )
             .options(

--- a/Backend_FastAPI/app/routers/admission_config.py
+++ b/Backend_FastAPI/app/routers/admission_config.py
@@ -10,7 +10,7 @@ Scoring preview endpoint for testing.
 from decimal import Decimal
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import (
@@ -24,6 +24,7 @@ from app.core.deps import (
 from app.models.admission_config.criteria import AdmissionCriteria
 from app.database import get_db
 from app.schemas.organization import ConfigDegreeLevel, MajorProgramShallow
+from app.schemas.admission_path import AdmissionAudience, ResolvedDocumentResponse
 from app.models import User
 from app.repositories.admission_config_repository import AdmissionConfigRepository
 from app.services.admission_scoring_service import AdmissionScoringService
@@ -51,6 +52,7 @@ from app.schemas.admission_config import (
     ScoringPreviewResponse,
     SharedDocumentGroupResponse,
     SharedDocumentGroupUpdate,
+    SharedDocumentPreviewRequest,
     DocumentGroupItemResponse,
 )
 
@@ -818,25 +820,57 @@ def _build_doc_group_response(group) -> Optional[SharedDocumentGroupResponse]:
         offering_type_id=group.offering_type_id,
         code=group.code,
         name=group.name,
+        applicable_audience=group.applicable_audience,
         items=items
     )
+
+
+@router.get(
+    "/document-groups/shared/{offering_type_id}/layers",
+    response_model=list[SharedDocumentGroupResponse],
+)
+async def list_shared_document_group_layers(
+    offering_type_id: int,
+    active_only: bool = Depends(get_config_filter),
+    db: AsyncSession = Depends(get_db),
+):
+    """List TẤT CẢ shared layer (NỀN + lớp audience) của 1 offering type.
+
+    feat/document-group-audience-merge §10.17: panel enumerate lớp để admin
+    chọn lớp sửa (NỀN / Tốt nghiệp THPT / THCS / ...). Ordered NỀN trước.
+    Auth mirror GET shared (get_config_filter → current_user, KHÔNG Casbin — N2).
+    """
+    service = AdmissionConfigService(db)
+    groups = await service.list_shared_document_groups(offering_type_id)
+    return [
+        _build_doc_group_response(g)
+        for g in groups
+        if not (active_only and not g.is_active)
+    ]
 
 
 @router.get("/document-groups/shared/{offering_type_id}", response_model=Optional[SharedDocumentGroupResponse])
 async def get_shared_document_group(
     offering_type_id: int,
+    audience: Optional[AdmissionAudience] = Query(
+        None,
+        description="Lớp audience (POST_THPT/...); None = lớp NỀN. §10.8/§10.13.",
+    ),
     active_only: bool = Depends(get_config_filter),
     db: AsyncSession = Depends(get_db),
 ):
     """
     Get shared document group configuration for an Offering Type.
 
+    feat/document-group-audience-merge §10.8: ``?audience=`` chọn lớp (None =
+    NỀN). Lookup CHÍNH XÁC theo (ot, audience) — fix R10 groups[0] nondeterministic.
+
     ADM-009: non-admin must not see inactive shared document groups.
     Returns ``None`` (the list-shape contract) when filtered out, same
     as when no group exists for the offering type.
     """
     service = AdmissionConfigService(db)
-    group = await service.get_shared_document_group(offering_type_id)
+    group = await service.get_shared_document_group(offering_type_id, audience)
 
     if not group or (active_only and not group.is_active):
         return None
@@ -848,17 +882,48 @@ async def get_shared_document_group(
 async def upsert_shared_document_group(
     offering_type_id: int,
     data: SharedDocumentGroupUpdate,
+    audience: Optional[AdmissionAudience] = Query(
+        None,
+        description="Lớp audience cần upsert; None = lớp NỀN. §10.8.",
+    ),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_admin_or_manager),
 ):
     """
     Create or Update shared document group configuration.
-    Requires: Admin or Manager role.
+    feat/document-group-audience-merge §10.8: ``?audience=`` chọn lớp (None =
+    NỀN). Requires: Admin or Manager role.
     """
     service = AdmissionConfigService(db)
-    group, callback = await service.upsert_shared_document_group(offering_type_id, data, current_user)
+    group, callback = await service.upsert_shared_document_group(
+        offering_type_id, data, current_user, audience=audience
+    )
     await db.commit()
     await callback()
-    
+
     return _build_doc_group_response(group)
+
+
+@router.post(
+    "/document-groups/shared/{offering_type_id}/preview",
+    response_model=list[ResolvedDocumentResponse],
+)
+async def preview_shared_documents(
+    offering_type_id: int,
+    data: SharedDocumentPreviewRequest,
+    active_only: bool = Depends(get_config_filter),
+    db: AsyncSession = Depends(get_db),
+):
+    """Preview bộ hồ sơ shared theo TS giả định (§5b/G5 "Xem trước theo TS").
+
+    Thin-client: FE gửi raw cultural/vocational → BE derive audience + resolve
+    (NỀN + lớp khớp, loại bằng TN khi completed_*). Read-only, mirror auth GET
+    shared (get_config_filter → current_user, KHÔNG Casbin — N2).
+    """
+    service = AdmissionConfigService(db)
+    return await service.preview_shared_documents(
+        offering_type_id,
+        data.cultural_education_level,
+        data.vocational_qualification,
+    )
 

--- a/Backend_FastAPI/app/routers/admission_config.py
+++ b/Backend_FastAPI/app/routers/admission_config.py
@@ -911,14 +911,14 @@ async def upsert_shared_document_group(
 async def preview_shared_documents(
     offering_type_id: int,
     data: SharedDocumentPreviewRequest,
-    active_only: bool = Depends(get_config_filter),
+    _: User = Depends(get_current_active_user),
     db: AsyncSession = Depends(get_db),
 ):
     """Preview bộ hồ sơ shared theo TS giả định (§5b/G5 "Xem trước theo TS").
 
     Thin-client: FE gửi raw cultural/vocational → BE derive audience + resolve
-    (NỀN + lớp khớp, loại bằng TN khi completed_*). Read-only, mirror auth GET
-    shared (get_config_filter → current_user, KHÔNG Casbin — N2).
+    (NỀN + lớp khớp, loại bằng TN khi completed_*). Read-only; auth active-user
+    (KHÔNG lọc active_only như GET list, KHÔNG Casbin — N2).
     """
     service = AdmissionConfigService(db)
     return await service.preview_shared_documents(

--- a/Backend_FastAPI/app/schemas/admission_config.py
+++ b/Backend_FastAPI/app/schemas/admission_config.py
@@ -8,7 +8,9 @@ Pydantic schemas for API responses.
 from decimal import Decimal
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.admission_path import AdmissionAudience
 
 
 # =============================================================================
@@ -297,6 +299,9 @@ class SharedDocumentGroupResponse(BaseModel):
     offering_type_id: int
     code: str
     name: str
+    # feat/document-group-audience-merge §10.10: lớp audience của group.
+    # NULL = lớp NỀN; [..] = lớp theo đối tượng/trình độ.
+    applicable_audience: Optional[list[AdmissionAudience]] = None
     items: list[DocumentGroupItemResponse] = []
 
 
@@ -315,4 +320,20 @@ class SharedDocumentGroupUpdate(BaseModel):
     Replaces ALL items in the group.
     """
     items: list[DocumentGroupItemCreate]
+
+
+class SharedDocumentPreviewRequest(BaseModel):
+    """Preview bộ hồ sơ theo TS giả định (§5b/G5).
+
+    Thin-client: FE gửi raw cultural/vocational → BE derive audience + resolve
+    (KHÔNG để FE tự tính audience). ``cultural`` constrain đúng enum BE.
+    """
+    cultural_education_level: Optional[str] = Field(
+        None,
+        pattern=(
+            r"^(completed_thcs|graduated_thcs|completed_thpt|"
+            r"graduated_thpt|graduated_gdtx)$"
+        ),
+    )
+    vocational_qualification: Optional[str] = None
 

--- a/Backend_FastAPI/app/services/admission_config_service.py
+++ b/Backend_FastAPI/app/services/admission_config_service.py
@@ -523,8 +523,12 @@ class AdmissionConfigService:
                 name = f"Hồ sơ {label} (OT-{offering_type_id})"
                 description = f"Lớp theo đối tượng: {label}."
                 applicable = [audience]
-            # code UNIQUE VARCHAR(50) — fail-loud nếu vượt (thực tế ≤ ~30).
-            assert len(code) <= 50, f"group code '{code}' ({len(code)}) > 50"
+            # code UNIQUE VARCHAR(50) — fail-loud nếu vượt (thực tế ≤ ~30;
+            # raise thật, KHÔNG assert — tránh bị strip với python -O).
+            if len(code) > 50:
+                raise ValueError(
+                    f"group code '{code}' ({len(code)}) > 50 — đổi scheme hậu tố"
+                )
 
             group = await self.document_group_repo.create_group(
                 offering_type_id=offering_type_id,
@@ -565,15 +569,15 @@ class AdmissionConfigService:
         Thin-client: admin nhập raw cultural/vocational → BE derive audience +
         resolve (NỀN + lớp khớp) + loại bằng TN khi completed_* (§6). Tái dùng
         nguyên machinery ĐỢT A (filter_shared_by_audience + mandatory_wins_merge
-        + _build_resolved_response) để preview KHỚP resolve thật.
+        + build_resolved_response) để preview KHỚP resolve thật.
 
         Chỉ tier shared (config panel không gắn path/method) → đủ cho nhu cầu
         gốc THCS↔THPT. LIEN_THONG/VLVH layer chưa tồn tại GĐ1 (known-limitation).
         """
         from types import SimpleNamespace
 
-        from app.services.admission_path_service import AdmissionPathService
         from app.services.document_resolution_service import (
+            build_resolved_response,
             compute_completed_doc_codes,
             compute_preview_audience_set,
             filter_shared_by_audience,
@@ -602,6 +606,6 @@ class AdmissionConfigService:
         completed = compute_completed_doc_codes(
             SimpleNamespace(cultural_education_level=cultural_education_level)
         )
-        return AdmissionPathService._build_resolved_response(doc_map, completed)
+        return build_resolved_response(doc_map, completed)
 
 

--- a/Backend_FastAPI/app/services/admission_config_service.py
+++ b/Backend_FastAPI/app/services/admission_config_service.py
@@ -9,7 +9,7 @@ Follows MASTER_ARCHITECTURE.md:
 - Returns (result, callback) tuple
 """
 
-from typing import Callable, Any
+from typing import Callable, Any, Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models import User
@@ -25,6 +25,7 @@ from app.utils.exceptions import (
     ResourceNotFoundError,
     DuplicateResourceError,
     BusinessRuleViolation,
+    ValidationError,
 )
 
 
@@ -468,46 +469,77 @@ class AdmissionConfigService:
     async def get_shared_document_group(
         self,
         offering_type_id: int,
+        audience: Optional[str] = None,
     ):
-        """Get shared document group for offering type."""
-        from app.models.admission_config import DocumentGroup
-        groups = await self.document_group_repo.get_shared_groups(offering_type_id)
-        return groups[0] if groups else None
+        """Get shared document group cho ``(offering_type, audience)``.
+
+        feat/document-group-audience-merge §10.8: ``audience=None`` → lớp NỀN
+        (``applicable_audience`` NULL); ``audience=<X>`` → lớp theo đối tượng.
+        Lookup CHÍNH XÁC (fix R10 ``groups[0]`` nondeterministic sau ĐỢT B).
+        """
+        return await self.document_group_repo.get_shared_group_by_audience(
+            offering_type_id, audience
+        )
+
+    async def list_shared_document_groups(self, offering_type_id: int):
+        """List TẤT CẢ shared group (NỀN + lớp audience) — panel enumerate lớp
+        để admin chọn lớp sửa (§10.17). Ordered by id (NỀN trước)."""
+        return await self.document_group_repo.get_shared_groups(offering_type_id)
 
     async def upsert_shared_document_group(
         self,
         offering_type_id: int,
         data: SharedDocumentGroupUpdate,
         user: User,
+        audience: Optional[str] = None,
     ) -> tuple["DocumentGroup", Callable[[], Any]]:
+        """Create/Update shared document group cho ``(offering_type, audience)``.
+
+        Replaces all items. feat/document-group-audience-merge §10.8/G4:
+        lookup theo ``(ot, audience)`` (KHÔNG ``groups[0]``); tạo mới nếu chưa
+        có với code deterministic + set ``applicable_audience``.
         """
-        Create or Update Shared Document Group for Offering Type.
-        
-        Replaces all items in the group.
-        """
-        # Find existing shared group
-        groups = await self.document_group_repo.get_shared_groups(offering_type_id)
-        group = groups[0] if groups else None
+        from app.services.document_resolution_service import AUDIENCE_LABELS
+
+        if audience is not None and audience not in AUDIENCE_LABELS:
+            raise ValidationError(
+                f"audience '{audience}' không hợp lệ "
+                f"(phải thuộc {sorted(AUDIENCE_LABELS)})"
+            )
+
+        group = await self.document_group_repo.get_shared_group_by_audience(
+            offering_type_id, audience
+        )
 
         if not group:
-            # Create new shared group
-            # Generate code/name
-            # Note: offering_type_id is int, we assume it exists. 
-            # Ideally we check offering type existence but we trust FK constraint for now.
-            # Code: SHARED_DOC_{offering_type_id}
-            
+            if audience is None:
+                code = f"SHARED_DOC_OT_{offering_type_id}"
+                name = f"Hồ sơ chung (OT-{offering_type_id})"
+                description = "Lớp NỀN — giấy tờ chung cho mọi thí sinh."
+                applicable = None
+            else:
+                code = f"SHARED_DOC_OT_{offering_type_id}_{audience}"
+                label = AUDIENCE_LABELS[audience]
+                name = f"Hồ sơ {label} (OT-{offering_type_id})"
+                description = f"Lớp theo đối tượng: {label}."
+                applicable = [audience]
+            # code UNIQUE VARCHAR(50) — fail-loud nếu vượt (thực tế ≤ ~30).
+            assert len(code) <= 50, f"group code '{code}' ({len(code)}) > 50"
+
             group = await self.document_group_repo.create_group(
                 offering_type_id=offering_type_id,
-                admission_method_id=None, # Shared
-                code=f"SHARED_DOC_OT_{offering_type_id}",
-                name=f"Hồ sơ chung (OT-{offering_type_id})",
-                description="Cấu hình hồ sơ mặc định cho loại hình đào tạo này",
-                is_active=True
+                admission_method_id=None,  # tier shared
+                admission_path_id=None,
+                code=code,
+                name=name,
+                description=description,
+                is_active=True,
+                applicable_audience=applicable,
             )
-        
+
         # Replace items
         await self.document_group_repo.remove_all_items_from_group(group.id)
-        
+
         for item in data.items:
             await self.document_group_repo.add_item_to_group(
                 group_id=group.id,
@@ -517,9 +549,59 @@ class AdmissionConfigService:
                 submission_format=item.submission_format,
                 display_order=item.display_order,
             )
-            
+
         # Refetch with items
         updated = await self.document_group_repo.get_by_id_with_items(group.id)
         return updated, _noop_callback
+
+    async def preview_shared_documents(
+        self,
+        offering_type_id: int,
+        cultural_education_level: Optional[str],
+        vocational_qualification: Optional[str],
+    ):
+        """Preview bộ hồ sơ shared cho 1 thí sinh giả định (§5b/G5).
+
+        Thin-client: admin nhập raw cultural/vocational → BE derive audience +
+        resolve (NỀN + lớp khớp) + loại bằng TN khi completed_* (§6). Tái dùng
+        nguyên machinery ĐỢT A (filter_shared_by_audience + mandatory_wins_merge
+        + _build_resolved_response) để preview KHỚP resolve thật.
+
+        Chỉ tier shared (config panel không gắn path/method) → đủ cho nhu cầu
+        gốc THCS↔THPT. LIEN_THONG/VLVH layer chưa tồn tại GĐ1 (known-limitation).
+        """
+        from types import SimpleNamespace
+
+        from app.services.admission_path_service import AdmissionPathService
+        from app.services.document_resolution_service import (
+            compute_completed_doc_codes,
+            compute_preview_audience_set,
+            filter_shared_by_audience,
+            mandatory_wins_merge,
+        )
+
+        # offering_type code cho chiều VLVH (cultural là chính cho THCS/THPT).
+        ot_code = await self.document_group_repo.get_offering_type_code(
+            offering_type_id
+        )
+        audience_set = compute_preview_audience_set(
+            cultural_education_level, ot_code
+        )
+
+        shared_groups = await self.document_group_repo.get_shared_groups(
+            offering_type_id
+        )
+        layers = filter_shared_by_audience(
+            shared_groups, audience_set if audience_set else None
+        )
+
+        doc_map: dict = {}
+        # Config preview = snapshot-shape (KHÔNG exclude_inactive) khớp create.
+        mandatory_wins_merge(doc_map, layers, "shared", exclude_inactive=False)
+
+        completed = compute_completed_doc_codes(
+            SimpleNamespace(cultural_education_level=cultural_education_level)
+        )
+        return AdmissionPathService._build_resolved_response(doc_map, completed)
 
 

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -36,6 +36,7 @@ from app.schemas.admission_path import (
     ResolvedDocumentResponse,
 )
 from app.services.document_resolution_service import (
+    build_resolved_response,
     compute_completed_doc_codes,
     derive_audience_set,
     filter_shared_by_audience,
@@ -931,7 +932,7 @@ class AdmissionPathService:
             )
             mandatory_wins_merge(doc_map, layers, "shared")
 
-        resolved = self._build_resolved_response(doc_map, completed_codes)
+        resolved = build_resolved_response(doc_map, completed_codes)
         return resolved, _noop_callback
 
     async def resolve_documents_for_profile(
@@ -955,50 +956,6 @@ class AdmissionPathService:
             audience_set=audience_set,
             completed_codes=completed_codes,
         )
-
-    @staticmethod
-    def _build_resolved_response(
-        doc_map: dict,
-        completed_codes: Optional[set] = None,
-    ) -> List[ResolvedDocumentResponse]:
-        """doc_map ``(item, source, group_audience)`` → list response.
-
-        Loại item có code ∈ ``completed_codes`` (cultural=completed_* → bỏ bằng TN).
-        ``layer_kind``: path_override / method_override / shared_audience / shared_base.
-        ``applicable_audience``: audience của group thắng (None cho NỀN/override).
-        """
-        completed = completed_codes or set()
-        resolved: List[ResolvedDocumentResponse] = []
-        for _doc_type_id, (item, source, grp_aud) in doc_map.items():
-            code = item.document_type.code if item.document_type else ""
-            if code in completed:
-                continue
-            if source == "path_override":
-                layer_kind = "path_override"
-            elif source == "method_override":
-                layer_kind = "method_override"
-            elif grp_aud:
-                layer_kind = "shared_audience"
-            else:
-                layer_kind = "shared_base"
-            resolved.append(
-                ResolvedDocumentResponse(
-                    document_type_id=item.document_type_id,
-                    document_type_code=code,
-                    document_type_name=(
-                        item.document_type.name if item.document_type else ""
-                    ),
-                    is_mandatory=item.is_mandatory,
-                    requires_upload=item.requires_upload,
-                    submission_format=item.submission_format,
-                    display_order=item.display_order,
-                    source=source,
-                    applicable_audience=list(grp_aud) if grp_aud else None,
-                    layer_kind=layer_kind,
-                )
-            )
-        resolved.sort(key=lambda x: x.display_order)
-        return resolved
 
     # =========================================================================
     # CONTROL FIELD COMPUTATION (for response)

--- a/Backend_FastAPI/app/services/document_resolution_service.py
+++ b/Backend_FastAPI/app/services/document_resolution_service.py
@@ -151,6 +151,28 @@ def derive_audience_set(profile, path) -> Set[str]:
     return audience
 
 
+def compute_preview_audience_set(
+    cultural: Optional[str],
+    offering_type_code: Optional[str],
+) -> Set[str]:
+    """Audience set cho PREVIEW config-level (§5b/G5 "Xem trước theo TS").
+
+    KHÔNG cần path/profile (admin chỉ nhập raw cultural/vocational/offering_type
+    → BE derive, thin-client). Chỉ suy:
+    - **Văn hóa**: ``cultural`` trực tiếp → POST_THCS/POST_THPT (nhu cầu gốc).
+    - **VLVH**: offering_type ``vua_lam_vua_hoc``.
+
+    LIEN_THONG_TC/CD cần degree level (program cụ thể) → KHÔNG suy được ở
+    tầng offering_type; defer known-limitation GĐ1 (lớp LIEN_THONG chưa tồn tại).
+    """
+    audience: Set[str] = set()
+    if cultural in _CULTURAL_TO_AUDIENCE:
+        audience.add(_CULTURAL_TO_AUDIENCE[cultural])
+    if offering_type_code == "vua_lam_vua_hoc":
+        audience.add("VLVH")
+    return audience
+
+
 def compute_completed_doc_codes(profile) -> Set[str]:
     """Mã bằng TN cần LOẠI khỏi bộ hồ sơ khi ``cultural='completed_*'``.
 

--- a/Backend_FastAPI/app/services/document_resolution_service.py
+++ b/Backend_FastAPI/app/services/document_resolution_service.py
@@ -18,9 +18,11 @@ Pure: chỉ import models + lazy ``priority_service`` (no FastAPI, no import cyc
 """
 from __future__ import annotations
 
-from typing import Dict, Iterable, List, Optional, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Set
 
 import structlog
+
+from app.schemas.admission_path import ResolvedDocumentResponse
 
 log = structlog.get_logger(__name__)
 
@@ -182,3 +184,50 @@ def compute_completed_doc_codes(profile) -> Set[str]:
     cultural = getattr(profile, "cultural_education_level", None)
     code = _COMPLETED_DIPLOMA_TO_REMOVE.get(cultural)
     return {code} if code else set()
+
+
+def build_resolved_response(
+    doc_map: Dict[int, tuple],
+    completed_codes: Optional[Set[str]] = None,
+) -> List[ResolvedDocumentResponse]:
+    """``doc_map`` ``(item, source, group_audience)`` → list ResolvedDocumentResponse.
+
+    Builder canonical cho resolve (path/create) + preview config — cùng module
+    với ``mandatory_wins_merge`` (đúng layering, tránh caller reach vào private
+    của service khác). Loại item code ∈ ``completed_codes`` (cultural=completed_*
+    → bỏ bằng TN §6). ``layer_kind``: path_override / method_override /
+    shared_audience / shared_base. ``applicable_audience``: audience group thắng
+    (None cho NỀN/override).
+    """
+    completed = completed_codes or set()
+    resolved: List[ResolvedDocumentResponse] = []
+    for _doc_type_id, (item, source, grp_aud) in doc_map.items():
+        code = item.document_type.code if item.document_type else ""
+        if code in completed:
+            continue
+        if source == "path_override":
+            layer_kind = "path_override"
+        elif source == "method_override":
+            layer_kind = "method_override"
+        elif grp_aud:
+            layer_kind = "shared_audience"
+        else:
+            layer_kind = "shared_base"
+        resolved.append(
+            ResolvedDocumentResponse(
+                document_type_id=item.document_type_id,
+                document_type_code=code,
+                document_type_name=(
+                    item.document_type.name if item.document_type else ""
+                ),
+                is_mandatory=item.is_mandatory,
+                requires_upload=item.requires_upload,
+                submission_format=item.submission_format,
+                display_order=item.display_order,
+                source=source,
+                applicable_audience=list(grp_aud) if grp_aud else None,
+                layer_kind=layer_kind,
+            )
+        )
+    resolved.sort(key=lambda x: x.display_order)
+    return resolved

--- a/Backend_FastAPI/tests/integration/test_document_audience_config_panel.py
+++ b/Backend_FastAPI/tests/integration/test_document_audience_config_panel.py
@@ -1,0 +1,268 @@
+"""Integration — config-panel audience support (feat/document-group-audience-merge §10.8).
+
+Anchor cho BE config-panel sau ĐỢT B (split lớp → nhiều shared group/ot):
+- **R10 fix**: get/upsert lookup CHÍNH XÁC theo (ot, audience), KHÔNG ``groups[0]``
+  nondeterministic. get NỀN (None) trả group applicable_audience NULL; get
+  POST_THCS trả đúng lớp THCS.
+- **G4**: NỀN lookup theo (ot, audience IS NULL) — KHÔNG theo code (reuse group
+  seed/upsert bất kể code, không tạo 2 NỀN/ot).
+- **list layers**: trả TẤT CẢ shared group ordered (NỀN trước).
+- **upsert**: update đúng lớp (không đụng lớp khác); tạo lớp mới với code
+  deterministic + applicable_audience khi chưa có; validate audience.
+- **preview** (§5b/G5): graduated_thcs→bộ THCS (KHÔNG THPT); graduated_thpt→bộ
+  THPT (KHÔNG THCS); completed_thpt→loại bằng TN (§6); None→chỉ NỀN.
+
+Test DB dùng ``Base.metadata.create_all`` (cột applicable_audience có trong model).
+"""
+import random
+
+import pytest
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.schemas.admission_config import (
+    DocumentGroupItemCreate,
+    SharedDocumentGroupUpdate,
+)
+from app.services.admission_config_service import AdmissionConfigService
+from app.utils.exceptions import ValidationError
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _get_or_create_doc_type(session, code: str, name: str) -> int:
+    existing = (
+        await session.execute(
+            select(models.ConfigDocumentType).where(
+                models.ConfigDocumentType.code == code
+            )
+        )
+    ).scalar_one_or_none()
+    if existing:
+        return existing.id
+    dt = models.ConfigDocumentType(code=code, name=name, is_active=True)
+    session.add(dt)
+    await session.flush()
+    return dt.id
+
+
+async def _setup(ot_code_prefix: str = "cfgpanel") -> dict:
+    """Tạo offering_type + doc types + 3 shared group (NỀN/POST_THPT/POST_THCS)."""
+    suffix = random.randint(100000, 999999)
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            ot = models.ConfigOfferingType(
+                code=f"{ot_code_prefix}_{suffix}",
+                name=f"Cfg Panel OT {suffix}",
+                is_active=True,
+            )
+            session.add(ot)
+            await session.flush()
+
+            cccd = await _get_or_create_doc_type(session, "cccd", "CCCD")
+            hb_thpt = await _get_or_create_doc_type(session, "hoc_ba_thpt", "Học bạ THPT")
+            bts_thpt = await _get_or_create_doc_type(
+                session, "bang_tot_nghiep_thpt", "Bằng TN THPT"
+            )
+            hb_thcs = await _get_or_create_doc_type(session, "hoc_ba_thcs", "Học bạ THCS")
+            bts_thcs = await _get_or_create_doc_type(
+                session, "bang_tot_nghiep_thcs", "Bằng TN THCS"
+            )
+
+            def _mk_group(code, audience):
+                g = models.DocumentGroup(
+                    offering_type_id=ot.id,
+                    admission_method_id=None,
+                    admission_path_id=None,
+                    code=code,
+                    name=code,
+                    is_active=True,
+                    applicable_audience=audience,
+                )
+                session.add(g)
+                return g
+
+            g_base = _mk_group(f"CFG_BASE_{suffix}", None)
+            g_thpt = _mk_group(f"CFG_THPT_{suffix}", ["POST_THPT"])
+            g_thcs = _mk_group(f"CFG_THCS_{suffix}", ["POST_THCS"])
+            await session.flush()
+
+            def _mk_item(group_id, dt_id, order):
+                session.add(
+                    models.DocumentGroupItem(
+                        group_id=group_id,
+                        document_type_id=dt_id,
+                        is_mandatory=True,
+                        requires_upload=True,
+                        submission_format="photo",
+                        display_order=order,
+                    )
+                )
+
+            _mk_item(g_base.id, cccd, 1)
+            _mk_item(g_thpt.id, hb_thpt, 2)
+            _mk_item(g_thpt.id, bts_thpt, 3)
+            _mk_item(g_thcs.id, hb_thcs, 2)
+            _mk_item(g_thcs.id, bts_thcs, 3)
+
+            return {
+                "ot_id": ot.id,
+                "base_id": g_base.id,
+                "thpt_id": g_thpt.id,
+                "thcs_id": g_thcs.id,
+                "cccd": cccd,
+                "hb_thpt": hb_thpt,
+                "bts_thpt": bts_thpt,
+                "hb_thcs": hb_thcs,
+                "bts_thcs": bts_thcs,
+            }
+
+
+# ---------------------------------------------------------------------------
+# get_shared_group_by_audience — R10 / G4 fix
+# ---------------------------------------------------------------------------
+
+
+async def test_get_by_audience_none_returns_nen():
+    d = await _setup()
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        g = await svc.get_shared_document_group(d["ot_id"], None)
+        assert g is not None and g.id == d["base_id"]
+        assert not g.applicable_audience  # NỀN = NULL/empty
+
+
+async def test_get_by_audience_post_thcs_returns_thcs_layer():
+    d = await _setup()
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        g = await svc.get_shared_document_group(d["ot_id"], "POST_THCS")
+        assert g is not None and g.id == d["thcs_id"]
+        assert g.applicable_audience == ["POST_THCS"]
+        codes = {i.document_type.code for i in g.items}
+        assert codes == {"hoc_ba_thcs", "bang_tot_nghiep_thcs"}
+
+
+async def test_list_layers_ordered_nen_first():
+    d = await _setup()
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        groups = await svc.list_shared_document_groups(d["ot_id"])
+        assert [g.id for g in groups] == [d["base_id"], d["thpt_id"], d["thcs_id"]]
+        # NỀN đứng đầu (id ASC) — deterministic (fix groups[0] nondeterministic).
+        assert not groups[0].applicable_audience
+
+
+# ---------------------------------------------------------------------------
+# upsert — target đúng lớp, tạo lớp mới, validate
+# ---------------------------------------------------------------------------
+
+
+async def test_upsert_targets_correct_audience_layer_not_groups0():
+    d = await _setup()
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        # Update lớp POST_THPT → chỉ còn 1 item (hoc_ba_thpt).
+        payload = SharedDocumentGroupUpdate(
+            items=[DocumentGroupItemCreate(document_type_id=d["hb_thpt"], display_order=1)]
+        )
+        updated, _ = await svc.upsert_shared_document_group(
+            d["ot_id"], payload, None, audience="POST_THPT"
+        )
+        await s.commit()
+        assert updated.id == d["thpt_id"]  # đúng lớp THPT, KHÔNG phải NỀN
+        assert {i.document_type_id for i in updated.items} == {d["hb_thpt"]}
+
+    # NỀN + THCS KHÔNG bị đụng.
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        nen = await svc.get_shared_document_group(d["ot_id"], None)
+        assert {i.document_type_id for i in nen.items} == {d["cccd"]}
+        thcs = await svc.get_shared_document_group(d["ot_id"], "POST_THCS")
+        assert len(thcs.items) == 2
+
+
+async def test_upsert_creates_layer_when_missing_with_code_and_audience():
+    """ot CHỈ có NỀN → upsert POST_THCS tạo lớp mới (code + applicable_audience)."""
+    suffix = random.randint(100000, 999999)
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            ot = models.ConfigOfferingType(
+                code=f"cfgnew_{suffix}", name=f"New OT {suffix}", is_active=True
+            )
+            session.add(ot)
+            await session.flush()
+            ot_id = ot.id
+            hb_thcs = await _get_or_create_doc_type(session, "hoc_ba_thcs", "Học bạ THCS")
+
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        payload = SharedDocumentGroupUpdate(
+            items=[DocumentGroupItemCreate(document_type_id=hb_thcs, display_order=1)]
+        )
+        created, _ = await svc.upsert_shared_document_group(
+            ot_id, payload, None, audience="POST_THCS"
+        )
+        await s.commit()
+        assert created.applicable_audience == ["POST_THCS"]
+        assert created.code == f"SHARED_DOC_OT_{ot_id}_POST_THCS"
+        assert created.admission_method_id is None
+        assert created.admission_path_id is None
+
+
+async def test_upsert_rejects_invalid_audience():
+    d = await _setup()
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        payload = SharedDocumentGroupUpdate(items=[])
+        with pytest.raises(ValidationError):
+            await svc.upsert_shared_document_group(
+                d["ot_id"], payload, None, audience="NOT_A_REAL_AUDIENCE"
+            )
+
+
+# ---------------------------------------------------------------------------
+# preview (§5b/G5) — derive raw cultural → resolve
+# ---------------------------------------------------------------------------
+
+
+async def test_preview_graduated_thcs_gets_thcs_not_thpt():
+    d = await _setup()
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        docs = await svc.preview_shared_documents(d["ot_id"], "graduated_thcs", None)
+        codes = {x.document_type_code for x in docs}
+        assert "hoc_ba_thcs" in codes and "bang_tot_nghiep_thcs" in codes
+        assert "hoc_ba_thpt" not in codes and "bang_tot_nghiep_thpt" not in codes
+        assert "cccd" in codes  # NỀN luôn gộp
+
+
+async def test_preview_graduated_thpt_gets_thpt_not_thcs():
+    d = await _setup()
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        docs = await svc.preview_shared_documents(d["ot_id"], "graduated_thpt", None)
+        codes = {x.document_type_code for x in docs}
+        assert "hoc_ba_thpt" in codes and "bang_tot_nghiep_thpt" in codes
+        assert "hoc_ba_thcs" not in codes
+
+
+async def test_preview_completed_thpt_drops_diploma():
+    """§6: completed_* → loại bằng TN (chưa có bằng)."""
+    d = await _setup()
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        docs = await svc.preview_shared_documents(d["ot_id"], "completed_thpt", None)
+        codes = {x.document_type_code for x in docs}
+        assert "hoc_ba_thpt" in codes  # học bạ giữ
+        assert "bang_tot_nghiep_thpt" not in codes  # bằng TN loại
+
+
+async def test_preview_no_cultural_returns_nen_only():
+    d = await _setup()
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        docs = await svc.preview_shared_documents(d["ot_id"], None, None)
+        codes = {x.document_type_code for x in docs}
+        assert codes == {"cccd"}  # chỉ NỀN

--- a/Backend_FastAPI/tests/integration/test_document_audience_config_panel.py
+++ b/Backend_FastAPI/tests/integration/test_document_audience_config_panel.py
@@ -273,27 +273,19 @@ async def test_preview_no_cultural_returns_nen_only():
 # ---------------------------------------------------------------------------
 
 
-async def _setup_with_path_override() -> dict:
+async def _setup_with_path_override(major_id: int) -> dict:
     """ot + NỀN group + 1 admission_path + path-override group (method NULL,
     path SET, item marker). Path-override ĐƯỢC PHÉP method NULL (invariant) →
-    phải bị get_shared_groups loại khỏi tier shared."""
+    phải bị get_shared_groups loại khỏi tier shared.
+
+    ``major_id`` từ fixture ``seed_lead_dependencies`` (tránh tự tạo
+    OrganizationUnit/MajorProgram → collision id=1 với seed test khác trong CI).
+    """
     from tests.fixtures.builders import AdmissionRoundBuilder
 
     suffix = random.randint(100000, 999999)
     async with AsyncSessionLocal() as session:
         async with session.begin():
-            unit = models.OrganizationUnit(
-                name=f"Unit {suffix}", type="Khoa"
-            )
-            session.add(unit)
-            await session.flush()
-            major = models.MajorProgram(
-                name=f"Major {suffix}", code=f"M{suffix}",
-                degree_level="Cao đẳng", unit_id=unit.id,
-            )
-            session.add(major)
-            await session.flush()
-
             ot = models.ConfigOfferingType(
                 code=f"cfgpath_{suffix}", name=f"Path OT {suffix}", is_active=True
             )
@@ -302,7 +294,7 @@ async def _setup_with_path_override() -> dict:
 
             offering = models.ProgramOffering(
                 offering_type=f"PathTest_{suffix}",
-                program_id=major.id,
+                program_id=major_id,
                 offering_type_id=ot.id,
             )
             session.add(offering)
@@ -372,8 +364,8 @@ async def _setup_with_path_override() -> dict:
             return {"ot_id": ot.id, "nen_id": g_nen.id, "path_id": g_path.id}
 
 
-async def test_list_layers_excludes_path_override():
-    d = await _setup_with_path_override()
+async def test_list_layers_excludes_path_override(seed_lead_dependencies):
+    d = await _setup_with_path_override(seed_lead_dependencies["major_program_id"])
     async with AsyncSessionLocal() as s:
         svc = AdmissionConfigService(s)
         groups = await svc.list_shared_document_groups(d["ot_id"])
@@ -382,8 +374,8 @@ async def test_list_layers_excludes_path_override():
         assert d["path_id"] not in ids  # path-override KHÔNG phải shared layer
 
 
-async def test_preview_excludes_path_override():
-    d = await _setup_with_path_override()
+async def test_preview_excludes_path_override(seed_lead_dependencies):
+    d = await _setup_with_path_override(seed_lead_dependencies["major_program_id"])
     async with AsyncSessionLocal() as s:
         svc = AdmissionConfigService(s)
         docs = await svc.preview_shared_documents(d["ot_id"], "graduated_thpt", None)

--- a/Backend_FastAPI/tests/integration/test_document_audience_config_panel.py
+++ b/Backend_FastAPI/tests/integration/test_document_audience_config_panel.py
@@ -266,3 +266,127 @@ async def test_preview_no_cultural_returns_nen_only():
         docs = await svc.preview_shared_documents(d["ot_id"], None, None)
         codes = {x.document_type_code for x in docs}
         assert codes == {"cccd"}  # chỉ NỀN
+
+
+# ---------------------------------------------------------------------------
+# P1 review — path-override group (method NULL + path SET) KHÔNG lẫn shared
+# ---------------------------------------------------------------------------
+
+
+async def _setup_with_path_override() -> dict:
+    """ot + NỀN group + 1 admission_path + path-override group (method NULL,
+    path SET, item marker). Path-override ĐƯỢC PHÉP method NULL (invariant) →
+    phải bị get_shared_groups loại khỏi tier shared."""
+    from tests.fixtures.builders import AdmissionRoundBuilder
+
+    suffix = random.randint(100000, 999999)
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            unit = models.OrganizationUnit(
+                name=f"Unit {suffix}", type="Khoa"
+            )
+            session.add(unit)
+            await session.flush()
+            major = models.MajorProgram(
+                name=f"Major {suffix}", code=f"M{suffix}",
+                degree_level="Cao đẳng", unit_id=unit.id,
+            )
+            session.add(major)
+            await session.flush()
+
+            ot = models.ConfigOfferingType(
+                code=f"cfgpath_{suffix}", name=f"Path OT {suffix}", is_active=True
+            )
+            session.add(ot)
+            await session.flush()
+
+            offering = models.ProgramOffering(
+                offering_type=f"PathTest_{suffix}",
+                program_id=major.id,
+                offering_type_id=ot.id,
+            )
+            session.add(offering)
+            await session.flush()
+
+            academic_info = models.OfferingAcademicInfo(
+                offering_id=offering.id, academic_year=2025, is_published=True
+            )
+            session.add(academic_info)
+            await session.flush()
+
+            method = models.AdmissionMethod(
+                code=f"pathm_{suffix}", name="Path Method", is_active=True
+            )
+            session.add(method)
+            await session.flush()
+
+            criteria = models.AdmissionCriteria(
+                method_id=method.id, code=f"pathc_{suffix}", name="C",
+                min_gpa=0, is_active=True,
+            )
+            session.add(criteria)
+            await session.flush()
+
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                session, academic_year=2025
+            )
+            path = models.AdmissionPath(
+                academic_info_id=academic_info.id,
+                admission_method_id=method.id,
+                admission_round_id=round_id,
+                criteria_id=criteria.id,
+                status="active",
+            )
+            session.add(path)
+            await session.flush()
+
+            cccd = await _get_or_create_doc_type(session, "cccd", "CCCD")
+            marker = await _get_or_create_doc_type(
+                session, "marker_path_doc", "Marker Path Doc"
+            )
+
+            # NỀN (method+path NULL).
+            g_nen = models.DocumentGroup(
+                offering_type_id=ot.id, admission_method_id=None,
+                admission_path_id=None, code=f"PNEN_{suffix}", name="nen",
+                is_active=True, applicable_audience=None,
+            )
+            # Path-override: method NULL NHƯNG path SET (invariant cho phép).
+            g_path = models.DocumentGroup(
+                offering_type_id=ot.id, admission_method_id=None,
+                admission_path_id=path.id, code=f"PPATH_{suffix}", name="path",
+                is_active=True, applicable_audience=None,
+            )
+            session.add_all([g_nen, g_path])
+            await session.flush()
+
+            session.add(models.DocumentGroupItem(
+                group_id=g_nen.id, document_type_id=cccd, is_mandatory=True,
+                requires_upload=True, display_order=1,
+            ))
+            session.add(models.DocumentGroupItem(
+                group_id=g_path.id, document_type_id=marker, is_mandatory=True,
+                requires_upload=True, display_order=1,
+            ))
+
+            return {"ot_id": ot.id, "nen_id": g_nen.id, "path_id": g_path.id}
+
+
+async def test_list_layers_excludes_path_override():
+    d = await _setup_with_path_override()
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        groups = await svc.list_shared_document_groups(d["ot_id"])
+        ids = {g.id for g in groups}
+        assert d["nen_id"] in ids
+        assert d["path_id"] not in ids  # path-override KHÔNG phải shared layer
+
+
+async def test_preview_excludes_path_override():
+    d = await _setup_with_path_override()
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionConfigService(s)
+        docs = await svc.preview_shared_documents(d["ot_id"], "graduated_thpt", None)
+        codes = {x.document_type_code for x in docs}
+        assert "cccd" in codes  # NỀN có
+        assert "marker_path_doc" not in codes  # path-override KHÔNG merge vào preview

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/SharedDocumentConfigPanel.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/SharedDocumentConfigPanel.tsx
@@ -5,9 +5,26 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Loader2, Save } from "lucide-react";
-import { useOfferingTypes, useDocumentTypes, useSharedDocumentGroup, useUpsertSharedDocumentGroup } from "@/hooks/admissions/useMasterData";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Loader2, Save, Eye } from "lucide-react";
+import {
+  useOfferingTypes,
+  useDocumentTypes,
+  useSharedDocumentGroup,
+  useUpsertSharedDocumentGroup,
+  usePreviewSharedDocuments,
+} from "@/hooks/admissions/useMasterData";
+import { AUDIENCE_LABELS } from "@/lib/zod/admission-path";
 import { DocumentType, OfferingType } from "../shared/types";
 
 interface DocSelection {
@@ -26,20 +43,150 @@ interface SharedDocItem {
   display_order: number;
 }
 
+// Sentinel cho lớp NỀN trong Select (Radix value phải là string non-empty).
+const NEN = "__NEN__";
+
+// Nhãn trình độ văn hóa cho dialog Xem trước (display-only, mirror BE enum).
+const CULTURAL_LABELS: Record<string, string> = {
+  graduated_thpt: "Đã tốt nghiệp THPT",
+  completed_thpt: "Hoàn thành THPT (chưa có bằng)",
+  graduated_gdtx: "Tốt nghiệp GDTX",
+  graduated_thcs: "Đã tốt nghiệp THCS",
+  completed_thcs: "Hoàn thành THCS (chưa có bằng)",
+};
+
+interface PreviewDoc {
+  document_type_code: string;
+  document_type_name: string;
+  is_mandatory: boolean;
+  layer_kind: string;
+  applicable_audience: string[] | null;
+}
+
+/** Dialog "Xem trước theo TS" (§5b/G5) — thin-client: gửi raw cultural cho BE derive. */
+function PreviewDialog({ offeringTypeId }: { offeringTypeId: number }) {
+  const [open, setOpen] = useState(false);
+  const [cultural, setCultural] = useState<string | null>(null);
+  const previewMutation = usePreviewSharedDocuments();
+  const docs: PreviewDoc[] = previewMutation.data ?? [];
+
+  const handleCompute = () => {
+    previewMutation.mutate({
+      offeringTypeId,
+      body: { cultural_education_level: cultural },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <Eye className="h-4 w-4 mr-2" aria-hidden="true" />
+          Xem trước theo TS
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Xem trước bộ hồ sơ theo thí sinh</DialogTitle>
+          <DialogDescription>
+            Chọn trình độ văn hóa của thí sinh giả định — hệ thống tính bộ giấy
+            tờ thực tế (lớp NỀN + lớp theo đối tượng).
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-end gap-3">
+          <div className="flex-1 space-y-1">
+            <Label>Trình độ văn hóa</Label>
+            <Select
+              value={cultural ?? undefined}
+              onValueChange={(v) => setCultural(v)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Chọn trình độ..." />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(CULTURAL_LABELS).map(([code, label]) => (
+                  <SelectItem key={code} value={code}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button onClick={handleCompute} disabled={previewMutation.isPending}>
+            {previewMutation.isPending ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
+            ) : null}
+            Tính bộ hồ sơ
+          </Button>
+        </div>
+
+        {previewMutation.isSuccess && (
+          <div className="border rounded-lg divide-y max-h-[300px] overflow-y-auto">
+            {docs.length === 0 ? (
+              <p className="p-3 text-sm text-muted-foreground">
+                Không có giấy tờ nào cho cấu hình này.
+              </p>
+            ) : (
+              docs.map((d) => (
+                <div
+                  key={d.document_type_code}
+                  className="flex items-center justify-between p-2.5 text-sm"
+                >
+                  <span>
+                    {d.document_type_name}
+                    {d.is_mandatory && (
+                      <span className="text-error-600 ml-1" aria-hidden="true">
+                        *
+                      </span>
+                    )}
+                  </span>
+                  {d.layer_kind === "shared_audience" && d.applicable_audience ? (
+                    <Badge
+                      variant="outline"
+                      className="text-[10px] h-5 border-info-100 bg-info-50 text-info-700"
+                    >
+                      {d.applicable_audience
+                        .map((a) => AUDIENCE_LABELS[a as keyof typeof AUDIENCE_LABELS] ?? a)
+                        .join(", ")}
+                    </Badge>
+                  ) : (
+                    <Badge variant="secondary" className="text-[10px] h-5">
+                      NỀN
+                    </Badge>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <p className="text-xs text-muted-foreground mr-auto">
+            <span className="text-error-600">*</span> bắt buộc nộp.
+          </p>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function SharedDocumentConfigPanel() {
   // Queries
   const { data: offeringTypes = [], isLoading: loadingOfferingTypes } = useOfferingTypes();
   const { data: allDocTypes = [], isLoading: loadingDocTypes } = useDocumentTypes();
-  
+
   // State
   const [selectedOfferingTypeId, setSelectedOfferingTypeId] = useState<number | null>(null);
-  
-  // Dependent Query
-  const { 
-    data: sharedGroup, 
-    isLoading: loadingSharedGroup 
-  } = useSharedDocumentGroup(selectedOfferingTypeId);
-  
+  // feat/document-group-audience-merge §10.17: lớp đang sửa (null = NỀN).
+  const [selectedAudience, setSelectedAudience] = useState<string | null>(null);
+
+  // Dependent Query — theo (offering_type, audience).
+  const {
+    data: sharedGroup,
+    isLoading: loadingSharedGroup,
+  } = useSharedDocumentGroup(selectedOfferingTypeId, selectedAudience);
+
   const upsertMutation = useUpsertSharedDocumentGroup();
 
   // ✅ Section 2.6.8: Derive initial selections from API data using useMemo
@@ -60,11 +207,12 @@ export function SharedDocumentConfigPanel() {
 
   // Local modifications state - tracks user changes
   const [modifications, setModifications] = useState<Record<number, DocSelection | null>>({});
-  
-  // Reset modifications when offering type changes
-  const [lastOfferingTypeId, setLastOfferingTypeId] = useState<number | null>(null);
-  if (selectedOfferingTypeId !== lastOfferingTypeId) {
-    setLastOfferingTypeId(selectedOfferingTypeId);
+
+  // Reset modifications khi đổi offering type HOẶC audience (sửa lớp khác).
+  const ctxKey = `${selectedOfferingTypeId}|${selectedAudience ?? NEN}`;
+  const [lastCtxKey, setLastCtxKey] = useState<string | null>(null);
+  if (ctxKey !== lastCtxKey) {
+    setLastCtxKey(ctxKey);
     setModifications({});
   }
 
@@ -85,21 +233,19 @@ export function SharedDocumentConfigPanel() {
   // Handlers
   const handleSelect = (typeId: number, checked: boolean) => {
     if (checked) {
-      // Add new or restore from initial
       const existing = initialSelections[typeId];
       setModifications(prev => {
         if (existing) {
-          // Re-enable: delete the null marker so it falls back to initialSelections
-          const { [typeId]: _, ...rest } = prev;
+          // Omit key qua destructure (restore từ initialSelections).
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [typeId]: _removed, ...rest } = prev;
           return rest;
         }
-        // New selection: compute display_order from prev + initialSelections
         const currentActiveCount = Object.keys(initialSelections).length
           + Object.values(prev).filter(v => v !== null).length;
         return { ...prev, [typeId]: { document_type_id: typeId, is_mandatory: true, requires_upload: true, submission_format: null, display_order: currentActiveCount + 1 } };
       });
     } else {
-      // Mark as removed
       setModifications(prev => ({
         ...prev,
         [typeId]: null
@@ -110,7 +256,7 @@ export function SharedDocumentConfigPanel() {
   const handleUpdate = <K extends keyof DocSelection>(typeId: number, field: K, value: DocSelection[K]) => {
     const current = selections[typeId];
     if (!current) return;
-    
+
     setModifications(prev => ({
       ...prev,
       [typeId]: {
@@ -122,12 +268,13 @@ export function SharedDocumentConfigPanel() {
 
   const handleSave = async () => {
     if (!selectedOfferingTypeId) return;
-    
+
     try {
       const payload = Object.values(selections);
       await upsertMutation.mutateAsync({
         offeringTypeId: selectedOfferingTypeId,
-        data: { items: payload }
+        data: { items: payload },
+        audience: selectedAudience,
       });
       setModifications({});
     } catch {
@@ -145,35 +292,75 @@ export function SharedDocumentConfigPanel() {
     );
   }
 
+  const audienceLabel =
+    selectedAudience === null
+      ? "NỀN (mọi thí sinh)"
+      : AUDIENCE_LABELS[selectedAudience as keyof typeof AUDIENCE_LABELS] ?? selectedAudience;
+
   return (
     <div className="space-y-6">
-      {/* 1. Select Offering Type */}
-      <div className="flex items-center gap-4 p-4 border rounded-lg bg-muted">
-        <Label className="w-32">Loại hình đào tạo:</Label>
-        <Select 
-          value={selectedOfferingTypeId?.toString()} 
-          onValueChange={(val) => setSelectedOfferingTypeId(Number(val))}
-        >
-          <SelectTrigger className="w-[300px]">
-            <SelectValue placeholder="Chọn loại hình đào tạo..." />
-          </SelectTrigger>
-          <SelectContent>
-            {offeringTypes.map((type: OfferingType) => (
-              <SelectItem key={type.id} value={type.id.toString()}>
-                {type.name} ({type.code})
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+      {/* 1. Bộ lọc lớp: Loại hình + Đối tượng + Xem trước */}
+      <div className="flex flex-wrap items-end gap-4 p-4 border rounded-lg bg-muted">
+        <div className="space-y-1">
+          <Label>Loại hình đào tạo</Label>
+          <Select
+            value={selectedOfferingTypeId?.toString()}
+            onValueChange={(val) => setSelectedOfferingTypeId(Number(val))}
+          >
+            <SelectTrigger className="w-[260px]">
+              <SelectValue placeholder="Chọn loại hình đào tạo..." />
+            </SelectTrigger>
+            <SelectContent>
+              {offeringTypes.map((type: OfferingType) => (
+                <SelectItem key={type.id} value={type.id.toString()}>
+                  {type.name} ({type.code})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1">
+          <Label>Đối tượng / trình độ</Label>
+          <Select
+            value={selectedAudience ?? NEN}
+            onValueChange={(v) => setSelectedAudience(v === NEN ? null : v)}
+          >
+            <SelectTrigger className="w-[220px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NEN}>NỀN (mọi thí sinh)</SelectItem>
+              {Object.entries(AUDIENCE_LABELS).map(([code, label]) => (
+                <SelectItem key={code} value={code}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {selectedOfferingTypeId && (
+          <div className="ml-auto">
+            <PreviewDialog offeringTypeId={selectedOfferingTypeId} />
+          </div>
+        )}
       </div>
 
       {/* 2. Config Area */}
       {selectedOfferingTypeId ? (
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">Cấu hình hồ sơ dùng chung</CardTitle>
+            <CardTitle className="text-lg flex items-center gap-2">
+              Cấu hình lớp giấy tờ
+              <Badge variant={selectedAudience === null ? "secondary" : "outline"}>
+                {audienceLabel}
+              </Badge>
+            </CardTitle>
             <CardDescription>
-              Các loại giấy tờ được chọn ở đây sẽ tự động áp dụng cho tất cả Phương thức xét tuyển thuộc loại hình đào tạo này.
+              {selectedAudience === null
+                ? "Lớp NỀN — luôn gộp cho MỌI thí sinh thuộc loại hình này."
+                : `Chỉ áp dụng cho thí sinh thuộc đối tượng "${audienceLabel}" (gộp thêm trên lớp NỀN).`}
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -190,25 +377,25 @@ export function SharedDocumentConfigPanel() {
                     <div className="col-span-2 text-center">Yêu cầu up file</div>
                     <div className="col-span-2 text-center">Thứ tự</div>
                   </div>
-                  
+
                   <div className="max-h-[500px] overflow-y-auto">
                     {allDocTypes.map((type: DocumentType) => {
                       const isSelected = !!selections[type.id];
                       const current = selections[type.id];
 
                       return (
-                        <div 
-                          key={type.id} 
+                        <div
+                          key={type.id}
                           className={`grid grid-cols-12 p-3 items-center border-b last:border-0 hover:bg-muted ${isSelected ? 'bg-info-50/50' : ''}`}
                         >
                           <div className="col-span-6 flex items-center gap-3">
-                            <Checkbox 
+                            <Checkbox
                               id={`doc-${type.id}`}
                               checked={isSelected}
                               onCheckedChange={(checked) => handleSelect(type.id, checked as boolean)}
                             />
                             <div className="grid gap-0.5">
-                              <Label 
+                              <Label
                                 htmlFor={`doc-${type.id}`}
                                 className="text-sm font-medium cursor-pointer"
                               >
@@ -219,7 +406,7 @@ export function SharedDocumentConfigPanel() {
                           </div>
 
                           <div className="col-span-2 flex justify-center">
-                            <Checkbox 
+                            <Checkbox
                               checked={current?.is_mandatory || false}
                               disabled={!isSelected}
                               onCheckedChange={(c) => handleUpdate(type.id, 'is_mandatory', c === true)}
@@ -227,13 +414,13 @@ export function SharedDocumentConfigPanel() {
                           </div>
 
                           <div className="col-span-2 flex justify-center">
-                            <Checkbox 
+                            <Checkbox
                               checked={current?.requires_upload || false}
                               disabled={!isSelected}
                               onCheckedChange={(c) => handleUpdate(type.id, 'requires_upload', c === true)}
                             />
                           </div>
-                          
+
                           <div className="col-span-2 flex justify-center text-xs text-muted-foreground">
                              {current?.display_order || "-"}
                           </div>
@@ -250,7 +437,7 @@ export function SharedDocumentConfigPanel() {
                     ) : (
                       <Save className="h-4 w-4 mr-2" />
                     )}
-                    Lưu cấu hình
+                    Lưu lớp “{audienceLabel}”
                   </Button>
                 </div>
               </div>

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/SharedDocumentConfigPanel.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/SharedDocumentConfigPanel.tsx
@@ -342,7 +342,12 @@ export function SharedDocumentConfigPanel() {
 
         {selectedOfferingTypeId && (
           <div className="ml-auto">
-            <PreviewDialog offeringTypeId={selectedOfferingTypeId} />
+            {/* key remount → reset mutation result + cultural khi đổi loại hình
+                (review P2: tránh giữ kết quả preview của loại hình trước). */}
+            <PreviewDialog
+              key={selectedOfferingTypeId}
+              offeringTypeId={selectedOfferingTypeId}
+            />
           </div>
         )}
       </div>

--- a/frontend/src/hooks/admissions/useMasterData.ts
+++ b/frontend/src/hooks/admissions/useMasterData.ts
@@ -406,10 +406,15 @@ export function useRemoveSubjectFromGroup() {
 // SHARED DOCUMENT GROUPS
 // ============================================
 
-export function useSharedDocumentGroup(offeringTypeId: number | null) {
+// feat/document-group-audience-merge §10.16: audience vào queryKey (NỀN=null).
+export function useSharedDocumentGroup(
+  offeringTypeId: number | null,
+  audience?: string | null,
+) {
   return useQuery({
-    queryKey: ["shared-document-group", offeringTypeId],
-    queryFn: () => masterDataApi.getSharedDocumentGroup(offeringTypeId!),
+    queryKey: ["shared-document-group", offeringTypeId, audience ?? null],
+    queryFn: () =>
+      masterDataApi.getSharedDocumentGroup(offeringTypeId!, audience),
     enabled: !!offeringTypeId, // Only fetch if offeringTypeId is present
   });
 }
@@ -418,14 +423,28 @@ export function useUpsertSharedDocumentGroup() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ offeringTypeId, data }: { offeringTypeId: number; data: import("@/app/(dashboard)/admin/admission-config/_components/shared/types").SharedDocumentGroupUpdate }) =>
-      masterDataApi.upsertSharedDocumentGroup(offeringTypeId, data),
+    mutationFn: ({ offeringTypeId, data, audience }: { offeringTypeId: number; data: import("@/app/(dashboard)/admin/admission-config/_components/shared/types").SharedDocumentGroupUpdate; audience?: string | null }) =>
+      masterDataApi.upsertSharedDocumentGroup(offeringTypeId, data, audience),
     onSuccess: (_, variables) => {
-      toast.success("Shared documents configuration saved successfully");
-      queryClient.invalidateQueries({ queryKey: ["shared-document-group", variables.offeringTypeId] });
+      toast.success("Đã lưu cấu hình lớp giấy tờ");
+      // Invalidate đúng key gồm audience (parity §10.16 — react-query-mutation-cache-parity).
+      queryClient.invalidateQueries({
+        queryKey: ["shared-document-group", variables.offeringTypeId, variables.audience ?? null],
+      });
     },
     onError: (error: ApiError) => {
-      toast.error(error.response?.data?.detail || "Failed to save shared documents configuration");
+      toast.error(error.response?.data?.detail || "Lưu cấu hình lớp giấy tờ thất bại");
+    },
+  });
+}
+
+// §5b/G5 preview — mutation (POST body), KHÔNG cache.
+export function usePreviewSharedDocuments() {
+  return useMutation({
+    mutationFn: ({ offeringTypeId, body }: { offeringTypeId: number; body: { cultural_education_level?: string | null; vocational_qualification?: string | null } }) =>
+      masterDataApi.previewSharedDocuments(offeringTypeId, body),
+    onError: (error: ApiError) => {
+      toast.error(error.response?.data?.detail || "Xem trước bộ hồ sơ thất bại");
     },
   });
 }

--- a/frontend/src/lib/api/master-data.ts
+++ b/frontend/src/lib/api/master-data.ts
@@ -232,13 +232,43 @@ export async function updateSubjectPosition(groupId: number, subjectId: number, 
 // SHARED DOCUMENT GROUPS
 // ============================================
 
-export async function getSharedDocumentGroup(offeringTypeId: number) {
-  const response = await api.get(`/api/admission-config/document-groups/shared/${offeringTypeId}`);
+// feat/document-group-audience-merge §10.8/§10.16: lớp audience (NỀN = null).
+export async function getSharedDocumentGroup(
+  offeringTypeId: number,
+  audience?: string | null,
+) {
+  const response = await api.get(
+    `/api/admission-config/document-groups/shared/${offeringTypeId}`,
+    { params: audience ? { audience } : undefined },
+  );
   return response.data;
 }
 
-export async function upsertSharedDocumentGroup(offeringTypeId: number, data: SharedDocumentGroupUpdate) {
-  const response = await api.put(`/api/admission-config/document-groups/shared/${offeringTypeId}`, data);
+export async function upsertSharedDocumentGroup(
+  offeringTypeId: number,
+  data: SharedDocumentGroupUpdate,
+  audience?: string | null,
+) {
+  const response = await api.put(
+    `/api/admission-config/document-groups/shared/${offeringTypeId}`,
+    data,
+    { params: audience ? { audience } : undefined },
+  );
+  return response.data;
+}
+
+// §5b/G5 preview "Xem trước theo TS": gửi raw cultural/vocational → BE derive.
+export async function previewSharedDocuments(
+  offeringTypeId: number,
+  body: {
+    cultural_education_level?: string | null;
+    vocational_qualification?: string | null;
+  },
+) {
+  const response = await api.post(
+    `/api/admission-config/document-groups/shared/${offeringTypeId}/preview`,
+    body,
+  );
   return response.data;
 }
 


### PR DESCRIPTION
## Mục tiêu
Nền tảng BE để admin quản lý **từng lớp giấy tờ theo đối tượng** (NỀN / Tốt nghiệp THPT / THCS) qua SharedDocumentConfigPanel + **fix bug PROD do ĐỢT B tạo ra**. FE panel = PR sau (consume BE này).

## 🔴 Fix bug PROD (R10 — do ĐỢT B)
Sau ĐỢT B split, `get_shared_groups(ot)` trả **nhiều** group nhưng config get/upsert lấy `groups[0]` + repo **không ORDER BY** → panel admin hiện/ghi shared group **ngẫu nhiên** (NỀN hoặc POST_THPT/THCS tùy query plan).
- `get_shared_groups`: +ORDER BY id (resolve order-independent → vô hại; NỀN đầu).
- `get_shared_group_by_audience(ot, audience)`: lookup CHÍNH XÁC (None=NỀN theo `applicable_audience IS NULL` — G4 KHÔNG theo code; `<X>`=lớp khớp).
- service get/upsert nhận `audience` → bỏ `groups[0]`; upsert tạo lớp mới code deterministic `SHARED_DOC_OT_{ot}[_{audience}]` + set `applicable_audience` + validate + assert code≤50.

## 🔴 Fix bug pre-existing (upsert stale response)
`get_by_id_with_items` refetch sau bulk DELETE+add trả collection CŨ từ identity map → response item stale. Fix `populate_existing=True` (DB truth). Ảnh hưởng 5 caller — tất cả read/post-mutation → chỉ fresh hơn, an toàn.

## Thêm
- **Layers**: `GET /document-groups/shared/{ot}/layers` (panel enumerate lớp). `GET`/`PUT /shared/{ot}` thêm `?audience=` (path KHÔNG đổi → deps/auth N2 giữ, không Casbin).
- **Preview** (§5b/G5): `POST /shared/{ot}/preview` nhận raw cultural/vocational → BE `compute_preview_audience_set` derive → resolve (tái dùng `filter_shared_by_audience` + `mandatory_wins_merge` + `_build_resolved_response` ĐỢT A) + loại bằng TN khi `completed_*` (§6). **Thin-client** (FE KHÔNG tự tính audience).
- schema `SharedDocumentGroupResponse` +`applicable_audience`; `SharedDocumentPreviewRequest` (cultural pattern-constrained).

## Test
- **10 integration** (`test_document_audience_config_panel.py`): get-by-audience None/POST_THCS, list ordered (NỀN first), upsert target đúng lớp + tạo lớp mới + validate, preview THCS/THPT/completed-removal/NỀN-only. Thêm Tier 5.
- **Regression batch 111 pass** (reresolve ĐỢT A + config + admin_config), **0 regression**. 2 fail = **PRE-EXISTING test-debt** (`test_update_document_type_cascade` staleness + `test_admin_skill_rules_crud_flow` message punctuation) — verify trên clean main (stash), KHÔNG gated CI.
- Runtime smoke dev DB (ĐỢT B data): get/list/preview tất cả đúng (graduated_thcs→bộ THCS không THPT; completed_thpt→loại bằng TN).

## Defer
FE SharedDocumentConfigPanel (Select đối tượng + CRUD lớp + dialog Xem trước) = PR FE sau (consume API này). Public §9 storefront = surface riêng.

Plan: §10.8/§10.10/§10.13/§5b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)