### PR TITLE
feat(leads): cây filter "Giai đoạn" 2 cấp tri-state + đếm theo trạng thái

### DIFF
--- a/Backend_FastAPI/app/core/deps.py
+++ b/Backend_FastAPI/app/core/deps.py
@@ -2038,6 +2038,16 @@ class LeadListFilter:
         self.requesting_user = requesting_user
         self.is_forced_officer_filter = is_forced_officer_filter
 
+    def scope_kwargs(self) -> dict:
+        """RBAC scope (officer/unit) as kwargs for lead queries — single source
+        so list, export and count honour the SAME scope. Add any new scope
+        field here so every consumer updates atomically (no silent drift)."""
+        return {
+            "assigned_officer_id": self.assigned_officer_id,
+            "unit_id": self.unit_id,
+            "unit_ids": self.unit_ids,
+        }
+
 
 async def get_lead_list_filter(
     assigned_officer_id: str | None = None,

--- a/Backend_FastAPI/app/repositories/lead_repository.py
+++ b/Backend_FastAPI/app/repositories/lead_repository.py
@@ -793,6 +793,34 @@ class LeadRepository(BaseRepository[models.Lead]):
         result = await self.db.execute(query)
         return {row.status: row.count for row in result}
 
+    async def count_by_consultation_status(self, filters: list) -> dict:
+        """
+        Count leads grouped by consultation_status_id over a pre-built filter set.
+
+        Mirrors get_summary's filter contract (shared _build_filters output) so
+        the "Giai đoạn" filter tree honours the EXACT same scope as the lead
+        list. The caller passes scope-only filters → "static per-scope" counts
+        (Documents/LEAD_STAGE_TREE_FILTER_PLAN.md §2). Leads with NULL
+        consultation_status_id are bucketed under "__null__" so the tree never
+        hides a lead.
+        """
+        query = (
+            select(
+                models.Lead.consultation_status_id,
+                func.count(models.Lead.id).label("count"),
+            )
+            .group_by(models.Lead.consultation_status_id)
+        )
+        if filters:
+            query = query.where(*filters)
+
+        result = await self.db.execute(query)
+        return {
+            ("__null__" if row.consultation_status_id is None
+             else row.consultation_status_id): row.count
+            for row in result
+        }
+
     # =========================================================================
     # LEAD INSIGHTS CACHE: Aggregation methods for cache update
     # =========================================================================

--- a/Backend_FastAPI/app/routers/leads.py
+++ b/Backend_FastAPI/app/routers/leads.py
@@ -300,6 +300,13 @@ async def get_all_leads(
     consultation_status_id: Optional[str] = Query(
         None, description="Consultation status IDs (comma-separated, e.g. sts04,sts20)"
     ),
+    with_status_counts: bool = Query(
+        False,
+        description=(
+            "Also return lead counts grouped by consultation_status_id "
+            "(scope-only, ignores other filters) for the Giai đoạn filter tree."
+        ),
+    ),
 ):
     """
     Lấy danh sách Leads (có phân trang, filter, search, sort).
@@ -343,11 +350,22 @@ async def get_all_leads(
         is_hot=is_hot,
         consultation_status_id=consultation_status_id,
     )
+
+    # Scope-only counts for the "Giai đoạn" filter tree (static navigation map).
+    # Reuses the SAME LeadListFilter scope as the list → no RBAC leak; ignores
+    # secondary filters on purpose. See LEAD_STAGE_TREE_FILTER_PLAN.md §2.
+    consultation_status_counts = None
+    if with_status_counts:
+        consultation_status_counts = await lead_service.get_consultation_status_counts(
+            db, **lead_filter.scope_kwargs()
+        )
+
     return {
         "total_count": total,
         "leads": leads,
         "summary": summary,
         "effective_scope": lead_filter.effective_scope,
+        "consultation_status_counts": consultation_status_counts,
     }
 
 

--- a/Backend_FastAPI/app/schemas/lead.py
+++ b/Backend_FastAPI/app/schemas/lead.py
@@ -549,6 +549,12 @@ class LeadsPage(BaseModel):
     leads: List[Lead]
     summary: Optional[LeadsSummary] = None
     effective_scope: Optional[EffectiveScope] = None
+    # Scope-only counts per consultation_status_id for the "Giai đoạn" filter
+    # tree — populated only when ?with_status_counts=true. Honours RBAC scope
+    # (same as the list) but ignores secondary filters → a stable "navigation
+    # map". Key "__null__" = leads with no consultation_status (no lead hidden).
+    # See Documents/LEAD_STAGE_TREE_FILTER_PLAN.md.
+    consultation_status_counts: Optional[Dict[str, int]] = None
 
 
 class BulkAssignLeadsSchema(BaseModel):

--- a/Backend_FastAPI/app/services/lead_service.py
+++ b/Backend_FastAPI/app/services/lead_service.py
@@ -762,6 +762,33 @@ async def get_leads(
     return total_count, leads, summary
 
 
+async def get_consultation_status_counts(
+    db: AsyncSession,
+    *,
+    assigned_officer_id: Optional[str] = None,
+    unit_id: Optional[int] = None,
+    unit_ids: Optional[List[int]] = None,
+) -> dict:
+    """
+    Đếm lead theo consultation_status_id, CHỈ áp RBAC scope (officer/unit) —
+    KHÔNG áp filter phụ (nguồn/ngày/điểm/search) → count "tĩnh theo scope"
+    làm bản đồ điều hướng cho cây filter Giai đoạn.
+
+    Tái dùng `_build_filters` với CHỈ scope params để khớp chính xác
+    phạm vi của danh sách (officer ép self, manager ép unit, admin
+    full) đã được LeadListFilter giải quyết ở router. Xem
+    LEAD_STAGE_TREE_FILTER_PLAN §2.
+    """
+    from app.repositories import LeadRepository
+
+    repo = LeadRepository(db)
+    scope_filters = repo._build_filters(
+        assigned_officer_id=assigned_officer_id,
+        unit_id=unit_id,
+        unit_ids=unit_ids,
+    )
+    return await repo.count_by_consultation_status(scope_filters)
+
 
 async def create_lead(
     db: AsyncSession,

--- a/Backend_FastAPI/tests/api/test_lead_filters_api.py
+++ b/Backend_FastAPI/tests/api/test_lead_filters_api.py
@@ -180,3 +180,69 @@ async def test_search_unaccent_via_api(
     names2 = [lead["full_name"] for lead in r2.json()["leads"]]
     assert "Nguyễn Văn Hùng" not in names2
     assert "Trần Thị Bình" not in names2
+
+
+@pytest.mark.asyncio
+async def test_with_status_counts_returns_grouped_map(
+    client: AsyncClient, admin_token_headers: dict, filter_env: dict
+):
+    """?with_status_counts=1 adds a counts map grouped by
+    consultation_status_id; absent flag → field stays null (no extra query)."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            s.add(models.ConsultationStatus(
+                id="fltcnt", name="Filter Count", color_code="#123456",
+                stage_id=None, is_final=False,
+            ))
+    u = filter_env
+    await _seed_lead(u["unit_id"], "fltcnt", "CountLeadA", "0911000010")
+    await _seed_lead(u["unit_id"], "fltcnt", "CountLeadB", "0911000011")
+
+    r = await client.get(
+        f"{LEADS_URL}?with_status_counts=1", headers=admin_token_headers
+    )
+    assert r.status_code == 200, r.text
+    counts = r.json()["consultation_status_counts"]
+    assert counts is not None
+    # Dedicated status → exact count regardless of what other tests seeded.
+    assert counts.get("fltcnt") == 2
+
+    # No flag → field is null (avoids the extra group-by on every page request).
+    r2 = await client.get(LEADS_URL, headers=admin_token_headers)
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["consultation_status_counts"] is None
+
+
+@pytest.mark.asyncio
+async def test_with_status_counts_honours_officer_scope(
+    client: AsyncClient, officer_token_headers: dict,
+    officer_user_in_db: dict, filter_env: dict
+):
+    """The counts map reuses the SAME LeadListFilter scope as the list: an
+    officer sees the count for THEIR OWN lead but NOT for leads they can't
+    access. Seeds one owned + one unassigned lead so the assertion can tell
+    'correctly scoped to self' apart from 'returns nothing' (non-vacuous)."""
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            s.add(models.ConsultationStatus(
+                id="fltown", name="Filter Owned", color_code="#222222",
+                stage_id=None, is_final=False,
+            ))
+            s.add(models.ConsultationStatus(
+                id="fltsco", name="Filter Scope", color_code="#654321",
+                stage_id=None, is_final=False,
+            ))
+    u = filter_env
+    # One lead OWNED by the calling officer + one unassigned (invisible to them).
+    await _seed_lead(u["unit_id"], "fltown", "OwnedByOfficer", "0911000020",
+                     assigned_officer_id=officer_user_in_db["id"])
+    await _seed_lead(u["unit_id"], "fltsco", "NotOwnedByOfficer", "0911000021",
+                     assigned_officer_id=None)
+
+    r = await client.get(
+        f"{LEADS_URL}?with_status_counts=1", headers=officer_token_headers
+    )
+    assert r.status_code == 200, r.text
+    counts = r.json()["consultation_status_counts"] or {}
+    assert counts.get("fltown") == 1   # officer's OWN lead IS counted
+    assert "fltsco" not in counts      # unowned lead excluded (no RBAC leak)

