### PR TITLE
feat(sms): PR-3 campaign build backend

### DIFF
--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -42,6 +42,13 @@ os.makedirs(_AVATAR_UPLOAD_FOLDER, exist_ok=True)
 # # --- KẾT THÚC TÍNH TOÁN TRƯỚC ---
 
 
+# Default placeholder hướng dẫn từ chối (SMS/điện thoại) — prod PHẢI đặt
+# kênh từ chối THẬT; build refuse nếu còn placeholder này trong production.
+SMS_OPTOUT_INSTRUCTION_DEFAULT = (
+    "Tu choi QC: soan TC gui 1900xxxx hoac goi 1900xxxx."
+)
+
+
 class Settings(BaseSettings):
     # Application Settings
     # Pydantic tự đọc APP_ENV từ môi trường
@@ -226,6 +233,44 @@ class Settings(BaseSettings):
     MFA_ENFORCE_ROLES: List[str] = Field(
         default=["admin", "manager"], validation_alias="MFA_ENFORCE_ROLES"
     )  # Roles that MUST enable MFA (OWASP ASVS 5.0)
+
+    # -- SMS Marketing: token + build (PR-3) --
+    # Short-link token: HMAC hash secret (lookup) + Fernet keyring (re-export).
+    # Prod cần giá trị thật. CỐ Ý KHÔNG fail-fast startup (để không gãy backend
+    # prod khi SMS chưa cấu hình) — thiếu/invalid sẽ lỗi tại thời điểm BUILD
+    # campaign có {link} (lazy, app/utils/sms_token.py). Dev/test: helper dẫn
+    # xuất key từ default → chạy được không cần env.
+    SMS_TOKEN_HASH_SECRET: str = Field(
+        default="dev-sms-token-hash-secret-change-in-prod",
+        validation_alias="SMS_TOKEN_HASH_SECRET",
+    )
+    # JSON string {version: fernet_key}, vd {"v1":"<Fernet.generate_key()>"}.
+    SMS_TOKEN_ENCRYPTION_KEYS: str = Field(
+        default="", validation_alias="SMS_TOKEN_ENCRYPTION_KEYS",
+    )
+    SMS_TOKEN_ACTIVE_KEY_VERSION: str = Field(
+        default="", validation_alias="SMS_TOKEN_ACTIVE_KEY_VERSION",
+    )
+    SMS_IP_HASH_SECRET: str = Field(
+        default="dev-sms-ip-hash-secret-change-in-prod",
+        validation_alias="SMS_IP_HASH_SECRET",
+    )  # click ip_hash (PR-5) — thêm sẵn cho keyring nhất quán
+    SMS_PUBLIC_BASE_URL: str = Field(
+        default="https://qlts.tnpc.edu.vn",
+        validation_alias="SMS_PUBLIC_BASE_URL",
+    )  # link {SMS_PUBLIC_BASE_URL}/r/{code}
+    SMS_ALLOWED_REDIRECT_DOMAINS: str = Field(
+        default="qlts.tnpc.edu.vn,tnpc.edu.vn",
+        validation_alias="SMS_ALLOWED_REDIRECT_DOMAINS",
+    )  # CSV host cho landing_type=external (§6.2)
+    SMS_FREQUENCY_CAP_DAYS: int = Field(
+        default=0, ge=0, le=3650, validation_alias="SMS_FREQUENCY_CAP_DAYS",
+    )  # 0 = tắt; ge=0 chống âm; le=3650 trần (khớp campaign cap, chống 1e9)
+    # [QC] LUÔN được chèn ở build (advertising NĐ91 Đ15) — không có toggle.
+    SMS_OPTOUT_INSTRUCTION: str = Field(
+        default=SMS_OPTOUT_INSTRUCTION_DEFAULT,
+        validation_alias="SMS_OPTOUT_INSTRUCTION",
+    )  # hướng dẫn từ chối SMS/điện thoại — org BẮT BUỘC đặt nội dung thật
 
     # -- Docker self-hosted deployment --
     # When True, skip TLS enforcement for DB/Redis connections.

--- a/Backend_FastAPI/app/repositories/sms_campaign_repository.py
+++ b/Backend_FastAPI/app/repositories/sms_campaign_repository.py
@@ -1,0 +1,318 @@
+# app/repositories/sms_campaign_repository.py
+"""
+Data-access SMS campaign domain (PR-3): campaign CRUD, campaign↔group,
+nguồn build (members-of-groups, opt-out, carrier prefix map), recipient
+bulk-insert + invalidate-old-revision, và aggregate cho preflight.
+
+Standalone repository (giống sms_contact_repository). Service flush, router
+commit. Xem SMS_MARKETING_MODULE_DESIGN.md §3/§6/§7/§8.
+"""
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from sqlalchemy import func, insert, or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.sms import (
+    SmsCampaign,
+    SmsCampaignGroup,
+    SmsCampaignRecipient,
+    SmsContact,
+    SmsContactGroup,
+    SmsContactGroupMember,
+    SmsOptOut,
+    SmsPrefixCarrierRule,
+)
+
+
+class SmsCampaignRepository:
+    """Repository campaign + recipient build + preflight."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    # ---------------------------------------------------------------
+    # Campaign
+    # ---------------------------------------------------------------
+    async def create_campaign(self, data: dict) -> SmsCampaign:
+        campaign = SmsCampaign(**data)
+        self.db.add(campaign)
+        await self.db.flush()
+        return campaign
+
+    async def get_campaign(self, campaign_id: int) -> Optional[SmsCampaign]:
+        res = await self.db.execute(
+            select(SmsCampaign).where(SmsCampaign.id == campaign_id)
+        )
+        return res.scalars().first()
+
+    async def get_campaign_for_update(
+        self, campaign_id: int
+    ) -> Optional[SmsCampaign]:
+        """Lock campaign row — build/attestation cập nhật build_revision."""
+        res = await self.db.execute(
+            select(SmsCampaign)
+            .where(SmsCampaign.id == campaign_id)
+            .with_for_update()
+        )
+        return res.scalar_one_or_none()
+
+    async def get_campaign_by_code(
+        self, code: str
+    ) -> Optional[SmsCampaign]:
+        res = await self.db.execute(
+            select(SmsCampaign).where(SmsCampaign.code == code)
+        )
+        return res.scalars().first()
+
+    async def list_campaigns(
+        self,
+        skip: int = 0,
+        limit: int = 50,
+        status: Optional[str] = None,
+        search: Optional[str] = None,
+    ) -> Tuple[int, List[SmsCampaign]]:
+        conds = []
+        if status is not None:
+            conds.append(SmsCampaign.status == status)
+        if search:
+            like = f"%{search.strip()}%"
+            conds.append(
+                or_(
+                    SmsCampaign.name.ilike(like),
+                    SmsCampaign.code.ilike(like),
+                )
+            )
+        base = select(SmsCampaign)
+        if conds:
+            base = base.where(*conds)
+        total = await self.db.scalar(
+            select(func.count()).select_from(base.subquery())
+        )
+        res = await self.db.execute(
+            base.order_by(SmsCampaign.created_at.desc())
+            .offset(skip)
+            .limit(limit)
+        )
+        return int(total or 0), list(res.scalars().all())
+
+    # ---------------------------------------------------------------
+    # Campaign ↔ group
+    # ---------------------------------------------------------------
+    async def get_campaign_group(
+        self, campaign_id: int, group_id: int
+    ) -> Optional[SmsCampaignGroup]:
+        res = await self.db.execute(
+            select(SmsCampaignGroup).where(
+                SmsCampaignGroup.campaign_id == campaign_id,
+                SmsCampaignGroup.group_id == group_id,
+            )
+        )
+        return res.scalars().first()
+
+    async def create_campaign_group(
+        self, campaign_id: int, group_id: int
+    ) -> SmsCampaignGroup:
+        cg = SmsCampaignGroup(campaign_id=campaign_id, group_id=group_id)
+        self.db.add(cg)
+        await self.db.flush()
+        return cg
+
+    async def delete_campaign_group(self, cg: SmsCampaignGroup) -> None:
+        await self.db.delete(cg)
+        await self.db.flush()
+
+    async def get_campaign_group_ids(self, campaign_id: int) -> List[int]:
+        res = await self.db.execute(
+            select(SmsCampaignGroup.group_id)
+            .where(SmsCampaignGroup.campaign_id == campaign_id)
+            .order_by(SmsCampaignGroup.group_id)
+        )
+        return [r[0] for r in res.all()]
+
+    async def get_group_counts(
+        self, campaign_ids: Sequence[int]
+    ) -> Dict[int, int]:
+        """{campaign_id: số nhóm} cho list (tránh group_count=null ở list API)."""
+        if not campaign_ids:
+            return {}
+        res = await self.db.execute(
+            select(SmsCampaignGroup.campaign_id, func.count())
+            .where(SmsCampaignGroup.campaign_id.in_(set(campaign_ids)))
+            .group_by(SmsCampaignGroup.campaign_id)
+        )
+        return {r[0]: int(r[1]) for r in res.all()}
+
+    # ---------------------------------------------------------------
+    # Build inputs
+    # ---------------------------------------------------------------
+    async def get_members_of_groups(
+        self, group_ids: Sequence[int]
+    ) -> List[Tuple[int, SmsContact]]:
+        """(group_id, contact) cho member của các nhóm đã chọn — CHỈ nhóm
+        is_active (nhóm đã ngừng KHÔNG đóng góp recipient, kể cả khi bị tắt
+        sau attach). Service dedupe theo phone + gom group_ids đóng góp."""
+        if not group_ids:
+            return []
+        res = await self.db.execute(
+            select(SmsContactGroupMember.group_id, SmsContact)
+            .join(
+                SmsContact,
+                SmsContact.id == SmsContactGroupMember.contact_id,
+            )
+            .join(
+                SmsContactGroup,
+                SmsContactGroup.id == SmsContactGroupMember.group_id,
+            )
+            .where(
+                SmsContactGroupMember.group_id.in_(set(group_ids)),
+                SmsContactGroup.is_active.is_(True),
+            )
+        )
+        return [(row[0], row[1]) for row in res.all()]
+
+    async def get_optout_source_map(
+        self, phones: Sequence[str]
+    ) -> Dict[str, str]:
+        """{phone_normalized: source} cho số trong sms_opt_out (suppression
+        toàn cục). source phân biệt opt-out người dùng (landing/manual/sms_reply
+        /phone_call) vs `external_suppression` (DNC list) → service map
+        excluded_reason đúng (opted_out vs dnc_suppressed). phone UNIQUE → 1
+        row/phone."""
+        if not phones:
+            return {}
+        res = await self.db.execute(
+            select(SmsOptOut.phone_normalized, SmsOptOut.source).where(
+                SmsOptOut.phone_normalized.in_(set(phones))
+            )
+        )
+        return {r[0]: r[1] for r in res.all()}
+
+    async def get_active_carrier_prefix_map(self) -> Dict[str, str]:
+        res = await self.db.execute(
+            select(
+                SmsPrefixCarrierRule.prefix,
+                SmsPrefixCarrierRule.carrier_code,
+            ).where(SmsPrefixCarrierRule.is_active.is_(True))
+        )
+        return {r[0]: r[1] for r in res.all()}
+
+    async def has_handed_off_recipients(self, campaign_id: int) -> bool:
+        """True nếu ≥1 recipient của campaign đã bàn giao (handed_off_at NOT
+        NULL) — chặn rebuild sau partial handoff (§232: chỉ rebuild khi CHƯA
+        có batch bàn giao)."""
+        res = await self.db.scalar(
+            select(SmsCampaignRecipient.id)
+            .where(
+                SmsCampaignRecipient.campaign_id == campaign_id,
+                SmsCampaignRecipient.handed_off_at.is_not(None),
+            )
+            .limit(1)
+        )
+        return res is not None
+
+    # ---------------------------------------------------------------
+    # Recipients
+    # ---------------------------------------------------------------
+    async def invalidate_recipients_before(
+        self, campaign_id: int, before_revision: int
+    ) -> None:
+        """Vô hiệu recipient revision CŨ (chưa bàn giao) khi rebuild (§4.8)."""
+        await self.db.execute(
+            update(SmsCampaignRecipient)
+            .where(
+                SmsCampaignRecipient.campaign_id == campaign_id,
+                SmsCampaignRecipient.build_revision < before_revision,
+                SmsCampaignRecipient.invalidated_at.is_(None),
+                SmsCampaignRecipient.handed_off_at.is_(None),
+            )
+            .values(invalidated_at=func.now())
+        )
+
+    async def bulk_insert_recipients(self, rows: List[dict]) -> None:
+        """Core multi-row INSERT (KHÔNG ORM instance) → savepoint rollback
+        sạch khi token collision retry (không để instance lingering)."""
+        if not rows:
+            return
+        await self.db.execute(insert(SmsCampaignRecipient), rows)
+
+    # ---------------------------------------------------------------
+    # Preflight aggregates (build_revision hiện tại, invalidated_at NULL)
+    # ---------------------------------------------------------------
+    def _rev_filter(self, campaign_id: int, revision: int):
+        return (
+            SmsCampaignRecipient.campaign_id == campaign_id,
+            SmsCampaignRecipient.build_revision == revision,
+            SmsCampaignRecipient.invalidated_at.is_(None),
+        )
+
+    async def counts_by_excluded_reason(
+        self, campaign_id: int, revision: int
+    ) -> List[Tuple[Optional[str], int]]:
+        """(excluded_reason|None, count) — None = exportable."""
+        res = await self.db.execute(
+            select(SmsCampaignRecipient.excluded_reason, func.count())
+            .where(*self._rev_filter(campaign_id, revision))
+            .group_by(SmsCampaignRecipient.excluded_reason)
+        )
+        return [(r[0], int(r[1])) for r in res.all()]
+
+    async def counts_by_carrier_exportable(
+        self, campaign_id: int, revision: int
+    ) -> Dict[str, int]:
+        res = await self.db.execute(
+            select(SmsCampaignRecipient.carrier_bucket, func.count())
+            .where(
+                *self._rev_filter(campaign_id, revision),
+                SmsCampaignRecipient.excluded_reason.is_(None),
+            )
+            .group_by(SmsCampaignRecipient.carrier_bucket)
+        )
+        return {r[0]: int(r[1]) for r in res.all()}
+
+    async def get_over_limit_rows(
+        self, campaign_id: int, revision: int, limit: int = 200
+    ) -> List[SmsCampaignRecipient]:
+        """CHỈ row bị loại CHÍNH VÌ over_limit (excluded_reason='over_limit')
+        — nhất quán với excluded_by_reason['over_limit'] + warning. Row vừa
+        over vừa no_consent/opted_out đã loại vì lý do ưu tiên cao hơn nên
+        KHÔNG liệt kê (tránh báo cáo tự mâu thuẫn: list≠count)."""
+        res = await self.db.execute(
+            select(SmsCampaignRecipient)
+            .where(
+                *self._rev_filter(campaign_id, revision),
+                SmsCampaignRecipient.excluded_reason == "over_limit",
+            )
+            .order_by(SmsCampaignRecipient.id)  # ổn định để phát hiện cắt
+            .limit(limit)
+        )
+        return list(res.scalars().all())
+
+    async def get_sample_skeletons(
+        self, campaign_id: int, revision: int, limit: int = 5
+    ) -> List[str]:
+        """≤N skeleton của recipient EXPORTABLE (excluded_reason NULL) cho
+        preview preflight (§D6 "5 dòng mẫu từ chính segment")."""
+        res = await self.db.execute(
+            select(SmsCampaignRecipient.rendered_message_skeleton)
+            .where(
+                *self._rev_filter(campaign_id, revision),
+                SmsCampaignRecipient.excluded_reason.is_(None),
+            )
+            .order_by(SmsCampaignRecipient.id)
+            .limit(limit)
+        )
+        return [r[0] for r in res.all() if r[0]]
+
+    async def list_recipients(
+        self, campaign_id: int, revision: int, skip: int = 0, limit: int = 50
+    ) -> Tuple[int, List[SmsCampaignRecipient]]:
+        base = select(SmsCampaignRecipient).where(
+            *self._rev_filter(campaign_id, revision)
+        )
+        total = await self.db.scalar(
+            select(func.count()).select_from(base.subquery())
+        )
+        res = await self.db.execute(
+            base.order_by(SmsCampaignRecipient.id).offset(skip).limit(limit)
+        )
+        return int(total or 0), list(res.scalars().all())

--- a/Backend_FastAPI/app/routers/sms_campaigns.py
+++ b/Backend_FastAPI/app/routers/sms_campaigns.py
@@ -1,9 +1,165 @@
 # app/routers/sms_campaigns.py
 """
