### PR TITLE
feat(admissions): redesign trang danh sách hồ sơ — operations desk v2

### DIFF
--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsBulkActionsBar.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsBulkActionsBar.tsx
@@ -61,7 +61,7 @@ export function AdmissionsBulkActionsBar({
         "fixed bottom-[calc(var(--bottom-nav-height-safe)_+_0.5rem)] lg:bottom-6 left-1/2 z-50 -translate-x-1/2",
         "animate-in slide-in-from-bottom-4 fade-in-0 duration-200",
         "bg-background/95 supports-[backdrop-filter]:bg-background/80 backdrop-blur",
-        "flex flex-wrap items-center gap-2 sm:gap-3 rounded-lg border px-3 sm:px-4 py-2 sm:py-3 shadow-lg",
+        "flex flex-wrap items-center gap-2 sm:gap-3 rounded-2xl border px-3 sm:px-4 py-2 sm:py-3 shadow-lg",
         "max-w-[95vw] sm:max-w-none"
       )}
     >

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -1,21 +1,17 @@
 // src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
 /**
- * AdmissionsClient - Main client component for admissions list
+ * AdmissionsClient — danh sách hồ sơ tuyển sinh ("Operations desk" v2).
  *
- * Features:
- * - TanStack Table with sorting and selection
- * - Advanced filters: status, major, academic year, degree level, payment status, date range
- * - Status tabs with count badges
- * - Stats cards (totals, conversion rate, avg completion)
- * - Mobile card view
- * - Bulk actions (approve, reject, assign, export)
- * - URL sync + localStorage persistence (via useAdmissionsFilter)
- * - Next page prefetch for instant pagination
+ * Redesign thuần presentation: metric rail · filter bar (search + Năm + popover
+ * Bộ lọc + Sắp xếp + chips) · status tabs gạch chân · roster bảng + card mobile
+ * (status chấm, progress ngưỡng, monogram, avatar chip) · density Thoáng/Gọn
+ * (localStorage). GIỮ NGUYÊN data layer: useAdmissionsFilter (URL+localStorage),
+ * TanStack table (sort + selection), SSR initialData, prefetch, bulk + permission.
  */
 
 "use client"
 
-import { useState, useMemo, useCallback, useEffect, memo } from "react"
+import { useState, useMemo, useCallback, useEffect } from "react"
 import {
   useReactTable,
   getCoreRowModel,
@@ -26,75 +22,19 @@ import {
 } from "@tanstack/react-table"
 import { useQueryClient } from "@tanstack/react-query"
 import { AxiosError } from "axios"
-import { format } from "date-fns"
-import { vi } from "date-fns/locale"
-import {
-  ClipboardCheck,
-  Search,
-  X,
-  Calendar,
-  Filter,
-  MoreVertical,
-  FileText,
-  Users,
-  CheckCircle2,
-  GraduationCap,
-  TrendingUp,
-  BarChart3,
-} from "lucide-react"
+import { ClipboardCheck } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Badge } from "@/components/ui/badge"
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
-import { Progress } from "@/components/ui/progress"
 import { Skeleton } from "@/components/ui/skeleton"
-import {
-  BaseCard,
-  CardHeader as BaseCardHeader,
-  CardBody,
-  CardMeta,
-  CardTime,
-  CardActions,
-} from "@/components/ui/base-card"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuCheckboxItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-  DropdownMenuLabel,
-} from "@/components/ui/dropdown-menu"
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover"
-import { Calendar as CalendarComponent } from "@/components/ui/calendar"
 import { PageContainer } from "@/components/layouts/PageContainer"
 import { EmptyState, ErrorEmptyState } from "@/components/common/EmptyState"
 import { Pagination } from "@/components/common/table/Pagination"
 import { cn } from "@/lib/utils"
