### PR TITLE
fix(security): lock down inactive accounts — token gate + DB-authoritative session + force-disconnect

### DIFF
--- a/Backend_FastAPI/.flake8
+++ b/Backend_FastAPI/.flake8
@@ -1,0 +1,14 @@
+[flake8]
+# Match the project's Black/isort standard (pyproject.toml line_length = 88)
+# so the linter agrees with the formatter. Without this, flake8 defaults to 79
+# and reports E501 on Black-compliant lines.
+max-line-length = 88
+# Black-compatible ignores: E203 (whitespace before ':') and W503 (line break
+# before binary operator) conflict with Black's formatting.
+extend-ignore = E203, W503
+exclude =
+    .git,
+    __pycache__,
+    alembic/versions,
+    .venv,
+    venv

--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -11,7 +11,7 @@ from jwt.exceptions import PyJWTError as JWTError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import database, models, security  # ✅ THÊM IMPORT security
-from ..database import safe_redis_exists, safe_redis_get
+from ..database import safe_redis_delete, safe_redis_exists, safe_redis_get
 from ..services import user_service
 from ..utils.exceptions import (
     BusinessRuleViolation,
@@ -109,7 +109,15 @@ async def get_current_user(
     1. httpOnly cookie (access_token) - RECOMMENDED for browser requests
     2. Authorization header (fallback for API clients & backwards compatibility)
 
-    Checks: session validity (r_jti), blacklist, and user status.
+    Checks: JWT validity, access-JTI blacklist, user existence, user global
+    blacklist, and session validity (Redis `session:{r_jti}` corroborated by a
+    non-revoked, non-expired DB session row — DB is the source of truth).
+
+    Does NOT gate `User.status` — intentional. Recovery / self-service endpoints
+    (change-password, secure-account, logout, sessions, trusted devices, MFA
+    setup/disable, public config) must let an inactive user still authenticate
+    here. `status` is enforced by `get_current_active_user` for business APIs
+    and by the token-issuance gate in /login, /verify-mfa and /refresh.
     """
     credentials_exception = InvalidToken(detail="Could not validate credentials")
 
@@ -233,49 +241,67 @@ async def get_current_user(
                 )
                 raise credentials_exception
 
-        # === ✅ NEW STEP 4: CHECK SESSION VALIDITY ===
-        # (Kiểm tra xem session (liên kết qua r_jti) có bị revoke không)
+        # === STEP 4: CHECK SESSION VALIDITY (Redis cache + DB authoritative) ===
+        # Redis is only a cache. A Redis `session:{jti}` hit can be STALE (an
+        # invalidate_all_sessions cleanup miss) or a PHANTOM (Redis-only row with
+        # no DB session, from the historical no-commit bug). Trusting it alone
+        # lets a revoked/old access token resurrect once `user_blacklist` is
+        # cleared by a later login. So: fast-reject on a clear Redis miss, then
+        # ALWAYS corroborate against a non-revoked, non-expired DB session row
+        # (the source of truth for revocation).
         try:
             stored_user_id = await safe_redis_get(f"session:{refresh_jti}")
-            if not stored_user_id or int(stored_user_id) != user.id:
-                log.warning(
-                    "Token validation failed: Session not found in Redis (revoked?)",
-                    user_id=user.id,
-                    refresh_jti=refresh_jti,
-                )
-                raise credentials_exception
+            # True = hit, False = clear miss, None = Redis unavailable (DB decides)
+            redis_session_ok = (
+                bool(stored_user_id) and int(stored_user_id) == user.id
+            )
         except InvalidToken:
             raise
         except Exception as e:
             log.error(
-                "Redis Session check failed", refresh_jti=refresh_jti, error=str(e)
+                "Redis Session check failed; relying on DB",
+                refresh_jti=refresh_jti,
+                error=str(e),
             )
-            # (Fallback CSDL cho session check)
-            # (✅ PHASE 2: Use SessionRepository instead of direct SQL)
-            try:
-                from app.repositories import SessionRepository
+            redis_session_ok = None
 
-                repo = SessionRepository(db)
-                session = await repo.get_by_refresh_jti_and_user(refresh_jti, user.id)
-                if session is None:
-                    log.warning(
-                        "Database fallback: Session not found or revoked",
-                        jti=refresh_jti,
-                    )
-                    raise credentials_exception
-                log.info(
-                    "Database fallback successful: Session validated via database",
-                    jti=refresh_jti,
-                )
-            except InvalidToken:
-                raise
-            except Exception as db_error:
-                log.error(
-                    "Database fallback failed during Session check",
-                    jti=refresh_jti,
-                    error=str(db_error),
-                )
-                raise credentials_exception
+        if redis_session_ok is False:
+            log.warning(
+                "Token validation failed: Session not found in Redis (revoked?)",
+                user_id=user.id,
+                refresh_jti=refresh_jti,
+            )
+            raise credentials_exception
+
+        # STEP 4b: authoritative DB cross-check (ALWAYS runs after a Redis hit
+        # OR when Redis is unavailable). DB row must exist, be non-revoked and
+        # non-expired (get_by_refresh_jti_and_user filters revoked_at IS NULL
+        # AND expires_at > now).
+        try:
+            from app.repositories import SessionRepository
+
+            db_session = await SessionRepository(db).get_by_refresh_jti_and_user(
+                refresh_jti, user.id
+            )
+        except InvalidToken:
+            raise
+        except Exception as db_error:
+            log.error(
+                "DB session cross-check failed", jti=refresh_jti, error=str(db_error)
+            )
+            raise credentials_exception  # fail-closed
+        if db_session is None:
+            log.warning(
+                "Session rejected: no non-revoked DB row (stale/phantom Redis)",
+                user_id=user.id,
+                refresh_jti=refresh_jti,
+            )
+            # Best-effort purge the stale/phantom Redis key so it can't resurrect.
+            try:
+                await safe_redis_delete(f"session:{refresh_jti}")
+            except Exception:
+                pass
+            raise credentials_exception
 
         # ← PHASE 2: Auto-sync DB role to match Casbin (source of truth)
         # ⚠️ DISABLED (Phase 7): This was causing issues because:

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -528,6 +528,44 @@ async def lifespan(app: FastAPI):
             "❌ FAILED TO CONNECT TO REDIS on startup!", error=str(e), exc_info=True
         )
 
+    # === Server-side force-disconnect enforcement (per-worker, fail-fast) ===
+    # Register this worker, start its heartbeat, and run the force-disconnect
+    # subscriber. These are REQUIRED for offboarding enforcement, so a startup
+    # failure is fatal (raise → worker does not come up). If a task later dies,
+    # we terminate the worker so Gunicorn restarts a fresh one (workers share a
+    # port and /health is always 200, so a single worker cannot be drained).
+    from .socket_manager import (
+        register_socket_worker,
+        start_heartbeat_thread,
+        subscribe_force_disconnect,
+        consume_force_disconnect,
+    )
+
+    # Readiness handshake: SUBSCRIBE first, register this worker as live only
+    # AFTER it is actually listening, THEN start the consume loop — so a command
+    # can never be missed by a worker that is "live" but not yet subscribed.
+    _socket_pubsub = await subscribe_force_disconnect()
+    await register_socket_worker()
+    # Heartbeat runs in a DEDICATED THREAD so it survives event-loop stalls
+    # (a stalled worker stays in the ACK set but can't ACK → fail-closed).
+    start_heartbeat_thread()
+    fastapi_app.state._socket_pubsub = _socket_pubsub
+    fastapi_app.state._socket_dc_task = asyncio.create_task(
+        consume_force_disconnect(_socket_pubsub)
+    )
+
+    def _socket_task_died(task: asyncio.Task):
+        if task.cancelled():
+            return  # expected during graceful shutdown
+        exc = task.exception()
+        log.critical(
+            "Force-disconnect subscriber died — exiting worker for Gunicorn restart",
+            error=str(exc) if exc else "returned unexpectedly",
+        )
+        os._exit(1)
+
+    fastapi_app.state._socket_dc_task.add_done_callback(_socket_task_died)
+
     # --- Ứng dụng chạy ---
     yield
 
@@ -572,6 +610,21 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         # Lỗi này giờ đây chỉ bắt các lỗi chung (ví dụ: lỗi khi emit)
         log.error("Error during Socket.IO shutdown", error=str(e))
+
+    # Only AFTER this worker's sockets are disconnected do we stop enforcement:
+    # cancel the consumer (cancelled()=True → no os._exit), stop the heartbeat
+    # thread, and deregister. Order matters — deregistering before sockets are
+    # closed would drop the worker from the ACK set while it still holds sockets.
+    try:
+        from .socket_manager import deregister_socket_worker, stop_heartbeat_thread
+
+        _dc = getattr(fastapi_app.state, "_socket_dc_task", None)
+        if _dc is not None:
+            _dc.cancel()
+        stop_heartbeat_thread()
+        await deregister_socket_worker()
+    except Exception as e_sock:
+        log.error("Socket enforcement shutdown cleanup failed", error=str(e_sock))
 
     # Close Redis lock client
     try:

--- a/Backend_FastAPI/app/routers/admin/users.py
+++ b/Backend_FastAPI/app/routers/admin/users.py
@@ -470,7 +470,7 @@ async def bulk_user_action(
     enforcer = request.app.state.enforcer
 
     # Perform bulk action
-    message, bulk_callback = await user_service.perform_bulk_action(
+    message, bulk_callback, disconnect_ids = await user_service.perform_bulk_action(
         db,
         action=action_data.action,
         user_ids=action_data.user_ids,
@@ -502,7 +502,13 @@ async def bulk_user_action(
         action_desc += f" to {action_data.status}"
     action_desc += f" for {len(action_data.user_ids)} users"
 
-    _, log_callback = await log_admin_activity(
+    # NOTE: activity_service.log_activity (via log_admin_activity) returns a
+    # single UserActivityLog (PR #251 dropped the old (log, callback) tuple — the
+    # Tuple annotation on log_admin_activity is stale). It is staged in THIS
+    # transaction and committed below. Do NOT unpack it (the previous
+    # `_, log_callback = ` raised TypeError, 500-ing every bulk action — latent
+    # because the bulk endpoint had no endpoint-level test).
+    await log_admin_activity(
         db=db,
         request=request,
         action=f"bulk_{action_data.action}",
@@ -511,9 +517,33 @@ async def bulk_user_action(
         description=action_desc,
         changes={"user_ids": action_data.user_ids, "status": action_data.status} if action_data.status else {"user_ids": action_data.user_ids},
     )
+    # Server-side socket force-disconnect for deactivated users (transport
+    # boundary — done here in the router, NOT the service). BEFORE commit: any
+    # failure (publish error / ACK timeout) raises → no commit → the status
+    # change rolls back (fail-closed). disconnect_ids is only populated when the
+    # bulk moved accounts to a non-active status.
+    if disconnect_ids:
+        # ONE batched command for the whole set → bounded to a single ACK
+        # timeout regardless of how many users (avoids N × timeout holding the
+        # transaction + row locks). Fail-closed: any failure rolls back the
+        # status change and returns 500 (mirrors update_existing_user).
+        from app.socket_manager import force_disconnect_user_strict
+        try:
+            await force_disconnect_user_strict(disconnect_ids)
+        except Exception:
+            await db.rollback()
+            log.error(
+                "Bulk deactivation failed: could not disconnect sockets",
+                user_ids=disconnect_ids,
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Deactivation failed: could not disconnect sockets.",
+            )
+
     await db.commit()
     await bulk_callback()
-    await log_callback()
 
     return {"detail": message}
 
@@ -1015,6 +1045,35 @@ async def update_existing_user(
     _updated_role = updated_user.role
     _updated_unit_id = updated_user.unit_id
     _current_admin_id = current_admin.id
+
+    # === Offboarding: revoke sessions + server-side socket disconnect ===
+    # When status moves to a non-active value, persist it (flush ⇒ row lock)
+    # BEFORE revoking so a concurrent login serializes on the locked row
+    # (flush-before-revoke, P0), then revoke all sessions (strict cache cleanup)
+    # and force-disconnect live sockets across workers (ACK-confirmed). Any
+    # failure rolls back the whole change → fail-closed (status stays unchanged).
+    if "status" in changes and changes["status"]["new"] != "active":
+        await db.flush()
+        try:
+            await user_service.invalidate_all_sessions(
+                db,
+                db_user,
+                reason="Account deactivated by administrator",
+                fail_on_cache_cleanup=True,
+            )
+            from app.socket_manager import force_disconnect_user_strict
+            await force_disconnect_user_strict(db_user.id)
+        except Exception:
+            await db.rollback()
+            log.error(
+                "Deactivation failed: could not revoke sessions / disconnect sockets",
+                user_id=_updated_user_id,
+                exc_info=True,
+            )
+            raise HTTPException(
+                status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Deactivation failed: could not revoke sessions.",
+            )
 
     # ✅ TRANSACTION PATTERN: Commit and execute callback
     await db.commit()

--- a/Backend_FastAPI/app/routers/auth.py
+++ b/Backend_FastAPI/app/routers/auth.py
@@ -72,6 +72,27 @@ def _suspicious_login_only_channels(risk_score: int) -> Optional[List[str]]:
 # Used by both /login (non-MFA) and /verify-mfa to avoid code duplication.
 # =============================================================================
 
+
+def _deny_if_not_active(user, *, ip_address):
+    """Token-issuance gate: block any non-active account (offboarding / lock).
+
+    Raises a generic ``InvalidCredentials`` (401) — identical to a wrong
+    password, so an unauthenticated caller cannot enumerate account state.
+    Do NOT record a failed lockout attempt here: this is a legitimate deny,
+    not a brute-force attempt. Status is whitelisted on ``"active"`` so every
+    other value (inactive/pending/banned/suspended/locked) is rejected.
+    """
+    if user.status != "active":
+        log.warning(
+            "Token issuance blocked: account not active",
+            user_id=user.id,
+            status=user.status,
+            ip_address=ip_address,
+            security_event="LOGIN_BLOCKED_INACTIVE",
+        )
+        raise InvalidCredentials()
+
+
 async def _complete_login_flow(
     user: "models.User",
     request: Request,
@@ -88,6 +109,17 @@ async def _complete_login_flow(
     - /verify-mfa (after both password + MFA code verified)
     """
     from datetime import datetime, timedelta, timezone
+
+    # ===== AUTHORITATIVE STATUS GATE (Tầng A) =====
+    # Re-read status from the DB under a row lock immediately before minting
+    # tokens. The early gates in /login and /verify-mfa read a possibly-stale
+    # ORM object; this closes the deactivate↔mint race (admin sets the account
+    # non-active after authentication but before tokens are issued). Runs for
+    # BOTH callers (login + verify-mfa) since both mint through this helper.
+    await db.refresh(user, attribute_names=["status"], with_for_update=True)
+    _deny_if_not_active(
+        user, ip_address=request.client.host if request.client else None
+    )
 
     try:
         await user_service.remove_user_from_global_blacklist(user.id)
@@ -135,7 +167,23 @@ async def _complete_login_flow(
         if session_callback:
             post_commit_callbacks.append(session_callback)
     except Exception as session_error:
-        log.error("Failed to create session", user_id=user.id, error=str(session_error), exc_info=True)
+        # FAIL-CLOSED: get_current_user STEP 4 is now DB-authoritative — it
+        # requires a non-revoked DB session row for this jti. Without that row an
+        # issued token would be rejected (401) on the very next request. So undo
+        # the Redis session key and abort the login with 500 instead of minting a
+        # token that is dead on arrival.
+        log.error(
+            "Failed to create DB session — aborting login (fail-closed)",
+            user_id=user.id,
+            error=str(session_error),
+            exc_info=True,
+        )
+        await db.rollback()
+        try:
+            await safe_redis_delete(f"session:{refresh_jti}")
+        except Exception:
+            pass
+        raise HTTPException(status_code=500, detail="Could not process session")
 
     # 4. Record login history + suspicious login detection
     login_notification_data = None
@@ -436,6 +484,15 @@ async def login_for_access_token(
         # Re-raise original error (don't reveal lockout info to attacker)
         raise auth_error
 
+    # ===== STATUS GATE (Tầng B — early) =====
+    # Block non-active accounts BEFORE the MFA branch so an inactive account
+    # never receives an mfa_token. Placed OUTSIDE the authenticate try/except so
+    # the raise is not recorded as a failed lockout attempt (legitimate deny).
+    # Authoritative re-check happens in _complete_login_flow (Tầng A).
+    _deny_if_not_active(
+        user, ip_address=request.client.host if request.client else None
+    )
+
     # ===== MFA CHECK =====
     # If user has MFA enabled, return mfa_token instead of full login.
     # CRITICAL: Do NOT reset_attempts here. Password correct ≠ auth complete.
@@ -589,7 +646,7 @@ async def check_session_status(
     )
 
     return {
-        "status": "active",
+        "status": current_user.status,  # real account status, not hardcoded
         "user_id": current_user.id,
         "username": current_user.username,
         "session_valid": True,
@@ -885,6 +942,18 @@ async def refresh_access_token(
                     log.warning("User not found during refresh", username=username)
                     raise credentials_exception
 
+                # ===== AUTHORITATIVE STATUS GATE (Tầng A) =====
+                # get_user_for_refresh already holds a FOR UPDATE row lock, so
+                # this status read is authoritative. Block token rotation for a
+                # non-active account. Raises InvalidCredentials (NOT InvalidToken)
+                # → handled by the dedicated outer `except InvalidCredentials`
+                # below: returns 401 WITHOUT incrementing the refresh-abuse
+                # counter (legitimate deny, not abuse).
+                _deny_if_not_active(
+                    user,
+                    ip_address=request.client.host if request.client else None,
+                )
+
                 # SECURITY: Check user-level blacklist (set by invalidate_all_sessions
                 # on password change/reset). Without this, old refresh tokens could
                 # still rotate even after all sessions were invalidated.
@@ -1120,6 +1189,11 @@ async def refresh_access_token(
 
         return response
 
+    except InvalidCredentials:
+        # Non-active account denied at the Tầng A gate above. Route to a clean
+        # 401 via the global handler WITHOUT tripping the refresh-abuse counter
+        # or revoking sessions (this is a legitimate deny, not token abuse).
+        raise
     except (JWTError, InvalidToken):
         # ✅ M4: Increment failed refresh counter
         if _refresh_username:
@@ -1228,6 +1302,15 @@ async def verify_mfa(
     user = await user_service.get_user_by_username(db, username=username)
     if not user or user.id != user_id:
         raise HTTPException(status_code=401, detail="Invalid MFA token")
+
+    # ===== STATUS GATE (Tầng B — early) =====
+    # Block non-active accounts BEFORE spending an OTP / bumping the MFA counter.
+    # Catches the TOCTOU window where the account is deactivated between /login
+    # (mfa_token issued) and /verify-mfa. Authoritative re-check happens in
+    # _complete_login_flow (Tầng A) below.
+    _deny_if_not_active(
+        user, ip_address=request.client.host if request.client else None
+    )
 
     # 4. Verify MFA code
     is_valid = await mfa_service.verify_mfa_code(db, user, mfa_data.code)

--- a/Backend_FastAPI/app/services/user_service.py
+++ b/Backend_FastAPI/app/services/user_service.py
@@ -1296,7 +1296,13 @@ async def set_password_by_admin(
         raise e
 
 
-async def invalidate_all_sessions(db: AsyncSession, user: models.User):
+async def invalidate_all_sessions(
+    db: AsyncSession,
+    user: models.User,
+    *,
+    reason: str = "Password changed",
+    fail_on_cache_cleanup: bool = False,
+):
     """
     (V5 - Fixed) Vô hiệu hóa tất cả các phiên hoạt động.
     Sửa lỗi Race Condition bằng cách khóa (lock) và cập nhật DB trong 1 transaction.
@@ -1356,8 +1362,12 @@ async def invalidate_all_sessions(db: AsyncSession, user: models.User):
                     }
                 )
 
-        # 4. ✅ COMMIT TỰ ĐỘNG (khi ra khỏi `async with db.begin()`)
-        log.info("DB transaction committed, sessions revoked in DB", user_id=user_id)
+        # 4. Savepoint released here — the session-revoke rows are STAGED in the
+        #    caller's OUTER transaction (NOT committed yet; the caller commits).
+        log.info(
+            "Session-revoke staged in caller transaction (savepoint released)",
+            user_id=user_id,
+        )
 
         # 5. ✅ XÓA REDIS KEYS (SAU KHI COMMIT THÀNH CÔNG)
         if revoked_jtis:
@@ -1377,18 +1387,33 @@ async def invalidate_all_sessions(db: AsyncSession, user: models.User):
                     user_id=user_id,
                     error=str(e_redis_del),
                 )
-                # Không ném lỗi ở đây, vì DB đã commit (nhưng cần log)
+                # STRICT (offboarding): a Redis cleanup miss leaves a phantom
+                # session:{jti} that can resurrect an old access token after the
+                # account is reactivated + logs in (which clears user_blacklist).
+                # Raise so the caller rolls back the status change → fail-closed.
+                # Default path (change_password) stays best-effort: the DB
+                # session-revoke is staged in the CALLER's transaction (savepoint
+                # released into it above, NOT yet committed) and is durable only
+                # if the caller commits.
+                if fail_on_cache_cleanup:
+                    raise CacheServiceError(
+                        detail="Failed to clear session keys from cache",
+                        context={
+                            "operation": "redis_session_cleanup",
+                            "user_id": user_id,
+                        },
+                    )
 
         # 6. ✅ DISPATCH EVENT (Event Dispatcher Pattern - SAU KHI MỌI THỨ HOÀN TẤT)
         try:
             await dispatcher.dispatch(
                 TransportEvents.USER_FORCE_LOGOUT,
                 user_id=user_id,
-                reason="Password changed",
+                reason=reason,
                 revoked_jtis=[]  # All sessions revoked
             )
             socket_events_emitted_total.labels(event_type="force_logout_all").inc()
-            log.info("Dispatched force_logout event (password change)", user_id=user_id)
+            log.info("Dispatched force_logout event", user_id=user_id, reason=reason)
         except Exception as e_dispatch:
             socket_emit_failures_total.labels(event_type="force_logout_all").inc()
             log.error(
@@ -1503,10 +1528,11 @@ async def perform_bulk_action(
             # ✅ FIX Bug #2: Return Tuple instead of string
             async def _noop():
                 pass
-            return "No users found for the provided IDs. 0 users affected.", _noop
+            return "No users found for the provided IDs. 0 users affected.", _noop, []
 
         processed_count = 0
         message = ""
+        disconnect_ids: list = []  # status-changed ids the router must force-disconnect
         if action == "delete":
             # ✅ SPRINT 5: Use Repository for consultation check
             # Check if any users have consultations (cannot delete)
@@ -1604,6 +1630,26 @@ async def perform_bulk_action(
                     new_status=new_status,
                 )
 
+            # Revoke sessions for accounts moved to a NON-active status. Persist
+            # the status (flush ⇒ row lock) BEFORE revoking so a concurrent login
+            # is serialized on the locked row (flush-before-revoke, P0). Strict
+            # cache cleanup so a Redis miss fails the whole bulk → router rollback.
+            # Server-side socket force-disconnect is done by the ROUTER (transport
+            # boundary): this service returns the ids to disconnect.
+            if new_status != "active" and ids_changed:
+                await db.flush()
+                by_id = {u.id: u for u in users_to_process}
+                for uid in sorted(ids_changed):
+                    u = by_id.get(uid)
+                    if u is not None:
+                        await invalidate_all_sessions(
+                            db,
+                            u,
+                            reason="Account deactivated by administrator",
+                            fail_on_cache_cleanup=True,
+                        )
+                disconnect_ids = sorted(ids_changed)
+
         # ✅ TRANSACTION FIX: Flush instead of commit
         await db.flush()
 
@@ -1612,7 +1658,7 @@ async def perform_bulk_action(
             """Execute after router commits the transaction."""
             pass
 
-        return message, _post_commit
+        return message, _post_commit, disconnect_ids
 
     except Exception as e:
         # ✅ Router will handle rollback

--- a/Backend_FastAPI/app/socket_manager.py
+++ b/Backend_FastAPI/app/socket_manager.py
@@ -1,5 +1,13 @@
 # app/socket_manager.py
 
+import asyncio
+import json
+import math
+import os
+import threading
+import uuid
+
+import redis as _redis_sync  # sync client for the heartbeat watchdog thread
 import socketio
 import structlog
 from fastapi import HTTPException
@@ -211,6 +219,25 @@ async def _get_user_from_token(token: str) -> models.User:
                 raise HTTPException(status_code=404, detail="User not found")
             if user.id != int(stored_user_id):
                 raise HTTPException(status_code=401, detail="Token/User mismatch")
+
+            # DB-authoritative session cross-check (parity with HTTP deps STEP 4).
+            # The Redis session:{jti} hit above can be stale (cleanup miss) or a
+            # phantom (Redis-only, no DB row). Require a non-revoked, non-expired
+            # DB session row for THIS jti, else reject — closes token resurrection
+            # after reactivate + login clears user_blacklist.
+            from app.repositories import SessionRepository
+            db_session = await SessionRepository(db).get_by_refresh_jti_and_user(
+                refresh_jti, user.id
+            )
+            if db_session is None:
+                log.warning(
+                    "Socket auth rejected: no non-revoked DB session (stale/phantom)",
+                    user_id=user.id,
+                    jti=refresh_jti,
+                )
+                raise HTTPException(
+                    status_code=401, detail="Session revoked or expired"
+                )
 
             # ✅ FIX-3: Check user blacklist (CRITICAL SECURITY FIX)
             try:
@@ -480,6 +507,18 @@ async def revalidate_auth(sid):
             user_id = session.get("user_id")
             refresh_jti = session.get("jti")
 
+            # Fail-closed: a session without user_id/jti cannot be validated
+            # against the DB (the exact-jti check below would be skipped),
+            # leaving it permanently trusted. Disconnect immediately.
+            if not user_id or not refresh_jti:
+                log.warning(
+                    "Revalidation failed: missing user_id/jti in socket session",
+                    sid=sid,
+                    user_id=user_id,
+                )
+                await sio.disconnect(sid)
+                return {"valid": False, "reason": "Invalid session"}
+
             # Check if this specific session is still valid in Redis
             if refresh_jti:
                 session_valid = await safe_redis_get(f"session:{refresh_jti}")
@@ -504,32 +543,27 @@ async def revalidate_auth(sid):
                 await sio.disconnect(sid)
                 return {"valid": False, "reason": "User session invalidated"}
 
-            # Fallback: Check if ANY active session exists in DB
-            from datetime import datetime, timezone
-            from sqlalchemy import and_, select
+            # DB-authoritative cross-check for THIS jti (NOT "any active session"
+            # of the user). The old code passed an old/revoked socket as long as
+            # the user had *some* active session — so a fresh login after
+            # deactivate→reactivate kept a stale socket alive. Require a
+            # non-revoked, non-expired DB row matching exactly refresh_jti.
+            if refresh_jti:
+                async with AsyncSessionLocal() as db:
+                    from app.repositories import SessionRepository
 
-            async with AsyncSessionLocal() as db:
-                result = await db.execute(
-                    select(models.UserSession)
-                    .where(
-                        and_(
-                            models.UserSession.user_id == user_id,
-                            models.UserSession.revoked_at.is_(None),
-                            models.UserSession.expires_at > datetime.now(timezone.utc),
-                        )
-                    )
-                    .limit(1)
-                )
-                active_session = result.scalar_one_or_none()
-
-                if not active_session:
+                    db_session = await SessionRepository(
+                        db
+                    ).get_by_refresh_jti_and_user(refresh_jti, user_id)
+                if db_session is None:
                     log.warning(
-                        "Revalidation failed: No active sessions in DB",
+                        "Revalidation failed: session revoked/expired in DB (exact jti)",
                         sid=sid,
-                        user_id=user_id
+                        user_id=user_id,
+                        jti=refresh_jti,
                     )
                     await sio.disconnect(sid)
-                    return {"valid": False, "reason": "No active sessions"}
+                    return {"valid": False, "reason": "Session revoked"}
 
             log.debug("Revalidation successful", sid=sid, user_id=user_id)
             socket_events_received_total.labels(event_type="revalidate_auth").inc()
@@ -618,6 +652,275 @@ async def emit_force_logout(user_id: int, revoked_jtis: list, **kwargs):
             log.warning("Emitted broadcast force_logout_batch (ALL)", user_id=user_id)
     except Exception as e:
         log.error("Failed to emit force_logout event", user_id=user_id, error=str(e))
+
+
+# =====================================================================
+# SERVER-SIDE FORCE-DISCONNECT (enforcement, NOT client-dependent)
+# =====================================================================
+# emit_force_logout() above only EMITS an event the client must honour — a
+# custom/malicious client can ignore it and keep receiving realtime. For real
+# offboarding we disconnect sockets server-side, across ALL Gunicorn workers,
+# with confirmation. Mechanism: the offboarding request publishes a command on a
+# Redis channel; every worker runs a subscriber that disconnects its LOCAL
+# participants (AsyncRedisManager.get_participants is local-only) and ACKs. The
+# publisher BLOCKS until every REQUIRED worker ACKs, else raises → the admin
+# request rolls back the status change (fail-closed).
+#
+# A "required" worker is any registered worker whose heartbeat key still exists.
+# The heartbeat is refreshed by a DEDICATED THREAD (not a coroutine) so it keeps
+# proving "process alive" even when the event loop stalls — a stalled worker then
+# stays in the required set but cannot ACK → fail-closed. A worker that cannot
+# refresh its heartbeat (Redis unreachable) or whose process dies stops the
+# thread, so a missing heartbeat key (past the TTL grace) provably means the
+# process exited and its sockets are closed. A worker with a live heartbeat that
+# fails to ACK makes offboarding fail-closed (NOT pruned).
+FORCE_DISCONNECT_CHANNEL = "socket:force_disconnect"
+_WORKERS_SET = "socket:workers"
+_WORKER_HB_PREFIX = "socket:worker_hb:"
+_ACK_PREFIX = "socket:dc_ack:"
+# TTL must exceed the max tolerated event-loop stall; a worker that stops
+# refreshing self-terminates, so key-gone (past this grace) == process gone.
+_WORKER_HB_TTL = 30        # heartbeat key lifetime / death grace (s)
+_WORKER_HB_REFRESH = 5     # heartbeat refresh interval (s)
+_ACK_TTL = 30             # ack-set cleanup backstop (s)
+_ACK_TIMEOUT = 3.0        # publisher waits for all required workers (s)
+_ACK_POLL = 0.1          # ack poll interval (s)
+
+# Unique id for THIS worker process (set by register_socket_worker at startup).
+_worker_id = None
+
+_HB_MAX_FAILS = 3        # consecutive heartbeat-thread refresh failures → os._exit
+_hb_thread = None        # heartbeat watchdog thread (independent of event loop)
+_hb_stop = None          # threading.Event used to stop the heartbeat thread
+
+
+async def register_socket_worker():
+    """Register this worker: write heartbeat FIRST, then add to the set (so a
+    worker is never in the set without a live heartbeat). Called once at startup
+    AFTER the subscriber is listening; caller treats failure as fatal."""
+    global _worker_id
+    _worker_id = uuid.uuid4().hex
+    await redis_client.set(_WORKER_HB_PREFIX + _worker_id, "1", ex=_WORKER_HB_TTL)
+    await redis_client.sadd(_WORKERS_SET, _worker_id)
+    log.info("Socket worker registered", worker_id=_worker_id)
+    return _worker_id
+
+
+async def deregister_socket_worker():
+    """Remove this worker from the set + drop its heartbeat (graceful exit)."""
+    if not _worker_id:
+        return
+    try:
+        await redis_client.srem(_WORKERS_SET, _worker_id)
+        await redis_client.delete(_WORKER_HB_PREFIX + _worker_id)
+    except Exception as e:
+        log.error("Socket worker deregister failed", worker_id=_worker_id, error=str(e))
+
+
+def _heartbeat_thread_run(worker_id, stop_event):
+    """Runs in a DEDICATED THREAD, independent of the asyncio event loop, so the
+    heartbeat keeps proving 'process alive' even if the event loop STALLS. If the
+    loop hangs, this worker stays in the required ACK set (heartbeat still alive)
+    but cannot ACK → the offboarding request times out and rolls back
+    (fail-closed). A coroutine heartbeat could NOT do this: a stalled loop never
+    runs it, the key expires, and the worker would be wrongly pruned while its
+    sockets are still alive. If Redis is unreachable for too long, terminate the
+    process so its sockets close (heartbeat-gone then provably == process-gone).
+    Gunicorn's worker `timeout` (120s) > TTL (30s), so without this thread a
+    31–119s stall would silently drop a live worker."""
+    # Finite socket timeouts are REQUIRED: with the default (infinite) timeout a
+    # network blackhole makes client.set() hang past the TTL, the key expires and
+    # the worker is pruned while its process/sockets are still alive. With a 2s
+    # timeout, 3 consecutive failures trip os._exit well before the 30s TTL
+    # (~3×(2+5)s ≈ 21s), so heartbeat-gone still implies process-gone.
+    client = _redis_sync.Redis.from_url(
+        settings.REDIS_URL,
+        decode_responses=True,
+        socket_connect_timeout=2,
+        socket_timeout=2,
+        retry_on_timeout=False,
+    )
+    fails = 0
+    try:
+        while not stop_event.is_set():
+            try:
+                client.set(_WORKER_HB_PREFIX + worker_id, "1", ex=_WORKER_HB_TTL)
+                fails = 0
+            except Exception as e:
+                fails += 1
+                log.error(
+                    "Heartbeat thread refresh failed",
+                    worker_id=worker_id,
+                    attempt=fails,
+                    error=str(e),
+                )
+                if fails >= _HB_MAX_FAILS:
+                    log.critical(
+                        "Heartbeat unrecoverable — exiting worker (Gunicorn restart)",
+                        worker_id=worker_id,
+                    )
+                    os._exit(1)
+            stop_event.wait(_WORKER_HB_REFRESH)
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass
+
+
+def start_heartbeat_thread():
+    """Start the heartbeat watchdog thread (call AFTER register_socket_worker)."""
+    global _hb_thread, _hb_stop
+    _hb_stop = threading.Event()
+    _hb_thread = threading.Thread(
+        target=_heartbeat_thread_run,
+        args=(_worker_id, _hb_stop),
+        name="socket-heartbeat",
+        daemon=True,
+    )
+    _hb_thread.start()
+    log.info("Socket heartbeat thread started", worker_id=_worker_id)
+
+
+def stop_heartbeat_thread():
+    """Signal the heartbeat thread to stop and join it (graceful shutdown)."""
+    if _hb_stop is not None:
+        _hb_stop.set()
+    if _hb_thread is not None:
+        _hb_thread.join(timeout=5)
+
+
+async def _required_workers():
+    """Workers that MUST ACK a force-disconnect: every registered worker whose
+    heartbeat key still EXISTS. Entries whose key is gone (past the TTL grace)
+    are pruned — a worker that stopped refreshing self-terminated (os._exit), so
+    its process is gone and sockets closed. We do NOT prune a worker that merely
+    fails to ACK while its heartbeat is live: that path stays fail-closed."""
+    members = await redis_client.smembers(_WORKERS_SET)  # decode_responses → str
+    required, dead = set(), set()
+    for wid in members:
+        if await redis_client.exists(_WORKER_HB_PREFIX + wid):
+            required.add(wid)
+        else:
+            dead.add(wid)  # heartbeat gone past grace → process exited
+    if dead:
+        await redis_client.srem(_WORKERS_SET, *dead)
+    return required
+
+
+async def force_disconnect_user(user_ids) -> int:
+    """LOCAL: disconnect every SID of the given user(s) on THIS worker. Accepts a
+    single id or an iterable. Snapshots participants first (disconnect mutates
+    room membership). Raises on any disconnect failure → caller does NOT ACK →
+    publisher times out (fail-closed)."""
+    if isinstance(user_ids, int):
+        user_ids = [user_ids]
+    user_ids = list(user_ids)
+    count = 0
+    for uid in user_ids:
+        room = f"user_room_{uid}"
+        sids = [sid for sid, _ in sio.manager.get_participants("/", room)]
+        for sid in sids:
+            await sio.disconnect(sid)
+            count += 1
+    log.info("force_disconnect_user (local)", user_ids=user_ids, disconnected=count)
+    return count
+
+
+async def _handle_force_disconnect(raw: str):
+    """Subscriber handler: disconnect the whole batch locally, then ACK ONCE.
+    No ACK if the disconnect raises (publisher fail-closes)."""
+    data = json.loads(raw)
+    command_id = data["command_id"]
+    await force_disconnect_user(data["user_ids"])  # raises → no ACK below
+    ack_key = _ACK_PREFIX + command_id
+    await redis_client.sadd(ack_key, _worker_id)
+    await redis_client.expire(ack_key, _ACK_TTL)
+
+
+async def subscribe_force_disconnect():
+    """Create the pubsub and AWAIT the SUBSCRIBE before returning, so the caller
+    registers this worker as live only AFTER it is actually listening."""
+    pubsub = redis_client.pubsub()
+    await pubsub.subscribe(FORCE_DISCONNECT_CHANNEL)
+    return pubsub
+
+
+async def consume_force_disconnect(pubsub):
+    """Background consumer loop. Raises/returns on fatal pubsub error → the
+    lifespan supervisor terminates the worker so Gunicorn restarts it."""
+    log.info("Force-disconnect subscriber listening", worker_id=_worker_id)
+    try:
+        async for message in pubsub.listen():
+            if not message or message.get("type") != "message":
+                continue
+            try:
+                await _handle_force_disconnect(message["data"])
+            except Exception as e:
+                # Handler failure → deliberately do NOT ACK so the publisher
+                # times out and fail-closes. Keep consuming other commands.
+                log.error("Force-disconnect handler failed (no ACK)", error=str(e))
+    finally:
+        try:
+            await pubsub.unsubscribe(FORCE_DISCONNECT_CHANNEL)
+            await pubsub.aclose()
+        except Exception:
+            pass
+
+
+async def force_disconnect_user_strict(
+    user_ids, *, timeout: float = _ACK_TIMEOUT
+) -> str:
+    """ENFORCEMENT: publish ONE force-disconnect command for the whole batch and
+    BLOCK until every required worker ACKs, else raise (fail-closed). Redis
+    PUBLISH only reports how many subscribers RECEIVED the message — not that
+    they processed it — so we require explicit per-worker ACKs. A single batched
+    command bounds the admin request to ONE timeout regardless of batch size."""
+    if isinstance(user_ids, int):
+        user_ids = [user_ids]
+    user_ids = list(user_ids)
+    if not user_ids:
+        return ""
+    command_id = uuid.uuid4().hex
+    ack_key = _ACK_PREFIX + command_id
+    # Snapshot required workers BEFORE publishing. Workers that start AFTER are
+    # not required to ACK (they hold no sockets predating the command).
+    required = await _required_workers()
+    if not required:
+        # No worker alive → cannot guarantee enforcement → fail-closed.
+        raise RuntimeError("No live socket workers to enforce force-disconnect")
+    payload = json.dumps({"command_id": command_id, "user_ids": user_ids})
+    await redis_client.publish(FORCE_DISCONNECT_CHANNEL, payload)
+    try:
+        max_polls = max(1, int(math.ceil(timeout / _ACK_POLL)))
+        acked = set()
+        for _ in range(max_polls):
+            acked = set(await redis_client.smembers(ack_key))
+            if required <= acked:
+                break
+            await asyncio.sleep(_ACK_POLL)
+        missing = required - acked
+        if missing:
+            log.error(
+                "force_disconnect_user_strict: ACK timeout",
+                user_ids=user_ids,
+                command_id=command_id,
+                missing=list(missing),
+            )
+            raise TimeoutError(
+                f"Force-disconnect not ACKed by workers: {sorted(missing)}"
+            )
+        log.info(
+            "force_disconnect_user_strict OK",
+            user_ids=user_ids,
+            workers=len(required),
+        )
+        return command_id
+    finally:
+        try:
+            await redis_client.delete(ack_key)
+        except Exception:
+            pass
 
 
 async def emit_data_updated(event_data: dict, **kwargs):

--- a/Backend_FastAPI/tests/api/test_auth_inactive_user_gate.py
+++ b/Backend_FastAPI/tests/api/test_auth_inactive_user_gate.py
@@ -1,0 +1,367 @@
+"""End-to-end tests for the inactive-account lockdown (security hotfix).
+
+Verifies the two layers:
+- (A) token-issuance gate: login / verify-mfa / refresh refuse a non-active
+  account (generic 401, no lockout side effects), with the authoritative
+  re-check in _complete_login_flow closing the deactivate↔mint race;
+- (B) deactivation revokes live sessions: an admin status change to a non-active
+  value kills existing access tokens immediately (DB-authoritative session
+  check), is fail-closed, and does NOT reactivate via change-password.
+
+Also covers the Redis/DB session desync (stale + phantom) that previously let an
+old token resurrect.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import update
+
+from app import models, security
+from app.database import AsyncSessionLocal, safe_redis_get
+from app.main import fastapi_app
+from app.security import get_password_hash
+from app.services import user_service
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.security]
+
+NON_ACTIVE = ["inactive", "pending", "banned"]
+PWD = "TestPassword123!"
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+async def _seed_user(username, *, status="active", role="user"):
+    async with AsyncSessionLocal() as s:
+        u = models.User(
+            username=username,
+            email=f"{username}@test.local",
+            password_hash=get_password_hash(PWD),
+            role=role,
+            status=status,
+        )
+        s.add(u)
+        await s.commit()
+        await s.refresh(u)
+        return u.id
+
+
+async def _set_status(user_id, status):
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            update(models.User).where(models.User.id == user_id).values(status=status)
+        )
+        await s.commit()
+
+
+async def _get_status(user_id):
+    async with AsyncSessionLocal() as s:
+        u = await s.get(models.User, user_id)
+        return u.status
+
+
+def _bare_client():
+    return AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test")
+
+
+async def _login(pc, username, password=PWD):
+    """Login on the given client; returns the response (cookies land on pc)."""
+    return await pc.post(
+        "/api/auth/login", data={"username": username, "password": password}
+    )
+
+
+# --------------------------------------------------------------------------- #
+# (A) Token-issuance gate
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("status", NON_ACTIVE)
+async def test_login_non_active_rejected_generic_401(client: AsyncClient, status):
+    uid = await _seed_user(f"login_gate_{status}", status=status)
+    assert uid
+    res = await _login(client, f"login_gate_{status}")
+    assert res.status_code == 401
+    body = res.text.lower()
+    # Generic message — must not leak account state ("inactive"/"banned").
+    assert "inactive" not in body and "banned" not in body
+    assert "access_token" not in res.cookies
+
+
+async def test_login_inactive_no_mfa_token(client: AsyncClient):
+    await _seed_user("login_gate_nomfa", status="inactive")
+    res = await _login(client, "login_gate_nomfa")
+    assert res.status_code == 401
+    assert "mfa_token" not in res.text and "mfa_required" not in res.text
+
+
+async def test_refresh_non_active_401_not_500_and_no_counter(client: AsyncClient):
+    uid = await _seed_user("refresh_gate", status="active")
+    async with _bare_client() as pc:
+        r = await _login(pc, "refresh_gate")
+        assert r.status_code == 200
+        await _set_status(uid, "inactive")
+        rr = await pc.post("/api/auth/refresh")
+    assert rr.status_code == 401  # NOT 500
+    # legitimate deny must not trip the refresh-abuse counter
+    assert await safe_redis_get("refresh_fail:refresh_gate") in (None, "0")
+
+
+async def test_tang_a_race_deactivate_after_authenticate(
+    client: AsyncClient, monkeypatch
+):
+    """Account is active when authenticate_user returns (Tầng B early gate sees a
+    stale active object), but flipped to inactive before the token is minted.
+    _complete_login_flow's authoritative db.refresh must catch it → 401."""
+    await _seed_user("race_gate", status="active")
+    orig = user_service.authenticate_user
+
+    async def fake_auth(db, username, password):
+        user = await orig(db, username=username, password=password)
+        await _set_status(user.id, "inactive")  # flip DB after returning stale obj
+        return user
+
+    monkeypatch.setattr(user_service, "authenticate_user", fake_auth)
+    res = await _login(client, "race_gate")
+    assert res.status_code == 401
+    assert "access_token" not in res.cookies
+
+
+# --------------------------------------------------------------------------- #
+# (B) Deactivation revokes live sessions
+# --------------------------------------------------------------------------- #
+async def test_single_deactivate_kills_existing_token(
+    client: AsyncClient, admin_token_headers: dict
+):
+    uid = await _seed_user("revoke_single", status="active")
+    async with _bare_client() as pc:
+        r = await _login(pc, "revoke_single")
+        assert r.status_code == 200
+        token = pc.cookies.get("access_token")
+        # token works before deactivation
+        ok = await pc.get("/api/auth/check-status")
+        assert ok.status_code == 200
+
+        res = await client.put(
+            f"/api/admin/users/{uid}",
+            data={"status": "inactive"},
+            headers=admin_token_headers,
+        )
+        assert res.status_code == 200, res.text
+
+        # old token must now be rejected immediately
+        async with _bare_client() as probe:
+            probe.cookies.set("access_token", token)
+            gone = await probe.get("/api/auth/check-status")
+        assert gone.status_code == 401
+
+
+async def test_single_deactivate_fail_closed_on_revoke_error(
+    client: AsyncClient, admin_token_headers: dict, monkeypatch
+):
+    uid = await _seed_user("revoke_failclosed", status="active")
+
+    async def boom(*a, **k):
+        raise RuntimeError("revoke exploded")
+
+    monkeypatch.setattr(user_service, "invalidate_all_sessions", boom)
+    res = await client.put(
+        f"/api/admin/users/{uid}",
+        data={"status": "inactive"},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 500
+    # fail-closed: status must NOT have changed
+    assert await _get_status(uid) == "active"
+
+
+async def test_single_deactivate_fail_closed_on_disconnect_timeout(
+    client: AsyncClient, admin_token_headers: dict, monkeypatch
+):
+    """An ACK timeout from the force-disconnect must roll back the whole change."""
+    import app.socket_manager as sm
+
+    uid = await _seed_user("revoke_dc_timeout", status="active")
+
+    async def boom(*a, **k):
+        raise TimeoutError("ack timeout")
+
+    monkeypatch.setattr(sm, "force_disconnect_user_strict", boom)
+    res = await client.put(
+        f"/api/admin/users/{uid}",
+        data={"status": "inactive"},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 500
+    assert await _get_status(uid) == "active"
+
+
+async def test_bulk_deactivate_kills_existing_token(
+    client: AsyncClient, admin_token_headers: dict
+):
+    uid = await _seed_user("revoke_bulk", status="active")
+    async with _bare_client() as pc:
+        await _login(pc, "revoke_bulk")
+        token = pc.cookies.get("access_token")
+        res = await client.post(
+            "/api/admin/users/bulk",
+            json={"action": "change_status", "user_ids": [uid], "status": "banned"},
+            headers=admin_token_headers,
+        )
+        assert res.status_code == 200, res.text
+        async with _bare_client() as probe:
+            probe.cookies.set("access_token", token)
+            gone = await probe.get("/api/auth/check-status")
+        assert gone.status_code == 401
+    assert await _get_status(uid) == "banned"
+
+
+async def test_bulk_deactivate_fail_closed_on_disconnect_error(
+    client: AsyncClient, admin_token_headers: dict, monkeypatch
+):
+    """If the batched force-disconnect fails, the bulk status change rolls back."""
+    import app.socket_manager as sm
+
+    uid = await _seed_user("revoke_bulk_failclosed", status="active")
+
+    async def boom(*a, **k):
+        raise RuntimeError("disconnect exploded")
+
+    monkeypatch.setattr(sm, "force_disconnect_user_strict", boom)
+    res = await client.post(
+        "/api/admin/users/bulk",
+        json={"action": "change_status", "user_ids": [uid], "status": "banned"},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 500
+    assert await _get_status(uid) == "active"  # fail-closed
+
+
+async def test_verify_mfa_tang_a_race(client: AsyncClient, monkeypatch):
+    """Account is active at the verify-mfa early gate and through OTP, but flipped
+    to inactive before the token mints. _complete_login_flow (Tầng A) must 401."""
+    from app.services import mfa_service
+
+    uid = await _seed_user("mfa_race", status="active")
+    mfa_token = mfa_service.create_mfa_token(username="mfa_race", user_id=uid)
+
+    async def fake_verify(db, user, code):
+        await _set_status(user.id, "inactive")  # flip right after a "good" OTP
+        return True
+
+    monkeypatch.setattr(mfa_service, "verify_mfa_code", fake_verify)
+    async with _bare_client() as pc:
+        res = await pc.post(
+            "/api/auth/verify-mfa",
+            json={"mfa_token": mfa_token, "code": "123456"},
+        )
+    assert res.status_code == 401
+    assert "access_token" not in res.cookies
+
+
+# --------------------------------------------------------------------------- #
+# (B) Redis/DB session desync — no token resurrection
+# --------------------------------------------------------------------------- #
+async def _jti_of(token):
+    return security.decode_token(token).get("r_jti")
+
+
+async def test_desync_db_revoked_redis_present_rejected(client: AsyncClient):
+    await _seed_user("desync_revoked", status="active")
+    async with _bare_client() as pc:
+        await _login(pc, "desync_revoked")
+        token = pc.cookies.get("access_token")
+        jti = await _jti_of(token)
+        # Revoke the DB session row but LEAVE the Redis session key in place.
+        async with AsyncSessionLocal() as s:
+            await s.execute(
+                update(models.UserSession)
+                .where(models.UserSession.refresh_jti == jti)
+                .values(revoked_at=datetime.now(timezone.utc))
+            )
+            await s.commit()
+        gone = await pc.get("/api/auth/check-status")
+    assert gone.status_code == 401  # DB cross-check rejects the stale Redis hit
+
+
+async def test_phantom_redis_only_rejected(client: AsyncClient):
+    await _seed_user("desync_phantom", status="active")
+    async with _bare_client() as pc:
+        await _login(pc, "desync_phantom")
+        token = pc.cookies.get("access_token")
+        jti = await _jti_of(token)
+        # Delete the DB session row entirely (phantom: Redis key, no DB row).
+        async with AsyncSessionLocal() as s:
+            await s.execute(
+                models.UserSession.__table__.delete().where(
+                    models.UserSession.refresh_jti == jti
+                )
+            )
+            await s.commit()
+        gone = await pc.get("/api/auth/check-status")
+    assert gone.status_code == 401
+
+
+# --------------------------------------------------------------------------- #
+# Recovery / contract — SYNTHETIC valid session (status flipped directly, not
+# via the admin endpoint, so the session is NOT revoked and the token is valid)
+# --------------------------------------------------------------------------- #
+async def test_change_password_does_not_reactivate(client: AsyncClient):
+    uid = await _seed_user("recover_chpwd", status="active")
+    async with _bare_client() as pc:
+        await _login(pc, "recover_chpwd")
+        await _set_status(uid, "inactive")  # synthetic inactive, session still valid
+        res = await pc.post(
+            "/api/auth/change-password",
+            json={"old_password": PWD, "new_password": "NewPassword456!"},
+        )
+    assert res.status_code == 204
+    # change-password must NOT reactivate the account
+    assert await _get_status(uid) == "inactive"
+
+
+async def test_check_status_returns_real_status(client: AsyncClient):
+    uid = await _seed_user("recover_status", status="active")
+    async with _bare_client() as pc:
+        await _login(pc, "recover_status")
+        await _set_status(uid, "inactive")
+        res = await pc.get("/api/auth/check-status")
+    assert res.status_code == 200
+    assert res.json()["status"] == "inactive"  # real status, not hardcoded "active"
+
+
+# --------------------------------------------------------------------------- #
+# No lockout side effect for a legitimate inactive deny
+# --------------------------------------------------------------------------- #
+async def test_inactive_login_does_not_lock_account(client: AsyncClient):
+    await _seed_user("nolock_gate", status="inactive")
+    for _ in range(6):
+        res = await _login(client, "nolock_gate")
+        assert res.status_code == 401
+    from app.security.account_lockout import AccountLockoutService
+
+    is_locked, _ttl = await AccountLockoutService.check_lockout("nolock_gate")
+    assert is_locked is False
+
+
+# --------------------------------------------------------------------------- #
+# Login-session contract: a DB session-creation failure must fail-closed
+# (STEP 4 is DB-authoritative, so a token without a DB session row is 401 on
+# arrival — we must NOT mint it).
+# --------------------------------------------------------------------------- #
+async def test_login_fail_closed_when_db_session_creation_fails(
+    client: AsyncClient, monkeypatch
+):
+    from app.services import session_service
+
+    await _seed_user("login_session_fail", status="active")
+
+    async def boom(*a, **k):
+        raise RuntimeError("db session create failed")
+
+    monkeypatch.setattr(session_service, "create_session", boom)
+    async with _bare_client() as pc:
+        res = await _login(pc, "login_session_fail")
+    assert res.status_code == 500
+    assert "access_token" not in res.cookies

--- a/Backend_FastAPI/tests/security/test_session_revocation.py
+++ b/Backend_FastAPI/tests/security/test_session_revocation.py
@@ -19,6 +19,9 @@ from ..fixtures.constants import AuthURLs
 
 log = logging.getLogger(__name__)
 
+# Select these Socket.IO revocation tests under `-m security`.
+pytestmark = pytest.mark.security
+
 
 @pytest.mark.asyncio
 async def test_targeted_revocation_flow(test_server, client, regular_user_in_db, test_redis_client):

--- a/Backend_FastAPI/tests/security/test_socket_auth_session.py
+++ b/Backend_FastAPI/tests/security/test_socket_auth_session.py
@@ -1,0 +1,121 @@
+"""Unit tests for Socket.IO session validation hardening
+(``app/socket_manager.py:revalidate_auth`` + ``_get_user_from_token``).
+
+Reviewed invariants:
+- revalidate fails CLOSED when the socket session is missing user_id/jti,
+- revalidate cross-checks the DB for the EXACT refresh_jti (not "any active
+  session of the user"), so an old/revoked socket cannot ride on a new login,
+- a connecting token whose DB session is revoked/phantom is rejected.
+
+Mock-based (no live Socket.IO server).
+"""
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app import socket_manager as sm
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+
+def _fake_session_local(db):
+    @asynccontextmanager
+    async def _cm():
+        yield db
+    return MagicMock(side_effect=lambda: _cm())
+
+
+@pytest.mark.asyncio
+async def test_revalidate_missing_jti_disconnects():
+    fake_sio = MagicMock()
+    fake_sio.get_session = AsyncMock(return_value={"user_id": 1, "jti": None})
+    fake_sio.disconnect = AsyncMock()
+    with patch.object(sm, "sio", fake_sio):
+        out = await sm.revalidate_auth("sid1")
+    assert out["valid"] is False
+    fake_sio.disconnect.assert_awaited_once_with("sid1")
+
+
+@pytest.mark.asyncio
+async def test_revalidate_missing_user_id_disconnects():
+    fake_sio = MagicMock()
+    fake_sio.get_session = AsyncMock(return_value={"user_id": None, "jti": "j1"})
+    fake_sio.disconnect = AsyncMock()
+    with patch.object(sm, "sio", fake_sio):
+        out = await sm.revalidate_auth("sid1")
+    assert out["valid"] is False
+    fake_sio.disconnect.assert_awaited_once_with("sid1")
+
+
+@pytest.mark.asyncio
+async def test_revalidate_exact_jti_revoked_disconnects():
+    """Redis says the session is valid AND the user has SOME active session, but
+    the EXACT jti has no non-revoked DB row → must disconnect."""
+    fake_sio = MagicMock()
+    fake_sio.get_session = AsyncMock(return_value={"user_id": 5, "jti": "old-jti"})
+    fake_sio.disconnect = AsyncMock()
+
+    repo = MagicMock()
+    repo.get_by_refresh_jti_and_user = AsyncMock(return_value=None)  # exact jti gone
+
+    async def _redis_get(key):
+        # Redis session valid + user NOT blacklisted → reach the DB cross-check.
+        return "5" if key.startswith("session:") else None
+
+    with patch.object(sm, "sio", fake_sio), \
+            patch.object(sm, "safe_redis_get", AsyncMock(side_effect=_redis_get)), \
+            patch.object(sm, "AsyncSessionLocal", _fake_session_local(MagicMock())), \
+            patch("app.repositories.SessionRepository", MagicMock(return_value=repo)):
+        out = await sm.revalidate_auth("sid1")
+
+    assert out["valid"] is False
+    fake_sio.disconnect.assert_awaited_once_with("sid1")
+    repo.get_by_refresh_jti_and_user.assert_awaited_once_with("old-jti", 5)
+
+
+@pytest.mark.asyncio
+async def test_revalidate_exact_jti_valid_passes():
+    fake_sio = MagicMock()
+    fake_sio.get_session = AsyncMock(return_value={"user_id": 5, "jti": "good-jti"})
+    fake_sio.disconnect = AsyncMock()
+
+    repo = MagicMock()
+    repo.get_by_refresh_jti_and_user = AsyncMock(return_value=MagicMock())  # live row
+
+    async def _redis_get(key):
+        # session valid, user not blacklisted
+        return "5" if key.startswith("session:") else None
+
+    with patch.object(sm, "sio", fake_sio), \
+            patch.object(sm, "safe_redis_get", AsyncMock(side_effect=_redis_get)), \
+            patch.object(sm, "AsyncSessionLocal", _fake_session_local(MagicMock())), \
+            patch("app.repositories.SessionRepository", MagicMock(return_value=repo)):
+        out = await sm.revalidate_auth("sid1")
+
+    assert out["valid"] is True
+    fake_sio.disconnect.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_user_from_token_db_revoked_phantom_rejected():
+    """Socket CONNECT: a Redis session hit whose exact jti has no non-revoked DB
+    row (stale cleanup miss / phantom) must be refused. _get_user_from_token
+    converts any auth failure into ConnectionRefusedError (connect refusal)."""
+    payload = {"sub": "u", "r_jti": "jx"}
+    user = MagicMock()
+    user.id = 9
+    repo = MagicMock()
+    repo.get_by_refresh_jti_and_user = AsyncMock(return_value=None)  # no live DB row
+
+    with patch.object(sm.security, "decode_token", return_value=payload), \
+            patch.object(sm, "safe_redis_get", AsyncMock(return_value="9")), \
+            patch.object(sm, "AsyncSessionLocal", _fake_session_local(MagicMock())), \
+            patch("app.services.user_service.get_user_by_username",
+                  AsyncMock(return_value=user)), \
+            patch("app.repositories.SessionRepository", MagicMock(return_value=repo)):
+        with pytest.raises(ConnectionRefusedError):
+            await sm._get_user_from_token("tok")
+
+    # The DB cross-check ran for the exact jti before the refusal.
+    repo.get_by_refresh_jti_and_user.assert_awaited_once_with("jx", 9)

--- a/Backend_FastAPI/tests/security/test_socket_force_disconnect.py
+++ b/Backend_FastAPI/tests/security/test_socket_force_disconnect.py
@@ -1,0 +1,221 @@
+"""Unit tests for the server-side force-disconnect ACK subsystem
+(``app/socket_manager.py``).
+
+Covers the invariants hardened during review:
+- heartbeat watchdog uses FINITE socket timeouts (no infinite hang),
+- 3 consecutive heartbeat failures call ``os._exit(1)`` BEFORE the TTL grace,
+- ``_required_workers`` prunes ONLY workers whose heartbeat key is gone
+  (process exited), never a live-heartbeat worker,
+- ``force_disconnect_user_strict`` fails closed: no live workers → raise,
+  missing ACK → TimeoutError, and emits ONE batched command for all user ids,
+- a handler failure does NOT ACK (publisher fail-closes),
+- ``force_disconnect_user`` disconnects every local SID of the user.
+
+These are pure unit tests with mocked Redis / Socket.IO — no live app needed.
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app import socket_manager as sm
+
+pytestmark = [pytest.mark.unit, pytest.mark.security]
+
+
+# --------------------------------------------------------------------------- #
+# Heartbeat watchdog thread (sync function, runs off the event loop)
+# --------------------------------------------------------------------------- #
+def test_heartbeat_thread_uses_finite_socket_timeouts():
+    """A network blackhole must not be able to hang the heartbeat past the TTL,
+    so the sync Redis client MUST be created with finite socket timeouts."""
+    captured = {}
+
+    def fake_from_url(url, **kwargs):
+        captured.update(kwargs)
+        client = MagicMock()
+        client.set.return_value = True
+        return client
+
+    stop = MagicMock()
+    stop.is_set.side_effect = [False, True]  # one iteration then exit
+    stop.wait.return_value = None
+
+    with patch.object(sm._redis_sync.Redis, "from_url", side_effect=fake_from_url):
+        sm._heartbeat_thread_run("w1", stop)
+
+    assert captured.get("socket_timeout") == 2
+    assert captured.get("socket_connect_timeout") == 2
+    assert captured.get("retry_on_timeout") is False
+    assert captured.get("decode_responses") is True
+
+
+def test_heartbeat_three_failures_exits_worker():
+    """3 consecutive refresh failures must call ``os._exit(1)`` (so the process
+    dies and its sockets close BEFORE the 30s TTL lets it be pruned)."""
+    client = MagicMock()
+    client.set.side_effect = Exception("blackhole")
+    stop = MagicMock()
+    stop.is_set.return_value = False
+    stop.wait.return_value = None
+
+    with patch.object(sm._redis_sync.Redis, "from_url", return_value=client), \
+            patch.object(sm.os, "_exit", side_effect=SystemExit) as mexit:
+        with pytest.raises(SystemExit):
+            sm._heartbeat_thread_run("w1", stop)
+
+    mexit.assert_called_once_with(1)
+    assert client.set.call_count == sm._HB_MAX_FAILS  # exits exactly at the 3rd
+
+
+def test_heartbeat_transient_failure_does_not_exit():
+    """A single transient failure (then success) must NOT kill the worker."""
+    client = MagicMock()
+    client.set.side_effect = [Exception("blip"), True]
+    stop = MagicMock()
+    stop.is_set.side_effect = [False, False, True]
+    stop.wait.return_value = None
+
+    with patch.object(sm._redis_sync.Redis, "from_url", return_value=client), \
+            patch.object(sm.os, "_exit", side_effect=SystemExit) as mexit:
+        sm._heartbeat_thread_run("w1", stop)
+
+    mexit.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# _required_workers — prune only the provably-dead
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_required_workers_prunes_only_heartbeat_gone():
+    rc = AsyncMock()
+    rc.smembers.return_value = {"w_live", "w_dead"}
+
+    async def _exists(key):
+        return 1 if key.endswith("w_live") else 0
+
+    rc.exists.side_effect = _exists
+    with patch.object(sm, "redis_client", rc):
+        required = await sm._required_workers()
+
+    assert required == {"w_live"}
+    # The dead worker (heartbeat gone) is pruned; the live one is kept.
+    rc.srem.assert_awaited_once()
+    assert "w_dead" in rc.srem.await_args.args
+
+
+# --------------------------------------------------------------------------- #
+# force_disconnect_user_strict — fail-closed + batched
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_strict_no_live_workers_raises():
+    with patch.object(sm, "_required_workers", AsyncMock(return_value=set())):
+        with pytest.raises(RuntimeError):
+            await sm.force_disconnect_user_strict([1])
+
+
+@pytest.mark.asyncio
+async def test_strict_ack_timeout_raises():
+    rc = AsyncMock()
+    rc.smembers.return_value = set()  # nobody ever ACKs
+    with patch.object(sm, "redis_client", rc), \
+            patch.object(sm, "_required_workers", AsyncMock(return_value={"w1"})), \
+            patch.object(sm.asyncio, "sleep", AsyncMock()):
+        with pytest.raises(TimeoutError):
+            await sm.force_disconnect_user_strict([1], timeout=0.3)
+    rc.publish.assert_awaited_once()
+    rc.delete.assert_awaited()  # ack key cleaned up in finally
+
+
+@pytest.mark.asyncio
+async def test_strict_success_one_batched_command():
+    rc = AsyncMock()
+    rc.smembers.return_value = {"w1"}  # immediate ACK
+    with patch.object(sm, "redis_client", rc), \
+            patch.object(sm, "_required_workers", AsyncMock(return_value={"w1"})):
+        cmd = await sm.force_disconnect_user_strict([1, 2, 3])
+
+    assert isinstance(cmd, str) and cmd
+    rc.publish.assert_awaited_once()
+    channel, raw = rc.publish.await_args.args
+    assert channel == sm.FORCE_DISCONNECT_CHANNEL
+    payload = json.loads(raw)
+    assert payload["user_ids"] == [1, 2, 3]  # ONE command for the whole batch
+
+
+@pytest.mark.asyncio
+async def test_strict_waits_for_all_workers_multi():
+    """Multi-worker: succeeds only when EVERY required worker ACKs."""
+    rc = AsyncMock()
+    rc.smembers.return_value = {"w1", "w2"}  # both ACK
+    with patch.object(sm, "redis_client", rc), \
+            patch.object(sm, "_required_workers", AsyncMock(return_value={"w1", "w2"})):
+        cmd = await sm.force_disconnect_user_strict([1])
+    assert cmd
+
+
+@pytest.mark.asyncio
+async def test_strict_one_worker_missing_ack_fails_multi():
+    """Multi-worker: a single non-ACKing worker → TimeoutError (fail-closed)."""
+    rc = AsyncMock()
+    rc.smembers.return_value = {"w1"}  # w2 never ACKs
+    two = AsyncMock(return_value={"w1", "w2"})
+    with patch.object(sm, "redis_client", rc), \
+            patch.object(sm, "_required_workers", two), \
+            patch.object(sm.asyncio, "sleep", AsyncMock()):
+        with pytest.raises(TimeoutError):
+            await sm.force_disconnect_user_strict([1], timeout=0.3)
+
+
+@pytest.mark.asyncio
+async def test_strict_empty_list_is_noop():
+    with patch.object(sm, "_required_workers", AsyncMock()) as req:
+        out = await sm.force_disconnect_user_strict([])
+    assert out == ""
+    req.assert_not_awaited()  # never even looks up workers
+
+
+# --------------------------------------------------------------------------- #
+# Handler — no ACK on failure
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_handler_failure_does_not_ack():
+    rc = AsyncMock()
+    with patch.object(sm, "redis_client", rc), \
+            patch.object(sm, "force_disconnect_user",
+                         AsyncMock(side_effect=Exception("boom"))):
+        with pytest.raises(Exception):
+            await sm._handle_force_disconnect(
+                json.dumps({"command_id": "c1", "user_ids": [1]})
+            )
+    rc.sadd.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handler_success_acks_once():
+    rc = AsyncMock()
+    sm._worker_id = "w-self"
+    with patch.object(sm, "redis_client", rc), \
+            patch.object(sm, "force_disconnect_user", AsyncMock(return_value=0)):
+        await sm._handle_force_disconnect(
+            json.dumps({"command_id": "c2", "user_ids": [1, 2]})
+        )
+    rc.sadd.assert_awaited_once()
+    ack_key, wid = rc.sadd.await_args.args
+    assert ack_key == sm._ACK_PREFIX + "c2"
+    assert wid == "w-self"
+
+
+# --------------------------------------------------------------------------- #
+# force_disconnect_user — local disconnect of every SID
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_force_disconnect_user_disconnects_all_local_sids():
+    fake_sio = MagicMock()
+    fake_sio.manager.get_participants.return_value = [("sidA", "e1"), ("sidB", "e2")]
+    fake_sio.disconnect = AsyncMock()
+    with patch.object(sm, "sio", fake_sio):
+        n = await sm.force_disconnect_user([7])
+    assert n == 2
+    assert fake_sio.disconnect.await_count == 2
+    fake_sio.manager.get_participants.assert_called_with("/", "user_room_7")

--- a/Backend_FastAPI/tests/security/test_socket_offboarding.py
+++ b/Backend_FastAPI/tests/security/test_socket_offboarding.py
@@ -1,0 +1,81 @@
+"""Integration test: server-side force-disconnect end-to-end over REAL Redis
+pub/sub with a single in-process worker.
+
+Verifies the full path: publish → subscribe → local disconnect → ACK → publisher
+returns. The multi-worker ACK aggregation / required-set logic is unit-tested in
+``test_socket_force_disconnect.py``; a true 2-OS-process fan-out run is left to
+manual/CI (pytest is single-process and the worker id is process-global).
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app import socket_manager as sm
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.security]
+
+
+async def test_force_disconnect_end_to_end_real_redis(setup_test_database):
+    # Fake the local socket layer: 2 SIDs in the target user's room.
+    fake_sio = MagicMock()
+    fake_sio.manager.get_participants.return_value = [("sidA", "e1"), ("sidB", "e2")]
+    fake_sio.disconnect = AsyncMock()
+
+    pubsub = await sm.subscribe_force_disconnect()
+    await sm.register_socket_worker()
+    task = asyncio.create_task(sm.consume_force_disconnect(pubsub))
+    await asyncio.sleep(0.15)  # let the consumer actually start listening
+    try:
+        with patch.object(sm, "sio", fake_sio):
+            cmd = await sm.force_disconnect_user_strict([4242], timeout=3.0)
+        assert cmd, "strict disconnect should be ACKed by the in-process worker"
+        # The worker disconnected both local SIDs of the user.
+        assert fake_sio.disconnect.await_count == 2
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        await sm.deregister_socket_worker()
+
+
+async def test_force_disconnect_strict_raises_without_workers(setup_test_database):
+    """With no registered worker, enforcement cannot be guaranteed → fail-closed.
+    (Clean any leftover registry entries first so the set is genuinely empty.)"""
+    from app.database import redis_client
+
+    members = await redis_client.smembers(sm._WORKERS_SET)
+    if members:
+        await redis_client.srem(sm._WORKERS_SET, *members)
+
+    with pytest.raises(RuntimeError):
+        await sm.force_disconnect_user_strict([1], timeout=0.5)
+
+
+async def test_worker_register_deregister_roundtrip(setup_test_database):
+    """Lifecycle: register adds the worker + heartbeat; deregister removes both."""
+    from app.database import redis_client
+
+    await sm.register_socket_worker()
+    wid = sm._worker_id
+    assert await redis_client.sismember(sm._WORKERS_SET, wid)
+    assert await redis_client.exists(sm._WORKER_HB_PREFIX + wid)
+
+    await sm.deregister_socket_worker()
+    assert not await redis_client.sismember(sm._WORKERS_SET, wid)
+    assert not await redis_client.exists(sm._WORKER_HB_PREFIX + wid)
+
+
+async def test_subscribe_handshake_returns_listening_pubsub(setup_test_database):
+    """Readiness handshake: subscribe_force_disconnect returns a pubsub that is
+    already subscribed to the channel BEFORE the worker is registered as live."""
+    pubsub = await sm.subscribe_force_disconnect()
+    try:
+        channels = pubsub.channels  # decode_responses → str keys
+        ch = sm.FORCE_DISCONNECT_CHANNEL
+        assert any((c == ch or c == ch.encode()) for c in channels)
+    finally:
+        await pubsub.unsubscribe(sm.FORCE_DISCONNECT_CHANNEL)
+        await pubsub.aclose()

--- a/Backend_FastAPI/tests/security/test_websocket_security.py
+++ b/Backend_FastAPI/tests/security/test_websocket_security.py
@@ -52,10 +52,13 @@ log = logging.getLogger(__name__)
 
 
 # Skip all tests if socketio client not available
-pytestmark = pytest.mark.skipif(
-    not SOCKETIO_AVAILABLE,
-    reason="python-socketio not installed. Install with: pip install python-socketio[asyncio_client]"
-)
+pytestmark = [
+    pytest.mark.security,
+    pytest.mark.skipif(
+        not SOCKETIO_AVAILABLE,
+        reason="python-socketio not installed. Install with: pip install python-socketio[asyncio_client]",
+    ),
+]
 
 
 # ============================================

--- a/Backend_FastAPI/tests/services/test_user.py
+++ b/Backend_FastAPI/tests/services/test_user.py
@@ -667,9 +667,9 @@ class TestBulkActions:
             mock_lead_repo = MockLeadRepo.return_value
             mock_lead_repo.unassign_leads_from_officers = AsyncMock(return_value=0)
             
-            msg, callback = await user_service.perform_bulk_action(
-                db, 
-                "delete", 
+            msg, callback, _disconnect_ids = await user_service.perform_bulk_action(
+                db,
+                "delete",
                 user_ids, 
                 admin_user
             )
@@ -708,7 +708,7 @@ class TestBulkActions:
         user_ids = [u.id for u in inactive_users]
         
         # Act - use change_status action with new_status parameter
-        msg, callback = await user_service.perform_bulk_action(
+        msg, callback, _disconnect_ids = await user_service.perform_bulk_action(
             db, 
             "change_status", 
             user_ids, 
@@ -749,7 +749,7 @@ class TestBulkActions:
         user_ids = [u.id for u in active_users]
         
         # Act - use change_status with banned status
-        msg, callback = await user_service.perform_bulk_action(
+        msg, callback, _disconnect_ids = await user_service.perform_bulk_action(
             db, 
             "change_status", 
             user_ids, 


### PR DESCRIPTION
## Vấn đề
"Vô hiệu hóa tài khoản" (`User.status` non-active) **KHÔNG thực sự khóa**: login/verify-mfa/refresh không gate `status`; `get_current_user` tin Redis session mà không cross-check DB; deactivate không thu hồi session/socket đang sống. Nhân viên bị set inactive vẫn login + refresh + nhận realtime (business API bị `get_current_active_user` chặn nên lỗ âm thầm).

## Thay đổi
**(A) Token-issuance gate (2 tầng)** — gate ở `/login`, `/verify-mfa`, `/refresh` + authoritative `db.refresh(..., with_for_update=True)` trong `_complete_login_flow` (bịt race deactivate↔mint); refresh thêm `except InvalidCredentials` (401, KHÔNG trip refresh-abuse counter). Generic 401 chống enumeration.

**(B) Session DB-authoritative** — `get_current_user` STEP 4 LUÔN cross-check DB (`get_by_refresh_jti_and_user`: `revoked_at IS NULL` + chưa expired); Redis chỉ là cache → đóng kịch bản stale/phantom token resurrection. Áp cả Socket.IO `_get_user_from_token` (connect) + `revalidate_auth` (exact-jti, bỏ "any active session").

**(C) Revoke + server-side force-disconnect** — admin deactivate (single/bulk) revoke toàn bộ session (strict cache cleanup, fail-closed) + ngắt Socket.IO **server-side, đa worker, có ACK** (heartbeat chạy thread độc lập event-loop + `socket_timeout=2` + `os._exit` sau 3-fail; subscribe-before-register; batch 1-command/N-user; required không prune live-heartbeat). `/check-status` trả status thật (bỏ hardcode).

## Fix kèm
- **P1 (production bug)**: `_complete_login_flow` khi `create_session` fail → **fail-closed 500** (rollback + xóa Redis `session:{jti}`), vì STEP 4 DB-authoritative — token không có DB session row sẽ 401 ngay.
- **Bug pre-existing**: bulk endpoint `_, log_callback = await log_admin_activity(...)` unpack non-tuple (`log_activity` trả single từ PR#251) → bulk endpoint 500 mọi lần; nay bỏ unpack + fail-closed try/except.

## Test
**40 test mới** (18 gate HTTP + 13 ACK unit + 5 socket-auth unit + 4 offboarding redis-E2E) + **138 regression** (auth/user/mfa): **ALL PASS**. flake8 test files = 0 (thêm `.flake8` max-line-length=88 khớp black). 2-OS-process socket fan-out defer CI/manual (pytest single-process; logic multi-worker đã unit-test).

## ⚠️ Runbook (posture change)
Backend nay **KHÔNG boot nếu Redis down** (lifespan `register_socket_worker` + `subscribe_force_disconnect` = fatal). Có chủ đích: không Redis ⇒ không enforce được offboarding. Redis vốn critical ở môi trường này.

## Liên quan
**Prerequisite** cho PR "Hạch toán lệ phí" (seed 2 technical principal `status='inactive'` — phụ thuộc gate này để non-login). Merge + deploy + verify (inactive không nhận/dùng được token) PR này **TRƯỚC**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
