### PR TITLE
fix(admissions): humanize nhãn hiển thị (Nguyện vọng/phương thức/môn/đợt/điểm multi-NV) + đủ nhãn trạng thái list

### DIFF
--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/PerNvScoreSummary.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/executive-summary/PerNvScoreSummary.tsx
@@ -60,8 +60,9 @@ export function PerNvScoreSummary({
           scoreNum !== null && !Number.isNaN(scoreNum)
             ? scoreNum.toFixed(2)
             : "—"
-        const title =
-          choice.display_program_name || choice.display_path_name || "—"
+        // Program name only — drop the `|| display_path_name` machine-composite
+        // fallback (… - 2026 - 201 - DOT_2) so it never leaks codes here.
+        const title = (choice.display_program_name ?? "").trim() || "—"
 
         return (
           <li

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/ReadinessHero.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/ReadinessHero.test.tsx
@@ -62,6 +62,22 @@ describe("ReadinessHero", () => {
     expect(screen.getByText("Có thể nộp")).toBeInTheDocument()
   })
 
+  it("'Nguyện vọng' shows the choice (program/degree); 'Phương thức' shows the humanized method, never the raw code", () => {
+    const { container } = render(
+      <ReadinessHero
+        profile={buildProfile({
+          applied_rules: { admission_method: "201", method_type: "subject_based" },
+          choices: [{ display_program_name: "Công nghệ ô tô", display_degree_level: "Trung cấp" }],
+        } as Partial<AdmissionProfileResponse>)}
+        readiness={buildReadiness()}
+      />,
+    )
+    expect(screen.getByText("Công nghệ ô tô — Trung cấp")).toBeInTheDocument()
+    expect(screen.getByText("Xét theo tổ hợp môn")).toBeInTheDocument()
+    expect(container.textContent).not.toContain("Nguyện vọng: 201")
+    expect(screen.queryByText("201")).not.toBeInTheDocument()
+  })
+
   it("does NOT render a separate eligibility badge or eligibility metric (one verdict only)", () => {
     const { container } = render(
       <ReadinessHero profile={buildProfile()} readiness={buildReadiness()} />,
@@ -93,7 +109,12 @@ describe("ReadinessHero", () => {
   it("document metric falls back to — when document_stats null", () => {
     render(
       <ReadinessHero
-        profile={buildProfile({ document_stats: null } as Partial<AdmissionProfileResponse>)}
+        profile={buildProfile({
+          document_stats: null,
+          // Give a choice so the "Nguyện vọng" field isn't also "—" (which would
+          // make the bare getByText("—") ambiguous) — isolate the doc metric.
+          choices: [{ display_program_name: "X", display_degree_level: "Y" }],
+        } as Partial<AdmissionProfileResponse>)}
         readiness={buildReadiness()}
       />,
     )

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/ReadinessHero.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/ReadinessHero.tsx
@@ -22,7 +22,7 @@ import { Badge } from "@/components/ui/badge"
 import { Progress } from "@/components/ui/progress"
 import { cn } from "@/lib/utils"
 import { User } from "lucide-react"
-import { getAdmissionMethodLabel } from "@/lib/utils/admission-helpers"
+import { getAdmissionMethodLabel, getChoiceSummaryLabel } from "@/lib/utils/admission-helpers"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 import type { ReadinessTone, SubmissionReadiness } from "./useSubmissionReadiness"
 import {
@@ -58,6 +58,9 @@ function Metric({ label, children }: { label: string; children: ReactNode }) {
 }
 
 export function ReadinessHero({ profile, readiness, cta }: ReadinessHeroProps) {
+  // "Nguyện vọng" = the candidate's actual choice(s) (program/degree), NOT the
+  // method. "Phương thức" shows the humanized method separately (never a raw code).
+  const choiceLabel = getChoiceSummaryLabel(profile)
   const methodLabel = getAdmissionMethodLabel(profile.applied_rules)
   const completion = profile.completion_percent ?? 0
   const stats = profile.document_stats
@@ -102,7 +105,11 @@ export function ReadinessHero({ profile, readiness, cta }: ReadinessHeroProps) {
                 </span>
                 <span className="flex items-center gap-1.5 min-w-0">
                   <span className="font-medium text-foreground">Nguyện vọng:</span>
-                  <span className="font-semibold text-foreground break-words">{methodLabel}</span>
+                  <span className="font-semibold text-foreground break-words">{choiceLabel}</span>
+                </span>
+                <span className="flex items-center gap-1.5 min-w-0">
+                  <span className="font-medium text-foreground">Phương thức:</span>
+                  <span className="break-words">{methodLabel}</span>
                 </span>
               </div>
             </div>

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/SectionReview.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/SectionReview.test.tsx
@@ -82,4 +82,19 @@ describe("SectionReview (table)", () => {
     render(<SectionReview profile={buildProfile()} onNavigateToStep={vi.fn()} />)
     expect(screen.getByText("Tổng điểm: —")).toBeInTheDocument()
   })
+
+  it("Step 5 detail shows NV completeness for multi-NV (not 'Tổng điểm: —')", () => {
+    render(
+      <SectionReview
+        profile={buildProfile({
+          uses_choice_engine: true,
+          total_score: null,
+          choices: [{ data_complete: true }, { data_complete: false }],
+        } as Partial<AdmissionProfileResponse>)}
+        onNavigateToStep={vi.fn()}
+      />,
+    )
+    expect(screen.getByText("1/2 NV đủ điểm")).toBeInTheDocument()
+    expect(screen.queryByText("Tổng điểm: —")).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/SectionReview.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/SectionReview.tsx
@@ -54,6 +54,14 @@ function resolveDisplayStatus(
 /** "Chi tiết" cell — a specific metric for steps 5/6, otherwise "—". */
 function resolveDetail(step: number, profile: AdmissionProfileResponse): string {
   if (step === 5) {
+    // Multi-NV: profile-level total_score is null by design (scores live per-NV),
+    // so a flat "Tổng điểm: —" would read as "missing scores". Show NV completeness.
+    if (profile.uses_choice_engine) {
+      const choices = profile.choices ?? []
+      if (choices.length === 0) return "Chưa có nguyện vọng"
+      const complete = choices.filter((c) => c.data_complete).length
+      return `${complete}/${choices.length} NV đủ điểm`
+    }
     const total =
       typeof profile.total_score === "number" ? profile.total_score.toFixed(2) : "—"
     return `Tổng điểm: ${total}`

--- a/frontend/src/app/(dashboard)/admissions/_components/columns.test.ts
+++ b/frontend/src/app/(dashboard)/admissions/_components/columns.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Admissions list STATUS_CONFIG — completeness pin.
+ *
+ * Derived from the canonical ADMISSION_STATUS_CONFIG so the list status badge
+ * covers EVERY admission state (incl. the multi-NV states the old inline map
+ * omitted, which rendered the raw English enum on the list).
+ */
+
+import { describe, it, expect } from "vitest"
+import { STATUS_CONFIG } from "./columns"
+import { ADMISSION_STATUS_CONFIG } from "@/lib/status-config"
+
+describe("admissions list STATUS_CONFIG", () => {
+  it("covers the multi-NV states that were previously missing (no raw enum on the list)", () => {
+    for (const s of ["reviewing", "result_published", "admitted", "waitlisted"]) {
+      expect(STATUS_CONFIG[s]?.label).toBeTruthy()
+      expect(STATUS_CONFIG[s].label).not.toBe(s) // not the raw enum
+    }
+  })
+
+  it("stays in parity with the canonical ADMISSION_STATUS_CONFIG (single source)", () => {
+    for (const [status, cfg] of Object.entries(ADMISSION_STATUS_CONFIG)) {
+      expect(STATUS_CONFIG[status]?.label).toBe(cfg.label)
+      expect(STATUS_CONFIG[status]?.color).toBe(cfg.badgeColor)
+    }
+  })
+
+  it("keeps the core states", () => {
+    expect(STATUS_CONFIG.submitted?.label).toBe("Chờ duyệt")
+    expect(STATUS_CONFIG.draft?.label).toBe("Nháp")
+  })
+})

--- a/frontend/src/app/(dashboard)/admissions/_components/columns.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/columns.tsx
@@ -31,23 +31,23 @@ import {
 } from "@/components/ui/dropdown-menu"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 import { hasAction } from "@/lib/admission/permissions"
+import { ADMISSION_STATUS_CONFIG } from "@/lib/status-config"
 
 // =============================================================================
 // STATUS CONFIGURATION
 // =============================================================================
 
-export const STATUS_CONFIG: Record<string, { label: string; color: string }> = {
-  draft: { label: "Nháp", color: "bg-muted text-muted-foreground" },
-  submitted: { label: "Chờ duyệt", color: "bg-info-100 text-info-700" },
-  resubmitted: { label: "Đã nộp lại", color: "bg-info-100 text-info-700" },
-  approved: { label: "Đã duyệt", color: "bg-success-100 text-success-700" },
-  rejected: { label: "Từ chối", color: "bg-error-100 text-error-700" },
-  revision_requested: { label: "Yêu cầu bổ sung", color: "bg-orange-100 text-orange-700" },
-  confirmed: { label: "Đã xác nhận", color: "bg-emerald-100 text-emerald-700" },
-  overridden: { label: "Đã override", color: "bg-purple-100 text-purple-700" },
-  enrolled: { label: "Đã nhập học", color: "bg-blue-100 text-blue-700" },
-  withdrawn: { label: "Đã rút hồ sơ", color: "bg-muted text-muted-foreground" },
-}
+// Derived from the canonical ADMISSION_STATUS_CONFIG (single source of truth) so
+// the list status badge covers EVERY admission state — incl. the multi-NV states
+// reviewing / result_published / admitted / waitlisted that the old inline map
+// omitted, which made the list render the raw English enum for those rows.
+export const STATUS_CONFIG: Record<string, { label: string; color: string }> =
+  Object.fromEntries(
+    Object.entries(ADMISSION_STATUS_CONFIG).map(([status, cfg]) => [
+      status,
+      { label: cfg.label, color: cfg.badgeColor },
+    ]),
+  )
 
 export const ELIGIBILITY_CONFIG: Record<string, { label: string; color: string }> = {
   eligible: { label: "Đủ điều kiện", color: "bg-success-100 text-success-700" },

--- a/frontend/src/app/(dashboard)/admissions/create/page.tsx
+++ b/frontend/src/app/(dashboard)/admissions/create/page.tsx
@@ -25,6 +25,7 @@ import { getPathsForOffering } from "@/lib/api/admission-paths"
 import { toast } from "sonner"
 import { PageContainer } from "@/components/layouts/PageContainer"
 import { todayVN } from "@/lib/utils/vn-date"
+import { formatRoundLabel } from "@/lib/utils/admission-helpers"
 import type { LeadAdmissionBlocker } from "@/types/lead.types"
 
 // Blocker code → user-facing VN message. Source of truth lives in backend
@@ -477,7 +478,7 @@ export default function CreateAdmissionPage() {
                     return (
                       <SelectItem key={r.id} value={r.id.toString()}>
                         <span className="flex items-center gap-2">
-                          <span>{r.name ?? r.code ?? `Đợt #${r.id}`}</span>
+                          <span>{formatRoundLabel(r)}</span>
                           {windowLabel && (
                             <span className="text-xs text-muted-foreground">
                               ({windowLabel})

--- a/frontend/src/components/admissions/ChoiceListEditor/ChoiceListEditor.test.tsx
+++ b/frontend/src/components/admissions/ChoiceListEditor/ChoiceListEditor.test.tsx
@@ -165,7 +165,7 @@ describe("ChoiceListEditor", () => {
     expect(onRequestAdd).toHaveBeenCalledOnce()
   })
 
-  it("clicking delete shows confirm dialog with NV label + path name", () => {
+  it("clicking delete shows confirm dialog with NV label + choice display name", () => {
     const choices = [
       makeChoice({
         id: 7,
@@ -186,9 +186,11 @@ describe("ChoiceListEditor", () => {
     fireEvent.click(screen.getByLabelText("Xoá nguyện vọng 2"))
     // Radix Dialog renders in portal — query against document.body
     expect(screen.getByText("Xoá nguyện vọng?")).toBeTruthy()
+    // Humanized display name (program — degree), NOT the machine composite path name.
     expect(
-      screen.getByText(/NV2.*CNTT 2026 - HSA - DOT_1/),
+      screen.getByText(/NV2.*Cao đẳng Công nghệ thông tin — Cao đẳng/),
     ).toBeTruthy()
+    expect(screen.queryByText(/CNTT 2026 - HSA - DOT_1/)).toBeNull()
   })
 
   it("confirm in delete dialog triggers deleteChoice API with correct id", async () => {

--- a/frontend/src/components/admissions/ChoiceListEditor/ChoiceListEditor.tsx
+++ b/frontend/src/components/admissions/ChoiceListEditor/ChoiceListEditor.tsx
@@ -57,6 +57,7 @@ import {
 import { DecisionBadge } from "@/components/admissions/DecisionBadge"
 import { ChoiceScoreCard } from "@/components/admissions/ChoiceScoreCard"
 import { AuditReasonDialog } from "@/components/admissions/AuditReasonDialog"
+import { getChoiceDisplayName } from "@/lib/utils/admission-helpers"
 import { pushRecentReason } from "@/components/admissions/AuditReasonDialog/reason-templates"
 import {
   useDeleteChoice,
@@ -179,9 +180,9 @@ function SortableChoiceRow({
             {choice.display_program_name}
           </p>
         )}
-        <p className="mt-0.5 truncate text-xs text-muted-foreground">
-          {choice.display_path_name || "—"}
-        </p>
+        {/* Program + degree + tổ hợp already identify the choice; the machine
+            composite `display_path_name` (… - 2026 - 201 - DOT_2) is omitted so we
+            don't leak the method/round codes to the user. */}
         <p className="text-xs text-muted-foreground">
           Tổ hợp: {choice.display_subject_group_name || "Chưa chọn"}
         </p>
@@ -462,7 +463,7 @@ export function ChoiceListEditor({
               Sửa điểm NV{pendingEditScores?.display_order ?? ""}
             </DialogTitle>
             <DialogDescription>
-              {pendingEditScores?.display_path_name || "—"}
+              {pendingEditScores ? getChoiceDisplayName(pendingEditScores) : "—"}
               {pendingEditScores?.display_subject_group_name
                 ? ` · ${pendingEditScores.display_subject_group_name}`
                 : ""}
@@ -489,9 +490,9 @@ export function ChoiceListEditor({
             <AlertDialogTitle>Xoá nguyện vọng?</AlertDialogTitle>
             <AlertDialogDescription>
               {pendingRemove
-                ? `Bạn sắp xoá NV${pendingRemove.display_order}: ${
-                    pendingRemove.display_path_name || "(chưa rõ)"
-                  }. Hành động này không thể hoàn tác.`
+                ? `Bạn sắp xoá NV${pendingRemove.display_order}: ${getChoiceDisplayName(
+                    pendingRemove,
+                  )}. Hành động này không thể hoàn tác.`
                 : null}
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/frontend/src/lib/utils/admission-helpers.test.ts
+++ b/frontend/src/lib/utils/admission-helpers.test.ts
@@ -7,7 +7,13 @@
  */
 
 import { describe, it, expect } from "vitest"
-import { getAdmissionMethodLabel, getChoiceSummaryLabel } from "./admission-helpers"
+import {
+  getAdmissionMethodLabel,
+  getChoiceSummaryLabel,
+  getChoiceDisplayName,
+  getSubjectLabel,
+  formatRoundLabel,
+} from "./admission-helpers"
 import type { AppliedRules } from "@/lib/zod/admissions"
 
 const ar = (o: Partial<AppliedRules>) => o as AppliedRules
@@ -59,5 +65,45 @@ describe("getChoiceSummaryLabel", () => {
 
   it("nothing available → '—'", () => {
     expect(getChoiceSummaryLabel({})).toBe("—")
+  })
+})
+
+describe("getChoiceDisplayName", () => {
+  it("program + degree → 'Ngành — Bậc'", () => {
+    expect(
+      getChoiceDisplayName({ display_program_name: "Công nghệ ô tô", display_degree_level: "Trung cấp" }),
+    ).toBe("Công nghệ ô tô — Trung cấp")
+  })
+  it("program only → program", () => {
+    expect(getChoiceDisplayName({ display_program_name: "Kế toán", display_degree_level: "" })).toBe("Kế toán")
+  })
+  it("empty → '—' (never the machine composite)", () => {
+    expect(getChoiceDisplayName({})).toBe("—")
+  })
+})
+
+describe("getSubjectLabel (THCS additions)", () => {
+  it("natural_science → 'Khoa học tự nhiên' (not the raw code)", () => {
+    expect(getSubjectLabel("natural_science")).toBe("Khoa học tự nhiên")
+  })
+  it("social_science → 'Khoa học xã hội'", () => {
+    expect(getSubjectLabel("social_science")).toBe("Khoa học xã hội")
+  })
+  it("known THPT subject still works", () => {
+    expect(getSubjectLabel("math")).toBe("Toán")
+  })
+})
+
+describe("formatRoundLabel", () => {
+  it("round_name present → name", () => {
+    expect(formatRoundLabel({ name: "Đợt tuyển sinh sớm", code: "DOT_1" })).toBe("Đợt tuyển sinh sớm")
+  })
+  it("no name → humanizes DOT_n code (not raw 'DOT_2')", () => {
+    expect(formatRoundLabel({ name: null, code: "DOT_2" })).toBe("Đợt 2")
+    expect(formatRoundLabel({ name: "", code: "DOT-3" })).toBe("Đợt 3")
+  })
+  it("unknown code format → code as-is; nothing → 'Đợt #id'", () => {
+    expect(formatRoundLabel({ code: "SPRING" })).toBe("SPRING")
+    expect(formatRoundLabel({ id: 9 })).toBe("Đợt #9")
   })
 })

--- a/frontend/src/lib/utils/admission-helpers.test.ts
+++ b/frontend/src/lib/utils/admission-helpers.test.ts
@@ -1,0 +1,63 @@
+/**
+ * admission-helpers — method label + choice summary.
+ *
+ * Pins the "Nguyện vọng: 201" fix: getAdmissionMethodLabel must NEVER return a raw
+ * numeric TS2026 method code (falls back to method_type), and getChoiceSummaryLabel
+ * surfaces the candidate's actual choice(s), not the method.
+ */
+
+import { describe, it, expect } from "vitest"
+import { getAdmissionMethodLabel, getChoiceSummaryLabel } from "./admission-helpers"
+import type { AppliedRules } from "@/lib/zod/admissions"
+
+const ar = (o: Partial<AppliedRules>) => o as AppliedRules
+
+describe("getAdmissionMethodLabel", () => {
+  it("legacy enum → specific label", () => {
+    expect(getAdmissionMethodLabel(ar({ admission_method: "HOC_BA" }))).toBe("Xét học bạ THPT")
+  })
+
+  it("TS2026 numeric code → method_type label, NEVER the raw code", () => {
+    const label = getAdmissionMethodLabel(ar({ admission_method: "201", method_type: "subject_based" }))
+    expect(label).toBe("Xét theo tổ hợp môn")
+    expect(label).not.toBe("201")
+  })
+
+  it("gpa_only method_type → 'Xét học bạ'", () => {
+    expect(getAdmissionMethodLabel(ar({ admission_method: "100", method_type: "gpa_only" }))).toBe("Xét học bạ")
+  })
+
+  it("unknown method + no method_type → generic 'Xét tuyển' (never raw)", () => {
+    expect(getAdmissionMethodLabel(ar({ admission_method: "999", method_type: null }))).toBe("Xét tuyển")
+    expect(getAdmissionMethodLabel(ar({ admission_method: null, method_type: null }))).toBe("Xét tuyển")
+  })
+})
+
+describe("getChoiceSummaryLabel", () => {
+  it("multi-NV: first program — degree + '+N NV'", () => {
+    expect(
+      getChoiceSummaryLabel({
+        choices: [
+          { display_program_name: "Công nghệ ô tô", display_degree_level: "Trung cấp" },
+          { display_program_name: "Điện công nghiệp", display_degree_level: "Cao đẳng" },
+        ],
+      }),
+    ).toBe("Công nghệ ô tô — Trung cấp +1 NV")
+  })
+
+  it("single choice: program — degree, no suffix", () => {
+    expect(
+      getChoiceSummaryLabel({
+        choices: [{ display_program_name: "Công nghệ ô tô", display_degree_level: "Trung cấp" }],
+      }),
+    ).toBe("Công nghệ ô tô — Trung cấp")
+  })
+
+  it("no choices → profile.program_name", () => {
+    expect(getChoiceSummaryLabel({ choices: [], program_name: "Kế toán" })).toBe("Kế toán")
+  })
+
+  it("nothing available → '—'", () => {
+    expect(getChoiceSummaryLabel({})).toBe("—")
+  })
+})

--- a/frontend/src/lib/utils/admission-helpers.ts
+++ b/frontend/src/lib/utils/admission-helpers.ts
@@ -12,12 +12,19 @@ import type { AppliedRules, DocumentItem } from "@/lib/zod/admissions"
 // ==============================================================================
 
 /**
- * Get human-readable label for admission method code.
+ * Get a human-readable label for the admission METHOD (phương thức xét tuyển).
+ *
+ * `applied_rules.admission_method` is EITHER a legacy enum string (HOC_BA/…) OR a
+ * TS2026 numeric method CODE ("201"/"301"/…) — the latter is meaningless to a
+ * user. So: a known legacy enum → its specific label; otherwise fall back to the
+ * stable `method_type` enum (gpa_only/subject_based/combined). NEVER return the
+ * raw numeric code (that's the "Nguyện vọng: 201" bug).
+ *
  * @param appliedRules Applied rules snapshot from backend
- * @returns Formatted admission method label
+ * @returns Vietnamese method label (never a raw code)
  */
 export function getAdmissionMethodLabel(appliedRules: AppliedRules): string {
-  const methodLabels: Record<string, string> = {
+  const legacyLabels: Record<string, string> = {
     HOC_BA: "Xét học bạ THPT",
     THI_THPT: "Xét điểm thi THPT Quốc gia",
     DGNL: "Xét điểm đánh giá năng lực",
@@ -26,11 +33,46 @@ export function getAdmissionMethodLabel(appliedRules: AppliedRules): string {
     TUYEN_THANG: "Tuyển thẳng",
     UU_TIEN: "Xét ưu tiên",
   }
+  const methodTypeLabels: Record<string, string> = {
+    gpa_only: "Xét học bạ",
+    subject_based: "Xét theo tổ hợp môn",
+    combined: "Xét kết hợp",
+  }
 
   const method = appliedRules.admission_method
-  if (!method) return "Chưa xác định"
+  if (method && legacyLabels[method]) return legacyLabels[method]
 
-  return methodLabels[method] ?? method
+  // Numeric TS2026 codes (or any unknown method) → use the coarse-but-stable
+  // method_type instead of leaking the raw code to the UI.
+  const methodType = appliedRules.method_type
+  if (methodType && methodTypeLabels[methodType]) return methodTypeLabels[methodType]
+
+  return "Xét tuyển"
+}
+
+/**
+ * Summary of the candidate's actual CHOICE(S) (nguyện vọng) for compact identity
+ * rows. Multi-NV (uses_choice_engine): the first choice's program — degree, plus
+ * "+N NV" when there are more. Single-NV / no choices: the profile-level
+ * `program_name`. Returns "—" only when nothing is available. This is the field a
+ * "Nguyện vọng:" caption should show — NOT the admission method.
+ */
+export function getChoiceSummaryLabel(profile: {
+  choices?: ReadonlyArray<{
+    display_program_name?: string | null
+    display_degree_level?: string | null
+  }> | null
+  program_name?: string | null
+}): string {
+  const choices = profile.choices ?? []
+  if (choices.length > 0) {
+    const first = choices[0]
+    const program = (first.display_program_name ?? "").trim()
+    const degree = (first.display_degree_level ?? "").trim()
+    const base = [program, degree].filter(Boolean).join(" — ") || program || "—"
+    return choices.length > 1 ? `${base} +${choices.length - 1} NV` : base
+  }
+  return (profile.program_name ?? "").trim() || "—"
 }
 
 // ==============================================================================

--- a/frontend/src/lib/utils/admission-helpers.ts
+++ b/frontend/src/lib/utils/admission-helpers.ts
@@ -84,7 +84,9 @@ export function getChoiceDisplayName(choice: {
 }): string {
   const program = (choice.display_program_name ?? "").trim()
   const degree = (choice.display_degree_level ?? "").trim()
-  return [program, degree].filter(Boolean).join(" — ") || program || degree || "—"
+  // filter(Boolean) + join already covers the single-value cases; only reaches ""
+  // when both are empty → "—".
+  return [program, degree].filter(Boolean).join(" — ") || "—"
 }
 
 /**

--- a/frontend/src/lib/utils/admission-helpers.ts
+++ b/frontend/src/lib/utils/admission-helpers.ts
@@ -66,13 +66,44 @@ export function getChoiceSummaryLabel(profile: {
 }): string {
   const choices = profile.choices ?? []
   if (choices.length > 0) {
-    const first = choices[0]
-    const program = (first.display_program_name ?? "").trim()
-    const degree = (first.display_degree_level ?? "").trim()
-    const base = [program, degree].filter(Boolean).join(" — ") || program || "—"
+    const base = getChoiceDisplayName(choices[0])
     return choices.length > 1 ? `${base} +${choices.length - 1} NV` : base
   }
   return (profile.program_name ?? "").trim() || "—"
+}
+
+/**
+ * Human display name for a SINGLE choice (nguyện vọng): "Ngành — Bậc". Use this
+ * everywhere a choice is labelled instead of `display_path_name`, which is a
+ * machine composite that leaks year/method-code/round-code (e.g.
+ * "Công nghệ ô tô - 2026 - 201 - DOT_2").
+ */
+export function getChoiceDisplayName(choice: {
+  display_program_name?: string | null
+  display_degree_level?: string | null
+}): string {
+  const program = (choice.display_program_name ?? "").trim()
+  const degree = (choice.display_degree_level ?? "").trim()
+  return [program, degree].filter(Boolean).join(" — ") || program || degree || "—"
+}
+
+/**
+ * Human label for an admission round. Prefers `round_name`; otherwise humanizes
+ * the internal `round_code` ("DOT_2" → "Đợt 2") instead of leaking it; last resort
+ * "Đợt #{id}". Avoids the raw "DOT_2" in pickers/labels.
+ */
+export function formatRoundLabel(round: {
+  name?: string | null
+  code?: string | null
+  id?: number | null
+}): string {
+  const name = (round.name ?? "").trim()
+  if (name) return name
+  const code = round.code ?? ""
+  const m = code.match(/^DOT[_-]?(\d+)$/i)
+  if (m) return `Đợt ${m[1]}`
+  if (code) return code
+  return round.id != null ? `Đợt #${round.id}` : "Đợt —"
 }
 
 // ==============================================================================
@@ -96,6 +127,9 @@ export function getSubjectLabel(code: string): string {
     geography: "Địa lý",
     civic_education: "GDCD",
     foreign_language: "Ngoại ngữ",
+    // THCS (TS2026 trung cấp / cao đẳng nghề) integrated-subject codes.
+    natural_science: "Khoa học tự nhiên",
+    social_science: "Khoa học xã hội",
   }
 
   return labels[code] ?? code


### PR DESCRIPTION
## Bối cảnh
Smoke prod #25 lộ **"Nguyện vọng: 201"** ("201" = mã phương thức TS2026 in thô). Audit toàn admission UI tìm các nội dung dễ nhầm/thiếu thông tin → gom **1 PR** (commit 1: #1/#2/#3 chính; commit 2: 4 item tier-2).

## Commit 1 — #1/#2/#3
- **#2** `getAdmissionMethodLabel` không bao giờ in raw code: enum legacy → nhãn riêng; còn lại fallback `method_type` (gpa_only/subject_based/combined); cuối cùng "Xét tuyển".
- **#1** `ReadinessHero`: **"Nguyện vọng"** = NV thật (ngành — bậc; "+N NV"); thêm ô **"Phương thức"** (method humanize).
- **#3** list `STATUS_CONFIG` derive từ `ADMISSION_STATUS_CONFIG` (đủ 14 state, hết raw English; fix desktop + mobile).

## Commit 2 — 4 item tier-2 (humanize labels v2)
- **getSubjectLabel** thêm môn THCS: `natural_science`→"Khoa học tự nhiên", `social_science`→"Khoa học xã hội" (hết raw code ở bảng điểm THCS).
- **display_path_name** composite "X - 2026 - 201 - DOT_2": ChoiceListEditor bỏ dòng thừa; dialog sửa/xoá + PerNvScoreSummary dùng ngành/bậc (`getChoiceDisplayName`).
- **Dropdown đợt**: `formatRoundLabel` → "Đợt 2" thay vì raw "DOT_2".
- **SectionReview Bước 5**: multi-NV hiện "N/N NV đủ điểm" thay vì "Tổng điểm: —" gây hiểu nhầm.

## Kiểm chứng
- ✅ type-check (toàn project)
- ✅ **169 unit test** (admissions/finalize/executive-summary/ChoiceListEditor/helpers) — gồm test mới cho mọi helper + behavior.

FE-only, không migration. ExecutiveSummaryHeader (dead-code) không đụng. Đã verify live #25 + code (loại các claim mis-path của audit agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)