### PR TITLE
fix(admissions): hết bug "amp" tên trường + tài liệu tùy chọn vào danh sách chính + officer reset tài liệu

### DIFF
--- a/Backend_FastAPI/alembic/versions/ampfix01_20260609_backfill_school_name_unescape.py
+++ b/Backend_FastAPI/alembic/versions/ampfix01_20260609_backfill_school_name_unescape.py
@@ -1,0 +1,107 @@
+"""Backfill: gỡ double HTML-escape ("amp") trong school_name + family_info.
+
+Revision ID: ampfix01_20260609
+Revises: leadreopen_b_20260609
+Create Date: 2026-06-09
+
+Bug "amp": ``AcademicRecordSchema``/``FamilyMemberSchema`` html.escape() KHÔNG
+idempotent (``&`` → ``&amp;``) + schema dùng chung request/response → mỗi vòng
+đọc→sửa→lưu cộng thêm một lớp ``&amp;`` vào ``school_name`` (và text family).
+Schema đã NGỪNG escape (commit trước); migration này gỡ các giá trị lịch sử đã
+hỏng bằng ``html.unescape`` lặp tới khi ổn định.
+
+- Predicate CHẶT: chỉ profiles có HTML entity trong academic_history/family_info.
+- Idempotent: giá trị sạch unescape ra chính nó (chạy lại = no-op).
+- Downgrade: no-op — double-escape là dữ liệu HỎNG, không tái tạo (forward-only).
+- Scope đã verify (prod + dev 2026-06-09): 1 hồ sơ #31 (academic), 0 family.
+"""
+import html
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "ampfix01_20260609"
+down_revision = "leadreopen_b_20260609"
+branch_labels = None
+depends_on = None
+
+# HTML entity (độ dài thay đổi) còn sót trong giá trị đã lưu — POSIX regex.
+_ENTITY_RE = r"&(amp;|#x[0-9a-fA-F]+;|#[0-9]+;|lt;|gt;|quot;)"
+
+_FAMILY_TEXT_FIELDS = ("full_name", "occupation", "relationship")
+
+
+def _unescape_stable(value):
+    """html.unescape lặp tới khi ổn định — gỡ N lớp ``&amp;...``."""
+    if not isinstance(value, str):
+        return value
+    prev = value
+    for _ in range(20):  # guard; thực tế chỉ 8-9 lớp
+        cur = html.unescape(prev)
+        if cur == prev:
+            return cur
+        prev = cur
+    return prev
+
+
+def _clean_list(items, fields):
+    """Unescape các field text trong list dict; trả True nếu có thay đổi."""
+    changed = False
+    for entry in items or []:
+        if not isinstance(entry, dict):
+            continue
+        for field in fields:
+            if isinstance(entry.get(field), str):
+                new = _unescape_stable(entry[field])
+                if new != entry[field]:
+                    entry[field] = new
+                    changed = True
+    return changed
+
+
+def _coerce_json(value):
+    """JSONB qua sa.text() có thể về str (asyncpg) hoặc list/dict — chuẩn hóa."""
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, academic_history, family_info FROM admission_profile "
+            "WHERE academic_history::text ~ :pat OR family_info::text ~ :pat"
+        ),
+        {"pat": _ENTITY_RE},
+    ).fetchall()
+
+    for row in rows:
+        m = row._mapping
+        academic = _coerce_json(m["academic_history"]) or []
+        family = _coerce_json(m["family_info"]) or []
+
+        a_changed = _clean_list(academic, ("school_name",))
+        f_changed = _clean_list(family, _FAMILY_TEXT_FIELDS)
+
+        if a_changed or f_changed:
+            bind.execute(
+                sa.text(
+                    "UPDATE admission_profile "
+                    "SET academic_history = CAST(:a AS jsonb), "
+                    "    family_info = CAST(:f AS jsonb) "
+                    "WHERE id = :id"
+                ),
+                {
+                    "a": json.dumps(academic, ensure_ascii=False),
+                    "f": json.dumps(family, ensure_ascii=False),
+                    "id": m["id"],
+                },
+            )
+
+
+def downgrade() -> None:
+    # No-op: double-escape là dữ liệu hỏng — không tái tạo. Forward-only.
+    pass

--- a/Backend_FastAPI/alembic/versions/resetcasbin01_20260609_officer_reset_casbin.py
+++ b/Backend_FastAPI/alembic/versions/resetcasbin01_20260609_officer_reset_casbin.py
@@ -1,0 +1,111 @@
+"""resetcasbin01: seed Casbin policy cho officer RESET tài liệu
+
+Revision ID: resetcasbin01
+Revises: ampfix01_20260609
+Create Date: 2026-06-09
+
+BR3 (2026-06-09) — officer được tự RESET tài liệu của hồ sơ mình phụ trách khi
+hồ sơ ở draft/rejected/revision_requested (gỡ submission để sửa). Route
+``POST /api/admissions/{id}/documents/{doc_code}/reset`` được ``CasbinAuth`` bảo
+vệ và TRƯỚC ĐÂY chỉ nằm trong MANAGER_TEMPLATE → officer bị 403 ở tầng route.
+
+``policy_templates.py`` đã thêm 1 ALLOW row vào OFFICER_TEMPLATE trong CÙNG
+commit. Nhưng auto-sync template chỉ chạy ở dev/test; prod KHÔNG sync → cần
+migration seed row ``role:officer`` cho prod (nếu thiếu: dev PASS nhưng prod
+officer-reset 403, bug ẩn dev-prod). Service ``DocumentActionPolicy`` mới
+narrows tiếp owner + OWNER_DOC_MUTATION_STATES + doc non-missing; reset KHÔNG
+mở verify/reject.
+
+Manager + admin đã có reset (MANAGER_TEMPLATE + admin ``/*`` wildcard) → chỉ
+seed lone ``role:officer`` row để "fresh seed + migration = same end state".
+Accountant: no deny (mirror paper-submitted/graduation-proof family — finance
+không qua owning-officer IDOR scope nên allow kế thừa là moot).
+
+Per memory ``casbin-insert-must-include-eft``: v3 (eft) BẮT BUỘC trong INSERT —
+NULL eft làm ``load_policy()`` crash → 500. Idempotent ``INSERT ... WHERE NOT
+EXISTS`` để rerun + boot ``sync_casbin_policy`` an toàn.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "resetcasbin01"
+down_revision: Union[str, None] = "ampfix01_20260609"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Single row: (v0=subject, v1=object, v2=action, v3=eft). Mirror lone row thêm
+# vào OFFICER_TEMPLATE — manager/admin kế thừa, accountant moot.
+_OFFICER_RESET_POLICIES = [
+    (
+        "role:officer",
+        "/api/admissions/{id}/documents/{doc_code}/reset",
+        "POST",
+        "allow",
+    ),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    pre_count = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM casbin_rule "
+            "WHERE v1 LIKE '/api/admissions/%documents%reset' AND v0='role:officer'"
+        )
+    ).scalar()
+    print(f"[resetcasbin01] Pre-flight: existing officer-reset rows={pre_count}")
+
+    inserted = 0
+    for v0, v1, v2, v3 in _OFFICER_RESET_POLICIES:
+        result = conn.execute(
+            sa.text(
+                """
+                INSERT INTO casbin_rule
+                    (ptype, v0, v1, v2, v3, template_id, applied_at)
+                SELECT 'p',
+                       CAST(:v0 AS VARCHAR),
+                       CAST(:v1 AS VARCHAR),
+                       CAST(:v2 AS VARCHAR),
+                       CAST(:v3 AS VARCHAR),
+                       '_resetcasbin01_officer_reset_seed',
+                       NOW()
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM casbin_rule
+                    WHERE ptype='p'
+                      AND v0=CAST(:v0 AS VARCHAR)
+                      AND v1=CAST(:v1 AS VARCHAR)
+                      AND v2=CAST(:v2 AS VARCHAR)
+                      AND v3=CAST(:v3 AS VARCHAR)
+                )
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+        inserted += result.rowcount
+
+    print(f"[resetcasbin01] Seeded {inserted} new policy row(s).")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    deleted = 0
+    for v0, v1, v2, v3 in _OFFICER_RESET_POLICIES:
+        result = conn.execute(
+            sa.text(
+                """
+                DELETE FROM casbin_rule
+                WHERE ptype='p'
+                  AND v0=CAST(:v0 AS VARCHAR)
+                  AND v1=CAST(:v1 AS VARCHAR)
+                  AND v2=CAST(:v2 AS VARCHAR)
+                  AND v3=CAST(:v3 AS VARCHAR)
+                """
+            ),
+            {"v0": v0, "v1": v1, "v2": v2, "v3": v3},
+        )
+        deleted += result.rowcount
+    print(f"[resetcasbin01] Removed {deleted} policy row(s).")

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -192,6 +192,12 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         # deny row (same as paper-submitted — finance never reaches the
         # owning-officer scope check).
         {"subject": "{role}", "object": "/api/admissions/{id}/documents/{doc_code}/graduation-proof", "action": "POST"},
