### PR TITLE
fix(admission): 2 hotfix — mất địa chỉ khi đổi mode + 500 PATCH tổ hợp môn

### DIFF
--- a/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
+++ b/Backend_FastAPI/app/routers/admin_v2_path_subject_group.py
@@ -175,8 +175,12 @@ async def update_config(
         description=f"Updated config {config_id}",
     )
     await db.commit()
-    await db.refresh(config, ["items"])
-    return config
+    # An UPDATE expires the server-side ``onupdate`` column (updated_at); a bare
+    # ``return config`` would lazy-load it during response serialization →
+    # MissingGreenlet (async session has no greenlet at serialize time). Re-fetch
+    # via a fresh eager query so every response_model field is loaded in-context.
+    # (INSERT paths populate these via RETURNING, so create_config is unaffected.)
+    return await service.repo.get_config_by_id(config_id)
 
 
 @limiter.limit(RateLimits.ADMIN_WRITE)
@@ -262,6 +266,9 @@ async def update_item(
         description=f"Updated item {item_id} of config {config_id}",
     )
     await db.commit()
+    # UPDATE expires the server-side ``onupdate`` updated_at; reload in-context so
+    # response serialization doesn't lazy-load it (MissingGreenlet). See update_config.
+    await db.refresh(item)
     return item
 
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -1317,6 +1317,30 @@ async def _outstanding_debt_for_approval(db, profile) -> list[str]:
     return _compute_outstanding_debt_codes(profile, documents)
 
 
+def _validate_permanent_address(
+    profile: models.AdmissionProfile,
+) -> tuple[list[str], list[str]]:
+    """Validate the required permanent-address hierarchy shared by read + submit.
+
+    District is intentionally optional because current administrative data is
+    two-tier. The current-era commune-code check remains async at submit time;
+    this pure helper owns the province/ward presence contract so readiness,
+    grouped errors, document-debt eligibility, and submit cannot drift.
+    """
+    missing_fields: list[str] = []
+    validation_errors: list[str] = []
+
+    if not (getattr(profile, "permanent_province", None) or "").strip():
+        missing_fields.append("Tỉnh/Thành phố thường trú")
+        validation_errors.append("Thiếu địa chỉ thường trú: Tỉnh/Thành phố")
+
+    if not (getattr(profile, "permanent_ward", None) or "").strip():
+        missing_fields.append("Phường/Xã thường trú")
+        validation_errors.append("Thiếu địa chỉ thường trú: Phường/Xã")
+
+    return missing_fields, validation_errors
+
+
 def _validate_personal_info(
     profile: models.AdmissionProfile,
 ) -> tuple[list[str], list[str]]:
