### PR TITLE
feat(hardening): CSPRNG student_code + image-verify upload + f_unaccent admission search

### DIFF
--- a/Backend_FastAPI/app/repositories/admission_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_repository.py
@@ -258,21 +258,10 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         if filters.get("lead_id"):
             base_conditions.append(models.AdmissionProfile.lead_id == filters["lead_id"])
 
-        # Search filter (name, email, citizen_id)
+        # Search filter: name diacritic-insensitive (f_unaccent) + exact
+        # email/citizen_id. Shared helper keeps list parity with status-counts.
         if search:
-            # Normalize Unicode for Vietnamese diacritics
-            normalized_search = unicodedata.normalize('NFC', search.strip())
-            # Escape LIKE wildcards (% _) so user input (incl. citizen_id) is
-            # treated literally — prevents wildcard-injection / DoS backtracking.
-            search_term = f"%{escape_like_pattern(normalized_search)}%"
-            search_conditions = or_(
-                models.Lead.full_name.ilike(search_term, escape=LIKE_ESCAPE_CHAR),
-                models.Lead.email.ilike(search_term, escape=LIKE_ESCAPE_CHAR),
-                models.AdmissionProfile.citizen_id.ilike(
-                    search_term, escape=LIKE_ESCAPE_CHAR
-                ),
-            )
-            base_conditions.append(search_conditions)
+            base_conditions.append(self._name_search_condition(search))
 
         # Major/Program filter via ProgramOffering.program_id (MajorProgram ID)
         # Requires JOIN through Lead → ProgramOffering → MajorProgram
@@ -407,6 +396,27 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
             ).correlate(models.AdmissionProfile).exists()
             base_conditions.append(no_fees)
 
+    def _name_search_condition(self, search: str):
+        """Diacritic-insensitive name search (+ exact email/citizen_id).
+
+        ``f_unaccent(full_name)`` is backed by ``ix_lead_fullname_unaccent_trgm``
+        (migration leadsrch01) so "nguyen" matches "Nguyễn". Keeps
+        ``escape=LIKE_ESCAPE_CHAR`` because the term is escaped literal via
+        ``escape_like_pattern()``. Shared by the list query and
+        ``_build_base_conditions`` (status-counts) so list + tab counts agree.
+        """
+        normalized = unicodedata.normalize("NFC", search.strip())
+        term = f"%{escape_like_pattern(normalized)}%"
+        return or_(
+            func.f_unaccent(models.Lead.full_name).ilike(
+                func.f_unaccent(term), escape=LIKE_ESCAPE_CHAR
+            ),
+            models.Lead.email.ilike(term, escape=LIKE_ESCAPE_CHAR),
+            models.AdmissionProfile.citizen_id.ilike(
+                term, escape=LIKE_ESCAPE_CHAR
+            ),
+        )
+
     # =========================================================================
     # AGGREGATE QUERY METHODS (Phase 2 & 3)
     # =========================================================================
@@ -434,17 +444,8 @@ class AdmissionRepository(BaseRepository[models.AdmissionProfile]):
         if unit_id is not None:
             conditions.append(models.Lead.unit_id == unit_id)
         if search:
-            normalized_search = unicodedata.normalize('NFC', search.strip())
-            # Escape LIKE wildcards (% _) so user input (incl. citizen_id) is
-            # treated literally — prevents wildcard-injection / DoS backtracking.
-            search_term = f"%{escape_like_pattern(normalized_search)}%"
-            conditions.append(or_(
-                models.Lead.full_name.ilike(search_term, escape=LIKE_ESCAPE_CHAR),
-                models.Lead.email.ilike(search_term, escape=LIKE_ESCAPE_CHAR),
-                models.AdmissionProfile.citizen_id.ilike(
-                    search_term, escape=LIKE_ESCAPE_CHAR
-                ),
-            ))
+            # Same diacritic-insensitive search as the list query (parity).
+            conditions.append(self._name_search_condition(search))
         if major_ids and len(major_ids) > 0:
             conditions.append(models.ProgramOffering.program_id.in_(major_ids))
         if academic_year is not None:

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -156,8 +156,15 @@ def _sniff_document_signature(stream) -> Optional[str]:
 # Active-content markers that make a PDF unsafe (JavaScript / auto-run actions /
 # embedded files — common malware vectors). ID papers / transcripts never need
 # these, so rejecting them is a cheap, low-false-positive guard.