+        # BR3 (2026-06-09) — officer tự RESET tài liệu hồ sơ mình phụ trách khi
+        # ở draft/rejected/revision_requested (gỡ submission để sửa). Route gate
+        # cho officer chạm tới; service DocumentActionPolicy narrows owner +
+        # OWNER_DOC_MUTATION_STATES + doc non-missing. Manager/admin đã có reset
+        # ở template riêng; reset KHÔNG mở verify/reject (vẫn reviewer-only).
+        {"subject": "{role}", "object": "/api/admissions/{id}/documents/{doc_code}/reset", "action": "POST"},
         # Phase 3 multi-NV read-only (PR-3B). Officer can VIEW result-published
         # profiles + choice list for their assigned unit; mutations stay
         # manager-only per RBAC matrix plan v0.7. Service-layer IDOR

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -32,7 +32,8 @@ class FamilyMemberSchema(BaseModel):
     Family member information (stored in admission_profile.family_info JSONB array).
 
     Security:
-    - XSS Prevention: html.escape() on full_name, occupation
+    - Text fields trim-only; HTML escape ở tầng render (KHÔNG tầng lưu —
+      tránh bug double-escape "amp"). Xem ``sanitize_text``.
     - Phone Validation: Vietnam format (0 + 9-10 digits)
     """
     relationship: str = Field(
@@ -65,10 +66,17 @@ class FamilyMemberSchema(BaseModel):
     @field_validator('full_name', 'occupation', 'relationship')
     @classmethod
     def sanitize_text(cls, v: str) -> str:
-        """XSS Prevention: Escape HTML entities."""
+        """Trim khoảng trắng — KHÔNG html.escape.
+
+        Schema này dùng chung cho cả request LẪN response. html.escape
+        không idempotent (``&`` → ``&amp;``) nên escape ở tầng lưu khiến
+        giá trị tích lũy thêm một lớp ``&amp;`` mỗi vòng đọc/lưu (bug
+        "amp"). Escape HTML là việc của tầng render (React/JSX, Jinja
+        autoescape của email_service), KHÔNG phải tầng lưu.
+        """
         if not v:
             return v
-        return html.escape(v.strip())
+        return v.strip()
 
     model_config = ConfigDict(
         str_strip_whitespace=True,
@@ -88,7 +96,8 @@ class AcademicRecordSchema(BaseModel):
       THCS, 12 for THPT). Used by `resolve_kv_for_profile()` Phase C.
 
     Security:
-    - XSS Prevention: html.escape() on school_name
+    - school_name trim-only; HTML escape ở tầng render (KHÔNG tầng lưu —
+      tránh bug double-escape "amp"). Xem ``sanitize_school_name``.
     - Year Validation: year_from <= year_to, reasonable range (1900-2100)
     - GPA Validation: 0.0 - 10.0 range
     """
@@ -140,8 +149,14 @@ class AcademicRecordSchema(BaseModel):
     @field_validator('school_name')
     @classmethod
     def sanitize_school_name(cls, v: str) -> str:
-        """XSS Prevention: Escape HTML entities."""
-        return html.escape(v.strip())
+        """Trim khoảng trắng — KHÔNG html.escape.
+
+        Xem ghi chú ``FamilyMemberSchema.sanitize_text``: ``AcademicRecordSchema``
+        dùng chung cho request + response, html.escape không idempotent nên
+        escape ở tầng lưu sinh bug "amp" (``&#x27;`` → ``&amp;#x27;`` → …).
+        Escape thuộc tầng render, không phải tầng lưu.
+        """
+        return v.strip()
 
     @field_validator('level')
     @classmethod

--- a/Backend_FastAPI/app/services/admission_document_policy.py
+++ b/Backend_FastAPI/app/services/admission_document_policy.py
@@ -55,8 +55,11 @@ missing or previously rejected.
 ``"reject"``: reviewer, status is anything past ``missing`` except
 the rejected/missing terminal states (= ``uploaded`` /
 ``paper_submitted`` / ``verified``), profile NOT blocked.
