### PR TITLE
fix(finance): cân đối Fee.status sau khi hủy hóa đơn (PR-B / Nhóm A)

### DIFF
--- a/Backend_FastAPI/app/repositories/fee_repository.py
+++ b/Backend_FastAPI/app/repositories/fee_repository.py
@@ -552,6 +552,31 @@ class InvoiceRepository(BaseRepository[Invoice]):
         result = await self.db.execute(query)
         return list(result.scalars().all())
 
+    async def count_active_for_fee(
+        self,
+        fee_id: int,
+        unit_id: Optional[int] = None,
+    ) -> int:
+        """Count non-cancelled invoices for a fee (IDOR-scoped).
+
+        Cheap aggregate for the Fee.status recompute (PR-B) — a single COUNT, no
+        payment hydration (unlike ``get_by_fee_id`` which selectinloads payments).
+        """
+        query = (
+            select(func.count(Invoice.id))
+            .join(Fee)
+            .join(models.AdmissionProfile)
+            .join(models.Lead)
+            .where(
+                Invoice.fee_id == fee_id,
+                Invoice.status != 'cancelled',
+            )
+        )
+        if unit_id is not None:
+            query = query.where(models.Lead.unit_id == unit_id)
+        result = await self.db.execute(query)
+        return int(result.scalar() or 0)
+
     async def get_for_update(
         self,
         invoice_id: int,

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -379,10 +379,10 @@ class InvoiceService:
             ) from exc
         await self.db.refresh(invoice)
 
-        # Update fee status if not already invoiced
-        if fee.status == FeeStatusEnum.calculated.value:
-            fee.status = FeeStatusEnum.invoiced.value
-            await self.db.flush()
+        # Keep Fee.status consistent (PR-B): recompute under a FRESH fee lock so a
+        # concurrent cancel that committed e.g. 'calculated' isn't shadowed by a
+        # stale in-memory snapshot of fee.status here (re-reads the fee row).
+        await self.recompute_fee_from_invoices(fee_id, unit_id)
 
         log.info(
             "invoice_created",
@@ -570,62 +570,58 @@ class InvoiceService:
         fee_id: int,
         unit_id: Optional[int] = None,
     ) -> Fee:
-        """Recompute ``Fee.status`` from its ACTIVE (non-cancelled) invoices.
+        """Recompute ``Fee.status`` from settlement (paid + waived) and whether
+        any ACTIVE (non-cancelled) invoice remains.
 
-        Nhóm A balance fix (PR-B): ``cancel_invoice`` doesn't touch the Fee, so
-        after a cancel the Fee can drift (status stuck at 'invoiced' while fewer
-        invoices remain billed). Call this in the SAME transaction after a cancel
-        (or any path that changes the active-invoice set) to keep the Fee
-        consistent.
+        Nhóm A balance fix (PR-B): paths that change the active-invoice set
+        (cancel, supplemental create) must keep ``Fee.status`` consistent in the
+        SAME transaction, else the Fee drifts (status stuck at 'invoiced' with
+        fewer invoices than billed).
 
-        Status rules (there is no 'partially invoiced' enum — do NOT overload
-        'partial', which means "đã thu một phần"):
-        - ``paid_amount > 0``  -> 'paid' if remaining <= 0 else 'partial'
-        - ``paid_amount == 0`` -> 'invoiced' if any active invoice else 'calculated'
-        Terminal statuses ('waived', 'cancelled') are left untouched — those are
-        deliberate decisions, not a side-effect of cancelling one installment.
+        Status rules (no 'partially invoiced' enum — don't overload 'partial' =
+        "đã thu một phần"):
+        - fully settled (``final - waived - paid <= 0``) -> 'paid'. Catches a FULL
+          WAIVER too (``waive_fee`` sets 'paid' with ``paid_amount == 0``).
+        - else ``paid_amount > 0`` -> 'partial'
+        - else any active invoice -> 'invoiced'
+        - else -> 'calculated'
 
