### PR TITLE
feat(leads): mở lại lead "Đã ngừng tư vấn" (reopen sts20→sts04) — Phase A

### DIFF
--- a/Backend_FastAPI/alembic/versions/leadreopen_a_20260609_reopen_phase_a.py
+++ b/Backend_FastAPI/alembic/versions/leadreopen_a_20260609_reopen_phase_a.py
@@ -1,0 +1,83 @@
+"""Lead reopen Phase A: consultation_reengaged_at column + reopen Casbin policies.
+
+Adds:
+  - ``lead.consultation_reengaged_at`` (timestamptz, NULL) — mốc re-engage. NULL = chưa
+    reopen → RULE #13.2 (fsm_engine) giữ nguyên hành vi "EVER" (backfill = no-op).
+  - Casbin ``p`` policies cho ``POST /api/leads/{lead_id}/reopen`` (manager + admin).
+    v3=eft BẮT BUỘC: ``auth_model.conf`` dùng ``p.eft`` → NULL eft crash load.
+
+Revision ID: leadreopen_a_20260609
+Revises: sts20_consult_giveup_20260609
+Create Date: 2026-06-09
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "leadreopen_a_20260609"
+down_revision: Union[str, None] = "sts20_consult_giveup_20260609"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TEMPLATE_ID = "_leadreopen_a_20260609"
+_REOPEN_OBJ = "/api/leads/{lead_id}/reopen"
+# (v0=role, v1=obj, v2=act, v3=eft). Officer KHÔNG có quyền ở Phase A.
+_REOPEN_POLICIES = (
+    ("role:manager", _REOPEN_OBJ, "POST", "allow"),
+    ("role:admin", _REOPEN_OBJ, "POST", "allow"),
+)
+
+
+def _seed_policy(conn, v0: str, v1: str, v2: str, v3: str) -> None:
+    """Idempotent INSERT của 1 casbin policy row (đủ v0..v3 + template_id)."""
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id, applied_at)
+            SELECT 'p',
+                   CAST(:v0 AS VARCHAR),
+                   CAST(:v1 AS VARCHAR),
+                   CAST(:v2 AS VARCHAR),
+                   CAST(:v3 AS VARCHAR),
+                   :tid, NOW()
+            WHERE NOT EXISTS (
+                SELECT 1 FROM casbin_rule
+                WHERE ptype='p'
+                  AND v0=CAST(:v0 AS VARCHAR)
+                  AND v1=CAST(:v1 AS VARCHAR)
+                  AND v2=CAST(:v2 AS VARCHAR)
+                  AND v3=CAST(:v3 AS VARCHAR)
+            )
+            """
+        ),
+        {"v0": v0, "v1": v1, "v2": v2, "v3": v3, "tid": _TEMPLATE_ID},
+    )
+
+
+def upgrade() -> None:
+    op.add_column(
+        "lead",
+        sa.Column(
+            "consultation_reengaged_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+    conn = op.get_bind()
+    for v0, v1, v2, v3 in _REOPEN_POLICIES:
+        _seed_policy(conn, v0, v1, v2, v3)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("DELETE FROM casbin_rule WHERE template_id = :tid"),
+        {"tid": _TEMPLATE_ID},
+    )
+    op.drop_column("lead", "consultation_reengaged_at")

--- a/Backend_FastAPI/app/core/status_mapping.py
+++ b/Backend_FastAPI/app/core/status_mapping.py
@@ -61,6 +61,23 @@ DEFAULT_LEAD_STATUS = "new"
 
 
 # =============================================================================
+# CONSULTATION TERMINAL PREDICATE (single source of truth)
+# =============================================================================
+
+def is_consultation_terminal_status(cs: "Optional[ConsultationStatus]") -> bool:
+    """True nếu consultation status là trạng thái CUỐI của phase tư vấn (vd sts20
+    CONSULT_GIVEUP — "đã ngừng tư vấn").
+
+    Một định nghĩa DUY NHẤT cho mọi nơi cần phân biệt "lead đã ngừng tư vấn":
+    chặn tạo hồ sơ (admission eligibility), khóa đổi phone (§9.1 B-2), gợi ý mở
+    lại (§9.1 B-1'), cờ ``can_reopen``, và service reopen. Scope
+    ``phase == 'consultation'`` để KHÔNG bắt nhầm terminal phase admission/fee
+    (sts16/sts08/...). Xem Documents/LEAD_REOPEN_WORKFLOW_PLAN.md.
+    """
+    return cs is not None and bool(cs.is_final) and cs.phase == "consultation"
+
+
+# =============================================================================
 # DATA CLASSES
 # =============================================================================
 

--- a/Backend_FastAPI/app/models/lead.py
+++ b/Backend_FastAPI/app/models/lead.py
@@ -207,6 +207,14 @@ class Lead(Base):
     pipeline_stage_id = Column(
         String(50), ForeignKey("pipeline_stage.id"), nullable=True, index=True
     )
+    # Mốc re-engage: set = now() mỗi lần lead consultation-terminal (sts20) được mở lại
+    # (reopen sts20→sts04). NULL = chưa từng reopen → RULE #13.2 (fsm_engine) giữ nguyên
+    # hành vi "EVER" (blast-radius tối thiểu). Đã reopen → guard idempotency chỉ tính
+    # history sau mốc này, nên beat có thể auto-close lại lần sau mà KHÔNG cần xóa.
+    # Xem LEAD_REOPEN_WORKFLOW_PLAN §3.1/§3.2 + execute_system_transition.
+    consultation_reengaged_at = Column(
+        DateTime(timezone=True), nullable=True
+    )
     # Blacklist: Officers who have reassigned this lead (cannot receive it again)
     rejected_by_officer_ids = Column(
         JSON,

--- a/Backend_FastAPI/app/repositories/lead_repository.py
+++ b/Backend_FastAPI/app/repositories/lead_repository.py
@@ -1110,19 +1110,27 @@ class LeadRepository(BaseRepository[models.Lead]):
 
     async def get_by_id_for_update(
         self,
-        lead_id: int
+        lead_id: int,
+        *,
+        populate_existing: bool = False,
     ) -> Optional[models.Lead]:
         """
         Get lead by ID with row-level lock (FOR UPDATE).
-        
+
         ✅ ARCHITECTURE COMPLIANT: Replaces direct query in process_officer_action.
-        
+
         Used when modifying lead state in transactions where you need
         to prevent concurrent modifications.
-        
+
         Args:
             lead_id: Lead ID
-            
+            populate_existing: When True, OVERWRITE the in-session instance's
+                attributes from the freshly-locked row (SQLAlchemy otherwise
+                returns the cached identity-map instance WITHOUT refreshing it,
+                so a re-check after the lock would read pre-lock/stale values —
+                e.g. a lead already loaded by a non-locking IDOR dependency).
+                Set True when the caller re-validates state under the lock.
+
         Returns:
             Lead with lock acquired, or None if not found
         """
@@ -1131,6 +1139,8 @@ class LeadRepository(BaseRepository[models.Lead]):
             .where(models.Lead.id == lead_id)
             .with_for_update()
         )
+        if populate_existing:
+            query = query.execution_options(populate_existing=True)
         result = await self.db.execute(query)
         return result.scalar_one_or_none()
 

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -17,7 +17,11 @@ from ..services.notification_dispatcher import safe_dispatch, rooms_for_lead  # 
 from ..services.notification_payloads import EventPayload  # ✅ Phase 1
 from ..core.events import SystemEvents  # ✅ NOTIFICATION 2.0
 from ..core.constants import UserRole
-from ..utils.exceptions import BusinessRuleViolation, ConflictError
+from ..utils.exceptions import (
+    BusinessRuleViolation,
+    ConflictError,
+    ResourceNotFoundError,
+)
 from app.core.rate_limits import limiter, RateLimits
 
 log = structlog.get_logger(__name__)
@@ -1732,6 +1736,54 @@ async def update_lead_consultation_status(
     )
 
     return lead
+
+
+# =============================================================================
+# REOPEN LEAD (Phase A) — mở lại lead đã ngừng tư vấn (sts20 → sts04)
+# =============================================================================
+
+
+@limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
+@router.post("/{lead_id}/reopen", response_model=schemas.Lead)
+async def reopen_lead_endpoint(
+    request: Request,
+    body: schemas.LeadReopenRequest,
+    lead: models.Lead = LeadAccessDep,
+    current_user: models.User = CasbinAuth,
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Mở lại một lead đã ngừng tư vấn (consultation-terminal, vd sts20) → sts04.
+
+    Manager/Admin only (Casbin role-gate + IDOR ``get_lead_for_user`` → 404 ngoài phạm
+    vi). Lead về sts04 (re-engage point), set mốc ``consultation_reengaged_at`` để beat
+    SLA có thể auto-close lại lần sau mà không cần xóa history. Reopen là service chuyên
+    dụng (KHÔNG seed allowed_transition sts20→sts04). Xem
+    Documents/LEAD_REOPEN_WORKFLOW_PLAN.md.
+
+    **Error Responses:**
+    - 400: lead không ở trạng thái cuối phase tư vấn / đã xóa (BusinessRuleViolation)
+    - 404: lead không tồn tại hoặc ngoài phạm vi IDOR (ResourceNotFoundError)
+    """
+    from ..services import lead_reopen_service
+    from ..repositories.lead_repository import LeadRepository
+
+    result, callback = await lead_reopen_service.reopen_lead(
+        db, lead.id, reviewer=current_user, reason=body.reason
+    )
+    await db.commit()
+    if callback:
+        await callback()
+
+    # Re-fetch eager-loaded for response_model=schemas.Lead (nested
+    # consultation_status/unit/offering/assigned_officer — returning the bare locked
+    # `result` would lazy-load post-commit → MissingGreenlet). Guard the
+    # near-impossible None from a concurrent soft-delete so we never serialize None
+    # against a non-optional response_model (500); surface a clean 404 instead.
+    repo = LeadRepository(db)
+    reopened = await repo.get_by_id_shallow(result.id)
+    if reopened is None:
+        raise ResourceNotFoundError(detail=f"Lead {result.id} not found after reopen")
+    return reopened
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -129,6 +129,7 @@ from .lead import (
     LeadBase,
     LeadCreate,
     LeadDetail,
+    LeadReopenRequest,  # ✅ Reopen Phase A: body POST /leads/{id}/reopen
     LeadImportError,
     LeadImportResult,
     LeadInsights,

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -448,6 +448,24 @@ class LeadDetail(Lead):
     model_config = ConfigDict(from_attributes=True)
 
 
+class LeadReopenRequest(BaseModel):
+    """Body cho POST /leads/{lead_id}/reopen — mở lại lead đã ngừng tư vấn.
+
+    Chỉ manager/admin (role-gate ở backend Casbin + IDOR). ``reason`` bắt buộc, lưu
+    nguyên văn để audit. Xem Documents/LEAD_REOPEN_WORKFLOW_PLAN.md.
+    """
+    # Strip whitespace TRƯỚC khi đếm min_length → "     " (5 dấu cách) bị chặn ngay ở
+    # Pydantic (422) thay vì lọt tới service rồi mới reject (400) — nhất quán mã lỗi.
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    reason: str = Field(
+        ...,
+        min_length=5,
+        max_length=500,
+        description="Lý do mở lại (bắt buộc, tối thiểu 5 ký tự).",
+    )
+
+
 class LeadsSummary(BaseModel):
     """Aggregate stats over the entire filtered set (not just current page)."""
     new_count: int = 0

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1389,14 +1389,11 @@ async def check_lead_level_admission_eligibility(
     # is_final status would break multi-year re-application. Explicit DB get
     # avoids a lazy-load crash in async context.
     if lead.consultation_status_id:
+        from ..core.status_mapping import is_consultation_terminal_status
         current_cs = await db.get(
             models.ConsultationStatus, lead.consultation_status_id
         )
-        if (
-            current_cs is not None
-            and current_cs.is_final
-            and current_cs.phase == "consultation"
-        ):
+        if is_consultation_terminal_status(current_cs):
             return LeadAdmissionEligibility(
                 False,
                 "consultation_terminal",

--- a/Backend_FastAPI/app/services/fsm_engine.py
+++ b/Backend_FastAPI/app/services/fsm_engine.py
@@ -531,15 +531,27 @@ async def execute_system_transition(
         )
         return False
 
-    # ✅ RULE #13.2: Check if lead was EVER in this status before (prevent loops)
+    # ✅ RULE #13.2: Skip if lead has been in this status SINCE its last re-engage
+    # (prevent loops). Semantics changed from "EVER" → "since last re-engage": a lead
+    # deliberately re-opened (consultation_reengaged_at set, e.g. reopen sts20→sts04 via
+    # lead_reopen_service) can be auto-closed AGAIN later without deleting any history.
+    # A lead never re-opened (column NULL) → behaves exactly as the old "EVER" check, so
+    # idempotency of every other system event is unchanged (blast-radius minimal).
+    # NOTE: ``lead`` is the in-memory object passed in — read
+    # consultation_reengaged_at in Python and append a ``changed_at`` predicate;
+    # do NOT join the lead table.
+    # See LEAD_REOPEN_WORKFLOW_PLAN §3.2.
+    _history_conditions = [
+        models.LeadStatusHistory.lead_id == lead.id,
+        models.LeadStatusHistory.new_consultation_status_id == to_status_id,
+    ]
+    if lead.consultation_reengaged_at is not None:
+        _history_conditions.append(
+            models.LeadStatusHistory.changed_at > lead.consultation_reengaged_at
+        )
     result = await db.execute(
         select(models.LeadStatusHistory)
-        .where(
-            and_(
-                models.LeadStatusHistory.lead_id == lead.id,
-                models.LeadStatusHistory.new_consultation_status_id == to_status_id
-            )
-        )
+        .where(and_(*_history_conditions))
         .limit(1)
     )
     previous_occurrence = result.scalar_one_or_none()

--- a/Backend_FastAPI/app/services/lead_reopen_service.py
+++ b/Backend_FastAPI/app/services/lead_reopen_service.py
@@ -1,0 +1,175 @@
+# app/services/lead_reopen_service.py
+"""Lead reopen service (Phase A) — mở lại lead consultation-terminal (sts20).
+
+Xem ``Documents/LEAD_REOPEN_WORKFLOW_PLAN.md``.
+
+Reopen KHÔNG dùng FSM transition thường và KHÔNG seed
+``allowed_transition sts20→sts04`` (nếu seed, manager đổi được sts20→sts04 qua
+``add_consultation`` thường, bỏ qua kiểm soát). Đây là service chuyên dụng,
+trong 1 transaction:
+
+1. ``SELECT ... FOR UPDATE`` lead (chống double-reopen / TOCTOU — pattern #345).
+2. Re-check (theo DB, không tin client) lead đang ở trạng thái cuối phase tư vấn
+   (``is_final && phase=='consultation'``, vd sts20) → nếu không thì
+   ``BusinessRuleViolation``.
+3. Suy ``status`` + ``pipeline_stage_id`` từ sts04 bằng
+   ``StatusHelper.sync_lead_status`` (KHÔNG hardcode 'contacted'/'stg02') + set
+   mốc ``consultation_reengaged_at = now()``.
+4. Ghi ``lead_status_history`` (changed_by = reviewer) + ``audit_service``. KHÔNG
+   xóa history nào — mốc thời gian cho phép beat auto-close lại lần sau (RULE
+   #13.2 đổi sang semantics "since last re-engage", xem
+   ``fsm_engine.execute_system_transition``).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Callable, Tuple
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models
+from ..services import audit_service
+from ..utils.exceptions import (
+    BusinessRuleViolation,
+    ResourceNotFoundError,
+    ValidationError,
+)
+from ..repositories import LeadRepository
+from ..core.status_mapping import is_consultation_terminal_status
+from .status_helper import StatusHelper
+from .lead_service import _get_current_lead_state, _log_lead_state_change
+
+log = structlog.get_logger(__name__)
+
+# Điểm re-engage chuẩn của phase tư vấn: sts04 (CONSULT_REJECTED, is_final=false →
+# officer tiếp tục luồng tư vấn bình thường sts04→sts03/05/06).
+REOPEN_TARGET_STATUS_ID = "sts04"
+
+# Lý do bắt buộc — min length (service-side guard; schema cũng validate cho đường API).
+_REASON_MIN_LEN = 5
+
+
+async def reopen_lead(
+    db: AsyncSession,
+    lead_id: int,
+    reviewer: models.User,
+    reason: str,
+) -> Tuple[models.Lead, Callable]:
+    """Mở lại một lead consultation-terminal (sts20) → sts04.
+
+    Args:
+        db: AsyncSession (router commit; service chỉ flush qua helper).
+        lead_id: Lead cần mở lại.
+        reviewer: Manager/Admin thực hiện (ghi vào history + audit).
+        reason: Lý do bắt buộc (>= 5 ký tự), lưu nguyên văn để audit.
+
+    Returns:
+        ``(lead, post_commit_callback)`` — callback no-op ở MVP (chỗ cắm notification
+        Phase C). Router phải ``await callback()`` sau commit.
+
+    Raises:
+        ResourceNotFoundError: lead không tồn tại (404).
+        BusinessRuleViolation: lead đã xóa / không ở trạng thái cuối phase tư vấn.
+        ValidationError: thiếu lý do.
+    """
+    if not reason or len(reason.strip()) < _REASON_MIN_LEN:
+        raise ValidationError(
+            detail=f"Lý do mở lại là bắt buộc (tối thiểu {_REASON_MIN_LEN} ký tự)."
+        )
+
+    repo = LeadRepository(db)
+
+    async with db.begin_nested():
+        # 1. Lock lead row (chống double-reopen / TOCTOU). populate_existing=True để
+        #    ĐỌC LẠI giá trị từ row đã khóa — nếu không, LeadAccessDep đã nạp lead vào
+        #    identity-map trước đó (không khóa) và SQLAlchemy trả instance cũ KHÔNG
+        #    refresh → re-check bên dưới sẽ chạy trên snapshot pre-lock.
+        lead = await repo.get_by_id_for_update(lead_id, populate_existing=True)
+        if lead is None:
+            raise ResourceNotFoundError(detail=f"Lead with id {lead_id} not found")
+        if lead.deleted_at is not None:
+            raise BusinessRuleViolation(detail="Không thể mở lại một lead đã bị xóa.")
+
+        # 2. Re-check trạng thái cuối phase tư vấn (DB, giá trị đã refresh dưới lock).
+        current_cs = (
+            await db.get(models.ConsultationStatus, lead.consultation_status_id)
+            if lead.consultation_status_id
+            else None
+        )
+        if not is_consultation_terminal_status(current_cs):
+            raise BusinessRuleViolation(
+                detail=(
+                    "Chỉ mở lại được lead đang ở trạng thái cuối phase tư vấn "
+                    "(đã ngừng tư vấn). Lead này không ở trạng thái đó."
+                )
+            )
+
+        # 3. Capture old state TRƯỚC khi đổi.
+        old_state = _get_current_lead_state(lead)
+        old_cs_id = lead.consultation_status_id
+
+        target_cs = await db.get(models.ConsultationStatus, REOPEN_TARGET_STATUS_ID)
+        if target_cs is None:
+            # Cấu hình thiếu trạng thái re-engage — fail-closed, không mutate.
+            raise ResourceNotFoundError(
+                detail=f"Thiếu trạng thái re-engage '{REOPEN_TARGET_STATUS_ID}'."
+            )
+
+        # 4. Mutate + sync (KHÔNG gán literal status/stage — suy từ sts04).
+        now = datetime.now(timezone.utc)
+        await StatusHelper.sync_lead_status(lead, target_cs)
+        lead.consultation_reengaged_at = now
+        lead.updated_at = now
+        # Reset đồng hồ SLA: nếu không, coalesce(last_consultation_at, updated_at,
+        # created_at) trong close_stale_rejected_leads vẫn thấy mốc give-up cũ → beat
+        # auto-close lại NGAY lần chạy kế, vô hiệu hóa reopen khi bật
+        # SLA_AUTO_GIVEUP_ENABLED. Cho lead một cửa sổ SLA mới kể từ lúc mở lại.
+        lead.last_consultation_at = now
+        # Optimistic-lock: mọi thay đổi trạng thái phải tăng version (đồng bộ
+        # update_lead) để một edit dựa trên snapshot pre-reopen bị chặn 409 đúng cách.
+        lead.version = (lead.version or 1) + 1
+
+        # 5. Ghi history từ state đã capture + ĐỌC LẠI status/stage SAU sync.
+        new_state = _get_current_lead_state(lead)
+        await _log_lead_state_change(
+            db,
+            lead,
+            old_state,
+            new_state,
+            changed_by=reviewer,
+            reason=f"reopen: {reason.strip()}",
+        )
+
+        # 6. Audit.
+        await audit_service.log_audit(
+            db,
+            entity_type="Lead",
+            entity_id=lead.id,
+            action="consultation_reopened",
+            actor_user_id=reviewer.id,
+            changes={
+                "consultation_status_id": {
+                    "old": old_cs_id,
+                    "new": REOPEN_TARGET_STATUS_ID,
+                },
+                "status": {"old": old_state.get("status"), "new": lead.status},
+            },
+            reason=f"reopen: {reason.strip()}",
+            source="api",
+        )
+
+        log.info(
+            "Lead reopened",
+            lead_id=lead.id,
+            from_consultation_status=old_cs_id,
+            to_consultation_status=REOPEN_TARGET_STATUS_ID,
+            reviewer_id=reviewer.id,
+            reengaged_at=now,
+        )
+
+    async def _post_commit() -> None:
+        # MVP: no-op. Phase C: dispatch LEAD_REOPEN_* notifications here.
+        return None
+
+    return lead, _post_commit

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -23,7 +23,10 @@ from ..utils.exceptions import (
     ValidationError,
 )
 from ..services import pipeline_service, distribution_service, audit_service
-from ..core.status_mapping import sync_lead_status_from_consultation
+from ..core.status_mapping import (
+    sync_lead_status_from_consultation,
+    is_consultation_terminal_status,
+)
 from ..core.constants import UserRole
 from .status_helper import StatusHelper, AssignmentStatus
 from ..repositories import LeadRepository  # ✅ PHASE 2: Repository Pattern
@@ -931,7 +934,25 @@ async def create_lead(
             
             lead_name = existing_phone_lead.full_name or "N/A"
             lead_phone = existing_phone_lead.phone or "N/A"
-            
+
+            # ✅ §9.1 B-1′: nếu SĐT thuộc một lead đã ngừng tư vấn (consultation
+            # terminal, sts20), gợi ý MỞ LẠI (reopen) thay vì báo "trùng SĐT" chung
+            # chung — đúng nghiệp vụ. (Security thật do B-2 + check_phone_conflict.)
+            if existing_phone_lead.consultation_status_id:
+                _dup_cs = await db.get(
+                    models.ConsultationStatus,
+                    existing_phone_lead.consultation_status_id,
+                )
+                if is_consultation_terminal_status(_dup_cs):
+                    raise DuplicateResourceError(
+                        detail=(
+                            f"Số điện thoại thuộc lead đã ngừng tư vấn: {lead_name} "
+                            f"(SĐT: {lead_phone}) - Đơn vị: {unit_name} - "
+                            f"Quản lý bởi: {officer_name}. Vui lòng MỞ LẠI "
+                            "(reopen) lead đó thay vì tạo mới."
+                        )
+                    )
+
             raise DuplicateResourceError(
                 detail=f"Số điện thoại này đã tồn tại. Lead: {lead_name} (SĐT: {lead_phone}) - Đơn vị: {unit_name} - Quản lý bởi: {officer_name}"
             )
@@ -1342,6 +1363,32 @@ async def update_lead(
 
             if not allowed:
                 raise BusinessRuleViolation(detail=block_reason)
+
+            # =========================================================================
+            # ✅ §9.1 B-2: Khóa SĐT trên lead consultation-terminal (sts20).
+            # Lead ở trạng thái cuối phase tư vấn vẫn "giam" SĐT của nó trên
+            # lead_phone_identity. Cho officer đổi phone/phone2 sẽ GIẢI PHÓNG số đó
+            # (uq_lead_phone_active) → tạo lead mới cùng SĐT, bỏ qua kiểm soát reopen
+            # ("reopen lậu"). Giữ số khóa → buộc dùng đường mở lại (reopen, lúc đó
+            # lock tự gỡ). Chỉ chặn khi giá trị THẬT SỰ đổi (no-op resubmit qua
+            # được). Xem LEAD_REOPEN_WORKFLOW_PLAN §9.1.
+            # =========================================================================
+            phone_being_released = (
+                ("phone" in update_data and update_data["phone"] != db_lead.phone)
+                or ("phone2" in update_data and update_data["phone2"] != db_lead.phone2)
+            )
+            if phone_being_released and db_lead.consultation_status_id:
+                _term_cs = await db.get(
+                    models.ConsultationStatus, db_lead.consultation_status_id
+                )
+                if is_consultation_terminal_status(_term_cs):
+                    raise BusinessRuleViolation(
+                        detail=(
+                            f"Lead đang ở trạng thái '{_term_cs.name}' (đã ngừng "
+                            "tư vấn) — không thể đổi số điện thoại. Vui lòng mở lại "
+                            "tư vấn (reopen) trước khi chỉnh sửa."
+                        )
+                    )
 
             # Kiểm tra trùng lặp email nếu email được cập nhật (case-insensitive)
             # Kiểm tra trùng lặp email nếu email được cập nhật (case-insensitive)
@@ -4556,6 +4603,20 @@ async def _populate_lead_detail_fields(
     blockers: dict[str, str] = {}
     if not eligibility.eligible and eligibility.blocker_code:
         blockers["create_admission"] = eligibility.blocker_code
+
+    # ✅ Reopen (Phase A): manager/admin mở lại được lead consultation-terminal (sts20).
+    # FE hiện nút "Mở lại tư vấn" THUẦN theo cờ này (KHÔNG đọc user.role ở FE). Backend
+    # là nơi role-gate. Blocker: not_terminal (lead chưa ở trạng thái cuối tư vấn) /
+    # forbidden (đúng trạng thái nhưng user không phải manager/admin).
+    is_manager_admin = current_user.role in (UserRole.MANAGER, UserRole.ADMIN)
+    cs_terminal = False
+    if lead.consultation_status_id:
+        _cs = await db.get(models.ConsultationStatus, lead.consultation_status_id)
+        cs_terminal = is_consultation_terminal_status(_cs)
+    can_reopen = is_manager_admin and cs_terminal
+    permissions["can_reopen"] = can_reopen
+    if not can_reopen:
+        blockers["can_reopen"] = "not_terminal" if not cs_terminal else "forbidden"
 
     lead.permissions = permissions
     lead.available_actions = [k for k, v in permissions.items() if v]

--- a/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
+++ b/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
@@ -27,6 +27,7 @@ from app.services.fsm_engine import (
     execute_system_transition,
     get_next_statuses_for_lead,
 )
+from app.services.lead_reopen_service import reopen_lead
 from app.tasks.sla_tasks import close_stale_rejected_leads
 
 pytestmark = pytest.mark.asyncio
@@ -970,3 +971,297 @@ async def test_backfill_script_closes_only_stale_and_is_idempotent(db: AsyncSess
 
     # Idempotent: re-run matches zero (moved leads are no longer sts04).
     assert await count_stale_sts04(db, 30) == 0
+
+
+# ---------------------------------------------------------------------------
+# Reopen workflow (Phase A) — mở lại lead consultation-terminal (sts20 → sts04)
+# ---------------------------------------------------------------------------
+
+async def test_reopen_sts20_to_sts04_sets_reengaged_and_history(db: AsyncSession):
+    """Manager mở lại lead sts20 → sts04: derive status (KHÔNG hardcode), set mốc
+    re-engage, ghi history (changed_by=reviewer, reason='reopen:')."""
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    manager = await _make_manager(db, unit.id)
+    officer = await _make_officer(db, unit.id, cap=10)
+    lead = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+        officer_id=officer.id,
+    )
+    v_before = lead.version
+
+    reopened, cb = await reopen_lead(
+        db, lead.id, reviewer=manager, reason="Khách đổi ý, muốn tư vấn lại",
+    )
+    if cb:
+        await cb()
+
+    assert reopened.consultation_status_id == "sts04"
+    assert reopened.pipeline_stage_id == "stg02"
+    # status suy từ sts04 qua sync_lead_status (Rule 4: stg02 non-final) -> 'contacted'.
+    assert reopened.status == "contacted"
+    assert reopened.status != "rejected"  # đã rời khỏi trạng thái give-up
+    assert reopened.consultation_reengaged_at is not None
+    # #1: reopen reset đồng hồ SLA (last_consultation_at = now == reengaged_at) để beat
+    # KHÔNG đóng lại ngay.
+    assert reopened.last_consultation_at == reopened.consultation_reengaged_at
+    # #3: bump version (optimistic-lock) — mọi thay đổi trạng thái phải tăng version.
+    assert reopened.version == (v_before or 1) + 1
+    # assigned_officer giữ nguyên (reopen KHÔNG đụng assignment) — C1.
+    assert reopened.assigned_officer_id == officer.id
+
+    await db.flush()
+    hist = (await db.execute(
+        select(models.LeadStatusHistory)
+        .where(
+            models.LeadStatusHistory.lead_id == lead.id,
+            models.LeadStatusHistory.new_consultation_status_id == "sts04",
+        )
+    )).scalars().all()
+    assert len(hist) == 1
+    assert hist[0].old_consultation_status_id == "sts20"
+    assert hist[0].changed_by_user_id == manager.id
+    assert "reopen:" in (hist[0].reason or "")
+
+
+async def test_reopen_rejects_non_terminal_lead(db: AsyncSession):
+    """Lead KHÔNG ở trạng thái cuối phase tư vấn (sts04) → BusinessRuleViolation."""
+    from app.utils.exceptions import BusinessRuleViolation
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    manager = await _make_manager(db, unit.id)
+    lead = await _make_lead(db, unit.id, status="contacted")  # sts04, non-final
+
+    with pytest.raises(BusinessRuleViolation):
+        await reopen_lead(db, lead.id, reviewer=manager, reason="thử mở lại")
+    await db.refresh(lead)
+    assert lead.consultation_status_id == "sts04"  # unchanged
+
+
+async def test_reopen_rejects_deleted_lead(db: AsyncSession):
+    """Lead sts20 đã soft-delete → không mở lại được (BusinessRuleViolation)."""
+    from app.utils.exceptions import BusinessRuleViolation
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    manager = await _make_manager(db, unit.id)
+    lead = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+    )
+    lead.deleted_at = datetime.now(timezone.utc)
+    await db.flush()
+
+    with pytest.raises(BusinessRuleViolation):
+        await reopen_lead(db, lead.id, reviewer=manager, reason="mở lại lead đã xóa")
+
+
+async def test_reopen_requires_reason(db: AsyncSession):
+    """Thiếu lý do (hoặc quá ngắn) → ValidationError."""
+    from app.utils.exceptions import ValidationError
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    manager = await _make_manager(db, unit.id)
+    lead = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+    )
+
+    with pytest.raises(ValidationError):
+        await reopen_lead(db, lead.id, reviewer=manager, reason="  ")
+
+
+async def test_reopen_then_beat_can_close_again(db: AsyncSession):
+    """⭐ Lõi §3.2: sau reopen (reengaged_at set), beat auto-close ĐÓNG LẠI ĐƯỢC dù
+    đã có history sts20 cũ — RULE #13.2 'since last re-engage' chỉ tính history sau mốc.
+    Audit đủ CẢ 2 lần give-up (không xóa history nào)."""
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    manager = await _make_manager(db, unit.id)
+    now = datetime.now(timezone.utc)
+
+    # Lead đang sts20, ĐÃ give-up 1 lần (history sts20 cũ, trước mốc reopen).
+    lead = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+        officer_id=officer.id, last_consultation_at=now - timedelta(days=40),
+    )
+    db.add(models.LeadStatusHistory(
+        lead_id=lead.id, old_status="contacted", new_status="rejected",
+        old_consultation_status_id="sts04", new_consultation_status_id="sts20",
+        changed_by_user_id=None, reason="prior give-up",
+        changed_at=now - timedelta(days=50),
+    ))
+    await db.flush()
+
+    # Mở lại -> sts04 + reengaged_at ~ now.
+    reopened, cb = await reopen_lead(
+        db, lead.id, reviewer=manager, reason="khách quay lại hỏi học phí",
+    )
+    if cb:
+        await cb()
+    assert reopened.consultation_status_id == "sts04"
+    assert reopened.consultation_reengaged_at is not None
+
+    # Reopen reset last_consultation_at = now (#1). Mô phỏng officer tư vấn lại rồi im
+    # lặng tiếp quá SLA: đẩy last_consultation_at về quá khứ SAU reopen -> stale LẠI.
+    lead.last_consultation_at = now - timedelta(days=40)
+    await db.flush()
+
+    # Stale lại -> beat đóng LẠI được nhờ RULE #13.2 'since last re-engage'
+    # (history sts20 cũ changed_at < reengaged_at bị bỏ qua).
+    cutoff = now - timedelta(days=30)
+    result = await close_stale_rejected_leads(db, cutoff=cutoff, days=15)
+    assert result["transitioned"] == 1  # #13.2 KHÔNG còn skip (history cũ < reengaged)
+    await db.refresh(lead)
+    assert lead.consultation_status_id == "sts20"
+
+    # Audit append-only: CẢ 2 history give-up tồn tại (không mất lớp nào).
+    sts20_hist = (await db.execute(
+        select(models.LeadStatusHistory).where(
+            models.LeadStatusHistory.lead_id == lead.id,
+            models.LeadStatusHistory.new_consultation_status_id == "sts20",
+        )
+    )).scalars().all()
+    assert len(sts20_hist) == 2
+
+
+async def test_reopen_resets_sla_clock_so_beat_does_not_immediately_reclose(
+    db: AsyncSession,
+):
+    """#1: reopen reset last_consultation_at = now → lead KHÔNG còn stale → beat
+    auto-close KHÔNG đóng lại NGAY sau reopen (cho officer cửa sổ SLA mới)."""
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    manager = await _make_manager(db, unit.id)
+    now = datetime.now(timezone.utc)
+
+    # Lead give-up tồn đọng đã rất lâu (40 ngày).
+    lead = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+        officer_id=officer.id, last_consultation_at=now - timedelta(days=40),
+    )
+
+    reopened, cb = await reopen_lead(
+        db, lead.id, reviewer=manager, reason="khách quay lại, hẹn gọi tuần sau",
+    )
+    if cb:
+        await cb()
+
+    # Beat chạy NGAY (cutoff 30d). Vì last_consultation_at đã = now, lead KHÔNG stale.
+    cutoff = now - timedelta(days=30)
+    result = await close_stale_rejected_leads(db, cutoff=cutoff, days=15)
+    assert result["checked"] == 0  # không khớp stale-predicate
+    assert result["transitioned"] == 0
+    await db.refresh(lead)
+    assert lead.consultation_status_id == "sts04"  # vẫn mở, không bị đóng lại
+
+
+async def test_can_reopen_flag_thin_client(db: AsyncSession):
+    """§6.0 permission contract: can_reopen=True cho manager/admin trên sts20; False +
+    blocker not_terminal (sts04) / forbidden (officer)."""
+    from app.services.lead_service import _populate_lead_detail_fields
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    manager = await _make_manager(db, unit.id)
+    officer = await _make_officer(db, unit.id, cap=10)
+    sts20_lead = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+        officer_id=officer.id,
+    )
+    sts04_lead = await _make_lead(
+        db, unit.id, consultation_status_id="sts04", status="contacted",
+        officer_id=officer.id,
+    )
+
+    # Manager trên sts20 -> can_reopen True, có trong available_actions.
+    await _populate_lead_detail_fields(db, sts20_lead, manager)
+    assert sts20_lead.permissions["can_reopen"] is True
+    assert "can_reopen" in sts20_lead.available_actions
+
+    # Manager trên sts04 -> False + blocker not_terminal.
+    await _populate_lead_detail_fields(db, sts04_lead, manager)
+    assert sts04_lead.permissions["can_reopen"] is False
+    assert sts04_lead.action_blockers["can_reopen"] == "not_terminal"
+
+    # Officer trên sts20 -> False + blocker forbidden (role-gate).
+    await _populate_lead_detail_fields(db, sts20_lead, officer)
+    assert sts20_lead.permissions["can_reopen"] is False
+    assert sts20_lead.action_blockers["can_reopen"] == "forbidden"
+
+
+async def test_b2_block_phone_change_on_terminal_lead(db: AsyncSession):
+    """§9.1 B-2: officer KHÔNG đổi được phone của lead sts20 (giữ SĐT khóa → chống
+    'reopen lậu'); sau reopen (sts04) đổi được."""
+    from app.services.lead_service import update_lead
+    from app.utils.exceptions import BusinessRuleViolation
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    manager = await _make_manager(db, unit.id)
+    officer = await _make_officer(db, unit.id, cap=10)
+    lead = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+        officer_id=officer.id,
+    )
+
+    # Officer assigned đổi phone lead terminal -> bị chặn.
+    with pytest.raises(BusinessRuleViolation):
+        await update_lead(
+            db, lead.id, schemas.LeadUpdate(phone="0988111222"),
+            updated_by=officer,
+        )
+
+    # Mở lại -> sts04, lock gỡ -> đổi phone OK.
+    await reopen_lead(db, lead.id, reviewer=manager, reason="khách muốn tiếp tục")
+    updated, _cb = await update_lead(
+        db, lead.id, schemas.LeadUpdate(phone="0988111222"), updated_by=officer,
+    )
+    assert updated.phone == "0988111222"
+
+
+async def test_b1_create_lead_duplicate_phone_terminal_suggests_reopen(
+    db: AsyncSession, monkeypatch,
+):
+    """§9.1 B-1′: tạo lead trùng SĐT của một lead sts20 → message gợi ý MỞ LẠI."""
+    from app.services.lead_service import create_lead
+    from app.utils.exceptions import DuplicateResourceError
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    admin = await _make_admin(db, unit.id)
+    existing = await _make_lead(
+        db, unit.id, consultation_status_id="sts20", status="rejected",
+    )
+    dup_phone = existing.phone
+
+    import app.celery_utils as cu
+    monkeypatch.setattr(cu, "process_automatic_lead_assignment_task", MagicMock())
+
+    lead_in = schemas.LeadCreate(
+        full_name="Trùng SĐT", phone=dup_phone, source="website", unit_id=unit.id,
+    )
+    with pytest.raises(DuplicateResourceError) as exc:
+        await create_lead(db, lead_in, created_by=admin)
+    assert "MỞ LẠI" in str(exc.value) or "reopen" in str(exc.value).lower()
+
+
+async def test_reopen_idor_manager_outside_unit_gets_404(db: AsyncSession):
+    """IDOR: manager mở lead ngoài unit → ResourceNotFoundError (404, không 403)."""
+    from app.core.deps import get_lead_for_user
+    from app.utils.exceptions import ResourceNotFoundError
+
+    await _seed_fsm(db)
+    unit_a = await _make_unit(db)
+    unit_b = await _make_unit(db)
+    manager_b = await _make_manager(db, unit_b.id)
+    lead_a = await _make_lead(
+        db, unit_a.id, consultation_status_id="sts20", status="rejected",
+    )
+
+    with pytest.raises(ResourceNotFoundError):
+        await get_lead_for_user(
+            lead_id=lead_a.id, db=db, current_user=manager_b,
+        )

