### PR TITLE
fix(notifications): isolate health alerts from system broadcast

### DIFF
--- a/Backend_FastAPI/alembic/versions/naflood001_cleanup_system_alert_rule.py
+++ b/Backend_FastAPI/alembic/versions/naflood001_cleanup_system_alert_rule.py
@@ -1,0 +1,119 @@
+"""Cleanup system_alert rule: drop zalo_bot action + restore all_users recipient.
+
+Revision ID: naflood001
+Revises: docgrp_audience_bf_20260530
+Create Date: 2026-06-01
+
+Part of the ``fix/notification-alert-flood`` hotfix. The notification
+health-check beat task now dispatches the dedicated admin-only
+``notification_health_alert`` event (shipped in the same PR), so the
+``system_alert`` rule no longer needs the zalo_bot fan-out — and is
+restored to its seed contract (``all_users``) for the manual admin
+broadcast endpoint ``POST /system/alert``.
+
+upgrade()
+---------
+1. DELETE the ``zalo_bot`` action that ``zalobot002`` seeded onto the
+   ``system_alert`` rule (marker ``config->>'seeded_by' = 'zalobot002'``).
+   Scoped to ``system_alert`` ONLY — the other 9 zalobot002 pilot events
+   keep their zalo_bot actions untouched. Idempotent: if already deleted
+   (e.g. by Phase 0 prod mitigation), the DELETE matches zero rows.
+2. UPDATE recipient_config from ``all_admins`` back to ``all_users`` for
+   ``system_alert``. Narrow predicate ``resolver_type = 'all_admins'`` so
+   this ONLY undoes the Phase 0 mitigation — it never overwrites a custom
+   resolver an operator may have set, and is a no-op if Phase 0 never ran
+   (recipient still ``all_users``). Idempotent.
+
+   ``recipient_config`` is a JSON (not JSONB) column
+   (``models/notification.py``), so the cast is ``::json`` and the
+   ``->>'resolver_type'`` text-extraction operator applies normally.
+
+Removing zalo_bot from ``system_alert`` is INTENTIONAL, not a side
+effect: an admin broadcast to ``all_users`` (most of whom have no Zalo
+Bot link) would only dead-letter on the zalo_bot channel. browser + email
+is the correct delivery surface for a system-wide broadcast.
+
+downgrade()
+-----------
+Re-insert the zalo_bot action for ``system_alert`` ONLY, gated by
+``WHERE NOT EXISTS`` so it never duplicates, carrying the zalobot002
+marker. recipient_config is NOT touched on downgrade — ``all_users`` is
+the seed default, not a state that needs reverting.
+
+⚠️ Do NOT run ``downgrade`` on production as a flood remediation: it
+re-creates exactly the zalo_bot fan-out this hotfix removed. See the
+plan's rollback runbook (stop the beat source FIRST).
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "naflood001"
+down_revision: Union[str, None] = "docgrp_audience_bf_20260530"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Drop the zalobot002-seeded zalo_bot action — scoped to system_alert.
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM notification_action
+            WHERE channel = 'zalo_bot'
+              AND config IS NOT NULL
+              AND config->>'seeded_by' = 'zalobot002'
+              AND rule_id = (
+                  SELECT id FROM notification_rule WHERE event = 'system_alert'
+              );
+            """
+        )
+    )
+
+    # 2. Restore recipient all_users — undoes Phase 0 mitigation only.
+    op.execute(
+        sa.text(
+            """
+            UPDATE notification_rule
+            SET recipient_config = '{"resolver_type": "all_users", "params": {}}'::json,
+                updated_at = now()
+            WHERE event = 'system_alert'
+              AND recipient_config->>'resolver_type' = 'all_admins';
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Re-insert the zalo_bot action for system_alert ONLY, idempotently.
+    # Mirrors zalobot002's INSERT shape; recipient_config left as-is.
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO notification_action (
+                rule_id, step, channel, delay_minutes, content_mode,
+                branch_key, config, created_at, updated_at
+            )
+            SELECT
+                nr.id,
+                COALESCE(MAX(na.step), 0) + 1,
+                'zalo_bot',
+                0,
+                'inherit_default',
+                'group_' || (COALESCE(MAX(na.step), 0) + 1) || '_zalo_bot',
+                '{"seeded_by": "zalobot002"}'::json,
+                now(),
+                now()
+            FROM notification_rule nr
+            LEFT JOIN notification_action na ON na.rule_id = nr.id
+            WHERE nr.event = 'system_alert'
+              AND NOT EXISTS (
+                  SELECT 1 FROM notification_action
+                  WHERE rule_id = nr.id AND channel = 'zalo_bot'
+              )
+            GROUP BY nr.id;
+            """
+        )
+    )

--- a/Backend_FastAPI/app/core/event_catalog.py
+++ b/Backend_FastAPI/app/core/event_catalog.py
@@ -1621,7 +1621,7 @@ _CTV_FUTURE_EVENTS: tuple = (
 )
 
 # -------------------------------------------------------------------
