### PR TITLE
chore(admissions): follow-up #395 — audit data thường trú + gộp query resolve-ward + test nhánh badge

### DIFF
--- a/Backend_FastAPI/app/repositories/administrative_repository.py
+++ b/Backend_FastAPI/app/repositories/administrative_repository.py
@@ -160,51 +160,44 @@ class AdministrativeRepository(BaseRepository[AdministrativeNode]):
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
 
-    async def get_current_ward_name(self, code: str) -> Optional[str]:
-        """Name of a CURRENT-era (valid_to IS NULL) ward by code — for the
-        resolve-ward endpoint to display the canonical commune to the officer."""
-        code = (code or "").strip()
-        if not code:
-            return None
-        stmt = (
-            select(AdministrativeNode.name)
-            .where(
-                AdministrativeNode.code == code,
-                AdministrativeNode.level == AdministrativeLevel.WARD,
-                AdministrativeNode.valid_to.is_(None),
-                AdministrativeNode.is_active == True,
-            )
-            .limit(1)
-        )
-        result = await self.db.execute(stmt)
-        return result.scalar_one_or_none()
-
-    async def get_current_province_name_for_ward(
+    async def get_current_commune_display(
         self, ward_code: str
-    ) -> Optional[str]:
-        """Province name (CURRENT era) that a CURRENT-era ward code belongs to.
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Display tuple ``(ward_name, province_name)`` for a CURRENT-era ward code.
 
-        Resolves WARD.code → WARD.province_code → PROVINCE.name (both valid_to IS
-        NULL). Lets the resolve-ward endpoint return the full 2-level address
-        ("Xã X, Tỉnh Y") so the officer can confirm the standardized residence.
-        Returns None if the ward or its province isn't found in the current snapshot.
+        ONE query for the ward row (name + province_code) + ONE for the province
+        name — both ``valid_to IS NULL``. Powers the resolve-ward endpoint's full
+        2-level address ("Xã X, Tỉnh Y") so the officer confirms the standardized
+        residence (NĐ 238/NĐ-CP KV/miễn-giảm). Was 3 sequential round-trips when
+        the ward name + province were fetched separately (review #5).
+
+        Returns ``(None, None)`` if the code isn't a current-era commune;
+        ``(name, None)`` if its current province can't be resolved.
         """
         code = (ward_code or "").strip()
         if not code:
-            return None
-        province_code = await self.db.scalar(
-            select(AdministrativeNode.province_code)
-            .where(
-                AdministrativeNode.code == code,
-                AdministrativeNode.level == AdministrativeLevel.WARD,
-                AdministrativeNode.valid_to.is_(None),
-                AdministrativeNode.is_active.is_(True),
+            return None, None
+        ward = (
+            await self.db.execute(
+                select(
+                    AdministrativeNode.name,
+                    AdministrativeNode.province_code,
+                )
+                .where(
+                    AdministrativeNode.code == code,
+                    AdministrativeNode.level == AdministrativeLevel.WARD,
+                    AdministrativeNode.valid_to.is_(None),
+                    AdministrativeNode.is_active.is_(True),
+                )
+                .limit(1)
             )
-            .limit(1)
-        )
+        ).first()
+        if ward is None:
+            return None, None
+        ward_name, province_code = ward
         if not province_code:
-            return None
-        return await self.db.scalar(
+            return ward_name, None
+        province_name = await self.db.scalar(
             select(AdministrativeNode.name)
             .where(
                 AdministrativeNode.code == province_code,
@@ -214,6 +207,7 @@ class AdministrativeRepository(BaseRepository[AdministrativeNode]):
             )
             .limit(1)
         )
+        return ward_name, province_name
 
     # ------------------------------------------------------------------
     # GENERIC FILTERED (admin panel)

--- a/Backend_FastAPI/app/routers/administrative.py
+++ b/Backend_FastAPI/app/routers/administrative.py
@@ -126,13 +126,10 @@ async def resolve_ward(
     """
     repo = AdministrativeRepository(db)
     current_code = await repo.resolve_current_ward_code(code)
-    current_name = (
-        await repo.get_current_ward_name(current_code) if current_code else None
-    )
-    current_province_name = (
-        await repo.get_current_province_name_for_ward(current_code)
+    current_name, current_province_name = (
+        await repo.get_current_commune_display(current_code)
         if current_code
-        else None
+        else (None, None)
     )
     return ResolveWardResponse(
         input_code=code,

--- a/Backend_FastAPI/app/scripts/audit_permanent_commune_codes.py
+++ b/Backend_FastAPI/app/scripts/audit_permanent_commune_codes.py
@@ -1,0 +1,93 @@
+# app/scripts/audit_permanent_commune_codes.py
+"""Audit tính toàn vẹn của địa chỉ thường trú (permanent_commune_code) trên hồ sơ
+tuyển sinh — dữ liệu quyết định KV → chính sách ưu tiên / miễn-giảm học phí
+(Nghị định 238/NĐ-CP). KHÔNG được để sai lệch.
+
+Read-only. Cờ các hồ sơ mà ``permanent_commune_code`` không dùng được cho KV:
+
+1. ward_set_but_code_missing — có tên xã (``permanent_ward``) nhưng THIẾU mã
+   (``permanent_commune_code`` NULL/rỗng) → engine không resolve được KV.
+2. code_not_current_era — có mã nhưng mã KHÔNG phải xã hiện hành (valid_to IS NULL)
+   → mã legacy/stale, KV resolve sai hoặc fail.
+3. code_orphan — mã không tồn tại như bất kỳ ward nào (administrative_nodes).
+
+Chạy:
+    docker compose exec backend python -m app.scripts.audit_permanent_commune_codes
+    # one-off: docker compose run --rm --no-deps backend \
+    #     python -m app.scripts.audit_permanent_commune_codes
+
+Exit code: 0 nếu sạch, 1 nếu có hồ sơ lỗi (dùng được làm cổng pre/post data-import,
+vd sau khi import MOET các tỉnh sáp nhập 2025 thay đổi administrative_nodes).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from sqlalchemy import text
+
+from app.database import AsyncSessionLocal
+
+
+# Một câu SELECT tổng hợp đếm + gom id để vừa báo số liệu vừa chỉ rõ hồ sơ lỗi.
+_AUDIT_SQL = text(
+    """
+    WITH flagged AS (
+        SELECT
+            ap.id,
+            (ap.permanent_ward IS NOT NULL AND ap.permanent_ward <> ''
+             AND (ap.permanent_commune_code IS NULL OR ap.permanent_commune_code = '')
+            ) AS ward_set_but_code_missing,
+            (ap.permanent_commune_code IS NOT NULL AND ap.permanent_commune_code <> ''
+             AND NOT EXISTS (
+                SELECT 1 FROM administrative_nodes an
+                WHERE an.code = ap.permanent_commune_code
+                  AND an.level = 'WARD' AND an.valid_to IS NULL AND an.is_active = true)
+            ) AS code_not_current_era,
+            (ap.permanent_commune_code IS NOT NULL AND ap.permanent_commune_code <> ''
+             AND NOT EXISTS (
+                SELECT 1 FROM administrative_nodes an
+                WHERE an.code = ap.permanent_commune_code AND an.level = 'WARD')
+            ) AS code_orphan
+        FROM admission_profile ap
+    )
+    SELECT
+        (SELECT count(*) FROM admission_profile) AS total_profiles,
+        array_remove(array_agg(id) FILTER (WHERE ward_set_but_code_missing), NULL)
+            AS ward_set_but_code_missing,
+        array_remove(array_agg(id) FILTER (WHERE code_not_current_era), NULL)
+            AS code_not_current_era,
+        array_remove(array_agg(id) FILTER (WHERE code_orphan), NULL)
+            AS code_orphan
+    FROM flagged
+    """
+)
+
+
+async def audit() -> int:
+    async with AsyncSessionLocal() as session:
+        row = (await session.execute(_AUDIT_SQL)).mappings().one()
+
+    total = row["total_profiles"]
+    missing = list(row["ward_set_but_code_missing"] or [])
+    not_current = list(row["code_not_current_era"] or [])
+    orphan = list(row["code_orphan"] or [])
+    bad_total = len(set(missing) | set(not_current) | set(orphan))
+
+    print(f"[audit] permanent_commune_code — {total} hồ sơ")
+    print(f"  - ward_set_but_code_missing : {len(missing)} {missing}")
+    print(f"  - code_not_current_era      : {len(not_current)} {not_current}")
+    print(f"  - code_orphan               : {len(orphan)} {orphan}")
+
+    if bad_total == 0:
+        print("[audit] OK — 0 hồ sơ sai lệch địa chỉ thường trú.")
+        return 0
+    print(
+        f"[audit] FAIL — {bad_total} hồ sơ cần xử lý (KV/miễn-giảm có thể sai). "
+        "Yêu cầu officer chọn lại Phường/Xã hiện hành hoặc backfill có kiểm soát."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(audit()))

--- a/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
+++ b/Backend_FastAPI/tests/unit/test_kv_pr2_successor.py
@@ -120,28 +120,16 @@ async def test_identity_backfill_predicate(db) -> None:
     assert by[("M", False)] is None  # merged away → still NULL (needs merger CSV)
 
 
-async def test_get_current_ward_name(db) -> None:
-    """PR-3 resolve endpoint helper: name of a CURRENT-era ward by code;
-    legacy/unknown → None."""
-    db.add(_ward("CURX", current=True, successor="CURX"))
-    db.add(_ward("LEGX", current=False, successor="CURX", dist="99_1"))
-    await db.flush()
-    repo = AdministrativeRepository(db)
-    assert await repo.get_current_ward_name("CURX") == "Ward CURX"
-    assert await repo.get_current_ward_name("LEGX") is None  # legacy, not current
-    assert await repo.get_current_ward_name("NOPE") is None
-    assert await repo.get_current_ward_name("") is None
-
-
-async def test_get_current_province_name_for_ward(db) -> None:
-    """PR-3 + Cách B: a CURRENT ward code → its CURRENT province name (full
-    2-level address). Legacy ward / unknown / empty → None."""
+async def test_get_current_commune_display(db) -> None:
+    """PR-3 + Cách B (review #5): a CURRENT ward code → (ward_name, province_name)
+    cho địa chỉ 2 cấp. Legacy ward / unknown / empty → (None, None); ward hiện
+    hành nhưng tỉnh không resolve được → (name, None)."""
     db.add(_province("99", current=True))                   # current province 99
     db.add(_ward("CURY", current=True, successor="CURY"))   # current ward under 99
     db.add(_ward("LEGY", current=False, successor="CURY", dist="99_1"))  # legacy ward
     await db.flush()
     repo = AdministrativeRepository(db)
-    assert await repo.get_current_province_name_for_ward("CURY") == "Province 99"
-    assert await repo.get_current_province_name_for_ward("LEGY") is None  # legacy ward
-    assert await repo.get_current_province_name_for_ward("NOPE") is None
-    assert await repo.get_current_province_name_for_ward("") is None
+    assert await repo.get_current_commune_display("CURY") == ("Ward CURY", "Province 99")
+    assert await repo.get_current_commune_display("LEGY") == (None, None)  # legacy, not current
+    assert await repo.get_current_commune_display("NOPE") == (None, None)
+    assert await repo.get_current_commune_display("") == (None, None)

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.test.tsx
@@ -23,11 +23,14 @@ vi.mock("@/lib/hooks/useConfigData", () => ({
 
 // Mock useAdministrative — place_of_birth combobox uses useProvinces("legacy");
 // no network calls allowed in test (would emit MSW-style XHR errors).
+// useResolveWard is configurable per-test (badge branch coverage) via the hoisted
+// spy; default return set in beforeEach (after clearAllMocks).
+const { mockUseResolveWard } = vi.hoisted(() => ({ mockUseResolveWard: vi.fn() }));
 vi.mock("@/lib/hooks/useAdministrative", () => ({
   useProvinces: () => ({ data: [], isLoading: false }),
   useDistricts: () => ({ data: [], isLoading: false }),
   useWards: () => ({ data: [], isLoading: false }),
-  useResolveWard: () => ({ data: undefined, isLoading: false, isError: false }),
+  useResolveWard: (...args: unknown[]) => mockUseResolveWard(...args),
 }));
 
 // Mock AdaptiveAddressSelect — lightweight spy that exposes key props
@@ -168,6 +171,8 @@ describe("PersonalInfoTab", () => {
     vi.clearAllMocks();
     capturedAddressProps = {};
     capturedFormRef = null;
+    // Default: no resolve data (component destructures { data } → must not be undefined call result)
+    mockUseResolveWard.mockReturnValue({ data: undefined, isLoading: false, isError: false });
   });
 
   describe("addressMode derivation", () => {
@@ -340,6 +345,79 @@ describe("PersonalInfoTab", () => {
       });
 
       expect(capturedFormRef?.getValues("permanent_commune_code")).toBeNull();
+    });
+  });
+
+  // Review #8 — badge "đã chuẩn hóa" precedence theo useResolveWard state.
+  // Hồ sơ có permanent_commune_code (permanentCommuneCode truthy) để vào chuỗi nhánh.
+  describe("address normalized badge (useResolveWard branches)", () => {
+    const withCode = () =>
+      buildProfile({ permanent_commune_code: "24717", version: 1 } as Partial<AdmissionProfileResponse>);
+
+    it("resolved + province → hiện địa chỉ 2 cấp đầy đủ", () => {
+      mockUseResolveWard.mockReturnValue({
+        data: { resolved: true, current_name: "Xã Đức An", current_province_name: "Tỉnh Lâm Đồng" },
+        isLoading: false,
+        isError: false,
+      });
+      render(<TestFormHost profile={withCode()} />);
+
+      const badge = screen.getByTestId("address-resolved-current");
+      expect(badge.textContent).toContain("Xã Đức An");
+      expect(badge.textContent).toContain("Tỉnh Lâm Đồng");
+      expect(badge.textContent).toContain("KV có thể tự xác định");
+      expect(screen.queryByTestId("address-normalized-ok")).toBeNull();
+    });
+
+    it("resolved nhưng không có province → chỉ hiện tên xã", () => {
+      mockUseResolveWard.mockReturnValue({
+        data: { resolved: true, current_name: "Xã Đức An", current_province_name: null },
+        isLoading: false,
+        isError: false,
+      });
+      render(<TestFormHost profile={withCode()} />);
+
+      const badge = screen.getByTestId("address-resolved-current");
+      expect(badge.textContent).toContain("Xã Đức An");
+      expect(badge.textContent).not.toContain("Tỉnh");
+    });
+
+    it("not-resolved → cảnh báo không khớp địa giới", () => {
+      mockUseResolveWard.mockReturnValue({
+        data: { resolved: false, current_name: null, current_province_name: null },
+        isLoading: false,
+        isError: false,
+      });
+      render(<TestFormHost profile={withCode()} />);
+
+      expect(screen.getByTestId("address-resolve-warning")).toBeTruthy();
+      expect(screen.queryByTestId("address-resolved-current")).toBeNull();
+      expect(screen.queryByTestId("address-normalized-ok")).toBeNull();
+    });
+
+    it("đang loading → trạng thái trung tính, KHÔNG hiện ✓ xanh", () => {
+      mockUseResolveWard.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+      render(<TestFormHost profile={withCode()} />);
+
+      expect(screen.getByTestId("address-resolving")).toBeTruthy();
+      expect(screen.queryByTestId("address-resolved-current")).toBeNull();
+      expect(screen.queryByTestId("address-normalized-ok")).toBeNull();
+    });
+
+    it("lỗi resolve → cảnh báo, KHÔNG hiện ✓ xanh", () => {
+      mockUseResolveWard.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+      render(<TestFormHost profile={withCode()} />);
+
+      expect(screen.getByTestId("address-resolve-error")).toBeTruthy();
+      expect(screen.queryByTestId("address-resolved-current")).toBeNull();
+      expect(screen.queryByTestId("address-normalized-ok")).toBeNull();
+    });
+
+    it("có mã, chưa có data resolve (fallback) → 'đã chuẩn hóa mã' generic", () => {
+      // default beforeEach: data undefined, not loading, not error
+      render(<TestFormHost profile={withCode()} />);
+
+      expect(screen.getByTestId("address-normalized-ok")).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
Follow-up từ code-review của #395 (đã merged+deployed). **Không sửa bug mới** — bug "nhảy xã" + tính đúng dữ liệu đã xử lý ở #395. PR này thêm phòng vệ + dọn dẹp.

## Bối cảnh data (đã audit)
✅ Prod audit SẠCH: 15/15 hồ sơ có mã xã hợp lệ hiện hành, **0 missing/legacy/orphan** → KHÔNG cần backfill. Dữ liệu thường trú quyết định KV → ưu tiên / miễn-giảm học phí (NĐ 238/NĐ-CP) nên cần phòng vệ lâu dài.

## Thay đổi
1. **Audit script** `app/scripts/audit_permanent_commune_codes.py` (read-only, re-runnable): cờ hồ sơ có ward nhưng THIẾU mã / mã KHÔNG hiện hành / orphan; **exit 1** nếu lỗi → dùng làm **cổng kiểm tra trước/sau import dữ liệu hành chính** (vd sau import MOET tỉnh sáp nhập 2025).
2. **#5** gộp `get_current_ward_name` + `get_current_province_name_for_ward` → `get_current_commune_display()` (**2 query thay vì 3**); router resolve-ward dùng method này.
3. **#8** test 6 nhánh badge `useResolveWard` (resolved 2 cấp / no-province / not-resolved / loading / error / generic) — mock configurable.

**Defer:** #6 (cột `legacy_ward_code` — schema, chỉ phục vụ hiển thị, data đã sạch nên chưa gấp), #2/#4 (edge hiển thị legacy, phụ thuộc #6).

## Verify
- Backend: 11 pytest (`test_kv_pr2_successor` + `test_kv_pr3_resolve_and_canonicalize`); flake8 net-zero mới.
- Frontend: type-check sạch, **38 vitest** (gồm 6 badge test mới), lint 0 errors.
- Audit script chạy thật (dev: 9 hồ sơ, 0 lỗi, exit 0) + `get_current_commune_display('24717')` → `('Xã Đức An','Tỉnh Lâm Đồng')`.
- Chrome smoke dev #28: badge "Đã chuẩn hóa mã xã/phường: Xã Đức An, Tỉnh Lâm Đồng — KV có thể tự xác định".

🤖 Generated with [Claude Code](https://claude.com/claude-code)