### PR TITLE
fix(admission): tìm trường THPT — xếp hạng độ liên quan + id tie-break + limit 50

### DIFF
--- a/Backend_FastAPI/app/services/vn_school_service.py
+++ b/Backend_FastAPI/app/services/vn_school_service.py
@@ -16,7 +16,8 @@ Query pattern:
       AND (:level IS NULL OR s.level = :level)
       AND (:province IS NULL OR s.moet_province_code = :province)
       AND unaccent(s.name) ILIKE unaccent('%' || :q || '%')
-    ORDER BY s.name
+    -- Relevance: 0=prefix, 1=q ở đầu một từ, 2=giữa từ; rồi length, name, id
+    ORDER BY relevance, length(s.name), s.name, s.id
     LIMIT :limit OFFSET :offset;
 
 Auth: caller responsible for authentication. This service does NOT
@@ -126,7 +127,10 @@ class VnSchoolService:
         #   0 = tên bắt đầu bằng q (prefix)
         #   1 = q ở đầu một từ (word boundary — phổ biến nhất khi gõ tên riêng)
         #   2 = q ở giữa từ
-        # rồi tên ngắn lên trước (khớp sát hơn), cuối cùng alphabet cho ổn định.
+        # rồi tên ngắn lên trước (khớp sát hơn), tên (alphabet), cuối cùng id —
+        # tie-break DUY NHẤT để thứ tự ổn định: phân trang không lặp/bỏ sót khi
+        # nhiều trường trùng tên giữa các tỉnh (vd "THPT Lê Quý Đôn" ~48 tỉnh,
+        # cùng relevance + length + name). Mirror list_schools (đã có .id).
         name_unaccent = func.unaccent(VnSchool.name)
         relevance = case(
             (name_unaccent.ilike(func.unaccent(f"{q_escaped}%")), 0),
@@ -148,7 +152,12 @@ class VnSchoolService:
                 current_kv_subq.label("current_kv"),
             )
             .where(*filters)
-            .order_by(relevance, func.length(VnSchool.name), VnSchool.name)
+            .order_by(
+                relevance,
+                func.length(VnSchool.name),
+                VnSchool.name,
+                VnSchool.id,
+            )
             .limit(limit)
             .offset(offset)
         )

--- a/Backend_FastAPI/app/services/vn_school_service.py
+++ b/Backend_FastAPI/app/services/vn_school_service.py
@@ -29,7 +29,7 @@ import csv
 import io
 from typing import Any, Awaitable, Callable, Optional, Tuple
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import case, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.vn_school import VnSchool, VnSchoolKvAssignment
@@ -117,6 +117,23 @@ class VnSchoolService:
             .scalar_subquery()
         )
 
+        # Relevance ranking (thay cho ORDER BY name thuần). Không có nó, sắp xếp
+        # alphabet vùi các trường "THPT <tên>" phổ biến xuống sau hàng loạt tiền
+        # tố đứng trước theo bảng chữ cái (DTNT/GDNN/PT/TH-/THCS...). Với limit
+        # ~50, trường người dùng cần có thể không bao giờ xuất hiện (đo thực tế:
+        # q="nguyen" khớp 438 trường nhưng dòng "THPT ..." đầu tiên nằm ở vị trí
+        # alphabet 40). Ưu tiên:
+        #   0 = tên bắt đầu bằng q (prefix)
+        #   1 = q ở đầu một từ (word boundary — phổ biến nhất khi gõ tên riêng)
+        #   2 = q ở giữa từ
+        # rồi tên ngắn lên trước (khớp sát hơn), cuối cùng alphabet cho ổn định.
+        name_unaccent = func.unaccent(VnSchool.name)
+        relevance = case(
+            (name_unaccent.ilike(func.unaccent(f"{q_escaped}%")), 0),
+            (name_unaccent.ilike(func.unaccent(f"% {q_escaped}%")), 1),
+            else_=2,
+        )
+
         stmt = (
             select(
                 VnSchool.id,
@@ -131,7 +148,7 @@ class VnSchoolService:
                 current_kv_subq.label("current_kv"),
             )
             .where(*filters)
-            .order_by(VnSchool.name)
+            .order_by(relevance, func.length(VnSchool.name), VnSchool.name)
             .limit(limit)
             .offset(offset)
         )

