### PR TITLE
fix(admissions): địa chỉ thường trú legacy hết "nhảy" sang xã sai sau khi lưu + hiển thị rõ xã/phường 2 cấp

### DIFF
--- a/Backend_FastAPI/app/repositories/administrative_repository.py
+++ b/Backend_FastAPI/app/repositories/administrative_repository.py
@@ -147,6 +147,14 @@ class AdministrativeRepository(BaseRepository[AdministrativeNode]):
                 AdministrativeNode.level == AdministrativeLevel.WARD,
                 AdministrativeNode.successor_ward_code.isnot(None),
             )
+            # A GSO ward code can be REUSED across the 2025 reform (the same code
+            # exists in BOTH the legacy and current snapshots — e.g. 24717 =
+            # legacy "Thị trấn Đức An" AND current "Xã Đức An"). The CURRENT-era
+            # row (valid_to IS NULL) is authoritative: its successor is the live
+            # commune. Order current-first so resolution is DETERMINISTIC and
+            # correct regardless of row/scan order — a bare ``.limit(1)`` would
+            # pick an arbitrary era when the code collides.
+            .order_by(AdministrativeNode.valid_to.is_(None).desc())
             .limit(1)
         )
         result = await self.db.execute(stmt)

--- a/Backend_FastAPI/app/repositories/administrative_repository.py
+++ b/Backend_FastAPI/app/repositories/administrative_repository.py
@@ -171,6 +171,42 @@ class AdministrativeRepository(BaseRepository[AdministrativeNode]):
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def get_current_province_name_for_ward(
+        self, ward_code: str
+    ) -> Optional[str]:
+        """Province name (CURRENT era) that a CURRENT-era ward code belongs to.
+
+        Resolves WARD.code → WARD.province_code → PROVINCE.name (both valid_to IS
+        NULL). Lets the resolve-ward endpoint return the full 2-level address
+        ("Xã X, Tỉnh Y") so the officer can confirm the standardized residence.
+        Returns None if the ward or its province isn't found in the current snapshot.
+        """
+        code = (ward_code or "").strip()
+        if not code:
+            return None
+        province_code = await self.db.scalar(
+            select(AdministrativeNode.province_code)
+            .where(
+                AdministrativeNode.code == code,
+                AdministrativeNode.level == AdministrativeLevel.WARD,
+                AdministrativeNode.valid_to.is_(None),
+                AdministrativeNode.is_active.is_(True),
+            )
+            .limit(1)
+        )
+        if not province_code:
+            return None
+        return await self.db.scalar(
+            select(AdministrativeNode.name)
+            .where(
+                AdministrativeNode.code == province_code,
+                AdministrativeNode.level == AdministrativeLevel.PROVINCE,
+                AdministrativeNode.valid_to.is_(None),
+                AdministrativeNode.is_active.is_(True),
+            )
+            .limit(1)
+        )
+
     # ------------------------------------------------------------------
     # GENERIC FILTERED (admin panel)
     # ------------------------------------------------------------------

