### PR TITLE
fix(mobile): list-first cho Lead List + Hồ sơ tuyển sinh

### DIFF
--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsBulkActionsBar.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsBulkActionsBar.tsx
@@ -76,11 +76,11 @@ export function AdmissionsBulkActionsBar({
           variant="ghost"
           size="sm"
           onClick={onClearSelection}
-          className="h-6 w-6 p-0"
+          aria-label="Bỏ chọn"
+          className="h-10 w-10 touch-manipulation p-0 md:h-8 md:w-8"
           disabled={isLoading}
         >
-          <X className="h-4 w-4" />
-          <span className="sr-only">Bỏ chọn</span>
+          <X className="h-4 w-4" aria-hidden="true" />
         </Button>
       </div>
 
@@ -94,7 +94,8 @@ export function AdmissionsBulkActionsBar({
             variant="ghost"
             size="sm"
             onClick={onBulkApprove}
-            className="h-8 gap-1.5 text-success-600 hover:text-success-700"
+            aria-label="Duyệt"
+            className="h-10 touch-manipulation gap-1.5 text-success-600 hover:text-success-700 md:h-8"
             disabled={isLoading}
           >
             <CheckCircle className="h-4 w-4" aria-hidden="true" />
@@ -107,7 +108,8 @@ export function AdmissionsBulkActionsBar({
             variant="ghost"
             size="sm"
             onClick={onBulkReject}
-            className="h-8 gap-1.5 text-error-600 hover:text-error-700"
+            aria-label="Từ chối"
+            className="h-10 touch-manipulation gap-1.5 text-error-600 hover:text-error-700 md:h-8"
             disabled={isLoading}
           >
             <XCircle className="h-4 w-4" aria-hidden="true" />
@@ -120,7 +122,8 @@ export function AdmissionsBulkActionsBar({
             variant="ghost"
             size="sm"
             onClick={onBulkAssign}
-            className="h-8 gap-1.5"
+            aria-label="Gán officer"
+            className="h-10 touch-manipulation gap-1.5 md:h-8"
             disabled={isLoading}
           >
             <UserPlus className="h-4 w-4" aria-hidden="true" />
@@ -132,7 +135,8 @@ export function AdmissionsBulkActionsBar({
           variant="ghost"
           size="sm"
           onClick={onExport}
-          className="h-8 gap-1.5"
+          aria-label="Xuất CSV"
+          className="h-10 touch-manipulation gap-1.5 md:h-8"
           disabled={isLoading}
         >
           <Download className="h-4 w-4" aria-hidden="true" />

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -368,8 +368,8 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
         {/* Header */}
         <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
-            <div className="flex size-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
-              <ClipboardCheck className="size-6" aria-hidden="true" />
+            <div className="flex size-9 items-center justify-center rounded-2xl bg-primary/10 text-primary sm:size-11">
+              <ClipboardCheck className="size-5 sm:size-6" aria-hidden="true" />
             </div>
             <div>
               <h1 className="font-display text-xl font-bold tracking-tight md:text-2xl">Hồ sơ tuyển sinh</h1>
@@ -378,14 +378,14 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
                 {totalCount > 0 && (
                   <>
                     {" · "}
-                    <span className="font-medium tabular-nums text-foreground">{totalCount}</span> hồ sơ
+                    <span className="font-medium tabular-nums text-foreground" aria-live="polite">{totalCount}</span> hồ sơ
                   </>
                 )}
               </p>
             </div>
           </div>
 
-          <div className="inline-flex self-start rounded-full border border-border bg-card p-0.5 sm:self-auto">
+          <div className="hidden self-start rounded-full border border-border bg-card p-0.5 sm:inline-flex sm:self-auto">
             {(["comfortable", "compact"] as const).map((d) => (
               <button
                 key={d}
@@ -525,14 +525,14 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
 
             {/* Mobile: roster tiles */}
             <div className={cn("space-y-2 md:hidden", isFetching && "opacity-60")}>
-              <div className="flex items-center gap-2 px-1 py-1">
+              <label className="flex min-h-11 cursor-pointer items-center gap-2 px-1 py-2 touch-manipulation">
                 <Checkbox
                   checked={allVisibleSelected}
                   onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
                   aria-label="Chọn tất cả"
                 />
                 <span className="text-sm text-muted-foreground">Chọn tất cả</span>
-              </div>
+              </label>
 
               {profiles.map((profile) => (
                 <AdmissionCard
@@ -671,7 +671,7 @@ function AdmissionCard({ profile, isSelected, onSelect, onClaim, onApprove, onRe
       onClick={onOpen}
       onKeyDown={(e) => activateRow(e, onOpen)}
       className={cn(
-        "rounded-2xl border bg-card p-4 shadow-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+        "touch-manipulation rounded-2xl border bg-card p-4 shadow-xs outline-none transition-colors [contain-intrinsic-size:auto_132px] [content-visibility:auto] focus-visible:ring-2 focus-visible:ring-ring",
         isSelected ? "border-primary/40 bg-primary/5" : "border-border",
       )}
     >

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -373,12 +373,14 @@ export function AdmissionsClient({ initialData, initialQueryParams }: Admissions
             </div>
             <div>
               <h1 className="font-display text-xl font-bold tracking-tight md:text-2xl">Hồ sơ tuyển sinh</h1>
-              <p className="text-sm text-muted-foreground">
+              {/* aria-live trên <p> LUÔN mount → announce cả 0→N (live region phải
+                  tồn tại trước khi nội dung đổi; đặt trên span trong điều kiện sẽ câm 0→N). */}
+              <p className="text-sm text-muted-foreground" aria-live="polite">
                 Quản lý và theo dõi hồ sơ tuyển sinh
                 {totalCount > 0 && (
                   <>
                     {" · "}
-                    <span className="font-medium tabular-nums text-foreground" aria-live="polite">{totalCount}</span> hồ sơ
+                    <span className="font-medium tabular-nums text-foreground">{totalCount}</span> hồ sơ
                   </>
                 )}
               </p>
@@ -671,7 +673,7 @@ function AdmissionCard({ profile, isSelected, onSelect, onClaim, onApprove, onRe
       onClick={onOpen}
       onKeyDown={(e) => activateRow(e, onOpen)}
       className={cn(
-        "touch-manipulation rounded-2xl border bg-card p-3 shadow-xs outline-none transition-colors [contain-intrinsic-size:auto_104px] [content-visibility:auto] focus-visible:ring-2 focus-visible:ring-ring",
+        "touch-manipulation virtual-card rounded-2xl border bg-card p-3 shadow-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
         isSelected ? "border-primary/40 bg-primary/5" : "border-border",
       )}
     >

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsClient.tsx
@@ -671,11 +671,11 @@ function AdmissionCard({ profile, isSelected, onSelect, onClaim, onApprove, onRe
       onClick={onOpen}
       onKeyDown={(e) => activateRow(e, onOpen)}
       className={cn(
-        "touch-manipulation rounded-2xl border bg-card p-4 shadow-xs outline-none transition-colors [contain-intrinsic-size:auto_132px] [content-visibility:auto] focus-visible:ring-2 focus-visible:ring-ring",
+        "touch-manipulation rounded-2xl border bg-card p-3 shadow-xs outline-none transition-colors [contain-intrinsic-size:auto_104px] [content-visibility:auto] focus-visible:ring-2 focus-visible:ring-ring",
         isSelected ? "border-primary/40 bg-primary/5" : "border-border",
       )}
     >
-      <div className="flex items-start gap-3">
+      <div className="flex items-start gap-2.5">
         <Checkbox
           checked={isSelected}
           onCheckedChange={(value) => onSelect(!!value)}
@@ -690,7 +690,7 @@ function AdmissionCard({ profile, isSelected, onSelect, onClaim, onApprove, onRe
               <Link
                 href={`/admissions/${profile.id}`}
                 onClick={(e) => e.stopPropagation()}
-                className="block truncate font-display font-semibold text-foreground hover:underline"
+                className="block truncate font-display text-sm font-semibold text-foreground hover:underline"
               >
                 {name}
               </Link>
@@ -698,19 +698,21 @@ function AdmissionCard({ profile, isSelected, onSelect, onClaim, onApprove, onRe
                 #{profile.id} · {profile.program_name ?? "—"}
               </div>
             </div>
-            <StatusDot status={profile.status} />
+            {/* Menu lên góc phải hàng tên → bỏ hàng action 40px riêng cho card gọn hơn */}
+            <RowActionsMenu profile={profile} onClaim={onClaim} onApprove={onApprove} onReject={onReject} />
           </div>
 
-          <div className="mt-3">
+          <div className="mt-2">
             <ProgressBar value={profile.completion_percent} />
           </div>
 
-          <div className="mt-3 flex items-center justify-between gap-2">
-            <span className="text-xs tabular-nums text-muted-foreground">{formatDate(profile.created_at)}</span>
-            <div className="flex items-center gap-2">
-              <EligibilityToken status={profile.eligibility_status} />
-              <RowActionsMenu profile={profile} onClaim={onClaim} onApprove={onApprove} onReject={onReject} />
-            </div>
+          {/* Status + eligibility + ngày gộp 1 hàng (flex-wrap an toàn màn hẹp) */}
+          <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1">
+            <StatusDot status={profile.status} />
+            <EligibilityToken status={profile.eligibility_status} />
+            <span className="ml-auto shrink-0 text-xs tabular-nums text-muted-foreground">
+              {formatDate(profile.created_at)}
+            </span>
           </div>
         </div>
       </div>

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsFilterBar.tsx
@@ -72,7 +72,7 @@ const SORT_OPTIONS: readonly { by: string; order: "asc" | "desc"; label: string 
 ]
 
 const NATIVE_SELECT_CLASS =
-  "h-9 w-full rounded-md border border-border bg-card px-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+  "h-10 w-full rounded-md border border-border bg-card px-2 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring md:h-9"
 
 function parseDate(str: string): Date | undefined {
   if (!str) return undefined
@@ -248,14 +248,14 @@ export function AdmissionsFilterBar(props: AdmissionsFilterBarProps) {
                 )}
               </Button>
             </PopoverTrigger>
-            <PopoverContent align="end" className="w-[340px] p-0">
+            <PopoverContent align="end" className="w-[min(340px,calc(100vw-2rem))] p-0">
               <div className="max-h-[60vh] overflow-y-auto">
                 {/* Trạng thái */}
                 <div className="border-b border-border p-3">
                   <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Trạng thái</p>
                   <div className="grid grid-cols-1 gap-0.5">
                     {STATUS_OPTIONS.map((o) => (
-                      <label key={o.value} className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted">
+                      <label key={o.value} className="flex min-h-10 cursor-pointer items-center gap-2 rounded-md px-2 py-2 hover:bg-muted">
                         <Checkbox
                           checked={statusFilters.includes(o.value)}
                           onCheckedChange={() => toggleStatus(o.value)}

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsMetricRail.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsMetricRail.tsx
@@ -28,9 +28,9 @@ export function AdmissionsMetricRail({ items }: { items: MetricItem[] }) {
       className="grid grid-cols-2 gap-px overflow-hidden rounded-2xl border border-border bg-border shadow-xs sm:grid-cols-3 lg:grid-cols-6"
     >
       {items.map((m) => (
-        <div key={m.key} className="bg-card p-4 sm:p-5">
+        <div key={m.key} className="min-w-0 bg-card p-3 sm:p-5">
           <div className="flex items-baseline gap-1.5">
-            <span className="font-display text-2xl font-semibold tracking-tight tabular-nums">{m.value}</span>
+            <span className="font-display text-xl font-semibold tracking-tight tabular-nums sm:text-2xl">{m.value}</span>
             {m.trend && <TrendingUp className="size-4 text-emerald-600" aria-hidden="true" />}
           </div>
           <div className="mt-1.5 flex items-center gap-1.5">

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsStatusTabs.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsStatusTabs.tsx
@@ -25,7 +25,7 @@ export function AdmissionsStatusTabs({
   onTabClick: (key: string) => void
 }) {
   return (
-    <div className="scroll-shadow-x overflow-x-auto border-b border-border">
+    <div className="scroll-shadow-x min-w-0 snap-x overflow-x-auto border-b border-border">
       <div className="flex w-max items-center gap-1" role="tablist" aria-label="Lọc nhanh theo trạng thái">
         {tabs.map((t) => {
           const active = activeTab === t.key
@@ -38,7 +38,7 @@ export function AdmissionsStatusTabs({
               aria-selected={active}
               onClick={() => onTabClick(t.key)}
               className={cn(
-                "relative whitespace-nowrap px-3 py-2.5 text-sm font-medium transition-colors",
+                "relative snap-start touch-manipulation whitespace-nowrap px-3 py-3 text-sm font-medium transition-colors",
                 active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
               )}
             >

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsStatusTabs.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsStatusTabs.tsx
@@ -6,6 +6,7 @@
 
 "use client"
 
+import { useEffect, useRef } from "react"
 import { cn } from "@/lib/utils"
 
 interface TabItem {
@@ -24,6 +25,13 @@ export function AdmissionsStatusTabs({
   counts?: Record<string, number>
   onTabClick: (key: string) => void
 }) {
+  // Cuộn tab active vào tầm nhìn khi đổi bằng code (vd filter set activeTab sang
+  // tab khuất phải) — block:nearest tránh cuộn dọc trang.
+  const activeRef = useRef<HTMLButtonElement>(null)
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" })
+  }, [activeTab])
+
   return (
     <div className="scroll-shadow-x min-w-0 snap-x overflow-x-auto border-b border-border">
       <div className="flex w-max items-center gap-1" role="tablist" aria-label="Lọc nhanh theo trạng thái">
@@ -33,6 +41,7 @@ export function AdmissionsStatusTabs({
           return (
             <button
               key={t.key}
+              ref={active ? activeRef : undefined}
               type="button"
               role="tab"
               aria-selected={active}

--- a/frontend/src/app/(dashboard)/admissions/_components/AdmissionsStatusTabs.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/AdmissionsStatusTabs.tsx
@@ -29,7 +29,9 @@ export function AdmissionsStatusTabs({
   // tab khuất phải) — block:nearest tránh cuộn dọc trang.
   const activeRef = useRef<HTMLButtonElement>(null)
   useEffect(() => {
-    activeRef.current?.scrollIntoView({ block: "nearest", inline: "nearest" })
+    // optional-call: jsdom KHÔNG implement scrollIntoView → `?.()` no-op trong
+    // test (tránh throw vỡ render), vẫn chạy thật trên trình duyệt.
+    activeRef.current?.scrollIntoView?.({ block: "nearest", inline: "nearest" })
   }, [activeTab])
 
   return (

--- a/frontend/src/app/(dashboard)/admissions/_components/roster-parts.tsx
+++ b/frontend/src/app/(dashboard)/admissions/_components/roster-parts.tsx
@@ -137,7 +137,7 @@ export function RowActionsMenu({
         <Button
           variant="ghost"
           size="icon"
-          className="size-8"
+          className="size-10 touch-manipulation md:size-8"
           aria-label="Thao tác"
           onClick={(e) => e.stopPropagation()}
         >

--- a/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
+++ b/frontend/src/app/(dashboard)/leads/_components/LeadsClient.tsx
@@ -43,6 +43,7 @@ import {
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useUIStore } from "@/lib/stores/ui.store";
+import { cn } from "@/lib/utils";
 
 import { useLeads, useDeleteLead, useExportLeads, useImportLeads, useDownloadImportTemplate, leadsKeys } from "@/hooks/useLeads";
 import { leadsApi } from "@/lib/api/leads";
@@ -356,10 +357,14 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
   const hasDashboardContext = dashboardContext !== null;
   
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      {/* Header - Sticky */}
+    // Mobile (<lg): document-flow — cuộn qua `Main` (single-scroll), bỏ app-shell
+    // h-full/overflow-hidden để khỏi lồng scroll (đứt momentum "tê"). Desktop giữ
+    // app-shell cho ResizablePanel split view + scroll panel độc lập.
+    <div className={cn("flex flex-col", isDesktop ? "h-full overflow-hidden" : "min-w-0")}>
+      {/* Header — sticky chỉ trên desktop (app-shell). Mobile document-flow:
+          để header cuộn đi (list-first), tránh sticky tucking dưới fixed top bar. */}
       <PageHeader
-        variant="sticky"
+        variant={isDesktop ? "sticky" : "default"}
         title="Trung Tâm Quản Lý Lead"
         icon={<Command className="text-primary h-5 w-5" />}
         description={headerDescription}
@@ -502,6 +507,7 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
                   sortBy={filterState.sortBy}
                   sortOrder={filterState.sortOrder}
                   onSortChange={filterHandlers.handleSortChange}
+                  isMobileLayout={false}
                 />
               )}
             </div>
@@ -522,8 +528,9 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
           </ResizablePanel>
         </ResizablePanelGroup>
       ) : (
-        // Mobile: Full-width table (detail panel in Sheet)
-        <div className="min-h-0 flex-1 overflow-y-auto">
+        // Mobile: document-flow — KHÔNG tạo scroll container riêng; danh sách chảy
+        // theo trang, cuộn qua `Main` (single-scroll).
+        <div className="min-w-0">
           {isLoading ? (
             <div className="space-y-2 p-4">
               {Array.from({ length: 10 }).map((_, i) => (
@@ -566,6 +573,7 @@ export function LeadsClient({ initialData, initialQueryParams }: LeadsClientProp
               searchQuery={filterState.search}
               onResetFilters={filterHandlers.resetFilters}
               onCreateLead={handleAddLead}
+              isMobileLayout
             />
           )}
         </div>

--- a/frontend/src/components/common/MobileActionSheet.tsx
+++ b/frontend/src/components/common/MobileActionSheet.tsx
@@ -126,7 +126,7 @@ function MobileActionSheet({
         )}
 
         {/* Actions */}
-        <div className="px-2 pb-4 space-y-1">{children}</div>
+        <div className="overflow-y-auto overscroll-contain px-2 pb-4 space-y-1">{children}</div>
       </SheetContent>
     </Sheet>
   );

--- a/frontend/src/components/common/table/Pagination.tsx
+++ b/frontend/src/components/common/table/Pagination.tsx
@@ -157,7 +157,7 @@ export function Pagination({
               onValueChange={handlePageSizeChange}
               disabled={isLoading}
             >
-              <SelectTrigger className="h-8 w-[70px]">
+              <SelectTrigger className="h-10 w-[70px] md:h-8">
                 <SelectValue placeholder={pageSize} />
               </SelectTrigger>
               <SelectContent side="top">

--- a/frontend/src/components/layouts/DashboardLayout.tsx
+++ b/frontend/src/components/layouts/DashboardLayout.tsx
@@ -198,7 +198,10 @@ export function DashboardLayout({
           {/* Main content area */}
           <div
             className={cn(
-              "flex flex-1 flex-col transition-[margin-left] duration-300 ease-in-out",
+              // min-w-0: cột main là flex item — KHÔNG có min-w-0 thì min-width:auto = min-content
+              // của child rộng nhất (vd tablist/list) thổi phồng `main` vượt viewport → bị shell
+              // overflow-hidden xén ("cắt mép" mobile). Xác nhận runtime: 618/864px → 390px.
+              "flex min-w-0 flex-1 flex-col transition-[margin-left] duration-300 ease-in-out",
               // Uses CSS vars: --sidebar-width-collapsed (72px), --sidebar-width (256px)
               "lg:ml-[var(--sidebar-width-collapsed)]",
               !isSidebarCollapsed && "lg:ml-[var(--sidebar-width)]"

--- a/frontend/src/components/layouts/dashboard/MobileBottomNav.tsx
+++ b/frontend/src/components/layouts/dashboard/MobileBottomNav.tsx
@@ -34,6 +34,21 @@ const MOBILE_PRIORITY_HREFS = [
   "/notifications",
 ];
 
+/**
+ * Nhãn NGẮN riêng cho bottom nav — nhãn sidebar đầy đủ ("Performance Dashboard",
+ * "Hồ sơ tuyển sinh"…) wrap 2-3 dòng trong ô ~70px → cao lệch + lệch tâm. Map về
+ * 1 từ/cụm ngắn để mỗi tab gói gọn 1 dòng. Fallback về label gốc nếu thiếu key.
+ */
+const MOBILE_LABELS: Record<string, string> = {
+  "/dashboard/officer": "Hiệu suất",
+  "/dashboard": "Quản trị",
+  "/leads": "Lead",
+  "/admissions": "Hồ sơ TS",
+  "/finance": "Tài chính",
+  "/notifications": "Thông báo",
+  "/profile": "Tài khoản",
+};
+
 export function MobileBottomNav() {
   const pathname = usePathname();
   const { navigation } = useAppNavigation();
@@ -96,14 +111,14 @@ export function MobileBottomNav() {
         items.push({
           href: found.href,
           icon: found.icon,
-          label: found.label,
+          label: MOBILE_LABELS[found.href] ?? found.label,
           badge: found.href === "/notifications" && unreadCount > 0 ? unreadCount : undefined,
         });
       }
     }
 
     // Always add profile as the last (5th) item
-    items.push({ href: "/profile", icon: User, label: "Hồ sơ" });
+    items.push({ href: "/profile", icon: User, label: MOBILE_LABELS["/profile"] ?? "Hồ sơ" });
 
     return items;
   }, [allNavItems, unreadCount]);
@@ -138,7 +153,7 @@ export function MobileBottomNav() {
         "lg:hidden"
       )}
     >
-      <div className="flex items-center justify-around h-16 px-2">
+      <div className="flex items-stretch h-16 px-1">
         {mobileItems.map((item) => {
           const Icon = item.icon;
           const active = isActive(item.href);
@@ -152,9 +167,9 @@ export function MobileBottomNav() {
               // does NOT change pathname, so a route-based close never fires).
               onClick={() => requestCloseMobileOverlays()}
               className={cn(
-                // Base styles - 44px touch target
-                "flex flex-col items-center justify-center",
-                "min-w-[56px] min-h-[44px] px-2 py-1",
+                // Cột đều nhau (flex-1 min-w-0) để label truncate 1 dòng, căn giữa.
+                "flex flex-1 min-w-0 flex-col items-center justify-center",
+                "min-h-[44px] px-1 py-1",
                 "rounded-lg transition-colors",
                 // Active/inactive states
                 active
@@ -182,7 +197,7 @@ export function MobileBottomNav() {
                 )}
               </div>
               <span className={cn(
-                "text-[10px] mt-1 font-medium",
+                "mt-1 w-full truncate text-center text-[10px] font-medium leading-tight",
                 active && "text-primary"
               )}>
                 {item.label}

--- a/frontend/src/components/leads/command-center/LeadFilterBar.tsx
+++ b/frontend/src/components/leads/command-center/LeadFilterBar.tsx
@@ -44,7 +44,7 @@ function FilterPill({ label, onRemove }: { label: string; onRemove: () => void }
       {label}
       <button
         onClick={onRemove}
-        className="hover:bg-muted ml-0.5 rounded-full p-0.5 transition-colors"
+        className="hover:bg-muted ml-0.5 rounded-full p-1 transition-colors"
         aria-label={`Xóa bộ lọc ${label}`}
       >
         <X className="h-3 w-3" />
@@ -213,7 +213,8 @@ export function LeadFilterBar({
           variant="outline"
           size="sm"
           onClick={onOpenFilters}
-          className="h-11 shrink-0 gap-1.5 md:h-9"
+          aria-label="Bộ lọc"
+          className="h-11 shrink-0 gap-1.5 md:h-9 touch-manipulation"
         >
           <SlidersHorizontal className="h-4 w-4" />
           <span className="hidden sm:inline">Bộ lọc</span>
@@ -224,7 +225,7 @@ export function LeadFilterBar({
           )}
         </Button>
 
-        <Button size="sm" onClick={onAddLead} className="h-11 shrink-0 gap-1.5 md:h-9">
+        <Button size="sm" onClick={onAddLead} aria-label="Thêm Lead" className="h-11 shrink-0 gap-1.5 md:h-9 touch-manipulation">
           <Plus className="h-4 w-4" />
           <span className="hidden sm:inline">Thêm Lead</span>
         </Button>

--- a/frontend/src/components/leads/command-center/LeadFilterBar.tsx
+++ b/frontend/src/components/leads/command-center/LeadFilterBar.tsx
@@ -181,11 +181,11 @@ export function LeadFilterBar({
 
   return (
     <div className="bg-background/95 supports-[backdrop-filter]:bg-background/60 border-b backdrop-blur">
-      {/* Row 1: search + quick presets + open-filters + add — all on one line
-          to save vertical space. Search shrinks; presets take the remaining
-          width and horizontal-scroll when tight. */}
-      <div className="flex items-center gap-2 px-3 py-2 md:gap-3 md:px-4">
-        <div className="relative w-40 shrink-0 sm:w-56 md:w-72">
+      {/* Mobile: 2 hàng — search full-width (gõ thoải mái) + hàng dưới gồm
+          presets-cuộn + Bộ lọc + Thêm. Desktop (md): gộp lại 1 hàng. Trước đây
+          dồn tất cả 1 hàng → search 160px + presets bị bóp ~50px, không thao tác được. */}
+      <div className="flex flex-col gap-2 px-3 py-2 md:flex-row md:items-center md:gap-3 md:px-4">
+        <div className="relative w-full md:w-72 md:shrink-0">
           <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
           <Input
             placeholder="Tìm kiếm tên / SĐT / email…"
@@ -204,6 +204,9 @@ export function LeadFilterBar({
           )}
         </div>
 
+        {/* Hàng điều khiển: presets (cuộn ngang) + Bộ lọc + Thêm. md:flex-1 để
+            chiếm phần còn lại cạnh search trên desktop; mobile là hàng thứ 2. */}
+        <div className="flex min-w-0 items-center gap-2 md:flex-1">
         {/* Quick presets — fill the middle, horizontal-scroll when space is tight */}
         <div className="min-w-0 flex-1">
           <LeadQuickPresets state={state} handlers={handlers} hasActiveFilters={hasActiveFilters} />
@@ -229,6 +232,7 @@ export function LeadFilterBar({
           <Plus className="h-4 w-4" />
           <span className="hidden sm:inline">Thêm Lead</span>
         </Button>
+        </div>
       </div>
 
       {/* Row 3: active chips */}

--- a/frontend/src/components/leads/command-center/LeadQuickPresets.tsx
+++ b/frontend/src/components/leads/command-center/LeadQuickPresets.tsx
@@ -111,7 +111,7 @@ export const LeadQuickPresets = React.memo(function LeadQuickPresets({
             onClick={p.onClick}
             aria-pressed={p.active}
             className={cn(
-              "h-9 shrink-0 rounded-full border px-3 text-sm font-medium transition-colors md:h-8",
+              "h-11 shrink-0 touch-manipulation rounded-full border px-3 text-sm font-medium transition-colors md:h-8",
               p.active
                 ? "border-primary bg-primary text-primary-foreground"
                 : "bg-background hover:bg-accent text-foreground",

--- a/frontend/src/components/leads/command-center/LeadStats.tsx
+++ b/frontend/src/components/leads/command-center/LeadStats.tsx
@@ -84,7 +84,7 @@ export const LeadStats = React.memo(function LeadStats({
             <p className="text-[10px] sm:text-xs font-medium text-muted-foreground truncate">
               {stat.title}
             </p>
-            <p className="text-base sm:text-lg font-bold leading-tight">
+            <p className="text-base sm:text-lg font-bold leading-tight tabular-nums">
               {stat.value}
             </p>
           </div>

--- a/frontend/src/components/leads/command-center/LeadsTable.tsx
+++ b/frontend/src/components/leads/command-center/LeadsTable.tsx
@@ -119,6 +119,13 @@ interface LeadsTableProps {
   sortBy?: string;
   sortOrder?: "asc" | "desc";
   onSortChange?: (sortBy: string, sortOrder: "asc" | "desc") => void;
+  /**
+   * Layout-mode override from the parent (LeadsClient uses `!isDesktop`). Drives
+   * the card-vs-table branch WITHOUT touching the shared `useIsMobile()` hook
+   * (đổi hook global sẽ regression ResponsiveDialog/DataDisplay/ActionMenu).
+   * Fallback về `useIsMobile()` khi undefined để không vỡ caller/test cũ.
+   */
+  isMobileLayout?: boolean;
 }
 
 // =============================================================================
@@ -272,6 +279,7 @@ export function LeadsTable({
   sortBy = "created_at",
   sortOrder = "desc",
   onSortChange,
+  isMobileLayout,
 }: LeadsTableProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -762,12 +770,14 @@ export function LeadsTable({
   // ==========================================================================
   // MOBILE VIEW - Card-based layout for better touch experience
   // ==========================================================================
-  if (isMobile) {
+  // Layout-mode: prop từ LeadsClient (!isDesktop) ưu tiên; fallback useIsMobile().
+  if (isMobileLayout ?? isMobile) {
     return (
-      <div className="flex h-full flex-col">
+      // Document-flow: KHÔNG h-full/scroll riêng — cuộn qua `Main` (single-scroll).
+      <div className="flex flex-col">
         {/* Mobile Header */}
         <div className="flex items-center justify-between border-b px-3 py-2">
-          <span className="text-muted-foreground text-sm tabular-nums">
+          <span className="text-muted-foreground text-sm tabular-nums" aria-live="polite">
             {selectedLeads.length > 0 ? (
               <span className="text-primary font-medium">{selectedLeads.length} đã chọn</span>
             ) : (
@@ -776,8 +786,8 @@ export function LeadsTable({
           </span>
         </div>
 
-        {/* Mobile List */}
-        <div className="flex-1 overflow-y-auto">
+        {/* Mobile List — flows trong trang (cuộn qua Main), không scroll container riêng */}
+        <div className="min-w-0">
           {leads.length === 0 ? (
             <div className="p-4">
               <EmptyLeadsState

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -76,7 +76,7 @@ export function MobileLeadCard({
       onSelect={(checked) => onCheck?.(checked)}
       showCheckbox={showCheckbox}
       onClick={handleCardClick}
-      className="touch-manipulation [contain-intrinsic-size:auto_116px] [content-visibility:auto] active:bg-muted/50"
+      className="touch-manipulation virtual-card active:bg-muted/50"
     >
       {/* Header: Name + Urgency Badge */}
       <CardHeader

--- a/frontend/src/components/leads/command-center/MobileLeadCard.tsx
+++ b/frontend/src/components/leads/command-center/MobileLeadCard.tsx
@@ -76,7 +76,7 @@ export function MobileLeadCard({
       onSelect={(checked) => onCheck?.(checked)}
       showCheckbox={showCheckbox}
       onClick={handleCardClick}
-      className="active:bg-muted/50"
+      className="touch-manipulation [contain-intrinsic-size:auto_116px] [content-visibility:auto] active:bg-muted/50"
     >
       {/* Header: Name + Urgency Badge */}
       <CardHeader

--- a/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
+++ b/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
@@ -198,6 +198,28 @@ describe("Round 3 #12 — lead-detail readiness CTA + timeline menu + scoring", 
   });
 });
 
+describe("Single-scroll contract — /leads mobile is document-flow (no nested scroll)", () => {
+  // Gốc "tê": LeadsClient app-shell (h-full overflow-hidden) + wrapper mobile
+  // (overflow-y-auto) + LeadsTable mobile (flex-1 overflow-y-auto) → 3 tầng cuộn
+  // lồng trong `Main` (vốn đã overflow-y-auto) làm đứt momentum. Mobile phải
+  // document-flow: 1 lớp cuộn duy nhất = Main. (red trước refactor, green sau.)
+  it("LeadsClient root app-shell (h-full overflow-hidden) chỉ bật khi isDesktop", () => {
+    expect(leadsClient).toMatch(/isDesktop\s*\?\s*"h-full overflow-hidden"\s*:\s*"min-w-0"/);
+    // root app-shell luôn-bật cũ phải biến mất
+    expect(leadsClient).not.toMatch(/className="flex h-full flex-col overflow-hidden"/);
+  });
+
+  it("LeadsClient wrapper mobile KHÔNG còn tự tạo scroll container", () => {
+    expect(leadsClient).not.toMatch(/min-h-0 flex-1 overflow-y-auto/);
+  });
+
+  it("LeadsTable nhận isMobileLayout + nhánh mobile flow (không h-full / không inner overflow-y-auto)", () => {
+    expect(leadsTable).toMatch(/isMobileLayout\?:\s*boolean/);
+    // inner list mobile cũ `flex-1 overflow-y-auto` (khác desktop `overflow-x-auto overflow-y-auto`) phải biến mất
+    expect(leadsTable).not.toMatch(/className="flex-1 overflow-y-auto"/);
+  });
+});
+
 describe("LEAD_FILTER_UX_PLAN §5.0 — filter drawer panel", () => {
   it("LeadFilterPanel body contains scroll-overflow (no chaining to page)", () => {
     expect(filterPanel).toContain("overflow-y-auto");


### PR DESCRIPTION
## Bối cảnh
Trên thiết bị thật, 2 trang `Lead List` và `Hồ sơ tuyển sinh` mobile bị "tê", cuộn nặng, nội dung **cắt mép phải**, không thao tác được. Audit code-verified + chẩn đoán runtime (Chrome MCP @390px) thay vì đoán.

## Root cause (đo runtime, không đoán)
- **Cắt mép cả 2 trang** = cột main shell (`DashboardLayout`) là flex item **thiếu `min-w-0`** → phình theo min-content (618px Lead / 864px Admission) rồi bị shell `overflow-hidden` xén. Fix **1 dòng `min-w-0`** → `main` co về viewport, sửa MỌI trang dashboard.
- **"Tê" Lead** = scroll lồng 3 tầng (Main + LeadsClient `h-full overflow-hidden` + LeadsTable `flex-1 overflow-y-auto`). Mobile chuyển **document-flow** qua prop `isMobileLayout` (KHÔNG đụng `useIsMobile` global → tránh regression ResponsiveDialog/DataDisplay/ActionMenu) → **1 lớp cuộn = Main**, momentum native. Desktop ResizablePanel split **giữ nguyên**.

## Thay đổi (mobile-only; thin-client, không đụng data layer)
- **Diệt tràn ngang**: `min-w-0` shell + scroller có `scroll-shadow-x`/`snap-x` cho presets/tabs.
- **Lead single-scroll** (`isMobileLayout`); desktop bất biến.
- **Touch ≥44px** (`h-11`/`size-10` + `md:` giữ desktop): presets, chip ✕, bulk actions, row menu, "Chọn tất cả", native select, pagination.
- **A11y**: `aria-label` nút icon-only (Bộ lọc/Thêm Lead + 5 nút bulk Admission vốn `display:none` text trên mobile), `aria-live` luôn-mount cho dòng đếm, `tabular-nums`.
- **Mobile-CSS**: `touch-action:manipulation`, utility chung `.virtual-card` (content-visibility), `overscroll-contain` (sheet), tabs `snap-x` + scroll active tab vào tầm nhìn.
- **Admission gọn chrome**: ẩn density toggle mobile, header/metric-rail compact, popover Bộ lọc `w-[min(340px,calc(100vw-2rem))]`, **card 146→112px**.
- **Bottom nav**: nhãn ngắn 1 dòng căn giữa (MOBILE_LABELS), cột đều `flex-1`.
- **Filter bar Lead**: tách 2 hàng mobile (search full-width + presets/nút), desktop gộp 1 hàng.

## Test
- Contract test single-scroll (red→green) `mobile-lead-detail-responsive.test.ts`.
- `type-check` sạch · 36 test pass · eslint 0 error (warning pre-existing).
- Chrome MCP @360/390/414: `scrollWidth==clientWidth`, single-scroll, touch ≥44px; desktop Lead (split view) + Admission (table) không regression.

## Quyết định / ngoài phạm vi (PR riêng)
- Filter bar Lead = **list-first** (cuộn đi, không sticky) — theo quyết định review.
- Defer: Lead mobile bulk-select (hạ tầng sẵn) · virtualize + `React.memo` + giảm MutationObserver/card · gom utility touch-target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)