### PR TITLE
fix(admission): fail-closed IDOR scope khi manager/officer thiếu unit_id

### DIFF
--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -262,12 +262,36 @@ def _resolve_idor_filters(current_user: models.User) -> tuple[Optional[int], Opt
     - Admin: (None, None) — see all
     - Manager: (unit_id, None) — see unit
     - Officer: (unit_id, officer_id) — see only assigned
+
+    Fail-closed: a MANAGER/OFFICER whose ``unit_id IS NULL`` is a
+    misconfiguration, not "see everything". The repository treats
+    ``unit_id=None`` as *no unit filter* (``admission_repository`` only
+    applies the predicate ``if unit_id is not None``), so returning
+    ``(None, ...)`` here would silently widen a unit-scoped staff member to a
+    system-wide view of every profile / CSV row / status count / nợ-bằng
+    entry. Deny instead — mirrors the KPI precedent
+    (``test_coverage_manager_no_unit_gets_403``).
     """
     if current_user.role == UserRole.ADMIN:
         return None, None
     elif current_user.role == UserRole.MANAGER:
+        if current_user.unit_id is None:
+            raise PermissionDeniedError(
+                "Tài khoản quản lý chưa được gán đơn vị nên không thể truy "
+                "cập danh sách hồ sơ tuyển sinh. Liên hệ quản trị viên để "
+                "gán đơn vị."
+            )
         return current_user.unit_id, None
     elif current_user.role == UserRole.OFFICER:
+        if current_user.unit_id is None:
+            # Without a unit the officer filter would collapse to
+            # assigned_officer_id alone, leaking any cross-unit lead ever
+            # assigned to this officer. Deny rather than under-scope.
+            raise PermissionDeniedError(
+                "Tài khoản cán bộ chưa được gán đơn vị nên không thể truy "
+                "cập danh sách hồ sơ tuyển sinh. Liên hệ quản trị viên để "
+                "gán đơn vị."
+            )
         return current_user.unit_id, current_user.id
     else:
         # F8 fix 2026-05-16: defense-in-depth fallback. The expected gate

--- a/Backend_FastAPI/tests/integration/test_admission_idor.py
+++ b/Backend_FastAPI/tests/integration/test_admission_idor.py
@@ -589,3 +589,136 @@ class TestFeeStatusIDOR:
             f"must NOT read fee-status; got {response.status_code} - "
             f"{response.text[:200]}"
         )
+
+
+# ==============================================================================
+# TEST: LIST-ENDPOINT SCOPE FAIL-CLOSED (audit P1 regression)
+# ==============================================================================
+#
+# The admission list / export / status-counts / stats / academic-years /
+# pending-diploma endpoints all derive their IDOR scope from
+# ``admission_service._resolve_idor_filters``. Before the fix a manager/officer
+# whose ``unit_id IS NULL`` resolved to ``(None, ...)``, which the repository
+# reads as "no unit filter" → a system-wide leak of every profile / CSV row /
+# status count / nợ-bằng entry. These tests lock the fail-closed contract
+# end-to-end.
+#
+# Status mapping: five endpoints let ``PermissionDeniedError`` reach the global
+# handler → 403; ``/pending-diploma`` catches it in the router and re-raises 404
+# (IDOR enumeration convention — admissions.py:285).
+
+# Endpoints that surface the denial as a raw 403.
+_SCOPED_LIST_ENDPOINTS_403 = [
+    "/api/admissions",
+    "/api/admissions/export",
+    "/api/admissions/status-counts",
+    "/api/admissions/stats",
+    "/api/admissions/academic-years",
+]
+_PENDING_DIPLOMA_ENDPOINT = "/api/admissions/pending-diploma"
+
+
+@pytest_asyncio.fixture
+async def officer_no_unit_headers(client: AsyncClient, setup_test_database) -> dict:
+    """Auth headers for an OFFICER with ``unit_id IS NULL``.
+
+    Casbin role IS seeded (``role:officer`` covers every list endpoint via
+    OFFICER_TEMPLATE), so the request clears the gateway and genuinely
+    exercises the *service* scope gate rather than a role deny.
+    """
+    from tests.conftest import _create_user_and_role, _get_token_headers
+
+    data = {
+        "username": "officer_no_unit_idor",
+        "email": "officer_nounit_idor@test.com",
+        "password": "OfficerNoUnit!123",
+        "role": "officer",
+        "status": "active",
+    }
+    await _create_user_and_role(data, "role:officer", unit_id=None)
+    return await _get_token_headers(client, data)
+
+
+@pytest_asyncio.fixture
+async def manager_no_unit_headers(client: AsyncClient, setup_test_database) -> dict:
+    """Auth headers for a MANAGER with ``unit_id IS NULL`` (mirrors the KPI
+    precedent ``test_coverage_manager_no_unit_gets_403``)."""
+    from tests.conftest import _create_user_and_role, _get_token_headers
+
+    data = {
+        "username": "manager_no_unit_idor",
+        "email": "manager_nounit_idor@test.com",
+        "password": "ManagerNoUnit!123",
+        "role": "manager",
+        "status": "active",
+    }
+    await _create_user_and_role(data, "role:manager", unit_id=None)
+    return await _get_token_headers(client, data)
+
+
+class TestListScopeFailClosed:
+    """Manager/Officer without a unit must never see system-wide list data."""
+
+    async def test_officer_with_unit_can_list(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """Non-vacuous anchor: a properly-scoped officer reaches the list (200).
+
+        Proves the fail-closed 403s below come from the missing-unit scope
+        gate, not a blanket Casbin deny on the officer role.
+        """
+        headers = await get_auth_headers(client, officer_user_in_db)
+        response = await client.get("/api/admissions", headers=headers)
+        assert response.status_code == 200, (
+            f"Scoped officer must list profiles: {response.status_code} - "
+            f"{response.text[:200]}"
+        )
+
+    @pytest.mark.parametrize("endpoint", _SCOPED_LIST_ENDPOINTS_403)
+    async def test_officer_no_unit_denied_403(
+        self,
+        client: AsyncClient,
+        officer_no_unit_headers: dict,
+        endpoint: str,
+    ):
+        response = await client.get(endpoint, headers=officer_no_unit_headers)
+        assert response.status_code == 403, (
+            f"IDOR leak: unit-less officer must be denied on {endpoint}, got "
+            f"{response.status_code} - {response.text[:200]}"
+        )
+
+    async def test_officer_no_unit_denied_pending_diploma_404(
+        self,
+        client: AsyncClient,
+        officer_no_unit_headers: dict,
+    ):
+        # Router translates PermissionDeniedError → 404 (enumeration convention).
+        response = await client.get(
+            _PENDING_DIPLOMA_ENDPOINT, headers=officer_no_unit_headers
+        )
+        assert response.status_code == 404, (
+            f"unit-less officer must be denied on pending-diploma, got "
+            f"{response.status_code} - {response.text[:200]}"
+        )
+
+    @pytest.mark.parametrize(
+        "endpoint", _SCOPED_LIST_ENDPOINTS_403 + [_PENDING_DIPLOMA_ENDPOINT]
+    )
+    async def test_manager_no_unit_never_leaks(
+        self,
+        client: AsyncClient,
+        manager_no_unit_headers: dict,
+        endpoint: str,
+    ):
+        """A unit-less manager must never see data. 403 (scope or Casbin deny)
+        and 404 (pending-diploma translation) are both acceptable; 200 is the
+        bug. Mirrors KPI ``test_coverage_manager_no_unit_gets_403``.
+        """
+        response = await client.get(endpoint, headers=manager_no_unit_headers)
+        assert response.status_code in (403, 404), (
+            f"IDOR leak: unit-less manager saw data on {endpoint}: "
+            f"{response.status_code} - {response.text[:200]}"
+        )

--- a/Backend_FastAPI/tests/unit/test_admission_idor_filters.py
+++ b/Backend_FastAPI/tests/unit/test_admission_idor_filters.py
@@ -1,0 +1,71 @@
+# tests/unit/test_admission_idor_filters.py
+"""
+Unit tests for ``admission_service._resolve_idor_filters`` — the 3-tier IDOR
+scope resolver shared by the admission list / export / status-counts / stats /
+academic-years / pending-diploma endpoints.
+
+Focus: the fail-closed contract for staff whose ``unit_id IS NULL``. Returning
+``(None, ...)`` for such a user makes ``admission_repository`` drop the unit
+predicate (it only filters ``if unit_id is not None``), silently widening a
+unit-scoped manager/officer to a system-wide view of every profile / CSV row /
+status count / nợ-bằng entry. The resolver must deny instead — mirrors the KPI
+precedent ``test_coverage_manager_no_unit_gets_403``.
+
+Pure function test — no DB, no Casbin, no HTTP client (mirrors the
+``models.User`` in-memory construction in
+``tests/services/test_organization_m12_scoping.py``).
+"""
+import pytest
+
+from app import models
+from app.core.constants import UserRole
+from app.services.admission_service import _resolve_idor_filters
+from app.utils.exceptions import PermissionDeniedError
+
+pytestmark = pytest.mark.unit
+
+
+class TestResolveIdorFiltersScope:
+    """Well-configured users resolve to the expected (unit, officer) tuple."""
+
+    def test_admin_sees_all(self):
+        user = models.User(id=1, username="admin", role=UserRole.ADMIN, unit_id=None)
+        assert _resolve_idor_filters(user) == (None, None)
+
+    def test_admin_with_unit_still_sees_all(self):
+        # An admin carrying a unit_id is still unscoped — admin bypasses unit.
+        user = models.User(id=1, username="admin", role=UserRole.ADMIN, unit_id=5)
+        assert _resolve_idor_filters(user) == (None, None)
+
+    def test_manager_scoped_to_own_unit(self):
+        user = models.User(id=2, username="mgr", role=UserRole.MANAGER, unit_id=7)
+        assert _resolve_idor_filters(user) == (7, None)
+
+    def test_officer_scoped_to_unit_and_self(self):
+        user = models.User(id=3, username="off", role=UserRole.OFFICER, unit_id=7)
+        assert _resolve_idor_filters(user) == (7, 3)
+
+
+class TestResolveIdorFiltersFailClosed:
+    """Mis-scoped / unexpected users are denied, never widened to (None, ...)."""
+
+    def test_manager_without_unit_denied(self):
+        user = models.User(
+            id=4, username="mgr_nounit", role=UserRole.MANAGER, unit_id=None
+        )
+        with pytest.raises(PermissionDeniedError):
+            _resolve_idor_filters(user)
+
+    def test_officer_without_unit_denied(self):
+        user = models.User(
+            id=5, username="off_nounit", role=UserRole.OFFICER, unit_id=None
+        )
+        with pytest.raises(PermissionDeniedError):
+            _resolve_idor_filters(user)
+
+    def test_unknown_role_denied(self):
+        # accountant (or any non-admission role) that somehow bypasses the
+        # Casbin gate hits the defense-in-depth else-branch.
+        user = models.User(id=6, username="acct", role=UserRole.ACCOUNTANT, unit_id=7)
+        with pytest.raises(PermissionDeniedError):
+            _resolve_idor_filters(user)


### PR DESCRIPTION
## Vấn đề (audit P1, read-only main `e9f1b04d`)

`admission_service._resolve_idor_filters` trả `(unit_id, ...)` cho manager/officer, nhưng khi `unit_id IS NULL` lại rơi về `(None, ...)`. Repository hiểu `unit_id=None` là **không filter đơn vị** (chỉ áp predicate khi `unit_id is not None`), nên một manager/officer thiếu đơn vị bị **nâng scope thành xem TOÀN hệ thống** ở các endpoint:
`GET /api/admissions` · `/export` · `/status-counts` · `/stats` · `/academic-years` · `/pending-diploma`.

Tác động: nếu prod có manager/officer với `unit_id IS NULL`, họ có thể thấy hồ sơ / CSV / counts / danh sách "nợ bằng" của mọi đơn vị.

## Fix

Fail-closed trong `_resolve_idor_filters`: manager/officer có `unit_id IS NULL` → `PermissionDeniedError`. Admin và nhánh `else` (role lạ) giữ nguyên; system-path `get_profiles(current_user=None)` không đổi nhờ guard `if current_user else` sẵn có. Mirror precedent KPI `test_coverage_manager_no_unit_gets_403`.

Status mapping (giữ đúng contract router): 5 endpoint để `PermissionDeniedError` lên global handler → **403**; `/pending-diploma` router catch và dịch → **404** (IDOR enumeration convention).

## Tests

- **`tests/unit/test_admission_idor_filters.py`** (mới, 7 case, thuần in-memory): admin → `(None,None)`; manager/officer có unit → tuple đúng; manager/officer thiếu unit + role lạ → deny.
- **`tests/integration/test_admission_idor.py::TestListScopeFailClosed`** (13 case): anchor officer-có-unit → 200 (chống vacuous); officer-thiếu-unit → 403 ×5 + pending-diploma → 404; manager-thiếu-unit → 403/404 ×6.

## Verify local

- Unit **7/7 PASS**
- Full `test_admission_idor.py` **29/29 PASS** (one-off container, `qlts_test`) — không regression 16 test cũ
- flake8@88 net-zero lỗi mới; file unit black/isort sạch

## Ngoài phạm vi (follow-up riêng)

- **P2**: migration `gpkind01` không backfill → legacy `bang_tot_nghiep_thpt` có `graduation_proof_kind` NULL không vào query nợ-bằng. Cần đếm prod read-only trước, count>0 mới mở PR backfill.
- **P3**: pagination/index cho `/pending-diploma`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)