### PR TITLE
feat(admissions): cảnh báo mềm rà soát nhãn THCS theo năm hoàn thành lớp 9 (TT10/2026)

### DIFF
--- a/Backend_FastAPI/app/config.py
+++ b/Backend_FastAPI/app/config.py
@@ -666,6 +666,17 @@ class Settings(BaseSettings):
     SCHOOL_BANK_ACCOUNT: str = Field(default="", validation_alias="SCHOOL_BANK_ACCOUNT")
     SCHOOL_BANK_HOLDER: str = Field(default="", validation_alias="SCHOOL_BANK_HOLDER")
 
+    # -- THCS diploma policy (Thông tư 10/2026/TT-BGDĐT) --
+    # Từ 15/04/2026 bỏ cấp Bằng tốt nghiệp THCS, thay bằng xác nhận hoàn thành
+    # chương trình trong học bạ. Học sinh hoàn thành lớp 9 (year_to) TỪ năm này
+    # trở đi rơi vào diện mới → nếu hồ sơ vẫn ghi 'graduated_thcs' (có bằng) thì
+    # bật cảnh báo MỀM rà soát nhãn. Chỉ lưu NĂM nên đây là heuristic rà soát,
+    # KHÔNG khẳng định tuyệt đối. Nguồn 2026 DUY NHẤT ở đây (live caller truyền
+    # tường minh; pure helper nhận None = no-op).
+    THCS_DIPLOMA_REVIEW_FROM_GRADE9_YEAR: int = Field(
+        default=2026, validation_alias="THCS_DIPLOMA_REVIEW_FROM_GRADE9_YEAR"
+    )
+
     # === Pydantic Settings Configuration ===
     model_config = ConfigDict(
         # Đường dẫn tới file .env cần tải (chỉ tải nếu tồn tại)

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1556,6 +1556,108 @@ async def _resolve_verifier_names(
     return out
 
 
+def _strict_int(value) -> Optional[int]:
+    """Ép int NGHIÊM + AN TOÀN (KHÔNG bao giờ raise).
+
+    Loại bool (subclass int → int(True)==1) và float (int(9.7) cắt cụt).
+    Với str: CHỈ nhận chuỗi-integer ASCII — loại '²' (isdigit()=True nhưng
+    int() ném ValueError) + chữ số Unicode khác; giới hạn độ dài (tránh
+    ValueError "integer string conversion limit" với chuỗi cực dài). Bọc
+    try/except phòng hờ. Dùng cho JSONB academic_history (grade_to/year_to)
+    vốn có thể lẫn bool/float/rác do nhập tay.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        s = value.strip()
+        core = s[1:] if s.startswith("-") else s
+        if core.isascii() and core.isdigit() and 0 < len(core) <= 9:
+            try:
+                return int(s)
+            except ValueError:
+                return None
+    return None
+
+
+def _coerce_year(value) -> Optional[int]:
+    """Như ``_strict_int`` nhưng CHẤP NHẬN thêm float nguyên (2026.0 → 2026)
+    cho year_to — số trong JSONB có thể là float. Loại bool, float lẻ
+    (2026.5), NaN/inf. Chuỗi-integer ASCII đi qua ``_strict_int``.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            return None  # NaN / inf
+        return int(value) if value == int(value) else None
+    return _strict_int(value)
+
+
+def _thcs_grade9_completion_year(academic_history) -> Optional[int]:
+    """Năm hoàn thành lớp 9 = max(year_to) của các record THCS lớp 9.
+
+    academic_history = JSONB list[dict] (AcademicRecordSchema). Nhận record
+    khi ``grade_to == 9`` HOẶC ``level == 'THCS'`` — officer có thể điền 1
+    trong 2 (cả hai đều Optional); 'THCS_THPT' KHÔNG tính (year_to là năm TN
+    THPT, không phải lớp 9). Trả None nếu không có record lớp 9 hợp lệ →
+    caller KHÔNG cảnh báo (tránh false-positive khi thiếu dữ liệu).
+    """
+    if not academic_history:
+        return None
+    years: List[int] = []
+    for rec in academic_history:
+        if not isinstance(rec, dict):
+            continue
+        level = rec.get("level")
+        is_thcs = _strict_int(rec.get("grade_to")) == 9 or (
+            isinstance(level, str) and level.strip().upper() == "THCS"
+        )
+        if not is_thcs:
+            continue
+        year_to = _coerce_year(rec.get("year_to"))
+        # Chỉ nhận năm hợp lệ (mirror AcademicRecordSchema ge=1900 le=2100) —
+        # applied JSONB có thể bẩn (không qua schema validate khi đọc lại).
+        if year_to is not None and 1900 <= year_to <= 2100:
+            years.append(year_to)
+    return max(years) if years else None
+
+
+def _thcs_diploma_review_warning(
+    cultural: Optional[str],
+    academic_history,
+    review_from_year: Optional[int],
+) -> Optional[dict]:
+    """Cảnh báo MỀM rà soát nhãn THCS (KHÔNG chặn submit).
+
+    Bật khi hồ sơ ghi `graduated_thcs` (có bằng TN THCS) nhưng học sinh
+    hoàn thành lớp 9 TỪ `review_from_year` trở đi — diện Thông tư
+    10/2026/TT-BGDĐT (từ 15/04/2026 không cấp bằng TN THCS, thay bằng xác
+    nhận hoàn thành chương trình trong học bạ). `review_from_year=None` →
+    no-op (pure-test / chưa cấu hình). Trả None nếu không áp dụng.
+    """
+    if cultural != "graduated_thcs" or review_from_year is None:
+        return None
+    year9 = _thcs_grade9_completion_year(academic_history)
+    if year9 is None or year9 < review_from_year:
+        return None
+    return {
+        "code": "thcs_diploma_review",
+        "message": (
+            f"Hoàn thành lớp 9 năm {year9} — theo Thông tư 10/2026/TT-BGDĐT, "
+            "học sinh hoàn thành chương trình THCS được xác nhận trong học bạ "
+            "thay cho cấp Bằng tốt nghiệp THCS. Vui lòng kiểm tra lại trình độ "
+            "đã chọn."
+        ),
+        "step": 4,
+        "section": "priority",
+        "severity": "warning",
+    }
+
+
 def _build_executive_summary_items(
     *,
     personal_error_count: int,
@@ -1565,6 +1667,9 @@ def _build_executive_summary_items(
     has_family: bool,
     has_academic: bool,
     docs_format_confirmed: bool,
+    cultural: Optional[str] = None,
+    academic_history=None,
+    thcs_review_from_year: Optional[int] = None,
 ) -> tuple[list[dict], list[dict]]:
     """Build executive_summary ``(critical_blockers, warnings)`` as structured items.
 
@@ -1640,6 +1745,15 @@ def _build_executive_summary_items(
             "section": "documents",
             "severity": "warning",
         })
+
+    # Cảnh báo MỀM rà soát nhãn THCS (Thông tư 10/2026 — bỏ bằng TN THCS từ
+    # 15/04/2026). KHÔNG chặn submit; chỉ append vào warnings để FE nhắc officer.
+    thcs_warn = _thcs_diploma_review_warning(
+        cultural, academic_history, thcs_review_from_year
+    )
+    if thcs_warn:
+        warnings.append(thcs_warn)
+
     return critical_blockers, warnings
 
 
@@ -2476,6 +2590,9 @@ def _compute_frontend_fields(
     # to its exact step). Built by a pure helper for unit-testability. Semantics
     # UNCHANGED vs the old string form (same conditions, same blocker/warning
     # split). Transient field (no DB migration).
+    # Local import (mirror :777) — KHÔNG global để pure-test import sạch.
+    from app.config import settings
+
     critical_blockers, warning_messages = _build_executive_summary_items(
         personal_error_count=personal_error_count,
         missing_doc_count=len(missing_doc_codes),
@@ -2484,6 +2601,9 @@ def _compute_frontend_fields(
         has_family=bool(has_family),
         has_academic=bool(has_academic),
         docs_format_confirmed=bool(docs_format_confirmed),
+        cultural=profile.cultural_education_level,
+        academic_history=profile.academic_history,
+        thcs_review_from_year=settings.THCS_DIPLOMA_REVIEW_FROM_GRADE9_YEAR,
     )
 
     # Suggest next action (Phase E.4 — 8-step model: Step 4=Priority, 5=Scores, 6=Documents)

--- a/Backend_FastAPI/tests/services/test_admission_service.py
+++ b/Backend_FastAPI/tests/services/test_admission_service.py
@@ -1838,3 +1838,98 @@ class TestCreateProfileResponseFields:
                 f"create={create_body.get(field)!r}, get={get_body.get(field)!r}. "
                 f"_populate_response_fields may be missing from create_profile."
             )
+
+
+class TestThcsDiplomaReviewWarning:
+    """GO #3 — projection qua endpoint: chứng minh _compute_frontend_fields
+    NỐI profile.cultural_education_level + academic_history vào cảnh báo THCS
+    (Thông tư 10/2026), không chỉ test pure helper. Cảnh báo là warning →
+    KHÔNG chặn submit (không vào critical_blockers).
+    """
+
+    async def test_graduated_thcs_grade9_2026_emits_review_warning(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        major_id = seed_lead_dependencies["major_program_id"]
+        # academic_year (năm TUYỂN SINH) = 2025, KHÁC năm lớp 9 → chứng minh
+        # cảnh báo dùng năm hoàn thành lớp 9, không phải năm tuyển sinh.
+        data = await setup_admission_api_data(
+            major_id=major_id,
+            unit_id=unit_id,
+            officer_id=officer_user_in_db["id"],
+            academic_year=2025,
+        )
+        headers = await get_auth_headers(client, officer_user_in_db)
+
+        create_response = await client.post(
+            "/api/admissions",
+            json={
+                "lead_id": data["lead_id"],
+                "admission_method_id": data["admission_method_id"],
+                "admission_round_id": data["admission_round_id"],
+                "academic_year": data["academic_year"],
+            },
+            headers=headers,
+        )
+        assert create_response.status_code == 201, create_response.text
+        profile_id = create_response.json()["id"]
+        version = create_response.json()["version"]
+
+        # graduated_thcs + hoàn thành lớp 9 năm 2026 → cảnh báo rà soát.
+        put_2026 = await client.put(
+            f"/api/admissions/{profile_id}",
+            json={
+                "version": version,
+                "cultural_education_level": "graduated_thcs",
+                "academic_history": [
+                    {
+                        "school_name": "THCS Kiểm Thử",
+                        "year_from": 2022,
+                        "year_to": 2026,
+                        "grade_to": 9,
+                    }
+                ],
+            },
+            headers=headers,
+        )
+        assert put_2026.status_code == 200, put_2026.text
+        es = put_2026.json()["executive_summary"]
+        warn_codes = {w["code"] for w in es["warnings"]}
+        blocker_codes = {b["code"] for b in es["critical_blockers"]}
+        # Wiring proven: field từ profile → cảnh báo xuất hiện qua endpoint.
+        assert "thcs_diploma_review" in warn_codes, es["warnings"]
+        # Là warning, KHÔNG phải blocker → không chặn submit.
+        assert "thcs_diploma_review" not in blocker_codes
+        assert "can_submit" in es
+        can_submit_with_warning = es["can_submit"]
+
+        # Đối chứng wiring: cùng graduated_thcs nhưng lớp 9 năm 2020 (có bằng
+        # thật) → KHÔNG cảnh báo. Chứng minh dùng academic_history THẬT từ
+        # profile, không hardcode theo cultural.
+        version2 = put_2026.json()["version"]
+        put_2020 = await client.put(
+            f"/api/admissions/{profile_id}",
+            json={
+                "version": version2,
+                "academic_history": [
+                    {
+                        "school_name": "THCS Kiểm Thử",
+                        "year_from": 2016,
+                        "year_to": 2020,
+                        "grade_to": 9,
+                    }
+                ],
+            },
+            headers=headers,
+        )
+        assert put_2020.status_code == 200, put_2020.text
+        es2 = put_2020.json()["executive_summary"]
+        warn_codes2 = {w["code"] for w in es2["warnings"]}
+        assert "thcs_diploma_review" not in warn_codes2, es2["warnings"]
+        # can_submit KHÔNG đổi giữa có cảnh báo (lớp 9 2026) và không (2020) →
+        # cảnh báo là warning thuần, không tác động quyền nộp hồ sơ.
+        assert es2["can_submit"] == can_submit_with_warning

--- a/Backend_FastAPI/tests/unit/test_executive_summary_items.py
+++ b/Backend_FastAPI/tests/unit/test_executive_summary_items.py
@@ -4,7 +4,31 @@ Pins the ``{code, message, step, section, severity}`` shape + step/section
 mapping + UNCHANGED blocker/warning semantics for
 ``_build_executive_summary_items``. Pure function — no DB, no fixtures.
 """
-from app.services.admission_service import _build_executive_summary_items
+from app.services.admission_service import (
+    _build_executive_summary_items,
+    _coerce_year,
+    _strict_int,
+    _thcs_grade9_completion_year,
+)
+
+
+def _summary(**overrides):
+    """Gọi builder với baseline SẠCH (0 blocker/warning) + override.
+
+    Dùng cho nhóm test cảnh báo THCS — chỉ bật field cần kiểm tra, phần còn
+    lại sạch để warning THCS là item duy nhất xuất hiện.
+    """
+    base = dict(
+        personal_error_count=0,
+        missing_doc_count=0,
+        unverified_doc_count=0,
+        gpa_error=False,
+        has_family=True,
+        has_academic=True,
+        docs_format_confirmed=True,
+    )
+    base.update(overrides)
+    return _build_executive_summary_items(**base)
 
 
 def _all_triggered():
@@ -82,3 +106,158 @@ def test_no_tuition_step_7_item():
     # Tuition is display-only — the builder must NEVER emit a step-7 item.
     blockers, warnings = _all_triggered()
     assert all(item["step"] != 7 for item in [*blockers, *warnings])
+
+
+# ---------------------------------------------------------------------------
+# THCS diploma review (soft warning) — Thông tư 10/2026 (bỏ bằng TN THCS)
+# ---------------------------------------------------------------------------
+
+
+def test_thcs_review_warning_fires_when_grade9_at_threshold():
+    _, warnings = _summary(
+        cultural="graduated_thcs",
+        academic_history=[{"grade_to": 9, "year_to": 2026}],
+        thcs_review_from_year=2026,
+    )
+    by_code = {w["code"]: w for w in warnings}
+    assert "thcs_diploma_review" in by_code
+    w = by_code["thcs_diploma_review"]
+    assert w["step"] == 4
+    assert w["section"] == "priority"
+    assert w["severity"] == "warning"
+    assert "2026" in w["message"]
+
+
+def test_thcs_review_warning_silent_when_grade9_before_threshold():
+    # Lớp 9 xong 2025 (NH 2024-2025) → còn có bằng TN THCS → không cảnh báo.
+    _, warnings = _summary(
+        cultural="graduated_thcs",
+        academic_history=[{"grade_to": 9, "year_to": 2025}],
+        thcs_review_from_year=2026,
+    )
+    assert all(w["code"] != "thcs_diploma_review" for w in warnings)
+
+
+def test_thcs_review_warning_silent_for_completed_thcs():
+    _, warnings = _summary(
+        cultural="completed_thcs",
+        academic_history=[{"grade_to": 9, "year_to": 2026}],
+        thcs_review_from_year=2026,
+    )
+    assert all(w["code"] != "thcs_diploma_review" for w in warnings)
+
+
+def test_thcs_review_warning_silent_when_no_grade9_record():
+    # Thiếu record lớp 9 → không đủ cơ sở → KHÔNG cảnh báo (tránh false-positive).
+    for hist in (None, [], [{"grade_to": 12, "year_to": 2026}]):
+        _, warnings = _summary(
+            cultural="graduated_thcs",
+            academic_history=hist,
+            thcs_review_from_year=2026,
+        )
+        assert all(w["code"] != "thcs_diploma_review" for w in warnings)
+
+
+def test_thcs_review_warning_silent_when_year_not_configured():
+    # review_from_year=None (mặc định) → no-op kể cả graduated_thcs + lớp 9 mới.
+    _, warnings = _summary(
+        cultural="graduated_thcs",
+        academic_history=[{"grade_to": 9, "year_to": 2030}],
+    )
+    assert all(w["code"] != "thcs_diploma_review" for w in warnings)
+
+
+def test_thcs_review_warning_takes_max_grade9_year():
+    # Nhiều record lớp 9 (học lại/chuyển trường) → lấy max(year_to).
+    _, warnings = _summary(
+        cultural="graduated_thcs",
+        academic_history=[
+            {"grade_to": 9, "year_to": 2024},
+            {"grade_to": 9, "year_to": 2026},
+        ],
+        thcs_review_from_year=2026,
+    )
+    assert any(w["code"] == "thcs_diploma_review" for w in warnings)
+
+
+# -- parser nghiêm: chỉ int + chuỗi-int; loại bool/float --
+
+
+def test_strict_int_accepts_int_and_int_string():
+    assert _strict_int(9) == 9
+    assert _strict_int("9") == 9
+    assert _strict_int("  2026 ") == 2026
+    assert _strict_int("-5") == -5
+
+
+def test_strict_int_rejects_bool_float_and_garbage():
+    assert _strict_int(True) is None  # bool KHÔNG được coi là 1
+    assert _strict_int(False) is None
+    assert _strict_int(9.0) is None  # float bị int() cắt cụt → loại
+    assert _strict_int(9.7) is None
+    assert _strict_int("9.0") is None
+    assert _strict_int("nine") is None
+    assert _strict_int(None) is None
+
+
+def test_grade9_year_ignores_bool_float_grade():
+    assert _thcs_grade9_completion_year(
+        [{"grade_to": True, "year_to": 2026}]
+    ) is None
+    assert _thcs_grade9_completion_year(
+        [{"grade_to": 9.0, "year_to": 2026}]
+    ) is None
+    assert (
+        _thcs_grade9_completion_year([{"grade_to": "9", "year_to": "2026"}])
+        == 2026
+    )
+
+
+def test_strict_int_rejects_unicode_digit_and_overlong():
+    # '²' isdigit()=True nhưng int('²') ném ValueError → PHẢI trả None.
+    assert _strict_int("²") is None
+    assert _strict_int("٩") is None  # chữ số Ả Rập-Ấn (non-ASCII)
+    # Chuỗi cực dài → tránh ValueError "integer string conversion limit".
+    assert _strict_int("9" * 5000) is None
+    assert _strict_int("9" * 10) is None  # >9 ký tự → loại
+
+
+def test_grade9_year_rejects_out_of_range():
+    # year_to ngoài [1900, 2100] → bỏ (applied JSONB bẩn không qua schema).
+    assert _thcs_grade9_completion_year([{"grade_to": 9, "year_to": 9999}]) is None
+    assert _thcs_grade9_completion_year([{"grade_to": 9, "year_to": "1899"}]) is None
+    assert _thcs_grade9_completion_year([{"grade_to": 9, "year_to": 2026}]) == 2026
+
+
+def test_grade9_year_accepts_level_thcs_without_grade_to():
+    # F1: officer điền level='THCS' nhưng để grade_to NULL → vẫn nhận (recall).
+    assert (
+        _thcs_grade9_completion_year(
+            [{"level": "THCS", "year_from": 2022, "year_to": 2026}]
+        )
+        == 2026
+    )
+    assert (
+        _thcs_grade9_completion_year([{"level": "thcs", "year_to": 2026}]) == 2026
+    )
+    # THCS_THPT (cấp 2+3): year_to là năm TN THPT, KHÔNG phải lớp 9 → loại.
+    assert (
+        _thcs_grade9_completion_year([{"level": "THCS_THPT", "year_to": 2026}])
+        is None
+    )
+
+
+def test_grade9_year_accepts_float_integer_year():
+    # F2: year_to dạng float nguyên (2026.0) vẫn nhận; float lẻ thì loại.
+    assert _thcs_grade9_completion_year([{"grade_to": 9, "year_to": 2026.0}]) == 2026
+    assert _thcs_grade9_completion_year([{"grade_to": 9, "year_to": 2026.5}]) is None
+
+
+def test_coerce_year_accepts_int_float_integer_string():
+    assert _coerce_year(2026) == 2026
+    assert _coerce_year(2026.0) == 2026
+    assert _coerce_year("2026") == 2026
+    assert _coerce_year(2026.5) is None
+    assert _coerce_year(True) is None  # bool KHÔNG phải năm
+    assert _coerce_year(float("nan")) is None
+    assert _coerce_year(float("inf")) is None

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/priority/PriorityInputsSection.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/priority/PriorityInputsSection.tsx
@@ -42,8 +42,11 @@ import type { AdmissionProfileUpdateInput } from "@/lib/zod/admissions"
 
 // Mirror BE app/services/priority_service.py _derive_kv_basis_level enum.
 const CULTURAL_OPTIONS = [
-  { value: "completed_thcs",  label: "Hoàn thành chương trình THCS (chưa tốt nghiệp)" },
-  { value: "graduated_thcs",  label: "Tốt nghiệp THCS" },
+  // THCS: từ NH 2025-2026 (Thông tư 10/2026) không còn cấp Bằng TN THCS, thay
+  // bằng xác nhận hoàn thành chương trình trong học bạ. Nhãn tránh "(chưa tốt
+  // nghiệp)" (gây hiểu nhầm là trượt) → phân biệt rõ "có bằng" vs "không cấp bằng".
+  { value: "completed_thcs",  label: "Hoàn thành chương trình THCS (không cấp bằng TN)" },
+  { value: "graduated_thcs",  label: "Tốt nghiệp THCS (có bằng)" },
   { value: "completed_thpt",  label: "Hoàn thành chương trình THPT (chưa tốt nghiệp)" },
   { value: "graduated_thpt",  label: "Tốt nghiệp THPT" },
   { value: "graduated_gdtx",  label: "Tốt nghiệp GDTX (Giáo dục thường xuyên cấp 3)" },

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/useSubmissionReadiness.test.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/useSubmissionReadiness.test.ts
@@ -496,3 +496,91 @@ describe("useSubmissionReadiness — data consistency (eligible but warnings)", 
     expect(r.documentTone).toBe("warning")
   })
 })
+
+describe("useSubmissionReadiness — THCS diploma review warning (Thông tư 10/2026)", () => {
+  const thcsExecSummary = () => ({
+    overall_status: "warning" as const,
+    completion_percent: 100,
+    step_summary: {},
+    critical_blockers: [],
+    warnings: [
+      {
+        code: "thcs_diploma_review",
+        message:
+          "Hoàn thành lớp 9 năm 2026, có thể thuộc diện áp dụng quy định " +
+          "từ 15/04/2026...",
+        step: 4,
+        section: "priority",
+        severity: "warning" as const,
+      },
+    ],
+    next_action: "Kiểm tra trình độ văn hóa đã chọn",
+    can_submit: true,
+  })
+
+  function withThcsWarning(
+    overrides: Partial<AdmissionProfileResponse> = {},
+  ): AdmissionProfileResponse {
+    return buildProfile({
+      cultural_education_level: "graduated_thcs",
+      executive_summary: thcsExecSummary(),
+      ...overrides,
+    } as Partial<AdmissionProfileResponse>)
+  }
+
+  it("warning step 4 → ActionItem step 4 (warning) + verdict 'Còn cảnh báo', submit KHÔNG bị chặn", () => {
+    const r = run(buildParams({ profile: withThcsWarning(), canSubmit: true, isEligible: true }))
+
+    // 1. executive_summary.warnings được route thành ActionItem Step 4 (warning).
+    const item = r.actionItems.find((i) => i.id === "thcs_diploma_review")
+    expect(item).toBeDefined()
+    expect(item?.step).toBe(4)
+    expect(item?.severity).toBe("warning")
+    expect(r.actionItemCount).toBeGreaterThan(0)
+
+    // 2. Verdict đổi thành "Còn cảnh báo" (warning) — KHÔNG còn success.
+    expect(r.verdictLabel).toBe("Còn cảnh báo")
+    expect(r.verdictTone).toBe("warning")
+
+    // 3. QUAN TRỌNG: cảnh báo KHÔNG chặn submit — primaryAction giữ "submit".
+    expect(r.primaryAction).toBe("submit")
+  })
+
+  it("không có cảnh báo THCS → verdict 'Có thể nộp' (success) [đối chứng]", () => {
+    const r = run(buildParams({ canSubmit: true, isEligible: true }))
+    expect(r.primaryAction).toBe("submit")
+    expect(r.verdictLabel).toBe("Có thể nộp")
+    expect(r.verdictTone).toBe("success")
+    expect(r.actionItems.find((i) => i.id === "thcs_diploma_review")).toBeUndefined()
+  })
+
+  // Blocker: warning THCS (Step 4) KHÔNG được che derivePriorityIssues (cũng Step
+  // 4 nhưng id="step-4"). Cả hai phải cùng hiện — dedupe theo id, không theo step.
+  it("warning THCS + thiếu minh chứng UT → CẢ 2 item Step 4 (không che nhau)", () => {
+    const r = run(
+      buildParams({
+        profile: withThcsWarning({ missing_priority_evidence_codes: ["UT07"] }),
+        canSubmit: true,
+        isEligible: true,
+      }),
+    )
+    const ids = r.actionItems.map((i) => i.id)
+    expect(ids).toContain("thcs_diploma_review") // structured warning từ BE
+    expect(ids).toContain("step-4") // FE-derived (thiếu UT) — KHÔNG bị che
+  })
+
+  it("warning THCS + requires_manual_override → CẢ 2 item Step 4 (không che nhau)", () => {
+    const r = run(
+      buildParams({
+        profile: withThcsWarning({
+          priority_resolution_snapshot: { requires_manual_override: true },
+        } as Partial<AdmissionProfileResponse>),
+        canSubmit: true,
+        isEligible: true,
+      }),
+    )
+    const ids = r.actionItems.map((i) => i.id)
+    expect(ids).toContain("thcs_diploma_review")
+    expect(ids).toContain("step-4")
+  })
+})

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/useSubmissionReadiness.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/useSubmissionReadiness.ts
@@ -223,8 +223,12 @@ export function buildReadinessActionItems(
   }
 
   // Priority (Step 4) is FE-derived (derivePriorityIssues) — NEVER in
-  // executive_summary. Add once, unless a Step 4 item is already present.
-  if (!items.some((i) => i.step === 4)) {
+  // executive_summary. The BE MAY also emit a structured Step-4 warning with a
+  // DIFFERENT id (e.g. thcs_diploma_review): that must NOT suppress the
+  // FE-derived priority issues (missing UT / manual-override / unresolved KV) —
+  // they are distinct concerns and dedupe is by id (below). Guard only against
+  // re-adding the SAME FE-derived "step-4" item, not against ANY Step-4 item.
+  if (!items.some((i) => i.id === "step-4")) {
     const priorityIssues = derivePriorityIssues(profile)
     if (priorityIssues.length > 0) {
       items.push({


### PR DESCRIPTION
## Bối cảnh
Thông tư 10/2026/TT-BGDĐT bỏ cấp **Bằng tốt nghiệp THCS** từ 15/04/2026 (thay bằng xác nhận hoàn thành chương trình trong học bạ). Hệ thống đã tự loại bằng TN THCS cho `completed_thcs`, nhưng officer có thể chọn nhầm `graduated_thcs` (vẫn yêu cầu bằng) cho học sinh diện mới. Audit prod 06-15 phát hiện hồ sơ TS2026 đầu vào THCS dùng lẫn 2 nhãn.

## Thay đổi
- **BE — cảnh báo MỀM** (không chặn submit): khi `cultural=='graduated_thcs'` AND năm hoàn thành lớp 9 ≥ ngưỡng cấu hình (mặc định 2026) → thêm warning `thcs_diploma_review` vào `executive_summary` để officer rà soát nhãn.
  - Năm lớp 9 suy từ `academic_history`: `grade_to==9` **HOẶC** `level=='THCS'` (officer điền 1 trong 2; loại `THCS_THPT`).
  - Parser an toàn: `_strict_int` (loại bool/float/non-ASCII/overlong, không raise) + `_coerce_year` (year nhận float nguyên) + guard 1900..2100.
  - Hằng số `THCS_DIPLOMA_REVIEW_FROM_GRADE9_YEAR` (config — nguồn năm duy nhất); message tham chiếu số Thông tư (không hardcode ngày).
- **FE — nhãn**: `completed_thcs` "(chưa tốt nghiệp)" → "(không cấp bằng TN)"; `graduated_thcs` +"(có bằng)". Giữ nguyên THPT/GDTX.
- **FE — dedupe Step 4 theo `id`** (không theo `step`): warning THCS KHÔNG che `derivePriorityIssues` (thiếu minh chứng UT / manual-override / KV chưa resolve).

## Test & verify
- BE: 20 unit + 1 integration projection (qua endpoint — chứng minh field profile → warning; `can_submit` 2026 vs 2020 không đổi). flake8 net-zero.
- FE: type-check 0, vitest 38/38, lint 0 errors.
- **Chrome smoke hồ sơ disposable** (dev): cảnh báo render đúng Step 8 + nhãn mới Step 4; `can_submit` không bị warning chặn; disposable đã xóa.
- Không migration, không đổi schema. Rủi ro thấp (additive transient field).

## Nợ follow-up (defer — không ảnh hưởng hành vi)
- **F3**: gộp parser `academic_history` dùng chung với `priority_service` (hiện 2 chuẩn parse).
- **F4**: dời logic THCS-diploma sang `document_resolution_service.py` (cạnh `_COMPLETED_DIPLOMA_TO_REMOVE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)