### PR TITLE
feat(lead): nút Hủy/Dời lịch hẹn trên card consultation + guard updates_pipeline (A-safe)

### DIFF
--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -2993,21 +2993,37 @@ async def update_consultation(
                         # ✅ SECURITY FIX: Status already validated above, use validated_status
                         # No need for redundant db.get() - status existence is guaranteed
                         new_status = validated_status  # Reuse from validation above
-                        lead.consultation_status_id = new_status.id
-                        lead.pipeline_stage_id = new_status.stage_id
-                        # ✅ Sync lead.status từ consultation_status (Hybrid Approach)
-                        sync_lead_status_from_consultation(lead, new_status)
-                        lead.version = (lead.version or 1) + 1
-                        db.add(lead)
-                        status_changed = True
+                        # ✅ Guard updates_pipeline (fix bug stage→NULL): CHỈ sync lead
+                        # status/stage khi status THẬT SỰ đẩy pipeline. Universal
+                        # (sts01/15/19: updates_pipeline=false, stage_id=NULL ở prod)
+                        # → CHỈ đổi consultation row (đã set ở trên), KHÔNG đụng lead —
+                        # khớp luồng add_new_consultation. Trước đây set thẳng
+                        # lead.pipeline_stage_id = new_status.stage_id bất kể cờ → sửa
+                        # tay consultation mới nhất sang universal làm NULL stage lead.
+                        if new_status.updates_pipeline:
+                            lead.consultation_status_id = new_status.id
+                            lead.pipeline_stage_id = new_status.stage_id
+                            # ✅ Sync lead.status từ consultation_status (Hybrid Approach)
+                            sync_lead_status_from_consultation(lead, new_status)
+                            lead.version = (lead.version or 1) + 1
+                            db.add(lead)
+                            status_changed = True
 
-                        log.info(
-                            "Lead status updated via consultation update",
-                            lead_id=lead_id,
-                            consultation_id=consultation_id,
-                            old_status=old_consultation_status_id,
-                            new_status=new_status.id,
-                        )
+                            log.info(
+                                "Lead status updated via consultation update",
+                                lead_id=lead_id,
+                                consultation_id=consultation_id,
+                                old_status=old_consultation_status_id,
+                                new_status=new_status.id,
+                            )
+                        else:
+                            log.info(
+                                "Latest consultation set to non-pipeline (universal) "
+                                "status — lead status/stage giữ nguyên (no NULL stage)",
+                                lead_id=lead_id,
+                                consultation_id=consultation_id,
+                                new_status=new_status.id,
+                            )
 
             # Clear loss_reason if status is no longer negative
             effective_status = validated_status or (

--- a/Backend_FastAPI/tests/services/test_lead.py
+++ b/Backend_FastAPI/tests/services/test_lead.py
@@ -1239,6 +1239,65 @@ class TestConsultation:
         # Assert
         assert updated.notes == "Updated notes"
 
+    async def test_update_latest_consultation_to_universal_keeps_lead_stage(
+        self,
+        db: AsyncSession,
+        seeded_lead: models.Lead,
+        officer_user: models.User,
+        admin_user: models.User,
+        seeded_dependencies: dict,
+    ):
+        """Fix bug 2997: sửa consultation MỚI NHẤT sang status universal
+        (updates_pipeline=false — vd sts19 'Đã hủy lịch hẹn', stage_id=NULL) CHỈ
+        đổi consultation row, KHÔNG null/đổi ``pipeline_stage_id`` +
+        ``consultation_status_id`` của lead. Nền tảng an toàn cho nút 'Hủy lịch
+        hẹn' (A-safe). Trước fix: 2997 set thẳng stage = new_status.stage_id (NULL)."""
+        stage_id = seeded_dependencies["stage_id"]
+
+        piped = models.ConsultationStatus(
+            id="sts_pipe_guard", name="Pipeline Guard", color_code="#0b0b0b",
+            stage_id=stage_id, is_universal=False, updates_pipeline=True,
+        )
+        # sts19 ∈ UNIVERSAL_STATUSES (bypass phase guard) · updates_pipeline=False · stage NULL.
+        uni = models.ConsultationStatus(
+            id="sts19", name="Đã hủy lịch hẹn", color_code="#0c0c0c",
+            stage_id=None, is_universal=True, updates_pipeline=False,
+        )
+        db.add_all([piped, uni])
+        await db.flush()
+
+        # Lead đang ở stage pipeline; consultation mới nhất = piped.
+        seeded_lead.pipeline_stage_id = stage_id
+        seeded_lead.consultation_status_id = "sts_pipe_guard"
+        db.add(seeded_lead)
+        c = models.Consultation(
+            lead_id=seeded_lead.id, officer_id=officer_user.id,
+            consultation_date=datetime.now(timezone.utc),
+            method="phone", consultation_status_id="sts_pipe_guard",
+        )
+        db.add(c)
+        await db.flush()
+
+        class _Upd:
+            def model_dump(self, **kwargs):
+                return {"status_id": "sts19"}
+
+        with patch("app.services.lead_cache_service.update_lead_cache", new_callable=AsyncMock), \
+             patch(
+                 "app.services.lead_service.pipeline_service.validate_status_transition",
+                 new_callable=AsyncMock,
+             ) as m:
+            m.return_value = True
+            updated = await lead_service.update_consultation(
+                db, seeded_lead.id, c.id, _Upd(), admin_user
+            )
+            await db.flush()
+
+        await db.refresh(seeded_lead)
+        assert updated.consultation_status_id == "sts19"               # row ĐÃ đổi
+        assert seeded_lead.pipeline_stage_id == stage_id               # ✅ stage GIỮ NGUYÊN
+        assert seeded_lead.consultation_status_id == "sts_pipe_guard"  # ✅ status lead giữ nguyên
+
     async def test_add_consultation_stores_loss_reason_on_consultation(
         self,
         db: AsyncSession,

--- a/Backend_FastAPI/tests/services/test_lead.py
+++ b/Backend_FastAPI/tests/services/test_lead.py
@@ -1298,6 +1298,123 @@ class TestConsultation:
         assert seeded_lead.pipeline_stage_id == stage_id               # ✅ stage GIỮ NGUYÊN
         assert seeded_lead.consultation_status_id == "sts_pipe_guard"  # ✅ status lead giữ nguyên
 
+    async def test_cancel_latest_consultation_clears_scheduled_at(
+        self,
+        db: AsyncSession,
+        seeded_lead: models.Lead,
+        officer_user: models.User,
+        admin_user: models.User,
+        seeded_dependencies: dict,
+    ):
+        """Nút 'Hủy lịch hẹn': gửi đồng thời ``status_id=sts19`` + ``scheduled_at=None``
+        phải GỠ giờ hẹn (→ hết 'sống' → hết nhắc phụ huynh) NHƯNG KHÔNG null
+        stage/status lead (nhờ guard updates_pipeline). Đây là điểm cốt lõi của
+        action — verify scheduled_at thực sự bị clear, không chỉ đổi status."""
+        stage_id = seeded_dependencies["stage_id"]
+
+        piped = models.ConsultationStatus(
+            id="sts_pipe_cxl", name="Pipeline Cancel", color_code="#0b0b0b",
+            stage_id=stage_id, is_universal=False, updates_pipeline=True,
+        )
+        # sts19 universal: neutral (KHÔNG negative → không vướng loss_reason 400).
+        uni = models.ConsultationStatus(
+            id="sts19", name="Đã hủy lịch hẹn", color_code="#0c0c0c",
+            stage_id=None, is_universal=True, updates_pipeline=False,
+            outcome_type="neutral",
+        )
+        db.add_all([piped, uni])
+        await db.flush()
+
+        future = datetime.now(timezone.utc) + timedelta(days=3)
+        seeded_lead.pipeline_stage_id = stage_id
+        seeded_lead.consultation_status_id = "sts_pipe_cxl"
+        db.add(seeded_lead)
+        c = models.Consultation(
+            lead_id=seeded_lead.id, officer_id=officer_user.id,
+            consultation_date=datetime.now(timezone.utc),
+            scheduled_at=future,  # hẹn TƯƠNG LAI đang "sống"
+            method="phone", consultation_status_id="sts_pipe_cxl",
+        )
+        db.add(c)
+        await db.flush()
+
+        class _Cancel:
+            # FE gửi cả status_id lẫn scheduled_at=null → exclude_unset giữ cả 2.
+            def model_dump(self, **kwargs):
+                return {"status_id": "sts19", "scheduled_at": None}
+
+        with patch("app.services.lead_cache_service.update_lead_cache", new_callable=AsyncMock), \
+             patch(
+                 "app.services.lead_service.pipeline_service.validate_status_transition",
+                 new_callable=AsyncMock,
+             ) as m:
+            m.return_value = True
+            updated = await lead_service.update_consultation(
+                db, seeded_lead.id, c.id, _Cancel(), admin_user
+            )
+            await db.flush()
+
+        await db.refresh(seeded_lead)
+        assert updated.consultation_status_id == "sts19"               # row ĐÃ đổi
+        assert updated.scheduled_at is None                            # ✅ giờ hẹn ĐÃ gỡ
+        assert seeded_lead.pipeline_stage_id == stage_id               # ✅ stage GIỮ NGUYÊN
+        assert seeded_lead.consultation_status_id == "sts_pipe_cxl"    # ✅ status lead giữ nguyên
+
+    async def test_reschedule_consultation_changes_scheduled_at_only(
+        self,
+        db: AsyncSession,
+        seeded_lead: models.Lead,
+        officer_user: models.User,
+        admin_user: models.User,
+        seeded_dependencies: dict,
+    ):
+        """Nút 'Dời lịch': chỉ gửi ``scheduled_at`` mới (KHÔNG status_id) → đổi
+        đúng giờ hẹn trên chính dòng đó; status consultation + stage/status lead
+        giữ nguyên (khối status bị skip vì status_id không có trong update)."""
+        stage_id = seeded_dependencies["stage_id"]
+
+        piped = models.ConsultationStatus(
+            id="sts_pipe_resched", name="Pipeline Resched", color_code="#0d0d0d",
+            stage_id=stage_id, is_universal=False, updates_pipeline=True,
+        )
+        db.add(piped)
+        await db.flush()
+
+        old_dt = datetime.now(timezone.utc) + timedelta(days=2)
+        new_dt = datetime.now(timezone.utc) + timedelta(days=5)
+        seeded_lead.pipeline_stage_id = stage_id
+        seeded_lead.consultation_status_id = "sts_pipe_resched"
+        db.add(seeded_lead)
+        c = models.Consultation(
+            lead_id=seeded_lead.id, officer_id=officer_user.id,
+            consultation_date=datetime.now(timezone.utc),
+            scheduled_at=old_dt,
+            method="phone", consultation_status_id="sts_pipe_resched",
+        )
+        db.add(c)
+        await db.flush()
+
+        class _Reschedule:
+            # FE gửi DUY NHẤT scheduled_at → exclude_unset chỉ giữ field này.
+            def model_dump(self, **kwargs):
+                return {"scheduled_at": new_dt}
+
+        with patch("app.services.lead_cache_service.update_lead_cache", new_callable=AsyncMock):
+            updated = await lead_service.update_consultation(
+                db, seeded_lead.id, c.id, _Reschedule(), admin_user
+            )
+            await db.flush()
+
+        await db.refresh(seeded_lead)
+        got = updated.scheduled_at
+        assert got is not None
+        if got.tzinfo is None:
+            got = got.replace(tzinfo=timezone.utc)
+        assert abs((got - new_dt).total_seconds()) < 2                 # ✅ giờ hẹn = giờ MỚI
+        assert updated.consultation_status_id == "sts_pipe_resched"    # status row giữ nguyên
+        assert seeded_lead.pipeline_stage_id == stage_id               # ✅ stage lead giữ nguyên
+        assert seeded_lead.consultation_status_id == "sts_pipe_resched"
+
     async def test_add_consultation_stores_loss_reason_on_consultation(
         self,
         db: AsyncSession,

--- a/frontend/src/components/leads/LeadTimelineTab.tsx
+++ b/frontend/src/components/leads/LeadTimelineTab.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -19,6 +20,8 @@ import {
   Mail,
   MessageSquare,
   Calendar,
+  CalendarClock,
+  CalendarX2,
   UserPlus,
   Video,
   Trash2,
@@ -26,7 +29,18 @@ import {
   MoreVertical,
   AlertTriangle,
 } from "lucide-react";
-import { useLeadTimeline, useDeleteConsultation } from "@/hooks/useLeads";
+import { useLeadTimeline, useDeleteConsultation, useUpdateConsultation } from "@/hooks/useLeads";
+import { useConsultationStatuses } from "@/hooks/usePipeline";
+import { useAuthStore } from "@/lib/stores/auth.store";
+import { useClientNow } from "@/hooks/useClientNow";
+import { DateTimePicker } from "@/components/common/form";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { format, isToday, isYesterday, parseISO } from "date-fns";
 import { vi } from "date-fns/locale";
 import { cn, sanitizeColorCode } from "@/lib/utils";
@@ -220,11 +234,19 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
   const { data: timeline, isLoading } = useLeadTimeline(leadId);
   const effectiveLimit = limit ?? maxItems;
   const deleteMutation = useDeleteConsultation();
+  const updateMutation = useUpdateConsultation();
+  const { user } = useAuthStore();
+  const { data: allStatuses = [] } = useConsultationStatuses();
+  // Hydration-safe client time (null khi SSR) — gate hiển thị action theo "hẹn tương lai".
+  const now = useClientNow();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [selectedConsultationId, setSelectedConsultationId] = useState<number | null>(null);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [editingConsultation, setEditingConsultation] = useState<Consultation | null>(null);
   const [showAll, setShowAll] = useState(false);
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [reschedulingConsultation, setReschedulingConsultation] = useState<Consultation | null>(null);
+  const [rescheduleDate, setRescheduleDate] = useState<Date | undefined>(undefined);
 
   if (isLoading || !timeline) {
     return (
@@ -393,6 +415,30 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
   const itemsToShow = hasLimit ? maxItems : totalItems;
   let itemCount = 0;
 
+  // Quyền thao tác lịch hẹn: officer chỉ sửa được consultation MỚI NHẤT (khớp
+  // BE leads.py:1091 → tránh bấm rồi ăn 403); manager/admin sửa bất kỳ.
+  const userRole = user?.role;
+  const isPrivilegedActor = userRole === "admin" || userRole === "manager";
+  // Status "Đã hủy lịch hẹn" (sts19) — không hardcode, lấy động từ catalog.
+  const cancelStatusId = allStatuses.find(
+    (s) => s.id === "sts19" || s.name === "Đã hủy lịch hẹn",
+  )?.id;
+  // Consultation mới nhất của lead (theo consultation_date) — để gate officer.
+  const latestConsultationId = (() => {
+    let best: { id: number; t: number } | null = null;
+    for (const ev of timeline as TimelineItem[]) {
+      const et = ev.type || "";
+      const d = ev.data as Consultation | undefined;
+      const isConsult =
+        et === "consultation" || et === "consultation_added" || et === "consultation_updated";
+      if (isConsult && d?.id && d?.consultation_date) {
+        const ms = new Date(d.consultation_date).getTime();
+        if (!best || ms > best.t) best = { id: d.id, t: ms };
+      }
+    }
+    return best?.id ?? null;
+  })();
+
   const handleEditConsultation = (consultation: Consultation) => {
     setEditingConsultation(consultation);
     setEditDialogOpen(true);
@@ -413,6 +459,57 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
             setSelectedConsultationId(null);
           },
         }
+      );
+    }
+  };
+
+  const openReschedule = (consultation: Consultation) => {
+    setReschedulingConsultation(consultation);
+    setRescheduleDate(
+      consultation.scheduled_at ? new Date(consultation.scheduled_at) : undefined,
+    );
+  };
+
+  const confirmReschedule = () => {
+    if (reschedulingConsultation?.id && rescheduleDate) {
+      updateMutation.mutate(
+        {
+          leadId,
+          consultationId: reschedulingConsultation.id,
+          data: { scheduled_at: rescheduleDate.toISOString() },
+        },
+        {
+          onSuccess: () => {
+            setReschedulingConsultation(null);
+            setRescheduleDate(undefined);
+          },
+        },
+      );
+    }
+  };
+
+  // "Hủy lịch hẹn": đổi status → sts19 + xóa giờ hẹn. AN TOÀN nhờ BE guard
+  // updates_pipeline (universal KHÔNG null stage lead). Sửa in-place đúng cái
+  // hẹn → hết "sống" → hết nhắc phụ huynh; ghi nhận vẫn giữ trong lịch sử.
+  const openCancelAppointment = (consultationId: number) => {
+    setSelectedConsultationId(consultationId);
+    setCancelDialogOpen(true);
+  };
+
+  const confirmCancelAppointment = () => {
+    if (selectedConsultationId && cancelStatusId) {
+      updateMutation.mutate(
+        {
+          leadId,
+          consultationId: selectedConsultationId,
+          data: { status_id: cancelStatusId, scheduled_at: null },
+        },
+        {
+          onSuccess: () => {
+            setCancelDialogOpen(false);
+            setSelectedConsultationId(null);
+          },
+        },
       );
     }
   };
@@ -600,6 +697,36 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
                                 </Button>
                               </DropdownMenuTrigger>
                               <DropdownMenuContent align="end">
+                                {(() => {
+                                  // Chỉ hiện khi: hẹn ở TƯƠNG LAI (client-time, tránh
+                                  // hydration) + có quyền (privileged, hoặc officer trên
+                                  // consultation MỚI NHẤT — khớp BE, tránh 403).
+                                  const schedMs = consultData?.scheduled_at
+                                    ? new Date(consultData.scheduled_at).getTime()
+                                    : null;
+                                  const isFutureAppt =
+                                    now !== null && schedMs !== null && schedMs > now;
+                                  const canActOnAppt =
+                                    isPrivilegedActor ||
+                                    consultData?.id === latestConsultationId;
+                                  if (!isFutureAppt || !canActOnAppt || !consultData?.id) {
+                                    return null;
+                                  }
+                                  const cid = consultData.id;
+                                  return (
+                                    <>
+                                      <DropdownMenuItem onClick={() => openReschedule(consultData)}>
+                                        <CalendarClock className="h-4 w-4 mr-2" />
+                                        Dời lịch
+                                      </DropdownMenuItem>
+                                      <DropdownMenuItem onClick={() => openCancelAppointment(cid)}>
+                                        <CalendarX2 className="h-4 w-4 mr-2" />
+                                        Hủy lịch hẹn
+                                      </DropdownMenuItem>
+                                      <DropdownMenuSeparator />
+                                    </>
+                                  );
+                                })()}
                                 <DropdownMenuItem
                                   onClick={() => handleEditConsultation(consultData)}
                                 >
@@ -750,6 +877,69 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Cancel Appointment Confirmation */}
+      <AlertDialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Hủy lịch hẹn này?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Lịch hẹn sẽ được đánh dấu &quot;Đã hủy lịch hẹn&quot; và gỡ giờ hẹn —
+              KHÔNG gửi nhắc tới phụ huynh nữa. Ghi nhận tư vấn vẫn giữ trong lịch sử.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Không</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmCancelAppointment}
+              disabled={!cancelStatusId}
+              className="bg-error-600 hover:bg-error-700"
+            >
+              Hủy lịch hẹn
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Reschedule Appointment (gọn — chỉ chọn giờ mới, không mở full form) */}
+      <Dialog
+        open={Boolean(reschedulingConsultation)}
+        onOpenChange={(o) => {
+          if (!o) {
+            setReschedulingConsultation(null);
+            setRescheduleDate(undefined);
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Dời lịch hẹn</DialogTitle>
+          </DialogHeader>
+          <div className="py-2">
+            <DateTimePicker
+              value={rescheduleDate ?? null}
+              onChange={(d) => setRescheduleDate(d)}
+              minDate={now !== null ? new Date(now) : undefined}
+              placeholder="Chọn giờ hẹn mới"
+              clearable={false}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setReschedulingConsultation(null);
+                setRescheduleDate(undefined);
+              }}
+            >
+              Hủy
+            </Button>
+            <Button onClick={confirmReschedule} disabled={!rescheduleDate}>
+              Lưu
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Edit Consultation Dialog */}
       <ConsultationDialog

