### PR TITLE
chore(test): dọn 2 pre-existing test-debt (cascade-removed + msg period)

### DIFF
--- a/Backend_FastAPI/tests/api/test_admin_config.py
+++ b/Backend_FastAPI/tests/api/test_admin_config.py
@@ -350,7 +350,8 @@ async def test_admin_skill_rules_crud_flow(
     ), f"DELETE Not Found Resp: {response_delete_404.text}"
     error_data_delete = response_delete_404.json()
     assert "detail" in error_data_delete
-    assert error_data_delete["detail"] == f"Skill rule with id {rule_id} not found."
+    # config_service:324 raise "...not found" (KHÔNG period — convention file).
+    assert error_data_delete["detail"] == f"Skill rule with id {rule_id} not found"
     log.info("DELETE (not found) successful (404) with correct detail message.")
 
     # --- 6. GET (Empty List Again) ---

--- a/Backend_FastAPI/tests/services/test_config.py
+++ b/Backend_FastAPI/tests/services/test_config.py
@@ -1853,30 +1853,28 @@ async def test_get_assignment_config_not_found_security(mock_config_repo_class, 
 
 @pytest.mark.asyncio
 @patch("app.services.config_service.DocumentTypeRepository")
-async def test_update_document_type_cascade(mock_repo_class, mock_db_session):
-    """Test forensic polish: Ensure document type code update cascades to ProgramOffering."""
+async def test_update_document_type_no_offering_cascade(mock_repo_class, mock_db_session):
+    """``update_document_type`` đổi code KHÔNG cascade ``ProgramOffering.
+    admission_rules`` — cascade cũ ĐÃ BỎ chủ đích (config_service:871; documents
+    giờ qua relational DocumentGroup). Guard giữ removal: nếu ai đó tái thêm
+    cascade (fetch offerings để rewrite mandatory_docs) → test này đỏ.
+    """
     mock_repo = AsyncMock()
     doc_model = models.ConfigDocumentType(id=1, code="old_doc", name="Old Doc")
     mock_repo.get_by_id.return_value = doc_model
     mock_repo.check_name_exists.return_value = False
     mock_repo.check_code_exists.return_value = False
-    
-    # Mock dependent offerings
-    mock_offering = MagicMock()
-    mock_offering.admission_rules = {
-        "mandatory_docs": ["old_doc", "other_doc"]
-    }
-    mock_repo.get_all_offerings_with_admission_rules.return_value = [mock_offering]
-    
+
     update_schema = schemas.ConfigDocumentTypeUpdate(code="new_doc")
-    
-    # Repo update returns the updated model
     updated_doc_model = models.ConfigDocumentType(id=1, code="new_doc", name="Old Doc")
     mock_repo.update.return_value = updated_doc_model
     mock_repo_class.return_value = mock_repo
-    
-    await config_service.update_document_type(mock_db_session, 1, update_schema)
-    
-    # Verify cascade update
-    assert mock_offering.admission_rules["mandatory_docs"] == ["new_doc", "other_doc"]
-    mock_repo.get_all_offerings_with_admission_rules.assert_awaited_once()
+
+    result, _callback = await config_service.update_document_type(
+        mock_db_session, 1, update_schema
+    )
+
+    # Doc type code được cập nhật.
+    assert result.code == "new_doc"
+    # KHÔNG fetch offerings để cascade (cascade đã bỏ).
+    mock_repo.get_all_offerings_with_admission_rules.assert_not_awaited()


### PR DESCRIPTION
## Mục tiêu
Dọn 2 test fail **pre-existing** trong nightly full suite (KHÔNG gated Tier 5 nên không block PR khác, nhưng làm bẩn nightly). Phát hiện khi làm feature document-group-audience. **Cả 2 = assert outdated, KHÔNG phải code bug.**

## #1 — `test_update_document_type_cascade` (test_config.py)
Test cũ assert `update_document_type` cascade rename code → `ProgramOffering.admission_rules.mandatory_docs`. Nhưng cascade này **ĐÃ BỎ chủ đích** (`config_service.py:871`: *"Old cascade logic for ProgramOffering.admission_rules removed. Documents are now managed via relational DocumentGroup tables."*) → test đỏ.
→ **Rewrite** thành `test_update_document_type_no_offering_cascade`: guard **non-tautological** assert code KHÔNG fetch offerings để cascade (`get_all_offerings_with_admission_rules.assert_not_awaited()`) + doc type code vẫn đổi. Nếu ai đó tái thêm cascade → test đỏ (đúng ý đồ).

## #2 — `test_admin_skill_rules_crud_flow` (test_admin_config.py)
Assert message DELETE-404 = `"Skill rule with id {id} not found."` (có period). Code (`config_service.py:324`) raise `"...not found"` **KHÔNG period** — đúng convention file (vd `"Document type with ID ... not found"`). → Bỏ period trong assert (theo code, không đổi message để giữ nhất quán file).

## Verify
- 2 test target pass.
- Full `test_config.py` + `test_admin_config.py`: **97 passed, 0 fail**.

Test-only, không đổi source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)