### PR TITLE
feat(finance): tái tạo hóa đơn đợt sau khi hủy (PR-A)

### DIFF
--- a/Backend_FastAPI/alembic/versions/pra20260624001_partial_unique_invoice_installment.py
+++ b/Backend_FastAPI/alembic/versions/pra20260624001_partial_unique_invoice_installment.py
@@ -1,0 +1,48 @@
+"""PR-A: partial unique index on invoice (fee_id, installment_no) excluding cancelled
+
+Replaces the hard UNIQUE constraint ``uq_invoice_fee_installment`` with a partial
+unique index ``uq_invoice_fee_installment_active`` (``WHERE status <> 'cancelled'``)
+so a cancelled invoice no longer reserves the installment slot — enabling
+re-creation of an installment after cancellation (PR-A).
+
+Revision ID: pra20260624001
+Revises: feepicker_casbin_20260621
+Create Date: 2026-06-24
+
+Downgrade safety
+----------------
+Recreating the old UNIQUE constraint will FAIL if any ``(fee_id, installment_no)``
+pair now has BOTH a cancelled and an active row — a state PR-A intentionally
+allows once an installment is re-created after cancellation. Such duplicates
+must be resolved (merge/remove the stale cancelled rows) BEFORE downgrading.
+The migration is otherwise idempotent at the DDL level.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "pra20260624001"
+down_revision = "feepicker_casbin_20260621"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("uq_invoice_fee_installment", "invoice", type_="unique")
+    op.create_index(
+        "uq_invoice_fee_installment_active",
+        "invoice",
+        ["fee_id", "installment_no"],
+        unique=True,
+        postgresql_where=sa.text("status <> 'cancelled'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_invoice_fee_installment_active", table_name="invoice")
+    op.create_unique_constraint(
+        "uq_invoice_fee_installment",
+        "invoice",
+        ["fee_id", "installment_no"],
+    )

--- a/Backend_FastAPI/app/models/finance/invoice.py
+++ b/Backend_FastAPI/app/models/finance/invoice.py
@@ -22,8 +22,8 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, List, Optional
 
 from sqlalchemy import (
-    CheckConstraint, Date, DateTime, ForeignKey,
-    Integer, Numeric, String, Text, UniqueConstraint
+    CheckConstraint, Date, DateTime, ForeignKey, Index,
+    Integer, Numeric, String, Text, text
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -82,9 +82,15 @@ class Invoice(Base):
     __tablename__ = "invoice"
 
     __table_args__ = (
-        UniqueConstraint(
+        # PR-A: partial unique — chỉ ràng buộc (fee_id, installment_no) trên các
+        # invoice CHƯA hủy. Hóa đơn 'cancelled' không còn chiếm slot đợt → cho
+        # phép tạo lại đợt sau khi hủy (thay UniqueConstraint cứng cũ
+        # 'uq_invoice_fee_installment'). PR-F sẽ mở predicate thêm 'replaced'.
+        Index(
+            'uq_invoice_fee_installment_active',
             'fee_id', 'installment_no',
-            name='uq_invoice_fee_installment'
+            unique=True,
+            postgresql_where=text("status <> 'cancelled'"),
         ),
         CheckConstraint('amount > 0', name='chk_invoice_amount_positive'),
         CheckConstraint('paid_amount >= 0', name='chk_invoice_paid_amount_non_negative'),

--- a/Backend_FastAPI/app/repositories/fee_repository.py
+++ b/Backend_FastAPI/app/repositories/fee_repository.py
@@ -508,7 +508,8 @@ class InvoiceRepository(BaseRepository[Invoice]):
     async def get_by_fee_id(
         self,
         fee_id: int,
-        unit_id: Optional[int] = None
+        unit_id: Optional[int] = None,
+        active_only: bool = False,
     ) -> List[Invoice]:
         """
         Get all invoices for a fee.