-        Does NOT change ``final_amount`` / ``waived_amount`` / ``paid_amount`` — a
-        real reduction (giảm trừ) is a separate audited flow. Enforces the balance
-        invariant ``Σ active invoice.amount <= final_amount - waived_amount``.
+        Terminal statuses ('waived', 'cancelled') are deliberate and left as-is.
+        Does NOT touch final/waived/paid amounts — a real reduction is a separate
+        audited flow. NO over-bill guard here: recompute runs on REDUCTIONS
+        (cancel) and must never block clearing an already over-billed fee — a
+        post-issue waiver can legitimately make Σ active > (final - waived). The
+        over-bill guard lives at invoice CREATION (``create_single_invoice``).
         """
         fee = await self.fee_repo.get_for_update(fee_id, unit_id)
         if not fee:
             raise ResourceNotFoundError("Fee not found")
 
-        active = await self.invoice_repo.get_by_fee_id(
-            fee_id, unit_id, active_only=True
-        )
-        total_active = sum((inv.amount for inv in active), Decimal("0"))
-        target = fee.final_amount - fee.waived_amount
-
-        # Invariant: active invoices must never over-bill the fee.
-        if total_active > target:
-            raise BusinessRuleViolation(
-                f"Active invoices ({total_active}) exceed fee billable amount "
-                f"({target}) for fee {fee_id}"
-            )
-
-        # Terminal statuses are deliberate — leave them.
+        # Terminal statuses first: a stale over-billed waived/cancelled fee stays
+        # a no-op rather than being recomputed.
         if fee.status in (
             FeeStatusEnum.waived.value,
             FeeStatusEnum.cancelled.value,
         ):
             return fee
 
-        remaining = target - fee.paid_amount
-        if fee.paid_amount > 0:
-            fee.status = (
-                FeeStatusEnum.paid.value
-                if remaining <= 0
-                else FeeStatusEnum.partial.value
-            )
-        elif active:
-            fee.status = FeeStatusEnum.invoiced.value
-        else:
-            fee.status = FeeStatusEnum.calculated.value
+        active_count = await self.invoice_repo.count_active_for_fee(fee_id, unit_id)
 
-        await self.db.flush()
+        # Settled by EITHER payment OR waiver.
+        remaining = fee.final_amount - fee.waived_amount - fee.paid_amount
+        if remaining <= 0:
+            new_status = FeeStatusEnum.paid.value
+        elif fee.paid_amount > 0:
+            new_status = FeeStatusEnum.partial.value
+        elif active_count > 0:
+            new_status = FeeStatusEnum.invoiced.value
+        else:
+            new_status = FeeStatusEnum.calculated.value
+
+        if new_status != fee.status:
+            fee.status = new_status
+            fee.version += 1  # optimistic-lock token, like every Fee mutator
+            await self.db.flush()
         return fee
 
     async def apply_penalty(

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -317,17 +317,18 @@ class InvoiceService:
             BusinessRuleViolation: If amount exceeds remaining balance
             BadRequest: If duplicate installment number
         """
-        # PR-B (review v7): LOCK the fee row up-front (not get_by_id_with_relations).
-        # Two reasons:
-        #  (a) recompute below re-reads the fee under the SAME lock — but a plain
-        #      get_for_update on an instance ALREADY in the session does NOT reload
-        #      columns without populate_existing, so without this first-load lock
-        #      recompute would mix a stale status/paid/version with a fresh
-        #      active_count → drift / lost-update under concurrency.
-        #  (b) taking FOR UPDATE before the INSERT avoids the KEY-SHARE→FOR UPDATE
-        #      lock upgrade that two concurrent creates on the same fee deadlock on.
-        # Lock order (fee→invoice) shares only the fee row with cancel
-        # (invoice→fee), so no cycle.
+        # Global lock order (review v8): advisory(invoice-number) -> fee-row ->
+        # invoice — the SAME order generate_invoices_for_fee uses. Acquire the
+        # invoice-number advisory FIRST; v7 took the fee row first, which let
+        # create×generate on one fee ABBA-deadlock on (fee-row ↔ number-advisory).
+        invoice_number = await self._generate_invoice_number()
+
+        # LOCK the fee row up-front (not get_by_id_with_relations) so the checks
+        # below + recompute act on a FRESH fee under the lock (recompute calls
+        # db.refresh — get_for_update alone does NOT repopulate an instance already
+        # in the session), and FOR UPDATE is taken before the INSERT (no
+        # KEY-SHARE→FOR UPDATE upgrade that two concurrent creates would deadlock
+        # on). Shares only the fee row with cancel (invoice→fee), so no cycle.
         fee = await self.fee_repo.get_for_update(fee_id, unit_id)
         if not fee:
             raise ResourceNotFoundError("Fee not found")
@@ -361,9 +362,6 @@ class InvoiceService:
                 f"Invoice amount ({amount}) exceeds remaining balance ({remaining_to_invoice})"
             )
 