+#
+# The 3-byte b"/JS" marker was dropped on purpose: it collides by chance inside
+# the FlateDecode/DCTDecode stream bytes of legitimate scanned PDFs (~46% of
+# 10MB scans), false-rejecting real documents. The remaining markers are ≥7
+# bytes (~0 random collision) and a real JS action always also carries the full
+# b"/JavaScript" token, so dropping /JS loses no detection. (Compressed or
+# name-escaped active content stays out of scope — ClamAV is future hardening.)
 _PDF_ACTIVE_CONTENT_MARKERS = (
-    b"/JavaScript", b"/JS", b"/OpenAction", b"/Launch", b"/EmbeddedFile",
+    b"/JavaScript", b"/OpenAction", b"/Launch", b"/EmbeddedFile",
 )
 # Per-side pixel cap — rejects decompression-bomb images from the header BEFORE
 # PIL decodes the pixel data.
@@ -11358,7 +11365,6 @@ async def generate_action_magic_link(
     Raises:
         BadRequest: action invalid hoặc profile.status không phù hợp
     """
-    import secrets
     from datetime import timedelta, datetime, timezone
     from app.config import settings
     from app.repositories import AdmissionRepository
@@ -11435,7 +11441,6 @@ async def generate_confirmation_token(
     Raises:
         BadRequest: Profile status is not 'approved'
     """
-    import secrets
     from datetime import timedelta, datetime, timezone
     from app.config import settings
     from app.repositories import AdmissionRepository

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -22,7 +22,7 @@ Security Features:
 - ACID Transactions: enroll_student uses begin_nested() savepoint
 """
 
-import random
+import secrets
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from typing import Awaitable, List, Optional, Dict, Any, Tuple, Callable
@@ -151,6 +151,88 @@ def _sniff_document_signature(stream) -> Optional[str]:
     if head.startswith(b"\x89PNG\r\n\x1a\n"):
         return "png"
     return None
+
+
+# Active-content markers that make a PDF unsafe (JavaScript / auto-run actions /
+# embedded files — common malware vectors). ID papers / transcripts never need
+# these, so rejecting them is a cheap, low-false-positive guard.
+_PDF_ACTIVE_CONTENT_MARKERS = (
+    b"/JavaScript", b"/JS", b"/OpenAction", b"/Launch", b"/EmbeddedFile",
+)
+# Per-side pixel cap — rejects decompression-bomb images from the header BEFORE
+# PIL decodes the pixel data.
+_MAX_IMAGE_DIMENSION = 10000
+
+
+def _sniff_and_verify_upload(file) -> str:
+    """Validate an uploaded document by its ACTUAL bytes; return the sniffed
+    kind ('pdf'/'jpeg'/'png') or raise ``BadRequest``.
+
+    Shared by ``upload_document()`` and the priority-evidence upload so both
+    paths get identical validation:
+      1. magic-byte sniff (``_sniff_document_signature``),
+      2. content-type-match (client header must agree with the real bytes),
+      3. PDF: reject active content (JavaScript / auto-run / embedded files),
+      4. image: cap dimensions (decompression-bomb guard, from the header
+         before decode) + PIL structural ``verify()`` (corrupt/forged JPEG/PNG).
+
+    NOTE: this is cheap content validation, NOT a full AV scan — it catches
+    active-content PDFs, image bombs, and corrupt/fake images, but not arbitrary
+    embedded malware. ClamAV is future hardening.
+    """
+    sniffed_kind = _sniff_document_signature(file.file)
+    if sniffed_kind is None:
+        raise BadRequest(
+            "Tệp tải lên không phải PDF, JPG hoặc PNG hợp lệ "
+            "(magic bytes không khớp)."
+        )
+    expected_content_type = {
+        "pdf": "application/pdf",
+        "jpeg": "image/jpeg",
+        "png": "image/png",
+    }[sniffed_kind]
+    if file.content_type != expected_content_type:
+        raise BadRequest(
+            f"Content-Type '{file.content_type}' không khớp nội dung thực tế "
+            f"({expected_content_type})."
+        )
+    if sniffed_kind == "pdf":
+        # Active-content scan. Read the whole file (size already capped ≤10MB by
+        # the caller) and reject auto-run / scripting / embed markers.
+        file.file.seek(0)
+        try:
+            content = file.file.read()
+        finally:
+            file.file.seek(0)
+        if any(marker in content for marker in _PDF_ACTIVE_CONTENT_MARKERS):
+            raise BadRequest(
+                "PDF chứa nội dung động không được phép "
+                "(JavaScript/OpenAction/EmbeddedFile)."
+            )
+    elif sniffed_kind in ("jpeg", "png"):
+        # Dimension cap (from the header, before decode) + PIL structural verify.
+        # The try/except wraps ONLY the PIL ops so it cannot swallow the
+        # content-type/magic BadRequests above; the dimension BadRequest is
+        # re-raised explicitly. finally restores the cursor for the downstream
+        # write.
+        from PIL import Image
+        file.file.seek(0)
+        try:
+            with Image.open(file.file) as img:
+                if (img.width > _MAX_IMAGE_DIMENSION
+                        or img.height > _MAX_IMAGE_DIMENSION):
+                    raise BadRequest(
+                        f"Ảnh quá lớn ({img.width}x{img.height}px); tối đa "
+                        f"{_MAX_IMAGE_DIMENSION}px mỗi chiều."
+                    )
+                img.verify()
+        except BadRequest:
+            raise
+        except Exception:
+            raise BadRequest("Ảnh tải lên hỏng hoặc cấu trúc không hợp lệ.")
+        finally:
+            file.file.seek(0)
+    return sniffed_kind
 
 
 def _safe_bulk_error_message(
@@ -6494,25 +6576,11 @@ async def upload_document(
             f"Maximum allowed: {MAX_FILE_SIZE:,} bytes ({max_mb_exact:.0f}MB)."
         )
 
-    # ADM-019: content_type and extension are client-controlled. Sniff
-    # the first bytes of the actual stream and reject mismatches so an
-    # attacker cannot upload a .exe with content_type=application/pdf.
-    sniffed_kind = _sniff_document_signature(file.file)
-    if sniffed_kind is None:
-        raise BadRequest(
-            "Tệp tải lên không phải PDF, JPG hoặc PNG hợp lệ "
-            "(magic bytes không khớp)."
-        )
-    expected_content_type = {
-        "pdf": "application/pdf",
-        "jpeg": "image/jpeg",
-        "png": "image/png",
-    }[sniffed_kind]
-    if file.content_type != expected_content_type:
-        raise BadRequest(
-            f"Content-Type '{file.content_type}' không khớp nội dung "
-            f"thực tế ({expected_content_type})."
-        )
+    # ADM-019 + image verify: content_type/extension are client-controlled.
+    # Validate by ACTUAL bytes (magic + image structure) so an attacker can't
+    # upload a .exe as application/pdf nor a corrupt/forged image. Shared helper
+    # covers both this path and the priority-evidence upload.
+    sniffed_kind = _sniff_and_verify_upload(file)
 
     # doc_record was already fetched above for the authz guard — no need to re-query.
 
@@ -6856,21 +6924,8 @@ async def upload_priority_evidence_document(
             f"Maximum allowed: {MAX_FILE_SIZE:,} bytes ({max_mb_exact:.0f}MB)."
         )
 
-    sniffed_kind = _sniff_document_signature(file.file)
-    if sniffed_kind is None:
-        raise BadRequest(
-            "Tệp tải lên không phải PDF, JPG hoặc PNG hợp lệ (magic bytes không khớp)."
-        )
-    expected_content_type = {
-        "pdf": "application/pdf",
-        "jpeg": "image/jpeg",
-        "png": "image/png",
-    }[sniffed_kind]
-    if file.content_type != expected_content_type:
-        raise BadRequest(
-            f"Content-Type '{file.content_type}' không khớp nội dung thực tế "
-            f"({expected_content_type})."
-        )
+    # ADM-019 + image verify (shared helper — same validation as upload_document).
+    sniffed_kind = _sniff_and_verify_upload(file)
 
     # Find existing priority_evidence row (for re-upload scenario)
     existing_doc_q = await db.execute(
@@ -7979,7 +8034,11 @@ async def _perform_enrollment_core(
                     )
 
                 for attempt in range(10):  # Retry up to 10 times
-                    random_digits = random.randint(0, 9999)
+                    # CSPRNG (secrets) so the next unissued student_code isn't
+                    # predictable from observed ones. student_code is a public
+                    # identifier (SV+YYYY+4d), not a secret credential — this is
+                    # defense-in-depth, format/entropy unchanged.
+                    random_digits = secrets.randbelow(10000)
                     candidate_code = f"SV{year}{random_digits:04d}"
 
                     # ✅ SPRINT 6: Use Repository for uniqueness check

--- a/Backend_FastAPI/tests/repositories/test_admission_search_unaccent.py
+++ b/Backend_FastAPI/tests/repositories/test_admission_search_unaccent.py
@@ -1,0 +1,95 @@
+"""#7 — diacritic-insensitive (f_unaccent) search for admission profiles.
+
+Mirrors the lead search behavior (already shipped via leadsrch01): typing
+"nguyen" must match "Nguyễn". Pins BOTH the admission list query AND the
+status-counts path (they share ``_name_search_condition`` → list/count parity).
+
+User search is intentionally OUT OF SCOPE: the real /api/admin/users path
+(``search_with_hierarchy`` → ``_apply_user_filters``) and the CSV export both
+match on ``search_vector @@ to_tsquery`` (tsvector), not ILIKE — diacritic
+folding there needs a tsvector-config change, deferred.
+
+Requires the test DB's ``f_unaccent`` wrapper (created in
+tests/fixtures/database.py for the same reason).
+"""
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.repositories import AdmissionRepository
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_admission(db: AsyncSession, unit_id, status_id, full_name: str):
+    ts = datetime.now().timestamp()
+    lead = models.Lead(
+        full_name=full_name,
+        phone=f"09{int(ts) % 10_000_000:07d}",
+        email=f"srch_{ts:.6f}@test.com",
+        source="website",
+        unit_id=unit_id,
+        consultation_status_id=status_id,
+        status="new",
+    )
+    db.add(lead)
+    await db.flush()
+    profile = models.AdmissionProfile(
+        lead_id=lead.id,
+        status="submitted",
+        citizen_id=f"0{int(ts * 1000) % 10**11:011d}",
+        version=1,
+        applied_rules={},
+        academic_year=2026,
+        full_name=full_name,
+        phone=lead.phone,
+    )
+    db.add(profile)
+    await db.flush()
+    return profile
+
+
+async def test_admission_search_unaccent_list_and_counts(
+    db: AsyncSession, seeded_dependencies: dict
+):
+    """Unaccented "nguyen van a" must match "Nguyễn Văn Á" in BOTH the list
+    query and the status-counts aggregate (shared helper → parity)."""
+    unit_id = seeded_dependencies["unit_id"]
+    status_id = seeded_dependencies["initial_status_id"]
+    profile = await _seed_admission(db, unit_id, status_id, "Nguyễn Văn Á")
+
+    repo = AdmissionRepository(db)
+
+    profiles, total = await repo.get_filtered_with_count(
+        unit_id=unit_id, search="nguyen van a", limit=50,
+    )
+    assert any(p.id == profile.id for p in profiles), (
+        "list search must f_unaccent-match the diacritic name"
+    )
+
+    counts = await repo.get_status_counts(unit_id=unit_id, search="nguyen van a")
+    assert counts["total"] >= 1, (
+        "status-counts must f_unaccent-match too (parity with the list query)"
+    )
+
+
+async def test_admission_search_unaccent_discriminates_between_profiles(
+    db: AsyncSession, seeded_dependencies: dict
+):
+    """With TWO profiles seeded, the search must return ONLY the matching one —
+    guards against an over-broad f_unaccent/ilike clause that would match both."""
+    unit_id = seeded_dependencies["unit_id"]
+    status_id = seeded_dependencies["initial_status_id"]
+    target = await _seed_admission(db, unit_id, status_id, "Nguyễn Văn Á")
+    other = await _seed_admission(db, unit_id, status_id, "Hoàng Thị Bích")
+
+    repo = AdmissionRepository(db)
+    profiles, _ = await repo.get_filtered_with_count(
+        unit_id=unit_id, search="nguyen van a", limit=50,
+    )
+    ids = {p.id for p in profiles}
+    assert target.id in ids, "matching profile must be returned"
+    assert other.id not in ids, "non-matching profile must NOT be returned"

--- a/Backend_FastAPI/tests/repositories/test_admission_search_unaccent.py
+++ b/Backend_FastAPI/tests/repositories/test_admission_search_unaccent.py
@@ -12,7 +12,7 @@ folding there needs a tsvector-config change, deferred.
 Requires the test DB's ``f_unaccent`` wrapper (created in
 tests/fixtures/database.py for the same reason).
 """
