### PR TITLE
fix(prod-audit): invoice number atomicity + lead submit regression + snapshot dbname

### DIFF
--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -3275,6 +3275,25 @@ async def _create_admission_milestone_consultation(
         )
         return
 
+    # SL1 regression guard: on a submit/resubmit milestone for a lead that
+    # already carries a finance overlay (prepay application fee → sts13, or the
+    # HK1 tuition lifecycle → sts14/sts10/sts18), we STILL record the milestone
+    # consultation below (Golden Rule audit + consultation_count) but must NOT
+    # downgrade the lead pipeline back to sts07 ("Đã tiếp nhận"). This helper is
+    # the CANONICAL lead writer on submit (it runs before the officer-independent
+    # sync_lead_from_admission fallback), so the guard MUST live here — the sync
+    # guard alone is a no-op on the officer path because the lead would already
+    # be at sts07 by the time sync runs. Other events (approve/reject/enroll/...)
+    # are legitimate progressions and are intentionally NOT preserved.
+    from .lead_admission_sync import (
+        SUBMIT_FLOOR_EVENTS,
+        FEE_OVERLAY_LEAD_STATUSES,
+    )
+    preserve_lead_overlay = (
+        event in SUBMIT_FLOOR_EVENTS
+        and lead.consultation_status_id in FEE_OVERLAY_LEAD_STATUSES
+    )
+
     # Capture old state for history logging
     old_state = _get_current_lead_state(lead)
 
@@ -3336,6 +3355,20 @@ async def _create_admission_milestone_consultation(
         duration_minutes=0,  # System consultations have no duration
     )
     db.add(system_consultation)
+
+    if preserve_lead_overlay:
+        # Milestone recorded for audit, but the lead keeps its finance overlay
+        # (sts13/sts14/sts10/sts18) — do NOT downgrade it to the submit status.
+        log.info(
+            "SL1 guard: recorded submit milestone but preserved lead finance "
+            "overlay (not downgrading to sts07)",
+            lead_id=lead.id,
+            admission_event=event,
+            preserved_status=lead.consultation_status_id,
+            milestone_status=projection.consultation_status_id,
+            profile_id=profile_id,
+        )
+        return
 
     # Update lead pipeline (stage + status)
     lead.consultation_status_id = projection.consultation_status_id
