### PR TITLE
fix(admission): multi-NV đọc điểm choice-level cho eligibility/submit/total + per-NV display

### DIFF
--- a/Backend_FastAPI/app/repositories/admission_profile_choice_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_profile_choice_repository.py
@@ -25,6 +25,8 @@ from app.models import (
     OfferingAdmissionRound,
     ProfileChoiceScore,
     ProgramOffering,
+    SubjectGroup,
+    SubjectGroupSubject,
 )
 
 
@@ -85,10 +87,19 @@ class AdmissionProfileChoiceRepository:
                 selectinload(AdmissionProfileChoice.admission_path).selectinload(
                     AdmissionPath.admission_round
                 ),
-                # path_subject_group_config → subject_group (Contract-06)
+                # path_subject_group_config → subject_group → mappings →
+                # subject (P0 hotfix multi-NV — _resolve_allowed_subjects walks
+                # the M2M; submit gate + computed_total_score need codes)
                 selectinload(
                     AdmissionProfileChoice.path_subject_group_config
-                ).selectinload(PathSubjectGroupConfig.subject_group),
+                ).selectinload(PathSubjectGroupConfig.subject_group)
+                .selectinload(SubjectGroup.subject_mappings)
+                .selectinload(SubjectGroupSubject.subject),
+                # admission_path → criteria (P0 hotfix multi-NV — per-NV
+                # computed_total_score via calculate_score(criteria=…))
+                selectinload(AdmissionProfileChoice.admission_path).selectinload(
+                    AdmissionPath.criteria
+                ),
                 # scores → subject
                 selectinload(AdmissionProfileChoice.scores).selectinload(
                     ProfileChoiceScore.subject
@@ -131,9 +142,17 @@ class AdmissionProfileChoiceRepository:
                 selectinload(AdmissionProfileChoice.admission_path).selectinload(
                     AdmissionPath.admission_round
                 ),
+                # P0 hotfix multi-NV — extend to mappings→subject + criteria
+                # so submit_and_evaluate's fresh list_by_profile() feeds the
+                # gate, and 8d defensive choices load covers the display path.
                 selectinload(
                     AdmissionProfileChoice.path_subject_group_config
-                ).selectinload(PathSubjectGroupConfig.subject_group),
+                ).selectinload(PathSubjectGroupConfig.subject_group)
+                .selectinload(SubjectGroup.subject_mappings)
+                .selectinload(SubjectGroupSubject.subject),
+                selectinload(AdmissionProfileChoice.admission_path).selectinload(
+                    AdmissionPath.criteria
+                ),
                 selectinload(AdmissionProfileChoice.scores).selectinload(
                     ProfileChoiceScore.subject
                 ),

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -29,6 +29,10 @@ from app.models.admission_config.admission_path import AdmissionPath
 from app.models.admission_config.path_subject_group import (
     PathSubjectGroupConfig,
 )
+from app.models.admission_config.subject import (
+    SubjectGroup,
+    SubjectGroupSubject,
+)
 from app.models.admission_profile_choice import (
     AdmissionProfileChoice,
     ProfileChoiceScore,
@@ -48,6 +52,14 @@ from app.repositories.base import BaseRepository
 # (trước fix: chỉ load academic_info → program lazy → swallowed → empty
 # → display "2026 - hoc_ba - DOT_1" mất ngành/trình độ).
 def _choices_eager_load_options() -> tuple:
+    # P0 hotfix multi-NV (2026-06-04): +2 legs so the sync eligibility/
+    # submit/display helpers (validate_choice_scores_complete +
+    # AdmissionProfileChoiceResponse._compute_display_fields) never lazy-load
+    # in async context (MissingGreenlet):
+    #   * subject_group → subject_mappings → subject — _resolve_allowed_subjects
+    #     walks the M2M to list allowed combo subject codes.
+    #   * admission_path → criteria — per-NV computed_total_score scores via
+    #     AdmissionScoringService.calculate_score(criteria=path.criteria, …).
     return (
         selectinload(models.AdmissionProfile.choices).selectinload(
             AdmissionProfileChoice.admission_path
@@ -61,8 +73,13 @@ def _choices_eager_load_options() -> tuple:
             AdmissionProfileChoice.admission_path
         ).selectinload(AdmissionPath.admission_round),
         selectinload(models.AdmissionProfile.choices).selectinload(
+            AdmissionProfileChoice.admission_path
+        ).selectinload(AdmissionPath.criteria),
+        selectinload(models.AdmissionProfile.choices).selectinload(
             AdmissionProfileChoice.path_subject_group_config
-        ).selectinload(PathSubjectGroupConfig.subject_group),
+        ).selectinload(PathSubjectGroupConfig.subject_group)
+        .selectinload(SubjectGroup.subject_mappings)
+        .selectinload(SubjectGroupSubject.subject),
         selectinload(models.AdmissionProfile.choices).selectinload(
             AdmissionProfileChoice.scores
         ).selectinload(ProfileChoiceScore.subject),
@@ -274,6 +291,12 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
                 selectinload(models.AdmissionProfile.student),
                 selectinload(models.AdmissionProfile.subject_scores).selectinload(ProfileSubjectScore.subject),
                 selectinload(models.AdmissionProfile.documents).joinedload(ProfileDocument.document_type),
+                # P0 hotfix multi-NV — list/export/stats call
+                # _compute_frontend_fields/_compute_completion_percent per row,
+                # which now read profile.choices (+ nested scores/group/criteria)
+                # for multi-NV eligibility/completion. Without this the per-row
+                # sync access lazy-loads → MissingGreenlet (N-row 500).
+                *_choices_eager_load_options(),
             ).order_by(order_func(sort_column)).offset(skip).limit(limit)
         if base_conditions:
             data_query = data_query.where(and_(*base_conditions))

--- a/Backend_FastAPI/app/schemas/admission_profile_choice.py
+++ b/Backend_FastAPI/app/schemas/admission_profile_choice.py
@@ -92,6 +92,35 @@ class AdmissionProfileChoiceResponse(BaseModel):
     )
     scores: list[ChoiceScoreSummary] = Field(default_factory=list)
 
+    # P0 hotfix multi-NV (2026-06-04) — per-NV computed score for DISPLAY.
+    # profile.total_score is None for multi-NV (scores live per choice), so
+    # the FE renders these per NV instead of the profile-level total. Names
+    # are deliberately unambiguous: ``data_complete`` is the submit gate
+    # signal (NO sàn), ``admission_threshold_passed`` is DISPLAY-ONLY (the
+    # min_score floor is enforced by the T6 publish cascade, never by submit).
+    data_complete: bool = Field(
+        default=False,
+        description=(
+            "Đủ điểm để NỘP (|submitted∩allowed| ≥ required_subject_count) — "
+            "KHÔNG xét sàn min_score. Mirror submit gate per-NV."
+        ),
+    )
+    computed_total_score: Optional[Decimal] = Field(
+        default=None,
+        description=(
+            "Điểm tổng NV tính được (no priority bonus); None khi thiếu "
+            "data / invalid / chưa cấu hình criteria."
+        ),
+    )
+    admission_threshold_passed: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Đạt sàn min_score — DISPLAY ONLY, KHÔNG dùng để gate submit. "
+            "None khi data chưa đủ để chấm."
+        ),
+    )
+    threshold_failure_reasons: list[str] = Field(default_factory=list)
+
     model_config = ConfigDict(from_attributes=True)
 
     @model_validator(mode="before")
@@ -195,6 +224,99 @@ class AdmissionProfileChoiceResponse(BaseModel):
                 "weight_snapshot": getattr(score_row, "weight_snapshot", None),
             })
         out["scores"] = scores_list
+
+        # ----------------------------------------------------------------
+        # P0 hotfix multi-NV — per-NV computed score (DISPLAY).
+        # ----------------------------------------------------------------
+        # Defensive: ANY failure (missing eager-loaded criteria / group,
+        # scoring edge) falls back to safe defaults so response never 500s.
+        # Reuses AdmissionScoringService.calculate_score (respects
+        # subject_selection_mode + required_subject_count) — no new math.
+        data_complete = False
+        computed_total_score = None
+        admission_threshold_passed = None
+        threshold_failure_reasons: list[str] = []
+        try:
+            # data_complete = the SUBMIT GATE verdict for THIS choice. Reuse
+            # validate_choice_scores_complete so the display badge can NEVER
+            # disagree with whether Submit is actually allowed — range-check,
+            # config-gap fail-closed, and per-choice-criteria required-count
+            # all live in ONE place. applied_rules is unavailable in the schema
+            # layer → pass {}; the gate then derives `required` from the
+            # choice's own criteria (the normal case), falling back to
+            # len(allowed) for a criteria-less choice exactly as the gate does
+            # when applied_rules also lacks the count.
+            from app.services.admission_choice_engine_service import (
+                validate_choice_scores_complete,
+            )
+            data_complete = not validate_choice_scores_complete([data], {})
+
+            # computed score (DISPLAY) via the scoring service — respects
+            # subject_selection_mode + required_subject_count; raw combo score
+            # (no priority bonus). None when data is incomplete / INVALID.
+            allowed_codes: list[str] = []
+            if config is not None:
+                sg = getattr(config, "subject_group", None)
+                if sg is not None:
+                    for sgs in (getattr(sg, "subject_mappings", None) or []):
+                        subj = getattr(sgs, "subject", None)
+                        code = getattr(subj, "code", None) if subj else None
+                        if code:
+                            allowed_codes.append(code)
+            submitted_map: dict[str, Any] = {}
+            for srow in (getattr(data, "scores", None) or []):
+                subj = getattr(srow, "subject", None)
+                code = getattr(subj, "code", None) if subj else None
+                if code is not None:
+                    submitted_map[code] = getattr(srow, "score", None)
+
+            criteria = getattr(path, "criteria", None) if path is not None else None
+            if criteria is not None and allowed_codes and submitted_map:
+                from app.services.admission_scoring_service import (
+                    AdmissionScoringService,
+                    ProfileStatus as _ProfileStatus,
+                )
+
+                score_input = {
+                    c: Decimal(str(v))
+                    for c, v in submitted_map.items()
+                    if v is not None
+                }
+                result = AdmissionScoringService.calculate_score(
+                    criteria=criteria,
+                    subject_scores=score_input,
+                    allowed_subjects=allowed_codes,
+                    # subject_weights=None MIRRORS the T6 publish cascade
+                    # (admission_choice_engine_service._evaluate_single_choice
+                    # passes None too — "Phase 4: read from path snapshot").
+                    # Both call sites are unweighted today; keep them in
+                    # LOCKSTEP. Wiring weight_snapshot into this DISPLAY call
+                    # alone would make computed_total_score diverge from the
+                    # actual admission decision. When Phase 4 wires weights,
+                    # update both sites together.
+                    subject_weights=None,
+                )
+                computed_total_score = result.final_score
+                # A sàn verdict is only meaningful for a VALID result. When
+                # INVALID (missing subject / điểm liệt) leave threshold_passed
+                # None AND threshold_failure_reasons empty — a data-completeness
+                # reason must NOT be mislabelled as a sàn (min_score) failure;
+                # completeness is conveyed by data_complete instead.
+                if result.status == _ProfileStatus.VALID:
+                    admission_threshold_passed = bool(result.passed)
+                    threshold_failure_reasons = list(
+                        result.failure_reasons or []
+                    )
+        except Exception:  # noqa: BLE001 — display-only; never break response
+            data_complete = False
+            computed_total_score = None
+            admission_threshold_passed = None
+            threshold_failure_reasons = []
+
+        out["data_complete"] = data_complete
+        out["computed_total_score"] = computed_total_score
+        out["admission_threshold_passed"] = admission_threshold_passed
+        out["threshold_failure_reasons"] = threshold_failure_reasons
 
         return out
 

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -60,7 +60,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
 
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 import structlog
 from sqlalchemy import Integer, func, select
