### PR TITLE
feat(admission-config): wire archive endpoint for draft/inactive admission path

### DIFF
--- a/Backend_FastAPI/app/routers/admission_paths.py
+++ b/Backend_FastAPI/app/routers/admission_paths.py
@@ -591,6 +591,40 @@ async def deactivate_admission_path(
     return await build_path_response(path, service, current_user)
 
 
+@router.post(
+    "/paths/{path_id}/archive",
+    response_model=AdmissionPathResponse,
+    summary="Archive admission path (admin-only)",
+)
+async def archive_admission_path(
+    path: models.AdmissionPath = Depends(get_admission_path_for_user),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),  # ADM-008 admin-only
+):
+    """
+    Archive (soft-delete) a ``draft`` or ``inactive`` admission path →
+    ``archived``.
+
+    **Authorization (ADM-008 / Q3=a):** Admin only — symmetric to
+    activate/deactivate; service re-checks as defense-in-depth.
+
+    Lets admin retire an unused draft/inactive path through the API instead
+    of raw SQL. Active paths return 400 (deactivate first); already-archived
+    return 400. Archived paths are terminal & immutable (``can_update``).
+
+    IDOR: Protected via get_admission_path_for_user dependency.
+    """
+    service = AdmissionPathService(db)
+    path, callback = await service.archive_path(path, current_user)
+    await db.commit()
+    await callback()
+
+    # Reload
+    path = await AdmissionPathRepository(db).get_by_id_with_relations(path.id)
+
+    return await build_path_response(path, service, current_user)
+
+
 # =============================================================================
 # DOCUMENT RESOLUTION ENDPOINTS
 # =============================================================================