--- a/Backend_FastAPI/tests/unit/test_vn_school_search.py
+++ b/Backend_FastAPI/tests/unit/test_vn_school_search.py
@@ -282,3 +282,42 @@ async def test_search_ranking_prefix_and_word_boundary_first(db):
     assert names[-1] == "ABCSáng Tạo Center"
     # word-boundary ("THPT Sáng Tạo") xếp trên mid-word
     assert names.index("THPT Sáng Tạo") < names.index("ABCSáng Tạo Center")
+
+
+@pytest.mark.asyncio
+async def test_search_duplicate_names_paginate_stable_by_id(db):
+    """Trùng tên giữa các tỉnh (phổ biến: "THPT Lê Quý Đôn" ~48 tỉnh) → cùng
+    relevance + length + name; id là tie-break duy nhất giữ thứ tự ổn định,
+    phân trang limit/offset không lặp hay bỏ sót row."""
+    await db.execute(text("CREATE EXTENSION IF NOT EXISTS unaccent"))
+    db.add_all(
+        [
+            VnSchool(
+                moet_province_code="091", moet_school_code="D001",
+                name="THPT Lê Quý Đôn", province="Tỉnh A", level="THPT",
+                is_dtnt=False, is_active=True,
+            ),
+            VnSchool(
+                moet_province_code="092", moet_school_code="D001",
+                name="THPT Lê Quý Đôn", province="Tỉnh B", level="THPT",
+                is_dtnt=False, is_active=True,
+            ),
+            VnSchool(
+                moet_province_code="093", moet_school_code="D001",
+                name="THPT Lê Quý Đôn", province="Tỉnh C", level="THPT",
+                is_dtnt=False, is_active=True,
+            ),
+        ]
+    )
+    await db.flush()
+
+    svc = VnSchoolService(db)
+    page1, total = await svc.search_schools(query="Lê Quý Đôn", limit=2, offset=0)
+    page2, _ = await svc.search_schools(query="Lê Quý Đôn", limit=2, offset=2)
+    assert total == 3
+    ids = [r["id"] for r in page1] + [r["id"] for r in page2]
+    # Không lặp / không bỏ sót dù cả 3 row trùng (relevance, length, name)
+    assert len(ids) == 3
+    assert len(set(ids)) == 3
+    # id tie-break → thứ tự tăng dần ổn định
+    assert ids == sorted(ids)

--- a/Backend_FastAPI/tests/unit/test_vn_school_search.py
+++ b/Backend_FastAPI/tests/unit/test_vn_school_search.py
@@ -241,3 +241,44 @@ async def test_search_sql_injection_safe(seed_schools, db):
     # '%' should not match everything if escaped
     rows, total = await svc.search_schools(query="100% nothing", limit=10)
     assert total == 0  # literal "100% nothing" not in any school name