--- a/Documents/LEAD_REOPEN_WORKFLOW_PLAN.md
+++ b/Documents/LEAD_REOPEN_WORKFLOW_PLAN.md
@@ -1,9 +1,9 @@
 # Plan: Lead Reopen Workflow — mở lại lead sts20 (CONSULT_GIVEUP) có kiểm soát
 
-> Trạng thái: **PLAN — chưa code.** Tiền đề: PR sts20 CONSULT_GIVEUP đã code+test
-> local (branch `feat/sts20-consult-giveup`, chưa push) + gate chặn tạo hồ sơ từ
-> lead consultation-terminal (`consultation_terminal` trong
-> `check_lead_level_admission_eligibility`).
+> Trạng thái: **PLAN — chưa code.** Tiền đề: PR sts20 CONSULT_GIVEUP đã **MERGED
+> (#390) + deploy prod** — chạy với `SLA_AUTO_GIVEUP_ENABLED=false` (beat CHƯA tự
+> đóng) + gate chặn tạo hồ sơ từ lead consultation-terminal (`consultation_terminal`
+> trong `check_lead_level_admission_eligibility`). `SLA_CONSULT_GIVEUP_DAYS` prod = 15.
 >
 > **Hai quyết định đã chốt (2026-06-09):**
 > 1. **RULE #13.2 → mốc re-engage** (KHÔNG xóa history). Giữ `lead_status_history`
