### PR TITLE
feat(leads): xin mở lại lead — officer xin → manager/admin duyệt (Phase B)

### DIFF
--- a/Backend_FastAPI/alembic/versions/leadreopen_b_20260609_reopen_request_table.py
+++ b/Backend_FastAPI/alembic/versions/leadreopen_b_20260609_reopen_request_table.py
@@ -1,0 +1,142 @@
+"""Phase B: bảng lead_reopen_request + Casbin policies (officer-request flow).
+
+Tạo bảng yêu cầu mở lại (officer xin → manager/admin duyệt) + 8 casbin policy cho
+5 endpoint. v3=eft BẮT BUỘC (auth_model.conf dùng p.eft).
+
+Revision ID: leadreopen_b_20260609
+Revises: leadreopen_a_20260609
+Create Date: 2026-06-09
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "leadreopen_b_20260609"
+down_revision: Union[str, None] = "leadreopen_a_20260609"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TEMPLATE_ID = "_leadreopen_b_20260609"
+# (v0=role, v1=obj, v2=act, v3=eft)
+_POLICIES = (
+    ("role:officer", "/api/leads/{lead_id}/reopen-requests", "POST", "allow"),
+    ("role:officer", "/api/reopen-requests/{request_id}", "DELETE", "allow"),
+    ("role:manager", "/api/reopen-requests", "GET", "allow"),
+    ("role:admin", "/api/reopen-requests", "GET", "allow"),
+    ("role:manager", "/api/reopen-requests/{request_id}/approve", "POST", "allow"),
+    ("role:admin", "/api/reopen-requests/{request_id}/approve", "POST", "allow"),
+    ("role:manager", "/api/reopen-requests/{request_id}/reject", "POST", "allow"),
+    ("role:admin", "/api/reopen-requests/{request_id}/reject", "POST", "allow"),
+)
+
+
+def _seed_policy(conn, v0: str, v1: str, v2: str, v3: str) -> None:
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id, applied_at)
+            SELECT 'p',
+                   CAST(:v0 AS VARCHAR), CAST(:v1 AS VARCHAR),
+                   CAST(:v2 AS VARCHAR), CAST(:v3 AS VARCHAR),
+                   :tid, NOW()
+            WHERE NOT EXISTS (
+                SELECT 1 FROM casbin_rule
+                WHERE ptype='p'
+                  AND v0=CAST(:v0 AS VARCHAR) AND v1=CAST(:v1 AS VARCHAR)
+                  AND v2=CAST(:v2 AS VARCHAR) AND v3=CAST(:v3 AS VARCHAR)
+            )
+            """
+        ),
+        {"v0": v0, "v1": v1, "v2": v2, "v3": v3, "tid": _TEMPLATE_ID},
+    )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "lead_reopen_request",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "lead_id", sa.Integer(), sa.ForeignKey("lead.id"), nullable=False
+        ),
+        sa.Column(
+            "requested_by_id",
+            sa.Integer(),
+            sa.ForeignKey("user.id"),
+            nullable=False,
+        ),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column(
+            "reviewed_by_id",
+            sa.Integer(),
+            sa.ForeignKey("user.id"),
+            nullable=True,
+        ),
+        sa.Column("review_note", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "unit_id",
+            sa.Integer(),
+            sa.ForeignKey("organization_unit.id"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'approved', 'rejected', 'cancelled')",
+            name="ck_lead_reopen_request_status",
+        ),
+    )
+    op.create_index(
+        "ix_lead_reopen_request_lead_id", "lead_reopen_request", ["lead_id"]
+    )
+    op.create_index(
+        "ix_lead_reopen_request_requested_by_id",
+        "lead_reopen_request",
+        ["requested_by_id"],
+    )
+    op.create_index(
+        "ix_lead_reopen_request_status", "lead_reopen_request", ["status"]
+    )
+    op.create_index(
+        "ix_lead_reopen_request_unit_id", "lead_reopen_request", ["unit_id"]
+    )
+    op.create_index(
+        "ix_lead_reopen_request_unit_status",
+        "lead_reopen_request",
+        ["unit_id", "status"],
+    )
+    op.create_index(
+        "uq_reopen_one_pending_per_lead",
+        "lead_reopen_request",
+        ["lead_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+
+    conn = op.get_bind()
+    for v0, v1, v2, v3 in _POLICIES:
+        _seed_policy(conn, v0, v1, v2, v3)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("DELETE FROM casbin_rule WHERE template_id = :tid"),
+        {"tid": _TEMPLATE_ID},
+    )
+    op.drop_table("lead_reopen_request")

--- a/Backend_FastAPI/alembic/versions/leadreopen_b_20260609_reopen_request_table.py
+++ b/Backend_FastAPI/alembic/versions/leadreopen_b_20260609_reopen_request_table.py
@@ -112,9 +112,8 @@ def upgrade() -> None:
     op.create_index(
         "ix_lead_reopen_request_status", "lead_reopen_request", ["status"]
     )
-    op.create_index(
-        "ix_lead_reopen_request_unit_id", "lead_reopen_request", ["unit_id"]
-    )
+    # KHÔNG tạo single index unit_id: composite (unit_id, status) bên dưới đã phủ
+    # (unit_id là cột dẫn đầu) → tránh index dư (chi phí ghi/space).
     op.create_index(
         "ix_lead_reopen_request_unit_status",
         "lead_reopen_request",

--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -1052,6 +1052,43 @@ async def get_lead_for_user(
     raise ResourceNotFoundError(detail="Lead not found")
 
 
+async def get_reopen_request_for_user(
+    request_id: int = Path(..., description="ID của reopen request"),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> models.LeadReopenRequest:
+    """IDOR cho approve/reject reopen-request (manager/admin).
+
+    Manager CHỈ thao tác request của lead trong unit của mình — so theo ``lead.unit_id``
+    HIỆN TẠI (KHÔNG dùng ``request.unit_id`` snapshot). Ngoài phạm vi → 404 (không 403,
+    không lộ tồn tại). Admin: toàn hệ thống. Xem LEAD_REOPEN_WORKFLOW_PLAN §7.4.
+    """
+    req = await db.get(models.LeadReopenRequest, request_id)
+    if req is None:
+        raise ResourceNotFoundError(detail="Reopen request not found")
+
+    if current_user.role == UserRole.ADMIN:
+        return req
+
+    if current_user.role == UserRole.MANAGER:
+        if current_user.unit_id is not None:
+            lead = await db.get(models.Lead, req.lead_id)
+            if lead is not None:
+                from ..repositories.organization_repository import (
+                    OrganizationRepository,
+                )
+
+                org_repo = OrganizationRepository(db)
+                allowed_unit_ids = await org_repo.get_descendant_unit_ids(
+                    current_user.unit_id
+                )
+                if lead.unit_id in allowed_unit_ids:
+                    return req
+        raise ResourceNotFoundError(detail="Reopen request not found")
+
+    raise ResourceNotFoundError(detail="Reopen request not found")
+
+
 # ============================================================================
 # OWNERSHIP VERIFICATION DEPENDENCIES (IDOR PREVENTION)
 # ============================================================================

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -64,6 +64,7 @@ from .routers import (
     kpi_planning,  # ✅ PHASE A6: KPI Planning Engine
     kpi_setup,  # ✅ KPI Setup: Coverage Dashboard
     leads,
+    reopen_requests,  # ✅ Lead reopen Phase B: officer-request inbox
     meta,  # ✅ Public metadata (KPI catalog)
     monitoring,
     notification_consents,  # ✅ PHASE B7: Notification Consent management
@@ -867,6 +868,7 @@ fastapi_app.include_router(zalo_webhooks.router)  # ✅ PHASE C1: Zalo webhooks 
 fastapi_app.include_router(zalo_bot_webhooks.router)  # ✅ v5 Step 18: Zalo Bot webhook (shared-secret header)
 fastapi_app.include_router(zalo_bot_link.router)  # ✅ v5 Step 19: Staff Zalo Bot link API
 fastapi_app.include_router(leads.router, prefix="/api/leads")
+fastapi_app.include_router(reopen_requests.router, prefix="/api/reopen-requests")
 fastapi_app.include_router(collaborators.admin_router, prefix="/api")  # ✅ CTV: Admin/Manager CTV management
 fastapi_app.include_router(collaborators.ctv_router, prefix="/api")  # ✅ CTV: Self-service endpoints
 fastapi_app.include_router(collaborators.public_router, prefix="/api")  # ✅ CTV P2: Public self-registration (no auth)

--- a/Backend_FastAPI/app/models/__init__.py
+++ b/Backend_FastAPI/app/models/__init__.py
@@ -32,6 +32,7 @@ from .commission import CommissionPolicy, CommissionRecord
 from .lead import AssignmentDecisionLog, AssignmentLog, Consultation, CRMInteraction, Lead
 from .lead_history import LeadStatusHistory
 from .lead_phone import LeadPhoneIdentity
+from .lead_reopen_request import LeadReopenRequest
 
 # Admission models (NEW: Replacement for Application)
 from .admission import AdmissionProfile, AdmissionConfirmationToken
@@ -183,6 +184,7 @@ __all__ = [
     "CRMInteraction",
     "Lead",
     "LeadPhoneIdentity",
+    "LeadReopenRequest",
     "LeadStatusHistory",
     # Admission (NEW)
     "AdmissionProfile",

--- a/Backend_FastAPI/app/models/lead_reopen_request.py
+++ b/Backend_FastAPI/app/models/lead_reopen_request.py
@@ -77,11 +77,12 @@ class LeadReopenRequest(Base):
     # CHỈ để filter/sort list duyệt — KHÔNG phải nguồn phân quyền. IDOR
     # approve/reject dùng lead.unit_id HIỆN TẠI (get_reopen_request_for_user §7.4),
     # KHÔNG dùng snapshot.
+    # KHÔNG index=True đơn lẻ: composite ix_lead_reopen_request_unit_status có
+    # unit_id làm cột dẫn đầu nên đã phủ truy vấn theo unit_id.
     unit_id = Column(
         Integer,
         ForeignKey("organization_unit.id"),
         nullable=False,
-        index=True,
     )
 
     lead = relationship("Lead", foreign_keys=[lead_id])

--- a/Backend_FastAPI/app/models/lead_reopen_request.py
+++ b/Backend_FastAPI/app/models/lead_reopen_request.py
@@ -1,0 +1,89 @@
+# app/models/lead_reopen_request.py
+"""Lead reopen request (Phase B) — officer xin mở lại lead "Đã ngừng tư vấn".
+
+Phase A: chỉ manager/admin tự mở lại (sts20→sts04). Phase B: officer assigned GỬI yêu
+cầu → manager/admin DUYỆT (approve gọi lõi ``lead_reopen_service.reopen_lead``) hoặc TỪ
+CHỐI (lead giữ sts20). Xem Documents/LEAD_REOPEN_WORKFLOW_PLAN.md §7.
+"""
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    text,
+)
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class LeadReopenRequest(Base):
+    """Yêu cầu mở lại lead consultation-terminal (officer xin → manager/admin duyệt)."""
+
+    __tablename__ = "lead_reopen_request"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('pending', 'approved', 'rejected', 'cancelled')",
+            name="ck_lead_reopen_request_status",
+        ),
+        # Chặn 2 pending cùng 1 lead (race-safe, chống spam). Partial unique.
+        Index(
+            "uq_reopen_one_pending_per_lead",
+            "lead_id",
+            unique=True,
+            postgresql_where=text("status = 'pending'"),
+        ),
+        # Index list duyệt theo unit + status.
+        Index("ix_lead_reopen_request_unit_status", "unit_id", "status"),
+    )
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    lead_id = Column(Integer, ForeignKey("lead.id"), nullable=False, index=True)
+    requested_by_id = Column(
+        Integer,
+        ForeignKey("user.id"),
+        nullable=False,
+        index=True,
+        comment="Officer xin mở lại",
+    )
+    reason = Column(Text, nullable=False)
+    status = Column(
+        String(20),
+        nullable=False,
+        default="pending",
+        index=True,
+        comment="pending | approved | rejected | cancelled",
+    )
+    reviewed_by_id = Column(
+        Integer,
+        ForeignKey("user.id"),
+        nullable=True,
+        comment="Manager/admin duyệt",
+    )
+    review_note = Column(Text, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("now()"),
+    )
+    reviewed_at = Column(DateTime(timezone=True), nullable=True)
+    # CHỈ để filter/sort list duyệt — KHÔNG phải nguồn phân quyền. IDOR
+    # approve/reject dùng lead.unit_id HIỆN TẠI (get_reopen_request_for_user §7.4),
+    # KHÔNG dùng snapshot.
+    unit_id = Column(
+        Integer,
+        ForeignKey("organization_unit.id"),
+        nullable=False,
+        index=True,
+    )
+
+    lead = relationship("Lead", foreign_keys=[lead_id])
+    requested_by = relationship("User", foreign_keys=[requested_by_id])
+    reviewed_by = relationship("User", foreign_keys=[reviewed_by_id])

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -1787,6 +1787,54 @@ async def reopen_lead_endpoint(
 
 
 # =============================================================================
+# REOPEN REQUEST (Phase B) — officer XIN mở lại (chờ manager/admin duyệt)
+# =============================================================================
+
+
+@limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
+@router.post(
+    "/{lead_id}/reopen-requests",
+    response_model=schemas.LeadReopenRequestOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_reopen_request(
+    request: Request,
+    body: schemas.LeadReopenRequest,
+    lead: models.Lead = LeadAccessDep,
+    current_user: models.User = CasbinAuth,
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Officer (assigned) XIN mở lại lead đã ngừng tư vấn — chờ manager/admin duyệt.
+
+    IDOR officer-assigned qua ``get_lead_for_user`` (404 nếu không phải lead của mình);
+    Casbin chỉ cho ``role:officer``. Manager/admin dùng ``POST /reopen`` (mở trực tiếp).
+    """
+    from ..services import lead_reopen_service
+
+    result, callback = await lead_reopen_service.request_reopen(
+        db, lead.id, current_user, body.reason
+    )
+    await db.commit()
+    if callback:
+        await callback()
+
+    return schemas.LeadReopenRequestOut(
+        id=result.id,
+        lead_id=result.lead_id,
+        requested_by_id=result.requested_by_id,
+        reason=result.reason,
+        status=result.status,
+        reviewed_by_id=result.reviewed_by_id,
+        review_note=result.review_note,
+        created_at=result.created_at,
+        reviewed_at=result.reviewed_at,
+        unit_id=result.unit_id,
+        lead_name=lead.full_name,
+        requested_by_name=current_user.full_name or current_user.username,
+    )
+
+
+# =============================================================================
 # LEAD VALIDITY STATUS (Collaborator System Phase 1)
 # =============================================================================
 

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -1747,7 +1747,7 @@ async def update_lead_consultation_status(
 @router.post("/{lead_id}/reopen", response_model=schemas.Lead)
 async def reopen_lead_endpoint(
     request: Request,
-    body: schemas.LeadReopenRequest,
+    body: schemas.ReopenReasonBody,
     lead: models.Lead = LeadAccessDep,
     current_user: models.User = CasbinAuth,
     db: AsyncSession = Depends(database.get_db),
@@ -1799,7 +1799,7 @@ async def reopen_lead_endpoint(
 )
 async def create_reopen_request(
     request: Request,
-    body: schemas.LeadReopenRequest,
+    body: schemas.ReopenReasonBody,
     lead: models.Lead = LeadAccessDep,
     current_user: models.User = CasbinAuth,
     db: AsyncSession = Depends(database.get_db),

--- a/Backend_FastAPI/app/routers/reopen_requests.py
+++ b/Backend_FastAPI/app/routers/reopen_requests.py
@@ -1,0 +1,127 @@
+# app/routers/reopen_requests.py
+"""Reopen request inbox (Phase B) — duyệt/từ chối/hủy yêu cầu mở lại lead.
+
+Đăng ký với prefix ``/api/reopen-requests`` (main.py). Casbin (migration
+leadreopen_b) gate role per-endpoint; IDOR approve/reject qua
+``get_reopen_request_for_user`` (unit-scope theo lead hiện tại). Xem
+Documents/LEAD_REOPEN_WORKFLOW_PLAN.md §7.
+"""
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Path, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import database, models, schemas
+from ..core.deps import CasbinAuth, get_reopen_request_for_user
+from ..core.rate_limits import limiter, RateLimits
+from ..services import lead_reopen_service
+
+router = APIRouter(tags=["reopen-requests"])
+
+ReopenRequestDep = Depends(get_reopen_request_for_user)
+
+
+def _name(user: Optional[models.User]) -> Optional[str]:
+    if user is None:
+        return None
+    return user.full_name or user.username
+
+
+def _serialize(
+    req: models.LeadReopenRequest,
+    *,
+    lead_name: Optional[str] = None,
+    requested_by_name: Optional[str] = None,
+    reviewed_by_name: Optional[str] = None,
+) -> schemas.LeadReopenRequestOut:
+    return schemas.LeadReopenRequestOut(
+        id=req.id,
+        lead_id=req.lead_id,
+        requested_by_id=req.requested_by_id,
+        reason=req.reason,
+        status=req.status,
+        reviewed_by_id=req.reviewed_by_id,
+        review_note=req.review_note,
+        created_at=req.created_at,
+        reviewed_at=req.reviewed_at,
+        unit_id=req.unit_id,
+        lead_name=lead_name,
+        requested_by_name=requested_by_name,
+        reviewed_by_name=reviewed_by_name,
+    )
+
+
+@limiter.limit(RateLimits.DATA_READ)  # 1000/hour
+@router.get("", response_model=List[schemas.LeadReopenRequestOut])
+async def list_requests(
+    request: Request,
+    status: Optional[str] = None,
+    current_user: models.User = CasbinAuth,
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Inbox duyệt (manager/admin). Manager scope theo ``lead.unit_id`` hiện tại; admin
+    toàn hệ thống. ``status`` lọc tùy chọn (vd 'pending')."""
+    reqs = await lead_reopen_service.list_reopen_requests(
+        db, current_user, status=status
+    )
+    return [
+        _serialize(
+            r,
+            lead_name=r.lead.full_name if r.lead else None,
+            requested_by_name=_name(r.requested_by),
+            reviewed_by_name=_name(r.reviewed_by),
+        )
+        for r in reqs
+    ]
+
+
+@limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
+@router.post("/{request_id}/approve", response_model=schemas.LeadReopenRequestOut)
+async def approve_request(
+    request: Request,
+    body: schemas.ReopenReviewBody,
+    reopen_request: models.LeadReopenRequest = ReopenRequestDep,
+    current_user: models.User = CasbinAuth,
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Manager/admin DUYỆT → gọi lõi reopen (lead về sts04)."""
+    result, callback = await lead_reopen_service.approve_reopen(
+        db, reopen_request.id, current_user, note=body.note
+    )
+    await db.commit()
+    if callback:
+        await callback()
+    return _serialize(result, reviewed_by_name=_name(current_user))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
+@router.post("/{request_id}/reject", response_model=schemas.LeadReopenRequestOut)
+async def reject_request(
+    request: Request,
+    body: schemas.ReopenReviewBody,
+    reopen_request: models.LeadReopenRequest = ReopenRequestDep,
+    current_user: models.User = CasbinAuth,
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Manager/admin TỪ CHỐI (note bắt buộc, validate ở service); lead giữ sts20."""
+    result, callback = await lead_reopen_service.reject_reopen(
+        db, reopen_request.id, current_user, note=body.note or ""
+    )
+    await db.commit()
+    if callback:
+        await callback()
+    return _serialize(result, reviewed_by_name=_name(current_user))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
+@router.delete("/{request_id}", response_model=schemas.LeadReopenRequestOut)
+async def cancel_request(
+    request: Request,
+    request_id: int = Path(..., description="ID reopen request"),
+    current_user: models.User = CasbinAuth,
+    db: AsyncSession = Depends(database.get_db),
+):
+    """Officer HỦY yêu cầu pending của CHÍNH mình (service check ownership → 404)."""
+    result = await lead_reopen_service.cancel_reopen(db, request_id, current_user)
+    await db.commit()
+    return _serialize(result)

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -129,7 +129,7 @@ from .lead import (
     LeadBase,
     LeadCreate,
     LeadDetail,
-    LeadReopenRequest,  # ✅ Reopen Phase A: body POST /leads/{id}/reopen
+    ReopenReasonBody,  # ✅ Reopen: body {reason} (Phase A reopen + Phase B request)
     ReopenReviewBody,  # ✅ Reopen Phase B: body approve/reject
     LeadReopenRequestOut,  # ✅ Reopen Phase B: response 1 yêu cầu
     LeadImportError,

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -130,6 +130,8 @@ from .lead import (
     LeadCreate,
     LeadDetail,
     LeadReopenRequest,  # ✅ Reopen Phase A: body POST /leads/{id}/reopen
+    ReopenReviewBody,  # ✅ Reopen Phase B: body approve/reject
+    LeadReopenRequestOut,  # ✅ Reopen Phase B: response 1 yêu cầu
     LeadImportError,
     LeadImportResult,
     LeadInsights,

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -466,6 +466,36 @@ class LeadReopenRequest(BaseModel):
     )
 
 
+class ReopenReviewBody(BaseModel):
+    """Body approve/reject reopen-request. ``note`` optional khi duyệt, BẮT BUỘC khi
+    từ chối (validate ở service)."""
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    note: Optional[str] = Field(
+        None, max_length=500, description="Ghi chú duyệt / lý do từ chối."
+    )
+
+
+class LeadReopenRequestOut(BaseModel):
+    """Response 1 yêu cầu mở lại (inbox manager). Tên denormalized populate ở router."""
+    id: int
+    lead_id: int
+    requested_by_id: int
+    reason: str
+    status: str
+    reviewed_by_id: Optional[int] = None
+    review_note: Optional[str] = None
+    created_at: datetime
+    reviewed_at: Optional[datetime] = None
+    unit_id: int
+    # Denormalized cho hiển thị inbox (router set từ selectinload):
+    lead_name: Optional[str] = None
+    requested_by_name: Optional[str] = None
+    reviewed_by_name: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class LeadsSummary(BaseModel):
     """Aggregate stats over the entire filtered set (not just current page)."""
     new_count: int = 0

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -448,11 +448,13 @@ class LeadDetail(Lead):
     model_config = ConfigDict(from_attributes=True)
 
 
-class LeadReopenRequest(BaseModel):
-    """Body cho POST /leads/{lead_id}/reopen — mở lại lead đã ngừng tư vấn.
+class ReopenReasonBody(BaseModel):
+    """Body ``{reason}`` cho mở lại / xin mở lại lead đã ngừng tư vấn.
 
-    Chỉ manager/admin (role-gate ở backend Casbin + IDOR). ``reason`` bắt buộc, lưu
-    nguyên văn để audit. Xem Documents/LEAD_REOPEN_WORKFLOW_PLAN.md.
+    Dùng cho POST /leads/{id}/reopen (Phase A, manager/admin) và
+    POST /leads/{id}/reopen-requests (Phase B, officer xin). Đổi tên từ
+    ``LeadReopenRequest`` để KHÔNG nhầm với model ``models.LeadReopenRequest`` (bảng).
+    ``reason`` bắt buộc, lưu nguyên văn để audit.
     """
     # Strip whitespace TRƯỚC khi đếm min_length → "     " (5 dấu cách) bị chặn ngay ở
     # Pydantic (422) thay vì lọt tới service rồi mới reject (400) — nhất quán mã lỗi.

--- a/Backend_FastAPI/app/services/lead_reopen_service.py
+++ b/Backend_FastAPI/app/services/lead_reopen_service.py
@@ -141,6 +141,29 @@ async def _apply_reopen(
     )
 
 
+async def _resolve_pending_requests(
+    db: AsyncSession, lead_id: int, reviewer: models.User
+) -> None:
+    """Đánh dấu mọi pending reopen-request của lead = ``approved`` (tự động) khi lead
+    đã được mở lại bằng đường khác (Phase A direct reopen). Partial-unique đảm bảo tối
+    đa 1 pending. Gọi DƯỚI lock lead (serialize với request_reopen) nên không race.
+    """
+    pending = (
+        await db.execute(
+            select(models.LeadReopenRequest).where(
+                models.LeadReopenRequest.lead_id == lead_id,
+                models.LeadReopenRequest.status == "pending",
+            )
+        )
+    ).scalars().all()
+    now = datetime.now(timezone.utc)
+    for preq in pending:
+        preq.status = "approved"
+        preq.reviewed_by_id = reviewer.id
+        preq.review_note = "Tự động duyệt: lead đã được mở lại trực tiếp."
+        preq.reviewed_at = now
+
+
 async def reopen_lead(
     db: AsyncSession,
     lead_id: int,
@@ -173,6 +196,11 @@ async def reopen_lead(
     async with db.begin_nested():
         lead = await _lock_terminal_lead(db, lead_id)
         await _apply_reopen(db, lead, reviewer, reason_text)
+        # Lead mở lại TRỰC TIẾP (Phase A, không qua approve_reopen) → mọi pending
+        # request của officer trở nên mồ côi nếu để nguyên (không bao giờ duyệt được
+        # vì lead hết terminal). Auto-resolve để inbox sạch + officer không kẹt
+        # ConflictError khi xin lại sau này.
+        await _resolve_pending_requests(db, lead.id, reviewer)
 
     async def _post_commit() -> None:
         # MVP: no-op. Phase C: dispatch LEAD_REOPEN_* notifications here.
@@ -428,7 +456,9 @@ async def list_reopen_requests(
     if status:
         q = q.where(models.LeadReopenRequest.status == status)
 
-    if user.role == UserRole.MANAGER:
+    if user.role == UserRole.ADMIN:
+        pass  # admin: toàn hệ thống (không lọc unit).
+    elif user.role == UserRole.MANAGER:
         if user.unit_id is None:
             return []
         from ..repositories.organization_repository import OrganizationRepository
@@ -439,7 +469,10 @@ async def list_reopen_requests(
         q = q.join(
             models.Lead, models.LeadReopenRequest.lead_id == models.Lead.id
         ).where(models.Lead.unit_id.in_(allowed))
-    # admin: không lọc unit (toàn hệ thống).
+    else:
+        # Defense-in-depth: role ngoài {admin, manager} KHÔNG xem được. Casbin đã
+        # gate endpoint; đây là rào nếu hàm bị tái dùng nơi khác.
+        return []
 
     result = await db.execute(q)
     return list(result.scalars().all())

--- a/Backend_FastAPI/app/services/lead_reopen_service.py
+++ b/Backend_FastAPI/app/services/lead_reopen_service.py
@@ -188,12 +188,18 @@ async def reopen_lead(
 async def _lock_request(
     db: AsyncSession, request_id: int
 ) -> models.LeadReopenRequest:
-    """Lock 1 reopen request row (FOR UPDATE). Raise 404 nếu không có."""
+    """Lock 1 reopen request row (FOR UPDATE). Raise 404 nếu không có.
+
+    populate_existing=True: dep IDOR ``get_reopen_request_for_user`` đã nạp request vào
+    identity-map (không khóa) trước handler → FOR UPDATE phải refresh để re-check status
+    đọc giá trị fresh dưới lock (cùng bài học bug #2 của lead).
+    """
     req = (
         await db.execute(
             select(models.LeadReopenRequest)
             .where(models.LeadReopenRequest.id == request_id)
             .with_for_update()
+            .execution_options(populate_existing=True)
         )
     ).scalar_one_or_none()
     if req is None:

--- a/Backend_FastAPI/app/services/lead_reopen_service.py
+++ b/Backend_FastAPI/app/services/lead_reopen_service.py
@@ -23,15 +23,19 @@ trong 1 transaction:
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Callable, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import structlog
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from .. import models
+from ..core.constants import UserRole
 from ..services import audit_service
 from ..utils.exceptions import (
     BusinessRuleViolation,
+    ConflictError,
     ResourceNotFoundError,
     ValidationError,
 )
@@ -48,6 +52,93 @@ REOPEN_TARGET_STATUS_ID = "sts04"
 
 # Lý do bắt buộc — min length (service-side guard; schema cũng validate cho đường API).
 _REASON_MIN_LEN = 5
+
+
+async def _lock_terminal_lead(db: AsyncSession, lead_id: int) -> models.Lead:
+    """Lock lead row (FOR UPDATE, đọc fresh dưới lock) + verify chưa xóa + đang ở
+    consultation-terminal. Raise nếu không hợp lệ. Trả lead đã khóa.
+
+    Dùng chung cho reopen trực tiếp (Phase A) và request/approve (Phase B).
+    """
+    repo = LeadRepository(db)
+    lead = await repo.get_by_id_for_update(lead_id, populate_existing=True)
+    if lead is None:
+        raise ResourceNotFoundError(detail=f"Lead with id {lead_id} not found")
+    if lead.deleted_at is not None:
+        raise BusinessRuleViolation(detail="Không thể mở lại một lead đã bị xóa.")
+    current_cs = (
+        await db.get(models.ConsultationStatus, lead.consultation_status_id)
+        if lead.consultation_status_id
+        else None
+    )
+    if not is_consultation_terminal_status(current_cs):
+        raise BusinessRuleViolation(
+            detail=(
+                "Chỉ thao tác được khi lead đang ở trạng thái cuối phase tư vấn "
+                "(đã ngừng tư vấn). Lead này không ở trạng thái đó."
+            )
+        )
+    return lead
+
+
+async def _apply_reopen(
+    db: AsyncSession,
+    lead: models.Lead,
+    reviewer: models.User,
+    reason_text: str,
+) -> None:
+    """Lõi mutate reopen sts20→sts04 — GIẢ ĐỊNH lead đã được lock + đã verify terminal.
+
+    Dùng chung Phase A (``reopen_lead``) và Phase B (``approve_reopen``). KHÔNG tự
+    lock / begin_nested (caller giữ lock). Suy status/stage từ sts04, set mốc re-engage,
+    reset đồng hồ SLA, bump version, ghi history + audit.
+    """
+    old_state = _get_current_lead_state(lead)
+    old_cs_id = lead.consultation_status_id
+
+    target_cs = await db.get(models.ConsultationStatus, REOPEN_TARGET_STATUS_ID)
+    if target_cs is None:
+        raise ResourceNotFoundError(
+            detail=f"Thiếu trạng thái re-engage '{REOPEN_TARGET_STATUS_ID}'."
+        )
+
+    now = datetime.now(timezone.utc)
+    await StatusHelper.sync_lead_status(lead, target_cs)
+    lead.consultation_reengaged_at = now
+    lead.updated_at = now
+    # Reset đồng hồ SLA (close_stale dùng coalesce(last_consultation_at,...)) + bump
+    # version (optimistic-lock — mọi thay đổi trạng thái phải tăng version).
+    lead.last_consultation_at = now
+    lead.version = (lead.version or 1) + 1
+
+    new_state = _get_current_lead_state(lead)
+    await _log_lead_state_change(
+        db, lead, old_state, new_state,
+        changed_by=reviewer, reason=f"reopen: {reason_text}",
+    )
+    await audit_service.log_audit(
+        db,
+        entity_type="Lead",
+        entity_id=lead.id,
+        action="consultation_reopened",
+        actor_user_id=reviewer.id,
+        changes={
+            "consultation_status_id": {
+                "old": old_cs_id,
+                "new": REOPEN_TARGET_STATUS_ID,
+            },
+            "status": {"old": old_state.get("status"), "new": lead.status},
+        },
+        reason=f"reopen: {reason_text}",
+        source="api",
+    )
+    log.info(
+        "Lead reopened",
+        lead_id=lead.id,
+        from_consultation_status=old_cs_id,
+        to_consultation_status=REOPEN_TARGET_STATUS_ID,
+        reviewer_id=reviewer.id,
+    )
 
 
 async def reopen_lead(
@@ -73,103 +164,276 @@ async def reopen_lead(
         BusinessRuleViolation: lead đã xóa / không ở trạng thái cuối phase tư vấn.
         ValidationError: thiếu lý do.
     """
-    if not reason or len(reason.strip()) < _REASON_MIN_LEN:
+    reason_text = (reason or "").strip()
+    if len(reason_text) < _REASON_MIN_LEN:
         raise ValidationError(
             detail=f"Lý do mở lại là bắt buộc (tối thiểu {_REASON_MIN_LEN} ký tự)."
         )
 
-    repo = LeadRepository(db)
-
     async with db.begin_nested():
-        # 1. Lock lead row (chống double-reopen / TOCTOU). populate_existing=True để
-        #    ĐỌC LẠI giá trị từ row đã khóa — nếu không, LeadAccessDep đã nạp lead vào
-        #    identity-map trước đó (không khóa) và SQLAlchemy trả instance cũ KHÔNG
-        #    refresh → re-check bên dưới sẽ chạy trên snapshot pre-lock.
-        lead = await repo.get_by_id_for_update(lead_id, populate_existing=True)
-        if lead is None:
-            raise ResourceNotFoundError(detail=f"Lead with id {lead_id} not found")
-        if lead.deleted_at is not None:
-            raise BusinessRuleViolation(detail="Không thể mở lại một lead đã bị xóa.")
-
-        # 2. Re-check trạng thái cuối phase tư vấn (DB, giá trị đã refresh dưới lock).
-        current_cs = (
-            await db.get(models.ConsultationStatus, lead.consultation_status_id)
-            if lead.consultation_status_id
-            else None
-        )
-        if not is_consultation_terminal_status(current_cs):
-            raise BusinessRuleViolation(
-                detail=(
-                    "Chỉ mở lại được lead đang ở trạng thái cuối phase tư vấn "
-                    "(đã ngừng tư vấn). Lead này không ở trạng thái đó."
-                )
-            )
-
-        # 3. Capture old state TRƯỚC khi đổi.
-        old_state = _get_current_lead_state(lead)
-        old_cs_id = lead.consultation_status_id
-
-        target_cs = await db.get(models.ConsultationStatus, REOPEN_TARGET_STATUS_ID)
-        if target_cs is None:
-            # Cấu hình thiếu trạng thái re-engage — fail-closed, không mutate.
-            raise ResourceNotFoundError(
-                detail=f"Thiếu trạng thái re-engage '{REOPEN_TARGET_STATUS_ID}'."
-            )
-
-        # 4. Mutate + sync (KHÔNG gán literal status/stage — suy từ sts04).
-        now = datetime.now(timezone.utc)
-        await StatusHelper.sync_lead_status(lead, target_cs)
-        lead.consultation_reengaged_at = now
-        lead.updated_at = now
-        # Reset đồng hồ SLA: nếu không, coalesce(last_consultation_at, updated_at,
-        # created_at) trong close_stale_rejected_leads vẫn thấy mốc give-up cũ → beat
-        # auto-close lại NGAY lần chạy kế, vô hiệu hóa reopen khi bật
-        # SLA_AUTO_GIVEUP_ENABLED. Cho lead một cửa sổ SLA mới kể từ lúc mở lại.
-        lead.last_consultation_at = now
-        # Optimistic-lock: mọi thay đổi trạng thái phải tăng version (đồng bộ
-        # update_lead) để một edit dựa trên snapshot pre-reopen bị chặn 409 đúng cách.
-        lead.version = (lead.version or 1) + 1
-
-        # 5. Ghi history từ state đã capture + ĐỌC LẠI status/stage SAU sync.
-        new_state = _get_current_lead_state(lead)
-        await _log_lead_state_change(
-            db,
-            lead,
-            old_state,
-            new_state,
-            changed_by=reviewer,
-            reason=f"reopen: {reason.strip()}",
-        )
-
-        # 6. Audit.
-        await audit_service.log_audit(
-            db,
-            entity_type="Lead",
-            entity_id=lead.id,
-            action="consultation_reopened",
-            actor_user_id=reviewer.id,
-            changes={
-                "consultation_status_id": {
-                    "old": old_cs_id,
-                    "new": REOPEN_TARGET_STATUS_ID,
-                },
-                "status": {"old": old_state.get("status"), "new": lead.status},
-            },
-            reason=f"reopen: {reason.strip()}",
-            source="api",
-        )
-
-        log.info(
-            "Lead reopened",
-            lead_id=lead.id,
-            from_consultation_status=old_cs_id,
-            to_consultation_status=REOPEN_TARGET_STATUS_ID,
-            reviewer_id=reviewer.id,
-            reengaged_at=now,
-        )
+        lead = await _lock_terminal_lead(db, lead_id)
+        await _apply_reopen(db, lead, reviewer, reason_text)
 
     async def _post_commit() -> None:
         # MVP: no-op. Phase C: dispatch LEAD_REOPEN_* notifications here.
         return None
 
     return lead, _post_commit
+
+
+# ===========================================================================
+# Phase B — officer xin mở lại → manager/admin duyệt (lead_reopen_request)
+# ===========================================================================
+
+async def _lock_request(
+    db: AsyncSession, request_id: int
+) -> models.LeadReopenRequest:
+    """Lock 1 reopen request row (FOR UPDATE). Raise 404 nếu không có."""
+    req = (
+        await db.execute(
+            select(models.LeadReopenRequest)
+            .where(models.LeadReopenRequest.id == request_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if req is None:
+        raise ResourceNotFoundError(
+            detail=f"Reopen request {request_id} not found"
+        )
+    return req
+
+
+async def request_reopen(
+    db: AsyncSession,
+    lead_id: int,
+    requested_by: models.User,
+    reason: str,
+) -> Tuple[models.LeadReopenRequest, Callable]:
+    """Officer GỬI yêu cầu mở lại lead terminal (KHÔNG tự mở — chờ duyệt).
+
+    IDOR (officer assigned) đã enforce ở dep ``get_lead_for_user``. Guard: lead
+    terminal + chưa có pending (partial-unique cũng chặn; check trước cho 409 rõ).
+    """
+    reason_text = (reason or "").strip()
+    if len(reason_text) < _REASON_MIN_LEN:
+        raise ValidationError(
+            detail=f"Lý do là bắt buộc (tối thiểu {_REASON_MIN_LEN} ký tự)."
+        )
+
+    async with db.begin_nested():
+        lead = await _lock_terminal_lead(db, lead_id)
+
+        existing = (
+            await db.execute(
+                select(models.LeadReopenRequest)
+                .where(
+                    models.LeadReopenRequest.lead_id == lead_id,
+                    models.LeadReopenRequest.status == "pending",
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            raise ConflictError(
+                detail="Lead này đã có một yêu cầu mở lại đang chờ duyệt."
+            )
+
+        req = models.LeadReopenRequest(
+            lead_id=lead_id,
+            requested_by_id=requested_by.id,
+            reason=reason_text,
+            status="pending",
+            unit_id=lead.unit_id,
+        )
+        db.add(req)
+        await db.flush()
+
+        await audit_service.log_audit(
+            db,
+            entity_type="LeadReopenRequest",
+            entity_id=req.id,
+            action="created",
+            actor_user_id=requested_by.id,
+            reason=f"reopen-request: {reason_text}",
+            source="api",
+        )
+        log.info(
+            "Reopen request created",
+            request_id=req.id,
+            lead_id=lead_id,
+            requested_by=requested_by.id,
+        )
+
+    async def _post_commit() -> None:
+        # Phase C: dispatch LEAD_REOPEN_REQUESTED → manager unit.
+        return None
+
+    return req, _post_commit
+
+
+async def approve_reopen(
+    db: AsyncSession,
+    request_id: int,
+    reviewer: models.User,
+    note: Optional[str] = None,
+) -> Tuple[models.LeadReopenRequest, Callable]:
+    """Manager/admin DUYỆT yêu cầu → gọi lõi reopen. FOR UPDATE cả request + lead;
+    re-check request pending + lead vẫn terminal."""
+    async with db.begin_nested():
+        req = await _lock_request(db, request_id)
+        if req.status != "pending":
+            raise BusinessRuleViolation(
+                detail=f"Yêu cầu đã được xử lý ('{req.status}'), không thể duyệt."
+            )
+
+        # Lock lead + re-check terminal (có thể đã được mở lại bởi đường khác).
+        lead = await _lock_terminal_lead(db, req.lead_id)
+        await _apply_reopen(db, lead, reviewer, req.reason)
+
+        req.status = "approved"
+        req.reviewed_by_id = reviewer.id
+        req.review_note = (note or "").strip() or None
+        req.reviewed_at = datetime.now(timezone.utc)
+        await db.flush()
+
+        await audit_service.log_audit(
+            db,
+            entity_type="LeadReopenRequest",
+            entity_id=req.id,
+            action="approved",
+            actor_user_id=reviewer.id,
+            reason=req.review_note,
+            source="api",
+        )
+        log.info(
+            "Reopen request approved",
+            request_id=req.id,
+            lead_id=req.lead_id,
+            reviewer_id=reviewer.id,
+        )
+
+    async def _post_commit() -> None:
+        # Phase C: dispatch LEAD_REOPEN_APPROVED → officer xin.
+        return None
+
+    return req, _post_commit
+
+
+async def reject_reopen(
+    db: AsyncSession,
+    request_id: int,
+    reviewer: models.User,
+    note: str,
+) -> Tuple[models.LeadReopenRequest, Callable]:
+    """Manager/admin TỪ CHỐI yêu cầu (note bắt buộc); lead giữ nguyên sts20."""
+    note_text = (note or "").strip()
+    if len(note_text) < _REASON_MIN_LEN:
+        raise ValidationError(
+            detail=f"Lý do từ chối là bắt buộc (tối thiểu {_REASON_MIN_LEN} ký tự)."
+        )
+
+    async with db.begin_nested():
+        req = await _lock_request(db, request_id)
+        if req.status != "pending":
+            raise BusinessRuleViolation(
+                detail=f"Yêu cầu đã được xử lý ('{req.status}'), không thể từ chối."
+            )
+
+        req.status = "rejected"
+        req.reviewed_by_id = reviewer.id
+        req.review_note = note_text
+        req.reviewed_at = datetime.now(timezone.utc)
+        await db.flush()
+
+        await audit_service.log_audit(
+            db,
+            entity_type="LeadReopenRequest",
+            entity_id=req.id,
+            action="rejected",
+            actor_user_id=reviewer.id,
+            reason=note_text,
+            source="api",
+        )
+        log.info(
+            "Reopen request rejected",
+            request_id=req.id,
+            lead_id=req.lead_id,
+            reviewer_id=reviewer.id,
+        )
+
+    async def _post_commit() -> None:
+        # Phase C: dispatch LEAD_REOPEN_REJECTED → officer xin.
+        return None
+
+    return req, _post_commit
+
+
+async def cancel_reopen(
+    db: AsyncSession,
+    request_id: int,
+    requester: models.User,
+) -> models.LeadReopenRequest:
+    """Officer tự HỦY yêu cầu pending của CHÍNH mình. Người khác → 404 (không lộ)."""
+    async with db.begin_nested():
+        req = await _lock_request(db, request_id)
+        # Chỉ người xin tự hủy. Trả 404 (không 403) để không lộ tồn tại request.
+        if req.requested_by_id != requester.id:
+            raise ResourceNotFoundError(
+                detail=f"Reopen request {request_id} not found"
+            )
+        if req.status != "pending":
+            raise BusinessRuleViolation(
+                detail=f"Yêu cầu đã được xử lý ('{req.status}'), không thể hủy."
+            )
+
+        req.status = "cancelled"
+        req.reviewed_at = datetime.now(timezone.utc)
+        await db.flush()
+
+        await audit_service.log_audit(
+            db,
+            entity_type="LeadReopenRequest",
+            entity_id=req.id,
+            action="cancelled",
+            actor_user_id=requester.id,
+            source="api",
+        )
+        log.info("Reopen request cancelled", request_id=req.id)
+
+    return req
+
+
+async def list_reopen_requests(
+    db: AsyncSession,
+    user: models.User,
+    status: Optional[str] = None,
+) -> List[models.LeadReopenRequest]:
+    """Inbox duyệt cho manager/admin. Admin: toàn hệ thống; manager: scope theo
+    ``lead.unit_id`` HIỆN TẠI (join lead, KHÔNG dùng request.unit_id snapshot)."""
+    q = (
+        select(models.LeadReopenRequest)
+        .options(
+            selectinload(models.LeadReopenRequest.lead),
+            selectinload(models.LeadReopenRequest.requested_by),
+            selectinload(models.LeadReopenRequest.reviewed_by),
+        )
+        .order_by(models.LeadReopenRequest.created_at.desc())
+    )
+    if status:
+        q = q.where(models.LeadReopenRequest.status == status)
+
+    if user.role == UserRole.MANAGER:
+        if user.unit_id is None:
+            return []
+        from ..repositories.organization_repository import OrganizationRepository
+
+        allowed = await OrganizationRepository(db).get_descendant_unit_ids(
+            user.unit_id
+        )
+        q = q.join(
+            models.Lead, models.LeadReopenRequest.lead_id == models.Lead.id
+        ).where(models.Lead.unit_id.in_(allowed))
+    # admin: không lọc unit (toàn hệ thống).
+
+    result = await db.execute(q)
+    return list(result.scalars().all())

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -4625,10 +4625,28 @@ async def _populate_lead_detail_fields(
         and lead.assigned_officer_id == current_user.id
     )
     can_request_reopen = is_officer_assigned and cs_terminal
+    pending_exists = False
+    if can_request_reopen:
+        # Đã có pending request cho lead → ẩn nút "Xin mở lại" (backend cũng chặn
+        # ConflictError). Chỉ query khi đã đủ điều kiện kia (tránh query thừa).
+        pending_exists = (
+            await db.execute(
+                select(models.LeadReopenRequest.id)
+                .where(
+                    models.LeadReopenRequest.lead_id == lead.id,
+                    models.LeadReopenRequest.status == "pending",
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none() is not None
+        if pending_exists:
+            can_request_reopen = False
     permissions["can_request_reopen"] = can_request_reopen
     if not can_request_reopen:
         blockers["can_request_reopen"] = (
-            "not_terminal" if not cs_terminal else "forbidden"
+            "pending_exists"
+            if pending_exists
+            else ("not_terminal" if not cs_terminal else "forbidden")
         )
 
     lead.permissions = permissions

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -4618,6 +4618,19 @@ async def _populate_lead_detail_fields(
     if not can_reopen:
         blockers["can_reopen"] = "not_terminal" if not cs_terminal else "forbidden"
 
+    # Phase B: officer assigned XIN mở lại (chờ manager/admin duyệt). Manager/admin
+    # dùng can_reopen (mở trực tiếp), nên can_request_reopen chỉ bật cho officer.
+    is_officer_assigned = (
+        current_user.role == UserRole.OFFICER
+        and lead.assigned_officer_id == current_user.id
+    )
+    can_request_reopen = is_officer_assigned and cs_terminal
+    permissions["can_request_reopen"] = can_request_reopen
+    if not can_request_reopen:
+        blockers["can_request_reopen"] = (
+            "not_terminal" if not cs_terminal else "forbidden"
+        )
+
     lead.permissions = permissions
     lead.available_actions = [k for k, v in permissions.items() if v]
     lead.action_blockers = blockers

--- a/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
+++ b/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
@@ -1535,3 +1535,43 @@ async def test_can_request_reopen_flag(db: AsyncSession):
     # Officer KHÔNG assigned → can_request_reopen False.
     await _populate_lead_detail_fields(db, lead, other)
     assert lead.permissions["can_request_reopen"] is False
+
+    # #2: đã có pending request → officer assigned cũng KHÔNG xin được nữa (ẩn nút).
+    await request_reopen(db, lead.id, officer, "xin mở lại lần này")
+    await _populate_lead_detail_fields(db, lead, officer)
+    assert lead.permissions["can_request_reopen"] is False
+    assert lead.action_blockers["can_request_reopen"] == "pending_exists"
+
+
+async def test_reopen_lead_auto_resolves_pending_request(db: AsyncSession):
+    """#1: lead mở lại TRỰC TIẾP (Phase A reopen_lead) khi đang có pending request →
+    request được AUTO-approved (không mồ côi 'Chờ duyệt' mãi)."""
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    manager = await _make_manager(db, unit.id)
+    lead = await _make_sts20_lead(db, unit.id, officer_id=officer.id)
+
+    req, _ = await request_reopen(db, lead.id, officer, "officer xin mở lại")
+    assert req.status == "pending"
+
+    # Manager mở lại TRỰC TIẾP (không qua approve_reopen).
+    reopened, _ = await reopen_lead(db, lead.id, manager, "manager mở thẳng")
+    assert reopened.consultation_status_id == "sts04"
+
+    await db.refresh(req)
+    assert req.status == "approved"  # auto-resolved
+    assert req.reviewed_by_id == manager.id
+    assert "Tự động" in (req.review_note or "")
+
+
+async def test_list_reopen_requests_other_role_empty(db: AsyncSession):
+    """#3 defense-in-depth: role ngoài {admin, manager} → list rỗng (Casbin đã gate
+    endpoint; đây là rào nếu hàm bị tái dùng nơi khác)."""
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    lead = await _make_sts20_lead(db, unit.id, officer_id=officer.id)
+    await request_reopen(db, lead.id, officer, "xin mở lại")
+
+    assert await list_reopen_requests(db, officer, status="pending") == []

--- a/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
+++ b/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
@@ -27,7 +27,14 @@ from app.services.fsm_engine import (
     execute_system_transition,
     get_next_statuses_for_lead,
 )
-from app.services.lead_reopen_service import reopen_lead
+from app.services.lead_reopen_service import (
+    approve_reopen,
+    cancel_reopen,
+    list_reopen_requests,
+    reject_reopen,
+    reopen_lead,
+    request_reopen,
+)
 from app.tasks.sla_tasks import close_stale_rejected_leads
 
 pytestmark = pytest.mark.asyncio
@@ -1265,3 +1272,266 @@ async def test_reopen_idor_manager_outside_unit_gets_404(db: AsyncSession):
         await get_lead_for_user(
             lead_id=lead_a.id, db=db, current_user=manager_b,
         )
+
+
+# ---------------------------------------------------------------------------
+# Reopen REQUEST workflow (Phase B) — officer xin → manager/admin duyệt
+# ---------------------------------------------------------------------------
+
+async def _make_sts20_lead(db, unit_id, officer_id=None):
+    return await _make_lead(
+        db, unit_id, consultation_status_id="sts20", status="rejected",
+        officer_id=officer_id,
+    )
+
+
+async def test_request_reopen_creates_pending(db: AsyncSession):
+    """Officer xin → tạo LeadReopenRequest pending (unit = lead.unit)."""
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    lead = await _make_sts20_lead(db, unit.id, officer_id=officer.id)
+
+    req, cb = await request_reopen(db, lead.id, officer, "khách muốn tư vấn lại")
+    if cb:
+        await cb()
+
+    assert req.status == "pending"
+    assert req.requested_by_id == officer.id
+    assert req.unit_id == unit.id
+    assert req.reviewed_by_id is None
+    # Lead chưa đổi (chờ duyệt).
+    await db.refresh(lead)
+    assert lead.consultation_status_id == "sts20"
+
+
+async def test_request_reopen_duplicate_pending_conflict(db: AsyncSession):
+    """Lead đã có pending → request thứ 2 raise ConflictError."""
+    from app.utils.exceptions import ConflictError
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    lead = await _make_sts20_lead(db, unit.id, officer_id=officer.id)
+
+    await request_reopen(db, lead.id, officer, "lần 1 xin mở lại")
+    with pytest.raises(ConflictError):
+        await request_reopen(db, lead.id, officer, "lần 2 xin mở lại")
+
+
+async def test_request_reopen_partial_unique_db_guard(db: AsyncSession):
+    """Belt: partial-unique uq_reopen_one_pending_per_lead chặn 2 pending ở DB
+    (race-safe kể cả khi service-check bị bypass)."""
+    from sqlalchemy.exc import IntegrityError
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    lead = await _make_sts20_lead(db, unit.id)
+
+    db.add(models.LeadReopenRequest(
+        lead_id=lead.id, requested_by_id=officer.id, reason="x" * 5,
+        status="pending", unit_id=unit.id,
+    ))
+    await db.flush()
+    # Pending thứ 2 cùng lead → vi phạm partial-unique. begin_nested để IntegrityError
+    # chỉ rollback savepoint (session vẫn dùng được sau).
+    with pytest.raises(IntegrityError):
+        async with db.begin_nested():
+            db.add(models.LeadReopenRequest(
+                lead_id=lead.id, requested_by_id=officer.id, reason="y" * 5,
+                status="pending", unit_id=unit.id,
+            ))
+            await db.flush()
+
+
+async def test_request_reopen_non_terminal_rejected(db: AsyncSession):
+    """Lead KHÔNG terminal (sts04) → BusinessRuleViolation."""
+    from app.utils.exceptions import BusinessRuleViolation
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    lead = await _make_lead(db, unit.id, status="contacted", officer_id=officer.id)
+
+    with pytest.raises(BusinessRuleViolation):
+        await request_reopen(db, lead.id, officer, "xin mở lead chưa đóng")
+
+
+async def test_approve_reopen_opens_lead_and_marks_approved(db: AsyncSession):
+    """Manager duyệt → lead về sts04, request approved, history changed_by=manager,
+    request giữ requested_by=officer (attribution tách bạch)."""
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    manager = await _make_manager(db, unit.id)
+    lead = await _make_sts20_lead(db, unit.id, officer_id=officer.id)
+
+    req, _ = await request_reopen(db, lead.id, officer, "khách quay lại")
+    approved, cb = await approve_reopen(db, req.id, manager, note="ok duyệt")
+    if cb:
+        await cb()
+
+    assert approved.status == "approved"
+    assert approved.reviewed_by_id == manager.id
+    assert approved.requested_by_id == officer.id  # attribution giữ officer
+    await db.refresh(lead)
+    assert lead.consultation_status_id == "sts04"
+    assert lead.consultation_reengaged_at is not None
+
+    hist = (await db.execute(
+        select(models.LeadStatusHistory).where(
+            models.LeadStatusHistory.lead_id == lead.id,
+            models.LeadStatusHistory.new_consultation_status_id == "sts04",
+        )
+    )).scalars().all()
+    assert len(hist) == 1
+    assert hist[0].changed_by_user_id == manager.id  # người duyệt thực hiện reopen
+
+
+async def test_approve_reopen_already_processed_blocked(db: AsyncSession):
+    """Duyệt lại request đã approved → BusinessRuleViolation (re-check pending)."""
+    from app.utils.exceptions import BusinessRuleViolation
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    manager = await _make_manager(db, unit.id)
+    lead = await _make_sts20_lead(db, unit.id, officer_id=officer.id)
+
+    req, _ = await request_reopen(db, lead.id, officer, "khách quay lại")
+    await approve_reopen(db, req.id, manager)
+    with pytest.raises(BusinessRuleViolation):
+        await approve_reopen(db, req.id, manager)
+
+
+async def test_reject_reopen_keeps_lead_sts20(db: AsyncSession):
+    """Từ chối → request rejected, lead GIỮ sts20; note bắt buộc."""
+    from app.utils.exceptions import BusinessRuleViolation, ValidationError
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    manager = await _make_manager(db, unit.id)
+    lead = await _make_sts20_lead(db, unit.id, officer_id=officer.id)
+
+    req, _ = await request_reopen(db, lead.id, officer, "xin mở lại")
+
+    # note rỗng → ValidationError.
+    with pytest.raises(ValidationError):
+        await reject_reopen(db, req.id, manager, note="  ")
+
+    rejected, cb = await reject_reopen(
+        db, req.id, manager, note="lead đã liên hệ nhiều lần không phản hồi",
+    )
+    if cb:
+        await cb()
+    assert rejected.status == "rejected"
+    assert rejected.reviewed_by_id == manager.id
+    await db.refresh(lead)
+    assert lead.consultation_status_id == "sts20"  # KHÔNG mở lại
+
+    # reject lại request đã xử lý → BusinessRuleViolation.
+    with pytest.raises(BusinessRuleViolation):
+        await reject_reopen(db, req.id, manager, note="thử lại lần nữa")
+
+
+async def test_cancel_reopen_owner_only(db: AsyncSession):
+    """Chỉ chủ sở hữu hủy được; người khác → ResourceNotFoundError (không lộ)."""
+    from app.utils.exceptions import ResourceNotFoundError
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    other = await _make_officer(db, unit.id, cap=10)
+    lead = await _make_sts20_lead(db, unit.id, officer_id=officer.id)
+
+    req, _ = await request_reopen(db, lead.id, officer, "xin mở lại")
+
+    # Officer khác hủy → 404.
+    with pytest.raises(ResourceNotFoundError):
+        await cancel_reopen(db, req.id, other)
+
+    cancelled = await cancel_reopen(db, req.id, officer)
+    assert cancelled.status == "cancelled"
+
+
+async def test_list_reopen_requests_manager_unit_scoped(db: AsyncSession):
+    """Manager chỉ thấy request của lead trong unit mình; admin thấy tất cả."""
+    await _seed_fsm(db)
+    unit_a = await _make_unit(db)
+    unit_b = await _make_unit(db)
+    off_a = await _make_officer(db, unit_a.id, cap=10)
+    off_b = await _make_officer(db, unit_b.id, cap=10)
+    manager_a = await _make_manager(db, unit_a.id)
+    admin = await _make_admin(db, unit_a.id)
+    lead_a = await _make_sts20_lead(db, unit_a.id, officer_id=off_a.id)
+    lead_b = await _make_sts20_lead(db, unit_b.id, officer_id=off_b.id)
+
+    req_a, _ = await request_reopen(db, lead_a.id, off_a, "unit A xin mở lại")
+    req_b, _ = await request_reopen(db, lead_b.id, off_b, "unit B xin mở lại")
+    await db.flush()
+
+    mgr_list = await list_reopen_requests(db, manager_a, status="pending")
+    mgr_ids = {r.id for r in mgr_list}
+    assert req_a.id in mgr_ids
+    assert req_b.id not in mgr_ids  # ngoài unit -> không thấy
+
+    admin_list = await list_reopen_requests(db, admin, status="pending")
+    admin_ids = {r.id for r in admin_list}
+    assert req_a.id in admin_ids and req_b.id in admin_ids  # admin thấy hết
+
+
+async def test_get_reopen_request_for_user_idor(db: AsyncSession):
+    """Dep IDOR: manager ngoài unit → 404; cùng unit/admin → ok (theo lead.unit)."""
+    from app.core.deps import get_reopen_request_for_user
+    from app.utils.exceptions import ResourceNotFoundError
+
+    await _seed_fsm(db)
+    unit_a = await _make_unit(db)
+    unit_b = await _make_unit(db)
+    off_a = await _make_officer(db, unit_a.id, cap=10)
+    manager_a = await _make_manager(db, unit_a.id)
+    manager_b = await _make_manager(db, unit_b.id)
+    admin = await _make_admin(db, unit_a.id)
+    lead_a = await _make_sts20_lead(db, unit_a.id, officer_id=off_a.id)
+
+    req, _ = await request_reopen(db, lead_a.id, off_a, "xin mở lại")
+
+    # Cùng unit + admin → trả request.
+    assert (await get_reopen_request_for_user(
+        request_id=req.id, db=db, current_user=manager_a)).id == req.id
+    assert (await get_reopen_request_for_user(
+        request_id=req.id, db=db, current_user=admin)).id == req.id
+
+    # Manager ngoài unit → 404.
+    with pytest.raises(ResourceNotFoundError):
+        await get_reopen_request_for_user(
+            request_id=req.id, db=db, current_user=manager_b)
+
+
+async def test_can_request_reopen_flag(db: AsyncSession):
+    """§6.0 Phase B: can_request_reopen=True cho officer ASSIGNED trên sts20; False cho
+    manager (dùng can_reopen) và officer KHÔNG assigned."""
+    from app.services.lead_service import _populate_lead_detail_fields
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+    other = await _make_officer(db, unit.id, cap=10)
+    manager = await _make_manager(db, unit.id)
+    lead = await _make_sts20_lead(db, unit.id, officer_id=officer.id)
+
+    # Officer assigned → can_request_reopen True, can_reopen False.
+    await _populate_lead_detail_fields(db, lead, officer)
+    assert lead.permissions["can_request_reopen"] is True
+    assert lead.permissions["can_reopen"] is False
+
+    # Manager → can_request_reopen False (dùng can_reopen trực tiếp).
+    await _populate_lead_detail_fields(db, lead, manager)
+    assert lead.permissions["can_request_reopen"] is False
+    assert lead.permissions["can_reopen"] is True
+
+    # Officer KHÔNG assigned → can_request_reopen False.
+    await _populate_lead_detail_fields(db, lead, other)
+    assert lead.permissions["can_request_reopen"] is False

--- a/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/[id]/_components/LeadDetailClient.tsx
@@ -100,6 +100,7 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
   const [assignDialogOpen, setAssignDialogOpen] = useState(false);
   const [reassignDialogOpen, setReassignDialogOpen] = useState(false);
   const [reopenDialogOpen, setReopenDialogOpen] = useState(false);
+  const [requestReopenDialogOpen, setRequestReopenDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [phoneCopied, setPhoneCopied] = useState(false);
 
@@ -367,6 +368,18 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
                 Mở lại tư vấn
               </Button>
             )}
+            {/* Xin mở lại — officer assigned (cờ can_request_reopen). Khác can_reopen
+                (manager/admin mở trực tiếp): officer chỉ GỬI yêu cầu chờ duyệt. */}
+            {lead.permissions?.can_request_reopen && (
+              <Button
+                variant="outline"
+                className="rounded-xl border-amber-300 text-amber-700 hover:bg-amber-50"
+                onClick={() => setRequestReopenDialogOpen(true)}
+              >
+                <RotateCcw className="mr-1.5 h-4 w-4" />
+                Xin mở lại
+              </Button>
+            )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon" className="rounded-xl" aria-label="Tùy chọn khác">
@@ -530,6 +543,13 @@ export function LeadDetailClient({ leadId, initialData, initialTimeline, initial
       <ReopenLeadDialog
         open={reopenDialogOpen}
         onOpenChange={setReopenDialogOpen}
+        lead={lead}
+      />
+
+      <ReopenLeadDialog
+        mode="request"
+        open={requestReopenDialogOpen}
+        onOpenChange={setRequestReopenDialogOpen}
         lead={lead}
       />
 

--- a/frontend/src/app/(dashboard)/reopen-requests/_components/ReopenRequestsInbox.tsx
+++ b/frontend/src/app/(dashboard)/reopen-requests/_components/ReopenRequestsInbox.tsx
@@ -1,0 +1,253 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { Check, Clock, Loader2, RotateCcw, X } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  useApproveReopenRequest,
+  useRejectReopenRequest,
+  useReopenRequests,
+} from "@/hooks/useLeads"
+import type { ReopenRequestItem } from "@/lib/api/leads"
+
+const STATUS_LABEL: Record<string, string> = {
+  pending: "Chờ duyệt",
+  approved: "Đã duyệt",
+  rejected: "Đã từ chối",
+  cancelled: "Đã hủy",
+}
+
+const STATUS_CLASS: Record<string, string> = {
+  pending: "bg-amber-100 text-amber-700",
+  approved: "bg-emerald-100 text-emerald-700",
+  rejected: "bg-rose-100 text-rose-700",
+  cancelled: "bg-gray-100 text-gray-600",
+}
+
+const REJECT_NOTE_MIN = 5
+
+/**
+ * Inbox duyệt yêu cầu mở lại (manager/admin). Dữ liệu IDOR-scoped ở backend
+ * (manager chỉ thấy request của unit mình). Hành động: duyệt (mở lại lead ngay) /
+ * từ chối (note bắt buộc).
+ */
+export function ReopenRequestsInbox() {
+  const [statusFilter, setStatusFilter] = useState<string>("pending")
+  const { data: requests, isLoading } = useReopenRequests(
+    statusFilter === "all" ? undefined : statusFilter,
+  )
+  const approve = useApproveReopenRequest()
+  const reject = useRejectReopenRequest()
+
+  const [rejectTarget, setRejectTarget] = useState<ReopenRequestItem | null>(null)
+  const [rejectNote, setRejectNote] = useState("")
+  const rejectValid = rejectNote.trim().length >= REJECT_NOTE_MIN
+
+  function closeReject() {
+    if (reject.isPending) return
+    setRejectTarget(null)
+    setRejectNote("")
+  }
+
+  function handleReject() {
+    if (!rejectTarget || !rejectValid) return
+    reject.mutate(
+      { requestId: rejectTarget.id, note: rejectNote.trim() },
+      {
+        onSuccess: () => {
+          setRejectTarget(null)
+          setRejectNote("")
+        },
+      },
+    )
+  }
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <RotateCcw className="h-6 w-6 text-amber-600" />
+            Yêu cầu mở lại tư vấn
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Officer xin mở lại lead &ldquo;Đã ngừng tư vấn&rdquo; — duyệt để mở
+            lại ngay, hoặc từ chối kèm lý do.
+          </p>
+        </div>
+        <Select value={statusFilter} onValueChange={setStatusFilter}>
+          <SelectTrigger className="w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="pending">Chờ duyệt</SelectItem>
+            <SelectItem value="approved">Đã duyệt</SelectItem>
+            <SelectItem value="rejected">Đã từ chối</SelectItem>
+            <SelectItem value="cancelled">Đã hủy</SelectItem>
+            <SelectItem value="all">Tất cả</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-32 rounded-lg" />
+          ))}
+        </div>
+      ) : !requests || requests.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground">
+            <Clock className="mx-auto h-10 w-10 mb-2 opacity-40" />
+            Không có yêu cầu nào.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {requests.map((req) => (
+            <Card key={req.id}>
+              <CardHeader className="pb-2">
+                <div className="flex items-start justify-between gap-2">
+                  <CardTitle className="text-base">
+                    <Link
+                      href={`/leads/${req.lead_id}`}
+                      className="hover:underline"
+                    >
+                      {req.lead_name ?? `Lead #${req.lead_id}`}
+                    </Link>
+                  </CardTitle>
+                  <Badge
+                    variant="outline"
+                    className={`border-0 ${STATUS_CLASS[req.status] ?? ""}`}
+                  >
+                    {STATUS_LABEL[req.status] ?? req.status}
+                  </Badge>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {req.requested_by_name ?? `User #${req.requested_by_id}`}
+                  {" • "}
+                  {new Date(req.created_at).toLocaleString("vi-VN")}
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <p className="text-sm whitespace-pre-wrap">{req.reason}</p>
+                {req.review_note && (
+                  <p className="text-xs text-muted-foreground">
+                    Ghi chú: {req.review_note}
+                  </p>
+                )}
+                {req.status === "pending" && (
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      className="bg-emerald-600 hover:bg-emerald-700"
+                      disabled={approve.isPending}
+                      onClick={() => approve.mutate({ requestId: req.id })}
+                    >
+                      {approve.isPending ? (
+                        <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Check className="mr-1.5 h-4 w-4" />
+                      )}
+                      Duyệt
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="border-rose-300 text-rose-700 hover:bg-rose-50"
+                      onClick={() => {
+                        setRejectTarget(req)
+                        setRejectNote("")
+                      }}
+                    >
+                      <X className="mr-1.5 h-4 w-4" />
+                      Từ chối
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <Dialog
+        open={rejectTarget !== null}
+        onOpenChange={(o) => {
+          if (!o) closeReject()
+        }}
+      >
+        <DialogContent className="sm:max-w-[460px]">
+          <DialogHeader>
+            <DialogTitle>Từ chối yêu cầu mở lại</DialogTitle>
+            <DialogDescription>
+              Lead{" "}
+              <strong>
+                {rejectTarget?.lead_name ?? `#${rejectTarget?.lead_id}`}
+              </strong>
+              . Lý do từ chối sẽ được gửi tới officer.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <Label htmlFor="reject-note">
+              Lý do từ chối{" "}
+              <span className="text-muted-foreground text-xs">
+                (bắt buộc, ≥ {REJECT_NOTE_MIN} ký tự)
+              </span>
+            </Label>
+            <Textarea
+              id="reject-note"
+              value={rejectNote}
+              onChange={(e) => setRejectNote(e.target.value)}
+              disabled={reject.isPending}
+              rows={3}
+              placeholder="Ví dụ: lead đã liên hệ nhiều lần không phản hồi, không nên mở lại."
+              autoFocus
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              disabled={reject.isPending}
+              onClick={closeReject}
+            >
+              Hủy
+            </Button>
+            <Button
+              className="bg-rose-600 hover:bg-rose-700"
+              disabled={!rejectValid || reject.isPending}
+              onClick={handleReject}
+            >
+              {reject.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              Từ chối
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/reopen-requests/page.tsx
+++ b/frontend/src/app/(dashboard)/reopen-requests/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from "react"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ReopenRequestsInbox } from "./_components/ReopenRequestsInbox"
+
+function Loading() {
+  return (
+    <div className="p-4 sm:p-6 space-y-4">
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-96 rounded-lg" />
+    </div>
+  )
+}
+
+export default function ReopenRequestsPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <ReopenRequestsInbox />
+    </Suspense>
+  )
+}

--- a/frontend/src/components/leads/ReopenLeadDialog.tsx
+++ b/frontend/src/components/leads/ReopenLeadDialog.tsx
@@ -14,34 +14,52 @@ import {
 } from "@/components/ui/dialog"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { useReopenLead } from "@/hooks/useLeads"
+import { useReopenLead, useCreateReopenRequest } from "@/hooks/useLeads"
 import type { LeadDetail } from "@/types/lead.types"
 
 interface ReopenLeadDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   lead: LeadDetail
+  /** "reopen": manager/admin mở trực tiếp; "request": officer XIN (chờ duyệt). */
+  mode?: "reopen" | "request"
 }
 
 // Mirror backend LeadReopenRequest.reason (min_length=5, max_length=500).
 const REASON_MIN = 5
 const REASON_MAX = 500
 
+const COPY = {
+  reopen: {
+    title: "Mở lại tư vấn",
+    desc: "Mở lại sẽ đưa lead về luồng tư vấn để tiếp tục chăm sóc.",
+    label: "Lý do mở lại",
+    submit: "Mở lại tư vấn",
+  },
+  request: {
+    title: "Xin mở lại tư vấn",
+    desc: "Yêu cầu sẽ được gửi tới quản lý duyệt trước khi lead được mở lại.",
+    label: "Lý do xin mở lại",
+    submit: "Gửi yêu cầu",
+  },
+} as const
+
 /**
- * Manager/admin entry to ``POST /leads/{id}/reopen`` — đưa một lead đã ngừng tư
- * vấn (sts20) trở lại luồng tư vấn (sts04).
- *
- * Visibility được quyết định ở nơi gọi qua cờ ``lead.permissions.can_reopen``
- * từ API (Thin Client — FE không tự suy quyền). Dialog chỉ thu lý do bắt buộc
- * và gọi mutation; mọi guard nghiệp vụ nằm ở backend.
+ * Dialog mở lại / xin mở lại lead đã ngừng tư vấn (sts20). Visibility quyết định ở
+ * nơi gọi qua cờ ``permissions.can_reopen`` (manager/admin) hoặc
+ * ``permissions.can_request_reopen`` (officer) — Thin Client. Dialog chỉ thu lý do.
  */
 export function ReopenLeadDialog({
   open,
   onOpenChange,
   lead,
+  mode = "reopen",
 }: ReopenLeadDialogProps) {
   const [reason, setReason] = useState("")
-  const mutation = useReopenLead()
+  const reopenMutation = useReopenLead()
+  const requestMutation = useCreateReopenRequest()
+  const mutation = mode === "request" ? requestMutation : reopenMutation
+  const copy = COPY[mode]
 
   // reason được xóa khi đóng dialog (onOpenChange !next → reset). Nút "Mở lại" chỉ mở
   // dialog từ trạng thái đã đóng nên mỗi lần mở reason luôn rỗng — không cần effect
@@ -78,17 +96,16 @@ export function ReopenLeadDialog({
     >
       <DialogContent className="sm:max-w-[480px]">
         <DialogHeader>
-          <DialogTitle>Mở lại tư vấn</DialogTitle>
+          <DialogTitle>{copy.title}</DialogTitle>
           <DialogDescription>
             Lead <strong>{lead.full_name}</strong> đang ở trạng thái đã ngừng tư
-            vấn. Mở lại sẽ đưa lead về luồng tư vấn để tiếp tục chăm sóc. Lý do
-            được lưu lại để đối soát.
+            vấn. {copy.desc} Lý do được lưu lại để đối soát.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-2 py-2">
           <Label htmlFor="reopen-reason">
-            Lý do mở lại{" "}
+            {copy.label}{" "}
             <span className="text-muted-foreground text-xs">
               (bắt buộc, ≥ {REASON_MIN} ký tự)
             </span>
@@ -135,7 +152,7 @@ export function ReopenLeadDialog({
             ) : (
               <RotateCcw className="mr-2 h-4 w-4" />
             )}
-            Mở lại tư vấn
+            {copy.submit}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/hooks/useLeads.ts
+++ b/frontend/src/hooks/useLeads.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { leadsApi } from "@/lib/api/leads";
 import { workflowContextKeys } from "@/hooks/useWorkflowContext";
 import type { ApiErrorResponse } from "@/types/api.types";
+import type { ReopenRequestItem } from "@/lib/api/leads";
 import type {
   Lead,
   LeadDetail,
@@ -880,6 +881,128 @@ export function useReopenLead() {
             : "Không thể mở lại tư vấn";
       toast.error("Lỗi mở lại tư vấn", { description: message });
     },
+  });
+}
+
+// =====================================================================
+// REOPEN REQUESTS (Phase B) — officer xin → manager/admin duyệt
+// =====================================================================
+
+export const reopenRequestKeys = {
+  all: ["reopen-requests"] as const,
+  list: (status?: string) =>
+    [...reopenRequestKeys.all, "list", status ?? "all"] as const,
+};
+
+function _reopenErr(fallback: string) {
+  return (error: AxiosError<ApiErrorResponse>) => {
+    const detail = error.response?.data?.detail;
+    const message =
+      typeof detail === "string"
+        ? detail
+        : Array.isArray(detail)
+          ? detail.map((e) => e.msg).join(", ")
+          : fallback;
+    toast.error(fallback, { description: message });
+  };
+}
+
+/** Inbox duyệt (manager/admin) — IDOR-scoped ở backend. */
+export function useReopenRequests(status?: string) {
+  return useQuery<ReopenRequestItem[], AxiosError<ApiErrorResponse>>({
+    queryKey: reopenRequestKeys.list(status),
+    queryFn: () => leadsApi.listReopenRequests(status),
+  });
+}
+
+/** Officer XIN mở lại lead. */
+export function useCreateReopenRequest() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    ReopenRequestItem,
+    AxiosError<ApiErrorResponse>,
+    { leadId: number; reason: string }
+  >({
+    mutationFn: ({ leadId, reason }) =>
+      leadsApi.createReopenRequest(leadId, { reason }),
+    onSuccess: async (_d, { leadId }) => {
+      toast.success("Đã gửi yêu cầu mở lại", {
+        description: "Yêu cầu đang chờ quản lý duyệt.",
+      });
+      await queryClient.invalidateQueries({
+        queryKey: leadsKeys.detail(leadId),
+        exact: true,
+        refetchType: "active",
+      });
+      queryClient.invalidateQueries({ queryKey: reopenRequestKeys.all });
+    },
+    onError: _reopenErr("Không gửi được yêu cầu mở lại"),
+  });
+}
+
+/** Manager/admin DUYỆT yêu cầu → lead mở lại. */
+export function useApproveReopenRequest() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    ReopenRequestItem,
+    AxiosError<ApiErrorResponse>,
+    { requestId: number; note?: string }
+  >({
+    mutationFn: ({ requestId, note }) =>
+      leadsApi.approveReopenRequest(requestId, { note }),
+    onSuccess: (r) => {
+      toast.success("Đã duyệt — lead được mở lại");
+      queryClient.invalidateQueries({ queryKey: reopenRequestKeys.all });
+      queryClient.invalidateQueries({
+        queryKey: leadsKeys.detail(r.lead_id),
+        exact: true,
+        refetchType: "active",
+      });
+      queryClient.invalidateQueries({ queryKey: leadsKeys.lists() });
+    },
+    onError: _reopenErr("Không duyệt được yêu cầu"),
+  });
+}
+
+/** Manager/admin TỪ CHỐI yêu cầu (note bắt buộc). */
+export function useRejectReopenRequest() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    ReopenRequestItem,
+    AxiosError<ApiErrorResponse>,
+    { requestId: number; note: string }
+  >({
+    mutationFn: ({ requestId, note }) =>
+      leadsApi.rejectReopenRequest(requestId, { note }),
+    onSuccess: () => {
+      toast.success("Đã từ chối yêu cầu");
+      queryClient.invalidateQueries({ queryKey: reopenRequestKeys.all });
+    },
+    onError: _reopenErr("Không từ chối được yêu cầu"),
+  });
+}
+
+/** Officer HỦY yêu cầu pending của chính mình. */
+export function useCancelReopenRequest() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    ReopenRequestItem,
+    AxiosError<ApiErrorResponse>,
+    { requestId: number; leadId?: number }
+  >({
+    mutationFn: ({ requestId }) => leadsApi.cancelReopenRequest(requestId),
+    onSuccess: (_d, { leadId }) => {
+      toast.success("Đã hủy yêu cầu mở lại");
+      queryClient.invalidateQueries({ queryKey: reopenRequestKeys.all });
+      if (leadId) {
+        queryClient.invalidateQueries({
+          queryKey: leadsKeys.detail(leadId),
+          exact: true,
+          refetchType: "active",
+        });
+      }
+    },
+    onError: _reopenErr("Không hủy được yêu cầu"),
   });
 }
 

--- a/frontend/src/lib/api/leads.ts
+++ b/frontend/src/lib/api/leads.ts
@@ -303,6 +303,77 @@ export async function reopenLead(
   return response.data
 }
 
+/** Một yêu cầu mở lại (Phase B) — officer xin, manager/admin duyệt. */
+export interface ReopenRequestItem {
+  id: number
+  lead_id: number
+  requested_by_id: number
+  reason: string
+  status: "pending" | "approved" | "rejected" | "cancelled"
+  reviewed_by_id: number | null
+  review_note: string | null
+  created_at: string
+  reviewed_at: string | null
+  unit_id: number
+  lead_name: string | null
+  requested_by_name: string | null
+  reviewed_by_name: string | null
+}
+
+/** Officer XIN mở lại lead (chờ duyệt). */
+export async function createReopenRequest(
+  leadId: number,
+  data: { reason: string }
+): Promise<ReopenRequestItem> {
+  const r = await api.post<ReopenRequestItem>(
+    `/api/leads/${leadId}/reopen-requests`,
+    data
+  )
+  return r.data
+}
+
+/** Inbox duyệt (manager/admin) — IDOR-scoped ở backend. */
+export async function listReopenRequests(
+  status?: string
+): Promise<ReopenRequestItem[]> {
+  const r = await api.get<ReopenRequestItem[]>("/api/reopen-requests", {
+    params: status ? { status } : undefined,
+  })
+  return r.data
+}
+
+export async function approveReopenRequest(
+  requestId: number,
+  data?: { note?: string }
+): Promise<ReopenRequestItem> {
+  const r = await api.post<ReopenRequestItem>(
+    `/api/reopen-requests/${requestId}/approve`,
+    data ?? {}
+  )
+  return r.data
+}
+
+export async function rejectReopenRequest(
+  requestId: number,
+  data: { note: string }
+): Promise<ReopenRequestItem> {
+  const r = await api.post<ReopenRequestItem>(
+    `/api/reopen-requests/${requestId}/reject`,
+    data
+  )
+  return r.data
+}
+
+/** Officer hủy yêu cầu pending của chính mình. */
+export async function cancelReopenRequest(
+  requestId: number
+): Promise<ReopenRequestItem> {
+  const r = await api.delete<ReopenRequestItem>(
+    `/api/reopen-requests/${requestId}`
+  )
+  return r.data
+}
+
 /**
  * Update consultation (admin: all, officer: most recent only)
  *
@@ -611,6 +682,13 @@ export const leadsApi = {
 
   // Reopen (Phase A)
   reopenLead,
+
+  // Reopen request (Phase B)
+  createReopenRequest,
+  listReopenRequests,
+  approveReopenRequest,
+  rejectReopenRequest,
+  cancelReopenRequest,
 
   // Data Access
   getLeadTimeline,

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -137,6 +137,12 @@ export const navigationConfig: NavigationConfig = {
           icon: ClipboardCheck,
           roles: [], // Accessible to all roles
         },
+        {
+          label: "Yêu cầu mở lại",
+          href: "/reopen-requests",
+          icon: RotateCcw,
+          roles: ["admin", "manager"], // Inbox duyệt reopen (officer xin)
+        },
       ],
     },
 


### PR DESCRIPTION
## Vì sao
Tiếp nối Phase A (#392, manager/admin mở lại trực tiếp), Phase B cho **officer** được **XIN mở lại** lead "Đã ngừng tư vấn" (sts20) → **manager/admin duyệt/từ chối**. Hoàn thiện luồng self-service mà vẫn giữ kiểm soát (officer không tự mở lại).

## Thay đổi
**Backend**
- Bảng `lead_reopen_request` + migration (**partial-unique 1-pending/lead** chống spam + CHECK status + composite index) + **8 Casbin policy** (officer request/cancel; manager+admin list/approve/reject, v3=eft).
- Service: refactor **lõi dùng chung A/B** (`_lock_terminal_lead` + `_apply_reopen`, FOR UPDATE + `populate_existing` đọc fresh dưới lock) + 6 method `request/approve/reject/cancel/list`. Approve khóa **cả request + lead**, re-check pending+terminal.
- **IDOR** `get_reopen_request_for_user`: manager scope theo `lead.unit_id` **hiện tại** (không snapshot) → 404; cancel chỉ chủ sở hữu → 404. `list` admin-explicit, role lạ → `[]`.
- Cờ thin-client `can_request_reopen` (officer assigned + terminal + **chưa có pending**).
- Reopen trực tiếp (Phase A) **auto-resolve pending mồ côi** (tránh "Chờ duyệt" kẹt).

**Frontend** — nút "Xin mở lại" (officer) + dialog generalize `mode` + **inbox `/reopen-requests`** (manager duyệt/từ chối) + nav.

## Review (2 vòng)
Tự `/code-review` + review của owner → fix: orphan pending auto-resolve, nút phản ánh pending, list defense-in-depth role, rename `schemas.LeadReopenRequest`→`ReopenReasonBody` (hết nhầm với model), bỏ index dư.

## Verify
- **163 pytest** (test_sts20 50 gồm 14 ca Phase B + test_lead + test_pipeline).
- flake8 net-zero · FE type-check + lint 0 errors.
- **Chrome smoke**: officer "Xin mở lại" → manager inbox "Duyệt" → lead sts04 (DB: request approved officer→manager, history changed_by=manager, attribution tách bạch).

## Defer (PR follow-up)
- **C** notifications (3 event LEAD_REOPEN_* + LEAD_AUTO_GIVEUP beat §8.1) — plan §8 đánh dấu "tùy chọn"; callback hiện no-op.
- **D** abuse tracking (reject ≥3/30 ngày → flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)