### PR TITLE
feat(admin-kv): UI quản lý KV theo Xã (commune KV) — CRUD + đổi-KV temporal + CSV import (PR-A)

### DIFF
--- a/Backend_FastAPI/app/routers/admin_vn_locality.py
+++ b/Backend_FastAPI/app/routers/admin_vn_locality.py
@@ -15,7 +15,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import database
 from app.core.deps import require_admin
-from app.schemas.vn_locality import CsvImportResponse
+from app.schemas.vn_locality import (
+    CsvImportResponse,
+    VnCommuneAreaMapCreate,
+    VnCommuneAreaMapListResponse,
+    VnCommuneAreaMapReplaceArea,
+    VnCommuneAreaMapResponse,
+    VnCommuneAreaMapUpdate,
+)
 from app.services.vn_locality_service import VnLocalityService
 
 
@@ -97,6 +104,143 @@ async def import_commune_csv(
         actor=user.id,
     )
     return CsvImportResponse(**result)
+
+
+# =============================================================================
+# Admin: commune KV CRUD (PR-A — UI quản lý danh mục KV theo xã)
+#
+# Tất cả ``require_admin`` (quy chế tuyển sinh, không per-unit). Đổi KV đi qua
+# ``/replace-area`` (temporal: retire cũ + insert mới), KHÔNG update tại chỗ.
+# =============================================================================
+
+
+@admin_router.get("/communes", response_model=VnCommuneAreaMapListResponse)
+async def list_communes(
+    province: str | None = None,
+    q: str | None = None,
+    active_only: bool = True,
+    page: int = 1,
+    page_size: int = 50,
+    db: AsyncSession = Depends(database.get_db),
+    _user=Depends(require_admin),
+) -> VnCommuneAreaMapListResponse:
+    """Bảng paginated + lọc tỉnh (``province`` = tên tỉnh) + search
+    (``q`` khớp ward/commune_code)."""
+    service = VnLocalityService(db)
+    rows, total = await service.list_communes(
+        province=province,
+        q=q,
+        active_only=active_only,
+        page=page,
+        page_size=page_size,
+    )
+    return VnCommuneAreaMapListResponse(
+        items=[VnCommuneAreaMapResponse.model_validate(r) for r in rows],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@admin_router.post(
+    "/communes",
+    response_model=VnCommuneAreaMapResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_commune(
+    payload: VnCommuneAreaMapCreate,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> VnCommuneAreaMapResponse:
+    service = VnLocalityService(db)
+    row, callback = await service.create_commune(payload.model_dump())
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "vn_commune_created",
+        id=row.id,
+        commune_code=row.commune_code,
+        area_code=row.area_code,
+        actor=user.id,
+    )
+    return VnCommuneAreaMapResponse.model_validate(row)
+
+
+@admin_router.patch(
+    "/communes/{commune_id}",
+    response_model=VnCommuneAreaMapResponse,
+)
+async def update_commune(
+    commune_id: int,
+    payload: VnCommuneAreaMapUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> VnCommuneAreaMapResponse:
+    """PATCH metadata (province/district/ward/effective_to). area_code KHÔNG
+    sửa được ở đây (đổi KV → /replace-area)."""
+    service = VnLocalityService(db)
+    row, callback = await service.update_commune(
+        commune_id, payload.model_dump(exclude_unset=True)
+    )
+    await db.commit()
+    if callback:
+        await callback()
+    log.info("vn_commune_updated", id=row.id, actor=user.id)
+    return VnCommuneAreaMapResponse.model_validate(row)
+
+
+@admin_router.post(
+    "/communes/{commune_id}/replace-area",
+    response_model=VnCommuneAreaMapResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def replace_commune_area(
+    commune_id: int,
+    payload: VnCommuneAreaMapReplaceArea,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> VnCommuneAreaMapResponse:
+    """Đổi KV temporal: retire dòng cũ + trả dòng active MỚI (201)."""
+    service = VnLocalityService(db)
+    row, callback = await service.replace_commune_area(
+        commune_id, payload.area_code, payload.effective_from
+    )
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "vn_commune_area_replaced",
+        old_id=commune_id,
+        new_id=row.id,
+        area_code=row.area_code,
+        actor=user.id,
+    )
+    return VnCommuneAreaMapResponse.model_validate(row)
+
+
+@admin_router.delete(
+    "/communes/{commune_id}",
+    response_model=VnCommuneAreaMapResponse,
+)
+async def retire_commune(
+    commune_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> VnCommuneAreaMapResponse:
+    """Retire (soft-close ``effective_to`` = hôm nay). KHÔNG hard-delete."""
+    service = VnLocalityService(db)
+    row, callback = await service.retire_commune(commune_id)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "vn_commune_retired",
+        id=row.id,
+        effective_to=str(row.effective_to),
+        actor=user.id,
+    )
+    return VnCommuneAreaMapResponse.model_validate(row)
 
 
 # =============================================================================

--- a/Backend_FastAPI/app/schemas/vn_locality.py
+++ b/Backend_FastAPI/app/schemas/vn_locality.py
@@ -32,6 +32,47 @@ class VnCommuneAreaMapResponse(VnCommuneAreaMapRow):
     effective_to: Optional[date] = None
 
 
+# =============================================================================
+# Admin CRUD (PR-A — UI quản lý commune KV). Temporal half-open: đổi KV đi qua
+# /replace-area (retire dòng cũ + insert dòng mới), KHÔNG update area_code tại chỗ.
+# =============================================================================
+
+
+class VnCommuneAreaMapCreate(VnCommuneAreaMapRow):
+    """Tạo dòng KV mới. Kế thừa field CSV row + cho override effective_from."""
+
+    effective_from: Optional[date] = None
+
+
+class VnCommuneAreaMapUpdate(BaseModel):
+    """PATCH metadata — KHÔNG nhận ``area_code``/``commune_code`` (đổi KV =
+    /replace-area để giữ lịch sử temporal). ``effective_to=null`` tường minh =
+    re-activate (service chặn nếu tạo 2 dòng active cùng ``commune_code``)."""
+
+    province: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    district: Optional[str] = Field(default=None, max_length=100)
+    ward: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    effective_to: Optional[date] = None
+
+
+class VnCommuneAreaMapReplaceArea(BaseModel):
+    """Đổi KV theo kiểu temporal: retire dòng active cũ (``effective_to`` =
+    ``effective_from`` mới) + insert dòng active mới cùng
+    ``commune_code/province/district/ward`` với ``area_code`` mới."""
+
+    area_code: str = Field(pattern=r"^KV[1-9](-NT)?$")
+    effective_from: Optional[date] = None
+
+
+class VnCommuneAreaMapListResponse(BaseModel):
+    """Paginated list cho bảng admin (commune ~nghìn dòng)."""
+
+    items: list[VnCommuneAreaMapResponse]
+    total: int
+    page: int
+    page_size: int
+
+
 # VnHighSchoolRow + VnHighSchoolResponse DROPPED phase1_09 (Q9 #07 PR5 v1.3).
 # Replaced by VnSchool family schemas (TBD in Phase B.1 import script
 # + Phase D candidate FE). See Documents/Q9_07_PR5_REDESIGN.md v1.3.

--- a/Backend_FastAPI/app/services/vn_locality_service.py
+++ b/Backend_FastAPI/app/services/vn_locality_service.py
@@ -87,6 +87,18 @@ async def _noop_callback() -> None:
     return None
 
 
+def _guard_close_not_before_open(open_date: date, close_date: date) -> None:
+    """``effective_to`` / cutover phải >= ``effective_from`` — chặn khoảng
+    temporal ngược. vn_commune_area_map KHÔNG có CHECK interval ở DB (khác
+    vn_school_kv_assignment), nên guard ở service để 1 effective_from/to quá
+    khứ không tạo dòng [from, to) với to < from (làm sai lookup/audit lịch sử)."""
+    if close_date < open_date:
+        raise BusinessRuleViolation(
+            f"Ngày đóng ({close_date}) không được trước ngày bắt đầu "
+            f"({open_date}) — sẽ tạo khoảng thời gian ngược."
+        )
+
+
 # SAMPLE_HIGH_SCHOOLS DROPPED phase1_09. Demo seed for VnSchool family
 # will live in app/scripts/import_moet_schools_2025.py (Phase B.1).
 
@@ -280,6 +292,8 @@ class VnLocalityService:
                     f"Không thể re-activate: mã xã {row.commune_code!r} đã có "
                     f"dòng active khác (id={other.id})."
                 )
+        if data.get("effective_to") is not None:
+            _guard_close_not_before_open(row.effective_from, data["effective_to"])
         for key in ("province", "district", "ward", "effective_to"):
             if key in data:
                 setattr(row, key, data[key])
@@ -304,6 +318,7 @@ class VnLocalityService:
                 f"— không thể đổi KV trên dòng đã đóng."
             )
         cutover = effective_from or date.today()
+        _guard_close_not_before_open(old.effective_from, cutover)
         # Đóng dòng cũ TRƯỚC + flush để giải phóng partial-unique active slot,
         # rồi mới insert dòng mới (tránh 2 active cùng commune_code lúc INSERT).
         old.effective_to = cutover
@@ -334,6 +349,8 @@ class VnLocalityService:
                 f"Dòng {commune_id} đã retire trước đó "
                 f"(effective_to={row.effective_to})."
             )
-        row.effective_to = effective_to or date.today()
+        target = effective_to or date.today()
+        _guard_close_not_before_open(row.effective_from, target)
+        row.effective_to = target
         await self.db.flush()
         return row, _noop_callback

--- a/Backend_FastAPI/app/services/vn_locality_service.py
+++ b/Backend_FastAPI/app/services/vn_locality_service.py
@@ -14,14 +14,20 @@ from __future__ import annotations
 
 import csv
 import io
+from datetime import date
 from typing import Any, Awaitable, Callable, Optional, Tuple
 
 from pydantic import ValidationError
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.vn_locality import VnCommuneAreaMap
 from app.schemas.vn_locality import VnCommuneAreaMapRow
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    DuplicateResourceError,
+    ResourceNotFoundError,
+)
 from app.utils.exceptions import ValidationError as DomainValidationError
 
 # VnHighSchool DROPPED in phase1_09 — see app/models/vn_school.py for the