@@ -516,6 +517,11 @@ class InvoiceRepository(BaseRepository[Invoice]):
         Args:
             fee_id: Fee ID
             unit_id: Filter by lead.unit_id (for IDOR protection)
+            active_only: When True, exclude cancelled invoices. Default False
+                keeps the legacy behaviour — display/audit callers must still
+                see cancelled rows. Only the duplicate-guard callers in
+                InvoiceService pass True so a cancelled installment no longer
+                blocks re-creating that installment (PR-A).
 
         Returns:
             List of invoices
@@ -530,6 +536,12 @@ class InvoiceRepository(BaseRepository[Invoice]):
             )
             .where(Invoice.fee_id == fee_id)
         )
+
+        if active_only:
+            # 'cancelled' is the only non-active invoice state today; the partial
+            # unique index uq_invoice_fee_installment_active uses the same
+            # predicate so this guard and the DB constraint stay in agreement.
+            query = query.where(Invoice.status != 'cancelled')
 
         # IDOR Filter
         if unit_id is not None:

--- a/Backend_FastAPI/app/routers/invoices.py
+++ b/Backend_FastAPI/app/routers/invoices.py
@@ -10,6 +10,7 @@ Architecture Compliance:
 - IDOR Protection: Unit-based access control via service layer
 
 Endpoints:
+- POST /api/invoices - Create a supplemental/replacement invoice for a fee
 - GET /api/invoices/{invoice_id} - Get invoice details with payments
 - GET /api/invoices/by-fee/{fee_id} - Get all invoices for a fee
 - PUT /api/invoices/{invoice_id}/issue - Issue invoice
@@ -49,6 +50,7 @@ from app.utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
     BusinessRuleViolation,
+    DuplicateResourceError,
 )
 
 log = structlog.get_logger(__name__)
@@ -471,6 +473,71 @@ async def cancel_invoice(
     except ResourceNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except BusinessRuleViolation as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "",
+    response_model=finance_schemas.InvoiceResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a supplemental/replacement invoice for a fee",
+)
+async def create_invoice(
+    request: Request,
+    data: finance_schemas.InvoiceCreate,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = RequireManager,
+):
+    """
+    Create a single invoice (installment) for a fee.
+
+    Primary use: re-create an installment after the original was cancelled.
+    PR-A made cancelled invoices stop reserving the (fee_id, installment_no)
+    slot, so a manager can issue a fresh invoice for that installment. Also
+    serves manual / supplemental installments.
+
+    **Business Rules:**
+    - Fee status must be calculated / invoiced / partial
+    - installment_no must not collide with an ACTIVE (non-cancelled) invoice
+    - amount must not exceed the fee's remaining-to-invoice
+    - Requires manager or admin role
+
+    **Security:**
+    - IDOR protection: scoped to the caller's unit
+    - Role enforced via RequireManager dependency
+    """
+    invoice_service = InvoiceService(db)
+    unit_id = finance_scope_unit_id(current_user)
+
+    try:
+        invoice, _ = await invoice_service.create_single_invoice(
+            fee_id=data.fee_id,
+            amount=data.amount,
+            due_date=data.due_date,
+            installment_no=data.installment_no,
+            user_id=current_user.id,
+            unit_id=unit_id,
+        )
+
+        await db.commit()
+
+        log.info(
+            "invoice_created_via_api",
+            invoice_id=invoice.id,
+            fee_id=data.fee_id,
+            installment_no=data.installment_no,
+            user_id=current_user.id,
+        )
+
+        await db.refresh(invoice)
+        return _build_invoice_response(invoice, current_user_role=current_user.role)
+
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except DuplicateResourceError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except (BadRequest, BusinessRuleViolation) as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -28,6 +28,7 @@ from typing import List, Optional, Tuple, Callable
 import structlog
 
 from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -41,6 +42,7 @@ from app.utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
     BusinessRuleViolation,