-``"reset"``: reviewer, anything except ``missing``, profile NOT
-blocked.
+``"reset"``: reviewer (admin/manager-in-scope) on any non-``missing`` doc of
+a non-enrolled profile; OR the owning officer when the profile is in
+``OWNER_DOC_MUTATION_STATES`` (draft / rejected / revision_requested) — a
+self-service undo of the officer's own submission. verify/reject stay
+reviewer-only (review ≠ editing content).
 """
 from __future__ import annotations
 
@@ -101,6 +104,16 @@ APPLICANT_DOC_MUTATION_STATES: frozenset[str] = frozenset(
 # pre-Student so we leave reviewer access open for evidence cleanup.
 REVIEWER_DOC_MUTATION_BLOCKED_STATES: frozenset[str] = frozenset({"enrolled"})
 
+# BR3 (2026-06-09): trạng thái hồ sơ mà OWNER (officer phụ trách) được tự RESET
+# tài liệu — gỡ submission của chính mình để sửa khi hồ sơ chưa nộp/bị trả về.
+# Khớp đúng các trạng thái officer được sửa hồ sơ (``profile.permissions.edit``).
+# HẸP HƠN ``APPLICANT_DOC_MUTATION_STATES`` (vốn gồm submitted/resubmitted để
+# officer THÊM evidence sau nộp): officer upload được ở submitted NHƯNG KHÔNG
+# reset khi hồ sơ đang chờ reviewer thẩm định.
+OWNER_DOC_MUTATION_STATES: frozenset[str] = frozenset(
+    {"draft", "rejected", "revision_requested"}
+)
+
 
 # Cached derived flags — computed once per (profile, user) pair so the
 # five authorize() calls a single response makes don't re-derive them.
@@ -112,6 +125,7 @@ class _UserProfileContext:
     reviewer_scope: bool
     applicant_can_modify_docs: bool
     reviewer_can_modify_docs: bool
+    owner_can_modify_docs: bool
 
 
 def _build_context(
@@ -145,6 +159,7 @@ def _build_context(
     reviewer_can_modify_docs = (
         profile.status not in REVIEWER_DOC_MUTATION_BLOCKED_STATES
     )
+    owner_can_modify_docs = profile.status in OWNER_DOC_MUTATION_STATES
     return _UserProfileContext(
         is_admin=is_admin,
         is_owner=is_owner,
@@ -152,6 +167,7 @@ def _build_context(
         reviewer_scope=reviewer_scope,
         applicant_can_modify_docs=applicant_can_modify_docs,
         reviewer_can_modify_docs=reviewer_can_modify_docs,
+        owner_can_modify_docs=owner_can_modify_docs,
     )
 
 
@@ -237,11 +253,14 @@ class DocumentActionPolicy:
                 and doc_status in ("uploaded", "paper_submitted", "verified")
             )
         if action == "reset":
-            return (
-                ctx.reviewer_scope
-                and ctx.reviewer_can_modify_docs
-                and doc_status != "missing"
-            )
+            # BR3 (2026-06-09): reviewer (admin/manager-in-scope) reset bất kỳ
+            # doc non-missing của hồ sơ non-enrolled; HOẶC owner (officer phụ
+            # trách) tự reset khi hồ sơ ở draft/rejected/revision_requested
+            # (gỡ submission của chính mình để sửa). verify/reject vẫn
+            # reviewer-only (thẩm định ≠ sửa nội dung).
+            reviewer_ok = ctx.reviewer_scope and ctx.reviewer_can_modify_docs
+            owner_ok = ctx.is_owner and ctx.owner_can_modify_docs
+            return (reviewer_ok or owner_ok) and doc_status != "missing"
 
         # Unknown action — treat as deny so a typo in calling code
         # never grants access. Service guard surfaces the bug as a

--- a/Backend_FastAPI/app/services/admission_document_policy.py
+++ b/Backend_FastAPI/app/services/admission_document_policy.py
@@ -57,9 +57,11 @@ the rejected/missing terminal states (= ``uploaded`` /
 ``paper_submitted`` / ``verified``), profile NOT blocked.
 ``"reset"``: reviewer (admin/manager-in-scope) on any non-``missing`` doc of
 a non-enrolled profile; OR the owning officer when the profile is in
-``OWNER_DOC_MUTATION_STATES`` (draft / rejected / revision_requested) — a
-self-service undo of the officer's own submission. verify/reject stay
-reviewer-only (review ≠ editing content).
+``OWNER_DOC_MUTATION_STATES`` (draft / rejected / revision_requested) AND the
+doc is NOT yet ``verified`` — a self-service undo of the officer's OWN
+submission (uploaded / paper_submitted / rejected). The officer cannot reset
+a manager-``verified`` doc ("đã duyệt thì không cho chỉnh sửa"); only a
+reviewer can. verify/reject stay reviewer-only (review ≠ editing content).
 """
 from __future__ import annotations
 
@@ -255,11 +257,18 @@ class DocumentActionPolicy:
         if action == "reset":
             # BR3 (2026-06-09): reviewer (admin/manager-in-scope) reset bất kỳ
             # doc non-missing của hồ sơ non-enrolled; HOẶC owner (officer phụ
-            # trách) tự reset khi hồ sơ ở draft/rejected/revision_requested
-            # (gỡ submission của chính mình để sửa). verify/reject vẫn
-            # reviewer-only (thẩm định ≠ sửa nội dung).
+            # trách) tự reset khi hồ sơ ở draft/rejected/revision_requested —
+            # NHƯNG owner KHÔNG được reset doc đã ``verified`` ("đã duyệt thì
+            # không cho chỉnh sửa": officer chỉ gỡ submission CỦA CHÍNH MÌNH —
+            # uploaded/paper_submitted/rejected — không xoá verification của
+            # manager). Chỉ reviewer mới reset được doc đã verified. verify/
+            # reject vẫn reviewer-only (thẩm định ≠ sửa nội dung).
             reviewer_ok = ctx.reviewer_scope and ctx.reviewer_can_modify_docs