--- a/Backend_FastAPI/app/routers/administrative.py
+++ b/Backend_FastAPI/app/routers/administrative.py
@@ -129,9 +129,15 @@ async def resolve_ward(
     current_name = (
         await repo.get_current_ward_name(current_code) if current_code else None
     )
+    current_province_name = (
+        await repo.get_current_province_name_for_ward(current_code)
+        if current_code
+        else None
+    )
     return ResolveWardResponse(
         input_code=code,
         current_code=current_code,
         current_name=current_name,
+        current_province_name=current_province_name,
         resolved=current_code is not None,
     )

--- a/Backend_FastAPI/app/schemas/administrative.py
+++ b/Backend_FastAPI/app/schemas/administrative.py
@@ -44,8 +44,13 @@ class ResolveWardResponse(BaseModel):
 
     ``resolved=False`` (current_code=None) means the input couldn't be mapped to a
     current-era commune → FE keeps the officer on a current-mode pick (submit gate
-    also fail-closes)."""
+    also fail-closes).
+
+    ``current_province_name`` is the province the resolved commune now belongs to
+    (post 01/07/2025 2-level地giới) — lets the FE show the full standardized address
+    "Xã X, Tỉnh Y" so the officer can confirm the 2-level resolution at a glance."""
     input_code: str
     current_code: Optional[str] = None
     current_name: Optional[str] = None
+    current_province_name: Optional[str] = None
     resolved: bool

--- a/Backend_FastAPI/tests/api/test_kv_pr3_resolve_and_canonicalize.py
+++ b/Backend_FastAPI/tests/api/test_kv_pr3_resolve_and_canonicalize.py
@@ -35,6 +35,8 @@ ADMISSIONS = "/api/admissions"
 # test seeds running in the same module session.
 CURRENT_CODE = "KVC01"
 CURRENT_NAME = "Phường Hiện Hành KV"
+CURRENT_PROVINCE_CODE = "95"
+CURRENT_PROVINCE_NAME = "Tỉnh Hiện Hành KV"
 LEGACY_MERGED_CODE = "KVL01"   # merged away → successor = CURRENT_CODE
 LEGACY_UNMAPPED_CODE = "KVL02"  # legacy, no successor mapped yet → fail-closed
 
@@ -56,9 +58,15 @@ async def _seed_kv_nodes(setup_test_database):
                          ward_code, valid_from, valid_to, is_active,
                          successor_ward_code)
                     VALUES
