### PR TITLE
security: backend hardening — close 9 audit findings (PR1)

### DIFF
--- a/Backend_FastAPI/alembic/versions/docdl_audit_001_allow_downloaded_action.py
+++ b/Backend_FastAPI/alembic/versions/docdl_audit_001_allow_downloaded_action.py
@@ -1,0 +1,77 @@
+"""Allow 'downloaded' in document_audit_log.action CHECK constraint.
+
+Revision ID: docdl_audit_001
+Revises: naflood001
+Create Date: 2026-06-01
+
+PR1 Commit 1 (Gap 1 — A09 Logging). The new authed document-download
+endpoint
+    GET /api/admissions/{profile_id}/documents/{document_id}/download
+records a ``downloaded`` audit row so PII document access (CCCD, học bạ,
+priority evidence) leaves a trail — the previous public ``/uploads``
+static serve logged nothing. ``DocumentAuditLog.action`` is gated by the
+DB CHECK constraint ``ck_document_audit_log_action``, whose enum did NOT
+include ``downloaded``; inserting it would raise IntegrityError. This
+migration widens the constraint by one value.
+
+upgrade()
+---------
+DROP + re-ADD ``ck_document_audit_log_action`` with ``'downloaded'``
+appended. Additive only — every previously-valid value stays valid, so
+no existing row can violate the new constraint. ``DROP ... IF EXISTS``
+keeps it idempotent.
+
+downgrade()
+-----------
+Restore the original 6-value enum. SAFE because ``downloaded`` rows are
+append-only audit records that no business logic reads; if any exist the
+downgrade would fail the re-ADD (Postgres validates existing rows), which
+is the correct fail-closed signal that the new action is already in use —
+purge or retain those rows deliberately before downgrading.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "docdl_audit_001"
+down_revision: Union[str, None] = "naflood001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_OLD = "('uploaded','verified','rejected','reset','paper_submitted','deleted')"
+_NEW = "('uploaded','verified','rejected','reset','paper_submitted','deleted','downloaded')"
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "ALTER TABLE document_audit_log "
+            "DROP CONSTRAINT IF EXISTS ck_document_audit_log_action;"
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE document_audit_log "
+            "ADD CONSTRAINT ck_document_audit_log_action "
+            f"CHECK (action IN {_NEW});"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "ALTER TABLE document_audit_log "
+            "DROP CONSTRAINT IF EXISTS ck_document_audit_log_action;"
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE document_audit_log "
+            "ADD CONSTRAINT ck_document_audit_log_action "
+            f"CHECK (action IN {_OLD});"
+        )
+    )

--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -261,6 +261,25 @@ class Settings(BaseSettings):
                 "CRITICAL: DEVICE_FINGERPRINT_SALT is still the default value. "
                 "Generate with: openssl rand -base64 32"
             )
+        # PR1 Commit 6: MFA TOTP secrets are encrypted at rest with this key
+        # via Fernet (mfa_service._get_fernet -> Fernet(key)). A missing OR
+        # malformed key passes a naive "is set" check but crashes MFA at
+        # runtime ("Fernet key must be 32 url-safe base64-encoded bytes"), so
+        # validate the actual Fernet format here.
+        if not self.MFA_ENCRYPTION_KEY:
+            raise RuntimeError(
+                "CRITICAL: MFA_ENCRYPTION_KEY must be set in production."
+            )
+        try:
+            from cryptography.fernet import Fernet
+
+            Fernet(self.MFA_ENCRYPTION_KEY.encode())
+        except Exception as exc:
+            raise RuntimeError(
+                "CRITICAL: MFA_ENCRYPTION_KEY is not a valid Fernet key "
+                "(32 url-safe base64 bytes). Generate with: "
+                "Fernet.generate_key().decode()"
+            ) from exc
         if self.LOG_LEVEL == "DEBUG":
             raise RuntimeError(
                 "CRITICAL: LOG_LEVEL=DEBUG is not allowed in production. Use INFO or higher."

--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -68,6 +68,12 @@ class Settings(BaseSettings):
     FRONTEND_URL: str = Field(
         default="http://localhost:5173", validation_alias="FRONTEND_URL"
     )
+    # PR1 Commit 5: canonical public base URL of THIS backend. Used to build
+    # the MoMo IPN (server callback) URL instead of deriving it from the
+    # client-supplied return_url. Prod fail-fast: https + non-localhost.
+    PUBLIC_BACKEND_URL: str = Field(
+        default="http://localhost:8000", validation_alias="PUBLIC_BACKEND_URL"
+    )
     CORS_ORIGINS: str = Field(
         default="http://localhost:5173", validation_alias="CORS_ORIGINS"
     )  # Mặc định lấy từ FRONTEND_URL không hoạt động tốt với pydantic-settings, nên đặt giá trị mặc định rõ ràng
@@ -259,6 +265,24 @@ class Settings(BaseSettings):
             raise RuntimeError(
                 "CRITICAL: LOG_LEVEL=DEBUG is not allowed in production. Use INFO or higher."
             )
+
+        # PR1 Commit 5: payment-facing URLs must be HTTPS + non-localhost in
+        # production. FRONTEND_URL is echoed back to the user by the payment
+        # gateway (open-redirect surface) and PUBLIC_BACKEND_URL is the MoMo
+        # IPN host — localhost/HTTP would break callbacks or leak plaintext.
+        for _name, _url in (
+            ("FRONTEND_URL", self.FRONTEND_URL),
+            ("PUBLIC_BACKEND_URL", self.PUBLIC_BACKEND_URL),
+        ):
+            _u = _url.lower()
+            if not _u.startswith("https://"):
+                raise RuntimeError(
+                    f"CRITICAL: {_name} must use https:// in production."
+                )
+            if "localhost" in _u or "127.0.0.1" in _u:
+                raise RuntimeError(
+                    f"CRITICAL: {_name} points to localhost in production."
+                )
 
         # ✅ C1: Reject localhost/default DB URLs in production
         db_url_lower = self.DATABASE_URL.lower()

--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -161,6 +161,12 @@ async def get_current_user(
             )
             raise credentials_exception
 
+        # PR1 Commit 2: expose the live refresh jti (r_jti embedded in the
+        # access token) on request.state so /api/sessions can resolve
+        # is_current server-side without re-decoding the refresh cookie. Set
+        # here, after r_jti is validated non-None, on every authed request.
+        request.state.refresh_jti = refresh_jti
+
         # === STEP 2: CHECK ACCESS JTI BLACKLIST ===
         # (Kiểm tra xem chính Access Token này đã bị logout/xoay vòng chưa)
         try:

--- a/Backend_FastAPI/app/gateways/momo.py
+++ b/Backend_FastAPI/app/gateways/momo.py
@@ -92,6 +92,7 @@ class MoMoAdapter(BaseGatewayAdapter):
         endpoint: str = "https://test-payment.momo.vn/v2/gateway/api/create",
         request_type: str = "payWithMethod",
         auto_capture: bool = True,
+        public_backend_url: str = "",
     ):
         """
         Initialize MoMo adapter.
@@ -103,6 +104,7 @@ class MoMoAdapter(BaseGatewayAdapter):
             endpoint: MoMo API endpoint URL
             request_type: Payment type (payWithMethod, captureWallet, etc.)
             auto_capture: Whether to auto-capture payment