+    DuplicateResourceError,
 )
 from app.config import settings
 
@@ -117,7 +119,9 @@ class InvoiceService:
             )
 
         # Check if invoices already exist
-        existing = await self.invoice_repo.get_by_fee_id(fee_id, unit_id)
+        existing = await self.invoice_repo.get_by_fee_id(
+            fee_id, unit_id, active_only=True
+        )
         if existing:
             raise BadRequest(
                 f"Invoices already exist for this fee. "
@@ -329,7 +333,9 @@ class InvoiceService:
             )
 
         # Check for duplicate installment
-        existing = await self.invoice_repo.get_by_fee_id(fee_id, unit_id)
+        existing = await self.invoice_repo.get_by_fee_id(
+            fee_id, unit_id, active_only=True
+        )
         for inv in existing:
             if inv.installment_no == installment_no:
                 raise BadRequest(
@@ -360,7 +366,17 @@ class InvoiceService:
         )
 
         self.db.add(invoice)
-        await self.db.flush()
+        try:
+            await self.db.flush()
+        except IntegrityError as exc:
+            # Race: a concurrent create for the same (fee_id, installment_no)
+            # slipped past the active_only pre-check and won the INSERT; the
+            # partial unique index uq_invoice_fee_installment_active rejects
+            # this one. Map the raw DB error to a domain 409, not a 500.
+            await self.db.rollback()
+            raise DuplicateResourceError(
+                f"Invoice for installment #{installment_no} already exists"
+            ) from exc
         await self.db.refresh(invoice)
 
         # Update fee status if not already invoiced

