### PR TITLE
feat(admissions): dropdown nguyện vọng — nhóm phương thức + combobox tra cứu (trình độ/chặn trùng/bỏ dấu)

### DIFF
--- a/Backend_FastAPI/app/routers/admission_paths.py
+++ b/Backend_FastAPI/app/routers/admission_paths.py
@@ -120,6 +120,16 @@ async def build_path_response(
         response.round_archived_at = _round.archived_at
         response.round_is_active = _round.is_active
         response.round_allow_multi_nv = _round.allow_multi_nv
+    # Trình độ + tên ngành (FE phân biệt CĐ/TC trong dropdown nguyện vọng).
+    # ``__dict__.get`` tránh lazy load (MissingGreenlet) khi chain chưa eager-load
+    # — flat field stay None. degree_level là column trên MajorProgram nên load
+    # cùng ``program`` (không trigger lazy thêm).
+    _ai = path.__dict__.get("academic_info")
+    _offering = _ai.__dict__.get("offering") if _ai is not None else None
+    _program = _offering.__dict__.get("program") if _offering is not None else None
+    if _program is not None:
+        response.degree_level = getattr(_program, "degree_level", None)
+        response.major_name = getattr(_program, "name", None)
     response.available_actions = service.compute_available_actions(path, current_user)
     response.can_edit = service.compute_can_edit(path, current_user)
     response.can_activate = await service.compute_can_activate(path, current_user)

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -425,6 +425,19 @@ class AdmissionPathResponse(BaseModel):
     display_order: int
     visibility: VisibilityStatus
 
+    # Trình độ (cấp đào tạo) + tên ngành — FLAT, populated trong
+    # ``build_path_response`` từ academic_info.offering.program (đã eager-load ở
+    # các list query). Để FE phân biệt CĐ/TC trong dropdown nguyện vọng (2 ngành
+    # cùng tên khác cấp hiện y hệt). Default None khi chain chưa load (an toàn
+    # như các flat field round bên dưới).
+    degree_level: Optional[str] = Field(
+        default=None,
+        description="Cấp đào tạo của ngành (vd 'Cao đẳng' / 'Trung cấp'). NULL nếu chưa load.",
+    )
+    major_name: Optional[str] = Field(
+        default=None, description="Tên ngành (major_program.name). NULL nếu chưa load."
+    )
+
     # Phase 2 v8.2 PR-2B v2 / PR-2C v2 — round + per-path quota fields.
     admission_round_id: int = Field(
         description="Round FK (NOT NULL post PR-2C v2 3-col UNIQUE swap)."

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/ScoresTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/ScoresTab.tsx
@@ -876,6 +876,7 @@ function MultiNvScoresTab({
           nextDisplayOrder={nextDisplayOrder}
           currentPathId={currentPathId}
           roundIdOverride={roundIdFromAppliedRules}
+          existingPathIds={choices.map((c) => c.admission_path_id)}
         />
       </CardContent>
     </Card>

--- a/frontend/src/app/(dashboard)/admissions/create/page.tsx
+++ b/frontend/src/app/(dashboard)/admissions/create/page.tsx
@@ -13,7 +13,8 @@ import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { groupByMethodType } from "@/lib/admissions/method-groups"
 import { Label } from "@/components/ui/label"
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert"
 import { ClipboardCheck, ArrowLeft, Loader2, AlertCircle } from "lucide-react"
@@ -55,6 +56,11 @@ interface AdmissionMethod {
   name: string
   description?: string
   is_active: boolean
+  // BE /api/admission-config/methods trả đủ các cờ này (mirror admin-config
+  // AdmissionMethod) — dùng để nhóm dropdown theo loại + sort.
+  requires_gpa: boolean
+  requires_subject_scores: boolean
+  display_order?: number
 }
 
 interface AdmissionMethodListResponse {
@@ -542,11 +548,28 @@ export default function CreateAdmissionPage() {
                   <SelectValue placeholder="Chọn phương thức xét tuyển" />
                 </SelectTrigger>
                 <SelectContent>
-                  {methodsForYear.map((method) => (
-                    <SelectItem key={method.id} value={method.id.toString()}>
-                      {method.name}
-                    </SelectItem>
-                  ))}
+                  {/* Nhóm theo loại (Học bạ / Điểm thi / Kết hợp / Khác) + sort
+                      display_order trong nhóm → danh sách có tổ chức, giảm chọn
+                      nhầm. Ẩn tiêu đề khi chỉ 1 nhóm. */}
+                  {(() => {
+                    const groups = groupByMethodType(
+                      methodsForYear,
+                      (m) => m,
+                      (m) => m.display_order ?? 0,
+                      (m) => m.name,
+                    )
+                    const showHeaders = groups.length > 1
+                    return groups.map((g) => (
+                      <SelectGroup key={g.key}>
+                        {showHeaders && <SelectLabel>{g.label}</SelectLabel>}
+                        {g.items.map((method) => (
+                          <SelectItem key={method.id} value={method.id.toString()}>
+                            {method.name}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    ))
+                  })()}
                 </SelectContent>
               </Select>
             )}

--- a/frontend/src/components/admissions/AddChoiceDialog/AddChoiceDialog.tsx
+++ b/frontend/src/components/admissions/AddChoiceDialog/AddChoiceDialog.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/lib/api/admission-paths"
 import { useCreateChoice } from "@/hooks/admissions/useAdmissionChoices"
 import { parseApiError } from "@/lib/utils/api-errors"
+import { foldVietnamese } from "@/lib/utils/vietnamese"
 
 export interface AddChoiceDialogProps {
   profileId: number
@@ -300,7 +301,13 @@ export function AddChoiceDialog({
                   className="w-[var(--radix-popover-trigger-width)] p-0"
                   align="start"
                 >
-                  <Command>
+                  {/* filter bỏ dấu: officer gõ KHÔNG dấu ("ke toan") vẫn match
+                      "Kế toán" (cmdk filter mặc định không fold dấu tiếng Việt). */}
+                  <Command
+                    filter={(value, search) =>
+                      foldVietnamese(value).includes(foldVietnamese(search)) ? 1 : 0
+                    }
+                  >
                     <CommandInput placeholder="Gõ tên ngành…" />
                     <CommandList>
                       <CommandEmpty>Không tìm thấy ngành.</CommandEmpty>

--- a/frontend/src/components/admissions/AddChoiceDialog/AddChoiceDialog.tsx
+++ b/frontend/src/components/admissions/AddChoiceDialog/AddChoiceDialog.tsx
@@ -41,10 +41,13 @@ import { Label } from "@/components/ui/label"
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { groupByMethodType } from "@/lib/admissions/method-groups"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import {
   getAdmissionPath,
@@ -259,11 +262,28 @@ export function AddChoiceDialog({
                   />
                 </SelectTrigger>
                 <SelectContent>
-                  {pathsData?.items.map((p) => (
-                    <SelectItem key={p.id} value={p.id.toString()}>
-                      {p.display_name || `Path ${p.id}`}
-                    </SelectItem>
-                  ))}
+                  {/* Nhóm path theo loại phương thức (Học bạ / Điểm thi / Kết
+                      hợp / Khác) của method gắn với path + sort display_order →
+                      giảm officer chọn nhầm. Ẩn tiêu đề khi chỉ 1 nhóm. */}
+                  {(() => {
+                    const groups = groupByMethodType(
+                      pathsData?.items ?? [],
+                      (p) => p.admission_method,
+                      (p) => p.display_order ?? 0,
+                      (p) => p.display_name || `Path ${p.id}`,
+                    )
+                    const showHeaders = groups.length > 1
+                    return groups.map((g) => (
+                      <SelectGroup key={g.key}>
+                        {showHeaders && <SelectLabel>{g.label}</SelectLabel>}
+                        {g.items.map((p) => (
+                          <SelectItem key={p.id} value={p.id.toString()}>
+                            {p.display_name || `Path ${p.id}`}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    ))
+                  })()}
                 </SelectContent>
               </Select>
             </div>

--- a/frontend/src/components/admissions/AddChoiceDialog/AddChoiceDialog.tsx
+++ b/frontend/src/components/admissions/AddChoiceDialog/AddChoiceDialog.tsx
@@ -24,8 +24,21 @@
  */
 import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { Loader2 } from "lucide-react"
+import { Check, ChevronsUpDown, Loader2 } from "lucide-react"
 import { toast } from "sonner"
+import { cn } from "@/lib/utils"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
 
 import {
   Dialog,
@@ -41,13 +54,10 @@ import { Label } from "@/components/ui/label"
 import {
   Select,
   SelectContent,
-  SelectGroup,
   SelectItem,
-  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { groupByMethodType } from "@/lib/admissions/method-groups"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import {
   getAdmissionPath,
@@ -68,6 +78,10 @@ export interface AddChoiceDialogProps {
   currentPathId: number | null
   /** Optional fallback nếu profile chưa có NV nào — truyền round_id đã biết. */
   roundIdOverride?: number
+  /** admission_path_id của các NV đã có → disable trong dropdown ("đã chọn"),
+   * chặn officer chọn lại cùng path. Cùng ngành khác phương thức (path khác)
+   * vẫn cho. Mặc định []. */
+  existingPathIds?: number[]
 }
 
 interface ScoreState {
@@ -83,8 +97,10 @@ export function AddChoiceDialog({
   nextDisplayOrder,
   currentPathId,
   roundIdOverride,
+  existingPathIds = [],
 }: AddChoiceDialogProps) {
   const [selectedPathId, setSelectedPathId] = useState<number | null>(null)
+  const [pathOpen, setPathOpen] = useState(false)
   const [selectedConfigId, setSelectedConfigId] = useState<number | null>(null)
   const [scores, setScores] = useState<ScoreState[]>([])
   const [serverError, setServerError] = useState<string | null>(null)
@@ -215,6 +231,8 @@ export function AddChoiceDialog({
 
   const isLoading = loadingCurrentPath || loadingPaths
   const isSubmitting = createChoice.isPending
+  const selectedPath =
+    pathsData?.items.find((p) => p.id === selectedPathId) ?? null
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
@@ -246,46 +264,95 @@ export function AddChoiceDialog({
           <div className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="select-path">Ngành / Phương thức xét tuyển</Label>
-              <Select
-                value={selectedPathId?.toString() ?? ""}
-                onValueChange={(v) => {
-                  setSelectedPathId(Number(v))
-                  setSelectedConfigId(null)
-                }}
-                disabled={loadingPaths || isSubmitting}
-              >
-                <SelectTrigger id="select-path">
-                  <SelectValue
-                    placeholder={
-                      loadingPaths ? "Đang tải…" : "Chọn ngành + phương thức"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {/* Nhóm path theo loại phương thức (Học bạ / Điểm thi / Kết
-                      hợp / Khác) của method gắn với path + sort display_order →
-                      giảm officer chọn nhầm. Ẩn tiêu đề khi chỉ 1 nhóm. */}
-                  {(() => {
-                    const groups = groupByMethodType(
-                      pathsData?.items ?? [],
-                      (p) => p.admission_method,
-                      (p) => p.display_order ?? 0,
-                      (p) => p.display_name || `Path ${p.id}`,
-                    )
-                    const showHeaders = groups.length > 1
-                    return groups.map((g) => (
-                      <SelectGroup key={g.key}>
-                        {showHeaders && <SelectLabel>{g.label}</SelectLabel>}
-                        {g.items.map((p) => (
-                          <SelectItem key={p.id} value={p.id.toString()}>
-                            {p.display_name || `Path ${p.id}`}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    ))
-                  })()}
-                </SelectContent>
-              </Select>
+              {/* Combobox gõ-để-lọc: officer gõ tên ngành → lọc tức thì (danh sách
+                  dài, dễ tra cứu nhất). Mỗi dòng = tên ngành + tag [cấp] [phương
+                  thức]; path đã là NV bị disable "(đã chọn)" — chặn chọn trùng
+                  cùng path (cùng ngành khác phương thức vẫn cho). */}
+              <Popover open={pathOpen} onOpenChange={setPathOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    id="select-path"
+                    type="button"
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={pathOpen}
+                    disabled={loadingPaths || isSubmitting}
+                    className="w-full justify-between font-normal"
+                  >
+                    <span
+                      className={cn(
+                        "truncate",
+                        !selectedPath && "text-muted-foreground",
+                      )}
+                    >
+                      {selectedPath
+                        ? selectedPath.major_name ||
+                          selectedPath.display_name ||
+                          `Path ${selectedPath.id}`
+                        : loadingPaths
+                          ? "Đang tải…"
+                          : "Chọn ngành (gõ để tìm)…"}
+                    </span>
+                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  className="w-[var(--radix-popover-trigger-width)] p-0"
+                  align="start"
+                >
+                  <Command>
+                    <CommandInput placeholder="Gõ tên ngành…" />
+                    <CommandList>
+                      <CommandEmpty>Không tìm thấy ngành.</CommandEmpty>
+                      {(pathsData?.items ?? []).map((p) => {
+                        const taken = existingPathIds.includes(p.id)
+                        const label =
+                          p.major_name || p.display_name || `Path ${p.id}`
+                        const methodName = p.admission_method?.name ?? ""
+                        return (
+                          <CommandItem
+                            key={p.id}
+                            // value = keyword tìm kiếm (ngành + cấp + phương thức)
+                            // + id đảm bảo unique cho cmdk.
+                            value={`${label} ${p.degree_level ?? ""} ${methodName} ${p.id}`}
+                            disabled={taken}
+                            onSelect={() => {
+                              setSelectedPathId(p.id)
+                              setSelectedConfigId(null)
+                              setPathOpen(false)
+                            }}
+                          >
+                            <Check
+                              className={cn(
+                                "mr-2 h-4 w-4 shrink-0",
+                                selectedPathId === p.id
+                                  ? "opacity-100"
+                                  : "opacity-0",
+                              )}
+                            />
+                            <span className="flex-1 truncate">{label}</span>
+                            {p.degree_level && (
+                              <span className="ml-2 shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                                {p.degree_level}
+                              </span>
+                            )}
+                            {methodName && (
+                              <span className="ml-1 shrink-0 rounded bg-info-50 px-1.5 py-0.5 text-[11px] text-info-700">
+                                {methodName}
+                              </span>
+                            )}
+                            {taken && (
+                              <span className="ml-1 shrink-0 text-[11px] text-muted-foreground">
+                                (đã chọn)
+                              </span>
+                            )}
+                          </CommandItem>
+                        )
+                      })}
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
             </div>
 
             {selectedPathId !== null && (

--- a/frontend/src/lib/admissions/method-groups.test.ts
+++ b/frontend/src/lib/admissions/method-groups.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest"
+import {
+  classifyMethod,
+  groupByMethodType,
+  type MethodLike,
+} from "./method-groups"
+
+describe("classifyMethod", () => {
+  it("gpa only → Xét học bạ (order 1)", () => {
+    expect(classifyMethod({ requires_gpa: true, requires_subject_scores: false })).toMatchObject({
+      key: "hoc_ba",
+      order: 1,
+    })
+  })
+  it("subject only → Xét điểm thi (order 2)", () => {
+    expect(classifyMethod({ requires_gpa: false, requires_subject_scores: true })).toMatchObject({
+      key: "diem_thi",
+      order: 2,
+    })
+  })
+  it("cả hai → Xét kết hợp (order 3)", () => {
+    expect(classifyMethod({ requires_gpa: true, requires_subject_scores: true })).toMatchObject({
+      key: "ket_hop",
+      order: 3,
+    })
+  })
+  it("không cờ nào → Phương thức khác (order 4)", () => {
+    expect(classifyMethod({ requires_gpa: false, requires_subject_scores: false })).toMatchObject({
+      key: "khac",
+      order: 4,
+    })
+  })
+})
+
+interface Row {
+  id: number
+  method: MethodLike | null
+  order: number
+  label: string
+}
+const hocBa: MethodLike = { requires_gpa: true, requires_subject_scores: false }
+const diemThi: MethodLike = { requires_gpa: false, requires_subject_scores: true }
+const ketHop: MethodLike = { requires_gpa: true, requires_subject_scores: true }
+
+const group = (rows: Row[]) =>
+  groupByMethodType(
+    rows,
+    (r) => r.method,
+    (r) => r.order,
+    (r) => r.label,
+  )
+
+describe("groupByMethodType", () => {
+  it("nhóm sắp theo order 1→4 (học bạ trước điểm thi trước kết hợp trước khác)", () => {
+    const rows: Row[] = [
+      { id: 1, method: ketHop, order: 0, label: "C" },
+      { id: 2, method: diemThi, order: 0, label: "B" },
+      { id: 3, method: hocBa, order: 0, label: "A" },
+      { id: 4, method: null, order: 0, label: "D" },
+    ]
+    expect(group(rows).map((g) => g.key)).toEqual(["hoc_ba", "diem_thi", "ket_hop", "khac"])
+  })
+
+  it("trong nhóm sort theo sortKey rồi tie-break label", () => {
+    const rows: Row[] = [
+      { id: 1, method: hocBa, order: 2, label: "Z" },
+      { id: 2, method: hocBa, order: 1, label: "Y" },
+      { id: 3, method: hocBa, order: 1, label: "X" }, // cùng order 1 → tie-break label X < Y
+    ]
+    const g = group(rows)
+    expect(g).toHaveLength(1)
+    expect(g[0].items.map((r) => r.id)).toEqual([3, 2, 1])
+  })
+
+  it("method null/undefined → rơi nhóm 'khac'", () => {
+    const rows: Row[] = [{ id: 1, method: null, order: 0, label: "X" }]
+    expect(group(rows)).toEqual([{ key: "khac", label: "Phương thức khác", items: rows }])
+  })
+
+  it("nhóm rỗng không xuất hiện (chỉ 1 loại → 1 nhóm)", () => {
+    const rows: Row[] = [
+      { id: 1, method: hocBa, order: 1, label: "A" },
+      { id: 2, method: hocBa, order: 2, label: "B" },
+    ]
+    const g = group(rows)
+    expect(g).toHaveLength(1)
+    expect(g[0].key).toBe("hoc_ba")
+  })
+
+  it("danh sách rỗng → []", () => {
+    expect(group([])).toEqual([])
+  })
+})

--- a/frontend/src/lib/admissions/method-groups.ts
+++ b/frontend/src/lib/admissions/method-groups.ts
@@ -1,0 +1,76 @@
+/**
+ * Nhóm phương thức xét tuyển theo loại để danh sách chọn "có tổ chức", giảm
+ * officer chọn nhầm. Thuần hiển thị (FE) — phân loại từ `requires_gpa` +
+ * `requires_subject_scores` (nguồn dữ liệu chuẩn của method); KHÔNG đổi dữ
+ * liệu gửi backend.
+ *
+ * Dùng bởi: trang tạo hồ sơ (dropdown phương thức NV1) + AddChoiceDialog
+ * (dropdown "Ngành / Phương thức" NV2/NV3, nhóm theo method của từng path).
+ */
+
+export interface MethodLike {
+  requires_gpa: boolean
+  requires_subject_scores: boolean
+}
+
+export type MethodGroupKey = "hoc_ba" | "diem_thi" | "ket_hop" | "khac"
+
+export interface MethodGroupMeta {
+  key: MethodGroupKey
+  label: string
+  /** Thứ tự hiển thị nhóm (1 = trên cùng). */
+  order: number
+}
+
+const KHAC: MethodGroupMeta = { key: "khac", label: "Phương thức khác", order: 4 }
+
+/** Phân loại 1 method thành nhóm theo cờ requires_*. */
+export function classifyMethod(m: MethodLike): MethodGroupMeta {
+  if (m.requires_gpa && !m.requires_subject_scores)
+    return { key: "hoc_ba", label: "Xét học bạ", order: 1 }
+  if (!m.requires_gpa && m.requires_subject_scores)
+    return { key: "diem_thi", label: "Xét điểm thi", order: 2 }
+  if (m.requires_gpa && m.requires_subject_scores)
+    return { key: "ket_hop", label: "Xét kết hợp", order: 3 }
+  return KHAC
+}
+
+export interface MethodGroup<T> {
+  key: MethodGroupKey
+  label: string
+  items: T[]
+}
+
+/**
+ * Nhóm `items` theo loại method.
+ * - Nhóm sắp theo `order` (1→4).
+ * - Trong nhóm sort theo `getSortKey` (vd display_order), tie-break `getLabel`.
+ * - `getMethod` trả null/undefined (vd path chưa gắn method) → rơi nhóm "Khác".
+ * - Nhóm rỗng không xuất hiện.
+ */
+export function groupByMethodType<T>(
+  items: readonly T[],
+  getMethod: (item: T) => MethodLike | null | undefined,
+  getSortKey: (item: T) => number,
+  getLabel: (item: T) => string,
+): MethodGroup<T>[] {
+  const buckets = new Map<MethodGroupKey, { meta: MethodGroupMeta; items: T[] }>()
+  for (const item of items) {
+    const m = getMethod(item)
+    const meta = m ? classifyMethod(m) : KHAC
+    const bucket = buckets.get(meta.key)
+    if (bucket) bucket.items.push(item)
+    else buckets.set(meta.key, { meta, items: [item] })
+  }
+  return [...buckets.values()]
+    .sort((a, b) => a.meta.order - b.meta.order)
+    .map((b) => ({
+      key: b.meta.key,
+      label: b.meta.label,
+      items: [...b.items].sort(
+        (x, y) =>
+          getSortKey(x) - getSortKey(y) ||
+          getLabel(x).localeCompare(getLabel(y), "vi"),
+      ),
+    }))
+}

--- a/frontend/src/lib/utils/vietnamese.test.ts
+++ b/frontend/src/lib/utils/vietnamese.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest"
+import { foldVietnamese } from "./vietnamese"
+
+describe("foldVietnamese", () => {
+  it("bỏ dấu nguyên âm + lowercase", () => {
+    expect(foldVietnamese("Kế toán")).toBe("ke toan")
+    expect(foldVietnamese("Dược")).toBe("duoc")
+    expect(foldVietnamese("Điều dưỡng")).toBe("dieu duong")
+    expect(foldVietnamese("Y sỹ đa khoa")).toBe("y sy da khoa")
+  })
+
+  it("đ/Đ → d/D", () => {
+    expect(foldVietnamese("Đắk Lắk")).toBe("dak lak")
+    expect(foldVietnamese("đ")).toBe("d")
+  })
+
+  it("match substring không dấu (use-case combobox filter)", () => {
+    const fold = foldVietnamese
+    expect(fold("Công nghệ thông tin").includes(fold("cong nghe"))).toBe(true)
+    expect(fold("Kế toán Cao đẳng Xét học bạ").includes(fold("ke toan"))).toBe(true)
+    expect(fold("Kỹ thuật chế biến món ăn").includes(fold("ky thuat"))).toBe(true)
+  })
+
+  it("chuỗi không dấu giữ nguyên (idempotent-ish)", () => {
+    expect(foldVietnamese("ke toan")).toBe("ke toan")
+  })
+})

--- a/frontend/src/lib/utils/vietnamese.ts
+++ b/frontend/src/lib/utils/vietnamese.ts
@@ -1,0 +1,15 @@
+/**
+ * Bỏ dấu tiếng Việt + lowercase để so khớp tìm kiếm KHÔNG phân biệt dấu
+ * (officer thường gõ không dấu, vd "ke toan" → "Kế toán").
+ *
+ * - normalize("NFD") tách dấu kết hợp khỏi nguyên âm (á = a + U+0301).
+ * - Strip combining marks (U+0300–U+036F).
+ * - đ/Đ là KÝ TỰ RIÊNG (không tách qua NFD) nên map thủ công sang d/D.
+ */
+export function foldVietnamese(s: string): string {
+  return s
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[đĐ]/g, (c) => (c === "đ" ? "d" : "D"))
+    .toLowerCase()
+}

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -350,6 +350,11 @@ export const admissionPathResponseSchema = z.object({
   display_name: z.string().nullable(),
   display_order: z.number(),
   visibility: z.enum(["public", "internal"]),
+  // Trình độ (cấp đào tạo) + tên ngành — BE populate từ
+  // academic_info.offering.program (build_path_response). FE phân biệt CĐ/TC
+  // trong dropdown nguyện vọng. NULL/absent nếu BE chưa load chain.
+  degree_level: z.string().nullable().optional(),
+  major_name: z.string().nullable().optional(),
   activated_at: z.string().datetime({ offset: true }).nullable(),
   // BE Pydantic trả nested ``activator: Optional[UserNested]`` (admission_path.py:499).
   // Trước đây FE viết ``activated_by: number`` → Zod parse fail khi BE trả object.


### PR DESCRIPTION
## Tổng quan
Cải thiện cách officer chọn **phương thức xét tuyển / nguyện vọng** — danh sách trước đây phẳng, không tổ chức, không phân biệt được trình độ, chọn trùng được. BE+FE.

## Thay đổi (3 commit)
**Create flow (NV1) — `create/page.tsx`:** dropdown phương thức **nhóm theo loại** (Học bạ / Điểm thi / Kết hợp / Khác — từ `requires_gpa`/`requires_subject_scores`), sort `display_order`, ẩn tiêu đề khi 1 nhóm. Helper dùng chung `lib/admissions/method-groups.ts` + 9 unit test.

**AddChoiceDialog (NV2/NV3) — combobox tra cứu:**
- Đổi Select → **combobox gõ-để-lọc** (Popover + cmdk); officer gõ tên ngành → lọc tức thì.
- Mỗi dòng = tên ngành (ngắn) + tag **[trình độ]** + **[phương thức]** → 2 ngành cùng tên khác cấp (CĐ/TC) phân biệt rõ.
- **Tìm kiếm KHÔNG dấu** (`foldVietnamese`): gõ "ke toan" match "Kế toán" (cmdk mặc định không fold dấu) — 4 unit test.
- **Chặn chọn trùng path:** path đã là NV → disable "(đã chọn)" (cùng ngành khác phương thức vẫn cho).

**BE (`admission_path` schema + router):** `AdmissionPathResponse` thêm `degree_level` + `major_name`, populate trong `build_path_response` từ `academic_info.offering.program` (đã eager-load; `__dict__.get` an toàn lazy-load). Không migration. zod mirror.

## Kiểm thử
- type-check + ESLint sạch · `method-groups` 9/9 · `foldVietnamese` 4/4 · py_compile BE OK.
- Browser smoke dev #42: combobox gõ "ke toan"→3 "Kế toán" phân biệt CĐ/TC + phương thức; path NV3 disable "(đã chọn)".
- /code-review max: 1 bug thật (search không dấu) đã fix; còn lại no-op/defer có lý do.

## Phạm vi
Thuần hiển thị/UX — KHÔNG đổi dữ liệu gửi BE (vẫn submit method_id/path_id). BE chỉ thêm field response (degree_level/major_name), không migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
