### PR TITLE
feat(admissions-fe): add advanced governance tab to quota matrix

### DIFF
--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AdvancedTab.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/AdvancedTab.tsx
@@ -1,0 +1,413 @@
+/**
+ * AdvancedTab — thẻ "Nâng cao" của PathDetailDrawer. Gom 4 trường governance
+ * chỉ-admin của AdmissionPath:
+ *   - ``applicable_to``                     (bộ lọc audience storefront)
+ *   - ``method_quota``                      (trần theo phương thức — cấu hình/
+ *                                            snapshot, CHƯA enforcement runtime)
+ *   - ``bonus_rule_override``               (override cộng điểm theo path)
+ *   - ``minor_correction_allowed_fields``   (allowlist hiệu chỉnh sau duyệt)
+ *
+ * Port từ wizard cũ ``PathBasicInfo`` để drawer ma trận là UI duy nhất cho 4
+ * trường này. Cả thẻ chỉ render cho admin (do ``PathDetailDrawer`` gate bằng
+ * ``user.role === "admin"``; máy chủ cũng chặn non-admin qua
+ * ``BusinessRuleViolation``), nên các trường ở đây KHÔNG gate lại bằng
+ * ``can_edit`` — đúng như wizard cũ chỉ gate governance bằng role admin.
+ */
+"use client"
+
+import { Loader2, Save } from "lucide-react"
+import { useMemo, useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { useUpdateAdmissionPath } from "@/hooks/admissions/useAdmissionPaths"
+import {
+  AUDIENCE_LABELS_VI,
+  AUDIENCE_OPTIONS,
+} from "@/lib/constants/admission-audience"
+import {
+  FIELD_GROUPS_VI,
+  FIELD_LABELS_VI,
+} from "@/lib/constants/minor-correction"
+import { parseApiError } from "@/lib/utils/api-errors"
+import {
+  buildApplicableToPayload,
+  buildBonusOverridePayload,
+  buildMethodQuotaPayload,
+} from "@/lib/utils/admission-path-payload"
+import type {
+  AdmissionAudience,
+  AdmissionPathResponse,
+} from "@/lib/zod/admission-path"
+
+export function AdvancedTab({
+  path,
+  pathId,
+  onClose,
+}: {
+  path: AdmissionPathResponse
+  pathId: number
+  onClose: () => void
+}) {
+  // Khởi tạo state governance từ path đã load.
+  const [applicableTo, setApplicableTo] = useState<Set<AdmissionAudience>>(
+    new Set(path.applicable_to ?? []),
+  )
+  const [methodQuotaInput, setMethodQuotaInput] = useState<string>(
+    path.method_quota != null ? String(path.method_quota) : "",
+  )
+  const [bonusOverrideEnabled, setBonusOverrideEnabled] = useState<boolean>(
+    path.bonus_rule_override != null,
+  )
+  const [applyAreaBonus, setApplyAreaBonus] = useState<boolean>(
+    path.bonus_rule_override?.apply_area_bonus ?? false,
+  )
+  const [applyObjectBonus, setApplyObjectBonus] = useState<boolean>(
+    path.bonus_rule_override?.apply_object_bonus ?? false,
+  )
+  const [maxTotalBonusInput, setMaxTotalBonusInput] = useState<string>(
+    path.bonus_rule_override?.max_total_bonus != null
+      ? String(path.bonus_rule_override.max_total_bonus)
+      : "",
+  )
+  const [allowedFields, setAllowedFields] = useState<Set<string>>(
+    new Set(path.minor_correction_allowed_fields ?? []),
+  )
+
+  const updateMutation = useUpdateAdmissionPath()
+
+  const allowedFieldsArray = useMemo(
+    () => Array.from(allowedFields).sort(),
+    [allowedFields],
+  )
+
+  function toggleAudience(audience: AdmissionAudience) {
+    setApplicableTo((prev) => {
+      const next = new Set(prev)
+      if (next.has(audience)) next.delete(audience)
+      else next.add(audience)
+      return next
+    })
+  }
+
+  function toggleField(field: string) {
+    setAllowedFields((prev) => {
+      const next = new Set(prev)
+      if (next.has(field)) next.delete(field)
+      else next.add(field)
+      return next
+    })
+  }
+
+  const [confirmActiveSave, setConfirmActiveSave] = useState(false)
+
+  /**
+   * Cảnh báo khi sửa field tác động scoring/storefront trên path ĐANG hoạt
+   * động: ``bonus_rule_override`` đổi điểm hồ sơ/NV CHƯA freeze (engine resolve
+   * tại publish/evaluate) và ``applicable_to`` đổi bộ lọc hiển thị công khai
+   * (plan §Business impact). ``method_quota`` (config/snapshot) +
+   * ``minor_correction_allowed_fields`` không nằm trong cảnh báo này.
+   */
+  const highImpactChangedOnActive = (): boolean => {
+    if (path.status !== "active") return false
+
+    const audienceNow = buildApplicableToPayload(applicableTo)
+    const audienceWas = path.applicable_to ?? null
+    const audienceDiff =
+      JSON.stringify(audienceNow ? [...audienceNow].sort() : null) !==
+      JSON.stringify(audienceWas ? [...audienceWas].sort() : null)
+
+    const bonusNow = buildBonusOverridePayload(
+      bonusOverrideEnabled,
+      applyAreaBonus,
+      applyObjectBonus,
+      maxTotalBonusInput,
+    )
+    const bonusWas = path.bonus_rule_override ?? null
+    let bonusDiff: boolean
+    if (bonusNow === null || bonusWas === null) {
+      bonusDiff = bonusNow !== bonusWas
+    } else {
+      bonusDiff =
+        bonusNow.apply_area_bonus !== bonusWas.apply_area_bonus ||
+        bonusNow.apply_object_bonus !== bonusWas.apply_object_bonus ||
+        (bonusNow.max_total_bonus ?? null) !== (bonusWas.max_total_bonus ?? null)
+    }
+
+    return audienceDiff || bonusDiff
+  }
+
+  const persist = async () => {
+    setConfirmActiveSave(false)
+    try {
+      await updateMutation.mutateAsync({
+        pathId,
+        data: {
+          minor_correction_allowed_fields: allowedFieldsArray,
+          applicable_to: buildApplicableToPayload(applicableTo),
+          method_quota: buildMethodQuotaPayload(methodQuotaInput),
+          bonus_rule_override: buildBonusOverridePayload(
+            bonusOverrideEnabled,
+            applyAreaBonus,
+            applyObjectBonus,
+            maxTotalBonusInput,
+          ),
+        },
+      })
+      toast.success("Đã lưu cấu hình nâng cao")
+      onClose()
+    } catch (e: unknown) {
+      toast.error(parseApiError(e, "Lỗi lưu — kiểm tra mạng và thử lại."))
+    }
+  }
+
+  const handleSave = () => {
+    if (highImpactChangedOnActive()) {
+      setConfirmActiveSave(true)
+      return
+    }
+    void persist()
+  }
+
+  const isSaving = updateMutation.isPending
+
+  return (
+    <div className="space-y-6">
+      {/* applicable_to — lọc audience storefront. Bỏ trống = áp dụng cho mọi
+          đối tượng (Phase 1+2 contract; empty Set → null trên wire). */}
+      <div className="space-y-3 rounded-md border p-3">
+        <div className="space-y-1">
+          <Label className="text-sm font-medium">Đối tượng áp dụng</Label>
+          <p className="text-xs text-muted-foreground max-w-lg">
+            Chọn nhóm thí sinh có thể đăng ký phương thức này. Bỏ trống tất cả =
+            áp dụng cho mọi đối tượng (mặc định mùa cũ).
+          </p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {AUDIENCE_OPTIONS.map((audience) => (
+            <label
+              key={audience}
+              className="flex items-start gap-2 text-sm cursor-pointer"
+            >
+              <Checkbox
+                id={`adv-audience-${audience}`}
+                checked={applicableTo.has(audience)}
+                onCheckedChange={() => toggleAudience(audience)}
+                aria-label={AUDIENCE_LABELS_VI[audience]}
+              />
+              <span className="leading-tight">
+                {AUDIENCE_LABELS_VI[audience]}
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* method_quota — trần theo phương thức. Bỏ trống = không giới hạn ở tầng
+          phương thức (kế thừa round.admit_quota / group_quota). Cấu hình thuần
+          ở thời điểm hiện tại — chưa enforcement runtime. */}
+      <div className="space-y-2 rounded-md border p-3">
+        <div className="space-y-1">
+          <Label htmlFor="adv-method-quota" className="text-sm font-medium">
+            Chỉ tiêu phương thức
+          </Label>
+          <p className="text-xs text-muted-foreground max-w-lg">
+            Số lượng tối đa thí sinh tuyển qua phương thức này. Để trống = không
+            giới hạn ở tầng phương thức (kế thừa chỉ tiêu đợt tuyển sinh).
+          </p>
+        </div>
+        <Input
+          id="adv-method-quota"
+          type="number"
+          inputMode="numeric"
+          value={methodQuotaInput}
+          onChange={(e) => setMethodQuotaInput(e.target.value)}
+          min={0}
+          placeholder="Để trống nếu không giới hạn"
+          autoComplete="off"
+        />
+      </div>
+
+      {/* bonus_rule_override — typed (KHÔNG raw JSON). Tắt → null = kế thừa
+          mặc định phương thức. Sửa trên path active đổi điểm hồ sơ/NV chưa
+          freeze. */}
+      <div className="space-y-3 rounded-md border p-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <Label className="text-sm font-medium">
+              Quy tắc cộng điểm tùy chỉnh
+            </Label>
+            <p className="text-xs text-muted-foreground max-w-lg">
+              Tắt = dùng quy tắc cộng điểm mặc định của phương thức. Bật để
+              override cộng điểm khu vực / đối tượng và đặt trần tổng (0..10) —
+              bỏ trống trần = không giới hạn.
+            </p>
+          </div>
+          <Switch
+            id="adv-bonus-enabled"
+            checked={bonusOverrideEnabled}
+            onCheckedChange={setBonusOverrideEnabled}
+            aria-label="Bật quy tắc cộng điểm tùy chỉnh"
+          />
+        </div>
+        {bonusOverrideEnabled && (
+          <div className="space-y-3 pl-3 border-l-2">
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="adv-apply-area-bonus"
+                checked={applyAreaBonus}
+                onCheckedChange={(v) => setApplyAreaBonus(v === true)}
+                aria-label="Cộng điểm khu vực"
+              />
+              <Label
+                htmlFor="adv-apply-area-bonus"
+                className="text-sm cursor-pointer"
+              >
+                Cộng điểm khu vực (KV1 / KV2-NT / KV2 / KV3)
+              </Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="adv-apply-object-bonus"
+                checked={applyObjectBonus}
+                onCheckedChange={(v) => setApplyObjectBonus(v === true)}
+                aria-label="Cộng điểm đối tượng ưu tiên"
+              />
+              <Label
+                htmlFor="adv-apply-object-bonus"
+                className="text-sm cursor-pointer"
+              >
+                Cộng điểm đối tượng ưu tiên (mã 01..07)
+              </Label>
+            </div>
+            <div className="space-y-1">
+              <Label
+                htmlFor="adv-max-total-bonus"
+                className="text-sm font-medium"
+              >
+                Trần tổng cộng điểm (0..10)
+              </Label>
+              <Input
+                id="adv-max-total-bonus"
+                type="number"
+                inputMode="decimal"
+                value={maxTotalBonusInput}
+                onChange={(e) => setMaxTotalBonusInput(e.target.value)}
+                min={0}
+                max={10}
+                step={0.25}
+                placeholder="Để trống = không giới hạn"
+                autoComplete="off"
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* minor_correction_allowed_fields — allowlist hiệu chỉnh sau duyệt. */}
+      <div className="space-y-3 rounded-md border p-3">
+        <div className="space-y-1">
+          <Label className="text-sm font-medium">
+            Hiệu chỉnh sau duyệt — danh sách trường được phép
+          </Label>
+          <p className="text-xs text-muted-foreground max-w-lg">
+            Cho phép officer/manager hiệu chỉnh các trường không ảnh hưởng tiêu
+            chí xét tuyển trên hồ sơ đã duyệt. Chỉ trường được tick mới hiển thị
+            trong dialog hiệu chỉnh; mọi thay đổi đều bị log kèm lý do.
+          </p>
+        </div>
+        <div className="space-y-4">
+          {Object.entries(FIELD_GROUPS_VI).map(([groupName, fields]) => (
+            <div key={groupName} className="space-y-2">
+              <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                {groupName}
+              </h4>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {fields.map((field) => (
+                  <label
+                    key={field}
+                    className="flex items-start gap-2 text-sm cursor-pointer"
+                  >
+                    <Checkbox
+                      id={`adv-mc-${field}`}
+                      checked={allowedFields.has(field)}
+                      onCheckedChange={() => toggleField(field)}
+                      aria-label={FIELD_LABELS_VI[field] ?? field}
+                    />
+                    <span className="leading-tight">
+                      {FIELD_LABELS_VI[field] ?? field}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-2 border-t pt-3">
+        <Button variant="outline" onClick={onClose}>
+          Đóng
+        </Button>
+        <Button
+          onClick={handleSave}
+          disabled={isSaving}
+          aria-busy={isSaving}
+        >
+          {isSaving ? (
+            <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+          ) : (
+            <Save className="h-4 w-4 mr-1" aria-hidden="true" />
+          )}
+          Lưu nâng cao
+        </Button>
+      </div>
+
+      {/* Cảnh báo sửa field tác động cao trên path đang hoạt động — mẫu như
+          dialog Vô hiệu hoá ở LifecycleTab (custom Dialog, không JS confirm). */}
+      <Dialog open={confirmActiveSave} onOpenChange={setConfirmActiveSave}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              Lưu thay đổi trên phương thức đang hoạt động?
+            </DialogTitle>
+            <DialogDescription>
+              Phương thức này đang hoạt động. Đổi &quot;Đối tượng áp dụng&quot;
+              hoặc &quot;Quy tắc cộng điểm&quot; sẽ ảnh hưởng hồ sơ / nguyện vọng
+              CHƯA chốt điểm và bộ lọc hiển thị công khai. Hồ sơ đã chốt điểm
+              giữ nguyên.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setConfirmActiveSave(false)}
+            >
+              Huỷ
+            </Button>
+            <Button onClick={persist} disabled={isSaving} aria-busy={isSaving}>
+              {isSaving ? (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+              ) : (
+                <Save className="h-4 w-4 mr-1" aria-hidden="true" />
+              )}
+              Vẫn lưu
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
@@ -1,11 +1,13 @@
 /**
- * Vitest tests cho PathDetailDrawer 5-tab (Phase 2 v8.2 PR-2D.1 v4a).
+ * Vitest tests cho PathDetailDrawer (Phase 2 v8.2 PR-2D.1 v4a).
  *
  * Anchor:
- * - 5 tabs render
+ * - 5 tab luôn-hiện render (+ tab "Nâng cao" chỉ-admin)
  * - Quota tab client guard (admit ≤ round)
  * - Identity tab can_edit gate
  * - Lifecycle tab can_activate gate (thin-client)
+ * - Tab "Nâng cao": admin thấy / non-admin ẩn / non-admin ?tab=advanced
+ *   fallback quota / payload MUTATE đúng 4 trường governance
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { render, screen, waitFor } from "@testing-library/react"
@@ -43,9 +45,17 @@ const hoisted = vi.hoisted(() => {
     criteria: { id: 200, code: "HB2026_CNTT" },
     admission_method: { id: 1, code: "hoc_ba" },
     admission_method_id: 1,
+    // phase1_03 governance fields — null/empty default (AdvancedTab reads these).
+    applicable_to: null as string[] | null,
+    method_quota: null as number | null,
+    bonus_rule_override: null as Record<string, unknown> | null,
+    minor_correction_allowed_fields: [] as string[],
   }
   return {
     defaultPath,
+    // Mutable role for the admin-gate tests (default non-admin so the base
+    // suite sees exactly the 5 always-on tabs).
+    authState: { role: "manager" as string },
     mockUseAdmissionPath: vi.fn(() => ({ data: defaultPath, isLoading: false })),
     mockUpdateQuota: vi.fn(),
     mockUpdatePath: vi.fn(),
@@ -65,6 +75,11 @@ vi.mock("@/hooks/admissions/useAdmissionPaths", () => ({
 vi.mock("@/hooks/admissions/useQuotaMatrix", () => ({
   quotaMatrixKeys: { all: ["quota-matrix"] },
   useUpdatePathQuota: () => ({ mutateAsync: hoisted.mockUpdateQuota, isPending: false }),
+}))
+
+// useAuth — controls user.role for the "Nâng cao" admin-gate tests.
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: 1, role: hoisted.authState.role } }),
 }))
 
 vi.mock("../ConfigCriteria", () => ({
@@ -98,6 +113,8 @@ beforeEach(() => {
   toastError.mockReset()
   toastSuccess.mockReset()
   tabReplaceMock.mockReset()
+  // Default non-admin; admin-gate tests opt in via hoisted.authState.role.
+  hoisted.authState.role = "manager"
   // Reset URL search params về default empty cho mỗi test; test có thể
   // override qua searchParamsMock.mockReturnValue(...) inside test body.
   searchParamsMock.mockImplementation(() => new URLSearchParams())
@@ -266,5 +283,228 @@ describe("PathDetailDrawer 5-tab", () => {
     // Default tab "quota" xóa ?tab= param khỏi URL — FM-2 contract line 99
     // `if (next === "quota") params.delete("tab")`.
     expect(url).not.toContain("tab=")
+  })
+})
+
+describe("PathDetailDrawer — thẻ Nâng cao (governance, chỉ-admin)", () => {
+  it("admin THẤY tab Nâng cao", () => {
+    hoisted.authState.role = "admin"
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+    expect(screen.getByRole("tab", { name: "Nâng cao" })).toBeTruthy()
+  })
+
+  it("non-admin KHÔNG thấy tab Nâng cao (5 tab luôn-hiện vẫn render)", () => {
+    hoisted.authState.role = "manager"
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+    expect(screen.getByRole("tab", { name: /Chỉ tiêu/ })).toBeTruthy()
+    expect(screen.queryByRole("tab", { name: "Nâng cao" })).toBeNull()
+  })
+
+  it("non-admin dán ?tab=advanced → fallback quota (không render drawer rỗng)", async () => {
+    hoisted.authState.role = "manager"
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=advanced"))
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+    // Fallback về quota: nút "Lưu chỉ tiêu" hiện; KHÔNG có tab/nút Nâng cao.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Lưu chỉ tiêu/ })).toBeTruthy()
+    })
+    expect(screen.queryByRole("tab", { name: "Nâng cao" })).toBeNull()
+    expect(screen.queryByRole("button", { name: "Lưu nâng cao" })).toBeNull()
+  })
+
+  it("MUTATE: admin lưu → gửi đủ 4 trường governance với audience + method_quota đã sửa", async () => {
+    hoisted.authState.role = "admin"
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=advanced"))
+    const user = userEvent.setup()
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    // AdvancedTab active ngay khi render (admin + ?tab=advanced).
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Lưu nâng cao" })).toBeTruthy()
+    })
+
+    // Mutate 2 trường governance.
+    await user.click(screen.getByRole("checkbox", { name: /Sau THPT/ }))
+    await user.type(screen.getByLabelText("Chỉ tiêu phương thức"), "50")
+
+    await user.click(screen.getByRole("button", { name: "Lưu nâng cao" }))
+
+    expect(hoisted.mockUpdatePath).toHaveBeenCalledTimes(1)
+    expect(hoisted.mockUpdatePath).toHaveBeenCalledWith({
+      pathId: 109,
+      data: {
+        minor_correction_allowed_fields: [],
+        applicable_to: ["POST_THPT"],
+        method_quota: 50,
+        bonus_rule_override: null,
+      },
+    })
+  })
+
+  it("MUTATE: serialize bonus_rule_override + allowlist hiệu chỉnh khi sửa", async () => {
+    hoisted.authState.role = "admin"
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=advanced"))
+    const user = userEvent.setup()
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Lưu nâng cao" })).toBeTruthy()
+    })
+
+    // Bật override cộng điểm → tick cộng điểm khu vực → đặt trần 5.
+    await user.click(
+      screen.getByRole("switch", { name: "Bật quy tắc cộng điểm tùy chỉnh" }),
+    )
+    await user.click(screen.getByRole("checkbox", { name: "Cộng điểm khu vực" }))
+    await user.type(screen.getByLabelText("Trần tổng cộng điểm (0..10)"), "5")
+
+    // Tick 1 trường hiệu chỉnh hợp lệ (gender).
+    await user.click(screen.getByRole("checkbox", { name: "Giới tính" }))
+
+    await user.click(screen.getByRole("button", { name: "Lưu nâng cao" }))
+
+    expect(hoisted.mockUpdatePath).toHaveBeenCalledWith({
+      pathId: 109,
+      data: {
+        minor_correction_allowed_fields: ["gender"],
+        applicable_to: null,
+        method_quota: null,
+        bonus_rule_override: {
+          apply_area_bonus: true,
+          apply_object_bonus: false,
+          max_total_bonus: 5,
+        },
+      },
+    })
+  })
+
+  it("MUTATE clear→null: admin xoá hết governance đang có → gửi null/[]", async () => {
+    hoisted.authState.role = "admin"
+    hoisted.mockUseAdmissionPath.mockReturnValue({
+      data: {
+        ...hoisted.defaultPath,
+        status: "draft", // draft → lưu thẳng, không dính dialog cảnh báo
+        applicable_to: ["POST_THPT"],
+        method_quota: 50,
+        bonus_rule_override: {
+          apply_area_bonus: true,
+          apply_object_bonus: false,
+          max_total_bonus: 5,
+        },
+        minor_correction_allowed_fields: ["gender"],
+      },
+      isLoading: false,
+    })
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=advanced"))
+    const user = userEvent.setup()
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Lưu nâng cao" })).toBeTruthy()
+    })
+
+    // Bỏ chọn / xoá cả 4 trường đang có giá trị.
+    await user.click(screen.getByRole("checkbox", { name: /Sau THPT/ })) // audience → empty
+    await user.clear(screen.getByLabelText("Chỉ tiêu phương thức")) // quota → ""
+    await user.click(
+      screen.getByRole("switch", { name: "Bật quy tắc cộng điểm tùy chỉnh" }),
+    ) // bonus OFF
+    await user.click(screen.getByRole("checkbox", { name: "Giới tính" })) // allowlist → []
+
+    await user.click(screen.getByRole("button", { name: "Lưu nâng cao" }))
+
+    expect(hoisted.mockUpdatePath).toHaveBeenCalledWith({
+      pathId: 109,
+      data: {
+        minor_correction_allowed_fields: [],
+        applicable_to: null,
+        method_quota: null,
+        bonus_rule_override: null,
+      },
+    })
+  })
+
+  it("WARN: path active + sửa applicable_to → hiện dialog cảnh báo; Huỷ → KHÔNG lưu", async () => {
+    hoisted.authState.role = "admin"
+    hoisted.mockUseAdmissionPath.mockReturnValue({
+      data: { ...hoisted.defaultPath, status: "active" },
+      isLoading: false,
+    })
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=advanced"))
+    const user = userEvent.setup()
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Lưu nâng cao" })).toBeTruthy()
+    })
+
+    await user.click(screen.getByRole("checkbox", { name: /Sau THPT/ }))
+    await user.click(screen.getByRole("button", { name: "Lưu nâng cao" }))
+
+    // Dialog hiện ("Vẫn lưu" chỉ có trong dialog) và CHƯA gọi mutation.
+    expect(screen.getByRole("button", { name: "Vẫn lưu" })).toBeTruthy()
+    expect(hoisted.mockUpdatePath).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: "Huỷ" }))
+    expect(hoisted.mockUpdatePath).not.toHaveBeenCalled()
+  })
+
+  it("WARN: path active → dialog → Vẫn lưu → gửi payload", async () => {
+    hoisted.authState.role = "admin"
+    hoisted.mockUseAdmissionPath.mockReturnValue({
+      data: { ...hoisted.defaultPath, status: "active" },
+      isLoading: false,
+    })
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=advanced"))
+    const user = userEvent.setup()
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Lưu nâng cao" })).toBeTruthy()
+    })
+
+    await user.click(screen.getByRole("checkbox", { name: /Sau THPT/ }))
+    await user.click(screen.getByRole("button", { name: "Lưu nâng cao" }))
+    await user.click(screen.getByRole("button", { name: "Vẫn lưu" }))
+
+    expect(hoisted.mockUpdatePath).toHaveBeenCalledWith({
+      pathId: 109,
+      data: {
+        minor_correction_allowed_fields: [],
+        applicable_to: ["POST_THPT"],
+        method_quota: null,
+        bonus_rule_override: null,
+      },
+    })
+  })
+
+  it("WARN scope: path active + chỉ sửa method_quota → KHÔNG dialog, lưu thẳng", async () => {
+    hoisted.authState.role = "admin"
+    hoisted.mockUseAdmissionPath.mockReturnValue({
+      data: { ...hoisted.defaultPath, status: "active" },
+      isLoading: false,
+    })
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=advanced"))
+    const user = userEvent.setup()
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Lưu nâng cao" })).toBeTruthy()
+    })
+
+    await user.type(screen.getByLabelText("Chỉ tiêu phương thức"), "20")
+    await user.click(screen.getByRole("button", { name: "Lưu nâng cao" }))
+
+    // method_quota KHÔNG phải field high-impact → không dialog, gọi mutation luôn.
+    expect(screen.queryByRole("button", { name: "Vẫn lưu" })).toBeNull()
+    expect(hoisted.mockUpdatePath).toHaveBeenCalledWith({
+      pathId: 109,
+      data: {
+        minor_correction_allowed_fields: [],
+        applicable_to: null,
+        method_quota: 20,
+        bonus_rule_override: null,
+      },
+    })
   })
 })

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
@@ -61,11 +61,13 @@ import {
   quotaMatrixKeys,
   useUpdatePathQuota,
 } from "@/hooks/admissions/useQuotaMatrix"
+import { useAuth } from "@/hooks/useAuth"
 import { parseApiError } from "@/lib/utils/api-errors"
 import type { AdmissionPathResponse } from "@/lib/zod/admission-path"
 
 import { ConfigCriteria } from "../ConfigCriteria"
 import { ConfigDocuments } from "../ConfigDocuments"
+import { AdvancedTab } from "./AdvancedTab"
 import { pathStatusLabel } from "./labels"
 
 type PathLike = AdmissionPathResponse
@@ -75,11 +77,24 @@ interface Props {
   onClose: () => void
 }
 
-const VALID_TABS = ["quota", "identity", "criteria", "documents", "lifecycle"] as const
+const VALID_TABS = [
+  "quota",
+  "identity",
+  "criteria",
+  "documents",
+  "advanced",
+  "lifecycle",
+] as const
 type TabId = (typeof VALID_TABS)[number]
 
 export function PathDetailDrawer({ pathId, onClose }: Props) {
   const { data: path, isLoading } = useAdmissionPath(pathId)
+
+  // Thẻ "Nâng cao" (governance) chỉ-admin — cùng role gate như wizard cũ
+  // PathBasicInfo. Máy chủ cũng enforce (BusinessRuleViolation khi non-admin
+  // ghi governance); FE gate chỉ là UX, KHÔNG phải lớp bảo mật chính.
+  const { user } = useAuth()
+  const isAdmin = user?.role === "admin"
 
   // Pass 2 hard-review FM-2: tab active sync với ?tab= URL param.
   // Reload page giữ tab user đang xem; share link mở thẳng tab cụ thể.
@@ -89,10 +104,12 @@ export function PathDetailDrawer({ pathId, onClose }: Props) {
   const searchParams = useSearchParams()
   const tab: TabId = useMemo(() => {
     const raw = searchParams.get("tab")
-    return (VALID_TABS as readonly string[]).includes(raw ?? "")
+    const valid = (VALID_TABS as readonly string[]).includes(raw ?? "")
       ? (raw as TabId)
       : "quota"
-  }, [searchParams])
+    // Non-admin dán ?tab=advanced → fallback "quota" (tránh rơi vào thẻ ẩn).
+    return valid === "advanced" && !isAdmin ? "quota" : valid
+  }, [searchParams, isAdmin])
   const setTab = useCallback(
     (next: string) => {
       // Idempotent guard: Radix Tabs + React 19 effects có thể fire
@@ -153,11 +170,18 @@ export function PathDetailDrawer({ pathId, onClose }: Props) {
             onValueChange={setTab}
             className="flex-1 flex flex-col min-h-0"
           >
-            <TabsList className="grid grid-cols-5 shrink-0">
+            <TabsList
+              className={`flex w-full justify-start overflow-x-auto shrink-0 sm:grid sm:justify-center ${
+                isAdmin ? "sm:grid-cols-6" : "sm:grid-cols-5"
+              }`}
+            >
               <TabsTrigger value="quota">Chỉ tiêu</TabsTrigger>
               <TabsTrigger value="identity">Định danh</TabsTrigger>
               <TabsTrigger value="criteria">Tiêu chí</TabsTrigger>
               <TabsTrigger value="documents">Giấy tờ</TabsTrigger>
+              {isAdmin && (
+                <TabsTrigger value="advanced">Nâng cao</TabsTrigger>
+              )}
               <TabsTrigger value="lifecycle">Vòng đời</TabsTrigger>
             </TabsList>
 
@@ -184,6 +208,11 @@ export function PathDetailDrawer({ pathId, onClose }: Props) {
                   embedded
                 />
               </TabsContent>
+              {isAdmin && (
+                <TabsContent value="advanced">
+                  <AdvancedTab path={path} pathId={pathId} onClose={onClose} />
+                </TabsContent>
+              )}
               <TabsContent value="lifecycle">
                 <LifecycleTab path={path} pathId={pathId} onClose={onClose} />
               </TabsContent>

--- a/frontend/src/lib/utils/admission-path-payload.test.ts
+++ b/frontend/src/lib/utils/admission-path-payload.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildApplicableToPayload,
+  buildMethodQuotaPayload,
+  buildBonusOverridePayload,
+} from "./admission-path-payload";
+import type { AdmissionAudience } from "@/lib/zod/admission-path";
+
+/**
+ * Unit tests for the extracted AdmissionPath governance payload builders.
+ *
+ * These import the REAL pure functions (not a re-implementation) so the
+ * clear→null semantics stay pinned to the shipped code. Independent of the
+ * legacy ``PathBasicInfo.payload.test.tsx`` lifecycle on purpose.
+ */
+describe("admission-path-payload builders", () => {
+  describe("buildApplicableToPayload", () => {
+    it("returns null for an empty set (clear filter = every audience)", () => {
+      expect(buildApplicableToPayload(new Set())).toBeNull();
+    });
+
+    it("returns the audience array for a non-empty set", () => {
+      const set = new Set<AdmissionAudience>(["POST_THPT", "POST_THCS"]);
+      expect(buildApplicableToPayload(set)).toEqual(["POST_THPT", "POST_THCS"]);
+    });
+  });
+
+  describe("buildMethodQuotaPayload", () => {
+    it("returns null for empty / whitespace-only input", () => {
+      expect(buildMethodQuotaPayload("")).toBeNull();
+      expect(buildMethodQuotaPayload("   ")).toBeNull();
+    });
+
+    it("returns null for a negative number", () => {
+      expect(buildMethodQuotaPayload("-1")).toBeNull();
+    });
+
+    it("returns null for non-numeric input", () => {
+      expect(buildMethodQuotaPayload("abc")).toBeNull();
+    });
+
+    it("floors a decimal", () => {
+      expect(buildMethodQuotaPayload("1.5")).toBe(1);
+    });
+
+    it("passes a valid integer through", () => {
+      expect(buildMethodQuotaPayload("50")).toBe(50);
+    });
+
+    it("treats 0 as a real cap (not a clear)", () => {
+      expect(buildMethodQuotaPayload("0")).toBe(0);
+    });
+  });
+
+  describe("buildBonusOverridePayload", () => {
+    it("returns null when the override toggle is off", () => {
+      expect(buildBonusOverridePayload(false, true, true, "5")).toBeNull();
+    });
+
+    it("returns max_total_bonus null when enabled but max is empty (no cap)", () => {
+      expect(buildBonusOverridePayload(true, true, false, "")).toEqual({
+        apply_area_bonus: true,
+        apply_object_bonus: false,
+        max_total_bonus: null,
+      });
+    });
+
+    it("builds the full shape when enabled with a valid max", () => {
+      expect(buildBonusOverridePayload(true, true, false, "5")).toEqual({
+        apply_area_bonus: true,
+        apply_object_bonus: false,
+        max_total_bonus: 5,
+      });
+    });
+
+    it("clamps a max above 10 down to 10", () => {
+      expect(buildBonusOverridePayload(true, false, false, "11.5")).toEqual({
+        apply_area_bonus: false,
+        apply_object_bonus: false,
+        max_total_bonus: 10,
+      });
+    });
+
+    it("clamps a negative max up to 0", () => {
+      expect(buildBonusOverridePayload(true, false, true, "-3")).toEqual({
+        apply_area_bonus: false,
+        apply_object_bonus: true,
+        max_total_bonus: 0,
+      });
+    });
+
+    it("returns max_total_bonus null for a non-numeric max", () => {
+      expect(buildBonusOverridePayload(true, false, false, "abc")).toEqual({
+        apply_area_bonus: false,
+        apply_object_bonus: false,
+        max_total_bonus: null,
+      });
+    });
+  });
+});

--- a/frontend/src/lib/utils/admission-path-payload.ts
+++ b/frontend/src/lib/utils/admission-path-payload.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure wire-payload builders for the AdmissionPath governance fields
+ * (phase1_02 / phase1_03).
+ *
+ * Extracted from the legacy ``PathBasicInfo`` wizard
+ * (``PathBasicInfo.tsx:148-199``) so the new "Nâng cao" tab in
+ * ``PathDetailDrawer`` reuses the exact same clear→null semantics instead of
+ * re-implementing them. Unlike the wizard versions these take their inputs as
+ * arguments (no component-state closure), which keeps them pure and directly
+ * unit-testable.
+ */
+
+import type {
+  AdmissionAudience,
+  BonusRuleOverride,
+} from "@/lib/zod/admission-path";
+
+/**
+ * Build the wire payload for ``applicable_to``.
+ *
+ * Empty Set → ``null`` (NULL on the wire = applicable to every audience).
+ * A non-empty set serialises to the explicit audience array so the
+ * "clear filter" semantic stays unambiguous under
+ * ``model_dump(exclude_unset=True)`` on the BE.
+ */
+export function buildApplicableToPayload(
+  applicableTo: Set<AdmissionAudience>,
+): AdmissionAudience[] | null {
+  return applicableTo.size > 0 ? Array.from(applicableTo) : null;
+}
+
+/**
+ * Build the wire payload for ``method_quota``.
+ *
+ * BE column is ``Integer`` with Pydantic ``ge=0``. Floor decimal input
+ * (e.g. ``"1.5"`` → ``1``) so the BE doesn't reject with a 400. Empty,
+ * negative, or non-numeric input → ``null`` (admin intent = "clear the cap").
+ * ``"0"`` is a real cap, not a clear.
+ */
+export function buildMethodQuotaPayload(
+  methodQuotaInput: string,
+): number | null {
+  if (methodQuotaInput.trim() === "") return null;
+  const parsed = Number(methodQuotaInput);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Math.floor(parsed);
+}
+
+/**
+ * Build the wire payload for ``bonus_rule_override``.
+ *
+ * Toggle OFF → ``null`` (= inherit the method default). Toggle ON → the full
+ * 3-field shape; an empty ``max_total_bonus`` → ``null`` (no cap). A provided
+ * cap is clamped into ``[0, 10]`` (the BE Pydantic range) rather than rejected
+ * — admin intent at the form boundary is "cap me", not "drop the cap".
+ * Non-numeric cap → ``null``.
+ */
+export function buildBonusOverridePayload(
+  enabled: boolean,
+  applyAreaBonus: boolean,
+  applyObjectBonus: boolean,
+  maxTotalBonusInput: string,
+): BonusRuleOverride | null {
+  if (!enabled) return null;
+  const trimmed = maxTotalBonusInput.trim();
+  let maxTotal: number | null;
+  if (trimmed === "") {
+    maxTotal = null;
+  } else {
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed)) {
+      maxTotal = null;
+    } else {
+      // Clamp into [0, 10] — BE Pydantic enforces the same range.
+      maxTotal = Math.min(10, Math.max(0, parsed));
+    }
+  }
+  return {
+    apply_area_bonus: applyAreaBonus,
+    apply_object_bonus: applyObjectBonus,
+    max_total_bonus: maxTotal,
+  };
+}


### PR DESCRIPTION
## Summary

PR-1 adds an admin-only **Nâng cao** tab to the admission quota matrix path drawer so governance fields can be edited from the current Phase 3 matrix flow without removing the legacy wizard yet.

Changed scope:
- Add pure payload builders for AdmissionPath governance fields:
  - `buildApplicableToPayload`
  - `buildMethodQuotaPayload`
  - `buildBonusOverridePayload`
- Add `AdvancedTab` under `QuotaMatrix/` for 4 admin-only governance fields:
  - `applicable_to`
  - `method_quota`
  - `bonus_rule_override`
  - `minor_correction_allowed_fields`
- Wire `PathDetailDrawer` with:
  - admin-only `Nâng cao` tab
  - non-admin `?tab=advanced` fallback to `quota`
  - responsive tab list for mobile
  - active-path high-impact warning dialog for `applicable_to` / `bonus_rule_override`
- Add focused unit/component coverage for payload semantics, admin gate, mutation payloads, clear-to-null, and active-path warning behavior.

Out of scope:
- Does not remove `PathBasicInfo`, `ContextSelector`, `PathsList`, `PathWizard`, or `ConfigReview`.
- Does not change backend engine/quota/scoring/public filter/submit-approve gates.
- Does not claim runtime enforcement for `method_quota`; it remains config/snapshot until backend enforcement work.

## Business Impact

This PR is not a no-op UI move. It re-exposes admin editing for governance fields that affect admission behavior:

- `applicable_to`: affects public catalog/audience filtering. Empty selection serializes to `null`, meaning every audience.
- `bonus_rule_override`: affects path-level bonus rule resolution for profiles/choices that are not score-frozen.
- `minor_correction_allowed_fields`: controls which approved-profile fields are available for minor correction.
- `method_quota`: persisted as a per-method quota config/snapshot field, with no runtime enforcement claimed in this PR.

For active paths, the UI now warns before saving changes to the high-impact fields `applicable_to` and `bonus_rule_override`.

## Verification

Container verification, using a one-off frontend container with `frontend/src` bind-mounted so tests/type-check/lint use the current working tree:

```bash
docker compose run --rm --no-deps -v $PWD\frontend\src:/app/src frontend npm run test -- --run src/lib/utils/admission-path-payload.test.ts src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
# 2 files passed, 34 tests passed

docker compose run --rm --no-deps -v $PWD\frontend\src:/app/src frontend npm run type-check
# exit 0

docker compose run --rm --no-deps -v $PWD\frontend\src:/app/src frontend npm run lint
# exit 0, 0 errors; existing repo warnings only

git diff --check -- frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
# exit 0; CRLF warning only
```

Browser smoke completed with isolated admin context, no `localStorage.clear()`, full reload preserving auth, and DB checks:

- Admin sees `Nâng cao` tab and 6-tab drawer.
- Edit 4 fields -> save -> success toast.
- DB persisted `applicable_to={POST_THPT}`, `method_quota=20`, `bonus_rule_override={area:true, object:false, max:5}`, `minor_correction_allowed_fields=[gender]`.
- Full reload preserves admin auth and hydrates all 4 fields from API/UI.
- Active path warning dialog appears; cancel does not write.
- Mobile 375px tab list is flex/overflow-x responsive and not clipped.
- Clear-to-null round-trip verified.
- DB cleanup verified for touched paths.

Non-admin browser access to `/admin/admission-config` is route-blocked and redirects to `/dashboard`; component tests still cover manager hidden-tab and `?tab=advanced` fallback behavior.

## Reviewer Notes

This is PR-1 only. PR-2 remains blocked until this additive path is reviewed and merged.