### PR TITLE
feat(finance): Finance Phase 1 — VietQR · báo cáo công nợ · refunds/overpayments (+2 vòng hardening)

### DIFF
--- a/Backend_FastAPI/alembic/versions/finance_phase1_20260608_vietqr_refund_policies.py
+++ b/Backend_FastAPI/alembic/versions/finance_phase1_20260608_vietqr_refund_policies.py
@@ -32,7 +32,6 @@ _SYSTEM_CONFIG_SQL = sa.text(
 
 _POLICIES = [
     ("role:officer", "/api/invoices/{id}/vietqr", "GET", "allow"),
-    ("role:officer", "/api/refunds", "POST", "allow"),
     ("role:accountant", "/api/finance/debt-report", "GET", "allow"),
     ("role:accountant", "/api/invoices/{id}/vietqr", "GET", "allow"),
     ("role:accountant", "/api/refunds", "GET", "allow"),

--- a/Backend_FastAPI/alembic/versions/finance_phase1_20260608_vietqr_refund_policies.py
+++ b/Backend_FastAPI/alembic/versions/finance_phase1_20260608_vietqr_refund_policies.py
@@ -1,0 +1,120 @@
+"""Finance Phase 1: VietQR config and refund/overpayment Casbin policies.
+
+Revision ID: finance_phase1_20260608
+Revises: appfee_finance_20260607
+Create Date: 2026-06-08
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "finance_phase1_20260608"
+down_revision: Union[str, None] = "appfee_finance_20260607"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_SYSTEM_CONFIG_SQL = sa.text(
+    """
+    INSERT INTO system_config (key, value, description, updated_at)
+    VALUES (
+        'bank_collection_account',
+        CAST(:value AS jsonb),
+        'Public bank collection account for offline VietQR transfers',
+        NOW()
+    )
+    ON CONFLICT (key) DO NOTHING
+    """
+)
+
+
+_POLICIES = [
+    ("role:officer", "/api/invoices/{id}/vietqr", "GET", "allow"),
+    ("role:officer", "/api/refunds", "POST", "allow"),
+    ("role:accountant", "/api/finance/debt-report", "GET", "allow"),
+    ("role:accountant", "/api/invoices/{id}/vietqr", "GET", "allow"),
+    ("role:accountant", "/api/refunds", "GET", "allow"),
+    ("role:accountant", "/api/refunds", "POST", "allow"),
+    ("role:accountant", "/api/refunds/{id}", "GET", "allow"),
+    ("role:accountant", "/api/refunds/{id}/process", "POST", "allow"),
+    ("role:accountant", "/api/overpayments", "GET", "allow"),
+    ("role:accountant", "/api/overpayments/{id}", "GET", "allow"),
+    ("role:accountant", "/api/overpayments/{id}/apply", "POST", "allow"),
+    ("role:accountant", "/api/overpayments/{id}/refund", "POST", "allow"),
+    ("role:manager", "/api/finance/debt-report", "GET", "allow"),
+    ("role:manager", "/api/refunds", "GET", "allow"),
+    ("role:manager", "/api/refunds/{id}", "GET", "allow"),
+    ("role:manager", "/api/refunds/{id}/approve", "POST", "allow"),
+    ("role:manager", "/api/refunds/{id}/reject", "POST", "allow"),
+    ("role:manager", "/api/overpayments", "GET", "allow"),
+    ("role:manager", "/api/overpayments/{id}", "GET", "allow"),
+    ("role:manager", "/api/overpayments/{id}/write-off", "POST", "allow"),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        _SYSTEM_CONFIG_SQL,
+        {
+            "value": (
+                '{"bank_bin":"","account_number":"","account_name":""}'
+            )
+        },
+    )
+
+    for v0, v1, v2, v3 in _POLICIES:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO casbin_rule
+                    (ptype, v0, v1, v2, v3, template_id, applied_at)
+                SELECT 'p',
+                       CAST(:v0 AS VARCHAR),
+                       CAST(:v1 AS VARCHAR),
+                       CAST(:v2 AS VARCHAR),
+                       CAST(:v3 AS VARCHAR),
+                       '_finance_phase1_20260608',
+                       NOW()
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM casbin_rule
+                    WHERE ptype='p'
+                      AND v0=CAST(:v0 AS VARCHAR)
+                      AND v1=CAST(:v1 AS VARCHAR)
+                      AND v2=CAST(:v2 AS VARCHAR)
+                      AND v3=CAST(:v3 AS VARCHAR)
+                )
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for v0, v1, v2, v3 in _POLICIES:
+        conn.execute(
+            sa.text(
+                """
+                DELETE FROM casbin_rule
+                WHERE ptype='p'
+                  AND v0=CAST(:v0 AS VARCHAR)
+                  AND v1=CAST(:v1 AS VARCHAR)
+                  AND v2=CAST(:v2 AS VARCHAR)
+                  AND v3=CAST(:v3 AS VARCHAR)
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM system_config
+            WHERE key = 'bank_collection_account'
+              AND value = CAST(:value AS jsonb)
+            """
+        ),
+        {"value": '{"bank_bin":"","account_number":"","account_name":""}'},
+    )

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -280,7 +280,6 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/payments/intents", "action": "POST"},  # Create payment intent (online)
         {"subject": "{role}", "object": "/api/payments/intents/{id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/payments/methods", "action": "GET"},
-        {"subject": "{role}", "object": "/api/refunds", "action": "POST"},
         # NOTE (PR #324 Commit 5) — Officer DENY for /api/leads/export,
         # /bulk-assign, /bulk-delete, /distribution-preview was DESIGNED
         # here but NOT shipped. Reason: officer sits as an inheritance

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -273,12 +273,14 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/fees/by-profile/{profile_id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/fees/summary/{profile_id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/invoices/{id}", "action": "GET"},
+        {"subject": "{role}", "object": "/api/invoices/{id}/vietqr", "action": "GET"},
         {"subject": "{role}", "object": "/api/invoices/by-fee/{fee_id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/payments/{id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/payments/by-invoice/{invoice_id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/payments/intents", "action": "POST"},  # Create payment intent (online)
         {"subject": "{role}", "object": "/api/payments/intents/{id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/payments/methods", "action": "GET"},
+        {"subject": "{role}", "object": "/api/refunds", "action": "POST"},
         # NOTE (PR #324 Commit 5) — Officer DENY for /api/leads/export,
         # /bulk-assign, /bulk-delete, /distribution-preview was DESIGNED
         # here but NOT shipped. Reason: officer sits as an inheritance
@@ -330,6 +332,7 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
 
         # DASHBOARD - Finance overview
         {"subject": "{role}", "object": "/api/finance/dashboard", "action": "GET"},
+        {"subject": "{role}", "object": "/api/finance/debt-report", "action": "GET"},
 
         # FEES - Read + Calculate + Waive + Recalculate (not Cancel - admin only)
         {"subject": "{role}", "object": "/api/fees", "action": "GET"},
@@ -343,6 +346,7 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         # INVOICES - Full CRUD (except delete)
         {"subject": "{role}", "object": "/api/invoices", "action": "GET"},
         {"subject": "{role}", "object": "/api/invoices/{id}", "action": "GET"},
+        {"subject": "{role}", "object": "/api/invoices/{id}/vietqr", "action": "GET"},
         {"subject": "{role}", "object": "/api/invoices/by-fee/{fee_id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/invoices/{id}/issue", "action": "PUT"},
         {"subject": "{role}", "object": "/api/invoices/{id}/cancel", "action": "PUT"},
@@ -365,10 +369,17 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/accounting/periods/{id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/accounting/periods/{id}/summary", "action": "GET"},
 
-        # REFUNDS — DEAD POLICY removed 2026-05-16. Refunds module deferred
-        # (no router exists; live probe /api/refunds → 404). Per memory
-        # `finance-event-decisions`, REFUND_PROCESSED tagged internal_future
-        # với 0 prod traffic. Promote back when router ships.
+        # REFUNDS - request + process, approval remains manager/admin maker-checker.
+        {"subject": "{role}", "object": "/api/refunds", "action": "GET"},
+        {"subject": "{role}", "object": "/api/refunds", "action": "POST"},
+        {"subject": "{role}", "object": "/api/refunds/{id}", "action": "GET"},
+        {"subject": "{role}", "object": "/api/refunds/{id}/process", "action": "POST"},
+
+        # OVERPAYMENTS - finance resolution except manager-only write-off.
+        {"subject": "{role}", "object": "/api/overpayments", "action": "GET"},
+        {"subject": "{role}", "object": "/api/overpayments/{id}", "action": "GET"},
+        {"subject": "{role}", "object": "/api/overpayments/{id}/apply", "action": "POST"},
+        {"subject": "{role}", "object": "/api/overpayments/{id}/refund", "action": "POST"},
 
         # Admission config (read-only lookup data)
         {"subject": "{role}", "object": "/api/admission-config/subjects", "action": "GET"},
@@ -556,12 +567,20 @@ MANAGER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/admission-config/paths/{path_id}/validate-activation", "action": "GET"},  # Validate
         # Finance Module - Manager can verify/reject payments, waive fees, apply penalties
         {"subject": "{role}", "object": "/api/finance/dashboard", "action": "GET"},  # Finance overview
+        {"subject": "{role}", "object": "/api/finance/debt-report", "action": "GET"},
         {"subject": "{role}", "object": "/api/fees/{id}/waive", "action": "POST"},  # Waive fee
         {"subject": "{role}", "object": "/api/fees/{id}/recalculate", "action": "POST"},  # Recalculate fee
         {"subject": "{role}", "object": "/api/invoices/{id}/cancel", "action": "PUT"},  # Cancel invoice
         {"subject": "{role}", "object": "/api/invoices/{id}/apply-penalty", "action": "POST"},  # Apply penalty
         {"subject": "{role}", "object": "/api/payments/{id}/verify", "action": "PUT"},  # Verify payment (maker-checker)
         {"subject": "{role}", "object": "/api/payments/{id}/reject", "action": "PUT"},  # Reject payment
+        {"subject": "{role}", "object": "/api/refunds", "action": "GET"},
+        {"subject": "{role}", "object": "/api/refunds/{id}", "action": "GET"},
+        {"subject": "{role}", "object": "/api/refunds/{id}/approve", "action": "POST"},
+        {"subject": "{role}", "object": "/api/refunds/{id}/reject", "action": "POST"},
+        {"subject": "{role}", "object": "/api/overpayments", "action": "GET"},
+        {"subject": "{role}", "object": "/api/overpayments/{id}", "action": "GET"},
+        {"subject": "{role}", "object": "/api/overpayments/{id}/write-off", "action": "POST"},
         {"subject": "{role}", "object": "/api/accounting/periods/{id}", "action": "GET"},  # View period details
         {"subject": "{role}", "object": "/api/accounting/periods/{id}/summary", "action": "GET"},  # View period summary
         # CTV Management (Phase 1: Collaborator System)

--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -554,6 +554,27 @@ async def require_finance_staff(
     return current_user
 
 
+def finance_scope_unit_id(current_user: models.User) -> Optional[int]:
+    """Resolve the unit-scope filter for finance list/detail endpoints.
+
+    Admin → ``None`` (all units). A non-admin is scoped to their own unit. A
+    non-admin WITHOUT a unit cannot be safely scoped — the repositories treat
+    ``unit_id=None`` as "no filter / all units", so returning None for such a
+    user would silently leak every unit's data (IDOR). Deny instead.
+
+    Use this everywhere finance endpoints derive their unit scope, replacing the
+    ad-hoc ``None if admin else current_user.unit_id`` idiom.
+    """
+    if current_user.role == UserRole.ADMIN:
+        return None
+    if current_user.unit_id is None:
+        raise PermissionDeniedError(
+            detail="Your account is not assigned to a unit; finance scope cannot "
+            "be determined."
+        )
+    return current_user.unit_id
+
+
 async def require_any_staff(
     current_user: models.User = Depends(get_current_active_user),
 ) -> models.User:

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -74,10 +74,12 @@ from .routers import (
     notifications,
     officer,
     organization,
+    overpayments,
     payments,  # ✅ FINANCE MODULE: Payment Processing
     pipeline,
     profile,
     public_admissions,  # ✅ Public admissions portal API
+    refunds,
     security,  # ✅ LOGIN SECURITY: Phase 5 - User response flow
     sessions,
     users,
@@ -901,6 +903,8 @@ fastapi_app.include_router(monitoring.router, prefix="/api")
 fastapi_app.include_router(fees.router, prefix="/api")
 fastapi_app.include_router(invoices.router, prefix="/api")
 fastapi_app.include_router(payments.router, prefix="/api")
+fastapi_app.include_router(refunds.router, prefix="/api")
+fastapi_app.include_router(overpayments.router, prefix="/api")
 fastapi_app.include_router(accounting.router, prefix="/api")
 fastapi_app.include_router(finance_dashboard.router, prefix="/api")
 fastapi_app.include_router(installment_plans.router, prefix="/api")

--- a/Backend_FastAPI/app/models/finance/__init__.py
+++ b/Backend_FastAPI/app/models/finance/__init__.py
@@ -27,7 +27,7 @@ from .installment_plan import InstallmentPlan
 from .payment_method import PaymentMethod
 from .accounting import AccountingPeriod
 from .fee import Fee, FeeAppliedDiscount, FeeTypeEnum, FeeStatusEnum
-from .invoice import Invoice, InvoiceStatusEnum
+from .invoice import Invoice, InvoiceStatusEnum, PAYABLE_INVOICE_STATUSES
 from .payment_intent import PaymentIntent, PaymentIntentStatusEnum, GatewayStatusEnum
 from .payment import Payment, PaymentTransaction, PaymentStatusEnum, TransactionTypeEnum
 from .refund import RefundRequest, RefundStatusEnum
@@ -39,6 +39,7 @@ __all__ = [
     "FeeStatusEnum",
     # Enums - Invoice
     "InvoiceStatusEnum",
+    "PAYABLE_INVOICE_STATUSES",
     # Enums - Payment
     "PaymentIntentStatusEnum",
     "GatewayStatusEnum",

--- a/Backend_FastAPI/app/models/finance/invoice.py
+++ b/Backend_FastAPI/app/models/finance/invoice.py
@@ -46,6 +46,16 @@ class InvoiceStatusEnum(str, enum.Enum):
     overdue = "overdue"      # Past due date, not fully paid
 
 
+# Single source of truth for "an invoice that can still receive money".
+# Used by manual payment recording, overpayment apply, VietQR generation, and
+# the debt report so the payable-status rule never diverges across the module.
+PAYABLE_INVOICE_STATUSES = (
+    InvoiceStatusEnum.issued.value,
+    InvoiceStatusEnum.partial.value,
+    InvoiceStatusEnum.overdue.value,
+)
+
+
 class Invoice(Base):
     """
     Invoice record for a fee installment.

--- a/Backend_FastAPI/app/repositories/fee_repository.py
+++ b/Backend_FastAPI/app/repositories/fee_repository.py
@@ -449,7 +449,9 @@ class InvoiceRepository(BaseRepository[Invoice]):
             .options(
                 selectinload(Invoice.payments),
                 selectinload(Invoice.payment_intents),
-                joinedload(Invoice.fee).joinedload(Fee.admission_profile),
+                joinedload(Invoice.fee)
+                .joinedload(Fee.admission_profile)
+                .joinedload(models.AdmissionProfile.lead),
             )
             .where(Invoice.id == invoice_id)
         )

--- a/Backend_FastAPI/app/repositories/payment_repository.py
+++ b/Backend_FastAPI/app/repositories/payment_repository.py
@@ -85,6 +85,34 @@ class PaymentRepository(BaseRepository[Payment]):
         result = await self.db.execute(query)
         return result.scalars().first()
 
+    async def get_for_update(
+        self,
+        payment_id: int,
+        unit_id: Optional[int] = None,
+    ) -> Optional[Payment]:
+        """Get a payment with a pessimistic row lock (SELECT FOR UPDATE).
+
+        Used by refund creation to serialize concurrent requests against the
+        same payment: the second request blocks until the first commits, then
+        re-reads the committed-refund total and cannot over-commit. No nullable
+        joinedloads (FOR UPDATE can't apply to the nullable side of an outer
+        join); only the row's own columns (amount/status) are needed.
+        """
+        query = (
+            select(Payment)
+            .join(Invoice)
+            .join(Fee)
+            .join(models.AdmissionProfile)
+            .join(models.Lead)
+            .where(Payment.id == payment_id)
+            .with_for_update(of=Payment)
+        )
+        if unit_id is not None:
+            query = query.where(models.Lead.unit_id == unit_id)
+
+        result = await self.db.execute(query)
+        return result.scalars().first()
+
     async def get_by_invoice_id(
         self,
         invoice_id: int,
@@ -620,6 +648,38 @@ class RefundRepository(BaseRepository[RefundRequest]):
         )
 
         # IDOR Filter
+        if unit_id is not None:
+            query = query.where(models.Lead.unit_id == unit_id)
+
+        result = await self.db.execute(query)
+        return result.scalars().first()
+
+    async def get_for_update(
+        self,
+        refund_id: int,
+        unit_id: Optional[int] = None,
+    ) -> Optional[RefundRequest]:
+        """Get a refund request with a pessimistic row lock (SELECT FOR UPDATE).
+
+        Used by approve/reject/process so concurrent lifecycle ops on the same
+        refund serialize: the second op blocks until the first commits, then
+        re-reads the (now-changed) status and is rejected. Locks only the
+        refund row (``of=RefundRequest``); payment→invoice are inner-joined and
+        eager-loaded so process can update balances without a lazy load.
+        """
+        query = (
+            select(RefundRequest)
+            .join(Payment)
+            .join(Invoice)
+            .join(Fee)
+            .join(models.AdmissionProfile)
+            .join(models.Lead)
+            .options(
+                joinedload(RefundRequest.payment).joinedload(Payment.invoice),
+            )
+            .where(RefundRequest.id == refund_id)
+            .with_for_update(of=RefundRequest)
+        )
         if unit_id is not None:
             query = query.where(models.Lead.unit_id == unit_id)
 

--- a/Backend_FastAPI/app/repositories/payment_repository.py
+++ b/Backend_FastAPI/app/repositories/payment_repository.py
@@ -375,22 +375,26 @@ class PaymentRepository(BaseRepository[Payment]):
         payment_id: int
     ) -> Decimal:
         """
-        Get total refunded amount for a payment.
+        Get the total committed refund amount for a payment.
 
-        Used to enforce: total_refunds <= payment.amount
+        Counts every non-rejected request (pending + approved + refunded) so
+        that open requests are *reserved* against the payment. Used to enforce
+        ``total_committed_refunds <= payment.amount`` — this prevents creating
+        a second open refund whose amount would exceed what remains once the
+        already-open requests are processed (Finance Phase 1 F2).
 
         Args:
             payment_id: Payment ID
 
         Returns:
-            Total refunded amount
+            Total committed (non-rejected) refund amount
         """
         query = (
             select(func.coalesce(func.sum(RefundRequest.amount), 0))
             .where(
                 and_(
                     RefundRequest.payment_id == payment_id,
-                    RefundRequest.status == RefundStatusEnum.refunded.value
+                    RefundRequest.status != RefundStatusEnum.rejected.value
                 )
             )
         )
@@ -822,6 +826,32 @@ class OverpaymentRepository(BaseRepository[OverpaymentRecord]):
             .where(OverpaymentRecord.id == overpayment_id)
         )
 
+        if unit_id is not None:
+            query = query.where(models.Lead.unit_id == unit_id)
+
+        result = await self.db.execute(query)
+        return result.scalars().first()
+
+    async def get_for_update(
+        self,
+        overpayment_id: int,
+        unit_id: Optional[int] = None,
+    ) -> Optional[OverpaymentRecord]:
+        """Get an overpayment with a pessimistic row lock (SELECT FOR UPDATE).
+
+        Used by every resolution path (apply/refund/write-off) so two concurrent
+        requests cannot both pass the pending check and double-resolve the same
+        liability (Finance Phase 1 F6). No nullable joinedloads here — FOR UPDATE
+        cannot be applied to the nullable side of an outer join; relations are
+        re-fetched separately by the service.
+        """
+        query = (
+            select(OverpaymentRecord)
+            .join(models.AdmissionProfile)
+            .join(models.Lead)
+            .where(OverpaymentRecord.id == overpayment_id)
+            .with_for_update(of=OverpaymentRecord)
+        )
         if unit_id is not None:
             query = query.where(models.Lead.unit_id == unit_id)
 

--- a/Backend_FastAPI/app/repositories/payment_repository.py
+++ b/Backend_FastAPI/app/repositories/payment_repository.py
@@ -732,6 +732,65 @@ class RefundRepository(BaseRepository[RefundRequest]):
         result = await self.db.execute(query)
         return list(result.scalars().all())
 
+    async def get_filtered_with_count(
+        self,
+        skip: int = 0,
+        limit: int = 50,
+        unit_id: Optional[int] = None,
+        statuses: Optional[List[str]] = None,
+        payment_id: Optional[int] = None,
+    ) -> Tuple[List[RefundRequest], int]:
+        """Get filtered refund requests with total count and IDOR scope."""
+        base_conditions = []
+
+        if unit_id is not None:
+            base_conditions.append(models.Lead.unit_id == unit_id)
+
+        if statuses:
+            base_conditions.append(RefundRequest.status.in_(statuses))
+
+        if payment_id:
+            base_conditions.append(RefundRequest.payment_id == payment_id)
+
+        count_query = (
+            select(func.count(RefundRequest.id))
+            .join(Payment)
+            .join(Invoice)
+            .join(Fee)
+            .join(models.AdmissionProfile)
+            .join(models.Lead)
+        )
+        if base_conditions:
+            count_query = count_query.where(and_(*base_conditions))
+
+        count_result = await self.db.execute(count_query)
+        total = count_result.scalar() or 0
+
+        data_query = (
+            select(RefundRequest)
+            .join(Payment)
+            .join(Invoice)
+            .join(Fee)
+            .join(models.AdmissionProfile)
+            .join(models.Lead)
+            .options(
+                joinedload(RefundRequest.payment)
+                .joinedload(Payment.invoice)
+                .joinedload(Invoice.fee),
+                joinedload(RefundRequest.requested_by),
+                joinedload(RefundRequest.approved_by),
+                joinedload(RefundRequest.rejected_by),
+            )
+            .offset(skip)
+            .limit(limit)
+            .order_by(RefundRequest.created_at.desc())
+        )
+        if base_conditions:
+            data_query = data_query.where(and_(*base_conditions))
+
+        result = await self.db.execute(data_query)
+        return list(result.scalars().all()), total
+
 
 class OverpaymentRepository(BaseRepository[OverpaymentRecord]):
     """Repository for OverpaymentRecord model operations."""
@@ -739,6 +798,35 @@ class OverpaymentRepository(BaseRepository[OverpaymentRecord]):
     def __init__(self, db: AsyncSession):
         """Initialize OverpaymentRecord repository."""
         super().__init__(db, OverpaymentRecord)