--- a/Backend_FastAPI/tests/repositories/test_lead_filter_predicates.py
+++ b/Backend_FastAPI/tests/repositories/test_lead_filter_predicates.py
@@ -272,3 +272,48 @@ async def test_consultation_status_with_is_final(db, filter_dataset):
     )
     assert ids["L1"] not in res_empty
     assert ids["L4"] not in res_empty
+
+
+# ============================================================================
+# count_by_consultation_status — scope-only counts for the "Giai đoạn" tree
+# (LEAD_STAGE_TREE_FILTER_PLAN §2)
+# ============================================================================
+
+@pytest.mark.asyncio
+async def test_count_by_consultation_status_groups(db, filter_dataset):
+    """Groups lead counts by consultation_status_id over the unscoped set."""
+    repo = LeadRepository(db)
+    counts = await repo.count_by_consultation_status(repo._build_filters())
+    assert counts.get(ACCEPTED_STATUS_ID) == 2   # L1, L4
+    assert counts.get(GIVEUP_STATUS_ID) == 1     # L2
+
+
+@pytest.mark.asyncio
+async def test_count_by_consultation_status_honours_scope(db, filter_dataset):
+    """Scope-only filters narrow counts exactly like the list: the unassigned
+    L2 (sts20) drops out once scoped to the officer — proving the count honours
+    the SAME scope plumbing as get_filtered (no RBAC leak)."""
+    officer_id = filter_dataset["officer_id"]
+    repo = LeadRepository(db)
+    scoped = repo._build_filters(assigned_officer_id=str(officer_id))
+    counts = await repo.count_by_consultation_status(scoped)
+    assert counts.get(ACCEPTED_STATUS_ID) == 2   # L1, L4 (officer's)
+    assert GIVEUP_STATUS_ID not in counts        # L2 unassigned → excluded
+
+
+@pytest.mark.asyncio
+async def test_count_by_consultation_status_null_bucket(
+    db, filter_dataset, seeded_dependencies
+):
+    """Leads with NULL consultation_status_id land in the '__null__' bucket so
+    the tree never hides a lead."""
+    db.add(models.Lead(
+        full_name="Khong Trang Thai", phone="0900000099", source="Website",
+        unit_id=seeded_dependencies["unit_id"],
+        status=seeded_dependencies["initial_status_id"],
+        consultation_status_id=None,
+    ))
+    await db.flush()
+    repo = LeadRepository(db)
+    counts = await repo.count_by_consultation_status(repo._build_filters())
+    assert counts.get("__null__") == 1

