### PR TITLE
fix(auth): giữ return-url sau hết phiên + proactive token refresh

### DIFF
--- a/frontend/src/components/layouts/SocketHandler.tsx
+++ b/frontend/src/components/layouts/SocketHandler.tsx
@@ -17,6 +17,7 @@ import { financeDashboardKeys } from "@/hooks/finance/useFinanceDashboard";
 import { pipelineKeys } from "@/hooks/usePipeline";
 import { isSafeUrl } from "@/lib/utils";
 import { bumpSuspiciousLoginBanner } from "@/components/layouts/SecurityBanner";
+import { useProactiveTokenRefresh } from "@/hooks/useProactiveTokenRefresh";
 import type { SuspiciousLoginSocketPayload } from "@/types/api.types";
 
 // =============================================================================
@@ -52,6 +53,9 @@ export const INVALIDATION_DEBOUNCE_MS = 300; // 300ms debounce
 export function SocketHandler() {
   // ✅ PERF FIX: Granular selectors to avoid re-registering 30+ socket listeners on unrelated store changes
   const isAuthenticated = useAuthStore(s => s.isAuthenticated);
+  // Proactive refresh access token cho tab đang hoạt động (giữ phiên sống,
+  // giảm 401 + tránh bị middleware đá ra login sau khi access hết hạn).
+  useProactiveTokenRefresh(isAuthenticated);
   const logout = useAuthStore(s => s.logout);
   const user = useAuthStore(s => s.user);
   const addNotification = useAddNotification();

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -21,20 +21,13 @@ import React, { useEffect } from "react";
 import { AxiosError } from "axios";
 import { triggerBannerCheck, triggerSuspiciousLoginBanner } from "@/components/layouts/SecurityBanner";
 import { adminUsersKeys } from "@/hooks/useAdminUsers";
+import { isValidRedirect, buildLoginRedirect } from "@/lib/auth/login-redirect";
 
 /**
  * ✅ PHASE 1 - WEEK 3 - DAY 2: Added initialData support for SSR
  */
 export interface UseAuthOptions {
   initialData?: User;
-}
-
-function isValidRedirect(url: string | null): url is string {
-  if (!url) return false;
-  if (!url.startsWith('/')) return false;
-  if (url.startsWith('//')) return false;
-  if (url.includes(':')) return false;
-  return true;
 }
 
 export function useAuth(options?: UseAuthOptions) {
@@ -485,7 +478,12 @@ export function useAuth(options?: UseAuthOptions) {
         toast.error("Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.");
         logoutStore();
         queryClient.clear();
-        router.push("/login");
+        router.push(
+          buildLoginRedirect(
+            window.location.pathname + window.location.search,
+            { reason: "session_expired" },
+          ),
+        );
       } else {
         toast.error("Không thể tải thông tin người dùng.");
       }

--- a/frontend/src/hooks/useProactiveTokenRefresh.test.tsx
+++ b/frontend/src/hooks/useProactiveTokenRefresh.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Tests cho useProactiveTokenRefresh.
+ *
+ * Trọng tâm: visible-only guard, cross-tab localStorage guard, không
+ * logout khi fail + rollback CAS.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const refreshAccessToken = vi.fn();
+vi.mock("@/lib/api/refresh", () => ({
+  refreshAccessToken: () => refreshAccessToken(),
+}));
+const isApiLoggedOutMock = vi.fn(() => false);
+vi.mock("@/lib/api/client", () => ({
+  isApiLoggedOut: () => isApiLoggedOutMock(),
+}));
+
+import { useProactiveTokenRefresh } from "./useProactiveTokenRefresh";
+
+const KEY = "qlts_last_refresh_at";
+
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+const tick = (ms = 10) => new Promise((r) => setTimeout(r, ms));
+
+describe("useProactiveTokenRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear(); // setup.ts không tự clear giữa các test
+    setVisibility("visible");
+    refreshAccessToken.mockResolvedValue(undefined);
+    isApiLoggedOutMock.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    // Khôi phục visibilityState về mặc định jsdom — Object.defineProperty KHÔNG
+    // bị restoreMocks hoàn tác, phải reset tay tránh leak getter sang file sau.
+    setVisibility("visible");
+  });
+
+  it("refresh on mount khi visible + chưa có timestamp; có ghi timestamp", async () => {
+    renderHook(() => useProactiveTokenRefresh(true));
+    await waitFor(() => expect(refreshAccessToken).toHaveBeenCalledTimes(1));
+    expect(localStorage.getItem(KEY)).not.toBeNull();
+  });
+
+  it("KHÔNG refresh nếu timestamp < 12' (cross-tab guard)", async () => {
+    localStorage.setItem(KEY, String(Date.now()));
+    renderHook(() => useProactiveTokenRefresh(true));
+    await tick();
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("KHÔNG refresh khi tab hidden", async () => {
+    setVisibility("hidden");
+    renderHook(() => useProactiveTokenRefresh(true));
+    await tick();
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("KHÔNG refresh khi enabled=false", async () => {
+    renderHook(() => useProactiveTokenRefresh(false));
+    await tick();
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  it("fail → không throw + rollback timestamp (prev null → xoá key)", async () => {
+    refreshAccessToken.mockRejectedValue(new Error("net"));
+    renderHook(() => useProactiveTokenRefresh(true));
+    await waitFor(() => expect(refreshAccessToken).toHaveBeenCalledTimes(1));
+    // Rollback CAS: prev null → khôi phục bằng cách xoá key.
+    await waitFor(() => expect(localStorage.getItem(KEY)).toBeNull());
+  });
+});

--- a/frontend/src/hooks/useProactiveTokenRefresh.ts
+++ b/frontend/src/hooks/useProactiveTokenRefresh.ts
@@ -1,0 +1,101 @@
+// src/hooks/useProactiveTokenRefresh.ts
+"use client";
+
+import { useEffect, useRef } from "react";
+import { refreshAccessToken } from "@/lib/api/refresh";
+import { isApiLoggedOut } from "@/lib/api/client";
+
+// Access token sống 15' (backend). Refresh chủ động mỗi 13' để luôn còn
+// biên an toàn ~2'. Ngưỡng 12' chặn refresh quá dày khi nhiều tab / nhiều
+// sự kiện focus liên tiếp.
+const REFRESH_INTERVAL_MS = 13 * 60 * 1000;
+const MIN_REFRESH_GAP_MS = 12 * 60 * 1000;
+const LAST_REFRESH_KEY = "qlts_last_refresh_at";
+
+/**
+ * Proactive token refresh cho tab ĐANG HOẠT ĐỘNG.
+ *
+ * Giữ access token sống khi user còn dùng app → giảm 401 và tránh bị
+ * middleware (`proxy.ts`) đá ra login khi hard-reload/điều hướng sau khi
+ * access hết hạn. KHÔNG thay thế reactive 401 flow — chỉ bổ trợ.
+ *
+ * Multi-tab guard (token rotation backend → 2 refresh đồng thời có thể bị
+ * reuse-detection → logout oan):
+ *  - CHỈ tab `visible` mới refresh (thường chỉ 1 tab visible tại 1 thời điểm).
+ *  - `localStorage[qlts_last_refresh_at]` (chia sẻ giữa tab) + ghi-trước-await
+ *    (claim slot) để thu hẹp cửa sổ đua xuống sub-ms.
+ *  - Refresh fail → KHÔNG logout (để reactive 401 xử lý); rollback timestamp
+ *    theo CAS (chỉ khi slot vẫn là của lần gọi này) để cho phép thử lại sớm.
+ */
+export function useProactiveTokenRefresh(enabled: boolean) {
+  const runningRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof window === "undefined") return;
+
+    let cancelled = false;
+
+    const maybeRefresh = async () => {
+      // Chỉ tab đang xem mới refresh (guard đồng-thời multi-tab chính).
+      if (document.visibilityState !== "visible") return;
+      if (isApiLoggedOut()) return;
+      if (runningRef.current) return; // tránh chồng trong cùng tab
+
+      const now = Date.now();
+      const prevRaw = window.localStorage.getItem(LAST_REFRESH_KEY);
+      const prevNum = prevRaw ? Number(prevRaw) : 0;
+      // Sanitize: corrupt/NaN → 0 (coi như chưa refresh). Clamp elapsed>=0 để
+      // timestamp future-dated (clock-skew/tamper) KHÔNG kẹt throttle vĩnh viễn.
+      const prev = Number.isFinite(prevNum) ? prevNum : 0;
+      const elapsed = now - prev;
+      if (elapsed >= 0 && elapsed < MIN_REFRESH_GAP_MS) {
+        return; // tab khác (hoặc chính tab này) vừa refresh → bỏ qua
+      }
+
+      // Claim slot TRƯỚC khi await (thu hẹp race cross-tab xuống sub-ms).
+      const stamp = String(now);
+      window.localStorage.setItem(LAST_REFRESH_KEY, stamp);
+      runningRef.current = true;
+      try {
+        await refreshAccessToken();
+      } catch {
+        // Nuốt lỗi — KHÔNG logout/redirect (reactive 401 của request kế
+        // tiếp sẽ xử lý). Rollback CAS: chỉ khôi phục nếu slot vẫn là `stamp`
+        // mình vừa ghi (chưa tab/lần khác ghi đè) → cho phép thử lại sớm
+        // sau lỗi mạng tạm, KHÔNG đạp lên refresh thành công của tab khác.
+        if (window.localStorage.getItem(LAST_REFRESH_KEY) === stamp) {
+          // Khôi phục prev hợp lệ; nếu prev corrupt/null → xoá (lần sau coi như
+          // chưa refresh, tự lành sau 1 refresh thành công).
+          if (prevRaw !== null && Number.isFinite(Number(prevRaw))) {
+            window.localStorage.setItem(LAST_REFRESH_KEY, prevRaw);
+          } else {
+            window.localStorage.removeItem(LAST_REFRESH_KEY);
+          }
+        }
+      } finally {
+        runningRef.current = false;
+      }
+    };
+
+    const intervalId = setInterval(() => {
+      void maybeRefresh();
+    }, REFRESH_INTERVAL_MS);
+
+    const onWake = () => {
+      if (!cancelled) void maybeRefresh();
+    };
+    document.addEventListener("visibilitychange", onWake);
+    window.addEventListener("focus", onWake);
+
+    // 1 lần khi mount (cover tab mở với access token đã cũ).
+    void maybeRefresh();
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", onWake);
+      window.removeEventListener("focus", onWake);
+    };
+  }, [enabled]);
+}

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -29,6 +29,7 @@ vi.mock("axios", () => {
 
 // Now safe to import
 import { setApiLoggedOut } from "./client";
+import { buildLoginRedirect } from "@/lib/auth/login-redirect";
 
 describe("API Client — Logout Guard", () => {
   beforeEach(() => {
@@ -55,9 +56,23 @@ describe("API Client — Force Login Contract", () => {
     expect(url.searchParams.get("force_login")).toBe("true");
   });
 
-  it("force_login URL does not include other params", () => {
-    const redirectUrl = "/login?force_login=true";
-    const url = new URL(redirectUrl, "http://localhost:3000");
-    expect(Array.from(url.searchParams.keys())).toEqual(["force_login"]);
+  it("force_login URL nay kèm redirect khi có path hợp lệ (contract mới)", () => {
+    // Interceptor 401 nay dùng buildLoginRedirect(path, { forceLogin: true }).
+    const withPath = new URL(
+      buildLoginRedirect("/leads/5", { forceLogin: true }),
+      "http://localhost:3000",
+    );
+    expect(Array.from(withPath.searchParams.keys())).toEqual([
+      "force_login",
+      "redirect",
+    ]);
+    expect(withPath.searchParams.get("redirect")).toBe("/leads/5");
+
+    // Không có path hợp lệ → vẫn chỉ force_login (giữ contract cũ).
+    const noPath = new URL(
+      buildLoginRedirect(null, { forceLogin: true }),
+      "http://localhost:3000",
+    );
+    expect(Array.from(noPath.searchParams.keys())).toEqual(["force_login"]);
   });
 });

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -27,6 +27,8 @@ import {
 } from "./csrf";
 import { env } from "@/lib/config/env";
 import { inspectVersionHeaders } from "@/lib/api/api-versioning";
+import { refreshAccessToken } from "./refresh";
+import { buildLoginRedirect } from "@/lib/auth/login-redirect";
 export const API_BASE_URL = env.NEXT_PUBLIC_API_URL;
 
 // ============================================
@@ -34,7 +36,7 @@ export const API_BASE_URL = env.NEXT_PUBLIC_API_URL;
 // ============================================
 // Uses window global to survive Turbopack HMR module reloads.
 // Set by logoutMutation in useAuth.ts, reset on login success.
-function isApiLoggedOut(): boolean {
+export function isApiLoggedOut(): boolean {
   return typeof window !== "undefined" && !!(window as unknown as Record<string, unknown>).__qlts_logged_out;
 }
 export function setApiLoggedOut(value: boolean) {
@@ -53,36 +55,11 @@ export const api = axios.create({
 });
 
 // ============================================
-// 🔒 AUTO-REFRESH TOKEN MECHANISM (FIX-4 ENHANCED)
+// 🔒 AUTO-REFRESH TOKEN MECHANISM
 // ============================================
-
-/**
- * Mutex lock + Queue mechanism to prevent race conditions
- *
- * When multiple requests receive 401 simultaneously:
- * - Only ONE refresh request is made (Leader)
- * - Other requests wait in queue (Followers)
- * - After refresh success, all queued requests retry
- *
- * This prevents "Token Reuse Detection" false positives
- * caused by duplicate refresh requests hitting backend.
- */
-let isRefreshing = false;
-let failedQueue: Array<{
-  resolve: (value?: unknown) => void;
-  reject: (reason?: unknown) => void;
-}> = [];
-
-const processQueue = (error: unknown, token: string | null = null) => {
-  failedQueue.forEach((prom) => {
-    if (error) {
-      prom.reject(error);
-    } else {
-      prom.resolve(token);
-    }
-  });
-  failedQueue = [];
-};
+// Logic single-flight (mutex + queue + delay 100ms cookie-persist) đã được
+// tách sang ./refresh (`refreshAccessToken`) để dùng chung cho: interceptor
+// 401, CSRF-recovery, và hook proactive (useProactiveTokenRefresh).
 
 // ============================================
 // 📤 REQUEST INTERCEPTOR
@@ -166,6 +143,9 @@ api.interceptors.response.use(
       }
 
       const currentPath = typeof window !== "undefined" ? window.location.pathname : "";
+      // Capture search CÙNG LÚC (trước await refresh) — tránh trộn pathname cũ
+      // với query mới nếu user điều hướng client-side trong lúc refresh.
+      const currentSearch = typeof window !== "undefined" ? window.location.search : "";
 
       // Don't redirect if already on public pages
       const publicPages = ["/login", "/register", "/forgot-password", "/reset-password"];
@@ -174,74 +154,21 @@ api.interceptors.response.use(
       }
 
       // ========================================
-      // STEP 2: QUEUE MECHANISM (Follower)
-      // If refresh is already in progress, queue this request
-      // ========================================
-      if (isRefreshing) {
-        if (process.env.NODE_ENV === "development") {
-          console.log("[API Client] 🔄 Request queued (refresh in progress)");
-        }
-
-        return new Promise((resolve, reject) => {
-          failedQueue.push({ resolve, reject });
-        })
-          .then(() => {
-            // When queue is processed, retry original request
-            return api(originalRequest);
-          })
-          .catch((err) => {
-            return Promise.reject(err);
-          });
-      }
-
-      // ========================================
-      // STEP 3: START REFRESH PROCESS (Leader)
+      // STEP 2: REFRESH (single-flight) + RETRY
+      // refreshAccessToken() tự xử lý mutex/queue/100ms (xem ./refresh):
+      // request đầu là leader gọi /auth/refresh, các request khác chờ.
       // ========================================
       originalRequest._retry = true;
-      isRefreshing = true;
 
       try {
-        if (process.env.NODE_ENV === "development") {
-          console.log("[API Client] 🔄 Access token expired, refreshing...");
-        }
-
-        // Call /refresh endpoint (tokens sent/received via httpOnly cookies)
-        await axios.post(
-          `${API_BASE_URL}/api/auth/refresh`,
-          {},
-          {
-            withCredentials: true, // ✅ Important: Send refresh_token cookie
-          }
-        );
-
-        // ⚠️ DEFENSIVE FIX: Wait for browser to persist new cookie
-        // This prevents race condition at browser storage level
-        // Some browsers (especially mobile) need 50-150ms to persist cookies
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        if (process.env.NODE_ENV === "development") {
-          console.log("[API Client] ✅ Token refreshed successfully (via httpOnly cookie)");
-        }
-
-        // ========================================
-        // STEP 4: NOTIFY QUEUED REQUESTS
-        // ========================================
-        processQueue(null, "success");
-
-        // ========================================
-        // STEP 5: RETRY ORIGINAL REQUEST
-        // ========================================
+        await refreshAccessToken();
+        // Refresh thành công → retry request gốc với cookie mới.
         return api(originalRequest);
       } catch (refreshError) {
         console.error("[API Client] ❌ Refresh failed:", refreshError);
 
-        // ========================================
-        // STEP 6: HANDLE REFRESH FAILURE
-        // ========================================
-        processQueue(refreshError, null);
-
-        // Fallback Logout: Set logout flag to stop further API calls,
-        // call logout API to clear httpOnly cookies, then hard redirect.
+        // Fallback Logout: chặn API tiếp theo, clear store, rồi hard
+        // redirect KÈM return-url để sau khi đăng nhập lại quay về đúng trang.
         if (typeof window !== "undefined" && !publicPages.includes(currentPath)) {
           console.log("[API Client] 🚪 Session invalid — logging out...");
           setApiLoggedOut(true);
@@ -254,15 +181,13 @@ api.interceptors.response.use(
             // Best-effort
           }
 
-          // Redirect with force_login flag — middleware will clear stale
-          // httpOnly cookies that JS can't delete directly
-          window.location.href = "/login?force_login=true";
+          // force_login → middleware xoá cookie cũ mà JS không xoá được.
+          window.location.href = buildLoginRedirect(currentPath + currentSearch, {
+            forceLogin: true,
+          });
         }
 
         return Promise.reject(refreshError);
-      } finally {
-        // Always unlock mutex
-        isRefreshing = false;
       }
     }
 
@@ -312,30 +237,30 @@ api.interceptors.response.use(
           }
         }
 
-        // Try refresh — /auth/refresh is CSRF-exempt and sets a new csrf_token cookie
+        // Try refresh — /auth/refresh là CSRF-exempt và set lại csrf_token cookie.
+        // Dùng chung refreshAccessToken() (single-flight) — tránh chạy song song
+        // với một refresh do 401 đang diễn ra.
         originalRequest._retry = true;
         try {
-          await axios.post(
-            `${API_BASE_URL}/api/auth/refresh`,
-            {},
-            { withCredentials: true }
-          );
-
-          // Wait for browser to persist the new csrf_token cookie
-          await new Promise((resolve) => setTimeout(resolve, 100));
+          await refreshAccessToken();
 
           if (process.env.NODE_ENV === "development") {
             console.log("[API Client] ✅ CSRF recovery: refresh succeeded, retrying original request");
           }
 
-          // Retry original request — interceptor will re-read fresh csrf_token from document.cookie
+          // Retry — interceptor sẽ đọc lại csrf_token mới từ document.cookie.
           return api(originalRequest);
         } catch (refreshError) {
           console.warn("[API Client] ❌ CSRF recovery failed (refresh rejected) — redirecting to login");
 
           if (typeof window !== "undefined") {
             setApiLoggedOut(true);
-            window.location.href = "/login?reason=session_expired";
+            // forceLogin → middleware xoá httpOnly cookie chết (giống nhánh 401);
+            // CSRF-recovery fail nghĩa session đã hết hiệu lực.
+            window.location.href = buildLoginRedirect(
+              window.location.pathname + window.location.search,
+              { forceLogin: true, reason: "session_expired" },
+            );
           }
 
           return Promise.reject(refreshError);

--- a/frontend/src/lib/api/refresh.test.ts
+++ b/frontend/src/lib/api/refresh.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests cho refreshAccessToken — single-flight refresh.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("axios", () => {
+  const post = vi.fn();
+  return { default: { post }, post };
+});
+
+import axios from "axios";
+import { refreshAccessToken } from "./refresh";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPost = axios.post as any;
+
+describe("refreshAccessToken — single-flight", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("nhiều lời gọi đồng thời → chỉ 1 POST /api/auth/refresh", async () => {
+    mockPost.mockResolvedValue({ data: {} });
+
+    const callers = [
+      refreshAccessToken(),
+      refreshAccessToken(),
+      refreshAccessToken(),
+    ];
+    await Promise.all(callers);
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.stringContaining("/api/auth/refresh"),
+      {},
+      expect.objectContaining({ withCredentials: true }),
+    );
+  });
+
+  it("fail → mọi caller reject + mutex reset (lần sau phát POST mới)", async () => {
+    mockPost.mockRejectedValueOnce(new Error("boom"));
+
+    const callers = [refreshAccessToken(), refreshAccessToken()];
+    await expect(Promise.all(callers)).rejects.toThrow("boom");
+
+    // Mutex đã reset → lời gọi mới tạo POST mới (không bị kẹt isRefreshing).
+    mockPost.mockResolvedValueOnce({ data: {} });
+    await refreshAccessToken();
+    expect(mockPost).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/lib/api/refresh.ts
+++ b/frontend/src/lib/api/refresh.ts
@@ -1,0 +1,44 @@
+// src/lib/api/refresh.ts
+/**
+ * Single-flight refresh access token (tách từ client.ts interceptor).
+ *
+ * Dùng chung cho: interceptor 401, CSRF-recovery (client.ts), và hook
+ * proactive (useProactiveTokenRefresh). Single-flight bằng SHARED-PROMISE:
+ * N caller đồng thời chia sẻ CÙNG promise đang bay → chỉ 1 POST /auth/refresh
+ * thật (tránh token-reuse-detection do refresh trùng). Giữ delay 100ms cho
+ * browser persist cookie mới.
+ *
+ * Module CHỈ import axios + env + endpoints (KHÔNG import `api` từ client.ts)
+ * để tránh circular import. Leader dùng bare `axios.post` — không cần
+ * interceptor cho chính call refresh (đúng hành vi inline cũ).
+ */
+import axios from "axios";
+import { env } from "@/lib/config/env";
+import { API_ENDPOINTS } from "@/lib/api/endpoints";
+
+let inflight: Promise<void> | null = null;
+
+/**
+ * Refresh access token (rotate cookie qua POST /api/auth/refresh).
+ *
+ * Single-flight: các lời gọi đồng thời chia sẻ cùng promise đang bay;
+ * resolve khi xong, reject khi thất bại, rồi `inflight` reset để lần sau
+ * phát request mới. KHÔNG side-effect logout/redirect — caller tự quyết
+ * (interceptor 401 logout, hook proactive im lặng).
+ */
+export function refreshAccessToken(): Promise<void> {
+  if (inflight) return inflight;
+  inflight = (async () => {
+    // Tokens gửi/nhận qua httpOnly cookie.
+    await axios.post(
+      `${env.NEXT_PUBLIC_API_URL}${API_ENDPOINTS.AUTH.REFRESH}`,
+      {},
+      { withCredentials: true },
+    );
+    // ⚠️ DEFENSIVE: chờ browser persist cookie mới trước khi caller retry.
+    await new Promise((r) => setTimeout(r, 100));
+  })().finally(() => {
+    inflight = null;
+  });
+  return inflight;
+}

--- a/frontend/src/lib/api/server.ts
+++ b/frontend/src/lib/api/server.ts
@@ -170,7 +170,11 @@ async function serverFetch<T>(
 
   // Handle non-OK responses
   if (!response.ok) {
-    // 401 Unauthorized — token expired/blacklisted → redirect to login
+    // 401 Unauthorized — token expired/blacklisted → redirect to login.
+    // LIMITATION (scope return-url): RSC serverFetch không có request path nên
+    // không đính được ?redirect=<trang đang xem>; user về dashboard mặc định
+    // sau khi đăng nhập lại. Client-side navigation (case phổ biến nhất) đã giữ
+    // return-url qua proxy.ts + client.ts interceptor (buildLoginRedirect).
     if (response.status === 401) {
       redirect('/login?force_login=true');
     }

--- a/frontend/src/lib/auth/login-redirect.test.ts
+++ b/frontend/src/lib/auth/login-redirect.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests cho login-redirect helper (return-url an toàn).
+ *
+ * Trọng tâm: isValidRedirect CHỈ validate path-part (query/hash tự do),
+ * và buildLoginRedirect giữ thứ tự param cố định + chỉ đính redirect hợp lệ.
+ */
+import { describe, it, expect } from "vitest";
+import { isValidRedirect, buildLoginRedirect } from "./login-redirect";
+
+describe("isValidRedirect", () => {
+  it("accept path nội bộ thường", () => {
+    expect(isValidRedirect("/leads/1")).toBe(true);
+    expect(isValidRedirect("/dashboard")).toBe(true);
+  });
+
+  it("accept query/hash chứa ':' hoặc encoded — chỉ validate path-part", () => {
+    expect(isValidRedirect("/finance?from=2026-06-24T10:00:00")).toBe(true);
+    expect(isValidRedirect("/leads?q=a:b")).toBe(true);
+    expect(isValidRedirect("/x#sec")).toBe(true);
+    // encoded slash NẰM Ở QUERY → vẫn hợp lệ (path-part sạch; router.push không đổi origin)
+    expect(isValidRedirect("/finance?next=%2f%2fevil")).toBe(true);
+  });
+
+  it("reject falsy / non-internal / path-part xấu", () => {
+    expect(isValidRedirect(null)).toBe(false);
+    expect(isValidRedirect(undefined)).toBe(false);
+    expect(isValidRedirect("")).toBe(false);
+    expect(isValidRedirect("http://evil.com")).toBe(false);
+    expect(isValidRedirect("//evil.com")).toBe(false);
+    expect(isValidRedirect("/a:b")).toBe(false); // ':' ở path-part
+    expect(isValidRedirect("\\evil")).toBe(false);
+    expect(isValidRedirect("/%2f%2fevil")).toBe(false); // encoded slash ở path-part
+    expect(isValidRedirect("/%5cevil")).toBe(false);
+  });
+
+  it("reject public auth path (tránh loop redirect về /login)", () => {
+    expect(isValidRedirect("/login")).toBe(false);
+    expect(isValidRedirect("/login?x=1")).toBe(false);
+    expect(isValidRedirect("/login/abc")).toBe(false);
+    expect(isValidRedirect("/register")).toBe(false);
+    expect(isValidRedirect("/forgot-password")).toBe(false);
+    expect(isValidRedirect("/reset-password")).toBe(false);
+    // Không nhầm prefix: '/loginx' KHÔNG phải '/login' hay '/login/'
+    expect(isValidRedirect("/loginx")).toBe(true);
+  });
+});
+
+describe("buildLoginRedirect", () => {
+  it("trả /login khi không path hợp lệ và không opts", () => {
+    expect(buildLoginRedirect(null)).toBe("/login");
+    expect(buildLoginRedirect("http://evil")).toBe("/login");
+    expect(buildLoginRedirect(undefined)).toBe("/login");
+  });
+
+  it("đính redirect (gồm query) khi path hợp lệ", () => {
+    const url = new URL(
+      buildLoginRedirect("/finance/invoices?profile=123"),
+      "http://localhost",
+    );
+    expect(url.pathname).toBe("/login");
+    expect(url.searchParams.get("redirect")).toBe("/finance/invoices?profile=123");
+  });
+
+  it("force_login + reason + redirect theo THỨ TỰ cố định", () => {
+    const url = new URL(
+      buildLoginRedirect("/leads/1", {
+        forceLogin: true,
+        reason: "session_expired",
+      }),
+      "http://localhost",
+    );
+    expect(Array.from(url.searchParams.keys())).toEqual([
+      "force_login",
+      "reason",
+      "redirect",
+    ]);
+    expect(url.searchParams.get("redirect")).toBe("/leads/1");
+  });
+
+  it("forceLogin nhưng path không hợp lệ → chỉ force_login (giữ contract cũ)", () => {
+    const url = new URL(
+      buildLoginRedirect(null, { forceLogin: true }),
+      "http://localhost",
+    );
+    expect(Array.from(url.searchParams.keys())).toEqual(["force_login"]);
+  });
+
+  it("bỏ redirect khi cross-origin, vẫn giữ reason", () => {
+    const url = new URL(
+      buildLoginRedirect("http://evil", { reason: "session_expired" }),
+      "http://localhost",
+    );
+    expect(url.searchParams.has("redirect")).toBe(false);
+    expect(url.searchParams.get("reason")).toBe("session_expired");
+  });
+});

--- a/frontend/src/lib/auth/login-redirect.ts
+++ b/frontend/src/lib/auth/login-redirect.ts
@@ -1,0 +1,65 @@
+// src/lib/auth/login-redirect.ts
+/**
+ * Helper canonical cho luồng redirect tới /login + giữ return-url.
+ *
+ * Dùng chung cho cả EDGE (proxy.ts middleware) lẫn BROWSER (client.ts,
+ * useAuth.ts). Vì vậy module này PHẢI runtime-agnostic: chỉ dùng
+ * URLSearchParams/String — KHÔNG `window`, không API riêng của Node.
+ */
+
+/**
+ * Một chuỗi redirect có an toàn để điều hướng nội bộ không.
+ *
+ * CHỈ validate PHẦN PATH (đoạn trước `?`/`#`) — query/hash để TỰ DO,
+ * cho phép giá trị filter/timestamp/text chứa `:` hoặc encoded slash
+ * (vd `/finance?from=2026-06-24T10:00:00`, `/leads?q=a:b`). An toàn vì
+ * path đã chắc chắn internal (bắt đầu `/`, không `//`, không protocol),
+ * và `router.push`/`new URL(x, origin)` không thể đổi origin từ query.
+ *
+ * Cũng reject các public auth path (/login, /register, ...) làm return-url —
+ * tránh vòng lặp redirect về chính trang đăng nhập.
+ */
+const AUTH_PATHS = ["/login", "/register", "/forgot-password", "/reset-password"];
+
+export function isValidRedirect(
+  url: string | null | undefined,
+): url is string {
+  if (!url) return false;
+  if (!url.startsWith("/")) return false;
+  if (url.startsWith("//")) return false;
+  // Chỉ xét path-part (đoạn trước query/hash).
+  const pathPart = url.split(/[?#]/, 1)[0];
+  if (pathPart.includes(":")) return false; // protocol-like
+  if (pathPart.includes("\\")) return false; // backslash
+  if (/%2f|%5c/i.test(pathPart)) return false; // encoded slash/backslash
+  // Không return-url về trang auth (tránh loop /login?redirect=/login).
+  if (AUTH_PATHS.some((p) => pathPart === p || pathPart.startsWith(`${p}/`)))
+    return false;
+  return true;
+}
+
+export interface BuildLoginRedirectOptions {
+  /** Thêm `force_login=true` (proxy middleware sẽ xoá cookie cũ). */
+  forceLogin?: boolean;
+  /** Thêm `reason=<...>` (chỉ để hiển thị/debug ở trang login). */
+  reason?: string;
+}
+
+/**
+ * Build URL tương đối `/login?...` cho luồng redirect-do-hết-phiên.
+ *
+ * Param theo THỨ TỰ CỐ ĐỊNH `force_login, reason, redirect` (test
+ * `client.test.ts` assert mảng keys chính xác). Chỉ đính `redirect` khi
+ * `currentPath` hợp lệ (internal). Trả `/login` khi không có param.
+ */
+export function buildLoginRedirect(
+  currentPath: string | null | undefined,
+  opts: BuildLoginRedirectOptions = {},
+): string {
+  const params = new URLSearchParams();
+  if (opts.forceLogin) params.set("force_login", "true");
+  if (opts.reason) params.set("reason", opts.reason);
+  if (isValidRedirect(currentPath)) params.set("redirect", currentPath);
+  const qs = params.toString();
+  return qs ? `/login?${qs}` : "/login";
+}

--- a/frontend/src/lib/socket/client.ts
+++ b/frontend/src/lib/socket/client.ts
@@ -3,6 +3,7 @@ import { io, Socket } from "socket.io-client";
 import { env } from "@/lib/config/env";
 import { useAuthStore } from "../stores/auth.store";
 import { toast } from "sonner";
+import { buildLoginRedirect } from "@/lib/auth/login-redirect";
 
 class SocketService {
   private socket: Socket | null = null;
@@ -195,7 +196,12 @@ class SocketService {
               });
 
               if (typeof window !== "undefined") {
-                window.location.href = "/login";
+                // Return-url vô điều kiện: revalidate_auth fail (hết phiên/thu
+                // hồi) — login lại vẫn là chính user nên quay về trang cũ an toàn.
+                window.location.href = buildLoginRedirect(
+                  window.location.pathname + window.location.search,
+                  { reason: "session_expired" },
+                );
               }
             }
           }

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -17,6 +17,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { decodeJWT, isTokenExpired } from "@/lib/auth/jwt-decode";
 import { hasAdminAccess, hasFinanceAccess } from "@/lib/config/roles";
+import { buildLoginRedirect } from "@/lib/auth/login-redirect";
 
 // ============================================
 // 🛣️ ROUTE CONFIGURATION
@@ -129,10 +130,11 @@ export function proxy(request: NextRequest) {
   const accessToken = request.cookies.get("access_token")?.value;
 
   if (!accessToken) {
-    // Expected for unauthenticated visitors — redirect silently
-    const loginUrl = new URL("/login", request.url);
-    loginUrl.searchParams.set("redirect", pathname);
-    return NextResponse.redirect(loginUrl);
+    // Expected for unauthenticated visitors — redirect silently, giữ cả query
+    // (nhất quán với nhánh token invalid/expired bên dưới).
+    return NextResponse.redirect(
+      new URL(buildLoginRedirect(pathname + request.nextUrl.search), request.url),
+    );
   }
 
   // ========================================
@@ -144,8 +146,10 @@ export function proxy(request: NextRequest) {
   if (!payload) {
     console.warn(`[Proxy] ❌ Invalid token format for: ${pathname}`);
 
-    // Clear invalid cookie and redirect
-    const response = NextResponse.redirect(new URL("/login", request.url));
+    // Clear invalid cookie and redirect (giữ return-url để login xong quay lại)
+    const response = NextResponse.redirect(
+      new URL(buildLoginRedirect(pathname + request.nextUrl.search), request.url),
+    );
     response.cookies.delete("access_token");
     return response;
   }
@@ -154,8 +158,10 @@ export function proxy(request: NextRequest) {
   if (isTokenExpired(accessToken)) {
     console.warn(`[Proxy] ❌ Expired token for: ${pathname}`);
 
-    // Clear expired cookie and redirect
-    const response = NextResponse.redirect(new URL("/login", request.url));
+    // Clear expired cookie and redirect (giữ return-url để login xong quay lại)
+    const response = NextResponse.redirect(
+      new URL(buildLoginRedirect(pathname + request.nextUrl.search), request.url),
+    );
     response.cookies.delete("access_token");
     return response;
   }


### PR DESCRIPTION
## Vấn đề
Sau khi access token hết hạn → bị đá về `/login`; **login lại KHÔNG quay về trang đang làm** (luôn về dashboard). Và không có cơ chế refresh khi token *sắp* hết hạn.

## #1 Return-URL
- **Mới** `lib/auth/login-redirect.ts`: `isValidRedirect` chỉ validate **path-part** (giữ query chứa `:`/encoded) + reject public auth-path (chống loop `/login`); `buildLoginRedirect` param order cố định.
- Mọi nhánh redirect-do-hết-phiên kèm `?redirect=<path+query>`: `proxy.ts` (no-token + invalid + expired), `client.ts` (401 + CSRF, đều `forceLogin` xóa httpOnly cookie), `useAuth` /me 401, `socket/client.ts` (revalidate-fail). Giữ nguyên logout/đổi-mật-khẩu. `LoginForm` hiển thị `reason=session_expired`. `server.ts` RSC: comment limitation.

## #2 Proactive refresh
- **Mới** `hooks/useProactiveTokenRefresh.ts`: visible-only + `localStorage` CAS-guard (robust NaN/future-date), interval 13′ < 15′ TTL, fail **KHÔNG** logout. Mount ở `SocketHandler`.
- **Mới** `lib/api/refresh.ts`: `refreshAccessToken()` single-flight (shared-promise) dùng chung 401 + CSRF + hook; export `isApiLoggedOut`.

## Kiểm thử
- type-check + `next build` compile sạch · **38 test** (20 mới + 18 consumer) pass.
- **Chrome smoke** (dev, code mới): `/finance/invoices?profile_id=123&tab=issued` (logged-out) → `/login?redirect=...` (giữ đầy đủ query) → login → **quay về đúng URL kèm query** ✓; `/login?reason=session_expired` → hiển thị "Phiên đăng nhập đã hết hạn" ✓; console sạch.
- Đã qua 2 vòng code-review max (7 finding đã fix: no-token query, auth-path guard, CSRF forceLogin, timestamp robust, capture pathname+search, reason UX, test restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)