### PR TITLE
feat(reports): card "Đóng phí chưa nộp" (prepay-draft) trong báo cáo tuyển sinh

### DIFF
--- a/Backend_FastAPI/app/schemas/admission_report.py
+++ b/Backend_FastAPI/app/schemas/admission_report.py
@@ -53,6 +53,9 @@ class AdmissionMetrics(BaseModel):
     submitted_cumulative: int = 0
     admitted_cumulative: int = 0
     enrolled_cumulative: int = 0
+    # Đã đóng lệ phí xét tuyển (application paid) NHƯNG hồ sơ CHƯA nộp (chưa có
+    # milestone submitted) — nhóm prepay fast-track cần nhắc hoàn tất nộp hồ sơ.
+    fee_paid_not_submitted: int = 0
     # chỉ tiêu (annual_admission_quota) — major grouping only; None for officer
     # view / buckets / total rows where a quota does not apply.
     quota: Optional[int] = None

--- a/Backend_FastAPI/app/services/admission_report_service.py
+++ b/Backend_FastAPI/app/services/admission_report_service.py
@@ -226,6 +226,9 @@ class AdmissionReportService:
 
         # ---- finance ledger (cash: payment/refund; refund amount stored negative)
         paid_profiles: dict[GroupKey, set] = {}
+        # Profiles with a cumulative APPLICATION-fee payment — used to surface the
+        # "đã đóng lệ phí nhưng chưa nộp hồ sơ" (prepay-draft) cohort below.
+        app_paid_profiles: dict[GroupKey, set] = {}
         for pid, fee_type, ttype, amount, created_at in fin_rows:
             dim = dims.get(pid)
             if dim is None:
@@ -236,6 +239,8 @@ class AdmissionReportService:
             f.net_cumulative += amt
             if ttype == "payment":
                 paid_profiles.setdefault(key, set()).add(pid)
+                if fee_type == "application":
+                    app_paid_profiles.setdefault(key, set()).add(pid)
             if week.start <= created_at < week.end_excl:
                 f.net_in_week += amt
                 if ttype == "payment":
@@ -248,6 +253,14 @@ class AdmissionReportService:
                     f.tuition_net_in_week += amt
         for key, pids in paid_profiles.items():
             _row(key).finance.profiles_paid = len(pids)
+        # Prepay-draft: đã đóng lệ phí xét tuyển nhưng CHƯA nộp hồ sơ (no submitted
+        # milestone) — nhóm prepay fast-track cần nhắc hoàn tất nộp hồ sơ.
+        for key, pids in app_paid_profiles.items():
+            _row(key).admission.fee_paid_not_submitted = sum(
+                1
+                for pid in pids
+                if not milestones.get(pid, {}).get("submitted_cumulative")
+            )
 
         # ---- labels
         officer_names: dict[int, str] = {}
@@ -361,6 +374,7 @@ class AdmissionReportService:
                 "submitted_cumulative",
                 "admitted_cumulative",
                 "enrolled_cumulative",