-# 6. System + Security events (7 entries)
+# 6. System + Security events (8 entries)
 # -------------------------------------------------------------------
 
 _SYSTEM_EVENTS: tuple = (
@@ -1648,6 +1648,32 @@ _SYSTEM_EVENTS: tuple = (
         # matrix. Classifying as "public" would let a misuse at any
         # call site leak admin-authored payloads to connected clients
         # with no scope check.
+        privacy="sensitive",
+    ),
+    EventDefinition(
+        event=SystemEvents.NOTIFICATION_HEALTH_ALERT,
+        category="system",
+        display_name="Cảnh báo sức khỏe hệ thống thông báo",
+        description=(
+            "Tín hiệu vận hành dành riêng cho admin về sức khỏe phân phối "
+            "thông báo (failure rate, backlog, webhook lag, circuit breaker)"
+        ),
+        variables=(
+            _var("severity", "string", "Mức độ nghiêm trọng"),
+            _var("message", "string", "Nội dung cảnh báo"),
+            _var("alert_type", "string", "Loại cảnh báo", False),
+        ),
+        # Admin-only operational signal — NOT a user broadcast. Mirrors
+        # HOLIDAY_CALENDAR_INCOMPLETE's admin-scoped resolver set so the
+        # health task can never fan out to all_users.
+        default_resolver="all_admins",
+        allowed_resolvers=_ADMIN_RESOLVERS,
+        # browser + email (no zalo_bot — group SYSTEM defaults zalo_bot=False).
+        default_channels=("browser", "email"),
+        priority=10,
+        # Sensitive: the dispatch site passes explicit rooms=["role_admin"]
+        # so it clears the fail-closed socket guard. Classifying public would
+        # let any misuse leak operational payloads to all connected clients.
         privacy="sensitive",
     ),
     EventDefinition(

--- a/Backend_FastAPI/app/core/event_groups.py
+++ b/Backend_FastAPI/app/core/event_groups.py
@@ -140,6 +140,7 @@ EVENT_GROUP_MAPPING: Dict[SystemEvents, NotificationEventGroup] = {
 
     # System events
     SystemEvents.SYSTEM_ALERT: NotificationEventGroup.SYSTEM,
+    SystemEvents.NOTIFICATION_HEALTH_ALERT: NotificationEventGroup.SYSTEM,
     SystemEvents.SYSTEM_ANNOUNCEMENT: NotificationEventGroup.SYSTEM,
     SystemEvents.USER_ROLE_CHANGED: NotificationEventGroup.SYSTEM,
     SystemEvents.USER_DEACTIVATED: NotificationEventGroup.SYSTEM,

--- a/Backend_FastAPI/app/core/events.py
+++ b/Backend_FastAPI/app/core/events.py
@@ -664,6 +664,28 @@ class SystemEvents(str, Enum):
     Recipients: All active users or specified user_ids
     """
 
+    NOTIFICATION_HEALTH_ALERT = "notification_health_alert"
+    """
+    Operational health alert for the notification delivery subsystem.
+
+    Admin-only operational signal raised by the Celery beat task
+    ``check_notification_alerts`` (``app/tasks/delivery_tasks.py``). Kept
+    SEPARATE from ``SYSTEM_ALERT`` so the health task never fans out to the
+    full ``all_users`` broadcast audience (which previously flooded every
+    staff inbox + dead-lettered zalo_bot deliveries and self-fed the
+    failure-rate loop). Dispatched to ``all_admins`` over browser + email
+    only — never zalo_bot.
+
+    Payload Schema:
+        {
+            "severity": str,              # Required: "info" | "warning" | "error"
+            "message": str,               # Required: Alert message
+            "alert_type": str,            # e.g. "failure_rate_high", "breaker_open"
+        }
+
+    Recipients: Admin users only (operators who action pipeline health).
+    """
+
     HOLIDAY_CALENDAR_INCOMPLETE = "holiday_calendar_incomplete"
     """
     Holiday calendar missing lunar holidays for next year.

--- a/Backend_FastAPI/app/core/notification_seed_defaults.py
+++ b/Backend_FastAPI/app/core/notification_seed_defaults.py
@@ -477,6 +477,15 @@ NOTIFICATION_SEED_DEFAULTS: Dict[SystemEvents, Dict[str, Any]] = {
         "notification_type": "warning",
         "recipient_config": {"resolver_type": "all_users", "params": {}},
     },
+    # Admin-only operational health signal — recipient all_admins so the
+    # beat health task never fans out to all_users. See SystemEvents
+    # docstring + plan fix/notification-alert-flood.
+    SystemEvents.NOTIFICATION_HEALTH_ALERT: {
+        "title_template": "[${severity}] Cảnh báo sức khỏe thông báo",
+        "message_template": "${message}",
+        "notification_type": "warning",
+        "recipient_config": {"resolver_type": "all_admins", "params": {}},
+    },
     SystemEvents.SYSTEM_ANNOUNCEMENT: {
         "title_template": "${title}",
         "message_template": "${message}",

--- a/Backend_FastAPI/app/repositories/notification_delivery_repository.py
+++ b/Backend_FastAPI/app/repositories/notification_delivery_repository.py
@@ -434,26 +434,48 @@ class NotificationDeliveryRepository(BaseRepository[NotificationDelivery]):
 
     # --- D3: Alerting helper methods ---
 
-    async def get_failure_rate(self, minutes: int = 30) -> float | None:
-        """Get failure rate for last N minutes. None if no deliveries."""
+    async def get_failure_rate(
+        self,
+        minutes: int = 30,
+        exclude_events: list[str] | None = None,
+    ) -> float | None:
+        """Get failure rate for last N minutes. None if no deliveries.
+
+        ``exclude_events`` removes the listed event names from BOTH the
+        numerator (failures) and denominator (total) — used to keep the
+        operational ``notification_health_alert`` event from measuring its
+        own fan-out (self-reference loop). Default ``None`` preserves the
+        original behaviour exactly. Predicate is supported by the
+        ``ix_delivery_event_created`` index on ``(event, created_at)``.
+        """
         since = datetime.now(timezone.utc) - timedelta(minutes=minutes)
-        where = NotificationDelivery.created_at >= since
-        total_q = select(func.count()).select_from(NotificationDelivery).where(where)
+        where = [NotificationDelivery.created_at >= since]
+        if exclude_events:
+            where.append(NotificationDelivery.event.notin_(exclude_events))
+        total_q = select(func.count()).select_from(NotificationDelivery).where(*where)
         total = (await self.db.execute(total_q)).scalar() or 0
         if total == 0:
             return None
         fail_q = (
             select(func.count()).select_from(NotificationDelivery)
-            .where(where, NotificationDelivery.status.in_(["failed", "dead_lettered"]))
+            .where(*where, NotificationDelivery.status.in_(["failed", "dead_lettered"]))
         )
         failures = (await self.db.execute(fail_q)).scalar() or 0
         return failures / total
 
-    async def get_queued_backlog_count(self) -> int:
-        """Count deliveries currently in queued status."""
-        q = select(func.count()).select_from(NotificationDelivery).where(
-            NotificationDelivery.status == "queued"
-        )
+    async def get_queued_backlog_count(
+        self, exclude_events: list[str] | None = None
+    ) -> int:
+        """Count deliveries currently in queued status.
+
+        ``exclude_events`` optionally excludes operational events (same
+        rationale as ``get_failure_rate``). Default ``None`` = original
+        behaviour.
+        """
+        where = [NotificationDelivery.status == "queued"]
+        if exclude_events:
+            where.append(NotificationDelivery.event.notin_(exclude_events))
+        q = select(func.count()).select_from(NotificationDelivery).where(*where)
         return (await self.db.execute(q)).scalar() or 0
 
     async def get_stale_sent_count(self, lag_minutes: int = 60) -> int:

--- a/Backend_FastAPI/app/scripts/reset_notification_rules_dev.py
+++ b/Backend_FastAPI/app/scripts/reset_notification_rules_dev.py
@@ -237,6 +237,13 @@ CURATED_RULES: dict[str, dict[str, Any]] = {
         link_template="$action_url",
         groups=[_internal_group("all_users", ["browser", "email"])],
     ),
+    "notification_health_alert": _build_rule(
+        event="notification_health_alert",
+        title_template="[${severity}] Cảnh báo sức khỏe thông báo",
+        message_template="$message",
+        notification_type="warning",
+        groups=[_internal_group("all_admins", ["browser", "email"])],
+    ),
     "system_announcement": _build_rule(
         event="system_announcement",
         title_template="$title",

--- a/Backend_FastAPI/app/services/notification_alert_service.py
+++ b/Backend_FastAPI/app/services/notification_alert_service.py
@@ -2,7 +2,10 @@
 """
 Phase D3: Automated alerting for notification delivery health.
 
-4 check functions, Redis dedup to prevent alert storms, dispatches via SYSTEM_ALERT.
+4 check functions, Redis dedup to prevent alert storms. The fired alerts are
+dispatched by the ``check_notification_alerts`` Celery task via the admin-only
+``NOTIFICATION_HEALTH_ALERT`` event (browser + email, all_admins) — info-
+severity alerts are logged but not dispatched.
 """
 import structlog
 from typing import Dict, List, Optional
@@ -11,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database
 from app.config import settings
+from app.core.events import SystemEvents
 from app.repositories.notification_delivery_repository import NotificationDeliveryRepository
 from app.services.notification_circuit_breaker import get_all_breaker_states
 
@@ -20,11 +24,21 @@ log = structlog.get_logger(__name__)
 _ALERT_DEDUP_KEY = "notif:alert:dedup:{alert_type}"
 _ALERT_DEDUP_TTL = 3600  # 1 hour
 
+# Operational events the health checks must NOT measure — the health task
+# itself dispatches NOTIFICATION_HEALTH_ALERT, so counting its own deliveries
+# in the failure-rate / backlog windows would let a single fan-out re-trigger
+# the failure_rate_high alert next cycle (self-feeding loop). We exclude ONLY
+# the self-referential event — NOT system_alert, which (after Approach Y) is a
+# real admin broadcast whose delivery failures we still want to surface.
+_OPERATIONAL_ALERT_EVENTS = [SystemEvents.NOTIFICATION_HEALTH_ALERT.value]
+
 
 async def check_failure_rate_alert(db: AsyncSession) -> Optional[Dict]:
     """Check if failure rate exceeds threshold in last 30 minutes."""
     repo = NotificationDeliveryRepository(db)
-    rate = await repo.get_failure_rate(minutes=30)
+    rate = await repo.get_failure_rate(
+        minutes=30, exclude_events=_OPERATIONAL_ALERT_EVENTS
+    )
 
     if rate is not None and rate > settings.ALERT_FAILURE_RATE_THRESHOLD:
         return {
@@ -39,7 +53,9 @@ async def check_failure_rate_alert(db: AsyncSession) -> Optional[Dict]:
 async def check_backlog_alert(db: AsyncSession) -> Optional[Dict]:
     """Check if queued backlog exceeds threshold."""
     repo = NotificationDeliveryRepository(db)
-    backlog = await repo.get_queued_backlog_count()
+    backlog = await repo.get_queued_backlog_count(
+        exclude_events=_OPERATIONAL_ALERT_EVENTS
+    )
 
     if backlog > settings.ALERT_BACKLOG_THRESHOLD:
         return {

--- a/Backend_FastAPI/app/tasks/delivery_tasks.py
+++ b/Backend_FastAPI/app/tasks/delivery_tasks.py
@@ -591,8 +591,9 @@ def check_notification_alerts(self):
     """
     Celery Beat task: run all notification alert checks.
 
-    Runs every 5 minutes. Dispatches SYSTEM_ALERT for any fired alerts.
-    Redis dedup prevents alert storms (same alert type within 1 hour).
+    Runs every 5 minutes. Dispatches NOTIFICATION_HEALTH_ALERT (admin-only)
+    for warning/error alerts; info-severity alerts are logged but not
+    dispatched. Redis dedup prevents alert storms (same alert type within 1h).
     """
     task_name = "check_notification_alerts"
     task_log = logging.getLogger(task_name)
@@ -612,25 +613,70 @@ def check_notification_alerts(self):
 
             # Notification health alerts target operators — scope to admin
             # room only (the others are end-user roles that don't action
-            # pipeline health metrics).
+            # pipeline health metrics). Dispatched via NOTIFICATION_HEALTH_ALERT
+            # (admin-only, browser+email — never zalo_bot), NOT SYSTEM_ALERT,
+            # so the health check never fans out to the all_users broadcast
+            # audience (which flooded staff inboxes + self-fed the failure-rate
+            # loop via zalo_bot dead-letters).
             _alert_rooms = ["role_admin"]
+            dispatched_types: list[str] = []
+            skipped_info = 0
             for alert in alerts:
+                severity = alert.get("severity", "warning")
+                alert_type = alert.get("alert_type", "")
+                # F-info: info-severity alerts (e.g. webhook_lag) are
+                # observational only — log and skip, do NOT email operators.
+                # Done in the task loop (not run_all_checks) so the D3
+                # dedup/aggregation tests stay green.
+                if severity == "info":
+                    skipped_info += 1
+                    task_log.info(
+                        f"Skipping info-severity alert (no dispatch): {alert_type}"
+                    )
+                    continue
                 try:
-                    await safe_dispatch(
+                    notif_ids = await safe_dispatch(
                         db=session,
-                        event=SystemEvents.SYSTEM_ALERT,
+                        event=SystemEvents.NOTIFICATION_HEALTH_ALERT,
                         payload={
-                            "severity": alert.get("severity", "warning"),
+                            "severity": severity,
                             "message": alert["message"],
+                            "alert_type": alert_type,
                         },
                         rooms=_alert_rooms,
+                        # error (e.g. breaker_open) must reach operators even
+                        # if they muted system-group email; warning respects
+                        # the operator's preference (they may opt out).
+                        skip_preference_check=(severity == "error"),
                     )
                 except Exception as e:
                     task_log.error(f"Failed to dispatch alert: {e}")
+                    continue
+                # Count ONLY real deliveries. safe_dispatch returns [] when no
+                # enabled rule exists (e.g. notification_health_alert not yet
+                # synced into the DB), no recipient resolves, or a failure was
+                # swallowed — counting those as "fired" would mask exactly the
+                # fail-silent case the rollout gate watches for.
+                if notif_ids:
+                    dispatched_types.append(alert_type)
+                else:
+                    task_log.warning(
+                        "Alert dispatch produced 0 notifications — rule synced? "
+                        f"recipients resolved? alert_type={alert_type}"
+                    )
 
             await session.commit()
-            task_log.info(f"Notification alerts fired: {len(alerts)}")
-            return {"fired": len(alerts), "types": [a["alert_type"] for a in alerts]}
+            # Count what was ACTUALLY dispatched, not len(alerts) — info
+            # alerts are skipped above and must not inflate the metric.
+            task_log.info(
+                f"Notification alerts dispatched: {len(dispatched_types)} "
+                f"(info skipped: {skipped_info})"
+            )
+            return {
+                "fired": len(dispatched_types),
+                "skipped_info": skipped_info,
+                "types": dispatched_types,
+            }
 
     result = run_async_task(
         async_func=_run,

--- a/Backend_FastAPI/tests/repositories/test_notification_delivery_failure_rate.py
+++ b/Backend_FastAPI/tests/repositories/test_notification_delivery_failure_rate.py
@@ -1,0 +1,126 @@
+"""Repository tests: NotificationDeliveryRepository.get_failure_rate /
+get_queued_backlog_count ``exclude_events`` — fix/notification-alert-flood
+F-metric.
+
+The operational ``notification_health_alert`` event must be excludable from
+BOTH numerator and denominator so the health task never measures its own
+fan-out (the self-feeding failure-rate loop). Default arg preserves the
+original behaviour exactly.
+
+The ``db`` fixture truncates ``notification_delivery`` per test, so the rows
+seeded here are the only ones in the 30-minute window — rates are exact.
+"""
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.repositories.notification_delivery_repository import (
+    NotificationDeliveryRepository,
+)
+
+
+def _delivery(event: str, status: str, *, channel: str = "email"):
+    return models.NotificationDelivery(
+        event=event,
+        channel=channel,
+        recipient_kind="internal",
+        status=status,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestGetFailureRateExclude:
+    """``notification_health_alert`` dead-letters must not inflate the rate."""
+
+    async def _seed(self, db: AsyncSession):
+        # 10 normal lead_assigned: 8 sent + 2 failed → real fail rate = 20%.
+        rows = [_delivery("lead_assigned", "sent") for _ in range(8)]
+        rows += [_delivery("lead_assigned", "failed") for _ in range(2)]
+        # 5 health-alert deliveries ALL dead_lettered (the self-pumping rows
+        # that previously drove a single fan-out above the 20% threshold).
+        rows += [
+            _delivery("notification_health_alert", "dead_lettered")
+            for _ in range(5)
+        ]
+        db.add_all(rows)
+        await db.flush()
+
+    async def test_default_includes_all_events(self, db: AsyncSession):
+        await self._seed(db)
+        repo = NotificationDeliveryRepository(db)
+        rate = await repo.get_failure_rate(minutes=30)
+        # total 15, failures 7 (2 normal + 5 health) → inflated to ~46.7%.
+        assert rate == pytest.approx(7 / 15)
+
+    async def test_exclude_operational_event_yields_real_rate(
+        self, db: AsyncSession
+    ):
+        await self._seed(db)
+        repo = NotificationDeliveryRepository(db)
+        rate = await repo.get_failure_rate(
+            minutes=30, exclude_events=["notification_health_alert"]
+        )
+        # Only the normal rows count: total 10, failures 2 → 20%.
+        assert rate == pytest.approx(0.2)
+
+    async def test_exclude_strictly_lower_than_default(self, db: AsyncSession):
+        await self._seed(db)
+        repo = NotificationDeliveryRepository(db)
+        default = await repo.get_failure_rate(minutes=30)
+        excluded = await repo.get_failure_rate(
+            minutes=30, exclude_events=["notification_health_alert"]
+        )
+        assert excluded < default, (
+            "Excluding the self-referential event must lower the measured rate "
+            "(that is the whole point of the F-metric fix)."
+        )
+
+    async def test_empty_exclude_list_is_no_op(self, db: AsyncSession):
+        await self._seed(db)
+        repo = NotificationDeliveryRepository(db)
+        default = await repo.get_failure_rate(minutes=30)
+        empty = await repo.get_failure_rate(minutes=30, exclude_events=[])
+        # exclude_events=[] means "exclude NOTHING" → identical to default.
+        # (Here the truthy guard is intentional: empty exclusion = no filter.)
+        assert empty == default
+
+    async def test_none_when_only_excluded_events_exist(self, db: AsyncSession):
+        # Only health rows exist; excluding them → total 0 → None (no data).
+        db.add_all(
+            [
+                _delivery("notification_health_alert", "dead_lettered")
+                for _ in range(3)
+            ]
+        )
+        await db.flush()
+        repo = NotificationDeliveryRepository(db)
+        rate = await repo.get_failure_rate(
+            minutes=30, exclude_events=["notification_health_alert"]
+        )
+        assert rate is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+class TestGetQueuedBacklogExclude:
+    async def test_backlog_excludes_operational(self, db: AsyncSession):
+        db.add_all(
+            [
+                _delivery("lead_assigned", "queued"),
+                _delivery("lead_assigned", "queued"),
+                _delivery("notification_health_alert", "queued"),
+            ]
+        )
+        await db.flush()
+        repo = NotificationDeliveryRepository(db)
+        assert await repo.get_queued_backlog_count() == 3
+        assert (
+            await repo.get_queued_backlog_count(
+                exclude_events=["notification_health_alert"]
+            )
+            == 2
+        )

--- a/Backend_FastAPI/tests/unit/test_naflood001_cleanup_system_alert_migration.py
+++ b/Backend_FastAPI/tests/unit/test_naflood001_cleanup_system_alert_migration.py
@@ -1,0 +1,158 @@
+"""Contract tests for ``naflood001`` system_alert cleanup migration.
+
+fix/notification-alert-flood Step 7 — after the health-check beat task moves
+to the dedicated ``notification_health_alert`` event, the ``system_alert``
+rule (a) drops the zalobot002-seeded zalo_bot action and (b) is restored to
+its seed contract recipient ``all_users`` (undoing Phase 0 mitigation).
+
+Pattern follows ``test_docgrp_audience_backfill_migration.py`` — importlib-load
+the module and contract-assert revision chain + SQL body. The actual
+upgrade/downgrade roundtrip is run on a real dev DB pre-PR + the CI migration
+sweep post-merge.
+
+Safety invariants asserted here:
+1. Revision chains off the current head.
+2. upgrade DELETE is scoped to ``system_alert`` ONLY and gated by the
+   zalobot002 marker (the other 9 pilot events keep their zalo_bot actions).
+3. upgrade UPDATE uses the NARROW predicate ``resolver_type = 'all_admins'``
+   (only undoes Phase 0, never overwrites a custom resolver) and writes
+   ``all_users`` as a ``::json`` cast (recipient_config is JSON, not JSONB).
+4. downgrade re-inserts the zalo_bot action idempotently (WHERE NOT EXISTS)
+   with the zalobot002 marker, scoped to ``system_alert``.
+5. downgrade is non-destructive to recipient_config (no rule UPDATE).
+6. Literal SQL via ``sa.text`` (no f-string interpolation from input).
+"""
+from __future__ import annotations
+
+import importlib.util
+import inspect
+from pathlib import Path
+
+import pytest
+
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+_MIGRATION_FILE = "naflood001_cleanup_system_alert_rule.py"
+
+
+@pytest.fixture
+def migration():
+    path = _VERSIONS_DIR / _MIGRATION_FILE
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    assert spec is not None and spec.loader is not None, f"Cannot load {path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def module_src(migration):
+    return inspect.getsource(migration)
+
+
+# ---------------------------------------------------------------------------
+# 1. Revision chain lock
+# ---------------------------------------------------------------------------
+
+
+def test_revision_id(migration):
+    assert migration.revision == "naflood001"
+
+
+def test_down_revision_chains_off_head(migration):
+    """If another migration lands between this commit and merge, bump that
+    migration's down_revision onto ``naflood001`` OR rebase this onto the
+    new head."""
+    assert migration.down_revision == "docgrp_audience_bf_20260530"
+
+
+# ---------------------------------------------------------------------------
+# 2. upgrade — scoped DELETE of zalobot002 zalo_bot action
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_deletes_zalo_bot_action(migration):
+    src = inspect.getsource(migration.upgrade)
+    assert "DELETE FROM notification_action" in src
+    assert "channel = 'zalo_bot'" in src
+
+
+def test_upgrade_delete_gated_by_zalobot002_marker(migration):
+    """Only rows the zalobot002 migration seeded are removed — hand-added or
+    wizard-added zalo_bot actions carry no marker and survive."""
+    src = inspect.getsource(migration.upgrade)
+    assert "config->>'seeded_by' = 'zalobot002'" in src
+
+
+def test_upgrade_delete_scoped_to_system_alert_only(migration):
+    """DELETE must be scoped to the system_alert rule — the other 9
+    zalobot002 pilot events keep their zalo_bot actions."""
+    src = inspect.getsource(migration.upgrade)
+    assert "WHERE event = 'system_alert'" in src, (
+        "DELETE must restrict rule_id to the system_alert rule via subquery."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. upgrade — narrow recipient restore (undo Phase 0 only)
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_restores_all_users_recipient(migration):
+    src = inspect.getsource(migration.upgrade)
+    assert "UPDATE notification_rule" in src
+    assert '"resolver_type": "all_users"' in src
+
+
+def test_upgrade_recipient_predicate_is_narrow_all_admins(migration):
+    """Predicate must match ONLY all_admins (Phase 0 state). A broad
+    ``WHERE event='system_alert'`` would clobber a custom resolver an
+    operator legitimately set."""
+    src = inspect.getsource(migration.upgrade)
+    assert "recipient_config->>'resolver_type' = 'all_admins'" in src
+
+
+def test_upgrade_recipient_cast_is_json_not_jsonb(migration):
+    """recipient_config is a JSON column (models/notification.py) — keep
+    ``::json``, not ``::jsonb``."""
+    src = inspect.getsource(migration.upgrade)
+    assert "::json" in src
+    assert "::jsonb" not in src
+
+
+# ---------------------------------------------------------------------------
+# 4. downgrade — idempotent re-insert, recipient untouched
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_reinserts_zalo_bot_idempotently(migration):
+    src = inspect.getsource(migration.downgrade)
+    assert "INSERT INTO notification_action" in src
+    assert "NOT EXISTS" in src, "Re-insert must be guarded to avoid duplicates."
+    assert '"seeded_by": "zalobot002"' in src
+
+
+def test_downgrade_scoped_to_system_alert(migration):
+    src = inspect.getsource(migration.downgrade)
+    assert "nr.event = 'system_alert'" in src
+
+
+def test_downgrade_does_not_touch_recipient_config(migration):
+    """recipient all_users is the seed default — downgrade must NOT revert it
+    (that is not a state needing reversal)."""
+    src = inspect.getsource(migration.downgrade)
+    assert "UPDATE notification_rule" not in src, (
+        "Downgrade must not modify recipient_config."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. SQL hygiene — literal sa.text, no f-string interpolation
+# ---------------------------------------------------------------------------
+
+
+def test_uses_sa_text_literal_not_fstring(module_src):
+    assert "sa.text(" in module_src
+    # No f-string op.execute (zalobot002 used f"..."; this migration is clean).
+    assert "op.execute(f" not in module_src
+    assert 'op.execute(\n            f"' not in module_src

--- a/Backend_FastAPI/tests/unit/test_notification_contract.py
+++ b/Backend_FastAPI/tests/unit/test_notification_contract.py
@@ -447,6 +447,10 @@ class TestUserEventsHaveDispatchCallers:
         "user_deactivated", "user_profile_updated", "pipeline_config_updated",
         "officer_availability_changed", "suspicious_login",
         "holiday_calendar_incomplete",
+        # fix/notification-alert-flood (2026-06-01): admin-only operational
+        # health alert. Dispatched from app/tasks/delivery_tasks.py
+        # ``check_notification_alerts`` (replaced the SYSTEM_ALERT fan-out).
+        "notification_health_alert",
         # PR-Audit-1: dispatched from zalo_bot_link_service.verify_and_link
         # post_commit closure when chat_id displacement happens.
         "zalo_bot_link_displaced",

--- a/Backend_FastAPI/tests/unit/test_notification_d3.py
+++ b/Backend_FastAPI/tests/unit/test_notification_d3.py
@@ -5,7 +5,7 @@ Covers: failure rate alert, backlog alert, webhook lag alert, breaker alert, ded
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 
 class TestFailureRateAlert:
@@ -360,3 +360,191 @@ class TestRunAllChecksSessionSafety:
             "Circuit breaker alert must still fire when all DB checks fail — "
             "it does not depend on the shared session."
         )
+
+
+# =============================================================================
+# fix/notification-alert-flood — F-metric: exclude self-referential event
+# =============================================================================
+
+
+class TestHealthChecksExcludeOperationalEvent:
+    """The failure-rate + backlog checks must exclude the operational
+    ``notification_health_alert`` event so the health task never measures
+    its own fan-out (self-feeding loop). See plan Finding 3."""
+
+    @pytest.mark.asyncio
+    async def test_failure_rate_passes_operational_exclude(self):
+        from app.services.notification_alert_service import (
+            check_failure_rate_alert,
+            _OPERATIONAL_ALERT_EVENTS,
+        )
+
+        # The exclude set must contain ONLY the self-referential event —
+        # NOT system_alert (a real admin broadcast post-Approach-Y).
+        assert _OPERATIONAL_ALERT_EVENTS == ["notification_health_alert"]
+
+        mock_db = AsyncMock()
+        with patch(
+            "app.services.notification_alert_service.NotificationDeliveryRepository"
+        ) as MockRepo, patch(
+            "app.services.notification_alert_service.settings"
+        ) as mock_settings:
+            mock_settings.ALERT_FAILURE_RATE_THRESHOLD = 0.20
+            repo = AsyncMock()
+            repo.get_failure_rate = AsyncMock(return_value=0.05)
+            MockRepo.return_value = repo
+
+            await check_failure_rate_alert(mock_db)
+            repo.get_failure_rate.assert_awaited_once_with(
+                minutes=30, exclude_events=_OPERATIONAL_ALERT_EVENTS
+            )
+
+    @pytest.mark.asyncio
+    async def test_backlog_passes_operational_exclude(self):
+        from app.services.notification_alert_service import (
+            check_backlog_alert,
+            _OPERATIONAL_ALERT_EVENTS,
+        )
+
+        mock_db = AsyncMock()
+        with patch(
+            "app.services.notification_alert_service.NotificationDeliveryRepository"
+        ) as MockRepo, patch(
+            "app.services.notification_alert_service.settings"
+        ) as mock_settings:
+            mock_settings.ALERT_BACKLOG_THRESHOLD = 500
+            repo = AsyncMock()
+            repo.get_queued_backlog_count = AsyncMock(return_value=10)
+            MockRepo.return_value = repo
+
+            await check_backlog_alert(mock_db)
+            repo.get_queued_backlog_count.assert_awaited_once_with(
+                exclude_events=_OPERATIONAL_ALERT_EVENTS
+            )
+
+
+# =============================================================================
+# fix/notification-alert-flood — task dispatch: event routing + F-info
+# =============================================================================
+
+
+class _FakeSessionCM:
+    """Minimal async-context-manager standing in for ``task_db_session()``."""
+
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class TestAlertTaskDispatch:
+    """``check_notification_alerts`` task: dispatches via NOTIFICATION_HEALTH_ALERT
+    (not SYSTEM_ALERT), skips info-severity, respects/skips preference by
+    severity, and counts only what it actually dispatched.
+
+    Invoked synchronously (``.apply().get()``) with the alert source and
+    dispatcher mocked — same celery-eager idiom as the reminder-task tests.
+    Sync test so ``run_async_task`` takes the ``run_until_complete`` branch.
+    """
+
+    def _run_task(self, alerts, dispatch_return=None):
+        from app.tasks import delivery_tasks
+
+        # Default: safe_dispatch created 1 notification (truthy). Pass [] to
+        # simulate "no enabled rule / no recipient / swallowed failure".
+        if dispatch_return is None:
+            dispatch_return = [1]
+        mock_session = AsyncMock()
+        dispatch_mock = AsyncMock(return_value=dispatch_return)
+        with patch.object(
+            delivery_tasks, "task_db_session",
+            return_value=_FakeSessionCM(mock_session),
+        ), patch(
+            "app.services.notification_alert_service.run_all_checks",
+            new=AsyncMock(return_value=alerts),
+        ), patch(
+            "app.services.notification_dispatcher.safe_dispatch",
+            new=dispatch_mock,
+        ):
+            result = delivery_tasks.check_notification_alerts.apply().get()
+        return result, dispatch_mock
+
+    def test_warning_and_error_dispatched_info_skipped(self):
+        alerts = [
+            {"alert_type": "failure_rate_high", "severity": "warning", "message": "warn"},
+            {"alert_type": "webhook_lag", "severity": "info", "message": "lag"},
+            {"alert_type": "breaker_open", "severity": "error", "message": "breaker"},
+        ]
+        result, dispatch_mock = self._run_task(alerts)
+
+        assert dispatch_mock.await_count == 2, "info-severity alert must NOT dispatch"
+        assert result["fired"] == 2, "metric counts real dispatches, not len(alerts)"
+        assert result["skipped_info"] == 1
+        assert set(result["types"]) == {"failure_rate_high", "breaker_open"}
+
+    def test_dispatch_uses_health_alert_event_and_payload(self):
+        from app.core.events import SystemEvents
+
+        alerts = [
+            {"alert_type": "failure_rate_high", "severity": "warning", "message": "warn"}
+        ]
+        _, dispatch_mock = self._run_task(alerts)
+
+        kwargs = dispatch_mock.await_args.kwargs
+        assert kwargs["event"] == SystemEvents.NOTIFICATION_HEALTH_ALERT, (
+            "Health alert must dispatch via NOTIFICATION_HEALTH_ALERT, never "
+            "SYSTEM_ALERT (which fans out to all_users)."
+        )
+        assert kwargs["payload"]["alert_type"] == "failure_rate_high"
+        assert kwargs["payload"]["severity"] == "warning"
+        assert kwargs["payload"]["message"] == "warn"
+        assert kwargs["rooms"] == ["role_admin"]
+        # warning → respects operator preference (they may opt out)
+        assert kwargs["skip_preference_check"] is False
+
+    def test_error_severity_skips_preference_check(self):
+        alerts = [
+            {"alert_type": "breaker_open", "severity": "error", "message": "breaker"}
+        ]
+        _, dispatch_mock = self._run_task(alerts)
+
+        kwargs = dispatch_mock.await_args.kwargs
+        assert kwargs["skip_preference_check"] is True, (
+            "error severity (e.g. breaker_open) must reach operators even if "
+            "they muted system-group email."
+        )
+
+    def test_all_info_alerts_dispatch_nothing(self):
+        alerts = [
+            {"alert_type": "webhook_lag", "severity": "info", "message": "lag"}
+        ]
+        result, dispatch_mock = self._run_task(alerts)
+
+        assert dispatch_mock.await_count == 0
+        assert result["fired"] == 0
+        assert result["skipped_info"] == 1
+
+    def test_no_alerts_returns_zero(self):
+        result, dispatch_mock = self._run_task([])
+
+        assert dispatch_mock.await_count == 0
+        assert result["fired"] == 0
+
+    def test_empty_dispatch_result_not_counted_as_fired(self):
+        """safe_dispatch returning [] (no synced rule / no resolved recipient /
+        swallowed failure) must NOT inflate ``fired`` — otherwise the metric
+        masks exactly the fail-silent case the rollout gate watches for
+        (notification_health_alert rule not yet in the DB)."""
+        alerts = [
+            {"alert_type": "failure_rate_high", "severity": "warning", "message": "warn"},
+            {"alert_type": "breaker_open", "severity": "error", "message": "breaker"},
+        ]
+        result, dispatch_mock = self._run_task(alerts, dispatch_return=[])
+
+        assert dispatch_mock.await_count == 2, "dispatch is still attempted"
+        assert result["fired"] == 0, "empty dispatch result must not count as fired"
+        assert result["types"] == []


### PR DESCRIPTION
## Vấn đề
Beat task `check_notification_alerts` (mỗi 5'') dispatch `SYSTEM_ALERT` — rule này resolve `all_users` + có action `zalo_bot`. Mỗi tick health-check fanout ~15 email cho toàn nhân sự + 9-10 delivery `zalo_bot` `dead_lettered` (`no_zalo_bot_link`). Các dead-letter đó bơm `get_failure_rate(30')` vượt ngưỡng 20% → tự kích `failure_rate_high` chu kỳ sau (vòng lặp flood, ~360 email/7 ngày).

## Cách fix (Approach Y + F-info + F-metric)
- **Event riêng**: `SystemEvents.NOTIFICATION_HEALTH_ALERT` — catalog `all_admins`, channels `browser+email`, group `SYSTEM` (zalo_bot=False), `class=user` + seed default; **không** thêm vào `LEGACY_REGISTRY_EVENTS`. Task dispatch event mới với `rooms=[role_admin]` + `alert_type`; `error` bỏ qua preference (phải tới operator), `warning` tôn trọng preference.
- **F-info**: alert severity `info` (webhook_lag) chỉ log, không dispatch.
- **F-metric**: `get_failure_rate`/`get_queued_backlog_count` thêm `exclude_events`; alert service loại `_OPERATIONAL_ALERT_EVENTS` → health task không đo fanout của chính nó. `fired` chỉ đếm delivery THẬT — `safe_dispatch` trả `[]` (rule chưa sync / không ra recipient) **không** tính fired mà log warning, lộ đúng fail-silent case.
- **Migration `naflood001`**: drop action `zalo_bot` của `system_alert` (scoped, marker `zalobot002`) + khôi phục recipient `all_users` qua predicate hẹp `='all_admins'` (undo Phase 0 mitigation, idempotent). Downgrade re-insert idempotent, không đụng recipient.

## Verification
- CI Tier 3 notification đầy đủ: **107 passed** + coverage gate xanh.
- Test mới: task event/payload/rooms + info-skip + empty-result-không-đếm; alert-service exclude; repo `get_failure_rate`/backlog exclude (integration); migration contract.
- Migration roundtrip trên **dữ liệu dev thật** (txn rollback, zero mutation): scoped DELETE (9 pilot event khác nguyên vẹn), recipient no-op/flip/giữ-custom đúng, downgrade idempotent.

## Phạm vi / liên quan
- Đây là **Phase 1 PR-A** (code fix gốc, không cần prod).
- **Phase 0** (mitigate prod) chỉ làm nếu flood còn gây nhiễu trước khi PR-A deploy — Step 7 migration tự undo Phase 0 idempotent.
- **Phase 2 PR-B** (suspicious_login IP risk-gate) tách branch riêng.
- Test-debt 4 event stale-whitelist (`admission_waitlist_rejected`, `priority_*`) là pre-existing, defer PR riêng — không nằm trong CI per-PR Tier 3.

## Deploy
merge → `alembic upgrade head` (naflood001) → `sync_notification_rules` tạo rule `notification_health_alert`. ⚠️ Sau deploy xác nhận rule `notification_health_alert` TỒN TẠI trong DB + `RUN_SYNC_NOTIFICATION_RULES_ON_STARTUP` không bị set `false` (fail-mode = mất cảnh báo im lặng).

🤖 Generated with [Claude Code](https://claude.com/claude-code)