@@ -590,6 +590,178 @@ def _resolve_allowed_subjects(choice: "AdmissionProfileChoice") -> List[str]:
         if code:
             codes.append(code)
     return codes
+
+
+def _collect_subject_score_rows(
+    choice: "AdmissionProfileChoice",
+) -> List[Any]:
+    """Return the raw ``ProfileChoiceScore`` rows eager-loaded on ``choice``.
+
+    Sibling of ``_collect_subject_scores`` — that one flattens to a
+    ``{code: Decimal}`` map (for set membership / count checks); this one
+    keeps the rows so range validation can read ``score`` +
+    ``max_score_snapshot`` per row. Pure / sync — relies on
+    ``choice.scores`` being eager-loaded (admission_repository
+    ``_choices_eager_load_options`` + choice repo chains).
+    """
+    return list(getattr(choice, "scores", None) or [])
+
+
+def _resolve_choice_rule(
+    choice: "AdmissionProfileChoice",
+    applied_rules: Dict[str, Any],
+) -> Tuple[Optional[int], str]:
+    """Resolve ``(required_subject_count, subject_selection_mode)`` PER CHOICE.
+
+    Multi-NV is per-choice: each ``choice.admission_path.criteria`` may
+    differ (e.g. NV1 fixed-3, NV2 best_n-2). Display
+    (``AdmissionProfileChoiceResponse._compute_display_fields``) and the T6
+    publish cascade (``_evaluate_single_choice``) both score against
+    ``choice.admission_path.criteria`` — the submit gate MUST read the same
+    per-choice rule or it could let a choice submit short (its criteria
+    needs MORE than the snapshot) or block a valid one (its criteria is
+    best_n with a smaller required). Fall back to the profile-level
+    ``applied_rules`` snapshot ONLY when the choice has no live criteria
+    (legacy profile / config-gap).
+
+    Sync — relies on ``choice.admission_path.criteria`` being eager-loaded
+    (``admission_repository._choices_eager_load_options`` + choice repo
+    chains add the ``admission_path → criteria`` leg).
+    """
+    criteria = None
+    path = getattr(choice, "admission_path", None)
+    if path is not None:
+        criteria = getattr(path, "criteria", None)
+    required = (
+        getattr(criteria, "required_subject_count", None)
+        if criteria is not None
+        else None
+    )
+    mode = (
+        getattr(criteria, "subject_selection_mode", None)
+        if criteria is not None
+        else None
+    )
+    # Fall back to the immutable profile snapshot only when the choice's
+    # path has no criteria configured.
+    if required is None:
+        required = applied_rules.get("required_subject_count")
+    if not mode:
+        mode = applied_rules.get("subject_selection_mode")
+    return required, (mode or "fixed")
+
+
+def validate_choice_scores_complete(
+    choices: List["AdmissionProfileChoice"],
+    applied_rules: Dict[str, Any],
+) -> List[str]:
+    """P0 hotfix multi-NV — per-NV *data-completeness* gate for SUBMIT.
+
+    Phase 3 moved scores to ``ProfileChoiceScore`` (per choice) but the
+    legacy submit/eligibility/completion path still read profile-level
+    ``ProfileSubjectScore`` → every multi-NV profile read ``0`` scores and
+    could never submit. This helper is the choice-aware replacement.
+
+    Contract (LOCKED — see plan "P0 Hotfix Multi-NV"):
+      * Gate = for EVERY choice: ``|submitted ∩ allowed_subjects| ≥
+        required_subject_count`` AND every counted score is valid
+        numeric/range. "Nộp" ≠ "trúng tuyển".
+      * **NO** ``min_score`` / ``min_gpa`` / sàn / quota / ranking check —
+        that is the T6 publish per-NV cascade (``evaluate_cascade``).
+      * Returns ``[]`` when every choice is data-complete.
+
+    The required-subject rule is resolved **PER CHOICE** from
+    ``choice.admission_path.criteria`` (matching display + T6), falling back
+    to the profile snapshot only when a choice has no criteria — see
+    ``_resolve_choice_rule``.
+
+    Pure + sync. Caller passes ``choices`` EXPLICIT (already async-fetched
+    / eager-loaded); this function only touches ``choice.scores`` +
+    ``choice.path_subject_group_config.subject_group.subject_mappings`` +
+    ``choice.admission_path.criteria`` (all eager). ``choices == []`` returns
+    ``[]`` (the ≥1-choice gate is enforced separately so callers can phrase
+    that error in their own voice — submit gate raises ``BadRequest`` at
+    ``submit_and_evaluate``; ``_validate_scores`` adds a "≥1 nguyện vọng"
+    validation error).
+
+    Args:
+        choices: AdmissionProfileChoice rows (any order — sorted here).
+        applied_rules: profile snapshot — FALLBACK for
+            ``required_subject_count`` + ``subject_selection_mode`` only when
+            a choice's path criteria is absent.
+
+    Returns:
+        list[str] — one Vietnamese message per problem, prefixed ``NV{n}``.
+    """
+    errors: List[str] = []
+
+    ordered = sorted(
+        choices, key=lambda c: getattr(c, "display_order", 0) or 0
+    )
+    for choice in ordered:
+        order = getattr(choice, "display_order", "?")
+        allowed = _resolve_allowed_subjects(choice)
+
+        # Config-gap → fail-closed. allowed==[] would make the count check
+        # vacuously pass (required falls back to 0); refuse instead so a
+        # mis-configured combo can never silently let a profile submit.
+        if not allowed:
+            errors.append(f"NV{order}: tổ hợp chưa cấu hình môn")
+            continue
+
+        allowed_set = set(allowed)
+        submitted = _collect_subject_scores(choice)  # {code: Decimal}
+        rows = _collect_subject_score_rows(choice)
+
+        # PER-CHOICE rule from choice.admission_path.criteria (matches
+        # display + T6); applied_rules is fallback only. See blocker fix
+        # 2026-06-04 — NV2 may carry different criteria than NV1.
+        req_raw, mode = _resolve_choice_rule(choice, applied_rules)
+        # required: configured count if present, else "need all allowed".
+        # A falsy 0 OR an unset (None) count BOTH fall back to len(allowed):
+        # a 0/unset required_subject_count means "every combo subject"
+        # (fail-CLOSED on misconfig), never "zero subjects required" — a
+        # submit gate must not let a stray 0 wave through an empty profile.
+        # Pinned by test_required_zero_falls_back_to_all_subjects.
+        required = int(req_raw) if req_raw else len(allowed)
+
+        valid_submitted = [c for c in submitted if c in allowed_set]
+        if len(valid_submitted) < required:
+            msg = (
+                f"NV{order}: thiếu điểm (cần {required} môn tổ hợp, "
+                f"có {len(valid_submitted)})"
+            )
+            # List the still-missing combo subjects only when every allowed
+            # subject is needed (fixed). For best_n the candidate may pick
+            # any subset so naming specific subjects would mislead.
+            if mode == "fixed" or required >= len(allowed):
+                missing = [c for c in allowed if c not in submitted]
+                if missing:
+                    msg += f" — chưa nhập: {', '.join(missing)}"
+            errors.append(msg)
+
+        # Range check — only on rows that count toward the combo.
+        for row in rows:
+            subj = getattr(row, "subject", None)
+            code = getattr(subj, "code", None) if subj else None
+            if code is None or code not in allowed_set:
+                continue
+            raw = getattr(row, "score", None)
+            if raw is None:
+                errors.append(f"NV{order}: điểm môn {code} không hợp lệ")
+                continue
+            try:
+                val = Decimal(str(raw))
+            except (InvalidOperation, ValueError, TypeError):
+                errors.append(f"NV{order}: điểm môn {code} không hợp lệ")
+                continue
+            max_snap = getattr(row, "max_score_snapshot", None)
+            if val < 0 or (
+                max_snap is not None and val > Decimal(str(max_snap))
+            ):
+                errors.append(f"NV{order}: điểm môn {code} không hợp lệ")
+
+    return errors
 
 
 # ============================================================================

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -924,6 +924,46 @@ def _validate_scores(
     Validate score requirements based on applied rules.
     Returns: (has_gpa_error, validation_errors_list, gpa_errors_list)
     """
+    # P0 hotfix multi-NV (2026-06-04) — scores live per-choice in
+    # ProfileChoiceScore, NOT the profile-level ProfileSubjectScore the
+    # legacy body below reads. Branch out so multi-NV eligibility/completion
+    # use the choice-aware data-completeness gate. Data-complete ONLY (no
+    # min_score/sàn → that is T6 publish per-NV); when complete this returns
+    # no error so eligibility_status flips to "eligible" even below the
+    # threshold (correct per contract — "nộp" ≠ "trúng tuyển").
+    if getattr(profile, "uses_choice_engine", False):
+        # Sync helper — read choices from __dict__ to avoid triggering a
+        # lazy-load (MissingGreenlet) in the async session. All response
+        # paths eager-load choices (admission_repository
+        # _choices_eager_load_options + _populate_response_fields 8d
+        # defensive fetch); the submit gate re-queries fresh.
+        choices = profile.__dict__.get("choices")
+        if choices is None:
+            # Relationship not eager-loaded on this path — stay non-blocking
+            # rather than crash (MissingGreenlet) or spuriously block. This is
+            # display-only fail-open; the authoritative submit gate re-queries
+            # fresh. Log so a missing eager-load on a NEW code path is
+            # observable instead of silently masking incompleteness.
+            log.warning(
+                "validate_scores_choices_unloaded",
+                profile_id=getattr(profile, "id", None),
+                reason=(
+                    "multi-NV profile reached _validate_scores without "
+                    "eager-loaded choices; eligibility computed fail-open. "
+                    "Ensure the caller eager-loads choices "
+                    "(_choices_eager_load_options / _populate_response_fields)."
+                ),
+            )
+            return False, [], []
+        if not choices:
+            msg = "Cần ít nhất 1 nguyện vọng để nộp hồ sơ"
+            return True, [msg], [msg]
+        from .admission_choice_engine_service import (
+            validate_choice_scores_complete,
+        )
+        errs = validate_choice_scores_complete(choices, applied_rules)
+        return bool(errs), errs, errs
+
     min_gpa = float(applied_rules.get("min_gpa") or 0)
     req_count_val = applied_rules.get("required_subject_count")
     required_count = int(req_count_val) if req_count_val is not None else 3
@@ -1174,7 +1214,18 @@ def _compute_completion_percent(
     personal_optional_filled = all(getattr(profile, f, None) for f in personal_optional)
     has_family = profile.family_info and len(profile.family_info) > 0
     has_academic = profile.academic_history and len(profile.academic_history) > 0
-    has_any_scores = bool(profile.subject_scores) if hasattr(profile, "subject_scores") else False
+    # P0 hotfix multi-NV — Step 5 (Scores) "has any" reads per-choice
+    # ProfileChoiceScore, not the profile-level relation (always empty for
+    # multi-NV). __dict__ access is lazy-load-safe in this sync helper.
+    if getattr(profile, "uses_choice_engine", False):
+        _ch = profile.__dict__.get("choices") or []
+        has_any_scores = any(bool(c.__dict__.get("scores")) for c in _ch)
+    else:
+        has_any_scores = (
+            bool(profile.subject_scores)
+            if hasattr(profile, "subject_scores")
+            else False
+        )
 
     # Phase E.4 — Step 4 Priority compute (KV resolved + cultural input)
     has_priority_input = bool(
@@ -1515,10 +1566,23 @@ def _compute_frontend_fields(
     # 1. PERMISSIONS (computed from role + status + Casbin-like rules)
     # =========================================================================
     _is_dropped = getattr(profile, "is_dropped", False)
+    # P0 hotfix multi-NV — a multi-NV profile needs ≥1 choice before the
+    # Submit button shows (otherwise the candidate clicks Nộp only to hit a
+    # 400 from submit_and_evaluate's ≥1-choice gate). Block ONLY when it is
+    # multi-NV AND choices are eager-loaded AND empty; an unloaded relation
+    # (None) does NOT block (display-only paths — the submit gate
+    # re-validates with a fresh query). __dict__ access avoids a sync
+    # lazy-load (MissingGreenlet).
+    _loaded_choices = profile.__dict__.get("choices")
+    _multi_nv_no_choice = (
+        getattr(profile, "uses_choice_engine", False)
+        and _loaded_choices is not None
+        and len(_loaded_choices) == 0
+    )
     permissions = {
         "edit": status in ["draft", "rejected", "revision_requested"] and (is_owner or is_manager or is_admin),
         "save": status in ["draft", "rejected", "revision_requested"] and (is_owner or is_manager or is_admin),
-        "submit": status == "draft" and (is_owner or is_manager or is_admin),
+        "submit": status == "draft" and (is_owner or is_manager or is_admin) and not _multi_nv_no_choice,
         "approve": status in ["submitted", "resubmitted"] and (is_manager or is_admin),
         "reject": status in ["submitted", "resubmitted"] and (is_manager or is_admin),
         # Phase 3 multi-NV simplified flow 2026-05-15: manager/admin click
@@ -1887,7 +1951,20 @@ def _compute_frontend_fields(
     # Academic
     has_academic = profile.academic_history and len(profile.academic_history) > 0
     
-    has_any_scores = bool(profile.subject_scores) if hasattr(profile, 'subject_scores') else False
+    # P0 hotfix multi-NV — Step 5 (Scores) "has any" must read per-choice
+    # ProfileChoiceScore for multi-NV (profile.subject_scores is always empty
+    # there), mirroring _compute_completion_percent. Without this branch the
+    # RESPONSE step_status[5] stays 'warning' for a fully-scored multi-NV
+    # profile (it never turns 'success'), contradicting completion_percent.
+    if getattr(profile, "uses_choice_engine", False):
+        _ch = profile.__dict__.get("choices") or []
+        has_any_scores = any(bool(c.__dict__.get("scores")) for c in _ch)
+    else:
+        has_any_scores = (
+            bool(profile.subject_scores)
+            if hasattr(profile, 'subject_scores')
+            else False
+        )
 
     # Phase E.4 — Step 4 Priority compute (KV resolved + cultural input)
     has_priority_input = bool(getattr(profile, "cultural_education_level", None))
@@ -2574,6 +2651,29 @@ async def _populate_response_fields(
     if current_user is None:
         # System callback path: no role/permissions to compute. Skip silently.
         return
+
+    # P0 hotfix multi-NV (8d) — DEFENSIVE choices eager-load at the async
+    # chokepoint. deps.py get_admission_for_* (IDOR) + admissions_v2 reload
+    # helpers preload lead/reviewer but NOT choices; _compute_frontend_fields
+    # → _validate_scores + submit-perm + _compute_completion_percent now read
+    # profile.choices for multi-NV, and a lazy access from that sync code
+    # raises MissingGreenlet. Inject the eager-loaded list as a *committed*
+    # value (does NOT mark the instance dirty, does NOT re-lazy) so EVERY
+    # mutation response (approve/reject/override/submit/v2 helpers) is covered
+    # without touching each dependency. Skip when already loaded (GET paths
+    # eager-load via _choices_eager_load_options).
+    if getattr(profile, "uses_choice_engine", False):
+        import sqlalchemy as _sa
+        from sqlalchemy.orm.attributes import set_committed_value
+
+        if "choices" in _sa.inspect(profile).unloaded:
+            from app.repositories.admission_profile_choice_repository import (
+                AdmissionProfileChoiceRepository,
+            )
+            _fresh_choices = await AdmissionProfileChoiceRepository(
+                db
+            ).list_by_profile(profile.id)
+            set_committed_value(profile, "choices", _fresh_choices)
 
     from app.repositories import AdmissionRepository
     admission_repo = AdmissionRepository(db)
@@ -4065,7 +4165,10 @@ async def update_profile(
     # Prevent Race Condition (Lost Update) by locking the row
     from sqlalchemy import select
     from sqlalchemy.orm import selectinload
-    
+    from app.repositories.admission_repository import (
+        _choices_eager_load_options,
+    )
+
     stmt = (
         select(models.AdmissionProfile)
         .where(models.AdmissionProfile.id == profile_id)
@@ -4075,6 +4178,11 @@ async def update_profile(
             .selectinload(models.Lead.assigned_officer),
             # Eager load assigned_reviewer for _compute_frontend_fields
             selectinload(models.AdmissionProfile.assigned_reviewer),
+            # P0 hotfix multi-NV — update_profile calls _compute_frontend_fields
+            # directly (NOT via _populate_response_fields 8d), so eager-load
+            # choices here too or the sync eligibility read MissingGreenlets.
+            # selectinload uses separate SELECTs → compatible with FOR UPDATE.
+            *_choices_eager_load_options(),
         )
         .with_for_update() # Lock the row
     )
@@ -4406,6 +4514,20 @@ def _calculate_and_update_totals(profile: models.AdmissionProfile, scores: list 
     
     Note: These fields are transient (not in DB) but required by Schema.
     """
+    # P0 hotfix multi-NV (2026-06-04) — profile-level total/average/snapshot
+    # are meaningless for multi-NV (scores live per-choice in
+    # ProfileChoiceScore). The legacy branches below hard-set 0.00 when the
+    # profile-level relation is empty → FE renders a fake "0.00 / Tổng điểm".
+    # Set every profile-level score field to None (schema fields are
+    # Optional) so the response renders "—" and the FE switches to per-NV
+    # display (choice.computed_total_score). See plan step 6.
+    if getattr(profile, "uses_choice_engine", False):
+        profile.total_score = None
+        profile.average_score = None
+        profile.admission_scores = None
+        profile.snapshot_score = None
+        return
+
     # Use provided scores OR fallback to profile relationship
     # If scores arg is provided managed explicitly, use it.
     # Otherwise check if profile.subject_scores is loaded and populated.
@@ -5066,7 +5188,30 @@ async def submit_and_evaluate(
 
     method_type = applied_rules.get("method_type", "subject_based")
 
-    if method_type == "gpa_only":
+    if profile.uses_choice_engine:
+        # =====================================================================
+        # P0 hotfix multi-NV — per-NV data-completeness gate.
+        # =====================================================================
+        # Scores live per-choice in ProfileChoiceScore; the gpa_only /
+        # subject-based branches below read profile-level ProfileSubjectScore
+        # (always empty for multi-NV → a spurious "thiếu điểm" on every
+        # submit). Gate on per-NV completeness instead: every choice carries
+        # ≥ required combo subjects with valid numeric/range scores. NO
+        # min_score / sàn here — the T6 publish cascade (evaluate_cascade)
+        # applies the threshold per NV. ``with_for_update()`` above did NOT
+        # eager choices, so fetch them fresh with the full eager chain the
+        # helper walks (scores+subject + subject_group.subject_mappings).
+        from app.repositories.admission_profile_choice_repository import (
+            AdmissionProfileChoiceRepository,
+        )
+        from .admission_choice_engine_service import (
+            validate_choice_scores_complete,
+        )
+        _choices = await AdmissionProfileChoiceRepository(db).list_by_profile(
+            profile.id
+        )
+        errors.extend(validate_choice_scores_complete(_choices, applied_rules))
+    elif method_type == "gpa_only":
         # =====================================================================
         # GPA-Only Branch: validate using Lead.gpa, no subject scores required
         # =====================================================================

--- a/Backend_FastAPI/tests/services/test_multi_nv_submit_gate.py
+++ b/Backend_FastAPI/tests/services/test_multi_nv_submit_gate.py
@@ -1,0 +1,656 @@
+"""Service-layer integration tests — multi-NV choice-score plumbing (P0 hotfix).
+
+Real DB via ``AsyncSessionLocal``. HEAVY → run in a one-off backend container
+(memory ``local-test-oneoff-container-pattern``).
+
+Scope: the parts the P0 hotfix actually changed, tested deterministically and
+WITHOUT coupling to the full ``submit_and_evaluate`` eligibility/KV/docs
+pipeline (which requires config_degree_level + config_offering_type +
+current-era ward + KV-resolution seed — a fully-valid submittable profile,
+out of scope for a score-gate test). The submit gate's *logic* is exercised
+via its exact data path + the helper unit tests
+(``test_validate_choice_scores_complete``):
+
+  * submit gate DATA PATH = AdmissionProfileChoiceRepository.list_by_profile()
+    (real eager-load chain 8c) + validate_choice_scores_complete()
+      - complete → [],  missing subject → error,  best_n no over-block
+  * submit_and_evaluate 0-choice → BadRequest (early ≥1-choice gate, fires
+    BEFORE eligibility — deterministic)
+  * _calculate_and_update_totals → None for multi-NV, 0.0/number for legacy
+  * GET detail (get_profile) serialize: total_score None, eligibility eligible,
+    can_submit True, per-NV computed_total_score + data_complete — NO MissingGreenlet
+  * GET detail 0-choice → can_submit False + "≥1 nguyện vọng" validation error
+  * GET list (get_profiles) serialize: NO MissingGreenlet, multi-NV total None
+  * Choice response (get_by_id_with_relations) serialize → computed fields
+  * _populate_response_fields (8d) defensive: profile loaded WITHOUT choices
+    eager → choices injected + serialize OK (mutation-response 500 guard)
+  * legacy single-NV _validate_scores untouched (multi-NV branch not taken)
+
+Non-tautological per memory ``pattern-change-impact-audit``.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.services import admission_service
+from app.services.admission_choice_engine_service import (
+    validate_choice_scores_complete,
+)
+from app.repositories.admission_profile_choice_repository import (
+    AdmissionProfileChoiceRepository,
+)
+from app.schemas.admission import AdmissionProfileResponse
+from app.schemas.admission_profile_choice import AdmissionProfileChoiceResponse
+from app.utils.exceptions import BadRequest
+
+
+# ============================================================================
+# Seed helpers — inline (mirror pr3a_seed pattern; tests/api are not importable)
+# ============================================================================
+
+
+async def _seed_path_and_group(
+    s,
+    seed_deps: dict,
+    subject_codes: list[str],
+    *,
+    required_count: int | None = None,
+    selection_mode: str = "fixed",
+    tag: str = "",
+    offering_type: str = "full_time",
+):
+    """Create offering→academic_info→path + subject_group(subjects) + config
+    + AdmissionCriteria (so path.criteria drives computed_total_score AND the
+    per-choice submit gate).
+
+    Args:
+        required_count: criteria.required_subject_count (default len(codes)).
+        selection_mode: criteria.subject_selection_mode (fixed / best_n).
+        tag: code-uniqueness discriminator when seeding multiple paths in one
+            test (avoids UNIQUE collisions on a shared microsecond).
+
+    Returns dict with path_id, config_id, subject ids keyed by code.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1_000_000) % 1_000_000
+    ts = f"{tag}{ts}"
+
+    offering = models.ProgramOffering(
+        program_id=seed_deps["major_program_id"],
+        offering_type=offering_type,
+        duration_semesters=8,
+    )
+    s.add(offering)
+    await s.flush()
+
+    ai = models.OfferingAcademicInfo(
+        offering_id=offering.id,
+        academic_year=2026,
+        annual_admission_quota=50,
+        tuition_fee_per_year=1_000_000,
+    )
+    s.add(ai)
+    await s.flush()
+
+    from tests.fixtures.builders import AdmissionRoundBuilder
+    round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+        s, academic_year=2026,
+    )
+
+    method = models.AdmissionMethod(
+        code=f"MNV{ts}"[:20],
+        name=f"multi-nv method {ts}",
+        requires_subject_scores=True,
+        is_active=True,
+    )
+    s.add(method)
+    await s.flush()
+
+    criteria = models.AdmissionCriteria(
+        code=f"CRIT{ts}"[:20],
+        name=f"Criteria {ts}",
+        method_id=method.id,
+        min_score=Decimal("18.00"),
+        required_subject_count=(
+            required_count if required_count is not None else len(subject_codes)
+        ),
+        subject_selection_mode=selection_mode,
+        scoring_method="sum",
+    )
+    s.add(criteria)
+    await s.flush()
+
+    path = models.AdmissionPath(
+        academic_info_id=ai.id,
+        admission_method_id=method.id,
+        admission_round_id=round_id,
+        criteria_id=criteria.id,
+        status="active",
+    )
+    s.add(path)
+    await s.flush()
+
+    sg = models.SubjectGroup(code=f"G{ts}"[:20], name=f"group {ts}")
+    s.add(sg)
+    await s.flush()
+
+    subj_ids: dict[str, int] = {}
+    for pos, code in enumerate(subject_codes, start=1):
+        subj = models.Subject(
+            code=f"{code}{ts}"[:20],
+            name_vi=f"{code} {ts}",
+            max_score=Decimal("10.00"),
+            min_possible_score=Decimal("0.00"),
+        )
+        s.add(subj)
+        await s.flush()
+        subj_ids[code] = subj.id
+        s.add(models.SubjectGroupSubject(
+            subject_group_id=sg.id,
+            subject_id=subj.id,
+            position=pos,
+            weight=Decimal("1.00"),
+        ))
+    await s.flush()
+
+    config = models.PathSubjectGroupConfig(
+        admission_path_id=path.id,
+        subject_group_id=sg.id,
+        min_score=Decimal("18.00"),
+    )
+    s.add(config)
+    await s.flush()
+
+    round_obj = await s.get(models.OfferingAdmissionRound, round_id)
+    round_obj.allow_multi_nv = True
+    await s.flush()
+
+    return {
+        "path_id": path.id,
+        "config_id": config.id,
+        "subject_ids": subj_ids,
+        "round_id": round_id,
+    }
+
+
+def _full_personal(**overrides):
+    """Personal fields so _validate_personal_info passes (no personal errors)."""
+    base = dict(
+        full_name="Nguyễn Văn Test",
+        dob=date(2008, 1, 1),
+        gender="male",
+        nationality="Việt Nam",
+        ethnicity="Kinh",
+        phone="0970000000",
+        place_of_birth="Đắk Lắk",
+    )
+    base.update(overrides)
+    return base
+
+
+async def _seed_profile(
+    s,
+    seed_deps: dict,
+    *,
+    uses_choice_engine: bool,
+    applied_rules: dict | None = None,
+    citizen_suffix: str = "0",
+    full_personal: bool = False,
+):
+    ts = int(datetime.now(timezone.utc).timestamp() * 1_000_000) % 1_000_000
+    lead = models.Lead(
+        full_name=f"Lead {ts}",
+        phone=f"098{ts:07d}"[:10],
+        unit_id=seed_deps["unit_id"],
+        pipeline_stage_id=seed_deps["stage_id"],
+        source="walkin",
+    )
+    s.add(lead)
+    await s.flush()
+
+    kwargs = dict(
+        lead_id=lead.id,
+        citizen_id=f"05{ts:08d}{citizen_suffix}"[:12],
+        status="draft",
+        applied_rules=applied_rules if applied_rules is not None else {},
+        academic_year=2026,
+        uses_choice_engine=uses_choice_engine,
+    )
+    if full_personal:
+        kwargs.update(_full_personal())
+    profile = models.AdmissionProfile(**kwargs)
+    s.add(profile)
+    await s.flush()
+    return profile.id, lead.id
+
+
+async def _add_choice(s, *, profile_id, path_id, config_id, display_order,
+                      scores: list[tuple[int, Decimal]]):
+    """scores: list[(subject_id, value)]."""
+    choice = models.AdmissionProfileChoice(
+        admission_profile_id=profile_id,
+        admission_path_id=path_id,
+        path_subject_group_config_id=config_id,
+        display_order=display_order,
+        decision="pending",
+    )
+    s.add(choice)
+    await s.flush()
+    for subject_id, value in scores:
+        s.add(models.ProfileChoiceScore(
+            admission_profile_choice_id=choice.id,
+            subject_id=subject_id,
+            score=value,
+            max_score_snapshot=Decimal("10.00"),
+            weight_snapshot=Decimal("1.00"),
+        ))
+    await s.flush()
+    return choice.id
+
+
+async def _get_admin(s, admin_user_in_db: dict) -> models.User:
+    return await s.get(models.User, admin_user_in_db["id"])
+
+
+# ============================================================================
+# 1–3 + best_n : submit-gate data path (list_by_profile + helper) + 0-choice
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_submit_gate_data_path_complete_returns_no_error(
+    seed_lead_dependencies: dict,
+):
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pg = await _seed_path_and_group(s, seed_lead_dependencies, ["TOAN", "VAN"])
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=True,
+            )
+            await _add_choice(
+                s, profile_id=pid, path_id=pg["path_id"], config_id=pg["config_id"],
+                display_order=1,
+                scores=[(pg["subject_ids"]["TOAN"], Decimal("8")),
+                        (pg["subject_ids"]["VAN"], Decimal("7"))],
+            )
+
+    async with AsyncSessionLocal() as s:
+        choices = await AdmissionProfileChoiceRepository(s).list_by_profile(pid)
+        # required falls back to len(allowed)=2; both entered → no error.
+        assert validate_choice_scores_complete(choices, {}) == []
+
+
+@pytest.mark.asyncio
+async def test_submit_gate_data_path_missing_subject_blocks(
+    seed_lead_dependencies: dict,
+):
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pg = await _seed_path_and_group(s, seed_lead_dependencies, ["TOAN", "VAN"])
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=True,
+            )
+            await _add_choice(
+                s, profile_id=pid, path_id=pg["path_id"], config_id=pg["config_id"],
+                display_order=1,
+                scores=[(pg["subject_ids"]["TOAN"], Decimal("8"))],  # VAN missing
+            )
+
+    async with AsyncSessionLocal() as s:
+        choices = await AdmissionProfileChoiceRepository(s).list_by_profile(pid)
+        errs = validate_choice_scores_complete(choices, {})
+        assert len(errs) == 1
+        assert "NV1" in errs[0] and "thiếu điểm" in errs[0]
+
+
+@pytest.mark.asyncio
+async def test_submit_gate_best_n_no_overblock(seed_lead_dependencies: dict):
+    # Path criteria = best_n required=2 (the per-choice rule the gate reads).
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pg = await _seed_path_and_group(
+                s, seed_lead_dependencies, ["TOAN", "VAN", "ANH"],
+                required_count=2, selection_mode="best_n",
+            )
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=True,
+            )
+            await _add_choice(
+                s, profile_id=pid, path_id=pg["path_id"], config_id=pg["config_id"],
+                display_order=1,
+                scores=[(pg["subject_ids"]["TOAN"], Decimal("8")),
+                        (pg["subject_ids"]["VAN"], Decimal("7"))],  # 2 of 3
+            )
+
+    async with AsyncSessionLocal() as s:
+        choices = await AdmissionProfileChoiceRepository(s).list_by_profile(pid)
+        # applied_rules empty → relies purely on path criteria (best_n-2).
+        assert validate_choice_scores_complete(choices, {}) == []
+
+
+@pytest.mark.asyncio
+async def test_submit_gate_reads_per_choice_criteria_from_db(
+    seed_lead_dependencies: dict,
+):
+    """Blocker fix 2026-06-04 — gate reads choice.admission_path.criteria PER
+    CHOICE (eager-loaded by list_by_profile 8c), NOT the uniform snapshot.
+
+    NV1 → path A (fixed, required=3, 3 scores); NV2 → path B (best_n,
+    required=2, 2 scores). Snapshot applied_rules.required=3 would FALSELY
+    block NV2 (2 < 3). Per-choice criteria (best_n 2) → NV2 passes → errs==[].
+    """
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pg_a = await _seed_path_and_group(
+                s, seed_lead_dependencies, ["TOAN", "VAN", "ANH"],
+                required_count=3, selection_mode="fixed", tag="A",
+                offering_type="full_time",
+            )
+            pg_b = await _seed_path_and_group(
+                s, seed_lead_dependencies, ["TOAN", "VAN", "ANH"],
+                required_count=2, selection_mode="best_n", tag="B",
+                offering_type="part_time",
+            )
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=True,
+            )
+            await _add_choice(
+                s, profile_id=pid, path_id=pg_a["path_id"],
+                config_id=pg_a["config_id"], display_order=1,
+                scores=[(pg_a["subject_ids"]["TOAN"], Decimal("8")),
+                        (pg_a["subject_ids"]["VAN"], Decimal("7")),
+                        (pg_a["subject_ids"]["ANH"], Decimal("6"))],
+            )
+            await _add_choice(
+                s, profile_id=pid, path_id=pg_b["path_id"],
+                config_id=pg_b["config_id"], display_order=2,
+                scores=[(pg_b["subject_ids"]["TOAN"], Decimal("8")),
+                        (pg_b["subject_ids"]["VAN"], Decimal("7"))],
+            )
+
+    async with AsyncSessionLocal() as s:
+        choices = await AdmissionProfileChoiceRepository(s).list_by_profile(pid)
+        # snapshot=3 would block NV2; per-choice best_n-2 lets it through.
+        errs = validate_choice_scores_complete(
+            choices, {"required_subject_count": 3}
+        )
+        assert errs == []
+
+
+@pytest.mark.asyncio
+async def test_submit_zero_choice_raises_badrequest(
+    seed_lead_dependencies: dict, admin_user_in_db: dict,
+):
+    """0-choice multi-NV → submit_and_evaluate raises BadRequest (early gate,
+    fires before eligibility → deterministic without full pipeline seed)."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=True,
+            )
+
+    async with AsyncSessionLocal() as s:
+        admin = await _get_admin(s, admin_user_in_db)
+        with pytest.raises(BadRequest):
+            await admission_service.submit_and_evaluate(s, pid, admin)
+
+
+# ============================================================================
+# 4 : _calculate_and_update_totals — None for multi-NV, NOT None for legacy
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_calculate_totals_multi_nv_sets_none(seed_lead_dependencies: dict):
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=True,
+            )
+
+    async with AsyncSessionLocal() as s:
+        profile = await s.get(models.AdmissionProfile, pid)
+        admission_service._calculate_and_update_totals(profile)
+        assert profile.total_score is None
+        assert profile.average_score is None
+        assert profile.admission_scores is None
+        assert profile.snapshot_score is None
+
+
+@pytest.mark.asyncio
+async def test_calculate_totals_legacy_not_none(seed_lead_dependencies: dict):
+    """Legacy single-NV (uses_choice_engine=False) untouched — the multi-NV
+    None guard must NOT fire (0.0 placeholder for insufficient scores)."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=False,
+                applied_rules={"method_type": "subject_based",
+                               "required_subject_count": 3},
+            )
+
+    async with AsyncSessionLocal() as s:
+        profile = await s.get(models.AdmissionProfile, pid)
+        # no subject_scores → legacy path sets 0.0 (NOT None). The point: it
+        # ran the legacy body, not the multi-NV early-None guard.
+        admission_service._calculate_and_update_totals(profile, scores=[])
+        assert profile.total_score is not None
+
+
+@pytest.mark.asyncio
+async def test_validate_scores_legacy_unchanged(seed_lead_dependencies: dict):
+    """Legacy _validate_scores hits the legacy body (count check), not the
+    multi-NV choice branch."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=False,
+                applied_rules={"method_type": "subject_based",
+                               "required_subject_count": 3},
+            )
+
+    async with AsyncSessionLocal() as s:
+        # eager-load subject_scores (legacy _validate_scores reads it; lazy in
+        # async → MissingGreenlet otherwise).
+        stmt = (
+            select(models.AdmissionProfile)
+            .where(models.AdmissionProfile.id == pid)
+            .options(selectinload(models.AdmissionProfile.subject_scores))
+        )
+        profile = (await s.execute(stmt)).scalar_one()
+        # total_score/average_score are TRANSIENT (set by
+        # _calculate_and_update_totals, not DB columns); production always
+        # calls it before _validate_scores. Mirror that here.
+        admission_service._calculate_and_update_totals(profile, scores=[])
+        # subject_scores empty → legacy "Chưa nhập đủ đầu điểm" error.
+        gpa_error, ve, _ = admission_service._validate_scores(
+            profile, profile.applied_rules or {}
+        )
+        assert gpa_error is True
+        assert any("đầu điểm" in e for e in ve)
+
+
+# ============================================================================
+# 5–7 : GET detail serialization (computed fields, eligibility, can_submit)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_detail_multi_nv_complete_serializes(
+    seed_lead_dependencies: dict, admin_user_in_db: dict,
+):
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pg = await _seed_path_and_group(s, seed_lead_dependencies, ["TOAN", "VAN"])
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=True, full_personal=True,
+            )
+            await _add_choice(
+                s, profile_id=pid, path_id=pg["path_id"], config_id=pg["config_id"],
+                display_order=1,
+                scores=[(pg["subject_ids"]["TOAN"], Decimal("8")),
+                        (pg["subject_ids"]["VAN"], Decimal("7"))],
+            )
+
+    async with AsyncSessionLocal() as s:
+        admin = await _get_admin(s, admin_user_in_db)
+        profile = await admission_service.get_profile(s, pid, admin)
+        resp = AdmissionProfileResponse.model_validate(profile)  # no MissingGreenlet
+
+    # profile-level total is None for multi-NV (FE renders per-NV).
+    assert resp.total_score is None
+    # data-complete + below-sàn → eligible + can_submit (nộp ≠ trúng tuyển).
+    assert resp.eligibility_status == "eligible"
+    assert resp.permissions.get("submit") is True
+    # per-NV computed score populated.
+    assert len(resp.choices) == 1
+    assert resp.choices[0].data_complete is True
+    assert resp.choices[0].computed_total_score is not None
+    # sum 8+7=15 < min_score 18 → below sàn (display only).
+    assert resp.choices[0].admission_threshold_passed is False
+    # Review #1 regression guard — step_status[5] (Scores) must be 'success'
+    # for a fully data-complete multi-NV profile. _compute_frontend_fields'
+    # has_any_scores must be multi-NV-aware (it reads choices, not the always-
+    # empty profile.subject_scores); otherwise step 5 stays 'warning' forever.
+    assert resp.step_status is not None
+    assert resp.step_status.get(5) == "success"
+
+
+@pytest.mark.asyncio
+async def test_get_detail_zero_choice_cannot_submit(
+    seed_lead_dependencies: dict, admin_user_in_db: dict,
+):
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=True, full_personal=True,
+            )
+
+    async with AsyncSessionLocal() as s:
+        admin = await _get_admin(s, admin_user_in_db)
+        profile = await admission_service.get_profile(s, pid, admin)
+        resp = AdmissionProfileResponse.model_validate(profile)
+
+    assert resp.permissions.get("submit") is False
+    assert any("nguyện vọng" in e for e in (resp.validation_errors or []))
+
+
+@pytest.mark.asyncio
+async def test_get_list_multi_nv_no_missing_greenlet(
+    seed_lead_dependencies: dict, admin_user_in_db: dict,
+):
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pg = await _seed_path_and_group(s, seed_lead_dependencies, ["TOAN", "VAN"])
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=True, full_personal=True,
+            )
+            await _add_choice(
+                s, profile_id=pid, path_id=pg["path_id"], config_id=pg["config_id"],
+                display_order=1,
+                scores=[(pg["subject_ids"]["TOAN"], Decimal("8")),
+                        (pg["subject_ids"]["VAN"], Decimal("7"))],
+            )
+
+    async with AsyncSessionLocal() as s:
+        admin = await _get_admin(s, admin_user_in_db)
+        profiles, _ = await admission_service.get_profiles(
+            s, skip=0, limit=100, current_user=admin,
+        )
+        # serialize ALL (this is where a missing eager-load 500s).
+        serialized = [AdmissionProfileResponse.model_validate(p) for p in profiles]
+
+    target = next(r for r in serialized if r.id == pid)
+    assert target.total_score is None  # NOT 0.00
+    assert len(target.choices) == 1
+    assert target.choices[0].computed_total_score is not None
+
+
+# ============================================================================
+# 8 : choice response serialization (computed fields, no lazy fail)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_choice_response_has_computed_fields(seed_lead_dependencies: dict):
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pg = await _seed_path_and_group(s, seed_lead_dependencies, ["TOAN", "VAN"])
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=True,
+            )
+            cid = await _add_choice(
+                s, profile_id=pid, path_id=pg["path_id"], config_id=pg["config_id"],
+                display_order=1,
+                scores=[(pg["subject_ids"]["TOAN"], Decimal("9")),
+                        (pg["subject_ids"]["VAN"], Decimal("9"))],
+            )
+
+    async with AsyncSessionLocal() as s:
+        choice = await AdmissionProfileChoiceRepository(s).get_by_id_with_relations(cid)
+        resp = AdmissionProfileChoiceResponse.model_validate(choice)  # no lazy fail
+
+    assert resp.data_complete is True
+    assert resp.computed_total_score is not None
+    # 9+9=18 >= min_score 18 → passes sàn.
+    assert resp.admission_threshold_passed is True
+
+
+# ============================================================================
+# 9 : _populate_response_fields (8d) defensive choices load
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_populate_response_fields_defensive_loads_choices(
+    seed_lead_dependencies: dict, admin_user_in_db: dict,
+):
+    """Mutation-response guard: a profile loaded WITHOUT choices eager-loaded
+    must have choices injected by _populate_response_fields, so the response
+    serializes (no MissingGreenlet) and computed fields are correct."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            pg = await _seed_path_and_group(s, seed_lead_dependencies, ["TOAN", "VAN"])
+            pid, _ = await _seed_profile(
+                s, seed_lead_dependencies, uses_choice_engine=True, full_personal=True,
+            )
+            await _add_choice(
+                s, profile_id=pid, path_id=pg["path_id"], config_id=pg["config_id"],
+                display_order=1,
+                scores=[(pg["subject_ids"]["TOAN"], Decimal("8")),
+                        (pg["subject_ids"]["VAN"], Decimal("7"))],
+            )
+
+    async with AsyncSessionLocal() as s:
+        admin = await _get_admin(s, admin_user_in_db)
+        # Load lead eager but NOT choices (mirrors deps.py / v2 reload helpers).
+        stmt = (
+            select(models.AdmissionProfile)
+            .where(models.AdmissionProfile.id == pid)
+            .options(
+                selectinload(models.AdmissionProfile.lead)
+                .selectinload(models.Lead.assigned_officer),
+                selectinload(models.AdmissionProfile.assigned_reviewer),
+            )
+        )
+        profile = (await s.execute(stmt)).scalar_one()
+        # Pre-condition: choices NOT loaded.
+        import sqlalchemy as sa
+        assert "choices" in sa.inspect(profile).unloaded
+
+        await admission_service._populate_response_fields(s, profile, admin)
+
+        # 8d injected choices as a committed value.
+        assert "choices" not in sa.inspect(profile).unloaded
+        resp = AdmissionProfileResponse.model_validate(profile)
+
+    assert resp.total_score is None
+    assert len(resp.choices) == 1
+    assert resp.choices[0].computed_total_score is not None