+            public_backend_url: Canonical backend base for the IPN URL
         """
         self.partner_code = partner_code
         self.access_key = access_key
@@ -110,6 +112,9 @@ class MoMoAdapter(BaseGatewayAdapter):
         self.endpoint = endpoint
         self.request_type = request_type
         self.auto_capture = auto_capture
+        # PR1 Commit 5: canonical backend base for the MoMo IPN URL (no longer
+        # derived from the client-supplied return_url).
+        self.public_backend_url = public_backend_url
 
     @property
     def gateway_code(self) -> str:
@@ -118,6 +123,13 @@ class MoMoAdapter(BaseGatewayAdapter):
     @property
     def gateway_name(self) -> str:
         return "MoMo"
+
+    def _build_ipn_url(self) -> str:
+        """Server-to-server IPN (callback) URL MoMo notifies. PR1 Commit 5:
+        built from the trusted PUBLIC_BACKEND_URL, never the client-supplied
+        return_url, so an attacker can't redirect MoMo's IPN to their host."""
+        base = self.public_backend_url.rstrip("/")
+        return f"{base}/api/payments/callback/momo"
 
     @classmethod
     def from_settings(cls, settings) -> "MoMoAdapter":
@@ -139,6 +151,7 @@ class MoMoAdapter(BaseGatewayAdapter):
                 "MOMO_ENDPOINT",
                 "https://test-payment.momo.vn/v2/gateway/api/create"
             ),
+            public_backend_url=getattr(settings, "PUBLIC_BACKEND_URL", ""),
         )
 
     async def create_payment_url(
@@ -181,9 +194,9 @@ class MoMoAdapter(BaseGatewayAdapter):
         if hasattr(intent, 'invoice') and intent.invoice:
             order_info = f"Thanh toan {intent.invoice.invoice_number}"
 
-        # Build IPN URL (callback URL for MoMo to notify)
-        # This should be configured in your application
-        ipn_url = return_url.replace("/return", "/callback/momo")
+        # IPN (server-to-server callback) URL — from PUBLIC_BACKEND_URL, never
+        # the client return_url (SSRF / redirect guard). See _build_ipn_url.
+        ipn_url = self._build_ipn_url()
 
         # Create raw signature string (MoMo format)
         raw_signature = (

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -777,8 +777,13 @@ async def add_security_headers(request: Request, call_next):
             "frame-ancestors 'none'"
         )
 
-    # ✅ Referrer Policy
-    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    # ✅ Referrer Policy — global default. A sensitive route (token/URL in the
+    # path: confirm-info, document download) may have already set a STRICTER
+    # value (no-referrer); use setdefault so that route-level override wins
+    # instead of being clobbered here (PR1 Commit 7).
+    response.headers.setdefault(
+        "Referrer-Policy", "strict-origin-when-cross-origin"
+    )
 
     # ✅ Permissions Policy (restrict browser features)
     response.headers["Permissions-Policy"] = (

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -917,67 +917,48 @@ async def detailed_health_check(db: AsyncSession = Depends(database.get_db)):
     """
     Kiểm tra sức khỏe chi tiết của API và các dịch vụ phụ thuộc.
     """
+    # PR1 Commit 6 (A02 Security Misconfiguration / A09): the RESPONSE is
+    # trimmed to a per-dependency up/down boolean — no exception class names,
+    # worker counts, or other internal detail that would aid reconnaissance
+    # from this public endpoint. Full diagnostics are still logged
+    # server-side; the overall 503 on any failure is kept for external uptime
+    # monitors. ``/health`` (the Docker/nginx healthcheck target) is unchanged.
     checks = {
-        "api": {"status": "ok", "message": "API is responsive"},
-        "database": {"status": "unknown", "message": ""},
-        "redis_cache": {"status": "unknown", "message": ""},
-        "celery_broker": {"status": "unknown", "message": ""},
+        "api": {"status": "up"},
+        "database": {"status": "down"},
+        "redis_cache": {"status": "down"},
+        "celery_broker": {"status": "down"},
     }
     is_healthy = True
 
-    # 1. Kiểm tra Database
+    # 1. Database
     try:
         await db.execute(text("SELECT 1"))
-        checks["database"]["status"] = "ok"
-        checks["database"]["message"] = "Database connection successful"
+        checks["database"]["status"] = "up"
     except Exception as e:
         is_healthy = False
-        checks["database"]["status"] = "error"
-        checks["database"][
-            "message"
-        ] = f"Database connection failed: {type(e).__name__}"
-        log.error(
-            "Health check failed (Database)", error=str(e)
-        )  # ✅ SỬA LỖI: Xóa `await`
+        log.error("Health check failed (Database)", error=str(e))
 
-    # 2. Kiểm tra Redis
+    # 2. Redis
     try:
         await safe_redis_ping()
-        checks["redis_cache"]["status"] = "ok"
-        checks["redis_cache"]["message"] = "Redis connection successful"
+        checks["redis_cache"]["status"] = "up"
     except Exception as e:
         is_healthy = False
-        checks["redis_cache"]["status"] = "error"
-        checks["redis_cache"][
-            "message"
-        ] = f"Redis connection failed: {type(e).__name__}"
-        log.error(
-            "Health check failed (Redis Cache)", error=str(e)
-        )  # ✅ SỬA LỖI: Xóa `await`
+        log.error("Health check failed (Redis Cache)", error=str(e))
 
-    # 3. Kiểm tra Celery
+    # 3. Celery
     try:
         inspect = celery_app.control.inspect(timeout=1.0)
         active_workers = await run_in_threadpool(inspect.active)
-
         if active_workers:
-            checks["celery_broker"]["status"] = "ok"
-            checks["celery_broker"][
-                "message"
-            ] = f"Found {len(active_workers)} active worker(s)."
+            checks["celery_broker"]["status"] = "up"
         else:
             is_healthy = False
-            checks["celery_broker"]["status"] = "error"
-            checks["celery_broker"]["message"] = "No active Celery workers found."
+            log.warning("Health check: no active Celery workers found")
     except Exception as e:
         is_healthy = False
-        checks["celery_broker"]["status"] = "error"
-        checks["celery_broker"][
-            "message"
-        ] = f"Celery check failed (broker down?): {type(e).__name__}"
-        log.error(
-            "Health check failed (Celery)", error=str(e)
-        )  # ✅ SỬA LỖI: Xóa `await`
+        log.error("Health check failed (Celery)", error=str(e))
 
     status_code = (
         status.HTTP_200_OK if is_healthy else status.HTTP_503_SERVICE_UNAVAILABLE

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -883,15 +883,14 @@ if STATIC_DIR.exists():
 else:
     log.warning(f"⚠️ Static directory not found at {STATIC_DIR}")
 
-# Mount uploads directory to serve uploaded documents (admissions, etc.)
-UPLOADS_DIR = Path(__file__).parent.parent / "uploads"
-if UPLOADS_DIR.exists():
-    fastapi_app.mount("/uploads", StaticFiles(directory=str(UPLOADS_DIR)), name="uploads")
-    log.info(f"✅ Uploads files mounted at /uploads from {UPLOADS_DIR}")
-else:
-    UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
-    fastapi_app.mount("/uploads", StaticFiles(directory=str(UPLOADS_DIR)), name="uploads")
-    log.info(f"✅ Uploads directory created and mounted at /uploads from {UPLOADS_DIR}")
+# SECURITY (PR1 Commit 1 — A01/A02): the public StaticFiles mount for
+# ``/uploads`` was REMOVED. Admission documents contain PII (CCCD, học bạ,
+# priority evidence) and must never be served unauthenticated. They are now
+# streamed through the authed, IDOR-scoped, audited endpoint
+#   GET /api/admissions/{profile_id}/documents/{document_id}/download
+# ``/static`` (avatars) stays public by design. The uploads directory itself
+# is still created on demand by the upload service (os.makedirs), so no mount
+# is needed here.
 
 
 # === ✅ CẢI TIẾN: Vấn đề #4 - Thêm Metrics Endpoint ===

--- a/Backend_FastAPI/app/models/admission_config/profile_data.py
+++ b/Backend_FastAPI/app/models/admission_config/profile_data.py
@@ -282,7 +282,7 @@ class DocumentAuditLog(Base):
         String(50),
         nullable=False,
         index=True,
-        comment="uploaded | verified | rejected | reset | paper_submitted | deleted"
+        comment="uploaded | verified | rejected | reset | paper_submitted | deleted | downloaded"
     )
 
     # Actor
@@ -395,7 +395,7 @@ class DocumentAuditLog(Base):
 
     __table_args__ = (
         CheckConstraint(
-            "action IN ('uploaded','verified','rejected','reset','paper_submitted','deleted')",
+            "action IN ('uploaded','verified','rejected','reset','paper_submitted','deleted','downloaded')",
             name="ck_document_audit_log_action"
         ),
     )

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -991,6 +991,23 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def get_document_by_id(
+        self,
+        document_id: int,
+    ) -> Optional[models.ProfileDocument]:
+        """Lookup a ProfileDocument by primary key.
+
+        Used by the authed document-download endpoint (PR1 Commit 1). The
+        caller binds the result to an already IDOR-authorized profile
+        (``doc.profile_id == profile.id``) before serving the file, so no
+        join/eager-load is needed here — only ``file_path`` is read.
+        """
+        stmt = select(models.ProfileDocument).where(
+            models.ProfileDocument.id == document_id
+        )
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()
+
     async def update_document_status(
         self,
         profile_id: int,

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -20,7 +20,7 @@ Endpoints:
 
 from datetime import datetime, timezone
 from typing import Dict, List, Literal, Optional
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status, UploadFile, File, Form
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status, UploadFile, File, Form
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
@@ -2109,9 +2109,13 @@ async def finalize_enrollment(
 async def get_confirm_token_info(
     request: Request,
     token: str,
+    response: Response,
     db: AsyncSession = Depends(database.get_db),
 ):
     """Get token info for frontend to display confirmation form."""
+    # PR1 Commit 7: the token is in the URL — don't leak it via the Referer
+    # header to anything the public confirm page subsequently loads.
+    response.headers["Referrer-Policy"] = "no-referrer"
     try:
         token_info = await admission_service.get_token_info(db, token)
         return token_info

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -883,6 +883,69 @@ async def upload_document(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "/{profile_id}/documents/{document_id}/download",
+    summary="Download an admission document (authed, IDOR-scoped, audited)",
+)
+async def download_document(
+    request: Request,
+    document_id: int,
+    profile: models.AdmissionProfile = Depends(get_admission_for_user_read),
+    current_user: models.User = Depends(deps.get_current_active_user),
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Stream a ProfileDocument file for staff (admin / manager / officer).
+
+    PR1 Commit 1 (A01/A05/A09). Access is gated by
+    ``get_admission_for_user_read`` (3-tier IDOR scope; non-staff and
+    out-of-scope callers get a fake 404). The document must belong to the
+    authorized profile and have a real file, otherwise 404 (no existence
+    leak). A ``downloaded`` audit row is committed before the file streams.
+    The public ``/uploads`` static mount was removed in the same commit, so
+    this is the ONLY way to read an admission document.
+    """
+    from fastapi.responses import FileResponse
+
+    try:
+        abs_path, safe_basename, media_type = (
+            await admission_service.get_document_file_for_download(
+                db=db,
+                profile=profile,
+                document_id=document_id,
+                actor_user_id=current_user.id,
+                actor_ip=get_client_ip(request),
+                actor_user_agent=request.headers.get("user-agent"),
+            )
+        )
+        # Persist the ``downloaded`` audit row before the response streams.
+        await db.commit()
+    except ResourceNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
+        )
+    except PermissionDeniedError:
+        # IDOR protection: 404, never 403, to avoid resource enumeration.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
+        )
+
+    return FileResponse(
+        abs_path,
+        media_type=media_type,
+        filename=safe_basename,
+        content_disposition_type="inline",
+        headers={
+            # PII document: never cache + don't leak the referrer + no MIME
+            # sniffing. nginx also sets nosniff globally; this keeps the
+            # contract correct when the backend is hit directly (dev/tests).
+            "Cache-Control": "private, no-store",
+            "Referrer-Policy": "no-referrer",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
 @limiter.limit(RateLimits.DATA_WRITE)
 @router.post(
     "/{profile_id}/documents/{doc_code}/paper-submitted",

--- a/Backend_FastAPI/app/routers/auth.py
+++ b/Backend_FastAPI/app/routers/auth.py
@@ -809,6 +809,15 @@ async def refresh_access_token(
     service_unavailable = HTTPException(
         status_code=503, detail="Auth service unavailable"
     )
+    # PR1 Commit 2: distinct 401 for session desync — the OLD jti is valid in
+    # Redis (the session:{jti} check passes) but has NO matching DB session row.
+    # That only happens for sessions frozen by the historical no-commit bug, so
+    # it is NOT abuse. A plain HTTPException (not the InvalidToken
+    # credentials_exception) routes to the ``except HTTPException`` arm and so
+    # bypasses the refresh-abuse counter / invalidate_all_sessions path below.
+    session_desync_exception = HTTPException(
+        status_code=401, detail="Session desynchronized. Please login again."
+    )
 
     # ✅ M4: Per-user rate limiting for failed refresh attempts
     # We extract username from token even on failure to track abuse
@@ -952,110 +961,164 @@ async def refresh_access_token(
 
                 # (Đã xóa logic active_jti)
 
-                # (STEP 6: Update Session - Giữ nguyên)
-                try:
-                    await session_service.update_session_activity(
-                        db=db,
-                        old_refresh_jti=old_refresh_jti,
-                        new_refresh_jti=new_refresh_jti,
-                        user_id=user.id,
-                    )
-                except Exception as session_error:
+                # (STEP 6: Update Session) — PR1 Commit 2
+                # Capture the return. ``None`` = the OLD jti has no matching DB
+                # session row. The Redis ``session:{jti}`` check already passed
+                # above, so a genuine reuse/forged token was already rejected;
+                # None here is a DESYNC from the historical no-commit bug. FATAL:
+                # force re-login instead of rotating a phantom session — this is
+                # the self-heal for FROZEN sessions (their next refresh 401s →
+                # clean re-login). Plain 401 so it does NOT feed the abuse
+                # counter. A real DB error PROPAGATES (fail-closed: never rotate
+                # Redis + return success on a half-written session).
+                session = await session_service.update_session_activity(
+                    db=db,
+                    old_refresh_jti=old_refresh_jti,
+                    new_refresh_jti=new_refresh_jti,
+                    user_id=user.id,
+                )
+                if session is None:
                     log.warning(
-                        "Failed to update session activity",
+                        "Refresh aborted: session desync (old jti not in DB) — "
+                        "forcing re-login",
                         user_id=user.id,
-                        error=str(session_error),
+                        old_jti=old_refresh_jti[:8],
                     )
+                    raise session_desync_exception
 
-                log.info("DB changes staged", user_id=user.id)
-
-                # (STEP 7: Update Redis - Giữ nguyên)
-                try:
-                    async with safe_redis_pipeline(transaction=True) as pipe:
-                        pipe.delete(f"session:{old_refresh_jti}")
-                        pipe.set(
-                            f"session:{new_refresh_jti}",
-                            str(user.id),
-                            ex=new_refresh_ttl,
-                        )
-
-                        # ✅ SỬA LỖI: Blacklist token cũ bằng đúng TTL của nó
-                        full_refresh_ttl = int(
-                            settings.REFRESH_TOKEN_EXPIRE_DAYS * 86400
-                        )
-                        safe_ttl = max(60, full_refresh_ttl)  # Đảm bảo TTL dương
-                        pipe.set(f"blacklist:{old_refresh_jti}", "rotated", ex=safe_ttl)
-
-                        await pipe.execute()
-
-                    log.info(
-                        "✅ Redis update successful (session rotated)", user_id=user.id
-                    )
-                except Exception as e_redis:
-                    log.error(
-                        "❌ Redis pipeline failed, will rollback DB",
-                        user_id=user.id,
-                        error=str(e_redis),
-                        exc_info=True,
-                    )
-                    raise service_unavailable
-
-                log.info("✅ Token rotation completed successfully", user_id=user.id)
-
-                # ✅ FIX-4: Add user info to refresh response for auto-refresh mechanism
-                # ✅ FIX-5: Tokens are ONLY in httpOnly cookies (not in response body)
-                response = JSONResponse(
-                    content={
-                        # "access_token": new_access_token,  # REMOVED - httpOnly cookies only
-                        "token_type": "bearer",
-                        "user": {
-                            "id": user.id,
-                            "username": user.username,
-                            "email": user.email,
-                            "full_name": user.full_name,
-                            "role": user.role,
-                        },
-                    },
-                    status_code=200,
+                log.info(
+                    "DB changes staged (savepoint, not yet committed)",
+                    user_id=user.id,
                 )
-
-                # ✅ SECURITY FIX: Set new access_token in httpOnly cookie
-                new_access_ttl = settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
-                response.set_cookie(
-                    key="access_token",
-                    value=new_access_token,
-                    httponly=True,
-                    secure=settings.APP_ENV == "production",
-                    samesite="lax",
-                    max_age=int(new_access_ttl),
-                    path="/",
-                )
-
-                response.set_cookie(
-                    key="refresh_token",
-                    value=new_refresh_token,
-                    httponly=True,
-                    secure=settings.APP_ENV == "production",
-                    samesite="strict",
-                    max_age=int(new_refresh_ttl),
-                    path="/api",  # ✅ FIX: Changed from "/api/auth" to "/api" so cookie is sent to all /api/* endpoints
-                )
-
-                # ✅ CSRF Protection: Refresh CSRF token on token refresh
-                set_csrf_cookie(response)
-
-                # ✅ M4: Clear failed refresh counter on success
-                try:
-                    await safe_redis_delete(f"refresh_fail:{username}")
-                except Exception:
-                    pass
-
-                return response
 
             except InvalidToken:
                 raise credentials_exception
             except HTTPException:
                 raise
+
+        # ── Savepoint released: the new refresh_jti is staged in the OUTER
+        #    transaction but NOT yet committed. Approach A ordering from here:
+        #    Redis rotate FIRST, then DB commit, with best-effort compensation
+        #    to OLD on either failure. Rationale: if we committed DB first and
+        #    Redis then failed, DB=new while cookie/Redis=old → the next refresh
+        #    would re-desync and blacklist the wrong jti. Redis-first +
+        #    compensate keeps both stores consistent without a DB compensation
+        #    transaction; the None-FATAL above stops the desync loop entirely.
+
+        async def _compensate_session_to_old() -> None:
+            """Best-effort: restore the OLD session to Redis (and drop the NEW
+            key + un-blacklist OLD) so the client's UNCHANGED old refresh cookie
+            still authenticates — no lockout. Uses the OLD token's REMAINING ttl
+            (never the full window) so compensation can't silently extend the
+            session."""
+            try:
+                _, _old_ttl = security.decode_token_for_invalidation(refresh_token)
+                comp_ttl = max(60, int(_old_ttl)) if _old_ttl else 60
+                async with safe_redis_pipeline(transaction=True) as pipe:
+                    pipe.set(f"session:{old_refresh_jti}", str(user.id), ex=comp_ttl)
+                    pipe.delete(f"session:{new_refresh_jti}")
+                    pipe.delete(f"blacklist:{old_refresh_jti}")
+                    await pipe.execute()
+            except Exception as e_comp:  # pragma: no cover — best-effort
+                log.error(
+                    "Refresh compensation to OLD failed (manual review needed)",
+                    user_id=getattr(user, "id", None),
+                    error=str(e_comp),
+                    exc_info=True,
+                )
+
+        # (STEP 7: Redis rotate — BEFORE commit)
+        try:
+            async with safe_redis_pipeline(transaction=True) as pipe:
+                pipe.delete(f"session:{old_refresh_jti}")
+                pipe.set(
+                    f"session:{new_refresh_jti}",
+                    str(user.id),
+                    ex=new_refresh_ttl,
+                )
+                # Blacklist the old token for its full remaining window.
+                full_refresh_ttl = int(settings.REFRESH_TOKEN_EXPIRE_DAYS * 86400)
+                safe_ttl = max(60, full_refresh_ttl)
+                pipe.set(f"blacklist:{old_refresh_jti}", "rotated", ex=safe_ttl)
+                await pipe.execute()
+            log.info("✅ Redis update successful (session rotated)", user_id=user.id)
+        except Exception as e_redis:
+            # The pipeline may have applied partially → undefined Redis state.
+            # Compensate to OLD, roll back the staged DB change, fail closed.
+            log.error(
+                "❌ Redis pipeline failed during rotate — compensating to OLD",
+                user_id=user.id,
+                error=str(e_redis),
+                exc_info=True,
+            )
+            await _compensate_session_to_old()
+            await db.rollback()
+            raise service_unavailable
+
+        # (STEP 8: Commit the DB refresh_jti rotation)
+        try:
+            await db.commit()
+        except Exception as e_commit:
+            # Redis already rotated to NEW; undo it so the client's still-held
+            # OLD cookie keeps working (no lockout), then roll back DB.
+            log.error(
+                "❌ DB commit failed after Redis rotate — compensating Redis to OLD",
+                user_id=user.id,
+                error=str(e_commit),
+                exc_info=True,
+            )
+            await _compensate_session_to_old()
+            await db.rollback()
+            raise service_unavailable
+
+        log.info("✅ Token rotation completed successfully", user_id=user.id)
+
+        # ✅ FIX-4/5: user info in body; tokens ONLY in httpOnly cookies.
+        response = JSONResponse(
+            content={
+                "token_type": "bearer",
+                "user": {
+                    "id": user.id,
+                    "username": user.username,
+                    "email": user.email,
+                    "full_name": user.full_name,
+                    "role": user.role,
+                },
+            },
+            status_code=200,
+        )
+
+        # ✅ SECURITY FIX: Set new access_token in httpOnly cookie
+        new_access_ttl = settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
+        response.set_cookie(
+            key="access_token",
+            value=new_access_token,
+            httponly=True,
+            secure=settings.APP_ENV == "production",
+            samesite="lax",
+            max_age=int(new_access_ttl),
+            path="/",
+        )
+        response.set_cookie(
+            key="refresh_token",
+            value=new_refresh_token,
+            httponly=True,
+            secure=settings.APP_ENV == "production",
+            samesite="strict",
+            max_age=int(new_refresh_ttl),
+            path="/api",  # cookie sent to all /api/* endpoints
+        )
+
+        # ✅ CSRF Protection: refresh CSRF token on token refresh.
+        set_csrf_cookie(response)
+
+        # ✅ M4: clear failed refresh counter on success.
+        try:
+            await safe_redis_delete(f"refresh_fail:{username}")
+        except Exception:
+            pass
+
+        return response
 
     except (JWTError, InvalidToken):
         # ✅ M4: Increment failed refresh counter

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
 from .. import database, models, schemas
-from ..core.deps import CasbinAuth, LeadListFilter, get_lead_for_user, get_lead_list_filter, require_admin_or_manager  # ✅ Phase 2.2
+from ..core.deps import CasbinAuth, LeadListFilter, get_lead_for_user, get_lead_list_filter, require_admin, require_admin_or_manager  # ✅ Phase 2.2
 from ..schemas.collaborator import LeadValidityUpdate
 from ..services import distribution_service, insights_service, lead_service
 from ..utils.csv_helpers import sanitize_csv_cell
@@ -91,7 +91,14 @@ async def get_my_reassign_quota(
 
 
 @limiter.limit(RateLimits.DATA_READ)  # 1000/hour
-@router.get("/distribution-preview")
+@router.get(
+    "/distribution-preview",
+    # PR1 Commit 3: hard role gate IN FRONT of CasbinAuth so the keyMatch4
+    # static-vs-/{lead_id} collision can never leak this route to officers.
+    # Casbin is kept (defense-in-depth + policy-table consistency, e.g. the
+    # accountant explicit deny); this dependency is the authoritative gate.
+    dependencies=[Depends(require_admin_or_manager)],
+)
 async def get_distribution_preview(
     request: Request,
     offering_id: int = Query(..., description="Offering ID to preview distribution"),
@@ -316,7 +323,11 @@ async def get_all_leads(
 # ==============================================================================
 
 @limiter.limit(RateLimits.DATA_EXPORT)  # 20/hour - Export operation
-@router.get("/export")
+@router.get(
+    "/export",
+    # PR1 Commit 3: admin/manager-only hard gate (keyMatch4 collision fix).
+    dependencies=[Depends(require_admin_or_manager)],
+)
 async def export_leads(
     request: Request,
     db: AsyncSession = Depends(database.get_db),
@@ -1313,7 +1324,12 @@ async def download_import_template(
 
 
 @limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
-@router.post("/bulk-assign", status_code=status.HTTP_200_OK)
+@router.post(
+    "/bulk-assign",
+    status_code=status.HTTP_200_OK,
+    # PR1 Commit 3: admin/manager-only hard gate (keyMatch4 collision fix).
+    dependencies=[Depends(require_admin_or_manager)],
+)
 async def bulk_assign_leads(
     request: Request,
     bulk_assign_data: schemas.BulkAssignLeadsSchema,
@@ -1408,7 +1424,14 @@ async def bulk_update_leads_stage(
 
 
 @limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
-@router.post("/bulk-delete", status_code=status.HTTP_200_OK)
+@router.post(
+    "/bulk-delete",
+    status_code=status.HTTP_200_OK,
+    # PR1 Commit 3: ADMIN-ONLY hard gate. Manager has no bulk-delete policy
+    # (policy_templates), and the docstring says "Admin only" — enforce it in
+    # code, independent of the keyMatch4-prone Casbin static-route matching.
+    dependencies=[Depends(require_admin)],
+)
 async def bulk_delete_leads(
     request: Request,
     bulk_data: schemas.BulkDeleteSchema,

--- a/Backend_FastAPI/app/routers/payments.py
+++ b/Backend_FastAPI/app/routers/payments.py
@@ -606,10 +606,14 @@ async def payment_callback(
         form = await request.form()
         callback_data = dict(form)
 
+    # PR1 Commit 5: do NOT log the raw, UNVERIFIED callback_data — it is
+    # attacker-influenced (public IPN endpoint) and may carry sensitive gateway
+    # fields or log-injection payloads. Signature verification + detailed
+    # logging happen inside the service after verify.
     log.info(
         "payment_callback_received",
         gateway_code=gateway_code,
-        callback_data=callback_data,
+        content_type=content_type,
     )
 
     intent_service = PaymentIntentService(db)

--- a/Backend_FastAPI/app/routers/sessions.py
+++ b/Backend_FastAPI/app/routers/sessions.py
@@ -42,14 +42,20 @@ async def get_active_sessions(
     """
     log.info("Fetching active sessions", user_id=current_user.id)
 
-    # Identify current session from refresh token cookie
-    # This is intentional exception handling for token parsing
-    current_refresh_jti = None
-    if refresh_token:
+    # PR1 Commit 2: prefer the live refresh jti that get_current_user derived
+    # from the access token's r_jti (request.state.refresh_jti). This resolves
+    # is_current even when the refresh cookie isn't sent on this request, and is
+    # consistent with the DB session.refresh_jti now that /auth/refresh commits
+    # the rotation. Fall back to decoding the refresh cookie.
+    current_refresh_jti = getattr(request.state, "refresh_jti", None)
+    if not current_refresh_jti and refresh_token:
         try:
             payload = security.decode_token(refresh_token)
             current_refresh_jti = payload.get("jti")
-            log.info("Current session identified", refresh_jti=current_refresh_jti)
+            log.info(
+                "Current session identified (cookie fallback)",
+                refresh_jti=current_refresh_jti,
+            )
         except Exception as e:
             log.warning(
                 "Failed to decode refresh token for session identification",

--- a/Backend_FastAPI/app/routers/zalo_webhooks.py
+++ b/Backend_FastAPI/app/routers/zalo_webhooks.py
@@ -123,7 +123,25 @@ async def zalo_webhook(
         and zevent_server == "ZNS"
     )
     if event_name in ("oa_send_text", "oa_send_template") or is_zbs_delivery:
-        await _handle_delivery_status(db, data)
+        # PR1 Commit 4 (A08 Integrity / A10 fail-closed):
+        # _handle_delivery_status mutates NotificationDelivery (status /
+        # sent_at / error_reason) and commits — a durable write reachable from
+        # this UNAUTHENTICATED public endpoint. Gate it on a valid signature
+        # exactly like the user_feedback branch below; without this, anyone
+        # could forge callbacks to flip any row's delivery status (lookup is
+        # by msg_id or delivery_{id}). Every Zalo OA webhook event carries
+        # X-ZEvent-Signature (sha256(appId+data+timeStamp+OAsecretKey)),
+        # verified across chat + ZBS docs, so legit callbacks pass; only
+        # forged/unsigned ones are dropped. Still 200-ack (no retry storm).
+        if not sig_ok:
+            log.warning(
+                "Zalo delivery-status callback rejected: signature missing or "
+                "invalid — 200-acked, NotificationDelivery NOT mutated",
+                event_name=event_name,
+                signature_present=bool(signature),
+            )
+        else:
+            await _handle_delivery_status(db, data)
 
     # 5. Handle follow/unfollow events (future: update consent)
     elif event_name == "user_follow_oa":

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -256,6 +256,16 @@ class DocumentItemSchema(BaseModel):
         default="missing",
         description="Upload status"
     )
+    # PR1 Commit 1: ProfileDocument PK, present only when a downloadable file
+    # artifact exists. The FE builds the authed download URL
+    # /api/admissions/{profile_id}/documents/{document_id}/download from it
+    # (file_path is no longer publicly servable). Null → no file to view, FE
+    # hides the "Xem PDF" button. Declared on the schema so the response_model
+    # doesn't silently drop it (Pydantic only serializes declared fields).
+    document_id: Optional[int] = Field(
+        None,
+        description="ProfileDocument PK for the authed download endpoint (null when no file artifact)",
+    )
     file_path: Optional[str] = Field(
         None,
         max_length=512,

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1966,6 +1966,17 @@ class ConfirmTokenResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+def _mask_display_name(name: str) -> str:
+    """Mask a display name for the PUBLIC confirm-info endpoint so the full
+    name (PII) is not exposed before CCCD verification — the token sits in the
+    URL and anyone with the link can hit this endpoint. Keeps the first
+    character of each word and replaces the rest with a fixed mask (does not
+    leak the exact length)."""
+    parts = (name or "").split()
+    out = [p if len(p) <= 1 else p[0] + "•••" for p in parts]
+    return " ".join(out) if out else (name or "")
+
+
 class ConfirmTokenInfoResponse(BaseModel):
     """
     Info about token (for frontend to show confirmation form).
@@ -1980,8 +1991,21 @@ class ConfirmTokenInfoResponse(BaseModel):
     locked: bool
     already_used: bool
     attempts_remaining: int
-    profile_name: str = Field(description="Lead's full_name for display")
+    profile_name: str = Field(
+        description=(
+            "Lead's full_name MASKED (first letter of each word). The full "
+            "name is only revealed after CCCD verification via "
+            "POST /confirm/{token} — the token is public (in the URL)."
+        )
+    )
     expires_at: Optional[datetime] = None
+
+    @field_validator("profile_name")
+    @classmethod
+    def _mask_name(cls, v: str) -> str:
+        # PR1 Commit 7: never expose the full name from this public,
+        # pre-verification endpoint.
+        return _mask_display_name(v)
     
     model_config = ConfigDict(from_attributes=True)
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -87,6 +87,29 @@ _BULK_SAFE_DOMAIN_EXCEPTIONS = (
 )
 
 
+def _resolve_under(base_dir: str, candidate_path: str) -> Optional[str]:
+    """Path-traversal guard. Return the resolved absolute path iff
+    ``candidate_path`` stays under ``base_dir`` after normalizing ``..``,
+    else ``None``.
+
+    Mirrors ``file_helpers.py`` (``Path.resolve`` + ``os.path.commonpath``);
+    reused by the upload builders and the authed download endpoint so a
+    tampered/malformed path can never escape the profile's upload dir.
+    """
+    import os
+    from pathlib import Path
+
+    base = Path(base_dir).resolve(strict=False)
+    target = Path(candidate_path).resolve(strict=False)
+    try:
+        if os.path.commonpath([str(base), str(target)]) != str(base):
+            return None
+    except ValueError:
+        # commonpath raises on mixed drives / empty input — treat as unsafe.
+        return None
+    return str(target)
+
+
 def _sniff_document_signature(stream) -> Optional[str]:
     """ADM-019: detect a document upload's true type by magic bytes.
 
@@ -1924,6 +1947,11 @@ def _compute_frontend_fields(
                 _has_artifact = doc.status in _ARTIFACT_STATUSES
                 _is_verified = doc.status == "verified"
                 doc_by_code[doc.document_type.code] = {
+                    # PR1 Commit 1: ProfileDocument PK — surfaced as
+                    # ``document_id`` in the checklist projection so the FE
+                    # builds the authed download URL. The append blocks below
+                    # only expose it when a real file_path exists.
+                    "id": doc.id,
                     "status": doc.status,
                     "label_from_db": doc.document_type.name,
                     # rejection_reason is the only field that is meaningful
@@ -2047,6 +2075,9 @@ def _compute_frontend_fields(
             "verified_format": uploaded_doc.get("verified_format"),
             "status": _doc_status,
             "file_path": uploaded_doc.get("file_path"),
+            # PR1 Commit 1: PK only when a real downloadable file exists, so
+            # the FE renders the "Xem PDF" button iff document_id is non-null.
+            "document_id": uploaded_doc.get("id") if uploaded_doc.get("file_path") else None,
             "uploaded_at": uploaded_doc.get("uploaded_at"),
             # ADM-031 round 7: paper-receipt timestamp
             "paper_submitted_at": uploaded_doc.get("paper_submitted_at"),
@@ -2080,6 +2111,8 @@ def _compute_frontend_fields(
             "verified_format": uploaded_doc.get("verified_format"),
             "status": _doc_status,
             "file_path": uploaded_doc.get("file_path"),
+            # PR1 Commit 1: PK only when a real downloadable file exists.
+            "document_id": uploaded_doc.get("id") if uploaded_doc.get("file_path") else None,
             "uploaded_at": uploaded_doc.get("uploaded_at"),
             "paper_submitted_at": uploaded_doc.get("paper_submitted_at"),
             "verified_at": uploaded_doc.get("verified_at"),
@@ -5426,6 +5459,82 @@ async def submit_and_evaluate(
         )
 
 
+async def get_document_file_for_download(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    document_id: int,
+    actor_user_id: int,
+    actor_ip: Optional[str] = None,
+    actor_user_agent: Optional[str] = None,
+) -> Tuple[str, str, str]:
+    """Resolve a downloadable file for a ProfileDocument under ``profile``.
+
+    PR1 Commit 1 (A01/A05/A09). IDOR is enforced upstream by the router dep
+    ``get_admission_for_user_read`` (3-tier scope, fake-404). Here we
+    additionally:
+
+    - bind the document to the authorized profile (``doc.profile_id ==
+      profile.id``) and require a real ``file_path`` — any miss raises
+      ``ResourceNotFoundError`` (→404) so existence is never leaked;
+    - apply a defense-in-depth path guard so a tampered ``file_path`` can
+      never escape ``uploads/admissions/{profile.id}/``;
+    - derive ``media_type`` from a server-controlled extension allowlist
+      (ProfileDocument persists no MIME type — never trust a stored/client
+      value);
+    - record a ``downloaded`` audit row (Gap 1 — A09). It is flushed here;
+      the router commits it before the FileResponse streams.
+
+    Returns ``(abs_path, safe_basename, media_type)``.
+    """
+    import os
+    from app.repositories import AdmissionRepository
+
+    repo = AdmissionRepository(db)
+    doc = await repo.get_document_by_id(document_id)
+    if doc is None or doc.profile_id != profile.id or not doc.file_path:
+        raise ResourceNotFoundError("Document not found")
+
+    base_dir = f"uploads/admissions/{profile.id}"
+    abs_path = _resolve_under(base_dir, doc.file_path)
+    if abs_path is None or not os.path.isfile(abs_path):
+        log.warning(
+            "admission document download: file missing or path invalid",
+            profile_id=profile.id,
+            document_id=document_id,
+            file_path=doc.file_path,
+        )
+        raise ResourceNotFoundError("Document not found")
+
+    # media_type from a server-controlled extension allowlist (Gap 3 —
+    # A05/A03). Extension is set from sniffed magic bytes at upload time, so
+    # it is trustworthy; no persisted/client MIME value is ever used.
+    ext = os.path.splitext(abs_path)[1].lower()
+    media_type = {
+        ".pdf": "application/pdf",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+    }.get(ext, "application/octet-stream")
+
+    # safe_basename: strip CR/LF so the filename can't smuggle header content
+    # (Starlette still applies RFC-compliant Content-Disposition encoding).
+    safe_basename = os.path.basename(abs_path).replace("\r", "").replace("\n", "")
+
+    # Audit (Gap 1 — A09): record who downloaded which document. db.flush is
+    # inside log_document_action; the router commits before streaming.
+    from .document_audit_service import log_document_action, DocumentAction
+    await log_document_action(
+        db=db,
+        profile_document_id=doc.id,
+        action=DocumentAction.DOWNLOADED,
+        actor_user_id=actor_user_id,
+        ip_address=actor_ip,
+        user_agent=actor_user_agent,
+    )
+
+    return abs_path, safe_basename, media_type
+
+
 async def upload_document(
     db: AsyncSession,
     profile_id: int,
@@ -5581,6 +5690,19 @@ async def upload_document(
     # same filesystem). Hidden by leading ``.staging.`` prefix so it
     # does not show up in casual ``ls`` of the uploads dir.
     staging_path = f"{upload_dir}/.staging.{unique_id}{file_extension}"
+
+    # PR1 Commit 1 (defense-in-depth — A05): doc_code is bound to a catalog
+    # ConfigDocumentType, but still guard the built paths so neither the final
+    # nor staging path can escape this profile's upload dir.
+    for _candidate in (final_path, staging_path):
+        if _resolve_under(upload_dir, _candidate) is None:
+            log.critical(
+                "🚨 PATH TRAVERSAL ATTEMPT (admission document upload)",
+                profile_id=profile_id,
+                doc_code=doc_code,
+                candidate=_candidate,
+            )
+            raise BadRequest("Invalid file path detected.")
 
     # Stage the file to the staging path. If this fails, clean up the
     # partially-written staging file before raising — we never let
@@ -5924,6 +6046,19 @@ async def upload_priority_evidence_document(
     unique_filename = f"priority_{sub_code}_{unique_id}{file_extension}"
     final_path = f"{upload_dir}/{unique_filename}"
     staging_path = f"{upload_dir}/.staging.{unique_id}{file_extension}"
+
+    # PR1 Commit 1 (defense-in-depth — A05): sub_code is constrained to the
+    # PriorityObjectConfig catalog above, but still guard the built paths so a
+    # malformed catalog sub_code can never escape the upload dir.
+    for _candidate in (final_path, staging_path):
+        if _resolve_under(upload_dir, _candidate) is None:
+            log.critical(
+                "🚨 PATH TRAVERSAL ATTEMPT (admission priority evidence upload)",
+                profile_id=profile_id,
+                sub_code=sub_code,
+                candidate=_candidate,
+            )
+            raise BadRequest("Invalid file path detected.")
 
     # Stage file
     try:

--- a/Backend_FastAPI/app/services/document_audit_service.py
+++ b/Backend_FastAPI/app/services/document_audit_service.py
@@ -36,6 +36,11 @@ class DocumentAction:
     RESET = "reset"
     PAPER_SUBMITTED = "paper_submitted"
     DELETED = "deleted"
+    # PR1 Commit 1 (Gap 1 — A09): authed PII document download. Paired with
+    # the ``ck_document_audit_log_action`` CHECK relax migration
+    # ``docdl_audit_001`` — inserting this value before the migration applies
+    # would violate the DB constraint.
+    DOWNLOADED = "downloaded"
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/services/payment_intent_service.py
+++ b/Backend_FastAPI/app/services/payment_intent_service.py
@@ -53,8 +53,33 @@ from app.utils.exceptions import (
     ConflictError,
 )
 from app.config import settings
+from urllib.parse import urlparse
 
 log = structlog.get_logger(__name__)
+
+
+def build_safe_return_url(return_url: Optional[str]) -> str:
+    """Allowlist + normalize the client-supplied post-payment return URL
+    (open-redirect / SSRF guard — PR1 Commit 5).
+
+    - None/empty → canonical default ``{FRONTEND_URL}/finance/payments/return``
+      so callers that pass no return_url keep working (backward-compatible).
+    - Same scheme+host as ``settings.FRONTEND_URL`` → kept as-is.
+    - Any other origin → ``BusinessRuleViolation`` (mapped to HTTP 400 by the
+      payments router). The gateway echoes this URL back to the user, so an
+      attacker-controlled value would be an open redirect.
+    """
+    base = settings.FRONTEND_URL.rstrip("/")
+    default_url = f"{base}/finance/payments/return"
+    if not return_url:
+        return default_url
+    allowed = urlparse(settings.FRONTEND_URL)
+    candidate = urlparse(return_url)
+    allowed_origin = (allowed.scheme, allowed.netloc)
+    if (candidate.scheme, candidate.netloc) != allowed_origin:
+        raise BusinessRuleViolation("return_url is not an allowed origin")
+    return return_url
+
 
 # Default intent expiration (15 minutes)
 DEFAULT_INTENT_EXPIRATION_MINUTES = 15
@@ -187,7 +212,9 @@ class PaymentIntentService:
                 f"Payment method '{method.name}' is not an online payment method"
             )
 
-        # Create intent
+        # Create intent. PR1 Commit 5: allowlist/normalize the return_url
+        # before storing it or handing it to a gateway adapter.
+        safe_return_url = build_safe_return_url(return_url)
         expires_at = datetime.now(timezone.utc) + timedelta(minutes=expiration_minutes)
 
         intent = PaymentIntent(
@@ -197,7 +224,7 @@ class PaymentIntentService:
             currency="VND",
             idempotency_key=idempotency_key,
             status=PaymentIntentStatusEnum.created.value,
-            return_url=return_url,
+            return_url=safe_return_url,
             expires_at=expires_at,
         )
 
@@ -209,7 +236,9 @@ class PaymentIntentService:
         gateway_code = method.code
         if gateway_code in self._gateway_adapters:
             adapter = self._gateway_adapters[gateway_code]
-            pay_url, gateway_ref = await adapter.create_payment_url(intent, return_url)
+            pay_url, gateway_ref = await adapter.create_payment_url(
+                intent, safe_return_url
+            )
             intent.pay_url = pay_url
             intent.gateway_ref = gateway_ref
             intent.status = PaymentIntentStatusEnum.pending.value
@@ -850,6 +879,10 @@ def register_default_gateways(service: PaymentIntentService) -> None:
             access_key=settings.MOMO_ACCESS_KEY,
             secret_key=settings.MOMO_SECRET_KEY,
             endpoint=settings.MOMO_ENDPOINT,
+            # PR1 Commit 5: wire the canonical backend base so the IPN URL is
+            # built from it, NOT the client return_url. This is the real
+            # runtime registration path (from_settings is a separate ctor).
+            public_backend_url=settings.PUBLIC_BACKEND_URL,
         )
         service.register_gateway("momo", momo)
         log.info("momo_gateway_registered")

--- a/Backend_FastAPI/tests/api/test_admission_document_download.py
+++ b/Backend_FastAPI/tests/api/test_admission_document_download.py
@@ -1,0 +1,237 @@
+"""PR1 Commit 1 anchor tests — authed admission document download (A01/A05/A09).
+
+Pins the contract that:
+  * the checklist projection exposes ``document_id`` for a path doc that has a
+    real file (and null when there's no artifact) — without it the FE can't
+    build the download URL and PR2 breaks (Pydantic drops undeclared fields);
+  * GET .../documents/{document_id}/download serves the file only to in-scope
+    staff, binds the document to the authorized profile (cross-profile id →
+    404), refuses anonymous callers (401), and writes a ``downloaded`` audit
+    row;
+  * the path-traversal guard ``_resolve_under`` rejects escapes.
+
+Reuses the self-contained fixture chain from
+``test_admission_doc_mutations_response_parity`` (one upload doc + one
+paper-only doc on a fresh admission path).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.services.admission_service import _resolve_under
+
+# Reuse the parity fixture + helpers (self-contained admission path + docs).
+from tests.api.test_admission_doc_mutations_response_parity import (  # noqa: F401
+    parity_config,
+    _login,
+    _create_profile,
+)
+
+ADMISSIONS = "/api/admissions"
+PDF_BYTES = b"%PDF-1.4\n%%EOF"
+
+
+async def _upload_and_get_checklist(client, oh, pid, doc_code):
+    """Officer uploads a PDF, return the upload response's checklist keyed by code."""
+    up = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{doc_code}/upload",
+        headers=oh,
+        files={"file": ("u.pdf", PDF_BYTES, "application/pdf")},
+        data={"actual_submission_format": "photo"},
+    )
+    assert up.status_code in (200, 201), up.text
+    return {d["code"]: d for d in up.json()["documents_checklist"]}
+
+
+def test_resolve_under_rejects_traversal():
+    """Pure-function guard: in-dir paths pass; escapes return None."""
+    base = "uploads/admissions/42"
+    assert _resolve_under(base, "uploads/admissions/42/HOC_BA_abc.pdf") is not None
+    # ../ escape into a sibling profile dir → rejected.
+    assert _resolve_under(base, "uploads/admissions/42/../43/secret.pdf") is None
+    # Absolute escape → rejected.
+    assert _resolve_under(base, "/etc/passwd") is None
+    # Deep traversal out of the tree → rejected.
+    assert _resolve_under(base, "uploads/admissions/42/../../../../etc/passwd") is None
+
+
+@pytest.mark.asyncio
+async def test_checklist_exposes_document_id_for_path_doc(
+    client: AsyncClient, admin_token_headers, officer_user_in_db, parity_config
+):
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, parity_config, "docid"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    checklist = await _upload_and_get_checklist(
+        client, oh, pid, parity_config["upload_doc_code"]
+    )
+
+    up_item = checklist[parity_config["upload_doc_code"]]
+    assert isinstance(up_item.get("document_id"), int), (
+        "uploaded path doc must expose an int document_id for the download URL; "
+        f"got {up_item.get('document_id')!r}"
+    )
+    # The paper-only doc has no file artifact → document_id must stay null so
+    # the FE doesn't render a broken "Xem PDF" button.
+    paper_item = checklist[parity_config["paper_doc_code"]]
+    assert paper_item.get("document_id") is None, (
+        "doc with no file must have document_id=None; "
+        f"got {paper_item.get('document_id')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_checklist_exposes_document_id_for_extra_doc(
+    client: AsyncClient, admin_token_headers, officer_user_in_db, parity_config
+):
+    """Plan parity: document_id must also appear on EXTRA docs (the is_extra
+    block — a ProfileDocument whose code is NOT in the current mandatory
+    snapshot, e.g. after the path was edited). Same projection code as path
+    docs, asserted here so the FE contract holds for BOTH append branches."""
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, parity_config, "extra"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+
+    # Insert a ProfileDocument for a doc type NOT in the path's document group
+    # → it lands in the is_extra block of the checklist projection. file_path
+    # is set, so document_id must be exposed.
+    ts = f"{int(datetime.now().timestamp() * 1000)}"
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            dt_extra = models.ConfigDocumentType(
+                code=f"extra_{ts}", name=f"EXTRA_{ts}", display_order=99
+            )
+            s.add(dt_extra)
+            await s.flush()
+            pd = models.ProfileDocument(
+                profile_id=pid,
+                document_type_id=dt_extra.id,
+                category="path",
+                status="uploaded",
+                file_path=f"uploads/admissions/{pid}/extra_{ts}.pdf",
+                uploaded_at=datetime.now(timezone.utc),
+            )
+            s.add(pd)
+            await s.flush()
+            extra_doc_id = pd.id
+            extra_code = dt_extra.code
+
+    res = await client.get(f"{ADMISSIONS}/{pid}", headers=oh)
+    assert res.status_code == 200, res.text
+    checklist = {d["code"]: d for d in res.json()["documents_checklist"]}
+    assert extra_code in checklist, "inserted extra doc must appear in checklist"
+    item = checklist[extra_code]
+    assert item.get("is_extra") is True, (
+        f"expected is_extra=True, got {item.get('is_extra')!r}"
+    )
+    assert item.get("document_id") == extra_doc_id, (
+        "extra doc with a file must expose document_id (is_extra projection "
+        f"block); got {item.get('document_id')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_owner_officer_ok_and_audited(
+    client: AsyncClient, admin_token_headers, officer_user_in_db, parity_config
+):
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, parity_config, "dl_ok"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    checklist = await _upload_and_get_checklist(
+        client, oh, pid, parity_config["upload_doc_code"]
+    )
+    document_id = checklist[parity_config["upload_doc_code"]]["document_id"]
+
+    resp = await client.get(
+        f"{ADMISSIONS}/{pid}/documents/{document_id}/download", headers=oh
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.content == PDF_BYTES
+    assert resp.headers["content-type"].startswith("application/pdf")
+    assert "inline" in resp.headers.get("content-disposition", "")
+    assert resp.headers.get("cache-control") == "private, no-store"
+
+    # Gap 1 (A09): a ``downloaded`` audit row must exist for this document.
+    async with AsyncSessionLocal() as s:
+        rows = (
+            await s.execute(
+                select(models.DocumentAuditLog).where(
+                    models.DocumentAuditLog.profile_document_id == document_id,
+                    models.DocumentAuditLog.action == "downloaded",
+                )
+            )
+        ).scalars().all()
+    assert len(rows) >= 1, "download must write a 'downloaded' DocumentAuditLog row"
+    assert rows[0].actor_user_id == officer_user_in_db["id"]
+
+
+@pytest.mark.asyncio
+async def test_download_requires_auth(
+    client: AsyncClient, admin_token_headers, officer_user_in_db, parity_config
+):
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, parity_config, "dl_401"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    checklist = await _upload_and_get_checklist(
+        client, oh, pid, parity_config["upload_doc_code"]
+    )
+    document_id = checklist[parity_config["upload_doc_code"]]["document_id"]
+
+    # Clear the cookie jar so the prior login's access_token cookie doesn't
+    # silently authenticate this "anonymous" request (memory
+    # ``test-httpx-cookie-jar-contamination``).
+    client.cookies.clear()
+    resp = await client.get(f"{ADMISSIONS}/{pid}/documents/{document_id}/download")
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_download_cross_profile_document_id_404(
+    client: AsyncClient, admin_token_headers, officer_user_in_db, parity_config
+):
+    """IDOR binding: a document_id belonging to another profile must 404 even
+    when the caller is authorized for the profile named in the URL."""
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    # Profile A — upload a doc, capture its document_id.
+    prof_a = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, parity_config, "idor_a"
+    )
+    checklist_a = await _upload_and_get_checklist(
+        client, oh, prof_a["id"], parity_config["upload_doc_code"]
+    )
+    doc_id_a = checklist_a[parity_config["upload_doc_code"]]["document_id"]
+
+    # Profile B — same officer/unit (authorized), different profile.
+    prof_b = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, parity_config, "idor_b"
+    )
+
+    # Request A's document under B's URL → doc.profile_id != B → 404.
+    resp = await client.get(
+        f"{ADMISSIONS}/{prof_b['id']}/documents/{doc_id_a}/download", headers=oh
+    )
+    assert resp.status_code == 404, resp.text

--- a/Backend_FastAPI/tests/api/test_confirm_token_mask.py
+++ b/Backend_FastAPI/tests/api/test_confirm_token_mask.py
@@ -1,0 +1,64 @@
+"""PR1 Commit 7 anchor: the PUBLIC confirm-info endpoint masks the lead name
+before CCCD verification and sets Referrer-Policy: no-referrer (A01 / A09).
+
+The token sits in the URL, so GET /api/admissions/confirm/{token} is reachable
+by anyone with the link; it must not echo the full name (PII) nor leak the
+token via the Referer header.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from app.schemas.admission import ConfirmTokenInfoResponse, _mask_display_name
+
+
+def test_mask_display_name_cases():
+    masked = _mask_display_name("Nguyễn Văn An")
+    assert masked != "Nguyễn Văn An"
+    assert "Nguyễn" not in masked and "Văn" not in masked
+    assert masked.count("•••") == 3  # one mask per word, length not leaked
+    assert _mask_display_name("A") == "A"  # single char unchanged
+    assert _mask_display_name("") == ""
+
+
+def test_schema_masks_profile_name():
+    r = ConfirmTokenInfoResponse(
+        valid=True,
+        expired=False,
+        locked=False,
+        already_used=False,
+        attempts_remaining=3,
+        profile_name="Trần Thị Bích",
+    )
+    assert r.profile_name != "Trần Thị Bích"
+    assert "Trần" not in r.profile_name
+    assert "•••" in r.profile_name
+
+
+@pytest.mark.asyncio
+async def test_confirm_get_masks_and_sets_referrer_policy(
+    client: AsyncClient, monkeypatch
+):
+    async def _fake_get_token_info(db, token):
+        return {
+            "valid": True,
+            "expired": False,
+            "locked": False,
+            "already_used": False,
+            "attempts_remaining": 3,
+            "profile_name": "Nguyễn Văn An",
+            "expires_at": None,
+        }
+
+    monkeypatch.setattr(
+        "app.routers.admissions.admission_service.get_token_info",
+        _fake_get_token_info,
+    )
+    resp = await client.get("/api/admissions/confirm/sometoken")
+    assert resp.status_code == 200, resp.text
+    assert resp.headers.get("referrer-policy") == "no-referrer"
+    body = resp.json()
+    assert body["profile_name"] != "Nguyễn Văn An"
+    assert "Nguyễn" not in body["profile_name"]
+    assert "•••" in body["profile_name"]

--- a/Backend_FastAPI/tests/api/test_health_detailed_trim.py
+++ b/Backend_FastAPI/tests/api/test_health_detailed_trim.py
@@ -1,0 +1,32 @@
+"""PR1 Commit 6 anchor: /health/detailed response is trimmed to an up/down
+boolean per dependency — no exception class names, worker counts, or other
+internal detail that aids reconnaissance from this public endpoint (A02 / A09).
+``/health`` (the Docker/nginx healthcheck target) stays unchanged.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_health_detailed_no_internal_leak(client: AsyncClient):
+    resp = await client.get("/health/detailed")
+    # 200 when all deps up, 503 when any down (Celery has no worker in tests).
+    assert resp.status_code in (200, 503), resp.text
+    body = resp.json()
+    for dep in ("api", "database", "redis_cache", "celery_broker"):
+        assert dep in body, f"missing dependency {dep}"
+        # Each check must expose ONLY a status — no message / exception class /
+        # worker count.
+        assert set(body[dep].keys()) == {"status"}, (
+            f"{dep} leaks extra keys: {body[dep]}"
+        )
+        assert body[dep]["status"] in ("up", "down")
+
+
+@pytest.mark.asyncio
+async def test_health_simple_unchanged(client: AsyncClient):
+    resp = await client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"

--- a/Backend_FastAPI/tests/api/test_lead_static_route_http_gate.py
+++ b/Backend_FastAPI/tests/api/test_lead_static_route_http_gate.py
@@ -1,0 +1,80 @@
+"""PR1 Commit 3 anchor: lead static routes carry an HTTP-layer role hard gate
+in front of CasbinAuth (A01).
+
+The Casbin keyMatch4 matcher collides the static paths (/export,
+/distribution-preview, /bulk-assign, /bulk-delete) with /api/leads/{id},
+which let officers reach the two GETs by direct API call (see the
+Casbin-layer matrix in
+tests/integration/test_casbin_lead_static_route_collision.py — kept as the
+policy-table contract). These tests pin that the actual HTTP endpoints now:
+  * 403 officers on ALL four static routes (require_admin_or_manager /
+    require_admin gate runs before/independent of Casbin), and
+  * 403 managers on bulk-delete (ADMIN-only), while allowing them the other
+    three, and admins on bulk-delete.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+LEADS = "/api/leads"
+
+
+async def _bearer(client: AsyncClient, user: dict) -> dict:
+    r = await client.post(
+        "/api/auth/login",
+        data={"username": user["username"], "password": user["password"]},
+    )
+    assert r.status_code == 200, r.text
+    return {"Authorization": f"Bearer {r.cookies.get('access_token')}"}
+
+
+@pytest.mark.asyncio
+async def test_officer_blocked_from_all_lead_static_routes(
+    client: AsyncClient, officer_user_in_db: dict
+):
+    oh = await _bearer(client, officer_user_in_db)
+    # The two GETs used to leak to officers via the keyMatch4 collision; the
+    # hard gate now 403s all four static routes.
+    assert (await client.get(f"{LEADS}/export", headers=oh)).status_code == 403
+    assert (
+        await client.get(
+            f"{LEADS}/distribution-preview?offering_id=1", headers=oh
+        )
+    ).status_code == 403
+    assert (
+        await client.post(
+            f"{LEADS}/bulk-assign?officer_id=1", headers=oh, json={"lead_ids": [1]}
+        )
+    ).status_code == 403
+    assert (
+        await client.post(f"{LEADS}/bulk-delete", headers=oh, json={"lead_ids": [1]})
+    ).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_manager_allowed_except_bulk_delete(
+    client: AsyncClient, manager_user_in_db: dict
+):
+    mh = await _bearer(client, manager_user_in_db)
+    # Manager is admin-or-manager → passes the gate on export (not 403).
+    export = await client.get(f"{LEADS}/export", headers=mh)
+    assert export.status_code != 403, f"manager must pass the export gate: {export.text}"
+    # bulk-delete is ADMIN-only → manager 403 even though Casbin has no
+    # manager bulk-delete allow either.
+    rev = await client.post(
+        f"{LEADS}/bulk-delete", headers=mh, json={"lead_ids": [999999]}
+    )
+    assert rev.status_code == 403, f"manager must be blocked from bulk-delete: {rev.text}"
+
+
+@pytest.mark.asyncio
+async def test_admin_passes_bulk_delete_gate(
+    client: AsyncClient, admin_token_headers: dict
+):
+    # Admin clears the require_admin gate (not 403); the body runs and deletes
+    # nothing for a non-existent id.
+    r = await client.post(
+        f"{LEADS}/bulk-delete", headers=admin_token_headers, json={"lead_ids": [999999]}
+    )
+    assert r.status_code != 403, f"admin must pass the bulk-delete gate: {r.text}"

--- a/Backend_FastAPI/tests/api/test_session_refresh_commit.py
+++ b/Backend_FastAPI/tests/api/test_session_refresh_commit.py
@@ -1,0 +1,213 @@
+"""PR1 Commit 2 anchor tests — session refresh now COMMITS the rotation
+(A07/A10), plus fail-closed/no-lockout on Redis or commit failure.
+
+Root cause fixed: /auth/refresh staged the refresh_jti rotation inside a
+``begin_nested()`` savepoint but never called ``db.commit()`` → ``get_db``
+closed the session and the OUTER transaction rolled back, FREEZING
+``user_session.refresh_jti`` at the original value. Symptoms: is_current
+never resolved ("Không thể xác định phiên hiện tại") and revoke blacklisted
+the wrong (frozen) jti.
+
+Anchors:
+  1. refresh persists the rotation to the DB (refresh_jti changes,
+     last_activity_at advances) — the core fix.
+  2. is_current resolves after refreshes (request.state.refresh_jti /
+     committed session.refresh_jti).
+  3. desync (old jti valid in Redis but no DB row) → 401 force re-login,
+     NOT a phantom rotation (None-FATAL self-heal).
+  4. commit failure → compensate Redis to OLD → 503, no new cookie, and the
+     client's still-held OLD refresh token keeps working (NO LOCKOUT).
+  5. Redis-rotate failure → 503, no new cookie, old token still works.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.database import AsyncSessionLocal
+
+LOGIN = "/api/auth/login"
+REFRESH = "/api/auth/refresh"
+SESSIONS = "/api/sessions"
+
+
+async def _login(client: AsyncClient, user: dict):
+    r = await client.post(LOGIN, data={"username": user["username"], "password": user["password"]})
+    assert r.status_code == 200, r.text
+    return r
+
+
+async def _latest_session(user_id: int) -> models.UserSession:
+    async with AsyncSessionLocal() as s:
+        rows = (
+            await s.execute(
+                select(models.UserSession)
+                .where(
+                    models.UserSession.user_id == user_id,
+                    models.UserSession.revoked_at.is_(None),
+                )
+                .order_by(models.UserSession.id.desc())
+            )
+        ).scalars().all()
+    assert rows, "expected an active UserSession row after login"
+    return rows[0]
+
+
+@pytest.mark.asyncio
+async def test_refresh_commits_rotation_to_db(client: AsyncClient, regular_user_in_db: dict):
+    """The core fix: a successful refresh must PERSIST the rotated refresh_jti
+    and an advanced last_activity_at — not roll them back."""
+    uid = regular_user_in_db["id"]
+    await _login(client, regular_user_in_db)
+
+    before = await _latest_session(uid)
+    jti_before = before.refresh_jti
+    last_before = before.last_activity_at
+
+    r = await client.post(REFRESH)
+    assert r.status_code == 200, r.text
+
+    async with AsyncSessionLocal() as s:
+        after = (
+            await s.execute(
+                select(models.UserSession).where(models.UserSession.id == before.id)
+            )
+        ).scalar_one()
+
+    assert after.refresh_jti != jti_before, (
+        "refresh_jti must rotate AND commit — frozen jti means the no-commit "
+        "bug regressed"
+    )
+    assert after.last_activity_at > last_before, (
+        "last_activity_at must advance on refresh (was equal to created_at "
+        "while the rotation rolled back)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_current_resolves_after_refresh(client: AsyncClient, regular_user_in_db: dict):
+    """After refreshes, GET /api/sessions must mark exactly one session
+    is_current (committed refresh_jti == access-token r_jti)."""
+    await _login(client, regular_user_in_db)
+    assert (await client.post(REFRESH)).status_code == 200
+    assert (await client.post(REFRESH)).status_code == 200
+
+    res = await client.get(SESSIONS)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    current = [s for s in body["sessions"] if s["is_current"]]
+    assert len(current) == 1, f"exactly one current session expected, got {current}"
+    assert body["current_session_id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_revoke_session_then_access_token_401(client: AsyncClient, regular_user_in_db: dict):
+    """End-to-end HTTP fail-fast + revocation correctness: after a refresh,
+    revoking the current session must 401 the very access token that session
+    minted. Before the commit fix, session.refresh_jti was frozen at the login
+    jti while the live access r_jti was the rotated jti, so revoke deleted the
+    WRONG session key and the access token stayed valid. Now they match →
+    deps.py session:{r_jti} check rejects the next request immediately."""
+    await _login(client, regular_user_in_db)
+    assert (await client.post(REFRESH)).status_code == 200
+
+    res = await client.get(SESSIONS)
+    assert res.status_code == 200, res.text
+    sid = res.json()["current_session_id"]
+    assert sid is not None, "current session must resolve to be revocable"
+
+    rev = await client.delete(f"{SESSIONS}/{sid}")
+    assert rev.status_code == 204, rev.text
+
+    # The access-token cookie (r_jti = the now-revoked session) must be rejected
+    # on the very next authed request — no waiting for the access TTL to lapse.
+    after = await client.get(SESSIONS)
+    assert after.status_code == 401, (
+        f"revoked session's access token must 401 immediately; got {after.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_desync_forces_relogin_401(client: AsyncClient, regular_user_in_db: dict):
+    """Old jti still valid in Redis but DB has no matching row (desync) →
+    update_session_activity returns None → plain 401 (force re-login), NOT a
+    rotated phantom session."""
+    uid = regular_user_in_db["id"]
+    await _login(client, regular_user_in_db)
+
+    # Break the DB↔cookie link: change the row's refresh_jti so the lookup by
+    # the cookie's (still-Redis-valid) jti misses → None.
+    sess = await _latest_session(uid)
+    async with AsyncSessionLocal() as s:
+        row = (
+            await s.execute(
+                select(models.UserSession).where(models.UserSession.id == sess.id)
+            )
+        ).scalar_one()
+        row.refresh_jti = "BOGUS_DESYNC_JTI"
+        await s.commit()
+
+    r = await client.post(REFRESH)
+    assert r.status_code == 401, r.text
+    # No new cookies were issued on the desync path.
+    assert "access_token" not in r.cookies
+
+
+@pytest.mark.asyncio
+async def test_commit_failure_no_lockout(
+    client: AsyncClient, regular_user_in_db: dict, monkeypatch
+):
+    """If the DB commit fails after the Redis rotate, the endpoint must
+    compensate Redis back to OLD, issue NO new cookie, and 503 — so the
+    client's still-held OLD refresh token keeps working (no lockout)."""
+    await _login(client, regular_user_in_db)
+
+    async def _failing_commit(self):
+        raise RuntimeError("simulated commit failure")
+
+    monkeypatch.setattr(AsyncSession, "commit", _failing_commit, raising=True)
+    r = await client.post(REFRESH)
+    assert r.status_code == 503, r.text
+    assert "access_token" not in r.cookies, "no new cookie may be set on failure"
+    assert "refresh_token" not in r.cookies
+
+    # Undo the patch and prove the OLD refresh token still authenticates.
+    monkeypatch.undo()
+    r2 = await client.post(REFRESH)
+    assert r2.status_code == 200, (
+        "old refresh token must still work after a compensated commit failure "
+        f"(no lockout); got {r2.status_code}: {r2.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_redis_rotate_failure_no_lockout(
+    client: AsyncClient, regular_user_in_db: dict, monkeypatch
+):
+    """If the Redis rotate fails, the endpoint must roll back the staged DB
+    change and 503 with no new cookie; the old token still works."""
+    await _login(client, regular_user_in_db)
+
+    class _BrokenPipe:
+        async def __aenter__(self):
+            raise RuntimeError("redis down")
+
+        async def __aexit__(self, *exc):
+            return False
+
+    def _broken_pipeline(*args, **kwargs):
+        return _BrokenPipe()
+
+    monkeypatch.setattr("app.routers.auth.safe_redis_pipeline", _broken_pipeline)
+    r = await client.post(REFRESH)
+    assert r.status_code == 503, r.text
+    assert "access_token" not in r.cookies
+
+    monkeypatch.undo()
+    r2 = await client.post(REFRESH)
+    assert r2.status_code == 200, (
+        f"old token must still work after a failed Redis rotate; got {r2.status_code}"
+    )

--- a/Backend_FastAPI/tests/api/test_zalo_webhook.py
+++ b/Backend_FastAPI/tests/api/test_zalo_webhook.py
@@ -2,12 +2,14 @@
 """
 API tests for Zalo webhook endpoint.
 
-Policy (commit bdd57f1f): the route is best-effort on signature for
-the read-only branches (oa_send_* / user_follow_oa) — missing or
-invalid signature still returns 200 so Zalo does not retry-storm
-the endpoint. Strict persistence gating now lives only on the
-``user_feedback`` branch (Phase E.5), tested in
-``tests/integration/test_admission_survey_webhook.py``.
+Policy: the route always returns 200 (even on missing/invalid signature) so
+Zalo does not retry-storm the endpoint. WRITE branches are signature-gated:
+``user_feedback`` (Phase E.5, tested in
+``tests/integration/test_admission_survey_webhook.py``) and — since PR1
+Commit 4 — the delivery-status branch (oa_send_* / ZBS
+user_received_message), whose no-mutation contract is tested in
+``tests/api/test_zalo_webhook_delivery_gate.py``. Read-only branches
+(user_follow_oa / user_unfollow_oa) remain best-effort log-only.
 """
 import json
 import pytest
@@ -21,9 +23,10 @@ class TestZaloWebhook:
     """Tests for POST /api/webhooks/zalo."""
 
     async def test_missing_signature_200_acks(self, client: AsyncClient):
-        """Read-only branches accept unsigned POSTs — 200 ack, logged as
-        signature_valid=false for observability. Persistence branches
-        (user_feedback) have their own gate tested separately."""
+        """Unsigned POSTs always 200-ack (no Zalo retry storm). The
+        delivery-status branch (oa_send_template) is signature-gated since PR1
+        Commit 4: no signature → 200 but NotificationDelivery is NOT mutated
+        (no-mutation contract in test_zalo_webhook_delivery_gate.py)."""
         response = await client.post(
             "/api/webhooks/zalo",
             json={"event_name": "oa_send_template"},
@@ -31,7 +34,8 @@ class TestZaloWebhook:
         assert response.status_code == 200
 
     async def test_invalid_signature_200_acks(self, client: AsyncClient):
-        """Wrong signature still returns 200 for the same retry-storm reason."""
+        """Wrong signature still returns 200 (retry-storm avoidance); the
+        delivery-status write is skipped by the Commit 4 gate."""
         response = await client.post(
             "/api/webhooks/zalo",
             json={"event_name": "oa_send_template"},
@@ -57,18 +61,21 @@ class TestZaloWebhook:
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
 
+    @patch("app.gateways.zalo.zalo_gateway")
     async def test_zbs_user_received_routes_to_delivery_handler(
-        self, client: AsyncClient
+        self, mock_gw, client: AsyncClient
     ):
         """ZBS Template Message delivery confirmation arrives as
         ``user_received_message`` with header ``X-ZEvent-Server: ZNS``
         (per ZBS docs ``webhook-gui-tin-qua-sdt/su-kien-nguoi-dung-nhan-tin-qua-sdt``).
 
-        The endpoint must accept it as a delivery status event and 200-ack
-        even when no matching ``notification_delivery`` row exists (the
-        handler logs ``Delivery not found for Zalo callback`` in that case).
-        Without the routing wired, this would be a no-op silent miss.
+        With a valid signature (PR1 Commit 4 gate), the endpoint routes it to
+        the delivery handler and 200-acks even when no matching
+        ``notification_delivery`` row exists (the handler logs ``Delivery not
+        found for Zalo callback`` in that case). Signature is mocked valid so
+        the Commit 4 gate lets it through to the handler.
         """
+        mock_gw.verify_webhook_signature.return_value = True
         body = json.dumps({
             "event_name": "user_received_message",
             "app_id": "1860141329355019864",
@@ -86,7 +93,8 @@ class TestZaloWebhook:
             content=body.encode(),
             headers={
                 "Content-Type": "application/json",
-                "X-ZEvent-Server": "ZNS",  # marker that distinguishes ZBS from chat
+                "X-ZEvent-Server": "ZNS",  # ZBS marker (vs chat)
+                "X-ZEvent-Signature": "valid",  # gate mock True
             },
         )
         assert response.status_code == 200

--- a/Backend_FastAPI/tests/api/test_zalo_webhook_delivery_gate.py
+++ b/Backend_FastAPI/tests/api/test_zalo_webhook_delivery_gate.py
@@ -1,0 +1,100 @@
+"""PR1 Commit 4 anchor: Zalo delivery-status callbacks are fail-closed
+(A08 Integrity / A10).
+
+``_handle_delivery_status`` mutates ``NotificationDelivery`` (status /
+sent_at / error_reason) and commits — a durable write reachable from the
+unauthenticated public webhook. After Commit 4 it runs ONLY when the
+X-ZEvent-Signature verifies; a forged/unsigned callback is still 200-acked
+(no Zalo retry storm) but must NOT mutate any row.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.database import AsyncSessionLocal
+from app.models.notification_delivery import NotificationDelivery
+
+WEBHOOK = "/api/webhooks/zalo"
+
+
+async def _make_delivery(msg_id: str, status: str = "sent") -> int:
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            d = NotificationDelivery(
+                event="test_delivery_gate",
+                channel="zalo",
+                status=status,
+                provider_message_id=msg_id,
+            )
+            s.add(d)
+            await s.flush()
+            return d.id
+
+
+async def _status_of(delivery_id: int) -> str:
+    async with AsyncSessionLocal() as s:
+        row = await s.execute(
+            select(NotificationDelivery).where(
+                NotificationDelivery.id == delivery_id
+            )
+        )
+        return row.scalar_one().status
+
+
+@pytest.mark.asyncio
+async def test_forged_delivery_callback_does_not_mutate(client: AsyncClient):
+    """Unsigned callback claiming error=1 must NOT flip the row to failed."""
+    did = await _make_delivery("msg_forge_gate", status="sent")
+    body = json.dumps(
+        {
+            "event_name": "oa_send_template",
+            "msg_id": "msg_forge_gate",
+            "error": 1,
+            "status": "FAILED",
+        }
+    )
+    resp = await client.post(
+        WEBHOOK,
+        content=body.encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    # Still 200-ack (no Zalo retry storm) but the row is untouched.
+    assert resp.status_code == 200
+    assert await _status_of(did) == "sent", (
+        "forged unsigned callback must NOT mutate NotificationDelivery"
+    )
+
+
+@pytest.mark.asyncio
+@patch("app.gateways.zalo.zalo_gateway")
+async def test_signed_delivery_callback_still_mutates(
+    mock_gw, client: AsyncClient
+):
+    """A validly-signed callback still processes (sent -> delivered) — the
+    gate must not break legitimate delivery tracking."""
+    mock_gw.verify_webhook_signature.return_value = True
+    did = await _make_delivery("msg_valid_gate", status="sent")
+    body = json.dumps(
+        {
+            "event_name": "oa_send_template",
+            "msg_id": "msg_valid_gate",
+            "error": 0,
+        }
+    )
+    resp = await client.post(
+        WEBHOOK,
+        content=body.encode(),
+        headers={
+            "Content-Type": "application/json",
+            "X-ZEvent-Signature": "valid",
+        },
+    )
+    assert resp.status_code == 200
+    assert await _status_of(did) == "delivered", (
+        "validly-signed callback must still update the row (sent->delivered)"
+    )

--- a/Backend_FastAPI/tests/integration/test_admission_state_transitions.py
+++ b/Backend_FastAPI/tests/integration/test_admission_state_transitions.py
@@ -659,7 +659,10 @@ class TestStateTransitionWorkflows:
         assert token_info_response.status_code == 200, f"Token info failed: {token_info_response.text}"
         token_info = token_info_response.json()
         assert token_info["valid"] is True
-        assert token_info["profile_name"] == "Test Applicant"
+        # PR1 Commit 7: profile_name is MASKED on this public, pre-verification
+        # endpoint (the full name is only revealed after CCCD verify).
+        assert token_info["profile_name"] == "T••• A•••"
+        assert token_info["profile_name"] != "Test Applicant"
 
         # 5. Lead confirms with wrong CCCD (should fail)
         wrong_confirm_response = await client.post(
@@ -824,7 +827,10 @@ class TestTokenBasedConfirmation:
         assert data["locked"] is False
         assert data["already_used"] is False
         assert data["attempts_remaining"] == 5
-        assert data["profile_name"] == "Test Applicant"
+        # PR1 Commit 7: profile_name is MASKED on this public, pre-verification
+        # endpoint (full name only after CCCD verify).
+        assert data["profile_name"] == "T••• A•••"
+        assert data["profile_name"] != "Test Applicant"
 
     async def test_invalid_token_returns_404(
         self,

--- a/Backend_FastAPI/tests/integration/test_casbin_lead_static_route_collision.py
+++ b/Backend_FastAPI/tests/integration/test_casbin_lead_static_route_collision.py
@@ -46,6 +46,17 @@ Matrix expectations (4 routes × 4 roles = 16 cells):
 Plus 1 regression test: officer GET /api/leads/123 must STILL succeed
 (non-collision numeric ID — verifies we didn't accidentally break the
 legitimate /{id} lookup path).
+
+NOTE (PR1 Commit 3, 2026-06-01): the officer/accountant "leak" cells in
+EXPECTED below are CASBIN-LAYER truth ONLY. The 4 HTTP routes now carry an
+explicit ``Depends(require_admin_or_manager)`` hard gate (``require_admin``
+for bulk-delete) IN FRONT of CasbinAuth, so a direct API call by an
+officer/accountant now 403s regardless of the keyMatch4 collision — pinned
+by tests/api/test_lead_static_route_http_gate.py. This Casbin matrix is kept
+as the policy-table contract (e.g. accountant explicit deny); the
+custom-matcher cleanup (memory ``lead-keymatch4-collision-followup``)
+remains a separate follow-up. Assertions here are unchanged because the
+policy templates were not touched.
 """
 from __future__ import annotations
 

--- a/Backend_FastAPI/tests/integration/test_finance_workflow.py
+++ b/Backend_FastAPI/tests/integration/test_finance_workflow.py
@@ -32,11 +32,17 @@ from app.services.invoice_service import InvoiceService
 from app.services.payment_service import PaymentService, RefundService
 from app.services.payment_intent_service import PaymentIntentService
 from app.services.accounting_service import AccountingPeriodService
+from app.config import settings
 from app.utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
     BusinessRuleViolation,
     ConflictError,
+)
+
+# PR1 Commit 5: create_intent now allowlists return_url against FRONTEND_URL.
+VALID_RETURN_URL = (
+    f"{settings.FRONTEND_URL.rstrip('/')}/finance/payments/return"
 )
 
 
@@ -737,7 +743,7 @@ class TestOnlinePayment:
             method_id=finance_fixtures["vnpay"].id,
             amount=Decimal("500000"),
             idempotency_key="test-uuid-123",
-            return_url="https://example.com/payment/return",
+            return_url=VALID_RETURN_URL,
             unit_id=finance_fixtures["unit_id"],
         )
         await db.commit()
@@ -787,7 +793,7 @@ class TestOnlinePayment:
             method_id=finance_fixtures["vnpay"].id,
             amount=Decimal("1000000"),
             idempotency_key="idempotency-test-456",
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=finance_fixtures["unit_id"],
         )
         await db.commit()
@@ -798,7 +804,7 @@ class TestOnlinePayment:
             method_id=finance_fixtures["vnpay"].id,
             amount=Decimal("1000000"),
             idempotency_key="idempotency-test-456",  # Same key
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=finance_fixtures["unit_id"],
         )
         await db.commit()

--- a/Backend_FastAPI/tests/services/test_payment_intent_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_intent_service.py
@@ -32,6 +32,7 @@ from app.models.finance import (
 from app.services.fee_calculation_service import FeeCalculationService
 from app.services.invoice_service import InvoiceService
 from app.services.payment_intent_service import PaymentIntentService
+from app.config import settings
 from app.utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
@@ -39,6 +40,12 @@ from app.utils.exceptions import (
 )
 
 pytestmark = pytest.mark.asyncio
+
+# PR1 Commit 5: create_intent now allowlists return_url against FRONTEND_URL.
+# Use a same-origin URL so these fixtures pass the new guard.
+VALID_RETURN_URL = (
+    f"{settings.FRONTEND_URL.rstrip('/')}/finance/payments/return"
+)
 
 
 # =============================================================================
@@ -147,7 +154,7 @@ class TestCreateIntent:
             method_id=method.id,
             amount=Decimal("1000000"),
             idempotency_key=key,
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=intent_fixtures["unit_id"],
         )
         await db.commit()
@@ -161,6 +168,26 @@ class TestCreateIntent:
         assert intent.pay_url is not None
         assert intent.expires_at is not None
 
+    async def test_create_intent_rejects_foreign_return_url(
+        self, db, intent_fixtures, admin_user
+    ):
+        """PR1 Commit 5: a return_url whose origin differs from FRONTEND_URL is
+        rejected (open-redirect guard) → BusinessRuleViolation (mapped to HTTP
+        400 by the payments router). Proves the guard is wired into
+        create_intent, not just the standalone helper."""
+        service = PaymentIntentService(db)
+        invoice = intent_fixtures["invoice"]
+        method = intent_fixtures["online_method"]
+        with pytest.raises(BusinessRuleViolation):
+            await service.create_intent(
+                invoice_id=invoice.id,
+                method_id=method.id,
+                amount=Decimal("1000000"),
+                idempotency_key=str(uuid.uuid4()),
+                return_url="https://attacker.evil/finance/payments/return",
+                unit_id=intent_fixtures["unit_id"],
+            )
+
     async def test_create_intent_idempotency_same_key(self, db, intent_fixtures, admin_user):
         """Same idempotency key + invoice returns existing non-terminal intent."""
         service = PaymentIntentService(db)
@@ -173,7 +200,7 @@ class TestCreateIntent:
             method_id=method.id,
             amount=Decimal("1000000"),
             idempotency_key=key,
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=intent_fixtures["unit_id"],
         )
         await db.commit()
@@ -183,7 +210,7 @@ class TestCreateIntent:
             method_id=method.id,
             amount=Decimal("1000000"),
             idempotency_key=key,
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=intent_fixtures["unit_id"],
         )
 
@@ -205,7 +232,7 @@ class TestCreateIntent:
                 method_id=method.id,
                 amount=Decimal("1000000"),
                 idempotency_key=str(uuid.uuid4()),
-                return_url="https://example.com/return",
+                return_url=VALID_RETURN_URL,
                 unit_id=intent_fixtures["unit_id"],
             )
 
@@ -223,7 +250,7 @@ class TestCreateIntent:
                 method_id=method.id,
                 amount=Decimal("1000000"),
                 idempotency_key=str(uuid.uuid4()),
-                return_url="https://example.com/return",
+                return_url=VALID_RETURN_URL,
                 unit_id=intent_fixtures["unit_id"],
             )
 
@@ -241,7 +268,7 @@ class TestCreateIntent:
                 method_id=method.id,
                 amount=Decimal("999999999"),
                 idempotency_key=str(uuid.uuid4()),
-                return_url="https://example.com/return",
+                return_url=VALID_RETURN_URL,
                 unit_id=intent_fixtures["unit_id"],
             )
 
@@ -259,7 +286,7 @@ class TestCreateIntent:
                 method_id=method.id,
                 amount=Decimal("1000000"),
                 idempotency_key=str(uuid.uuid4()),
-                return_url="https://example.com/return",
+                return_url=VALID_RETURN_URL,
                 unit_id=intent_fixtures["unit_id"],
             )
 
@@ -285,7 +312,7 @@ class TestProcessCallback:
             method_id=method.id,
             amount=amount,
             idempotency_key=str(uuid.uuid4()),
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=intent_fixtures["unit_id"],
         )
         await db.commit()
@@ -319,7 +346,7 @@ class TestProcessCallback:
             method_id=method.id,
             amount=Decimal("1000000"),
             idempotency_key=str(uuid.uuid4()),
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=intent_fixtures["unit_id"],
         )
         await db.commit()
@@ -353,7 +380,7 @@ class TestProcessCallback:
             method_id=method.id,
             amount=Decimal("1000000"),
             idempotency_key=str(uuid.uuid4()),
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=intent_fixtures["unit_id"],
             expiration_minutes=0,  # Already expired
         )
@@ -389,7 +416,7 @@ class TestProcessCallback:
             method_id=method.id,
             amount=amount,
             idempotency_key=str(uuid.uuid4()),
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=intent_fixtures["unit_id"],
         )
         await db.commit()
@@ -428,7 +455,7 @@ class TestIntentLifecycle:
             method_id=method.id,
             amount=Decimal("1000000"),
             idempotency_key=str(uuid.uuid4()),
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=intent_fixtures["unit_id"],
         )
         await db.commit()
@@ -454,7 +481,7 @@ class TestIntentLifecycle:
             method_id=method.id,
             amount=Decimal("1000000"),
             idempotency_key=str(uuid.uuid4()),
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=intent_fixtures["unit_id"],
         )
         await db.commit()
@@ -490,7 +517,7 @@ class TestIntentLifecycle:
             method_id=method.id,
             amount=Decimal("1000000"),
             idempotency_key=str(uuid.uuid4()),
-            return_url="https://example.com/return",
+            return_url=VALID_RETURN_URL,
             unit_id=intent_fixtures["unit_id"],
         )
         await db.commit()
@@ -520,7 +547,7 @@ class TestIntentLifecycle:
                 method_id=method.id,
                 amount=Decimal("100000"),
                 idempotency_key=str(uuid.uuid4()),
-                return_url="https://example.com/return",
+                return_url=VALID_RETURN_URL,
                 unit_id=intent_fixtures["unit_id"],
             )
             intent.expires_at = datetime.now(timezone.utc) - timedelta(minutes=30)

--- a/Backend_FastAPI/tests/unit/test_config_production_fail_fast.py
+++ b/Backend_FastAPI/tests/unit/test_config_production_fail_fast.py
@@ -1,0 +1,67 @@
+"""PR1 Commit 6 (+ C5) anchor: _validate_production_secrets fails fast on
+missing/weak payment + MFA config in production (A02 / A04).
+
+Sets every earlier prod check to a valid value so the validator reaches the
+specific check under test, then asserts the RuntimeError.
+"""
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.config import settings
+
+
+def _set_valid_prod(monkeypatch):
+    """Make every prod check except the one under test pass."""
+    monkeypatch.setattr(settings, "APP_ENV", "production")
+    monkeypatch.setattr(settings, "SECRET_KEY", "s" * 40)
+    monkeypatch.setattr(settings, "JWT_SECRET_KEY", "j" * 40)
+    monkeypatch.setattr(settings, "DEVICE_FINGERPRINT_SALT", "real-salt-value")
+    monkeypatch.setattr(settings, "LOG_LEVEL", "INFO")
+    monkeypatch.setattr(
+        settings,
+        "DATABASE_URL",
+        "postgresql+asyncpg://u:p@remote/db?sslmode=require",
+    )
+    monkeypatch.setattr(settings, "ALLOW_DOCKER_INTERNAL_NETWORK", True)
+    monkeypatch.setattr(settings, "FRONTEND_URL", "https://app.prod")
+    monkeypatch.setattr(settings, "PUBLIC_BACKEND_URL", "https://backend.prod")
+    monkeypatch.setattr(
+        settings, "MFA_ENCRYPTION_KEY", Fernet.generate_key().decode()
+    )
+
+
+def test_valid_production_config_passes(monkeypatch):
+    _set_valid_prod(monkeypatch)
+    settings._validate_production_secrets()  # must not raise
+
+
+def test_mfa_encryption_key_required(monkeypatch):
+    _set_valid_prod(monkeypatch)
+    monkeypatch.setattr(settings, "MFA_ENCRYPTION_KEY", "")
+    with pytest.raises(RuntimeError, match="MFA_ENCRYPTION_KEY"):
+        settings._validate_production_secrets()
+
+
+def test_mfa_encryption_key_must_be_valid_fernet(monkeypatch):
+    _set_valid_prod(monkeypatch)
+    # Non-empty but NOT a valid Fernet key (32 url-safe base64 bytes) — would
+    # pass a naive "is set" check yet crash MFA at runtime.
+    monkeypatch.setattr(settings, "MFA_ENCRYPTION_KEY", "not-a-fernet-key")
+    with pytest.raises(RuntimeError, match="MFA_ENCRYPTION_KEY"):
+        settings._validate_production_secrets()
+
+
+def test_frontend_url_must_be_https(monkeypatch):
+    _set_valid_prod(monkeypatch)
+    monkeypatch.setattr(settings, "FRONTEND_URL", "http://localhost:3000")
+    with pytest.raises(RuntimeError, match="FRONTEND_URL"):
+        settings._validate_production_secrets()
+
+
+def test_public_backend_url_must_be_https(monkeypatch):
+    _set_valid_prod(monkeypatch)
+    monkeypatch.setattr(settings, "PUBLIC_BACKEND_URL", "http://backend.prod")
+    with pytest.raises(RuntimeError, match="PUBLIC_BACKEND_URL"):
+        settings._validate_production_secrets()

--- a/Backend_FastAPI/tests/unit/test_payment_return_url_guard.py
+++ b/Backend_FastAPI/tests/unit/test_payment_return_url_guard.py
@@ -1,0 +1,103 @@
+"""PR1 Commit 5 anchor: payment return_url allowlist + MoMo IPN host guard
+(A01 open-redirect / A06 SSRF).
+
+build_safe_return_url normalizes/allowlists the client-supplied return_url
+(the gateway echoes it back to the user), and the MoMo IPN URL is derived
+from the trusted PUBLIC_BACKEND_URL instead of that return_url.
+"""
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import pytest
+
+from app.config import settings
+from app.gateways.momo import MoMoAdapter
+from app.services.payment_intent_service import build_safe_return_url
+from app.utils.exceptions import BusinessRuleViolation
+
+CANONICAL = f"{settings.FRONTEND_URL.rstrip('/')}/finance/payments/return"
+
+
+def test_none_or_empty_returns_canonical_default():
+    assert build_safe_return_url(None) == CANONICAL
+    assert build_safe_return_url("") == CANONICAL
+
+
+def test_same_origin_return_url_kept():
+    url = f"{settings.FRONTEND_URL.rstrip('/')}/finance/payments/return?x=1"
+    assert build_safe_return_url(url) == url
+
+
+def test_foreign_host_rejected():
+    with pytest.raises(BusinessRuleViolation):
+        build_safe_return_url("https://attacker.evil/finance/payments/return")
+
+
+def test_suffix_confusion_host_rejected():
+    # A naive `FRONTEND_URL in url` / startswith check would ACCEPT this
+    # look-alike host; the netloc tuple compare must reject it.
+    p = urlparse(settings.FRONTEND_URL)
+    attack = f"{p.scheme}://{p.netloc}.evil.com/finance/payments/return"
+    with pytest.raises(BusinessRuleViolation):
+        build_safe_return_url(attack)
+
+
+def test_userinfo_host_rejected():
+    # The real host is after '@' (evil.com); a naive substring check would see
+    # the FRONTEND host in the userinfo and wrongly accept it.
+    p = urlparse(settings.FRONTEND_URL)
+    attack = f"{p.scheme}://{p.netloc}@evil.com/finance/payments/return"
+    with pytest.raises(BusinessRuleViolation):
+        build_safe_return_url(attack)
+
+
+def test_scheme_mismatch_rejected():
+    # Origin is scheme+host; same host but a different scheme is rejected.
+    p = urlparse(settings.FRONTEND_URL)
+    other = "https" if p.scheme == "http" else "http"
+    with pytest.raises(BusinessRuleViolation):
+        build_safe_return_url(f"{other}://{p.netloc}/finance/payments/return")
+
+
+def test_momo_ipn_url_from_public_backend_not_return_url():
+    adapter = MoMoAdapter(
+        partner_code="P",
+        access_key="A",
+        secret_key="S",
+        public_backend_url="https://backend.test",
+    )
+    assert adapter._build_ipn_url() == (
+        "https://backend.test/api/payments/callback/momo"
+    )
+
+
+def test_momo_from_settings_wires_public_backend_url():
+    adapter = MoMoAdapter.from_settings(settings)
+    assert adapter.public_backend_url == settings.PUBLIC_BACKEND_URL
+
+
+def test_register_default_gateways_wires_momo_public_backend_url(monkeypatch):
+    # The REAL runtime registration path (NOT from_settings) must also wire
+    # public_backend_url — else the IPN URL loses its host and the SSRF guard
+    # is silently defeated. Regression lock for the gate finding.
+    from app.services.payment_intent_service import (
+        PaymentIntentService,
+        register_default_gateways,
+    )
+
+    monkeypatch.setattr(settings, "MOMO_PARTNER_CODE", "P")
+    monkeypatch.setattr(settings, "MOMO_ACCESS_KEY", "A")
+    monkeypatch.setattr(settings, "MOMO_SECRET_KEY", "S")
+    monkeypatch.setattr(settings, "MOMO_ENDPOINT", "https://momo.test")
+    monkeypatch.setattr(settings, "PUBLIC_BACKEND_URL", "https://backend.test")
+
+    service = PaymentIntentService(None)
+    register_default_gateways(service)
+
+    adapter = service._gateway_adapters.get("momo")
+    assert adapter is not None, "momo must register when creds are set"
+    assert adapter.public_backend_url == "https://backend.test"
+    assert adapter._build_ipn_url() == (
+        "https://backend.test/api/payments/callback/momo"
+    )

--- a/nginx/conf.d/default.conf.template
+++ b/nginx/conf.d/default.conf.template
@@ -153,13 +153,11 @@ server {
     }
 
     # --- Static file uploads (served directly by Nginx) ---
-    location /uploads/ {
-        alias /app/uploads/;
-        expires 7d;
-        add_header Cache-Control "public, no-transform";
-        try_files $uri =404;
-    }
-
+    # SECURITY (PR1 Commit 1 — A01/A02): the public `location /uploads/` was
+    # REMOVED. Admission documents (PII: CCCD, học bạ, priority evidence) are
+    # now served ONLY via the authed, IDOR-scoped, audited FastAPI endpoint
+    #   GET /api/admissions/{id}/documents/{doc_id}/download
+    # (proxied under the `/api/` location). Avatars stay public below.
     location /static/uploads/ {
         alias /app/static/uploads/;
         expires 30d;


### PR DESCRIPTION
## Security hardening — backend boundaries + session-revocation fix (7 commits)

Closes 9 verified findings from the 2026-05-25 security audit. Backend-only, packaged as 1 PR / 1 backend deploy. Each commit is independent (one per finding) for review/rollback. The frontend call-site changes + test-artifact cleanup are a **separate follow-up (PR2)** — see below.

### Commits
| # | Commit | Closes |
|---|---|---|
| C1 | authed document download + remove public `/uploads` | Admission docs (CCCD/học bạ) were served UNAUTHENTICATED; now an IDOR-scoped, audited download endpoint, public mount removed |
| C2 | commit session refresh rotation + fail-closed compensation | `/auth/refresh` never committed the rotation → `refresh_jti` frozen (8/16 live sessions desynced); revoke blacklisted the wrong jti |
| C3 | admin/manager hard gate on lead static routes | Casbin keyMatch4 collision leaked `/export` + `/distribution-preview` to officers by direct API call |
| C4 | fail-closed Zalo delivery-status webhook | The public webhook mutated `NotificationDelivery` regardless of signature (forgeable) |
| C5 | payment return_url allowlist + MoMo IPN from PUBLIC_BACKEND_URL | Open-redirect / SSRF (IPN derived from the client return_url) + raw unverified callback logged |
| C6 | trim `/health/detailed` + MFA Fernet-key fail-fast | Recon leak (exception class names / worker counts) + MFA key only checked non-empty, not Fernet-valid |
| C7 | mask confirm-token name + effective no-referrer | The public confirm endpoint exposed the lead's full name (PII) before CCCD verification |

### :warning: DEPLOY PREREQUISITE (§0) — set BEFORE deploying this PR
This PR adds production fail-fast checks. The backend will **crash on boot (by design)** if these are missing/invalid in `.env.production`:

- `PUBLIC_BACKEND_URL=https://qlts.tnpc.edu.vn` — must be `https://`, non-localhost
- `FRONTEND_URL=https://qlts.tnpc.edu.vn` — must be `https://`, non-localhost
- `MFA_ENCRYPTION_KEY` — must be a **valid Fernet key** (NOT a hand-typed string): `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`

Verify before deploy: `docker compose --env-file .env.production --profile production config` + a startup smoke. **Do NOT deploy until all three are set.**

Migration `docdl_audit_001` (relax `ck_document_audit_log_action` to allow `downloaded`) runs automatically via the entrypoint `alembic upgrade head`. Nginx `default.conf` must be regenerated (the `/uploads` location was removed).

### Follow-up — NOT in this PR
- **PR2 (frontend)**: switch the 4 document-view call-sites to the new authed `/documents/{document_id}/download` endpoint (zod gains optional `document_id`; hide the button when null); remove the hardcoded TOTP secret (17 `.spec.ts` files) + `.mfa-backup-codes.txt` and **rotate** the key (it lives in git history).

### Tests
Each commit ships anchor tests + green regressions. Consolidated pre-push run: **45/45** across all 7 commits' suites (sequential). Full flake8 net-new = 0 per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