-SMS Marketing — campaigns + build + preflight (admin only).
-Stub PR-1; routes thêm ở **PR-3 (Claude)**: campaigns CRUD + groups + build
-+ preflight. KHÔNG sửa main.py (đã wire ở PR-1).
+SMS Marketing — campaigns + build + preflight + attestations (admin only).
+PR-3. Router "dumb": dịch HTTP ↔ service, commit, không business logic.
+Hard gate `require_admin`. KHÔNG sửa main.py (đã wire ở PR-1).
 """
-from fastapi import APIRouter
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, Path, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import database, models
+from app.core.deps import require_admin
+from app.schemas import sms as sms_schemas
+from app.services.sms_campaign_service import SmsCampaignService
 
 router = APIRouter(prefix="/api/sms", tags=["SMS Campaigns"])
+
+# Giới hạn ID khớp cột Integer (int4) — chặn int32 overflow → 500 (#1 R4).
+_MAX_ID = 2147483647
+
+
+# =====================================================================
+# Campaign CRUD
+# =====================================================================
+@router.post(
+    "/campaigns",
+    response_model=sms_schemas.SmsCampaignOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_campaign(
+    payload: sms_schemas.SmsCampaignCreate,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    campaign = await SmsCampaignService(db).create_campaign(
+        payload, current_user
+    )
+    await db.commit()
+    return campaign
+
+
+@router.get("/campaigns", response_model=sms_schemas.SmsCampaignList)
+async def list_campaigns(
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+    skip: int = Query(0, ge=0, le=_MAX_ID),
+    limit: int = Query(50, ge=1, le=200),
+    status_filter: Optional[str] = Query(None, alias="status"),
+    search: Optional[str] = Query(None),
+):
+    total, items = await SmsCampaignService(db).list_campaigns(
+        skip=skip, limit=limit, status=status_filter, search=search
+    )
+    return {"total": total, "items": items}
+
+
+@router.get(
+    "/campaigns/{campaign_id}", response_model=sms_schemas.SmsCampaignOut
+)
+async def get_campaign(
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    return await SmsCampaignService(db).get_campaign(campaign_id)
+
+
+@router.patch(
+    "/campaigns/{campaign_id}", response_model=sms_schemas.SmsCampaignOut
+)
+async def update_campaign(
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    payload: sms_schemas.SmsCampaignUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    campaign = await SmsCampaignService(db).update_campaign(
+        campaign_id, payload
+    )
+    await db.commit()
+    return campaign
+
+
+# =====================================================================
+# Campaign ↔ group
+# =====================================================================
+@router.post(
+    "/campaigns/{campaign_id}/groups",
+    response_model=sms_schemas.SmsCampaignOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def attach_group(
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    payload: sms_schemas.SmsCampaignGroupAttach,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    campaign = await SmsCampaignService(db).attach_group(
+        campaign_id, payload.group_id
+    )
+    await db.commit()
+    return campaign
+
+
+@router.delete(
+    "/campaigns/{campaign_id}/groups/{group_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def detach_group(
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    group_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    await SmsCampaignService(db).detach_group(campaign_id, group_id)
+    await db.commit()
+    return None
+
+
+# =====================================================================
+# Build + preflight + attestations
+# =====================================================================
+@router.post(
+    "/campaigns/{campaign_id}/build",
+    response_model=sms_schemas.SmsPreflightReport,
+)
+async def build_campaign(
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    report = await SmsCampaignService(db).build(campaign_id, current_user)
+    await db.commit()
+    return report
+
+
+@router.get(
+    "/campaigns/{campaign_id}/preflight",
+    response_model=sms_schemas.SmsPreflightReport,
+)
+async def get_preflight(
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    return await SmsCampaignService(db).preflight(campaign_id)
+
+
+@router.post(
+    "/campaigns/{campaign_id}/attestations",
+    response_model=sms_schemas.SmsCampaignOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_attestation(
+    campaign_id: Annotated[int, Path(ge=1, le=_MAX_ID)],
+    payload: sms_schemas.SmsAttestationCreate,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = Depends(require_admin),
+):
+    campaign = await SmsCampaignService(db).add_attestation(
+        campaign_id, payload, current_user
+    )
+    await db.commit()
+    return campaign

--- a/Backend_FastAPI/app/schemas/sms.py
+++ b/Backend_FastAPI/app/schemas/sms.py
@@ -8,7 +8,7 @@ constraint ở model (app/models/sms/) để validate fail-fast (400) trước k
 chạm DB. Xem `Documents/SMS_MARKETING_MODULE_DESIGN.md` §4 + §10.
 """
 from datetime import datetime, timedelta, timezone
-from typing import List, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 from pydantic import (
     BaseModel,
@@ -44,6 +44,26 @@ def validate_consent_datetime(dt, *, label="thời điểm"):
     if dt > datetime.now(timezone.utc) + timedelta(minutes=5):
         raise ValueError(f"{label} không được ở tương lai")
     return dt
+
+
+def validate_future_datetime(dt, *, label="thời điểm"):
+    """Yêu cầu tz-aware + PHẢI ở tương lai (link hết hạn không được quá khứ/
+    naive → tránh tạo link chết hoặc expiry lệch 7h). Raise → 422."""
+    if dt is None:
+        return dt
+    if dt.tzinfo is None:
+        raise ValueError(f"{label} phải kèm timezone (vd +07:00 hoặc Z)")
+    if dt <= datetime.now(timezone.utc):
+        raise ValueError(f"{label} phải ở tương lai")
+    return dt
+
+
+def _strip_optional_url(v):
+    """Strip URL optional; chuỗi rỗng sau strip → None (chống lưu whitespace)."""
+    if v is None:
+        return v
+    v = v.strip()
+    return v or None
 
 
 # --- Enum literal (mirror CHECK constraint model) ---
@@ -292,3 +312,171 @@ class SmsImportResult(BaseModel):
         "trong lô (theo occurred_at; revoke mới hơn không bị override)",
     )
     errors: List[SmsImportRowError] = Field(default_factory=list)
+
+
+# =====================================================================
+# Campaign (PR-3 — build BE)
+# =====================================================================
+SmsLandingType = Literal["qlts_hosted", "external"]
+SmsAttestationKind = Literal["consent", "dnc", "optout_channel"]
+# Lý do loại recipient (mirror CHECK chk_sms_recipient_excluded_reason)
+SmsExcludedReason = Literal[
+    "no_consent", "opted_out", "dnc_suppressed", "frequency_capped",
+    "over_limit", "missing_data",
+]
+
+
+class SmsCampaignCreate(BaseModel):
+    """Tạo campaign. Validate cross-field (biến template, external+{link},
+    allowlist host) ở service (cần config + candidate state)."""
+
+    name: str = Field(..., min_length=1, max_length=200)
+    code: Optional[str] = Field(
+        None, max_length=50, pattern=r"^[a-z0-9][a-z0-9-]*$",
+        description="slug duy nhất; bỏ trống để tự sinh từ name",
+    )
+    sms_template: str = Field(..., min_length=1, max_length=2000)
+    landing_type: SmsLandingType = "qlts_hosted"
+    landing_url: Optional[str] = Field(None, max_length=2000)
+    landing_headline: Optional[str] = Field(None, max_length=200)
+    landing_body: Optional[str] = Field(None, max_length=10000)
+    landing_cta_label: Optional[str] = Field(None, max_length=100)
+    landing_cta_url: Optional[str] = Field(None, max_length=2000)
+    frequency_cap_days: Optional[int] = Field(None, ge=0, le=3650)
+    link_expires_at: Optional[datetime] = None
+
+    @field_validator("name", "sms_template")
+    @classmethod
+    def _v_text(cls, v):
+        return _strip_required_text(v)
+
+    @field_validator("landing_url", "landing_cta_url")
+    @classmethod
+    def _v_url(cls, v):
+        return _strip_optional_url(v)
+
+    @field_validator("link_expires_at")
+    @classmethod
+    def _v_expiry(cls, v):
+        return validate_future_datetime(v, label="link_expires_at")
+
+
+class SmsCampaignUpdate(BaseModel):
+    """Sửa campaign — chỉ khi status=draft (gate ở service). KHÔNG đổi code."""
+
+    name: Optional[str] = Field(None, min_length=1, max_length=200)
+    sms_template: Optional[str] = Field(None, min_length=1, max_length=2000)
+    landing_type: Optional[SmsLandingType] = None
+    landing_url: Optional[str] = Field(None, max_length=2000)
+    landing_headline: Optional[str] = Field(None, max_length=200)
+    landing_body: Optional[str] = Field(None, max_length=10000)
+    landing_cta_label: Optional[str] = Field(None, max_length=100)
+    landing_cta_url: Optional[str] = Field(None, max_length=2000)
+    frequency_cap_days: Optional[int] = Field(None, ge=0, le=3650)
+    link_expires_at: Optional[datetime] = None
+
+    @field_validator("name", "sms_template")
+    @classmethod
+    def _v_text(cls, v):
+        return _strip_required_text(v)
+
+    @field_validator("landing_url", "landing_cta_url")
+    @classmethod
+    def _v_url(cls, v):
+        return _strip_optional_url(v)
+
+    @field_validator("link_expires_at")
+    @classmethod
+    def _v_expiry(cls, v):
+        return validate_future_datetime(v, label="link_expires_at")
+
+
+class SmsCampaignOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    code: str
+    status: str
+    sms_template: str
+    frequency_cap_days: Optional[int] = None
+    landing_type: str
+    landing_url: Optional[str] = None
+    landing_headline: Optional[str] = None
+    landing_body: Optional[str] = None
+    landing_cta_label: Optional[str] = None
+    landing_cta_url: Optional[str] = None
+    build_revision: int
+    link_expires_at: Optional[datetime] = None
+    optout_instruction_snapshot: Optional[str] = None
+    # Attestation (khớp build_revision mới hợp lệ)
+    consent_checked_at: Optional[datetime] = None
+    consent_checked_by_id: Optional[int] = None
+    consent_reference: Optional[str] = None
+    consent_checked_build_revision: Optional[int] = None
+    dnc_checked_at: Optional[datetime] = None
+    dnc_checked_by_id: Optional[int] = None
+    dnc_reference: Optional[str] = None
+    dnc_checked_build_revision: Optional[int] = None
+    optout_channel_checked_at: Optional[datetime] = None
+    optout_channel_checked_by_id: Optional[int] = None
+    optout_channel_reference: Optional[str] = None
+    optout_channel_checked_build_revision: Optional[int] = None
+    created_by_id: Optional[int] = None
+    created_at: datetime
+    updated_at: datetime
+    handed_off_marked_at: Optional[datetime] = None
+    # Computed (service điền)
+    has_link: Optional[bool] = None
+    group_count: Optional[int] = None
+
+
+class SmsCampaignList(BaseModel):
+    total: int
+    items: List[SmsCampaignOut]
+
+
+class SmsCampaignGroupAttach(BaseModel):
+    group_id: int = Field(..., ge=1, le=2147483647)  # int4 — chặn overflow
+
+
+class SmsOverLimitRow(BaseModel):
+    """1 recipient vượt 1 segment (admin cần rút gọn template/dữ liệu)."""
+
+    phone_normalized: str
+    full_name: str
+    encoding: Optional[str] = None
+    length: Optional[int] = None
+    segments: Optional[int] = None
+
+
+class SmsPreflightReport(BaseModel):
+    """Báo cáo build/preflight: tổng/exportable/loại theo lý do + phân bố
+    nhà mạng + danh sách over_limit + cảnh báo. Dùng cho POST build và
+    GET preflight."""
+
+    campaign_id: int
+    build_revision: int
+    status: str
+    has_link: bool
+    total: int
+    exportable: int
+    excluded_by_reason: Dict[str, int]
+    carrier_distribution: Dict[str, int]
+    over_limit: List[SmsOverLimitRow] = Field(default_factory=list)
+    warnings: List[str] = Field(default_factory=list)
+    # ≤5 dòng tin cuối MẪU từ segment thực (sentinel link → URL mẫu) — §D6.
+    preview: List[str] = Field(default_factory=list)
+
+
+class SmsAttestationCreate(BaseModel):
+    """Ghi attestation consent/DNC/opt-out-channel cho build_revision hiện
+    tại (gate export PR-4)."""
+
+    kind: SmsAttestationKind
+    reference: str = Field(..., min_length=1, max_length=512)
+
+    @field_validator("reference")
+    @classmethod
+    def _v_reference(cls, v):
+        return _strip_required_text(v)

