### PR TITLE
feat(leads): chống gian lận officer sửa SĐT/nguồn/CTV lead auto-assign

### DIFF
--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -717,7 +717,11 @@ async def update_existing_lead(
     current_user: models.User = CasbinAuth,  # <<< LẤY USER TỪ DEPENDENCY
     db: AsyncSession = Depends(database.get_db),
 ):
-    """Cập nhật một Lead (chỉ Admin/Manager)."""
+    """Cập nhật một Lead.
+
+    Quyền: Admin/Manager sửa lead theo scope; Officer chỉ sửa lead ĐƯỢC PHÂN
+    cho mình (enforced ở lead_service.update_lead + IDOR tại LeadAccessDep).
+    """
     # <<< SỬA Ở ĐÂY: Truyền current_user vào service >>>
 
     # Track which fields are being updated

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -149,6 +149,30 @@ class AdmissionProfileShallow(BaseModel):
 # -----------------
 
 
+def _validate_lead_source(v: Optional[str]) -> Optional[str]:
+    """Chặn giá trị ``source`` ngoài ``LeadSourceEnum`` (chống officer SỬA nguồn
+    rác / thổi attribution — xem Documents/LEAD_ANTIFRAUD_PLAN.md §5.2).
+
+    CỐ Ý chỉ áp cho ``LeadUpdate`` (đường officer chỉnh sửa lead). KHÔNG gắn lên
+    ``LeadBase`` (vì response schema ``Lead``/``LeadDetail`` kế thừa → sẽ raise
+    500 khi đọc lead legacy có source ngoài enum) và KHÔNG gắn lên ``LeadCreate``
+    (vì bulk-import dựng ``LeadCreate`` → sẽ chặn nhãn nguồn tự do trong file).
+
+    Lazy-import enum để tránh circular import schemas <-> models (cùng pattern
+    với ``phone_helpers`` đã dùng trong file này).
+    """
+    if v is None:
+        return v
+    from app.models.lead import LeadSourceEnum
+
+    allowed = {e.value for e in LeadSourceEnum}
+    if v not in allowed:
+        raise ValueError(
+            "Nguồn không hợp lệ. Giá trị cho phép: " + ", ".join(sorted(allowed))
+        )
+    return v
+
+
 class LeadBase(BaseModel):
     # ✅ SỬA: Thêm validation cho tất cả các trường string
     full_name: str = Field(..., min_length=1, max_length=255, strip_whitespace=True)
@@ -324,6 +348,12 @@ class LeadUpdate(BaseModel):
             )
 
         return normalized
+
+    @field_validator("source")
+    @classmethod
+    def _check_source(cls, v):
+        """Chống nhập nguồn rác (chỉ chấp nhận LeadSourceEnum)."""
+        return _validate_lead_source(v)
 
     @model_validator(mode="after")
     def phone2_must_differ_from_phone(self):

