### PR TITLE
fix(admission): completed_thcs vào TC (TT22) + guard TC sức khỏe đóng đầu vào THCS 2026

### DIFF
--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -444,13 +444,14 @@ def _evaluate_single_choice(
     # imports app.models → circular dep nếu top-level import.
     try:
         from app.services.priority_service import (
+            derive_major_code,
             derive_target_level_and_type,
             validate_eligibility,
         )
 
         target_level, admission_type = derive_target_level_and_type(path)
         passed_elig, elig_reason = validate_eligibility(
-            profile, target_level, admission_type
+            profile, target_level, admission_type, derive_major_code(path)
         )
         if not passed_elig:
             reason_codes.append(f"ELIGIBILITY_FAIL:{elig_reason}")
@@ -850,6 +851,7 @@ async def evaluate_cascade(
         # create a circular dep at module load time of this engine file.
         from app.services.priority_service import (
             calculate_priority_bonus,
+            derive_major_code,
             derive_profile_target_context,
             derive_target_level_and_type,
             freeze_priority_snapshot,
@@ -875,7 +877,7 @@ async def evaluate_cascade(
             try:
                 t6_target_level, t6_admission_type = derive_target_level_and_type(path)
                 ok, reason = validate_eligibility(
-                    profile, t6_target_level, t6_admission_type
+                    profile, t6_target_level, t6_admission_type, derive_major_code(path)
                 )
                 t6_eligibility = {"passed": ok, "reason": reason}
             except Exception:  # noqa: BLE001

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4810,6 +4810,7 @@ async def _validate_eligibility_all_choices(
 
     from .priority_service import (
         _make_path_shim_from_academic_info,
+        derive_major_code,
         derive_target_level_and_type,
         validate_eligibility,
     )
@@ -4854,7 +4855,9 @@ async def _validate_eligibility_all_choices(
             choices_summary.append(
                 f"NV{choice.display_order}={target_level}/{admission_type}"
             )
-            ok, reason = validate_eligibility(profile, target_level, admission_type)
+            ok, reason = validate_eligibility(
+                profile, target_level, admission_type, derive_major_code(path)
+            )
             if not ok:
                 failures.append(
                     f"NV{choice.display_order} ({target_level}/{admission_type}): "
@@ -4909,7 +4912,9 @@ async def _validate_eligibility_all_choices(
         # pattern (xem priority_service._make_path_shim_from_academic_info).
         shim = _make_path_shim_from_academic_info(config.academic_info)
         target_level, admission_type = derive_target_level_and_type(shim)  # type: ignore[arg-type]
-        ok, reason = validate_eligibility(profile, target_level, admission_type)
+        ok, reason = validate_eligibility(
+            profile, target_level, admission_type, derive_major_code(shim)
+        )
         if not ok:
             failures.append(
                 f"Legacy single-path ({target_level}/{admission_type}): {reason}"

--- a/Backend_FastAPI/app/services/priority_service.py
+++ b/Backend_FastAPI/app/services/priority_service.py
@@ -218,8 +218,7 @@ async def _resolve_object_bonus(
     verified_codes = [
         c
         for c in codes
-        if isinstance(evidence.get(c), dict)
-        and evidence[c].get("status") == "verified"
+        if isinstance(evidence.get(c), dict) and evidence[c].get("status") == "verified"
     ]
     meta: dict[str, Any] = {
         "verified_codes": verified_codes,
@@ -316,7 +315,7 @@ def _derive_kv_basis_level(
     Phase E.4 (commit 5) refactor — signature mở rộng target_level +
     admission_type + academic_history để khớp matrix nghiệp vụ #6:
 
-      - TC sau THCS (target=trung_cap chính quy, cultural=graduated_thcs) → THUONG_TRU
+      - TC sau THCS (target=trung_cap chính quy, cultural=completed_thcs/graduated_thcs) → THUONG_TRU
       - TC sau THPT/hoàn thành THPT → LICH_SU_THPT
       - CĐ chính quy sau THPT/hoàn thành THPT → LICH_SU_THPT
       - CĐ chính quy hoàn thành THPT + TC → LICH_SU_THPT (extended TT path)
@@ -403,7 +402,7 @@ def _derive_kv_basis_level(
         if cultural == "completed_thpt":
             # CĐ chính quy + hoàn thành THPT đủ kiến thức → LICH_SU_THPT (nghiệp vụ #5)
             return "LICH_SU_THPT", f"cd_{atype}_completed_thpt_uses_school_history"
-        # Eligibility gate đã chặn graduated_thcs/completed_thcs cho CĐ chính quy.
+        # Eligibility gate đã chặn completed_thcs/graduated_thcs cho CĐ chính quy.
         # Defensive: nếu reach here → cấu hình mismatch upstream.
         return "INSUFFICIENT_DATA", f"cd_{atype}_cultural_insufficient_for_kv_basis"
 
@@ -411,16 +410,22 @@ def _derive_kv_basis_level(
     if target_level == "trung_cap":
         if atype == "lien_thong":
             # TC liên thông từ SC/TC sau THCS → THUONG_TRU
-            if cultural == "graduated_thcs" and voc in ("so_cap", "trung_cap"):
+            if cultural in ("completed_thcs", "graduated_thcs") and voc in (
+                "so_cap",
+                "trung_cap",
+            ):
                 return "THUONG_TRU", "tc_lien_thong_post_thcs_with_voc_uses_commune"
             # TC liên thông có THPT/hoàn thành THPT → LICH_SU_THPT
             if cultural in ("completed_thpt", "graduated_thpt", "graduated_gdtx"):
                 return "LICH_SU_THPT", "tc_lien_thong_post_thpt_uses_school_history"
-            return "INSUFFICIENT_DATA", "tc_lien_thong_cultural_insufficient_for_kv_basis"
+            return (
+                "INSUFFICIENT_DATA",
+                "tc_lien_thong_cultural_insufficient_for_kv_basis",
+            )
         # TC chính quy:
-        # - TN_THCS → THUONG_TRU
+        # - Hoàn thành/TN_THCS → THUONG_TRU
         # - completed/graduated THPT/GDTX → LICH_SU_THPT
-        if cultural == "graduated_thcs":
+        if cultural in ("completed_thcs", "graduated_thcs"):
             return "THUONG_TRU", "tc_chinh_quy_post_thcs_uses_commune"
         if cultural in ("completed_thpt", "graduated_thpt", "graduated_gdtx"):
             return "LICH_SU_THPT", "tc_chinh_quy_post_thpt_uses_school_history"
@@ -650,7 +655,8 @@ async def resolve_kv_for_profile(
     accepted_levels = {"THPT", "THCS_THPT", "GDTX"}
 
     basis_entries = [
-        e for e in academic_history
+        e
+        for e in academic_history
         if isinstance(e, dict)
         and e.get("level") in accepted_levels
         and e.get("school_id")
@@ -689,13 +695,15 @@ async def resolve_kv_for_profile(
             else:
                 missing_lookups.append({"school_id": sid, "year": year})
 
-        breakdown_entries.append({
-            "school_id": sid,
-            "school_name_at_time": entry.get("school_name"),
-            "year_from": y_from,
-            "year_to": y_to,
-            "years_by_kv": entry_years_by_kv,
-        })
+        breakdown_entries.append(
+            {
+                "school_id": sid,
+                "school_name_at_time": entry.get("school_name"),
+                "year_from": y_from,
+                "year_to": y_to,
+                "years_by_kv": entry_years_by_kv,
+            }
+        )
 
     if not kv_years:
         # Tất cả lookup miss → vn_school_kv_assignment thiếu catalog cho 100%
@@ -746,10 +754,9 @@ async def resolve_kv_for_profile(
     if len(sorted_entries) >= 2:
         top_entry = sorted_entries[0][1]
         second_entry = sorted_entries[1][1]
-        if (
-            top_entry.get("year_to") == second_entry.get("year_to")
-            and top_entry.get("grade_to") == second_entry.get("grade_to")
-        ):
+        if top_entry.get("year_to") == second_entry.get("year_to") and top_entry.get(
+            "grade_to"
+        ) == second_entry.get("grade_to"):
             return None, _meta_base(
                 rule_applied="ambiguous_requires_manual",
                 pathway=pathway,
@@ -894,8 +901,10 @@ def _make_path_shim_from_academic_info(academic_info: Any) -> Any:
     placeholder=None (legacy không có method chain — bonus_rule context fall
     về admission_method default).
     """
+
     class _PathShim:
         pass
+
     shim = _PathShim()
     shim.__dict__["academic_info"] = academic_info
     shim.__dict__["admission_method"] = None
@@ -992,10 +1001,30 @@ def derive_target_level_and_type(path: "AdmissionPath") -> tuple[str, str]:
     return target_code, admission_type
 
 
+def derive_major_code(path: "AdmissionPath") -> Optional[str]:
+    """Lấy ``MajorProgram.code`` (mã ngành GDNN cấp IV) từ AdmissionPath chain.
+
+    Chain: AdmissionPath → academic_info → offering → program.code. Trả None
+    nếu chain chưa eager-load / thiếu (caller eager-load cùng lúc với
+    ``derive_target_level_and_type`` nên thực tế hai giá trị đi cùng nhau).
+    """
+    academic_info = path.__dict__.get("academic_info")
+    offering = academic_info.__dict__.get("offering") if academic_info else None
+    program = offering.__dict__.get("program") if offering else None
+    return getattr(program, "code", None) if program else None
+
+
+def _is_health_sector_code(major_code: Optional[str]) -> bool:
+    """Mã ngành GDNN cấp IV (TT 04/2017/TT-BLĐTBXH): chữ số 2-3 = '72' →
+    lĩnh vực Sức khỏe (vd 5720101 Y sỹ TC, 6720201 Dược CĐ)."""
+    return bool(major_code) and len(major_code) >= 3 and major_code[1:3] == "72"
+
+
 def validate_eligibility(
     profile: "AdmissionProfile",
     target_level: str,
     admission_type: str = "chinh_quy",
+    major_code: Optional[str] = None,
 ) -> tuple[bool, Optional[str]]:
     """Validate candidate eligibility for target program level + type.
 
@@ -1022,9 +1051,24 @@ def validate_eligibility(
     cultural = getattr(profile, "cultural_education_level", None)
     vocational = getattr(profile, "vocational_qualification", "none") or "none"
 
+    # === Compliance guard — Luật GDNN 2025 Điều 45 Khoản 2 ===
+    # TC lĩnh vực sức khỏe CHẤM DỨT tuyển sinh diện đầu-vào-THCS từ 01/01/2026.
+    # Chặn CẢ completed_thcs (thuật ngữ TT22) lẫn graduated_thcs (nhãn legacy
+    # cùng tầng đầu vào THCS) để không tạo bypass bằng nhãn cũ. Đầu vào THPT
+    # (completed/graduated_thpt, graduated_gdtx) + ngành khác KHÔNG bị chặn.
+    academic_year = getattr(profile, "academic_year", None)
+    if (
+        target_level in ("trung_cap", "TC")
+        and _is_health_sector_code(major_code)
+        and (academic_year or 0) >= 2026
+        and cultural in ("completed_thcs", "graduated_thcs")
+    ):
+        return False, "tc_health_thcs_entry_closed_2026"
+
     _THPT_GRADUATED = ("graduated_thpt", "graduated_gdtx")
     _THPT_KNOWLEDGE = ("completed_thpt", "graduated_thpt", "graduated_gdtx")
     _THCS_OR_HIGHER = (
+        "completed_thcs",
         "graduated_thcs",
         "completed_thpt",
         "graduated_thpt",
@@ -1159,8 +1203,9 @@ async def derive_profile_target_context(
                     models.AdmissionProfileChoice.display_order == 1,
                 )
                 .options(
-                    _sel_in(models.AdmissionProfileChoice.admission_path)
-                    .selectinload(models.AdmissionPath.admission_method),
+                    _sel_in(models.AdmissionProfileChoice.admission_path).selectinload(
+                        models.AdmissionPath.admission_method
+                    ),
                     _sel_in(models.AdmissionProfileChoice.admission_path)
                     .selectinload(models.AdmissionPath.academic_info)
                     .selectinload(models.OfferingAcademicInfo.offering)
@@ -1184,7 +1229,10 @@ async def derive_profile_target_context(
             # context sẽ là None cho legacy; engine fallback admission_method default.
             stmt = (
                 _sel(models.OfferingAdmissionConfig)
-                .where(models.OfferingAdmissionConfig.id == profile.offering_admission_config_id)
+                .where(
+                    models.OfferingAdmissionConfig.id
+                    == profile.offering_admission_config_id
+                )
                 .options(
                     _sel_in(models.OfferingAdmissionConfig.academic_info)
                     .selectinload(models.OfferingAcademicInfo.offering)
@@ -1220,7 +1268,10 @@ async def derive_profile_target_context(
             # path_bonus_rule snapshot: chain override → method.default.
             # Lazy import để tránh circular.
             try:
-                from .admission_choice_engine_service import resolve_effective_bonus_rule
+                from .admission_choice_engine_service import (
+                    resolve_effective_bonus_rule,
+                )
+
                 if hasattr(path, "bonus_rule_override") or method is not None:
                     rule = resolve_effective_bonus_rule(path)  # type: ignore[arg-type]
                     if rule is not None:
@@ -1237,7 +1288,10 @@ async def derive_profile_target_context(
         # Eligibility check audit — chỉ compute khi cả 2 field có.
         if ctx["target_level"] and ctx["admission_type"]:
             ok, reason = validate_eligibility(
-                profile, ctx["target_level"], ctx["admission_type"]
+                profile,
+                ctx["target_level"],
+                ctx["admission_type"],
+                derive_major_code(path),
             )
             ctx["eligibility"] = {"passed": ok, "reason": reason}
 

--- a/Backend_FastAPI/tests/unit/test_priority_eligibility.py
+++ b/Backend_FastAPI/tests/unit/test_priority_eligibility.py
@@ -8,6 +8,7 @@ Q9 #07 Phase E.4 — exercises:
 Pure-logic tests dùng SimpleNamespace + stub objects. KHÔNG cần DB; gọi
 helpers trực tiếp.
 """
+
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -15,6 +16,7 @@ from types import SimpleNamespace
 import pytest
 
 from app.services.priority_service import (
+    _is_health_sector_code,
     derive_target_level_and_type,
     normalize_target_level,
     validate_eligibility,
@@ -59,10 +61,15 @@ def _build_path(degree_level_code: str | None, offering_type_code: str | None):
     return path
 
 
-def _profile(cultural: str | None = None, vocational: str = "none"):
+def _profile(
+    cultural: str | None = None,
+    vocational: str = "none",
+    academic_year: int | None = None,
+):
     return SimpleNamespace(
         cultural_education_level=cultural,
         vocational_qualification=vocational,
+        academic_year=academic_year,
     )
 
 
@@ -214,6 +221,7 @@ def test_cd_lien_thong_fail(cultural: str, vocational: str) -> None:
 @pytest.mark.parametrize(
     "cultural",
     [
+        "completed_thcs",
         "graduated_thcs",
         "completed_thpt",
         "graduated_thpt",
@@ -226,7 +234,7 @@ def test_tc_chinh_quy_pass(cultural: str) -> None:
     assert ok is True
 
 
-@pytest.mark.parametrize("cultural", [None, "completed_thcs"])
+@pytest.mark.parametrize("cultural", [None])
 def test_tc_chinh_quy_fail(cultural: str | None) -> None:
     profile = _profile(cultural=cultural)
     ok, reason = validate_eligibility(profile, "trung_cap", "chinh_quy")
@@ -242,6 +250,8 @@ def test_tc_chinh_quy_fail(cultural: str | None) -> None:
 @pytest.mark.parametrize(
     "cultural, vocational",
     [
+        ("completed_thcs", "so_cap"),
+        ("completed_thcs", "trung_cap"),
         ("graduated_thcs", "so_cap"),
         ("graduated_thcs", "trung_cap"),
         ("graduated_thpt", "so_cap"),
@@ -256,9 +266,10 @@ def test_tc_lien_thong_pass(cultural: str, vocational: str) -> None:
 @pytest.mark.parametrize(
     "cultural, vocational",
     [
+        ("completed_thcs", "none"),  # cần SC/TC
+        ("completed_thcs", "cao_dang"),  # CĐ đã cao hơn TC — out of liên thông scope
         ("graduated_thcs", "none"),  # cần SC/TC
         ("graduated_thcs", "cao_dang"),  # CĐ đã cao hơn TC — out of liên thông scope
-        ("completed_thcs", "trung_cap"),  # cần ≥ TN_THCS
     ],
 )
 def test_tc_lien_thong_fail(cultural: str, vocational: str) -> None:
@@ -295,6 +306,64 @@ def test_unsupported_target_level_blocks() -> None:
     ok, reason = validate_eligibility(profile, "dai_hoc", "chinh_quy")
     assert ok is False
     assert "unsupported_target_level" in reason
+
+
+# ===========================================================================
+# Health-sector TC guard — Luật GDNN 2025 Điều 45 K2 (đóng đầu vào THCS từ 2026)
+# ===========================================================================
+
+_YSY_TC = "5720101"  # Y sỹ đa khoa — Trung cấp (lĩnh vực sức khỏe "72")
+_OTO_TC = "5510216"  # Công nghệ ô tô — Trung cấp (lĩnh vực "51", non-health)
+
+
+def test_is_health_sector_code() -> None:
+    assert _is_health_sector_code("5720101") is True
+    assert _is_health_sector_code("6720201") is True  # Dược CĐ
+    assert _is_health_sector_code("5510216") is False  # CN ô tô
+    assert _is_health_sector_code(None) is False
+    assert _is_health_sector_code("72") is False  # len < 3
+
+
+@pytest.mark.parametrize("cultural", ["completed_thcs", "graduated_thcs"])
+def test_tc_health_thcs_blocked_2026_chinh_quy(cultural: str) -> None:
+    # Cả completed_thcs lẫn graduated_thcs (nhãn legacy cùng tầng THCS) đều chặn.
+    profile = _profile(cultural=cultural, academic_year=2026)
+    ok, reason = validate_eligibility(profile, "trung_cap", "chinh_quy", _YSY_TC)
+    assert ok is False
+    assert reason == "tc_health_thcs_entry_closed_2026"
+
+
+@pytest.mark.parametrize("cultural", ["completed_thcs", "graduated_thcs"])
+def test_tc_health_thcs_blocked_2026_lien_thong(cultural: str) -> None:
+    profile = _profile(cultural=cultural, vocational="trung_cap", academic_year=2026)
+    ok, reason = validate_eligibility(profile, "trung_cap", "lien_thong", _YSY_TC)
+    assert ok is False
+    assert reason == "tc_health_thcs_entry_closed_2026"
+
+
+@pytest.mark.parametrize(
+    "cultural", ["completed_thpt", "graduated_thpt", "graduated_gdtx"]
+)
+def test_tc_health_thpt_input_still_passes(cultural: str) -> None:
+    # Chỉ đóng đầu vào THCS; đầu vào THPT vào TC sức khỏe vẫn hợp lệ.
+    profile = _profile(cultural=cultural, academic_year=2026)
+    ok, _ = validate_eligibility(profile, "trung_cap", "chinh_quy", _YSY_TC)
+    assert ok is True
+
+
+def test_tc_nonhealth_completed_thcs_passes_2026() -> None:
+    # Ngành thường (CN ô tô) + completed_thcs + 2026 → vẫn pass (Option B).
+    profile = _profile(cultural="completed_thcs", academic_year=2026)
+    ok, _ = validate_eligibility(profile, "trung_cap", "chinh_quy", _OTO_TC)
+    assert ok is True
+
+
+@pytest.mark.parametrize("cultural", ["completed_thcs", "graduated_thcs"])
+def test_tc_health_thcs_pre_2026_passes(cultural: str) -> None:
+    # Trước mốc 01/01/2026 guard không áp (backward-compat cycle cũ).
+    profile = _profile(cultural=cultural, academic_year=2025)
+    ok, _ = validate_eligibility(profile, "trung_cap", "chinh_quy", _YSY_TC)
+    assert ok is True
 
 
 # ===========================================================================

--- a/Backend_FastAPI/tests/unit/test_priority_kv_phase_e4_matrix.py
+++ b/Backend_FastAPI/tests/unit/test_priority_kv_phase_e4_matrix.py
@@ -106,13 +106,15 @@ def test_has_thpt_history_thpt_missing_year_returns_false() -> None:
         # TC chính quy + cultural đủ THPT → LICH_SU_THPT
         ("graduated_thpt", "none", "trung_cap", "chinh_quy", "LICH_SU_THPT", "tc_chinh_quy_post_thpt"),
         ("completed_thpt", "so_cap", "trung_cap", "chinh_quy", "LICH_SU_THPT", "tc_chinh_quy_post_thpt"),
-        # TC liên thông từ SC/TC + cultural graduated_thcs → THUONG_TRU
+        # TC liên thông từ SC/TC + cultural completed_thcs/graduated_thcs → THUONG_TRU
+        ("completed_thcs", "so_cap", "trung_cap", "lien_thong", "THUONG_TRU", "tc_lien_thong_post_thcs_with_voc"),
+        ("completed_thcs", "trung_cap", "trung_cap", "lien_thong", "THUONG_TRU", "tc_lien_thong_post_thcs_with_voc"),
         ("graduated_thcs", "so_cap", "trung_cap", "lien_thong", "THUONG_TRU", "tc_lien_thong_post_thcs_with_voc"),
         ("graduated_thcs", "trung_cap", "trung_cap", "lien_thong", "THUONG_TRU", "tc_lien_thong_post_thcs_with_voc"),
         # TC liên thông + cultural THPT → LICH_SU_THPT
         ("graduated_thpt", "so_cap", "trung_cap", "lien_thong", "LICH_SU_THPT", "tc_lien_thong_post_thpt"),
-        # TC chính quy + completed_thcs → INSUFFICIENT_DATA
-        ("completed_thcs", "none", "trung_cap", "chinh_quy", "INSUFFICIENT_DATA", "tc_chinh_quy_cultural_insufficient"),
+        # TC chính quy + completed_thcs → THUONG_TRU (TT22 hoàn thành = đủ ĐK TC)
+        ("completed_thcs", "none", "trung_cap", "chinh_quy", "THUONG_TRU", "tc_chinh_quy_post_thcs"),
         # SC chính quy → THUONG_TRU
         ("graduated_thcs", "none", "so_cap", "chinh_quy", "THUONG_TRU", "sc_uses_commune"),
         # SC chính quy + cultural=None — yêu cầu nghiệp vụ #5: SC KHÔNG yêu
@@ -341,6 +343,24 @@ async def test_resolve_thuong_tru_happy_with_commune_in_catalog() -> None:
     """TC chính quy + graduated_thcs + commune_code resolve OK."""
     profile = _profile_stub(
         cultural_education_level="graduated_thcs",
+        permanent_commune_code="66_22255",
+    )
+    db = _mock_db(commune_kv="KV2-NT")
+    kv, meta = await resolve_kv_for_profile(
+        profile, db, target_level="trung_cap", admission_type="chinh_quy",
+    )
+    assert kv == "KV2-NT"
+    assert meta["rule_applied"] == "commune_lookup"
+    assert meta["pathway"] == "thuong_tru"
+    assert meta["basis"] == "THUONG_TRU"
+    assert meta["breakdown"]["commune_code_used"] == "66_22255"
+
+
+@pytest.mark.asyncio
+async def test_resolve_completed_thcs_tc_chinh_quy_uses_commune_lookup() -> None:
+    """TC chinh quy + completed_thcs + commune_code resolve OK (TT22)."""
+    profile = _profile_stub(
+        cultural_education_level="completed_thcs",
         permanent_commune_code="66_22255",
     )
     db = _mock_db(commune_kv="KV2-NT")

--- a/Backend_FastAPI/tests/unit/test_priority_kv_resolution.py
+++ b/Backend_FastAPI/tests/unit/test_priority_kv_resolution.py
@@ -372,14 +372,14 @@ async def test_resolve_kv_thcs_plus_tc_falls_to_commune():
         ("completed_thpt", "none", "CD", True),
         ("graduated_thcs", "trung_cap", "CD", False),  # Chưa TN THPT → CD FAIL (path 2 strict)
         ("graduated_thcs", "none", "CD", False),  # Chỉ TN THCS → CD FAIL
-        ("completed_thcs", "trung_cap", "CD", False),  # Chưa TN THCS → CD FAIL
+        ("completed_thcs", "trung_cap", "CD", False),  # Chưa đủ THPT → CD FAIL
         (None, "none", "CD", False),  # Cultural draft → CD FAIL
         # TC target — TN THCS trở lên OK
         ("graduated_thcs", "none", "TC", True),
         ("graduated_thpt", "none", "TC", True),
         ("completed_thpt", "so_cap", "TC", True),
-        # TC target — fail
-        ("completed_thcs", "none", "TC", False),  # Chưa TN THCS
+        # TC target — completed_thcs OK (TT22); draft cultural (None) still fails
+        ("completed_thcs", "none", "TC", True),
         (None, "none", "TC", False),
         # SC target — luôn pass
         ("completed_thcs", "none", "SC", True),

--- a/Backend_FastAPI/tests/unit/test_validate_eligibility_all_choices.py
+++ b/Backend_FastAPI/tests/unit/test_validate_eligibility_all_choices.py
@@ -14,6 +14,7 @@ Tests verify:
 
 Mock pattern: AsyncMock cho db.execute dispatching theo statement target.
 """
+
 from __future__ import annotations
 
 from types import SimpleNamespace
@@ -173,7 +174,9 @@ async def test_multi_nv_inconsistent_admission_types_blocks() -> None:
     """Cùng target_level (CĐ) nhưng admission_type khác (chính quy vs liên thông)
     → MULTI_NV_INCONSISTENT."""
     profile = _profile(
-        cultural="graduated_thpt", vocational="trung_cap", uses_choice_engine=True,
+        cultural="graduated_thpt",
+        vocational="trung_cap",
+        uses_choice_engine=True,
     )
     choices = [
         SimpleNamespace(
@@ -234,7 +237,9 @@ async def test_single_nv_no_consistency_check_needed() -> None:
     await _validate_eligibility_all_choices(db, profile)
 
 
-async def test_multi_nv_inconsistent_with_eligibility_fail_prefers_consistency_msg() -> None:
+async def test_multi_nv_inconsistent_with_eligibility_fail_prefers_consistency_msg() -> (
+    None
+):
     """Khi cả 2 vấn đề tồn tại (multi-NV inconsistent + eligibility fail
     cho ít nhất 1 NV), helper raise MULTI_NV_INCONSISTENT trước (architectural
     error first; data error after split sẽ surface eligibility riêng cho mỗi
@@ -242,7 +247,9 @@ async def test_multi_nv_inconsistent_with_eligibility_fail_prefers_consistency_m
     profile = _profile(cultural="graduated_thcs", uses_choice_engine=True)
     choices = [
         SimpleNamespace(
-            admission_path=_make_path("cao_dang", "chinh_quy"),  # graduated_thcs fail CĐ
+            admission_path=_make_path(
+                "cao_dang", "chinh_quy"
+            ),  # graduated_thcs fail CĐ
             display_order=1,
         ),
         SimpleNamespace(
@@ -379,7 +386,7 @@ async def test_legacy_tc_chinh_quy_graduated_thcs_passes() -> None:
     await _validate_eligibility_all_choices(db, profile)
 
 
-async def test_legacy_tc_chinh_quy_completed_thcs_blocks() -> None:
+async def test_legacy_tc_chinh_quy_completed_thcs_passes() -> None:
     profile = _profile(
         cultural="completed_thcs",
         uses_choice_engine=False,
@@ -390,10 +397,7 @@ async def test_legacy_tc_chinh_quy_completed_thcs_blocks() -> None:
     config_stub.academic_info = path.__dict__["academic_info"]
     db = _make_db_legacy(config_stub=config_stub)
 
-    with pytest.raises(BusinessRuleViolation) as exc:
-        await _validate_eligibility_all_choices(db, profile)
-    assert "ELIGIBILITY_FAIL" in str(exc.value)
-    assert "trung_cap" in str(exc.value)
+    await _validate_eligibility_all_choices(db, profile)
 
 
 async def test_legacy_sc_chinh_quy_no_cultural_passes() -> None:


### PR DESCRIPTION
## Bối cảnh
Phát hiện khi smoke hồ sơ THCS→TC THẬT đầu tiên (#25 — Công nghệ ô tô TC, `completed_thcs`): engine Phase E.4 chỉ nhận `graduated_thcs` cho bậc TC → `completed_thcs` bị **chặn submit** (`ELIGIBILITY_FAIL: tc_requires_graduated_thcs_or_higher`) + KV `INSUFFICIENT_DATA`, dù tầng tài liệu đã coi `completed_thcs` là diện `POST_THCS` hợp lệ.

## Thay đổi — Luật GDNN 2025 Điều 45

### 1. Khoản 1 — `completed_thcs` (TT22 "hoàn thành CT THCS") đủ điều kiện vào TC
- Thêm `completed_thcs` vào `_THCS_OR_HIGHER` (eligibility TC chính quy + liên thông).
- Nhánh TC chính quy/liên thông trong `_derive_kv_basis_level` nhận `completed_thcs` → `THUONG_TRU` (KV theo thường trú).

### 2. Khoản 2 — TC lĩnh vực sức khỏe đóng đầu-vào-THCS từ 01/01/2026 (compliance guard)
- Trường **CÓ 4 path Y sỹ đa khoa TC** (`5720101`, id 156/157/186/204 active) → guard cần thiết; cũng khóa latent bug `graduated_thcs`→Y sỹ TC.
- `validate_eligibility` nhận thêm `major_code`; **fail** khi `target=trung_cap` + `academic_year≥2026` + lĩnh vực sức khỏe (`code[1:3]='72'`, TT04/2017) + cultural THCS — chặn **cả** `completed_thcs` lẫn `graduated_thcs` (nhãn legacy cùng tầng → không bypass).
- Reason `tc_health_thcs_entry_closed_2026`. 5 caller truyền `derive_major_code(path)`.

## Verify
- **166 unit test pass** (11 guard test: Y sỹ TC + THCS→fail · +THPT→pass · ngành thường + completed_thcs→pass · pre-2026→pass · liên thông→fail).
- 7 path THCS→TC hiện hữu (210-216) đều **phi sức khỏe** → data hiện tại an toàn.
- **Không** đụng document layer (khác biệt bằng TN vs giấy CN) + CĐ chính quy. **Không migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)