### PR TITLE
fix(officer): workload đếm theo consultation_status.is_final, không theo stage

### DIFF
--- a/Backend_FastAPI/app/repositories/officer_repository.py
+++ b/Backend_FastAPI/app/repositories/officer_repository.py
@@ -88,23 +88,31 @@ class OfficerRepository(BaseRepository[models.User]):
     
     async def get_workload_count(self, officer_id: int) -> int:
         """
-        Count active leads (non-final stage) for an officer.
-        
+        Count active leads for an officer.
+
+        "Active" = consultation_status.is_final là False hoặc NULL — KHỚP với
+        is_officer_at_threshold (assignment_service) và get_kpi_stats realtime
+        active_leads. KHÔNG dùng PipelineStage.is_final_stage: một trạng thái
+        terminal (is_final=true) có thể nằm trong stage CHƯA final
+        (sts20@stg02, sts16@stg04, sts18@stg05) — lọc theo stage sẽ đếm nhầm
+        các lead đã đóng vào workload, khiến con số dashboard không khớp với
+        thuật toán auto-assign và với manager view (get_aggregated_kpis).
+
         Optimized: Single COUNT query with LEFT JOIN.
         """
         query = (
             select(func.count(models.Lead.id))
             .join(
-                models.PipelineStage,
-                models.Lead.pipeline_stage_id == models.PipelineStage.id,
+                models.ConsultationStatus,
+                models.Lead.consultation_status_id == models.ConsultationStatus.id,
                 isouter=True,
             )
             .where(
                 models.Lead.assigned_officer_id == officer_id,
                 models.Lead.deleted_at.is_(None),
                 or_(
-                    models.PipelineStage.is_final_stage == False,
-                    models.PipelineStage.is_final_stage.is_(None),
+                    models.ConsultationStatus.is_final == False,
+                    models.ConsultationStatus.is_final.is_(None),
                 ),
             )
         )

--- a/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
+++ b/Backend_FastAPI/tests/integration/test_sts20_consult_giveup.py
@@ -394,6 +394,43 @@ async def test_giveup_leads_do_not_count_as_workload(db: AsyncSession):
     assert await is_officer_at_threshold(db, officer) is False
 
 
+async def test_dashboard_workload_count_excludes_terminal_in_nonfinal_stage(
+    db: AsyncSession,
+):
+    """OfficerRepository.get_workload_count (nguồn của dashboard 'Đang xử lý' /
+    utilization) PHẢI loại lead terminal nằm trong stage CHƯA-final (sts20@stg02),
+    khớp với is_officer_at_threshold + get_kpi_stats realtime active_leads.
+
+    Regression guard: bản cũ lọc theo PipelineStage.is_final_stage, mà sts20 vẫn
+    ở stg02 (is_final_stage=false) nên lead give-up bị đếm nhầm vào workload — con
+    số dashboard không bao giờ giảm sau khi đóng lead. Nếu ai revert về is_final_stage
+    test này fail (stg02 là non-final stage).
+    """
+    from app.repositories.officer_repository import OfficerRepository
+
+    await _seed_fsm(db)
+    unit = await _make_unit(db)
+    officer = await _make_officer(db, unit.id, cap=10)
+
+    # 3 active (sts04, is_final=False) + 5 terminal give-up (sts20, is_final=True).
+    for _ in range(3):
+        await _make_lead(
+            db, unit.id, consultation_status_id="sts04", officer_id=officer.id,
+        )
+    for _ in range(5):
+        await _make_lead(
+            db, unit.id, consultation_status_id="sts20", officer_id=officer.id,
+        )
+
+    repo = OfficerRepository(db)
+    # Chỉ 3 lead active được tính; 5 lead sts20 đã đóng bị loại.
+    assert await repo.get_workload_count(officer.id) == 3
+
+    # Parity: dashboard count khớp định nghĩa workload của thuật toán auto-assign.
+    # 3/10 = 0.3 < 0.8 -> officer còn dưới ngưỡng (sts20 không làm officer "đầy tải").
+    assert await is_officer_at_threshold(db, officer) is False
+
+
 # ---------------------------------------------------------------------------
 # Beat task body: moves only stale sts04 leads (predicate + transition)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fix: officer dashboard workload đếm sai lead terminal

`OfficerRepository.get_workload_count` (nguồn "Đang xử lý"/utilization) lọc theo `PipelineStage.is_final_stage`. Trạng thái terminal `sts20` (Đã ngừng tư vấn) nằm trong stage `stg02` chưa-final → lead give-up **không bị loại** → workload không giảm sau khi đóng lead. Cũng ảnh hưởng sts16 (stg04), sts18 (stg05).

### Fix
Đổi sang `ConsultationStatus.is_final` — khớp single source of truth của `is_officer_at_threshold` (auto-assign), `get_kpi_stats` realtime active_leads, `get_aggregated_kpis` (manager view). On-demand query → không backfill; WorkloadCard thin-client + Socket.IO → FE không đổi.

### Test
+`test_dashboard_workload_count_excludes_terminal_in_nonfinal_stage`: 3 active (sts04) + 5 give-up (sts20) → workload=3. Regression guard nếu revert về is_final_stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)