--- a/Backend_FastAPI/app/scripts/audit_lead_fraud_signals.py
+++ b/Backend_FastAPI/app/scripts/audit_lead_fraud_signals.py
@@ -1,0 +1,242 @@
+# app/scripts/audit_lead_fraud_signals.py
+"""Giám sát tín hiệu gian lận của officer trên lead được phân phối tự động —
+SĐT / nguồn / CTV. Read-only. Xem Documents/LEAD_ANTIFRAUD_PLAN.md §6.2.
+
+Bối cảnh: officer có quyền sửa lead được-phân-cho-mình (PUT /api/leads/{id}).
+3 vector:
+
+  V1 (hoa hồng CTV khống) — officer gán referrer_id (CTV do CHÍNH mình quản lý)
+     / đổi source sang 'referral' SAU khi lead đã auto-assign → CTV ăn hoa hồng
+     khống. Tín hiệu MẠNH = có audit action='flagged' hoặc đổi source→referral
+     trên lead mà CTV thuộc officer giữ lead. (referral-gốc, gán lúc tạo = bình
+     thường, KHÔNG cờ.)
+  V2 (bắt cóc SĐT) — officer đổi 'phone' nhiều lần; hoặc gom cùng 1 SĐT mới cho
+     >1 lead (kéo khách về 1 số). Gom số = tín hiệu MẠNH.
+  V3 (thổi nguồn) — officer đổi 'source' hàng loạt / sang 'referral' (thổi
+     lead_score). Tín hiệu YẾU (chỉ để soát, không tính exit code).
+
+Chạy:
+    docker compose exec backend python -m app.scripts.audit_lead_fraud_signals
+    # one-off: docker compose run --rm --no-deps backend \
+    #     python -m app.scripts.audit_lead_fraud_signals
+
+Exit code: 0 nếu không có tín hiệu MẠNH (V1 gán-sau / V2 gom số), 1 nếu có.
+Dùng được làm cổng cron/alert hoặc chạy trước mỗi kỳ chốt hoa hồng.
+
+SĐT được mask (app.utils.masking.mask_phone — chỉ hiện 4 số cuối) trong output.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from sqlalchemy import text
+
+from app.database import AsyncSessionLocal
+from app.utils.masking import mask_phone
+
+# === Ngưỡng giám sát (quyết định mở — tinh chỉnh theo baseline, plan §10) ===
+WINDOW_DAYS = 30          # cửa sổ đếm đổi SĐT
+PHONE_CHANGE_THRESHOLD = 3  # officer đổi 'phone' >= N lần / cửa sổ → đáng chú ý
+
+
+# V1: lead có referrer_id mà CTV do CHÍNH officer giữ lead quản lý, kèm dấu hiệu
+# "gán sau" (audit flagged HOẶC từng đổi source→referral). source_at_create
+# không có trong audit → dùng has_flag/source_changed_to_referral để phân biệt.
+_V1_SQL = text(
+    """
+    SELECT l.id AS lead_id,
+           uo.username AS officer,
+           l.referrer_id AS ctv_id,
+           l.source, l.validity_status, l.status,
+           EXISTS (SELECT 1 FROM entity_audit_log a
+                   WHERE a.entity_type='Lead' AND a.entity_id=l.id
+                     AND a.action='flagged') AS has_flag,
+           EXISTS (SELECT 1 FROM entity_audit_log a
+                   WHERE a.entity_type='Lead' AND a.entity_id=l.id
+                     AND a.action='updated'
+                     AND a.changes->'source'->>'new'='referral') AS src_to_referral
+    FROM lead l
+    JOIN collaborator c ON c.id = l.referrer_id
+    LEFT JOIN "user" uo ON uo.id = l.assigned_officer_id
+    WHERE l.referrer_id IS NOT NULL AND l.deleted_at IS NULL
+      AND (
+        -- CTV thuộc officer ĐANG giữ lead (còn assigned)
+        c.managed_by_officer_id = l.assigned_officer_id
+        -- HOẶC lead từng bị cờ (soft-warn) — bắt cả case officer "rút ruột" rồi
+        -- offering-change reset assigned_officer_id=NULL (so sánh '=NULL' luôn false).
+        OR EXISTS (SELECT 1 FROM entity_audit_log a
+                   WHERE a.entity_type='Lead' AND a.entity_id=l.id
+                     AND a.action='flagged')
+      )
+    ORDER BY has_flag DESC, src_to_referral DESC, l.id
+    """
+)
+
+# V1b: hoa hồng đã phát sinh cho CTV do MỘT officer quản lý (mất tiền thật).
+# JOIN theo cr.collaborator_id (CTV THỰC nhận hoa hồng), KHÔNG theo l.referrer_id
+# hiện tại — nếu không sẽ bỏ sót case officer gán CTV → commission fires → officer
+# revert referrer về NULL/CTV khác (lúc đó l.referrer_id không còn khớp).
+_V1_COMMISSION_SQL = text(
+    """
+    SELECT cr.lead_id, cr.collaborator_id, cr.amount, cr.status,
+           cr.created_at::date AS d,
+           c.managed_by_officer_id AS ctv_officer,
+           l.assigned_officer_id AS lead_officer
+    FROM commission_record cr
+    JOIN collaborator c ON c.id = cr.collaborator_id
+    LEFT JOIN lead l ON l.id = cr.lead_id
+    WHERE c.managed_by_officer_id IS NOT NULL
+    ORDER BY cr.created_at DESC
+    """
+)
+
+# V2a: officer đổi 'phone' >= ngưỡng trong cửa sổ.
+_V2_FREQ_SQL = text(
+    """
+    SELECT u.username,
+           count(*) AS phone_changes,
+           count(DISTINCT a.entity_id) AS leads_touched
+    FROM entity_audit_log a
+    JOIN "user" u ON u.id = a.actor_user_id
+    WHERE a.entity_type='Lead' AND a.action='updated' AND a.changes ? 'phone'
+      AND a.created_at >= now() - make_interval(days => :days)
+    GROUP BY u.username
+    HAVING count(*) >= :threshold
+    ORDER BY phone_changes DESC
+    """
+)
+
+# V2b: cùng 1 SĐT mới được gán cho >1 lead (gom khách về 1 số) — tín hiệu MẠNH.
+_V2_FANIN_SQL = text(
+    """
+    SELECT a.changes->'phone'->>'new' AS new_phone,
+           count(DISTINCT a.entity_id) AS n_leads,
+           string_agg(DISTINCT u.username, ',') AS actors
+    FROM entity_audit_log a
+    JOIN "user" u ON u.id = a.actor_user_id
+    WHERE a.entity_type='Lead' AND a.action='updated' AND a.changes ? 'phone'
+      AND a.changes->'phone'->>'new' IS NOT NULL
+    GROUP BY a.changes->'phone'->>'new'
+    HAVING count(DISTINCT a.entity_id) > 1
+    ORDER BY n_leads DESC
+    """
+)
+
+# V3: officer đổi 'source' (đặc biệt sang 'referral').
+_V3_SQL = text(
+    """
+    SELECT u.username,
+           count(*) FILTER (
+               WHERE a.changes->'source'->>'new'='referral'
+           ) AS to_referral,
+           count(*) AS source_changes
+    FROM entity_audit_log a
+    JOIN "user" u ON u.id = a.actor_user_id
+    WHERE a.entity_type='Lead' AND a.action='updated' AND a.changes ? 'source'
+    GROUP BY u.username
+    HAVING count(*) > 0
+    ORDER BY to_referral DESC, source_changes DESC
+    """
+)
+
+
+async def audit() -> int:
+    async with AsyncSessionLocal() as session:
+        v1 = (await session.execute(_V1_SQL)).mappings().all()
+        v1_comm = (await session.execute(_V1_COMMISSION_SQL)).mappings().all()
+        v2_freq = (
+            await session.execute(
+                _V2_FREQ_SQL, {"days": WINDOW_DAYS, "threshold": PHONE_CHANGE_THRESHOLD}
+            )
+        ).mappings().all()
+        v2_fanin = (await session.execute(_V2_FANIN_SQL)).mappings().all()
+        v3 = (await session.execute(_V3_SQL)).mappings().all()
+
+    strong = 0  # đếm tín hiệu MẠNH → exit code
+
+    print("=" * 64)
+    print("[V1] Hoa hồng CTV — lead có CTV do CHÍNH officer giữ lead quản lý")
+    print("=" * 64)
+    v1_suspicious = [r for r in v1 if r["has_flag"] or r["src_to_referral"]]
+    v1_legit = [r for r in v1 if not (r["has_flag"] or r["src_to_referral"])]
+    for r in v1:
+        _susp = r["has_flag"] or r["src_to_referral"]
+        tag = "[!] GÁN-SAU" if _susp else "ok(referral-gốc)"
+        print(
+            f"  lead#{r['lead_id']:<6} officer={r['officer'] or '-':<16} "
+            f"ctv#{r['ctv_id']:<4} src={r['source']:<12} "
+            f"validity={r['validity_status']:<10} "
+            f"flag={r['has_flag']} src->ref={r['src_to_referral']}  {tag}"
+        )
+    print(
+        f"  -> {len(v1_suspicious)} nghi vấn gán-sau / "
+        f"{len(v1_legit)} referral-gốc / {len(v1)} tổng"
+    )
+    strong += len(v1_suspicious)
+
+    if v1_comm:
+        print("  ⛔ COMMISSION đã phát sinh cho nhóm này (kiểm tra mất tiền):")
+        for r in v1_comm:
+            print(
+                f"     lead#{r['lead_id']} ctv#{r['collaborator_id']} "
+                f"ctv_officer={r['ctv_officer']} lead_officer={r['lead_officer']} "
+                f"amount={r['amount']} status={r['status']} {r['d']}"
+            )
+        strong += len(v1_comm)
+    else:
+        print("  (commission_record: 0 row liên quan)")
+
+    print()
+    print("=" * 64)
+    print(
+        f"[V2a] Officer đổi 'phone' >= {PHONE_CHANGE_THRESHOLD} lần "
+        f"/ {WINDOW_DAYS} ngày"
+    )
+    print("=" * 64)
+    if v2_freq:
+        for r in v2_freq:
+            print(
+                f"  {r['username']:<18} phone_changes={r['phone_changes']:<4} "
+                f"leads={r['leads_touched']}  (đáng chú ý — soát thủ công)"
+            )
+    else:
+        print("  (không có)")
+
+    print()
+    print("=" * 64)
+    print("[V2b] Gom NHIỀU lead về CÙNG 1 SĐT mới (tín hiệu MẠNH)")
+    print("=" * 64)
+    if v2_fanin:
+        for r in v2_fanin:
+            print(
+                f"  [!] {mask_phone(r['new_phone'])}  n_leads={r['n_leads']} "
+                f" actors={r['actors']}"
+            )
+        strong += len(v2_fanin)
+    else:
+        print("  (không có)")
+
+    print()
+    print("=" * 64)
+    print("[V3] Officer đổi 'source' (→referral thổi điểm — tín hiệu yếu, để soát)")
+    print("=" * 64)
+    if v3:
+        for r in v3:
+            print(
+                f"  {r['username']:<18} ->referral={r['to_referral']:<4} "
+                f"total_source_changes={r['source_changes']}"
+            )
+    else:
+        print("  (không có)")
+
+    print()
+    if strong == 0:
+        print("[audit] OK — 0 tín hiệu MẠNH (V1 gán-sau / V2 gom số).")
+        return 0
+    print(f"[audit] FAIL — {strong} tín hiệu MẠNH cần điều tra thủ công.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(audit()))

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -627,6 +627,10 @@ def _get_lead_audit_state(lead: models.Lead) -> dict:
         "consultation_status_id": lead.consultation_status_id,
         "pipeline_stage_id": lead.pipeline_stage_id,
         "assigned_officer_id": lead.assigned_officer_id,
+        # ✅ ANTIFRAUD: track referrer_id — vector hoa hồng CTV (trước là điểm mù:
+        # officer gán/đổi CTV không để dấu vết). validity_status KHÔNG track ở đây vì
+        # update_lead không đổi nó (mutation thật ở collaborator_service).
+        "referrer_id": lead.referrer_id,
     }
 
 
@@ -1572,6 +1576,58 @@ async def update_lead(
                 db_lead.referrer_id = new_referrer_id
                 if new_referrer_id is not None:
                     db_lead.source = "referral"
+
+            # =========================================================================
+            # ✅ ANTIFRAUD SOFT-WARN (V1): officer gán/đổi CTV hoặc đổi nguồn sang
+            # 'referral' trên lead của mình (mở khóa hoa hồng CTV). KHÔNG chặn — chỉ
+            # đánh dấu (audit action="flagged" + log.warning) để giám sát.
+            #   - Chỉ cần điều kiện actor là OFFICER: officer chỉ tới được đây với lead
+            #     ĐƯỢC PHÂN CHO MÌNH (đã qua permission check ở trên), nên kiểm tra
+            #     assigned_officer_id ở đây là thừa.
+            #   - Bắt MỌI thay đổi referrer sang một CTV: NULL→X *và* swap X→Y
+            #     (chuyển hướng hoa hồng), HOẶC source vừa chuyển sang 'referral'.
+            # Giám sát rộng có chủ đích (kể cả lead officer tự tạo) — false-positive chỉ
+            # là 1 dòng audit để soi, không chặn. Xem LEAD_ANTIFRAUD_PLAN.md §6.1.
+            # =========================================================================
+            if updated_by.role == UserRole.OFFICER:
+                _old_ref = old_audit_state.get("referrer_id")
+                _old_src = old_audit_state.get("source")
+                _ref_changed_to_ctv = (
+                    db_lead.referrer_id is not None
+                    and db_lead.referrer_id != _old_ref
+                )
+                _src_to_referral = (
+                    _old_src != "referral" and db_lead.source == "referral"
+                )
+                if _ref_changed_to_ctv or _src_to_referral:
+                    log.warning(
+                        "antifraud_referral_set_after_autoassign",
+                        lead_id=lead_id,
+                        actor_user_id=updated_by.id,
+                        old_referrer_id=_old_ref,
+                        new_referrer_id=db_lead.referrer_id,
+                        old_source=_old_src,
+                        new_source=db_lead.source,
+                    )
+                    await audit_service.log_audit(
+                        db,
+                        entity_type="Lead",
+                        entity_id=lead_id,
+                        action="flagged",
+                        actor_user_id=updated_by.id,
+                        reason=(
+                            "Officer gán CTV / đổi nguồn sang 'referral' trên lead đã "
+                            "được phân tự động (nghi vấn hoa hồng) — soft-warn"
+                        ),
+                        changes={
+                            "referrer_id": {
+                                "old": _old_ref,
+                                "new": db_lead.referrer_id,
+                            },
+                            "source": {"old": _old_src, "new": db_lead.source},
+                        },
+                        source="api",
+                    )
 
             # === NEW FEATURE: Auto-Reassign when Offering Changes ===
             # If offering_id changed, re-route Lead to new Unit and reset assignment

--- a/Backend_FastAPI/tests/services/test_lead_antifraud.py
+++ b/Backend_FastAPI/tests/services/test_lead_antifraud.py
@@ -1,0 +1,211 @@
+# tests/services/test_lead_antifraud.py
+"""Antifraud hardening tests — xem Documents/LEAD_ANTIFRAUD_PLAN.md.
+
+Phủ:
+- V3: validate ``source`` theo LeadSourceEnum (chống nhập nguồn rác).
+- V1/L1: audit completeness — đổi ``referrer_id`` được ghi vào entity_audit_log.
+- V1 soft-warn: officer gán CTV / đổi source->referral SAU auto-assign → audit
+  action='flagged'; admin/manager hoặc no-op thì KHÔNG flag.
+"""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models, schemas
+from app.services import lead_service
+
+
+# Patch các side-effect ngoài phạm vi test (scoring cần rules, cache cần Redis).
+def _patches():
+    return (
+        patch(
+            "app.services.lead_service.calculate_lead_score",
+            new_callable=AsyncMock,
+            return_value=50,
+        ),
+        patch(
+            "app.services.lead_cache_service.update_lead_cache",
+            new_callable=AsyncMock,
+        ),
+    )
+
+
+async def _audit_rows(db: AsyncSession, lead_id: int, action: str):
+    res = await db.execute(
+        select(models.EntityAuditLog).where(
+            models.EntityAuditLog.entity_type == "Lead",
+            models.EntityAuditLog.entity_id == lead_id,
+            models.EntityAuditLog.action == action,
+        )
+    )
+    return res.scalars().all()
+
+
+# ---------------------------------------------------------------------------
+# V3 — Source validation (pure schema, no DB)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSourceValidation:
+    def test_lead_update_rejects_unknown_source(self):
+        with pytest.raises(ValidationError):
+            schemas.LeadUpdate(source="bogus_source")
+
+    def test_lead_update_accepts_known_source_and_none(self):
+        assert schemas.LeadUpdate(source="referral").source == "referral"
+        assert schemas.LeadUpdate().source is None  # không truyền source
+
+    def test_lead_create_allows_freeform_source(self):
+        """CỐ Ý không siết create/import (tránh vỡ bulk-import) — chỉ siết edit (#2)."""
+        obj = schemas.LeadCreate(full_name="X", phone="0901234567", source="facebook")
+        assert obj.source == "facebook"
+
+    def test_lead_create_accepts_known_source(self):
+        obj = schemas.LeadCreate(full_name="X", phone="0901234567", source="website")
+        assert obj.source == "website"
+
+    def test_response_schema_accepts_legacy_source(self):
+        """Đọc lead source legacy ngoài enum KHÔNG được raise (regression #1)."""
+        from datetime import datetime
+
+        common = dict(
+            id=1, full_name="X", phone="0901234567", source="facebook",
+            status="new", lead_score=0,
+            created_at=datetime(2026, 1, 1), updated_at=datetime(2026, 1, 1),
+        )
+        assert schemas.Lead(**common).source == "facebook"
+        assert schemas.LeadDetail(**common).source == "facebook"
+
+
+# ---------------------------------------------------------------------------
+# V1 / L1 — Audit completeness cho referrer_id
+# ---------------------------------------------------------------------------
+@pytest.mark.integration
+class TestReferrerAuditCompleteness:
+    async def test_referrer_change_is_audited(
+        self, db, seeded_dependencies, officer_user, active_collaborator, seeded_lead
+    ):
+        """Đổi referrer_id phải xuất hiện trong changes của audit 'updated'."""
+        lead_in = schemas.LeadUpdate(referrer_id=active_collaborator.id)
+        p_score, p_cache = _patches()
+        with p_score, p_cache:
+            result, cb = await lead_service.update_lead(
+                db, seeded_lead.id, lead_in, updated_by=officer_user
+            )
+            await db.commit()
+            if cb:
+                await cb()
+
+        assert result.referrer_id == active_collaborator.id
+        rows = await _audit_rows(db, seeded_lead.id, "updated")
+        assert any(r.changes and "referrer_id" in r.changes for r in rows), (
+            "referrer_id phải được ghi vào entity_audit_log (bịt điểm mù L1)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# V1 — Soft-warn flag
+# ---------------------------------------------------------------------------
+@pytest.mark.integration
+class TestSoftWarnReferralAfterAutoassign:
+    async def test_officer_assigns_ctv_after_autoassign_is_flagged(
+        self, db, seeded_dependencies, officer_user, active_collaborator, seeded_lead
+    ):
+        """Officer gán CTV trên lead đã auto-assign → audit action='flagged'."""
+        lead_in = schemas.LeadUpdate(referrer_id=active_collaborator.id)
+        p_score, p_cache = _patches()
+        with p_score, p_cache:
+            _, cb = await lead_service.update_lead(
+                db, seeded_lead.id, lead_in, updated_by=officer_user
+            )
+            await db.commit()
+            if cb:
+                await cb()
+
+        flagged = await _audit_rows(db, seeded_lead.id, "flagged")
+        assert len(flagged) == 1
+        assert flagged[0].actor_user_id == officer_user.id
+
+    async def test_officer_swaps_referrer_is_flagged(
+        self, db, seeded_dependencies, officer_user, active_collaborator, seeded_lead
+    ):
+        """Officer đổi referrer A→B (CTV khác của mình) — swap phải bị flag (#3)."""
+        from datetime import datetime, timezone
+
+        ctv_b = models.Collaborator(
+            code="CTV-SWAP-B", full_name="CTV B", phone="0911777888",
+            status="active", unit_id=seeded_dependencies["unit_id"],
+            managed_by_officer_id=officer_user.id,
+            approved_at=datetime.now(timezone.utc),
+        )
+        db.add(ctv_b)
+        # Lead đã có referrer A + source 'referral' từ trước.
+        seeded_lead.referrer_id = active_collaborator.id
+        seeded_lead.source = "referral"
+        await db.flush()
+
+        lead_in = schemas.LeadUpdate(referrer_id=ctv_b.id)
+        p_score, p_cache = _patches()
+        with p_score, p_cache:
+            _, cb = await lead_service.update_lead(
+                db, seeded_lead.id, lead_in, updated_by=officer_user
+            )
+            await db.commit()
+            if cb:
+                await cb()
+
+        flagged = await _audit_rows(db, seeded_lead.id, "flagged")
+        assert len(flagged) == 1
+
+    async def test_officer_changes_source_to_referral_is_flagged(
+        self, db, seeded_dependencies, officer_user, seeded_lead
+    ):
+        """Officer đổi source sang 'referral' (không referrer) → flagged."""
+        lead_in = schemas.LeadUpdate(source="referral")
+        p_score, p_cache = _patches()
+        with p_score, p_cache:
+            _, cb = await lead_service.update_lead(
+                db, seeded_lead.id, lead_in, updated_by=officer_user
+            )
+            await db.commit()
+            if cb:
+                await cb()
+
+        flagged = await _audit_rows(db, seeded_lead.id, "flagged")
+        assert len(flagged) == 1
+
+    async def test_admin_assigns_ctv_is_not_flagged(
+        self, db, seeded_dependencies, admin_user, active_collaborator, seeded_lead
+    ):
+        """Admin gán CTV → KHÔNG flag (chỉ officer mới bị soft-warn)."""
+        lead_in = schemas.LeadUpdate(referrer_id=active_collaborator.id)
+        p_score, p_cache = _patches()
+        with p_score, p_cache:
+            _, cb = await lead_service.update_lead(
+                db, seeded_lead.id, lead_in, updated_by=admin_user
+            )
+            await db.commit()
+            if cb:
+                await cb()
+
+        flagged = await _audit_rows(db, seeded_lead.id, "flagged")
+        assert len(flagged) == 0
+
+    async def test_officer_noop_update_is_not_flagged(
+        self, db, seeded_dependencies, officer_user, seeded_lead
+    ):
+        """Officer cập nhật field thường (không referrer/source) → KHÔNG flag."""
+        lead_in = schemas.LeadUpdate(full_name="Đổi Tên Khách")
+        p_score, p_cache = _patches()
+        with p_score, p_cache:
+            _, cb = await lead_service.update_lead(
+                db, seeded_lead.id, lead_in, updated_by=officer_user
+            )
+            await db.commit()
+            if cb:
+                await cb()
+
+        flagged = await _audit_rows(db, seeded_lead.id, "flagged")
+        assert len(flagged) == 0

--- a/Documents/LEAD_ANTIFRAUD_PLAN.md
+++ b/Documents/LEAD_ANTIFRAUD_PLAN.md
@@ -1,0 +1,161 @@
+# KẾ HOẠCH CHỐNG GIAN LẬN LEAD — SĐT / NGUỒN / CTV
+
+> Hardening sau điều tra "officer gian lận sửa SĐT/nguồn của lead được phân phối tự động".
+> Soạn: 2026-06-16. Trạng thái: **PLAN — chưa code.**
+
+---
+
+## 0. TL;DR
+
+- Điều tra toàn diện 3 vector gian lận (V1 hoa hồng CTV, V2 bắt cóc SĐT, V3 thổi nguồn).
+- **Truy vết prod (read-only) ngày 2026-06-16: KHÔNG tìm thấy bằng chứng gian lận gây hại.**
+  `commission_record` trống 100%; không có SĐT bị gom; 4 lead referrer đều hợp lệ từ lúc tạo.
+- **Nhưng 3 lỗ hổng cấu trúc vẫn còn nguyên** → khắc phục phòng ngừa, **ưu tiên làm TRƯỚC khi module commission đi vào hoạt động**.
+- Hướng đã chốt: **V1 = soft-warn + audit đầy đủ**, **V2 = audit + giám sát** (đều nhẹ, hợp solo-dev).
+- Khối lượng: **2 PR** (~2.5–3.5 ngày). PR-1 (P0) độc lập, ship ngay.
+
+---
+
+## 1. Kết quả điều tra prod (bằng chứng nền)
+
+Truy vết qua SSH `qlts_production` (read-only, mask PII), 2026-06-16:
+
+| Vector | Phát hiện | Kết luận |
+|--------|-----------|----------|
+| **V1 — Hoa hồng CTV khống** | `commission_record` **0 row** toàn hệ thống. 4 lead có `referrer_id` (67,90,91,93) đều `n_updates=0` (referrer gắn lúc tạo, không sửa sau) — đúng luồng smart-referral fast-path. | ✅ Sạch / chưa khai thác |
+| **V2 — Bắt cóc SĐT** | 15 lần đổi `phone` + 43 lần đổi `phone2`, mỗi officer trên lead của mình. **Không SĐT nào bị gom cho >1 lead.** | ✅ Không dấu hiệu |
+| **V3 — Đổi nguồn** | 35 lần đổi `source`; `ksorhohon` 24 lần/1 ngày (website→social/other, giống dọn data); vài lần →referral **không kèm referrer_id** (không trigger hoa hồng). | 🟡 Bất thường nhẹ, không ra tiền |
+
+**Giới hạn:** vì `referrer_id` **không** nằm trong audit log, không thể loại trừ 100% kịch bản "gán CTV rồi gỡ" trong quá khứ — nhưng `commission_record` trống là bằng chứng mạnh chưa có thiệt hại.
+
+---
+
+## 2. Mô hình đe dọa & lỗ hổng cấu trúc
+
+Officer được phân lead tự động có quyền `PUT /api/leads/{id}` (Casbin `policy_templates.py:120`) và sửa lead **được phân cho mình** (`lead_service.py:1325-1329`). Các lỗ hổng:
+
+| # | Lỗ hổng | Vị trí | Hệ quả |
+|---|---------|--------|--------|
+| L1 | `referrer_id` **không** có trong snapshot audit | `lead_service.py:614-630` (`_get_lead_audit_state`) | Gán/đổi CTV **không để lại dấu vết** → gian lận hoa hồng vô hình |
+| L2 | Officer tự gán `referrer_id` sau auto-assign; tự động set `source='referral'` | `lead_service.py:1556-1574` | Mở khóa dòng tiền hoa hồng cho CTV đồng phạm (commission trigger theo `referrer_id`) |
+| L3 | `source` **không** validate theo enum | `schemas/lead.py:257`; `models/lead.py:99` (String(50)) | Nhập nguồn tùy ý; đổi →`referral` thổi `lead_score` (referral=30đ) |
+| L4 | Đổi `phone` tự do trên lead active (chỉ chặn ở trạng thái terminal sts20) | `lead_service.py:1389-1404` | Bắt cóc/cô lập lead; lan sang AdmissionProfile (sync `:1699-1715`) |
+| L5 | Docstring sai sự thật "chỉ Admin/Manager" | `routers/leads.py:720` | Hiểu nhầm bề mặt tấn công |
+
+**Đã loại trừ (không phải lỗ hổng):** đổi `consultation_status_id`/`pipeline_stage_id` (chặn cứng `:1549-1553`); đổi `assigned_officer_id` (ngoài whitelist `:78-97`); tự gọi `/assign` (Casbin manager-only).
+
+---
+
+## 3. Quyết định thiết kế (đã chốt với user)
+
+- **V1 (CTV/nguồn → hoa hồng): Soft-warn + audit đầy đủ.** Không đổi workflow officer; vá điểm mù audit + đánh dấu đậm hành vi nhạy cảm để giám sát.
+- **V2 (SĐT): Audit + giám sát.** Giữ quyền sửa; tận dụng audit sẵn có + thêm phát hiện bất thường + (FE) lịch sử SĐT.
+- **V3 (nguồn): Validate enum.** Chặn giá trị rác (gộp vào PR-1).
+- Nguyên tắc xuyên suốt: **không thêm `SystemEvents` mới** (theo `Backend_FastAPI/CLAUDE.md` — tốn catalog+rule row); cảnh báo đi qua **audit log + script giám sát**, realtime-notify để defer.
+
+---
+
+## 4. Phạm vi & thứ tự PR
+
+| PR | Nội dung | Ưu tiên | Ước tính | Phụ thuộc |
+|----|----------|---------|----------|-----------|
+| **PR-1** | Audit completeness + validate `source` + sửa docstring | **P0** | ~1 ngày | độc lập, ship trước |
+| **PR-2** | Soft-warn V1 (flag hành vi nhạy cảm) + script giám sát V1/V2/V3 | P1 | ~1.5–2 ngày | sau PR-1 |
+| (opt) | FE: hiển thị "Lịch sử SĐT" của lead (đọc audit-logs) | P2 | ~0.5 ngày | sau PR-1 |
+
+> Có thể gộp PR-1+PR-2 thành 1 PR (giảm overhead CI, theo `solo-dev-batch-prs`) — nhưng PR-1 đủ giá trị độc lập và **nên ship gấp trước khi bật commission**, nên tách là hợp lý.
+
+---
+
+## 5. PR-1 (P0) — Audit completeness + validate source + docstring
+
+**Mục tiêu:** mọi thay đổi `referrer_id` để lại dấu vết; chặn nguồn rác; sửa tài liệu sai. Rẻ, không đổi nghiệp vụ.
+
+### 5.1 Bịt điểm mù audit (L1)
+`lead_service.py:614-630` — thêm field vào `_get_lead_audit_state()`:
+```python
+"referrer_id": lead.referrer_id,          # ← BẮT BUỘC (vector hoa hồng)
+"validity_status": lead.validity_status,  # ← hữu ích: commission gate theo validity
+# lead_score / is_hot_lead: KHÔNG thêm (derived, gây audit noise mỗi lần đổi gpa/source)
+```
+→ Tự động: thay đổi `referrer_id` sẽ vào `changes` JSONB của audit "updated" hiện có (`:1724-1740`), không cần code thêm.
+
+### 5.2 Validate `source` theo enum (L3)
+`schemas/lead.py` — `LeadUpdate.source` (line 257) **và** `LeadCreate.source`: thêm validator reject giá trị ngoài `LeadSourceEnum` (`models/lead.py:48-57`). Reuse enum, không hardcode:
+```python
+@field_validator("source")
+@classmethod
+def validate_source(cls, v):
+    if v is None: return v
+    allowed = {e.value for e in LeadSourceEnum}
+    if v not in allowed:
+        raise ValueError(f"Nguồn không hợp lệ. Cho phép: {', '.join(sorted(allowed))}")
+    return v
+```
+> Lưu ý: kiểm tra dữ liệu prod hiện có giá trị `source` nào ngoài enum không trước khi siết (tránh vỡ lead cũ). Truy vết đã thấy toàn giá trị enum hợp lệ — nhưng xác nhận lại bằng `SELECT DISTINCT source FROM lead`.
+
+### 5.3 Sửa docstring sai (L5)
+`routers/leads.py:720` — `"""Cập nhật một Lead (chỉ Admin/Manager)."""` → mô tả đúng: officer sửa được lead **được phân cho mình**; Admin/Manager sửa theo scope.
+
+### 5.4 Test PR-1
+- Unit: update `referrer_id` → có row `entity_audit_log` với key `referrer_id` trong `changes`.
+- Unit: `source` ngoài enum → `ValidationError` (400).
+- Regression: cập nhật lead bình thường vẫn pass; audit vẫn ghi phone/source như cũ.
+
+---
+
+## 6. PR-2 (P1) — Soft-warn V1 + script giám sát
+
+**Mục tiêu:** đánh dấu đậm hành vi nhạy cảm (không chặn) + công cụ phát hiện bất thường định kỳ.
+
+### 6.1 Soft-warn khi officer "mở khóa hoa hồng" sau auto-assign (L2)
+Trong `update_lead`, sau khối xử lý `referrer_id` (`lead_service.py:1556-1574`), thêm phát hiện hành vi nhạy cảm:
+- Điều kiện cờ: actor là **officer** (`updated_by.role == OFFICER`) **và** lead **đã auto-assign** (`db_lead.assigned_officer_id` set từ trước) **và** (`referrer_id` chuyển `NULL→X` **hoặc** `source` chuyển sang `'referral'`).
+- Hành động (soft, không raise):
+  1. `log.warning("lead_referral_set_after_autoassign", lead_id, actor_id, old_referrer, new_referrer, old_source, new_source)`.
+  2. Ghi 1 audit entry **đánh dấu** qua `audit_service.log_audit(..., action="flagged", reason="referrer/source set sau auto-assign", source="api")` (cột `reason` + `action` đã có — `audit_service.py:62-117`).
+- **Không** chặn thao tác (đúng quyết định soft-warn).
+
+### 6.2 Script giám sát (pattern `app/scripts/audit_*.py`, ref PR #397)
+Tạo `app/scripts/audit_lead_fraud_signals.py` — chạy tay / cron nhẹ, in báo cáo (mask PII):
+- **V1:** lead có `referrer_id` mà CTV `managed_by_officer_id == assigned_officer_id` **VÀ** có audit `flagged`/đổi `source→referral` (phân biệt gán-sau vs referral-gốc); đối chiếu `commission_record` nếu có.
+- **V2:** officer đổi `phone`/`phone2` ≥ N lần / cửa sổ thời gian; cùng 1 `phone_new` cho >1 lead (gom số).
+- **V3:** officer đổi `source` hàng loạt; tỉ lệ →`referral` cao.
+- Output: bảng `actor → tín hiệu → số lần`, kèm `lead_id` để soát thủ công.
+
+### 6.3 Test PR-2
+- Unit: officer set `referrer_id` trên lead đã assign → có audit `action="flagged"` + log.warning; thao tác vẫn thành công (không 4xx).
+- Unit: admin/manager làm điều tương tự → **không** flag (chỉ officer).
+- Script: seed vài lead/audit giả → script in đúng tín hiệu.
+
+---
+
+## 7. (Optional, P2) FE — Lịch sử SĐT
+
+Endpoint `/api/leads/{id}/audit-logs` đã tồn tại + officer có quyền GET (`policy_templates.py:130`). FE thêm mục "Lịch sử số điện thoại" trong timeline/detail lead: lọc audit có key `phone`/`phone2` trong `changes`, hiển thị `cũ → mới`, ai sửa, khi nào. Tăng khả năng tự-soát, răn đe. Defer nếu cần ship nhanh.
+
+---
+
+## 8. Rollout & verify
+
+1. PR-1 merge + deploy (no migration, code-only) → **làm trước khi bật bất kỳ `commission_policy` nào.**
+2. Sau deploy PR-1: smoke — officer đổi `referrer_id` 1 lead dev → xác nhận audit có `referrer_id`; thử `source="xxx"` → bị reject.
+3. PR-2 merge + deploy → chạy `audit_lead_fraud_signals.py` trên prod (read-only) làm baseline.
+4. Lịch giám sát: chạy script định kỳ (vd tuần/lần) hoặc trước mỗi kỳ chốt hoa hồng.
+
+---
+
+## 9. Out of scope / defer
+
+- **Maker-checker gán CTV** (đã cân nhắc, user chọn soft-warn) — để dành nếu tương lai phát hiện lạm dụng thật.
+- **Khóa/maker-checker đổi SĐT theo trạng thái** (V2 mức cao) — defer; hiện chỉ audit + giám sát.
+- **Realtime notify manager** khi có cờ — defer (tránh thêm `SystemEvents`); dùng script giám sát trước.
+- **Backfill audit lịch sử `referrer_id`** quá khứ — không khả thi (dữ liệu không tồn tại); chấp nhận điểm mù lịch sử, chỉ vá từ nay.
+
+---
+
+## 10. Quyết định mở (cần xác nhận khi code)
+
+1. **Ngưỡng giám sát V2/V3** (N lần đổi / cửa sổ) — đề xuất mặc định: phone ≥3 lần/30 ngày, source→referral bất kỳ lần nào sau auto-assign. Tinh chỉnh theo baseline thật.
+2. **Thêm `lead_score`/`is_hot_lead` vào audit?** — mặc định KHÔNG (noise). Bật nếu muốn truy vết thổi điểm chi tiết.
+3. **Gộp PR-1+PR-2 hay tách?** — đề xuất tách (PR-1 ship gấp trước commission).


### PR DESCRIPTION
## Bối cảnh
Officer được phân lead tự động có thể sửa SĐT/nguồn/CTV của lead để trục lợi (hoa hồng CTV khống, bắt cóc/cô lập lead, thổi lead_score). Truy vết prod 2026-06-16 (read-only): **chưa bị khai thác** (`commission_record` trống) nhưng còn lỗ hổng cấu trúc → vá phòng ngừa **trước khi bật `commission_policy`**.

## Thay đổi
**Audit — bịt điểm mù vector hoa hồng**
- Thêm `referrer_id` vào `_get_lead_audit_state` → đổi CTV nay để lại dấu vết trong `entity_audit_log`.

**Soft-warn V1 (không chặn, chỉ giám sát)**
- Officer gán/đổi CTV (gồm swap X→Y) hoặc đổi `source→referral` trên lead của mình → audit `action="flagged"` + `log.warning`.

**Validate nguồn (V3)**
- `source` validate theo `LeadSourceEnum` **chỉ trên `LeadUpdate`** — cố ý KHÔNG trên `LeadBase` (response schema kế thừa → 500 khi đọc data legacy) và KHÔNG trên `LeadCreate` (bulk-import dùng nhãn tự do).

**Giám sát**
- `app/scripts/audit_lead_fraud_signals.py` — script read-only phát hiện tín hiệu V1/V2/V3; exit-code làm cổng cron/alert; chạy trước mỗi kỳ chốt hoa hồng.

**Khác**: fix docstring `PUT /leads` sai "chỉ Admin/Manager".

## Self-review (`/code-review max`)
10 finder + verify + sweep → bắt & sửa 6 finding, gồm **1 CRITICAL**: validator đặt trên `LeadBase` rò sang response schema → HTTP 500 khi đọc lead có `source` legacy. Đã sửa + thêm regression test.

## Verify
- flake8 sạch (file mới 0 lỗi, file sửa net-zero lỗi mới)
- script giám sát chạy thật (read-only) exit 0
- **67 + 11 pytest PASS** (`test_lead_antifraud`, `test_lead_filters_api`, `test_leads_crud`, `test_create_lead_referral`, `test_lead_assignment_api`) — gồm guard #1 end-to-end
- **No migration** → deploy an toàn

## Defer (post-launch)
double-audit-row, household-phone false-positive, no-time-window cho V2b/V3, source-enum-typing, GIN index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)