-        # Generate invoice number
-        invoice_number = await self._generate_invoice_number()
-
         invoice = Invoice(
             fee_id=fee_id,
             invoice_number=invoice_number,
@@ -390,9 +388,8 @@ class InvoiceService:
             ) from exc
         await self.db.refresh(invoice)
 
-        # Keep Fee.status consistent (PR-B): recompute under a FRESH fee lock so a
-        # concurrent cancel that committed e.g. 'calculated' isn't shadowed by a
-        # stale in-memory snapshot of fee.status here (re-reads the fee row).
+        # Keep Fee.status consistent (PR-B): recompute re-reads the locked fee
+        # (db.refresh inside) and updates status from the active-invoice set.
         await self.recompute_fee_from_invoices(fee_id, unit_id)
 
         log.info(
@@ -607,6 +604,12 @@ class InvoiceService:
         fee = await self.fee_repo.get_for_update(fee_id, unit_id)
         if not fee:
             raise ResourceNotFoundError("Fee not found")
+        # get_for_update does NOT repopulate an instance already in this session
+        # (no populate_existing), so force a fresh read under the lock before
+        # branching on fee.status/paid/waived — a fee loaded earlier in the same
+        # session (e.g. by create_single_invoice) would otherwise be a stale
+        # snapshot and we could skip a needed status UPDATE.
+        await self.db.refresh(fee)
 
         # Terminal statuses first: a stale over-billed waived/cancelled fee stays
         # a no-op rather than being recomputed.

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -550,6 +550,11 @@ class InvoiceService:
 
         await self.db.flush()
 
+        # Nhóm A (PR-B): cancelling an invoice must not leave the parent Fee
+        # stranded ('invoiced' while fewer invoices remain billed). Recompute
+        # Fee.status from the remaining active invoices in the SAME transaction.
+        await self.recompute_fee_from_invoices(invoice.fee_id, unit_id)
+
         log.info(
             "invoice_cancelled",
             invoice_id=invoice_id,
@@ -559,6 +564,69 @@ class InvoiceService:
         )
 
         return invoice, None
+
+    async def recompute_fee_from_invoices(
+        self,
+        fee_id: int,
+        unit_id: Optional[int] = None,
+    ) -> Fee:
+        """Recompute ``Fee.status`` from its ACTIVE (non-cancelled) invoices.
+
+        Nhóm A balance fix (PR-B): ``cancel_invoice`` doesn't touch the Fee, so
+        after a cancel the Fee can drift (status stuck at 'invoiced' while fewer
+        invoices remain billed). Call this in the SAME transaction after a cancel
+        (or any path that changes the active-invoice set) to keep the Fee
+        consistent.
+
+        Status rules (there is no 'partially invoiced' enum — do NOT overload
+        'partial', which means "đã thu một phần"):
+        - ``paid_amount > 0``  -> 'paid' if remaining <= 0 else 'partial'
+        - ``paid_amount == 0`` -> 'invoiced' if any active invoice else 'calculated'
+        Terminal statuses ('waived', 'cancelled') are left untouched — those are
+        deliberate decisions, not a side-effect of cancelling one installment.
+
+        Does NOT change ``final_amount`` / ``waived_amount`` / ``paid_amount`` — a
+        real reduction (giảm trừ) is a separate audited flow. Enforces the balance
+        invariant ``Σ active invoice.amount <= final_amount - waived_amount``.
+        """
+        fee = await self.fee_repo.get_for_update(fee_id, unit_id)
+        if not fee:
+            raise ResourceNotFoundError("Fee not found")
+
+        active = await self.invoice_repo.get_by_fee_id(
+            fee_id, unit_id, active_only=True
+        )
+        total_active = sum((inv.amount for inv in active), Decimal("0"))
+        target = fee.final_amount - fee.waived_amount
+
+        # Invariant: active invoices must never over-bill the fee.
+        if total_active > target:
+            raise BusinessRuleViolation(
+                f"Active invoices ({total_active}) exceed fee billable amount "
+                f"({target}) for fee {fee_id}"
+            )
+
+        # Terminal statuses are deliberate — leave them.
+        if fee.status in (
+            FeeStatusEnum.waived.value,
+            FeeStatusEnum.cancelled.value,
+        ):
+            return fee
+
+        remaining = target - fee.paid_amount
+        if fee.paid_amount > 0:
+            fee.status = (
+                FeeStatusEnum.paid.value
+                if remaining <= 0
+                else FeeStatusEnum.partial.value
+            )
+        elif active:
+            fee.status = FeeStatusEnum.invoiced.value
+        else:
+            fee.status = FeeStatusEnum.calculated.value
+
+        await self.db.flush()
+        return fee
 
     async def apply_penalty(
         self,

--- a/Backend_FastAPI/app/services/invoice_service.py
+++ b/Backend_FastAPI/app/services/invoice_service.py
@@ -317,7 +317,18 @@ class InvoiceService:
             BusinessRuleViolation: If amount exceeds remaining balance
             BadRequest: If duplicate installment number
         """
-        fee = await self.fee_repo.get_by_id_with_relations(fee_id, unit_id)
+        # PR-B (review v7): LOCK the fee row up-front (not get_by_id_with_relations).
+        # Two reasons:
+        #  (a) recompute below re-reads the fee under the SAME lock — but a plain
+        #      get_for_update on an instance ALREADY in the session does NOT reload
+        #      columns without populate_existing, so without this first-load lock
+        #      recompute would mix a stale status/paid/version with a fresh
+        #      active_count → drift / lost-update under concurrency.
+        #  (b) taking FOR UPDATE before the INSERT avoids the KEY-SHARE→FOR UPDATE
+        #      lock upgrade that two concurrent creates on the same fee deadlock on.
+        # Lock order (fee→invoice) shares only the fee row with cancel
+        # (invoice→fee), so no cycle.
+        fee = await self.fee_repo.get_for_update(fee_id, unit_id)
         if not fee:
             raise ResourceNotFoundError("Fee not found")
 

--- a/Backend_FastAPI/tests/services/test_invoice_service.py
+++ b/Backend_FastAPI/tests/services/test_invoice_service.py
@@ -721,3 +721,131 @@ class TestInvoiceRecreateAfterCancelPRA:
                 fee_id=fee.id, amount=Decimal("100000"), due_date=due,
                 installment_no=1, user_id=admin_user.id, unit_id=unit_id,
             )
+
+
+# =============================================================================
+# PR-B: FEE.STATUS RECOMPUTE ON CANCEL (Nhóm A balance)
+# =============================================================================
+
+class TestFeeRecomputeOnCancelPRB:
+    """PR-B: cancelling an invoice recomputes the parent Fee.status from the
+    remaining ACTIVE invoices (+ paid_amount), WITHOUT touching final_amount."""
+
+    async def test_cancel_one_of_many_keeps_invoiced(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Cancel one of several unpaid installments → Fee stays 'invoiced'
+        (still has active invoices, paid=0); final_amount NOT auto-reduced."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee_with_plan"]
+        unit_id = invoice_fixtures["unit_id"]
+        original_final = fee.final_amount
+        invs, _ = await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        await service.cancel_invoice(invs[1].id, "drop one", admin_user.id, unit_id)
+        await db.commit()
+        await db.refresh(fee)
+
+        assert fee.status == FeeStatusEnum.invoiced.value
+        assert fee.final_amount == original_final
+
+    async def test_cancel_all_returns_calculated(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Cancel every invoice (paid=0) → Fee back to 'calculated'; final_amount
+        unchanged (real reduction is a separate audited flow)."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee_with_plan"]
+        unit_id = invoice_fixtures["unit_id"]
+        original_final = fee.final_amount
+        invs, _ = await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        for inv in invs:
+            await service.cancel_invoice(inv.id, "drop all", admin_user.id, unit_id)
+        await db.commit()
+        await db.refresh(fee)
+
+        assert fee.status == FeeStatusEnum.calculated.value
+        assert fee.final_amount == original_final
+
+    async def test_recompute_status_paid_branches(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """paid_amount > 0 → 'partial'; paid >= billable → 'paid'. Never overload
+        'partial' with "đã lập một phần"."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee_with_plan"]
+        unit_id = invoice_fixtures["unit_id"]
+        await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        fee.paid_amount = Decimal("100000")  # > 0, < billable
+        await db.flush()
+        await service.recompute_fee_from_invoices(fee.id, unit_id)
+        await db.refresh(fee)
+        assert fee.status == FeeStatusEnum.partial.value
+
+        fee.paid_amount = fee.final_amount - fee.waived_amount  # >= billable
+        await db.flush()
+        await service.recompute_fee_from_invoices(fee.id, unit_id)
+        await db.refresh(fee)
+        assert fee.status == FeeStatusEnum.paid.value
+
+    async def test_invariant_over_target_raises(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Σ active invoice.amount must not exceed final_amount - waived."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee_with_plan"]
+        unit_id = invoice_fixtures["unit_id"]
+        await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        # Raw-insert an extra ACTIVE invoice (distinct installment_no) pushing the
+        # active total over final_amount, bypassing the service guard.
+        over = Invoice(
+            fee_id=fee.id, invoice_number="INV-TEST-OVER-0001",
+            installment_no=99, amount=Decimal("1000000"),
+            paid_amount=Decimal("0"), penalty_amount=Decimal("0"),
+            status=InvoiceStatusEnum.draft.value,
+            due_date=date.today() + timedelta(days=30),
+        )
+        db.add(over)
+        await db.flush()
+
+        with pytest.raises(BusinessRuleViolation):
+            await service.recompute_fee_from_invoices(fee.id, unit_id)
+        await db.rollback()
+
+    async def test_cancel_blocked_when_invoice_paid(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """Existing guard preserved: an invoice with paid_amount > 0 cannot be
+        cancelled (recompute never runs on a paid installment)."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee_with_plan"]
+        unit_id = invoice_fixtures["unit_id"]
+        invs, _ = await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+        invs[0].paid_amount = Decimal("1")
+        await db.flush()
+
+        with pytest.raises(BusinessRuleViolation):
+            await service.cancel_invoice(invs[0].id, "x", admin_user.id, unit_id)

--- a/Backend_FastAPI/tests/services/test_invoice_service.py
+++ b/Backend_FastAPI/tests/services/test_invoice_service.py
@@ -802,34 +802,83 @@ class TestFeeRecomputeOnCancelPRB:
         await db.refresh(fee)
         assert fee.status == FeeStatusEnum.paid.value
 
-    async def test_invariant_over_target_raises(
+    async def test_cancel_after_post_issue_waive_not_blocked(
         self, db, invoice_fixtures, admin_user
     ):
-        """Σ active invoice.amount must not exceed final_amount - waived."""
+        """F1 (review 06-24): a post-issue waiver can make Σ active >
+        (final - waived). Cancelling to clean up must NOT be blocked — recompute
+        no longer enforces an over-bill invariant (that guard lives at creation)."""
         service = InvoiceService(db)
-        fee = invoice_fixtures["fee_with_plan"]
+        fee = invoice_fixtures["fee_with_plan"]  # final 9_000_000, 3 installments
         unit_id = invoice_fixtures["unit_id"]
-        await service.generate_invoices_for_fee(
+        invs, _ = await service.generate_invoices_for_fee(
             fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
             user_id=admin_user.id, unit_id=unit_id,
         )
         await db.commit()
 
-        # Raw-insert an extra ACTIVE invoice (distinct installment_no) pushing the
-        # active total over final_amount, bypassing the service guard.
-        over = Invoice(
-            fee_id=fee.id, invoice_number="INV-TEST-OVER-0001",
-            installment_no=99, amount=Decimal("1000000"),
-            paid_amount=Decimal("0"), penalty_amount=Decimal("0"),
-            status=InvoiceStatusEnum.draft.value,
-            due_date=date.today() + timedelta(days=30),
-        )
-        db.add(over)
+        # Post-issue waiver shrinking billable below Σ active (still un-paid).
+        fee.waived_amount = Decimal("6000000")  # billable 3M < Σ active 9M
         await db.flush()
 
-        with pytest.raises(BusinessRuleViolation):
-            await service.recompute_fee_from_invoices(fee.id, unit_id)
-        await db.rollback()
+        # Must succeed (no over-bill BusinessRuleViolation).
+        await service.cancel_invoice(
+            invs[0].id, "cleanup over-billed", admin_user.id, unit_id
+        )
+        await db.commit()
+        await db.refresh(fee)
+
+        # remaining = 9M - 6M - 0 = 3M > 0, paid=0, active>0 → invoiced
+        assert fee.status == FeeStatusEnum.invoiced.value
+
+    async def test_full_waive_then_cancel_stays_paid(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """F2 (review 06-24): a fully-waived fee (settled, paid_amount 0) must NOT
+        be reopened to 'calculated' when its invoice is cancelled."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee"]  # single application fee 900_000
+        unit_id = invoice_fixtures["unit_id"]
+        invs, _ = await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+
+        # Full waiver: settled by waiver, status 'paid', paid_amount 0.
+        fee.waived_amount = fee.final_amount
+        fee.status = FeeStatusEnum.paid.value
+        await db.flush()
+
+        await service.cancel_invoice(invs[0].id, "redo billing", admin_user.id, unit_id)
+        await db.commit()
+        await db.refresh(fee)
+
+        assert fee.status == FeeStatusEnum.paid.value  # stays settled, not reopened
+
+    async def test_recompute_bumps_version_on_status_change(
+        self, db, invoice_fixtures, admin_user
+    ):
+        """F3 (review 06-24): recompute bumps fee.version when it changes status,
+        so the optimistic-lock token can't be silently stale."""
+        service = InvoiceService(db)
+        fee = invoice_fixtures["fee_with_plan"]
+        unit_id = invoice_fixtures["unit_id"]
+        invs, _ = await service.generate_invoices_for_fee(
+            fee_id=fee.id, due_date_base=date.today() + timedelta(days=30),
+            user_id=admin_user.id, unit_id=unit_id,
+        )
+        await db.commit()
+        await db.refresh(fee)
+        v0 = fee.version
+
+        for inv in invs:
+            await service.cancel_invoice(inv.id, "all", admin_user.id, unit_id)
+        await db.commit()
+        await db.refresh(fee)
+
+        assert fee.status == FeeStatusEnum.calculated.value
+        assert fee.version > v0  # invoiced→calculated bumped the token
 
     async def test_cancel_blocked_when_invoice_paid(
         self, db, invoice_fixtures, admin_user


### PR DESCRIPTION
## Vấn đề
`cancel_invoice` trước đây **không cập nhật Fee** → Fee drift: status kẹt `'invoiced'` dù số hóa đơn active đã ít hơn, và một fee đã waive toàn phần vẫn hiển thị sai. Nối tiếp PR-A (#429, đóng Nhóm B — tái tạo hóa đơn sau hủy).

## Giải pháp (PR-B — Nhóm A balance)
- **`recompute_fee_from_invoices(fee_id)`**: tính lại `Fee.status` từ **settlement (paid + waived)** và việc còn invoice active hay không. Rule (KHÔNG có enum "đã lập một phần"; KHÔNG overload `'partial'` = đã thu một phần):
  - `final − waived − paid ≤ 0` → `paid` (bắt cả **full-waiver** — `waive_fee` đặt `paid` với `paid_amount==0`)
  - else `paid_amount > 0` → `partial`
  - else còn invoice active → `invoiced`
  - else → `calculated`
- Gọi trong **cùng transaction** sau `cancel_invoice` và trong `create_single_invoice`.
- **Terminal** (`waived`/`cancelled`) short-circuit lên đầu — không đụng.
- **KHÔNG** đổi `final_amount`/`waived_amount`/`paid_amount` (giảm trừ thật = flow riêng có audit).
- **KHÔNG** đặt invariant over-bill trong recompute: recompute chạy trên thao tác **giảm** (cancel) nên không được chặn việc dọn một fee đã over-billed hợp lệ (waiver sau phát hành có thể khiến Σ active > final−waived). Guard over-bill nằm ở **lúc tạo** (`create_single_invoice`).
- Mọi mutator Fee đều bump `fee.version` (optimistic-lock token) — recompute cũng vậy, chỉ khi status đổi.
- Repo `count_active_for_fee` (COUNT thuần, không hydrate payments).

## Đồng thời (concurrency)
- Thứ tự khóa toàn cục thống nhất **advisory(invoice-number) → fee-row → invoice**, khớp `generate_invoices_for_fee` → không ABBA-deadlock (create×create / create×generate).
- `recompute` `db.refresh(fee)` ép đọc tươi dưới khóa (`get_for_update` không repopulate instance đã trong session).
- Lock order chỉ chia sẻ row fee với `cancel_invoice` (invoice→fee) → không chu trình.

## Test — 33/33 pass (service + API)
PR-B thêm: F1 (cancel sau waive không bị chặn) · F2 (full-waive giữ `paid`) · F3 (version bump khi đổi status) · regenerate/recreate/duplicate-block/`total_invoiced` loại cancelled.

## Migration
**Không** (logic only).

## Review
Qua 3 vòng code review (v6/v7/v8): bỏ invariant chặn-cancel-sai + terminal-first; settle-by-waiver; bump version; đóng F5 staleness (khóa fee đầu create + `db.refresh`); thống nhất lock order khử deadlock.

## Phạm vi
3 file, +288/−8. Thuộc lộ trình `Documents/MISA_INVOICE_INTEGRATION_PLAN.md` (Nhóm A); độc lập, ship trước được.

🤖 Generated with [Claude Code](https://claude.com/claude-code)