### PR TITLE
test(admission): fix #337 CONFIG_GAP submit test-debt (config + KV seed)

### DIFF
--- a/Backend_FastAPI/tests/fixtures/builders.py
+++ b/Backend_FastAPI/tests/fixtures/builders.py
@@ -90,6 +90,187 @@ async def ensure_submittable_ward() -> str:
     return SUBMITTABLE_WARD_CODE
 
 
+async def seed_submittable_offering_config(session, unit_id: int) -> dict:
+    """Seed the full legacy single-NV submit chain (#337) and return its ids.
+
+    ``unit_id`` is the owning OrganizationUnit for the MajorProgram (NOT NULL
+    FK) — pass the lead's unit so the chain stays scope-consistent.
+
+    ``submit_and_evaluate``'s legacy path (``uses_choice_engine=False``)
+    derives the target level from ``offering_admission_config_id`` →
+    academic_info → offering → ``MajorProgram.degree_level_id`` +
+    ``ProgramOffering.offering_type_id``, then resolves the applicant's KV
+    from the academic_history THPT entry → ``VnSchool`` →
+    ``VnSchoolKvAssignment``. Without both, submit fail-closes with
+    ``CONFIG_GAP_TARGET_LEVEL`` / ``KV_UNRESOLVED`` (the #337 test-debt).
+
+    Mirrors ``tests/api/test_magic_link_3_actions_wire.py::_seed`` — the
+    proven recipe shipped with the 2026-05-29 magic-link #337 fix.
+    ``ConfigOfferingType``/``ConfigDegreeLevel`` are get-or-created (shared
+    UNIQUE codes); everything else uses a per-call suffix to avoid
+    cross-test collisions. The caller owns the session/transaction; this
+    helper flushes but does not commit.
+
+    Returns ``{offering_admission_config_id, school_id, academic_year,
+    major_program_id}``. Pair with ``ensure_submittable_ward()`` +
+    ``SUBMITTABLE_PERMANENT_ADDRESS`` + a ``graduated_thpt`` cultural level
+    on the profile for a fully submittable hồ sơ.
+    """
+    from sqlalchemy import select
+
+    from app import models
+
+    suffix = _next_id()
+    academic_year = 2026
+
+    offering_type = (
+        await session.execute(
+            select(models.ConfigOfferingType).where(
+                models.ConfigOfferingType.code == "chinh_quy"
+            )
+        )
+    ).scalar_one_or_none()
+    if offering_type is None:
+        offering_type = models.ConfigOfferingType(
+            code="chinh_quy", name="Chính quy", is_active=True,
+        )
+        session.add(offering_type)
+        await session.flush()
+
+    degree_level = (
+        await session.execute(
+            select(models.ConfigDegreeLevel).where(
+                models.ConfigDegreeLevel.code == "cao_dang"
+            )
+        )
+    ).scalar_one_or_none()
+    if degree_level is None:
+        degree_level = models.ConfigDegreeLevel(
+            code="cao_dang", name="Cao đẳng", display_order=2, is_active=True,
+        )
+        session.add(degree_level)
+        await session.flush()
+
+    # MajorProgram.degree_level_id (FK) is what derive_target_level_and_type
+    # reads; the legacy ``degree_level`` text column is still NOT NULL so it
+    # must be populated in parallel.
+    # Explicit id via the shared _next_id() counter — SeedDependenciesBuilder
+    # also inserts MajorProgram with explicit ids, leaving the SERIAL
+    # sequence behind, so an auto-id insert here would collide on the pkey.
+    major = models.MajorProgram(
+        id=suffix,
+        name=f"Submittable Major {suffix}",
+        code=f"SM{suffix}",
+        degree_level="Cao đẳng",
+        degree_level_id=degree_level.id,
+        unit_id=unit_id,
+    )
+    session.add(major)
+    await session.flush()
+
+    offering = models.ProgramOffering(
+        offering_type=f"sm_{suffix}",
+        program_id=major.id,
+        offering_type_id=offering_type.id,
+    )
+    session.add(offering)
+    await session.flush()
+
+    academic_info = models.OfferingAcademicInfo(
+        offering_id=offering.id,
+        academic_year=academic_year,
+        is_published=True,
+    )
+    session.add(academic_info)
+    await session.flush()
+
+    method = models.AdmissionMethod(
+        code=f"sm_method_{suffix}", name="Submittable method", is_active=True,
+    )
+    session.add(method)
+    await session.flush()
+
+    criteria = models.AdmissionCriteria(
+        method_id=method.id,
+        code=f"sm_crit_{suffix}",
+        name="Submittable criteria",
+        min_gpa=0,
+        is_active=True,
+    )
+    session.add(criteria)
+    await session.flush()
+
+    config = models.OfferingAdmissionConfig(
+        academic_info_id=academic_info.id,
+        criteria_id=criteria.id,
+        is_active=True,
+    )
+    session.add(config)
+    await session.flush()
+
+    # KV layer: a THPT school + KV3 assignment covering graduation years
+    # 2020-2024 so the academic_history THPT entry resolves to a KV.
+    school = models.VnSchool(
+        moet_school_code=f"S{suffix}",
+        moet_province_code="001",
+        name=f"THPT Submittable {suffix}",
+        province="Hà Nội",
+        district="Ba Đình",
+        level="THPT",
+    )
+    session.add(school)
+    await session.flush()
+    session.add(
+        models.VnSchoolKvAssignment(
+            school_id=school.id,
+            kv_code="KV3",
+            effective_from_year=2020,
+            effective_to_year=2024,
+            source="manual_admin",
+        )
+    )
+    await session.flush()
+
+    return {
+        "offering_admission_config_id": config.id,
+        "school_id": school.id,
+        "academic_year": academic_year,
+        "major_program_id": major.id,
+    }
+
+
+def submittable_profile_fields(seed: dict) -> dict:
+    """Profile column kwargs that clear every ``submit_and_evaluate`` gate,
+    given a seed from ``seed_submittable_offering_config()``.
+
+    Covers (#337): the legacy target-level config, a KV-resolvable THPT
+    ``academic_history`` entry, ``graduated_thpt`` cultural eligibility, and
+    the Gap #3 permanent address. The caller must ALSO
+    ``await ensure_submittable_ward()`` once before creating the profile.
+    """
+    return {
+        "offering_admission_config_id": seed["offering_admission_config_id"],
+        "cultural_education_level": "graduated_thpt",
+        "vocational_qualification": "none",
+        "uses_choice_engine": False,
+        "full_name": "Submittable Candidate",
+        "phone": "0901234567",
+        **SUBMITTABLE_PERMANENT_ADDRESS,
+        "academic_history": [
+            {
+                "school_name": "THPT Submittable",
+                "year_from": 2020,
+                "year_to": 2024,
+                "gpa": 8.0,
+                "graduation_type": "THPT",
+                "level": "THPT",
+                "grade_to": 12,
+                "school_id": seed["school_id"],
+            }
+        ],
+    }
+
+
 class SeedDependenciesBuilder:
     """
     Builder for seeding unit/stage/status dependencies.

--- a/Backend_FastAPI/tests/fixtures/builders.py
+++ b/Backend_FastAPI/tests/fixtures/builders.py
@@ -90,11 +90,16 @@ async def ensure_submittable_ward() -> str:
     return SUBMITTABLE_WARD_CODE
 
 
-async def seed_submittable_offering_config(session, unit_id: int) -> dict:
+async def seed_submittable_offering_config(
+    session, unit_id: int, academic_year: int = 2026
+) -> dict:
     """Seed the full legacy single-NV submit chain (#337) and return its ids.
 
     ``unit_id`` is the owning OrganizationUnit for the MajorProgram (NOT NULL
     FK) — pass the lead's unit so the chain stays scope-consistent.
+    ``academic_year`` flows into ``OfferingAcademicInfo`` and is echoed back in
+    the result so the caller's profile honors the SAME year — avoids a silent
+    mismatch against the UNIQUE(lead_id/citizen_id, academic_year) constraints.
 
     ``submit_and_evaluate``'s legacy path (``uses_choice_engine=False``)
     derives the target level from ``offering_admission_config_id`` →
@@ -121,7 +126,6 @@ async def seed_submittable_offering_config(session, unit_id: int) -> dict:
     from app import models
 
     suffix = _next_id()
-    academic_year = 2026
 
     offering_type = (
         await session.execute(

--- a/Backend_FastAPI/tests/integration/test_admission_security.py
+++ b/Backend_FastAPI/tests/integration/test_admission_security.py
@@ -18,6 +18,11 @@ from sqlalchemy import select
 
 from app import models
 from app.database import AsyncSessionLocal
+from tests.fixtures.builders import (
+    ensure_submittable_ward,
+    seed_submittable_offering_config,
+    submittable_profile_fields,
+)
 
 
 pytestmark = pytest.mark.asyncio
@@ -81,8 +86,16 @@ async def create_submittable_profile_direct(
     academic_year: int = 2025,
 ) -> models.AdmissionProfile:
     """Create a profile that can be submitted (with subject scores, family_info, etc.)."""
+    # Gap #3: a current-era ward so the permanent address validates.
+    await ensure_submittable_ward()
     async with AsyncSessionLocal() as session:
         async with session.begin():
+            lead = await session.get(models.Lead, lead_id)
+            # #337: legacy config + KV chain so submit can derive the
+            # target level + resolve KV (else CONFIG_GAP / KV_UNRESOLVED).
+            seed = await seed_submittable_offering_config(
+                session, lead.unit_id
+            )
             subj = (await session.execute(
                 select(models.Subject).where(models.Subject.code == "TOAN")
             )).scalar_one_or_none()
@@ -95,7 +108,7 @@ async def create_submittable_profile_direct(
                 lead_id=lead_id,
                 status="draft",
                 citizen_id=citizen_id,
-                academic_year=academic_year,
+                academic_year=seed["academic_year"],
                 version=1,
                 applied_rules={
                     "min_gpa": 0,
@@ -106,7 +119,7 @@ async def create_submittable_profile_direct(
                     "subject_selection_mode": "fixed",
                 },
                 family_info=[{"relationship": "Cha", "full_name": "Test Father", "phone": "0901234567"}],
-                academic_history=[{"school_name": "THPT Test", "year_from": 2020, "year_to": 2024}],
+                **submittable_profile_fields(seed),
             )
             session.add(profile)
             await session.flush()

--- a/Backend_FastAPI/tests/integration/test_admission_security.py
+++ b/Backend_FastAPI/tests/integration/test_admission_security.py
@@ -94,7 +94,7 @@ async def create_submittable_profile_direct(
             # #337: legacy config + KV chain so submit can derive the
             # target level + resolve KV (else CONFIG_GAP / KV_UNRESOLVED).
             seed = await seed_submittable_offering_config(
-                session, lead.unit_id
+                session, lead.unit_id, academic_year
             )
             subj = (await session.execute(
                 select(models.Subject).where(models.Subject.code == "TOAN")

--- a/Backend_FastAPI/tests/services/test_admission_service.py
+++ b/Backend_FastAPI/tests/services/test_admission_service.py
@@ -20,6 +20,11 @@ from sqlalchemy import select
 
 from app import models
 from app.database import AsyncSessionLocal
+from tests.fixtures.builders import (
+    ensure_submittable_ward,
+    seed_submittable_offering_config,
+    submittable_profile_fields,
+)
 
 
 pytestmark = pytest.mark.asyncio
@@ -196,8 +201,19 @@ async def create_submittable_profile_direct(
             "subject_selection_mode": "fixed",
         }
 
+    # Gap #3: a current-era ward so the permanent address validates.
+    await ensure_submittable_ward()
+
     async with AsyncSessionLocal() as session:
         async with session.begin():
+            lead = await session.get(models.Lead, lead_id)
+            # #337: seed the legacy config + KV chain so submit can derive the
+            # target level and resolve the applicant's KV (else
+            # CONFIG_GAP_TARGET_LEVEL / KV_UNRESOLVED keep the profile draft).
+            seed = await seed_submittable_offering_config(
+                session, lead.unit_id
+            )
+
             # Create subject if needed
             subj = (await session.execute(
                 select(models.Subject).where(models.Subject.code == "TOAN")
@@ -213,9 +229,9 @@ async def create_submittable_profile_direct(
                 citizen_id=citizen_id,
                 version=1,
                 applied_rules=applied_rules,
-                academic_year=2025,
+                academic_year=seed["academic_year"],
                 family_info=[{"relationship": "Cha", "full_name": "Test Father", "phone": "0901234567"}],
-                academic_history=[{"school_name": "THPT Test", "year_from": 2020, "year_to": 2024}],
+                **submittable_profile_fields(seed),
             )
             session.add(profile)
             await session.flush()
@@ -842,9 +858,13 @@ class TestSubmitAndEvaluate:
             unit_id, assigned_officer_id=officer_user_in_db["id"]
         )
 
-        # Create profile WITHOUT citizen_id (required for submit)
+        # Create profile WITHOUT citizen_id (required for submit). Everything
+        # else clears the submit gates (#337 seed) so the ONLY failure is the
+        # missing citizen_id → draft + validation_errors, not CONFIG_GAP 400.
+        await ensure_submittable_ward()
         async with AsyncSessionLocal() as session:
             async with session.begin():
+                seed = await seed_submittable_offering_config(session, unit_id)
                 subj = (await session.execute(
                     select(models.Subject).where(models.Subject.code == "TOAN")
                 )).scalar_one_or_none()
@@ -866,9 +886,13 @@ class TestSubmitAndEvaluate:
                         "required_subject_count": 1,
                         "subject_selection_mode": "fixed",
                     },
-                    academic_year=2025,
-                    family_info=[{"relationship": "Cha", "full_name": "Test Father", "phone": "0901234567"}],
-                    academic_history=[{"school_name": "THPT Test", "year_from": 2020, "year_to": 2024}],
+                    academic_year=seed["academic_year"],
+                    family_info=[{
+                        "relationship": "Cha",
+                        "full_name": "Test Father",
+                        "phone": "0901234567",
+                    }],
+                    **submittable_profile_fields(seed),
                 )
                 session.add(profile)
                 await session.flush()
@@ -963,8 +987,11 @@ class TestSubmitAndEvaluate:
         )
 
         # Create profile with best_n selection (pick best 3 of 4)
+        await ensure_submittable_ward()
         async with AsyncSessionLocal() as session:
             async with session.begin():
+                # #337: legacy config + KV chain so submit can reach "submitted".
+                seed = await seed_submittable_offering_config(session, unit_id)
                 # Create subjects
                 subjects = {}
                 for code in ["MATH", "PHYSICS", "ENGLISH", "HISTORY"]:
@@ -990,9 +1017,13 @@ class TestSubmitAndEvaluate:
                         "required_subject_count": 3,
                         "subject_selection_mode": "best_n",
                     },
-                    academic_year=2025,
-                    family_info=[{"relation": "father", "name": "Test Father"}],
-                    academic_history=[{"school": "Test School", "year": 2024}],
+                    academic_year=seed["academic_year"],
+                    family_info=[{
+                        "relationship": "Cha",
+                        "full_name": "Test Father",
+                        "phone": "0901234567",
+                    }],
+                    **submittable_profile_fields(seed),
                 )
                 session.add(profile)
                 await session.flush()

--- a/Backend_FastAPI/tests/services/test_admission_workflow.py
+++ b/Backend_FastAPI/tests/services/test_admission_workflow.py
@@ -18,6 +18,11 @@ from sqlalchemy import select
 
 from app import models
 from app.database import AsyncSessionLocal
+from tests.fixtures.builders import (
+    ensure_submittable_ward,
+    seed_submittable_offering_config,
+    submittable_profile_fields,
+)
 
 
 pytestmark = pytest.mark.asyncio
@@ -81,8 +86,16 @@ async def create_submittable_profile_direct(
     academic_year: int = 2025,
 ) -> models.AdmissionProfile:
     """Create a profile that can be submitted (with subject scores, family_info, etc.)."""
+    # Gap #3: a current-era ward so the permanent address validates.
+    await ensure_submittable_ward()
     async with AsyncSessionLocal() as session:
         async with session.begin():
+            lead = await session.get(models.Lead, lead_id)
+            # #337: legacy config + KV chain so submit can derive the
+            # target level + resolve KV (else CONFIG_GAP / KV_UNRESOLVED).
+            seed = await seed_submittable_offering_config(
+                session, lead.unit_id
+            )
             subj = (await session.execute(
                 select(models.Subject).where(models.Subject.code == "TOAN")
             )).scalar_one_or_none()
@@ -95,7 +108,7 @@ async def create_submittable_profile_direct(
                 lead_id=lead_id,
                 status="draft",
                 citizen_id=citizen_id,
-                academic_year=academic_year,
+                academic_year=seed["academic_year"],
                 version=1,
                 applied_rules={
                     "min_gpa": 0,
@@ -106,7 +119,7 @@ async def create_submittable_profile_direct(
                     "subject_selection_mode": "fixed",
                 },
                 family_info=[{"relationship": "Cha", "full_name": "Test Father", "phone": "0901234567"}],
-                academic_history=[{"school_name": "THPT Test", "year_from": 2020, "year_to": 2024}],
+                **submittable_profile_fields(seed),
             )
             session.add(profile)
             await session.flush()

--- a/Backend_FastAPI/tests/services/test_admission_workflow.py
+++ b/Backend_FastAPI/tests/services/test_admission_workflow.py
@@ -94,7 +94,7 @@ async def create_submittable_profile_direct(
             # #337: legacy config + KV chain so submit can derive the
             # target level + resolve KV (else CONFIG_GAP / KV_UNRESOLVED).
             seed = await seed_submittable_offering_config(
-                session, lead.unit_id
+                session, lead.unit_id, academic_year
             )
             subj = (await session.execute(
                 select(models.Subject).where(models.Subject.code == "TOAN")


### PR DESCRIPTION
## Summary
Closes the #337 submit test-debt: the legacy single-NV submit path
(`uses_choice_engine=False`) fail-closes in several layers that accumulated
after these tests were written, so every submit-to-success test stayed `draft`
or 400'd on `CONFIG_GAP_TARGET_LEVEL`:

- **CONFIG_GAP_TARGET_LEVEL** — needs `offering_admission_config_id` →
  `academic_info` → `offering` → `MajorProgram.degree_level_id` chain.
- **KV_UNRESOLVED** — needs a THPT `academic_history` entry resolvable via
  `VnSchool` + `VnSchoolKvAssignment`.
- **cultural eligibility** (`graduated_thpt`) + **Gap #3** permanent address + ward.

This is test-only — no production code changes.

## Approach
Two shared helpers added to `tests/fixtures/builders.py`, mirroring the proven
`test_magic_link._seed` recipe (the 2026-05-29 magic-link #337 fix):

- `seed_submittable_offering_config(session, unit_id)` — the full config + KV
  chain; returns `offering_admission_config_id` + `school_id`.
- `submittable_profile_fields(seed)` — the profile kwargs that clear every gate.

All three `create_submittable_profile_direct` copies (service / workflow /
security) plus the two inline profiles in `test_admission_service.py`
(`test_submit_uses_best_n_logic`, `test_submit_with_validation_errors_stays_draft`)
now use them.

## Test
One-off container (per repo heavy-suite policy):
- `tests/services/test_admission_service.py::TestSubmitAndEvaluate` — 4/4
- `tests/services/test_admission_workflow.py` + `tests/integration/test_admission_security.py`

→ **16 passed.** `git diff --check` clean; flake8 net-zero/negative on all 4 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)