### PR TITLE
fix(admissions): materialize ProfileDocument cho tài liệu tùy chọn — hết 404 "Xác nhận bản giấy" + backfill

### DIFF
--- a/Backend_FastAPI/alembic/versions/optdocmat01_20260610_backfill_optional_doc_rows.py
+++ b/Backend_FastAPI/alembic/versions/optdocmat01_20260610_backfill_optional_doc_rows.py
@@ -1,0 +1,72 @@
+"""Backfill: materialize ProfileDocument row cho optional doc thiếu row.
+
+Revision ID: optdocmat01_20260610
+Revises: resetcasbin01
+Create Date: 2026-06-10
+
+Bug: officer bấm "Xác nhận bản giấy vừa nhận" cho tài liệu TÙY CHỌN
+(``is_mandatory=false``, vd ``giay_xac_nhan_cu_tru`` / ``giay_kham_suc_khoe``)
+→ 404 ``Document code '...' not found in profile documents``.
+
+Gốc: lúc tạo hồ sơ (``initialize_documents_for_profile``) và lúc re-resolve
+(``add_path_documents_delta``) chỉ materialize ``ProfileDocument`` row cho
+``mandatory_docs``, KHÔNG cho optional doc. Nhưng GET response (sau PR #394)
+dựng ``documents_checklist`` từ TOÀN BỘ ``applied_rules.doc_configs`` keyset →
+optional doc hiện nút thao tác nhưng không có row để cập nhật → 404
+(``mark_paper_submitted``) hoặc no-op thầm lặng (``upload``). Service đã sửa
+gốc (truyền full doc_configs keyset ở cả 2 điểm); migration này vá các hồ sơ
+LỊCH SỬ đã tạo trước fix.
+
+- Predicate CHẶT: chỉ INSERT cho ``doc_configs`` key CHƯA có row
+  ``category='path'`` (NOT EXISTS guard) → tôn trọng ``uq_profile_document_path``.
+- Idempotent: chạy lại = no-op (NOT EXISTS lọc hết row đã có).
+- Row mới: ``status='missing'``, ``category='path'``, không file/paper → trung
+  tính. Optional row KHÔNG ảnh hưởng submit/completion (``_validate_documents``
+  + ``document_stats`` lọc theo ``mandatory_docs``).
+- Downgrade: no-op — không phân biệt được row do migration tạo vs row 'missing'
+  hợp lệ; xoá là rủi ro. Forward-only.
+- Scope đã verify prod 2026-06-10: 15 hồ sơ draft × 2 optional doc = 30 row.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "optdocmat01_20260610"
+down_revision = "resetcasbin01"
+branch_labels = None
+depends_on = None
+
+
+# INSERT 1 row category='path' status='missing' cho mỗi doc_configs key đang
+# thiếu row. CROSS JOIN LATERAL bung keyset; JOIN config_document_type ánh xạ
+# code→id; NOT EXISTS chặn trùng (idempotent + không vi phạm partial-unique).
+_BACKFILL_SQL = """
+INSERT INTO profile_document
+    (profile_id, document_type_id, category, status, created_at, updated_at)
+SELECT ap.id, cdt.id, 'path', 'missing', now(), now()
+FROM admission_profile ap
+CROSS JOIN LATERAL jsonb_object_keys(ap.applied_rules->'doc_configs') AS k(code)
+JOIN config_document_type cdt ON cdt.code = k.code
+WHERE ap.applied_rules ? 'doc_configs'
+  -- ``?`` chỉ kiểm tra KEY tồn tại; nếu value là JSON null / array / scalar,
+  -- jsonb_object_keys() sẽ NÉM "cannot call jsonb_object_keys on a non-object"
+  -- và làm hỏng CẢ migration. Guard kiểu để bỏ qua row dị thường (legacy / sửa
+  -- tay) thay vì crash. Dry-run prod 2026-06-10: 0 row dính, nhưng vá phòng xa.
+  AND jsonb_typeof(ap.applied_rules -> 'doc_configs') = 'object'
+  AND NOT EXISTS (
+      SELECT 1 FROM profile_document pd
+      WHERE pd.profile_id = ap.id
+        AND pd.document_type_id = cdt.id
+        AND pd.category = 'path'
+  );
+"""
+
+
+def upgrade() -> None:
+    op.get_bind().execute(sa.text(_BACKFILL_SQL))
+
+
+def downgrade() -> None:
+    # No-op: row 'missing' do migration tạo không phân biệt được với row 'missing'
+    # hợp lệ → không xoá. Forward-only.
+    pass

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -3808,9 +3808,23 @@ async def create_profile(
     )
 
     # Step 16: Initialize ProfileDocument records
+    # Materialize a row for EVERY doc in the path snapshot (mandatory +
+    # optional), not just ``mandatory_docs``. The GET response builds the
+    # ``documents_checklist`` from the full ``doc_configs`` keyset (PR #394),
+    # so an optional doc (``is_mandatory=false``, e.g. ``giay_xac_nhan_cu_tru``
+    # / ``giay_kham_suc_khoe``) surfaces with a "Xác nhận bản giấy" action
+    # button. Without a row, ``paper-submitted`` has nothing to update → 404,
+    # and ``upload`` silently no-ops (orphan file). Materializing all path docs
+    # restores the invariant "every doc_configs key ⇒ one category='path'
+    # ProfileDocument row". Optional rows stay ``status=missing`` and never
+    # block submit (``_validate_documents`` filters by ``mandatory_docs``).
+    # Use the ``doc_configs`` keyset directly (not a list over ``resolved_docs``)
+    # — it is the exact set GET renders, is inherently de-duplicated (dict
+    # keys), and keeps this site symmetric with ``_reresolve_documents_snapshot``
+    # (both feed the materializer ``list(doc_configs.keys())``).
     await admission_repo.initialize_documents_for_profile(
         profile_id=new_profile.id,
-        document_type_codes=mandatory_docs
+        document_type_codes=list(applied_rules["doc_configs"].keys()),
     )
 
     # Step 17: Reload with relationships for response
@@ -4238,6 +4252,9 @@ async def _reresolve_documents_snapshot(
         return
 
     old_mandatory = set(applied.get("mandatory_docs") or [])
+    # Capture old keyset (mandatory + optional) BEFORE overwrite — the audit
+    # below tracks the FULL doc_configs delta, not just mandatory.
+    old_doc_codes = set((applied.get("doc_configs") or {}).keys())
 
     # MERGE per-key (giữ mọi key khác — KHÔNG gán dict mới).
     applied["mandatory_docs"] = new_mandatory
@@ -4245,12 +4262,26 @@ async def _reresolve_documents_snapshot(
     profile.applied_rules = applied
     flag_modified(profile, "applied_rules")
 
-    # DELTA INSERT ProfileDocument cho code mới (idempotent, không xóa upload).
-    await admission_repo.add_path_documents_delta(profile.id, new_mandatory)
+    # DELTA INSERT ProfileDocument cho MỌI doc trong snapshot mới (mandatory +
+    # optional), idempotent, không xóa upload. PHẢI dùng full doc_configs
+    # keyset — KHÔNG chỉ ``new_mandatory`` — để optional doc cũng có row; nếu
+    # không, paper-submitted/upload trên optional doc sẽ 404 / no-op (cùng
+    # invariant với bước Initialize lúc tạo hồ sơ).
+    await admission_repo.add_path_documents_delta(
+        profile.id, list(new_doc_configs.keys())
+    )
 
-    # N5 — audit entry cho mutate snapshot.
-    added = sorted(set(new_mandatory) - old_mandatory)
-    removed = sorted(old_mandatory - set(new_mandatory))
+    # N5 — audit entry cho mutate snapshot. Tính delta trên TOÀN BỘ doc_configs
+    # keyset (mandatory + optional), KHÔNG chỉ mandatory: delta INSERT giờ
+    # materialize cả optional row, nên một thay đổi CHỈ-optional (thêm/bớt giấy
+    # tùy chọn) cũng phải để lại dấu vết — nếu không sẽ có mutation tạo row mà
+    # 0 audit entry. ``docs_added``/``docs_removed`` = full keyset; thêm
+    # ``mandatory_added``/``mandatory_removed`` để giữ phân biệt độ quan trọng.
+    new_doc_codes = set(new_doc_configs.keys())
+    added = sorted(new_doc_codes - old_doc_codes)
+    removed = sorted(old_doc_codes - new_doc_codes)
+    mandatory_added = sorted(set(new_mandatory) - old_mandatory)
+    mandatory_removed = sorted(old_mandatory - set(new_mandatory))
     if added or removed:
         from ..services import audit_service
 
@@ -4266,6 +4297,8 @@ async def _reresolve_documents_snapshot(
                 ),
                 "docs_added": added,
                 "docs_removed": removed,
+                "mandatory_added": mandatory_added,
+                "mandatory_removed": mandatory_removed,
             },
             actor_user_id=current_user.id if current_user else None,
             source="system",

--- a/Backend_FastAPI/tests/integration/test_document_audience_reresolve.py
+++ b/Backend_FastAPI/tests/integration/test_document_audience_reresolve.py
@@ -105,6 +105,13 @@ async def _setup_audience_data(major_id: int, unit_id: int, officer_id: int) -> 
 
             # Doc types (get-or-create — bằng TN THCS có thể chưa có trong qlts_test).
             cccd = await _get_or_create_doc_type(session, "cccd", "Căn cước công dân")
+            # Optional, paper-only doc (is_mandatory=false, requires_upload=false)
+            # — mirrors prod giay_xac_nhan_cu_tru. Exercises the materialization
+            # fix: it lives in doc_configs but NOT mandatory_docs, so before the
+            # fix it got no ProfileDocument row → paper-submitted 404.
+            curtru = await _get_or_create_doc_type(
+                session, "giay_xac_nhan_cu_tru", "Giấy xác nhận cư trú / hộ khẩu"
+            )
             hb_thpt = await _get_or_create_doc_type(session, "hoc_ba_thpt", "Học bạ THPT")
             bts_thpt = await _get_or_create_doc_type(
                 session, "bang_tot_nghiep_thpt", "Bằng tốt nghiệp THPT"
@@ -139,19 +146,37 @@ async def _setup_audience_data(major_id: int, unit_id: int, officer_id: int) -> 
             g_thcs = _mk_group(f"AUD_THCS_{suffix}", ["POST_THCS"], None)
             await session.flush()
 
-            def _mk_item(group_id, dt_id, order):
+            def _mk_item(
+                group_id,
+                dt_id,
+                order,
+                is_mandatory=True,
+                requires_upload=True,
+                submission_format="photo",
+            ):
                 session.add(
                     models.DocumentGroupItem(
                         group_id=group_id,
                         document_type_id=dt_id,
-                        is_mandatory=True,
-                        requires_upload=True,
-                        submission_format="photo",
+                        is_mandatory=is_mandatory,
+                        requires_upload=requires_upload,
+                        submission_format=submission_format,
                         display_order=order,
                     )
                 )
 
             _mk_item(g_base.id, cccd, 1)
+            # Optional, paper-only doc in the ALWAYS-applicable base group → it is
+            # present in doc_configs at create regardless of audience, but absent
+            # from mandatory_docs (is_mandatory=false).
+            _mk_item(
+                g_base.id,
+                curtru,
+                4,
+                is_mandatory=False,
+                requires_upload=False,
+                submission_format="certified_copy",
+            )
             _mk_item(g_thpt.id, hb_thpt, 2)
             _mk_item(g_thpt.id, bts_thpt, 3)
             _mk_item(g_thcs.id, hb_thcs, 2)
@@ -386,3 +411,42 @@ class TestReresolveAudience:
         assert ar.get("schema_version") == 2  # N1: không bump
         assert ar.get("admission_path_id") is not None
         assert "allow_unverified_submission" in ar
+
+    async def test_create_materializes_optional_doc_row(
+        self, client, officer_user_in_db, seed_lead_dependencies
+    ):
+        """Materialization fix: optional doc (``is_mandatory=false``) trong
+        ``doc_configs`` PHẢI có ProfileDocument row ngay khi tạo hồ sơ, dù KHÔNG
+        nằm trong ``mandatory_docs``. Trước fix chỉ ``mandatory_docs`` được
+        materialize → optional row thiếu → paper-submitted 404 (prod #44)."""
+        data = await _setup_audience_data(
+            seed_lead_dependencies["major_program_id"],
+            seed_lead_dependencies["unit_id"],
+            officer_user_in_db["id"],
+        )
+        headers = await _auth(client, officer_user_in_db)
+        pid = await _create_profile(client, headers, data)
+        # Optional doc KHÔNG vào mandatory snapshot ...
+        assert await _snapshot_mandatory(pid) == {"cccd"}
+        # ... nhưng VẪN phải có ProfileDocument row được materialize.
+        assert "giay_xac_nhan_cu_tru" in await _profile_doc_codes(pid)
+
+    async def test_paper_submitted_on_optional_doc_succeeds(
+        self, client, officer_user_in_db, seed_lead_dependencies
+    ):
+        """Regression end-to-end (prod #44): officer "Xác nhận bản giấy vừa
+        nhận" cho optional paper-only doc trả 200, KHÔNG 404. Đi qua đúng route
+        ``paper-submitted`` mà bug gốc phát lỗi."""
+        data = await _setup_audience_data(
+            seed_lead_dependencies["major_program_id"],
+            seed_lead_dependencies["unit_id"],
+            officer_user_in_db["id"],
+        )
+        headers = await _auth(client, officer_user_in_db)
+        pid = await _create_profile(client, headers, data)
+        res = await client.post(
+            f"/api/admissions/{pid}/documents/giay_xac_nhan_cu_tru/paper-submitted",
+            json={"actual_submission_format": "certified_copy"},
+            headers=headers,
+        )
+        assert res.status_code == 200, res.text


### PR DESCRIPTION
## Vấn đề
Officer bấm **"Xác nhận bản giấy vừa nhận"** cho tài liệu **TÙY CHỌN** (`is_mandatory=false`, vd `giay_xac_nhan_cu_tru` / `giay_kham_suc_khoe`) → **404** `Document code not found in profile documents`. Phát hiện trên prod hồ sơ #44 (log backend).

## Gốc rễ
`create_profile` + `_reresolve_documents_snapshot` chỉ materialize `ProfileDocument` row cho `mandatory_docs`, **KHÔNG** cho optional. Nhưng GET response (sau #394) dựng `documents_checklist` từ **FULL `doc_configs` keyset** → optional doc hiện nút "Đánh dấu đã nhận giấy" (`can_mark_paper_submitted=true`) nhưng repo `mark_paper_submitted` không có row để update → 404. Route `upload` còn no-op thầm lặng (orphan file) nếu optional `requires_upload=true`.

## Thay đổi
- **Fix gốc** — `create_profile` (`:3811`) + `_reresolve_documents_snapshot` (`:4249`): materialize **toàn bộ** `doc_configs` keyset qua `list(doc_configs.keys())` (dedup sẵn + đối xứng 2 site). Khôi phục invariant *"mọi doc_configs key ⇒ 1 `category='path'` ProfileDocument row"*. Optional row giữ `status=missing`, **không** chặn submit (`_validate_documents` lọc theo `mandatory_docs`).
- **Migration `optdocmat01`** — backfill row cho hồ sơ lịch sử. Idempotent (`NOT EXISTS`) + guard `jsonb_typeof='object'` (chống crash migration). Dry-run prod = **30 row / 15 hồ sơ draft**.
- **Audit `documents_reresolved`** — tính delta trên full keyset (+ `mandatory_added`/`mandatory_removed`) để thay đổi chỉ-optional cũng để lại dấu vết.

## Verify
- ✅ **8 pytest** integration (`test_document_audience_reresolve` — +2 case: create materialize optional row + paper-submitted optional → 200)
- ✅ **flake8** net-zero (file mới 0 lỗi)
- ✅ Migration: dry-run prod 30 row, apply dev sạch (head `optdocmat01`)
- ✅ **Chrome smoke dev** (hồ sơ #33): `POST /api/admissions/33/documents/giay_xac_nhan_cu_tru/paper-submitted` → **200** (đúng endpoint trả 404 trên prod), DB `paper_submitted` + badge "Đã nhận giấy"
- ✅ code-review xhigh: 3 finding (migration guard / altitude / audit completeness) đã vá

🤖 Generated with [Claude Code](https://claude.com/claude-code)