### PR TITLE
feat(admissions): học phí hồ sơ đa nguyện vọng có đúng 1 NV + fix resolver ngành theo NV trúng tuyển

### DIFF
--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -99,6 +99,49 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         """
         super().__init__(db, models.AdmissionProfile)
 
+    async def get_by_id_for_update(
+        self,
+        profile_id: int,
+        *,
+        populate_existing: bool = False,
+        with_choices: bool = False,
+    ) -> Optional[models.AdmissionProfile]:
+        """Lock the AdmissionProfile row (``SELECT ... FOR UPDATE``).
+
+        Serializes the "fee sees N choices" vs "add/delete/reorder choice"
+        race: both fee creation (``FeeCalculationService.calculate_fee``) and
+        every NV-structure mutation acquire THIS row lock first, then
+        re-validate state under it within the same transaction.
+
+        ``lead`` is ``selectinload``-ed (a separate SELECT) instead of the
+        mapper-default ``lazy="joined"`` so the locking query carries no OUTER
+        JOIN — Postgres rejects ``FOR UPDATE`` on the nullable side of an outer
+        join. ``with_choices`` adds a ``selectinload`` of ``choices`` so the
+        caller can re-check ``is_fee_eligible`` under the lock.
+
+        Args:
+            profile_id: AdmissionProfile ID.
+            populate_existing: overwrite any in-session instance's attributes
+                from the freshly-locked row (otherwise the identity-map copy
+                loaded by a non-locking IDOR dependency stays stale on re-check).
+            with_choices: eager-load ``choices`` for an under-lock eligibility
+                re-check.
+        """
+        query = (
+            select(models.AdmissionProfile)
+            .where(models.AdmissionProfile.id == profile_id)
+            .options(selectinload(models.AdmissionProfile.lead))
+            .with_for_update(of=models.AdmissionProfile)
+        )
+        if with_choices:
+            query = query.options(
+                selectinload(models.AdmissionProfile.choices)
+            )
+        if populate_existing:
+            query = query.execution_options(populate_existing=True)
+        result = await self.db.execute(query)
+        return result.scalar_one_or_none()
+
     async def get_filtered(
         self,
         skip: int = 0,

--- a/Backend_FastAPI/app/repositories/fee_repository.py
+++ b/Backend_FastAPI/app/repositories/fee_repository.py
@@ -118,6 +118,26 @@ class FeeRepository(BaseRepository[Fee]):
         result = await self.db.execute(query)
         return list(result.scalars().all())
 
+    async def has_active_tuition_fee(self, profile_id: int) -> bool:
+        """True if a NON-cancelled tuition fee exists for the profile.
+
+        Used by the choice-mutation finance lock. Excludes ``cancelled`` — a
+        cancelled fee no longer commits the profile to a ngành, so it must not
+        freeze NV edits (otherwise a prepay→cancel→rollback profile is locked
+        out of editing its own NVs forever). EXISTS-style (``LIMIT 1``, id only)
+        so it does not hydrate fee children / discounts / invoices.
+        """
+        result = await self.db.execute(
+            select(Fee.id)
+            .where(
+                Fee.admission_profile_id == profile_id,
+                Fee.fee_type == "tuition",
+                Fee.status != "cancelled",
+            )
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+
     async def sum_paid_amount_by_profile(self, profile_id: int) -> Decimal:
         """Sum of ``paid_amount`` across all fees of an admission profile.
 

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -23,7 +23,6 @@ from datetime import date, timedelta
 from decimal import Decimal
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
@@ -279,61 +278,25 @@ async def calculate_fee(
         # only the profile lookup is unscoped now.
         unit_id = finance_scope_unit_id(current_user)
 
-        # Resolve base_amount + discount_policy_ids depending on fee type.
-        # For tuition: service looks up amount from offering_semester_tuition
-        # (PR 3 — ADR-002). Router only needs discount policy IDs.
-        # For non-tuition: keep existing path via academic_info.tuition_fee_per_year.
+        # Resolve academic_info via the SHARED resolver (single source of truth
+        # with FeeCalculationService) so the discount ngành matches the ngành the
+        # service prices the tuition against — handles legacy single-path AND
+        # multi-NV (admitted-choice / single-choice). For tuition the service
+        # looks up the amount from offering_semester_tuition (PR 3 — ADR-002);
+        # the router only needs discount policy IDs. For non-tuition the base
+        # amount still comes from academic_info.tuition_fee_per_year.
+        from app.services.fee_calculation_service import resolve_fee_academic_info
+
+        academic_info = await resolve_fee_academic_info(db, profile)
+        discount_policy_ids = list(academic_info.applied_discount_policy_ids or [])
+
         base_amount = Decimal("0")
-        discount_policy_ids: list = []
-        academic_info = None
-
         if data.fee_type != FeeTypeEnum.tuition:
-            # Non-tuition: existing path — look up from academic_info
-            oac = profile.offering_admission_config
-            if oac and oac.academic_info:
-                academic_info = oac.academic_info
-
-            if not academic_info and profile.applied_rules:
-                ai_id = profile.applied_rules.get("academic_info_id")
-                if ai_id:
-                    from app.models.offering_academic_info import OfferingAcademicInfo
-                    ai_result = await db.execute(
-                        sa.select(OfferingAcademicInfo).where(
-                            OfferingAcademicInfo.id == int(ai_id)
-                        )
-                    )
-                    academic_info = ai_result.scalars().first()
-
-            if academic_info:
-                base_amount = academic_info.tuition_fee_per_year or Decimal("0")
-
+            base_amount = academic_info.tuition_fee_per_year or Decimal("0")
             if base_amount <= 0:
                 raise BadRequest(
                     "Cannot calculate fee: No fee amount configured for this offering"
                 )
-
-            if academic_info:
-                discount_policy_ids = academic_info.applied_discount_policy_ids or []
-        else:
-            # Tuition: service will look up amount from offering_semester_tuition.
-            # Router still resolves discount policy IDs from academic_info.
-            oac = profile.offering_admission_config
-            if oac and oac.academic_info:
-                academic_info = oac.academic_info
-
-            if not academic_info and profile.applied_rules:
-                ai_id = profile.applied_rules.get("academic_info_id")
-                if ai_id:
-                    from app.models.offering_academic_info import OfferingAcademicInfo
-                    ai_result = await db.execute(
-                        sa.select(OfferingAcademicInfo).where(
-                            OfferingAcademicInfo.id == int(ai_id)
-                        )
-                    )
-                    academic_info = ai_result.scalars().first()
-
-            if academic_info:
-                discount_policy_ids = academic_info.applied_discount_policy_ids or []
 
         # Calculate fee
         fee, post_commit = await fee_service.calculate_fee(

--- a/Backend_FastAPI/app/services/admission_choice_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_service.py
@@ -551,20 +551,22 @@ class AdmissionChoiceService:
     async def _assert_no_finance_lock(
         self, profile: AdmissionProfile, *, action: str
     ) -> None:
-        """Freeze NV-structure edits once ANY tuition fee exists for the profile.
+        """Freeze NV-structure edits while a NON-cancelled tuition fee exists.
 
-        ``cancel_fee`` only flips status→cancelled; the tuition partial-unique
-        index ``uq_fee_profile_type_semester_tuition`` + ``check_duplicate``
-        ignore status, so a cancelled HK1 still holds the
-        ``(profile, tuition, semester_no)`` slot and the ngành cannot be
-        re-priced in-flow. There is no fee supersede/recreate flow, so ANY
-        tuition row (incl. cancelled) freezes add/delete/reorder/score-replace —
-        finance changes must go through a separate void/supersede process.
+        A live tuition fee pins the ngành (changing NVs would orphan / mis-price
+        it). A ``cancelled`` fee voids that obligation, so it must NOT freeze NV
+        edits — otherwise a prepay→``cancel_fee``→rollback (T17) profile would be
+        locked out of editing its own NVs forever (``cancel_fee`` keeps the row;
+        there is no fee delete/supersede flow). Hence only non-cancelled tuition
+        fees freeze add/delete/reorder/score-replace.
+
+        Residual (tracked as debt): re-creating an HK1 fee AFTER a cancel is
+        still blocked by ``check_duplicate`` + the partial-unique index
+        ``uq_fee_profile_type_semester_tuition`` (both ignore status, so the
+        cancelled row keeps the ``(profile, tuition, semester_no)`` slot) — that
+        needs a dedicated void/supersede flow.
         """
-        tuition_fees = await self.fee_repo.get_by_profile_id(
-            profile.id, fee_type="tuition"
-        )
-        if tuition_fees:
+        if await self.fee_repo.has_active_tuition_fee(profile.id):
             raise BusinessRuleViolation(
                 f"Hồ sơ đã phát sinh học phí, không thể {action}; "
                 "cần xử lý tài chính bằng quy trình riêng."

--- a/Backend_FastAPI/app/services/admission_choice_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_service.py
@@ -40,6 +40,8 @@ from app.repositories.admission_profile_choice_repository import (
     AdmissionProfileChoiceRepository,
 )
 from app.repositories.admission_path_repository import AdmissionPathRepository
+from app.repositories.admission_repository import AdmissionRepository
+from app.repositories.fee_repository import FeeRepository
 from app.services.activity_service import log_activity
 from app.services.system_config_service import SystemConfigService
 from app.utils.admission_round_guards import assert_round_open
@@ -77,6 +79,8 @@ class AdmissionChoiceService:
         self.choice_repo = AdmissionProfileChoiceRepository(db)
         self.path_repo = AdmissionPathRepository(db)
         self.sysconfig = SystemConfigService(db)
+        self.admission_repo = AdmissionRepository(db)
+        self.fee_repo = FeeRepository(db)
 
     async def add_choice(
         self,
@@ -103,6 +107,14 @@ class AdmissionChoiceService:
             BusinessRuleViolation: violation any precheck
             ResourceNotFoundError: path/config not found
         """
+        # ============================================================
+        # Finance lock: lock the profile row FIRST (the same row
+        # calculate_fee locks) then freeze NV edits if a tuition fee already
+        # exists. Serializes "fee sees N choices" vs add-NV; see helpers.
+        # ============================================================
+        await self._lock_profile(profile)
+        await self._assert_no_finance_lock(profile, action="thêm nguyện vọng")
+
         # ============================================================
         # Precheck 1: uses_choice_engine flag — Phase 3 gate
         # ============================================================
@@ -323,6 +335,8 @@ class AdmissionChoiceService:
         (draft / revision_requested) leaves no forensic record for a
         "where did NV 3 go?" complaint months later.
         """
+        await self._lock_profile(profile)
+        await self._assert_no_finance_lock(profile, action="xoá nguyện vọng")
         self._assert_choice_editable(profile, action="xoá nguyện vọng")
 
         # Snapshot the row + score children BEFORE the cascade delete so
@@ -399,6 +413,8 @@ class AdmissionChoiceService:
           410). Load round qua choice.admission_path_id (lazy add — single
           extra query, paths này low-traffic vs add_choice).
         """
+        await self._lock_profile(profile)
+        await self._assert_no_finance_lock(profile, action="đổi thứ tự nguyện vọng")
         self._assert_choice_editable(profile, action="đổi thứ tự nguyện vọng")
 
         round_obj = await self.choice_repo.get_round_by_path_id(
@@ -459,6 +475,8 @@ class AdmissionChoiceService:
         update_choice_display_order — load round qua admission_path_id
         + assert open. RoundClosedError → 410.
         """
+        await self._lock_profile(profile)
+        await self._assert_no_finance_lock(profile, action="cập nhật điểm nguyện vọng")
         self._assert_choice_editable(profile, action="cập nhật điểm nguyện vọng")
 
         round_obj = await self.choice_repo.get_round_by_path_id(
@@ -515,6 +533,41 @@ class AdmissionChoiceService:
                 f"Không thể {action} khi hồ sơ ở trạng thái "
                 f"'{profile.status}'. Chỉ cho phép khi 'draft' hoặc "
                 f"'revision_requested'."
+            )
+
+    async def _lock_profile(self, profile: AdmissionProfile) -> None:
+        """Acquire the AdmissionProfile row lock + refresh in-session attrs.
+
+        Serializes NV-structure mutations against fee creation, which locks the
+        SAME row first (``FeeCalculationService.calculate_fee``).
+        ``populate_existing`` overwrites the (non-locking) IDOR-loaded instance
+        so the finance-lock + status re-checks read committed state under the
+        lock rather than a stale identity-map copy.
+        """
+        await self.admission_repo.get_by_id_for_update(
+            profile.id, populate_existing=True
+        )
+
+    async def _assert_no_finance_lock(
+        self, profile: AdmissionProfile, *, action: str
+    ) -> None:
+        """Freeze NV-structure edits once ANY tuition fee exists for the profile.
+
+        ``cancel_fee`` only flips status→cancelled; the tuition partial-unique
+        index ``uq_fee_profile_type_semester_tuition`` + ``check_duplicate``
+        ignore status, so a cancelled HK1 still holds the
+        ``(profile, tuition, semester_no)`` slot and the ngành cannot be
+        re-priced in-flow. There is no fee supersede/recreate flow, so ANY
+        tuition row (incl. cancelled) freezes add/delete/reorder/score-replace —
+        finance changes must go through a separate void/supersede process.
+        """
+        tuition_fees = await self.fee_repo.get_by_profile_id(
+            profile.id, fee_type="tuition"
+        )
+        if tuition_fees:
+            raise BusinessRuleViolation(
+                f"Hồ sơ đã phát sinh học phí, không thể {action}; "
+                "cần xử lý tài chính bằng quy trình riêng."
             )
 
     async def _snapshot_and_store_scores(

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -73,6 +73,141 @@ def is_hk1_cleared(
     return False
 
 
+def _academic_info_of_choice(choice: "models.AdmissionProfileChoice") -> Any:
+    """OfferingAcademicInfo behind a choice's admission_path (or None).
+
+    Reads only attributes the caller eager-loaded (``admission_path`` →
+    ``academic_info``); returns None on an incomplete chain instead of
+    triggering a lazy-load (MissingGreenlet in async).
+    """
+    path = getattr(choice, "admission_path", None)
+    if path is None:
+        return None
+    return getattr(path, "academic_info", None)
+
+
+async def resolve_fee_academic_info(
+    db: AsyncSession,
+    profile: "models.AdmissionProfile",
+) -> Any:
+    """Resolve the OfferingAcademicInfo a fee must be priced against.
+
+    SINGLE SOURCE OF TRUTH shared by ``routers/fees.py`` (discount policy IDs +
+    non-tuition base amount) and ``FeeCalculationService`` (tuition amount
+    lookup), so the ngành used for the amount, the discount and the eligibility
+    gate never drift apart.
+
+    The choice engine stores the ngành PER CHOICE; ``evaluate_cascade`` writes
+    only ``choice.decision`` at publish — it does NOT update
+    ``profile.offering_admission_config_id`` / ``applied_rules``. Resolving from
+    the profile snapshot would therefore price a multi-NV admit against NV gốc
+    (NV1), not the NV actually admitted. So for choice-engine profiles we
+    resolve from the choices themselves:
+
+      * exactly one choice ``decision == "admitted"`` → that choice's ngành
+        (post-publish — the correct admitted ngành; fixes the snapshot bug),
+      * more than one admitted → fail-closed (corrupt data: the cascade admits
+        at most one NV — never guess),
+      * not yet published + exactly one choice → that single choice's ngành
+        (prepay / giữ chỗ at ``submitted`` — mirrors ``is_fee_eligible``),
+      * otherwise (≥2 pending, or zero choices) → BadRequest.
+
+    Legacy single-path profiles resolve from the profile snapshot, in order:
+    eager-loaded ``offering_admission_config.academic_info`` (read via
+    ``__dict__`` to avoid a lazy-load) → an OAC lookup by
+    ``offering_admission_config_id`` (when the relationship is not eager-loaded,
+    e.g. under the fee-create lock that loads only lead + choices) →
+    ``applied_rules['academic_info_id']``. Choice-engine profiles never fall
+    through to this path.
+    """
+    if getattr(profile, "uses_choice_engine", False):
+        stmt = (
+            select(models.AdmissionProfileChoice)
+            .where(
+                models.AdmissionProfileChoice.admission_profile_id == profile.id
+            )
+            .options(
+                selectinload(
+                    models.AdmissionProfileChoice.admission_path
+                ).selectinload(models.AdmissionPath.academic_info)
+            )
+            .order_by(models.AdmissionProfileChoice.display_order)
+        )
+        choices = list((await db.execute(stmt)).scalars().all())
+        admitted = [c for c in choices if c.decision == "admitted"]
+        if len(admitted) > 1:
+            raise BadRequest(
+                "Dữ liệu lỗi: hồ sơ có nhiều hơn 1 nguyện vọng trúng tuyển — "
+                "không thể xác định ngành để tính học phí."
+            )
+        if len(admitted) == 1:
+            chosen = admitted[0]
+        elif len(choices) == 1:
+            chosen = choices[0]
+        else:
+            # 0 choices (degenerate / corrupt) OR ≥2 still pending: the ngành is
+            # NOT determinable. FAIL CLOSED — a choice-engine profile must NEVER
+            # fall back to the profile snapshot here, which could price a
+            # multi-NV profile against the wrong (NV gốc) ngành. This is the
+            # exact wrong-ngành case the fee gate exists to prevent.
+            raise BadRequest(
+                "Hồ sơ đa nguyện vọng chưa xác định được ngành để tính học phí "
+                "(chưa có nguyện vọng, hoặc nhiều nguyện vọng chưa công bố kết "
+                "quả). Cần công bố kết quả trước."
+            )
+        academic_info = _academic_info_of_choice(chosen)
+        if academic_info is None:
+            raise BadRequest(
+                "Không tìm được thông tin tuyển sinh (academic_info) cho "
+                "nguyện vọng đã chọn."
+            )
+        return academic_info
+
+    # Legacy single-path snapshot. Choice-engine profiles NEVER reach here —
+    # they resolve from choices or fail closed above.
+    oac = profile.__dict__.get("offering_admission_config")
+    if oac is not None and oac.__dict__.get("academic_info") is not None:
+        return oac.__dict__["academic_info"]
+    # OAC relationship not eager-loaded (the fee-create lock loads only lead +
+    # choices) — resolve the "modern" OAC path by its scalar FK so a direct
+    # service call / fresh session still works when applied_rules lacks
+    # academic_info_id (preserves the pre-existing Step-1 OAC behaviour).
+    oac_id = getattr(profile, "offering_admission_config_id", None)
+    if oac_id is not None:
+        academic_info = (
+            await db.execute(
+                select(models.OfferingAcademicInfo)
+                .join(
+                    models.OfferingAdmissionConfig,
+                    models.OfferingAdmissionConfig.academic_info_id
+                    == models.OfferingAcademicInfo.id,
+                )
+                .where(models.OfferingAdmissionConfig.id == oac_id)
+            )
+        ).scalars().first()
+        if academic_info is not None:
+            return academic_info
+
+    applied = profile.applied_rules or {}
+    ai_id = applied.get("academic_info_id")
+    if ai_id is not None:
+        academic_info = (
+            await db.execute(
+                select(models.OfferingAcademicInfo).where(
+                    models.OfferingAcademicInfo.id == int(ai_id)
+                )
+            )
+        ).scalars().first()
+        if academic_info is not None:
+            return academic_info
+
+    raise BadRequest(
+        "Không tìm được thông tin tuyển sinh cho hồ sơ này. "
+        "Profile thiếu cả offering_admission_config lẫn "
+        "applied_rules.academic_info_id."
+    )
+
+
 class FeeCalculationService:
     """
     Service for fee calculation and lifecycle management.
@@ -97,26 +232,15 @@ class FeeCalculationService:
     async def _resolve_academic_info_id(
         self, profile: models.AdmissionProfile,
     ) -> int:
-        """Resolve academic_info_id from profile via 2-step fallback.
+        """Resolve academic_info_id for the tuition-amount lookup.
 
-        Step 1: profile.offering_admission_config.academic_info_id (modern)
-        Step 2: profile.applied_rules["academic_info_id"] (legacy, matches
-                current fees.py:203-211)
+        Delegates to the shared module-level ``resolve_fee_academic_info``
+        (single source of truth with ``routers/fees.py``) and returns its id.
+        Handles legacy single-path AND choice-engine (admitted-choice /
+        single-choice) profiles — see that resolver's docstring.
         """
-        oac = getattr(profile, "offering_admission_config", None)
-        if oac is not None and getattr(oac, "academic_info_id", None):
-            return oac.academic_info_id
-
-        applied = profile.applied_rules or {}
-        ai_id = applied.get("academic_info_id")
-        if ai_id is not None:
-            return int(ai_id)
-
-        raise BadRequest(
-            "Không tìm được thông tin tuyển sinh cho hồ sơ này. "
-            "Profile thiếu cả offering_admission_config lẫn "
-            "applied_rules.academic_info_id."
-        )
+        academic_info = await resolve_fee_academic_info(self.db, profile)
+        return academic_info.id
 
     async def _lookup_semester_tuition_amount(
         self, profile: models.AdmissionProfile, semester_no: int,
@@ -192,10 +316,38 @@ class FeeCalculationService:
         elif fee_type != FeeTypeEnum.tuition:
             semester_no = None
 
-        # Validate profile exists and is accessible
-        profile = await self._get_profile(admission_profile_id, unit_id)
+        # Profile-first row lock — serialize vs choice mutation. Acquiring the
+        # AdmissionProfile row lock BEFORE reading choices closes the race where
+        # another request adds/removes a NV between the router's authz check and
+        # this fee insert. ``with_choices`` loads choices so the eligibility
+        # re-check below counts the committed NVs under the lock; choice
+        # mutations acquire this SAME row lock first (admission_choice_service).
+        from app.repositories.admission_repository import AdmissionRepository
+        from app.utils.admission_status import is_fee_eligible
+
+        admission_repo = AdmissionRepository(self.db)
+        profile = await admission_repo.get_by_id_for_update(
+            admission_profile_id, populate_existing=True, with_choices=True
+        )
         if not profile:
             raise ResourceNotFoundError("Admission profile not found")
+
+        # IDOR parity with the previous _get_profile(unit_id) filter: the router
+        # already authorized, but keep the service-layer unit scope as
+        # defense-in-depth.
+        if unit_id is not None:
+            lead = profile.__dict__.get("lead")
+            if lead is None or lead.unit_id != unit_id:
+                raise ResourceNotFoundError("Admission profile not found")
+
+        # Re-validate the fee-eligible STATE under the lock. A multi-NV profile
+        # that gained a 2nd NV — or left a fee-eligible state — since the router
+        # check now fails closed instead of pricing the wrong ngành.
+        if not is_fee_eligible(profile):
+            raise BadRequest(
+                "Hồ sơ không ở trạng thái cho phép tạo học phí (đa nguyện vọng "
+                "chưa công bố kết quả, hoặc nguyện vọng đã thay đổi)."
+            )
 
         # For tuition: look up canonical amount from offering_semester_tuition
         if fee_type == FeeTypeEnum.tuition:
@@ -612,6 +764,10 @@ class FeeCalculationService:
                 selectinload(models.AdmissionProfile.lead),
                 selectinload(models.AdmissionProfile.offering_admission_config)
                 .selectinload(models.OfferingAdmissionConfig.academic_info),
+                # Needed by _fee_calc_authorized → is_fee_eligible to count NVs
+                # (multi-NV single-choice prepay gate). Without this the gate
+                # reads __dict__['choices'] as unset and fails closed.
+                selectinload(models.AdmissionProfile.choices),
             )
             .where(models.AdmissionProfile.id == profile_id)
         )

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -76,9 +76,13 @@ def is_hk1_cleared(
 def _academic_info_of_choice(choice: "models.AdmissionProfileChoice") -> Any:
     """OfferingAcademicInfo behind a choice's admission_path (or None).
 
-    Reads only attributes the caller eager-loaded (``admission_path`` →
-    ``academic_info``); returns None on an incomplete chain instead of
-    triggering a lazy-load (MissingGreenlet in async).
+    Reads ``admission_path`` → ``academic_info`` from ALREADY-LOADED state. The
+    caller MUST eager-load that chain (``resolve_fee_academic_info`` does, via
+    ``selectinload(admission_path).selectinload(academic_info)``). This helper
+    does NOT guard against an async lazy-load — ``getattr(..., None)`` only
+    swallows a genuinely-absent attribute (AttributeError), NOT the
+    ``MissingGreenlet`` a lazy relationship access raises in async context. So
+    only reuse it with an eager-loaded ``choice``.
     """
     path = getattr(choice, "admission_path", None)
     if path is None:
@@ -191,10 +195,20 @@ async def resolve_fee_academic_info(
     applied = profile.applied_rules or {}
     ai_id = applied.get("academic_info_id")
     if ai_id is not None:
+        # applied_rules is JSONB — academic_info_id may be a non-numeric string
+        # on legacy/corrupt data. Convert defensively so a bad value yields a
+        # 400 (BadRequest) rather than an unhandled ValueError → 500.
+        try:
+            ai_id_int = int(ai_id)
+        except (TypeError, ValueError):
+            raise BadRequest(
+                "Không xác định được ngành: applied_rules.academic_info_id "
+                f"không phải số hợp lệ ({ai_id!r})."
+            )
         academic_info = (
             await db.execute(
                 select(models.OfferingAcademicInfo).where(
-                    models.OfferingAcademicInfo.id == int(ai_id)
+                    models.OfferingAcademicInfo.id == ai_id_int
                 )
             )
         ).scalars().first()

--- a/Backend_FastAPI/app/utils/admission_status.py
+++ b/Backend_FastAPI/app/utils/admission_status.py
@@ -115,21 +115,32 @@ def is_fee_eligible(profile: "AdmissionProfile") -> bool:
       * admitted-like (legacy ``approved`` / ``overridden`` + choice-engine
         ``admitted``) — the post-decision happy path,
       * ``confirmed`` / ``enrolled`` — later post-decision milestones,
-      * ``submitted`` ONLY for single-path profiles (C2 fast-track prepay /
-        giữ chỗ). A multi-NV profile (``uses_choice_engine``) at ``submitted``
-        has not locked its admitted choice yet (all choices ``pending`` until
-        publish), so calculating tuition would risk the wrong ngành — it
-        qualifies later via ``admitted`` (``is_admitted_like``).
+      * ``submitted`` for single-path profiles (C2 fast-track prepay / giữ chỗ),
+      * ``submitted`` for a multi-NV profile (``uses_choice_engine``) that has
+        EXACTLY ONE nguyện vọng. With a single choice the ngành is already
+        determined (publish can only admit that one choice or reject the whole
+        profile — ``add_choice`` is locked at ``submitted``), so prepay / giữ
+        chỗ is as safe as the single-path case. A multi-NV profile with ≥2
+        choices at ``submitted`` has not locked its admitted choice (all choices
+        ``pending`` until publish) → calculating tuition would risk the wrong
+        ngành, so it qualifies later via ``admitted`` (``is_admitted_like``).
+
+    The multi-NV single-choice branch reads ``profile.__dict__`` (no lazy-load
+    → no MissingGreenlet) and FAILS CLOSED when ``choices`` is not eager-loaded:
+    the fee-create path re-validates this under a row lock anyway, so a missing
+    eager-load degrades to "not eligible" rather than a wrong-ngành fee.
 
     Earlier states (``draft`` etc.) are NOT eligible (a fee would be premature).
-    Behaviour-preserving extraction — keep this in lockstep with both call
-    sites if the gate ever changes.
+    Keep this in lockstep with both call sites if the gate ever changes.
     """
-    return (
-        is_admitted_like(profile)
-        or profile.status in ("confirmed", "enrolled")
-        or (profile.status == "submitted" and not profile.uses_choice_engine)
-    )
+    if is_admitted_like(profile) or profile.status in ("confirmed", "enrolled"):
+        return True
+    if profile.status == "submitted":
+        if not profile.uses_choice_engine:
+            return True
+        choices = profile.__dict__.get("choices")
+        return choices is not None and len(choices) == 1
+    return False
 
 
 def is_confirmation_eligible(profile: "AdmissionProfile") -> bool:

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -844,20 +844,23 @@ async def test_accountant_denied_heavy_finance_mutations(
 
 
 # ==============================================================================
-# L2 — submitted gate is single-path ONLY (multi-NV awaits publish)
+# L2 — submitted gate for multi-NV is gated on the NV count
 # ==============================================================================
 #
-# C2 opened the ``submitted`` state for fee calculation, but a MULTI-NV profile
-# (``uses_choice_engine=True``) at ``submitted`` has not yet locked its admitted
-# choice (all choices decision="pending" until the round is published). The fee
-# service's ``_resolve_academic_info_id`` would pick ONE config-driven ngành and
-# could auto-issue tuition for the WRONG ngành. L2 therefore tightens BOTH gate
-# sites so ``submitted`` is eligible only when ``not uses_choice_engine``:
+# C2 opened the ``submitted`` state for fee calculation. A MULTI-NV profile
+# (``uses_choice_engine=True``) at ``submitted`` with ≥2 nguyện vọng — or none
+# added yet — has not locked its admitted ngành (all choices decision="pending"
+# until publish), so pricing tuition now risks the WRONG ngành. BUT a multi-NV
+# profile with EXACTLY ONE nguyện vọng has its ngành already determined, so it
+# IS eligible (single-choice carve-out — see is_fee_eligible + the multi-NV
+# single-choice 201 test in test_phase3_pr3d_b_choice_crud.py). The gate is
+# shared across BOTH sites:
 #   * routers/fees.py::_fee_calc_authorized               (route gate, 404)
 #   * admission_service.py _compute_*["calculate_fee"]    (FE flag)
-# A multi-NV profile becomes eligible again only after publish → admitted-like
-# (covered by ``is_admitted_like``), which these tests also assert is NOT over-
-# tightened.
+# The tests below flip ``uses_choice_engine`` WITHOUT adding choices, so they
+# exercise the 0-NV case (blocked); a multi-NV profile also becomes eligible
+# after publish → admitted-like (covered by ``is_admitted_like``), which these
+# tests assert is NOT over-tightened.
 #
 # ``uses_choice_engine`` is a real Boolean COLUMN on AdmissionProfile (not a
 # computed property), so the tests flip it directly in the DB — mirroring how
@@ -894,8 +897,9 @@ async def test_calculate_fee_hidden_for_multi_nv_at_submitted(
     officer_user_in_db: dict,
     fee_calc_config: dict,
 ):
-    """Site B mirror: a MULTI-NV profile (``uses_choice_engine=True``) at
-    ``submitted`` must NOT expose calculate_fee — it awaits publish.
+    """Site B mirror: a MULTI-NV profile (``uses_choice_engine=True``) with no
+    nguyện vọng yet (0 choices) at ``submitted`` must NOT expose calculate_fee —
+    the ngành is undetermined (only the EXACTLY-ONE-choice case is eligible).
 
     The owning officer would otherwise see the button and be able to auto-issue
     tuition for an as-yet-undecided ngành.
@@ -925,7 +929,8 @@ async def test_calculate_fee_route_404_for_multi_nv_at_submitted(
     fee_calc_config: dict,
 ):
     """Site A mirror: the route gate (_fee_calc_authorized) rejects a multi-NV
-    profile at ``submitted`` with 404 even for the owning officer.
+    profile with no nguyện vọng yet (0 choices) at ``submitted`` with 404 even
+    for the owning officer (only the EXACTLY-ONE-choice case is eligible).
     """
     pid = await _create_approved_profile(
         client, admin_token_headers, officer_user_in_db, fee_calc_config,
@@ -997,37 +1002,36 @@ async def test_single_path_calculate_fee_at_submitted_still_ok(
 
 
 @pytest.mark.asyncio
-async def test_multi_nv_calculate_fee_at_admitted_not_over_tightened(
+async def test_multi_nv_zero_choice_at_admitted_fails_closed(
     client: AsyncClient,
     admin_token_headers: dict,
     officer_user_in_db: dict,
     fee_calc_config: dict,
 ):
-    """A MULTI-NV profile that has reached an admitted-like state (post-publish)
-    must STILL be able to calculate fee — L2 only narrows ``submitted``, it must
-    not regress the admitted/confirmed/enrolled path that ``is_admitted_like``
-    already authorizes.
+    """A multi-NV profile in an admitted-like state but with ZERO choices
+    (corrupt data / direct flag flip) must FAIL CLOSED at fee creation (400) —
+    the resolver refuses to price an undetermined ngành and must NOT silently
+    fall back to the profile snapshot (offering_admission_config / applied_rules).
 
-    Uses ``approved`` (admitted-like, allowed by the status CheckConstraint) to
-    simulate the post-publish decision while keeping ``uses_choice_engine=True``.
+    Note: ``_create_approved_profile`` DOES leave a valid snapshot
+    (offering_admission_config_id set at create), so a 201 here would mean the
+    resolver used the stale NV-gốc snapshot — exactly the wrong-ngành bug. The
+    state gate (is_fee_eligible) is choice-agnostic for admitted-like (a *real*
+    admitted multi-NV has an admitted choice and resolves fine — covered by the
+    resolver-picks-admitted-choice test in test_phase3_pr3d_b_choice_crud.py);
+    the resolver is the safety net for the corrupt 0-choice case.
     """
     pid = await _create_approved_profile(
         client, admin_token_headers, officer_user_in_db, fee_calc_config,
-        lead_name="L2 MultiNV Admitted OK", approve=False,
+        lead_name="L2 MultiNV ZeroChoice FailClosed", approve=False,
     )
-    # Flip to multi-NV AND advance to an admitted-like decision state.
+    # Flip to multi-NV AND advance to an admitted-like decision state, WITHOUT
+    # creating any choice — the corrupt/degenerate shape the resolver guards.
     await _set_choice_engine(pid, value=True, status="approved")
 
     oh = await _login(
         client, officer_user_in_db["username"], officer_user_in_db["password"]
     )
-    # FE flag visible.
-    detail = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
-    assert detail["status"] == "approved", detail.get("status")
-    assert "calculate_fee" in detail["available_actions"], detail["available_actions"]
-    assert detail["permissions"]["calculate_fee"] is True
-
-    # Route admits → 201.
     resp = await client.post(
         "/api/fees/calculate",
         json={
@@ -1038,7 +1042,7 @@ async def test_multi_nv_calculate_fee_at_admitted_not_over_tightened(
         },
         headers=oh,
     )
-    assert resp.status_code == 201, (
-        f"Multi-NV at admitted-like state should still calculate fee, got "
-        f"{resp.status_code}: {resp.text[:300]}"
+    assert resp.status_code == 400, (
+        f"0-choice admitted multi-NV must fail closed at fee creation (no "
+        f"snapshot fallback), got {resp.status_code}: {resp.text[:300]}"
     )

--- a/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
@@ -786,3 +786,424 @@ async def test_delete_choice_allowed_when_round_closed(
             models.AdmissionProfileChoice, pr3d_b_seed_with_choice["choice_id"]
         )
         assert gone is None, "Choice phải bị xoá khỏi DB sau DELETE thành công"
+
+
+# ============================================================================
+# Multi-NV single-choice fee carve-out + finance-lock freeze
+# ----------------------------------------------------------------------------
+# Two coupled behaviours:
+#   1. A multi-NV profile with EXACTLY ONE nguyện vọng may calculate tuition at
+#      ``submitted`` (ngành is already determined; prepay / giữ chỗ) — the fee
+#      service resolves the ngành from that single choice, NOT the profile
+#      snapshot (which would be the wrong ngành for a multi-NV admit).
+#   2. Once a tuition fee exists, NV-structure edits (add/delete/reorder/
+#      score-replace) are frozen — there is no fee supersede/recreate flow, so
+#      changing the ngành after pricing would orphan / mis-price the fee.
+# ============================================================================
+
+
+async def _insert_tuition_fee(profile_id: int) -> int:
+    """Insert a minimal tuition Fee row so the finance-lock guard fires.
+
+    The freeze guard only checks EXISTENCE of a tuition fee for the profile
+    (any status), so a calculated row with HK1 semester_no is enough.
+    """
+    from app.models.finance import Fee
+
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            fee = Fee(
+                admission_profile_id=profile_id,
+                fee_type="tuition",
+                academic_year=2026,
+                semester_no=1,
+                base_amount=Decimal("1000000"),
+                total_discount=Decimal("0"),
+                final_amount=Decimal("1000000"),
+                paid_amount=Decimal("0"),
+                waived_amount=Decimal("0"),
+                status="calculated",
+                version=1,
+            )
+            s.add(fee)
+            await s.flush()
+            return fee.id
+
+
+@pytest_asyncio.fixture
+async def multinv_submitted_fee_ready(pr3d_b_seed_with_choice: dict) -> dict:
+    """``pr3d_b_seed_with_choice`` (multi-NV, exactly 1 choice) + HK1 tuition
+    amount + FULL installment plan, profile flipped to ``submitted`` — ready for
+    POST /api/fees/calculate to exercise the single-choice carve-out end-to-end.
+    """
+    seed = pr3d_b_seed_with_choice
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            from sqlalchemy import select, update
+
+            path = await s.get(models.AdmissionPath, seed["path_id"])
+            ai_id = path.academic_info_id
+            # ADR-002: tuition amount comes from offering_semester_tuition (HK1).
+            s.add(models.OfferingSemesterTuition(
+                academic_info_id=ai_id, semester_no=1, amount=1_000_000,
+            ))
+            # FULL single-payment plan — the route rejects unknown plan codes.
+            full = (await s.execute(
+                select(models.InstallmentPlan).where(
+                    models.InstallmentPlan.code == "FULL"
+                )
+            )).scalar_one_or_none()
+            if full is None:
+                s.add(models.InstallmentPlan(
+                    code="FULL", name="Thanh toán 1 lần", installment_count=1,
+                    schedule=[{
+                        "installment_no": 1, "due_days_offset": 0,
+                        "percent": 100.0, "description": "Toàn bộ",
+                    }],
+                    is_active=True,
+                ))
+            await s.execute(
+                update(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == seed["profile_id"])
+                .values(status="submitted")
+            )
+    return {**seed, "academic_info_id": ai_id}
+
+
+@pytest.mark.asyncio
+async def test_multinv_single_choice_calculate_fee_at_submitted_201(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    multinv_submitted_fee_ready: dict,
+):
+    """A multi-NV profile with EXACTLY ONE nguyện vọng at ``submitted`` →
+    /api/fees/calculate returns 201 and prices against THAT choice's ngành
+    (amount from the choice's offering_semester_tuition HK1 = 1,000,000).
+    """
+    pid = multinv_submitted_fee_ready["profile_id"]
+    resp = await client.post(
+        "/api/fees/calculate",
+        headers=manager_token_headers,
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+    )
+    assert resp.status_code == 201, (
+        f"Multi-NV single-choice at submitted should calculate fee, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+    body = resp.json()
+    assert Decimal(str(body["final_amount"])) == Decimal("1000000"), body
+
+
+@pytest.mark.asyncio
+async def test_add_choice_blocked_when_tuition_fee_exists(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3a_seed: dict,
+):
+    """Finance lock: once a tuition fee exists, adding a NV is blocked (400)
+    even while the profile is still ``draft`` — the ngành is frozen for finance.
+    """
+    await _insert_tuition_fee(pr3a_seed["profile_id"])
+    resp = await client.post(
+        f"/api/v2/admissions/{pr3a_seed['profile_id']}/choices",
+        headers=manager_token_headers,
+        json={
+            "admission_path_id": pr3a_seed["path_id"],
+            "path_subject_group_config_id": pr3a_seed["config_id"],
+            "display_order": 1,
+            "scores": [{"subject_id": pr3a_seed["subject_id"], "score": "8.50"}],
+        },
+    )
+    assert resp.status_code == 400, (
+        f"add_choice must be blocked when a tuition fee exists, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+    assert "đã phát sinh học phí" in resp.text, resp.text
+
+
+@pytest.mark.asyncio
+async def test_delete_choice_blocked_when_tuition_fee_exists(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3d_b_seed_with_choice: dict,
+):
+    """Finance lock: deleting a NV is blocked (400) once a tuition fee exists."""
+    await _insert_tuition_fee(pr3d_b_seed_with_choice["profile_id"])
+    resp = await client.delete(
+        f"/api/v2/admissions/{pr3d_b_seed_with_choice['profile_id']}"
+        f"/choices/{pr3d_b_seed_with_choice['choice_id']}",
+        headers=manager_token_headers,
+    )
+    assert resp.status_code == 400, (
+        f"delete_choice must be blocked when a tuition fee exists, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+    assert "đã phát sinh học phí" in resp.text, resp.text
+    # Choice must survive the blocked delete.
+    async with AsyncSessionLocal() as s:
+        still = await s.get(
+            models.AdmissionProfileChoice, pr3d_b_seed_with_choice["choice_id"]
+        )
+        assert still is not None
+
+
+@pytest.mark.asyncio
+async def test_reorder_choice_blocked_when_tuition_fee_exists(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3d_b_seed_with_choice: dict,
+):
+    """Finance lock: reordering a NV is blocked (400) once a tuition fee exists."""
+    await _insert_tuition_fee(pr3d_b_seed_with_choice["profile_id"])
+    resp = await client.patch(
+        f"/api/v2/admissions/{pr3d_b_seed_with_choice['profile_id']}"
+        f"/choices/{pr3d_b_seed_with_choice['choice_id']}",
+        headers=manager_token_headers,
+        json={"display_order": 2},
+    )
+    assert resp.status_code == 400, (
+        f"reorder must be blocked when a tuition fee exists, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+    assert "đã phát sinh học phí" in resp.text, resp.text
+
+
+@pytest.mark.asyncio
+async def test_replace_scores_blocked_when_tuition_fee_exists(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3d_b_seed_with_choice: dict,
+):
+    """Finance lock: replacing scores is blocked (400) once a tuition fee
+    exists — 'đã chốt finance thì không đổi dữ liệu xét tuyển'.
+    """
+    await _insert_tuition_fee(pr3d_b_seed_with_choice["profile_id"])
+    resp = await client.patch(
+        f"/api/v2/admissions/{pr3d_b_seed_with_choice['profile_id']}"
+        f"/choices/{pr3d_b_seed_with_choice['choice_id']}/scores",
+        headers=manager_token_headers,
+        json={
+            "scores": [
+                {"subject_id": pr3d_b_seed_with_choice["subject_id"], "score": "9.00"}
+            ]
+        },
+    )
+    assert resp.status_code == 400, (
+        f"score-replace must be blocked when a tuition fee exists, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+    assert "đã phát sinh học phí" in resp.text, resp.text
+
+
+# ============================================================================
+# Resolver bug-fix — multi-NV fee priced against the ADMITTED choice, NOT the
+# stale profile snapshot (NV gốc). evaluate_cascade writes only choice.decision
+# at publish, so the profile snapshot (applied_rules / OAC) still points at NV1;
+# resolve_fee_academic_info must prefer the admitted choice.
+# ============================================================================
+
+
+@pytest_asyncio.fixture
+async def multinv_bugfix_seed(
+    pr3a_seed: dict, seed_lead_dependencies: dict
+) -> dict:
+    """pr3a_seed (NV1 ngành, HK1 = 1,000,000) + a 2nd ngành NV2 (HK1 =
+    2,000,000) + FULL plan + a STALE NV1 snapshot written onto the profile
+    (``applied_rules.academic_info_id`` = NV1 ngành).
+
+    If the resolver wrongly used the snapshot it would price NV1 (1,000,000);
+    the admitted-choice fix prices the admitted NV2 (2,000,000).
+    """
+    from sqlalchemy import select, update
+
+    seed = pr3a_seed
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            path1 = await s.get(models.AdmissionPath, seed["path_id"])
+            ai1_id = path1.academic_info_id
+            method_id = path1.admission_method_id
+            round_id = seed["round_id"]
+            config1 = await s.get(
+                models.PathSubjectGroupConfig, seed["config_id"]
+            )
+            sg_id = config1.subject_group_id
+
+            # HK1 tuition for the NV1 ngành (snapshot would price this).
+            s.add(models.OfferingSemesterTuition(
+                academic_info_id=ai1_id, semester_no=1, amount=1_000_000,
+            ))
+
+            # 2nd ngành (NV2): offering2 + ai2 (tuition 2,000,000) + path2 +
+            # config2 (reuse the existing subject_group).
+            offering2 = models.ProgramOffering(
+                program_id=seed_lead_dependencies["major_program_id"],
+                offering_type=f"ft2_{ts}",
+                duration_semesters=8,
+            )
+            s.add(offering2)
+            await s.flush()
+            ai2 = models.OfferingAcademicInfo(
+                offering_id=offering2.id,
+                academic_year=2026,
+                annual_admission_quota=20,
+                tuition_fee_per_year=2_000_000,
+            )
+            s.add(ai2)
+            await s.flush()
+            s.add(models.OfferingSemesterTuition(
+                academic_info_id=ai2.id, semester_no=1, amount=2_000_000,
+            ))
+            path2 = models.AdmissionPath(
+                academic_info_id=ai2.id,
+                admission_method_id=method_id,
+                admission_round_id=round_id,
+                status="active",
+            )
+            s.add(path2)
+            await s.flush()
+            config2 = models.PathSubjectGroupConfig(
+                admission_path_id=path2.id,
+                subject_group_id=sg_id,
+                min_score=Decimal("18.00"),
+            )
+            s.add(config2)
+            await s.flush()
+            ai2_id = ai2.id
+            path2_id = path2.id
+            config2_id = config2.id
+
+            full = (await s.execute(
+                select(models.InstallmentPlan).where(
+                    models.InstallmentPlan.code == "FULL"
+                )
+            )).scalar_one_or_none()
+            if full is None:
+                s.add(models.InstallmentPlan(
+                    code="FULL", name="Thanh toán 1 lần", installment_count=1,
+                    schedule=[{
+                        "installment_no": 1, "due_days_offset": 0,
+                        "percent": 100.0, "description": "Toàn bộ",
+                    }],
+                    is_active=True,
+                ))
+
+            # Stale NV1 snapshot — the wrong ngành the resolver must NOT use.
+            await s.execute(
+                update(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == seed["profile_id"])
+                .values(applied_rules={"academic_info_id": ai1_id})
+            )
+    return {
+        **seed,
+        "ai1_id": ai1_id,
+        "ai2_id": ai2_id,
+        "path2_id": path2_id,
+        "config2_id": config2_id,
+    }
+
+
+async def _set_choices_and_status(
+    profile_id: int, choices: list[tuple[int, int, int, str]], status: str
+) -> None:
+    """Insert ``(path_id, config_id, display_order, decision)`` choices and set
+    the profile status (direct DB — bypasses the choice-engine workflow to set
+    up resolver scenarios deterministically)."""
+    from sqlalchemy import update
+
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            for path_id, config_id, order, decision in choices:
+                s.add(models.AdmissionProfileChoice(
+                    admission_profile_id=profile_id,
+                    admission_path_id=path_id,
+                    path_subject_group_config_id=config_id,
+                    display_order=order,
+                    decision=decision,
+                ))
+            await s.execute(
+                update(models.AdmissionProfile)
+                .where(models.AdmissionProfile.id == profile_id)
+                .values(status=status)
+            )
+
+
+@pytest.mark.asyncio
+async def test_resolver_prices_against_admitted_choice_not_snapshot(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    multinv_bugfix_seed: dict,
+):
+    """NV1 (pending, snapshot ngành = 1,000,000) + NV2 (admitted, ngành =
+    2,000,000), profile admitted-like → /api/fees/calculate prices the ADMITTED
+    NV2 ngành (2,000,000), NOT the stale snapshot. This is the wrong-ngành bug
+    fix: a 201 with amount 1,000,000 would mean the resolver used the snapshot.
+    """
+    seed = multinv_bugfix_seed
+    await _set_choices_and_status(
+        seed["profile_id"],
+        choices=[
+            (seed["path_id"], seed["config_id"], 1, "pending"),
+            (seed["path2_id"], seed["config2_id"], 2, "admitted"),
+        ],
+        status="approved",  # admitted-like (CHECK-allowed); NV2 decision drives it
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        headers=manager_token_headers,
+        json={
+            "admission_profile_id": seed["profile_id"],
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+    )
+    assert resp.status_code == 201, (
+        f"admitted multi-NV should calculate fee, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+    body = resp.json()
+    assert Decimal(str(body["final_amount"])) == Decimal("2000000"), (
+        f"Fee must be priced against the ADMITTED NV2 ngành (2,000,000), not "
+        f"the stale NV1 snapshot (1,000,000): {body}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolver_multiple_admitted_fails_closed(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    multinv_bugfix_seed: dict,
+):
+    """Two choices both ``decision="admitted"`` (corrupt — the cascade admits
+    at most one) → fee creation FAILS CLOSED (400), never guesses a ngành.
+    """
+    seed = multinv_bugfix_seed
+    await _set_choices_and_status(
+        seed["profile_id"],
+        choices=[
+            (seed["path_id"], seed["config_id"], 1, "admitted"),
+            (seed["path2_id"], seed["config2_id"], 2, "admitted"),
+        ],
+        status="approved",
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        headers=manager_token_headers,
+        json={
+            "admission_profile_id": seed["profile_id"],
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+    )
+    assert resp.status_code == 400, (
+        f">1 admitted choice must fail closed, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+    assert "nhiều hơn 1 nguyện vọng trúng tuyển" in resp.text, resp.text

--- a/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
@@ -802,11 +802,12 @@ async def test_delete_choice_allowed_when_round_closed(
 # ============================================================================
 
 
-async def _insert_tuition_fee(profile_id: int) -> int:
-    """Insert a minimal tuition Fee row so the finance-lock guard fires.
+async def _insert_tuition_fee(profile_id: int, status: str = "calculated") -> int:
+    """Insert a minimal tuition Fee row (default status ``calculated``).
 
-    The freeze guard only checks EXISTENCE of a tuition fee for the profile
-    (any status), so a calculated row with HK1 semester_no is enough.
+    The finance-lock guard freezes NV edits only for a NON-cancelled tuition
+    fee, so pass ``status="cancelled"`` to model a voided fee that must NOT
+    freeze.
     """
     from app.models.finance import Fee
 
@@ -822,7 +823,7 @@ async def _insert_tuition_fee(profile_id: int) -> int:
                 final_amount=Decimal("1000000"),
                 paid_amount=Decimal("0"),
                 waived_amount=Decimal("0"),
-                status="calculated",
+                status=status,
                 version=1,
             )
             s.add(fee)
@@ -1000,6 +1001,38 @@ async def test_replace_scores_blocked_when_tuition_fee_exists(
     assert "đã phát sinh học phí" in resp.text, resp.text
 
 
+@pytest.mark.asyncio
+async def test_cancelled_tuition_fee_does_not_freeze_choices(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3d_b_seed_with_choice: dict,
+):
+    """Escape-hatch: a CANCELLED tuition fee must NOT freeze NV edits.
+
+    cancel_fee voids the obligation but keeps the row; without this carve-out a
+    prepay→cancel→rollback profile would be locked out of editing its own NVs
+    forever. delete_choice on a draft profile that has only a cancelled tuition
+    fee must succeed (200), not 400.
+    """
+    await _insert_tuition_fee(
+        pr3d_b_seed_with_choice["profile_id"], status="cancelled"
+    )
+    resp = await client.delete(
+        f"/api/v2/admissions/{pr3d_b_seed_with_choice['profile_id']}"
+        f"/choices/{pr3d_b_seed_with_choice['choice_id']}",
+        headers=manager_token_headers,
+    )
+    assert resp.status_code == 200, (
+        f"cancelled tuition fee must NOT freeze NV edits, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+    async with AsyncSessionLocal() as s:
+        gone = await s.get(
+            models.AdmissionProfileChoice, pr3d_b_seed_with_choice["choice_id"]
+        )
+        assert gone is None, "choice should be deleted (no active fee freeze)"
+
+
 # ============================================================================
 # Resolver bug-fix — multi-NV fee priced against the ADMITTED choice, NOT the
 # stale profile snapshot (NV gốc). evaluate_cascade writes only choice.decision
@@ -1139,10 +1172,17 @@ async def test_resolver_prices_against_admitted_choice_not_snapshot(
     manager_token_headers: dict,
     multinv_bugfix_seed: dict,
 ):
-    """NV1 (pending, snapshot ngành = 1,000,000) + NV2 (admitted, ngành =
-    2,000,000), profile admitted-like → /api/fees/calculate prices the ADMITTED
-    NV2 ngành (2,000,000), NOT the stale snapshot. This is the wrong-ngành bug
-    fix: a 201 with amount 1,000,000 would mean the resolver used the snapshot.
+    """NV1 (pending, ngành = 1,000,000) + NV2 (admitted, ngành = 2,000,000),
+    profile admitted-like → /api/fees/calculate prices the ADMITTED NV2 ngành
+    (2,000,000). Proves the observable bug fix: the fee is priced from the
+    admitted choice, not NV1.
+
+    The profile also carries a stale ``applied_rules.academic_info_id`` = NV1
+    (1,000,000) as a REGRESSION TRIPWIRE: a 1,000,000 result would mean the
+    resolver leaked to the snapshot. (Today the choice-engine branch returns
+    before the snapshot path, so this guards against a future change that
+    reintroduces snapshot consultation for choice-engine profiles — it does NOT
+    prove a runtime precedence between two live code paths.)
     """
     seed = multinv_bugfix_seed
     await _set_choices_and_status(
@@ -1182,6 +1222,11 @@ async def test_resolver_multiple_admitted_fails_closed(
 ):
     """Two choices both ``decision="admitted"`` (corrupt — the cascade admits
     at most one) → fee creation FAILS CLOSED (400), never guesses a ngành.
+
+    The 400 is raised by the SHARED ``resolve_fee_academic_info`` helper. Both
+    entry points call it: the router (fees.py, resolving discount IDs) hits it
+    first, and ``calculate_fee`` (service, under the row lock) calls the same
+    helper — so the >1-admitted guard is covered regardless of which runs.
     """
     seed = multinv_bugfix_seed
     await _set_choices_and_status(

--- a/Backend_FastAPI/tests/unit/test_admission_status_helpers.py
+++ b/Backend_FastAPI/tests/unit/test_admission_status_helpers.py
@@ -30,12 +30,32 @@ from app.utils.admission_status import (
     effective_status,
     is_admitted_like,
     is_confirmation_eligible,
+    is_fee_eligible,
 )
 
 
 def _profile(status: str) -> SimpleNamespace:
     """Tiny stand-in — helpers only read ``profile.status``."""
     return SimpleNamespace(status=status)
+
+
+def _fee_profile(
+    status: str,
+    *,
+    uses_choice_engine: bool = False,
+    choices: object = "__unset__",
+) -> SimpleNamespace:
+    """Stand-in for ``is_fee_eligible``.
+
+    Reads ``status`` + ``uses_choice_engine`` + ``__dict__['choices']``.
+    Pass ``choices="__unset__"`` (default) to model a profile whose
+    ``choices`` relationship was NOT eager-loaded (the gate must fail
+    closed); pass a list (possibly empty) to model a loaded collection.
+    """
+    ns = SimpleNamespace(status=status, uses_choice_engine=uses_choice_engine)
+    if choices != "__unset__":
+        ns.choices = choices
+    return ns
 
 
 # ---------------------------------------------------------------------------
@@ -215,3 +235,107 @@ def test_admitted_like_set_matches_effective_status_admitted_targets() -> None:
     }
     expected = legacy_aliases_pointing_to_admitted | {"admitted"}
     assert ADMITTED_LIKE_STATUSES == frozenset(expected)
+
+
+# ---------------------------------------------------------------------------
+# is_fee_eligible — fee-create state gate (shared by routers/fees.py
+# _fee_calc_authorized + admission_service calculate_fee permission flag).
+# Post-decision states always pass; ``submitted`` passes for single-path
+# (C2 prepay) AND for a multi-NV profile that has EXACTLY ONE nguyện vọng
+# (ngành already determined). Multi-NV ≥2 at ``submitted`` must wait for
+# publish → ``admitted``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", sorted(ADMITTED_LIKE_STATUSES))
+def test_is_fee_eligible_true_for_admitted_like(status: str) -> None:
+    """Post-decision admitted-like passes regardless of engine / choices —
+    the resolver later prices against the admitted choice (multi-NV) or the
+    profile snapshot (single-path)."""
+    assert is_fee_eligible(_fee_profile(status)) is True
+    assert (
+        is_fee_eligible(
+            _fee_profile(status, uses_choice_engine=True, choices=[object(), object()])
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize("status", ["confirmed", "enrolled"])
+def test_is_fee_eligible_true_for_later_post_decision(status: str) -> None:
+    assert is_fee_eligible(_fee_profile(status)) is True
+    assert (
+        is_fee_eligible(
+            _fee_profile(status, uses_choice_engine=True, choices=[object()])
+        )
+        is True
+    )
+
+
+def test_is_fee_eligible_submitted_single_path_true() -> None:
+    """Legacy single-path at ``submitted`` = C2 fast-track prepay / giữ chỗ.
+    Choices are irrelevant for single-path."""
+    assert is_fee_eligible(_fee_profile("submitted", uses_choice_engine=False)) is True
+    # Even with a stray loaded (empty) choices list, single-path stays eligible.
+    assert (
+        is_fee_eligible(_fee_profile("submitted", uses_choice_engine=False, choices=[]))
+        is True
+    )
+
+
+def test_is_fee_eligible_submitted_multinv_single_choice_true() -> None:
+    """The new rule: a multi-NV profile with EXACTLY ONE nguyện vọng may
+    prepay at ``submitted`` (ngành is already determined)."""
+    assert (
+        is_fee_eligible(
+            _fee_profile("submitted", uses_choice_engine=True, choices=[object()])
+        )
+        is True
+    )
+
+
+@pytest.mark.parametrize("n_choices", [2, 3, 5])
+def test_is_fee_eligible_submitted_multinv_multi_choice_false(n_choices: int) -> None:
+    """Multi-NV with ≥2 NVs at ``submitted`` is NOT eligible — the admitted
+    ngành is not locked until publish, so pricing now risks the wrong ngành."""
+    choices = [object() for _ in range(n_choices)]
+    assert (
+        is_fee_eligible(
+            _fee_profile("submitted", uses_choice_engine=True, choices=choices)
+        )
+        is False
+    )
+
+
+def test_is_fee_eligible_submitted_multinv_zero_choice_false() -> None:
+    assert (
+        is_fee_eligible(_fee_profile("submitted", uses_choice_engine=True, choices=[]))
+        is False
+    )
+
+
+def test_is_fee_eligible_submitted_multinv_choices_not_loaded_fails_closed() -> None:
+    """If ``choices`` was not eager-loaded the gate must fail closed (the
+    fee-create path re-checks under a row lock; a missing eager-load must
+    degrade to 'not eligible', never to a wrong-ngành fee)."""
+    assert (
+        is_fee_eligible(_fee_profile("submitted", uses_choice_engine=True))
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["draft", "reviewing", "waitlisted", "rejected", "withdrawn",
+     "revision_requested", "result_published", "resubmitted", "", "SUBMITTED"],
+)
+@pytest.mark.parametrize("engine", [False, True])
+def test_is_fee_eligible_false_for_non_eligible_states(status: str, engine: bool) -> None:
+    """Pre-decision (other than the submitted prepay carve-outs) and negative
+    outcomes are never fee-eligible — even a single-choice multi-NV profile."""
+    assert (
+        is_fee_eligible(
+            _fee_profile(status, uses_choice_engine=engine, choices=[object()])
+        )
+        is False
+    )


### PR DESCRIPTION
## Mục tiêu
Hồ sơ đa nguyện vọng (`uses_choice_engine=True`) nhưng **thực tế chỉ có 1 NV** vẫn được tạo học phí ở trạng thái `submitted` (prepay/giữ chỗ như single-path). `uses_choice_engine` kế thừa từ `admission_round.allow_multi_nv` lúc tạo hồ sơ — KHÔNG đồng nghĩa "có ≥2 NV", nên gate cũ chặn quá tay.

## Bug tiềm ẩn fix kèm
`evaluate_cascade` khi publish chỉ ghi `choice.decision`, **không** cập nhật `offering_admission_config_id`/`applied_rules` theo NV trúng tuyển → resolver học phí cũ tính theo ngành NV gốc (NV1), **sai ngành** khi thí sinh đỗ NV khác. Nay resolver lấy ngành theo NV `admitted`.

## Thay đổi chính
- **`is_fee_eligible`**: `submitted` đủ điều kiện khi single-path **hoặc** multi-NV **đúng 1 NV** (fail-closed nếu `choices` chưa load).
- **`resolve_fee_academic_info`** (helper chung router + service): choice-engine → ưu tiên choice `admitted`; **>1 admitted hoặc 0/≥2 pending → BadRequest fail-closed** (không fallback snapshot); legacy → OAC eager → OAC-by-id → `applied_rules`.
- **`calculate_fee`**: lock profile (`FOR UPDATE`) + re-check `is_fee_eligible` dưới lock → serialize race "fee thấy 1 NV" vs "thêm/xóa NV".
- **Freeze** add/delete/reorder/replace-scores khi đã có tuition fee **chưa cancelled** (escape-hatch: fee cancelled không khóa NV).
- `AdmissionRepository.get_by_id_for_update` (lock + tránh `FOR UPDATE` trên outer-join).

## Review
Qua **2 vòng code review**: P1/P2 (fail-closed 0/≥2 không fallback; giữ OAC fallback qua id-query; test NV2-admitted thật) + round-2 (#1 escape-hatch fee cancelled, #10 guard int→400, #15 docstring, #3/#4 docstring test). Tất cả finding cao/trung đã sửa.

## Test
**150 passed** (one-off container): gate matrix + resolver (NV2-admitted=2tr không phải snapshot NV1=1tr, >1-admitted & 0-choice fail-closed) + fee-auth + choice-CRUD + freeze (gồm cancelled-không-freeze).

## Nợ defer (KHÔNG chặn PR — follow-up riêng)
- **Perf/race (follow-up A/B):** #5 lock nạp nặng, #6 nạp hồ sơ 2 lần, #7 resolve 2 lần, #9 khóa hở nửa (resolve-once-under-lock), #11 DRY `get_by_id_for_update`, #12 gộp freeze vào gate, #13 rule trùng.
- **Tách riêng (C):** #2 refresh snapshot @publish — `priority_service` còn đọc NV1 (chờ product chốt cố ý/bug; **đã verify quota KHÔNG over-admit**); #14 loại multi-NV khỏi `approve`/`reject`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
