### PR TITLE
fix(auth): risk-gate suspicious-login email to in-app for IP-only anomalies

### DIFF
--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -171,6 +171,15 @@ class Settings(BaseSettings):
     ANOMALY_UNUSUAL_LOGIN_END_HOUR: int = Field(
         default=6, validation_alias="ANOMALY_UNUSUAL_LOGIN_END_HOUR"
     )  # End of unusual login hours (local time)
+    # Risk-gate for suspicious-login EMAIL/zalo dispatch. risk_score weights
+    # (login_history_service.RISK_WEIGHTS): new_ip 30 / new_device 40 /
+    # new_location 50 / impossible_travel 80 (−20% if trusted device). A
+    # bare new_ip (30, or 24 trusted) falls BELOW 40 → in-app banner only,
+    # no email; new_device (40) and above keep all channels. Tunable without
+    # code change.
+    SUSPICIOUS_LOGIN_EMAIL_RISK_THRESHOLD: int = Field(
+        default=40, validation_alias="SUSPICIOUS_LOGIN_EMAIL_RISK_THRESHOLD"
+    )
 
     # -- Security: Socket Rate Limiting --
     SOCKET_MAX_CONN_PER_MINUTE: int = Field(

--- a/Backend_FastAPI/app/routers/auth.py
+++ b/Backend_FastAPI/app/routers/auth.py
@@ -1,5 +1,5 @@
 # app/routers/auth.py
-from typing import Annotated
+from typing import Annotated, List, Optional
 
 import structlog
 from fastapi import (
@@ -47,6 +47,24 @@ from ..core.events import SystemEvents  # Security: Event registry
 
 router = APIRouter(tags=["Authentication"])
 log = structlog.get_logger(__name__)
+
+
+def _suspicious_login_only_channels(risk_score: int) -> Optional[List[str]]:
+    """Channel filter for a suspicious-login dispatch, by risk score.
+
+    Below ``SUSPICIOUS_LOGIN_EMAIL_RISK_THRESHOLD`` (a bare new-IP login =
+    30, or 24 on a trusted device — IP churn on mobile/dynamic ISPs) →
+    return ``["browser"]`` so only the in-app banner fires, no email/zalo.
+    At/above the threshold (new_device 40, new_location 50, impossible-travel
+    80, and any combination) → return ``None`` = all channels per the rule.
+
+    In-app banner + login_history are recorded for EVERY anomaly regardless —
+    only the email/zalo fan-out is risk-gated. Pure function so the decision
+    is unit-testable without a full login flow.
+    """
+    if risk_score >= settings.SUSPICIOUS_LOGIN_EMAIL_RISK_THRESHOLD:
+        return None
+    return ["browser"]
 
 
 # =============================================================================
@@ -185,6 +203,12 @@ async def _complete_login_flow(
                 "actor_id": _notif_user_id,
             }
 
+            # Phase 2 PR-B: risk-gate the EMAIL/zalo channels (see helper).
+            # Snapshot to a plain value (not ORM) for the post-commit closure.
+            _notif_only_channels = _suspicious_login_only_channels(
+                login_record.risk_score
+            )
+
             # Option-B Commit 7: DO NOT pass ``rooms_for_user`` for the
             # SUSPICIOUS_LOGIN event. The dispatcher computes the socket
             # rooms itself, gated by each user's ``browser`` notification
@@ -201,6 +225,7 @@ async def _complete_login_flow(
                             event=SystemEvents.SUSPICIOUS_LOGIN,
                             payload=_notif_payload,
                             rooms=None,
+                            only_channels=_notif_only_channels,
                         )
                 except Exception as notif_error:
                     log.error("Failed to dispatch suspicious login notification",

--- a/Backend_FastAPI/app/services/notification_dispatcher.py
+++ b/Backend_FastAPI/app/services/notification_dispatcher.py
@@ -641,6 +641,28 @@ async def _apply_delivery_deduplication(
         return user_ids
 
 
+def _validate_only_channels(only_channels: Optional[List[str]]) -> None:
+    """Fail-fast validation for the ``only_channels`` dispatch filter.
+
+    ``None`` = no restriction (default). A non-empty list must contain only
+    canonical channels — ``validate_channels_for_write`` raises ``ValueError``
+    on a typo (e.g. ``["brower"]``) or legacy ``"socket"``. An EMPTY list also
+    raises: silently filtering every action out would swallow a security
+    notification (e.g. suspicious-login). MUST be called BEFORE
+    ``safe_dispatch``'s try/except, which absorbs all exceptions and would
+    otherwise turn a typo into a silent zero-notification dispatch.
+    """
+    if only_channels is None:
+        return
+    if not only_channels:
+        raise ValueError(
+            "only_channels must be a non-empty list of canonical channels; "
+            "use None for no restriction."
+        )
+    from app.services.notification_channels import validate_channels_for_write
+    validate_channels_for_write(only_channels)  # raises on unknown / 'socket'
+
+
 async def dispatch(
     db: AsyncSession,
     event: SystemEvents,
@@ -649,6 +671,7 @@ async def dispatch(
     skip_preference_check: bool = False,
     strict: bool = False,
     rooms: Optional[List[str]] = None,
+    only_channels: Optional[List[str]] = None,
 ) -> Tuple[List[int], Optional[Callable]]:
     """
     Dispatch a notification event — caller-controlled transaction.
@@ -685,6 +708,12 @@ async def dispatch(
                events (org/pipeline config) may pass None and broadcast.
                Use ``rooms_for_admission(profile)`` / ``rooms_for_lead(lead)``
                / ``rooms_for_user(user_id)`` helpers at the call site.
+        only_channels: Optional whitelist of canonical channels. When set,
+                       only actions whose channel is in this list are
+                       dispatched (in-app + external alike); the rest are
+                       dropped. ``None`` (default) = all channels per the
+                       rule. Used to gate low-risk suspicious-login to
+                       browser-only without a per-action condition system.
 
     Returns:
         Tuple of (notification_ids, post_commit_callback)
@@ -714,6 +743,11 @@ async def dispatch(
         dedupe_key=dedupe_key,
         payload_keys=list(payload.keys())
     )
+
+    # Validate the channel filter up-front (fail-fast). Done here AND in
+    # safe_dispatch (before its swallowing try) so a typo never silently
+    # filters every action out.
+    _validate_only_channels(only_channels)
 
     # Step 1: PR1 single-path — catalog + DB rule, no registry fallback
     from app.utils.exceptions import NotificationConfigError
@@ -843,6 +877,13 @@ async def dispatch(
 
     rule_resolver = config.resolver
     action_configs = config.actions  # List[ActionConfig]
+    if only_channels is not None:
+        # Restrict to the requested channels (already validated above).
+        # Reassigning action_configs HERE — before has_external_actions and
+        # every downstream action loop (internal resolution, external
+        # resolver, enqueue) — propagates the filter to all paths, so no
+        # non-selected channel can leak a delivery through any branch.
+        action_configs = [a for a in action_configs if a.channel in only_channels]
     action_user_map: Dict[int, List[int]] = {}  # step -> user_ids
 
     # Pre-compute: does ANY non-browser action have external_resolver?
@@ -1972,6 +2013,7 @@ async def safe_dispatch(
     dedupe_key: Optional[str] = None,
     skip_preference_check: bool = False,
     rooms: Optional[List[str]] = None,
+    only_channels: Optional[List[str]] = None,
 ) -> List[int]:
     """
     Fire-and-forget dispatch — commits + runs callback + swallows errors.
@@ -2000,12 +2042,20 @@ async def safe_dispatch(
         payload: Event payload with data for resolution and templates
         dedupe_key: Optional deduplication key
         skip_preference_check: Skip user preference filtering
+        only_channels: Optional whitelist of canonical channels — drop all
+            other actions. ``None`` = all channels. Validated before the
+            try/except so a typo raises instead of silently dropping.
 
     Returns:
         List of created notification IDs (empty on failure)
 
     See also: ``dispatch()`` for the caller-controlled transaction variant.
     """
+    # Validate the channel filter BEFORE the try/except below — that block
+    # swallows ALL exceptions and returns []. A typo inside dispatch() would
+    # be absorbed and silently drop the notification; validating here makes
+    # it raise loudly to the caller instead.
+    _validate_only_channels(only_channels)
     try:
         notif_ids, notif_cb = await dispatch(
             db=db,
@@ -2014,6 +2064,7 @@ async def safe_dispatch(
             dedupe_key=dedupe_key,
             skip_preference_check=skip_preference_check,
             rooms=rooms,
+            only_channels=only_channels,
         )
         await db.commit()
         if notif_cb:

--- a/Backend_FastAPI/tests/services/test_notification_dispatcher.py
+++ b/Backend_FastAPI/tests/services/test_notification_dispatcher.py
@@ -382,7 +382,139 @@ class TestNotificationDispatcher:
         
         # Act
         notification_ids, _ = await dispatch(db, event, {"user_id": user_id})
-        
+
         # Assert
         # Should be empty because preference filtered out the only channel
         assert len(notification_ids) == 0
+
+    # =====================================================================
+    # Phase 2 PR-B: only_channels filter (suspicious-login risk-gate)
+    # =====================================================================
+
+    async def _seed_browser_email_rule(self, db, event):
+        """Seed an enabled rule with BOTH a browser and an email action."""
+        rule = models.NotificationRule(
+            event=event.value,
+            title_template="T",
+            message_template="M",
+            recipient_config={"resolver_type": "specific_users", "params": {}},
+            enabled=True,
+        )
+        db.add(rule)
+        await db.flush()
+        await db.refresh(rule)
+        db.add(models.NotificationAction(
+            rule_id=rule.id, step=1, channel="browser",
+            content_mode="inherit_default",
+        ))
+        db.add(models.NotificationAction(
+            rule_id=rule.id, step=2, channel="email",
+            content_mode="inherit_default",
+        ))
+        await db.commit()
+        from app.services.notification_rule_loader import invalidate_rule_cache
+        await invalidate_rule_cache(event.value)
+
+    async def _delivery_channels(self, db, event):
+        result = await db.execute(
+            select(models.NotificationDelivery.channel)
+            .where(models.NotificationDelivery.event == event.value)
+        )
+        return set(result.scalars().all())
+
+    async def test_only_channels_browser_filters_out_email(
+        self, db: AsyncSession, officer_user_in_db: dict, clear_redis_keys, mocker
+    ):
+        """only_channels=['browser'] drops the email action entirely — only
+        a browser delivery row is created, and the email worker is never
+        enqueued."""
+        user_id = officer_user_in_db["id"]
+        event = SystemEvents.SYSTEM_ALERT
+        await self._seed_browser_email_rule(db, event)
+
+        mocker.patch(
+            "app.services.notification_dispatcher._emit_domain_event",
+            new_callable=AsyncMock,
+        )
+        mocker.patch(
+            "app.services.notification_dispatcher._send_via_channel",
+            new_callable=AsyncMock,
+            return_value=("browser", MagicMock(sent_count=1, failed_ids=[], success=True), None),
+        )
+        enqueue = mocker.patch(
+            "app.tasks.delivery_tasks.execute_notification_delivery.apply_async"
+        )
+
+        ids, cb = await dispatch(
+            db, event,
+            {"user_id": user_id, "severity": "warning", "message": "x"},
+            only_channels=["browser"],
+        )
+        if cb:
+            await cb()
+        await db.commit()
+
+        channels = await self._delivery_channels(db, event)
+        assert channels == {"browser"}, (
+            f"only_channels=['browser'] must drop email; got delivery channels {channels}"
+        )
+        enqueue.assert_not_called()  # email action filtered → no worker enqueue
+
+    async def test_default_none_dispatches_all_channels(
+        self, db: AsyncSession, officer_user_in_db: dict, clear_redis_keys, mocker
+    ):
+        """Regression: without only_channels, BOTH browser and email actions
+        produce delivery rows (default behaviour unchanged)."""
+        user_id = officer_user_in_db["id"]
+        event = SystemEvents.SYSTEM_ALERT
+        await self._seed_browser_email_rule(db, event)
+
+        mocker.patch(
+            "app.services.notification_dispatcher._emit_domain_event",
+            new_callable=AsyncMock,
+        )
+        mocker.patch(
+            "app.services.notification_dispatcher._send_via_channel",
+            new_callable=AsyncMock,
+            return_value=("browser", MagicMock(sent_count=1, failed_ids=[], success=True), None),
+        )
+        mocker.patch(
+            "app.tasks.delivery_tasks.execute_notification_delivery.apply_async"
+        )
+
+        ids, cb = await dispatch(
+            db, event,
+            {"user_id": user_id, "severity": "warning", "message": "x"},
+        )
+        if cb:
+            await cb()
+        await db.commit()
+
+        channels = await self._delivery_channels(db, event)
+        assert {"browser", "email"} <= channels, (
+            f"default (only_channels=None) must dispatch all channels; got {channels}"
+        )
+
+    async def test_only_channels_typo_raises_value_error(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        """A typo'd channel raises ValueError up front — it must NOT silently
+        filter everything out (which would swallow the notification)."""
+        with pytest.raises(ValueError):
+            await dispatch(
+                db, SystemEvents.SYSTEM_ALERT,
+                {"user_id": officer_user_in_db["id"]},
+                only_channels=["brower"],  # typo
+            )
+
+    async def test_only_channels_empty_raises_value_error(
+        self, db: AsyncSession, officer_user_in_db: dict
+    ):
+        """An empty list is rejected (deliberate raise, not no-op) so an
+        accidental [] can't silently drop a security notification."""
+        with pytest.raises(ValueError):
+            await dispatch(
+                db, SystemEvents.SYSTEM_ALERT,
+                {"user_id": officer_user_in_db["id"]},
+                only_channels=[],
+            )

--- a/Backend_FastAPI/tests/unit/test_suspicious_login_risk_gate.py
+++ b/Backend_FastAPI/tests/unit/test_suspicious_login_risk_gate.py
@@ -1,0 +1,42 @@
+"""Unit tests: suspicious-login email/zalo risk-gate (Phase 2 PR-B).
+
+The decision "which channels does a suspicious-login dispatch use?" is
+extracted into ``auth._suspicious_login_only_channels`` so it can be tested
+without driving a full login flow. risk_score weights come from
+``login_history_service.RISK_WEIGHTS`` (new_ip 30 / new_device 40 /
+new_location 50 / impossible_travel 80, −20% trusted).
+"""
+
+
+class TestSuspiciousLoginChannelGate:
+    def test_new_ip_only_below_threshold_browser_only(self):
+        from app.routers.auth import _suspicious_login_only_channels
+        # bare new_ip = 30 < 40 → in-app banner only, NO email
+        assert _suspicious_login_only_channels(30) == ["browser"]
+
+    def test_trusted_new_ip_below_threshold_browser_only(self):
+        from app.routers.auth import _suspicious_login_only_channels
+        # new_ip on a trusted device = int(30 * 0.8) = 24 < 40
+        assert _suspicious_login_only_channels(24) == ["browser"]
+
+    def test_new_device_at_threshold_all_channels(self):
+        from app.routers.auth import _suspicious_login_only_channels
+        # new_device = 40 >= 40 → all channels (email fires)
+        assert _suspicious_login_only_channels(40) is None
+
+    def test_new_ip_plus_new_device_all_channels(self):
+        from app.routers.auth import _suspicious_login_only_channels
+        # 30 + 40 = 70 >= 40 → all channels
+        assert _suspicious_login_only_channels(70) is None
+
+    def test_zero_risk_is_browser_only(self):
+        from app.routers.auth import _suspicious_login_only_channels
+        assert _suspicious_login_only_channels(0) == ["browser"]
+
+    def test_threshold_is_config_tunable_not_hardcoded(self, monkeypatch):
+        from app.config import settings
+        from app.routers import auth
+        # Raise the bar to 50 → new_device (40) now falls below → browser-only.
+        monkeypatch.setattr(settings, "SUSPICIOUS_LOGIN_EMAIL_RISK_THRESHOLD", 50)
+        assert auth._suspicious_login_only_channels(40) == ["browser"]
+        assert auth._suspicious_login_only_channels(50) is None


### PR DESCRIPTION
## Vấn đề
Sau fix fingerprint thiết bị (2026-05-24), ~100% cờ `suspicious_login` 7-14 ngày qua là **new-IP đơn thuần** (IP động mobile/ISP), mỗi cái bắn 1 email + zalo người dùng không thao tác được — ~119 email/14 ngày. `is_new_ip` không gate theo risk, không giảm bởi trusted device, không có GeoIP nên `is_new_location` vô hiệu.

## Cách fix (gate kênh theo rủi ro ở call-site)
Không có hệ thống condition cấp action → lọc kênh tại call-site:
- **`dispatch()` / `safe_dispatch()`** thêm `only_channels`: whitelist canonical channels đã validate. Lọc bằng cách reassign `action_configs` **ngay sau `config.actions`** — TRƯỚC `has_external_actions`, recipient resolution, external resolver, và worker-enqueue loop — nên không kênh non-selected nào lọt qua bất kỳ nhánh. Default `None` = mọi kênh (không đổi hành vi).
- **`_validate_only_channels()`** fail-fast, chạy **TRƯỚC try/except nuốt lỗi của `safe_dispatch`**: typo (`["brower"]`) / list rỗng → raise `ValueError` thay vì âm thầm drop cảnh báo bảo mật. `None` = không hạn chế.
- **`auth._suspicious_login_only_channels(risk_score)`**: dưới `SUSPICIOUS_LOGIN_EMAIL_RISK_THRESHOLD` (=40 — new_ip đơn = 30, hoặc 24 khi trusted) → `["browser"]` (chỉ in-app banner); ≥ ngưỡng (new_device 40 / new_location 50 / impossible_travel 80 / tổ hợp) → `None` (mọi kênh theo rule). In-app banner + `login_history` GIỮ cho MỌI anomaly — chỉ email/zalo bị gate.

Ngưỡng tunable qua env `SUSPICIOUS_LOGIN_EMAIL_RISK_THRESHOLD`.

## Tests
- Dispatcher integration: default all-channel / browser-only lọc email / typo raise / empty raise.
- Auth helper unit: ranh giới risk (30/24→browser, 40/70→None) + config tunability.
- Full CI Tier 3 (111) + auth/security E2E (23) regression-clean.

## Phạm vi
- **Phase 2 PR-B** của hotfix notification flood; độc lập với PR-A (#363, đã merge+deploy). Branch off `main` (đã có PR-A).
- Hoãn (ngoài scope): GeoIP (`country` luôn NULL → location/impossible-travel vô hiệu); ngưỡng 40 đã sẵn sàng tính cả 2 khi bật GeoIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)