@@ -9691,6 +9724,11 @@ async def resubmit_profile(
     profile.assigned_reviewer_id = None
     profile.assigned_at = None
 
+    # Capture lead consultation status BEFORE the milestone so we can tell
+    # whether the lead actually moved. The SL1 guard may preserve a finance
+    # overlay (sts13/sts14/sts10/sts18) instead of flooring to sts07.
+    _old_lead_cs = profile.lead.consultation_status_id if profile.lead else None
+
     # ✅ PIPELINE SYNC: Create system consultation for resubmission milestone
     if profile.lead:
         await _create_admission_milestone_consultation(
@@ -9724,6 +9762,13 @@ async def resubmit_profile(
     # Path C / Arch-3: paired notification bundle + commission callback.
     # Mirrors router admissions.py:1796+1811 (paired dispatch) + 1824
     # (commission). new_status="resubmitted" / lead "sts07".
+    # Did the lead actually change consultation status? The SL1 guard preserves
+    # a finance overlay (sts13/sts14/sts10/sts18) instead of flooring to sts07,
+    # so on that path the lead did NOT move — we must not broadcast a phantom
+    # LEAD_STATUS_CHANGED nor run commission bookkeeping for a non-transition.
+    _new_lead_cs = profile.lead.consultation_status_id if profile.lead else None
+    _lead_status_changed = bool(_new_lead_cs) and _new_lead_cs != _old_lead_cs
+
     bundle_callback = None
     if profile.lead_id:
         intents = [
@@ -9740,38 +9785,44 @@ async def resubmit_profile(
                 dedupe_key=f"admission_profile_resubmitted:{profile_id}",
                 rooms=rooms_for_admission(profile),
             ),
-            NotificationIntent(
-                event=SystemEvents.LEAD_STATUS_CHANGED,
-                payload={
-                    "lead_id": profile.lead_id,
-                    "lead_name": f"Profile #{profile_id}",
-                    "old_status": _old_status_for_audit,
-                    "new_status": "sts07",
-                    "actor_id": _actor_id,
-                    "actor_name": _actor_name,
-                },
-                dedupe_key=f"lead_status_changed:{profile.lead_id}:sts07",
-                rooms=rooms_for_admission(profile),
-            ),
         ]
+        # Only broadcast a lead status change when the lead actually moved
+        # (suppressed when the SL1 guard preserved a finance overlay).
+        if _lead_status_changed:
+            intents.append(
+                NotificationIntent(
+                    event=SystemEvents.LEAD_STATUS_CHANGED,
+                    payload={
+                        "lead_id": profile.lead_id,
+                        "lead_name": f"Profile #{profile_id}",
+                        "old_status": _old_status_for_audit,
+                        "new_status": _new_lead_cs,
+                        "actor_id": _actor_id,
+                        "actor_name": _actor_name,
+                    },
+                    dedupe_key=f"lead_status_changed:{profile.lead_id}:{_new_lead_cs}",
+                    rooms=rooms_for_admission(profile),
+                )
+            )
         bundle = await dispatch_bundle(
             db, bundle_label="admission_resubmit", intents=intents,
         )
         bundle_callback = bundle.callback
 
     commission_callback = None
-    # Commission attribution requires a real actor (sts07 itself doesn't
-    # forward-trigger commissions, but regression bookkeeping records the
-    # cancelling actor). Skip for the magic-link candidate path —
-    # candidate-driven resubmit is not a commission-relevant event.
-    if profile.lead_id and _actor_id is not None:
+    # Commission attribution requires a real actor AND an actual lead status
+    # change. sts07 itself doesn't forward-trigger commissions, but regression
+    # bookkeeping records the cancelling actor. Skip for the magic-link
+    # candidate path and when the SL1 guard preserved the overlay (no move).
+    if profile.lead_id and _actor_id is not None and _lead_status_changed:
         captured_lead_id = profile.lead_id
         captured_old = _old_status_for_audit
+        captured_new = _new_lead_cs
         captured_actor_id = _actor_id
 
         async def _commission_callback():
             await safe_check_commission_on_status_change(
-                db, captured_lead_id, captured_old, "sts07", captured_actor_id,
+                db, captured_lead_id, captured_old, captured_new, captured_actor_id,
             )
 
         commission_callback = _commission_callback

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -27,7 +27,7 @@ from decimal import Decimal, ROUND_HALF_UP
 from typing import List, Optional, Tuple, Callable
 import structlog
 
-from sqlalchemy import select, func, text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -775,47 +775,83 @@ class InvoiceService:
     # HELPER METHODS
     # ==========================================================================
 
+    # Tuition invoice number prefix. Application-fee invoices use a separate
+    # ``APP-{fee.id}`` scheme (see admission_service) and never pass through
+    # this helper, so the MAX scan below is naturally scoped to INV rows.
+    _INVOICE_PREFIX = "INV"
+
     async def _generate_invoice_number(self) -> str:
         """
-        Generate unique invoice number using database sequence.
+        Generate a unique tuition invoice number atomically.
 
-        Format: INV-YYYY-XXXXXX
-        Example: INV-2026-000001
+        Format: ``INV-YYYY-NNNNNN`` (e.g. ``INV-2026-000001``).
+
+        Concurrency: a transaction-scoped advisory lock keyed on
+        ``(prefix, year)`` serialises allocation so two invoices issued at the
+        same instant cannot read the same counter and collide on the
+        ``invoice_number`` UNIQUE index (which previously surfaced as an HTTP
+        500 under concurrent issue). The lock auto-releases when the
+        surrounding transaction commits or rolls back.
+
+        Counter: the next number is ``MAX(existing suffix) + 1`` scoped to
+        ``INV-{year}-`` rows whose suffix is purely numeric — replacing the old
+        ``COUNT(*) + 1`` over the whole table, which counted ``APP-*`` rows too
+        (so INV suffixes jumped and never reset per year). The
+        ``~ '^[0-9]{1,9}$'`` guard means a stray non-numeric OR oversized INV
+        row can never make the ``CAST`` overflow int4 or throw.
+        Note: ``invoice_number_seq`` was never created in prod, so the previous
+        code always fell through to that fragile count-based path.
 
         Returns:
-            Unique invoice number string
+            Unique invoice number string.
         """
         year = datetime.now(timezone.utc).year
+        prefix = self._INVOICE_PREFIX
 
-        # Use PostgreSQL sequence for atomic counter
-        # First try to get existing sequence, or use a fallback
-        seq_num = None
-        try:
-            # Use savepoint so failure doesn't abort the whole transaction
-            async with self.db.begin_nested():
-                result = await self.db.execute(
-                    text("SELECT nextval('invoice_number_seq')")
-                )
-                seq_num = result.scalar()
-        except Exception:
-            # Sequence doesn't exist - fallback to count-based generation
-            pass
+        # Flush pending invoices first so the MAX() scan below sees rows added
+        # earlier in the SAME transaction — e.g. sibling installment invoices in
+        # one generate_invoices_for_fee batch. Raw text() queries do not trigger
+        # the ORM autoflush that the old COUNT(*) select relied on, so make it
+        # explicit; otherwise every invoice in a multi-installment batch reads
+        # the same MAX and collides on the invoice_number UNIQUE index.
+        await self.db.flush()
 
-        if seq_num is None:
-            # Fallback: count existing invoices + 1
-            result = await self.db.execute(
-                select(func.count(Invoice.id))
-            )
-            seq_num = (result.scalar() or 0) + 1
+        # Serialise allocation for this (prefix, year). hashtext() is a stable
+        # PostgreSQL hash → deterministic across workers (Python's hash() is
+        # per-process salted and must NOT be used for a shared lock key).
+        await self.db.execute(
+            text("SELECT pg_advisory_xact_lock(hashtext(:lock_ns), :year)"),
+            {"lock_ns": f"invoice_number:{prefix}", "year": year},
+        )
 
-        invoice_number = f"INV-{year}-{seq_num:06d}"
+        # Highest suffix already issued for this prefix+year (NULL-safe → 0).
+        # The ``split_part ~ '^[0-9]{1,9}$'`` predicate keeps the CAST safe: it
+        # excludes any row whose 3rd segment is non-numeric (e.g. a manually
+        # inserted ``INV-2026-FOO``) AND any suffix longer than 9 digits, so the
+        # CAST can never overflow int4 (max 2,147,483,647) nor throw — one bad
+        # row cannot poison generation for the whole year. The timestamped
+        # collision fallback ``INV-2026-000001-<ts>`` IS still counted: its 3rd
+        # dash-segment is the numeric seq ``000001`` (the ts is the 4th).
+        result = await self.db.execute(
+            text(
+                "SELECT COALESCE(MAX(CAST(split_part(invoice_number, '-', 3) "
+                "AS INTEGER)), 0) FROM invoice "
+                "WHERE invoice_number LIKE :pattern "
+                "AND split_part(invoice_number, '-', 3) ~ '^[0-9]{1,9}$'"
+            ),
+            {"pattern": f"{prefix}-{year}-%"},
+        )
+        seq_num = (result.scalar() or 0) + 1
 
-        # Verify uniqueness (should not happen with sequence)
+        invoice_number = f"{prefix}-{year}-{seq_num:06d}"
+
+        # Belt-and-suspenders: the advisory lock makes a collision impossible,
+        # but verify once and fall back to a timestamped suffix if a row with a
+        # non-standard format ever slipped past the MAX scan.
         existing = await self.invoice_repo.get_by_invoice_number(invoice_number)
         if existing:
-            # Collision - append timestamp
             ts = int(datetime.now(timezone.utc).timestamp())
-            invoice_number = f"INV-{year}-{seq_num:06d}-{ts}"
+            invoice_number = f"{prefix}-{year}-{seq_num:06d}-{ts}"
 
         return invoice_number
 

--- a/Backend_FastAPI/app/services/lead_admission_sync.py
+++ b/Backend_FastAPI/app/services/lead_admission_sync.py
@@ -85,6 +85,35 @@ PRE_APPLICATION_LEAD_STATUSES: frozenset = frozenset({
     None, "sts00", "sts02", "sts03", "sts04", "sts05", "sts06",
 })
 
+# Profile submit transitions that must not REGRESS a lead already carrying a
+# finance overlay. ``submitted`` / ``resubmitted`` normally floor the lead up to
+# sts07 (Đã tiếp nhận hồ sơ), but with the prepay fast-track a lead can reach
+# sts13 (lệ phí đã đóng) — or a later tuition overlay — while the profile is
+# still ``draft``. Submitting then must NOT pull the lead back down to sts07 and
+# erase the "đã đóng tiền" signal. This is regression SL1.
+SUBMIT_FLOOR_PROFILE_STATUSES: frozenset[str] = frozenset({"submitted", "resubmitted"})
+
+# Lead consultation statuses representing a finance overlay that sits ABOVE the
+# "hồ sơ đã tiếp nhận" milestone — application fee paid (sts13) plus the HK1
+# tuition lifecycle (sts14 chờ đóng / sts10 đã đóng / sts18 đã hoàn). A
+# submit/resubmit must PRESERVE these. NOTE: rejected (sts16) and
+# revision_requested (sts17) are intentionally ABSENT so a genuine resubmit
+# after a reject/revision still floors the lead back up to sts07.
+FEE_OVERLAY_LEAD_STATUSES: frozenset[str] = frozenset(
+    {"sts13", "sts14", "sts10", "sts18"}
+)
+
+# Admission milestone events that represent a submit/resubmit transition.
+# ``_create_admission_milestone_consultation`` is the CANONICAL writer of lead
+# state on submit — it runs BEFORE the officer-independent
+# ``sync_lead_from_admission`` fallback and sets the lead unconditionally. It
+# must therefore apply the same FEE_OVERLAY floor as ``_should_apply_admission_floor``;
+# otherwise the overlay regresses to sts07 on the officer path before the sync
+# guard ever sees it (SL1). Keep this set in sync with SUBMIT_FLOOR_PROFILE_STATUSES.
+SUBMIT_FLOOR_EVENTS: frozenset[str] = frozenset(
+    {"profile_submitted", "profile_resubmitted"}
+)
+
 # Sentinel for ``profile.status == "result_published"``. Kept as a constant
 # so the test suite can lock the no-op contract without restringifying the
 # value at the call site.
@@ -95,16 +124,28 @@ def _should_apply_admission_floor(
     profile_status: str,
     lead_consultation_status_id: Optional[str],
 ) -> bool:
-    """Pure decision rule for floor-only profile statuses.
+    """Pure decision rule guarding regression-prone profile statuses.
 
-    Returns ``True`` when the sync should proceed (lead still below the
-    admission floor) and ``False`` to preserve a later lead state.
-    Non-floor statuses always return ``True`` so the existing fall-through
+    Returns ``True`` when the sync should proceed and ``False`` to preserve a
+    later lead state. Two guarded families:
+
+    1. ``reviewing`` / ``waitlisted`` (choice-engine floor-up): only progress a
+       lead still in the pre-application phase; never regress one past sts07.
+    2. ``submitted`` / ``resubmitted``: floor the lead up to sts07 UNLESS it
+       already carries a finance overlay (sts13/sts14/sts10/sts18). This stops
+       the prepay regression (SL1) where submitting after paying the
+       application fee dragged the lead sts13 → sts07. Resubmits from
+       rejected/revision (sts16/sts17) are NOT overlays, so they still progress.
+
+    Every other status short-circuits to ``True`` so the existing fall-through
     logic applies unchanged.
     """
-    if profile_status not in FLOOR_FROM_PROFILE_STATUSES:
-        return True
-    return lead_consultation_status_id in PRE_APPLICATION_LEAD_STATUSES
+    if profile_status in FLOOR_FROM_PROFILE_STATUSES:
+        return lead_consultation_status_id in PRE_APPLICATION_LEAD_STATUSES
+    if profile_status in SUBMIT_FLOOR_PROFILE_STATUSES:
+        return lead_consultation_status_id not in FEE_OVERLAY_LEAD_STATUSES
+    return True
+
 
 # Application fee status from event mapping (Single Source of Truth)
 # Uses admission_event_mapping.py -> "application_fee_paid" event
@@ -190,9 +231,10 @@ async def sync_lead_from_admission(
         )
         return False
 
-    # Floor-only statuses (``reviewing`` / ``waitlisted``) must not regress
-    # a lead that already advanced past sts07. See FLOOR_FROM_PROFILE_STATUSES
-    # docstring for the rationale.
+    # Regression guard: floor-only statuses (``reviewing`` / ``waitlisted``)
+    # must not regress a lead past sts07, and ``submitted`` / ``resubmitted``
+    # must not erase a finance overlay (sts13/sts14/sts10/sts18 — SL1). See the
+    # _should_apply_admission_floor docstring for the rationale.
     if not _should_apply_admission_floor(profile.status, lead.consultation_status_id):
         log.debug(
             "sync_lead_from_admission: Floor-only status, lead already past "

--- a/Backend_FastAPI/tests/integration/test_finance_workflow.py
+++ b/Backend_FastAPI/tests/integration/test_finance_workflow.py
@@ -457,6 +457,14 @@ class TestInvoiceGeneration:
         assert invoices[1].installment_no == 2
         assert invoices[2].installment_no == 3
 
+        # F1 regression guard: every invoice in one batch must get a distinct,
+        # sequential number. The MAX-without-flush collision made all three
+        # collapse to INV-YYYY-000001 and violate the UNIQUE index.
+        invoice_numbers = [inv.invoice_number for inv in invoices]
+        assert len(set(invoice_numbers)) == 3, \
+            f"Invoice numbers must be unique, got {invoice_numbers}"
+        assert all(n.startswith("INV-") for n in invoice_numbers)
+
         # Verify due dates
         assert invoices[1].due_date == invoices[0].due_date + timedelta(days=30)
         assert invoices[2].due_date == invoices[1].due_date + timedelta(days=30)

--- a/Backend_FastAPI/tests/integration/test_lead_admission_sync.py
+++ b/Backend_FastAPI/tests/integration/test_lead_admission_sync.py
@@ -67,6 +67,9 @@ async def sync_statuses(db: AsyncSession) -> dict:
         # Revision & Drop statuses
         "sts17": {"name": "Yêu cầu bổ sung hồ sơ", "phase": "admission", "order": 217},
         "sts12": {"name": "Ngưng theo học", "phase": "enrolled", "order": 212},
+        # Application fee paid (prepay fast-track overlay) — needed for the
+        # submit-regression guard test (SL1).
+        "sts13": {"name": "Đã hoàn tất lệ phí", "phase": "admission", "order": 213},
         # Finance Phase statuses
         "sts14": {"name": "Chưa hoàn tất học phí", "phase": "finance", "order": 214},
         "sts10": {"name": "Đã hoàn tất học phí", "phase": "finance", "order": 210},
@@ -105,6 +108,23 @@ async def sync_statuses(db: AsyncSession) -> dict:
         db.add(status)
         created_status_ids.append(status_id)
 
+    await db.flush()
+
+    # Canonical pipeline stages used by admission_event_mapping projections.
+    # The milestone helper sets lead.pipeline_stage_id = projection.pipeline_stage_id
+    # (stg03/stg04/stg05/stg06/stg07) — distinct from the stg_sync_* stages above
+    # that back the consultation statuses. Without these the milestone path trips
+    # the lead_pipeline_stage_id_fkey FK. High order values avoid collisions.
+    for std_stage_id, std_order in [
+        ("stg03", 8003), ("stg04", 8004), ("stg05", 8005),
+        ("stg06", 8006), ("stg07", 8007),
+    ]:
+        if not await db.get(models.PipelineStage, std_stage_id):
+            db.add(models.PipelineStage(
+                id=std_stage_id,
+                name=f"Canonical {std_stage_id}",
+                order=std_order,
+            ))
     await db.flush()
 
     return {"status_ids": created_status_ids}
@@ -1260,3 +1280,294 @@ class TestSyncStudentDropped:
     async def test_sts12_fixture_exists(self, sync_statuses: dict):
         """sts12 should be created in fixture for integration tests."""
         assert "sts12" in sync_statuses["status_ids"]
+
+
+# ==============================================================================
+# TEST: SUBMIT REGRESSION GUARD (SL1 — prepay fast-track)
+# ==============================================================================
+
+
+class TestSyncSubmitFinanceRegressionGuard:
+    """SL1 guard at the SYNC level (officer-independent fallback path only).
+
+    These call ``sync_lead_from_admission`` DIRECTLY — they pin the guard on
+    the magic-link / no-officer fallback branch, where the milestone helper
+    skipped the lead update (no officer resolvable) and sync is the sole
+    protection. The dominant OFFICER path goes through
+    ``_create_admission_milestone_consultation`` FIRST (which would otherwise
+    clobber the overlay to sts07 before sync runs) — that path is covered by
+    ``TestSubmitMilestoneFinanceRegressionGuard`` below. Both layers must hold.
+    """
+
+    async def test_submit_preserves_sts13_fee_paid(
+        self,
+        db: AsyncSession,
+        sync_lead: models.Lead,
+        sync_user: models.User,
+        sync_statuses: dict,
+    ):
+        """Lead at sts13 (đã đóng lệ phí) must stay at sts13 when the profile
+        is submitted — no regression to sts07."""
+        sync_lead.consultation_status_id = "sts13"
+        await db.flush()
+
+        profile = await create_profile(db, sync_lead, "submitted")
+
+        result = await sync_lead_from_admission(
+            db=db,
+            profile=profile,
+            changed_by_user_id=sync_user.id,
+            reason="Profile submitted after prepay",
+        )
+
+        assert result is False, "Submit must not regress a fee-paid lead"
+
+        await db.refresh(sync_lead)
+        assert sync_lead.consultation_status_id == "sts13", \
+            f"Expected sts13 preserved, got {sync_lead.consultation_status_id}"
+
+    @pytest.mark.parametrize("overlay_status", ["sts14", "sts10", "sts18"])
+    async def test_submit_preserves_tuition_overlay(
+        self,
+        db: AsyncSession,
+        sync_lead: models.Lead,
+        sync_user: models.User,
+        sync_statuses: dict,
+        overlay_status: str,
+    ):
+        """Tuition overlays (calculated/paid/refunded) must also survive a
+        late submit/resubmit."""
+        sync_lead.consultation_status_id = overlay_status
+        await db.flush()
+
+        profile = await create_profile(db, sync_lead, "resubmitted")
+
+        result = await sync_lead_from_admission(
+            db=db,
+            profile=profile,
+            changed_by_user_id=sync_user.id,
+            reason="Resubmit while tuition overlay active",
+        )
+
+        assert result is False
+        await db.refresh(sync_lead)
+        assert sync_lead.consultation_status_id == overlay_status
+
+    async def test_resubmit_from_rejected_still_floors_to_sts07(
+        self,
+        db: AsyncSession,
+        sync_lead: models.Lead,
+        sync_user: models.User,
+        sync_statuses: dict,
+    ):
+        """A genuine resubmit after a reject (sts16) MUST progress to sts07 —
+        rejected is not a finance overlay, so the guard must not block it."""
+        sync_lead.consultation_status_id = "sts16"
+        await db.flush()
+
+        profile = await create_profile(db, sync_lead, "resubmitted")
+
+        result = await sync_lead_from_admission(
+            db=db,
+            profile=profile,
+            changed_by_user_id=sync_user.id,
+            reason="Resubmit after reject",
+        )
+
+        assert result is True
+        await db.refresh(sync_lead)
+        assert sync_lead.consultation_status_id == "sts07", \
+            f"Expected sts07 after resubmit, got {sync_lead.consultation_status_id}"
+
+    async def test_submit_from_consultation_floors_to_sts07(
+        self,
+        db: AsyncSession,
+        sync_lead: models.Lead,
+        sync_user: models.User,
+        sync_statuses: dict,
+    ):
+        """The normal path (no prepay): lead at sts06 → submit → sts07,
+        unchanged by the guard."""
+        # sync_lead fixture starts at sts06
+        profile = await create_profile(db, sync_lead, "submitted")
+
+        result = await sync_lead_from_admission(
+            db=db,
+            profile=profile,
+            changed_by_user_id=sync_user.id,
+            reason="Normal submit",
+        )
+
+        assert result is True
+        await db.refresh(sync_lead)
+        assert sync_lead.consultation_status_id == "sts07"
+
+
+class TestSubmitMilestoneFinanceRegressionGuard:
+    """SL1 guard at the MILESTONE level — the actual prod regression site.
+
+    On the officer path ``_create_admission_milestone_consultation`` runs on
+    submit/resubmit BEFORE the sync fallback and used to set the lead to sts07
+    unconditionally (its only skip was ``lead.status == 'converted'``). Prod
+    verification: 18/18 regressed leads carried history reason
+    "Admission event: profile_submitted" — i.e. the milestone, not the sync,
+    was the culprit. These tests exercise the milestone helper directly so a
+    revert of the milestone guard fails here even though the sync-level tests
+    stay green.
+    """
+
+    @pytest.mark.parametrize("overlay_status", ["sts13", "sts14", "sts10", "sts18"])
+    async def test_submit_milestone_preserves_finance_overlay(
+        self,
+        db: AsyncSession,
+        sync_lead: models.Lead,
+        sync_user: models.User,
+        sync_statuses: dict,
+        overlay_status: str,
+    ):
+        """A profile_submitted milestone must NOT regress a fee/tuition-overlay
+        lead down to sts07."""
+        from app.services.admission_service import (
+            _create_admission_milestone_consultation,
+        )
+
+        sync_lead.consultation_status_id = overlay_status
+        await db.flush()
+
+        await _create_admission_milestone_consultation(
+            db=db,
+            lead=sync_lead,
+            event="profile_submitted",
+            actor=sync_user,
+            profile_id=1,
+        )
+        await db.flush()
+
+        await db.refresh(sync_lead)
+        assert sync_lead.consultation_status_id == overlay_status, \
+            f"Milestone regressed {overlay_status} → {sync_lead.consultation_status_id}"
+
+        # Golden Rule: the SYSTEM milestone consultation IS still recorded even
+        # when the lead status is preserved. This also distinguishes "guard
+        # preserved the overlay" from "the milestone silently did nothing".
+        system_consultations = (
+            await db.execute(
+                select(models.Consultation).where(
+                    models.Consultation.lead_id == sync_lead.id,
+                    models.Consultation.method == "system",
+                )
+            )
+        ).scalars().all()
+        assert len(system_consultations) == 1, \
+            "submit milestone consultation must be recorded even when overlay preserved"
+
+    async def test_resubmit_milestone_preserves_sts13(
+        self,
+        db: AsyncSession,
+        sync_lead: models.Lead,
+        sync_user: models.User,
+        sync_statuses: dict,
+    ):
+        """profile_resubmitted is also floored when a fee overlay is present."""
+        from app.services.admission_service import (
+            _create_admission_milestone_consultation,
+        )
+
+        sync_lead.consultation_status_id = "sts13"
+        await db.flush()
+
+        await _create_admission_milestone_consultation(
+            db=db,
+            lead=sync_lead,
+            event="profile_resubmitted",
+            actor=sync_user,
+            profile_id=1,
+        )
+        await db.flush()
+
+        await db.refresh(sync_lead)
+        assert sync_lead.consultation_status_id == "sts13"
+
+    async def test_submit_milestone_floors_sts06_to_sts07(
+        self,
+        db: AsyncSession,
+        sync_lead: models.Lead,
+        sync_user: models.User,
+        sync_statuses: dict,
+    ):
+        """Normal path (no overlay): a profile_submitted milestone still floors
+        a consultation-phase lead up to sts07."""
+        from app.services.admission_service import (
+            _create_admission_milestone_consultation,
+        )
+
+        # sync_lead starts at sts06
+        await _create_admission_milestone_consultation(
+            db=db,
+            lead=sync_lead,
+            event="profile_submitted",
+            actor=sync_user,
+            profile_id=1,
+        )
+        await db.flush()
+
+        await db.refresh(sync_lead)
+        assert sync_lead.consultation_status_id == "sts07"
+
+    async def test_resubmit_milestone_from_rejected_floors_to_sts07(
+        self,
+        db: AsyncSession,
+        sync_lead: models.Lead,
+        sync_user: models.User,
+        sync_statuses: dict,
+    ):
+        """Resubmit after reject (sts16, not an overlay) must still floor to
+        sts07 — the guard must not block a genuine resubmit."""
+        from app.services.admission_service import (
+            _create_admission_milestone_consultation,
+        )
+
+        sync_lead.consultation_status_id = "sts16"
+        await db.flush()
+
+        await _create_admission_milestone_consultation(
+            db=db,
+            lead=sync_lead,
+            event="profile_resubmitted",
+            actor=sync_user,
+            profile_id=1,
+        )
+        await db.flush()
+
+        await db.refresh(sync_lead)
+        assert sync_lead.consultation_status_id == "sts07"
+
+    async def test_approve_milestone_not_floored_from_sts13(
+        self,
+        db: AsyncSession,
+        sync_lead: models.Lead,
+        sync_user: models.User,
+        sync_statuses: dict,
+    ):
+        """The guard must NOT over-reach: a profile_approved milestone is a
+        legitimate progression and must advance a sts13 lead to sts09, even
+        though sts13 is a fee overlay (only submit/resubmit are floored)."""
+        from app.services.admission_service import (
+            _create_admission_milestone_consultation,
+        )
+
+        sync_lead.consultation_status_id = "sts13"
+        await db.flush()
+
+        await _create_admission_milestone_consultation(
+            db=db,
+            lead=sync_lead,
+            event="profile_approved",
+            actor=sync_user,
+            profile_id=1,
+        )
+        await db.flush()
+
+        await db.refresh(sync_lead)
+        assert sync_lead.consultation_status_id == "sts09", \
+            "approve must still progress a fee-paid lead (guard is submit-only)"

--- a/Backend_FastAPI/tests/unit/test_lead_admission_sync_extended_map.py
+++ b/Backend_FastAPI/tests/unit/test_lead_admission_sync_extended_map.py
@@ -22,8 +22,11 @@ import pytest
 
 from app.services.lead_admission_sync import (
     ADMISSION_TO_LEAD_STATUS_MAP,
+    FEE_OVERLAY_LEAD_STATUSES,
     FLOOR_FROM_PROFILE_STATUSES,
     PRE_APPLICATION_LEAD_STATUSES,
+    SUBMIT_FLOOR_EVENTS,
+    SUBMIT_FLOOR_PROFILE_STATUSES,
     _RESULT_PUBLISHED_NO_OP,
     _should_apply_admission_floor,
 )
@@ -173,9 +176,9 @@ def test_floor_blocks_downgrade(profile_status: str, lead_cs: str) -> None:
 @pytest.mark.parametrize(
     "profile_status",
     [
-        # Every non-floor value the admission column can hold today (legacy)
-        # plus the choice-engine new values that are NOT floor-only.
-        "draft", "submitted", "resubmitted", "approved", "confirmed",
+        # Every status that is neither floor-only (reviewing/waitlisted) nor a
+        # submit transition (submitted/resubmitted) — these always fall through.
+        "draft", "approved", "confirmed",
         "overridden", "rejected", "revision_requested", "enrolled",
         "withdrawn", "admitted",
     ],
@@ -187,8 +190,65 @@ def test_floor_blocks_downgrade(profile_status: str, lead_cs: str) -> None:
 def test_floor_no_op_for_non_floor_statuses(
     profile_status: str, lead_cs
 ) -> None:
-    """Non-floor statuses must always allow the existing fall-through —
+    """Non-guarded statuses must always allow the existing fall-through —
     helper short-circuits to True regardless of the lead state. Without
     this, refactoring the function would accidentally veto valid
     transitions (e.g. approve from any prior lead state)."""
+    assert _should_apply_admission_floor(profile_status, lead_cs) is True
+
+
+# ---------------------------------------------------------------------------
+# Submit / resubmit regression guard (SL1)
+# ---------------------------------------------------------------------------
+
+
+def test_submit_floor_profile_set_locked() -> None:
+    """Lock the exact set of submit transitions guarded against finance
+    regression. Adding another value without thinking through the overlay
+    semantics would silently change which transitions are floored."""
+    assert SUBMIT_FLOOR_PROFILE_STATUSES == frozenset({"submitted", "resubmitted"})
+
+
+def test_fee_overlay_set_locked() -> None:
+    """Lock the finance overlay set. sts13 = application fee paid; sts14/sts10/
+    sts18 = HK1 tuition pending/paid/refunded. rejected (sts16) and
+    revision_requested (sts17) MUST stay out so resubmits still floor to sts07."""
+    assert FEE_OVERLAY_LEAD_STATUSES == frozenset({"sts13", "sts14", "sts10", "sts18"})
+    assert "sts16" not in FEE_OVERLAY_LEAD_STATUSES
+    assert "sts17" not in FEE_OVERLAY_LEAD_STATUSES
+
+
+def test_submit_floor_events_locked_and_in_parity() -> None:
+    """SUBMIT_FLOOR_EVENTS gates the milestone-level guard
+    (_create_admission_milestone_consultation), while SUBMIT_FLOOR_PROFILE_STATUSES
+    gates the sync-level guard. They are two keys for the SAME two transitions and
+    MUST stay in parity (the milestone event names just prefix the profile statuses
+    with ``profile_``). This pins both so editing one without the other fails."""
+    assert SUBMIT_FLOOR_EVENTS == frozenset(
+        {"profile_submitted", "profile_resubmitted"}
+    )
+    assert {
+        e.removeprefix("profile_") for e in SUBMIT_FLOOR_EVENTS
+    } == SUBMIT_FLOOR_PROFILE_STATUSES
+
+
+@pytest.mark.parametrize("profile_status", ["submitted", "resubmitted"])
+@pytest.mark.parametrize("lead_cs", ["sts13", "sts14", "sts10", "sts18"])
+def test_submit_preserves_finance_overlay(profile_status: str, lead_cs: str) -> None:
+    """SL1 fix: submitting a profile must NOT drag a lead that already paid the
+    application fee (sts13) or entered the tuition lifecycle back to sts07."""
+    assert _should_apply_admission_floor(profile_status, lead_cs) is False
+
+
+@pytest.mark.parametrize("profile_status", ["submitted", "resubmitted"])
+@pytest.mark.parametrize(
+    "lead_cs",
+    # Pre-application phase + the normal admission-receipt target + the
+    # reject/revision branch a genuine resubmit comes from.
+    [None, "sts00", "sts02", "sts05", "sts06", "sts07", "sts16", "sts17"],
+)
+def test_submit_floors_up_when_no_finance_overlay(profile_status: str, lead_cs) -> None:
+    """Submit/resubmit still progresses the lead to sts07 from the consultation
+    phase, from sts07 itself (idempotent downstream), and crucially from
+    rejected/revision — flooring those is the whole point of a resubmit."""
     assert _should_apply_admission_floor(profile_status, lead_cs) is True

--- a/scripts/phase3-pre-deploy-snapshot.sh
+++ b/scripts/phase3-pre-deploy-snapshot.sh
@@ -35,7 +35,7 @@ echo ""
 
 # Step 1: Capture current alembic version (for restore verification)
 echo "[1/4] Capturing alembic version..."
-ALEMBIC_VERSION=$(docker compose exec -T postgres psql -U qlts -d qlts -t -c \
+ALEMBIC_VERSION=$(docker compose exec -T postgres psql -U qlts -d "${POSTGRES_DB:-qlts_production}" -t -c \
   "SELECT version_num FROM alembic_version" 2>&1 | tr -d ' \n' || echo "UNKNOWN")
 echo "Alembic version: ${ALEMBIC_VERSION}" | tee -a "${LOG_FILE}"
 
@@ -47,7 +47,7 @@ fi
 
 # Step 2: Capture row counts (for restore verification)
 echo "[2/4] Capturing table row counts..."
-docker compose exec -T postgres psql -U qlts -d qlts -c "
+docker compose exec -T postgres psql -U qlts -d "${POSTGRES_DB:-qlts_production}" -c "
 SELECT 'admission_profile' AS table, COUNT(*) FROM admission_profile
 UNION ALL SELECT 'admission_path', COUNT(*) FROM admission_path
 UNION ALL SELECT 'offering_admission_round', COUNT(*) FROM offering_admission_round
@@ -63,13 +63,21 @@ docker compose exec -T postgres pg_dump -U qlts \
   --no-owner \
   --no-acl \
   --file=/tmp/snapshot.dump \
-  qlts
+  "${POSTGRES_DB:-qlts_production}"
 
 docker compose cp postgres:/tmp/snapshot.dump "${SNAPSHOT_PATH}"
 docker compose exec -T postgres rm /tmp/snapshot.dump
 
 SNAPSHOT_SIZE=$(stat -c%s "${SNAPSHOT_PATH}" 2>/dev/null || stat -f%z "${SNAPSHOT_PATH}")
 echo "Snapshot size: $(numfmt --to=iec ${SNAPSHOT_SIZE}) (${SNAPSHOT_SIZE} bytes)" | tee -a "${LOG_FILE}"
+
+# Guard: a wrong dbname / failed pg_dump can yield a near-empty file. With the
+# pipefail change a pg_dump error would already abort, but this is a final
+# safety net so an empty/truncated snapshot is never treated as a valid backup.
+if [[ "${SNAPSHOT_SIZE:-0}" -lt 1024 ]]; then
+  echo "ERROR: Snapshot ${SNAPSHOT_PATH} is ${SNAPSHOT_SIZE} bytes (<1KiB) — dump likely failed, refusing to continue" >&2
+  exit 3
+fi
 
 # Step 4: Verify integrity (pg_restore --list parse-only)
 echo "[4/4] Verifying snapshot integrity..."
@@ -86,7 +94,7 @@ echo "==== Snapshot complete ===="
 echo "Path: ${SNAPSHOT_PATH}"
 echo "Log: ${LOG_FILE}"
 echo "Restore command:"
-echo "  docker compose exec postgres pg_restore -U qlts -d qlts ${SNAPSHOT_PATH}"
+echo "  docker compose exec postgres pg_restore -U qlts -d ${POSTGRES_DB:-qlts_production} ${SNAPSHOT_PATH}"
 echo ""
 
 # MD5 checksum (final integrity stamp)


### PR DESCRIPTION
Ba fix từ **audit production 2026-06-19**, verify lại trên `main` + prod live (read-only), qua **3 vòng code-review (max)**.

## F1 — Số hóa đơn học phí dễ trùng → 500
Prod thiếu sequence `invoice_number_seq` nên code cũ luôn fallback `COUNT(*)+1` (đếm lẫn cả `APP-` lệ phí + `INV-` học phí). 2 kế toán issue đồng thời → cùng số → **DUPLICATE KEY 500**.
- Thay bằng `pg_advisory_xact_lock` + `MAX-by-prefix-year` → atomic, tách INV/APP, reset theo năm. **Không migration/schema.**
- `flush()` đầu hàm để `MAX` thấy invoice pending trong batch installment (raw `text()` không trigger ORM autoflush).
- CAST-safe `~ '^[0-9]{1,9}$'` (loại suffix phi số + chặn overflow int4). Bỏ `prefix` param dead-code.

## SL1 — Lead mất dấu "đã đóng tiền" khi nộp hồ sơ
Submit/resubmit sau prepay lệ phí kéo lead **sts13 → sts07** (mất dấu đã-đóng-lệ-phí). **18/18 ca prod**, reason `"Admission event: profile_submitted"`.
- Thủ phạm là `_create_admission_milestone_consultation` (canonical, chạy **trước** sync) — review vòng 1 phát hiện guard chỉ-ở-sync là no-op trên officer path.
- Thêm `SUBMIT_FLOOR_EVENTS` + `FEE_OVERLAY` guard ở milestone + giữ guard sync (fallback magic-link).
- Guard **vẫn ghi** SYSTEM consultation (Golden Rule audit + `consultation_count`), chỉ bỏ phần hạ lead status.
- `resubmit_profile` gate `LEAD_STATUS_CHANGED` + commission theo lead-có-thực-sự-đổi (không broadcast phantom sts07 khi overlay được giữ).
- Chỉ floor submit/resubmit; approve/reject/enroll không bị đụng.

## F2 — Script snapshot pre-deploy ghi sai dbname
`scripts/phase3-pre-deploy-snapshot.sh` gõ `qlts` thay vì `qlts_production` (4 chỗ) → snapshot rollback **thất bại âm thầm**. Sửa `${POSTGRES_DB:-qlts_production}` + guard dump size < 1KiB.

## Test
150 unit + lead-sync/finance/bundle integration **xanh**. flake8 net-new sạch.

> ⚠️ `test_admission_state_transitions::test_happy_path_normal_flow` fail nhưng **pre-existing** (verify fail y hệt trên `main` — CCCD cooldown, KHÔNG do PR này).

🤖 Generated with [Claude Code](https://claude.com/claude-code)