--- a/Backend_FastAPI/tests/api/test_invoice_create_authorization.py
+++ b/Backend_FastAPI/tests/api/test_invoice_create_authorization.py
@@ -1,0 +1,134 @@
+"""Authorization + behaviour for POST /api/invoices (PR-A).
+
+Matrix:
+* manager on a fee in their unit              → 201 (create installment)
+* officer on the same fee                     → 403 (RequireManager gate)
+* manager in a DIFFERENT unit                 → 404 (IDOR convention)
+* manager re-creating an ACTIVE installment   → 400 (pre-check duplicate guard)
+
+The concurrent-race path (pre-check passes, the partial-unique index then
+rejects the INSERT → DuplicateResourceError → 409) is verified deterministically
+at the service layer in
+``tests/services/test_invoice_service.py::TestInvoiceRecreateAfterCancelPRA``.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.models.finance import FeeTypeEnum
+from app.services.fee_calculation_service import FeeCalculationService
+from tests.fixtures.constants import AuthURLs
+from tests.fixtures.users import get_auth_headers
+
+pytestmark = pytest.mark.asyncio
+
+INVOICES = "/api/invoices"
+
+
+def _body(fee_id: int, installment_no: int = 1, amount: int = 900000) -> dict:
+    return {
+        "fee_id": fee_id,
+        "installment_no": installment_no,
+        "amount": amount,
+        "due_date": (date.today() + timedelta(days=30)).isoformat(),
+    }
+
+
+@pytest_asyncio.fixture
+async def invoice_api_fee(seed_lead_dependencies: dict, admin_user_in_db: dict) -> dict:
+    """Seed a calculated application fee (900000, single payment) in the default
+    unit so POST /api/invoices has a target. Returns {fee_id, unit_id}."""
+    unit_id = seed_lead_dependencies["unit_id"]
+    async with AsyncSessionLocal() as s:
+        lead = models.Lead(
+            full_name="Invoice API Student",
+            phone="0901330001",
+            source="test",
+            unit_id=unit_id,
+            consultation_status_id=seed_lead_dependencies["initial_status_id"],
+        )
+        s.add(lead)
+        await s.flush()
+
+        profile = models.AdmissionProfile(
+            lead_id=lead.id,
+            status="submitted",
+            academic_year=2025,
+            applied_rules={},
+        )
+        s.add(profile)
+        await s.flush()
+
+        fee_service = FeeCalculationService(s)
+        fee, _ = await fee_service.calculate_fee(
+            admission_profile_id=profile.id,
+            fee_type=FeeTypeEnum.application,
+            base_amount=Decimal("900000"),
+            academic_year=2025,
+            user_id=admin_user_in_db["id"],
+            unit_id=unit_id,
+        )
+        await s.commit()
+        return {"fee_id": fee.id, "unit_id": unit_id}
+
+
+class TestCreateInvoiceAuthorization:
+    async def test_manager_creates_invoice_201(
+        self, client: AsyncClient, manager_token_headers: dict, invoice_api_fee: dict
+    ):
+        r = await client.post(
+            INVOICES, json=_body(invoice_api_fee["fee_id"]),
+            headers=manager_token_headers,
+        )
+        assert r.status_code == 201, r.text
+        data = r.json()
+        assert data["fee_id"] == invoice_api_fee["fee_id"]
+        assert data["installment_no"] == 1
+        assert data["status"] == "draft"
+        assert Decimal(str(data["amount"])) == Decimal("900000")
+
+    async def test_officer_forbidden_403(
+        self, client: AsyncClient, officer_token_headers: dict, invoice_api_fee: dict
+    ):
+        # RequireManager blocks before any DB work; a real fee_id just proves the
+        # only reason for non-201 is the role gate.
+        r = await client.post(
+            INVOICES, json=_body(invoice_api_fee["fee_id"]),
+            headers=officer_token_headers,
+        )
+        assert r.status_code == 403, r.text
+
+    async def test_cross_unit_manager_404(
+        self,
+        client: AsyncClient,
+        manager_other_unit_user_in_db: dict,
+        invoice_api_fee: dict,
+    ):
+        headers = await get_auth_headers(
+            client, manager_other_unit_user_in_db, AuthURLs.LOGIN
+        )
+        # Manager passes RequireManager but the fee lives in another unit → 404
+        # (no existence leak), per the IDOR convention.
+        r = await client.post(
+            INVOICES, json=_body(invoice_api_fee["fee_id"]), headers=headers
+        )
+        assert r.status_code == 404, r.text
+
+    async def test_duplicate_active_installment_400(
+        self, client: AsyncClient, manager_token_headers: dict, invoice_api_fee: dict
+    ):
+        body = _body(invoice_api_fee["fee_id"], installment_no=1)
+        r1 = await client.post(INVOICES, json=body, headers=manager_token_headers)
+        assert r1.status_code == 201, r1.text
+        # Sequential duplicate: the active_only pre-check sees the live row and
+        # rejects with a domain BadRequest → 400 (the 409 path is the concurrent
+        # race backstop, service-tested).
+        r2 = await client.post(INVOICES, json=body, headers=manager_token_headers)
+        assert r2.status_code == 400, r2.text

--- a/Backend_FastAPI/tests/services/test_invoice_service.py
+++ b/Backend_FastAPI/tests/services/test_invoice_service.py
@@ -530,3 +530,194 @@ class TestInvoiceLifecycle:
         assert inv_num.startswith("INV-")
         # Format: INV-YYYY-XXXXXX (possibly with timestamp suffix)
         assert re.match(r"INV-\d{4}-\d+", inv_num)
+
+
+# =============================================================================
+# PR-A: RE-CREATE INVOICE AFTER CANCEL
+# =============================================================================
+
+class TestInvoiceRecreateAfterCancelPRA:
+    """PR-A: a cancelled invoice no longer reserves the (fee_id, installment_no)
+    slot, so an installment can be re-created after cancellation. The DB partial
+    unique index still forbids two ACTIVE invoices on the same installment.
+    """
+
+    async def test_regenerate_after_all_cancelled(self, db, invoice_fixtures, admin_user):
+        """Cancel every invoice → generate_invoices_for_fee runs again instead of
+        raising BadRequest('Invoices already exist')."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee_with_plan"]
+        unit_id = invoice_fixtures["unit_id"]
+        due = date.today() + timedelta(days=30)
+
+        invoices, _ = await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=due, user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+        assert len(invoices) == 3
+
+        for inv in invoices:
+            await service.cancel_invoice(
+                invoice_id=inv.id, reason="test recreate",
+                user_id=admin_user.id, unit_id=unit_id,
+            )
+        await db.commit()
+
+        regenerated, _ = await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=due, user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        assert len(regenerated) == 3
+        # New rows are distinct from the cancelled ones (no slot collision).
+        assert {inv.id for inv in invoices}.isdisjoint({inv.id for inv in regenerated})
+
+    async def test_recreate_single_installment_after_cancel(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Cancel one installment → create_single_invoice with the SAME
+        installment_no succeeds (partial index frees the slot)."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee_with_plan"]
+        unit_id = invoice_fixtures["unit_id"]
+        due = date.today() + timedelta(days=30)
+
+        invoices, _ = await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=due, user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+        target = next(inv for inv in invoices if inv.installment_no == 2)
+
+        await service.cancel_invoice(
+            invoice_id=target.id, reason="wrong amount",
+            user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        new_inv, _ = await service.create_single_invoice(
+            fee_id=fee.id, amount=target.amount, due_date=due,
+            installment_no=2, user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        assert new_inv.installment_no == 2
+        assert new_inv.id != target.id
+        assert new_inv.status == InvoiceStatusEnum.draft.value
+
+    async def test_duplicate_active_installment_still_blocked(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """create_single_invoice on an installment that still has an ACTIVE
+        invoice is rejected — active_only guard sees the live row."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee_with_plan"]
+        unit_id = invoice_fixtures["unit_id"]
+        due = date.today() + timedelta(days=30)
+
+        await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=due, user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        with pytest.raises(BadRequest):
+            await service.create_single_invoice(
+                fee_id=fee.id, amount=Decimal("100000"), due_date=due,
+                installment_no=1, user_id=admin_user.id, unit_id=unit_id,
+            )
+
+    async def test_total_invoiced_excludes_cancelled(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Hidden-bug guard: create_single_invoice's remaining-to-invoice must
+        ignore cancelled amounts, else re-invoicing a cancelled installment
+        wrongly trips 'exceeds remaining balance'."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee"]  # single 900000, no plan
+        unit_id = invoice_fixtures["unit_id"]
+        due = date.today() + timedelta(days=30)
+
+        invoices, _ = await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=due, user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+        await service.cancel_invoice(
+            invoice_id=invoices[0].id, reason="redo",
+            user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        # The full 900000 is invoiceable again (cancelled amount not counted).
+        new_inv, _ = await service.create_single_invoice(
+            fee_id=fee.id, amount=Decimal("900000"), due_date=due,
+            installment_no=1, user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+        assert new_inv.amount == Decimal("900000")
+
+    async def test_db_partial_unique_blocks_two_active(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """DB-level: two ACTIVE invoices on the same (fee_id, installment_no)
+        violate uq_invoice_fee_installment_active."""
+        from sqlalchemy.exc import IntegrityError
+
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee"]
+        unit_id = invoice_fixtures["unit_id"]
+        due = date.today() + timedelta(days=30)
+
+        await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=due, user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        dup = Invoice(
+            fee_id=fee.id,
+            invoice_number="INV-TEST-DUP-0001",
+            installment_no=1,
+            amount=Decimal("900000"),
+            paid_amount=Decimal("0"),
+            penalty_amount=Decimal("0"),
+            status=InvoiceStatusEnum.draft.value,
+            due_date=due,
+        )
+        db.add(dup)
+        with pytest.raises(IntegrityError):
+            await db.flush()
+        await db.rollback()
+
+    async def test_race_integrity_error_maps_to_duplicate(
+        self, db, invoice_fixtures, admin_user, monkeypatch
+    ):
+        """Race backstop: when a concurrent INSERT wins between the active_only
+        pre-check and the flush, create_single_invoice maps the partial-unique
+        IntegrityError to a domain DuplicateResourceError (→ 409 at the router),
+        not a raw 500.
+
+        Simulated by stubbing the duplicate pre-check to 'see nothing' while a
+        real ACTIVE invoice for the same installment already exists.
+        """
+        from app.utils.exceptions import DuplicateResourceError
+
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee"]
+        unit_id = invoice_fixtures["unit_id"]
+        due = date.today() + timedelta(days=30)
+
+        await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=due, user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        async def _no_existing(*args, **kwargs):
+            return []
+
+        # Pre-check now "sees nothing", so create proceeds to the flush where the
+        # real active installment #1 trips the partial unique index.
+        monkeypatch.setattr(service.invoice_repo, "get_by_fee_id", _no_existing)
+
+        with pytest.raises(DuplicateResourceError):
+            await service.create_single_invoice(
+                fee_id=fee.id, amount=Decimal("100000"), due_date=due,
+                installment_no=1, user_id=admin_user.id, unit_id=unit_id,
+            )


### PR DESCRIPTION
## Vấn đề
Học phí trả góp 2 đợt → tạo 2 hóa đơn. Khi quản lý **hủy** 1 đợt (nhập sai số tiền/ngày), **không thể tạo lại** hóa đơn cho đợt đó: hệ thống báo *"Invoices already exist"* vì bản đã hủy vẫn **giữ chỗ** `(fee_id, installment_no)` → phải sửa DB bằng tay.

## Giải pháp (PR-A — gỡ kẹt, độc lập với tích hợp MISA)
- **Model**: `UniqueConstraint(fee_id, installment_no)` → **partial unique index** `uq_invoice_fee_installment_active` (`WHERE status <> 'cancelled'`). Hóa đơn `cancelled` không còn chiếm slot đợt.
- **Repo**: `get_by_fee_id(active_only=False)` — default **giữ nguyên** (caller hiển thị/đối soát vẫn thấy bản hủy); chỉ 2 guard nhân bản (`generate_invoices_for_fee`, `create_single_invoice`) truyền `True`. Cũng sửa **lỗi ẩn**: `total_invoiced` trước đây cộng cả bản hủy → tính nhầm "vượt số dư".
- **Endpoint mới** `POST /api/invoices` (chỉ **Manager/Admin**, IDOR theo unit) để ra lại hóa đơn đợt. Race 2 request đồng thời cùng đợt → map `IntegrityError` thành **409** (thay vì raw 500).
- **Không đổi** hành vi hiển thị: hóa đơn đã hủy vẫn hiện trong lịch sử/đối soát.

## Test — 26/26 pass
- **Service (6 mới)**: regenerate sau khi hủy hết · tái tạo 1 đợt · chặn trùng đợt active · `total_invoiced` loại cancelled · **DB partial-unique chặn 2 active** · **race IntegrityError→409 (DuplicateResourceError)**.
- **API (4 mới)**: manager `201` · officer `403` · cross-unit manager `404` · duplicate active `400`.

## Migration
- `pra20260624001` (down_rev `feepicker_casbin_20260621`). **Upgrade + downgrade roundtrip đã verify sạch** trên DB thật.
- ⚠️ `downgrade()` sẽ FAIL nếu DB đã có 1 `cancelled` + 1 active cùng đợt (trạng thái PR-A cố tình cho phép) — phải dọn bản trùng trước khi hạ cấp. Đã ghi rõ trong docstring migration.

## Phạm vi
7 file, +482/-8. Thuộc lộ trình `Documents/MISA_INVOICE_INTEGRATION_PLAN.md` §6.1; độc lập, ship trước được.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