-            owner_ok = ctx.is_owner and ctx.owner_can_modify_docs
+            owner_ok = (
+                ctx.is_owner
+                and ctx.owner_can_modify_docs
+                and doc_status != "verified"
+            )
             return (reviewer_ok or owner_ok) and doc_status != "missing"
 
         # Unknown action — treat as deny so a typo in calling code

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -7133,9 +7133,12 @@ async def reset_document(
 
     Permissions (DocumentActionPolicy = single source of truth):
     - Officer (owning): reset trên hồ sơ draft / rejected / revision_requested
-      (gỡ submission của chính mình; OWNER_DOC_MUTATION_STATES). KHÔNG reset khi
-      submitted/resubmitted (đang chờ reviewer) hay approved/enrolled.
-    - Manager (in-scope) / Admin: reset bất kỳ doc non-missing trừ hồ sơ enrolled.
+      (gỡ submission CỦA CHÍNH MÌNH: uploaded/paper_submitted/rejected;
+      OWNER_DOC_MUTATION_STATES). KHÔNG reset doc đã ``verified`` ("đã duyệt thì
+      không cho chỉnh sửa"); KHÔNG reset khi submitted/resubmitted (đang chờ
+      reviewer) hay approved/enrolled.
+    - Manager (in-scope) / Admin: reset bất kỳ doc non-missing (kể cả verified)
+      trừ hồ sơ enrolled.
     - verify/reject vẫn reviewer-only (review ≠ sửa nội dung).
 
     Args:

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -223,23 +223,21 @@ def _authorize_document_action(
     config = doc_configs.get(doc_code, {}) or {}
     requires_upload = bool(config.get("requires_upload", True))
 
-    # BR2 (2026-04-29): the document is "extra" — exists in the DB but
-    # is no longer in the current applied_rules.mandatory_docs snapshot
-    # (typically because the AdmissionPath was edited after the profile
-    # was created). The response marks these rows with ``is_extra=True``
-    # and clamps every ``can_*`` flag to False so the FE row renders
-    # read-only. The service-side gate must mirror that contract,
-    # otherwise a direct call to ``verify-format`` / ``reject`` /
-    # ``reset`` / ``upload`` / ``paper-submitted`` bypasses the
-    # read-only promise (the policy alone never sees ``is_extra``).
-    # Treat missing ``mandatory_docs`` as ``[]`` for safety: a profile
-    # without a snapshot can't tell which docs are "active" so every
-    # request is necessarily on extras.
-    mandatory_docs = applied_rules.get("mandatory_docs") or []
-    if doc_code not in mandatory_docs:
+    # BR2 (2026-04-29; fix 2026-06-09): the document is "extra" — exists in
+    # the DB but is no longer in the current ``applied_rules.doc_configs``
+    # (typically because the AdmissionPath was edited after the profile was
+    # created). The response marks these rows ``is_extra=True`` + clamps every
+    # ``can_*`` flag to False (read-only). The service-side gate must mirror
+    # that contract. MUST check ``doc_configs`` (mandatory + optional), NOT
+    # just ``mandatory_docs`` — else optional docs (``is_mandatory=false``)
+    # would be treated as extra here and a real officer/manager mutation
+    # rejected even though the FE shows action buttons. Mirrors the builder's
+    # ``_active_set`` (= doc_configs keyset). Empty config → every request is
+    # on an extra (no snapshot to tell which docs are active).
+    if doc_code not in doc_configs:
         raise PermissionDeniedError(
             f"Document '{doc_code}' is no longer in the current admission "
-            f"path's mandatory list (treated as extra / evidence-only). "
+            f"path's document config (treated as extra / evidence-only). "
             f"Direct '{action}' actions are blocked until an explicit "
             f"sync-path action ships."
         )
@@ -2316,8 +2314,19 @@ def _compute_frontend_fields(
     #       is intentionally out of scope for this PR.
     documents_checklist = []
     _mandatory_set = set(all_mandatory_docs)
+    # BR2 fix (2026-06-09): "active" = MỌI doc trong doc_configs hiện tại
+    # (mandatory + optional), KHÔNG chỉ mandatory_docs. Optional doc
+    # (is_mandatory=false trong doc_configs, vd giay_kham_suc_khoe /
+    # giay_xac_nhan_cu_tru) khi đã nộp trước đây rơi vào pass 2 →
+    # is_extra=True + read-only + nhãn "ngoài yêu cầu hiện tại" SAI (thực
+    # ra là tài liệu tùy chọn của phương thức hiện tại). Thứ tự: mandatory
+    # trước (giữ thứ tự required), optional sau (thứ tự config).
+    _active_codes = list(all_mandatory_docs) + [
+        c for c in doc_configs.keys() if c not in _mandatory_set
+    ]
+    _active_set = set(_active_codes)
 
-    for i, doc_code in enumerate(all_mandatory_docs):
+    for i, doc_code in enumerate(_active_codes):
         config = doc_configs.get(doc_code, {})
         uploaded_doc = doc_by_code.get(doc_code, {})
         _doc_status = uploaded_doc.get("status", "missing")
@@ -2327,7 +2336,7 @@ def _compute_frontend_fields(
         documents_checklist.append({
             "code": doc_code,
             "label": config.get("label") or uploaded_doc.get("label_from_db") or doc_code,
-            "is_mandatory": True,
+            "is_mandatory": doc_code in _mandatory_set,
             "is_extra": False,
             "requires_upload": _requires_upload,
             "submission_format": config.get("submission_format"),
@@ -2361,9 +2370,11 @@ def _compute_frontend_fields(
             **_perms,
         })
 
-    # Pass (2): extra ProfileDocument rows. Stable sort by code so
-    # repeated GETs render in a consistent order.
-    for extra_code in sorted(c for c in doc_by_code.keys() if c not in _mandatory_set):
+    # Pass (2): extra ProfileDocument rows — code KHÔNG còn trong doc_configs
+    # hiện tại (path đã đổi sau khi nộp). Stable sort by code so repeated GETs
+    # render in a consistent order. Dùng _active_set (= doc_configs keyset),
+    # KHÔNG _mandatory_set, để optional doc không bị coi nhầm là extra.
+    for extra_code in sorted(c for c in doc_by_code.keys() if c not in _active_set):
         uploaded_doc = doc_by_code[extra_code]
         _doc_status = uploaded_doc.get("status", "missing")
         # No live config for extras (path changed). Infer
@@ -6896,13 +6907,16 @@ async def update_graduation_proof_kind(
             f"Document code '{doc_code}' not found in profile documents"
         )
 
-    # BR2 — extras (dropped from the mandatory snapshot) are read-only.
+    # BR2 (fix 2026-06-09) — extras (dropped from doc_configs) are read-only.
+    # Dùng doc_configs keyset (mandatory + optional) cho NHẤT QUÁN 1 định nghĩa
+    # "extra" với builder + _authorize_document_action. Vô hại với
+    # bang_tot_nghiep_thpt (luôn mandatory) — chỉ tránh drift về sau.
     applied_rules = profile.applied_rules or {}
-    mandatory_docs = applied_rules.get("mandatory_docs") or []
-    if doc_code not in mandatory_docs:
+    doc_configs = applied_rules.get("doc_configs") or {}
+    if doc_code not in doc_configs:
         raise PermissionDeniedError(
             f"Document '{doc_code}' is no longer in the current admission "
-            f"path's mandatory list (extra / evidence-only)."
+            f"path's document config (extra / evidence-only)."
         )
 
     # Coherence — only a RECEIVED graduation doc can be upgraded to official.

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -6872,7 +6872,7 @@ async def update_graduation_proof_kind(
     Auth: ``get_profile`` đã chặn IDOR scope (officer=assigned+unit /
     manager=unit / admin all). Thêm 2 guard mirror ``_authorize_document_action``
     mà sibling endpoints (paper-submit/verify/reject/reset) áp:
-    - **BR2 is_extra**: doc đã rớt khỏi ``mandatory_docs`` snapshot = read-only.
+    - **BR2 is_extra**: doc đã rớt khỏi ``doc_configs`` snapshot = read-only.
     - **doc-status**: chỉ cập nhật khi giấy ĐÃ được ghi nhận
       (``paper_submitted`` / ``verified``) — không stamp lên doc chưa nhận.
     Chỉ nhận ``official_diploma``: giấy tạm thời + hạn bổ sung ghi qua paper-

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -7131,9 +7131,12 @@ async def reset_document(
     consistent. The caller-side pattern lives in
     ``app/routers/admissions.py::reset_document_endpoint``.
 
-    Permissions:
-    - Officer: Can reset documents for profiles in draft/rejected status
-    - Manager/Admin: Can reset any document except for enrolled profiles
+    Permissions (DocumentActionPolicy = single source of truth):
+    - Officer (owning): reset trên hồ sơ draft / rejected / revision_requested
+      (gỡ submission của chính mình; OWNER_DOC_MUTATION_STATES). KHÔNG reset khi
+      submitted/resubmitted (đang chờ reviewer) hay approved/enrolled.
+    - Manager (in-scope) / Admin: reset bất kỳ doc non-missing trừ hồ sơ enrolled.
+    - verify/reject vẫn reviewer-only (review ≠ sửa nội dung).
 
     Args:
         db: Database session

--- a/Backend_FastAPI/tests/api/test_admission_document_permissions.py
+++ b/Backend_FastAPI/tests/api/test_admission_document_permissions.py
@@ -239,27 +239,27 @@ async def test_officer_owner_has_upload_but_not_verify(
 
 
 @pytest.mark.asyncio
-async def test_officer_cannot_verify_reject_or_reset_even_with_casbin_allow(
+async def test_officer_cannot_verify_or_reject_but_can_reset(
     client: AsyncClient,
     admin_token_headers: dict,
     officer_user_in_db: dict,
     doc_perm_config: dict,
 ):
-    """Service-layer guard keeps reviewer actions out of officer reach.
-
-    Before PR #5 review follow-up, the 4 doc-mutation routes only ran
-    Casbin + an IDOR check. Even after we relax Casbin to let the
-    officer hit /paper-submitted (needed for the can_mark_paper_submitted
-    flag), a separate `_authorize_document_action` guard must still
-    reject officer attempts on verify-format / reject / reset — the
-    can_* flags the FE receives would be false for those actions, and
-    the API must honour that, not just hide the buttons.
+    """Service-layer guard: officer (owning) trên hồ sơ draft ĐƯỢC tự reset
+    upload của mình (BR3 self-service undo) NHƯNG KHÔNG verify / reject — hai
+    việc đó vẫn reviewer-only bất kể route Casbin có chạm tới hay không.
     """
-    prof = await _create_profile(client, admin_token_headers, officer_user_in_db, doc_perm_config)
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, doc_perm_config
+    )
     pid = prof["id"]
 
-    oh = await _login(client, officer_user_in_db["username"], officer_user_in_db["password"])
-    current = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()["documents_checklist"]
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    current = (
+        await client.get(f"{ADMISSIONS}/{pid}", headers=oh)
+    ).json()["documents_checklist"]
     target = next(d for d in current if d.get("requires_upload"))
 
     # Officer uploads first so verify/reject/reset have a non-missing target.
@@ -271,18 +271,33 @@ async def test_officer_cannot_verify_reject_or_reset_even_with_casbin_allow(
     )
     assert upload.status_code in (200, 201), upload.text
 
-    # Casbin may also reject officer — either way, the action is forbidden.
-    # Accept any 4xx that is NOT 200 so behaviour is robust to whether
-    # Casbin seed has been applied yet.
+    # verify-format + reject stay reviewer-only — officer bị từ chối (403/404).
     for route, method, body in [
         (f"{ADMISSIONS}/{pid}/documents/{target['code']}/verify-format", "PATCH", {"format": "photo"}),
         (f"{ADMISSIONS}/{pid}/documents/{target['code']}/reject", "POST", {"reason": "officer-not-allowed"}),
-        (f"{ADMISSIONS}/{pid}/documents/{target['code']}/reset", "POST", {}),
     ]:
         resp = await client.request(method, route, headers=oh, json=body)
         assert resp.status_code in (403, 404), (
             f"{method} {route}: expected 403/404 for officer, got {resp.status_code}: {resp.text[:200]}"
         )
+
+    # BR3 (2026-06-09): officer (owner) RESET THÀNH CÔNG trên hồ sơ draft —
+    # gỡ chính upload của mình. Doc trở về 'missing'.
+    reset = await client.request(
+        "POST",
+        f"{ADMISSIONS}/{pid}/documents/{target['code']}/reset",
+        headers=oh,
+        json={},
+    )
+    assert reset.status_code in (200, 201), (
+        f"officer reset trên hồ sơ draft phải thành công, "
+        f"got {reset.status_code}: {reset.text[:200]}"
+    )
+    after = (
+        await client.get(f"{ADMISSIONS}/{pid}", headers=oh)
+    ).json()["documents_checklist"]
+    target_after = next(d for d in after if d["code"] == target["code"])
+    assert target_after["status"] == "missing", target_after
 
 
 @pytest.mark.asyncio

--- a/Backend_FastAPI/tests/api/test_admission_document_permissions.py
+++ b/Backend_FastAPI/tests/api/test_admission_document_permissions.py
@@ -232,10 +232,13 @@ async def test_officer_owner_has_upload_but_not_verify(
     for doc in upload_docs:
         # missing + owning officer + profile editable → may upload
         assert doc["can_upload"] is True, f"{doc['code']}: owning officer should upload"
-        # Verify/reject/reset belong to reviewer scope only.
+        # Verify/reject = reviewer-only. Reset: owning officer CÓ quyền ở draft
+        # (BR3) NHƯNG ở đây các doc đang 'missing' → can_reset=False vì reset cần
+        # doc non-missing, KHÔNG phải vì reviewer-only. (Officer-reset-được kiểm
+        # ở test_officer_cannot_verify_or_reject_but_can_reset.)
         assert doc["can_verify"] is False, f"{doc['code']}: officer must not verify"
         assert doc["can_reject"] is False, f"{doc['code']}: officer must not reject"
-        assert doc["can_reset"] is False, f"{doc['code']}: officer must not reset"
+        assert doc["can_reset"] is False, f"{doc['code']}: missing doc → no reset"
 
 
 @pytest.mark.asyncio

--- a/Backend_FastAPI/tests/api/test_admission_document_permissions.py
+++ b/Backend_FastAPI/tests/api/test_admission_document_permissions.py
@@ -44,6 +44,10 @@ async def doc_perm_config(seed_lead_dependencies: dict):
             s.add(ot); await s.flush()
             dt = models.ConfigDocumentType(code=f"tcc_{ts}", name=f"TCC_{ts}", display_order=1)
             s.add(dt); await s.flush()
+            # Optional doc type (is_mandatory=False) — để test phân loại is_extra:
+            # tài liệu tùy chọn của method hiện tại KHÔNG được coi là "ngoài yêu cầu".
+            dt_opt = models.ConfigDocumentType(code=f"opt_{ts}", name=f"OPT_{ts}", display_order=2)
+            s.add(dt_opt); await s.flush()
             po = models.ProgramOffering(
                 offering_type=f"TQ_{ts}", program_id=mpid, offering_type_id=ot.id,
                 is_active=True, duration_semesters=6,
@@ -94,7 +98,20 @@ async def doc_perm_config(seed_lead_dependencies: dict):
                 display_order=1,
             )
             s.add(dgi); await s.flush()
-    return {"unit_id": uid, "offering_id": po.id, "method_id": am.id, "round_id": round_id}
+            # Optional (paper) item — mirrors giay_kham_suc_khoe trong prod config.
+            dgi_opt = models.DocumentGroupItem(
+                group_id=dg.id,
+                document_type_id=dt_opt.id,
+                is_mandatory=False,
+                requires_upload=False,
+                submission_format="original",
+                display_order=2,
+            )
+            s.add(dgi_opt); await s.flush()
+    return {
+        "unit_id": uid, "offering_id": po.id, "method_id": am.id,
+        "round_id": round_id, "optional_doc_code": f"opt_{ts}",
+    }
 
 
 async def _create_profile(client, admin_token_headers, officer_user_in_db, cfg):
@@ -152,6 +169,49 @@ async def test_documents_checklist_exposes_permission_flags(
             assert isinstance(doc[flag], bool), (
                 f"{flag} on {doc.get('code')!r} should be bool, got {type(doc[flag]).__name__}"
             )
+
+
+@pytest.mark.asyncio
+async def test_optional_doc_in_main_list_not_extra(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    doc_perm_config: dict,
+):
+    """Tài liệu TÙY CHỌN (is_mandatory=false trong doc_configs) phải nằm trong
+    danh sách chính: ``is_extra=false`` + ``is_mandatory=false`` — KHÔNG bị gán
+    nhầm "ngoài yêu cầu / phương thức trước đó".
+
+    Regression cho bug phân loại is_extra: builder cũ chỉ duyệt mandatory_docs
+    nên optional doc (vd giay_kham_suc_khoe) khi đã nộp rơi vào pass 2 →
+    is_extra=True + read-only. Sau fix: builder duyệt cả doc_configs keyset →
+    optional hiển thị ngay cả khi chưa nộp, có nút thao tác bình thường.
+    """
+    prof = await _create_profile(
+        client, admin_token_headers, officer_user_in_db, doc_perm_config
+    )
+    pid = prof["id"]
+
+    checklist = (
+        await client.get(f"{ADMISSIONS}/{pid}", headers=admin_token_headers)
+    ).json()["documents_checklist"]
+    opt_code = doc_perm_config["optional_doc_code"]
+    opt = next((d for d in checklist if d["code"] == opt_code), None)
+
+    assert opt is not None, (
+        f"optional doc {opt_code!r} phải xuất hiện trong checklist chính "
+        f"(logic is_extra cũ làm nó vô hình khi chưa nộp). "
+        f"codes: {[d['code'] for d in checklist]}"
+    )
+    assert opt["is_extra"] is False, "optional doc của method hiện tại KHÔNG phải extra"
+    assert opt["is_mandatory"] is False, "optional doc phải đánh dấu không bắt buộc"
+    # KHÔNG bị clamp read-only như extra: admin thấy đủ 5 flag (giá trị tùy status).
+    expected_flags = (
+        "can_upload", "can_verify", "can_reject", "can_reset",
+        "can_mark_paper_submitted",
+    )
+    for flag in expected_flags:
+        assert flag in opt, f"optional doc thiếu flag {flag}"
 
 
 @pytest.mark.asyncio
@@ -273,18 +333,17 @@ async def test_extras_are_locked_at_service_layer_not_just_in_response(
     officer_user_in_db: dict,
     doc_perm_config: dict,
 ):
-    """BR2 (2026-04-29): documents whose code is no longer in the
-    profile's ``applied_rules.mandatory_docs`` snapshot are
-    evidence-only — every direct API mutation must be rejected, not
-    just hidden in the UI.
+    """BR2 (2026-04-29; def fix 2026-06-09): documents whose code is no longer
+    in the profile's ``applied_rules.doc_configs`` (mandatory + optional) are
+    evidence-only — every direct API mutation must be rejected, not just hidden
+    in the UI.
 
-    Set up: create a profile (which seeds ``mandatory_docs`` from the
-    path), upload its mandatory doc, then mutate the snapshot in DB so
-    that doc becomes "extra". Re-fetch and confirm the response marks
+    Set up: create a profile (which seeds ``doc_configs`` from the path), upload
+    its mandatory doc, then mutate the snapshot in DB so that doc drops out of
+    ``doc_configs`` (becomes "extra"). Re-fetch and confirm the response marks
     it ``is_extra=True`` with all ``can_*`` false. Then call every
-    document-mutation endpoint directly and assert each one is
-    rejected — proves the service guard, not just the response shape,
-    enforces the read-only contract.
+    document-mutation endpoint directly and assert each one is rejected —
+    proves the service guard, not just the response shape, enforces read-only.
     """
     from sqlalchemy.orm.attributes import flag_modified
     from sqlalchemy import select
@@ -315,7 +374,7 @@ async def test_extras_are_locked_at_service_layer_not_just_in_response(
 
     # Mutate the snapshot so target becomes "extra". This simulates the
     # AdmissionPath being edited after profile creation; the service
-    # under test must observe applied_rules.mandatory_docs as the
+    # under test must observe applied_rules.doc_configs as the
     # source of truth and reject mutations on the now-stale doc.
     async with AsyncSessionLocal() as s:
         async with s.begin():
@@ -326,7 +385,12 @@ async def test_extras_are_locked_at_service_layer_not_just_in_response(
             )
             db_profile = row.scalar_one()
             new_rules = dict(db_profile.applied_rules or {})
+            # BR2 (fix 2026-06-09): "extra" giờ định nghĩa theo doc_configs
+            # (mandatory + optional), KHÔNG chỉ mandatory_docs. Để target thành
+            # extra THẬT (mô phỏng AdmissionPath đổi → doc rớt hẳn), xóa khỏi CẢ
+            # mandatory_docs LẪN doc_configs.
             new_rules["mandatory_docs"] = []
+            new_rules["doc_configs"] = {}
             db_profile.applied_rules = new_rules
             flag_modified(db_profile, "applied_rules")
 

--- a/Backend_FastAPI/tests/unit/test_admission_document_policy.py
+++ b/Backend_FastAPI/tests/unit/test_admission_document_policy.py
@@ -290,11 +290,51 @@ class TestReset:
         policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, admin)
         assert not policy.authorize("reset", "missing", requires_upload=True)
 
-    def test_officer_cannot_reset(
+    @pytest.mark.parametrize(
+        "profile_status", ["draft", "rejected", "revision_requested"]
+    )
+    def test_owner_officer_can_reset_in_editable_states(
+        self, officer_owner, profile_status,
+    ):
+        """BR3 (2026-06-09): owning officer tự reset (gỡ submission của chính
+        mình) khi hồ sơ ở OWNER_DOC_MUTATION_STATES."""
+        profile = _StubProfile(
+            status=profile_status,
+            lead=_StubLead(unit_id=42, assigned_officer_id=20),
+        )
+        policy = DocumentActionPolicy.for_(profile, officer_owner)
+        assert policy.authorize("reset", "uploaded", requires_upload=True)
+
+    @pytest.mark.parametrize(
+        "profile_status", ["submitted", "resubmitted", "approved", "enrolled"]
+    )
+    def test_owner_officer_cannot_reset_outside_editable_states(
+        self, officer_owner, profile_status,
+    ):
+        """Officer KHÔNG reset khi hồ sơ đang chờ reviewer (submitted/
+        resubmitted) hay đã quyết định (approved/enrolled) — reviewer-only."""
+        profile = _StubProfile(
+            status=profile_status,
+            lead=_StubLead(unit_id=42, assigned_officer_id=20),
+        )
+        policy = DocumentActionPolicy.for_(profile, officer_owner)
+        assert not policy.authorize("reset", "uploaded", requires_upload=True)
+
+    def test_officer_not_owner_cannot_reset(
+        self, profile_draft_lead42_owner20, officer_not_owner,
+    ):
+        """Officer KHÁC (không phụ trách) không reset dù hồ sơ draft."""
+        policy = DocumentActionPolicy.for_(
+            profile_draft_lead42_owner20, officer_not_owner
+        )
+        assert not policy.authorize("reset", "uploaded", requires_upload=True)
+
+    def test_missing_blocks_owner_reset(
         self, profile_draft_lead42_owner20, officer_owner,
     ):
+        """reset cần doc non-missing kể cả với owner."""
         policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
-        assert not policy.authorize("reset", "uploaded", requires_upload=True)
+        assert not policy.authorize("reset", "missing", requires_upload=True)
 
 
 # ---------------------------------------------------------------------------

--- a/Backend_FastAPI/tests/unit/test_admission_document_policy.py
+++ b/Backend_FastAPI/tests/unit/test_admission_document_policy.py
@@ -336,6 +336,31 @@ class TestReset:
         policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
         assert not policy.authorize("reset", "missing", requires_upload=True)
 
+    @pytest.mark.parametrize(
+        "profile_status", ["draft", "rejected", "revision_requested"]
+    )
+    def test_owner_officer_cannot_reset_verified_doc(
+        self, officer_owner, profile_status,
+    ):
+        """BR3 "đã duyệt thì không cho chỉnh sửa": owner KHÔNG reset doc đã
+        ``verified`` (manager duyệt) — chỉ reviewer mới reset được verified."""
+        profile = _StubProfile(
+            status=profile_status,
+            lead=_StubLead(unit_id=42, assigned_officer_id=20),
+        )
+        policy = DocumentActionPolicy.for_(profile, officer_owner)
+        assert not policy.authorize("reset", "verified", requires_upload=True)
+
+    @pytest.mark.parametrize(
+        "doc_status", ["uploaded", "paper_submitted", "rejected"]
+    )
+    def test_owner_officer_can_reset_own_submission(
+        self, profile_draft_lead42_owner20, officer_owner, doc_status,
+    ):
+        """Owner reset được submission CỦA CHÍNH MÌNH (chưa verified)."""
+        policy = DocumentActionPolicy.for_(profile_draft_lead42_owner20, officer_owner)
+        assert policy.authorize("reset", doc_status, requires_upload=True)
+
 
 # ---------------------------------------------------------------------------
 # Defensive: unknown action denies — typo in caller never grants access

--- a/Backend_FastAPI/tests/unit/test_admission_schema_no_html_escape.py
+++ b/Backend_FastAPI/tests/unit/test_admission_schema_no_html_escape.py
@@ -1,0 +1,72 @@
+"""Regression test cho bug "amp" (double HTML-escape).
+
+``AcademicRecordSchema`` và ``FamilyMemberSchema`` dùng CHUNG cho cả
+request lẫn response. Trước đây cả hai html.escape() text fields ở tầng
+schema; vì ``html.escape`` không idempotent (``&`` → ``&amp;``), mỗi vòng
+đọc→sửa→lưu cộng thêm một lớp ``&amp;`` → tên trường "THPT Ea H'leo" biến
+thành "THPT Ea H&amp;amp;...amp;#x27;leo".
+
+Fix: schema chỉ trim, KHÔNG escape (escape là việc của tầng render —
+React/JSX, Jinja autoescape). Test này khóa hành vi: giá trị đi qua schema
+phải giữ NGUYÊN VĂN ký tự ``&``, ``'``, ``<``, ``>`` (không thành entity).
+"""
+import pytest
+
+from app.schemas.admission import AcademicRecordSchema, FamilyMemberSchema
+
+
+# Tên trường thật trong vn_school có cả & (THCS&THPT) lẫn ' (Ea H'leo).
+RAW_SCHOOL_NAMES = [
+    "THPT Ea H'leo (Từ 04/6/2021)",
+    "THCS & THPT Nguyễn Du - Đà Lạt",
+    "Trường <Test> \"Quote\" & Co",
+]
+
+HTML_ENTITY_FRAGMENTS = ["&amp;", "&#x27;", "&#39;", "&lt;", "&gt;", "&quot;"]
+
+
+def _assert_no_html_entity(value: str) -> None:
+    for frag in HTML_ENTITY_FRAGMENTS:
+        assert frag not in value, f"giá trị bị escape thành entity ({frag}): {value!r}"
+
+
+@pytest.mark.parametrize("raw", RAW_SCHOOL_NAMES)
+def test_academic_school_name_not_escaped(raw):
+    rec = AcademicRecordSchema(school_name=raw, year_from=2020, year_to=2023)
+    assert rec.school_name == raw
+    _assert_no_html_entity(rec.school_name)
+
+
+@pytest.mark.parametrize("raw", RAW_SCHOOL_NAMES)
+def test_family_text_fields_not_escaped(raw):
+    member = FamilyMemberSchema(
+        relationship="Bố & Mẹ",
+        full_name=raw,
+        occupation="Kỹ sư R&D",
+        phone="0901234567",
+    )
+    assert member.full_name == raw
+    assert member.relationship == "Bố & Mẹ"
+    assert member.occupation == "Kỹ sư R&D"
+    _assert_no_html_entity(member.full_name)
+    _assert_no_html_entity(member.relationship)
+    _assert_no_html_entity(member.occupation)
+
+
+def test_school_name_still_trimmed():
+    """Vẫn trim khoảng trắng (giữ hành vi cũ, chỉ bỏ escape)."""
+    rec = AcademicRecordSchema(
+        school_name="  THPT Ea H'leo  ", year_from=2020, year_to=2023
+    )
+    assert rec.school_name == "THPT Ea H'leo"
+
+
+def test_already_escaped_value_passes_through_unchanged():
+    """Giá trị đã chứa '&amp;' KHÔNG bị escape thêm lớp nữa (idempotent).
+
+    (Backfill migration mới là nơi 'gỡ' giá trị lịch sử đã hỏng — schema
+    chỉ cần ngừng tạo thêm lớp.)
+    """
+    already = "THPT Ea H&amp;#x27;leo"
+    rec = AcademicRecordSchema(school_name=already, year_from=2020, year_to=2023)
+    assert rec.school_name == already  # không thành &amp;amp;#x27;

--- a/Backend_FastAPI/tests/unit/test_amp_backfill_migration.py
+++ b/Backend_FastAPI/tests/unit/test_amp_backfill_migration.py
@@ -1,0 +1,88 @@
+"""Unit test cho logic backfill migration ampfix01 (gỡ double-escape "amp").
+
+Khóa nửa "sửa dữ liệu lịch sử" của fix amp: ``_unescape_stable`` (gỡ N lớp
+``&amp;``), ``_ENTITY_RE`` (predicate nhận diện entity), ``_coerce_json``
+(asyncpg trả str vs list), ``_clean_list``. Migration không chạy qua alembic
+trong test DB (create_all), nên test này là tầng bảo vệ runtime cho logic gỡ
+corruption.
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "ampfix01_20260609_backfill_school_name_unescape.py"
+)
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("ampfix01_mig", str(MIGRATION_PATH))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mig = _load()
+
+
+def test_unescape_stable_collapses_many_amp_layers():
+    corrupted = "THPT Ea H&amp;amp;amp;amp;amp;amp;amp;amp;#x27;leo (Từ 04/6/2021)"
+    assert mig._unescape_stable(corrupted) == "THPT Ea H'leo (Từ 04/6/2021)"
+
+
+def test_unescape_stable_single_layer():
+    assert mig._unescape_stable("THPT Ea H&#x27;leo") == "THPT Ea H'leo"
+    assert mig._unescape_stable("THCS &amp; THPT") == "THCS & THPT"
+
+
+def test_unescape_stable_idempotent_on_clean():
+    cleans = ["THPT Ea H'leo (Từ 04/6/2021)", "THCS & THPT Nguyễn Du", "Bình thường"]
+    for clean in cleans:
+        assert mig._unescape_stable(clean) == clean
+
+
+def test_unescape_stable_non_string_passthrough():
+    assert mig._unescape_stable(None) is None
+    assert mig._unescape_stable(123) == 123
+
+
+def test_entity_regex_matches_real_entities_not_bare_ampersand():
+    pat = re.compile(mig._ENTITY_RE)
+    for hit in ["a&amp;b", "x&#x27;y", "p&#39;q", "u&lt;v", "m&gt;n", "s&quot;t"]:
+        assert pat.search(hit), f"phải match entity: {hit}"
+    # Bare '&' (tên trường thật "THCS & THPT") KHÔNG được match → không backfill nhầm.
+    for clean in ["THCS & THPT", "THCS&THPT", "A & B & C", "Plain name"]:
+        assert not pat.search(clean), f"KHÔNG được match clean: {clean}"
+
+
+def test_coerce_json_handles_str_and_parsed():
+    # asyncpg có thể trả JSONB đã parse (list) hoặc str — cả hai phải ra list.
+    assert mig._coerce_json('[{"school_name": "X"}]') == [{"school_name": "X"}]
+    assert mig._coerce_json([{"school_name": "X"}]) == [{"school_name": "X"}]
+
+
+def test_clean_list_unescapes_target_fields_and_reports_change():
+    academic = [{"school_name": "THPT Ea H&amp;#x27;leo", "gpa": None}]
+    changed = mig._clean_list(academic, ("school_name",))
+    assert changed is True
+    assert academic[0]["school_name"] == "THPT Ea H'leo"
+    # field không nằm trong danh sách → không đụng; clean → không báo changed.
+    clean = [{"school_name": "THPT Sạch", "full_name": "Nguyễn &amp; Văn"}]
+    assert mig._clean_list(clean, ("school_name",)) is False
+    assert clean[0]["full_name"] == "Nguyễn &amp; Văn"
+
+
+@pytest.mark.parametrize("bad", [None, "not-a-list", 42])
+def test_clean_list_tolerates_non_list_entries(bad):
+    # _clean_list duyệt entry; entry không phải dict bị bỏ qua, không crash.
+    assert mig._clean_list([bad], ("school_name",)) is False

--- a/Backend_FastAPI/tests/unit/test_officer_reset_casbin_seed.py
+++ b/Backend_FastAPI/tests/unit/test_officer_reset_casbin_seed.py
@@ -1,0 +1,72 @@
+"""BR3: officer-reset Casbin policy — template ↔ migration agreement lock.
+
+Route officer RESET (``POST /api/admissions/{id}/documents/{doc_code}/reset``)
+phải vừa nằm trong ``OFFICER_TEMPLATE`` (dev/test auto-seed dựa vào đây) VỪA
+được migration ``resetcasbin01`` seed (prod — auto-sync template TẮT). Nếu một
+bên thiếu → dev PASS nhưng prod officer-reset 403 (bug ẩn dev-prod). Test này
+khóa cả hai khớp nhau.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+from app.casbin_config.policy_templates import OFFICER_TEMPLATE
+
+
+RESET_ROUTE = "/api/admissions/{id}/documents/{doc_code}/reset"
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "resetcasbin01_20260609_officer_reset_casbin.py"
+)
+
+
+def _load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "resetcasbin01_mig", str(MIGRATION_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_officer_template_grants_reset_route():
+    """OFFICER_TEMPLATE phải cấp route reset (dev/test auto-seed dựa vào đây)."""
+    matches = [
+        p
+        for p in OFFICER_TEMPLATE["policies"]
+        if p.get("object") == RESET_ROUTE and p.get("action") == "POST"
+    ]
+    assert matches, (
+        "OFFICER_TEMPLATE thiếu route reset → dev/test auto-seed không cấp "
+        "officer reset (trong khi prod migration lại có → drift)."
+    )
+
+
+def test_migration_seeds_officer_reset_with_eft():
+    """Migration seed đúng 1 row role:officer reset + eft='allow' (v3 bắt buộc)."""
+    mig = _load_migration()
+    assert mig._OFFICER_RESET_POLICIES == [
+        ("role:officer", RESET_ROUTE, "POST", "allow")
+    ], mig._OFFICER_RESET_POLICIES
+    assert mig.revision == "resetcasbin01"
+    assert mig.down_revision == "ampfix01_20260609"
+
+
+def test_template_and_migration_agree_on_route():
+    """Route reset trong migration phải có trong OFFICER_TEMPLATE (chống drift)."""
+    mig = _load_migration()
+    mig_routes = {row[1] for row in mig._OFFICER_RESET_POLICIES}
+    tmpl_routes = {
+        p["object"]
+        for p in OFFICER_TEMPLATE["policies"]
+        if p.get("action") == "POST" and p.get("object", "").endswith("/reset")
+    }
+    assert mig_routes <= tmpl_routes, (
+        f"migration route {mig_routes} không có trong OFFICER_TEMPLATE {tmpl_routes}"
+    )

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/TuitionTab.tsx
@@ -59,6 +59,13 @@ export function TuitionTab({ profile }: TuitionTabProps) {
   // Module-level role gate for the deep-link CTAs into /finance/*. The
   // proxy blocks officers from that area entirely — surfacing a button
   // that redirects them out of the page is a worse UX than hiding it.
+  //
+  // NOTE (audit 2026-06-09): đây là NGOẠI LỆ CÓ CHỦ ĐÍCH của quy tắc thin-client
+  // "no role checks". Nó CHỈ ẩn link điều hướng sang module Finance — KHÔNG gate
+  // bất kỳ mutation/dữ liệu nào (mọi thao tác tài chính do BE + proxy enforce,
+  // vd hasAction(calculate_fee)/record_fee_payment ở trên). Vì "được vào module
+  // Finance" là quyền cấp-module (không gắn với 1 hồ sơ) nên không có permission
+  // flag profile-scoped phù hợp để thay; role check ở đây là chấp nhận được.
   const userRole = useAuthStore((s) => s.user?.role)
   const canAccessFinanceModule = hasFinanceAccess(userRole)
   // P3 (2026-05-22) — BE coi {approved, overridden, admitted} là admitted-like


### PR DESCRIPTION
Gom 6 finding module Admission phát hiện qua smoke hồ sơ #31 + audit gating tab. 8 commit, mỗi finding 1 commit để theo dõi.

## Findings & fix

**1. Bug "amp" trong Tên trường** (`321acc44` + `02ce4853`)
`AcademicRecordSchema.school_name` + `FamilyMemberSchema` dùng chung schema cho request lẫn response; `html.escape` không idempotent → mỗi vòng đọc/lưu cộng 1 lớp `&amp;` (DB 8 lớp / response 9 lớp). "THPT Ea H'leo" hiển thị đầy "amp".
→ Bỏ escape ở schema (escape thuộc tầng render — React/JSX, Jinja autoescape). Migration `ampfix01` `html.unescape` lặp gỡ corruption (prod scope: 1 hồ sơ #31). Verify an toàn XSS: FE 0 `dangerouslySetInnerHTML`, email/export escape tầng riêng.

**2. Tài liệu tùy chọn bị gán "ngoài yêu cầu"** (`64f546df`)
`giay_kham_suc_khoe` / `giay_xac_nhan_cu_tru` (optional, `is_mandatory=false` trong `doc_configs`) bị builder (chỉ duyệt `mandatory_docs`) đẩy thành `is_extra=true` + read-only.
→ 3 site dùng chung 1 định nghĩa extra = code ∉ `doc_configs` (builder 2-pass + `_authorize_document_action` + `update_graduation_proof_kind`). Optional doc giờ vào danh sách chính, badge "Tùy chọn", có nút thao tác, không chặn submit.

**3. Officer reset tài liệu khi hồ sơ chưa nộp** (`2ba661ca` + `4883d880`)
Trước đây reset reviewer-only → officer lỡ upload sai ở draft bị kẹt.
→ `DocumentActionPolicy`: owner reset khi hồ sơ ∈ {draft, rejected, revision_requested} — NHƯNG **không reset doc đã `verified`** ("đã duyệt thì không cho chỉnh sửa": officer chỉ gỡ submission của chính mình; reviewer vẫn reset verified). Casbin: route reset vào OFFICER_TEMPLATE + migration `resetcasbin01` seed `role:officer` (eft=allow) cho prod (auto-sync tắt). verify/reject vẫn reviewer-only.

**4. TuitionTab** (`19b5c945`) — comment làm rõ `hasFinanceAccess` là gate điều hướng (proxy enforce), không đổi hành vi.
**5. ChoiceListEditor** — false alarm: promote/reject waitlist gate bằng `choice.decision`, không phải `canEdit`. No-op.
**6. Review-followup** (`680af7ac`) — docstring stale + comment test + `test_amp_backfill_migration`.

## Verify
- **105 pytest PASS**: schema (8) + policy unit (89) + API permissions (6) + backfill (10) + casbin drift-lock (3).
- Code-review xhigh (7 finder agent): 0 correctness bug.
- Migration roundtrip dev: `ampfix01` → #31 "THPT Ea H'leo (Từ 04/6/2021)" sạch; `resetcasbin01` seed 1 row officer-reset.
- Chrome smoke (admin): amp hết (#31), optional docs vào main list (#25 verified + #31 missing), hết mục "ngoài yêu cầu".

## ⚠️ Deploy note
2 migration mới chạy qua entrypoint `alembic upgrade head`:
- `ampfix01_20260609` — backfill data, prod đúng 1 hồ sơ #31 (idempotent, forward-only).
- `resetcasbin01_20260609` — seed Casbin officer-reset (eft bắt buộc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)