### PR TITLE
feat(sms): PR-2 contact management BE — CRUD + import dedupe + consent ledger

### DIFF
--- a/Backend_FastAPI/app/repositories/sms_contact_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_contact_repository.py
@@ -1,0 +1,329 @@
+# app/repositories/sms_contact_repository.py
+"""
+Data-access cho SMS Marketing contact domain (PR-2): group, contact,
+membership, consent-event ledger, import batch.
+
+Standalone repository (KHÔNG kế thừa BaseRepository — model SMS không có
+`deleted_at` và không cần `get_filtered` abstract). Mọi method async, dùng
+`select()` + `selectinload`/`func.count`. Projection consent cập nhật dưới
+row lock (`get_contact_for_update`). Service gọi `flush`, router `commit`.
+"""
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+from sqlalchemy import case, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.sms import (
+    SmsContact,
+    SmsContactGroup,
+    SmsContactGroupMember,
+    SmsContactImportBatch,
+    SmsMarketingConsentEvent,
+)
+
+
+class SmsContactRepository:
+    """Repository cho contact group/contact/membership/consent/import."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    # ---------------------------------------------------------------
+    # Contact group
+    # ---------------------------------------------------------------
+    async def create_group(self, data: dict) -> SmsContactGroup:
+        group = SmsContactGroup(**data)
+        self.db.add(group)
+        await self.db.flush()
+        return group
+
+    async def get_group(self, group_id: int) -> Optional[SmsContactGroup]:
+        res = await self.db.execute(
+            select(SmsContactGroup).where(SmsContactGroup.id == group_id)
+        )
+        return res.scalars().first()
+
+    async def get_group_by_code(
+        self, code: str
+    ) -> Optional[SmsContactGroup]:
+        res = await self.db.execute(
+            select(SmsContactGroup).where(SmsContactGroup.code == code)
+        )
+        return res.scalars().first()
+
+    async def list_groups(
+        self,
+        skip: int = 0,
+        limit: int = 50,
+        group_type: Optional[str] = None,
+        is_active: Optional[bool] = None,
+        search: Optional[str] = None,
+    ) -> Tuple[int, List[SmsContactGroup]]:
+        conds = []
+        if group_type is not None:
+            conds.append(SmsContactGroup.group_type == group_type)
+        if is_active is not None:
+            conds.append(SmsContactGroup.is_active == is_active)
+        if search:
+            like = f"%{search.strip()}%"
+            conds.append(
+                or_(
+                    SmsContactGroup.name.ilike(like),
+                    SmsContactGroup.code.ilike(like),
+                )
+            )
+        base = select(SmsContactGroup)
+        if conds:
+            base = base.where(*conds)
+        total = await self.db.scalar(
+            select(func.count()).select_from(base.subquery())
+        )
+        res = await self.db.execute(
+            base.order_by(SmsContactGroup.created_at.desc())
+            .offset(skip)
+            .limit(limit)
+        )
+        return int(total or 0), list(res.scalars().all())
+
+    async def count_members_by_group(
+        self, group_ids: Sequence[int]
+    ) -> Dict[int, int]:
+        """Đếm thành viên cho nhiều nhóm 1 query (anti-N+1)."""
+        if not group_ids:
+            return {}
+        res = await self.db.execute(
+            select(
+                SmsContactGroupMember.group_id, func.count()
+            )
+            .where(SmsContactGroupMember.group_id.in_(group_ids))
+            .group_by(SmsContactGroupMember.group_id)
+        )
+        return {row[0]: int(row[1]) for row in res.all()}
+
+    # ---------------------------------------------------------------
+    # Contact
+    # ---------------------------------------------------------------
+    async def create_contact(self, data: dict) -> SmsContact:
+        contact = SmsContact(**data)
+        self.db.add(contact)
+        await self.db.flush()
+        return contact
+
+    async def get_contact(self, contact_id: int) -> Optional[SmsContact]:
+        res = await self.db.execute(
+            select(SmsContact).where(SmsContact.id == contact_id)
+        )
+        return res.scalars().first()
+
+    async def get_contact_for_update(
+        self, contact_id: int
+    ) -> Optional[SmsContact]:
+        """Lock row contact (FOR UPDATE) trước khi cập nhật projection
+        consent — chặn race 2 consent-event ghi latest-state lẫn nhau."""
+        res = await self.db.execute(
+            select(SmsContact)
+            .where(SmsContact.id == contact_id)
+            .with_for_update()
+        )
+        return res.scalar_one_or_none()
+
+    async def lock_contacts_by_ids(
+        self, contact_ids: Sequence[int]
+    ) -> None:
+        """Lock nhiều row contact (FOR UPDATE) 1 query — dùng trước khi
+        cập nhật projection consent hàng loạt (import có bằng chứng)."""
+        if not contact_ids:
+            return
+        await self.db.execute(
+            select(SmsContact.id)
+            .where(SmsContact.id.in_(set(contact_ids)))
+            .with_for_update()
+        )
+
+    async def get_contact_by_phone(
+        self, phone_normalized: str
+    ) -> Optional[SmsContact]:
+        res = await self.db.execute(
+            select(SmsContact).where(
+                SmsContact.phone_normalized == phone_normalized
+            )
+        )
+        return res.scalars().first()
+
+    async def get_contacts_by_phones(
+        self, phones: Sequence[str]
+    ) -> Dict[str, SmsContact]:
+        """Map phone_normalized → contact cho 1 lô (anti-N+1 import)."""
+        if not phones:
+            return {}
+        res = await self.db.execute(
+            select(SmsContact).where(
+                SmsContact.phone_normalized.in_(set(phones))
+            )
+        )
+        return {c.phone_normalized: c for c in res.scalars().all()}
+
+    async def list_contacts(
+        self,
+        skip: int = 0,
+        limit: int = 50,
+        search: Optional[str] = None,
+        consent_status: Optional[str] = None,
+        group_id: Optional[int] = None,
+    ) -> Tuple[int, List[SmsContact]]:
+        base = select(SmsContact)
+        conds = []
+        if group_id is not None:
+            base = base.join(
+                SmsContactGroupMember,
+                SmsContactGroupMember.contact_id == SmsContact.id,
+            )
+            conds.append(SmsContactGroupMember.group_id == group_id)
+        if consent_status is not None:
+            conds.append(
+                SmsContact.marketing_consent_status == consent_status
+            )
+        if search:
+            like = f"%{search.strip()}%"
+            conds.append(
+                or_(
+                    SmsContact.full_name.ilike(like),
+                    SmsContact.phone_normalized.ilike(like),
+                    SmsContact.phone_international.ilike(like),
+                )
+            )
+        if conds:
+            base = base.where(*conds)
+        total = await self.db.scalar(
+            select(func.count()).select_from(base.subquery())
+        )
+        res = await self.db.execute(
+            base.order_by(SmsContact.created_at.desc())
+            .offset(skip)
+            .limit(limit)
+        )
+        return int(total or 0), list(res.scalars().all())
+
+    # ---------------------------------------------------------------
+    # Membership
+    # ---------------------------------------------------------------
+    async def get_membership(
+        self, group_id: int, contact_id: int
+    ) -> Optional[SmsContactGroupMember]:
+        res = await self.db.execute(
+            select(SmsContactGroupMember).where(
+                SmsContactGroupMember.group_id == group_id,
+                SmsContactGroupMember.contact_id == contact_id,
+            )
+        )
+        return res.scalars().first()
+
+    async def get_existing_member_contact_ids(
+        self, group_id: int, contact_ids: Sequence[int]
+    ) -> Set[int]:
+        """Tập contact_id ĐÃ là member nhóm (anti-N+1 import)."""
+        if not contact_ids:
+            return set()
+        res = await self.db.execute(
+            select(SmsContactGroupMember.contact_id).where(
+                SmsContactGroupMember.group_id == group_id,
+                SmsContactGroupMember.contact_id.in_(set(contact_ids)),
+            )
+        )
+        return {row[0] for row in res.all()}
+
+    async def create_membership(
+        self, data: dict
+    ) -> SmsContactGroupMember:
+        member = SmsContactGroupMember(**data)
+        self.db.add(member)
+        await self.db.flush()
+        return member
+
+    async def delete_membership(
+        self, member: SmsContactGroupMember
+    ) -> None:
+        await self.db.delete(member)
+        await self.db.flush()
+
+    # ---------------------------------------------------------------
+    # Consent-event ledger
+    # ---------------------------------------------------------------
+    async def create_consent_event(
+        self, data: dict
+    ) -> SmsMarketingConsentEvent:
+        event = SmsMarketingConsentEvent(**data)
+        self.db.add(event)
+        await self.db.flush()
+        return event
+
+    @staticmethod
+    def _latest_event_order():
+        """Thứ tự chọn event "mới nhất": occurred_at DESC; khi BẰNG nhau →
+        REVOKE thắng (fail-closed, không để grant ghi-sau khôi phục revoke);
+        cuối cùng id DESC cho ổn định."""
+        revoke_first = case(
+            (SmsMarketingConsentEvent.event_type == "revoked", 0), else_=1
+        )
+        return (
+            SmsMarketingConsentEvent.occurred_at.desc(),
+            revoke_first.asc(),
+            SmsMarketingConsentEvent.id.desc(),
+        )
+
+    async def get_latest_consent_event(
+        self, contact_id: int
+    ) -> Optional[SmsMarketingConsentEvent]:
+        """Event consent "mới nhất" của 1 contact (xem `_latest_event_order`)."""
+        res = await self.db.execute(
+            select(SmsMarketingConsentEvent)
+            .where(SmsMarketingConsentEvent.contact_id == contact_id)
+            .order_by(*self._latest_event_order())
+            .limit(1)
+        )
+        return res.scalars().first()
+
+    async def get_latest_consent_events_for_contacts(
+        self, contact_ids: Sequence[int]
+    ) -> Dict[int, SmsMarketingConsentEvent]:
+        """Map contact_id → event "mới nhất" cho nhiều contact 1 query
+        (DISTINCT ON) — thay N+1 khi reproject hàng loạt lúc import."""
+        if not contact_ids:
+            return {}
+        res = await self.db.execute(
+            select(SmsMarketingConsentEvent)
+            .where(SmsMarketingConsentEvent.contact_id.in_(set(contact_ids)))
+            .distinct(SmsMarketingConsentEvent.contact_id)
+            .order_by(
+                SmsMarketingConsentEvent.contact_id,
+                *self._latest_event_order(),
+            )
+        )
+        return {e.contact_id: e for e in res.scalars().all()}
+
+    async def list_consent_events(
+        self, contact_id: int, skip: int = 0, limit: int = 50
+    ) -> Tuple[int, List[SmsMarketingConsentEvent]]:
+        base = select(SmsMarketingConsentEvent).where(
+            SmsMarketingConsentEvent.contact_id == contact_id
+        )
+        total = await self.db.scalar(
+            select(func.count()).select_from(base.subquery())
+        )
+        res = await self.db.execute(
+            base.order_by(SmsMarketingConsentEvent.occurred_at.desc())
+            .offset(skip)
+            .limit(limit)
+        )
+        return int(total or 0), list(res.scalars().all())
+
+    # ---------------------------------------------------------------
+    # Import batch
+    # ---------------------------------------------------------------
+    async def create_import_batch(
+        self, data: dict
+    ) -> SmsContactImportBatch:
+        batch = SmsContactImportBatch(**data)
+        self.db.add(batch)
+        await self.db.flush()
+        return batch

--- a/Backend_FastAPI/app/routers/sms_contacts.py
+++ b/Backend_FastAPI/app/routers/sms_contacts.py
@@ -1,9 +1,281 @@
 # app/routers/sms_contacts.py
 """
