### PR TITLE
feat(admissions): học phí trả trước + nợ giấy tờ (fast-track giữ chỗ)

### DIFF
--- a/Backend_FastAPI/alembic/versions/docdebt01_20260616_add_document_debt_to_admission_profile.py
+++ b/Backend_FastAPI/alembic/versions/docdebt01_20260616_add_document_debt_to_admission_profile.py
@@ -1,0 +1,69 @@
+"""add document_debt JSONB to admission_profile (fast-track nợ giấy tờ — C1)
+
+## Why
+
+Fast-track prepay/giữ chỗ (TUITION_PREPAY_FASTTRACK_PLAN.md C1) lets an
+officer submit a profile that is eligible in every other respect but still
+missing mandatory documents ("Nộp kèm nợ giấy tờ"). The system records a
+snapshot of that debt — ``{codes, reason, by_user_id, at}`` — so the FE can
+show "đã từng nợ + lý do" while the live badge counts the COMPUTED
+``outstanding_debt_codes`` (snapshot codes ∩ docs still missing now).
+
+## Why a SEPARATE column (not applied_rules)
+
+The ``prevent_applied_rules_update`` trigger (``ardockeys01``) whitelists
+only 7 keys (fee_* + mandatory_docs/doc_configs); any other key change on
+``applied_rules`` RAISEs on UPDATE. ``document_debt`` is mutable
+post-create (written at submit-with-debt time, well after creation), so it
+MUST live in its own column with no immutability guard.
+
+## What
+
+Add ``admission_profile.document_debt JSONB NULL``. NULL = no debt ever
+recorded. No backfill (existing rows simply have no debt). No index — the
+column is read per-profile alongside the row, never filtered/aggregated.
+
+## Downgrade
+
+Drop the column. Safe: the feature is additive and the column is nullable
+with no FK/constraint dependents.
+
+Revision ID: docdebt01
+Revises: leadsrch01
+Create Date: 2026-06-16
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "docdebt01"
+down_revision: Union[str, Sequence[str], None] = "leadsrch01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add nullable document_debt JSONB column to admission_profile."""
+    op.add_column(
+        "admission_profile",
+        sa.Column(
+            "document_debt",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+            comment=(
+                "Nợ giấy tờ snapshot {codes, reason, by_user_id, at} captured "
+                "at staff submit-with-debt. NULL = no debt ever recorded. "
+                "Separate column (NOT applied_rules) to dodge the immutability "
+                "trigger."
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the document_debt column."""
+    op.drop_column("admission_profile", "document_debt")

--- a/Backend_FastAPI/app/models/admission.py
+++ b/Backend_FastAPI/app/models/admission.py
@@ -316,6 +316,34 @@ class AdmissionProfile(Base):
         comment="Snapshot of admission rules: {min_gpa, mandatory_docs[], admission_method}"
     )
 
+    # Document debt (nợ giấy tờ) — fast-track prepay/giữ chỗ (C1).
+    #
+    # Snapshot captured ONCE when an officer submits a profile that is
+    # otherwise eligible but still missing mandatory documents (the
+    # "Nộp kèm nợ giấy tờ" flow). Shape:
+    #   {"codes": [...], "reason": str, "by_user_id": int, "at": iso8601}
+    #
+    # ⚠️ DELIBERATELY a SEPARATE mutable column, NOT a key inside
+    # ``applied_rules``. The ``prevent_applied_rules_update`` trigger
+    # (ardockeys01) whitelists only 7 keys; any new applied_rules key
+    # RAISEs on UPDATE. A standalone column has no such guard.
+    #
+    # The badge/count the FE renders is the COMPUTED
+    # ``outstanding_debt_codes`` (this snapshot's codes ∩ docs still
+    # missing now) — so once the officer uploads the owed docs the debt
+    # self-resolves; this snapshot is retained only as an audit record of
+    # "was once owed + why".
+    document_debt: Mapped[Optional[dict]] = mapped_column(
+        JSONB,
+        nullable=True,
+        comment=(
+            "Nợ giấy tờ snapshot {codes, reason, by_user_id, at} captured "
+            "at staff submit-with-debt. NULL = no debt ever recorded. "
+            "Separate column (NOT applied_rules) to dodge the immutability "
+            "trigger."
+        ),
+    )
+
     # Family Information (Array of FamilyMember objects)
     # Structure: [{relationship, full_name, occupation, phone}, ...]
     family_info: Mapped[list] = mapped_column(

--- a/Backend_FastAPI/app/repositories/fee_repository.py
+++ b/Backend_FastAPI/app/repositories/fee_repository.py
@@ -118,6 +118,25 @@ class FeeRepository(BaseRepository[Fee]):
         result = await self.db.execute(query)
         return list(result.scalars().all())
 
+    async def sum_paid_amount_by_profile(self, profile_id: int) -> Decimal:
+        """Sum of ``paid_amount`` across all fees of an admission profile.
+
+        Because a processed refund DECREMENTS ``fee.paid_amount``
+        (``payment_service.process_approved_refund``), this sum is exactly the
+        money currently HELD against the profile (i.e. collected and NOT yet
+        refunded). Used to flag "đã thu học phí nhưng chưa hoàn" on a
+        rejected/withdrawn profile (no IDOR filter needed — the caller has
+        already authorized access to the profile).
+
+        Returns ``Decimal("0")`` when the profile has no fees.
+        """
+        result = await self.db.execute(
+            select(func.coalesce(func.sum(Fee.paid_amount), 0)).where(
+                Fee.admission_profile_id == profile_id
+            )
+        )
+        return Decimal(str(result.scalar() or 0))
+
     async def get_for_update(
         self,
         fee_id: int,

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -761,12 +761,19 @@ async def submit_admission_profile(
     profile_id: int,
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = CasbinAuth,
+    body: Optional[schemas.AdmissionSubmitRequest] = None,
 ):
     """
     Submit AdmissionProfile for review.
 
     Transitions profile from draft → submitted. Validation checks
     document completeness and data integrity against snapshot rules.
+
+    **Request Body (optional — fast-track C1):**
+    - acknowledge_missing_docs: staff may submit with mandatory docs still
+      missing (nợ giấy tờ)
+    - document_debt_reason: required reason when acknowledging the debt
+    Omitting the body reproduces the original no-body behaviour.
 
     **On Success:**
     - Profile.status = 'submitted'
@@ -784,11 +791,16 @@ async def submit_admission_profile(
     - 404: Profile not found (or IDOR protection)
     - 400: Profile is not in draft status
     """
+    # Body is optional; default to an empty request so the no-body call path
+    # is preserved (Router stays dumb — the service owns all the waiver logic).
+    submit_body = body or schemas.AdmissionSubmitRequest()
     try:
         result, post_commit = await admission_service.submit_and_evaluate(
             db=db,
             profile_id=profile_id,
             current_user=current_user,
+            acknowledge_missing_docs=submit_body.acknowledge_missing_docs,
+            document_debt_reason=submit_body.document_debt_reason,
         )
 
         # Transaction commit

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -37,7 +37,7 @@ from app.schemas import finance as finance_schemas
 from app.services.fee_calculation_service import FeeCalculationService
 from app.services.invoice_service import InvoiceService
 from app.repositories.fee_repository import FeeRepository
-from app.utils.admission_status import is_admitted_like
+from app.utils.admission_status import is_fee_eligible
 from app.utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
@@ -80,22 +80,13 @@ def _fee_calc_authorized(
       can't spin up invoices for profiles they don't own.
     * everyone else: denied.
     """
-    # Fee-eligible states gate: admitted-like (legacy approved/overridden +
-    # choice-engine admitted) plus the post-confirmation milestones
-    # (confirmed/enrolled). C2 fast-track: ``submitted`` is also eligible so
-    # officers can calculate tuition + collect a prepay/hold-spot payment
-    # before the decision — but ONLY for single-path profiles. A multi-NV
-    # profile (``uses_choice_engine``) at ``submitted`` has not yet locked its
-    # admitted choice (all choices decision="pending" until publish), so
-    # ``_resolve_academic_info_id`` would pick ONE config-driven ngành and
-    # could auto-issue tuition for the WRONG ngành (different fees per ngành).
-    # Multi-NV becomes eligible only after publish → ``admitted`` (covered by
-    # ``is_admitted_like``). Earlier states (draft) stay blocked.
-    if not (
-        is_admitted_like(profile)
-        or profile.status in ("confirmed", "enrolled")
-        or (profile.status == "submitted" and not profile.uses_choice_engine)
-    ):
+    # Fee-eligible states gate — shared with the ``calculate_fee`` permission
+    # flag in ``admission_service._compute_frontend_fields`` via the single
+    # ``is_fee_eligible`` helper (anti-drift): admitted-like + confirmed/enrolled
+    # + ``submitted`` for SINGLE-PATH profiles only (C2 fast-track prepay / giữ
+    # chỗ). A multi-NV profile at ``submitted`` qualifies only after publish →
+    # ``admitted``. Earlier states (draft) stay blocked.
+    if not is_fee_eligible(profile):
         return False
 
     if user.role == UserRole.ADMIN:

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -84,8 +84,18 @@ def _fee_calc_authorized(
     # choice-engine admitted) plus the post-confirmation milestones
     # (confirmed/enrolled). C2 fast-track: ``submitted`` is also eligible so
     # officers can calculate tuition + collect a prepay/hold-spot payment
-    # before the decision. Earlier states (draft) stay blocked.
-    if not (is_admitted_like(profile) or profile.status in ("submitted", "confirmed", "enrolled")):
+    # before the decision — but ONLY for single-path profiles. A multi-NV
+    # profile (``uses_choice_engine``) at ``submitted`` has not yet locked its
+    # admitted choice (all choices decision="pending" until publish), so
+    # ``_resolve_academic_info_id`` would pick ONE config-driven ngành and
+    # could auto-issue tuition for the WRONG ngành (different fees per ngành).
+    # Multi-NV becomes eligible only after publish → ``admitted`` (covered by
+    # ``is_admitted_like``). Earlier states (draft) stay blocked.
+    if not (
+        is_admitted_like(profile)
+        or profile.status in ("confirmed", "enrolled")
+        or (profile.status == "submitted" and not profile.uses_choice_engine)
+    ):
         return False
 
     if user.role == UserRole.ADMIN:

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -69,9 +69,10 @@ def _fee_calc_authorized(
     any drift will surface as "FE hides button / API 404s" or vice versa.
 
     Rules:
-    * Profile must be in a post-decision state
-      (``approved`` | ``confirmed`` | ``enrolled``). Earlier states would
-      create a fee for a profile that might still be rejected.
+    * Profile must be in a fee-eligible state: ``submitted`` (fast-track
+      prepay / hold-spot — C2) plus the post-decision states
+      (``approved`` | ``confirmed`` | ``enrolled``). Earlier states
+      (``draft`` etc.) would create a fee prematurely.
     * admin: any profile.
     * manager / accountant: profile whose lead is in the user's unit.
     * officer: lead in the user's unit AND assigned to the user — matches
@@ -79,11 +80,12 @@ def _fee_calc_authorized(
       can't spin up invoices for profiles they don't own.
     * everyone else: denied.
     """
-    # Post-decision states gate: admitted-like (legacy approved/overridden +
+    # Fee-eligible states gate: admitted-like (legacy approved/overridden +
     # choice-engine admitted) plus the post-confirmation milestones
-    # (confirmed/enrolled) are eligible for fee creation. Earlier states
-    # would create a fee for a profile that might still flip to rejected.
-    if not (is_admitted_like(profile) or profile.status in ("confirmed", "enrolled")):
+    # (confirmed/enrolled). C2 fast-track: ``submitted`` is also eligible so
+    # officers can calculate tuition + collect a prepay/hold-spot payment
+    # before the decision. Earlier states (draft) stay blocked.
+    if not (is_admitted_like(profile) or profile.status in ("submitted", "confirmed", "enrolled")):
         return False
 
     if user.role == UserRole.ADMIN:
@@ -350,20 +352,30 @@ async def calculate_fee(
             if approved_at is not None:
                 invoice_anchor = approved_at.date() if hasattr(approved_at, "date") else approved_at
 
-        invoices, _ = await invoice_service.generate_invoices_for_fee(
+        # C2 fast-track (B4): auto-issue tuition invoices so the prepay/
+        # hold-spot payment can be collected immediately. Only tuition is
+        # auto-issued — other fee types keep the legacy draft->issue-by-hand
+        # flow. CAPTURE invoice_cb (was discarded with `_`): the issue path
+        # builds an INVOICE_ISSUED post-commit fanout that must be awaited,
+        # otherwise the invoice is issued silently with no notification/sync.
+        invoices, invoice_cb = await invoice_service.generate_invoices_for_fee(
             fee_id=fee.id,
             due_date_base=date.today() + timedelta(days=30),
             user_id=current_user.id,
             unit_id=unit_id,
-            auto_issue=False,
+            auto_issue=(data.fee_type == FeeTypeEnum.tuition),
             anchor_date=invoice_anchor,
         )
 
         await db.commit()
 
-        # Execute post-commit callback
+        # Execute post-commit callbacks: fee creation (post_commit) AND, when
+        # tuition was auto-issued, the INVOICE_ISSUED fanout (invoice_cb).
+        # invoice_cb is None for non-auto-issue fee types.
         if post_commit:
             await post_commit()
+        if invoice_cb:
+            await invoice_cb()
 
         # Refresh to load relationships
         await db.refresh(fee)

--- a/Backend_FastAPI/app/schemas/__init__.py
+++ b/Backend_FastAPI/app/schemas/__init__.py
@@ -161,6 +161,7 @@ from .admission import (
     AdmissionsPage,
     PendingDiplomaItem,  # PR #13.7 — nợ bằng reminder
     PendingDiplomaResponse,  # PR #13.7 — nợ bằng reminder
+    AdmissionSubmitRequest,  # Fast-track C1 — submit-with-document-debt body
     AdmissionSubmitResponse,
     # Phase 3 PR-3C Sub-3 — choice-engine endpoint schemas
     AdmissionPublishResultResponse,

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1369,6 +1369,20 @@ class AdmissionProfileResponse(BaseModel):
             "document debt (eligible apart from missing docs)."
         ),
     )
+    # COMPUTED (transient): true only when a rejected/withdrawn profile still
+    # holds collected (unrefunded) tuition (SUM(fee.paid_amount) > 0). A prepaid
+    # hold-spot fee survives reject/withdraw and is NOT auto-refunded → the FE
+    # shows a "cần hoàn tiền" warning. False for every non-terminal status (no
+    # DB hit). Self-resolves to False once the money is refunded (refund
+    # decrements paid_amount).
+    has_unrefunded_payment: bool = Field(
+        default=False,
+        description=(
+            "True when a rejected/withdrawn profile still holds collected, "
+            "not-yet-refunded tuition (SUM(fee.paid_amount) > 0). Drives the "
+            "'cần hoàn tiền' warning banner."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/Backend_FastAPI/app/schemas/admission.py
+++ b/Backend_FastAPI/app/schemas/admission.py
@@ -1326,6 +1326,50 @@ class AdmissionProfileResponse(BaseModel):
         description="Backend-computed score pass/fail status: {total_status, subject_statuses: {code: status}}"
     )
 
+    # =========================================================================
+    # Fast-track prepay/giữ chỗ — nợ giấy tờ contract (C1)
+    # =========================================================================
+    # Persisted snapshot captured at staff submit-with-debt. Shape:
+    # {codes, reason, by_user_id, at}. None = no debt ever recorded.
+    document_debt: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Snapshot of nợ giấy tờ captured at submit-with-debt: "
+            "{codes, reason, by_user_id, at}. None when no debt recorded."
+        ),
+    )
+    # COMPUTED (transient): the snapshot's codes that are STILL missing now.
+    # Self-resolves to [] once the officer uploads the owed docs — this is
+    # what the FE badge counts (NOT document_debt.codes which is frozen).
+    outstanding_debt_codes: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Document codes from document_debt that are still missing now "
+            "(document_debt.codes ∩ currently-missing docs). Empty when the "
+            "debt has been fully resolved."
+        ),
+    )
+    # Mandatory document codes currently missing (truly-missing, excluding
+    # uploaded-pending-verify). FE lists these in the submit-with-debt dialog.
+    missing_doc_codes: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Mandatory document codes currently missing (excludes "
+            "uploaded-but-pending-verify). Drives the submit-with-debt dialog."
+        ),
+    )
+    # COMPUTED flag — true only when a staff actor could submit this draft
+    # with a document debt: draft + staff + no non-document errors + at least
+    # one missing doc + not a multi-NV-without-choice. FE gates the "Nộp kèm
+    # nợ giấy tờ" button on this.
+    can_submit_with_document_debt: bool = Field(
+        default=False,
+        description=(
+            "True when the acting staff user may submit this draft with a "
+            "document debt (eligible apart from missing docs)."
+        ),
+    )
+
     @model_validator(mode="before")
     @classmethod
     def _safely_handle_unloaded_choices(cls, data: Any) -> Any:
@@ -1499,6 +1543,44 @@ class BulkActionResponse(BaseModel):
     failed_ids: List[int] = Field(default_factory=list, description="IDs of profiles that failed")
     errors: Optional[Dict[int, str]] = Field(None, description="Error messages per failed profile ID")
     message: str = Field(..., description="Summary message")
+
+
+class AdmissionSubmitRequest(BaseModel):
+    """Request body for ``POST /api/admissions/{id}/submit`` (fast-track C1).
+
+    The endpoint historically took no body. The two optional fields enable
+    the staff-only "Nộp kèm nợ giấy tờ" flow: when a profile is eligible in
+    every respect except missing mandatory documents, an officer/manager/
+    admin may acknowledge the missing docs and supply a reason; the service
+    then transitions the profile to ``submitted`` and records a
+    ``document_debt`` snapshot.
+
+    Defaults (``acknowledge_missing_docs=False``, ``document_debt_reason=
+    None``) reproduce the original no-body behaviour exactly, so existing
+    callers (including the magic-link candidate path) are unaffected. The
+    service enforces the staff-only gate + reason requirement; this schema
+    only carries the inputs.
+    """
+
+    acknowledge_missing_docs: bool = Field(
+        default=False,
+        description=(
+            "Staff acknowledges submitting with mandatory documents still "
+            "missing (nợ giấy tờ). Ignored unless the actor is staff and "
+            "the only outstanding errors are missing documents."
+        ),
+    )
+    document_debt_reason: Optional[str] = Field(
+        default=None,
+        max_length=500,
+        description=(
+            "Required when acknowledge_missing_docs=True — officer's reason "
+            "for allowing the document debt (e.g. 'HS xin cấp lại học bạ, "
+            "hẹn nộp 30/06')."
+        ),
+    )
+
+    model_config = ConfigDict(str_strip_whitespace=True)
 
 
 class AdmissionSubmitResponse(BaseModel):

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -1161,6 +1161,39 @@ async def publish_result(
             f"trạng thái hiện tại: '{profile.status}'"
         )
 
+    # Fast-track nợ giấy tờ (C1.5) — DECISION GATE. A multi-NV profile can be
+    # submitted WITH a document debt (acknowledge + reason), so it may sit at
+    # ``submitted`` with owed docs still unverified. ``publish_result`` is the
+    # multi-NV decision site (it runs the admit/reject cascade), so it must obey
+    # the same "no decision while docs are owed" rule the legacy ``approve``
+    # gate enforces — otherwise a manager could publish/admit a profile that has
+    # not had its documents verified, side-stepping C1.5. Computed from the
+    # persisted ``document_debt`` snapshot ∩ docs-not-yet-verified via the same
+    # helper the FE-facing ``_compute_frontend_fields`` + the approve gate use
+    # (one definition everywhere). A profile without a debt snapshot has no
+    # outstanding codes → this is a no-op (no regression). Placed BEFORE the
+    # auto-transition + any cascade so a blocked publish never mutates state.
+    #
+    # Local import: ``admission_service`` imports ``admission_choice_engine_
+    # service`` (lazily, at call time) for the submit cascade, so a module-level
+    # import here would risk a circular import. Importing the helper inside the
+    # function defers resolution to call time, when both modules are fully
+    # loaded — guaranteed cycle-free.
+    from .admission_service import _outstanding_debt_for_approval
+
+    outstanding = await _outstanding_debt_for_approval(db, profile)
+    if outstanding:
+        log.warning(
+            "admission_choice_engine.publish_result_blocked_document_debt",
+            profile_id=profile.id,
+            actor_id=getattr(actor, "id", None),
+            outstanding_debt_codes=outstanding,
+        )
+        raise BusinessRuleViolation(
+            "Hồ sơ còn nợ giấy tờ chưa bổ sung/xác minh đủ, không thể công bố "
+            "kết quả. Cần verify đủ giấy tờ trước khi công bố."
+        )
+
     # Auto-transition submitted → reviewing trước engine cascade. Engine
     # vẫn cần reviewing state làm intermediate (per state_machine T6 edge:
     # reviewing → result_published only). transition() handle audit log

--- a/Backend_FastAPI/app/services/admission_document_policy.py
+++ b/Backend_FastAPI/app/services/admission_document_policy.py
@@ -66,10 +66,34 @@ reviewer can. verify/reject stay reviewer-only (review ≠ editing content).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Iterable, Literal
 
 from app.core.constants import UserRole
 from app import models
+
+
+def _satisfied_doc_codes(documents: "Iterable | None") -> set[str]:
+    """Codes of documents that count as SATISFIED (verified or paper_submitted).
+
+    Single source of truth for "a required document has actually been confirmed
+    by a reviewer". A ``priority_evidence`` row maps 1:1 with a priority object
+    (no ``document_type`` FK), so it is filtered out before reading
+    ``doc.document_type.code`` — exactly the guard
+    ``_compute_outstanding_debt_codes`` and ``_validate_documents`` both apply.
+
+    STRICT by design: merely ``uploaded`` (file present, not yet verified) does
+    NOT satisfy — the fast-track nợ giấy tờ rule is "hết nợ chỉ khi VERIFY"
+    (PLAN §C1.5). Returns ``set()`` for ``None`` (nothing satisfied).
+    """
+    if documents is None:
+        return set()
+    return {
+        doc.document_type.code
+        for doc in documents
+        if doc.document_type is not None
+        and getattr(doc, "category", None) != "priority_evidence"
+        and doc.status in ("verified", "paper_submitted")
+    }
 
 
 DocumentAction = Literal[

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1910,10 +1910,20 @@ def _compute_frontend_fields(
         # Bỏ T2 start-review explicit step (YAGNI per user clarification).
         # Mirror BE service guard publish_result(): uses_choice_engine=True +
         # status IN (submitted, reviewing) + manager/admin role.
+        #
+        # Fast-track nợ giấy tờ (C1.5) — publish_result is the multi-NV DECISION
+        # site (admit/reject cascade), so it must obey the same "no decision
+        # while docs are owed" gate as ``approve``: a multi-NV profile can submit
+        # WITH a document debt, so it could reach ``submitted`` with a non-empty
+        # ``_outstanding_debt_codes``. Block the FE button (and the
+        # ``admission_choice_engine_service.publish_result`` service guard raises
+        # BusinessRuleViolation if attempted anyway). No debt snapshot → [] → no
+        # behaviour change for the common path.
         "publish_result": (
             getattr(profile, "uses_choice_engine", False)
             and status in ["submitted", "reviewing"]
             and (is_manager or is_admin)
+            and not _outstanding_debt_codes
         ),
         "request_revision": status in ["submitted", "resubmitted"] and (is_manager or is_admin),
         "resubmit": status in ["rejected", "revision_requested"] and (is_owner or is_manager or is_admin),

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1972,9 +1972,18 @@ def _compute_frontend_fields(
         # manager/accountant same-unit, officer same-unit AND assigned.
         # Status-gated to fee-eligible states: C2 fast-track adds ``submitted``
         # (prepay/hold-spot before the decision) on top of post-decision
-        # (approved/confirmed/enrolled). draft stays blocked.
+        # (approved/confirmed/enrolled). draft stays blocked. ``submitted`` is
+        # gated to SINGLE-PATH profiles only: a multi-NV profile
+        # (``uses_choice_engine``) at ``submitted`` has not locked its admitted
+        # choice yet (đợi công bố), so calculating tuition would pick the wrong
+        # ngành. Multi-NV qualifies after publish → ``admitted`` via
+        # ``is_admitted_like``. Must stay mirrored with _fee_calc_authorized.
         "calculate_fee": (
-            (is_admitted_like(profile) or status in ("submitted", "confirmed", "enrolled"))
+            (
+                is_admitted_like(profile)
+                or status in ("confirmed", "enrolled")
+                or (status == "submitted" and not profile.uses_choice_engine)
+            )
             and (
                 is_admin
                 or (
@@ -2184,16 +2193,19 @@ def _compute_frontend_fields(
     # in the submit-with-debt dialog (B3).
     profile.missing_doc_codes = list(missing_doc_codes)
 
-    # Staff-only gate mirrors submit_and_evaluate: a candidate/magic-link
-    # actor (current_user=None) never reaches here (helper is a no-op for
-    # None), but accountant/user roles can — so require officer/manager/admin
-    # explicitly. The button shows only when the draft is eligible apart from
-    # missing docs (other_errors empty + ≥1 missing doc) and is not a
-    # multi-NV profile lacking choices.
-    _is_staff_actor = is_admin or is_manager or is_officer
+    # L1 owner-consistency: gate the submit-with-debt button on the SAME actor
+    # set as ``permissions["submit"]`` (is_owner or is_manager or is_admin) to
+    # prevent drift — submit-with-debt is just submit + a doc-debt snapshot, so
+    # an actor who can't submit must not see the debt variant either. (Previous
+    # ``is_admin or is_manager or is_officer`` admitted any officer, including
+    # one not assigned to the lead, which submit itself rejects via is_owner.)
+    # The server-side submit gate in submit_and_evaluate is role+IDOR based and
+    # unchanged — this only aligns the FE flag. The button shows only when the
+    # draft is eligible apart from missing docs (other_errors empty + ≥1 missing
+    # doc) and is not a multi-NV profile lacking choices.
     profile.can_submit_with_document_debt = bool(
         status == "draft"
-        and _is_staff_actor
+        and (is_owner or is_manager or is_admin)
         and not _other_errors
         and missing_doc_codes
         and not _multi_nv_no_choice

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -3132,6 +3132,44 @@ async def _populate_response_fields(
     # documents lazy-load fails.
     await _populate_priority_evidence_projections(db, profile, documents)
 
+    # TUITION_PREPAY_FASTTRACK finding #1 — flag học phí trả trước chưa hoàn
+    # khi hồ sơ đã rejected/withdrawn (giữ-chỗ rồi từ chối/rút). Parity:
+    # also set on the GET path (``get_profile``) which does NOT call this
+    # helper — keep both in lockstep.
+    await _populate_unrefunded_payment_flag(db, profile)
+
+
+async def _populate_unrefunded_payment_flag(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+) -> None:
+    """Set transient ``has_unrefunded_payment`` for the FE warning badge.
+
+    A profile can be charged + collect a PREPAID tuition while ``submitted``
+    (hold-spot flow). If it is later ``rejected`` (manager) or ``withdrawn``
+    (candidate) — both valid from ``submitted`` — any money already collected
+    becomes orphaned: it is NOT auto-refunded and is easy to forget. This flag
+    lets ops see "cần hoàn tiền" on the detail page (refund stays manual via
+    the existing maker-checker flow).
+
+    ``SUM(fee.paid_amount)`` is the currently-HELD amount: a processed refund
+    decrements ``paid_amount`` (``payment_service.process_approved_refund``),
+    so the sum is exactly the unrefunded balance.
+
+    Cost guard: ONLY queries when ``status in (rejected, withdrawn)``; every
+    other status short-circuits to ``False`` with no DB hit. Idempotent — safe
+    to call from both ``_populate_response_fields`` (mutations) and
+    ``get_profile`` (GET detail) for parity.
+    """
+    if profile.status not in ("rejected", "withdrawn"):
+        profile.has_unrefunded_payment = False
+        return
+
+    from app.repositories.fee_repository import FeeRepository
+
+    total_paid = await FeeRepository(db).sum_paid_amount_by_profile(profile.id)
+    profile.has_unrefunded_payment = total_paid > 0
+
 
 async def _load_priority_audit_log(
     db: AsyncSession,
@@ -4455,6 +4493,12 @@ async def get_profile(
     # ``_populate_response_fields`` callers, leaving the read-side dark.
     profile.priority_audit_log = await _load_priority_audit_log(db, profile.id)
     await _populate_priority_evidence_projections(db, profile, documents)
+
+    # Parity with mutation responses (reject/withdraw go through
+    # ``_populate_response_fields``): GET detail builds via
+    # ``_compute_frontend_fields`` directly, so set the unrefunded-payment
+    # flag here too — otherwise GET would default it to False.
+    await _populate_unrefunded_payment_flag(db, profile)
 
     return profile
 
@@ -8536,6 +8580,21 @@ async def reject_profile(
         reason_length=len(data["reason"]),
     )
 
+    # TUITION_PREPAY_FASTTRACK finding #1 — surface orphaned prepaid tuition.
+    # ``_populate_response_fields`` above already computed the flag; only hit
+    # the DB for the exact amount when there IS something held (rare path).
+    # We do NOT block reject — refund stays manual via the maker-checker flow.
+    if getattr(profile, "has_unrefunded_payment", False):
+        from app.repositories.fee_repository import FeeRepository
+
+        _total_paid = await FeeRepository(db).sum_paid_amount_by_profile(profile.id)
+        log.warning(
+            "Profile reject với khoản học phí chưa hoàn",
+            profile_id=profile.id,
+            total_paid=str(_total_paid),
+            status=profile.status,
+        )
+
     # Path C / Arch-3: paired notification bundle + commission callback.
     # Mirrors router admissions.py:1606+1621 (paired dispatch) + 1636
     # (commission). new_status="rejected" / lead "sts16".
@@ -10469,6 +10528,23 @@ async def withdraw_profile(
         actor_id=_actor_id,
         old_status=_old_status_for_audit,
     )
+
+    # TUITION_PREPAY_FASTTRACK finding #1 — flag + warn về học phí trả trước
+    # chưa hoàn khi rút hồ sơ. ``withdraw_profile`` không gọi
+    # ``_populate_response_fields`` (response tối giản theo thiết kế), nên set
+    # cờ trực tiếp qua helper nhẹ để mutation response có parity với GET. KHÔNG
+    # chặn rút — hoàn tiền vẫn thủ công qua maker-checker.
+    await _populate_unrefunded_payment_flag(db, profile)
+    if getattr(profile, "has_unrefunded_payment", False):
+        from app.repositories.fee_repository import FeeRepository
+
+        _total_paid = await FeeRepository(db).sum_paid_amount_by_profile(profile.id)
+        log.warning(
+            "Profile withdraw với khoản học phí chưa hoàn",
+            profile_id=profile.id,
+            total_paid=str(_total_paid),
+            status=profile.status,
+        )
 
     # Path C / Arch-3: build atomic notification bundle for the paired
     # transition (APPLICATION_STATUS_CHANGED + LEAD_STATUS_CHANGED).

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1970,11 +1970,11 @@ def _compute_frontend_fields(
         # PR #7 — official fee/invoice creation via POST /api/fees/calculate.
         # Mirrors _fee_calc_authorized in routers/fees.py: admin always,
         # manager/accountant same-unit, officer same-unit AND assigned.
-        # Status-gated to post-decision (approved/confirmed/enrolled) so we
-        # don't create finance records for profiles that might still flip
-        # to rejected.
+        # Status-gated to fee-eligible states: C2 fast-track adds ``submitted``
+        # (prepay/hold-spot before the decision) on top of post-decision
+        # (approved/confirmed/enrolled). draft stays blocked.
         "calculate_fee": (
-            (is_admitted_like(profile) or status in ("confirmed", "enrolled"))
+            (is_admitted_like(profile) or status in ("submitted", "confirmed", "enrolled"))
             and (
                 is_admin
                 or (

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -58,7 +58,11 @@ from .admission_correction_helpers import (
     post_parse_business_check,
     safe_serialize,
 )
-from ..utils.admission_status import is_admitted_like, is_confirmation_eligible
+from ..utils.admission_status import (
+    is_admitted_like,
+    is_confirmation_eligible,
+    is_fee_eligible,
+)
 from ..utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
@@ -1197,16 +1201,14 @@ def _compute_outstanding_debt_codes(
     if not debt_codes:
         return []
 
-    satisfied_now: set[str] = set()
-    if documents is not None:
-        satisfied_now = {
-            doc.document_type.code
-            for doc in documents
-            if doc.document_type is not None
-            and getattr(doc, "category", None) != "priority_evidence"
-            and doc.status in ("verified", "paper_submitted")
-        }
+    # Shared "verified/paper_submitted, priority_evidence filtered out" logic —
+    # single source of truth in ``admission_document_policy`` so the satisfied-
+    # doc definition can't drift from the doc-policy layer. Local import keeps
+    # this leaf helper cycle-free (matches the other ``admission_document_policy``
+    # imports in this module).
+    from .admission_document_policy import _satisfied_doc_codes
 
+    satisfied_now = _satisfied_doc_codes(documents)
     return [code for code in debt_codes if code not in satisfied_now]
 
 
@@ -2008,21 +2010,14 @@ def _compute_frontend_fields(
         ),
         # PR #7 — official fee/invoice creation via POST /api/fees/calculate.
         # Mirrors _fee_calc_authorized in routers/fees.py: admin always,
-        # manager/accountant same-unit, officer same-unit AND assigned.
-        # Status-gated to fee-eligible states: C2 fast-track adds ``submitted``
-        # (prepay/hold-spot before the decision) on top of post-decision
-        # (approved/confirmed/enrolled). draft stays blocked. ``submitted`` is
-        # gated to SINGLE-PATH profiles only: a multi-NV profile
-        # (``uses_choice_engine``) at ``submitted`` has not locked its admitted
-        # choice yet (đợi công bố), so calculating tuition would pick the wrong
-        # ngành. Multi-NV qualifies after publish → ``admitted`` via
-        # ``is_admitted_like``. Must stay mirrored with _fee_calc_authorized.
+        # manager/accountant same-unit, officer same-unit AND assigned. The
+        # fee-eligible STATE gate is the shared ``is_fee_eligible`` helper
+        # (anti-drift, single source of truth with _fee_calc_authorized): C2
+        # fast-track adds ``submitted`` (prepay/hold-spot before the decision,
+        # single-path only) on top of post-decision (admitted-like/confirmed/
+        # enrolled); draft stays blocked.
         "calculate_fee": (
-            (
-                is_admitted_like(profile)
-                or status in ("confirmed", "enrolled")
-                or (status == "submitted" and not profile.uses_choice_engine)
-            )
+            is_fee_eligible(profile)
             and (
                 is_admin
                 or (

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1137,7 +1137,7 @@ def _validate_documents(
                     f"để verify trước khi nộp hồ sơ."
                 )
             else:
-                validation_errors.append(f"Thiếu tài liệu bắt buộc: {doc_code}")
+                validation_errors.append(_missing_doc_error_message(doc_code))
 
     return (
         doc_errors,
@@ -1146,6 +1146,19 @@ def _validate_documents(
         upload_required_docs,
         unverified_doc_codes,
     )
+
+
+def _missing_doc_error_message(code: str) -> str:
+    """Single source of truth for the "missing mandatory document" message.
+
+    Emitted by ``_validate_documents`` when a required doc is absent and
+    reconstructed by ``_compute_frontend_fields`` to SUBTRACT those messages
+    from ``validation_errors`` (computing ``_other_errors`` for
+    ``can_submit_with_document_debt``). Both sites MUST use this helper so the
+    format can never drift apart — a drift would break the subtraction and
+    silently kill ``can_submit_with_document_debt`` (fast-track nợ giấy tờ).
+    """
+    return f"Thiếu tài liệu bắt buộc: {code}"
 
 
 def _compute_outstanding_debt_codes(
@@ -1195,6 +1208,22 @@ def _compute_outstanding_debt_codes(
         }
 
     return [code for code in debt_codes if code not in satisfied_now]
+
+
+async def _outstanding_debt_for_approval(db, profile) -> list[str]:
+    """Outstanding (verified-based) debt codes for an approval gate; [] if no debt.
+
+    Shared by ``approve_profile`` and ``bulk_approve`` so both approve gates
+    compute the same thing: load the profile's documents and intersect the
+    ``document_debt`` snapshot with docs not yet verified/paper_submitted. A
+    profile without a debt snapshot returns ``[]`` (no query, never gates).
+    """
+    if not getattr(profile, "document_debt", None):
+        return []
+    from app.repositories import AdmissionRepository
+
+    documents = await AdmissionRepository(db).get_all_documents(profile.id)
+    return _compute_outstanding_debt_codes(profile, documents)
 
 
 def _validate_personal_info(
@@ -2174,7 +2203,7 @@ def _compute_frontend_fields(
     # message and stay in other_errors → they still block, honouring B2:
     # only truly-missing docs are waivable, never unverified ones).
     _missing_doc_messages = {
-        f"Thiếu tài liệu bắt buộc: {code}" for code in missing_doc_codes
+        _missing_doc_error_message(code) for code in missing_doc_codes
     }
     _other_errors = [
         err for err in validation_errors if err not in _missing_doc_messages
@@ -8225,26 +8254,18 @@ async def approve_profile(
     # gate agree). Profiles without a debt snapshot have no outstanding codes →
     # this is a no-op (no regression). Runs BEFORE the irreversible quota
     # increment so a blocked approve never consumes a seat.
-    if getattr(profile, "document_debt", None):
-        from app.repositories import AdmissionRepository as _ApproveAdmissionRepo
-
-        _approve_documents = await _ApproveAdmissionRepo(db).get_all_documents(
-            profile.id
+    _approve_outstanding = await _outstanding_debt_for_approval(db, profile)
+    if _approve_outstanding:
+        log.warning(
+            "Attempt to approve profile with outstanding document debt",
+            profile_id=profile.id,
+            approver_id=approver.id,
+            outstanding_debt_codes=_approve_outstanding,
         )
-        _approve_outstanding = _compute_outstanding_debt_codes(
-            profile, _approve_documents
+        raise BusinessRuleViolation(
+            "Hồ sơ còn nợ giấy tờ chưa bổ sung/xác minh đủ, không thể "
+            "duyệt. Cần verify đủ giấy tờ trước khi duyệt."
         )
-        if _approve_outstanding:
-            log.warning(
-                "Attempt to approve profile with outstanding document debt",
-                profile_id=profile.id,
-                approver_id=approver.id,
-                outstanding_debt_codes=_approve_outstanding,
-            )
-            raise BusinessRuleViolation(
-                "Hồ sơ còn nợ giấy tờ chưa bổ sung/xác minh đủ, không thể "
-                "duyệt. Cần verify đủ giấy tờ trước khi duyệt."
-            )
 
     # ADM-026: quota gate. Locks the OfferingAcademicInfo row before
     # counting committed seats so concurrent approve calls cannot blow the
@@ -11657,20 +11678,14 @@ async def bulk_approve(
             # approve_profile: a profile with an unresolved document debt may
             # NOT be (bulk-)approved. Per-item skip (not a batch abort) to match
             # the other bulk gates. No-op for profiles without a debt snapshot.
-            if getattr(profile, "document_debt", None):
-                from app.repositories import AdmissionRepository as _BulkRepo
-
-                _bulk_docs = await _BulkRepo(db).get_all_documents(profile.id)
-                _bulk_outstanding = _compute_outstanding_debt_codes(
-                    profile, _bulk_docs
+            _bulk_outstanding = await _outstanding_debt_for_approval(db, profile)
+            if _bulk_outstanding:
+                failed_ids.append(profile_id)
+                errors[profile_id] = (
+                    "Hồ sơ còn nợ giấy tờ chưa bổ sung/xác minh đủ, "
+                    "không thể duyệt."
                 )
-                if _bulk_outstanding:
-                    failed_ids.append(profile_id)
-                    errors[profile_id] = (
-                        "Hồ sơ còn nợ giấy tờ chưa bổ sung/xác minh đủ, "
-                        "không thể duyệt."
-                    )
-                    continue
+                continue
 
             # ADM-026: per-item quota gate. Per-item bypass fields let admin
             # selectively override the cap for some profiles in the batch

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2088,6 +2088,58 @@ def _compute_frontend_fields(
     
     profile.validation_errors = validation_errors
 
+    # =========================================================================
+    # Fast-track prepay/giữ chỗ — nợ giấy tờ contract (C1)
+    # =========================================================================
+    # SUBTRACTION (not enumeration): "other_errors" = every validation error
+    # EXCEPT the truly-missing-mandatory-document ones. We can submit-with-debt
+    # only when other_errors is empty (eligible apart from missing docs).
+    #
+    # The missing-doc messages produced by _validate_documents are exactly
+    # ``"Thiếu tài liệu bắt buộc: {code}"`` for each code in missing_doc_codes
+    # (uploaded-but-pending-verify docs use a DIFFERENT "chưa được xác minh"
+    # message and stay in other_errors → they still block, honouring B2:
+    # only truly-missing docs are waivable, never unverified ones).
+    _missing_doc_messages = {
+        f"Thiếu tài liệu bắt buộc: {code}" for code in missing_doc_codes
+    }
+    _other_errors = [
+        err for err in validation_errors if err not in _missing_doc_messages
+    ]
+
+    # Snapshot of a previously-recorded debt (persisted column). The badge the
+    # FE renders is the COMPUTED intersection with docs STILL missing now, so
+    # it self-resolves once the owed docs are uploaded. document_debt may be a
+    # dict {codes, reason, ...} or None.
+    _debt_snapshot = getattr(profile, "document_debt", None)
+    _debt_codes = (
+        _debt_snapshot.get("codes", [])
+        if isinstance(_debt_snapshot, dict)
+        else []
+    )
+    _missing_now = set(missing_doc_codes)
+    profile.outstanding_debt_codes = [
+        code for code in _debt_codes if code in _missing_now
+    ]
+    # Expose the currently-missing mandatory doc codes so the FE can list them
+    # in the submit-with-debt dialog (B3).
+    profile.missing_doc_codes = list(missing_doc_codes)
+
+    # Staff-only gate mirrors submit_and_evaluate: a candidate/magic-link
+    # actor (current_user=None) never reaches here (helper is a no-op for
+    # None), but accountant/user roles can — so require officer/manager/admin
+    # explicitly. The button shows only when the draft is eligible apart from
+    # missing docs (other_errors empty + ≥1 missing doc) and is not a
+    # multi-NV profile lacking choices.
+    _is_staff_actor = is_admin or is_manager or is_officer
+    profile.can_submit_with_document_debt = bool(
+        status == "draft"
+        and _is_staff_actor
+        and not _other_errors
+        and missing_doc_codes
+        and not _multi_nv_no_choice
+    )
+
     # F7 fix 2026-05-16: surface bypass-eligibility hazard to FE.
     # When `applied_rules.allow_unverified_submission=True`, applicant can
     # submit a profile despite missing required data (per Decision 1 in
@@ -5337,6 +5389,9 @@ async def submit_and_evaluate(
     db: AsyncSession,
     profile_id: int,
     current_user: Optional[models.User],
+    *,
+    acknowledge_missing_docs: bool = False,
+    document_debt_reason: Optional[str] = None,
 ) -> Tuple[Dict[str, Any], Optional[Callable[[], Awaitable[None]]]]:
     """
     Submit AdmissionProfile for evaluation (auto-approve or return errors).
@@ -5357,6 +5412,15 @@ async def submit_and_evaluate(
         profile_id: AdmissionProfile ID
         current_user: Current authenticated user, or None for magic-link
             self-service candidate path (CCCD already verified upstream).
+        acknowledge_missing_docs: Fast-track C1 — when True AND the actor is
+            staff (officer/manager/admin) AND ``document_debt_reason`` is set
+            AND the only outstanding errors are truly-missing mandatory
+            documents, the profile transitions to ``submitted`` and a
+            ``document_debt`` snapshot is recorded. Candidate/magic-link
+            (current_user=None) can never use this. Defaults False (original
+            no-body behaviour: missing docs block submit).
+        document_debt_reason: Officer's reason for allowing the document debt;
+            required when ``acknowledge_missing_docs`` is honoured.
 
     Returns:
         Tuple of (result_dict, post_commit_callback):
@@ -5651,22 +5715,42 @@ async def submit_and_evaluate(
     ]
     if allow_unverified:
         uploaded_doc_codes = {doc.document_type.code for doc in path_uploaded_docs}
+        # Lax mode: anything not in uploaded_doc_codes has no file → truly missing.
+        pending_verify_codes: set[str] = set()
     else:
         uploaded_doc_codes = {
             doc.document_type.code for doc in path_uploaded_docs
             if doc.status in ("verified", "paper_submitted")
         }
+        # Strict mode: a mandatory doc with a file but status='uploaded' is
+        # uploaded-but-pending-verify, NOT truly missing. Mirror
+        # _validate_documents (:1114) so the nợ-giấy-tờ waiver only ever
+        # waives TRULY-missing docs (B2) — unverified docs still block.
+        pending_verify_codes = {
+            doc.document_type.code for doc in path_uploaded_docs
+            if doc.file_path and doc.status == "uploaded"
+        }
 
+    # Fast-track C1 — collect TRULY-missing mandatory doc codes + their error
+    # messages separately so the submit-with-debt path can waive ONLY these
+    # (uploaded-pending-verify errors stay in ``errors`` and keep blocking).
+    missing_doc_codes: List[str] = []
+    missing_doc_errors: List[str] = []
     for doc_code in mandatory_docs:
         if doc_code not in uploaded_doc_codes:
             doc = await admission_repo.get_document_by_type(profile.id, doc_code)
             label = doc.document_type.name if doc else doc_code
-            if allow_unverified:
-                errors.append(f"Thiếu tài liệu bắt buộc: {label} ({doc_code})")
-            else:
+            if not allow_unverified and doc_code in pending_verify_codes:
+                # Uploaded but not yet verified — NOT waivable; blocks submit.
                 errors.append(
                     f"Tài liệu {label} ({doc_code}) chưa được xác minh. "
                     f"Liên hệ quản lý để verify trước khi nộp hồ sơ."
+                )
+            else:
+                # Truly missing (no file). Waivable via document debt.
+                missing_doc_codes.append(doc_code)
+                missing_doc_errors.append(
+                    f"Thiếu tài liệu bắt buộc: {label} ({doc_code})"
                 )
 
     # Validation 3: Check citizen_id uniqueness
@@ -5781,6 +5865,63 @@ async def submit_and_evaluate(
             "Phường/Xã thường trú phải theo địa giới hiện hành (2 cấp, sau "
             "01/07/2025). Vui lòng chọn lại Phường/Xã hiện tại."
         )
+
+    # =========================================================================
+    # Fast-track prepay/giữ chỗ — submit-with-document-debt waiver (C1)
+    # =========================================================================
+    # SUBTRACTION (not enumeration): ``errors`` already holds EVERY blocking
+    # validation error EXCEPT truly-missing mandatory docs (those were split
+    # into ``missing_doc_errors`` / ``missing_doc_codes`` above). The early
+    # hard ``raise`` gates (multi-NV-no-choice :5426, round cutoff :5454,
+    # status!=draft :5433, eligibility :5483, atomic quota below) already
+    # fired and are NOT document errors → still block regardless.
+    #
+    # We may transition to ``submitted`` + record a document_debt snapshot
+    # ONLY when ALL of:
+    #   - acknowledge_missing_docs is True
+    #   - a non-empty document_debt_reason is supplied
+    #   - the actor is STAFF (officer/manager/admin) — never candidate/
+    #     magic-link (current_user=None) nor accountant/user roles
+    #   - there is at least one truly-missing mandatory doc to waive
+    #   - ``errors`` (all other validation) is empty
+    # Otherwise the missing-doc errors are folded back into ``errors`` and the
+    # profile stays in draft exactly as before (defaults reproduce old flow).
+    _actor_is_staff = current_user is not None and current_user.role in (
+        UserRole.OFFICER,
+        UserRole.MANAGER,
+        UserRole.ADMIN,
+    )
+    _reason_clean = (document_debt_reason or "").strip()
+    _waive_document_debt = bool(
+        acknowledge_missing_docs
+        and _reason_clean
+        and _actor_is_staff
+        and missing_doc_codes
+        and not errors
+    )
+
+    if _waive_document_debt:
+        # Persist the debt snapshot on the dedicated column (NOT applied_rules
+        # — see model comment / ardockeys01 trigger). The FE badge counts the
+        # COMPUTED outstanding_debt_codes (codes ∩ docs still missing), so the
+        # debt self-resolves once the owed docs are uploaded; this snapshot is
+        # the audit record of "was once owed + why".
+        profile.document_debt = {
+            "codes": list(missing_doc_codes),
+            "reason": _reason_clean,
+            "by_user_id": current_user.id,
+            "at": datetime.now(timezone.utc).isoformat(),
+        }
+        log.info(
+            "admission_submit_with_document_debt",
+            profile_id=profile_id,
+            user_id=current_user.id,
+            waived_doc_codes=missing_doc_codes,
+        )
+    else:
+        # Not a valid waiver → missing docs block submit like every other
+        # error. Combine so the FE sees the full list (missing docs included).
+        errors = errors + missing_doc_errors
 
     # ✅ CRITICAL FIX #1: Submit should transition to SUBMITTED, not APPROVED/REJECTED
     # Per ADMISSION_STATE_MACHINE: draft → submitted (wait for Manager approval)

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1148,6 +1148,55 @@ def _validate_documents(
     )
 
 
+def _compute_outstanding_debt_codes(
+    profile: models.AdmissionProfile,
+    documents: list | None,
+) -> list[str]:
+    """Fast-track nợ giấy tờ — VERIFIED-based resolution of a document debt.
+
+    A debt code is "satisfied" (no longer outstanding) ONLY once the
+    corresponding document reaches ``verified`` or ``paper_submitted`` — i.e.
+    an officer/reviewer has actually confirmed it. Merely UPLOADING the file
+    (status ``uploaded``) does NOT clear the debt; the decision is "hết nợ chỉ
+    khi VERIFY" (PLAN §C1.5).
+
+    This is intentionally STRICTER than ``missing_doc_codes`` (which, in lax
+    ``allow_unverified=True`` mode, counts an uploaded-but-unverified doc as
+    present and would prematurely empty the debt). Mirrors the priority_evidence
+    filter from ``_validate_documents`` so a priority-evidence row (no
+    ``document_type`` FK) never crashes on ``doc.document_type.code``.
+
+    Args:
+        profile: AdmissionProfile carrying the ``document_debt`` snapshot.
+        documents: Eager-loaded ProfileDocument list (or None → nothing
+            satisfied, every debt code stays outstanding).
+
+    Returns:
+        The subset of ``document_debt['codes']`` not yet verified/paper_submitted.
+        ``[]`` when there is no debt snapshot (NULL column → never gates approve).
+    """
+    debt_snapshot = getattr(profile, "document_debt", None)
+    debt_codes = (
+        debt_snapshot.get("codes", [])
+        if isinstance(debt_snapshot, dict)
+        else []
+    )
+    if not debt_codes:
+        return []
+
+    satisfied_now: set[str] = set()
+    if documents is not None:
+        satisfied_now = {
+            doc.document_type.code
+            for doc in documents
+            if doc.document_type is not None
+            and getattr(doc, "category", None) != "priority_evidence"
+            and doc.status in ("verified", "paper_submitted")
+        }
+
+    return [code for code in debt_codes if code not in satisfied_now]
+
+
 def _validate_personal_info(
     profile: models.AdmissionProfile,
 ) -> tuple[list[str], list[str]]:
@@ -1805,11 +1854,26 @@ def _compute_frontend_fields(
         and _loaded_choices is not None
         and len(_loaded_choices) == 0
     )
+    # Fast-track nợ giấy tờ (C1.5) — compute the VERIFIED-based outstanding debt
+    # FIRST so the approve permission below can be gated on it. A code stays
+    # outstanding until the doc is verified/paper_submitted (NOT merely
+    # uploaded). No debt snapshot → [] → approve is unaffected. Mirror of the
+    # service-side gate in ``approve_profile``; assigned to the profile lower
+    # down (single source of truth for the FE badge + parity with GET).
+    _outstanding_debt_codes = _compute_outstanding_debt_codes(profile, documents)
     permissions = {
         "edit": status in ["draft", "rejected", "revision_requested"] and (is_owner or is_manager or is_admin),
         "save": status in ["draft", "rejected", "revision_requested"] and (is_owner or is_manager or is_admin),
         "submit": status == "draft" and (is_owner or is_manager or is_admin) and not _multi_nv_no_choice,
-        "approve": status in ["submitted", "resubmitted"] and (is_manager or is_admin),
+        # Approve is BLOCKED while any owed doc is unverified (nợ giấy tờ): the
+        # FE hides/disables the button and the service raises BusinessRuleViolation
+        # if it is attempted anyway. ``_outstanding_debt_codes`` is [] for every
+        # profile without a debt snapshot → no behaviour change there.
+        "approve": (
+            status in ["submitted", "resubmitted"]
+            and (is_manager or is_admin)
+            and not _outstanding_debt_codes
+        ),
         "reject": status in ["submitted", "resubmitted"] and (is_manager or is_admin),
         # Phase 3 multi-NV simplified flow 2026-05-15: manager/admin click
         # "Công bố kết quả" trực tiếp từ submitted/reviewing → engine cascade
@@ -2107,20 +2171,15 @@ def _compute_frontend_fields(
         err for err in validation_errors if err not in _missing_doc_messages
     ]
 
-    # Snapshot of a previously-recorded debt (persisted column). The badge the
-    # FE renders is the COMPUTED intersection with docs STILL missing now, so
-    # it self-resolves once the owed docs are uploaded. document_debt may be a
-    # dict {codes, reason, ...} or None.
-    _debt_snapshot = getattr(profile, "document_debt", None)
-    _debt_codes = (
-        _debt_snapshot.get("codes", [])
-        if isinstance(_debt_snapshot, dict)
-        else []
-    )
-    _missing_now = set(missing_doc_codes)
-    profile.outstanding_debt_codes = [
-        code for code in _debt_codes if code in _missing_now
-    ]
+    # The badge the FE renders is the COMPUTED set of debt codes whose docs are
+    # STILL not VERIFIED — it self-resolves once a reviewer verifies (or marks
+    # paper_submitted) each owed doc. VERIFIED-based, NOT missing-based: a doc
+    # that was merely uploaded (status ``uploaded``, not yet verified) still
+    # counts as outstanding (PLAN §C1.5 — hết nợ chỉ khi VERIFY). Computed via
+    # the shared ``_compute_outstanding_debt_codes`` helper above so the FE
+    # badge, the gated ``approve`` permission here, and the service-side approve
+    # gate all agree on one definition.
+    profile.outstanding_debt_codes = list(_outstanding_debt_codes)
     # Expose the currently-missing mandatory doc codes so the FE can list them
     # in the submit-with-debt dialog (B3).
     profile.missing_doc_codes = list(missing_doc_codes)
@@ -8146,6 +8205,35 @@ async def approve_profile(
             "Vui lòng xác nhận thanh toán lệ phí trước khi duyệt hồ sơ."
         )
 
+    # Fast-track nợ giấy tờ (C1.5) — APPROVE GATE. A profile submitted with a
+    # document debt may NOT be approved until every owed doc is VERIFIED (or
+    # paper_submitted). Computed from the persisted ``document_debt`` snapshot ∩
+    # docs-not-yet-verified, via the same helper the FE-facing
+    # ``_compute_frontend_fields`` uses (so the disabled button + the server
+    # gate agree). Profiles without a debt snapshot have no outstanding codes →
+    # this is a no-op (no regression). Runs BEFORE the irreversible quota
+    # increment so a blocked approve never consumes a seat.
+    if getattr(profile, "document_debt", None):
+        from app.repositories import AdmissionRepository as _ApproveAdmissionRepo
+
+        _approve_documents = await _ApproveAdmissionRepo(db).get_all_documents(
+            profile.id
+        )
+        _approve_outstanding = _compute_outstanding_debt_codes(
+            profile, _approve_documents
+        )
+        if _approve_outstanding:
+            log.warning(
+                "Attempt to approve profile with outstanding document debt",
+                profile_id=profile.id,
+                approver_id=approver.id,
+                outstanding_debt_codes=_approve_outstanding,
+            )
+            raise BusinessRuleViolation(
+                "Hồ sơ còn nợ giấy tờ chưa bổ sung/xác minh đủ, không thể "
+                "duyệt. Cần verify đủ giấy tờ trước khi duyệt."
+            )
+
     # ADM-026: quota gate. Locks the OfferingAcademicInfo row before
     # counting committed seats so concurrent approve calls cannot blow the
     # cap. Admin can override with bypass_quota + bypass_reason; manager
@@ -11552,6 +11640,25 @@ async def bulk_approve(
                 failed_ids.append(profile_id)
                 errors[profile_id] = "Lệ phí xét tuyển chưa được thanh toán"
                 continue
+
+            # Fast-track nợ giấy tờ (C1.5) — same approve gate as single
+            # approve_profile: a profile with an unresolved document debt may
+            # NOT be (bulk-)approved. Per-item skip (not a batch abort) to match
+            # the other bulk gates. No-op for profiles without a debt snapshot.
+            if getattr(profile, "document_debt", None):
+                from app.repositories import AdmissionRepository as _BulkRepo
+
+                _bulk_docs = await _BulkRepo(db).get_all_documents(profile.id)
+                _bulk_outstanding = _compute_outstanding_debt_codes(
+                    profile, _bulk_docs
+                )
+                if _bulk_outstanding:
+                    failed_ids.append(profile_id)
+                    errors[profile_id] = (
+                        "Hồ sơ còn nợ giấy tờ chưa bổ sung/xác minh đủ, "
+                        "không thể duyệt."
+                    )
+                    continue
 
             # ADM-026: per-item quota gate. Per-item bypass fields let admin
             # selectively override the cap for some profiles in the batch

--- a/Backend_FastAPI/app/utils/admission_status.py
+++ b/Backend_FastAPI/app/utils/admission_status.py
@@ -101,6 +101,37 @@ def is_admitted_like(profile: "AdmissionProfile") -> bool:
     return profile.status in ADMITTED_LIKE_STATUSES
 
 
+def is_fee_eligible(profile: "AdmissionProfile") -> bool:
+    """True iff an official Fee/Invoice may be created for ``profile``.
+
+    Single source of truth for the fee-eligible state gate, shared by
+    ``routers/fees.py:_fee_calc_authorized`` (the service-side authorization)
+    and the ``calculate_fee`` permission flag in
+    ``admission_service._compute_frontend_fields`` (the FE button). Both
+    previously inlined the SAME three-way predicate kept in sync by a
+    "must stay mirrored" comment; lifting it here removes the drift risk.
+
+    Fee-eligible states:
+      * admitted-like (legacy ``approved`` / ``overridden`` + choice-engine
+        ``admitted``) — the post-decision happy path,
+      * ``confirmed`` / ``enrolled`` — later post-decision milestones,
+      * ``submitted`` ONLY for single-path profiles (C2 fast-track prepay /
+        giữ chỗ). A multi-NV profile (``uses_choice_engine``) at ``submitted``
+        has not locked its admitted choice yet (all choices ``pending`` until
+        publish), so calculating tuition would risk the wrong ngành — it
+        qualifies later via ``admitted`` (``is_admitted_like``).
+
+    Earlier states (``draft`` etc.) are NOT eligible (a fee would be premature).
+    Behaviour-preserving extraction — keep this in lockstep with both call
+    sites if the gate ever changes.
+    """
+    return (
+        is_admitted_like(profile)
+        or profile.status in ("confirmed", "enrolled")
+        or (profile.status == "submitted" and not profile.uses_choice_engine)
+    )
+
+
 def is_confirmation_eligible(profile: "AdmissionProfile") -> bool:
     """True iff the profile is eligible to issue / redeem a magic-link
     confirmation token.

--- a/Backend_FastAPI/tests/api/test_admission_submit_document_debt.py
+++ b/Backend_FastAPI/tests/api/test_admission_submit_document_debt.py
@@ -190,6 +190,28 @@ async def _verify_doc(profile_id: int, doc_type_id: int) -> None:
             pd.verified_at = datetime.now(timezone.utc)
 
 
+async def _set_doc_status(profile_id: int, doc_type_id: int, status: str) -> None:
+    """Set a ProfileDocument to an arbitrary status (e.g. paper_submitted)."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            pd = (
+                await session.execute(
+                    select(models.ProfileDocument).where(
+                        models.ProfileDocument.profile_id == profile_id,
+                        models.ProfileDocument.document_type_id == doc_type_id,
+                    )
+                )
+            ).scalar_one()
+            pd.status = status
+
+
+async def _ver(client: AsyncClient, headers: dict, profile_id: int) -> int:
+    """Current profile version (for optimistic-lock-guarded actions)."""
+    res = await client.get(f"/api/admissions/{profile_id}", headers=headers)
+    assert res.status_code == 200, res.text
+    return res.json()["version"]
+
+
 async def _auth(client: AsyncClient, user: dict) -> dict:
     res = await client.post(
         "/api/auth/login",
@@ -451,3 +473,285 @@ class TestSubmitWithDocumentDebt:
         ]
         # snapshot retained for audit ("đã từng nợ")
         assert get_body2["document_debt"]["codes"] == [doc_code]
+
+
+class TestOutstandingDebtVerifiedBased:
+    """outstanding_debt_codes resolves on VERIFY, not on mere upload (C1.5).
+
+    The regression these guard: when the path is in LAX mode
+    (``allow_unverified_submission=True``), an uploaded-but-unverified doc
+    LEAVES ``missing_doc_codes`` (lax counts an uploaded file as present). The
+    OLD outstanding logic (``codes ∩ missing_doc_codes``) therefore emptied the
+    debt the instant the officer uploaded — before any reviewer verified. The
+    decision is "hết nợ chỉ khi VERIFY", so outstanding must stay non-empty
+    until the doc is verified/paper_submitted.
+    """
+
+    async def test_upload_without_verify_keeps_debt_outstanding_lax_mode(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """LAX mode: officer uploads owed doc (status uploaded, NOT verified)
+        → outstanding_debt_codes STILL lists it. Verify → it clears."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        doc_type_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        # allow_unverified=True (lax) is the case that exposed the bug.
+        pid = await _build_profile(
+            lead_id, mandatory_docs=[doc_code], allow_unverified=True
+        )
+        headers = await _auth(client, officer_user_in_db)
+
+        submit_res = await client.post(
+            f"/api/admissions/{pid}/submit",
+            headers=headers,
+            json={
+                "acknowledge_missing_docs": True,
+                "document_debt_reason": "cho nợ học bạ",
+            },
+        )
+        assert submit_res.status_code == 200, submit_res.text
+        assert submit_res.json()["status"] == "submitted", submit_res.json()
+
+        # Officer uploads the owed doc but it is NOT yet verified.
+        await _add_uploaded_doc(pid, doc_type_id)
+
+        get_res = await client.get(f"/api/admissions/{pid}", headers=headers)
+        assert get_res.status_code == 200, get_res.text
+        body = get_res.json()
+        # VERIFIED-based: still outstanding despite the upload (the bug fix).
+        assert body["outstanding_debt_codes"] == [doc_code], body[
+            "outstanding_debt_codes"
+        ]
+        # In lax mode the uploaded doc is no longer "missing" — proving the
+        # outstanding set is NOT derived from missing_doc_codes anymore.
+        assert doc_code not in body["missing_doc_codes"], body["missing_doc_codes"]
+
+        # Reviewer verifies → debt clears.
+        await _verify_doc(pid, doc_type_id)
+        get_res2 = await client.get(f"/api/admissions/{pid}", headers=headers)
+        assert get_res2.status_code == 200, get_res2.text
+        assert get_res2.json()["outstanding_debt_codes"] == [], get_res2.json()[
+            "outstanding_debt_codes"
+        ]
+
+    async def test_paper_submitted_resolves_debt(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """A doc marked paper_submitted (bản giấy) also clears the debt."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        doc_type_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(
+            lead_id, mandatory_docs=[doc_code], allow_unverified=False
+        )
+        headers = await _auth(client, officer_user_in_db)
+
+        submit_res = await client.post(
+            f"/api/admissions/{pid}/submit",
+            headers=headers,
+            json={
+                "acknowledge_missing_docs": True,
+                "document_debt_reason": "cho nợ",
+            },
+        )
+        assert submit_res.status_code == 200, submit_res.text
+        assert submit_res.json()["status"] == "submitted"
+
+        await _add_uploaded_doc(pid, doc_type_id)
+        # Still outstanding until verify/paper_submitted.
+        get_a = await client.get(f"/api/admissions/{pid}", headers=headers)
+        assert get_a.json()["outstanding_debt_codes"] == [doc_code]
+
+        await _set_doc_status(pid, doc_type_id, "paper_submitted")
+        get_b = await client.get(f"/api/admissions/{pid}", headers=headers)
+        assert get_b.json()["outstanding_debt_codes"] == [], get_b.json()[
+            "outstanding_debt_codes"
+        ]
+
+
+class TestApproveGateDocumentDebt:
+    """Approve is BLOCKED while a document debt is outstanding (C1.5)."""
+
+    async def _submit_with_debt(
+        self,
+        client: AsyncClient,
+        officer_headers: dict,
+        pid: int,
+        reason: str = "cho nợ giấy tờ",
+    ) -> None:
+        res = await client.post(
+            f"/api/admissions/{pid}/submit",
+            headers=officer_headers,
+            json={
+                "acknowledge_missing_docs": True,
+                "document_debt_reason": reason,
+            },
+        )
+        assert res.status_code == 200, res.text
+        assert res.json()["status"] == "submitted", res.json()
+
+    async def test_approve_blocked_while_debt_outstanding(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """submitted-with-debt + owed doc unverified → manager approve is
+        rejected with a 400 BusinessRuleViolation; the FE approve flag is off."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        doc_type_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(
+            lead_id, mandatory_docs=[doc_code], allow_unverified=False
+        )
+        officer_headers = await _auth(client, officer_user_in_db)
+        await self._submit_with_debt(client, officer_headers, pid)
+
+        manager_headers = await _auth(client, manager_user_in_db)
+
+        # FE contract: the approve permission/action is suppressed.
+        get_res = await client.get(f"/api/admissions/{pid}", headers=manager_headers)
+        assert get_res.status_code == 200, get_res.text
+        body = get_res.json()
+        assert body["outstanding_debt_codes"] == [doc_code]
+        assert body["permissions"].get("approve") is False, body["permissions"]
+        assert "approve" not in body["available_actions"], body["available_actions"]
+
+        # Server gate: attempting approve anyway → 400.
+        version = body["version"]
+        approve_res = await client.post(
+            f"/api/admissions/{pid}/approve",
+            headers=manager_headers,
+            json={"notes": "duyệt", "version": version},
+        )
+        assert approve_res.status_code == 400, approve_res.text
+        assert "nợ giấy tờ" in approve_res.json()["detail"], approve_res.json()
+
+        # Profile stayed submitted (no seat consumed, no transition).
+        profile = await _load_profile(pid)
+        assert profile.status == "submitted"
+
+    async def test_approve_ok_after_debt_verified(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """Once the owed doc is verified (outstanding empties) approve works."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        doc_type_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(
+            lead_id, mandatory_docs=[doc_code], allow_unverified=False
+        )
+        officer_headers = await _auth(client, officer_user_in_db)
+        await self._submit_with_debt(client, officer_headers, pid)
+
+        # Officer supplies + reviewer verifies the owed doc.
+        await _add_uploaded_doc(pid, doc_type_id)
+        await _verify_doc(pid, doc_type_id)
+
+        manager_headers = await _auth(client, manager_user_in_db)
+        get_res = await client.get(f"/api/admissions/{pid}", headers=manager_headers)
+        assert get_res.status_code == 200, get_res.text
+        body = get_res.json()
+        assert body["outstanding_debt_codes"] == [], body["outstanding_debt_codes"]
+        assert body["permissions"].get("approve") is True, body["permissions"]
+
+        version = body["version"]
+        approve_res = await client.post(
+            f"/api/admissions/{pid}/approve",
+            headers=manager_headers,
+            json={"notes": "đủ giấy tờ", "version": version},
+        )
+        assert approve_res.status_code == 200, approve_res.text
+        assert approve_res.json()["status"] == "approved", approve_res.json()
+
+    async def test_approve_unaffected_without_document_debt(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """No-regression: a profile submitted WITHOUT a debt (all docs present)
+        approves exactly as before — the gate is a no-op when document_debt is
+        NULL."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        doc_type_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(
+            lead_id, mandatory_docs=[doc_code], allow_unverified=True
+        )
+        # Upload the mandatory doc up-front so a plain submit (no debt) passes.
+        await _add_uploaded_doc(pid, doc_type_id)
+        officer_headers = await _auth(client, officer_user_in_db)
+
+        submit_res = await client.post(
+            f"/api/admissions/{pid}/submit", headers=officer_headers
+        )
+        assert submit_res.status_code == 200, submit_res.text
+        assert submit_res.json()["status"] == "submitted", submit_res.json()
+
+        profile = await _load_profile(pid)
+        assert profile.document_debt is None
+
+        manager_headers = await _auth(client, manager_user_in_db)
+        version = await _ver(client, manager_headers, pid)
+        approve_res = await client.post(
+            f"/api/admissions/{pid}/approve",
+            headers=manager_headers,
+            json={"notes": "ok", "version": version},
+        )
+        assert approve_res.status_code == 200, approve_res.text
+        assert approve_res.json()["status"] == "approved", approve_res.json()
+
+    async def test_bulk_approve_skips_profile_with_outstanding_debt(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """bulk_approve must NOT bypass the debt gate — the debt-laden item is
+        skipped (recorded in errors), not approved."""
+        from app.services import admission_service
+
+        unit_id = seed_lead_dependencies["unit_id"]
+        doc_type_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(
+            lead_id, mandatory_docs=[doc_code], allow_unverified=False
+        )
+        officer_headers = await _auth(client, officer_user_in_db)
+        await self._submit_with_debt(client, officer_headers, pid)
+
+        profile = await _load_profile(pid)
+        version = profile.version
+
+        async with AsyncSessionLocal() as session:
+            manager = await session.get(models.User, manager_user_in_db["id"])
+            result, post_commit = await admission_service.bulk_approve(
+                db=session,
+                items=[{"profile_id": pid, "version": version}],
+                approver=manager,
+            )
+            await session.commit()
+            if post_commit is not None:
+                await post_commit()
+
+        assert result["success_count"] == 0, result
+        assert pid in result["failed_ids"], result
+        assert "nợ giấy tờ" in result["errors"][pid], result["errors"]
+
+        # Profile stayed submitted (not approved).
+        profile_after = await _load_profile(pid)
+        assert profile_after.status == "submitted"

--- a/Backend_FastAPI/tests/api/test_admission_submit_document_debt.py
+++ b/Backend_FastAPI/tests/api/test_admission_submit_document_debt.py
@@ -1,0 +1,453 @@
+"""Fast-track prepay/giữ chỗ — submit-with-document-debt contract (C1).
+
+Covers TUITION_PREPAY_FASTTRACK_PLAN.md §6 (C1):
+
+- staff submit with ONLY missing mandatory docs + acknowledge + reason →
+  ``submitted`` + ``document_debt`` column populated correctly.
+- SUBTRACTION: still blocked (stays draft) when ANY non-document error
+  remains (here: a missing citizen_id) even with acknowledge + reason.
+- No reason → blocked (acknowledge alone is insufficient).
+- B2: an uploaded-but-pending-verify doc (strict mode) is NOT waivable —
+  submit-with-debt stays blocked.
+- Candidate/magic-link (current_user=None) can NEVER waive (service-level).
+- ``outstanding_debt_codes`` is computed (snapshot ∩ docs still missing) and
+  is in PARITY between the submit response and a subsequent GET; uploading
+  the owed doc empties it (badge self-resolves).
+
+All tests build profiles directly in the DB (mirroring the proven
+``create_submittable_profile_direct`` recipe + the #337 seed chain) so the
+ONLY remaining submit gate is the document one under test.
+"""
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+from tests.fixtures.builders import (
+    ensure_submittable_ward,
+    seed_submittable_offering_config,
+    submittable_profile_fields,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _submittable_applied_rules(
+    mandatory_docs: list[str],
+    *,
+    allow_unverified: bool = True,
+) -> dict:
+    """applied_rules that clear scoring + carry the given mandatory docs.
+
+    ``schema_version=2`` + an explicit ``allow_unverified_submission`` so the
+    strict/lax document branch is deterministic (no grandfather fallback).
+    """
+    return {
+        "min_gpa": 0,
+        "mandatory_docs": list(mandatory_docs),
+        "allowed_subject_codes": ["TOAN"],
+        "scoring_method": "sum",
+        "required_subject_count": 1,
+        "subject_selection_mode": "fixed",
+        "schema_version": 2,
+        "allow_unverified_submission": allow_unverified,
+    }
+
+
+async def _create_test_lead(unit_id: int, officer_id: int) -> int:
+    unique = uuid.uuid4().hex[:12]
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            lead = models.Lead(
+                full_name=f"Debt Applicant {unique}",
+                phone=f"09{unique[:8]}",
+                email=f"debt_{unique}@example.com",
+                source="website",
+                unit_id=unit_id,
+                assigned_officer_id=officer_id,
+            )
+            session.add(lead)
+            await session.flush()
+            return lead.id
+
+
+async def _ensure_subject_toan() -> int:
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            subj = (
+                await session.execute(
+                    select(models.Subject).where(models.Subject.code == "TOAN")
+                )
+            ).scalar_one_or_none()
+            if subj is None:
+                subj = models.Subject(code="TOAN", name_vi="Toan", is_active=True)
+                session.add(subj)
+                await session.flush()
+            return subj.id
+
+
+async def _create_doc_type(label: str) -> tuple[int, str]:
+    """Create a ConfigDocumentType, return (id, code)."""
+    ts = uuid.uuid4().hex[:10]
+    code = f"{label}_{ts}"
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            dt = models.ConfigDocumentType(
+                code=code, name=f"DOC {code}", display_order=99
+            )
+            session.add(dt)
+            await session.flush()
+            return dt.id, code
+
+
+async def _build_profile(
+    lead_id: int,
+    *,
+    mandatory_docs: list[str],
+    allow_unverified: bool = True,
+    citizen_id: str | None = "",  # "" → auto; None → leave NULL (force error)
+) -> int:
+    """Create a draft profile that is submittable EXCEPT for the docs under
+    test. Returns the profile id."""
+    await ensure_submittable_ward()
+    subj_id = await _ensure_subject_toan()
+    cid = (
+        None
+        if citizen_id is None
+        else (citizen_id or f"0{datetime.now().timestamp():.0f}"[:12])
+    )
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            lead = await session.get(models.Lead, lead_id)
+            seed = await seed_submittable_offering_config(session, lead.unit_id)
+            profile = models.AdmissionProfile(
+                lead_id=lead_id,
+                status="draft",
+                citizen_id=cid,
+                version=1,
+                applied_rules=_submittable_applied_rules(
+                    mandatory_docs, allow_unverified=allow_unverified
+                ),
+                academic_year=seed["academic_year"],
+                family_info=[
+                    {
+                        "relationship": "Cha",
+                        "full_name": "Test Father",
+                        "phone": "0901234567",
+                    }
+                ],
+                **submittable_profile_fields(seed),
+            )
+            session.add(profile)
+            await session.flush()
+            session.add(
+                models.ProfileSubjectScore(
+                    profile_id=profile.id, subject_id=subj_id, score=8.0
+                )
+            )
+            await session.flush()
+            return profile.id
+
+
+async def _add_uploaded_doc(profile_id: int, doc_type_id: int) -> None:
+    """Attach an uploaded-but-unverified ProfileDocument (file present,
+    status='uploaded') for a mandatory doc — the B2 'pending verify' case."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            session.add(
+                models.ProfileDocument(
+                    profile_id=profile_id,
+                    document_type_id=doc_type_id,
+                    category="path",
+                    status="uploaded",
+                    file_path=f"uploads/admissions/{profile_id}/pending.pdf",
+                    uploaded_at=datetime.now(timezone.utc),
+                )
+            )
+
+
+async def _verify_doc(profile_id: int, doc_type_id: int) -> None:
+    """Flip the pending doc to verified (officer resolved the debt)."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            pd = (
+                await session.execute(
+                    select(models.ProfileDocument).where(
+                        models.ProfileDocument.profile_id == profile_id,
+                        models.ProfileDocument.document_type_id == doc_type_id,
+                    )
+                )
+            ).scalar_one()
+            pd.status = "verified"
+            pd.verified_at = datetime.now(timezone.utc)
+
+
+async def _auth(client: AsyncClient, user: dict) -> dict:
+    res = await client.post(
+        "/api/auth/login",
+        data={"username": user["username"], "password": user["password"]},
+    )
+    assert res.status_code == 200, f"login failed: {res.text}"
+    token = res.cookies.get("access_token")
+    client.cookies.delete("access_token")
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _load_profile(profile_id: int) -> models.AdmissionProfile:
+    async with AsyncSessionLocal() as session:
+        return (
+            await session.execute(
+                select(models.AdmissionProfile).where(
+                    models.AdmissionProfile.id == profile_id
+                )
+            )
+        ).scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitWithDocumentDebt:
+    async def test_staff_submit_with_debt_succeeds_and_records_snapshot(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """Officer + acknowledge + reason + only missing docs → submitted +
+        document_debt column populated with {codes, reason, by_user_id, at}."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        _doc_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(lead_id, mandatory_docs=[doc_code])
+        headers = await _auth(client, officer_user_in_db)
+
+        res = await client.post(
+            f"/api/admissions/{pid}/submit",
+            headers=headers,
+            json={
+                "acknowledge_missing_docs": True,
+                "document_debt_reason": "HS xin cấp lại học bạ, hẹn 30/06",
+            },
+        )
+        assert res.status_code == 200, res.text
+        assert res.json()["status"] == "submitted", res.json()
+
+        profile = await _load_profile(pid)
+        assert profile.status == "submitted"
+        assert profile.document_debt is not None
+        assert profile.document_debt["codes"] == [doc_code]
+        assert profile.document_debt["reason"] == "HS xin cấp lại học bạ, hẹn 30/06"
+        assert profile.document_debt["by_user_id"] == officer_user_in_db["id"]
+        assert "at" in profile.document_debt
+
+        # ⚠️ Anti-tamper: document_debt must NOT have leaked into applied_rules
+        # (that would RAISE on the immutability trigger in prod).
+        assert "document_debt" not in (profile.applied_rules or {})
+
+    async def test_submit_with_debt_no_reason_blocks(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """acknowledge_missing_docs=True but NO reason → stays draft."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        _doc_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(lead_id, mandatory_docs=[doc_code])
+        headers = await _auth(client, officer_user_in_db)
+
+        res = await client.post(
+            f"/api/admissions/{pid}/submit",
+            headers=headers,
+            json={"acknowledge_missing_docs": True},
+        )
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["status"] == "draft", body
+        assert body["validation_errors"]
+        profile = await _load_profile(pid)
+        assert profile.status == "draft"
+        assert profile.document_debt is None
+
+    async def test_plain_submit_missing_docs_blocks(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """No body (default) + missing docs → stays draft (original flow)."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        _doc_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(lead_id, mandatory_docs=[doc_code])
+        headers = await _auth(client, officer_user_in_db)
+
+        res = await client.post(f"/api/admissions/{pid}/submit", headers=headers)
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["status"] == "draft", body
+        # missing-doc error is surfaced in the full list
+        assert any("Thiếu tài liệu" in e for e in body["validation_errors"])
+        profile = await _load_profile(pid)
+        assert profile.document_debt is None
+
+    async def test_other_error_still_blocks_despite_reason(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """SUBTRACTION: a non-document error (missing citizen_id) keeps the
+        profile in draft even with acknowledge + reason — only docs waivable."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        _doc_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(
+            lead_id, mandatory_docs=[doc_code], citizen_id=None
+        )
+        headers = await _auth(client, officer_user_in_db)
+
+        res = await client.post(
+            f"/api/admissions/{pid}/submit",
+            headers=headers,
+            json={
+                "acknowledge_missing_docs": True,
+                "document_debt_reason": "cho nợ",
+            },
+        )
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["status"] == "draft", body
+        assert any("CCCD" in e or "citizen_id" in e for e in body["validation_errors"])
+        profile = await _load_profile(pid)
+        assert profile.status == "draft"
+        assert profile.document_debt is None
+
+    async def test_unverified_doc_not_waived(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """B2: a doc uploaded-but-pending-verify (strict mode) is NOT missing,
+        so submit-with-debt does not waive it — stays draft."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        doc_type_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(
+            lead_id, mandatory_docs=[doc_code], allow_unverified=False
+        )
+        # Upload the file but leave it unverified → strict mode rejects it,
+        # but it is "pending verify", not "missing" → not waivable.
+        await _add_uploaded_doc(pid, doc_type_id)
+        headers = await _auth(client, officer_user_in_db)
+
+        res = await client.post(
+            f"/api/admissions/{pid}/submit",
+            headers=headers,
+            json={
+                "acknowledge_missing_docs": True,
+                "document_debt_reason": "cho nợ",
+            },
+        )
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["status"] == "draft", body
+        assert any("chưa được xác minh" in e for e in body["validation_errors"])
+        profile = await _load_profile(pid)
+        assert profile.status == "draft"
+        assert profile.document_debt is None
+
+    async def test_candidate_magic_link_cannot_waive(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """Service-level: current_user=None (magic-link candidate) may NOT
+        waive even with acknowledge + reason — stays draft, no debt."""
+        from app.services import admission_service
+
+        unit_id = seed_lead_dependencies["unit_id"]
+        _doc_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(lead_id, mandatory_docs=[doc_code])
+
+        async with AsyncSessionLocal() as session:
+            result, post_commit = await admission_service.submit_and_evaluate(
+                db=session,
+                profile_id=pid,
+                current_user=None,  # magic-link candidate path
+                acknowledge_missing_docs=True,
+                document_debt_reason="candidate trying to skip docs",
+            )
+            await session.commit()
+            if post_commit is not None:
+                await post_commit()
+
+        assert result["status"] == "draft", result
+        profile = await _load_profile(pid)
+        assert profile.status == "draft"
+        assert profile.document_debt is None
+
+    async def test_outstanding_debt_codes_parity_and_resolution(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """outstanding_debt_codes = snapshot ∩ docs-still-missing; parity
+        between submit response and GET; empties after the doc is verified."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        doc_type_id, doc_code = await _create_doc_type("needdoc")
+        lead_id = await _create_test_lead(unit_id, officer_user_in_db["id"])
+        pid = await _build_profile(
+            lead_id, mandatory_docs=[doc_code], allow_unverified=False
+        )
+        headers = await _auth(client, officer_user_in_db)
+
+        submit_res = await client.post(
+            f"/api/admissions/{pid}/submit",
+            headers=headers,
+            json={
+                "acknowledge_missing_docs": True,
+                "document_debt_reason": "cho nợ",
+            },
+        )
+        assert submit_res.status_code == 200, submit_res.text
+        submit_body = submit_res.json()
+        assert submit_body["status"] == "submitted", submit_body
+
+        # GET reflects the debt + computed outstanding codes.
+        get_res = await client.get(f"/api/admissions/{pid}", headers=headers)
+        assert get_res.status_code == 200, get_res.text
+        get_body = get_res.json()
+        assert get_body["document_debt"]["codes"] == [doc_code]
+        assert get_body["outstanding_debt_codes"] == [doc_code]
+        assert doc_code in get_body["missing_doc_codes"]
+
+        # Officer uploads + verifies the owed doc → outstanding self-resolves
+        # to [] while the snapshot (audit) is retained.
+        await _add_uploaded_doc(pid, doc_type_id)
+        await _verify_doc(pid, doc_type_id)
+
+        get_res2 = await client.get(f"/api/admissions/{pid}", headers=headers)
+        assert get_res2.status_code == 200, get_res2.text
+        get_body2 = get_res2.json()
+        assert get_body2["outstanding_debt_codes"] == [], get_body2[
+            "outstanding_debt_codes"
+        ]
+        # snapshot retained for audit ("đã từng nợ")
+        assert get_body2["document_debt"]["codes"] == [doc_code]

--- a/Backend_FastAPI/tests/api/test_admission_submit_document_debt.py
+++ b/Backend_FastAPI/tests/api/test_admission_submit_document_debt.py
@@ -20,6 +20,7 @@ ONLY remaining submit gate is the document one under test.
 """
 import uuid
 from datetime import datetime, timezone
+from decimal import Decimal
 
 import pytest
 from httpx import AsyncClient
@@ -28,6 +29,7 @@ from sqlalchemy import select
 from app import models
 from app.database import AsyncSessionLocal
 from tests.fixtures.builders import (
+    AdmissionRoundBuilder,
     ensure_submittable_ward,
     seed_submittable_offering_config,
     submittable_profile_fields,
@@ -755,3 +757,263 @@ class TestApproveGateDocumentDebt:
         # Profile stayed submitted (not approved).
         profile_after = await _load_profile(pid)
         assert profile_after.status == "submitted"
+
+
+# ---------------------------------------------------------------------------
+# Choice-engine (multi-NV) seed helper — for the publish_result gate (C1.5).
+# ---------------------------------------------------------------------------
+
+
+async def _build_choice_engine_profile_submitted(
+    unit_id: int,
+    stage_id: str,
+    major_program_id: int,
+    *,
+    mandatory_docs: list[str],
+    document_debt_codes: list[str] | None,
+) -> tuple[int, int]:
+    """Seed a multi-NV (``uses_choice_engine=True``) profile already at
+    ``submitted`` with ≥1 choice + a full path/config chain the publish cascade
+    can evaluate.
+
+    Mirrors the proven ``pr3a_seed`` chain (lead → profile + path +
+    path_subject_group_config + subject_group_subject + 1 choice). When
+    ``document_debt_codes`` is non-empty a ``document_debt`` snapshot is written
+    directly (simulating an earlier staff submit-with-debt) so the publish gate
+    sees an outstanding debt — keeping this test isolated to the gate (the
+    submit-with-debt path itself is covered above for single-path profiles).
+
+    Returns ``(profile_id, path_id)``.
+    """
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            offering = models.ProgramOffering(
+                program_id=major_program_id,
+                offering_type="full_time",
+                duration_semesters=8,
+            )
+            s.add(offering)
+            await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=offering.id,
+                academic_year=2026,
+                annual_admission_quota=20,
+                tuition_fee_per_year=1_000_000,
+            )
+            s.add(ai)
+            await s.flush()
+
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                s, academic_year=2026,
+            )
+
+            method = models.AdmissionMethod(
+                code=f"MDEBT_{ts}",
+                name=f"Debt method {ts}",
+                requires_subject_scores=True,
+                is_active=True,
+            )
+            s.add(method)
+            await s.flush()
+
+            path = models.AdmissionPath(
+                academic_info_id=ai.id,
+                admission_method_id=method.id,
+                admission_round_id=round_id,
+                status="active",
+            )
+            s.add(path)
+            await s.flush()
+
+            sg = models.SubjectGroup(code=f"SGD{ts}"[:20], name=f"SG debt {ts}")
+            s.add(sg)
+            await s.flush()
+            subj = models.Subject(code=f"SUD{ts}"[:20], name_vi=f"Subj debt {ts}")
+            s.add(subj)
+            await s.flush()
+            s.add(
+                models.SubjectGroupSubject(
+                    subject_group_id=sg.id, subject_id=subj.id, position=1
+                )
+            )
+            await s.flush()
+            config = models.PathSubjectGroupConfig(
+                admission_path_id=path.id,
+                subject_group_id=sg.id,
+                min_score=Decimal("18.00"),
+            )
+            s.add(config)
+            await s.flush()
+
+            round_obj = await s.get(models.OfferingAdmissionRound, round_id)
+            round_obj.allow_multi_nv = True
+            await s.flush()
+
+            lead = models.Lead(
+                full_name=f"Debt MultiNV Lead {ts}",
+                phone=f"098{ts:07d}"[:10],
+                unit_id=unit_id,
+                pipeline_stage_id=stage_id,
+                source="walkin",
+            )
+            s.add(lead)
+            await s.flush()
+
+            document_debt = None
+            if document_debt_codes:
+                document_debt = {
+                    "codes": list(document_debt_codes),
+                    "reason": "Multi-NV nộp kèm nợ giấy tờ",
+                    "by_user_id": None,
+                    "at": datetime.now(timezone.utc).isoformat(),
+                }
+            profile = models.AdmissionProfile(
+                lead_id=lead.id,
+                citizen_id=f"6{ts:08d}2"[:12],
+                status="submitted",
+                applied_rules={"mandatory_docs": list(mandatory_docs)},
+                academic_year=2026,
+                uses_choice_engine=True,
+                document_debt=document_debt,
+            )
+            s.add(profile)
+            await s.flush()
+
+            choice = models.AdmissionProfileChoice(
+                admission_profile_id=profile.id,
+                admission_path_id=path.id,
+                path_subject_group_config_id=config.id,
+                display_order=1,
+                decision="pending",
+            )
+            s.add(choice)
+            await s.flush()
+
+            return profile.id, path.id
+
+
+class TestPublishResultGateDocumentDebt:
+    """publish_result (multi-NV decision site) is BLOCKED while a document debt
+    is outstanding (C1.5 — closes the choice-engine gap).
+
+    A multi-NV profile can submit WITH a document debt, so it can sit at
+    ``submitted`` with owed docs unverified. ``publish-result`` is the multi-NV
+    admit/reject cascade — it must obey the same "no decision while docs are
+    owed" gate as legacy ``approve``; otherwise a manager could publish/admit a
+    profile whose documents were never verified.
+    """
+
+    async def test_publish_blocked_while_debt_outstanding(
+        self,
+        client: AsyncClient,
+        manager_token_headers: dict,
+        seed_lead_dependencies: dict,
+    ):
+        doc_type_id, doc_code = await _create_doc_type("needdoc")
+        pid, _path_id = await _build_choice_engine_profile_submitted(
+            seed_lead_dependencies["unit_id"],
+            seed_lead_dependencies["stage_id"],
+            seed_lead_dependencies["major_program_id"],
+            mandatory_docs=[doc_code],
+            document_debt_codes=[doc_code],
+        )
+
+        # FE contract: publish_result permission is suppressed + outstanding listed.
+        get_res = await client.get(
+            f"/api/admissions/{pid}", headers=manager_token_headers
+        )
+        assert get_res.status_code == 200, get_res.text
+        body = get_res.json()
+        assert body["outstanding_debt_codes"] == [doc_code], body[
+            "outstanding_debt_codes"
+        ]
+        assert body["permissions"].get("publish_result") is False, body[
+            "permissions"
+        ]
+
+        # Server gate: attempting publish anyway → 400 BusinessRuleViolation.
+        pub = await client.post(
+            f"/api/v2/admissions/{pid}/publish-result",
+            headers=manager_token_headers,
+        )
+        assert pub.status_code == 400, pub.text
+        assert "nợ giấy tờ" in pub.json()["detail"], pub.json()
+
+        # Blocked publish must NOT have mutated state (no transition/cascade).
+        profile = await _load_profile(pid)
+        assert profile.status == "submitted"
+
+    async def test_publish_ok_after_debt_verified(
+        self,
+        client: AsyncClient,
+        manager_token_headers: dict,
+        seed_lead_dependencies: dict,
+    ):
+        doc_type_id, doc_code = await _create_doc_type("needdoc")
+        pid, _path_id = await _build_choice_engine_profile_submitted(
+            seed_lead_dependencies["unit_id"],
+            seed_lead_dependencies["stage_id"],
+            seed_lead_dependencies["major_program_id"],
+            mandatory_docs=[doc_code],
+            document_debt_codes=[doc_code],
+        )
+        # Officer supplies + reviewer verifies the owed doc → outstanding empties.
+        await _add_uploaded_doc(pid, doc_type_id)
+        await _verify_doc(pid, doc_type_id)
+
+        get_res = await client.get(
+            f"/api/admissions/{pid}", headers=manager_token_headers
+        )
+        assert get_res.status_code == 200, get_res.text
+        body = get_res.json()
+        assert body["outstanding_debt_codes"] == [], body["outstanding_debt_codes"]
+        assert body["permissions"].get("publish_result") is True, body[
+            "permissions"
+        ]
+
+        # Gate cleared → publish runs the cascade (200; decision admit/reject
+        # depends on scores, but the gate no longer blocks).
+        pub = await client.post(
+            f"/api/v2/admissions/{pid}/publish-result",
+            headers=manager_token_headers,
+        )
+        assert pub.status_code == 200, pub.text
+        assert pub.json()["final_status"] in {"admitted", "rejected", "waitlisted"}
+
+    async def test_publish_unaffected_without_document_debt(
+        self,
+        client: AsyncClient,
+        manager_token_headers: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """No-regression: a multi-NV profile WITHOUT a debt publishes exactly as
+        before — the gate is a no-op when ``document_debt`` is NULL."""
+        doc_type_id, doc_code = await _create_doc_type("needdoc")
+        pid, _path_id = await _build_choice_engine_profile_submitted(
+            seed_lead_dependencies["unit_id"],
+            seed_lead_dependencies["stage_id"],
+            seed_lead_dependencies["major_program_id"],
+            mandatory_docs=[doc_code],
+            document_debt_codes=None,  # no debt snapshot
+        )
+
+        profile = await _load_profile(pid)
+        assert profile.document_debt is None
+
+        get_res = await client.get(
+            f"/api/admissions/{pid}", headers=manager_token_headers
+        )
+        assert get_res.status_code == 200, get_res.text
+        body = get_res.json()
+        assert body["outstanding_debt_codes"] == []
+        assert body["permissions"].get("publish_result") is True, body[
+            "permissions"
+        ]
+
+        pub = await client.post(
+            f"/api/v2/admissions/{pid}/publish-result",
+            headers=manager_token_headers,
+        )
+        assert pub.status_code == 200, pub.text
+        assert pub.json()["final_status"] in {"admitted", "rejected", "waitlisted"}

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -723,3 +723,204 @@ async def test_accountant_same_unit_can_calculate_at_submitted(
         f"Same-unit accountant should calculate fee at submitted, got "
         f"{resp.status_code}: {resp.text[:300]}"
     )
+
+
+# ==============================================================================
+# L2 — submitted gate is single-path ONLY (multi-NV awaits publish)
+# ==============================================================================
+#
+# C2 opened the ``submitted`` state for fee calculation, but a MULTI-NV profile
+# (``uses_choice_engine=True``) at ``submitted`` has not yet locked its admitted
+# choice (all choices decision="pending" until the round is published). The fee
+# service's ``_resolve_academic_info_id`` would pick ONE config-driven ngành and
+# could auto-issue tuition for the WRONG ngành. L2 therefore tightens BOTH gate
+# sites so ``submitted`` is eligible only when ``not uses_choice_engine``:
+#   * routers/fees.py::_fee_calc_authorized               (route gate, 404)
+#   * admission_service.py _compute_*["calculate_fee"]    (FE flag)
+# A multi-NV profile becomes eligible again only after publish → admitted-like
+# (covered by ``is_admitted_like``), which these tests also assert is NOT over-
+# tightened.
+#
+# ``uses_choice_engine`` is a real Boolean COLUMN on AdmissionProfile (not a
+# computed property), so the tests flip it directly in the DB — mirroring how
+# the cross-unit / unassigned tests above mutate User.unit_id / Lead.assigned_
+# officer_id. This isolates the gate under test from the choice-engine
+# evaluation pipeline.
+
+
+async def _set_choice_engine(pid: int, *, value: bool, status: str | None = None):
+    """Flip ``uses_choice_engine`` (and optionally ``status``) on a profile.
+
+    Direct DB mutation keeps the L2 gate tests deterministic without driving the
+    full multi-NV publish workflow. ``status`` is constrained by the model
+    CheckConstraint — pass an allowed value (e.g. ``approved`` for an
+    admitted-like state).
+    """
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            from sqlalchemy import update
+            values = {"uses_choice_engine": value}
+            if status is not None:
+                values["status"] = status
+            await s.execute(
+                update(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == pid)
+                .values(**values)
+            )
+
+
+@pytest.mark.asyncio
+async def test_calculate_fee_hidden_for_multi_nv_at_submitted(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Site B mirror: a MULTI-NV profile (``uses_choice_engine=True``) at
+    ``submitted`` must NOT expose calculate_fee — it awaits publish.
+
+    The owning officer would otherwise see the button and be able to auto-issue
+    tuition for an as-yet-undecided ngành.
+    """
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="L2 MultiNV Submitted Hidden", approve=False,
+    )
+    await _set_choice_engine(pid, value=True)
+
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    detail = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
+    assert detail["status"] == "submitted", detail.get("status")
+    assert (
+        "calculate_fee" not in detail["available_actions"]
+    ), detail["available_actions"]
+    assert detail["permissions"]["calculate_fee"] is False
+
+
+@pytest.mark.asyncio
+async def test_calculate_fee_route_404_for_multi_nv_at_submitted(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Site A mirror: the route gate (_fee_calc_authorized) rejects a multi-NV
+    profile at ``submitted`` with 404 even for the owning officer.
+    """
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="L2 MultiNV Submitted 404", approve=False,
+    )
+    await _set_choice_engine(pid, value=True)
+
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 404, (
+        f"Multi-NV profile at submitted must be blocked by the route gate, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_path_calculate_fee_at_submitted_still_ok(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Control for L2: a SINGLE-PATH profile (``uses_choice_engine=False`` — the
+    fixture default) at ``submitted`` is still admitted (201). Confirms L2 only
+    narrows multi-NV, not the single-path fast-track C2 opened.
+    """
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="L2 SinglePath Submitted OK", approve=False,
+    )
+    # Assert the precondition explicitly so the control can't silently pass via
+    # a future default flip.
+    async with AsyncSessionLocal() as s:
+        prof = (await s.execute(
+            select(models.AdmissionProfile).where(models.AdmissionProfile.id == pid)
+        )).scalar_one()
+        assert (
+            prof.uses_choice_engine is False
+        ), "fixture should default to single-path"
+
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 201, (
+        f"Single-path profile at submitted should still calculate fee, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_multi_nv_calculate_fee_at_admitted_not_over_tightened(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """A MULTI-NV profile that has reached an admitted-like state (post-publish)
+    must STILL be able to calculate fee — L2 only narrows ``submitted``, it must
+    not regress the admitted/confirmed/enrolled path that ``is_admitted_like``
+    already authorizes.
+
+    Uses ``approved`` (admitted-like, allowed by the status CheckConstraint) to
+    simulate the post-publish decision while keeping ``uses_choice_engine=True``.
+    """
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="L2 MultiNV Admitted OK", approve=False,
+    )
+    # Flip to multi-NV AND advance to an admitted-like decision state.
+    await _set_choice_engine(pid, value=True, status="approved")
+
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    # FE flag visible.
+    detail = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
+    assert detail["status"] == "approved", detail.get("status")
+    assert "calculate_fee" in detail["available_actions"], detail["available_actions"]
+    assert detail["permissions"]["calculate_fee"] is True
+
+    # Route admits → 201.
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 201, (
+        f"Multi-NV at admitted-like state should still calculate fee, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -103,6 +103,14 @@ async def fee_calc_config(seed_lead_dependencies: dict):
                 tuition_fee_per_year=5000000, annual_admission_quota=100, is_published=True,
             )
             s.add(ai); await s.flush()
+            # C2 happy-path: tuition calculate_fee resolves the canonical
+            # amount from offering_semester_tuition (ADR-002), NOT
+            # tuition_fee_per_year. Without a HK1 row the service raises
+            # BadRequest("Chưa cấu hình học phí cho HK1") → 400. Seed HK1.
+            s.add(models.OfferingSemesterTuition(
+                academic_info_id=ai.id, semester_no=1, amount=5000000,
+            ))
+            await s.flush()
             am = models.AdmissionMethod(
                 code=f"hb_{ts}", name=f"HB_{ts}",
                 requires_gpa=True, requires_subject_scores=False, is_active=True,
@@ -161,6 +169,31 @@ async def fee_calc_config(seed_lead_dependencies: dict):
             )
             s.add(kva); await s.flush()
             school_id = sch.id
+
+            # C2 happy-path needs a real installment plan: the route rejects
+            # unknown/inactive codes with 400 before fee creation. "FULL" is
+            # the canonical single-payment seed code (schemas/finance.py
+            # default) but the test DB uses create_all() (no seed), so
+            # get-or-create it here. Tolerates parallel-module collisions.
+            full_plan = (await s.execute(
+                select(models.InstallmentPlan).where(
+                    models.InstallmentPlan.code == "FULL"
+                )
+            )).scalar_one_or_none()
+            if full_plan is None:
+                s.add(models.InstallmentPlan(
+                    code="FULL",
+                    name="Thanh toán 1 lần",
+                    installment_count=1,
+                    schedule=[{
+                        "installment_no": 1,
+                        "due_days_offset": 0,
+                        "percent": 100.0,
+                        "description": "Toàn bộ",
+                    }],
+                    is_active=True,
+                ))
+                await s.flush()
     return {
         "unit_id": uid,
         "offering_id": po.id,
@@ -178,8 +211,13 @@ async def _create_approved_profile(
     cfg,
     *,
     lead_name="PR7 Probe",
+    approve: bool = True,
 ):
-    """Create lead + admission, officer submits, admin approves."""
+    """Create lead + admission, officer submits, admin approves.
+
+    ``approve=False`` stops at the ``submitted`` state — used by the C2
+    fast-track tests (fee calculation is now allowed at ``submitted``).
+    """
     from tests._lead_status_test_ids import INITIAL_LEAD_STATUS_ID
 
     phone = f"0988{int(datetime.now().timestamp() * 1000) % 10**6:06d}"
@@ -247,18 +285,21 @@ async def _create_approved_profile(
     assert submit.status_code == 200, submit.text
     assert submit.json()["status"] == "submitted", submit.json()
 
+    if not approve:
+        return prof["id"]
+
     # Re-login as admin since the shared cookie jar was last written by
     # the officer submit; bearer token from the fixture may already be
     # invalidated via rotation.
     fresh_admin = await _login(client, "testadmin", "AdminPassword!123")
     v = (await client.get(f"{ADMISSIONS}/{prof['id']}", headers=fresh_admin)).json()["version"]
-    approve = await client.post(
+    approve_resp = await client.post(
         f"{ADMISSIONS}/{prof['id']}/approve",
         json={"notes": "OK", "version": v},
         headers=fresh_admin,
     )
-    assert approve.status_code == 200, approve.text
-    assert approve.json()["status"] == "approved"
+    assert approve_resp.status_code == 200, approve_resp.text
+    assert approve_resp.json()["status"] == "approved"
 
     return prof["id"]
 
@@ -462,4 +503,223 @@ async def test_calculate_fee_route_404_for_cross_unit_officer(
     # officer can't create fees for a profile outside their unit.
     assert resp.status_code in (403, 404), (
         f"Cross-unit officer should be denied, got {resp.status_code}: {resp.text[:200]}"
+    )
+
+
+# ==============================================================================
+# C2 — fee calculation allowed at ``submitted`` (fast-track prepay/hold-spot)
+# ==============================================================================
+#
+# Mirrors the two sites that gate fee creation (must stay in sync):
+#   * routers/fees.py::_fee_calc_authorized  (route gate, 404 on fail)
+#   * admission_service.py _compute_permissions["calculate_fee"] (FE flag)
+# Before C2 both required post-decision status (approved/confirmed/enrolled);
+# C2 adds ``submitted`` so officers can collect a tuition prepay before the
+# decision. Quyền giữ nguyên: officer phụ trách + manager/accountant cùng unit.
+
+
+@pytest.mark.asyncio
+async def test_calculate_fee_visible_in_actions_at_submitted(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Site B mirror: available_actions/permissions carry calculate_fee for the
+    owning officer while the profile is still ``submitted`` (not yet approved).
+    """
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="C2 Submitted Visible", approve=False,
+    )
+    oh = await _login(client, officer_user_in_db["username"], officer_user_in_db["password"])
+    detail = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
+    assert detail["status"] == "submitted", detail.get("status")
+    assert "calculate_fee" in detail["available_actions"], detail["available_actions"]
+    assert detail["permissions"]["calculate_fee"] is True
+
+
+@pytest.mark.asyncio
+async def test_owning_officer_calculate_tuition_at_submitted_auto_issues(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """C2 + B4 end-to-end at ``submitted``:
+    * owning officer → 201 (Site A route gate now admits submitted);
+    * tuition invoice is auto-issued (status == "issued", not draft);
+    * the captured invoice_cb fires INVOICE_ISSUED (router awaits it).
+
+    INVOICE_ISSUED is asserted by patching the dispatcher used inside the
+    invoice post-commit closure (same technique as
+    test_fee_calculated_event.py). The closure does a late import of
+    ``safe_dispatch`` from notification_dispatcher, so patching the module
+    attribute intercepts it regardless of call site.
+    """
+    from unittest.mock import AsyncMock, patch
+    from app.core.events import SystemEvents
+
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="C2 Submitted AutoIssue", approve=False,
+    )
+    oh = await _login(client, officer_user_in_db["username"], officer_user_in_db["password"])
+
+    with patch(
+        "app.services.notification_dispatcher.safe_dispatch",
+        new_callable=AsyncMock,
+    ) as mock_dispatch:
+        resp = await client.post(
+            "/api/fees/calculate",
+            json={
+                "admission_profile_id": pid,
+                "fee_type": "tuition",
+                "installment_plan_code": "FULL",
+                "semester_no": 1,
+            },
+            headers=oh,
+        )
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    invoices = body.get("invoices") or []
+    assert invoices, f"Expected at least one invoice, got: {body}"
+    # Auto-issue: tuition invoice is issued immediately, not left as draft.
+    assert all(inv["status"] == "issued" for inv in invoices), invoices
+
+    # B4: the issue callback must have been awaited → INVOICE_ISSUED dispatched.
+    events = {c.kwargs.get("event") for c in mock_dispatch.await_args_list}
+    assert SystemEvents.INVOICE_ISSUED in events, (
+        f"INVOICE_ISSUED not dispatched; events seen: {events}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_owning_officer_404_at_submitted(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """An officer who does NOT own the lead is denied (404) even at submitted —
+    the same-unit AND assigned scope is preserved by C2 (only status loosened).
+    """
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="C2 Submitted Unassigned", approve=False,
+    )
+    # Un-assign the officer from the lead — officer keeps same unit_id.
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            from sqlalchemy import update
+            prof = (await s.execute(
+                select(models.AdmissionProfile).where(models.AdmissionProfile.id == pid)
+            )).scalar_one()
+            await s.execute(
+                update(models.Lead)
+                .where(models.Lead.id == prof.lead_id)
+                .values(assigned_officer_id=None)
+            )
+
+    oh = await _login(client, officer_user_in_db["username"], officer_user_in_db["password"])
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+        headers=oh,
+    )
+    assert resp.status_code in (403, 404), (
+        f"Non-owning officer should be denied at submitted, got "
+        f"{resp.status_code}: {resp.text[:200]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_manager_same_unit_can_calculate_at_submitted(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    manager_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Manager in the same unit can calculate fee at submitted (quyền giữ
+    nguyên — manager/accountant cùng unit đều tính được)."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="C2 Submitted Manager", approve=False,
+    )
+    mh = await _login(
+        client, manager_user_in_db["username"], manager_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+        headers=mh,
+    )
+    assert resp.status_code == 201, (
+        f"Same-unit manager should calculate fee at submitted, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+
+
+@pytest_asyncio.fixture
+async def accountant_same_unit(seed_lead_dependencies: dict):
+    """Accountant user in the SAME unit as the seeded leads/profiles.
+
+    Built inline (no ACCOUNTANT entry in TestUsers / shared conftest) via
+    the canonical _create_user_and_role helper so the C2 same-unit case
+    doesn't depend on a fixture local to another module.
+    """
+    from tests.conftest import _create_user_and_role
+    user_data = {
+        "username": "c2_accountant_unit1",
+        "email": "c2_accountant_unit1@example.com",
+        "password": "AccountantPassword!345",
+        "role": "accountant",
+        "status": "active",
+    }
+    return await _create_user_and_role(
+        user_data, "role:accountant", unit_id=seed_lead_dependencies["unit_id"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_accountant_same_unit_can_calculate_at_submitted(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    accountant_same_unit: dict,
+    fee_calc_config: dict,
+):
+    """Accountant in the same unit can calculate fee at submitted."""
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="C2 Submitted Accountant", approve=False,
+    )
+    ah = await _login(
+        client, accountant_same_unit["username"], accountant_same_unit["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+        headers=ah,
+    )
+    assert resp.status_code == 201, (
+        f"Same-unit accountant should calculate fee at submitted, got "
+        f"{resp.status_code}: {resp.text[:300]}"
     )

--- a/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
+++ b/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
@@ -399,6 +399,61 @@ async def _calculate_tuition(
     return res.json()
 
 
+async def _ensure_consultation_status(
+    status_id: str, name: str, stage_id: str, color_code: str = "#888888"
+) -> None:
+    """Get-or-create a ConsultationStatus row.
+
+    ``seed_lead_dependencies`` (conftest) seeds most statuses but NOT ``sts08``
+    (withdrawn → "Từ chối tư vấn"), so the withdraw lead-sync 404s without it.
+    Idempotent so parallel modules don't collide on the PK.
+    """
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            existing = await session.get(models.ConsultationStatus, status_id)
+            if existing is None:
+                session.add(
+                    models.ConsultationStatus(
+                        id=status_id,
+                        name=name,
+                        color_code=color_code,
+                        stage_id=stage_id,
+                    )
+                )
+
+
+async def _reject(
+    client: AsyncClient, manager_headers: dict, pid: int, reason: str
+) -> dict:
+    """Reject a submitted profile (manager). Reads the live version first."""
+    body = await _get(client, manager_headers, pid)
+    res = await client.post(
+        f"{ADMISSIONS}/{pid}/reject",
+        headers=manager_headers,
+        json={"reason": reason, "version": body["version"]},
+    )
+    assert res.status_code == 200, res.text
+    out = res.json()
+    assert out["status"] == "rejected", out
+    return out
+
+
+async def _withdraw(
+    client: AsyncClient, headers: dict, pid: int, reason: str
+) -> dict:
+    """Withdraw a profile (officer/manager). Reads the live version first."""
+    body = await _get(client, headers, pid)
+    res = await client.post(
+        f"{ADMISSIONS}/{pid}/withdraw",
+        headers=headers,
+        json={"reason": reason, "version": body["version"]},
+    )
+    assert res.status_code == 200, res.text
+    out = res.json()
+    assert out["status"] == "withdrawn", out
+    return out
+
+
 async def _record_and_verify_payment(
     client: AsyncClient,
     accountant_headers: dict,
@@ -722,3 +777,164 @@ class TestNoDebtNonRegression:
         fee = (await client.get(f"/api/fees/{fee_id}", headers=accountant)).json()
         assert fee["status"] == FeeStatusEnum.partial.value, fee
         assert Decimal(str(fee["paid_amount"])) == PREPAY
+
+
+# ===========================================================================
+# Scenario 5 — finding #1: has_unrefunded_payment flag + log.warning on
+#              reject/withdraw of a hold-spot profile that prepaid tuition.
+# ===========================================================================
+
+async def _submit_and_prepay(
+    client: AsyncClient,
+    officer: dict,
+    manager: dict,
+    accountant: dict,
+    unit_id: int,
+    officer_id: int,
+) -> int:
+    """Build → submit-with-debt → calculate tuition → record+verify a PARTIAL
+    prepay so the profile is ``submitted`` with ``SUM(fee.paid_amount) > 0``.
+    Returns the profile id."""
+    _doc_id, doc_code = await _create_doc_type("hocba")
+    lead_id = await _create_lead(unit_id, officer_id)
+    pid, _oac = await _build_draft_profile(lead_id, mandatory_docs=[doc_code])
+    await _submit_with_debt(client, officer, pid, "giữ chỗ — chờ học bạ")
+    fee_detail = await _calculate_tuition(client, officer, pid)
+    invoice_id = fee_detail["invoices"][0]["id"]
+    await _record_and_verify_payment(client, accountant, manager, invoice_id, PREPAY)
+    return pid
+
+
+class TestUnrefundedPaymentFlag:
+    async def test_reject_with_prepay_sets_flag_and_warns(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """(a) Reject a profile that holds a verified prepay → response +
+        subsequent GET both carry ``has_unrefunded_payment=True`` (parity).
+        Reject is NOT blocked; the flag being True proves the warning branch
+        (``if has_unrefunded_payment: log.warning(...)``) was reached — the log
+        line itself is trivial and structlog routing is config-dependent, so we
+        assert the contract (the flag) rather than the caplog text."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+
+        pid = await _submit_and_prepay(
+            client, officer, manager, accountant, unit_id, officer_user_in_db["id"]
+        )
+
+        # Before the terminal transition the flag is False (submitted holds
+        # money but is not rejected/withdrawn → no warning, no query cost).
+        pre = await _get(client, manager, pid)
+        assert pre["has_unrefunded_payment"] is False, pre
+
+        rejected = await _reject(client, manager, pid, "Không đủ điều kiện xét tuyển")
+
+        # Mutation response parity.
+        assert rejected["has_unrefunded_payment"] is True, rejected
+        # GET parity (get_profile sets the flag independently).
+        after = await _get(client, manager, pid)
+        assert after["has_unrefunded_payment"] is True, after
+
+    async def test_reject_without_prepay_flag_false(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """(b) Reject a submitted profile with NO collected fee → flag False."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        _doc_id, doc_code = await _create_doc_type("hocba")
+        lead_id = await _create_lead(unit_id, officer_user_in_db["id"])
+        pid, _oac = await _build_draft_profile(lead_id, mandatory_docs=[doc_code])
+
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        await _submit_with_debt(client, officer, pid, "giữ chỗ không trả trước")
+
+        rejected = await _reject(client, manager, pid, "Hồ sơ không hợp lệ lần này")
+        assert rejected["has_unrefunded_payment"] is False, rejected
+        after = await _get(client, manager, pid)
+        assert after["has_unrefunded_payment"] is False, after
+
+    async def test_withdraw_with_prepay_sets_flag(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """(c) Withdraw a profile that holds a verified prepay → flag True on
+        the mutation response AND a subsequent GET."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+
+        pid = await _submit_and_prepay(
+            client, officer, manager, accountant, unit_id, officer_user_in_db["id"]
+        )
+
+        # withdraw lead-sync advances the lead to sts08 (not in the conftest
+        # seed list) — seed it so the sync resolves.
+        await _ensure_consultation_status(
+            "sts08", "Tu choi tu van", "stg07", "#CC0000"
+        )
+
+        withdrawn = await _withdraw(client, manager, pid, "Học sinh đổi nguyện vọng")
+        assert withdrawn["has_unrefunded_payment"] is True, withdrawn
+        after = await _get(client, manager, pid)
+        assert after["has_unrefunded_payment"] is True, after
+
+    async def test_nonterminal_statuses_flag_false(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """(d) submitted (with money) and approved both keep the flag False —
+        the flag is gated on terminal rejected/withdrawn only (no DB cost on
+        the hot read path)."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        doc_type_id, doc_code = await _create_doc_type("hocba")
+        lead_id = await _create_lead(unit_id, officer_user_in_db["id"])
+        pid, _oac = await _build_draft_profile(lead_id, mandatory_docs=[doc_code])
+
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+
+        await _submit_with_debt(client, officer, pid, "giữ chỗ — chờ học bạ")
+        fee_detail = await _calculate_tuition(client, officer, pid)
+        invoice_id = fee_detail["invoices"][0]["id"]
+        await _record_and_verify_payment(
+            client, accountant, manager, invoice_id, PREPAY
+        )
+
+        # submitted + holds money → still False (not terminal).
+        submitted = await _get(client, manager, pid)
+        assert submitted["status"] == "submitted", submitted
+        assert submitted["has_unrefunded_payment"] is False, submitted
+
+        # Verify the owed doc so approve is allowed, then approve → False.
+        await _add_uploaded_doc(pid, doc_type_id)
+        await _verify_doc(pid, doc_type_id)
+        body = await _get(client, manager, pid)
+        ok = await client.post(
+            f"{ADMISSIONS}/{pid}/approve",
+            headers=manager,
+            json={"notes": "đủ giấy tờ", "version": body["version"]},
+        )
+        assert ok.status_code == 200, ok.text
+        assert ok.json()["status"] == "approved", ok.json()
+        assert ok.json()["has_unrefunded_payment"] is False, ok.json()

--- a/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
+++ b/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
@@ -1,0 +1,724 @@
+"""C3 — end-to-end smoke for the tuition prepay / hold-spot fast-track.
+
+Covers TUITION_PREPAY_FASTTRACK_PLAN.md §C3 + §6 (C3/C4) + §2 flow. This
+file writes NO new business logic — it proves that the EXISTING infra
+(submit-with-document-debt from C1/C1.5 + fee@submitted+auto-issue from C2 +
+the unchanged Finance Phase 1 partial-payment / HK1-cleared-sync / refund
+maker-checker) composes into the advertised "giữ chỗ = học phí trả trước"
+journey when driven through the real HTTP endpoints.
+
+Scenarios:
+
+1. Happy path (full journey): academically-eligible profile that is MISSING a
+   mandatory doc → officer submit-with-debt (acknowledge + reason) → status
+   ``submitted`` + ``document_debt`` snapshot recorded → officer calculates
+   tuition at ``submitted`` → invoice **auto-issued** (status ``issued``) →
+   accountant records a PARTIAL prepay (3,000,000 / 9,200,000) → manager
+   verifies → invoice + fee go ``partial`` with the right ``paid_amount`` AND
+   the HK1-cleared lead sync fires (lead advances to TUITION_PAID_STATUS / sts10
+   — the ``sync_lead_tuition_paid`` projection inside ``verify_payment``) →
+   accountant records the remaining 6,200,000 → manager verifies → invoice +
+   fee go ``paid``.
+
+2. Approve gate in the integrated flow (cross-check C1.5 end-to-end): while the
+   document debt is outstanding ``approve`` is blocked (400); after the owed doc
+   is verified (outstanding empties) ``approve`` succeeds.
+
+3. Refund (cross-check C4): refund one verified prepay through the standard
+   maker-checker chain (accountant request → manager approve → accountant
+   process) → fee ``paid_amount`` drops by the refunded amount, refund row
+   ends ``refunded``.
+
+4. Non-regression: a profile submitted WITHOUT a document debt runs the exact
+   same calculate→prepay→verify path — the C1/C1.5 gates are no-ops when
+   ``document_debt`` is NULL.
+
+The fee/payment/refund infra is unit/service tested in
+``tests/integration/test_finance_workflow.py`` + ``tests/services/
+test_payment_service.py`` + ``tests/integration/test_lead_admission_sync.py``;
+the per-gate contracts are in ``tests/api/test_admission_submit_document_debt.py``
+(C1/C1.5) + ``tests/api/test_fees_calculate_authorization.py`` (C2). This file
+is the glue smoke that exercises them together via ``/api/...`` routes.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.models.finance import (
+    FeeStatusEnum,
+    InstallmentPlan,
+    InvoiceStatusEnum,
+    PaymentMethod,
+    PaymentStatusEnum,
+    RefundStatusEnum,
+)
+from tests.fixtures.builders import (
+    ensure_submittable_ward,
+    seed_submittable_offering_config,
+    submittable_profile_fields,
+)
+
+pytestmark = pytest.mark.asyncio
+
+ADMISSIONS = "/api/admissions"
+
+# Plan §2 example figures: HK1 tuition 9,200,000; prepay/hold-spot 3,000,000.
+HK1_TUITION = Decimal("9200000")
+PREPAY = Decimal("3000000")
+REMAINDER = HK1_TUITION - PREPAY  # 6,200,000
+
+
+# ---------------------------------------------------------------------------
+# Auth + low-level helpers
+# ---------------------------------------------------------------------------
+
+async def _auth(client: AsyncClient, user: dict) -> dict:
+    """Login → Bearer header. Clears the shared cookie jar so a later login
+    by a different role doesn't ride the previous user's access_token cookie
+    (memory ``test-httpx-cookie-jar-contamination``)."""
+    res = await client.post(
+        "/api/auth/login",
+        data={"username": user["username"], "password": user["password"]},
+    )
+    assert res.status_code == 200, f"login failed for {user['username']}: {res.text}"
+    token = res.cookies.get("access_token")
+    client.cookies.delete("access_token")
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _get(client: AsyncClient, headers: dict, pid: int) -> dict:
+    res = await client.get(f"{ADMISSIONS}/{pid}", headers=headers)
+    assert res.status_code == 200, res.text
+    return res.json()
+
+
+async def _load_profile(profile_id: int) -> models.AdmissionProfile:
+    async with AsyncSessionLocal() as session:
+        return (
+            await session.execute(
+                select(models.AdmissionProfile).where(
+                    models.AdmissionProfile.id == profile_id
+                )
+            )
+        ).scalar_one()
+
+
+async def _load_lead(lead_id: int) -> models.Lead:
+    async with AsyncSessionLocal() as session:
+        return (
+            await session.execute(
+                select(models.Lead).where(models.Lead.id == lead_id)
+            )
+        ).scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers (test DB uses create_all() — NO prod seed; fixtures self-seed)
+# ---------------------------------------------------------------------------
+
+def _submittable_applied_rules(
+    mandatory_docs: list[str],
+    *,
+    allow_unverified: bool = False,
+) -> dict:
+    """applied_rules that clear scoring + carry the given mandatory docs.
+
+    Mirrors ``test_admission_submit_document_debt.py`` so the ONLY submit gate
+    left is the document one. ``allow_unverified=False`` (strict) by default so
+    an uploaded-but-unverified doc still counts as outstanding for the debt /
+    approve-gate cross-checks.
+    """
+    return {
+        "min_gpa": 0,
+        "mandatory_docs": list(mandatory_docs),
+        "allowed_subject_codes": ["TOAN"],
+        "scoring_method": "sum",
+        "required_subject_count": 1,
+        "subject_selection_mode": "fixed",
+        "schema_version": 2,
+        "allow_unverified_submission": allow_unverified,
+    }
+
+
+async def _ensure_subject_toan() -> int:
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            subj = (
+                await session.execute(
+                    select(models.Subject).where(models.Subject.code == "TOAN")
+                )
+            ).scalar_one_or_none()
+            if subj is None:
+                subj = models.Subject(code="TOAN", name_vi="Toan", is_active=True)
+                session.add(subj)
+                await session.flush()
+            return subj.id
+
+
+async def _create_doc_type(label: str) -> tuple[int, str]:
+    ts = uuid.uuid4().hex[:10]
+    code = f"{label}_{ts}"
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            dt = models.ConfigDocumentType(
+                code=code, name=f"DOC {code}", display_order=99
+            )
+            session.add(dt)
+            await session.flush()
+            return dt.id, code
+
+
+async def _ensure_cash_method() -> int:
+    """Get-or-create a single offline ``cash`` payment method.
+
+    Tolerates parallel-module collisions (UNIQUE code) the same way
+    ``fee_calc_config`` get-or-creates the FULL plan.
+    """
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            method = (
+                await session.execute(
+                    select(PaymentMethod).where(PaymentMethod.code == "cash")
+                )
+            ).scalar_one_or_none()
+            if method is None:
+                method = PaymentMethod(
+                    code="cash", name="Tiền mặt", is_online=False, is_active=True
+                )
+                session.add(method)
+                await session.flush()
+            return method.id
+
+
+async def _ensure_full_plan() -> None:
+    """Get-or-create the canonical single-payment ``FULL`` installment plan."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            existing = (
+                await session.execute(
+                    select(InstallmentPlan).where(InstallmentPlan.code == "FULL")
+                )
+            ).scalar_one_or_none()
+            if existing is None:
+                session.add(
+                    InstallmentPlan(
+                        code="FULL",
+                        name="Thanh toán 1 lần",
+                        installment_count=1,
+                        schedule=[
+                            {
+                                "installment_no": 1,
+                                "due_days_offset": 0,
+                                "percent": 100.0,
+                                "description": "Toàn bộ",
+                            }
+                        ],
+                        is_active=True,
+                    )
+                )
+                await session.flush()
+
+
+async def _seed_hk1_tuition_for_config(oac_id: int, amount: Decimal) -> None:
+    """Attach an OfferingSemesterTuition HK1 row to the academic_info behind a
+    given OfferingAdmissionConfig so ``calculate_fee(tuition)`` resolves the
+    canonical amount (ADR-002: tuition reads offering_semester_tuition, NOT
+    tuition_fee_per_year). Without this the service raises
+    ``Chưa cấu hình học phí cho HK1`` → 400.
+    """
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            oac = await session.get(models.OfferingAdmissionConfig, oac_id)
+            assert oac is not None and oac.academic_info_id is not None
+            existing = (
+                await session.execute(
+                    select(models.OfferingSemesterTuition).where(
+                        models.OfferingSemesterTuition.academic_info_id
+                        == oac.academic_info_id,
+                        models.OfferingSemesterTuition.semester_no == 1,
+                    )
+                )
+            ).scalar_one_or_none()
+            if existing is None:
+                session.add(
+                    models.OfferingSemesterTuition(
+                        academic_info_id=oac.academic_info_id,
+                        semester_no=1,
+                        amount=amount,
+                    )
+                )
+                await session.flush()
+
+
+async def _create_lead(unit_id: int, officer_id: int) -> int:
+    unique = uuid.uuid4().hex[:12]
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            lead = models.Lead(
+                full_name=f"Prepay Applicant {unique}",
+                phone=f"09{unique[:8]}",
+                email=f"prepay_{unique}@example.com",
+                source="website",
+                unit_id=unit_id,
+                assigned_officer_id=officer_id,
+            )
+            session.add(lead)
+            await session.flush()
+            return lead.id
+
+
+async def _build_draft_profile(
+    lead_id: int,
+    *,
+    mandatory_docs: list[str],
+    allow_unverified: bool = False,
+) -> tuple[int, int]:
+    """Build a draft profile that is submittable EXCEPT for the mandatory docs.
+
+    Also seeds the HK1 tuition + FULL plan against the profile's offering so a
+    tuition fee can be calculated at ``submitted``. Returns
+    ``(profile_id, oac_id)``.
+    """
+    await ensure_submittable_ward()
+    subj_id = await _ensure_subject_toan()
+    cid = f"0{datetime.now().timestamp():.0f}"[:12]
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            lead = await session.get(models.Lead, lead_id)
+            seed = await seed_submittable_offering_config(session, lead.unit_id)
+            profile = models.AdmissionProfile(
+                lead_id=lead_id,
+                status="draft",
+                citizen_id=cid,
+                version=1,
+                applied_rules=_submittable_applied_rules(
+                    mandatory_docs, allow_unverified=allow_unverified
+                ),
+                academic_year=seed["academic_year"],
+                family_info=[
+                    {
+                        "relationship": "Cha",
+                        "full_name": "Test Father",
+                        "phone": "0901234567",
+                    }
+                ],
+                **submittable_profile_fields(seed),
+            )
+            session.add(profile)
+            await session.flush()
+            session.add(
+                models.ProfileSubjectScore(
+                    profile_id=profile.id, subject_id=subj_id, score=8.0
+                )
+            )
+            await session.flush()
+            pid = profile.id
+            oac_id = seed["offering_admission_config_id"]
+
+    await _seed_hk1_tuition_for_config(oac_id, HK1_TUITION)
+    await _ensure_full_plan()
+    await _ensure_cash_method()
+    return pid, oac_id
+
+
+async def _add_uploaded_doc(profile_id: int, doc_type_id: int) -> None:
+    """Attach an uploaded-but-unverified ProfileDocument (file present,
+    status='uploaded')."""
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            session.add(
+                models.ProfileDocument(
+                    profile_id=profile_id,
+                    document_type_id=doc_type_id,
+                    category="path",
+                    status="uploaded",
+                    file_path=f"uploads/admissions/{profile_id}/doc.pdf",
+                    uploaded_at=datetime.now(timezone.utc),
+                )
+            )
+
+
+async def _verify_doc(profile_id: int, doc_type_id: int) -> None:
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            pd = (
+                await session.execute(
+                    select(models.ProfileDocument).where(
+                        models.ProfileDocument.profile_id == profile_id,
+                        models.ProfileDocument.document_type_id == doc_type_id,
+                    )
+                )
+            ).scalar_one()
+            pd.status = "verified"
+            pd.verified_at = datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Flow-level helpers (drive the real endpoints)
+# ---------------------------------------------------------------------------
+
+async def _submit_with_debt(
+    client: AsyncClient, officer_headers: dict, pid: int, reason: str
+) -> dict:
+    res = await client.post(
+        f"{ADMISSIONS}/{pid}/submit",
+        headers=officer_headers,
+        json={"acknowledge_missing_docs": True, "document_debt_reason": reason},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["status"] == "submitted", body
+    return body
+
+
+async def _calculate_tuition(
+    client: AsyncClient, headers: dict, pid: int
+) -> dict:
+    """Calculate the tuition fee (FULL plan, HK1). Returns the fee detail
+    response (with nested ``invoices``). The C2 route auto-issues tuition."""
+    res = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+        headers=headers,
+    )
+    assert res.status_code == 201, res.text
+    return res.json()
+
+
+async def _record_and_verify_payment(
+    client: AsyncClient,
+    accountant_headers: dict,
+    manager_headers: dict,
+    invoice_id: int,
+    amount: Decimal,
+) -> dict:
+    """Standard manual-payment maker-checker: accountant records → manager
+    verifies. Returns the verified payment response."""
+    rec = await client.post(
+        "/api/payments",
+        json={
+            "invoice_id": invoice_id,
+            "method_id": await _ensure_cash_method(),
+            "amount": str(amount),
+            "reference_code": f"CASH-{uuid.uuid4().hex[:8]}",
+            "payer_name": "Prepay Student",
+        },
+        headers=accountant_headers,
+    )
+    assert rec.status_code == 201, rec.text
+    payment = rec.json()
+    assert payment["status"] == PaymentStatusEnum.pending.value, payment
+
+    ver = await client.put(
+        f"/api/payments/{payment['id']}/verify", headers=manager_headers
+    )
+    assert ver.status_code == 200, ver.text
+    verified = ver.json()
+    assert verified["status"] == PaymentStatusEnum.verified.value, verified
+    return verified
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def accountant_user_in_db(seed_lead_dependencies: dict) -> dict:
+    """Accountant in the SAME unit as the seeded leads/profiles (records +
+    requests/processes refunds). Built inline via the canonical helper — there
+    is no shared ACCOUNTANT fixture in conftest (mirrors the C2
+    ``accountant_same_unit`` fixture)."""
+    from tests.conftest import _create_user_and_role
+
+    return await _create_user_and_role(
+        {
+            "username": "prepay_accountant_u1",
+            "email": "prepay_accountant_u1@example.com",
+            "password": "AccountantPass!345",
+            "role": "accountant",
+            "status": "active",
+        },
+        "role:accountant",
+        unit_id=seed_lead_dependencies["unit_id"],
+    )
+
+
+# ===========================================================================
+# Scenario 1 — Happy path: submit-with-debt → fee@submitted → auto-issue →
+#              partial prepay (+HK1 sync) → paid
+# ===========================================================================
+
+class TestPrepayHappyPath:
+    async def test_full_prepay_journey_debt_to_paid(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        _doc_id, doc_code = await _create_doc_type("hocba")
+        lead_id = await _create_lead(unit_id, officer_user_in_db["id"])
+        pid, _oac = await _build_draft_profile(lead_id, mandatory_docs=[doc_code])
+
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+
+        # --- Step 1: submit-with-document-debt (officer) ---------------------
+        await _submit_with_debt(
+            client, officer, pid, "HS xin cấp lại học bạ, hẹn 30/06"
+        )
+        profile = await _load_profile(pid)
+        assert profile.status == "submitted"
+        assert profile.document_debt is not None
+        assert profile.document_debt["codes"] == [doc_code]
+        assert profile.document_debt["by_user_id"] == officer_user_in_db["id"]
+        # Snapshot must NOT leak into applied_rules (immutability trigger).
+        assert "document_debt" not in (profile.applied_rules or {})
+
+        detail = await _get(client, officer, pid)
+        assert detail["outstanding_debt_codes"] == [doc_code]
+
+        # --- Step 2: calculate tuition at submitted → auto-issued -----------
+        fee_detail = await _calculate_tuition(client, officer, pid)
+        assert Decimal(str(fee_detail["final_amount"])) == HK1_TUITION
+        invoices = fee_detail["invoices"]
+        assert len(invoices) == 1, invoices
+        invoice = invoices[0]
+        assert invoice["status"] == InvoiceStatusEnum.issued.value, invoice
+        assert Decimal(str(invoice["amount"])) == HK1_TUITION
+        invoice_id = invoice["id"]
+        fee_id = fee_detail["id"]
+
+        # --- Step 3: partial prepay (3,000,000) → partial + HK1 sync --------
+        await _record_and_verify_payment(
+            client, accountant, manager, invoice_id, PREPAY
+        )
+
+        inv = (
+            await client.get(f"/api/invoices/{invoice_id}", headers=accountant)
+        ).json()
+        assert inv["status"] == InvoiceStatusEnum.partial.value, inv
+        assert Decimal(str(inv["paid_amount"])) == PREPAY
+
+        fee = (await client.get(f"/api/fees/{fee_id}", headers=accountant)).json()
+        assert fee["status"] == FeeStatusEnum.partial.value, fee
+        assert Decimal(str(fee["paid_amount"])) == PREPAY
+
+        # HK1 cleared-state sync fired: the lead advanced to the
+        # "đã hoàn tất học phí" projection (sts10) on the FIRST partial
+        # clearance (sync_lead_tuition_paid inside verify_payment).
+        from app.services.lead_admission_sync import TUITION_PAID_STATUS
+
+        lead = await _load_lead(lead_id)
+        assert lead.consultation_status_id == TUITION_PAID_STATUS, (
+            f"HK1 sync should advance lead to {TUITION_PAID_STATUS}, "
+            f"got {lead.consultation_status_id}"
+        )
+
+        # --- Step 4: pay the remainder (6,200,000) → paid -------------------
+        await _record_and_verify_payment(
+            client, accountant, manager, invoice_id, REMAINDER
+        )
+
+        inv2 = (
+            await client.get(f"/api/invoices/{invoice_id}", headers=accountant)
+        ).json()
+        assert inv2["status"] == InvoiceStatusEnum.paid.value, inv2
+        assert Decimal(str(inv2["paid_amount"])) == HK1_TUITION
+
+        fee2 = (await client.get(f"/api/fees/{fee_id}", headers=accountant)).json()
+        assert fee2["status"] == FeeStatusEnum.paid.value, fee2
+        assert Decimal(str(fee2["paid_amount"])) == HK1_TUITION
+
+
+# ===========================================================================
+# Scenario 2 — Approve gate inside the integrated flow (cross-check C1.5)
+# ===========================================================================
+
+class TestApproveGateInFlow:
+    async def test_approve_blocked_then_ok_after_docs_verified(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        doc_type_id, doc_code = await _create_doc_type("hocba")
+        lead_id = await _create_lead(unit_id, officer_user_in_db["id"])
+        pid, _oac = await _build_draft_profile(lead_id, mandatory_docs=[doc_code])
+
+        officer = await _auth(client, officer_user_in_db)
+        await _submit_with_debt(client, officer, pid, "cho nợ giấy tờ")
+
+        manager = await _auth(client, manager_user_in_db)
+
+        # Debt outstanding → approve flag off + server gate rejects.
+        body = await _get(client, manager, pid)
+        assert body["outstanding_debt_codes"] == [doc_code]
+        assert body["permissions"].get("approve") is False, body["permissions"]
+        rej = await client.post(
+            f"{ADMISSIONS}/{pid}/approve",
+            headers=manager,
+            json={"notes": "duyệt", "version": body["version"]},
+        )
+        assert rej.status_code == 400, rej.text
+        assert "nợ giấy tờ" in rej.json()["detail"], rej.json()
+        assert (await _load_profile(pid)).status == "submitted"
+
+        # Officer supplies + reviewer verifies the owed doc → outstanding
+        # empties (verified-based) → approve succeeds.
+        await _add_uploaded_doc(pid, doc_type_id)
+        await _verify_doc(pid, doc_type_id)
+
+        body2 = await _get(client, manager, pid)
+        assert body2["outstanding_debt_codes"] == []
+        assert body2["permissions"].get("approve") is True, body2["permissions"]
+        ok = await client.post(
+            f"{ADMISSIONS}/{pid}/approve",
+            headers=manager,
+            json={"notes": "đủ giấy tờ", "version": body2["version"]},
+        )
+        assert ok.status_code == 200, ok.text
+        assert ok.json()["status"] == "approved", ok.json()
+
+
+# ===========================================================================
+# Scenario 3 — Refund the prepay through the maker-checker chain (cross-check C4)
+# ===========================================================================
+
+class TestRefundPrepay:
+    async def test_refund_prepay_reduces_paid_amount(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        unit_id = seed_lead_dependencies["unit_id"]
+        _doc_id, doc_code = await _create_doc_type("hocba")
+        lead_id = await _create_lead(unit_id, officer_user_in_db["id"])
+        pid, _oac = await _build_draft_profile(lead_id, mandatory_docs=[doc_code])
+
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+
+        await _submit_with_debt(client, officer, pid, "cho nợ")
+        fee_detail = await _calculate_tuition(client, officer, pid)
+        invoice_id = fee_detail["invoices"][0]["id"]
+        fee_id = fee_detail["id"]
+
+        # Collect a prepay then verify it (this is the payment we refund).
+        verified = await _record_and_verify_payment(
+            client, accountant, manager, invoice_id, PREPAY
+        )
+        payment_id = verified["id"]
+
+        # Refund maker-checker chain: accountant request → manager approve →
+        # accountant process (standard Finance Phase 1 flow).
+        req = await client.post(
+            "/api/refunds",
+            json={
+                "payment_id": payment_id,
+                "amount": str(PREPAY),
+                "reason": "Học sinh rút hồ sơ — hoàn khoản trả trước",
+            },
+            headers=accountant,
+        )
+        assert req.status_code == 201, req.text
+        refund = req.json()
+        assert refund["status"] == RefundStatusEnum.pending.value, refund
+        refund_id = refund["id"]
+
+        appr = await client.post(
+            f"/api/refunds/{refund_id}/approve", headers=manager
+        )
+        assert appr.status_code == 200, appr.text
+        assert appr.json()["status"] == RefundStatusEnum.approved.value, appr.json()
+
+        proc = await client.post(
+            f"/api/refunds/{refund_id}/process",
+            json={"refund_id": refund_id, "refund_reference": "BANK-REF-001"},
+            headers=accountant,
+        )
+        assert proc.status_code == 200, proc.text
+        processed = proc.json()
+        assert processed["status"] == RefundStatusEnum.refunded.value, processed
+        assert processed["refund_reference"] == "BANK-REF-001"
+
+        # Fee paid_amount dropped back to 0 (the single prepay was refunded).
+        fee = (await client.get(f"/api/fees/{fee_id}", headers=accountant)).json()
+        assert Decimal(str(fee["paid_amount"])) == Decimal("0"), fee
+
+
+# ===========================================================================
+# Scenario 4 — Non-regression: NO document debt → same calc/prepay path
+# ===========================================================================
+
+class TestNoDebtNonRegression:
+    async def test_clean_profile_prepay_unaffected_by_debt_gates(
+        self,
+        client: AsyncClient,
+        officer_user_in_db: dict,
+        manager_user_in_db: dict,
+        accountant_user_in_db: dict,
+        seed_lead_dependencies: dict,
+    ):
+        """A profile whose mandatory doc is present submits WITHOUT a debt, and
+        the calculate→prepay→verify path behaves exactly as before — the C1/C1.5
+        gates are inert when ``document_debt`` is NULL."""
+        unit_id = seed_lead_dependencies["unit_id"]
+        doc_type_id, doc_code = await _create_doc_type("hocba")
+        lead_id = await _create_lead(unit_id, officer_user_in_db["id"])
+        # Lax mode + an uploaded doc → a plain submit (no body) passes with no debt.
+        pid, _oac = await _build_draft_profile(
+            lead_id, mandatory_docs=[doc_code], allow_unverified=True
+        )
+        await _add_uploaded_doc(pid, doc_type_id)
+
+        officer = await _auth(client, officer_user_in_db)
+        manager = await _auth(client, manager_user_in_db)
+        accountant = await _auth(client, accountant_user_in_db)
+
+        # Plain submit (no debt body).
+        sub = await client.post(f"{ADMISSIONS}/{pid}/submit", headers=officer)
+        assert sub.status_code == 200, sub.text
+        assert sub.json()["status"] == "submitted", sub.json()
+
+        profile = await _load_profile(pid)
+        assert profile.document_debt is None
+        detail = await _get(client, officer, pid)
+        assert detail["outstanding_debt_codes"] == []
+
+        # Same calculate→prepay→verify path works.
+        fee_detail = await _calculate_tuition(client, officer, pid)
+        invoice = fee_detail["invoices"][0]
+        assert invoice["status"] == InvoiceStatusEnum.issued.value, invoice
+        invoice_id = invoice["id"]
+        fee_id = fee_detail["id"]
+
+        await _record_and_verify_payment(
+            client, accountant, manager, invoice_id, PREPAY
+        )
+        fee = (await client.get(f"/api/fees/{fee_id}", headers=accountant)).json()
+        assert fee["status"] == FeeStatusEnum.partial.value, fee
+        assert Decimal(str(fee["paid_amount"])) == PREPAY

--- a/Backend_FastAPI/tests/services/test_invoice_service.py
+++ b/Backend_FastAPI/tests/services/test_invoice_service.py
@@ -191,6 +191,66 @@ class TestInvoiceGeneration:
         assert invoices[0].issued_at is not None
         assert invoices[0].issued_by_id == admin_user.id
 
+    async def test_auto_issue_returns_invoice_issued_callback(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """C2 / B4: auto_issue=True returns a non-None, awaitable post_commit
+        callback (the INVOICE_ISSUED fanout).
+
+        The router (POST /api/fees/calculate) must CAPTURE and await this
+        callback; previously it discarded it (``invoices, _ = ...``) so the
+        invoice was issued silently with no notification/sync. This guards the
+        callback wiring at the service boundary. The actual dispatch is
+        guarded on ``payload['user_id']`` (assigned officer) — this fixture's
+        lead has no owner, so no dispatch fires; the end-to-end dispatch is
+        asserted at the route level in test_fees_calculate_authorization.py
+        where the lead has an assigned officer.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee"]
+        due = date.today() + timedelta(days=30)
+
+        invoices, invoice_cb = await service.generate_invoices_for_fee(
+            fee_id=fee.id,
+            due_date_base=due,
+            user_id=admin_user.id,
+            unit_id=invoice_fixtures["unit_id"],
+            auto_issue=True,
+        )
+        await db.commit()
+
+        assert invoices[0].status == InvoiceStatusEnum.issued.value
+        # B4: callback must be captured, not None, and awaitable without error.
+        assert invoice_cb is not None and callable(invoice_cb)
+        with patch(
+            "app.services.notification_dispatcher.safe_dispatch",
+            new_callable=AsyncMock,
+        ):
+            await invoice_cb()  # must not raise
+
+    async def test_no_auto_issue_returns_none_callback(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """C2 regression guard: without auto_issue, no callback is returned and
+        invoices stay draft → no INVOICE_ISSUED for non-tuition fee types."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee"]
+        due = date.today() + timedelta(days=30)
+
+        invoices, invoice_cb = await service.generate_invoices_for_fee(
+            fee_id=fee.id,
+            due_date_base=due,
+            user_id=admin_user.id,
+            unit_id=invoice_fixtures["unit_id"],
+            auto_issue=False,
+        )
+        await db.commit()
+
+        assert invoices[0].status == InvoiceStatusEnum.draft.value
+        assert invoice_cb is None
+
     async def test_generate_invoices_wrong_status(self, db, invoice_fixtures, admin_user):
         """H8: Cannot generate invoices for cancelled fee."""
         service = InvoiceService(db)

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
@@ -356,7 +356,18 @@ export function AdmissionDetailClient({
   }
 
   const handleSubmit = async () => {
-    await submitMutation.mutateAsync()
+    await submitMutation.mutateAsync(undefined)
+  }
+
+  // Fast-track nợ giấy tờ (TUITION_PREPAY_FASTTRACK_PLAN.md C4): officer submits
+  // with a document debt. The dialog (SubmitWithDebtDialog) collects the
+  // mandatory reason; here we just forward the payload to the same submit
+  // mutation, which records the document_debt snapshot server-side.
+  const handleSubmitWithDebt = (payload: {
+    acknowledge_missing_docs: true
+    document_debt_reason: string
+  }) => {
+    submitMutation.mutate(payload)
   }
 
   const handleResubmit = () => {
@@ -535,6 +546,8 @@ export function AdmissionDetailClient({
               onSubmit={handleSubmit}
               isSubmitting={submitMutation.isPending}
               canSubmit={can('submit')}
+              onSubmitWithDebt={handleSubmitWithDebt}
+              canSubmitWithDocumentDebt={profile.can_submit_with_document_debt ?? false}
               onResubmit={handleResubmit}
               isResubmitting={resubmitMutation.isPending}
               canResubmit={can('resubmit')}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
@@ -363,11 +363,14 @@ export function AdmissionDetailClient({
   // with a document debt. The dialog (SubmitWithDebtDialog) collects the
   // mandatory reason; here we just forward the payload to the same submit
   // mutation, which records the document_debt snapshot server-side.
-  const handleSubmitWithDebt = (payload: {
+  const handleSubmitWithDebt = async (payload: {
     acknowledge_missing_docs: true
     document_debt_reason: string
   }) => {
-    submitMutation.mutate(payload)
+    // Return the promise so SubmitWithDebtDialog can close + clear ONLY on
+    // success; on failure it rethrows → the dialog keeps the reason text (the
+    // mutation's onError toast surfaces the error).
+    await submitMutation.mutateAsync(payload)
   }
 
   const handleResubmit = () => {

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
@@ -524,6 +524,27 @@ export function AdmissionDetailClient({
           </div>
         )}
 
+        {/* Tuition prepay fast-track finding #1: a rejected/withdrawn profile
+            that still holds collected (unrefunded) tuition. BE flag combines
+            status ∈ {rejected, withdrawn} + SUM(fee.paid_amount) > 0, so FE
+            just renders. Refund stays manual via the existing maker-checker
+            flow (this is only a reminder, not an action). */}
+        {profile.has_unrefunded_payment && (
+          <div
+            role="alert"
+            className="mb-4 rounded-lg border-2 border-error-300 bg-error-50 p-4 text-error-900"
+          >
+            <p className="font-semibold mb-1">
+              ⚠️ Hồ sơ đã hủy/từ chối nhưng còn khoản học phí đã thu chưa hoàn
+            </p>
+            <p className="text-sm">
+              Hồ sơ đã <strong>{profile.status === "withdrawn" ? "rút" : "từ chối"}</strong>{" "}
+              nhưng vẫn còn khoản học phí đã thu (trả trước/giữ chỗ) chưa được hoàn.
+              Vui lòng xử lý <strong>hoàn tiền</strong> ở tab Học phí (quy trình hoàn tiền thủ công).
+            </p>
+          </div>
+        )}
+
         {/* TAB CONTENT */}
         <div className="bg-card rounded-lg shadow-sm min-h-[500px] p-1">
           {currentStep === 1 && <PersonalInfoTab profile={profile} form={form} isEditable={can('edit')} />}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.test.tsx
@@ -1349,3 +1349,139 @@ describe("DocumentsTab — Phase E.4 eligibility summary footer", () => {
     ).toHaveTextContent(/0\/1 đã tải lên.*UT08 thiếu/);
   });
 });
+
+// =============================================================================
+// FAST-TRACK NỢ GIẤY TỜ — "Nợ giấy tờ" BANNER (TUITION_PREPAY_FASTTRACK_PLAN.md §4b ③)
+// =============================================================================
+
+/** buildProfile + the fast-track debt fields the banner reads. */
+function buildProfileWithDebt(opts: {
+  docs: DocRow[];
+  outstanding_debt_codes?: string[];
+  missing_doc_codes?: string[];
+  document_debt?: {
+    codes: string[];
+    reason: string;
+    by_user_id: number;
+    at: string;
+  } | null;
+}) {
+  const base = buildProfile(opts.docs) as Record<string, unknown>;
+  base.outstanding_debt_codes = opts.outstanding_debt_codes ?? [];
+  base.missing_doc_codes = opts.missing_doc_codes ?? [];
+  base.document_debt = opts.document_debt ?? null;
+  return base;
+}
+
+describe("DocumentsTab — fast-track nợ giấy tờ banner", () => {
+  it("hides the banner when outstanding_debt_codes is empty", () => {
+    const profile = buildProfileWithDebt({
+      docs: [
+        {
+          code: "hoc_ba_thpt",
+          label: "Học bạ THPT",
+          status: "verified",
+          is_mandatory: true,
+          requires_upload: true,
+        },
+      ],
+      outstanding_debt_codes: [],
+      document_debt: {
+        codes: ["hoc_ba_thpt"],
+        reason: "đã bổ sung",
+        by_user_id: 7,
+        at: "2026-06-16T03:00:00+00:00",
+      },
+    });
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    expect(screen.queryByText(/Nợ giấy tờ/)).not.toBeInTheDocument();
+  });
+
+  it("renders the banner with count + owed-doc labels + reason/when when outstanding", () => {
+    const profile = buildProfileWithDebt({
+      docs: [
+        {
+          code: "hoc_ba_thpt",
+          label: "Học bạ THPT",
+          status: "missing",
+          is_mandatory: true,
+          requires_upload: true,
+        },
+        {
+          code: "cccd",
+          label: "CCCD bản sao",
+          status: "uploaded",
+          is_mandatory: true,
+          requires_upload: true,
+        },
+      ],
+      outstanding_debt_codes: ["hoc_ba_thpt", "cccd"],
+      missing_doc_codes: ["hoc_ba_thpt"],
+      document_debt: {
+        codes: ["hoc_ba_thpt", "cccd"],
+        reason: "HS xin cấp lại học bạ, hẹn 30/06",
+        by_user_id: 7,
+        at: "2026-06-16T03:00:00+00:00",
+      },
+    });
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const banner = screen.getByRole("status");
+    expect(within(banner).getByText("Nợ giấy tờ (2)")).toBeInTheDocument();
+    expect(within(banner).getByText("Học bạ THPT")).toBeInTheDocument();
+    expect(within(banner).getByText("CCCD bản sao")).toBeInTheDocument();
+    expect(within(banner).getByText(/HS xin cấp lại học bạ/)).toBeInTheDocument();
+  });
+
+  it("L5: labels a still-missing code 'Chưa nộp' and an uploaded-pending code 'Chờ xác minh'", () => {
+    const profile = buildProfileWithDebt({
+      docs: [
+        {
+          code: "hoc_ba_thpt",
+          label: "Học bạ THPT",
+          status: "missing",
+          is_mandatory: true,
+          requires_upload: true,
+        },
+        {
+          code: "cccd",
+          label: "CCCD bản sao",
+          status: "uploaded",
+          is_mandatory: true,
+          requires_upload: true,
+        },
+      ],
+      // Both still owed (verified-based); only hoc_ba is still fully missing.
+      outstanding_debt_codes: ["hoc_ba_thpt", "cccd"],
+      missing_doc_codes: ["hoc_ba_thpt"],
+      document_debt: {
+        codes: ["hoc_ba_thpt", "cccd"],
+        reason: "cho nợ",
+        by_user_id: 7,
+        at: "2026-06-16T03:00:00+00:00",
+      },
+    });
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const banner = screen.getByRole("status");
+    // hoc_ba_thpt ∈ missing_doc_codes → "Chưa nộp".
+    expect(within(banner).getByText("Chưa nộp")).toBeInTheDocument();
+    // cccd ∈ outstanding but NOT missing (uploaded, awaiting verify) → "Chờ xác minh".
+    expect(within(banner).getByText("Chờ xác minh")).toBeInTheDocument();
+  });
+
+  it("falls back to the raw code when documents_checklist has no matching label", () => {
+    const profile = buildProfileWithDebt({
+      docs: [],
+      outstanding_debt_codes: ["mystery_doc"],
+      missing_doc_codes: ["mystery_doc"],
+      document_debt: {
+        codes: ["mystery_doc"],
+        reason: "cho nợ",
+        by_user_id: 7,
+        at: "2026-06-16T03:00:00+00:00",
+      },
+    });
+    render(<DocumentsTab profile={profile as never} isEditable />);
+    const banner = screen.getByRole("status");
+    expect(within(banner).getByText("mystery_doc")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -440,6 +440,81 @@ function KpiTile({ label, value, hint, accent = "default" }: KpiTileProps) {
   )
 }
 
+// ADM fast-track nợ giấy tờ (TUITION_PREPAY_FASTTRACK_PLAN.md §4b ③).
+// Render the "Nợ giấy tờ" banner ONLY when there are still-outstanding debt
+// codes. The banner self-hides once `outstanding_debt_codes` empties (it goes
+// empty once every owed doc is verified/paper_submitted — VERIFIED-based, see
+// `_compute_outstanding_debt_codes` BE). L5: each code is labelled either
+// "Chưa nộp" (still in `missing_doc_codes`) or "Chờ xác minh" (uploaded but not
+// yet verified — in `outstanding_debt_codes` but NOT in `missing_doc_codes`),
+// so an officer who just uploaded isn't confused that the badge persists.
+function DocumentDebtBanner({ profile }: { profile: AdmissionProfileResponse }) {
+  const outstanding = profile.outstanding_debt_codes ?? []
+  if (outstanding.length === 0) return null
+
+  const debt = profile.document_debt
+  const missingSet = new Set(profile.missing_doc_codes ?? [])
+  const codeLabel = new Map<string, string>()
+  for (const doc of profile.documents_checklist ?? []) {
+    if (doc.code && doc.label) codeLabel.set(doc.code, doc.label)
+  }
+
+  const reason = debt?.reason?.trim() || null
+  const atFormatted = debt?.at
+    ? VI_DATETIME_FORMATTER.format(new Date(debt.at))
+    : null
+
+  return (
+    <div
+      role="status"
+      className="mb-4 rounded-lg border border-warning-300 bg-warning-50 p-4"
+    >
+      <div className="flex items-center gap-2 text-warning-800">
+        <AlertTriangle className="h-5 w-5 shrink-0" aria-hidden="true" />
+        <h3 className="font-semibold">Nợ giấy tờ ({outstanding.length})</h3>
+      </div>
+      <p className="mt-1 text-sm text-warning-700">
+        Officer đã cho nợ — học sinh bổ sung sau. Phải bổ sung và được xác minh
+        đủ trước khi duyệt hồ sơ.
+      </p>
+      <ul className="mt-3 space-y-1.5">
+        {outstanding.map((code) => {
+          // L5 — distinguish not-yet-submitted vs uploaded-pending-verify.
+          const pendingVerify = !missingSet.has(code)
+          return (
+            <li
+              key={code}
+              className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm text-warning-800"
+            >
+              <span className="font-medium break-words">
+                {codeLabel.get(code) ?? code}
+              </span>
+              <Badge
+                className={
+                  pendingVerify
+                    ? "bg-info-100 text-info-700"
+                    : "bg-muted text-muted-foreground"
+                }
+              >
+                {pendingVerify ? "Chờ xác minh" : "Chưa nộp"}
+              </Badge>
+            </li>
+          )
+        })}
+      </ul>
+      {(reason || atFormatted) && (
+        <p className="mt-3 text-xs text-warning-700 break-words">
+          {reason && <span>Lý do: {reason}</span>}
+          {reason && atFormatted && <span> · </span>}
+          {atFormatted && (
+            <span className="tabular-nums">Ghi nhận {atFormatted}</span>
+          )}
+        </p>
+      )}
+    </div>
+  )
+}
+
 interface ActionsCellProps {
   doc: DocumentItem
   state: RowState
@@ -1076,6 +1151,9 @@ export function DocumentsTab({ profile }: DocumentsTabProps) {
     // (DocumentRowActions has its own provider for legacy reasons; nested
     // is harmless) both have a context.
     <TooltipProvider delayDuration={150}>
+      {/* Fast-track nợ giấy tờ banner — self-hides when no outstanding debt. */}
+      <DocumentDebtBanner profile={profile} />
+
       {/* KPI strip — 4 tiles so officer reads the global state at a glance.
           Counts use tabular-nums so the digits stay aligned across columns. */}
       <div

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/DocumentsTab.tsx
@@ -460,9 +460,13 @@ function DocumentDebtBanner({ profile }: { profile: AdmissionProfileResponse }) 
   }
 
   const reason = debt?.reason?.trim() || null
-  const atFormatted = debt?.at
-    ? VI_DATETIME_FORMATTER.format(new Date(debt.at))
-    : null
+  // Guard against a malformed `debt.at` (Invalid Date → Intl.format throws a
+  // RangeError that would crash the whole tab). Only format a valid date.
+  const debtAt = debt?.at ? new Date(debt.at) : null
+  const atFormatted =
+    debtAt && !Number.isNaN(debtAt.getTime())
+      ? VI_DATETIME_FORMATTER.format(debtAt)
+      : null
 
   return (
     <div

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FinalizeTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/FinalizeTab.tsx
@@ -33,6 +33,13 @@ interface FinalizeTabProps {
   isSubmitting: boolean
   canSubmit: boolean
 
+  // Submit-with-debt (fast-track nợ giấy tờ — officer/owner, state draft)
+  onSubmitWithDebt?: (payload: {
+    acknowledge_missing_docs: true
+    document_debt_reason: string
+  }) => void
+  canSubmitWithDocumentDebt?: boolean
+
   // Resubmit (officer — state rejected/revision_requested)
   onResubmit?: () => void
   isResubmitting?: boolean
@@ -77,6 +84,8 @@ export function FinalizeTab({
   onSubmit,
   isSubmitting,
   canSubmit,
+  onSubmitWithDebt,
+  canSubmitWithDocumentDebt = false,
   onResubmit,
   isResubmitting = false,
   canResubmit,
@@ -135,6 +144,8 @@ export function FinalizeTab({
       onSubmit={onSubmit}
       isSubmitting={isSubmitting}
       canSubmit={canSubmit}
+      onSubmitWithDebt={onSubmitWithDebt}
+      canSubmitWithDocumentDebt={canSubmitWithDocumentDebt}
       onResubmit={onResubmit}
       isResubmitting={isResubmitting}
       canResubmit={canResubmit}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/DecisionActionsPanel.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/DecisionActionsPanel.test.tsx
@@ -32,6 +32,18 @@ vi.mock("@/components/ui/alert-dialog", () => ({
   ),
 }))
 
+// Pass-through Dialog mock (no Radix portal) so the SubmitWithDebtDialog body is
+// always in the tree for the submit-with-debt assertions below.
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => <>{children}</>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div data-testid="debt-dialog-content">{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
 import { DecisionActionsPanel } from "./DecisionActionsPanel"
 
 function buildProfile(overrides: Partial<AdmissionProfileResponse> = {}): AdmissionProfileResponse {
@@ -251,5 +263,73 @@ describe("DecisionActionsPanel — no send-link (D1/D3)", () => {
   it("does not render any 'Gửi link' utility action", () => {
     renderPanel(buildProfile(), { primaryAction: "submit", canSubmit: true, canApprove: true })
     expect(screen.queryByText(/Gửi link/i)).not.toBeInTheDocument()
+  })
+})
+
+describe("DecisionActionsPanel — submit-with-debt (fast-track nợ giấy tờ)", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("shows 'Nộp kèm nợ giấy tờ' alongside the normal submit when canSubmitWithDocumentDebt", () => {
+    renderPanel(
+      buildProfile({
+        eligibility_status: "ineligible",
+        missing_doc_codes: ["hoc_ba_thpt"],
+        documents_checklist: [
+          { code: "hoc_ba_thpt", label: "Học bạ THPT", status: "missing" },
+        ],
+      }),
+      {
+        primaryAction: "submit",
+        canSubmit: true,
+        isEligible: false,
+        canSubmitWithDocumentDebt: true,
+        onSubmitWithDebt: vi.fn(),
+      },
+    )
+    // Normal submit still present (disabled, since ineligible) — distinct CTA.
+    expect(screen.getByText("Nộp hồ sơ chính thức").closest("button")).toBeDisabled()
+    // The fast-track debt CTA is the actionable one.
+    expect(screen.getByText("Nộp kèm nợ giấy tờ")).toBeInTheDocument()
+    // Reason line points at the debt path, not a dead "chưa đủ điều kiện".
+    expect(screen.getByText(/có thể nộp kèm nợ giấy tờ/i)).toBeInTheDocument()
+  })
+
+  it("does NOT show the debt CTA when canSubmitWithDocumentDebt is false", () => {
+    renderPanel(buildProfile({ eligibility_status: "ineligible" }), {
+      primaryAction: "submit",
+      canSubmit: true,
+      isEligible: false,
+      canSubmitWithDocumentDebt: false,
+    })
+    expect(screen.queryByText("Nộp kèm nợ giấy tờ")).not.toBeInTheDocument()
+    expect(screen.getByText("Chưa đủ điều kiện để nộp.")).toBeInTheDocument()
+  })
+
+  it("confirming the dialog fires onSubmitWithDebt with the acknowledge + reason payload", () => {
+    const onSubmitWithDebt = vi.fn()
+    renderPanel(
+      buildProfile({
+        eligibility_status: "ineligible",
+        missing_doc_codes: ["hoc_ba_thpt"],
+        documents_checklist: [
+          { code: "hoc_ba_thpt", label: "Học bạ THPT", status: "missing" },
+        ],
+      }),
+      {
+        primaryAction: "submit",
+        canSubmit: true,
+        isEligible: false,
+        canSubmitWithDocumentDebt: true,
+        onSubmitWithDebt,
+      },
+    )
+    fireEvent.change(screen.getByLabelText(/Lý do cho nợ/), {
+      target: { value: "cấp lại học bạ" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Xác nhận nộp" }))
+    expect(onSubmitWithDebt).toHaveBeenCalledWith({
+      acknowledge_missing_docs: true,
+      document_debt_reason: "cấp lại học bạ",
+    })
   })
 })

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/DecisionActionsPanel.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/DecisionActionsPanel.tsx
@@ -39,6 +39,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { ApprovalDecisionButton } from "../../ApprovalDecisionButton"
+import { SubmitWithDebtDialog } from "./SubmitWithDebtDialog"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
 import type { PrimaryAction } from "./useSubmissionReadiness"
 
@@ -58,6 +59,18 @@ export interface DecisionActionsPanelProps {
   onSubmit: () => void
   isSubmitting: boolean
   canSubmit: boolean
+
+  /**
+   * Fast-track nợ giấy tờ — confirm a document debt and submit
+   * (TUITION_PREPAY_FASTTRACK_PLAN.md §4). Surfaced as a distinct
+   * "Nộp kèm nợ giấy tờ" CTA, gated by `canSubmitWithDocumentDebt`
+   * (= `profile.can_submit_with_document_debt`, an API flag — NOT role).
+   */
+  onSubmitWithDebt?: (payload: {
+    acknowledge_missing_docs: true
+    document_debt_reason: string
+  }) => void
+  canSubmitWithDocumentDebt?: boolean
 
   onResubmit?: () => void
   isResubmitting?: boolean
@@ -107,6 +120,8 @@ export function DecisionActionsPanel({
   onSubmit,
   isSubmitting,
   canSubmit,
+  onSubmitWithDebt,
+  canSubmitWithDocumentDebt = false,
   onResubmit,
   isResubmitting = false,
   canResubmit,
@@ -333,12 +348,26 @@ export function DecisionActionsPanel({
     return <Shell className={className}>{enrollButton()}</Shell>
   }
   if (primaryAction === "submit" && canSubmit) {
+    // Fast-track: when the profile is eligible on every axis EXCEPT missing
+    // mandatory docs, the backend grants `can_submit_with_document_debt`. Offer
+    // "Nộp kèm nợ giấy tờ" alongside the (disabled) normal submit. The reason
+    // line then points at the debt option instead of a dead "chưa đủ điều kiện".
+    const showDebt = canSubmitWithDocumentDebt && !!onSubmitWithDebt
+    const reasonNode = showDebt ? (
+      <Reason>Còn thiếu giấy tờ — có thể nộp kèm nợ giấy tờ.</Reason>
+    ) : !isEligible ? (
+      <Reason>Chưa đủ điều kiện để nộp.</Reason>
+    ) : undefined
     return (
-      <Shell
-        className={className}
-        reason={!isEligible ? <Reason>Chưa đủ điều kiện để nộp.</Reason> : undefined}
-      >
+      <Shell className={className} reason={reasonNode}>
         {submitButton()}
+        {showDebt && (
+          <SubmitWithDebtDialog
+            profile={profile}
+            onConfirm={onSubmitWithDebt!}
+            isSubmitting={isSubmitting}
+          />
+        )}
       </Shell>
     )
   }

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/SubmitWithDebtDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/SubmitWithDebtDialog.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * SubmitWithDebtDialog — fast-track "Nộp kèm nợ giấy tờ" tests
+ * (TUITION_PREPAY_FASTTRACK_PLAN.md §4 / C4).
+ *
+ * Pins:
+ *   - Trigger "Nộp kèm nợ giấy tờ" renders.
+ *   - Owed docs come from `missing_doc_codes`, humanised via documents_checklist.
+ *   - Reason is MANDATORY: confirm disabled while empty, enabled once filled.
+ *   - Confirm fires `{ acknowledge_missing_docs: true, document_debt_reason }`
+ *     with the trimmed reason.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+
+// Pass-through Dialog mock (no Radix portal / open-state) so the dialog body is
+// always in the tree — we assert on its content + confirm directly.
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => <>{children}</>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div data-testid="dialog-content">{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { SubmitWithDebtDialog } from "./SubmitWithDebtDialog"
+
+function buildProfile(overrides: Partial<AdmissionProfileResponse> = {}): AdmissionProfileResponse {
+  return {
+    id: 1,
+    lead_id: 1,
+    status: "draft",
+    version: 1,
+    academic_year: 2026,
+    permissions: {},
+    eligibility_status: "ineligible",
+    validation_errors: [],
+    available_actions: [],
+    completion_percent: 90,
+    applied_rules: {},
+    family_info: [],
+    academic_history: [],
+    documents_checklist: [
+      { code: "hoc_ba_thpt", label: "Học bạ THPT", status: "missing" },
+      { code: "cccd", label: "CCCD bản sao", status: "missing" },
+    ],
+    missing_priority_evidence_codes: [],
+    missing_doc_codes: ["hoc_ba_thpt", "cccd"],
+    outstanding_debt_codes: [],
+    can_submit_with_document_debt: true,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  } as unknown as AdmissionProfileResponse
+}
+
+describe("SubmitWithDebtDialog", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renders the 'Nộp kèm nợ giấy tờ' trigger", () => {
+    render(
+      <SubmitWithDebtDialog profile={buildProfile()} onConfirm={vi.fn()} isSubmitting={false} />,
+    )
+    expect(screen.getByText("Nộp kèm nợ giấy tờ")).toBeInTheDocument()
+  })
+
+  it("lists owed docs from missing_doc_codes, humanised via documents_checklist", () => {
+    render(
+      <SubmitWithDebtDialog profile={buildProfile()} onConfirm={vi.fn()} isSubmitting={false} />,
+    )
+    expect(screen.getByText("Học bạ THPT")).toBeInTheDocument()
+    expect(screen.getByText("CCCD bản sao")).toBeInTheDocument()
+    // Count heading reflects the number of owed codes.
+    expect(screen.getByText("Giấy tờ còn nợ (2)")).toBeInTheDocument()
+  })
+
+  it("falls back to the raw code when no checklist label matches", () => {
+    render(
+      <SubmitWithDebtDialog
+        profile={buildProfile({ documents_checklist: [], missing_doc_codes: ["weird_code"] })}
+        onConfirm={vi.fn()}
+        isSubmitting={false}
+      />,
+    )
+    expect(screen.getByText("weird_code")).toBeInTheDocument()
+  })
+
+  it("disables confirm while the reason is empty, enables once filled", () => {
+    render(
+      <SubmitWithDebtDialog profile={buildProfile()} onConfirm={vi.fn()} isSubmitting={false} />,
+    )
+    const confirm = screen.getByRole("button", { name: "Xác nhận nộp" })
+    expect(confirm).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText(/Lý do cho nợ/), {
+      target: { value: "HS xin cấp lại học bạ, hẹn 30/06" },
+    })
+    expect(confirm).not.toBeDisabled()
+  })
+
+  it("keeps confirm disabled for whitespace-only reason", () => {
+    render(
+      <SubmitWithDebtDialog profile={buildProfile()} onConfirm={vi.fn()} isSubmitting={false} />,
+    )
+    fireEvent.change(screen.getByLabelText(/Lý do cho nợ/), { target: { value: "   " } })
+    expect(screen.getByRole("button", { name: "Xác nhận nộp" })).toBeDisabled()
+  })
+
+  it("fires onConfirm with acknowledge_missing_docs + trimmed reason", () => {
+    const onConfirm = vi.fn()
+    render(
+      <SubmitWithDebtDialog profile={buildProfile()} onConfirm={onConfirm} isSubmitting={false} />,
+    )
+    fireEvent.change(screen.getByLabelText(/Lý do cho nợ/), {
+      target: { value: "  cấp lại học bạ  " },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Xác nhận nộp" }))
+    expect(onConfirm).toHaveBeenCalledWith({
+      acknowledge_missing_docs: true,
+      document_debt_reason: "cấp lại học bạ",
+    })
+  })
+
+  it("shows a spinner label + disables confirm while submitting", () => {
+    render(
+      <SubmitWithDebtDialog profile={buildProfile()} onConfirm={vi.fn()} isSubmitting={true} />,
+    )
+    // Even with a reason present, the submitting state blocks re-confirm.
+    fireEvent.change(screen.getByLabelText(/Lý do cho nợ/), { target: { value: "abc" } })
+    const confirm = screen.getByRole("button", { name: /Đang xử lý/ })
+    expect(confirm).toBeDisabled()
+  })
+})

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/SubmitWithDebtDialog.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/SubmitWithDebtDialog.tsx
@@ -1,0 +1,186 @@
+/**
+ * SubmitWithDebtDialog — fast-track "Nộp kèm nợ giấy tờ" (TUITION_PREPAY_FASTTRACK_PLAN.md §4 / §4b ②).
+ *
+ * Officer/owner CTA shown ONLY when the backend grants
+ * `profile.can_submit_with_document_debt` (the profile is eligible on every
+ * axis EXCEPT it is still missing some mandatory documents). The acting staff
+ * confirms a document debt — listing the owed docs + a MANDATORY reason — and
+ * the profile transitions to `submitted` while the backend records a
+ * `document_debt` snapshot.
+ *
+ * Thin Client: visibility is driven by the API permission flag
+ * `can_submit_with_document_debt`, NEVER by `user.role`. The owed-doc list comes
+ * straight from `profile.missing_doc_codes`; codes are humanised against
+ * `documents_checklist` labels when available, otherwise the raw code is shown.
+ */
+
+"use client"
+
+import { useMemo, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { FileWarning, Loader2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+
+const TRIGGER_CLASS = "w-full sm:w-auto min-w-[200px]"
+
+export interface SubmitWithDebtDialogProps {
+  profile: AdmissionProfileResponse
+  /** Fires with the submit-with-debt payload after the staff confirms. */
+  onConfirm: (payload: { acknowledge_missing_docs: true; document_debt_reason: string }) => void
+  isSubmitting: boolean
+  className?: string
+}
+
+/**
+ * Resolve a missing-doc code to its human label using the profile's document
+ * checklist (single source of truth for code→label). Falls back to the raw code
+ * when no checklist row matches (e.g. a code dropped from the current snapshot).
+ */
+function buildCodeLabelMap(profile: AdmissionProfileResponse): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const doc of profile.documents_checklist ?? []) {
+    if (doc.code && doc.label) map.set(doc.code, doc.label)
+  }
+  return map
+}
+
+export function SubmitWithDebtDialog({
+  profile,
+  onConfirm,
+  isSubmitting,
+  className,
+}: SubmitWithDebtDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [reason, setReason] = useState("")
+
+  const codeLabelMap = useMemo(() => buildCodeLabelMap(profile), [profile])
+  const missingCodes = profile.missing_doc_codes ?? []
+
+  const reasonEmpty = reason.trim().length === 0
+  const confirmDisabled = reasonEmpty || isSubmitting
+
+  const handleConfirm = () => {
+    const trimmed = reason.trim()
+    if (!trimmed) return
+    onConfirm({ acknowledge_missing_docs: true, document_debt_reason: trimmed })
+    // Leave closing to the caller's mutation success path? The mutation here is
+    // fire-and-forget from the dialog's view; close + reset locally so the UI
+    // returns to rest immediately (the detail refetch updates the surface).
+    setOpen(false)
+    setReason("")
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) setReason("")
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          size="lg"
+          className={cn(
+            TRIGGER_CLASS,
+            "border-warning-300 text-warning-700 hover:bg-warning-50 hover:text-warning-800",
+            className,
+          )}
+        >
+          <FileWarning className="w-4 h-4 mr-2" aria-hidden="true" />
+          Nộp kèm nợ giấy tờ
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Nộp hồ sơ kèm nợ giấy tờ</DialogTitle>
+          <DialogDescription>
+            Hồ sơ đủ điều kiện nhưng còn thiếu giấy tờ. Officer xác nhận cho nợ — học sinh
+            bổ sung sau. Hồ sơ vẫn phải bổ sung và được xác minh đủ trước khi duyệt.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm font-medium mb-2">
+              Giấy tờ còn nợ ({missingCodes.length})
+            </p>
+            {missingCodes.length > 0 ? (
+              <ul className="space-y-1 rounded-md border border-warning-200 bg-warning-50 p-3">
+                {missingCodes.map((code) => (
+                  <li
+                    key={code}
+                    className="flex items-start gap-2 text-sm text-warning-800"
+                  >
+                    <FileWarning
+                      className="h-4 w-4 shrink-0 mt-0.5"
+                      aria-hidden="true"
+                    />
+                    <span className="break-words">{codeLabelMap.get(code) ?? code}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">Không có giấy tờ còn thiếu.</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="document-debt-reason">
+              Lý do cho nợ <span className="text-error-600">*</span>
+            </Label>
+            <Textarea
+              id="document-debt-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="VD: HS đang xin cấp lại học bạ, hẹn nộp 30/06"
+              rows={3}
+              aria-required="true"
+            />
+            {reasonEmpty && (
+              <p className="text-xs text-muted-foreground">
+                Bắt buộc nhập lý do cho nợ giấy tờ.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => {
+              setOpen(false)
+              setReason("")
+            }}
+            disabled={isSubmitting}
+          >
+            Hủy
+          </Button>
+          <Button onClick={handleConfirm} disabled={confirmDisabled}>
+            {isSubmitting ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" aria-hidden="true" />
+                Đang xử lý…
+              </>
+            ) : (
+              "Xác nhận nộp"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/SubmitWithDebtDialog.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/SubmitWithDebtDialog.tsx
@@ -148,6 +148,9 @@ export function SubmitWithDebtDialog({
               onChange={(e) => setReason(e.target.value)}
               placeholder="VD: HS đang xin cấp lại học bạ, hẹn nộp 30/06"
               rows={3}
+              // Mirrors the backend `document_debt_reason` Field(max_length=500)
+              // so the client can't compose a reason the API would 422-reject.
+              maxLength={500}
               aria-required="true"
             />
             {reasonEmpty && (

--- a/frontend/src/hooks/admissions/useAdmissions.test.tsx
+++ b/frontend/src/hooks/admissions/useAdmissions.test.tsx
@@ -115,7 +115,7 @@ describe("useAdmissions – BUG-14 & BUG-16 invalidation", () => {
       );
 
       act(() => {
-        result.current.mutate();
+        result.current.mutate(undefined);
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -152,7 +152,7 @@ describe("useAdmissions – BUG-14 & BUG-16 invalidation", () => {
       );
 
       act(() => {
-        result.current.mutate();
+        result.current.mutate(undefined);
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -190,7 +190,7 @@ describe("useAdmissions – BUG-14 & BUG-16 invalidation", () => {
       );
 
       act(() => {
-        result.current.mutate();
+        result.current.mutate(undefined);
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
@@ -234,7 +234,7 @@ describe("useAdmissions – BUG-14 & BUG-16 invalidation", () => {
       );
 
       act(() => {
-        result.current.mutate();
+        result.current.mutate(undefined);
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/frontend/src/hooks/admissions/useAdmissions.ts
+++ b/frontend/src/hooks/admissions/useAdmissions.ts
@@ -231,11 +231,22 @@ export function useRecordApplicationFeePayment(id: number) {
   })
 }
 
+/**
+ * Submit Admission hook.
+ *
+ * Accepts an OPTIONAL payload so the same hook drives both the plain submit
+ * (no args / undefined → legacy no-body request) and the fast-track
+ * submit-with-debt flow (`{ acknowledge_missing_docs, document_debt_reason }`).
+ * Parity (memory react-query-mutation-cache-parity): invalidate the detail key
+ * on success so `document_debt` / `outstanding_debt_codes` / status refetch.
+ */
 export function useSubmitAdmission(id: number) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: () => admissionsApi.submitAdmission(id),
+    mutationFn: (
+      payload?: { acknowledge_missing_docs?: boolean; document_debt_reason?: string }
+    ) => admissionsApi.submitAdmission(id, payload),
     onSuccess: (data) => {
       // Phase 7: Use status-config for async-first workflow (ADR-FE-003)
       // Backend only returns "draft" (validation failed) or "submitted" (success)

--- a/frontend/src/lib/api/admissions.ts
+++ b/frontend/src/lib/api/admissions.ts
@@ -92,12 +92,25 @@ export async function recordApplicationFeePayment(
 // ============================================
 
 /**
- * Submit admission profile
+ * Submit admission profile.
+ *
+ * Fast-track nợ giấy tờ (TUITION_PREPAY_FASTTRACK_PLAN.md C1): the backend
+ * submit endpoint now accepts an OPTIONAL body. A plain submit (no payload)
+ * keeps the legacy no-body behaviour. When the acting staff user submits with
+ * a document debt, pass `{ acknowledge_missing_docs: true, document_debt_reason }`
+ * — the backend waives the missing-doc validation errors (only when every OTHER
+ * validation passes) and records a `document_debt` snapshot.
  */
 export async function submitAdmission(
-  id: number
+  id: number,
+  payload?: { acknowledge_missing_docs?: boolean; document_debt_reason?: string }
 ): Promise<AdmissionSubmitResponse> {
-  const response = await api.post<AdmissionSubmitResponse>(`/api/admissions/${id}/submit`)
+  const response = await api.post<AdmissionSubmitResponse>(
+    `/api/admissions/${id}/submit`,
+    // Preserve the legacy no-body call when no payload is supplied; only send a
+    // JSON body for the submit-with-debt flow.
+    payload ?? undefined
+  )
   return response.data
 }
 

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -1200,7 +1200,7 @@ export const admissionProfileResponseSchema = z.object({
       codes: z.array(z.string()).default([]),
       reason: z.string(),
       by_user_id: z.number().int(),
-      at: z.string(),
+      at: z.string().datetime({ offset: true }),
     })
     .nullable()
     .optional()

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -1188,6 +1188,39 @@ export const admissionProfileResponseSchema = z.object({
     min_subject_score: z.number(),
     min_score: z.number(),
   }).nullable().optional().describe("Backend-computed score pass/fail status for each subject and total"),
+
+  // =========================================================================
+  // Fast-track prepay/giữ chỗ — nợ giấy tờ contract (C1). Mirror of BE
+  // AdmissionProfileResponse. C1 adds only the contract; the dialog + badge
+  // that consume these land in C4.
+  // =========================================================================
+  // Persisted snapshot captured at staff submit-with-debt. null = no debt.
+  document_debt: z
+    .object({
+      codes: z.array(z.string()).default([]),
+      reason: z.string(),
+      by_user_id: z.number().int(),
+      at: z.string(),
+    })
+    .nullable()
+    .optional()
+    .describe("Snapshot {codes, reason, by_user_id, at} of nợ giấy tờ. null when none."),
+  // COMPUTED: snapshot codes that are STILL missing now → the badge counts
+  // this (self-resolves to [] once owed docs uploaded).
+  outstanding_debt_codes: z
+    .array(z.string())
+    .default([])
+    .describe("document_debt codes still missing now; empty when resolved."),
+  // Mandatory doc codes currently missing (excludes uploaded-pending-verify).
+  missing_doc_codes: z
+    .array(z.string())
+    .default([])
+    .describe("Currently-missing mandatory doc codes for the submit-with-debt dialog."),
+  // COMPUTED flag — staff may submit this draft with a document debt.
+  can_submit_with_document_debt: z
+    .boolean()
+    .default(false)
+    .describe("True when the acting staff user may submit with a document debt."),
 })
 
 export type AdmissionProfileResponse = z.infer<

--- a/frontend/src/lib/zod/admissions.ts
+++ b/frontend/src/lib/zod/admissions.ts
@@ -1221,6 +1221,15 @@ export const admissionProfileResponseSchema = z.object({
     .boolean()
     .default(false)
     .describe("True when the acting staff user may submit with a document debt."),
+  // COMPUTED flag — a rejected/withdrawn profile still holds collected,
+  // not-yet-refunded tuition (SUM(fee.paid_amount) > 0). Drives the
+  // "cần hoàn tiền" warning banner. False for every non-terminal status.
+  has_unrefunded_payment: z
+    .boolean()
+    .default(false)
+    .describe(
+      "True when a rejected/withdrawn profile still holds unrefunded tuition."
+    ),
 })
 
 export type AdmissionProfileResponse = z.infer<


### PR DESCRIPTION
## Mục tiêu
Rút ngắn quy trình thu học phí + cho phép **giữ chỗ = đóng học phí trả trước** ngay cả khi hồ sơ còn thiếu giấy tờ. Bỏ ý tưởng "cọc riêng" (plan v2.5 shelved) — khoản giữ chỗ chính là **học phí trả trước** (partial payment), tận dụng hạ tầng Finance Phase 1.

## Luồng nghiệp vụ
1. Officer nộp hồ sơ **kèm nợ giấy tờ** (đủ điều kiện học thuật, chỉ thiếu giấy tờ) → `submitted` + ghi `document_debt`.
2. Tính **học phí ở `submitted`** (chỉ hồ sơ **một-nguyện-vọng**; multi-NV đợi công bố) → hóa đơn **auto-issue**.
3. Kế toán **thu trả trước** (partial) → HK1 cleared → lead tiến.
4. Bổ sung + **verify** giấy tờ → hết nợ → mới được **duyệt / công bố kết quả**.
5. Hoàn tiền: dùng refund flow sẵn có.

## Thay đổi (10 commit)
- **C1** `document_debt` (cột riêng, né trigger `applied_rules`) + nới submit bằng SUBTRACTION (`other_errors==[]`, chỉ waive giấy tờ thật) + staff-only + contract đầy đủ.
- **C1.5** `outstanding_debt_codes` **verified-based** + **approve-gate** (approve_profile + bulk_approve).
- **C2** fee gate `submitted` (2 site mirror) + auto-issue tuition + capture `invoice_cb` (sự kiện INVOICE_ISSUED).
- **C3** integration smoke end-to-end.
- **fix L2/L1** siết `submitted` cho single-path (multi-NV chưa chốt ngành → tránh thu nhầm) + nhất quán owner.
- **publish-gate** chặn `publish_result` khi còn nợ giấy tờ (đóng lỗ C1.5 cho choice-engine).
- **#1** cảnh báo `has_unrefunded_payment` + log khi reject/withdraw hồ sơ còn tiền chưa hoàn (không chặn).
- **2 commit dọn** anti-drift (`is_fee_eligible`, `_satisfied_doc_codes`, helper format/approve-gate) + FE robustness (date-guard, reason maxLength/preserve).
- **FE (C4)**: dialog "Nộp kèm nợ giấy tờ" + badge "Nợ giấy tờ" (phân biệt **Chưa nộp** / **Chờ xác minh**).

## Kiểm chứng
- Test BE + FE xanh (one-off container): document-debt 16, fee-auth 18, prepay-flow 8, choice-engine publish 50, unrefunded 4, + regression; FE type-check + vitest + eslint.
- `/code-review` max-effort **2 vòng** → mọi correctness bug đã đóng (publish_result là lỗ thật, đã vá).
- **Chrome smoke PASS**: badge + L5 render đúng từ API thật; approve/publish-gate đúng.
- Migration `docdebt01` (cột `document_debt`) — head tuyến tính.

## Quyết định nghiệp vụ (đã chốt với chủ sản phẩm)
- Multi-NV: tính học phí ở submitted **chỉ single-path**; multi-NV đợi công bố.
- Tiền mồ côi khi reject/withdraw: **cảnh báo + cờ** (không chặn; hoàn thủ công).
- Lead nhảy sts10 khi prepay ở submitted: **giữ nguyên** (đã trả tiền thật).

## Defer (mức thấp / by-design / dormant)
Nhắc bổ-sung-giấy-tờ tự động; auto-issue due_date; `paper_submitted` self-clear; `upload_required_docs` dormant; vài cleanup nhỏ + N+1 bulk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
