### PR TITLE
feat(admission-config): granular subject↔group endpoints (fix "Phân môn" 404)

### DIFF
--- a/Backend_FastAPI/app/repositories/admission_config_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_config_repository.py
@@ -363,6 +363,42 @@ class AdmissionConfigRepository(BaseRepository[AdmissionCriteria]):
         await self.db.flush()
         return await self.get_subject_group_by_id(group_id, with_subjects=True)
 
+    async def get_subject_group_subject(
+        self, group_id: int, subject_id: int
+    ) -> Optional[SubjectGroupSubject]:
+        """Get the join row linking a subject to a group (or None)."""
+        result = await self.db.execute(
+            select(SubjectGroupSubject).where(
+                SubjectGroupSubject.subject_group_id == group_id,
+                SubjectGroupSubject.subject_id == subject_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def add_subject_group_subject(
+        self, group_id: int, subject_id: int, position: int
+    ) -> SubjectGroupSubject:
+        """Insert one subject→group mapping at the given position."""
+        mapping = SubjectGroupSubject(
+            subject_group_id=group_id,
+            subject_id=subject_id,
+            position=position,
+        )
+        self.db.add(mapping)
+        await self.db.flush()
+        return mapping
+
+    async def delete_subject_group_subject(
+        self, group_id: int, subject_id: int
+    ) -> bool:
+        """Remove one subject→group mapping. Returns False if absent."""
+        mapping = await self.get_subject_group_subject(group_id, subject_id)
+        if not mapping:
+            return False
+        await self.db.delete(mapping)
+        await self.db.flush()
+        return True
+
     # =========================================================================
     # ADMISSION METHODS
     # =========================================================================

--- a/Backend_FastAPI/app/routers/admission_config.py
+++ b/Backend_FastAPI/app/routers/admission_config.py
@@ -40,6 +40,8 @@ from app.schemas.admission_config import (
     SubjectGroupListResponse,
     SubjectGroupCreate,
     SubjectGroupUpdate,
+    SubjectGroupSubjectAdd,
+    SubjectPositionUpdate,
     AdmissionMethodResponse,
     AdmissionMethodListResponse,
     AdmissionMethodCreate,
@@ -346,6 +348,81 @@ async def delete_subject_group(
     await db.commit()
     await callback()
     return None
+
+
+# =============================================================================
+# SUBJECT GROUP ↔ SUBJECT (granular M2M sub-resource)
+# =============================================================================
+
+@router.post(
+    "/subject-groups/{group_id}/subjects",
+    response_model=SubjectGroupResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_subject_to_group(
+    group_id: int,
+    data: SubjectGroupSubjectAdd,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_admin_or_manager),
+):
+    """Add a subject to a group at a position. Requires: Admin or Manager.
+
+    404 if group/subject missing; 409 if the subject is already in the group.
+    """
+    service = AdmissionConfigService(db)
+    group, callback = await service.add_subject_to_group(
+        group_id, data.subject_id, data.position, current_user
+    )
+    await db.commit()
+    await callback()
+    return _build_subject_group_response(group)
+
+
+@router.delete(
+    "/subject-groups/{group_id}/subjects/{subject_id}",
+    response_model=SubjectGroupResponse,
+)
+async def remove_subject_from_group(
+    group_id: int,
+    subject_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_admin_or_manager),
+):
+    """Remove a subject from a group. Requires: Admin or Manager.
+
+    404 if the group is missing or the subject is not in the group.
+    """
+    service = AdmissionConfigService(db)
+    group, callback = await service.remove_subject_from_group(
+        group_id, subject_id, current_user
+    )
+    await db.commit()
+    await callback()
+    return _build_subject_group_response(group)
+
+
+@router.put(
+    "/subject-groups/{group_id}/subjects/{subject_id}",
+    response_model=SubjectGroupResponse,
+)
+async def update_subject_position(
+    group_id: int,
+    subject_id: int,
+    data: SubjectPositionUpdate,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_admin_or_manager),
+):
+    """Update a subject's position within a group. Requires: Admin or Manager.
+
+    404 if the group is missing or the subject is not in the group.
+    """
+    service = AdmissionConfigService(db)
+    group, callback = await service.update_subject_position(
+        group_id, subject_id, data.position, current_user
+    )
+    await db.commit()
+    await callback()
+    return _build_subject_group_response(group)
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/schemas/admission_config.py
+++ b/Backend_FastAPI/app/schemas/admission_config.py
@@ -97,6 +97,17 @@ class SubjectGroupUpdate(BaseModel):
     subject_ids: Optional[list[int]] = None  # Replace all subject mappings
 
 
+class SubjectGroupSubjectAdd(BaseModel):
+    """Add a single subject to a group at a position (granular M2M)."""
+    subject_id: int
+    position: int = Field(ge=1, description="1-based position in group")
+
+
+class SubjectPositionUpdate(BaseModel):
+    """Update one subject's position within a group (granular M2M)."""
+    position: int = Field(ge=1, description="1-based position in group")
+
+
 # =============================================================================
 # ADMISSION METHOD SCHEMAS
 # =============================================================================

--- a/Backend_FastAPI/app/services/admission_config_service.py
+++ b/Backend_FastAPI/app/services/admission_config_service.py
@@ -374,6 +374,113 @@ class AdmissionConfigService:
         return success, _noop_callback
 
     # =========================================================================
+    # SUBJECT GROUP ↔ SUBJECT (granular M2M sub-resource)
+    # =========================================================================
+
+    async def _get_group_or_404(self, group_id: int) -> "SubjectGroup":
+        """Load a subject group (no mappings) or raise 404."""
+        group = await self.repo.get_subject_group_by_id(
+            group_id, with_subjects=False
+        )
+        if not group:
+            raise ResourceNotFoundError(
+                f"Subject group with ID {group_id} not found"
+            )
+        return group
+
+    async def _get_mapping_or_404(self, group_id: int, subject_id: int):
+        """Load the subject→group join row or raise 404."""
+        mapping = await self.repo.get_subject_group_subject(
+            group_id, subject_id
+        )
+        if not mapping:
+            raise ResourceNotFoundError(
+                f"Subject {subject_id} is not in subject group {group_id}"
+            )
+        return mapping
+
+    async def add_subject_to_group(
+        self,
+        group_id: int,
+        subject_id: int,
+        position: int,
+        user: User,
+    ) -> tuple["SubjectGroup", Callable[[], Any]]:
+        """Add one subject to a group at a position (granular M2M).
+
+        Raises ResourceNotFoundError (404) if the group or subject is missing,
+        DuplicateResourceError (409) if the subject is already in the group —
+        pre-checked so no raw DB IntegrityError leaks; the
+        ``uq_subject_group_subject`` UNIQUE constraint backstops races.
+        """
+        await self._get_group_or_404(group_id)
+        subject = await self.repo.get_subject_by_id(subject_id)
+        if not subject:
+            raise ResourceNotFoundError(
+                f"Subject with ID {subject_id} not found"
+            )
+        existing = await self.repo.get_subject_group_subject(
+            group_id, subject_id
+        )
+        if existing:
+            raise DuplicateResourceError(
+                f"Subject {subject_id} is already in subject group {group_id}"
+            )
+
+        await self.repo.add_subject_group_subject(
+            group_id, subject_id, position
+        )
+        group = await self.repo.get_subject_group_by_id(
+            group_id, with_subjects=True
+        )
+        return group, _noop_callback
+
+    async def remove_subject_from_group(
+        self,
+        group_id: int,
+        subject_id: int,
+        user: User,
+    ) -> tuple["SubjectGroup", Callable[[], Any]]:
+        """Remove one subject from a group (granular M2M).
+
+        Raises ResourceNotFoundError (404) if the group is missing or the
+        subject is not mapped to it.
+        """
+        await self._get_group_or_404(group_id)
+        deleted = await self.repo.delete_subject_group_subject(
+            group_id, subject_id
+        )
+        if not deleted:
+            raise ResourceNotFoundError(
+                f"Subject {subject_id} is not in subject group {group_id}"
+            )
+        group = await self.repo.get_subject_group_by_id(
+            group_id, with_subjects=True
+        )
+        return group, _noop_callback
+
+    async def update_subject_position(
+        self,
+        group_id: int,
+        subject_id: int,
+        position: int,
+        user: User,
+    ) -> tuple["SubjectGroup", Callable[[], Any]]:
+        """Update one subject's position within a group (granular M2M).
+
+        Raises ResourceNotFoundError (404) if the group is missing or the
+        subject is not mapped to it.
+        """
+        await self._get_group_or_404(group_id)
+        mapping = await self._get_mapping_or_404(group_id, subject_id)
+        mapping.position = position
+        await self.db.flush()
+        group = await self.repo.get_subject_group_by_id(
+            group_id, with_subjects=True
+        )
+        return group, _noop_callback
+
+    # =========================================================================
     # ADMISSION METHOD CRUD (Phase 1 Refactor)
     # =========================================================================
 

--- a/Backend_FastAPI/tests/api/test_subject_group_subjects.py
+++ b/Backend_FastAPI/tests/api/test_subject_group_subjects.py
@@ -1,0 +1,197 @@
+"""Granular subject↔group M2M sub-resource endpoints.
+
+The "Phân môn vào tổ hợp" tab calls the granular sub-resource
+``.../subject-groups/{group_id}/subjects[/{subject_id}]`` (POST/DELETE/PUT),
+but the backend only had replace-all (`PUT /subject-groups/{id}` with
+``subject_ids``) — the granular routes 404'd, leaving subject groups empty.
+These tests lock the new contract: add at a position, remove, reorder, with
+404 (missing group/subject) + 409 (duplicate) + position>=1 gates.
+"""
+import time
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from app import models
+from app.database import AsyncSessionLocal
+
+
+pytestmark = pytest.mark.asyncio
+
+BASE = "/api/admission-config/subject-groups"
+
+
+async def _login(client: AsyncClient, user_info: dict) -> dict:
+    res = await client.post(
+        "/api/auth/login",
+        data={
+            "username": user_info["username"],
+            "password": user_info["password"],
+        },
+    )
+    assert res.status_code == 200, res.text
+    token = res.cookies.get("access_token")
+    assert token, "Login succeeded but access_token cookie missing"
+    # Clear the cookie jar so the Bearer header is the sole auth (avoids
+    # cross-request cookie contamination per memory test-httpx-cookie-jar).
+    client.cookies.clear()
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest_asyncio.fixture
+async def group_and_subjects(setup_test_database) -> dict:
+    """A fresh empty subject group + 2 standalone subjects (not yet linked)."""
+    tail = str(int(time.time() * 1000))[-6:]
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            group = models.SubjectGroup(
+                code=f"G{tail}", name="Tổ hợp test", is_active=True,
+            )
+            subj1 = models.Subject(
+                code=f"sub1_{tail}", name_vi="Toán", is_active=True,
+            )
+            subj2 = models.Subject(
+                code=f"sub2_{tail}", name_vi="Vật lý", is_active=True,
+            )
+            s.add_all([group, subj1, subj2])
+            await s.flush()
+            ids = {
+                "group_id": group.id,
+                "subject1_id": subj1.id,
+                "subject2_id": subj2.id,
+            }
+    return ids
+
+
+class TestAddSubjectToGroup:
+    async def test_add_returns_group_with_subject(
+        self, client, admin_user_in_db, group_and_subjects
+    ):
+        headers = await _login(client, admin_user_in_db)
+        g = group_and_subjects
+        resp = await client.post(
+            f"{BASE}/{g['group_id']}/subjects",
+            json={"subject_id": g["subject1_id"], "position": 1},
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert len(body["subjects"]) == 1
+        assert body["subjects"][0]["position"] == 1
+
+    async def test_add_duplicate_returns_409(
+        self, client, admin_user_in_db, group_and_subjects
+    ):
+        headers = await _login(client, admin_user_in_db)
+        g = group_and_subjects
+        first = await client.post(
+            f"{BASE}/{g['group_id']}/subjects",
+            json={"subject_id": g["subject1_id"], "position": 1},
+            headers=headers,
+        )
+        assert first.status_code == 201, first.text
+        dup = await client.post(
+            f"{BASE}/{g['group_id']}/subjects",
+            json={"subject_id": g["subject1_id"], "position": 2},
+            headers=headers,
+        )
+        assert dup.status_code == 409, dup.text
+
+    async def test_add_to_missing_group_returns_404(
+        self, client, admin_user_in_db, group_and_subjects
+    ):
+        headers = await _login(client, admin_user_in_db)
+        sid = group_and_subjects["subject1_id"]
+        resp = await client.post(
+            f"{BASE}/999999/subjects",
+            json={"subject_id": sid, "position": 1},
+            headers=headers,
+        )
+        assert resp.status_code == 404, resp.text
+
+    async def test_add_missing_subject_returns_404(
+        self, client, admin_user_in_db, group_and_subjects
+    ):
+        headers = await _login(client, admin_user_in_db)
+        resp = await client.post(
+            f"{BASE}/{group_and_subjects['group_id']}/subjects",
+            json={"subject_id": 999999, "position": 1},
+            headers=headers,
+        )
+        assert resp.status_code == 404, resp.text
+
+    async def test_position_zero_returns_422(
+        self, client, admin_user_in_db, group_and_subjects
+    ):
+        headers = await _login(client, admin_user_in_db)
+        g = group_and_subjects
+        resp = await client.post(
+            f"{BASE}/{g['group_id']}/subjects",
+            json={"subject_id": g["subject1_id"], "position": 0},
+            headers=headers,
+        )
+        assert resp.status_code == 422, resp.text
+
+
+class TestRemoveSubjectFromGroup:
+    async def test_remove_clears_mapping(
+        self, client, admin_user_in_db, group_and_subjects
+    ):
+        headers = await _login(client, admin_user_in_db)
+        g = group_and_subjects
+        await client.post(
+            f"{BASE}/{g['group_id']}/subjects",
+            json={"subject_id": g["subject1_id"], "position": 1},
+            headers=headers,
+        )
+        resp = await client.delete(
+            f"{BASE}/{g['group_id']}/subjects/{g['subject1_id']}",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["subjects"] == []
+
+    async def test_remove_unmapped_returns_404(
+        self, client, admin_user_in_db, group_and_subjects
+    ):
+        headers = await _login(client, admin_user_in_db)
+        g = group_and_subjects
+        resp = await client.delete(
+            f"{BASE}/{g['group_id']}/subjects/{g['subject1_id']}",
+            headers=headers,
+        )
+        assert resp.status_code == 404, resp.text
+
+
+class TestUpdateSubjectPosition:
+    async def test_update_position(
+        self, client, admin_user_in_db, group_and_subjects
+    ):
+        headers = await _login(client, admin_user_in_db)
+        g = group_and_subjects
+        await client.post(
+            f"{BASE}/{g['group_id']}/subjects",
+            json={"subject_id": g["subject1_id"], "position": 1},
+            headers=headers,
+        )
+        resp = await client.put(
+            f"{BASE}/{g['group_id']}/subjects/{g['subject1_id']}",
+            json={"position": 5},
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        subjects = resp.json()["subjects"]
+        assert subjects[0]["position"] == 5
+
+    async def test_update_unmapped_returns_404(
+        self, client, admin_user_in_db, group_and_subjects
+    ):
+        headers = await _login(client, admin_user_in_db)
+        g = group_and_subjects
+        resp = await client.put(
+            f"{BASE}/{g['group_id']}/subjects/{g['subject1_id']}",
+            json={"position": 2},
+            headers=headers,
+        )
+        assert resp.status_code == 404, resp.text


### PR DESCRIPTION
## Summary
The admin **"Phân môn vào tổ hợp"** tab calls 3 granular sub-resource endpoints
that the backend never implemented, so subjects couldn't be assigned to groups
(404) — leaving e.g. the 4 THCS combos empty:

| FE call (`master-data.ts`) | Was | Now |
|---|---|---|
| `POST   /api/admission-config/subject-groups/{id}/subjects` `{subject_id, position}` | 404 | **201** |
| `DELETE /api/admission-config/subject-groups/{id}/subjects/{subject_id}` | 404 | **200** |
| `PUT    /api/admission-config/subject-groups/{id}/subjects/{subject_id}` `{position}` | 404 | **200** |

Backend previously only had replace-all (`PUT /subject-groups/{id}` with
`subject_ids`). The granular routes match the FE's already-written contract +
the `SubjectGroupSubject` model (which already carries `position`/`weight` +
`uq_subject_group_subject` UNIQUE).

## Implementation (layered, `require_admin_or_manager`)
- **schemas**: `SubjectGroupSubjectAdd {subject_id, position>=1}`, `SubjectPositionUpdate {position>=1}` (Pydantic `Field(ge=1)` → 422).
- **repo**: `get/add/delete_subject_group_subject`.
- **service**: `add_subject_to_group` / `remove_subject_from_group` / `update_subject_position` (domain exceptions, `(result, callback)`, `_get_group_or_404` / `_get_mapping_or_404` helpers).
- **router**: 3 routes returning the reloaded `SubjectGroupResponse`.

**Gates:** 404 (missing group/subject) · 409 (duplicate mapping — pre-checked, no raw IntegrityError leak; UNIQUE backstops races) · position>=1. The replace-all route is untouched (backward-compatible).

## Test
- `tests/api/test_subject_group_subjects.py` — add / 409 / 404×2 / 422 + remove / 404 + position / 404 = **9 passed** (one-off container); flake8 net-zero.
- **Browser smoke (Chrome MCP, dev)**: the actual "Phân môn vào tổ hợp" tab → `POST .../851/subjects` **201**, `DELETE .../851/subjects/73` **200**, list refetch 200; dev data restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)