### PR TITLE
i18n+fix(finance): Việt hóa toàn bộ UI finance + thu lệ phí mã biên lai gợi ý

### DIFF
--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/ApplicationFeeCollectionPanel.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/ApplicationFeeCollectionPanel.tsx
@@ -30,6 +30,15 @@ interface ApplicationFeeCollectionPanelProps {
 const RECEIPT_MIN_LENGTH = 6
 const RECEIPT_MAX_LENGTH = 80
 
+function suggestReceiptCode(profileId: number): string {
+  // Pre-fill an editable default so the officer isn't stuck on a blank,
+  // required field ("không biết nhập gì"). Unique per (hồ sơ, ngày) → thỏa
+  // ràng buộc chống trùng biên lai của backend. Officer giữ nguyên khi thu
+  // tiền mặt tại quầy, hoặc thay bằng số phiếu thu giấy thực tế.
+  const today = new Date().toISOString().slice(0, 10).replace(/-/g, "")
+  return `PT-${profileId}-${today}`
+}
+
 export function ApplicationFeeCollectionPanel({
   profile,
 }: ApplicationFeeCollectionPanelProps) {
@@ -169,7 +178,9 @@ function ApplicationFeePaymentDialog({
   profileId: number
   onOpenChange: (open: boolean) => void
 }) {
-  const [transactionId, setTransactionId] = useState("")
+  const [transactionId, setTransactionId] = useState(() =>
+    suggestReceiptCode(profileId),
+  )
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const mutation = useRecordApplicationFeePayment(profileId)
   const trimmedTransactionId = transactionId.trim()
@@ -235,11 +246,17 @@ function ApplicationFeePaymentDialog({
               id="application_fee_receipt"
               value={transactionId}
               onChange={(event) => setTransactionId(event.target.value)}
+              onFocus={(event) => event.target.select()}
               minLength={RECEIPT_MIN_LENGTH}
               maxLength={RECEIPT_MAX_LENGTH}
+              placeholder="VD: số phiếu thu giấy — hoặc giữ mã gợi ý"
               disabled={isPending}
               autoFocus
             />
+            <p className="text-xs text-muted-foreground">
+              Số biên lai/phiếu thu giấy (nếu có). Đã điền sẵn mã gợi ý duy nhất —
+              giữ nguyên hoặc thay bằng số biên lai thực tế (6–80 ký tự).
+            </p>
           </div>
 
           <div className="space-y-2">

--- a/frontend/src/app/(dashboard)/finance/_components/FinanceDashboardClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/_components/FinanceDashboardClient.tsx
@@ -158,7 +158,7 @@ function FinanceDashboardInner() {
       <div className="flex flex-col gap-4">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">Finance Dashboard</h1>
+            <h1 className="text-2xl font-bold tracking-tight">Tổng quan tài chính</h1>
             <p className="text-muted-foreground">
               Quản lý học phí, hóa đơn và thanh toán
             </p>

--- a/frontend/src/app/(dashboard)/finance/debt-report/_components/DebtReportClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/debt-report/_components/DebtReportClient.tsx
@@ -102,10 +102,10 @@ export function DebtReportClient() {
         <Card className="border-destructive">
           <CardContent className="p-6 text-center">
             <AlertTriangle className="mx-auto mb-2 h-8 w-8 text-destructive" />
-            <p className="font-medium text-destructive">Khong the tai bao cao cong no</p>
+            <p className="font-medium text-destructive">Không thể tải báo cáo công nợ</p>
             <Button variant="outline" className="mt-4" onClick={() => refetch()}>
               <RefreshCw className="mr-2 h-4 w-4" />
-              Thu lai
+              Thử lại
             </Button>
           </CardContent>
         </Card>
@@ -117,13 +117,13 @@ export function DebtReportClient() {
     <div className="p-4 sm:p-6 space-y-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Bao cao cong no</h1>
-          <p className="text-muted-foreground">Tong hop theo ho so tuyen sinh</p>
+          <h1 className="text-2xl font-bold tracking-tight">Báo cáo công nợ</h1>
+          <p className="text-muted-foreground">Tổng hợp theo hồ sơ tuyển sinh</p>
         </div>
         <div className="flex gap-2">
           <Button variant="outline" onClick={() => refetch()}>
             <RefreshCw className="mr-2 h-4 w-4" />
-            Lam moi
+            Làm mới
           </Button>
           <Button variant="outline" onClick={exportCsv} disabled={!data?.items?.length}>
             <Download className="mr-2 h-4 w-4" />
@@ -133,55 +133,55 @@ export function DebtReportClient() {
       </div>
 
       <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
-        <SummaryCard title="Ho so no" value={data?.summary.debtor_count ?? 0} />
-        <SummaryCard title="Du thu" amount={data?.summary.total_expected ?? "0"} />
-        <SummaryCard title="Da thu" amount={data?.summary.total_paid ?? "0"} />
-        <SummaryCard title="Con lai" amount={data?.summary.total_outstanding ?? "0"} emphasis />
+        <SummaryCard title="Hồ sơ nợ" value={data?.summary.debtor_count ?? 0} />
+        <SummaryCard title="Dự thu" amount={data?.summary.total_expected ?? "0"} />
+        <SummaryCard title="Đã thu" amount={data?.summary.total_paid ?? "0"} />
+        <SummaryCard title="Còn lại" amount={data?.summary.total_outstanding ?? "0"} emphasis />
       </div>
 
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-lg">
             <Filter className="h-5 w-5" />
-            Bo loc
+            Bộ lọc
           </CardTitle>
         </CardHeader>
         <CardContent className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
           <Input
             inputMode="numeric"
-            placeholder="Nam hoc"
+            placeholder="Năm học"
             value={academicYear}
             onChange={(event) => setAcademicYear(event.target.value.replace(/\D/g, ""))}
           />
           <Input
             inputMode="numeric"
-            placeholder="Dot tuyen sinh"
+            placeholder="Đợt tuyển sinh"
             value={roundId}
             onChange={(event) => setRoundId(event.target.value.replace(/\D/g, ""))}
           />
           <Select value={feeType} onValueChange={(value) => setFeeType(value as FeeType | "all")}>
             <SelectTrigger>
-              <SelectValue placeholder="Loai phi" />
+              <SelectValue placeholder="Loại phí" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">Tat ca phi</SelectItem>
-              <SelectItem value="application">Xet tuyen</SelectItem>
-              <SelectItem value="tuition">Hoc phi</SelectItem>
-              <SelectItem value="enrollment">Nhap hoc</SelectItem>
-              <SelectItem value="insurance">Bao hiem</SelectItem>
-              <SelectItem value="dormitory">Ky tuc xa</SelectItem>
-              <SelectItem value="other">Khac</SelectItem>
+              <SelectItem value="all">Tất cả phí</SelectItem>
+              <SelectItem value="application">Xét tuyển</SelectItem>
+              <SelectItem value="tuition">Học phí</SelectItem>
+              <SelectItem value="enrollment">Nhập học</SelectItem>
+              <SelectItem value="insurance">Bảo hiểm</SelectItem>
+              <SelectItem value="dormitory">Ký túc xá</SelectItem>
+              <SelectItem value="other">Khác</SelectItem>
             </SelectContent>
           </Select>
           <Select value={aging} onValueChange={(value) => setAging(value as DebtAgingBucket | "all")}>
             <SelectTrigger>
-              <SelectValue placeholder="Tuoi no" />
+              <SelectValue placeholder="Tuổi nợ" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">Tat ca tuoi no</SelectItem>
-              <SelectItem value="0_30">0-30 ngay</SelectItem>
-              <SelectItem value="31_60">31-60 ngay</SelectItem>
-              <SelectItem value="over_60">Tren 60 ngay</SelectItem>
+              <SelectItem value="all">Tất cả tuổi nợ</SelectItem>
+              <SelectItem value="0_30">0-30 ngày</SelectItem>
+              <SelectItem value="31_60">31-60 ngày</SelectItem>
+              <SelectItem value="over_60">Trên 60 ngày</SelectItem>
             </SelectContent>
           </Select>
         </CardContent>
@@ -192,19 +192,19 @@ export function DebtReportClient() {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Ho so</TableHead>
-                <TableHead>Don vi</TableHead>
-                <TableHead>Loai phi</TableHead>
-                <TableHead className="text-right">Con lai</TableHead>
-                <TableHead className="text-right">Ngay qua han</TableHead>
-                <TableHead>Bucket</TableHead>
+                <TableHead>Hồ sơ</TableHead>
+                <TableHead>Đơn vị</TableHead>
+                <TableHead>Loại phí</TableHead>
+                <TableHead className="text-right">Còn lại</TableHead>
+                <TableHead className="text-right">Ngày quá hạn</TableHead>
+                <TableHead>Nhóm tuổi nợ</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {isLoading ? (
                 <TableRow>
                   <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
-                    Dang tai...
+                    Đang tải...
                   </TableCell>
                 </TableRow>
               ) : data?.items.length ? (
@@ -230,7 +230,7 @@ export function DebtReportClient() {
               ) : (
                 <TableRow>
                   <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
-                    Khong co du lieu
+                    Không có dữ liệu
                   </TableCell>
                 </TableRow>
               )}

--- a/frontend/src/app/(dashboard)/finance/fees/_components/FeeCalculateDialog.tsx
+++ b/frontend/src/app/(dashboard)/finance/fees/_components/FeeCalculateDialog.tsx
@@ -174,7 +174,7 @@ export function FeeCalculateDialog({
                     />
                   </FormControl>
                   <FormDescription>
-                    ID của hồ sơ tuyển sinh đã được duyệt (approved)
+                    ID của hồ sơ tuyển sinh đã được duyệt
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/frontend/src/app/(dashboard)/finance/overpayments/_components/OverpaymentListClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/overpayments/_components/OverpaymentListClient.tsx
@@ -40,10 +40,10 @@ import {
 import type { OverpaymentRecord, OverpaymentStatus } from "@/types/finance.types"
 
 const STATUS_LABELS: Record<OverpaymentStatus, string> = {
-  pending: "Cho xu ly",
-  applied: "Da ap dung",
-  refunded: "Da hoan",
-  cancelled: "Da xoa so",
+  pending: "Chờ xử lý",
+  applied: "Đã áp dụng",
+  refunded: "Đã hoàn",
+  cancelled: "Đã xóa sổ",
 }
 
 type ActionState =
@@ -119,10 +119,10 @@ export function OverpaymentListClient() {
         <Card className="border-destructive">
           <CardContent className="p-6 text-center">
             <AlertTriangle className="mx-auto mb-2 h-8 w-8 text-destructive" />
-            <p className="font-medium text-destructive">Khong the tai danh sach tien thua</p>
+            <p className="font-medium text-destructive">Không thể tải danh sách tiền nộp thừa</p>
             <Button variant="outline" className="mt-4" onClick={() => refetch()}>
               <RefreshCw className="mr-2 h-4 w-4" />
-              Thu lai
+              Thử lại
             </Button>
           </CardContent>
         </Card>
@@ -134,26 +134,26 @@ export function OverpaymentListClient() {
     <div className="p-4 sm:p-6 space-y-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Tien thua</h1>
-          <p className="text-muted-foreground">Xu ly cac khoan overpayment dang treo</p>
+          <h1 className="text-2xl font-bold tracking-tight">Tiền nộp thừa</h1>
+          <p className="text-muted-foreground">Xử lý các khoản tiền nộp thừa đang treo</p>
         </div>
         <Button variant="outline" onClick={() => refetch()}>
           <RefreshCw className="mr-2 h-4 w-4" />
-          Lam moi
+          Làm mới
         </Button>
       </div>
 
       <div className="flex max-w-xs">
         <Select value={statusFilter} onValueChange={(value) => setStatusFilter(value as OverpaymentStatus | "all")}>
           <SelectTrigger>
-            <SelectValue placeholder="Trang thai" />
+            <SelectValue placeholder="Trạng thái" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="pending">Cho xu ly</SelectItem>
-            <SelectItem value="all">Tat ca</SelectItem>
-            <SelectItem value="applied">Da ap dung</SelectItem>
-            <SelectItem value="refunded">Da hoan</SelectItem>
-            <SelectItem value="cancelled">Da xoa so</SelectItem>
+            <SelectItem value="pending">Chờ xử lý</SelectItem>
+            <SelectItem value="all">Tất cả</SelectItem>
+            <SelectItem value="applied">Đã áp dụng</SelectItem>
+            <SelectItem value="refunded">Đã hoàn</SelectItem>
+            <SelectItem value="cancelled">Đã xóa sổ</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -163,19 +163,19 @@ export function OverpaymentListClient() {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Overpayment</TableHead>
-                <TableHead>Ho so</TableHead>
-                <TableHead>Invoice</TableHead>
-                <TableHead className="text-right">So tien</TableHead>
-                <TableHead>Trang thai</TableHead>
-                <TableHead className="text-right">Thao tac</TableHead>
+                <TableHead>Khoản nộp thừa</TableHead>
+                <TableHead>Hồ sơ</TableHead>
+                <TableHead>Hóa đơn</TableHead>
+                <TableHead className="text-right">Số tiền</TableHead>
+                <TableHead>Trạng thái</TableHead>
+                <TableHead className="text-right">Thao tác</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {isLoading ? (
                 <TableRow>
                   <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
-                    Dang tai...
+                    Đang tải...
                   </TableCell>
                 </TableRow>
               ) : data?.items.length ? (
@@ -197,19 +197,19 @@ export function OverpaymentListClient() {
                         {overpayment.can_apply && (
                           <Button size="sm" variant="outline" onClick={() => setAction({ type: "apply", overpayment })}>
                             <CheckCircle className="mr-2 h-4 w-4" />
-                            Ap dung
+                            Áp dụng
                           </Button>
                         )}
                         {overpayment.can_refund && (
                           <Button size="sm" variant="outline" onClick={() => setAction({ type: "refund", overpayment })}>
                             <RotateCcw className="mr-2 h-4 w-4" />
-                            Hoan
+                            Hoàn tiền
                           </Button>
                         )}
                         {overpayment.can_write_off && (
                           <Button size="sm" variant="outline" onClick={() => setAction({ type: "write_off", overpayment })}>
                             <XCircle className="mr-2 h-4 w-4" />
-                            Xoa so
+                            Xóa sổ
                           </Button>
                         )}
                       </div>
@@ -219,7 +219,7 @@ export function OverpaymentListClient() {
               ) : (
                 <TableRow>
                   <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
-                    Khong co du lieu
+                    Không có dữ liệu
                   </TableCell>
                 </TableRow>
               )}
@@ -231,17 +231,17 @@ export function OverpaymentListClient() {
       <Dialog open={action?.type === "apply"} onOpenChange={(open) => !open && closeAction()}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Ap dung tien thua</DialogTitle>
+            <DialogTitle>Áp dụng tiền nộp thừa</DialogTitle>
           </DialogHeader>
           <div className="space-y-3">
-            <Field label="Invoice dich">
+            <Field label="Hóa đơn đích">
               <Input
                 inputMode="numeric"
                 value={targetInvoiceId}
                 onChange={(event) => setTargetInvoiceId(event.target.value.replace(/\D/g, ""))}
               />
             </Field>
-            <Field label="So tien">
+            <Field label="Số tiền">
               <Input
                 inputMode="decimal"
                 placeholder={action?.type === "apply" ? action.overpayment.overpayment_amount : undefined}
@@ -249,14 +249,14 @@ export function OverpaymentListClient() {
                 onChange={(event) => setAmount(event.target.value)}
               />
             </Field>
-            <Field label="Ghi chu">
+            <Field label="Ghi chú">
               <Textarea value={notes} onChange={(event) => setNotes(event.target.value)} />
             </Field>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={closeAction}>Huy</Button>
+            <Button variant="outline" onClick={closeAction}>Hủy</Button>
             <Button onClick={handleApply} disabled={!targetInvoiceId || applyOverpayment.isPending}>
-              Ap dung
+              Áp dụng
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -265,15 +265,15 @@ export function OverpaymentListClient() {
       <Dialog open={action?.type === "refund"} onOpenChange={(open) => !open && closeAction()}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Tao yeu cau hoan tien thua</DialogTitle>
+            <DialogTitle>Tạo yêu cầu hoàn tiền nộp thừa</DialogTitle>
           </DialogHeader>
-          <Field label="Ghi chu">
+          <Field label="Ghi chú">
             <Textarea value={notes} onChange={(event) => setNotes(event.target.value)} />
           </Field>
           <DialogFooter>
-            <Button variant="outline" onClick={closeAction}>Huy</Button>
+            <Button variant="outline" onClick={closeAction}>Hủy</Button>
             <Button onClick={handleRefund} disabled={refundOverpayment.isPending}>
-              Tao yeu cau
+              Tạo yêu cầu
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -282,15 +282,15 @@ export function OverpaymentListClient() {
       <Dialog open={action?.type === "write_off"} onOpenChange={(open) => !open && closeAction()}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Xoa so tien thua</DialogTitle>
+            <DialogTitle>Xóa sổ tiền nộp thừa</DialogTitle>
           </DialogHeader>
-          <Field label="Ly do">
+          <Field label="Lý do">
             <Textarea value={notes} onChange={(event) => setNotes(event.target.value)} />
           </Field>
           <DialogFooter>
-            <Button variant="outline" onClick={closeAction}>Huy</Button>
+            <Button variant="outline" onClick={closeAction}>Hủy</Button>
             <Button variant="destructive" onClick={handleWriteOff} disabled={!notes || writeOffOverpayment.isPending}>
-              Xoa so
+              Xóa sổ
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/app/(dashboard)/finance/payments/return/_components/PaymentReturnClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/return/_components/PaymentReturnClient.tsx
@@ -256,7 +256,7 @@ export function PaymentReturnClient() {
               <Button variant="outline" className="flex-1" asChild>
                 <Link href="/finance">
                   <ArrowLeft className="h-4 w-4 mr-2" />
-                  Về Finance
+                  Về Tài chính
                 </Link>
               </Button>
             )}

--- a/frontend/src/app/(dashboard)/finance/payments/return/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/return/page.tsx
@@ -4,8 +4,8 @@ import { PaymentReturnClient } from "./_components/PaymentReturnClient"
 import { Skeleton } from "@/components/ui/skeleton"
 
 export const metadata = {
-  title: "Kết quả thanh toán - Finance",
-  description: "Kết quả thanh toán online",
+  title: "Kết quả thanh toán - Tài chính",
+  description: "Kết quả thanh toán trực tuyến",
 }
 
 /**

--- a/frontend/src/app/(dashboard)/finance/refunds/_components/RefundListClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/refunds/_components/RefundListClient.tsx
@@ -41,10 +41,10 @@ import {
 import type { RefundRequest, RefundStatus } from "@/types/finance.types"
 
 const STATUS_LABELS: Record<RefundStatus, string> = {
-  pending: "Cho duyet",
-  approved: "Da duyet",
-  rejected: "Tu choi",
-  refunded: "Da hoan",
+  pending: "Chờ duyệt",
+  approved: "Đã duyệt",
+  rejected: "Từ chối",
+  refunded: "Đã hoàn",
 }
 
 export function RefundListClient() {
@@ -101,10 +101,10 @@ export function RefundListClient() {
         <Card className="border-destructive">
           <CardContent className="p-6 text-center">
             <AlertTriangle className="mx-auto mb-2 h-8 w-8 text-destructive" />
-            <p className="font-medium text-destructive">Khong the tai danh sach hoan phi</p>
+            <p className="font-medium text-destructive">Không thể tải danh sách hoàn phí</p>
             <Button variant="outline" className="mt-4" onClick={() => refetch()}>
               <RefreshCw className="mr-2 h-4 w-4" />
-              Thu lai
+              Thử lại
             </Button>
           </CardContent>
         </Card>
@@ -116,18 +116,18 @@ export function RefundListClient() {
     <div className="p-4 sm:p-6 space-y-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Hoan phi</h1>
-          <p className="text-muted-foreground">Yeu cau, phe duyet va xu ly hoan phi</p>
+          <h1 className="text-2xl font-bold tracking-tight">Hoàn phí</h1>
+          <p className="text-muted-foreground">Yêu cầu, phê duyệt và xử lý hoàn phí</p>
         </div>
         <div className="flex gap-2">
           <Button variant="outline" onClick={() => refetch()}>
             <RefreshCw className="mr-2 h-4 w-4" />
-            Lam moi
+            Làm mới
           </Button>
           {data?.can_create && (
             <Button onClick={() => setCreateOpen(true)}>
               <Plus className="mr-2 h-4 w-4" />
-              Tao yeu cau
+              Tạo yêu cầu
             </Button>
           )}
         </div>
@@ -136,14 +136,14 @@ export function RefundListClient() {
       <div className="flex max-w-xs">
         <Select value={statusFilter} onValueChange={(value) => setStatusFilter(value as RefundStatus | "all")}>
           <SelectTrigger>
-            <SelectValue placeholder="Trang thai" />
+            <SelectValue placeholder="Trạng thái" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="pending">Cho duyet</SelectItem>
-            <SelectItem value="all">Tat ca</SelectItem>
-            <SelectItem value="approved">Da duyet</SelectItem>
-            <SelectItem value="rejected">Tu choi</SelectItem>
-            <SelectItem value="refunded">Da hoan</SelectItem>
+            <SelectItem value="pending">Chờ duyệt</SelectItem>
+            <SelectItem value="all">Tất cả</SelectItem>
+            <SelectItem value="approved">Đã duyệt</SelectItem>
+            <SelectItem value="rejected">Từ chối</SelectItem>
+            <SelectItem value="refunded">Đã hoàn</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -153,19 +153,19 @@ export function RefundListClient() {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Refund</TableHead>
-                <TableHead>Payment</TableHead>
-                <TableHead className="text-right">So tien</TableHead>
-                <TableHead>Trang thai</TableHead>
-                <TableHead>Ngay tao</TableHead>
-                <TableHead className="text-right">Thao tac</TableHead>
+                <TableHead>Hoàn phí</TableHead>
+                <TableHead>Thanh toán</TableHead>
+                <TableHead className="text-right">Số tiền</TableHead>
+                <TableHead>Trạng thái</TableHead>
+                <TableHead>Ngày tạo</TableHead>
+                <TableHead className="text-right">Thao tác</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {isLoading ? (
                 <TableRow>
                   <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
-                    Dang tai...
+                    Đang tải...
                   </TableCell>
                 </TableRow>
               ) : data?.items.length ? (
@@ -190,7 +190,7 @@ export function RefundListClient() {
                         {refund.can_approve && (
                           <Button size="sm" variant="outline" onClick={() => approveRefund.mutate(refund.id)}>
                             <CheckCircle className="mr-2 h-4 w-4" />
-                            Duyet
+                            Duyệt
                           </Button>
                         )}
                         {refund.can_reject && (
@@ -200,13 +200,13 @@ export function RefundListClient() {
                             onClick={() => setAction({ type: "reject", refund })}
                           >
                             <XCircle className="mr-2 h-4 w-4" />
-                            Tu choi
+                            Từ chối
                           </Button>
                         )}
                         {refund.can_process && (
                           <Button size="sm" onClick={() => setAction({ type: "process", refund })}>
                             <RotateCcw className="mr-2 h-4 w-4" />
-                            Xu ly
+                            Xử lý
                           </Button>
                         )}
                       </div>
@@ -216,7 +216,7 @@ export function RefundListClient() {
               ) : (
                 <TableRow>
                   <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
-                    Khong co du lieu
+                    Không có dữ liệu
                   </TableCell>
                 </TableRow>
               )}
@@ -228,24 +228,24 @@ export function RefundListClient() {
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Tao yeu cau hoan phi</DialogTitle>
+            <DialogTitle>Tạo yêu cầu hoàn phí</DialogTitle>
           </DialogHeader>
           <div className="space-y-3">
-            <Field label="Payment ID">
+            <Field label="Mã thanh toán">
               <Input
                 inputMode="numeric"
                 value={createForm.payment_id}
                 onChange={(event) => setCreateForm((prev) => ({ ...prev, payment_id: event.target.value.replace(/\D/g, "") }))}
               />
             </Field>
-            <Field label="So tien">
+            <Field label="Số tiền">
               <Input
                 inputMode="decimal"
                 value={createForm.amount}
                 onChange={(event) => setCreateForm((prev) => ({ ...prev, amount: event.target.value }))}
               />
             </Field>
-            <Field label="Ly do">
+            <Field label="Lý do">
               <Textarea
                 value={createForm.reason}
                 onChange={(event) => setCreateForm((prev) => ({ ...prev, reason: event.target.value }))}
@@ -253,12 +253,12 @@ export function RefundListClient() {
             </Field>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setCreateOpen(false)}>Huy</Button>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>Hủy</Button>
             <Button
               onClick={handleCreate}
               disabled={!createForm.payment_id || !createForm.amount || !createForm.reason || createRefund.isPending}
             >
-              Tao
+              Tạo
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -267,13 +267,13 @@ export function RefundListClient() {
       <Dialog open={action?.type === "reject"} onOpenChange={(open) => !open && setAction(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Tu choi hoan phi</DialogTitle>
+            <DialogTitle>Từ chối hoàn phí</DialogTitle>
           </DialogHeader>
           <Textarea value={rejectionReason} onChange={(event) => setRejectionReason(event.target.value)} />
           <DialogFooter>
-            <Button variant="outline" onClick={() => setAction(null)}>Huy</Button>
+            <Button variant="outline" onClick={() => setAction(null)}>Hủy</Button>
             <Button variant="destructive" onClick={handleReject} disabled={!rejectionReason || rejectRefund.isPending}>
-              Tu choi
+              Từ chối
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -282,15 +282,15 @@ export function RefundListClient() {
       <Dialog open={action?.type === "process"} onOpenChange={(open) => !open && setAction(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Xu ly hoan phi</DialogTitle>
+            <DialogTitle>Xử lý hoàn phí</DialogTitle>
           </DialogHeader>
-          <Field label="Ma tham chieu">
+          <Field label="Mã tham chiếu">
             <Input value={refundReference} onChange={(event) => setRefundReference(event.target.value)} />
           </Field>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setAction(null)}>Huy</Button>
+            <Button variant="outline" onClick={() => setAction(null)}>Hủy</Button>
             <Button onClick={handleProcess} disabled={!refundReference || processRefund.isPending}>
-              Xu ly
+              Xử lý
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/components/finance/PaymentMethodSelect.tsx
+++ b/frontend/src/components/finance/PaymentMethodSelect.tsx
@@ -170,7 +170,7 @@ export function PaymentMethodSelect({
                   {option.is_online ? (
                     <>
                       <Wifi className="h-3 w-3 mr-1" />
-                      Online
+                      Trực tuyến
                     </>
                   ) : (
                     <>

--- a/frontend/src/components/finance/VietQRDisplay.tsx
+++ b/frontend/src/components/finance/VietQRDisplay.tsx
@@ -19,7 +19,7 @@ interface VietQRDisplayProps {
 export function VietQRDisplay({ data, isLoading, error, onRetry }: VietQRDisplayProps) {
   const copy = React.useCallback(async (value: string, label: string) => {
     await navigator.clipboard.writeText(value)
-    toast.success(`Da copy ${label}`)
+    toast.success(`Đã sao chép ${label}`)
   }, [])
 
   return (
@@ -27,7 +27,7 @@ export function VietQRDisplay({ data, isLoading, error, onRetry }: VietQRDisplay
       <CardHeader>
         <CardTitle className="text-lg flex items-center gap-2">
           <QrCode className="h-5 w-5" />
-          Chuyen khoan VietQR
+          Chuyển khoản VietQR
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -39,10 +39,10 @@ export function VietQRDisplay({ data, isLoading, error, onRetry }: VietQRDisplay
           </>
         ) : error ? (
           <div className="space-y-3 text-sm text-muted-foreground">
-            <p>Chua the hien thi ma QR.</p>
+            <p>Chưa thể hiển thị mã QR.</p>
             {onRetry && (
               <Button variant="outline" size="sm" onClick={onRetry}>
-                Thu lai
+                Thử lại
               </Button>
             )}
           </div>
@@ -57,20 +57,20 @@ export function VietQRDisplay({ data, isLoading, error, onRetry }: VietQRDisplay
             </div>
             <div className="space-y-2 text-sm">
               <InfoRow
-                label="So tien"
+                label="Số tiền"
                 value={<AmountDisplay amount={data.amount} showCurrency size="sm" />}
               />
               <CopyRow
-                label="So tai khoan"
+                label="Số tài khoản"
                 value={data.bank_account.account_number}
-                onCopy={() => copy(data.bank_account.account_number, "so tai khoan")}
+                onCopy={() => copy(data.bank_account.account_number, "số tài khoản")}
               />
-              <InfoRow label="Ten tai khoan" value={data.bank_account.account_name} />
+              <InfoRow label="Tên tài khoản" value={data.bank_account.account_name} />
               <CopyRow
-                label="Noi dung"
+                label="Nội dung"
                 value={data.content}
                 mono
-                onCopy={() => copy(data.content, "noi dung")}
+                onCopy={() => copy(data.content, "nội dung")}
               />
             </div>
           </>
@@ -109,7 +109,7 @@ function CopyRow({
         </span>
         <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={onCopy}>
           <Copy className="h-3.5 w-3.5" />
-          <span className="sr-only">Copy {label}</span>
+          <span className="sr-only">Sao chép {label}</span>
         </Button>
       </div>
     </div>

--- a/frontend/src/hooks/finance/useOverpayments.ts
+++ b/frontend/src/hooks/finance/useOverpayments.ts
@@ -48,13 +48,13 @@ export function useApplyOverpayment() {
   >({
     mutationFn: ({ id, data }) => overpaymentsApi.applyOverpayment(id, data),
     onSuccess: (overpayment) => {
-      toast.success("Da ap dung tien thua")
+      toast.success("Đã áp dụng tiền nộp thừa")
       queryClient.invalidateQueries({ queryKey: overpaymentsKeys.lists() })
       queryClient.invalidateQueries({ queryKey: overpaymentsKeys.detail(overpayment.id) })
       queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
     },
     onError: (error) => {
-      toast.error(getErrorMessage(error, "Khong the ap dung tien thua"))
+      toast.error(getErrorMessage(error, "Không thể áp dụng tiền nộp thừa"))
     },
   })
 }
@@ -68,13 +68,13 @@ export function useRefundOverpayment() {
   >({
     mutationFn: ({ id, data }) => overpaymentsApi.refundOverpayment(id, data),
     onSuccess: (overpayment) => {
-      toast.success("Da tao yeu cau hoan tien thua")
+      toast.success("Đã tạo yêu cầu hoàn tiền nộp thừa")
       queryClient.invalidateQueries({ queryKey: overpaymentsKeys.lists() })
       queryClient.invalidateQueries({ queryKey: overpaymentsKeys.detail(overpayment.id) })
       queryClient.invalidateQueries({ queryKey: ["refunds"] })
     },
     onError: (error) => {
-      toast.error(getErrorMessage(error, "Khong the tao yeu cau hoan tien thua"))
+      toast.error(getErrorMessage(error, "Không thể tạo yêu cầu hoàn tiền nộp thừa"))
     },
   })
 }
@@ -88,13 +88,13 @@ export function useWriteOffOverpayment() {
   >({
     mutationFn: ({ id, data }) => overpaymentsApi.writeOffOverpayment(id, data),
     onSuccess: (overpayment) => {
-      toast.success("Da xoa so tien thua")
+      toast.success("Đã xóa sổ tiền nộp thừa")
       queryClient.invalidateQueries({ queryKey: overpaymentsKeys.lists() })
       queryClient.invalidateQueries({ queryKey: overpaymentsKeys.detail(overpayment.id) })
       queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
     },
     onError: (error) => {
-      toast.error(getErrorMessage(error, "Khong the xoa so tien thua"))
+      toast.error(getErrorMessage(error, "Không thể xóa sổ tiền nộp thừa"))
     },
   })
 }

--- a/frontend/src/hooks/finance/useRefunds.ts
+++ b/frontend/src/hooks/finance/useRefunds.ts
@@ -51,12 +51,12 @@ export function useCreateRefund() {
   return useMutation<RefundRequest, AxiosError<ApiErrorResponse>, RefundCreateRequest>({
     mutationFn: refundsApi.createRefund,
     onSuccess: () => {
-      toast.success("Da tao yeu cau hoan phi")
+      toast.success("Đã tạo yêu cầu hoàn phí")
       queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
       queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
     },
     onError: (error) => {
-      toast.error(getErrorMessage(error, "Khong the tao yeu cau hoan phi"))
+      toast.error(getErrorMessage(error, "Không thể tạo yêu cầu hoàn phí"))
     },
   })
 }
@@ -66,12 +66,12 @@ export function useApproveRefund() {
   return useMutation<RefundRequest, AxiosError<ApiErrorResponse>, number>({
     mutationFn: refundsApi.approveRefund,
     onSuccess: (refund) => {
-      toast.success("Da phe duyet hoan phi")
+      toast.success("Đã phê duyệt hoàn phí")
       queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
       queryClient.invalidateQueries({ queryKey: refundsKeys.detail(refund.id) })
     },
     onError: (error) => {
-      toast.error(getErrorMessage(error, "Khong the phe duyet hoan phi"))
+      toast.error(getErrorMessage(error, "Không thể phê duyệt hoàn phí"))
     },
   })
 }
@@ -85,12 +85,12 @@ export function useRejectRefund() {
   >({
     mutationFn: ({ id, data }) => refundsApi.rejectRefund(id, data),
     onSuccess: (refund) => {
-      toast.success("Da tu choi hoan phi")
+      toast.success("Đã từ chối hoàn phí")
       queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
       queryClient.invalidateQueries({ queryKey: refundsKeys.detail(refund.id) })
     },
     onError: (error) => {
-      toast.error(getErrorMessage(error, "Khong the tu choi hoan phi"))
+      toast.error(getErrorMessage(error, "Không thể từ chối hoàn phí"))
     },
   })
 }
@@ -104,7 +104,7 @@ export function useProcessRefund() {
   >({
     mutationFn: ({ id, data }) => refundsApi.processRefund(id, data),
     onSuccess: (refund) => {
-      toast.success("Da xu ly hoan phi")
+      toast.success("Đã xử lý hoàn phí")
       queryClient.invalidateQueries({ queryKey: refundsKeys.lists() })
       queryClient.invalidateQueries({ queryKey: refundsKeys.detail(refund.id) })
       queryClient.invalidateQueries({ queryKey: ["finance", "dashboard"] })
@@ -113,7 +113,7 @@ export function useProcessRefund() {
       queryClient.invalidateQueries({ queryKey: ["overpayments"] })
     },
     onError: (error) => {
-      toast.error(getErrorMessage(error, "Khong the xu ly hoan phi"))
+      toast.error(getErrorMessage(error, "Không thể xử lý hoàn phí"))
     },
   })
 }

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -147,7 +147,7 @@ export const navigationConfig: NavigationConfig = {
       title: "Finance",
       items: [
         {
-          label: "Finance Dashboard",
+          label: "Tổng quan tài chính",
           href: "/finance",
           icon: DollarSign,
           roles: ["accountant", "manager", "admin"],
@@ -161,38 +161,38 @@ export const navigationConfig: NavigationConfig = {
           ],
         },
         {
-          label: "Fees",
+          label: "Khoản phí",
           href: "/finance/fees",
           icon: Calculator,
           roles: ["accountant", "manager", "admin"],
         },
         {
-          label: "Invoices",
+          label: "Hóa đơn",
           href: "/finance/invoices",
           icon: Receipt,
           roles: ["accountant", "manager", "admin"],
         },
         {
-          label: "Pending Payments",
+          label: "Thanh toán chờ duyệt",
           href: "/finance/payments",
           icon: CreditCard,
           roles: ["accountant", "manager", "admin"],
           // Badge for pending count can be added dynamically
         },
         {
-          label: "Debt Report",
+          label: "Báo cáo công nợ",
           href: "/finance/debt-report",
           icon: BarChart3,
           roles: ["accountant", "manager", "admin"],
         },
         {
-          label: "Refunds",
+          label: "Hoàn phí",
           href: "/finance/refunds",
           icon: RotateCcw,
           roles: ["accountant", "manager", "admin"],
         },
         {
-          label: "Overpayments",
+          label: "Tiền nộp thừa",
           href: "/finance/overpayments",
           icon: WalletCards,
           roles: ["accountant", "manager", "admin"],


### PR DESCRIPTION
## Finance follow-up (2 commit, FE-only)

Sau khi Finance Phase 1 (#389) lên prod, xử lý 2 nhóm vấn đề UX.

### 1. Việt hóa toàn bộ UI finance (`6b76ec47`)
Rà 42 màn + 14 hook. Màn cũ (fees/invoices/payments/accounting/dashboard) + label maps canonical đã chuẩn tiếng Việt có dấu; khoảng trống ở **màn Phase 1 mới** (viết không dấu) + **nav English** + **toast hoàn phí/tiền thừa**.
- 4 màn Phase 1 (DebtReport/Refund/Overpayment/VietQR) thêm dấu + dịch header
- Nav finance 7 mục → Tổng quan tài chính/Khoản phí/Hóa đơn/Thanh toán chờ duyệt/Báo cáo công nợ/Hoàn phí/Tiền nộp thừa
- Toast useRefunds(8)+useOverpayments(6); lẻ tẻ màn cũ (heading, Online→Trực tuyến, Về Finance→Về Tài chính)
- Chỉ đổi text hiển thị; GIỮ NGUYÊN value/key/enum/testid/logic (đã verify SelectItem `value=` không đổi)

### 2. Thu lệ phí — mã biên lai gợi ý sẵn (`c6c49cf9`)
Điều tra 2 vấn đề:
- **Mã biên lai**: field bắt buộc 6–80 ký tự không có hướng dẫn → officer lúng túng. BE dùng receipt làm idempotency/replay key. **Fix**: prefill mã gợi ý duy nhất `PT-{id}-{ngày}` (sửa được) + placeholder + helper + select-on-focus.
- **Số tiền lệ phí**: ĐÃ đúng — FE read-only từ `application_fee` (snapshot phương thức TS), BE ghi sổ config-authoritative. KHÔNG sửa.

### Kiểm thử
FE type-check clean (cả 2 lần). Không đụng BE/migration. Rebase sạch trên main (#390), 0 overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)