--- a/Backend_FastAPI/tests/unit/test_validate_choice_scores_complete.py
+++ b/Backend_FastAPI/tests/unit/test_validate_choice_scores_complete.py
@@ -1,0 +1,249 @@
+"""Unit tests — ``validate_choice_scores_complete`` (P0 hotfix multi-NV).
+
+Pure SimpleNamespace stubs (no DB). Pins the per-NV *data-completeness*
+submit-gate contract (plan "P0 Hotfix Multi-NV"):
+
+  * gate = for every choice: ``|submitted ∩ allowed| ≥ required`` AND every
+    counted score is valid numeric/range.
+  * **NO** ``min_score`` / sàn check — that is the T6 publish per-NV cascade.
+  * config-gap (``allowed == []``) → fail-closed.
+  * best_n (``required_subject_count < len(allowed)``) → no over-block.
+
+Non-tautological per memory ``pattern-change-impact-audit``: each test pins a
+specific return shape / message substring, not merely "callable".
+"""
+from decimal import Decimal
+from types import SimpleNamespace
+
+from app.services.admission_choice_engine_service import (
+    validate_choice_scores_complete,
+)
+
+
+def _choice(
+    display_order,
+    allowed_codes,
+    scores,
+    *,
+    criteria_required=None,
+    criteria_mode=None,
+):
+    """Build a stub AdmissionProfileChoice.
+
+    Args:
+        display_order: NV order (1-based).
+        allowed_codes: subject codes in the combo (subject_group mappings).
+        scores: list[(code, value, max_score_snapshot)].
+        criteria_required / criteria_mode: when set, attach a per-choice
+            ``admission_path.criteria`` (so the helper reads it instead of
+            the profile snapshot). Left unset → no admission_path → helper
+            falls back to applied_rules.
+    """
+    mappings = [
+        SimpleNamespace(subject=SimpleNamespace(code=c)) for c in allowed_codes
+    ]
+    config = SimpleNamespace(
+        subject_group=SimpleNamespace(subject_mappings=mappings)
+    )
+    score_rows = [
+        SimpleNamespace(
+            subject=SimpleNamespace(code=c),
+            score=v,
+            max_score_snapshot=m,
+        )
+        for (c, v, m) in scores
+    ]
+    admission_path = None
+    if criteria_required is not None or criteria_mode is not None:
+        admission_path = SimpleNamespace(
+            criteria=SimpleNamespace(
+                required_subject_count=criteria_required,
+                subject_selection_mode=criteria_mode,
+            )
+        )
+    return SimpleNamespace(
+        display_order=display_order,
+        path_subject_group_config=config,
+        scores=score_rows,
+        admission_path=admission_path,
+    )
+
+
+def test_complete_two_choices_below_floor_returns_no_error():
+    """(1) NV1 đủ + NV2 đủ-nhưng-dưới-sàn → [] (helper KHÔNG xét min_score)."""
+    nv1 = _choice(
+        1,
+        ["TOAN", "VAN"],
+        [("TOAN", Decimal("8.0"), Decimal("10")),
+         ("VAN", Decimal("7.0"), Decimal("10"))],
+    )
+    # NV2 data-complete nhưng điểm rất thấp (dưới mọi sàn). Helper chỉ check
+    # data-complete → vẫn pass (contract: "nộp" ≠ "trúng tuyển").
+    nv2 = _choice(
+        2,
+        ["TOAN", "VAN"],
+        [("TOAN", Decimal("1.0"), Decimal("10")),
+         ("VAN", Decimal("1.0"), Decimal("10"))],
+    )
+    assert validate_choice_scores_complete([nv1, nv2], {}) == []
+
+
+def test_missing_subject_returns_one_error_naming_nv_and_subject():
+    """(2) NV2 thiếu 1 môn tổ hợp → đúng 1 lỗi nêu NV2 + môn thiếu."""
+    nv1 = _choice(
+        1,
+        ["TOAN", "VAN"],
+        [("TOAN", Decimal("8"), Decimal("10")),
+         ("VAN", Decimal("7"), Decimal("10"))],
+    )
+    nv2 = _choice(
+        2,
+        ["TOAN", "VAN"],
+        [("TOAN", Decimal("8"), Decimal("10"))],  # VAN missing
+    )
+    errs = validate_choice_scores_complete([nv1, nv2], {})
+    assert len(errs) == 1
+    assert "NV2" in errs[0]
+    assert "VAN" in errs[0]
+
+
+def test_zero_choices_returns_empty():
+    """(3) 0 choice → [] (≥1-choice gate enforced bởi caller, not helper)."""
+    assert validate_choice_scores_complete([], {}) == []
+
+
+def test_out_of_range_score_returns_error():
+    """(4) Điểm > max_score_snapshot → lỗi 'không hợp lệ' nêu môn."""
+    nv1 = _choice(1, ["TOAN"], [("TOAN", Decimal("11.0"), Decimal("10"))])
+    errs = validate_choice_scores_complete([nv1], {})
+    assert any("không hợp lệ" in e and "TOAN" in e for e in errs)
+
+
+def test_negative_score_returns_error():
+    """(4b) Điểm < 0 → lỗi 'không hợp lệ'."""
+    nv1 = _choice(1, ["TOAN"], [("TOAN", Decimal("-1"), Decimal("10"))])
+    errs = validate_choice_scores_complete([nv1], {})
+    assert any("không hợp lệ" in e for e in errs)
+
+
+def test_config_gap_empty_allowed_fail_closed():
+    """(5) Config-gap allowed==[] → fail-closed 'tổ hợp chưa cấu hình môn'."""
+    nv1 = _choice(1, [], [])  # subject_group has no mappings
+    errs = validate_choice_scores_complete([nv1], {})
+    assert len(errs) == 1
+    assert "NV1" in errs[0]
+    assert "chưa cấu hình môn" in errs[0]
+
+
+def test_best_n_required_less_than_allowed_no_overblock():
+    """(6) best_n: required_subject_count=2 < allowed=3, nhập đủ 2 → pass."""
+    nv1 = _choice(
+        1,
+        ["TOAN", "VAN", "ANH"],
+        [("TOAN", Decimal("8"), Decimal("10")),
+         ("VAN", Decimal("7"), Decimal("10"))],  # 2 of 3 entered
+    )
+    applied = {"required_subject_count": 2, "subject_selection_mode": "best_n"}
+    assert validate_choice_scores_complete([nv1], applied) == []
+
+
+def test_best_n_below_required_still_blocks():
+    """(6b) best_n: required=2 nhưng chỉ nhập 1 → vẫn báo thiếu (đúng gate)."""
+    nv1 = _choice(
+        1,
+        ["TOAN", "VAN", "ANH"],
+        [("TOAN", Decimal("8"), Decimal("10"))],  # only 1 of required 2
+    )
+    applied = {"required_subject_count": 2, "subject_selection_mode": "best_n"}
+    errs = validate_choice_scores_complete([nv1], applied)
+    assert len(errs) == 1
+    assert "NV1" in errs[0] and "cần 2" in errs[0]
+
+
+def test_per_choice_criteria_stricter_than_snapshot_blocks():
+    """(7) Mixed criteria — NV2 path criteria stricter than the snapshot.
+
+    applied_rules.required=2, NV2.criteria.required=3, chỉ nhập 2 môn → NV2
+    PHẢI fail (gate đọc per-choice criteria, KHÔNG dùng snapshot=2)."""
+    nv1 = _choice(
+        1,
+        ["TOAN", "VAN"],
+        [("TOAN", Decimal("8"), Decimal("10")),
+         ("VAN", Decimal("7"), Decimal("10"))],
+        criteria_required=2,
+    )
+    nv2 = _choice(
+        2,
+        ["TOAN", "VAN", "ANH"],
+        [("TOAN", Decimal("8"), Decimal("10")),
+         ("VAN", Decimal("7"), Decimal("10"))],  # 2 entered, criteria needs 3
+        criteria_required=3,
+    )
+    errs = validate_choice_scores_complete(
+        [nv1, nv2], {"required_subject_count": 2}
+    )
+    assert len(errs) == 1  # NV1 ok (criteria 2), NV2 fails (criteria 3)
+    assert "NV2" in errs[0] and "cần 3" in errs[0]
+
+
+def test_per_choice_best_n_looser_than_snapshot_passes():
+    """(8) Mixed criteria — NV2 path criteria best_n looser than snapshot.
+
+    applied_rules.required=3, NV2.criteria best_n required=2, nhập 2 môn →
+    PHẢI pass (gate đọc per-choice criteria, KHÔNG dùng snapshot=3)."""
+    nv1 = _choice(
+        1,
+        ["TOAN", "VAN", "ANH"],
+        [("TOAN", Decimal("8"), Decimal("10")),
+         ("VAN", Decimal("7"), Decimal("10")),
+         ("ANH", Decimal("6"), Decimal("10"))],
+        criteria_required=3,
+    )
+    nv2 = _choice(
+        2,
+        ["TOAN", "VAN", "ANH"],
+        [("TOAN", Decimal("8"), Decimal("10")),
+         ("VAN", Decimal("7"), Decimal("10"))],  # 2 of 3, best_n needs 2
+        criteria_required=2,
+        criteria_mode="best_n",
+    )
+    errs = validate_choice_scores_complete(
+        [nv1, nv2], {"required_subject_count": 3}
+    )
+    assert errs == []
+
+
+def test_best_n_out_of_range_extra_blocks_data_integrity():
+    """(9) best_n with a VALID best-N PLUS an out-of-range extra → BLOCKS.
+
+    The gate hard-rejects any out-of-range in-combo score (data integrity):
+    ``AdmissionScoringService.calculate_score`` does NOT range-check, so an
+    out-of-range value must never reach the T6 cascade (best_n could select
+    the inflated score). The candidate must fix/remove the bad entry — the
+    UI input is range-clamped, so this only fires on API/stale-snapshot data.
+    """
+    nv1 = _choice(
+        1,
+        ["TOAN", "VAN", "ANH"],
+        [("TOAN", Decimal("8"), Decimal("10")),
+         ("VAN", Decimal("7"), Decimal("10")),
+         ("ANH", Decimal("11"), Decimal("10"))],  # > max 10 → invalid
+        criteria_required=2,
+        criteria_mode="best_n",
+    )
+    errs = validate_choice_scores_complete([nv1], {})
+    assert any("không hợp lệ" in e and "ANH" in e for e in errs)
+
+
+def test_required_zero_falls_back_to_all_subjects():
+    """(10) required_subject_count=0 is fail-CLOSED to 'need ALL allowed', NOT
+    'zero required'. A choice with 1 of 2 combo subjects entered → blocks."""
+    nv1 = _choice(
+        1,
+        ["TOAN", "VAN"],
+        [("TOAN", Decimal("8"), Decimal("10"))],  # only 1 of 2
+        criteria_required=0,
+    )
+    errs = validate_choice_scores_complete([nv1], {})
+    assert len(errs) == 1
+    assert "NV1" in errs[0] and "cần 2" in errs[0]

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/AcademicCard.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/AcademicCard.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * AcademicCard — score-display branch tests.
+ *
+ * P0 hotfix multi-NV: when uses_choice_engine, the profile-level "Tổng Điểm
+ * Xét Tuyển" box is replaced by per-NV scores (total_score is null for
+ * multi-NV → would otherwise render "N/A"/0.00).
+ */
+
+import { describe, it, expect } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+import { AcademicCard } from "./AcademicCard"
+
+function buildProfile(overrides: Partial<Record<string, unknown>> = {}) {
+  const base = {
+    id: 1,
+    status: "submitted",
+    version: 1,
+    step_status: { "3": "success", "4": "success" },
+    grouped_validation_errors: { scores: { count: 0 } },
+    applied_rules: { method_type: "subject_based" },
+    total_score: 22.5,
+    average_score: 7.5,
+    admission_scores: { gpa: null, selected_group: "A00", subject_scores: {} },
+    uses_choice_engine: false,
+    choices: [],
+  }
+  return { ...base, ...overrides } as unknown as Parameters<
+    typeof AcademicCard
+  >[0]["profile"]
+}
+
+describe("AcademicCard — legacy single-NV", () => {
+  it("subject-based: hiển thị Tổng Điểm Xét Tuyển profile-level", () => {
+    render(<AcademicCard profile={buildProfile()} />)
+    expect(screen.getByText(/Tổng Điểm Xét Tuyển/)).toBeInTheDocument()
+    expect(screen.getByText("22.50")).toBeInTheDocument()
+  })
+})
+
+describe("AcademicCard — multi-NV (uses_choice_engine)", () => {
+  it("render per-NV thay vì Tổng Điểm Xét Tuyển profile-level (KHÔNG N/A/0.00)", () => {
+    const profile = buildProfile({
+      uses_choice_engine: true,
+      total_score: null,
+      choices: [
+        {
+          id: 10,
+          admission_profile_id: 1,
+          admission_path_id: 5,
+          path_subject_group_config_id: 7,
+          display_order: 1,
+          decision: "pending",
+          display_path_name: "Y sỹ đa khoa 2026 - HSA - DOT_2",
+          display_program_name: "Y sỹ đa khoa",
+          display_degree_level: "Cao đẳng",
+          display_subject_group_name: "Toán-Hóa-Sinh",
+          scores: [],
+          data_complete: true,
+          computed_total_score: "24.50",
+          admission_threshold_passed: true,
+          threshold_failure_reasons: [],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    })
+    render(<AcademicCard profile={profile} />)
+    expect(screen.getByTestId("per-nv-score-summary")).toBeInTheDocument()
+    expect(screen.getByText("24.50")).toBeInTheDocument()
+    expect(screen.getByText("Y sỹ đa khoa")).toBeInTheDocument()
+    // profile-level box label must NOT render for multi-NV
+    expect(screen.queryByText(/Tổng Điểm Xét Tuyển/)).not.toBeInTheDocument()
+    expect(screen.queryByText("N/A")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/AcademicCard.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/AcademicCard.tsx
@@ -10,6 +10,7 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { GraduationCap, CheckCircle2, XCircle, AlertTriangle } from "lucide-react"
 import { HealthCheckItem } from "./HealthCheckItem"
+import { PerNvScoreSummary } from "./PerNvScoreSummary"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
 interface AcademicCardProps {
@@ -41,6 +42,8 @@ export function AcademicCard({ profile }: AcademicCardProps) {
     : "text-warning-600"
 
   // Determine which score to display
+  const isMultiNv = profile.uses_choice_engine === true
+  const choices = profile.choices ?? []
   const methodType = profile.applied_rules?.method_type
   const isGpaOnly = methodType === "gpa_only"
 
@@ -62,7 +65,16 @@ export function AcademicCard({ profile }: AcademicCardProps) {
       </CardHeader>
 
       <CardContent className="space-y-3">
-        {/* Score Display - Large */}
+        {/* Score Display - Large. P0 hotfix multi-NV: per-NV thay vì
+            profile-level total (null cho multi-NV). */}
+        {isMultiNv ? (
+          <div className="rounded-lg border border-info-200 bg-info-50/60 p-3">
+            <div className="mb-2 text-xs font-medium text-info-600">
+              Điểm Xét Tuyển Theo Nguyện Vọng
+            </div>
+            <PerNvScoreSummary choices={choices} compact />
+          </div>
+        ) : (
         <div className="bg-gradient-to-br from-info-50 to-info-100 rounded-lg p-4 border border-info-200">
           {isGpaOnly ? (
             // GPA-only method
@@ -101,6 +113,7 @@ export function AcademicCard({ profile }: AcademicCardProps) {
             </div>
           )}
         </div>
+        )}
 
         {/* Step 3: Academic History */}
         <HealthCheckItem

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/PerNvScoreSummary.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/PerNvScoreSummary.tsx
@@ -1,0 +1,125 @@
+/**
+ * PerNvScoreSummary Component
+ *
+ * P0 hotfix multi-NV (2026-06-04) — per-nguyện-vọng score summary (DISPLAY).
+ *
+ * Multi-NV profiles keep scores per choice (ProfileChoiceScore); the
+ * profile-level `total_score` is null. The backend computes each NV's
+ * `computed_total_score` + `data_complete` + `admission_threshold_passed`
+ * and the FE renders them verbatim (thin client — NO scoring math here).
+ *
+ * `admission_threshold_passed` is DISPLAY ONLY: being below the sàn does
+ * NOT block submit ("nộp" ≠ "trúng tuyển"), so it renders as a neutral
+ * reference badge, never a blocking error.
+ *
+ * Shared by ScoreReviewCard / ScoreSnapshot / AcademicCard so the
+ * profile-level "Tổng Điểm Xét Tuyển" never shows a misleading 0.00 for a
+ * multi-NV profile.
+ */
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import type { AdmissionProfileChoiceResponse } from "@/lib/zod/admission-choices"
+
+interface PerNvScoreSummaryProps {
+  choices: AdmissionProfileChoiceResponse[]
+  /** Tighter score font for the cockpit cards. */
+  compact?: boolean
+}
+
+export function PerNvScoreSummary({
+  choices,
+  compact = false,
+}: PerNvScoreSummaryProps) {
+  const ordered = [...choices].sort(
+    (a, b) => a.display_order - b.display_order,
+  )
+
+  if (ordered.length === 0) {
+    return (
+      <p
+        className="text-sm text-muted-foreground"
+        data-testid="per-nv-score-empty"
+      >
+        Chưa có nguyện vọng
+      </p>
+    )
+  }
+
+  return (
+    <ul className="space-y-2" data-testid="per-nv-score-summary">
+      {ordered.map((choice) => {
+        // computed_total_score is a Pydantic Decimal → arrives as a STRING
+        // ("7.50") over JSON (the Zod type infers `number` but the profile
+        // payload reaching these cards is not runtime-parsed). Coerce
+        // defensively so .toFixed never throws on a string.
+        const rawScore = choice.computed_total_score
+        const scoreNum =
+          rawScore === null || rawScore === undefined ? null : Number(rawScore)
+        const scoreLabel =
+          scoreNum !== null && !Number.isNaN(scoreNum)
+            ? scoreNum.toFixed(2)
+            : "—"
+        const title =
+          choice.display_program_name || choice.display_path_name || "—"
+
+        return (
+          <li
+            key={choice.id}
+            className="flex items-start justify-between gap-3 rounded-md border p-2"
+            data-testid={`per-nv-row-${choice.id}`}
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5">
+                <span className="shrink-0 text-xs font-semibold text-muted-foreground">
+                  NV{choice.display_order}
+                </span>
+                <span className="truncate text-sm font-medium" title={title}>
+                  {title}
+                </span>
+              </div>
+              {choice.display_subject_group_name && (
+                <span className="text-xs text-muted-foreground">
+                  {choice.display_subject_group_name}
+                </span>
+              )}
+            </div>
+
+            <div className="flex shrink-0 flex-col items-end gap-1">
+              <span
+                className={`font-bold tabular-nums text-info-700 ${
+                  compact ? "text-lg" : "text-xl"
+                }`}
+                data-testid={`per-nv-score-${choice.id}`}
+              >
+                {scoreLabel}
+              </span>
+              <div className="flex items-center gap-1">
+                {choice.data_complete ? (
+                  <Badge variant="success" className="text-[10px]">
+                    Đủ điểm
+                  </Badge>
+                ) : (
+                  <Badge variant="warning" className="text-[10px]">
+                    Thiếu điểm
+                  </Badge>
+                )}
+                {/* DISPLAY ONLY — does not gate submit. */}
+                {choice.admission_threshold_passed === true && (
+                  <Badge variant="info" className="text-[10px]">
+                    Đạt sàn
+                  </Badge>
+                )}
+                {choice.admission_threshold_passed === false && (
+                  <Badge variant="outline" className="text-[10px]">
+                    Dưới sàn
+                  </Badge>
+                )}
+              </div>
+            </div>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/ScoreReviewCard.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/ScoreReviewCard.test.tsx
@@ -16,6 +16,8 @@ function buildProfile(opts: {
   totalScore?: number | null
   averageScore?: number | null
   selectedGroup?: string | null
+  usesChoiceEngine?: boolean
+  choices?: unknown[]
 } = {}): AdmissionProfileResponse {
   return {
     id: 1,
@@ -40,9 +42,44 @@ function buildProfile(opts: {
       selected_group: opts.selectedGroup ?? null,
       subject_scores: {},
     },
+    uses_choice_engine: opts.usesChoiceEngine ?? false,
+    choices: opts.choices ?? [],
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
   } as unknown as AdmissionProfileResponse
+}
+
+function buildChoice(opts: {
+  id?: number
+  displayOrder?: number
+  programName?: string
+  computedTotalScore?: number | string | null
+  dataComplete?: boolean
+  thresholdPassed?: boolean | null
+} = {}) {
+  return {
+    id: opts.id ?? 10,
+    admission_profile_id: 1,
+    admission_path_id: 5,
+    path_subject_group_config_id: 7,
+    display_order: opts.displayOrder ?? 1,
+    decision: "pending",
+    display_path_name: "Y sỹ đa khoa 2026 - HSA - DOT_2",
+    display_program_name: opts.programName ?? "Y sỹ đa khoa",
+    display_degree_level: "Cao đẳng",
+    display_subject_group_name: "Toán-Hóa-Sinh",
+    scores: [],
+    data_complete: opts.dataComplete ?? true,
+    // API serializes Pydantic Decimal as a STRING ("24.50") — mirror that so
+    // the test catches a string.toFixed() regression in PerNvScoreSummary.
+    computed_total_score:
+      opts.computedTotalScore === undefined ? "24.50" : opts.computedTotalScore,
+    admission_threshold_passed:
+      opts.thresholdPassed === undefined ? true : opts.thresholdPassed,
+    threshold_failure_reasons: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  }
 }
 
 describe("ScoreReviewCard — GPA-only method", () => {
@@ -100,5 +137,54 @@ describe("ScoreReviewCard — subject-based method", () => {
     render(<ScoreReviewCard profile={profile} />)
     expect(screen.getByText("18.00")).toBeInTheDocument()
     expect(screen.queryByText(/Trung bình/)).not.toBeInTheDocument()
+  })
+})
+
+describe("ScoreReviewCard — multi-NV (uses_choice_engine)", () => {
+  it("render per-NV computed score + 'Đủ điểm', KHÔNG dùng total_score profile-level (KHÔNG 0.00)", () => {
+    const profile = buildProfile({
+      usesChoiceEngine: true,
+      totalScore: null, // BE sets None for multi-NV
+      choices: [
+        buildChoice({ computedTotalScore: "24.50", dataComplete: true, thresholdPassed: true }),
+      ],
+    })
+    render(<ScoreReviewCard profile={profile} />)
+    expect(screen.getByTestId("per-nv-score-summary")).toBeInTheDocument()
+    expect(screen.getByText("Y sỹ đa khoa")).toBeInTheDocument()
+    expect(screen.getByText("24.50")).toBeInTheDocument()
+    expect(screen.getByText("Đủ điểm")).toBeInTheDocument()
+    // profile-level "Tổng điểm" block must NOT render for multi-NV
+    expect(screen.queryByText(/^Tổng điểm/)).not.toBeInTheDocument()
+    expect(screen.queryByText("0.00")).not.toBeInTheDocument()
+  })
+
+  it("multi-NV choice thiếu điểm → '—' + 'Thiếu điểm' + warning icon", () => {
+    const profile = buildProfile({
+      usesChoiceEngine: true,
+      totalScore: null,
+      choices: [
+        buildChoice({ computedTotalScore: null, dataComplete: false, thresholdPassed: null }),
+      ],
+    })
+    render(<ScoreReviewCard profile={profile} />)
+    const card = screen.getByTestId("score-review-card")
+    expect(screen.getByText("—")).toBeInTheDocument()
+    expect(screen.getByText("Thiếu điểm")).toBeInTheDocument()
+    expect(card.querySelector(".text-warning-600")).toBeTruthy()
+  })
+
+  it("multi-NV dưới sàn vẫn data_complete → 'Đủ điểm' + 'Dưới sàn' (display only, KHÔNG chặn)", () => {
+    const profile = buildProfile({
+      usesChoiceEngine: true,
+      totalScore: null,
+      choices: [
+        buildChoice({ computedTotalScore: "12.00", dataComplete: true, thresholdPassed: false }),
+      ],
+    })
+    render(<ScoreReviewCard profile={profile} />)
+    expect(screen.getByText("12.00")).toBeInTheDocument()
+    expect(screen.getByText("Đủ điểm")).toBeInTheDocument()
+    expect(screen.getByText("Dưới sàn")).toBeInTheDocument()
   })
 })

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/ScoreReviewCard.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/ScoreReviewCard.tsx
@@ -3,6 +3,7 @@
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { Calculator, CheckCircle2, AlertTriangle } from "lucide-react"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+import { PerNvScoreSummary } from "./PerNvScoreSummary"
 
 interface ScoreReviewCardProps {
   profile: AdmissionProfileResponse
@@ -11,8 +12,14 @@ interface ScoreReviewCardProps {
 /**
  * Cockpit card cho § điểm xét tuyển. BE-driven: đọc total_score /
  * average_score / admission_scores root-level fields.
+ *
+ * P0 hotfix multi-NV: khi uses_choice_engine, total_score profile-level là
+ * null → render điểm per-NV (PerNvScoreSummary) thay vì "—"/0.00.
  */
 export function ScoreReviewCard({ profile }: ScoreReviewCardProps) {
+  const isMultiNv = profile.uses_choice_engine === true
+  const choices = profile.choices ?? []
+
   const methodType = profile.applied_rules?.method_type
   const isGpaOnly = methodType === "gpa_only"
 
@@ -21,7 +28,9 @@ export function ScoreReviewCard({ profile }: ScoreReviewCardProps) {
   const averageScore = profile.average_score
   const selectedGroup = profile.admission_scores?.selected_group
 
-  const hasScore = isGpaOnly
+  const hasScore = isMultiNv
+    ? choices.length > 0 && choices.every((c) => c.data_complete)
+    : isGpaOnly
     ? gpa !== null && gpa !== undefined
     : totalScore !== null && totalScore !== undefined
 
@@ -41,7 +50,9 @@ export function ScoreReviewCard({ profile }: ScoreReviewCardProps) {
       </CardHeader>
 
       <CardContent className="space-y-2 text-sm">
-        {isGpaOnly ? (
+        {isMultiNv ? (
+          <PerNvScoreSummary choices={choices} compact />
+        ) : isGpaOnly ? (
           <div className="flex justify-between items-baseline">
             <span className="text-muted-foreground">GPA:</span>
             <span className="font-bold text-2xl tabular-nums">

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/ScoreSnapshot.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/ScoreSnapshot.test.tsx
@@ -311,3 +311,47 @@ describe("ScoreSnapshot — weighted breakdown (PR6 Step 3)", () => {
     expect(screen.getByText("24.00")).toBeInTheDocument()
   })
 })
+
+describe("ScoreSnapshot — multi-NV (uses_choice_engine)", () => {
+  function buildMultiNvProfile() {
+    return buildProfile({
+      uses_choice_engine: true,
+      total_score: null,
+      choices: [
+        {
+          id: 10,
+          admission_profile_id: 1,
+          admission_path_id: 5,
+          path_subject_group_config_id: 7,
+          display_order: 1,
+          decision: "pending",
+          display_path_name: "Y sỹ đa khoa 2026 - HSA - DOT_2",
+          display_program_name: "Y sỹ đa khoa",
+          display_degree_level: "Cao đẳng",
+          display_subject_group_name: "Toán-Hóa-Sinh",
+          scores: [],
+          data_complete: true,
+          computed_total_score: "24.50",
+          admission_threshold_passed: true,
+          threshold_failure_reasons: [],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    })
+  }
+
+  it("render collapsible 'Điểm Theo Nguyện Vọng' + per-NV score, KHÔNG bảng snapshot profile-level", () => {
+    render(<ScoreSnapshot profile={buildMultiNvProfile()} />)
+    const trigger = screen.getByRole("button", { name: /điểm theo nguyện vọng/i })
+    fireEvent.click(trigger)
+
+    expect(screen.getByTestId("per-nv-score-summary")).toBeInTheDocument()
+    expect(screen.getByText("Y sỹ đa khoa")).toBeInTheDocument()
+    expect(screen.getByText("24.50")).toBeInTheDocument()
+    // Legacy snapshot table label must NOT show for multi-NV
+    expect(
+      screen.queryByText(/snapshot điểm chuẩn/i),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/ScoreSnapshot.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/ScoreSnapshot.tsx
@@ -25,6 +25,7 @@ import {
 import { ChevronDown } from "lucide-react"
 import { useState } from "react"
 import { getSubjectLabel } from "@/lib/utils/admission-helpers"
+import { PerNvScoreSummary } from "./PerNvScoreSummary"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 
 interface ScoreSnapshotProps {
@@ -34,6 +35,8 @@ interface ScoreSnapshotProps {
 export function ScoreSnapshot({ profile }: ScoreSnapshotProps) {
   const [isOpen, setIsOpen] = useState(false)
 
+  const isMultiNv = profile.uses_choice_engine === true
+  const choices = profile.choices ?? []
   const methodType = profile.applied_rules?.method_type
   const isGpaOnly = methodType === "gpa_only"
   const allSubjectScores = profile.admission_scores?.subject_scores ?? {}
@@ -91,6 +94,30 @@ export function ScoreSnapshot({ profile }: ScoreSnapshotProps) {
     Object.keys(subjectWeights).length > 0
   const getWeight = (code: string): number =>
     subjectWeights[code] !== undefined ? subjectWeights[code] : 1.0
+
+  // P0 hotfix multi-NV — scores live per choice (ProfileChoiceScore), the
+  // profile-level snapshot table below is empty. Render per-NV instead.
+  if (isMultiNv) {
+    return (
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger className="flex items-center justify-between w-full p-4 hover:bg-muted/50 rounded-lg transition-colors border">
+          <div className="flex items-center gap-2">
+            <Calculator className="w-5 h-5 text-muted-foreground" />
+            <span className="font-semibold">Điểm Theo Nguyện Vọng</span>
+          </div>
+          <ChevronDown
+            className={`w-4 h-4 transition-transform ${
+              isOpen ? "transform rotate-180" : ""
+            }`}
+          />
+        </CollapsibleTrigger>
+
+        <CollapsibleContent className="p-4 border border-t-0 rounded-b-lg">
+          <PerNvScoreSummary choices={choices} />
+        </CollapsibleContent>
+      </Collapsible>
+    )
+  }
 
   // If GPA-only method, show message
   if (isGpaOnly) {

--- a/frontend/src/components/admissions/ChoiceListEditor/ChoiceListEditor.test.tsx
+++ b/frontend/src/components/admissions/ChoiceListEditor/ChoiceListEditor.test.tsx
@@ -51,6 +51,10 @@ function makeChoice(
     display_degree_level: "Cao đẳng",
     display_subject_group_name: "Toán-Lý-Hoá",
     scores: [],
+    data_complete: false,
+    computed_total_score: null,
+    admission_threshold_passed: null,
+    threshold_failure_reasons: [],
     ...overrides,
   }
 }

--- a/frontend/src/components/admissions/ChoiceScoreCard/ChoiceScoreCard.test.tsx
+++ b/frontend/src/components/admissions/ChoiceScoreCard/ChoiceScoreCard.test.tsx
@@ -67,6 +67,10 @@ function makeChoice(
         weight_snapshot: 1,
       },
     ],
+    data_complete: false,
+    computed_total_score: null,
+    admission_threshold_passed: null,
+    threshold_failure_reasons: [],
     ...overrides,
   }
 }

--- a/frontend/src/lib/zod/admission-choices.ts
+++ b/frontend/src/lib/zod/admission-choices.ts
@@ -67,6 +67,22 @@ export const admissionProfileChoiceResponseSchema = z.object({
   display_degree_level: z.string().default(""),
   display_subject_group_name: z.string(),
   scores: z.array(choiceScoreSummarySchema),
+  // P0 hotfix multi-NV (2026-06-04) — per-NV computed score for display.
+  // profile.total_score is null for multi-NV; FE renders these per choice.
+  // `data_complete` mirrors the submit gate (no sàn);
+  // `admission_threshold_passed` is DISPLAY ONLY (sàn enforced at publish).
+  data_complete: z.boolean().default(false),
+  computed_total_score: z
+    .union([z.string(), z.number()])
+    .nullable()
+    .optional()
+    .transform((v) => (v === null || v === undefined ? null : Number(v))),
+  admission_threshold_passed: z
+    .boolean()
+    .nullable()
+    .optional()
+    .transform((v) => (v === undefined ? null : v)),
+  threshold_failure_reasons: z.array(z.string()).default([]),
 })
 export type AdmissionProfileChoiceResponse = z.infer<
   typeof admissionProfileChoiceResponseSchema


### PR DESCRIPTION
## P0 — Hồ sơ multi-NV không nộp được

Phase 3 chuyển điểm sang per-choice `ProfileChoiceScore`, nhưng eligibility/completion/submit/total vẫn đọc `ProfileSubjectScore` profile-level → mọi hồ sơ multi-NV: `total=0`, "Không đủ điều kiện", **không có nút Nộp**. Scope = toàn bộ round multi-NV (DOT_2 đang mở). Prod 0 multi-NV profile → chưa lộ, nhưng sẽ chặn mọi hồ sơ thật.

## Thay đổi

**Backend**
- `validate_choice_scores_complete()` — gate nộp per-NV *data-complete* (`|submitted∩allowed| ≥ required` + range hợp lệ), **KHÔNG** gate min_score/sàn (sàn để T6 publish per-NV). `required`/`mode` đọc **per-choice** từ `choice.admission_path.criteria` (khớp display + T6), fallback `applied_rules` chỉ khi choice thiếu criteria.
- `_validate_scores` / `_compute_completion_percent` / `_compute_frontend_fields` (step_status[5] + submit-perm) / submit gate: branch `uses_choice_engine` đọc choices. `_calculate_and_update_totals` set `None` cho multi-NV (thay `0.0`). Submit-perm guard ≥1 choice.
- Schema +4 field per-NV: `data_complete` / `computed_total_score` / `admission_threshold_passed` (display-only) / `threshold_failure_reasons`.
- Eager-load (8a–8e) + `_populate_response_fields` defensive `set_committed_value` → chống MissingGreenlet trên list/detail/mutation.

**Frontend**
- `PerNvScoreSummary` + branch `uses_choice_engine` ở `ScoreReviewCard` / `ScoreSnapshot` / `AcademicCard` (render per-NV thay total profile-level; coerce Decimal-string qua `Number()`).
- Zod `admission-choices` +4 field mirror Pydantic.

## Hardening (code-review max + Chrome smoke dev #42)
- FIX `string.toFixed` crash trên Decimal-string (smoke bắt).
- FIX `step_status[5]` multi-NV-aware (đồng bộ `completion_percent`).
- `data_complete` (display) reuse `validate_choice_scores_complete` = **1 nguồn** với submit gate → badge không mâu thuẫn nút Nộp.
- `threshold_failure_reasons` chỉ set khi VALID (hết conflate thiếu-môn vs sàn).
- `log.warning` khi choices unloaded (fail-open observable).

## Test
- **12 unit** (`test_validate_choice_scores_complete`: mixed per-choice criteria, best_n out-of-range, required=0) + **13 service** (`test_multi_nv_submit_gate`: submit-gate data-path, per-choice criteria from DB, totals None vs legacy, GET detail/list no-MissingGreenlet, step_status[5]=success, _populate 8d defensive) — one-off container, qlts_test.
- FE: type-check pass + **1468 vitest** pass.
- **Chrome smoke #42 dev**: per-NV render đúng (NV1 "—"/Thiếu điểm, NV2/NV3 7.50/Đủ điểm/Đạt sàn), không 500, `total_score=null`, list 200.

## Rủi ro / Defer
- **Không migration**. Rollback = revert (prod 0 multi-NV → 0 data impact). Off `main`, tách khỏi IDOR #376.
- Defer (efficiency/altitude, PR follow-up): per-row `calculate_score` trên list; eager-load nặng vào export 10k + update FOR-UPDATE + 8d re-query mỗi mutation; gom 6 nhánh `uses_choice_engine` về 1 resolver.
- Defer (Phase-4): wire `weight_snapshot` vào CẢ display (schema) lẫn T6 cascade (`_evaluate_single_choice:507`) — hiện cả hai cùng `subject_weights=None` (đã khớp), wire 1 bên sẽ tạo lệch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