-from datetime import datetime
+import itertools
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,12 +24,19 @@ from app.repositories import AdmissionRepository
 pytestmark = pytest.mark.asyncio
 
 
+# Monotonic per-call sequence → unique citizen_id / phone / email regardless of
+# timing or per-test rollback. The previous datetime-millisecond derivation
+# could collide when two profiles seeded within the same millisecond, tripping
+# uq_citizen_academic_year (citizen_id + academic_year, fixed at 2026).
+_seed_seq = itertools.count(1)
+
+
 async def _seed_admission(db: AsyncSession, unit_id, status_id, full_name: str):
-    ts = datetime.now().timestamp()
+    n = next(_seed_seq)
     lead = models.Lead(
         full_name=full_name,
-        phone=f"09{int(ts) % 10_000_000:07d}",
-        email=f"srch_{ts:.6f}@test.com",
+        phone=f"09{n:08d}",
+        email=f"srch_{n}@test.com",
         source="website",
         unit_id=unit_id,
         consultation_status_id=status_id,
@@ -40,7 +47,7 @@ async def _seed_admission(db: AsyncSession, unit_id, status_id, full_name: str):
     profile = models.AdmissionProfile(
         lead_id=lead.id,
         status="submitted",
-        citizen_id=f"0{int(ts * 1000) % 10**11:011d}",
+        citizen_id=f"{n:012d}",
         version=1,
         applied_rules={},
         academic_year=2026,

--- a/Backend_FastAPI/tests/unit/test_upload_image_verify.py
+++ b/Backend_FastAPI/tests/unit/test_upload_image_verify.py
@@ -1,0 +1,201 @@
+"""Security hardening tests (1-PR backend hardening).
+
+Covers:
+- #6 — ``_sniff_and_verify_upload`` helper (magic-byte sniff + content-type
+  match + PIL structural verify for images). Unit tests on the helper PLUS one
+  REAL service-level test through ``upload_priority_evidence_document`` so the
+  priority-evidence path (a sibling of ``upload_document``) is exercised end to
+  end, not just the helper in isolation.
+- #5 — student_code uses ``secrets`` (CSPRNG), not ``random``.
+
+NOTE: PIL ``.verify()`` catches corrupt / fake image structure (valid magic
+bytes but broken body), NOT arbitrary polyglot/malware — see helper docstring.
+"""
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from PIL import Image
+
+from app.services import admission_service
+from app.utils.exceptions import BadRequest
+
+
+pytestmark = pytest.mark.unit
+
+
+def _png_bytes(color: str = "red", size=(2, 2)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _upload(content: bytes, content_type: str):
+    """Minimal UploadFile-like with a real BytesIO stream."""
+    return SimpleNamespace(
+        file=io.BytesIO(content),
+        content_type=content_type,
+        filename="test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# #6 — helper unit tests (shared by upload_document + priority evidence)
+# ---------------------------------------------------------------------------
+
+
+def test_sniff_and_verify_valid_png_returns_png():
+    assert admission_service._sniff_and_verify_upload(
+        _upload(_png_bytes(), "image/png")
+    ) == "png"
+
+
+def test_sniff_and_verify_valid_jpeg_returns_jpeg():
+    buf = io.BytesIO()
+    Image.new("RGB", (2, 2), "blue").save(buf, "JPEG")
+    assert admission_service._sniff_and_verify_upload(
+        _upload(buf.getvalue(), "image/jpeg")
+    ) == "jpeg"
+
+
+def test_sniff_and_verify_corrupt_png_raises():
+    # Valid PNG magic header but garbage body → PIL verify() fails.
+    corrupt = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+    with pytest.raises(BadRequest, match="Ảnh"):
+        admission_service._sniff_and_verify_upload(_upload(corrupt, "image/png"))
+
+
+def test_sniff_and_verify_clean_pdf_passes():
+    # A clean PDF (no active-content markers) passes; PDFs skip PIL.
+    pdf = b"%PDF-1.4\n1 0 obj<<>>endobj\ntrailer<<>>"
+    assert admission_service._sniff_and_verify_upload(
+        _upload(pdf, "application/pdf")
+    ) == "pdf"
+
+
+def test_sniff_and_verify_pdf_with_active_content_raises():
+    # A PDF carrying JavaScript / OpenAction is rejected (malware vector).
+    pdf = b"%PDF-1.4\n/OpenAction << /S /JavaScript /JS (app.alert(1)) >>\ntrailer"
+    with pytest.raises(BadRequest, match="nội dung động"):
+        admission_service._sniff_and_verify_upload(_upload(pdf, "application/pdf"))
+
+
+def test_sniff_and_verify_oversized_image_raises(monkeypatch):
+    # Image-bomb guard: cap monkeypatched low so we don't allocate a real bomb.
+    monkeypatch.setattr(admission_service, "_MAX_IMAGE_DIMENSION", 2)
+    big = _png_bytes(size=(64, 64))  # 64 > 2 per side → rejected before decode
+    with pytest.raises(BadRequest, match="quá lớn"):
+        admission_service._sniff_and_verify_upload(_upload(big, "image/png"))
+
+
+def test_sniff_and_verify_truncated_png_raises():
+    # A real PNG cut mid-stream: the header opens fine (lazy read) but
+    # Image.verify() detects the truncation. This exercises the .verify()
+    # branch specifically — the magic+garbage fixture above trips Image.open()
+    # first, so this is the case that pins verify() itself.
+    full = _png_bytes(size=(64, 64))
+    truncated = full[: len(full) // 2]
+    with pytest.raises(BadRequest, match="Ảnh"):
+        admission_service._sniff_and_verify_upload(_upload(truncated, "image/png"))
+
+
+def test_sniff_and_verify_unknown_magic_raises():
+    with pytest.raises(BadRequest, match="magic bytes"):
+        admission_service._sniff_and_verify_upload(
+            _upload(b"not-a-real-file", "image/png")
+        )
+
+
+def test_sniff_and_verify_content_type_mismatch_raises():
+    # Real PNG bytes but client claims application/pdf → mismatch raised
+    # OUTSIDE the PIL try/except (the except must not swallow it).
+    with pytest.raises(BadRequest, match="Content-Type"):
+        admission_service._sniff_and_verify_upload(
+            _upload(_png_bytes(), "application/pdf")
+        )
+
+
+# ---------------------------------------------------------------------------
+# #6 — REAL priority-evidence upload path rejects a corrupt image
+# ---------------------------------------------------------------------------
+
+
+def _make_profile(status="draft", codes=None):
+    return SimpleNamespace(
+        id=42,
+        lead_id=100,
+        status=status,
+        version=5,
+        academic_year=2026,
+        priority_object_codes=codes or ["04"],
+        priority_object_evidence={},
+        priority_resolution_snapshot={},
+    )
+
+
+def _make_actor():
+    return SimpleNamespace(id=7, role="officer", full_name="U7", email="u7@e.com")
+
+
+def _make_catalog_db(has_sub_code=True):
+    catalog_result = MagicMock()
+    catalog_result.scalar_one_or_none = MagicMock(
+        return_value=1 if has_sub_code else None
+    )
+
+    async def _execute(stmt, *a, **k):
+        return catalog_result
+
+    db = MagicMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+async def test_priority_evidence_upload_rejects_corrupt_image(monkeypatch):
+    """The priority-evidence path passes all guards (status/sub_code/catalog)
+    then hits the SHARED helper — a corrupt PNG must be rejected with 400."""
+    profile = _make_profile(status="draft", codes=["04"])
+    db = _make_catalog_db(has_sub_code=True)
+
+    async def _mock_get_profile(db_, profile_id, current_user):
+        return profile
+
+    monkeypatch.setattr(admission_service, "get_profile", _mock_get_profile)
+
+    corrupt_png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+    upload = _upload(corrupt_png, "image/png")
+
+    with pytest.raises(BadRequest, match="Ảnh"):
+        await admission_service.upload_priority_evidence_document(
+            db=db,
+            profile_id=42,
+            sub_code="04",
+            file=upload,
+            current_user=_make_actor(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# #5 — student_code uses CSPRNG (secrets), not random
+# ---------------------------------------------------------------------------
+
+
+def test_student_code_module_uses_secrets_not_random():
+    """Pins the CSPRNG swap: admission_service uses ``secrets.randbelow`` and no
+    longer uses ``random.randint`` anywhere. The source-level check below also
+    catches a FUNCTION-LOCAL ``import random; random.randint(...)`` regression
+    that the module-attribute check alone would miss."""
+    import inspect
+    import secrets as _secrets
+
+    assert admission_service.secrets is _secrets
+    assert not hasattr(admission_service, "random")
+
+    src = inspect.getsource(admission_service)
+    assert "secrets.randbelow" in src, "student_code generator must use CSPRNG"
+    assert "random.randint" not in src, "no insecure random.randint may return"

--- a/Backend_FastAPI/tests/unit/test_upload_image_verify.py
+++ b/Backend_FastAPI/tests/unit/test_upload_image_verify.py
@@ -83,6 +83,28 @@ def test_sniff_and_verify_pdf_with_active_content_raises():
         admission_service._sniff_and_verify_upload(_upload(pdf, "application/pdf"))
 
 
+def test_sniff_and_verify_pdf_js_substring_not_false_rejected():
+    # REGRESSION: the 3-byte "/JS" sequence occurs by chance inside the
+    # compressed stream bytes of legitimate scanned PDFs. With /JS dropped from
+    # the marker set it must NOT trigger a reject — only the longer real tokens
+    # do. (No /JavaScript/OpenAction/Launch/EmbeddedFile present here.)
+    pdf = (
+        b"%PDF-1.4\n1 0 obj\nstream\n"
+        b"random /JS bytes here /JS"
+        b"\nendstream\nendobj\ntrailer<<>>"
+    )
+    assert admission_service._sniff_and_verify_upload(
+        _upload(pdf, "application/pdf")
+    ) == "pdf"
+
+
+def test_sniff_and_verify_pdf_launch_still_rejected():
+    # The longer markers stay active: /Launch (run external program) is rejected.
+    pdf = b"%PDF-1.4\n<< /S /Launch /F (calc.exe) >>\ntrailer<<>>"
+    with pytest.raises(BadRequest, match="nội dung động"):
+        admission_service._sniff_and_verify_upload(_upload(pdf, "application/pdf"))
+
+
 def test_sniff_and_verify_oversized_image_raises(monkeypatch):
     # Image-bomb guard: cap monkeypatched low so we don't allocate a real bomb.
     monkeypatch.setattr(admission_service, "_MAX_IMAGE_DIMENSION", 2)


### PR DESCRIPTION
Backend hardening gom **1 PR** (god-file split + Step8 realtime XL **loại trừ** theo yêu cầu), qua 2 vòng plan-review.

## #5 — CSPRNG cho student_code
`secrets.randbelow` thay `random.randint`. student_code là **mã định danh công khai** (SV+YYYY+4d) → defense-in-depth giảm predictability mã chưa cấp, **giữ format**. Không phải credential bí mật.

## #6 — Image verify khi upload (CẢ 2 path)
Tách helper `_sniff_and_verify_upload` (magic-byte sniff + content-type match + PIL structural verify), gọi ở **cả** `upload_document` **và** priority-evidence upload — review round 1 ban đầu chỉ vá 1 chỗ. `try/except` **chỉ** bọc `Image.verify()` (không nuốt content-type error). Pillow đã có sẵn.
- Verify bắt **corrupt/fake image structure**, không phải mọi polyglot/malware (ClamAV cho PDF = future).

## #7 — f_unaccent admission search (list + counts parity)
Tách helper `_name_search_condition`, dùng ở **cả** list query (`get_filtered_with_count`) **và** status-counts (`_build_base_conditions`) → "nguyen" khớp "Nguyễn" ở **cả** list lẫn tab counts (P2 parity). Index `ix_lead_fullname_unaccent_trgm` (leadsrch01).
- **User search EXCLUDED**: path thực `/api/admin/users` (`search_with_hierarchy` → `_apply_user_filters`) + CSV export đều dùng `search_vector @@ to_tsquery` tsvector (không ilike); bỏ dấu cần đổi tsvector config → deferred. (v1 sửa nhầm `UserRepository.get_filtered` — không phải path thực — đã **revert** sau khi test lộ ra.)

## Ngoài PR
- **Sentry/APM**: code init đã có (`main.py:115`); chỉ cần set `SENTRY_DSN` env (ops, không code).
- God-file split · Step8 realtime · Zalo cleanup: tách riêng.

## Test
`test_upload_image_verify` (6 helper + priority-evidence **integration thật** + CSPRNG pin) + `test_admission_search_unaccent` (list+counts parity + no-false-positive) + **16 priority regression**. flake8 net-new sạch.
> ⚠️ Pre-existing fail KHÔNG liên quan: `test_admission_document_staging` (authz/doc-config) fail cả trên `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)