+                        -- current province (2-level) the current ward belongs to
+                        ('{CURRENT_PROVINCE_CODE}', '{CURRENT_PROVINCE_NAME}',
+                         'PROVINCE', '{CURRENT_PROVINCE_CODE}',
+                         '{CURRENT_PROVINCE_CODE}', NULL, NULL,
+                         '2025-07-01', NULL, true, NULL),
                         -- current ward (2-level): identity successor = self
                         ('{CURRENT_CODE}', '{CURRENT_NAME}', 'WARD',
-                         '95/{CURRENT_CODE}', '95', NULL,
+                         '{CURRENT_PROVINCE_CODE}/{CURRENT_CODE}',
+                         '{CURRENT_PROVINCE_CODE}', NULL,
                          '{CURRENT_CODE}', '2025-07-01', NULL, true, '{CURRENT_CODE}'),
                         -- legacy ward merged into the current commune
                         ('{LEGACY_MERGED_CODE}', 'Xã Cũ Gộp', 'WARD',
@@ -94,6 +102,7 @@ async def test_resolve_ward_current_returns_self(
         "input_code": CURRENT_CODE,
         "current_code": CURRENT_CODE,
         "current_name": CURRENT_NAME,
+        "current_province_name": CURRENT_PROVINCE_NAME,
         "resolved": True,
     }
 
@@ -114,6 +123,7 @@ async def test_resolve_ward_legacy_merged_returns_current(
     assert body["input_code"] == LEGACY_MERGED_CODE
     assert body["current_code"] == CURRENT_CODE        # ← cross-era resolve
     assert body["current_name"] == CURRENT_NAME
+    assert body["current_province_name"] == CURRENT_PROVINCE_NAME  # full 2-level addr
     assert body["resolved"] is True
 
 
@@ -132,6 +142,7 @@ async def test_resolve_ward_unmapped_legacy_fails_closed(
         "input_code": LEGACY_UNMAPPED_CODE,
         "current_code": None,
         "current_name": None,
+        "current_province_name": None,
         "resolved": False,
     }
 

--- a/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
+++ b/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
@@ -42,6 +42,16 @@ def _ward(code, *, current, successor, dist=None):
     )
 
 
+def _province(code, *, current):
+    return AdministrativeNode(
+        code=code, name=f"Province {code}", level=AdministrativeLevel.PROVINCE,
+        path=f"{code}", province_code=code, district_code=None, ward_code=None,
+        valid_from=date(2025, 7, 1) if current else date(2010, 1, 1),
+        valid_to=None if current else date(2025, 7, 1),
+        is_active=True, successor_ward_code=None,
+    )
+
+
 async def test_resolve_current_ward_code(db) -> None:
     db.add(_ward("CUR1", current=True, successor="CUR1"))                  # current identity
     db.add(_ward("LEGSAME", current=False, successor="LEGSAME"))           # legacy survived
@@ -98,3 +108,17 @@ async def test_get_current_ward_name(db) -> None:
     assert await repo.get_current_ward_name("LEGX") is None  # legacy, not current
     assert await repo.get_current_ward_name("NOPE") is None
     assert await repo.get_current_ward_name("") is None
+
+
+async def test_get_current_province_name_for_ward(db) -> None:
+    """PR-3 + Cách B: a CURRENT ward code → its CURRENT province name (full
+    2-level address). Legacy ward / unknown / empty → None."""
+    db.add(_province("99", current=True))                   # current province 99
+    db.add(_ward("CURY", current=True, successor="CURY"))   # current ward under 99
+    db.add(_ward("LEGY", current=False, successor="CURY", dist="99_1"))  # legacy ward
+    await db.flush()
+    repo = AdministrativeRepository(db)
+    assert await repo.get_current_province_name_for_ward("CURY") == "Province 99"
+    assert await repo.get_current_province_name_for_ward("LEGY") is None  # legacy ward
+    assert await repo.get_current_province_name_for_ward("NOPE") is None
+    assert await repo.get_current_province_name_for_ward("") is None

--- a/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
+++ b/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
@@ -77,11 +77,16 @@ async def test_resolve_current_ward_code_reused_code_prefers_current(db) -> None
 
     Mirrors the real 24717 collision ("Thị trấn Đức An" legacy / "Xã Đức An"
     current). Without the era-priority ORDER BY, ``.limit(1)`` returned an
-    arbitrary row → could store a wrong permanent_commune_code on save."""
+    arbitrary row → could store a wrong permanent_commune_code on save.
+
+    NOTE: the LEGACY row is inserted FIRST on purpose. On a freshly truncated
+    table a bare ``LIMIT 1`` (no ORDER BY) returns heap order ≈ insert order, so
+    legacy-first makes this test FAIL if the ``ORDER BY valid_to IS NULL`` is
+    removed — i.e. it actually pins the fix instead of passing coincidentally."""
+    # legacy row reusing the SAME code, pointing somewhere else (divergent) — FIRST
+    db.add(_ward("DUP", current=False, successor="OTHER", dist="99_1"))
     # current row: code is a live commune → successor = self
     db.add(_ward("DUP", current=True, successor="DUP"))
-    # legacy row reusing the SAME code, pointing somewhere else (divergent)
-    db.add(_ward("DUP", current=False, successor="OTHER", dist="99_1"))
     await db.flush()
     repo = AdministrativeRepository(db)
     # Current-era row wins → DUP (its own code), never the legacy "OTHER".

--- a/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
+++ b/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
@@ -70,6 +70,24 @@ async def test_resolve_current_ward_code(db) -> None:
     assert await repo.resolve_current_ward_code(None) is None          # None
 
 
+async def test_resolve_current_ward_code_reused_code_prefers_current(db) -> None:
+    """Regression (review #1): a GSO ward code REUSED across the 2025 reform —
+    same code present in BOTH eras with DIFFERENT successors — must resolve to the
+    CURRENT-era commune deterministically, never the legacy row's successor.
+
+    Mirrors the real 24717 collision ("Thị trấn Đức An" legacy / "Xã Đức An"
+    current). Without the era-priority ORDER BY, ``.limit(1)`` returned an
+    arbitrary row → could store a wrong permanent_commune_code on save."""
+    # current row: code is a live commune → successor = self
+    db.add(_ward("DUP", current=True, successor="DUP"))
+    # legacy row reusing the SAME code, pointing somewhere else (divergent)
+    db.add(_ward("DUP", current=False, successor="OTHER", dist="99_1"))
+    await db.flush()
+    repo = AdministrativeRepository(db)
+    # Current-era row wins → DUP (its own code), never the legacy "OTHER".
+    assert await repo.resolve_current_ward_code("DUP") == "DUP"
+
+
 async def test_identity_backfill_predicate(db) -> None:
     """Migration's identity UPDATE: code still current → successor=self;
     merged-away code (no current equivalent) → stays NULL."""

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.test.tsx
@@ -27,7 +27,7 @@ vi.mock("@/lib/hooks/useAdministrative", () => ({
   useProvinces: () => ({ data: [], isLoading: false }),
   useDistricts: () => ({ data: [], isLoading: false }),
   useWards: () => ({ data: [], isLoading: false }),
-  useResolveWard: () => ({ data: undefined, isLoading: false }),
+  useResolveWard: () => ({ data: undefined, isLoading: false, isError: false }),
 }));
 
 // Mock AdaptiveAddressSelect — lightweight spy that exposes key props

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@/lib/hooks/useAdministrative", () => ({
   useProvinces: () => ({ data: [], isLoading: false }),
   useDistricts: () => ({ data: [], isLoading: false }),
   useWards: () => ({ data: [], isLoading: false }),
+  useResolveWard: () => ({ data: undefined, isLoading: false }),
 }));
 
 // Mock AdaptiveAddressSelect — lightweight spy that exposes key props

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
@@ -54,7 +54,11 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
   // (hydrate an existing profile) and whenever the officer re-picks — no imperative
   // state. Officer always sees which current commune+province an old/legacy ward
   // maps to (+ a warning when it can't be resolved → must pick a current commune).
