### PR TITLE
feat(admissions): §9 public storefront audience layers (khép kín plan)

### DIFF
--- a/Backend_FastAPI/app/schemas/public_admissions.py
+++ b/Backend_FastAPI/app/schemas/public_admissions.py
@@ -179,6 +179,20 @@ class PublicAdmissionsMethodDocumentChecklist(BaseModel):
     documents: List[PublicAdmissionsDocumentRequirement] = Field(default_factory=list)
 
 
+class PublicAdmissionsAudienceDocumentLayer(BaseModel):
+    """§9 (feat/document-group-audience-merge): lớp giấy tờ theo đối tượng/trình
+    độ (``DocumentGroup.applicable_audience``) trong tier shared.
+
+    Sau ĐỢT B, group shared tách thành NỀN + lớp audience. Trang công khai
+    hiển thị TÁCH: ``shared_documents`` = NỀN (mọi TS), ``audience_layers`` =
+    từng lớp để TS thấy đúng bộ theo trình độ (vd Tốt nghiệp THCS → bộ THCS),
+    KHÔNG union tất cả (tránh liệt kê dư cả THPT lẫn THCS).
+    """
+    audience: PublicAdmissionsAudience
+    audience_label: str
+    documents: List[PublicAdmissionsDocumentRequirement] = Field(default_factory=list)
+
+
 class PublicAdmissionsOfferingTypeDocumentChecklist(BaseModel):
     offering_type_id: int
     offering_type_code: str
@@ -188,6 +202,9 @@ class PublicAdmissionsOfferingTypeDocumentChecklist(BaseModel):
     public_method_count: int = Field(default=0, ge=0)
     sample_programs: List[str] = Field(default_factory=list)
     shared_documents: List[PublicAdmissionsDocumentRequirement] = Field(default_factory=list)
+    # §9: lớp NỀN = shared_documents (backward-compat FE cũ); audience_layers =
+    # các lớp theo đối tượng (POST_THPT/POST_THCS/...).
+    audience_layers: List[PublicAdmissionsAudienceDocumentLayer] = Field(default_factory=list)
     method_documents: List[PublicAdmissionsMethodDocumentChecklist] = Field(default_factory=list)
 
 

