### PR TITLE
feat(admission): giấy tốt nghiệp — phân biệt bằng chính thức/tạm thời (#13) + SWAP Giấy CN hoàn thành GDPT (#10)

### DIFF
--- a/Backend_FastAPI/alembic/versions/gdpt01_seed_giay_cn_hoan_thanh_gdpt.py
+++ b/Backend_FastAPI/alembic/versions/gdpt01_seed_giay_cn_hoan_thanh_gdpt.py
@@ -1,0 +1,87 @@
+"""gdpt01: seed doc type giay_cn_hoan_thanh_gdpt (PR #10)
+
+Revision ID: gdpt01
+Revises: gppenddip01
+Create Date: 2026-06-04
+
+PR #10 — người TRƯỢT tốt nghiệp THPT (``cultural_education_level =
+'completed_thpt'``) nộp Giấy chứng nhận hoàn thành chương trình GDPT THAY cho
+Bằng tốt nghiệp THPT (đã bị ``_COMPLETED_DIPLOMA_TO_REMOVE`` loại). Đối xứng
+với việc loại bằng: ``_COMPLETED_DIPLOMA_TO_ADD`` thêm doc type này khi
+re-resolve cho hồ sơ ``completed_thpt``.
+
+Chỉ seed doc type (1 row config_document_type). KHÔNG tạo DocumentGroupItem —
+giấy GDPT được caller dựng thành ResolvedDocumentResponse synthetic
+(is_mandatory=True, requires_upload=False, paper-only) tại
+``admission_path_service.resolve_documents_for_profile``.
+
+Idempotent ``INSERT ... ON CONFLICT (code) DO NOTHING``. ``name`` độc nhất
+(cột UNIQUE). Downgrade non-destructive: chỉ xoá row CHƯA được tham chiếu
+bởi profile_document / document_group_item (giữ an toàn dữ liệu thật).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "gdpt01"
+down_revision: Union[str, None] = "gppenddip01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_CODE = "giay_cn_hoan_thanh_gdpt"
+_NAME = "Giấy chứng nhận hoàn thành chương trình GDPT"
+_DESC = (
+    "Cấp cho thí sinh đã hoàn thành chương trình GDPT nhưng chưa tốt nghiệp "
+    "THPT (thay cho Bằng tốt nghiệp THPT)."
+)
+# Cạnh Bằng tốt nghiệp THPT trong thứ tự hiển thị (paper-only, nhóm bằng cấp).
+_DISPLAY_ORDER = 45
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            """
+            INSERT INTO config_document_type
+                (code, name, description, display_order, is_active)
+            VALUES (:code, :name, :desc, :display_order, TRUE)
+            ON CONFLICT (code) DO NOTHING
+            """
+        ),
+        {
+            "code": _CODE,
+            "name": _NAME,
+            "desc": _DESC,
+            "display_order": _DISPLAY_ORDER,
+        },
+    )
+    print(f"[gdpt01] Seeded {result.rowcount} doc type row(s) ({_CODE}).")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    # Non-destructive: only drop the seed row if nothing references it yet
+    # (no profile_document / document_group_item points at it). Real data
+    # created after the seed is preserved.
+    result = conn.execute(
+        sa.text(
+            """
+            DELETE FROM config_document_type t
+            WHERE t.code = :code
+              AND NOT EXISTS (
+                  SELECT 1 FROM profile_document pd
+                  WHERE pd.document_type_id = t.id
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM document_group_item gi
+                  WHERE gi.document_type_id = t.id
+              )
+            """
+        ),
+        {"code": _CODE},
+    )
+    print(f"[gdpt01] Removed {result.rowcount} unreferenced doc type row(s).")

--- a/Backend_FastAPI/alembic/versions/gpcasbin01_seed_graduation_proof_casbin.py
+++ b/Backend_FastAPI/alembic/versions/gpcasbin01_seed_graduation_proof_casbin.py
@@ -1,0 +1,116 @@
+"""gpcasbin01: seed Casbin policy for graduation-proof update endpoint
+
+Revision ID: gpcasbin01
+Revises: gpkind01
+Create Date: 2026-06-04
+
+PR #13.4b — NEW endpoint ``POST /api/admissions/{id}/documents/{doc_code}/
+graduation-proof`` lets an officer upgrade a graduation proof
+(provisional_cert → official_diploma) WITHOUT changing doc status. It is
+defended by ``CasbinAuth`` and therefore needs a Casbin policy row, exactly
+like ``paper-submitted`` (PR #5, migration ``zz7h8i9j0k1l2``).
+
+``policy_templates.py`` is updated in the SAME commit (one ALLOW row added to
+``OFFICER_TEMPLATE`` right after paper-submitted). To keep "fresh seed +
+this migration → same end state", we seed ONLY the single ``role:officer``
+ALLOW row that the template fresh-seed produces. Manager + admin reach the
+route via the diamond inheritance g-rules (``g, role:manager, role:officer``
+and the admin ``/*`` ``.*`` wildcard) — exactly the paper-submitted contract.
+
+Accountant: no deny row, mirroring paper-submitted. Finance staff never pass
+the owning-officer IDOR scope check in ``update_graduation_proof_kind``
+(``get_profile``), so a Casbin allow they inherit is moot — and the
+paper-submitted family deliberately carries no accountant deny.
+
+Per memory ``casbin-insert-must-include-eft``: v3 (eft) MUST be present in
+the INSERT — a NULL eft makes ``load_policy()`` crash → 500 on every
+endpoint. Idempotent ``INSERT ... WHERE NOT EXISTS`` so reruns (and the boot
+``sync_casbin_policy`` template pickup) are safe.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "gpcasbin01"
+down_revision: Union[str, None] = "gpkind01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Single row: (v0=subject, v1=object, v2=action, v3=eft). Mirrors the lone
+# row added to OFFICER_TEMPLATE — manager/admin inherit, accountant moot.
+_GRADUATION_PROOF_POLICIES = [
+    (
+        "role:officer",
+        "/api/admissions/{id}/documents/{doc_code}/graduation-proof",
+        "POST",
+        "allow",
+    ),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    pre_count = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM casbin_rule "
+            "WHERE v1 LIKE '/api/admissions/%documents%graduation-proof'"
+        )
+    ).scalar()
+    print(
+        f"[gpcasbin01] Pre-flight: existing graduation-proof policy "
+        f"rows={pre_count}"
+    )
+
+    inserted = 0
+    for v0, v1, v2, v3 in _GRADUATION_PROOF_POLICIES:
+        result = conn.execute(
+            sa.text(
+                """
+                INSERT INTO casbin_rule
+                    (ptype, v0, v1, v2, v3, template_id, applied_at)
+                SELECT 'p',
+                       CAST(:v0 AS VARCHAR),
+                       CAST(:v1 AS VARCHAR),
+                       CAST(:v2 AS VARCHAR),
+                       CAST(:v3 AS VARCHAR),
+                       '_gpcasbin01_graduation_proof_seed',
+                       NOW()
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM casbin_rule
+                    WHERE ptype='p'
+                      AND v0=CAST(:v0 AS VARCHAR)
+                      AND v1=CAST(:v1 AS VARCHAR)
+                      AND v2=CAST(:v2 AS VARCHAR)
+                      AND v3=CAST(:v3 AS VARCHAR)
+                )
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+        inserted += result.rowcount
+
+    print(f"[gpcasbin01] Seeded {inserted} new policy row(s).")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    deleted = 0
+    for v0, v1, v2, v3 in _GRADUATION_PROOF_POLICIES:
+        result = conn.execute(
+            sa.text(
+                """
+                DELETE FROM casbin_rule
+                WHERE ptype='p'
+                  AND v0=CAST(:v0 AS VARCHAR)
+                  AND v1=CAST(:v1 AS VARCHAR)
+                  AND v2=CAST(:v2 AS VARCHAR)
+                  AND v3=CAST(:v3 AS VARCHAR)
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+        deleted += result.rowcount
+    print(f"[gpcasbin01] Removed {deleted} policy row(s).")

--- a/Backend_FastAPI/alembic/versions/gpkind01_add_graduation_proof_to_profile_document.py
+++ b/Backend_FastAPI/alembic/versions/gpkind01_add_graduation_proof_to_profile_document.py
@@ -1,0 +1,90 @@
+"""PR #13 — graduation_proof_kind + supplement_due_date trên profile_document.
+
+Phân biệt **Bằng tốt nghiệp THPT chính thức** vs **Giấy CN tốt nghiệp tạm
+thời** (Phương án C). Officer khi tick "đã nhận" giấy `bang_tot_nghiep_thpt`
+chọn loại; `provisional_cert` → nhập hạn bổ sung bằng chính thức. Cho phép
+truy vấn hồ sơ "còn nợ bằng" để nhắc.
+
+- 2 cột mới trên `profile_document` (KHÔNG đụng `applied_rules`):
+  * `graduation_proof_kind` String(20) — official_diploma|provisional_cert
+  * `supplement_due_date` Date — chỉ set khi kind=provisional_cert
+- 2 CHECK constraint giữ invariant (kind hợp lệ; due chỉ khi provisional).
+- Data migration: đổi `config_document_type.name` của `bang_tot_nghiep_thpt`
+  thành "Bằng tốt nghiệp THPT / Giấy CN tốt nghiệp tạm thời" để officer hiểu
+  mục này nhận cả 2 loại giấy. Idempotent (WHERE code); downgrade revert.
+
+Revision ID: gpkind01
+Revises: ardockeys01
+Create Date: 2026-06-04
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "gpkind01"
+down_revision: Union[str, None] = "ardockeys01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+GRAD_DOC_CODE = "bang_tot_nghiep_thpt"
+NEW_LABEL = "Bằng tốt nghiệp THPT / Giấy CN tốt nghiệp tạm thời"
+OLD_LABEL = "Bằng tốt nghiệp THPT"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "profile_document",
+        sa.Column(
+            "graduation_proof_kind",
+            sa.String(length=20),
+            nullable=True,
+            comment="official_diploma | provisional_cert (NULL nếu N/A)",
+        ),
+    )
+    op.add_column(
+        "profile_document",
+        sa.Column(
+            "supplement_due_date",
+            sa.Date(),
+            nullable=True,
+            comment="Hạn bổ sung bằng — chỉ set khi kind='provisional_cert'",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_graduation_proof_kind",
+        "profile_document",
+        "graduation_proof_kind IS NULL "
+        "OR graduation_proof_kind IN ('official_diploma','provisional_cert')",
+    )
+    op.create_check_constraint(
+        "ck_supplement_due_only_provisional",
+        "profile_document",
+        "supplement_due_date IS NULL "
+        "OR graduation_proof_kind = 'provisional_cert'",
+    )
+    # Data: đổi label doc type (idempotent theo code).
+    op.execute(
+        sa.text(
+            "UPDATE config_document_type SET name = :new WHERE code = :code"
+        ).bindparams(new=NEW_LABEL, code=GRAD_DOC_CODE)
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE config_document_type SET name = :old WHERE code = :code"
+        ).bindparams(old=OLD_LABEL, code=GRAD_DOC_CODE)
+    )
+    op.drop_constraint(
+        "ck_supplement_due_only_provisional", "profile_document", type_="check"
+    )
+    op.drop_constraint(
+        "ck_graduation_proof_kind", "profile_document", type_="check"
+    )
+    op.drop_column("profile_document", "supplement_due_date")
+    op.drop_column("profile_document", "graduation_proof_kind")

--- a/Backend_FastAPI/alembic/versions/gppenddip01_seed_pending_diploma_casbin.py
+++ b/Backend_FastAPI/alembic/versions/gppenddip01_seed_pending_diploma_casbin.py
@@ -1,0 +1,106 @@
+"""gppenddip01: seed Casbin policy for the pending-diploma reminder endpoint
+
+Revision ID: gppenddip01
+Revises: gpcasbin01
+Create Date: 2026-06-04
+
+PR #13.7 — NEW read endpoint ``GET /api/admissions/pending-diploma`` lists
+profiles that still owe the official diploma ("nợ bằng"). It is defended by
+``CasbinAuth`` and therefore needs Casbin policy rows. ``policy_templates.py``
+is updated in the SAME commit (officer ALLOW + accountant DENY).
+
+2 rows seeded, mirroring the ``/stats`` / ``/status-counts`` read routes:
+* role:officer ALLOW — primary subject (officer follows up on the debt; the
+  service IDOR-scopes to assigned profiles). Manager + admin inherit via the
+  diamond g-rules.
+* role:accountant DENY — the list carries candidate PII (name/phone);
+  finance staff have no business need + separation-of-duties. accountant
+  inherits officer, so without this explicit deny the inherited ALLOW would
+  leak the list.
+
+Per memory ``casbin-insert-must-include-eft``: v3 (eft) MUST be present —
+NULL eft makes ``load_policy()`` crash → 500. Idempotent
+``INSERT ... WHERE NOT EXISTS`` so reruns + boot template sync are safe.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "gppenddip01"
+down_revision: Union[str, None] = "gpcasbin01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# (v0=subject, v1=object, v2=action, v3=eft)
+_PENDING_DIPLOMA_POLICIES = [
+    ("role:officer", "/api/admissions/pending-diploma", "GET", "allow"),
+    ("role:accountant", "/api/admissions/pending-diploma", "GET", "deny"),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    pre_count = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM casbin_rule "
+            "WHERE v1 = '/api/admissions/pending-diploma'"
+        )
+    ).scalar()
+    print(
+        f"[gppenddip01] Pre-flight: existing pending-diploma policy "
+        f"rows={pre_count}"
+    )
+
+    inserted = 0
+    for v0, v1, v2, v3 in _PENDING_DIPLOMA_POLICIES:
+        result = conn.execute(
+            sa.text(
+                """
+                INSERT INTO casbin_rule
+                    (ptype, v0, v1, v2, v3, template_id, applied_at)
+                SELECT 'p',
+                       CAST(:v0 AS VARCHAR),
+                       CAST(:v1 AS VARCHAR),
+                       CAST(:v2 AS VARCHAR),
+                       CAST(:v3 AS VARCHAR),
+                       '_gppenddip01_pending_diploma_seed',
+                       NOW()
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM casbin_rule
+                    WHERE ptype='p'
+                      AND v0=CAST(:v0 AS VARCHAR)
+                      AND v1=CAST(:v1 AS VARCHAR)
+                      AND v2=CAST(:v2 AS VARCHAR)
+                      AND v3=CAST(:v3 AS VARCHAR)
+                )
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+        inserted += result.rowcount
+
+    print(f"[gppenddip01] Seeded {inserted} new policy row(s).")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    deleted = 0
+    for v0, v1, v2, v3 in _PENDING_DIPLOMA_POLICIES:
+        result = conn.execute(
+            sa.text(
+                """
+                DELETE FROM casbin_rule
+                WHERE ptype='p'
+                  AND v0=CAST(:v0 AS VARCHAR)
+                  AND v1=CAST(:v1 AS VARCHAR)
+                  AND v2=CAST(:v2 AS VARCHAR)
+                  AND v3=CAST(:v3 AS VARCHAR)
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+        deleted += result.rowcount
+    print(f"[gppenddip01] Removed {deleted} policy row(s).")

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -179,6 +179,13 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         # (requires_upload=false); service-layer guard enforces the
         # owning-officer + profile-editable + missing-status contract.
         {"subject": "{role}", "object": "/api/admissions/{id}/documents/{doc_code}/paper-submitted", "action": "POST"},
+        # PR #13 — officer records a graduation-proof upgrade (provisional
+        # cert → official diploma) WITHOUT changing doc status. Mirrors
+        # paper-submitted (officer-initiated); service layer narrows IDOR +
+        # bang_tot_nghiep_thpt-only. Manager/admin inherit; accountant has no
+        # deny row (same as paper-submitted — finance never reaches the
+        # owning-officer scope check).
+        {"subject": "{role}", "object": "/api/admissions/{id}/documents/{doc_code}/graduation-proof", "action": "POST"},
         # Phase 3 multi-NV read-only (PR-3B). Officer can VIEW result-published
         # profiles + choice list for their assigned unit; mutations stay
         # manager-only per RBAC matrix plan v0.7. Service-layer IDOR

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -240,6 +240,9 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/admissions/stats", "action": "GET"},  # Stats dashboard
         {"subject": "{role}", "object": "/api/admissions/status-counts", "action": "GET"},  # Tab badges
         {"subject": "{role}", "object": "/api/admissions/academic-years", "action": "GET"},  # Year filter
+        # PR #13.7 — "nợ bằng" reminder list (provisional graduation cert still
+        # outstanding). IDOR-scoped in the service (officer assigned scope).
+        {"subject": "{role}", "object": "/api/admissions/pending-diploma", "action": "GET"},
         # Admission config (read-only lookup data)
         {"subject": "{role}", "object": "/api/program-offerings", "action": "GET"},  # Dropdown data
         {"subject": "{role}", "object": "/api/admission-config/subjects", "action": "GET"},
@@ -442,6 +445,10 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/admissions/stats",          "action": "GET",  "eft": "deny"},
         {"subject": "{role}", "object": "/api/admissions/status-counts",  "action": "GET",  "eft": "deny"},
         {"subject": "{role}", "object": "/api/admissions/academic-years", "action": "GET",  "eft": "deny"},
+        # PR #13.7 — nợ bằng list carries candidate PII (name/phone); finance
+        # staff have no business need + separation-of-duties. Mirror the
+        # /stats /status-counts denies above (accountant inherits officer).
+        {"subject": "{role}", "object": "/api/admissions/pending-diploma", "action": "GET",  "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads",                     "action": "GET",  "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads",                     "action": "POST", "eft": "deny"},
         {"subject": "{role}", "object": "/api/leads/{id}",                "action": "GET",  "eft": "deny"},

--- a/Backend_FastAPI/app/models/admission_config/profile_data.py
+++ b/Backend_FastAPI/app/models/admission_config/profile_data.py
@@ -7,7 +7,7 @@ Replaces JSON fields in AdmissionProfile:
 - documents_checklist → ProfileDocument
 """
 
-from sqlalchemy import CheckConstraint, Column, Index, Integer, String, ForeignKey, Numeric, DateTime, UniqueConstraint, Text, BigInteger, text
+from sqlalchemy import CheckConstraint, Column, Date, Index, Integer, String, ForeignKey, Numeric, DateTime, UniqueConstraint, Text, BigInteger, text
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.dialects.postgresql import JSONB
 from datetime import datetime, timezone
@@ -192,6 +192,20 @@ class ProfileDocument(Base):
         comment="Verified by officer after inspection: original | certified_copy | photo"
     )
 
+    # PR #13 — phân biệt Bằng TN THPT chính thức vs Giấy CN tốt nghiệp
+    # tạm thời (chỉ áp cho doc 'bang_tot_nghiep_thpt'). Officer chọn loại
+    # khi tick "đã nhận"; provisional_cert → nhập hạn bổ sung bằng.
+    graduation_proof_kind = Column(
+        String(20),
+        nullable=True,
+        comment="official_diploma | provisional_cert | NULL"
+    )
+    supplement_due_date = Column(
+        Date,
+        nullable=True,
+        comment="Hạn bổ sung bằng — set khi kind=provisional_cert"
+    )
+
     created_at = Column(
         DateTime(timezone=True),
         nullable=False,
@@ -245,6 +259,18 @@ class ProfileDocument(Base):
         CheckConstraint(
             "category <> 'path' OR document_type_id IS NOT NULL",
             name="ck_path_requires_doc_type"
+        ),
+        # PR #13 — graduation_proof_kind chỉ nhận 2 giá trị hợp lệ hoặc NULL.
+        CheckConstraint(
+            "graduation_proof_kind IS NULL OR graduation_proof_kind IN "
+            "('official_diploma','provisional_cert')",
+            name="ck_graduation_proof_kind",
+        ),
+        # PR #13 — hạn bổ sung chỉ có ý nghĩa khi nộp giấy tạm thời.
+        CheckConstraint(
+            "supplement_due_date IS NULL "
+            "OR graduation_proof_kind = 'provisional_cert'",
+            name="ck_supplement_due_only_provisional",
         ),
     )
 

--- a/Backend_FastAPI/app/repositories/admission_path_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_path_repository.py
@@ -23,6 +23,7 @@ from app.models.admission_config import (
     SubjectGroup,
     SubjectGroupSubject,
 )
+from app.models.config import ConfigDocumentType
 from app.models.offering_academic_info import OfferingAcademicInfo
 from app.models.program_offering import ProgramOffering
 from app.models.major_program import MajorProgram
@@ -414,6 +415,26 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
     # DOCUMENT GROUP QUERIES (Override Resolution)
     # =========================================================================
     
+    async def get_document_types_by_codes(
+        self, codes: Iterable[str]
+    ) -> List[ConfigDocumentType]:
+        """PR #10 — lookup active ConfigDocumentType cho synthetic add-items.
+
+        ``resolve_documents_for_profile`` cần id/name/display_order của Giấy CN
+        hoàn thành GDPT (chỉ seed doc type, KHÔNG có DocumentGroupItem) để dựng
+        ``ResolvedDocumentResponse``. Chỉ trả doc type ``is_active=True``; [] cho
+        ``codes`` rỗng (giấy chưa seed → swap im lặng bỏ qua, fail-safe).
+        """
+        code_list = list(codes)
+        if not code_list:
+            return []
+        stmt = select(ConfigDocumentType).where(
+            ConfigDocumentType.code.in_(code_list),
+            ConfigDocumentType.is_active == True,  # noqa: E712
+        )
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
     async def get_document_groups_for_path(
         self,
         offering_type_id: int,

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -584,6 +584,55 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         result = await self.db.execute(stmt)
         return list(result.scalars().all())
 
+    async def list_profiles_with_pending_diploma(
+        self,
+        unit_id: Optional[int] = None,
+        assigned_officer_id: Optional[int] = None,
+        due_before: Optional[date] = None,
+    ) -> list[models.AdmissionProfile]:
+        """PR #13.7 — hồ sơ còn "nợ bằng" (Giấy CN tốt nghiệp tạm thời).
+
+        Lọc ``ProfileDocument.graduation_proof_kind == 'provisional_cert'``.
+        IDOR scope mirror ``_resolve_idor_filters``: ``unit_id``
+        (``lead.unit_id``) + ``assigned_officer_id`` (``lead.assigned_officer_id``),
+        bỏ qua khi None (admin). ``due_before`` (optional): chỉ lấy hồ sơ có
+        hạn bổ sung <= ngày (sắp / đã quá hạn). Eager-load lead +
+        assigned_officer + documents.document_type để service dựng tên thí
+        sinh + officer + lấy hạn không N+1. Order ``supplement_due_date`` tăng
+        dần (gần hạn nhất trước; Postgres ASC = NULLS LAST).
+        """
+        stmt = (
+            select(models.AdmissionProfile)
+            .join(
+                models.Lead,
+                models.AdmissionProfile.lead_id == models.Lead.id,
+            )
+            .join(
+                ProfileDocument,
+                ProfileDocument.profile_id == models.AdmissionProfile.id,
+            )
+            .where(ProfileDocument.graduation_proof_kind == "provisional_cert")
+            .options(
+                selectinload(models.AdmissionProfile.lead).selectinload(
+                    models.Lead.assigned_officer
+                ),
+                selectinload(models.AdmissionProfile.documents).joinedload(
+                    ProfileDocument.document_type
+                ),
+            )
+            .order_by(asc(ProfileDocument.supplement_due_date))
+        )
+        if due_before is not None:
+            stmt = stmt.where(ProfileDocument.supplement_due_date <= due_before)
+        if unit_id is not None:
+            stmt = stmt.where(models.Lead.unit_id == unit_id)
+        if assigned_officer_id is not None:
+            stmt = stmt.where(
+                models.Lead.assigned_officer_id == assigned_officer_id
+            )
+        result = await self.db.execute(stmt)
+        return list(result.scalars().unique().all())
+
     async def get_profile_by_lead_year(
         self,
         lead_id: int,

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -612,6 +612,13 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
                 ProfileDocument.profile_id == models.AdmissionProfile.id,
             )
             .where(ProfileDocument.graduation_proof_kind == "provisional_cert")
+            # Review F3 — chỉ nhắc hồ sơ CÒN actionable: bỏ withdrawn (thí sinh
+            # rút) + dropped (is_dropped=True, status vẫn 'enrolled'). GIỮ
+            # enrolled-không-dropped (đúng use case: nhập học với giấy tạm thời,
+            # vẫn nợ bằng) + rejected (có thể resubmit; reject_document đã clear
+            # field khi reject ở tầng doc).
+            .where(models.AdmissionProfile.status != "withdrawn")
+            .where(models.AdmissionProfile.is_dropped.isnot(True))
             .options(
                 selectinload(models.AdmissionProfile.lead).selectinload(
                     models.Lead.assigned_officer

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -1303,7 +1303,12 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         doc.rejection_reason = reason
         doc.rejected_at = datetime.now(timezone.utc)
         doc.rejected_by = officer_id
-        
+        # PR #13 — a rejected graduation submission voids the "nợ bằng" debt
+        # fields (mirror reset_document) so the pending-diploma reminder + the
+        # detail badge don't surface a debt on a rejected row.
+        doc.graduation_proof_kind = None
+        doc.supplement_due_date = None
+
         return doc
 
     async def confirm_document_format(

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -13,7 +13,7 @@ Benefits:
 """
 
 import logging
-from datetime import datetime
+from datetime import date, datetime
 from typing import List, Optional, Tuple
 import unicodedata
 
@@ -1112,6 +1112,8 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         document_type_code: str,
         officer_id: int,
         actual_submission_format: Optional[str] = None,
+        graduation_proof_kind: Optional[str] = None,
+        supplement_due_date: Optional[date] = None,
     ) -> Optional[models.ProfileDocument]:
         """
         Mark a document as paper submitted (officer confirms receipt).
@@ -1122,7 +1124,10 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             profile_id: AdmissionProfile ID
             document_type_code: Document type code
             officer_id: ID of officer confirming receipt
-            actual_submission_format: Declared document format (original | certified_copy | photo)
+            actual_submission_format: Declared format (original|certified_copy|photo)
+            graduation_proof_kind: PR#13 — official_diploma|provisional_cert
+                (chỉ áp cho giấy tốt nghiệp THPT bang_tot_nghiep_thpt)
+            supplement_due_date: PR#13 — hạn bổ sung khi provisional_cert
 
         Returns:
             Updated ProfileDocument or None if not found
@@ -1139,6 +1144,37 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         if actual_submission_format:
             doc.actual_submission_format = actual_submission_format
 
+        # PR #13 — loại giấy tốt nghiệp (bằng chính thức / giấy tạm thời).
+        if graduation_proof_kind is not None:
+            doc.graduation_proof_kind = graduation_proof_kind
+            doc.supplement_due_date = (
+                supplement_due_date
+                if graduation_proof_kind == "provisional_cert"
+                else None
+            )
+
+        return doc
+
+    async def update_graduation_proof(
+        self,
+        profile_id: int,
+        document_type_code: str,
+        new_kind: str,
+    ) -> Optional[models.ProfileDocument]:
+        """PR #13 — nâng cấp loại giấy tốt nghiệp (vd provisional→official).
+
+        Dùng khi hồ sơ ĐÃ nộp giấy (status paper_submitted/verified) rồi thí
+        sinh bổ sung bằng chính thức. KHÔNG đổi status (khác
+        mark_paper_submitted vốn theo policy chỉ chạy khi status='missing').
+        official_diploma → xoá hạn bổ sung.
+        """
+        doc = await self.get_document_by_type(profile_id, document_type_code)
+        if not doc:
+            return None
+
+        doc.graduation_proof_kind = new_kind
+        if new_kind == "official_diploma":
+            doc.supplement_due_date = None
         return doc
 
     async def reset_document(
@@ -1181,6 +1217,9 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         doc.rejected_at = None
         doc.rejected_by = None
         doc.rejection_reason = None
+        # PR #13 — rewind graduation proof fields.
+        doc.graduation_proof_kind = None
+        doc.supplement_due_date = None
 
         return doc
 

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -980,6 +980,8 @@ async def mark_document_paper_submitted(
             doc_code=doc_code,
             current_user=current_user,
             actual_submission_format=data.actual_submission_format,
+            graduation_proof_kind=data.graduation_proof_kind,
+            supplement_due_date=data.supplement_due_date,
         )
         await db.commit()
         await db.refresh(profile)

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -18,7 +18,7 @@ Endpoints:
 - POST /api/admissions/{id}/enroll - Enroll student (ACID transaction)
 """
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Dict, List, Literal, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status, UploadFile, File, Form
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -248,6 +248,46 @@ async def get_admission_stats(
         current_user=current_user,
         academic_year=academic_year,
     )
+
+
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "/pending-diploma",
+    response_model=schemas.PendingDiplomaResponse,
+    summary="List profiles owing the official diploma (nợ bằng)",
+)
+async def list_pending_diploma(
+    request: Request,
+    due_before: date | None = Query(
+        None,
+        description="Chỉ lấy hồ sơ có hạn bổ sung bằng <= ngày này (YYYY-MM-DD)",
+    ),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    """
+    List admission profiles that submitted a provisional graduation
+    certificate and still owe the official diploma ("nợ bằng"), IDOR-scoped to
+    the caller (admin all / manager unit / officer assigned).
+
+    Optional ``due_before`` narrows to profiles whose supplement due date has
+    passed or is approaching — the reminder query for the officer follow-up.
+
+    **Note:** declared BEFORE ``/{profile_id}`` so FastAPI does not capture
+    ``pending-diploma`` as a profile id.
+    """
+    try:
+        items = await admission_service.list_pending_diploma_profiles(
+            db=db,
+            current_user=current_user,
+            due_before=due_before,
+        )
+    except PermissionDeniedError:
+        # IDOR protection: return 404 to prevent resource enumeration
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found"
+        )
+    return schemas.PendingDiplomaResponse(total_count=len(items), items=items)
 
 
 @limiter.limit(RateLimits.DATA_WRITE)  # 200/hour

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -1001,6 +1001,70 @@ async def mark_document_paper_submitted(
 
 
 @limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "/{profile_id}/documents/{doc_code}/graduation-proof",
+    response_model=schemas.AdmissionProfileResponse,
+    summary="Update graduation proof kind (provisional cert -> official diploma)",
+    status_code=status.HTTP_200_OK,
+)
+async def update_document_graduation_proof(
+    request: Request,
+    profile_id: int,
+    doc_code: str,
+    data: schemas.GraduationProofUpdateRequest,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    """
+    Update the graduation proof kind for a graduation document (PR #13).
+
+    Use case: a candidate who previously submitted a provisional graduation
+    certificate (``provisional_cert``) later brings the official diploma
+    (``official_diploma``). The officer records the upgrade WITHOUT changing
+    the document status (it stays ``paper_submitted``); ``official_diploma``
+    clears the supplement due date so the "nợ bằng" badge disappears.
+
+    Only applies to ``bang_tot_nghiep_thpt``. Casbin admits officer (manager
+    + admin inherit, mirror ``paper-submitted``); the service layer enforces
+    the IDOR scope via ``get_profile``.
+
+    **Request Body:**
+    - kind: official_diploma | provisional_cert
+
+    **Returns:**
+    - Full AdmissionProfileResponse with updated validation_summary
+    """
+    try:
+        profile = await admission_service.update_graduation_proof_kind(
+            db=db,
+            profile_id=profile_id,
+            doc_code=doc_code,
+            new_kind=data.kind,
+            current_user=current_user,
+        )
+        await db.commit()
+        await db.refresh(profile)
+        # PR #13 — emit AFTER commit settles (mirror paper-submitted) so the
+        # FE refetches and the "nợ bằng" badge + completion stay in sync.
+        await _emit_admission_doc_mutation(
+            profile_id,
+            document_action="graduation_proof_updated",
+            doc_code=doc_code,
+        )
+        return profile
+
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except PermissionDeniedError:
+        # IDOR protection: return 404 to prevent resource enumeration
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resource not found")
+    except ValidationError as e:
+        # BusinessRuleViolation (non-graduation doc) + ValidationError
+        # (invalid kind) are both ValidationError subclasses → 400.
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
 @router.patch(
     "/{profile_id}/documents/{doc_code}/verify-format",
     response_model=schemas.AdmissionProfileResponse,

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -188,6 +188,7 @@ from .admission import (
     DocumentUploadResponse,
     DocumentRejectRequest,
     DocumentSubmissionRequest,
+    GraduationProofUpdateRequest,  # PR #13 — graduation proof upgrade
     # Student schemas
     StudentDocumentResponse,
     StudentResponse,

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -156,6 +156,8 @@ from .admission import (
     AdmissionProfileUpdate,
     AdmissionProfileResponse,
     AdmissionsPage,
+    PendingDiplomaItem,  # PR #13.7 — nợ bằng reminder
+    PendingDiplomaResponse,  # PR #13.7 — nợ bằng reminder
     AdmissionSubmitResponse,
     # Phase 3 PR-3C Sub-3 — choice-engine endpoint schemas
     AdmissionPublishResultResponse,

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1381,6 +1381,22 @@ class AdmissionsPage(BaseModel):
     profiles: List[AdmissionProfileResponse]
 
 
+class PendingDiplomaItem(BaseModel):
+    """PR #13.7 — một hồ sơ còn "nợ bằng" (Giấy CN tốt nghiệp tạm thời)."""
+    profile_id: int
+    candidate_name: Optional[str] = None
+    phone: Optional[str] = None
+    status: str
+    supplement_due_date: Optional[date] = None
+    assigned_officer_name: Optional[str] = None
+
+
+class PendingDiplomaResponse(BaseModel):
+    """PR #13.7 — danh sách hồ sơ nợ bằng, IDOR-scoped theo người gọi."""
+    total_count: int
+    items: List[PendingDiplomaItem]
+
+
 # ==============================================================================
 # BULK ACTION SCHEMAS
 # ==============================================================================

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -321,6 +321,16 @@ class DocumentItemSchema(BaseModel):
             "here (staff-to-staff privacy)."
         ),
     )
+    # PR #13 — loại giấy tốt nghiệp + hạn "nợ bằng" + cờ cho phép cập nhật.
+    graduation_proof_kind: Optional[
+        Literal["official_diploma", "provisional_cert"]
+    ] = Field(None, description="Loại giấy tốt nghiệp THPT (PR#13)")
+    supplement_due_date: Optional[date] = Field(
+        None, description="Hạn bổ sung bằng khi provisional_cert (PR#13)"
+    )
+    can_update_graduation_kind: Optional[bool] = Field(
+        None, description="FE hiện nút 'Đã nhận bằng chính thức' (PR#13)"
+    )
 
     # =========================================================================
     # Checklist-only display fields populated by _compute_frontend_fields.
@@ -1557,6 +1567,33 @@ class DocumentSubmissionRequest(BaseModel):
     actual_submission_format: Literal["original", "certified_copy", "photo"] = Field(
         ...,
         description="Type of physical document being submitted/uploaded"
+    )
+    # PR #13 — chỉ áp cho giấy TN THPT (bang_tot_nghiep_thpt); bỏ qua doc khác.
+    graduation_proof_kind: Optional[
+        Literal["official_diploma", "provisional_cert"]
+    ] = Field(None, description="Loại giấy tốt nghiệp THPT (PR#13)")
+    supplement_due_date: Optional[date] = Field(
+        None, description="Hạn bổ sung bằng khi provisional_cert (PR#13)"
+    )
+
+    @model_validator(mode="after")
+    def _check_provisional_due(self):
+        if (
+            self.graduation_proof_kind == "provisional_cert"
+            and self.supplement_due_date is None
+        ):
+            raise ValueError(
+                "supplement_due_date bắt buộc khi provisional_cert"
+            )
+        return self
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+
+class GraduationProofUpdateRequest(BaseModel):
+    """PR #13 — cập nhật loại giấy tốt nghiệp (vd provisional→official)."""
+    kind: Literal["official_diploma", "provisional_cert"] = Field(
+        ..., description="Loại giấy tốt nghiệp mới"
     )
 
     model_config = ConfigDict(str_strip_whitespace=True)

--- a/Backend_FastAPI/app/services/admission_config_service.py
+++ b/Backend_FastAPI/app/services/admission_config_service.py
@@ -684,7 +684,9 @@ class AdmissionConfigService:
         from types import SimpleNamespace
 
         from app.services.document_resolution_service import (
+            build_completed_add_items,
             build_resolved_response,
+            compute_completed_add_doc_codes,
             compute_completed_doc_codes,
             compute_preview_audience_set,
             filter_shared_by_audience,
@@ -710,9 +712,26 @@ class AdmissionConfigService:
         # Config preview = snapshot-shape (KHÔNG exclude_inactive) khớp create.
         mandatory_wins_merge(doc_map, layers, "shared", exclude_inactive=False)
 
-        completed = compute_completed_doc_codes(
-            SimpleNamespace(cultural_education_level=cultural_education_level)
+        profile_like = SimpleNamespace(
+            cultural_education_level=cultural_education_level
         )
-        return build_resolved_response(doc_map, completed)
+        completed = compute_completed_doc_codes(profile_like)
+
+        # PR #10 — preview parity: SWAP cho completed_* cũng THÊM Giấy CN hoàn
+        # thành GDPT (synthetic, paper-only) như resolve_documents_for_profile.
+        # Lookup qua AdmissionPathRepository (tái dùng, không inline SQL/duplicate).
+        add_codes = compute_completed_add_doc_codes(profile_like)
+        add_items = []
+        if add_codes:
+            from app.repositories.admission_path_repository import (
+                AdmissionPathRepository,
+            )
+
+            doc_types = await AdmissionPathRepository(
+                self.db
+            ).get_document_types_by_codes(add_codes)
+            add_items = build_completed_add_items(doc_types)
+
+        return build_resolved_response(doc_map, completed, add_items)
 
 

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -36,7 +36,9 @@ from app.schemas.admission_path import (
     ResolvedDocumentResponse,
 )
 from app.services.document_resolution_service import (
+    build_completed_add_items,
     build_resolved_response,
+    compute_completed_add_doc_codes,
     compute_completed_doc_codes,
     derive_audience_set,
     filter_shared_by_audience,
@@ -912,6 +914,7 @@ class AdmissionPathService:
         audience_set: Optional[set] = None,
         all_audiences: bool = False,
         completed_codes: Optional[set] = None,
+        add_items: Optional[List[ResolvedDocumentResponse]] = None,
     ) -> Tuple[List[ResolvedDocumentResponse], PostCommitCallback]:
         """
         Resolve document requirements for a path (3-tier + audience).
@@ -929,6 +932,10 @@ class AdmissionPathService:
                 endpoint /paths/{id}/documents không ?audience= → thấy đủ bộ, KHÔNG
                 co lại sau backfill).
             completed_codes: mã bằng TN LOẠI khỏi kết quả (cultural=completed_* §6).
+            add_items: PR #10 — synthetic ResolvedDocumentResponse THÊM vào kết
+                quả (vd Giấy CN hoàn thành GDPT cho completed_thpt). Caller dựng
+                từ DB; builder append nếu code chưa có. CHỈ đường profile truyền
+                (có cultural); path view thuần để None.
 
         Returns:
             (list resolved docs với source + layer_kind + applicable_audience,
@@ -959,7 +966,7 @@ class AdmissionPathService:
             )
             mandatory_wins_merge(doc_map, layers, "shared")
 
-        resolved = build_resolved_response(doc_map, completed_codes)
+        resolved = build_resolved_response(doc_map, completed_codes, add_items)
         return resolved, _noop_callback
 
     async def resolve_documents_for_profile(
@@ -974,15 +981,37 @@ class AdmissionPathService:
         CONFIG_GAP nội bộ → luôn ≥ tập văn hóa; ``compute_completed_doc_codes``
         loại bằng TN khi cultural=completed_* (§6). Caller truyền ``path`` =
         path primary để derive chiều loại hình (P1-A: chain phải eager-load).
+
+        PR #10 — SWAP cho completed_*: ngoài LOẠI bằng TN còn THÊM Giấy CN hoàn
+        thành GDPT (synthetic add-item, paper-only) qua
+        ``_build_completed_add_items``.
         """
         audience_set = derive_audience_set(profile, path)
         completed_codes = compute_completed_doc_codes(profile)
+        add_items = await self._build_completed_add_items(profile)
         return await self.resolve_documents_for_path(
             path,
             offering_type_id,
             audience_set=audience_set,
             completed_codes=completed_codes,
+            add_items=add_items,
         )
+
+    async def _build_completed_add_items(
+        self, profile
+    ) -> List[ResolvedDocumentResponse]:
+        """PR #10 — dựng synthetic add-items cho ``cultural=completed_*`` (SWAP).
+
+        Lookup doc type từ DB rồi delegate shape cho pure
+        ``build_completed_add_items`` (1 nguồn shape, dùng chung với preview).
+        Giấy chưa seed / inactive → repo trả ``[]`` → bỏ qua (fail-safe, không
+        vỡ resolve).
+        """
+        add_codes = compute_completed_add_doc_codes(profile)
+        if not add_codes:
+            return []
+        doc_types = await self.repo.get_document_types_by_codes(add_codes)
+        return build_completed_add_items(doc_types)
 
     # =========================================================================
     # CONTROL FIELD COMPUTATION (for response)

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -6581,6 +6581,59 @@ async def update_graduation_proof_kind(
     return profile
 
 
+async def list_pending_diploma_profiles(
+    db: AsyncSession,
+    current_user: models.User,
+    due_before: Optional[date] = None,
+) -> List[Dict[str, Any]]:
+    """PR #13.7 — danh sách hồ sơ còn "nợ bằng" (Giấy CN tốt nghiệp tạm thời).
+
+    IDOR scope qua ``_resolve_idor_filters`` (admin all / manager unit /
+    officer assigned). ``due_before`` lọc hồ sơ có hạn bổ sung <= ngày — query
+    nhắc officer follow-up thí sinh bổ sung bằng chính thức. Casbin admits
+    officer/manager/admin; accountant denied at the gateway.
+    """
+    from app.repositories import AdmissionRepository
+    admission_repo = AdmissionRepository(db)
+
+    unit_id, assigned_officer_id = _resolve_idor_filters(current_user)
+    profiles = await admission_repo.list_profiles_with_pending_diploma(
+        unit_id=unit_id,
+        assigned_officer_id=assigned_officer_id,
+        due_before=due_before,
+    )
+
+    items: List[Dict[str, Any]] = []
+    for profile in profiles:
+        grad_doc = next(
+            (
+                d
+                for d in profile.documents
+                if d.document_type
+                and d.document_type.code == "bang_tot_nghiep_thpt"
+                and d.graduation_proof_kind == "provisional_cert"
+            ),
+            None,
+        )
+        lead = profile.lead
+        officer = lead.assigned_officer if lead else None
+        items.append(
+            {
+                "profile_id": profile.id,
+                "candidate_name": lead.full_name if lead else None,
+                "phone": lead.phone if lead else None,
+                "status": profile.status,
+                "supplement_due_date": (
+                    grad_doc.supplement_due_date if grad_doc else None
+                ),
+                "assigned_officer_name": (
+                    officer.full_name if officer else None
+                ),
+            }
+        )
+    return items
+
+
 async def reject_document(
     db: AsyncSession,
     profile_id: int,

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -24,7 +24,7 @@ Security Features:
 
 import random
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Awaitable, List, Optional, Dict, Any, Tuple, Callable
 from decimal import Decimal
 import structlog
@@ -6386,12 +6386,16 @@ async def mark_paper_submitted(
     doc_code: str,
     current_user: models.User,
     actual_submission_format: Optional[str] = None,
+    graduation_proof_kind: Optional[str] = None,
+    supplement_due_date: Optional[date] = None,
 ) -> models.AdmissionProfile:
     """
     Mark a document as paper submitted (officer confirms receipt).
 
     For documents where requires_upload=false.
     Only officers/managers/admins can mark paper submitted.
+    PR #13: graduation_proof_kind/supplement_due_date chỉ áp cho giấy tốt
+    nghiệp THPT (bằng chính thức / giấy tạm thời + hạn bổ sung).
 
     Args:
         db: Database session
@@ -6435,12 +6439,29 @@ async def mark_paper_submitted(
         current_user=current_user,
     )
 
+    # PR #13 — graduation proof chỉ áp cho giấy TN THPT; doc khác bỏ qua 2
+    # field. Validate provisional ⇒ bắt buộc có hạn bổ sung.
+    _grad_kind = graduation_proof_kind
+    _grad_due = supplement_due_date
+    if doc_code != "bang_tot_nghiep_thpt":
+        _grad_kind = None
+        _grad_due = None
+    elif _grad_kind is not None:
+        if _grad_kind not in ("official_diploma", "provisional_cert"):
+            raise ValidationError("graduation_proof_kind không hợp lệ")
+        if _grad_kind == "provisional_cert" and _grad_due is None:
+            raise ValidationError(
+                "Cần nhập hạn bổ sung cho Giấy CN tốt nghiệp tạm thời"
+            )
+
     # Mark paper submitted
     doc = await admission_repo.mark_paper_submitted(
         profile_id=profile_id,
         document_type_code=doc_code,
         officer_id=current_user.id,
         actual_submission_format=actual_submission_format,
+        graduation_proof_kind=_grad_kind,
+        supplement_due_date=_grad_due,
     )
 
     if not doc:
@@ -6456,6 +6477,8 @@ async def mark_paper_submitted(
         actor_user_id=current_user.id,
         old_status=old_status,
         declared_format=actual_submission_format,
+        graduation_proof_kind=_grad_kind,
+        supplement_due_date=_grad_due,
     )
 
     # G2 (ADM-032 partial) — full response contract parity. Mirrors
@@ -6470,6 +6493,71 @@ async def mark_paper_submitted(
         "Document paper submitted confirmed with audit log",
         profile_id=profile_id,
         doc_code=doc_code,
+        officer_id=current_user.id,
+    )
+
+    return profile
+
+
+async def update_graduation_proof_kind(
+    db: AsyncSession,
+    profile_id: int,
+    doc_code: str,
+    new_kind: str,
+    current_user: models.User,
+) -> models.AdmissionProfile:
+    """PR #13 — nâng cấp loại giấy tốt nghiệp THPT (vd provisional→official).
+
+    Dùng khi thí sinh bổ sung bằng chính thức cho hồ sơ trước đó nộp Giấy CN
+    tốt nghiệp tạm thời. KHÔNG đổi status. official_diploma → xoá hạn bổ sung.
+    IDOR qua get_profile; role gate ở router (Casbin như paper-submitted).
+    """
+    from app.repositories import AdmissionRepository
+    admission_repo = AdmissionRepository(db)
+
+    profile = await get_profile(db, profile_id, current_user)
+
+    if doc_code != "bang_tot_nghiep_thpt":
+        raise BusinessRuleViolation("Chỉ áp dụng cho giấy tốt nghiệp THPT")
+    if new_kind not in ("official_diploma", "provisional_cert"):
+        raise ValidationError("graduation_proof_kind không hợp lệ")
+
+    doc_before = await admission_repo.get_document_by_type(
+        profile_id, doc_code
+    )
+    status = doc_before.status if doc_before else "missing"
+
+    doc = await admission_repo.update_graduation_proof(
+        profile_id=profile_id,
+        document_type_code=doc_code,
+        new_kind=new_kind,
+    )
+    if not doc:
+        raise ResourceNotFoundError(
+            f"Document code '{doc_code}' not found in profile documents"
+        )
+
+    await db.flush()
+
+    from .document_audit_service import log_graduation_proof_update
+    await log_graduation_proof_update(
+        db=db,
+        profile_document_id=doc.id,
+        actor_user_id=current_user.id,
+        status=status,
+        new_kind=new_kind,
+    )
+
+    documents = await admission_repo.get_all_documents(profile_id)
+    await _populate_response_fields(
+        db, profile, current_user, documents=documents
+    )
+
+    log.info(
+        "Graduation proof kind updated",
+        profile_id=profile_id,
+        doc_code=doc_code,
+        new_kind=new_kind,
         officer_id=current_user.id,
     )
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2149,6 +2149,13 @@ def _compute_frontend_fields(
             "submission_format_confirmed": uploaded_doc.get(
                 "submission_format_confirmed", False
             ),
+            # PR #13 — surface the "nợ bằng" debt even on an extra row so the
+            # badge stays visible if bang_tot_nghiep_thpt drops out of the
+            # snapshot; extras are read-only → no upgrade action (the service
+            # is_extra guard would reject it anyway).
+            "graduation_proof_kind": uploaded_doc.get("graduation_proof_kind"),
+            "supplement_due_date": uploaded_doc.get("supplement_due_date"),
+            "can_update_graduation_kind": False,
             # Extras are read-only: row visible for evidence + audit,
             # but no action buttons. A future sync-path action will own
             # the cleanup workflow.
@@ -6523,26 +6530,64 @@ async def update_graduation_proof_kind(
     new_kind: str,
     current_user: models.User,
 ) -> models.AdmissionProfile:
-    """PR #13 — nâng cấp loại giấy tốt nghiệp THPT (vd provisional→official).
+    """PR #13 — officer ghi nhận đã nhận BẰNG CHÍNH THỨC (provisional→official).
 
     Dùng khi thí sinh bổ sung bằng chính thức cho hồ sơ trước đó nộp Giấy CN
-    tốt nghiệp tạm thời. KHÔNG đổi status. official_diploma → xoá hạn bổ sung.
-    IDOR qua get_profile; role gate ở router (Casbin như paper-submitted).
+    tốt nghiệp tạm thời. KHÔNG đổi status; official_diploma → xoá hạn bổ sung.
+
+    Auth: ``get_profile`` đã chặn IDOR scope (officer=assigned+unit /
+    manager=unit / admin all). Thêm 2 guard mirror ``_authorize_document_action``
+    mà sibling endpoints (paper-submit/verify/reject/reset) áp:
+    - **BR2 is_extra**: doc đã rớt khỏi ``mandatory_docs`` snapshot = read-only.
+    - **doc-status**: chỉ cập nhật khi giấy ĐÃ được ghi nhận
+      (``paper_submitted`` / ``verified``) — không stamp lên doc chưa nhận.
+    Chỉ nhận ``official_diploma``: giấy tạm thời + hạn bổ sung ghi qua paper-
+    submit (mang theo hạn); endpoint này không có field hạn nên nhận
+    provisional_cert sẽ tạo "nợ bằng" hạn NULL mà query nhắc bỏ sót.
     """
     from app.repositories import AdmissionRepository
     admission_repo = AdmissionRepository(db)
 
+    # get_profile eager-loads documents.document_type + enforces IDOR scope.
     profile = await get_profile(db, profile_id, current_user)
 
     if doc_code != "bang_tot_nghiep_thpt":
         raise BusinessRuleViolation("Chỉ áp dụng cho giấy tốt nghiệp THPT")
-    if new_kind not in ("official_diploma", "provisional_cert"):
-        raise ValidationError("graduation_proof_kind không hợp lệ")
+    if new_kind != "official_diploma":
+        raise BusinessRuleViolation(
+            "Endpoint chỉ ghi nhận bằng chính thức; giấy tạm thời + hạn bổ "
+            "sung được ghi qua thao tác nhận giấy."
+        )
 
-    doc_before = await admission_repo.get_document_by_type(
-        profile_id, doc_code
+    # Locate the graduation doc in the eager-loaded snapshot (no extra query).
+    doc_before = next(
+        (
+            d
+            for d in profile.documents
+            if d.document_type and d.document_type.code == doc_code
+        ),
+        None,
     )
-    status = doc_before.status if doc_before else "missing"
+    if not doc_before:
+        raise ResourceNotFoundError(
+            f"Document code '{doc_code}' not found in profile documents"
+        )
+
+    # BR2 — extras (dropped from the mandatory snapshot) are read-only.
+    applied_rules = profile.applied_rules or {}
+    mandatory_docs = applied_rules.get("mandatory_docs") or []
+    if doc_code not in mandatory_docs:
+        raise PermissionDeniedError(
+            f"Document '{doc_code}' is no longer in the current admission "
+            f"path's mandatory list (extra / evidence-only)."
+        )
+
+    # Coherence — only a RECEIVED graduation doc can be upgraded to official.
+    status = doc_before.status
+    if status not in ("paper_submitted", "verified"):
+        raise BusinessRuleViolation(
+            "Chỉ cập nhật loại giấy khi đã ghi nhận giấy tốt nghiệp."
+        )
 
     doc = await admission_repo.update_graduation_proof(
         profile_id=profile_id,
@@ -6565,9 +6610,10 @@ async def update_graduation_proof_kind(
         new_kind=new_kind,
     )
 
-    documents = await admission_repo.get_all_documents(profile_id)
+    # Reuse the eager-loaded collection (mutated in-place via the identity
+    # map) instead of re-querying all documents.
     await _populate_response_fields(
-        db, profile, current_user, documents=documents
+        db, profile, current_user, documents=profile.documents
     )
 
     log.info(

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2010,6 +2010,15 @@ def _compute_frontend_fields(
                         if _is_verified and doc.verified_by is not None
                         else None
                     ),
+                    # PR #13 — loại giấy tốt nghiệp + hạn "nợ bằng".
+                    "graduation_proof_kind": (
+                        doc.graduation_proof_kind if _has_artifact else None
+                    ),
+                    "supplement_due_date": (
+                        doc.supplement_due_date.isoformat()
+                        if _has_artifact and doc.supplement_due_date
+                        else None
+                    ),
                 }
     
     # PR #5 — per-document action permissions delegate to the
@@ -2097,6 +2106,14 @@ def _compute_frontend_fields(
             "verified_by_name": uploaded_doc.get("verified_by_name"),
             "rejection_reason": uploaded_doc.get("rejection_reason"),
             "submission_format_confirmed": uploaded_doc.get("submission_format_confirmed", False),
+            # PR #13 — graduation proof + cờ "đã nhận bằng chính thức".
+            "graduation_proof_kind": uploaded_doc.get("graduation_proof_kind"),
+            "supplement_due_date": uploaded_doc.get("supplement_due_date"),
+            "can_update_graduation_kind": (
+                doc_code == "bang_tot_nghiep_thpt"
+                and uploaded_doc.get("graduation_proof_kind")
+                == "provisional_cert"
+            ),
             **_perms,
         })
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -6464,13 +6464,25 @@ async def mark_paper_submitted(
     )
 
     # PR #13 — graduation proof chỉ áp cho giấy TN THPT; doc khác bỏ qua 2
-    # field. Validate provisional ⇒ bắt buộc có hạn bổ sung.
+    # field. Giấy TN THPT BẮT BUỘC phân loại khi ghi nhận.
     _grad_kind = graduation_proof_kind
     _grad_due = supplement_due_date
     if doc_code != "bang_tot_nghiep_thpt":
         _grad_kind = None
         _grad_due = None
-    elif _grad_kind is not None:
+    else:
+        # The graduation doc MUST be classified on receipt. Defaulting (e.g.
+        # to official_diploma) would risk silently recording a provisional
+        # cert as an official diploma — the candidate would owe the diploma
+        # but the system would show no "nợ bằng" debt, no badge and no way to
+        # clear it. Require the kind explicitly. The FE dialog always sends
+        # it (RadioGroup forces a choice); this closes the gap for raw API /
+        # Swagger / old clients that omit it.
+        if _grad_kind is None:
+            raise ValidationError(
+                "Cần chọn loại giấy tốt nghiệp (bằng chính thức / giấy tạm "
+                "thời) khi ghi nhận giấy tốt nghiệp THPT."
+            )
         if _grad_kind not in ("official_diploma", "provisional_cert"):
             raise ValidationError("graduation_proof_kind không hợp lệ")
         if _grad_kind == "provisional_cert" and _grad_due is None:

--- a/Backend_FastAPI/app/services/document_audit_service.py
+++ b/Backend_FastAPI/app/services/document_audit_service.py
@@ -255,10 +255,21 @@ async def log_paper_submission(
     actor_user_id: int,
     old_status: str,
     declared_format: Optional[str] = None,
+    graduation_proof_kind: Optional[str] = None,
+    supplement_due_date: Optional[Any] = None,
     ip_address: Optional[str] = None,
     user_agent: Optional[str] = None,
 ) -> models.DocumentAuditLog:
-    """Log a paper submission confirmation action."""
+    """Log a paper submission confirmation action.
+
+    PR #13 — nếu là giấy tốt nghiệp THPT: ghi loại giấy (bằng/tạm thời) +
+    hạn bổ sung vào ``extra_data`` để truy vết "nợ bằng".
+    """
+    extra: Dict[str, Any] = {}
+    if graduation_proof_kind is not None:
+        extra["graduation_proof_kind"] = graduation_proof_kind
+        if supplement_due_date is not None:
+            extra["supplement_due_date"] = supplement_due_date.isoformat()
     return await log_document_action(
         db=db,
         profile_document_id=profile_document_id,
@@ -267,6 +278,34 @@ async def log_paper_submission(
         old_status=old_status,
         new_status="paper_submitted",
         declared_format=declared_format,
+        extra_data=extra or None,
+        ip_address=ip_address,
+        user_agent=user_agent,
+    )
+
+
+async def log_graduation_proof_update(
+    db: AsyncSession,
+    profile_document_id: int,
+    actor_user_id: int,
+    status: str,
+    new_kind: str,
+    ip_address: Optional[str] = None,
+    user_agent: Optional[str] = None,
+) -> models.DocumentAuditLog:
+    """PR #13 — log nâng cấp loại giấy tốt nghiệp (provisional→official).
+
+    Status không đổi (giấy đã nộp) → old=new. Chi tiết ở ``extra_data`` để
+    tránh thêm action enum mới (khỏi migration relax constraint).
+    """
+    return await log_document_action(
+        db=db,
+        profile_document_id=profile_document_id,
+        action=DocumentAction.PAPER_SUBMITTED,
+        actor_user_id=actor_user_id,
+        old_status=status,
+        new_status=status,
+        extra_data={"graduation_proof_update": True, "new_kind": new_kind},
         ip_address=ip_address,
         user_agent=user_agent,
     )

--- a/Backend_FastAPI/app/services/document_resolution_service.py
+++ b/Backend_FastAPI/app/services/document_resolution_service.py
@@ -53,6 +53,15 @@ _COMPLETED_DIPLOMA_TO_REMOVE: Dict[str, str] = {
     "completed_thcs": "bang_tot_nghiep_thcs",
 }
 
+# PR #10 — ĐỐI XỨNG with ..._TO_REMOVE: "completed_*" nộp Giấy CN hoàn thành
+# chương trình THAY cho bằng TN bị loại. Vì ``_CULTURAL_TO_AUDIENCE`` map cả
+# completed_thpt + graduated_thpt → CÙNG POST_THPT, audience layer KHÔNG phân
+# biệt được → SWAP phải làm ở tầng code (caller dựng synthetic resolved item).
+# completed_thcs CHƯA có giấy nguồn → để trống (known-limitation GĐ1).
+_COMPLETED_DIPLOMA_TO_ADD: Dict[str, str] = {
+    "completed_thpt": "giay_cn_hoan_thanh_gdpt",
+}
+
 
 def mandatory_wins_merge(
     doc_map: Dict[int, tuple],
@@ -186,9 +195,23 @@ def compute_completed_doc_codes(profile) -> Set[str]:
     return {code} if code else set()
 
 
+def compute_completed_add_doc_codes(profile) -> Set[str]:
+    """PR #10 — mã giấy cần THÊM khi ``cultural='completed_*'`` (đối xứng
+    ``compute_completed_doc_codes``).
+
+    "completed_thpt" (trượt tốt nghiệp) nộp Giấy CN hoàn thành chương trình
+    GDPT thay cho bằng TN bị loại. "graduated_*" giữ bằng, KHÔNG thêm.
+    Trả set rỗng cho cultural khác (kể cả completed_thcs — chưa có giấy nguồn).
+    """
+    cultural = getattr(profile, "cultural_education_level", None)
+    code = _COMPLETED_DIPLOMA_TO_ADD.get(cultural)
+    return {code} if code else set()
+
+
 def build_resolved_response(
     doc_map: Dict[int, tuple],
     completed_codes: Optional[Set[str]] = None,
+    add_items: Optional[List[ResolvedDocumentResponse]] = None,
 ) -> List[ResolvedDocumentResponse]:
     """``doc_map`` ``(item, source, group_audience)`` → list ResolvedDocumentResponse.
 
@@ -198,6 +221,12 @@ def build_resolved_response(
     → bỏ bằng TN §6). ``layer_kind``: path_override / method_override /
     shared_audience / shared_base. ``applicable_audience``: audience group thắng
     (None cho NỀN/override).
+
+    PR #10 — ``add_items``: synthetic ResolvedDocumentResponse do CALLER dựng
+    từ DB (vd Giấy CN hoàn thành GDPT cho ``completed_thpt``). Builder GIỮ PURE:
+    chỉ APPEND item có ``document_type_code`` CHƯA xuất hiện trong kết quả
+    (dedup — nếu DocumentGroup đã cấu hình giấy đó thì giữ bản config, không
+    nhân đôi), rồi sort lại theo ``display_order``.
     """
     completed = completed_codes or set()
     resolved: List[ResolvedDocumentResponse] = []
@@ -229,5 +258,47 @@ def build_resolved_response(
                 layer_kind=layer_kind,
             )
         )
+
+    if add_items:
+        existing_codes = {r.document_type_code for r in resolved}
+        for extra in add_items:
+            if extra.document_type_code not in existing_codes:
+                resolved.append(extra)
+                existing_codes.add(extra.document_type_code)
+
     resolved.sort(key=lambda x: x.display_order)
     return resolved
+
+
+def build_completed_add_items(doc_types) -> List[ResolvedDocumentResponse]:
+    """PR #10 — dựng synthetic add-items (paper-only) từ list ConfigDocumentType.
+
+    Pure builder dùng CHUNG cho cả ``resolve_documents_for_profile`` (resolve
+    thật) lẫn preview config → 1 nguồn shape, KHÔNG drift (finding #3). Caller
+    lookup doc type từ DB rồi truyền vào (chỉ ``id``/``code``/``name``/
+    ``display_order`` được đọc). Phần paper-only dựng CỨNG: vì #10 KHÔNG tạo
+    ``DocumentGroupItem`` cho giấy GDPT, các field config (``requires_upload``,
+    ``submission_format``, ``is_mandatory``) — vốn nằm ở ``DocumentGroupItem`` —
+    phải set tường minh ở đây.
+
+    ``layer_kind='shared_base'`` + ``applicable_audience=None``: item chỉ xuất
+    hiện trong context resolve của hồ sơ completed_*, KHÔNG gắn badge audience
+    (tránh hiểu nhầm "đã tốt nghiệp" cho người trượt TN).
+    """
+    items: List[ResolvedDocumentResponse] = []
+    for dt in doc_types:
+        items.append(
+            ResolvedDocumentResponse(
+                document_type_id=dt.id,
+                document_type_code=dt.code,
+                document_type_name=dt.name,
+                is_mandatory=True,
+                requires_upload=False,  # paper-only — officer ghi nhận tại quầy
+                submission_format=None,
+                display_order=dt.display_order,
+                source="shared",
+                applicable_audience=None,
+                layer_kind="shared_base",
+            )
+        )
+    return items

--- a/Backend_FastAPI/requirements.txt
+++ b/Backend_FastAPI/requirements.txt
@@ -1,7 +1,7 @@
 aiobreaker==1.2.0
 aiofiles==25.1.0
 aiohappyeyeballs==2.6.1
-aiohttp==3.13.4
+aiohttp==3.14.0
 aiosignal==1.4.0
 aiosmtplib==5.1.0
 alembic==1.17.0

--- a/Backend_FastAPI/tests/api/test_pr13_graduation_proof_api.py
+++ b/Backend_FastAPI/tests/api/test_pr13_graduation_proof_api.py
@@ -426,3 +426,108 @@ async def test_regular_user_denied_by_casbin(
         json={"kind": "official_diploma"},
     )
     assert resp.status_code in (403, 404), resp.text
+
+
+# =============================================================================
+# PR #13.7 — pending-diploma ("nợ bằng") reminder endpoint
+# =============================================================================
+
+
+async def _paper_submit_official(client, oh, pid):
+    resp = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{GRAD_CODE}/paper-submitted",
+        headers=oh,
+        json={
+            "actual_submission_format": "original",
+            "graduation_proof_kind": "official_diploma",
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_pending_diploma_lists_provisional(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    graduation_config: dict,
+):
+    """A provisional-cert profile appears in the officer's nợ-bằng list."""
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "pdl"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    await _paper_submit_provisional(client, oh, pid)
+
+    resp = await client.get(f"{ADMISSIONS}/pending-diploma", headers=oh)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    item = next((i for i in body["items"] if i["profile_id"] == pid), None)
+    assert item is not None, f"profile {pid} missing from nợ-bằng list: {body}"
+    assert item["supplement_due_date"] == DUE, item
+    assert item["candidate_name"], item
+    assert body["total_count"] == len(body["items"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_pending_diploma_excludes_official_and_honours_due_before(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    graduation_config: dict,
+):
+    """official_diploma carries no debt; due_before narrows by supplement date."""
+    # Create BOTH profiles before the officer login so the admin Bearer is not
+    # shadowed by an officer cookie (cookie jar contamination).
+    prof_a = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "pdA"
+    )
+    prof_b = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "pdB"
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    await _paper_submit_provisional(client, oh, prof_a["id"])  # debt (DUE)
+    await _paper_submit_official(client, oh, prof_b["id"])  # no debt
+
+    body = (
+        await client.get(f"{ADMISSIONS}/pending-diploma", headers=oh)
+    ).json()
+    ids = {i["profile_id"] for i in body["items"]}
+    assert prof_a["id"] in ids, body
+    assert prof_b["id"] not in ids, "official_diploma must not show as nợ bằng"
+
+    # due_before BEFORE the supplement date (DUE=2027-06-30) excludes A.
+    early = (
+        await client.get(
+            f"{ADMISSIONS}/pending-diploma?due_before=2027-01-01", headers=oh
+        )
+    ).json()
+    assert prof_a["id"] not in {i["profile_id"] for i in early["items"]}, early
+
+    # due_before AFTER the supplement date includes A.
+    late = (
+        await client.get(
+            f"{ADMISSIONS}/pending-diploma?due_before=2027-12-31", headers=oh
+        )
+    ).json()
+    assert prof_a["id"] in {i["profile_id"] for i in late["items"]}, late
+
+
+@pytest.mark.asyncio
+async def test_pending_diploma_regular_user_denied(
+    client: AsyncClient,
+    regular_user_token_headers: dict,
+    graduation_config: dict,
+):
+    """A basic ``user`` role has no pending-diploma policy → Casbin bounces."""
+    client.cookies.clear()
+    resp = await client.get(
+        f"{ADMISSIONS}/pending-diploma", headers=regular_user_token_headers
+    )
+    assert resp.status_code in (403, 404), resp.text

--- a/Backend_FastAPI/tests/api/test_pr13_graduation_proof_api.py
+++ b/Backend_FastAPI/tests/api/test_pr13_graduation_proof_api.py
@@ -1,0 +1,428 @@
+"""PR #13.4b — API + Casbin contract cho graduation-proof update endpoint.
+
+Covers the whole officer flow for ``bang_tot_nghiep_thpt``:
+
+1. Officer marks the paper-only graduation doc as paper-submitted with
+   ``provisional_cert`` + a supplement due date → the checklist row surfaces
+   ``graduation_proof_kind`` / ``supplement_due_date`` and flips
+   ``can_update_graduation_kind`` on (the "nợ bằng" badge).
+2. Officer later records the official diploma via the NEW endpoint
+   ``POST /documents/{code}/graduation-proof`` → status unchanged, due date
+   cleared, flag off.
+3. Realtime ``data_updated`` emit fires once with
+   ``document_action="graduation_proof_updated"`` (review finding #4).
+4. ``DocumentAuditLog.extra_data`` records the proof kind on paper-submit AND
+   the upgrade on update (review finding #4 — audit trail for "nợ bằng").
+5. Guard: a non-graduation doc code → 400; a basic ``user`` role is denied by
+   Casbin (the endpoint mirrors paper-submitted: officer ALLOW, others bounce).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.models.admission_config.profile_data import (
+    DocumentAuditLog,
+    ProfileDocument,
+)
+from tests.fixtures.constants import AuthURLs, LeadsURLs
+
+
+ADMISSIONS = "/api/admissions"
+GRAD_CODE = "bang_tot_nghiep_thpt"
+DUE = "2027-06-30"
+# Mock target — the router calls this helper inside the thin
+# ``_emit_admission_doc_mutation`` wrapper, so asserting on it counts
+# emits 1:1 with mutation success (mirror test_admission_doc_realtime_emit).
+_EMIT_HELPER = "app.routers.admissions._emit_realtime_update"
+
+
+async def _login(client: AsyncClient, username: str, password: str) -> dict:
+    r = await client.post(
+        AuthURLs.LOGIN, data={"username": username, "password": password}
+    )
+    assert r.status_code == 200, f"Login {username}: {r.text}"
+    return {"Authorization": f"Bearer {r.cookies.get('access_token')}"}
+
+
+@pytest_asyncio.fixture
+async def graduation_config(seed_lead_dependencies: dict):
+    """Admission path wired to a paper-only ``bang_tot_nghiep_thpt`` doc.
+
+    The graduation doc type has a FIXED code (the service hard-checks it), so
+    we get-or-create it; the offering/method/criteria/group are per-``ts`` to
+    stay isolated. The doc is paper-only (``requires_upload=False``) so a new
+    profile exposes a paper-submittable graduation row.
+    """
+    uid = seed_lead_dependencies["unit_id"]
+    mpid = seed_lead_dependencies["major_program_id"]
+    ts = f"{int(datetime.now().timestamp() * 1000)}"
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            ot = models.ConfigOfferingType(
+                code=f"tq_{ts}", name=f"TQ_{ts}", display_order=1
+            )
+            s.add(ot)
+            await s.flush()
+            existing = await s.execute(
+                select(models.ConfigDocumentType).where(
+                    models.ConfigDocumentType.code == GRAD_CODE
+                )
+            )
+            dt_grad = existing.scalar_one_or_none()
+            if dt_grad is None:
+                dt_grad = models.ConfigDocumentType(
+                    code=GRAD_CODE,
+                    name="Bằng tốt nghiệp THPT / Giấy CN tốt nghiệp tạm thời",
+                    display_order=1,
+                )
+                s.add(dt_grad)
+                await s.flush()
+            po = models.ProgramOffering(
+                offering_type=f"TQ_{ts}",
+                program_id=mpid,
+                offering_type_id=ot.id,
+                is_active=True,
+                duration_semesters=6,
+            )
+            s.add(po)
+            await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=po.id,
+                academic_year=2026,
+                tuition_fee_per_year=5000000,
+                annual_admission_quota=100,
+                is_published=True,
+            )
+            s.add(ai)
+            await s.flush()
+            am = models.AdmissionMethod(
+                code=f"hb_{ts}",
+                name=f"HB_{ts}",
+                requires_gpa=True,
+                requires_subject_scores=False,
+                is_active=True,
+            )
+            s.add(am)
+            await s.flush()
+            ac = models.AdmissionCriteria(
+                method_id=am.id,
+                code=f"TC_{ts}",
+                name=f"TC_{ts}",
+                min_gpa=0.0,
+                scoring_method="average",
+                subject_selection_mode="fixed",
+                policy_version="2026.1",
+                is_active=True,
+            )
+            s.add(ac)
+            await s.flush()
+            from tests.fixtures.builders import AdmissionRoundBuilder
+
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                s, academic_year=2026
+            )
+            ap = models.AdmissionPath(
+                academic_info_id=ai.id,
+                admission_method_id=am.id,
+                admission_round_id=round_id,
+                criteria_id=ac.id,
+                status="active",
+                display_name=f"GRAD {ts}",
+                display_order=0,
+                visibility="public",
+            )
+            s.add(ap)
+            await s.flush()
+            dg = models.DocumentGroup(
+                offering_type_id=ot.id,
+                admission_method_id=am.id,
+                code=f"dg_{ts}",
+                name=f"DG_{ts}",
+                is_active=True,
+            )
+            s.add(dg)
+            await s.flush()
+            s.add(
+                models.DocumentGroupItem(
+                    group_id=dg.id,
+                    document_type_id=dt_grad.id,
+                    is_mandatory=True,
+                    requires_upload=False,  # paper-only graduation doc
+                    submission_format="original",
+                    display_order=1,
+                )
+            )
+            await s.flush()
+    return {
+        "unit_id": uid,
+        "offering_id": po.id,
+        "method_id": am.id,
+        "round_id": round_id,
+    }
+
+
+async def _create_profile(client, admin_token_headers, officer_user_in_db, cfg, suffix):
+    from tests._lead_status_test_ids import INITIAL_LEAD_STATUS_ID
+
+    phone = f"0988{int(datetime.now().timestamp() * 1000) % 10**6:06d}"
+    lead = (
+        await client.post(
+            LeadsURLs.LEADS,
+            json={
+                "full_name": f"GradProof {suffix}",
+                "phone": phone,
+                "source": "website",
+                "unit_id": cfg["unit_id"],
+                "assigned_officer_id": officer_user_in_db["id"],
+                "offering_id": cfg["offering_id"],
+            },
+            headers=admin_token_headers,
+        )
+    ).json()
+    await client.post(
+        f"{LeadsURLs.LEADS}/{lead['id']}/consultations",
+        json={
+            "status_id": INITIAL_LEAD_STATUS_ID,
+            "method": "phone",
+            "notes": "Pre-admission",
+        },
+        headers=admin_token_headers,
+    )
+    prof = (
+        await client.post(
+            ADMISSIONS,
+            json={
+                "lead_id": lead["id"],
+                "admission_method_id": cfg["method_id"],
+                "admission_round_id": cfg["round_id"],
+                "academic_year": 2026,
+            },
+            headers=admin_token_headers,
+        )
+    ).json()
+    return prof
+
+
+def _grad_row(detail: dict) -> dict:
+    row = next(
+        (d for d in detail.get("documents_checklist", []) if d["code"] == GRAD_CODE),
+        None,
+    )
+    assert row is not None, (
+        f"graduation doc {GRAD_CODE!r} missing from checklist: "
+        f"{[d['code'] for d in detail.get('documents_checklist', [])]}"
+    )
+    return row
+
+
+async def _paper_submit_provisional(client, oh, pid):
+    resp = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{GRAD_CODE}/paper-submitted",
+        headers=oh,
+        json={
+            "actual_submission_format": "certified_copy",
+            "graduation_proof_kind": "provisional_cert",
+            "supplement_due_date": DUE,
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_provisional_then_official_roundtrip(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    graduation_config: dict,
+):
+    """provisional_cert + due → official_diploma clears the "nợ bằng" debt."""
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "rt"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+
+    # 1. Officer records the provisional certificate + supplement due date.
+    await _paper_submit_provisional(client, oh, pid)
+
+    after_submit = _grad_row(
+        (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
+    )
+    assert after_submit["graduation_proof_kind"] == "provisional_cert", after_submit
+    assert after_submit["supplement_due_date"] == DUE, after_submit
+    assert after_submit["can_update_graduation_kind"] is True, after_submit
+    assert after_submit["status"] == "paper_submitted", after_submit
+
+    # 2. Officer upgrades to the official diploma via the NEW endpoint.
+    upd = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{GRAD_CODE}/graduation-proof",
+        headers=oh,
+        json={"kind": "official_diploma"},
+    )
+    assert upd.status_code == 200, upd.text
+
+    after_update = _grad_row(
+        (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
+    )
+    assert after_update["graduation_proof_kind"] == "official_diploma", after_update
+    assert after_update["supplement_due_date"] is None, after_update
+    assert after_update["can_update_graduation_kind"] is False, after_update
+    # Status must NOT change — the doc was already received.
+    assert after_update["status"] == "paper_submitted", after_update
+
+
+@pytest.mark.asyncio
+async def test_update_emits_data_updated(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    graduation_config: dict,
+):
+    """The update endpoint emits exactly one ``graduation_proof_updated``."""
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "emit"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    await _paper_submit_provisional(client, oh, pid)
+
+    with patch(_EMIT_HELPER, new_callable=AsyncMock) as mock_emit:
+        resp = await client.post(
+            f"{ADMISSIONS}/{pid}/documents/{GRAD_CODE}/graduation-proof",
+            headers=oh,
+            json={"kind": "official_diploma"},
+        )
+        assert resp.status_code == 200, resp.text
+
+    assert mock_emit.await_count == 1, (
+        f"Expected exactly 1 emit, got {mock_emit.await_count}: "
+        f"{mock_emit.await_args_list}"
+    )
+    kwargs = mock_emit.await_args.kwargs
+    assert kwargs["resource_type"] == "admission_profile", kwargs
+    assert kwargs["operation"] == "update", kwargs
+    assert kwargs["resource_id"] == pid, kwargs
+    payload = kwargs.get("data") or {}
+    assert payload.get("document_action") == "graduation_proof_updated", payload
+    assert payload.get("doc_code") == GRAD_CODE, payload
+
+
+@pytest.mark.asyncio
+async def test_paper_submit_and_update_write_audit_extra_data(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    graduation_config: dict,
+):
+    """extra_data carries the proof kind on submit + the upgrade on update."""
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "audit"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    await _paper_submit_provisional(client, oh, pid)
+    upd = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{GRAD_CODE}/graduation-proof",
+        headers=oh,
+        json={"kind": "official_diploma"},
+    )
+    assert upd.status_code == 200, upd.text
+
+    async with AsyncSessionLocal() as s:
+        logs = (
+            await s.execute(
+                select(DocumentAuditLog)
+                .join(
+                    ProfileDocument,
+                    DocumentAuditLog.profile_document_id == ProfileDocument.id,
+                )
+                .where(ProfileDocument.profile_id == pid)
+                .order_by(DocumentAuditLog.created_at)
+            )
+        ).scalars().all()
+
+    extras = [dict(log.extra_data or {}) for log in logs]
+    # Paper-submit logged the provisional kind + the supplement due date.
+    submit_extra = next(
+        (e for e in extras if e.get("graduation_proof_kind") == "provisional_cert"),
+        None,
+    )
+    assert submit_extra is not None, f"no paper-submit proof-kind audit: {extras}"
+    assert submit_extra.get("supplement_due_date") == DUE, submit_extra
+    # Update logged the upgrade flag + the new kind.
+    update_extra = next(
+        (e for e in extras if e.get("graduation_proof_update") is True), None
+    )
+    assert update_extra is not None, f"no graduation-proof update audit: {extras}"
+    assert update_extra.get("new_kind") == "official_diploma", update_extra
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_non_graduation_doc(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    graduation_config: dict,
+):
+    """Any doc code other than bang_tot_nghiep_thpt → 400 (BusinessRule)."""
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "guard"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/hoc_ba_thpt/graduation-proof",
+        headers=oh,
+        json={"kind": "official_diploma"},
+    )
+    assert resp.status_code == 400, resp.text
+
+
+@pytest.mark.asyncio
+async def test_regular_user_denied_by_casbin(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    regular_user_token_headers: dict,
+    graduation_config: dict,
+):
+    """A basic ``user`` role has no graduation-proof policy → Casbin bounces.
+
+    Mirrors paper-submitted: officer ALLOW, others denied. Accept 403 or 404
+    (the latter is the IDOR-safe shape some gates return)."""
+    # The ``regular_user_token_headers`` fixture logs in → its cookie lands in
+    # the shared jar, and the backend prefers the cookie over the Bearer
+    # header. Clear before the admin-driven setup so admin's Bearer is
+    # authoritative (else /api/leads 403s as role:user — cookie jar
+    # contamination, memory test-httpx-cookie-jar-contamination).
+    client.cookies.clear()
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "deny"
+    )
+    pid = prof["id"]
+    # Drop admin's cookie so the regular user's Bearer is the authoritative
+    # identity for the probe under test.
+    client.cookies.clear()
+    resp = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{GRAD_CODE}/graduation-proof",
+        headers=regular_user_token_headers,
+        json={"kind": "official_diploma"},
+    )
+    assert resp.status_code in (403, 404), resp.text

--- a/Backend_FastAPI/tests/api/test_pr13_graduation_proof_api.py
+++ b/Backend_FastAPI/tests/api/test_pr13_graduation_proof_api.py
@@ -626,3 +626,38 @@ async def test_reject_clears_graduation_debt(
     # Debt cleared → no longer in the reminder list.
     after = (await client.get(f"{ADMISSIONS}/pending-diploma", headers=admin)).json()
     assert pid not in {i["profile_id"] for i in after["items"]}, after
+
+
+@pytest.mark.asyncio
+async def test_paper_submit_graduation_requires_kind(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    graduation_config: dict,
+):
+    """Marking the graduation doc received WITHOUT graduation_proof_kind → 400.
+
+    Defaulting (e.g. to official_diploma) would risk silently recording a
+    provisional cert as an official diploma — hiding the nợ-bằng debt. A raw
+    API / Swagger / old client that omits the kind must be rejected, not
+    quietly accepted with NULL classification.
+    """
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "reqkind"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{GRAD_CODE}/paper-submitted",
+        headers=oh,
+        # No graduation_proof_kind — the gap the gate closes.
+        json={"actual_submission_format": "certified_copy"},
+    )
+    assert resp.status_code == 400, resp.text
+
+    # And the doc must NOT have been recorded as received with a NULL kind.
+    row = _grad_row((await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json())
+    assert row["status"] == "missing", row
+    assert row["graduation_proof_kind"] is None, row

--- a/Backend_FastAPI/tests/api/test_pr13_graduation_proof_api.py
+++ b/Backend_FastAPI/tests/api/test_pr13_graduation_proof_api.py
@@ -531,3 +531,98 @@ async def test_pending_diploma_regular_user_denied(
         f"{ADMISSIONS}/pending-diploma", headers=regular_user_token_headers
     )
     assert resp.status_code in (403, 404), resp.text
+
+
+# =============================================================================
+# Review hardening — graduation-proof update guards
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_provisional_kind(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    graduation_config: dict,
+):
+    """The endpoint records the OFFICIAL diploma only; provisional_cert (which
+    needs a supplement due date this endpoint can't carry) → 400."""
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "prov"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    await _paper_submit_provisional(client, oh, pid)
+    resp = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{GRAD_CODE}/graduation-proof",
+        headers=oh,
+        json={"kind": "provisional_cert"},
+    )
+    assert resp.status_code == 400, resp.text
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_unreceived_doc(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    graduation_config: dict,
+):
+    """Cannot stamp official_diploma on a graduation doc never received
+    (status='missing') → 400 (doc-status coherence guard)."""
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "unrcv"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    # No paper-submit → graduation doc is still 'missing'.
+    resp = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{GRAD_CODE}/graduation-proof",
+        headers=oh,
+        json={"kind": "official_diploma"},
+    )
+    assert resp.status_code == 400, resp.text
+
+
+@pytest.mark.asyncio
+async def test_reject_clears_graduation_debt(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    graduation_config: dict,
+):
+    """Rejecting a provisional graduation submission voids the nợ-bằng debt:
+    the profile drops out of the pending-diploma list."""
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "rejdebt"
+    )
+    pid = prof["id"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    await _paper_submit_provisional(client, oh, pid)
+
+    # Sanity: the debt is listed before rejection.
+    before = (await client.get(f"{ADMISSIONS}/pending-diploma", headers=oh)).json()
+    assert pid in {i["profile_id"] for i in before["items"]}, before
+
+    # Admin (reviewer) rejects the graduation doc.
+    from tests.fixtures.constants import TestUsers
+
+    admin = await _login(
+        client, TestUsers.ADMIN["username"], TestUsers.ADMIN["password"]
+    )
+    rej = await client.post(
+        f"{ADMISSIONS}/{pid}/documents/{GRAD_CODE}/reject",
+        headers=admin,
+        json={"reason": "Giấy tạm thời không hợp lệ, yêu cầu nộp lại"},
+    )
+    assert rej.status_code == 200, rej.text
+
+    # Debt cleared → no longer in the reminder list.
+    after = (await client.get(f"{ADMISSIONS}/pending-diploma", headers=admin)).json()
+    assert pid not in {i["profile_id"] for i in after["items"]}, after

--- a/Backend_FastAPI/tests/api/test_pr13_graduation_proof_api.py
+++ b/Backend_FastAPI/tests/api/test_pr13_graduation_proof_api.py
@@ -24,7 +24,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from app import models
 from app.database import AsyncSessionLocal
@@ -661,3 +661,53 @@ async def test_paper_submit_graduation_requires_kind(
     row = _grad_row((await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json())
     assert row["status"] == "missing", row
     assert row["graduation_proof_kind"] is None, row
+
+
+@pytest.mark.asyncio
+async def test_pending_diploma_excludes_withdrawn_and_dropped(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    graduation_config: dict,
+):
+    """Review F3 — non-actionable profiles drop out of the nợ-bằng reminder:
+    withdrawn (status) and dropped (is_dropped=True) even with a provisional
+    cert outstanding; an actionable profile stays listed."""
+    # Create all three before officer login (admin Bearer not shadowed).
+    p_wd = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "wd"
+    )
+    p_drop = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "drp"
+    )
+    p_ok = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, graduation_config, "ok"
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    for pid in (p_wd["id"], p_drop["id"], p_ok["id"]):
+        await _paper_submit_provisional(client, oh, pid)
+
+    # All three listed initially.
+    before = (await client.get(f"{ADMISSIONS}/pending-diploma", headers=oh)).json()
+    listed = {i["profile_id"] for i in before["items"]}
+    assert {p_wd["id"], p_drop["id"], p_ok["id"]} <= listed, before
+
+    # Flip to non-actionable states (terminal): withdrawn + dropped.
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text("UPDATE admission_profile SET status='withdrawn' WHERE id=:id"),
+            {"id": p_wd["id"]},
+        )
+        await s.execute(
+            text("UPDATE admission_profile SET is_dropped=true WHERE id=:id"),
+            {"id": p_drop["id"]},
+        )
+        await s.commit()
+
+    after = (await client.get(f"{ADMISSIONS}/pending-diploma", headers=oh)).json()
+    ids = {i["profile_id"] for i in after["items"]}
+    assert p_wd["id"] not in ids, "withdrawn must be excluded"
+    assert p_drop["id"] not in ids, "dropped must be excluded"
+    assert p_ok["id"] in ids, "actionable profile must remain listed"

--- a/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
+++ b/Backend_FastAPI/tests/integration/test_casbin_b1_4x14_matrix.py
@@ -445,6 +445,8 @@ async def test_accountant_deny_rows_seeded(setup_test_database):
             ("/api/admissions/stats",                 "GET"),
             ("/api/admissions/status-counts",         "GET"),
             ("/api/admissions/academic-years",        "GET"),
+            # PR #13.7 — nợ bằng reminder list carries candidate PII → accountant deny.
+            ("/api/admissions/pending-diploma",       "GET"),
             # Wave 4 — lead legacy routes deny (10 rows)
             ("/api/leads",                            "GET"),
             ("/api/leads",                            "POST"),

--- a/Backend_FastAPI/tests/integration/test_document_audience_reresolve.py
+++ b/Backend_FastAPI/tests/integration/test_document_audience_reresolve.py
@@ -113,6 +113,13 @@ async def _setup_audience_data(major_id: int, unit_id: int, officer_id: int) -> 
             bts_thcs = await _get_or_create_doc_type(
                 session, "bang_tot_nghiep_thcs", "Bằng tốt nghiệp THCS"
             )
+            # PR #10 — seed Giấy CN hoàn thành GDPT (doc type ONLY, no group
+            # item). The completed_thpt SWAP injects it synthetically.
+            await _get_or_create_doc_type(
+                session,
+                "giay_cn_hoan_thanh_gdpt",
+                "Giấy chứng nhận hoàn thành chương trình GDPT",
+            )
 
             def _mk_group(code, audience, items):
                 g = models.DocumentGroup(
@@ -290,11 +297,14 @@ class TestReresolveAudience:
         snap = await _snapshot_mandatory(pid)
         assert snap == {"cccd", "hoc_ba_thpt", "bang_tot_nghiep_thpt"}
         assert "hoc_ba_thcs" not in snap
+        # PR #10 — graduated keeps the diploma; NO GDPT swap.
+        assert "giay_cn_hoan_thanh_gdpt" not in snap
 
-    async def test_reresolve_completed_thpt_drops_diploma(
+    async def test_reresolve_completed_thpt_swaps_diploma_for_gdpt(
         self, client, officer_user_in_db, seed_lead_dependencies
     ):
-        """§6 / finding round-8 #2: completed_thpt → LOẠI bằng TN khỏi snapshot."""
+        """§6 + PR #10: completed_thpt → LOẠI bằng TN, THÊM Giấy CN hoàn thành
+        GDPT vào snapshot + tạo ProfileDocument tương ứng."""
         data = await _setup_audience_data(
             seed_lead_dependencies["major_program_id"],
             seed_lead_dependencies["unit_id"],
@@ -311,6 +321,12 @@ class TestReresolveAudience:
         snap = await _snapshot_mandatory(pid)
         assert "hoc_ba_thpt" in snap
         assert "bang_tot_nghiep_thpt" not in snap  # completed → bỏ bằng TN
+        # PR #10 — SWAP: GDPT cert added in its place.
+        assert "giay_cn_hoan_thanh_gdpt" in snap
+        # The delta INSERT must materialise a ProfileDocument for the GDPT cert.
+        doc_codes = await _profile_doc_codes(pid)
+        assert "giay_cn_hoan_thanh_gdpt" in doc_codes
+        assert "bang_tot_nghiep_thpt" not in doc_codes
 
     async def test_reresolve_delta_no_unique_violation_idempotent(
         self, client, officer_user_in_db, seed_lead_dependencies

--- a/Backend_FastAPI/tests/unit/test_gpkind01_graduation_proof_migration.py
+++ b/Backend_FastAPI/tests/unit/test_gpkind01_graduation_proof_migration.py
@@ -1,0 +1,80 @@
+"""PR #13 — coverage for graduation_proof migration (gpkind01).
+
+Source-level lock-in (same rationale as ``test_ardockeys01`` /
+``test_m_p0b``): the test DB is built with ``Base.metadata.create_all``
+(no alembic — memory ``test-db-schema-source``), so structural behaviour
+is verified by the alembic CLI roundtrip on the dev DB (upgrade → cols +
+constraints + label present → downgrade → cols dropped + label reverted).
+These tests pin the migration source against silent drift.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "gpkind01_add_graduation_proof_to_profile_document.py"
+)
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "gpkind01_migration", str(MIGRATION_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _section(start: str, end: str | None) -> str:
+    src = MIGRATION_PATH.read_text(encoding="utf-8")
+    s = src.index(start)
+    e = len(src) if end is None else src.index(end)
+    return src[s:e]
+
+
+def test_revision_chain():
+    mod = _load()
+    assert mod.revision == "gpkind01"
+    assert mod.down_revision == "ardockeys01"
+
+
+def test_label_constants():
+    """Label mới gộp cả 2 loại giấy; revert về tên cũ ở downgrade."""
+    mod = _load()
+    assert mod.GRAD_DOC_CODE == "bang_tot_nghiep_thpt"
+    assert "Giấy CN tốt nghiệp tạm thời" in mod.NEW_LABEL
+    assert mod.OLD_LABEL == "Bằng tốt nghiệp THPT"
+
+
+def test_upgrade_adds_columns_constraints_and_label():
+    up = _section("def upgrade", "def downgrade")
+    # 2 cột mới
+    assert up.count("add_column") == 2
+    assert "graduation_proof_kind" in up
+    assert "supplement_due_date" in up
+    # 2 CHECK constraint
+    assert "ck_graduation_proof_kind" in up
+    assert "ck_supplement_due_only_provisional" in up
+    assert "official_diploma" in up and "provisional_cert" in up
+    assert "supplement_due_date IS NULL" in up
+    # data migration đổi label doc type (idempotent theo code)
+    assert "config_document_type" in up
+    assert "WHERE code = :code" in up
+
+
+def test_downgrade_drops_columns_constraints_and_reverts_label():
+    down = _section("def downgrade", None)
+    assert down.count("drop_column") == 2
+    assert "graduation_proof_kind" in down
+    assert "supplement_due_date" in down
+    assert down.count("drop_constraint") == 2
+    # revert label về tên cũ
+    assert "config_document_type" in down
+    assert "OLD_LABEL" in down or "Bằng tốt nghiệp THPT" in down

--- a/Backend_FastAPI/tests/unit/test_pr10_gdpt_resolution.py
+++ b/Backend_FastAPI/tests/unit/test_pr10_gdpt_resolution.py
@@ -1,0 +1,146 @@
+"""PR #10 — unit tests cho SWAP Giấy CN hoàn thành GDPT (completed_thpt).
+
+Pure resolution logic (no DB): the ``completed_*`` swap drops the diploma
+(``compute_completed_doc_codes``) AND adds the GDPT certificate
+(``compute_completed_add_doc_codes`` + ``build_completed_add_items`` +
+``build_resolved_response(add_items=...)``).
+"""
+from types import SimpleNamespace
+
+from app.services.document_resolution_service import (
+    build_completed_add_items,
+    build_resolved_response,
+    compute_completed_add_doc_codes,
+    compute_completed_doc_codes,
+)
+
+
+GDPT = "giay_cn_hoan_thanh_gdpt"
+DIPLOMA = "bang_tot_nghiep_thpt"
+
+
+def _profile(cultural):
+    return SimpleNamespace(cultural_education_level=cultural)
+
+
+def _doc_type(dt_id, code, name="X", order=1):
+    return SimpleNamespace(id=dt_id, code=code, name=name, display_order=order)
+
+
+def _map_item(dt_id, code, name="X", mandatory=True, upload=True, fmt="photo", order=1):
+    dt = SimpleNamespace(code=code, name=name)
+    item = SimpleNamespace(
+        document_type_id=dt_id,
+        document_type=dt,
+        is_mandatory=mandatory,
+        requires_upload=upload,
+        submission_format=fmt,
+        display_order=order,
+    )
+    return {dt_id: (item, "shared", None)}
+
+
+# ---------------------------------------------------------------------------
+# compute_completed_add_doc_codes — symmetric with the remove map
+# ---------------------------------------------------------------------------
+
+
+def test_completed_thpt_adds_gdpt():
+    assert compute_completed_add_doc_codes(_profile("completed_thpt")) == {GDPT}
+
+
+def test_completed_thpt_also_drops_diploma():
+    # The swap is two-sided: drop the diploma AND add the GDPT cert.
+    assert compute_completed_doc_codes(_profile("completed_thpt")) == {DIPLOMA}
+    assert compute_completed_add_doc_codes(_profile("completed_thpt")) == {GDPT}
+
+
+def test_graduated_thpt_adds_nothing_and_keeps_diploma():
+    assert compute_completed_add_doc_codes(_profile("graduated_thpt")) == set()
+    assert compute_completed_doc_codes(_profile("graduated_thpt")) == set()
+
+
+def test_completed_thcs_adds_nothing_known_limitation():
+    # completed_thcs has no source certificate yet → empty (GĐ1 limitation).
+    assert compute_completed_add_doc_codes(_profile("completed_thcs")) == set()
+
+
+def test_none_cultural_adds_nothing():
+    assert compute_completed_add_doc_codes(_profile(None)) == set()
+
+
+# ---------------------------------------------------------------------------
+# build_completed_add_items — synthetic paper-only shape (finding #3)
+# ---------------------------------------------------------------------------
+
+
+def test_build_add_items_paper_only_shape():
+    items = build_completed_add_items([_doc_type(9, GDPT, "Giấy CN GDPT", 45)])
+    assert len(items) == 1
+    it = items[0]
+    assert it.document_type_id == 9
+    assert it.document_type_code == GDPT
+    assert it.document_type_name == "Giấy CN GDPT"
+    assert it.is_mandatory is True
+    assert it.requires_upload is False  # paper-only
+    assert it.submission_format is None
+    assert it.display_order == 45
+    assert it.source == "shared"
+    assert it.applicable_audience is None
+    assert it.layer_kind == "shared_base"
+
+
+def test_build_add_items_empty_for_no_doc_types():
+    assert build_completed_add_items([]) == []
+
+
+# ---------------------------------------------------------------------------
+# build_resolved_response(add_items=...) — append + dedup + sort
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_appends_add_item_when_absent():
+    doc_map = _map_item(1, "hoc_ba", order=1)
+    add = build_completed_add_items([_doc_type(9, GDPT, order=5)])
+    resolved = build_resolved_response(doc_map, completed_codes=None, add_items=add)
+    codes = [r.document_type_code for r in resolved]
+    assert "hoc_ba" in codes
+    assert GDPT in codes
+    assert len(resolved) == 2
+
+
+def test_resolved_dedups_add_item_when_code_already_present():
+    # If a DocumentGroup already configured the GDPT cert, keep the config
+    # row (requires_upload from config) and DO NOT append the synthetic one.
+    doc_map = _map_item(9, GDPT, upload=True, order=5)
+    add = build_completed_add_items([_doc_type(9, GDPT, order=5)])
+    resolved = build_resolved_response(doc_map, completed_codes=None, add_items=add)
+    gdpt_rows = [r for r in resolved if r.document_type_code == GDPT]
+    assert len(gdpt_rows) == 1, "must not duplicate the GDPT cert"
+    # The surviving row is the config one (requires_upload=True), not synthetic.
+    assert gdpt_rows[0].requires_upload is True
+
+
+def test_resolved_sorts_by_display_order_after_append():
+    # add-item with a small display_order must sort before a larger config doc.
+    doc_map = _map_item(1, "hoc_ba", order=10)
+    add = build_completed_add_items([_doc_type(9, GDPT, order=3)])
+    resolved = build_resolved_response(doc_map, completed_codes=None, add_items=add)
+    assert [r.document_type_code for r in resolved] == [GDPT, "hoc_ba"]
+
+
+def test_resolved_drops_diploma_and_adds_gdpt_together():
+    # Full swap shape: a doc_map containing the diploma + completed_codes
+    # dropping it + add_items injecting the GDPT cert.
+    doc_map = {
+        **_map_item(1, "hoc_ba", order=1),
+        **_map_item(2, DIPLOMA, order=2),
+    }
+    add = build_completed_add_items([_doc_type(9, GDPT, order=2)])
+    resolved = build_resolved_response(
+        doc_map, completed_codes={DIPLOMA}, add_items=add
+    )
+    codes = {r.document_type_code for r in resolved}
+    assert DIPLOMA not in codes, "diploma must be dropped for completed_thpt"
+    assert GDPT in codes, "GDPT cert must be added"
+    assert "hoc_ba" in codes

--- a/Backend_FastAPI/tests/unit/test_pr13_graduation_proof_schema.py
+++ b/Backend_FastAPI/tests/unit/test_pr13_graduation_proof_schema.py
@@ -1,0 +1,57 @@
+"""PR #13 — schema validation tests cho graduation proof (no DB)."""
+from datetime import date
+
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from app.schemas.admission import (
+    DocumentSubmissionRequest,
+    GraduationProofUpdateRequest,
+)
+
+
+def test_submission_official_no_due_ok():
+    r = DocumentSubmissionRequest(
+        actual_submission_format="certified_copy",
+        graduation_proof_kind="official_diploma",
+    )
+    assert r.graduation_proof_kind == "official_diploma"
+    assert r.supplement_due_date is None
+
+
+def test_submission_provisional_requires_due():
+    with pytest.raises(PydanticValidationError):
+        DocumentSubmissionRequest(
+            actual_submission_format="certified_copy",
+            graduation_proof_kind="provisional_cert",
+        )
+
+
+def test_submission_provisional_with_due_ok():
+    r = DocumentSubmissionRequest(
+        actual_submission_format="certified_copy",
+        graduation_proof_kind="provisional_cert",
+        supplement_due_date=date(2027, 6, 30),
+    )
+    assert r.supplement_due_date == date(2027, 6, 30)
+
+
+def test_submission_no_graduation_fields_ok():
+    r = DocumentSubmissionRequest(actual_submission_format="photo")
+    assert r.graduation_proof_kind is None
+    assert r.supplement_due_date is None
+
+
+def test_submission_invalid_kind_rejected():
+    with pytest.raises(PydanticValidationError):
+        DocumentSubmissionRequest(
+            actual_submission_format="photo",
+            graduation_proof_kind="invalid_kind",
+        )
+
+
+def test_graduation_update_request_ok_and_invalid():
+    r = GraduationProofUpdateRequest(kind="official_diploma")
+    assert r.kind == "official_diploma"
+    with pytest.raises(PydanticValidationError):
+        GraduationProofUpdateRequest(kind="bad")

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -29,6 +29,7 @@ import { DocumentsTab } from "./DocumentsTab";
 vi.mock("@/hooks/admissions/useAdmissions", () => ({
   useUploadAdmissionDocument: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
   useMarkPaperSubmitted: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+  useUpdateGraduationProof: () => ({ mutate: vi.fn(), isPending: false }),
   useRejectDocument: () => ({ mutate: vi.fn(), isPending: false }),
   useResetDocument: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
   useVerifyDocument: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -68,6 +68,7 @@ import {
   FileSpreadsheet,
   FileText,
   Globe,
+  GraduationCap,
   Loader2,
   RotateCcw,
   Upload,
@@ -81,6 +82,7 @@ import type {
 import {
   useUploadAdmissionDocument,
   useMarkPaperSubmitted,
+  useUpdateGraduationProof,
   useRejectDocument,
   useResetDocument,
   useVerifyDocument,
@@ -214,6 +216,21 @@ const VI_DATETIME_FORMATTER = new Intl.DateTimeFormat("vi-VN", {
   minute: "2-digit",
   hour12: false,
 })
+
+// PR #13 — only this document distinguishes the official diploma from the
+// provisional graduation certificate ("nợ bằng"). Kept in one place so the
+// graduation-proof UI branches stay tied to the backend's hard-checked code.
+const GRADUATION_DOC_CODE = "bang_tot_nghiep_thpt"
+
+// Format the supplement due date (backend "YYYY-MM-DD", date-only) → dd/mm/yyyy.
+// Parse the parts manually: ``new Date("YYYY-MM-DD")`` is interpreted as UTC
+// midnight and would shift back a day when rendered in VN (UTC+7).
+function formatSupplementDue(iso: string | null | undefined): string | null {
+  if (!iso) return null
+  const [y, m, d] = iso.split("-").map(Number)
+  if (!y || !m || !d) return null
+  return VI_DATE_FORMATTER.format(new Date(y, m - 1, d))
+}
 
 // ============================================================================
 // HELPERS
@@ -432,6 +449,7 @@ interface ActionsCellProps {
   isCurrentResetTarget: boolean
   isVerifyPending: boolean
   isCurrentVerifyTarget: boolean
+  isGradPending: boolean
   onView: (documentId: number) => void
   onUpload: (
     code: string,
@@ -443,6 +461,7 @@ interface ActionsCellProps {
     label: string,
     requiredFormat?: string,
   ) => void
+  onUpdateGraduationProof: (code: string) => void
   onRejectClick: (code: string, label: string) => void
   onResetClick: (code: string, label: string) => void
   onVerifyClick: (code: string, format: string) => void
@@ -499,14 +518,22 @@ function DocumentRowActions(props: ActionsCellProps) {
     isCurrentResetTarget,
     isVerifyPending,
     isCurrentVerifyTarget,
+    isGradPending,
     onView,
     onUpload,
     onPaperSubmit,
+    onUpdateGraduationProof,
     onRejectClick,
     onResetClick,
     onVerifyClick,
     alignEnd,
   } = props
+
+  // PR #13 — "nợ bằng" debt badge (provisional cert still outstanding) +
+  // the officer/manager "đã nhận bằng chính thức" action that clears it.
+  const isProvisionalDebt = doc.graduation_proof_kind === "provisional_cert"
+  const canUpdateGraduationKind = doc.can_update_graduation_kind ?? false
+  const supplementDueLabel = formatSupplementDue(doc.supplement_due_date)
 
   // Verify uses the actual / required format as the format claim. The
   // verify dialog (executive checklist) is the deeper review surface;
@@ -602,6 +629,37 @@ function DocumentRowActions(props: ActionsCellProps) {
             </span>
           )}
 
+        {/* PR #13 — "nợ bằng" debt badge + clear-debt action. */}
+        {isProvisionalDebt && (
+          <span
+            className="inline-flex items-center gap-1 rounded bg-warning-50 px-1.5 py-0.5 text-xs font-medium text-warning-700"
+            title={
+              supplementDueLabel
+                ? `Hạn bổ sung bằng: ${supplementDueLabel}`
+                : undefined
+            }
+          >
+            <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+            Nợ bằng{supplementDueLabel ? ` — hạn ${supplementDueLabel}` : ""}
+          </span>
+        )}
+
+        {canUpdateGraduationKind && (
+          <IconActionButton
+            ariaLabel="Đã nhận bằng chính thức"
+            tooltip="Ghi nhận đã nhận bằng tốt nghiệp THPT chính thức (xoá nợ bằng)"
+            className="text-success-700 hover:text-success-800 hover:bg-success-50"
+            disabled={isGradPending}
+            onClick={() => onUpdateGraduationProof(doc.code)}
+          >
+            {isGradPending ? (
+              <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
+            ) : (
+              <GraduationCap className="h-4 w-4" />
+            )}
+          </IconActionButton>
+        )}
+
         {hasOfficerGroup && hasManagerGroup && (
           <span
             aria-hidden="true"
@@ -678,6 +736,7 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
   )
   const uploadMutation = useUploadAdmissionDocument(profile.id)
   const paperMutation = useMarkPaperSubmitted(profile.id)
+  const updateGradMutation = useUpdateGraduationProof(profile.id)
   const rejectMutation = useRejectDocument(profile.id)
   const resetMutation = useResetDocument(profile.id)
   const verifyMutation = useVerifyDocument(profile.id)
@@ -695,6 +754,14 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
     file?: File
   } | null>(null)
   const [selectedFormat, setSelectedFormat] = useState<string>("")
+
+  // PR #13 — graduation proof kind chosen inside the paper-submit dialog,
+  // only for GRADUATION_DOC_CODE. Default to the official diploma;
+  // provisional_cert requires a supplement due date.
+  const [graduationKind, setGraduationKind] = useState<
+    "official_diploma" | "provisional_cert"
+  >("official_diploma")
+  const [supplementDue, setSupplementDue] = useState<string>("")
 
   // Reset/Undo Confirmation Dialog State
   const [pendingResetDoc, setPendingResetDoc] = useState<{
@@ -858,6 +925,10 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
       action: "paper",
     })
     setSelectedFormat(requiredFormat || "")
+    // PR #13 — reset the graduation choice for the graduation doc; default to
+    // the official diploma, officer switches to provisional + due if needed.
+    setGraduationKind("official_diploma")
+    setSupplementDue("")
   }
 
   const handleSubmissionFormatConfirm = async () => {
@@ -872,14 +943,44 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
         actualSubmissionFormat: selectedFormat,
       })
     } else if (action === "paper") {
+      const isGraduation = docCode === GRADUATION_DOC_CODE
+      // PR #13 — provisional_cert ("nợ bằng") requires a supplement due date.
+      // Block early so the officer fills it rather than eating a 400.
+      if (
+        isGraduation &&
+        graduationKind === "provisional_cert" &&
+        !supplementDue
+      ) {
+        toast.error(
+          "Vui lòng nhập hạn bổ sung bằng cho Giấy CN tốt nghiệp tạm thời",
+        )
+        return
+      }
       paperMutation.mutate({
         docCode,
         actualSubmissionFormat: selectedFormat,
+        ...(isGraduation
+          ? {
+              graduationProofKind: graduationKind,
+              supplementDueDate:
+                graduationKind === "provisional_cert"
+                  ? supplementDue
+                  : undefined,
+            }
+          : {}),
       })
     }
 
     setSubmissionFormatDialog(null)
     setSelectedFormat("")