-  const { data: resolvedWard } = useResolveWard(permanentCommuneCode)
+  const {
+    data: resolvedWard,
+    isLoading: resolvingWard,
+    isError: resolveWardError,
+  } = useResolveWard(permanentCommuneCode)
 
   // Address mode: local state, re-derived when profile.version changes.
   // Uses React's "adjusting state during render" pattern — no useEffect.
@@ -326,6 +330,28 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
                 <span aria-hidden="true">⚠</span>
                 Xã/phường đã chọn không khớp địa giới hiện hành — vui lòng chọn lại
                 xã/phường hiện tại.
+              </p>
+            ) : permanentCommuneCode && resolvingWard ? (
+              // Đang gọi resolve-ward — KHÔNG hiện dấu ✓ xanh (tránh trấn an sai
+              // khi chưa biết kết quả). Trạng thái trung tính.
+              <p
+                className="text-xs text-muted-foreground flex items-center gap-1"
+                data-testid="address-resolving"
+              >
+                <span aria-hidden="true">…</span>
+                Đang kiểm tra xã/phường theo địa giới hiện hành…
+              </p>
+            ) : permanentCommuneCode && resolveWardError ? (
+              // resolve-ward lỗi mạng/5xx: mã đã được canonicalize & lưu (KV vẫn
+              // resolve được phía server), nhưng KHÔNG khẳng định bằng dấu ✓ xanh.
+              <p
+                className="text-xs text-warning-700 flex items-center gap-1"
+                data-testid="address-resolve-error"
+                role="alert"
+              >
+                <span aria-hidden="true">⚠</span>
+                Đã lưu mã xã/phường nhưng chưa kiểm tra được xã/phường hiện hành —
+                vui lòng tải lại trang.
               </p>
             ) : permanentCommuneCode ? (
               <p

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
@@ -342,16 +342,15 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
                 Đang kiểm tra xã/phường theo địa giới hiện hành…
               </p>
             ) : permanentCommuneCode && resolveWardError ? (
-              // resolve-ward lỗi mạng/5xx: mã đã được canonicalize & lưu (KV vẫn
-              // resolve được phía server), nhưng KHÔNG khẳng định bằng dấu ✓ xanh.
+              // resolve-ward lỗi mạng/5xx: KHÔNG khẳng định bằng dấu ✓ xanh, và
+              // KHÔNG nói "đã lưu" (giá trị có thể còn dirty/chưa submit). Trung tính.
               <p
                 className="text-xs text-warning-700 flex items-center gap-1"
                 data-testid="address-resolve-error"
                 role="alert"
               >
                 <span aria-hidden="true">⚠</span>
-                Đã lưu mã xã/phường nhưng chưa kiểm tra được xã/phường hiện hành —
-                vui lòng tải lại trang.
+                Chưa kiểm tra được xã/phường hiện hành — vui lòng tải lại trang.
               </p>
             ) : permanentCommuneCode ? (
               <p

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
@@ -9,11 +9,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Combobox } from "@/components/ui/combobox"
 
 import { useMemo, useState } from "react"