--- a/Backend_FastAPI/app/routers/admission_paths.py
+++ b/Backend_FastAPI/app/routers/admission_paths.py
@@ -610,7 +610,8 @@ async def archive_admission_path(
 
     Lets admin retire an unused draft/inactive path through the API instead
     of raw SQL. Active paths return 400 (deactivate first); already-archived
-    return 400. Archived paths are terminal & immutable (``can_update``).
+    return 400. Archived is terminal — ``_check_lifecycle_guard`` blocks
+    edits and ``activate_path`` rejects re-activation.
 
     IDOR: Protected via get_admission_path_for_user dependency.
     """

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -856,13 +856,30 @@ class AdmissionPathService:
         self, path: AdmissionPath, user: User
     ) -> Tuple[AdmissionPath, PostCommitCallback]:
         """
-        Archive an AdmissionPath.
+        Archive (soft-delete) an AdmissionPath: ``draft``/``inactive`` →
+        ``archived``.
+
+        ADM-008 (Q3=a): admin-only, symmetric to activate/deactivate. Lets
+        admin retire an unused draft/inactive path without raw SQL. Active
+        paths must be deactivated first (``archived`` is terminal &
+        immutable per ``can_update`` guard). Archived → archived rejected so
+        the action is explicit, not a silent no-op.
 
         Raises:
-            BusinessRuleViolation: If path is active
+            PermissionDeniedError: If caller is not admin
+            BusinessRuleViolation: If path is active or already archived
         """
+        if user.role != UserRole.ADMIN:
+            raise PermissionDeniedError(
+                "Chỉ admin được lưu trữ admission path."
+            )
+
         if path.status == "active":
-            raise BusinessRuleViolation("Cannot archive active path. Deactivate first.")
+            raise BusinessRuleViolation(
+                "Cannot archive active path. Deactivate first."
+            )
+        if path.status == "archived":
+            raise BusinessRuleViolation("Path is already archived.")
 
         path = await self.repo.update(
             path,

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -774,6 +774,15 @@ class AdmissionPathService:
                 "Manager tạo/sửa draft, admin duyệt = activate."
             )
 
+        # ``archived`` is terminal — make that explicit at the activate gate
+        # (validate_activation Check 1 also rejects it, but an early guard
+        # gives a clear message + keeps the terminal contract self-evident
+        # now that ``archived`` is reachable via the archive endpoint).
+        if path.status == "archived":
+            raise BusinessRuleViolation(
+                "Path đã lưu trữ; không hỗ trợ kích hoạt lại."
+            )
+
         can_activate, errors = await self.validate_activation(path)
 
         if not can_activate:
@@ -861,9 +870,10 @@ class AdmissionPathService:
 
         ADM-008 (Q3=a): admin-only, symmetric to activate/deactivate. Lets
         admin retire an unused draft/inactive path without raw SQL. Active
-        paths must be deactivated first (``archived`` is terminal &
-        immutable per ``can_update`` guard). Archived → archived rejected so
-        the action is explicit, not a silent no-op.
+        paths must be deactivated first; ``archived`` is terminal —
+        ``_check_lifecycle_guard`` blocks every edit and ``activate_path``
+        rejects re-activation. Archived → archived rejected so the action is
+        explicit, not a silent no-op.
 
         Raises:
             PermissionDeniedError: If caller is not admin

--- a/Backend_FastAPI/tests/unit/test_admission_path_action_flags.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_action_flags.py
@@ -82,6 +82,22 @@ class TestAdmissionPathRoleAwareActionFlags:
             assert service.compute_can_edit(path, admin) is True
             assert await service.compute_can_activate(path, admin) is False
 
+    async def test_admin_inactive_lists_activate_and_archive(self):
+        """inactive (như draft) cho admin cả activate + archive — pin để
+        nút 'Lưu trữ' FE (canPerformAction archive) không regress thầm lặng
+        khi path ở trạng thái inactive, không chỉ draft."""
+        service, doc_repo = _make_service()
+        path = _path("inactive")
+        admin = _user(UserRole.ADMIN)
+
+        with _patch_doc_repo(doc_repo):
+            assert service.compute_available_actions(path, admin) == [
+                "save",
+                "activate",
+                "archive",
+            ]
+            assert service.compute_can_edit(path, admin) is True
+
     async def test_admin_archived_has_no_actions(self):
         service, doc_repo = _make_service()
         path = _path("archived")

--- a/Backend_FastAPI/tests/unit/test_admission_path_admin_only_lifecycle.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_admin_only_lifecycle.py
@@ -13,7 +13,7 @@ import pytest
 
 from app.core.constants import UserRole
 from app.services.admission_path_service import AdmissionPathService
-from app.utils.exceptions import PermissionDeniedError
+from app.utils.exceptions import BusinessRuleViolation, PermissionDeniedError
 
 
 pytestmark = pytest.mark.unit
@@ -133,4 +133,63 @@ class TestDeactivatePathAdminOnly:
         with pytest.raises(PermissionDeniedError, match="admin"):
             await service.deactivate_path(
                 _ready_path("draft"), _user(UserRole.MANAGER)
+            )
+
+
+class TestArchivePathAdminOnly:
+    """Archive (draft/inactive → archived) is admin-only, symmetric to
+    activate/deactivate. Wires the previously-unexposed ``archive_path``
+    service so admin can retire unused draft/inactive paths via API/UI
+    instead of raw SQL."""
+
+    async def test_manager_cannot_archive(self):
+        service, _doc_repo = _make_service()
+        with pytest.raises(PermissionDeniedError, match="admin"):
+            await service.archive_path(
+                _ready_path("draft"), _user(UserRole.MANAGER)
+            )
+
+    @pytest.mark.parametrize(
+        "role",
+        [UserRole.OFFICER, UserRole.ACCOUNTANT, UserRole.USER],
+    )
+    async def test_non_admin_cannot_archive(self, role):
+        service, _doc_repo = _make_service()
+        with pytest.raises(PermissionDeniedError, match="admin"):
+            await service.archive_path(_ready_path("draft"), _user(role))
+
+    async def test_admin_can_archive_draft(self):
+        service, _doc_repo = _make_service()
+        path = _ready_path("draft")
+        updated, _cb = await service.archive_path(path, _user(UserRole.ADMIN))
+        assert updated.status == "archived"
+
+    async def test_admin_can_archive_inactive(self):
+        service, _doc_repo = _make_service()
+        path = _ready_path("inactive")
+        updated, _cb = await service.archive_path(path, _user(UserRole.ADMIN))
+        assert updated.status == "archived"
+
+    async def test_cannot_archive_active_path(self):
+        """Active must be deactivated first (archived is terminal)."""
+        service, _doc_repo = _make_service()
+        with pytest.raises(BusinessRuleViolation, match="[Dd]eactivate"):
+            await service.archive_path(
+                _ready_path("active"), _user(UserRole.ADMIN)
+            )
+
+    async def test_cannot_archive_already_archived(self):
+        service, _doc_repo = _make_service()
+        with pytest.raises(BusinessRuleViolation, match="already archived"):
+            await service.archive_path(
+                _ready_path("archived"), _user(UserRole.ADMIN)
+            )
+
+    async def test_role_check_runs_before_status_check(self):
+        """Manager hitting archive on an active path still gets
+        PermissionDeniedError (role gate first), not a state-leak."""
+        service, _doc_repo = _make_service()
+        with pytest.raises(PermissionDeniedError, match="admin"):
+            await service.archive_path(
+                _ready_path("active"), _user(UserRole.MANAGER)
             )

--- a/Backend_FastAPI/tests/unit/test_admission_path_admin_only_lifecycle.py
+++ b/Backend_FastAPI/tests/unit/test_admission_path_admin_only_lifecycle.py
@@ -98,6 +98,17 @@ class TestActivatePathAdminOnly:
         assert updated.status == "active"
         assert updated.activated_by == 1
 
+    async def test_cannot_activate_archived_path(self):
+        """``archived`` is terminal: re-activation rejected by the early
+        guard (before readiness/round-lock), so the terminal contract holds
+        even though ``archived`` is now reachable via the archive endpoint."""
+        service, doc_repo = _make_service()
+        with _patch_doc_repo(doc_repo):
+            with pytest.raises(BusinessRuleViolation, match="lưu trữ"):
+                await service.activate_path(
+                    _ready_path("archived"), _user(UserRole.ADMIN)
+                )
+
 
 class TestDeactivatePathAdminOnly:
     async def test_manager_cannot_deactivate(self):

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
@@ -54,6 +54,9 @@ const hoisted = vi.hoisted(() => {
     method_quota: null as number | null,
     bonus_rule_override: null as Record<string, unknown> | null,
     minor_correction_allowed_fields: [] as string[],
+    // Thin-client: FE đọc cờ role-aware này (BE compute_available_actions).
+    // Default draft+admin → có "archive" (nút "Lưu trữ" hiện).
+    available_actions: ["save", "activate", "archive"] as string[],
   }
   return {
     defaultPath,
@@ -62,6 +65,7 @@ const hoisted = vi.hoisted(() => {
     mockUpdatePath: vi.fn(),
     mockActivate: vi.fn(),
     mockDeactivate: vi.fn(),
+    mockArchive: vi.fn(),
   }
 })
 
@@ -71,6 +75,7 @@ vi.mock("@/hooks/admissions/useAdmissionPaths", () => ({
   useUpdateAdmissionPath: () => ({ mutateAsync: hoisted.mockUpdatePath, isPending: false }),
   useActivateAdmissionPath: () => ({ mutateAsync: hoisted.mockActivate, isPending: false }),
   useDeactivateAdmissionPath: () => ({ mutateAsync: hoisted.mockDeactivate, isPending: false }),
+  useArchiveAdmissionPath: () => ({ mutateAsync: hoisted.mockArchive, isPending: false }),
 }))
 
 vi.mock("@/hooks/admissions/useQuotaMatrix", () => ({
@@ -188,6 +193,41 @@ describe("PathDetailDrawer 5-tab", () => {
       expect(activateBtn.disabled).toBe(true)
     })
     expect(screen.getByText(/Missing criteria/)).toBeTruthy()
+  })
+
+  it("ANCHOR (thin-client archive): nút 'Lưu trữ' hiện khi available_actions có 'archive'", async () => {
+    hoisted.mockUseAdmissionPath.mockReturnValue({
+      data: {
+        ...hoisted.defaultPath,
+        status: "draft",
+        available_actions: ["save", "activate", "archive"],
+      },
+      isLoading: false,
+    })
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=lifecycle"))
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Lưu trữ/ })).toBeTruthy()
+    })
+  })
+
+  it("ANCHOR (thin-client archive): nút 'Lưu trữ' ẨN khi available_actions không có 'archive' (vd manager) — không suy role", async () => {
+    hoisted.mockUseAdmissionPath.mockReturnValue({
+      data: {
+        ...hoisted.defaultPath,
+        status: "draft",
+        available_actions: ["save"], // manager: BE không trả "archive"
+      },
+      isLoading: false,
+    })
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=lifecycle"))
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Vòng đời/ })).toBeTruthy()
+    })
+    expect(screen.queryByRole("button", { name: /Lưu trữ/ })).toBeNull()
   })
 
   it("ANCHOR (status=active): shows Deactivate button, NOT Activate", async () => {

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
@@ -64,7 +64,7 @@ import {
   useUpdatePathQuota,
 } from "@/hooks/admissions/useQuotaMatrix"
 import { parseApiError } from "@/lib/utils/api-errors"
-import type { AdmissionPathResponse } from "@/lib/zod/admission-path"
+import { canPerformAction, type AdmissionPathResponse } from "@/lib/zod/admission-path"
 
 import { ConfigCriteria } from "../ConfigCriteria"
 import { ConfigDocuments } from "../ConfigDocuments"
@@ -561,9 +561,12 @@ function LifecycleTab({
 
   const isActive = path.status === "active"
   const isArchived = path.status === "archived"
-  // Archive khả dụng cho draft/inactive (BE chặn active: phải deactivate
-  // trước; chặn archived: terminal). Cho admin retire path thừa qua UI.
-  const canArchive = !isActive && !isArchived
+  // Thin-client: đọc cờ role-aware từ BE (compute_available_actions),
+  // KHÔNG suy state từ status / KHÔNG check role. BE chỉ trả "archive"
+  // cho admin + draft/inactive → manager không thấy nút (tránh 403
+  // dead-end); active/archived cũng ẩn. isArchived vẫn dùng cho nhánh
+  // ẩn nút Kích hoạt bên dưới.
+  const canArchive = canPerformAction(path, "archive")
   const isPending =
     activateMutation.isPending ||
     deactivateMutation.isPending ||

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
@@ -12,6 +12,7 @@
 import { useQueryClient } from "@tanstack/react-query"
 import {
   AlertTriangle,
+  Archive,
   CheckCircle2,
   Loader2,
   Power,
@@ -54,6 +55,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   useActivateAdmissionPath,
   useAdmissionPath,
+  useArchiveAdmissionPath,
   useDeactivateAdmissionPath,
   useUpdateAdmissionPath,
 } from "@/hooks/admissions/useAdmissionPaths"
@@ -512,9 +514,11 @@ function LifecycleTab({
   const queryClient = useQueryClient()
   const activateMutation = useActivateAdmissionPath()
   const deactivateMutation = useDeactivateAdmissionPath()
+  const archiveMutation = useArchiveAdmissionPath()
   // Pass 2 hard-review FM-1: custom Dialog confirm thay JS confirm()
   // (mobile UX kém + a11y kém — không có focus trap, không styled).
   const [confirmDeactivate, setConfirmDeactivate] = useState(false)
+  const [confirmArchive, setConfirmArchive] = useState(false)
 
   const hasCriteria = path.criteria !== null
   const hasQuota = path.admit_quota !== null && path.admit_quota > 0
@@ -543,8 +547,27 @@ function LifecycleTab({
     }
   }
 
+  const performArchive = async () => {
+    setConfirmArchive(false)
+    try {
+      await archiveMutation.mutateAsync(pathId)
+      queryClient.invalidateQueries({ queryKey: quotaMatrixKeys.all })
+      toast.success("Đã lưu trữ phương thức tuyển sinh")
+      onClose()
+    } catch (e: unknown) {
+      toast.error(parseApiError(e, "Lỗi lưu trữ — thử lại sau."))
+    }
+  }
+
   const isActive = path.status === "active"
-  const isPending = activateMutation.isPending || deactivateMutation.isPending
+  const isArchived = path.status === "archived"
+  // Archive khả dụng cho draft/inactive (BE chặn active: phải deactivate
+  // trước; chặn archived: terminal). Cho admin retire path thừa qua UI.
+  const canArchive = !isActive && !isArchived
+  const isPending =
+    activateMutation.isPending ||
+    deactivateMutation.isPending ||
+    archiveMutation.isPending
 
   return (
     <div className="space-y-5">
@@ -619,18 +642,37 @@ function LifecycleTab({
             Vô hiệu hoá
           </Button>
         ) : (
-          <Button
-            onClick={handleActivate}
-            disabled={!path.can_activate || isPending}
-            aria-busy={isPending}
-          >
-            {isPending ? (
-              <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
-            ) : (
-              <Power className="h-4 w-4 mr-1" aria-hidden="true" />
+          <>
+            {canArchive && (
+              <Button
+                variant="outline"
+                onClick={() => setConfirmArchive(true)}
+                disabled={isPending}
+                aria-busy={isPending}
+              >
+                {isPending ? (
+                  <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Archive className="h-4 w-4 mr-1" aria-hidden="true" />
+                )}
+                Lưu trữ
+              </Button>
             )}
-            Kích hoạt
-          </Button>
+            {!isArchived && (
+              <Button
+                onClick={handleActivate}
+                disabled={!path.can_activate || isPending}
+                aria-busy={isPending}
+              >
+                {isPending ? (
+                  <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Power className="h-4 w-4 mr-1" aria-hidden="true" />
+                )}
+                Kích hoạt
+              </Button>
+            )}
+          </>
         )}
       </div>
 
@@ -661,6 +703,38 @@ function LifecycleTab({
                 <PowerOff className="h-4 w-4 mr-1" aria-hidden="true" />
               )}
               Vô hiệu hoá
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={confirmArchive} onOpenChange={setConfirmArchive}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Lưu trữ phương thức tuyển sinh?</DialogTitle>
+            <DialogDescription>
+              Phương thức tuyển sinh sẽ chuyển sang trạng thái lưu trữ
+              (archived) — ẩn khỏi danh mục cấu hình và không thể chỉnh sửa
+              hay kích hoạt lại. Dùng để gỡ các đường nháp/đã vô hiệu không
+              còn dùng. Hồ sơ đã nộp (nếu có) giữ nguyên snapshot path.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmArchive(false)}>
+              Huỷ
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={performArchive}
+              disabled={isPending}
+              aria-busy={isPending}
+            >
+              {isPending ? (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+              ) : (
+                <Archive className="h-4 w-4 mr-1" aria-hidden="true" />
+              )}
+              Lưu trữ
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/hooks/admissions/useAdmissionPaths.ts
+++ b/frontend/src/hooks/admissions/useAdmissionPaths.ts
@@ -14,6 +14,7 @@ import {
   updateAdmissionPath,
   activateAdmissionPath,
   deactivateAdmissionPath,
+  archiveAdmissionPath,
 
   updateCriteria,
   updatePathDocuments,
@@ -221,6 +222,27 @@ export function useDeactivateAdmissionPath() {
   
   return useMutation({
     mutationFn: (pathId: number) => deactivateAdmissionPath(pathId),
+    onSuccess: (updatedPath) => {
+      queryClient.invalidateQueries({ queryKey: admissionPathKeys.detail(updatedPath.id) })
+      queryClient.invalidateQueries({ queryKey: admissionPathKeys.all })
+      // status hiển thị trên by-major PathMatrixCell (chấm màu) — key
+      // ["quota-matrix"] KHÔNG nằm dưới .all → invalidate riêng ở hook.
+      queryClient.invalidateQueries({ queryKey: ["quota-matrix"] })
+      // Invalidate academic infos to update path_count and admission_status
+      queryClient.invalidateQueries({ queryKey: ["academic-infos"] })
+    },
+  })
+}
+
+/**
+ * Hook to archive (soft-delete) a draft/inactive admission path (Admin only).
+ * Active paths must be deactivated first; archived is terminal & immutable.
+ */
+export function useArchiveAdmissionPath() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (pathId: number) => archiveAdmissionPath(pathId),
     onSuccess: (updatedPath) => {
       queryClient.invalidateQueries({ queryKey: admissionPathKeys.detail(updatedPath.id) })
       queryClient.invalidateQueries({ queryKey: admissionPathKeys.all })

--- a/frontend/src/lib/api/admission-paths.ts
+++ b/frontend/src/lib/api/admission-paths.ts
@@ -128,6 +128,19 @@ export async function deactivateAdmissionPath(
   return response.data
 }
 
+/**
+ * Archive (soft-delete) a draft or inactive admission path → "archived".
+ * Active paths must be deactivated first. Archived is terminal & immutable.
+ */
+export async function archiveAdmissionPath(
+  pathId: number
+): Promise<AdmissionPathResponse> {
+  const response = await api.post<AdmissionPathResponse>(
+    `/api/admission-config/paths/${pathId}/archive`
+  )
+  return response.data
+}
+
 // ============================================
 // VALIDATION & DOCUMENTS
 // ============================================
@@ -244,6 +257,7 @@ export const admissionPathsApi = {
   // Actions (Admin only)
   activateAdmissionPath,
   deactivateAdmissionPath,
+  archiveAdmissionPath,
   // Validation & Documents
   validatePathActivation,
   getPathDocuments,


### PR DESCRIPTION
## Vì sao
Service `archive_path()` (`draft`/`inactive` → `archived`) đã tồn tại nhưng **chưa có HTTP endpoint, FE client, hay nút UI** — nợ tính năng phát hiện khi dọn DOT_2 TS2026: 20 đường nháp "Xét tuyển thẳng" (301) không thể archive qua UI (tab Vòng đời draft chỉ có "Kích hoạt"; `deactivate` chỉ `active→inactive`). Trước đây chỉ bỏ được bằng raw SQL.

## Thay đổi
**BE**
- `POST /paths/{path_id}/archive` (admin-only + IDOR `get_admission_path_for_user`), đối xứng `activate`/`deactivate`.
- `archive_path()`: thêm `require_admin` (defense-in-depth) + chặn "already archived".
- `activate_path()`: guard sớm chặn `status=="archived"` (terminal tường minh; `validate_activation` Check 1 cũng đã chặn).

**FE** (thin-client — đọc `available_actions` từ BE, không infer/role-check)
- `archiveAdmissionPath()` client + `useArchiveAdmissionPath()` hook (invalidate detail/all/quota-matrix/academic-infos).
- Nút "Lưu trữ" + dialog xác nhận trong `PathDetailDrawer` LifecycleTab; hiển thị qua `canPerformAction(path, "archive")` → admin+draft/inactive mới thấy (manager/active/archived ẩn).

## Test & smoke
- +9 unit test (7 archive admin-only + admin/inactive action-flags + archived-không-activate). BE local: archive tests PASS.
- *Pre-existing fails không liên quan PR*: `test_admin_can_activate_ready_path` + 4 action_flags admin gọi `compute_can_activate→validate_activation→admission_round_id` (fixture debt; chứng minh bằng stash).
- `tsc --noEmit` clean; flake8 net-zero E501 cho code mới.
- **Smoke dev (Chrome MCP):** admin+draft → thấy "Lưu trữ" → archive → status `archived`, ẩn nút (terminal); manager+draft → KHÔNG thấy "Lưu trữ" (hết 403 dead-end).

## Sau merge
Dùng nút "Lưu trữ" dọn 20 đường nháp 301 DOT_2 trên prod (đóng GĐ5 setup TS2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)