### PR TITLE
feat(reports): báo cáo tuyển sinh tuần + cockpit ra quyết định (pivot ngành/cán bộ)

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -250,6 +250,9 @@ jobs:
           tests/unit/test_b2_1_admission_milestone_events.py
           tests/integration/test_delete_profile_revert.py
           tests/repositories/test_admission_soft_delete_excluded.py
+          tests/unit/test_admission_report_helpers.py
+          tests/repositories/test_admission_report_integration.py
+          tests/api/test_admission_report_api.py
           -q --tb=short --timeout=60
 
       # =====================================================================

--- a/Backend_FastAPI/app/main.py
+++ b/Backend_FastAPI/app/main.py
@@ -43,6 +43,7 @@ from .routers import (
     admin_v2_casbin,  # ✅ T0-5 cold cutover: admin-only Casbin reload endpoint
     admin_v2_admission_round,  # ✅ #184 Phase 2 v8.2 PR-2A v2: year-level rounds CRUD + bulk-create + extend
     admin_v2_path_subject_group,  # ✅ #184 Phase 2 v8.2 PR-2D: path-level subject group config + clone endpoint
+    admission_reports,  # Weekly admission report (lead→admission→finance by ngành/officer)
     admin_priority_config,  # ✅ Q9 #07 PR3: priority KV/UT bonus configs per year + clone + seed TT 05/2021
     admin_vn_locality,  # ✅ Q9 #07 PR4: commune + high school CSV import + dropdown search
     admin_vn_school,  # PR-B: admin CRUD vn_school + KV assignment
@@ -892,6 +893,7 @@ fastapi_app.include_router(admin_v2_casbin.router)  # ✅ T0-5: POST /api/v2/adm
 fastapi_app.include_router(admin_v2_system_config.router)  # ✅ #184 PR-1D: GET/PATCH /api/v2/admin/system-config (router declares full prefix)
 fastapi_app.include_router(admin_v2_admission_round.router)  # ✅ #184 Phase 2 v8.2 PR-2A v2: year-level rounds (router declares full prefix)
 fastapi_app.include_router(admin_v2_path_subject_group.router)  # ✅ #184 Phase 2 v8.2 PR-2D: path-level subject group config + clone
+fastapi_app.include_router(admission_reports.router)  # Weekly admission report (admin/manager read-only)
 fastapi_app.include_router(admin_priority_config.router)  # ✅ Q9 #07 PR3: priority KV/UT configs (router declares full prefix)
 fastapi_app.include_router(admin_vn_locality.admin_router)  # ✅ Q9 #07 PR4: admin commune CSV import
 fastapi_app.include_router(admin_vn_school.admin_router)  # PR-B: admin vn_school + KV assignment CRUD

--- a/Backend_FastAPI/app/repositories/admission_report_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_report_repository.py
@@ -1,0 +1,535 @@
+"""Data access for the weekly admission report.
+
+Design (locked with product owner):
+- **Attribution = recomputed-current**: ngành/officer resolve theo trạng thái HIỆN
+  TẠI (admitted choice → NV1 → applied_rules → lead.offering). Số tuần đã qua có
+  thể đổi khi publish/đổi NV.
+- **Event-based weeks**: lead ``created_at`` (new) / ``LeadStatusHistory.changed_at``;
+  admission milestones = FIRST transition into a status (status_history MIN
+  ``occurred_at``); finance = ledger ``PaymentTransaction.created_at``.
+- Resolution + bucketing done in Python (catalog is small) so ``ambiguous`` (>1
+  admitted choice) and ``unresolved`` (no choice/offering) are explicit, never
+  silently folded into a real ngành.
+- Soft-deleted leads (``Lead.deleted_at``) are excluded everywhere (parity with the
+  admission stats fix).
+
+The service layer owns the week/round contract and passes pre-computed VN-aware
+ranges in; this repo only aggregates.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional, Union
+
+from sqlalchemy import and_, distinct, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.utils.admission_status import ADMITTED_LIKE_STATUSES
+
+# Milestone status sets (event-based, first-transition).
+SUBMITTED_STATUSES = frozenset({"submitted", "resubmitted"})
+ENROLLED_STATUS = "enrolled"
+
+# Bucket sentinels (group keys that are not a real major_id / officer_id).
+AMBIGUOUS = "ambiguous"
+UNRESOLVED = "unresolved"
+UNASSIGNED = "unassigned"
+
+# Cash-affecting ledger types only (waive/adjustment/penalty/reversal are not cash).
+_CASH_TYPES = ("payment", "refund")
+
+GroupKey = Union[int, str]  # major_id / officer_id, or a bucket sentinel
+
+
+@dataclass
+class MajorInfo:
+    major_id: int
+    code: Optional[str]
+    name: Optional[str]
+    degree_level: Optional[str]
+
+
+@dataclass
+class ProfileDim:
+    """Resolved reporting dimensions for one profile."""
+
+    profile_id: int
+    lead_id: int
+    # major group key: int major_id, or AMBIGUOUS / UNRESOLVED
+    major_key: GroupKey
+    major: Optional[MajorInfo]
+    # officer group key: int officer_id, or UNASSIGNED
+    officer_key: GroupKey
+    officer_name: Optional[str]
+    round_code: Optional[str]
+
+
+@dataclass
+class WindowRange:
+    start: datetime  # VN-aware
+    end_excl: datetime  # VN-aware, half-open
+
+
+@dataclass
+class _Counts:
+    submitted_in_week: int = 0
+    admitted_in_week: int = 0
+    enrolled_in_week: int = 0
+    submitted_cumulative: int = 0
+    admitted_cumulative: int = 0
+    enrolled_cumulative: int = 0
+
+
+@dataclass
+class _Money:
+    gross_in_week: Decimal = field(default_factory=lambda: Decimal("0"))
+    refund_in_week: Decimal = field(default_factory=lambda: Decimal("0"))
+    net_in_week: Decimal = field(default_factory=lambda: Decimal("0"))
+    application_net_in_week: Decimal = field(default_factory=lambda: Decimal("0"))
+    tuition_net_in_week: Decimal = field(default_factory=lambda: Decimal("0"))
+    net_cumulative: Decimal = field(default_factory=lambda: Decimal("0"))
+
+
+@dataclass
+class _Leads:
+    new_in_week: int = 0
+    active_current: int = 0
+    consulting_positive_current: int = 0
+
+
+class AdmissionReportRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    # ------------------------------------------------------------------ filters
+    async def list_report_years(self) -> list[int]:
+        """Years with admission CONFIG (rounds) OR data (profiles), newest first.
+
+        Union of both so a year just set up (rounds created, no profiles yet) is
+        still selectable — unlike the profile-only ``get_distinct_academic_years``.
+        """
+        round_years = select(models.OfferingAdmissionRound.academic_year)
+        profile_years = select(models.AdmissionProfile.academic_year).where(
+            models.AdmissionProfile.academic_year.isnot(None)
+        )
+        rows = (await self.db.execute(round_years.union(profile_years))).scalars().all()
+        return sorted({y for y in rows if y is not None}, reverse=True)
+
+    async def list_report_rounds(self, academic_year: int) -> list[str]:
+        """Distinct round_codes configured for the year, ordered by code."""
+        stmt = (
+            select(models.OfferingAdmissionRound.round_code)
+            .where(models.OfferingAdmissionRound.academic_year == academic_year)
+            .distinct()
+            .order_by(models.OfferingAdmissionRound.round_code)
+        )
+        return list((await self.db.execute(stmt)).scalars().all())
+
+    # ------------------------------------------------------------------ catalog
+    async def _build_catalog(
+        self,
+    ) -> tuple[
+        dict[int, tuple[MajorInfo, Optional[str]]],
+        dict[int, MajorInfo],
+        dict[int, MajorInfo],
+    ]:
+        """Return (path_id -> (MajorInfo, round_code), offering_id -> MajorInfo).
+
+        One pass over the (small) catalog. ``degree_level`` uses the plain text
+        column to avoid the ``degree_level_ref`` ``lazy="raise"`` relationship.
+        """
+        # offering_id -> MajorInfo
+        off_rows = await self.db.execute(
+            select(
+                models.OfferingAcademicInfo.id,
+                models.ProgramOffering.program_id,
+                models.MajorProgram.code,
+                models.MajorProgram.name,
+                models.MajorProgram.degree_level,
+                models.OfferingAcademicInfo.offering_id,
+            )
+            .join(
+                models.ProgramOffering,
+                models.OfferingAcademicInfo.offering_id == models.ProgramOffering.id,
+            )
+            .join(
+                models.MajorProgram,
+                models.ProgramOffering.program_id == models.MajorProgram.id,
+            )
+        )
+        academic_info_to_major: dict[int, MajorInfo] = {}
+        offering_to_major: dict[int, MajorInfo] = {}
+        major_by_id: dict[int, MajorInfo] = {}
+        for ai_id, major_id, code, name, degree, offering_id in off_rows:
+            info = MajorInfo(
+                major_id=major_id, code=code, name=name, degree_level=degree
+            )
+            academic_info_to_major[ai_id] = info
+            offering_to_major[offering_id] = info
+            major_by_id[major_id] = info
+
+        # path_id -> (academic_info_id, round_code)
+        path_rows = await self.db.execute(
+            select(
+                models.AdmissionPath.id,
+                models.AdmissionPath.academic_info_id,
+                models.OfferingAdmissionRound.round_code,
+            ).join(
+                models.OfferingAdmissionRound,
+                models.AdmissionPath.admission_round_id
+                == models.OfferingAdmissionRound.id,
+            )
+        )
+        path_to_major: dict[int, tuple[MajorInfo, Optional[str]]] = {}
+        for path_id, ai_id, round_code in path_rows:
+            info = academic_info_to_major.get(ai_id)
+            if info is not None:
+                path_to_major[path_id] = (info, round_code)
+        return path_to_major, offering_to_major, major_by_id
+
+    async def get_user_names(self, user_ids: list[int]) -> dict[int, str]:
+        """user_id -> display name (full_name → username → #id)."""
+        if not user_ids:
+            return {}
+        rows = await self.db.execute(
+            select(models.User.id, models.User.full_name, models.User.username).where(
+                models.User.id.in_(user_ids)
+            )
+        )
+        return {uid: (full or username or f"#{uid}") for uid, full, username in rows}
+
+    # --------------------------------------------------------------- resolution
+    async def resolve_profiles(
+        self,
+        academic_year: int,
+        scope_unit_id: Optional[int],
+        officer_id: Optional[int],
+        round_code: Optional[str],
+    ) -> tuple[dict[int, ProfileDim], dict[int, MajorInfo]]:
+        """Resolve every in-scope profile to its (major, officer, round) dims.
+
+        Scope: ``profile.academic_year == academic_year``, ``lead.deleted_at IS
+        NULL``, optional ``lead.unit_id``/``lead.assigned_officer_id``. When
+        ``round_code`` is given, profiles whose resolved round differs are dropped.
+        """
+        path_to_major, offering_to_major, major_by_id = await self._build_catalog()
+
+        conds = [
+            models.AdmissionProfile.academic_year == academic_year,
+            models.Lead.deleted_at.is_(None),
+        ]
+        if scope_unit_id is not None:
+            conds.append(models.Lead.unit_id == scope_unit_id)
+        if officer_id is not None:
+            conds.append(models.Lead.assigned_officer_id == officer_id)
+
+        rows = await self.db.execute(
+            select(
+                models.AdmissionProfile.id,
+                models.AdmissionProfile.lead_id,
+                models.AdmissionProfile.applied_rules,
+                models.Lead.assigned_officer_id,
+                models.Lead.offering_id,
+                models.User.full_name,
+                models.User.username,
+            )
+            .join(models.Lead, models.AdmissionProfile.lead_id == models.Lead.id)
+            .join(
+                models.User,
+                models.Lead.assigned_officer_id == models.User.id,
+                isouter=True,
+            )
+            .where(and_(*conds))
+        )
+        profiles = rows.all()
+        profile_ids = [r[0] for r in profiles]
+        choices_by_profile = await self._load_choices(profile_ids)
+
+        out: dict[int, ProfileDim] = {}
+        for (
+            pid,
+            lead_id,
+            applied_rules,
+            officer,
+            offering_id,
+            full_name,
+            username,
+        ) in profiles:
+            major_key, major_info, resolved_round = self._resolve_one(
+                pid,
+                applied_rules,
+                offering_id,
+                choices_by_profile,
+                path_to_major,
+                offering_to_major,
+            )
+            if (
+                round_code is not None
+                and resolved_round is not None
+                and resolved_round != round_code
+            ):
+                continue  # different round (None-round profiles are always shown)
+            officer_key: GroupKey = officer if officer is not None else UNASSIGNED
+            out[pid] = ProfileDim(
+                profile_id=pid,
+                lead_id=lead_id,
+                major_key=major_key,
+                major=major_info,
+                officer_key=officer_key,
+                officer_name=(full_name or username) if officer is not None else None,
+                round_code=resolved_round,
+            )
+        return out, major_by_id
+
+    async def _load_choices(self, profile_ids: list[int]) -> dict[int, list]:
+        if not profile_ids:
+            return {}
+        rows = await self.db.execute(
+            select(
+                models.AdmissionProfileChoice.admission_profile_id,
+                models.AdmissionProfileChoice.admission_path_id,
+                models.AdmissionProfileChoice.decision,
+                models.AdmissionProfileChoice.display_order,
+            ).where(models.AdmissionProfileChoice.admission_profile_id.in_(profile_ids))
+        )
+        by_profile: dict[int, list] = defaultdict(list)
+        for pid, path_id, decision, order in rows:
+            by_profile[pid].append((path_id, decision, order))
+        return by_profile
+
+    @staticmethod
+    def _resolve_one(
+        pid: int,
+        applied_rules: Optional[dict],
+        offering_id: Optional[int],
+        choices_by_profile: dict[int, list],
+        path_to_major: dict[int, tuple[MajorInfo, Optional[str]]],
+        offering_to_major: dict[int, MajorInfo],
+    ) -> tuple[GroupKey, Optional[MajorInfo], Optional[str]]:
+        """5-tier resolver: admitted → NV1 → applied_rules → offering → unresolved.
+        >1 admitted → ambiguous (never auto-pick).
+        """
+        chs = choices_by_profile.get(pid, [])
+        admitted = [c for c in chs if c[1] == "admitted"]
+        if len(admitted) > 1:
+            return AMBIGUOUS, None, None
+
+        # Ordered path candidates; use the FIRST that actually resolves so a
+        # broken/archived path does NOT short-circuit into UNRESOLVED — it falls
+        # through to the next tier (legacy applied_rules, then lead.offering).
+        candidate_paths: list[int] = []
+        if len(admitted) == 1:
+            candidate_paths.append(admitted[0][0])
+        nv1 = next((c for c in chs if c[2] == 1), None)  # NV1 = display_order == 1
+        if nv1 is not None:
+            candidate_paths.append(nv1[0])
+        if isinstance(applied_rules, dict):  # guard non-dict JSONB (list/str → no .get)
+            legacy_path = applied_rules.get("admission_path_id")
+            if legacy_path is not None:
+                try:
+                    candidate_paths.append(int(legacy_path))
+                except (TypeError, ValueError):
+                    pass
+        for path_id in candidate_paths:
+            res = AdmissionReportRepository._from_path(path_id, path_to_major)
+            if res[0] != UNRESOLVED:
+                return res
+
+        # final fallback: lead intent offering
+        if offering_id is not None and offering_id in offering_to_major:
+            info = offering_to_major[offering_id]
+            return info.major_id, info, None
+        return UNRESOLVED, None, None
+
+    @staticmethod
+    def _from_path(
+        path_id: int, path_to_major: dict[int, tuple[MajorInfo, Optional[str]]]
+    ) -> tuple[GroupKey, Optional[MajorInfo], Optional[str]]:
+        hit = path_to_major.get(path_id)
+        if hit is None:
+            return UNRESOLVED, None, None
+        info, round_code = hit
+        return info.major_id, info, round_code
+
+    # ------------------------------------------------------------- admission ev
+    async def admission_milestones(
+        self,
+        profile_ids: list[int],
+        week: WindowRange,
+        cumulative_end: datetime,
+    ) -> dict[int, dict[str, bool]]:
+        """For each profile → which milestone events land in-week / cumulative.
+
+        Milestone = FIRST transition into the status set (MIN occurred_at). Counting
+        the first occurrence keeps a resubmitted profile from being counted twice
+        across weeks.
+        """
+        if not profile_ids:
+            return {}
+        hist = models.AdmissionProfileStatusHistory
+        result: dict[int, dict[str, bool]] = {}
+
+        async def _first_into(status_pred):
+            rows = await self.db.execute(
+                select(hist.profile_id, func.min(hist.occurred_at))
+                .where(
+                    hist.profile_id.in_(profile_ids),
+                    # Exclude the phase1_10 synthetic "initial state" backfill row
+                    # (from_status NULL → current @ profile.created_at) — it would
+                    # mis-date legacy milestones to the creation week. Scalar-derived
+                    # backfills + real transitions keep a non-NULL from_status.
+                    hist.from_status.isnot(None),
+                    status_pred,
+                )
+                .group_by(hist.profile_id)
+            )
+            return {pid: ts for pid, ts in rows}
+
+        # Monotone funnel: a profile that reached a later milestone is counted at
+        # every earlier one too (override/bulk-import can skip the 'submitted' row),
+        # so submitted ⊇ admitted ⊇ enrolled → MIN(submitted) ≤ MIN(admitted) ≤ ...
+        admitted_set = set(ADMITTED_LIKE_STATUSES) | {ENROLLED_STATUS}
+        submitted_set = set(SUBMITTED_STATUSES) | admitted_set
+        firsts = {
+            "submitted": await _first_into(hist.to_status.in_(submitted_set)),
+            "admitted": await _first_into(hist.to_status.in_(admitted_set)),
+            "enrolled": await _first_into(hist.to_status == ENROLLED_STATUS),
+        }
+        for milestone, by_pid in firsts.items():
+            for pid, ts in by_pid.items():
+                slot = result.setdefault(pid, {})
+                if ts is not None and ts < cumulative_end:
+                    slot[f"{milestone}_cumulative"] = True
+                    if week.start <= ts < week.end_excl:
+                        slot[f"{milestone}_in_week"] = True
+        return result
+
+    # ----------------------------------------------------------------- finance
+    async def finance_rows(
+        self,
+        profile_ids: list[int],
+        cumulative_end: datetime,
+    ) -> list[tuple[int, str, str, Decimal, datetime]]:
+        """Raw cash ledger rows for in-scope profiles up to ``cumulative_end``.
+
+        Returns (profile_id, fee_type, transaction_type, amount, created_at).
+        ``amount`` keeps its stored sign (refund negative). Bucketing into
+        week/cumulative + by dimension is done by the caller.
+        """
+        if not profile_ids:
+            return []
+        rows = await self.db.execute(
+            select(
+                models.Fee.admission_profile_id,
+                models.Fee.fee_type,
+                models.PaymentTransaction.transaction_type,
+                models.PaymentTransaction.amount,
+                models.PaymentTransaction.created_at,
+            )
+            .join(models.Fee, models.PaymentTransaction.fee_id == models.Fee.id)
+            .where(
+                models.Fee.admission_profile_id.in_(profile_ids),
+                # Admission-relevant fees only, so gross/net reconciles with the
+                # application+tuition split (excludes dormitory/insurance/...).
+                models.Fee.fee_type.in_(("application", "tuition")),
+                models.PaymentTransaction.transaction_type.in_(_CASH_TYPES),
+                models.PaymentTransaction.created_at < cumulative_end,
+            )
+        )
+        return [tuple(r) for r in rows.all()]
+
+    # -------------------------------------------------------------------- leads
+    async def lead_counts(
+        self,
+        academic_year: int,
+        cohort_ranges: list[WindowRange],
+        week: WindowRange,
+        group_by: str,
+        scope_unit_id: Optional[int],
+        officer_id: Optional[int],
+        profile_lead_ids: Optional[set] = None,
+    ) -> dict[GroupKey, _Leads]:
+        """Lead funnel grouped by intent-offering→major (major mode) or officer.
+
+        Cohort = ``lead.created_at`` within any round window of the year. Leads
+        without an offering go to UNRESOLVED (major mode); without an officer to
+        UNASSIGNED (officer mode). Stocks (``active_current``/``consulting_positive``)
+        are NOW among cohort leads (cohort-restricted, not all leads ever).
+        """
+        window_preds = [
+            and_(
+                models.Lead.created_at >= r.start,
+                models.Lead.created_at < r.end_excl,
+            )
+            for r in cohort_ranges
+        ]
+        # Cohort = leads created in a round window OR leads that already produced an
+        # in-scope profile (walk-ins between rounds) — keeps the lead funnel aligned
+        # with the admission/finance population so admission never exceeds lead.
+        if profile_lead_ids:
+            window_preds.append(models.Lead.id.in_(profile_lead_ids))
+        if not window_preds:
+            return {}
+        cohort_pred = or_(*window_preds)
+        conds = [models.Lead.deleted_at.is_(None), cohort_pred]
+        if scope_unit_id is not None:
+            conds.append(models.Lead.unit_id == scope_unit_id)
+        if officer_id is not None:
+            conds.append(models.Lead.assigned_officer_id == officer_id)
+
+        new_in_week = and_(
+            models.Lead.created_at >= week.start, models.Lead.created_at < week.end_excl
+        )
+        # active = consultation status not final (NULL status → treat as active)
+        active = models.ConsultationStatus.is_final.isnot(True)
+        # "Tư vấn+" stock: currently at a positive consultation-phase status.
+        consulting = and_(
+            models.ConsultationStatus.phase == "consultation",
+            models.ConsultationStatus.outcome_type == "positive",
+        )
+
+        if group_by == "officer":
+            group_col = models.Lead.assigned_officer_id
+        else:
+            group_col = models.ProgramOffering.program_id
+
+        stmt = (
+            select(
+                group_col,
+                func.count(distinct(models.Lead.id)).filter(new_in_week),
+                func.count(distinct(models.Lead.id)).filter(active),
+                func.count(distinct(models.Lead.id)).filter(consulting),
+            )
+            .select_from(models.Lead)
+            .join(
+                models.ConsultationStatus,
+                models.Lead.consultation_status_id == models.ConsultationStatus.id,
+                isouter=True,
+            )
+            .where(and_(*conds))
+            .group_by(group_col)
+        )
+        if group_by != "officer":
+            stmt = stmt.join(
+                models.ProgramOffering,
+                models.Lead.offering_id == models.ProgramOffering.id,
+                isouter=True,
+            )
+
+        rows = await self.db.execute(stmt)
+        out: dict[GroupKey, _Leads] = {}
+        for key_val, new_cnt, active_cnt, consult_cnt in rows:
+            if key_val is None:
+                key: GroupKey = UNASSIGNED if group_by == "officer" else UNRESOLVED
+            else:
+                key = key_val
+            bucket = out.setdefault(key, _Leads())
+            bucket.new_in_week += int(new_cnt or 0)
+            bucket.active_current += int(active_cnt or 0)
+            bucket.consulting_positive_current += int(consult_cnt or 0)
+        return out

--- a/Backend_FastAPI/app/repositories/admission_report_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_report_repository.py
@@ -108,16 +108,32 @@ class AdmissionReportRepository:
 
     # ------------------------------------------------------------------ filters
     async def list_report_years(self) -> list[int]:
-        """Years with admission CONFIG (rounds) OR data (profiles), newest first.
+        """Years selectable in the report (config ∪ live report data), newest first.
 
-        Union of both so a year just set up (rounds created, no profiles yet) is
-        still selectable — unlike the profile-only ``get_distinct_academic_years``.
+        Union of: ``OfferingAcademicInfo`` (excl. soft-deleted) ∪
+        ``OfferingAdmissionRound`` (config) ∪ academic years of LIVE (non-deleted
+        lead) profiles (data). So a year configured with offerings but no rounds
+        appears, AND a year whose config was removed but still has live profiles
+        (the endpoint serves it) stays selectable — while a year that exists ONLY
+        via soft-deleted leads cannot leak in.
         """
-        round_years = select(models.OfferingAdmissionRound.academic_year)
-        profile_years = select(models.AdmissionProfile.academic_year).where(
-            models.AdmissionProfile.academic_year.isnot(None)
+        info_years = select(models.OfferingAcademicInfo.academic_year).where(
+            models.OfferingAcademicInfo.is_deleted.is_(False)
         )
-        rows = (await self.db.execute(round_years.union(profile_years))).scalars().all()
+        round_years = select(models.OfferingAdmissionRound.academic_year)
+        profile_years = (
+            select(models.AdmissionProfile.academic_year)
+            .join(models.Lead, models.AdmissionProfile.lead_id == models.Lead.id)
+            .where(
+                models.AdmissionProfile.academic_year.isnot(None),
+                models.Lead.deleted_at.is_(None),
+            )
+        )
+        rows = (
+            (await self.db.execute(info_years.union(round_years, profile_years)))
+            .scalars()
+            .all()
+        )
         return sorted({y for y in rows if y is not None}, reverse=True)
 
     async def list_report_rounds(self, academic_year: int) -> list[str]:
@@ -129,6 +145,56 @@ class AdmissionReportRepository:
             .order_by(models.OfferingAdmissionRound.round_code)
         )
         return list((await self.db.execute(stmt)).scalars().all())
+
+    async def major_quotas(
+        self, academic_year: int
+    ) -> dict[int, tuple[int, MajorInfo]]:
+        """major_id -> (Σ annual_admission_quota, MajorInfo) for the year, toàn trường.
+
+        Returns EVERY ACTIVE major with a (non-soft-deleted) quota row — even with
+        zero activity — so the cockpit can rank 0%-progress ngành. Whole-school
+        only: ``annual_admission_quota`` is a per-offering institution target with
+        no per-unit split, so the service shows it for admin scope only.
+        """
+        stmt = (
+            select(
+                models.MajorProgram.id,
+                models.MajorProgram.code,
+                models.MajorProgram.name,
+                models.MajorProgram.degree_level,
+                func.sum(models.OfferingAcademicInfo.annual_admission_quota),
+            )
+            .join(
+                models.ProgramOffering,
+                models.ProgramOffering.program_id == models.MajorProgram.id,
+            )
+            .join(
+                models.OfferingAcademicInfo,
+                models.OfferingAcademicInfo.offering_id == models.ProgramOffering.id,
+            )
+            .where(
+                models.OfferingAcademicInfo.academic_year == academic_year,
+                models.OfferingAcademicInfo.annual_admission_quota.isnot(None),
+                models.OfferingAcademicInfo.is_deleted.is_(False),
+                models.MajorProgram.is_active.is_(True),
+                models.ProgramOffering.is_active.is_(True),
+            )
+            .group_by(
+                models.MajorProgram.id,
+                models.MajorProgram.code,
+                models.MajorProgram.name,
+                models.MajorProgram.degree_level,
+            )
+        )
+        rows = (await self.db.execute(stmt)).all()
+        return {
+            mid: (
+                int(total),
+                MajorInfo(major_id=mid, code=code, name=name, degree_level=degree),
+            )
+            for mid, code, name, degree, total in rows
+            if total is not None
+        }
 
     # ------------------------------------------------------------------ catalog
     async def _build_catalog(

--- a/Backend_FastAPI/app/routers/admission_reports.py
+++ b/Backend_FastAPI/app/routers/admission_reports.py
@@ -1,0 +1,60 @@
+"""Admin/manager read-only admission reports (v2).
+
+Dumb HTTP translator: validates query params, delegates to
+``AdmissionReportService``. Scope (admin = all / chosen unit; manager = own unit)
+is enforced inside the service via domain exceptions. Read-only → no commit.
+"""
+
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.core.deps import require_admin_or_manager
+from app.database import get_db
+from app.schemas.admission_report import AdmissionWeeklyReportResponse, ReportFilters
+from app.services.admission_report_service import AdmissionReportService
+
+router = APIRouter(prefix="/api/v2/admin/reports", tags=["Admin v2 - Reports"])
+
+
+@router.get("/admission-weekly", response_model=AdmissionWeeklyReportResponse)
+async def get_admission_weekly_report(
+    academic_year: int = Query(..., ge=2020, le=2100),
+    group_by: str = Query("major", pattern="^(major|officer)$"),
+    round_code: Optional[str] = Query(None, max_length=20),
+    week_start: Optional[date] = Query(
+        None, description="Bất kỳ ngày trong tuần (VN); bỏ trống = tuần hiện tại"
+    ),
+    officer_id: Optional[int] = Query(None, ge=1),
+    unit_id: Optional[int] = Query(
+        None, ge=1, description="Admin chọn đơn vị; manager bị ép về đơn vị của mình"
+    ),
+    db: AsyncSession = Depends(get_db),
+    current_user: models.User = Depends(require_admin_or_manager),
+) -> AdmissionWeeklyReportResponse:
+    service = AdmissionReportService(db)
+    return await service.get_weekly_report(
+        current_user=current_user,
+        academic_year=academic_year,
+        group_by=group_by,
+        round_code=round_code,
+        week_start=week_start,
+        officer_id=officer_id,
+        unit_id=unit_id,
+    )
+
+
+@router.get("/admission-weekly/filters", response_model=ReportFilters)
+async def get_admission_weekly_report_filters(
+    academic_year: Optional[int] = Query(
+        None, ge=2020, le=2100, description="Truyền để lấy danh sách đợt của năm đó"
+    ),
+    db: AsyncSession = Depends(get_db),
+    current_user: models.User = Depends(require_admin_or_manager),
+) -> ReportFilters:
+    """Năm (config ∪ data) + đợt cho bộ lọc báo cáo — admin & manager (cùng cổng)."""
+    service = AdmissionReportService(db)
+    return await service.get_filter_options(academic_year)

--- a/Backend_FastAPI/app/schemas/admission_report.py
+++ b/Backend_FastAPI/app/schemas/admission_report.py
@@ -1,0 +1,115 @@
+"""Weekly admission report schemas (lead → admission → finance, by ngành/officer).
+
+Contract notes (locked with product owner):
+- **Attribution = recomputed-current**: ngành/officer resolve theo trạng thái HIỆN
+  TẠI. Số của một tuần đã qua CÓ THỂ đổi khi hồ sơ publish/đổi NV/reopen. The
+  ``attribution`` field flags this for the client.
+- **Week = event-based**: các chỉ số ``*_in_week`` đếm SỰ KIỆN phát sinh trong
+  ``[week_start, week_end]`` (lịch sử ``changed_at`` / ``occurred_at`` / ledger
+  ``created_at``), KHÔNG phải trạng thái hiện tại. ``active_current`` là metric
+  TỒN (stock) tại thời điểm xem — tách riêng để tránh hiểu nhầm.
+- **Money = Decimal**: serialize ra JSON string (Pydantic v2 default) để giữ
+  precision; FE ``formatVND`` nhận string.
+- **Buckets**: hồ sơ không quy được về đúng 1 ngành (``ambiguous`` = >1 admitted
+  choice; ``unresolved`` = không có choice/offering) hoặc lead/hồ sơ chưa gán
+  officer (``unassigned``) đi vào dòng riêng — KHÔNG nuốt vào ngành/officer nào.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+GroupBy = Literal["major", "officer"]
+BucketKind = Literal["ambiguous", "unresolved", "unassigned"]
+
+
+class WeekMeta(BaseModel):
+    """ISO week (Asia/Ho_Chi_Minh). BE owns the week contract; FE does not derive it."""
+
+    iso_year: int
+    iso_week: int
+    week_start: date  # Monday (VN)
+    week_end: date  # Sunday (VN, inclusive)
+    timezone: str = "Asia/Ho_Chi_Minh"
+
+
+class LeadMetrics(BaseModel):
+    new_in_week: int = 0  # leads created in [week_start, week_end]
+    active_current: int = 0  # STOCK: leads at a non-final consultation status (now)
+    consulting_positive_current: int = 0  # STOCK: positive consultation phase (now)
+
+
+class AdmissionMetrics(BaseModel):
+    # all resolved profiles in this group (even with no status history yet)
+    profiles_total: int = 0
+    # event = first transition INTO the milestone (status_history.occurred_at)
+    submitted_in_week: int = 0
+    admitted_in_week: int = 0
+    enrolled_in_week: int = 0
+    submitted_cumulative: int = 0
+    admitted_cumulative: int = 0
+    enrolled_cumulative: int = 0
+
+
+class FinanceMetrics(BaseModel):
+    # ledger PaymentTransaction.created_at; payment|refund (refund stored negative).
+    gross_in_week: Decimal = Decimal("0")
+    refund_in_week: Decimal = Decimal("0")
+    net_in_week: Decimal = Decimal("0")
+    application_net_in_week: Decimal = Decimal("0")
+    tuition_net_in_week: Decimal = Decimal("0")
+    net_cumulative: Decimal = Decimal("0")
+    profiles_paid: int = 0  # DISTINCT profiles with ≥1 cash payment (cumulative)
+
+
+class ReportRow(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    group_key: Optional[int] = None  # major_id or officer_id; None for buckets/total
+    label: str  # "CNTT (6480201)" / officer name / bucket label
+    code: Optional[str] = None  # major code (major grouping only)
+    degree_level: Optional[str] = None  # major grouping only
+    is_bucket: bool = False
+    bucket_kind: Optional[BucketKind] = None
+    lead: LeadMetrics = Field(default_factory=LeadMetrics)
+    admission: AdmissionMetrics = Field(default_factory=AdmissionMetrics)
+    finance: FinanceMetrics = Field(default_factory=FinanceMetrics)
+
+
+class DataQuality(BaseModel):
+    """Profiles that could not be cleanly attributed (surfaced, never hidden)."""
+
+    total_profiles: int = 0
+    ambiguous_profiles: int = 0  # >1 admitted choice
+    unresolved_profiles: int = 0  # no resolvable major
+    unassigned_profiles: int = 0  # no officer (officer grouping)
+
+
+class AdmissionWeeklyReportResponse(BaseModel):
+    academic_year: int
+    round_code: Optional[str] = None  # None = mọi đợt của năm
+    group_by: GroupBy
+    week: WeekMeta
+    scope_unit_id: Optional[int] = None  # None = toàn trường (admin)
+    # week numbers may shift on publish/reopen — see module docstring.
+    attribution: Literal["recomputed-current"] = "recomputed-current"
+    rows: list[ReportRow]
+    totals: ReportRow  # aggregate across rows (label="TỔNG")
+    data_quality: DataQuality = Field(default_factory=DataQuality)
+
+
+class ReportFilters(BaseModel):
+    """Options to populate the report filter controls (admin + manager).
+
+    ``academic_years`` = năm có CẤU HÌNH đợt HOẶC có hồ sơ (không chỉ năm-có-hồ-sơ,
+    nên năm vừa setup chưa có hồ sơ vẫn hiện). ``rounds`` = mã đợt của
+    ``academic_year`` (rỗng nếu không truyền năm). Đây là catalog metadata toàn cục,
+    không phải dữ liệu phạm vi đơn vị → manager đọc được (cùng cổng report).
+    """
+
+    academic_years: list[int] = Field(default_factory=list)
+    rounds: list[str] = Field(default_factory=list)

--- a/Backend_FastAPI/app/schemas/admission_report.py
+++ b/Backend_FastAPI/app/schemas/admission_report.py
@@ -53,6 +53,16 @@ class AdmissionMetrics(BaseModel):
     submitted_cumulative: int = 0
     admitted_cumulative: int = 0
     enrolled_cumulative: int = 0
+    # chỉ tiêu (annual_admission_quota) — major grouping only; None for officer
+    # view / buckets / total rows where a quota does not apply.
+    quota: Optional[int] = None
+
+
+class ConversionMetrics(BaseModel):
+    """Cumulative funnel ratios (0..1); null when the denominator is 0."""
+
+    submit_to_admit: Optional[float] = None  # admitted_cum / submitted_cum
+    admit_to_enroll: Optional[float] = None  # enrolled_cum / admitted_cum
 
 
 class FinanceMetrics(BaseModel):
@@ -77,6 +87,7 @@ class ReportRow(BaseModel):
     bucket_kind: Optional[BucketKind] = None
     lead: LeadMetrics = Field(default_factory=LeadMetrics)
     admission: AdmissionMetrics = Field(default_factory=AdmissionMetrics)
+    conversion: ConversionMetrics = Field(default_factory=ConversionMetrics)
     finance: FinanceMetrics = Field(default_factory=FinanceMetrics)
 
 

--- a/Backend_FastAPI/app/services/admission_report_service.py
+++ b/Backend_FastAPI/app/services/admission_report_service.py
@@ -156,12 +156,18 @@ class AdmissionReportService:
         unit_id: Optional[int] = None,
     ) -> AdmissionWeeklyReportResponse:
         scope_unit_id = self._resolve_scope(current_user, unit_id)
-        # Implicit week for a FUTURE academic_year: anchor to that year (ISO week 1)
-        # instead of silently using the current calendar week — otherwise the response
-        # would carry current-year week metadata for a future year.
+        # Implicit week for a NON-current academic_year: anchor INSIDE that year so
+        # the week + cumulative cutoffs stay in-year (today's week would compute
+        # cutoffs outside it). Future → ISO week 1 (Jan 4; cumulative ~0, chưa bắt
+        # đầu); past → last ISO week (Dec 28; cumulative ≈ trọn năm). Both dates are
+        # always inside the year's own ISO weeks.
         anchor = week_start
-        if anchor is None and academic_year > today_vn().year:
-            anchor = date(academic_year, 1, 4)  # Jan 4 is always inside ISO week 1
+        if anchor is None and academic_year != today_vn().year:
+            anchor = (
+                date(academic_year, 1, 4)
+                if academic_year > today_vn().year
+                else date(academic_year, 12, 28)
+            )
         week_meta, week = self._compute_week(anchor)
         # An EXPLICIT week_start before the academic year is a stale bookmark → reject
         # on the NORMALIZED ISO year (ISO week 1's Monday can fall in the prior Dec).
@@ -252,6 +258,22 @@ class AdmissionReportService:
             missing = [k for k in acc if isinstance(k, int) and k not in officer_names]
             officer_names.update(await self.repo.get_user_names(missing))
 
+        # ---- chỉ tiêu: include EVERY quota-bearing major (even with 0 activity)
+        # so behind-target ngành surface instead of vanishing.
+        #  • Year-level only — skip when a single đợt is filtered (numerator round ≠
+        #    denominator năm); FE hides the progress column.
+        #  • Toàn-trường only (scope None) — quota is a per-offering institution
+        #    target with NO per-unit split; activity scopes by Lead.unit_id while a
+        #    shared offering's quota can't be attributed to one unit, so a manager
+        #    gets the count cockpit instead of a misleading gap.
+        quota_by_major: dict[int, int] = {}
+        if group_by == "major" and round_code is None and scope_unit_id is None:
+            for mid, (q, info) in (await self.repo.major_quotas(academic_year)).items():
+                quota_by_major[mid] = q
+                if mid not in acc:
+                    _row(mid)  # materialise an empty row (0 counts)
+                major_labels.setdefault(mid, info)
+
         rows: list[ReportRow] = []
         for key, row in acc.items():
             if isinstance(key, str):  # bucket sentinel
@@ -271,6 +293,12 @@ class AdmissionReportService:
                 row.group_key = key
                 row.label = officer_names.get(key, f"Cán bộ #{key}")
             rows.append(row)
+
+        # ---- attach chỉ tiêu + tỷ lệ chuyển đổi
+        for row in rows:
+            if not row.is_bucket and isinstance(row.group_key, int):
+                row.admission.quota = quota_by_major.get(row.group_key)
+            self._apply_conversion(row)
 
         rows.sort(key=self._sort_key)
         totals = self._totals(rows)
@@ -306,6 +334,19 @@ class AdmissionReportService:
         )
 
     @staticmethod
+    def _apply_conversion(row: ReportRow) -> None:
+        """Cumulative funnel ratios; left None when the denominator is 0."""
+        a = row.admission
+        if a.submitted_cumulative:
+            row.conversion.submit_to_admit = round(
+                a.admitted_cumulative / a.submitted_cumulative, 4
+            )
+        if a.admitted_cumulative:
+            row.conversion.admit_to_enroll = round(
+                a.enrolled_cumulative / a.admitted_cumulative, 4
+            )
+
+    @staticmethod
     def _totals(rows: list[ReportRow]) -> ReportRow:
         t = ReportRow(label="TỔNG")
         for row in rows:
@@ -334,4 +375,7 @@ class AdmissionReportService:
                 "profiles_paid",
             ):
                 setattr(t.finance, m, getattr(t.finance, m) + getattr(row.finance, m))
