### PR TITLE
fix(sms): bound contact IDs to int32 (PR-2 hotfix)

### DIFF
--- a/Backend_FastAPI/app/routers/sms_contacts.py
+++ b/Backend_FastAPI/app/routers/sms_contacts.py
@@ -9,13 +9,14 @@ main.py (đã wire ở PR-1).
 """
 import hashlib
 from datetime import datetime
-from typing import Optional
+from typing import Annotated, Optional
 
 from fastapi import (
     APIRouter,
     Depends,
     File,
     Form,
+    Path,
     Query,
     UploadFile,
     status,
@@ -28,6 +29,10 @@ from app.schemas import sms as sms_schemas
 from app.services.sms_contact_service import SmsContactService
 
 router = APIRouter(prefix="/api/sms", tags=["SMS Contacts"])
+
+# PostgreSQL Integer is int4. Reject oversized path/query values before asyncpg
+# receives them and turns an invalid API input into a 500 response.
+_MAX_ID = 2147483647
 
 
 # =====================================================================
@@ -54,7 +59,7 @@ async def create_contact_group(
 async def list_contact_groups(
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(require_admin),
-    skip: int = Query(0, ge=0),
+    skip: int = Query(0, ge=0, le=_MAX_ID),
     limit: int = Query(50, ge=1, le=200),
     group_type: Optional[str] = Query(None),
     is_active: Optional[bool] = Query(None),
@@ -75,7 +80,7 @@ async def list_contact_groups(
     response_model=sms_schemas.SmsContactGroupOut,
 )
 async def get_contact_group(
-    group_id: int,
+    group_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(require_admin),
 ):
@@ -87,7 +92,7 @@ async def get_contact_group(
     response_model=sms_schemas.SmsContactGroupOut,
 )
 async def update_contact_group(
-    group_id: int,
+    group_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
     payload: sms_schemas.SmsContactGroupUpdate,
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(require_admin),
@@ -102,7 +107,7 @@ async def update_contact_group(
     response_model=sms_schemas.SmsImportResult,
 )
 async def upload_contacts_to_group(
-    group_id: int,
+    group_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
     file: UploadFile = File(..., description="File .csv hoặc .xlsx"),
     source_label: Optional[str] = Form(None),
     consent_basis: Optional[str] = Form(None),
@@ -135,10 +140,10 @@ async def upload_contacts_to_group(
     response_model=sms_schemas.SmsContactList,
 )
 async def list_group_contacts(
-    group_id: int,
+    group_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(require_admin),
-    skip: int = Query(0, ge=0),
+    skip: int = Query(0, ge=0, le=_MAX_ID),
     limit: int = Query(50, ge=1, le=200),
     search: Optional[str] = Query(None),
     consent_status: Optional[str] = Query(None),
@@ -162,7 +167,7 @@ async def list_group_contacts(
 async def list_contacts(
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(require_admin),
-    skip: int = Query(0, ge=0),
+    skip: int = Query(0, ge=0, le=_MAX_ID),
     limit: int = Query(50, ge=1, le=200),
     search: Optional[str] = Query(None),
     consent_status: Optional[str] = Query(None),
@@ -197,7 +202,7 @@ async def create_contact(
     "/contacts/{contact_id}", response_model=sms_schemas.SmsContactOut
 )
 async def update_contact(
-    contact_id: int,
+    contact_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
     payload: sms_schemas.SmsContactUpdate,
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(require_admin),
@@ -215,7 +220,7 @@ async def update_contact(
     status_code=status.HTTP_201_CREATED,
 )
 async def append_consent_event(
-    contact_id: int,
+    contact_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
     payload: sms_schemas.SmsConsentEventCreate,
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(require_admin),
@@ -232,10 +237,10 @@ async def append_consent_event(
     response_model=sms_schemas.SmsConsentEventList,
 )
 async def list_consent_events(
-    contact_id: int,
+    contact_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(require_admin),
-    skip: int = Query(0, ge=0),
+    skip: int = Query(0, ge=0, le=_MAX_ID),
     limit: int = Query(50, ge=1, le=200),
 ):
     total, items = await SmsContactService(db).list_consent_events(
@@ -250,7 +255,7 @@ async def list_consent_events(
     status_code=status.HTTP_201_CREATED,
 )
 async def add_contact_to_group(
-    contact_id: int,
+    contact_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
     payload: sms_schemas.SmsGroupMembershipAdd,
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(require_admin),
@@ -269,8 +274,8 @@ async def add_contact_to_group(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def remove_contact_from_group(
-    contact_id: int,
-    group_id: int,
+    contact_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    group_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = Depends(require_admin),
 ):

--- a/Backend_FastAPI/app/schemas/sms.py
+++ b/Backend_FastAPI/app/schemas/sms.py
@@ -179,7 +179,7 @@ class SmsContactList(BaseModel):
 class SmsGroupMembershipAdd(BaseModel):
     """Thêm contact vào 1 nhóm (note riêng trong nhóm tùy chọn)."""
 
-    group_id: int = Field(..., ge=1)
+    group_id: int = Field(..., ge=1, le=2147483647)
     note: Optional[str] = Field(None, max_length=2000)
 
 

--- a/Backend_FastAPI/tests/integration/test_sms_contacts.py
+++ b/Backend_FastAPI/tests/integration/test_sms_contacts.py
@@ -12,9 +12,11 @@ Chạy one-off container (CLAUDE.md):
   docker compose run --rm --no-deps backend \
     python -m pytest tests/integration/test_sms_contacts.py -q
 """
