### PR TITLE
feat(admin-kv): UI quản lý Trường THPT (vn_school) + KV-assignment + chuẩn hóa KV (PR-B)

### DIFF
--- a/Backend_FastAPI/alembic/versions/schoolkv01_20260610_add_moet_code_commune_code.py
+++ b/Backend_FastAPI/alembic/versions/schoolkv01_20260610_add_moet_code_commune_code.py
@@ -1,0 +1,71 @@
+"""vn_school: add moet_code + commune_code (khóa đối chiếu MOET/QĐ19-2025)
+
+Revision ID: schoolkv01_20260610
+Revises: optdocmat01_20260610
+Create Date: 2026-06-10
+
+Thêm 2 cột khóa đối chiếu cho ``vn_school``, phục vụ rebuild KV trường từ danh
+sách THPT chính thức của MOET (file XLS có Khu Vực + Mã Xã theo QĐ 19/2025) và
+đối chiếu ổn định cho các lần cập nhật năm sau:
+
+- ``moet_code``    : mã chính thức = Mã Tỉnh (GSO, 2 số) + Mã Trường (3 số) = 5
+                     số (vd '66006' = THPT Buôn Ma Thuột). DUY NHẤT toàn quốc
+                     trong danh sách MOET. Khóa đối chiếu CHÍNH cho năm sau.
+- ``commune_code`` : mã xã 5 số (= Mã Xã[:5] của XLS, khớp 98%
+                     administrative_nodes.code hiện hành). Khóa PHỤ: fallback
+                     (commune_code + tên) khi MOET đổi số trường, đồng thời nối
+                     trường → xã để reconcile vn_commune_area_map.
+
+Cả 2 nullable (backfill bằng script rebuild_school_kv_from_xls.py, không chặn
+dữ liệu cũ). KHÔNG unique-constraint cứng ở DB: dữ liệu hiện có nhiều bản ghi
+cũ/dup chưa chuẩn hóa (trước/từ rename) → unique sẽ vỡ; dedup/chuẩn hóa do
+script xử lý trước, ràng buộc unique để PR sau khi data đã sạch. Chỉ thêm INDEX
+để tra nhanh.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "schoolkv01_20260610"
+down_revision: Union[str, None] = "optdocmat01_20260610"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "vn_school",
+        sa.Column(
+            "moet_code",
+            sa.String(length=8),
+            nullable=True,
+            comment=(
+                "Mã chính thức MOET = Mã Tỉnh(GSO 2) + Mã Trường(3); "
+                "khóa đối chiếu chính"
+            ),
+        ),
+    )
+    op.add_column(
+        "vn_school",
+        sa.Column(
+            "commune_code",
+            sa.String(length=10),
+            nullable=True,
+            comment=(
+                "Mã xã 5 số (QĐ 19/2025, = administrative_nodes.code); "
+                "khóa phụ + nối xã"
+            ),
+        ),
+    )
+    op.create_index("ix_vn_school_moet_code", "vn_school", ["moet_code"])
+    op.create_index("ix_vn_school_commune_code", "vn_school", ["commune_code"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_vn_school_commune_code", table_name="vn_school")
+    op.drop_index("ix_vn_school_moet_code", table_name="vn_school")
+    op.drop_column("vn_school", "commune_code")
+    op.drop_column("vn_school", "moet_code")

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -45,6 +45,7 @@ from .routers import (
     admin_v2_path_subject_group,  # ✅ #184 Phase 2 v8.2 PR-2D: path-level subject group config + clone endpoint
     admin_priority_config,  # ✅ Q9 #07 PR3: priority KV/UT bonus configs per year + clone + seed TT 05/2021
     admin_vn_locality,  # ✅ Q9 #07 PR4: commune + high school CSV import + dropdown search
+    admin_vn_school,  # PR-B: admin CRUD vn_school + KV assignment
     vn_school,  # ✅ Q9 #07 Phase D.0b: public school search (candidate FE)
     admin_v2_system_config,  # ✅ #184 PR-1D / phase1_13: admin runtime config
     admin_backfill,  # ✅ #184 Phase 3 PR-3D-B BE-2: admin backfill exception queue (Q-P3-09)
@@ -887,6 +888,7 @@ fastapi_app.include_router(admin_v2_admission_round.router)  # ✅ #184 Phase 2 
 fastapi_app.include_router(admin_v2_path_subject_group.router)  # ✅ #184 Phase 2 v8.2 PR-2D: path-level subject group config + clone
 fastapi_app.include_router(admin_priority_config.router)  # ✅ Q9 #07 PR3: priority KV/UT configs (router declares full prefix)
 fastapi_app.include_router(admin_vn_locality.admin_router)  # ✅ Q9 #07 PR4: admin commune CSV import
+fastapi_app.include_router(admin_vn_school.admin_router)  # PR-B: admin vn_school + KV assignment CRUD
 fastapi_app.include_router(vn_school.router)  # ✅ Q9 #07 Phase D.0b: public search (candidate FE dropdown)
 fastapi_app.include_router(document_groups.router, prefix="/api")  # ✅ PHASE A.3: DocumentGroup CRUD
 fastapi_app.include_router(config_data.router, prefix="/api") # ✅ NEW: Config Data

--- a/Backend_FastAPI/app/models/vn_school.py
+++ b/Backend_FastAPI/app/models/vn_school.py
@@ -82,6 +82,13 @@ class VnSchool(Base):
     )
     moet_district_code: Mapped[Optional[str]] = mapped_column(String(5), nullable=True)
 
+    # Khóa đối chiếu chuẩn hóa (schoolkv01) — nguồn: danh sách THPT MOET + QĐ 19/2025.
+    # moet_code = Mã Tỉnh(GSO 2) + Mã Trường(3) = 5 số, duy nhất toàn quốc → khóa
+    # đối chiếu CHÍNH khi cập nhật năm sau. commune_code = mã xã 5 số (QĐ 19/2025,
+    # = administrative_nodes.code) → khóa PHỤ (fallback commune+tên) + nối trường→xã.
+    moet_code: Mapped[Optional[str]] = mapped_column(String(8), nullable=True)
+    commune_code: Mapped[Optional[str]] = mapped_column(String(10), nullable=True)
+
     # Canonical current info
     name: Mapped[str] = mapped_column(
         String(255),

--- a/Backend_FastAPI/app/routers/admin_vn_school.py
+++ b/Backend_FastAPI/app/routers/admin_vn_school.py
@@ -1,0 +1,288 @@
+# app/routers/admin_vn_school.py
+"""Admin CRUD endpoints cho vn_school + vn_school_kv_assignment (PR-B).
+
+Prefix ``/api/v2/admin/vn-school`` (bổ trợ public ``/api/v2/vn-school/search``).
+Tất cả ``require_admin`` (danh mục quy chế, không per-unit). DELETE school =
+deactivate (``is_active=false``), KHÔNG hard-delete (FK
+``vn_school_kv_assignment.school_id`` CASCADE).
+"""
+import structlog
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database
+from app.core.deps import require_admin
+from app.models.vn_school import VnSchool
+from app.schemas.vn_locality import (
+    CsvImportResponse,
+    VnSchoolAdminResponse,
+    VnSchoolCreate,
+    VnSchoolKvAssignmentCreate,
+    VnSchoolKvAssignmentResponse,
+    VnSchoolKvAssignmentUpdate,
+    VnSchoolListResponse,
+    VnSchoolProvinceItem,
+    VnSchoolUpdate,
+)
+from app.services.vn_school_service import VnSchoolService
+
+log = structlog.get_logger(__name__)
+
+MAX_CSV_SIZE_BYTES = 10 * 1024 * 1024
+
+admin_router = APIRouter(
+    prefix="/api/v2/admin/vn-school",
+    tags=["Admin v2 - VN School"],
+)
+
+
+def _school_resp(school: VnSchool, current_kv) -> VnSchoolAdminResponse:
+    return VnSchoolAdminResponse(
+        id=school.id,
+        moet_school_code=school.moet_school_code,
+        moet_province_code=school.moet_province_code,
+        moet_district_code=school.moet_district_code,
+        name=school.name,
+        address=school.address,
+        province=school.province,
+        district=school.district,
+        ward=school.ward,
+        level=school.level,
+        is_dtnt=school.is_dtnt,
+        is_active=school.is_active,
+        current_kv=current_kv,
+    )
+
+
+# =============================================================================
+# Schools
+# =============================================================================
+
+
+@admin_router.get("/schools", response_model=VnSchoolListResponse)
+async def list_schools(
+    moet_province_code: str | None = None,
+    level: str | None = None,
+    q: str | None = None,
+    active_only: bool = True,
+    page: int = 1,
+    page_size: int = 50,
+    db: AsyncSession = Depends(database.get_db),
+    _user=Depends(require_admin),
+) -> VnSchoolListResponse:
+    service = VnSchoolService(db)
+    rows, total = await service.list_schools(
+        moet_province_code=moet_province_code,
+        level=level,
+        q=q,
+        active_only=active_only,
+        page=page,
+        page_size=page_size,
+    )
+    return VnSchoolListResponse(
+        items=[VnSchoolAdminResponse.model_validate(r) for r in rows],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@admin_router.get("/provinces", response_model=list[VnSchoolProvinceItem])
+async def list_school_provinces(
+    db: AsyncSession = Depends(database.get_db),
+    _user=Depends(require_admin),
+) -> list[VnSchoolProvinceItem]:
+    service = VnSchoolService(db)
+    rows = await service.list_school_provinces()
+    return [VnSchoolProvinceItem.model_validate(r) for r in rows]
+
+
+@admin_router.post(
+    "/schools",
+    response_model=VnSchoolAdminResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_school(
+    payload: VnSchoolCreate,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> VnSchoolAdminResponse:
+    service = VnSchoolService(db)
+    school, callback = await service.create_school(payload.model_dump())
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "vn_school_created",
+        id=school.id,
+        moet_code=school.moet_school_code,
+        actor=user.id,
+    )
+    return _school_resp(school, await service.current_kv(school.id))
+
+
+@admin_router.patch(
+    "/schools/{school_id}",
+    response_model=VnSchoolAdminResponse,
+)
+async def update_school(
+    school_id: int,
+    payload: VnSchoolUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> VnSchoolAdminResponse:
+    service = VnSchoolService(db)
+    school, callback = await service.update_school(
+        school_id, payload.model_dump(exclude_unset=True)
+    )
+    await db.commit()
+    if callback:
+        await callback()
+    log.info("vn_school_updated", id=school.id, actor=user.id)
+    return _school_resp(school, await service.current_kv(school.id))
+
+
+@admin_router.delete(
+    "/schools/{school_id}",
+    response_model=VnSchoolAdminResponse,
+)
+async def deactivate_school(
+    school_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> VnSchoolAdminResponse:
+    """DELETE = deactivate (is_active=false). KHÔNG hard-delete."""
+    service = VnSchoolService(db)
+    school, callback = await service.deactivate_school(school_id)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info("vn_school_deactivated", id=school.id, actor=user.id)
+    return _school_resp(school, await service.current_kv(school.id))
+
+
+@admin_router.post(
+    "/schools/import",
+    response_model=CsvImportResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def import_schools_csv(
+    file: UploadFile = File(...),
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> CsvImportResponse:
+    """Bulk import trường (CSV UTF-8). Cột: moet_school_code, moet_province_code,
+    name, province, level (+ tuỳ chọn). Idempotent. KV assignment qua endpoint
+    /kv (KHÔNG qua CSV)."""
+    if not file.filename or not file.filename.lower().endswith(".csv"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File phải có đuôi .csv",
+        )
+    if file.size is not None and file.size > MAX_CSV_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"CSV vượt {MAX_CSV_SIZE_BYTES // (1024 * 1024)}MB",
+        )
+    csv_bytes = await file.read()
+    if len(csv_bytes) > MAX_CSV_SIZE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"CSV vượt {MAX_CSV_SIZE_BYTES // (1024 * 1024)}MB",
+        )
+    service = VnSchoolService(db)
+    result, callback = await service.import_schools_csv(csv_bytes)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "vn_school_csv_imported",
+        inserted=result["inserted"],
+        skipped=result["skipped_existing"],
+        error_count=len(result["error_rows"]),
+        actor=user.id,
+    )
+    return CsvImportResponse(**result)
+
+
+# =============================================================================
+# KV assignment (per school)
+# =============================================================================
+
+
+@admin_router.get(
+    "/schools/{school_id}/kv",
+    response_model=list[VnSchoolKvAssignmentResponse],
+)
+async def list_kv_assignments(
+    school_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    _user=Depends(require_admin),
+) -> list[VnSchoolKvAssignmentResponse]:
+    service = VnSchoolService(db)
+    rows = await service.list_kv_assignments(school_id)
+    return [VnSchoolKvAssignmentResponse.model_validate(r) for r in rows]
+
+
+@admin_router.post(
+    "/schools/{school_id}/kv",
+    response_model=VnSchoolKvAssignmentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_kv_assignment(
+    school_id: int,
+    payload: VnSchoolKvAssignmentCreate,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> VnSchoolKvAssignmentResponse:
+    service = VnSchoolService(db)
+    row, callback = await service.add_kv_assignment(school_id, payload.model_dump())
+    await db.commit()
+    if callback:
+        await callback()
+    log.info(
+        "vn_school_kv_added",
+        id=row.id,
+        school_id=school_id,
+        kv=row.kv_code,
+        actor=user.id,
+    )
+    return VnSchoolKvAssignmentResponse.model_validate(row)
+
+
+@admin_router.patch(
+    "/kv/{assignment_id}",
+    response_model=VnSchoolKvAssignmentResponse,
+)
+async def update_kv_assignment(
+    assignment_id: int,
+    payload: VnSchoolKvAssignmentUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> VnSchoolKvAssignmentResponse:
+    service = VnSchoolService(db)
+    row, callback = await service.update_kv_assignment(
+        assignment_id, payload.model_dump(exclude_unset=True)
+    )
+    await db.commit()
+    if callback:
+        await callback()
+    log.info("vn_school_kv_updated", id=row.id, actor=user.id)
+    return VnSchoolKvAssignmentResponse.model_validate(row)
+
+
+@admin_router.delete(
+    "/kv/{assignment_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_kv_assignment(
+    assignment_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    user=Depends(require_admin),
+) -> None:
+    service = VnSchoolService(db)
+    _row, callback = await service.delete_kv_assignment(assignment_id)
+    await db.commit()
+    if callback:
+        await callback()
+    log.info("vn_school_kv_deleted", id=assignment_id, actor=user.id)

--- a/Backend_FastAPI/app/schemas/vn_locality.py
+++ b/Backend_FastAPI/app/schemas/vn_locality.py
@@ -7,7 +7,7 @@ Both shape mirror the migration phase1_08b column set. Read endpoints
 from __future__ import annotations
 
 from datetime import date
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -118,3 +118,105 @@ class VnSchoolSearchResponse(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+# =============================================================================
+# Admin CRUD trường học (PR-B). Co-locate ở đây (cùng file VnSchoolSearchItem).
+# DELETE school = deactivate (is_active=false), KHÔNG hard-delete (FK
+# vn_school_kv_assignment.school_id CASCADE). merged_into_id/merge_effective_date
+# read-only (để script merger lo) — KHÔNG trong CRUD.
+# =============================================================================
+
+VnSchoolLevel = Literal["THCS", "THPT", "THCS_THPT", "TRUNG_HOC_NGHE", "OTHER"]
+_KV_CODE_PATTERN = r"^KV[1-9](-NT)?$"
+
+
+class VnSchoolCreate(BaseModel):
+    moet_school_code: str = Field(min_length=1, max_length=10)
+    moet_province_code: str = Field(min_length=1, max_length=3)
+    moet_district_code: Optional[str] = Field(default=None, max_length=5)
+    name: str = Field(min_length=1, max_length=255)
+    address: Optional[str] = None
+    province: str = Field(min_length=1, max_length=100)
+    district: Optional[str] = Field(default=None, max_length=100)
+    ward: Optional[str] = Field(default=None, max_length=100)
+    level: VnSchoolLevel
+    is_dtnt: bool = False
+
+
+class VnSchoolUpdate(BaseModel):
+    """PATCH — KHÔNG đổi moet_school_code/moet_province_code (định danh MOET) và
+    KHÔNG đổi is_active (dùng DELETE=deactivate)."""
+
+    moet_district_code: Optional[str] = Field(default=None, max_length=5)
+    name: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    address: Optional[str] = None
+    province: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    district: Optional[str] = Field(default=None, max_length=100)
+    ward: Optional[str] = Field(default=None, max_length=100)
+    level: Optional[VnSchoolLevel] = None
+    is_dtnt: Optional[bool] = None
+
+
+class VnSchoolAdminResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    moet_school_code: str
+    moet_province_code: str
+    moet_district_code: Optional[str] = None
+    name: str
+    address: Optional[str] = None
+    province: str
+    district: Optional[str] = None
+    ward: Optional[str] = None
+    level: str
+    is_dtnt: bool
+    is_active: bool
+    current_kv: Optional[str] = None
+
+
+class VnSchoolListResponse(BaseModel):
+    items: list[VnSchoolAdminResponse]
+    total: int
+    page: int
+    page_size: int
+
+
+class VnSchoolProvinceItem(BaseModel):
+    """Distinct {moet_province_code, province} từ vn_school active — cho FE filter
+    (administrative getProvinces KHÔNG có moet_province_code)."""
+
+    moet_province_code: str
+    province: str
+
+
+# --- KV assignment (vn_school_kv_assignment) ---
+
+
+class VnSchoolKvAssignmentCreate(BaseModel):
+    kv_code: str = Field(pattern=_KV_CODE_PATTERN)
+    effective_from_year: int = Field(ge=2000, le=2100)
+    effective_to_year: Optional[int] = Field(default=None, ge=2000, le=2100)
+    source: str = Field(default="manual_admin", min_length=1, max_length=50)
+    notes: Optional[str] = None
+
+
+class VnSchoolKvAssignmentUpdate(BaseModel):
+    kv_code: Optional[str] = Field(default=None, pattern=_KV_CODE_PATTERN)
+    effective_from_year: Optional[int] = Field(default=None, ge=2000, le=2100)
+    effective_to_year: Optional[int] = Field(default=None, ge=2000, le=2100)
+    source: Optional[str] = Field(default=None, min_length=1, max_length=50)
+    notes: Optional[str] = None
+
+
+class VnSchoolKvAssignmentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    school_id: int
+    kv_code: str
+    effective_from_year: int
+    effective_to_year: Optional[int] = None
+    source: str
+    notes: Optional[str] = None

--- a/Backend_FastAPI/app/scripts/rebuild_school_kv_from_xls.py
+++ b/Backend_FastAPI/app/scripts/rebuild_school_kv_from_xls.py
@@ -1,0 +1,374 @@
+"""PHỦ DATA MỚI: nạp toàn bộ catalog trường THPT từ XLS chính thức MOET (QĐ 60 + TT05).
+
+Quyết định (vì trường có ĐỔI TÊN → match-tên không tin cậy):
+  ĐỢT 1 (script này):
+    1) INSERT toàn bộ trường vùng target từ XLS — catalog SẠCH mới (moet_code +
+       commune_code + KV chuẩn, source=moet_thpt_2026_qd60).
+    2) XÓA CỨNG (DELETE) TOÀN BỘ bản ghi cũ vùng target (CASCADE kéo theo
+       kv_assignment + name_history) → dropdown chỉ còn catalog sạch; hồ sơ MỚI
+       chọn = đúng ngay. (academic_history JSONB của hồ sơ cũ KHÔNG có FK cứng →
+       school_id dangling, resolve graceful + officer chọn lại.)
+    3) FIX dòng ACTIVE + ADD commune mới vn_commune_area_map theo KV suy từ XLS
+       (khóa = mã xã; CHỈ đụng dòng effective_to IS NULL; ADD lấy ward/tỉnh từ
+       administrative_nodes hiện hành — không resolve được thì CẢNH BÁO + bỏ
+       qua để thêm tay qua /admin/commune-kv). KV3 không lưu (= default vắng mặt).
+  ĐỢT 2 (backfill — script riêng, làm SAU):
+    Re-link academic_history của các hồ sơ ĐÃ chọn (school_id cũ → bản ghi mới),
+    khớp theo commune_code + fuzzy/tay (vì đổi tên). Script này CHỈ liệt kê
+    danh sách cần backfill, KHÔNG đụng.
+
+KV mới: effective_from_year=2000 (sentinel; KV trường hằng số; resolve được cả
+engine năm-học lẫn năm-tuyển-sinh), effective_to_year=NULL.
+
+CHẾ ĐỘ:
+  --dry-run (mặc định): đọc --source + --state-dir (dump prod), KHÔNG DB, KHÔNG ghi.
+  --apply: kết nối DB, 1 transaction, idempotent theo moet_code. Chạy sau backup+duyệt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from collections import Counter, defaultdict
+
+KV_EFFECTIVE_FROM = 2000
+SOURCE_OF = "moet_thpt_2026_qd60"
+# Tỉnh cũ (DB) -> GSO hiện hành (XLS)
+OLD_TO_GSO = {
+    "Đắk Lắk": "66",
+    "Phú Yên": "66",
+    "Gia Lai": "52",
+    "Bình Định": "52",
+    "Lâm Đồng": "68",
+    "Đắk Nông": "68",
+    "Bình Thuận": "68",
+}
+
+
+REQUIRED_SOURCE_COLS = {
+    "gso", "moet_code", "commune_code", "kv", "name", "province",
+}
+
+
+def nkv(k: str) -> str:
+    return str(k).strip().upper().replace("_", "-")
+
+
+def read_csv(path):
+    if not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8") as f:
+        return [r for r in csv.reader(f) if r]
+
+
+def load_source(path):
+    """Đọc source.csv + validate cột bắt buộc + chuẩn hóa kv NGAY khi nạp
+    (mọi downstream — dry_run/apply/commune — thấy KV canonical 'KV2-NT')."""
+    with open(path, encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        missing = REQUIRED_SOURCE_COLS - set(reader.fieldnames or [])
+        if missing:
+            raise SystemExit(
+                f"source CSV thiếu cột bắt buộc: {', '.join(sorted(missing))}"
+            )
+        rows = list(reader)
+    for r in rows:
+        r["kv"] = nkv(r.get("kv") or "")
+    return rows
+
+
+def commune_plan(src_t, map_now):
+    """Trả (fix, add): sửa/thêm vn_commune_area_map theo KV suy từ XLS."""
+    sck = defaultdict(Counter)
+    for s in src_t:
+        if s["commune_code"]:
+            sck[s["commune_code"]][s["kv"]] += 1
+    fix, add = [], []
+    for cc, ctr in sck.items():
+        want = ctr.most_common(1)[0][0]
+        cur = map_now.get(cc)
+        if cur is None:
+            if want in ("KV1", "KV2", "KV2-NT"):
+                add.append((cc, want))
+        elif cur != want:
+            fix.append((cc, cur, want))
+    return fix, add
+
+
+def dry_run(args) -> int:
+    src = load_source(args.source)
+    provinces = set(p.strip() for p in args.provinces.split(","))
+    src_t = [s for s in src if s["gso"] in provinces]
+
+    schools = read_csv(os.path.join(args.state_dir, "schools.csv"))
+    cmap = read_csv(os.path.join(args.state_dir, "commune_map.csv"))
+    prof = read_csv(os.path.join(args.state_dir, "profile_schools.csv"))
+
+    db_region = [
+        (r + [""] * 7)[:7]
+        for r in schools
+        if (r + [""] * 7)[6].lower() in ("t", "true", "1")
+        and OLD_TO_GSO.get((r + [""] * 7)[2].strip()) in provinces
+    ]
+    map_now = {r[0]: nkv(r[3]) for r in cmap}
+    cfix, cadd = commune_plan(src_t, map_now)
+
+    sel_ids = set(r[2] for r in prof if len(r) >= 3 and r[2])
+    sch_by_id = {r[0]: r for r in db_region}
+    backfill = [sch_by_id[sid] for sid in sel_ids if sid in sch_by_id]
+
+    print("=" * 70)
+    print(f"PHỦ DATA MỚI (blanket) — DRY-RUN | GSO={sorted(provinces)}")
+    print("=" * 70)
+    print(
+        f"[1] INSERT trường mới từ XLS     : {len(src_t)}  "
+        f"(KV {dict(Counter(s['kv'] for s in src_t))})"
+    )
+    print(
+        f"      effective_from={KV_EFFECTIVE_FROM}, effective_to=NULL, "
+        f"source={SOURCE_OF}"
+    )
+    print(
+        f"[2] XÓA CỨNG bản ghi cũ          : {len(db_region)} "
+        f"(toàn bộ vùng target; CASCADE kv+name_history)"
+    )
+    print(f"[3] commune_area_map  SỬA={len(cfix)} | THÊM={len(cadd)}")
+    print(
+        f"[4] HỒ SƠ DANGLING (officer chọn lại): {len(backfill)} "
+        f"trường đã chọn sẽ mất link"
+    )
+    for r in backfill:
+        print(f"        school_id={r[0]:>4} | {r[1][:40]:42} | {r[2]}")
+    print("-" * 70)
+    print(f"=> active sau ĐỢT 1 = {len(src_t)} (catalog XLS sạch)")
+    print("=" * 70)
+
+    out = os.path.join(args.state_dir, "phu_data_plan.csv")
+    with open(out, "w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["action", "key", "name", "detail"])
+        for s in src_t:
+            w.writerow(["INSERT", s["moet_code"], s["name"], s["kv"]])
+        for r in db_region:
+            w.writerow(["DELETE", r[0], r[1], ""])
+        for cc, a, b in cfix:
+            w.writerow(["COMMUNE_FIX", cc, a, b])
+        for cc, b in cadd:
+            w.writerow(["COMMUNE_ADD", cc, "", b])
+        for r in backfill:
+            w.writerow(["BACKFILL_DEFER", r[0], r[1], r[2]])
+    print(f"Kế hoạch -> {out}")
+    return 0
+
+
+async def apply(args) -> int:
+    from app.database import AsyncSessionLocal
+    from app.models.vn_school import VnSchool, VnSchoolKvAssignment
+    from app.models.vn_locality import VnCommuneAreaMap
+    from sqlalchemy import select, update
+
+    src = load_source(args.source)
+    provinces = set(p.strip() for p in args.provinces.split(","))
+    src_t = [s for s in src if s["gso"] in provinces]
+
+    from sqlalchemy import delete as sa_delete
+
+    old_names = [n for n, g in OLD_TO_GSO.items() if g in provinces]
+    async with AsyncSessionLocal() as db:
+        async with db.begin():
+            # (2) XÓA CỨNG toàn bộ cũ vùng target.
+            # FK: vn_school_kv_assignment + vn_school_name_history = CASCADE (tự xóa).
+            # merged_into_id (self-ref, NO ACTION): set NULL trước để không vỡ.
+            await db.execute(
+                update(VnSchool)
+                .where(VnSchool.province.in_(old_names))
+                .values(merged_into_id=None)
+            )
+            res = await db.execute(
+                sa_delete(VnSchool).where(VnSchool.province.in_(old_names))
+            )
+            react = res.rowcount or 0
+            # (1) INSERT catalog mới (idempotent theo moet_code)
+            ins = 0
+            for s in src_t:
+                if await db.scalar(
+                    select(VnSchool.id)
+                    .where(
+                        VnSchool.moet_code == s["moet_code"],
+                        VnSchool.is_active.is_(True),
+                    )
+                    .limit(1)
+                ):
+                    continue
+                sch = VnSchool(
+                    moet_school_code=s["moet_code"][2:],
+                    moet_province_code=s["gso"],
+                    moet_code=s["moet_code"],
+                    commune_code=s["commune_code"] or None,
+                    name=s["name"],
+                    address=s.get("address") or None,
+                    province=s["province"],
+                    level=s.get("level") or "THPT",
+                    is_dtnt=str(s.get("is_dtnt")).lower() in ("1", "true", "t"),
+                    is_active=True,
+                )
+                db.add(sch)
+                await db.flush()
+                db.add(
+                    VnSchoolKvAssignment(
+                        school_id=sch.id,
+                        kv_code=s["kv"],
+                        effective_from_year=KV_EFFECTIVE_FROM,
+                        effective_to_year=None,
+                        source=SOURCE_OF,
+                    )
+                )
+                ins += 1
+            # (3) commune_area_map: FIX dòng ACTIVE (effective_to IS NULL) + ADD
+            # commune mới (lấy ward/tỉnh hiện hành từ administrative_nodes).
+            from app.repositories.administrative_repository import (
+                AdministrativeRepository,
+            )
+
+            admin_repo = AdministrativeRepository(db)
+            cfix = 0
+            cadd = 0
+            cadd_skip = 0
+            sck = defaultdict(Counter)
+            for s in src_t:
+                if s["commune_code"]:
+                    sck[s["commune_code"]][s["kv"]] += 1
+            for cc, ctr in sck.items():
+                want = ctr.most_common(1)[0][0]
+                # KV3 = default (vắng mặt trong map) → KHÔNG add/fix về KV3.
+                if want not in ("KV1", "KV2", "KV2-NT"):
+                    continue
+                # CHỈ dòng ACTIVE (effective_to IS NULL) — KHÔNG đụng dòng retire.
+                row = await db.scalar(
+                    select(VnCommuneAreaMap)
+                    .where(
+                        VnCommuneAreaMap.commune_code == cc,
+                        VnCommuneAreaMap.effective_to.is_(None),
+                    )
+                    .limit(1)
+                )
+                if row is not None:
+                    if row.area_code != want:
+                        row.area_code = want
+                        cfix += 1
+                    continue
+                # Commune chưa có trong map → ADD (resolve ward/tỉnh hiện hành).
+                ward_name, province_name = (
+                    await admin_repo.get_current_commune_display(cc)
+                )
+                if not (ward_name and province_name):
+                    cadd_skip += 1  # không resolve → KHÔNG bỏ âm thầm, đếm + cảnh báo
+                    continue
+                db.add(
+                    VnCommuneAreaMap(
+                        commune_code=cc,
+                        province=province_name,
+                        district="",
+                        ward=ward_name,
+                        area_code=want,
+                    )
+                )
+                cadd += 1
+    print(
+        f"[apply] insert={ins} deleted={react} commune_fix={cfix} "
+        f"commune_add={cadd} commune_add_skip={cadd_skip}"
+    )
+    if cadd_skip:
+        print(
+            f"[apply] CẢNH BÁO: {cadd_skip} commune mới KHÔNG resolve được "
+            f"ward/tỉnh hiện hành → CHƯA thêm vào map; thêm tay qua "
+            f"/admin/commune-kv."
+        )
+    print(
+        "[apply] Hồ sơ đã chọn trường cũ -> dangling; officer chọn lại từ catalog mới."
+    )
+    return 0
+
+
+def export_source(xls_path: str, out_path: str, provinces: set[str]) -> int:
+    """XLS chính thức MOET -> source.csv (cột chuẩn cho --apply). Cần pandas+xlrd.
+    Đọc Mã Xã/Mã Tỉnh/Mã Trường dạng CHUỖI (giữ số 0 đầu)."""
+    import pandas as pd
+
+    conv = {"Mã Xã/ Phường": str, "Mã Tỉnh/TP": str, "Mã Trường": str}
+    df = pd.read_excel(xls_path, sheet_name="Sheet1", header=6, converters=conv)
+    df.columns = [str(c).strip() for c in df.columns]
+    rows = []
+    for _, r in df.iterrows():
+        mt = str(r["Mã Tỉnh/TP"]).strip()
+        if mt not in provinces:
+            continue
+        mtr = str(r["Mã Trường"]).strip()
+        mx = str(r["Mã Xã/ Phường"]).strip()
+        name = str(r["Tên Trường"]).strip()
+        rows.append(
+            {
+                "moet_code": mt.zfill(2) + mtr.zfill(3),
+                "commune_code": mx[:5] if mx and mx.lower() != "nan" else "",
+                "gso": mt,
+                "province": str(r["Tên Tỉnh/TP"]).strip(),
+                "name": name,
+                "address": (
+                    str(r["Địa Chỉ"]).strip() if str(r["Địa Chỉ"]) != "nan" else ""
+                ),
+                "level": "THPT",
+                "is_dtnt": "1" if "DTNT" in name.upper() else "0",
+                "kv": nkv(r["Khu Vực"]),
+            }
+        )
+    with open(out_path, "w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(
+            f,
+            fieldnames=[
+                "moet_code",
+                "commune_code",
+                "gso",
+                "province",
+                "name",
+                "address",
+                "level",
+                "is_dtnt",
+                "kv",
+            ],
+        )
+        w.writeheader()
+        w.writerows(rows)
+    print(f"[export] {len(rows)} trường -> {out_path}")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--source", help="source.csv (cho dry-run/apply)")
+    ap.add_argument("--state-dir", default="/tmp/state")
+    ap.add_argument("--provinces", default="52,66,68")
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument(
+        "--export-source", metavar="XLS", help="sinh source.csv từ XLS MOET"
+    )
+    ap.add_argument(
+        "--out", default="/tmp/source.csv", help="đường ra cho --export-source"
+    )
+    args = ap.parse_args()
+    provinces = set(p.strip() for p in args.provinces.split(","))
+    if args.export_source:
+        return export_source(args.export_source, args.out, provinces)
+    if not args.source:
+        print("Cần --source (hoặc --export-source). Dừng.", file=sys.stderr)
+        return 2
+    if args.apply:
+        import asyncio
+
+        return asyncio.run(apply(args))
+    return dry_run(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Backend_FastAPI/app/services/vn_school_service.py
+++ b/Backend_FastAPI/app/services/vn_school_service.py
@@ -25,12 +25,38 @@ architecture (memory CLAUDE.md MANDATORY ARCHITECTURE RULES).
 """
 from __future__ import annotations
 
-from typing import Optional, Tuple
+import csv
+import io
+from typing import Any, Awaitable, Callable, Optional, Tuple
 
-from sqlalchemy import func, select, text
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.vn_school import VnSchool, VnSchoolKvAssignment
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    DuplicateResourceError,
+    ResourceNotFoundError,
+)
+from app.utils.exceptions import ValidationError as DomainValidationError
+
+PostCommitCallback = Optional[Callable[[], Awaitable[None]]]
+
+
+async def _noop_callback() -> None:
+    return None
+
+
+_VN_SCHOOL_LEVELS = {"THCS", "THPT", "THCS_THPT", "TRUNG_HOC_NGHE", "OTHER"}
+
+
+def _years_overlap(
+    a_from: int, a_to: Optional[int], b_from: int, b_to: Optional[int]
+) -> bool:
+    """2 khoảng năm [from, to] (to=None → ongoing) có giao nhau không."""
+    a_to_eff = a_to if a_to is not None else 9999
+    b_to_eff = b_to if b_to is not None else 9999
+    return a_from <= b_to_eff and b_from <= a_to_eff
 
 
 class VnSchoolService:
@@ -113,3 +139,347 @@ class VnSchoolService:
         result = await self.db.execute(stmt)
         rows = [dict(row._mapping) for row in result.all()]
         return rows, total
+
+    # =========================================================================
+    # Admin CRUD (PR-B). DELETE school = deactivate (is_active=false). KV
+    # assignment overlap check ở service (M3: không GiST EXCLUDE).
+    # =========================================================================
+
+    SCHOOL_CSV_REQUIRED = {
+        "moet_school_code", "moet_province_code", "name", "province", "level",
+    }
+
+    def _current_kv_subq(self):
+        return (
+            select(VnSchoolKvAssignment.kv_code)
+            .where(
+                VnSchoolKvAssignment.school_id == VnSchool.id,
+                VnSchoolKvAssignment.effective_to_year.is_(None),
+            )
+            .order_by(VnSchoolKvAssignment.effective_from_year.desc())
+            .limit(1)
+            .correlate(VnSchool)
+            .scalar_subquery()
+        )
+
+    async def list_schools(
+        self,
+        moet_province_code: Optional[str] = None,
+        level: Optional[str] = None,
+        q: Optional[str] = None,
+        active_only: bool = True,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> Tuple[list[dict], int]:
+        """Paginated list + lọc moet_province_code/level/q. Read-only."""
+        page = max(1, page)
+        page_size = min(max(1, page_size), 200)
+        filters = []
+        if active_only:
+            filters.append(VnSchool.is_active.is_(True))
+        if moet_province_code:
+            filters.append(VnSchool.moet_province_code == moet_province_code)
+        if level:
+            filters.append(VnSchool.level == level)
+        if q:
+            qc = (
+                q.strip()
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_")
+            )
+            filters.append(
+                or_(
+                    func.unaccent(VnSchool.name).ilike(func.unaccent(f"%{qc}%")),
+                    VnSchool.moet_school_code.ilike(f"%{qc}%"),
+                )
+            )
+        total = (
+            await self.db.execute(
+                select(func.count(VnSchool.id)).where(*filters)
+            )
+        ).scalar_one()
+        stmt = (
+            select(
+                VnSchool.id,
+                VnSchool.moet_school_code,
+                VnSchool.moet_province_code,
+                VnSchool.moet_district_code,
+                VnSchool.name,
+                VnSchool.address,
+                VnSchool.province,
+                VnSchool.district,
+                VnSchool.ward,
+                VnSchool.level,
+                VnSchool.is_dtnt,
+                VnSchool.is_active,
+                self._current_kv_subq().label("current_kv"),
+            )
+            .where(*filters)
+            .order_by(VnSchool.province, VnSchool.name, VnSchool.id)
+            .limit(page_size)
+            .offset((page - 1) * page_size)
+        )
+        rows = [dict(r._mapping) for r in (await self.db.execute(stmt)).all()]
+        return rows, int(total)
+
+    async def list_school_provinces(self) -> list[dict]:
+        """Distinct {moet_province_code, province} từ trường active — FE filter."""
+        stmt = (
+            select(VnSchool.moet_province_code, VnSchool.province)
+            .where(VnSchool.is_active.is_(True))
+            .distinct()
+            .order_by(VnSchool.province)
+        )
+        return [dict(r._mapping) for r in (await self.db.execute(stmt)).all()]
+
+    async def current_kv(self, school_id: int) -> Optional[str]:
+        """KV active mới nhất của 1 trường (effective_to_year IS NULL) — cho
+        response single-school (create/update/deactivate)."""
+        stmt = (
+            select(VnSchoolKvAssignment.kv_code)
+            .where(
+                VnSchoolKvAssignment.school_id == school_id,
+                VnSchoolKvAssignment.effective_to_year.is_(None),
+            )
+            .order_by(VnSchoolKvAssignment.effective_from_year.desc())
+            .limit(1)
+        )
+        return (await self.db.execute(stmt)).scalar_one_or_none()
+
+    async def _active_school(
+        self, moet_school_code: str, moet_province_code: str
+    ) -> Optional[VnSchool]:
+        stmt = select(VnSchool).where(
+            VnSchool.moet_school_code == moet_school_code,
+            VnSchool.moet_province_code == moet_province_code,
+            VnSchool.is_active.is_(True),
+        )
+        return (await self.db.execute(stmt.limit(1))).scalar_one_or_none()
+
+    async def create_school(
+        self, data: dict[str, Any]
+    ) -> Tuple[VnSchool, PostCommitCallback]:
+        if (
+            await self._active_school(
+                data["moet_school_code"], data["moet_province_code"]
+            )
+            is not None
+        ):
+            raise DuplicateResourceError(
+                f"Đã có trường active với mã MOET "
+                f"{data['moet_school_code']!r}/{data['moet_province_code']!r}."
+            )
+        clean = {k: v for k, v in data.items() if v is not None}
+        school = VnSchool(**clean)
+        self.db.add(school)
+        await self.db.flush()
+        return school, _noop_callback
+
+    async def update_school(
+        self, school_id: int, data: dict[str, Any]
+    ) -> Tuple[VnSchool, PostCommitCallback]:
+        school = await self.db.get(VnSchool, school_id)
+        if school is None:
+            raise ResourceNotFoundError(f"VnSchool {school_id} not found")
+        # Không đổi định danh MOET / is_active qua PATCH (DELETE=deactivate).
+        for f in ("moet_school_code", "moet_province_code", "is_active"):
+            data.pop(f, None)
+        for key in (
+            "moet_district_code", "name", "address", "province",
+            "district", "ward", "level", "is_dtnt",
+        ):
+            if key in data:
+                setattr(school, key, data[key])
+        await self.db.flush()
+        return school, _noop_callback
+
+    async def deactivate_school(
+        self, school_id: int
+    ) -> Tuple[VnSchool, PostCommitCallback]:
+        """DELETE = soft-delete (is_active=false). KHÔNG hard-delete (FK
+        vn_school_kv_assignment.school_id CASCADE sẽ xoá lịch sử KV)."""
+        school = await self.db.get(VnSchool, school_id)
+        if school is None:
+            raise ResourceNotFoundError(f"VnSchool {school_id} not found")
+        if not school.is_active:
+            raise BusinessRuleViolation(
+                f"Trường {school_id} đã ngừng kích hoạt trước đó."
+            )
+        school.is_active = False
+        await self.db.flush()
+        return school, _noop_callback
+
+    # --- KV assignment (vn_school_kv_assignment) ---
+
+    async def list_kv_assignments(
+        self, school_id: int
+    ) -> list[VnSchoolKvAssignment]:
+        if await self.db.get(VnSchool, school_id) is None:
+            raise ResourceNotFoundError(f"VnSchool {school_id} not found")
+        stmt = (
+            select(VnSchoolKvAssignment)
+            .where(VnSchoolKvAssignment.school_id == school_id)
+            .order_by(VnSchoolKvAssignment.effective_from_year)
+        )
+        return list((await self.db.execute(stmt)).scalars().all())
+
+    async def _guard_kv(
+        self,
+        school_id: int,
+        from_year: int,
+        to_year: Optional[int],
+        exclude_id: Optional[int] = None,
+    ) -> None:
+        if to_year is not None and to_year < from_year:
+            raise BusinessRuleViolation(
+                f"effective_to_year ({to_year}) < effective_from_year "
+                f"({from_year})."
+            )
+        stmt = select(VnSchoolKvAssignment).where(
+            VnSchoolKvAssignment.school_id == school_id
+        )
+        if exclude_id is not None:
+            stmt = stmt.where(VnSchoolKvAssignment.id != exclude_id)
+        for row in (await self.db.execute(stmt)).scalars().all():
+            if _years_overlap(
+                from_year, to_year,
+                row.effective_from_year, row.effective_to_year,
+            ):
+                raise BusinessRuleViolation(
+                    f"Khoảng năm chồng lấn phân loại KV đã có (id={row.id}: "
+                    f"{row.effective_from_year}-"
+                    f"{row.effective_to_year or 'nay'})."
+                )
+
+    async def add_kv_assignment(
+        self, school_id: int, data: dict[str, Any]
+    ) -> Tuple[VnSchoolKvAssignment, PostCommitCallback]:
+        if await self.db.get(VnSchool, school_id) is None:
+            raise ResourceNotFoundError(f"VnSchool {school_id} not found")
+        await self._guard_kv(
+            school_id, data["effective_from_year"],
+            data.get("effective_to_year"),
+        )
+        clean = {k: v for k, v in data.items() if v is not None}
+        row = VnSchoolKvAssignment(school_id=school_id, **clean)
+        self.db.add(row)
+        await self.db.flush()
+        return row, _noop_callback
+
+    async def update_kv_assignment(
+        self, assignment_id: int, data: dict[str, Any]
+    ) -> Tuple[VnSchoolKvAssignment, PostCommitCallback]:
+        row = await self.db.get(VnSchoolKvAssignment, assignment_id)
+        if row is None:
+            raise ResourceNotFoundError(
+                f"VnSchoolKvAssignment {assignment_id} not found"
+            )
+        # Validate trạng thái ỨNG VIÊN TRƯỚC khi mutate — guard raise sẽ không
+        # để row hỏng trong session (memory partial-update-loses-cross-field).
+        new_from = data.get("effective_from_year", row.effective_from_year)
+        new_to = (
+            data["effective_to_year"]
+            if "effective_to_year" in data
+            else row.effective_to_year
+        )
+        await self._guard_kv(
+            row.school_id, new_from, new_to, exclude_id=row.id
+        )
+        for key in (
+            "kv_code", "effective_from_year", "effective_to_year",
+            "source", "notes",
+        ):
+            if key in data:
+                setattr(row, key, data[key])
+        await self.db.flush()
+        return row, _noop_callback
+
+    async def delete_kv_assignment(
+        self, assignment_id: int
+    ) -> Tuple[None, PostCommitCallback]:
+        row = await self.db.get(VnSchoolKvAssignment, assignment_id)
+        if row is None:
+            raise ResourceNotFoundError(
+                f"VnSchoolKvAssignment {assignment_id} not found"
+            )
+        await self.db.delete(row)
+        await self.db.flush()
+        return None, _noop_callback
+
+    # --- CSV import (school-only; KV-via-CSV defer → quản lý qua endpoint KV) ---
+
+    async def import_schools_csv(
+        self, csv_bytes: bytes
+    ) -> Tuple[dict[str, Any], PostCommitCallback]:
+        """Bulk import trường (idempotent theo (moet_school_code,
+        moet_province_code) active). Cột: moet_school_code, moet_province_code,
+        name, province, level (+ moet_district_code/district/ward/is_dtnt tuỳ
+        chọn). KV assignment KHÔNG qua CSV — dùng endpoint /kv."""
+        try:
+            text_data = csv_bytes.decode("utf-8-sig", errors="strict")
+        except UnicodeDecodeError:
+            raise DomainValidationError(
+                "CSV phải encode UTF-8. Trong Excel: 'Save As → CSV UTF-8'."
+            )
+        reader = csv.DictReader(io.StringIO(text_data))
+        missing = self.SCHOOL_CSV_REQUIRED - set(reader.fieldnames or [])
+        if missing:
+            raise DomainValidationError(
+                f"CSV thiếu cột bắt buộc: {', '.join(sorted(missing))}."
+            )
+        inserted = 0
+        skipped = 0
+        errors: list[dict] = []
+        # Dedupe TRONG file: tránh 2 dòng cùng (code, prov) cùng được add →
+        # vi phạm partial-unique lúc flush (IntegrityError). KHÔNG dựa autoflush.
+        seen: set[tuple[str, str]] = set()
+        for row_num, raw in enumerate(reader, start=2):
+            try:
+                code = (raw.get("moet_school_code") or "").strip()
+                prov = (raw.get("moet_province_code") or "").strip()
+                name = (raw.get("name") or "").strip()
+                province = (raw.get("province") or "").strip()
+                level = (raw.get("level") or "").strip()
+                if not (code and prov and name and province):
+                    raise ValueError(
+                        "thiếu giá trị bắt buộc "
+                        "(moet_school_code/moet_province_code/name/province)"
+                    )
+                if level not in _VN_SCHOOL_LEVELS:
+                    raise ValueError(f"level không hợp lệ: {level!r}")
+                if (code, prov) in seen or (
+                    await self._active_school(code, prov) is not None
+                ):
+                    skipped += 1
+                    continue
+                seen.add((code, prov))
+                self.db.add(
+                    VnSchool(
+                        moet_school_code=code,
+                        moet_province_code=prov,
+                        moet_district_code=(
+                            raw.get("moet_district_code") or ""
+                        ).strip() or None,
+                        name=name,
+                        province=province,
+                        district=(raw.get("district") or "").strip() or None,
+                        ward=(raw.get("ward") or "").strip() or None,
+                        level=level,
+                        is_dtnt=(raw.get("is_dtnt") or "").strip().lower()
+                        in ("1", "true", "yes", "x", "có"),
+                    )
+                )
+                inserted += 1
+            except ValueError as e:
+                errors.append({"row_num": row_num, "error": str(e)})
+                continue
+        await self.db.flush()
+        return (
+            {
+                "inserted": inserted,
+                "skipped_existing": skipped,
+                "error_rows": errors,
+            },
+            _noop_callback,
+        )

--- a/Backend_FastAPI/tests/api/test_admin_vn_school.py
+++ b/Backend_FastAPI/tests/api/test_admin_vn_school.py
@@ -1,0 +1,147 @@
+"""API smoke for admin vn_school CRUD + KV assignment router (PR-B).
+
+End-to-end qua app + real DB: lifecycle school + KV, dup-409, overlap-400,
+DELETE=deactivate giữ KV (GET /kv vẫn trả), provinces, require_admin (403).
+Mỗi test dùng moet_school_code RIÊNG (API commit thật).
+"""
+import pytest
+from httpx import AsyncClient
+
+pytestmark = [pytest.mark.asyncio]
+
+BASE = "/api/v2/admin/vn-school"
+
+
+def _school(code: str, **kw) -> dict:
+    return {
+        "moet_school_code": code,
+        "moet_province_code": kw.get("prov", "048"),
+        "name": kw.get("name", f"Trường {code}"),
+        "province": kw.get("province", "Tỉnh Lâm Đồng"),
+        "level": kw.get("level", "THPT"),
+    }
+
+
+async def test_school_lifecycle_and_kv(
+    client: AsyncClient, admin_token_headers: dict, setup_test_database
+) -> None:
+    h = admin_token_headers
+    # CREATE
+    r = await client.post(f"{BASE}/schools", json=_school("APISCH_A"), headers=h)
+    assert r.status_code == 201, r.text
+    sid = r.json()["id"]
+    assert r.json()["is_active"] is True
+    assert r.json()["current_kv"] is None
+
+    # LIST (lọc mã tỉnh MOET — tránh phụ thuộc extension unaccent của q-search).
+    r = await client.get(
+        f"{BASE}/schools",
+        params={"moet_province_code": "048"},
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["total"] == 1
+
+    # ADD KV
+    r = await client.post(
+        f"{BASE}/schools/{sid}/kv",
+        json={"kv_code": "KV1", "effective_from_year": 2025, "source": "manual_admin"},
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+
+    # LIST KV
+    r = await client.get(f"{BASE}/schools/{sid}/kv", headers=h)
+    assert r.status_code == 200
+    assert len(r.json()) == 1
+    aid = r.json()[0]["id"]
+
+    # current_kv giờ = KV1 (qua GET schools)
+    r = await client.get(
+        f"{BASE}/schools", params={"moet_province_code": "048"}, headers=h
+    )
+    assert r.json()["items"][0]["current_kv"] == "KV1"
+
+    # UPDATE KV
+    r = await client.patch(
+        f"{BASE}/kv/{aid}", json={"kv_code": "KV2-NT"}, headers=h
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["kv_code"] == "KV2-NT"
+
+    # DELETE school = deactivate; KV assignment VẪN còn.
+    r = await client.delete(f"{BASE}/schools/{sid}", headers=h)
+    assert r.status_code == 200, r.text
+    assert r.json()["is_active"] is False
+    r = await client.get(f"{BASE}/schools/{sid}/kv", headers=h)
+    assert r.status_code == 200 and len(r.json()) == 1  # KV không bị xoá
+
+
+async def test_create_duplicate_409(
+    client: AsyncClient, admin_token_headers: dict, setup_test_database
+) -> None:
+    h = admin_token_headers
+    r1 = await client.post(
+        f"{BASE}/schools", json=_school("APISCH_DUP"), headers=h
+    )
+    assert r1.status_code == 201, r1.text
+    r2 = await client.post(
+        f"{BASE}/schools", json=_school("APISCH_DUP"), headers=h
+    )
+    assert r2.status_code == 409, r2.text
+
+
+async def test_kv_overlap_400(
+    client: AsyncClient, admin_token_headers: dict, setup_test_database
+) -> None:
+    h = admin_token_headers
+    r = await client.post(f"{BASE}/schools", json=_school("APISCH_OV"), headers=h)
+    sid = r.json()["id"]
+    r1 = await client.post(
+        f"{BASE}/schools/{sid}/kv",
+        json={"kv_code": "KV1", "effective_from_year": 2020, "effective_to_year": 2025},
+        headers=h,
+    )
+    assert r1.status_code == 201, r1.text
+    r2 = await client.post(
+        f"{BASE}/schools/{sid}/kv",
+        json={"kv_code": "KV2", "effective_from_year": 2024},
+        headers=h,
+    )
+    assert r2.status_code == 400, r2.text  # overlap → BusinessRuleViolation
+
+
+async def test_create_invalid_level_422(
+    client: AsyncClient, admin_token_headers: dict, setup_test_database
+) -> None:
+    r = await client.post(
+        f"{BASE}/schools",
+        json=_school("APISCH_BAD", level="KHONG_HOP_LE"),
+        headers=admin_token_headers,
+    )
+    assert r.status_code == 422, r.text
+
+
+async def test_provinces_endpoint(
+    client: AsyncClient, admin_token_headers: dict, setup_test_database
+) -> None:
+    h = admin_token_headers
+    await client.post(
+        f"{BASE}/schools",
+        json=_school("APISCH_P", prov="042", province="Tỉnh Gia Lai"),
+        headers=h,
+    )
+    r = await client.get(f"{BASE}/provinces", headers=h)
+    assert r.status_code == 200, r.text
+    codes = {p["moet_province_code"] for p in r.json()}
+    assert "042" in codes
+
+
+async def test_non_admin_forbidden(
+    client: AsyncClient, officer_token_headers: dict, setup_test_database
+) -> None:
+    client.cookies.clear()
+    r = await client.post(
+        f"{BASE}/schools", json=_school("APISCH_OFF"), headers=officer_token_headers
+    )
+    assert r.status_code == 403, r.text

--- a/Backend_FastAPI/tests/unit/test_vn_school_admin_service.py
+++ b/Backend_FastAPI/tests/unit/test_vn_school_admin_service.py
@@ -1,0 +1,259 @@
+"""Unit tests for VnSchoolService admin CRUD + KV assignment (PR-B).
+
+Mirror commune admin test: real ``db`` fixture, rollback teardown. Trọng tâm:
+DELETE=deactivate giữ KV assignment (KHÔNG hard-delete), overlap năm check ở
+service, CSV import idempotent.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.database import AsyncSessionLocal
+from app.models.vn_school import VnSchool, VnSchoolKvAssignment
+from app.services.vn_school_service import VnSchoolService
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    DuplicateResourceError,
+    ResourceNotFoundError,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture
+async def db(setup_test_database):
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+        finally:
+            await session.rollback()
+            await session.close()
+
+
+def _school(code: str = "S001", prov: str = "048", **kw) -> dict:
+    return {
+        "moet_school_code": code,
+        "moet_province_code": prov,
+        "name": kw.get("name", f"Trường {code}"),
+        "province": kw.get("province", "Tỉnh Lâm Đồng"),
+        "level": kw.get("level", "THPT"),
+        "is_dtnt": kw.get("is_dtnt", False),
+    }
+
+
+def _kv(from_year: int, to_year=None, kv: str = "KV1") -> dict:
+    return {
+        "kv_code": kv,
+        "effective_from_year": from_year,
+        "effective_to_year": to_year,
+        "source": "manual_admin",
+    }
+
+
+# --- school CRUD ---
+
+
+async def test_create_and_duplicate(db) -> None:
+    s = VnSchoolService(db)
+    school, _ = await s.create_school(_school("S001"))
+    await db.flush()
+    assert school.id is not None
+    assert school.is_active is True
+    with pytest.raises(DuplicateResourceError):
+        await s.create_school(_school("S001"))
+
+
+async def test_update_keeps_identity_and_active(db) -> None:
+    s = VnSchoolService(db)
+    school, _ = await s.create_school(_school("S010", name="Cũ"))
+    await db.flush()
+    updated, _ = await s.update_school(
+        school.id,
+        {"name": "Mới", "moet_school_code": "HACK", "is_active": False},
+    )
+    await db.flush()
+    assert updated.name == "Mới"
+    assert updated.moet_school_code == "S010"  # KHÔNG đổi định danh
+    assert updated.is_active is True  # KHÔNG deactivate qua PATCH
+
+
+async def test_deactivate_keeps_kv_no_hard_delete(db) -> None:
+    """Acceptance plan: DELETE=deactivate giữ KV assignment, KHÔNG hard-delete."""
+    s = VnSchoolService(db)
+    school, _ = await s.create_school(_school("S020"))
+    await db.flush()
+    await s.add_kv_assignment(school.id, _kv(2025))
+    await db.flush()
+    await s.deactivate_school(school.id)
+    await db.flush()
+
+    still = await db.get(VnSchool, school.id)
+    assert still is not None and still.is_active is False  # soft-delete
+    kvs = (
+        await db.execute(
+            select(VnSchoolKvAssignment).where(
+                VnSchoolKvAssignment.school_id == school.id
+            )
+        )
+    ).scalars().all()
+    assert len(kvs) == 1  # assignment KHÔNG bị CASCADE xoá
+
+
+async def test_deactivate_double_blocks(db) -> None:
+    s = VnSchoolService(db)
+    school, _ = await s.create_school(_school("S021"))
+    await db.flush()
+    await s.deactivate_school(school.id)
+    await db.flush()
+    with pytest.raises(BusinessRuleViolation):
+        await s.deactivate_school(school.id)
+
+
+async def test_update_missing_raises(db) -> None:
+    s = VnSchoolService(db)
+    with pytest.raises(ResourceNotFoundError):
+        await s.update_school(999999, {"name": "X"})
+
+
+# --- KV assignment ---
+
+
+async def test_add_kv_overlap_blocked(db) -> None:
+    s = VnSchoolService(db)
+    school, _ = await s.create_school(_school("S030"))
+    await db.flush()
+    await s.add_kv_assignment(school.id, _kv(2020, 2025, "KV1"))
+    await db.flush()
+    with pytest.raises(BusinessRuleViolation):
+        await s.add_kv_assignment(school.id, _kv(2024, None, "KV2"))
+
+
+async def test_add_kv_bad_year_range(db) -> None:
+    s = VnSchoolService(db)
+    school, _ = await s.create_school(_school("S031"))
+    await db.flush()
+    with pytest.raises(BusinessRuleViolation):
+        await s.add_kv_assignment(school.id, _kv(2025, 2020, "KV1"))
+
+
+async def test_add_kv_nonoverlap_ok_and_current_kv(db) -> None:
+    s = VnSchoolService(db)
+    school, _ = await s.create_school(_school("S032"))
+    await db.flush()
+    await s.add_kv_assignment(school.id, _kv(2020, 2023, "KV1"))
+    await s.add_kv_assignment(school.id, _kv(2024, None, "KV2"))
+    await db.flush()
+    assert await s.current_kv(school.id) == "KV2"  # active mới nhất
+    kvs = await s.list_kv_assignments(school.id)
+    assert [k.kv_code for k in kvs] == ["KV1", "KV2"]  # order by from_year
+
+
+async def test_update_kv_overlap_excludes_self(db) -> None:
+    s = VnSchoolService(db)
+    school, _ = await s.create_school(_school("S033"))
+    await db.flush()
+    await s.add_kv_assignment(school.id, _kv(2020, 2022, "KV1"))
+    b, _ = await s.add_kv_assignment(school.id, _kv(2023, 2025, "KV2"))
+    await db.flush()
+    # Đổi b chồng a → block (validate-before-mutate: b KHÔNG hỏng).
+    with pytest.raises(BusinessRuleViolation):
+        await s.update_kv_assignment(b.id, {"effective_from_year": 2021})
+    # Đổi kv_code (không chồng) → OK (không tự coi mình overlap).
+    upd, _ = await s.update_kv_assignment(b.id, {"kv_code": "KV3"})
+    await db.flush()
+    assert upd.kv_code == "KV3"
+    assert upd.effective_from_year == 2023  # lần update lỗi KHÔNG để lại mutate
+
+
+async def test_delete_kv_assignment(db) -> None:
+    s = VnSchoolService(db)
+    school, _ = await s.create_school(_school("S034"))
+    await db.flush()
+    a, _ = await s.add_kv_assignment(school.id, _kv(2025))
+    await db.flush()
+    await s.delete_kv_assignment(a.id)
+    await db.flush()
+    assert await db.get(VnSchoolKvAssignment, a.id) is None
+
+
+async def test_add_kv_missing_school_raises(db) -> None:
+    s = VnSchoolService(db)
+    with pytest.raises(ResourceNotFoundError):
+        await s.add_kv_assignment(999999, _kv(2025))
+
+
+# --- list + CSV ---
+
+
+async def test_list_schools_filter_pagination(db) -> None:
+    s = VnSchoolService(db)
+    for i in range(4):
+        await s.create_school(_school(f"S04{i}", prov="048", level="THPT"))
+    await s.create_school(_school("S060", prov="040", level="THCS"))
+    await db.flush()
+    items, total = await s.list_schools(
+        moet_province_code="048", page=1, page_size=2
+    )
+    assert total == 4 and len(items) == 2
+    _items2, total2 = await s.list_schools(level="THCS")
+    assert total2 == 1
+
+
+async def test_import_csv_idempotent_and_invalid_level(db) -> None:
+    s = VnSchoolService(db)
+    csv_bytes = (
+        b"moet_school_code,moet_province_code,name,province,level\n"
+        b"S100,048,Truong A,Tinh X,THPT\n"
+        b"S101,048,Truong B,Tinh X,BADLEVEL\n"
+    )
+    result, _ = await s.import_schools_csv(csv_bytes)
+    await db.flush()
+    assert result["inserted"] == 1  # S100 ok; S101 bad level → error
+    assert result["skipped_existing"] == 0
+    assert len(result["error_rows"]) == 1
+    # Chạy lại → S100 skip (idempotent).
+    result2, _ = await s.import_schools_csv(csv_bytes)
+    await db.flush()
+    assert result2["inserted"] == 0 and result2["skipped_existing"] == 1
+
+
+async def test_current_kv_none_when_no_active_assignment(db) -> None:
+    """current_kv = None nếu mọi assignment đã đóng (effective_to_year != NULL)."""
+    s = VnSchoolService(db)
+    school, _ = await s.create_school(_school("S050"))
+    await db.flush()
+    assert await s.current_kv(school.id) is None  # chưa có assignment
+    await s.add_kv_assignment(school.id, _kv(2020, 2023, "KV1"))  # đã đóng
+    await db.flush()
+    assert await s.current_kv(school.id) is None  # không có dòng to=NULL
+
+
+async def test_list_active_only_false_includes_deactivated(db) -> None:
+    s = VnSchoolService(db)
+    school, _ = await s.create_school(_school("S055"))
+    await db.flush()
+    await s.deactivate_school(school.id)
+    await db.flush()
+    _a, total_active = await s.list_schools(active_only=True, q=None)
+    assert total_active == 0  # active_only ẩn trường đã ngừng
+    items_all, total_all = await s.list_schools(active_only=False)
+    assert total_all == 1
+    assert items_all[0]["is_active"] is False
+
+
+async def test_import_csv_dedup_same_file(db) -> None:
+    """2 dòng cùng (code, prov) trong 1 file → chỉ insert 1, skip 1 (không
+    IntegrityError nhờ in-memory dedup)."""
+    s = VnSchoolService(db)
+    csv_bytes = (
+        b"moet_school_code,moet_province_code,name,province,level\n"
+        b"S200,048,Truong A,Tinh X,THPT\n"
+        b"S200,048,Truong A bis,Tinh X,THPT\n"
+    )
+    result, _ = await s.import_schools_csv(csv_bytes)
+    await db.flush()
+    assert result["inserted"] == 1
+    assert result["skipped_existing"] == 1
+    assert len(result["error_rows"]) == 0

--- a/frontend/src/app/(dashboard)/admin/vn-schools/_components/ImportSchoolCsvDialog.tsx
+++ b/frontend/src/app/(dashboard)/admin/vn-schools/_components/ImportSchoolCsvDialog.tsx
@@ -1,0 +1,151 @@
+/**
+ * ImportSchoolCsvDialog — upload CSV trường (school-only; KV qua dialog KV).
+ * POST /api/v2/admin/vn-school/schools/import (idempotent).
+ * Cột: moet_school_code,moet_province_code,name,province,level (+ tuỳ chọn).
+ */
+
+"use client"
+
+import { useRef, useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+import { useImportSchoolCsv } from "@/lib/hooks/useVnSchoolAdmin"
+import { parseApiError } from "@/lib/utils/api-errors"
+import type { CsvImportResponse } from "@/lib/zod/vn-school-admin"
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ImportSchoolCsvDialog({ open, onOpenChange }: Props) {
+  const importMutation = useImportSchoolCsv()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [file, setFile] = useState<File | null>(null)
+  const [result, setResult] = useState<CsvImportResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const reset = () => {
+    setFile(null)
+    setResult(null)
+    setError(null)
+    if (inputRef.current) inputRef.current.value = ""
+  }
+
+  const handleImport = async () => {
+    if (!file) {
+      setError("Chọn file CSV trước")
+      return
+    }
+    setError(null)
+    try {
+      const res = await importMutation.mutateAsync(file)
+      setResult(res)
+      toast.success(
+        `Import xong: +${res.inserted} mới, ${res.skipped_existing} bỏ qua`,
+      )
+    } catch (e) {
+      setError(parseApiError(e, "Import thất bại"))
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) reset()
+        onOpenChange(o)
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Import CSV — Trường</DialogTitle>
+          <DialogDescription>
+            Cột bắt buộc:{" "}
+            <code>moet_school_code,moet_province_code,name,province,level</code>
+            {" "}(+ moet_district_code/district/ward/is_dtnt tuỳ chọn). UTF-8,
+            idempotent. KV phân loại qua nút &quot;Quản lý KV&quot;.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="grid gap-2">
+            <Label htmlFor="school-csv">File CSV</Label>
+            <Input
+              id="school-csv"
+              ref={inputRef}
+              type="file"
+              accept=".csv"
+              onChange={(e) => {
+                setFile(e.target.files?.[0] ?? null)
+                setResult(null)
+                setError(null)
+              }}
+            />
+          </div>
+
+          {result && (
+            <div className="bg-muted/40 rounded-md border p-3 text-sm">
+              <p>
+                ✅ Thêm mới: <strong>{result.inserted}</strong> · Bỏ qua (đã có):{" "}
+                <strong>{result.skipped_existing}</strong> · Lỗi dòng:{" "}
+                <strong>{result.error_rows.length}</strong>
+              </p>
+              {result.error_rows.length > 0 && (
+                <ul className="text-muted-foreground mt-2 max-h-32 list-disc overflow-auto pl-5 text-xs">
+                  {result.error_rows.slice(0, 20).map((row, i) => {
+                    const rn = row.row_num
+                    const err = row.error
+                    return (
+                      <li key={i}>
+                        {rn != null ? `Dòng ${rn}: ` : ""}
+                        {typeof err === "string" ? err : JSON.stringify(row)}
+                      </li>
+                    )
+                  })}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {error && (
+            <p className="text-destructive text-sm" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              reset()
+              onOpenChange(false)
+            }}
+            disabled={importMutation.isPending}
+          >
+            Đóng
+          </Button>
+          <Button
+            onClick={handleImport}
+            disabled={importMutation.isPending || !file}
+          >
+            {importMutation.isPending ? "Đang import…" : "Import"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/vn-schools/_components/SchoolClient.tsx
+++ b/frontend/src/app/(dashboard)/admin/vn-schools/_components/SchoolClient.tsx
@@ -1,0 +1,210 @@
+/**
+ * SchoolClient — orchestrator trang Quản lý Trường THPT.
+ *
+ * Lọc tỉnh dùng **moet_province_code** (từ endpoint /provinces — administrative
+ * getProvinces KHÔNG có mã MOET) + lọc cấp + search (tên/mã). Pagination +
+ * Import CSV. KV assignment quản lý qua dialog trong SchoolTable.
+ */
+
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { Upload } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+
+import { useSchoolProvinces, useSchools } from "@/lib/hooks/useVnSchoolAdmin"
+import {
+  VN_SCHOOL_LEVELS,
+  VN_SCHOOL_LEVEL_LABELS,
+} from "@/lib/zod/vn-school-admin"
+
+import { ImportSchoolCsvDialog } from "./ImportSchoolCsvDialog"
+import { SchoolTable } from "./SchoolTable"
+
+const PAGE_SIZE = 50
+const ALL = "__all__"
+
+export function SchoolClient() {
+  const [provinceCode, setProvinceCode] = useState<string>(ALL)
+  const [level, setLevel] = useState<string>(ALL)
+  const [qInput, setQInput] = useState("")
+  const [q, setQ] = useState("")
+  const [activeOnly, setActiveOnly] = useState(true)
+  const [page, setPage] = useState(1)
+  const [importOpen, setImportOpen] = useState(false)
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setQ(qInput.trim())
+      setPage(1)
+    }, 300)
+    return () => clearTimeout(t)
+  }, [qInput])
+
+  const params = {
+    moetProvinceCode: provinceCode === ALL ? null : provinceCode,
+    level: level === ALL ? null : level,
+    q: q || null,
+    activeOnly,
+    page,
+    pageSize: PAGE_SIZE,
+  }
+  const { data, isLoading, isFetching } = useSchools(params)
+  const { data: provinces } = useSchoolProvinces()
+
+  // De-dupe theo mã tỉnh MOET — phòng data bẩn (1 mã map 2 tên province) gây
+  // SelectItem trùng value + React key collision.
+  const uniqueProvinces = useMemo(() => {
+    const seen = new Set<string>()
+    return (provinces ?? []).filter((p) => {
+      if (seen.has(p.moet_province_code)) return false
+      seen.add(p.moet_province_code)
+      return true
+    })
+  }, [provinces])
+
+  const total = data?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  return (
+    <div className="container mx-auto space-y-4 p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">Trường THPT</h1>
+          <p className="text-muted-foreground text-sm">
+            Danh mục trường (vn_school) + phân loại KV theo năm. Ngừng trường =
+            ẩn (không xoá), giữ lịch sử KV.
+          </p>
+        </div>
+        <Button variant="outline" onClick={() => setImportOpen(true)}>
+          <Upload className="mr-2 h-4 w-4" />
+          Import CSV
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Bộ lọc</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="grid gap-1.5">
+              <Label htmlFor="f-province">Tỉnh (MOET)</Label>
+              <Select
+                value={provinceCode}
+                onValueChange={(v) => {
+                  setProvinceCode(v)
+                  setPage(1)
+                }}
+              >
+                <SelectTrigger id="f-province" className="w-[240px]">
+                  <SelectValue placeholder="Tất cả tỉnh" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL}>Tất cả tỉnh</SelectItem>
+                  {uniqueProvinces.map((p) => (
+                    <SelectItem
+                      key={p.moet_province_code}
+                      value={p.moet_province_code}
+                    >
+                      {p.province} ({p.moet_province_code})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="grid gap-1.5">
+              <Label htmlFor="f-level">Cấp</Label>
+              <Select
+                value={level}
+                onValueChange={(v) => {
+                  setLevel(v)
+                  setPage(1)
+                }}
+              >
+                <SelectTrigger id="f-level" className="w-[180px]">
+                  <SelectValue placeholder="Tất cả cấp" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL}>Tất cả cấp</SelectItem>
+                  {VN_SCHOOL_LEVELS.map((lv) => (
+                    <SelectItem key={lv} value={lv}>
+                      {VN_SCHOOL_LEVEL_LABELS[lv]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="grid gap-1.5">
+              <Label htmlFor="f-q">Tìm (tên / mã trường)</Label>
+              <Input
+                id="f-q"
+                value={qInput}
+                onChange={(e) => setQInput(e.target.value)}
+                placeholder="VD: Đắk Mil"
+                className="w-[220px]"
+              />
+            </div>
+
+            <div className="flex items-center gap-2 pb-2">
+              <Switch
+                id="f-active"
+                checked={activeOnly}
+                onCheckedChange={(v) => {
+                  setActiveOnly(v)
+                  setPage(1)
+                }}
+              />
+              <Label htmlFor="f-active">Chỉ trường đang hoạt động</Label>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <SchoolTable rows={data?.items ?? []} isLoading={isLoading} />
+
+      <div className="flex items-center justify-between">
+        <p className="text-muted-foreground text-sm">
+          {total} trường{isFetching ? " · đang tải…" : ""}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Trước
+          </Button>
+          <span className="text-sm tabular-nums">
+            Trang {page} / {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          >
+            Sau
+          </Button>
+        </div>
+      </div>
+
+      <ImportSchoolCsvDialog open={importOpen} onOpenChange={setImportOpen} />
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/vn-schools/_components/SchoolKvDialog.tsx
+++ b/frontend/src/app/(dashboard)/admin/vn-schools/_components/SchoolKvDialog.tsx
@@ -1,0 +1,327 @@
+/**
+ * SchoolKvDialog — quản lý phân loại KV theo năm của 1 trường (2 cấp).
+ *
+ * List assignment + form thêm/sửa (kv_code, năm từ-đến, source) + xoá. Overlap
+ * năm do BE chặn (400). Tránh nested Radix dialog: form inline trong dialog.
+ */
+
+"use client"
+
+import { useEffect, useState } from "react"
+import { Pencil, Trash2 } from "lucide-react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+import {
+  useAddKvAssignment,
+  useDeleteKvAssignment,
+  useKvAssignments,
+  useUpdateKvAssignment,
+} from "@/lib/hooks/useVnSchoolAdmin"
+import { parseApiError } from "@/lib/utils/api-errors"
+import {
+  kvAssignmentCreateSchema,
+  kvAssignmentUpdateSchema,
+  type KvAssignmentResponse,
+  type SchoolResponse,
+} from "@/lib/zod/vn-school-admin"
+
+const KV_OPTIONS = ["KV1", "KV2-NT", "KV2", "KV3"] as const
+
+interface Props {
+  school: SchoolResponse | null
+  onOpenChange: (open: boolean) => void
+}
+
+interface KvForm {
+  kv_code: string
+  from_year: string
+  to_year: string
+  source: string
+}
+
+const EMPTY: KvForm = {
+  kv_code: "KV1",
+  from_year: "",
+  to_year: "",
+  source: "manual_admin",
+}
+
+export function SchoolKvDialog({ school, onOpenChange }: Props) {
+  const schoolId = school?.id ?? null
+  const { data: rows, isLoading } = useKvAssignments(schoolId)
+  const addMutation = useAddKvAssignment()
+  const updateMutation = useUpdateKvAssignment()
+  const deleteMutation = useDeleteKvAssignment()
+
+  const [editId, setEditId] = useState<number | null>(null)
+  const [form, setForm] = useState<KvForm>(EMPTY)
+  const [error, setError] = useState<string | null>(null)
+
+  // Reset form khi đổi trường (đóng/mở dialog).
+  useEffect(() => {
+    setEditId(null)
+    setForm(EMPTY)
+    setError(null)
+  }, [schoolId])
+
+  const busy =
+    addMutation.isPending ||
+    updateMutation.isPending ||
+    deleteMutation.isPending
+
+  const startEdit = (a: KvAssignmentResponse) => {
+    setEditId(a.id)
+    setForm({
+      kv_code: a.kv_code,
+      from_year: String(a.effective_from_year),
+      to_year: a.effective_to_year != null ? String(a.effective_to_year) : "",
+      source: a.source,
+    })
+    setError(null)
+  }
+
+  const resetForm = () => {
+    setEditId(null)
+    setForm(EMPTY)
+    setError(null)
+  }
+
+  const handleSubmit = async () => {
+    if (schoolId == null) return
+    setError(null)
+    const fromYear = Number(form.from_year)
+    if (!form.from_year || Number.isNaN(fromYear)) {
+      setError("Năm bắt đầu phải là số")
+      return
+    }
+    const toYear = form.to_year.trim() ? Number(form.to_year) : null
+    if (toYear != null && Number.isNaN(toYear)) {
+      setError("Năm kết thúc phải là số hoặc để trống")
+      return
+    }
+    try {
+      if (editId == null) {
+        const parsed = kvAssignmentCreateSchema.safeParse({
+          kv_code: form.kv_code,
+          effective_from_year: fromYear,
+          effective_to_year: toYear,
+          source: form.source.trim() || "manual_admin",
+        })
+        if (!parsed.success) {
+          setError(parsed.error.issues[0]?.message ?? "Dữ liệu không hợp lệ")
+          return
+        }
+        await addMutation.mutateAsync({ schoolId, data: parsed.data })
+        toast.success("Đã thêm phân loại KV")
+      } else {
+        const parsed = kvAssignmentUpdateSchema.safeParse({
+          kv_code: form.kv_code,
+          effective_from_year: fromYear,
+          effective_to_year: toYear,
+          source: form.source.trim() || "manual_admin",
+        })
+        if (!parsed.success) {
+          setError(parsed.error.issues[0]?.message ?? "Dữ liệu không hợp lệ")
+          return
+        }
+        await updateMutation.mutateAsync({ id: editId, data: parsed.data })
+        toast.success("Đã cập nhật phân loại KV")
+      }
+      resetForm()
+    } catch (e) {
+      setError(parseApiError(e, "Thao tác thất bại"))
+    }
+  }
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteMutation.mutateAsync(id)
+      toast.success("Đã xoá phân loại KV")
+      if (editId === id) resetForm()
+    } catch (e) {
+      toast.error(parseApiError(e, "Xoá thất bại"))
+    }
+  }
+
+  return (
+    <Dialog open={school != null} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Phân loại KV theo năm</DialogTitle>
+          <DialogDescription>
+            {school?.name} — mỗi khoảng năm 1 KV, không chồng lấn. Để trống &quot;Năm
+            kết thúc&quot; = đang áp dụng.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[90px]">KV</TableHead>
+                <TableHead className="w-[140px]">Năm</TableHead>
+                <TableHead>Nguồn</TableHead>
+                <TableHead className="w-[90px] text-right">Thao tác</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="py-4 text-center text-sm">
+                    Đang tải…
+                  </TableCell>
+                </TableRow>
+              ) : !rows || rows.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={4}
+                    className="text-muted-foreground py-4 text-center text-sm"
+                  >
+                    Chưa có phân loại KV nào.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                rows.map((a) => (
+                  <TableRow key={a.id}>
+                    <TableCell className="font-mono">{a.kv_code}</TableCell>
+                    <TableCell className="tabular-nums">
+                      {a.effective_from_year}–{a.effective_to_year ?? "nay"}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-xs">
+                      {a.source}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => startEdit(a)}
+                          disabled={busy}
+                          aria-label="Sửa phân loại KV"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleDelete(a.id)}
+                          disabled={busy}
+                          aria-label="Xoá phân loại KV"
+                        >
+                          <Trash2 className="text-destructive h-4 w-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Add / Edit form */}
+        <div className="space-y-3 rounded-md border bg-muted/30 p-3">
+          <p className="text-sm font-medium">
+            {editId == null ? "Thêm phân loại KV" : `Sửa phân loại #${editId}`}
+          </p>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <div className="grid gap-1.5">
+              <Label htmlFor="kv-code">KV</Label>
+              <Select
+                value={form.kv_code}
+                onValueChange={(v) => setForm((s) => ({ ...s, kv_code: v }))}
+              >
+                <SelectTrigger id="kv-code">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {KV_OPTIONS.map((kv) => (
+                    <SelectItem key={kv} value={kv}>
+                      {kv}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="kv-from">Năm bắt đầu</Label>
+              <Input
+                id="kv-from"
+                type="number"
+                value={form.from_year}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, from_year: e.target.value }))
+                }
+                placeholder="2025"
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="kv-to">Năm kết thúc</Label>
+              <Input
+                id="kv-to"
+                type="number"
+                value={form.to_year}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, to_year: e.target.value }))
+                }
+                placeholder="trống = nay"
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="kv-source">Nguồn</Label>
+              <Input
+                id="kv-source"
+                value={form.source}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, source: e.target.value }))
+                }
+                placeholder="manual_admin"
+              />
+            </div>
+          </div>
+          {error && (
+            <p className="text-destructive text-sm" role="alert">
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            {editId != null && (
+              <Button variant="outline" size="sm" onClick={resetForm} disabled={busy}>
+                Huỷ sửa
+              </Button>
+            )}
+            <Button size="sm" onClick={handleSubmit} disabled={busy}>
+              {editId == null ? "Thêm" : "Lưu"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/vn-schools/_components/SchoolKvDialog.tsx
+++ b/frontend/src/app/(dashboard)/admin/vn-schools/_components/SchoolKvDialog.tsx
@@ -7,7 +7,7 @@
 
 "use client"
 
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { Pencil, Trash2 } from "lucide-react"
 import { toast } from "sonner"
 
@@ -79,16 +79,12 @@ export function SchoolKvDialog({ school, onOpenChange }: Props) {
   const updateMutation = useUpdateKvAssignment()
   const deleteMutation = useDeleteKvAssignment()
 
+  // State khởi tạo mới mỗi lần component remount (SchoolTable truyền key=school.id
+  // → đổi trường = remount = form sạch). Tránh setState đồng bộ trong useEffect
+  // (react-hooks: cascading renders).
   const [editId, setEditId] = useState<number | null>(null)
   const [form, setForm] = useState<KvForm>(EMPTY)
   const [error, setError] = useState<string | null>(null)
-
-  // Reset form khi đổi trường (đóng/mở dialog).
-  useEffect(() => {
-    setEditId(null)
-    setForm(EMPTY)
-    setError(null)
-  }, [schoolId])
 
   const busy =
     addMutation.isPending ||

--- a/frontend/src/app/(dashboard)/admin/vn-schools/_components/SchoolTable.tsx
+++ b/frontend/src/app/(dashboard)/admin/vn-schools/_components/SchoolTable.tsx
@@ -458,8 +458,9 @@ export function SchoolTable({ rows, isLoading }: SchoolTableProps) {
         </AlertDialogContent>
       </AlertDialog>
 
-      {/* KV management */}
+      {/* KV management — key=school.id để remount (reset form) khi đổi trường */}
       <SchoolKvDialog
+        key={kvSchool?.id ?? "none"}
         school={kvSchool}
         onOpenChange={(o) => !o && setKvSchool(null)}
       />

--- a/frontend/src/app/(dashboard)/admin/vn-schools/_components/SchoolTable.tsx
+++ b/frontend/src/app/(dashboard)/admin/vn-schools/_components/SchoolTable.tsx
@@ -1,0 +1,468 @@
+/**
+ * SchoolTable — bảng vn_school + dialog Thêm / Sửa / Ngừng + nút Quản lý KV.
+ *
+ * Ngừng (DELETE) = deactivate (is_active=false) — KHÔNG hard-delete (giữ KV
+ * assignment). KV quản lý qua SchoolKvDialog (2 cấp: list + add/edit/delete).
+ */
+
+"use client"
+
+import { useState } from "react"
+import { Layers, Pencil, Plus, Power } from "lucide-react"
+import { toast } from "sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Switch } from "@/components/ui/switch"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+import {
+  useCreateSchool,
+  useDeactivateSchool,
+  useUpdateSchool,
+} from "@/lib/hooks/useVnSchoolAdmin"
+import { parseApiError } from "@/lib/utils/api-errors"
+import {
+  schoolCreateSchema,
+  schoolUpdateSchema,
+  VN_SCHOOL_LEVELS,
+  VN_SCHOOL_LEVEL_LABELS,
+  type SchoolResponse,
+  type VnSchoolLevel,
+} from "@/lib/zod/vn-school-admin"
+
+import { SchoolKvDialog } from "./SchoolKvDialog"
+
+interface SchoolTableProps {
+  rows: SchoolResponse[]
+  isLoading: boolean
+}
+
+interface FormState {
+  moet_school_code: string
+  moet_province_code: string
+  name: string
+  province: string
+  district: string
+  ward: string
+  level: VnSchoolLevel
+  is_dtnt: boolean
+}
+
+const EMPTY: FormState = {
+  moet_school_code: "",
+  moet_province_code: "",
+  name: "",
+  province: "",
+  district: "",
+  ward: "",
+  level: "THPT",
+  is_dtnt: false,
+}
+
+export function SchoolTable({ rows, isLoading }: SchoolTableProps) {
+  const createMutation = useCreateSchool()
+  const updateMutation = useUpdateSchool()
+  const deactivateMutation = useDeactivateSchool()
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editId, setEditId] = useState<number | null>(null)
+  const [form, setForm] = useState<FormState>(EMPTY)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const [deactivateRow, setDeactivateRow] = useState<SchoolResponse | null>(null)
+  const [kvSchool, setKvSchool] = useState<SchoolResponse | null>(null)
+
+  const busy =
+    createMutation.isPending ||
+    updateMutation.isPending ||
+    deactivateMutation.isPending
+
+  const openCreate = () => {
+    setEditId(null)
+    setForm(EMPTY)
+    setFormError(null)
+    setDialogOpen(true)
+  }
+
+  const openEdit = (row: SchoolResponse) => {
+    setEditId(row.id)
+    setForm({
+      moet_school_code: row.moet_school_code,
+      moet_province_code: row.moet_province_code,
+      name: row.name,
+      province: row.province,
+      district: row.district ?? "",
+      ward: row.ward ?? "",
+      level: row.level as VnSchoolLevel,
+      is_dtnt: row.is_dtnt,
+    })
+    setFormError(null)
+    setDialogOpen(true)
+  }
+
+  const handleSubmit = async () => {
+    setFormError(null)
+    try {
+      if (editId == null) {
+        const parsed = schoolCreateSchema.safeParse({
+          moet_school_code: form.moet_school_code.trim(),
+          moet_province_code: form.moet_province_code.trim(),
+          name: form.name.trim(),
+          province: form.province.trim(),
+          district: form.district.trim() || undefined,
+          ward: form.ward.trim() || undefined,
+          level: form.level,
+          is_dtnt: form.is_dtnt,
+        })
+        if (!parsed.success) {
+          setFormError(parsed.error.issues[0]?.message ?? "Dữ liệu không hợp lệ")
+          return
+        }
+        await createMutation.mutateAsync(parsed.data)
+        toast.success(`Đã thêm trường ${parsed.data.moet_school_code}`)
+      } else {
+        const parsed = schoolUpdateSchema.safeParse({
+          name: form.name.trim(),
+          province: form.province.trim(),
+          district: form.district.trim() || undefined,
+          ward: form.ward.trim() || undefined,
+          level: form.level,
+          is_dtnt: form.is_dtnt,
+        })
+        if (!parsed.success) {
+          setFormError(parsed.error.issues[0]?.message ?? "Dữ liệu không hợp lệ")
+          return
+        }
+        await updateMutation.mutateAsync({ id: editId, data: parsed.data })
+        toast.success(`Đã cập nhật trường #${editId}`)
+      }
+      setDialogOpen(false)
+    } catch (e) {
+      setFormError(parseApiError(e, "Thao tác thất bại"))
+    }
+  }
+
+  const handleDeactivate = async () => {
+    if (!deactivateRow) return
+    try {
+      await deactivateMutation.mutateAsync(deactivateRow.id)
+      toast.success(`Đã ngừng ${deactivateRow.name}`)
+    } catch (e) {
+      toast.error(parseApiError(e, "Ngừng trường thất bại"))
+    } finally {
+      setDeactivateRow(null)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex justify-end">
+        <Button size="sm" onClick={openCreate}>
+          <Plus className="mr-1 h-4 w-4" />
+          Thêm trường
+        </Button>
+      </div>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[130px]">Mã MOET</TableHead>
+              <TableHead>Tên trường</TableHead>
+              <TableHead>Tỉnh</TableHead>
+              <TableHead className="w-[110px]">Cấp</TableHead>
+              <TableHead className="w-[90px]">KV</TableHead>
+              <TableHead className="w-[180px] text-right">Thao tác</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              [1, 2, 3, 4, 5].map((i) => (
+                <TableRow key={i}>
+                  <TableCell colSpan={6}>
+                    <Skeleton className="h-6 w-full" />
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={6}
+                  className="text-muted-foreground py-8 text-center text-sm"
+                >
+                  Không có trường nào khớp bộ lọc.
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => (
+                <TableRow key={row.id} data-testid={`school-row-${row.id}`}>
+                  <TableCell className="font-mono text-xs">
+                    {row.moet_school_code}/{row.moet_province_code}
+                  </TableCell>
+                  <TableCell>
+                    {row.name}
+                    {!row.is_active && (
+                      <Badge variant="outline" className="ml-2">
+                        Đã ngừng
+                      </Badge>
+                    )}
+                    {row.is_dtnt && (
+                      <Badge variant="secondary" className="ml-2">
+                        DTNT
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell>{row.province}</TableCell>
+                  <TableCell className="text-xs">
+                    {VN_SCHOOL_LEVEL_LABELS[row.level as VnSchoolLevel] ??
+                      row.level}
+                  </TableCell>
+                  <TableCell>
+                    {row.current_kv ? (
+                      <Badge variant="secondary" className="font-mono">
+                        {row.current_kv}
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setKvSchool(row)}
+                        aria-label={`Quản lý KV ${row.name}`}
+                        title="Quản lý KV theo năm"
+                      >
+                        <Layers className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => openEdit(row)}
+                        aria-label={`Sửa ${row.name}`}
+                        disabled={!row.is_active}
+                        title="Sửa thông tin"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setDeactivateRow(row)}
+                        aria-label={`Ngừng ${row.name}`}
+                        disabled={!row.is_active}
+                        title="Ngừng (ẩn) trường"
+                      >
+                        <Power className="text-destructive h-4 w-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Create / Edit */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              {editId == null ? "Thêm trường" : `Sửa trường #${editId}`}
+            </DialogTitle>
+            <DialogDescription>
+              {editId == null
+                ? "Mã MOET (trường + tỉnh) phải chưa tồn tại."
+                : "Mã MOET không đổi được. Ngừng trường dùng nút Ngừng."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div className="grid gap-2">
+                <Label htmlFor="s-code">Mã trường MOET</Label>
+                <Input
+                  id="s-code"
+                  value={form.moet_school_code}
+                  disabled={editId != null}
+                  onChange={(e) =>
+                    setForm((s) => ({ ...s, moet_school_code: e.target.value }))
+                  }
+                  placeholder="VD: 040123"
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="s-prov-code">Mã tỉnh MOET</Label>
+                <Input
+                  id="s-prov-code"
+                  value={form.moet_province_code}
+                  disabled={editId != null}
+                  onChange={(e) =>
+                    setForm((s) => ({
+                      ...s,
+                      moet_province_code: e.target.value,
+                    }))
+                  }
+                  placeholder="VD: 040"
+                />
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="s-name">Tên trường</Label>
+              <Input
+                id="s-name"
+                value={form.name}
+                onChange={(e) =>
+                  setForm((s) => ({ ...s, name: e.target.value }))
+                }
+                placeholder="VD: THPT Đắk Mil"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="grid gap-2">
+                <Label htmlFor="s-prov">Tỉnh</Label>
+                <Input
+                  id="s-prov"
+                  value={form.province}
+                  onChange={(e) =>
+                    setForm((s) => ({ ...s, province: e.target.value }))
+                  }
+                  placeholder="VD: Đắk Lắk"
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="s-district">Huyện/Quận</Label>
+                <Input
+                  id="s-district"
+                  value={form.district}
+                  onChange={(e) =>
+                    setForm((s) => ({ ...s, district: e.target.value }))
+                  }
+                  placeholder="Tuỳ chọn"
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="grid gap-2">
+                <Label htmlFor="s-level">Cấp</Label>
+                <Select
+                  value={form.level}
+                  onValueChange={(v) =>
+                    setForm((s) => ({ ...s, level: v as VnSchoolLevel }))
+                  }
+                >
+                  <SelectTrigger id="s-level">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {VN_SCHOOL_LEVELS.map((lv) => (
+                      <SelectItem key={lv} value={lv}>
+                        {VN_SCHOOL_LEVEL_LABELS[lv]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-center gap-2 pt-7">
+                <Switch
+                  id="s-dtnt"
+                  checked={form.is_dtnt}
+                  onCheckedChange={(v) =>
+                    setForm((s) => ({ ...s, is_dtnt: v }))
+                  }
+                />
+                <Label htmlFor="s-dtnt">Trường DTNT</Label>
+              </div>
+            </div>
+            {formError && (
+              <p className="text-destructive text-sm" role="alert">
+                {formError}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDialogOpen(false)}
+              disabled={busy}
+            >
+              Hủy
+            </Button>
+            <Button onClick={handleSubmit} disabled={busy}>
+              {editId == null ? "Tạo" : "Lưu"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Deactivate */}
+      <AlertDialog
+        open={!!deactivateRow}
+        onOpenChange={(o) => !o && setDeactivateRow(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Ngừng trường</AlertDialogTitle>
+            <AlertDialogDescription>
+              Ngừng (ẩn) {deactivateRow?.name}? Trường sẽ không hiện trong dropdown
+              tuyển sinh nhưng GIỮ lịch sử KV (không xoá). Có thể tạo lại nếu cần.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Hủy</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleDeactivate}
+            >
+              Ngừng
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* KV management */}
+      <SchoolKvDialog
+        school={kvSchool}
+        onOpenChange={(o) => !o && setKvSchool(null)}
+      />
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admin/vn-schools/page.tsx
+++ b/frontend/src/app/(dashboard)/admin/vn-schools/page.tsx
@@ -1,0 +1,25 @@
+/**
+ * Admin — Quản lý Trường THPT (vn_school + KV assignment) — PR-B.
+ *
+ * Thin Suspense wrapper. Admin auth = BE require_admin + nav role filter.
+ */
+import { Suspense } from "react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+
+import { SchoolClient } from "./_components/SchoolClient"
+
+export default function VnSchoolsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="container mx-auto space-y-4 p-6">
+          <Skeleton className="h-10 w-1/3" />
+          <Skeleton className="h-[500px] w-full" />
+        </div>
+      }
+    >
+      <SchoolClient />
+    </Suspense>
+  )
+}

--- a/frontend/src/lib/api/admin-vn-school.ts
+++ b/frontend/src/lib/api/admin-vn-school.ts
@@ -1,0 +1,139 @@
+/**
+ * Admin VN School API Client (PR-B).
+ *
+ * Mirrors `Backend_FastAPI/app/routers/admin_vn_school.py`. All `require_admin`.
+ * Base: `/api/v2/admin/vn-school`. DELETE school = deactivate (BE).
+ */
+
+import { api } from "@/lib/api/client"
+
+import type {
+  CsvImportResponse,
+  KvAssignmentCreate,
+  KvAssignmentResponse,
+  KvAssignmentUpdate,
+  SchoolCreate,
+  SchoolListResponse,
+  SchoolProvince,
+  SchoolResponse,
+  SchoolUpdate,
+} from "@/lib/zod/vn-school-admin"
+
+const BASE = "/api/v2/admin/vn-school"
+
+export interface ListSchoolsParams {
+  moetProvinceCode?: string | null
+  level?: string | null
+  q?: string | null
+  activeOnly?: boolean
+  page?: number
+  pageSize?: number
+}
+
+export async function listSchools(
+  params: ListSchoolsParams = {},
+): Promise<SchoolListResponse> {
+  const { data } = await api.get<SchoolListResponse>(`${BASE}/schools`, {
+    params: {
+      moet_province_code: params.moetProvinceCode || undefined,
+      level: params.level || undefined,
+      q: params.q || undefined,
+      active_only: params.activeOnly ?? true,
+      page: params.page ?? 1,
+      page_size: params.pageSize ?? 50,
+    },
+  })
+  return data
+}
+
+export async function listSchoolProvinces(): Promise<SchoolProvince[]> {
+  const { data } = await api.get<SchoolProvince[]>(`${BASE}/provinces`)
+  return data
+}
+
+export async function createSchool(
+  payload: SchoolCreate,
+): Promise<SchoolResponse> {
+  const { data } = await api.post<SchoolResponse>(`${BASE}/schools`, payload)
+  return data
+}
+
+export async function updateSchool(
+  id: number,
+  payload: SchoolUpdate,
+): Promise<SchoolResponse> {
+  const { data } = await api.patch<SchoolResponse>(
+    `${BASE}/schools/${id}`,
+    payload,
+  )
+  return data
+}
+
+/** DELETE = deactivate (is_active=false). */
+export async function deactivateSchool(id: number): Promise<SchoolResponse> {
+  const { data } = await api.delete<SchoolResponse>(`${BASE}/schools/${id}`)
+  return data
+}
+
+export async function importSchoolCsv(file: File): Promise<CsvImportResponse> {
+  const fd = new FormData()
+  fd.append("file", file)
+  const { data } = await api.post<CsvImportResponse>(
+    `${BASE}/schools/import`,
+    fd,
+    { headers: { "Content-Type": "multipart/form-data" } },
+  )
+  return data
+}
+
+// --- KV assignment ---
+
+export async function listKvAssignments(
+  schoolId: number,
+): Promise<KvAssignmentResponse[]> {
+  const { data } = await api.get<KvAssignmentResponse[]>(
+    `${BASE}/schools/${schoolId}/kv`,
+  )
+  return data
+}
+
+export async function addKvAssignment(
+  schoolId: number,
+  payload: KvAssignmentCreate,
+): Promise<KvAssignmentResponse> {
+  const { data } = await api.post<KvAssignmentResponse>(
+    `${BASE}/schools/${schoolId}/kv`,
+    payload,
+  )
+  return data
+}
+
+export async function updateKvAssignment(
+  assignmentId: number,
+  payload: KvAssignmentUpdate,
+): Promise<KvAssignmentResponse> {
+  const { data } = await api.patch<KvAssignmentResponse>(
+    `${BASE}/kv/${assignmentId}`,
+    payload,
+  )
+  return data
+}
+
+export async function deleteKvAssignment(assignmentId: number): Promise<void> {
+  await api.delete(`${BASE}/kv/${assignmentId}`)
+}
+
+export const adminVnSchoolApi = {
+  listSchools,
+  listSchoolProvinces,
+  createSchool,
+  updateSchool,
+  deactivateSchool,
+  importSchoolCsv,
+  listKvAssignments,
+  addKvAssignment,
+  updateKvAssignment,
+  deleteKvAssignment,
+}
+
+export default adminVnSchoolApi

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -25,6 +25,7 @@ import {
   LayoutDashboard,
   MapPin,
   Percent,
+  School,
   Receipt,
   RotateCcw,
   Settings,
@@ -281,6 +282,13 @@ export const navigationConfig: NavigationConfig = {
           label: "KV theo Xã",
           href: "/admin/commune-kv",
           icon: MapPin,
+          roles: ["admin"],
+        },
+        {
+          // PR-B — quản lý danh mục trường (vn_school) + KV theo năm. Admin-only.
+          label: "Trường THPT",
+          href: "/admin/vn-schools",
+          icon: School,
           roles: ["admin"],
         },
         {

--- a/frontend/src/lib/hooks/useVnSchoolAdmin.ts
+++ b/frontend/src/lib/hooks/useVnSchoolAdmin.ts
@@ -1,0 +1,123 @@
+/**
+ * React Query hooks for admin vn_school + KV assignment CRUD (PR-B).
+ *
+ * School list keyed theo filter/pagination. KV assignment keyed theo schoolId.
+ * Mutations invalidate đúng nhánh (school write → school tree; KV write → KV
+ * của school đó + school tree để current_kv refresh).
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import {
+  addKvAssignment,
+  createSchool,
+  deactivateSchool,
+  deleteKvAssignment,
+  importSchoolCsv,
+  listKvAssignments,
+  listSchoolProvinces,
+  listSchools,
+  updateKvAssignment,
+  updateSchool,
+  type ListSchoolsParams,
+} from "@/lib/api/admin-vn-school"
+import type {
+  KvAssignmentCreate,
+  KvAssignmentUpdate,
+  SchoolCreate,
+  SchoolUpdate,
+} from "@/lib/zod/vn-school-admin"
+
+export const vnSchoolKeys = {
+  all: ["vn-school-admin"] as const,
+  list: (params: ListSchoolsParams) =>
+    [...vnSchoolKeys.all, "list", params] as const,
+  provinces: () => [...vnSchoolKeys.all, "provinces"] as const,
+  kv: (schoolId: number) => [...vnSchoolKeys.all, "kv", schoolId] as const,
+}
+
+export function useSchools(params: ListSchoolsParams) {
+  return useQuery({
+    queryKey: vnSchoolKeys.list(params),
+    queryFn: () => listSchools(params),
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useSchoolProvinces() {
+  return useQuery({
+    queryKey: vnSchoolKeys.provinces(),
+    queryFn: () => listSchoolProvinces(),
+    staleTime: 60 * 60 * 1000,
+  })
+}
+
+export function useCreateSchool() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: SchoolCreate) => createSchool(data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: vnSchoolKeys.all }),
+  })
+}
+
+export function useUpdateSchool() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: SchoolUpdate }) =>
+      updateSchool(id, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: vnSchoolKeys.all }),
+  })
+}
+
+export function useDeactivateSchool() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => deactivateSchool(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: vnSchoolKeys.all }),
+  })
+}
+
+export function useImportSchoolCsv() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (file: File) => importSchoolCsv(file),
+    onSuccess: () => qc.invalidateQueries({ queryKey: vnSchoolKeys.all }),
+  })
+}
+
+// --- KV assignment ---
+
+export function useKvAssignments(schoolId: number | null) {
+  return useQuery({
+    queryKey: vnSchoolKeys.kv(schoolId ?? 0),
+    queryFn: () => listKvAssignments(schoolId!),
+    enabled: schoolId != null,
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useAddKvAssignment() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ schoolId, data }: { schoolId: number; data: KvAssignmentCreate }) =>
+      addKvAssignment(schoolId, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: vnSchoolKeys.all }),
+  })
+}
+
+export function useUpdateKvAssignment() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: KvAssignmentUpdate }) =>
+      updateKvAssignment(id, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: vnSchoolKeys.all }),
+  })
+}
+
+export function useDeleteKvAssignment() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => deleteKvAssignment(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: vnSchoolKeys.all }),
+  })
+}

--- a/frontend/src/lib/zod/vn-school-admin.ts
+++ b/frontend/src/lib/zod/vn-school-admin.ts
@@ -1,0 +1,143 @@
+/**
+ * Zod schemas for admin vn_school + KV assignment CRUD (PR-B).
+ *
+ * Mirror `Backend_FastAPI/app/schemas/vn_locality.py` (school admin). Reuse
+ * `AREA_CODE_REGEX` + `csvImportResponseSchema` (single source). DELETE school =
+ * deactivate (BE); KV assignment quản lý qua sub-resource.
+ */
+import { z } from "zod"
+
+import { AREA_CODE_REGEX } from "@/lib/zod/priority-config"
+
+export {
+  csvImportResponseSchema,
+  type CsvImportResponse,
+} from "@/lib/zod/commune-kv"
+
+export const VN_SCHOOL_LEVELS = [
+  "THCS",
+  "THPT",
+  "THCS_THPT",
+  "TRUNG_HOC_NGHE",
+  "OTHER",
+] as const
+export type VnSchoolLevel = (typeof VN_SCHOOL_LEVELS)[number]
+
+export const VN_SCHOOL_LEVEL_LABELS: Record<VnSchoolLevel, string> = {
+  THCS: "THCS",
+  THPT: "THPT",
+  THCS_THPT: "Liên cấp THCS-THPT",
+  TRUNG_HOC_NGHE: "Trung học nghề",
+  OTHER: "Khác",
+}
+
+const kvCodeField = z
+  .string()
+  .regex(AREA_CODE_REGEX, "Mã KV không hợp lệ (VD: KV1, KV2-NT, KV3)")
+const yearField = z.number().int().min(2000).max(2100)
+
+// --- school ---
+
+export const schoolCreateSchema = z.object({
+  moet_school_code: z.string().min(1, "Mã trường MOET bắt buộc").max(10),
+  moet_province_code: z.string().min(1, "Mã tỉnh MOET bắt buộc").max(3),
+  moet_district_code: z.string().max(5).optional(),
+  name: z.string().min(1, "Tên trường bắt buộc").max(255),
+  address: z.string().optional(),
+  province: z.string().min(1, "Tỉnh bắt buộc").max(100),
+  district: z.string().max(100).optional(),
+  ward: z.string().max(100).optional(),
+  level: z.enum(VN_SCHOOL_LEVELS),
+  is_dtnt: z.boolean().default(false),
+})
+export type SchoolCreate = z.infer<typeof schoolCreateSchema>
+
+export const schoolUpdateSchema = z.object({
+  moet_district_code: z.string().max(5).optional(),
+  name: z.string().min(1).max(255).optional(),
+  address: z.string().optional(),
+  province: z.string().min(1).max(100).optional(),
+  district: z.string().max(100).optional(),
+  ward: z.string().max(100).optional(),
+  level: z.enum(VN_SCHOOL_LEVELS).optional(),
+  is_dtnt: z.boolean().optional(),
+})
+export type SchoolUpdate = z.infer<typeof schoolUpdateSchema>
+
+export const schoolResponseSchema = z.object({
+  id: z.number().int().positive(),
+  moet_school_code: z.string(),
+  moet_province_code: z.string(),
+  moet_district_code: z.string().nullable(),
+  name: z.string(),
+  address: z.string().nullable(),
+  province: z.string(),
+  district: z.string().nullable(),
+  ward: z.string().nullable(),
+  level: z.string(),
+  is_dtnt: z.boolean(),
+  is_active: z.boolean(),
+  current_kv: z.string().nullable(),
+})
+export type SchoolResponse = z.infer<typeof schoolResponseSchema>
+
+export const schoolListResponseSchema = z.object({
+  items: z.array(schoolResponseSchema),
+  total: z.number().int().min(0),
+  page: z.number().int().min(1),
+  page_size: z.number().int().min(1),
+})
+export type SchoolListResponse = z.infer<typeof schoolListResponseSchema>
+
+export const schoolProvinceSchema = z.object({
+  moet_province_code: z.string(),
+  province: z.string(),
+})
+export type SchoolProvince = z.infer<typeof schoolProvinceSchema>
+
+// --- KV assignment ---
+
+export const kvAssignmentCreateSchema = z
+  .object({
+    kv_code: kvCodeField,
+    effective_from_year: yearField,
+    effective_to_year: yearField.nullable().optional(),
+    source: z.string().min(1).max(50).default("manual_admin"),
+    notes: z.string().nullable().optional(),
+  })
+  .refine(
+    (d) =>
+      d.effective_to_year == null ||
+      d.effective_to_year >= d.effective_from_year,
+    { message: "Năm kết thúc phải >= năm bắt đầu", path: ["effective_to_year"] },
+  )
+export type KvAssignmentCreate = z.infer<typeof kvAssignmentCreateSchema>
+
+export const kvAssignmentUpdateSchema = z
+  .object({
+    kv_code: kvCodeField.optional(),
+    effective_from_year: yearField.optional(),
+    effective_to_year: yearField.nullable().optional(),
+    source: z.string().min(1).max(50).optional(),
+    notes: z.string().nullable().optional(),
+  })
+  // Chỉ kiểm khi CẢ HAI năm có mặt (nhất quán với create — FE form luôn gửi cả 2).
+  .refine(
+    (d) =>
+      d.effective_from_year == null ||
+      d.effective_to_year == null ||
+      d.effective_to_year >= d.effective_from_year,
+    { message: "Năm kết thúc phải >= năm bắt đầu", path: ["effective_to_year"] },
+  )
+export type KvAssignmentUpdate = z.infer<typeof kvAssignmentUpdateSchema>
+
+export const kvAssignmentResponseSchema = z.object({
+  id: z.number().int().positive(),
+  school_id: z.number().int().positive(),
+  kv_code: z.string(),
+  effective_from_year: z.number().int(),
+  effective_to_year: z.number().int().nullable(),
+  source: z.string(),
+  notes: z.string().nullable(),
+})
+export type KvAssignmentResponse = z.infer<typeof kvAssignmentResponseSchema>


### PR DESCRIPTION
## Mục tiêu (PR-B của plan Admin UI quản lý danh mục KV — phần còn lại sau PR-A #398)
Admin chưa có UI quản lý `vn_school` + phân loại KV theo năm → thêm trang `/admin/vn-schools` + backend CRUD. Đồng thời gộp phần **chuẩn hóa KV trường THPT** (migration + model + script 1-off phủ data từ XLS MOET chính thức).

## Backend — admin CRUD (router MỚI `admin_vn_school`, `require_admin`)
- 10 endpoint `/api/v2/admin/vn-school`: schools `GET` list (paginated + lọc `moet_province_code`/`level`/`q`) · `POST` create · `PATCH` metadata · `DELETE` = **deactivate** (`is_active=false`, KHÔNG hard-delete → giữ lịch sử KV) · `POST` import CSV; `GET /provinces` (distinct `moet_province_code`); KV-assignment list/add/update/delete (**overlap năm check ở service** — M3 không GiST).
- `VnSchoolService` +CRUD + `_years_overlap` + CSV in-file dedup; schemas co-locate `vn_locality.py`.
- Test: **16 unit + 6 API** (deactivate giữ KV; overlap-400; dup-409; non-admin-403; re-activate; CSV dedup).

## Frontend (`/admin/vn-schools` — group Organization, `roles:["admin"]`)
- `zod`/`api`/`hooks` + page → **SchoolClient** (lọc tỉnh MOET + cấp + search debounce + pagination + import) → **SchoolTable** (Thêm/Sửa/Ngừng) → **SchoolKvDialog** (KV-assignment 2 cấp: list + thêm/sửa/xoá) → **ImportSchoolCsvDialog**. Nav "Trường THPT".

## Chuẩn hóa KV trường (gộp)
- Migration `schoolkv01` (down=`optdocmat01`): +`moet_code` +`commune_code` +2 index (additive nullable, khóa đối chiếu MOET/QĐ19-2025). alembic single-head.
- Model `vn_school`: +2 cột.
- Script 1-off `rebuild_school_kv_from_xls.py` (`--dry-run`/`--apply`/`--export-source`): phủ catalog trường từ XLS MOET (DELETE cứng cũ + INSERT mới + fix/add commune KV). **KHÔNG chạy trong PR** — prod apply RIÊNG sau merge+deploy (backup 4 bảng + dry-run + dev-apply trước).

## /code-review (max) đã vá
- Admin CRUD: 5 finding (2 vòng) — busy/delete, zod refine, dedupe provinces, CSV dedup, +test.
- Script: **#1** apply commune-ADD (thực hiện qua `administrative_nodes`, không bỏ âm thầm) · **#2** commune-fix CHỈ dòng active (`effective_to IS NULL`) · **#3** chuẩn hóa KV `nkv()` tại `load_source` · **#5** validate cột CSV. **#4** (xã hạ về KV3) defer — chờ xác nhận data.

## Verify
✅ **22 pytest** (16+6) + FE type-check/lint sạch + **Chrome smoke** `/admin/vn-schools` (443 trường, Thêm + KV-add + overlap-guard + **DELETE=deactivate giữ KV**) + alembic single-head + migration áp dev sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)