@@ -1342,7 +1366,11 @@ def _validate_personal_info(
         if not getattr(profile, field, None):
             missing_personal.append(label)
             validation_errors.append(f"Thiếu thông tin cá nhân: {label}")
-            
+
+    missing_address, address_errors = _validate_permanent_address(profile)
+    missing_personal.extend(missing_address)
+    validation_errors.extend(address_errors)
+
     return missing_personal, validation_errors
 
 
@@ -1379,6 +1407,10 @@ def _compute_completion_percent(
     personal_optional = ["email", "dob", "gender", "nationality", "ethnicity"]
     personal_required_filled = all(getattr(profile, f, None) for f in personal_required)
     personal_optional_filled = all(getattr(profile, f, None) for f in personal_optional)
+    permanent_address_complete = all(
+        (getattr(profile, field, None) or "").strip()
+        for field in ("permanent_province", "permanent_ward")
+    )
     has_family = profile.family_info and len(profile.family_info) > 0
     has_academic = profile.academic_history and len(profile.academic_history) > 0
     # P0 hotfix multi-NV — Step 5 (Scores) "has any" reads per-choice
@@ -1412,7 +1444,9 @@ def _compute_completion_percent(
     # Previous Step 4 (Scores) renumbered → Step 5. Step 5 (Documents) → 6.
     # Step 6 (Tuition) → 7. Step 7 (Finalize) → 8. FE PipelineSidebar đã 8 steps.
     step_status = {
-        1: "error" if (cccd_error or not personal_required_filled) else ("success" if personal_optional_filled else "warning"),
+        1: "error" if (
+            cccd_error or not personal_required_filled or not permanent_address_complete
+        ) else ("success" if personal_optional_filled else "warning"),
         2: "success" if has_family else "warning",
         3: "success" if has_academic else "warning",
         4: (
@@ -2448,6 +2482,10 @@ def _compute_frontend_fields(
     personal_optional = ["email", "dob", "gender", "nationality", "ethnicity"]
     personal_required_filled = all(getattr(profile, f, None) for f in personal_required)
     personal_optional_filled = all(getattr(profile, f, None) for f in personal_optional)
+    permanent_address_complete = all(
+        (getattr(profile, field, None) or "").strip()
+        for field in ("permanent_province", "permanent_ward")
+    )
     
     # Family
     has_family = profile.family_info and len(profile.family_info) > 0
@@ -2490,7 +2528,9 @@ def _compute_frontend_fields(
     # Step 6 (Tuition) → 7. Step 7 (Finalize) → 8. FE PipelineSidebar đã 8 steps.
     step_status = {
         # Step 1: Personal Info
-        1: "error" if (cccd_error or not personal_required_filled) else ("success" if personal_optional_filled else "warning"),
+        1: "error" if (
+            cccd_error or not personal_required_filled or not permanent_address_complete
+        ) else ("success" if personal_optional_filled else "warning"),
         # Step 2: Family
         2: "success" if has_family else "warning",
         # Step 3: Academic History
@@ -6130,11 +6170,12 @@ async def submit_and_evaluate(
         errors.append("Chưa nhập họ tên thí sinh (full_name)")
     if not (profile.phone or "").strip():
         errors.append("Chưa nhập số điện thoại (phone)")
-    if not (profile.permanent_province or "").strip():
-        errors.append("Thiếu địa chỉ thường trú: Tỉnh/Thành phố")
-    if not (profile.permanent_ward or "").strip():
-        errors.append("Thiếu địa chỉ thường trú: Phường/Xã")
-    elif not await _is_current_era_ward(db, profile.permanent_commune_code):
+    _, permanent_address_errors = _validate_permanent_address(profile)
+    errors.extend(permanent_address_errors)
+    if (
+        (profile.permanent_ward or "").strip()
+        and not await _is_current_era_ward(db, profile.permanent_commune_code)
+    ):
         errors.append(
             "Phường/Xã thường trú phải theo địa giới hiện hành (2 cấp, sau "
             "01/07/2025). Vui lòng chọn lại Phường/Xã hiện tại."

--- a/Backend_FastAPI/tests/api/test_admin_v2_path_subject_group_config.py
+++ b/Backend_FastAPI/tests/api/test_admin_v2_path_subject_group_config.py
@@ -1,0 +1,127 @@
+"""API-level regression: PATCH update_config / update_item must return 200, not 500.
+
+Prod bug 2026-06-23 (#425 follow-up): an UPDATE expires the server-side
+``onupdate`` ``updated_at`` column; the router returned the bare ORM object, so
+FastAPI lazy-loaded ``updated_at`` during response serialization → MissingGreenlet
+(async session has no greenlet at serialize time) → HTTP 500. The DB write itself
+committed, so the failure was *response-only* — invisible to service-level tests,
+which reload via ``get_config_by_id``. These tests hit the real HTTP route so the
+serialization path is exercised. INSERT paths (create/add_item) populate the
+timestamps via RETURNING and were never affected.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.schemas.path_subject_group import (
+    PathSubjectGroupConfigCreate,
+    PathSubjectGroupItemCreate,
+)
+from app.services.path_subject_group_service import PathSubjectGroupService
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def cfg_seed(seed_lead_dependencies: dict) -> dict:
+    """Seed an active path + one config (with one item) to PATCH over HTTP."""
+    ts = int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            offering = models.ProgramOffering(
+                program_id=seed_lead_dependencies["major_program_id"],
+                offering_type="full_time",
+                duration_semesters=8,
+            )
+            s.add(offering); await s.flush()
+            ai = models.OfferingAcademicInfo(
+                offering_id=offering.id,
+                academic_year=2026,
+                annual_admission_quota=20,
+                tuition_fee_per_year=1_000_000,
+            )
+            s.add(ai); await s.flush()
+
+            from tests.fixtures.builders import AdmissionRoundBuilder
+            round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+                s, academic_year=2026,
+            )
+            method = models.AdmissionMethod(
+                code=f"M{ts}", name=f"M {ts}",
+                requires_subject_scores=True, is_active=True,
+            )
+            s.add(method); await s.flush()
+            path = models.AdmissionPath(
+                academic_info_id=ai.id,
+                admission_method_id=method.id,
+                admission_round_id=round_id,
+                admit_quota=10,
+                status="active",
+            )
+            s.add(path); await s.flush()
+            sg = models.SubjectGroup(code=f"A{ts}"[:20], name=f"SG {ts}")
+            s.add(sg); await s.flush()
+            subj = models.Subject(code=f"S{ts}"[:20], name_vi=f"Subj {ts}")
+            s.add(subj); await s.flush()
+            sgs = models.SubjectGroupSubject(
+                subject_group_id=sg.id, subject_id=subj.id, position=1,
+            )
+            s.add(sgs); await s.flush()
+            path_id, sg_id, sgs_id = path.id, sg.id, sgs.id
+
+    # Create a config + one item via the service (own txn), then reload PKs.
+    async with AsyncSessionLocal() as s:
+        svc = PathSubjectGroupService(s)
+        cfg = await svc.create_config(
+            path_id,
+            PathSubjectGroupConfigCreate(
+                subject_group_id=sg_id,
+                group_quota=5,
+                items=[PathSubjectGroupItemCreate(subject_group_subject_id=sgs_id)],
+            ),
+        )
+        await s.commit()
+        cfg = await svc.repo.get_config_by_id(cfg.id)
+        return {"config_id": cfg.id, "item_id": cfg.items[0].id}
+
+
+@pytest.mark.asyncio
+async def test_update_config_returns_200_not_missing_greenlet(
+    client: AsyncClient, admin_token_headers: dict, cfg_seed: dict,
+):
+    """PATCH update_config must serialize ``updated_at`` without MissingGreenlet."""
+    resp = await client.patch(
+        f"/api/v2/admin/path-subject-group-configs/{cfg_seed['config_id']}",
+        json={"min_score": 5.5},
+        headers=admin_token_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == cfg_seed["config_id"]
+    assert body["min_score"] == 5.5
+    # ``updated_at`` was the attribute that raised MissingGreenlet pre-fix.
+    assert body.get("updated_at")
+
+
+@pytest.mark.asyncio
+async def test_update_item_returns_200_not_missing_greenlet(
+    client: AsyncClient, admin_token_headers: dict, cfg_seed: dict,
+):
+    """PATCH update_item must serialize ``updated_at`` without MissingGreenlet."""
+    resp = await client.patch(
+        f"/api/v2/admin/path-subject-group-configs/{cfg_seed['config_id']}"
+        f"/items/{cfg_seed['item_id']}",
+        json={"is_principal": True},
+        headers=admin_token_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == cfg_seed["item_id"]
+    assert body["is_principal"] is True
+    assert body.get("updated_at")

--- a/Backend_FastAPI/tests/api/test_admission_workflow_api.py
+++ b/Backend_FastAPI/tests/api/test_admission_workflow_api.py
@@ -395,6 +395,21 @@ async def test_submit_without_permanent_address_stays_draft_gap3(client, officer
     assert body["status"] == "draft", body
     assert "thường trú" in " ".join(body.get("validation_errors") or []), body
 
+    # Read-side readiness must expose the same blocker after submit refetch.
+    # Otherwise FE only shows a transient toast count, then loses the address
+    # error and may incorrectly offer the document-debt action.
+    after = (await client.get(ADM(pid), headers=oh)).json()
+    personal_errors = (
+        after.get("grouped_validation_errors", {})
+        .get("personal_info", {})
+        .get("errors", [])
+    )
+    assert after["eligibility_status"] == "ineligible", after
+    assert after["step_status"]["1"] == "error", after
+    assert any("Tỉnh/Thành phố" in error for error in personal_errors), after
+    assert any("Phường/Xã" in error for error in personal_errors), after
+    assert after["can_submit_with_document_debt"] is False, after
+
 
 @pytest.mark.asyncio
 async def test_submit_approve_override_finalize_enrolled(client, officer_user_in_db, adm_lead, adm_config):

--- a/Backend_FastAPI/tests/services/test_multi_nv_submit_gate.py
+++ b/Backend_FastAPI/tests/services/test_multi_nv_submit_gate.py
@@ -181,7 +181,14 @@ async def _seed_path_and_group(
 
 
 def _full_personal(**overrides):
-    """Personal fields so _validate_personal_info passes (no personal errors)."""
+    """Personal fields so _validate_personal_info passes (no personal errors).
+
+    Includes the permanent-address hierarchy (province + ward + commune code):
+    ``_validate_personal_info`` now folds ``_validate_permanent_address`` in, so
+    a profile missing province/ward is ``ineligible`` at GET time. The current-
+    era ward check only runs at submit, which these GET/serialize tests never
+    reach, so any non-empty commune code keeps eligibility green here.
+    """
     base = dict(
         full_name="Nguyễn Văn Test",
         dob=date(2008, 1, 1),
@@ -190,6 +197,9 @@ def _full_personal(**overrides):
         ethnicity="Kinh",
         phone="0970000000",
         place_of_birth="Đắk Lắk",
+        permanent_province="Tỉnh Test KV",
+        permanent_ward="Phường Test KV",
+        permanent_commune_code="99TESTKV",
     )
     base.update(overrides)
     return base

--- a/Backend_FastAPI/tests/unit/test_admission_permanent_address_validation.py
+++ b/Backend_FastAPI/tests/unit/test_admission_permanent_address_validation.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+from app.services.admission_service import (
+    _validate_permanent_address,
+    _validate_personal_info,
+)
+
+
+def _profile(**overrides):
+    values = {
+        "full_name": "Nguyen Van A",
+        "dob": "2001-01-01",
+        "gender": "Nam",
+        "citizen_id": "001234567890",
+        "nationality": "VN",
+        "ethnicity": "Kinh",
+        "phone": "0901234567",
+        "place_of_birth": "Ha Noi",
+        "permanent_province": "Dak Lak",
+        "permanent_ward": "Xa Ea Kao",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_permanent_address_validator_returns_specific_required_errors():
+    missing, errors = _validate_permanent_address(
+        _profile(permanent_province=None, permanent_ward=""),
+    )
+
+    assert missing == ["Tỉnh/Thành phố thường trú", "Phường/Xã thường trú"]
+    assert errors == [
+        "Thiếu địa chỉ thường trú: Tỉnh/Thành phố",
+        "Thiếu địa chỉ thường trú: Phường/Xã",
+    ]
+
+
+def test_personal_info_readiness_includes_permanent_address_errors():
+    missing, errors = _validate_personal_info(
+        _profile(permanent_province=None, permanent_ward=None),
+    )
+
+    assert "Tỉnh/Thành phố thường trú" in missing
+    assert "Phường/Xã thường trú" in missing
+    assert "Thiếu địa chỉ thường trú: Tỉnh/Thành phố" in errors
+    assert "Thiếu địa chỉ thường trú: Phường/Xã" in errors
+
+
+def test_permanent_address_validator_accepts_two_tier_address_without_district():
+    missing, errors = _validate_permanent_address(_profile())
+
+    assert missing == []
+    assert errors == []

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/AdmissionDetailClient.tsx
@@ -266,6 +266,13 @@ export function AdmissionDetailClient({
           form.setError("dob", { type: "backend", message: error })
         } else if (lower.includes("chưa chọn giới tính")) {
           form.setError("gender", { type: "backend", message: error })
+        } else if (lower.includes("thiếu địa chỉ thường trú: tỉnh/thành phố")) {
+          form.setError("permanent_province", { type: "backend", message: error })
+        } else if (
+          lower.includes("thiếu địa chỉ thường trú: phường/xã") ||
+          lower.includes("phường/xã thường trú phải theo địa giới hiện hành")
+        ) {
+          form.setError("permanent_ward", { type: "backend", message: error })
         } else if (lower.includes("gpa") && !lower.includes("tài liệu")) {
           form.setError("admission_scores", { type: "backend", message: error })
         }

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@/components/forms/AdaptiveAddressSelect", () => ({
         <span data-testid="address-mode">{String(props.mode)}</span>
         <span data-testid="address-disabled">{String(props.disabled)}</span>
         <span data-testid="address-label">{String(props.label)}</span>
+        <span data-testid="address-error">{String(props.errorMessage || "")}</span>
       </div>
     );
   },
@@ -328,7 +329,7 @@ describe("PersonalInfoTab", () => {
       expect(capturedFormRef?.getValues("permanent_commune_code")).toBeNull();
     });
 
-    it("changing address mode clears permanent_commune_code", () => {
+    it("mode callback alone preserves commune code until the child confirms and clears", () => {
       const profile = buildProfile({ version: 1 });
       render(<TestFormHost profile={profile} />);
 
@@ -344,7 +345,53 @@ describe("PersonalInfoTab", () => {
         onModeChange("legacy");
       });
 
+      expect(capturedFormRef?.getValues("permanent_commune_code")).toBe("66_002");
+
+      act(() => {
+        onWardCodeChange(null);
+      });
       expect(capturedFormRef?.getValues("permanent_commune_code")).toBeNull();
+    });
+
+    it("shows an inline address error after the confirmed reset clears province", () => {
+      const profile = buildProfile({
+        permanent_province: "Đắk Lắk",
+        permanent_ward: "Xã Ea Kao",
+        version: 1,
+      });
+      render(<TestFormHost profile={profile} />);
+
+      const onProvinceChange =
+        capturedAddressProps.onProvinceChange as (v: string) => void;
+      act(() => {
+        onProvinceChange("");
+      });
+
+      expect(screen.getByTestId("address-error").textContent).toContain(
+        "thiếu Tỉnh/Thành phố",
+      );
+    });
+
+    it("combines province AND ward errors when both are cleared", () => {
+      const profile = buildProfile({
+        permanent_province: "Đắk Lắk",
+        permanent_ward: "Xã Ea Kao",
+        version: 1,
+      });
+      render(<TestFormHost profile={profile} />);
+
+      const onProvinceChange =
+        capturedAddressProps.onProvinceChange as (v: string) => void;
+      const onWardChange =
+        capturedAddressProps.onWardChange as (v: string) => void;
+      act(() => {
+        onProvinceChange("");
+        onWardChange("");
+      });
+
+      const text = screen.getByTestId("address-error").textContent ?? "";
+      expect(text).toContain("thiếu Tỉnh/Thành phố");
+      expect(text).toContain("thiếu Phường/Xã");
     });
   });
 

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/PersonalInfoTab.tsx
@@ -47,6 +47,19 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
   const permanentCommuneCode = useWatch({ control: form.control, name: "permanent_commune_code" }) ?? null
   const permanentResidentialGroup = useWatch({ control: form.control, name: "permanent_residential_group" }) || ""
   const permanentStreetAddress = useWatch({ control: form.control, name: "permanent_street_address" }) || ""
+  // Combine ALL present address errors (province + ward + commune) into one
+  // multi-line message instead of surfacing only the first: after a mode
+  // switch both Tỉnh/Thành phố AND Phường/Xã go missing at once, so the officer
+  // must see both. Deduped — identical messages collapse to a single line.
+  const addressErrorMessage = Array.from(
+    new Set(
+      [
+        form.formState.errors.permanent_province?.message,
+        form.formState.errors.permanent_ward?.message,
+        form.formState.errors.permanent_commune_code?.message,
+      ].filter((m): m is string => Boolean(m)),
+    ),
+  ).join("\n")
 
   // PR-3 + Cách B: resolved CURRENT commune (2-cấp) for the picked ward, driven
   // by a React Query hook keyed on permanent_commune_code. The BE canonicalizes
@@ -273,6 +286,14 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
               streetAddressValue={permanentStreetAddress}
               onProvinceChange={(value) => {
                 form.setValue("permanent_province", value, { shouldDirty: true })
+                if (value) {
+                  form.clearErrors("permanent_province")
+                } else {
+                  form.setError("permanent_province", {
+                    type: "address",
+                    message: "Địa chỉ thường trú đang thiếu Tỉnh/Thành phố. Vui lòng chọn lại trước khi lưu hoặc nộp hồ sơ.",
+                  })
+                }
                 // Province reset clears ward chain → mã xã canonical theo đó.
                 // (useResolveWard tự clear badge khi commune_code về null.)
                 form.setValue("permanent_commune_code", null, { shouldDirty: true })
@@ -281,24 +302,33 @@ export function PersonalInfoTab({ profile, form, isEditable }: PersonalInfoTabPr
                 form.setValue("permanent_district", value || "", { shouldDirty: true })
                 form.setValue("permanent_commune_code", null, { shouldDirty: true })
               }}
-              onWardChange={(value) => form.setValue("permanent_ward", value, { shouldDirty: true })}
+              onWardChange={(value) => {
+                form.setValue("permanent_ward", value, { shouldDirty: true })
+                if (value) {
+                  form.clearErrors("permanent_ward")
+                } else {
+                  form.setError("permanent_ward", {
+                    type: "address",
+                    message: "Địa chỉ thường trú đang thiếu Phường/Xã. Vui lòng chọn lại trước khi lưu hoặc nộp hồ sơ.",
+                  })
+                }
+              }}
               // Phase E.4 KV bridge — engine đọc permanent_commune_code chuẩn,
               // KHÔNG đọc tên ward. PriorityTab hết phải hỏi officer gõ mã.
               // Cách B: chỉ set form value; useResolveWard(permanentCommuneCode)
               // tự fetch lại badge theo mã mới (cả lúc đổi lẫn lúc load).
               onWardCodeChange={(code) => {
                 form.setValue("permanent_commune_code", code, { shouldDirty: true })
+                if (code) form.clearErrors("permanent_commune_code")
               }}
               onResidentialGroupChange={(value) => form.setValue("permanent_residential_group", value)}
               onStreetAddressChange={(value) => form.setValue("permanent_street_address", value)}
               mode={addressMode}
               onModeChange={(newMode) => {
                 setAddressMode(newMode)
-                // Mode switch resets cả tỉnh/quận/xã → mã xã cũng phải clear
-                // để tránh stale code orphan.
-                form.setValue("permanent_commune_code", null, { shouldDirty: true })
               }}
               disabled={!isEditable}
+              errorMessage={addressErrorMessage ? String(addressErrorMessage) : undefined}
             />
 
             {/* Commit 5 + PR-3 — Address normalized indicator. BE engine resolve

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/ActionItemsList.test.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/ActionItemsList.test.tsx
@@ -12,6 +12,7 @@ import type { ReadinessActionItem } from "./useSubmissionReadiness"
 
 const items: ReadinessActionItem[] = [
   { id: "step-5", step: 5, severity: "error", message: "Điểm chưa đạt", source: "message" },
+  { id: "step-6", step: 6, severity: "error", message: "Thiếu giấy khai sinh", source: "message", canDeferAsDocumentDebt: true },
   { id: "step-3", step: 3, severity: "warning", message: "Học tập cần bổ sung", source: "section" },
 ]
 
@@ -23,9 +24,12 @@ describe("ActionItemsList", () => {
 
   it("renders one button row per item with 'Sửa Bước X'", () => {
     render(<ActionItemsList items={items} onNavigateToStep={vi.fn()} />)
-    expect(screen.getByText("Việc cần xử lý (2)")).toBeInTheDocument()
+    expect(screen.getByText("Việc cần xử lý (3)")).toBeInTheDocument()
     expect(screen.getByText("Điểm chưa đạt")).toBeInTheDocument()
     expect(screen.getByText("Sửa Bước 5")).toBeInTheDocument()
+    expect(screen.getByText("Có thể nộp kèm nợ giấy tờ")).toBeInTheDocument()
+    expect(screen.getByText("Phải sửa trước khi nộp")).toBeInTheDocument()
+    expect(screen.getByText("Cần rà soát")).toBeInTheDocument()
     expect(screen.getByText("Sửa Bước 3")).toBeInTheDocument()
     // rows are real buttons (keyboard-activatable)
     expect(screen.getByText("Điểm chưa đạt").closest("button")).toBeTruthy()

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/ActionItemsList.tsx
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/ActionItemsList.tsx
@@ -52,8 +52,25 @@ export function ActionItemsList({ items, onNavigateToStep }: ActionItemsListProp
                   aria-hidden="true"
                 />
               )}
-              <span className="text-sm text-foreground break-words min-w-0">
-                {item.message}
+              <span className="min-w-0 space-y-1">
+                <span className="block text-sm text-foreground break-words">
+                  {item.message}
+                </span>
+                <span
+                  className={
+                    item.canDeferAsDocumentDebt
+                      ? "block text-xs font-medium text-warning-700"
+                      : item.severity === "error"
+                        ? "block text-xs font-medium text-error-700"
+                        : "block text-xs font-medium text-warning-700"
+                  }
+                >
+                  {item.canDeferAsDocumentDebt
+                    ? "Có thể nộp kèm nợ giấy tờ"
+                    : item.severity === "error"
+                      ? "Phải sửa trước khi nộp"
+                      : "Cần rà soát"}
+                </span>
               </span>
             </span>
             <span className="flex items-center gap-1 text-sm font-medium text-primary shrink-0">

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/useSubmissionReadiness.test.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/useSubmissionReadiness.test.ts
@@ -410,6 +410,56 @@ describe("useSubmissionReadiness — Phase 3 structured blockers routing", () =>
     expect(step6[0].message).toBe("structured doc")
   })
 
+  it("personal blocker uses the specific grouped address error and routes to Step 1", () => {
+    const profile = buildProfile({
+      grouped_validation_errors: {
+        personal_info: {
+          category: "Thông tin cá nhân",
+          errors: [
+            "Thiếu địa chỉ thường trú: Tỉnh/Thành phố",
+            "Thiếu địa chỉ thường trú: Phường/Xã",
+          ],
+          count: 2,
+        },
+      },
+      executive_summary: es({
+        critical_blockers: [{
+          code: "personal_info_missing",
+          message: "Thiếu 2 thông tin cá nhân bắt buộc",
+          step: 1,
+          section: "personal_info",
+          severity: "blocker",
+        }],
+      }),
+    } as Partial<AdmissionProfileResponse>)
+
+    const r = run(buildParams({ profile }))
+    const addressItem = r.actionItems.find((item) => item.id === "personal_info_missing")
+    expect(addressItem?.step).toBe(1)
+    expect(addressItem?.message).toBe(
+      "Thiếu địa chỉ thường trú: Tỉnh/Thành phố (+1 mục khác)",
+    )
+    expect(addressItem?.canDeferAsDocumentDebt).toBe(false)
+  })
+
+  it("marks missing documents as deferrable only when backend grants document debt", () => {
+    const profile = buildProfile({
+      can_submit_with_document_debt: true,
+      executive_summary: es({
+        critical_blockers: [{
+          code: "documents_missing",
+          message: "Thiếu giấy khai sinh",
+          step: 6,
+          section: "documents",
+          severity: "blocker",
+        }],
+      }),
+    } as Partial<AdmissionProfileResponse>)
+
+    const r = run(buildParams({ profile }))
+    expect(r.actionItems.find((item) => item.step === 6)?.canDeferAsDocumentDebt).toBe(true)
+  })
+
   it("priority (Step 4) still added alongside structured items", () => {
     const profile = buildProfile({
       cultural_education_level: null,

--- a/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/useSubmissionReadiness.ts
+++ b/frontend/src/app/(dashboard)/admissions/[id]/_components/tabs/finalize/useSubmissionReadiness.ts
@@ -62,6 +62,8 @@ export interface ReadinessActionItem {
   source: "message" | "section"
   /** Number of underlying issues at this step (≥1) — for the reviewer locator chip. */
   count?: number
+  /** True only when the backend currently allows the missing-doc debt flow. */
+  canDeferAsDocumentDebt?: boolean
 }
 
 export interface SubmissionReadiness {
@@ -186,13 +188,22 @@ export function buildReadinessActionItems(
   const stepStatus = profile.step_status
 
   // Precise: structured BE items (objects with a numeric step).
-  const structured = buildStructuredActionItems(profile.executive_summary)
+  const grouped = profile.grouped_validation_errors
+  const structured = buildStructuredActionItems(profile.executive_summary).map((item) => {
+    if (item.id !== "personal_info_missing" || !grouped?.personal_info?.count) {
+      return item
+    }
+    return {
+      ...item,
+      message: summarizeMany(grouped.personal_info.errors),
+      count: Math.max(1, grouped.personal_info.count),
+    }
+  })
   const coveredSteps = new Set<number>(structured.map((i) => i.step))
   const items: ReadinessActionItem[] = [...structured]
 
   // Heuristic recovery — fill ONLY the steps structured items did not cover.
   // grouped_validation_errors → Step 1/5/6.
-  const grouped = profile.grouped_validation_errors
   const groupedBuckets: Array<
     [GroupedSectionKey, { category: string; errors: string[]; count: number } | undefined]
   > = [
@@ -251,10 +262,17 @@ export function buildReadinessActionItems(
   })
 
   // error before warning, then ascending step.
-  return deduped.sort((a, b) => {
-    if (a.severity !== b.severity) return a.severity === "error" ? -1 : 1
-    return a.step - b.step
-  })
+  return deduped
+    .map((item) => ({
+      ...item,
+      canDeferAsDocumentDebt: Boolean(
+        profile.can_submit_with_document_debt && item.step === 6,
+      ),
+    }))
+    .sort((a, b) => {
+      if (a.severity !== b.severity) return a.severity === "error" ? -1 : 1
+      return a.step - b.step
+    })
 }
 
 function eligibilityLabelFor(verdict: EligibilityVerdict): string {

--- a/frontend/src/components/forms/AdaptiveAddressSelect.test.tsx
+++ b/frontend/src/components/forms/AdaptiveAddressSelect.test.tsx
@@ -198,22 +198,65 @@ describe("AdaptiveAddressSelect", () => {
   // MODE SWITCHING
   // -----------------------------------------------------------------
 
-  it("switching mode resets province, district, and ward", async () => {
+  it("switching mode with existing data asks before resetting address", async () => {
     const { props } = await renderComponent({
       mode: "current",
       provinceValue: "Dak Lak",
+      wardValue: "Xa Ea Kao",
+      wardCodeValue: "66_002",
     })
 
-    // Click legacy radio
     const legacyRadio = screen.getByLabelText(/Hộ khẩu cũ/)
     fireEvent.click(legacyRadio)
+
+    expect(screen.getByText("Đổi chế độ địa chỉ?")).toBeInTheDocument()
+    expect(props.onModeChange).not.toHaveBeenCalled()
+    expect(props.onProvinceChange).not.toHaveBeenCalled()
+    expect(props.onWardChange).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole("button", { name: "Đổi và xóa địa chỉ" }))
 
     await waitFor(() => {
       expect(props.onModeChange).toHaveBeenCalledWith("legacy")
       expect(props.onProvinceChange).toHaveBeenCalledWith("")
       expect(props.onDistrictChange).toHaveBeenCalledWith(null)
       expect(props.onWardChange).toHaveBeenCalledWith("")
+      expect(props.onWardCodeChange).toHaveBeenCalledWith(null)
     })
+  })
+
+  it("cancelling mode switch preserves the current address", async () => {
+    const { props } = await renderComponent({
+      mode: "current",
+      provinceValue: "Dak Lak",
+      wardValue: "Xa Ea Kao",
+      wardCodeValue: "66_002",
+    })
+
+    fireEvent.click(screen.getByLabelText(/Hộ khẩu cũ/))
+    fireEvent.click(screen.getByRole("button", { name: "Giữ địa chỉ hiện tại" }))
+
+    await waitFor(() => {
+      expect(screen.queryByText("Đổi chế độ địa chỉ?")).not.toBeInTheDocument()
+    })
+    expect(props.onModeChange).not.toHaveBeenCalled()
+    expect(props.onProvinceChange).not.toHaveBeenCalled()
+    expect(props.onDistrictChange).not.toHaveBeenCalled()
+    expect(props.onWardChange).not.toHaveBeenCalled()
+    expect(props.onWardCodeChange).not.toHaveBeenCalled()
+  })
+
+  it("switching mode without address data applies immediately", async () => {
+    const { props } = await renderComponent({ mode: "current" })
+
+    fireEvent.click(screen.getByLabelText(/Hộ khẩu cũ/))
+
+    await waitFor(() => {
+      expect(props.onModeChange).toHaveBeenCalledWith("legacy")
+      expect(props.onProvinceChange).toHaveBeenCalledWith("")
+      expect(props.onWardChange).toHaveBeenCalledWith("")
+    })
+    expect(screen.queryByText("Đổi chế độ địa chỉ?")).not.toBeInTheDocument()
   })
 
   it("switching to current hides district field", async () => {
@@ -414,6 +457,7 @@ describe("AdaptiveAddressSelect", () => {
     })
 
     fireEvent.click(screen.getByLabelText(/Hộ khẩu cũ/))
+    fireEvent.click(screen.getByRole("button", { name: "Đổi và xóa địa chỉ" }))
 
     await waitFor(() => {
       expect(props.onWardCodeChange).toHaveBeenCalledWith(null)

--- a/frontend/src/components/forms/AdaptiveAddressSelect.tsx
+++ b/frontend/src/components/forms/AdaptiveAddressSelect.tsx
@@ -7,12 +7,13 @@
  * - "legacy":   63 provinces, 3-level (province → district → ward)
  *
  * Mode is chosen by the user via a radio toggle at the top.
- * Switching mode resets province/district/ward selections.
+ * Switching mode resets province/district/ward selections after confirmation
+ * when the user already has hierarchical address data.
  */
 
 "use client"
 
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 
 import type { AddressMode } from "@/lib/api/administrative"
 import { useDistricts, useProvinces, useWards } from "@/lib/hooks/useAdministrative"
@@ -20,6 +21,16 @@ import { useDistricts, useProvinces, useWards } from "@/lib/hooks/useAdministrat
 import { Label } from "@/components/ui/label"
 import { Combobox } from "@/components/ui/combobox"
 import { Input } from "@/components/ui/input"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 
 interface AdaptiveAddressSelectProps {
   provinceValue: string
@@ -61,6 +72,7 @@ interface AdaptiveAddressSelectProps {
   onModeChange: (mode: AddressMode) => void
   label?: string
   disabled?: boolean
+  errorMessage?: string
 }
 
 export function AdaptiveAddressSelect({
@@ -80,8 +92,10 @@ export function AdaptiveAddressSelect({
   onModeChange,
   label = "Hộ khẩu thường trú",
   disabled = false,
+  errorMessage,
 }: AdaptiveAddressSelectProps) {
   const isLegacy = mode === "legacy"
+  const [pendingMode, setPendingMode] = useState<AddressMode | null>(null)
 
   // ---- Data fetching ----
   const { data: provinces = [], isLoading: loadingProvinces } = useProvinces(mode)
@@ -165,12 +179,32 @@ export function AdaptiveAddressSelect({
   // must mirror cả name (display) lẫn code (canonical KV input) qua callbacks
   // để callers tracking `permanent_commune_code` không có stale orphan code.
 
-  const handleModeChange = (newMode: AddressMode) => {
+  const applyModeChange = (newMode: AddressMode) => {
     onModeChange(newMode)
     onProvinceChange("")
     onDistrictChange(null)
     onWardChange("")
     onWardCodeChange?.(null)
+  }
+
+  const handleModeChange = (newMode: AddressMode) => {
+    if (newMode === mode) return
+
+    const hasHierarchicalAddress = Boolean(
+      provinceValue || districtValue || wardValue || wardCodeValue,
+    )
+    if (hasHierarchicalAddress) {
+      setPendingMode(newMode)
+      return
+    }
+
+    applyModeChange(newMode)
+  }
+
+  const confirmModeChange = () => {
+    if (!pendingMode) return
+    applyModeChange(pendingMode)
+    setPendingMode(null)
   }
 
   const handleProvinceChange = (name: string) => {
@@ -231,6 +265,30 @@ export function AdaptiveAddressSelect({
           <span className="text-muted-foreground">(trước 01/07/2025)</span>
         </label>
       </div>
+
+      <AlertDialog
+        open={pendingMode !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingMode(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Đổi chế độ địa chỉ?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Tỉnh/Thành phố, Quận/Huyện và Phường/Xã đang chọn sẽ bị xóa.
+              Tổ/Thôn và số nhà, tên đường vẫn được giữ lại. Bạn sẽ cần chọn
+              lại địa chỉ trước khi lưu hoặc nộp hồ sơ.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Giữ địa chỉ hiện tại</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmModeChange}>
+              Đổi và xóa địa chỉ
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Address fields */}
       <div
@@ -317,6 +375,17 @@ export function AdaptiveAddressSelect({
           )}
         </div>
       )}
+
+      {errorMessage ? (
+        <p
+          role="alert"
+          aria-live="assertive"
+          className="mt-2 whitespace-pre-line text-[0.8rem] font-medium text-destructive"
+          data-testid="address-field-error"
+        >
+          {errorMessage}
+        </p>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
Gộp 2 hotfix độc lập (cùng base `c81d9ae9`, không trùng file).

## 1. Mất địa chỉ thường trú khi đổi chế độ địa chỉ (prod #45) — `e1a52015`
**Bug**: đổi radio mode địa chỉ (legacy 3 cấp ↔ current 2 cấp) **xóa thầm** province/ward/district → user không biết → submit báo chung chung "Thiếu địa chỉ".

**Fix**:
- **FE** `AdaptiveAddressSelect`: đổi mode khi đã có dữ liệu → **AlertDialog confirm** ("Đổi và xóa địa chỉ" / "Giữ địa chỉ hiện tại"); giữ street/house; thêm prop `errorMessage` (inline error proactive). `PersonalInfoTab` + `useSubmissionReadiness` + `ActionItemsList` hiển thị lỗi địa chỉ cụ thể ngay khi load (không đợi submit).
- **BE** helper thuần `_validate_permanent_address` (province + ward; district optional vì dữ liệu 2 cấp) — **nguồn sự thật chung** cho `_validate_personal_info` (readiness/grouped), `_compute_completion_percent` + `_compute_frontend_fields` (step_status[1]), và `submit_and_evaluate` → read-side ↔ submit-side **đồng bộ**, hết drift. Giữ nguyên check current-era ward.

## 2. 500 MissingGreenlet khi sửa tổ hợp môn (#425 follow-up) — `e0eec560`
**Bug**: PATCH sửa `min_score`/`quota` của 1 tổ hợp → UPDATE expire cột server-side `onupdate` `updated_at` → router trả bare ORM → FastAPI lazy-load lúc serialize ngoài async context → **MissingGreenlet 500**. DB đã commit nên là **lỗi response-only** (data đã lưu). POST tạo tổ hợp OK vì INSERT có RETURNING.

**Fix**:
- `update_config` → re-fetch `repo.get_config_by_id` (fresh eager: scalars + items).
- `update_item` → `db.refresh(item)` (cùng class bug).
- `create_config`/`add_item` (INSERT+RETURNING) → không đụng.
- **+ API regression test** hit route thật — service-test cũ reload qua getter nên bỏ sót tầng router→serialization.

## Verify
- **BE 35/35 pass** (one-off `qlts_test`): address-validation 3 · submit-gate 13 · sg-config-api 2 · workflow-api 17.
- FE test (address: PersonalInfoTab / AdaptiveAddressSelect / ActionItemsList / useSubmissionReadiness) → CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)