### PR TITLE
fix(admissions): hardening xóa hồ sơ — escape PII + dọn file + revert trạng thái lead

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -176,6 +176,7 @@ jobs:
           tests/services/test_phase3_create_profile_inherits_multi_nv.py
           tests/unit/test_admission_path_service_field_drift.py
           tests/integration/test_admission_path_method_filter_and_activator.py
+          tests/unit/test_delete_profile_file_cleanup.py
           -q --tb=short --timeout=60
 
       # =====================================================================
@@ -247,6 +248,7 @@ jobs:
           tests/api/test_lead_assignment_api.py::test_lead_assignment_lifecycle_end_to_end
           tests/unit/test_admission_state_machine.py
           tests/unit/test_b2_1_admission_milestone_events.py
+          tests/integration/test_delete_profile_revert.py
           -q --tb=short --timeout=60
 
       # =====================================================================

--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -38,6 +38,7 @@ from app.models.admission_profile_choice import (
     ProfileChoiceScore,
 )
 from app.repositories.base import BaseRepository
+from app.utils.text_helpers import LIKE_ESCAPE_CHAR, escape_like_pattern
 
 
 # Phase 3 multi-NV: eager-load chain cho AdmissionProfile.choices + nested
@@ -207,11 +208,15 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         if search:
             # Normalize Unicode for Vietnamese diacritics
             normalized_search = unicodedata.normalize('NFC', search.strip())
-            search_term = f"%{normalized_search}%"
+            # Escape LIKE wildcards (% _) so user input (incl. citizen_id) is
+            # treated literally — prevents wildcard-injection / DoS backtracking.
+            search_term = f"%{escape_like_pattern(normalized_search)}%"
             search_conditions = or_(
-                models.Lead.full_name.ilike(search_term),
-                models.Lead.email.ilike(search_term),
-                models.AdmissionProfile.citizen_id.ilike(search_term),
+                models.Lead.full_name.ilike(search_term, escape=LIKE_ESCAPE_CHAR),
+                models.Lead.email.ilike(search_term, escape=LIKE_ESCAPE_CHAR),
+                models.AdmissionProfile.citizen_id.ilike(
+                    search_term, escape=LIKE_ESCAPE_CHAR
+                ),
             )
             base_conditions.append(search_conditions)
 
@@ -376,11 +381,15 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             conditions.append(models.Lead.unit_id == unit_id)
         if search:
             normalized_search = unicodedata.normalize('NFC', search.strip())
-            search_term = f"%{normalized_search}%"
+            # Escape LIKE wildcards (% _) so user input (incl. citizen_id) is
+            # treated literally — prevents wildcard-injection / DoS backtracking.
+            search_term = f"%{escape_like_pattern(normalized_search)}%"
             conditions.append(or_(
-                models.Lead.full_name.ilike(search_term),
-                models.Lead.email.ilike(search_term),
-                models.AdmissionProfile.citizen_id.ilike(search_term),
+                models.Lead.full_name.ilike(search_term, escape=LIKE_ESCAPE_CHAR),
+                models.Lead.email.ilike(search_term, escape=LIKE_ESCAPE_CHAR),
+                models.AdmissionProfile.citizen_id.ilike(
+                    search_term, escape=LIKE_ESCAPE_CHAR
+                ),
             ))
         if major_ids and len(major_ids) > 0:
             conditions.append(models.ProgramOffering.program_id.in_(major_ids))

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -42,6 +42,8 @@ from ..services.magic_link_rate_limit import (
 )
 from ..services.notification_dispatcher import safe_dispatch, rooms_for_admission, rooms_for_lead
 from ..services.notification_payloads import EventPayload