+            if row.admission.quota is not None:
+                t.admission.quota = (t.admission.quota or 0) + row.admission.quota
+        AdmissionReportService._apply_conversion(t)
         return t

--- a/Backend_FastAPI/app/services/admission_report_service.py
+++ b/Backend_FastAPI/app/services/admission_report_service.py
@@ -1,0 +1,337 @@
+"""Weekly admission report service (orchestration only — no FastAPI imports).
+
+Owns the week/round/scope contract; delegates all data access to
+``AdmissionReportRepository``. Raises domain exceptions (never HTTPException).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.core.constants import UserRole
+from app.repositories.admission_report_repository import (
+    AMBIGUOUS,
+    UNASSIGNED,
+    UNRESOLVED,
+    AdmissionReportRepository,
+    GroupKey,
+    WindowRange,
+)
+from app.schemas.admission_report import (
+    AdmissionWeeklyReportResponse,
+    DataQuality,
+    ReportFilters,
+    ReportRow,
+    WeekMeta,
+)
+from app.utils.datetime_helpers import today_vn
+from app.utils.exceptions import (
+    BusinessRuleViolation,
+    PermissionDeniedError,
+    ResourceNotFoundError,
+    ValidationError,
+)
+
+VN_TZ = ZoneInfo("Asia/Ho_Chi_Minh")
+
+_BUCKET_LABELS = {
+    AMBIGUOUS: "Nhiều NV trúng (chưa xác định ngành)",
+    UNRESOLVED: "Chưa phân loại ngành",
+    UNASSIGNED: "Chưa gán cán bộ",
+}
+
+
+class AdmissionReportService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = AdmissionReportRepository(db)
+
+    # ------------------------------------------------------------------- scope
+    @staticmethod
+    def _resolve_scope(
+        current_user: models.User, requested_unit_id: Optional[int]
+    ) -> Optional[int]:
+        """Admin → toàn trường (or chosen unit); manager → ép unit của mình.
+
+        Caller has already gated role to {admin, manager}. Manager without a unit
+        fails closed; manager requesting another unit gets 404 (no existence leak).
+        """
+        if current_user.role == UserRole.ADMIN:
+            return requested_unit_id  # None = all units
+        if current_user.unit_id is None:
+            raise PermissionDeniedError(
+                detail="Tài khoản chưa được gán đơn vị, không thể xem báo cáo."
+            )
+        if requested_unit_id is not None and requested_unit_id != current_user.unit_id:
+            raise ResourceNotFoundError(detail="Không tìm thấy đơn vị.")
+        return current_user.unit_id
+
+    # -------------------------------------------------------------------- week
+    @staticmethod
+    def _compute_week(week_start: Optional[date]) -> tuple[WeekMeta, WindowRange]:
+        anchor = week_start or today_vn()
+        iso_year, iso_week, iso_weekday = anchor.isocalendar()
+        monday = anchor - timedelta(days=iso_weekday - 1)
+        sunday = monday + timedelta(days=6)
+        start_dt = datetime(monday.year, monday.month, monday.day, tzinfo=VN_TZ)
+        end_excl = datetime(
+            sunday.year, sunday.month, sunday.day, tzinfo=VN_TZ
+        ) + timedelta(days=1)
+        meta = WeekMeta(
+            iso_year=iso_year, iso_week=iso_week, week_start=monday, week_end=sunday
+        )
+        return meta, WindowRange(start=start_dt, end_excl=end_excl)
+
+    # ------------------------------------------------------------ cohort window
+    async def _cohort_ranges(
+        self, academic_year: int, round_code: Optional[str]
+    ) -> list[WindowRange]:
+        """VN [start 00:00, end+1day 00:00) windows for the year's round(s).
+
+        Fail-closed: a selected round missing start/end raises (don't silently span
+        everything). ``round_code`` not found → 404.
+        """
+        stmt = select(
+            models.OfferingAdmissionRound.round_code,
+            models.OfferingAdmissionRound.start_date,
+            models.OfferingAdmissionRound.end_date,
+        ).where(models.OfferingAdmissionRound.academic_year == academic_year)
+        if round_code is not None:
+            stmt = stmt.where(models.OfferingAdmissionRound.round_code == round_code)
+        rows = (await self.db.execute(stmt)).all()
+        if round_code is not None and not rows:
+            raise ResourceNotFoundError(
+                detail=f"Không tìm thấy đợt {round_code} năm {academic_year}."
+            )
+        ranges: list[WindowRange] = []
+        for rc, start, end in rows:
+            if start is None or end is None:
+                raise BusinessRuleViolation(
+                    detail=(
+                        f"Đợt {rc} thiếu ngày bắt đầu/kết thúc — "
+                        "không xác định được cohort lead."
+                    )
+                )
+            ranges.append(
+                WindowRange(
+                    start=datetime(start.year, start.month, start.day, tzinfo=VN_TZ),
+                    end_excl=datetime(end.year, end.month, end.day, tzinfo=VN_TZ)
+                    + timedelta(days=1),
+                )
+            )
+        return ranges
+
+    # ----------------------------------------------------------------- filters
+    async def get_filter_options(self, academic_year: Optional[int]) -> ReportFilters:
+        """Years + rounds for the report filter controls.
+
+        Catalog metadata (not unit-scoped data) → no IDOR scope here; the route
+        gate (admin_or_manager) is the only check the filter list needs.
+        """
+        years = await self.repo.list_report_years()
+        rounds = (
+            await self.repo.list_report_rounds(academic_year)
+            if academic_year is not None
+            else []
+        )
+        return ReportFilters(academic_years=years, rounds=rounds)
+
+    # ------------------------------------------------------------------ report
+    async def get_weekly_report(
+        self,
+        *,
+        current_user: models.User,
+        academic_year: int,
+        group_by: str,
+        round_code: Optional[str] = None,
+        week_start: Optional[date] = None,
+        officer_id: Optional[int] = None,
+        unit_id: Optional[int] = None,
+    ) -> AdmissionWeeklyReportResponse:
+        scope_unit_id = self._resolve_scope(current_user, unit_id)
+        # Implicit week for a FUTURE academic_year: anchor to that year (ISO week 1)
+        # instead of silently using the current calendar week — otherwise the response
+        # would carry current-year week metadata for a future year.
+        anchor = week_start
+        if anchor is None and academic_year > today_vn().year:
+            anchor = date(academic_year, 1, 4)  # Jan 4 is always inside ISO week 1
+        week_meta, week = self._compute_week(anchor)
+        # An EXPLICIT week_start before the academic year is a stale bookmark → reject
+        # on the NORMALIZED ISO year (ISO week 1's Monday can fall in the prior Dec).
+        if week_start is not None and week_meta.iso_year < academic_year:
+            raise ValidationError(
+                detail="week_start trước năm tuyển sinh — hãy chọn tuần trong năm."
+            )
+        cohort_ranges = await self._cohort_ranges(academic_year, round_code)
+
+        dims, major_labels = await self.repo.resolve_profiles(
+            academic_year, scope_unit_id, officer_id, round_code
+        )
+        profile_ids = list(dims.keys())
+        milestones = await self.repo.admission_milestones(
+            profile_ids, week, week.end_excl
+        )
+        fin_rows = await self.repo.finance_rows(profile_ids, week.end_excl)
+        profile_lead_ids = {d.lead_id for d in dims.values()}
+        lead_map = await self.repo.lead_counts(
+            academic_year,
+            cohort_ranges,
+            week,
+            group_by,
+            scope_unit_id,
+            officer_id,
+            profile_lead_ids,
+        )
+
+        acc: dict[GroupKey, ReportRow] = {}
+
+        def _row(key: GroupKey) -> ReportRow:
+            row = acc.get(key)
+            if row is None:
+                row = ReportRow(label="")
+                acc[key] = row
+            return row
+
+        # ---- leads (intent offering→major | officer)
+        for key, lc in lead_map.items():
+            r = _row(key).lead
+            r.new_in_week += lc.new_in_week
+            r.active_current += lc.active_current
+            r.consulting_positive_current += lc.consulting_positive_current
+
+        # ---- admission milestones (first-transition, by resolved dim)
+        for pid, dim in dims.items():
+            key = dim.major_key if group_by == "major" else dim.officer_key
+            ms = milestones.get(pid, {})
+            a = _row(key).admission
+            a.profiles_total += 1  # count every resolved profile (even if no history)
+            for m in ("submitted", "admitted", "enrolled"):
+                if ms.get(f"{m}_in_week"):
+                    setattr(a, f"{m}_in_week", getattr(a, f"{m}_in_week") + 1)
+                if ms.get(f"{m}_cumulative"):
+                    setattr(a, f"{m}_cumulative", getattr(a, f"{m}_cumulative") + 1)
+
+        # ---- finance ledger (cash: payment/refund; refund amount stored negative)
+        paid_profiles: dict[GroupKey, set] = {}
+        for pid, fee_type, ttype, amount, created_at in fin_rows:
+            dim = dims.get(pid)
+            if dim is None:
+                continue
+            key = dim.major_key if group_by == "major" else dim.officer_key
+            f = _row(key).finance
+            amt = Decimal(amount)
+            f.net_cumulative += amt
+            if ttype == "payment":
+                paid_profiles.setdefault(key, set()).add(pid)
+            if week.start <= created_at < week.end_excl:
+                f.net_in_week += amt
+                if ttype == "payment":
+                    f.gross_in_week += amt
+                else:  # refund — amount is negative; report as a positive figure
+                    f.refund_in_week += abs(amt)
+                if fee_type == "application":
+                    f.application_net_in_week += amt
+                elif fee_type == "tuition":
+                    f.tuition_net_in_week += amt
+        for key, pids in paid_profiles.items():
+            _row(key).finance.profiles_paid = len(pids)
+
+        # ---- labels
+        officer_names: dict[int, str] = {}
+        if group_by == "officer":
+            for dim in dims.values():
+                if isinstance(dim.officer_key, int) and dim.officer_name:
+                    officer_names[dim.officer_key] = dim.officer_name
+            missing = [k for k in acc if isinstance(k, int) and k not in officer_names]
+            officer_names.update(await self.repo.get_user_names(missing))
+
+        rows: list[ReportRow] = []
+        for key, row in acc.items():
+            if isinstance(key, str):  # bucket sentinel
+                row.is_bucket = True
+                row.bucket_kind = key  # type: ignore[assignment]
+                row.label = _BUCKET_LABELS.get(key, key)
+            elif group_by == "major":
+                info = major_labels.get(key)
+                row.group_key = key
+                row.code = info.code if info else None
+                row.degree_level = info.degree_level if info else None
+                if info and info.name:
+                    row.label = f"{info.name} ({info.code})" if info.code else info.name
+                else:
+                    row.label = f"Ngành #{key}"
+            else:  # officer
+                row.group_key = key
+                row.label = officer_names.get(key, f"Cán bộ #{key}")
+            rows.append(row)
+
+        rows.sort(key=self._sort_key)
+        totals = self._totals(rows)
+
+        dq = DataQuality(total_profiles=len(dims))
+        for dim in dims.values():
+            if dim.major_key == AMBIGUOUS:
+                dq.ambiguous_profiles += 1
+            elif dim.major_key == UNRESOLVED:
+                dq.unresolved_profiles += 1
+            if dim.officer_key == UNASSIGNED:
+                dq.unassigned_profiles += 1
+
+        return AdmissionWeeklyReportResponse(
+            academic_year=academic_year,
+            round_code=round_code,
+            group_by=group_by,  # type: ignore[arg-type]
+            week=week_meta,
+            scope_unit_id=scope_unit_id,
+            rows=rows,
+            totals=totals,
+            data_quality=dq,
+        )
+
+    # --------------------------------------------------------------- helpers
+    @staticmethod
+    def _sort_key(row: ReportRow):
+        # buckets to the bottom; real rows by activity (hồ sơ nộp lũy kế, rồi lead).
+        return (
+            row.is_bucket,
+            -(row.admission.submitted_cumulative + row.lead.new_in_week),
+            row.label,
+        )
+
+    @staticmethod
+    def _totals(rows: list[ReportRow]) -> ReportRow:
+        t = ReportRow(label="TỔNG")
+        for row in rows:
+            t.lead.new_in_week += row.lead.new_in_week
+            t.lead.active_current += row.lead.active_current
+            t.lead.consulting_positive_current += row.lead.consulting_positive_current
+            for m in (
+                "profiles_total",
+                "submitted_in_week",
+                "admitted_in_week",
+                "enrolled_in_week",
+                "submitted_cumulative",
+                "admitted_cumulative",
+                "enrolled_cumulative",
+            ):
+                setattr(
+                    t.admission, m, getattr(t.admission, m) + getattr(row.admission, m)
+                )
+            for m in (
+                "gross_in_week",
+                "refund_in_week",
+                "net_in_week",
+                "application_net_in_week",
+                "tuition_net_in_week",
+                "net_cumulative",
+                "profiles_paid",
+            ):
+                setattr(t.finance, m, getattr(t.finance, m) + getattr(row.finance, m))
+        return t

--- a/Backend_FastAPI/tests/api/test_admission_report_api.py
+++ b/Backend_FastAPI/tests/api/test_admission_report_api.py
@@ -1,0 +1,326 @@
+# tests/api/test_admission_report_api.py
+"""
+API-LEVEL TESTS: Weekly Admission Report endpoint.
+
+Endpoint under test:
+    GET /api/v2/admin/reports/admission-weekly
+    Router:  app/routers/admission_reports.py
+    Schema:  app/schemas/admission_report.py  (AdmissionWeeklyReportResponse)
+    Service: app/services/admission_report_service.py  (scope/week/cohort contract)
+    Gate:    require_admin_or_manager
+
+Coverage (HTTP contract only — the service scope/week math has its own unit
+tests in tests/services/ / tests/unit/):
+
+  422  - group_by regex fail / academic_year ge fail / academic_year missing
+  200  - admin, isolated empty year (2099): full response shape + week meta +
+         attribution=="recomputed-current" + timezone, group_by=major & officer
+  200  - money fields (FinanceMetrics Decimal) serialize as JSON *string*
+  403  - manager WITHOUT a unit (PermissionDeniedError → 403)
+  404  - manager WITH a unit requesting a DIFFERENT unit_id (ResourceNotFoundError
+         → 404, no existence leak)
+
+Auth pattern (mirrors tests/api/test_admission_workflow_api.py):
+  Real DB users (conftest fixtures) + per-context ``_login()`` that re-reads the
+  ``access_token`` cookie into an ``Authorization: Bearer`` header. We re-login
+  immediately before each request to defeat shared httpx cookie-jar
+  contamination when several users authenticate against the same ``client``
+  (memory: ``test-httpx-cookie-jar-contamination``).
+
+Run: pytest tests/api/test_admission_report_api.py -v
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from app.database import AsyncSessionLocal
+
+try:
+    from tests.fixtures.constants import AuthURLs, TestOrgData, TestUsers
+except ImportError:
+    pytest.fail("Could not import from tests.fixtures.constants")
+
+pytestmark = pytest.mark.integration
+
+
+# =============================================================================
+# URL + helpers
+# =============================================================================
+
+REPORT_URL = "/api/v2/admin/reports/admission-weekly"
+
+# Isolated academic year with no offerings/rounds/profiles in the test DB, so
+# the 200 path is deterministic (empty rows, all-zero totals) and never depends
+# on seeded data drifting under it.
+EMPTY_YEAR = 2099
+
+
+async def _login(client: AsyncClient, username: str, password: str) -> dict:
+    """Re-login to refresh the shared cookie jar. Returns Bearer headers."""
+    res = await client.post(
+        AuthURLs.LOGIN, data={"username": username, "password": password}
+    )
+    assert res.status_code == 200, f"Login failed for {username}: {res.text}"
+    token = res.cookies.get("access_token")
+    assert token, f"Login for {username} returned no access_token cookie"
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _assert_report_shape(body: dict, *, group_by: str) -> None:
+    """Assert the AdmissionWeeklyReportResponse contract surface."""
+    # top-level keys
+    for key in ("academic_year", "group_by", "week", "attribution", "rows", "totals"):
+        assert key in body, f"missing top-level key '{key}': {body}"
+
+    assert body["group_by"] == group_by
+    assert body["attribution"] == "recomputed-current"
+    assert isinstance(body["rows"], list)
+    assert isinstance(body["totals"], dict)
+
+    # week meta (BE owns the ISO-week contract; FE never derives it)
+    week = body["week"]
+    for key in ("iso_year", "iso_week", "week_start", "week_end", "timezone"):
+        assert key in week, f"missing week key '{key}': {week}"
+    assert week["timezone"] == "Asia/Ho_Chi_Minh"
+    assert isinstance(week["iso_year"], int)
+    assert isinstance(week["iso_week"], int)
+    # week_start / week_end are ISO date strings (YYYY-MM-DD)
+    assert isinstance(week["week_start"], str)
+    assert isinstance(week["week_end"], str)
+
+
+# =============================================================================
+# Local fixture: manager WITHOUT a unit
+# =============================================================================
+#
+# The shared ``manager_user_in_db`` fixture ALWAYS attaches a unit (pulled from
+# ``seed_lead_dependencies``), so it cannot exercise the "manager without unit
+# → 403" branch. Build a distinct unitless manager here via the same
+# ``create_user_with_role`` helper conftest uses (unit_id=None), reusing the
+# Casbin reload + idempotent-insert behavior. Separate username/email so it can
+# coexist with the other manager fixtures in one DB.
+
+
+@pytest_asyncio.fixture(scope="function")
+async def manager_no_unit_user_in_db(setup_test_database):
+    from app import models
+    from app.main import fastapi_app
+    from app.security import get_password_hash
+    from tests.fixtures.users import create_user_with_role
+
+    try:
+        from casbin_async_sqlalchemy_adapter.adapter import CasbinRule
+    except ImportError:  # pragma: no cover - adapter always present in test env
+        CasbinRule = None
+
+    user_data = {
+        "username": "testmanager_nounit",
+        "email": "manager_nounit@example.com",
+        "password": "ManagerPassword!789",
+        "role": "manager",
+        "status": "active",
+    }
+    return await create_user_with_role(
+        session_factory=AsyncSessionLocal,
+        user_data=user_data,
+        casbin_role="role:manager",
+        unit_id=None,  # the point of this fixture
+        models=models,
+        get_password_hash=get_password_hash,
+        CasbinRule=CasbinRule,
+        app=fastapi_app,
+    )
+
+
+# =============================================================================
+# 422 — query-param validation (no auth needed; FastAPI validates before deps,
+# but we still send a valid admin token so a 401/403 can't mask a 422)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_group_by_invalid_regex_returns_422(
+    client: AsyncClient, admin_user_in_db
+):
+    h = await _login(client, TestUsers.ADMIN["username"], TestUsers.ADMIN["password"])
+    res = await client.get(
+        REPORT_URL,
+        params={"academic_year": EMPTY_YEAR, "group_by": "foo"},
+        headers=h,
+    )
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_academic_year_below_min_returns_422(
+    client: AsyncClient, admin_user_in_db
+):
+    h = await _login(client, TestUsers.ADMIN["username"], TestUsers.ADMIN["password"])
+    res = await client.get(
+        REPORT_URL,
+        params={"academic_year": 1900},  # ge=2020
+        headers=h,
+    )
+    assert res.status_code == 422, res.text
+
+
+@pytest.mark.asyncio
+async def test_academic_year_missing_returns_422(client: AsyncClient, admin_user_in_db):
+    h = await _login(client, TestUsers.ADMIN["username"], TestUsers.ADMIN["password"])
+    res = await client.get(REPORT_URL, headers=h)  # academic_year required
+    assert res.status_code == 422, res.text
+
+
+# =============================================================================
+# 200 — admin happy path (isolated empty year → empty rows, zero totals)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_admin_empty_year_returns_200_with_shape(
+    client: AsyncClient, admin_user_in_db
+):
+    h = await _login(client, TestUsers.ADMIN["username"], TestUsers.ADMIN["password"])
+    res = await client.get(
+        REPORT_URL,
+        params={"academic_year": EMPTY_YEAR},  # group_by defaults to "major"
+        headers=h,
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    _assert_report_shape(body, group_by="major")
+
+    assert body["academic_year"] == EMPTY_YEAR
+    # round_code omitted → all rounds of the year; admin no unit → toàn trường.
+    assert body["round_code"] is None
+    assert body["scope_unit_id"] is None
+    # Isolated year: nothing to report.
+    assert body["rows"] == []
+
+
+@pytest.mark.asyncio
+async def test_admin_group_by_officer_returns_200_with_shape(
+    client: AsyncClient, admin_user_in_db
+):
+    h = await _login(client, TestUsers.ADMIN["username"], TestUsers.ADMIN["password"])
+    res = await client.get(
+        REPORT_URL,
+        params={"academic_year": EMPTY_YEAR, "group_by": "officer"},
+        headers=h,
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    _assert_report_shape(body, group_by="officer")
+    assert body["rows"] == []
+
+
+@pytest.mark.asyncio
+async def test_finance_metrics_serialize_as_string(
+    client: AsyncClient, admin_user_in_db
+):
+    """FinanceMetrics are Decimal → JSON string (Pydantic v2 default), even at
+    zero on the empty path. FE ``formatVND`` expects strings; a regression to
+    float/int here would silently break precision."""
+    h = await _login(client, TestUsers.ADMIN["username"], TestUsers.ADMIN["password"])
+    res = await client.get(
+        REPORT_URL,
+        params={"academic_year": EMPTY_YEAR},
+        headers=h,
+    )
+    assert res.status_code == 200, res.text
+    finance = res.json()["totals"]["finance"]
+    for field in (
+        "gross_in_week",
+        "refund_in_week",
+        "net_in_week",
+        "application_net_in_week",
+        "tuition_net_in_week",
+        "net_cumulative",
+    ):
+        assert field in finance, f"missing finance field '{field}'"
+        assert isinstance(
+            finance[field], str
+        ), f"finance.{field} should serialize as str, got {type(finance[field])}"
+
+
+# =============================================================================
+# 403 — manager without a unit (PermissionDeniedError)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_manager_without_unit_returns_403(
+    client: AsyncClient, manager_no_unit_user_in_db
+):
+    h = await _login(
+        client,
+        manager_no_unit_user_in_db["username"],
+        manager_no_unit_user_in_db["password"],
+    )
+    res = await client.get(
+        REPORT_URL,
+        params={"academic_year": EMPTY_YEAR},
+        headers=h,
+    )
+    assert res.status_code == 403, res.text
+
+
+# =============================================================================
+# 404 — manager requesting a unit that is not their own (no existence leak)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_manager_foreign_unit_returns_404(
+    client: AsyncClient,
+    manager_user_in_db,  # attached to seed_lead_dependencies unit (UNIT_1 = 1)
+    seed_other_unit,  # ensures UNIT_2 (9001) exists as a real, different unit
+):
+    h = await _login(
+        client, TestUsers.MANAGER["username"], TestUsers.MANAGER["password"]
+    )
+    foreign_unit_id = TestOrgData.UNIT_2["id"]
+    assert foreign_unit_id != TestOrgData.UNIT_1["id"]
+    res = await client.get(
+        REPORT_URL,
+        params={"academic_year": EMPTY_YEAR, "unit_id": foreign_unit_id},
+        headers=h,
+    )
+    assert res.status_code == 404, res.text
+
+
+# =============================================================================
+# Filter options — /admission-weekly/filters (admin + manager)
+# =============================================================================
+
+FILTERS_URL = "/api/v2/admin/reports/admission-weekly/filters"
+
+
+@pytest.mark.asyncio
+async def test_filters_manager_can_load_returns_200(
+    client: AsyncClient, manager_user_in_db
+):
+    """Manager (a report user) MUST be able to load filter options. The old
+    per-year rounds endpoint was admin-only, so managers got an empty Đợt
+    dropdown; this endpoint shares the report's admin_or_manager gate."""
+    h = await _login(
+        client, TestUsers.MANAGER["username"], TestUsers.MANAGER["password"]
+    )
+    res = await client.get(FILTERS_URL, params={"academic_year": EMPTY_YEAR}, headers=h)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert isinstance(body["academic_years"], list)
+    assert isinstance(body["rounds"], list)
+    # EMPTY_YEAR has no configured rounds → empty list (not an error).
+    assert body["rounds"] == []
+
+
+@pytest.mark.asyncio
+async def test_filters_without_year_omits_rounds(client: AsyncClient, admin_user_in_db):
+    h = await _login(client, TestUsers.ADMIN["username"], TestUsers.ADMIN["password"])
+    res = await client.get(FILTERS_URL, headers=h)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["rounds"] == []  # no academic_year → rounds omitted
+    assert isinstance(body["academic_years"], list)

