### PR TITLE
perf(fee/choice): follow-up #416 — resolve-once-under-lock + lock perf + gate consolidation

### DIFF
--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 from sqlalchemy import select, or_, and_, func, desc, asc, distinct
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import joinedload, raiseload, selectinload
 
 from app import models
 from app.models import ProfileSubjectScore, ProfileDocument
@@ -119,6 +119,14 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         join. ``with_choices`` adds a ``selectinload`` of ``choices`` so the
         caller can re-check ``is_fee_eligible`` under the lock.
 
+        ``raiseload("*")`` suppresses the AdmissionProfile mapper's ~12 other
+        ``lazy="selectin"`` relations (student / documents / fees / audit
+        ``*_by`` …) that would otherwise all re-fire on this entity load — the
+        only consumer (``calculate_fee``) needs just ``lead`` + ``choices``. Any
+        stray access to a non-eager-loaded relation then RAISES (caught in
+        tests) instead of silently lazy-loading (runtime-only MissingGreenlet in
+        async). Scalar columns + ``__dict__.get`` reads are unaffected.
+
         Args:
             profile_id: AdmissionProfile ID.
             populate_existing: overwrite any in-session instance's attributes
@@ -130,7 +138,10 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         query = (
             select(models.AdmissionProfile)
             .where(models.AdmissionProfile.id == profile_id)
-            .options(selectinload(models.AdmissionProfile.lead))
+            .options(
+                raiseload("*"),
+                selectinload(models.AdmissionProfile.lead),
+            )
             .with_for_update(of=models.AdmissionProfile)
         )
         if with_choices:

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -278,33 +278,19 @@ async def calculate_fee(
         # only the profile lookup is unscoped now.
         unit_id = finance_scope_unit_id(current_user)
 
-        # Resolve academic_info via the SHARED resolver (single source of truth
-        # with FeeCalculationService) so the discount ngành matches the ngành the
-        # service prices the tuition against — handles legacy single-path AND
-        # multi-NV (admitted-choice / single-choice). For tuition the service
-        # looks up the amount from offering_semester_tuition (PR 3 — ADR-002);
-        # the router only needs discount policy IDs. For non-tuition the base
-        # amount still comes from academic_info.tuition_fee_per_year.
-        from app.services.fee_calculation_service import resolve_fee_academic_info
-
-        academic_info = await resolve_fee_academic_info(db, profile)
-        discount_policy_ids = list(academic_info.applied_discount_policy_ids or [])
-
-        base_amount = Decimal("0")
-        if data.fee_type != FeeTypeEnum.tuition:
-            base_amount = academic_info.tuition_fee_per_year or Decimal("0")
-            if base_amount <= 0:
-                raise BadRequest(
-                    "Cannot calculate fee: No fee amount configured for this offering"
-                )
-
-        # Calculate fee
+        # #7/#9: pricing is resolved ONCE, UNDER THE ROW LOCK, inside
+        # calculate_fee. Pass base_amount/discount_policy_ids = None so the
+        # service derives BOTH the amount and the discount policies from a single
+        # resolve_fee_academic_info held under the lock — removing the pre-lock
+        # resolve here (no double resolve) and closing the race where the router
+        # resolved discount pre-lock while the service resolved amount post-lock
+        # (a concurrent waitlist-promote could have mismatched the two ngành).
         fee, post_commit = await fee_service.calculate_fee(
             admission_profile_id=data.admission_profile_id,
             fee_type=data.fee_type,
-            base_amount=base_amount,
+            base_amount=None,
             academic_year=profile.academic_year,
-            discount_policy_ids=discount_policy_ids,
+            discount_policy_ids=None,
             installment_plan_id=plan_id,
             user_id=current_user.id,
             unit_id=unit_id,

--- a/Backend_FastAPI/app/services/admission_choice_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_service.py
@@ -29,6 +29,7 @@ Tighten ngăn typosquat `/api/v2/admissions/abc/choices` đụng route khác.
 """
 from typing import Any, Callable, Optional, Tuple  # noqa: F401
 
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -528,22 +529,25 @@ class AdmissionChoiceService:
             )
 
     async def _lock_profile(self, profile: AdmissionProfile) -> None:
-        """Acquire the AdmissionProfile row lock + refresh the re-check columns.
+        """Acquire the AdmissionProfile row lock + refresh ALL scalar columns.
 
         Serializes NV-structure mutations against fee creation, which locks the
         SAME row first (``FeeCalculationService.calculate_fee``). Uses
-        ``db.refresh(..., with_for_update=True)`` — ONE ``SELECT … FOR UPDATE``
-        that both locks the row and refreshes ONLY the two columns the
-        downstream re-checks read (``status`` + ``uses_choice_engine``). This
-        avoids re-hydrating the whole entity (the ``AdmissionProfile`` mapper
-        has ~12 ``lazy="selectin"`` relations that a full entity reload would
-        all re-fire), while still reading committed state under the lock rather
-        than a stale identity-map copy.
+        ``db.refresh(..., with_for_update=True)`` over the model's mapped COLUMN
+        attributes only — ONE ``SELECT … FOR UPDATE`` that locks the row and
+        refreshes every scalar (status / uses_choice_engine / academic_year /
+        applied_rules / …) WITHOUT touching relationships, so the ~12
+        ``lazy="selectin"`` relations a full entity reload would re-fire stay
+        untouched (no fan-out). Refreshing the WHOLE column set — not just the
+        columns today's re-checks happen to read — is the lock contract: any
+        present OR future under-lock read of a scalar sees committed state,
+        never a stale identity-map value from the non-locking IDOR load.
         """
+        column_attrs = [
+            attr.key for attr in sa_inspect(type(profile)).column_attrs
+        ]
         await self.db.refresh(
-            profile,
-            attribute_names=["status", "uses_choice_engine"],
-            with_for_update=True,
+            profile, attribute_names=column_attrs, with_for_update=True
         )
 
     async def _assert_no_finance_lock(

--- a/Backend_FastAPI/app/services/admission_choice_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_service.py
@@ -40,7 +40,6 @@ from app.repositories.admission_profile_choice_repository import (
     AdmissionProfileChoiceRepository,
 )
 from app.repositories.admission_path_repository import AdmissionPathRepository
-from app.repositories.admission_repository import AdmissionRepository
 from app.repositories.fee_repository import FeeRepository
 from app.services.activity_service import log_activity
 from app.services.system_config_service import SystemConfigService
@@ -79,7 +78,6 @@ class AdmissionChoiceService:
         self.choice_repo = AdmissionProfileChoiceRepository(db)
         self.path_repo = AdmissionPathRepository(db)
         self.sysconfig = SystemConfigService(db)
-        self.admission_repo = AdmissionRepository(db)
         self.fee_repo = FeeRepository(db)
 
     async def add_choice(
@@ -335,9 +333,7 @@ class AdmissionChoiceService:
         (draft / revision_requested) leaves no forensic record for a
         "where did NV 3 go?" complaint months later.
         """
-        await self._lock_profile(profile)
-        await self._assert_no_finance_lock(profile, action="xoá nguyện vọng")
-        self._assert_choice_editable(profile, action="xoá nguyện vọng")
+        await self._assert_choice_mutable(profile, action="xoá nguyện vọng")
 
         # Snapshot the row + score children BEFORE the cascade delete so
         # the audit log carries the full forensic state. Resolve the
@@ -413,9 +409,7 @@ class AdmissionChoiceService:
           410). Load round qua choice.admission_path_id (lazy add — single
           extra query, paths này low-traffic vs add_choice).
         """
-        await self._lock_profile(profile)
-        await self._assert_no_finance_lock(profile, action="đổi thứ tự nguyện vọng")
-        self._assert_choice_editable(profile, action="đổi thứ tự nguyện vọng")
+        await self._assert_choice_mutable(profile, action="đổi thứ tự nguyện vọng")
 
         round_obj = await self.choice_repo.get_round_by_path_id(
             choice.admission_path_id
@@ -475,9 +469,7 @@ class AdmissionChoiceService:
         update_choice_display_order — load round qua admission_path_id
         + assert open. RoundClosedError → 410.
         """
-        await self._lock_profile(profile)
-        await self._assert_no_finance_lock(profile, action="cập nhật điểm nguyện vọng")
-        self._assert_choice_editable(profile, action="cập nhật điểm nguyện vọng")
+        await self._assert_choice_mutable(profile, action="cập nhật điểm nguyện vọng")
 
         round_obj = await self.choice_repo.get_round_by_path_id(
             choice.admission_path_id
@@ -536,16 +528,22 @@ class AdmissionChoiceService:
             )
 
     async def _lock_profile(self, profile: AdmissionProfile) -> None:
-        """Acquire the AdmissionProfile row lock + refresh in-session attrs.
+        """Acquire the AdmissionProfile row lock + refresh the re-check columns.
 
         Serializes NV-structure mutations against fee creation, which locks the
-        SAME row first (``FeeCalculationService.calculate_fee``).
-        ``populate_existing`` overwrites the (non-locking) IDOR-loaded instance
-        so the finance-lock + status re-checks read committed state under the
-        lock rather than a stale identity-map copy.
+        SAME row first (``FeeCalculationService.calculate_fee``). Uses
+        ``db.refresh(..., with_for_update=True)`` — ONE ``SELECT … FOR UPDATE``
+        that both locks the row and refreshes ONLY the two columns the
+        downstream re-checks read (``status`` + ``uses_choice_engine``). This
+        avoids re-hydrating the whole entity (the ``AdmissionProfile`` mapper
+        has ~12 ``lazy="selectin"`` relations that a full entity reload would
+        all re-fire), while still reading committed state under the lock rather
+        than a stale identity-map copy.
         """
-        await self.admission_repo.get_by_id_for_update(
-            profile.id, populate_existing=True
+        await self.db.refresh(
+            profile,
+            attribute_names=["status", "uses_choice_engine"],
+            with_for_update=True,
         )
 
     async def _assert_no_finance_lock(
@@ -571,6 +569,23 @@ class AdmissionChoiceService:
                 f"Hồ sơ đã phát sinh học phí, không thể {action}; "
                 "cần xử lý tài chính bằng quy trình riêng."
             )
+
+    async def _assert_choice_mutable(
+        self, profile: AdmissionProfile, *, action: str
+    ) -> None:
+        """Single gate for NV-structure mutations: lock → finance-freeze →
+        editable, IN THAT ORDER.
+
+        Bundling the three so a future NV-structure mutation can't silently skip
+        the finance freeze (the failure mode this consolidation guards). Order
+        matters: the finance freeze fires BEFORE the editable/status check so
+        error messages stay stable for the existing tests. ``add_choice`` keeps
+        its own inline prechecks (different wording + extra round/quota checks)
+        but still runs ``_lock_profile`` + ``_assert_no_finance_lock`` first.
+        """
+        await self._lock_profile(profile)
+        await self._assert_no_finance_lock(profile, action=action)
+        self._assert_choice_editable(profile, action=action)
 
     async def _snapshot_and_store_scores(
         self,

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -355,6 +355,18 @@ class FeeCalculationService:
         elif fee_type != FeeTypeEnum.tuition:
             semester_no = None
 
+        # #5 review: ``base_amount=None`` is the "service resolves pricing"
+        # sentinel (router path) and it also derives discount_policy_ids, so an
+        # explicit discount_policy_ids alongside it is contradictory. Reject the
+        # ambiguous combo fail-fast — a programming/contract error; no real
+        # caller mixes them (router passes both None, direct callers pass both).
+        if base_amount is None and discount_policy_ids is not None:
+            raise ValueError(
+                "calculate_fee: base_amount=None (service-resolve mode) cannot "
+                "be combined with an explicit discount_policy_ids — pass both "
+                "None (router) or both explicit (direct caller)."
+            )
+
         # Profile-first row lock — serialize vs choice mutation. Acquiring the
         # AdmissionProfile row lock BEFORE reading choices closes the race where
         # another request adds/removes a NV between the router's authz check and

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -123,6 +123,12 @@ async def resolve_fee_academic_info(
     e.g. under the fee-create lock that loads only lead + choices) →
     ``applied_rules['academic_info_id']``. Choice-engine profiles never fall
     through to this path.
+
+    COUPLING (do not let drift): the "exactly 1 choice" branch is the PRICING
+    counterpart of the submitted-prepay GATE in
+    ``admission_status.is_fee_eligible`` (multi-NV ⇒ exactly 1 NV). Keep both in
+    lockstep; the end-to-end anchor is
+    ``tests/api/test_phase3_pr3d_b_choice_crud.py``.
     """
     if getattr(profile, "uses_choice_engine", False):
         stmt = (

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -265,12 +265,23 @@ class FeeCalculationService:
     async def _lookup_semester_tuition_amount(
         self, profile: models.AdmissionProfile, semester_no: int,
     ) -> Decimal:
-        """Look up canonical tuition amount from offering_semester_tuition.
+        """Resolve the ngành then look up its HK tuition amount.
 
         Direct query — does NOT navigate ORM relationships to avoid
         async lazy-load issues.
         """
         academic_info_id = await self._resolve_academic_info_id(profile)
+        return await self._semester_tuition_amount_for_ai(
+            academic_info_id, semester_no
+        )
+
+    async def _semester_tuition_amount_for_ai(
+        self, academic_info_id: int, semester_no: int,
+    ) -> Decimal:
+        """HK tuition amount from ``offering_semester_tuition`` for an ALREADY
+        resolved ``academic_info_id`` — lets ``calculate_fee`` reuse a single
+        ``resolve_fee_academic_info`` call (amount + discount from the SAME
+        ngância) instead of resolving twice (#7)."""
         result = await self.db.execute(
             select(models.OfferingSemesterTuition.amount).where(
                 models.OfferingSemesterTuition.academic_info_id == academic_info_id,
@@ -290,7 +301,7 @@ class FeeCalculationService:
         self,
         admission_profile_id: int,
         fee_type: FeeTypeEnum,
-        base_amount: Decimal,
+        base_amount: Optional[Decimal],
         academic_year: str,
         discount_policy_ids: Optional[List[int]] = None,
         installment_plan_id: Optional[int] = None,
@@ -306,6 +317,14 @@ class FeeCalculationService:
         ``base_amount`` parameter is ignored for tuition — the caller need
         not provide it. For non-tuition fees, ``base_amount`` is used as
         before and ``semester_no`` stays None.
+
+        Pricing resolution (#7/#9): pass ``base_amount=None`` (the HTTP router
+        does) to have the service resolve the ngành ONCE under the row lock and
+        derive BOTH the amount and ``discount_policy_ids`` from the same
+        ``resolve_fee_academic_info`` — no pre-lock resolve, no double resolve,
+        no discount/amount ngành mismatch. Direct/test callers pass an explicit
+        ``base_amount`` → values used as-is (``discount_policy_ids=None`` keeps
+        the legacy "no discount" meaning, not auto-derive).
 
         Args:
             admission_profile_id: Profile to create fee for
@@ -369,8 +388,34 @@ class FeeCalculationService:
                 "chưa công bố kết quả, hoặc nguyện vọng đã thay đổi)."
             )
 
-        # For tuition: look up canonical amount from offering_semester_tuition
-        if fee_type == FeeTypeEnum.tuition:
+        # #7/#9: when base_amount is None (the HTTP router path) resolve the
+        # ngành ONCE under the lock and derive BOTH the amount and the discount
+        # policies from the SAME academic_info — closing the race where the
+        # router resolved discount pre-lock while the service resolved amount
+        # post-lock (a concurrent waitlist-promote could mismatch the two), and
+        # removing the double resolve. Direct/test callers pass an explicit
+        # base_amount → their values are used as-is; a ``discount_policy_ids`` of
+        # None then keeps the legacy "no discount" meaning (NOT auto-derive).
+        if base_amount is None:
+            academic_info = await resolve_fee_academic_info(self.db, profile)
+            if discount_policy_ids is None:
+                discount_policy_ids = list(
+                    academic_info.applied_discount_policy_ids or []
+                )
+            if fee_type == FeeTypeEnum.tuition:
+                base_amount = await self._semester_tuition_amount_for_ai(
+                    academic_info.id, semester_no
+                )
+            else:
+                base_amount = academic_info.tuition_fee_per_year or Decimal("0")
+                if base_amount <= 0:
+                    raise BadRequest(
+                        "Cannot calculate fee: No fee amount configured "
+                        "for this offering"
+                    )
+        elif fee_type == FeeTypeEnum.tuition:
+            # Explicit base_amount provided, but tuition's amount is always the
+            # canonical offering_semester_tuition value (base_amount ignored).
             base_amount = await self._lookup_semester_tuition_amount(
                 profile, semester_no
             )

--- a/Backend_FastAPI/app/utils/admission_status.py
+++ b/Backend_FastAPI/app/utils/admission_status.py
@@ -132,6 +132,14 @@ def is_fee_eligible(profile: "AdmissionProfile") -> bool:
 
     Earlier states (``draft`` etc.) are NOT eligible (a fee would be premature).
     Keep this in lockstep with both call sites if the gate ever changes.
+
+    COUPLING (do not let drift): the "multi-NV ⇒ exactly 1 NV" rule here is the
+    GATE (may a fee be created at all?). Its PRICING counterpart — which NV's
+    ngành the fee is computed against — lives in
+    ``fee_calculation_service.resolve_fee_academic_info``. Change one ⇒ change
+    the other. The end-to-end anchor that fails on drift:
+    ``tests/api/test_phase3_pr3d_b_choice_crud.py`` (single-choice→201;
+    ≥2-pending / 0-choice → fail-closed).
     """
     if is_admitted_like(profile) or profile.status in ("confirmed", "enrolled"):
         return True

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -16,6 +16,7 @@ downstream fee service is unit-tested elsewhere.
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 
 import pytest
 import pytest_asyncio
@@ -1046,3 +1047,120 @@ async def test_multi_nv_zero_choice_at_admitted_fails_closed(
         f"0-choice admitted multi-NV must fail closed at fee creation (no "
         f"snapshot fallback), got {resp.status_code}: {resp.text[:300]}"
     )
+
+
+# ==============================================================================
+# Follow-up #1/#2 — service-resolved pricing branches (base_amount=None path)
+# ==============================================================================
+# After the resolve-once refactor the router passes base_amount=None /
+# discount_policy_ids=None and the SERVICE derives both under the lock. These
+# two branches are prod-reachable but were uncovered (every other test passes an
+# explicit base_amount → the legacy elif path).
+
+
+@pytest.mark.asyncio
+async def test_calculate_nontuition_fee_derives_base_from_academic_info(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """A NON-tuition fee via POST /api/fees/calculate exercises the service's
+    ``base_amount=None`` → ``academic_info.tuition_fee_per_year`` derive branch
+    (the router no longer pre-resolves base/discount). Locks that branch — no
+    other test POSTs a non-tuition fee through this route.
+    """
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="NonTuition Derive",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "enrollment",
+            "installment_plan_code": "FULL",
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 201, (
+        f"non-tuition fee should derive base from academic_info, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+    body = resp.json()
+    # academic_info.tuition_fee_per_year (5,000,000); no discount configured.
+    assert Decimal(str(body["base_amount"])) == Decimal("5000000"), body
+    assert Decimal(str(body["final_amount"])) == Decimal("5000000"), body
+
+
+@pytest.mark.asyncio
+async def test_calculate_tuition_auto_derives_discount_from_academic_info(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Tuition via POST (``base_amount=None``) auto-derives ``discount_policy_ids``
+    from the resolved academic_info under the lock. Seed a fixed 500k discount +
+    link it to the ngành → the created fee must reflect ``total_discount>0``
+    (final < base). Guards against the auto-derive silently returning ``[]`` (the
+    discount vanishing from a tuition prepay).
+    """
+    from sqlalchemy import update as sa_update
+    from app.models.tuition_discount_policy import TuitionDiscountPolicy
+
+    ts = str(int(datetime.now().timestamp() * 1000) % 10**9)
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            policy = TuitionDiscountPolicy(
+                code=f"DISC_{ts}"[:50],
+                name=f"Follow-up smoke discount {ts}",
+                discount_type="amount",
+                discount_value=Decimal("500000"),
+                is_active=True,
+                applicable_scope={},
+                target_criteria={},
+            )
+            s.add(policy)
+            await s.flush()
+            ai_id = (await s.execute(
+                select(models.OfferingAcademicInfo.id).where(
+                    models.OfferingAcademicInfo.offering_id
+                    == fee_calc_config["offering_id"]
+                )
+            )).scalar_one()
+            await s.execute(
+                sa_update(models.OfferingAcademicInfo)
+                .where(models.OfferingAcademicInfo.id == ai_id)
+                .values(applied_discount_policy_ids=[policy.id])
+            )
+
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Discount Derive",
+    )
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 201, (
+        f"tuition with a linked discount policy should auto-derive it, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+    body = resp.json()
+    # HK1 tuition 5,000,000 − fixed 500,000 = 4,500,000 (discount auto-derived
+    # under the lock from the resolved academic_info).
+    assert Decimal(str(body["total_discount"])) == Decimal("500000"), body
+    assert Decimal(str(body["final_amount"])) == Decimal("4500000"), body


### PR DESCRIPTION
Follow-up cho #416 (học phí multi-NV 1 NV). **Correctness-preserving** (chỉ perf + hardening + test coverage); 152 test pass local + browser smoke (tạo phí thật) + qua 3 vòng code review.

## Thay đổi (3 commit)
**Perf / khử race (đụng khối lock + resolver):**
- **#7/#9**: `calculate_fee` resolve ngành **1 lần dưới row lock** → suy ra cả amount + discount_policy_ids từ cùng academic_info. Router thôi resolve pre-lock (`base_amount=None`/`discount_policy_ids=None`) → bỏ double-resolve + đóng race discount(pre-lock) vs amount(post-lock). **Backward-compat**: `base_amount: Optional`, resolve CHỈ khi None; ~50 direct caller truyền giá trị → giữ nguyên (discount `None→[]`).
- **#5(lock)**: `_lock_profile` dùng `db.refresh(with_for_update=True)` thay `get_by_id_for_update` re-hydrate ~12 selectin.
- **#6**: `get_by_id_for_update` + `raiseload("*")` + selectinload(lead, choices) → bỏ fan-out; stray-access RAISES (test bắt) thay lazy-load MissingGreenlet.

**Hardening / maintainability:**
- **#12**: gộp lock+finance-freeze+editable vào `_assert_choice_mutable` (giữ thứ tự).
- **#4**: `_lock_profile` refresh TOÀN BỘ cột scalar (introspect `column_attrs`, không fan-out) — lock contract, mọi read scalar dưới lock thấy committed state.
- **#5(param)**: reject `base_amount=None`+`discount_policy_ids` set (ValueError fail-fast — khử nghĩa kép sentinel).
- **#13**: ghim coupling `is_fee_eligible` (gate) ↔ `resolve_fee_academic_info` (pricing) bằng doc.

**Test (#1/#2)**: non-tuition POST → derive base; tuition auto-derive discount (final < base).

## Defer (PR riêng / chờ product)
- **#11** DRY `get_by_id_for_update` vào deps.py (đụng IDOR mọi route approve/reject/finalize).
- **#3** chokepoint tuyệt đối `add_choice` (đổi message → vỡ test).
- **#6-eager** OAC eager-load thừa trên đường calculate; **#7-double-load** router nạp profile 2 lần.
- **#2** refresh snapshot @publish (priority đọc NV1 — chờ product chốt); **#14** loại multi-NV khỏi approve/reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
