### PR TITLE
fix(admin): TS2026 smoke UI cleanup — loại bản + bậc combobox + clone display_name

### DIFF
--- a/Backend_FastAPI/app/services/path_clone_service.py
+++ b/Backend_FastAPI/app/services/path_clone_service.py
@@ -200,7 +200,12 @@ class PathCloneService:
                 admission_round_id=target_round_id,
                 criteria_id=new_criteria_id,
                 status="draft",  # cloned paths start draft
-                display_name=f"{src_path.display_name or 'Path'} (cloned)",
+                # Copy display_name as-is. Cloned paths live in a DIFFERENT
+                # round (round_code disambiguates), so the old " (cloned)"
+                # suffix only leaked to the storefront/admin UI looking unclean
+                # (TS2026 smoke finding #1). The criteria name keeps its
+                # "(cloned từ round X)" trace for internal audit.
+                display_name=src_path.display_name,
                 display_order=src_path.display_order,
                 visibility=src_path.visibility,
                 application_fee=src_path.application_fee,

--- a/Backend_FastAPI/tests/services/test_phase2_pr2d_path_clone_service.py
+++ b/Backend_FastAPI/tests/services/test_phase2_pr2d_path_clone_service.py
@@ -127,6 +127,12 @@ async def test_clone_creates_new_criteria_with_derived_code(
         cloned_path = await s.get(models.AdmissionPath, cloned_item.cloned_path_id)
         assert cloned_path.criteria_id != clone_seed["source_criteria_id"]
         assert cloned_path.admission_round_id == clone_seed["target_round_id"]
+        # TS2026 smoke #1 — display_name copied AS-IS (no " (cloned)" suffix).
+        # Cloned paths live in a different round (round_code disambiguates);
+        # the old suffix only leaked to the storefront/admin UI looking unclean.
+        # Locks the contract so a future edit can't re-introduce the suffix.
+        assert cloned_path.display_name == "Source path"
+        assert "(cloned)" not in (cloned_path.display_name or "")
 
 
 @pytest.mark.asyncio

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/SharedDocumentConfigPanel.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase1Master/SharedDocumentConfigPanel.tsx
@@ -25,6 +25,7 @@ import {
   usePreviewSharedDocuments,
 } from "@/hooks/admissions/useMasterData";
 import { AUDIENCE_LABELS } from "@/lib/zod/admission-path";
+import { getShortFormatLabel, type DocumentFormatCode } from "@/lib/utils/admission-helpers";
 import { DocumentType, OfferingType } from "../shared/types";
 
 interface DocSelection {
@@ -45,6 +46,13 @@ interface SharedDocItem {
 
 // Sentinel cho lớp NỀN trong Select (Radix value phải là string non-empty).
 const NEN = "__NEN__";
+
+// Sentinel cho "không yêu cầu loại bản" (submission_format=null) — Radix
+// Select value phải non-empty string. Cho phép officer set Gốc/Chứng thực/
+// Chụp-scan trực tiếp ở màn này (trước đây bảng chỉ có Bắt buộc/Up file/Thứ tự
+// → submission_format luôn NULL → cột "Yêu cầu" tab Tài liệu hiện "—").
+const FMT_NONE = "__FMT_NONE__";
+const FORMAT_CODES: DocumentFormatCode[] = ["original", "certified_copy", "photo"];
 
 // Nhãn trình độ văn hóa cho dialog Xem trước (display-only, mirror BE enum).
 const CULTURAL_LABELS: Record<string, string> = {
@@ -400,10 +408,11 @@ export function SharedDocumentConfigPanel() {
               <div className="space-y-6">
                 <div className="border rounded-lg overflow-hidden">
                   <div className="grid grid-cols-12 bg-muted/50 p-3 text-sm font-medium border-b">
-                    <div className="col-span-6">Loại giấy tờ</div>
+                    <div className="col-span-4">Loại giấy tờ</div>
                     <div className="col-span-2 text-center">Bắt buộc</div>
                     <div className="col-span-2 text-center">Yêu cầu up file</div>
-                    <div className="col-span-2 text-center">Thứ tự</div>
+                    <div className="col-span-3 text-center">Loại bản</div>
+                    <div className="col-span-1 text-center">Thứ tự</div>
                   </div>
 
                   <div className="max-h-[500px] overflow-y-auto">
@@ -425,6 +434,9 @@ export function SharedDocumentConfigPanel() {
                       const orderText = nenItem
                         ? nenItem.display_order
                         : current?.display_order || "-";
+                      const formatValue = nenItem
+                        ? nenItem.submission_format
+                        : current?.submission_format ?? null;
 
                       return (
                         <div
@@ -437,7 +449,7 @@ export function SharedDocumentConfigPanel() {
                                 : ''
                           }`}
                         >
-                          <div className="col-span-6 flex items-center gap-3">
+                          <div className="col-span-4 flex items-center gap-3">
                             <Checkbox
                               id={`doc-${type.id}`}
                               checked={isSelected}
@@ -476,7 +488,36 @@ export function SharedDocumentConfigPanel() {
                             />
                           </div>
 
-                          <div className="col-span-2 flex justify-center text-xs text-muted-foreground">
+                          <div className="col-span-3 flex justify-center">
+                            <Select
+                              value={formatValue ?? FMT_NONE}
+                              disabled={isInheritedNen || !isSelected}
+                              onValueChange={(v) =>
+                                handleUpdate(
+                                  type.id,
+                                  'submission_format',
+                                  v === FMT_NONE ? null : v,
+                                )
+                              }
+                            >
+                              <SelectTrigger
+                                className="h-8 w-full"
+                                aria-label={`Loại bản giấy ${type.name}`}
+                              >
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value={FMT_NONE}>Không yêu cầu</SelectItem>
+                                {FORMAT_CODES.map((code) => (
+                                  <SelectItem key={code} value={code}>
+                                    {getShortFormatLabel(code)}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </div>
+
+                          <div className="col-span-1 flex justify-center text-xs text-muted-foreground">
                              {orderText}
                           </div>
                         </div>

--- a/frontend/src/components/common/selectors/SmartOfferingSelector.tsx
+++ b/frontend/src/components/common/selectors/SmartOfferingSelector.tsx
@@ -75,6 +75,7 @@ export interface SmartOfferingSelectorProps {
 
 interface ProcessedOffering extends ProgramOffering {
   displayName: string;
+  triggerName: string;
   programName: string;
   degreeLevel: string;
   searchText: string;
@@ -91,6 +92,16 @@ const DEGREE_LEVEL_LABELS: Record<string, string> = {
   "Đại học": "🎓 ĐẠI HỌC",
   "Cao đẳng": "📚 CAO ĐẲNG",
   "Trung cấp": "📖 TRUNG CẤP",
+};
+
+// Compact bậc cho nhãn TRIGGER (giá trị đã chọn). Dropdown đã phân nhóm theo
+// bậc, nhưng khi đóng lại trigger mất ngữ cảnh nhóm → "Công nghệ ô tô" không
+// phân biệt được TC vs CĐ (2 offering cùng tên khác bậc). Thêm bậc rút gọn vào
+// nhãn trigger để disambiguate.
+const DEGREE_LEVEL_SHORT: Record<string, string> = {
+  "Đại học": "ĐH",
+  "Cao đẳng": "CĐ",
+  "Trung cấp": "TC",
 };
 
 // =============================================================================
@@ -125,14 +136,21 @@ function processOfferings(
       const degreeLevel = offering.program?.degree_level || "Khác";
       const offeringType = offering.offering_type || "Chính quy";
 
+      const shortLevel = DEGREE_LEVEL_SHORT[degreeLevel];
       return {
         ...offering,
-        // Display format: "Ngành - Loại hình"
+        // Display format trong dropdown: "Ngành - Loại hình" (bậc đã ở group header)
         displayName: `${programName} - ${offeringType}`,
+        // Nhãn TRIGGER kèm bậc (TC/CĐ/ĐH) để giá trị đã chọn không nhập nhằng
+        // khi mất ngữ cảnh nhóm.
+        triggerName: shortLevel
+          ? `${programName} (${shortLevel}) - ${offeringType}`
+          : `${programName} - ${offeringType}`,
         programName,
         degreeLevel,
-        // Search text includes all relevant fields
-        searchText: `${programName} ${offeringType} ${degreeLevel}`.toLowerCase(),
+        // Search text includes all relevant fields + the short bậc (TC/CĐ/ĐH)
+        // so a user who sees "(TC)" in the trigger can type "TC" to find it.
+        searchText: `${programName} ${offeringType} ${degreeLevel} ${shortLevel ?? ""}`.toLowerCase(),
       };
     })
     .sort((a, b) => {
@@ -211,7 +229,7 @@ function SelectVariant({
       <SelectTrigger className={className}>
         <SelectValue placeholder={isLoading ? "Đang tải…" : placeholder}>
           {selectedOffering && (
-            <span className="truncate">{selectedOffering.displayName}</span>
+            <span className="truncate">{selectedOffering.triggerName}</span>
           )}
         </SelectValue>
       </SelectTrigger>
@@ -312,7 +330,7 @@ function ComboboxVariant({
   };
 
   const displayValue = selectedOffering
-    ? selectedOffering.displayName
+    ? selectedOffering.triggerName
     : value === "all" || !value
       ? allLabel
       : placeholder;


### PR DESCRIPTION
3 finding nhỏ từ smoke hồ sơ thật #25 (2026-06-04), độc lập multi-NV hotfix #377.

## Thay đổi
- **#6 `SharedDocumentConfigPanel`** — thêm cột **"Loại bản"** (Select Gốc/Chứng thực/Chụp-scan) wire `submission_format`. Officer set được loại bản trực tiếp ở màn "Cấu hình Hồ sơ chung" (trước bảng chỉ Bắt buộc/Up file/Thứ tự → `submission_format` luôn NULL → cột "Yêu cầu" tab Tài liệu hiện "—"; **gốc rễ DQ #5**). BE đã nhận `submission_format` sẵn (schema + router) — chỉ thiếu control FE.
- **#3 `SmartOfferingSelector`** — nhãn **trigger** kèm bậc `(TC)/(CĐ)/(ĐH)` → 2 offering cùng tên khác bậc hết nhập nhằng khi đóng dropdown. `searchText` cũng kèm bậc rút gọn (gõ "TC" tìm được). Dropdown giữ nguyên (group header đã có bậc). Shared component → lợi mọi caller (LeadDialog/LeadFilters/DistributionRuleDialog).
- **#1 `path_clone_service`** — clone path copy `display_name` as-is, **bỏ hậu tố " (cloned)"** (cloned path ở round khác → `round_code` đã disambiguate; hậu tố chỉ leak ra storefront/admin nhìn bẩn). Criteria name giữ "(cloned từ round X)" cho audit.

## Test / Verify
- FE **type-check** pass + **1462 vitest** pass.
- BE **clone test 7 pass** — +assertion `cloned_path.display_name == src` (no suffix, khoá contract chống regression).
- **Chrome smoke DEV** màn "Cấu hình Hồ sơ chung": cột "Loại bản" render (5 cột) + load format hiện hữu + set → Lưu (PUT 200) → reload **persist** OK.

## Defer / Follow-up
- **DQ #1 data**: 32 path "(cloned)" hiện hữu ở prod cần SQL one-off strip (idempotent, chỉ hậu tố cuối) — chạy **SAU** khi PR này deploy (kẻo clone mới re-add). Cần approval prod.
- **DQ #4** (lọc "Thêm NV" theo eligibility) = BE feature → PR riêng.
- panel vitest: defer (Chrome smoke đã phủ end-to-end).

Không migration. Off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