--- a/Backend_FastAPI/app/services/public_admissions_service.py
+++ b/Backend_FastAPI/app/services/public_admissions_service.py
@@ -840,8 +840,10 @@ async def get_public_documents_catalog(
         # NULL) + lớp audience. TÁCH hiển thị thay vì union (tránh trang công
         # khai liệt kê dư cả THPT lẫn THCS cho 1 chương trình).
         all_shared_groups = shared_groups_by_offering_type.get(offering_type_id, [])
-        # getattr default None (consistent mandatory_wins_merge ĐỢT A): group
-        # thiếu attr/applicable_audience NULL = lớp NỀN.
+        # getattr default None (consistent mandatory_wins_merge ĐỢT A): NULL —
+        # và cả ``[]`` rỗng (falsy) — = lớp NỀN (áp mọi TS). Migration §8.2 chỉ
+        # sinh lớp audience non-rỗng ([POST_THPT],...) nên [] không xảy ra thực
+        # tế; fold vào NỀN là default an toàn, khớp filter_shared_by_audience.
         nen_groups = [
             g for g in all_shared_groups
             if not getattr(g, "applicable_audience", None)

--- a/Backend_FastAPI/app/services/public_admissions_service.py
+++ b/Backend_FastAPI/app/services/public_admissions_service.py
@@ -29,6 +29,7 @@ from app.schemas.public_admissions import (
     PublicAdmissionsMethodUsage,
     PublicAdmissionsOfferingSummary,
     PublicAdmissionsOfferingTypeDocumentChecklist,
+    PublicAdmissionsAudienceDocumentLayer,
     PublicAdmissionsProgramsMeta,
     PublicAdmissionsProgramsResponse,
     PublicAdmissionsProgramSummary,
@@ -38,6 +39,7 @@ from app.schemas.public_admissions import (
     PublicAdmissionsTuitionOffering,
     PublicAdmissionsTuitionResponse,
 )
+from app.services.document_resolution_service import AUDIENCE_LABELS
 from app.utils.datetime_helpers import today_vn
 
 
@@ -833,16 +835,49 @@ async def get_public_documents_catalog(
         if offering_type_model is None or not offering_type_model.is_active:
             continue
 
-        # Tier 3 — offering-type-wide shared bucket. Mandatory-wins
-        # merge across DocumentGroup rows so multiple shared groups
-        # for the same offering_type collapse correctly.
+        # Tier 3 — offering-type-wide shared bucket. §9 (feat/document-group-
+        # audience-merge): sau ĐỢT B, group shared tách NỀN (applicable_audience
+        # NULL) + lớp audience. TÁCH hiển thị thay vì union (tránh trang công
+        # khai liệt kê dư cả THPT lẫn THCS cho 1 chương trình).
+        all_shared_groups = shared_groups_by_offering_type.get(offering_type_id, [])
+        # getattr default None (consistent mandatory_wins_merge ĐỢT A): group
+        # thiếu attr/applicable_audience NULL = lớp NỀN.
+        nen_groups = [
+            g for g in all_shared_groups
+            if not getattr(g, "applicable_audience", None)
+        ]
+        audience_groups = [
+            g for g in all_shared_groups
+            if getattr(g, "applicable_audience", None)
+        ]
+
+        # shared_documents = lớp NỀN (luôn gộp cho mọi TS) — backward-compat FE cũ.
         shared_items: Dict[int, "models.DocumentGroupItem"] = {}
-        _merge_items_with_mandatory_wins(
-            shared_items, shared_groups_by_offering_type.get(offering_type_id, [])
-        )
+        _merge_items_with_mandatory_wins(shared_items, nen_groups)
         shared_documents = _items_to_public_documents(
             shared_items.values(), source="shared"
         )
+
+        # audience_layers = 1 layer / audience (merge mandatory-wins trong lớp).
+        layers_by_audience: Dict[str, List[models.DocumentGroup]] = defaultdict(list)
+        for group in audience_groups:
+            for aud in (getattr(group, "applicable_audience", None) or []):
+                layers_by_audience[aud].append(group)
+        audience_layers: List[PublicAdmissionsAudienceDocumentLayer] = []
+        for aud in sorted(layers_by_audience):
+            layer_items: Dict[int, "models.DocumentGroupItem"] = {}
+            _merge_items_with_mandatory_wins(layer_items, layers_by_audience[aud])
+            layer_docs = _items_to_public_documents(
+                layer_items.values(), source="shared"
+            )
+            if layer_docs:
+                audience_layers.append(
+                    PublicAdmissionsAudienceDocumentLayer(
+                        audience=aud,
+                        audience_label=AUDIENCE_LABELS.get(aud, aud),
+                        documents=layer_docs,
+                    )
+                )
 
         method_documents: List[PublicAdmissionsMethodDocumentChecklist] = []
         for method_id in sorted(offering_type_method_ids.get(offering_type_id, set())):
@@ -866,7 +901,9 @@ async def get_public_documents_catalog(
             for path in scope_paths:
                 path_groups = path_groups_by_path.get(path.id, [])
                 method_groups = method_groups_by_scope.get(scope_key, [])
-                shared_groups = shared_groups_by_offering_type.get(offering_type_id, [])
+                # §9: tier shared fallback chỉ lấy NỀN (lớp audience hiển thị
+                # riêng ở audience_layers, KHÔNG union vào method docs).
+                shared_groups = nen_groups
 
                 if path_groups:
                     tier_groups, tier_source = path_groups, "path_override"
@@ -910,12 +947,16 @@ async def get_public_documents_catalog(
                 )
             )
 
-        if not shared_documents and not method_documents:
+        if not shared_documents and not audience_layers and not method_documents:
             continue
 
         resolved_document_type_ids.update(
             item.document_type_id for item in shared_documents
         )
+        for layer in audience_layers:
+            resolved_document_type_ids.update(
+                doc.document_type_id for doc in layer.documents
+            )
         sample_programs = sorted(offering_type_programs.get(offering_type_id, set()))[:4]
         offering_type_checklists.append(
             PublicAdmissionsOfferingTypeDocumentChecklist(
@@ -931,6 +972,7 @@ async def get_public_documents_catalog(
                 public_method_count=len({item.method_id for item in method_documents}),
                 sample_programs=sample_programs,
                 shared_documents=shared_documents,
+                audience_layers=audience_layers,
                 method_documents=sorted(
                     method_documents,
                     key=lambda item: (item.method_name.lower(), item.method_id),

--- a/Backend_FastAPI/tests/unit/test_public_admissions_phase1_wave6.py
+++ b/Backend_FastAPI/tests/unit/test_public_admissions_phase1_wave6.py
@@ -647,6 +647,68 @@ class TestDocumentsCatalogTierAggregation:
         assert len(ot.audience_layers) == 1
         assert ot.audience_layers[0].audience == "POST_THCS"
 
+    @pytest.mark.asyncio
+    async def test_multi_audience_group_appears_in_both_layers(self, monkeypatch):
+        """Group applicable_audience nhiều giá trị → xuất hiện ở MỌI layer khớp
+        (review nit: loop trên array audience)."""
+        path = _admission_path()
+        ot_model = SimpleNamespace(id=5, code="OT", name="Chính quy", is_active=True)
+        result = await self._run(
+            monkeypatch,
+            paths=[path],
+            path_groups_by_path={},
+            method_groups_by_scope={},
+            shared_groups_by_offering_type={
+                5: [
+                    _doc_group(
+                        _doc_item("SHARED_BOTH"),
+                        admission_method_id=None,
+                        applicable_audience=["POST_THPT", "POST_THCS"],
+                    )
+                ]
+            },
+            offering_type_models={5: ot_model},
+            method_models={10: path.admission_method},
+        )
+        ot = result.offering_types[0]
+        layers = {
+            l.audience: {d.document_type_code for d in l.documents}
+            for l in ot.audience_layers
+        }
+        assert layers == {"POST_THPT": {"SHARED_BOTH"}, "POST_THCS": {"SHARED_BOTH"}}
+
+    @pytest.mark.asyncio
+    async def test_layer_merge_mandatory_wins(self, monkeypatch):
+        """2 group cùng audience trùng doc-type (1 optional, 1 mandatory) → layer
+        chọn mandatory (mandatory-wins TRONG lớp — review nit)."""
+        path = _admission_path()
+        ot_model = SimpleNamespace(id=5, code="OT", name="Chính quy", is_active=True)
+        result = await self._run(
+            monkeypatch,
+            paths=[path],
+            path_groups_by_path={},
+            method_groups_by_scope={},
+            shared_groups_by_offering_type={
+                5: [
+                    _doc_group(
+                        _doc_item("HB", is_mandatory=False),
+                        admission_method_id=None,
+                        applicable_audience=["POST_THPT"],
+                    ),
+                    _doc_group(
+                        _doc_item("HB", is_mandatory=True),
+                        admission_method_id=None,
+                        applicable_audience=["POST_THPT"],
+                    ),
+                ]
+            },
+            offering_type_models={5: ot_model},
+            method_models={10: path.admission_method},
+        )
+        layer = result.offering_types[0].audience_layers[0]
+        docs = {d.document_type_code: d.is_mandatory for d in layer.documents}
+        assert docs == {"HB": True}  # mandatory wins
+
 
 # =============================================================================
 # Audience enum surface

--- a/Backend_FastAPI/tests/unit/test_public_admissions_phase1_wave6.py
+++ b/Backend_FastAPI/tests/unit/test_public_admissions_phase1_wave6.py
@@ -66,12 +66,19 @@ def _doc_item(
     )
 
 
-def _doc_group(*items, offering_type_id=5, admission_method_id=10, admission_path_id=None):
+def _doc_group(
+    *items,
+    offering_type_id=5,
+    admission_method_id=10,
+    admission_path_id=None,
+    applicable_audience=None,
+):
     return SimpleNamespace(
         items=list(items),
         offering_type_id=offering_type_id,
         admission_method_id=admission_method_id,
         admission_path_id=admission_path_id,
+        applicable_audience=applicable_audience,
         offering_type=SimpleNamespace(
             id=offering_type_id,
             code="OT",
@@ -540,6 +547,105 @@ class TestDocumentsCatalogTierAggregation:
         ot = result.offering_types[0]
         assert {d.document_type_code for d in ot.shared_documents} == {"ANH3X4"}
         assert all(d.source == "shared" for d in ot.shared_documents)
+
+    # -------------------------------------------------------------------------
+    # §9 (feat/document-group-audience-merge): tách NỀN vs audience_layers
+    # -------------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_shared_splits_nen_vs_audience_layers(self, monkeypatch):
+        """Sau ĐỢT B: shared groups = NỀN + lớp audience. Catalog public TÁCH:
+        shared_documents=NỀN; audience_layers=từng lớp (KHÔNG union dư)."""
+        path = _admission_path()
+        ot_model = SimpleNamespace(id=5, code="OT", name="Chính quy", is_active=True)
+        result = await self._run(
+            monkeypatch,
+            paths=[path],
+            path_groups_by_path={},
+            method_groups_by_scope={},
+            shared_groups_by_offering_type={
+                5: [
+                    _doc_group(_doc_item("CCCD"), admission_method_id=None),
+                    _doc_group(
+                        _doc_item("HB_THPT"),
+                        admission_method_id=None,
+                        applicable_audience=["POST_THPT"],
+                    ),
+                    _doc_group(
+                        _doc_item("HB_THCS"),
+                        admission_method_id=None,
+                        applicable_audience=["POST_THCS"],
+                    ),
+                ]
+            },
+            offering_type_models={5: ot_model},
+            method_models={10: path.admission_method},
+        )
+        ot = result.offering_types[0]
+        # NỀN: chỉ base, KHÔNG academic.
+        assert {d.document_type_code for d in ot.shared_documents} == {"CCCD"}
+        # audience_layers: 2 lớp, mỗi lớp đúng giấy của nó.
+        layers = {l.audience: {d.document_type_code for d in l.documents} for l in ot.audience_layers}
+        assert layers == {"POST_THPT": {"HB_THPT"}, "POST_THCS": {"HB_THCS"}}
+        assert all(l.audience_label for l in ot.audience_layers)  # có nhãn
+
+    @pytest.mark.asyncio
+    async def test_method_fallback_uses_nen_not_audience_union(self, monkeypatch):
+        """Method fallback tier shared chỉ lấy NỀN — KHÔNG union lớp audience
+        (academic hiển thị riêng ở audience_layers)."""
+        path = _admission_path()
+        ot_model = SimpleNamespace(id=5, code="OT", name="Chính quy", is_active=True)
+        result = await self._run(
+            monkeypatch,
+            paths=[path],
+            path_groups_by_path={},
+            method_groups_by_scope={},
+            shared_groups_by_offering_type={
+                5: [
+                    _doc_group(_doc_item("CCCD"), admission_method_id=None),
+                    _doc_group(
+                        _doc_item("HB_THPT"),
+                        admission_method_id=None,
+                        applicable_audience=["POST_THPT"],
+                    ),
+                ]
+            },
+            offering_type_models={5: ot_model},
+            method_models={10: path.admission_method},
+        )
+        ot = result.offering_types[0]
+        method_doc = ot.method_documents[0]
+        # method shared-fallback = NỀN only (KHÔNG có HB_THPT).
+        assert {d.document_type_code for d in method_doc.documents} == {"CCCD"}
+
+    @pytest.mark.asyncio
+    async def test_offering_type_with_only_audience_layers_included(self, monkeypatch):
+        """Offering type chỉ có lớp audience (không NỀN) VẪN xuất hiện (skip
+        condition tính cả audience_layers)."""
+        path = _admission_path()
+        ot_model = SimpleNamespace(id=5, code="OT", name="Chính quy", is_active=True)
+        result = await self._run(
+            monkeypatch,
+            paths=[path],
+            path_groups_by_path={},
+            method_groups_by_scope={},
+            shared_groups_by_offering_type={
+                5: [
+                    _doc_group(
+                        _doc_item("HB_THCS"),
+                        admission_method_id=None,
+                        applicable_audience=["POST_THCS"],
+                    )
+                ]
+            },
+            offering_type_models={5: ot_model},
+            method_models={10: path.admission_method},
+        )
+        assert len(result.offering_types) == 1
+        ot = result.offering_types[0]
+        assert ot.shared_documents == []
+        assert len(ot.audience_layers) == 1
+        assert ot.audience_layers[0].audience == "POST_THCS"
 
 
 # =============================================================================

--- a/frontend/src/components/public/PublicDocumentsPage.tsx
+++ b/frontend/src/components/public/PublicDocumentsPage.tsx
@@ -105,8 +105,9 @@ export default function PublicDocumentsPage({ catalog }: PublicDocumentsPageProp
         offeringTypes.flatMap((item) => [
           ...item.shared_documents,
           // §9: gộp cả lớp audience để section "chuẩn bị theo nhóm việc" không
-          // bỏ sót giấy academic (đã tách khỏi shared_documents).
-          ...item.audience_layers.flatMap((layer) => layer.documents),
+          // bỏ sót giấy academic (đã tách khỏi shared_documents). ?? [] phòng
+          // payload stale/partial.
+          ...(item.audience_layers ?? []).flatMap((layer) => layer.documents),
           ...item.method_documents.flatMap((method) => method.documents),
         ]),
       )
@@ -225,7 +226,7 @@ export default function PublicDocumentsPage({ catalog }: PublicDocumentsPageProp
 
                       {/* §9: lớp giấy tờ theo đối tượng/trình độ (Tốt nghiệp
                           THCS / THPT) — tách rõ để TS thấy đúng bộ mình cần. */}
-                      {checklist.audience_layers.map((layer) => (
+                      {(checklist.audience_layers ?? []).map((layer) => (
                         <div key={layer.audience} className="space-y-3 pt-2">
                           <div className="flex flex-wrap items-center gap-2">
                             <span className="rounded-full bg-info-50 px-3 py-1 text-xs font-semibold text-info-700">

--- a/frontend/src/components/public/PublicDocumentsPage.tsx
+++ b/frontend/src/components/public/PublicDocumentsPage.tsx
@@ -104,6 +104,9 @@ export default function PublicDocumentsPage({ catalog }: PublicDocumentsPageProp
     ? dedupeDocuments(
         offeringTypes.flatMap((item) => [
           ...item.shared_documents,
+          // §9: gộp cả lớp audience để section "chuẩn bị theo nhóm việc" không
+          // bỏ sót giấy academic (đã tách khỏi shared_documents).
+          ...item.audience_layers.flatMap((layer) => layer.documents),
           ...item.method_documents.flatMap((method) => method.documents),
         ]),
       )
@@ -219,6 +222,22 @@ export default function PublicDocumentsPage({ catalog }: PublicDocumentsPageProp
                           Hệ đào tạo này hiện chưa có checklist mặc định public.
                         </div>
                       )}
+
+                      {/* §9: lớp giấy tờ theo đối tượng/trình độ (Tốt nghiệp
+                          THCS / THPT) — tách rõ để TS thấy đúng bộ mình cần. */}
+                      {checklist.audience_layers.map((layer) => (
+                        <div key={layer.audience} className="space-y-3 pt-2">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="rounded-full bg-info-50 px-3 py-1 text-xs font-semibold text-info-700">
+                              {layer.audience_label}
+                            </span>
+                            <span className="text-xs text-muted-foreground">
+                              Bổ sung cho thí sinh thuộc đối tượng này
+                            </span>
+                          </div>
+                          <DocumentRequirementList documents={layer.documents} />
+                        </div>
+                      ))}
                     </div>
 
                     <div className="space-y-4">

--- a/frontend/src/types/public-admissions.types.ts
+++ b/frontend/src/types/public-admissions.types.ts
@@ -130,6 +130,13 @@ export interface PublicAdmissionsMethodDocumentChecklist {
   documents: PublicAdmissionsDocumentRequirement[]
 }
 
+// §9 (feat/document-group-audience-merge): lớp giấy tờ theo đối tượng/trình độ.
+export interface PublicAdmissionsAudienceDocumentLayer {
+  audience: string
+  audience_label: string
+  documents: PublicAdmissionsDocumentRequirement[]
+}
+
 export interface PublicAdmissionsOfferingTypeDocumentChecklist {
   offering_type_id: number
   offering_type_code: string
@@ -139,6 +146,8 @@ export interface PublicAdmissionsOfferingTypeDocumentChecklist {
   public_method_count: number
   sample_programs: string[]
   shared_documents: PublicAdmissionsDocumentRequirement[]
+  // §9: NỀN = shared_documents; audience_layers = lớp theo đối tượng.
+  audience_layers: PublicAdmissionsAudienceDocumentLayer[]
   method_documents: PublicAdmissionsMethodDocumentChecklist[]
 }
 


### PR DESCRIPTION
## Mục tiêu
**Phần cuối cùng** của plan document-group-audience-merge. Fix gap **đang LIVE trên prod** (do ĐỢT B): trang công khai `/tuyen-sinh/ho-so` union TẤT CẢ shared group → liệt kê **dư** cả giấy THPT lẫn THCS cho 1 chương trình (CĐ chính quy hiện cả "Học bạ THCS", TC chính quy hiện cả giấy THPT) → gây nhầm cho thí sinh.

## §9 — tách thay vì union (plan §9/§10.9/§10.12)
**BE:**
- Schema `PublicAdmissionsAudienceDocumentLayer {audience, audience_label, documents}` + field `audience_layers` trên `OfferingTypeDocumentChecklist`.
- `get_public_documents_catalog`: tách shared groups → **NỀN** (`applicable_audience` NULL; `getattr` default → robust với mock) vs **lớp audience**. `shared_documents`=NỀN (backward-compat FE cũ); `audience_layers`=từng lớp (merge mandatory-wins); **method-fallback tier shared dùng NỀN** (không union); skip-condition + summary doc-count tính cả audience_layers. Nhãn từ `AUDIENCE_LABELS` (1 nguồn).

**FE:** types + `PublicDocumentsPage` render `audience_layers` dưới "Hồ sơ mặc định theo hệ" + gộp vào `allLiveDocuments` (Preparation Tips không sót academic).

## Finding #4 reassess (public merge unify)
**KHÔNG** rewrite `_merge_items_with_mandatory_wins` (public) sang `mandatory_wins_merge` (module). Lý do: doc_map shape khác (public `{id:item}` + bucket-source; module `{id:(item,source,audience)}`); rewrite data-flow của fail-closed catalog **rủi ro > lợi**. Public merge là mirror documented **tương đương** (mandatory-wins + exclude_inactive=True) — giữ, đã verify. (Tech-debt low-value, defer.)

## Verify
- **3 anchor §9** (`test_public_admissions_phase1_wave6`): split NỀN/audience, method-fallback NỀN-only, offering-type chỉ-audience-layer vẫn included.
- **Full Tier 5: 108 passed / 3 skip, 0 regression.**
- FE type-check + eslint clean.
- **Chrome smoke** `/tuyen-sinh/ho-so`: "Hồ sơ mặc định" = base only; "Tốt nghiệp THCS" = Học bạ+Bằng TN THCS; "Tốt nghiệp THPT" = THPT; method [DÙNG BỘ MẶC ĐỊNH] = base only; Preparation Tips gộp đủ; 0 console error.

## Kết quả
Plan document-group-audience-merge **đóng hoàn toàn** (ĐỢT A + ĐỢT B + FE badge + config panel + §9 public).

🤖 Generated with [Claude Code](https://claude.com/claude-code)