-import { administrativeApi, type AddressMode, type ResolvedWard } from "@/lib/api/administrative"
+import { type AddressMode } from "@/lib/api/administrative"
 import { AdaptiveAddressSelect } from "@/components/forms/AdaptiveAddressSelect"
 import type { AdmissionProfileResponse, AdmissionProfileUpdateInput } from "@/lib/zod/admissions"
 import { useConfigData } from "@/lib/hooks/useConfigData"
-import { useProvinces } from "@/lib/hooks/useAdministrative"
+import { useProvinces, useResolveWard } from "@/lib/hooks/useAdministrative"
 import { format } from "date-fns" // Optional if needed for display, but input date handles ISO
 
 interface PersonalInfoTabProps {
@@ -48,21 +48,13 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
   const permanentResidentialGroup = useWatch({ control: form.control, name: "permanent_residential_group" }) || ""
   const permanentStreetAddress = useWatch({ control: form.control, name: "permanent_street_address" }) || ""
 
-  // PR-3: resolved CURRENT commune for the picked ward (display badge). The BE
-  // canonicalizes permanent_commune_code → current on save, so this is UX only:
-  // officer sees which current commune an old/legacy ward maps to (+ a warning
-  // when it can't be resolved → must pick a current-mode commune).
-  const [resolvedWard, setResolvedWard] = useState<ResolvedWard | null>(null)
-  const resolvePermanentWard = (code: string | null) => {
-    if (!code) {
-      setResolvedWard(null)
-      return
-    }
-    administrativeApi
-      .resolveWard(code)
-      .then(setResolvedWard)
-      .catch(() => setResolvedWard(null))
-  }
+  // PR-3 + Cách B: resolved CURRENT commune (2-cấp) for the picked ward, driven
+  // by a React Query hook keyed on permanent_commune_code. The BE canonicalizes
+  // permanent_commune_code → current on save; this hook auto-fetches both on LOAD
+  // (hydrate an existing profile) and whenever the officer re-picks — no imperative
+  // state. Officer always sees which current commune+province an old/legacy ward
+  // maps to (+ a warning when it can't be resolved → must pick a current commune).
+  const { data: resolvedWard } = useResolveWard(permanentCommuneCode)
 
   // Address mode: local state, re-derived when profile.version changes.
   // Uses React's "adjusting state during render" pattern — no useEffect.
@@ -278,21 +270,20 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
               onProvinceChange={(value) => {
                 form.setValue("permanent_province", value, { shouldDirty: true })
                 // Province reset clears ward chain → mã xã canonical theo đó.
+                // (useResolveWard tự clear badge khi commune_code về null.)
                 form.setValue("permanent_commune_code", null, { shouldDirty: true })
-                setResolvedWard(null)
               }}
               onDistrictChange={(value) => {
                 form.setValue("permanent_district", value || "", { shouldDirty: true })
                 form.setValue("permanent_commune_code", null, { shouldDirty: true })
-                setResolvedWard(null)
               }}
               onWardChange={(value) => form.setValue("permanent_ward", value, { shouldDirty: true })}
               // Phase E.4 KV bridge — engine đọc permanent_commune_code chuẩn,
               // KHÔNG đọc tên ward. PriorityTab hết phải hỏi officer gõ mã.
-              // PR-3: resolve picked code → current commune for the badge.
+              // Cách B: chỉ set form value; useResolveWard(permanentCommuneCode)
+              // tự fetch lại badge theo mã mới (cả lúc đổi lẫn lúc load).
               onWardCodeChange={(code) => {
                 form.setValue("permanent_commune_code", code, { shouldDirty: true })
-                resolvePermanentWard(code)
               }}
               onResidentialGroupChange={(value) => form.setValue("permanent_residential_group", value)}
               onStreetAddressChange={(value) => form.setValue("permanent_street_address", value)}
@@ -302,7 +293,6 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
                 // Mode switch resets cả tỉnh/quận/xã → mã xã cũng phải clear
                 // để tránh stale code orphan.
                 form.setValue("permanent_commune_code", null, { shouldDirty: true })
-                setResolvedWard(null)
               }}
               disabled={!isEditable}
             />