+
+
+@pytest.mark.asyncio
+async def test_search_ranking_prefix_and_word_boundary_first(db):
+    """Relevance ranking: prefix-match > word-boundary > mid-word, then shorter
+    name. Với ORDER BY name thuần, trường đứng đầu alphabet sẽ thắng bất kể độ
+    khớp — bug gốc khiến "THPT <tên>" bị vùi sau DTNT/GDNN/PT/THCS."""
+    await db.execute(text("CREATE EXTENSION IF NOT EXISTS unaccent"))
+    db.add_all(
+        [
+            # word-boundary: " Sáng Tạo" sau tiền tố THPT
+            VnSchool(
+                moet_province_code="099", moet_school_code="R001",
+                name="THPT Sáng Tạo", province="Test", level="THPT",
+                is_dtnt=False, is_active=True,
+            ),
+            # prefix: tên bắt đầu ngay bằng query
+            VnSchool(
+                moet_province_code="099", moet_school_code="R002",
+                name="Sáng Tạo Quốc Tế", province="Test", level="THPT",
+                is_dtnt=False, is_active=True,
+            ),
+            # mid-word: "sang tao" nằm giữa từ, không có space đứng trước
+            VnSchool(
+                moet_province_code="099", moet_school_code="R003",
+                name="ABCSáng Tạo Center", province="Test", level="THPT",
+                is_dtnt=False, is_active=True,
+            ),
+        ]
+    )
+    await db.flush()
+
+    svc = VnSchoolService(db)
+    rows, total = await svc.search_schools(query="Sáng Tạo", limit=10)
+    assert total == 3
+    names = [r["name"] for r in rows]
+    # prefix-match đứng đầu, mid-word đứng cuối
+    assert names[0] == "Sáng Tạo Quốc Tế"
+    assert names[-1] == "ABCSáng Tạo Center"
+    # word-boundary ("THPT Sáng Tạo") xếp trên mid-word
+    assert names.index("THPT Sáng Tạo") < names.index("ABCSáng Tạo Center")

--- a/frontend/src/components/admissions/VnSchoolPicker.tsx
+++ b/frontend/src/components/admissions/VnSchoolPicker.tsx
@@ -82,7 +82,10 @@ export function VnSchoolPicker({
   const { data, isLoading } = useVnSchoolSearch({
     q: debouncedQuery,
     level: levelFilter,
-    limit: 20,
+    // 50 (không phải 20): danh mục có ~4900 trường, nhiều trường trùng tên ở
+    // các tỉnh khác nhau (vd "THPT Lê Quý Đôn" ~48 tỉnh). 20 cắt mất trường
+    // người dùng cần dù backend đã rank theo độ liên quan. Backend max = 100.
+    limit: 50,
   })
 
   const handleSelect = (school: VnSchoolSearchItem) => {


### PR DESCRIPTION
## Vấn đề
Dropdown chọn trường (tab "Lịch sử học tập") không hiển thị được trường officer cần khi danh mục lớn (~4900 trường THPT). Nguyên nhân:
- **Backend** `ORDER BY name` (alphabet) đẩy `THPT <tên>` xuống sau các tiền tố `DTNT/GDNN/PT/TH-/THCS` (sắp trước theo bảng chữ cái). Đo thực tế: gõ `nguyen` khớp **438 trường** nhưng `THPT ...` đầu tiên nằm ở vị trí alphabet **40** → ngoài tầm hiển thị.
- **Frontend** limit cứng **20** quá nhỏ; nhiều trường trùng tên giữa các tỉnh (vd `THPT Lê Quý Đôn` ~48 tỉnh).

## Thay đổi
- **BE** (`vn_school_service.py`): thay `ORDER BY name` bằng **ranking độ-liên-quan** — prefix > đầu-từ (word boundary) > giữa-từ → tên ngắn → alphabet → **`id` tie-break** (giữ phân trang `limit/offset` ổn định khi nhiều trường trùng tên hệt nhau; mirror `list_schools`).
- **FE** (`VnSchoolPicker.tsx`): `limit` 20 → **50** (backend max 100).
- Đồng bộ docstring `ORDER BY` + thêm test (ranking prefix/word-boundary + phân trang trùng tên theo id).

## Kiểm thử
- Backend **15/15** test (`tests/unit/test_vn_school_search.py`) pass.
- Frontend `type-check` sạch.
- **Chrome smoke** (hồ sơ #109):
  - gõ `nguyen` → top toàn `THPT Nguyễn Du/Huệ/Trực` (trước là DTNT/GDNN), 50 kết quả.
  - gõ `le quy don` → **48 trường** cùng tên hiển thị đủ, top toàn `THPT Lê Quý Đôn` các tỉnh, thứ tự ổn định theo id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)