-SMS Marketing — contact groups & contacts (admin only).
-Stub PR-1; routes thêm ở **PR-2 (Codex)**: contact-groups CRUD + contacts
-CRUD + membership + import. KHÔNG sửa main.py (đã wire ở PR-1).
+SMS Marketing — contact groups & contacts (admin only). PR-2.
+
+Router "dumb": chỉ dịch HTTP ↔ service, commit transaction, không chứa
+business logic. Hard gate `require_admin` (Phase 1 admin-only, §2.1 #9).
+Service raise domain exception → middleware map sang HTTP. KHÔNG sửa
+main.py (đã wire ở PR-1).
 """
-from fastapi import APIRouter
+import hashlib
+from datetime import datetime
+from typing import Optional
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    Query,
+    UploadFile,
+    status,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database, models
+from app.core.deps import require_admin
+from app.schemas import sms as sms_schemas
+from app.services.sms_contact_service import SmsContactService
 
 router = APIRouter(prefix="/api/sms", tags=["SMS Contacts"])
+
+
+# =====================================================================
+# Contact groups
+# =====================================================================
+@router.post(
+    "/contact-groups",
+    response_model=sms_schemas.SmsContactGroupOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_contact_group(
+    payload: sms_schemas.SmsContactGroupCreate,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    group = await SmsContactService(db).create_group(payload, current_user)
+    await db.commit()
+    return group
+
+
+@router.get(
+    "/contact-groups", response_model=sms_schemas.SmsContactGroupList
+)
+async def list_contact_groups(
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    group_type: Optional[str] = Query(None),
+    is_active: Optional[bool] = Query(None),
+    search: Optional[str] = Query(None),
+):
+    total, items = await SmsContactService(db).list_groups(
+        skip=skip,
+        limit=limit,
+        group_type=group_type,
+        is_active=is_active,
+        search=search,
+    )
+    return {"total": total, "items": items}
+
+
+@router.get(
+    "/contact-groups/{group_id}",
+    response_model=sms_schemas.SmsContactGroupOut,
+)
+async def get_contact_group(
+    group_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    return await SmsContactService(db).get_group(group_id)
+
+
+@router.patch(
+    "/contact-groups/{group_id}",
+    response_model=sms_schemas.SmsContactGroupOut,
+)
+async def update_contact_group(
+    group_id: int,
+    payload: sms_schemas.SmsContactGroupUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    group = await SmsContactService(db).update_group(group_id, payload)
+    await db.commit()
+    return group
+
+
+@router.post(
+    "/contact-groups/{group_id}/contacts/upload",
+    response_model=sms_schemas.SmsImportResult,
+)
+async def upload_contacts_to_group(
+    group_id: int,
+    file: UploadFile = File(..., description="File .csv hoặc .xlsx"),
+    source_label: Optional[str] = Form(None),
+    consent_basis: Optional[str] = Form(None),
+    consent_disclosure_version: Optional[str] = Form(None),
+    consent_proof_ref: Optional[str] = Form(None),
+    consent_obtained_at: Optional[datetime] = Form(None),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    content = await file.read()
+    file_sha256 = hashlib.sha256(content).hexdigest() if content else None
+    result = await SmsContactService(db).import_contacts(
+        group_id=group_id,
+        file_content=content,
+        filename=file.filename or "",
+        user=current_user,
+        source_label=source_label,
+        consent_basis=consent_basis,
+        consent_disclosure_version=consent_disclosure_version,
+        consent_proof_ref=consent_proof_ref,
+        consent_obtained_at=consent_obtained_at,
+        file_sha256=file_sha256,
+    )
+    await db.commit()
+    return result
+
+
+@router.get(
+    "/contact-groups/{group_id}/contacts",
+    response_model=sms_schemas.SmsContactList,
+)
+async def list_group_contacts(
+    group_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    search: Optional[str] = Query(None),
+    consent_status: Optional[str] = Query(None),
+):
+    # 404 nếu nhóm không tồn tại
+    await SmsContactService(db).get_group(group_id)
+    total, items = await SmsContactService(db).list_contacts(
+        skip=skip,
+        limit=limit,
+        search=search,
+        consent_status=consent_status,
+        group_id=group_id,
+    )
+    return {"total": total, "items": items}
+
+
+# =====================================================================
+# Contacts
+# =====================================================================
+@router.get("/contacts", response_model=sms_schemas.SmsContactList)
+async def list_contacts(
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    search: Optional[str] = Query(None),
+    consent_status: Optional[str] = Query(None),
+):
+    total, items = await SmsContactService(db).list_contacts(
+        skip=skip,
+        limit=limit,
+        search=search,
+        consent_status=consent_status,
+    )
+    return {"total": total, "items": items}
+
+
+@router.post(
+    "/contacts",
+    response_model=sms_schemas.SmsContactOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_contact(
+    payload: sms_schemas.SmsContactCreate,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    contact = await SmsContactService(db).create_contact(
+        payload, current_user
+    )
+    await db.commit()
+    return contact
+
+
+@router.patch(
+    "/contacts/{contact_id}", response_model=sms_schemas.SmsContactOut
+)
+async def update_contact(
+    contact_id: int,
+    payload: sms_schemas.SmsContactUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    contact = await SmsContactService(db).update_contact(
+        contact_id, payload
+    )
+    await db.commit()
+    return contact
+
+
+@router.post(
+    "/contacts/{contact_id}/consent-events",
+    response_model=sms_schemas.SmsConsentEventOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def append_consent_event(
+    contact_id: int,
+    payload: sms_schemas.SmsConsentEventCreate,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    event = await SmsContactService(db).append_consent_event(
+        contact_id, payload, current_user
+    )
+    await db.commit()
+    return event
+
+
+@router.get(
+    "/contacts/{contact_id}/consent-events",
+    response_model=sms_schemas.SmsConsentEventList,
+)
+async def list_consent_events(
+    contact_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+):
+    total, items = await SmsContactService(db).list_consent_events(
+        contact_id, skip=skip, limit=limit
+    )
+    return {"total": total, "items": items}
+
+
+@router.post(
+    "/contacts/{contact_id}/groups",
+    response_model=sms_schemas.SmsContactOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_contact_to_group(
+    contact_id: int,
+    payload: sms_schemas.SmsGroupMembershipAdd,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    service = SmsContactService(db)
+    await service.add_contact_to_group(
+        contact_id, payload.group_id, payload.note, current_user
+    )
+    await db.commit()
+    # Trả contact (kèm trạng thái mới nhất) cho client tiện refresh
+    return await service.get_contact(contact_id)
+
+
+@router.delete(
+    "/contacts/{contact_id}/groups/{group_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def remove_contact_from_group(
+    contact_id: int,
+    group_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    await SmsContactService(db).remove_contact_from_group(
+        contact_id, group_id
+    )
+    await db.commit()
+    return None

--- a/Backend_FastAPI/app/schemas/sms.py
+++ b/Backend_FastAPI/app/schemas/sms.py
@@ -1,0 +1,294 @@
+# app/schemas/sms.py
+"""
+Pydantic v2 schemas cho SMS Marketing — PR-2 (Contact Management BE).
+
+Bao gồm: contact group CRUD, contact CRUD, membership, consent-event
+ledger (append-only), kết quả import. Các enum literal mirror đúng CHECK
+constraint ở model (app/models/sms/) để validate fail-fast (400) trước khi
+chạm DB. Xem `Documents/SMS_MARKETING_MODULE_DESIGN.md` §4 + §10.
+"""
+from datetime import datetime, timedelta, timezone
+from typing import List, Literal, Optional
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
+
+
+def _strip_required_text(v):
+    """Strip + chặn chuỗi toàn khoảng trắng cho trường NOT NULL. None
+    (field không gửi / gửi null ở Update) giữ nguyên để service xử lý."""
+    if v is None:
+        return v
+    v = v.strip()
+    if not v:
+        raise ValueError("không được rỗng/toàn khoảng trắng")
+    return v
+
+
+def validate_consent_datetime(dt, *, label="thời điểm"):
+    """Yêu cầu datetime CÓ timezone và KHÔNG ở tương lai.
+
+    Naive datetime bị TỪ CHỐI (KHÔNG tự coi là UTC): client gửi giờ địa
+    phương (vd Asia/Saigon +07) mà coi là UTC sẽ lệch 7h → giờ hiện tại bị
+    xem là "tương lai" + sai thứ tự consent ledger. Bắt buộc tz tường minh.
+    Dung sai 5' cho lệch đồng hồ. Raise ValueError (Pydantic → 422)."""
+    if dt is None:
+        return dt
+    if dt.tzinfo is None:
+        raise ValueError(f"{label} phải kèm timezone (vd +07:00 hoặc Z)")
+    if dt > datetime.now(timezone.utc) + timedelta(minutes=5):
+        raise ValueError(f"{label} không được ở tương lai")
+    return dt
+
+
+# --- Enum literal (mirror CHECK constraint model) ---
+GroupType = Literal["parent", "student", "teacher", "lead", "custom"]
+ConsentBasis = Literal[
+    "explicit_form", "signed_form", "recorded_call", "imported_proof"
+]
+RevokeSource = Literal[
+    "sms_reply", "landing_optout", "manual", "phone_call",
+    "external_suppression",
+]
+ConsentEventType = Literal["granted", "revoked"]
+
+
+# =====================================================================
+# Contact Group
+# =====================================================================
+class SmsContactGroupCreate(BaseModel):
+    """Tạo nhóm liên hệ. `code` tùy chọn — service tự slugify từ `name`."""
+
+    name: str = Field(..., min_length=1, max_length=200)
+    code: Optional[str] = Field(
+        None, max_length=50, pattern=r"^[a-z0-9][a-z0-9-]*$",
+        description="slug duy nhất; bỏ trống để tự sinh từ name",
+    )
+    group_type: GroupType
+    description: Optional[str] = Field(None, max_length=2000)
+
+    @field_validator("name")
+    @classmethod
+    def _v_name(cls, v):
+        return _strip_required_text(v)
+
+
+class SmsContactGroupUpdate(BaseModel):
+    """Sửa nhóm — không cho đổi `code` (slug bền vững)."""
+
+    name: Optional[str] = Field(None, min_length=1, max_length=200)
+    group_type: Optional[GroupType] = None
+    description: Optional[str] = Field(None, max_length=2000)
+    is_active: Optional[bool] = None
+
+    @field_validator("name")
+    @classmethod
+    def _v_name(cls, v):
+        return _strip_required_text(v)
+
+
+class SmsContactGroupOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    code: str
+    group_type: str
+    description: Optional[str] = None
+    is_active: bool
+    created_by_id: Optional[int] = None
+    created_at: datetime
+    updated_at: datetime
+    member_count: Optional[int] = Field(
+        None, description="số thành viên (chỉ điền ở list/detail có đếm)"
+    )
+
+
+class SmsContactGroupList(BaseModel):
+    total: int
+    items: List[SmsContactGroupOut]
+
+
+# =====================================================================
+# Contact
+# =====================================================================
+class SmsContactCreate(BaseModel):
+    """Tạo 1 liên hệ. `phone` là số gốc — service normalize + validate
+    mobile-only. Consent KHÔNG set ở đây (mặc định `unknown`); dùng
+    endpoint consent-events để ghi bằng chứng."""
+
+    full_name: str = Field(..., min_length=1, max_length=255)
+    phone: str = Field(..., min_length=1, max_length=32)
+    note: Optional[str] = Field(None, max_length=2000)
+    source_label: Optional[str] = Field(None, max_length=255)
+
+    @field_validator("full_name")
+    @classmethod
+    def _v_full_name(cls, v):
+        return _strip_required_text(v)
+
+
+class SmsContactUpdate(BaseModel):
+    """Sửa identity/note — KHÔNG cho đổi `phone` (identity unique) và
+    KHÔNG đụng consent ledger (dùng consent-events)."""
+
+    full_name: Optional[str] = Field(None, min_length=1, max_length=255)
+    note: Optional[str] = Field(None, max_length=2000)
+    source_label: Optional[str] = Field(None, max_length=255)
+
+    @field_validator("full_name")
+    @classmethod
+    def _v_full_name(cls, v):
+        return _strip_required_text(v)
+
+
+class SmsContactOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    full_name: str
+    phone_raw: Optional[str] = None
+    phone_normalized: str
+    phone_international: str
+    note: Optional[str] = None
+    source_label: Optional[str] = None
+    marketing_consent_status: str
+    marketing_consented_at: Optional[datetime] = None
+    marketing_consent_basis: Optional[str] = None
+    marketing_consent_proof_ref: Optional[str] = None
+    consent_disclosure_version: Optional[str] = None
+    last_handed_off_at: Optional[datetime] = None
+    created_by_id: Optional[int] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class SmsContactList(BaseModel):
+    total: int
+    items: List[SmsContactOut]
+
+
+# =====================================================================
+# Membership
+# =====================================================================
+class SmsGroupMembershipAdd(BaseModel):
+    """Thêm contact vào 1 nhóm (note riêng trong nhóm tùy chọn)."""
+
+    group_id: int = Field(..., ge=1)
+    note: Optional[str] = Field(None, max_length=2000)
+
+
+# =====================================================================
+# Consent event (append-only ledger)
+# =====================================================================
+class SmsConsentEventCreate(BaseModel):
+    """Append 1 sự kiện consent. GRANT cần đủ basis + disclosure_version +
+    proof_reference (non-rỗng); REVOKE cần revoke_source. Validate fail-fast
+    mirror CHECK ở DB để trả 400 thay vì 500."""
+
+    event_type: ConsentEventType
+    occurred_at: datetime
+    # GRANT-only
+    basis: Optional[ConsentBasis] = None
+    disclosure_version: Optional[str] = Field(None, max_length=50)
+    proof_reference: Optional[str] = Field(None, max_length=512)
+    # REVOKE-only
+    revoke_source: Optional[RevokeSource] = None
+    metadata_json: Optional[dict] = None
+
+    @field_validator("occurred_at")
+    @classmethod
+    def _v_occurred_at(cls, v):
+        return validate_consent_datetime(v, label="occurred_at")
+
+    @model_validator(mode="after")
+    def _check_consent_contract(self) -> "SmsConsentEventCreate":
+        if self.event_type == "granted":
+            missing = (
+                self.basis is None
+                or not (self.disclosure_version or "").strip()
+                or not (self.proof_reference or "").strip()
+            )
+            if missing:
+                raise ValueError(
+                    "GRANT cần basis + disclosure_version + proof_reference "
+                    "(không rỗng)"
+                )
+            if self.revoke_source is not None:
+                raise ValueError("GRANT không được mang revoke_source")
+        else:  # revoked
+            if self.revoke_source is None:
+                raise ValueError("REVOKE cần revoke_source")
+            if (
+                self.basis is not None
+                or (self.disclosure_version or "").strip()
+                or (self.proof_reference or "").strip()
+            ):
+                raise ValueError(
+                    "REVOKE không được mang grant-data "
+                    "(basis/disclosure_version/proof_reference)"
+                )
+        return self
+
+
+class SmsConsentEventOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    contact_id: Optional[int] = None
+    phone_normalized_snapshot: str
+    event_type: str
+    basis: Optional[str] = None
+    revoke_source: Optional[str] = None
+    disclosure_version: Optional[str] = None
+    proof_reference: Optional[str] = None
+    occurred_at: datetime
+    recorded_by_id: Optional[int] = None
+    import_batch_id: Optional[int] = None
+    metadata_json: Optional[dict] = None
+    created_at: datetime
+
+
+class SmsConsentEventList(BaseModel):
+    total: int
+    items: List[SmsConsentEventOut]
+
+
+# =====================================================================
+# Import (upload contacts vào nhóm)
+# =====================================================================
+class SmsImportRowError(BaseModel):
+    """Lỗi 1 dòng import (bỏ qua, không chặn cả lô)."""
+
+    row_number: int = Field(..., description="số dòng trong file (1-based)")
+    phone_raw: Optional[str] = None
+    reason: str
+
+
+class SmsImportResult(BaseModel):
+    """Kết quả import — counts thỏa bất biến anchor (§4.4)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    batch_id: int
+    group_id: Optional[int] = None
+    file_name: Optional[str] = None
+    row_count: int
+    valid_count: int
+    invalid_count: int
+    duplicate_contact_count: int
+    existing_member_count: int
+    inserted_contact_count: int
+    added_member_count: int
+    skipped_count: int
+    consent_applied: bool = Field(
+        ...,
+        description="True nếu lô đủ bằng chứng → áp granted cho mọi contact "
+        "trong lô (theo occurred_at; revoke mới hơn không bị override)",
+    )
+    errors: List[SmsImportRowError] = Field(default_factory=list)

--- a/Backend_FastAPI/app/services/sms_contact_service.py
+++ b/Backend_FastAPI/app/services/sms_contact_service.py
@@ -1,0 +1,705 @@
+# app/services/sms_contact_service.py
+"""
+Business logic SMS Marketing contact domain (PR-2).
+
+Bao gồm: CRUD contact group/contact, membership N-N, consent-event ledger
+append-only + projection latest-state dưới row lock, import mobile-only
+dedupe global (counts thỏa bất biến §4.4).
+
+Tuân thủ kiến trúc QLTS: KHÔNG import fastapi; raise domain exception (không
+HTTPException); chỉ `flush` (router `commit`). SMS marketing KHÔNG qua
+dispatch() (§11.8) nên service trả thẳng result, không (result, callback).
+"""
+import io
+import re
+import unicodedata
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.sms import (
+    SmsContact,
+    SmsContactGroup,
+    SmsContactGroupMember,
+    SmsMarketingConsentEvent,
+)
+from app.repositories.sms_contact_repository import SmsContactRepository
+from app.schemas import sms as sms_schemas
+from app.utils.exceptions import (
+    ConflictError,
+    DuplicateResourceError,
+    FileSizeError,
+    FileTypeError,
+    ResourceNotFoundError,
+    ValidationError,
+)
+from app.utils.phone_helpers import (
+    is_vietnam_mobile,
+    normalize_vietnam_phone,
+    to_zalo_phone,
+)
+
+# Import giới hạn an toàn
+MAX_IMPORT_FILE_SIZE = 10 * 1024 * 1024  # 10 MB
+MAX_IMPORT_ROWS = 50000
+
+# Alias header tiếng Việt → tên cột chuẩn
+_COL_ALIASES = {
+    "full_name": {"full_name", "fullname", "ho_ten", "hoten", "ten", "name"},
+    "phone": {
+        "phone", "so_dien_thoai", "sodienthoai", "sdt", "dien_thoai",
+        "phone_number", "phonenumber",
+    },
+    "note": {"note", "ghi_chu", "ghichu", "notes"},
+}
+
+
+def _slugify(name: str) -> str:
+    """Sinh slug ASCII (bỏ dấu tiếng Việt) cho group code."""
+    s = unicodedata.normalize("NFD", name or "")
+    s = "".join(c for c in s if unicodedata.category(c) != "Mn")
+    s = s.replace("đ", "d").replace("Đ", "D").lower().strip()
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
+    return s[:50] or "group"
+
+
+def _resolve_columns(columns: List[str]) -> dict:
+    """Map tên cột thực (đã chuẩn hóa) → cột chuẩn. Trả {chuẩn: thực}."""
+    found = {}
+    norm = {c.lower().strip().replace(" ", "_"): c for c in columns}
+    for canonical, aliases in _COL_ALIASES.items():
+        for key, original in norm.items():
+            if key in aliases:
+                found[canonical] = original
+                break
+    return found
+
+
+def _reject_null(patch: dict, fields) -> None:
+    """Raise ValidationError nếu PATCH gửi explicit null cho cột NOT NULL.
+
+    `exclude_unset=True` GIỮ explicit null → `setattr(obj, f, None)` →
+    IntegrityError 500. Chặn sớm thành 400 cho rõ nghĩa.
+    """
+    for f in fields:
+        if f in patch and patch[f] is None:
+            raise ValidationError(detail=f"Trường '{f}' không được null")
+
+
+class SmsContactService:
+    """Service contact group/contact/membership/consent/import."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = SmsContactRepository(db)
+
+    # ===============================================================
+    # Contact group
+    # ===============================================================
+    async def create_group(
+        self, data: sms_schemas.SmsContactGroupCreate, user
+    ) -> SmsContactGroup:
+        code = (data.code or _slugify(data.name)).strip()
+        existing = await self.repo.get_group_by_code(code)
+        if existing is not None:
+            raise DuplicateResourceError(
+                detail=f"Mã nhóm '{code}' đã tồn tại"
+            )
+        try:
+            group = await self.repo.create_group(
+                {
+                    "name": data.name.strip(),
+                    "code": code,
+                    "group_type": data.group_type,
+                    "description": data.description,
+                    "created_by_id": getattr(user, "id", None),
+                }
+            )
+        except IntegrityError:  # race UNIQUE(code) → 409 thay vì 500
+            raise DuplicateResourceError(
+                detail=f"Mã nhóm '{code}' đã tồn tại"
+            )
+        group.member_count = 0
+        return group
+
+    async def get_group(self, group_id: int) -> SmsContactGroup:
+        group = await self.repo.get_group(group_id)
+        if group is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy nhóm liên hệ")
+        counts = await self.repo.count_members_by_group([group_id])
+        group.member_count = counts.get(group_id, 0)
+        return group
+
+    async def list_groups(
+        self,
+        skip: int,
+        limit: int,
+        group_type: Optional[str] = None,
+        is_active: Optional[bool] = None,
+        search: Optional[str] = None,
+    ) -> Tuple[int, List[SmsContactGroup]]:
+        total, items = await self.repo.list_groups(
+            skip=skip,
+            limit=limit,
+            group_type=group_type,
+            is_active=is_active,
+            search=search,
+        )
+        counts = await self.repo.count_members_by_group(
+            [g.id for g in items]
+        )
+        for g in items:
+            g.member_count = counts.get(g.id, 0)
+        return total, items
+
+    async def update_group(
+        self, group_id: int, data: sms_schemas.SmsContactGroupUpdate
+    ) -> SmsContactGroup:
+        group = await self.repo.get_group(group_id)
+        if group is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy nhóm liên hệ")
+        patch = data.model_dump(exclude_unset=True)
+        # name đã strip ở schema; chặn explicit null cho cột NOT NULL.
+        _reject_null(patch, ("name", "group_type", "is_active"))
+        for key, value in patch.items():
+            setattr(group, key, value)
+        await self.db.flush()
+        # onupdate=func.now() expire updated_at sau UPDATE → refresh để
+        # load lại trước khi serialize (tránh lazy-load IO ngoài greenlet).
+        await self.db.refresh(group)
+        counts = await self.repo.count_members_by_group([group_id])
+        group.member_count = counts.get(group_id, 0)
+        return group
+
+    # ===============================================================
+    # Contact
+    # ===============================================================
+    def _normalize_mobile(self, phone_raw: str) -> Tuple[str, str]:
+        """Normalize + ép mobile-only. Trả (normalized, international).
+        Raise ValidationError nếu không phải di động VN hợp lệ."""
+        normalized = normalize_vietnam_phone(phone_raw)
+        if not normalized or not is_vietnam_mobile(normalized):
+            raise ValidationError(
+                detail="Số điện thoại không hợp lệ (chỉ nhận di động VN)"
+            )
+        international = to_zalo_phone(normalized)
+        return normalized, international
+
+    async def create_contact(
+        self, data: sms_schemas.SmsContactCreate, user
+    ) -> SmsContact:
+        normalized, international = self._normalize_mobile(data.phone)
+        existing = await self.repo.get_contact_by_phone(normalized)
+        if existing is not None:
+            raise DuplicateResourceError(
+                detail="Số điện thoại đã tồn tại trong danh bạ"
+            )
+        try:
+            return await self.repo.create_contact(
+                {
+                    "full_name": data.full_name.strip(),
+                    "phone_raw": data.phone.strip(),
+                    "phone_normalized": normalized,
+                    "phone_international": international,
+                    "note": data.note,
+                    "source_label": data.source_label,
+                    "created_by_id": getattr(user, "id", None),
+                }
+            )
+        except IntegrityError:
+            # Race TOCTOU: 2 request cùng vượt pre-check → UNIQUE bắt → 409.
+            raise DuplicateResourceError(
+                detail="Số điện thoại đã tồn tại trong danh bạ"
+            )
+
+    async def get_contact(self, contact_id: int) -> SmsContact:
+        contact = await self.repo.get_contact(contact_id)
+        if contact is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy liên hệ")
+        return contact
+
+    async def list_contacts(
+        self,
+        skip: int,
+        limit: int,
+        search: Optional[str] = None,
+        consent_status: Optional[str] = None,
+        group_id: Optional[int] = None,
+    ) -> Tuple[int, List[SmsContact]]:
+        return await self.repo.list_contacts(
+            skip=skip,
+            limit=limit,
+            search=search,
+            consent_status=consent_status,
+            group_id=group_id,
+        )
+
+    async def update_contact(
+        self, contact_id: int, data: sms_schemas.SmsContactUpdate
+    ) -> SmsContact:
+        contact = await self.get_contact(contact_id)
+        patch = data.model_dump(exclude_unset=True)
+        # full_name đã strip ở schema; chặn explicit null (cột NOT NULL).
+        _reject_null(patch, ("full_name",))
+        for key, value in patch.items():
+            setattr(contact, key, value)
+        await self.db.flush()
+        # onupdate=func.now() expire updated_at → refresh trước serialize.
+        await self.db.refresh(contact)
+        return contact
+
+    # ===============================================================
+    # Membership
+    # ===============================================================
+    async def add_contact_to_group(
+        self, contact_id: int, group_id: int, note: Optional[str], user
+    ) -> SmsContactGroupMember:
+        # IDOR/existence: cả contact lẫn group phải tồn tại
+        if await self.repo.get_contact(contact_id) is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy liên hệ")
+        if await self.repo.get_group(group_id) is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy nhóm liên hệ")
+        existing = await self.repo.get_membership(group_id, contact_id)
+        if existing is not None:
+            raise DuplicateResourceError(
+                detail="Liên hệ đã thuộc nhóm này"
+            )
+        try:
+            return await self.repo.create_membership(
+                {
+                    "group_id": group_id,
+                    "contact_id": contact_id,
+                    "note": note,
+                    "added_by_id": getattr(user, "id", None),
+                }
+            )
+        except IntegrityError:  # race UNIQUE(group,contact) → 409
+            raise DuplicateResourceError(
+                detail="Liên hệ đã thuộc nhóm này"
+            )
+
+    async def remove_contact_from_group(
+        self, contact_id: int, group_id: int
+    ) -> None:
+        member = await self.repo.get_membership(group_id, contact_id)
+        if member is None:
+            raise ResourceNotFoundError(
+                detail="Liên hệ không thuộc nhóm này"
+            )
+        await self.repo.delete_membership(member)
+
+    # ===============================================================
+    # Consent-event ledger (append-only) + projection latest-state
+    # ===============================================================
+    @staticmethod
+    def _apply_consent_projection(
+        contact: SmsContact, event: SmsMarketingConsentEvent
+    ) -> None:
+        """Đặt projection latest-state trên contact theo 1 event đã chọn."""
+        if event.event_type == "granted":
+            contact.marketing_consent_status = "granted"
+            contact.marketing_consented_at = event.occurred_at
+            contact.marketing_consent_basis = event.basis
+            contact.marketing_consent_proof_ref = event.proof_reference
+            contact.consent_disclosure_version = event.disclosure_version
+        else:  # revoked
+            contact.marketing_consent_status = "revoked"
+
+    async def _reproject_from_latest(self, contact: SmsContact) -> None:
+        """Chiếu projection theo event "mới nhất" của contact.
+
+        Fail-closed (§4.12): event occurred_at CŨ KHÔNG override trạng thái
+        mới hơn; khi cùng occurred_at thì REVOKE thắng (repo tie-break).
+        Gọi sau khi đã append event (event đã flush nên query thấy).
+        """
+        event = await self.repo.get_latest_consent_event(contact.id)
+        if event is not None:
+            self._apply_consent_projection(contact, event)
+
+    async def append_consent_event(
+        self, contact_id: int, data: sms_schemas.SmsConsentEventCreate, user
+    ) -> SmsMarketingConsentEvent:
+        # Row lock chặn race 2 event ghi projection lẫn nhau (§13).
+        contact = await self.repo.get_contact_for_update(contact_id)
+        if contact is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy liên hệ")
+
+        event = await self.repo.create_consent_event(
+            {
+                "contact_id": contact.id,
+                "phone_normalized_snapshot": contact.phone_normalized,
+                "event_type": data.event_type,
+                "basis": data.basis,
+                "revoke_source": data.revoke_source,
+                "disclosure_version": data.disclosure_version,
+                "proof_reference": data.proof_reference,
+                "occurred_at": data.occurred_at,
+                "recorded_by_id": getattr(user, "id", None),
+                "metadata_json": data.metadata_json,
+            }
+        )
+        # Projection latest-state theo occurred_at (đang giữ lock) — KHÔNG
+        # set mù theo event vừa ghi (event cũ không override trạng thái mới).
+        await self._reproject_from_latest(contact)
+        await self.db.flush()
+        return event
+
+    async def list_consent_events(
+        self, contact_id: int, skip: int, limit: int
+    ) -> Tuple[int, List[SmsMarketingConsentEvent]]:
+        # Đảm bảo contact tồn tại (404 nếu không)
+        await self.get_contact(contact_id)
+        return await self.repo.list_consent_events(
+            contact_id, skip=skip, limit=limit
+        )
+
+    # ===============================================================
+    # Import contacts vào nhóm (mobile-only, dedupe global)
+    # ===============================================================
+    def _validate_consent_evidence(
+        self,
+        consent_basis: Optional[str],
+        consent_disclosure_version: Optional[str],
+        consent_proof_ref: Optional[str],
+        consent_obtained_at: Optional[datetime],
+    ) -> bool:
+        """Hợp lệ hóa bằng chứng consent cấp-lô. Trả True nếu ĐỦ cả 4 →
+        áp granted cho mọi contact trong lô (mới + cũ) qua ledger +
+        reproject. Nếu CÓ một phần nhưng thiếu → 400 (tránh granted nửa
+        vời). Không có gì → False (contact giữ trạng thái hiện tại)."""
+        provided = [
+            bool(consent_basis),
+            bool((consent_disclosure_version or "").strip()),
+            bool((consent_proof_ref or "").strip()),
+            consent_obtained_at is not None,
+        ]
+        if not any(provided):
+            return False
+        if not all(provided):
+            raise ValidationError(
+                detail="Bằng chứng consent thiếu: cần đủ basis + "
+                "disclosure_version + proof_reference + obtained_at"
+            )
+        valid_basis = {
+            "explicit_form", "signed_form", "recorded_call", "imported_proof"
+        }
+        if consent_basis not in valid_basis:
+            raise ValidationError(detail="consent_basis không hợp lệ")
+        try:
+            sms_schemas.validate_consent_datetime(
+                consent_obtained_at, label="consent_obtained_at"
+            )
+        except ValueError as exc:
+            raise ValidationError(detail=str(exc))
+        return True
+
+    def _parse_rows(
+        self, file_content: bytes, filename: str
+    ) -> List[dict]:
+        """Đọc CSV/XLSX → list {full_name, phone, note} (giữ số 0 đầu)."""
+        import pandas as pd
+
+        if not file_content:
+            raise ValidationError(detail="File rỗng")
+        if len(file_content) > MAX_IMPORT_FILE_SIZE:
+            raise FileSizeError(
+                detail=f"File quá lớn (> {MAX_IMPORT_FILE_SIZE // (1024*1024)} MB)"
+            )
+        ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        try:
+            if ext == "csv":
+                df = pd.read_csv(io.BytesIO(file_content), dtype=str)
+            elif ext == "xlsx":
+                df = pd.read_excel(
+                    io.BytesIO(file_content), engine="openpyxl", dtype=str
+                )
+            else:
+                raise FileTypeError(detail="Chỉ nhận file .csv hoặc .xlsx")
+        except (FileTypeError, FileSizeError, ValidationError):
+            raise
+        except Exception as exc:  # noqa: BLE001 — bao lỗi parse thành 400
+            raise ValidationError(detail=f"Không đọc được file: {exc}")
+
+        if len(df) > MAX_IMPORT_ROWS:
+            raise ValidationError(
+                detail=f"File có {len(df)} dòng, tối đa {MAX_IMPORT_ROWS}"
+            )
+        # dtype=str để ô trống thành NaN — ép về "" để tránh str(NaN)="nan".
+        df = df.fillna("")
+        colmap = _resolve_columns(list(df.columns))
+        if "full_name" not in colmap or "phone" not in colmap:
+            raise ValidationError(
+                detail="File thiếu cột bắt buộc 'full_name' và 'phone'"
+            )
+        rows = []
+        for _, row in df.iterrows():
+            rows.append(
+                {
+                    "full_name": str(
+                        row.get(colmap["full_name"]) or ""
+                    ).strip(),
+                    "phone": str(row.get(colmap["phone"]) or "").strip(),
+                    "note": (
+                        str(row.get(colmap["note"]) or "").strip()
+                        if "note" in colmap
+                        else None
+                    ),
+                }
+            )
+        return rows
+
+    async def import_contacts(
+        self,
+        group_id: int,
+        file_content: bytes,
+        filename: str,
+        user,
+        source_label: Optional[str] = None,
+        consent_basis: Optional[str] = None,
+        consent_disclosure_version: Optional[str] = None,
+        consent_proof_ref: Optional[str] = None,
+        consent_obtained_at: Optional[datetime] = None,
+        file_sha256: Optional[str] = None,
+    ) -> sms_schemas.SmsImportResult:
+        group = await self.repo.get_group(group_id)
+        if group is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy nhóm liên hệ")
+        if source_label and len(source_label) > 255:  # cột String(255)
+            raise ValidationError(detail="source_label quá dài (>255 ký tự)")
+        if consent_disclosure_version and len(consent_disclosure_version) > 50:
+            raise ValidationError(
+                detail="consent_disclosure_version quá dài (>50 ký tự)"
+            )
+        if consent_proof_ref and len(consent_proof_ref) > 512:
+            raise ValidationError(
+                detail="consent_proof_ref quá dài (>512 ký tự)"
+            )
+
+        consent_applied = self._validate_consent_evidence(
+            consent_basis,
+            consent_disclosure_version,
+            consent_proof_ref,
+            consent_obtained_at,
+        )
+        rows = self._parse_rows(file_content, filename or "")
+
+        # --- Phân loại từng dòng (mỗi dòng vào ĐÚNG 1 bucket) ---
+        errors: List[sms_schemas.SmsImportRowError] = []
+        invalid_count = 0
+        duplicate_count = 0
+        seen_in_file: set = set()
+        valid_rows: List[dict] = []  # {full_name, phone_raw, normalized}
+        for idx, r in enumerate(rows):
+            line = idx + 2  # +1 header, +1 cho 1-based
+            if not r["full_name"]:
+                invalid_count += 1
+                errors.append(
+                    sms_schemas.SmsImportRowError(
+                        row_number=line, phone_raw=r["phone"] or None,
+                        reason="Thiếu họ tên",
+                    )
+                )
+                continue
+            if len(r["full_name"]) > 255:  # cột NOT NULL String(255) → 500
+                invalid_count += 1
+                errors.append(
+                    sms_schemas.SmsImportRowError(
+                        row_number=line, phone_raw=r["phone"] or None,
+                        reason="Họ tên quá dài (>255 ký tự)",
+                    )
+                )
+                continue
+            normalized = normalize_vietnam_phone(r["phone"])
+            if not normalized or not is_vietnam_mobile(normalized):
+                invalid_count += 1
+                errors.append(
+                    sms_schemas.SmsImportRowError(
+                        row_number=line, phone_raw=r["phone"] or None,
+                        reason="Số không phải di động VN hợp lệ",
+                    )
+                )
+                continue
+            if normalized in seen_in_file:
+                duplicate_count += 1
+                errors.append(
+                    sms_schemas.SmsImportRowError(
+                        row_number=line, phone_raw=r["phone"],
+                        reason="Trùng số trong cùng file",
+                    )
+                )
+                continue
+            seen_in_file.add(normalized)
+            valid_rows.append(
+                {
+                    "full_name": r["full_name"],
+                    # phone_raw chỉ để tham chiếu — cắt theo cột String(32).
+                    "phone_raw": r["phone"][:32],
+                    "normalized": normalized,
+                    "note": r["note"] or None,
+                }
+            )
+
+        valid_count = len(valid_rows)
+        row_count = len(rows)
+        phone_to_note = {v["normalized"]: v["note"] for v in valid_rows}
+
+        # --- Dedupe global: tách contact mới vs đã tồn tại ---
+        phones = [v["normalized"] for v in valid_rows]
+        existing_map = await self.repo.get_contacts_by_phones(phones)
+
+        inserted_count = 0
+        new_contacts: List[SmsContact] = []
+        phone_to_contact = dict(existing_map)
+        for v in valid_rows:
+            if v["normalized"] in existing_map:
+                continue  # tái dùng, KHÔNG ghi đè identity (B3)
+            # Contact mới tạo = 'unknown'; consent áp đồng nhất ở bước sau
+            # (cho cả contact cũ) qua ledger + reproject.
+            contact = SmsContact(
+                full_name=v["full_name"],
+                phone_raw=v["phone_raw"],
+                phone_normalized=v["normalized"],
+                phone_international=to_zalo_phone(v["normalized"]),
+                note=v["note"],
+                source_label=source_label,
+                created_by_id=getattr(user, "id", None),
+            )
+            self.db.add(contact)
+            new_contacts.append(contact)
+            inserted_count += 1
+        if new_contacts:
+            try:
+                await self.db.flush()  # lấy id cho membership + consent
+            except IntegrityError:
+                # Race: import đồng thời chèn cùng phone (UNIQUE) → 409.
+                raise ConflictError(
+                    detail="Import trùng số đồng thời, vui lòng thử lại"
+                )
+        for c in new_contacts:
+            phone_to_contact[c.phone_normalized] = c
+
+        # --- Membership: thêm mới vs đã là thành viên (giữ note theo nhóm) ---
+        all_contact_ids = [
+            phone_to_contact[p].id for p in phones if p in phone_to_contact
+        ]
+        existing_member_ids = (
+            await self.repo.get_existing_member_contact_ids(
+                group_id, all_contact_ids
+            )
+        )
+        added_member_count = 0
+        existing_member_count = 0
+        for p in phones:
+            contact = phone_to_contact.get(p)
+            if contact is None:
+                continue
+            if contact.id in existing_member_ids:
+                existing_member_count += 1
+                continue
+            self.db.add(
+                SmsContactGroupMember(
+                    group_id=group_id,
+                    contact_id=contact.id,
+                    note=phone_to_note.get(p),
+                    added_by_id=getattr(user, "id", None),
+                )
+            )
+            existing_member_ids.add(contact.id)
+            added_member_count += 1
+        if added_member_count:
+            try:
+                await self.db.flush()
+            except IntegrityError:  # race UNIQUE(group,contact) → 409
+                raise ConflictError(
+                    detail="Import xung đột thành viên đồng thời, thử lại"
+                )
+
+        # --- Lưu batch (counts) ---
+        batch = await self.repo.create_import_batch(
+            {
+                "group_id": group_id,
+                # file_name = audit metadata → cắt theo cột String(255)
+                "file_name": (filename[:255] if filename else None),
+                "file_sha256": file_sha256,
+                "source_label": source_label,
+                "consent_basis": consent_basis if consent_applied else None,
+                "consent_disclosure_version": (
+                    consent_disclosure_version if consent_applied else None
+                ),
+                "consent_proof_ref": (
+                    consent_proof_ref if consent_applied else None
+                ),
+                "consent_obtained_at": (
+                    consent_obtained_at if consent_applied else None
+                ),
+                "row_count": row_count,
+                "valid_count": valid_count,
+                "invalid_count": invalid_count,
+                "duplicate_contact_count": duplicate_count,
+                "existing_member_count": existing_member_count,
+                "inserted_contact_count": inserted_count,
+                "added_member_count": added_member_count,
+                "skipped_count": invalid_count + duplicate_count,
+                "uploaded_by_id": getattr(user, "id", None),
+            }
+        )
+
+        # --- Consent event + projection cho MỌI contact valid (§4.4) ---
+        # Áp bằng chứng cấp-lô cho cả contact mới LẪN cũ (không chỉ contact
+        # mới). Projection chiếu theo occurred_at mới nhất → grant của lô
+        # KHÔNG phục hồi một revoke có occurred_at mới hơn (fail-closed).
+        if consent_applied:
+            valid_contacts = [
+                phone_to_contact[p] for p in phones if p in phone_to_contact
+            ]
+            # Lock contact ĐÃ tồn tại trước khi đụng projection (tránh race).
+            existing_ids = [
+                c.id
+                for c in valid_contacts
+                if c.phone_normalized in existing_map
+            ]
+            await self.repo.lock_contacts_by_ids(existing_ids)
+            for c in valid_contacts:
+                self.db.add(
+                    SmsMarketingConsentEvent(
+                        contact_id=c.id,
+                        phone_normalized_snapshot=c.phone_normalized,
+                        event_type="granted",
+                        basis=consent_basis,
+                        disclosure_version=consent_disclosure_version,
+                        proof_reference=consent_proof_ref,
+                        occurred_at=consent_obtained_at,
+                        recorded_by_id=getattr(user, "id", None),
+                        import_batch_id=batch.id,
+                    )
+                )
+            await self.db.flush()
+            # Bulk reproject (1 query DISTINCT ON) — tránh N+1 ở lô lớn.
+            latest = (
+                await self.repo.get_latest_consent_events_for_contacts(
+                    [c.id for c in valid_contacts]
+                )
+            )
+            for c in valid_contacts:
+                event = latest.get(c.id)
+                if event is not None:
+                    self._apply_consent_projection(c, event)
+            await self.db.flush()
+
+        return sms_schemas.SmsImportResult(
+            batch_id=batch.id,
+            group_id=group_id,
+            file_name=filename,
+            row_count=row_count,
+            valid_count=valid_count,
+            invalid_count=invalid_count,
+            duplicate_contact_count=duplicate_count,
+            existing_member_count=existing_member_count,
+            inserted_contact_count=inserted_count,
+            added_member_count=added_member_count,
+            skipped_count=invalid_count + duplicate_count,
+            consent_applied=consent_applied,
+            errors=errors,
+        )

--- a/Backend_FastAPI/app/utils/phone_helpers.py
+++ b/Backend_FastAPI/app/utils/phone_helpers.py
@@ -20,7 +20,14 @@ log = structlog.get_logger(__name__)
 
 # Regex for normalized Vietnam phone (after removing +84/84 prefix)
 # Format: 0 + (3|5|7|8|9|2) + 8-9 digits = 10-11 total
-VIETNAM_PHONE_REGEX = re.compile(r"^0(3|5|7|8|9|2)\d{8,9}$")
+# ⚠ Dùng [0-9] (KHÔNG \d): \d của Python khớp cả Unicode digit (full-width
+# ０-９, Arabic ٠-٩) → 2 chuỗi cùng "số" nhưng khác byte sẽ lọt UNIQUE,
+# phá dedupe global + sinh số export không hợp lệ.
+VIETNAM_PHONE_REGEX = re.compile(r"^0(3|5|7|8|9|2)[0-9]{8,9}$")
+
+# Mobile-ONLY: 0 + (3|5|7|8|9) + 8 digits = đúng 10 chữ số (ASCII).
+# Loại đầu số 02x (landline) mà VIETNAM_PHONE_REGEX vẫn chấp nhận.
+VIETNAM_MOBILE_REGEX = re.compile(r"^0[35789][0-9]{8}$")
 
 # Characters to strip from phone input
 PHONE_STRIP_CHARS = " \t\n\r.-()/"
@@ -165,6 +172,24 @@ def normalize_and_validate_vietnam_phone(phone: Optional[str]) -> tuple[Optional
     normalized = normalize_vietnam_phone(phone)
     if normalized is None:
         return None, False
-    
+
     is_valid = bool(VIETNAM_PHONE_REGEX.match(normalized))
     return normalized, is_valid
+
+
+def is_vietnam_mobile(phone_normalized: Optional[str]) -> bool:
+    """
+    True nếu là số DI ĐỘNG Việt Nam (0[35789]xxxxxxxx — đúng 10 chữ số).
+
+    Khác ``validate_vietnam_phone`` (chấp nhận cả landline 02x). SMS
+    Marketing chỉ gửi tới di động nên import phải lọc mobile-only.
+
+    Args:
+        phone_normalized: Số đã normalize (0xxxxxxxxx); KHÔNG tự normalize.
+
+    Returns:
+        True nếu khớp đầu số di động VN.
+    """
+    if not phone_normalized:
+        return False
+    return bool(VIETNAM_MOBILE_REGEX.match(phone_normalized))

--- a/Backend_FastAPI/tests/integration/test_sms_contacts.py
+++ b/Backend_FastAPI/tests/integration/test_sms_contacts.py
@@ -1,0 +1,804 @@
+# tests/integration/test_sms_contacts.py
+"""
+Integration test PR-2 (SMS Marketing — Contact Management BE).
+
+Phủ: group CRUD + auto-slug, contact CRUD, dedupe global (giữ bản đầu),
+mobile-only, membership add/remove + idempotent, consent-event ledger
+fail-closed + projection latest-state, và ANCHOR import counts invariant
+(§4.4): row=valid+invalid+dup; skipped=invalid+dup; added+existing=valid;
+inserted<=valid.
+
+Chạy one-off container (CLAUDE.md):
+  docker compose run --rm --no-deps backend \
+    python -m pytest tests/integration/test_sms_contacts.py -q
+"""
+from httpx import AsyncClient
+
+API = "/api/sms"
+
+
+# ---------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------
+async def _create_group(client, headers, name="Nhóm Phụ huynh 2026"):
+    res = await client.post(
+        f"{API}/contact-groups",
+        json={"name": name, "group_type": "parent"},
+        headers=headers,
+    )
+    assert res.status_code == 201, res.text
+    return res.json()
+
+
+async def _create_contact(client, headers, full_name, phone, note=None):
+    res = await client.post(
+        f"{API}/contacts",
+        json={"full_name": full_name, "phone": phone, "note": note},
+        headers=headers,
+    )
+    return res
+
+
+def _upload_files(csv_text: str):
+    return {"file": ("contacts.csv", csv_text.encode("utf-8"), "text/csv")}
+
+
+# ---------------------------------------------------------------------
+# Group CRUD
+# ---------------------------------------------------------------------
+async def test_group_crud_and_autoslug(
+    client: AsyncClient, admin_token_headers: dict
+):
+    group = await _create_group(client, admin_token_headers, "Phụ Huynh K10")
+    # auto-slug bỏ dấu
+    assert group["code"] == "phu-huynh-k10"
+    assert group["member_count"] == 0
+    gid = group["id"]
+
+    # GET detail
+    res = await client.get(
+        f"{API}/contact-groups/{gid}", headers=admin_token_headers
+    )
+    assert res.status_code == 200
+
+    # LIST
+    res = await client.get(
+        f"{API}/contact-groups", headers=admin_token_headers
+    )
+    assert res.status_code == 200
+    assert res.json()["total"] >= 1
+
+    # PATCH
+    res = await client.patch(
+        f"{API}/contact-groups/{gid}",
+        json={"description": "mô tả mới", "is_active": False},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 200
+    assert res.json()["is_active"] is False
+
+    # duplicate slug → 409
+    res = await client.post(
+        f"{API}/contact-groups",
+        json={"name": "Phụ Huynh K10", "group_type": "parent"},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 409
+
+
+async def test_group_not_found(
+    client: AsyncClient, admin_token_headers: dict
+):
+    res = await client.get(
+        f"{API}/contact-groups/999999", headers=admin_token_headers
+    )
+    assert res.status_code == 404
+
+
+# ---------------------------------------------------------------------
+# Contact CRUD + dedupe + mobile-only
+# ---------------------------------------------------------------------
+async def test_contact_create_dedupe_and_mobile_only(
+    client: AsyncClient, admin_token_headers: dict
+):
+    # tạo hợp lệ — normalize + international
+    res = await _create_contact(
+        client, admin_token_headers, "Nguyễn A", "0901234567"
+    )
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["phone_normalized"] == "0901234567"
+    assert body["phone_international"] == "84901234567"
+    assert body["marketing_consent_status"] == "unknown"
+
+    # PATCH identity (phủ nhánh refresh updated_at onupdate)
+    res = await client.patch(
+        f"{API}/contacts/{body['id']}",
+        json={"full_name": "Nguyễn A (sửa)", "note": "vip"},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["full_name"] == "Nguyễn A (sửa)"
+
+    # trùng phone toàn cục → 409
+    res = await _create_contact(
+        client, admin_token_headers, "Người khác", "0901234567"
+    )
+    assert res.status_code == 409
+
+    # landline 02x → 400 (mobile-only)
+    res = await _create_contact(
+        client, admin_token_headers, "Cố định", "02839991234"
+    )
+    assert res.status_code == 400
+
+    # +84 normalize hợp lệ
+    res = await _create_contact(
+        client, admin_token_headers, "Quốc tế", "+84 912 345 678"
+    )
+    assert res.status_code == 201
+    assert res.json()["phone_normalized"] == "0912345678"
+
+
+# ---------------------------------------------------------------------
+# Membership
+# ---------------------------------------------------------------------
+async def test_membership_add_remove_idempotent(
+    client: AsyncClient, admin_token_headers: dict
+):
+    group = await _create_group(client, admin_token_headers)
+    gid = group["id"]
+    contact = (
+        await _create_contact(
+            client, admin_token_headers, "Trần B", "0987000111"
+        )
+    ).json()
+    cid = contact["id"]
+
+    # add
+    res = await client.post(
+        f"{API}/contacts/{cid}/groups",
+        json={"group_id": gid, "note": "ghi chú nhóm"},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 201
+
+    # add lần 2 → 409
+    res = await client.post(
+        f"{API}/contacts/{cid}/groups",
+        json={"group_id": gid},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 409
+
+    # group hiện 1 member
+    res = await client.get(
+        f"{API}/contact-groups/{gid}/contacts", headers=admin_token_headers
+    )
+    assert res.json()["total"] == 1
+
+    # remove
+    res = await client.delete(
+        f"{API}/contacts/{cid}/groups/{gid}", headers=admin_token_headers
+    )
+    assert res.status_code == 204
+
+    # remove lần 2 → 404
+    res = await client.delete(
+        f"{API}/contacts/{cid}/groups/{gid}", headers=admin_token_headers
+    )
+    assert res.status_code == 404
+
+
+# ---------------------------------------------------------------------
+# Consent-event ledger + projection
+# ---------------------------------------------------------------------
+async def test_consent_event_ledger_and_projection(
+    client: AsyncClient, admin_token_headers: dict
+):
+    cid = (
+        await _create_contact(
+            client, admin_token_headers, "Lê C", "0903000222"
+        )
+    ).json()["id"]
+
+    # GRANT đủ proof → 201 + projection granted
+    res = await client.post(
+        f"{API}/contacts/{cid}/consent-events",
+        json={
+            "event_type": "granted",
+            "occurred_at": "2026-06-01T08:00:00+07:00",
+            "basis": "signed_form",
+            "disclosure_version": "v1",
+            "proof_reference": "ho-so/2026/PH-001",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 201, res.text
+
+    res = await client.get(
+        f"{API}/contacts", params={"search": "0903000222"},
+        headers=admin_token_headers,
+    )
+    contact = res.json()["items"][0]
+    assert contact["marketing_consent_status"] == "granted"
+    assert contact["marketing_consent_basis"] == "signed_form"
+
+    # GRANT thiếu proof → 422 (schema fail-closed)
+    res = await client.post(
+        f"{API}/contacts/{cid}/consent-events",
+        json={
+            "event_type": "granted",
+            "occurred_at": "2026-06-02T08:00:00+07:00",
+            "basis": "signed_form",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 422
+
+    # REVOKE → 201 + projection revoked
+    res = await client.post(
+        f"{API}/contacts/{cid}/consent-events",
+        json={
+            "event_type": "revoked",
+            "occurred_at": "2026-06-03T08:00:00+07:00",
+            "revoke_source": "manual",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 201, res.text
+
+    # REVOKE kèm grant-data → 422
+    res = await client.post(
+        f"{API}/contacts/{cid}/consent-events",
+        json={
+            "event_type": "revoked",
+            "occurred_at": "2026-06-03T09:00:00+07:00",
+            "revoke_source": "manual",
+            "proof_reference": "x",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 422
+
+    # ledger có 2 sự kiện (granted + revoked)
+    res = await client.get(
+        f"{API}/contacts/{cid}/consent-events", headers=admin_token_headers
+    )
+    assert res.json()["total"] == 2
+
+
+# ---------------------------------------------------------------------
+# Import — ANCHOR counts invariant + dedupe global
+# ---------------------------------------------------------------------
+async def test_import_counts_invariant_and_dedupe(
+    client: AsyncClient, admin_token_headers: dict
+):
+    group = await _create_group(client, admin_token_headers)
+    gid = group["id"]
+
+    # contact tồn tại trước (toàn cục), CHƯA ở nhóm
+    await _create_contact(
+        client, admin_token_headers, "Contact X", "0901111111"
+    )
+
+    csv_text = (
+        "full_name,phone,note\n"
+        "Nguyen A,0901234567,note1\n"          # valid mới
+        "Tran B,0912345678,\n"                  # valid mới
+        ",0987654321,khong-ten\n"               # invalid: thiếu tên
+        "Le C,02839999999,landline\n"           # invalid: không di động
+        "Pham D,0901234567,trung-file\n"        # duplicate trong file
+        "Existing X,0901111111,tai-dung\n"      # valid: contact đã có
+    )
+    res = await client.post(
+        f"{API}/contact-groups/{gid}/contacts/upload",
+        files=_upload_files(csv_text),
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 200, res.text
+    r = res.json()
+
+    assert r["row_count"] == 6
+    assert r["invalid_count"] == 2
+    assert r["duplicate_contact_count"] == 1
+    assert r["valid_count"] == 3
+    assert r["inserted_contact_count"] == 2   # row6 tái dùng X
+    assert r["added_member_count"] == 3
+    assert r["existing_member_count"] == 0
+    assert r["skipped_count"] == 3
+    assert r["consent_applied"] is False
+    # bất biến
+    assert r["row_count"] == (
+        r["valid_count"] + r["invalid_count"] + r["duplicate_contact_count"]
+    )
+    assert r["skipped_count"] == r["invalid_count"] + r["duplicate_contact_count"]
+    assert r["added_member_count"] + r["existing_member_count"] == r["valid_count"]
+    assert r["inserted_contact_count"] <= r["valid_count"]
+    assert len(r["errors"]) == 3
+
+    # contact X giữ identity gốc (B3 — không ghi đè tên)
+    res = await client.get(
+        f"{API}/contacts", params={"search": "0901111111"},
+        headers=admin_token_headers,
+    )
+    assert res.json()["items"][0]["full_name"] == "Contact X"
+
+    # import LẦN 2 cùng file → tất cả đã là member (idempotent)
+    res = await client.post(
+        f"{API}/contact-groups/{gid}/contacts/upload",
+        files=_upload_files(csv_text),
+        headers=admin_token_headers,
+    )
+    r2 = res.json()
+    assert r2["inserted_contact_count"] == 0      # phone đã tồn tại toàn cục
+    assert r2["added_member_count"] == 0
+    assert r2["existing_member_count"] == 3
+    assert r2["added_member_count"] + r2["existing_member_count"] == r2["valid_count"]
+
+
+# ---------------------------------------------------------------------
+# Import — consent áp cho contact MỚI + partial reject
+# ---------------------------------------------------------------------
+async def test_import_consent_applied_and_partial_reject(
+    client: AsyncClient, admin_token_headers: dict
+):
+    group = await _create_group(client, admin_token_headers)
+    gid = group["id"]
+
+    # consent một phần (chỉ basis) → 400
+    res = await client.post(
+        f"{API}/contact-groups/{gid}/contacts/upload",
+        files=_upload_files("full_name,phone\nA,0905000111\n"),
+        data={"consent_basis": "signed_form"},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 400, res.text
+
+    # consent đủ 4 → contact mới granted + có consent event
+    res = await client.post(
+        f"{API}/contact-groups/{gid}/contacts/upload",
+        files=_upload_files("full_name,phone\nNguyen A,0905000222\n"),
+        data={
+            "consent_basis": "signed_form",
+            "consent_disclosure_version": "v1",
+            "consent_proof_ref": "ho-so/lo-2026",
+            "consent_obtained_at": "2026-05-20T00:00:00+07:00",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["consent_applied"] is True
+    assert res.json()["inserted_contact_count"] == 1
+
+    res = await client.get(
+        f"{API}/contacts", params={"search": "0905000222"},
+        headers=admin_token_headers,
+    )
+    contact = res.json()["items"][0]
+    assert contact["marketing_consent_status"] == "granted"
+
+    res = await client.get(
+        f"{API}/contacts/{contact['id']}/consent-events",
+        headers=admin_token_headers,
+    )
+    assert res.json()["total"] == 1
+    assert res.json()["items"][0]["import_batch_id"] is not None
+
+
+# ---------------------------------------------------------------------
+# Codex R1 #1 — import consent áp cho contact ĐÃ tồn tại (không chỉ mới)
+# ---------------------------------------------------------------------
+async def test_import_consent_applies_to_existing_contact(
+    client: AsyncClient, admin_token_headers: dict
+):
+    group = await _create_group(client, admin_token_headers)
+    gid = group["id"]
+    cid = (
+        await _create_contact(
+            client, admin_token_headers, "Cũ", "0906000111"
+        )
+    ).json()["id"]
+
+    res = await client.get(
+        f"{API}/contacts", params={"search": "0906000111"},
+        headers=admin_token_headers,
+    )
+    assert res.json()["items"][0]["marketing_consent_status"] == "unknown"
+
+    # import lô CÓ bằng chứng, chứa đúng số contact cũ
+    res = await client.post(
+        f"{API}/contact-groups/{gid}/contacts/upload",
+        files=_upload_files("full_name,phone\nCũ,0906000111\n"),
+        data={
+            "consent_basis": "signed_form",
+            "consent_disclosure_version": "v1",
+            "consent_proof_ref": "ho-so/lo-X",
+            "consent_obtained_at": "2026-05-20T00:00:00+07:00",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["inserted_contact_count"] == 0  # tái dùng
+
+    # contact CŨ giờ granted + có ledger event
+    res = await client.get(
+        f"{API}/contacts", params={"search": "0906000111"},
+        headers=admin_token_headers,
+    )
+    assert res.json()["items"][0]["marketing_consent_status"] == "granted"
+    res = await client.get(
+        f"{API}/contacts/{cid}/consent-events", headers=admin_token_headers
+    )
+    assert res.json()["total"] == 1
+
+
+# ---------------------------------------------------------------------
+# Codex R1 #2 — projection theo occurred_at (grant cũ KHÔNG phục hồi revoke)
+# ---------------------------------------------------------------------
+async def test_consent_projection_respects_occurred_at(
+    client: AsyncClient, admin_token_headers: dict
+):
+    cid = (
+        await _create_contact(
+            client, admin_token_headers, "X", "0907000222"
+        )
+    ).json()["id"]
+
+    # revoke MỚI (06-10)
+    res = await client.post(
+        f"{API}/contacts/{cid}/consent-events",
+        json={
+            "event_type": "revoked",
+            "occurred_at": "2026-06-10T00:00:00+07:00",
+            "revoke_source": "manual",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 201
+
+    # grant CŨ hơn (06-01) — KHÔNG được override → vẫn revoked
+    res = await client.post(
+        f"{API}/contacts/{cid}/consent-events",
+        json={
+            "event_type": "granted",
+            "occurred_at": "2026-06-01T00:00:00+07:00",
+            "basis": "signed_form",
+            "disclosure_version": "v1",
+            "proof_reference": "ref",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 201
+    res = await client.get(
+        f"{API}/contacts", params={"search": "0907000222"},
+        headers=admin_token_headers,
+    )
+    assert res.json()["items"][0]["marketing_consent_status"] == "revoked"
+
+    # grant MỚI hơn (06-11, vẫn ≤ hôm nay) → granted
+    res = await client.post(
+        f"{API}/contacts/{cid}/consent-events",
+        json={
+            "event_type": "granted",
+            "occurred_at": "2026-06-11T00:00:00+07:00",
+            "basis": "signed_form",
+            "disclosure_version": "v1",
+            "proof_reference": "ref2",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 201
+    res = await client.get(
+        f"{API}/contacts", params={"search": "0907000222"},
+        headers=admin_token_headers,
+    )
+    assert res.json()["items"][0]["marketing_consent_status"] == "granted"
+
+
+# ---------------------------------------------------------------------
+# Codex R1 #3 — note trong file được giữ (không mất im lặng)
+# ---------------------------------------------------------------------
+async def test_import_preserves_note(
+    client: AsyncClient, admin_token_headers: dict
+):
+    group = await _create_group(client, admin_token_headers)
+    gid = group["id"]
+    res = await client.post(
+        f"{API}/contact-groups/{gid}/contacts/upload",
+        files=_upload_files(
+            "full_name,phone,note\nNguyen A,0908000333,ghi-chu-quan-trong\n"
+        ),
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 200, res.text
+    res = await client.get(
+        f"{API}/contacts", params={"search": "0908000333"},
+        headers=admin_token_headers,
+    )
+    assert res.json()["items"][0]["note"] == "ghi-chu-quan-trong"
+
+
+# ---------------------------------------------------------------------
+# Codex R1 #4 — PATCH chặn null (400) / toàn khoảng trắng (422)
+# ---------------------------------------------------------------------
+async def test_patch_rejects_null_and_blank(
+    client: AsyncClient, admin_token_headers: dict
+):
+    gid = (await _create_group(client, admin_token_headers))["id"]
+
+    # explicit null cho cột NOT NULL → 400 (không phải 500)
+    for body in ({"name": None}, {"group_type": None}, {"is_active": None}):
+        res = await client.patch(
+            f"{API}/contact-groups/{gid}", json=body,
+            headers=admin_token_headers,
+        )
+        assert res.status_code == 400, f"{body} → {res.status_code}"
+
+    # toàn khoảng trắng → 422 (schema validator)
+    res = await client.patch(
+        f"{API}/contact-groups/{gid}", json={"name": "   "},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 422
+
+    cid = (
+        await _create_contact(
+            client, admin_token_headers, "Nguyễn A", "0909000444"
+        )
+    ).json()["id"]
+    res = await client.patch(
+        f"{API}/contacts/{cid}", json={"full_name": None},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 400
+    res = await client.patch(
+        f"{API}/contacts/{cid}", json={"full_name": "   "},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------
+# Codex R2 #1 — chặn consent ở tương lai (API 422 / import 400)
+# ---------------------------------------------------------------------
+async def test_future_consent_rejected(
+    client: AsyncClient, admin_token_headers: dict
+):
+    cid = (
+        await _create_contact(
+            client, admin_token_headers, "F", "0906000888"
+        )
+    ).json()["id"]
+    # API consent-events occurred_at tương lai → 422
+    res = await client.post(
+        f"{API}/contacts/{cid}/consent-events",
+        json={
+            "event_type": "granted",
+            "occurred_at": "2099-01-01T00:00:00+07:00",
+            "basis": "signed_form",
+            "disclosure_version": "v1",
+            "proof_reference": "ref",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 422
+
+    # import consent_obtained_at tương lai → 400
+    gid = (await _create_group(client, admin_token_headers))["id"]
+    res = await client.post(
+        f"{API}/contact-groups/{gid}/contacts/upload",
+        files=_upload_files("full_name,phone\nA,0906000777\n"),
+        data={
+            "consent_basis": "signed_form",
+            "consent_disclosure_version": "v1",
+            "consent_proof_ref": "ref",
+            "consent_obtained_at": "2099-01-01T00:00:00+07:00",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R2 #2 — cùng occurred_at: REVOKE thắng (fail-closed)
+# ---------------------------------------------------------------------
+async def test_equal_time_revoke_wins(
+    client: AsyncClient, admin_token_headers: dict
+):
+    cid = (
+        await _create_contact(
+            client, admin_token_headers, "Z", "0907000999"
+        )
+    ).json()["id"]
+    same = "2026-06-05T00:00:00+07:00"
+    # revoke trước
+    res = await client.post(
+        f"{API}/contacts/{cid}/consent-events",
+        json={
+            "event_type": "revoked", "occurred_at": same,
+            "revoke_source": "manual",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 201
+    # grant CÙNG occurred_at, ghi SAU → revoke vẫn thắng (không fail-open)
+    res = await client.post(
+        f"{API}/contacts/{cid}/consent-events",
+        json={
+            "event_type": "granted", "occurred_at": same,
+            "basis": "signed_form", "disclosure_version": "v1",
+            "proof_reference": "ref",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 201
+    res = await client.get(
+        f"{API}/contacts", params={"search": "0907000999"},
+        headers=admin_token_headers,
+    )
+    assert res.json()["items"][0]["marketing_consent_status"] == "revoked"
+
+
+# ---------------------------------------------------------------------
+# Codex R2 #3 — họ tên >255 ký tự = row invalid (KHÔNG 500)
+# ---------------------------------------------------------------------
+async def test_import_oversized_name_is_row_invalid(
+    client: AsyncClient, admin_token_headers: dict
+):
+    gid = (await _create_group(client, admin_token_headers))["id"]
+    long_name = "A" * 256
+    csv_text = (
+        "full_name,phone\n"
+        f"{long_name},0905001111\n"
+        "Ngan,0905002222\n"
+    )
+    res = await client.post(
+        f"{API}/contact-groups/{gid}/contacts/upload",
+        files=_upload_files(csv_text),
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 200, res.text
+    r = res.json()
+    assert r["row_count"] == 2
+    assert r["invalid_count"] == 1
+    assert r["valid_count"] == 1
+    assert r["inserted_contact_count"] == 1
+    assert any("quá dài" in e["reason"] for e in r["errors"])
+
+
+# ---------------------------------------------------------------------
+# Codex R3 #1 — datetime KHÔNG timezone bị từ chối (422)
+# ---------------------------------------------------------------------
+async def test_naive_occurred_at_rejected(
+    client: AsyncClient, admin_token_headers: dict
+):
+    cid = (
+        await _create_contact(
+            client, admin_token_headers, "N", "0903009999"
+        )
+    ).json()["id"]
+    res = await client.post(
+        f"{API}/contacts/{cid}/consent-events",
+        json={
+            "event_type": "granted",
+            "occurred_at": "2026-06-01T00:00:00",  # KHÔNG có timezone
+            "basis": "signed_form",
+            "disclosure_version": "v1",
+            "proof_reference": "ref",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------
+# Codex R3 #2 — consent field quá dài khi import → 400 (KHÔNG 500)
+# ---------------------------------------------------------------------
+async def test_import_oversized_consent_field_rejected(
+    client: AsyncClient, admin_token_headers: dict
+):
+    gid = (await _create_group(client, admin_token_headers))["id"]
+    res = await client.post(
+        f"{API}/contact-groups/{gid}/contacts/upload",
+        files=_upload_files("full_name,phone\nA,0905003333\n"),
+        data={
+            "consent_basis": "signed_form",
+            "consent_disclosure_version": "v1",
+            "consent_proof_ref": "x" * 513,  # cột String(512)
+            "consent_obtained_at": "2026-05-20T00:00:00+07:00",
+        },
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R3 #3 — race tạo trùng phone → 409 (không 500)
+# ---------------------------------------------------------------------
+async def test_concurrent_duplicate_phone_returns_409(
+    client: AsyncClient, admin_token_headers: dict, monkeypatch
+):
+    # Giả lập race TOCTOU: pre-check LUÔN miss (None) → INSERT thứ 2 đụng
+    # UNIQUE constraint → service phải đổi IntegrityError thành 409.
+    from app.repositories.sms_contact_repository import (
+        SmsContactRepository,
+    )
+
+    async def _always_none(self, phone):
+        return None
+
+    monkeypatch.setattr(
+        SmsContactRepository, "get_contact_by_phone", _always_none
+    )
+    r1 = await _create_contact(
+        client, admin_token_headers, "A", "0904111222"
+    )
+    assert r1.status_code == 201
+    r2 = await _create_contact(
+        client, admin_token_headers, "B", "0904111222"
+    )
+    assert r2.status_code == 409
+
+
+# ---------------------------------------------------------------------
+# Codex R4 — chặn Unicode digit (full-width/Arabic) bypass dedupe
+# ---------------------------------------------------------------------
+# Full-width "７６５４３２１０" + Arabic-Indic "١٢٣٤٥٦٧٨"
+_FULLWIDTH = "05" + "７６５４３２１０"
+_ARABIC = "09" + "١٢٣٤٥٦٧٨"
+
+
+async def test_create_contact_rejects_unicode_digits(
+    client: AsyncClient, admin_token_headers: dict
+):
+    # full-width digits → 400 (không được coi là di động hợp lệ)
+    res = await _create_contact(
+        client, admin_token_headers, "FW", _FULLWIDTH
+    )
+    assert res.status_code == 400, res.text
+    # Arabic-Indic digits → 400
+    res = await _create_contact(
+        client, admin_token_headers, "AR", _ARABIC
+    )
+    assert res.status_code == 400, res.text
+
+
+async def test_import_rejects_unicode_digit_phone(
+    client: AsyncClient, admin_token_headers: dict
+):
+    gid = (await _create_group(client, admin_token_headers))["id"]
+    # contact ASCII thật cùng "số" với bản full-width
+    await _create_contact(
+        client, admin_token_headers, "Real", "0576543210"
+    )
+    csv_text = (
+        "full_name,phone\n"
+        "Real,0576543210\n"
+        f"Fake,{_FULLWIDTH}\n"
+    )
+    res = await client.post(
+        f"{API}/contact-groups/{gid}/contacts/upload",
+        files=_upload_files(csv_text),
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 200, res.text
+    r = res.json()
+    # dòng full-width = invalid (KHÔNG tạo contact trùng lách dedupe)
+    assert r["invalid_count"] == 1
+    assert r["valid_count"] == 1
+    assert r["inserted_contact_count"] == 0  # ASCII row tái dùng contact cũ
+    # toàn hệ thống vẫn chỉ 1 contact cho số này
+    res = await client.get(
+        f"{API}/contacts", params={"search": "576543210"},
+        headers=admin_token_headers,
+    )
+    assert res.json()["total"] == 1
+
+
+# ---------------------------------------------------------------------
+# Auth gate
+# ---------------------------------------------------------------------
+async def test_requires_auth(client: AsyncClient):
+    res = await client.get(f"{API}/contact-groups")
+    assert res.status_code == 401


### PR DESCRIPTION
## PR-2: Contact Management BE (SMS Marketing — sau PR-1 schema #401)

Quản lý danh bạ/nhóm, import mobile-only **dedupe toàn cục theo `phone_normalized`**, consent-event ledger **append-only** + projection latest-state **fail-closed**. Phase 1 **admin-only** (`require_admin`).

### Nội dung (6 file, +2435/-6)
- **schemas/sms.py** — group/contact/consent/import; validator strip + chặn whitespace/null, future-time (tz-aware), grant/revoke contract mirror DB CHECK.
- **repositories/sms_contact_repository.py** — data access + row-lock consent + bulk latest-event (DISTINCT ON), anti-N+1.
- **services/sms_contact_service.py** — CRUD, membership, import counts-invariant (`row=valid+invalid+dup`; `added+existing=valid`), consent ledger + reproject theo `occurred_at` (revoke thắng khi cùng mốc), `IntegrityError`→409.
- **routers/sms_contacts.py** — 13 endpoint, router-commit, dumb translator.
- **utils/phone_helpers.py** — `is_vietnam_mobile` + regex ASCII `[0-9]` (chặn Unicode-digit bypass dedupe).
- **tests/integration/test_sms_contacts.py** — 20 test.

### 13 endpoint (`/api/sms`, admin-only)
contact-groups CRUD + upload + list-contacts; contacts CRUD + consent-events (append/list) + membership (add/remove).

### Đã qua Codex review 4 round (12 finding fix)
- **R1**: consent áp cả contact cũ; projection fail-closed.
- **R2**: revoke-wins-tie (`occurred_at`); length guards; `IntegrityError`→409; bulk reproject (N+1).
- **R3**: tz-aware datetime (chặn naive lệch giờ); batch field length; race→409.
- **R4**: regex ASCII-only chặn full-width/Arabic digit bypass dedupe.

### Verify
28/28 pytest (20 contacts + 8 schema PR-1) · flake8 sạch · migration bảng SMS đã nằm ở main (PR-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)