+import pytest
 from httpx import AsyncClient
 
 API = "/api/sms"
+_TOO_LARGE_INT4 = 2147483648
 
 
 # ---------------------------------------------------------------------
@@ -802,3 +804,101 @@ async def test_import_rejects_unicode_digit_phone(
 async def test_requires_auth(client: AsyncClient):
     res = await client.get(f"{API}/contact-groups")
     assert res.status_code == 401
+
+
+# ---------------------------------------------------------------------
+# PR-2 hotfix — reject values outside PostgreSQL int4 before DB access
+# ---------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("method", "path", "request_kwargs"),
+    [
+        ("GET", f"/contact-groups/{_TOO_LARGE_INT4}", {}),
+        (
+            "PATCH",
+            f"/contact-groups/{_TOO_LARGE_INT4}",
+            {"json": {"description": "x"}},
+        ),
+        (
+            "POST",
+            f"/contact-groups/{_TOO_LARGE_INT4}/contacts/upload",
+            {
+                "files": _upload_files(
+                    "full_name,phone\nA,0901234567\n"
+                )
+            },
+        ),
+        ("GET", f"/contact-groups/{_TOO_LARGE_INT4}/contacts", {}),
+        (
+            "PATCH",
+            f"/contacts/{_TOO_LARGE_INT4}",
+            {"json": {"note": "x"}},
+        ),
+        (
+            "POST",
+            f"/contacts/{_TOO_LARGE_INT4}/consent-events",
+            {
+                "json": {
+                    "event_type": "revoked",
+                    "occurred_at": "2026-06-01T00:00:00+07:00",
+                    "revoke_source": "manual",
+                }
+            },
+        ),
+        ("GET", f"/contacts/{_TOO_LARGE_INT4}/consent-events", {}),
+        (
+            "POST",
+            f"/contacts/{_TOO_LARGE_INT4}/groups",
+            {"json": {"group_id": 1}},
+        ),
+        ("DELETE", f"/contacts/{_TOO_LARGE_INT4}/groups/1", {}),
+        ("DELETE", f"/contacts/1/groups/{_TOO_LARGE_INT4}", {}),
+    ],
+)
+async def test_path_ids_reject_values_outside_int4(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    method: str,
+    path: str,
+    request_kwargs: dict,
+):
+    res = await client.request(
+        method,
+        f"{API}{path}",
+        headers=admin_token_headers,
+        **request_kwargs,
+    )
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/contact-groups",
+        "/contact-groups/1/contacts",
+        "/contacts",
+        "/contacts/1/consent-events",
+    ],
+)
+async def test_skip_rejects_values_outside_int4(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    path: str,
+):
+    res = await client.get(
+        f"{API}{path}",
+        params={"skip": _TOO_LARGE_INT4},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 422, res.text
+
+
+async def test_membership_group_id_rejects_values_outside_int4(
+    client: AsyncClient,
+    admin_token_headers: dict,
+):
+    res = await client.post(
+        f"{API}/contacts/1/groups",
+        json={"group_id": _TOO_LARGE_INT4},
+        headers=admin_token_headers,
+    )
+    assert res.status_code == 422, res.text


### PR DESCRIPTION
## Vấn đề
Các endpoint contact/group của PR-2 (đã deploy prod) nhận `contact_id`/`group_id` path + `skip` query KHÔNG giới hạn. ID/offset cực lớn (vượt int32/int64) → asyncpg DataError → **HTTP 500** thay vì 422. Codex nêu độc lập qua 4 vòng (R4/R5/R7/R8).

## Fix
- `_MAX_ID = 2147483647` (int4 ceiling).
- 10 path `contact_id`/`group_id` → `Annotated[int, Path(ge=1, le=_MAX_ID)]`.
- 4 `skip` query → `Query(0, ge=0, le=_MAX_ID)`.
- `SmsGroupMembershipAdd.group_id` → `Field(..., ge=1, le=2147483647)`.

## Test
43/43 pass (gồm regression ID/offset cực lớn → 422, không 500). flake8 + compileall sạch. **Không migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)