--- a/frontend/src/components/leads/command-center/LeadFilterPanel.tsx
+++ b/frontend/src/components/leads/command-center/LeadFilterPanel.tsx
@@ -20,7 +20,7 @@
  */
 
 import React from "react";
-import { RotateCcw } from "lucide-react";
+import { ChevronRight, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -43,17 +43,16 @@ import { MultiOfferingSelector } from "@/components/common/selectors";
 import { ColorDot } from "@/components/ui/dynamic-color-badge";
 import { cn, sanitizeColorCode } from "@/lib/utils";
 import {
-  LEAD_STATUS_OPTIONS,
   LEAD_SOURCE_OPTIONS,
   LEAD_VALIDITY_OPTIONS,
+  STAGE_BRANCHES,
 } from "@/constants/lead.constants";
-import { STAGE_COLORS } from "@/types/pipeline.types";
-import { usePipelineStages, useConsultationStatuses } from "@/hooks/usePipeline";
+import { useConsultationStatuses } from "@/hooks/usePipeline";
+import { useConsultationStatusCounts } from "@/hooks/useLeads";
 import { useOrganizationUnits } from "@/hooks/useOrganization";
 import { useAdminUsersList } from "@/hooks/useAdminUsers";
 import { useAuth } from "@/hooks/useAuth";
 import { isAdmin as checkIsAdmin, canFilterByOfficer as checkCanFilterByOfficer } from "@/lib/utils/permissions";
-import type { LeadStatus } from "@/types/lead.types";
 import type { LeadsFilterState, LeadsFilterHandlers } from "@/hooks/useLeadsFilter";
 
 interface LeadFilterPanelProps {
@@ -89,6 +88,10 @@ function toggle(arr: string[], value: string): string[] {
   return arr.includes(value) ? arr.filter((v) => v !== value) : [...arr, value];
 }
 
+// All stage ids that belong to a NAMED branch — statuses whose stage_id is null
+// or not in this set route into the "Hoạt động khác" branch (no status vanishes).
+const NAMED_BRANCH_STAGE_IDS = new Set(STAGE_BRANCHES.flatMap((b) => b.stageIds));
+
 function GroupSubheading({ children }: { children: React.ReactNode }) {
   return (
     <div className="text-muted-foreground text-xs font-medium uppercase tracking-wide pt-1">
@@ -111,9 +114,26 @@ export const LeadFilterPanel = React.memo(function LeadFilterPanel({
   const canFilterByOfficerFlag = isMounted && checkCanFilterByOfficer(user);
 
   // Data sources (moved here from the bar — §5.0-C regression note)
-  const { data: pipelineStages = [] } = usePipelineStages();
   const { data: consultationStatuses = [] } = useConsultationStatuses();
+  const { data: statusCounts } = useConsultationStatusCounts();
   const { data: organizationUnits = [] } = useOrganizationUnits();
+  // Distinguish "loading" (undefined) from "genuinely 0" so the tree doesn't
+  // flash every branch as 0 before counts resolve.
+  const countsReady = statusCounts != null;
+  const countOf = (id: string) => statusCounts?.[id] ?? 0;
+
+  // Collapse state for the Giai đoạn tree (default collapsed → compact overview
+  // of branch totals; expand a branch to pick individual statuses).
+  const [expandedBranches, setExpandedBranches] = React.useState<Set<string>>(
+    () => new Set(),
+  );
+  const toggleBranch = (key: string) =>
+    setExpandedBranches((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
 
   const [officerSearch, setOfficerSearch] = React.useState("");
   const [debouncedOfficerSearch, setDebouncedOfficerSearch] = React.useState("");
@@ -148,31 +168,22 @@ export const LeadFilterPanel = React.memo(function LeadFilterPanel({
     return result;
   }, [organizationUnits]);
 
-  // Consultation statuses grouped by stage (§5.6). Display-only grouping; the
-  // selection state stays a flat array. Universal statuses (stage_id == null)
-  // fall into a final "Mọi giai đoạn" bucket.
-  const consultationGroups = React.useMemo(() => {
-    const orderedStages = [...pipelineStages].sort((a, b) => a.order - b.order);
-    const stageIds = new Set(orderedStages.map((s) => s.id));
-    const groups = orderedStages.map((stage) => ({
-      key: stage.id,
-      title: stage.name,
+  // Consultation statuses grouped into the 6 stage-branches (cây 2 cấp). The
+  // selection state stays a flat array; the tree is display-only. A status goes
+  // to "Hoạt động khác" when its stage_id is null OR references a stage not in
+  // any named branch (universal/orphan) — so no active status ever vanishes.
+  const consultationBranches = React.useMemo(() => {
+    return STAGE_BRANCHES.map((branch) => ({
+      ...branch,
       statuses: consultationStatuses
-        .filter((s) => s.stage_id === stage.id)
+        .filter((s) =>
+          branch.stageIds.length > 0
+            ? s.stage_id != null && branch.stageIds.includes(s.stage_id)
+            : !s.stage_id || !NAMED_BRANCH_STAGE_IDS.has(s.stage_id),
+        )
         .sort((a, b) => (a.display_order ?? 0) - (b.display_order ?? 0)),
-    }));
-    // "Mọi giai đoạn": universal statuses (stage_id == null) PLUS any orphan
-    // whose stage_id references a stage not in the loaded list (archived /
-    // not-yet-cached). Without the orphan catch they'd vanish from the drawer
-    // while still being active + removable as chips → no checkbox to toggle.
-    const universal = consultationStatuses
-      .filter((s) => !s.stage_id || !stageIds.has(s.stage_id))
-      .sort((a, b) => (a.display_order ?? 0) - (b.display_order ?? 0));
-    if (universal.length > 0) {
-      groups.push({ key: "__universal__", title: "Mọi giai đoạn", statuses: universal });
-    }
-    return groups.filter((g) => g.statuses.length > 0);
-  }, [pipelineStages, consultationStatuses]);
+    })).filter((b) => b.statuses.length > 0);
+  }, [consultationStatuses]);
 
   const showAssignmentGroup = canFilterByOfficerFlag || isAdminFlag;
 
@@ -305,80 +316,128 @@ export const LeadFilterPanel = React.memo(function LeadFilterPanel({
               🏷️ Trạng thái &amp; phân loại
             </AccordionTrigger>
             <AccordionContent className="space-y-4 pb-3">
-              {/* Tình trạng tư vấn (grouped by stage) */}
-              <div className="space-y-2">
-                <GroupSubheading>Tình trạng tư vấn</GroupSubheading>
-                {consultationGroups.map((group) => (
-                  <div key={group.key} className="space-y-1.5">
-                    <div className="text-muted-foreground/80 text-[11px] font-medium">
-                      {group.title}
-                    </div>
-                    <div className="space-y-1.5 pl-1">
-                      {group.statuses.map((s) => (
-                        <label
-                          key={s.id}
-                          className="flex cursor-pointer items-center gap-2 text-sm font-normal"
-                        >
-                          <Checkbox
-                            checked={state.consultationStatusFilters.includes(s.id)}
-                            onCheckedChange={() =>
-                              handlers.handleConsultationStatusChange(
-                                toggle(state.consultationStatusFilters, s.id),
-                              )
-                            }
-                          />
-                          <ColorDot color={sanitizeColorCode(s.color_code)} size="sm" />
-                          {s.name}
-                        </label>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              {/* Giai đoạn */}
-              <div className="space-y-2">
+              {/* Giai đoạn — cây 2 cấp (cha = nhánh, lá = tình trạng tư vấn).
+                  HỢP NHẤT "Tình trạng tư vấn" + "Giai đoạn" cũ thành 1 trục.
+                  "Vòng đời Lead" (lead.status legacy) bỏ control nhưng GIỮ state
+                  + param ?status= cho preset "Mới" (LEAD_STAGE_TREE_FILTER_PLAN). */}
+              <div className="space-y-1.5">
                 <GroupSubheading>Giai đoạn</GroupSubheading>
-                {pipelineStages.map((stage) => (
-                  <label
-                    key={stage.id}
-                    className="flex cursor-pointer items-center gap-2 text-sm font-normal"
-                  >
-                    <Checkbox
-                      checked={state.stageFilters.includes(stage.id)}
-                      onCheckedChange={() =>
-                        handlers.handleStageChange(toggle(state.stageFilters, stage.id))
-                      }
-                    />
-                    <ColorDot color={sanitizeColorCode(stage.color_code) || STAGE_COLORS[stage.id]} size="sm" />
-                    {stage.name}
-                  </label>
-                ))}
+                {consultationBranches.map((branch) => {
+                  const ids = branch.statuses.map((s) => s.id);
+                  const selected = ids.filter((id) =>
+                    state.consultationStatusFilters.includes(id),
+                  ).length;
+                  const allSelected = selected === ids.length && ids.length > 0;
+                  const parentChecked = allSelected
+                    ? true
+                    : selected > 0
+                      ? "indeterminate"
+                      : false;
+                  // Branch total = Σ leaf counts. Leads with NULL
+                  // consultation_status (BE "__null__" bucket) are NOT folded in:
+                  // they can't be filtered via cstatus, so counting them here
+                  // would over-promise (parent count > clicked result). The
+                  // "Chưa có lần tư vấn" preset reaches not-yet-consulted leads.
+                  const branchTotal = ids.reduce(
+                    (sum, id) => sum + countOf(id),
+                    0,
+                  );
+                  const expanded = expandedBranches.has(branch.key);
+                  return (
+                    <div key={branch.key} className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          checked={parentChecked}
+                          onCheckedChange={() =>
+                            handlers.handleConsultationStatusChange(
+                              allSelected
+                                ? state.consultationStatusFilters.filter(
+                                    (id) => !ids.includes(id),
+                                  )
+                                : Array.from(
+                                    new Set([
+                                      ...state.consultationStatusFilters,
+                                      ...ids,
+                                    ]),
+                                  ),
+                            )
+                          }
+                          aria-label={`Chọn tất cả ${branch.label}`}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => toggleBranch(branch.key)}
+                          aria-expanded={expanded}
+                          className="flex flex-1 items-center justify-between gap-2 text-sm font-medium"
+                        >
+                          <span className="flex items-center gap-1">
+                            <ChevronRight
+                              className={cn(
+                                "h-3.5 w-3.5 shrink-0 transition-transform",
+                                expanded && "rotate-90",
+                              )}
+                            />
+                            {branch.label}
+                          </span>
+                          {countsReady && (
+                            <span
+                              className={cn(
+                                "text-xs tabular-nums",
+                                branchTotal === 0
+                                  ? "text-muted-foreground/50"
+                                  : "text-muted-foreground",
+                              )}
+                            >
+                              {branchTotal.toLocaleString("vi-VN")}
+                            </span>
+                          )}
+                        </button>
+                      </div>
+                      {expanded && (
+                        <div className="space-y-1.5 pl-6">
+                          {branch.statuses.map((s) => {
+                            const c = countOf(s.id);
+                            return (
+                              <label
+                                key={s.id}
+                                className="flex cursor-pointer items-center gap-2 text-sm font-normal"
+                              >
+                                <Checkbox
+                                  checked={state.consultationStatusFilters.includes(
+                                    s.id,
+                                  )}
+                                  onCheckedChange={() =>
+                                    handlers.handleConsultationStatusChange(
+                                      toggle(state.consultationStatusFilters, s.id),
+                                    )
+                                  }
+                                />
+                                <ColorDot
+                                  color={sanitizeColorCode(s.color_code)}
+                                  size="sm"
+                                />
+                                <span className="flex-1">{s.name}</span>
+                                {countsReady && (
+                                  <span
+                                    className={cn(
+                                      "text-xs tabular-nums",
+                                      c === 0
+                                        ? "text-muted-foreground/50"
+                                        : "text-muted-foreground",
+                                    )}
+                                  >
+                                    {c.toLocaleString("vi-VN")}
+                                  </span>
+                                )}
+                              </label>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
-
-              {/* Vòng đời Lead (admin only) */}
-              {isAdminFlag && (
-                <div className="space-y-2">
-                  <GroupSubheading>Vòng đời Lead</GroupSubheading>
-                  {LEAD_STATUS_OPTIONS.map((option) => (
-                    <label
-                      key={option.value}
-                      className="flex cursor-pointer items-center gap-2 text-sm font-normal"
-                    >
-                      <Checkbox
-                        checked={state.statusFilters.includes(option.value)}
-                        onCheckedChange={() =>
-                          handlers.handleStatusChange(
-                            toggle(state.statusFilters, option.value) as LeadStatus[],
-                          )
-                        }
-                      />
-                      <span className={`h-2 w-2 rounded-full ${option.color}`} />
-                      {option.label}
-                    </label>
-                  ))}
-                </div>
-              )}
 
               {/* Tính hợp lệ */}
               <div className="space-y-2">

--- a/frontend/src/components/leads/command-center/LeadQuickPresets.tsx
+++ b/frontend/src/components/leads/command-center/LeadQuickPresets.tsx
@@ -17,7 +17,9 @@
 import React from "react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
+import { useConsultationStatuses } from "@/hooks/usePipeline";
 import { canFilterByOfficer as checkCanFilterByOfficer } from "@/lib/utils/permissions";
+import { ONBOARDED_STAGE_IDS } from "@/constants/lead.constants";
 import type { LeadStatus } from "@/types/lead.types";
 import type { LeadsFilterState, LeadsFilterHandlers } from "@/hooks/useLeadsFilter";
 
@@ -38,6 +40,20 @@ export const LeadQuickPresets = React.memo(function LeadQuickPresets({
 
   const canFilterByOfficerFlag = isMounted && checkCanFilterByOfficer(user);
   const myId = user?.id != null ? String(user.id) : null;
+
+  // Preset "Đã vào hồ sơ/tài chính" = consultation_status thuộc nhánh Hồ sơ +
+  // Học phí + Đã nhập học (derive runtime từ stageIds — KHÔNG hardcode sts).
+  const { data: consultationStatuses = [] } = useConsultationStatuses();
+  const onboardedIds = React.useMemo(
+    () =>
+      consultationStatuses
+        .filter((s) => s.stage_id && ONBOARDED_STAGE_IDS.includes(s.stage_id))
+        .map((s) => s.id),
+    [consultationStatuses],
+  );
+  const onboardedActive =
+    onboardedIds.length > 0 &&
+    onboardedIds.every((id) => state.consultationStatusFilters.includes(id));
 
   const presets: { key: string; label: string; active: boolean; onClick: () => void; show: boolean }[] = [
     {
@@ -97,6 +113,24 @@ export const LeadQuickPresets = React.memo(function LeadQuickPresets({
         );
       },
       show: true,
+    },
+    {
+      // Đã vào khâu hồ sơ/tài chính (không sót ai vì fee-overlay). Toggle là
+      // additive: chỉ thêm/bỏ nhóm onboarded, KHÔNG đụng nhánh khác đang chọn.
+      key: "onboarded",
+      label: "Đã vào hồ sơ/tài chính",
+      active: onboardedActive,
+      onClick: () =>
+        handlers.handleConsultationStatusChange(
+          onboardedActive
+            ? state.consultationStatusFilters.filter(
+                (id) => !onboardedIds.includes(id),
+              )
+            : Array.from(
+                new Set([...state.consultationStatusFilters, ...onboardedIds]),
+              ),
+        ),
+      show: onboardedIds.length > 0,
     },
   ];
 

--- a/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
+++ b/frontend/src/components/leads/mobile-lead-detail-responsive.test.ts
@@ -238,6 +238,6 @@ describe("LEAD_FILTER_UX_PLAN §5.0 — filter drawer panel", () => {
     expect(filterPanel).toContain("Chưa có lần tư vấn"); // group 1 control (JSX)
     expect(filterPanel).toContain("Cán bộ phụ trách");   // group 3 sub-heading (JSX)
     expect(filterPanel).toContain("Ưu tiên follow-up");  // sort option (JSX)
-    expect(filterPanel).toContain("Mọi giai đoạn");      // universal consultation bucket (JSX)
+    expect(filterPanel).toContain("Chọn tất cả");          // tri-state parent aria-label (cây 2 cấp)
   });
 });

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -3,7 +3,7 @@
 
 import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
-import { Check } from "lucide-react";
+import { Check, Minus } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -14,7 +14,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground",
       className
     )}
     {...props}
@@ -22,7 +22,11 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("flex items-center justify-center text-current")}
     >
-      <Check aria-hidden="true" className="h-4 w-4" />
+      {props.checked === "indeterminate" ? (
+        <Minus aria-hidden="true" className="h-4 w-4" />
+      ) : (
+        <Check aria-hidden="true" className="h-4 w-4" />
+      )}
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ));

--- a/frontend/src/constants/lead.constants.ts
+++ b/frontend/src/constants/lead.constants.ts
@@ -260,3 +260,35 @@ export function getLeadValidityOption(value: string): LeadValidityOption | undef
 export function getLeadValidityLabel(value: string): string {
   return LEAD_VALIDITY_MAP.get(value)?.label ?? value
 }
+
+// =============================================================================
+// STAGE BRANCHES — cây filter "Giai đoạn" 2 cấp (LEAD_STAGE_TREE_FILTER_PLAN)
+// =============================================================================
+// Cha = nhánh (gộp pipeline_stage theo "khâu lead dừng"), lá = consultation_status.
+// CHỈ hardcode stage→nhánh ở đây; tên/màu/đếm của lá lấy runtime từ API
+// (thin-client). Cây gửi consultation_status_id (KHÔNG phải pipeline_stage_id);
+// vì lead.pipeline_stage_id sync TỪ consultation_status.stage_id nên chọn nhánh
+// XẤP XỈ lọc theo stage — không khớp tuyệt đối nếu 2 cột lệch nhau.
+
+export interface StageBranch {
+  key: string
+  label: string
+  stageIds: string[] // pipeline_stage ids; [] = universal (stage_id == null)
+}
+
+export const STAGE_BRANCHES: StageBranch[] = [
+  { key: "tu_van", label: "Tư vấn", stageIds: ["stg01", "stg02"] },
+  { key: "ho_so", label: "Hồ sơ", stageIds: ["stg03", "stg04"] },
+  { key: "hoc_phi", label: "Học phí", stageIds: ["stg05"] },
+  { key: "nhap_hoc", label: "Đã nhập học", stageIds: ["stg06"] },
+  { key: "khong_di_hoc", label: "Không đi học", stageIds: ["stg07"] },
+  // "Hoạt động khác" = universal (stage_id null) + orphan (stage không thuộc nhánh)
+  { key: "khac", label: "Hoạt động khác", stageIds: [] },
+]
+
+// Preset "Đã vào hồ sơ/tài chính" = nhánh Hồ sơ + Học phí + Đã nhập học (loại
+// "Không đi học"). Derive từ STAGE_BRANCHES (1 nguồn) thay vì hardcode lại stage
+// ids — đổi nhánh thì preset tự cập nhật, không lệch.
+export const ONBOARDED_STAGE_IDS = STAGE_BRANCHES.filter((b) =>
+  ["ho_so", "hoc_phi", "nhap_hoc"].includes(b.key),
+).flatMap((b) => b.stageIds)

--- a/frontend/src/hooks/useLeads.ts
+++ b/frontend/src/hooks/useLeads.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { toast } from "sonner";
 import { leadsApi } from "@/lib/api/leads";
+import { api } from "@/lib/api/client";
 import { workflowContextKeys } from "@/hooks/useWorkflowContext";
 import type { ApiErrorResponse } from "@/types/api.types";
 import type { ReopenRequestItem } from "@/lib/api/leads";
@@ -39,6 +40,8 @@ export const leadsKeys = {
   detail: (id: number) => [...leadsKeys.details(), id] as const,
   timeline: (id: number) => [...leadsKeys.all, "timeline", id] as const,
   insights: (id: number) => [...leadsKeys.all, "insights", id] as const,
+  consultationStatusCounts: () =>
+    [...leadsKeys.all, "consultationStatusCounts"] as const,
 };
 
 // =====================================================================
@@ -136,6 +139,32 @@ export function useLeads(
     // table does not flash back to a skeleton when filters switch (e.g.
     // post-hydration localStorage restore, pagination, sort, etc.).
     placeholderData: (previousData) => previousData,
+  });
+}
+
+/**
+ * Scope-only lead counts per consultation_status_id for the "Giai đoạn" filter
+ * tree. Honours the caller's RBAC scope (BE get_lead_list_filter) but ignores
+ * secondary filters → a stable navigation map. Fetched once (page_size=1) and
+ * cached; the tree reads parent (Σ leaves) + leaf counts. Key "__null__" =
+ * leads with no consultation_status. See LEAD_STAGE_TREE_FILTER_PLAN.
+ */
+export function useConsultationStatusCounts(enabled: boolean = true) {
+  return useQuery<Record<string, number> | null, AxiosError<ApiErrorResponse>>({
+    queryKey: leadsKeys.consultationStatusCounts(),
+    queryFn: async () => {
+      const res = await api.get<LeadsPage>("/api/leads", {
+        params: { page: 1, page_size: 1, with_status_counts: true },
+      });
+      return res.data.consultation_status_counts ?? null;
+    },
+    enabled,
+    // staleTime 0 → refetch on each drawer open (the Sheet remounts the Panel),
+    // so branch counts are fresh after a status change without wiring every
+    // mutation. No window-focus refetch to avoid churn while the drawer is open.
+    staleTime: 0,
+    gcTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/frontend/src/types/lead.types.ts
+++ b/frontend/src/types/lead.types.ts
@@ -643,6 +643,8 @@ export interface LeadListParams extends PaginationParams {
   no_consultation?: boolean;
   is_hot?: boolean;
   consultation_status_id?: string;
+  // Also return consultation_status_counts (scope-only) for the Giai đoạn tree
+  with_status_counts?: boolean;
 }
 
 /**
@@ -671,6 +673,9 @@ export interface LeadsPage {
   leads: Lead[];
   summary?: LeadsSummary;
   effective_scope?: EffectiveScope;
+  // Scope-only counts per consultation_status_id (only when with_status_counts);
+  // key "__null__" = leads with no consultation_status. For the Giai đoạn tree.
+  consultation_status_counts?: Record<string, number> | null;
 }
 
 // ============================================


### PR DESCRIPTION
## Tóm tắt

Hợp nhất 2 filter rời ở command-center Leads — **"Giai đoạn"** (`pipeline_stage`) + **"Tình trạng tư vấn"** (`consultation_status`) — thành **MỘT cây 2 cấp tri-state** (cha = giai đoạn · lá = trạng thái), **6 nhánh khớp stage**, kèm **đếm số lead theo từng nhánh** (theo scope) + **preset 1-click**.

**Gỡ "cú sốc 19":** do fee-overlay (`lead_admission_sync.py` `FEE_OVERLAY_LEAD_STATUSES`), lead đã nộp hồ sơ nhưng đã đóng tiền bị đẩy sang trạng thái tài chính → bộ lọc cũ "Đã nộp hồ sơ = sts07" hiện 0/19 gây hiểu nhầm. Cây gộp + đếm cả nhánh khắc phục.

## 6 nhánh (cha = stage, lá = consultation_status)

| Nhánh | stage | |
|---|---|---|
| Tư vấn | stg01+02 | đang tư vấn |
| Hồ sơ | stg03+04 | đã/đang nộp hồ sơ |
| Học phí | stg05 | đã đóng học phí |
| Đã nhập học | stg06 | |
| Không đi học | stg07 | |
| Hoạt động khác | universal (NULL) | sts01/15/19 |

Preset **"Đã vào hồ sơ/tài chính"** = Hồ sơ + Học phí + Đã nhập học (9 mã consultation_status).

## Thay đổi

**Backend** (`2730f961`):
- Đếm lead `GROUP BY consultation_status` **theo scope** — qua `get_lead_list_filter` (IDOR unit-scope **y như list**, không rò phạm vi). `leads` router + `lead_service` + `lead_repository` + schema `lead` + `deps`.

**Frontend** (`ee0d73b9`):
- `LeadFilterPanel`: cây 2 cấp **tri-state** (checked / indeterminate / unchecked); `checkbox` hỗ trợ tri-state.
- `LeadQuickPresets` + preset "Đã vào hồ sơ/tài chính".
- `useLeads` truyền param · `lead.constants` / `lead.types`.
- **Thin-client:** chỉ hardcode **stage→nhánh** (6 dòng) + universal; lá (name/color/order) lấy runtime từ `useConsultationStatuses()`.

## Lưu ý 3 trục trạng thái (đừng nhầm)
- `consultation_status` → **lá** cây (điều hướng) · `pipeline_stage` → **cha** (control phẳng cũ bỏ được vì stage derive 1-1 từ status) · `lead.status` legacy → **trục riêng**, ẩn control nhưng giữ param.
- Số hồ sơ **thực** để báo cáo đếm theo `admission_profile.status` (tách trục — caveat fee-overlay), KHÔNG dùng cây này.

## Test (verify trước khi mở PR)
- 2 vòng `/code-review max` + 2 đợt Chrome smoke (dev).
- BE: `test_lead_filters_api` + `test_lead_filter_predicates` · FE: type-check + lint + 63 test.
- Rebased lên main `5accacd0` (0 conflict — vùng leads độc lập với #432/#433/#434).

Ref: `Documents/LEAD_STAGE_TREE_FILTER_PLAN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