--- a/Backend_FastAPI/app/services/sms_campaign_service.py
+++ b/Backend_FastAPI/app/services/sms_campaign_service.py
@@ -1,0 +1,676 @@
+# app/services/sms_campaign_service.py
+"""
+Business logic SMS campaign (PR-3): CRUD campaign + group, BUILD engine
+(snapshot revisioned + fail-closed consent/suppression/freq filter + carrier
++ token HMAC/Fernet + render [QC]/optout + preflight measure + invalidate
+revision cũ), preflight report, attestations.
+
+Tuân thủ kiến trúc QLTS: KHÔNG import fastapi; raise domain exception; chỉ
+`flush` (router commit). Build chạy dưới row lock campaign. Xem
+SMS_MARKETING_MODULE_DESIGN.md §3/§6/§7/§8.
+"""
+import re
+import unicodedata
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+from urllib.parse import urlparse
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import SMS_OPTOUT_INSTRUCTION_DEFAULT, settings
+from app.models.sms import SmsCampaign
+from app.repositories.sms_campaign_repository import SmsCampaignRepository
+from app.repositories.sms_contact_repository import SmsContactRepository
+from app.schemas import sms as sms_schemas
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    ConflictError,
+    DuplicateResourceError,
+    ResourceNotFoundError,
+    ValidationError,
+)
+from app.utils.sms_render import (
+    assemble_skeleton,
+    classify_carrier,
+    find_unknown_vars,
+    has_link,
+    measure_skeleton,
+    preview_message,
+    skeleton_is_broken,
+)
+from app.utils.sms_token import (
+    LINK_SENTINEL,
+    compute_token_hash,
+    encrypt_code,
+    ensure_token_secrets_configured,
+    generate_short_code,
+)
+
+# Status cho phép build lại (chưa bàn giao/đóng).
+_REBUILDABLE = {"draft", "ready", "exported"}
+_IP_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
+_TOKEN_RETRY = 5  # số lần auto-retry khi token_hash collision (§6.1)
+
+
+def _slugify(name: str) -> str:
+    s = unicodedata.normalize("NFD", name or "")
+    s = "".join(c for c in s if unicodedata.category(c) != "Mn")
+    s = s.replace("đ", "d").replace("Đ", "D").lower().strip()
+    s = re.sub(r"[^a-z0-9]+", "-", s).strip("-")
+    return s[:50] or "campaign"
+
+
+def _aware(dt: datetime) -> datetime:
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+class SmsCampaignService:
+    """Service campaign CRUD + build + preflight + attestations."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = SmsCampaignRepository(db)
+        self.contact_repo = SmsContactRepository(db)
+
+    # ===============================================================
+    # Content validation (cross-field — cần config + candidate state)
+    # ===============================================================
+    def _host_allowed(self, url: str) -> bool:
+        """https + host ∈ SMS_ALLOWED_REDIRECT_DOMAINS (exact/subdomain);
+        chặn @, IP literal, scheme ≠ https (§6.2)."""
+        raw = (url or "").strip()
+        if "@" in raw:
+            return False
+        try:
+            parsed = urlparse(raw)
+        except ValueError:
+            return False
+        if parsed.scheme != "https":
+            return False
+        host = (parsed.hostname or "").lower()
+        if not host or _IP_RE.match(host):
+            return False
+        allowed = [
+            d.strip().lower()
+            for d in settings.SMS_ALLOWED_REDIRECT_DOMAINS.split(",")
+            if d.strip()
+        ]
+        return any(host == d or host.endswith("." + d) for d in allowed)
+
+    def _validate_content(
+        self,
+        *,
+        sms_template: str,
+        landing_type: str,
+        landing_url: Optional[str],
+        landing_cta_url: Optional[str],
+        landing_cta_label: Optional[str] = None,
+    ) -> None:
+        if LINK_SENTINEL in (sms_template or ""):
+            raise ValidationError(
+                detail="Template không được chứa chuỗi nội bộ "
+                f"'{LINK_SENTINEL}'."
+            )
+        unknown = find_unknown_vars(sms_template)
+        if unknown:
+            raise ValidationError(
+                detail="Biến template không hợp lệ: "
+                + ", ".join("{" + v + "}" for v in sorted(unknown))
+                + " (chỉ {name}/{full_name}/{link})"
+            )
+        if landing_type == "external":
+            if not (landing_url and landing_url.strip()):
+                raise ValidationError(
+                    detail="landing_type=external cần landing_url"
+                )
+            if not has_link(sms_template):
+                raise ValidationError(
+                    detail="external + landing_url cần {link} trong template"
+                )
+        # Allowlist host cho mọi URL external (landing_url + CTA).
+        if landing_type == "external" and not self._host_allowed(landing_url):
+            raise ValidationError(
+                detail="landing_url host không thuộc allowlist redirect"
+            )
+        if landing_cta_url and landing_cta_url.strip():
+            if not self._host_allowed(landing_cta_url):
+                raise ValidationError(
+                    detail="landing_cta_url host không thuộc allowlist redirect"
+                )
+        # CTA cần CẢ nhãn lẫn URL, hoặc bỏ trống cả hai (chống CTA nửa vời).
+        if bool((landing_cta_label or "").strip()) != bool(
+            (landing_cta_url or "").strip()
+        ):
+            raise ValidationError(
+                detail="CTA cần CẢ nhãn (landing_cta_label) lẫn URL "
+                "(landing_cta_url), hoặc bỏ trống cả hai."
+            )
+
+    def _with_computed(
+        self, campaign: SmsCampaign, group_count: Optional[int] = None
+    ) -> SmsCampaign:
+        # Luôn set cả 2 transient attr (kể cả None) để Pydantic from_attributes
+        # không thiếu thuộc tính khi serialize SmsCampaignOut ở list.
+        campaign.has_link = has_link(campaign.sms_template)
+        campaign.group_count = group_count
+        return campaign
+
+    # ===============================================================
+    # CRUD campaign
+    # ===============================================================
+    async def create_campaign(
+        self, data: sms_schemas.SmsCampaignCreate, user
+    ) -> SmsCampaign:
+        self._validate_content(
+            sms_template=data.sms_template,
+            landing_type=data.landing_type,
+            landing_url=data.landing_url,
+            landing_cta_url=data.landing_cta_url,
+            landing_cta_label=data.landing_cta_label,
+        )
+        code = (data.code or _slugify(data.name)).strip()
+        if await self.repo.get_campaign_by_code(code) is not None:
+            raise DuplicateResourceError(
+                detail=f"Mã campaign '{code}' đã tồn tại"
+            )
+        fields = {
+            "name": data.name.strip(),
+            "code": code,
+            "sms_template": data.sms_template,
+            "landing_type": data.landing_type,
+            "landing_url": data.landing_url,
+            "landing_headline": data.landing_headline,
+            "landing_body": data.landing_body,
+            "landing_cta_label": data.landing_cta_label,
+            "landing_cta_url": data.landing_cta_url,
+            "frequency_cap_days": data.frequency_cap_days,
+            "link_expires_at": data.link_expires_at,
+            "created_by_id": getattr(user, "id", None),
+        }
+        try:
+            campaign = await self.repo.create_campaign(fields)
+        except IntegrityError:
+            raise DuplicateResourceError(
+                detail=f"Mã campaign '{code}' đã tồn tại"
+            )
+        return self._with_computed(campaign, group_count=0)
+
+    async def get_campaign(self, campaign_id: int) -> SmsCampaign:
+        campaign = await self.repo.get_campaign(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        gids = await self.repo.get_campaign_group_ids(campaign_id)
+        return self._with_computed(campaign, group_count=len(gids))
+
+    async def list_campaigns(
+        self,
+        skip: int,
+        limit: int,
+        status: Optional[str] = None,
+        search: Optional[str] = None,
+    ) -> Tuple[int, List[SmsCampaign]]:
+        total, items = await self.repo.list_campaigns(
+            skip=skip, limit=limit, status=status, search=search
+        )
+        counts = await self.repo.get_group_counts([c.id for c in items])
+        for c in items:
+            self._with_computed(c, group_count=counts.get(c.id, 0))
+        return total, items
+
+    async def update_campaign(
+        self, campaign_id: int, data: sms_schemas.SmsCampaignUpdate
+    ) -> SmsCampaign:
+        # Lock campaign row (cùng lock build) → serialize sửa template vs
+        # build, tránh build snapshot bằng template cũ rồi update đổi mới (#1).
+        campaign = await self.repo.get_campaign_for_update(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        if campaign.status != "draft":
+            raise BusinessRuleViolation(
+                detail="Chỉ sửa campaign khi đang ở trạng thái draft"
+            )
+        await self._ensure_not_handed_off(campaign_id)
+        patch = data.model_dump(exclude_unset=True)
+        # Chặn explicit null cho cột NOT NULL.
+        for f in ("name", "sms_template", "landing_type"):
+            if f in patch and patch[f] is None:
+                raise ValidationError(detail=f"Trường '{f}' không được null")
+        # Validate trên candidate state (existing + patch).
+        self._validate_content(
+            sms_template=patch.get("sms_template", campaign.sms_template),
+            landing_type=patch.get("landing_type", campaign.landing_type),
+            landing_url=patch.get("landing_url", campaign.landing_url),
+            landing_cta_url=patch.get(
+                "landing_cta_url", campaign.landing_cta_url
+            ),
+            landing_cta_label=patch.get(
+                "landing_cta_label", campaign.landing_cta_label
+            ),
+        )
+        if "name" in patch and patch["name"]:
+            patch["name"] = patch["name"].strip()
+        for key, value in patch.items():
+            setattr(campaign, key, value)
+        await self.db.flush()
+        await self.db.refresh(campaign)
+        gids = await self.repo.get_campaign_group_ids(campaign_id)
+        return self._with_computed(campaign, group_count=len(gids))
+
+    # ===============================================================
+    # Campaign ↔ group
+    # ===============================================================
+    async def _ensure_not_handed_off(self, campaign_id: int) -> None:
+        """Chặn MỌI sửa audience/nội dung sau khi đã bàn giao ≥1 batch — giữ
+        bất biến audit sau handoff (§232). build() reset-draft qua attach rồi
+        PATCH sẽ lách nếu chỉ gate ở build; gate cả attach/detach/update."""
+        if await self.repo.has_handed_off_recipients(campaign_id):
+            raise BusinessRuleViolation(
+                detail="Đã bàn giao ≥1 batch cho nhà mạng — KHÔNG sửa "
+                "nhóm/nội dung; tạo campaign mới."
+            )
+
+    async def _mark_audience_changed(self, campaign: SmsCampaign) -> None:
+        """Đổi nhóm sau khi ĐÃ build → snapshot recipient stale → reset
+        status='draft' (buộc build lại; export PR-4 chặn vì draft, build kế
+        tiếp tăng revision làm attestation cũ lệch). Fail-closed #3."""
+        if campaign.status != "draft":
+            campaign.status = "draft"
+            await self.db.flush()
+            # onupdate=func.now() expire updated_at → refresh trước serialize.
+            await self.db.refresh(campaign)
+
+    async def attach_group(
+        self, campaign_id: int, group_id: int
+    ) -> SmsCampaign:
+        # Lock campaign row (CÙNG lock với build) → serialize đổi audience vs
+        # build, tránh group chèn lọt khi build đang snapshot (#1 R2).
+        campaign = await self.repo.get_campaign_for_update(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        if campaign.status not in _REBUILDABLE:
+            raise BusinessRuleViolation(
+                detail="Campaign đã bàn giao/đóng — không đổi nhóm"
+            )
+        await self._ensure_not_handed_off(campaign_id)
+        grp = await self.contact_repo.get_group(group_id)
+        if grp is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy nhóm liên hệ")
+        if not grp.is_active:
+            raise BusinessRuleViolation(
+                detail="Nhóm đã ngừng hoạt động — không thể chọn cho campaign"
+            )
+        if await self.repo.get_campaign_group(campaign_id, group_id):
+            raise DuplicateResourceError(
+                detail="Nhóm đã được chọn cho campaign"
+            )
+        try:
+            await self.repo.create_campaign_group(campaign_id, group_id)
+        except IntegrityError:
+            raise DuplicateResourceError(
+                detail="Nhóm đã được chọn cho campaign"
+            )
+        await self._mark_audience_changed(campaign)
+        gids = await self.repo.get_campaign_group_ids(campaign_id)
+        return self._with_computed(campaign, group_count=len(gids))
+
+    async def detach_group(self, campaign_id: int, group_id: int) -> None:
+        # Lock campaign row (cùng lock build) — serialize đổi audience (#1 R2).
+        campaign = await self.repo.get_campaign_for_update(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        if campaign.status not in _REBUILDABLE:
+            raise BusinessRuleViolation(
+                detail="Campaign đã bàn giao/đóng — không đổi nhóm"
+            )
+        await self._ensure_not_handed_off(campaign_id)
+        cg = await self.repo.get_campaign_group(campaign_id, group_id)
+        if cg is None:
+            raise ResourceNotFoundError(
+                detail="Nhóm không thuộc campaign này"
+            )
+        await self.repo.delete_campaign_group(cg)
+        await self._mark_audience_changed(campaign)
+
+    # ===============================================================
+    # BUILD — snapshot revisioned + fail-closed + token + render
+    # ===============================================================
+    def _gen_token_triplet(
+        self, seen_hashes: set
+    ) -> Tuple[str, str, str]:
+        """Sinh (token_hash, ciphertext, key_version). Tránh trùng hash
+        trong cùng build (global trùng ~0 nhờ HMAC random; UNIQUE backstop)."""
+        for _ in range(8):
+            code = generate_short_code()
+            token_hash = compute_token_hash(code)
+            if token_hash in seen_hashes:
+                continue
+            ciphertext, key_version = encrypt_code(code)
+            seen_hashes.add(token_hash)
+            return token_hash, ciphertext, key_version
+        raise BusinessRuleViolation(detail="Không sinh được token duy nhất")
+
+    async def build(self, campaign_id: int, user) -> sms_schemas.SmsPreflightReport:
+        campaign = await self.repo.get_campaign_for_update(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        if campaign.status not in _REBUILDABLE:
+            raise BusinessRuleViolation(
+                detail="Campaign đã bàn giao/đóng — không build lại"
+            )
+        # Chặn rebuild sau PARTIAL handoff: campaign vẫn 'exported' nhưng đã
+        # bàn giao ≥1 batch → recipient cũ active SONG SONG revision mới (vì
+        # invalidate cố ý chừa dòng đã handoff) → trùng/lệch evidence (§232).
+        if await self.repo.has_handed_off_recipients(campaign_id):
+            raise BusinessRuleViolation(
+                detail="Đã bàn giao ≥1 batch cho nhà mạng — KHÔNG build lại; "
+                "tạo campaign mới để tránh trùng người nhận."
+            )
+        self._validate_content(
+            sms_template=campaign.sms_template,
+            landing_type=campaign.landing_type,
+            landing_url=campaign.landing_url,
+            landing_cta_url=campaign.landing_cta_url,
+            landing_cta_label=campaign.landing_cta_label,
+        )
+        group_ids = await self.repo.get_campaign_group_ids(campaign_id)
+        if not group_ids:
+            raise BusinessRuleViolation(
+                detail="Campaign chưa chọn nhóm nào để build"
+            )
+        # Re-check expiry lúc BUILD (schema chỉ validate create/update; campaign
+        # tạo với expiry tương lai có thể đã quá hạn khi build). Chặn TRƯỚC
+        # invalidate revision cũ / sinh token → không build link chết. R8 P2.
+        if has_link(campaign.sms_template) and campaign.link_expires_at and (
+            _aware(campaign.link_expires_at) <= datetime.now(timezone.utc)
+        ):
+            raise BusinessRuleViolation(
+                detail="link_expires_at đã hết hạn — cập nhật thời hạn link "
+                "trước khi build (tránh tạo link chết)."
+            )
+
+        new_revision = campaign.build_revision + 1
+        await self.repo.invalidate_recipients_before(campaign_id, new_revision)
+
+        # Gom member → dedupe theo phone, gom group_ids đóng góp.
+        members = await self.repo.get_members_of_groups(group_ids)
+        by_phone: dict = {}
+        for gid, contact in members:
+            entry = by_phone.setdefault(
+                contact.phone_normalized,
+                {"contact": contact, "groups": set()},
+            )
+            entry["groups"].add(gid)
+
+        if not by_phone:
+            raise BusinessRuleViolation(
+                detail="Các nhóm đã chọn không có liên hệ nào (hoặc nhóm đã "
+                "ngừng hoạt động) — không có người nhận để build."
+            )
+        phones = list(by_phone.keys())
+        optout_src = await self.repo.get_optout_source_map(phones)
+        carrier_map = await self.repo.get_active_carrier_prefix_map()
+
+        link = has_link(campaign.sms_template)
+        # --- Compliance fail-closed (NĐ91) ---
+        # [QC] LUÔN được chèn (assemble_skeleton); optout PHẢI cấu hình thật.
+        optout_instruction = (settings.SMS_OPTOUT_INSTRUCTION or "").strip()
+        if not optout_instruction:
+            raise BusinessRuleViolation(
+                detail="Chưa cấu hình hướng dẫn từ chối "
+                "(SMS_OPTOUT_INSTRUCTION) — bắt buộc footer từ chối NĐ91."
+            )
+        if settings.APP_ENV == "production" and (
+            optout_instruction == SMS_OPTOUT_INSTRUCTION_DEFAULT.strip()
+            or re.search(r"[xX]{3,}", optout_instruction)
+        ):
+            raise BusinessRuleViolation(
+                detail="SMS_OPTOUT_INSTRUCTION còn là placeholder (vd 'xxxx') — "
+                "production phải đặt kênh từ chối SMS/điện thoại thật."
+            )
+        # Footer ≤160 (khớp cột optout_instruction_snapshot String(160)) → bản
+        # ghi audit KHỚP đúng footer trong tin cuối, không cắt ngầm.
+        if len(optout_instruction) > 160:
+            raise BusinessRuleViolation(
+                detail="Hướng dẫn từ chối quá dài (>160 ký tự) — rút gọn để "
+                "khớp bản ghi audit và tiết kiệm segment."
+            )
+        # Token secret/keyring (prod) — chỉ cần khi có {link}.
+        if link:
+            ensure_token_secrets_configured()
+        freq_days = (
+            campaign.frequency_cap_days
+            if campaign.frequency_cap_days is not None
+            else settings.SMS_FREQUENCY_CAP_DAYS
+        )
+        now = datetime.now(timezone.utc)
+        seen_hashes: set = set()
+        rows: List[dict] = []
+
+        for phone, entry in by_phone.items():
+            contact = entry["contact"]
+            carrier = classify_carrier(phone, carrier_map)
+            # Fail-closed (ưu tiên consent > opt-out > frequency).
+            reason: Optional[str] = None
+            if contact.marketing_consent_status != "granted":
+                reason = "no_consent"
+            elif phone in optout_src:
+                # external_suppression = DNC list (đối tác); còn lại = opt-out
+                # do người dùng → excluded_reason phân biệt cho báo cáo/audit.
+                reason = (
+                    "dnc_suppressed"
+                    if optout_src[phone] == "external_suppression"
+                    else "opted_out"
+                )
+            elif (
+                freq_days > 0
+                and contact.last_handed_off_at is not None
+                and (now - _aware(contact.last_handed_off_at)).days
+                < freq_days
+            ):
+                reason = "frequency_capped"
+
+            skeleton = assemble_skeleton(
+                campaign.sms_template,
+                contact.full_name,
+                optout_instruction=optout_instruction,
+            )
+            encoding, length, segments, is_over = measure_skeleton(skeleton)
+            if reason is None and is_over:
+                reason = "over_limit"
+            # Defensive drop-broken-row (§18.D): tin cuối còn placeholder lạ
+            # hoặc sentinel-không-link → missing_data (trước khi sinh token).
+            if reason is None and skeleton_is_broken(skeleton, has_link=link):
+                reason = "missing_data"
+
+            token_hash = token_ciphertext = token_key_version = None
+            if link and reason is None:
+                token_hash, token_ciphertext, token_key_version = (
+                    self._gen_token_triplet(seen_hashes)
+                )
+
+            rows.append(
+                {
+                    "campaign_id": campaign_id,
+                    "build_revision": new_revision,
+                    "contact_id": contact.id,
+                    "group_ids_snapshot": sorted(entry["groups"]),
+                    "full_name_snapshot": contact.full_name,
+                    "phone_normalized_snapshot": phone,
+                    "phone_international_snapshot": contact.phone_international,
+                    "note_snapshot": contact.note,
+                    "carrier_bucket": carrier,
+                    "token_hash": token_hash,
+                    "token_ciphertext": token_ciphertext,
+                    "token_key_version": token_key_version,
+                    "rendered_message_skeleton": skeleton,
+                    "message_length": length,
+                    "encoding": encoding,
+                    "segments": segments,
+                    "is_over_limit": is_over,
+                    "excluded_reason": reason,
+                }
+            )
+
+        # Insert recipient + AUTO-RETRY token collision (committed HOẶC TOCTOU
+        # concurrent) tối đa N lần (§6.1 "retry N lần"): Core insert TRONG
+        # savepoint; IntegrityError (unique token_hash) → regenerate token có
+        # link + thử lại; hết N → 409. Core insert nên savepoint rollback
+        # sạch (không ORM instance lingering). #3 R4.
+        for _attempt in range(_TOKEN_RETRY):
+            try:
+                async with self.db.begin_nested():
+                    await self.repo.bulk_insert_recipients(rows)
+                break
+            except IntegrityError as exc:
+                # CHỈ retry khi đụng UNIQUE token_hash; lỗi khác (FK / check /
+                # phone-rev UNIQUE) KHÔNG phải collision → re-raise ngay.
+                if "uq_sms_recipient_token_hash" not in str(
+                    getattr(exc, "orig", exc)
+                ):
+                    raise
+                for r in rows:
+                    if r["token_hash"]:
+                        th, ct, kv = self._gen_token_triplet(seen_hashes)
+                        r["token_hash"] = th
+                        r["token_ciphertext"] = ct
+                        r["token_key_version"] = kv
+        else:
+            raise ConflictError(
+                detail="Token collision không giải được sau retry — build lại."
+            )
+
+        campaign.build_revision = new_revision
+        campaign.status = "ready"
+        # Lưu ĐỦ footer (đã chặn >160 ở trên) → snapshot khớp tin cuối, audit
+        # không bị cắt ngầm (P2-2 R7).
+        campaign.optout_instruction_snapshot = optout_instruction or None
+        await self.db.flush()
+        return await self.preflight(campaign_id)
+
+    # ===============================================================
+    # Preflight report
+    # ===============================================================
+    async def preflight(
+        self, campaign_id: int
+    ) -> sms_schemas.SmsPreflightReport:
+        campaign = await self.repo.get_campaign(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        rev = campaign.build_revision
+        link = has_link(campaign.sms_template)
+
+        reason_counts = await self.repo.counts_by_excluded_reason(
+            campaign_id, rev
+        )
+        total = sum(c for _, c in reason_counts)
+        exportable = sum(c for r, c in reason_counts if r is None)
+        excluded_by_reason = {
+            r: c for r, c in reason_counts if r is not None
+        }
+        carrier_dist = await self.repo.counts_by_carrier_exportable(
+            campaign_id, rev
+        )
+        over_rows = await self.repo.get_over_limit_rows(campaign_id, rev)
+        over_limit = [
+            sms_schemas.SmsOverLimitRow(
+                phone_normalized=r.phone_normalized_snapshot,
+                full_name=r.full_name_snapshot,
+                encoding=r.encoding,
+                length=r.message_length,
+                segments=r.segments,
+            )
+            for r in over_rows
+        ]
+
+        warnings: List[str] = []
+        if rev == 0:
+            warnings.append("Chưa build — preflight trống.")
+        if not link:
+            warnings.append(
+                "Template không có {link} → campaign này KHÔNG đo được click."
+            )
+        n_over = excluded_by_reason.get("over_limit", 0)
+        if n_over:
+            warnings.append(
+                f"{n_over} recipient vượt 1 segment — EXPORT sẽ bị CHẶN cho "
+                "tới khi rút gọn template/dữ liệu."
+            )
+        if n_over > len(over_limit):
+            warnings.append(
+                f"Danh sách over_limit chỉ hiển thị {len(over_limit)}/{n_over} "
+                "(đã cắt) — sắp theo id."
+            )
+
+        # Stale: đã build (rev>0) nhưng đổi nhóm/nội dung sau đó (status=draft)
+        # → số liệu & skeleton thuộc revision CŨ → báo rõ + KHÔNG show preview
+        # cũ (tránh preview còn link khi has_link hiện tại đã =false). P2-1 R7.
+        stale = campaign.status == "draft" and rev > 0
+        if stale:
+            warnings.append(
+                "⚠ Có thay đổi nhóm/nội dung CHƯA build — số liệu & preview "
+                f"thuộc revision {rev} CŨ; bấm Build lại để cập nhật."
+            )
+
+        # Preview ≤5 dòng tin cuối từ recipient exportable thực (§D6).
+        if stale:
+            preview: List[str] = []
+        else:
+            sample_skeletons = await self.repo.get_sample_skeletons(
+                campaign_id, rev
+            )
+            preview = [preview_message(s) for s in sample_skeletons]
+
+        return sms_schemas.SmsPreflightReport(
+            campaign_id=campaign_id,
+            build_revision=rev,
+            status=campaign.status,
+            has_link=link,
+            total=total,
+            exportable=exportable,
+            excluded_by_reason=excluded_by_reason,
+            carrier_distribution=carrier_dist,
+            over_limit=over_limit,
+            warnings=warnings,
+            preview=preview,
+        )
+
+    # ===============================================================
+    # Attestations (khớp build_revision hiện tại)
+    # ===============================================================
+    async def add_attestation(
+        self, campaign_id: int, data: sms_schemas.SmsAttestationCreate, user
+    ) -> SmsCampaign:
+        campaign = await self.repo.get_campaign_for_update(campaign_id)
+        if campaign is None:
+            raise ResourceNotFoundError(detail="Không tìm thấy campaign")
+        # CHỈ attest khi 'ready' (đã build, CHƯA export/bàn giao). Sau export
+        # evidence đã đóng băng cho file đã sinh — cho sửa reference/actor/ts sẽ
+        # khiến attestation lệch bằng chứng thực dùng; muốn đổi phải build lại.
+        if campaign.status != "ready":
+            raise BusinessRuleViolation(
+                detail="Chỉ attest khi campaign ở trạng thái 'ready' (đã build, "
+                "chưa export/bàn giao) — sau export evidence bị đóng băng."
+            )
+        now = datetime.now(timezone.utc)
+        rev = campaign.build_revision
+        uid = getattr(user, "id", None)
+        if data.kind == "consent":
+            campaign.consent_checked_at = now
+            campaign.consent_checked_by_id = uid
+            campaign.consent_reference = data.reference
+            campaign.consent_checked_build_revision = rev
+        elif data.kind == "dnc":
+            campaign.dnc_checked_at = now
+            campaign.dnc_checked_by_id = uid
+            campaign.dnc_reference = data.reference
+            campaign.dnc_checked_build_revision = rev
+        else:  # optout_channel
+            campaign.optout_channel_checked_at = now
+            campaign.optout_channel_checked_by_id = uid
+            campaign.optout_channel_reference = data.reference
+            campaign.optout_channel_checked_build_revision = rev
+        await self.db.flush()
+        await self.db.refresh(campaign)
+        gids = await self.repo.get_campaign_group_ids(campaign_id)
+        return self._with_computed(campaign, group_count=len(gids))

--- a/Backend_FastAPI/app/utils/sms_render.py
+++ b/Backend_FastAPI/app/utils/sms_render.py
@@ -1,0 +1,167 @@
+# app/utils/sms_render.py
+"""
+SMS render + preflight (PR-3): biến template, lắp TIN CUỐI ([QC]+body+optout
++link sentinel), smart-encoding, đo độ dài GSM7/UCS2 + segments, phân loại
+nhà mạng theo prefix. Xem SMS_MARKETING_MODULE_DESIGN.md §7.
+
+Đo trên TIN CUỐI (gồm [QC]+optout, sentinel link thay bằng chuỗi cùng độ dài
+URL thực) — không đo body trần.
+"""
+import math
+import re
+from typing import Dict, List, Set, Tuple
+
+from app.utils.sms_token import (
+    CODE_LENGTH,
+    LINK_SENTINEL,
+    build_link,
+    link_placeholder_length,
+)
+
+# --- Whitelist biến template (chỉ field cấp contact). Thứ tự strip:
+# full_name TRƯỚC name (tránh sót). ---
+ALLOWED_TEMPLATE_VARS = ("full_name", "name", "link")
+_BRACE_RE = re.compile(r"\{[^{}]*\}")
+# Render: chỉ thay đúng 3 token whitelist, 1 lượt (re.sub không re-scan).
+_RENDER_RE = re.compile(r"\{(full_name|name|link)\}")
+# Tên fallback bắt buộc (§D6) khi tên rỗng/chỉ-sentinel sau sanitize.
+NAME_FALLBACK = "Quý phụ huynh/học sinh"
+
+# --- GSM 03.38 basic + extension (ext đếm = 2). Tiếng Việt có dấu → UCS2. ---
+_GSM7_BASIC = frozenset(
+    "@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ "
+    "!\"#¤%&'()*+,-./0123456789:;<=>?"
+    "¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿"
+    "abcdefghijklmnopqrstuvwxyzäöñüà"
+)
+_GSM7_EXT = frozenset("^{}\\[~]|€\f")
+
+# --- Smart-encoding: ký tự "thông minh" → tương đương GSM7 (miễn phí) ---
+_SMART_SUBS = {
+    "‘": "'", "’": "'", "‚": "'", "‛": "'",
+    "“": '"', "”": '"', "„": '"',
+    "–": "-", "—": "-", "―": "-",
+    "…": "...", " ": " ", " ": " ",
+}
+
+
+def find_unknown_vars(template: str) -> Set[str]:
+    """Tập token `{...}` KHÔNG hợp lệ (rỗng = OK). FAIL-CLOSED: bắt mọi
+    `{...}` lạ/dị dạng (`{foo-1}`, `{name!r}`, `{{name}}`, ngoặc lẻ) — sau
+    khi gỡ 3 token whitelist, còn bất kỳ `{`/`}` nào đều bị từ chối."""
+    stripped = template or ""
+    for v in ALLOWED_TEMPLATE_VARS:
+        stripped = stripped.replace("{" + v + "}", "")
+    if "{" in stripped or "}" in stripped:
+        return set(_BRACE_RE.findall(stripped)) or {"{ hoặc } lạ"}
+    return set()
+
+
+def has_link(template: str) -> bool:
+    return "{link}" in (template or "")
+
+
+def smart_encode(text: str) -> str:
+    """Thay ký tự smart-quote/dash/NBSP bằng tương đương ASCII (giữ nghĩa)."""
+    return "".join(_SMART_SUBS.get(c, c) for c in (text or ""))
+
+
+def render_body(
+    template: str, full_name: str, *, name_fallback: str = NAME_FALLBACK
+) -> str:
+    """Thay biến đúng 1 lượt (re.sub, KHÔNG re-scan nội dung đã thay):
+    {full_name}/{name}→full_name; {link}→sentinel.
+
+    Fail-closed: GỠ literal `__SMS_LINK__` khỏi DỮ LIỆU (template + tên)
+    TRƯỚC substitution → sentinel duy nhất trong output là cái CỐ Ý đặt cho
+    {link} (chống inject sentinel qua template/tên contact). Tên chứa
+    '{link}'/'{name}' cũng KHÔNG bị biến thành sentinel/đệ quy. Tên rỗng
+    (sau gỡ sentinel + strip) → dùng name_fallback (tránh tin tên rỗng)."""
+    cleaned = (full_name or "").replace(LINK_SENTINEL, "").strip()
+    name = cleaned or name_fallback
+    safe_template = (template or "").replace(LINK_SENTINEL, "")
+
+    def _repl(m: "re.Match") -> str:
+        return LINK_SENTINEL if m.group(1) == "link" else name
+
+    return _RENDER_RE.sub(_repl, safe_template)
+
+
+def assemble_skeleton(
+    template: str,
+    full_name: str,
+    *,
+    optout_instruction: str,
+) -> str:
+    """TIN CUỐI dạng skeleton: **[QC] luôn có** (advertising NĐ91 Đ15) +
+    body(render, smart-encoded) + optout. Link vẫn là sentinel (KHÔNG raw
+    code). optout_instruction được build đảm bảo non-rỗng trước khi gọi."""
+    body = smart_encode(render_body(template, full_name))
+    parts: List[str] = ["[QC]"]
+    if body:
+        parts.append(body)
+    if optout_instruction and optout_instruction.strip():
+        # Footer cũng gỡ sentinel (org có thể vô tình đưa __SMS_LINK__ vào).
+        footer = smart_encode(optout_instruction.strip()).replace(
+            LINK_SENTINEL, ""
+        )
+        if footer:
+            parts.append(footer)
+    return " ".join(parts)
+
+
+def measure(msg: str) -> Tuple[str, int, int, bool]:
+    """Trả (encoding, length, segments, is_over_limit). §7.2."""
+    msg = msg or ""
+    if all((c in _GSM7_BASIC) or (c in _GSM7_EXT) for c in msg):
+        encoding = "GSM7"
+        n = len(msg) + sum(1 for c in msg if c in _GSM7_EXT)
+        per_single, per_multi = 160, 153
+    else:
+        encoding = "UCS2"
+        # UCS-2/UTF-16: ký tự non-BMP (emoji, ord>0xFFFF) = 2 code units.
+        n = sum(2 if ord(c) > 0xFFFF else 1 for c in msg)
+        per_single, per_multi = 70, 67
+    segments = 1 if n <= per_single else math.ceil(n / per_multi)
+    return encoding, n, segments, segments > 1
+
+
+def measure_skeleton(skeleton: str) -> Tuple[str, int, int, bool]:
+    """Đo skeleton: thay sentinel bằng chuỗi cùng độ dài URL link thực rồi đo.
+    Link là base62 ASCII nên không đổi encoding, chỉ cộng độ dài cố định."""
+    final = (skeleton or "").replace(
+        LINK_SENTINEL, "X" * link_placeholder_length()
+    )
+    return measure(final)
+
+
+def classify_carrier(
+    phone_normalized: str, prefix_map: Dict[str, str]
+) -> str:
+    """Bucket nhà mạng theo 3 ký tự đầu (gồm số 0). Không khớp → 'unknown'.
+    CHỈ để khớp format upload (MNP — xem docstring model §4.5)."""
+    if not phone_normalized or len(phone_normalized) < 3:
+        return "unknown"
+    return prefix_map.get(phone_normalized[:3], "unknown")
+
+
+def skeleton_is_broken(skeleton: str, *, has_link: bool) -> bool:
+    """Tin cuối 'hỏng' → loại row (excluded_reason='missing_data', §D6
+    "rendered KHÔNG còn placeholder sót"):
+    (1) còn BẤT KỲ `{` hoặc `}` nào — kể cả ngoặc LẺ `{foo`/`foo}` (tên/footer
+    dị dạng) lẫn `{foo}` cân bằng, hoặc biến render chưa thay; HOẶC (2) còn
+    sentinel mà campaign KHÔNG có {link} (sentinel lạ → export không thay được)."""
+    sk = skeleton or ""
+    if "{" in sk or "}" in sk:
+        return True
+    if LINK_SENTINEL in sk and not has_link:
+        return True
+    return False
+
+
+def preview_message(skeleton: str) -> str:
+    """Bản XEM TRƯỚC cho admin (§D6 "5 dòng mẫu"): thay sentinel link bằng URL
+    mẫu (đúng host + đúng độ dài code thực) để thấy ~tin cuối. KHÔNG phải tin
+    gửi thật — code thật chỉ sinh lúc export (PR-4)."""
+    sample = build_link("x" * CODE_LENGTH)
+    return (skeleton or "").replace(LINK_SENTINEL, sample)

--- a/Backend_FastAPI/app/utils/sms_token.py
+++ b/Backend_FastAPI/app/utils/sms_token.py
@@ -1,0 +1,188 @@
+# app/utils/sms_token.py
+"""
+SMS short-link token (PR-3): base62×9 bearer code + HMAC hash (lookup) +
+Fernet ciphertext (re-export). KHÔNG bao giờ lưu/log raw code — chỉ trả về
+trong memory lúc build/export. Xem SMS_MARKETING_MODULE_DESIGN.md §6.
+
+Key lifecycle: prod BẮT BUỘC cấu hình `SMS_TOKEN_ENCRYPTION_KEYS` (JSON
+keyring) + `SMS_TOKEN_ACTIVE_KEY_VERSION`; thiếu → raise tại thời điểm build
+(lazy, KHÔNG fail-fast startup để không gãy prod khi SMS chưa dùng). Dev/test
+dẫn xuất 1 key ổn định từ hash secret → chạy được không cần env.
+"""
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+from typing import Dict, Optional, Tuple
+from urllib.parse import urlparse
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from app.config import settings
+
+# Sentinel cố định cho {link} trong rendered_message_skeleton (KHÔNG raw code).
+LINK_SENTINEL = "__SMS_LINK__"
+
+_BASE62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+CODE_LENGTH = 9
+
+# Default công khai — prod KHÔNG được dùng (token_hash sẽ đoán được).
+_DEV_HASH_DEFAULT = "dev-sms-token-hash-secret-change-in-prod"
+_DEV_IP_HASH_DEFAULT = "dev-sms-ip-hash-secret-change-in-prod"
+
+
+def generate_short_code() -> str:
+    """Sinh bearer code base62×9 (~54 bit) bằng secrets (CSPRNG)."""
+    return "".join(secrets.choice(_BASE62) for _ in range(CODE_LENGTH))
+
+
+def compute_token_hash(code: str) -> str:
+    """HMAC-SHA256(code, SMS_TOKEN_HASH_SECRET) → hex 64 ký tự [0-9a-f]
+    (khớp CHECK `chk_sms_recipient_token_triplet`). Dùng để lookup /r/{code}."""
+    secret = settings.SMS_TOKEN_HASH_SECRET.encode()
+    return hmac.new(secret, code.encode(), hashlib.sha256).hexdigest()
+
+
+def _load_keyring() -> Tuple[Dict[str, str], str]:
+    """Trả (keyring {version: fernet_key}, active_version).
+
+    Prod: bắt buộc cấu hình thật (raise nếu thiếu/sai — lazy). Dev/test:
+    dẫn xuất 1 Fernet key ổn định từ hash secret nếu chưa cấu hình.
+    """
+    raw = (settings.SMS_TOKEN_ENCRYPTION_KEYS or "").strip()
+    active = (settings.SMS_TOKEN_ACTIVE_KEY_VERSION or "").strip()
+    if raw:
+        try:
+            keyring = json.loads(raw)
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(
+                "SMS_TOKEN_ENCRYPTION_KEYS không phải JSON hợp lệ"
+            ) from exc
+        if not isinstance(keyring, dict) or not keyring:
+            raise RuntimeError(
+                "SMS_TOKEN_ENCRYPTION_KEYS phải là object {version: key}"
+            )
+        if not active:
+            raise RuntimeError("SMS_TOKEN_ACTIVE_KEY_VERSION chưa được set")
+        if active not in keyring:
+            raise RuntimeError(
+                f"SMS_TOKEN_ACTIVE_KEY_VERSION '{active}' không có trong keyring"
+            )
+        return keyring, active
+
+    if settings.APP_ENV == "production":
+        raise RuntimeError(
+            "SMS token encryption chưa cấu hình (SMS_TOKEN_ENCRYPTION_KEYS + "
+            "SMS_TOKEN_ACTIVE_KEY_VERSION) — bắt buộc trong production để build "
+            "campaign có {link}."
+        )
+    # Dev/test: 1 Fernet key ổn định (32 byte → urlsafe-b64) từ hash secret.
+    derived = base64.urlsafe_b64encode(
+        hashlib.sha256(
+            ("sms-dev-fernet::" + settings.SMS_TOKEN_HASH_SECRET).encode()
+        ).digest()
+    ).decode()
+    return {"dev": derived}, "dev"
+
+
+def ensure_token_secrets_configured() -> None:
+    """Lazy gate gọi lúc BUILD campaign có {link}. Prod BẮT BUỘC:
+    `SMS_TOKEN_HASH_SECRET` thật (≠ default công khai, ≥32 ký tự) + Fernet
+    keyring hợp lệ. KHÔNG fail-fast startup (tránh gãy prod chưa dùng SMS)."""
+    if settings.APP_ENV == "production":
+        secret = settings.SMS_TOKEN_HASH_SECRET or ""
+        if secret == _DEV_HASH_DEFAULT or len(secret) < 32:
+            raise RuntimeError(
+                "SMS_TOKEN_HASH_SECRET chưa cấu hình mạnh (≥32 ký tự, KHÔNG "
+                "dùng default công khai) — bắt buộc trong production để build "
+                "campaign có {link}."
+            )
+        # IP-hash secret (PR-5 click) — link campaign SẼ bị click → fail-closed.
+        ip_secret = settings.SMS_IP_HASH_SECRET or ""
+        if ip_secret == _DEV_IP_HASH_DEFAULT or len(ip_secret) < 32:
+            raise RuntimeError(
+                "SMS_IP_HASH_SECRET chưa cấu hình mạnh (≥32 ký tự, KHÔNG dùng "
+                "default công khai) — bắt buộc trong production (hash IP click)."
+            )
+        # Bearer link base: phải https + host thuộc allowlist (chống link trỏ
+        # domain lạ xuất hiện trong tin/preview).
+        parsed = urlparse((settings.SMS_PUBLIC_BASE_URL or "").strip())
+        host = (parsed.hostname or "").lower()
+        allowed = [
+            d.strip().lower()
+            for d in settings.SMS_ALLOWED_REDIRECT_DOMAINS.split(",")
+            if d.strip()
+        ]
+        if (
+            parsed.scheme != "https"
+            or not host
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+            or not any(host == d or host.endswith("." + d) for d in allowed)
+        ):
+            raise RuntimeError(
+                "SMS_PUBLIC_BASE_URL phải https + host thuộc "
+                "SMS_ALLOWED_REDIRECT_DOMAINS, KHÔNG userinfo/query/fragment "
+                "(tránh URL link sai như https://host?x=1/r/code) trong "
+                "production."
+            )
+    # _load_keyring raise nếu keyring thiếu/JSON sai (prod). Thêm: KHỞI TẠO
+    # Fernet cho MỌI key → bắt key sai định dạng (32 url-safe base64) ngay
+    # tại gate, thay vì văng giữa build lúc encrypt. #4 R3.
+    keyring, _active = _load_keyring()
+    for ver, key in keyring.items():
+        # Version lưu vào cột token_key_version VARCHAR(32) — dài hơn → 500
+        # StringDataRightTruncation lúc insert recipient. Chặn tại gate. #3 R5.
+        if len(ver) > 32:
+            raise RuntimeError(
+                f"SMS_TOKEN version '{ver[:12]}…' quá dài (≤32 ký tự — khớp "
+                "cột token_key_version VARCHAR(32))."
+            )
+        # key phải là CHUỖI (JSON có thể là số/obj → .encode() AttributeError).
+        if not isinstance(key, str):
+            raise RuntimeError(
+                f"SMS_TOKEN_ENCRYPTION_KEYS['{ver}'] phải là chuỗi Fernet key."
+            )
+        try:
+            Fernet(key.encode())
+        except (ValueError, TypeError) as exc:
+            raise RuntimeError(
+                f"SMS_TOKEN_ENCRYPTION_KEYS['{ver}'] không phải Fernet key "
+                "hợp lệ (32 url-safe base64 bytes)."
+            ) from exc
+
+
+def encrypt_code(code: str) -> Tuple[str, str]:
+    """Trả (ciphertext, key_version). Fernet active key trong keyring."""
+    keyring, active = _load_keyring()
+    cipher = Fernet(keyring[active].encode())
+    return cipher.encrypt(code.encode()).decode(), active
+
+
+def decrypt_code(ciphertext: str, key_version: str) -> Optional[str]:
+    """Giải mã code (re-export PR-4). None nếu version/key sai hoặc hỏng."""
+    keyring, _ = _load_keyring()
+    key = keyring.get(key_version)
+    # key có thể không phải chuỗi (keyring JSON dạng số) → .encode() sẽ
+    # AttributeError. Trả None theo contract thay vì 500 lúc export.
+    if not key or not isinstance(key, str):
+        return None
+    try:
+        return Fernet(key.encode()).decrypt(ciphertext.encode()).decode()
+    except (InvalidToken, ValueError, TypeError):
+        return None
+
+
+def build_link(code: str) -> str:
+    """URL public của bearer link: {SMS_PUBLIC_BASE_URL}/r/{code}."""
+    base = settings.SMS_PUBLIC_BASE_URL.rstrip("/")
+    return f"{base}/r/{code}"
+
+
+def link_placeholder_length() -> int:
+    """Độ dài URL link (cố định vì code base62×9) — để preflight đo TIN CUỐI
+    bằng cách thay sentinel bằng chuỗi cùng độ dài."""
+    return len(build_link("X" * CODE_LENGTH))

--- a/Backend_FastAPI/tests/integration/test_sms_campaign_build.py
+++ b/Backend_FastAPI/tests/integration/test_sms_campaign_build.py
@@ -1,0 +1,1153 @@
+# tests/integration/test_sms_campaign_build.py
+"""
+Integration test PR-3 (SMS Campaign Build BE).
+
+Phủ: campaign CRUD + validation (biến lạ, external+{link}, allowlist host,
+update-non-draft), group attach/detach, BUILD (dedupe snapshot + fail-closed
+consent/opt-out filter + token triplet khi {link} + [QC]/optout trong
+skeleton + over_limit gate + rebuild invalidate revision cũ), preflight,
+attestation khớp build_revision.
+
+Build nội bộ (token/skeleton/excluded_reason) verify trực tiếp qua SQL
+(chưa expose recipient API tới PR-4). Chạy one-off container (CLAUDE.md).
+"""
+import re
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.database import AsyncSessionLocal
+
+API = "/api/sms"
+_GRANT = {
+    "event_type": "granted",
+    "occurred_at": "2026-05-01T00:00:00+07:00",
+    "basis": "signed_form",
+    "disclosure_version": "v1",
+    "proof_reference": "ho-so/ref",
+}
+
+
+# ---------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------
+async def _mk_group(client, h, name):
+    res = await client.post(
+        f"{API}/contact-groups",
+        json={"name": name, "group_type": "custom"},
+        headers=h,
+    )
+    assert res.status_code == 201, res.text
+    return res.json()["id"]
+
+
+async def _mk_contact(client, h, name, phone, granted=True):
+    res = await client.post(
+        f"{API}/contacts",
+        json={"full_name": name, "phone": phone},
+        headers=h,
+    )
+    assert res.status_code == 201, res.text
+    cid = res.json()["id"]
+    if granted:
+        r = await client.post(
+            f"{API}/contacts/{cid}/consent-events", json=_GRANT, headers=h
+        )
+        assert r.status_code == 201, r.text
+    return cid
+
+
+async def _add_to_group(client, h, cid, gid):
+    res = await client.post(
+        f"{API}/contacts/{cid}/groups", json={"group_id": gid}, headers=h
+    )
+    assert res.status_code == 201, res.text
+
+
+async def _mk_campaign(client, h, template, **kw):
+    body = {"name": kw.pop("name", "Chien dich QA"), "sms_template": template}
+    body.update(kw)
+    return await client.post(f"{API}/campaigns", json=body, headers=h)
+
+
+async def _recipients(campaign_id):
+    async with AsyncSessionLocal() as s:
+        res = await s.execute(
+            text(
+                "SELECT phone_normalized_snapshot AS phone, excluded_reason, "
+                "token_hash, token_ciphertext, rendered_message_skeleton AS sk, "
+                "group_ids_snapshot AS gids, build_revision AS rev, "
+                "invalidated_at, is_over_limit, encoding "
+                "FROM sms_campaign_recipient WHERE campaign_id=:c "
+                "ORDER BY phone_normalized_snapshot, build_revision"
+            ),
+            {"c": campaign_id},
+        )
+        return [dict(r) for r in res.mappings().all()]
+
+
+# ---------------------------------------------------------------------
+# Campaign CRUD + validation
+# ---------------------------------------------------------------------
+async def test_campaign_crud_and_validation(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    # create + auto-slug
+    res = await _mk_campaign(client, h, "Chao {name}, xem {link}",
+                             name="Tuyen Sinh 2026")
+    assert res.status_code == 201, res.text
+    body = res.json()
+    assert body["code"] == "tuyen-sinh-2026"
+    assert body["has_link"] is True
+    assert body["status"] == "draft"
+    cid = body["id"]
+
+    # get + list
+    assert (await client.get(f"{API}/campaigns/{cid}", headers=h)).status_code == 200
+    assert (await client.get(f"{API}/campaigns", headers=h)).json()["total"] >= 1
+
+    # update draft OK
+    res = await client.patch(
+        f"{API}/campaigns/{cid}",
+        json={"sms_template": "Xin chao {full_name}"},
+        headers=h,
+    )
+    assert res.status_code == 200
+    assert res.json()["has_link"] is False  # bỏ {link}
+
+    # biến template lạ → 400
+    res = await _mk_campaign(client, h, "Hi {foo}", name="X1")
+    assert res.status_code == 400
+
+    # external + thiếu {link} → 400
+    res = await _mk_campaign(
+        client, h, "Khong co link", name="X2",
+        landing_type="external",
+        landing_url="https://qlts.tnpc.edu.vn/landing",
+    )
+    assert res.status_code == 400
+
+    # external host ngoài allowlist → 400
+    res = await _mk_campaign(
+        client, h, "Bam {link}", name="X3",
+        landing_type="external", landing_url="https://evil.com/x",
+    )
+    assert res.status_code == 400
+
+    # external hợp lệ (host allowlist + {link}) → 201
+    res = await _mk_campaign(
+        client, h, "Bam {link}", name="X4",
+        landing_type="external",
+        landing_url="https://qlts.tnpc.edu.vn/landing",
+    )
+    assert res.status_code == 201, res.text
+
+
+# ---------------------------------------------------------------------
+# Group attach/detach
+# ---------------------------------------------------------------------
+async def test_campaign_group_attach_detach(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    gid = await _mk_group(client, h, "Nhom QA G")
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="CG")).json()["id"]
+
+    res = await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": gid}, headers=h
+    )
+    assert res.status_code == 201
+    assert res.json()["group_count"] == 1
+
+    # trùng → 409
+    res = await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": gid}, headers=h
+    )
+    assert res.status_code == 409
+
+    # detach
+    res = await client.delete(
+        f"{API}/campaigns/{cid}/groups/{gid}", headers=h
+    )
+    assert res.status_code == 204
+    # detach lại → 404
+    res = await client.delete(
+        f"{API}/campaigns/{cid}/groups/{gid}", headers=h
+    )
+    assert res.status_code == 404
+
+
+# ---------------------------------------------------------------------
+# BUILD — dedupe + snapshot + fail-closed + token + skeleton
+# ---------------------------------------------------------------------
+async def test_build_dedupe_failclosed_token(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g1 = await _mk_group(client, h, "Nhom 1")
+    g2 = await _mk_group(client, h, "Nhom 2")
+
+    # granted, chỉ G1
+    c1 = await _mk_contact(client, h, "Nguyen A", "0901000001", granted=True)
+    await _add_to_group(client, h, c1, g1)
+    # unknown (chưa consent), G1 → bị loại no_consent
+    c2 = await _mk_contact(client, h, "Tran B", "0901000002", granted=False)
+    await _add_to_group(client, h, c2, g1)
+    # granted, ở CẢ G1 + G2 → dedupe 1 recipient, group_ids gồm cả 2
+    c3 = await _mk_contact(client, h, "Le C", "0901000003", granted=True)
+    await _add_to_group(client, h, c3, g1)
+    await _add_to_group(client, h, c3, g2)
+    # granted nhưng opt-out toàn cục → bị loại opted_out
+    c4 = await _mk_contact(client, h, "Pham D", "0901000004", granted=True)
+    await _add_to_group(client, h, c4, g1)
+    async with AsyncSessionLocal() as s:
+        await s.execute(text(
+            "INSERT INTO sms_opt_out (phone_normalized, source, observed_at) "
+            "VALUES ('0901000004','manual', now())"))
+        await s.commit()
+
+    cid = (
+        await _mk_campaign(client, h, "Chao {name}, xem {link}", name="Build1")
+    ).json()["id"]
+    for g in (g1, g2):
+        await client.post(
+            f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+        )
+
+    res = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert res.status_code == 200, res.text
+    rep = res.json()
+    assert rep["build_revision"] == 1
+    assert rep["status"] == "ready"
+    assert rep["has_link"] is True
+    assert rep["total"] == 4          # 4 phone unique (dedupe c3)
+    assert rep["exportable"] == 2     # c1, c3
+    assert rep["excluded_by_reason"].get("no_consent") == 1
+    assert rep["excluded_by_reason"].get("opted_out") == 1
+
+    rows = {r["phone"]: r for r in await _recipients(cid)}
+    # c1 granted → exportable + token hex 64 + skeleton có [QC] + optout
+    r1 = rows["0901000001"]
+    assert r1["excluded_reason"] is None
+    assert re.fullmatch(r"[0-9a-f]{64}", r1["token_hash"])
+    assert r1["token_ciphertext"]
+    assert r1["sk"].startswith("[QC]")
+    assert "huy" in r1["sk"].lower() or "tu choi" in r1["sk"].lower()
+    assert "__SMS_LINK__" in r1["sk"]   # sentinel, KHÔNG raw code
+    # c2 unknown → no_consent + KHÔNG token
+    r2 = rows["0901000002"]
+    assert r2["excluded_reason"] == "no_consent"
+    assert r2["token_hash"] is None
+    # c3 dedupe: group_ids gồm cả g1,g2
+    r3 = rows["0901000003"]
+    assert r3["excluded_reason"] is None
+    assert set(r3["gids"]) == {g1, g2}
+    # c4 opt-out
+    assert rows["0901000004"]["excluded_reason"] == "opted_out"
+
+
+# ---------------------------------------------------------------------
+# BUILD — over_limit gate + no-{link}
+# ---------------------------------------------------------------------
+async def test_build_over_limit_and_no_link(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom OL")
+    c = await _mk_contact(client, h, "Nguyen Dai", "0902000001", granted=True)
+    await _add_to_group(client, h, c, g)
+
+    # template dài (ASCII 200) → tin cuối > 160 GSM7 → over_limit
+    long_tpl = "X" * 200
+    cid = (await _mk_campaign(client, h, long_tpl, name="OverLimit")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    res = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert res.status_code == 200, res.text
+    rep = res.json()
+    assert rep["has_link"] is False
+    assert rep["exportable"] == 0
+    assert rep["excluded_by_reason"].get("over_limit") == 1
+    assert len(rep["over_limit"]) == 1
+    assert rep["over_limit"][0]["segments"] >= 2
+    assert any("EXPORT" in w for w in rep["warnings"])
+    assert any("{link}" in w for w in rep["warnings"])
+
+    rows = await _recipients(cid)
+    assert rows[0]["is_over_limit"] is True
+    assert rows[0]["token_hash"] is None  # no {link} → no token
+
+
+# ---------------------------------------------------------------------
+# Rebuild invalidate revision cũ + attestation khớp revision
+# ---------------------------------------------------------------------
+async def test_rebuild_invalidate_and_attestation(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom RB")
+    c = await _mk_contact(client, h, "Nguyen E", "0903000001", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="Rebuild")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+
+    # build 1
+    r1 = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert r1.json()["build_revision"] == 1
+    # attestation khớp rev 1
+    res = await client.post(
+        f"{API}/campaigns/{cid}/attestations",
+        json={"kind": "consent", "reference": "bao-cao-kiem-consent"},
+        headers=h,
+    )
+    assert res.status_code == 201
+    assert res.json()["consent_checked_build_revision"] == 1
+
+    # build 2 (rebuild) → revision 2; recipient rev 1 bị invalidate
+    r2 = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert r2.json()["build_revision"] == 2
+
+    rows = await _recipients(cid)
+    by_rev = {r["rev"]: r for r in rows}
+    assert by_rev[1]["invalidated_at"] is not None   # rev cũ vô hiệu
+    assert by_rev[2]["invalidated_at"] is None        # rev mới hợp lệ
+
+    # attestation rev 1 giờ KHÔNG khớp build_revision=2 (gate export PR-4)
+    detail = (await client.get(f"{API}/campaigns/{cid}", headers=h)).json()
+    assert detail["build_revision"] == 2
+    assert detail["consent_checked_build_revision"] == 1  # stale → gate sẽ chặn
+
+    # update campaign khi status=ready → 400 (chỉ draft)
+    res = await client.patch(
+        f"{API}/campaigns/{cid}", json={"name": "doi ten"}, headers=h
+    )
+    assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R1 #1 — compliance fail-closed: optout rỗng → build 400
+# ---------------------------------------------------------------------
+async def test_build_requires_optout(
+    client: AsyncClient, admin_token_headers: dict, monkeypatch
+):
+    from app.config import settings as cfg
+    monkeypatch.setattr(cfg, "SMS_OPTOUT_INSTRUCTION", "   ")  # rỗng sau strip
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom Optout")
+    c = await _mk_contact(client, h, "A", "0908100001", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="OptoutReq")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    res = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R1 #2 — template/render fail-closed
+# ---------------------------------------------------------------------
+async def test_template_strict_validation(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    for i, tpl in enumerate(
+        ["Hi {foo-1}", "Hi {{name}}", "Hi {name!r}", "Hi {}", "Hi {name"]
+    ):
+        res = await _mk_campaign(client, h, tpl, name=f"BadTpl{i}")
+        assert res.status_code == 400, f"{tpl!r} → {res.status_code}"
+
+
+async def test_name_equals_link_no_sentinel(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom Inject")
+    # tên contact = "{link}" nhưng template KHÔNG có {link}
+    c = await _mk_contact(client, h, "{link}", "0908300001", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Xin chao {name}", name="Inject")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    res = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert res.json()["has_link"] is False
+    sk = (await _recipients(cid))[0]["sk"]
+    assert "__SMS_LINK__" not in sk   # tên '{link}' KHÔNG thành sentinel
+    assert "{link}" in sk             # giữ literal trong tên
+    assert (await _recipients(cid))[0]["token_hash"] is None
+
+
+# ---------------------------------------------------------------------
+# Codex R1 #3 — đổi nhóm sau build → reset draft
+# ---------------------------------------------------------------------
+async def test_group_change_resets_to_draft(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g1 = await _mk_group(client, h, "GC G1")
+    g2 = await _mk_group(client, h, "GC G2")
+    c = await _mk_contact(client, h, "A", "0908200001", granted=True)
+    await _add_to_group(client, h, c, g1)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="GChange")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g1}, headers=h
+    )
+    r = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert r.json()["status"] == "ready"
+    # attach nhóm khác → status reset draft
+    res = await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g2}, headers=h
+    )
+    assert res.json()["status"] == "draft"
+    # build lại → ready; detach → draft
+    assert (await client.post(
+        f"{API}/campaigns/{cid}/build", headers=h)).json()["status"] == "ready"
+    assert (await client.delete(
+        f"{API}/campaigns/{cid}/groups/{g2}", headers=h)).status_code == 204
+    assert (await client.get(
+        f"{API}/campaigns/{cid}", headers=h)).json()["status"] == "draft"
+
+
+# ---------------------------------------------------------------------
+# Codex R1 #6 — UCS-2 đo theo UTF-16 code units (non-BMP = 2)
+# ---------------------------------------------------------------------
+def test_measure_ucs2_emoji():
+    from app.utils.sms_render import measure
+    enc, n, seg, over = measure("\U0001F600" * 36)  # 36 emoji non-BMP
+    assert enc == "UCS2"
+    assert n == 72        # 36 × 2 UTF-16 code units (KHÔNG phải 36)
+    assert seg >= 2       # > 70 → multi-segment
+    assert over is True
+
+
+# ---------------------------------------------------------------------
+# Codex R2 #2 — sentinel injection fail-closed
+# ---------------------------------------------------------------------
+async def test_template_rejects_sentinel(
+    client: AsyncClient, admin_token_headers: dict
+):
+    res = await _mk_campaign(
+        client, admin_token_headers, "Xem __SMS_LINK__ ngay", name="SentTpl"
+    )
+    assert res.status_code == 400  # template chứa chuỗi nội bộ → từ chối
+
+
+async def test_name_sentinel_sanitized(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom Sent")
+    # tên contact = literal sentinel; template KHÔNG có {link}
+    c = await _mk_contact(client, h, "__SMS_LINK__", "0908400001", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="NameSent")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    res = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert res.json()["has_link"] is False
+    row = (await _recipients(cid))[0]
+    assert "__SMS_LINK__" not in row["sk"]  # tên bị sanitize → không sentinel
+    assert row["token_hash"] is None
+
+
+# ---------------------------------------------------------------------
+# Codex R2 #4 — template toàn khoảng trắng → 422
+# ---------------------------------------------------------------------
+async def test_template_whitespace_rejected(
+    client: AsyncClient, admin_token_headers: dict
+):
+    res = await _mk_campaign(client, admin_token_headers, "    ", name="WsTpl")
+    assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------
+# Codex R3 #1 — update_campaign serialize với build qua campaign row lock
+# ---------------------------------------------------------------------
+async def test_update_serializes_with_build_lock(
+    client: AsyncClient, admin_token_headers: dict
+):
+    from app.schemas import sms as sms_schemas
+    from app.services.sms_campaign_service import SmsCampaignService
+
+    h = admin_token_headers
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="LockRace")).json()["id"]
+    # Session A giữ lock FOR UPDATE trên campaign (mô phỏng build đang chạy).
+    async with AsyncSessionLocal() as sa:
+        await sa.execute(
+            text("SELECT id FROM sms_campaign WHERE id=:c FOR UPDATE"),
+            {"c": cid},
+        )
+        # Session B: lock_timeout ngắn → update_campaign (FOR UPDATE) phải lỗi
+        # → chứng tỏ update serialize với build (không đọc không khóa).
+        async with AsyncSessionLocal() as sb:
+            await sb.execute(text("SET lock_timeout = '400ms'"))
+            svc = SmsCampaignService(sb)
+            with pytest.raises(Exception):
+                await svc.update_campaign(
+                    cid, sms_schemas.SmsCampaignUpdate(name="doi ten")
+                )
+        await sa.rollback()
+
+
+# ---------------------------------------------------------------------
+# Codex R3 #2 — name fallback + drop-broken-row (missing_data)
+# ---------------------------------------------------------------------
+async def test_name_fallback_when_empty(
+    client: AsyncClient, admin_token_headers: dict, monkeypatch
+):
+    from app.config import settings as cfg
+    monkeypatch.setattr(cfg, "SMS_OPTOUT_INSTRUCTION", "STOP")  # footer ngắn
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom FB")
+    # tên = literal sentinel → sanitize rỗng → fallback quy định (§D6)
+    c = await _mk_contact(client, h, "__SMS_LINK__", "0908500001", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="Fallback")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    res = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert res.json()["exportable"] == 1     # fallback → vẫn gửi được
+    sk = (await _recipients(cid))[0]["sk"]
+    assert "Quý phụ huynh/học sinh" in sk
+    assert "__SMS_LINK__" not in sk
+
+
+async def test_name_render_token_dropped_missing_data(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom MD")
+    # tên contact = literal "{name}" → tin cuối còn placeholder → missing_data
+    c = await _mk_contact(client, h, "{name}", "0908600001", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="MissData")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    res = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert res.json()["exportable"] == 0
+    assert res.json()["excluded_by_reason"].get("missing_data") == 1
+
+
+# ---------------------------------------------------------------------
+# Codex R3 #4 — gate từ chối Fernet key sai định dạng (prod)
+# ---------------------------------------------------------------------
+def test_fernet_malformed_key_rejected(monkeypatch):
+    from app.config import settings as cfg
+    from app.utils import sms_token
+
+    monkeypatch.setattr(cfg, "APP_ENV", "production")
+    monkeypatch.setattr(cfg, "SMS_TOKEN_HASH_SECRET", "x" * 40)
+    monkeypatch.setattr(
+        cfg, "SMS_TOKEN_ENCRYPTION_KEYS", '{"v1": "not-a-fernet-key"}'
+    )
+    monkeypatch.setattr(cfg, "SMS_TOKEN_ACTIVE_KEY_VERSION", "v1")
+    with pytest.raises(RuntimeError):
+        sms_token.ensure_token_secrets_configured()
+
+
+# ---------------------------------------------------------------------
+# Codex R4 #1 — ID cực lớn → 422 (chống int32 overflow 500)
+# ---------------------------------------------------------------------
+async def test_extreme_id_rejected(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    big = "1" * 101
+    assert (await client.get(
+        f"{API}/campaigns/{big}", headers=h)).status_code == 422
+    assert (await client.post(
+        f"{API}/campaigns/{big}/build", headers=h)).status_code == 422
+    # group_id trong body cũng bị chặn
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="ExtremeId")).json()["id"]
+    res = await client.post(
+        f"{API}/campaigns/{cid}/groups",
+        json={"group_id": int("9" * 30)}, headers=h,
+    )
+    assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------
+# Codex R4 #2 — footer chứa {foo} → drop missing_data (no placeholder sót)
+# ---------------------------------------------------------------------
+async def test_footer_placeholder_dropped(
+    client: AsyncClient, admin_token_headers: dict, monkeypatch
+):
+    from app.config import settings as cfg
+    monkeypatch.setattr(cfg, "SMS_OPTOUT_INSTRUCTION", "Tu choi {foo}")
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom FootPH")
+    c = await _mk_contact(client, h, "Nguyen A", "0908700001", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="FootPH")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    res = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert res.json()["exportable"] == 0
+    assert res.json()["excluded_by_reason"].get("missing_data") == 1
+
+
+# ---------------------------------------------------------------------
+# Codex R4 #4 — keyring value không phải chuỗi → RuntimeError (không AttributeError)
+# ---------------------------------------------------------------------
+def test_keyring_nonstring_key_rejected(monkeypatch):
+    from app.config import settings as cfg
+    from app.utils import sms_token
+
+    monkeypatch.setattr(cfg, "APP_ENV", "production")
+    monkeypatch.setattr(cfg, "SMS_TOKEN_HASH_SECRET", "x" * 40)
+    monkeypatch.setattr(cfg, "SMS_TOKEN_ENCRYPTION_KEYS", '{"v1": 123}')
+    monkeypatch.setattr(cfg, "SMS_TOKEN_ACTIVE_KEY_VERSION", "v1")
+    with pytest.raises(RuntimeError):
+        sms_token.ensure_token_secrets_configured()
+
+
+# ---------------------------------------------------------------------
+# Codex R5 #1 — skip cực lớn → 422 (chống offset int64 overflow 500)
+# ---------------------------------------------------------------------
+async def test_skip_extreme_rejected(
+    client: AsyncClient, admin_token_headers: dict
+):
+    res = await client.get(
+        f"{API}/campaigns?skip={'1' * 101}", headers=admin_token_headers
+    )
+    assert res.status_code == 422
+
+
+# ---------------------------------------------------------------------
+# Codex R5 #2 — skeleton_is_broken bắt ngoặc LẺ (không cân bằng)
+# ---------------------------------------------------------------------
+def test_skeleton_lone_brace_broken():
+    from app.utils.sms_render import skeleton_is_broken
+
+    # ngoặc LẺ '{foo' / 'foo}' (không cân bằng) cũng phải bị coi là hỏng
+    assert skeleton_is_broken("[QC] Hi {foo STOP", has_link=False) is True
+    assert skeleton_is_broken("[QC] Hi foo} STOP", has_link=False) is True
+    # bình thường (không ngoặc) → OK; sentinel mà không link → hỏng
+    assert skeleton_is_broken("[QC] Hi An STOP", has_link=False) is False
+    assert skeleton_is_broken("[QC] x __SMS_LINK__", has_link=False) is True
+
+
+# ---------------------------------------------------------------------
+# Codex R5 #3 — token_key_version > 32 ký tự → RuntimeError (cột VARCHAR(32))
+# ---------------------------------------------------------------------
+def test_key_version_too_long_rejected(monkeypatch):
+    import json
+
+    from cryptography.fernet import Fernet
+
+    from app.config import settings as cfg
+    from app.utils import sms_token
+
+    long_ver = "v" * 33
+    key = Fernet.generate_key().decode()  # key HỢP LỆ → chỉ version sai
+    monkeypatch.setattr(cfg, "APP_ENV", "production")
+    monkeypatch.setattr(cfg, "SMS_TOKEN_HASH_SECRET", "x" * 40)
+    monkeypatch.setattr(
+        cfg, "SMS_TOKEN_ENCRYPTION_KEYS", json.dumps({long_ver: key})
+    )
+    monkeypatch.setattr(cfg, "SMS_TOKEN_ACTIVE_KEY_VERSION", long_ver)
+    with pytest.raises(RuntimeError):
+        sms_token.ensure_token_secrets_configured()
+
+
+# ---------------------------------------------------------------------
+# Codex R5 #4 — frequency cap âm bị từ chối (campaign + global config)
+# ---------------------------------------------------------------------
+async def test_freq_cap_negative_rejected(
+    client: AsyncClient, admin_token_headers: dict
+):
+    res = await _mk_campaign(
+        client, admin_token_headers, "Hi {name}",
+        name="NegFreq", frequency_cap_days=-1,
+    )
+    assert res.status_code == 422
+
+
+def test_global_freq_cap_rejects_negative():
+    from pydantic import ValidationError
+
+    from app.config import Settings
+
+    with pytest.raises(ValidationError) as ei:
+        Settings(SMS_FREQUENCY_CAP_DAYS=-5)
+    assert "SMS_FREQUENCY_CAP_DAYS" in str(ei.value)
+
+
+# ---------------------------------------------------------------------
+# Codex R5 #5 — preflight có preview ≤5 dòng (sentinel → URL mẫu), §D6
+# ---------------------------------------------------------------------
+async def test_preflight_includes_preview(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom PV")
+    c = await _mk_contact(client, h, "Nguyen Preview", "0908800001", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (
+        await _mk_campaign(client, h, "Chao {name}, xem {link}", name="Preview")
+    ).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    rep = (await client.post(f"{API}/campaigns/{cid}/build", headers=h)).json()
+    assert rep["exportable"] == 1
+    assert 1 <= len(rep["preview"]) <= 5
+    line = rep["preview"][0]
+    assert "__SMS_LINK__" not in line   # sentinel đã thay bằng URL mẫu
+    assert "/r/" in line                # link mẫu có path /r/
+    assert line.startswith("[QC]")
+    assert "Nguyen Preview" in line     # tên đã render vào preview
+
+
+# ---------------------------------------------------------------------
+# Codex R6 #1 — chặn rebuild sau khi đã bàn giao ≥1 batch (§232)
+# ---------------------------------------------------------------------
+async def test_rebuild_blocked_after_handoff(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom HO")
+    c = await _mk_contact(client, h, "Nguyen HO", "0909000001", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="Handoff")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    assert (await client.post(
+        f"{API}/campaigns/{cid}/build", headers=h)).status_code == 200
+    # mô phỏng đã bàn giao batch: set handed_off_at cho recipient
+    async with AsyncSessionLocal() as s:
+        await s.execute(text(
+            "UPDATE sms_campaign_recipient SET handed_off_at = now() "
+            "WHERE campaign_id = :c"), {"c": cid})
+        await s.commit()
+    # rebuild → 400 (đã handoff → không build lại, tạo campaign mới)
+    res = await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R6 #2 — attestation chỉ ở 'ready'; sau export bị đóng băng
+# ---------------------------------------------------------------------
+async def test_attestation_blocked_after_export(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom AE")
+    c = await _mk_contact(client, h, "Nguyen AE", "0909000002", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="AttestExp")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    # attest ở 'ready' → OK
+    r = await client.post(
+        f"{API}/campaigns/{cid}/attestations",
+        json={"kind": "consent", "reference": "rep-ready"}, headers=h,
+    )
+    assert r.status_code == 201
+    # chuyển 'exported' (mô phỏng đã sinh file) → attest bị chặn 400
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text("UPDATE sms_campaign SET status='exported' WHERE id=:c"),
+            {"c": cid},
+        )
+        await s.commit()
+    res = await client.post(
+        f"{API}/campaigns/{cid}/attestations",
+        json={"kind": "consent", "reference": "rep-after"}, headers=h,
+    )
+    assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R6 #3 — over_limit nhất quán: row no_consent+dài KHÔNG vào over_limit
+# ---------------------------------------------------------------------
+async def test_over_limit_excludes_higher_priority_row(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom OLC")
+    # chưa consent + template dài → no_consent thắng (ưu tiên cao hơn)
+    c = await _mk_contact(client, h, "Nguyen OLC", "0909000003", granted=False)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "X" * 200, name="OLConsist")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    rep = (await client.post(f"{API}/campaigns/{cid}/build", headers=h)).json()
+    assert rep["excluded_by_reason"].get("no_consent") == 1
+    assert rep["excluded_by_reason"].get("over_limit") is None  # KHÔNG đếm over
+    assert rep["over_limit"] == []                              # list rỗng (nhất quán)
+    assert not any("EXPORT" in w for w in rep["warnings"])      # không cảnh báo over
+
+
+# ---------------------------------------------------------------------
+# Codex R6 #4 — external_suppression → dnc_suppressed (KHÔNG phải opted_out)
+# ---------------------------------------------------------------------
+async def test_external_suppression_is_dnc(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom DNC")
+    c = await _mk_contact(client, h, "Nguyen DNC", "0909000004", granted=True)
+    await _add_to_group(client, h, c, g)
+    async with AsyncSessionLocal() as s:
+        await s.execute(text(
+            "INSERT INTO sms_opt_out (phone_normalized, source, observed_at) "
+            "VALUES ('0909000004','external_suppression', now())"))
+        await s.commit()
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="DncSup")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    rep = (await client.post(f"{API}/campaigns/{cid}/build", headers=h)).json()
+    assert rep["excluded_by_reason"].get("dnc_suppressed") == 1
+    assert rep["excluded_by_reason"].get("opted_out") is None
+    assert (await _recipients(cid))[0]["excluded_reason"] == "dnc_suppressed"
+
+
+# ---------------------------------------------------------------------
+# Codex R6 #5 — API trả actor (*_checked_by_id) của attestation
+# ---------------------------------------------------------------------
+async def test_attestation_exposes_actor(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom Actor")
+    c = await _mk_contact(client, h, "Nguyen Actor", "0909000005", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="Actor")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    r = await client.post(
+        f"{API}/campaigns/{cid}/attestations",
+        json={"kind": "consent", "reference": "rep-actor"}, headers=h,
+    )
+    assert r.status_code == 201
+    actor = r.json()["consent_checked_by_id"]
+    assert actor is not None                       # actor lộ ra ở response mutation
+    detail = (await client.get(f"{API}/campaigns/{cid}", headers=h)).json()
+    assert detail["consent_checked_by_id"] == actor  # GET cũng trả actor
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P1-1 — đã handoff thì chặn attach + update (không lách qua draft)
+# ---------------------------------------------------------------------
+async def test_handoff_blocks_attach_and_update(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom HOA")
+    g2 = await _mk_group(client, h, "Nhom HOA2")
+    c = await _mk_contact(client, h, "Nguyen HOA", "0909100001", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="HandoffMut")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    await client.post(f"{API}/campaigns/{cid}/build", headers=h)
+    async with AsyncSessionLocal() as s:
+        await s.execute(text(
+            "UPDATE sms_campaign_recipient SET handed_off_at=now() "
+            "WHERE campaign_id=:c"), {"c": cid})
+        await s.commit()
+    # attach nhóm khác → 400 (không reset về draft sau handoff)
+    assert (await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g2}, headers=h
+    )).status_code == 400
+    # ép draft (giả lập) + đã handoff → update cũng bị chặn 400
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text("UPDATE sms_campaign SET status='draft' WHERE id=:c"),
+            {"c": cid},
+        )
+        await s.commit()
+    assert (await client.patch(
+        f"{API}/campaigns/{cid}", json={"name": "doi"}, headers=h
+    )).status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P1-2 — prod fail-closed: footer placeholder xxxx + base_url + ip
+# ---------------------------------------------------------------------
+async def test_prod_footer_placeholder_xxxx_rejected(
+    client: AsyncClient, admin_token_headers: dict, monkeypatch
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom PFX")
+    c = await _mk_contact(client, h, "Nguyen PFX", "0909100002", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="ProdFx")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    from app.config import settings as cfg
+    monkeypatch.setattr(cfg, "APP_ENV", "production")
+    monkeypatch.setattr(cfg, "SMS_OPTOUT_INSTRUCTION", "Tu choi: goi 1900 XXXX")
+    # footer còn 'XXXX' placeholder → build 400 (no-link nên không cần keyring)
+    assert (await client.post(
+        f"{API}/campaigns/{cid}/build", headers=h)).status_code == 400
+
+
+def test_prod_base_url_must_be_https_allowlisted(monkeypatch):
+    from app.config import settings as cfg
+    from app.utils import sms_token
+
+    monkeypatch.setattr(cfg, "APP_ENV", "production")
+    monkeypatch.setattr(cfg, "SMS_TOKEN_HASH_SECRET", "x" * 40)
+    monkeypatch.setattr(cfg, "SMS_IP_HASH_SECRET", "y" * 40)
+    monkeypatch.setattr(cfg, "SMS_PUBLIC_BASE_URL", "http://evil.example")
+    with pytest.raises(RuntimeError):
+        sms_token.ensure_token_secrets_configured()
+
+
+def test_prod_ip_hash_secret_must_be_strong(monkeypatch):
+    from app.config import settings as cfg
+    from app.utils import sms_token
+
+    monkeypatch.setattr(cfg, "APP_ENV", "production")
+    monkeypatch.setattr(cfg, "SMS_TOKEN_HASH_SECRET", "x" * 40)
+    # ip secret còn default công khai → RuntimeError
+    monkeypatch.setattr(
+        cfg, "SMS_IP_HASH_SECRET", "dev-sms-ip-hash-secret-change-in-prod"
+    )
+    with pytest.raises(RuntimeError):
+        sms_token.ensure_token_secrets_configured()
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P2-1 — preflight stale: draft sau build → preview rỗng + warning
+# ---------------------------------------------------------------------
+async def test_preflight_stale_clears_preview(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom STL")
+    g2 = await _mk_group(client, h, "Nhom STL2")
+    c = await _mk_contact(client, h, "Nguyen STL", "0909100003", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (
+        await _mk_campaign(client, h, "Chao {name} {link}", name="Stale")
+    ).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    rep = (await client.post(f"{API}/campaigns/{cid}/build", headers=h)).json()
+    assert rep["preview"]                       # ready → có preview
+    # đổi audience → draft (stale)
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g2}, headers=h
+    )
+    rep2 = (await client.get(f"{API}/campaigns/{cid}/preflight", headers=h)).json()
+    assert rep2["status"] == "draft"
+    assert rep2["build_revision"] == 1          # số liệu thuộc rev cũ
+    assert rep2["preview"] == []                # preview cũ KHÔNG hiển thị
+    assert any("CŨ" in w for w in rep2["warnings"])
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P2-2 — footer > 160 → build 400 (snapshot không cắt ngầm)
+# ---------------------------------------------------------------------
+async def test_footer_too_long_rejected(
+    client: AsyncClient, admin_token_headers: dict, monkeypatch
+):
+    from app.config import settings as cfg
+    monkeypatch.setattr(cfg, "SMS_OPTOUT_INSTRUCTION", "A" * 161)
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom FL")
+    c = await _mk_contact(client, h, "Nguyen FL", "0909100004", granted=True)
+    await _add_to_group(client, h, c, g)
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="FootLong")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    assert (await client.post(
+        f"{API}/campaigns/{cid}/build", headers=h)).status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P2-3 — link_expires_at: quá khứ/naive → 422; tương lai tz → 201
+# ---------------------------------------------------------------------
+async def test_link_expires_validation(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    # quá khứ → 422
+    assert (await _mk_campaign(
+        client, h, "Hi {name}", name="ExpPast",
+        link_expires_at="2020-01-01T00:00:00+07:00")).status_code == 422
+    # naive (không timezone) → 422
+    assert (await _mk_campaign(
+        client, h, "Hi {name}", name="ExpNaive",
+        link_expires_at="2099-01-01T00:00:00")).status_code == 422
+    # tương lai + tz → 201
+    assert (await _mk_campaign(
+        client, h, "Hi {name}", name="ExpOk",
+        link_expires_at="2099-01-01T00:00:00+07:00")).status_code == 201
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P2-4 — decrypt_code key không phải chuỗi → None (không 500)
+# ---------------------------------------------------------------------
+def test_decrypt_nonstring_key_returns_none(monkeypatch):
+    from app.config import settings as cfg
+    from app.utils import sms_token
+
+    monkeypatch.setattr(cfg, "SMS_TOKEN_ENCRYPTION_KEYS", '{"v1": 123}')
+    monkeypatch.setattr(cfg, "SMS_TOKEN_ACTIVE_KEY_VERSION", "v1")
+    assert sms_token.decrypt_code("anything", "v1") is None
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P3-1 — nhóm is_active=false → attach 400
+# ---------------------------------------------------------------------
+async def test_inactive_group_attach_rejected(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom Inact")
+    async with AsyncSessionLocal() as s:
+        await s.execute(
+            text("UPDATE sms_contact_group SET is_active=false WHERE id=:g"),
+            {"g": g},
+        )
+        await s.commit()
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="InactG")).json()["id"]
+    assert (await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )).status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P3-2 — nhóm rỗng (0 member) → build 400
+# ---------------------------------------------------------------------
+async def test_empty_group_build_rejected(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom Empty")  # KHÔNG add member
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="EmptyG")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    assert (await client.post(
+        f"{API}/campaigns/{cid}/build", headers=h)).status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P3-3 — list campaign trả group_count thực (không null)
+# ---------------------------------------------------------------------
+async def test_list_group_count_populated(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom GC")
+    cid = (await _mk_campaign(client, h, "Hi {name}", name="ListGCx")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    res = await client.get(f"{API}/campaigns?search=ListGCx", headers=h)
+    item = next(i for i in res.json()["items"] if i["id"] == cid)
+    assert item["group_count"] == 1
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P3-4 — CTA chỉ có label (thiếu URL) → 400
+# ---------------------------------------------------------------------
+async def test_cta_requires_both_label_and_url(
+    client: AsyncClient, admin_token_headers: dict
+):
+    res = await _mk_campaign(
+        client, admin_token_headers, "Hi {name}", name="CtaHalf",
+        landing_cta_label="Bam day",
+    )
+    assert res.status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P3-5 — global frequency cap có trần (le=3650)
+# ---------------------------------------------------------------------
+def test_global_freq_cap_ceiling():
+    from pydantic import ValidationError
+
+    from app.config import Settings
+
+    with pytest.raises(ValidationError):
+        Settings(SMS_FREQUENCY_CAP_DAYS=999999999)
+
+
+# ---------------------------------------------------------------------
+# Codex R7 P3-7 — URL lưu sau khi strip whitespace
+# ---------------------------------------------------------------------
+async def test_landing_url_stored_stripped(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    res = await _mk_campaign(
+        client, h, "Bam {link}", name="UrlStrip", landing_type="external",
+        landing_url="  https://qlts.tnpc.edu.vn/x  ",
+    )
+    assert res.status_code == 201, res.text
+    cid = res.json()["id"]
+    detail = (await client.get(f"{API}/campaigns/{cid}", headers=h)).json()
+    assert detail["landing_url"] == "https://qlts.tnpc.edu.vn/x"
+
+
+# ---------------------------------------------------------------------
+# Codex R8 P2 — build re-check expiry: future lúc create, expired trước build
+# ---------------------------------------------------------------------
+async def test_build_rejects_expired_link(
+    client: AsyncClient, admin_token_headers: dict
+):
+    h = admin_token_headers
+    g = await _mk_group(client, h, "Nhom EXP")
+    c = await _mk_contact(client, h, "Nguyen EXP", "0909200001", granted=True)
+    await _add_to_group(client, h, c, g)
+    # tạo với expiry TƯƠNG LAI (qua schema), template có {link}
+    cid = (await _mk_campaign(
+        client, h, "Chao {name} {link}", name="ExpBuild",
+        link_expires_at="2099-01-01T00:00:00+07:00")).json()["id"]
+    await client.post(
+        f"{API}/campaigns/{cid}/groups", json={"group_id": g}, headers=h
+    )
+    # giả lập thời gian trôi: expiry đã quá khứ
+    async with AsyncSessionLocal() as s:
+        await s.execute(text(
+            "UPDATE sms_campaign SET link_expires_at='2020-01-01T00:00:00+07' "
+            "WHERE id=:c"), {"c": cid})
+        await s.commit()
+    # build → 400 (link đã hết hạn, không build link chết)
+    assert (await client.post(
+        f"{API}/campaigns/{cid}/build", headers=h)).status_code == 400
+
+
+# ---------------------------------------------------------------------
+# Codex R8 P3 — prod SMS_PUBLIC_BASE_URL từ chối userinfo/query/fragment
+# ---------------------------------------------------------------------
+def test_prod_base_url_rejects_userinfo_query(monkeypatch):
+    from app.config import settings as cfg
+    from app.utils import sms_token
+
+    monkeypatch.setattr(cfg, "APP_ENV", "production")
+    monkeypatch.setattr(cfg, "SMS_TOKEN_HASH_SECRET", "x" * 40)
+    monkeypatch.setattr(cfg, "SMS_IP_HASH_SECRET", "y" * 40)
+    # host đúng allowlist NHƯNG có userinfo + query → URL link sẽ sai
+    monkeypatch.setattr(
+        cfg, "SMS_PUBLIC_BASE_URL", "https://user@qlts.tnpc.edu.vn?x=1"
+    )
+    with pytest.raises(RuntimeError):
+        sms_token.ensure_token_secrets_configured()


### PR DESCRIPTION
## Tính năng
PR-3 module SMS Marketing — **Campaign Build backend** (admin-only): CRUD campaign + gắn/gỡ nhóm + BUILD engine (snapshot revisioned, dedupe theo phone, fail-closed consent>opt-out>frequency>over_limit, phân loại nhà mạng, short-link token chỉ khi có `{link}`, render `[QC]`+body+footer NĐ91, đo GSM7/UCS2 + segments) + preflight report (preview 5 dòng) + attestation gate export.

8 file in-scope (config/router/schema/service/repo/sms_render/sms_token/test), **không migration** (bảng đã ở PR-1).

## Review
Qua **8 vòng Codex review — 44 finding đã fix** (6+4+4+4+5+5+14+2), hội tụ ở R8 (0 P0/P1). Bao phủ: compliance fail-closed NĐ91, race build vs attach/detach (campaign row lock), token collision savepoint auto-retry, int32/int64 bound, handoff immutability (attach/detach/update/build), attestation evidence integrity (chỉ ready), prod config fail-closed (token/IP secret + base_url allowlist), link expiry re-check lúc build.

## Test
75/75 SMS pytest pass. flake8 sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)