@@ -164,3 +170,170 @@ class VnLocalityService:
         )
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none()
+
+    # =========================================================================
+    # vn_commune_area_map — admin CRUD (PR-A)
+    #
+    # Temporal half-open (active = ``effective_to IS NULL``, ≤1/commune_code per
+    # partial-unique ``uq_vn_commune_area_map_code_active``). Mirror SEMANTICS
+    # của priority_config_service (temporal, ``(row, callback)``, domain
+    # exceptions) nhưng giữ STRUCTURE direct-``db.execute`` của file này (không
+    # repo). Đổi KV ĐI QUA ``replace_commune_area`` (giữ lịch sử), KHÔNG update
+    # ``area_code`` tại chỗ.
+    # =========================================================================
+
+    async def _active_commune(
+        self, commune_code: str, exclude_id: Optional[int] = None
+    ) -> Optional[VnCommuneAreaMap]:
+        """Dòng active (effective_to IS NULL) của 1 commune_code, nếu có."""
+        stmt = select(VnCommuneAreaMap).where(
+            VnCommuneAreaMap.commune_code == commune_code,
+            VnCommuneAreaMap.effective_to.is_(None),
+        )
+        if exclude_id is not None:
+            stmt = stmt.where(VnCommuneAreaMap.id != exclude_id)
+        return (await self.db.execute(stmt.limit(1))).scalar_one_or_none()
+
+    async def list_communes(
+        self,
+        province: Optional[str] = None,
+        q: Optional[str] = None,
+        active_only: bool = True,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> Tuple[list[VnCommuneAreaMap], int]:
+        """Paginated list + lọc tỉnh/search. Read-only (no callback)."""
+        page = max(1, page)
+        page_size = min(max(1, page_size), 200)
+        conds = []
+        if active_only:
+            conds.append(VnCommuneAreaMap.effective_to.is_(None))
+        if province:
+            conds.append(VnCommuneAreaMap.province == province)
+        if q:
+            like = f"%{q.strip()}%"
+            conds.append(
+                or_(
+                    VnCommuneAreaMap.ward.ilike(like),
+                    VnCommuneAreaMap.commune_code.ilike(like),
+                )
+            )
+        total = (
+            await self.db.execute(
+                select(func.count())
+                .select_from(VnCommuneAreaMap)
+                .where(*conds)
+            )
+        ).scalar_one()
+        rows = (
+            (
+                await self.db.execute(
+                    select(VnCommuneAreaMap)
+                    .where(*conds)
+                    .order_by(
+                        VnCommuneAreaMap.province,
+                        VnCommuneAreaMap.ward,
+                        VnCommuneAreaMap.id,
+                    )
+                    .offset((page - 1) * page_size)
+                    .limit(page_size)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows), int(total)
+
+    async def create_commune(
+        self, data: dict[str, Any]
+    ) -> Tuple[VnCommuneAreaMap, PostCommitCallback]:
+        """Tạo dòng KV mới. Chặn nếu commune_code đã có dòng active."""
+        if await self._active_commune(data["commune_code"]) is not None:
+            raise DuplicateResourceError(
+                f"Đã có dòng KV active cho mã xã {data['commune_code']!r} — "
+                f"retire dòng cũ hoặc dùng /replace-area để đổi KV."
+            )
+        # Drop None để effective_from lấy server_default (CURRENT_DATE).
+        clean = {k: v for k, v in data.items() if v is not None}
+        row = VnCommuneAreaMap(**clean)
+        self.db.add(row)
+        await self.db.flush()
+        return row, _noop_callback
+
+    async def update_commune(
+        self, commune_id: int, data: dict[str, Any]
+    ) -> Tuple[VnCommuneAreaMap, PostCommitCallback]:
+        """PATCH metadata (province/district/ward/effective_to). KHÔNG đổi
+        area_code/commune_code. effective_to=None = re-activate (chặn 2 active)."""
+        row = await self.db.get(VnCommuneAreaMap, commune_id)
+        if row is None:
+            raise ResourceNotFoundError(
+                f"VnCommuneAreaMap {commune_id} not found"
+            )
+        # Defense-in-depth: schema đã loại 2 field này, service vẫn drop.
+        data.pop("area_code", None)
+        data.pop("commune_code", None)
+        if "effective_to" in data and data["effective_to"] is None:
+            other = await self._active_commune(row.commune_code, exclude_id=row.id)
+            if other is not None:
+                raise BusinessRuleViolation(
+                    f"Không thể re-activate: mã xã {row.commune_code!r} đã có "
+                    f"dòng active khác (id={other.id})."
+                )
+        for key in ("province", "district", "ward", "effective_to"):
+            if key in data:
+                setattr(row, key, data[key])
+        await self.db.flush()
+        return row, _noop_callback
+
+    async def replace_commune_area(
+        self,
+        commune_id: int,
+        area_code: str,
+        effective_from: Optional[date] = None,
+    ) -> Tuple[VnCommuneAreaMap, PostCommitCallback]:
+        """Đổi KV temporal: retire dòng active cũ + insert dòng active mới."""
+        old = await self.db.get(VnCommuneAreaMap, commune_id)
+        if old is None:
+            raise ResourceNotFoundError(
+                f"VnCommuneAreaMap {commune_id} not found"
+            )
+        if old.effective_to is not None:
+            raise BusinessRuleViolation(
+                f"Dòng {commune_id} đã retire (effective_to={old.effective_to}) "
+                f"— không thể đổi KV trên dòng đã đóng."
+            )
+        cutover = effective_from or date.today()
+        # Đóng dòng cũ TRƯỚC + flush để giải phóng partial-unique active slot,
+        # rồi mới insert dòng mới (tránh 2 active cùng commune_code lúc INSERT).
+        old.effective_to = cutover
+        await self.db.flush()
+        new_row = VnCommuneAreaMap(
+            commune_code=old.commune_code,
+            province=old.province,
+            district=old.district,
+            ward=old.ward,
+            area_code=area_code,
+            effective_from=cutover,
+        )
+        self.db.add(new_row)
+        await self.db.flush()
+        return new_row, _noop_callback
+
+    async def retire_commune(
+        self, commune_id: int, effective_to: Optional[date] = None
+    ) -> Tuple[VnCommuneAreaMap, PostCommitCallback]:
+        """Retire dòng KV (soft-close effective_to). Chặn double-retire."""
+        row = await self.db.get(VnCommuneAreaMap, commune_id)
+        if row is None:
+            raise ResourceNotFoundError(
+                f"VnCommuneAreaMap {commune_id} not found"
+            )
+        if row.effective_to is not None:
+            raise BusinessRuleViolation(
+                f"Dòng {commune_id} đã retire trước đó "
+                f"(effective_to={row.effective_to})."
+            )
+        row.effective_to = effective_to or date.today()
+        await self.db.flush()
+        return row, _noop_callback

--- a/Backend_FastAPI/tests/api/test_admin_vn_locality_communes.py
+++ b/Backend_FastAPI/tests/api/test_admin_vn_locality_communes.py
@@ -1,0 +1,134 @@
+"""API smoke for admin commune KV CRUD router (PR-A).
+
+End-to-end qua FastAPI app + real test DB: lifecycle admin (create →
+list → replace-area temporal → retire), gate dup/404, PATCH không đổi
+area_code, và require_admin (officer → 403).
+
+Mỗi test dùng commune_code RIÊNG (API commit thật, không rollback per-test)
+→ tránh đụng partial-active guard giữa các test trong cùng run.
+"""
+import pytest
+from httpx import AsyncClient
+
+pytestmark = [pytest.mark.asyncio]
+
+BASE = "/api/v2/admin/vn-locality/communes"
+
+
+def _payload(code: str, area: str = "KV3", **kw) -> dict:
+    return {
+        "commune_code": code,
+        "province": kw.get("province", "Tỉnh Lâm Đồng"),
+        "ward": kw.get("ward", f"Xã {code}"),
+        "area_code": area,
+    }
+
+
+async def test_commune_lifecycle_create_replace_retire(
+    client: AsyncClient, admin_token_headers: dict, setup_test_database
+) -> None:
+    code = "APISMK_LIFE"
+    # CREATE
+    r = await client.post(BASE, json=_payload(code, "KV3"), headers=admin_token_headers)
+    assert r.status_code == 201, r.text
+    created = r.json()
+    assert created["area_code"] == "KV3"
+    assert created["effective_to"] is None
+
+    # LIST (active) — phải thấy code vừa tạo.
+    r = await client.get(
+        BASE, params={"q": code, "active_only": True}, headers=admin_token_headers
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["total"] == 1
+    old_id = body["items"][0]["id"]
+
+    # REPLACE-AREA (đổi KV temporal → dòng active MỚI).
+    r = await client.post(
+        f"{BASE}/{old_id}/replace-area",
+        json={"area_code": "KV1"},
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 201, r.text
+    new_row = r.json()
+    assert new_row["area_code"] == "KV1"
+    assert new_row["effective_to"] is None
+    assert new_row["id"] != old_id
+
+    # active list → CHỈ dòng KV1; full list (active_only=false) → 2 dòng.
+    r_active = await client.get(
+        BASE, params={"q": code, "active_only": True}, headers=admin_token_headers
+    )
+    assert r_active.json()["total"] == 1
+    assert r_active.json()["items"][0]["area_code"] == "KV1"
+    r_all = await client.get(
+        BASE, params={"q": code, "active_only": False}, headers=admin_token_headers
+    )
+    assert r_all.json()["total"] == 2  # cũ (retired KV3) + mới (active KV1)
+
+    # RETIRE dòng active mới.
+    r = await client.delete(f"{BASE}/{new_row['id']}", headers=admin_token_headers)
+    assert r.status_code == 200, r.text
+    assert r.json()["effective_to"] is not None
+
+
+async def test_create_duplicate_active_returns_409(
+    client: AsyncClient, admin_token_headers: dict, setup_test_database
+) -> None:
+    code = "APISMK_DUP"
+    r1 = await client.post(
+        BASE, json=_payload(code, "KV3"), headers=admin_token_headers
+    )
+    assert r1.status_code == 201, r1.text
+    r2 = await client.post(
+        BASE, json=_payload(code, "KV2"), headers=admin_token_headers
+    )
+    assert r2.status_code == 409, r2.text
+
+
+async def test_update_missing_returns_404(
+    client: AsyncClient, admin_token_headers: dict, setup_test_database
+) -> None:
+    r = await client.patch(
+        f"{BASE}/999999", json={"ward": "X"}, headers=admin_token_headers
+    )
+    assert r.status_code == 404, r.text
+
+
+async def test_patch_ignores_area_code(
+    client: AsyncClient, admin_token_headers: dict, setup_test_database
+) -> None:
+    code = "APISMK_PATCH"
+    r = await client.post(BASE, json=_payload(code, "KV3"), headers=admin_token_headers)
+    cid = r.json()["id"]
+    # Gửi kèm area_code (KHÔNG có trong schema Update → Pydantic loại) + đổi ward.
+    r = await client.patch(
+        f"{BASE}/{cid}",
+        json={"ward": "Xã Đổi Tên", "area_code": "KV1"},
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["ward"] == "Xã Đổi Tên"
+    assert r.json()["area_code"] == "KV3"  # KHÔNG đổi qua PATCH
+
+
+async def test_create_invalid_area_code_rejected(
+    client: AsyncClient, admin_token_headers: dict, setup_test_database
+) -> None:
+    # Zod/Pydantic regex chặn underscore → 422.
+    r = await client.post(
+        BASE, json=_payload("APISMK_BAD", "KV2_NT"), headers=admin_token_headers
+    )
+    assert r.status_code == 422, r.text
+
+
+async def test_non_admin_forbidden(
+    client: AsyncClient, officer_token_headers: dict, setup_test_database
+) -> None:
+    # require_admin → officer bị chặn (403). Clear cookie tránh contamination.
+    client.cookies.clear()
+    r = await client.post(
+        BASE, json=_payload("APISMK_OFF", "KV3"), headers=officer_token_headers
+    )
+    assert r.status_code == 403, r.text

--- a/Backend_FastAPI/tests/unit/test_vn_locality_admin_service.py
+++ b/Backend_FastAPI/tests/unit/test_vn_locality_admin_service.py
@@ -1,0 +1,218 @@
+"""Unit tests for VnLocalityService commune KV admin CRUD (PR-A).
+
+Mirror ``test_priority_config_service.py``: real test DB session (``db``
+fixture) → CHECK constraint ``ck_vn_commune_area_map_area_code_format``
+fires; temporal half-open + service-level active guard.
+
+Lưu ý: qlts_test dùng ``create_all()`` (memory ``test-db-schema-source``) →
+partial-unique ``uq_vn_commune_area_map_code_active`` (định nghĩa ở migration,
+KHÔNG trong model ``__table_args__``) KHÔNG được tạo. Vì vậy dedup dựa vào
+service-level ``_active_commune`` (không phải DB constraint) — đúng contract
+prod (index chỉ là defense-in-depth).
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.exc import IntegrityError
+
+from app.database import AsyncSessionLocal
+from app.services.vn_locality_service import VnLocalityService
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    DuplicateResourceError,
+    ResourceNotFoundError,
+)
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def db(setup_test_database):
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+        finally:
+            await session.rollback()
+            await session.close()
+
+
+def _commune(code: str, area: str = "KV3", **kw) -> dict:
+    return {
+        "commune_code": code,
+        "province": kw.get("province", "Tỉnh Lâm Đồng"),
+        "district": kw.get("district", ""),
+        "ward": kw.get("ward", f"Xã {code}"),
+        "area_code": area,
+    }
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+async def test_create_persists_with_server_default_effective_from(db) -> None:
+    service = VnLocalityService(db)
+    row, _cb = await service.create_commune(_commune("00001", "KV1"))
+    await db.flush()
+    assert row.id is not None
+    assert row.commune_code == "00001"
+    assert row.area_code == "KV1"
+    assert row.effective_from is not None  # server_default CURRENT_DATE
+    assert row.effective_to is None  # active
+
+
+async def test_create_duplicate_active_raises(db) -> None:
+    service = VnLocalityService(db)
+    await service.create_commune(_commune("00002", "KV1"))
+    with pytest.raises(DuplicateResourceError):
+        await service.create_commune(_commune("00002", "KV2"))
+
+
+async def test_create_rejects_invalid_area_code_via_db_check(db) -> None:
+    """CHECK regex chặn 'KV2_NT' (underscore) — chỉ 'KV2-NT' (hyphen)."""
+    service = VnLocalityService(db)
+    with pytest.raises(IntegrityError):
+        await service.create_commune(_commune("00003", "KV2_NT"))
+        await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# update (PATCH metadata) — KHÔNG đổi area_code
+# ---------------------------------------------------------------------------
+
+
+async def test_update_patches_metadata_only_keeps_area_code(db) -> None:
+    service = VnLocalityService(db)
+    row, _ = await service.create_commune(_commune("00010", "KV3", ward="Xã Cũ"))
+    await db.flush()
+    # Gửi kèm area_code + commune_code — service PHẢI bỏ qua 2 field này.
+    updated, _ = await service.update_commune(
+        row.id,
+        {"ward": "Xã Mới", "area_code": "KV1", "commune_code": "HACK"},
+    )
+    await db.flush()
+    assert updated.ward == "Xã Mới"
+    assert updated.area_code == "KV3"  # KHÔNG đổi qua PATCH
+    assert updated.commune_code == "00010"  # KHÔNG đổi
+
+
+async def test_update_missing_raises_not_found(db) -> None:
+    service = VnLocalityService(db)
+    with pytest.raises(ResourceNotFoundError):
+        await service.update_commune(999999, {"ward": "X"})
+
+
+# ---------------------------------------------------------------------------
+# replace_commune_area — temporal: retire cũ + insert mới
+# ---------------------------------------------------------------------------
+
+
+async def test_replace_area_creates_new_row_retires_old(db) -> None:
+    service = VnLocalityService(db)
+    old, _ = await service.create_commune(_commune("00020", "KV3"))
+    await db.flush()
+    old_id = old.id
+
+    new_row, _ = await service.replace_commune_area(old_id, "KV1")
+    await db.flush()
+
+    # Dòng cũ bị đóng (effective_to set), dòng mới active với KV mới.
+    refreshed_old = await db.get(type(old), old_id)
+    assert refreshed_old.effective_to is not None
+    assert new_row.id != old_id
+    assert new_row.area_code == "KV1"
+    assert new_row.effective_to is None
+    assert new_row.commune_code == "00020"
+    # lookup hiện tại trả area_code MỚI.
+    assert await service.lookup_commune_kv("00020") == "KV1"
+
+
+async def test_replace_area_on_retired_row_raises(db) -> None:
+    service = VnLocalityService(db)
+    row, _ = await service.create_commune(_commune("00021", "KV3"))
+    await db.flush()
+    await service.retire_commune(row.id)
+    await db.flush()
+    with pytest.raises(BusinessRuleViolation):
+        await service.replace_commune_area(row.id, "KV1")
+
+
+async def test_replace_area_missing_raises_not_found(db) -> None:
+    service = VnLocalityService(db)
+    with pytest.raises(ResourceNotFoundError):
+        await service.replace_commune_area(999999, "KV1")
+
+
+# ---------------------------------------------------------------------------
+# retire — soft-close + chặn double-retire
+# ---------------------------------------------------------------------------
+
+
+async def test_retire_sets_effective_to(db) -> None:
+    service = VnLocalityService(db)
+    row, _ = await service.create_commune(_commune("00030", "KV2"))
+    await db.flush()
+    retired, _ = await service.retire_commune(row.id)
+    await db.flush()
+    assert retired.effective_to is not None
+    # KHÔNG còn active → lookup trả None.
+    assert await service.lookup_commune_kv("00030") is None
+
+
+async def test_retire_double_blocks(db) -> None:
+    service = VnLocalityService(db)
+    row, _ = await service.create_commune(_commune("00031", "KV2"))
+    await db.flush()
+    await service.retire_commune(row.id)
+    await db.flush()
+    with pytest.raises(BusinessRuleViolation):
+        await service.retire_commune(row.id)
+
+
+# ---------------------------------------------------------------------------
+# re-activate (effective_to=None) — chặn nếu đã có dòng active khác
+# ---------------------------------------------------------------------------
+
+
+async def test_reactivate_blocked_when_other_active_exists(db) -> None:
+    service = VnLocalityService(db)
+    old, _ = await service.create_commune(_commune("00040", "KV3"))
+    await db.flush()
+    # replace → old retired, new active cho cùng commune_code.
+    await service.replace_commune_area(old.id, "KV1")
+    await db.flush()
+    # Re-activate old (effective_to=None) phải bị chặn (đã có new active).
+    with pytest.raises(BusinessRuleViolation):
+        await service.update_commune(old.id, {"effective_to": None})
+
+
+# ---------------------------------------------------------------------------
+# list_communes — pagination + filter
+# ---------------------------------------------------------------------------
+
+
+async def test_list_pagination_and_province_filter(db) -> None:
+    service = VnLocalityService(db)
+    for i in range(5):
+        await service.create_commune(
+            _commune(f"0005{i}", "KV3", province="Tỉnh Lâm Đồng", ward=f"Xã {i}")
+        )
+    await service.create_commune(
+        _commune("00060", "KV2", province="Tỉnh Gia Lai", ward="Xã Khác")
+    )
+    await db.flush()
+
+    # Lọc tỉnh Lâm Đồng → 5 dòng; page_size=2 → 2 items, total=5.
+    items, total = await service.list_communes(
+        province="Tỉnh Lâm Đồng", page=1, page_size=2
+    )
+    assert total == 5
+    assert len(items) == 2
+
+    # Search theo ward.
+    items2, total2 = await service.list_communes(q="Xã Khác")
+    assert total2 == 1
+    assert items2[0].commune_code == "00060"

--- a/Backend_FastAPI/tests/unit/test_vn_locality_admin_service.py
+++ b/Backend_FastAPI/tests/unit/test_vn_locality_admin_service.py
@@ -12,6 +12,8 @@ prod (index chỉ là defense-in-depth).
 """
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
 import pytest_asyncio
 from sqlalchemy.exc import IntegrityError
@@ -216,3 +218,47 @@ async def test_list_pagination_and_province_filter(db) -> None:
     items2, total2 = await service.list_communes(q="Xã Khác")
     assert total2 == 1
     assert items2[0].commune_code == "00060"
+
+
+# ---------------------------------------------------------------------------
+# re-activate THÀNH CÔNG (đối nghịch test_reactivate_blocked_*)
+# ---------------------------------------------------------------------------
+
+
+async def test_reactivate_succeeds_when_no_other_active(db) -> None:
+    """retire rồi update_commune(effective_to=None) PHẢI thành công khi KHÔNG
+    còn dòng active khác → dòng active trở lại + lookup trả KV."""
+    service = VnLocalityService(db)
+    row, _ = await service.create_commune(_commune("00070", "KV2"))
+    await db.flush()
+    await service.retire_commune(row.id)
+    await db.flush()
+    assert row.effective_to is not None  # đã retire
+
+    reactivated, _ = await service.update_commune(row.id, {"effective_to": None})
+    await db.flush()
+    assert reactivated.effective_to is None  # active lại
+    assert await service.lookup_commune_kv("00070") == "KV2"
+
+
+# ---------------------------------------------------------------------------
+# guard interval (effective_to/cutover >= effective_from)
+# ---------------------------------------------------------------------------
+
+
+async def test_replace_area_rejects_past_effective_from(db) -> None:
+    service = VnLocalityService(db)
+    row, _ = await service.create_commune(_commune("00071", "KV3"))
+    await db.flush()
+    past = row.effective_from - timedelta(days=1)
+    with pytest.raises(BusinessRuleViolation):
+        await service.replace_commune_area(row.id, "KV1", effective_from=past)
+
+
+async def test_retire_rejects_past_effective_to(db) -> None:
+    service = VnLocalityService(db)
+    row, _ = await service.create_commune(_commune("00072", "KV3"))
+    await db.flush()
+    past = row.effective_from - timedelta(days=1)
+    with pytest.raises(BusinessRuleViolation):
+        await service.retire_commune(row.id, effective_to=past)

--- a/frontend/src/app/(dashboard)/admin/commune-kv/_components/CommuneKvClient.tsx
+++ b/frontend/src/app/(dashboard)/admin/commune-kv/_components/CommuneKvClient.tsx
@@ -1,0 +1,177 @@
+/**
+ * CommuneKvClient — orchestrator trang Quản lý KV theo Xã.
+ *
+ * Sở hữu bộ lọc (tỉnh + search + active toggle) + pagination + nút Import CSV,
+ * chạy `useCommunes` rồi truyền rows xuống `CommuneKvTable`. Mutations (trong
+ * Table + Import dialog) invalidate `commune-kv` tree → query refetch.
+ *
+ * Lọc tỉnh dùng TÊN tỉnh (vn_commune_area_map.province là text) — KHÔNG mã.
+ */
+
+"use client"
+
+import { useEffect, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { Upload } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+
+import { administrativeApi } from "@/lib/api/administrative"
+import { useCommunes } from "@/lib/hooks/useCommuneKvAdmin"
+
+import { CommuneKvTable } from "./CommuneKvTable"
+import { ImportCommuneCsvDialog } from "./ImportCommuneCsvDialog"
+
+const PAGE_SIZE = 50
+const ALL_PROVINCES = "__all__"
+
+export function CommuneKvClient() {
+  const [provinceName, setProvinceName] = useState<string>(ALL_PROVINCES)
+  const [qInput, setQInput] = useState("")
+  const [q, setQ] = useState("")
+  const [activeOnly, setActiveOnly] = useState(true)
+  const [page, setPage] = useState(1)
+  const [importOpen, setImportOpen] = useState(false)
+
+  // Debounce search → tránh refetch mỗi keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setQ(qInput.trim())
+      setPage(1)
+    }, 300)
+    return () => clearTimeout(t)
+  }, [qInput])
+
+  const params = {
+    province: provinceName === ALL_PROVINCES ? null : provinceName,
+    q: q || null,
+    activeOnly,
+    page,
+    pageSize: PAGE_SIZE,
+  }
+  const { data, isLoading, isFetching } = useCommunes(params)
+
+  const { data: provinces } = useQuery({
+    queryKey: ["administrative", "provinces", "current"],
+    queryFn: () => administrativeApi.getProvinces("current"),
+    staleTime: 60 * 60 * 1000,
+  })
+
+  const total = data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  return (
+    <div className="container mx-auto space-y-4 p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">KV theo Xã</h1>
+          <p className="text-muted-foreground text-sm">
+            Danh mục khu vực ưu tiên theo xã/phường (vn_commune_area_map). Đổi
+            KV của một xã sẽ tạo bản ghi mới theo thời gian, giữ lịch sử cũ.
+          </p>
+        </div>
+        <Button variant="outline" onClick={() => setImportOpen(true)}>
+          <Upload className="mr-2 h-4 w-4" />
+          Import CSV
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Bộ lọc</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="grid gap-1.5">
+              <Label htmlFor="filter-province">Tỉnh</Label>
+              <Select
+                value={provinceName}
+                onValueChange={(v) => {
+                  setProvinceName(v)
+                  setPage(1)
+                }}
+              >
+                <SelectTrigger id="filter-province" className="w-[260px]">
+                  <SelectValue placeholder="Tất cả tỉnh" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL_PROVINCES}>Tất cả tỉnh</SelectItem>
+                  {(provinces ?? []).map((p) => (
+                    <SelectItem key={p.code} value={p.name}>
+                      {p.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="grid gap-1.5">
+              <Label htmlFor="filter-q">Tìm (xã / mã xã)</Label>
+              <Input
+                id="filter-q"
+                value={qInput}
+                onChange={(e) => setQInput(e.target.value)}
+                placeholder="VD: Đắk Mil / 24717"
+                className="w-[240px]"
+              />
+            </div>
+
+            <div className="flex items-center gap-2 pb-2">
+              <Switch
+                id="filter-active"
+                checked={activeOnly}
+                onCheckedChange={(v) => {
+                  setActiveOnly(v)
+                  setPage(1)
+                }}
+              />
+              <Label htmlFor="filter-active">Chỉ dòng đang áp dụng</Label>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <CommuneKvTable rows={data?.items ?? []} isLoading={isLoading} />
+
+      <div className="flex items-center justify-between">
+        <p className="text-muted-foreground text-sm">
+          {total} dòng{isFetching ? " · đang tải…" : ""}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Trước
+          </Button>
+          <span className="text-sm tabular-nums">
+            Trang {page} / {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          >
+            Sau
+          </Button>
+        </div>
+      </div>
+
+      <ImportCommuneCsvDialog open={importOpen} onOpenChange={setImportOpen} />
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/commune-kv/_components/CommuneKvTable.tsx
+++ b/frontend/src/app/(dashboard)/admin/commune-kv/_components/CommuneKvTable.tsx
@@ -118,7 +118,8 @@ export function CommuneKvTable({ rows, isLoading }: CommuneKvTableProps) {
   const busy =
     createMutation.isPending ||
     updateMutation.isPending ||
-    replaceMutation.isPending
+    replaceMutation.isPending ||
+    retireMutation.isPending
 
   const handleCreate = async () => {
     setCreateError(null)
@@ -154,7 +155,9 @@ export function CommuneKvTable({ rows, isLoading }: CommuneKvTableProps) {
     setEditError(null)
     const parsed = communeAreaUpdateSchema.safeParse({
       province: editForm.province.trim(),
-      district: editForm.district.trim(),
+      // Empty → undefined để Pydantic exclude_unset bỏ qua (nhất quán với create
+      // form), tránh PATCH district="" thừa khi không đổi.
+      district: editForm.district.trim() || undefined,
       ward: editForm.ward.trim(),
     })
     if (!parsed.success) {
@@ -500,7 +503,10 @@ export function CommuneKvTable({ rows, isLoading }: CommuneKvTableProps) {
             <Button variant="outline" onClick={() => setReplaceRow(null)} disabled={busy}>
               Hủy
             </Button>
-            <Button onClick={handleReplace} disabled={busy}>
+            <Button
+              onClick={handleReplace}
+              disabled={busy || replaceArea === replaceRow?.area_code}
+            >
               Đổi KV
             </Button>
           </DialogFooter>

--- a/frontend/src/app/(dashboard)/admin/commune-kv/_components/CommuneKvTable.tsx
+++ b/frontend/src/app/(dashboard)/admin/commune-kv/_components/CommuneKvTable.tsx
@@ -1,0 +1,536 @@
+/**
+ * CommuneKvTable — bảng vn_commune_area_map + dialog CRUD.
+ *
+ * 4 thao tác:
+ * - Thêm xã (create)
+ * - Sửa (PATCH metadata: tỉnh/xã — KHÔNG đổi KV ở đây)
+ * - Đổi KV (replace-area): tạo bản ghi temporal MỚI, retire bản ghi cũ → giữ
+ *   lịch sử KV theo thời gian
+ * - Ngưng (retire): soft-close effective_to
+ */
+
+"use client"
+
+import { useState } from "react"
+import { History, Pencil, Plus, Trash2 } from "lucide-react"
+import { toast } from "sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+import {
+  useCreateCommune,
+  useReplaceCommuneArea,
+  useRetireCommune,
+  useUpdateCommune,
+} from "@/lib/hooks/useCommuneKvAdmin"
+import { parseApiError } from "@/lib/utils/api-errors"
+import {
+  communeAreaCreateSchema,
+  communeAreaUpdateSchema,
+  communeReplaceAreaSchema,
+  type CommuneAreaResponse,
+} from "@/lib/zod/commune-kv"
+
+const KV_OPTIONS = ["KV1", "KV2-NT", "KV2", "KV3"] as const
+
+interface CommuneKvTableProps {
+  rows: CommuneAreaResponse[]
+  isLoading: boolean
+}
+
+interface CreateForm {
+  commune_code: string
+  province: string
+  district: string
+  ward: string
+  area_code: string
+}
+
+const EMPTY_CREATE: CreateForm = {
+  commune_code: "",
+  province: "",
+  district: "",
+  ward: "",
+  area_code: "KV3",
+}
+
+export function CommuneKvTable({ rows, isLoading }: CommuneKvTableProps) {
+  const createMutation = useCreateCommune()
+  const updateMutation = useUpdateCommune()
+  const replaceMutation = useReplaceCommuneArea()
+  const retireMutation = useRetireCommune()
+
+  // Create
+  const [createOpen, setCreateOpen] = useState(false)
+  const [createForm, setCreateForm] = useState<CreateForm>(EMPTY_CREATE)
+  const [createError, setCreateError] = useState<string | null>(null)
+
+  // Edit metadata
+  const [editRow, setEditRow] = useState<CommuneAreaResponse | null>(null)
+  const [editForm, setEditForm] = useState({ province: "", district: "", ward: "" })
+  const [editError, setEditError] = useState<string | null>(null)
+
+  // Replace area (đổi KV)
+  const [replaceRow, setReplaceRow] = useState<CommuneAreaResponse | null>(null)
+  const [replaceArea, setReplaceArea] = useState<string>("KV3")
+  const [replaceError, setReplaceError] = useState<string | null>(null)
+
+  // Retire
+  const [retireRow, setRetireRow] = useState<CommuneAreaResponse | null>(null)
+
+  const busy =
+    createMutation.isPending ||
+    updateMutation.isPending ||
+    replaceMutation.isPending
+
+  const handleCreate = async () => {
+    setCreateError(null)
+    const parsed = communeAreaCreateSchema.safeParse({
+      commune_code: createForm.commune_code.trim(),
+      province: createForm.province.trim(),
+      district: createForm.district.trim() || undefined,
+      ward: createForm.ward.trim(),
+      area_code: createForm.area_code,
+    })
+    if (!parsed.success) {
+      setCreateError(parsed.error.issues[0]?.message ?? "Dữ liệu không hợp lệ")
+      return
+    }
+    try {
+      await createMutation.mutateAsync(parsed.data)
+      toast.success(`Đã thêm xã ${parsed.data.commune_code}`)
+      setCreateOpen(false)
+      setCreateForm(EMPTY_CREATE)
+    } catch (e) {
+      setCreateError(parseApiError(e, "Thêm xã thất bại"))
+    }
+  }
+
+  const openEdit = (row: CommuneAreaResponse) => {
+    setEditRow(row)
+    setEditForm({ province: row.province, district: row.district, ward: row.ward })
+    setEditError(null)
+  }
+
+  const handleEdit = async () => {
+    if (!editRow) return
+    setEditError(null)
+    const parsed = communeAreaUpdateSchema.safeParse({
+      province: editForm.province.trim(),
+      district: editForm.district.trim(),
+      ward: editForm.ward.trim(),
+    })
+    if (!parsed.success) {
+      setEditError(parsed.error.issues[0]?.message ?? "Dữ liệu không hợp lệ")
+      return
+    }
+    try {
+      await updateMutation.mutateAsync({ id: editRow.id, data: parsed.data })
+      toast.success(`Đã cập nhật ${editRow.ward}`)
+      setEditRow(null)
+    } catch (e) {
+      setEditError(parseApiError(e, "Cập nhật thất bại"))
+    }
+  }
+
+  const openReplace = (row: CommuneAreaResponse) => {
+    setReplaceRow(row)
+    setReplaceArea(row.area_code)
+    setReplaceError(null)
+  }
+
+  const handleReplace = async () => {
+    if (!replaceRow) return
+    setReplaceError(null)
+    const parsed = communeReplaceAreaSchema.safeParse({ area_code: replaceArea })
+    if (!parsed.success) {
+      setReplaceError(parsed.error.issues[0]?.message ?? "Mã KV không hợp lệ")
+      return
+    }
+    if (replaceArea === replaceRow.area_code) {
+      setReplaceError("KV mới trùng KV hiện tại")
+      return
+    }
+    try {
+      await replaceMutation.mutateAsync({
+        id: replaceRow.id,
+        data: parsed.data,
+      })
+      toast.success(`Đã đổi KV ${replaceRow.ward} → ${replaceArea}`)
+      setReplaceRow(null)
+    } catch (e) {
+      setReplaceError(parseApiError(e, "Đổi KV thất bại"))
+    }
+  }
+
+  const handleRetire = async () => {
+    if (!retireRow) return
+    try {
+      await retireMutation.mutateAsync(retireRow.id)
+      toast.success(`Đã ngưng ${retireRow.ward}`)
+    } catch (e) {
+      toast.error(parseApiError(e, "Ngưng thất bại"))
+    } finally {
+      setRetireRow(null)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <Button
+          size="sm"
+          onClick={() => {
+            setCreateForm(EMPTY_CREATE)
+            setCreateError(null)
+            setCreateOpen(true)
+          }}
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Thêm xã
+        </Button>
+      </div>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[120px]">Mã xã</TableHead>
+              <TableHead>Tỉnh</TableHead>
+              <TableHead>Xã / Phường</TableHead>
+              <TableHead className="w-[100px]">KV</TableHead>
+              <TableHead className="w-[170px]">Hiệu lực</TableHead>
+              <TableHead className="w-[150px] text-right">Thao tác</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              [1, 2, 3, 4, 5].map((i) => (
+                <TableRow key={i}>
+                  <TableCell colSpan={6}>
+                    <Skeleton className="h-6 w-full" />
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="text-muted-foreground py-8 text-center text-sm"
+                >
+                  Không có dòng nào khớp bộ lọc.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => (
+                <TableRow key={row.id} data-testid={`commune-row-${row.commune_code}`}>
+                  <TableCell className="font-mono">{row.commune_code}</TableCell>
+                  <TableCell>{row.province}</TableCell>
+                  <TableCell>{row.ward}</TableCell>
+                  <TableCell>
+                    <Badge variant="secondary" className="font-mono">
+                      {row.area_code}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-xs tabular-nums">
+                    {row.effective_from}
+                    {row.effective_to ? ` → ${row.effective_to}` : " → nay"}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => openEdit(row)}
+                        aria-label={`Sửa ${row.ward}`}
+                        disabled={!!row.effective_to}
+                        title="Sửa thông tin"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => openReplace(row)}
+                        aria-label={`Đổi KV ${row.ward}`}
+                        disabled={!!row.effective_to}
+                        title="Đổi KV (tạo bản ghi mới)"
+                      >
+                        <History className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setRetireRow(row)}
+                        aria-label={`Ngưng ${row.ward}`}
+                        disabled={!!row.effective_to}
+                        title="Ngưng áp dụng"
+                      >
+                        <Trash2 className="text-destructive h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Create */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Thêm xã</DialogTitle>
+            <DialogDescription>
+              Tạo bản ghi KV active mới. Mã xã phải chưa có dòng đang áp dụng.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="grid gap-2">
+              <Label htmlFor="c-code">Mã xã (BNV)</Label>
+              <Input
+                id="c-code"
+                value={createForm.commune_code}
+                onChange={(e) =>
+                  setCreateForm((s) => ({ ...s, commune_code: e.target.value }))
+                }
+                placeholder="VD: 24717"
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="c-province">Tỉnh</Label>
+              <Input
+                id="c-province"
+                value={createForm.province}
+                onChange={(e) =>
+                  setCreateForm((s) => ({ ...s, province: e.target.value }))
+                }
+                placeholder="VD: Tỉnh Lâm Đồng"
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="c-ward">Xã / Phường</Label>
+              <Input
+                id="c-ward"
+                value={createForm.ward}
+                onChange={(e) =>
+                  setCreateForm((s) => ({ ...s, ward: e.target.value }))
+                }
+                placeholder="VD: Xã Đắk Mil"
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="c-district">Huyện (cũ — để trống nếu 2 cấp)</Label>
+              <Input
+                id="c-district"
+                value={createForm.district}
+                onChange={(e) =>
+                  setCreateForm((s) => ({ ...s, district: e.target.value }))
+                }
+                placeholder="Tuỳ chọn"
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="c-kv">KV</Label>
+              <Select
+                value={createForm.area_code}
+                onValueChange={(v) =>
+                  setCreateForm((s) => ({ ...s, area_code: v }))
+                }
+              >
+                <SelectTrigger id="c-kv">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {KV_OPTIONS.map((kv) => (
+                    <SelectItem key={kv} value={kv}>
+                      {kv}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {createError && (
+              <p className="text-destructive text-sm" role="alert">
+                {createError}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)} disabled={busy}>
+              Hủy
+            </Button>
+            <Button onClick={handleCreate} disabled={busy}>
+              Tạo
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit metadata */}
+      <Dialog open={!!editRow} onOpenChange={(o) => !o && setEditRow(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Sửa thông tin xã</DialogTitle>
+            <DialogDescription>
+              Mã xã {editRow?.commune_code} · KV {editRow?.area_code}. Đổi KV
+              dùng nút &quot;Đổi KV&quot; (tạo bản ghi mới, giữ lịch sử).
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="grid gap-2">
+              <Label htmlFor="e-province">Tỉnh</Label>
+              <Input
+                id="e-province"
+                value={editForm.province}
+                onChange={(e) =>
+                  setEditForm((s) => ({ ...s, province: e.target.value }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="e-ward">Xã / Phường</Label>
+              <Input
+                id="e-ward"
+                value={editForm.ward}
+                onChange={(e) =>
+                  setEditForm((s) => ({ ...s, ward: e.target.value }))
+                }
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="e-district">Huyện (cũ)</Label>
+              <Input
+                id="e-district"
+                value={editForm.district}
+                onChange={(e) =>
+                  setEditForm((s) => ({ ...s, district: e.target.value }))
+                }
+              />
+            </div>
+            {editError && (
+              <p className="text-destructive text-sm" role="alert">
+                {editError}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditRow(null)} disabled={busy}>
+              Hủy
+            </Button>
+            <Button onClick={handleEdit} disabled={busy}>
+              Lưu
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Replace area (đổi KV) */}
+      <Dialog open={!!replaceRow} onOpenChange={(o) => !o && setReplaceRow(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Đổi KV — {replaceRow?.ward}</DialogTitle>
+            <DialogDescription>
+              KV hiện tại: <strong>{replaceRow?.area_code}</strong>. Hệ thống sẽ
+              đóng bản ghi cũ (giữ lịch sử) và tạo bản ghi KV mới áp dụng từ hôm
+              nay.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="grid gap-2">
+              <Label htmlFor="r-kv">KV mới</Label>
+              <Select value={replaceArea} onValueChange={setReplaceArea}>
+                <SelectTrigger id="r-kv">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {KV_OPTIONS.map((kv) => (
+                    <SelectItem key={kv} value={kv}>
+                      {kv}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            {replaceError && (
+              <p className="text-destructive text-sm" role="alert">
+                {replaceError}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setReplaceRow(null)} disabled={busy}>
+              Hủy
+            </Button>
+            <Button onClick={handleReplace} disabled={busy}>
+              Đổi KV
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Retire */}
+      <AlertDialog
+        open={!!retireRow}
+        onOpenChange={(o) => !o && setRetireRow(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Ngưng áp dụng KV</AlertDialogTitle>
+            <AlertDialogDescription>
+              Ngưng KV của {retireRow?.ward} ({retireRow?.commune_code})? Bản ghi
+              sẽ đóng (effective_to = hôm nay), không xoá lịch sử.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Hủy</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleRetire}
+            >
+              Ngưng
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/commune-kv/_components/ImportCommuneCsvDialog.tsx
+++ b/frontend/src/app/(dashboard)/admin/commune-kv/_components/ImportCommuneCsvDialog.tsx
@@ -104,9 +104,16 @@ export function ImportCommuneCsvDialog({ open, onOpenChange }: Props) {
               </p>
               {result.error_rows.length > 0 && (
                 <ul className="text-muted-foreground mt-2 max-h-32 list-disc overflow-auto pl-5 text-xs">
-                  {result.error_rows.slice(0, 20).map((row, i) => (
-                    <li key={i}>{JSON.stringify(row)}</li>
-                  ))}
+                  {result.error_rows.slice(0, 20).map((row, i) => {
+                    const rn = row.row_num
+                    const err = row.error
+                    return (
+                      <li key={i}>
+                        {rn != null ? `Dòng ${rn}: ` : ""}
+                        {typeof err === "string" ? err : JSON.stringify(row)}
+                      </li>
+                    )
+                  })}
                 </ul>
               )}
             </div>

--- a/frontend/src/app/(dashboard)/admin/commune-kv/_components/ImportCommuneCsvDialog.tsx
+++ b/frontend/src/app/(dashboard)/admin/commune-kv/_components/ImportCommuneCsvDialog.tsx
@@ -1,0 +1,143 @@
+/**
+ * ImportCommuneCsvDialog — upload CSV BNV → endpoint sẵn có
+ * POST /api/v2/admin/vn-locality/communes/import (idempotent).
+ *
+ * Cột CSV: commune_code,province,district,ward,area_code.
+ */
+
+"use client"
+
+import { useRef, useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+import { useImportCommuneCsv } from "@/lib/hooks/useCommuneKvAdmin"
+import { parseApiError } from "@/lib/utils/api-errors"
+import type { CsvImportResponse } from "@/lib/zod/commune-kv"
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ImportCommuneCsvDialog({ open, onOpenChange }: Props) {
+  const importMutation = useImportCommuneCsv()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [file, setFile] = useState<File | null>(null)
+  const [result, setResult] = useState<CsvImportResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const reset = () => {
+    setFile(null)
+    setResult(null)
+    setError(null)
+    if (inputRef.current) inputRef.current.value = ""
+  }
+
+  const handleImport = async () => {
+    if (!file) {
+      setError("Chọn file CSV trước")
+      return
+    }
+    setError(null)
+    try {
+      const res = await importMutation.mutateAsync(file)
+      setResult(res)
+      toast.success(
+        `Import xong: +${res.inserted} mới, ${res.skipped_existing} bỏ qua`,
+      )
+    } catch (e) {
+      setError(parseApiError(e, "Import thất bại"))
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) reset()
+        onOpenChange(o)
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Import CSV — KV theo Xã</DialogTitle>
+          <DialogDescription>
+            Cột bắt buộc: <code>commune_code,province,district,ward,area_code</code>
+            . Encode UTF-8. Idempotent — bỏ qua xã đã có dòng đang áp dụng.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="grid gap-2">
+            <Label htmlFor="csv-file">File CSV</Label>
+            <Input
+              id="csv-file"
+              ref={inputRef}
+              type="file"
+              accept=".csv"
+              onChange={(e) => {
+                setFile(e.target.files?.[0] ?? null)
+                setResult(null)
+                setError(null)
+              }}
+            />
+          </div>
+
+          {result && (
+            <div className="bg-muted/40 rounded-md border p-3 text-sm">
+              <p>
+                ✅ Thêm mới: <strong>{result.inserted}</strong> · Bỏ qua (đã có):{" "}
+                <strong>{result.skipped_existing}</strong> · Lỗi dòng:{" "}
+                <strong>{result.error_rows.length}</strong>
+              </p>
+              {result.error_rows.length > 0 && (
+                <ul className="text-muted-foreground mt-2 max-h-32 list-disc overflow-auto pl-5 text-xs">
+                  {result.error_rows.slice(0, 20).map((row, i) => (
+                    <li key={i}>{JSON.stringify(row)}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {error && (
+            <p className="text-destructive text-sm" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              reset()
+              onOpenChange(false)
+            }}
+            disabled={importMutation.isPending}
+          >
+            Đóng
+          </Button>
+          <Button
+            onClick={handleImport}
+            disabled={importMutation.isPending || !file}
+          >
+            {importMutation.isPending ? "Đang import…" : "Import"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/commune-kv/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/commune-kv/page.tsx
@@ -1,0 +1,26 @@
+/**
+ * Admin — Quản lý KV theo Xã (vn_commune_area_map) — PR-A.
+ *
+ * Thin Suspense wrapper. Admin auth enforced by BE (`require_admin` trên mọi
+ * endpoint) + nav role filter (`roles:["admin"]`).
+ */
+import { Suspense } from "react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+
+import { CommuneKvClient } from "./_components/CommuneKvClient"
+
+export default function CommuneKvPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="container mx-auto space-y-4 p-6">
+          <Skeleton className="h-10 w-1/3" />
+          <Skeleton className="h-[500px] w-full" />
+        </div>
+      }
+    >
+      <CommuneKvClient />
+    </Suspense>
+  )
+}

--- a/frontend/src/lib/api/admin-commune-kv.ts
+++ b/frontend/src/lib/api/admin-commune-kv.ts
@@ -1,0 +1,109 @@
+/**
+ * Admin Commune KV API Client (PR-A).
+ *
+ * Mirrors `Backend_FastAPI/app/routers/admin_vn_locality.py` commune CRUD.
+ * All endpoints sit behind `require_admin`. Base: `/api/v2/admin/vn-locality`.
+ */
+
+import { api } from "@/lib/api/client"
+
+import type {
+  CommuneAreaCreate,
+  CommuneAreaListResponse,
+  CommuneAreaResponse,
+  CommuneAreaUpdate,
+  CommuneReplaceArea,
+  CsvImportResponse,
+} from "@/lib/zod/commune-kv"
+
+const BASE = "/api/v2/admin/vn-locality"
+
+export interface ListCommunesParams {
+  province?: string | null
+  q?: string | null
+  activeOnly?: boolean
+  page?: number
+  pageSize?: number
+}
+
+export async function listCommunes(
+  params: ListCommunesParams = {},
+): Promise<CommuneAreaListResponse> {
+  const { data } = await api.get<CommuneAreaListResponse>(`${BASE}/communes`, {
+    params: {
+      // province = TÊN tỉnh (vn_commune_area_map.province là text), KHÔNG mã.
+      province: params.province || undefined,
+      q: params.q || undefined,
+      active_only: params.activeOnly ?? true,
+      page: params.page ?? 1,
+      page_size: params.pageSize ?? 50,
+    },
+  })
+  return data
+}
+
+export async function createCommune(
+  payload: CommuneAreaCreate,
+): Promise<CommuneAreaResponse> {
+  const { data } = await api.post<CommuneAreaResponse>(
+    `${BASE}/communes`,
+    payload,
+  )
+  return data
+}
+
+export async function updateCommune(
+  id: number,
+  payload: CommuneAreaUpdate,
+): Promise<CommuneAreaResponse> {
+  const { data } = await api.patch<CommuneAreaResponse>(
+    `${BASE}/communes/${id}`,
+    payload,
+  )
+  return data
+}
+
+/** Đổi KV temporal — trả dòng active MỚI (BE retire dòng cũ). */
+export async function replaceCommuneArea(
+  id: number,
+  payload: CommuneReplaceArea,
+): Promise<CommuneAreaResponse> {
+  const { data } = await api.post<CommuneAreaResponse>(
+    `${BASE}/communes/${id}/replace-area`,
+    payload,
+  )
+  return data
+}
+
+export async function retireCommune(
+  id: number,
+): Promise<CommuneAreaResponse> {
+  const { data } = await api.delete<CommuneAreaResponse>(
+    `${BASE}/communes/${id}`,
+  )
+  return data
+}
+
+export async function importCommuneCsv(
+  file: File,
+): Promise<CsvImportResponse> {
+  const fd = new FormData()
+  fd.append("file", file)
+  const { data } = await api.post<CsvImportResponse>(
+    `${BASE}/communes/import`,
+    fd,
+    { headers: { "Content-Type": "multipart/form-data" } },
+  )
+  return data
+}
+
+export const adminCommuneKvApi = {
+  listCommunes,
+  createCommune,
+  updateCommune,
+  replaceCommuneArea,
+  retireCommune,
+  importCommuneCsv,
+}
+
+export default adminCommuneKvApi

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -23,6 +23,7 @@ import {
   Handshake,
   History,
   LayoutDashboard,
+  MapPin,
   Percent,
   Receipt,
   RotateCcw,
@@ -272,6 +273,14 @@ export const navigationConfig: NavigationConfig = {
           label: "Cấu hình Ưu tiên",
           href: "/admin/priority-config",
           icon: Calculator,
+          roles: ["admin"],
+        },
+        {
+          // PR-A — quản lý danh mục KV theo xã (vn_commune_area_map). Admin-only
+          // (BE require_admin trên mọi endpoint).
+          label: "KV theo Xã",
+          href: "/admin/commune-kv",
+          icon: MapPin,
           roles: ["admin"],
         },
         {

--- a/frontend/src/lib/hooks/useCommuneKvAdmin.ts
+++ b/frontend/src/lib/hooks/useCommuneKvAdmin.ts
@@ -1,0 +1,80 @@
+/**
+ * React Query hooks for admin commune KV CRUD (PR-A).
+ *
+ * Query key includes the full filter/pagination params so each
+ * page/province/search combo caches independently. Mutations invalidate the
+ * whole `commune-kv` tree (any write can shift pagination/totals).
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import {
+  createCommune,
+  importCommuneCsv,
+  listCommunes,
+  replaceCommuneArea,
+  retireCommune,
+  updateCommune,
+  type ListCommunesParams,
+} from "@/lib/api/admin-commune-kv"
+import type {
+  CommuneAreaCreate,
+  CommuneAreaUpdate,
+  CommuneReplaceArea,
+} from "@/lib/zod/commune-kv"
+
+export const communeKvKeys = {
+  all: ["commune-kv"] as const,
+  list: (params: ListCommunesParams) =>
+    [...communeKvKeys.all, "list", params] as const,
+}
+
+export function useCommunes(params: ListCommunesParams) {
+  return useQuery({
+    queryKey: communeKvKeys.list(params),
+    queryFn: () => listCommunes(params),
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useCreateCommune() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: CommuneAreaCreate) => createCommune(data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: communeKvKeys.all }),
+  })
+}
+
+export function useUpdateCommune() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: CommuneAreaUpdate }) =>
+      updateCommune(id, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: communeKvKeys.all }),
+  })
+}
+
+export function useReplaceCommuneArea() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: CommuneReplaceArea }) =>
+      replaceCommuneArea(id, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: communeKvKeys.all }),
+  })
+}
+
+export function useRetireCommune() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => retireCommune(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: communeKvKeys.all }),
+  })
+}
+
+export function useImportCommuneCsv() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (file: File) => importCommuneCsv(file),
+    onSuccess: () => qc.invalidateQueries({ queryKey: communeKvKeys.all }),
+  })
+}

--- a/frontend/src/lib/zod/commune-kv.ts
+++ b/frontend/src/lib/zod/commune-kv.ts
@@ -1,0 +1,97 @@
+/**
+ * Zod schemas for admin commune KV CRUD (PR-A).
+ *
+ * Mirrors `Backend_FastAPI/app/schemas/vn_locality.py` commune admin shapes
+ * + the migration CHECK regex on `area_code` so a typo fails Zod BEFORE the
+ * round-trip. Reuses `AREA_CODE_REGEX` from priority-config (single source).
+ *
+ * Temporal model: đổi KV đi qua `/replace-area` (retire dòng cũ + insert mới),
+ * KHÔNG sửa `area_code` qua PATCH.
+ */
+import { z } from "zod"
+
+import { AREA_CODE_REGEX } from "@/lib/zod/priority-config"
+
+const dateField = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Định dạng phải là YYYY-MM-DD")
+
+const areaCodeField = z
+  .string()
+  .regex(AREA_CODE_REGEX, "Mã KV không hợp lệ (VD: KV1, KV2-NT, KV3)")
+
+// ==============================================================================
+// CREATE
+// ==============================================================================
+
+export const communeAreaCreateSchema = z.object({
+  commune_code: z.string().min(1, "Mã xã bắt buộc").max(20),
+  province: z.string().min(1, "Tỉnh bắt buộc").max(100),
+  district: z.string().max(100).optional(),
+  ward: z.string().min(1, "Tên xã/phường bắt buộc").max(100),
+  area_code: areaCodeField,
+  effective_from: dateField.nullable().optional(),
+})
+
+export type CommuneAreaCreate = z.infer<typeof communeAreaCreateSchema>
+
+// ==============================================================================
+// UPDATE (PATCH metadata — KHÔNG có area_code/commune_code)
+// ==============================================================================
+
+export const communeAreaUpdateSchema = z.object({
+  province: z.string().min(1).max(100).optional(),
+  district: z.string().max(100).optional(),
+  ward: z.string().min(1).max(100).optional(),
+  // effective_to=null tường minh = re-activate (BE chặn nếu 2 active).
+  effective_to: dateField.nullable().optional(),
+})
+
+export type CommuneAreaUpdate = z.infer<typeof communeAreaUpdateSchema>
+
+// ==============================================================================
+// REPLACE AREA (đổi KV temporal)
+// ==============================================================================
+
+export const communeReplaceAreaSchema = z.object({
+  area_code: areaCodeField,
+  effective_from: dateField.nullable().optional(),
+})
+
+export type CommuneReplaceArea = z.infer<typeof communeReplaceAreaSchema>
+
+// ==============================================================================
+// RESPONSE
+// ==============================================================================
+
+export const communeAreaResponseSchema = z.object({
+  id: z.number().int().positive(),
+  commune_code: z.string(),
+  province: z.string(),
+  district: z.string(),
+  ward: z.string(),
+  area_code: z.string(),
+  effective_from: z.string(),
+  effective_to: z.string().nullable(),
+})
+
+export type CommuneAreaResponse = z.infer<typeof communeAreaResponseSchema>
+
+export const communeAreaListResponseSchema = z.object({
+  items: z.array(communeAreaResponseSchema),
+  total: z.number().int().min(0),
+  page: z.number().int().min(1),
+  page_size: z.number().int().min(1),
+})
+
+export type CommuneAreaListResponse = z.infer<
+  typeof communeAreaListResponseSchema
+>
+
+export const csvImportResponseSchema = z.object({
+  inserted: z.number().int().min(0),
+  skipped_existing: z.number().int().min(0),
+  error_rows: z.array(z.record(z.string(), z.unknown())),
+})
+
+export type CsvImportResponse = z.infer<typeof csvImportResponseSchema>


### PR DESCRIPTION
## Mục tiêu (PR-A của plan Admin UI quản lý danh mục KV)
Admin chưa có UI quản lý `vn_commune_area_map` (chỉ có CSV import + lookup) → mọi thêm/sửa KV theo xã phải qua script/SQL/CSV thủ công. PR-A thêm **CRUD đầy đủ + đổi KV theo kiểu temporal** (giữ lịch sử) để vận hành tự chủ. Copy pattern `admin/priority-config`. **KHÔNG migration** (bảng đã tồn tại).

## Backend (mở rộng `admin_vn_locality`, `require_admin` mọi endpoint)
5 endpoint `/api/v2/admin/vn-locality/communes`:
- `GET` list (paginated + `province`/`q`/`active_only`)
- `POST` create (chặn dup active/commune_code)
- `PATCH {id}` metadata (province/district/ward/effective_to — **KHÔNG đổi area_code**)
- `POST {id}/replace-area` — **đổi KV temporal**: retire dòng cũ (`effective_to`=cutover) + insert dòng active mới
- `DELETE {id}` — retire (soft-close, KHÔNG hard-delete)

`VnLocalityService` +5 method (direct `db.execute` theo pattern file, semantics temporal/`(result,callback)`/domain-exception của priority_config_service) + guard `effective_to >= effective_from` (model thiếu CHECK interval). Schemas Create/Update/ReplaceArea/ListResponse.

## Frontend (trang `/admin/commune-kv` — group Organization, `roles:["admin"]`)
- `zod/commune-kv` (tái dùng `AREA_CODE_REGEX`) + `api/admin-commune-kv` + `hooks/useCommuneKvAdmin`.
- page Suspense → **CommuneKvClient** (lọc tỉnh theo TÊN + search debounce + active toggle + pagination + Import CSV) → **CommuneKvTable** (Thêm / Sửa / **Đổi KV** / Ngưng) → **ImportCommuneCsvDialog**. Dùng `parseApiError`. Nav entry "KV theo Xã".

## Verify
- ✅ **21 pytest** (15 unit `test_vn_locality_admin_service` + 6 API smoke `test_admin_vn_locality_communes`: lifecycle/dup-409/404/patch-ignore-area/invalid-422/non-admin-403/re-activate/guard-interval)
- ✅ flake8 net-zero + FE type-check/lint sạch
- ✅ **Chrome smoke dev**: list **361 dòng** + Thêm xã + **Đổi KV chứng minh temporal** (DB: row mới KV1 active + row cũ KV3 retired, KHÔNG mutate area_code cũ)
- ✅ **/code-review xhigh** đã vá: guard interval + busy/retire + test re-activate + 3 UX cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)