--- a/frontend/src/components/leads/LeadTimelineTab.tsx
+++ b/frontend/src/components/leads/LeadTimelineTab.tsx
@@ -37,6 +37,7 @@ import { DateTimePicker } from "@/components/common/form";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -914,6 +915,7 @@ export function LeadTimelineTab({ leadId, maxItems, compact, limit }: LeadTimeli
         <DialogContent className="sm:max-w-sm">
           <DialogHeader>
             <DialogTitle>Dời lịch hẹn</DialogTitle>
+            <DialogDescription>Chọn giờ hẹn mới cho lịch hẹn này.</DialogDescription>
           </DialogHeader>
           <div className="py-2">
             <DateTimePicker


### PR DESCRIPTION
## Tóm tắt (A-safe — follow-up của #419/B1)

Cho officer **hủy / dời một lịch hẹn TƯƠNG LAI bằng 1 click** ngay trên card consultation, thay vì thao tác thủ công nhiều bước. Kèm **fix một bug data-integrity pre-existing** (BE) làm nền tảng an toàn.

## 🔴 BE — fix bug 2997 (data-integrity, pre-existing)

`update_consultation` set thẳng `lead.consultation_status_id` + `lead.pipeline_stage_id = new_status.stage_id` cho consultation MỚI NHẤT mà **KHÔNG check `updates_pipeline`**; `sync_lead_status_from_consultation` chỉ set `lead.status`, không đụng stage. Nên sửa tay consultation mới nhất sang **universal status** (sts01/15/19: `updates_pipeline=false`, `stage_id=NULL` ở prod) → **NULL stage lead**. Luồng `add` xử lý universal đúng; chỉ luồng `update` lệch.

**Fix:** bọc khối sync lead status/stage trong `if new_status.updates_pipeline`. `updates_pipeline=false` → CHỈ đổi consultation row. +test: edit consultation mới nhất → sts19 giữ NGUYÊN stage + status lead (các test update_consultation cũ vẫn pass — 4/4).

## FE — nút "Hủy lịch hẹn" / "Dời lịch"

Quick-action contextual trên dropdown card consultation (`LeadTimelineTab`):
- **"Hủy lịch hẹn"** → `{ status_id: sts19, scheduled_at: null }` (sửa IN-PLACE đúng cái hẹn) → hết "sống" → **hết nhắc phụ huynh**; ghi nhận vẫn giữ trong lịch sử. AN TOÀN nhờ BE guard ở trên (universal không null stage).
- **"Dời lịch"** → Dialog GỌN chỉ `DateTimePicker` (không mở full ConsultationDialog).
- Chỉ hiện khi hẹn **TƯƠNG LAI** (`useClientNow` → hydration-safe) + có quyền: privileged (admin/manager) bất kỳ; **officer chỉ consultation MỚI NHẤT** (khớp BE `leads.py:1091` → tránh ăn 403). `cancelStatusId` lấy ĐỘNG (không hardcode).

## Vì sao
Sau #419/B1: hẹn TƯƠNG LAI luôn "sống" tới khi chính dòng hẹn đó bị sửa. Nếu officer "hủy" bằng cách thêm note rời → hẹn tương lai vẫn nhắc phụ huynh. Nút này làm thao tác in-place đúng đắn dễ + 1 click.

## Test
- BE: guard test + update_consultation tests **4/4 pass** (one-off container, qlts_test).
- FE: `tsc --noEmit` clean · eslint không warning mới ở file sửa.
- ⚠️ **Chrome MCP smoke: CHƯA chạy** — cần một lead có hẹn **TƯƠNG LAI** để thấy action; data dev/prod hiện tại KHÔNG có hẹn tương lai (đo prod: 0 future appointment) nên cần tạo data trước. **Khuyến nghị smoke action-flow trước merge.**

## Nợ defer
Backstop BE (tự clear scheduled_at hẹn tương lai cũ khi thêm consultation sts19) — policy rộng hơn, để sau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