--- a/Backend_FastAPI/tests/repositories/test_admission_report_integration.py
+++ b/Backend_FastAPI/tests/repositories/test_admission_report_integration.py
@@ -1,0 +1,690 @@
+"""Integration tests for the weekly admission report (service + repository + DB).
+
+Resolution here uses the **offering fallback** tier (lead.offering → major) so the
+seed stays light — no admission_path / method / criteria / subject-group chain.
+The deep multi-NV resolver tiers are covered by the pure unit tests.
+
+Each test uses a UNIQUE academic_year so a ``report(year)`` call never sees another
+test's rows (the shared test DB is not rolled back per-test).
+"""
+
+import itertools
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.repositories.admission_report_repository import (
+    UNRESOLVED,
+    AdmissionReportRepository,
+)
+from app.services.admission_report_service import VN_TZ, AdmissionReportService
+from app.utils.exceptions import BusinessRuleViolation, ValidationError
+
+pytestmark = pytest.mark.asyncio
+
+_seq = itertools.count(1)
+_year_seq = itertools.count(2050)
+
+
+def _admin() -> models.User:
+    return models.User(role="admin", unit_id=None)
+
+
+async def _seed_catalog(db: AsyncSession, year: int, unit_id: int):
+    n = next(_seq)
+    major = models.MajorProgram(
+        name=f"Ngành {n}", code=f"RPT{n:05d}", degree_level="Cao đẳng", unit_id=unit_id
+    )
+    db.add(major)
+    await db.flush()
+    offering = models.ProgramOffering(offering_type="Chính quy", program_id=major.id)
+    db.add(offering)
+    await db.flush()
+    db.add(models.OfferingAcademicInfo(academic_year=year, offering_id=offering.id))
+    db.add(
+        models.OfferingAdmissionRound(
+            academic_year=year,
+            round_code="DOT_TEST",
+            round_name="Đợt test",
+            start_date=date(year, 1, 1),
+            end_date=date(year, 12, 31),
+            is_active=True,
+        )
+    )
+    await db.flush()
+    return major, offering
+
+
+async def _seed_lead_profile(
+    db, deps, year, offering_id, officer_id, *, created_at, deleted=False, unit_id=None
+):
+    n = next(_seq)
+    lead = models.Lead(
+        full_name=f"RPT Lead {n}",
+        phone=f"08{n:08d}",
+        email=f"rpt_{n}@t.com",
+        source="website",
+        unit_id=unit_id or deps["unit_id"],
+        consultation_status_id=deps["initial_status_id"],
+        status="new",
+        offering_id=offering_id,
+        assigned_officer_id=officer_id,
+        created_at=created_at,
+        deleted_at=datetime.now(timezone.utc) if deleted else None,
+    )
+    db.add(lead)
+    await db.flush()
+    profile = models.AdmissionProfile(
+        lead_id=lead.id,
+        status="submitted",
+        citizen_id=f"{n:012d}",
+        version=1,
+        applied_rules={},
+        academic_year=year,
+        uses_choice_engine=False,
+    )
+    db.add(profile)
+    await db.flush()
+    return lead, profile
+
+
+async def _seed_history(db, profile_id, to_status, occurred_at, from_status="draft"):
+    db.add(
+        models.AdmissionProfileStatusHistory(
+            profile_id=profile_id,
+            from_status=from_status,
+            to_status=to_status,
+            occurred_at=occurred_at,
+            transitioned_by_role="system",
+            actor_actual_role="system",
+            effective_transition_role="system",
+        )
+    )
+    await db.flush()
+
+
+async def _seed_fee(db, profile_id, year, fee_type="application"):
+    fee = models.Fee(
+        admission_profile_id=profile_id,
+        fee_type=fee_type,
+        academic_year=year,
+        base_amount=Decimal("1000000"),
+        final_amount=Decimal("1000000"),
+        semester_no=(1 if fee_type == "tuition" else None),
+        calculated_at=datetime.now(timezone.utc),
+    )
+    db.add(fee)
+    await db.flush()
+    return fee
+
+
+async def _add_txn(db, fee_id, ttype, amount, created_at):
+    db.add(
+        models.PaymentTransaction(
+            fee_id=fee_id,
+            transaction_type=ttype,
+            amount=Decimal(amount),
+            balance_before=Decimal("0"),
+            balance_after=Decimal("0"),
+            created_at=created_at,
+        )
+    )
+    await db.flush()
+
+
+def _week(year: int):
+    anchor = date(year, 6, 17)
+    _, win = AdmissionReportService._compute_week(anchor)
+    return anchor, win
+
+
+def _find(rows, key):
+    return next((r for r in rows if r.group_key == key), None)
+
+
+async def test_weekly_report_major_end_to_end(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+
+    major, offering = await _seed_catalog(db, year, unit_id)
+    _, profile = await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=win.start + timedelta(days=2),
+    )
+    await _seed_history(db, profile.id, "submitted", win.start + timedelta(days=2))
+    fee = await _seed_fee(db, profile.id, year)
+    await _add_txn(db, fee.id, "payment", "1000000", win.start + timedelta(days=3))
+    await _add_txn(db, fee.id, "refund", "-200000", win.start + timedelta(days=3))
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+
+    row = _find(resp.rows, major.id)
+    assert row is not None, "major row must be present"
+    assert row.lead.new_in_week == 1
+    assert row.admission.submitted_in_week == 1
+    assert row.admission.submitted_cumulative == 1
+    assert row.finance.gross_in_week == Decimal("1000000")
+    assert row.finance.refund_in_week == Decimal("200000")
+    assert row.finance.net_in_week == Decimal("800000")
+    assert row.finance.application_net_in_week == Decimal("800000")
+    assert row.finance.net_cumulative == Decimal("800000")
+    assert row.admission.profiles_total == 1
+    assert row.finance.profiles_paid == 1
+    assert resp.data_quality.total_profiles == 1
+    assert resp.totals.finance.net_in_week == Decimal("800000")
+    assert resp.week.week_start == win.start.date()
+
+
+async def test_soft_deleted_lead_excluded_from_report(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+
+    major, offering = await _seed_catalog(db, year, unit_id)
+    # active
+    _, p_active = await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=win.start + timedelta(days=1),
+    )
+    fee_a = await _seed_fee(db, p_active.id, year)
+    await _add_txn(db, fee_a.id, "payment", "1000000", win.start + timedelta(days=1))
+    # soft-deleted lead — must contribute nothing
+    _, p_del = await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=win.start + timedelta(days=1),
+        deleted=True,
+    )
+    fee_d = await _seed_fee(db, p_del.id, year)
+    await _add_txn(db, fee_d.id, "payment", "5000000", win.start + timedelta(days=1))
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+    row = _find(resp.rows, major.id)
+    assert row is not None
+    assert row.lead.new_in_week == 1, "deleted lead must not be counted"
+    assert row.finance.gross_in_week == Decimal(
+        "1000000"
+    ), "deleted lead's 5M must be excluded"
+
+
+async def test_group_by_officer(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+
+    _, offering = await _seed_catalog(db, year, unit_id)
+    _, profile = await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=win.start + timedelta(days=2),
+    )
+    await _seed_history(db, profile.id, "submitted", win.start + timedelta(days=2))
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="officer", week_start=anchor
+    )
+    row = _find(resp.rows, officer_id)
+    assert row is not None, "officer row must be present"
+    assert row.lead.new_in_week == 1
+    assert row.admission.submitted_in_week == 1
+    assert row.label and not row.is_bucket
+
+
+async def test_lead_without_offering_goes_to_unresolved_bucket(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    anchor, win = _week(year)
+
+    # need a round for the cohort window even though the lead has no offering
+    await _seed_catalog(db, year, unit_id)
+    n = next(_seq)
+    db.add(
+        models.Lead(
+            full_name=f"RPT NoOff {n}",
+            phone=f"08{n:08d}",
+            email=f"rptno_{n}@t.com",
+            source="website",
+            unit_id=unit_id,
+            consultation_status_id=seeded_dependencies["initial_status_id"],
+            status="new",
+            offering_id=None,
+            created_at=win.start + timedelta(days=2),
+        )
+    )
+    await db.flush()
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+    bucket = next((r for r in resp.rows if r.bucket_kind == UNRESOLVED), None)
+    assert (
+        bucket is not None
+    ), "lead without offering must land in the unresolved bucket"
+    assert bucket.is_bucket and bucket.lead.new_in_week >= 1
+
+
+async def test_payment_before_week_counts_cumulative_not_in_week(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+
+    major, offering = await _seed_catalog(db, year, unit_id)
+    _, profile = await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=win.start + timedelta(days=1),
+    )
+    fee = await _seed_fee(db, profile.id, year)
+    # payment 10 days BEFORE the week → cumulative only
+    await _add_txn(db, fee.id, "payment", "300000", win.start - timedelta(days=10))
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+    row = _find(resp.rows, major.id)
+    assert row is not None
+    assert row.finance.net_in_week == Decimal("0")
+    assert row.finance.net_cumulative == Decimal("300000")
+
+
+async def _seed_consult_status(
+    db, *, outcome="positive", phase="consultation", is_final=False
+):
+    n = next(_seq)
+    cs = models.ConsultationStatus(
+        id=f"rptcs{n}",
+        name=f"CS {n}",
+        color_code="#00AA00",
+        phase=phase,
+        outcome_type=models.OutcomeTypeEnum(outcome),
+        is_final=is_final,
+    )
+    db.add(cs)
+    await db.flush()
+    return cs.id
+
+
+async def test_consulting_positive_stock(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    anchor, win = _week(year)
+    major, offering = await _seed_catalog(db, year, unit_id)
+    cs_id = await _seed_consult_status(db)  # phase=consultation, outcome=positive
+    n = next(_seq)
+    db.add(
+        models.Lead(
+            full_name=f"RPT CP {n}",
+            phone=f"08{n:08d}",
+            email=f"rptcp_{n}@t.com",
+            source="website",
+            unit_id=unit_id,
+            consultation_status_id=cs_id,
+            status="new",
+            offering_id=offering.id,
+            created_at=win.start + timedelta(days=2),
+        )
+    )
+    await db.flush()
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+    row = _find(resp.rows, major.id)
+    assert row is not None
+    assert row.lead.consulting_positive_current == 1
+    assert row.lead.active_current == 1  # not final
+
+
+async def test_admission_first_transition_not_double_counted(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    _, win_a = _week(year)
+    major, offering = await _seed_catalog(db, year, unit_id)
+    _, profile = await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=win_a.start + timedelta(days=1),
+    )
+    await _seed_history(db, profile.id, "submitted", win_a.start + timedelta(days=1))
+    await _seed_history(db, profile.id, "resubmitted", win_a.start + timedelta(days=40))
+
+    later_anchor = (win_a.start + timedelta(days=40)).date()
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(),
+        academic_year=year,
+        group_by="major",
+        week_start=later_anchor,
+    )
+    row = _find(resp.rows, major.id)
+    assert row is not None
+    assert row.admission.submitted_in_week == 0  # first transition was in week A
+    assert row.admission.submitted_cumulative == 1
+
+
+async def test_cohort_overlapping_rounds_dedup_lead(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+    major, offering = await _seed_catalog(db, year, unit_id)
+    db.add(
+        models.OfferingAdmissionRound(
+            academic_year=year,
+            round_code="DOT_TEST2",
+            round_name="Đợt 2",
+            start_date=date(year, 1, 1),
+            end_date=date(year, 12, 31),
+            is_active=True,
+        )
+    )
+    await db.flush()
+    await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=win.start + timedelta(days=2),
+    )
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+    row = _find(resp.rows, major.id)
+    assert row is not None
+    assert row.lead.new_in_week == 1  # not 2 despite overlapping round windows
+
+
+async def test_round_missing_dates_fails_closed(
+    db: AsyncSession, seeded_dependencies: dict
+):
+    year = next(_year_seq)
+    db.add(
+        models.OfferingAdmissionRound(
+            academic_year=year,
+            round_code="DOT_BAD",
+            round_name="Bad",
+            start_date=None,
+            end_date=None,
+            is_active=True,
+        )
+    )
+    await db.flush()
+    svc = AdmissionReportService(db)
+    with pytest.raises(BusinessRuleViolation):
+        await svc.get_weekly_report(
+            current_user=_admin(),
+            academic_year=year,
+            group_by="major",
+            round_code="DOT_BAD",
+            week_start=date(year, 6, 17),  # in-year week → reaches cohort validation
+        )
+
+
+async def test_round_filter_keeps_unresolved_profile_bucket(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    anchor, win = _week(year)
+    await _seed_catalog(db, year, unit_id)  # seeds round DOT_TEST with valid dates
+    n = next(_seq)
+    lead = models.Lead(
+        full_name=f"RPT UR {n}",
+        phone=f"08{n:08d}",
+        email=f"rptur_{n}@t.com",
+        source="website",
+        unit_id=unit_id,
+        consultation_status_id=seeded_dependencies["initial_status_id"],
+        status="new",
+        offering_id=None,
+        created_at=win.start + timedelta(days=2),
+    )
+    db.add(lead)
+    await db.flush()
+    db.add(
+        models.AdmissionProfile(
+            lead_id=lead.id,
+            status="submitted",
+            citizen_id=f"{n:012d}",
+            version=1,
+            applied_rules={},
+            academic_year=year,
+            uses_choice_engine=False,
+        )
+    )
+    await db.flush()
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(),
+        academic_year=year,
+        group_by="major",
+        week_start=anchor,
+        round_code="DOT_TEST",
+    )
+    bucket = next((r for r in resp.rows if r.bucket_kind == UNRESOLVED), None)
+    assert bucket is not None, "unresolved profile must survive round filter"
+    assert bucket.admission.profiles_total == 1
+    assert resp.data_quality.unresolved_profiles == 1
+
+
+async def test_funnel_monotone_admitted_without_submitted_history(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    """A profile with only an 'admitted' history row (override bypassed submitted)
+    must still count as submitted — funnel stays monotone (submitted ≥ admitted)."""
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+    major, offering = await _seed_catalog(db, year, unit_id)
+    _, profile = await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=win.start + timedelta(days=1),
+    )
+    await _seed_history(db, profile.id, "admitted", win.start + timedelta(days=2))
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+    row = _find(resp.rows, major.id)
+    assert row is not None
+    assert row.admission.admitted_cumulative == 1
+    assert row.admission.submitted_cumulative == 1  # derived (monotone)
+    assert row.admission.submitted_in_week >= row.admission.admitted_in_week
+
+
+async def test_walk_in_lead_outside_window_aligned_via_profile(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    """A lead created OUTSIDE the round window but holding an in-scope profile is
+    still part of the lead population (admission never exceeds lead)."""
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+    major, offering = await _seed_catalog(db, year, unit_id)
+    _, profile = await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=datetime(year - 1, 3, 1, tzinfo=VN_TZ),  # before the round window
+    )
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+    row = _find(resp.rows, major.id)
+    assert row is not None
+    assert row.admission.profiles_total == 1
+    assert row.lead.active_current == 1  # included despite created outside window
+    assert row.lead.new_in_week == 0  # but NOT a "new this week" lead
+
+
+async def test_week_start_before_academic_year_rejected(
+    db: AsyncSession, seeded_dependencies: dict
+):
+    year = next(_year_seq)
+    svc = AdmissionReportService(db)
+    with pytest.raises(ValidationError):
+        await svc.get_weekly_report(
+            current_user=_admin(),
+            academic_year=year,
+            group_by="major",
+            week_start=date(year - 1, 6, 1),
+        )
+
+
+async def test_future_year_implicit_week_defaults_in_year(
+    db: AsyncSession, seeded_dependencies: dict
+):
+    # FUTURE academic year + no week_start: anchor to that year's ISO week 1 instead
+    # of silently returning the current calendar year's week metadata.
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=2200, group_by="major"
+    )
+    assert resp.week.iso_year == 2200
+    assert resp.academic_year == 2200
+
+
+async def test_report_years_include_config_only_year(
+    db: AsyncSession, seeded_dependencies: dict
+):
+    # A year with a round configured but NO profiles must still be listable
+    # (config ∪ data) — unlike the profile-only get_distinct_academic_years.
+    year = next(_year_seq)
+    db.add(
+        models.OfferingAdmissionRound(
+            academic_year=year,
+            round_code="DOT_1",
+            round_name="Đợt 1",
+            start_date=date(year, 1, 1),
+            end_date=date(year, 12, 31),
+            is_active=True,
+        )
+    )
+    await db.flush()
+    repo = AdmissionReportRepository(db)
+    assert year in await repo.list_report_years()
+    assert await repo.list_report_rounds(year) == ["DOT_1"]
+
+
+async def test_synthetic_backfill_row_excluded_from_milestones(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    """A phase1_10 synthetic initial-state row (from_status=None → status @
+    created_at) must NOT be counted as a milestone (it mis-dates legacy events)."""
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+    major, offering = await _seed_catalog(db, year, unit_id)
+    _, profile = await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=win.start + timedelta(days=1),
+    )
+    # synthetic backfill row — from_status=None, mis-dated at the creation week
+    await _seed_history(
+        db, profile.id, "enrolled", win.start + timedelta(days=1), from_status=None
+    )
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+    row = _find(resp.rows, major.id)
+    assert row is not None
+    assert row.admission.profiles_total == 1  # profile still present
+    assert row.admission.enrolled_cumulative == 0  # synthetic row excluded
+    assert row.admission.submitted_cumulative == 0
+
+
+async def test_iso_week1_monday_in_prior_year_not_rejected(
+    db: AsyncSession, seeded_dependencies: dict
+):
+    """ISO week 1's Monday can fall in the prior calendar year; sending that
+    canonical Monday back for the same academic_year must NOT be rejected."""
+    year = next(_year_seq)
+    jan4 = date(year, 1, 4)  # ISO week 1 always contains Jan 4
+    monday_w1 = jan4 - timedelta(days=jan4.isocalendar()[2] - 1)  # Monday of ISO week 1
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(),
+        academic_year=year,
+        group_by="major",
+        week_start=monday_w1,
+    )
+    assert resp.week.iso_year == year
+    assert resp.week.week_start == monday_w1  # refetch-stable, not rejected

