### PR TITLE
fix(admissions): for-offering 500 (eager-load activator) + lọc phương thức theo trình độ văn hóa

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -175,6 +175,7 @@ jobs:
           tests/api/test_magic_link_3_actions_wire.py
           tests/services/test_phase3_create_profile_inherits_multi_nv.py
           tests/unit/test_admission_path_service_field_drift.py
+          tests/integration/test_admission_path_method_filter_and_activator.py
           -q --tb=short --timeout=60
 
       # =====================================================================

--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -5,7 +5,7 @@ import casbin
 import structlog
 
 from .constants import UserRole
-from fastapi import Cookie, Depends, Header, Path, Request, HTTPException, status
+from fastapi import Cookie, Depends, Header, Path, Query, Request, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jwt.exceptions import PyJWTError as JWTError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -2610,6 +2610,83 @@ async def get_admission_for_user_read(
                 raise ResourceNotFoundError(detail=f"Admission profile {profile_id} not found")
 
     return profile
+
+
+async def get_optional_profile_cultural_for_audience(
+    profile_id: Optional[int] = Query(
+        None,
+        ge=1,
+        # INT4 max của AdmissionProfile.id — chặn 500 asyncpg out-of-range.
+        le=2_147_483_647,
+        description=(
+            "Hồ sơ đang thêm nguyện vọng. Khi truyền, BE lọc phương thức theo "
+            "trình độ văn hóa (cultural_education_level) của hồ sơ. Bỏ trống = "
+            "không lọc (hiện tất cả)."
+        ),
+    ),
+    current_user: models.User = Depends(get_current_active_user),
+    db: AsyncSession = Depends(database.get_db),
+) -> Optional[str]:
+    """IDOR-scoped đọc ``cultural_education_level`` cho bộ lọc phương thức theo
+    trình độ văn hóa (AddChoiceDialog / GET /paths/by-round).
+
+    - ``profile_id`` không truyền → trả ``None`` → KHÔNG lọc.
+    - Scope 3-tier MIRROR ``get_admission_for_user_read``: admin mọi hồ sơ;
+      manager cùng unit; officer cùng unit + được phân công. Ngoài phạm vi /
+      không tồn tại → **404 fake** (không leak existence) — chặn oracle suy
+      trình độ văn hóa hồ sơ người khác qua chênh lệch danh sách path.
+
+    Trả ``cultural_education_level`` (có thể ``None`` nếu hồ sơ chưa khai) — KHÔNG
+    trả object hồ sơ, để router/service không vô tình lộ field khác.
+    """
+    if profile_id is None:
+        return None
+
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    # Fake 404 dùng chung mọi nhánh — không leak existence/role (404 chứ 403).
+    not_found = f"Admission profile {profile_id} not found"
+
+    # Defense-in-depth role gate.
+    if current_user.role not in _ADMISSION_READ_ALLOWED_ROLES:
+        log.warning(
+            "IDOR attempt: non-admission role read profile cultural for filter",
+            user_id=current_user.id,
+            user_role=str(current_user.role),
+            profile_id=profile_id,
+        )
+        raise ResourceNotFoundError(detail=not_found)
+
+    stmt = (
+        select(models.AdmissionProfile)
+        .where(models.AdmissionProfile.id == profile_id)
+        .options(selectinload(models.AdmissionProfile.lead))
+    )
+    profile = (await db.execute(stmt)).scalar_one_or_none()
+    if not profile:
+        raise ResourceNotFoundError(detail=not_found)
+
+    if current_user.role != UserRole.ADMIN:
+        if not profile.lead or profile.lead.unit_id != current_user.unit_id:
+            log.warning(
+                "IDOR attempt: user read profile cultural from different unit",
+                user_id=current_user.id,
+                user_unit_id=current_user.unit_id,
+                profile_id=profile_id,
+            )
+            raise ResourceNotFoundError(detail=not_found)
+        if current_user.role == UserRole.OFFICER:
+            if profile.lead.assigned_officer_id != current_user.id:
+                log.warning(
+                    "IDOR attempt: officer read profile cultural not assigned",
+                    user_id=current_user.id,
+                    profile_id=profile_id,
+                    assigned_officer_id=profile.lead.assigned_officer_id,
+                )
+                raise ResourceNotFoundError(detail=not_found)
+
+    return profile.cultural_education_level
 
 
 # ==============================================================================

--- a/Backend_FastAPI/app/repositories/admission_path_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_path_repository.py
@@ -9,7 +9,7 @@ Provides data access for AdmissionPath entities with:
 """
 
 from typing import Iterable, List, Optional, Sequence, Tuple
-from sqlalchemy import select, func, distinct, or_, cast
+from sqlalchemy import select, func, distinct, or_, not_, cast
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -46,6 +46,36 @@ _AUDIENCE_ENUM_TYPE = postgresql.ENUM(
     create_type=False,
 )
 _AUDIENCE_ARRAY_TYPE = postgresql.ARRAY(_AUDIENCE_ENUM_TYPE)
+
+# Audience values thuộc CHIỀU VĂN HÓA = tập giá trị range của
+# ``_CULTURAL_TO_AUDIENCE`` (document_resolution_service). Path gắn loại hình
+# (LIEN_THONG_TC/CD, VLVH) KHÔNG chứa giá trị nào ở đây → KHÔNG bị filter chiều
+# văn hóa loại bỏ. Giữ đồng bộ nếu thêm bậc văn hóa mới (enum audience ổn định).
+_CULTURAL_AUDIENCE_VALUES = ("POST_THCS", "POST_THPT")
+
+
+def _audience_visibility_filter(audience: str):
+    """Predicate "path khả kiến cho 1 audience chiều VĂN HÓA" (AddChoiceDialog).
+
+    SHOW path khi:
+      - ``applicable_to IS NULL`` (legacy = áp mọi đối tượng), HOẶC
+      - ``applicable_to @> [audience]`` (gắn đúng bậc văn hóa của hồ sơ), HOẶC
+      - ``NOT (applicable_to && [POST_THCS, POST_THPT])`` — path KHÔNG gắn tag
+        chiều văn hóa nào (chỉ gắn loại hình LIEN_THONG_*/VLVH, hoặc ``[]``
+        rỗng) → không bị lọc theo văn hóa.
+
+    ⟹ CHỈ ẩn path gắn tag bậc văn hóa ĐỐI LẬP (vd hồ sơ POST_THCS không thấy
+    đường gắn POST_THPT). NULL khớp nhánh 1; ``[]`` và path loại-hình-thuần
+    khớp nhánh 3. Dùng ``@>``/``&&`` qua typed cast để hit GIN index
+    ``ix_admission_path_applicable_to`` (KHÔNG ``= ANY()``).
+    """
+    aud_array = cast([audience], _AUDIENCE_ARRAY_TYPE)
+    cultural_tags = cast(list(_CULTURAL_AUDIENCE_VALUES), _AUDIENCE_ARRAY_TYPE)
+    return or_(
+        AdmissionPath.applicable_to.is_(None),
+        AdmissionPath.applicable_to.op("@>")(aud_array),
+        not_(AdmissionPath.applicable_to.op("&&")(cultural_tags)),
+    )
 
 
 class AdmissionPathRepository(BaseRepository[AdmissionPath]):
@@ -175,22 +205,34 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
     async def get_active_paths_by_round(
         self,
         admission_round_id: int,
+        audience: Optional[str] = None,
     ) -> List[AdmissionPath]:
         """List active paths trong 1 round, dùng cho AddChoiceDialog
         candidate-side: chọn ngành/method để thêm NV mới trong cùng đợt
         đang xét. Filter status='active' (cloned draft paths bị skip).
+
+        ``audience`` (optional ``admission_audience`` chiều VĂN HÓA, vd
+        ``POST_THCS``): khi set, ẩn path gắn tag bậc văn hóa ĐỐI LẬP — xem
+        ``_audience_visibility_filter``. Path ``applicable_to`` NULL / ``[]`` /
+        chỉ gắn loại hình (LIEN_THONG_*/VLVH) VẪN hiện. Caller (service) suy
+        audience từ ``cultural_education_level`` của hồ sơ (vd TN THCS không
+        thấy đường "Xét học bạ THPT"). ``audience=None`` → KHÔNG lọc (hồ sơ
+        chưa khai trình độ văn hóa).
 
         Eager-load chain match ``get_paths_by_academic_info`` đủ cho
         ``build_path_response`` Pydantic serialize (criteria + activator +
         academic_info chain). Without full chain, MissingGreenlet fires
         khi Pydantic getattr trên unloaded relations trong async context.
         """
+        conditions = [
+            AdmissionPath.admission_round_id == admission_round_id,
+            AdmissionPath.status == "active",
+        ]
+        if audience is not None:
+            conditions.append(_audience_visibility_filter(audience))
         query = (
             select(AdmissionPath)
-            .where(
-                AdmissionPath.admission_round_id == admission_round_id,
-                AdmissionPath.status == "active",
-            )
+            .where(*conditions)
             .options(
                 selectinload(AdmissionPath.academic_info)
                 .selectinload(OfferingAcademicInfo.offering)
@@ -382,6 +424,13 @@ class AdmissionPathRepository(BaseRepository[AdmissionPath]):
                 # Round contract hardening (plan v4 Section D) — round
                 # metadata drives the officer create-page round dropdown.
                 selectinload(AdmissionPath.admission_round),
+                # build_path_response serializes AdmissionPathResponse.activator
+                # (Optional[UserNested]); without this eager-load a path whose
+                # ``activated_by`` is NOT NULL triggers a lazy load at Pydantic
+                # serialize time → MissingGreenlet → 500. Mirrors the sibling
+                # get_active_paths_by_round (officer create-page hit 500 for any
+                # offering with an activated path, e.g. TS2026 TC-THCS paths).
+                selectinload(AdmissionPath.activator),
                 # Eager load criteria with subject groups (for LeadApplicationForm)
                 selectinload(AdmissionPath.criteria).selectinload(
                     AdmissionCriteria.subject_group_mappings

--- a/Backend_FastAPI/app/routers/admission_paths.py
+++ b/Backend_FastAPI/app/routers/admission_paths.py
@@ -21,6 +21,7 @@ from app import database, models
 from app.core.constants import UserRole
 from app.core.deps import (
     get_current_active_user,
+    get_optional_profile_cultural_for_audience,
     check_permission,
     require_admin,
     require_admin_or_manager,
@@ -334,6 +335,10 @@ async def list_path_subject_group_configs(
 )
 async def get_paths_by_round(
     round_id: int = PathParam(..., description="Admission round ID"),
+    # IDOR-scoped: dependency đọc query ``profile_id`` + scope theo hồ sơ
+    # officer được phép xem, trả cultural_education_level (hoặc None khi không
+    # truyền / chưa khai). 404 fake nếu profile_id ngoài phạm vi.
+    cultural: Optional[str] = Depends(get_optional_profile_cultural_for_audience),
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(get_current_active_user),
 ):
@@ -350,7 +355,9 @@ async def get_paths_by_round(
     (uses_choice_engine, allow_multi_nv, max_choices) áp dụng tại POST.
     """
     service = AdmissionPathService(db)
-    paths, callback = await service.list_active_paths_by_round(round_id)
+    paths, callback = await service.list_active_paths_by_round(
+        round_id, cultural=cultural
+    )
     # Read-only endpoint — KHÔNG cần db.commit() (nit fix #8)
     await callback()
 

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -43,6 +43,10 @@ from app.services.document_resolution_service import (
     derive_audience_set,
     filter_shared_by_audience,
     mandatory_wins_merge,
+    # Map cultural_education_level → admission_audience chiều văn hóa (public
+    # helper, nguồn chung document-resolution). AddChoiceDialog lọc phương
+    # thức theo trình độ văn hóa của hồ sơ.
+    cultural_to_audience,
 )
 from app.utils.exceptions import (
     ResourceNotFoundError,
@@ -131,13 +135,28 @@ class AdmissionPathService:
         return paths, _noop_callback
 
     async def list_active_paths_by_round(
-        self, admission_round_id: int
+        self,
+        admission_round_id: int,
+        cultural: Optional[str] = None,
     ) -> Tuple[List[AdmissionPath], PostCommitCallback]:
         """List active paths trong 1 round. Dùng cho AddChoiceDialog
         candidate-side: render dropdown ngành/method khả dụng để thêm NV
         mới trong cùng đợt đang xét tuyển.
+
+        ``cultural`` (optional ``cultural_education_level``): tầng deps
+        (``get_optional_profile_cultural_for_audience``) đã đọc + scope IDOR
+        theo hồ sơ officer được phép xem trước khi truyền vào đây. Service suy
+        ``admission_audience`` chiều văn hóa rồi lọc path — TN THCS chỉ thấy
+        phương thức phù hợp (ẩn đường gắn bậc văn hóa ĐỐI LẬP). ``cultural``
+        None / không map → audience None → KHÔNG lọc (hồ sơ chưa khai trình độ
+        hoặc không truyền profile_id). Path gắn loại hình (liên thông/VLVH)
+        hoặc ``applicable_to`` NULL/``[]`` KHÔNG bị ẩn — xem
+        ``AdmissionPathRepository._audience_visibility_filter``.
         """
-        paths = await self.repo.get_active_paths_by_round(admission_round_id)
+        audience = cultural_to_audience(cultural)
+        paths = await self.repo.get_active_paths_by_round(
+            admission_round_id, audience=audience
+        )
         return paths, _noop_callback
 
     async def get_distinct_years(self) -> Tuple[List[int], PostCommitCallback]:

--- a/Backend_FastAPI/app/services/document_resolution_service.py
+++ b/Backend_FastAPI/app/services/document_resolution_service.py
@@ -46,6 +46,20 @@ _CULTURAL_TO_AUDIENCE: Dict[str, str] = {
     "graduated_gdtx": "POST_THPT",
 }
 
+
+def cultural_to_audience(cultural: Optional[str]) -> Optional[str]:
+    """Map ``cultural_education_level`` → ``admission_audience`` chiều VĂN HÓA.
+
+    Public wrapper quanh ``_CULTURAL_TO_AUDIENCE`` (nguồn sự thật DUY NHẤT,
+    dùng chung document-resolution + filter phương thức ở AddChoiceDialog) →
+    caller KHÔNG import symbol private xuyên module. Trả ``None`` nếu cultural
+    là None / rỗng / không nằm trong map → caller KHÔNG lọc theo audience.
+    """
+    if not cultural:
+        return None
+    return _CULTURAL_TO_AUDIENCE.get(cultural)
+
+
 # cultural "completed_*" = hoàn thành chương trình nhưng CHƯA có bằng → mã bằng
 # TN cần LOẠI khỏi bộ hồ sơ (§6 GĐ1; doc type bằng TN tồn tại prod 2026-05-29).
 _COMPLETED_DIPLOMA_TO_REMOVE: Dict[str, str] = {

--- a/Backend_FastAPI/tests/integration/test_admission_path_method_filter_and_activator.py
+++ b/Backend_FastAPI/tests/integration/test_admission_path_method_filter_and_activator.py
@@ -1,0 +1,462 @@
+"""Tests cho branch ``fix/admission-path-activator-method-filter``.
+
+Hai fix độc lập, cùng domain AdmissionPath:
+
+* **Fix A — for-offering 500 MissingGreenlet.**
+  ``get_active_paths_by_offering_id`` thiếu ``selectinload(AdmissionPath.
+  activator)`` → khi ``build_path_response`` serialize
+  ``AdmissionPathResponse.activator`` (Optional[UserNested]), path có
+  ``activated_by`` NOT NULL trigger lazy-load async → MissingGreenlet → 500.
+  Officer/admin KHÔNG tạo được hồ sơ cho ngành có đường đã kích hoạt (vd 7
+  ngành Trung cấp THCS TS2026).
+
+* **Fix B — lọc phương thức theo trình độ văn hóa (AddChoiceDialog).**
+  ``get_active_paths_by_round(audience=...)`` ẩn path gắn tag bậc văn hóa ĐỐI
+  LẬP (``_audience_visibility_filter``): path NULL / ``[]`` / chỉ gắn loại hình
+  (LIEN_THONG_*/VLVH) VẪN hiện. Service ``list_active_paths_by_round(cultural)``
+  suy audience qua ``cultural_to_audience``. Dependency
+  ``get_optional_profile_cultural_for_audience`` đọc cultural có IDOR-scope
+  (404 nếu hồ sơ ngoài phạm vi officer).
+"""
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+
+from app import models
+from app.core.deps import get_optional_profile_cultural_for_audience
+from app.database import AsyncSessionLocal
+from app.repositories.admission_path_repository import AdmissionPathRepository
+from app.schemas.admission_path import AdmissionPathResponse
+from app.security import get_password_hash
+from app.services.admission_path_service import AdmissionPathService
+from app.services.document_resolution_service import cultural_to_audience
+from app.utils.exceptions import ResourceNotFoundError
+
+
+# ===========================================================================
+# Integration fixture — 1 round + 1 published academic_info + 6 active paths
+# phủ mọi nhánh _audience_visibility_filter (mỗi path 1 method để thoả UNIQUE
+# (round, academic_info, method)) + activator user trên mỗi path (Fix A).
+#   thcs      applicable_to = [POST_THCS]      → ẩn khi audience=POST_THPT
+#   thpt      applicable_to = [POST_THPT]      → ẩn khi audience=POST_THCS
+#   legacy    applicable_to = NULL             → luôn hiện (nhánh IS NULL)
+#   lien_thong applicable_to = [LIEN_THONG_CD] → luôn hiện (loại hình thuần)
+#   vlvh      applicable_to = [VLVH]           → luôn hiện (loại hình thuần)
+#   empty     applicable_to = []               → luôn hiện (nhánh NOT &&)
+# ===========================================================================
+@pytest_asyncio.fixture
+async def audience_seed(seed_lead_dependencies: dict) -> dict:
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            activator = models.User(
+                username=f"activator_{ts}",
+                email=f"activator_{ts}@test.local",
+                full_name="Path Activator",
+                password_hash=get_password_hash("test"),
+                role="admin",
+                status="active",
+            )
+            s.add(activator)
+            await s.flush()
+
+            rnd = models.OfferingAdmissionRound(
+                academic_year=2026,
+                round_code=f"AUD_{ts}",
+                round_name=f"Audience round {ts}",
+                is_active=True,
+            )
+            s.add(rnd)
+            await s.flush()
+
+            offering = models.ProgramOffering(
+                program_id=seed_lead_dependencies["major_program_id"],
+                offering_type="full_time",
+                duration_semesters=8,
+            )
+            s.add(offering)
+            await s.flush()
+
+            ai = models.OfferingAcademicInfo(
+                offering_id=offering.id,
+                academic_year=2026,
+                annual_admission_quota=20,
+                tuition_fee_per_year=1_000_000,
+                is_published=True,
+            )
+            s.add(ai)
+            await s.flush()
+
+            path_ids: dict[str, int] = {}
+            specs = (
+                ("thcs", ["POST_THCS"]),
+                ("thpt", ["POST_THPT"]),
+                ("legacy", None),  # NULL = áp mọi đối tượng
+                ("lien_thong", ["LIEN_THONG_CD"]),  # loại hình thuần
+                ("vlvh", ["VLVH"]),  # loại hình thuần
+                ("empty", []),  # mảng rỗng (KHÁC NULL)
+                ("both", ["POST_THCS", "POST_THPT"]),  # cả 2 bậc văn hóa
+                ("mixed_thcs", ["POST_THCS", "LIEN_THONG_CD"]),  # văn hóa + loại hình
+            )
+            for key, audience in specs:
+                method = models.AdmissionMethod(
+                    code=f"M_{key}_{ts}",
+                    name=f"Method {key} {ts}",
+                    requires_subject_scores=True,
+                    is_active=True,
+                )
+                s.add(method)
+                await s.flush()
+                path = models.AdmissionPath(
+                    academic_info_id=ai.id,
+                    admission_method_id=method.id,
+                    admission_round_id=rnd.id,
+                    status="active",
+                    visibility="public",
+                    applicable_to=audience,
+                    # activated_by NOT NULL → reproduce Fix A.
+                    activated_by=activator.id,
+                )
+                s.add(path)
+                await s.flush()
+                path_ids[key] = path.id
+
+            return {
+                "round_id": rnd.id,
+                "offering_id": offering.id,
+                "academic_info_id": ai.id,
+                "activator_id": activator.id,
+                "path_ids": path_ids,
+            }
+
+
+# ===========================================================================
+# Fix B — repo audience filter (runtime, seeded): chỉ ẩn bậc văn hóa ĐỐI LẬP
+# ===========================================================================
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_active_paths_by_round_filters_by_audience(audience_seed):
+    pid = audience_seed["path_ids"]
+    # NULL / loại-hình-thuần / [] / cả-2-bậc PHẢI luôn hiện cho mọi audience.
+    always_visible = {
+        pid["legacy"], pid["lien_thong"], pid["vlvh"], pid["empty"], pid["both"]
+    }
+    async with AsyncSessionLocal() as s:
+        repo = AdmissionPathRepository(s)
+
+        # POST_THCS → giữ THCS + mixed_thcs (có tag THCS) + always-visible; ẩn THPT.
+        thcs_ids = {
+            p.id
+            for p in await repo.get_active_paths_by_round(
+                audience_seed["round_id"], audience="POST_THCS"
+            )
+        }
+        assert pid["thcs"] in thcs_ids
+        assert pid["mixed_thcs"] in thcs_ids  # văn hóa THCS + loại hình → hiện cho THCS
+        assert always_visible <= thcs_ids
+        assert pid["thpt"] not in thcs_ids
+
+        # POST_THPT → giữ THPT + always-visible; ẩn THCS + mixed_thcs (gắn tag THCS).
+        thpt_ids = {
+            p.id
+            for p in await repo.get_active_paths_by_round(
+                audience_seed["round_id"], audience="POST_THPT"
+            )
+        }
+        assert pid["thpt"] in thpt_ids
+        assert always_visible <= thpt_ids
+        assert pid["thcs"] not in thpt_ids
+        assert pid["mixed_thcs"] not in thpt_ids  # gắn POST_THCS → ẩn khỏi THPT
+
+        # audience=None (mặc định) → KHÔNG lọc, trả cả 8.
+        all_ids = {
+            p.id
+            for p in await repo.get_active_paths_by_round(audience_seed["round_id"])
+        }
+        assert set(pid.values()) <= all_ids
+
+
+def test_cultural_audience_values_parity():
+    """#6: ``_CULTURAL_AUDIENCE_VALUES`` (repo) PHẢI = range của
+    ``_CULTURAL_TO_AUDIENCE`` (document_resolution_service). Khoá drift mà KHÔNG
+    đảo dependency layer (repo KHÔNG import service) — test import cả 2 private
+    rồi so set. Nếu ai thêm bậc văn hóa mới vào map mà quên repo → test đỏ."""
+    from app.repositories.admission_path_repository import _CULTURAL_AUDIENCE_VALUES
+    from app.services.document_resolution_service import _CULTURAL_TO_AUDIENCE
+
+    assert set(_CULTURAL_AUDIENCE_VALUES) == set(_CULTURAL_TO_AUDIENCE.values())
+
+
+# ===========================================================================
+# Fix A — serialize activator KHÔNG MissingGreenlet + đúng activator (seeded)
+# ===========================================================================
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_active_paths_by_offering_id_serializes_activator(audience_seed):
+    """Reproduce prod 500: path có ``activated_by`` NOT NULL. Trước fix,
+    ``AdmissionPathResponse.model_validate`` raise MissingGreenlet khi truy cập
+    ``activator`` (lazy). Sau fix (eager-load) → serialize OK + đúng activator
+    đã seed (loại trừ eager-load nhầm relationship)."""
+    async with AsyncSessionLocal() as s:
+        repo = AdmissionPathRepository(s)
+        paths = await repo.get_active_paths_by_offering_id(
+            audience_seed["offering_id"]
+        )
+        assert paths, "seed phải trả active published paths"
+
+        # KHÔNG raise MissingGreenlet — activator đã eager-load.
+        responses = [AdmissionPathResponse.model_validate(p) for p in paths]
+        assert all(r.activator is not None for r in responses)
+        # Đúng activator đã seed (không load nhầm user khác).
+        assert all(
+            r.activator.id == audience_seed["activator_id"] for r in responses
+        )
+
+
+# ===========================================================================
+# Fix B — cultural_to_audience (pure function, nguồn map chung)
+# ===========================================================================
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cultural,expected",
+    [
+        ("completed_thcs", "POST_THCS"),
+        ("graduated_thcs", "POST_THCS"),
+        ("completed_thpt", "POST_THPT"),
+        ("graduated_thpt", "POST_THPT"),
+        ("graduated_gdtx", "POST_THPT"),
+        (None, None),  # hồ sơ chưa khai trình độ → KHÔNG lọc
+        ("", None),  # rỗng (falsy) → KHÔNG lọc
+        ("unmapped_value", None),  # giá trị lạ → fail-safe KHÔNG lọc
+    ],
+)
+async def test_cultural_to_audience_mapping(cultural, expected):
+    assert cultural_to_audience(cultural) == expected
+
+
+# ===========================================================================
+# Fix B — service → repo e2e (seeded): cultural thật → đúng tập path hiển thị
+# ===========================================================================
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_service_list_active_paths_filters_by_cultural(audience_seed):
+    pid = audience_seed["path_ids"]
+    async with AsyncSessionLocal() as s:
+        svc = AdmissionPathService(s)
+
+        # cultural=graduated_thpt → audience POST_THPT → ẩn THCS, giữ THPT.
+        paths, _ = await svc.list_active_paths_by_round(
+            audience_seed["round_id"], cultural="graduated_thpt"
+        )
+        ids = {p.id for p in paths}
+        assert pid["thpt"] in ids
+        assert pid["lien_thong"] in ids  # loại hình thuần vẫn hiện
+        assert pid["thcs"] not in ids
+
+        # cultural=None → KHÔNG lọc, trả cả 6.
+        paths_all, _ = await svc.list_active_paths_by_round(
+            audience_seed["round_id"], cultural=None
+        )
+        assert set(pid.values()) <= {p.id for p in paths_all}
+
+
+# ===========================================================================
+# Fix B / #4 — IDOR scope của dependency get_optional_profile_cultural_for_audience
+# (profile thật + unauthorized profile → 404; mirror get_admission_for_user_read)
+# ===========================================================================
+@pytest_asyncio.fixture
+async def idor_seed(seed_lead_dependencies: dict, seed_other_unit: dict) -> dict:
+    """1 hồ sơ THCS thuộc unit A + officer được phân công, 1 officer cùng unit
+    NHƯNG không phân công, 1 admin, 1 officer unit khác (seed_other_unit =
+    UNIT_2 id 9001, trên dải autoincrement → không đụng PK seeded)."""
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    unit_a = seed_lead_dependencies["unit_id"]
+    unit_b = seed_other_unit["unit_id"]
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            def _mk_user(tag, role, unit_id):
+                u = models.User(
+                    username=f"{tag}_{ts}",
+                    email=f"{tag}_{ts}@test.local",
+                    full_name=f"{tag} {ts}",
+                    password_hash=get_password_hash("test"),
+                    role=role,
+                    status="active",
+                    unit_id=unit_id,
+                )
+                s.add(u)
+                return u
+
+            officer_assigned = _mk_user("off_assigned", "officer", unit_a)
+            officer_unassigned = _mk_user("off_unassigned", "officer", unit_a)
+            officer_other_unit = _mk_user("off_other", "officer", unit_b)
+            manager_user = _mk_user("mgr", "manager", unit_a)
+            admin_user = _mk_user("adm", "admin", unit_a)
+            await s.flush()
+
+            lead = models.Lead(
+                full_name="IDOR Cultural Lead",
+                phone=f"09010{ts % 100000:05d}",
+                email=f"idor_cult_{ts}@test.local",
+                source="website",
+                unit_id=unit_a,
+                assigned_officer_id=officer_assigned.id,
+            )
+            s.add(lead)
+            await s.flush()
+
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                status="draft",
+                citizen_id=f"IDOR{ts:08d}",
+                academic_year=2026,
+                version=1,
+                applied_rules={"min_gpa": 0, "mandatory_docs": []},
+                cultural_education_level="graduated_thcs",
+            )
+            s.add(profile)
+            await s.flush()
+
+            return {
+                "profile_id": profile.id,
+                "officer_assigned_id": officer_assigned.id,
+                "officer_assigned_username": officer_assigned.username,
+                "officer_unassigned_id": officer_unassigned.id,
+                "officer_other_unit_id": officer_other_unit.id,
+                "officer_other_unit_username": officer_other_unit.username,
+                "manager_id": manager_user.id,
+                "admin_id": admin_user.id,
+            }
+
+
+async def _call_dep(profile_id, user_id):
+    """Gọi dependency trực tiếp với 1 session + current_user đã load."""
+    async with AsyncSessionLocal() as s:
+        user = None
+        if user_id is not None:
+            user = await s.get(models.User, user_id)
+        return await get_optional_profile_cultural_for_audience(
+            profile_id=profile_id, current_user=user, db=s
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_idor_officer_assigned_reads_cultural(idor_seed):
+    # Officer được phân công + cùng unit → đọc được cultural.
+    got = await _call_dep(idor_seed["profile_id"], idor_seed["officer_assigned_id"])
+    assert got == "graduated_thcs"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_idor_admin_reads_any_cultural(idor_seed):
+    got = await _call_dep(idor_seed["profile_id"], idor_seed["admin_id"])
+    assert got == "graduated_thcs"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_idor_officer_unassigned_same_unit_blocked(idor_seed):
+    # Officer cùng unit nhưng KHÔNG được phân công → 404 (không leak cultural).
+    with pytest.raises(ResourceNotFoundError):
+        await _call_dep(idor_seed["profile_id"], idor_seed["officer_unassigned_id"])
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_idor_officer_other_unit_blocked(idor_seed):
+    with pytest.raises(ResourceNotFoundError):
+        await _call_dep(idor_seed["profile_id"], idor_seed["officer_other_unit_id"])
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_idor_nonexistent_profile_blocked(idor_seed):
+    with pytest.raises(ResourceNotFoundError):
+        await _call_dep(2_000_000_000, idor_seed["officer_assigned_id"])
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_idor_no_profile_id_returns_none(idor_seed):
+    # profile_id None → KHÔNG query, KHÔNG lọc.
+    assert await _call_dep(None, idor_seed["officer_assigned_id"]) is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_idor_manager_same_unit_reads_cultural(idor_seed):
+    # Manager cùng unit → đọc được cultural DÙ không được phân công (nhánh scope
+    # riêng: non-admin + same-unit + role != OFFICER → bỏ qua assigned check).
+    got = await _call_dep(idor_seed["profile_id"], idor_seed["manager_id"])
+    assert got == "graduated_thcs"
+
+
+# ===========================================================================
+# #5 — HTTP end-to-end: router → deps(IDOR) → service → repo (khoá wiring +
+# fake-404 thật qua tầng HTTP/Query parsing/auth, KHÔNG chỉ gọi dependency tay)
+# ===========================================================================
+async def _login_bearer(client, username, password="test"):
+    """Login → Bearer header. Clear cookie jar trước+sau để Bearer không bị
+    cookie phiên trước ghi đè (memory test-httpx-cookie-jar-contamination)."""
+    client.cookies.clear()
+    res = await client.post(
+        "/api/auth/login", data={"username": username, "password": password}
+    )
+    assert res.status_code == 200, f"login failed: {res.status_code} {res.text}"
+    token = res.cookies.get("access_token")
+    assert token, "login OK nhưng thiếu access_token cookie"
+    client.cookies.clear()
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_by_round_endpoint_idor_and_filter(client, audience_seed, idor_seed):
+    pid = audience_seed["path_ids"]
+    url = f"/api/admission-config/paths/by-round/{audience_seed['round_id']}"
+
+    # Officer được phân công + sở hữu hồ sơ graduated_thcs → 200 + lọc POST_THCS.
+    hdr = await _login_bearer(client, idor_seed["officer_assigned_username"])
+    res = await client.get(
+        url, params={"profile_id": idor_seed["profile_id"]}, headers=hdr
+    )
+    assert res.status_code == 200, res.text
+    ids = {item["id"] for item in res.json()["items"]}
+    assert pid["thcs"] in ids
+    assert pid["legacy"] in ids
+    assert pid["thpt"] not in ids  # ẩn đường THPT cho hồ sơ THCS
+
+    # KHÔNG truyền profile_id → KHÔNG lọc (trả cả 8) — khoá nhánh "bỏ trống".
+    res_all = await client.get(url, headers=hdr)
+    assert res_all.status_code == 200, res_all.text
+    assert set(pid.values()) <= {item["id"] for item in res_all.json()["items"]}
+
+    # Officer unit khác xin profile_id hồ sơ unit A → 404 FAKE (IDOR thật qua HTTP).
+    hdr_other = await _login_bearer(client, idor_seed["officer_other_unit_username"])
+    res_404 = await client.get(
+        url, params={"profile_id": idor_seed["profile_id"]}, headers=hdr_other
+    )
+    assert res_404.status_code == 404, res_404.text
+
+
+# ===========================================================================
+# Signature / contract (unit) — khoá API surface của 2 fix
+# ===========================================================================
+def test_repo_get_active_paths_by_round_has_audience_param():
+    sig = inspect.signature(AdmissionPathRepository.get_active_paths_by_round)
+    assert "audience" in sig.parameters
+    assert sig.parameters["audience"].default is None
+
+
+def test_service_list_active_paths_by_round_has_cultural_param():
+    sig = inspect.signature(AdmissionPathService.list_active_paths_by_round)
+    assert "cultural" in sig.parameters
+    assert sig.parameters["cultural"].default is None
+    # profile_id đã chuyển sang tầng deps (IDOR-scope) — service KHÔNG nhận id.
+    assert "profile_id" not in sig.parameters

--- a/frontend/src/components/admissions/AddChoiceDialog/AddChoiceDialog.tsx
+++ b/frontend/src/components/admissions/AddChoiceDialog/AddChoiceDialog.tsx
@@ -120,11 +120,19 @@ export function AddChoiceDialog({
     return currentPathDetail?.admission_round_id ?? null
   }, [roundIdOverride, currentPathDetail])
 
-  // Step 2: Load list paths in round
+  // Step 2: Load list paths in round.
+  // Truyền profileId → BE lọc phương thức theo trình độ văn hóa của hồ sơ
+  // (TN THCS không thấy đường yêu cầu THPT). Hồ sơ chưa khai trình độ →
+  // BE giữ nguyên toàn bộ danh sách. profileId trong queryKey để cache
+  // tách theo hồ sơ.
   const { data: pathsData, isLoading: loadingPaths } = useQuery({
-    queryKey: ["paths-by-round", roundId],
-    queryFn: () => getPathsByRound(roundId as number),
+    queryKey: ["paths-by-round", roundId, profileId],
+    queryFn: () => getPathsByRound(roundId as number, profileId),
     enabled: open && roundId !== null,
+    // staleTime 0: cultural_education_level (yếu tố BE lọc) KHÔNG nằm trong
+    // queryKey, nên luôn fetch lại khi dialog mở để lọc theo trình độ mới
+    // nhất; useUpdateAdmission cũng invalidate key này sau khi lưu trình độ.
+    staleTime: 0,
   })
 
   // Step 3: Load sg_configs khi user picks path
@@ -152,6 +160,23 @@ export function AddChoiceDialog({
       setScores([])
       setServerError(null)
     }
+  }
+
+  // Reset selection nếu path đang chọn biến mất khỏi danh sách sau refetch
+  // (vd bộ lọc trình độ văn hóa thu hẹp list). Render-time, idempotent: sau
+  // reset selectedPathId=null → điều kiện sai → dừng. Tránh hiển thị tổ hợp /
+  // fetch sg-configs / submit cho path không còn khả dụng. Chỉ chạy khi list
+  // đã load (pathsData !== undefined) để không reset nhầm lúc đang tải.
+  if (
+    selectedPathId !== null &&
+    pathsData !== undefined &&
+    !pathsData.items.some((p) => p.id === selectedPathId)
+  ) {
+    setSelectedPathId(null)
+    setSelectedConfigId(null)
+    setScores([])
+    // Xóa luôn lỗi server của path đã biến mất (nhất quán với khối reset-on-open).
+    setServerError(null)
   }
 
   // Initialize scores rows when sg_config changes — same pattern.

--- a/frontend/src/hooks/admissions/useAdmissions.ts
+++ b/frontend/src/hooks/admissions/useAdmissions.ts
@@ -181,6 +181,11 @@ export function useUpdateAdmission(id: number) {
       // Invalidate to refetch fresh data from server
       queryClient.invalidateQueries({ queryKey: admissionsKeys.detail(id) })
       queryClient.invalidateQueries({ queryKey: admissionsKeys.lists() })
+      // Trình độ văn hóa (cultural_education_level) lưu qua mutation này lọc
+      // danh sách phương thức ở AddChoiceDialog (BE lọc theo audience suy từ
+      // cultural). Invalidate ["paths-by-round"] để dropdown lọc lại theo
+      // trình độ mới — tránh stale (queryKey không gồm cultural).
+      queryClient.invalidateQueries({ queryKey: ["paths-by-round"] })
     },
     onError: (error: AxiosError<ApiErrorResponse>) => {
       // Phase 7: Use centralized handler with 409 conflict support

--- a/frontend/src/lib/api/admission-paths.ts
+++ b/frontend/src/lib/api/admission-paths.ts
@@ -197,10 +197,15 @@ export async function getCoverageMatrix(
  * Cross-academic_info — candidate có thể thêm NV ở ngành khác cùng đợt.
  */
 export async function getPathsByRound(
-  roundId: number
+  roundId: number,
+  profileId?: number,
 ): Promise<{ total: number; items: AdmissionPathResponse[] }> {
+  // profileId (optional): BE lọc phương thức theo trình độ văn hóa
+  // (cultural_education_level) của hồ sơ → TN THCS không thấy đường yêu cầu
+  // THPT. Bỏ trống / hồ sơ chưa khai trình độ → BE không lọc.
   const response = await api.get<{ total: number; items: AdmissionPathResponse[] }>(
-    `/api/admission-config/paths/by-round/${roundId}`
+    `/api/admission-config/paths/by-round/${roundId}`,
+    profileId != null ? { params: { profile_id: profileId } } : undefined,
   )
   return response.data
 }


### PR DESCRIPTION
Fix A — hotfix prod 500: get_active_paths_by_offering_id thiếu
selectinload(activator) → MissingGreenlet khi serialize
AdmissionPathResponse.activator cho path có activated_by NOT NULL (7 ngành
Trung cấp THCS TS2026) → officer/admin KHÔNG tạo được hồ sơ. Mirror sibling
get_active_paths_by_round.

Fix B — AddChoiceDialog lọc phương thức theo cultural_education_level:
- repo get_active_paths_by_round(audience): _audience_visibility_filter ẩn path
  gắn bậc văn hóa ĐỐI LẬP, giữ NULL/[]/liên-thông/VLVH (or_(@>, NOT(&&)))
- IDOR: deps get_optional_profile_cultural_for_audience (scope 3-tier mirror
  get_admission_for_user_read, 404-fake, le=INT4 max) → service nhận cultural
- public cultural_to_audience() (bỏ import private _CULTURAL_TO_AUDIENCE)
- FE getPathsByRound(profileId) + invalidate ["paths-by-round"] + staleTime0 +
  reset-selection khi path biến mất

Tests (22): truth-table both/mixed/NULL/[]/liên-thông, IDOR officer/manager/
cross-unit/nonexistent → 404, HTTP e2e fake-404, parity, activator serialize.
Thêm vào CI Tier 1 (234/234 pass). Defer: tách shared IDOR helper (cleanup PR).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