+from sqlalchemy.orm import selectinload
+from types import SimpleNamespace
 from ..services.user_service import emit_data_updated as _emit_realtime_update
 from ..core.events import SystemEvents
 from ..utils.exceptions import (
@@ -1426,9 +1428,41 @@ async def delete_admission_profile(
 
         # Dispatch APPLICATION_DELETED (profile is gone, use snapshot)
         if _snapshot_lead_id:
-            # Lead row still exists (FK was profile→lead, profile gone but lead kept).
-            # Fetch it so scoped emit can include unit + assigned officer rooms.
-            _deleted_lead = await db.get(models.Lead, _snapshot_lead_id)
+            # Lead row still exists (FK was profile→lead, profile gone but lead
+            # kept). Eager-load the officer so officer_name can be stamped
+            # without a lazy load.
+            _deleted_lead = await db.get(
+                models.Lead,
+                _snapshot_lead_id,
+                options=[selectinload(models.Lead.assigned_officer)],
+            )
+            # Snapshot EVERY scalar we need BEFORE the first safe_dispatch: on
+            # failure safe_dispatch rolls back the session, expiring ORM attrs —
+            # reading _deleted_lead / current_user afterwards would async
+            # lazy-load and 500 an already-committed delete before cleanup runs.
+            _lead_full_name = (
+                getattr(_deleted_lead, "full_name", None) or _snapshot_lead_name
+            )
+            _officer_name = (
+                _deleted_lead.assigned_officer.full_name
+                if _deleted_lead is not None and _deleted_lead.assigned_officer
+                else "Unknown"
+            )
+            _actor_id = current_user.id
+            _actor_name = current_user.full_name or current_user.username
+            # One namespace serves both rooms_for_lead (unit_id/officer_id) and
+            # for_lead_status_changed (id/full_name/email/officer_id).
+            _lead_ns = SimpleNamespace(
+                id=_snapshot_lead_id,
+                full_name=_lead_full_name,
+                email=None,
+                unit_id=getattr(_deleted_lead, "unit_id", None),
+                assigned_officer_id=getattr(
+                    _deleted_lead, "assigned_officer_id", None
+                ),
+            )
+            _lead_rooms = rooms_for_lead(_lead_ns)
+
             await safe_dispatch(
                 db=db,
                 event=SystemEvents.APPLICATION_DELETED,
@@ -1436,35 +1470,39 @@ async def delete_admission_profile(
                     "application_id": profile_id,
                     "lead_id": _snapshot_lead_id,
                     "lead_name": _snapshot_lead_name,
-                    "actor_id": current_user.id,
-                    "actor_name": current_user.full_name or current_user.username,
+                    "actor_id": _actor_id,
+                    "actor_name": _actor_name,
                 },
                 dedupe_key=f"admission_profile_deleted:{profile_id}",
-                rooms=rooms_for_lead(_deleted_lead),
+                rooms=_lead_rooms,
             )
 
-            # Deleting the last draft may have reverted the lead's status — surface
-            # that to lead-pipeline subscribers/notifications (parity with other
-            # status transitions). The DB is already consistent (history + lead
-            # row updated); this is the realtime/notification event.
-            if _lead_revert and _deleted_lead is not None:
+            # Deleting the last draft may have reverted the lead's status —
+            # surface it to lead-pipeline subscribers/notifications (parity with
+            # other transitions). Built from the scalar snapshot so a failed
+            # dispatch above (session rolled back) cannot break or skip this one.
+            if _lead_revert:
+                _actor_ns = SimpleNamespace(
+                    id=_actor_id, full_name=_actor_name, username=_actor_name
+                )
                 await safe_dispatch(
                     db=db,
                     event=SystemEvents.LEAD_STATUS_CHANGED,
                     payload=EventPayload.for_lead_status_changed(
-                        _deleted_lead,
-                        current_user,
+                        _lead_ns,
+                        _actor_ns,
                         old_status=_lead_revert["old_status"] or "none",
                         new_status=_lead_revert["new_status"] or "none",
+                        officer_name=_officer_name,
                         old_stage=_lead_revert.get("old_stage"),
                         new_stage=_lead_revert.get("new_stage"),
                         updated_fields=["consultation_status_id", "pipeline_stage_id"],
                     ),
                     dedupe_key=(
-                        f"lead_status_changed:{_deleted_lead.id}:"
+                        f"lead_status_changed:{_snapshot_lead_id}:"
                         f"{_lead_revert['new_status']}"
                     ),
-                    rooms=rooms_for_lead(_deleted_lead),
+                    rooms=_lead_rooms,
                 )
 
         # Post-commit best-effort file cleanup LAST so it can never block the

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -1412,7 +1412,7 @@ async def delete_admission_profile(
             if _lead:
                 _snapshot_lead_name = _lead.full_name
 
-        await admission_service.delete_profile(
+        _deleted, _cleanup_orphaned_files = await admission_service.delete_profile(
             db=db,
             profile_id=profile_id,
             current_user=current_user,
@@ -1420,6 +1420,12 @@ async def delete_admission_profile(
 
         # Transaction commit
         await db.commit()
+
+        # Post-commit best-effort: drop the physical uploaded files. The
+        # profile_document rows already cascade-deleted with the profile;
+        # this removes their files on disk so they don't leak as orphans.
+        if _cleanup_orphaned_files:
+            await _cleanup_orphaned_files()
 
         # Dispatch APPLICATION_DELETED (profile is gone, use snapshot)
         if _snapshot_lead_id:

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -1382,6 +1382,84 @@ async def enroll_student(
         )
 
 
+async def _emit_post_delete_events(
+    db,
+    *,
+    profile_id: int,
+    lead_id: int,
+    lead_name: str,
+    lead_revert: dict | None,
+    actor_id: int,
+    actor_name: str,
+) -> None:
+    """Post-commit fanout for a deleted admission profile.
+
+    Snapshots every scalar from the (still-attached) lead BEFORE the first
+    ``safe_dispatch``: a failed dispatch rolls back the session and expires ORM
+    instances, so the second dispatch's payload/rooms must come from plain
+    scalars — never from a (possibly expired) ORM object. Request-free so it is
+    unit-testable without the endpoint's rate-limiter/Request machinery.
+    """
+    _deleted_lead = await db.get(
+        models.Lead, lead_id, options=[selectinload(models.Lead.assigned_officer)]
+    )
+    _lead_full_name = getattr(_deleted_lead, "full_name", None) or lead_name
+    _officer_name = (
+        _deleted_lead.assigned_officer.full_name
+        if _deleted_lead is not None and _deleted_lead.assigned_officer
+        else "Unknown"
+    )
+    # One namespace serves both rooms_for_lead (unit_id/officer_id) and
+    # for_lead_status_changed (id/full_name/email/officer_id).
+    _lead_ns = SimpleNamespace(
+        id=lead_id,
+        full_name=_lead_full_name,
+        email=None,
+        unit_id=getattr(_deleted_lead, "unit_id", None),
+        assigned_officer_id=getattr(_deleted_lead, "assigned_officer_id", None),
+    )
+    _lead_rooms = rooms_for_lead(_lead_ns)
+
+    await safe_dispatch(
+        db=db,
+        event=SystemEvents.APPLICATION_DELETED,
+        payload={
+            "application_id": profile_id,
+            "lead_id": lead_id,
+            "lead_name": lead_name,
+            "actor_id": actor_id,
+            "actor_name": actor_name,
+        },
+        dedupe_key=f"admission_profile_deleted:{profile_id}",
+        rooms=_lead_rooms,
+    )
+
+    # Deleting the last draft may have reverted the lead's status — surface it to
+    # lead-pipeline subscribers/notifications (parity with other transitions).
+    # Built from the scalar snapshot so a failed dispatch above (session rolled
+    # back) cannot break or skip this one.
+    if lead_revert:
+        _actor_ns = SimpleNamespace(
+            id=actor_id, full_name=actor_name, username=actor_name
+        )
+        await safe_dispatch(
+            db=db,
+            event=SystemEvents.LEAD_STATUS_CHANGED,
+            payload=EventPayload.for_lead_status_changed(
+                _lead_ns,
+                _actor_ns,
+                old_status=lead_revert["old_status"] or "none",
+                new_status=lead_revert["new_status"] or "none",
+                officer_name=_officer_name,
+                old_stage=lead_revert.get("old_stage"),
+                new_stage=lead_revert.get("new_stage"),
+                updated_fields=["consultation_status_id", "pipeline_stage_id"],
+            ),
+            dedupe_key=f"lead_status_changed:{lead_id}:{lead_revert['new_status']}",
+            rooms=_lead_rooms,
+        )
+
+
 @limiter.limit(RateLimits.DATA_WRITE)  # 200/hour
 @router.delete(
     "/{profile_id}",
@@ -1423,87 +1501,29 @@ async def delete_admission_profile(
             )
         )
 
+        # Snapshot actor scalars BEFORE commit/dispatch: a failed safe_dispatch
+        # below rolls back the session and expires current_user, so any later
+        # read (the LEAD_STATUS_CHANGED payload or the final log) would async
+        # lazy-load on an expired instance and 500 an already-committed delete.
+        _actor_id = current_user.id
+        _actor_name = current_user.full_name or current_user.username
+
         # Transaction commit
         await db.commit()
 
-        # Dispatch APPLICATION_DELETED (profile is gone, use snapshot)
+        # Post-commit fanout via a request-free helper that snapshots all
+        # scalars BEFORE the first safe_dispatch (a failed dispatch rolls back
+        # the session and expires ORM attrs). See _emit_post_delete_events.
         if _snapshot_lead_id:
-            # Lead row still exists (FK was profile→lead, profile gone but lead
-            # kept). Eager-load the officer so officer_name can be stamped
-            # without a lazy load.
-            _deleted_lead = await db.get(
-                models.Lead,
-                _snapshot_lead_id,
-                options=[selectinload(models.Lead.assigned_officer)],
+            await _emit_post_delete_events(
+                db,
+                profile_id=profile_id,
+                lead_id=_snapshot_lead_id,
+                lead_name=_snapshot_lead_name,
+                lead_revert=_lead_revert,
+                actor_id=_actor_id,
+                actor_name=_actor_name,
             )
-            # Snapshot EVERY scalar we need BEFORE the first safe_dispatch: on
-            # failure safe_dispatch rolls back the session, expiring ORM attrs —
-            # reading _deleted_lead / current_user afterwards would async
-            # lazy-load and 500 an already-committed delete before cleanup runs.
-            _lead_full_name = (
-                getattr(_deleted_lead, "full_name", None) or _snapshot_lead_name
-            )
-            _officer_name = (
-                _deleted_lead.assigned_officer.full_name
-                if _deleted_lead is not None and _deleted_lead.assigned_officer
-                else "Unknown"
-            )
-            _actor_id = current_user.id
-            _actor_name = current_user.full_name or current_user.username
-            # One namespace serves both rooms_for_lead (unit_id/officer_id) and
-            # for_lead_status_changed (id/full_name/email/officer_id).
-            _lead_ns = SimpleNamespace(
-                id=_snapshot_lead_id,
-                full_name=_lead_full_name,
-                email=None,
-                unit_id=getattr(_deleted_lead, "unit_id", None),
-                assigned_officer_id=getattr(
-                    _deleted_lead, "assigned_officer_id", None
-                ),
-            )
-            _lead_rooms = rooms_for_lead(_lead_ns)
-
-            await safe_dispatch(
-                db=db,
-                event=SystemEvents.APPLICATION_DELETED,
-                payload={
-                    "application_id": profile_id,
-                    "lead_id": _snapshot_lead_id,
-                    "lead_name": _snapshot_lead_name,
-                    "actor_id": _actor_id,
-                    "actor_name": _actor_name,
-                },
-                dedupe_key=f"admission_profile_deleted:{profile_id}",
-                rooms=_lead_rooms,
-            )
-
-            # Deleting the last draft may have reverted the lead's status —
-            # surface it to lead-pipeline subscribers/notifications (parity with
-            # other transitions). Built from the scalar snapshot so a failed
-            # dispatch above (session rolled back) cannot break or skip this one.
-            if _lead_revert:
-                _actor_ns = SimpleNamespace(
-                    id=_actor_id, full_name=_actor_name, username=_actor_name
-                )
-                await safe_dispatch(
-                    db=db,
-                    event=SystemEvents.LEAD_STATUS_CHANGED,
-                    payload=EventPayload.for_lead_status_changed(
-                        _lead_ns,
-                        _actor_ns,
-                        old_status=_lead_revert["old_status"] or "none",
-                        new_status=_lead_revert["new_status"] or "none",
-                        officer_name=_officer_name,
-                        old_stage=_lead_revert.get("old_stage"),
-                        new_stage=_lead_revert.get("new_stage"),
-                        updated_fields=["consultation_status_id", "pipeline_stage_id"],
-                    ),
-                    dedupe_key=(
-                        f"lead_status_changed:{_snapshot_lead_id}:"
-                        f"{_lead_revert['new_status']}"
-                    ),
-                    rooms=_lead_rooms,
-                )
 
         # Post-commit best-effort file cleanup LAST so it can never block the
         # dispatches above (helper already swallows errors; belt-and-suspenders).
@@ -1519,7 +1539,7 @@ async def delete_admission_profile(
         log.info(
             "Admission profile deleted via API",
             profile_id=profile_id,
-            user_id=current_user.id,
+            user_id=_actor_id,
         )
 
         return None

--- a/Backend_FastAPI/app/routers/admissions.py
+++ b/Backend_FastAPI/app/routers/admissions.py
@@ -41,6 +41,7 @@ from ..services.magic_link_rate_limit import (
     consume_attempt,
 )
 from ..services.notification_dispatcher import safe_dispatch, rooms_for_admission, rooms_for_lead
+from ..services.notification_payloads import EventPayload
 from ..services.user_service import emit_data_updated as _emit_realtime_update
 from ..core.events import SystemEvents
 from ..utils.exceptions import (
@@ -1412,20 +1413,16 @@ async def delete_admission_profile(
             if _lead:
                 _snapshot_lead_name = _lead.full_name
 
-        _deleted, _cleanup_orphaned_files = await admission_service.delete_profile(
-            db=db,
-            profile_id=profile_id,
-            current_user=current_user,
+        _deleted, _cleanup_orphaned_files, _lead_revert = (
+            await admission_service.delete_profile(
+                db=db,
+                profile_id=profile_id,
+                current_user=current_user,
+            )
         )
 
         # Transaction commit
         await db.commit()
-
-        # Post-commit best-effort: drop the physical uploaded files. The
-        # profile_document rows already cascade-deleted with the profile;
-        # this removes their files on disk so they don't leak as orphans.
-        if _cleanup_orphaned_files:
-            await _cleanup_orphaned_files()
 
         # Dispatch APPLICATION_DELETED (profile is gone, use snapshot)
         if _snapshot_lead_id:
@@ -1445,6 +1442,41 @@ async def delete_admission_profile(
                 dedupe_key=f"admission_profile_deleted:{profile_id}",
                 rooms=rooms_for_lead(_deleted_lead),
             )
+
+            # Deleting the last draft may have reverted the lead's status — surface
+            # that to lead-pipeline subscribers/notifications (parity with other
+            # status transitions). The DB is already consistent (history + lead
+            # row updated); this is the realtime/notification event.
+            if _lead_revert and _deleted_lead is not None:
+                await safe_dispatch(
+                    db=db,
+                    event=SystemEvents.LEAD_STATUS_CHANGED,
+                    payload=EventPayload.for_lead_status_changed(
+                        _deleted_lead,
+                        current_user,
+                        old_status=_lead_revert["old_status"] or "none",
+                        new_status=_lead_revert["new_status"] or "none",
+                        old_stage=_lead_revert.get("old_stage"),
+                        new_stage=_lead_revert.get("new_stage"),
+                        updated_fields=["consultation_status_id", "pipeline_stage_id"],
+                    ),
+                    dedupe_key=(
+                        f"lead_status_changed:{_deleted_lead.id}:"
+                        f"{_lead_revert['new_status']}"
+                    ),
+                    rooms=rooms_for_lead(_deleted_lead),
+                )
+
+        # Post-commit best-effort file cleanup LAST so it can never block the
+        # dispatches above (helper already swallows errors; belt-and-suspenders).
+        if _cleanup_orphaned_files:
+            try:
+                await _cleanup_orphaned_files()
+            except Exception:  # noqa: BLE001 — best-effort storage cleanup
+                log.warning(
+                    "Profile upload cleanup failed post-commit",
+                    profile_id=profile_id,
+                )
 
         log.info(
             "Admission profile deleted via API",

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -10289,11 +10289,77 @@ async def finalize_profile(
     return profile, final_callback
 
 
+def _remove_orphaned_document_files(file_paths: List[str]) -> None:
+    """Best-effort removal of uploaded files left behind by a deleted profile.
+
+    ``profile_document`` rows cascade-delete with the profile via the FK
+    (``ondelete=CASCADE``), but the physical uploads on disk are NOT touched
+    by the database — a deleted draft would otherwise leak its files. Mirrors
+    the post-commit old-file cleanup in ``update_document``: a leftover file
+    is storage waste, not a correctness issue, so every failure is swallowed
+    and logged.
+
+    MUST run AFTER the deleting transaction commits (the rows must be gone
+    for good before we drop the bytes).
+    """
+    import os
+
+    for path in file_paths:
+        if not path or not os.path.exists(path):
+            continue
+        try:
+            os.remove(path)
+            log.info(
+                "Orphaned profile document file deleted post-commit",
+                path=path,
+            )
+        except OSError as e:
+            log.warning(
+                "Failed to delete orphaned profile document file",
+                path=path,
+                error=str(e),
+            )
+
+
+# Lead consultation status that ``create_profile`` bumps a lead to via the
+# ``profile_created`` milestone (== ADMISSION_TO_LEAD_STATUS_MAP["draft"] in
+# lead_admission_sync.py). sts06 is reached ONLY through profile creation.
+_CREATE_MILESTONE_STATUS = "sts06"
+
+
+def _resolve_lead_revert_status(
+    has_other_profile: bool,
+    current_consultation_status_id: Optional[str],
+    prev_consultation_status_id: Optional[str],
+) -> Optional[str]:
+    """Decide which consultation status a lead reverts to when its last draft
+    profile is deleted — or ``None`` to leave the lead untouched.
+
+    Pure policy (no DB) so the rule is exhaustively unit-testable. Revert ONLY
+    when ALL hold:
+      * the lead has NO other admission profile (this was the last one), AND
+      * the lead is still exactly at the create-milestone status (sts06) — i.e.
+        nothing advanced it further (another profile's submit, an officer
+        manual change, fee payment, …), AND
+      * we know the status held BEFORE creation, and it differs from sts06
+        (a self-revert would be a no-op).
+    """
+    if has_other_profile:
+        return None
+    if current_consultation_status_id != _CREATE_MILESTONE_STATUS:
+        return None
+    if not prev_consultation_status_id:
+        return None
+    if prev_consultation_status_id == _CREATE_MILESTONE_STATUS:
+        return None
+    return prev_consultation_status_id
+
+
 async def delete_profile(
     db: AsyncSession,
     profile_id: int,
     current_user: models.User,
-) -> bool:
+) -> Tuple[bool, Callable[[], Awaitable[None]]]:
     """
     Delete AdmissionProfile (only when status='draft').
 
@@ -10302,8 +10368,14 @@ async def delete_profile(
     - State Locking: Only draft profiles can be deleted
 
     Behavior:
-    - Does NOT revert Lead status (Lead already showed interest)
-    - Creates a consultation record noting the deletion
+    - Conditionally reverts the lead's consultation status to its
+      pre-creation value — ONLY when this was the lead's last profile AND
+      the lead is still at the create-milestone status (sts06). Otherwise
+      the lead status is preserved (it advanced on its own or another
+      profile justifies it).
+    - Keeps ALL existing consultation history (real data); ADDS a system
+      consultation record noting the deletion, plus a LeadStatusHistory
+      row when a revert actually happens.
     - Maintains full audit trail in timeline
 
     IMPORTANT: This function does NOT commit the transaction.
@@ -10315,7 +10387,10 @@ async def delete_profile(
         current_user: Current authenticated user
 
     Returns:
-        True if deleted successfully
+        Tuple of (True, post_commit_callback). The callback removes the
+        orphaned uploaded files (best-effort) and MUST be awaited by the
+        router AFTER ``db.commit()`` — the profile_document rows cascade
+        away with the profile but their files on disk do not.
 
     Raises:
         ResourceNotFoundError: Profile not found
@@ -10346,22 +10421,102 @@ async def delete_profile(
     lead_id = profile.lead_id
 
     # ==========================================================================
-    # CREATE CONSULTATION RECORD: Log the deletion event (no status revert)
+    # LEAD STATUS REVERT (conditional) + deletion consultation record
     # ==========================================================================
-    # Following the Golden Rule: Every admission event must have a consultation record
-    # Lead status stays the same (they already showed interest by creating profile)
-    
+    # Creating a draft profile bumps the lead to sts06 "Đồng ý tư vấn" via the
+    # ``profile_created`` milestone. Deleting that draft should undo the bump —
+    # but ONLY when it is safe:
+    #   (a) the lead has NO other admission profile left, AND
+    #   (b) the lead is still exactly at the create-milestone status (sts06),
+    #       i.e. nothing advanced it further (another profile's submit, an
+    #       officer manual change, fee payment, etc.).
+    # Otherwise the lead state is preserved. Consultation history is always
+    # KEPT (it is real history); we only ADD a system record per the Golden
+    # Rule, plus a LeadStatusHistory row when a revert actually happens.
+    from ..core.status_mapping import sync_lead_status_from_consultation
+    from .lead_service import _get_current_lead_state, _log_lead_state_change
+
+    _other_profile_count = await db.scalar(
+        select(func.count())
+        .select_from(models.AdmissionProfile)
+        .where(
+            models.AdmissionProfile.lead_id == lead_id,
+            models.AdmissionProfile.id != profile_id,
+        )
+    )
+
+    # Cheap-gate the history lookup: only query when the rule could possibly
+    # fire. The authoritative decision lives in _resolve_lead_revert_status,
+    # which re-checks these conditions on the values it is given.
+    _prev_status_id = None
+    if (
+        not _other_profile_count
+        and lead.consultation_status_id == _CREATE_MILESTONE_STATUS
+    ):
+        _bump = await db.scalar(
+            select(models.LeadStatusHistory)
+            .where(
+                models.LeadStatusHistory.lead_id == lead_id,
+                models.LeadStatusHistory.new_consultation_status_id
+                == _CREATE_MILESTONE_STATUS,
+            )
+            .order_by(models.LeadStatusHistory.id.desc())
+            .limit(1)
+        )
+        _prev_status_id = _bump.old_consultation_status_id if _bump else None
+
+    _revert_target = _resolve_lead_revert_status(
+        has_other_profile=bool(_other_profile_count),
+        current_consultation_status_id=lead.consultation_status_id,
+        prev_consultation_status_id=_prev_status_id,
+    )
+
+    reverted_status_id = None
+    if _revert_target:
+        _target_cs = await db.get(
+            models.ConsultationStatus,
+            _revert_target,
+            options=[selectinload(models.ConsultationStatus.stage)],
+        )
+        if _target_cs:
+            _old_state = _get_current_lead_state(lead)
+            lead.consultation_status_id = _revert_target
+            lead.pipeline_stage_id = _target_cs.stage_id
+            sync_lead_status_from_consultation(lead, _target_cs)
+            _new_state = _get_current_lead_state(lead)
+            await _log_lead_state_change(
+                db=db,
+                lead=lead,
+                old_state=_old_state,
+                new_state=_new_state,
+                changed_by=current_user,
+                reason=f"Hoàn trạng thái sau khi xóa hồ sơ draft #{profile_id}",
+            )
+            reverted_status_id = _revert_target
+
+    if reverted_status_id:
+        _deletion_note = (
+            f"[HỆ THỐNG] Hồ sơ xét tuyển #{profile_id} đã bị xóa — "
+            "hoàn trạng thái tư vấn về trước khi tạo hồ sơ."
+        )
+    else:
+        _deletion_note = (
+            f"[HỆ THỐNG] Hồ sơ xét tuyển đã bị xóa - Profile #{profile_id}"
+        )
+
+    # Golden Rule: every admission event gets a consultation record. The record
+    # reflects the lead's CURRENT (possibly reverted) consultation status.
     system_consultation = models.Consultation(
         lead_id=lead_id,
         officer_id=current_user.id,
-        consultation_status_id=lead.consultation_status_id,  # Keep current status
+        consultation_status_id=lead.consultation_status_id,
         consultation_date=datetime.now(timezone.utc),
         method="system",
-        notes=f"[HỆ THỐNG] Hồ sơ xét tuyển đã bị xóa - Profile #{profile_id}",
+        notes=_deletion_note,
         duration_minutes=0,
     )
     db.add(system_consultation)
-    
+
     # Update lead timestamp
     lead.updated_at = datetime.now(timezone.utc)
 
@@ -10370,6 +10525,7 @@ async def delete_profile(
         lead_id=lead_id,
         profile_id=profile_id,
         consultation_status_id=lead.consultation_status_id,
+        reverted_status_id=reverted_status_id,
         actor_id=current_user.id,
     )
 
@@ -10382,6 +10538,19 @@ async def delete_profile(
         source="api",
     )
 
+    # Collect physical upload paths BEFORE the cascade removes the rows.
+    # ``profile_document.profile_id`` is ondelete=CASCADE, so the rows vanish
+    # with the profile; the files on disk must be cleaned up separately
+    # (post-commit, best-effort) to avoid orphaned uploads. Covers both
+    # path documents and priority_evidence uploads.
+    _doc_paths_result = await db.execute(
+        select(models.ProfileDocument.file_path).where(
+            models.ProfileDocument.profile_id == profile_id,
+            models.ProfileDocument.file_path.isnot(None),
+        )
+    )
+    orphaned_file_paths = [p for (p,) in _doc_paths_result.all() if p]
+
     # Delete the profile
     await db.delete(profile)
     await db.flush()
@@ -10391,9 +10560,14 @@ async def delete_profile(
         profile_id=profile_id,
         lead_id=lead_id,
         user_id=current_user.id,
+        orphaned_files=len(orphaned_file_paths),
     )
 
-    return True
+    async def _post_commit_cleanup() -> None:
+        # Drop the uploaded files only after the delete is durably committed.
+        _remove_orphaned_document_files(orphaned_file_paths)
+
+    return True, _post_commit_cleanup
 
 
 # ==============================================================================

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -10289,41 +10289,41 @@ async def finalize_profile(
     return profile, final_callback
 
 
-def _remove_orphaned_document_files(file_paths: List[str]) -> None:
-    """Best-effort removal of uploaded files left behind by a deleted profile.
+def _remove_profile_upload_dir(profile_id: int) -> None:
+    """Best-effort removal of a deleted profile's entire upload directory.
 
-    ``profile_document`` rows cascade-delete with the profile via the FK
-    (``ondelete=CASCADE``), but the physical uploads on disk are NOT touched
-    by the database — a deleted draft would otherwise leak its files. Mirrors
-    the post-commit old-file cleanup in ``update_document``: a leftover file
-    is storage waste, not a correctness issue, so every failure is swallowed
-    and logged.
+    All of a profile's uploads — path documents, priority-evidence files and
+    the hidden ``.staging.{uuid}`` temp files — live under
+    ``uploads/admissions/{id}/`` and can never escape it (see
+    ``upload_document``). ``profile_document`` rows cascade-delete with the
+    profile, but the files and the now-empty directory are not touched by the
+    DB. ``shutil.rmtree`` drops docs + staging + the directory in one shot
+    (the per-file loop used to leak staging files and the empty dir).
 
-    MUST run AFTER the deleting transaction commits (the rows must be gone
-    for good before we drop the bytes).
+    A leftover file is storage waste, not a correctness issue — and this runs
+    AFTER the delete commits — so EVERY failure is swallowed (post-commit
+    cleanup must never raise and turn a successful delete into a 500).
     """
-    import os
+    import shutil
 
-    for path in file_paths:
-        if not path or not os.path.exists(path):
-            continue
-        try:
-            os.remove(path)
-            log.info(
-                "Orphaned profile document file deleted post-commit",
-                path=path,
-            )
-        except OSError as e:
-            log.warning(
-                "Failed to delete orphaned profile document file",
-                path=path,
-                error=str(e),
-            )
+    upload_dir = f"uploads/admissions/{profile_id}"
+    try:
+        shutil.rmtree(upload_dir, ignore_errors=True)
+    except Exception as e:  # noqa: BLE001 — best-effort, must never raise
+        log.warning(
+            "Failed to remove profile upload dir post-commit",
+            upload_dir=upload_dir,
+            error=str(e),
+        )
 
 
-# Lead consultation status that ``create_profile`` bumps a lead to via the
-# ``profile_created`` milestone (== ADMISSION_TO_LEAD_STATUS_MAP["draft"] in
-# lead_admission_sync.py). sts06 is reached ONLY through profile creation.
+# Lead consultation status the ``profile_created`` milestone moves a lead to
+# (== ADMISSION_TO_LEAD_STATUS_MAP["draft"] in lead_admission_sync.py).
+# IMPORTANT: sts06 is ALSO reachable via ``lead_agrees`` / a manual "Đồng ý
+# tư vấn" — so being at sts06 does NOT imply this profile caused it. A revert
+# must confirm the *most recent* lead status change was the profile-created
+# bump (see delete_profile), otherwise it would mis-attribute an independent
+# sts06 and silently demote the lead.
 _CREATE_MILESTONE_STATUS = "sts06"
 
 
@@ -10331,6 +10331,7 @@ def _resolve_lead_revert_status(
     has_other_profile: bool,
     current_consultation_status_id: Optional[str],
     prev_consultation_status_id: Optional[str],
+    prev_is_terminal_or_negative: bool = False,
 ) -> Optional[str]:
     """Decide which consultation status a lead reverts to when its last draft
     profile is deleted — or ``None`` to leave the lead untouched.
@@ -10341,8 +10342,12 @@ def _resolve_lead_revert_status(
       * the lead is still exactly at the create-milestone status (sts06) — i.e.
         nothing advanced it further (another profile's submit, an officer
         manual change, fee payment, …), AND
-      * we know the status held BEFORE creation, and it differs from sts06
-        (a self-revert would be a no-op).
+      * we know the status held BEFORE creation, it differs from sts06 (a
+        self-revert would be a no-op), AND
+      * that prior status is NOT terminal/negative — deleting a draft must
+        never re-close a lead (e.g. a lost lead reopened to sts06 then a
+        draft created+deleted should stay at sts06, not regress to sts20/
+        "Đã ngừng tư vấn").
     """
     if has_other_profile:
         return None
@@ -10352,6 +10357,8 @@ def _resolve_lead_revert_status(
         return None
     if prev_consultation_status_id == _CREATE_MILESTONE_STATUS:
         return None
+    if prev_is_terminal_or_negative:
+        return None
     return prev_consultation_status_id
 
 
@@ -10359,7 +10366,7 @@ async def delete_profile(
     db: AsyncSession,
     profile_id: int,
     current_user: models.User,
-) -> Tuple[bool, Callable[[], Awaitable[None]]]:
+) -> Tuple[bool, Callable[[], Awaitable[None]], Optional[dict]]:
     """
     Delete AdmissionProfile (only when status='draft').
 
@@ -10387,10 +10394,13 @@ async def delete_profile(
         current_user: Current authenticated user
 
     Returns:
-        Tuple of (True, post_commit_callback). The callback removes the
-        orphaned uploaded files (best-effort) and MUST be awaited by the
-        router AFTER ``db.commit()`` — the profile_document rows cascade
-        away with the profile but their files on disk do not.
+        Tuple of (True, post_commit_callback, lead_revert_delta):
+        - post_commit_callback: removes the profile's upload dir (best-effort);
+          MUST be awaited by the router AFTER ``db.commit()``.
+        - lead_revert_delta: ``None``, or a dict
+          ``{old_status, new_status, old_stage, new_stage}`` when the lead's
+          status was reverted — the router uses it to dispatch
+          LEAD_STATUS_CHANGED post-commit.
 
     Raises:
         ResourceNotFoundError: Profile not found
@@ -10420,21 +10430,36 @@ async def delete_profile(
     lead = profile.lead
     lead_id = profile.lead_id
 
+    # Serialize concurrent deletes on the SAME lead. Without this, two
+    # simultaneous last-profile deletes each see the other profile still
+    # present (READ COMMITTED) → both skip the revert → lead stuck at sts06
+    # with zero profiles. Locking the lead row makes the count + revert
+    # decision below run one-at-a-time per lead.
+    await db.execute(
+        select(models.Lead.id).where(models.Lead.id == lead_id).with_for_update()
+    )
+
     # ==========================================================================
     # LEAD STATUS REVERT (conditional) + deletion consultation record
     # ==========================================================================
     # Creating a draft profile bumps the lead to sts06 "Đồng ý tư vấn" via the
-    # ``profile_created`` milestone. Deleting that draft should undo the bump —
-    # but ONLY when it is safe:
+    # ``profile_created`` milestone. Deleting that draft undoes the bump — but
+    # ONLY when it is provably safe:
     #   (a) the lead has NO other admission profile left, AND
-    #   (b) the lead is still exactly at the create-milestone status (sts06),
-    #       i.e. nothing advanced it further (another profile's submit, an
-    #       officer manual change, fee payment, etc.).
-    # Otherwise the lead state is preserved. Consultation history is always
-    # KEPT (it is real history); we only ADD a system record per the Golden
-    # Rule, plus a LeadStatusHistory row when a revert actually happens.
+    #   (b) the lead's MOST RECENT status change was THIS profile's create bump
+    #       (latest LeadStatusHistory row: new==sts06 + reason profile_created).
+    #       This one check rules out both mis-attribution traps: a lead already
+    #       at sts06 before creation (lead_agrees / manual) writes NO history
+    #       row on create, and any intervening status change makes the create
+    #       bump no longer the latest row — both ⇒ no revert, AND
+    #   (c) the pre-creation status is known, differs from sts06, and is NOT
+    #       terminal/negative (never re-close a lead by deleting a draft).
+    # Consultation history is always KEPT (real data); we only ADD a system
+    # record per the Golden Rule, plus a LeadStatusHistory row on revert.
     from ..core.status_mapping import sync_lead_status_from_consultation
     from .lead_service import _get_current_lead_state, _log_lead_state_change
+
+    _status_at_delete = lead.consultation_status_id
 
     _other_profile_count = await db.scalar(
         select(func.count())
@@ -10445,54 +10470,76 @@ async def delete_profile(
         )
     )
 
-    # Cheap-gate the history lookup: only query when the rule could possibly
-    # fire. The authoritative decision lives in _resolve_lead_revert_status,
-    # which re-checks these conditions on the values it is given.
+    # The pre-creation status is recoverable ONLY when the lead's most recent
+    # status change is this profile's create bump (sts06 also comes from
+    # lead_agrees / manual consultation, so we must not key on sts06 alone).
+    _latest_history = await db.scalar(
+        select(models.LeadStatusHistory)
+        .where(models.LeadStatusHistory.lead_id == lead_id)
+        .order_by(models.LeadStatusHistory.id.desc())
+        .limit(1)
+    )
     _prev_status_id = None
     if (
-        not _other_profile_count
-        and lead.consultation_status_id == _CREATE_MILESTONE_STATUS
+        _latest_history is not None
+        and _latest_history.new_consultation_status_id == _CREATE_MILESTONE_STATUS
+        and "profile_created" in (_latest_history.reason or "")
     ):
-        _bump = await db.scalar(
-            select(models.LeadStatusHistory)
-            .where(
-                models.LeadStatusHistory.lead_id == lead_id,
-                models.LeadStatusHistory.new_consultation_status_id
-                == _CREATE_MILESTONE_STATUS,
-            )
-            .order_by(models.LeadStatusHistory.id.desc())
-            .limit(1)
+        _prev_status_id = _latest_history.old_consultation_status_id
+
+    # Load the candidate target once (reused on apply) + flag terminal/negative
+    # so the policy helper can refuse to re-close a lead.
+    _target_cs = None
+    _prev_is_terminal_or_negative = False
+    if _prev_status_id and _prev_status_id != _CREATE_MILESTONE_STATUS:
+        _target_cs = await db.get(
+            models.ConsultationStatus,
+            _prev_status_id,
+            options=[selectinload(models.ConsultationStatus.stage)],
         )
-        _prev_status_id = _bump.old_consultation_status_id if _bump else None
+        if _target_cs is None:
+            _prev_status_id = None  # unknown status — cannot revert safely
+        else:
+            _outcome = getattr(
+                _target_cs.outcome_type, "value", _target_cs.outcome_type
+            )
+            _prev_is_terminal_or_negative = (
+                bool(_target_cs.is_final) or _outcome == "negative"
+            )
 
     _revert_target = _resolve_lead_revert_status(
         has_other_profile=bool(_other_profile_count),
         current_consultation_status_id=lead.consultation_status_id,
         prev_consultation_status_id=_prev_status_id,
+        prev_is_terminal_or_negative=_prev_is_terminal_or_negative,
     )
 
     reverted_status_id = None
-    if _revert_target:
-        _target_cs = await db.get(
-            models.ConsultationStatus,
-            _revert_target,
-            options=[selectinload(models.ConsultationStatus.stage)],
+    lead_revert_delta = None
+    if _revert_target and _target_cs is not None:
+        _old_state = _get_current_lead_state(lead)
+        _old_stage_id = lead.pipeline_stage_id
+        lead.consultation_status_id = _revert_target
+        lead.pipeline_stage_id = _target_cs.stage_id
+        sync_lead_status_from_consultation(lead, _target_cs)
+        _new_state = _get_current_lead_state(lead)
+        await _log_lead_state_change(
+            db=db,
+            lead=lead,
+            old_state=_old_state,
+            new_state=_new_state,
+            changed_by=current_user,
+            reason=f"Hoàn trạng thái sau khi xóa hồ sơ draft #{profile_id}",
         )
-        if _target_cs:
-            _old_state = _get_current_lead_state(lead)
-            lead.consultation_status_id = _revert_target
-            lead.pipeline_stage_id = _target_cs.stage_id
-            sync_lead_status_from_consultation(lead, _target_cs)
-            _new_state = _get_current_lead_state(lead)
-            await _log_lead_state_change(
-                db=db,
-                lead=lead,
-                old_state=_old_state,
-                new_state=_new_state,
-                changed_by=current_user,
-                reason=f"Hoàn trạng thái sau khi xóa hồ sơ draft #{profile_id}",
-            )
-            reverted_status_id = _revert_target
+        reverted_status_id = _revert_target
+        # Surfaced to the router so it dispatches LEAD_STATUS_CHANGED
+        # post-commit (lead pipeline subscribers must see the revert).
+        lead_revert_delta = {
+            "old_status": _status_at_delete,
+            "new_status": _revert_target,
+            "old_stage": _old_stage_id,
+            "new_stage": _target_cs.stage_id,
+        }
 
     if reverted_status_id:
         _deletion_note = (
@@ -10504,12 +10551,13 @@ async def delete_profile(
             f"[HỆ THỐNG] Hồ sơ xét tuyển đã bị xóa - Profile #{profile_id}"
         )
 
-    # Golden Rule: every admission event gets a consultation record. The record
-    # reflects the lead's CURRENT (possibly reverted) consultation status.
+    # Golden Rule: every admission event gets a consultation record. Stamp it
+    # with the status the lead held AT deletion time (pre-revert), so the
+    # timeline reflects the state when the action happened.
     system_consultation = models.Consultation(
         lead_id=lead_id,
         officer_id=current_user.id,
-        consultation_status_id=lead.consultation_status_id,
+        consultation_status_id=_status_at_delete,
         consultation_date=datetime.now(timezone.utc),
         method="system",
         notes=_deletion_note,
@@ -10524,7 +10572,7 @@ async def delete_profile(
         "Profile deletion consultation record created",
         lead_id=lead_id,
         profile_id=profile_id,
-        consultation_status_id=lead.consultation_status_id,
+        status_at_delete=_status_at_delete,
         reverted_status_id=reverted_status_id,
         actor_id=current_user.id,
     )
@@ -10538,20 +10586,7 @@ async def delete_profile(
         source="api",
     )
 
-    # Collect physical upload paths BEFORE the cascade removes the rows.
-    # ``profile_document.profile_id`` is ondelete=CASCADE, so the rows vanish
-    # with the profile; the files on disk must be cleaned up separately
-    # (post-commit, best-effort) to avoid orphaned uploads. Covers both
-    # path documents and priority_evidence uploads.
-    _doc_paths_result = await db.execute(
-        select(models.ProfileDocument.file_path).where(
-            models.ProfileDocument.profile_id == profile_id,
-            models.ProfileDocument.file_path.isnot(None),
-        )
-    )
-    orphaned_file_paths = [p for (p,) in _doc_paths_result.all() if p]
-
-    # Delete the profile
+    # Delete the profile (profile_document rows cascade via FK ondelete=CASCADE).
     await db.delete(profile)
     await db.flush()
 
@@ -10560,14 +10595,13 @@ async def delete_profile(
         profile_id=profile_id,
         lead_id=lead_id,
         user_id=current_user.id,
-        orphaned_files=len(orphaned_file_paths),
     )
 
     async def _post_commit_cleanup() -> None:
-        # Drop the uploaded files only after the delete is durably committed.
-        _remove_orphaned_document_files(orphaned_file_paths)
+        # Drop the whole upload dir only after the delete is durably committed.
+        _remove_profile_upload_dir(profile_id)
 
-    return True, _post_commit_cleanup
+    return True, _post_commit_cleanup, lead_revert_delta
 
 
 # ==============================================================================

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -4186,7 +4186,7 @@ async def create_profile(
         await _create_admission_milestone_consultation(
             db=db,
             lead=new_profile.lead,
-            event="profile_created",
+            event=_PROFILE_CREATED_EVENT,
             actor=current_user,
             profile_id=new_profile.id,
         )
@@ -10326,6 +10326,11 @@ def _remove_profile_upload_dir(profile_id: int) -> None:
 # sts06 and silently demote the lead.
 _CREATE_MILESTONE_STATUS = "sts06"
 
+# Admission milestone event that bumps a lead to _CREATE_MILESTONE_STATUS.
+# Shared by create_profile (fires the milestone) and delete_profile (detects it
+# in the latest LeadStatusHistory.reason) so a rename can't silently desync them.
+_PROFILE_CREATED_EVENT = "profile_created"
+
 
 def _resolve_lead_revert_status(
     has_other_profile: bool,
@@ -10458,15 +10463,23 @@ async def delete_profile(
     # record per the Golden Rule, plus a LeadStatusHistory row on revert.
     from ..core.status_mapping import sync_lead_status_from_consultation
     from .lead_service import _get_current_lead_state, _log_lead_state_change
+    from ..models.pipeline import OutcomeTypeEnum
 
     _status_at_delete = lead.consultation_status_id
 
-    _other_profile_count = await db.scalar(
+    # Only OTHER DRAFT profiles justify keeping the lead at the create milestone
+    # (sts06 ↔ status 'draft' in ADMISSION_TO_LEAD_STATUS_MAP). A submitted/
+    # approved/enrolled profile advanced the lead (caught by the latest-history
+    # check below), and a completed prior-year profile (create dedups per
+    # (lead_id, academic_year), so a re-engaged lead keeps old-year rows) is
+    # historical — neither should block the revert.
+    _other_draft_count = await db.scalar(
         select(func.count())
         .select_from(models.AdmissionProfile)
         .where(
             models.AdmissionProfile.lead_id == lead_id,
             models.AdmissionProfile.id != profile_id,
+            models.AdmissionProfile.status == "draft",
         )
     )
 
@@ -10483,7 +10496,7 @@ async def delete_profile(
     if (
         _latest_history is not None
         and _latest_history.new_consultation_status_id == _CREATE_MILESTONE_STATUS
-        and "profile_created" in (_latest_history.reason or "")
+        and _PROFILE_CREATED_EVENT in (_latest_history.reason or "")
     ):
         _prev_status_id = _latest_history.old_consultation_status_id
 
@@ -10492,23 +10505,19 @@ async def delete_profile(
     _target_cs = None
     _prev_is_terminal_or_negative = False
     if _prev_status_id and _prev_status_id != _CREATE_MILESTONE_STATUS:
-        _target_cs = await db.get(
-            models.ConsultationStatus,
-            _prev_status_id,
-            options=[selectinload(models.ConsultationStatus.stage)],
-        )
+        # Only columns (stage_id / is_final / outcome_type) are read below, so a
+        # bare db.get suffices — no need to eager-load the .stage relationship.
+        _target_cs = await db.get(models.ConsultationStatus, _prev_status_id)
         if _target_cs is None:
             _prev_status_id = None  # unknown status — cannot revert safely
         else:
-            _outcome = getattr(
-                _target_cs.outcome_type, "value", _target_cs.outcome_type
-            )
             _prev_is_terminal_or_negative = (
-                bool(_target_cs.is_final) or _outcome == "negative"
+                bool(_target_cs.is_final)
+                or _target_cs.outcome_type == OutcomeTypeEnum.negative
             )
 
     _revert_target = _resolve_lead_revert_status(
-        has_other_profile=bool(_other_profile_count),
+        has_other_profile=bool(_other_draft_count),
         current_consultation_status_id=lead.consultation_status_id,
         prev_consultation_status_id=_prev_status_id,
         prev_is_terminal_or_negative=_prev_is_terminal_or_negative,

--- a/Backend_FastAPI/tests/integration/test_delete_profile_revert.py
+++ b/Backend_FastAPI/tests/integration/test_delete_profile_revert.py
@@ -55,14 +55,16 @@ async def _seed_revert_statuses(db) -> None:
             db.add(models.PipelineStage(id=stage_id, name=name, order=order))
     await db.flush()
 
-    # id,      stage,    outcome,                   is_final
+    # (id, stage, outcome, is_final). Labels: sts03 Có nhu cầu tìm hiểu,
+    # sts04 Từ chối tư vấn (neg), sts05 Hẹn liên hệ lại, sts06 Đồng ý tư vấn
+    # (create target), sts07 Đã tiếp nhận, sts20 Đã ngừng tư vấn (terminal).
     rows = [
-        ("sts03", "stg02", OutcomeTypeEnum.neutral, False),   # Có nhu cầu tìm hiểu
-        ("sts04", "stg02", OutcomeTypeEnum.negative, False),  # Từ chối tư vấn (negative)
-        ("sts05", "stg02", OutcomeTypeEnum.neutral, False),   # Hẹn liên hệ lại
-        ("sts06", "stg02", OutcomeTypeEnum.positive, False),  # Đồng ý tư vấn (create target)
-        ("sts07", "stg03", OutcomeTypeEnum.neutral, False),   # Đã tiếp nhận hồ sơ
-        ("sts20", "stg02", OutcomeTypeEnum.negative, True),   # Đã ngừng tư vấn (terminal)
+        ("sts03", "stg02", OutcomeTypeEnum.neutral, False),
+        ("sts04", "stg02", OutcomeTypeEnum.negative, False),
+        ("sts05", "stg02", OutcomeTypeEnum.neutral, False),
+        ("sts06", "stg02", OutcomeTypeEnum.positive, False),
+        ("sts07", "stg03", OutcomeTypeEnum.neutral, False),
+        ("sts20", "stg02", OutcomeTypeEnum.negative, True),
     ]
     for sid, stage_id, outcome, is_final in rows:
         if await db.get(models.ConsultationStatus, sid) is None:
@@ -373,3 +375,81 @@ class TestDeleteProfileLeadRevert:
         assert lead.consultation_status_id == "sts07"
         assert delta is None
         await cleanup()
+
+    async def test_revert_not_blocked_by_old_year_completed_profile(
+        self, db, seeded_dependencies, officer_user, revert_statuses
+    ):
+        """P2-A: a re-engaged lead keeps a prior-year COMPLETED (non-draft)
+        profile. Deleting the new draft must STILL revert — only drafts map to
+        sts06, so an enrolled old-year profile must not count as 'other' and
+        block the revert."""
+        lead = await _make_lead(
+            db, seeded_dependencies["unit_id"], officer_user.id, "sts06", "stg02"
+        )
+        await _add_history(
+            db, lead.id, old_cs="sts03", new_cs="sts06",
+            reason=PROFILE_CREATED_REASON, user_id=officer_user.id,
+        )
+        old = await _make_draft(db, lead.id, academic_year=2025)
+        old.status = "enrolled"  # prior-year completed, no longer a draft
+        await db.flush()
+        draft = await _make_draft(db, lead.id, academic_year=2026)
+
+        ok, cleanup, delta = await admission_service.delete_profile(
+            db=db, profile_id=draft.id, current_user=officer_user
+        )
+
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.consultation_status_id == "sts03"  # reverted despite old profile
+        assert delta is not None
+        # the completed prior-year profile is untouched
+        assert await db.get(models.AdmissionProfile, old.id) is not None
+        await cleanup()
+
+    async def test_post_delete_fanout_survives_dispatch_rollback(
+        self, db, seeded_dependencies, officer_user, revert_statuses, monkeypatch
+    ):
+        """P2-B (incl. residual): the post-commit fanout snapshots every scalar
+        BEFORE the first safe_dispatch, so a dispatch that rolls back / expires
+        the session cannot break the second dispatch's payload/rooms or any
+        later read. The first dispatch here calls ``expire_all()`` — exactly
+        what ``safe_dispatch``'s ``rollback()`` does to loaded ORM instances; on
+        the pre-fix code the second payload would touch the expired lead →
+        MissingGreenlet → 500. The fanout lives in a request-free helper so it
+        needs no rate-limiter/Request machinery and the function-scoped rollback
+        keeps it isolated."""
+        from app.routers import admissions
+
+        lead = await _make_lead(
+            db, seeded_dependencies["unit_id"], officer_user.id, "sts06", "stg02"
+        )
+
+        calls = {"n": 0}
+
+        async def _fake_safe_dispatch(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                db.expire_all()  # mimic rollback() expiring loaded ORM attrs
+            return []
+
+        monkeypatch.setattr(admissions, "safe_dispatch", _fake_safe_dispatch)
+
+        # Must NOT raise even though the lead row is expired after the first
+        # dispatch — payload/rooms come from scalars snapshotted beforehand.
+        await admissions._emit_post_delete_events(
+            db,
+            profile_id=999999,
+            lead_id=lead.id,
+            lead_name="Snapshot Name",
+            lead_revert={
+                "old_status": "sts06",
+                "new_status": "sts03",
+                "old_stage": "stg02",
+                "new_stage": "stg02",
+            },
+            actor_id=officer_user.id,
+            actor_name="Officer X",
+        )
+
+        assert calls["n"] == 2  # APPLICATION_DELETED + LEAD_STATUS_CHANGED

--- a/Backend_FastAPI/tests/integration/test_delete_profile_revert.py
+++ b/Backend_FastAPI/tests/integration/test_delete_profile_revert.py
@@ -1,0 +1,375 @@
+"""Integration tests for ``delete_profile``'s lead-status revert DERIVATION.
+
+The pure-policy unit tests in ``tests/unit/test_delete_profile_file_cleanup.py``
+pin ``_resolve_lead_revert_status`` in isolation — they feed it
+``prev_consultation_status_id`` / ``prev_is_terminal_or_negative`` directly.
+What they do NOT cover is how ``delete_profile`` *derives* those values from
+``LeadStatusHistory``: the "most-recent row must be THIS profile's
+``profile_created`` bump" rule plus the terminal/negative guard. That
+derivation is exactly where the review's finding #1 (an independent ``sts06``
+being mis-attributed to profile creation and silently demoting the lead) lived.
+
+These tests drive the real service against the DB so the history lookup, the
+``"profile_created" in reason`` attribution, the other-profile gate, the
+terminal/negative guard, the returned revert-delta and the deletion-record
+stamping are all exercised end-to-end. ``delete_profile`` flushes but does not
+commit; the function-scoped ``db`` fixture rolls back per test.
+"""
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app import models
+from app.models.pipeline import OutcomeTypeEnum
+from app.services import admission_service
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# Mirrors the reason written by ``_create_admission_milestone_consultation``
+# (``reason=f"Admission event: {event}"`` with ``event="profile_created"``).
+# ``delete_profile`` keys the revert on ``"profile_created" in reason``.
+PROFILE_CREATED_REASON = "Admission event: profile_created"
+
+# Per-test sequence so leads/profiles get unique phone/email/citizen_id.
+_seq = 0
+
+
+def _next() -> int:
+    global _seq
+    _seq += 1
+    return _seq
+
+
+# ---------------------------------------------------------------------------
+# Seed: consultation statuses + stages the revert logic needs, with the
+# outcome_type / is_final flags set EXACTLY (the policy reads them).
+# ---------------------------------------------------------------------------
+async def _seed_revert_statuses(db) -> None:
+    for stage_id, name, order in (
+        ("stg02", "Đang tư vấn", 1002),
+        ("stg03", "Đã nộp hồ sơ", 1003),
+    ):
+        if await db.get(models.PipelineStage, stage_id) is None:
+            db.add(models.PipelineStage(id=stage_id, name=name, order=order))
+    await db.flush()
+
+    # id,      stage,    outcome,                   is_final
+    rows = [
+        ("sts03", "stg02", OutcomeTypeEnum.neutral, False),   # Có nhu cầu tìm hiểu
+        ("sts04", "stg02", OutcomeTypeEnum.negative, False),  # Từ chối tư vấn (negative)
+        ("sts05", "stg02", OutcomeTypeEnum.neutral, False),   # Hẹn liên hệ lại
+        ("sts06", "stg02", OutcomeTypeEnum.positive, False),  # Đồng ý tư vấn (create target)
+        ("sts07", "stg03", OutcomeTypeEnum.neutral, False),   # Đã tiếp nhận hồ sơ
+        ("sts20", "stg02", OutcomeTypeEnum.negative, True),   # Đã ngừng tư vấn (terminal)
+    ]
+    for sid, stage_id, outcome, is_final in rows:
+        if await db.get(models.ConsultationStatus, sid) is None:
+            db.add(
+                models.ConsultationStatus(
+                    id=sid,
+                    name=sid,
+                    color_code="#123456",
+                    stage_id=stage_id,
+                    outcome_type=outcome,
+                    is_final=is_final,
+                )
+            )
+    await db.flush()
+
+
+@pytest_asyncio.fixture
+async def revert_statuses(db):
+    await _seed_revert_statuses(db)
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+async def _make_lead(db, unit_id, officer_id, cs_id, stage_id):
+    n = _next()
+    lead = models.Lead(
+        full_name=f"Revert Lead {n}",
+        phone=f"09{n:08d}",
+        email=f"revert_{n}@test.com",
+        source="website",
+        unit_id=unit_id,
+        assigned_officer_id=officer_id,
+        consultation_status_id=cs_id,
+        pipeline_stage_id=stage_id,
+        consultation_count=1,
+        status="qualified",
+    )
+    db.add(lead)
+    await db.flush()
+    return lead
+
+
+async def _make_draft(db, lead_id, academic_year=2026):
+    n = _next()
+    profile = models.AdmissionProfile(
+        lead_id=lead_id,
+        status="draft",
+        citizen_id=f"{n:012d}",
+        version=1,
+        applied_rules={"min_gpa": 6.0, "mandatory_docs": []},
+        academic_year=academic_year,
+        full_name="Revert Applicant",
+        phone="0901234567",
+    )
+    db.add(profile)
+    await db.flush()
+    return profile
+
+
+async def _add_history(db, lead_id, *, old_cs, new_cs, reason, user_id,
+                       old_stage="stg02", new_stage="stg02"):
+    """Append a LeadStatusHistory row. Insertion order == id order, so the
+    LAST row added is the one ``delete_profile`` treats as 'most recent'.
+
+    ``new_status`` (legacy lead.status) is NOT NULL; the revert derivation
+    never reads it, so a valid placeholder is fine."""
+    db.add(
+        models.LeadStatusHistory(
+            lead_id=lead_id,
+            old_status="qualified",
+            new_status="qualified",
+            old_consultation_status_id=old_cs,
+            new_consultation_status_id=new_cs,
+            old_pipeline_stage_id=old_stage,
+            new_pipeline_stage_id=new_stage,
+            reason=reason,
+            changed_by_user_id=user_id,
+        )
+    )
+    await db.flush()
+
+
+async def _latest_history(db, lead_id):
+    return (
+        await db.execute(
+            select(models.LeadStatusHistory)
+            .where(models.LeadStatusHistory.lead_id == lead_id)
+            .order_by(models.LeadStatusHistory.id.desc())
+        )
+    ).scalars().first()
+
+
+async def _system_consultation(db, lead_id):
+    return (
+        await db.execute(
+            select(models.Consultation)
+            .where(
+                models.Consultation.lead_id == lead_id,
+                models.Consultation.method == "system",
+            )
+            .order_by(models.Consultation.id.desc())
+        )
+    ).scalars().first()
+
+
+# ===========================================================================
+# TESTS
+# ===========================================================================
+class TestDeleteProfileLeadRevert:
+    async def test_reverts_to_prev_when_create_bump_is_latest(
+        self, db, seeded_dependencies, officer_user, revert_statuses
+    ):
+        """Happy path: lead was sts03, profile creation bumped it to sts06 and
+        that bump is the most-recent history row → deleting the draft reverts
+        the lead to sts03 and surfaces the delta to the router."""
+        lead = await _make_lead(
+            db, seeded_dependencies["unit_id"], officer_user.id, "sts06", "stg02"
+        )
+        await _add_history(
+            db, lead.id, old_cs="sts03", new_cs="sts06",
+            reason=PROFILE_CREATED_REASON, user_id=officer_user.id,
+        )
+        profile = await _make_draft(db, lead.id)
+
+        ok, cleanup, delta = await admission_service.delete_profile(
+            db=db, profile_id=profile.id, current_user=officer_user
+        )
+
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.consultation_status_id == "sts03"
+        assert lead.pipeline_stage_id == "stg02"
+        # profile is gone
+        assert await db.get(models.AdmissionProfile, profile.id) is None
+        # delta surfaced so the router can dispatch LEAD_STATUS_CHANGED
+        assert delta == {
+            "old_status": "sts06",
+            "new_status": "sts03",
+            "old_stage": "stg02",
+            "new_stage": "stg02",
+        }
+        # a revert history row was written
+        latest = await _latest_history(db, lead.id)
+        assert latest.new_consultation_status_id == "sts03"
+        assert "Hoàn trạng thái" in (latest.reason or "")
+        # finding #9: deletion record stamped with status AT delete (sts06),
+        # NOT the reverted sts03
+        consult = await _system_consultation(db, lead.id)
+        assert consult is not None
+        assert consult.consultation_status_id == "sts06"
+        # best-effort cleanup callback is awaitable and never raises
+        await cleanup()
+
+    async def test_no_revert_when_sts06_not_from_profile(
+        self, db, seeded_dependencies, officer_user, revert_statuses
+    ):
+        """Finding #1: the lead reached sts06 independently (officer "Đồng ý
+        tư vấn" / lead_agrees), then a profile was created while ALREADY at
+        sts06 (so creation wrote no history row). Deleting the draft must NOT
+        demote the lead — the latest history row is not a profile_created bump."""
+        lead = await _make_lead(
+            db, seeded_dependencies["unit_id"], officer_user.id, "sts06", "stg02"
+        )
+        await _add_history(
+            db, lead.id, old_cs="sts03", new_cs="sts06",
+            reason="Admission event: lead_agrees", user_id=officer_user.id,
+        )
+        profile = await _make_draft(db, lead.id)
+
+        ok, cleanup, delta = await admission_service.delete_profile(
+            db=db, profile_id=profile.id, current_user=officer_user
+        )
+
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.consultation_status_id == "sts06"  # preserved, NOT sts03
+        assert delta is None
+        await cleanup()
+
+    async def test_no_revert_when_status_changed_after_create_bump(
+        self, db, seeded_dependencies, officer_user, revert_statuses
+    ):
+        """An intervening status change after the create bump makes the bump no
+        longer the latest row → no revert (the lead's later state is real)."""
+        lead = await _make_lead(
+            db, seeded_dependencies["unit_id"], officer_user.id, "sts06", "stg02"
+        )
+        # create bump first ...
+        await _add_history(
+            db, lead.id, old_cs="sts03", new_cs="sts06",
+            reason=PROFILE_CREATED_REASON, user_id=officer_user.id,
+        )
+        profile = await _make_draft(db, lead.id)
+        # ... then an officer re-touches the lead (newer, non-profile_created row)
+        await _add_history(
+            db, lead.id, old_cs="sts05", new_cs="sts06",
+            reason="Cập nhật thủ công trạng thái tư vấn", user_id=officer_user.id,
+        )
+
+        ok, cleanup, delta = await admission_service.delete_profile(
+            db=db, profile_id=profile.id, current_user=officer_user
+        )
+
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.consultation_status_id == "sts06"
+        assert delta is None
+        await cleanup()
+
+    async def test_no_revert_when_other_profile_exists(
+        self, db, seeded_dependencies, officer_user, revert_statuses
+    ):
+        """A second profile justifies the lead's sts06 → deleting one draft
+        leaves the lead untouched and the other profile intact."""
+        lead = await _make_lead(
+            db, seeded_dependencies["unit_id"], officer_user.id, "sts06", "stg02"
+        )
+        await _add_history(
+            db, lead.id, old_cs="sts03", new_cs="sts06",
+            reason=PROFILE_CREATED_REASON, user_id=officer_user.id,
+        )
+        p1 = await _make_draft(db, lead.id, academic_year=2026)
+        p2 = await _make_draft(db, lead.id, academic_year=2027)
+
+        ok, cleanup, delta = await admission_service.delete_profile(
+            db=db, profile_id=p1.id, current_user=officer_user
+        )
+
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.consultation_status_id == "sts06"
+        assert delta is None
+        assert await db.get(models.AdmissionProfile, p2.id) is not None
+        await cleanup()
+
+    async def test_no_revert_to_terminal_prev(
+        self, db, seeded_dependencies, officer_user, revert_statuses
+    ):
+        """Finding #2: a lost lead (sts20, terminal) reopened to sts06 by
+        creating a draft must NOT be re-closed to sts20 when the draft is
+        deleted — the revert refuses a terminal/negative target."""
+        lead = await _make_lead(
+            db, seeded_dependencies["unit_id"], officer_user.id, "sts06", "stg02"
+        )
+        await _add_history(
+            db, lead.id, old_cs="sts20", new_cs="sts06",
+            reason=PROFILE_CREATED_REASON, user_id=officer_user.id,
+        )
+        profile = await _make_draft(db, lead.id)
+
+        ok, cleanup, delta = await admission_service.delete_profile(
+            db=db, profile_id=profile.id, current_user=officer_user
+        )
+
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.consultation_status_id == "sts06"  # NOT re-closed to sts20
+        assert delta is None
+        await cleanup()
+
+    async def test_no_revert_to_negative_prev(
+        self, db, seeded_dependencies, officer_user, revert_statuses
+    ):
+        """A negative (but non-terminal) prior status (sts04 "Từ chối tư vấn")
+        must also be refused — deleting a draft never regresses a lead into a
+        negative consultation outcome."""
+        lead = await _make_lead(
+            db, seeded_dependencies["unit_id"], officer_user.id, "sts06", "stg02"
+        )
+        await _add_history(
+            db, lead.id, old_cs="sts04", new_cs="sts06",
+            reason=PROFILE_CREATED_REASON, user_id=officer_user.id,
+        )
+        profile = await _make_draft(db, lead.id)
+
+        ok, cleanup, delta = await admission_service.delete_profile(
+            db=db, profile_id=profile.id, current_user=officer_user
+        )
+
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.consultation_status_id == "sts06"
+        assert delta is None
+        await cleanup()
+
+    async def test_no_revert_when_lead_advanced_past_sts06(
+        self, db, seeded_dependencies, officer_user, revert_statuses
+    ):
+        """The lead has advanced past sts06 (e.g. another profile submitted →
+        sts07). The latest history row's new status is not sts06 → no revert."""
+        lead = await _make_lead(
+            db, seeded_dependencies["unit_id"], officer_user.id, "sts07", "stg03"
+        )
+        await _add_history(
+            db, lead.id, old_cs="sts06", new_cs="sts07",
+            reason="Admission event: profile_submitted", user_id=officer_user.id,
+            old_stage="stg02", new_stage="stg03",
+        )
+        profile = await _make_draft(db, lead.id)
+
+        ok, cleanup, delta = await admission_service.delete_profile(
+            db=db, profile_id=profile.id, current_user=officer_user
+        )
+
+        assert ok is True
+        await db.refresh(lead)
+        assert lead.consultation_status_id == "sts07"
+        assert delta is None
+        await cleanup()

--- a/Backend_FastAPI/tests/unit/test_delete_profile_file_cleanup.py
+++ b/Backend_FastAPI/tests/unit/test_delete_profile_file_cleanup.py
@@ -1,0 +1,136 @@
+"""Unit tests for the orphaned-file cleanup wired into ``delete_profile``.
+
+``profile_document.profile_id`` is ``ondelete=CASCADE`` so deleting a draft
+profile removes the rows, but the physical uploads were previously left on
+disk. ``delete_profile`` now returns a post-commit callback that drops those
+files via ``_remove_orphaned_document_files``.
+
+These tests pin the helper's best-effort contract — it must NEVER raise, even
+on a missing/None/undeletable path — so a future change can't silently turn
+file cleanup into a request-failing exception after the profile is already
+gone from the DB.
+"""
+from app.services.admission_service import (
+    _CREATE_MILESTONE_STATUS,
+    _remove_orphaned_document_files,
+    _resolve_lead_revert_status,
+)
+
+
+class TestRemoveOrphanedDocumentFiles:
+    def test_removes_existing_files(self, tmp_path):
+        f1 = tmp_path / "doc1.pdf"
+        f2 = tmp_path / "doc2.pdf"
+        f1.write_text("x")
+        f2.write_text("y")
+
+        _remove_orphaned_document_files([str(f1), str(f2)])
+
+        assert not f1.exists()
+        assert not f2.exists()
+
+    def test_missing_path_is_ignored(self, tmp_path):
+        missing = str(tmp_path / "nope.pdf")
+        # Must not raise even though the file does not exist.
+        _remove_orphaned_document_files([missing])
+
+    def test_none_and_empty_paths_ignored(self):
+        # None / "" entries (file_path is nullable) must be skipped silently.
+        _remove_orphaned_document_files([None, "", None])
+
+    def test_partial_failure_does_not_stop_others(self, tmp_path):
+        good = tmp_path / "good.pdf"
+        good.write_text("z")
+        # A directory cannot be removed by os.remove → OSError; it must be
+        # swallowed and the good file must still be deleted.
+        a_dir = tmp_path / "subdir"
+        a_dir.mkdir()
+
+        _remove_orphaned_document_files([str(a_dir), str(good)])
+
+        assert not good.exists()
+        assert a_dir.exists()  # directory left intact, error swallowed
+
+    def test_empty_list_noop(self):
+        # No paths → no-op, no raise.
+        _remove_orphaned_document_files([])
+
+
+class TestResolveLeadRevertStatus:
+    """Exhaustive policy tests for the lead-status revert decision when a
+    draft profile is deleted (the business edge case: deleting a profile must
+    not leave the lead stranded at sts06 'Đồng ý tư vấn' with no profile).
+
+    Pure function → every branch is covered cheaply without a DB. The revert
+    fires ONLY when all three conditions hold; any single failing condition
+    must preserve the lead (return None).
+    """
+
+    PREV = "sts04"  # a plausible pre-creation consultation status
+
+    def test_reverts_when_all_conditions_met(self):
+        assert (
+            _resolve_lead_revert_status(
+                has_other_profile=False,
+                current_consultation_status_id=_CREATE_MILESTONE_STATUS,
+                prev_consultation_status_id=self.PREV,
+            )
+            == self.PREV
+        )
+
+    def test_no_revert_when_other_profile_exists(self):
+        # Another profile justifies the lead's status → keep it.
+        assert (
+            _resolve_lead_revert_status(
+                has_other_profile=True,
+                current_consultation_status_id=_CREATE_MILESTONE_STATUS,
+                prev_consultation_status_id=self.PREV,
+            )
+            is None
+        )
+
+    def test_no_revert_when_lead_advanced_past_milestone(self):
+        # Lead moved beyond sts06 (e.g. sts07 submitted, sts09 approved, or an
+        # officer manual change) → do not regress it.
+        for advanced in ("sts07", "sts09", "sts13", "sts05"):
+            assert (
+                _resolve_lead_revert_status(
+                    has_other_profile=False,
+                    current_consultation_status_id=advanced,
+                    prev_consultation_status_id=self.PREV,
+                )
+                is None
+            ), f"Should not revert when lead is at {advanced}"
+
+    def test_no_revert_when_prev_status_unknown(self):
+        # No history of the pre-creation status → cannot safely revert.
+        assert (
+            _resolve_lead_revert_status(
+                has_other_profile=False,
+                current_consultation_status_id=_CREATE_MILESTONE_STATUS,
+                prev_consultation_status_id=None,
+            )
+            is None
+        )
+
+    def test_no_revert_when_prev_equals_milestone(self):
+        # A self-revert (sts06 → sts06) is a no-op; treat as no revert.
+        assert (
+            _resolve_lead_revert_status(
+                has_other_profile=False,
+                current_consultation_status_id=_CREATE_MILESTONE_STATUS,
+                prev_consultation_status_id=_CREATE_MILESTONE_STATUS,
+            )
+            is None
+        )
+
+    def test_no_revert_when_current_status_none(self):
+        # Defensive: a lead with no consultation status set is not at sts06.
+        assert (
+            _resolve_lead_revert_status(
+                has_other_profile=False,
+                current_consultation_status_id=None,
+                prev_consultation_status_id=self.PREV,
+            )
+            is None
+        )

--- a/Backend_FastAPI/tests/unit/test_delete_profile_file_cleanup.py
+++ b/Backend_FastAPI/tests/unit/test_delete_profile_file_cleanup.py
@@ -1,68 +1,60 @@
-"""Unit tests for the orphaned-file cleanup wired into ``delete_profile``.
+"""Unit tests for the post-delete cleanup + lead-status revert policy wired
+into ``delete_profile``.
 
-``profile_document.profile_id`` is ``ondelete=CASCADE`` so deleting a draft
-profile removes the rows, but the physical uploads were previously left on
-disk. ``delete_profile`` now returns a post-commit callback that drops those
-files via ``_remove_orphaned_document_files``.
+Two pure/low-level pieces are pinned here so the riskiest logic is covered
+without a DB:
 
-These tests pin the helper's best-effort contract — it must NEVER raise, even
-on a missing/None/undeletable path — so a future change can't silently turn
-file cleanup into a request-failing exception after the profile is already
-gone from the DB.
+1. ``_remove_profile_upload_dir`` — best-effort removal of a deleted profile's
+   ``uploads/admissions/{id}/`` directory (docs + staging + the dir). It runs
+   AFTER the delete commits, so it must NEVER raise — otherwise a successful
+   delete becomes a 500 and the router's realtime dispatch is skipped.
+
+2. ``_resolve_lead_revert_status`` — the pure policy deciding whether (and to
+   what) a lead's consultation status reverts when its last draft is deleted.
 """
 from app.services.admission_service import (
     _CREATE_MILESTONE_STATUS,
-    _remove_orphaned_document_files,
+    _remove_profile_upload_dir,
     _resolve_lead_revert_status,
 )
 
 
-class TestRemoveOrphanedDocumentFiles:
-    def test_removes_existing_files(self, tmp_path):
-        f1 = tmp_path / "doc1.pdf"
-        f2 = tmp_path / "doc2.pdf"
-        f1.write_text("x")
-        f2.write_text("y")
+class TestRemoveProfileUploadDir:
+    def test_removes_dir_with_docs_and_staging(self, tmp_path, monkeypatch):
+        prof_id = 4242
+        target = tmp_path / "uploads" / "admissions" / str(prof_id)
+        (target / "docs").mkdir(parents=True)
+        (target / "docs" / "hocba.pdf").write_text("x")
+        (target / ".staging.abc.pdf").write_text("y")  # staging temp file
+        monkeypatch.chdir(tmp_path)
 
-        _remove_orphaned_document_files([str(f1), str(f2)])
+        _remove_profile_upload_dir(prof_id)
 
-        assert not f1.exists()
-        assert not f2.exists()
+        assert not target.exists()  # docs + staging + dir all gone
 
-    def test_missing_path_is_ignored(self, tmp_path):
-        missing = str(tmp_path / "nope.pdf")
-        # Must not raise even though the file does not exist.
-        _remove_orphaned_document_files([missing])
+    def test_missing_dir_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # No uploads/ tree at all → must not raise.
+        _remove_profile_upload_dir(999999)
 
-    def test_none_and_empty_paths_ignored(self):
-        # None / "" entries (file_path is nullable) must be skipped silently.
-        _remove_orphaned_document_files([None, "", None])
+    def test_never_raises_even_if_rmtree_throws(self, monkeypatch):
+        # Pins the regression flagged in review: the helper must swallow ANY
+        # error (not just OSError) — e.g. a ValueError("embedded null byte").
+        def _boom(*args, **kwargs):
+            raise ValueError("embedded null byte")
 
-    def test_partial_failure_does_not_stop_others(self, tmp_path):
-        good = tmp_path / "good.pdf"
-        good.write_text("z")
-        # A directory cannot be removed by os.remove → OSError; it must be
-        # swallowed and the good file must still be deleted.
-        a_dir = tmp_path / "subdir"
-        a_dir.mkdir()
-
-        _remove_orphaned_document_files([str(a_dir), str(good)])
-
-        assert not good.exists()
-        assert a_dir.exists()  # directory left intact, error swallowed
-
-    def test_empty_list_noop(self):
-        # No paths → no-op, no raise.
-        _remove_orphaned_document_files([])
+        monkeypatch.setattr("shutil.rmtree", _boom)
+        # Must not propagate.
+        _remove_profile_upload_dir(123)
 
 
 class TestResolveLeadRevertStatus:
-    """Exhaustive policy tests for the lead-status revert decision when a
-    draft profile is deleted (the business edge case: deleting a profile must
-    not leave the lead stranded at sts06 'Đồng ý tư vấn' with no profile).
+    """Exhaustive policy tests for the lead-status revert decision when a draft
+    profile is deleted (the business edge case: deleting a profile must not
+    leave the lead stranded at sts06 with no profile — nor mis-attribute an
+    independent sts06, nor re-close a lead).
 
-    Pure function → every branch is covered cheaply without a DB. The revert
-    fires ONLY when all three conditions hold; any single failing condition
+    Revert fires ONLY when all conditions hold; any single failing condition
     must preserve the lead (return None).
     """
 
@@ -79,7 +71,6 @@ class TestResolveLeadRevertStatus:
         )
 
     def test_no_revert_when_other_profile_exists(self):
-        # Another profile justifies the lead's status → keep it.
         assert (
             _resolve_lead_revert_status(
                 has_other_profile=True,
@@ -90,8 +81,7 @@ class TestResolveLeadRevertStatus:
         )
 
     def test_no_revert_when_lead_advanced_past_milestone(self):
-        # Lead moved beyond sts06 (e.g. sts07 submitted, sts09 approved, or an
-        # officer manual change) → do not regress it.
+        # Lead moved beyond sts06 (submit/approve/fee/manual) → don't regress.
         for advanced in ("sts07", "sts09", "sts13", "sts05"):
             assert (
                 _resolve_lead_revert_status(
@@ -103,7 +93,8 @@ class TestResolveLeadRevertStatus:
             ), f"Should not revert when lead is at {advanced}"
 
     def test_no_revert_when_prev_status_unknown(self):
-        # No history of the pre-creation status → cannot safely revert.
+        # No recoverable pre-creation status (e.g. lead was already at sts06
+        # before creation, so the create milestone wrote no history row).
         assert (
             _resolve_lead_revert_status(
                 has_other_profile=False,
@@ -133,4 +124,29 @@ class TestResolveLeadRevertStatus:
                 prev_consultation_status_id=self.PREV,
             )
             is None
+        )
+
+    def test_no_revert_when_prev_is_terminal_or_negative(self):
+        # A lost lead (sts20 "Đã ngừng tư vấn", terminal/negative) reopened to
+        # sts06 then create+delete must NOT be re-closed by the delete.
+        assert (
+            _resolve_lead_revert_status(
+                has_other_profile=False,
+                current_consultation_status_id=_CREATE_MILESTONE_STATUS,
+                prev_consultation_status_id="sts20",
+                prev_is_terminal_or_negative=True,
+            )
+            is None
+        )
+
+    def test_reverts_to_non_terminal_prev(self):
+        # Sanity: the terminal flag defaulting False still allows normal revert.
+        assert (
+            _resolve_lead_revert_status(
+                has_other_profile=False,
+                current_consultation_status_id=_CREATE_MILESTONE_STATUS,
+                prev_consultation_status_id="sts03",
+                prev_is_terminal_or_negative=False,
+            )
+            == "sts03"
         )

--- a/Backend_FastAPI/tests/unit/test_delete_profile_file_cleanup.py
+++ b/Backend_FastAPI/tests/unit/test_delete_profile_file_cleanup.py
@@ -12,11 +12,15 @@ without a DB:
 2. ``_resolve_lead_revert_status`` — the pure policy deciding whether (and to
    what) a lead's consultation status reverts when its last draft is deleted.
 """
+import pytest
+
 from app.services.admission_service import (
     _CREATE_MILESTONE_STATUS,
     _remove_profile_upload_dir,
     _resolve_lead_revert_status,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class TestRemoveProfileUploadDir:


### PR DESCRIPTION
## Tóm tắt
Hardening luồng **xóa hồ sơ tuyển sinh draft** (`delete_profile`) + escape search PII. Gồm 1 edge case nghiệp vụ (lead kẹt trạng thái sau khi xóa hồ sơ) + các fix correctness từ 2 vòng review.

## Thay đổi chính
- **QW-A — escape LIKE search PII** (`admission_repository`): 2 site search hồ sơ (`Lead.full_name/email` + `AdmissionProfile.citizen_id`) nay escape `% _` qua `escape_like_pattern` (chống wildcard-injection/DoS). 3 repo khác + lead đã xong ở #409/#413.
- **`delete_profile` — dọn file vật lý**: `profile_document` cascade-xóa theo FK nhưng file trên đĩa bị orphan → `shutil.rmtree(uploads/admissions/{id})` post-commit best-effort (dọn cả docs + `.staging` + thư mục).
- **`delete_profile` — revert trạng thái lead (edge case)**: tạo hồ sơ draft đẩy lead lên `sts06` "Đồng ý tư vấn"; xóa hồ sơ nay **hoàn lại trạng thái trước** — CHỈ khi an toàn:
  - history row **mới nhất** của lead đúng là bump `profile_created`→sts06 (loại mis-attribution khi lead đã sts06 sẵn do `lead_agrees`/thủ công, + loại thay đổi xen giữa);
  - lead **không còn hồ sơ draft khác** (`status='draft'`; hồ sơ năm cũ enrolled/đã nộp không chặn — multi-year dedup theo `(lead_id, academic_year)`);
  - trạng thái trước **không terminal/negative** (không re-close lead).
  - Giữ toàn bộ lịch sử tư vấn; thêm consultation record (đóng dấu status **tại thời điểm xóa**) + `LeadStatusHistory` audit.
- **Router post-commit hardening**: tách fanout thành helper request-free `_emit_post_delete_events`; **snapshot mọi scalar trước `safe_dispatch` đầu** (dispatch fail → rollback expire ORM → tránh deref expired gây 500 sau commit); dispatch `LEAD_STATUS_CHANGED` khi revert (parity).

## Kiểm thử
- **Unit 11** (`tests/unit/test_delete_profile_file_cleanup.py`): policy revert (exhaustive: mis-attribution/terminal/negative/other-draft/self-revert) + rmtree never-raise.
- **Integration 9** (`tests/integration/test_delete_profile_revert.py`): derivation end-to-end trên DB thật — latest-history + reason match + guard + cổng other-draft + revert-delta + stamp pre-revert + P2-A (enrolled năm cũ không chặn) + P2-B (dispatch rollback → fanout vẫn xong).
- Đã wire cả 2 vào `backend-test.yml` (Tier 1 + Tier 4) → chạy trong per-PR gate.
- **20/20 PASS** local; flake8 vùng sửa sạch; router/service import sạch.

## Verify
- `/code-review` (max effort, multi-agent) + **HARD GATE review độc lập** (truy vết từng deref, chạy lại test/lint/import) — PASS.
- Browser smoke E2E (dev): tạo hồ sơ → lead sts06 → xóa → revert đúng; kịch bản lead-đã-sts06 → giữ nguyên.

🤖 Generated with [Claude Code](https://claude.com/claude-code)