### PR TITLE
feat(admission): tab "Tổ hợp môn" — admin CRUD path_subject_group_config (multi-NV)

### DIFF
--- a/Backend_FastAPI/app/repositories/path_subject_group_repository.py
+++ b/Backend_FastAPI/app/repositories/path_subject_group_repository.py
@@ -26,17 +26,6 @@ class PathSubjectGroupRepository:
             stmt = stmt.options(selectinload(PathSubjectGroupConfig.items))
         return (await self.db.execute(stmt)).scalar_one_or_none()
 
-    async def list_configs_by_path(
-        self, admission_path_id: int
-    ) -> List[PathSubjectGroupConfig]:
-        stmt = (
-            select(PathSubjectGroupConfig)
-            .where(PathSubjectGroupConfig.admission_path_id == admission_path_id)
-            .options(selectinload(PathSubjectGroupConfig.items))
-            .order_by(PathSubjectGroupConfig.subject_group_id)
-        )
-        return list((await self.db.execute(stmt)).scalars().all())
-
     async def list_configs_by_path_with_subjects(
         self, admission_path_id: int
     ) -> List[PathSubjectGroupConfig]:
@@ -89,4 +78,19 @@ class PathSubjectGroupRepository:
         )
         if excluded_config_id is not None:
             stmt = stmt.where(PathSubjectGroupConfig.id != excluded_config_id)
+        return int((await self.db.execute(stmt)).scalar_one())
+
+    async def count_choices_by_config(self, config_id: int) -> int:
+        """Count admission_profile_choice rows referencing this config.
+
+        FK ``admission_profile_choice.path_subject_group_config_id`` is
+        ``ondelete=RESTRICT`` → precheck before delete to return a clean 409
+        instead of a raw IntegrityError 500.
+        """
+        from app.models.admission_profile_choice import AdmissionProfileChoice
+        stmt = (
+            select(func.count())
+            .select_from(AdmissionProfileChoice)
+            .where(AdmissionProfileChoice.path_subject_group_config_id == config_id)
+        )
         return int((await self.db.execute(stmt)).scalar_one())

--- a/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
+++ b/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
@@ -11,12 +11,15 @@ from app.core.rate_limits import RateLimits, limiter
 from app.schemas.path_subject_group import (
     ClonePathsRequest,
     ClonePathsResponse,
+    PathSubjectGroupConfigAdminListResponse,
+    PathSubjectGroupConfigAdminResponse,
     PathSubjectGroupConfigCreate,
-    PathSubjectGroupConfigListResponse,
     PathSubjectGroupConfigResponse,
+    PathSubjectGroupConfigSubjectAdmin,
     PathSubjectGroupConfigUpdate,
     PathSubjectGroupItemCreate,
     PathSubjectGroupItemResponse,
+    PathSubjectGroupItemUpdate,
 )
 from app.schemas.admission_path import AdmissionPathQuotaUpdate, AdmissionPathResponse
 from app.schemas.quota_matrix import PathMatrixResponse, QuotaMatrixResponse
