### PR TITLE
feat(admissions): cải thiện tab Lịch sử học tập (quick-add THCS + validation + layout + KV)

### DIFF
--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.test.tsx
@@ -51,7 +51,7 @@ vi.mock("@/components/admissions/VnSchoolPicker", () => ({
 }))
 
 import { AcademicHistoryTab } from "./AcademicHistoryTab"
-import type { AdmissionProfileUpdateInput } from "@/lib/zod/admissions"
+import type { AdmissionProfileUpdateInput, AcademicRecord } from "@/lib/zod/admissions"
 
 function Harness({
   defaults,
@@ -118,6 +118,124 @@ describe("AcademicHistoryTab — Commit 5 quick-add 3 năm THPT", () => {
     // Lớp 12 = graduation_type THPT, lớp 10/11 null
     expect((history[2] as { graduation_type?: string | null }).graduation_type).toBe("THPT")
     expect((history[0] as { graduation_type?: string | null }).graduation_type).toBeNull()
+  })
+})
+
+describe("AcademicHistoryTab — quick-add 4 năm THCS", () => {
+  it("Button 'Thêm 4 năm THCS' render khi isEditable=true", () => {
+    renderTab({ isEditable: true })
+    expect(screen.getByTestId("academic-quick-add-thcs")).toBeInTheDocument()
+  })
+
+  it("Button KHÔNG render khi isEditable=false", () => {
+    renderTab({ isEditable: false })
+    expect(screen.queryByTestId("academic-quick-add-thcs")).not.toBeInTheDocument()
+  })
+
+  it("Click tạo đúng 4 record lớp 6/7/8/9 + graduation_type=THCS ở lớp 9", () => {
+    let capturedForm: UseFormReturn<AdmissionProfileUpdateInput> | null = null
+    renderTab({
+      isEditable: true,
+      exposeForm: (f) => {
+        capturedForm = f
+      },
+    })
+
+    fireEvent.click(screen.getByTestId("academic-quick-add-thcs"))
+
+    const history = capturedForm!.getValues("academic_history") ?? []
+    expect(history).toHaveLength(4)
+    expect(history.map((h) => h.grade_to)).toEqual([6, 7, 8, 9])
+    // Lớp 9 = graduation_type THCS, lớp 6/7/8 null
+    expect((history[3] as { graduation_type?: string | null }).graduation_type).toBe("THCS")
+    expect((history[0] as { graduation_type?: string | null }).graduation_type).toBeNull()
+    // year_from === year_to mỗi record (1 năm/lớp), năm tăng dần
+    expect(history[0].year_to).toBe(history[0].year_from)
+    expect(history[3].year_to - history[0].year_from).toBe(3)
+  })
+})
+
+describe("AcademicHistoryTab — soft data-quality notices (Tầng 2/3)", () => {
+  const rec = (over: Partial<AcademicRecord>): AcademicRecord => ({
+    school_id: 1,
+    school_name: "Trường X",
+    level: "THPT",
+    year_from: 2020,
+    year_to: 2021,
+    grade_to: 12,
+    gpa: null,
+    ...over,
+  })
+
+  it("cảnh báo trùng lớp khi 2 entry cùng grade_to", () => {
+    renderTab({
+      defaults: {
+        academic_history: [
+          rec({ school_id: 1, grade_to: 12, year_from: 2020, year_to: 2021 }),
+          rec({ school_id: 2, grade_to: 12, year_from: 2021, year_to: 2022 }),
+        ],
+      } as Partial<AdmissionProfileUpdateInput>,
+    })
+    expect(screen.getByText(/Lớp 12 xuất hiện nhiều lần/i)).toBeInTheDocument()
+  })
+
+  it("cảnh báo khi > 3 năm THPT (cho phép, không chặn)", () => {
+    renderTab({
+      defaults: {
+        academic_history: [
+          rec({ school_id: 1, grade_to: 10 }),
+          rec({ school_id: 2, grade_to: 11 }),
+          rec({ school_id: 3, grade_to: 12 }),
+          rec({ school_id: 4, grade_to: 11 }),
+        ],
+      } as Partial<AdmissionProfileUpdateInput>,
+    })
+    expect(screen.getByText(/Đang có 4 năm THPT/i)).toBeInTheDocument()
+  })
+
+  it("cảnh báo năm kết thúc ở tương lai", () => {
+    const future = new Date().getFullYear() + 5
+    renderTab({
+      defaults: {
+        academic_history: [rec({ year_from: future, year_to: future, grade_to: 12 })],
+      } as Partial<AdmissionProfileUpdateInput>,
+    })
+    expect(screen.getByText(/kiểm tra lại năm học/i)).toBeInTheDocument()
+  })
+
+  it("hiện gợi ý KV khi có dòng THPT nhưng chưa chọn trường từ danh mục", () => {
+    renderTab({
+      defaults: {
+        academic_history: [rec({ school_id: null, school_name: "THPT gõ tay", grade_to: 12 })],
+      } as Partial<AdmissionProfileUpdateInput>,
+    })
+    expect(screen.getByTestId("academic-kv-hint")).toBeInTheDocument()
+  })
+
+  it("ẩn gợi ý KV khi đã chọn ít nhất 1 trường THPT từ danh mục", () => {
+    renderTab({
+      defaults: {
+        academic_history: [rec({ school_id: 42, grade_to: 12 })],
+      } as Partial<AdmissionProfileUpdateInput>,
+    })
+    expect(screen.queryByTestId("academic-kv-hint")).not.toBeInTheDocument()
+  })
+
+  it("KHÔNG có notice nào khi nhập chuẩn 3 THPT + 4 THCS đã chọn trường", () => {
+    renderTab({
+      defaults: {
+        academic_history: [
+          rec({ school_id: 1, level: "THCS", grade_to: 6 }),
+          rec({ school_id: 1, level: "THCS", grade_to: 7 }),
+          rec({ school_id: 1, level: "THCS", grade_to: 8 }),
+          rec({ school_id: 1, level: "THCS", grade_to: 9 }),
+          rec({ school_id: 2, grade_to: 10 }),
+          rec({ school_id: 2, grade_to: 11 }),
+          rec({ school_id: 2, grade_to: 12 }),
+        ],
+      } as Partial<AdmissionProfileUpdateInput>,
+    })
+    expect(screen.queryByTestId("academic-notices")).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.test.tsx
@@ -99,7 +99,7 @@ describe("AcademicHistoryTab — Commit 5 quick-add 3 năm THPT", () => {
     expect(screen.queryByTestId("academic-quick-add-thpt")).not.toBeInTheDocument()
   })
 
-  it("Click button tạo đúng 3 record lớp 10/11/12 + graduation_type=THPT ở lớp 12", () => {
+  it("Click button tạo đúng 3 record lớp 10/11/12 + graduation_type=THPT mọi lớp", () => {
     let capturedForm: UseFormReturn<AdmissionProfileUpdateInput> | null = null
     renderTab({
       isEditable: true,
@@ -115,9 +115,10 @@ describe("AcademicHistoryTab — Commit 5 quick-add 3 năm THPT", () => {
     expect(history[0].grade_to).toBe(10)
     expect(history[1].grade_to).toBe(11)
     expect(history[2].grade_to).toBe(12)
-    // Lớp 12 = graduation_type THPT, lớp 10/11 null
-    expect((history[2] as { graduation_type?: string | null }).graduation_type).toBe("THPT")
-    expect((history[0] as { graduation_type?: string | null }).graduation_type).toBeNull()
+    // Trình độ = THPT cho MỌI lớp (tương xứng cấp học quick-add)
+    expect(
+      (history as Array<{ graduation_type?: string | null }>).map((h) => h.graduation_type),
+    ).toEqual(["THPT", "THPT", "THPT"])
   })
 })
 
@@ -132,7 +133,7 @@ describe("AcademicHistoryTab — quick-add 4 năm THCS", () => {
     expect(screen.queryByTestId("academic-quick-add-thcs")).not.toBeInTheDocument()
   })
 
-  it("Click tạo đúng 4 record lớp 6/7/8/9 + graduation_type=THCS ở lớp 9", () => {
+  it("Click tạo đúng 4 record lớp 6/7/8/9 + graduation_type=THCS mọi lớp", () => {
     let capturedForm: UseFormReturn<AdmissionProfileUpdateInput> | null = null
     renderTab({
       isEditable: true,
@@ -146,9 +147,10 @@ describe("AcademicHistoryTab — quick-add 4 năm THCS", () => {
     const history = capturedForm!.getValues("academic_history") ?? []
     expect(history).toHaveLength(4)
     expect(history.map((h) => h.grade_to)).toEqual([6, 7, 8, 9])
-    // Lớp 9 = graduation_type THCS, lớp 6/7/8 null
-    expect((history[3] as { graduation_type?: string | null }).graduation_type).toBe("THCS")
-    expect((history[0] as { graduation_type?: string | null }).graduation_type).toBeNull()
+    // Trình độ = THCS cho MỌI lớp (tương xứng cấp học quick-add)
+    expect(
+      (history as Array<{ graduation_type?: string | null }>).map((h) => h.graduation_type),
+    ).toEqual(["THCS", "THCS", "THCS", "THCS"])
     // year_from === year_to mỗi record (1 năm/lớp), năm tăng dần
     expect(history[0].year_to).toBe(history[0].year_from)
     expect(history[3].year_to - history[0].year_from).toBe(3)

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
@@ -26,6 +26,20 @@ interface AcademicHistoryTabProps {
   isEditable: boolean
 }
 
+// Dải lớp theo cấp học — nguồn DUY NHẤT cho quick-add + phân loại notices,
+// tránh magic number rải rác (vd đổi range quick-add nhưng quên đổi filter
+// notices → lệch âm thầm). graduationType gán ở lớp cuối cấp. Engine KV chỉ
+// dùng entry THPT; THCS display-only.
+const GRADE_BANDS = {
+  THCS: { start: 6, end: 9, graduationType: "THCS" },
+  THPT: { start: 10, end: 12, graduationType: "THPT" },
+} as const
+
+type GradeBand = (typeof GRADE_BANDS)[keyof typeof GRADE_BANDS]
+const bandYears = (b: { start: number; end: number }) => b.end - b.start + 1
+const bandGradesLabel = (b: { start: number; end: number }) =>
+  Array.from({ length: bandYears(b) }, (_, i) => b.start + i).join("/")
+
 export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps) {
   const { fields, append, remove } = useFieldArray({
     control: form.control,
@@ -44,15 +58,14 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
     })
   }
 
-  // Commit 5 — quick-add 3 năm THPT. Tạo 3 record lớp 10/11/12 mặc định
-  // dùng năm hiện tại làm tốt nghiệp; officer chỉ cần điền tên trường +
-  // GPA. Engine yêu cầu lịch sử THPT để xác định KV → tăng tốc nhập hồ
-  // sơ tốt nghiệp năm hiện tại.
-  const addThreeYearsThpt = () => {
-    const gradYear = new Date().getFullYear()
-    for (let i = 0; i < 3; i++) {
-      const grade = 10 + i
-      const year = gradYear - 2 + i
+  // Quick-add toàn bộ các lớp của một cấp (THPT 10→12, THCS 6→9). Mỗi lớp 1
+  // năm, lớp cuối cấp = endYear; officer chỉ cần điền trường + GPA. graduation_type
+  // gán ở lớp cuối. Engine yêu cầu lịch sử THPT có school_id để xác định KV.
+  const addBand = (band: GradeBand, endYear: number) => {
+    const count = bandYears(band)
+    for (let i = 0; i < count; i++) {
+      const grade = band.start + i
+      const year = endYear - (count - 1) + i // lớp đầu = endYear−(count−1) … lớp cuối = endYear
       append({
         school_id: null,
         school_name: "",
@@ -61,43 +74,32 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
         year_to: year,
         grade_to: grade,
         gpa: null,
-        graduation_type: grade === 12 ? "THPT" : null,
+        graduation_type: grade === band.end ? band.graduationType : null,
       } as Parameters<typeof append>[0])
     }
   }
 
-  // Quick-add 4 năm THCS (lớp 6/7/8/9). Đối xứng với addThreeYearsThpt. Năm
-  // tự điền lùi: lớp 9 = năm ngay trước khi vào lớp 10 nếu đã có THPT (chuỗi
-  // liền mạch dưới THPT), else năm hiện tại − 3. Engine KV KHÔNG dùng entry
-  // THCS (chỉ lưu hồ sơ) — nút này phục vụ nhập liệu nhanh học bạ THCS.
+  // 3 năm THPT (lớp 10/11/12), tốt nghiệp = năm hiện tại.
+  const addThreeYearsThpt = () => addBand(GRADE_BANDS.THPT, new Date().getFullYear())
+
+  // 4 năm THCS (lớp 6/7/8/9). Năm tự lùi: lớp 9 = năm ngay trước khi vào lớp 10
+  // nếu hồ sơ đã có THPT (chuỗi liền mạch), else năm hiện tại − 3. Engine KV
+  // KHÔNG dùng entry THCS (chỉ lưu hồ sơ).
   const addFourYearsThcs = () => {
     const existing = form.getValues("academic_history") ?? []
     const thptStartYears = existing
       .filter(
         (r) =>
           r?.grade_to != null &&
-          r.grade_to >= 10 &&
-          r.grade_to <= 12 &&
+          r.grade_to >= GRADE_BANDS.THPT.start &&
+          r.grade_to <= GRADE_BANDS.THPT.end &&
           r?.year_from != null,
       )
       .map((r) => r.year_from as number)
     const grade9Year = thptStartYears.length
       ? Math.min(...thptStartYears) - 1
       : new Date().getFullYear() - 3
-    for (let i = 0; i < 4; i++) {
-      const grade = 6 + i
-      const year = grade9Year - 3 + i // lớp 6 = grade9Year−3 … lớp 9 = grade9Year
-      append({
-        school_id: null,
-        school_name: "",
-        level: null,
-        year_from: year,
-        year_to: year,
-        grade_to: grade,
-        gpa: null,
-        graduation_type: grade === 9 ? "THCS" : null,
-      } as Parameters<typeof append>[0])
-    }
+    addBand(GRADE_BANDS.THCS, grade9Year)
   }
 
   // ── Vệ sinh nhập liệu (Tầng 2) + gợi ý KV (Tầng 3) ─────────────────────────
@@ -113,8 +115,12 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
   const currentYear = new Date().getFullYear()
   const inBand = (g: number | null | undefined, lo: number, hi: number): boolean =>
     g != null && g >= lo && g <= hi
-  const thptRecords = records.filter((r) => inBand(r?.grade_to, 10, 12))
-  const thcsRecords = records.filter((r) => inBand(r?.grade_to, 6, 9))
+  const thptRecords = records.filter((r) =>
+    inBand(r?.grade_to, GRADE_BANDS.THPT.start, GRADE_BANDS.THPT.end),
+  )
+  const thcsRecords = records.filter((r) =>
+    inBand(r?.grade_to, GRADE_BANDS.THCS.start, GRADE_BANDS.THCS.end),
+  )
 
   const gradeCount = new Map<number, number>()
   records.forEach((r) => {
@@ -134,13 +140,13 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
     softNotices.push(
       `Lớp ${dupGrades.join(", ")} xuất hiện nhiều lần — kiểm tra lại nếu không phải chuyển trường giữa năm.`,
     )
-  if (thptRecords.length > 3)
+  if (thptRecords.length > bandYears(GRADE_BANDS.THPT))
     softNotices.push(
-      `Đang có ${thptRecords.length} năm THPT (thường 3 năm: lớp 10/11/12). Nhiều hơn là bình thường nếu chuyển trường.`,
+      `Đang có ${thptRecords.length} năm THPT (thường ${bandYears(GRADE_BANDS.THPT)} năm: lớp ${bandGradesLabel(GRADE_BANDS.THPT)}). Nhiều hơn là bình thường nếu chuyển trường.`,
     )
-  if (thcsRecords.length > 4)
+  if (thcsRecords.length > bandYears(GRADE_BANDS.THCS))
     softNotices.push(
-      `Đang có ${thcsRecords.length} năm THCS (thường 4 năm: lớp 6/7/8/9).`,
+      `Đang có ${thcsRecords.length} năm THCS (thường ${bandYears(GRADE_BANDS.THCS)} năm: lớp ${bandGradesLabel(GRADE_BANDS.THCS)}).`,
     )
   if (hasFutureYear)
     softNotices.push(

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
@@ -19,7 +19,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Plus, Trash2, GraduationCap } from "lucide-react"
 import { VnSchoolPicker } from "@/components/admissions/VnSchoolPicker"
 import { VN_SCHOOL_LEVELS } from "@/lib/zod/admissions"
-import type { AdmissionProfileUpdate, AdmissionProfileUpdateInput } from "@/lib/zod/admissions"
+import type { AdmissionProfileUpdateInput } from "@/lib/zod/admissions"
 
 interface AcademicHistoryTabProps {
   form: UseFormReturn<AdmissionProfileUpdateInput>
@@ -66,6 +66,93 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
     }
   }
 
+  // Quick-add 4 năm THCS (lớp 6/7/8/9). Đối xứng với addThreeYearsThpt. Năm
+  // tự điền lùi: lớp 9 = năm ngay trước khi vào lớp 10 nếu đã có THPT (chuỗi
+  // liền mạch dưới THPT), else năm hiện tại − 3. Engine KV KHÔNG dùng entry
+  // THCS (chỉ lưu hồ sơ) — nút này phục vụ nhập liệu nhanh học bạ THCS.
+  const addFourYearsThcs = () => {
+    const existing = form.getValues("academic_history") ?? []
+    const thptStartYears = existing
+      .filter(
+        (r) =>
+          r?.grade_to != null &&
+          r.grade_to >= 10 &&
+          r.grade_to <= 12 &&
+          r?.year_from != null,
+      )
+      .map((r) => r.year_from as number)
+    const grade9Year = thptStartYears.length
+      ? Math.min(...thptStartYears) - 1
+      : new Date().getFullYear() - 3
+    for (let i = 0; i < 4; i++) {
+      const grade = 6 + i
+      const year = grade9Year - 3 + i // lớp 6 = grade9Year−3 … lớp 9 = grade9Year
+      append({
+        school_id: null,
+        school_name: "",
+        level: null,
+        year_from: year,
+        year_to: year,
+        grade_to: grade,
+        gpa: null,
+        graduation_type: grade === 9 ? "THCS" : null,
+      } as Parameters<typeof append>[0])
+    }
+  }
+
+  // ── Vệ sinh nhập liệu (Tầng 2) + gợi ý KV (Tầng 3) ─────────────────────────
+  // Thuần data-quality hints (cảnh báo MỀM, KHÔNG chặn lưu/nộp) — engine BE
+  // mới là nguồn KV/eligibility chính thức (xem priority_service). Đếm theo
+  // grade_to (10-12 = THPT, 6-9 = THCS) để hoạt động ngay cả khi chưa chọn
+  // trường (level chỉ set sau khi pick từ danh mục).
+  const records = (form.watch("academic_history") ?? []) as Array<{
+    grade_to?: number | null
+    year_to?: number | null
+    school_id?: number | null
+  }>
+  const currentYear = new Date().getFullYear()
+  const inBand = (g: number | null | undefined, lo: number, hi: number): boolean =>
+    g != null && g >= lo && g <= hi
+  const thptRecords = records.filter((r) => inBand(r?.grade_to, 10, 12))
+  const thcsRecords = records.filter((r) => inBand(r?.grade_to, 6, 9))
+
+  const gradeCount = new Map<number, number>()
+  records.forEach((r) => {
+    if (r?.grade_to != null)
+      gradeCount.set(r.grade_to, (gradeCount.get(r.grade_to) ?? 0) + 1)
+  })
+  const dupGrades = [...gradeCount.entries()]
+    .filter(([, c]) => c > 1)
+    .map(([g]) => g)
+    .sort((a, b) => a - b)
+  const hasFutureYear = records.some(
+    (r) => r?.year_to != null && r.year_to > currentYear + 1,
+  )
+
+  const softNotices: string[] = []
+  if (dupGrades.length > 0)
+    softNotices.push(
+      `Lớp ${dupGrades.join(", ")} xuất hiện nhiều lần — kiểm tra lại nếu không phải chuyển trường giữa năm.`,
+    )
+  if (thptRecords.length > 3)
+    softNotices.push(
+      `Đang có ${thptRecords.length} năm THPT (thường 3 năm: lớp 10/11/12). Nhiều hơn là bình thường nếu chuyển trường.`,
+    )
+  if (thcsRecords.length > 4)
+    softNotices.push(
+      `Đang có ${thcsRecords.length} năm THCS (thường 4 năm: lớp 6/7/8/9).`,
+    )
+  if (hasFutureYear)
+    softNotices.push(
+      `Có năm kết thúc lớn hơn ${currentYear + 1} — kiểm tra lại năm học.`,
+    )
+
+  // Tầng 3 — engine chỉ resolve KV từ entry THPT CÓ school_id (chọn từ danh
+  // mục). Có dòng THPT nhưng chưa chọn trường nào từ danh mục → KV chưa tính
+  // được (fail-closed "insufficient_data"). Hint mềm, không chặn.
+  const needsThptCatalogPick =
+    thptRecords.length > 0 && !thptRecords.some((r) => r?.school_id != null)
+
   return (
     <div className="space-y-8">
         <Card className="shadow-sm border-border">
@@ -80,6 +167,38 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
             </CardHeader>
 
             <CardContent className="space-y-6 pt-6">
+                {/* NOTICES — soft data-quality hints (Tầng 2) + KV-readiness (Tầng 3).
+                    KHÔNG chặn lưu/nộp; engine BE là nguồn KV/eligibility chính thức. */}
+                {(softNotices.length > 0 || needsThptCatalogPick) && (
+                    <div className="space-y-2" data-testid="academic-notices">
+                        {needsThptCatalogPick && (
+                            <div
+                                role="status"
+                                data-testid="academic-kv-hint"
+                                className="rounded-md border border-info-300 bg-info-50 px-3 py-2 text-xs text-info-900 flex items-start gap-2"
+                            >
+                                <span aria-hidden="true">ℹ</span>
+                                <span>
+                                    Để hệ thống tự xác định KV ưu tiên, hãy chọn ít nhất một
+                                    trường THPT <strong>từ danh mục</strong> (trường nhập tay
+                                    không tự resolve được KV).
+                                </span>
+                            </div>
+                        )}
+                        {softNotices.map((msg, i) => (
+                            <div
+                                key={msg}
+                                role="status"
+                                data-testid={`academic-notice-${i}`}
+                                className="rounded-md border border-warning-300 bg-warning-50 px-3 py-2 text-xs text-warning-900 flex items-start gap-2"
+                            >
+                                <span aria-hidden="true">⚠</span>
+                                <span>{msg}</span>
+                            </div>
+                        ))}
+                    </div>
+                )}
+
                 {/* LIST */}
                 <div className="space-y-4">
                     {fields.map((field, index) => (
@@ -346,6 +465,16 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
                         >
                             <Plus className="w-4 h-4 mr-2" aria-hidden="true" />
                             Thêm 3 năm THPT (lớp 10/11/12)
+                        </Button>
+                        {/* Quick-add 4 năm THCS (lớp 6/7/8/9) */}
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={addFourYearsThcs}
+                            data-testid="academic-quick-add-thcs"
+                        >
+                            <Plus className="w-4 h-4 mr-2" aria-hidden="true" />
+                            Thêm 4 năm THCS (lớp 6/7/8/9)
                         </Button>
                     </div>
                 )}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
@@ -200,10 +200,10 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
                 )}
 
                 {/* LIST */}
-                <div className="space-y-4">
+                <div className="space-y-3">
                     {fields.map((field, index) => (
-                    <div key={field.id} className="p-4 border rounded-lg bg-muted/50 relative group transition-colors hover:bg-card hover:border-info-200 hover:shadow-sm">
-                        <div className="flex items-center justify-between mb-4">
+                    <div key={field.id} className="p-3 border rounded-lg bg-muted/50 relative group transition-colors hover:bg-card hover:border-info-200 hover:shadow-sm">
+                        <div className="flex items-center justify-between mb-3">
                             <span className="text-sm font-medium text-muted-foreground uppercase tracking-wide">Trường #{index + 1}</span>
                             {isEditable && (
                                 <Button
@@ -219,53 +219,59 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
                             )}
                         </div>
                         
-                        <div className="grid gap-6 md:grid-cols-2">
-                        <div className="md:col-span-2 space-y-2">
-                            <div className="space-y-1">
-                                <label className="text-xs font-medium leading-none">
-                                    Tên trường (tìm trong danh mục)
-                                </label>
-                                <VnSchoolPicker
-                                    value={{
-                                        school_id: form.watch(`academic_history.${index}.school_id`) ?? null,
-                                        school_name: form.watch(`academic_history.${index}.school_name`) ?? "",
-                                        level: form.watch(`academic_history.${index}.level`) ?? null,
-                                        current_kv: null,
-                                    }}
-                                    onChange={(v) => {
-                                        form.setValue(`academic_history.${index}.school_id`, v.school_id, { shouldDirty: true })
-                                        // `shouldValidate: true` — picking a school sets the value
-                                        // programmatically, which does NOT re-run validation by default;
-                                        // without it a prior "Tên trường không được để trống" error
-                                        // (set when the row was empty) would persist even after a school
-                                        // is selected. Re-validating clears the stale error.
-                                        form.setValue(`academic_history.${index}.school_name`, v.school_name, {
-                                            shouldDirty: true,
-                                            shouldValidate: true,
-                                        })
-                                        form.setValue(
-                                            `academic_history.${index}.level`,
-                                            v.level as (typeof VN_SCHOOL_LEVELS)[number] | null,
-                                            { shouldDirty: true },
-                                        )
-                                    }}
-                                    disabled={!isEditable}
-                                />
-                                {/* Manual error display ONLY when a school is picked (school_id set):
-                                    in that case the free-text fallback below is unmounted, so its
-                                    <FormMessage/> can't show the error. When school_id is null the
-                                    free-text FormField already renders the message — gating here avoids
-                                    showing "Tên trường không được để trống" twice. */}
-                                {form.watch(`academic_history.${index}.school_id`) &&
-                                    form.formState.errors.academic_history?.[index]?.school_name?.message && (
-                                    <p className="text-xs text-destructive">
-                                        {form.formState.errors.academic_history[index]?.school_name?.message as string}
-                                    </p>
-                                )}
-                            </div>
-                            {/* Free-text fallback if no school_id picked */}
-                            {!form.watch(`academic_history.${index}.school_id`) && (
-                                <>
+                        <div className="grid grid-cols-2 gap-3 md:grid-cols-5">
+                        <div className="col-span-2 md:col-span-5 space-y-2">
+                            {/* Picker + ô nhập tay trên CÙNG 1 dòng (tên trường thường ngắn).
+                                Khi đã chọn từ danh mục, ô nhập tay ẩn → picker chiếm full width. */}
+                            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 items-start">
+                                <div
+                                    className={
+                                        form.watch(`academic_history.${index}.school_id`)
+                                            ? "space-y-1 md:col-span-2"
+                                            : "space-y-1"
+                                    }
+                                >
+                                    <label className="text-xs font-medium leading-none">
+                                        Tên trường (tìm trong danh mục)
+                                    </label>
+                                    <VnSchoolPicker
+                                        value={{
+                                            school_id: form.watch(`academic_history.${index}.school_id`) ?? null,
+                                            school_name: form.watch(`academic_history.${index}.school_name`) ?? "",
+                                            level: form.watch(`academic_history.${index}.level`) ?? null,
+                                            current_kv: null,
+                                        }}
+                                        onChange={(v) => {
+                                            form.setValue(`academic_history.${index}.school_id`, v.school_id, { shouldDirty: true })
+                                            // `shouldValidate: true` — picking a school sets the value
+                                            // programmatically, which does NOT re-run validation by default;
+                                            // without it a prior "Tên trường không được để trống" error
+                                            // (set when the row was empty) would persist even after a school
+                                            // is selected. Re-validating clears the stale error.
+                                            form.setValue(`academic_history.${index}.school_name`, v.school_name, {
+                                                shouldDirty: true,
+                                                shouldValidate: true,
+                                            })
+                                            form.setValue(
+                                                `academic_history.${index}.level`,
+                                                v.level as (typeof VN_SCHOOL_LEVELS)[number] | null,
+                                                { shouldDirty: true },
+                                            )
+                                        }}
+                                        disabled={!isEditable}
+                                    />
+                                    {/* Manual error display ONLY when a school is picked (school_id set):
+                                        the free-text fallback is unmounted then, so its <FormMessage/>
+                                        can't show the error. Gating avoids showing it twice. */}
+                                    {form.watch(`academic_history.${index}.school_id`) &&
+                                        form.formState.errors.academic_history?.[index]?.school_name?.message && (
+                                        <p className="text-xs text-destructive">
+                                            {form.formState.errors.academic_history[index]?.school_name?.message as string}
+                                        </p>
+                                    )}
+                                </div>
+                                {/* Free-text fallback (ô bên phải) — chỉ khi chưa chọn từ danh mục */}
+                                {!form.watch(`academic_history.${index}.school_id`) && (
                                     <FormField
                                         control={form.control}
                                         name={`academic_history.${index}.school_name`}
@@ -287,29 +293,28 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
                                             </FormItem>
                                         )}
                                     />
-                                    {/* Commit 5 — free-text school warning. Engine resolve KV
-                                        cần school_id (administrative_nodes link). Trường nhập
-                                        tay sẽ không kết nối, KV chỉ resolve được khi quản lý
-                                        ấn định thủ công. */}
-                                    {(form.watch(`academic_history.${index}.school_name`) ?? "").trim().length > 0 && (
-                                        <div
-                                            role="alert"
-                                            data-testid={`academic-freetext-warning-${index}`}
-                                            className="rounded-md border border-warning-300 bg-warning-50 px-3 py-2 text-xs text-warning-900 flex items-start gap-2"
-                                        >
-                                            <span aria-hidden="true">⚠</span>
-                                            <span>
-                                                Trường nhập tay sẽ không dùng được để tự xác định
-                                                KV. Vui lòng chọn từ danh mục bên trên, hoặc đề
-                                                nghị quản lý ấn định KV thủ công.
-                                            </span>
-                                        </div>
-                                    )}
-                                </>
+                                )}
+                            </div>
+                            {/* Free-text KV warning — full width dưới 2 ô. Engine resolve KV cần
+                                school_id; trường nhập tay không tự resolve được. */}
+                            {!form.watch(`academic_history.${index}.school_id`) &&
+                                (form.watch(`academic_history.${index}.school_name`) ?? "").trim().length > 0 && (
+                                <div
+                                    role="alert"
+                                    data-testid={`academic-freetext-warning-${index}`}
+                                    className="rounded-md border border-warning-300 bg-warning-50 px-3 py-2 text-xs text-warning-900 flex items-start gap-2"
+                                >
+                                    <span aria-hidden="true">⚠</span>
+                                    <span>
+                                        Trường nhập tay sẽ không dùng được để tự xác định KV. Vui
+                                        lòng chọn từ danh mục bên trên, hoặc đề nghị quản lý ấn
+                                        định KV thủ công.
+                                    </span>
+                                </div>
                             )}
                         </div>
                         
-                        <div className="grid grid-cols-2 gap-4">
+                        <div className="contents">
                              <FormField
                                 control={form.control}
                                 name={`academic_history.${index}.year_from`}
@@ -355,7 +360,7 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
                             />
                         </div>
                         
-                        <div className="grid grid-cols-3 gap-4">
+                        <div className="contents">
                             <FormField
                                 control={form.control}
                                 name={`academic_history.${index}.grade_to`}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
@@ -234,11 +234,13 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
                                 <div
                                     className={
                                         form.watch(`academic_history.${index}.school_id`)
-                                            ? "space-y-1 md:col-span-2"
-                                            : "space-y-1"
+                                            ? "space-y-2 md:col-span-2"
+                                            : "space-y-2"
                                     }
                                 >
-                                    <label className="text-xs font-medium leading-none">
+                                    {/* Mirror FormLabel (flex items-center text-xs) để label + gap
+                                        khớp cột "nhập tay" → 2 control thẳng hàng dọc. */}
+                                    <label className="flex items-center text-xs font-medium text-muted-foreground">
                                         Tên trường (tìm trong danh mục)
                                     </label>
                                     <VnSchoolPicker

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/AcademicHistoryTab.tsx
@@ -59,8 +59,9 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
   }
 
   // Quick-add toàn bộ các lớp của một cấp (THPT 10→12, THCS 6→9). Mỗi lớp 1
-  // năm, lớp cuối cấp = endYear; officer chỉ cần điền trường + GPA. graduation_type
-  // gán ở lớp cuối. Engine yêu cầu lịch sử THPT có school_id để xác định KV.
+  // năm, lớp cuối cấp = endYear; officer chỉ cần điền trường + GPA. Trình độ
+  // (graduation_type) gán cho MỌI lớp = cấp học quick-add (cả thẻ tương xứng
+  // THPT/THCS). Engine yêu cầu lịch sử THPT có school_id để xác định KV.
   const addBand = (band: GradeBand, endYear: number) => {
     const count = bandYears(band)
     for (let i = 0; i < count; i++) {
@@ -74,7 +75,7 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
         year_to: year,
         grade_to: grade,
         gpa: null,
-        graduation_type: grade === band.end ? band.graduationType : null,
+        graduation_type: band.graduationType,
       } as Parameters<typeof append>[0])
     }
   }
@@ -424,7 +425,7 @@ export function AcademicHistoryTab({ form, isEditable }: AcademicHistoryTabProps
                                     <FormLabel className="text-xs">Trình độ</FormLabel>
                                     <Select onValueChange={field.onChange} value={field.value || ""} disabled={!isEditable}>
                                     <FormControl>
-                                        <SelectTrigger className="bg-background" aria-label="Chọn trình độ tốt nghiệp">
+                                        <SelectTrigger className="bg-background h-11 md:h-9" aria-label="Chọn trình độ tốt nghiệp">
                                         <SelectValue placeholder="Chọn" />
                                         </SelectTrigger>
                                     </FormControl>

--- a/frontend/src/components/admissions/VnSchoolPicker.tsx
+++ b/frontend/src/components/admissions/VnSchoolPicker.tsx
@@ -127,7 +127,7 @@ export function VnSchoolPicker({
             role="combobox"
             aria-expanded={open}
             aria-label="Chọn trường THPT từ danh mục"
-            className="flex-1 justify-between font-normal"
+            className="flex-1 justify-between font-normal h-11 md:h-9"
             disabled={disabled}
           >
             <span
@@ -230,7 +230,7 @@ export function VnSchoolPicker({
           size="icon"
           onClick={handleManualClear}
           aria-label="Bỏ chọn trường"
-          className="shrink-0 text-muted-foreground hover:text-destructive"
+          className="shrink-0 text-muted-foreground hover:text-destructive size-11 md:size-9"
         >
           <X className="h-4 w-4" />
         </Button>


### PR DESCRIPTION
## Tổng quan
Cải thiện tab **Lịch sử học tập** (admission detail Bước 3). Thuần FE, không đổi schema/contract BE.

## Thay đổi (5 commit)
- **Quick-add 4 năm THCS** (lớp 6/7/8/9) — đối xứng nút 3 năm THPT sẵn có; `graduation_type` gán **mọi lớp** = cấp học quick-add (THPT→cả 3 lớp, THCS→cả 4 lớp).
- **Cảnh báo mềm (data-quality, KHÔNG chặn lưu/nộp):** trùng lớp · > 3 THPT / > 4 THCS (cho phép chuyển trường) · năm kết thúc ở tương lai.
- **Gợi ý KV-readiness:** có dòng THPT nhưng chưa chọn trường từ danh mục → hint (đúng điều kiện fail-closed của engine).
- **Hiển thị KV** sau khi chọn trường (VnSchoolPicker giữ current_kv của trường vừa chọn — trước đây bị bỏ rơi).
- **Gọn layout thẻ:** 5 trường (Từ năm/Đến năm/Lớp cuối/GPA/Trình độ) trên 1 hàng; 2 ô chọn-trường + nhập-tay cùng dòng; căn đều chiều cao (picker/input/select = 36px desktop) + thẳng hàng dọc.
- Gom hằng `GRADE_BANDS` (1 nguồn) + gộp 2 hàm quick-add.

## Kiểm thử
- type-check + ESLint sạch.
- `AcademicHistoryTab` 15/15 + `VnSchoolPicker` 11/11 unit test.
- Browser smoke dev #46: nhập 3 năm (Lê Quý Đôn + Hồng Đức ×2), KV2 hiển thị, notices + KV hint đúng, layout đồng đều.

## Phạm vi
Thuần FE/UX. Nguồn KV/eligibility chính thức vẫn là engine BE (FE chỉ hiển thị + vệ sinh nhập liệu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