--- a/Backend_FastAPI/tests/repositories/test_admission_report_integration.py
+++ b/Backend_FastAPI/tests/repositories/test_admission_report_integration.py
@@ -33,17 +33,33 @@ def _admin() -> models.User:
     return models.User(role="admin", unit_id=None)
 
 
-async def _seed_catalog(db: AsyncSession, year: int, unit_id: int):
+def _manager(unit_id: int) -> models.User:
+    return models.User(role="manager", unit_id=unit_id)
+
+
+async def _seed_catalog(
+    db: AsyncSession, year: int, unit_id: int, *, quota=None, active=True
+):
     n = next(_seq)
     major = models.MajorProgram(
-        name=f"Ngành {n}", code=f"RPT{n:05d}", degree_level="Cao đẳng", unit_id=unit_id
+        name=f"Ngành {n}",
+        code=f"RPT{n:05d}",
+        degree_level="Cao đẳng",
+        unit_id=unit_id,
+        is_active=active,
     )
     db.add(major)
     await db.flush()
-    offering = models.ProgramOffering(offering_type="Chính quy", program_id=major.id)
+    offering = models.ProgramOffering(
+        offering_type="Chính quy", program_id=major.id, is_active=active
+    )
     db.add(offering)
     await db.flush()
-    db.add(models.OfferingAcademicInfo(academic_year=year, offering_id=offering.id))
+    db.add(
+        models.OfferingAcademicInfo(
+            academic_year=year, offering_id=offering.id, annual_admission_quota=quota
+        )
+    )
     db.add(
         models.OfferingAdmissionRound(
             academic_year=year,
@@ -634,6 +650,236 @@ async def test_report_years_include_config_only_year(
     repo = AdmissionReportRepository(db)
     assert year in await repo.list_report_years()
     assert await repo.list_report_rounds(year) == ["DOT_1"]
+
+
+async def test_quota_and_conversion_attached(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+
+    major, offering = await _seed_catalog(db, year, unit_id, quota=100)
+    # 4 submitted; of those 2 admitted (approved); of those 1 enrolled
+    for i in range(4):
+        _, p = await _seed_lead_profile(
+            db,
+            seeded_dependencies,
+            year,
+            offering.id,
+            officer_id,
+            created_at=win.start + timedelta(days=1),
+        )
+        await _seed_history(db, p.id, "submitted", win.start + timedelta(days=1))
+        if i < 2:
+            await _seed_history(
+                db,
+                p.id,
+                "approved",
+                win.start + timedelta(days=2),
+                from_status="submitted",
+            )
+        if i < 1:
+            await _seed_history(
+                db,
+                p.id,
+                "enrolled",
+                win.start + timedelta(days=3),
+                from_status="approved",
+            )
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+    row = _find(resp.rows, major.id)
+    assert row is not None
+    assert row.admission.quota == 100
+    assert row.admission.submitted_cumulative == 4
+    assert row.admission.admitted_cumulative == 2
+    assert row.admission.enrolled_cumulative == 1
+    assert row.conversion.submit_to_admit == 0.5  # 2/4
+    assert row.conversion.admit_to_enroll == 0.5  # 1/2
+    assert resp.totals.admission.quota == 100
+
+
+async def test_quota_none_for_officer_grouping(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+    _, offering = await _seed_catalog(db, year, unit_id, quota=50)
+    _, p = await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=win.start + timedelta(days=1),
+    )
+    await _seed_history(db, p.id, "submitted", win.start + timedelta(days=1))
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(),
+        academic_year=year,
+        group_by="officer",
+        week_start=anchor,
+    )
+    # officer grouping never carries a major quota
+    assert all(r.admission.quota is None for r in resp.rows)
+    assert resp.totals.admission.quota is None
+
+
+async def test_quota_major_with_no_activity_appears(
+    db: AsyncSession, seeded_dependencies: dict
+):
+    # A major with a quota but ZERO leads/profiles MUST still appear (0%, top of
+    # the cockpit) — it is exactly the behind-target ngành a manager needs to see.
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    major, _ = await _seed_catalog(db, year, unit_id, quota=120)
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(),
+        academic_year=year,
+        group_by="major",
+        week_start=date(year, 6, 17),
+    )
+    row = _find(resp.rows, major.id)
+    assert row is not None, "quota major with no activity must not vanish"
+    assert row.admission.quota == 120
+    assert row.admission.submitted_cumulative == 0
+    assert row.admission.profiles_total == 0
+    assert resp.totals.admission.quota == 120
+
+
+async def test_quota_hidden_when_round_filtered(
+    db: AsyncSession, seeded_dependencies: dict
+):
+    # Year quota as the denominator only makes sense across the whole year. When a
+    # single đợt is filtered, quota is omitted (FE then hides the progress).
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    major, _ = await _seed_catalog(db, year, unit_id, quota=80)
+    svc = AdmissionReportService(db)
+    full = await svc.get_weekly_report(
+        current_user=_admin(),
+        academic_year=year,
+        group_by="major",
+        week_start=date(year, 6, 17),
+    )
+    assert full.totals.admission.quota == 80
+    assert _find(full.rows, major.id) is not None
+    filtered = await svc.get_weekly_report(
+        current_user=_admin(),
+        academic_year=year,
+        group_by="major",
+        week_start=date(year, 6, 17),
+        round_code="DOT_TEST",
+    )
+    assert filtered.totals.admission.quota is None
+    assert all(r.admission.quota is None for r in filtered.rows)
+
+
+async def test_quota_admin_only_hidden_for_unit_scope(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    # Quota is a whole-school per-offering target → shown to admin (scope toàn
+    # trường) but hidden for a unit-scoped manager (no per-unit quota split).
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+    major, offering = await _seed_catalog(db, year, unit_id, quota=100)
+    _, p = await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        year,
+        offering.id,
+        officer_id,
+        created_at=win.start + timedelta(days=1),
+    )
+    await _seed_history(db, p.id, "submitted", win.start + timedelta(days=1))
+    svc = AdmissionReportService(db)
+    admin_resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+    assert _find(admin_resp.rows, major.id).admission.quota == 100
+    mgr_resp = await svc.get_weekly_report(
+        current_user=_manager(unit_id),
+        academic_year=year,
+        group_by="major",
+        week_start=anchor,
+    )
+    row = _find(mgr_resp.rows, major.id)
+    assert row is not None  # manager has the activity
+    assert row.admission.quota is None  # whole-school metric hidden for unit scope
+    assert mgr_resp.totals.admission.quota is None
+
+
+async def test_quota_excludes_archived_major(
+    db: AsyncSession, seeded_dependencies: dict
+):
+    # An archived (is_active=False) major must not surface a live quota row.
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    await _seed_catalog(db, year, unit_id, quota=100, active=False)
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(),
+        academic_year=year,
+        group_by="major",
+        week_start=date(year, 6, 17),
+    )
+    assert resp.totals.admission.quota is None
+    assert resp.rows == []
+
+
+async def test_past_year_implicit_week_defaults_in_year(
+    db: AsyncSession, seeded_dependencies: dict
+):
+    # Past year + no week_start → anchor inside that year (last ISO week), not
+    # today's week (which would compute week/cumulative cutoffs outside the year).
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=2020, group_by="major"
+    )
+    assert resp.week.iso_year == 2020
+    assert resp.academic_year == 2020
+
+
+async def test_report_years_include_live_profile_only_year(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    # A year with a LIVE-lead profile but no config IS selectable; a year that
+    # exists only via a soft-deleted lead is NOT.
+    live_year = next(_year_seq)
+    del_year = next(_year_seq)
+    officer_id = officer_user_in_db["id"]
+    await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        live_year,
+        None,
+        officer_id,
+        created_at=datetime(live_year, 6, 1, tzinfo=timezone.utc),
+    )
+    await _seed_lead_profile(
+        db,
+        seeded_dependencies,
+        del_year,
+        None,
+        officer_id,
+        created_at=datetime(del_year, 6, 1, tzinfo=timezone.utc),
+        deleted=True,
+    )
+    repo = AdmissionReportRepository(db)
+    years = await repo.list_report_years()
+    assert live_year in years
+    assert del_year not in years
 
 
 async def test_synthetic_backfill_row_excluded_from_milestones(

--- a/Backend_FastAPI/tests/unit/test_admission_report_helpers.py
+++ b/Backend_FastAPI/tests/unit/test_admission_report_helpers.py
@@ -1,0 +1,164 @@
+"""Pure-logic unit tests for the weekly admission report (no DB).
+
+Covers the trickiest, DB-free logic: the 5-tier major resolver (+ ambiguous/
+unresolved buckets), ISO-week computation (VN), admin/manager scope, and totals.
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.repositories.admission_report_repository import (
+    AMBIGUOUS,
+    UNRESOLVED,
+    AdmissionReportRepository,
+    MajorInfo,
+)
+from app.schemas.admission_report import ReportRow
+from app.services.admission_report_service import VN_TZ, AdmissionReportService
+from app.utils.exceptions import PermissionDeniedError, ResourceNotFoundError
+
+# path_id -> (MajorInfo, round_code)
+_PATHS = {
+    10: (MajorInfo(major_id=1, code="A", name="Ngành A", degree_level="CĐ"), "DOT_1"),
+    20: (MajorInfo(major_id=2, code="B", name="Ngành B", degree_level="CĐ"), "DOT_2"),
+}
+# offering_id -> MajorInfo
+_OFFERINGS = {100: MajorInfo(major_id=3, code="C", name="Ngành C", degree_level="TC")}
+
+_R = AdmissionReportRepository._resolve_one
+
+
+# --------------------------------------------------------------- resolver tiers
+def test_resolver_single_admitted_wins():
+    choices = {1: [(10, "admitted", 2), (20, "pending", 1)]}
+    key, info, rnd = _R(1, None, None, choices, _PATHS, _OFFERINGS)
+    assert key == 1 and info.code == "A" and rnd == "DOT_1"
+
+
+def test_resolver_multiple_admitted_is_ambiguous():
+    choices = {1: [(10, "admitted", 1), (20, "admitted", 2)]}
+    key, info, rnd = _R(1, None, None, choices, _PATHS, _OFFERINGS)
+    assert key == AMBIGUOUS and info is None and rnd is None
+
+
+def test_resolver_nv1_when_no_admitted():
+    # display_order 1 = NV1 → path 10, regardless of list order
+    choices = {1: [(20, "pending", 2), (10, "pending", 1)]}
+    key, info, rnd = _R(1, None, None, choices, _PATHS, _OFFERINGS)
+    assert key == 1 and rnd == "DOT_1"
+
+
+def test_resolver_legacy_applied_rules():
+    key, info, rnd = _R(1, {"admission_path_id": 20}, None, {}, _PATHS, _OFFERINGS)
+    assert key == 2 and rnd == "DOT_2"
+
+
+def test_resolver_offering_fallback():
+    key, info, rnd = _R(1, None, 100, {}, _PATHS, _OFFERINGS)
+    assert key == 3 and info.code == "C" and rnd is None
+
+
+def test_resolver_unresolved_when_nothing():
+    key, info, rnd = _R(1, None, None, {}, _PATHS, _OFFERINGS)
+    assert key == UNRESOLVED and info is None
+
+
+def test_resolver_unknown_path_is_unresolved():
+    choices = {1: [(999, "admitted", 1)]}
+    key, info, rnd = _R(1, None, None, choices, _PATHS, _OFFERINGS)
+    assert key == UNRESOLVED
+
+
+def test_resolver_broken_choice_falls_through_to_legacy():
+    # NV1 path is broken (unknown) but legacy applied_rules path is valid → legacy.
+    choices = {1: [(999, "pending", 1)]}
+    key, info, rnd = _R(1, {"admission_path_id": 20}, None, choices, _PATHS, _OFFERINGS)
+    assert key == 2 and rnd == "DOT_2"
+
+
+def test_resolver_broken_choice_falls_through_to_offering():
+    # NV1 path broken, no legacy → fall through to lead.offering (not unresolved).
+    choices = {1: [(999, "pending", 1)]}
+    key, info, rnd = _R(1, None, 100, choices, _PATHS, _OFFERINGS)
+    assert key == 3 and info.code == "C"
+
+
+def test_resolver_non_dict_applied_rules_does_not_crash():
+    # legacy/imported applied_rules can be a non-dict JSONB (list/str) → must not
+    # raise AttributeError; just skip the legacy tier.
+    key, info, rnd = _R(1, ["junk"], 100, {}, _PATHS, _OFFERINGS)
+    assert key == 3  # falls through to offering
+    assert _R(1, "weird", None, {}, _PATHS, _OFFERINGS)[0] == UNRESOLVED
+
+
+# ------------------------------------------------------------------- ISO week
+def test_compute_week_midweek_anchors_to_monday_sunday():
+    meta, win = AdmissionReportService._compute_week(date(2026, 6, 17))  # Wednesday
+    assert meta.week_start == date(2026, 6, 15)  # Monday
+    assert meta.week_end == date(2026, 6, 21)  # Sunday
+    assert win.start == datetime(2026, 6, 15, tzinfo=VN_TZ)
+    assert win.end_excl == datetime(2026, 6, 22, tzinfo=VN_TZ)  # half-open
+    iso = date(2026, 6, 17).isocalendar()
+    assert meta.iso_year == iso[0] and meta.iso_week == iso[1]
+
+
+def test_compute_week_sunday_stays_in_same_week():
+    meta, _ = AdmissionReportService._compute_week(date(2026, 6, 21))  # Sunday
+    assert meta.week_start == date(2026, 6, 15) and meta.week_end == date(2026, 6, 21)
+
+
+def test_compute_week_monday_boundary():
+    meta, win = AdmissionReportService._compute_week(date(2026, 6, 15))  # Monday
+    assert meta.week_start == date(2026, 6, 15)
+    assert win.end_excl == datetime(2026, 6, 22, tzinfo=VN_TZ)
+
+
+# ---------------------------------------------------------------------- scope
+class _FakeUser:
+    def __init__(self, role: str, unit_id):
+        self.role = role
+        self.unit_id = unit_id
+
+
+_S = AdmissionReportService._resolve_scope
+
+
+def test_scope_admin_all_units():
+    assert _S(_FakeUser("admin", None), None) is None
+
+
+def test_scope_admin_can_choose_unit():
+    assert _S(_FakeUser("admin", 1), 7) == 7
+
+
+def test_scope_manager_forced_to_own_unit():
+    assert _S(_FakeUser("manager", 5), None) == 5
+
+
+def test_scope_manager_no_unit_fails_closed():
+    with pytest.raises(PermissionDeniedError):
+        _S(_FakeUser("manager", None), None)
+
+
+def test_scope_manager_other_unit_is_404():
+    with pytest.raises(ResourceNotFoundError):
+        _S(_FakeUser("manager", 5), 9)
+
+
+def test_scope_manager_own_unit_ok():
+    assert _S(_FakeUser("manager", 5), 5) == 5
+
+
+# --------------------------------------------------------------------- totals
+def test_totals_sum_rows():
+    r1 = ReportRow(label="x")
+    r2 = ReportRow(label="y")
+    r1.lead.new_in_week, r2.lead.new_in_week = 3, 4
+    r1.admission.submitted_in_week, r2.admission.submitted_in_week = 1, 2
+    r1.finance.net_in_week, r2.finance.net_in_week = Decimal("100"), Decimal("250.50")
+    t = AdmissionReportService._totals([r1, r2])
+    assert t.lead.new_in_week == 7
+    assert t.admission.submitted_in_week == 3
+    assert t.finance.net_in_week == Decimal("350.50")

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/AdmissionsWeeklyClient.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/AdmissionsWeeklyClient.tsx
@@ -18,6 +18,8 @@ import { cn } from "@/lib/utils";
 import { subDaysVN } from "@/lib/utils/vn-date";
 import type { ReportGroupBy } from "@/lib/zod/reports";
 
+import { rankByQuotaGap } from "./cockpit-rank";
+import { SummaryBand } from "./SummaryBand";
 import { WeeklyReportTable, type Period } from "./WeeklyReportTable";
 
 const CURRENT_YEAR = new Date().getFullYear();
@@ -38,7 +40,7 @@ export function AdmissionsWeeklyClient() {
   const [year, setYear] = React.useState(CURRENT_YEAR);
   const [round, setRound] = React.useState<string>(ALL_ROUNDS);
   const [groupBy, setGroupBy] = React.useState<ReportGroupBy>("major");
-  const [period, setPeriod] = React.useState<Period>("week");
+  const [period, setPeriod] = React.useState<Period>("ytd");
   const [weekStart, setWeekStart] = React.useState<string | undefined>(undefined);
 
   // Filter options (năm config ∪ data + đợt) — admin & manager, same gate as report.
@@ -68,6 +70,14 @@ export function AdmissionsWeeklyClient() {
   // placeholder lag); fall back to the synced response's week.
   const navAnchor = weekStart ?? week?.week_start;
 
+  // Cockpit (lũy kế + ngành): rank by % chỉ tiêu ascending so the most-behind
+  // ngành surface first; buckets and no-target ngành sink to the bottom.
+  const cockpitRows = React.useMemo(() => {
+    if (!synced) return [];
+    if (period !== "ytd" || groupBy !== "major") return synced.rows;
+    return rankByQuotaGap(synced.rows);
+  }, [synced, period, groupBy]);
+
   const onYearChange = (next: number) => {
     setYear(next);
     // dependent filters may be invalid for the new year → reset both.
@@ -92,7 +102,7 @@ export function AdmissionsWeeklyClient() {
           <div className="space-y-1">
             <label className="text-xs text-muted-foreground">Năm</label>
             <Select value={year.toString()} onValueChange={(v) => onYearChange(Number(v))}>
-              <SelectTrigger className="w-24">
+              <SelectTrigger className="w-24" aria-label="Năm">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -107,7 +117,7 @@ export function AdmissionsWeeklyClient() {
           <div className="space-y-1">
             <label className="text-xs text-muted-foreground">Đợt</label>
             <Select value={round} onValueChange={setRound}>
-              <SelectTrigger className="w-32">
+              <SelectTrigger className="w-32" aria-label="Đợt">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -192,14 +202,36 @@ export function AdmissionsWeeklyClient() {
           ))}
         </div>
       ) : (
-        <div className={cn("space-y-3", isFetching && "opacity-60 transition-opacity")}>
-          <WeeklyReportTable
+        <div className={cn("space-y-4", isFetching && "opacity-60 transition-opacity")}>
+          <SummaryBand
             rows={synced.rows}
+            totals={synced.totals}
+            groupBy={synced.group_by}
+          />
+          <WeeklyReportTable
+            rows={cockpitRows}
             totals={synced.totals}
             groupBy={synced.group_by}
             period={period}
           />
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            {period === "ytd" && groupBy === "major" && round === ALL_ROUNDS && (
+              <span className="flex items-center gap-2">
+                Chỉ tiêu:
+                <span className="flex items-center gap-1">
+                  <span className="size-2 rounded-full bg-rose-500" />&lt;50%
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="size-2 rounded-full bg-amber-500" />50–90%
+                </span>
+                <span className="flex items-center gap-1">
+                  <span className="size-2 rounded-full bg-emerald-500" />≥90%
+                </span>
+              </span>
+            )}
+            {period === "ytd" && groupBy === "major" && round !== ALL_ROUNDS && (
+              <span>Đang lọc đợt — tiến độ chỉ tiêu (theo cả năm) tạm ẩn.</span>
+            )}
             <span>
               Số liệu tính lại theo phân bổ hiện tại — tuần đã qua có thể đổi sau khi
               công bố kết quả.

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/AdmissionsWeeklyClient.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/AdmissionsWeeklyClient.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import * as React from "react";
+import { BarChart3, ChevronLeft, ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useReportFilters, useWeeklyReport } from "@/hooks/reports/useWeeklyReport";
+import { cn } from "@/lib/utils";
+import { subDaysVN } from "@/lib/utils/vn-date";
+import type { ReportGroupBy } from "@/lib/zod/reports";
+
+import { WeeklyReportTable, type Period } from "./WeeklyReportTable";
+
+const CURRENT_YEAR = new Date().getFullYear();
+const ALL_ROUNDS = "__all__";
+
+const dm = (s: string) => `${s.slice(8, 10)}/${s.slice(5, 7)}`;
+
+/** Friendly message instead of dumping a raw AxiosError / ZodError. */
+function errMessage(err: unknown): string {
+  const status = (err as { response?: { status?: number } })?.response?.status;
+  if (status === 403) return "Bạn không có quyền xem báo cáo này.";
+  if (status === 404) return "Không tìm thấy đơn vị/đợt đã chọn.";
+  if (status === 400 || status === 422) return "Tham số không hợp lệ (năm/tuần/đợt).";
+  return "Không tải được báo cáo. Vui lòng thử lại.";
+}
+
+export function AdmissionsWeeklyClient() {
+  const [year, setYear] = React.useState(CURRENT_YEAR);
+  const [round, setRound] = React.useState<string>(ALL_ROUNDS);
+  const [groupBy, setGroupBy] = React.useState<ReportGroupBy>("major");
+  const [period, setPeriod] = React.useState<Period>("week");
+  const [weekStart, setWeekStart] = React.useState<string | undefined>(undefined);
+
+  // Filter options (năm config ∪ data + đợt) — admin & manager, same gate as report.
+  const { data: filters } = useReportFilters(year);
+  const yearOptions = React.useMemo(
+    () =>
+      Array.from(
+        new Set([...(filters?.academic_years ?? []), CURRENT_YEAR]),
+      ).sort((a, b) => b - a),
+    [filters],
+  );
+  const roundCodes = filters?.rounds ?? [];
+
+  const { data, isLoading, isError, error, isFetching } = useWeeklyReport({
+    academic_year: year,
+    group_by: groupBy,
+    round_code: round === ALL_ROUNDS ? undefined : round,
+    week_start: weekStart,
+  });
+
+  // Trust the response only once it matches the selected year: placeholderData
+  // keeps the PREVIOUS year's payload during a switch, and navigating off its
+  // stale week could POST a week the new academic_year rejects (422).
+  const synced = data && data.academic_year === year ? data : undefined;
+  const week = synced?.week;
+  // Anchor prev/next on the locally-chosen week (rapid clicks aren't swallowed by
+  // placeholder lag); fall back to the synced response's week.
+  const navAnchor = weekStart ?? week?.week_start;
+
+  const onYearChange = (next: number) => {
+    setYear(next);
+    // dependent filters may be invalid for the new year → reset both.
+    setWeekStart(undefined);
+    setRound(ALL_ROUNDS);
+  };
+
+  return (
+    <div className="flex h-full flex-col space-y-5 p-4 sm:p-6">
+      {/* Header + filters */}
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-bold">
+            <BarChart3 className="size-6 text-primary" /> Báo cáo tuyển sinh
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Phễu lead → hồ sơ → tài chính theo{" "}
+            {groupBy === "major" ? "ngành" : "cán bộ"}, theo tuần &amp; lũy kế.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">Năm</label>
+            <Select value={year.toString()} onValueChange={(v) => onYearChange(Number(v))}>
+              <SelectTrigger className="w-24">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {yearOptions.map((y) => (
+                  <SelectItem key={y} value={y.toString()}>
+                    {y}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">Đợt</label>
+            <Select value={round} onValueChange={setRound}>
+              <SelectTrigger className="w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_ROUNDS}>Tất cả đợt</SelectItem>
+                {roundCodes.map((rc) => (
+                  <SelectItem key={rc} value={rc}>
+                    {rc}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">Tuần</label>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="icon"
+                aria-label="Tuần trước"
+                disabled={!navAnchor}
+                onClick={() => navAnchor && setWeekStart(subDaysVN(navAnchor, 7))}
+              >
+                <ChevronLeft />
+              </Button>
+              <div className="min-w-[140px] rounded-md border px-3 py-1.5 text-center text-sm">
+                {week ? (
+                  <>
+                    <span className="font-medium">Tuần {week.iso_week}</span>
+                    <span className="block text-xs text-muted-foreground">
+                      {dm(week.week_start)} – {dm(week.week_end)}
+                    </span>
+                  </>
+                ) : (
+                  <Skeleton className="h-8 w-full" />
+                )}
+              </div>
+              <Button
+                variant="outline"
+                size="icon"
+                aria-label="Tuần sau"
+                disabled={!navAnchor}
+                onClick={() => navAnchor && setWeekStart(subDaysVN(navAnchor, -7))}
+              >
+                <ChevronRight />
+              </Button>
+              {weekStart && (
+                <Button variant="ghost" size="sm" onClick={() => setWeekStart(undefined)}>
+                  Tuần này
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Toggles */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Tabs value={groupBy} onValueChange={(v) => setGroupBy(v as ReportGroupBy)}>
+          <TabsList>
+            <TabsTrigger value="major">Theo ngành</TabsTrigger>
+            <TabsTrigger value="officer">Theo nhân viên</TabsTrigger>
+          </TabsList>
+        </Tabs>
+        <Tabs value={period} onValueChange={(v) => setPeriod(v as Period)}>
+          <TabsList>
+            <TabsTrigger value="week">Tuần này</TabsTrigger>
+            <TabsTrigger value="ytd">Lũy kế năm</TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {/* Body */}
+      {isError ? (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+          {errMessage(error)}
+        </div>
+      ) : isLoading || !synced ? (
+        <div className="space-y-2">
+          <Skeleton className="h-10 w-full" />
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      ) : (
+        <div className={cn("space-y-3", isFetching && "opacity-60 transition-opacity")}>
+          <WeeklyReportTable
+            rows={synced.rows}
+            totals={synced.totals}
+            groupBy={synced.group_by}
+            period={period}
+          />
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            <span>
+              Số liệu tính lại theo phân bổ hiện tại — tuần đã qua có thể đổi sau khi
+              công bố kết quả.
+            </span>
+            {synced.data_quality.ambiguous_profiles > 0 && (
+              <span>· Nhiều NV trúng: {synced.data_quality.ambiguous_profiles}</span>
+            )}
+            {synced.data_quality.unresolved_profiles > 0 && (
+              <span>· Chưa phân loại ngành: {synced.data_quality.unresolved_profiles}</span>
+            )}
+            {groupBy === "officer" && synced.data_quality.unassigned_profiles > 0 && (
+              <span>· Chưa gán cán bộ: {synced.data_quality.unassigned_profiles}</span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/SummaryBand.test.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/SummaryBand.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { ReportRow } from "@/lib/zod/reports";
+
+import { SummaryBand } from "./SummaryBand";
+
+function mkRow(o: {
+  label?: string;
+  quota?: number | null;
+  enrolled?: number;
+  admitted?: number;
+  submitted?: number;
+  active?: number;
+  netCum?: string;
+}): ReportRow {
+  return {
+    group_key: 1,
+    label: o.label ?? "Ngành",
+    code: null,
+    degree_level: null,
+    is_bucket: false,
+    bucket_kind: null,
+    lead: {
+      new_in_week: 0,
+      active_current: o.active ?? 0,
+      consulting_positive_current: 0,
+    },
+    admission: {
+      profiles_total: 0,
+      submitted_in_week: 0,
+      admitted_in_week: 0,
+      enrolled_in_week: 0,
+      submitted_cumulative: o.submitted ?? 0,
+      admitted_cumulative: o.admitted ?? 0,
+      enrolled_cumulative: o.enrolled ?? 0,
+      quota: o.quota ?? null,
+    },
+    conversion: { submit_to_admit: null, admit_to_enroll: null },
+    finance: {
+      gross_in_week: "0",
+      refund_in_week: "0",
+      net_in_week: "0",
+      application_net_in_week: "0",
+      tuition_net_in_week: "0",
+      net_cumulative: o.netCum ?? "0",
+      profiles_paid: 0,
+    },
+  };
+}
+
+describe("SummaryBand", () => {
+  it("major + quota → Nhập học/Chỉ tiêu, Đã thu money, ngành đạt count", () => {
+    const rows = [
+      mkRow({ label: "A", quota: 100, enrolled: 95 }), // 95% → đạt
+      mkRow({ label: "B", quota: 100, enrolled: 40 }),
+      mkRow({ label: "C", quota: 100, enrolled: 10 }),
+    ];
+    const totals = mkRow({
+      quota: 300,
+      enrolled: 145,
+      admitted: 280,
+      active: 700,
+      netCum: "6260000",
+    });
+    render(<SummaryBand rows={rows} totals={totals} groupBy="major" />);
+    expect(screen.getByText("Nhập học / Chỉ tiêu")).toBeTruthy();
+    expect(screen.getByText("6.260.000 ₫")).toBeTruthy(); // Đã thu (money string)
+    expect(screen.getByText("/ 3 ngành có chỉ tiêu")).toBeTruthy();
+    // scope the count to its own card so it can't collide with other numbers
+    const card = screen.getByText("Ngành đạt ≥90%").parentElement as HTMLElement;
+    expect(within(card).getByText("1")).toBeTruthy(); // exactly 1 ngành ≥90%
+  });
+
+  it("officer (no quota) → count fallback cards", () => {
+    const totals = mkRow({ quota: null, enrolled: 50, submitted: 120, active: 300 });
+    render(<SummaryBand rows={[]} totals={totals} groupBy="officer" />);
+    expect(screen.queryByText("Nhập học / Chỉ tiêu")).toBeNull();
+    expect(screen.getByText("Nhập học")).toBeTruthy();
+    expect(screen.getByText("Hồ sơ nộp")).toBeTruthy();
+  });
+
+  it("quota=0 totals → treated as no quota (count fallback)", () => {
+    const totals = mkRow({ quota: 0, enrolled: 0 });
+    render(<SummaryBand rows={[]} totals={totals} groupBy="major" />);
+    expect(screen.queryByText("Nhập học / Chỉ tiêu")).toBeNull();
+    expect(screen.getByText("Nhập học")).toBeTruthy();
+  });
+});

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/SummaryBand.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/SummaryBand.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { formatVND } from "@/lib/zod/finance";
+import type { ReportGroupBy, ReportRow } from "@/lib/zod/reports";
+
+import { quotaTone } from "./WeeklyReportTable";
+
+const nf = new Intl.NumberFormat("vi-VN");
+
+/** "Đạt" = green tier (≥90% chỉ tiêu) — same threshold `quotaTone` paints green. */
+const MET = 0.9;
+
+function Card({
+  label,
+  value,
+  hint,
+  children,
+}: {
+  label: string;
+  value?: React.ReactNode;
+  hint?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border bg-card p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      {value !== undefined && (
+        <div className="mt-1 text-xl font-bold tabular-nums">{value}</div>
+      )}
+      {children}
+      {hint && <div className="mt-0.5 text-xs text-muted-foreground">{hint}</div>}
+    </div>
+  );
+}
+
+export function SummaryBand({
+  rows,
+  totals,
+  groupBy,
+}: {
+  rows: ReportRow[];
+  totals: ReportRow;
+  groupBy: ReportGroupBy;
+}) {
+  const t = totals.admission;
+  const hasQuota = groupBy === "major" && t.quota != null && t.quota > 0;
+  const ratio = hasQuota ? t.enrolled_cumulative / (t.quota as number) : 0;
+
+  const withQuota = rows.filter(
+    (r) => !r.is_bucket && r.admission.quota && r.admission.quota > 0,
+  );
+  const met = withQuota.filter(
+    (r) => r.admission.enrolled_cumulative / (r.admission.quota as number) >= MET,
+  ).length;
+
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+      {hasQuota ? (
+        <Card label="Nhập học / Chỉ tiêu" hint={`${Math.round(ratio * 100)}% chỉ tiêu năm`}>
+          <div className="mt-1 text-xl font-bold tabular-nums">
+            {nf.format(t.enrolled_cumulative)}
+            <span className="text-sm font-normal text-muted-foreground">
+              {" / "}
+              {nf.format(t.quota as number)}
+            </span>
+          </div>
+          <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-muted">
+            <div
+              className={cn("h-full rounded-full", quotaTone(ratio))}
+              style={{ width: `${Math.min(100, Math.round(ratio * 100))}%` }}
+            />
+          </div>
+        </Card>
+      ) : (
+        <Card
+          label="Nhập học"
+          hint="lũy kế năm"
+          value={nf.format(t.enrolled_cumulative)}
+        />
+      )}
+      <Card label="Trúng tuyển" hint="lũy kế năm" value={nf.format(t.admitted_cumulative)} />
+      <Card
+        label="Đang theo"
+        hint="còn trong phễu"
+        value={nf.format(totals.lead.active_current)}
+      />
+      <Card
+        label="Đã thu"
+        hint="lũy kế năm"
+        value={formatVND(totals.finance.net_cumulative)}
+      />
+      {hasQuota ? (
+        <Card
+          label="Ngành đạt ≥90%"
+          hint={`/ ${withQuota.length} ngành có chỉ tiêu`}
+          value={met}
+        />
+      ) : (
+        <Card label="Hồ sơ nộp" hint="lũy kế năm" value={nf.format(t.submitted_cumulative)} />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/WeeklyReportTable.test.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/WeeklyReportTable.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { ReportRow } from "@/lib/zod/reports";
+
+import { WeeklyReportTable } from "./WeeklyReportTable";
+
+function mkRow(o: {
+  label?: string;
+  quota?: number | null;
+  enrolled?: number;
+}): ReportRow {
+  return {
+    group_key: 1,
+    label: o.label ?? "Ngành A",
+    code: "X",
+    degree_level: null,
+    is_bucket: false,
+    bucket_kind: null,
+    lead: { new_in_week: 0, active_current: 0, consulting_positive_current: 0 },
+    admission: {
+      profiles_total: 0,
+      submitted_in_week: 0,
+      admitted_in_week: 0,
+      enrolled_in_week: 0,
+      submitted_cumulative: 0,
+      admitted_cumulative: 0,
+      enrolled_cumulative: o.enrolled ?? 0,
+      quota: o.quota ?? null,
+    },
+    conversion: { submit_to_admit: null, admit_to_enroll: null },
+    finance: {
+      gross_in_week: "0",
+      refund_in_week: "0",
+      net_in_week: "0",
+      application_net_in_week: "0",
+      tuition_net_in_week: "0",
+      net_cumulative: "0",
+      profiles_paid: 0,
+    },
+  };
+}
+
+describe("WeeklyReportTable", () => {
+  it("ytd + major + quota → quota-progress column (with Nộp)", () => {
+    const totals = mkRow({ quota: 100, enrolled: 40 });
+    render(
+      <WeeklyReportTable
+        rows={[mkRow({ quota: 100, enrolled: 40 })]}
+        totals={totals}
+        groupBy="major"
+        period="ytd"
+      />,
+    );
+    expect(screen.getByText("Tiến độ chỉ tiêu (Nhập học)")).toBeTruthy();
+    expect(screen.getByText("Nộp")).toBeTruthy();
+    // standalone "Nhập học" count header only exists in the no-quota layout
+    expect(screen.queryByText("Nhập học")).toBeNull();
+  });
+
+  it("ytd without quota → count layout (standalone Nhập học)", () => {
+    const totals = mkRow({ quota: null, enrolled: 0 });
+    render(
+      <WeeklyReportTable
+        rows={[mkRow({ quota: null, enrolled: 0 })]}
+        totals={totals}
+        groupBy="major"
+        period="ytd"
+      />,
+    );
+    expect(screen.queryByText("Tiến độ chỉ tiêu (Nhập học)")).toBeNull();
+    expect(screen.getByText("Nhập học")).toBeTruthy();
+  });
+
+  it("week period → activity headers", () => {
+    const totals = mkRow({});
+    render(
+      <WeeklyReportTable
+        rows={[mkRow({})]}
+        totals={totals}
+        groupBy="major"
+        period="week"
+      />,
+    );
+    expect(screen.getByText("Lead (tư vấn)")).toBeTruthy();
+    expect(screen.getByText("Tư vấn+")).toBeTruthy();
+  });
+
+  it("ytd quota: bucket row renders placeholder (no NaN bar) + totals row", () => {
+    const bucket: ReportRow = {
+      ...mkRow({ label: "Chưa phân loại", quota: null, enrolled: 0 }),
+      is_bucket: true,
+      bucket_kind: "unresolved",
+      group_key: null,
+    };
+    const totals = mkRow({ label: "TỔNG", quota: 100, enrolled: 40 });
+    render(
+      <WeeklyReportTable
+        rows={[bucket]}
+        totals={totals}
+        groupBy="major"
+        period="ytd"
+      />,
+    );
+    // bucket gets an em-dash placeholder instead of a quota bar → no crash
+    expect(screen.getByText("Chưa phân loại")).toBeTruthy();
+    expect(screen.getByText("TỔNG")).toBeTruthy();
+  });
+});

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/WeeklyReportTable.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/WeeklyReportTable.tsx
@@ -16,26 +16,86 @@ export type Period = "week" | "ytd";
 
 const nf = new Intl.NumberFormat("vi-VN");
 const dimZero = "text-muted-foreground/40";
-// Show real zeros (a funnel that drops to 0 IS information), just dimmed — never a
-// placeholder dash/dot that reads as "missing data".
+
 const count = (n: number) => (
   <span className={n === 0 ? dimZero : undefined}>{nf.format(n)}</span>
 );
 const money = (s: string) => (
   <span className={parseFloat(s) === 0 ? dimZero : undefined}>{formatVND(s)}</span>
 );
+const pct = (r: number | null) =>
+  r === null ? <span className={dimZero}>—</span> : `${Math.round(r * 100)}%`;
 
-function admissionCells(row: ReportRow, period: Period) {
-  const a = row.admission;
-  return period === "week"
-    ? [a.submitted_in_week, a.admitted_in_week, a.enrolled_in_week]
-    : [a.submitted_cumulative, a.admitted_cumulative, a.enrolled_cumulative];
+// Quota-progress thresholds are PRESENTATION (coloring a returned ratio), not a
+// business rule — kept here, not on the backend contract. Shared with SummaryBand.
+export function quotaTone(ratio: number): string {
+  if (ratio >= 0.9) return "bg-emerald-500";
+  if (ratio >= 0.5) return "bg-amber-500";
+  return "bg-rose-500";
+}
+
+function QuotaProgress({
+  enrolled,
+  quota,
+}: {
+  enrolled: number;
+  quota: number | null;
+}) {
+  if (quota == null || quota === 0) {
+    return <span className={cn("text-xs", dimZero)}>chưa đặt chỉ tiêu</span>;
+  }
+  const ratio = enrolled / quota;
+  return (
+    <div className="min-w-[130px] space-y-1">
+      <div className="flex items-center justify-between text-xs tabular-nums">
+        <span>
+          {nf.format(enrolled)} / {nf.format(quota)}
+        </span>
+        <span className="font-semibold">{Math.round(ratio * 100)}%</span>
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn("h-full rounded-full", quotaTone(ratio))}
+          style={{ width: `${Math.min(100, Math.round(ratio * 100))}%` }}
+        />
+      </div>
+    </div>
+  );
 }
 
 function rowKey(row: ReportRow): string {
   return row.is_bucket
     ? `bucket-${row.bucket_kind}`
     : `major-${row.group_key ?? row.code ?? row.label}`;
+}
+
+function FirstCell({
+  row,
+  isTotal,
+  dot,
+}: {
+  row: ReportRow;
+  isTotal: boolean;
+  dot?: string | null;
+}) {
+  return (
+    <TableCell className="sticky left-0 bg-background">
+      <div className="flex items-center gap-2">
+        {dot && (
+          <span className={cn("size-2 shrink-0 rounded-full", dot)} aria-hidden />
+        )}
+        <span className={cn("font-medium", isTotal && "font-bold")}>{row.label}</span>
+        {row.degree_level && (
+          <span className="rounded border px-1 text-[10px] text-muted-foreground">
+            {row.degree_level}
+          </span>
+        )}
+      </div>
+      {row.code && (
+        <span className="block text-xs text-muted-foreground">{row.code}</span>
+      )}
+    </TableCell>
+  );
 }
 
 export function WeeklyReportTable({
@@ -49,89 +109,152 @@ export function WeeklyReportTable({
   groupBy: ReportGroupBy;
   period: Period;
 }) {
-  const firstColLabel = groupBy === "major" ? "Ngành" : "Cán bộ";
-  const isWeek = period === "week";
-  const leadCols = isWeek ? 3 : 2; // "Mới" is a weekly event → only in the week view
-  const finCols = isWeek ? 3 : 2;
-  const colCount = 1 + leadCols + 3 + finCols;
+  const isMajor = groupBy === "major";
+  const firstColLabel = isMajor ? "Ngành" : "Cán bộ";
 
-  const renderRow = (row: ReportRow, isTotal = false) => {
-    const [sub, adm, enr] = admissionCells(row, period);
-    const hot =
-      !isTotal && !row.is_bucket && parseFloat(row.finance.net_cumulative) > 0;
-    return (
-      <TableRow
-        key={isTotal ? "__total__" : rowKey(row)}
-        className={cn(
-          isTotal && "border-t-2 bg-muted/40 font-semibold",
-          row.is_bucket && "text-muted-foreground",
-        )}
-      >
-        <TableCell className="sticky left-0 bg-background">
-          <div className="flex items-center gap-2">
-            {hot && (
-              <span
-                className="size-1.5 shrink-0 rounded-full bg-amber-500"
-                aria-hidden
-              />
-            )}
-            <span className={cn("font-medium", isTotal && "font-bold")}>
-              {row.label}
-            </span>
-            {row.degree_level && (
-              <span className="rounded border px-1 text-[10px] text-muted-foreground">
-                {row.degree_level}
-              </span>
-            )}
-          </div>
-          {row.code && (
-            <span className="block text-xs text-muted-foreground">{row.code}</span>
+  // =========================================================== COCKPIT (lũy kế)
+  if (period === "ytd") {
+    // Quota progress only renders when the backend attached a quota (major view,
+    // không lọc đợt). Otherwise fall back to the count layout (Nộp/Trúng/NH).
+    const showQuota = isMajor && totals.admission.quota != null;
+    const colCount = 8;
+
+    const renderRow = (row: ReportRow, isTotal = false) => {
+      const a = row.admission;
+      const ratio = a.quota && a.quota > 0 ? a.enrolled_cumulative / a.quota : null;
+      const dot =
+        showQuota && !isTotal && !row.is_bucket && ratio !== null
+          ? quotaTone(ratio)
+          : null;
+      return (
+        <TableRow
+          key={isTotal ? "__total__" : rowKey(row)}
+          className={cn(
+            isTotal && "border-t-2 bg-muted/40 font-semibold",
+            row.is_bucket && "text-muted-foreground",
           )}
-        </TableCell>
-        {/* Lead — "Mới" (weekly event) hidden in the cumulative view */}
-        {isWeek && (
-          <TableCell className="border-l text-right tabular-nums">
-            {count(row.lead.new_in_week)}
+        >
+          <FirstCell row={row} isTotal={isTotal} dot={dot} />
+          {showQuota && (
+            <TableCell className="border-l">
+              {row.is_bucket ? (
+                <span className={dimZero}>—</span>
+              ) : (
+                <QuotaProgress enrolled={a.enrolled_cumulative} quota={a.quota} />
+              )}
+            </TableCell>
+          )}
+          <TableCell
+            className={cn("text-right tabular-nums", !showQuota && "border-l")}
+          >
+            {count(a.submitted_cumulative)}
           </TableCell>
-        )}
-        <TableCell className={cn("text-right tabular-nums", !isWeek && "border-l")}>
-          {count(row.lead.active_current)}
-        </TableCell>
-        <TableCell className="text-right tabular-nums">
-          {count(row.lead.consulting_positive_current)}
-        </TableCell>
-        {/* Hồ sơ */}
-        <TableCell className="border-l bg-muted/20 text-right tabular-nums">
-          {count(sub)}
-        </TableCell>
-        <TableCell className="bg-muted/20 text-right tabular-nums">{count(adm)}</TableCell>
-        <TableCell className="bg-muted/20 text-right tabular-nums">{count(enr)}</TableCell>
-        {/* Tài chính */}
-        {isWeek ? (
-          <>
-            <TableCell className="border-l text-right tabular-nums">
-              {money(row.finance.application_net_in_week)}
-            </TableCell>
+          <TableCell className="text-right tabular-nums">
+            {count(a.admitted_cumulative)}
+          </TableCell>
+          {!showQuota && (
             <TableCell className="text-right tabular-nums">
-              {money(row.finance.tuition_net_in_week)}
+              {count(a.enrolled_cumulative)}
             </TableCell>
-            <TableCell className="text-right font-medium tabular-nums">
-              {money(row.finance.net_in_week)}
-            </TableCell>
-          </>
-        ) : (
-          <>
-            <TableCell className="border-l text-right font-medium tabular-nums">
-              {money(row.finance.net_cumulative)}
-            </TableCell>
-            <TableCell className="text-right tabular-nums">
-              {count(row.finance.profiles_paid)}
-            </TableCell>
-          </>
-        )}
-      </TableRow>
+          )}
+          <TableCell className="border-l text-right tabular-nums">
+            {pct(row.conversion.submit_to_admit)}
+          </TableCell>
+          <TableCell className="text-right tabular-nums">
+            {pct(row.conversion.admit_to_enroll)}
+          </TableCell>
+          <TableCell className="border-l text-right tabular-nums">
+            {count(row.lead.active_current)}
+          </TableCell>
+          <TableCell className="text-right font-medium tabular-nums">
+            {money(row.finance.net_cumulative)}
+          </TableCell>
+        </TableRow>
+      );
+    };
+
+    return (
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-muted/50 text-xs">
+              <TableHead className="sticky left-0 bg-muted/50">{firstColLabel}</TableHead>
+              {showQuota && (
+                <TableHead className="border-l">Tiến độ chỉ tiêu (Nhập học)</TableHead>
+              )}
+              <TableHead className={cn("text-right", !showQuota && "border-l")}>
+                Nộp
+              </TableHead>
+              <TableHead className="text-right">Trúng</TableHead>
+              {!showQuota && <TableHead className="text-right">Nhập học</TableHead>}
+              <TableHead className="border-l text-right">Nộp→Trúng</TableHead>
+              <TableHead className="text-right">Trúng→NH</TableHead>
+              <TableHead className="border-l text-right">Đang theo</TableHead>
+              <TableHead className="text-right">Đã thu</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={colCount}
+                  className="py-8 text-center text-muted-foreground"
+                >
+                  Không có dữ liệu cho kỳ đã chọn.
+                </TableCell>
+              </TableRow>
+            ) : (
+              <>
+                {rows.map((r) => renderRow(r))}
+                {renderRow(totals, true)}
+              </>
+            )}
+          </TableBody>
+        </Table>
+      </div>
     );
-  };
+  }
+
+  // =========================================================== ACTIVITY (tuần)
+  const colCount = 1 + 3 + 3 + 3;
+  const renderRow = (row: ReportRow, isTotal = false) => (
+    <TableRow
+      key={isTotal ? "__total__" : rowKey(row)}
+      className={cn(
+        isTotal && "border-t-2 bg-muted/40 font-semibold",
+        row.is_bucket && "text-muted-foreground",
+      )}
+    >
+      <FirstCell row={row} isTotal={isTotal} />
+      <TableCell className="border-l text-right tabular-nums">
+        {count(row.lead.new_in_week)}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {count(row.lead.active_current)}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {count(row.lead.consulting_positive_current)}
+      </TableCell>
+      <TableCell className="border-l bg-muted/20 text-right tabular-nums">
+        {count(row.admission.submitted_in_week)}
+      </TableCell>
+      <TableCell className="bg-muted/20 text-right tabular-nums">
+        {count(row.admission.admitted_in_week)}
+      </TableCell>
+      <TableCell className="bg-muted/20 text-right tabular-nums">
+        {count(row.admission.enrolled_in_week)}
+      </TableCell>
+      <TableCell className="border-l text-right tabular-nums">
+        {money(row.finance.application_net_in_week)}
+      </TableCell>
+      <TableCell className="text-right tabular-nums">
+        {money(row.finance.tuition_net_in_week)}
+      </TableCell>
+      <TableCell className="text-right font-medium tabular-nums">
+        {money(row.finance.net_in_week)}
+      </TableCell>
+    </TableRow>
+  );
 
   return (
     <div className="overflow-x-auto rounded-lg border">
@@ -141,37 +264,26 @@ export function WeeklyReportTable({
             <TableHead rowSpan={2} className="sticky left-0 bg-muted/50 align-bottom">
               {firstColLabel}
             </TableHead>
-            <TableHead colSpan={leadCols} className="border-l text-center">
+            <TableHead colSpan={3} className="border-l text-center">
               Lead (tư vấn)
             </TableHead>
             <TableHead colSpan={3} className="border-l text-center">
-              Hồ sơ {isWeek ? "(tuần)" : "(lũy kế)"}
+              Hồ sơ (tuần)
             </TableHead>
-            <TableHead colSpan={finCols} className="border-l text-center">
-              Tài chính {isWeek ? "(thu tuần)" : "(lũy kế)"}
+            <TableHead colSpan={3} className="border-l text-center">
+              Tài chính (thu tuần)
             </TableHead>
           </TableRow>
           <TableRow className="bg-muted/50 text-xs">
-            {isWeek && <TableHead className="border-l text-right">Mới</TableHead>}
-            <TableHead className={cn("text-right", !isWeek && "border-l")}>
-              Đang theo
-            </TableHead>
+            <TableHead className="border-l text-right">Mới</TableHead>
+            <TableHead className="text-right">Đang theo</TableHead>
             <TableHead className="text-right">Tư vấn+</TableHead>
             <TableHead className="border-l text-right">Nộp</TableHead>
             <TableHead className="text-right">Trúng</TableHead>
             <TableHead className="text-right">Nhập học</TableHead>
-            {isWeek ? (
-              <>
-                <TableHead className="border-l text-right">Lệ phí</TableHead>
-                <TableHead className="text-right">Học phí</TableHead>
-                <TableHead className="text-right">Đã thu</TableHead>
-              </>
-            ) : (
-              <>
-                <TableHead className="border-l text-right">Đã thu</TableHead>
-                <TableHead className="text-right">HS đã thu</TableHead>
-              </>
-            )}
+            <TableHead className="border-l text-right">Lệ phí</TableHead>
+            <TableHead className="text-right">Học phí</TableHead>
+            <TableHead className="text-right">Đã thu</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/WeeklyReportTable.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/WeeklyReportTable.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { formatVND } from "@/lib/zod/finance";
+import type { ReportGroupBy, ReportRow } from "@/lib/zod/reports";
+
+export type Period = "week" | "ytd";
+
+const nf = new Intl.NumberFormat("vi-VN");
+const dimZero = "text-muted-foreground/40";
+// Show real zeros (a funnel that drops to 0 IS information), just dimmed — never a
+// placeholder dash/dot that reads as "missing data".
+const count = (n: number) => (
+  <span className={n === 0 ? dimZero : undefined}>{nf.format(n)}</span>
+);
+const money = (s: string) => (
+  <span className={parseFloat(s) === 0 ? dimZero : undefined}>{formatVND(s)}</span>
+);
+
+function admissionCells(row: ReportRow, period: Period) {
+  const a = row.admission;
+  return period === "week"
+    ? [a.submitted_in_week, a.admitted_in_week, a.enrolled_in_week]
+    : [a.submitted_cumulative, a.admitted_cumulative, a.enrolled_cumulative];
+}
+
+function rowKey(row: ReportRow): string {
+  return row.is_bucket
+    ? `bucket-${row.bucket_kind}`
+    : `major-${row.group_key ?? row.code ?? row.label}`;
+}
+
+export function WeeklyReportTable({
+  rows,
+  totals,
+  groupBy,
+  period,
+}: {
+  rows: ReportRow[];
+  totals: ReportRow;
+  groupBy: ReportGroupBy;
+  period: Period;
+}) {
+  const firstColLabel = groupBy === "major" ? "Ngành" : "Cán bộ";
+  const isWeek = period === "week";
+  const leadCols = isWeek ? 3 : 2; // "Mới" is a weekly event → only in the week view
+  const finCols = isWeek ? 3 : 2;
+  const colCount = 1 + leadCols + 3 + finCols;
+
+  const renderRow = (row: ReportRow, isTotal = false) => {
+    const [sub, adm, enr] = admissionCells(row, period);
+    const hot =
+      !isTotal && !row.is_bucket && parseFloat(row.finance.net_cumulative) > 0;
+    return (
+      <TableRow
+        key={isTotal ? "__total__" : rowKey(row)}
+        className={cn(
+          isTotal && "border-t-2 bg-muted/40 font-semibold",
+          row.is_bucket && "text-muted-foreground",
+        )}
+      >
+        <TableCell className="sticky left-0 bg-background">
+          <div className="flex items-center gap-2">
+            {hot && (
+              <span
+                className="size-1.5 shrink-0 rounded-full bg-amber-500"
+                aria-hidden
+              />
+            )}
+            <span className={cn("font-medium", isTotal && "font-bold")}>
+              {row.label}
+            </span>
+            {row.degree_level && (
+              <span className="rounded border px-1 text-[10px] text-muted-foreground">
+                {row.degree_level}
+              </span>
+            )}
+          </div>
+          {row.code && (
+            <span className="block text-xs text-muted-foreground">{row.code}</span>
+          )}
+        </TableCell>
+        {/* Lead — "Mới" (weekly event) hidden in the cumulative view */}
+        {isWeek && (
+          <TableCell className="border-l text-right tabular-nums">
+            {count(row.lead.new_in_week)}
+          </TableCell>
+        )}
+        <TableCell className={cn("text-right tabular-nums", !isWeek && "border-l")}>
+          {count(row.lead.active_current)}
+        </TableCell>
+        <TableCell className="text-right tabular-nums">
+          {count(row.lead.consulting_positive_current)}
+        </TableCell>
+        {/* Hồ sơ */}
+        <TableCell className="border-l bg-muted/20 text-right tabular-nums">
+          {count(sub)}
+        </TableCell>
+        <TableCell className="bg-muted/20 text-right tabular-nums">{count(adm)}</TableCell>
+        <TableCell className="bg-muted/20 text-right tabular-nums">{count(enr)}</TableCell>
+        {/* Tài chính */}
+        {isWeek ? (
+          <>
+            <TableCell className="border-l text-right tabular-nums">
+              {money(row.finance.application_net_in_week)}
+            </TableCell>
+            <TableCell className="text-right tabular-nums">
+              {money(row.finance.tuition_net_in_week)}
+            </TableCell>
+            <TableCell className="text-right font-medium tabular-nums">
+              {money(row.finance.net_in_week)}
+            </TableCell>
+          </>
+        ) : (
+          <>
+            <TableCell className="border-l text-right font-medium tabular-nums">
+              {money(row.finance.net_cumulative)}
+            </TableCell>
+            <TableCell className="text-right tabular-nums">
+              {count(row.finance.profiles_paid)}
+            </TableCell>
+          </>
+        )}
+      </TableRow>
+    );
+  };
+
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-muted/50">
+            <TableHead rowSpan={2} className="sticky left-0 bg-muted/50 align-bottom">
+              {firstColLabel}
+            </TableHead>
+            <TableHead colSpan={leadCols} className="border-l text-center">
+              Lead (tư vấn)
+            </TableHead>
+            <TableHead colSpan={3} className="border-l text-center">
+              Hồ sơ {isWeek ? "(tuần)" : "(lũy kế)"}
+            </TableHead>
+            <TableHead colSpan={finCols} className="border-l text-center">
+              Tài chính {isWeek ? "(thu tuần)" : "(lũy kế)"}
+            </TableHead>
+          </TableRow>
+          <TableRow className="bg-muted/50 text-xs">
+            {isWeek && <TableHead className="border-l text-right">Mới</TableHead>}
+            <TableHead className={cn("text-right", !isWeek && "border-l")}>
+              Đang theo
+            </TableHead>
+            <TableHead className="text-right">Tư vấn+</TableHead>
+            <TableHead className="border-l text-right">Nộp</TableHead>
+            <TableHead className="text-right">Trúng</TableHead>
+            <TableHead className="text-right">Nhập học</TableHead>
+            {isWeek ? (
+              <>
+                <TableHead className="border-l text-right">Lệ phí</TableHead>
+                <TableHead className="text-right">Học phí</TableHead>
+                <TableHead className="text-right">Đã thu</TableHead>
+              </>
+            ) : (
+              <>
+                <TableHead className="border-l text-right">Đã thu</TableHead>
+                <TableHead className="text-right">HS đã thu</TableHead>
+              </>
+            )}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={colCount}
+                className="py-8 text-center text-muted-foreground"
+              >
+                Không có dữ liệu cho kỳ đã chọn.
+              </TableCell>
+            </TableRow>
+          ) : (
+            <>
+              {rows.map((r) => renderRow(r))}
+              {renderRow(totals, true)}
+            </>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/cockpit-rank.test.ts
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/cockpit-rank.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import type { ReportRow } from "@/lib/zod/reports";
+
+import { rankByQuotaGap } from "./cockpit-rank";
+
+function mkRow(o: {
+  label: string;
+  quota?: number | null;
+  enrolled?: number;
+  bucket?: boolean;
+}): ReportRow {
+  return {
+    group_key: o.bucket ? null : 1,
+    label: o.label,
+    code: null,
+    degree_level: null,
+    is_bucket: !!o.bucket,
+    bucket_kind: o.bucket ? "unresolved" : null,
+    lead: { new_in_week: 0, active_current: 0, consulting_positive_current: 0 },
+    admission: {
+      profiles_total: 0,
+      submitted_in_week: 0,
+      admitted_in_week: 0,
+      enrolled_in_week: 0,
+      submitted_cumulative: 0,
+      admitted_cumulative: 0,
+      enrolled_cumulative: o.enrolled ?? 0,
+      quota: o.quota ?? null,
+    },
+    conversion: { submit_to_admit: null, admit_to_enroll: null },
+    finance: {
+      gross_in_week: "0",
+      refund_in_week: "0",
+      net_in_week: "0",
+      application_net_in_week: "0",
+      tuition_net_in_week: "0",
+      net_cumulative: "0",
+      profiles_paid: 0,
+    },
+  };
+}
+
+describe("rankByQuotaGap", () => {
+  it("most-behind chỉ tiêu first; no-target then bucket last", () => {
+    const out = rankByQuotaGap([
+      mkRow({ label: "B-90%", quota: 100, enrolled: 90 }),
+      mkRow({ label: "bucket", bucket: true }),
+      mkRow({ label: "A-20%", quota: 100, enrolled: 20 }),
+      mkRow({ label: "no-target", quota: null, enrolled: 5 }),
+    ]).map((r) => r.label);
+    expect(out).toEqual(["A-20%", "B-90%", "no-target", "bucket"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [
+      mkRow({ label: "x", quota: 100, enrolled: 50 }),
+      mkRow({ label: "y", quota: 100, enrolled: 10 }),
+    ];
+    const before = input.map((r) => r.label);
+    rankByQuotaGap(input);
+    expect(input.map((r) => r.label)).toEqual(before);
+  });
+
+  it("treats quota=0 as no-target (avoids divide-by-zero)", () => {
+    const out = rankByQuotaGap([
+      mkRow({ label: "zero-quota", quota: 0, enrolled: 0 }),
+      mkRow({ label: "behind", quota: 100, enrolled: 10 }),
+    ]).map((r) => r.label);
+    expect(out).toEqual(["behind", "zero-quota"]); // 0 → Infinity → sinks to bottom
+  });
+
+  it("breaks no-target (Infinity) ties by enrolled desc", () => {
+    const out = rankByQuotaGap([
+      mkRow({ label: "noq-5", quota: null, enrolled: 5 }),
+      mkRow({ label: "noq-20", quota: null, enrolled: 20 }),
+    ]).map((r) => r.label);
+    expect(out).toEqual(["noq-20", "noq-5"]);
+  });
+});

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/cockpit-rank.ts
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/cockpit-rank.ts
@@ -1,0 +1,20 @@
+import type { ReportRow } from "@/lib/zod/reports";
+
+/**
+ * Cockpit ranking (lũy kế + theo ngành): ngành thiếu chỉ tiêu nhất (thấp %
+ * Nhập học/Chỉ tiêu) lên đầu để cảnh báo; ngành chưa đặt chỉ tiêu và các dòng
+ * bucket dồn xuống cuối. Pure → unit-testable.
+ */
+export function rankByQuotaGap(rows: ReportRow[]): ReportRow[] {
+  const ratio = (r: ReportRow) =>
+    r.admission.quota && r.admission.quota > 0
+      ? r.admission.enrolled_cumulative / r.admission.quota
+      : Infinity;
+  return [...rows].sort((a, b) => {
+    if (a.is_bucket !== b.is_bucket) return a.is_bucket ? 1 : -1;
+    const ra = ratio(a);
+    const rb = ratio(b);
+    if (ra !== rb) return ra - rb;
+    return b.admission.enrolled_cumulative - a.admission.enrolled_cumulative;
+  });
+}

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/page.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from "react";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+import { AdmissionsWeeklyClient } from "./_components/AdmissionsWeeklyClient";
+
+function Loading() {
+  return (
+    <div className="space-y-4 p-4 sm:p-6">
+      <Skeleton className="h-8 w-56" />
+      <Skeleton className="h-72 w-full" />
+    </div>
+  );
+}
+
+export default function AdmissionsWeeklyReportPage() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <AdmissionsWeeklyClient />
+    </Suspense>
+  );
+}

--- a/frontend/src/hooks/reports/useWeeklyReport.test.tsx
+++ b/frontend/src/hooks/reports/useWeeklyReport.test.tsx
@@ -1,0 +1,54 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api/reports", () => ({
+  getAdmissionWeeklyReport: vi.fn(),
+}));
+
+import * as reportsApi from "@/lib/api/reports";
+
+import { useWeeklyReport, weeklyReportKeys } from "./useWeeklyReport";
+
+function makeWrapper(qc: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+const sample = { rows: [], totals: {}, group_by: "major" };
+
+describe("useWeeklyReport", () => {
+  it("fetches with the given params and exposes data", async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(reportsApi.getAdmissionWeeklyReport).mockResolvedValue(sample as never);
+
+    const { result } = renderHook(
+      () => useWeeklyReport({ academic_year: 2026, group_by: "major" }),
+      { wrapper: makeWrapper(qc) },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(reportsApi.getAdmissionWeeklyReport).toHaveBeenCalledWith({
+      academic_year: 2026,
+      group_by: "major",
+    });
+  });
+
+  it("is disabled when academic_year is falsy", () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(
+      () => useWeeklyReport({ academic_year: 0, group_by: "major" }),
+      { wrapper: makeWrapper(qc) },
+    );
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(reportsApi.getAdmissionWeeklyReport).not.toHaveBeenCalled();
+  });
+
+  it("key factory includes the params", () => {
+    expect(
+      weeklyReportKeys.query({ academic_year: 2026, group_by: "officer" }),
+    ).toEqual(["admission-weekly-report", { academic_year: 2026, group_by: "officer" }]);
+  });
+});

--- a/frontend/src/hooks/reports/useWeeklyReport.ts
+++ b/frontend/src/hooks/reports/useWeeklyReport.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  getAdmissionWeeklyReport,
+  getReportFilters,
+  type WeeklyReportParams,
+} from "@/lib/api/reports";
+
+export const weeklyReportKeys = {
+  all: ["admission-weekly-report"] as const,
+  query: (params: WeeklyReportParams) =>
+    [...weeklyReportKeys.all, params] as const,
+  filters: (year?: number) =>
+    [...weeklyReportKeys.all, "filters", year ?? null] as const,
+};
+
+/** Năm (config ∪ data) + đợt cho bộ lọc — admin & manager. */
+export function useReportFilters(year?: number) {
+  return useQuery({
+    queryKey: weeklyReportKeys.filters(year),
+    queryFn: () => getReportFilters(year),
+    staleTime: 5 * 60 * 1000, // catalog rarely changes
+  });
+}
+
+export function useWeeklyReport(params: WeeklyReportParams) {
+  return useQuery({
+    queryKey: weeklyReportKeys.query(params),
+    queryFn: () => getAdmissionWeeklyReport(params),
+    enabled: !!params.academic_year,
+    staleTime: 30 * 1000,
+    placeholderData: (prev) => prev, // keep table visible while switching week/filter
+  });
+}

--- a/frontend/src/lib/api/reports.test.ts
+++ b/frontend/src/lib/api/reports.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./client", () => ({
+  api: { get: vi.fn() },
+}));
+
+import { api } from "./client";
+
+import { getAdmissionWeeklyReport, getReportFilters } from "./reports";
+
+const row = {
+  group_key: 1,
+  label: "Công nghệ ô tô (6510216)",
+  code: "6510216",
+  degree_level: "Cao đẳng",
+  is_bucket: false,
+  bucket_kind: null,
+  lead: { new_in_week: 8, active_current: 196, consulting_positive_current: 115 },
+  admission: {
+    profiles_total: 32,
+    submitted_in_week: 19,
+    admitted_in_week: 0,
+    enrolled_in_week: 0,
+    submitted_cumulative: 19,
+    admitted_cumulative: 0,
+    enrolled_cumulative: 0,
+  },
+  finance: {
+    gross_in_week: "1680000",
+    refund_in_week: "0",
+    net_in_week: "800000",
+    application_net_in_week: "1680000",
+    tuition_net_in_week: "16400000",
+    net_cumulative: "18080000",
+    profiles_paid: 13,
+  },
+};
+
+const payload = {
+  academic_year: 2026,
+  round_code: "DOT_2",
+  group_by: "major",
+  week: {
+    iso_year: 2026,
+    iso_week: 25,
+    week_start: "2026-06-15",
+    week_end: "2026-06-21",
+    timezone: "Asia/Ho_Chi_Minh",
+  },
+  scope_unit_id: null,
+  attribution: "recomputed-current",
+  rows: [row],
+  totals: row,
+  data_quality: {
+    total_profiles: 1,
+    ambiguous_profiles: 0,
+    unresolved_profiles: 0,
+    unassigned_profiles: 0,
+  },
+};
+
+describe("getAdmissionWeeklyReport", () => {
+  it("calls the endpoint with params and parses the response", async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: payload } as never);
+
+    const result = await getAdmissionWeeklyReport({
+      academic_year: 2026,
+      group_by: "major",
+    });
+
+    expect(api.get).toHaveBeenCalledWith(
+      "/api/v2/admin/reports/admission-weekly",
+      { params: { academic_year: 2026, group_by: "major" } },
+    );
+    // proves the real .parse() ran (money kept as string, ints preserved)
+    expect(result.rows[0].finance.net_in_week).toBe("800000");
+    expect(result.totals.admission.profiles_total).toBe(32);
+  });
+
+  it("throws on contract drift (money sent as a number)", async () => {
+    const bad = structuredClone(payload);
+    (bad.rows[0].finance as Record<string, unknown>).net_in_week = 800000;
+    vi.mocked(api.get).mockResolvedValue({ data: bad } as never);
+
+    await expect(
+      getAdmissionWeeklyReport({ academic_year: 2026, group_by: "major" }),
+    ).rejects.toThrow();
+  });
+
+  it("throws when a required field is missing", async () => {
+    const bad = structuredClone(payload) as Record<string, unknown>;
+    delete bad.data_quality;
+    vi.mocked(api.get).mockResolvedValue({ data: bad } as never);
+
+    await expect(
+      getAdmissionWeeklyReport({ academic_year: 2026, group_by: "major" }),
+    ).rejects.toThrow();
+  });
+});
+
+describe("getReportFilters", () => {
+  it("parses filters and passes academic_year", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: { academic_years: [2026, 2025], rounds: ["DOT_1", "DOT_2"] },
+    } as never);
+
+    const result = await getReportFilters(2026);
+
+    expect(api.get).toHaveBeenCalledWith(
+      "/api/v2/admin/reports/admission-weekly/filters",
+      { params: { academic_year: 2026 } },
+    );
+    expect(result.academic_years).toEqual([2026, 2025]);
+    expect(result.rounds).toEqual(["DOT_1", "DOT_2"]);
+  });
+
+  it("omits params when no year is given", async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: { academic_years: [2026], rounds: [] },
+    } as never);
+
+    await getReportFilters();
+
+    expect(api.get).toHaveBeenCalledWith(
+      "/api/v2/admin/reports/admission-weekly/filters",
+      { params: undefined },
+    );
+  });
+});

--- a/frontend/src/lib/api/reports.test.ts
+++ b/frontend/src/lib/api/reports.test.ts
@@ -24,7 +24,9 @@ const row = {
     submitted_cumulative: 19,
     admitted_cumulative: 0,
     enrolled_cumulative: 0,
+    quota: 200,
   },
+  conversion: { submit_to_admit: 0.6, admit_to_enroll: 0.5 },
   finance: {
     gross_in_week: "1680000",
     refund_in_week: "0",

--- a/frontend/src/lib/api/reports.ts
+++ b/frontend/src/lib/api/reports.ts
@@ -1,0 +1,41 @@
+import { api } from "./client";
+import {
+  admissionWeeklyReportSchema,
+  reportFiltersSchema,
+  type AdmissionWeeklyReport,
+  type ReportFilters,
+  type ReportGroupBy,
+} from "@/lib/zod/reports";
+
+export interface WeeklyReportParams {
+  academic_year: number;
+  group_by: ReportGroupBy;
+  round_code?: string;
+  week_start?: string; // YYYY-MM-DD; omit = current week (BE picks)
+  officer_id?: number;
+  unit_id?: number;
+}
+
+export async function getAdmissionWeeklyReport(
+  params: WeeklyReportParams,
+): Promise<AdmissionWeeklyReport> {
+  const response = await api.get("/api/v2/admin/reports/admission-weekly", {
+    params,
+  });
+  // Runtime-validate the contract (throws on drift) instead of trusting the cast.
+  return admissionWeeklyReportSchema.parse(response.data);
+}
+
+/**
+ * Filter options (năm + đợt) for the report controls. Admin + manager (same gate
+ * as the report) — replaces the admin-only rounds endpoint + profile-only years.
+ */
+export async function getReportFilters(
+  academic_year?: number,
+): Promise<ReportFilters> {
+  const response = await api.get(
+    "/api/v2/admin/reports/admission-weekly/filters",
+    { params: academic_year !== undefined ? { academic_year } : undefined },
+  );
+  return reportFiltersSchema.parse(response.data);
+}

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -111,6 +111,12 @@ export const navigationConfig: NavigationConfig = {
           icon: LayoutDashboard,
           roles: ["admin"], // Admin-only legacy dashboard
         },
+        {
+          label: "Báo cáo tuyển sinh",
+          href: "/reports/admissions-weekly",
+          icon: BarChart3,
+          roles: ["admin", "manager"], // weekly pivot by ngành/cán bộ
+        },
       ],
     },
 

--- a/frontend/src/lib/zod/reports.test.ts
+++ b/frontend/src/lib/zod/reports.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { admissionWeeklyReportSchema } from "./reports";
+
+const row = {
+  group_key: 1,
+  label: "Công nghệ ô tô (6510216)",
+  code: "6510216",
+  degree_level: "Cao đẳng",
+  is_bucket: false,
+  bucket_kind: null,
+  lead: { new_in_week: 8, active_current: 196, consulting_positive_current: 115 },
+  admission: {
+    profiles_total: 32,
+    submitted_in_week: 19,
+    admitted_in_week: 0,
+    enrolled_in_week: 0,
+    submitted_cumulative: 19,
+    admitted_cumulative: 0,
+    enrolled_cumulative: 0,
+  },
+  finance: {
+    gross_in_week: "1680000",
+    refund_in_week: "0",
+    net_in_week: "800000",
+    application_net_in_week: "1680000",
+    tuition_net_in_week: "16400000",
+    net_cumulative: "18080000",
+    profiles_paid: 13,
+  },
+};
+
+const payload = {
+  academic_year: 2026,
+  round_code: "DOT_2",
+  group_by: "major",
+  week: {
+    iso_year: 2026,
+    iso_week: 25,
+    week_start: "2026-06-15",
+    week_end: "2026-06-21",
+    timezone: "Asia/Ho_Chi_Minh",
+  },
+  scope_unit_id: null,
+  attribution: "recomputed-current",
+  rows: [row],
+  totals: row,
+  data_quality: {
+    total_profiles: 1,
+    ambiguous_profiles: 0,
+    unresolved_profiles: 0,
+    unassigned_profiles: 0,
+  },
+};
+
+describe("admissionWeeklyReportSchema", () => {
+  it("parses a valid backend payload (money as strings)", () => {
+    const parsed = admissionWeeklyReportSchema.parse(payload);
+    expect(parsed.rows[0].finance.net_in_week).toBe("800000");
+    expect(parsed.totals.admission.profiles_total).toBe(32);
+    expect(parsed.group_by).toBe("major");
+  });
+
+  it("rejects a money field sent as a number (contract drift)", () => {
+    const bad = structuredClone(payload);
+    (bad.rows[0].finance as Record<string, unknown>).net_in_week = 800000;
+    expect(() => admissionWeeklyReportSchema.parse(bad)).toThrow();
+  });
+
+  it("accepts bucket rows with null group_key", () => {
+    const bad = structuredClone(payload);
+    const r = bad.rows[0] as Record<string, unknown>;
+    r.group_key = null;
+    r.is_bucket = true;
+    r.bucket_kind = "unresolved";
+    r.code = null;
+    expect(() => admissionWeeklyReportSchema.parse(bad)).not.toThrow();
+  });
+});

--- a/frontend/src/lib/zod/reports.test.ts
+++ b/frontend/src/lib/zod/reports.test.ts
@@ -18,7 +18,9 @@ const row = {
     submitted_cumulative: 19,
     admitted_cumulative: 0,
     enrolled_cumulative: 0,
+    quota: 200,
   },
+  conversion: { submit_to_admit: 0.6, admit_to_enroll: 0.5 },
   finance: {
     gross_in_week: "1680000",
     refund_in_week: "0",

--- a/frontend/src/lib/zod/reports.ts
+++ b/frontend/src/lib/zod/reports.ts
@@ -29,6 +29,12 @@ export const admissionMetricsSchema = z.object({
   submitted_cumulative: z.number().int(),
   admitted_cumulative: z.number().int(),
   enrolled_cumulative: z.number().int(),
+  quota: z.number().int().nullable(), // chỉ tiêu (major view); null = N/A
+});
+
+export const conversionMetricsSchema = z.object({
+  submit_to_admit: z.number().nullable(), // admitted/submitted (lũy kế); null nếu mẫu=0
+  admit_to_enroll: z.number().nullable(), // enrolled/admitted (lũy kế)
 });
 
 export const financeMetricsSchema = z.object({
@@ -52,6 +58,7 @@ export const reportRowSchema = z.object({
   bucket_kind: bucketKindSchema.nullable(),
   lead: leadMetricsSchema,
   admission: admissionMetricsSchema,
+  conversion: conversionMetricsSchema,
   finance: financeMetricsSchema,
 });
 

--- a/frontend/src/lib/zod/reports.ts
+++ b/frontend/src/lib/zod/reports.ts
@@ -1,0 +1,88 @@
+/**
+ * Runtime contract for the weekly admission report
+ * (GET /api/v2/admin/reports/admission-weekly).
+ *
+ * Backend Decimals arrive as JSON strings (precision-safe) → validate money as
+ * `z.string()` and format with `formatVND`. Counts are integers.
+ */
+import { z } from "zod";
+
+export const weekMetaSchema = z.object({
+  iso_year: z.number().int(),
+  iso_week: z.number().int(),
+  week_start: z.string(), // YYYY-MM-DD (Monday, VN)
+  week_end: z.string(), // YYYY-MM-DD (Sunday, VN)
+  timezone: z.string(),
+});
+
+export const leadMetricsSchema = z.object({
+  new_in_week: z.number().int(),
+  active_current: z.number().int(),
+  consulting_positive_current: z.number().int(),
+});
+
+export const admissionMetricsSchema = z.object({
+  profiles_total: z.number().int(),
+  submitted_in_week: z.number().int(),
+  admitted_in_week: z.number().int(),
+  enrolled_in_week: z.number().int(),
+  submitted_cumulative: z.number().int(),
+  admitted_cumulative: z.number().int(),
+  enrolled_cumulative: z.number().int(),
+});
+
+export const financeMetricsSchema = z.object({
+  gross_in_week: z.string(),
+  refund_in_week: z.string(),
+  net_in_week: z.string(),
+  application_net_in_week: z.string(),
+  tuition_net_in_week: z.string(),
+  net_cumulative: z.string(),
+  profiles_paid: z.number().int(),
+});
+
+export const bucketKindSchema = z.enum(["ambiguous", "unresolved", "unassigned"]);
+
+export const reportRowSchema = z.object({
+  group_key: z.number().int().nullable(),
+  label: z.string(),
+  code: z.string().nullable(),
+  degree_level: z.string().nullable(),
+  is_bucket: z.boolean(),
+  bucket_kind: bucketKindSchema.nullable(),
+  lead: leadMetricsSchema,
+  admission: admissionMetricsSchema,
+  finance: financeMetricsSchema,
+});
+
+export const dataQualitySchema = z.object({
+  total_profiles: z.number().int(),
+  ambiguous_profiles: z.number().int(),
+  unresolved_profiles: z.number().int(),
+  unassigned_profiles: z.number().int(),
+});
+
+export const admissionWeeklyReportSchema = z.object({
+  academic_year: z.number().int(),
+  round_code: z.string().nullable(),
+  group_by: z.enum(["major", "officer"]),
+  week: weekMetaSchema,
+  scope_unit_id: z.number().int().nullable(),
+  attribution: z.literal("recomputed-current"),
+  rows: z.array(reportRowSchema),
+  totals: reportRowSchema,
+  data_quality: dataQualitySchema,
+});
+
+/** GET /api/v2/admin/reports/admission-weekly/filters — năm (config ∪ data) + đợt. */
+export const reportFiltersSchema = z.object({
+  academic_years: z.array(z.number().int()),
+  rounds: z.array(z.string()),
+});
+
+export type WeekMeta = z.infer<typeof weekMetaSchema>;
+export type ReportRow = z.infer<typeof reportRowSchema>;
+export type DataQuality = z.infer<typeof dataQualitySchema>;
+export type AdmissionWeeklyReport = z.infer<typeof admissionWeeklyReportSchema>;
+export type ReportFilters = z.infer<typeof reportFiltersSchema>;
+export type ReportGroupBy = AdmissionWeeklyReport["group_by"];


### PR DESCRIPTION
Trang `/reports/admissions-weekly` — báo cáo tuyển sinh theo **tuần ISO** (Asia/Ho_Chi_Minh), pivot lead → hồ sơ → tài chính theo **NGÀNH** hoặc **CÁN BỘ**, kèm cockpit ra quyết định (chỉ tiêu + tỷ lệ chuyển đổi).

## BE — `GET /api/v2/admin/reports/admission-weekly`

- Resolver ngành 5 bậc: admitted → NV1 → applied_rules → offering (fail-closed khi ambiguous/unresolved)
- Event-based: lead `created_at` · admission first-transition (status_history MIN `occurred_at`, không đếm trùng resubmit) · finance ledger `created_at`
- Recompute-current (tuần cũ có thể đổi khi publish/đổi NV)
- Scope: admin (toàn trường / chọn unit) · manager (ép unit, fail-closed 403, unit lạ → 404)
- Finance gross/refund(ABS)/net chỉ app+tuition (đối soát) + DISTINCT hồ sơ đã thu; Decimal → JSON string
- Cohort lead theo cửa sổ đợt `[start, end+1d)` VN, fail-closed khi thiếu ngày; round filter giữ profile round-None (không nuốt bucket)
- Quality: `profiles_total`/bucket + `data_quality` (ambiguous/unresolved/unassigned)

## Cockpit (BE)

- `admission.quota` = Σ `annual_admission_quota` per ngành — toàn trường, admin-only; liệt kê **mọi** ngành ACTIVE kể cả 0 hoạt động; loại soft-delete + archived
- `conversion.{submit_to_admit, admit_to_enroll}` = tỷ lệ phễu **lũy kế** (null khi mẫu = 0)
- Quota chỉ áp khi "Tất cả đợt" (lọc 1 đợt → bỏ; FE ẩn cột tiến độ)
- `list_report_years` = offering ∪ rounds ∪ profile-years của lead **còn sống** (không lộ năm chỉ-lead-xóa-mềm)

## FE — `/reports/admissions-weekly`

- Toggle "Tuần này / Lũy kế năm" + điều hướng tuần (◀▶) + filter năm/đợt
- **Dải KPI** (SummaryBand): Nhập học/Chỉ tiêu (bar) · Trúng · Đang theo · Đã thu · số ngành đạt ≥90% chỉ tiêu
- **Bảng cockpit** "Lũy kế năm": cột Tiến độ chỉ tiêu (bar + % + màu đỏ<50 / vàng / xanh≥90) · phễu Nộp → Trúng → Nhập học · xếp ngành thiếu chỉ tiêu lên đầu (`rankByQuotaGap`)
- "Tuần này" = view hoạt động (Mới / Nộp / Trúng / NH + thu tuần)
- Zod runtime validate contract BE (money = string, không float); nav nhóm Overview, roles `["admin","manager"]`

## Test

- **BE**: 55 test (20 unit + 25 integration + 10 API), black/flake8 sạch
- **FE**: 22 vitest (zod/api/hook/sort + quota0 + Infinity/SummaryBand + money/table-mode/bucket), tsc 0, eslint sạch
- **Chrome smoke**: admin (20 ngành / 1.150) + manager (count layout) + lọc đợt; console sạch

## DEFER v2

Lead weekly status events (consulting+ / lost qua `LeadStatusHistory` old ≠ new).

## Phạm vi

- **24 file** (23 code + 1 CI), `+4029/-0` — thuần file mới + thêm dòng, không sửa/xóa code cũ
- **Độc lập** với PR `fix/admission-stats-soft-delete`: 0 import chéo (report dùng `admission_report_repository.py` riêng), chỉ đụng **cùng một dòng anchor** trong `backend-test.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