@@ -316,7 +306,16 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
                 data-testid="address-resolved-current"
               >
                 <span aria-hidden="true">✓</span>
-                Tương ứng xã/phường hiện hành: {resolvedWard.current_name} — KV tự xác định
+                <span>
+                  Đã chuẩn hóa mã xã/phường:{" "}
+                  <strong>
+                    {resolvedWard.current_name}
+                    {resolvedWard.current_province_name
+                      ? `, ${resolvedWard.current_province_name}`
+                      : ""}
+                  </strong>{" "}
+                  — KV có thể tự xác định
+                </span>
               </p>
             ) : resolvedWard && !resolvedWard.resolved ? (
               <p

--- a/frontend/src/components/forms/AdaptiveAddressSelect.test.tsx
+++ b/frontend/src/components/forms/AdaptiveAddressSelect.test.tsx
@@ -368,6 +368,33 @@ describe("AdaptiveAddressSelect", () => {
     )
   })
 
+  it("legacy mode: hiển thị xã theo TÊN — KHÔNG nhảy khi commune_code đã canonicalize trùng mã legacy khác", async () => {
+    // Regression (bug "Xã Nam Bình → Thị trấn Đức An"): mã GSO 24717 bị tái dùng
+    // 2 thời kỳ — legacy = "Thị trấn Đức An", đồng thời là successor của legacy
+    // "Xã Nam Bình" (24721). Sau khi BE canonicalize lúc lưu, wardCodeValue=24717.
+    // Combobox legacy PHẢI khớp theo name → "Xã Nam Bình" (24721), KHÔNG được khớp
+    // theo code → "Thị trấn Đức An" (24717).
+    mockUseWards.mockReturnValue({
+      data: [
+        { code: "24717", name: "Thị trấn Đức An", province_code: "10", district_code: "10_001" },
+        { code: "24721", name: "Xã Nam Bình", province_code: "10", district_code: "10_001" },
+      ],
+      isLoading: false,
+    })
+
+    await renderComponent({
+      mode: "legacy",
+      provinceValue: "Lao Cai",
+      districtValue: "Bat Xat",
+      wardValue: "Xã Nam Bình",
+      wardCodeValue: "24717", // mã hiện hành đã canonicalize (trùng mã legacy của xã khác)
+    })
+
+    const wardSelect = screen.getByLabelText("Phường/Xã") as HTMLSelectElement
+    // Khớp theo name → 24721 (Xã Nam Bình), KHÔNG phải 24717 (Thị trấn Đức An)
+    expect(wardSelect.value).toBe("24721")
+  })
+
   it("province change clears commune code along with ward/district", async () => {
     const { props } = await renderComponent({ mode: "current" })
 

--- a/frontend/src/components/forms/AdaptiveAddressSelect.tsx
+++ b/frontend/src/components/forms/AdaptiveAddressSelect.tsx
@@ -134,14 +134,30 @@ export function AdaptiveAddressSelect({
   //      list — backward-compat cho hồ sơ legacy chưa wire code.
   // Khi cả 2 đều miss (vd wards list chưa load, hoặc name không match) →
   // combobox shows placeholder; sẽ render đúng khi wards load và user re-pick.
+  //
+  // ⚠️ LEGACY MODE: KHÔNG dùng `wardCodeValue` để khớp option. `wardCodeValue`
+  // (= permanent_commune_code) là mã xã/phường **hiện hành** mà BE canonicalize
+  // khi lưu — nó KHÔNG phải key trong danh sách ward legacy, và mã GSO có thể bị
+  // tái sử dụng giữa 2 thời kỳ: vd legacy "Xã Nam Bình" (24721) canonicalize sang
+  // 24717, nhưng trong danh sách legacy mã 24717 lại là "Thị trấn Đức An" → field
+  // "nhảy" sang xã sai sau khi lưu. Ở legacy mode PHẢI resolve theo TÊN
+  // (`wardValue`, chính là permanent_ward officer đã chọn), không theo mã.
   const selectedWardCode = useMemo(() => {
+    if (isLegacy) {
+      if (wardValue) {
+        const matched = wards.find((w) => w.name === wardValue)
+        return matched?.code ?? ""
+      }
+      return ""
+    }
+    // Current mode: code là canonical primary key (tránh trùng tên 2 tỉnh).
     if (wardCodeValue) return wardCodeValue
     if (wardValue) {
       const matched = wards.find((w) => w.name === wardValue)
       return matched?.code ?? ""
     }
     return ""
-  }, [wardCodeValue, wardValue, wards])
+  }, [isLegacy, wardCodeValue, wardValue, wards])
 
   // ---- Handlers ----
   // Phase E.4 KV bridge: every transition that changes the selected ward

--- a/frontend/src/lib/api/administrative.ts
+++ b/frontend/src/lib/api/administrative.ts
@@ -33,6 +33,9 @@ export interface ResolvedWard {
   input_code: string
   current_code: string | null
   current_name: string | null
+  /** Province (current 2-level era) the resolved commune belongs to — for showing
+   *  the full standardized address "Xã X, Tỉnh Y". */
+  current_province_name: string | null
   resolved: boolean
 }
 

--- a/frontend/src/lib/hooks/useAdministrative.ts
+++ b/frontend/src/lib/hooks/useAdministrative.ts
@@ -13,6 +13,7 @@ import {
   type Province,
   type District,
   type Ward,
+  type ResolvedWard,
 } from "../api/administrative"
 
 export const administrativeQueryKeys = {
@@ -21,6 +22,8 @@ export const administrativeQueryKeys = {
     ["administrative", "districts", provinceCode] as const,
   wards: (provinceCode: string, mode: AddressMode, districtCode?: string | null) =>
     ["administrative", "wards", provinceCode, mode, districtCode ?? "none"] as const,
+  resolveWard: (code: string | null | undefined) =>
+    ["administrative", "resolve-ward", code ?? "none"] as const,
 }
 
 export function useProvinces(mode: AddressMode) {
@@ -50,6 +53,24 @@ export function useWards(
     queryKey: administrativeQueryKeys.wards(provinceCode!, mode, districtCode),
     queryFn: () => administrativeApi.getWards(provinceCode!, mode, districtCode),
     enabled: !!provinceCode,
+    staleTime: 1000 * 60 * 30,
+  })
+}
+
+/**
+ * Resolve a ward code (current OR legacy 3-tier) → canonical CURRENT-era commune
+ * (code + name). Keyed on the code so it auto-fetches both on load (hydrate an
+ * existing profile's `permanent_commune_code`) and whenever the officer re-picks
+ * — no imperative state needed. Disabled (returns no data) when `code` is empty.
+ *
+ * Drives the "→ Xã X (hiện hành)" badge so the officer always sees which current
+ * commune an old/legacy ward maps to, instead of a generic "đã chuẩn hóa" hint.
+ */
+export function useResolveWard(code: string | null | undefined) {
+  return useQuery<ResolvedWard>({
+    queryKey: administrativeQueryKeys.resolveWard(code),
+    queryFn: () => administrativeApi.resolveWard(code!),
+    enabled: !!code,
     staleTime: 1000 * 60 * 30,
   })
 }


### PR DESCRIPTION
## Vấn đề
Officer nhập địa chỉ thường trú **3 cấp (Hộ khẩu cũ)** rồi bấm **Lưu** → field **Phường/Xã nhảy sang xã khác** (vd nhập "Xã Nam Bình" → sau lưu hiển thị "Thị trấn Đức An"). Phát hiện trên prod hồ sơ #36 (Đắk Nông/Đắk Song).

## Gốc rễ
Mã GSO **bị tái sử dụng giữa 2 thời kỳ** cải cách 01/07/2025: `24717` = legacy "Thị trấn Đức An" **và** current "Xã Đức An"; legacy "Xã Nam Bình" (24721) sáp nhập vào 24717. Khi lưu, backend canonicalize `permanent_commune_code` sang mã hiện hành (24717); combobox ở legacy mode lại render nhãn theo **mã** → khớp 24717 trong danh sách legacy = "Thị trấn Đức An" → nhảy.

## Thay đổi
**Bug chính**
- `AdaptiveAddressSelect`: legacy mode resolve nhãn combobox theo **TÊN** (`wardValue`) thay vì mã canonical → hết nhảy; an toàn hơn (trống/buộc chọn lại > hiện sai xã).

**Cách B — resolve-on-load (officer an tâm)**
- Hook `useResolveWard(code)` (React Query, keyed theo mã) — badge resolve **cả lúc load lẫn lúc đổi**; bỏ state imperative trong `PersonalInfoTab` (Backend = source of truth).
- `resolve-ward` trả thêm `current_province_name` (repo join WARD→province→PROVINCE hiện hành) → badge hiển thị đầy đủ **2 cấp**:
  `Đã chuẩn hóa mã xã/phường: Xã Đức An, Tỉnh Lâm Đồng — KV có thể tự xác định`.

**Theo code-review**
- 🔴 **Gốc non-determinism** `resolve_current_ward_code` (gọi ở **cả path LƯU lẫn router**): thêm `ORDER BY (valid_to IS NULL) DESC` → row hiện hành luôn thắng khi mã tái dùng (deterministic + đúng nghĩa). *Đo thực địa: 0 mã phân kỳ trên dev+prod → hiện latent, vá phòng xa vì dựa vào invariant không enforce.*
- Test pin determinism **fail-without-fix** (verify: gỡ ORDER BY → FAIL, khôi phục → PASS).
- Badge **không trấn an sai** khi `useResolveWard` đang loading / lỗi (thread `isLoading`/`isError`; nhánh lỗi dùng wording trung tính, không khẳng định "đã lưu").

**Defer (follow-up):** trùng tên ward legacy, gộp query resolve-ward (perf), altitude `legacy_ward_code`, test nhánh badge chuyên biệt.

## Verify
- Backend: **12 pytest** (`test_kv_pr2_successor` + `test_kv_pr3_resolve_and_canonicalize`), flake8 net-zero mới.
- Frontend: type-check sạch, **32 vitest** (gồm test hồi quy ward-jump), lint 0 errors (= baseline).
- **Chrome smoke dev #28**: trước fix nhảy "Thị trấn Đức An"; sau fix giữ "Xã Nam Bình" (load + save + reload), badge 2 cấp "Xã Đức An, Tỉnh Lâm Đồng".

🤖 Generated with [Claude Code](https://claude.com/claude-code)