@@ -58,9 +61,8 @@ async def create_config(
     """Create path subject group config với items."""
     service = PathSubjectGroupService(db)
     config = await service.create_config(admission_path_id, payload)
-    await db.commit()
-    await db.refresh(config, ["items"])
-
+    # Audit BEFORE commit: log_activity only flushes (does not commit), so the
+    # activity row must share this transaction frame or it never persists.
     await activity_service.log_activity(
         db=db,
         action="path_subject_group_config_create",
@@ -72,12 +74,14 @@ async def create_config(
             f"subject_group={payload.subject_group_id}"
         ),
     )
+    await db.commit()
+    await db.refresh(config, ["items"])
     return config
 
 
 @router.get(
     "/admission-paths/{admission_path_id}/subject-group-configs",
-    response_model=PathSubjectGroupConfigListResponse,
+    response_model=PathSubjectGroupConfigAdminListResponse,
 )
 async def list_configs(
     request: Request,
@@ -85,10 +89,66 @@ async def list_configs(
     db: AsyncSession = Depends(database.get_db),
     _admin: models.User = Depends(require_admin),
 ):
-    """List all configs trên a given admission_path."""
+    """List configs (enriched) on a path for the admin "Tổ hợp môn" tab.
+
+    Hand-built (mirrors the officer GET in admission_paths.py) so the response
+    carries subject_group label + per-subject detail and emits scores as JSON
+    number (float) — the bare ``...ListResponse`` response_model would strip
+    those enriched fields and Decimal would serialize to string.
+    """
     service = PathSubjectGroupService(db)
-    configs = await service.repo.list_configs_by_path(admission_path_id)
-    return PathSubjectGroupConfigListResponse(total=len(configs), items=configs)
+    configs = await service.repo.list_configs_by_path_with_subjects(
+        admission_path_id
+    )
+    items_out = []
+    for c in configs:
+        sg = c.subject_group
+        subjects = []
+        if sg is not None and sg.subject_mappings:
+            for m in sorted(
+                sg.subject_mappings,
+                key=lambda x: getattr(x, "position", 0) or 0,
+            ):
+                s = m.subject
+                if s is None:
+                    continue
+                subjects.append(PathSubjectGroupConfigSubjectAdmin(
+                    subject_id=s.id,
+                    subject_code=s.code,
+                    subject_name=s.name_vi,
+                    subject_group_subject_id=m.id,
+                    max_score=(
+                        float(s.max_score) if s.max_score is not None else 10.0
+                    ),
+                    min_possible_score=(
+                        float(s.min_possible_score)
+                        if s.min_possible_score is not None else 0.0
+                    ),
+                    position=getattr(m, "position", 0) or 0,
+                ))
+        items_out.append(PathSubjectGroupConfigAdminResponse(
+            id=c.id,
+            admission_path_id=c.admission_path_id,
+            subject_group_id=c.subject_group_id,
+            subject_group_code=getattr(sg, "code", None) if sg else None,
+            subject_group_name=getattr(sg, "name", None) if sg else None,
+            min_score=float(c.min_score) if c.min_score is not None else None,
+            min_subject_score=(
+                float(c.min_subject_score)
+                if c.min_subject_score is not None else None
+            ),
+            group_quota=c.group_quota,
+            items=[
+                PathSubjectGroupItemResponse.model_validate(it, from_attributes=True)
+                for it in sorted(c.items, key=lambda it: it.id)
+            ],
+            subjects=subjects,
+            created_at=c.created_at,
+            updated_at=c.updated_at,
+        ))
+    return PathSubjectGroupConfigAdminListResponse(
+        total=len(items_out), items=items_out
+    )
 
 
 @limiter.limit(RateLimits.ADMIN_WRITE)
@@ -106,9 +166,6 @@ async def update_config(
     """Update score thresholds + group_quota (Tier 3 re-validation)."""
     service = PathSubjectGroupService(db)
     config = await service.update_config(config_id, payload)
-    await db.commit()
-    await db.refresh(config, ["items"])
-
     await activity_service.log_activity(
         db=db,
         action="path_subject_group_config_update",
@@ -117,6 +174,8 @@ async def update_config(
         actor_id=current_admin.id,
         description=f"Updated config {config_id}",
     )
+    await db.commit()
+    await db.refresh(config, ["items"])
     return config
 
 
@@ -134,8 +193,6 @@ async def delete_config(
     """Delete config + cascade items."""
     service = PathSubjectGroupService(db)
     await service.delete_config(config_id)
-    await db.commit()
-
     await activity_service.log_activity(
         db=db,
         action="path_subject_group_config_delete",
@@ -144,6 +201,7 @@ async def delete_config(
         actor_id=current_admin.id,
         description=f"Deleted config {config_id}",
     )
+    await db.commit()
 
 
 # =============================================================================
@@ -167,8 +225,70 @@ async def add_item(
     """Add single item to existing config (composite invariant guard)."""
     service = PathSubjectGroupService(db)
     item = await service.add_item(config_id, payload)
+    await activity_service.log_activity(
+        db=db,
+        action="path_subject_group_item_add",
+        resource_type="path_subject_group_config",
+        resource_id=config_id,
+        actor_id=current_admin.id,
+        description=f"Added item to config {config_id}",
+    )
     await db.commit()
     return item
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.patch(
+    "/path-subject-group-configs/{config_id}/items/{item_id}",
+    response_model=PathSubjectGroupItemResponse,
+)
+async def update_item(
+    request: Request,
+    config_id: int,
+    item_id: int,
+    payload: PathSubjectGroupItemUpdate,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """Update an item's is_principal / min_subject_score (scoped to config)."""
+    service = PathSubjectGroupService(db)
+    item = await service.update_item(config_id, item_id, payload)
+    await activity_service.log_activity(
+        db=db,
+        action="path_subject_group_item_update",
+        resource_type="path_subject_group_config",
+        resource_id=config_id,
+        actor_id=current_admin.id,
+        description=f"Updated item {item_id} of config {config_id}",
+    )
+    await db.commit()
+    return item
+
+
+@limiter.limit(RateLimits.ADMIN_WRITE)
+@router.delete(
+    "/path-subject-group-configs/{config_id}/items/{item_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_item(
+    request: Request,
+    config_id: int,
+    item_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_admin: models.User = Depends(require_admin),
+):
+    """Delete an item (scoped to config)."""
+    service = PathSubjectGroupService(db)
+    await service.delete_item(config_id, item_id)
+    await activity_service.log_activity(
+        db=db,
+        action="path_subject_group_item_delete",
+        resource_type="path_subject_group_config",
+        resource_id=config_id,
+        actor_id=current_admin.id,
+        description=f"Deleted item {item_id} of config {config_id}",
+    )
+    await db.commit()
 
 
 # =============================================================================
@@ -308,8 +428,9 @@ async def clone_paths_from_round(
         source_round_id=source_round_id,
         payload=payload,
     )
-    await db.commit()
-
+    # Audit BEFORE commit (log_activity only flushes) so the activity row shares
+    # this transaction frame — otherwise it is flushed then dropped on session
+    # close (same fix as the config/item endpoints above).
     await activity_service.log_activity(
         db=db,
         action="admission_paths_cloned",
@@ -321,4 +442,5 @@ async def clone_paths_from_round(
             f"→ round {target_round_id} (skipped {response.skipped_count})"
         ),
     )
+    await db.commit()
     return response

--- a/Backend_FastAPI/app/routers/admission_paths.py
+++ b/Backend_FastAPI/app/routers/admission_paths.py
@@ -137,6 +137,9 @@ async def build_path_response(
     response.can_edit_governance = service.compute_can_edit_governance(
         path, current_user
     )
+    response.can_manage_subject_group_configs = (
+        service.compute_can_manage_subject_group_configs(path, current_user)
+    )
     if include_validation_errors:
         _, errors = await service.validate_activation(path)
         response.validation_errors = errors

--- a/Backend_FastAPI/app/schemas/admission_path.py
+++ b/Backend_FastAPI/app/schemas/admission_path.py
@@ -585,6 +585,14 @@ class AdmissionPathResponse(BaseModel):
             "gates the 'Nâng cao' tab on this flag instead of user.role (thin-client)."
         ),
     )
+    can_manage_subject_group_configs: bool = Field(
+        default=False,
+        description=(
+            "Admin-only gate for the 'Tổ hợp môn' tab (path_subject_group_config "
+            "CRUD). Stricter than can_edit_governance: admin AND not archived. FE "
+            "gates the tab + controls on this (require_admin route + archived block)."
+        ),
+    )
     validation_errors: List[str] = Field(
         default_factory=list,
         description="Reasons why activation is blocked"

--- a/Backend_FastAPI/app/schemas/path_subject_group.py
+++ b/Backend_FastAPI/app/schemas/path_subject_group.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 
 class PathSubjectGroupItemBase(BaseModel):
@@ -22,7 +22,13 @@ class PathSubjectGroupItemCreate(PathSubjectGroupItemBase):
 
 
 class PathSubjectGroupItemUpdate(BaseModel):
-    is_principal: Optional[bool] = None
+    # ``bool`` (NOT ``Optional[bool]``): omit the field to leave is_principal
+    # unchanged (default applies, then ``model_dump(exclude_unset=True)`` drops
+    # it); an EXPLICIT null is rejected as 422 by the type itself. Using ``bool``
+    # also keeps the OpenAPI / generated-client contract honest (``boolean``, not
+    # ``boolean | null``) — a runtime-only validator on Optional[bool] would
+    # still advertise the field as nullable.
+    is_principal: bool = False
     min_subject_score: Optional[Decimal] = Field(default=None, ge=0)
 
 
@@ -32,6 +38,12 @@ class PathSubjectGroupItemResponse(PathSubjectGroupItemBase):
     path_subject_group_config_id: int
     created_at: datetime
     updated_at: datetime
+
+    @field_serializer("min_subject_score", when_used="json")
+    def _ser_min_subject_score(self, v: Optional[Decimal]) -> Optional[float]:
+        # Pydantic v2 serializes Decimal→string by default; FE parses score as
+        # z.number(). Emit JSON number (mirror application_fee serializer).
+        return float(v) if v is not None else None
 
 
 class PathSubjectGroupConfigBase(BaseModel):
@@ -64,10 +76,50 @@ class PathSubjectGroupConfigResponse(PathSubjectGroupConfigBase):
     created_at: datetime
     updated_at: datetime
 
+    @field_serializer("min_score", "min_subject_score", when_used="json")
+    def _ser_scores(self, v: Optional[Decimal]) -> Optional[float]:
+        # Decimal→JSON number for FE z.number() (see item serializer note).
+        return float(v) if v is not None else None
+
 
 class PathSubjectGroupConfigListResponse(BaseModel):
     total: int
     items: List[PathSubjectGroupConfigResponse]
+
+
+# ============================================================
+# Admin enriched read schema (#7 — subject-group config tab)
+# ============================================================
+# The admin GET hand-builds these (see admin_v2_path_subject_group.list_configs)
+# with float() scores, so they declare score fields as float — NOT Decimal —
+# and carry subject_group label + per-subject detail the AddChoiceDialog-style
+# UI needs. The base list response (above) only has bare config+items and would
+# strip these enriched fields under response_model.
+
+
+class PathSubjectGroupConfigSubjectAdmin(BaseModel):
+    """One subject of the config's subject_group (for principal-item UI)."""
+    subject_id: int
+    subject_code: str
+    subject_name: str
+    subject_group_subject_id: int  # = SubjectGroupSubject.id (item target)
+    max_score: float
+    min_possible_score: float
+    position: int = 0
+
+
+class PathSubjectGroupConfigAdminResponse(PathSubjectGroupConfigResponse):
+    # Override score fields → float (admin GET builds them via float()).
+    min_score: Optional[float] = None
+    min_subject_score: Optional[float] = None
+    subject_group_code: Optional[str] = None
+    subject_group_name: Optional[str] = None
+    subjects: List[PathSubjectGroupConfigSubjectAdmin] = Field(default_factory=list)
+
+
+class PathSubjectGroupConfigAdminListResponse(BaseModel):
+    total: int
+    items: List[PathSubjectGroupConfigAdminResponse]
 
 
 # ============================================================

--- a/Backend_FastAPI/app/services/admission_path_service.py
+++ b/Backend_FastAPI/app/services/admission_path_service.py
@@ -1103,6 +1103,25 @@ class AdmissionPathService:
         """
         return bool(user and user.role == UserRole.ADMIN)
 
+    def compute_can_manage_subject_group_configs(
+        self,
+        path: AdmissionPath,
+        user: User | None = None,
+    ) -> bool:
+        """Admin-only gate for the 'Tổ hợp môn' tab (path_subject_group_config
+        CRUD).
+
+        Stricter than ``compute_can_edit_governance``: admin AND not archived.
+        The routes are ``require_admin`` and the service blocks archived paths,
+        so the FE must gate the tab + controls on THIS (not ``can_edit``, which
+        is True for a manager on a draft → would show controls that then 403).
+        """
+        return bool(
+            user
+            and user.role == UserRole.ADMIN
+            and path.status != "archived"
+        )
+
     async def compute_can_activate(
         self,
         path: AdmissionPath,

--- a/Backend_FastAPI/app/services/path_subject_group_service.py
+++ b/Backend_FastAPI/app/services/path_subject_group_service.py
@@ -12,6 +12,7 @@ from typing import List
 
 import structlog
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models
@@ -19,6 +20,7 @@ from app.models.admission_config import (
     AdmissionPath,
     PathSubjectGroupConfig,
     PathSubjectGroupItem,
+    SubjectGroup,
     SubjectGroupSubject,
 )
 from app.repositories.path_subject_group_repository import PathSubjectGroupRepository
@@ -30,6 +32,7 @@ from app.schemas.path_subject_group import (
 )
 from app.utils.exceptions import (
     BusinessRuleViolation,
+    ConflictError,
     DuplicateResourceError,
     ResourceNotFoundError,
 )
@@ -43,6 +46,31 @@ class PathSubjectGroupService:
     def __init__(self, db: AsyncSession):
         self.db = db
         self.repo = PathSubjectGroupRepository(db)
+
+    async def _require_writable_path(self, admission_path_id: int) -> AdmissionPath:
+        """Load the path or 404; block writes on an archived path.
+
+        Mirrors the AdmissionPathService lifecycle guard for archived paths.
+        All config/item mutations run through this so a bad ``admission_path_id``
+        surfaces as a clean 404 (instead of falling through to an FK 500) and
+        archived paths reject with a domain 400. Routes are ``require_admin`` so
+        no manager branch is needed here.
+        """
+        path = (
+            await self.db.execute(
+                select(AdmissionPath).where(AdmissionPath.id == admission_path_id)
+            )
+        ).scalar_one_or_none()
+        if path is None:
+            raise ResourceNotFoundError(
+                f"AdmissionPath {admission_path_id} not found"
+            )
+        if path.status == "archived":
+            raise BusinessRuleViolation(
+                "Không thể sửa tổ hợp môn của đường tuyển sinh đã lưu trữ "
+                "(archived)."
+            )
+        return path
 
     async def validate_tier3_chain(
         self,
@@ -122,6 +150,8 @@ class PathSubjectGroupService:
         - Composite invariant — BusinessRuleViolation
         - Tier 3 chain (if group_quota set) — BusinessRuleViolation
         """
+        await self._require_writable_path(admission_path_id)
+
         existing = await self.repo.get_config_by_path_and_group(
             admission_path_id, payload.subject_group_id
         )
@@ -133,9 +163,30 @@ class PathSubjectGroupService:
 
         # Composite invariant check (if items provided)
         item_sgs_ids = [item.subject_group_subject_id for item in payload.items]
+        # Reject a duplicated payload item (FE double-add) up front — the
+        # composite-invariant check dedups via id.in_(set) so it would NOT catch
+        # it, and the insert would otherwise hit uq_path_subject_group_item.
+        if len(item_sgs_ids) != len(set(item_sgs_ids)):
+            raise DuplicateResourceError(
+                "Danh sách môn (items) có subject_group_subject_id trùng lặp."
+            )
         await self._validate_composite_invariant(
             payload.subject_group_id, item_sgs_ids
         )
+        # When NO items, the composite invariant is skipped, so a bad
+        # subject_group_id would only surface at the FK (→ 500). Validate here.
+        if not item_sgs_ids:
+            sg_exists = (
+                await self.db.execute(
+                    select(SubjectGroup.id).where(
+                        SubjectGroup.id == payload.subject_group_id
+                    )
+                )
+            ).scalar_one_or_none()
+            if sg_exists is None:
+                raise ResourceNotFoundError(
+                    f"SubjectGroup {payload.subject_group_id} not found"
+                )
 
         # Tier 3 chain check (if group_quota provided)
         if payload.group_quota is not None:
@@ -151,17 +202,29 @@ class PathSubjectGroupService:
             group_quota=payload.group_quota,
         )
         self.db.add(config)
-        await self.db.flush()
-
-        for item_payload in payload.items:
-            item = PathSubjectGroupItem(
-                path_subject_group_config_id=config.id,
-                subject_group_subject_id=item_payload.subject_group_subject_id,
-                is_principal=item_payload.is_principal,
-                min_subject_score=item_payload.min_subject_score,
+        # config + items in ONE savepoint so ANY UNIQUE violation — the config
+        # (admission_path_id, subject_group_id) race OR a duplicated payload
+        # item hitting uq_path_subject_group_item — maps to a clean 409, not an
+        # IntegrityError 500. (Payload item dup is also prechecked above for a
+        # clearer message; the config dup is prechecked via get_config_*.)
+        try:
+            async with self.db.begin_nested():
+                await self.db.flush()  # config insert
+                for item_payload in payload.items:
+                    self.db.add(PathSubjectGroupItem(
+                        path_subject_group_config_id=config.id,
+                        subject_group_subject_id=(
+                            item_payload.subject_group_subject_id
+                        ),
+                        is_principal=item_payload.is_principal,
+                        min_subject_score=item_payload.min_subject_score,
+                    ))
+                await self.db.flush()  # items insert
+        except IntegrityError:
+            raise DuplicateResourceError(
+                f"Tổ hợp trùng cho path={admission_path_id}, subject_group="
+                f"{payload.subject_group_id} (hoặc môn lặp trong danh sách)."
             )
-            self.db.add(item)
-        await self.db.flush()
 
         log.info(
             "path_subject_group_config_created",
@@ -184,6 +247,7 @@ class PathSubjectGroupService:
         config = await self.repo.get_config_by_id(config_id)
         if config is None:
             raise ResourceNotFoundError(f"Config {config_id} not found")
+        await self._require_writable_path(config.admission_path_id)
 
         update_data = payload.model_dump(exclude_unset=True)
 
@@ -216,6 +280,7 @@ class PathSubjectGroupService:
         config = await self.repo.get_config_by_id(config_id)
         if config is None:
             raise ResourceNotFoundError(f"Config {config_id} not found")
+        await self._require_writable_path(config.admission_path_id)
 
         await self._validate_composite_invariant(
             config.subject_group_id, [payload.subject_group_subject_id]
@@ -228,7 +293,16 @@ class PathSubjectGroupService:
             min_subject_score=payload.min_subject_score,
         )
         self.db.add(item)
-        await self.db.flush()
+        # Savepoint: UNIQUE(config_id, subject_group_subject_id) dup → 409, not
+        # an IntegrityError 500.
+        try:
+            async with self.db.begin_nested():
+                await self.db.flush()
+        except IntegrityError:
+            raise DuplicateResourceError(
+                f"Môn (subject_group_subject={payload.subject_group_subject_id}) "
+                f"đã có trong tổ hợp này."
+            )
 
         log.info(
             "path_subject_group_item_added",
@@ -238,10 +312,92 @@ class PathSubjectGroupService:
         return item
 
     async def delete_config(self, config_id: int) -> None:
-        """Delete config + cascade items."""
+        """Delete config (cascade items). Blocks if a choice references it."""
         config = await self.repo.get_config_by_id(config_id, with_items=False)
         if config is None:
             raise ResourceNotFoundError(f"Config {config_id} not found")
-        await self.db.delete(config)
-        await self.db.flush()
+        await self._require_writable_path(config.admission_path_id)
+
+        # FK admission_profile_choice.path_subject_group_config_id is RESTRICT.
+        used = await self.repo.count_choices_by_config(config_id)
+        if used > 0:
+            raise ConflictError(
+                f"Không thể xóa: tổ hợp đang được {used} nguyện vọng sử dụng."
+            )
+        # Savepoint catches the race where a choice is created after the
+        # precheck (still RESTRICT → IntegrityError) → clean 409, not 500.
+        try:
+            async with self.db.begin_nested():
+                await self.db.delete(config)
+                await self.db.flush()
+        except IntegrityError:
+            raise ConflictError(
+                "Không thể xóa: tổ hợp đang được nguyện vọng sử dụng."
+            )
         log.info("path_subject_group_config_deleted", config_id=config_id)
+
+    async def update_item(
+        self,
+        config_id: int,
+        item_id: int,
+        payload: PathSubjectGroupItemUpdate,
+    ) -> PathSubjectGroupItem:
+        """Update an item's is_principal / min_subject_score, scoped to its
+        config. ``subject_group_subject_id`` is NOT mutable here, so neither the
+        composite invariant nor the item UNIQUE can be violated."""
+        config = await self.repo.get_config_by_id(config_id, with_items=False)
+        if config is None:
+            raise ResourceNotFoundError(f"Config {config_id} not found")
+        await self._require_writable_path(config.admission_path_id)
+
+        item = (
+            await self.db.execute(
+                select(PathSubjectGroupItem).where(
+                    PathSubjectGroupItem.id == item_id,
+                    PathSubjectGroupItem.path_subject_group_config_id == config_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if item is None:
+            raise ResourceNotFoundError(
+                f"Item {item_id} not found trong config {config_id}"
+            )
+
+        update_data = payload.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(item, field, value)
+        await self.db.flush()
+        log.info(
+            "path_subject_group_item_updated",
+            config_id=config_id,
+            item_id=item_id,
+            fields=list(update_data.keys()),
+        )
+        return item
+
+    async def delete_item(self, config_id: int, item_id: int) -> None:
+        """Delete an item scoped to its config (avoids cross-config IDOR)."""
+        config = await self.repo.get_config_by_id(config_id, with_items=False)
+        if config is None:
+            raise ResourceNotFoundError(f"Config {config_id} not found")
+        await self._require_writable_path(config.admission_path_id)
+
+        item = (
+            await self.db.execute(
+                select(PathSubjectGroupItem).where(
+                    PathSubjectGroupItem.id == item_id,
+                    PathSubjectGroupItem.path_subject_group_config_id == config_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if item is None:
+            raise ResourceNotFoundError(
+                f"Item {item_id} not found trong config {config_id}"
+            )
+        await self.db.delete(item)
+        await self.db.flush()
+        log.info(
+            "path_subject_group_item_deleted",
+            config_id=config_id,
+            item_id=item_id,
+        )

--- a/Backend_FastAPI/tests/services/test_phase2_pr2d_path_subject_group_service.py
+++ b/Backend_FastAPI/tests/services/test_phase2_pr2d_path_subject_group_service.py
@@ -18,9 +18,15 @@ from app.database import AsyncSessionLocal
 from app.schemas.path_subject_group import (
     PathSubjectGroupConfigCreate,
     PathSubjectGroupItemCreate,
+    PathSubjectGroupItemUpdate,
 )
 from app.services.path_subject_group_service import PathSubjectGroupService
-from app.utils.exceptions import BusinessRuleViolation, DuplicateResourceError
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    ConflictError,
+    DuplicateResourceError,
+    ResourceNotFoundError,
+)
 
 
 pytestmark = pytest.mark.integration
@@ -222,3 +228,268 @@ async def test_tier3_chain_unbounded_when_admit_quota_null(
                 subject_group_id=sg_id, group_quota=10000,
             ),
         )
+
+
+# ============================================================
+# #7 follow-up — item PATCH/DELETE scope, dup, delete-guard, lifecycle
+# ============================================================
+
+
+@pytest_asyncio.fixture
+async def item_seed(seed_lead_dependencies: dict) -> dict:
+    """Active path + subject_group (2 subjects) + config 1 holding 1 item +
+    config 2 (other group, empty) for cross-config scope tests."""
+    ts = int(datetime.now(timezone.utc).timestamp() * 1_000_000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            offering = models.ProgramOffering(
+                program_id=seed_lead_dependencies["major_program_id"],
+                offering_type="full_time", duration_semesters=8,
+            )
+            s.add(offering); await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=offering.id, academic_year=2026,
+                annual_admission_quota=20, tuition_fee_per_year=1_000_000,
+            )
+            s.add(ai); await s.flush()
+            from tests.fixtures.builders import AdmissionRoundBuilder
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                s, academic_year=2026,
+            )
+            method = models.AdmissionMethod(
+                code=f"IM{ts}"[:20], name=f"IM {ts}",
+                requires_subject_scores=True, is_active=True,
+            )
+            s.add(method); await s.flush()
+            path = models.AdmissionPath(
+                academic_info_id=ai.id, admission_method_id=method.id,
+                admission_round_id=round_id, admit_quota=None, status="active",
+            )
+            s.add(path); await s.flush()
+            sg = models.SubjectGroup(code=f"IG{ts}"[:20], name=f"IG {ts}")
+            sg2 = models.SubjectGroup(code=f"IH{ts}"[:20], name=f"IH {ts}")
+            s.add_all([sg, sg2]); await s.flush()
+            subj1 = models.Subject(code=f"IS{ts}"[:20], name_vi=f"S1 {ts}")
+            subj2 = models.Subject(code=f"IT{ts}"[:20], name_vi=f"S2 {ts}")
+            s.add_all([subj1, subj2]); await s.flush()
+            sgs1 = models.SubjectGroupSubject(
+                subject_group_id=sg.id, subject_id=subj1.id, position=1,
+            )
+            sgs2 = models.SubjectGroupSubject(
+                subject_group_id=sg.id, subject_id=subj2.id, position=2,
+            )
+            s.add_all([sgs1, sgs2]); await s.flush()
+            ids = {
+                "path_id": path.id, "sg_id": sg.id, "sg2_id": sg2.id,
+                "sgs1_id": sgs1.id, "sgs2_id": sgs2.id,
+            }
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        cfg = await svc.create_config(
+            ids["path_id"],
+            PathSubjectGroupConfigCreate(
+                subject_group_id=ids["sg_id"],
+                items=[PathSubjectGroupItemCreate(
+                    subject_group_subject_id=ids["sgs1_id"]
+                )],
+            ),
+        )
+        cfg2 = await svc.create_config(
+            ids["path_id"],
+            PathSubjectGroupConfigCreate(subject_group_id=ids["sg2_id"]),
+        )
+        # Capture PKs BEFORE commit — expire_on_commit would turn later ORM
+        # attribute access into an async lazy-load (MissingGreenlet).
+        config_id, config2_id = cfg.id, cfg2.id
+        await s.commit()
+        # Reload with items via an awaited query (selectinload) to read item id.
+        reloaded = await svc.repo.get_config_by_id(config_id)
+        ids["config_id"] = config_id
+        ids["item_id"] = reloaded.items[0].id
+        ids["config2_id"] = config2_id
+    return ids
+
+
+@pytest.mark.asyncio
+async def test_update_item_changes_principal_and_score(item_seed: dict):
+    """update_item sets is_principal + min_subject_score on the scoped item."""
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        item = await svc.update_item(
+            item_seed["config_id"], item_seed["item_id"],
+            PathSubjectGroupItemUpdate(
+                is_principal=True, min_subject_score=Decimal("5.0")
+            ),
+        )
+        # Assert BEFORE commit (expire_on_commit → MissingGreenlet otherwise).
+        assert item.is_principal is True
+        assert item.min_subject_score == Decimal("5.0")
+        await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_update_item_cross_config_scope_404(item_seed: dict):
+    """Item belongs to config 1; updating under config 2's id → 404 (guards
+    cross-config IDOR)."""
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        with pytest.raises(ResourceNotFoundError):
+            await svc.update_item(
+                item_seed["config2_id"], item_seed["item_id"],
+                PathSubjectGroupItemUpdate(is_principal=True),
+            )
+
+
+@pytest.mark.asyncio
+async def test_delete_item_cross_config_scope_404(item_seed: dict):
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        with pytest.raises(ResourceNotFoundError):
+            await svc.delete_item(item_seed["config2_id"], item_seed["item_id"])
+
+
+@pytest.mark.asyncio
+async def test_delete_item_happy_then_gone(item_seed: dict):
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        await svc.delete_item(item_seed["config_id"], item_seed["item_id"])
+        await s.commit()
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        with pytest.raises(ResourceNotFoundError):
+            await svc.delete_item(item_seed["config_id"], item_seed["item_id"])
+
+
+@pytest.mark.asyncio
+async def test_add_item_duplicate_returns_409_not_500(item_seed: dict):
+    """Re-adding sgs1 (already in config 1) → DuplicateResourceError via the
+    savepoint catch, NOT a raw IntegrityError 500."""
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        with pytest.raises(DuplicateResourceError):
+            await svc.add_item(
+                item_seed["config_id"],
+                PathSubjectGroupItemCreate(
+                    subject_group_subject_id=item_seed["sgs1_id"]
+                ),
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_config_bad_path_404(seed_lead_dependencies: dict):
+    """Non-existent path → ResourceNotFoundError, not a fall-through FK 500."""
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        with pytest.raises(ResourceNotFoundError):
+            await svc.create_config(
+                999_999_999,
+                PathSubjectGroupConfigCreate(subject_group_id=1),
+            )
+
+
+@pytest.mark.asyncio
+async def test_create_config_bad_subject_group_no_items_404(item_seed: dict):
+    """No items → composite invariant skipped → a bad subject_group_id must
+    still surface as 404 (not an FK 500)."""
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        with pytest.raises(ResourceNotFoundError):
+            await svc.create_config(
+                item_seed["path_id"],
+                PathSubjectGroupConfigCreate(subject_group_id=999_999_999),
+            )
+
+
+@pytest.mark.asyncio
+async def test_mutation_on_archived_path_blocked(item_seed: dict):
+    """Archived path → BusinessRuleViolation on create/update/delete + item."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            path = await s.get(models.AdmissionPath, item_seed["path_id"])
+            path.status = "archived"
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        with pytest.raises(BusinessRuleViolation, match="archived"):
+            await svc.update_item(
+                item_seed["config_id"], item_seed["item_id"],
+                PathSubjectGroupItemUpdate(is_principal=True),
+            )
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        with pytest.raises(BusinessRuleViolation, match="archived"):
+            await svc.delete_config(item_seed["config_id"])
+
+
+@pytest.mark.asyncio
+async def test_delete_config_blocked_when_choice_references(
+    item_seed: dict, seed_lead_dependencies: dict
+):
+    """A choice referencing the config → ConflictError (FK RESTRICT precheck),
+    NOT a raw IntegrityError 500."""
+    from app.models.admission_profile_choice import AdmissionProfileChoice
+    ts = int(datetime.now(timezone.utc).timestamp() * 1_000_000) % 1_000_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            lead = models.Lead(
+                full_name="Choice Ref",
+                phone=f"09{ts % 100_000_000:08d}",
+                email=f"choiceref_{ts}@test.com",
+                source="website",
+                unit_id=seed_lead_dependencies["unit_id"],
+                consultation_status_id=seed_lead_dependencies[
+                    "initial_status_id"
+                ],
+                status="new",
+            )
+            s.add(lead); await s.flush()
+            profile = models.AdmissionProfile(
+                lead_id=lead.id, status="submitted",
+                citizen_id=f"{ts:012d}"[:12], version=1, applied_rules={},
+                academic_year=2026, full_name="Choice Ref", phone=lead.phone,
+            )
+            s.add(profile); await s.flush()
+            choice = AdmissionProfileChoice(
+                admission_profile_id=profile.id,
+                admission_path_id=item_seed["path_id"],
+                path_subject_group_config_id=item_seed["config_id"],
+                display_order=1, decision="pending",
+            )
+            s.add(choice); await s.flush()
+
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        with pytest.raises(ConflictError, match="nguyện vọng"):
+            await svc.delete_config(item_seed["config_id"])
+
+
+@pytest.mark.asyncio
+async def test_create_config_duplicate_items_in_payload_409(t3_seed: dict):
+    """FE double-add: items=[sgs, sgs] → DuplicateResourceError (409), NOT a
+    500. The composite invariant dedups via id.in_(set) so it cannot catch the
+    payload dup; the precheck + single savepoint do."""
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        with pytest.raises(DuplicateResourceError):
+            await svc.create_config(
+                t3_seed["path_id"],
+                PathSubjectGroupConfigCreate(
+                    subject_group_id=t3_seed["subject_group_a_id"],
+                    items=[
+                        PathSubjectGroupItemCreate(
+                            subject_group_subject_id=t3_seed["sgs_in_a_id"]
+                        ),
+                        PathSubjectGroupItemCreate(
+                            subject_group_subject_id=t3_seed["sgs_in_a_id"]
+                        ),
+                    ],
+                ),
+            )
+
+
+def test_item_update_rejects_explicit_null_is_principal():
+    """{"is_principal": null} → ValidationError (422); omitting is fine."""
+    import pydantic
+    with pytest.raises(pydantic.ValidationError):
+        PathSubjectGroupItemUpdate(is_principal=None)
+    omitted = PathSubjectGroupItemUpdate(min_subject_score=Decimal("3"))
+    assert "is_principal" not in omitted.model_dump(exclude_unset=True)

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.test.tsx
@@ -38,6 +38,9 @@ const hoisted = vi.hoisted(() => {
     // Default false: base 5-tab suite sees NO "Nâng cao" tab. Governance
     // tests override với can_edit_governance: true để hiện tab.
     can_edit_governance: false,
+    // #7 — gate thẻ "Tổ hợp môn" (admin-only). Default false: base suite KHÔNG
+    // thấy tab; subject-group tests override true.
+    can_manage_subject_group_configs: false,
     validation_errors: [] as string[],
     round_quota: 50,
     admit_quota: 30,
@@ -70,7 +73,12 @@ const hoisted = vi.hoisted(() => {
 })
 
 vi.mock("@/hooks/admissions/useAdmissionPaths", () => ({
-  admissionPathKeys: { all: ["admission-paths"] },
+  // detail() added: SubjectGroupConfigTab → usePathSubjectGroupConfigs invalidates
+  // admissionPathKeys.detail(pathId); without it a tab-mounting test would crash.
+  admissionPathKeys: {
+    all: ["admission-paths"],
+    detail: (id: number) => ["admission-paths", "detail", id],
+  },
   useAdmissionPath: hoisted.mockUseAdmissionPath,
   useUpdateAdmissionPath: () => ({ mutateAsync: hoisted.mockUpdatePath, isPending: false }),
   useActivateAdmissionPath: () => ({ mutateAsync: hoisted.mockActivate, isPending: false }),
@@ -538,5 +546,37 @@ describe("PathDetailDrawer — thẻ Nâng cao (governance, gate theo can_edit_g
         bonus_rule_override: null,
       },
     })
+  })
+})
+
+describe("PathDetailDrawer — thẻ Tổ hợp môn (gate theo can_manage_subject_group_configs)", () => {
+  // Active tab mặc định = "quota" → SubjectGroupConfigTab KHÔNG mount (Radix chỉ
+  // render content của tab active) nên các test chỉ kiểm tra trigger + fallback,
+  // không cần mock hook usePathSubjectGroupConfigs / useSubjectGroups.
+  const mngOn = (extra: Record<string, unknown> = {}) => ({
+    data: { ...hoisted.defaultPath, can_manage_subject_group_configs: true, ...extra },
+    isLoading: false,
+  })
+
+  it("can_manage_subject_group_configs=true → THẤY tab Tổ hợp môn", () => {
+    hoisted.mockUseAdmissionPath.mockReturnValue(mngOn())
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+    expect(screen.getByRole("tab", { name: "Tổ hợp môn" })).toBeTruthy()
+  })
+
+  it("can_manage=false → KHÔNG thấy tab Tổ hợp môn (gate admin-only)", () => {
+    // defaultPath.can_manage_subject_group_configs = false (beforeEach reset).
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+    expect(screen.getByRole("tab", { name: /Chỉ tiêu/ })).toBeTruthy()
+    expect(screen.queryByRole("tab", { name: "Tổ hợp môn" })).toBeNull()
+  })
+
+  it("can_manage=false + dán ?tab=subject-groups → fallback quota", async () => {
+    searchParamsMock.mockReturnValue(new URLSearchParams("tab=subject-groups"))
+    render(wrap(<PathDetailDrawer pathId={109} onClose={() => {}} />))
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Lưu chỉ tiêu/ })).toBeTruthy()
+    })
+    expect(screen.queryByRole("tab", { name: "Tổ hợp môn" })).toBeNull()
   })
 })

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/PathDetailDrawer.tsx
@@ -69,6 +69,7 @@ import { canPerformAction, type AdmissionPathResponse } from "@/lib/zod/admissio
 import { ConfigCriteria } from "../ConfigCriteria"
 import { ConfigDocuments } from "../ConfigDocuments"
 import { AdvancedTab } from "./AdvancedTab"
+import { SubjectGroupConfigTab } from "./SubjectGroupConfigTab"
 import { pathStatusLabel } from "./labels"
 
 type PathLike = AdmissionPathResponse
@@ -82,6 +83,7 @@ const VALID_TABS = [
   "quota",
   "identity",
   "criteria",
+  "subject-groups",
   "documents",
   "advanced",
   "lifecycle",
@@ -96,6 +98,18 @@ export function PathDetailDrawer({ pathId, onClose }: Props) {
   // server-side (BusinessRuleViolation khi non-admin ghi governance); flag
   // này chỉ mirror cho UX. `path` async undefined → canGov=false an toàn.
   const canGov = path?.can_edit_governance ?? false
+  // Thẻ "Tổ hợp môn" gate theo flag admin-only `can_manage_subject_group_configs`
+  // (route require_admin + chặn archived). KHÔNG dùng can_edit (manager trên
+  // draft = true → thấy control rồi 403). `path` async undefined → false an toàn.
+  const canMng = path?.can_manage_subject_group_configs ?? false
+  // TabsList: 5 thẻ cố định + (advanced nếu canGov) + (subject-groups nếu canMng).
+  const tabCount = 5 + (canGov ? 1 : 0) + (canMng ? 1 : 0)
+  const gridColsClass =
+    tabCount >= 7
+      ? "sm:grid-cols-7"
+      : tabCount === 6
+        ? "sm:grid-cols-6"
+        : "sm:grid-cols-5"
 
   // Pass 2 hard-review FM-2: tab active sync với ?tab= URL param.
   // Reload page giữ tab user đang xem; share link mở thẳng tab cụ thể.
@@ -108,9 +122,11 @@ export function PathDetailDrawer({ pathId, onClose }: Props) {
     const valid = (VALID_TABS as readonly string[]).includes(raw ?? "")
       ? (raw as TabId)
       : "quota"
-    // Non-gov dán ?tab=advanced → fallback "quota" (tránh rơi vào thẻ ẩn).
-    return valid === "advanced" && !canGov ? "quota" : valid
-  }, [searchParams, canGov])
+    // Dán ?tab=<thẻ-ẩn> khi không có quyền → fallback "quota".
+    if (valid === "advanced" && !canGov) return "quota"
+    if (valid === "subject-groups" && !canMng) return "quota"
+    return valid
+  }, [searchParams, canGov, canMng])
   const setTab = useCallback(
     (next: string) => {
       // Idempotent guard: Radix Tabs + React 19 effects có thể fire
@@ -172,13 +188,14 @@ export function PathDetailDrawer({ pathId, onClose }: Props) {
             className="flex-1 flex flex-col min-h-0"
           >
             <TabsList
-              className={`flex w-full justify-start overflow-x-auto shrink-0 sm:grid sm:justify-center ${
-                canGov ? "sm:grid-cols-6" : "sm:grid-cols-5"
-              }`}
+              className={`flex w-full justify-start overflow-x-auto shrink-0 sm:grid sm:justify-center ${gridColsClass}`}
             >
               <TabsTrigger value="quota">Chỉ tiêu</TabsTrigger>
               <TabsTrigger value="identity">Định danh</TabsTrigger>
               <TabsTrigger value="criteria">Tiêu chí</TabsTrigger>
+              {canMng && (
+                <TabsTrigger value="subject-groups">Tổ hợp môn</TabsTrigger>
+              )}
               <TabsTrigger value="documents">Giấy tờ</TabsTrigger>
               {canGov && (
                 <TabsTrigger value="advanced">Nâng cao</TabsTrigger>
@@ -201,6 +218,15 @@ export function PathDetailDrawer({ pathId, onClose }: Props) {
                   embedded
                 />
               </TabsContent>
+              {canMng && (
+                <TabsContent value="subject-groups">
+                  <SubjectGroupConfigTab
+                    path={path}
+                    pathId={pathId}
+                    onClose={onClose}
+                  />
+                </TabsContent>
+              )}
               <TabsContent value="documents">
                 <ConfigDocuments
                   path={path}

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/SubjectGroupConfigTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/SubjectGroupConfigTab.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * SubjectGroupConfigTab — mount tab body + pin the live-config dialog fix (#1).
+ *
+ * The PathDetailDrawer suite only asserts the tab TRIGGER (active tab stays
+ * "quota" so the body never mounts). This file mounts the body and pins that
+ * the "Môn chính" dialog reads the LIVE config from the refetched list, not a
+ * frozen snapshot — the bug that would re-add (409) / re-delete (404).
+ */
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type {
+  PathSubjectGroupConfigAdmin,
+  PathSubjectGroupItemAdmin,
+} from "@/lib/api/admission-paths"
+import type { AdmissionPathResponse } from "@/lib/zod/admission-path"
+
+import { SubjectGroupConfigTab } from "./SubjectGroupConfigTab"
+
+// Mutable list the mocked query reads — lets a test simulate a refetch.
+let mockConfigs: PathSubjectGroupConfigAdmin[] = []
+const noopMut = {
+  mutateAsync: vi.fn().mockResolvedValue({}),
+  isPending: false,
+  variables: undefined,
+}
+
+vi.mock("@/hooks/admissions/usePathSubjectGroupConfigs", () => ({
+  usePathSubjectGroupConfigsAdmin: () => ({
+    data: { total: mockConfigs.length, items: mockConfigs },
+    isLoading: false,
+  }),
+  useCreatePathSubjectGroupConfig: () => noopMut,
+  useUpdatePathSubjectGroupConfig: () => noopMut,
+  useDeletePathSubjectGroupConfig: () => noopMut,
+  useAddPathSubjectGroupItem: () => noopMut,
+  useUpdatePathSubjectGroupItem: () => noopMut,
+  useDeletePathSubjectGroupItem: () => noopMut,
+}))
+vi.mock("@/hooks/admissions/useMasterData", () => ({
+  useSubjectGroups: () => ({ data: [] }),
+}))
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+const SUBJECT = {
+  subject_id: 1,
+  subject_code: "TOAN",
+  subject_name: "Toán",
+  subject_group_subject_id: 11,
+  max_score: 10,
+  min_possible_score: 0,
+  position: 1,
+}
+
+function makeConfig(
+  items: PathSubjectGroupItemAdmin[],
+): PathSubjectGroupConfigAdmin {
+  return {
+    id: 5,
+    admission_path_id: 99,
+    subject_group_id: 7,
+    subject_group_code: "A00",
+    subject_group_name: "Toán - Lý - Hóa",
+    min_score: 5,
+    min_subject_score: null,
+    group_quota: null,
+    items,
+    subjects: [SUBJECT],
+  }
+}
+
+const PATH = {
+  id: 99,
+  can_manage_subject_group_configs: true,
+  criteria: null,
+} as unknown as AdmissionPathResponse
+
+const ariaChecked = (el: HTMLElement) => el.getAttribute("aria-checked")
+
+describe("SubjectGroupConfigTab", () => {
+  beforeEach(() => {
+    mockConfigs = [makeConfig([])]
+  })
+
+  it("can_manage=true → render bảng tổ hợp (tab body mount)", () => {
+    render(<SubjectGroupConfigTab path={PATH} pathId={99} onClose={() => {}} />)
+    expect(screen.getByText("A00")).toBeTruthy()
+  })
+
+  it("#1: dialog Môn chính đọc config LIVE — refetch thêm item → checkbox tick (không snapshot)", () => {
+    const { rerender } = render(
+      <SubjectGroupConfigTab path={PATH} pathId={99} onClose={() => {}} />,
+    )
+    // Mở dialog Môn chính.
+    fireEvent.click(screen.getByRole("button", { name: "Môn chính" }))
+    const cb = screen.getByRole("checkbox", { name: "Môn chính TOAN" })
+    expect(ariaChecked(cb)).toBe("false") // chưa có item → unchecked
+
+    // Mô phỏng refetch sau addItem: item giờ is_principal=true.
+    mockConfigs = [
+      makeConfig([
+        {
+          id: 1,
+          path_subject_group_config_id: 5,
+          subject_group_subject_id: 11,
+          is_principal: true,
+          min_subject_score: null,
+        },
+      ]),
+    ]
+    rerender(
+      <SubjectGroupConfigTab path={PATH} pathId={99} onClose={() => {}} />,
+    )
+    // Dialog vẫn mở (state giữ), derive từ config LIVE → checkbox CHECKED.
+    expect(
+      ariaChecked(screen.getByRole("checkbox", { name: "Môn chính TOAN" })),
+    ).toBe("true")
+  })
+})

--- a/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/SubjectGroupConfigTab.tsx
+++ b/frontend/src/app/(dashboard)/admin/admission-config/_components/Phase3Config/QuotaMatrix/SubjectGroupConfigTab.tsx
@@ -1,0 +1,701 @@
+/**
+ * SubjectGroupConfigTab — admin quản lý path_subject_group_config (#7).
+ *
+ * Tab "Tổ hợp môn" cho hồ sơ multi-NV: thêm/sửa/xóa tổ hợp (điểm sàn, quota
+ * Tier 3, môn chính) + gợi ý đồng bộ từ tiêu chí (drift hint). Độc lập với
+ * criteria_subject_group — KHÔNG auto-sync, chỉ gợi ý.
+ *
+ * Thin-client: hiển thị + bật control theo path.can_manage_subject_group_configs
+ * (admin-only + not-archived, server enforce). KHÔNG check role.
+ */
+"use client"
+
+import { Check, ChevronsUpDown, Loader2, Plus, Star, Trash2 } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  useAddPathSubjectGroupItem,
+  useCreatePathSubjectGroupConfig,
+  useDeletePathSubjectGroupConfig,
+  useDeletePathSubjectGroupItem,
+  usePathSubjectGroupConfigsAdmin,
+  useUpdatePathSubjectGroupConfig,
+  useUpdatePathSubjectGroupItem,
+} from "@/hooks/admissions/usePathSubjectGroupConfigs"
+import { useSubjectGroups } from "@/hooks/admissions/useMasterData"
+import type { PathSubjectGroupConfigAdmin } from "@/lib/api/admission-paths"
+import { parseApiError } from "@/lib/utils/api-errors"
+import { cn } from "@/lib/utils"
+import { foldVietnamese } from "@/lib/utils/vietnamese"
+import type { AdmissionPathResponse } from "@/lib/zod/admission-path"
+
+/**
+ * Parse a numeric input. "" → null (clear). Returns ``undefined`` for anything
+ * invalid (NaN / Infinity / negative / non-integer when required) so the caller
+ * BLOCKS instead of POSTing junk — Number() otherwise accepts "1e2"→100,
+ * "0x10"→16, "-5", "3.7", and "Infinity"→null (silently read as "clear").
+ */
+function numOrNull(
+  s: string,
+  opts?: { integer?: boolean },
+): number | null | undefined {
+  const t = s.trim()
+  if (t === "") return null
+  const n = Number(t)
+  if (!Number.isFinite(n) || n < 0) return undefined
+  if (opts?.integer && !Number.isInteger(n)) return undefined
+  return n
+}
+
+export function SubjectGroupConfigTab({
+  path,
+  pathId,
+  onClose,
+}: {
+  path: AdmissionPathResponse
+  pathId: number
+  onClose: () => void
+}) {
+  const canManage = path.can_manage_subject_group_configs ?? false
+  const { data, isLoading } = usePathSubjectGroupConfigsAdmin(pathId, canManage)
+  const configs = data?.items ?? []
+  const { data: allGroups } = useSubjectGroups()
+
+  const createMut = useCreatePathSubjectGroupConfig()
+  const updateMut = useUpdatePathSubjectGroupConfig()
+  const deleteMut = useDeletePathSubjectGroupConfig()
+
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [newGroupId, setNewGroupId] = useState<number | null>(null)
+  const [newMinScore, setNewMinScore] = useState("")
+  const [newGroupQuota, setNewGroupQuota] = useState("")
+
+  // #1: store only the configId; derive the LIVE config from the (refetched)
+  // list so the dialog reflects item add/remove instead of a frozen snapshot.
+  const [principalCfgId, setPrincipalCfgId] = useState<number | null>(null)
+  const [confirmDelete, setConfirmDelete] =
+    useState<PathSubjectGroupConfigAdmin | null>(null)
+  // Per-chip pending: a local Set (NOT createMut.variables, which only holds
+  // the last call) so concurrent drift-chip creates each track independently —
+  // a double-click on one chip can't re-POST (→ 409) while others stay usable.
+  const [creatingIds, setCreatingIds] = useState<ReadonlySet<number>>(
+    new Set<number>(),
+  )
+
+  const configuredIds = new Set(configs.map((c) => c.subject_group_id))
+  const groups = (allGroups ?? []) as { id: number; code: string; name: string }[]
+  const available = groups.filter((g) => !configuredIds.has(g.id))
+  // Drift: tổ hợp có trong tiêu chí nhưng chưa có config (criteria nullable).
+  const missing = (path.criteria?.subject_groups ?? []).filter(
+    (g) => !configuredIds.has(g.id),
+  )
+  const liveCfg = configs.find((c) => c.id === principalCfgId) ?? null
+
+  const newGroupLabel = (() => {
+    const g = groups.find((x) => x.id === newGroupId)
+    return g ? `${g.code} — ${g.name}` : "Chọn tổ hợp môn…"
+  })()
+
+  const doCreate = async (
+    subjectGroupId: number,
+    minScore: number | null,
+    groupQuota: number | null,
+  ) => {
+    setCreatingIds((s) => new Set(s).add(subjectGroupId))
+    try {
+      await createMut.mutateAsync({
+        pathId,
+        data: {
+          subject_group_id: subjectGroupId,
+          min_score: minScore,
+          group_quota: groupQuota,
+        },
+      })
+      toast.success("Đã thêm tổ hợp môn")
+      setNewGroupId(null)
+      setNewMinScore("")
+      setNewGroupQuota("")
+    } catch (e: unknown) {
+      toast.error(parseApiError(e, "Lỗi thêm tổ hợp — thử lại."))
+    } finally {
+      setCreatingIds((s) => {
+        const n = new Set(s)
+        n.delete(subjectGroupId)
+        return n
+      })
+    }
+  }
+
+  const handleAddClick = () => {
+    if (newGroupId == null) return
+    const ms = numOrNull(newMinScore)
+    const gq = numOrNull(newGroupQuota, { integer: true })
+    if (ms === undefined || gq === undefined) {
+      toast.error("Điểm sàn (≥0) / quota (số nguyên ≥0) không hợp lệ.")
+      return
+    }
+    void doCreate(newGroupId, ms, gq)
+  }
+
+  const handleDelete = async (cfg: PathSubjectGroupConfigAdmin) => {
+    try {
+      await deleteMut.mutateAsync({ pathId, configId: cfg.id })
+      toast.success("Đã xóa tổ hợp môn")
+      setConfirmDelete(null)
+    } catch (e: unknown) {
+      // 409 (đang dùng) / 400 (Tier 3) → message thân thiện từ BE.
+      toast.error(parseApiError(e, "Không xóa được tổ hợp."))
+    }
+  }
+
+  if (!canManage) {
+    return (
+      <p className="text-sm text-muted-foreground py-4">
+        Chỉ admin mới quản lý được tổ hợp môn cho phương thức này (phương thức
+        đã lưu trữ cũng không sửa được).
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      <p className="text-xs text-muted-foreground">
+        Tổ hợp môn cho hồ sơ đa nguyện vọng (multi-NV). Độc lập với &quot;Tiêu
+        chí&quot; — sửa ở đây KHÔNG đổi tiêu chí và ngược lại.
+      </p>
+
+      {/* Drift hint: criteria có nhưng config thiếu */}
+      {missing.length > 0 && (
+        <div className="rounded-md border border-amber-500/50 bg-amber-500/5 p-3 text-xs space-y-2">
+          <div className="font-medium text-amber-900 dark:text-amber-200">
+            {missing.length} tổ hợp có trong tiêu chí nhưng chưa có ở đây
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {missing.map((g) => (
+              <Button
+                key={g.id}
+                size="sm"
+                variant="outline"
+                className="h-7"
+                disabled={creatingIds.has(g.id)}
+                onClick={() => void doCreate(g.id, null, null)}
+              >
+                {creatingIds.has(g.id) ? (
+                  <Loader2 className="h-3 w-3 mr-1 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Plus className="h-3 w-3 mr-1" aria-hidden="true" />
+                )}
+                {g.code}
+              </Button>
+            ))}
+          </div>
+          <p className="text-muted-foreground">
+            &quot;Thêm nhanh&quot; tạo tổ hợp với điểm sàn/quota để trống —
+            chỉnh sau ở bảng dưới.
+          </p>
+        </div>
+      )}
+
+      {/* Bảng tổ hợp hiện có */}
+      {isLoading ? (
+        <div className="flex items-center gap-2 py-6 text-muted-foreground" aria-live="polite">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          <span className="text-sm">Đang tải tổ hợp môn…</span>
+        </div>
+      ) : configs.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-2">
+          Chưa có tổ hợp môn nào. Thêm bên dưới.
+        </p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Tổ hợp</TableHead>
+              <TableHead>Môn</TableHead>
+              <TableHead className="w-24 text-right">Điểm sàn</TableHead>
+              <TableHead className="w-24 text-right">Quota</TableHead>
+              <TableHead className="w-28" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {configs.map((c) => (
+              <ConfigRow
+                // #5: re-key on server values so a successful save / another
+                // admin's edit remounts the row with fresh inputs (no stale
+                // value, no phantom "Lưu").
+                key={`${c.id}:${c.min_score ?? ""}:${c.group_quota ?? ""}`}
+                config={c}
+                pathId={pathId}
+                updateMut={updateMut}
+                onPrincipal={() => setPrincipalCfgId(c.id)}
+                onDelete={() => setConfirmDelete(c)}
+              />
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {/* Thêm tổ hợp */}
+      <div className="rounded-md border p-3 space-y-3">
+        <Label className="text-xs text-muted-foreground">Thêm tổ hợp môn</Label>
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="flex-1 min-w-[200px] space-y-1">
+            <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  role="combobox"
+                  aria-expanded={pickerOpen}
+                  className="w-full justify-between font-normal"
+                >
+                  <span className="truncate">{newGroupLabel}</span>
+                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="w-[var(--radix-popover-trigger-width)] p-0"
+                align="start"
+              >
+                <Command
+                  filter={(value, search) =>
+                    foldVietnamese(value).includes(foldVietnamese(search)) ? 1 : 0
+                  }
+                >
+                  <CommandInput placeholder="Gõ mã/tên tổ hợp…" />
+                  <CommandList>
+                    <CommandEmpty>Không còn tổ hợp để thêm.</CommandEmpty>
+                    {available.map((g) => (
+                      <CommandItem
+                        key={g.id}
+                        value={`${g.code} ${g.name} ${g.id}`}
+                        onSelect={() => {
+                          setNewGroupId(g.id)
+                          setPickerOpen(false)
+                        }}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4 shrink-0",
+                            newGroupId === g.id ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                        <span className="flex-1 truncate">{g.name}</span>
+                        <span className="ml-2 shrink-0 text-[11px] text-muted-foreground" translate="no">
+                          {g.code}
+                        </span>
+                      </CommandItem>
+                    ))}
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+          </div>
+          <div className="space-y-1 w-24">
+            <Label htmlFor="new-min-score" className="text-[11px]">Điểm sàn</Label>
+            <Input
+              id="new-min-score"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              value={newMinScore}
+              onChange={(e) => setNewMinScore(e.target.value)}
+              placeholder="—"
+              autoComplete="off"
+            />
+          </div>
+          <div className="space-y-1 w-24">
+            <Label htmlFor="new-group-quota" className="text-[11px]">Quota</Label>
+            <Input
+              id="new-group-quota"
+              type="number"
+              inputMode="numeric"
+              min="0"
+              step="1"
+              value={newGroupQuota}
+              onChange={(e) => setNewGroupQuota(e.target.value)}
+              placeholder="—"
+              autoComplete="off"
+            />
+          </div>
+          <Button
+            onClick={handleAddClick}
+            disabled={newGroupId == null || createMut.isPending}
+            aria-busy={createMut.isPending}
+          >
+            {createMut.isPending ? (
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+            ) : (
+              <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
+            )}
+            Thêm
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex justify-end border-t pt-3">
+        <Button variant="outline" onClick={onClose}>Đóng</Button>
+      </div>
+
+      {liveCfg && (
+        <PrincipalItemsDialog
+          config={liveCfg}
+          pathId={pathId}
+          onOpenChange={(o) => { if (!o) setPrincipalCfgId(null) }}
+        />
+      )}
+
+      <Dialog
+        open={confirmDelete != null}
+        onOpenChange={(o) => { if (!o) setConfirmDelete(null) }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Xóa tổ hợp môn?</DialogTitle>
+            <DialogDescription>
+              Xóa tổ hợp{" "}
+              <span className="font-medium" translate="no">
+                {confirmDelete?.subject_group_code}
+              </span>{" "}
+              khỏi phương thức này. Không xóa được nếu đang có nguyện vọng dùng.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDelete(null)}>
+              Huỷ
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => confirmDelete && void handleDelete(confirmDelete)}
+              disabled={deleteMut.isPending}
+              aria-busy={deleteMut.isPending}
+            >
+              {deleteMut.isPending ? (
+                <Loader2 className="h-4 w-4 mr-1 animate-spin" aria-hidden="true" />
+              ) : (
+                <Trash2 className="h-4 w-4 mr-1" aria-hidden="true" />
+              )}
+              Xóa
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+// ============================================================================
+// Row: 1 config — inline edit điểm sàn/quota + nút Môn chính / Xóa
+// ============================================================================
+
+function ConfigRow({
+  config,
+  pathId,
+  updateMut,
+  onPrincipal,
+  onDelete,
+}: {
+  config: PathSubjectGroupConfigAdmin
+  pathId: number
+  updateMut: ReturnType<typeof useUpdatePathSubjectGroupConfig>
+  onPrincipal: () => void
+  onDelete: () => void
+}) {
+  // Init từ server value lúc mount. Parent re-key theo server value nên sau khi
+  // lưu / refetch row remount với giá trị mới (không stale).
+  const [minScore, setMinScore] = useState(config.min_score?.toString() ?? "")
+  const [quota, setQuota] = useState(config.group_quota?.toString() ?? "")
+  const principalCount = config.items.filter((it) => it.is_principal).length
+  const parsedMin = numOrNull(minScore)
+  const parsedQuota = numOrNull(quota, { integer: true })
+  // #5: dirty so sánh theo SỐ (đã chuẩn hóa) — "5.0" vs 5 KHÔNG còn là dirty;
+  // giá trị không hợp lệ coi như dirty để hiện nút Lưu (save sẽ chặn + toast).
+  const dirty =
+    parsedMin === undefined ||
+    parsedQuota === undefined ||
+    parsedMin !== (config.min_score ?? null) ||
+    parsedQuota !== (config.group_quota ?? null)
+
+  const save = async () => {
+    if (parsedMin === undefined || parsedQuota === undefined) {
+      toast.error("Điểm sàn (≥0) / quota (số nguyên ≥0) không hợp lệ.")
+      return
+    }
+    try {
+      await updateMut.mutateAsync({
+        pathId,
+        configId: config.id,
+        data: { min_score: parsedMin, group_quota: parsedQuota },
+      })
+      toast.success("Đã lưu tổ hợp")
+    } catch (e: unknown) {
+      toast.error(parseApiError(e, "Lỗi lưu tổ hợp."))
+    }
+  }
+
+  return (
+    <TableRow>
+      <TableCell>
+        <div className="font-medium" translate="no">{config.subject_group_code}</div>
+        <div className="text-[11px] text-muted-foreground">
+          {config.subject_group_name}
+        </div>
+      </TableCell>
+      <TableCell className="text-xs text-muted-foreground">
+        <div className="flex flex-wrap gap-1">
+          {config.subjects.map((s) => {
+            const item = config.items.find(
+              (it) => it.subject_group_subject_id === s.subject_group_subject_id,
+            )
+            return (
+              <Badge
+                key={s.subject_group_subject_id}
+                variant={item?.is_principal ? "default" : "outline"}
+                className="text-[10px] h-4 px-1 gap-0.5"
+                translate="no"
+              >
+                {item?.is_principal && <Star className="h-2.5 w-2.5" aria-hidden="true" />}
+                {s.subject_code}
+              </Badge>
+            )
+          })}
+        </div>
+        {principalCount > 0 && (
+          <span className="text-[10px]">({principalCount} môn chính)</span>
+        )}
+      </TableCell>
+      <TableCell className="text-right">
+        <Input
+          type="number"
+          inputMode="decimal"
+          min="0"
+          value={minScore}
+          onChange={(e) => setMinScore(e.target.value)}
+          className="h-8 text-right"
+          placeholder="—"
+          aria-label={`Điểm sàn ${config.subject_group_code}`}
+        />
+      </TableCell>
+      <TableCell className="text-right">
+        <Input
+          type="number"
+          inputMode="numeric"
+          min="0"
+          step="1"
+          value={quota}
+          onChange={(e) => setQuota(e.target.value)}
+          className="h-8 text-right"
+          placeholder="—"
+          aria-label={`Quota ${config.subject_group_code}`}
+        />
+      </TableCell>
+      <TableCell>
+        <div className="flex items-center justify-end gap-1">
+          {dirty && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 px-2"
+              onClick={() => void save()}
+              disabled={updateMut.isPending}
+            >
+              Lưu
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 px-2"
+            onClick={onPrincipal}
+            title="Môn chính"
+          >
+            <Star className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="sr-only">Môn chính</span>
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 px-2 text-destructive"
+            onClick={onDelete}
+            title="Xóa tổ hợp"
+          >
+            <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="sr-only">Xóa</span>
+          </Button>
+        </div>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+// ============================================================================
+// Dialog: Môn chính per config — toggle is_principal (tạo/xóa item)
+// ============================================================================
+
+function PrincipalItemsDialog({
+  config,
+  pathId,
+  onOpenChange,
+}: {
+  config: PathSubjectGroupConfigAdmin
+  pathId: number
+  onOpenChange: (open: boolean) => void
+}) {
+  const addItem = useAddPathSubjectGroupItem()
+  const updateItem = useUpdatePathSubjectGroupItem()
+  const deleteItem = useDeletePathSubjectGroupItem()
+  // #3/#2: pending theo TỪNG môn — Set (không phải 1-slot) để thao tác môn A
+  // rồi B khi A chưa xong KHÔNG tắt sớm spinner A / mở lại A.
+  const [pendingSgs, setPendingSgs] = useState<ReadonlySet<number>>(
+    new Set<number>(),
+  )
+
+  const itemFor = (sgsId: number) =>
+    config.items.find((it) => it.subject_group_subject_id === sgsId)
+
+  const run = async (sgsId: number, fn: () => Promise<unknown>) => {
+    setPendingSgs((s) => new Set(s).add(sgsId))
+    try {
+      await fn()
+    } catch (e: unknown) {
+      toast.error(parseApiError(e, "Lỗi cập nhật môn chính."))
+    } finally {
+      setPendingSgs((s) => {
+        const n = new Set(s)
+        n.delete(sgsId)
+        return n
+      })
+    }
+  }
+
+  const togglePrincipal = (sgsId: number, checked: boolean) => {
+    const item = itemFor(sgsId)
+    void run(sgsId, () =>
+      !item
+        ? addItem.mutateAsync({
+            pathId,
+            configId: config.id,
+            data: { subject_group_subject_id: sgsId, is_principal: checked },
+          })
+        : updateItem.mutateAsync({
+            pathId,
+            configId: config.id,
+            itemId: item.id,
+            data: { is_principal: checked },
+          }),
+    )
+  }
+
+  const removeItem = (sgsId: number) => {
+    const item = itemFor(sgsId)
+    if (!item) return
+    void run(sgsId, () =>
+      deleteItem.mutateAsync({ pathId, configId: config.id, itemId: item.id }),
+    )
+  }
+
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            Môn chính —{" "}
+            <span translate="no">{config.subject_group_code}</span>
+          </DialogTitle>
+          <DialogDescription>
+            Đánh dấu môn chính của tổ hợp. Lưu sẵn cấu hình —{" "}
+            <span className="font-medium">chưa ảnh hưởng chấm điểm</span> (engine
+            hiện dùng trọng số tổ hợp + điểm sàn tiêu chí); sẽ dùng ở bước sau.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2 max-h-[50vh] overflow-y-auto">
+          {config.subjects.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              Tổ hợp chưa khai báo môn (cấu hình ở master tổ hợp môn).
+            </p>
+          )}
+          {config.subjects.map((s) => {
+            const item = itemFor(s.subject_group_subject_id)
+            const rowPending = pendingSgs.has(s.subject_group_subject_id)
+            return (
+              <div
+                key={s.subject_group_subject_id}
+                className="flex items-center gap-2 rounded-md border p-2"
+              >
+                <Checkbox
+                  checked={item?.is_principal ?? false}
+                  disabled={rowPending}
+                  onCheckedChange={(v) =>
+                    togglePrincipal(s.subject_group_subject_id, v === true)
+                  }
+                  aria-label={`Môn chính ${s.subject_code}`}
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium truncate" translate="no">
+                    {s.subject_code}
+                  </div>
+                  <div className="text-[11px] text-muted-foreground truncate">
+                    {s.subject_name}
+                  </div>
+                </div>
+                {rowPending && (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" aria-hidden="true" />
+                )}
+                {item && !rowPending && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 px-2 text-destructive"
+                    onClick={() => removeItem(s.subject_group_subject_id)}
+                    title="Gỡ cấu hình môn"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                    <span className="sr-only">Gỡ</span>
+                  </Button>
+                )}
+              </div>
+            )
+          })}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Đóng
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
+++ b/frontend/src/hooks/admissions/useAdmissionPaths.test.tsx
@@ -88,6 +88,7 @@ const mockAdmissionPathResponse = {
   admit_quota: null,
   submission_count: 0,
   application_fee: null,
+  can_manage_subject_group_configs: false,
 } satisfies AdmissionPathResponse;
 
 /** The shape that PUT /paths/:id/documents returns. */

--- a/frontend/src/hooks/admissions/usePathSubjectGroupConfigs.test.tsx
+++ b/frontend/src/hooks/admissions/usePathSubjectGroupConfigs.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * usePathSubjectGroupConfigs — invalidation contract (#7).
+ *
+ * Every mutation (config + item CRUD) must invalidate the FULL set so the
+ * multi-NV dropdown (["path-sg-configs", pathId], AddChoiceDialog), the admin
+ * list, the path detail, .all, and ["quota-matrix"] all refetch. The first two
+ * + quota-matrix are raw literals NOT under admissionPathKeys.all, so they're
+ * easy to drop — pin all six hooks here.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  useAddPathSubjectGroupItem,
+  useCreatePathSubjectGroupConfig,
+  useDeletePathSubjectGroupConfig,
+  useDeletePathSubjectGroupItem,
+  useUpdatePathSubjectGroupConfig,
+  useUpdatePathSubjectGroupItem,
+} from "./usePathSubjectGroupConfigs"
+
+vi.mock("@/lib/api/admission-paths", () => ({
+  createPathSubjectGroupConfig: vi.fn().mockResolvedValue({ id: 1 }),
+  updatePathSubjectGroupConfig: vi.fn().mockResolvedValue({ id: 1 }),
+  deletePathSubjectGroupConfig: vi.fn().mockResolvedValue(undefined),
+  addPathSubjectGroupItem: vi.fn().mockResolvedValue({ id: 9 }),
+  updatePathSubjectGroupItem: vi.fn().mockResolvedValue({ id: 9 }),
+  deletePathSubjectGroupItem: vi.fn().mockResolvedValue(undefined),
+  getPathSubjectGroupConfigsAdmin: vi.fn(),
+}))
+
+function makeHarness() {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  const spy = vi.spyOn(qc, "invalidateQueries")
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  )
+  return { spy, wrapper }
+}
+
+const PATH = 42
+
+// The full invalidation set every mutation must emit.
+const FULL_SET = [
+  ["path-sg-configs-admin", PATH],
+  ["path-sg-configs", PATH], // AddChoiceDialog officer GET (raw literal)
+  ["admission-paths", "detail", PATH],
+  ["admission-paths"],
+  ["quota-matrix"], // raw literal, not under .all
+].map((k) => JSON.stringify(k))
+
+function assertFullSet(spy: ReturnType<typeof vi.spyOn>) {
+  const got = spy.mock.calls.map((c: unknown[]) =>
+    JSON.stringify((c[0] as { queryKey: unknown }).queryKey),
+  )
+  for (const key of FULL_SET) expect(got).toContain(key)
+}
+
+describe("usePathSubjectGroupConfigs — every mutation invalidates the full set", () => {
+  it("create config", async () => {
+    const { spy, wrapper } = makeHarness()
+    const { result } = renderHook(() => useCreatePathSubjectGroupConfig(), { wrapper })
+    await result.current.mutateAsync({ pathId: PATH, data: { subject_group_id: 7 } })
+    assertFullSet(spy)
+  })
+
+  it("update config", async () => {
+    const { spy, wrapper } = makeHarness()
+    const { result } = renderHook(() => useUpdatePathSubjectGroupConfig(), { wrapper })
+    await result.current.mutateAsync({ pathId: PATH, configId: 5, data: { min_score: 5 } })
+    assertFullSet(spy)
+  })
+
+  it("delete config", async () => {
+    const { spy, wrapper } = makeHarness()
+    const { result } = renderHook(() => useDeletePathSubjectGroupConfig(), { wrapper })
+    await result.current.mutateAsync({ pathId: PATH, configId: 5 })
+    assertFullSet(spy)
+  })
+
+  it("add item", async () => {
+    const { spy, wrapper } = makeHarness()
+    const { result } = renderHook(() => useAddPathSubjectGroupItem(), { wrapper })
+    await result.current.mutateAsync({
+      pathId: PATH,
+      configId: 5,
+      data: { subject_group_subject_id: 11 },
+    })
+    assertFullSet(spy)
+  })
+
+  it("update item", async () => {
+    const { spy, wrapper } = makeHarness()
+    const { result } = renderHook(() => useUpdatePathSubjectGroupItem(), { wrapper })
+    await result.current.mutateAsync({
+      pathId: PATH,
+      configId: 5,
+      itemId: 9,
+      data: { is_principal: true },
+    })
+    assertFullSet(spy)
+  })
+
+  it("delete item", async () => {
+    const { spy, wrapper } = makeHarness()
+    const { result } = renderHook(() => useDeletePathSubjectGroupItem(), { wrapper })
+    await result.current.mutateAsync({ pathId: PATH, configId: 5, itemId: 9 })
+    assertFullSet(spy)
+  })
+})

--- a/frontend/src/hooks/admissions/usePathSubjectGroupConfigs.ts
+++ b/frontend/src/hooks/admissions/usePathSubjectGroupConfigs.ts
@@ -1,0 +1,141 @@
+/**
+ * usePathSubjectGroupConfigs Hook (#7 — admin "Tổ hợp môn" tab)
+ *
+ * React Query hooks for admin CRUD of path_subject_group_config + items.
+ * Mirrors useAdmissionPaths mutation/invalidation patterns.
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import type { QueryClient } from "@tanstack/react-query"
+
+import {
+  getPathSubjectGroupConfigsAdmin,
+  createPathSubjectGroupConfig,
+  updatePathSubjectGroupConfig,
+  deletePathSubjectGroupConfig,
+  addPathSubjectGroupItem,
+  updatePathSubjectGroupItem,
+  deletePathSubjectGroupItem,
+} from "@/lib/api/admission-paths"
+import type {
+  PathSubjectGroupConfigCreatePayload,
+  PathSubjectGroupConfigUpdatePayload,
+  PathSubjectGroupItemPayload,
+  PathSubjectGroupItemUpdatePayload,
+} from "@/lib/api/admission-paths"
+import { admissionPathKeys } from "./useAdmissionPaths"
+
+// ============================================
+// QUERY KEYS
+// ============================================
+
+export const pathSgConfigKeys = {
+  all: ["path-sg-configs-admin"] as const,
+  list: (pathId: number) => ["path-sg-configs-admin", pathId] as const,
+}
+
+/**
+ * Invalidate every cache a config/item mutation can affect.
+ *
+ * NB: ``["path-sg-configs", pathId]`` (the AddChoiceDialog officer GET) is a
+ * raw literal NOT under ``admissionPathKeys.all``, so it must be invalidated
+ * explicitly — otherwise the multi-NV "Thêm nguyện vọng" dropdown stays stale
+ * after the admin adds/edits a combination. Same for ``["quota-matrix"]``.
+ */
+function invalidatePathSgConfigs(qc: QueryClient, pathId: number) {
+  // Return the combined promise so the mutation's onSuccess AWAITS the refetch
+  // — mutateAsync (and isPending) stay active until the list is fresh, closing
+  // the window where the UI unlocks on a stale config → re-action 409/404.
+  return Promise.all([
+    qc.invalidateQueries({ queryKey: pathSgConfigKeys.list(pathId) }),
+    qc.invalidateQueries({ queryKey: ["path-sg-configs", pathId] }),
+    qc.invalidateQueries({ queryKey: admissionPathKeys.detail(pathId) }),
+    qc.invalidateQueries({ queryKey: admissionPathKeys.all }),
+    qc.invalidateQueries({ queryKey: ["quota-matrix"] }),
+  ])
+}
+
+// ============================================
+// READ
+// ============================================
+
+export function usePathSubjectGroupConfigsAdmin(
+  pathId: number | undefined,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: pathSgConfigKeys.list(pathId ?? 0),
+    queryFn: () => getPathSubjectGroupConfigsAdmin(pathId as number),
+    enabled: enabled && pathId != null,
+  })
+}
+
+// ============================================
+// MUTATIONS (config CRUD + item CRUD)
+// ============================================
+
+export function useCreatePathSubjectGroupConfig() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: {
+      pathId: number
+      data: PathSubjectGroupConfigCreatePayload
+    }) => createPathSubjectGroupConfig(vars.pathId, vars.data),
+    onSuccess: (_r, vars) => invalidatePathSgConfigs(qc, vars.pathId),
+  })
+}
+
+export function useUpdatePathSubjectGroupConfig() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: {
+      pathId: number
+      configId: number
+      data: PathSubjectGroupConfigUpdatePayload
+    }) => updatePathSubjectGroupConfig(vars.configId, vars.data),
+    onSuccess: (_r, vars) => invalidatePathSgConfigs(qc, vars.pathId),
+  })
+}
+
+export function useDeletePathSubjectGroupConfig() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: { pathId: number; configId: number }) =>
+      deletePathSubjectGroupConfig(vars.configId),
+    onSuccess: (_r, vars) => invalidatePathSgConfigs(qc, vars.pathId),
+  })
+}
+
+export function useAddPathSubjectGroupItem() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: {
+      pathId: number
+      configId: number
+      data: PathSubjectGroupItemPayload
+    }) => addPathSubjectGroupItem(vars.configId, vars.data),
+    onSuccess: (_r, vars) => invalidatePathSgConfigs(qc, vars.pathId),
+  })
+}
+
+export function useUpdatePathSubjectGroupItem() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: {
+      pathId: number
+      configId: number
+      itemId: number
+      data: PathSubjectGroupItemUpdatePayload
+    }) => updatePathSubjectGroupItem(vars.configId, vars.itemId, vars.data),
+    onSuccess: (_r, vars) => invalidatePathSgConfigs(qc, vars.pathId),
+  })
+}
+
+export function useDeletePathSubjectGroupItem() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (vars: { pathId: number; configId: number; itemId: number }) =>
+      deletePathSubjectGroupItem(vars.configId, vars.itemId),
+    onSuccess: (_r, vars) => invalidatePathSgConfigs(qc, vars.pathId),
+  })
+}

--- a/frontend/src/lib/api/admission-paths.ts
+++ b/frontend/src/lib/api/admission-paths.ts
@@ -248,6 +248,156 @@ export async function getPathSubjectGroupConfigs(
 }
 
 // ============================================
+// ADMIN — PATH SUBJECT GROUP CONFIG CRUD (#7 "Tổ hợp môn" tab)
+// ============================================
+// Separate types from PathSubjectGroupConfigForChoice (officer GET) — that
+// shape feeds AddChoiceDialog and must stay untouched. Scores arrive as JSON
+// number (BE serializes Decimal→float; see admin GET).
+
+const ADMIN_SG_BASE = '/api/v2/admin'
+
+/** Item of an admin sg_config (principal + per-item min score). */
+export interface PathSubjectGroupItemAdmin {
+  id: number
+  path_subject_group_config_id: number
+  subject_group_subject_id: number
+  is_principal: boolean
+  min_subject_score: number | null
+}
+
+/** Subject of the config's subject_group (for the principal-item picker). */
+export interface PathSubjectGroupConfigSubjectAdmin {
+  subject_id: number
+  subject_code: string
+  subject_name: string
+  subject_group_subject_id: number
+  max_score: number
+  min_possible_score: number
+  position: number
+}
+
+/** Enriched admin config: subject_group label + items + subjects. */
+export interface PathSubjectGroupConfigAdmin {
+  id: number
+  admission_path_id: number
+  subject_group_id: number
+  subject_group_code: string | null
+  subject_group_name: string | null
+  min_score: number | null
+  min_subject_score: number | null
+  group_quota: number | null
+  items: PathSubjectGroupItemAdmin[]
+  subjects: PathSubjectGroupConfigSubjectAdmin[]
+}
+
+/** Base config returned by POST/PATCH (no enrichment — FE refetches list). */
+export interface PathSubjectGroupConfigBaseResponse {
+  id: number
+  admission_path_id: number
+  subject_group_id: number
+  min_score: number | null
+  min_subject_score: number | null
+  group_quota: number | null
+  items: PathSubjectGroupItemAdmin[]
+}
+
+export interface PathSubjectGroupItemPayload {
+  subject_group_subject_id: number
+  is_principal?: boolean
+  min_subject_score?: number | null
+}
+
+export interface PathSubjectGroupConfigCreatePayload {
+  subject_group_id: number
+  min_score?: number | null
+  min_subject_score?: number | null
+  group_quota?: number | null
+  items?: PathSubjectGroupItemPayload[]
+}
+
+export interface PathSubjectGroupConfigUpdatePayload {
+  min_score?: number | null
+  min_subject_score?: number | null
+  group_quota?: number | null
+}
+
+/** Item PATCH — omit a field to leave unchanged; do NOT send is_principal:null. */
+export interface PathSubjectGroupItemUpdatePayload {
+  is_principal?: boolean
+  min_subject_score?: number | null
+}
+
+export async function getPathSubjectGroupConfigsAdmin(
+  pathId: number,
+): Promise<{ total: number; items: PathSubjectGroupConfigAdmin[] }> {
+  const response = await api.get<{
+    total: number
+    items: PathSubjectGroupConfigAdmin[]
+  }>(`${ADMIN_SG_BASE}/admission-paths/${pathId}/subject-group-configs`)
+  return response.data
+}
+
+export async function createPathSubjectGroupConfig(
+  pathId: number,
+  data: PathSubjectGroupConfigCreatePayload,
+): Promise<PathSubjectGroupConfigBaseResponse> {
+  const response = await api.post<PathSubjectGroupConfigBaseResponse>(
+    `${ADMIN_SG_BASE}/admission-paths/${pathId}/subject-group-configs`,
+    data,
+  )
+  return response.data
+}
+
+export async function updatePathSubjectGroupConfig(
+  configId: number,
+  data: PathSubjectGroupConfigUpdatePayload,
+): Promise<PathSubjectGroupConfigBaseResponse> {
+  const response = await api.patch<PathSubjectGroupConfigBaseResponse>(
+    `${ADMIN_SG_BASE}/path-subject-group-configs/${configId}`,
+    data,
+  )
+  return response.data
+}
+
+export async function deletePathSubjectGroupConfig(
+  configId: number,
+): Promise<void> {
+  await api.delete(`${ADMIN_SG_BASE}/path-subject-group-configs/${configId}`)
+}
+
+export async function addPathSubjectGroupItem(
+  configId: number,
+  data: PathSubjectGroupItemPayload,
+): Promise<PathSubjectGroupItemAdmin> {
+  const response = await api.post<PathSubjectGroupItemAdmin>(
+    `${ADMIN_SG_BASE}/path-subject-group-configs/${configId}/items`,
+    data,
+  )
+  return response.data
+}
+
+export async function updatePathSubjectGroupItem(
+  configId: number,
+  itemId: number,
+  data: PathSubjectGroupItemUpdatePayload,
+): Promise<PathSubjectGroupItemAdmin> {
+  const response = await api.patch<PathSubjectGroupItemAdmin>(
+    `${ADMIN_SG_BASE}/path-subject-group-configs/${configId}/items/${itemId}`,
+    data,
+  )
+  return response.data
+}
+
+export async function deletePathSubjectGroupItem(
+  configId: number,
+  itemId: number,
+): Promise<void> {
+  await api.delete(
+    `${ADMIN_SG_BASE}/path-subject-group-configs/${configId}/items/${itemId}`,
+  )
+}
+
+// ============================================
 // EXPORT DEFAULT OBJECT
 // ============================================
 
@@ -271,6 +421,14 @@ export const admissionPathsApi = {
   // Phase 3 multi-NV AddChoiceDialog
   getPathsByRound,
   getPathSubjectGroupConfigs,
+  // Admin "Tổ hợp môn" tab CRUD (#7)
+  getPathSubjectGroupConfigsAdmin,
+  createPathSubjectGroupConfig,
+  updatePathSubjectGroupConfig,
+  deletePathSubjectGroupConfig,
+  addPathSubjectGroupItem,
+  updatePathSubjectGroupItem,
+  deletePathSubjectGroupItem,
 }
 
 export default admissionPathsApi

--- a/frontend/src/lib/zod/admission-path.ts
+++ b/frontend/src/lib/zod/admission-path.ts
@@ -378,6 +378,9 @@ export const admissionPathResponseSchema = z.object({
   // false mirrors BE default + keeps parse lenient for endpoints that return
   // raw ORM without the computed field.
   can_edit_governance: z.boolean().default(false),
+  // Admin-only gate for the "Tổ hợp môn" tab (path_subject_group_config CRUD).
+  // .default(false) so older/partial responses parse — mirror can_edit_governance.
+  can_manage_subject_group_configs: z.boolean().default(false),
   validation_errors: z.array(z.string()).default([]),
 
   // PR #6 — REQUIRED in the response so Zod fails loudly when the backend


### PR DESCRIPTION
## Vì sao
Hồ sơ **đa nguyện vọng (multi-NV)** đọc tổ hợp môn từ bảng `path_subject_group_config` (màn "Thêm nguyện vọng"). Nhưng admin thêm tổ hợp qua "Cập nhật tiêu chí" — chỉ ghi `criteria_subject_group`. **2 bảng độc lập, KHÔNG sync** → tổ hợp admin thêm không hiện cho hồ sơ multi-NV (verify prod: THCS_TL ở path 197/214 không hiện cho hồ sơ 51). Backend đã có đủ API CRUD nhưng **chưa có UI nào** gọi (chỉ GET đọc).

→ Thêm tab **"Tổ hợp môn"** vào `PathDetailDrawer` để admin tự quản lý `path_subject_group_config` (thêm/sửa/xóa tổ hợp, điểm sàn, quota Tier 3, môn chính) + **gợi ý đồng bộ từ tiêu chí** (drift hint).

## Backend
- **Admin enriched GET**: subject_group label + `subjects[]` + `items[]`; `field_serializer` Decimal→float (OpenAPI/contract = JSON number, không string). Build tay mirror officer GET.
- **Flag** `can_manage_subject_group_configs` (admin-only **+ not-archived**) — FE gate theo flag, KHÔNG theo `user.role`.
- **Item PATCH/DELETE** scoped `(config_id,item_id)`→404; `add_item`/`create_config` dup→**409** (savepoint); `delete_config` precheck choice + savepoint→**409** (FK RESTRICT, không 500).
- **Audit** `log_activity` TRƯỚC `commit()` (config + item + clone-paths); path-404/archived-400 guards.
- `is_principal: bool` (không Optional) → OpenAPI `boolean`, reject explicit null 422 (contract đúng cho generated-client).

## Frontend
- API client (7 admin fn + type riêng, không đụng officer `PathSubjectGroupConfigForChoice`).
- Hook `usePathSubjectGroupConfigs`: invalidate **AWAIT** (mutateAsync chờ refetch) + đủ key gồm `["path-sg-configs",pathId]` (AddChoiceDialog multi-NV refetch) + `["quota-matrix"]`.
- Component `SubjectGroupConfigTab`: bảng inline-edit (numeric-dirty, re-key theo server value) + combobox `foldVietnamese` + drift hint "Thêm nhanh" (per-chip pending) + **dialog Môn chính đọc config LIVE** (configId, không snapshot; per-row pending Set). Copy trung thực ("chưa ảnh hưởng chấm điểm — dùng ở bước sau").
- Wire `PathDetailDrawer`: tab gate flag + URL fallback + grid-cols động (5/6/7).

## Test
- **BE 15** (service, one-off container `qlts_test`): Tier3/composite/dup/scope-404/archived/delete-409/payload-dup/null-is_principal.
- **FE**: type-check + lint 0-error + **33 test** (hook full-invalidation ×6, dialog live-config stale-fix, drawer gate ×3, fixture).
- **Chrome MCP smoke (dev) PASS**: tab hiện cho admin (7 tab), 6 tổ hợp enriched render (score=number), dialog Môn chính honest-copy, add→checked+Gỡ / delete→unchecked (stale-fix + invalidate-await live), console 0 lỗi.

Qua **5 vòng review** (stale-snapshot, OpenAPI-contract, invalidate-await, pending-Set, payload-dup… đã vá + verify).

## Nợ defer (LOW, không chặn)
DRY (hand-build admin/officer GET, `_require_writable_path` vs `_check_lifecycle_guard`, 6-hook factory) · BE `except IntegrityError` rộng (bắt riêng UniqueViolation/FK) · FE admin GET chưa zod-parse (pattern file sẵn) · `?tab=` không strip khi fallback · delete/update_item chưa guard active-choice (**bắt buộc khi wire scoring**) · `is_principal`/`min_subject_score` per-item **chưa được engine consume** (chuẩn bị bước sau).

## Khắc phục ca prod (hồ sơ 51)
Sau deploy: path 197+214 → tab "Tổ hợp môn" → "Thêm nhanh" THCS_TL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)