### PR TITLE
fix(admissions): list tab/count drift + degree filter + academic-history validation + KV badge

### DIFF
--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.test.tsx
@@ -7,20 +7,46 @@
  */
 
 import { describe, it, expect, vi } from "vitest"
-import { render, screen, fireEvent } from "@testing-library/react"
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react"
 import { useForm, FormProvider } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import * as React from "react"
 import type { UseFormReturn } from "react-hook-form"
+import { admissionProfileUpdateSchema } from "@/lib/zod/admissions"
 
 // Mock VnSchoolPicker — heavy dependency chain (react-query).
+// - the input emits a free-text change (school_id stays null);
+// - the button simulates picking a real school from the list (school_id set).
 vi.mock("@/components/admissions/VnSchoolPicker", () => ({
-  VnSchoolPicker: ({ value, onChange }: { value: { school_name: string }; onChange: (v: { school_id: null; school_name: string; level: null }) => void }) => (
-    <input
-      data-testid="mock-vn-school-picker"
-      value={value.school_name ?? ""}
-      onChange={(e) => onChange({ school_id: null, school_name: e.target.value, level: null })}
-    />
+  VnSchoolPicker: ({
+    value,
+    onChange,
+  }: {
+    value: { school_name: string }
+    onChange: (v: {
+      school_id: number | null
+      school_name: string
+      level: string | null
+      current_kv?: string | null
+    }) => void
+  }) => (
+    <div>
+      <input
+        data-testid="mock-vn-school-picker"
+        value={value.school_name ?? ""}
+        onChange={(e) => onChange({ school_id: null, school_name: e.target.value, level: null })}
+      />
+      <button
+        type="button"
+        data-testid="mock-pick-real-school"
+        onClick={() =>
+          onChange({ school_id: 42, school_name: "THPT Chuyên Nguyễn Du", level: "THPT", current_kv: "KV1" })
+        }
+      >
+        pick
+      </button>
+    </div>
   ),
 }))
 
@@ -31,12 +57,16 @@ function Harness({
   defaults,
   isEditable = true,
   exposeForm,
+  withResolver = false,
 }: {
   defaults?: Partial<AdmissionProfileUpdateInput>
   isEditable?: boolean
   exposeForm?: (form: UseFormReturn<AdmissionProfileUpdateInput>) => void
+  withResolver?: boolean
 }) {
   const form = useForm<AdmissionProfileUpdateInput>({
+    resolver: withResolver ? zodResolver(admissionProfileUpdateSchema) : undefined,
+    mode: "onBlur",
     defaultValues: { academic_history: [], ...defaults } as AdmissionProfileUpdateInput,
   })
   React.useEffect(() => {
@@ -133,5 +163,38 @@ describe("AcademicHistoryTab — Commit 5 free-text school warning", () => {
       } as Partial<AdmissionProfileUpdateInput>,
     })
     expect(screen.queryByTestId("academic-freetext-warning-0")).not.toBeInTheDocument()
+  })
+})
+
+describe("AcademicHistoryTab — school_name validation re-runs on pick (regression)", () => {
+  it("clears 'Tên trường không được để trống' after a school is set (was: stale error persisted)", async () => {
+    let capturedForm: UseFormReturn<AdmissionProfileUpdateInput> | null = null
+    renderTab({
+      isEditable: true,
+      withResolver: true,
+      exposeForm: (f) => {
+        capturedForm = f
+      },
+      defaults: {
+        academic_history: [
+          { school_id: null, school_name: "", level: null, year_from: 2022, year_to: 2025, grade_to: 12, gpa: null },
+        ],
+      } as Partial<AdmissionProfileUpdateInput>,
+    })
+
+    // Empty school_name → validation marks it required (shown via the free-text FormMessage).
+    await act(async () => {
+      await capturedForm!.trigger("academic_history.0.school_name")
+    })
+    expect(screen.getByText("Tên trường không được để trống")).toBeInTheDocument()
+
+    // Pick a real school FROM THE LIST (school_id set) — the reported scenario. The
+    // onChange setValue uses shouldValidate, so the stale error must clear.
+    fireEvent.click(screen.getByTestId("mock-pick-real-school"))
+    expect(capturedForm!.getValues("academic_history.0.school_name")).toBe("THPT Chuyên Nguyễn Du")
+
+    await waitFor(() => {
+      expect(screen.queryByText("Tên trường không được để trống")).not.toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
@@ -115,7 +115,15 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
                                     }}
                                     onChange={(v) => {
                                         form.setValue(`academic_history.${index}.school_id`, v.school_id, { shouldDirty: true })
-                                        form.setValue(`academic_history.${index}.school_name`, v.school_name, { shouldDirty: true })
+                                        // `shouldValidate: true` — picking a school sets the value
+                                        // programmatically, which does NOT re-run validation by default;
+                                        // without it a prior "Tên trường không được để trống" error
+                                        // (set when the row was empty) would persist even after a school
+                                        // is selected. Re-validating clears the stale error.
+                                        form.setValue(`academic_history.${index}.school_name`, v.school_name, {
+                                            shouldDirty: true,
+                                            shouldValidate: true,
+                                        })
                                         form.setValue(
                                             `academic_history.${index}.level`,
                                             v.level as (typeof VN_SCHOOL_LEVELS)[number] | null,
@@ -124,7 +132,13 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
                                     }}
                                     disabled={!isEditable}
                                 />
-                                {form.formState.errors.academic_history?.[index]?.school_name?.message && (
+                                {/* Manual error display ONLY when a school is picked (school_id set):
+                                    in that case the free-text fallback below is unmounted, so its
+                                    <FormMessage/> can't show the error. When school_id is null the
+                                    free-text FormField already renders the message — gating here avoids
+                                    showing "Tên trường không được để trống" twice. */}
+                                {form.watch(`academic_history.${index}.school_id`) &&
+                                    form.formState.errors.academic_history?.[index]?.school_name?.message && (
                                     <p className="text-xs text-destructive">
                                         {form.formState.errors.academic_history[index]?.school_name?.message as string}
                                     </p>

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.status-tabs.test.ts
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.status-tabs.test.ts
@@ -1,157 +1,54 @@
 /**
- * STATUS_TABS sync drift guard (#184 Wave 3 PR-3A FE bundle).
+ * ADMISSION_STATUS_TABS — single shared source for the admissions list tabs.
  *
- * ``AdmissionsClient.STATUS_TABS`` (rendered tabs) and
- * ``useAdmissionsFilter.STATUS_TABS`` (versioned-storage hook)
- * are two independent declarations of the tab → status mapping.
- * Drift between them = filter inconsistency across page reload:
- * a user who clicks "approved" tab and reloads gets the hook's
- * stored mapping which may include / exclude different statuses
- * than what the rendered tab currently filters.
- *
- * This test reads both declarations and asserts:
- *   1. Same set of tab keys.
- *   2. Same status set per shared tab key.
- *
- * Intentional divergence: ``AdmissionsClient`` exposes a
- * separate ``confirmed`` tab for officer ergonomics
- * (magic-link-pending visibility) while the filter hook
- * collapses ``confirmed`` into ``approved``. This is a
- * pre-existing ergonomic split documented in the hook source
- * and doesn't constitute drift; the test allows the
- * ``confirmed`` key on the UI side to be missing from the hook.
+ * Previously the tab → status mapping was DUPLICATED in AdmissionsClient (rendered
+ * tabs) and useAdmissionsFilter (filter), and the two copies DRIFTED: the hook
+ * lacked a `confirmed` tab and folded `confirmed` into `approved`. Result:
+ *   - clicking "Đã xác nhận" → handleTabClick found no tab → empty filter → the
+ *     list showed ALL profiles instead of only confirmed;
+ *   - the "Đã duyệt" count (UI, excludes confirmed) disagreed with its filtered
+ *     result (hook, includes confirmed).
+ * Both now import this ONE constant, so cross-file drift is impossible. These
+ * tests pin the intended grouping + 14-state coverage on the shared source.
  */
 import { describe, expect, it } from "vitest"
+import { ADMISSION_STATUS_TABS } from "@/hooks/admissions/filterDefaults"
 
-import { readFileSync } from "node:fs"
-import { resolve } from "node:path"
+const byKey = new Map(ADMISSION_STATUS_TABS.map((t) => [t.key, new Set(t.statuses)]))
 
-
-// Read the source files directly (instead of importing the
-// non-test modules) — both files have heavy ``"use client"``
-// dependencies that wouldn't load in a vitest happydom
-// environment without extensive mocking. Source-text inspection
-// gives us the same drift guard with zero setup overhead.
-
-const PROJECT_ROOT = resolve(__dirname, "../../../../..")
-const ADMISSIONS_CLIENT = resolve(
-  PROJECT_ROOT,
-  "src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx",
-)
-const FILTER_HOOK = resolve(
-  PROJECT_ROOT,
-  "src/hooks/admissions/useAdmissionsFilter.ts",
-)
-
-
-/** Parse a ``STATUS_TABS`` declaration from the source text.
- *
- * Uses a permissive regex that matches both the AdmissionsClient
- * (``label`` field) and the filter hook (no ``label``) shapes.
- * Returns a map of ``key -> Set<status>``. */
-function parseStatusTabs(source: string): Map<string, Set<string>> {
-  // Find the value declaration ``STATUS_TABS [: TypeAnnotation] = [``,
-  // not the type annotation. The hook source has
-  // ``STATUS_TABS: ReadonlyArray<{...}> = [...]`` so we need the
-  // ``= [`` after the type annotation, not the ``[`` inside
-  // ``readonly string[]``.
-  const declMatch = source.match(/STATUS_TABS[^=]*=\s*\[/)
-  expect(declMatch, "STATUS_TABS value declaration not found").not.toBeNull()
-  const arrayStart = source.indexOf("[", declMatch!.index! + declMatch![0].length - 1)
-  let depth = 0
-  let arrayEnd = arrayStart
-  for (let i = arrayStart; i < source.length; i++) {
-    if (source[i] === "[") depth++
-    else if (source[i] === "]") {
-      depth--
-      if (depth === 0) {
-        arrayEnd = i
-        break
-      }
-    }
-  }
-  const body = source.slice(arrayStart, arrayEnd + 1)
-
-  const result = new Map<string, Set<string>>()
-  // Each entry: { key: "...", ..., statuses: ["...", ...] }.
-  const entryRe = /\{[^{}]*?key:\s*"([^"]+)"[^{}]*?statuses:\s*\[([^\]]*)\]/g
-  let match: RegExpExecArray | null
-  while ((match = entryRe.exec(body)) !== null) {
-    const [, key, statusList] = match
-    const statuses = new Set<string>(
-      statusList
-        .split(",")
-        .map((s) => s.trim().replace(/^"|"$/g, ""))
-        .filter((s) => s.length > 0),
-    )
-    result.set(key, statuses)
-  }
-  return result
-}
-
-
-// =============================================================================
-// Drift guards
-// =============================================================================
-
-
-describe("STATUS_TABS sync — AdmissionsClient ↔ useAdmissionsFilter", () => {
-  const clientTabs = parseStatusTabs(readFileSync(ADMISSIONS_CLIENT, "utf-8"))
-  const hookTabs = parseStatusTabs(readFileSync(FILTER_HOOK, "utf-8"))
-
-  it("both declarations parse to non-empty maps", () => {
-    expect(clientTabs.size).toBeGreaterThan(0)
-    expect(hookTabs.size).toBeGreaterThan(0)
+describe("ADMISSION_STATUS_TABS — grouping", () => {
+  it("'confirmed' is its OWN tab = ['confirmed']", () => {
+    expect(byKey.get("confirmed")).toEqual(new Set(["confirmed"]))
   })
 
-  // The "confirmed" tab is intentionally only in the UI (officer
-  // ergonomic split). All other tabs MUST share status sets.
-  const SHARED_TAB_KEYS = [
-    "all",
-    "draft",
-    "pending",
-    "approved",
-    "waitlisted",
-    "enrolled",
-    "rejected",
-  ] as const
+  it("'approved' = approved/admitted/overridden and does NOT include confirmed", () => {
+    expect(byKey.get("approved")).toEqual(new Set(["approved", "admitted", "overridden"]))
+  })
 
-  for (const tabKey of SHARED_TAB_KEYS) {
-    it(`tab "${tabKey}" has the same status set in both declarations`, () => {
-      const clientSet = clientTabs.get(tabKey)
-      const hookSet = hookTabs.get(tabKey)
-      expect(clientSet, `client tab ${tabKey} missing`).toBeDefined()
-      expect(hookSet, `hook tab ${tabKey} missing`).toBeDefined()
+  it("'pending' bundles submitted/resubmitted/reviewing/revision_requested", () => {
+    expect(byKey.get("pending")).toEqual(
+      new Set(["submitted", "resubmitted", "reviewing", "revision_requested"]),
+    )
+  })
 
-      if (tabKey === "approved") {
-        // Hook bundles ``confirmed`` into ``approved``; UI splits
-        // them. Compare the status sets after normalizing the
-        // hook's union with the UI's confirmed contribution.
-        const uiConfirmed = clientTabs.get("confirmed") ?? new Set<string>()
-        const uiApprovedPlusConfirmed = new Set<string>([
-          ...(clientSet ?? []),
-          ...uiConfirmed,
-        ])
-        expect(uiApprovedPlusConfirmed).toEqual(hookSet)
-      } else {
-        expect(clientSet).toEqual(hookSet)
-      }
-    })
-  }
+  it("'rejected' bundles rejected/withdrawn", () => {
+    expect(byKey.get("rejected")).toEqual(new Set(["rejected", "withdrawn"]))
+  })
+
+  it("'all' tab = empty (no filter)", () => {
+    expect(byKey.get("all")?.size).toBe(0)
+  })
 })
 
+describe("ADMISSION_STATUS_TABS — 14-state coverage", () => {
+  const inSpecificTabs = new Set<string>()
+  for (const t of ADMISSION_STATUS_TABS) {
+    if (t.key === "all") continue
+    for (const s of t.statuses) inSpecificTabs.add(s)
+  }
 
-// =============================================================================
-// Coverage — every status reachable from at least one tab or "all"
-// =============================================================================
-
-
-describe("STATUS_TABS coverage — 14 admission status reachable", () => {
-  const clientTabs = parseStatusTabs(readFileSync(ADMISSIONS_CLIENT, "utf-8"))
-
-  // Status union excluding ``result_published`` (Codex Q1 chốt:
-  // broadcast marker, NOT a per-profile workflow target → intentionally
-  // not in any specific tab; reachable only via "Tất cả").
+  // result_published is intentionally in NO tab (broadcast marker; reachable via
+  // "Tất cả" / the status drop-down only — Codex Q1 chốt).
   const TAB_REACHABLE_STATES = [
     "draft",
     "submitted",
@@ -169,22 +66,15 @@ describe("STATUS_TABS coverage — 14 admission status reachable", () => {
   ] as const
 
   it("every workflow-target status appears in at least one specific tab", () => {
-    const allStatusesInTabs = new Set<string>()
-    for (const [key, statuses] of clientTabs) {
-      if (key === "all") continue
-      for (const s of statuses) allStatusesInTabs.add(s)
-    }
     for (const status of TAB_REACHABLE_STATES) {
       expect(
-        allStatusesInTabs.has(status),
+        inSpecificTabs.has(status),
         `status ${status} not reachable from any specific tab`,
       ).toBe(true)
     }
   })
 
-  it("'all' tab has empty status array (= no filter)", () => {
-    const allTab = clientTabs.get("all")
-    expect(allTab).toBeDefined()
-    expect(allTab?.size).toBe(0)
+  it("'result_published' is intentionally NOT in any specific tab", () => {
+    expect(inSpecificTabs.has("result_published")).toBe(false)
   })
 })

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -575,8 +575,11 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">Tất cả trình độ</SelectItem>
+              {/* Filter value MUST be the degree-level NAME ("Cao đẳng"), not the
+                  code ("cao_dang"): the BE matches it against the MajorProgram.degree_level
+                  TEXT column, which stores the name. Sending the code matched nothing. */}
               {degreeLevels?.map((level) => (
-                <SelectItem key={level.code} value={level.code}>
+                <SelectItem key={level.code} value={level.name}>
                   {level.name}
                 </SelectItem>
               ))}

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -114,6 +114,7 @@ import {
 import {
   areAdmissionsListParamsEqual,
   CURRENT_ADMISSIONS_YEAR,
+  ADMISSION_STATUS_TABS as STATUS_TABS,
 } from "@/hooks/admissions/filterDefaults"
 import { admissionsApi } from "@/lib/api/admissions"
 import { handleApiError, type ApiErrorResponse } from "@/lib/error-handler"
@@ -158,52 +159,9 @@ const PAYMENT_STATUS_OPTIONS = [
   { value: "no_fee", label: "Chưa có học phí" },
 ]
 
-/** Tab definitions - group statuses for quick filtering.
- *
- * `approved` vs `confirmed`: the applicant still has to tap the magic link
- * before enrollment — keeping the two tabs separate lets officers spot
- * profiles that are stuck waiting on the applicant without hunting through
- * a mixed "Đã duyệt" bucket. `overridden` stays with `approved` because it's
- * still an admin-driven state awaiting enroll.
- *
- * phase1_11 (#184 Wave 3 PR-3A) — 14-state display readiness:
- *
- * * ``reviewing`` joins ``pending`` (officer đang xét, chưa quyết).
- * * ``revision_requested`` joins ``pending`` (đã nộp + yêu cầu bổ sung,
- *   chờ ứng viên fix; UI consistent với resubmitted parallel state).
- * * ``admitted`` joins ``approved`` tab (positive admission outcome,
- *   choice engine equivalent of legacy ``approved``).
- * * ``waitlisted`` gets a NEW dedicated tab "Chờ ghế" between
- *   ``approved`` and ``confirmed`` chronologically (admin needs
- *   visibility into the wait queue separately from approved batch).
- * * ``withdrawn`` joins ``rejected`` tab (negative outcome — admin
- *   already filters these together via ``useAdmissionsFilter``).
- * * ``result_published`` is NOT in any tab — broadcast marker
- *   reachable only via "Tất cả" filter or the dedicated drop-down
- *   ``STATUS_OPTIONS`` (Codex Q1 chốt: not per-profile workflow target).
- *
- * MUST sync with ``useAdmissionsFilter.STATUS_TABS`` — drift
- * causes inconsistent filter behavior between tabs UI and the
- * versioned-storage hook.
- */
-const STATUS_TABS = [
-  { key: "all", label: "Tất cả", statuses: [] as string[] },
-  { key: "draft", label: "Nháp", statuses: ["draft"] },
-  {
-    key: "pending",
-    label: "Chờ duyệt",
-    statuses: ["submitted", "resubmitted", "reviewing", "revision_requested"],
-  },
-  {
-    key: "approved",
-    label: "Đã duyệt",
-    statuses: ["approved", "admitted", "overridden"],
-  },
-  { key: "waitlisted", label: "Chờ ghế", statuses: ["waitlisted"] },
-  { key: "confirmed", label: "Đã xác nhận", statuses: ["confirmed"] },
-  { key: "enrolled", label: "Đã nhập học", statuses: ["enrolled"] },
-  { key: "rejected", label: "Từ chối", statuses: ["rejected", "withdrawn"] },
-] as const
+// Status tabs (rendered here) come from the SHARED `ADMISSION_STATUS_TABS`
+// (imported as STATUS_TABS) so the tab→status filter mapping in
+// useAdmissionsFilter.handleTabClick can never drift from these rendered tabs.
 
 // =============================================================================
 // STAT CARD COMPONENT

--- a/frontend/src/components/admissions/VnSchoolPicker.test.tsx
+++ b/frontend/src/components/admissions/VnSchoolPicker.test.tsx
@@ -10,6 +10,7 @@
  * - "Hiển thị X/Y kết quả" message when total > items.length
  */
 import { describe, it, expect, vi, beforeEach, beforeAll } from "vitest"
+import * as React from "react"
 import { render, screen, fireEvent } from "@/test/utils/test-utils"
 import { VnSchoolPicker, type VnSchoolPickerValue } from "./VnSchoolPicker"
 
@@ -201,6 +202,40 @@ describe("VnSchoolPicker", () => {
     const input = screen.getByPlaceholderText(/Gõ tên trường/i)
     fireEvent.change(input, { target: { value: "khong tim thay" } })
     expect(screen.getByText(/Không tìm thấy trường nào/i)).toBeInTheDocument()
+  })
+
+  it("shows KV badge after picking even when the parent never feeds current_kv back", () => {
+    // Regression: AcademicHistoryTab passes value.current_kv = null (the form
+    // schema has no current_kv field). Before the fix the "KV hiện tại" badge
+    // could never render after a pick. The picker now remembers the picked
+    // school's KV internally so the officer gets immediate KV feedback.
+    mockHook.mockReturnValue({
+      data: { items: sampleItems, total: 3, limit: 20, offset: 0 },
+      isLoading: false,
+    })
+    function Parent() {
+      const [val, setVal] = React.useState<VnSchoolPickerValue>(emptyValue)
+      return (
+        <VnSchoolPicker
+          // Mirror AcademicHistoryTab: parent persists id/name/level but drops KV.
+          value={{ ...val, current_kv: null }}
+          onChange={(v) =>
+            setVal({
+              school_id: v.school_id,
+              school_name: v.school_name,
+              level: v.level,
+              current_kv: null,
+            })
+          }
+        />
+      )
+    }
+    render(<Parent />)
+    fireEvent.click(screen.getByRole("combobox"))
+    fireEvent.click(screen.getByText("PT DTNT Tây Nguyên")) // current_kv: KV1
+
+    expect(screen.getByText(/Đã chọn từ danh mục/i)).toBeInTheDocument()
+    expect(screen.getByText(/KV hiện tại: KV1/i)).toBeInTheDocument()
   })
 
   it("disabled prop disables trigger button", () => {

--- a/frontend/src/components/admissions/VnSchoolPicker.tsx
+++ b/frontend/src/components/admissions/VnSchoolPicker.tsx
@@ -60,6 +60,18 @@ export function VnSchoolPicker({
   const [open, setOpen] = React.useState(false)
   const [query, setQuery] = React.useState("")
   const [debouncedQuery, setDebouncedQuery] = React.useState("")
+  // Display-only KV of the school picked in THIS session. The form schema
+  // (academicRecordSchema) has NO current_kv field — KV is engine-resolved at
+  // submit — so the AcademicHistoryTab parent always feeds `value.current_kv =
+  // null` back. Without this, the "KV hiện tại" badge could never render after
+  // a pick, even though the search API returns the school's current_kv. We keep
+  // {id, kv} so the badge only shows for the school currently selected (no stale
+  // KV if the selection changes). Falls back to value.current_kv when a parent
+  // does supply one (e.g. the unit tests).
+  const [pickedSchool, setPickedSchool] = React.useState<{
+    id: number
+    kv: string | null
+  } | null>(null)
 
   // Debounce search query (300ms)
   React.useEffect(() => {
@@ -74,6 +86,7 @@ export function VnSchoolPicker({
   })
 
   const handleSelect = (school: VnSchoolSearchItem) => {
+    setPickedSchool({ id: school.id, kv: school.current_kv })
     onChange({
       school_id: school.id,
       school_name: school.name,
@@ -85,6 +98,7 @@ export function VnSchoolPicker({
 
   const handleManualClear = (e: React.MouseEvent) => {
     e.stopPropagation()
+    setPickedSchool(null)
     onChange({
       school_id: null,
       school_name: "",
@@ -93,6 +107,13 @@ export function VnSchoolPicker({
     })
     setQuery("")
   }
+
+  // KV to display in the badge: the parent's value.current_kv if present, else
+  // the in-session pick — but only when it matches the currently selected school
+  // (guards against showing a previous school's KV after the selection changes).
+  const displayKv =
+    value.current_kv ??
+    (pickedSchool && pickedSchool.id === value.school_id ? pickedSchool.kv : null)
 
   const displayLabel = value.school_name || placeholder
 
@@ -224,9 +245,9 @@ export function VnSchoolPicker({
             {value.level && (
               <span className="ml-2 font-medium">{value.level}</span>
             )}
-            {value.current_kv && (
+            {displayKv && (
               <span className="ml-2 text-info-700 font-medium">
-                KV hiện tại: {value.current_kv}
+                KV hiện tại: {displayKv}
               </span>
             )}
           </span>

--- a/frontend/src/hooks/admissions/filterDefaults.ts
+++ b/frontend/src/hooks/admissions/filterDefaults.ts
@@ -2,6 +2,40 @@ import type { AdmissionListParams } from "@/lib/zod/admissions"
 
 export type AdmissionsSearchParamsRecord = Record<string, string | string[] | undefined>
 
+/**
+ * Status tabs for the admissions list — the SINGLE source for both the tab UI
+ * (AdmissionsClient renders `label`) and the tab→status filter mapping
+ * (useAdmissionsFilter.handleTabClick reads `statuses`). Keeping ONE constant
+ * prevents the drift that previously broke the "Đã xác nhận" filter (the hook's
+ * copy lacked a `confirmed` tab → handleTabClick("confirmed") set an empty filter
+ * → showed ALL profiles) and made the "Đã duyệt" count disagree with its result
+ * (the hook folded `confirmed` into `approved` while the UI counted it separately).
+ *
+ * 14-state grouping (phase1_11 #184): pending = submitted/resubmitted/reviewing/
+ * revision_requested; approved = approved/admitted/overridden (admin-driven,
+ * awaiting enroll); confirmed has its OWN tab (applicant tapped the magic link);
+ * waitlisted its own; rejected = rejected/withdrawn. `result_published` is in no
+ * tab (broadcast marker, reachable only via "Tất cả" / the status drop-down).
+ */
+export const ADMISSION_STATUS_TABS: ReadonlyArray<{
+  key: string
+  label: string
+  statuses: readonly string[]
+}> = [
+  { key: "all", label: "Tất cả", statuses: [] },
+  { key: "draft", label: "Nháp", statuses: ["draft"] },
+  {
+    key: "pending",
+    label: "Chờ duyệt",
+    statuses: ["submitted", "resubmitted", "reviewing", "revision_requested"],
+  },
+  { key: "approved", label: "Đã duyệt", statuses: ["approved", "admitted", "overridden"] },
+  { key: "waitlisted", label: "Chờ ghế", statuses: ["waitlisted"] },
+  { key: "confirmed", label: "Đã xác nhận", statuses: ["confirmed"] },
+  { key: "enrolled", label: "Đã nhập học", statuses: ["enrolled"] },
+  { key: "rejected", label: "Từ chối", statuses: ["rejected", "withdrawn"] },
+]
+
 export const ADMISSIONS_DEFAULT_PAGE_SIZE = 20
 export const ADMISSIONS_DEFAULT_SORT_BY: NonNullable<AdmissionListParams["sort_by"]> = "created_at"
 export const ADMISSIONS_DEFAULT_SORT_ORDER: NonNullable<AdmissionListParams["order"]> = "desc"

--- a/frontend/src/hooks/admissions/useAdmissionsFilter.test.ts
+++ b/frontend/src/hooks/admissions/useAdmissionsFilter.test.ts
@@ -154,7 +154,7 @@ describe("useAdmissionsFilter", () => {
       expect(result.current.state.statusFilters).toEqual([])
     })
 
-    it('should set statusFilters for the "approved" tab', () => {
+    it('should set statusFilters for the "approved" tab (admitted/overridden, NOT confirmed)', () => {
       const { result } = renderHook(() => useAdmissionsFilter())
 
       act(() => {
@@ -163,8 +163,22 @@ describe("useAdmissionsFilter", () => {
 
       expect(result.current.state.activeTab).toBe("approved")
       expect(result.current.state.statusFilters).toContain("approved")
-      expect(result.current.state.statusFilters).toContain("confirmed")
+      expect(result.current.state.statusFilters).toContain("admitted")
       expect(result.current.state.statusFilters).toContain("overridden")
+      // `confirmed` has its OWN tab — it must NOT be folded into approved, or the
+      // "Đã duyệt" count (which excludes confirmed) would disagree with the result.
+      expect(result.current.state.statusFilters).not.toContain("confirmed")
+    })
+
+    it('should filter to ["confirmed"] for the "confirmed" tab (regression: hook drift left it empty → showed ALL)', () => {
+      const { result } = renderHook(() => useAdmissionsFilter())
+
+      act(() => {
+        result.current.handlers.handleTabClick("confirmed")
+      })
+
+      expect(result.current.state.activeTab).toBe("confirmed")
+      expect(result.current.state.statusFilters).toEqual(["confirmed"])
     })
 
     it("should reset page to 1 when switching tabs", () => {

--- a/frontend/src/hooks/admissions/useAdmissionsFilter.ts
+++ b/frontend/src/hooks/admissions/useAdmissionsFilter.ts
@@ -20,6 +20,7 @@ import type { AdmissionListParams } from "@/lib/zod/admissions"
 import {
   ADMISSIONS_DEFAULT_PAGE_SIZE,
   CURRENT_ADMISSIONS_YEAR,
+  ADMISSION_STATUS_TABS as STATUS_TABS,
 } from "./filterDefaults"
 
 // =============================================================================
@@ -80,42 +81,10 @@ interface VersionedStorage {
   data: StoredFilters
 }
 
-/**
- * Tab definitions — group statuses for quick filtering.
- *
- * phase1_11 (#184 Wave 3 PR-3A) — 14-state display readiness.
- * MUST stay in lockstep with ``AdmissionsClient.STATUS_TABS``;
- * the UI tabs read the latter, this hook reads its own constant
- * for versioned storage rehydrate. Drift = filter inconsistency
- * across page reload.
- *
- * Differences from the AdmissionsClient version:
- * * ``confirmed`` lives in its own tab in the UI (officer ergonomic
- *   per Codex Q2 prior decision); but here it's bucketed into
- *   ``approved`` for the storage shape. The hook's STATUS_TABS is
- *   only used as the storage-version key set; UI rendering
- *   defers to the AdmissionsClient declaration. Keeping the two
- *   shapes intentionally diverging on ``confirmed`` is a
- *   pre-existing ergonomic split; phase1_11 doesn't change it.
- */
-const STATUS_TABS: ReadonlyArray<{
-  key: string
-  statuses: readonly string[]
-}> = [
-  { key: "all", statuses: [] },
-  { key: "draft", statuses: ["draft"] },
-  {
-    key: "pending",
-    statuses: ["submitted", "resubmitted", "reviewing", "revision_requested"],
-  },
-  {
-    key: "approved",
-    statuses: ["approved", "admitted", "confirmed", "overridden"],
-  },
-  { key: "waitlisted", statuses: ["waitlisted"] },
-  { key: "enrolled", statuses: ["enrolled"] },
-  { key: "rejected", statuses: ["rejected", "withdrawn"] },
-]
+// STATUS_TABS is the SHARED `ADMISSION_STATUS_TABS` (imported as STATUS_TABS) —
+// the SAME constant the UI renders, so handleTabClick's tab→status mapping can
+// never drift from the rendered tabs (the old local copy drifted: it lacked a
+// `confirmed` tab and folded `confirmed` into `approved`, breaking the filter).
 
 const DEFAULT_FILTERS: StoredFilters = {
   page: 1,

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -330,9 +330,11 @@ export const academicRecordSchema = z
       .nullable(),
     school_name: z
       .string()
+      // .trim() BEFORE .min(1) so a whitespace-only value ("   ") fails the
+      // required check instead of passing it and then collapsing to "".
+      .trim()
       .min(1, "Tên trường không được để trống")
-      .max(255, "Tên trường không được quá 255 ký tự")
-      .trim(),
+      .max(255, "Tên trường không được quá 255 ký tự"),
     level: z
       .enum(VN_SCHOOL_LEVELS)
       .optional()


### PR DESCRIPTION
## Tổng quan

Gom 4 fix bug cho **danh sách + chi tiết hồ sơ tuyển sinh** (admissions). Tất cả thuần frontend, đã type-check sạch + unit test xanh + smoke trực tiếp trên dev.

## Các fix

### 1. `0d363d09` — Tab danh sách lệch filter/count
Mapping tab → status bị **trùng lặp** ở `AdmissionsClient` (render tab) và `useAdmissionsFilter` (lọc), và 2 bản đã **drift**: hook thiếu tab `confirmed` và gộp `confirmed` vào `approved`. Hậu quả:
- Bấm **"Đã xác nhận"** → `handleTabClick` không tìm thấy tab → filter rỗng → danh sách hiện **TẤT CẢ** thay vì chỉ confirmed.
- Count "Đã duyệt" (UI, loại confirmed) lệch với kết quả lọc (hook, gồm confirmed).

→ Gộp về **một nguồn `ADMISSION_STATUS_TABS`** (`filterDefaults.ts`), cả 2 file cùng import. `confirmed` là tab riêng `["confirmed"]`; `approved = ["approved","admitted","overridden"]`. Viết lại test (bỏ source-parser tautological) + pin 14-state coverage.

### 2. `48c6eb4e` — Lọc trình độ gửi `code` thay vì `name`
`SelectItem value={level.code}` ("cao_dang") nhưng BE lọc `MajorProgram.degree_level == <param>` mà cột lưu **name** ("Cao đẳng") → luôn 0 kết quả.
→ Đổi `value={level.name}`. Verified trên API dev: name "Cao đẳng" → 10 hồ sơ; code "cao_dang" → 0.

### 3. `7de247d5` — Lịch sử học tập: lỗi "Tên trường không được để trống" dính sau khi chọn trường
`setValue(school_name, ...)` không kèm `shouldValidate` → react-hook-form **không re-validate** → lỗi required (set lúc dòng trống) còn dính dù đã chọn trường.
→ Thêm `shouldValidate: true`; `.trim()` trước `.min(1)` trong zod; gate hiển thị lỗi thủ công theo `school_id` để **không hiện trùng** với FormMessage của ô free-text. Regression test: trigger lỗi → chọn trường thật → lỗi clear.

### 4. `0a8f8045` — Lịch sử học tập: KV không hiển thị sau khi chọn trường
`academicRecordSchema` không có field `current_kv` (KV do engine resolve lúc submit) nên `AcademicHistoryTab` luôn truyền `value.current_kv = null` → badge **"KV hiện tại"** không bao giờ render, dù search API trả về `current_kv`. Officer thấy "✓ Đã chọn từ danh mục THPT" mà không có KV → cảm giác KV không xác định được.
→ `VnSchoolPicker` giữ `{id, kv}` của trường vừa chọn trong state **display-only**, render "KV hiện tại: KVx" ngay sau khi chọn (gate theo `id` khớp selection hiện tại để không stale). **Không gửi xuống BE** (tránh drift với engine). Fallback `value.current_kv` nếu parent có truyền.
- Giới hạn đã biết: khi mở lại hồ sơ đã lưu, KV chưa hiện (current_kv không nằm trong payload `academic_history`). In-session pick là phạm vi fix có chủ đích — fix sâu (BE thêm field) để follow-up nếu cần.

## Kiểm thử

- `npm run type-check` — sạch.
- `VnSchoolPicker.test.tsx` — 11/11 pass (gồm test KV mới: parent drop current_kv vẫn hiện KV sau pick).
- `AcademicHistoryTab.test.tsx` + `useAdmissionsFilter.test.ts` + `AdmissionsClient.status-tabs.test.ts` — cập nhật + xanh.
- **Smoke trực tiếp dev (#46):**
  - Nhập 3 năm: THPT Lê Quý Đôn (lớp 10) + THPT Hồng Đức (lớp 11/12) + Trình độ THPT.
  - Cả 3 dòng hiển thị **"KV hiện tại: KV2"**, 0 cảnh báo free-text.
  - Payload PUT gửi `school_id` 168/166/166 chuẩn (round-trip đúng). (Save 422 do CCCD placeholder của hồ sơ test, không liên quan lịch sử học tập.)

## Phạm vi
Thuần FE. Không đổi schema/migration BE. Không gửi thêm field nào xuống BE.