+
+    async def get_by_id_with_relations(
+        self,
+        overpayment_id: int,
+        unit_id: Optional[int] = None
+    ) -> Optional[OverpaymentRecord]:
+        """Get overpayment by ID with all related data and IDOR scope."""
+        query = (
+            select(OverpaymentRecord)
+            .join(models.AdmissionProfile)
+            .join(models.Lead)
+            .options(
+                joinedload(OverpaymentRecord.payment),
+                joinedload(OverpaymentRecord.invoice).joinedload(Invoice.fee),
+                joinedload(OverpaymentRecord.admission_profile).joinedload(
+                    models.AdmissionProfile.lead
+                ),
+                joinedload(OverpaymentRecord.resolved_by),
+                joinedload(OverpaymentRecord.applied_to_invoice),
+                joinedload(OverpaymentRecord.refund_request),
+            )
+            .where(OverpaymentRecord.id == overpayment_id)
+        )
+
+        if unit_id is not None:
+            query = query.where(models.Lead.unit_id == unit_id)
+
+        result = await self.db.execute(query)
+        return result.scalars().first()
 
     async def get_pending_for_profile(
         self,
@@ -825,6 +913,61 @@ class OverpaymentRepository(BaseRepository[OverpaymentRecord]):
 
         result = await self.db.execute(query)
         return list(result.scalars().all())
+
+    async def get_filtered_with_count(
+        self,
+        skip: int = 0,
+        limit: int = 50,
+        unit_id: Optional[int] = None,
+        statuses: Optional[List[str]] = None,
+        profile_id: Optional[int] = None,
+    ) -> Tuple[List[OverpaymentRecord], int]:
+        """Get filtered overpayments with total count and IDOR scope."""
+        base_conditions = []
+
+        if unit_id is not None:
+            base_conditions.append(models.Lead.unit_id == unit_id)
+
+        if statuses:
+            base_conditions.append(OverpaymentRecord.status.in_(statuses))
+
+        if profile_id:
+            base_conditions.append(OverpaymentRecord.admission_profile_id == profile_id)
+
+        count_query = (
+            select(func.count(OverpaymentRecord.id))
+            .join(models.AdmissionProfile)
+            .join(models.Lead)
+        )
+        if base_conditions:
+            count_query = count_query.where(and_(*base_conditions))
+
+        count_result = await self.db.execute(count_query)
+        total = count_result.scalar() or 0
+
+        data_query = (
+            select(OverpaymentRecord)
+            .join(models.AdmissionProfile)
+            .join(models.Lead)
+            .options(
+                joinedload(OverpaymentRecord.payment),
+                joinedload(OverpaymentRecord.invoice).joinedload(Invoice.fee),
+                joinedload(OverpaymentRecord.admission_profile).joinedload(
+                    models.AdmissionProfile.lead
+                ),
+                joinedload(OverpaymentRecord.resolved_by),
+                joinedload(OverpaymentRecord.applied_to_invoice),
+                joinedload(OverpaymentRecord.refund_request),
+            )
+            .offset(skip)
+            .limit(limit)
+            .order_by(OverpaymentRecord.created_at.desc())
+        )
+        if base_conditions:
+            data_query = data_query.where(and_(*base_conditions))
+
+        result = await self.db.execute(data_query)
+        return list(result.scalars().all()), total
 
 
 class PaymentTransactionRepository(BaseRepository[PaymentTransaction]):

--- a/Backend_FastAPI/app/routers/finance_dashboard.py
+++ b/Backend_FastAPI/app/routers/finance_dashboard.py
@@ -11,10 +11,10 @@ Endpoints:
 - GET /api/finance/dashboard - Get finance dashboard statistics
 """
 
-from datetime import date, datetime, timezone, timedelta
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Optional
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select, func, and_
 import structlog
@@ -24,6 +24,7 @@ from app.core.constants import UserRole
 from app.core.deps import CasbinAuth
 from app.core.rate_limits import limiter, RateLimits
 from app.schemas import finance as finance_schemas
+from app.services.finance_report_service import FinanceReportService
 from app.models.finance import (
     Fee, Invoice, Payment, RefundRequest, OverpaymentRecord,
     FeeStatusEnum, InvoiceStatusEnum, PaymentStatusEnum,
@@ -37,14 +38,56 @@ router = APIRouter(prefix="/finance", tags=["Finance - Dashboard"])
 
 @limiter.limit(RateLimits.DATA_READ)
 @router.get(
+    "/debt-report",
+    response_model=finance_schemas.DebtReportResponse,
+    summary="Get debt report grouped by admission profile",
+)
+async def get_debt_report(
+    request: Request,
+    unit_id: Optional[int] = Query(None, description="Admin-only unit filter"),
+    academic_year: Optional[int] = Query(
+        None, description="Filter by fee academic year"
+    ),
+    round_id: Optional[int] = Query(
+        None, description="Filter by applied_rules admission_round_id"
+    ),
+    fee_type: Optional[str] = Query(None, description="Filter by fee type"),
+    aging: Optional[str] = Query(None, pattern="^(0_30|31_60|over_60)$"),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    """Return debtor rows and summary totals.
+
+    Non-admin callers are always scoped to their own unit. Admin may optionally
+    pass ``unit_id`` to narrow the report.
+    """
+    scoped_unit_id = (
+        unit_id if current_user.role == UserRole.ADMIN else current_user.unit_id
+    )
+    report_service = FinanceReportService(db)
+    return await report_service.get_debt_report(
+        unit_id=scoped_unit_id,
+        academic_year=academic_year,
+        round_id=round_id,
+        fee_type=fee_type,
+        aging=aging,
+    )
+
+
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
     "/dashboard",
     response_model=finance_schemas.FinanceDashboardStats,
     summary="Get finance dashboard statistics",
 )
 async def get_dashboard_stats(
     request: Request,
-    start_date: Optional[date] = Query(None, description="Start date for period collections (YYYY-MM-DD)"),
-    end_date: Optional[date] = Query(None, description="End date for period collections (YYYY-MM-DD)"),
+    start_date: Optional[date] = Query(
+        None, description="Start date for period collections (YYYY-MM-DD)"
+    ),
+    end_date: Optional[date] = Query(
+        None, description="End date for period collections (YYYY-MM-DD)"
+    ),
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = CasbinAuth,
 ):
@@ -52,7 +95,7 @@ async def get_dashboard_stats(
     Get finance dashboard statistics.
 
     **Query Parameters:**
-    - start_date: Optional start date for period_collections calculation (default: 7 days ago)
+    - start_date: Optional start of period_collections range (default: 7 days ago)
     - end_date: Optional end date for period_collections calculation (default: today)
 
     **Returns:**
@@ -85,8 +128,16 @@ async def get_dashboard_stats(
 
     # Build base conditions for IDOR
     base_fee_query = select(Fee).join(models.AdmissionProfile).join(models.Lead)
-    base_invoice_query = select(Invoice).join(Fee).join(models.AdmissionProfile).join(models.Lead)
-    base_payment_query = select(Payment).join(Invoice).join(Fee).join(models.AdmissionProfile).join(models.Lead)
+    base_invoice_query = (
+        select(Invoice).join(Fee).join(models.AdmissionProfile).join(models.Lead)
+    )
+    base_payment_query = (
+        select(Payment)
+        .join(Invoice)
+        .join(Fee)
+        .join(models.AdmissionProfile)
+        .join(models.Lead)
+    )
 
     if unit_id is not None:
         base_fee_query = base_fee_query.where(models.Lead.unit_id == unit_id)
@@ -135,7 +186,9 @@ async def get_dashboard_stats(
         )
     )
     if unit_id is not None:
-        pending_payments_query = pending_payments_query.where(models.Lead.unit_id == unit_id)
+        pending_payments_query = pending_payments_query.where(
+            models.Lead.unit_id == unit_id
+        )
     result = await db.execute(pending_payments_query)
     pending_payments_count = result.scalar() or 0
 
@@ -143,7 +196,9 @@ async def get_dashboard_stats(
     overdue_query = (
         select(
             func.count(Invoice.id).label("count"),
-            func.coalesce(func.sum(Invoice.amount - Invoice.paid_amount), 0).label("amount")
+            func.coalesce(
+                func.sum(Invoice.amount - Invoice.paid_amount), 0
+            ).label("amount")
         )
         .join(Fee)
         .join(models.AdmissionProfile)

--- a/Backend_FastAPI/app/routers/finance_dashboard.py
+++ b/Backend_FastAPI/app/routers/finance_dashboard.py
@@ -21,7 +21,7 @@ import structlog
 
 from app import database, models
 from app.core.constants import UserRole
-from app.core.deps import CasbinAuth
+from app.core.deps import CasbinAuth, finance_scope_unit_id
 from app.core.rate_limits import limiter, RateLimits
 from app.schemas import finance as finance_schemas
 from app.services.finance_report_service import FinanceReportService
@@ -61,9 +61,12 @@ async def get_debt_report(
     Non-admin callers are always scoped to their own unit. Admin may optionally
     pass ``unit_id`` to narrow the report.
     """
-    scoped_unit_id = (
-        unit_id if current_user.role == UserRole.ADMIN else current_user.unit_id
-    )
+    # Admin may optionally narrow by unit_id; non-admins are hard-scoped to their
+    # own unit (and denied if they have none — avoids the NULL-unit IDOR leak).
+    if current_user.role == UserRole.ADMIN:
+        scoped_unit_id = unit_id
+    else:
+        scoped_unit_id = finance_scope_unit_id(current_user)
     report_service = FinanceReportService(db)
     return await report_service.get_debt_report(
         unit_id=scoped_unit_id,

--- a/Backend_FastAPI/app/routers/invoices.py
+++ b/Backend_FastAPI/app/routers/invoices.py
@@ -238,6 +238,17 @@ async def get_invoice_vietqr(
 
     try:
         invoice = await invoice_service.get_invoice(invoice_id, unit_id)
+
+        # F3: only payable invoices may produce a transfer QR. A draft/cancelled
+        # invoice can carry a positive remaining amount but cannot be paid through
+        # normal payment recording, so a QR for it would mislead the applicant.
+        # Mirror record_manual_payment's allowed statuses.
+        if invoice.status not in ("issued", "partial", "overdue"):
+            raise BadRequest(
+                f"VietQR is only available for payable invoices "
+                f"(issued/partial/overdue); current status: '{invoice.status}'"
+            )
+
         bank_account = await config_service.get_value("bank_collection_account")
         if not isinstance(bank_account, dict):
             raise ResourceNotFoundError("Bank collection account is not configured")

--- a/Backend_FastAPI/app/routers/invoices.py
+++ b/Backend_FastAPI/app/routers/invoices.py
@@ -17,25 +17,28 @@ Endpoints:
 - POST /api/invoices/{invoice_id}/apply-penalty - Apply late payment penalty
 """
 
+import base64
 from decimal import Decimal
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
-from app import database, models, schemas
-from app.core import deps
+from app import database, models
 from app.core.constants import UserRole
 from app.core.deps import CasbinAuth, RequireManager
 from app.core.rate_limits import limiter, RateLimits
 from app.schemas import finance as finance_schemas
 from app.services.invoice_service import InvoiceService
+from app.services.system_config_service import SystemConfigService
 from app.repositories.fee_repository import InvoiceRepository
+from app.utils.id_helpers import format_profile_code
+from app.utils.text_helpers import to_bank_transfer_note
+from app.utils.vietqr import build_vietqr_payload, render_qr_png
 from app.utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
     BusinessRuleViolation,
-    ConflictError,
 )
 
 log = structlog.get_logger(__name__)
@@ -62,9 +65,13 @@ async def list_invoices(
     request: Request,
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(20, ge=1, le=100, description="Items per page"),
-    status: Optional[str] = Query(None, description="Filter by status (comma-separated)"),
+    status: Optional[str] = Query(
+        None, description="Filter by status (comma-separated)"
+    ),
     fee_id: Optional[int] = Query(None, description="Filter by fee ID"),
-    overdue_only: Optional[bool] = Query(None, description="Filter only overdue invoices"),
+    overdue_only: Optional[bool] = Query(
+        None, description="Filter only overdue invoices"
+    ),
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = CasbinAuth,
 ):
@@ -205,6 +212,80 @@ async def get_invoices_by_fee(
     ]
 
 
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "/{invoice_id}/vietqr",
+    response_model=finance_schemas.VietQRResponse,
+    summary="Get VietQR transfer payload for an invoice",
+)
+async def get_invoice_vietqr(
+    request: Request,
+    invoice_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    """
+    Get a VietQR code for offline bank transfer.
+
+    **Security:**
+    - IDOR protection: Only accessible for user's unit
+    - Requires invoice read permission
+    - Bank collection config is public collection information, not a secret
+    """
+    invoice_service = InvoiceService(db)
+    config_service = SystemConfigService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+
+    try:
+        invoice = await invoice_service.get_invoice(invoice_id, unit_id)
+        bank_account = await config_service.get_value("bank_collection_account")
+        if not isinstance(bank_account, dict):
+            raise ResourceNotFoundError("Bank collection account is not configured")
+
+        bank_bin = str(bank_account.get("bank_bin") or "").strip()
+        account_number = str(bank_account.get("account_number") or "").strip()
+        account_name = str(bank_account.get("account_name") or "").strip()
+        if not bank_bin or not account_number or not account_name:
+            raise ResourceNotFoundError("Bank collection account is not configured")
+
+        fee = invoice.fee
+        profile = fee.admission_profile if fee else None
+        lead = profile.lead if profile and getattr(profile, "lead", None) else None
+        profile_code = format_profile_code(profile.id) if profile else "HS-000000"
+        raw_note = (
+            f"{lead.full_name if lead else 'Unknown'} "
+            f"{profile_code} thanh toan hoc phi"
+        )
+        content = to_bank_transfer_note(raw_note, max_len=90)
+        amount = invoice.remaining_amount
+
+        payload = build_vietqr_payload(
+            bank_bin=bank_bin,
+            account_number=account_number,
+            account_name=to_bank_transfer_note(account_name, max_len=25),
+            amount=amount,
+            add_info=content,
+        )
+        qr_png = render_qr_png(payload)
+
+        return finance_schemas.VietQRResponse(
+            qr_payload=payload,
+            qr_image_base64=base64.b64encode(qr_png).decode("ascii"),
+            bank_account=finance_schemas.VietQRBankAccount(
+                bank_bin=bank_bin,
+                account_number=account_number,
+                account_name=account_name,
+            ),
+            amount=amount,
+            content=content,
+        )
+
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except (BadRequest, ValueError) as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
 # ==============================================================================
 # INVOICE LIFECYCLE
 # ==============================================================================
@@ -270,7 +351,9 @@ async def issue_invoice(
 async def cancel_invoice(
     request: Request,
     invoice_id: int,
-    reason: str = Query(..., min_length=1, max_length=500, description="Cancellation reason"),
+    reason: str = Query(
+        ..., min_length=1, max_length=500, description="Cancellation reason"
+    ),
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = RequireManager,
 ):
@@ -324,7 +407,9 @@ async def cancel_invoice(
 async def apply_penalty(
     request: Request,
     invoice_id: int,
-    penalty_amount: Optional[Decimal] = Query(None, gt=0, description="Penalty amount (auto-calculated if not provided)"),
+    penalty_amount: Optional[Decimal] = Query(
+        None, gt=0, description="Penalty amount (auto-calculated if not provided)"
+    ),
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = RequireManager,
 ):
@@ -390,7 +475,9 @@ def _build_invoice_response(
         - can_apply_penalty: status == 'overdue' AND role in [admin, manager]
     """
     # P1: Compute permission flags based on status, amounts, AND role
-    status_value = invoice.status.value if hasattr(invoice.status, "value") else invoice.status
+    status_value = (
+        invoice.status.value if hasattr(invoice.status, "value") else invoice.status
+    )
     remaining_amount = invoice.amount - invoice.paid_amount
 
     # Role-aware permission computation
@@ -432,7 +519,9 @@ def _build_invoice_detail_response(
     invoice, current_user_role: str = None
 ) -> finance_schemas.InvoiceDetailResponse:
     """Build InvoiceDetailResponse from Invoice model with payments."""
-    base_response = _build_invoice_response(invoice, current_user_role=current_user_role)
+    base_response = _build_invoice_response(
+        invoice, current_user_role=current_user_role
+    )
 
     payment_summaries = [
         finance_schemas.PaymentSummaryResponse(

--- a/Backend_FastAPI/app/routers/invoices.py
+++ b/Backend_FastAPI/app/routers/invoices.py
@@ -26,9 +26,10 @@ import structlog
 
 from app import database, models
 from app.core.constants import UserRole
-from app.core.deps import CasbinAuth, RequireManager
+from app.core.deps import CasbinAuth, RequireManager, finance_scope_unit_id
 from app.core.rate_limits import limiter, RateLimits
 from app.schemas import finance as finance_schemas
+from app.models.finance import PAYABLE_INVOICE_STATUSES
 from app.services.invoice_service import InvoiceService
 from app.services.system_config_service import SystemConfigService
 from app.repositories.fee_repository import InvoiceRepository
@@ -234,7 +235,7 @@ async def get_invoice_vietqr(
     """
     invoice_service = InvoiceService(db)
     config_service = SystemConfigService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
 
     try:
         invoice = await invoice_service.get_invoice(invoice_id, unit_id)
@@ -243,7 +244,7 @@ async def get_invoice_vietqr(
         # invoice can carry a positive remaining amount but cannot be paid through
         # normal payment recording, so a QR for it would mislead the applicant.
         # Mirror record_manual_payment's allowed statuses.
-        if invoice.status not in ("issued", "partial", "overdue"):
+        if invoice.status not in PAYABLE_INVOICE_STATUSES:
             raise BadRequest(
                 f"VietQR is only available for payable invoices "
                 f"(issued/partial/overdue); current status: '{invoice.status}'"
@@ -268,7 +269,10 @@ async def get_invoice_vietqr(
             f"{profile_code} thanh toan hoc phi"
         )
         content = to_bank_transfer_note(raw_note, max_len=90)
-        amount = invoice.remaining_amount
+        # Quantize to whole VND (zero-decimal currency) so the QR-encoded amount
+        # and the returned/displayed amount are identical — build_vietqr_payload
+        # emits int(amount), so a fractional remaining would otherwise diverge.
+        amount = invoice.remaining_amount.quantize(Decimal("1"))
 
         payload = build_vietqr_payload(
             bank_bin=bank_bin,

--- a/Backend_FastAPI/app/routers/overpayments.py
+++ b/Backend_FastAPI/app/routers/overpayments.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database, models
 from app.core.constants import UserRole
-from app.core.deps import CasbinAuth
+from app.core.deps import CasbinAuth, finance_scope_unit_id
 from app.core.rate_limits import RateLimits, limiter
 from app.schemas import finance as finance_schemas
 from app.services.overpayment_service import OverpaymentService
@@ -37,7 +37,7 @@ async def list_overpayments(
     current_user: models.User = CasbinAuth,
 ):
     service = OverpaymentService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
     overpayments, total = await service.list_overpayments(
         skip=(page - 1) * page_size,
         limit=page_size,
@@ -69,7 +69,7 @@ async def get_overpayment(
     current_user: models.User = CasbinAuth,
 ):
     service = OverpaymentService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
     try:
         overpayment = await service.get_overpayment(overpayment_id, unit_id)
         return _build_overpayment_response(overpayment, current_user.role)
@@ -97,7 +97,7 @@ async def apply_overpayment(
         )
 
     service = OverpaymentService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
     try:
         overpayment, callback = await service.apply_to_invoice(
             overpayment_id=overpayment_id,
@@ -138,7 +138,7 @@ async def refund_overpayment(
         )
 
     service = OverpaymentService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
     try:
         overpayment, callback = await service.refund_overpayment(
             overpayment_id=overpayment_id,
@@ -177,7 +177,7 @@ async def write_off_overpayment(
         )
 
     service = OverpaymentService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
     try:
         overpayment, callback = await service.write_off(
             overpayment_id=overpayment_id,

--- a/Backend_FastAPI/app/routers/overpayments.py
+++ b/Backend_FastAPI/app/routers/overpayments.py
@@ -212,13 +212,23 @@ def _build_overpayment_response(
         else overpayment.status
     )
     is_pending = status_value == "pending"
+    # F4: an overpayment with an open (pending/approved) linked refund stays
+    # 'pending' but must not be re-resolved until that refund completes/rejects.
+    refund = getattr(overpayment, "refund_request", None)
+    refund_status = (
+        (refund.status.value if hasattr(refund.status, "value") else refund.status)
+        if refund is not None
+        else None
+    )
+    has_open_refund = refund_status in ("pending", "approved")
+    resolvable = is_pending and not has_open_refund
     # Mirror Casbin maker-checker: apply/refund are accountant finance actions,
     # write-off is a manager action; admin can do all three via wildcard.
     is_finance = current_user_role in [UserRole.ACCOUNTANT, UserRole.ADMIN]
     is_manager_admin = current_user_role in [UserRole.MANAGER, UserRole.ADMIN]
-    can_apply = is_pending and is_finance
-    can_refund = is_pending and is_finance
-    can_write_off = is_pending and is_manager_admin
+    can_apply = resolvable and is_finance
+    can_refund = resolvable and is_finance
+    can_write_off = resolvable and is_manager_admin
     can_resolve = can_apply or can_refund or can_write_off
 
     return finance_schemas.OverpaymentRecordResponse(

--- a/Backend_FastAPI/app/routers/overpayments.py
+++ b/Backend_FastAPI/app/routers/overpayments.py
@@ -1,0 +1,245 @@
+"""Overpayment resolution API."""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database, models
+from app.core.constants import UserRole
+from app.core.deps import CasbinAuth
+from app.core.rate_limits import RateLimits, limiter
+from app.schemas import finance as finance_schemas
+from app.services.overpayment_service import OverpaymentService
+from app.utils.exceptions import (
+    BadRequest,
+    BusinessRuleViolation,
+    ResourceNotFoundError,
+)
+
+
+router = APIRouter(prefix="/overpayments", tags=["Finance - Overpayments"])
+
+
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "",
+    response_model=finance_schemas.OverpaymentsPage,
+    summary="List overpayments",
+)
+async def list_overpayments(
+    request: Request,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    status_filter: Optional[str] = Query(None, alias="status"),
+    profile_id: Optional[int] = Query(None),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    service = OverpaymentService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    overpayments, total = await service.list_overpayments(
+        skip=(page - 1) * page_size,
+        limit=page_size,
+        unit_id=unit_id,
+        statuses=_parse_status_filter(status_filter),
+        profile_id=profile_id,
+    )
+    return finance_schemas.OverpaymentsPage(
+        items=[
+            _build_overpayment_response(overpayment, current_user.role)
+            for overpayment in overpayments
+        ],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "/{overpayment_id}",
+    response_model=finance_schemas.OverpaymentRecordResponse,
+    summary="Get overpayment detail",
+)
+async def get_overpayment(
+    request: Request,
+    overpayment_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    service = OverpaymentService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    try:
+        overpayment = await service.get_overpayment(overpayment_id, unit_id)
+        return _build_overpayment_response(overpayment, current_user.role)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "/{overpayment_id}/apply",
+    response_model=finance_schemas.OverpaymentRecordResponse,
+    summary="Apply overpayment to another invoice",
+)
+async def apply_overpayment(
+    request: Request,
+    overpayment_id: int,
+    data: finance_schemas.OverpaymentApplyRequest,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    if data.overpayment_id != overpayment_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="overpayment_id in body must match path",
+        )
+
+    service = OverpaymentService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    try:
+        overpayment, callback = await service.apply_to_invoice(
+            overpayment_id=overpayment_id,
+            target_invoice_id=data.target_invoice_id,
+            amount=data.amount,
+            notes=data.notes,
+            user_id=current_user.id,
+            unit_id=unit_id,
+        )
+        await db.commit()
+        if callback:
+            await callback()
+        overpayment = await service.get_overpayment(overpayment.id, unit_id)
+        return _build_overpayment_response(overpayment, current_user.role)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except (BadRequest, BusinessRuleViolation) as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "/{overpayment_id}/refund",
+    response_model=finance_schemas.OverpaymentRecordResponse,
+    summary="Create refund request for overpayment",
+)
+async def refund_overpayment(
+    request: Request,
+    overpayment_id: int,
+    data: finance_schemas.OverpaymentRefundRequest,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    if data.overpayment_id != overpayment_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="overpayment_id in body must match path",
+        )
+
+    service = OverpaymentService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    try:
+        overpayment, callback = await service.refund_overpayment(
+            overpayment_id=overpayment_id,
+            notes=data.notes,
+            user_id=current_user.id,
+            unit_id=unit_id,
+        )
+        await db.commit()
+        if callback:
+            await callback()
+        overpayment = await service.get_overpayment(overpayment.id, unit_id)
+        return _build_overpayment_response(overpayment, current_user.role)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except (BadRequest, BusinessRuleViolation) as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "/{overpayment_id}/write-off",
+    response_model=finance_schemas.OverpaymentRecordResponse,
+    summary="Write off overpayment",
+)
+async def write_off_overpayment(
+    request: Request,
+    overpayment_id: int,
+    data: finance_schemas.OverpaymentWriteOffRequest,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    if data.overpayment_id != overpayment_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="overpayment_id in body must match path",
+        )
+
+    service = OverpaymentService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    try:
+        overpayment, callback = await service.write_off(
+            overpayment_id=overpayment_id,
+            reason=data.reason,
+            user_id=current_user.id,
+            unit_id=unit_id,
+        )
+        await db.commit()
+        if callback:
+            await callback()
+        overpayment = await service.get_overpayment(overpayment.id, unit_id)
+        return _build_overpayment_response(overpayment, current_user.role)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except (BadRequest, BusinessRuleViolation) as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+def _parse_status_filter(status_filter: Optional[str]) -> Optional[List[str]]:
+    if not status_filter:
+        return None
+    return [part.strip() for part in status_filter.split(",") if part.strip()]
+
+
+def _build_overpayment_response(
+    overpayment,
+    current_user_role: str,
+) -> finance_schemas.OverpaymentRecordResponse:
+    status_value = (
+        overpayment.status.value
+        if hasattr(overpayment.status, "value")
+        else overpayment.status
+    )
+    is_pending = status_value == "pending"
+    # Mirror Casbin maker-checker: apply/refund are accountant finance actions,
+    # write-off is a manager action; admin can do all three via wildcard.
+    is_finance = current_user_role in [UserRole.ACCOUNTANT, UserRole.ADMIN]
+    is_manager_admin = current_user_role in [UserRole.MANAGER, UserRole.ADMIN]
+    can_apply = is_pending and is_finance
+    can_refund = is_pending and is_finance
+    can_write_off = is_pending and is_manager_admin
+    can_resolve = can_apply or can_refund or can_write_off
+
+    return finance_schemas.OverpaymentRecordResponse(
+        id=overpayment.id,
+        payment_id=overpayment.payment_id,
+        invoice_id=overpayment.invoice_id,
+        admission_profile_id=overpayment.admission_profile_id,
+        overpayment_amount=overpayment.overpayment_amount,
+        currency=overpayment.currency,
+        status=overpayment.status,
+        resolution_type=overpayment.resolution_type,
+        resolved_at=overpayment.resolved_at,
+        resolved_by_id=overpayment.resolved_by_id,
+        resolution_notes=overpayment.resolution_notes,
+        applied_to_invoice_id=overpayment.applied_to_invoice_id,
+        applied_amount=overpayment.applied_amount,
+        refund_request_id=overpayment.refund_request_id,
+        created_at=overpayment.created_at,
+        updated_at=overpayment.updated_at,
+        can_resolve=can_resolve,
+        can_apply=can_apply,
+        can_refund=can_refund,
+        can_write_off=can_write_off,
+    )

--- a/Backend_FastAPI/app/routers/refunds.py
+++ b/Backend_FastAPI/app/routers/refunds.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database, models
 from app.core.constants import UserRole
-from app.core.deps import CasbinAuth
+from app.core.deps import CasbinAuth, finance_scope_unit_id
 from app.core.rate_limits import RateLimits, limiter
 from app.schemas import finance as finance_schemas
 from app.services.payment_service import RefundService
@@ -37,7 +37,7 @@ async def list_refunds(
     current_user: models.User = CasbinAuth,
 ):
     refund_service = RefundService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
     statuses = _parse_status_filter(status_filter)
     refunds, total = await refund_service.list_refunds(
         skip=(page - 1) * page_size,
@@ -47,7 +47,6 @@ async def list_refunds(
         payment_id=payment_id,
     )
     can_create = current_user.role in [
-        UserRole.OFFICER,
         UserRole.ACCOUNTANT,
         UserRole.ADMIN,
     ]
@@ -76,23 +75,13 @@ async def create_refund(
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = CasbinAuth,
 ):
-    # F1: managers inherit officer in Casbin (g, role:manager, role:officer) so the
-    # officer POST grant leaks the create endpoint to managers. Managers are
-    # approver-only (maker-checker), so enforce the create capability here to match
-    # the `can_create` flag the FE reads. Casbin role inheritance cannot express
-    # "officer + accountant but not manager" because manager IS-A officer.
-    if current_user.role not in (
-        UserRole.OFFICER,
-        UserRole.ACCOUNTANT,
-        UserRole.ADMIN,
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Managers are approver-only and cannot create refund requests",
-        )
-
+    # F1/F12: create is authorized by Casbin alone — POST /api/refunds is granted
+    # only to accountant (explicit) + admin (wildcard). Officer was removed from
+    # the grant (it leaked to manager via `g, role:manager, role:officer` and had
+    # no UI), and manager/officer have no inheritance path to it. The can_create
+    # response flag mirrors this for the FE.
     refund_service = RefundService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
     try:
         refund, callback = await refund_service.request_refund(
             payment_id=data.payment_id,
@@ -125,7 +114,7 @@ async def get_refund(
     current_user: models.User = CasbinAuth,
 ):
     refund_service = RefundService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
     try:
         refund = await refund_service.get_refund(refund_id, unit_id)
         return _build_refund_response(refund, current_user.id, current_user.role)
@@ -146,7 +135,7 @@ async def approve_refund(
     current_user: models.User = CasbinAuth,
 ):
     refund_service = RefundService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
     try:
         refund, callback = await refund_service.approve_refund(
             refund_id=refund_id,
@@ -178,7 +167,7 @@ async def reject_refund(
     current_user: models.User = CasbinAuth,
 ):
     refund_service = RefundService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
     try:
         refund, callback = await refund_service.reject_refund(
             refund_id=refund_id,
@@ -217,7 +206,7 @@ async def process_refund(
         )
 
     refund_service = RefundService(db)
-    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    unit_id = finance_scope_unit_id(current_user)
     try:
         refund, callback = await refund_service.process_approved_refund(
             refund_id=refund_id,

--- a/Backend_FastAPI/app/routers/refunds.py
+++ b/Backend_FastAPI/app/routers/refunds.py
@@ -76,6 +76,21 @@ async def create_refund(
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = CasbinAuth,
 ):
+    # F1: managers inherit officer in Casbin (g, role:manager, role:officer) so the
+    # officer POST grant leaks the create endpoint to managers. Managers are
+    # approver-only (maker-checker), so enforce the create capability here to match
+    # the `can_create` flag the FE reads. Casbin role inheritance cannot express
+    # "officer + accountant but not manager" because manager IS-A officer.
+    if current_user.role not in (
+        UserRole.OFFICER,
+        UserRole.ACCOUNTANT,
+        UserRole.ADMIN,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Managers are approver-only and cannot create refund requests",
+        )
+
     refund_service = RefundService(db)
     unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
     try:

--- a/Backend_FastAPI/app/routers/refunds.py
+++ b/Backend_FastAPI/app/routers/refunds.py
@@ -1,0 +1,264 @@
+"""Refund request API."""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database, models
+from app.core.constants import UserRole
+from app.core.deps import CasbinAuth
+from app.core.rate_limits import RateLimits, limiter
+from app.schemas import finance as finance_schemas
+from app.services.payment_service import RefundService
+from app.utils.exceptions import (
+    BadRequest,
+    BusinessRuleViolation,
+    ResourceNotFoundError,
+)
+
+
+router = APIRouter(prefix="/refunds", tags=["Finance - Refunds"])
+
+
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "",
+    response_model=finance_schemas.RefundsPage,
+    summary="List refund requests",
+)
+async def list_refunds(
+    request: Request,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    status_filter: Optional[str] = Query(None, alias="status"),
+    payment_id: Optional[int] = Query(None),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    refund_service = RefundService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    statuses = _parse_status_filter(status_filter)
+    refunds, total = await refund_service.list_refunds(
+        skip=(page - 1) * page_size,
+        limit=page_size,
+        unit_id=unit_id,
+        statuses=statuses,
+        payment_id=payment_id,
+    )
+    can_create = current_user.role in [
+        UserRole.OFFICER,
+        UserRole.ACCOUNTANT,
+        UserRole.ADMIN,
+    ]
+    return finance_schemas.RefundsPage(
+        items=[
+            _build_refund_response(refund, current_user.id, current_user.role)
+            for refund in refunds
+        ],
+        total=total,
+        page=page,
+        page_size=page_size,
+        can_create=can_create,
+    )
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "",
+    response_model=finance_schemas.RefundRequestResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create refund request",
+)
+async def create_refund(
+    request: Request,
+    data: finance_schemas.RefundRequestCreate,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    refund_service = RefundService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    try:
+        refund, callback = await refund_service.request_refund(
+            payment_id=data.payment_id,
+            amount=data.amount,
+            reason=data.reason,
+            user_id=current_user.id,
+            unit_id=unit_id,
+        )
+        await db.commit()
+        if callback:
+            await callback()
+        refund = await refund_service.get_refund(refund.id, unit_id)
+        return _build_refund_response(refund, current_user.id, current_user.role)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except (BadRequest, BusinessRuleViolation) as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "/{refund_id}",
+    response_model=finance_schemas.RefundRequestResponse,
+    summary="Get refund request detail",
+)
+async def get_refund(
+    request: Request,
+    refund_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    refund_service = RefundService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    try:
+        refund = await refund_service.get_refund(refund_id, unit_id)
+        return _build_refund_response(refund, current_user.id, current_user.role)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "/{refund_id}/approve",
+    response_model=finance_schemas.RefundRequestResponse,
+    summary="Approve refund request",
+)
+async def approve_refund(
+    request: Request,
+    refund_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    refund_service = RefundService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    try:
+        refund, callback = await refund_service.approve_refund(
+            refund_id=refund_id,
+            approver_id=current_user.id,
+            unit_id=unit_id,
+        )
+        await db.commit()
+        if callback:
+            await callback()
+        refund = await refund_service.get_refund(refund.id, unit_id)
+        return _build_refund_response(refund, current_user.id, current_user.role)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except BusinessRuleViolation as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "/{refund_id}/reject",
+    response_model=finance_schemas.RefundRequestResponse,
+    summary="Reject refund request",
+)
+async def reject_refund(
+    request: Request,
+    refund_id: int,
+    data: finance_schemas.RefundRejectRequest,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    refund_service = RefundService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    try:
+        refund, callback = await refund_service.reject_refund(
+            refund_id=refund_id,
+            reason=data.rejection_reason,
+            rejector_id=current_user.id,
+            unit_id=unit_id,
+        )
+        await db.commit()
+        if callback:
+            await callback()
+        refund = await refund_service.get_refund(refund.id, unit_id)
+        return _build_refund_response(refund, current_user.id, current_user.role)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except (BadRequest, BusinessRuleViolation) as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "/{refund_id}/process",
+    response_model=finance_schemas.RefundRequestResponse,
+    summary="Process approved refund",
+)
+async def process_refund(
+    request: Request,
+    refund_id: int,
+    data: finance_schemas.RefundProcessRequest,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+):
+    if data.refund_id != refund_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="refund_id in body must match path",
+        )
+
+    refund_service = RefundService(db)
+    unit_id = None if current_user.role == UserRole.ADMIN else current_user.unit_id
+    try:
+        refund, callback = await refund_service.process_approved_refund(
+            refund_id=refund_id,
+            processor_id=current_user.id,
+            refund_reference=data.refund_reference,
+            unit_id=unit_id,
+        )
+        await db.commit()
+        if callback:
+            await callback()
+        refund = await refund_service.get_refund(refund.id, unit_id)
+        return _build_refund_response(refund, current_user.id, current_user.role)
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except BusinessRuleViolation as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+def _parse_status_filter(status_filter: Optional[str]) -> Optional[List[str]]:
+    if not status_filter:
+        return None
+    return [part.strip() for part in status_filter.split(",") if part.strip()]
+
+
+def _build_refund_response(
+    refund,
+    current_user_id: int,
+    current_user_role: str,
+) -> finance_schemas.RefundRequestResponse:
+    status_value = (
+        refund.status.value if hasattr(refund.status, "value") else refund.status
+    )
+    is_pending = status_value == "pending"
+    is_approved = status_value == "approved"
+    is_manager_or_admin = current_user_role in [UserRole.MANAGER, UserRole.ADMIN]
+    is_accountant_or_admin = current_user_role in [UserRole.ACCOUNTANT, UserRole.ADMIN]
+    is_different_user = refund.requested_by_id != current_user_id
+
+    return finance_schemas.RefundRequestResponse(
+        id=refund.id,
+        payment_id=refund.payment_id,
+        amount=refund.amount,
+        reason=refund.reason,
+        status=refund.status,
+        requested_at=refund.requested_at,
+        requested_by_id=refund.requested_by_id,
+        approved_at=refund.approved_at,
+        approved_by_id=refund.approved_by_id,
+        rejected_at=refund.rejected_at,
+        rejected_by_id=refund.rejected_by_id,
+        rejection_reason=refund.rejection_reason,
+        refunded_at=refund.refunded_at,
+        refund_reference=refund.refund_reference,
+        created_at=refund.created_at,
+        updated_at=refund.updated_at,
+        can_approve=is_pending and is_manager_or_admin and is_different_user,
+        can_reject=is_pending and is_manager_or_admin and is_different_user,
+        can_process=is_approved and is_accountant_or_admin,
+    )

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -614,6 +614,16 @@ class RefundProcessRequest(BaseModel):
     refund_reference: str = Field(..., min_length=1, max_length=100)
 
 
+class RefundRejectRequest(BaseModel):
+    """Schema for rejecting a refund request."""
+    rejection_reason: str = Field(..., min_length=1, max_length=500)
+
+    @field_validator('rejection_reason')
+    @classmethod
+    def sanitize_rejection_reason(cls, v: str) -> str:
+        return html.escape(v.strip())
+
+
 class RefundRequestResponse(BaseModel):
     """Response schema for refund request."""
     id: int
@@ -632,6 +642,9 @@ class RefundRequestResponse(BaseModel):
     refund_reference: Optional[str]
     created_at: datetime
     updated_at: datetime
+    can_approve: bool = False
+    can_reject: bool = False
+    can_process: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -697,6 +710,13 @@ class OverpaymentRecordResponse(BaseModel):
     refund_request_id: Optional[int]
     created_at: datetime
     updated_at: datetime
+    can_resolve: bool = False
+    # Granular maker-checker flags (mirror Casbin): apply/refund are accountant
+    # finance actions; write-off is a manager action. ``can_resolve`` stays as
+    # the coarse "row has any action for me" flag.
+    can_apply: bool = False
+    can_refund: bool = False
+    can_write_off: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -837,6 +857,80 @@ class PaymentsPage(BaseModel):
     page_size: int
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class RefundsPage(BaseModel):
+    """Paginated refunds response."""
+    items: List[RefundRequestResponse]
+    total: int
+    page: int
+    page_size: int
+    # Page-level capability: only officer/accountant/admin may create a refund
+    # request (mirror Casbin POST /api/refunds). Manager is approver-only.
+    can_create: bool = False
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class OverpaymentsPage(BaseModel):
+    """Paginated overpayments response."""
+    items: List[OverpaymentRecordResponse]
+    total: int
+    page: int
+    page_size: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class VietQRBankAccount(BaseModel):
+    """Public bank collection account shown beside a VietQR code."""
+    bank_bin: str
+    account_number: str
+    account_name: str
+
+
+class VietQRResponse(BaseModel):
+    """VietQR payload and rendered image for an invoice transfer."""
+    qr_payload: str
+    qr_image_base64: str
+    bank_account: VietQRBankAccount
+    amount: Decimal
+    content: str
+
+
+class DebtReportRow(BaseModel):
+    """Single debtor row aggregated by admission profile."""
+    admission_profile_id: int
+    profile_code: str
+    profile_name: str
+    unit_id: Optional[int] = None
+    unit_name: Optional[str] = None
+    academic_year: int
+    admission_round_id: Optional[int] = None
+    fee_types: List[str] = []
+    invoice_count: int
+    total_expected: Decimal
+    total_paid: Decimal
+    total_outstanding: Decimal
+    days_overdue: int
+    aging_bucket: str
+
+
+class DebtReportSummary(BaseModel):
+    """Debt report totals and bucket totals."""
+    debtor_count: int
+    total_expected: Decimal
+    total_paid: Decimal
+    total_outstanding: Decimal
+    bucket_0_30: Decimal = Decimal("0")
+    bucket_31_60: Decimal = Decimal("0")
+    bucket_over_60: Decimal = Decimal("0")
+
+
+class DebtReportResponse(BaseModel):
+    """Debt report response grouped by admission profile."""
+    items: List[DebtReportRow]
+    summary: DebtReportSummary
 
 
 # ==============================================================================

--- a/Backend_FastAPI/app/services/finance_report_service.py
+++ b/Backend_FastAPI/app/services/finance_report_service.py
@@ -61,10 +61,14 @@ class FinanceReportService:
             )
             .where(
                 and_(
-                    Invoice.status.notin_(
+                    # F7: only collectible invoices count as debt. Draft (generated
+                    # but not issued) invoices cannot accept payment, so including
+                    # them would overstate debtor balances.
+                    Invoice.status.in_(
                         [
-                            InvoiceStatusEnum.paid.value,
-                            InvoiceStatusEnum.cancelled.value,
+                            InvoiceStatusEnum.issued.value,
+                            InvoiceStatusEnum.partial.value,
+                            InvoiceStatusEnum.overdue.value,
                         ]
                     ),
                     (Invoice.amount + Invoice.penalty_amount - Invoice.paid_amount) > 0,

--- a/Backend_FastAPI/app/services/finance_report_service.py
+++ b/Backend_FastAPI/app/services/finance_report_service.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app import models
-from app.models.finance import Fee, Invoice, InvoiceStatusEnum
+from app.models.finance import Fee, Invoice, PAYABLE_INVOICE_STATUSES
 from app.schemas import finance as finance_schemas
 from app.utils.id_helpers import format_profile_code
 
@@ -64,13 +64,7 @@ class FinanceReportService:
                     # F7: only collectible invoices count as debt. Draft (generated
                     # but not issued) invoices cannot accept payment, so including
                     # them would overstate debtor balances.
-                    Invoice.status.in_(
-                        [
-                            InvoiceStatusEnum.issued.value,
-                            InvoiceStatusEnum.partial.value,
-                            InvoiceStatusEnum.overdue.value,
-                        ]
-                    ),
+                    Invoice.status.in_(PAYABLE_INVOICE_STATUSES),
                     (Invoice.amount + Invoice.penalty_amount - Invoice.paid_amount) > 0,
                 )
             )
@@ -92,7 +86,10 @@ class FinanceReportService:
         result = await self.db.execute(query)
         invoices = list(result.scalars().all())
 
-        grouped: dict[int, _DebtAccumulator] = {}
+        # Grain = (profile, academic_year). Grouping by profile alone would label a
+        # multi-year debtor with one year while summing outstanding across years,
+        # and break per-year filtering (#6).
+        grouped: dict[tuple[int, int], _DebtAccumulator] = {}
         for invoice in invoices:
             fee = invoice.fee
             if not fee or not fee.admission_profile:
@@ -110,7 +107,8 @@ class FinanceReportService:
             except (TypeError, ValueError):
                 parsed_round_id = None
 
-            accumulator = grouped.get(profile.id)
+            group_key = (profile.id, fee.academic_year)
+            accumulator = grouped.get(group_key)
             if accumulator is None:
                 accumulator = _DebtAccumulator(
                     admission_profile_id=profile.id,
@@ -120,7 +118,7 @@ class FinanceReportService:
                     academic_year=fee.academic_year,
                     admission_round_id=parsed_round_id,
                 )
-                grouped[profile.id] = accumulator
+                grouped[group_key] = accumulator
 
             outstanding = invoice.remaining_amount
             accumulator.invoice_count += 1

--- a/Backend_FastAPI/app/services/finance_report_service.py
+++ b/Backend_FastAPI/app/services/finance_report_service.py
@@ -1,0 +1,203 @@
+"""Finance reporting services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app import models
+from app.models.finance import Fee, Invoice, InvoiceStatusEnum
+from app.schemas import finance as finance_schemas
+from app.utils.id_helpers import format_profile_code
+
+
+@dataclass
+class _DebtAccumulator:
+    admission_profile_id: int
+    profile_name: str
+    unit_id: Optional[int]
+    unit_name: Optional[str]
+    academic_year: int
+    admission_round_id: Optional[int]
+    fee_types: set[str] = field(default_factory=set)
+    invoice_count: int = 0
+    total_expected: Decimal = Decimal("0")
+    total_paid: Decimal = Decimal("0")
+    total_outstanding: Decimal = Decimal("0")
+    days_overdue: int = 0
+
+
+class FinanceReportService:
+    """Read-only finance report queries."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_debt_report(
+        self,
+        unit_id: Optional[int] = None,
+        academic_year: Optional[int] = None,
+        round_id: Optional[int] = None,
+        fee_type: Optional[str] = None,
+        aging: Optional[str] = None,
+    ) -> finance_schemas.DebtReportResponse:
+        today = date.today()
+        query = (
+            select(Invoice)
+            .join(Fee)
+            .join(models.AdmissionProfile)
+            .join(models.Lead)
+            .options(
+                joinedload(Invoice.fee)
+                .joinedload(Fee.admission_profile)
+                .joinedload(models.AdmissionProfile.lead)
+                .joinedload(models.Lead.unit),
+            )
+            .where(
+                and_(
+                    Invoice.status.notin_(
+                        [
+                            InvoiceStatusEnum.paid.value,
+                            InvoiceStatusEnum.cancelled.value,
+                        ]
+                    ),
+                    (Invoice.amount + Invoice.penalty_amount - Invoice.paid_amount) > 0,
+                )
+            )
+        )
+
+        if unit_id is not None:
+            query = query.where(models.Lead.unit_id == unit_id)
+        if academic_year is not None:
+            query = query.where(Fee.academic_year == academic_year)
+        if round_id is not None:
+            query = query.where(
+                models.AdmissionProfile.applied_rules["admission_round_id"].astext
+                == str(round_id)
+            )
+        if fee_type:
+            query = query.where(Fee.fee_type == fee_type)
+
+        query = query.order_by(Invoice.due_date.asc(), Invoice.id.asc())
+        result = await self.db.execute(query)
+        invoices = list(result.scalars().all())
+
+        grouped: dict[int, _DebtAccumulator] = {}
+        for invoice in invoices:
+            fee = invoice.fee
+            if not fee or not fee.admission_profile:
+                continue
+            profile = fee.admission_profile
+            lead = profile.lead
+            if not lead:
+                continue
+
+            rules = profile.applied_rules or {}
+            round_value = rules.get("admission_round_id")
+            parsed_round_id: Optional[int]
+            try:
+                parsed_round_id = int(round_value) if round_value is not None else None
+            except (TypeError, ValueError):
+                parsed_round_id = None
+
+            accumulator = grouped.get(profile.id)
+            if accumulator is None:
+                accumulator = _DebtAccumulator(
+                    admission_profile_id=profile.id,
+                    profile_name=lead.full_name,
+                    unit_id=lead.unit_id,
+                    unit_name=lead.unit.name if getattr(lead, "unit", None) else None,
+                    academic_year=fee.academic_year,
+                    admission_round_id=parsed_round_id,
+                )
+                grouped[profile.id] = accumulator
+
+            outstanding = invoice.remaining_amount
+            accumulator.invoice_count += 1
+            accumulator.total_expected += invoice.total_due
+            accumulator.total_paid += invoice.paid_amount
+            accumulator.total_outstanding += outstanding
+            accumulator.fee_types.add(str(fee.fee_type))
+
+            if invoice.due_date and invoice.due_date < today:
+                accumulator.days_overdue = max(
+                    accumulator.days_overdue,
+                    (today - invoice.due_date).days,
+                )
+
+        rows = [
+            self._build_row(accumulator)
+            for accumulator in grouped.values()
+            if self._matches_aging(accumulator.days_overdue, aging)
+        ]
+        rows.sort(
+            key=lambda row: (
+                -row.days_overdue,
+                row.profile_name,
+                row.admission_profile_id,
+            )
+        )
+
+        summary = self._build_summary(rows)
+        return finance_schemas.DebtReportResponse(items=rows, summary=summary)
+
+    @staticmethod
+    def _build_row(accumulator: _DebtAccumulator) -> finance_schemas.DebtReportRow:
+        return finance_schemas.DebtReportRow(
+            admission_profile_id=accumulator.admission_profile_id,
+            profile_code=format_profile_code(accumulator.admission_profile_id),
+            profile_name=accumulator.profile_name,
+            unit_id=accumulator.unit_id,
+            unit_name=accumulator.unit_name,
+            academic_year=accumulator.academic_year,
+            admission_round_id=accumulator.admission_round_id,
+            fee_types=sorted(accumulator.fee_types),
+            invoice_count=accumulator.invoice_count,
+            total_expected=accumulator.total_expected,
+            total_paid=accumulator.total_paid,
+            total_outstanding=accumulator.total_outstanding,
+            days_overdue=accumulator.days_overdue,
+            aging_bucket=FinanceReportService._aging_bucket(accumulator.days_overdue),
+        )
+
+    @staticmethod
+    def _aging_bucket(days_overdue: int) -> str:
+        if days_overdue > 60:
+            return "over_60"
+        if days_overdue > 30:
+            return "31_60"
+        return "0_30"
+
+    @staticmethod
+    def _matches_aging(days_overdue: int, aging: Optional[str]) -> bool:
+        if not aging:
+            return True
+        return FinanceReportService._aging_bucket(days_overdue) == aging
+
+    @staticmethod
+    def _build_summary(
+        rows: list[finance_schemas.DebtReportRow],
+    ) -> finance_schemas.DebtReportSummary:
+        summary = finance_schemas.DebtReportSummary(
+            debtor_count=len(rows),
+            total_expected=Decimal("0"),
+            total_paid=Decimal("0"),
+            total_outstanding=Decimal("0"),
+        )
+        for row in rows:
+            summary.total_expected += row.total_expected
+            summary.total_paid += row.total_paid
+            summary.total_outstanding += row.total_outstanding
+            if row.aging_bucket == "over_60":
+                summary.bucket_over_60 += row.total_outstanding
+            elif row.aging_bucket == "31_60":
+                summary.bucket_31_60 += row.total_outstanding
+            else:
+                summary.bucket_0_30 += row.total_outstanding
+        return summary

--- a/Backend_FastAPI/app/services/overpayment_service.py
+++ b/Backend_FastAPI/app/services/overpayment_service.py
@@ -14,6 +14,8 @@ from app.models.finance import (
     OverpaymentRecord,
     OverpaymentStatusEnum,
     PaymentTransaction,
+    RefundRequest,
+    RefundStatusEnum,
     ResolutionTypeEnum,
     TransactionTypeEnum,
 )
@@ -24,6 +26,13 @@ from app.utils.exceptions import (
     BadRequest,
     BusinessRuleViolation,
     ResourceNotFoundError,
+)
+
+# Invoice statuses that can still receive money (mirror record_manual_payment).
+_PAYABLE_INVOICE_STATUSES = (
+    InvoiceStatusEnum.issued.value,
+    InvoiceStatusEnum.partial.value,
+    InvoiceStatusEnum.overdue.value,
 )
 
 
@@ -43,6 +52,20 @@ class OverpaymentService:
         unit_id: Optional[int] = None,
     ) -> OverpaymentRecord:
         overpayment = await self.overpayment_repo.get_by_id_with_relations(
+            overpayment_id,
+            unit_id,
+        )
+        if not overpayment:
+            raise ResourceNotFoundError("Overpayment not found")
+        return overpayment
+
+    async def _get_overpayment_locked(
+        self,
+        overpayment_id: int,
+        unit_id: Optional[int] = None,
+    ) -> OverpaymentRecord:
+        """Fetch an overpayment with a row lock for a resolution mutation (F6)."""
+        overpayment = await self.overpayment_repo.get_for_update(
             overpayment_id,
             unit_id,
         )
@@ -75,8 +98,8 @@ class OverpaymentService:
         notes: Optional[str] = None,
         unit_id: Optional[int] = None,
     ) -> Tuple[OverpaymentRecord, None]:
-        overpayment = await self.get_overpayment(overpayment_id, unit_id)
-        self._ensure_pending(overpayment)
+        overpayment = await self._get_overpayment_locked(overpayment_id, unit_id)
+        await self._ensure_resolvable(overpayment)
 
         target_invoice = await self.invoice_repo.get_for_update(
             target_invoice_id,
@@ -84,6 +107,13 @@ class OverpaymentService:
         )
         if not target_invoice:
             raise ResourceNotFoundError("Target invoice not found")
+
+        if target_invoice.status not in _PAYABLE_INVOICE_STATUSES:
+            raise BusinessRuleViolation(
+                f"Cannot apply overpayment to invoice with status "
+                f"'{target_invoice.status}'. Allowed: "
+                f"{list(_PAYABLE_INVOICE_STATUSES)}"
+            )
 
         target_fee = await self.fee_repo.get_for_update(target_invoice.fee_id, unit_id)
         if not target_fee:
@@ -165,8 +195,8 @@ class OverpaymentService:
         notes: Optional[str] = None,
         unit_id: Optional[int] = None,
     ) -> Tuple[OverpaymentRecord, None]:
-        overpayment = await self.get_overpayment(overpayment_id, unit_id)
-        self._ensure_pending(overpayment)
+        overpayment = await self._get_overpayment_locked(overpayment_id, unit_id)
+        await self._ensure_resolvable(overpayment)
 
         refund, _ = await self.refund_service.request_refund(
             payment_id=overpayment.payment_id,
@@ -176,11 +206,10 @@ class OverpaymentService:
             unit_id=unit_id,
         )
 
-        overpayment.status = OverpaymentStatusEnum.refunded.value
-        overpayment.resolution_type = ResolutionTypeEnum.refund.value
-        overpayment.resolved_at = datetime.now(timezone.utc)
-        overpayment.resolved_by_id = user_id
-        overpayment.resolution_notes = notes
+        # F4: the overpayment liability stays *pending* and is only linked to the
+        # refund request. It is closed to 'refunded' when that request is actually
+        # processed (RefundService.process_approved_refund). If the refund is
+        # rejected, the link clears and the overpayment remains re-resolvable.
         overpayment.refund_request_id = refund.id
 
         await self.db.flush()
@@ -193,8 +222,8 @@ class OverpaymentService:
         user_id: int,
         unit_id: Optional[int] = None,
     ) -> Tuple[OverpaymentRecord, None]:
-        overpayment = await self.get_overpayment(overpayment_id, unit_id)
-        self._ensure_pending(overpayment)
+        overpayment = await self._get_overpayment_locked(overpayment_id, unit_id)
+        await self._ensure_resolvable(overpayment)
 
         if not reason or not reason.strip():
             raise BadRequest("Write-off reason is required")
@@ -208,10 +237,25 @@ class OverpaymentService:
         await self.db.flush()
         return overpayment, None
 
-    @staticmethod
-    def _ensure_pending(overpayment: OverpaymentRecord) -> None:
+    async def _ensure_resolvable(self, overpayment: OverpaymentRecord) -> None:
+        """Guard a resolution: must be pending AND have no open linked refund.
+
+        Blocking on an open (pending/approved) linked refund prevents a second
+        resolution (apply/refund/write-off) from running while a refund created
+        via :meth:`refund_overpayment` is still in flight (F4 double-resolution).
+        """
         if overpayment.status != OverpaymentStatusEnum.pending.value:
             raise BusinessRuleViolation(
                 "Can only resolve pending overpayments. "
                 f"Current status: {overpayment.status}"
             )
+        if overpayment.refund_request_id is not None:
+            refund = await self.db.get(RefundRequest, overpayment.refund_request_id)
+            if refund and refund.status in (
+                RefundStatusEnum.pending.value,
+                RefundStatusEnum.approved.value,
+            ):
+                raise BusinessRuleViolation(
+                    f"Overpayment has an open refund request (#{refund.id}, "
+                    f"{refund.status}); resolve that refund first"
+                )

--- a/Backend_FastAPI/app/services/overpayment_service.py
+++ b/Backend_FastAPI/app/services/overpayment_service.py
@@ -13,6 +13,7 @@ from app.models.finance import (
     InvoiceStatusEnum,
     OverpaymentRecord,
     OverpaymentStatusEnum,
+    PAYABLE_INVOICE_STATUSES,
     PaymentTransaction,
     RefundRequest,
     RefundStatusEnum,
@@ -26,13 +27,6 @@ from app.utils.exceptions import (
     BadRequest,
     BusinessRuleViolation,
     ResourceNotFoundError,
-)
-
-# Invoice statuses that can still receive money (mirror record_manual_payment).
-_PAYABLE_INVOICE_STATUSES = (
-    InvoiceStatusEnum.issued.value,
-    InvoiceStatusEnum.partial.value,
-    InvoiceStatusEnum.overdue.value,
 )
 
 
@@ -108,11 +102,11 @@ class OverpaymentService:
         if not target_invoice:
             raise ResourceNotFoundError("Target invoice not found")
 
-        if target_invoice.status not in _PAYABLE_INVOICE_STATUSES:
+        if target_invoice.status not in PAYABLE_INVOICE_STATUSES:
             raise BusinessRuleViolation(
                 f"Cannot apply overpayment to invoice with status "
                 f"'{target_invoice.status}'. Allowed: "
-                f"{list(_PAYABLE_INVOICE_STATUSES)}"
+                f"{list(PAYABLE_INVOICE_STATUSES)}"
             )
 
         target_fee = await self.fee_repo.get_for_update(target_invoice.fee_id, unit_id)
@@ -124,7 +118,10 @@ class OverpaymentService:
                 "Overpayment can only be applied to an invoice on the same profile"
             )
 
-        apply_amount = amount or overpayment.overpayment_amount
+        # Use `is not None` (not `or`): Decimal('0') is falsy, so `amount or ...`
+        # would silently fall through to the full amount instead of being
+        # rejected by the `<= 0` guard below.
+        apply_amount = amount if amount is not None else overpayment.overpayment_amount
         if apply_amount <= 0:
             raise BadRequest("Applied amount must be positive")
         if apply_amount != overpayment.overpayment_amount:

--- a/Backend_FastAPI/app/services/overpayment_service.py
+++ b/Backend_FastAPI/app/services/overpayment_service.py
@@ -1,0 +1,217 @@
+"""Overpayment resolution service for finance workflows."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import List, Optional, Tuple
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.finance import (
+    FeeStatusEnum,
+    InvoiceStatusEnum,
+    OverpaymentRecord,
+    OverpaymentStatusEnum,
+    PaymentTransaction,
+    ResolutionTypeEnum,
+    TransactionTypeEnum,
+)
+from app.repositories.fee_repository import FeeRepository, InvoiceRepository
+from app.repositories.payment_repository import OverpaymentRepository
+from app.services.payment_service import RefundService
+from app.utils.exceptions import (
+    BadRequest,
+    BusinessRuleViolation,
+    ResourceNotFoundError,
+)
+
+
+class OverpaymentService:
+    """Business logic for resolving tracked overpayment liabilities."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.overpayment_repo = OverpaymentRepository(db)
+        self.invoice_repo = InvoiceRepository(db)
+        self.fee_repo = FeeRepository(db)
+        self.refund_service = RefundService(db)
+
+    async def get_overpayment(
+        self,
+        overpayment_id: int,
+        unit_id: Optional[int] = None,
+    ) -> OverpaymentRecord:
+        overpayment = await self.overpayment_repo.get_by_id_with_relations(
+            overpayment_id,
+            unit_id,
+        )
+        if not overpayment:
+            raise ResourceNotFoundError("Overpayment not found")
+        return overpayment
+
+    async def list_overpayments(
+        self,
+        skip: int = 0,
+        limit: int = 50,
+        unit_id: Optional[int] = None,
+        statuses: Optional[List[str]] = None,
+        profile_id: Optional[int] = None,
+    ) -> Tuple[List[OverpaymentRecord], int]:
+        return await self.overpayment_repo.get_filtered_with_count(
+            skip=skip,
+            limit=limit,
+            unit_id=unit_id,
+            statuses=statuses,
+            profile_id=profile_id,
+        )
+
+    async def apply_to_invoice(
+        self,
+        overpayment_id: int,
+        target_invoice_id: int,
+        user_id: int,
+        amount: Optional[Decimal] = None,
+        notes: Optional[str] = None,
+        unit_id: Optional[int] = None,
+    ) -> Tuple[OverpaymentRecord, None]:
+        overpayment = await self.get_overpayment(overpayment_id, unit_id)
+        self._ensure_pending(overpayment)
+
+        target_invoice = await self.invoice_repo.get_for_update(
+            target_invoice_id,
+            unit_id,
+        )
+        if not target_invoice:
+            raise ResourceNotFoundError("Target invoice not found")
+
+        target_fee = await self.fee_repo.get_for_update(target_invoice.fee_id, unit_id)
+        if not target_fee:
+            raise ResourceNotFoundError("Target fee not found")
+
+        if target_fee.admission_profile_id != overpayment.admission_profile_id:
+            raise BusinessRuleViolation(
+                "Overpayment can only be applied to an invoice on the same profile"
+            )
+
+        apply_amount = amount or overpayment.overpayment_amount
+        if apply_amount <= 0:
+            raise BadRequest("Applied amount must be positive")
+        if apply_amount != overpayment.overpayment_amount:
+            raise BusinessRuleViolation(
+                "Partial overpayment application is not supported; "
+                "apply the full amount"
+            )
+        if apply_amount > target_invoice.remaining_amount:
+            raise BusinessRuleViolation(
+                "Overpayment amount exceeds target invoice remaining balance"
+            )
+
+        fee_balance_before = (
+            target_fee.final_amount - target_fee.paid_amount - target_fee.waived_amount
+        )
+
+        target_invoice.paid_amount += apply_amount
+        if target_invoice.is_fully_paid:
+            target_invoice.status = InvoiceStatusEnum.paid.value
+            target_invoice.paid_at = datetime.now(timezone.utc)
+        elif target_invoice.paid_amount > 0:
+            target_invoice.status = InvoiceStatusEnum.partial.value
+
+        target_fee.paid_amount += apply_amount
+        target_fee.last_payment_at = datetime.now(timezone.utc)
+        target_fee.version += 1
+
+        fee_remaining = (
+            target_fee.final_amount - target_fee.paid_amount - target_fee.waived_amount
+        )
+        if fee_remaining <= 0:
+            target_fee.status = FeeStatusEnum.paid.value
+        elif target_fee.paid_amount > 0:
+            target_fee.status = FeeStatusEnum.partial.value
+
+        overpayment.status = OverpaymentStatusEnum.applied.value
+        overpayment.resolution_type = ResolutionTypeEnum.apply_to_next.value
+        overpayment.resolved_at = datetime.now(timezone.utc)
+        overpayment.resolved_by_id = user_id
+        overpayment.resolution_notes = notes
+        overpayment.applied_to_invoice_id = target_invoice_id
+        overpayment.applied_amount = apply_amount
+
+        default_note = (
+            f"Applied overpayment {overpayment.id} "
+            f"to invoice {target_invoice.invoice_number}"
+        )
+        transaction = PaymentTransaction(
+            payment_id=overpayment.payment_id,
+            fee_id=target_fee.id,
+            transaction_type=TransactionTypeEnum.adjustment.value,
+            amount=apply_amount,
+            balance_before=fee_balance_before,
+            balance_after=fee_remaining,
+            external_reference=f"OVERPAY-{overpayment.id}",
+            performed_by_id=user_id,
+            notes=notes or default_note,
+        )
+        self.db.add(transaction)
+
+        await self.db.flush()
+        return overpayment, None
+
+    async def refund_overpayment(
+        self,
+        overpayment_id: int,
+        user_id: int,
+        notes: Optional[str] = None,
+        unit_id: Optional[int] = None,
+    ) -> Tuple[OverpaymentRecord, None]:
+        overpayment = await self.get_overpayment(overpayment_id, unit_id)
+        self._ensure_pending(overpayment)
+
+        refund, _ = await self.refund_service.request_refund(
+            payment_id=overpayment.payment_id,
+            amount=overpayment.overpayment_amount,
+            reason=notes or f"Refund overpayment {overpayment.id}",
+            user_id=user_id,
+            unit_id=unit_id,
+        )
+
+        overpayment.status = OverpaymentStatusEnum.refunded.value
+        overpayment.resolution_type = ResolutionTypeEnum.refund.value
+        overpayment.resolved_at = datetime.now(timezone.utc)
+        overpayment.resolved_by_id = user_id
+        overpayment.resolution_notes = notes
+        overpayment.refund_request_id = refund.id
+
+        await self.db.flush()
+        return overpayment, None
+
+    async def write_off(
+        self,
+        overpayment_id: int,
+        reason: str,
+        user_id: int,
+        unit_id: Optional[int] = None,
+    ) -> Tuple[OverpaymentRecord, None]:
+        overpayment = await self.get_overpayment(overpayment_id, unit_id)
+        self._ensure_pending(overpayment)
+
+        if not reason or not reason.strip():
+            raise BadRequest("Write-off reason is required")
+
+        overpayment.status = OverpaymentStatusEnum.cancelled.value
+        overpayment.resolution_type = ResolutionTypeEnum.write_off.value
+        overpayment.resolved_at = datetime.now(timezone.utc)
+        overpayment.resolved_by_id = user_id
+        overpayment.resolution_notes = reason
+
+        await self.db.flush()
+        return overpayment, None
+
+    @staticmethod
+    def _ensure_pending(overpayment: OverpaymentRecord) -> None:
+        if overpayment.status != OverpaymentStatusEnum.pending.value:
+            raise BusinessRuleViolation(
+                "Can only resolve pending overpayments. "
+                f"Current status: {overpayment.status}"
+            )

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -34,7 +34,7 @@ from app import models
 from app.models.finance import (
     Fee, Invoice, Payment, PaymentTransaction, PaymentMethod,
     PaymentStatusEnum, InvoiceStatusEnum, FeeStatusEnum,
-    TransactionTypeEnum,
+    RefundRequest, RefundStatusEnum, TransactionTypeEnum,
 )
 from app.repositories.fee_repository import FeeRepository, InvoiceRepository
 from app.repositories.payment_repository import (
@@ -701,8 +701,6 @@ class RefundService:
             ResourceNotFoundError: If payment not found
             BusinessRuleViolation: If amount exceeds available
         """
-        from app.models.finance import RefundRequest, RefundStatusEnum
-
         payment = await self.payment_repo.get_by_id_with_relations(payment_id, unit_id)
         if not payment:
             raise ResourceNotFoundError("Payment not found")
@@ -769,8 +767,6 @@ class RefundService:
         Returns:
             Tuple of (RefundRequest, post_commit_callback)
         """
-        from app.models.finance import RefundRequest, RefundStatusEnum
-
         refund = await self.refund_repo.get_by_id_with_relations(refund_id, unit_id)
         if not refund:
             raise ResourceNotFoundError("Refund request not found")
@@ -778,6 +774,11 @@ class RefundService:
         if refund.status != RefundStatusEnum.pending.value:
             raise BusinessRuleViolation(
                 f"Can only approve pending refunds. Current status: {refund.status}"
+            )
+
+        if refund.requested_by_id == approver_id:
+            raise BusinessRuleViolation(
+                "Cannot approve your own refund request (maker-checker violation)"
             )
 
         # Update refund status
@@ -814,8 +815,6 @@ class RefundService:
         Returns:
             Tuple of (RefundRequest, post_commit_callback)
         """
-        from app.models.finance import RefundRequest, RefundStatusEnum
-
         refund = await self.refund_repo.get_by_id_with_relations(refund_id, unit_id)
         if not refund:
             raise ResourceNotFoundError("Refund request not found")
@@ -830,6 +829,8 @@ class RefundService:
 
         # Update refund status
         refund.status = RefundStatusEnum.rejected.value
+        refund.rejected_by_id = rejector_id
+        refund.rejected_at = datetime.now(timezone.utc)
         refund.rejection_reason = reason
 
         await self.db.flush()
@@ -847,6 +848,7 @@ class RefundService:
         self,
         refund_id: int,
         processor_id: int,
+        refund_reference: Optional[str] = None,
         unit_id: Optional[int] = None,
     ) -> Tuple["RefundRequest", Optional[Callable]]:
         """
@@ -857,13 +859,12 @@ class RefundService:
         Args:
             refund_id: Approved refund to process
             processor_id: User processing refund
+            refund_reference: External bank/gateway reference for the refund
             unit_id: Unit ID for IDOR protection
 
         Returns:
             Tuple of (RefundRequest, post_commit_callback)
         """
-        from app.models.finance import RefundRequest, RefundStatusEnum
-
         refund = await self.refund_repo.get_by_id_with_relations(refund_id, unit_id)
         if not refund:
             raise ResourceNotFoundError("Refund request not found")
@@ -885,6 +886,7 @@ class RefundService:
         # Update refund status
         refund.status = RefundStatusEnum.refunded.value
         refund.refunded_at = datetime.now(timezone.utc)
+        refund.refund_reference = refund_reference
 
         # Update invoice paid_amount (decrease)
         invoice.paid_amount = invoice.paid_amount - refund.amount
@@ -987,6 +989,34 @@ class RefundService:
             )
 
         return refund, post_commit
+
+    async def get_refund(
+        self,
+        refund_id: int,
+        unit_id: Optional[int] = None,
+    ) -> "RefundRequest":
+        """Get refund by ID with IDOR scope."""
+        refund = await self.refund_repo.get_by_id_with_relations(refund_id, unit_id)
+        if not refund:
+            raise ResourceNotFoundError("Refund request not found")
+        return refund
+
+    async def list_refunds(
+        self,
+        skip: int = 0,
+        limit: int = 50,
+        unit_id: Optional[int] = None,
+        statuses: Optional[List[str]] = None,
+        payment_id: Optional[int] = None,
+    ) -> Tuple[List["RefundRequest"], int]:
+        """List refund requests with total count."""
+        return await self.refund_repo.get_filtered_with_count(
+            skip=skip,
+            limit=limit,
+            unit_id=unit_id,
+            statuses=statuses,
+            payment_id=payment_id,
+        )
 
     async def _get_profile_for_fee(
         self,

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -35,6 +35,7 @@ from app.models.finance import (
     Fee, Invoice, Payment, PaymentTransaction, PaymentMethod,
     PaymentStatusEnum, InvoiceStatusEnum, FeeStatusEnum,
     RefundRequest, RefundStatusEnum, TransactionTypeEnum,
+    OverpaymentRecord, OverpaymentStatusEnum, ResolutionTypeEnum,
 )
 from app.repositories.fee_repository import FeeRepository, InvoiceRepository
 from app.repositories.payment_repository import (
@@ -713,14 +714,17 @@ class RefundService:
         if amount <= 0:
             raise BadRequest("Refund amount must be positive")
 
-        # Check total refunds don't exceed payment
-        total_refunded = await self.payment_repo.get_total_refunds_for_payment(payment_id)
-        available = payment.amount - total_refunded
+        # Reserve already-committed refunds (pending + approved + refunded) so a
+        # second open request cannot over-commit the payment (Finance Phase 1 F2).
+        total_committed = await self.payment_repo.get_total_refunds_for_payment(
+            payment_id
+        )
+        available = payment.amount - total_committed
 
         if amount > available:
             raise BusinessRuleViolation(
                 f"Refund amount ({amount}) exceeds available ({available}). "
-                f"Already refunded: {total_refunded}"
+                f"Already committed (pending/approved/refunded): {total_committed}"
             )
 
         if not reason or not reason.strip():
@@ -920,6 +924,27 @@ class RefundService:
         self.db.add(transaction)
 
         await self.db.flush()
+
+        # F4: if this refund resolves a tracked overpayment, close that liability
+        # now that the money-out is actually processed. The overpayment was kept
+        # 'pending' (linked via refund_request_id) so a rejected/abandoned refund
+        # leaves it re-resolvable; only a *processed* refund marks it 'refunded'.
+        linked_overpayment = (
+            await self.db.execute(
+                select(OverpaymentRecord)
+                .where(OverpaymentRecord.refund_request_id == refund.id)
+                .with_for_update(of=OverpaymentRecord)
+            )
+        ).scalars().first()
+        if (
+            linked_overpayment is not None
+            and linked_overpayment.status == OverpaymentStatusEnum.pending.value
+        ):
+            linked_overpayment.status = OverpaymentStatusEnum.refunded.value
+            linked_overpayment.resolution_type = ResolutionTypeEnum.refund.value
+            linked_overpayment.resolved_at = datetime.now(timezone.utc)
+            linked_overpayment.resolved_by_id = processor_id
+            await self.db.flush()
 
         # Hoist profile resolution BEFORE the tuition-only branch.
         # The notification payload below needs lead_id/admission_profile_id

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -36,6 +36,7 @@ from app.models.finance import (
     PaymentStatusEnum, InvoiceStatusEnum, FeeStatusEnum,
     RefundRequest, RefundStatusEnum, TransactionTypeEnum,
     OverpaymentRecord, OverpaymentStatusEnum, ResolutionTypeEnum,
+    PAYABLE_INVOICE_STATUSES,
 )
 from app.repositories.fee_repository import FeeRepository, InvoiceRepository
 from app.repositories.payment_repository import (
@@ -125,16 +126,11 @@ class PaymentService:
         if not invoice:
             raise ResourceNotFoundError("Invoice not found")
 
-        # Check invoice status allows payment
-        allowed_statuses = [
-            InvoiceStatusEnum.issued.value,
-            InvoiceStatusEnum.partial.value,
-            InvoiceStatusEnum.overdue.value,
-        ]
-        if invoice.status not in allowed_statuses:
+        # Check invoice status allows payment (canonical payable set)
+        if invoice.status not in PAYABLE_INVOICE_STATUSES:
             raise BusinessRuleViolation(
                 f"Cannot record payment for invoice with status '{invoice.status}'. "
-                f"Allowed: {allowed_statuses}"
+                f"Allowed: {list(PAYABLE_INVOICE_STATUSES)}"
             )
 
         # Validate amount doesn't exceed remaining
@@ -702,7 +698,10 @@ class RefundService:
             ResourceNotFoundError: If payment not found
             BusinessRuleViolation: If amount exceeds available
         """
-        payment = await self.payment_repo.get_by_id_with_relations(payment_id, unit_id)
+        # Lock the source payment row BEFORE computing committed refunds so two
+        # concurrent requests on the same payment serialize: the second blocks
+        # here until the first commits, then sees its reserved amount (race fix).
+        payment = await self.payment_repo.get_for_update(payment_id, unit_id)
         if not payment:
             raise ResourceNotFoundError("Payment not found")
 
@@ -771,7 +770,9 @@ class RefundService:
         Returns:
             Tuple of (RefundRequest, post_commit_callback)
         """
-        refund = await self.refund_repo.get_by_id_with_relations(refund_id, unit_id)
+        # Lock the refund row so concurrent lifecycle ops serialize and re-read
+        # status after acquiring the lock (race fix).
+        refund = await self.refund_repo.get_for_update(refund_id, unit_id)
         if not refund:
             raise ResourceNotFoundError("Refund request not found")
 
@@ -819,7 +820,9 @@ class RefundService:
         Returns:
             Tuple of (RefundRequest, post_commit_callback)
         """
-        refund = await self.refund_repo.get_by_id_with_relations(refund_id, unit_id)
+        # Lock the refund row so concurrent lifecycle ops serialize and re-read
+        # status after acquiring the lock (race fix).
+        refund = await self.refund_repo.get_for_update(refund_id, unit_id)
         if not refund:
             raise ResourceNotFoundError("Refund request not found")
 
@@ -869,7 +872,10 @@ class RefundService:
         Returns:
             Tuple of (RefundRequest, post_commit_callback)
         """
-        refund = await self.refund_repo.get_by_id_with_relations(refund_id, unit_id)
+        # Lock the refund row FIRST so a second concurrent process blocks here,
+        # then re-reads status after the first commits and sees 'refunded' →
+        # raises below instead of double-processing (race fix).
+        refund = await self.refund_repo.get_for_update(refund_id, unit_id)
         if not refund:
             raise ResourceNotFoundError("Refund request not found")
 
@@ -892,9 +898,15 @@ class RefundService:
         refund.refunded_at = datetime.now(timezone.utc)
         refund.refund_reference = refund_reference
 
-        # Update invoice paid_amount (decrease)
+        # Update invoice paid_amount (decrease). A full refund (paid back to 0)
+        # must return the invoice to 'issued', not leave it 'partial' with 0 paid
+        # (which would block re-collection — can_record_payment keys on 'issued').
         invoice.paid_amount = invoice.paid_amount - refund.amount
-        if invoice.paid_amount < invoice.amount:
+        if invoice.paid_amount <= 0:
+            invoice.paid_amount = Decimal("0")
+            invoice.status = InvoiceStatusEnum.issued.value
+            invoice.paid_at = None
+        elif invoice.paid_amount < invoice.amount:
             invoice.status = InvoiceStatusEnum.partial.value
             invoice.paid_at = None
 

--- a/Backend_FastAPI/app/utils/vietqr.py
+++ b/Backend_FastAPI/app/utils/vietqr.py
@@ -1,0 +1,99 @@
+"""VietQR EMVCo payload and PNG rendering helpers."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from io import BytesIO
+
+import qrcode
+
+
+VIETQR_GUID = "A000000727"
+VIETQR_SERVICE_CODE = "QRIBFTTA"
+CRC_POLY = 0x1021
+CRC_INIT = 0xFFFF
+
+
+def _tlv(tag: str, value: str) -> str:
+    if not isinstance(value, str):
+        value = str(value)
+    encoded = value.strip()
+    if len(encoded) > 99:
+        raise ValueError(f"EMVCo TLV value for tag {tag} exceeds 99 characters")
+    return f"{tag}{len(encoded):02d}{encoded}"
+
+
+def _crc16_ccitt(data: str) -> str:
+    crc = CRC_INIT
+    for byte in data.encode("ascii"):
+        crc ^= byte << 8
+        for _ in range(8):
+            if crc & 0x8000:
+                crc = ((crc << 1) ^ CRC_POLY) & 0xFFFF
+            else:
+                crc = (crc << 1) & 0xFFFF
+    return f"{crc:04X}"
+
+
+def build_vietqr_payload(
+    bank_bin: str,
+    account_number: str,
+    amount: Decimal,
+    add_info: str,
+    account_name: str | None = None,
+) -> str:
+    """Build a static merchant VietQR transfer payload.
+
+    The caller owns content normalization for ``add_info``. This helper only
+    emits EMVCo TLV and the final CRC field.
+    """
+    if amount <= 0:
+        raise ValueError("VietQR amount must be positive")
+
+    merchant_account = _tlv(
+        "00",
+        VIETQR_GUID,
+    ) + _tlv(
+        "01",
+        _tlv("00", bank_bin) + _tlv("01", account_number),
+    ) + _tlv(
+        "02",
+        VIETQR_SERVICE_CODE,
+    )
+
+    amount_text = str(int(amount))
+    payload_without_crc = (
+        _tlv("00", "01")
+        # Point of Initiation "12" = dynamic (one-time, amount locked). The
+        # invoice amount is fixed per-transfer, so "11" (static, payer-editable
+        # amount) would let the payer change the amount and break reconciliation.
+        + _tlv("01", "12")
+        + _tlv("38", merchant_account)
+        + _tlv("53", "704")
+        + _tlv("54", amount_text)
+        + _tlv("58", "VN")
+    )
+
+    if account_name:
+        payload_without_crc += _tlv("59", account_name[:25])
+
+    payload_without_crc += _tlv("62", _tlv("08", add_info))
+
+    crc_input = payload_without_crc + "6304"
+    return crc_input + _crc16_ccitt(crc_input)
+
+
+def render_qr_png(payload: str) -> bytes:
+    """Render a QR code PNG for the provided payload."""
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=8,
+        border=2,
+    )
+    qr.add_data(payload)
+    qr.make(fit=True)
+    image = qr.make_image(fill_color="black", back_color="white")
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()

--- a/Backend_FastAPI/tests/integration/test_qa_e2e_casbin_path_alignment.py
+++ b/Backend_FastAPI/tests/integration/test_qa_e2e_casbin_path_alignment.py
@@ -52,20 +52,13 @@ def _manager_export_entries() -> set[tuple[str, str]]:
     }
 
 
-def test_no_refunds_policy_entries_in_accountant_template():
-    """W2-2 anchor: /api/refunds/* entries không tồn tại trong
-    ACCOUNTANT_TEMPLATE seed list.
-
-    Refunds module deferred (no router). Re-introducing entry → ghost
-    permission grant cho action không thể thực hiện → confusion + audit
-    trail noise. Promote khi router ships per memory `finance-event-
-    decisions`.
-    """
+def test_refunds_policy_entries_present_in_accountant_template():
+    """Finance Phase 1 anchor: refund router shipped, so policy must exist."""
     objects = _accountant_objects()
-    refunds_dead = {o for o in objects if o.startswith("/api/refunds")}
-    assert not refunds_dead, (
-        f"ACCOUNTANT_TEMPLATE has /api/refunds/* dead policies — refunds "
-        f"module deferred (no router). Drop entries: {sorted(refunds_dead)}"
+    expected = {"/api/refunds", "/api/refunds/{id}", "/api/refunds/{id}/process"}
+    missing = expected - objects
+    assert not missing, (
+        f"ACCOUNTANT_TEMPLATE missing refund policies: {sorted(missing)}"
     )
 
 

--- a/Backend_FastAPI/tests/integration/test_qa_e2e_casbin_path_alignment.py
+++ b/Backend_FastAPI/tests/integration/test_qa_e2e_casbin_path_alignment.py
@@ -19,15 +19,25 @@ test fail loudly.
 """
 from __future__ import annotations
 
+import re
+
 import pytest
 from sqlalchemy import text
 
 from app.casbin_config.policy_templates import (
     ACCOUNTANT_TEMPLATE,
     MANAGER_TEMPLATE,
+    OFFICER_TEMPLATE,
 )
 from app.database import AsyncSessionLocal
 from app.main import fastapi_app
+
+
+def _normalize_path(path: str) -> str:
+    """Collapse ``{anything}`` path params to ``{}`` so policy placeholder names
+    (``{id}``) compare equal to route names (``{refund_id}``) — keyMatch4 treats
+    ``{...}`` as a single-segment wildcard regardless of the name."""
+    return re.sub(r"\{[^}]+\}", "{}", path)
 
 
 def _collect_route_paths() -> set[str]:
@@ -59,6 +69,39 @@ def test_refunds_policy_entries_present_in_accountant_template():
     missing = expected - objects
     assert not missing, (
         f"ACCOUNTANT_TEMPLATE missing refund policies: {sorted(missing)}"
+    )
+
+
+def test_finance_phase1_policies_map_to_real_routes():
+    """Anchor: every Finance Phase 1 policy object (refund/overpayment/debt-report
+    /vietqr) maps to an actually-mounted FastAPI route.
+
+    The earlier rewrite only checked template-vs-template; this restores the
+    route-table cross-check so a typo'd/non-existent finance policy path (which
+    keyMatch4 would silently deny → 404) fails loudly.
+    """
+    route_paths = {_normalize_path(p) for p in _collect_route_paths()}
+    prefixes = (
+        "/api/refunds",
+        "/api/overpayments",
+        "/api/finance/debt-report",
+        "/api/invoices/{id}/vietqr",
+    )
+    finance_objs = {
+        p["object"]
+        for tmpl in (ACCOUNTANT_TEMPLATE, MANAGER_TEMPLATE, OFFICER_TEMPLATE)
+        for p in tmpl["policies"]
+        if any(p["object"].startswith(pre) for pre in prefixes)
+    }
+    missing = {o for o in finance_objs if _normalize_path(o) not in route_paths}
+    mounted = sorted(
+        p
+        for p in route_paths
+        if any(k in p for k in ("refund", "overpay", "debt", "vietqr"))
+    )
+    assert not missing, (
+        f"Casbin finance policies point at non-existent routes: {sorted(missing)}. "
+        f"Mounted finance routes: {mounted}"
     )
 
 

--- a/Backend_FastAPI/tests/services/test_payment_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_service.py
@@ -837,6 +837,62 @@ class TestRefundService:
         await db.commit()
         assert ok.status == "pending"
 
+    async def test_double_process_same_refund_rejected_balance_unchanged(
+        self, db, payment_fixtures
+    ):
+        """Race regression (sequential proxy): processing an already-processed
+        refund a second time must be rejected (status re-checked under the row
+        lock) and must NOT change balances again. Also covers full-refund →
+        invoice 'issued' (#7)."""
+        pf = payment_fixtures
+        payment = await self._create_verified_payment(db, pf)  # 1,000,000
+        refund_service = RefundService(db)
+
+        refund, _ = await refund_service.request_refund(
+            payment_id=payment.id,
+            amount=Decimal("1000000"),
+            reason="Full refund",
+            user_id=pf["maker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+        await refund_service.approve_refund(
+            refund_id=refund.id,
+            approver_id=pf["checker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        await refund_service.process_approved_refund(
+            refund_id=refund.id,
+            processor_id=pf["checker"].id,
+            refund_reference="REF-1",
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        await db.refresh(pf["invoice"])
+        await db.refresh(pf["fee"])
+        assert pf["invoice"].paid_amount == Decimal("0")
+        # #7: a full refund returns the invoice to 'issued', not 'partial'.
+        assert pf["invoice"].status == InvoiceStatusEnum.issued.value
+        fee_paid_after_first = pf["fee"].paid_amount
+
+        # Second process of the SAME refund → rejected (status now 'refunded').
+        with pytest.raises(BusinessRuleViolation):
+            await refund_service.process_approved_refund(
+                refund_id=refund.id,
+                processor_id=pf["checker"].id,
+                refund_reference="REF-2",
+                unit_id=pf["unit_id"],
+            )
+        await db.rollback()
+
+        await db.refresh(pf["invoice"])
+        await db.refresh(pf["fee"])
+        assert pf["invoice"].paid_amount == Decimal("0")
+        assert pf["fee"].paid_amount == fee_paid_after_first
+
     async def test_list_refunds_filters_by_payment_and_status(
         self, db, payment_fixtures
     ):

--- a/Backend_FastAPI/tests/services/test_payment_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_service.py
@@ -22,9 +22,12 @@ from app import models
 from app.models.finance import (
     Fee, Invoice, Payment, PaymentMethod, InstallmentPlan,
     FeeTypeEnum, FeeStatusEnum, InvoiceStatusEnum, PaymentStatusEnum,
+    OverpaymentRecord, OverpaymentStatusEnum, ResolutionTypeEnum,
+    RefundRequest, RefundStatusEnum,
 )
 from app.services.fee_calculation_service import FeeCalculationService
 from app.services.invoice_service import InvoiceService
+from app.services.overpayment_service import OverpaymentService
 from app.services.payment_service import PaymentService, RefundService
 from app.security import get_password_hash
 from app.utils.exceptions import (
@@ -467,6 +470,196 @@ class TestOverpaymentCheck:
         assert excess == Decimal("500000")
 
 
+class TestOverpaymentService:
+    """Tests for overpayment list and resolution workflows."""
+
+    async def _create_pending_overpayment(self, db, pf):
+        """Helper: create a pending overpayment record with valid relations."""
+        payment_service = PaymentService(db)
+        payment, _ = await payment_service.record_manual_payment(
+            invoice_id=pf["invoice"].id,
+            method_id=pf["cash_method"].id,
+            amount=Decimal("100000"),
+            user_id=pf["maker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        payment, _ = await payment_service.verify_payment(
+            payment_id=payment.id,
+            verifier_id=pf["checker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        overpayment = OverpaymentRecord(
+            payment_id=payment.id,
+            invoice_id=pf["invoice"].id,
+            admission_profile_id=pf["profile"].id,
+            overpayment_amount=Decimal("50000"),
+            status=OverpaymentStatusEnum.pending.value,
+        )
+        db.add(overpayment)
+        await db.commit()
+        await db.refresh(overpayment)
+        return overpayment
+
+    async def test_list_overpayments_filters_and_write_off(
+        self, db, payment_fixtures
+    ):
+        """List/count overpayments and write-off pending liability."""
+        pf = payment_fixtures
+        overpayment = await self._create_pending_overpayment(db, pf)
+        service = OverpaymentService(db)
+
+        items, total = await service.list_overpayments(
+            unit_id=pf["unit_id"],
+            statuses=["pending"],
+            profile_id=pf["profile"].id,
+        )
+        assert total == 1
+        assert [item.id for item in items] == [overpayment.id]
+
+        resolved, _ = await service.write_off(
+            overpayment_id=overpayment.id,
+            reason="Small balance write-off",
+            user_id=pf["checker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        assert resolved.status == OverpaymentStatusEnum.cancelled.value
+        assert resolved.resolution_type == ResolutionTypeEnum.write_off.value
+        assert resolved.resolved_by_id == pf["checker"].id
+        assert resolved.resolved_at is not None
+
+    async def test_apply_overpayment_to_target_invoice(self, db, payment_fixtures):
+        """Apply moves the full overpayment onto another invoice of the same profile."""
+        pf = payment_fixtures
+        overpayment = await self._create_pending_overpayment(db, pf)
+
+        # Target invoice on the SAME fee/profile, with enough remaining balance.
+        target_invoice = Invoice(
+            fee_id=pf["fee"].id,
+            invoice_number="INV-TEST-APPLY-0001",
+            installment_no=2,
+            amount=Decimal("500000"),
+            paid_amount=Decimal("0"),
+            penalty_amount=Decimal("0"),
+            status=InvoiceStatusEnum.issued.value,
+            due_date=date.today() + timedelta(days=30),
+        )
+        db.add(target_invoice)
+        await db.flush()
+        await db.refresh(target_invoice)
+
+        await db.refresh(pf["fee"])
+        fee_paid_before = pf["fee"].paid_amount
+
+        service = OverpaymentService(db)
+        resolved, callback = await service.apply_to_invoice(
+            overpayment_id=overpayment.id,
+            target_invoice_id=target_invoice.id,
+            user_id=pf["checker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+        assert callback is None
+
+        assert resolved.status == OverpaymentStatusEnum.applied.value
+        assert resolved.resolution_type == ResolutionTypeEnum.apply_to_next.value
+        assert resolved.applied_to_invoice_id == target_invoice.id
+        assert resolved.applied_amount == Decimal("50000")
+        assert resolved.resolved_by_id == pf["checker"].id
+
+        await db.refresh(target_invoice)
+        await db.refresh(pf["fee"])
+        assert target_invoice.paid_amount == Decimal("50000")
+        assert pf["fee"].paid_amount == fee_paid_before + Decimal("50000")
+
+    async def test_apply_overpayment_rejects_other_profile_invoice(
+        self, db, payment_fixtures
+    ):
+        """Overpayment cannot be applied to an invoice on a different profile."""
+        pf = payment_fixtures
+        overpayment = await self._create_pending_overpayment(db, pf)
+
+        other_lead = models.Lead(
+            full_name="Other Student",
+            phone="0901330099",
+            source="test",
+            unit_id=pf["unit_id"],
+        )
+        db.add(other_lead)
+        await db.flush()
+        other_profile = models.AdmissionProfile(
+            lead_id=other_lead.id,
+            status="submitted",
+            academic_year=2025,
+            applied_rules={},
+        )
+        db.add(other_profile)
+        await db.flush()
+
+        fee_service = FeeCalculationService(db)
+        other_fee, _ = await fee_service.calculate_fee(
+            admission_profile_id=other_profile.id,
+            fee_type=FeeTypeEnum.application,
+            base_amount=Decimal("1000000"),
+            academic_year=2025,
+            user_id=pf["checker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.flush()
+        other_invoice = Invoice(
+            fee_id=other_fee.id,
+            invoice_number="INV-TEST-OTHER-0001",
+            installment_no=1,
+            amount=Decimal("500000"),
+            status=InvoiceStatusEnum.issued.value,
+            due_date=date.today() + timedelta(days=30),
+        )
+        db.add(other_invoice)
+        await db.flush()
+
+        service = OverpaymentService(db)
+        with pytest.raises(BusinessRuleViolation):
+            await service.apply_to_invoice(
+                overpayment_id=overpayment.id,
+                target_invoice_id=other_invoice.id,
+                user_id=pf["checker"].id,
+                unit_id=pf["unit_id"],
+            )
+
+    async def test_refund_overpayment_creates_refund_request(
+        self, db, payment_fixtures
+    ):
+        """Refund resolution spawns a pending RefundRequest linked to the record."""
+        pf = payment_fixtures
+        overpayment = await self._create_pending_overpayment(db, pf)
+
+        service = OverpaymentService(db)
+        resolved, callback = await service.refund_overpayment(
+            overpayment_id=overpayment.id,
+            notes="Student requested refund",
+            user_id=pf["checker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+        assert callback is None
+
+        assert resolved.status == OverpaymentStatusEnum.refunded.value
+        assert resolved.resolution_type == ResolutionTypeEnum.refund.value
+        assert resolved.refund_request_id is not None
+        assert resolved.resolved_by_id == pf["checker"].id
+
+        refund = await db.get(RefundRequest, resolved.refund_request_id)
+        assert refund is not None
+        assert refund.payment_id == overpayment.payment_id
+        assert refund.amount == Decimal("50000")
+        assert refund.status == RefundStatusEnum.pending.value
+
+
 # =============================================================================
 # REFUND SERVICE TESTS
 # =============================================================================
@@ -515,6 +708,39 @@ class TestRefundService:
         assert refund.status == "pending"
         assert refund.amount == Decimal("500000")
         assert refund.reason == "Student withdrawal"
+
+    async def test_list_refunds_filters_by_payment_and_status(
+        self, db, payment_fixtures
+    ):
+        """List refunds returns refund rows, not payment rows."""
+        pf = payment_fixtures
+        payment = await self._create_verified_payment(db, pf)
+
+        refund_service = RefundService(db)
+        refund, _ = await refund_service.request_refund(
+            payment_id=payment.id,
+            amount=Decimal("100000"),
+            reason="Need refund",
+            user_id=pf["maker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        items, total = await refund_service.list_refunds(
+            unit_id=pf["unit_id"],
+            statuses=["pending"],
+            payment_id=payment.id,
+        )
+        assert total == 1
+        assert [item.id for item in items] == [refund.id]
+
+        items, total = await refund_service.list_refunds(
+            unit_id=pf["unit_id"],
+            statuses=["approved"],
+            payment_id=payment.id,
+        )
+        assert total == 0
+        assert items == []
 
     async def test_request_refund_non_verified_payment(self, db, payment_fixtures):
         """Cannot refund non-verified payment."""
@@ -591,11 +817,13 @@ class TestRefundService:
         refund, _ = await refund_service.process_approved_refund(
             refund_id=refund.id,
             processor_id=pf["checker"].id,
+            refund_reference="BANK-REF-001",
             unit_id=pf["unit_id"],
         )
         await db.commit()
         assert refund.status == "refunded"
         assert refund.refunded_at is not None
+        assert refund.refund_reference == "BANK-REF-001"
 
         # Verify balances decreased
         await db.refresh(pf["fee"])
@@ -626,6 +854,32 @@ class TestRefundService:
 
         assert rejected.status == "rejected"
         assert rejected.rejection_reason == "Policy does not allow"
+        assert rejected.rejected_by_id == pf["checker"].id
+        assert rejected.rejected_at is not None
+
+    async def test_approve_refund_blocks_self_approval(self, db, payment_fixtures):
+        """Refund approval enforces maker-checker."""
+        pf = payment_fixtures
+        payment = await self._create_verified_payment(db, pf)
+
+        refund_service = RefundService(db)
+        refund, _ = await refund_service.request_refund(
+            payment_id=payment.id,
+            amount=Decimal("100000"),
+            reason="Need refund",
+            user_id=pf["maker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        with pytest.raises(BusinessRuleViolation) as exc_info:
+            await refund_service.approve_refund(
+                refund_id=refund.id,
+                approver_id=pf["maker"].id,
+                unit_id=pf["unit_id"],
+            )
+
+        assert "maker-checker" in str(exc_info.value).lower()
 
 
 # =============================================================================

--- a/Backend_FastAPI/tests/services/test_payment_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_service.py
@@ -631,10 +631,10 @@ class TestOverpaymentService:
                 unit_id=pf["unit_id"],
             )
 
-    async def test_refund_overpayment_creates_refund_request(
+    async def test_refund_overpayment_keeps_pending_until_processed(
         self, db, payment_fixtures
     ):
-        """Refund resolution spawns a pending RefundRequest linked to the record."""
+        """F4: refund resolution links a RefundRequest but keeps overpayment pending."""
         pf = payment_fixtures
         overpayment = await self._create_pending_overpayment(db, pf)
 
@@ -642,22 +642,112 @@ class TestOverpaymentService:
         resolved, callback = await service.refund_overpayment(
             overpayment_id=overpayment.id,
             notes="Student requested refund",
-            user_id=pf["checker"].id,
+            user_id=pf["maker"].id,
             unit_id=pf["unit_id"],
         )
         await db.commit()
         assert callback is None
 
-        assert resolved.status == OverpaymentStatusEnum.refunded.value
-        assert resolved.resolution_type == ResolutionTypeEnum.refund.value
+        # Liability stays pending; only linked to the (still-open) refund request.
+        assert resolved.status == OverpaymentStatusEnum.pending.value
         assert resolved.refund_request_id is not None
-        assert resolved.resolved_by_id == pf["checker"].id
 
         refund = await db.get(RefundRequest, resolved.refund_request_id)
         assert refund is not None
         assert refund.payment_id == overpayment.payment_id
         assert refund.amount == Decimal("50000")
         assert refund.status == RefundStatusEnum.pending.value
+
+    async def test_refund_overpayment_blocks_second_resolution(
+        self, db, payment_fixtures
+    ):
+        """F4: an open linked refund blocks any other resolution of the same record."""
+        pf = payment_fixtures
+        overpayment = await self._create_pending_overpayment(db, pf)
+        service = OverpaymentService(db)
+
+        await service.refund_overpayment(
+            overpayment_id=overpayment.id,
+            notes="Refund first",
+            user_id=pf["maker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await service.write_off(
+                overpayment_id=overpayment.id,
+                reason="cannot write off while refund open",
+                user_id=pf["checker"].id,
+                unit_id=pf["unit_id"],
+            )
+        assert "open refund" in str(exc.value).lower()
+
+    async def test_process_refund_closes_linked_overpayment(
+        self, db, payment_fixtures
+    ):
+        """F4: processing the refund finally marks the linked overpayment refunded."""
+        pf = payment_fixtures
+        overpayment = await self._create_pending_overpayment(db, pf)
+        op_service = OverpaymentService(db)
+        refund_service = RefundService(db)
+
+        resolved, _ = await op_service.refund_overpayment(
+            overpayment_id=overpayment.id,
+            notes="Refund",
+            user_id=pf["maker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+        refund_id = resolved.refund_request_id
+
+        await refund_service.approve_refund(
+            refund_id=refund_id,
+            approver_id=pf["checker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        await refund_service.process_approved_refund(
+            refund_id=refund_id,
+            processor_id=pf["checker"].id,
+            refund_reference="BANK-OP-001",
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        await db.refresh(overpayment)
+        assert overpayment.status == OverpaymentStatusEnum.refunded.value
+        assert overpayment.resolution_type == ResolutionTypeEnum.refund.value
+        assert overpayment.resolved_by_id == pf["checker"].id
+
+    async def test_apply_overpayment_rejects_non_payable_invoice(
+        self, db, payment_fixtures
+    ):
+        """F5: cannot apply an overpayment onto a cancelled/draft invoice."""
+        pf = payment_fixtures
+        overpayment = await self._create_pending_overpayment(db, pf)
+
+        cancelled_invoice = Invoice(
+            fee_id=pf["fee"].id,
+            invoice_number="INV-TEST-CANCELLED-1",
+            installment_no=3,
+            amount=Decimal("500000"),
+            status=InvoiceStatusEnum.cancelled.value,
+            due_date=date.today() + timedelta(days=30),
+        )
+        db.add(cancelled_invoice)
+        await db.flush()
+
+        service = OverpaymentService(db)
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await service.apply_to_invoice(
+                overpayment_id=overpayment.id,
+                target_invoice_id=cancelled_invoice.id,
+                user_id=pf["checker"].id,
+                unit_id=pf["unit_id"],
+            )
+        assert "status" in str(exc.value).lower()
 
 
 # =============================================================================
@@ -708,6 +798,44 @@ class TestRefundService:
         assert refund.status == "pending"
         assert refund.amount == Decimal("500000")
         assert refund.reason == "Student withdrawal"
+
+    async def test_request_refund_reserves_open_requests(self, db, payment_fixtures):
+        """F2: open (pending/approved) refunds are reserved against the payment."""
+        pf = payment_fixtures
+        payment = await self._create_verified_payment(db, pf)  # amount 1,000,000
+        refund_service = RefundService(db)
+
+        # First open request reserves 700,000.
+        await refund_service.request_refund(
+            payment_id=payment.id,
+            amount=Decimal("700000"),
+            reason="First refund",
+            user_id=pf["maker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        # Second request of 400,000 would over-commit (700k + 400k > 1,000k).
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await refund_service.request_refund(
+                payment_id=payment.id,
+                amount=Decimal("400000"),
+                reason="Second refund",
+                user_id=pf["maker"].id,
+                unit_id=pf["unit_id"],
+            )
+        assert "exceeds available" in str(exc.value).lower()
+
+        # A second request within the remaining 300,000 still succeeds.
+        ok, _ = await refund_service.request_refund(
+            payment_id=payment.id,
+            amount=Decimal("300000"),
+            reason="Second refund within budget",
+            user_id=pf["maker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+        assert ok.status == "pending"
 
     async def test_list_refunds_filters_by_payment_and_status(
         self, db, payment_fixtures

--- a/Backend_FastAPI/tests/unit/test_vietqr_utils.py
+++ b/Backend_FastAPI/tests/unit/test_vietqr_utils.py
@@ -1,0 +1,28 @@
+from decimal import Decimal
+
+from app.utils.vietqr import build_vietqr_payload, render_qr_png
+
+
+def test_build_vietqr_payload_includes_crc_field():
+    payload = build_vietqr_payload(
+        bank_bin="970436",
+        account_number="123456789",
+        account_name="QLTS",
+        amount=Decimal("1500000"),
+        add_info="Nguyen Van A HS 000001 thanh toan hoc phi",
+    )
+
+    assert payload.startswith("000201")
+    # Point of Initiation must be "12" (dynamic) so the fixed amount is locked.
+    assert "010212" in payload
+    assert "5303704" in payload
+    assert "54071500000" in payload
+    assert payload[-8:-4] == "6304"
+    assert len(payload[-4:]) == 4
+    int(payload[-4:], 16)
+
+
+def test_render_qr_png_returns_png_bytes():
+    image = render_qr_png("00020101021153037045405100006304ABCD")
+
+    assert image.startswith(b"\x89PNG\r\n\x1a\n")

--- a/frontend/src/app/(dashboard)/finance/debt-report/_components/DebtReportClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/debt-report/_components/DebtReportClient.tsx
@@ -76,8 +76,16 @@ export function DebtReportClient() {
       item.days_overdue,
       item.aging_bucket,
     ])
+    // Neutralize CSV/formula injection: a cell starting with = + - @ (or tab/CR)
+    // is treated as a formula by Excel/Sheets. profile_name is user-controlled
+    // (lead full_name), so prefix risky cells with a single quote before quoting.
+    const escapeCell = (cell: string | number) => {
+      let s = String(cell)
+      if (/^[=+\-@\t\r]/.test(s)) s = `'${s}`
+      return `"${s.replaceAll('"', '""')}"`
+    }
     const csv = [header, ...rows]
-      .map((row) => row.map((cell) => `"${String(cell).replaceAll("\"", "\"\"")}"`).join(","))
+      .map((row) => row.map(escapeCell).join(","))
       .join("\n")
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8" })
     const url = URL.createObjectURL(blob)

--- a/frontend/src/app/(dashboard)/finance/debt-report/_components/DebtReportClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/debt-report/_components/DebtReportClient.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import * as React from "react"
+import { AlertTriangle, Download, Filter, RefreshCw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Badge } from "@/components/ui/badge"
+import { AmountDisplay } from "@/components/finance"
+import { useDebtReport } from "@/hooks/finance/useDebtReport"
+import type { DebtAgingBucket, DebtReportFilters, FeeType } from "@/types/finance.types"
+
+const AGING_LABELS: Record<DebtAgingBucket, string> = {
+  "0_30": "0-30",
+  "31_60": "31-60",
+  over_60: ">60",
+}
+
+export function DebtReportClient() {
+  const [academicYear, setAcademicYear] = React.useState("")
+  const [roundId, setRoundId] = React.useState("")
+  const [feeType, setFeeType] = React.useState<FeeType | "all">("all")
+  const [aging, setAging] = React.useState<DebtAgingBucket | "all">("all")
+
+  const filters = React.useMemo<DebtReportFilters>(() => ({
+    academic_year: academicYear ? Number(academicYear) : undefined,
+    round_id: roundId ? Number(roundId) : undefined,
+    fee_type: feeType === "all" ? undefined : feeType,
+    aging: aging === "all" ? undefined : aging,
+  }), [academicYear, aging, feeType, roundId])
+
+  const { data, isLoading, error, refetch } = useDebtReport(filters)
+
+  const exportCsv = () => {
+    if (!data?.items?.length) return
+    const header = [
+      "profile_code",
+      "profile_name",
+      "unit_name",
+      "academic_year",
+      "admission_round_id",
+      "fee_types",
+      "invoice_count",
+      "total_expected",
+      "total_paid",
+      "total_outstanding",
+      "days_overdue",
+      "aging_bucket",
+    ]
+    const rows = data.items.map((item) => [
+      item.profile_code,
+      item.profile_name,
+      item.unit_name ?? "",
+      item.academic_year,
+      item.admission_round_id ?? "",
+      item.fee_types.join("|"),
+      item.invoice_count,
+      item.total_expected,
+      item.total_paid,
+      item.total_outstanding,
+      item.days_overdue,
+      item.aging_bucket,
+    ])
+    const csv = [header, ...rows]
+      .map((row) => row.map((cell) => `"${String(cell).replaceAll("\"", "\"\"")}"`).join(","))
+      .join("\n")
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = "debt-report.csv"
+    link.click()
+    URL.revokeObjectURL(url)
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 sm:p-6">
+        <Card className="border-destructive">
+          <CardContent className="p-6 text-center">
+            <AlertTriangle className="mx-auto mb-2 h-8 w-8 text-destructive" />
+            <p className="font-medium text-destructive">Khong the tai bao cao cong no</p>
+            <Button variant="outline" className="mt-4" onClick={() => refetch()}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Thu lai
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Bao cao cong no</h1>
+          <p className="text-muted-foreground">Tong hop theo ho so tuyen sinh</p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => refetch()}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Lam moi
+          </Button>
+          <Button variant="outline" onClick={exportCsv} disabled={!data?.items?.length}>
+            <Download className="mr-2 h-4 w-4" />
+            CSV
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        <SummaryCard title="Ho so no" value={data?.summary.debtor_count ?? 0} />
+        <SummaryCard title="Du thu" amount={data?.summary.total_expected ?? "0"} />
+        <SummaryCard title="Da thu" amount={data?.summary.total_paid ?? "0"} />
+        <SummaryCard title="Con lai" amount={data?.summary.total_outstanding ?? "0"} emphasis />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Filter className="h-5 w-5" />
+            Bo loc
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Input
+            inputMode="numeric"
+            placeholder="Nam hoc"
+            value={academicYear}
+            onChange={(event) => setAcademicYear(event.target.value.replace(/\D/g, ""))}
+          />
+          <Input
+            inputMode="numeric"
+            placeholder="Dot tuyen sinh"
+            value={roundId}
+            onChange={(event) => setRoundId(event.target.value.replace(/\D/g, ""))}
+          />
+          <Select value={feeType} onValueChange={(value) => setFeeType(value as FeeType | "all")}>
+            <SelectTrigger>
+              <SelectValue placeholder="Loai phi" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Tat ca phi</SelectItem>
+              <SelectItem value="application">Xet tuyen</SelectItem>
+              <SelectItem value="tuition">Hoc phi</SelectItem>
+              <SelectItem value="enrollment">Nhap hoc</SelectItem>
+              <SelectItem value="insurance">Bao hiem</SelectItem>
+              <SelectItem value="dormitory">Ky tuc xa</SelectItem>
+              <SelectItem value="other">Khac</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={aging} onValueChange={(value) => setAging(value as DebtAgingBucket | "all")}>
+            <SelectTrigger>
+              <SelectValue placeholder="Tuoi no" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Tat ca tuoi no</SelectItem>
+              <SelectItem value="0_30">0-30 ngay</SelectItem>
+              <SelectItem value="31_60">31-60 ngay</SelectItem>
+              <SelectItem value="over_60">Tren 60 ngay</SelectItem>
+            </SelectContent>
+          </Select>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Ho so</TableHead>
+                <TableHead>Don vi</TableHead>
+                <TableHead>Loai phi</TableHead>
+                <TableHead className="text-right">Con lai</TableHead>
+                <TableHead className="text-right">Ngay qua han</TableHead>
+                <TableHead>Bucket</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
+                    Dang tai...
+                  </TableCell>
+                </TableRow>
+              ) : data?.items.length ? (
+                data.items.map((item) => (
+                  <TableRow key={item.admission_profile_id}>
+                    <TableCell>
+                      <div className="font-medium">{item.profile_name}</div>
+                      <div className="font-mono text-xs text-muted-foreground">{item.profile_code}</div>
+                    </TableCell>
+                    <TableCell>{item.unit_name ?? "-"}</TableCell>
+                    <TableCell>{item.fee_types.join(", ")}</TableCell>
+                    <TableCell className="text-right">
+                      <AmountDisplay amount={item.total_outstanding} showCurrency={false} size="sm" />
+                    </TableCell>
+                    <TableCell className="text-right">{item.days_overdue}</TableCell>
+                    <TableCell>
+                      <Badge variant={item.aging_bucket === "over_60" ? "destructive" : "outline"}>
+                        {AGING_LABELS[item.aging_bucket]}
+                      </Badge>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
+                    Khong co du lieu
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function SummaryCard({
+  title,
+  value,
+  amount,
+  emphasis,
+}: {
+  title: string
+  value?: number
+  amount?: string
+  emphasis?: boolean
+}) {
+  return (
+    <Card className={emphasis ? "border-warning-500/50" : undefined}>
+      <CardContent className="p-4">
+        <p className="text-xs text-muted-foreground">{title}</p>
+        <div className="mt-2 text-xl font-semibold">
+          {amount !== undefined ? (
+            <AmountDisplay amount={amount} showCurrency={false} size="lg" />
+          ) : (
+            value
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/debt-report/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/debt-report/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from "react"
+import { Skeleton } from "@/components/ui/skeleton"
+import { DebtReportClient } from "./_components/DebtReportClient"
+
+function Loading() {
+  return (
+    <div className="p-4 sm:p-6 space-y-4">
+      <Skeleton className="h-8 w-48" />
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        {[0, 1, 2, 3].map((item) => (
+          <Skeleton key={item} className="h-24 rounded-lg" />
+        ))}
+      </div>
+      <Skeleton className="h-96 rounded-lg" />
+    </div>
+  )
+}
+
+export default function DebtReportPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <DebtReportClient />
+    </Suspense>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/[invoiceId]/_components/InvoiceDetailClient.tsx
@@ -31,8 +31,9 @@ import {
   Calendar,
   Wifi,
 } from "lucide-react"
+import { useInvoiceVietQR } from "@/hooks/finance/useInvoices"
 import { useInvoiceViewModel } from "@/hooks/finance/useInvoiceViewModel"
-import { AmountDisplay, InvoiceStatusBadge, PaymentStatusBadge } from "@/components/finance"
+import { AmountDisplay, InvoiceStatusBadge, PaymentStatusBadge, VietQRDisplay } from "@/components/finance"
 import { FEE_TYPE_LABELS, type PaymentStatus, type FeeType } from "@/types/finance.types"
 import { cn } from "@/lib/utils"
 import { PaymentRecordDialog } from "./PaymentRecordDialog"
@@ -84,6 +85,14 @@ export function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientProps) {
 
   // Fetch invoice detail
   const { data: invoice, isLoading, error } = useInvoiceViewModel(invoiceId)
+  const {
+    data: vietqr,
+    isLoading: vietqrLoading,
+    error: vietqrError,
+    refetch: refetchVietQR,
+  } = useInvoiceVietQR(invoiceId, {
+    enabled: !!invoice?.show_record_payment_button,
+  })
 
   // Handle dialog close
   const handleDialogClose = React.useCallback(() => {
@@ -331,6 +340,15 @@ export function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientProps) {
 
         {/* Sidebar */}
         <div className="space-y-6">
+          {invoice.show_record_payment_button && (
+            <VietQRDisplay
+              data={vietqr}
+              isLoading={vietqrLoading}
+              error={vietqrError}
+              onRetry={() => refetchVietQR()}
+            />
+          )}
+
           {/* Fee Info */}
           {invoice.fee && (
             <Card>

--- a/frontend/src/app/(dashboard)/finance/overpayments/_components/OverpaymentListClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/overpayments/_components/OverpaymentListClient.tsx
@@ -1,0 +1,312 @@
+"use client"
+
+import * as React from "react"
+import { AlertTriangle, CheckCircle, RefreshCw, RotateCcw, XCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
+import { AmountDisplay } from "@/components/finance"
+import {
+  useApplyOverpayment,
+  useOverpayments,
+  useRefundOverpayment,
+  useWriteOffOverpayment,
+} from "@/hooks/finance/useOverpayments"
+import type { OverpaymentRecord, OverpaymentStatus } from "@/types/finance.types"
+
+const STATUS_LABELS: Record<OverpaymentStatus, string> = {
+  pending: "Cho xu ly",
+  applied: "Da ap dung",
+  refunded: "Da hoan",
+  cancelled: "Da xoa so",
+}
+
+type ActionState =
+  | { type: "apply"; overpayment: OverpaymentRecord }
+  | { type: "refund"; overpayment: OverpaymentRecord }
+  | { type: "write_off"; overpayment: OverpaymentRecord }
+  | null
+
+export function OverpaymentListClient() {
+  const [statusFilter, setStatusFilter] = React.useState<OverpaymentStatus | "all">("pending")
+  const [action, setAction] = React.useState<ActionState>(null)
+  const [targetInvoiceId, setTargetInvoiceId] = React.useState("")
+  const [amount, setAmount] = React.useState("")
+  const [notes, setNotes] = React.useState("")
+
+  const { data, isLoading, error, refetch } = useOverpayments({
+    status: statusFilter === "all" ? undefined : statusFilter,
+    page: 1,
+    page_size: 50,
+  })
+  const applyOverpayment = useApplyOverpayment()
+  const refundOverpayment = useRefundOverpayment()
+  const writeOffOverpayment = useWriteOffOverpayment()
+
+  const closeAction = () => {
+    setAction(null)
+    setTargetInvoiceId("")
+    setAmount("")
+    setNotes("")
+  }
+
+  const handleApply = async () => {
+    if (!action || action.type !== "apply") return
+    await applyOverpayment.mutateAsync({
+      id: action.overpayment.id,
+      data: {
+        overpayment_id: action.overpayment.id,
+        target_invoice_id: Number(targetInvoiceId),
+        amount: amount || undefined,
+        notes: notes || undefined,
+      },
+    })
+    closeAction()
+  }
+
+  const handleRefund = async () => {
+    if (!action || action.type !== "refund") return
+    await refundOverpayment.mutateAsync({
+      id: action.overpayment.id,
+      data: {
+        overpayment_id: action.overpayment.id,
+        notes: notes || undefined,
+      },
+    })
+    closeAction()
+  }
+
+  const handleWriteOff = async () => {
+    if (!action || action.type !== "write_off") return
+    await writeOffOverpayment.mutateAsync({
+      id: action.overpayment.id,
+      data: {
+        overpayment_id: action.overpayment.id,
+        reason: notes,
+      },
+    })
+    closeAction()
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 sm:p-6">
+        <Card className="border-destructive">
+          <CardContent className="p-6 text-center">
+            <AlertTriangle className="mx-auto mb-2 h-8 w-8 text-destructive" />
+            <p className="font-medium text-destructive">Khong the tai danh sach tien thua</p>
+            <Button variant="outline" className="mt-4" onClick={() => refetch()}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Thu lai
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Tien thua</h1>
+          <p className="text-muted-foreground">Xu ly cac khoan overpayment dang treo</p>
+        </div>
+        <Button variant="outline" onClick={() => refetch()}>
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Lam moi
+        </Button>
+      </div>
+
+      <div className="flex max-w-xs">
+        <Select value={statusFilter} onValueChange={(value) => setStatusFilter(value as OverpaymentStatus | "all")}>
+          <SelectTrigger>
+            <SelectValue placeholder="Trang thai" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="pending">Cho xu ly</SelectItem>
+            <SelectItem value="all">Tat ca</SelectItem>
+            <SelectItem value="applied">Da ap dung</SelectItem>
+            <SelectItem value="refunded">Da hoan</SelectItem>
+            <SelectItem value="cancelled">Da xoa so</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Overpayment</TableHead>
+                <TableHead>Ho so</TableHead>
+                <TableHead>Invoice</TableHead>
+                <TableHead className="text-right">So tien</TableHead>
+                <TableHead>Trang thai</TableHead>
+                <TableHead className="text-right">Thao tac</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
+                    Dang tai...
+                  </TableCell>
+                </TableRow>
+              ) : data?.items.length ? (
+                data.items.map((overpayment) => (
+                  <TableRow key={overpayment.id}>
+                    <TableCell className="font-mono">#{overpayment.id}</TableCell>
+                    <TableCell className="font-mono">#{overpayment.admission_profile_id}</TableCell>
+                    <TableCell className="font-mono">#{overpayment.invoice_id}</TableCell>
+                    <TableCell className="text-right">
+                      <AmountDisplay amount={overpayment.overpayment_amount} showCurrency={false} size="sm" />
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={overpayment.status === "cancelled" ? "destructive" : "outline"}>
+                        {STATUS_LABELS[overpayment.status]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex justify-end gap-2">
+                        {overpayment.can_apply && (
+                          <Button size="sm" variant="outline" onClick={() => setAction({ type: "apply", overpayment })}>
+                            <CheckCircle className="mr-2 h-4 w-4" />
+                            Ap dung
+                          </Button>
+                        )}
+                        {overpayment.can_refund && (
+                          <Button size="sm" variant="outline" onClick={() => setAction({ type: "refund", overpayment })}>
+                            <RotateCcw className="mr-2 h-4 w-4" />
+                            Hoan
+                          </Button>
+                        )}
+                        {overpayment.can_write_off && (
+                          <Button size="sm" variant="outline" onClick={() => setAction({ type: "write_off", overpayment })}>
+                            <XCircle className="mr-2 h-4 w-4" />
+                            Xoa so
+                          </Button>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
+                    Khong co du lieu
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Dialog open={action?.type === "apply"} onOpenChange={(open) => !open && closeAction()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Ap dung tien thua</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Field label="Invoice dich">
+              <Input
+                inputMode="numeric"
+                value={targetInvoiceId}
+                onChange={(event) => setTargetInvoiceId(event.target.value.replace(/\D/g, ""))}
+              />
+            </Field>
+            <Field label="So tien">
+              <Input
+                inputMode="decimal"
+                placeholder={action?.type === "apply" ? action.overpayment.overpayment_amount : undefined}
+                value={amount}
+                onChange={(event) => setAmount(event.target.value)}
+              />
+            </Field>
+            <Field label="Ghi chu">
+              <Textarea value={notes} onChange={(event) => setNotes(event.target.value)} />
+            </Field>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={closeAction}>Huy</Button>
+            <Button onClick={handleApply} disabled={!targetInvoiceId || applyOverpayment.isPending}>
+              Ap dung
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={action?.type === "refund"} onOpenChange={(open) => !open && closeAction()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Tao yeu cau hoan tien thua</DialogTitle>
+          </DialogHeader>
+          <Field label="Ghi chu">
+            <Textarea value={notes} onChange={(event) => setNotes(event.target.value)} />
+          </Field>
+          <DialogFooter>
+            <Button variant="outline" onClick={closeAction}>Huy</Button>
+            <Button onClick={handleRefund} disabled={refundOverpayment.isPending}>
+              Tao yeu cau
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={action?.type === "write_off"} onOpenChange={(open) => !open && closeAction()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Xoa so tien thua</DialogTitle>
+          </DialogHeader>
+          <Field label="Ly do">
+            <Textarea value={notes} onChange={(event) => setNotes(event.target.value)} />
+          </Field>
+          <DialogFooter>
+            <Button variant="outline" onClick={closeAction}>Huy</Button>
+            <Button variant="destructive" onClick={handleWriteOff} disabled={!notes || writeOffOverpayment.isPending}>
+              Xoa so
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  const id = React.useId()
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      {React.isValidElement(children)
+        ? React.cloneElement(children as React.ReactElement<{ id?: string }>, { id })
+        : children}
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/overpayments/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/overpayments/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from "react"
+import { Skeleton } from "@/components/ui/skeleton"
+import { OverpaymentListClient } from "./_components/OverpaymentListClient"
+
+function Loading() {
+  return (
+    <div className="p-4 sm:p-6 space-y-4">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-96 rounded-lg" />
+    </div>
+  )
+}
+
+export default function OverpaymentsPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <OverpaymentListClient />
+    </Suspense>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/refunds/_components/RefundListClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/refunds/_components/RefundListClient.tsx
@@ -1,0 +1,312 @@
+"use client"
+
+import * as React from "react"
+import { AlertTriangle, CheckCircle, Plus, RefreshCw, RotateCcw, XCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
+import { AmountDisplay } from "@/components/finance"
+import {
+  useApproveRefund,
+  useCreateRefund,
+  useProcessRefund,
+  useRefunds,
+  useRejectRefund,
+} from "@/hooks/finance/useRefunds"
+import type { RefundRequest, RefundStatus } from "@/types/finance.types"
+
+const STATUS_LABELS: Record<RefundStatus, string> = {
+  pending: "Cho duyet",
+  approved: "Da duyet",
+  rejected: "Tu choi",
+  refunded: "Da hoan",
+}
+
+export function RefundListClient() {
+  const [statusFilter, setStatusFilter] = React.useState<RefundStatus | "all">("pending")
+  const [createOpen, setCreateOpen] = React.useState(false)
+  const [action, setAction] = React.useState<null | { type: "reject" | "process"; refund: RefundRequest }>(null)
+  const [createForm, setCreateForm] = React.useState({ payment_id: "", amount: "", reason: "" })
+  const [rejectionReason, setRejectionReason] = React.useState("")
+  const [refundReference, setRefundReference] = React.useState("")
+
+  const { data, isLoading, error, refetch } = useRefunds({
+    status: statusFilter === "all" ? undefined : statusFilter,
+    page: 1,
+    page_size: 50,
+  })
+  const createRefund = useCreateRefund()
+  const approveRefund = useApproveRefund()
+  const rejectRefund = useRejectRefund()
+  const processRefund = useProcessRefund()
+
+  const handleCreate = async () => {
+    await createRefund.mutateAsync({
+      payment_id: Number(createForm.payment_id),
+      amount: createForm.amount,
+      reason: createForm.reason,
+    })
+    setCreateOpen(false)
+    setCreateForm({ payment_id: "", amount: "", reason: "" })
+  }
+
+  const handleReject = async () => {
+    if (!action || action.type !== "reject") return
+    await rejectRefund.mutateAsync({
+      id: action.refund.id,
+      data: { rejection_reason: rejectionReason },
+    })
+    setAction(null)
+    setRejectionReason("")
+  }
+
+  const handleProcess = async () => {
+    if (!action || action.type !== "process") return
+    await processRefund.mutateAsync({
+      id: action.refund.id,
+      data: { refund_id: action.refund.id, refund_reference: refundReference },
+    })
+    setAction(null)
+    setRefundReference("")
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 sm:p-6">
+        <Card className="border-destructive">
+          <CardContent className="p-6 text-center">
+            <AlertTriangle className="mx-auto mb-2 h-8 w-8 text-destructive" />
+            <p className="font-medium text-destructive">Khong the tai danh sach hoan phi</p>
+            <Button variant="outline" className="mt-4" onClick={() => refetch()}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Thu lai
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Hoan phi</h1>
+          <p className="text-muted-foreground">Yeu cau, phe duyet va xu ly hoan phi</p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => refetch()}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Lam moi
+          </Button>
+          {data?.can_create && (
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Tao yeu cau
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex max-w-xs">
+        <Select value={statusFilter} onValueChange={(value) => setStatusFilter(value as RefundStatus | "all")}>
+          <SelectTrigger>
+            <SelectValue placeholder="Trang thai" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="pending">Cho duyet</SelectItem>
+            <SelectItem value="all">Tat ca</SelectItem>
+            <SelectItem value="approved">Da duyet</SelectItem>
+            <SelectItem value="rejected">Tu choi</SelectItem>
+            <SelectItem value="refunded">Da hoan</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Refund</TableHead>
+                <TableHead>Payment</TableHead>
+                <TableHead className="text-right">So tien</TableHead>
+                <TableHead>Trang thai</TableHead>
+                <TableHead>Ngay tao</TableHead>
+                <TableHead className="text-right">Thao tac</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
+                    Dang tai...
+                  </TableCell>
+                </TableRow>
+              ) : data?.items.length ? (
+                data.items.map((refund) => (
+                  <TableRow key={refund.id}>
+                    <TableCell>
+                      <div className="font-mono">#{refund.id}</div>
+                      <div className="line-clamp-1 text-xs text-muted-foreground">{refund.reason}</div>
+                    </TableCell>
+                    <TableCell className="font-mono">#{refund.payment_id}</TableCell>
+                    <TableCell className="text-right">
+                      <AmountDisplay amount={refund.amount} showCurrency={false} size="sm" />
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={refund.status === "rejected" ? "destructive" : "outline"}>
+                        {STATUS_LABELS[refund.status]}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>{new Intl.DateTimeFormat("vi-VN").format(new Date(refund.created_at))}</TableCell>
+                    <TableCell>
+                      <div className="flex justify-end gap-2">
+                        {refund.can_approve && (
+                          <Button size="sm" variant="outline" onClick={() => approveRefund.mutate(refund.id)}>
+                            <CheckCircle className="mr-2 h-4 w-4" />
+                            Duyet
+                          </Button>
+                        )}
+                        {refund.can_reject && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => setAction({ type: "reject", refund })}
+                          >
+                            <XCircle className="mr-2 h-4 w-4" />
+                            Tu choi
+                          </Button>
+                        )}
+                        {refund.can_process && (
+                          <Button size="sm" onClick={() => setAction({ type: "process", refund })}>
+                            <RotateCcw className="mr-2 h-4 w-4" />
+                            Xu ly
+                          </Button>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
+                    Khong co du lieu
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Tao yeu cau hoan phi</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <Field label="Payment ID">
+              <Input
+                inputMode="numeric"
+                value={createForm.payment_id}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, payment_id: event.target.value.replace(/\D/g, "") }))}
+              />
+            </Field>
+            <Field label="So tien">
+              <Input
+                inputMode="decimal"
+                value={createForm.amount}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, amount: event.target.value }))}
+              />
+            </Field>
+            <Field label="Ly do">
+              <Textarea
+                value={createForm.reason}
+                onChange={(event) => setCreateForm((prev) => ({ ...prev, reason: event.target.value }))}
+              />
+            </Field>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>Huy</Button>
+            <Button
+              onClick={handleCreate}
+              disabled={!createForm.payment_id || !createForm.amount || !createForm.reason || createRefund.isPending}
+            >
+              Tao
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={action?.type === "reject"} onOpenChange={(open) => !open && setAction(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Tu choi hoan phi</DialogTitle>
+          </DialogHeader>
+          <Textarea value={rejectionReason} onChange={(event) => setRejectionReason(event.target.value)} />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAction(null)}>Huy</Button>
+            <Button variant="destructive" onClick={handleReject} disabled={!rejectionReason || rejectRefund.isPending}>
+              Tu choi
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={action?.type === "process"} onOpenChange={(open) => !open && setAction(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Xu ly hoan phi</DialogTitle>
+          </DialogHeader>
+          <Field label="Ma tham chieu">
+            <Input value={refundReference} onChange={(event) => setRefundReference(event.target.value)} />
+          </Field>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAction(null)}>Huy</Button>
+            <Button onClick={handleProcess} disabled={!refundReference || processRefund.isPending}>
+              Xu ly
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  const id = React.useId()
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      {React.isValidElement(children)
+        ? React.cloneElement(children as React.ReactElement<{ id?: string }>, { id })
+        : children}
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/refunds/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/refunds/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from "react"
+import { Skeleton } from "@/components/ui/skeleton"
+import { RefundListClient } from "./_components/RefundListClient"
+
+function Loading() {
+  return (
+    <div className="p-4 sm:p-6 space-y-4">
+      <Skeleton className="h-8 w-48" />
+      <Skeleton className="h-96 rounded-lg" />
+    </div>
+  )
+}
+
+export default function RefundsPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <RefundListClient />
+    </Suspense>
+  )
+}

--- a/frontend/src/components/finance/VietQRDisplay.tsx
+++ b/frontend/src/components/finance/VietQRDisplay.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import * as React from "react"
+import { Copy, QrCode } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { AmountDisplay } from "./AmountDisplay"
+import type { VietQRResponse } from "@/types/finance.types"
+import { toast } from "sonner"
+
+interface VietQRDisplayProps {
+  data?: VietQRResponse
+  isLoading?: boolean
+  error?: unknown
+  onRetry?: () => void
+}
+
+export function VietQRDisplay({ data, isLoading, error, onRetry }: VietQRDisplayProps) {
+  const copy = React.useCallback(async (value: string, label: string) => {
+    await navigator.clipboard.writeText(value)
+    toast.success(`Da copy ${label}`)
+  }, [])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg flex items-center gap-2">
+          <QrCode className="h-5 w-5" />
+          Chuyen khoan VietQR
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <>
+            <Skeleton className="mx-auto h-44 w-44 rounded-md" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+          </>
+        ) : error ? (
+          <div className="space-y-3 text-sm text-muted-foreground">
+            <p>Chua the hien thi ma QR.</p>
+            {onRetry && (
+              <Button variant="outline" size="sm" onClick={onRetry}>
+                Thu lai
+              </Button>
+            )}
+          </div>
+        ) : data ? (
+          <>
+            <div className="flex justify-center">
+              <img
+                src={`data:image/png;base64,${data.qr_image_base64}`}
+                alt="VietQR"
+                className="h-44 w-44 rounded-md border bg-white p-2"
+              />
+            </div>
+            <div className="space-y-2 text-sm">
+              <InfoRow
+                label="So tien"
+                value={<AmountDisplay amount={data.amount} showCurrency size="sm" />}
+              />
+              <CopyRow
+                label="So tai khoan"
+                value={data.bank_account.account_number}
+                onCopy={() => copy(data.bank_account.account_number, "so tai khoan")}
+              />
+              <InfoRow label="Ten tai khoan" value={data.bank_account.account_name} />
+              <CopyRow
+                label="Noi dung"
+                value={data.content}
+                mono
+                onCopy={() => copy(data.content, "noi dung")}
+              />
+            </div>
+          </>
+        ) : null}
+      </CardContent>
+    </Card>
+  )
+}
+
+function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-right font-medium">{value}</span>
+    </div>
+  )
+}
+
+function CopyRow({
+  label,
+  value,
+  mono,
+  onCopy,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+  onCopy: () => void
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <div className="flex min-w-0 items-start gap-1">
+        <span className={mono ? "break-words text-right font-mono text-xs" : "break-words text-right font-medium"}>
+          {value}
+        </span>
+        <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={onCopy}>
+          <Copy className="h-3.5 w-3.5" />
+          <span className="sr-only">Copy {label}</span>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/finance/index.ts
+++ b/frontend/src/components/finance/index.ts
@@ -43,6 +43,7 @@ export {
 
 // Cross-reference components
 export { FeeStatusLink, type FeeStatusLinkProps } from "./FeeStatusLink"
+export { VietQRDisplay } from "./VietQRDisplay"
 
 // Invoice components
 export { InvoiceTable, type InvoiceTableProps } from "./InvoiceTable"

--- a/frontend/src/hooks/finance/index.ts
+++ b/frontend/src/hooks/finance/index.ts
@@ -42,6 +42,7 @@ export {
   useInvoices,
   useInvoiceDetail,
   useInvoicesByFee,
+  useInvoiceVietQR,
   useIssueInvoice,
   useCancelInvoice,
   useApplyPenalty,
@@ -114,3 +115,26 @@ export {
   type DashboardCard,
   type FinanceBadgeCounts,
 } from "./useFinanceDashboard"
+
+export {
+  debtReportKeys,
+  useDebtReport,
+} from "./useDebtReport"
+
+export {
+  refundsKeys,
+  useRefunds,
+  useRefundDetail,
+  useCreateRefund,
+  useApproveRefund,
+  useRejectRefund,
+  useProcessRefund,
+} from "./useRefunds"
+
+export {
+  overpaymentsKeys,
+  useOverpayments,
+  useApplyOverpayment,
+  useRefundOverpayment,
+  useWriteOffOverpayment,
+} from "./useOverpayments"

--- a/frontend/src/hooks/finance/useDebtReport.ts
+++ b/frontend/src/hooks/finance/useDebtReport.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query"
+import { AxiosError } from "axios"
+import { financeReportsApi } from "@/lib/api/finance-reports"
+import type { ApiErrorResponse } from "@/types/api.types"
+import type { DebtReportFilters, DebtReportResponse } from "@/types/finance.types"
+
+export const debtReportKeys = {
+  all: ["finance", "debt-report"] as const,
+  detail: (filters?: DebtReportFilters) => [...debtReportKeys.all, filters] as const,
+}
+
+export function useDebtReport(filters?: DebtReportFilters, options?: { enabled?: boolean }) {
+  return useQuery<DebtReportResponse, AxiosError<ApiErrorResponse>>({
+    queryKey: debtReportKeys.detail(filters),
+    queryFn: () => financeReportsApi.getDebtReport(filters),
+    enabled: options?.enabled ?? true,
+    staleTime: 1000 * 30,
+  })
+}

--- a/frontend/src/hooks/finance/useInvoices.ts
+++ b/frontend/src/hooks/finance/useInvoices.ts
@@ -14,6 +14,7 @@ import type {
   InvoiceDetail,
   InvoiceFilters,
   InvoicePenaltyRequest,
+  VietQRResponse,
 } from "@/types/finance.types"
 import { feesKeys } from "./useFees"
 
@@ -27,6 +28,7 @@ export const invoicesKeys = {
   list: (filters?: InvoiceFilters) => [...invoicesKeys.lists(), filters] as const,
   details: () => [...invoicesKeys.all, "detail"] as const,
   detail: (id: number) => [...invoicesKeys.details(), id] as const,
+  vietqr: (id: number) => [...invoicesKeys.detail(id), "vietqr"] as const,
   byFee: (feeId: number) => [...invoicesKeys.all, "by-fee", feeId] as const,
 }
 
@@ -158,6 +160,15 @@ export function useInvoicesByFee(feeId: number, options?: { enabled?: boolean })
     queryFn: () => invoicesApi.getInvoicesByFee(feeId),
     enabled: (options?.enabled ?? true) && !!feeId,
     staleTime: 1000 * 30,
+  })
+}
+
+export function useInvoiceVietQR(invoiceId: number, options?: { enabled?: boolean }) {
+  return useQuery<VietQRResponse, AxiosError<ApiErrorResponse>>({
+    queryKey: invoicesKeys.vietqr(invoiceId),
+    queryFn: () => invoicesApi.getInvoiceVietQR(invoiceId),
+    enabled: (options?.enabled ?? true) && !!invoiceId,
+    staleTime: 1000 * 60,
   })
 }
 

--- a/frontend/src/hooks/finance/useOverpayments.ts
+++ b/frontend/src/hooks/finance/useOverpayments.ts
@@ -1,0 +1,94 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { AxiosError } from "axios"
+import { toast } from "sonner"
+import { overpaymentsApi, type OverpaymentPaginatedResponse } from "@/lib/api/overpayments"
+import type { ApiErrorResponse } from "@/types/api.types"
+import type {
+  OverpaymentApplyRequest,
+  OverpaymentFilters,
+  OverpaymentRecord,
+  OverpaymentRefundRequest,
+  OverpaymentWriteOffRequest,
+} from "@/types/finance.types"
+
+export const overpaymentsKeys = {
+  all: ["overpayments"] as const,
+  lists: () => [...overpaymentsKeys.all, "list"] as const,
+  list: (filters?: OverpaymentFilters) => [...overpaymentsKeys.lists(), filters] as const,
+  details: () => [...overpaymentsKeys.all, "detail"] as const,
+  detail: (id: number) => [...overpaymentsKeys.details(), id] as const,
+}
+
+function getErrorMessage(error: AxiosError<ApiErrorResponse>, fallback: string) {
+  const detail = error.response?.data?.detail
+  return typeof detail === "string" ? detail : fallback
+}
+
+export function useOverpayments(filters?: OverpaymentFilters, options?: { enabled?: boolean }) {
+  return useQuery<OverpaymentPaginatedResponse, AxiosError<ApiErrorResponse>>({
+    queryKey: overpaymentsKeys.list(filters),
+    queryFn: () => overpaymentsApi.getOverpayments(filters),
+    enabled: options?.enabled ?? true,
+    staleTime: 1000 * 20,
+  })
+}
+
+export function useApplyOverpayment() {
+  const queryClient = useQueryClient()
+  return useMutation<
+    OverpaymentRecord,
+    AxiosError<ApiErrorResponse>,
+    { id: number; data: OverpaymentApplyRequest }
+  >({
+    mutationFn: ({ id, data }) => overpaymentsApi.applyOverpayment(id, data),
+    onSuccess: (overpayment) => {
+      toast.success("Da ap dung tien thua")
+      queryClient.invalidateQueries({ queryKey: overpaymentsKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: overpaymentsKeys.detail(overpayment.id) })
+      queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "Khong the ap dung tien thua"))
+    },
+  })
+}
+
+export function useRefundOverpayment() {
+  const queryClient = useQueryClient()
+  return useMutation<
+    OverpaymentRecord,
+    AxiosError<ApiErrorResponse>,
+    { id: number; data: OverpaymentRefundRequest }
+  >({
+    mutationFn: ({ id, data }) => overpaymentsApi.refundOverpayment(id, data),
+    onSuccess: (overpayment) => {
+      toast.success("Da tao yeu cau hoan tien thua")
+      queryClient.invalidateQueries({ queryKey: overpaymentsKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: overpaymentsKeys.detail(overpayment.id) })
+      queryClient.invalidateQueries({ queryKey: ["refunds"] })
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "Khong the tao yeu cau hoan tien thua"))
+    },
+  })
+}
+
+export function useWriteOffOverpayment() {
+  const queryClient = useQueryClient()
+  return useMutation<
+    OverpaymentRecord,
+    AxiosError<ApiErrorResponse>,
+    { id: number; data: OverpaymentWriteOffRequest }
+  >({
+    mutationFn: ({ id, data }) => overpaymentsApi.writeOffOverpayment(id, data),
+    onSuccess: (overpayment) => {
+      toast.success("Da xoa so tien thua")
+      queryClient.invalidateQueries({ queryKey: overpaymentsKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: overpaymentsKeys.detail(overpayment.id) })
+      queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "Khong the xoa so tien thua"))
+    },
+  })
+}

--- a/frontend/src/hooks/finance/useOverpayments.ts
+++ b/frontend/src/hooks/finance/useOverpayments.ts
@@ -21,7 +21,13 @@ export const overpaymentsKeys = {
 
 function getErrorMessage(error: AxiosError<ApiErrorResponse>, fallback: string) {
   const detail = error.response?.data?.detail
-  return typeof detail === "string" ? detail : fallback
+  if (typeof detail === "string") return detail
+  // FastAPI 422 returns detail as an array of {msg, loc, ...}; surface the first.
+  if (Array.isArray(detail) && detail.length > 0) {
+    const first = detail[0] as { msg?: unknown }
+    if (first && typeof first.msg === "string") return first.msg
+  }
+  return fallback
 }
 
 export function useOverpayments(filters?: OverpaymentFilters, options?: { enabled?: boolean }) {

--- a/frontend/src/hooks/finance/useRefunds.ts
+++ b/frontend/src/hooks/finance/useRefunds.ts
@@ -20,7 +20,13 @@ export const refundsKeys = {
 
 function getErrorMessage(error: AxiosError<ApiErrorResponse>, fallback: string) {
   const detail = error.response?.data?.detail
-  return typeof detail === "string" ? detail : fallback
+  if (typeof detail === "string") return detail
+  // FastAPI 422 returns detail as an array of {msg, loc, ...}; surface the first.
+  if (Array.isArray(detail) && detail.length > 0) {
+    const first = detail[0] as { msg?: unknown }
+    if (first && typeof first.msg === "string") return first.msg
+  }
+  return fallback
 }
 
 export function useRefunds(filters?: RefundFilters, options?: { enabled?: boolean }) {
@@ -102,6 +108,9 @@ export function useProcessRefund() {
       queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
       queryClient.invalidateQueries({ queryKey: refundsKeys.detail(refund.id) })
       queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
+      // Processing a refund can auto-close a linked overpayment (F4), so refresh
+      // the overpayments cache too.
+      queryClient.invalidateQueries({ queryKey: ["overpayments"] })
     },
     onError: (error) => {
       toast.error(getErrorMessage(error, "Khong the xu ly hoan phi"))

--- a/frontend/src/hooks/finance/useRefunds.ts
+++ b/frontend/src/hooks/finance/useRefunds.ts
@@ -1,0 +1,110 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { AxiosError } from "axios"
+import { toast } from "sonner"
+import { refundsApi, type RefundPaginatedResponse, type RefundRejectRequest } from "@/lib/api/refunds"
+import type { ApiErrorResponse } from "@/types/api.types"
+import type {
+  RefundCreateRequest,
+  RefundFilters,
+  RefundProcessRequest,
+  RefundRequest,
+} from "@/types/finance.types"
+
+export const refundsKeys = {
+  all: ["refunds"] as const,
+  lists: () => [...refundsKeys.all, "list"] as const,
+  list: (filters?: RefundFilters) => [...refundsKeys.lists(), filters] as const,
+  details: () => [...refundsKeys.all, "detail"] as const,
+  detail: (id: number) => [...refundsKeys.details(), id] as const,
+}
+
+function getErrorMessage(error: AxiosError<ApiErrorResponse>, fallback: string) {
+  const detail = error.response?.data?.detail
+  return typeof detail === "string" ? detail : fallback
+}
+
+export function useRefunds(filters?: RefundFilters, options?: { enabled?: boolean }) {
+  return useQuery<RefundPaginatedResponse, AxiosError<ApiErrorResponse>>({
+    queryKey: refundsKeys.list(filters),
+    queryFn: () => refundsApi.getRefunds(filters),
+    enabled: options?.enabled ?? true,
+    staleTime: 1000 * 20,
+  })
+}
+
+export function useRefundDetail(id: number, options?: { enabled?: boolean }) {
+  return useQuery<RefundRequest, AxiosError<ApiErrorResponse>>({
+    queryKey: refundsKeys.detail(id),
+    queryFn: () => refundsApi.getRefund(id),
+    enabled: (options?.enabled ?? true) && !!id,
+  })
+}
+
+export function useCreateRefund() {
+  const queryClient = useQueryClient()
+  return useMutation<RefundRequest, AxiosError<ApiErrorResponse>, RefundCreateRequest>({
+    mutationFn: refundsApi.createRefund,
+    onSuccess: () => {
+      toast.success("Da tao yeu cau hoan phi")
+      queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "Khong the tao yeu cau hoan phi"))
+    },
+  })
+}
+
+export function useApproveRefund() {
+  const queryClient = useQueryClient()
+  return useMutation<RefundRequest, AxiosError<ApiErrorResponse>, number>({
+    mutationFn: refundsApi.approveRefund,
+    onSuccess: (refund) => {
+      toast.success("Da phe duyet hoan phi")
+      queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: refundsKeys.detail(refund.id) })
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "Khong the phe duyet hoan phi"))
+    },
+  })
+}
+
+export function useRejectRefund() {
+  const queryClient = useQueryClient()
+  return useMutation<
+    RefundRequest,
+    AxiosError<ApiErrorResponse>,
+    { id: number; data: RefundRejectRequest }
+  >({
+    mutationFn: ({ id, data }) => refundsApi.rejectRefund(id, data),
+    onSuccess: (refund) => {
+      toast.success("Da tu choi hoan phi")
+      queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: refundsKeys.detail(refund.id) })
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "Khong the tu choi hoan phi"))
+    },
+  })
+}
+
+export function useProcessRefund() {
+  const queryClient = useQueryClient()
+  return useMutation<
+    RefundRequest,
+    AxiosError<ApiErrorResponse>,
+    { id: number; data: RefundProcessRequest }
+  >({
+    mutationFn: ({ id, data }) => refundsApi.processRefund(id, data),
+    onSuccess: (refund) => {
+      toast.success("Da xu ly hoan phi")
+      queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: refundsKeys.detail(refund.id) })
+      queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error, "Khong the xu ly hoan phi"))
+    },
+  })
+}

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -235,6 +235,7 @@ export const API_ENDPOINTS = {
   // ============================================================================
   FINANCE: {
     DASHBOARD: "/api/finance/dashboard",
+    DEBT_REPORT: "/api/finance/debt-report",
 
     FEES: {
       LIST: "/api/fees",
@@ -251,6 +252,7 @@ export const API_ENDPOINTS = {
       LIST: "/api/invoices",
       BY_FEE: (feeId: number) => `/api/invoices/by-fee/${feeId}`,
       DETAIL: (invoiceId: number) => `/api/invoices/${invoiceId}`,
+      VIETQR: (invoiceId: number) => `/api/invoices/${invoiceId}/vietqr`,
       ISSUE: (invoiceId: number) => `/api/invoices/${invoiceId}/issue`,
       CANCEL: (invoiceId: number) => `/api/invoices/${invoiceId}/cancel`,
       PENALTY: (invoiceId: number) => `/api/invoices/${invoiceId}/apply-penalty`,
@@ -277,7 +279,6 @@ export const API_ENDPOINTS = {
       DETAIL: (id: number) => `/api/installment-plans/${id}`,
     },
 
-    // P3 - Wait for backend router implementation
     OVERPAYMENTS: {
       LIST: "/api/overpayments",
       DETAIL: (id: number) => `/api/overpayments/${id}`,
@@ -286,7 +287,6 @@ export const API_ENDPOINTS = {
       WRITE_OFF: (id: number) => `/api/overpayments/${id}/write-off`,
     },
 
-    // P3 - Wait for backend router implementation
     REFUNDS: {
       LIST: "/api/refunds",
       CREATE: "/api/refunds",

--- a/frontend/src/lib/api/finance-reports.ts
+++ b/frontend/src/lib/api/finance-reports.ts
@@ -1,12 +1,14 @@
 import { api } from "./client"
 import { API_ENDPOINTS } from "./endpoints"
+import { debtReportResponseSchema } from "@/lib/zod/finance"
 import type { DebtReportFilters, DebtReportResponse } from "@/types/finance.types"
 
 export async function getDebtReport(filters?: DebtReportFilters): Promise<DebtReportResponse> {
   const response = await api.get<DebtReportResponse>(API_ENDPOINTS.FINANCE.DEBT_REPORT, {
     params: filters,
   })
-  return response.data
+  // Runtime-validate the contract (throws on drift) instead of trusting the cast.
+  return debtReportResponseSchema.parse(response.data) as DebtReportResponse
 }
 
 export const financeReportsApi = {

--- a/frontend/src/lib/api/finance-reports.ts
+++ b/frontend/src/lib/api/finance-reports.ts
@@ -1,0 +1,14 @@
+import { api } from "./client"
+import { API_ENDPOINTS } from "./endpoints"
+import type { DebtReportFilters, DebtReportResponse } from "@/types/finance.types"
+
+export async function getDebtReport(filters?: DebtReportFilters): Promise<DebtReportResponse> {
+  const response = await api.get<DebtReportResponse>(API_ENDPOINTS.FINANCE.DEBT_REPORT, {
+    params: filters,
+  })
+  return response.data
+}
+
+export const financeReportsApi = {
+  getDebtReport,
+}

--- a/frontend/src/lib/api/invoices.ts
+++ b/frontend/src/lib/api/invoices.ts
@@ -7,6 +7,7 @@
 
 import { api } from "./client"
 import { API_ENDPOINTS } from "./endpoints"
+import { vietQRResponseSchema } from "@/lib/zod/finance"
 import type {
   Invoice,
   InvoiceDetail,
@@ -83,7 +84,7 @@ export async function getInvoicesByFee(feeId: number): Promise<Invoice[]> {
  */
 export async function getInvoiceVietQR(invoiceId: number): Promise<VietQRResponse> {
   const response = await api.get<VietQRResponse>(API_ENDPOINTS.FINANCE.INVOICES.VIETQR(invoiceId))
-  return response.data
+  return vietQRResponseSchema.parse(response.data) as VietQRResponse
 }
 
 // ============================================================================

--- a/frontend/src/lib/api/invoices.ts
+++ b/frontend/src/lib/api/invoices.ts
@@ -12,6 +12,7 @@ import type {
   InvoiceDetail,
   InvoiceFilters,
   InvoicePenaltyRequest,
+  VietQRResponse,
 } from "@/types/finance.types"
 
 // ============================================================================
@@ -77,6 +78,14 @@ export async function getInvoicesByFee(feeId: number): Promise<Invoice[]> {
   return response.data
 }
 
+/**
+ * Get VietQR payload and PNG for an invoice.
+ */
+export async function getInvoiceVietQR(invoiceId: number): Promise<VietQRResponse> {
+  const response = await api.get<VietQRResponse>(API_ENDPOINTS.FINANCE.INVOICES.VIETQR(invoiceId))
+  return response.data
+}
+
 // ============================================================================
 // INVOICE ACTIONS
 // ============================================================================
@@ -138,6 +147,7 @@ export const invoicesApi = {
   getInvoices,
   getInvoice,
   getInvoicesByFee,
+  getInvoiceVietQR,
   // Actions
   issueInvoice,
   cancelInvoice,

--- a/frontend/src/lib/api/overpayments.ts
+++ b/frontend/src/lib/api/overpayments.ts
@@ -1,0 +1,51 @@
+import { api } from "./client"
+import { API_ENDPOINTS } from "./endpoints"
+import type {
+  OverpaymentApplyRequest,
+  OverpaymentFilters,
+  OverpaymentRecord,
+  OverpaymentRefundRequest,
+  OverpaymentWriteOffRequest,
+} from "@/types/finance.types"
+
+export interface OverpaymentPaginatedResponse {
+  items: OverpaymentRecord[]
+  total: number
+  page: number
+  page_size: number
+}
+
+export async function getOverpayments(filters?: OverpaymentFilters): Promise<OverpaymentPaginatedResponse> {
+  const response = await api.get<OverpaymentPaginatedResponse>(API_ENDPOINTS.FINANCE.OVERPAYMENTS.LIST, {
+    params: filters,
+  })
+  return response.data
+}
+
+export async function getOverpayment(id: number): Promise<OverpaymentRecord> {
+  const response = await api.get<OverpaymentRecord>(API_ENDPOINTS.FINANCE.OVERPAYMENTS.DETAIL(id))
+  return response.data
+}
+
+export async function applyOverpayment(id: number, data: OverpaymentApplyRequest): Promise<OverpaymentRecord> {
+  const response = await api.post<OverpaymentRecord>(API_ENDPOINTS.FINANCE.OVERPAYMENTS.APPLY(id), data)
+  return response.data
+}
+
+export async function refundOverpayment(id: number, data: OverpaymentRefundRequest): Promise<OverpaymentRecord> {
+  const response = await api.post<OverpaymentRecord>(API_ENDPOINTS.FINANCE.OVERPAYMENTS.REFUND(id), data)
+  return response.data
+}
+
+export async function writeOffOverpayment(id: number, data: OverpaymentWriteOffRequest): Promise<OverpaymentRecord> {
+  const response = await api.post<OverpaymentRecord>(API_ENDPOINTS.FINANCE.OVERPAYMENTS.WRITE_OFF(id), data)
+  return response.data
+}
+
+export const overpaymentsApi = {
+  getOverpayments,
+  getOverpayment,
+  applyOverpayment,
+  refundOverpayment,
+  writeOffOverpayment,
+}

--- a/frontend/src/lib/api/refunds.ts
+++ b/frontend/src/lib/api/refunds.ts
@@ -1,0 +1,62 @@
+import { api } from "./client"
+import { API_ENDPOINTS } from "./endpoints"
+import type {
+  RefundCreateRequest,
+  RefundFilters,
+  RefundProcessRequest,
+  RefundRequest,
+} from "@/types/finance.types"
+
+export interface RefundPaginatedResponse {
+  items: RefundRequest[]
+  total: number
+  page: number
+  page_size: number
+  /** Page-level capability: officer/accountant/admin may create (manager is approver-only). */
+  can_create: boolean
+}
+
+export interface RefundRejectRequest {
+  rejection_reason: string
+}
+
+export async function getRefunds(filters?: RefundFilters): Promise<RefundPaginatedResponse> {
+  const response = await api.get<RefundPaginatedResponse>(API_ENDPOINTS.FINANCE.REFUNDS.LIST, {
+    params: filters,
+  })
+  return response.data
+}
+
+export async function getRefund(id: number): Promise<RefundRequest> {
+  const response = await api.get<RefundRequest>(API_ENDPOINTS.FINANCE.REFUNDS.DETAIL(id))
+  return response.data
+}
+
+export async function createRefund(data: RefundCreateRequest): Promise<RefundRequest> {
+  const response = await api.post<RefundRequest>(API_ENDPOINTS.FINANCE.REFUNDS.CREATE, data)
+  return response.data
+}
+
+export async function approveRefund(id: number): Promise<RefundRequest> {
+  const response = await api.post<RefundRequest>(API_ENDPOINTS.FINANCE.REFUNDS.APPROVE(id))
+  return response.data
+}
+
+export async function rejectRefund(id: number, data: RefundRejectRequest): Promise<RefundRequest> {
+  const response = await api.post<RefundRequest>(API_ENDPOINTS.FINANCE.REFUNDS.REJECT(id), data)
+  return response.data
+}
+
+export async function processRefund(id: number, data: RefundProcessRequest): Promise<RefundRequest> {
+  const response = await api.post<RefundRequest>(API_ENDPOINTS.FINANCE.REFUNDS.PROCESS(id), data)
+  return response.data
+}
+
+export const refundsApi = {
+  getRefunds,
+  getRefund,
+  createRefund,
+  approveRefund,
+  rejectRefund,
+  processRefund,
+}

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -9,6 +9,7 @@
  */
 import {
   Activity,
+  BarChart3,
   Bell,
   Building2,
   Calculator,
@@ -24,6 +25,7 @@ import {
   LayoutDashboard,
   Percent,
   Receipt,
+  RotateCcw,
   Settings,
   Send,
   Share2,
@@ -34,6 +36,7 @@ import {
   Trello,
   UserCheck,
   Users,
+  WalletCards,
   Workflow,
 } from "lucide-react";
 import type { NavigationConfig } from "@/types/navigation";
@@ -148,7 +151,14 @@ export const navigationConfig: NavigationConfig = {
           href: "/finance",
           icon: DollarSign,
           roles: ["accountant", "manager", "admin"],
-          excludePaths: ["/finance/fees", "/finance/invoices", "/finance/payments"],
+          excludePaths: [
+            "/finance/fees",
+            "/finance/invoices",
+            "/finance/payments",
+            "/finance/debt-report",
+            "/finance/refunds",
+            "/finance/overpayments",
+          ],
         },
         {
           label: "Fees",
@@ -168,6 +178,24 @@ export const navigationConfig: NavigationConfig = {
           icon: CreditCard,
           roles: ["accountant", "manager", "admin"],
           // Badge for pending count can be added dynamically
+        },
+        {
+          label: "Debt Report",
+          href: "/finance/debt-report",
+          icon: BarChart3,
+          roles: ["accountant", "manager", "admin"],
+        },
+        {
+          label: "Refunds",
+          href: "/finance/refunds",
+          icon: RotateCcw,
+          roles: ["accountant", "manager", "admin"],
+        },
+        {
+          label: "Overpayments",
+          href: "/finance/overpayments",
+          icon: WalletCards,
+          roles: ["accountant", "manager", "admin"],
         },
       ],
     },

--- a/frontend/src/lib/zod/finance.ts
+++ b/frontend/src/lib/zod/finance.ts
@@ -514,6 +514,9 @@ export const financeDashboardStatsSchema = z.object({
   overdue_amount: z.string(),
   today_collections: z.string(),
   monthly_collections: z.string(),
+  period_collections: z.string(),
+  period_start: z.string().nullable().optional(),
+  period_end: z.string().nullable().optional(),
   pending_overpayments_count: z.number().int().min(0),
   pending_refunds_count: z.number().int().min(0),
 })

--- a/frontend/src/lib/zod/finance.ts
+++ b/frontend/src/lib/zod/finance.ts
@@ -361,7 +361,10 @@ export const overpaymentRecordSchema = z.object({
   refund_request_id: z.number().int().positive().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
-  // [TODO_BACKEND] Add permission flag: can_resolve
+  can_resolve: z.boolean(),
+  can_apply: z.boolean(),
+  can_refund: z.boolean(),
+  can_write_off: z.boolean(),
 })
 
 export type OverpaymentRecord = z.infer<typeof overpaymentRecordSchema>
@@ -387,11 +390,56 @@ export const refundRequestSchema = z.object({
   refund_reference: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),
-  // [TODO_BACKEND] Add: requested_by_name (denormalized)
-  // [TODO_BACKEND] Add permission flags: can_approve, can_reject, can_process
+  can_approve: z.boolean(),
+  can_reject: z.boolean(),
+  can_process: z.boolean(),
 })
 
 export type RefundRequest = z.infer<typeof refundRequestSchema>
+
+export const vietQRResponseSchema = z.object({
+  qr_payload: z.string(),
+  qr_image_base64: z.string(),
+  bank_account: z.object({
+    bank_bin: z.string(),
+    account_number: z.string(),
+    account_name: z.string(),
+  }),
+  amount: z.string(),
+  content: z.string(),
+})
+
+export const debtAgingBucketSchema = z.enum(["0_30", "31_60", "over_60"])
+
+export const debtReportRowSchema = z.object({
+  admission_profile_id: z.number().int().positive(),
+  profile_code: z.string(),
+  profile_name: z.string(),
+  unit_id: z.number().int().positive().nullable(),
+  unit_name: z.string().nullable(),
+  academic_year: z.number().int(),
+  admission_round_id: z.number().int().positive().nullable(),
+  fee_types: z.array(z.string()),
+  invoice_count: z.number().int().min(0),
+  total_expected: z.string(),
+  total_paid: z.string(),
+  total_outstanding: z.string(),
+  days_overdue: z.number().int().min(0),
+  aging_bucket: debtAgingBucketSchema,
+})
+
+export const debtReportResponseSchema = z.object({
+  items: z.array(debtReportRowSchema),
+  summary: z.object({
+    debtor_count: z.number().int().min(0),
+    total_expected: z.string(),
+    total_paid: z.string(),
+    total_outstanding: z.string(),
+    bucket_0_30: z.string(),
+    bucket_31_60: z.string(),
+    bucket_over_60: z.string(),
+  }),
+})
 
 // ==============================================================================
 // ACCOUNTING PERIOD RESPONSE SCHEMAS (from backend AccountingPeriodResponse)

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -261,7 +261,10 @@ export interface OverpaymentRecord {
   refund_request_id: number | null
   created_at: string
   updated_at: string
-  // [TODO_BACKEND] Add permission flag: can_resolve
+  can_resolve: boolean
+  can_apply: boolean
+  can_refund: boolean
+  can_write_off: boolean
 }
 
 // ============================================================================
@@ -284,8 +287,23 @@ export interface RefundRequest {
   refund_reference: string | null
   created_at: string
   updated_at: string
-  // [TODO_BACKEND] Add: requested_by_name (denormalized)
-  // [TODO_BACKEND] Add permission flags: can_approve, can_reject, can_process
+  can_approve: boolean
+  can_reject: boolean
+  can_process: boolean
+}
+
+export interface VietQRBankAccount {
+  bank_bin: string
+  account_number: string
+  account_name: string
+}
+
+export interface VietQRResponse {
+  qr_payload: string
+  qr_image_base64: string
+  bank_account: VietQRBankAccount
+  amount: string
+  content: string
 }
 
 // ============================================================================
@@ -356,6 +374,40 @@ export interface FinanceDashboardStats {
   period_end: string | null
   pending_overpayments_count: number
   pending_refunds_count: number
+}
+
+export type DebtAgingBucket = "0_30" | "31_60" | "over_60"
+
+export interface DebtReportRow {
+  admission_profile_id: number
+  profile_code: string
+  profile_name: string
+  unit_id: number | null
+  unit_name: string | null
+  academic_year: number
+  admission_round_id: number | null
+  fee_types: string[]
+  invoice_count: number
+  total_expected: string
+  total_paid: string
+  total_outstanding: string
+  days_overdue: number
+  aging_bucket: DebtAgingBucket
+}
+
+export interface DebtReportSummary {
+  debtor_count: number
+  total_expected: string
+  total_paid: string
+  total_outstanding: string
+  bucket_0_30: string
+  bucket_31_60: string
+  bucket_over_60: string
+}
+
+export interface DebtReportResponse {
+  items: DebtReportRow[]
+  summary: DebtReportSummary
 }
 
 // ============================================================================
@@ -676,6 +728,28 @@ export interface PaymentFilters {
   invoice_id?: number
   status?: PaymentStatus
   method_id?: number
+  page?: number
+  page_size?: number
+}
+
+export interface DebtReportFilters {
+  unit_id?: number
+  academic_year?: number
+  round_id?: number
+  fee_type?: FeeType
+  aging?: DebtAgingBucket
+}
+
+export interface RefundFilters {
+  payment_id?: number
+  status?: RefundStatus
+  page?: number
+  page_size?: number
+}
+
+export interface OverpaymentFilters {
+  profile_id?: number
+  status?: OverpaymentStatus
   page?: number
   page_size?: number
 }


### PR DESCRIPTION
## Finance Phase 1 (3 commits)

VietQR động · Báo cáo công nợ (grain hồ sơ×năm) · Un-defer Refunds + Overpayment + 2 vòng hardening review.

### Commits
- `3354bc36` feat: VietQR (EMVCo+CRC, PoI dynamic) · debt-report · refunds/overpayments routers+services · Casbin policy+migration · thin-client can_* flags
- `344a5de6` fix: hardening v1 (manager refund guard, double-refund reserve, VietQR/apply status gates, overpayment-keeps-pending-until-refund-done, FOR UPDATE overpayment, debt excludes draft)
- `9af24f7a` fix: hardening v2 (refund concurrency locks, IDOR null-unit scope, accounting gates) — xử lý /code-review

### Điểm chính vòng v2 (concurrency + authz + accounting)
- **Race**: `request_refund` SELECT FOR UPDATE Payment trước reserve; approve/reject/process FOR UPDATE RefundRequest + re-check status (double-process → 400, balance không đổi).
- **IDOR**: `finance_scope_unit_id()` — non-admin không có unit → 403 (hết leak all-units).
- **Officer** gỡ khỏi tạo refund (Casbin-only accountant+admin).
- Debt report grain (profile, academic_year) + chỉ PAYABLE; full refund → invoice 'issued'; VietQR amount quantize whole VND; `PAYABLE_INVOICE_STATUSES` gộp 1 hằng.
- FE: CSV formula-injection guard, 422 message, useProcessRefund invalidate overpayments, zod runtime-parse debt-report/VietQR.

### Kiểm thử
- BE one-off: **41 passed** (race double-process, reserve, F4 lifecycle, F5, casbin route cross-check, vietqr). flake8 0 lỗi mới. FE type-check clean. Chrome smoke: VietQR/debt-report/refund lifecycle/overpayment + re-smoke v2 (IDOR/amount/zod-parse) PASS.

### Defer có chủ đích
- REFUND_PROCESSED notification rule (fail-closed an toàn; cần full notification CI suite).
- Debt-report SQL-aggregate pagination (efficiency; scale hiện nhỏ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)