+    setGraduationKind("official_diploma")
+    setSupplementDue("")
+  }
+
+  // PR #13 — officer records the official diploma after a provisional cert
+  // (clears the "nợ bằng" debt). The document status is unchanged backend-side.
+  const handleUpdateGraduationProof = (code: string) => {
+    updateGradMutation.mutate({ docCode: code, kind: "official_diploma" })
   }
 
   const handleRejectClick = (code: string, label: string) => {
@@ -1252,9 +1353,11 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
                               isCurrentResetTarget={isResetPendingForCode(doc.code)}
                               isVerifyPending={verifyMutation.isPending}
                               isCurrentVerifyTarget={isVerifyPendingForCode(doc.code)}
+                              isGradPending={updateGradMutation.isPending}
                               onView={handleViewDocument}
                               onUpload={handleUploadClick}
                               onPaperSubmit={handlePaperSubmit}
+                              onUpdateGraduationProof={handleUpdateGraduationProof}
                               onRejectClick={handleRejectClick}
                               onResetClick={handleResetClick}
                               onVerifyClick={handleVerifyClick}
@@ -1438,9 +1541,11 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
                             isCurrentResetTarget={isResetPendingForCode(doc.code)}
                             isVerifyPending={verifyMutation.isPending}
                             isCurrentVerifyTarget={isVerifyPendingForCode(doc.code)}
+                            isGradPending={updateGradMutation.isPending}
                             onView={handleViewDocument}
                             onUpload={handleUploadClick}
                             onPaperSubmit={handlePaperSubmit}
+                            onUpdateGraduationProof={handleUpdateGraduationProof}
                             onRejectClick={handleRejectClick}
                             onResetClick={handleResetClick}
                             onVerifyClick={handleVerifyClick}
@@ -1685,6 +1790,73 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
             ))}
           </RadioGroup>
 