+import { formatDate } from "@/lib/utils/admission-helpers"
 import { hasAction } from "@/lib/admission/permissions"
 
 import {
@@ -119,92 +59,29 @@ import {
 import { admissionsApi } from "@/lib/api/admissions"
 import { handleApiError, type ApiErrorResponse } from "@/lib/error-handler"
 import type { AdmissionListParams, AdmissionProfileResponse, AdmissionsPage } from "@/lib/zod/admissions"
-import { getColumns, STATUS_CONFIG, ELIGIBILITY_CONFIG } from "./columns"
+
+import { getColumns } from "./columns"
 import { AdmissionsBulkActionsBar } from "./AdmissionsBulkActionsBar"
 import { BulkRejectDialog } from "./dialogs/BulkRejectDialog"
 import { BulkAssignDialog } from "./dialogs/BulkAssignDialog"
-
-// =============================================================================
-// CONSTANTS
-// =============================================================================
+import { AdmissionsMetricRail, type MetricItem } from "./AdmissionsMetricRail"
+import { AdmissionsFilterBar } from "./AdmissionsFilterBar"
+import { AdmissionsStatusTabs } from "./AdmissionsStatusTabs"
+import { Monogram, StatusDot, ProgressBar, EligibilityToken, RowActionsMenu } from "./roster-parts"
 
 const CURRENT_YEAR = CURRENT_ADMISSIONS_YEAR
+const DENSITY_STORAGE_KEY = "admissions:density"
 
-const STATUS_OPTIONS = [
-  { value: "draft", label: "Nháp" },
-  { value: "submitted", label: "Chờ duyệt" },
-  { value: "resubmitted", label: "Đã nộp lại" },
-  // phase1_11 (#184 Wave 3 PR-3A) — 4 status mới + 3 status
-  // legacy bị thiếu trong filter chooser cũ. Listed in workflow
-  // order (draft → submit → review → approve/admit/waitlist/
-  // publish → reject → revise → confirm → enroll → withdraw +
-  // override side-channel).
-  { value: "reviewing", label: "Đang xét" },
-  { value: "approved", label: "Đã duyệt" },
-  { value: "admitted", label: "Đậu" },
-  { value: "waitlisted", label: "Chờ ghế" },
-  { value: "result_published", label: "Đã công bố KQ" },
-  { value: "rejected", label: "Từ chối" },
-  { value: "revision_requested", label: "Yêu cầu bổ sung" },
-  { value: "confirmed", label: "Đã xác nhận" },
-  { value: "overridden", label: "Đã override" },
-  { value: "enrolled", label: "Đã nhập học" },
-  { value: "withdrawn", label: "Đã rút" },
-]
+type Density = "comfortable" | "compact"
 
-const PAYMENT_STATUS_OPTIONS = [
-  { value: "paid", label: "Đã thanh toán" },
-  { value: "unpaid", label: "Chưa thanh toán" },
-  { value: "partial", label: "Thanh toán một phần" },
-  { value: "no_fee", label: "Chưa có học phí" },
-]
-
-// Status tabs (rendered here) come from the SHARED `ADMISSION_STATUS_TABS`
-// (imported as STATUS_TABS) so the tab→status filter mapping in
-// useAdmissionsFilter.handleTabClick can never drift from these rendered tabs.
-
-// =============================================================================
-// STAT CARD COMPONENT
-// =============================================================================
-
-interface StatCardProps {
-  label: string
-  value: number | string
-  icon: React.ReactNode
-  className?: string
-}
-
-const StatCard = memo(function StatCard({ label, value, icon, className }: StatCardProps) {
-  return (
-    <Card className={cn("p-4", className)}>
-      <div className="flex items-center gap-3">
-        <div className="flex-shrink-0 rounded-lg bg-muted p-2">
-          {icon}
-        </div>
-        <div className="min-w-0">
-          <p className="text-2xl font-bold tracking-tight">{value}</p>
-          <p className="text-xs text-muted-foreground truncate">{label}</p>
-        </div>
-      </div>
-    </Card>
-  )
-})
-
-// =============================================================================
-// DATE HELPERS
-// =============================================================================
-
-/** Parse yyyy-MM-dd string to Date (noon to avoid timezone issues) */
-function parseDate(str: string): Date | undefined {
-  if (!str) return undefined
-  return new Date(str + "T12:00:00")
-}
-
-/** Format Date to dd/MM display string */
-function formatShortDate(str: string): string {
-  if (!str) return "…"
-  // str is "yyyy-MM-dd"
-  return str.slice(8, 10) + "/" + str.slice(5, 7)
+/** Enter/Space kích hoạt row, bỏ qua khi focus ở element interactive bên trong. */
+function activateRow(e: React.KeyboardEvent, fn: () => void) {
+  if (e.key !== "Enter" && e.key !== " ") return
+  const target = e.target as HTMLElement
+  const inner = target.closest("button, a, input, [role='checkbox']")
+  if (inner && inner !== e.currentTarget) return
+  e.preventDefault()
+  fn()
 }
 
 // =============================================================================
@@ -223,10 +100,28 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
   // ── Filter state (URL sync + localStorage) ────────────────────────────
   const { state, handlers, hasActiveFilters, apiFilters, countFilters } = useAdmissionsFilter()
 
-  // ── Table state (local only — not persisted) ──────────────────────────
+  // ── View state (local) ────────────────────────────────────────────────
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
   const [rejectDialogOpen, setRejectDialogOpen] = useState(false)
   const [assignDialogOpen, setAssignDialogOpen] = useState(false)
+  const [rowRejectTarget, setRowRejectTarget] = useState<AdmissionProfileResponse | null>(null)
+
+  // Density: default 'comfortable' (SSR-safe), đọc localStorage SAU mount
+  // để tránh hydration mismatch.
+  const [density, setDensity] = useState<Density>("comfortable")
+  useEffect(() => {
+    const stored = window.localStorage.getItem(DENSITY_STORAGE_KEY)
+    if (stored === "compact" || stored === "comfortable") setDensity(stored)
+  }, [])
+  const handleDensityChange = useCallback((value: Density) => {
+    setDensity(value)
+    try {
+      window.localStorage.setItem(DENSITY_STORAGE_KEY, value)
+    } catch {
+      // ignore storage errors
+    }
+  }, [])
+  const compact = density === "compact"
 
   // Derive TanStack sorting from hook state
   const tableSorting: SortingState = useMemo(() => {
@@ -236,8 +131,7 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
 
   const handleSortingChange = useCallback(
     (updaterOrValue: SortingState | ((prev: SortingState) => SortingState)) => {
-      const newSorting =
-        typeof updaterOrValue === "function" ? updaterOrValue(tableSorting) : updaterOrValue
+      const newSorting = typeof updaterOrValue === "function" ? updaterOrValue(tableSorting) : updaterOrValue
       if (newSorting.length > 0) {
         handlers.handleSortChange(newSorting[0].id, newSorting[0].desc ? "desc" : "asc")
       } else {
@@ -247,7 +141,7 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
     [tableSorting, handlers],
   )
 
-  // ── Reference data queries ────────────────────────────────────────────
+  // ── Reference data ────────────────────────────────────────────────────
   const { data: majorPrograms } = useAdmissionPrograms()
   const { data: academicYears } = useAcademicYears()
   const { data: degreeLevels } = useDegreeLevelsPublic()
@@ -258,8 +152,6 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
   }, [academicYears])
 
   // ── Data queries ──────────────────────────────────────────────────────
-  // Only attach SSR data while the current query still matches the server query.
-  // After localStorage hydration or user edits, a new query must fetch its own data.
   const safeInitialData = areAdmissionsListParamsEqual(apiFilters, initialQueryParams) ? initialData : undefined
   const { data, isLoading, isError, isFetching } = useListAdmissions(apiFilters, { initialData: safeInitialData })
   const { data: statusCounts } = useAdmissionStatusCounts(countFilters)
@@ -288,22 +180,75 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
     }
   }, [state.page, state.pageSize, totalCount, apiFilters, queryClient, data])
 
-  // ── Claim handler (list view) ────────────────────────────────────────
-  const handleClaimFromList = useCallback(async (profile: AdmissionProfileResponse) => {
-    if (profile.version == null) return
-    try {
-      await admissionsApi.claimAdmissionProfile(profile.id, { version: profile.version })
-      toast.success("Đã nhận duyệt hồ sơ")
-      queryClient.invalidateQueries({ queryKey: admissionsKeys.lists() })
-    } catch (error) {
-      handleApiError(error as AxiosError<ApiErrorResponse>, { context: "nhận duyệt hồ sơ" })
-    }
-  }, [queryClient])
+  // Đổi bộ lọc/tab/trang → xóa selection để không "rò rỉ" lựa chọn vô hình sang
+  // view khác (apiFilters đổi tham chiếu khi bất kỳ filter/page/sort đổi).
+  useEffect(() => {
+    setRowSelection({})
+  }, [apiFilters])
+
+  // ── Claim handler ─────────────────────────────────────────────────────
+  const handleClaimFromList = useCallback(
+    async (profile: AdmissionProfileResponse) => {
+      if (profile.version == null) return
+      try {
+        await admissionsApi.claimAdmissionProfile(profile.id, { version: profile.version })
+        toast.success("Đã nhận duyệt hồ sơ")
+        queryClient.invalidateQueries({ queryKey: admissionsKeys.lists() })
+      } catch (error) {
+        handleApiError(error as AxiosError<ApiErrorResponse>, { context: "nhận duyệt hồ sơ" })
+      }
+    },
+    [queryClient],
+  )
+
+  const openProfile = useCallback(
+    (id: number) => router.push(`/admissions/${id}`),
+    [router],
+  )
+
+  // ── Single-row approve/reject (row menu) — gated by hasAction ──────────
+  const handleRowApprove = useCallback(
+    async (profile: AdmissionProfileResponse) => {
+      try {
+        await bulkApprove.mutateAsync({
+          items: [{ profile_id: profile.id, version: profile.version ?? 1 }],
+        })
+      } catch (error) {
+        // Hook đã toast theo result 2xx; catch này phủ path ném (network/HTTP lỗi).
+        handleApiError(error as AxiosError<ApiErrorResponse>, { context: "phê duyệt hồ sơ" })
+      }
+    },
+    [bulkApprove],
+  )
+
+  // Reject cần lý do → mở dialog cho đúng 1 hồ sơ.
+  const requestRowReject = useCallback((profile: AdmissionProfileResponse) => {
+    setRowRejectTarget(profile)
+  }, [])
+
+  const handleRowReject = useCallback(
+    async (reason: string) => {
+      if (!rowRejectTarget) return
+      await bulkReject.mutateAsync({
+        items: [{ profile_id: rowRejectTarget.id, version: rowRejectTarget.version ?? 1 }],
+        reason,
+      })
+      setRowRejectTarget(null)
+    },
+    [rowRejectTarget, bulkReject],
+  )
 
   // ── Table instance ────────────────────────────────────────────────────
-  const columns = useMemo(() => getColumns({
-    onClaim: handleClaimFromList,
-  }), [handleClaimFromList])
+  const columns = useMemo(
+    () =>
+      getColumns({
+        onClaim: handleClaimFromList,
+        onApprove: handleRowApprove,
+        onReject: requestRowReject,
+        density,
+      }),
+    [handleClaimFromList, handleRowApprove, requestRowReject, density],
+  )
 
   const table = useReactTable({
     data: profiles,
@@ -319,23 +264,19 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
 
   const selectedProfiles = useMemo(() => {
     return table.getSelectedRowModel().rows.map((row) => row.original)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [table, rowSelection])
+    // `data` ở deps: re-derive khi refetch nền đổi profiles/available_actions → tránh
+    // bulkPermissions stale (table identity ổn định nên không tự recompute).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [table, rowSelection, data])
 
-  const selectedIds = useMemo(() => {
-    return selectedProfiles.map((p) => p.id)
-  }, [selectedProfiles])
+  const selectedIds = useMemo(() => selectedProfiles.map((p) => p.id), [selectedProfiles])
 
-  // Backend-driven bulk permissions: a bulk action is exposed only when EVERY
-  // selected row grants it. One profile without `approve` collapses the whole
-  // selection — avoids triggering a 404 on the first ineligible item.
+  // Backend-driven bulk permissions: chỉ lộ action khi MỌI dòng chọn đều cho phép.
   const bulkPermissions = useMemo(() => {
     if (selectedProfiles.length === 0) {
       return { canApprove: false, canReject: false, canAssign: false }
     }
-    // PR-3D-A Sub-1: hasAction() helper — v2 typed shape preferred, legacy fallback
-    const every = (action: string) =>
-      selectedProfiles.every((p) => hasAction(p, action))
+    const every = (action: string) => selectedProfiles.every((p) => hasAction(p, action))
     return {
       canApprove: every("approve"),
       canReject: every("reject"),
@@ -343,17 +284,7 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
     }
   }, [selectedProfiles])
 
-  const clearSelection = useCallback(() => {
-    setRowSelection({})
-  }, [])
-
-  // ── Status toggle handler (dropdown multi-select) ─────────────────────
-  const handleStatusToggle = useCallback((status: string) => {
-    const newStatuses = state.statusFilters.includes(status)
-      ? state.statusFilters.filter((s) => s !== status)
-      : [...state.statusFilters, status]
-    handlers.handleStatusChange(newStatuses)
-  }, [state.statusFilters, handlers])
+  const clearSelection = useCallback(() => setRowSelection({}), [])
 
   // ── Tab counts ────────────────────────────────────────────────────────
   const tabCounts = useMemo(() => {
@@ -367,6 +298,20 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
     return result
   }, [statusCounts])
 
+  // ── Metric rail items (từ useAdmissionStats) ──────────────────────────
+  const metricItems: MetricItem[] = useMemo(() => {
+    if (!stats) return []
+    const fmt = (n: number) => n.toLocaleString("vi-VN")
+    return [
+      { key: "total", label: "Tổng hồ sơ", value: fmt(stats.total_profiles ?? 0), dot: "bg-primary" },
+      { key: "pending", label: "Chờ duyệt", value: fmt(stats.submitted_count ?? 0), dot: "bg-info-500" },
+      { key: "approved", label: "Đã duyệt", value: fmt(stats.approved_count ?? 0), dot: "bg-success-500" },
+      { key: "enrolled", label: "Đã nhập học", value: fmt(stats.enrolled_count ?? 0), dot: "bg-blue-500" },
+      { key: "conversion", label: "Tỷ lệ chuyển đổi", value: `${stats.conversion_rate ?? 0}%`, dot: "bg-emerald-500", trend: true },
+      { key: "completion", label: "TB hoàn thiện", value: `${stats.avg_completion ?? 0}%`, dot: "bg-amber-500" },
+    ]
+  }, [stats])
+
   // ── Bulk actions ──────────────────────────────────────────────────────
   const handleBulkApprove = useCallback(async () => {
     if (selectedProfiles.length === 0) return
@@ -376,22 +321,28 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
     clearSelection()
   }, [selectedProfiles, bulkApprove, clearSelection])
 
-  const handleBulkReject = useCallback(async (reason: string) => {
-    if (selectedProfiles.length === 0) return
-    await bulkReject.mutateAsync({
-      items: selectedProfiles.map((p) => ({ profile_id: p.id, version: p.version ?? 1 })),
-      reason,
-    })
-    clearSelection()
-    setRejectDialogOpen(false)
-  }, [selectedProfiles, bulkReject, clearSelection])
+  const handleBulkReject = useCallback(
+    async (reason: string) => {
+      if (selectedProfiles.length === 0) return
+      await bulkReject.mutateAsync({
+        items: selectedProfiles.map((p) => ({ profile_id: p.id, version: p.version ?? 1 })),
+        reason,
+      })
+      clearSelection()
+      setRejectDialogOpen(false)
+    },
+    [selectedProfiles, bulkReject, clearSelection],
+  )
 
-  const handleBulkAssign = useCallback(async (officerId: number) => {
-    if (selectedIds.length === 0) return
-    await bulkAssign.mutateAsync({ profile_ids: selectedIds, officer_id: officerId })
-    clearSelection()
-    setAssignDialogOpen(false)
-  }, [selectedIds, bulkAssign, clearSelection])
+  const handleBulkAssign = useCallback(
+    async (officerId: number) => {
+      if (selectedIds.length === 0) return
+      await bulkAssign.mutateAsync({ profile_ids: selectedIds, officer_id: officerId })
+      clearSelection()
+      setAssignDialogOpen(false)
+    },
+    [selectedIds, bulkAssign, clearSelection],
+  )
 
   const handleExport = useCallback(() => {
     exportCsv.mutate({
@@ -408,453 +359,175 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
 
   const isAnyLoading = bulkApprove.isPending || bulkReject.isPending || bulkAssign.isPending || exportCsv.isPending
 
+  const allVisibleSelected =
+    table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && "indeterminate")
+
   return (
     <PageContainer maxWidth="xl">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <ClipboardCheck className="h-7 w-7 md:h-8 md:w-8 text-primary" aria-hidden="true" />
-          <div>
-            <h1 className="text-xl md:text-2xl font-bold font-display">Hồ sơ tuyển sinh</h1>
-            <p className="text-sm text-muted-foreground">
-              Quản lý và theo dõi hồ sơ tuyển sinh
-              {totalCount > 0 && ` (${totalCount} hồ sơ)`}
-            </p>
+      <div className="space-y-5">
+        {/* Header */}
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex size-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <ClipboardCheck className="size-6" aria-hidden="true" />
+            </div>
+            <div>
+              <h1 className="font-display text-xl font-bold tracking-tight md:text-2xl">Hồ sơ tuyển sinh</h1>
+              <p className="text-sm text-muted-foreground">
+                Quản lý và theo dõi hồ sơ tuyển sinh
+                {totalCount > 0 && (
+                  <>
+                    {" · "}
+                    <span className="font-medium tabular-nums text-foreground">{totalCount}</span> hồ sơ
+                  </>
+                )}
+              </p>
+            </div>
           </div>
-        </div>
-      </div>
 
-      {/* Stats Cards */}
-      {stats && (
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mt-4">
-          <StatCard
-            label="Tổng hồ sơ"
-            value={stats.total_profiles ?? 0}
-            icon={<FileText className="h-4 w-4 text-muted-foreground" />}
-          />
-          <StatCard
-            label="Chờ duyệt"
-            value={stats.submitted_count ?? 0}
-            icon={<Users className="h-4 w-4 text-info-600" />}
-          />
-          <StatCard
-            label="Đã duyệt"
-            value={stats.approved_count ?? 0}
-            icon={<CheckCircle2 className="h-4 w-4 text-success-600" />}
-          />
-          <StatCard
-            label="Đã nhập học"
-            value={stats.enrolled_count ?? 0}
-            icon={<GraduationCap className="h-4 w-4 text-blue-600" />}
-          />
-          <StatCard
-            label="Tỷ lệ chuyển đổi"
-            value={`${stats.conversion_rate ?? 0}%`}
-            icon={<TrendingUp className="h-4 w-4 text-emerald-600" />}
-          />
-          <StatCard
-            label="TB hoàn thiện"
-            value={`${stats.avg_completion ?? 0}%`}
-            icon={<BarChart3 className="h-4 w-4 text-amber-600" />}
-          />
-        </div>
-      )}
-
-      {/* Toolbar */}
-      <div className="flex flex-col gap-3 mt-4">
-        {/* Row 1: Search + Primary Filters */}
-        <div className="flex flex-col sm:flex-row gap-3">
-          {/* Search */}
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" aria-hidden="true" />
-            <Input
-              placeholder="Tìm kiếm theo tên, email, CCCD…"
-              aria-label="Tìm kiếm hồ sơ tuyển sinh"
-              name="admissions-search"
-              autoComplete="off"
-              spellCheck={false}
-              value={state.search}
-              onChange={(e) => handlers.handleSearchChange(e.target.value)}
-              className="pl-10"
-            />
-            {state.search && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7 p-0"
-                onClick={() => handlers.handleSearchChange("")}
-                aria-label="Xóa tìm kiếm"
+          <div className="inline-flex self-start rounded-full border border-border bg-card p-0.5 sm:self-auto">
+            {(["comfortable", "compact"] as const).map((d) => (
+              <button
+                key={d}
+                type="button"
+                onClick={() => handleDensityChange(d)}
+                aria-pressed={density === d}
+                className={cn(
+                  "rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
+                  density === d ? "bg-muted text-foreground" : "text-muted-foreground hover:text-foreground",
+                )}
               >
-                <X className="h-4 w-4" aria-hidden="true" />
-              </Button>
-            )}
+                {d === "comfortable" ? "Thoáng" : "Gọn"}
+              </button>
+            ))}
           </div>
+        </header>
 
-          {/* Academic Year */}
-          <Select
-            value={state.academicYear !== undefined ? String(state.academicYear) : "all"}
-            onValueChange={(val) => handlers.handleYearChange(val === "all" ? undefined : Number(val))}
-          >
-            <SelectTrigger className="w-full sm:w-[140px]" aria-label="Lọc theo năm học">
-              <SelectValue placeholder="Năm học" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Tất cả năm</SelectItem>
-              {yearOptions.map((year) => (
-                <SelectItem key={year} value={String(year)}>
-                  {year}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+        {/* Metric rail */}
+        {metricItems.length > 0 && <AdmissionsMetricRail items={metricItems} />}
 
-          {/* Major Program */}
-          <Select
-            value={state.majorFilter || "all"}
-            onValueChange={(val) => handlers.handleMajorChange(val === "all" ? "" : val)}
-          >
-            <SelectTrigger className="w-full sm:w-[180px]" aria-label="Lọc theo ngành học">
-              <SelectValue placeholder="Ngành" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Tất cả ngành</SelectItem>
-              {majorPrograms?.map((program: { id: number; name: string }) => (
-                <SelectItem key={program.id} value={String(program.id)}>
-                  {program.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+        {/* Filter bar */}
+        <AdmissionsFilterBar
+          search={state.search}
+          onSearchChange={handlers.handleSearchChange}
+          academicYear={state.academicYear}
+          yearOptions={yearOptions}
+          onYearChange={handlers.handleYearChange}
+          statusFilters={state.statusFilters}
+          onStatusChange={handlers.handleStatusChange}
+          majorFilter={state.majorFilter}
+          majorPrograms={majorPrograms}
+          onMajorChange={handlers.handleMajorChange}
+          degreeLevelFilter={state.degreeLevelFilter}
+          degreeLevels={degreeLevels}
+          onDegreeLevelChange={handlers.handleDegreeLevelChange}
+          paymentStatusFilter={state.paymentStatusFilter}
+          onPaymentStatusChange={handlers.handlePaymentStatusChange}
+          dateFrom={state.dateFrom}
+          dateTo={state.dateTo}
+          onDateFromChange={handlers.handleDateFromChange}
+          onDateToChange={handlers.handleDateToChange}
+          sortBy={state.sortBy}
+          sortOrder={state.sortOrder}
+          onSortChange={handlers.handleSortChange}
+          onReset={handlers.resetFilters}
+        />
 
-          {/* Status Filter (dropdown multi-select) */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" className="w-full sm:w-auto gap-2" aria-label="Lọc theo trạng thái hồ sơ">
-                <Filter className="h-4 w-4" aria-hidden="true" />
-                Trạng thái
-                {state.statusFilters.length > 0 && (
-                  <Badge variant="secondary" className="ml-1 h-5 px-1.5">
-                    {state.statusFilters.length}
-                  </Badge>
-                )}
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuLabel>Lọc theo trạng thái</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {STATUS_OPTIONS.map((option) => (
-                <DropdownMenuCheckboxItem
-                  key={option.value}
-                  checked={state.statusFilters.includes(option.value)}
-                  onCheckedChange={() => handleStatusToggle(option.value)}
-                >
-                  {option.label}
-                </DropdownMenuCheckboxItem>
-              ))}
-              {state.statusFilters.length > 0 && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={() => handlers.handleStatusChange([])}>
+        {/* Status tabs */}
+        <AdmissionsStatusTabs
+          tabs={STATUS_TABS}
+          activeTab={state.activeTab}
+          counts={tabCounts}
+          onTabClick={handlers.handleTabClick}
+        />
+
+        {/* Content */}
+        {isLoading ? (
+          <LoadingState />
+        ) : isError ? (
+          <div className="rounded-2xl border border-border bg-card">
+            <ErrorEmptyState message="Không thể tải danh sách hồ sơ. Vui lòng thử lại." />
+          </div>
+        ) : profiles.length === 0 ? (
+          <div className="rounded-2xl border border-border bg-card">
+            <EmptyState
+              icon={<ClipboardCheck className="h-12 w-12" />}
+              title={hasActiveFilters ? "Không tìm thấy kết quả" : "Chưa có hồ sơ nào"}
+              description={
+                hasActiveFilters
+                  ? "Thử thay đổi bộ lọc để xem kết quả khác"
+                  : "Để tạo hồ sơ mới, vào trang chi tiết Lead và nhấn 'Tạo hồ sơ tuyển sinh'"
+              }
+              action={
+                hasActiveFilters && (
+                  <Button variant="outline" onClick={handlers.resetFilters}>
                     Xóa bộ lọc
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-
-        {/* Row 2: Secondary Filters */}
-        <div className="flex flex-col sm:flex-row gap-3">
-          {/* Degree Level */}
-          <Select
-            value={state.degreeLevelFilter || "all"}
-            onValueChange={(val) => handlers.handleDegreeLevelChange(val === "all" ? "" : val)}
-          >
-            <SelectTrigger className="w-full sm:w-[160px]" aria-label="Lọc theo trình độ đào tạo">
-              <SelectValue placeholder="Trình độ" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Tất cả trình độ</SelectItem>
-              {/* Filter value MUST be the degree-level NAME ("Cao đẳng"), not the
-                  code ("cao_dang"): the BE matches it against the MajorProgram.degree_level
-                  TEXT column, which stores the name. Sending the code matched nothing. */}
-              {degreeLevels?.map((level) => (
-                <SelectItem key={level.code} value={level.name}>
-                  {level.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          {/* Payment Status */}
-          <Select
-            value={state.paymentStatusFilter || "all"}
-            onValueChange={(val) => handlers.handlePaymentStatusChange(val === "all" ? "" : val)}
-          >
-            <SelectTrigger className="w-full sm:w-[180px]" aria-label="Lọc theo trạng thái học phí">
-              <SelectValue placeholder="Học phí" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Tất cả học phí</SelectItem>
-              {PAYMENT_STATUS_OPTIONS.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          {/* Date Range Filter */}
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button variant="outline" className="w-full sm:w-auto gap-2">
-                <Calendar className="h-4 w-4" aria-hidden="true" />
-                {state.dateFrom || state.dateTo ? (
-                  <span className="text-xs">
-                    {formatShortDate(state.dateFrom)} -{" "}
-                    {formatShortDate(state.dateTo)}
-                  </span>
-                ) : (
-                  "Ngày tạo"
-                )}
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-auto p-0" align="end">
-              <div className="flex flex-col sm:flex-row">
-                <div className="p-2">
-                  <p className="text-xs font-medium mb-2 text-muted-foreground">Từ ngày</p>
-                  <CalendarComponent
-                    mode="single"
-                    selected={parseDate(state.dateFrom)}
-                    onSelect={(date) =>
-                      handlers.handleDateFromChange(date ? format(date, "yyyy-MM-dd") : "")
-                    }
-                    locale={vi}
-                  />
-                </div>
-                <div className="p-2 border-t sm:border-t-0 sm:border-l">
-                  <p className="text-xs font-medium mb-2 text-muted-foreground">Đến ngày</p>
-                  <CalendarComponent
-                    mode="single"
-                    selected={parseDate(state.dateTo)}
-                    onSelect={(date) =>
-                      handlers.handleDateToChange(date ? format(date, "yyyy-MM-dd") : "")
-                    }
-                    locale={vi}
-                  />
-                </div>
-              </div>
-              {(state.dateFrom || state.dateTo) && (
-                <div className="p-2 border-t">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="w-full"
-                    onClick={() => {
-                      handlers.handleDateFromChange("")
-                      handlers.handleDateToChange("")
-                    }}
-                  >
-                    Xóa bộ lọc ngày
                   </Button>
-                </div>
-              )}
-            </PopoverContent>
-          </Popover>
-
-          {/* Clear all filters */}
-          {hasActiveFilters && (
-            <Button variant="ghost" size="sm" onClick={handlers.resetFilters} className="gap-1">
-              <X className="h-4 w-4" aria-hidden="true" />
-              Xóa bộ lọc
-            </Button>
-          )}
-        </div>
-      </div>
-
-      {/* Status Tabs */}
-      <div className="flex items-center gap-1 mt-4 overflow-x-auto pb-1" role="tablist">
-        {STATUS_TABS.map((tab) => {
-          const count = tabCounts?.[tab.key]
-          const isActive = state.activeTab === tab.key
-          return (
-            <button
-              key={tab.key}
-              role="tab"
-              aria-selected={isActive}
-              onClick={() => handlers.handleTabClick(tab.key)}
+                )
+              }
+            />
+          </div>
+        ) : (
+          <>
+            {/* Desktop: roster table */}
+            <div
               className={cn(
-                "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium whitespace-nowrap transition-colors",
-                isActive
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground"
+                "hidden overflow-hidden rounded-2xl border border-border bg-card shadow-xs md:block",
+                isFetching && "opacity-60",
               )}
             >
-              {tab.label}
-              {count !== undefined && (
-                <span className={cn(
-                  "inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-xs font-medium",
-                  isActive
-                    ? "bg-primary-foreground/20 text-primary-foreground"
-                    : "bg-muted text-muted-foreground"
-                )}>
-                  {count}
-                </span>
-              )}
-            </button>
-          )
-        })}
-      </div>
-
-      {/* Content */}
-      <div className="mt-4">
-        {/* Loading state */}
-        {isLoading && (
-          <div className="space-y-3">
-            <div className="hidden md:block rounded-md border">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    {Array.from({ length: 7 }).map((_, i) => (
-                      <TableHead key={i}>
-                        <Skeleton className="h-4 w-20" />
-                      </TableHead>
-                    ))}
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {Array.from({ length: 5 }).map((_, i) => (
-                    <TableRow key={i}>
-                      {Array.from({ length: 7 }).map((_, j) => (
-                        <TableCell key={j}>
-                          <Skeleton className="h-4 w-full" />
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
-            <div className="md:hidden grid gap-3">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <Card key={i}>
-                  <CardHeader className="pb-2">
-                    <Skeleton className="h-5 w-32" />
-                    <Skeleton className="h-4 w-24" />
-                  </CardHeader>
-                  <CardContent>
-                    <Skeleton className="h-4 w-full mb-2" />
-                    <Skeleton className="h-2 w-3/4" />
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Error state */}
-        {isError && (
-          <Card>
-            <CardContent className="p-0">
-              <ErrorEmptyState message="Không thể tải danh sách hồ sơ. Vui lòng thử lại." />
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Empty state */}
-        {!isLoading && !isError && profiles.length === 0 && (
-          <Card>
-            <CardContent className="p-0">
-              <EmptyState
-                icon={<ClipboardCheck className="h-12 w-12" />}
-                title={hasActiveFilters ? "Không tìm thấy kết quả" : "Chưa có hồ sơ nào"}
-                description={
-                  hasActiveFilters
-                    ? "Thử thay đổi bộ lọc để xem kết quả khác"
-                    : "Để tạo hồ sơ mới, vào trang chi tiết Lead và nhấn 'Tạo hồ sơ tuyển sinh'"
-                }
-                action={
-                  hasActiveFilters && (
-                    <Button variant="outline" onClick={handlers.resetFilters}>
-                      Xóa bộ lọc
-                    </Button>
-                  )
-                }
-              />
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Data */}
-        {!isLoading && !isError && profiles.length > 0 && (
-          <>
-            {/* Desktop: Table View */}
-            <div className={cn("hidden md:block rounded-md border", isFetching && "opacity-60")}>
-              <Table>
-                <TableHeader>
+              <table className="w-full text-sm">
+                <thead>
                   {table.getHeaderGroups().map((headerGroup) => (
-                    <TableRow key={headerGroup.id}>
+                    <tr
+                      key={headerGroup.id}
+                      className="border-b border-border bg-muted/30 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground"
+                    >
                       {headerGroup.headers.map((header) => (
-                        <TableHead key={header.id}>
+                        <th key={header.id} className="px-3 py-3 font-medium">
                           {header.isPlaceholder
                             ? null
                             : flexRender(header.column.columnDef.header, header.getContext())}
-                        </TableHead>
+                        </th>
                       ))}
-                    </TableRow>
+                    </tr>
                   ))}
-                </TableHeader>
-                <TableBody>
+                </thead>
+                <tbody>
                   {table.getRowModel().rows.map((row) => {
-                    const profileId = (row.original as { id?: number })?.id
-                    const handleRowActivate = () => {
-                      if (profileId !== undefined) {
-                        router.push(`/admissions/${profileId}`)
-                      }
-                    }
+                    const profileId = row.original.id
+                    const sel = row.getIsSelected()
                     return (
-                      <TableRow
+                      <tr
                         key={row.id}
-                        data-state={row.getIsSelected() && "selected"}
-                        className="cursor-pointer"
-                        // Web Interface Guidelines: clickable row cần keyboard
-                        // a11y. tabIndex + Enter/Space handler để keyboard
-                        // users navigate được. Cells nội bộ có button/link
-                        // riêng vẫn focusable bình thường.
-                        tabIndex={profileId !== undefined ? 0 : -1}
-                        role={profileId !== undefined ? "link" : undefined}
-                        onKeyDown={(e) => {
-                          if (profileId === undefined) return
-                          if (e.key === "Enter" || e.key === " ") {
-                            // Skip nếu focus đang ở element interactive bên trong (button/link/input/checkbox)
-                            const target = e.target as HTMLElement
-                            const isInner = target.closest("button, a, input, [role='checkbox']")
-                            if (isInner && isInner !== e.currentTarget) return
-                            e.preventDefault()
-                            handleRowActivate()
-                          }
-                        }}
+                        data-state={sel && "selected"}
+                        role="link"
+                        tabIndex={0}
+                        aria-label={`Hồ sơ ${row.original.lead?.full_name ?? `Lead #${row.original.lead_id}`}`}
+                        onClick={() => openProfile(profileId)}
+                        onKeyDown={(e) => activateRow(e, () => openProfile(profileId))}
+                        className={cn(
+                          "group cursor-pointer border-b border-l-2 border-border/60 border-l-transparent outline-none transition-colors last:border-b-0 hover:bg-muted/40 hover:border-l-primary focus-visible:bg-muted/40",
+                          sel && "border-l-primary bg-primary/5",
+                        )}
                       >
                         {row.getVisibleCells().map((cell) => (
-                          <TableCell key={cell.id}>
+                          <td key={cell.id} className={cn("px-3 align-middle", compact ? "py-2" : "py-3")}>
                             {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                          </TableCell>
+                          </td>
                         ))}
-                      </TableRow>
+                      </tr>
                     )
                   })}
-                </TableBody>
-              </Table>
+                </tbody>
+              </table>
             </div>
 
-            {/* Mobile: Card View */}
-            <div className={cn("md:hidden space-y-2", isFetching && "opacity-60")}>
-              <div className="flex items-center gap-2 px-1 py-2">
+            {/* Mobile: roster tiles */}
+            <div className={cn("space-y-2 md:hidden", isFetching && "opacity-60")}>
+              <div className="flex items-center gap-2 px-1 py-1">
                 <Checkbox
-                  checked={
-                    table.getIsAllPageRowsSelected() ||
-                    (table.getIsSomePageRowsSelected() && "indeterminate")
-                  }
+                  checked={allVisibleSelected}
                   onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
                   aria-label="Chọn tất cả"
                 />
@@ -866,12 +539,11 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
                   key={profile.id}
                   profile={profile}
                   isSelected={rowSelection[String(profile.id)] ?? false}
-                  onSelect={(checked) => {
-                    setRowSelection((prev) => ({
-                      ...prev,
-                      [String(profile.id)]: checked,
-                    }))
-                  }}
+                  onSelect={(checked) => table.getRow(String(profile.id)).toggleSelected(checked)}
+                  onClaim={handleClaimFromList}
+                  onApprove={handleRowApprove}
+                  onReject={requestRowReject}
+                  onOpen={() => openProfile(profile.id)}
                 />
               ))}
             </div>
@@ -885,7 +557,7 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
                 onPageChange={handlers.setPage}
                 isLoading={isFetching}
                 showTotal
-                className="border-t mt-4"
+                className="border-t pt-4"
               />
             )}
           </>
@@ -922,81 +594,127 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
         onConfirm={handleBulkAssign}
         isLoading={bulkAssign.isPending}
       />
+
+      {/* Single-row reject (mở từ row menu) — tái dùng dialog có lý do */}
+      <BulkRejectDialog
+        open={!!rowRejectTarget}
+        onOpenChange={(open) => {
+          if (!open) setRowRejectTarget(null)
+        }}
+        selectedCount={1}
+        onConfirm={handleRowReject}
+        isLoading={bulkReject.isPending}
+      />
     </PageContainer>
   )
 }
 
 // =============================================================================
-// MOBILE CARD COMPONENT - Using BaseCard System
+// LOADING STATE
+// =============================================================================
+
+function LoadingState() {
+  return (
+    <div className="space-y-3">
+      <div className="hidden rounded-2xl border border-border bg-card p-4 md:block">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 py-2.5">
+            <Skeleton className="size-9 shrink-0 rounded-xl" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-3.5 w-40" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+            <Skeleton className="hidden h-2 w-28 sm:block" />
+            <Skeleton className="hidden h-5 w-20 rounded-full lg:block" />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-2 md:hidden">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-2xl border border-border bg-card p-4">
+            <div className="flex items-center gap-3">
+              <Skeleton className="size-9 shrink-0 rounded-xl" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-3 w-24" />
+              </div>
+            </div>
+            <Skeleton className="mt-3 h-2 w-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// =============================================================================
+// MOBILE CARD
 // =============================================================================
 
 interface AdmissionCardProps {
   profile: AdmissionProfileResponse
   isSelected: boolean
   onSelect: (checked: boolean) => void
+  onClaim: (profile: AdmissionProfileResponse) => void
+  onApprove: (profile: AdmissionProfileResponse) => void
+  onReject: (profile: AdmissionProfileResponse) => void
+  onOpen: () => void
 }
 
-function AdmissionCard({ profile, isSelected, onSelect }: AdmissionCardProps) {
-  const statusConfig = STATUS_CONFIG[profile.status] ?? { label: profile.status, color: "bg-muted" }
-  const eligibilityConfig = ELIGIBILITY_CONFIG[profile.eligibility_status] ?? { label: "-", color: "bg-muted" }
-
+function AdmissionCard({ profile, isSelected, onSelect, onClaim, onApprove, onReject, onOpen }: AdmissionCardProps) {
+  const name = profile.lead?.full_name ?? `Lead #${profile.lead_id}`
   return (
-    <BaseCard
-      selected={isSelected}
-      onSelect={onSelect}
-      showCheckbox
+    <article
+      role="link"
+      tabIndex={0}
+      aria-label={`Hồ sơ ${name}`}
+      onClick={onOpen}
+      onKeyDown={(e) => activateRow(e, onOpen)}
+      className={cn(
+        "rounded-2xl border bg-card p-4 shadow-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+        isSelected ? "border-primary/40 bg-primary/5" : "border-border",
+      )}
     >
-      {/* Header: Name + Status Badge */}
-      <BaseCardHeader
-        title={
-          <Link
-            href={`/admissions/${profile.id}`}
-            className="hover:underline"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {profile.lead?.full_name ?? `Lead #${profile.lead_id}`}
-          </Link>
-        }
-        subtitle={`Hồ sơ #${profile.id}`}
-        badge={<Badge className={statusConfig.color}>{statusConfig.label}</Badge>}
-      />
-
-      {/* Body: Progress bar */}
-      <CardBody>
-        <div className="flex items-center gap-2">
-          <Progress value={profile.completion_percent} className="h-2 flex-1" />
-          <span className="text-xs text-muted-foreground w-8">
-            {profile.completion_percent}%
-          </span>
-        </div>
-      </CardBody>
-
-      {/* Meta: Date + Eligibility */}
-      <CardMeta>
-        <CardTime date={profile.created_at} format="date" showIcon />
-        <Badge variant="outline" className={cn("text-xs", eligibilityConfig.color)}>
-          {eligibilityConfig.label}
-        </Badge>
-      </CardMeta>
-
-      {/* Actions */}
-      <CardActions>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Thao tác">
-              <MoreVertical className="h-4 w-4" aria-hidden="true" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem asChild>
-              <Link href={`/admissions/${profile.id}`}>
-                Xem chi tiết
+      <div className="flex items-start gap-3">
+        <Checkbox
+          checked={isSelected}
+          onCheckedChange={(value) => onSelect(!!value)}
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`Chọn ${name}`}
+          className="mt-0.5"
+        />
+        <Monogram name={name} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <Link
+                href={`/admissions/${profile.id}`}
+                onClick={(e) => e.stopPropagation()}
+                className="block truncate font-display font-semibold text-foreground hover:underline"
+              >
+                {name}
               </Link>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </CardActions>
-    </BaseCard>
+              <div className="truncate text-xs tabular-nums text-muted-foreground">
+                #{profile.id} · {profile.program_name ?? "—"}
+              </div>
+            </div>
+            <StatusDot status={profile.status} />
+          </div>
+
+          <div className="mt-3">
+            <ProgressBar value={profile.completion_percent} />
+          </div>
+
+          <div className="mt-3 flex items-center justify-between gap-2">
+            <span className="text-xs tabular-nums text-muted-foreground">{formatDate(profile.created_at)}</span>
+            <div className="flex items-center gap-2">
+              <EligibilityToken status={profile.eligibility_status} />
+              <RowActionsMenu profile={profile} onClaim={onClaim} onApprove={onApprove} onReject={onReject} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
   )
 }
 

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@/test/utils/test-utils"
+import { fireEvent } from "@testing-library/react"
+import { AdmissionsFilterBar, type AdmissionsFilterBarProps } from "./AdmissionsFilterBar"
+import { CURRENT_ADMISSIONS_YEAR } from "@/hooks/admissions/filterDefaults"
+
+function setup(overrides: Partial<AdmissionsFilterBarProps> = {}) {
+  const props: AdmissionsFilterBarProps = {
+    search: "",
+    onSearchChange: vi.fn(),
+    academicYear: CURRENT_ADMISSIONS_YEAR,
+    yearOptions: [CURRENT_ADMISSIONS_YEAR, CURRENT_ADMISSIONS_YEAR - 1],
+    onYearChange: vi.fn(),
+    statusFilters: [],
+    onStatusChange: vi.fn(),
+    majorFilter: "",
+    majorPrograms: [{ id: 1, name: "CNTT" }],
+    onMajorChange: vi.fn(),
+    degreeLevelFilter: "",
+    degreeLevels: [{ code: "cd", name: "Cao đẳng" }],
+    onDegreeLevelChange: vi.fn(),
+    paymentStatusFilter: "",
+    onPaymentStatusChange: vi.fn(),
+    dateFrom: "",
+    dateTo: "",
+    onDateFromChange: vi.fn(),
+    onDateToChange: vi.fn(),
+    sortBy: "created_at",
+    sortOrder: "desc",
+    onSortChange: vi.fn(),
+    onReset: vi.fn(),
+    ...overrides,
+  }
+  render(<AdmissionsFilterBar {...props} />)
+  return props
+}
+
+describe("AdmissionsFilterBar", () => {
+  it("forwards the search input value", () => {
+    const props = setup()
+    fireEvent.change(screen.getByLabelText(/tìm kiếm hồ sơ/i), { target: { value: "an" } })
+    expect(props.onSearchChange).toHaveBeenCalledWith("an")
+  })
+
+  it("renders a chip per active status filter; removing it calls onStatusChange", () => {
+    const props = setup({ statusFilters: ["submitted"] })
+    expect(screen.getByText("Chờ duyệt")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /bỏ lọc chờ duyệt/i }))
+    expect(props.onStatusChange).toHaveBeenCalledWith([])
+  })
+
+  it("counts active filter GROUPS on the Bộ lọc badge (status = 1 group)", () => {
+    // status group (1) + payment group (1) = 2
+    setup({ statusFilters: ["submitted", "approved"], paymentStatusFilter: "paid" })
+    expect(screen.getByText("2")).toBeInTheDocument()
+  })
+
+  it("shows a Năm chip for a non-default year; removing it resets to current year", () => {
+    const props = setup({ academicYear: CURRENT_ADMISSIONS_YEAR - 1 })
+    const removeBtn = screen.getByRole("button", {
+      name: new RegExp(`bỏ lọc năm ${CURRENT_ADMISSIONS_YEAR - 1}`, "i"),
+    })
+    fireEvent.click(removeBtn)
+    expect(props.onYearChange).toHaveBeenCalledWith(CURRENT_ADMISSIONS_YEAR)
+  })
+
+  it("Xóa tất cả calls onReset", () => {
+    const props = setup({ statusFilters: ["submitted"] })
+    fireEvent.click(screen.getByRole("button", { name: /xóa tất cả/i }))
+    expect(props.onReset).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.tsx
@@ -1,0 +1,411 @@
+// src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.tsx
+/**
+ * Filter bar cho trang danh sách hồ sơ.
+ *
+ * Bố cục (chốt Q4/Q5):
+ * - Ngoài: Search (command input) · Năm (dropdown) · "Bộ lọc" (popover) · Sắp xếp (dropdown).
+ * - Trong popover "Bộ lọc": Trạng thái (multi) · Ngành/Trình độ/Học phí (native select,
+ *   tránh overlay lồng trong Popover) · Khoảng ngày (CalendarComponent, giữ như cũ).
+ * - Active chips: gỡ từng lọc đang bật + "Xóa tất cả".
+ *
+ * Thuần trình bày — mọi thay đổi đẩy qua handler thật của useAdmissionsFilter.
+ */
+
+"use client"
+
+import { format } from "date-fns"
+import { vi } from "date-fns/locale"
+import { ArrowUpDown, Check, ChevronDown, Search, SlidersHorizontal, X } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Calendar as CalendarComponent } from "@/components/ui/calendar"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import { ADMISSION_STATUS_CONFIG, getStatusDotColor } from "@/lib/status-config"
+import { CURRENT_ADMISSIONS_YEAR } from "@/hooks/admissions/filterDefaults"
+
+// Workflow order; LABELS đến từ ADMISSION_STATUS_CONFIG (single source) nên nhãn
+// checkbox không bao giờ lệch nhãn chip lọc (statusLabel cũng đọc cùng config).
+const STATUS_ORDER: readonly string[] = [
+  "draft",
+  "submitted",
+  "resubmitted",
+  "reviewing",
+  "approved",
+  "admitted",
+  "waitlisted",
+  "result_published",
+  "rejected",
+  "revision_requested",
+  "confirmed",
+  "overridden",
+  "enrolled",
+  "withdrawn",
+]
+// Append bất kỳ status có trong config nhưng thiếu trong thứ tự tường minh, để
+// status mới của backend vẫn lọc được thay vì bị bỏ sót âm thầm.
+const STATUS_OPTIONS: { value: string; label: string }[] = [
+  ...STATUS_ORDER,
+  ...Object.keys(ADMISSION_STATUS_CONFIG).filter((s) => !STATUS_ORDER.includes(s)),
+].map((value) => ({ value, label: statusLabel(value) }))
+
+const PAYMENT_OPTIONS: readonly { value: string; label: string }[] = [
+  { value: "paid", label: "Đã thanh toán" },
+  { value: "unpaid", label: "Chưa thanh toán" },
+  { value: "partial", label: "Thanh toán một phần" },
+  { value: "no_fee", label: "Chưa có học phí" },
+]
+
+const SORT_OPTIONS: readonly { by: string; order: "asc" | "desc"; label: string }[] = [
+  { by: "created_at", order: "desc", label: "Mới nhất" },
+  { by: "created_at", order: "asc", label: "Cũ nhất" },
+  { by: "full_name", order: "asc", label: "Tên A → Z" },
+  { by: "full_name", order: "desc", label: "Tên Z → A" },
+]
+
+const NATIVE_SELECT_CLASS =
+  "h-9 w-full rounded-md border border-border bg-card px-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+
+function parseDate(str: string): Date | undefined {
+  if (!str) return undefined
+  return new Date(str + "T12:00:00")
+}
+
+function fmtShort(str: string): string {
+  if (!str) return "…"
+  return str.slice(8, 10) + "/" + str.slice(5, 7)
+}
+
+function statusLabel(status: string): string {
+  return ADMISSION_STATUS_CONFIG[status]?.label ?? status
+}
+
+export interface AdmissionsFilterBarProps {
+  search: string
+  onSearchChange: (value: string) => void
+  academicYear: number | undefined
+  yearOptions: number[]
+  onYearChange: (year: number | undefined) => void
+  statusFilters: string[]
+  onStatusChange: (statuses: string[]) => void
+  majorFilter: string
+  majorPrograms: { id: number; name: string }[] | undefined
+  onMajorChange: (majorId: string) => void
+  degreeLevelFilter: string
+  degreeLevels: { code: string; name: string }[] | undefined
+  onDegreeLevelChange: (level: string) => void
+  paymentStatusFilter: string
+  onPaymentStatusChange: (status: string) => void
+  dateFrom: string
+  dateTo: string
+  onDateFromChange: (date: string) => void
+  onDateToChange: (date: string) => void
+  sortBy: string
+  sortOrder: "asc" | "desc"
+  onSortChange: (sortBy: string, sortOrder: "asc" | "desc") => void
+  onReset: () => void
+}
+
+export function AdmissionsFilterBar(props: AdmissionsFilterBarProps) {
+  const {
+    search,
+    onSearchChange,
+    academicYear,
+    yearOptions,
+    onYearChange,
+    statusFilters,
+    onStatusChange,
+    majorFilter,
+    majorPrograms,
+    onMajorChange,
+    degreeLevelFilter,
+    degreeLevels,
+    onDegreeLevelChange,
+    paymentStatusFilter,
+    onPaymentStatusChange,
+    dateFrom,
+    dateTo,
+    onDateFromChange,
+    onDateToChange,
+    sortBy,
+    sortOrder,
+    onSortChange,
+    onReset,
+  } = props
+
+  const toggleStatus = (value: string) =>
+    onStatusChange(
+      statusFilters.includes(value) ? statusFilters.filter((s) => s !== value) : [...statusFilters, value],
+    )
+
+  // Đếm theo NHÓM lọc đang bật (Trạng thái = 1 nhóm, không phải số status).
+  const filterCount =
+    (statusFilters.length > 0 ? 1 : 0) +
+    (majorFilter ? 1 : 0) +
+    (degreeLevelFilter ? 1 : 0) +
+    (paymentStatusFilter ? 1 : 0) +
+    (dateFrom || dateTo ? 1 : 0)
+
+  const majorName = majorPrograms?.find((p) => String(p.id) === majorFilter)?.name ?? majorFilter
+
+  // Active chips: gồm cả Năm (khi ≠ năm mặc định) + các lọc trong popover.
+  type Chip = { key: string; label: string; dot?: string; onRemove: () => void }
+  const chips: Chip[] = []
+  if (academicYear != null && academicYear !== CURRENT_ADMISSIONS_YEAR) {
+    chips.push({ key: "year", label: `Năm ${academicYear}`, onRemove: () => onYearChange(CURRENT_ADMISSIONS_YEAR) })
+  }
+  statusFilters.forEach((s) =>
+    chips.push({ key: `status-${s}`, label: statusLabel(s), dot: getStatusDotColor(s), onRemove: () => toggleStatus(s) }),
+  )
+  if (majorFilter) chips.push({ key: "major", label: `Ngành: ${majorName}`, onRemove: () => onMajorChange("") })
+  if (degreeLevelFilter)
+    chips.push({ key: "degree", label: degreeLevelFilter, onRemove: () => onDegreeLevelChange("") })
+  if (paymentStatusFilter)
+    chips.push({
+      key: "payment",
+      label: PAYMENT_OPTIONS.find((o) => o.value === paymentStatusFilter)?.label ?? paymentStatusFilter,
+      onRemove: () => onPaymentStatusChange(""),
+    })
+  if (dateFrom || dateTo)
+    chips.push({
+      key: "date",
+      label: `${fmtShort(dateFrom)} – ${fmtShort(dateTo)}`,
+      onRemove: () => {
+        onDateFromChange("")
+        onDateToChange("")
+      },
+    })
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+        {/* Search (command input) */}
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+          <Input
+            value={search}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Tìm theo tên, email, CCCD…"
+            aria-label="Tìm kiếm hồ sơ tuyển sinh"
+            name="admissions-search"
+            autoComplete="off"
+            spellCheck={false}
+            className="h-10 pl-9 pr-9"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => onSearchChange("")}
+              aria-label="Xóa tìm kiếm"
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <X className="size-4" />
+            </button>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Year */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="h-10 gap-1.5">
+                {academicYear != null ? `Năm ${academicYear}` : "Tất cả năm"}
+                <ChevronDown className="size-4 text-muted-foreground" aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-40">
+              <DropdownMenuItem className="justify-between" onClick={() => onYearChange(undefined)}>
+                Tất cả năm
+                {academicYear == null && <Check className="size-4" />}
+              </DropdownMenuItem>
+              {yearOptions.map((y) => (
+                <DropdownMenuItem key={y} className="justify-between" onClick={() => onYearChange(y)}>
+                  {y}
+                  {academicYear === y && <Check className="size-4" />}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {/* Filter popover */}
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline" className="h-10 gap-1.5" aria-label="Bộ lọc nâng cao">
+                <SlidersHorizontal className="size-4" aria-hidden="true" />
+                Bộ lọc
+                {filterCount > 0 && (
+                  <span className="ml-0.5 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1 text-2xs font-semibold tabular-nums text-primary-foreground">
+                    {filterCount}
+                  </span>
+                )}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-[340px] p-0">
+              <div className="max-h-[60vh] overflow-y-auto">
+                {/* Trạng thái */}
+                <div className="border-b border-border p-3">
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Trạng thái</p>
+                  <div className="grid grid-cols-1 gap-0.5">
+                    {STATUS_OPTIONS.map((o) => (
+                      <label key={o.value} className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted">
+                        <Checkbox
+                          checked={statusFilters.includes(o.value)}
+                          onCheckedChange={() => toggleStatus(o.value)}
+                          aria-label={o.label}
+                        />
+                        <span className={cn("size-1.5 shrink-0 rounded-full", getStatusDotColor(o.value))} />
+                        <span className="text-sm">{o.label}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Ngành / Trình độ / Học phí — native select để tránh overlay lồng */}
+                <div className="space-y-3 border-b border-border p-3">
+                  <div>
+                    <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">Ngành</label>
+                    <select
+                      className={NATIVE_SELECT_CLASS}
+                      value={majorFilter}
+                      onChange={(e) => onMajorChange(e.target.value)}
+                      aria-label="Lọc theo ngành học"
+                    >
+                      <option value="">Tất cả ngành</option>
+                      {majorPrograms?.map((p) => (
+                        <option key={p.id} value={String(p.id)}>
+                          {p.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">Trình độ</label>
+                    {/* value = NAME ("Cao đẳng"), không phải code: BE match theo MajorProgram.degree_level TEXT. */}
+                    <select
+                      className={NATIVE_SELECT_CLASS}
+                      value={degreeLevelFilter}
+                      onChange={(e) => onDegreeLevelChange(e.target.value)}
+                      aria-label="Lọc theo trình độ đào tạo"
+                    >
+                      <option value="">Tất cả trình độ</option>
+                      {degreeLevels?.map((level) => (
+                        <option key={level.code} value={level.name}>
+                          {level.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">Học phí</label>
+                    <select
+                      className={NATIVE_SELECT_CLASS}
+                      value={paymentStatusFilter}
+                      onChange={(e) => onPaymentStatusChange(e.target.value)}
+                      aria-label="Lọc theo trạng thái học phí"
+                    >
+                      <option value="">Tất cả học phí</option>
+                      {PAYMENT_OPTIONS.map((o) => (
+                        <option key={o.value} value={o.value}>
+                          {o.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                {/* Khoảng ngày tạo — giữ CalendarComponent */}
+                <div className="p-3">
+                  <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Khoảng ngày tạo</p>
+                  <div className="space-y-3">
+                    <div>
+                      <p className="mb-1 text-xs text-muted-foreground">Từ ngày</p>
+                      <CalendarComponent
+                        mode="single"
+                        selected={parseDate(dateFrom)}
+                        onSelect={(date) => onDateFromChange(date ? format(date, "yyyy-MM-dd") : "")}
+                        locale={vi}
+                      />
+                    </div>
+                    <div>
+                      <p className="mb-1 text-xs text-muted-foreground">Đến ngày</p>
+                      <CalendarComponent
+                        mode="single"
+                        selected={parseDate(dateTo)}
+                        onSelect={(date) => onDateToChange(date ? format(date, "yyyy-MM-dd") : "")}
+                        locale={vi}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex items-center justify-between border-t border-border p-3">
+                <Button variant="ghost" size="sm" onClick={onReset}>
+                  Xóa lọc
+                </Button>
+                {filterCount > 0 && (
+                  <span className="text-xs tabular-nums text-muted-foreground">{filterCount} điều kiện</span>
+                )}
+              </div>
+            </PopoverContent>
+          </Popover>
+
+          {/* Sort */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="h-10 gap-1.5">
+                <ArrowUpDown className="size-4" aria-hidden="true" />
+                <span className="hidden sm:inline">Sắp xếp</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-44">
+              {SORT_OPTIONS.map((opt) => {
+                const active = sortBy === opt.by && sortOrder === opt.order
+                return (
+                  <DropdownMenuItem key={opt.label} className="justify-between" onClick={() => onSortChange(opt.by, opt.order)}>
+                    {opt.label}
+                    {active && <Check className="size-4" />}
+                  </DropdownMenuItem>
+                )
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* Active chips */}
+      {chips.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          {chips.map((c) => (
+            <span
+              key={c.key}
+              className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card py-1 pl-2.5 pr-1 text-xs font-medium shadow-xs"
+            >
+              {c.dot && <span className={cn("size-1.5 shrink-0 rounded-full", c.dot)} />}
+              {c.label}
+              <button
+                type="button"
+                onClick={c.onRemove}
+                aria-label={`Bỏ lọc ${c.label}`}
+                className="ml-0.5 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                <X className="size-3" />
+              </button>
+            </span>
+          ))}
+          <button type="button" onClick={onReset} className="text-xs font-medium text-muted-foreground hover:text-foreground">
+            Xóa tất cả
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsMetricRail.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsMetricRail.tsx
@@ -1,0 +1,44 @@
+// src/app/(dashboard)/admissions/_components/AdmissionsMetricRail.tsx
+/**
+ * Metric rail — dải chỉ số liền mạch thay 6 StatCard rời.
+ * Kỹ thuật seamless: container `bg-border` + `gap-px`, mỗi ô `bg-card` →
+ * khe 1px lộ màu border làm hairline (responsive, không cần border-math).
+ * Thuần trình bày; AdmissionsClient build `items` từ useAdmissionStats.
+ */
+
+"use client"
+
+import { TrendingUp } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+export interface MetricItem {
+  key: string
+  label: string
+  value: string
+  /** Tailwind class màu chấm accent (literal static). */
+  dot: string
+  trend?: boolean
+}
+
+export function AdmissionsMetricRail({ items }: { items: MetricItem[] }) {
+  if (items.length === 0) return null
+  return (
+    <section
+      aria-label="Chỉ số tuyển sinh"
+      className="grid grid-cols-2 gap-px overflow-hidden rounded-2xl border border-border bg-border shadow-xs sm:grid-cols-3 lg:grid-cols-6"
+    >
+      {items.map((m) => (
+        <div key={m.key} className="bg-card p-4 sm:p-5">
+          <div className="flex items-baseline gap-1.5">
+            <span className="font-display text-2xl font-semibold tracking-tight tabular-nums">{m.value}</span>
+            {m.trend && <TrendingUp className="size-4 text-emerald-600" aria-hidden="true" />}
+          </div>
+          <div className="mt-1.5 flex items-center gap-1.5">
+            <span className={cn("size-1.5 shrink-0 rounded-full", m.dot)} />
+            <span className="truncate text-xs text-muted-foreground">{m.label}</span>
+          </div>
+        </div>
+      ))}
+    </section>
+  )
+}

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsStatusTabs.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsStatusTabs.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@/test/utils/test-utils"
+import { fireEvent } from "@testing-library/react"
+import { AdmissionsStatusTabs } from "./AdmissionsStatusTabs"
+
+const tabs = [
+  { key: "all", label: "Tất cả" },
+  { key: "pending", label: "Chờ duyệt" },
+] as const
+
+describe("AdmissionsStatusTabs", () => {
+  it("marks the active tab via aria-selected and shows counts", () => {
+    render(
+      <AdmissionsStatusTabs
+        tabs={tabs}
+        activeTab="pending"
+        counts={{ all: 10, pending: 3 }}
+        onTabClick={vi.fn()}
+      />,
+    )
+    const active = screen.getByRole("tab", { name: /chờ duyệt/i })
+    expect(active).toHaveAttribute("aria-selected", "true")
+    expect(active).toHaveTextContent("3")
+    expect(screen.getByRole("tab", { name: /tất cả/i })).toHaveAttribute("aria-selected", "false")
+  })
+
+  it("calls onTabClick with the tab key", () => {
+    const onTabClick = vi.fn()
+    render(<AdmissionsStatusTabs tabs={tabs} activeTab="all" onTabClick={onTabClick} />)
+    fireEvent.click(screen.getByRole("tab", { name: /chờ duyệt/i }))
+    expect(onTabClick).toHaveBeenCalledWith("pending")
+  })
+})

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsStatusTabs.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsStatusTabs.tsx
@@ -1,0 +1,65 @@
+// src/app/(dashboard)/admissions/_components/AdmissionsStatusTabs.tsx
+/**
+ * Status tabs dạng gạch chân (editorial) thay pill nền. Dữ liệu tab + count
+ * truyền từ AdmissionsClient (reuse ADMISSION_STATUS_TABS + tabCounts).
+ */
+
+"use client"
+
+import { cn } from "@/lib/utils"
+
+interface TabItem {
+  key: string
+  label: string
+}
+
+export function AdmissionsStatusTabs({
+  tabs,
+  activeTab,
+  counts,
+  onTabClick,
+}: {
+  tabs: readonly TabItem[]
+  activeTab: string
+  counts?: Record<string, number>
+  onTabClick: (key: string) => void
+}) {
+  return (
+    <div className="scroll-shadow-x overflow-x-auto border-b border-border">
+      <div className="flex w-max items-center gap-1" role="tablist" aria-label="Lọc nhanh theo trạng thái">
+        {tabs.map((t) => {
+          const active = activeTab === t.key
+          const count = counts?.[t.key]
+          return (
+            <button
+              key={t.key}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => onTabClick(t.key)}
+              className={cn(
+                "relative whitespace-nowrap px-3 py-2.5 text-sm font-medium transition-colors",
+                active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                {t.label}
+                {count !== undefined && (
+                  <span
+                    className={cn(
+                      "rounded-full px-1.5 py-0.5 text-2xs tabular-nums",
+                      active ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground",
+                    )}
+                  >
+                    {count}
+                  </span>
+                )}
+              </span>
+              {active && <span className="absolute inset-x-2 -bottom-px h-0.5 rounded-full bg-primary" />}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/admissions/_components/columns.test.ts
+++ b/frontend/src/app/(dashboard)/admissions/_components/columns.test.ts
@@ -1,32 +1,26 @@
 /**
- * Admissions list STATUS_CONFIG — completeness pin.
+ * Admissions list status labels — coverage pin.
  *
- * Derived from the canonical ADMISSION_STATUS_CONFIG so the list status badge
- * covers EVERY admission state (incl. the multi-NV states the old inline map
- * omitted, which rendered the raw English enum on the list).
+ * The list status cell renders via <StatusDot> (roster-parts), which reads
+ * ADMISSION_STATUS_CONFIG for its label. Pin that EVERY admission state — incl.
+ * the multi-NV states (reviewing / result_published / admitted / waitlisted) the
+ * old inline map omitted — has a real, non-enum label, so the list never renders
+ * a raw English enum.
  */
 
 import { describe, it, expect } from "vitest"
-import { STATUS_CONFIG } from "./columns"
 import { ADMISSION_STATUS_CONFIG } from "@/lib/status-config"
 
-describe("admissions list STATUS_CONFIG", () => {
-  it("covers the multi-NV states that were previously missing (no raw enum on the list)", () => {
+describe("admissions list status labels (ADMISSION_STATUS_CONFIG)", () => {
+  it("covers the multi-NV states with non-enum labels", () => {
     for (const s of ["reviewing", "result_published", "admitted", "waitlisted"]) {
-      expect(STATUS_CONFIG[s]?.label).toBeTruthy()
-      expect(STATUS_CONFIG[s].label).not.toBe(s) // not the raw enum
-    }
-  })
-
-  it("stays in parity with the canonical ADMISSION_STATUS_CONFIG (single source)", () => {
-    for (const [status, cfg] of Object.entries(ADMISSION_STATUS_CONFIG)) {
-      expect(STATUS_CONFIG[status]?.label).toBe(cfg.label)
-      expect(STATUS_CONFIG[status]?.color).toBe(cfg.badgeColor)
+      expect(ADMISSION_STATUS_CONFIG[s]?.label).toBeTruthy()
+      expect(ADMISSION_STATUS_CONFIG[s].label).not.toBe(s) // not the raw enum
     }
   })
 
   it("keeps the core states", () => {
-    expect(STATUS_CONFIG.submitted?.label).toBe("Chờ duyệt")
-    expect(STATUS_CONFIG.draft?.label).toBe("Nháp")
+    expect(ADMISSION_STATUS_CONFIG.submitted?.label).toBe("Chờ duyệt")
+    expect(ADMISSION_STATUS_CONFIG.draft?.label).toBe("Nháp")
   })
 })

--- a/frontend/src/app/(dashboard)/admissions/_components/columns.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/columns.tsx
@@ -1,81 +1,69 @@
 // src/app/(dashboard)/admissions/_components/columns.tsx
 /**
- * TanStack Table Column Definitions for Admissions DataTable
+ * TanStack Table column definitions — Admissions roster (redesign v2).
  *
- * Features:
- * - Selection column with checkbox
- * - Sortable columns (name, status, date)
- * - Progress bar for completion percentage
- * - Status badges
- * - Action dropdown
+ * Giữ semantics bảng (sort + rowSelection + a11y) nhưng render cell theo
+ * roster mới: danh tính 2 dòng + monogram, status chấm, progress ngưỡng,
+ * eligibility token, gộp Phụ trách + Người duyệt thành 1 cột avatar chip.
+ * Các phần trình bày dùng chung ở `roster-parts` (chia sẻ với card mobile).
  */
 
 "use client"
 
-import { createColumnHelper, type ColumnDef } from "@tanstack/react-table"
-import { format } from "date-fns"
-import { vi } from "date-fns/locale"
-import { ArrowUpDown, MoreHorizontal, Eye, CheckCircle, XCircle, ClipboardCheck } from "lucide-react"
+import { createColumnHelper, type Column, type ColumnDef } from "@tanstack/react-table"
+import { ArrowDown, ArrowUp, ArrowUpDown, ChevronRight } from "lucide-react"
 import Link from "next/link"
 
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
-import { Progress } from "@/components/ui/progress"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
-import { hasAction } from "@/lib/admission/permissions"
-import { ADMISSION_STATUS_CONFIG } from "@/lib/status-config"
+import { formatDate } from "@/lib/utils/admission-helpers"
+import {
+  Assignees,
+  EligibilityToken,
+  Monogram,
+  ProgressBar,
+  RowActionsMenu,
+  StatusDot,
+} from "./roster-parts"
 
-// =============================================================================
-// STATUS CONFIGURATION
-// =============================================================================
-
-// Derived from the canonical ADMISSION_STATUS_CONFIG (single source of truth) so
-// the list status badge covers EVERY admission state — incl. the multi-NV states
-// reviewing / result_published / admitted / waitlisted that the old inline map
-// omitted, which made the list render the raw English enum for those rows.
-export const STATUS_CONFIG: Record<string, { label: string; color: string }> =
-  Object.fromEntries(
-    Object.entries(ADMISSION_STATUS_CONFIG).map(([status, cfg]) => [
-      status,
-      { label: cfg.label, color: cfg.badgeColor },
-    ]),
-  )
-
-export const ELIGIBILITY_CONFIG: Record<string, { label: string; color: string }> = {
-  eligible: { label: "Đủ điều kiện", color: "bg-success-100 text-success-700" },
-  ineligible: { label: "Không đủ ĐK", color: "bg-error-100 text-error-700" },
-  pending: { label: "Đang xét", color: "bg-muted text-muted-foreground" },
-}
-
-// =============================================================================
-// COLUMN HELPER
-// =============================================================================
+type Density = "comfortable" | "compact"
 
 const columnHelper = createColumnHelper<AdmissionProfileResponse>()
 
-// =============================================================================
-// COLUMN DEFINITIONS
-// =============================================================================
-
 interface ColumnOptions {
+  onClaim?: (profile: AdmissionProfileResponse) => void
   onApprove?: (profile: AdmissionProfileResponse) => void
   onReject?: (profile: AdmissionProfileResponse) => void
-  onClaim?: (profile: AdmissionProfileResponse) => void
-  canApprove?: boolean
-  canReject?: boolean
+  density?: Density
+}
+
+/** Header nút sắp xếp (icon đổi theo trạng thái sort) — dùng chung cho các cột sortable. */
+function SortableHeader<TValue>({
+  column,
+  label,
+}: {
+  column: Column<AdmissionProfileResponse, TValue>
+  label: string
+}) {
+  const sorted = column.getIsSorted()
+  const Icon = sorted === "asc" ? ArrowUp : sorted === "desc" ? ArrowDown : ArrowUpDown
+  return (
+    <button
+      type="button"
+      onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      className="inline-flex items-center gap-1 hover:text-foreground"
+    >
+      {label}
+      <Icon className="size-3.5" />
+    </button>
+  )
 }
 
 export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileResponse, unknown>[] {
+  const compact = options?.density === "compact"
+
   return [
-    // Selection column
+    // Selection
     columnHelper.display({
       id: "select",
       header: ({ table }) => (
@@ -101,212 +89,104 @@ export function getColumns(options?: ColumnOptions): ColumnDef<AdmissionProfileR
       size: 40,
     }) as ColumnDef<AdmissionProfileResponse, unknown>,
 
-    // Full Name column
-    columnHelper.accessor(
-      (row) => row.lead?.full_name ?? `Lead #${row.lead_id}`,
-      {
-        id: "full_name",
-        header: ({ column }) => (
-          <Button
-            variant="ghost"
-            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-            className="-ml-3 h-8"
-          >
-            Họ tên
-            <ArrowUpDown className="ml-2 h-4 w-4" />
-          </Button>
-        ),
-        cell: ({ row }) => {
-          const profile = row.original
-          const name = profile.lead?.full_name ?? `Lead #${profile.lead_id}`
-          return (
-            <Link
-              href={`/admissions/${profile.id}`}
-              className="font-medium hover:underline"
-            >
-              {name}
-            </Link>
-          )
-        },
-        size: 200,
-      }
-    ) as ColumnDef<AdmissionProfileResponse, unknown>,
-
-    // Status column
-    columnHelper.accessor("status", {
-      header: "Trạng thái",
-      cell: ({ getValue }) => {
-        const status = getValue()
-        const config = STATUS_CONFIG[status] ?? { label: status, color: "bg-muted" }
+    // Identity (sortable by name)
+    columnHelper.accessor((row) => row.lead?.full_name ?? `Lead #${row.lead_id}`, {
+      id: "full_name",
+      header: ({ column }) => <SortableHeader column={column} label="Hồ sơ" />,
+      cell: ({ row }) => {
+        const p = row.original
+        const name = p.lead?.full_name ?? `Lead #${p.lead_id}`
         return (
-          <Badge className={config.color}>
-            {config.label}
-          </Badge>
-        )
-      },
-      size: 120,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
-
-    // Completion column
-    columnHelper.accessor("completion_percent", {
-      header: "Tiến độ",
-      cell: ({ getValue }) => {
-        const percent = getValue()
-        return (
-          <div className="flex items-center gap-2 min-w-[100px]">
-            <Progress value={percent} className="h-2 flex-1" />
-            <span className="text-xs text-muted-foreground w-8">
-              {percent}%
-            </span>
+          <div className="flex items-center gap-3">
+            <Monogram name={name} />
+            <div className="min-w-0">
+              {/* Real <Link> (href) để reviewer Ctrl/giữa-chuột mở hồ sơ ra tab mới;
+                  stopPropagation để không kích hoạt thêm router.push của cả hàng. */}
+              <Link
+                href={`/admissions/${p.id}`}
+                onClick={(e) => e.stopPropagation()}
+                className="block truncate font-display font-semibold text-foreground hover:underline"
+              >
+                {name}
+              </Link>
+              {!compact && (
+                <div className="truncate text-xs tabular-nums text-muted-foreground">
+                  #{p.id} · {p.program_name ?? "—"}
+                </div>
+              )}
+            </div>
           </div>
         )
       },
-      size: 140,
+      size: 240,
     }) as ColumnDef<AdmissionProfileResponse, unknown>,
 
-    // Eligibility column
-    columnHelper.accessor("eligibility_status", {
-      header: "Đủ điều kiện",
-      cell: ({ getValue }) => {
-        const status = getValue()
-        const config = ELIGIBILITY_CONFIG[status] ?? { label: status, color: "bg-muted" }
-        return (
-          <Badge variant="outline" className={config.color}>
-            {config.label}
-          </Badge>
-        )
-      },
-      size: 120,
+    // Status
+    columnHelper.accessor("status", {
+      header: "Trạng thái",
+      cell: ({ getValue }) => <StatusDot status={getValue()} />,
+      enableSorting: false,
+      size: 130,
     }) as ColumnDef<AdmissionProfileResponse, unknown>,
 
-    // Program column (uses denormalized program_name field)
-    columnHelper.accessor("program_name", {
-      header: "Chương trình",
-      cell: ({ getValue }) => {
-        const program = getValue() ?? "-"
-        return (
-          <span className="text-sm truncate max-w-[150px] block">
-            {program}
-          </span>
-        )
-      },
+    // Progress
+    columnHelper.accessor("completion_percent", {
+      header: "Tiến độ",
+      cell: ({ getValue }) => <ProgressBar value={getValue()} className="min-w-[120px]" />,
+      enableSorting: false,
       size: 150,
     }) as ColumnDef<AdmissionProfileResponse, unknown>,
 
-    // Assigned officer column
+    // Eligibility
+    columnHelper.accessor("eligibility_status", {
+      header: "Điều kiện",
+      cell: ({ getValue }) => <EligibilityToken status={getValue()} />,
+      enableSorting: false,
+      size: 120,
+    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+
+    // Assignees (officer + reviewer — luôn hiện cả hai, mọi density)
     columnHelper.accessor("assigned_officer_name", {
+      id: "assignees",
       header: "Phụ trách",
-      cell: ({ getValue }) => {
-        const name = getValue()
-        return (
-          <span className="text-sm text-muted-foreground truncate max-w-[120px] block">
-            {name ?? "—"}
-          </span>
-        )
-      },
-      size: 120,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
-
-    // Assigned reviewer column
-    columnHelper.accessor("assigned_reviewer_name", {
-      header: "Người duyệt",
-      cell: ({ getValue }) => {
-        const name = getValue()
-        return (
-          <span className="text-sm text-muted-foreground truncate max-w-[120px] block">
-            {name ?? "—"}
-          </span>
-        )
-      },
-      size: 120,
-    }) as ColumnDef<AdmissionProfileResponse, unknown>,
-
-    // Created date column
-    columnHelper.accessor("created_at", {
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          className="-ml-3 h-8"
-        >
-          Ngày tạo
-          <ArrowUpDown className="ml-2 h-4 w-4" />
-        </Button>
+      cell: ({ row }) => (
+        <Assignees
+          officer={row.original.assigned_officer_name}
+          reviewer={row.original.assigned_reviewer_name}
+        />
       ),
-      cell: ({ getValue }) => {
-        const date = getValue()
-        return date ? (
-          <span className="text-sm text-muted-foreground">
-            {format(new Date(date), "dd/MM/yyyy", { locale: vi })}
-          </span>
-        ) : "-"
-      },
+      enableSorting: false,
       size: 110,
     }) as ColumnDef<AdmissionProfileResponse, unknown>,
 
-    // Actions column
+    // Created date (sortable)
+    columnHelper.accessor("created_at", {
+      header: ({ column }) => <SortableHeader column={column} label="Ngày tạo" />,
+      cell: ({ getValue }) => (
+        <span className="whitespace-nowrap text-sm tabular-nums text-muted-foreground">
+          {formatDate(getValue())}
+        </span>
+      ),
+      size: 110,
+    }) as ColumnDef<AdmissionProfileResponse, unknown>,
+
+    // Actions (chevron hover + menu)
     columnHelper.display({
       id: "actions",
       header: () => <span className="sr-only">Thao tác</span>,
-      cell: ({ row }) => {
-        const profile = row.original
-        const canApprove = options?.canApprove &&
-          (profile.status === "submitted" || profile.status === "resubmitted")
-        const canReject = options?.canReject &&
-          (profile.status === "submitted" || profile.status === "resubmitted")
-
-        return (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="h-8 w-8 p-0">
-                <span className="sr-only">Mở menu</span>
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem asChild>
-                <Link href={`/admissions/${profile.id}`}>
-                  <Eye className="mr-2 h-4 w-4" />
-                  Xem chi tiết
-                </Link>
-              </DropdownMenuItem>
-
-              {(canApprove || canReject) && <DropdownMenuSeparator />}
-
-              {canApprove && (
-                <DropdownMenuItem
-                  onClick={() => options?.onApprove?.(profile)}
-                  className="text-success-600"
-                >
-                  <CheckCircle className="mr-2 h-4 w-4" />
-                  Phê duyệt
-                </DropdownMenuItem>
-              )}
-
-              {canReject && (
-                <DropdownMenuItem
-                  onClick={() => options?.onReject?.(profile)}
-                  className="text-error-600"
-                >
-                  <XCircle className="mr-2 h-4 w-4" />
-                  Từ chối
-                </DropdownMenuItem>
-              )}
-
-              {hasAction(profile, "claim") && (
-                <DropdownMenuItem
-                  onClick={() => options?.onClaim?.(profile)}
-                  className="text-blue-600"
-                >
-                  <ClipboardCheck className="mr-2 h-4 w-4" />
-                  Nhận duyệt
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )
-      },
-      size: 60,
+      cell: ({ row }) => (
+        <div className="flex items-center justify-end gap-0.5">
+          <ChevronRight className="size-4 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" aria-hidden="true" />
+          <RowActionsMenu
+            profile={row.original}
+            onClaim={options?.onClaim}
+            onApprove={options?.onApprove}
+            onReject={options?.onReject}
+          />
+        </div>
+      ),
+      enableSorting: false,
+      size: 64,
     }) as ColumnDef<AdmissionProfileResponse, unknown>,
   ]
 }

--- a/frontend/src/app/(dashboard)/admissions/_components/roster-parts.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/roster-parts.tsx
@@ -1,0 +1,176 @@
+// src/app/(dashboard)/admissions/_components/roster-parts.tsx
+/**
+ * Shared presentational parts cho roster hồ sơ (bảng desktop + card mobile).
+ * Thuần trình bày — không logic nghiệp vụ. Màu chấm status lấy từ
+ * `status-config` (single source). Class màu là literal static (Tailwind JIT).
+ */
+
+"use client"
+
+import Link from "next/link"
+import { CheckCircle2, ClipboardCheck, Eye, MoreHorizontal, XCircle } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import { ADMISSION_STATUS_CONFIG, getStatusDotColor } from "@/lib/status-config"
+import { hasAction } from "@/lib/admission/permissions"
+import type { AdmissionProfileResponse } from "@/lib/zod/admissions"
+
+export function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return "?"
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+export function Monogram({ name, className }: { name: string; className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "flex size-9 shrink-0 items-center justify-center rounded-xl bg-muted font-display text-xs font-semibold text-foreground/70",
+        className,
+      )}
+    >
+      {getInitials(name)}
+    </span>
+  )
+}
+
+export function StatusDot({ status }: { status: string }) {
+  const label = ADMISSION_STATUS_CONFIG[status]?.label ?? status
+  return (
+    <span className="inline-flex items-center gap-2 whitespace-nowrap">
+      <span className={cn("size-2 shrink-0 rounded-full", getStatusDotColor(status))} />
+      <span className="text-sm text-foreground">{label}</span>
+    </span>
+  )
+}
+
+const ELIGIBILITY_META: Record<string, { label: string; dot: string; text: string }> = {
+  eligible: { label: "Đủ điều kiện", dot: "bg-success-500", text: "text-success-700" },
+  ineligible: { label: "Không đủ ĐK", dot: "bg-error-500", text: "text-error-700" },
+  pending: { label: "Đang xét", dot: "bg-gray-400", text: "text-muted-foreground" },
+}
+
+export function EligibilityToken({ status }: { status: string }) {
+  const m =
+    ELIGIBILITY_META[status] ?? { label: status, dot: "bg-gray-400", text: "text-muted-foreground" }
+  return (
+    <span className={cn("inline-flex items-center gap-1.5 whitespace-nowrap text-sm", m.text)}>
+      <span className={cn("size-1.5 shrink-0 rounded-full", m.dot)} />
+      {m.label}
+    </span>
+  )
+}
+
+export function ProgressBar({ value, className }: { value: number; className?: string }) {
+  const v = Math.max(0, Math.min(100, Math.round(value ?? 0)))
+  // Đổi màu theo ngưỡng hoàn thiện: thấp = cảnh báo, đủ = thành công.
+  const color = v >= 100 ? "bg-success-500" : v < 40 ? "bg-amber-500" : "bg-primary"
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+        <div className={cn("h-full rounded-full transition-all", color)} style={{ width: `${v}%` }} />
+      </div>
+      <span className="w-9 shrink-0 text-right text-xs tabular-nums text-muted-foreground">{v}%</span>
+    </div>
+  )
+}
+
+function AvatarChip({ name, title, muted }: { name: string; title: string; muted?: boolean }) {
+  return (
+    <span
+      title={title}
+      className={cn(
+        "flex size-7 items-center justify-center rounded-full text-2xs font-semibold ring-2 ring-card",
+        muted ? "bg-muted/60 text-muted-foreground" : "bg-muted text-foreground/70",
+      )}
+    >
+      {getInitials(name)}
+    </span>
+  )
+}
+
+export function Assignees({
+  officer,
+  reviewer,
+}: {
+  officer: string | null | undefined
+  reviewer: string | null | undefined
+}) {
+  if (!officer && !reviewer) return <span className="text-sm text-muted-foreground">—</span>
+  return (
+    <div className="flex items-center gap-1.5">
+      {officer && <AvatarChip name={officer} title={`Phụ trách: ${officer}`} />}
+      {reviewer && <AvatarChip name={reviewer} title={`Người duyệt: ${reviewer}`} muted />}
+    </div>
+  )
+}
+
+export function RowActionsMenu({
+  profile,
+  onClaim,
+  onApprove,
+  onReject,
+}: {
+  profile: AdmissionProfileResponse
+  onClaim?: (profile: AdmissionProfileResponse) => void
+  onApprove?: (profile: AdmissionProfileResponse) => void
+  onReject?: (profile: AdmissionProfileResponse) => void
+}) {
+  // Quyền hành động do BE quyết (available_actions) — thin client, không gate
+  // bằng status string ở FE.
+  const canApprove = !!onApprove && hasAction(profile, "approve")
+  const canReject = !!onReject && hasAction(profile, "reject")
+  const canClaim = !!onClaim && hasAction(profile, "claim")
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          aria-label="Thao tác"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <MoreHorizontal className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+        <DropdownMenuItem asChild>
+          <Link href={`/admissions/${profile.id}`}>
+            <Eye className="mr-2 size-4" />
+            Xem chi tiết
+          </Link>
+        </DropdownMenuItem>
+        {(canApprove || canReject || canClaim) && <DropdownMenuSeparator />}
+        {canApprove && (
+          <DropdownMenuItem className="text-success-700" onClick={() => onApprove?.(profile)}>
+            <CheckCircle2 className="mr-2 size-4" />
+            Phê duyệt
+          </DropdownMenuItem>
+        )}
+        {canReject && (
+          <DropdownMenuItem className="text-error-700" onClick={() => onReject?.(profile)}>
+            <XCircle className="mr-2 size-4" />
+            Từ chối
+          </DropdownMenuItem>
+        )}
+        {canClaim && (
+          <DropdownMenuItem className="text-primary" onClick={() => onClaim?.(profile)}>
+            <ClipboardCheck className="mr-2 size-4" />
+            Nhận duyệt
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/lib/status-config.ts
+++ b/frontend/src/lib/status-config.ts
@@ -163,6 +163,35 @@ export const ADMISSION_STATUS_CONFIG: Record<string, StatusUIConfig> = {
   },
 }
 
+/**
+ * Status dot color — màu chấm trạng thái cho redesign trang danh sách hồ sơ.
+ *
+ * Co-located với ADMISSION_STATUS_CONFIG để giữ SINGLE SOURCE (status →
+ * label/badge/dot ở cùng một module), tránh fork một map màu riêng trong
+ * columns.tsx. Class PHẢI là literal static (Tailwind JIT không thấy chuỗi ghép).
+ */
+export const ADMISSION_STATUS_DOT_COLOR: Record<string, string> = {
+  draft: 'bg-gray-400',
+  submitted: 'bg-info-500',
+  resubmitted: 'bg-info-600',
+  reviewing: 'bg-sky-500',
+  revision_requested: 'bg-orange-500',
+  approved: 'bg-success-500',
+  admitted: 'bg-green-500',
+  overridden: 'bg-purple-500',
+  waitlisted: 'bg-amber-500',
+  confirmed: 'bg-emerald-500',
+  enrolled: 'bg-blue-500',
+  rejected: 'bg-error-500',
+  withdrawn: 'bg-gray-400',
+  result_published: 'bg-sky-500',
+}
+
+/** Lấy class màu chấm cho 1 admission status (fallback xám trung tính). */
+export function getStatusDotColor(status: string): string {
+  return ADMISSION_STATUS_DOT_COLOR[status] ?? 'bg-gray-400'
+}
+
 // =============================================================================
 // LEAD STATUS CONFIG (for future use)
 // =============================================================================


### PR DESCRIPTION
## Tóm tắt
Thiết kế lại `/admissions` thành data-console ("operations desk" — Linear-list × Notion). **Thuần presentation (thin-client)** — giữ nguyên data layer; mọi đường ghi vẫn qua mutation cũ + `version` (optimistic-lock) → không có đường ghi mới, không rủi ro sai lệch dữ liệu.

## Thay đổi chính
- Tách `_components`: `AdmissionsMetricRail` / `AdmissionsFilterBar` / `AdmissionsStatusTabs` / `roster-parts` (dùng chung bảng desktop + card mobile).
- **Metric rail** liền mạch thay 6 StatCard; **filter bar** gọn (search + Năm + popover Bộ lọc + Sắp xếp + chips); **status tabs** gạch chân; **roster** 2 dòng (monogram, status chấm, progress đổi màu ngưỡng, eligibility token, avatar chip officer/reviewer); **density** Thoáng/Gọn (localStorage, hydration-safe).
- `columns`: tên hồ sơ là `<Link href>` (Ctrl/middle-click mở tab mới); gộp Phụ trách + Người duyệt 1 cột; `SortableHeader` dùng chung.
- `status-config`: thêm `ADMISSION_STATUS_DOT_COLOR` + `getStatusDotColor` (single source).
- **Row menu** (+ mobile): Xem chi tiết + claim/approve/reject theo `hasAction` (BE-driven) + single-row reject dialog.
- Filter: nhãn status derive từ `ADMISSION_STATUS_CONFIG` (chống drift), badge đếm nhóm, chip Năm, **xóa selection khi đổi filter/tab/trang**.
- Reuse `formatDate` helper; bỏ export dead `STATUS_CONFIG`/`ELIGIBILITY_CONFIG`.

## Giữ nguyên (không đổi behavior)
`useAdmissionsFilter` (URL+localStorage), TanStack sort+selection, SSR initialData, prefetch, bulk approve/reject/assign/export + permission gating, claim, pagination, status coverage. Cross-file review xác nhận 0 vỡ contract.

## Verify
- ✅ `tsc` type-check · ESLint (0 errors) · Vitest **22/22** (5 file, +2 mới).
- ✅ Chrome smoke desktop @1440 + mobile @375 + popover — **data thật** (85 hồ sơ; stats/tabs/lọc/phân trang đúng; row-menu gate quyền đúng).
- ✅ `/code-review max` (5 finder angle) → **sửa toàn bộ findings** (nav Link, label-drift, clear-selection, memo dep, reviewer-always, formatDate reuse, dead-export, SortableHeader, mobile table-API…).

## Caveat trung thực
Đường ghi **per-row approve/reject chưa chạy thật** trong smoke vì data hiện không có hồ sơ `submitted` — logic type-safe + tái dùng mutation bulk đã chứng minh; **nên bấm thử 1 approve + 1 reject trên hồ sơ submitted thật** trước khi tin 100%.

## Follow-up (đã audit API, KHÔNG trong PR này)
- **Gói A (FE-only):** badge Nợ giấy tờ (`document_debt`) + "Cập nhật X ngày trước" (`updated_at`) + sort "Cập nhật gần nhất" + presets.
- **Gói B (cần BE nhỏ):** lọc "Của tôi" (assignee=me), lọc `document_debt`, sort theo `completion_percent`.

## Dọn dẹp
`app/dev/admissions-preview` (preview tạm) là untracked, **không nằm trong PR**; xóa local sau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
