### PR TITLE
fix(admissions-fe): refresh matrix caches after path edits

### DIFF
--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/AdmissionConfigClient.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/AdmissionConfigClient.tsx
@@ -131,7 +131,6 @@ export function AdmissionConfigClient() {
           {currentState.type === "quota-matrix-overview" && (
             <QuotaMatrixOverview
               academicYear={currentState.academicYear}
-              academicInfoId={currentState.academicInfoId}
               onYearChange={(year) =>
                 navigate({
                   type: "quota-matrix-overview",

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrixOverview.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrixOverview.tsx
@@ -27,7 +27,6 @@ import { GlobalMatrixView } from "./QuotaMatrix/GlobalMatrixView"
 
 interface Props {
   academicYear: number
-  academicInfoId?: number
   onYearChange: (year: number) => void
   onBack: () => void
 }

--- a/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
+++ b/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
@@ -16,6 +16,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   useUpdatePathDocuments,
   useCreateAdmissionPath,
+  useUpdateAdmissionPath,
   admissionPathKeys,
 } from "./useAdmissionPaths";
 import { quotaMatrixKeys } from "./useQuotaMatrix";
@@ -331,6 +332,47 @@ describe("useAdmissionPaths – BUG-01 regression", () => {
       invalidateSpy.mockRestore();
     });
 
+    it("invalidates admission-paths root and quota-matrix caches", async () => {
+      server.use(
+        http.put(
+          `${API_BASE_URL}/api/admission-config/paths/:pathId/documents`,
+          () => HttpResponse.json(mockDocumentsResponse),
+        ),
+      );
+
+      const { queryClient, Wrapper } = createWrapperWithClient();
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+      const { result } = renderHook(() => useUpdatePathDocuments(), {
+        wrapper: Wrapper,
+      });
+
+      act(() => {
+        result.current.mutate({
+          pathId: MOCK_PATH_ID,
+          data: [
+            {
+              document_type_id: 10,
+              is_mandatory: true,
+              requires_upload: true,
+              display_order: 1,
+            },
+          ],
+        });
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: admissionPathKeys.all }),
+      );
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: quotaMatrixKeys.all }),
+      );
+
+      invalidateSpy.mockRestore();
+    });
+
     it("should NOT call setQueryData for the detail key", async () => {
       server.use(
         http.put(
@@ -379,6 +421,76 @@ describe("useAdmissionPaths – BUG-01 regression", () => {
 
       setQueryDataSpy.mockRestore();
     });
+  });
+});
+
+describe("useUpdateAdmissionPath – matrix cache parity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function arrangeUpdateHandler() {
+    server.use(
+      http.put(`${API_BASE_URL}/api/admission-config/paths/:pathId`, () =>
+        HttpResponse.json(mockAdmissionPathResponse),
+      ),
+    );
+  }
+
+  it("keeps detail cache fresh and invalidates admission-paths root", async () => {
+    arrangeUpdateHandler();
+    const { queryClient, Wrapper } = createWrapperWithClient();
+    const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateAdmissionPath(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.mutate({
+        pathId: MOCK_PATH_ID,
+        data: { display_name: "Updated Path" },
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(setQueryDataSpy).toHaveBeenCalledWith(
+      admissionPathKeys.detail(MOCK_PATH_ID),
+      mockAdmissionPathResponse,
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: admissionPathKeys.all }),
+    );
+
+    setQueryDataSpy.mockRestore();
+    invalidateSpy.mockRestore();
+  });
+
+  it("invalidates the quota-matrix cache after identity/governance updates", async () => {
+    arrangeUpdateHandler();
+    const { queryClient, Wrapper } = createWrapperWithClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateAdmissionPath(), {
+      wrapper: Wrapper,
+    });
+
+    act(() => {
+      result.current.mutate({
+        pathId: MOCK_PATH_ID,
+        data: { visibility: "internal" },
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: quotaMatrixKeys.all }),
+    );
+
+    invalidateSpy.mockRestore();
   });
 });
 

--- a/frontend/src/hooks/admissions/useAdmissionPaths.ts
+++ b/frontend/src/hooks/admissions/useAdmissionPaths.ts
@@ -136,8 +136,11 @@ export function useUpdateAdmissionPath() {
     onSuccess: (updatedPath) => {
       // Immediately update cache with fresh data to avoid stale prop issue
       queryClient.setQueryData(admissionPathKeys.detail(updatedPath.id), updatedPath)
-      // Invalidate list queries
+      // Invalidate admission-path derived views. After PR-2 removes the legacy
+      // list screen, readiness lives under coverageMatrix, not under lists().
       queryClient.invalidateQueries({ queryKey: admissionPathKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: admissionPathKeys.all })
+      queryClient.invalidateQueries({ queryKey: ["quota-matrix"] })
     },
   })
 }
@@ -177,6 +180,8 @@ export function useUpdatePathDocuments() {
       queryClient.invalidateQueries({ queryKey: admissionPathKeys.detail(variables.pathId) })
       queryClient.invalidateQueries({ queryKey: admissionPathKeys.documents(variables.pathId) })
       queryClient.invalidateQueries({ queryKey: admissionPathKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: admissionPathKeys.all })
+      queryClient.invalidateQueries({ queryKey: ["quota-matrix"] })
     },
     onError: (error) => {
       console.error("useUpdatePathDocuments: Mutation error:", error);


### PR DESCRIPTION
## Summary
- Fix PR #359 cache-parity follow-up: path identity/governance updates and document updates now refresh the admission-paths root and quota-matrix caches.
- Keeps readiness/by-major/global matrix from showing stale state after admin edits documents, identity, or governance fields.
- Removes the dead `academicInfoId` prop from `QuotaMatrixOverview`; the selected academic info remains URL-owned by `academicInfo` search param.

## Verification
- `docker compose run --rm --no-deps -v "$PWD\frontend\src:/app/src" frontend npm run test -- --run src/hooks/admissions/useAdmissionPaths.test.tsx` pass: 10 tests
- `docker compose run --rm --no-deps -v "$PWD\frontend\src:/app/src" frontend npm run type-check` pass
- `docker compose run --rm --no-deps -v "$PWD\frontend\src:/app/src" frontend npm run lint` pass: 0 errors; warnings are pre-existing outside this follow-up
- `git diff --check` pass

## Notes
- Builds on merged PR #359.
- Does not touch backend or admission business rules.