+          {/* PR #13 — graduation proof kind (only for the graduation doc). */}
+          {submissionFormatDialog?.action === "paper" &&
+            submissionFormatDialog?.docCode === GRADUATION_DOC_CODE && (
+              <div className="space-y-3 rounded-lg border border-info-200 bg-info-50/40 p-3">
+                <p className="text-sm font-medium">Loại giấy tốt nghiệp</p>
+                <RadioGroup
+                  value={graduationKind}
+                  onValueChange={(v) =>
+                    setGraduationKind(
+                      v as "official_diploma" | "provisional_cert",
+                    )
+                  }
+                >
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem
+                      value="official_diploma"
+                      id="grad-official"
+                    />
+                    <Label
+                      htmlFor="grad-official"
+                      className="flex-1 cursor-pointer"
+                    >
+                      <div className="font-medium">
+                        Bằng tốt nghiệp THPT (chính thức)
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        Thí sinh đã có bằng tốt nghiệp chính thức.
+                      </div>
+                    </Label>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <RadioGroupItem
+                      value="provisional_cert"
+                      id="grad-provisional"
+                    />
+                    <Label
+                      htmlFor="grad-provisional"
+                      className="flex-1 cursor-pointer"
+                    >
+                      <div className="font-medium">
+                        Giấy CN tốt nghiệp tạm thời
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        Chưa có bằng chính thức — cần bổ sung sau (nợ bằng).
+                      </div>
+                    </Label>
+                  </div>
+                </RadioGroup>
+
+                {graduationKind === "provisional_cert" && (
+                  <div className="space-y-1">
+                    <Label htmlFor="supplement-due" className="text-sm">
+                      Hạn bổ sung bằng{" "}
+                      <span className="text-error-600">*</span>
+                    </Label>
+                    <input
+                      id="supplement-due"
+                      type="date"
+                      value={supplementDue}
+                      onChange={(e) => setSupplementDue(e.target.value)}
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+
           {submissionFormatDialog?.requiredFormat &&
             selectedFormat &&
             selectedFormat !== submissionFormatDialog.requiredFormat && (
@@ -1710,7 +1882,15 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
             </Button>
             <Button
               onClick={handleSubmissionFormatConfirm}
-              disabled={!selectedFormat}
+              disabled={
+                !selectedFormat ||
+                // PR #13 — block until the supplement due date is filled for a
+                // provisional graduation certificate.
+                (submissionFormatDialog?.action === "paper" &&
+                  submissionFormatDialog?.docCode === GRADUATION_DOC_CODE &&
+                  graduationKind === "provisional_cert" &&
+                  !supplementDue)
+              }
             >
               {submissionFormatDialog?.action === "paper"
                 ? "Ghi nhận giấy"

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -461,7 +461,7 @@ interface ActionsCellProps {
     label: string,
     requiredFormat?: string,
   ) => void
-  onUpdateGraduationProof: (code: string) => void
+  onUpdateGraduationProof: (code: string, label: string) => void
   onRejectClick: (code: string, label: string) => void
   onResetClick: (code: string, label: string) => void
   onVerifyClick: (code: string, format: string) => void
@@ -650,7 +650,7 @@ function DocumentRowActions(props: ActionsCellProps) {
             tooltip="Ghi nhận đã nhận bằng tốt nghiệp THPT chính thức (xoá nợ bằng)"
             className="text-success-700 hover:text-success-800 hover:bg-success-50"
             disabled={isGradPending}
-            onClick={() => onUpdateGraduationProof(doc.code)}
+            onClick={() => onUpdateGraduationProof(doc.code, doc.label)}
           >
             {isGradPending ? (
               <Loader2 className="h-4 w-4 animate-spin motion-reduce:animate-none" />
@@ -756,15 +756,24 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
   const [selectedFormat, setSelectedFormat] = useState<string>("")
 
   // PR #13 — graduation proof kind chosen inside the paper-submit dialog,
-  // only for GRADUATION_DOC_CODE. Default to the official diploma;
+  // only for GRADUATION_DOC_CODE. Review F1: NO default — the officer must
+  // explicitly pick official vs provisional (a default would let a
+  // provisional cert be recorded as an official diploma, hiding the debt).
   // provisional_cert requires a supplement due date.
   const [graduationKind, setGraduationKind] = useState<
-    "official_diploma" | "provisional_cert"
-  >("official_diploma")
+    "" | "official_diploma" | "provisional_cert"
+  >("")
   const [supplementDue, setSupplementDue] = useState<string>("")
 
   // Reset/Undo Confirmation Dialog State
   const [pendingResetDoc, setPendingResetDoc] = useState<{
+    code: string
+    label: string
+  } | null>(null)
+
+  // Review F2 — confirm before clearing the "nợ bằng" debt (one-click +
+  // irreversible via this flow: the endpoint only accepts official_diploma).
+  const [pendingGradUpdate, setPendingGradUpdate] = useState<{
     code: string
     label: string
   } | null>(null)
@@ -925,9 +934,9 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
       action: "paper",
     })
     setSelectedFormat(requiredFormat || "")
-    // PR #13 — reset the graduation choice for the graduation doc; default to
-    // the official diploma, officer switches to provisional + due if needed.
-    setGraduationKind("official_diploma")
+    // PR #13 / review F1 — reset the graduation choice to UNSELECTED so the
+    // officer must explicitly pick official vs provisional each time.
+    setGraduationKind("")
     setSupplementDue("")
   }
 
@@ -944,8 +953,14 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
       })
     } else if (action === "paper") {
       const isGraduation = docCode === GRADUATION_DOC_CODE
-      // PR #13 — provisional_cert ("nợ bằng") requires a supplement due date.
-      // Block early so the officer fills it rather than eating a 400.
+      // Review F1 — the graduation doc must be classified explicitly (no
+      // default); block until the officer picks a kind. The confirm button is
+      // also disabled — this is defense-in-depth.
+      if (isGraduation && !graduationKind) {
+        toast.error("Vui lòng chọn loại giấy tốt nghiệp")
+        return
+      }
+      // provisional_cert ("nợ bằng") requires a supplement due date.
       if (
         isGraduation &&
         graduationKind === "provisional_cert" &&
@@ -959,7 +974,7 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
       paperMutation.mutate({
         docCode,
         actualSubmissionFormat: selectedFormat,
-        ...(isGraduation
+        ...(isGraduation && graduationKind
           ? {
               graduationProofKind: graduationKind,
               supplementDueDate:
@@ -973,14 +988,24 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
 
     setSubmissionFormatDialog(null)
     setSelectedFormat("")
-    setGraduationKind("official_diploma")
+    setGraduationKind("")
     setSupplementDue("")
   }
 
-  // PR #13 — officer records the official diploma after a provisional cert
-  // (clears the "nợ bằng" debt). The document status is unchanged backend-side.
-  const handleUpdateGraduationProof = (code: string) => {
-    updateGradMutation.mutate({ docCode: code, kind: "official_diploma" })
+  // PR #13 / review F2 — officer records the official diploma after a
+  // provisional cert (clears the "nợ bằng" debt). One-click + irreversible via
+  // this flow, so it goes through a confirm dialog first.
+  const handleUpdateGraduationProof = (code: string, label: string) => {
+    setPendingGradUpdate({ code, label })
+  }
+  const handleGradUpdateConfirm = () => {
+    if (pendingGradUpdate) {
+      updateGradMutation.mutate({
+        docCode: pendingGradUpdate.code,
+        kind: "official_diploma",
+      })
+    }
+    setPendingGradUpdate(null)
   }
 
   const handleRejectClick = (code: string, label: string) => {
@@ -1884,12 +1909,14 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
               onClick={handleSubmissionFormatConfirm}
               disabled={
                 !selectedFormat ||
-                // PR #13 — block until the supplement due date is filled for a
-                // provisional graduation certificate.
+                // Review F1 — for the graduation doc, block until the officer
+                // explicitly picks a kind, and (if provisional) fills the due
+                // date. No default kind → no silent mis-classification.
                 (submissionFormatDialog?.action === "paper" &&
                   submissionFormatDialog?.docCode === GRADUATION_DOC_CODE &&
-                  graduationKind === "provisional_cert" &&
-                  !supplementDue)
+                  (!graduationKind ||
+                    (graduationKind === "provisional_cert" &&
+                      !supplementDue)))
               }
             >
               {submissionFormatDialog?.action === "paper"
@@ -1971,6 +1998,35 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
               onClick={handleResetConfirm}
             >
               Hoàn tác
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Review F2 — confirm before clearing the "nợ bằng" debt. */}
+      <AlertDialog
+        open={!!pendingGradUpdate}
+        onOpenChange={(open) => !open && setPendingGradUpdate(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Đã nhận bằng chính thức?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Ghi nhận đã nhận bằng tốt nghiệp THPT chính thức cho
+              &ldquo;{pendingGradUpdate?.label}&rdquo;?
+            </AlertDialogDescription>
+            <p className="text-sm text-muted-foreground">
+              Thao tác này xoá trạng thái &ldquo;nợ bằng&rdquo; (giấy tạm thời)
+              và không thể hoàn tác từ thao tác này.
+            </p>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Hủy</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-success-700 text-white hover:bg-success-800"
+              onClick={handleGradUpdateConfirm}
+            >
+              Xác nhận đã nhận bằng
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/hooks/admissions/useAdmissions.ts
+++ b/frontend/src/hooks/admissions/useAdmissions.ts
@@ -547,8 +547,21 @@ export function useMarkPaperSubmitted(id: number) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (variables: { docCode: string, actualSubmissionFormat: string }) =>
-      admissionsApi.markPaperSubmitted(id, variables.docCode, variables.actualSubmissionFormat),
+    // PR #13 — graduationProofKind/supplementDueDate optional, only sent for
+    // bang_tot_nghiep_thpt (provisional_cert requires the due date).
+    mutationFn: (variables: {
+      docCode: string
+      actualSubmissionFormat: string
+      graduationProofKind?: "official_diploma" | "provisional_cert"
+      supplementDueDate?: string
+    }) =>
+      admissionsApi.markPaperSubmitted(
+        id,
+        variables.docCode,
+        variables.actualSubmissionFormat,
+        variables.graduationProofKind,
+        variables.supplementDueDate
+      ),
     onSuccess: (updatedProfile, variables) => {
       toast.success("Đã xác nhận nhận giấy tờ")
 
@@ -558,6 +571,31 @@ export function useMarkPaperSubmitted(id: number) {
     },
     onError: (error: AxiosError<ApiErrorResponse>) => {
       handleApiError(error, { context: "xác nhận giấy tờ" })
+    }
+  })
+}
+
+/**
+ * PR #13 — upgrade graduation proof kind (provisional cert → official
+ * diploma). Backend returns the full profile (status unchanged, supplement
+ * due date cleared for official_diploma) so we update the detail cache in
+ * place, matching useMarkPaperSubmitted's parity contract.
+ */
+export function useUpdateGraduationProof(id: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (variables: {
+      docCode: string
+      kind: "official_diploma" | "provisional_cert"
+    }) =>
+      admissionsApi.updateGraduationProof(id, variables.docCode, variables.kind),
+    onSuccess: (updatedProfile) => {
+      toast.success("Đã cập nhật loại giấy tốt nghiệp")
+      queryClient.setQueryData(admissionsKeys.detail(id), updatedProfile)
+    },
+    onError: (error: AxiosError<ApiErrorResponse>) => {
+      handleApiError(error, { context: "cập nhật giấy tốt nghiệp" })
     }
   })
 }

--- a/frontend/src/lib/api/admissions.ts
+++ b/frontend/src/lib/api/admissions.ts
@@ -266,11 +266,43 @@ export async function uploadAdmissionDocument(
 export async function markPaperSubmitted(
   id: number,
   docCode: string,
-  actualSubmissionFormat: string
+  actualSubmissionFormat: string,
+  // PR #13 — only meaningful for bang_tot_nghiep_thpt; backend ignores them
+  // on other doc codes. provisional_cert requires supplementDueDate.
+  graduationProofKind?: "official_diploma" | "provisional_cert",
+  supplementDueDate?: string
 ): Promise<AdmissionProfileResponse> {
+  const body: Record<string, unknown> = {
+    actual_submission_format: actualSubmissionFormat,
+  }
+  if (graduationProofKind) {
+    body.graduation_proof_kind = graduationProofKind
+    if (supplementDueDate) {
+      body.supplement_due_date = supplementDueDate
+    }
+  }
   const response = await api.post<AdmissionProfileResponse>(
     `/api/admissions/${id}/documents/${docCode}/paper-submitted`,
-    { actual_submission_format: actualSubmissionFormat }
+    body
+  )
+  return response.data
+}
+
+/**
+ * Update graduation proof kind (PR #13).
+ *
+ * Officer records that the candidate brought the official diploma after
+ * previously submitting a provisional certificate. The document status is
+ * NOT changed; the backend clears the supplement due date for official_diploma.
+ */
+export async function updateGraduationProof(
+  id: number,
+  docCode: string,
+  kind: "official_diploma" | "provisional_cert"
+): Promise<AdmissionProfileResponse> {
+  const response = await api.post<AdmissionProfileResponse>(
+    `/api/admissions/${id}/documents/${docCode}/graduation-proof`,
+    { kind }
   )
   return response.data
 }
@@ -533,6 +565,7 @@ export const admissionsApi = {
   deleteAdmission,
   uploadAdmissionDocument,
   markPaperSubmitted,
+  updateGraduationProof,
   verifyDocumentFormat,
   rejectDocument,
   resetDocument,

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -496,6 +496,19 @@ export const documentItemSchema = z.object({
   can_reject: z.boolean().optional(),
   can_reset: z.boolean().optional(),
   can_mark_paper_submitted: z.boolean().optional(),
+  // ---------------------------------------------------------------------
+  // PR #13 — graduation proof (chỉ áp cho doc bang_tot_nghiep_thpt).
+  // Officer ghi rõ "bằng chính thức" vs "giấy CN tốt nghiệp tạm thời" khi
+  // tick đã nhận; provisional_cert kèm hạn bổ sung bằng ("nợ bằng").
+  // can_update_graduation_kind = true ⇒ FE hiện nút "Đã nhận bằng chính
+  // thức". Tất cả optional/nullable cho doc khác + hồ sơ cũ (NULL).
+  // ---------------------------------------------------------------------
+  graduation_proof_kind: z
+    .enum(["official_diploma", "provisional_cert"])
+    .nullable()
+    .optional(),
+  supplement_due_date: z.string().nullable().optional(),
+  can_update_graduation_kind: z.boolean().nullable().optional(),
 })
 
 export type DocumentItem = z.infer<typeof documentItemSchema>


### PR DESCRIPTION
## Mục tiêu

Hai hạng mục giấy tốt nghiệp trong bộ hồ sơ tuyển sinh:

- **#13** — Officer khi tick "đã nhận" giấy `bang_tot_nghiep_thpt` ghi rõ **bằng chính thức** hay **Giấy CN tốt nghiệp tạm thời** (+ hạn bổ sung); truy vấn được hồ sơ "còn nợ bằng" để nhắc; ghi nhận khi thí sinh bổ sung bằng chính thức.
- **#10** — Thí sinh **trượt tốt nghiệp** (`cultural_education_level='completed_thpt'`) nộp **Giấy CN hoàn thành chương trình GDPT** THAY cho bằng TN bị loại. Vì `completed_thpt` + `graduated_thpt` cùng audience `POST_THPT` → SWAP làm ở tầng code (synthetic resolved item).

Phụ thuộc P0 `ardockeys01` (nới `applied_rules` immutability cho re-resolve) — đã merged `d8900124`.

## Backend

- **Model/Migration:** `profile_document` +2 cột `graduation_proof_kind` (String20) + `supplement_due_date` (Date) + 2 CHECK constraint (`gpkind01`). Seed doc type `giay_cn_hoan_thanh_gdpt` (`gdpt01`).
- **Endpoint mới:**
  - `POST /{id}/documents/{code}/graduation-proof` — officer ghi nhận bằng chính thức (provisional→official, xoá hạn, không đổi status) + emit `graduation_proof_updated` + audit.
  - `GET /pending-diploma?due_before=` — danh sách "nợ bằng", IDOR-scoped (admin all / manager unit / officer assigned).
- **Resolution SWAP (#10):** `_COMPLETED_DIPLOMA_TO_ADD` + `compute_completed_add_doc_codes` + `build_resolved_response(add_items=)` + pure `build_completed_add_items` (paper-only synthetic: `requires_upload=False`, `layer_kind='shared_base'`, `applicable_audience=None`). Chỉ áp đường profile (có cultural), không path thuần / public storefront (known-limitation).
- **Casbin:** OFFICER allow `graduation-proof` (mirror paper-submitted) + OFFICER allow / ACCOUNTANT deny `pending-diploma` (PII). 2 migration seed (`gpcasbin01`, `gppenddip01`, v3=eft).

## Frontend

- `zod` documentItemSchema +3 field; `api`/`hooks` `updateGraduationProof` + `markPaperSubmitted` +2 param (cache-parity setQueryData).
- `DocumentsTab`: dialog paper-submit thêm RadioGroup loại giấy + input hạn (provisional); row badge **"Nợ bằng — hạn dd/mm/yyyy"** + nút **"Đã nhận bằng chính thức"**. Thin-client: đọc cờ BE; logic FE chỉ là form-validation (provisional ⇒ due).

## Hardening (self `/code-review` + owner review)

- `update_graduation_proof_kind`: thêm guard `is_extra` (BR2 read-only) + doc-status (chỉ paper_submitted/verified); chỉ nhận `official_diploma` (provisional NULL-due bị query nhắc bỏ sót).
- `reject_document` clear graduation fields (mirror reset) → reject giấy tạm thời = hết nợ bằng.
- `_compute_frontend_fields` extras pass surface graduation fields (badge còn hiện khi doc thành extra).
- **`mark_paper_submitted` bắt buộc kind cho giấy TN** (thiếu → 400, KHÔNG default official — tránh âm thầm biến giấy tạm thời thành bằng chính thức).
- Cleanup: bỏ 2 query thừa trong update (dùng eager-loaded `profile.documents`).

## Testing

- **35 BE test** (one-off `qlts_test`): API graduation-proof (12) + schema (6) + pending-diploma + 3 guard + required-kind; PR#10 unit (11) + integration re-resolve (6). Tất cả pass.
- **Migration roundtrip** verify trên dev (5 migration: seed/remove/re-seed, eft non-NULL, doc type active, single-head `gdpt01`).
- **Chrome MCP browser smoke (2)**:
  - #13.6 — badge "Nợ bằng — hạn 30/06/2027" + nút "Đã nhận bằng chính thức" → click → API → DB (kind→official, due→NULL) + audit + badge biến mất.
  - #10 — UI chọn `completed_thpt` → save → checklist swap bằng TN → **Giấy CN hoàn thành GDPT** (paper-only "Nhận giấy"); DB mandatory_docs swap + ProfileDocument GDPT tạo.
- type-check + lint + flake8 (file mới) sạch.

## Rủi ro / known-limitation

- `add_path_documents_delta` INSERT-only: completed→graduated sau khi GDPT tạo → GDPT thành extra is_mandatory=false (hành vi sẵn có mọi audience swap).
- Public storefront KHÔNG SWAP (không biết đậu/trượt) — nhất quán với completed-removal hiện có.
- `completed_thcs` chưa có giấy nguồn → để trống (known-limitation GĐ1).
- Hồ sơ cũ 2 cột NULL (không backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)