### PR TITLE
fix(admissions): legacy numeric fee_payment_data.amount + enforce Casbin on record-fee-payment

### DIFF
--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -1601,7 +1601,7 @@ async def record_fee_payment(
         max_length=50,
         description="Payment method code. Application-fee collection is cash-only.",
     ),
-    current_user: models.User = Depends(deps.get_current_active_user),
+    current_user: models.User = CasbinAuth,
     profile: models.AdmissionProfile = Depends(get_admission_for_fee_collection),
     db: AsyncSession = Depends(database.get_db),
 ):

--- a/Backend_FastAPI/tests/services/test_admission_application_fee.py
+++ b/Backend_FastAPI/tests/services/test_admission_application_fee.py
@@ -763,14 +763,19 @@ class TestRecordFeePayment:
         updated_profile = await reload_profile(profile.id)
         assert updated_profile.applied_rules.get("fee_status") == "pending"
 
-    async def test_regular_user_gets_404(
+    async def test_regular_user_denied_by_casbin(
         self,
         client: AsyncClient,
         regular_user_in_db: dict,
         officer_user_in_db: dict,
         seed_admission_statuses: dict,
     ):
-        """Regular user receives fake 404, not a leaking permission response."""
+        """role:user has no Casbin allow for this route → denied 403 at the
+        route layer (CasbinAuth), BEFORE the IDOR scope dependency runs. The
+        404 no-leak applies to allowed roles with the wrong *scope* (officer
+        non-assigned / other-unit — covered by the tests above), not to a role
+        that may never collect fees at all. Mirrors every other admission write
+        endpoint, which is CasbinAuth-gated."""
         profile = await create_pending_fee_profile(
             unit_id=seed_admission_statuses["unit_id"],
             assigned_officer_id=officer_user_in_db["id"],
@@ -784,7 +789,7 @@ class TestRecordFeePayment:
             "IDORUSER1",
         )
 
-        assert response.status_code == 404, response.text
+        assert response.status_code == 403, response.text
         updated_profile = await reload_profile(profile.id)
         assert updated_profile.applied_rules.get("fee_status") == "pending"
 

--- a/frontend/src/lib/zod/admissions.test.ts
+++ b/frontend/src/lib/zod/admissions.test.ts
@@ -270,6 +270,46 @@ describe("appliedRulesSchema (top-level subject_weights)", () => {
     expect(parsed.fee_paid_at).toBeUndefined()
     expect(parsed.fee_payment_data).toBeUndefined()
   })
+
+  it("accepts a LEGACY paid snapshot with a numeric amount (pre-ledger route)", () => {
+    // Profiles paid before the ledger route stored fee_payment_data with
+    // `amount` as a JSON NUMBER (prod #25 = 70000.0). The migration does NOT
+    // rewrite that JSON, so the contract must still parse it — otherwise the
+    // paid profile fails to parse and its detail page breaks.
+    const parsed = appliedRulesSchema.parse({
+      scoring_method: "sum" as const,
+      allowed_subject_codes: ["math"],
+      subject_groups: [],
+      method_type: "subject_based" as const,
+      application_fee: 70000,
+      requires_application_fee: true,
+      fee_status: "paid",
+      fee_paid_at: "2026-06-05T12:03:35.646372",
+      fee_payment_data: {
+        amount: 70000.0,
+        paid_at: "2026-06-05T12:03:35.646372",
+        recorded_by: 15,
+        transaction_id: "CASH-HS25-20260605",
+      },
+    })
+
+    expect(parsed.fee_payment_data?.amount).toBe(70000)
+    expect(parsed.fee_payment_data?.transaction_id).toBe("CASH-HS25-20260605")
+  })
+
+  it("accepts a legacy fee_payment_data missing transaction_id", () => {
+    const parsed = appliedRulesSchema.parse({
+      scoring_method: "sum" as const,
+      allowed_subject_codes: ["math"],
+      subject_groups: [],
+      method_type: "subject_based" as const,
+      fee_status: "paid",
+      fee_payment_data: { amount: 50000 },
+    })
+
+    expect(parsed.fee_payment_data?.amount).toBe(50000)
+    expect(parsed.fee_payment_data?.transaction_id).toBeUndefined()
+  })
 })
 
 

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -759,10 +759,14 @@ export const appliedRulesSchema = z.object({
   requires_application_fee: z.boolean().nullish(),
   fee_status: z.string().nullish(),
   fee_paid_at: z.string().nullish(),
+  // Legacy paid snapshots (pre-ledger route) stored fee_payment_data directly:
+  // `amount` as a JSON number and may omit `transaction_id`. The migration does
+  // NOT rewrite that JSON, so the contract must accept both the legacy and the
+  // new (string amount) shapes — otherwise a paid profile fails to parse.
   fee_payment_data: z
     .object({
-      transaction_id: z.string(),
-      amount: z.string().optional(),
+      transaction_id: z.string().optional(),
+      amount: z.union([z.string(), z.number()]).optional(),
       payment_method_code: z.string().optional(),
       paid_at: z.string().optional(),
       recorded_by: z.number().optional(),


### PR DESCRIPTION
Fast-follow cho #387 — vá 2 regression review chỉ ra (đã audit code + DB prod thật, cả 2 VALID).

## [P2] FE zod từ chối legacy numeric amount 🔴 (user-facing)
Hồ sơ thu lệ phí **trước route ledger** lưu `fee_payment_data.amount` dạng **số** trong applied_rules; migration KHÔNG ghi đè JSON đó. FE zod mới khai `amount: z.string()` → parse FAIL → trang chi tiết vỡ.
- **Xác minh prod**: `jsonb_typeof` hồ sơ **#25** = `amount: 70000.0` (number).
- **Fix**: `amount: z.union([z.string(), z.number()]).optional()` + `transaction_id` optional (legacy tolerant). +2 zod test (numeric amount #25 shape, missing tx_id).

## [P2] BE route không enforce Casbin 🟡 (defense-in-depth)
Endpoint `record-fee-payment` dùng `get_current_active_user` → Casbin policy migration seed không được evaluate.
- **Fix**: `→ CasbinAuth` (giữ `get_admission_for_fee_collection` cho scope). Prod casbin_rule đã có `role:officer → record-fee-payment allow` → ALLOW đúng role.
- **Behavior 2-tầng (đúng, nhất quán các write-endpoint khác):** `role:user` → **403** route-deny (Casbin); role được phép nhưng sai **scope** → **404** IDOR no-leak (officer-non-assigned/other-unit vẫn 404). Cập nhật `test_regular_user_gets_404` → `test_regular_user_denied_by_casbin` (403).

## Verification
- BE one-off `test_admission_application_fee.py`: **46/46**.
- FE: type-check **clean** + zod test **37/37** (gồm 2 legacy mới).

## Deploy
**Không có migration mới** → routine deploy (Step 6 alembic no-op, đã ở `appfee_finance_20260607`). Khắc phục #25 vỡ trang chi tiết live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