+                "fee_paid_not_submitted",
             ):
                 setattr(
                     t.admission, m, getattr(t.admission, m) + getattr(row.admission, m)

--- a/Backend_FastAPI/tests/repositories/test_admission_report_integration.py
+++ b/Backend_FastAPI/tests/repositories/test_admission_report_integration.py
@@ -934,3 +934,51 @@ async def test_iso_week1_monday_in_prior_year_not_rejected(
     )
     assert resp.week.iso_year == year
     assert resp.week.week_start == monday_w1  # refetch-stable, not rejected
+
+
+async def test_application_paid_without_submit_counts_prepay_draft(
+    db: AsyncSession, seeded_dependencies: dict, officer_user_in_db: dict
+):
+    """fee_paid_not_submitted = đã đóng lệ phí XÉT TUYỂN nhưng CHƯA có milestone
+    submitted (nhóm prepay-draft cần nhắc hoàn tất). Một hồ sơ đã submit — dù
+    cũng đóng lệ phí — KHÔNG tính; lệ phí 'tuition' không tính (chỉ application)."""
+    year = next(_year_seq)
+    unit_id = seeded_dependencies["unit_id"]
+    officer_id = officer_user_in_db["id"]
+    anchor, win = _week(year)
+    major, offering = await _seed_catalog(db, year, unit_id)
+
+    # (1) prepay-draft: application paid, NO submitted history → counted
+    _, p_draft = await _seed_lead_profile(
+        db, seeded_dependencies, year, offering.id, officer_id,
+        created_at=win.start + timedelta(days=1),
+    )
+    fee_d = await _seed_fee(db, p_draft.id, year)  # application
+    await _add_txn(db, fee_d.id, "payment", "1000000", win.start + timedelta(days=2))
+
+    # (2) submitted + application paid → NOT prepay-draft (already nộp)
+    _, p_sub = await _seed_lead_profile(
+        db, seeded_dependencies, year, offering.id, officer_id,
+        created_at=win.start + timedelta(days=1),
+    )
+    await _seed_history(db, p_sub.id, "submitted", win.start + timedelta(days=2))
+    fee_s = await _seed_fee(db, p_sub.id, year)
+    await _add_txn(db, fee_s.id, "payment", "1000000", win.start + timedelta(days=2))
+
+    # (3) tuition paid only (no application, no submit) → NOT counted
+    _, p_tui = await _seed_lead_profile(
+        db, seeded_dependencies, year, offering.id, officer_id,
+        created_at=win.start + timedelta(days=1),
+    )
+    fee_t = await _seed_fee(db, p_tui.id, year, fee_type="tuition")
+    await _add_txn(db, fee_t.id, "payment", "1000000", win.start + timedelta(days=2))
+
+    svc = AdmissionReportService(db)
+    resp = await svc.get_weekly_report(
+        current_user=_admin(), academic_year=year, group_by="major", week_start=anchor
+    )
+    row = _find(resp.rows, major.id)
+    assert row is not None
+    assert row.admission.fee_paid_not_submitted == 1  # only p_draft
+    assert row.admission.submitted_cumulative == 1  # only p_sub (milestone)
+    assert resp.totals.admission.fee_paid_not_submitted == 1

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/SummaryBand.test.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/SummaryBand.test.tsx
@@ -13,6 +13,7 @@ function mkRow(o: {
   submitted?: number;
   active?: number;
   netCum?: string;
+  prepayDraft?: number;
 }): ReportRow {
   return {
     group_key: 1,
@@ -32,6 +33,7 @@ function mkRow(o: {
       admitted_in_week: 0,
       enrolled_in_week: 0,
       submitted_cumulative: o.submitted ?? 0,
+      fee_paid_not_submitted: o.prepayDraft ?? 0,
       admitted_cumulative: o.admitted ?? 0,
       enrolled_cumulative: o.enrolled ?? 0,
       quota: o.quota ?? null,
@@ -73,11 +75,20 @@ describe("SummaryBand", () => {
   });
 
   it("officer (no quota) → count fallback cards", () => {
-    const totals = mkRow({ quota: null, enrolled: 50, submitted: 120, active: 300 });
+    const totals = mkRow({
+      quota: null,
+      enrolled: 50,
+      submitted: 120,
+      active: 300,
+      prepayDraft: 14,
+    });
     render(<SummaryBand rows={[]} totals={totals} groupBy="officer" />);
     expect(screen.queryByText("Nhập học / Chỉ tiêu")).toBeNull();
     expect(screen.getByText("Nhập học")).toBeTruthy();
     expect(screen.getByText("Hồ sơ nộp")).toBeTruthy();
+    // prepay-draft card surfaces the "đã đóng lệ phí, chưa nộp" cohort
+    const prepay = screen.getByText("Đóng phí chưa nộp").parentElement as HTMLElement;
+    expect(within(prepay).getByText("14")).toBeTruthy();
   });
 
   it("quota=0 totals → treated as no quota (count fallback)", () => {

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/SummaryBand.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/SummaryBand.tsx
@@ -57,7 +57,7 @@ export function SummaryBand({
   ).length;
 
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
       {hasQuota ? (
         <Card label="Nhập học / Chỉ tiêu" hint={`${Math.round(ratio * 100)}% chỉ tiêu năm`}>
           <div className="mt-1 text-xl font-bold tabular-nums">
@@ -101,6 +101,11 @@ export function SummaryBand({
       ) : (
         <Card label="Hồ sơ nộp" hint="lũy kế năm" value={nf.format(t.submitted_cumulative)} />
       )}
+      <Card
+        label="Đóng phí chưa nộp"
+        hint="đã đóng lệ phí, hồ sơ còn nháp — cần nhắc hoàn tất"
+        value={nf.format(t.fee_paid_not_submitted)}
+      />
     </div>
   );
 }

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/WeeklyReportTable.test.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/WeeklyReportTable.test.tsx
@@ -24,6 +24,7 @@ function mkRow(o: {
       admitted_in_week: 0,
       enrolled_in_week: 0,
       submitted_cumulative: 0,
+      fee_paid_not_submitted: 0,
       admitted_cumulative: 0,
       enrolled_cumulative: o.enrolled ?? 0,
       quota: o.quota ?? null,

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/cockpit-rank.test.ts
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/cockpit-rank.test.ts
@@ -24,6 +24,7 @@ function mkRow(o: {
       admitted_in_week: 0,
       enrolled_in_week: 0,
       submitted_cumulative: 0,
+      fee_paid_not_submitted: 0,
       admitted_cumulative: 0,
       enrolled_cumulative: o.enrolled ?? 0,
       quota: o.quota ?? null,

--- a/frontend/src/lib/zod/reports.ts
+++ b/frontend/src/lib/zod/reports.ts
@@ -27,6 +27,9 @@ export const admissionMetricsSchema = z.object({
   admitted_in_week: z.number().int(),
   enrolled_in_week: z.number().int(),
   submitted_cumulative: z.number().int(),
+  // đã đóng lệ phí xét tuyển nhưng hồ sơ CHƯA nộp (prepay-draft). default(0) để
+  // không vỡ nếu BE cũ chưa trả field.
+  fee_paid_not_submitted: z.number().int().default(0),
   admitted_cumulative: z.number().int(),
   enrolled_cumulative: z.number().int(),
   quota: z.number().int().nullable(), // chỉ tiêu (major view); null = N/A


### PR DESCRIPTION
## Mục tiêu
Bổ sung chỉ số đối chiếu **admission_profile ↔ fee** vào báo cáo tuyển sinh (#428): đếm hồ sơ **đã đóng lệ phí xét tuyển** (application paid) nhưng **chưa nộp hồ sơ** (chưa có milestone `submitted`) — nhóm prepay fast-track cần nhắc hoàn tất.

> Con số "hồ sơ đã nộp" (`submitted_cumulative`) đã có sẵn ở #428 (SummaryBand). PR này chỉ bổ sung nhóm **prepay-draft** mà cockpit hiện chưa tách được (`profiles_paid` gộp mọi fee_type, không split theo status).

## Thay đổi
**BE**
- `AdmissionMetrics.fee_paid_not_submitted` (schema)
- `get_weekly_report`: track DISTINCT pid có **application** payment → đếm pid **không có submitted milestone** (đối xứng `submitted_cumulative`, cùng nguồn `status_history`)
- `_totals` cộng field

**FE**
- zod `admissionMetricsSchema` + field `.default(0)` (backward-safe nếu BE cũ chưa trả)
- `SummaryBand`: card **"Đóng phí chưa nộp"** + grid `lg` 5→6 cột

## Định nghĩa (đã chốt)
"Chưa nộp" = **không có submitted milestone** (status_history), KHÔNG phải `status=='draft'` hiện tại → nhất quán cách cockpit đếm submitted; hồ sơ submitted→reopen→draft KHÔNG bị đếm lại (đã từng nộp). "Đã đóng lệ phí" = gross (có payment), đối xứng `profiles_paid` (không trừ refund).

## Kiểm thử
- BE: **56 test pass** (toàn bộ `admission_report` + test `prepay-draft` 3-case: prepay-draft / submitted-paid / tuition-only)
- FE: **type-check 0 lỗi · lint 0 errors · 22 test pass** (gồm assertion card mới)
- `/code-review max`: 0 bug sai-số; 1 cosmetic (thứ tự field `_totals`) đã sửa
- **Không migration / không Casbin** (field tính runtime) → deploy = chỉ code

🤖 Generated with [Claude Code](https://claude.com/claude-code)