### PR TITLE
chore(deps): bump PyJWT 2.12.1 → 2.13.0 (4 PYSEC-2026 advisories)

### DIFF
--- a/Backend_FastAPI/requirements.txt
+++ b/Backend_FastAPI/requirements.txt
@@ -73,7 +73,7 @@ pydantic==2.12.5
 pydantic-settings==2.13.1
 pydantic_core==2.41.5
 Pygments==2.20.0
-PyJWT==2.12.1
+PyJWT==2.13.0
 pyotp==2.9.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2


### PR DESCRIPTION
## Summary
Clears the **Python Dependencies** (`pip-audit`) gate, which went red on
`PyJWT==2.12.1` after 4 new advisories landed — all fixed in **2.13.0**:

- **PYSEC-2026-179** — HMAC key-confusion: a verifier supporting both
  asymmetric + HMAC algorithms doesn't validate JWK use, letting an attacker
  use the issuer public key as the HMAC secret to forge tokens.
- **PYSEC-2026-175** — `PyJWKClient` passes its `jku` URI straight to
  `urllib.request.urlopen()` → SSRF via `file://` / `ftp` / `data:`.
- **PYSEC-2026-177** — unbounded JWKS fetch on unknown `kid` (no rate limit).
- **PYSEC-2026-178** — detached-JWS (`b64=false`) Base64URL work-amplification DoS.

PyJWT is the core JWT auth library (`app/services/auth_service.py`,
`app/routers/auth.py`, `app/services/mfa_service.py`), so #179 in particular is
directly relevant — not just a gate-clear.

This gate reds **every PR + the deploy test job** while main pins 2.12.1, so it
ships as its own minimal dep PR (1 line) ahead of the in-flight test-debt PRs.

## Test
Local (one-off container, `PyJWT==2.13.0`): API stable 2.12→2.13 —
`tests/utils/test_security_utils.py` + `tests/services/test_auth.py` +
`tests/services/test_auth_security_hardening.py` = **52 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)