### PR TITLE
chore(post-audit): test/cleanup follow-ups sau PR #422

### DIFF
--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -9739,7 +9739,7 @@ async def resubmit_profile(
             profile_id=profile.id,
         )
 
-    # ✅ SYNC: Update lead consultation status to match admission status (resubmitted → sts07)
+    # ✅ SYNC: lead → sts07 trên resubmit, TRỪ KHI giữ finance overlay (SL1 guard).
     from .lead_admission_sync import sync_lead_from_admission
     await sync_lead_from_admission(
         db=db,

--- a/Backend_FastAPI/tests/integration/test_admission_state_transitions.py
+++ b/Backend_FastAPI/tests/integration/test_admission_state_transitions.py
@@ -700,6 +700,21 @@ class TestStateTransitionWorkflows:
         )
         assert wrong_confirm_response.status_code == 400, f"Should fail with wrong CCCD"
 
+        # ADM-023 (2026-04-29) added a sliding cooldown ladder: every wrong CCCD
+        # attempt sets ``lock_until`` (1st miss = 5 min). Reset it so the
+        # legitimate retry below isn't rate-limited — the cooldown ladder itself
+        # is covered by test_admission_confirmation_lock_ladder + the cooldown
+        # unit tests, not this happy-path flow.
+        async with AsyncSessionLocal() as session:
+            reset_result = await session.execute(
+                select(models.AdmissionConfirmationToken)
+                .where(models.AdmissionConfirmationToken.profile_id == profile.id)
+            )
+            reset_tok = reset_result.scalar_one()
+            reset_tok.lock_until = None
+            reset_tok.attempt_count = 0
+            await session.commit()
+
         # 6. Lead confirms with correct CCCD (last 4 digits of citizen_id)
         correct_confirm_response = await client.post(
             f"/api/admissions/confirm/{token_value}",

--- a/Backend_FastAPI/tests/integration/test_finance_workflow.py
+++ b/Backend_FastAPI/tests/integration/test_finance_workflow.py
@@ -13,6 +13,7 @@ Tests cover end-to-end scenarios:
 Note: These tests require database fixtures from conftest.py
 """
 
+import asyncio
 import pytest
 import pytest_asyncio
 from datetime import datetime, timezone, date, timedelta
@@ -21,6 +22,7 @@ from decimal import Decimal
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.database import AsyncSessionLocal
 from app import models
 from app.models.finance import (
     Fee, Invoice, Payment, PaymentIntent, PaymentMethod, InstallmentPlan,
@@ -511,6 +513,64 @@ class TestInvoiceGeneration:
         assert invoice.status == InvoiceStatusEnum.issued.value
         assert invoice.issued_at is not None
         assert invoice.issued_by_id == maker_user.id
+
+    @pytest.mark.asyncio
+    async def test_concurrent_invoice_generation_unique_numbers(
+        self,
+        db: AsyncSession,
+        finance_fixtures: dict,
+        maker_user: models.User,
+    ):
+        """F1: hai luồng generate invoice cùng (prefix, year) ĐỒNG THỜI phải
+        nhận số khác nhau. pg_advisory_xact_lock serialise việc cấp số → không
+        có DUPLICATE KEY 500. Reverting the lock/flush would let both read the
+        same MAX and collide on the invoice_number UNIQUE index (one would raise
+        IntegrityError), so this is the regression guard for the F1 concurrency
+        fix that the sequential batch test cannot exercise."""
+        fee_service = FeeCalculationService(db)
+        profile = finance_fixtures["admission_profile"]
+        unit_id = finance_fixtures["unit_id"]
+
+        # Two independent fees (different types → no duplicate-fee constraint),
+        # committed so the concurrent sessions below can see them.
+        fee_a, _ = await fee_service.calculate_fee(
+            admission_profile_id=profile.id,
+            fee_type=FeeTypeEnum.dormitory,
+            base_amount=Decimal("2000000"),
+            academic_year=2025,
+            user_id=maker_user.id,
+            unit_id=unit_id,
+        )
+        fee_b, _ = await fee_service.calculate_fee(
+            admission_profile_id=profile.id,
+            fee_type=FeeTypeEnum.insurance,
+            base_amount=Decimal("500000"),
+            academic_year=2025,
+            user_id=maker_user.id,
+            unit_id=unit_id,
+        )
+        await db.commit()
+
+        async def _issue(fee_id: int) -> list[str]:
+            # Separate session/transaction per task so they genuinely race on
+            # the (prefix, year) advisory lock.
+            async with AsyncSessionLocal() as session:
+                svc = InvoiceService(session)
+                invoices, _ = await svc.generate_invoices_for_fee(
+                    fee_id=fee_id,
+                    due_date_base=date.today() + timedelta(days=30),
+                    user_id=maker_user.id,
+                    unit_id=unit_id,
+                )
+                await session.commit()
+                return [inv.invoice_number for inv in invoices]
+
+        nums_a, nums_b = await asyncio.gather(_issue(fee_a.id), _issue(fee_b.id))
+        all_nums = nums_a + nums_b
+
+        assert len(set(all_nums)) == len(all_nums), \
+            f"Concurrent invoice numbers collided: {all_nums}"
+        assert all(n.startswith("INV-") for n in all_nums)
 
 
 # =============================================================================

--- a/scripts/phase3-pre-deploy-snapshot.sh
+++ b/scripts/phase3-pre-deploy-snapshot.sh
@@ -39,9 +39,13 @@ ALEMBIC_VERSION=$(docker compose exec -T postgres psql -U qlts -d "${POSTGRES_DB
   "SELECT version_num FROM alembic_version" 2>&1 | tr -d ' \n' || echo "UNKNOWN")
 echo "Alembic version: ${ALEMBIC_VERSION}" | tee -a "${LOG_FILE}"
 
-# Expected: phase2_06 (Phase 2 PR-2D.1 v4a head)
-if [[ "${ALEMBIC_VERSION}" != "phase2_06" ]]; then
-  echo "WARNING: Expected alembic head 'phase2_06', got '${ALEMBIC_VERSION}'" | tee -a "${LOG_FILE}"
+# Optional expected-head guard. Set EXPECTED_ALEMBIC_HEAD before running to
+# assert the DB is at the head you intend to snapshot; left unset (default) it
+# just records the captured version above. The old hardcoded 'phase2_06' was a
+# one-shot Phase-3 value and is long stale on prod (head is now docdebt01+), so
+# it warned on every run — opt-in avoids that false alarm.
+if [[ -n "${EXPECTED_ALEMBIC_HEAD:-}" && "${ALEMBIC_VERSION}" != "${EXPECTED_ALEMBIC_HEAD}" ]]; then
+  echo "WARNING: Expected alembic head '${EXPECTED_ALEMBIC_HEAD}', got '${ALEMBIC_VERSION}'" | tee -a "${LOG_FILE}"
   echo "Continuing snapshot but verify post-restore manually." | tee -a "${LOG_FILE}"
 fi
 


### PR DESCRIPTION
Bốn dọn dẹp/hardening sau audit + deploy #422, gom 1 PR cho đỡ tốn CI.

## 1. Fix test stale `test_happy_path_normal_flow`
Test viết **trước** ADM-023 cooldown ladder (2026-04-29): bước nhập sai CCCD cố ý nay set `lock_until` 5' → bước nhập đúng bị rate-limit → fail (fail cả trên `main`, không phải regression mới). Reset cooldown giữa 2 bước (cooldown ladder đã có test riêng: `test_admission_confirmation_lock_ladder` + unit).

## 2. F1 concurrency test (gap review round 2)
`asyncio.gather` 2 session generate invoice cùng `(prefix, year)` → chứng minh `pg_advisory_xact_lock` cấp số khác nhau (chống `DUPLICATE KEY 500`). Test sequential batch cũ không exercise được race thật.

## 3. Snapshot script — bỏ hardcode alembic head stale
`phase2_06` là giá trị one-shot Phase-3, nay stale (head prod = `feepicker_casbin_*`) → warn giả mỗi lần chạy. Chuyển opt-in `EXPECTED_ALEMBIC_HEAD` env (mặc định chỉ ghi version).

## 4. Comment lỗi thời `resubmit_profile`
Phản ánh lead có thể **giữ** finance overlay (SL1 guard từ #422), không phải luôn → sts07.

## Test
`test_happy_path_normal_flow` pass + `test_finance_workflow` **29 pass** (gồm concurrency test mới). flake8 net-new sạch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)