@@ -24,9 +24,10 @@ transition ra). Khi lead sang sts20:
 lại** qua nghiệp vụ. Cần quy trình **manager/admin mở lại có lý do + audit + chống
 lạm dụng**; ở Phase B nâng lên **officer xin → manager/admin duyệt**.
 
-**Liên hệ với rollout flag:** Phase A là **tiền đề để bật `SLA_AUTO_GIVEUP_ENABLED`**
-(two-step rollout của PR sts20). Có đường mở lại tối thiểu thì việc beat tự đóng
-lead mới an toàn (đảo được). Không cần chờ trọn Phase B mới bật beat.
+**Liên hệ với rollout flag:** Điều kiện bật `SLA_AUTO_GIVEUP_ENABLED` (beat tự đóng)
+một cách an toàn = **PR-A (reopen MVP) + chốt §9.1 (chặn "reopen lậu" qua
+soft-delete)** — CẢ HAI nằm trong acceptance của PR-A. Đủ đường mở lại + bịt đường
+lách thì beat tự đóng lead mới mới đảo được. Không cần chờ trọn Phase B.
 
 ## 2. Quyết định thiết kế (chốt)
 
@@ -36,10 +37,11 @@ lead mới an toàn (đảo được). Không cần chờ trọn Phase B mới b
   sts20→sts04`.** Nếu seed, manager đổi được sts20→sts04 qua `add_consultation`
   thường, bỏ qua kiểm soát. → Reopen là **service chuyên dụng** (mutate có guard +
   ghi history thủ công + set mốc re-engage).
-- **Suy `lead.status` từ sts04 bằng `derive_lead_status`/`sync_lead_status`** —
-  KHÔNG hardcode `'contacted'`. Tránh drift nếu quy tắc derive đổi (cùng bài học
-  với migration backfill PR sts20). Canonical hiện tại: sts04 → `status='contacted'`,
-  `pipeline_stage_id='stg02'`.
+- **Suy `lead.status` + `pipeline_stage_id` từ sts04 bằng `sync_lead_status`/
+  `derive_lead_status`, rồi ĐỌC LẠI giá trị SAU sync để ghi history** — KHÔNG
+  hardcode `'contacted'`/`'stg02'`. Tránh drift nếu quy tắc derive đổi (cùng bài học
+  migration backfill PR sts20). Canonical hiện tại (chỉ để tham chiếu): sts04 →
+  `status='contacted'`, `pipeline_stage_id='stg02'`. Chi tiết bước ở §5.
 - **Lock khi mở lại**: `SELECT ... FOR UPDATE` trên lead row trong transaction
   (chống double-reopen / TOCTOU; pattern admin rollback lock #345). Re-check
   `consultation_status_id='sts20'` SAU khi đã lock.
@@ -81,10 +83,15 @@ WHERE lead_status_history.lead_id = :lead
 
 > ⚠ Đây là guard **dùng chung mọi system transition**. Bắt buộc:
 > - Chạy **full FSM anchor matrix** (`test-fixture-drift-after-policy-refactor`).
-> - Test riêng: reopen → stale ≥30d lại → **beat đóng lại được** (history sts20
->   mới tạo, audit đủ cả 2 lần give-up).
+> - Test riêng: reopen → stale lại ≥ `SLA_CONSULT_GIVEUP_DAYS` (prod 15) →
+>   **beat đóng lại được** (history sts20 mới tạo, audit đủ cả 2 lần give-up).
 > - Test hồi quy: lead chưa reopen vẫn skip đúng như cũ (idempotency các event khác
 >   không vỡ).
+> - **Lưu ý implement (B2):** `fsm_engine.py:~535` chỉ `SELECT FROM LeadStatusHistory`;
+>   `lead` là object Python **in-memory** (truyền vào hàm), KHÔNG join bảng `lead`. Đọc
+>   `lead.consultation_reengaged_at` bằng Python rồi: nếu `is not None` mới thêm
+>   `AND LeadStatusHistory.changed_at > :reengaged_at` vào WHERE. KHÔNG viết SQL join
+>   bảng `lead` — đoạn SQL ở §3.2 chỉ minh hoạ semantics, không phải query thật.
 
 ## 4. Vì sao mốc-thời-gian thay cho xóa history
 
@@ -112,14 +119,30 @@ Guard REOPEN (lõi, dùng chung A/B), trong 1 transaction:
 1. `SELECT lead ... FOR UPDATE`.
 2. Re-check `lead.consultation_status_id == 'sts20'` (DB, không tin client) → nếu
    không: `BusinessRuleViolation`.
-3. Set lead: `consultation_status_id='sts04'`, `pipeline_stage_id='stg02'`,
-   `status = derive_lead_status(sts04)` (= 'contacted'), `consultation_reengaged_at
-   = now`, `updated_at = now`.
-4. INSERT `lead_status_history` (old='sts20'/new='sts04', old_status='rejected'/
-   new_status='contacted', `changed_by_user_id` = reviewer, reason='reopen: <lý do>').
-5. `audit_service` log.
+3. **Capture old state TRƯỚC khi đổi**: `old_cs='sts20'`,
+   `old_status=lead.status` (canonical 'rejected'), `old_stage=lead.pipeline_stage_id`.
+4. **Mutate + sync (KHÔNG gán literal status/stage)**: set
+   `lead.consultation_status_id='sts04'`, `consultation_reengaged_at=now`,
+   `updated_at=now`; gọi `sync_lead_status`/`derive_lead_status` để suy `lead.status`
+   + `lead.pipeline_stage_id` từ sts04.
+5. **Ghi history từ state đã capture + ĐỌC LẠI sau sync**: INSERT
+   `lead_status_history` old=(`old_cs`, `old_status`, `old_stage`) →
+   new=(`'sts04'`, `lead.status`, `lead.pipeline_stage_id` *sau* sync),
+   `changed_by_user_id`=reviewer, reason='reopen: <lý do>'.
+6. `audit_service` log.
 
 ## 6. Phase A — MVP (manager/admin 1-click)
+
+### 6.0 Backend permission contract (BẮT BUỘC — để FE flag-driven)
+FE hiện nút theo **permission flag từ API**, KHÔNG `user.role`. Phải mở rộng chỗ
+populate `permissions`/`available_actions`/`action_blockers` của Lead detail
+(`lead_service.py` `_attach...`, hiện chỉ có `create_admission` —
+`permissions = {"create_admission": ...}`):
+- `permissions["can_reopen"] = (lead.consultation_status_id == 'sts20')` **và** user
+  là manager/admin (role-gate ở backend; FE chỉ đọc cờ).
+- `action_blockers["can_reopen"]` = lý do khi false (vd `not_terminal` / `forbidden`).
+- `available_actions` tự gồm `"can_reopen"` khi cờ true.
+Thiếu bước này → FE rơi lại role-check hoặc thiếu nút (đúng lỗi đã chỉ ra).
 
 ### 6.1 Service `app/services/lead_reopen_service.py`
 - `reopen_lead(db, lead_id, reviewer, reason) -> (lead, post_commit_cb)`
@@ -144,9 +167,13 @@ Guard REOPEN (lõi, dùng chung A/B), trong 1 transaction:
   onSuccess invalidate lead detail + danh sách (`react-query-mutation-cache-parity`).
 
 ### 6.5 Test Phase A (one-off container — `local-test-oneoff-container-pattern`)
-- reopen: lead sts20 → sts04 + status='contacted' + `reengaged_at` set + history
+- reopen: lead sts20 → sts04 + `status` = giá trị SAU `sync_lead_status` (canonical
+  'contacted' — verify qua helper, KHÔNG so literal) + `reengaged_at` set + history
   (changed_by=reviewer). Lead không sts20 → `BusinessRuleViolation`.
-- **beat đóng lại được** sau reopen rồi stale ≥30d (verify §3.2).
+- `can_reopen` flag (§6.0): true cho manager/admin trên lead sts20; false + blocker
+  cho lead không sts20.
+- **beat đóng lại được** sau reopen rồi stale lại ≥ `SLA_CONSULT_GIVEUP_DAYS`
+  (verify §3.2).
 - IDOR: manager mở lead ngoài unit → 404; role:user/officer → 403 (Casbin).
 - Race: 2 reopen song song → 1 thắng (FOR UPDATE).
 - Full FSM anchor matrix (guard #13.2 đổi).
@@ -239,42 +266,92 @@ thiệp = reopen). Khi code reopen, bổ sung:
 - **Abuse tracking** (Phase D): đếm reopen request bị REJECT của 1 officer trong N
   ngày; vượt ngưỡng → flag (giống `collaborator.is_flagged`). Báo admin.
 
-### 9.1 ⚠ Open question — vector soft-delete + tạo lại cùng SĐT
-Lead sts20 bị **soft-delete** → `uq_lead_phone_active` (partial `WHERE deleted_at
-IS NULL`) giải phóng SĐT → officer **tạo lead mới cùng SĐT**, **bỏ qua** kiểm soát
-reopen ("reopen lậu"). Cần quyết một trong:
-- (a) Hạn chế quyền xóa lead ở trạng thái terminal (sts20) cho officer; hoặc
-- (b) Khi tạo lead, phát hiện trùng SĐT với lead sts20 **đã xóa** → cảnh báo / buộc
-  dùng đường reopen.
-→ Chốt trước khi bật beat rộng (nếu để hở, beat càng đóng nhiều thì bề mặt lạm dụng
-càng lớn).
+### 9.1 Vector giải phóng SĐT + tạo lại cùng số — **acceptance bắt buộc của PR-A**
+
+> ⚠ **Sửa threat model (hard-review 2026-06-09).** Bản plan cũ giả định "officer
+> **xóa** lead sts20 → giải phóng SĐT". SAI: `delete_lead` là **admin-only**
+> (`lead_service.py:4201` enforce ở service + router Casbin) — officer KHÔNG xóa được
+> lead nào. Mitigation (a) cũ ("chặn officer xóa lead terminal") vì thế **vô nghĩa**
+> (officer vốn đã bị chặn xóa mọi lead). Cơ chế giải phóng SĐT cũng KHÔNG ở bảng `lead`:
+> `uq_lead_phone_active` nằm trên bảng riêng **`lead_phone_identity(phone_normalized)
+> WHERE deleted_at IS NULL`** (`lead_phone.py:34`, FK `ondelete=CASCADE`, cascade
+> soft-delete khi xóa/đổi phone).
+
+**Đường lách thật (officer làm được):** officer *assigned* **đổi số điện thoại** của
+lead sts20 qua `PUT /leads/{id}` — `update_lead` cho phép officer assigned
+(`lead_service.py:1291`); identity-lock (`:1334`) CHỈ khóa phone/email khi lead có
+AdmissionProfile ở approved/rejected/enrolled, mà lead sts20 (đi từ sts04 "từ chối tư
+vấn") gần như chắc chắn **chưa có** profile → KHÔNG bị khóa. Đổi phone →
+`update_phone_identities` (`:1613`) soft-delete identity cũ → SĐT cũ được giải phóng →
+officer `POST /leads` **tạo lead mới cùng SĐT** → lead mới ở sts00, **bỏ qua toàn bộ
+audit/kiểm soát reopen** ("reopen lậu").
+
+> ⚠⚠ **Sửa lần 2 (lúc bắt tay code 2026-06-09).** Ý "gate `create_lead` match SĐT lead
+> sts20" (B-1 bản đầu) **KHÔNG bịt được vector**: sau khi officer đổi phone lead sts20
+> X→Y, lead đó mang phone **Y** — query "lead sts20 có phone X" tìm thấy **rỗng**. Cơ
+> chế giải phóng phá luôn cái link mà B-1 định bắt. Defense đúng phải **giữ cho SĐT
+> không bị giải phóng khỏi lead terminal** ngay từ đầu.
+
+**Defense đúng = B-2 (khóa SĐT trên lead terminal) — PRIMARY, bắt buộc PR-A:**
+- **(B-2) Chặn đổi `phone`/`phone2` của lead consultation-terminal (sts20)** trong
+  `update_lead` (đặt ngay sau identity-lock `:1334`; chỉ chặn khi giá trị thật sự đổi).
+  Hệ quả dây chuyền bịt kín: SĐT **luôn khóa active** trên lead sts20 →
+  `create_lead` (`:912` `check_phone_conflict`, global `deleted_at IS NULL`) **đã** raise
+  `DuplicateResourceError` khi tạo trùng → officer **buộc phải reopen** (sts20→sts04, lúc
+  đó mới đổi/tái dùng được). **Airtight cho đường officer** — không cần gate create_lead.
+  - Lưu ý gồm **cả `phone2`** (cũng vào `lead_phone_identity`), KHÔNG chỉ `phone`.
+
+**Rẻ, nên có (UX — không phải security gate):**
+- **(B-1′) Cải thiện message `create_lead`**: khi `check_phone_conflict` trùng một lead
+  **sts20 chưa xóa**, đổi message từ "trùng SĐT" chung → **gợi ý mở lại (reopen)** lead
+  đó. Vì B-2 giữ SĐT luôn khóa trên lead sts20 nên B-1′ luôn có cơ hội kích hoạt đúng.
+
+**Defer / optional:**
+- Đường **admin-xóa** lead sts20 (giải phóng SĐT) → tạo lại: admin toàn quyền + có log
+  `audit_service.log_deleted` → defense-in-depth tùy chọn (gate create_lead match lead
+  sts20 **đã xóa**), KHÔNG bắt buộc PR-A.
 
 ## 10. PR breakdown (ước lượng)
 
 | PR | Phase | Nội dung | ~ |
 |---|---|---|---|
-| PR-A | A (MVP) | cột `consultation_reengaged_at` + sửa RULE #13.2 (mốc) + `reopen_lead` + endpoint `/leads/{id}/reopen` + Casbin manager/admin + FE nút/dialog + full FSM matrix | 1.5–2d |
+| PR-A | A (MVP) | cột `consultation_reengaged_at` + sửa RULE #13.2 (mốc) + `reopen_lead` + endpoint `/leads/{id}/reopen` + **permission contract `can_reopen` (§6.0)** + **guard "reopen lậu" §9.1 B-2 (khóa đổi phone/phone2 lead terminal) + B-1′ (message gợi ý reopen)** + Casbin manager/admin + FE nút/dialog + full FSM matrix | 2.5–3d |
 | PR-B | B | bảng `lead_reopen_request` + officer-request/approve/reject/cancel + IDOR scope (7.4) + inbox FE | 2–2.5d |
 | PR-C | C | notification events (requested/approved/rejected) | 1d |
 | PR-D | D | abuse tracking + báo cáo admin | 0.5–1d |
 
-**PR-A là lõi đủ để bật `SLA_AUTO_GIVEUP_ENABLED` an toàn** (manager mở lại được +
-beat đóng lại được + audit đủ). Phase B/C/D hoàn thiện luồng officer-self-service.
+**Bật `SLA_AUTO_GIVEUP_ENABLED` an toàn = PR-A TRỌN VẸN** (reopen MVP + guard §9.1 B-2
+khóa đổi phone lead terminal + permission contract §6.0): manager mở lại được + beat đóng lại
+được + audit đủ + không còn đường "reopen lậu". Phase B/C/D hoàn thiện luồng
+officer-self-service.
 
 ## 11. Rủi ro / điểm review kỹ
 
 - **Guard #13.2 đổi (§3.2)** là guard chung — phải full FSM anchor matrix + test
   hồi quy idempotency các event khác + test reopen→stale→đóng-lại. Đây là điểm
   review kỹ nhất của PR-A.
-- **Vector soft-delete-recreate (§9.1)** — chốt (a) hoặc (b) trước khi mở beat rộng.
+- **Vector "reopen lậu" (§9.1)** — đường thật = officer **đổi phone** lead sts20 rồi
+  tạo lead mới cùng số (KHÔNG phải officer-xóa: `delete_lead` admin-only). Bắt buộc
+  PR-A: **B-2 khóa đổi phone/phone2 trên lead terminal** (giữ SĐT khóa →
+  `check_phone_conflict` hiện hữu tự chặn tạo trùng → buộc reopen). Gate-match-phone ở
+  `create_lead` KHÔNG đủ (lead terminal mất phone sau giải phóng). Điểm review kỹ #2.
 - **IDOR scope approve/reject (§7.4)** — Phase B bắt buộc dependency unit-scope, không
   chỉ role.
 - **Không seed transition sts20→sts04** — nếu lỡ seed, bỏ qua được kiểm soát. Giữ
   reopen ở service chuyên dụng.
 - **derive_lead_status** — gọi helper, không hardcode `'contacted'` (verify canonical
   sts04 = contacted/stg02).
-- `uq_lead_phone_active` với **cùng** lead (reopen, không tạo mới) — an toàn; rủi ro
-  chỉ ở nhánh xóa-rồi-tạo-mới (§9.1).
-- **Consultation records outcome sts20**: nếu manager đóng tay qua `add_consultation`
-  tạo consultation `status_id='sts20'`, khi reopen lead về sts04 các consultation đó
-  vẫn ghi sts20 — xác nhận không lệch hiển thị/đếm.
+- `uq_lead_phone_active` (trên bảng `lead_phone_identity`, KHÔNG phải `lead`) với
+  **cùng** lead (reopen, không tạo mới) — an toàn; rủi ro chỉ ở nhánh giải-phóng-SĐT
+  (officer đổi-phone hoặc admin-xóa) rồi tạo-lead-mới (§9.1).
+- **Consultation records outcome sts20**: khi reopen lead về sts04, các consultation
+  `status_id='sts20'` đã tạo (cả **manual** qua `add_consultation` LẪN **beat**
+  `sla_tasks` — beat thêm Consultation hệ thống khi `assigned_officer_id` not null) vẫn
+  ghi sts20 → xác nhận không lệch hiển thị/đếm (sts20 `counts_for_funnel=true`). (C2)
+- **(C1) Assignment sau reopen**: beat KHÔNG reset `assigned_officer_id` → lead sts20
+  giữ officer cũ → reopen về sts04 thì officer cũ nhận lại + workload sts04 phục hồi
+  (assignment_service tính sts04 vào utilization). Đúng nghiệp vụ; reopen KHÔNG đụng
+  assignment. Nếu lead đã mất assignment thì quyết định auto-assign hay để pending.
+- **(C3) Index**: query #13.2 mới lọc `(lead_id, new_consultation_status_id,
+  changed_at)` — hiện chỉ single-column index. Scale nhỏ (ít history/lead) → KHÔNG
+  blocker; cân nhắc composite index khi tiện.

--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
@@ -25,6 +25,7 @@ import {
   Target,
   FileText,
   GraduationCap,
+  RotateCcw,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -59,6 +60,7 @@ import { useWorkflowContext } from "@/hooks/useWorkflowContext";
 import { LeadDialog } from "@/components/leads/LeadDialog";
 import { AssignLeadDialog } from "@/components/leads/AssignLeadDialog";
 import { ReassignLeadDialog } from "@/components/leads/ReassignLeadDialog";
+import { ReopenLeadDialog } from "@/components/leads/ReopenLeadDialog";
 import { LeadTimelineTab } from "@/components/leads/LeadTimelineTab";
 import { QuickConsultationSectionV2 } from "@/components/leads/QuickConsultationSectionV2";
 import { ActionBanner } from "@/components/leads/ActionBanner";
@@ -97,6 +99,7 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [assignDialogOpen, setAssignDialogOpen] = useState(false);
   const [reassignDialogOpen, setReassignDialogOpen] = useState(false);
+  const [reopenDialogOpen, setReopenDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [phoneCopied, setPhoneCopied] = useState(false);
 
@@ -351,6 +354,19 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
                 </TooltipProvider>
               )
             )}
+            {/* Mở lại tư vấn — hiện THUẦN theo cờ permissions.can_reopen từ API
+                (Thin Client: không đọc user.role). Backend bật cờ cho manager/admin
+                khi lead ở trạng thái cuối phase tư vấn (sts20). */}
+            {lead.permissions?.can_reopen && (
+              <Button
+                variant="default"
+                className="bg-amber-600 hover:bg-amber-700 rounded-xl shadow-lg shadow-amber-200"
+                onClick={() => setReopenDialogOpen(true)}
+              >
+                <RotateCcw className="mr-1.5 h-4 w-4" />
+                Mở lại tư vấn
+              </Button>
+            )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon" className="rounded-xl" aria-label="Tùy chọn khác">
@@ -508,6 +524,12 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
       <ReassignLeadDialog
         open={reassignDialogOpen}
         onOpenChange={setReassignDialogOpen}
+        lead={lead}
+      />
+
+      <ReopenLeadDialog
+        open={reopenDialogOpen}
+        onOpenChange={setReopenDialogOpen}
         lead={lead}
       />
 

--- a/frontend/src/components/leads/ReopenLeadDialog.tsx
+++ b/frontend/src/components/leads/ReopenLeadDialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { Loader2, RotateCcw } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -43,12 +43,9 @@ export function ReopenLeadDialog({
   const [reason, setReason] = useState("")
   const mutation = useReopenLead()
 
-  // Dialog luôn được mount (không key theo open) → xóa lý do cũ mỗi lần mở để không
-  // hiện lại text của lần submit lỗi trước nếu mở lại mà không qua bước đóng.
-  useEffect(() => {
-    if (open) setReason("")
-  }, [open])
-
+  // reason được xóa khi đóng dialog (onOpenChange !next → reset). Nút "Mở lại" chỉ mở
+  // dialog từ trạng thái đã đóng nên mỗi lần mở reason luôn rỗng — không cần effect
+  // reset-on-open (vi phạm rule setState-trong-effect).
   const reasonTrimmed = reason.trim()
   const reasonValid =
     reasonTrimmed.length >= REASON_MIN && reasonTrimmed.length <= REASON_MAX

--- a/frontend/src/components/leads/ReopenLeadDialog.tsx
+++ b/frontend/src/components/leads/ReopenLeadDialog.tsx
@@ -1,0 +1,147 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Loader2, RotateCcw } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { useReopenLead } from "@/hooks/useLeads"
+import type { LeadDetail } from "@/types/lead.types"
+
+interface ReopenLeadDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  lead: LeadDetail
+}
+
+// Mirror backend LeadReopenRequest.reason (min_length=5, max_length=500).
+const REASON_MIN = 5
+const REASON_MAX = 500
+
+/**
+ * Manager/admin entry to ``POST /leads/{id}/reopen`` — đưa một lead đã ngừng tư
+ * vấn (sts20) trở lại luồng tư vấn (sts04).
+ *
+ * Visibility được quyết định ở nơi gọi qua cờ ``lead.permissions.can_reopen``
+ * từ API (Thin Client — FE không tự suy quyền). Dialog chỉ thu lý do bắt buộc
+ * và gọi mutation; mọi guard nghiệp vụ nằm ở backend.
+ */
+export function ReopenLeadDialog({
+  open,
+  onOpenChange,
+  lead,
+}: ReopenLeadDialogProps) {
+  const [reason, setReason] = useState("")
+  const mutation = useReopenLead()
+
+  // Dialog luôn được mount (không key theo open) → xóa lý do cũ mỗi lần mở để không
+  // hiện lại text của lần submit lỗi trước nếu mở lại mà không qua bước đóng.
+  useEffect(() => {
+    if (open) setReason("")
+  }, [open])
+
+  const reasonTrimmed = reason.trim()
+  const reasonValid =
+    reasonTrimmed.length >= REASON_MIN && reasonTrimmed.length <= REASON_MAX
+
+  function reset() {
+    setReason("")
+  }
+
+  function handleSubmit() {
+    if (!reasonValid) return
+    mutation.mutate(
+      { leadId: lead.id, reason: reasonTrimmed },
+      {
+        onSuccess: () => {
+          reset()
+          onOpenChange(false)
+        },
+      },
+    )
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (mutation.isPending) return
+        onOpenChange(next)
+        if (!next) reset()
+      }}
+    >
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Mở lại tư vấn</DialogTitle>
+          <DialogDescription>
+            Lead <strong>{lead.full_name}</strong> đang ở trạng thái đã ngừng tư
+            vấn. Mở lại sẽ đưa lead về luồng tư vấn để tiếp tục chăm sóc. Lý do
+            được lưu lại để đối soát.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2 py-2">
+          <Label htmlFor="reopen-reason">
+            Lý do mở lại{" "}
+            <span className="text-muted-foreground text-xs">
+              (bắt buộc, ≥ {REASON_MIN} ký tự)
+            </span>
+          </Label>
+          <Textarea
+            id="reopen-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            disabled={mutation.isPending}
+            rows={3}
+            placeholder="Ví dụ: khách gọi lại ngày 09/06 muốn tiếp tục tư vấn ngành CĐ Điều dưỡng"
+            autoFocus
+          />
+          {reason && !reasonValid && (
+            <p className="text-xs text-destructive">
+              {reasonTrimmed.length < REASON_MIN
+                ? `Tối thiểu ${REASON_MIN} ký tự`
+                : `Tối đa ${REASON_MAX} ký tự`}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              if (mutation.isPending) return
+              onOpenChange(false)
+              reset()
+            }}
+            disabled={mutation.isPending}
+          >
+            Hủy
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!reasonValid || mutation.isPending}
+            className="bg-amber-600 hover:bg-amber-700"
+          >
+            {mutation.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <RotateCcw className="mr-2 h-4 w-4" />
+            )}
+            Mở lại tư vấn
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/hooks/useLeads.ts
+++ b/frontend/src/hooks/useLeads.ts
@@ -822,6 +822,68 @@ export function useAddConsultation() {
 }
 
 /**
+ * Reopen a consultation-terminal lead (sts20 → sts04). Manager/admin only —
+ * the button visibility is gated by ``lead.permissions.can_reopen`` from the API.
+ *
+ * @example
+ * ```tsx
+ * const reopen = useReopenLead();
+ * reopen.mutate({ leadId: 123, reason: "Khách đổi ý, muốn tư vấn lại" });
+ * ```
+ */
+export function useReopenLead() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    Lead,
+    AxiosError<ApiErrorResponse>,
+    { leadId: number; reason: string }
+  >({
+    mutationFn: async ({ leadId, reason }) => {
+      return await leadsApi.reopenLead(leadId, { reason });
+    },
+
+    onSuccess: async (_updatedLead, { leadId }) => {
+      toast.success("Đã mở lại tư vấn", {
+        description: "Lead trở về trạng thái tư vấn — bạn có thể tiếp tục.",
+      });
+
+      // Detail (cờ permissions + status đổi) + timeline + lists + workflow context.
+      await queryClient.invalidateQueries({
+        queryKey: leadsKeys.detail(leadId),
+        exact: true,
+        refetchType: "active",
+      });
+      queryClient.invalidateQueries({
+        queryKey: leadsKeys.timeline(leadId),
+        exact: true,
+        refetchType: "active",
+      });
+      queryClient.invalidateQueries({
+        queryKey: leadsKeys.lists(),
+        refetchType: "active",
+      });
+      queryClient.invalidateQueries({
+        queryKey: workflowContextKeys.byLead(leadId),
+        exact: true,
+        refetchType: "active",
+      });
+    },
+
+    onError: (error) => {
+      const detail = error.response?.data?.detail;
+      const message =
+        typeof detail === "string"
+          ? detail
+          : Array.isArray(detail)
+            ? detail.map((e) => e.msg).join(", ")
+            : "Không thể mở lại tư vấn";
+      toast.error("Lỗi mở lại tư vấn", { description: message });
+    },
+  });
+}
+
+/**
  * Update a consultation (admin: all, officer: most recent only)
  *
  * @example

--- a/frontend/src/lib/api/leads.ts
+++ b/frontend/src/lib/api/leads.ts
@@ -287,6 +287,23 @@ export async function addConsultation(
 }
 
 /**
+ * Reopen a consultation-terminal lead (sts20 → sts04). Manager/admin only.
+ *
+ * Backend re-opens the lead, sets the re-engage marker so the SLA beat can
+ * auto-close it again later. Returns the updated lead.
+ *
+ * @throws {AxiosError} 400 if lead not in a consultation-terminal state,
+ *   404 if lead not found / out of IDOR scope, 403 if not allowed (Casbin).
+ */
+export async function reopenLead(
+  leadId: number,
+  data: { reason: string }
+): Promise<Lead> {
+  const response = await api.post<Lead>(`/api/leads/${leadId}/reopen`, data)
+  return response.data
+}
+
+/**
  * Update consultation (admin: all, officer: most recent only)
  *
  * @throws {AxiosError} 404 if not found, 403 if no permission
@@ -591,6 +608,9 @@ export const leadsApi = {
   updateConsultation,
   deleteConsultation,
   restoreConsultation,
+
+  // Reopen (Phase A)
+  reopenLead,
 
   // Data Access
   getLeadTimeline,

--- a/frontend/src/types/lead.types.ts
+++ b/frontend/src/types/lead.types.ts
@@ -773,7 +773,11 @@ export interface APIError {
 export interface LeadDetail extends Lead {
   permissions: Record<string, boolean>;
   available_actions: string[];
-  action_blockers: Partial<Record<"create_admission", LeadAdmissionBlocker>>;
+  action_blockers: Partial<Record<"create_admission", LeadAdmissionBlocker>> & {
+    // Reopen (Phase A): "not_terminal" (lead không ở trạng thái cuối tư vấn) hoặc
+    // "forbidden" (không phải manager/admin). Cờ hiển thị đọc từ permissions.can_reopen.
+    can_reopen?: "not_terminal" | "forbidden";
+  };
 }
 
 /**


### PR DESCRIPTION
## Vì sao
`sts20 CONSULT_GIVEUP` ("Đã ngừng tư vấn") là trạng thái terminal cứng — lead quay lại (đổi ý) trước đây **không có đường mở lại** qua nghiệp vụ. PR này thêm reopen **có kiểm soát** cho manager/admin, đủ điều kiện để **bật `SLA_AUTO_GIVEUP_ENABLED` an toàn**.

## Thay đổi (Phase A / MVP)
**Backend**
- Cột `lead.consultation_reengaged_at` + migration `leadreopen_a_20260609` (kèm Casbin manager/admin `POST /api/leads/{id}/reopen`, `v3=eft`).
- **RULE #13.2** (`fsm_engine`): `EVER` → `since last re-engage` → beat auto-close đóng lại được sau reopen mà **KHÔNG xóa history** (audit append-only).
- `lead_reopen_service.reopen_lead`: `FOR UPDATE` (đọc fresh dưới lock) + re-check terminal + sync sts04 + **reset `last_consultation_at`** + bump `version` + history + audit. KHÔNG dùng FSM transition, KHÔNG seed sts20→sts04.
- **§9.1 chống "reopen lậu"**: B-2 khóa đổi phone/phone2 trên lead terminal (giữ SĐT khóa → `check_phone_conflict` tự chặn tạo trùng); B-1′ message gợi ý reopen.
- `can_reopen` permission contract (thin-client) + helper `is_consultation_terminal_status` (1 nguồn duy nhất, áp 5 site).

**Frontend** — nút "Mở lại tư vấn" gate `permissions.can_reopen` + dialog nhập lý do (`useReopenLead`, invalidate detail/list/timeline).

## Hard-review + tự review (max)
Plan `LEAD_REOPEN_WORKFLOW_PLAN.md` được hard-review (vá §9.1: officer KHÔNG xóa được lead — `delete_lead` admin-only — nên vector thật là **đổi phone**, defense = B-2 chứ không phải gate `create_lead`). Tự review `/code-review max` bắt + sửa **3 lỗi correctness thật**: (1) reopen không reset SLA clock → beat đóng lại ngay; (2) re-check đọc stale từ identity-map → `populate_existing=True`; (3) thiếu bump `version`.

## Verify
- **150/150 pytest** (one-off: test_sts20 + test_lead + test_pipeline).
- FE type-check + flake8 net-zero.
- Chrome smoke (admin, lead dev sts20→sts04): nút hiện đúng → dialog → submit → về sts04, nút biến mất + nút tư vấn trở lại, history/audit/`reengaged_at` đúng, 0 console error.

## Defer (theo plan)
Phase B (officer-request + bảng `lead_reopen_request`) · Phase C (notification + socket beat) · Phase D (abuse tracking). Hậu-merge: backfill ~100 lead sts04 tồn đọng + bật flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)