### PR TITLE
fix(finance): import thu học phí render client-only (ssr:false) — hết React #418

### DIFF
--- a/Backend_FastAPI/app/routers/admission_reports.py
+++ b/Backend_FastAPI/app/routers/admission_reports.py
@@ -8,16 +8,23 @@ is enforced inside the service via domain exceptions. Read-only → no commit.
 from datetime import date
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models
 from app.core.deps import require_admin_or_manager
+from app.core.rate_limits import RateLimits, limiter
 from app.database import get_db
 from app.schemas.admission_report import AdmissionWeeklyReportResponse, ReportFilters
 from app.services.admission_report_service import AdmissionReportService
+from app.services.admission_summary_export_service import (
+    AdmissionSummaryExportService,
+)
 
 router = APIRouter(prefix="/api/v2/admin/reports", tags=["Admin v2 - Reports"])
+
+_XLSX_MEDIA = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 
 @router.get("/admission-weekly", response_model=AdmissionWeeklyReportResponse)
@@ -58,3 +65,31 @@ async def get_admission_weekly_report_filters(
     """Năm (config ∪ data) + đợt cho bộ lọc báo cáo — admin & manager (cùng cổng)."""
     service = AdmissionReportService(db)
     return await service.get_filter_options(academic_year)
+
+
+@limiter.limit(RateLimits.DATA_EXPORT)  # 20/hour — heavyweight workbook build
+@router.get("/admission-summary/export.xlsx")
+async def export_admission_summary(
+    request: Request,  # required by slowapi rate limiter
+    academic_year: int = Query(..., ge=2020, le=2100),
+    unit_id: Optional[int] = Query(
+        None, ge=1, description="Admin chọn đơn vị; manager bị ép về đơn vị của mình"
+    ),
+    db: AsyncSession = Depends(get_db),
+    current_user: models.User = Depends(require_admin_or_manager),
+) -> Response:
+    """Xuất báo cáo tuyển sinh (snapshot) ra Excel — số liệu CẢ NĂM tại thời điểm xuất.
+
+    3 sheet: Số liệu chung (ngành × trạng thái) · Chia theo nhân viên · Quy ước.
+    Read-only → không commit. Scope theo vai trò (admin toàn trường / manager đơn vị).
+    """
+    service = AdmissionSummaryExportService(db)
+    content, filename = await service.build_xlsx(
+        current_user=current_user, academic_year=academic_year, unit_id=unit_id
+    )
+    # Plain Response (not StreamingResponse(iter([...]))) so Content-Length is set.
+    return Response(
+        content=content,
+        media_type=_XLSX_MEDIA,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -75,8 +75,9 @@ def _fee_calc_authorized(
     any drift will surface as "FE hides button / API 404s" or vice versa.
 
     Rules:
-    * Profile must be in a fee-eligible state: ``submitted`` (fast-track
-      prepay / hold-spot — C2) plus the post-decision states
+    * Profile must be in a fee-eligible state: ``submitted`` / ``resubmitted``
+      (fast-track prepay / hold-spot — C2; resubmitted = submitted after an
+      officer re-submit) plus the post-decision states
       (``approved`` | ``confirmed`` | ``enrolled``). Earlier states
       (``draft`` etc.) would create a fee prematurely.
     * admin / accountant: any profile. Both are central finance roles; Casbin
@@ -91,9 +92,10 @@ def _fee_calc_authorized(
     # Fee-eligible states gate — shared with the ``calculate_fee`` permission
     # flag in ``admission_service._compute_frontend_fields`` via the single
     # ``is_fee_eligible`` helper (anti-drift): admitted-like + confirmed/enrolled
-    # + ``submitted`` for SINGLE-PATH profiles only (C2 fast-track prepay / giữ
-    # chỗ). A multi-NV profile at ``submitted`` qualifies only after publish →
-    # ``admitted``. Earlier states (draft) stay blocked.
+    # + ``submitted`` / ``resubmitted`` (C2 fast-track prepay / giữ chỗ) for
+    # single-path OR a multi-NV profile with EXACTLY ONE NV. A multi-NV profile
+    # with ≥2 NVs qualifies only after publish → ``admitted``. Earlier states
+    # (draft) stay blocked.
     if not is_fee_eligible(profile):
         return False
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -2186,10 +2186,12 @@ def _compute_frontend_fields(
         # Thu lệ phí xét tuyển - POST /api/admissions/{id}/record-fee-payment.
         # Mirror get_admission_for_fee_collection (deps.py): admin all;
         # manager/accountant same-unit; officer assigned+same-unit. Gate
-        # draft/submitted + le phi thuc su pending -> nut khong hien cho exempt /
-        # da-paid / post-decision.
+        # draft/submitted/resubmitted + le phi thuc su pending -> nut khong hien
+        # cho exempt / da-paid / post-decision. ``resubmitted`` = submitted sau
+        # khi officer nop lai (mirror enforcement record_application_fee_payment
+        # + is_fee_eligible cho hoc phi).
         "record_fee_payment": (
-            status in ("draft", "submitted")
+            status in ("draft", "submitted", "resubmitted")
             and bool((profile.applied_rules or {}).get("requires_application_fee"))
             and (profile.applied_rules or {}).get("fee_status") == "pending"
             and (
@@ -9445,7 +9447,7 @@ async def record_application_fee_payment(
     2. Manual payment confirmation by admin
 
     Flow:
-    - Profile must be in "draft" or "submitted" status
+    - Profile must be in "draft", "submitted" or "resubmitted" status
     - Updates applied_rules.fee_status to "paid"
     - Syncs lead to sts13 (Đã hoàn lệ phí xét tuyển)
 
@@ -9481,11 +9483,16 @@ async def record_application_fee_payment(
     if not profile:
         raise ResourceNotFoundError(f"Admission profile {profile_id} not found")
 
-    # Check profile status — only allow fee payment for draft/submitted profiles
-    if profile.status not in ("draft", "submitted"):
+    # Check profile status — only allow fee payment for profiles still in the
+    # pre-decision intake window: draft / submitted / resubmitted. ``resubmitted``
+    # is submitted after an officer re-submit (rejected/revision_requested →
+    # resubmitted); omitting it blocked fee collection on a re-submitted profile
+    # even though it is still being processed (mirrors the FE record_fee_payment
+    # flag + is_fee_eligible for tuition).
+    if profile.status not in ("draft", "submitted", "resubmitted"):
         raise BadRequest(
             f"Cannot record fee payment for profile in '{profile.status}' status. "
-            "Only draft or submitted profiles accept fee payments."
+            "Only draft, submitted or resubmitted profiles accept fee payments."
         )
 
     # Check fee requirement

--- a/Backend_FastAPI/app/services/admission_summary_export_service.py
+++ b/Backend_FastAPI/app/services/admission_summary_export_service.py
@@ -1,0 +1,592 @@
+"""Xuất báo cáo tuyển sinh (snapshot) ra Excel — orchestration only, no FastAPI.
+
+Báo cáo "ảnh chụp" phân bố TẠI THỜI ĐIỂM xuất, KHÁC cockpit tuần (funnel theo
+thời gian). Đếm:
+- Phễu LEAD exclusive (mỗi lead 1 ô — cộng = tổng lead): Chưa tư vấn | Đang tư vấn
+  | Chỉ đóng lệ phí | Đã đóng học phí | Đã dừng. Ưu tiên theo TIỀN thật (đóng cả
+  lệ phí + học phí → CHỈ tính học phí); phần chưa đóng tiền phân theo
+  consultation_status.
+- HỒ SƠ đếm riêng theo ``admission_profile.status``: Nháp (draft) | Đã nộp (submitted).
+- Nguồn tuyển nhập học = breakdown nhóm "đã đóng học phí": Liên hệ/Giới thiệu
+  (referral / có referrer) vs Hệ thống phân phối (còn lại).
+
+Scope: admin = toàn trường (hoặc đơn vị chọn); manager = ép đơn vị của mình.
+Read-only → service không commit. Raises domain exceptions, never HTTPException.
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import datetime
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
+from openpyxl.utils import get_column_letter
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import models
+from app.services.admission_report_service import AdmissionReportService
+from app.utils.csv_helpers import sanitize_csv_cell
+
+VN_TZ = ZoneInfo("Asia/Ho_Chi_Minh")
+
+# ---- Quy ước phân nhóm (xem docstring) --------------------------------------
+LEAD_BUCKETS = [
+    ("chua", "Chưa tư vấn"),
+    ("dang", "Đang tư vấn"),
+    ("lephi", "Chỉ đóng lệ phí"),
+    ("hocphi", "Đã đóng học phí"),
+    ("dung", "Đã dừng"),
+]
+LB_KEYS = [b[0] for b in LEAD_BUCKETS]
+LB_LABEL = dict(LEAD_BUCKETS)
+HS_BUCKETS = [("nhap", "Nháp (draft)"), ("danop", "Đã nộp (submitted)")]
+HS_KEYS = [b[0] for b in HS_BUCKETS]
+HS_LABEL = dict(HS_BUCKETS)
+SRC_BUCKETS = [("lienhe", "Liên hệ/Giới thiệu"), ("hethong", "Hệ thống phân phối")]
+SRC_KEYS = [b[0] for b in SRC_BUCKETS]
+SRC_LABEL = dict(SRC_BUCKETS)
+
+_DUNG_CS = {"sts20", "sts16", "sts08", "sts18", "sts12"}
+_CHUA_CS = {"sts00", "sts02", "sts01", "sts15", "sts19"}
+
+# ---- Styling ----------------------------------------------------------------
+_THIN = Side(style="thin", color="B0B0B0")
+_BORDER = Border(left=_THIN, right=_THIN, top=_THIN, bottom=_THIN)
+_HEAD_FILL = PatternFill("solid", fgColor="4472C4")
+_HEAD_FONT = Font(bold=True, color="FFFFFF", size=10)
+_GRPA_FILL = PatternFill("solid", fgColor="D9E1F2")
+_GRPB_FILL = PatternFill("solid", fgColor="E2EFDA")
+_GRPC_FILL = PatternFill("solid", fgColor="FCE4D6")
+_SUB_FONT = Font(bold=True, color="1F3864", size=9)
+_TOTAL_FILL = PatternFill("solid", fgColor="FFF2CC")
+_TOTAL_FONT = Font(bold=True, size=10)
+_TITLE_FONT = Font(bold=True, size=14, color="1F3864")
+_CTR = Alignment(horizontal="center", vertical="center", wrap_text=True)
+_LEFT = Alignment(horizontal="left", vertical="center", wrap_text=True)
+
+# Lead is year-scoped via its offering's academic year (lead has no year column);
+# leads without an offering are kept (year unknown → '(Chưa xác định ngành)').
+# Major attribution: nguyện vọng 1 of the year's profile (display_order=1) if any,
+# else the lead's intent offering. "đã đóng" = paid_amount>0 OR waived (miễn).
+_YEAR_SCOPE = """
+      AND (
+          po.id IS NULL
+          OR EXISTS (
+              SELECT 1 FROM offering_academic_info oai
+              WHERE oai.offering_id = po.id AND oai.academic_year = :year
+          )
+      )"""
+_LEAD_SQL = text(
+    """
+    SELECT l.id,
+           COALESCE(max(nv1_po.program_id), max(po.program_id)) AS pid,
+           l.consultation_status_id AS cs,
+           l.assigned_officer_id AS off, l.source, l.referrer_id,
+           max(ap.status) AS pstatus,
+           bool_or(f.fee_type='application'
+                   AND (f.paid_amount > 0 OR f.status = 'waived')) AS has_app,
+           bool_or(f.fee_type='tuition'
+                   AND (f.paid_amount > 0 OR f.status = 'waived')) AS has_tui
+    FROM lead l
+    LEFT JOIN program_offering po ON l.offering_id = po.id
+    LEFT JOIN admission_profile ap ON ap.lead_id = l.id AND ap.academic_year = :year
+    LEFT JOIN admission_profile_choice nv1
+           ON nv1.admission_profile_id = ap.id AND nv1.display_order = 1
+    LEFT JOIN admission_path nv1_path ON nv1.admission_path_id = nv1_path.id
+    LEFT JOIN offering_academic_info nv1_oai
+           ON nv1_path.academic_info_id = nv1_oai.id
+    LEFT JOIN program_offering nv1_po ON nv1_oai.offering_id = nv1_po.id
+    LEFT JOIN fee f ON f.admission_profile_id = ap.id
+    WHERE l.deleted_at IS NULL
+      AND (CAST(:unit AS INTEGER) IS NULL OR l.unit_id = CAST(:unit AS INTEGER))"""
+    + _YEAR_SCOPE
+    + """
+    GROUP BY l.id, l.consultation_status_id,
+             l.assigned_officer_id, l.source, l.referrer_id
+    """
+)
+_OFFICER_SQL = text(
+    """
+    SELECT u.id, COALESCE(u.full_name, u.username) AS nm, count(l.id) AS c
+    FROM lead l
+    JOIN "user" u ON l.assigned_officer_id = u.id
+    LEFT JOIN program_offering po ON l.offering_id = po.id
+    WHERE l.deleted_at IS NULL
+      AND (CAST(:unit AS INTEGER) IS NULL OR l.unit_id = CAST(:unit AS INTEGER))"""
+    + _YEAR_SCOPE
+    + """
+    GROUP BY 1, 2 ORDER BY c DESC, u.id
+    """
+)
+_MAJOR_SQL = text("""
+    SELECT id, code, name, degree_level FROM major_program WHERE is_active
+    ORDER BY name, CASE degree_level WHEN 'Cao đẳng' THEN 0 ELSE 1 END, code
+    """)
+
+
+def _lead_bucket(has_tui, has_app, cs) -> str:
+    if has_tui:
+        return "hocphi"
+    if has_app:
+        return "lephi"
+    if cs in _DUNG_CS:
+        return "dung"
+    if cs is None or cs in _CHUA_CS:
+        return "chua"
+    return "dang"
+
+
+def _H(cell, fill=_HEAD_FILL, font=_HEAD_FONT):
+    cell.fill = fill
+    cell.font = font
+    cell.alignment = _CTR
+    cell.border = _BORDER
+
+
+def _officer_short_names(oname: dict, officer_ids: list) -> dict:
+    """Short header label (last name token) per officer.
+
+    Whitespace-safe ('   '.split() → [] → '#id', avoids IndexError),
+    CSV-injection-safe (sanitize_csv_cell), and disambiguated so two officers
+    sharing a last name fall back to the full name instead of colliding.
+    """
+    base = {}
+    for oid in officer_ids:
+        parts = (oname.get(oid) or "").split()
+        base[oid] = parts[-1] if parts else f"#{oid}"
+    counts: dict = {}
+    for v in base.values():
+        counts[v] = counts.get(v, 0) + 1
+    out = {}
+    for oid in officer_ids:
+        label = base[oid]
+        if counts[label] > 1:  # collision → fuller name to keep columns distinct
+            label = (oname.get(oid) or "").strip() or f"#{oid}"
+        out[oid] = sanitize_csv_cell(label)
+    return out
+
+
+class AdmissionSummaryExportService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def build_xlsx(
+        self,
+        current_user: models.User,
+        academic_year: int,
+        unit_id: Optional[int] = None,
+    ) -> tuple[bytes, str]:
+        # Reuse the weekly report's scope rule (admin all/chosen unit, manager
+        # forced own unit) so viewing and exporting enforce IDOR identically.
+        scope_unit = AdmissionReportService._resolve_scope(current_user, unit_id)
+        params = {"year": academic_year, "unit": scope_unit}
+        leads = (await self.db.execute(_LEAD_SQL, params)).mappings().all()
+        officers = (await self.db.execute(_OFFICER_SQL, params)).mappings().all()
+        majors = (await self.db.execute(_MAJOR_SQL)).mappings().all()
+
+        wb = self._build_workbook(academic_year, leads, officers, majors)
+        bio = io.BytesIO()
+        wb.save(bio)
+        bio.seek(0)
+        ts = datetime.now(VN_TZ).strftime("%Y%m%d_%H%M%S")
+        filename = f"bao_cao_tuyen_sinh_{academic_year}_{ts}.xlsx"
+        return bio.getvalue(), filename
+
+    # ----------------------------------------------------------- workbook build
+    def _build_workbook(self, year, leads, officers, majors) -> Workbook:
+        officer_ids = [r["id"] for r in officers]
+        oname = {r["id"]: r["nm"] for r in officers}
+        oshort = _officer_short_names(oname, officer_ids)
+        n_unassigned = sum(1 for r in leads if r["off"] not in officer_ids)
+
+        major_ids = [m["id"] for m in majors]
+        minfo = {m["id"]: m for m in majors}
+        NONE = -1
+        all_keys = major_ids + [NONE]
+
+        s1 = {p: {k: 0 for k in LB_KEYS} for p in all_keys}
+        s1hs = {p: {k: 0 for k in HS_KEYS} for p in all_keys}
+        s2 = {p: {k: {o: 0 for o in officer_ids} for k in LB_KEYS} for p in all_keys}
+        s2hs = {p: {k: {o: 0 for o in officer_ids} for k in HS_KEYS} for p in all_keys}
+        src = {p: {g: {o: 0 for o in officer_ids} for g in SRC_KEYS} for p in all_keys}
+
+        for r in leads:
+            pid = r["pid"] if r["pid"] in s1 else NONE
+            b = _lead_bucket(r["has_tui"], r["has_app"], r["cs"])
+            s1[pid][b] += 1
+            off = r["off"]
+            if off in officer_ids:
+                s2[pid][b][off] += 1
+            ps = r["pstatus"]
+            # draft → Nháp; bất kỳ trạng thái khác (đã nộp trở lên: submitted/
+            # approved/enrolled/…) → Đã nộp (mốc lũy kế); không hồ sơ → bỏ qua.
+            hk = "nhap" if ps == "draft" else ("danop" if ps is not None else None)
+            if hk:
+                s1hs[pid][hk] += 1
+                if off in officer_ids:
+                    s2hs[pid][hk][off] += 1
+            if b == "hocphi" and off in officer_ids:
+                g = (
+                    "lienhe"
+                    if (r["source"] == "referral" or r["referrer_id"] is not None)
+                    else "hethong"
+                )
+                src[pid][g][off] += 1
+
+        ordered = [
+            p for p in major_ids if sum(s1[p].values()) + sum(s1hs[p].values()) > 0
+        ]
+        if sum(s1[NONE].values()) + sum(s1hs[NONE].values()) > 0:
+            ordered.append(NONE)
+
+        def desc_of(pid):
+            if pid == NONE:
+                return "", "(Chưa xác định ngành)", ""
+            m = minfo[pid]
+            return (
+                sanitize_csv_cell(m["code"]),
+                sanitize_csv_cell(m["name"]),
+                sanitize_csv_cell(m["degree_level"]),
+            )
+
+        ts_label = datetime.now(VN_TZ).strftime("%d/%m/%Y %H:%M")
+        wb = Workbook()
+        DESC = ["TT", "Mã ngành", "Ngành, nghề", "Trình độ", "Liên thông/VB2"]
+        ND = len(DESC)
+
+        self._sheet_summary(wb, year, ts_label, DESC, ND, ordered, desc_of, s1, s1hs)
+        self._sheet_by_officer(
+            wb,
+            year,
+            ts_label,
+            DESC,
+            ND,
+            ordered,
+            desc_of,
+            officer_ids,
+            oshort,
+            n_unassigned,
+            s2,
+            s2hs,
+            src,
+        )
+        self._sheet_notes(wb, year, n_unassigned, len(leads))
+        return wb
+
+    # --------------------------------------------------------- sheet 1: chung
+    def _sheet_summary(self, wb, year, ts_label, DESC, ND, ordered, desc_of, s1, s1hs):
+        ws = wb.active
+        ws.title = "Số liệu chung"
+        c_tong = ND + 1
+        c_lead = c_tong + 1
+        c_hs = c_lead + len(LB_KEYS)
+        total = ND + 1 + len(LB_KEYS) + len(HS_KEYS)
+
+        ws.cell(1, 1, f"SỐ LIỆU TUYỂN SINH NĂM {year}").font = _TITLE_FONT
+        ws.merge_cells(start_row=1, start_column=1, end_row=1, end_column=total)
+        ws.cell(1, 1).alignment = Alignment(horizontal="center", vertical="center")
+        ws.cell(2, 1, "Thời điểm báo cáo:").font = Font(italic=True, size=9)
+        ws.cell(2, 2, ts_label).font = Font(italic=True, size=9)
+
+        for i, h in enumerate(DESC, 1):
+            ws.merge_cells(start_row=4, start_column=i, end_row=5, end_column=i)
+            _H(ws.cell(4, i, h))
+        ws.merge_cells(start_row=4, start_column=c_tong, end_row=5, end_column=c_tong)
+        _H(ws.cell(4, c_tong, "Tổng lead"))
+        ws.merge_cells(
+            start_row=4,
+            start_column=c_lead,
+            end_row=4,
+            end_column=c_lead + len(LB_KEYS) - 1,
+        )
+        _H(
+            ws.cell(
+                4,
+                c_lead,
+                "PHÂN LOẠI LEAD THEO TRẠNG THÁI  (mỗi lead 1 ô — cộng = Tổng lead)",
+            )
+        )
+        ws.merge_cells(
+            start_row=4,
+            start_column=c_hs,
+            end_row=4,
+            end_column=c_hs + len(HS_KEYS) - 1,
+        )
+        _H(ws.cell(4, c_hs, "HỒ SƠ (đếm theo hồ sơ)"))
+        for j, k in enumerate(LB_KEYS):
+            _H(ws.cell(5, c_lead + j, LB_LABEL[k]), fill=_GRPA_FILL, font=_SUB_FONT)
+        for j, k in enumerate(HS_KEYS):
+            _H(ws.cell(5, c_hs + j, HS_LABEL[k]), fill=_GRPB_FILL, font=_SUB_FONT)
+
+        # TỔNG (row 6)
+        ws.cell(6, 1, "TỔNG CỘNG")
+        ws.merge_cells(start_row=6, start_column=1, end_row=6, end_column=ND)
+        ws.cell(6, 1).font = _TOTAL_FONT
+        ws.cell(6, 1).alignment = _CTR
+        for i in range(1, ND + 1):
+            ws.cell(6, i).fill = _TOTAL_FILL
+            ws.cell(6, i).border = _BORDER
+        tot = sum(sum(s1[p].values()) for p in ordered)
+        vals = (
+            [tot]
+            + [sum(s1[p][k] for p in ordered) for k in LB_KEYS]
+            + [sum(s1hs[p][k] for p in ordered) for k in HS_KEYS]
+        )
+        for j, v in enumerate(vals):
+            c = ws.cell(6, c_tong + j, v)
+            c.fill = _TOTAL_FILL
+            c.font = _TOTAL_FONT
+            c.alignment = _CTR
+            c.border = _BORDER
+
+        r = 7
+        for n, pid in enumerate(ordered, 1):
+            code, name, deg = desc_of(pid)
+            ws.cell(r, 1, n).alignment = _CTR
+            ws.cell(r, 2, code).alignment = _CTR
+            ws.cell(r, 3, name).alignment = _LEFT
+            ws.cell(r, 4, deg).alignment = _CTR
+            ws.cell(r, 5, "Không").alignment = _CTR
+            row_vals = (
+                [sum(s1[pid].values())]
+                + [s1[pid][k] for k in LB_KEYS]
+                + [s1hs[pid][k] for k in HS_KEYS]
+            )
+            for j, v in enumerate(row_vals):
+                c = ws.cell(r, c_tong + j, v)
+                c.alignment = _CTR
+                if j == 0:
+                    c.font = Font(bold=True)
+            for i in range(1, total + 1):
+                ws.cell(r, i).border = _BORDER
+            r += 1
+
+        for col, w in zip("ABCDE", (4.5, 11, 34, 10, 9)):
+            ws.column_dimensions[col].width = w
+        ws.column_dimensions[get_column_letter(c_tong)].width = 8
+        for j in range(len(LB_KEYS)):
+            ws.column_dimensions[get_column_letter(c_lead + j)].width = 11
+        for j in range(len(HS_KEYS)):
+            ws.column_dimensions[get_column_letter(c_hs + j)].width = 12
+        # Freeze rows 1-6 (header + TỔNG) and the A-E descriptor cols, like sheet 2.
+        ws.freeze_panes = ws.cell(7, c_tong).coordinate
+
+    # ----------------------------------------------------- sheet 2: nhân viên
+    def _sheet_by_officer(
+        self,
+        wb,
+        year,
+        ts_label,
+        DESC,
+        ND,
+        ordered,
+        desc_of,
+        officer_ids,
+        oshort,
+        n_unassigned,
+        s2,
+        s2hs,
+        src,
+    ):
+        ws = wb.create_sheet("Chia theo nhân viên")
+        noff = len(officer_ids)
+        aA = ND + 1
+        aB = aA + len(LB_KEYS) * noff
+        aC = aB + len(HS_KEYS) * noff
+        total2 = ND + (len(LB_KEYS) + len(HS_KEYS) + len(SRC_KEYS)) * noff
+
+        ws.cell(1, 1, f"SỐ LIỆU TUYỂN SINH NĂM {year} — CHIA THEO NHÂN VIÊN").font = (
+            _TITLE_FONT
+        )
+        ws.merge_cells(
+            start_row=1, start_column=1, end_row=1, end_column=max(total2, 1)
+        )
+        ws.cell(1, 1).alignment = Alignment(horizontal="center", vertical="center")
+        ws.cell(2, 1, "Thời điểm báo cáo:").font = Font(italic=True, size=9)
+        ws.cell(2, 2, ts_label).font = Font(italic=True, size=9)
+        if n_unassigned:
+            ws.cell(
+                2,
+                6,
+                f"Lưu ý: chưa gồm {n_unassigned} lead chưa phân công nhân viên "
+                "(xem sheet 'Số liệu chung').",
+            ).font = Font(italic=True, color="C00000", size=9)
+
+        if noff == 0:
+            return  # không có nhân viên trong phạm vi → sheet chỉ có tiêu đề
+
+        for i, h in enumerate(DESC, 1):
+            ws.merge_cells(start_row=3, start_column=i, end_row=5, end_column=i)
+            _H(ws.cell(3, i, h))
+        ws.merge_cells(start_row=3, start_column=aA, end_row=3, end_column=aB - 1)
+        _H(ws.cell(3, aA, "PHÂN LOẠI LEAD THEO TRẠNG THÁI"))
+        ws.merge_cells(start_row=3, start_column=aB, end_row=3, end_column=aC - 1)
+        _H(ws.cell(3, aB, "HỒ SƠ (đếm theo hồ sơ)"))
+        ws.merge_cells(start_row=3, start_column=aC, end_row=3, end_column=total2)
+        _H(ws.cell(3, aC, "Nguồn tuyển nhập học (nhóm đã đóng học phí)"))
+
+        def grp(col, keys, label, fill):
+            for k in keys:
+                ws.merge_cells(
+                    start_row=4, start_column=col, end_row=4, end_column=col + noff - 1
+                )
+                _H(ws.cell(4, col, label[k]), fill=fill, font=_SUB_FONT)
+                for t, oid in enumerate(officer_ids):
+                    _H(ws.cell(5, col + t, oshort[oid]), fill=fill, font=_SUB_FONT)
+                col += noff
+
+        grp(aA, LB_KEYS, LB_LABEL, _GRPA_FILL)
+        grp(aB, HS_KEYS, HS_LABEL, _GRPB_FILL)
+        grp(aC, SRC_KEYS, SRC_LABEL, _GRPC_FILL)
+
+        # TỔNG row 6
+        ws.cell(6, 1, "TỔNG CỘNG")
+        ws.merge_cells(start_row=6, start_column=1, end_row=6, end_column=ND)
+        ws.cell(6, 1).font = _TOTAL_FONT
+        ws.cell(6, 1).alignment = _CTR
+        for i in range(1, ND + 1):
+            ws.cell(6, i).fill = _TOTAL_FILL
+            ws.cell(6, i).border = _BORDER
+
+        def emit(row, col, store, keys, pid, is_total):
+            for k in keys:
+                for t, oid in enumerate(officer_ids):
+                    v = (
+                        sum(store[p][k][oid] for p in ordered)
+                        if is_total
+                        else store[pid][k][oid]
+                    )
+                    c = ws.cell(row, col + t, v)
+                    c.alignment = _CTR
+                    if is_total:
+                        c.fill = _TOTAL_FILL
+                        c.font = _TOTAL_FONT
+                    c.border = _BORDER
+                col += noff
+            return col
+
+        emit(6, aA, s2, LB_KEYS, None, True)
+        emit(6, aB, s2hs, HS_KEYS, None, True)
+        emit(6, aC, src, SRC_KEYS, None, True)
+
+        r = 7
+        for n, pid in enumerate(ordered, 1):
+            code, name, deg = desc_of(pid)
+            ws.cell(r, 1, n).alignment = _CTR
+            ws.cell(r, 2, code).alignment = _CTR
+            ws.cell(r, 3, name).alignment = _LEFT
+            ws.cell(r, 4, deg).alignment = _CTR
+            ws.cell(r, 5, "Không").alignment = _CTR
+            emit(r, aA, s2, LB_KEYS, pid, False)
+            emit(r, aB, s2hs, HS_KEYS, pid, False)
+            emit(r, aC, src, SRC_KEYS, pid, False)
+            for i in range(1, ND + 1):
+                ws.cell(r, i).border = _BORDER
+            r += 1
+
+        for col, w in zip("ABCDE", (4.5, 11, 28, 9, 8)):
+            ws.column_dimensions[col].width = w
+        for cc in range(aA, total2 + 1):
+            ws.column_dimensions[get_column_letter(cc)].width = 6.5
+        ws.freeze_panes = ws.cell(7, aA).coordinate
+
+    # ----------------------------------------------------- sheet 3: quy ước
+    def _sheet_notes(self, wb, year, n_unassigned, n_leads):
+        ws = wb.create_sheet("Quy ước & ghi chú")
+        ws.column_dimensions["A"].width = 26
+        ws.column_dimensions["B"].width = 78
+        ws.cell(1, 1, "QUY ƯỚC ĐẾM & GHI CHÚ").font = _TITLE_FONT
+        ws.merge_cells("A1:B1")
+        rows = [
+            (
+                "Tổng lead",
+                "Tổng số lead theo ngành = nguyện vọng 1 của hồ sơ; nếu chưa "
+                "có hồ sơ thì theo ngành quan tâm (offering). Đếm theo LEAD.",
+            ),
+            (
+                "Chưa tư vấn",
+                "Lead chưa tiếp cận: sts00, sts02, các trạng thái phổ quát "
+                "sts01/sts15/sts19, hoặc chưa có trạng thái. Đếm theo LEAD.",
+            ),
+            (
+                "Đang tư vấn",
+                "Lead còn trong quy trình, chưa đóng phí và chưa dừng "
+                "(sts03–sts06 và các trạng thái khác). Đếm theo LEAD.",
+            ),
+            (
+                "Chỉ đóng lệ phí",
+                "Đã đóng/được miễn lệ phí xét tuyển NHƯNG chưa đóng học phí. "
+                "Đếm theo TIỀN thật (paid_amount>0 hoặc miễn).",
+            ),
+            (
+                "Đã đóng học phí",
+                "Đã đóng/được miễn học phí (đã gồm lệ phí). Đóng cả 2 → CHỈ "
+                "tính ở đây. Đếm theo TIỀN thật (paid_amount>0 hoặc miễn).",
+            ),
+            (
+                "Đã dừng",
+                "Lead ngừng/loại: sts20 (ngừng tư vấn), sts16/sts08 (hồ sơ "
+                "rớt/rút), sts18 (hoàn HP), sts12 (nghỉ học). Đếm theo LEAD.",
+            ),
+            (
+                "Nháp (draft)",
+                "Số HỒ SƠ đang nháp, chưa nộp (admission_profile = draft). "
+                "Đếm theo HỒ SƠ.",
+            ),
+            (
+                "Đã nộp (submitted)",
+                "Số HỒ SƠ đã nộp chính thức (submitted trở lên — gồm đã "
+                "duyệt/nhập học, KHÔNG gồm nháp). Đếm theo HỒ SƠ.",
+            ),
+            (
+                "Liên hệ/Giới thiệu",
+                "Trong nhóm đã đóng học phí: lead có source='referral' hoặc "
+                "có người giới thiệu.",
+            ),
+            (
+                "Hệ thống phân phối",
+                "Trong nhóm đã đóng học phí: các lead còn lại "
+                "(website/social/phone/walk-in/event/other).",
+            ),
+        ]
+        _H(ws.cell(3, 1, "Cột"))
+        _H(ws.cell(3, 2, "Cách đếm"))
+        r = 4
+        for a, b in rows:
+            ws.cell(r, 1, a).font = Font(bold=True)
+            ws.cell(r, 1).alignment = _LEFT
+            ws.cell(r, 2, b).alignment = _LEFT
+            for i in (1, 2):
+                ws.cell(r, i).border = _BORDER
+            r += 1
+        r += 1
+        notes = [
+            "GHI CHÚ:",
+            "• 5 cột phân loại lead (Chưa TV + Đang TV + Chỉ lệ phí + Học "
+            "phí + Đã dừng) LOẠI TRỪ nhau → cộng đúng = Tổng lead. Mỗi lead "
+            "chỉ nằm 1 ô (theo nấc cao nhất).",
+            "• Cột Nháp & Đã nộp đếm theo HỒ SƠ (chiều khác) — đặt riêng, "
+            "KHÔNG cộng vào Tổng lead. Nháp và Đã nộp rời nhau (mỗi hồ sơ 1 "
+            "trạng thái, mỗi lead tối đa 1 hồ sơ).",
+            "• 'Đã đóng học phí' nằm trong 'đã đóng lệ phí' về bản chất, "
+            "nhưng theo quy ước: đóng cả 2 CHỈ tính học phí → 2 cột rời "
+            "nhau, cộng = tổng đã đóng tiền.",
+            "• Nguồn tuyển nhập học chỉ tính cho nhóm 'đã đóng học phí'.",
+        ]
+        if n_unassigned:
+            notes.append(
+                f"• Sheet 'Chia theo nhân viên' KHÔNG gồm {n_unassigned} "
+                f"lead chưa phân công nhân viên → tổng theo nhân viên = "
+                f"{n_leads - n_unassigned}, ít hơn Tổng lead ({n_leads}) "
+                f"đúng {n_unassigned} lead."
+            )
+        for t in notes:
+            ws.cell(r, 1, t).alignment = _LEFT
+            ws.merge_cells(start_row=r, start_column=1, end_row=r, end_column=2)
+            if t.endswith(":"):
+                ws.cell(r, 1).font = Font(bold=True, size=11)
+            r += 1

--- a/Backend_FastAPI/app/services/admission_summary_export_service.py
+++ b/Backend_FastAPI/app/services/admission_summary_export_service.py
@@ -52,6 +52,7 @@ SRC_LABEL = dict(SRC_BUCKETS)
 
 _DUNG_CS = {"sts20", "sts16", "sts08", "sts18", "sts12"}
 _CHUA_CS = {"sts00", "sts02", "sts01", "sts15", "sts19"}
+_UNASSIGNED = 0  # sentinel cột "Chưa PC" cho lead không có nhân viên phụ trách
 
 # ---- Styling ----------------------------------------------------------------
 _THIN = Side(style="thin", color="B0B0B0")
@@ -122,10 +123,12 @@ _OFFICER_SQL = text(
     GROUP BY 1, 2 ORDER BY c DESC, u.id
     """
 )
-_MAJOR_SQL = text("""
+_MAJOR_SQL = text(
+    """
     SELECT id, code, name, degree_level FROM major_program WHERE is_active
     ORDER BY name, CASE degree_level WHEN 'Cao đẳng' THEN 0 ELSE 1 END, code
-    """)
+    """
+)
 
 
 def _lead_bucket(has_tui, has_app, cs) -> str:
@@ -199,9 +202,16 @@ class AdmissionSummaryExportService:
     # ----------------------------------------------------------- workbook build
     def _build_workbook(self, year, leads, officers, majors) -> Workbook:
         officer_ids = [r["id"] for r in officers]
+        officer_id_set = set(officer_ids)
         oname = {r["id"]: r["nm"] for r in officers}
         oshort = _officer_short_names(oname, officer_ids)
-        n_unassigned = sum(1 for r in leads if r["off"] not in officer_ids)
+        n_unassigned = sum(1 for r in leads if r["off"] not in officer_id_set)
+        # Sheet-2 columns = officers (+ "Chưa PC" if any lead has no officer) so
+        # EVERY lead is attributed → sheet 2 reconciles exactly with sheet 1.
+        officer_cols = list(officer_ids)
+        if n_unassigned:
+            officer_cols.append(_UNASSIGNED)
+            oshort[_UNASSIGNED] = "Chưa PC"
 
         major_ids = [m["id"] for m in majors]
         minfo = {m["id"]: m for m in majors}
@@ -210,32 +220,32 @@ class AdmissionSummaryExportService:
 
         s1 = {p: {k: 0 for k in LB_KEYS} for p in all_keys}
         s1hs = {p: {k: 0 for k in HS_KEYS} for p in all_keys}
-        s2 = {p: {k: {o: 0 for o in officer_ids} for k in LB_KEYS} for p in all_keys}
-        s2hs = {p: {k: {o: 0 for o in officer_ids} for k in HS_KEYS} for p in all_keys}
-        src = {p: {g: {o: 0 for o in officer_ids} for g in SRC_KEYS} for p in all_keys}
+        s2 = {p: {k: {o: 0 for o in officer_cols} for k in LB_KEYS} for p in all_keys}
+        s2hs = {p: {k: {o: 0 for o in officer_cols} for k in HS_KEYS} for p in all_keys}
+        src = {p: {g: {o: 0 for o in officer_cols} for g in SRC_KEYS} for p in all_keys}
 
         for r in leads:
             pid = r["pid"] if r["pid"] in s1 else NONE
             b = _lead_bucket(r["has_tui"], r["has_app"], r["cs"])
             s1[pid][b] += 1
             off = r["off"]
-            if off in officer_ids:
-                s2[pid][b][off] += 1
+            # col is always a valid key: an unassigned lead implies _UNASSIGNED ∈ cols
+            col = off if off in officer_id_set else _UNASSIGNED
+            s2[pid][b][col] += 1
             ps = r["pstatus"]
             # draft → Nháp; bất kỳ trạng thái khác (đã nộp trở lên: submitted/
             # approved/enrolled/…) → Đã nộp (mốc lũy kế); không hồ sơ → bỏ qua.
             hk = "nhap" if ps == "draft" else ("danop" if ps is not None else None)
             if hk:
                 s1hs[pid][hk] += 1
-                if off in officer_ids:
-                    s2hs[pid][hk][off] += 1
-            if b == "hocphi" and off in officer_ids:
+                s2hs[pid][hk][col] += 1
+            if b == "hocphi":
                 g = (
                     "lienhe"
                     if (r["source"] == "referral" or r["referrer_id"] is not None)
                     else "hethong"
                 )
-                src[pid][g][off] += 1
+                src[pid][g][col] += 1
 
         ordered = [
             p for p in major_ids if sum(s1[p].values()) + sum(s1hs[p].values()) > 0
@@ -267,7 +277,7 @@ class AdmissionSummaryExportService:
             ND,
             ordered,
             desc_of,
-            officer_ids,
+            officer_cols,
             oshort,
             n_unassigned,
             s2,
@@ -385,7 +395,7 @@ class AdmissionSummaryExportService:
         ND,
         ordered,
         desc_of,
-        officer_ids,
+        officer_cols,
         oshort,
         n_unassigned,
         s2,
@@ -393,11 +403,12 @@ class AdmissionSummaryExportService:
         src,
     ):
         ws = wb.create_sheet("Chia theo nhân viên")
-        noff = len(officer_ids)
+        noff = len(officer_cols)
+        block_w = 1 + noff  # cột "Tổng" + mỗi nhân viên (+ "Chưa PC" nếu có)
         aA = ND + 1
-        aB = aA + len(LB_KEYS) * noff
-        aC = aB + len(HS_KEYS) * noff
-        total2 = ND + (len(LB_KEYS) + len(HS_KEYS) + len(SRC_KEYS)) * noff
+        aB = aA + len(LB_KEYS) * block_w
+        aC = aB + len(HS_KEYS) * block_w
+        total2 = ND + (len(LB_KEYS) + len(HS_KEYS) + len(SRC_KEYS)) * block_w
 
         ws.cell(1, 1, f"SỐ LIỆU TUYỂN SINH NĂM {year} — CHIA THEO NHÂN VIÊN").font = (
             _TITLE_FONT
@@ -412,12 +423,12 @@ class AdmissionSummaryExportService:
             ws.cell(
                 2,
                 6,
-                f"Lưu ý: chưa gồm {n_unassigned} lead chưa phân công nhân viên "
-                "(xem sheet 'Số liệu chung').",
+                f"{n_unassigned} lead chưa phân công nằm ở cột 'Chưa PC' (mỗi "
+                "khối) → cột 'Tổng' khớp sheet 'Số liệu chung'.",
             ).font = Font(italic=True, color="C00000", size=9)
 
-        if noff == 0:
-            return  # không có nhân viên trong phạm vi → sheet chỉ có tiêu đề
+        if not officer_cols:
+            return  # không có lead trong phạm vi → sheet chỉ có tiêu đề
 
         for i, h in enumerate(DESC, 1):
             ws.merge_cells(start_row=3, start_column=i, end_row=5, end_column=i)
@@ -429,21 +440,26 @@ class AdmissionSummaryExportService:
         ws.merge_cells(start_row=3, start_column=aC, end_row=3, end_column=total2)
         _H(ws.cell(3, aC, "Nguồn tuyển nhập học (nhóm đã đóng học phí)"))
 
+        # mỗi khối: cột "Tổng" + 1 cột / nhân viên (+ "Chưa PC")
         def grp(col, keys, label, fill):
             for k in keys:
                 ws.merge_cells(
-                    start_row=4, start_column=col, end_row=4, end_column=col + noff - 1
+                    start_row=4,
+                    start_column=col,
+                    end_row=4,
+                    end_column=col + block_w - 1,
                 )
                 _H(ws.cell(4, col, label[k]), fill=fill, font=_SUB_FONT)
-                for t, oid in enumerate(officer_ids):
-                    _H(ws.cell(5, col + t, oshort[oid]), fill=fill, font=_SUB_FONT)
-                col += noff
+                _H(ws.cell(5, col, "Tổng"), fill=fill, font=_SUB_FONT)
+                for t, oid in enumerate(officer_cols):
+                    _H(ws.cell(5, col + 1 + t, oshort[oid]), fill=fill, font=_SUB_FONT)
+                col += block_w
 
         grp(aA, LB_KEYS, LB_LABEL, _GRPA_FILL)
         grp(aB, HS_KEYS, HS_LABEL, _GRPB_FILL)
         grp(aC, SRC_KEYS, SRC_LABEL, _GRPC_FILL)
 
-        # TỔNG row 6
+        # TỔNG CỘNG row 6
         ws.cell(6, 1, "TỔNG CỘNG")
         ws.merge_cells(start_row=6, start_column=1, end_row=6, end_column=ND)
         ws.cell(6, 1).font = _TOTAL_FONT
@@ -454,19 +470,27 @@ class AdmissionSummaryExportService:
 
         def emit(row, col, store, keys, pid, is_total):
             for k in keys:
-                for t, oid in enumerate(officer_ids):
-                    v = (
+                vals = [
+                    (
                         sum(store[p][k][oid] for p in ordered)
                         if is_total
                         else store[pid][k][oid]
                     )
-                    c = ws.cell(row, col + t, v)
+                    for oid in officer_cols
+                ]
+                # cột "Tổng" của khối = cộng các nhân viên (khớp sheet Số liệu chung)
+                cells = [(col, sum(vals), True)]
+                cells += [(col + 1 + t, v, False) for t, v in enumerate(vals)]
+                for cc, v, is_block_total in cells:
+                    c = ws.cell(row, cc, v)
                     c.alignment = _CTR
+                    c.border = _BORDER
                     if is_total:
                         c.fill = _TOTAL_FILL
                         c.font = _TOTAL_FONT
-                    c.border = _BORDER
-                col += noff
+                    elif is_block_total:
+                        c.font = Font(bold=True)
+                col += block_w
             return col
 
         emit(6, aA, s2, LB_KEYS, None, True)
@@ -576,13 +600,13 @@ class AdmissionSummaryExportService:
             "nhưng theo quy ước: đóng cả 2 CHỈ tính học phí → 2 cột rời "
             "nhau, cộng = tổng đã đóng tiền.",
             "• Nguồn tuyển nhập học chỉ tính cho nhóm 'đã đóng học phí'.",
+            "• Sheet 'Chia theo nhân viên': mỗi khối có cột 'Tổng' (= cộng các "
+            "nhân viên, KHỚP sheet 'Số liệu chung') và cột 'Chưa PC' (lead chưa "
+            "phân công nhân viên) nên sheet 2 đối chiếu khớp sheet 1.",
         ]
         if n_unassigned:
             notes.append(
-                f"• Sheet 'Chia theo nhân viên' KHÔNG gồm {n_unassigned} "
-                f"lead chưa phân công nhân viên → tổng theo nhân viên = "
-                f"{n_leads - n_unassigned}, ít hơn Tổng lead ({n_leads}) "
-                f"đúng {n_unassigned} lead."
+                f"• Có {n_unassigned} lead chưa phân công nhân viên (cột " "'Chưa PC')."
             )
         for t in notes:
             ws.cell(r, 1, t).alignment = _LEFT

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -114,7 +114,8 @@ async def resolve_fee_academic_info(
       * more than one admitted → fail-closed (corrupt data: the cascade admits
         at most one NV — never guess),
       * not yet published + exactly one choice → that single choice's ngành
-        (prepay / giữ chỗ at ``submitted`` — mirrors ``is_fee_eligible``),
+        (prepay / giữ chỗ at ``submitted`` / ``resubmitted`` — mirrors
+        ``is_fee_eligible``),
       * otherwise (≥2 pending, or zero choices) → BadRequest.
 
     Legacy single-path profiles resolve from the profile snapshot, in order:

--- a/Backend_FastAPI/app/utils/admission_status.py
+++ b/Backend_FastAPI/app/utils/admission_status.py
@@ -115,15 +115,27 @@ def is_fee_eligible(profile: "AdmissionProfile") -> bool:
       * admitted-like (legacy ``approved`` / ``overridden`` + choice-engine
         ``admitted``) — the post-decision happy path,
       * ``confirmed`` / ``enrolled`` — later post-decision milestones,
-      * ``submitted`` for single-path profiles (C2 fast-track prepay / giữ chỗ),
-      * ``submitted`` for a multi-NV profile (``uses_choice_engine``) that has
-        EXACTLY ONE nguyện vọng. With a single choice the ngành is already
-        determined (publish can only admit that one choice or reject the whole
-        profile — ``add_choice`` is locked at ``submitted``), so prepay / giữ
-        chỗ is as safe as the single-path case. A multi-NV profile with ≥2
-        choices at ``submitted`` has not locked its admitted choice (all choices
-        ``pending`` until publish) → calculating tuition would risk the wrong
-        ngành, so it qualifies later via ``admitted`` (``is_admitted_like``).
+      * ``submitted`` / ``resubmitted`` for single-path profiles (C2 fast-track
+        prepay / giữ chỗ),
+      * ``submitted`` / ``resubmitted`` for a multi-NV profile
+        (``uses_choice_engine``) that has EXACTLY ONE nguyện vọng. With a single
+        choice the ngành is already determined (publish can only admit that one
+        choice or reject the whole profile — ``add_choice`` is locked at
+        ``submitted`` / ``resubmitted``), so prepay / giữ chỗ is as safe as the
+        single-path case. A multi-NV profile with ≥2 choices has not locked its
+        admitted choice (all choices ``pending`` until publish) → calculating
+        tuition would risk the wrong ngành, so it qualifies later via
+        ``admitted`` (``is_admitted_like``).
+
+    ``resubmitted`` is treated exactly like ``submitted`` here: it is the state
+    a profile lands in after the officer fixes issues and re-submits a
+    ``rejected`` / ``revision_requested`` profile (``resubmit_profile``). It is
+    still pre-decision (chờ duyệt lại) — ``effective_status`` maps it to
+    ``submitted`` and every other workflow gate handles the pair
+    ``("submitted", "resubmitted")`` together. Omitting it here was a bug: a
+    multi-NV profile returned for "too many NVs", trimmed to one NV and
+    re-submitted, would land in ``resubmitted`` and silently lose the
+    "Tính học phí" button despite being just as fee-eligible as ``submitted``.
 
     The multi-NV single-choice branch reads ``profile.__dict__`` (no lazy-load
     → no MissingGreenlet) and FAILS CLOSED when ``choices`` is not eager-loaded:
@@ -143,7 +155,7 @@ def is_fee_eligible(profile: "AdmissionProfile") -> bool:
     """
     if is_admitted_like(profile) or profile.status in ("confirmed", "enrolled"):
         return True
-    if profile.status == "submitted":
+    if profile.status in ("submitted", "resubmitted"):
         if not profile.uses_choice_engine:
             return True
         choices = profile.__dict__.get("choices")

--- a/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
+++ b/Backend_FastAPI/tests/api/test_fees_calculate_authorization.py
@@ -1003,6 +1003,55 @@ async def test_single_path_calculate_fee_at_submitted_still_ok(
 
 
 @pytest.mark.asyncio
+async def test_calculate_fee_at_resubmitted_ok(
+    client: AsyncClient,
+    admin_token_headers: dict,
+    officer_user_in_db: dict,
+    fee_calc_config: dict,
+):
+    """Regression (prod profile 81, 2026-06-26): a profile the manager returned
+    and the officer re-submitted lands in ``resubmitted`` — still pre-decision,
+    still fee-eligible exactly like ``submitted`` (C2 fast-track prepay / giữ
+    chỗ). Before the fix ``is_fee_eligible`` only matched the literal
+    ``submitted`` so a re-submitted profile silently lost the "Tính học phí"
+    button. Asserts BOTH gate sites that share ``is_fee_eligible``:
+      * Site B — the FE ``calculate_fee`` permission flag,
+      * Site A — the ``/api/fees/calculate`` route gate.
+    """
+    pid = await _create_approved_profile(
+        client, admin_token_headers, officer_user_in_db, fee_calc_config,
+        lead_name="Resubmitted Calc OK", approve=False,
+    )
+    # Flip submitted → resubmitted directly (mirrors how the L2 tests mutate
+    # state without driving the full reject → resubmit workflow). Single-path
+    # so choices are irrelevant to the gate.
+    await _set_choice_engine(pid, value=False, status="resubmitted")
+
+    oh = await _login(
+        client, officer_user_in_db["username"], officer_user_in_db["password"]
+    )
+    detail = (await client.get(f"{ADMISSIONS}/{pid}", headers=oh)).json()
+    assert detail["status"] == "resubmitted", detail.get("status")
+    assert detail["permissions"]["calculate_fee"] is True, detail["permissions"]
+    assert "calculate_fee" in detail["available_actions"], detail["available_actions"]
+
+    resp = await client.post(
+        "/api/fees/calculate",
+        json={
+            "admission_profile_id": pid,
+            "fee_type": "tuition",
+            "installment_plan_code": "FULL",
+            "semester_no": 1,
+        },
+        headers=oh,
+    )
+    assert resp.status_code == 201, (
+        f"Resubmitted profile should be fee-eligible like submitted, got "
+        f"{resp.status_code}: {resp.text[:300]}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_multi_nv_zero_choice_at_admitted_fails_closed(
     client: AsyncClient,
     admin_token_headers: dict,

--- a/Backend_FastAPI/tests/services/test_admission_application_fee.py
+++ b/Backend_FastAPI/tests/services/test_admission_application_fee.py
@@ -575,6 +575,42 @@ class TestRecordFeePayment:
         assert transactions[0].performed_by_id == payment.verified_by_id
         assert transactions[0].external_reference == "TXN123456"
 
+    async def test_resubmitted_profile_record_fee_succeeds(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        seed_admission_statuses: dict,
+    ):
+        """Enforcement regression (prod profile 81, 2026-06-26): a profile
+        re-submitted after a manager return (rejected/revision_requested →
+        resubmitted) is still in the pre-decision intake window, so the service
+        gate must accept an application-fee payment. Before the fix the gate
+        only matched draft/submitted and raised BadRequest on resubmitted."""
+        unit_id = seed_admission_statuses["unit_id"]
+        lead_id = await create_test_lead_with_consultation(
+            unit_id=unit_id,
+            assigned_officer_id=admin_user_in_db["id"],
+        )
+        profile = await create_admission_profile_with_fee_status(
+            lead_id=lead_id,
+            citizen_id="200000000661",
+            academic_year=2026,
+            requires_fee=True,
+            fee_status="pending",
+            status="resubmitted",
+        )
+
+        admin_headers = await get_auth_headers(client, admin_user_in_db)
+        response = await client.post(
+            f"/api/admissions/{profile.id}/record-fee-payment",
+            params={"transaction_id": "TXN-RESUB-1", "amount": 100000},
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 200, f"Failed: {response.text}"
+        updated_profile = await reload_profile(profile.id)
+        assert updated_profile.applied_rules.get("fee_status") == "paid"
+
     async def test_assigned_officer_can_record_fee_payment(
         self,
         client: AsyncClient,
@@ -896,6 +932,36 @@ class TestRecordFeePaymentPermissionFlag:
 
         data = await self._get_detail(client, profile.id, manager_user_in_db)
 
+        assert data["permissions"]["record_fee_payment"] is True
+        assert "record_fee_payment" in data["available_actions"]
+
+    async def test_resubmitted_pending_profile_can_record_fee(
+        self,
+        client: AsyncClient,
+        admin_user_in_db: dict,
+        officer_user_in_db: dict,
+        seed_admission_statuses: dict,
+    ):
+        """Flag regression (prod profile 81, 2026-06-26): a re-submitted profile
+        with a pending application fee must still expose record_fee_payment —
+        resubmitted is part of the pre-decision intake window, exactly like
+        submitted. Before the fix the flag only matched draft/submitted."""
+        lead_id = await create_test_lead_with_consultation(
+            unit_id=seed_admission_statuses["unit_id"],
+            assigned_officer_id=officer_user_in_db["id"],
+        )
+        profile = await create_admission_profile_with_fee_status(
+            lead_id=lead_id,
+            citizen_id="200000000662",
+            academic_year=2026,
+            requires_fee=True,
+            fee_status="pending",
+            status="resubmitted",
+        )
+
+        data = await self._get_detail(client, profile.id, admin_user_in_db)
+
+        assert data["status"] == "resubmitted", data.get("status")
         assert data["permissions"]["record_fee_payment"] is True
         assert "record_fee_payment" in data["available_actions"]
 

--- a/Backend_FastAPI/tests/unit/test_admission_status_helpers.py
+++ b/Backend_FastAPI/tests/unit/test_admission_status_helpers.py
@@ -240,9 +240,9 @@ def test_admitted_like_set_matches_effective_status_admitted_targets() -> None:
 # ---------------------------------------------------------------------------
 # is_fee_eligible — fee-create state gate (shared by routers/fees.py
 # _fee_calc_authorized + admission_service calculate_fee permission flag).
-# Post-decision states always pass; ``submitted`` passes for single-path
-# (C2 prepay) AND for a multi-NV profile that has EXACTLY ONE nguyện vọng
-# (ngành already determined). Multi-NV ≥2 at ``submitted`` must wait for
+# Post-decision states always pass; ``submitted`` / ``resubmitted`` pass for
+# single-path (C2 prepay) AND for a multi-NV profile that has EXACTLY ONE
+# nguyện vọng (ngành already determined). Multi-NV ≥2 must wait for
 # publish → ``admitted``.
 # ---------------------------------------------------------------------------
 
@@ -272,54 +272,68 @@ def test_is_fee_eligible_true_for_later_post_decision(status: str) -> None:
     )
 
 
-def test_is_fee_eligible_submitted_single_path_true() -> None:
-    """Legacy single-path at ``submitted`` = C2 fast-track prepay / giữ chỗ.
-    Choices are irrelevant for single-path."""
-    assert is_fee_eligible(_fee_profile("submitted", uses_choice_engine=False)) is True
+@pytest.mark.parametrize("status", ["submitted", "resubmitted"])
+def test_is_fee_eligible_submitted_single_path_true(status: str) -> None:
+    """Legacy single-path at ``submitted`` / ``resubmitted`` = C2 fast-track
+    prepay / giữ chỗ. Choices are irrelevant for single-path."""
+    assert is_fee_eligible(_fee_profile(status, uses_choice_engine=False)) is True
     # Even with a stray loaded (empty) choices list, single-path stays eligible.
     assert (
-        is_fee_eligible(_fee_profile("submitted", uses_choice_engine=False, choices=[]))
+        is_fee_eligible(_fee_profile(status, uses_choice_engine=False, choices=[]))
         is True
     )
 
 
-def test_is_fee_eligible_submitted_multinv_single_choice_true() -> None:
+@pytest.mark.parametrize("status", ["submitted", "resubmitted"])
+def test_is_fee_eligible_submitted_multinv_single_choice_true(status: str) -> None:
     """The new rule: a multi-NV profile with EXACTLY ONE nguyện vọng may
-    prepay at ``submitted`` (ngành is already determined)."""
+    prepay at ``submitted`` / ``resubmitted`` (ngành is already determined).
+
+    ``resubmitted`` is the regression that hid the "Tính học phí" button after a
+    multi-NV profile was returned for too many NVs, trimmed to one NV and
+    re-submitted (prod profile 81, 2026-06-26)."""
     assert (
         is_fee_eligible(
-            _fee_profile("submitted", uses_choice_engine=True, choices=[object()])
+            _fee_profile(status, uses_choice_engine=True, choices=[object()])
         )
         is True
     )
 
 
+@pytest.mark.parametrize("status", ["submitted", "resubmitted"])
 @pytest.mark.parametrize("n_choices", [2, 3, 5])
-def test_is_fee_eligible_submitted_multinv_multi_choice_false(n_choices: int) -> None:
-    """Multi-NV with ≥2 NVs at ``submitted`` is NOT eligible — the admitted
-    ngành is not locked until publish, so pricing now risks the wrong ngành."""
+def test_is_fee_eligible_submitted_multinv_multi_choice_false(
+    n_choices: int, status: str
+) -> None:
+    """Multi-NV with ≥2 NVs at ``submitted`` / ``resubmitted`` is NOT eligible —
+    the admitted ngành is not locked until publish, so pricing now risks the
+    wrong ngành."""
     choices = [object() for _ in range(n_choices)]
     assert (
         is_fee_eligible(
-            _fee_profile("submitted", uses_choice_engine=True, choices=choices)
+            _fee_profile(status, uses_choice_engine=True, choices=choices)
         )
         is False
     )
 
 
-def test_is_fee_eligible_submitted_multinv_zero_choice_false() -> None:
+@pytest.mark.parametrize("status", ["submitted", "resubmitted"])
+def test_is_fee_eligible_submitted_multinv_zero_choice_false(status: str) -> None:
     assert (
-        is_fee_eligible(_fee_profile("submitted", uses_choice_engine=True, choices=[]))
+        is_fee_eligible(_fee_profile(status, uses_choice_engine=True, choices=[]))
         is False
     )
 
 
-def test_is_fee_eligible_submitted_multinv_choices_not_loaded_fails_closed() -> None:
+@pytest.mark.parametrize("status", ["submitted", "resubmitted"])
+def test_is_fee_eligible_submitted_multinv_choices_not_loaded_fails_closed(
+    status: str,
+) -> None:
     """If ``choices`` was not eager-loaded the gate must fail closed (the
     fee-create path re-checks under a row lock; a missing eager-load must
     degrade to 'not eligible', never to a wrong-ngành fee)."""
     assert (
-        is_fee_eligible(_fee_profile("submitted", uses_choice_engine=True))
+        is_fee_eligible(_fee_profile(status, uses_choice_engine=True))
         is False
     )
 
@@ -327,12 +341,13 @@ def test_is_fee_eligible_submitted_multinv_choices_not_loaded_fails_closed() -> 
 @pytest.mark.parametrize(
     "status",
     ["draft", "reviewing", "waitlisted", "rejected", "withdrawn",
-     "revision_requested", "result_published", "resubmitted", "", "SUBMITTED"],
+     "revision_requested", "result_published", "", "SUBMITTED"],
 )
 @pytest.mark.parametrize("engine", [False, True])
 def test_is_fee_eligible_false_for_non_eligible_states(status: str, engine: bool) -> None:
-    """Pre-decision (other than the submitted prepay carve-outs) and negative
-    outcomes are never fee-eligible — even a single-choice multi-NV profile."""
+    """Pre-decision (other than the submitted/resubmitted prepay carve-outs) and
+    negative outcomes are never fee-eligible — even a single-choice multi-NV
+    profile."""
     assert (
         is_fee_eligible(
             _fee_profile(status, uses_choice_engine=engine, choices=[object()])

--- a/Backend_FastAPI/tests/unit/test_admission_summary_export.py
+++ b/Backend_FastAPI/tests/unit/test_admission_summary_export.py
@@ -39,8 +39,12 @@ def test_officer_short_name_whitespace_does_not_crash():
 
 
 def test_officer_short_name_sanitizes_formula_injection():
-    out = _officer_short_names({1: "=cmd|'/c calc'!A1"}, [1])
-    assert out[1].startswith("'")  # neutralized for Excel
+    # single-token formula → prefixed with ' (neutralized for Excel)
+    assert _officer_short_names({1: "=cmd"}, [1])[1].startswith("'")
+    # output must never begin with a formula-trigger char
+    for nm in ("=1+1", "@SUM", "+x", "Trần |pipe"):
+        v = _officer_short_names({9: nm}, [9])[9]
+        assert v and v[0] not in ("=", "+", "-", "@", "|", "\t")
 
 
 def test_officer_short_name_disambiguates_collisions():

--- a/Backend_FastAPI/tests/unit/test_admission_summary_export.py
+++ b/Backend_FastAPI/tests/unit/test_admission_summary_export.py
@@ -1,0 +1,167 @@
+"""Pure-logic unit tests for the admission-summary Excel export (no DB).
+
+Covers the DB-free logic: lead bucketing priority, officer short-name safety
+(whitespace crash guard, CSV-injection sanitize, collision disambiguation),
+and the workbook aggregation (exclusive 5-bucket funnel sums to total leads,
+'Đã nộp' counts submitted-or-beyond).
+"""
+
+from app.services.admission_summary_export_service import (
+    AdmissionSummaryExportService,
+    _lead_bucket,
+    _officer_short_names,
+)
+
+
+# ----------------------------------------------------------------- _lead_bucket
+def test_lead_bucket_priority_money_first():
+    # paid tuition wins even over a terminal consultation status
+    assert _lead_bucket(True, True, "sts20") == "hocphi"
+    assert _lead_bucket(True, False, "sts06") == "hocphi"
+    # paid application (no tuition) → lephi, even over 'đã dừng'
+    assert _lead_bucket(False, True, "sts20") == "lephi"
+
+
+def test_lead_bucket_no_money_falls_to_status():
+    assert _lead_bucket(False, False, "sts20") == "dung"
+    assert _lead_bucket(False, False, "sts16") == "dung"
+    assert _lead_bucket(False, False, "sts00") == "chua"
+    assert _lead_bucket(False, False, "sts02") == "chua"
+    assert _lead_bucket(False, False, None) == "chua"
+    assert _lead_bucket(False, False, "sts06") == "dang"
+
+
+# ------------------------------------------------------- _officer_short_names
+def test_officer_short_name_whitespace_does_not_crash():
+    # whitespace-only name is truthy but split() == [] → must not IndexError
+    assert _officer_short_names({1: "   "}, [1]) == {1: "#1"}
+    assert _officer_short_names({1: None}, [1]) == {1: "#1"}
+
+
+def test_officer_short_name_sanitizes_formula_injection():
+    out = _officer_short_names({1: "=cmd|'/c calc'!A1"}, [1])
+    assert out[1].startswith("'")  # neutralized for Excel
+
+
+def test_officer_short_name_disambiguates_collisions():
+    out = _officer_short_names({1: "Nguyễn Văn An", 2: "Trần Thị An"}, [1, 2])
+    # both last-token "An" → fall back to full names, must stay distinct
+    assert out[1] != out[2]
+    assert out[1] == "Nguyễn Văn An" and out[2] == "Trần Thị An"
+
+
+def test_officer_short_name_plain_uses_last_token():
+    assert _officer_short_names({5: "Nguyễn Văn An"}, [5]) == {5: "An"}
+
+
+# ------------------------------------------------------------- _build_workbook
+def _rows():
+    leads = [
+        # (bucket, hồ sơ)
+        dict(
+            id=1,
+            pid=1,
+            cs="sts06",
+            off=10,
+            source="website",
+            referrer_id=None,
+            pstatus="draft",
+            has_app=False,
+            has_tui=False,
+        ),
+        dict(
+            id=2,
+            pid=1,
+            cs="sts13",
+            off=10,
+            source="website",
+            referrer_id=None,
+            pstatus="submitted",
+            has_app=True,
+            has_tui=False,
+        ),
+        # approved profile + paid tuition → hocphi + counts as 'đã nộp'
+        dict(
+            id=3,
+            pid=1,
+            cs="sts10",
+            off=11,
+            source="referral",
+            referrer_id=None,
+            pstatus="approved",
+            has_app=True,
+            has_tui=True,
+        ),
+        dict(
+            id=4,
+            pid=1,
+            cs="sts20",
+            off=12,
+            source="website",
+            referrer_id=None,
+            pstatus=None,
+            has_app=False,
+            has_tui=False,
+        ),
+        # unassigned officer
+        dict(
+            id=5,
+            pid=1,
+            cs="sts00",
+            off=None,
+            source="website",
+            referrer_id=None,
+            pstatus=None,
+            has_app=False,
+            has_tui=False,
+        ),
+        # offering points to a major not in catalog → '(Chưa xác định ngành)'
+        dict(
+            id=6,
+            pid=999,
+            cs="sts06",
+            off=10,
+            source="website",
+            referrer_id=None,
+            pstatus=None,
+            has_app=False,
+            has_tui=False,
+        ),
+    ]
+    officers = [
+        dict(id=10, nm="Nguyễn Văn An"),
+        dict(id=11, nm="   "),  # whitespace → must not crash
+        dict(id=12, nm="Trần Thị An"),  # last-name collision with id 10
+        dict(id=13, nm="=cmd|calc"),  # injection → sanitized header
+    ]
+    majors = [dict(id=1, code="6480201", name="CNTT", degree_level="Cao đẳng")]
+    return leads, officers, majors
+
+
+def test_build_workbook_structure_and_totals():
+    leads, officers, majors = _rows()
+    svc = AdmissionSummaryExportService(db=None)
+    wb = svc._build_workbook(2026, leads, officers, majors)
+
+    assert wb.sheetnames == [
+        "Số liệu chung",
+        "Chia theo nhân viên",
+        "Quy ước & ghi chú",
+    ]
+    ws = wb["Số liệu chung"]
+    # row 6 = TỔNG; col 6 = Tổng lead; cols 7..11 = 5 buckets; 12=Nháp 13=Đã nộp
+    assert ws.cell(6, 6).value == len(leads)  # 6 leads
+    bucket_sum = sum(ws.cell(6, c).value for c in range(7, 12))
+    assert bucket_sum == len(leads)  # exclusive funnel reconciles
+    assert ws.cell(6, 12).value == 1  # Nháp: only id=1 draft
+    # Đã nộp counts submitted-or-beyond: id=2 submitted + id=3 approved
+    assert ws.cell(6, 13).value == 2
+
+
+def test_build_workbook_handles_zero_officers():
+    leads, _, majors = _rows()
+    svc = AdmissionSummaryExportService(db=None)
+    # no officers in scope → sheet 2 still renders (title only), no crash
+    wb = svc._build_workbook(2026, leads, [], majors)
+    assert "Chia theo nhân viên" in wb.sheetnames
+    assert wb["Số liệu chung"].cell(6, 6).value == len(leads)

--- a/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportClientLoader.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/_components/PaymentImportClientLoader.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+/**
+ * Loader client-only cho trang Import thu học phí.
+ *
+ * Vì sao `ssr: false`: trang là công cụ nội bộ sau đăng nhập (không SEO). Dưới
+ * Next.js 16 Cache Components, `page.tsx` bị prerender TĨNH lúc build — sinh ra
+ * HTML shell CHƯA-đăng-nhập, lệch với cây client ĐÃ-đăng-nhập lúc hydrate →
+ * React #418 (hydration mismatch, chỉ hiện ở production build; dev luôn render
+ * động nên không repro). `export const dynamic = "force-dynamic"` KHÔNG được
+ * Cache Components tôn trọng (route vẫn ○ Static).
+ *
+ * `ssr: false` để server + client-initial cùng render `loading` fallback → khớp,
+ * không hydrate lệch; form thật mount sau ở client. Cùng pattern với
+ * `SocketHandler` trong `(dashboard)/layout.tsx`.
+ */
+const PaymentImportClient = dynamic(
+  () => import("./PaymentImportClient").then((m) => m.PaymentImportClient),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="container mx-auto space-y-6 py-6">
+        <div className="h-8 w-72 animate-pulse rounded-md bg-muted" />
+        <div className="h-64 w-full animate-pulse rounded-md bg-muted" />
+      </div>
+    ),
+  },
+)
+
+export function PaymentImportClientLoader() {
+  return <PaymentImportClient />
+}

--- a/frontend/src/app/(dashboard)/finance/payments/import/page.tsx
+++ b/frontend/src/app/(dashboard)/finance/payments/import/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next"
 
-import { PaymentImportClient } from "./_components/PaymentImportClient"
+import { PaymentImportClientLoader } from "./_components/PaymentImportClientLoader"
 
 export const metadata: Metadata = {
   title: "Import thu học phí | QLTS",
@@ -8,5 +8,5 @@ export const metadata: Metadata = {
 }
 
 export default function PaymentImportPage() {
-  return <PaymentImportClient />
+  return <PaymentImportClientLoader />
 }

--- a/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/AdmissionsWeeklyClient.tsx
+++ b/frontend/src/app/(dashboard)/reports/admissions-weekly/_components/AdmissionsWeeklyClient.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import * as React from "react";
-import { BarChart3, ChevronLeft, ChevronRight } from "lucide-react";
+import type { AxiosError } from "axios";
+import { BarChart3, ChevronLeft, ChevronRight, Download } from "lucide-react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -13,8 +15,10 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { exportAdmissionSummary } from "@/lib/api/reports";
 import { useReportFilters, useWeeklyReport } from "@/hooks/reports/useWeeklyReport";
 import { cn } from "@/lib/utils";
+import { blobErrorMessage, downloadBlob } from "@/lib/utils/download-blob";
 import { subDaysVN } from "@/lib/utils/vn-date";
 import type { ReportGroupBy } from "@/lib/zod/reports";
 
@@ -42,6 +46,15 @@ export function AdmissionsWeeklyClient() {
   const [groupBy, setGroupBy] = React.useState<ReportGroupBy>("major");
   const [period, setPeriod] = React.useState<Period>("ytd");
   const [weekStart, setWeekStart] = React.useState<string | undefined>(undefined);
+  const [exporting, setExporting] = React.useState(false);
+  // Guard the post-await setState if the user navigates away mid-export.
+  const mountedRef = React.useRef(true);
+  React.useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    [],
+  );
 
   // Filter options (năm config ∪ data + đợt) — admin & manager, same gate as report.
   const { data: filters } = useReportFilters(year);
@@ -83,6 +96,22 @@ export function AdmissionsWeeklyClient() {
     // dependent filters may be invalid for the new year → reset both.
     setWeekStart(undefined);
     setRound(ALL_ROUNDS);
+  };
+
+  // Xuất báo cáo "số liệu tổng" (snapshot cả năm) — KHÁC bảng tuần đang hiển thị.
+  const onExport = async () => {
+    setExporting(true);
+    try {
+      const { blob, filename } = await exportAdmissionSummary(year);
+      downloadBlob(blob, filename);
+      toast.success("Đã xuất báo cáo Excel");
+    } catch (err) {
+      toast.error(
+        await blobErrorMessage(err as AxiosError, "Không xuất được báo cáo."),
+      );
+    } finally {
+      if (mountedRef.current) setExporting(false);
+    }
   };
 
   return (
@@ -170,6 +199,15 @@ export function AdmissionsWeeklyClient() {
               )}
             </div>
           </div>
+          <Button
+            variant="outline"
+            onClick={onExport}
+            disabled={exporting}
+            title="Xuất số liệu tuyển sinh cả năm ra Excel (3 sheet: số liệu chung · chia theo nhân viên · quy ước)"
+          >
+            <Download className="mr-2 size-4" />
+            {exporting ? "Đang xuất…" : "Xuất Excel"}
+          </Button>
         </div>
       </div>
 

--- a/frontend/src/lib/api/reports.ts
+++ b/frontend/src/lib/api/reports.ts
@@ -39,3 +39,48 @@ export async function getReportFilters(
   );
   return reportFiltersSchema.parse(response.data);
 }
+
+export interface ExportedFile {
+  blob: Blob;
+  filename: string;
+}
+
+/** Lấy filename từ header Content-Disposition (giữ tên có timestamp của backend). */
+function filenameFromDisposition(
+  disposition: string | undefined,
+  fallback: string,
+): string {
+  if (!disposition) return fallback;
+  const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(disposition);
+  if (!match) return fallback;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+/**
+ * Xuất báo cáo tuyển sinh (snapshot) ra Excel — số liệu CẢ NĂM tại thời điểm bấm.
+ * Trả {blob, filename} (giữ tên có timestamp do backend đặt, tránh ghi đè file cũ);
+ * scope theo vai trò ở backend (admin toàn trường / manager đơn vị).
+ */
+export async function exportAdmissionSummary(
+  academic_year: number,
+  unit_id?: number,
+): Promise<ExportedFile> {
+  const response = await api.get(
+    "/api/v2/admin/reports/admission-summary/export.xlsx",
+    {
+      params: { academic_year, ...(unit_id ? { unit_id } : {}) },
+      responseType: "blob",
+    },
+  );
+  return {
+    blob: response.data,
+    filename: filenameFromDisposition(
+      response.headers["content-disposition"],
+      `bao_cao_tuyen_sinh_${academic_year}.xlsx`,
+    ),
+  };
+}


### PR DESCRIPTION
> ⚠️ **Bổ sung sau merge (tài liệu hóa) — PR này squash-gộp 3 nhóm thay đổi độc lập.**
> Branch `fix/payment-import-hydration` được nhánh ra từ `main` đang chứa sẵn các commit dưới, nên squash-merge #436 gộp cả 3. Liệt kê để tra cứu:
>
> **1. Báo cáo tuyển sinh — Xuất Excel** (`e9cfc73e`, `5748ad06`)
> Nút "Xuất Excel" báo cáo tuyển sinh (snapshot 3 sheet) + service `admission_summary_export_service.py` + sheet "Chia theo nhân viên" (cột "Tổng" + "Chưa PC" khớp Sheet 1). FE `AdmissionsWeeklyClient.tsx` + `lib/api/reports.ts`.
>
> **2. Fix: tính học phí + thu lệ phí ở trạng thái `resubmitted`** (`8f462006`)
> Bug prod (hồ sơ 81): hồ sơ multi-NV bị trả về → officer xoá còn 1 NV + nộp lại → status `resubmitted` → nút "Tính học phí" ẩn vì `is_fee_eligible` chỉ khớp literal `"submitted"`.
> Fix `is_fee_eligible` chấp nhận `submitted`/`resubmitted` (thông 3 site: cờ FE `calculate_fee`, route gate `POST /api/fees/calculate`, picker finance) + gộp fix lệ phí `record_fee_payment` (cờ FE + enforcement `record_application_fee_payment`). Resolver `resolve_fee_academic_info` không đổi (status-agnostic). Không migration/Casbin.
> Test: unit 91 + fee-auth 19 + application-fee 48 (đều có ca `resubmitted` mới).
>
> **3. Fix hydration import `ssr:false` — mục gốc của PR, mô tả bên dưới:**

---

## Vấn đề
Trang `/finance/payments/import` (#433) phát console error **React #418 (hydration mismatch)** trên production — phát hiện khi smoke prod.

## Root cause (đã verify)
- Next 16 **Cache Components** prerender trang **TĨNH** (`○ Static`) lúc build → HTML shell **chưa-đăng-nhập** lệch với cây client **đã-đăng-nhập** khi hydrate → #418.
- Bằng chứng: build route table `○ /finance/payments/import` vs `◐ /leads` (động); prod SSR HTML import (40KB) **thiếu H1** vs /leads (432KB) có nội dung.
- Chỉ hiện ở **production build** (dev luôn render động → không repro). **Non-blocking** (React tự client-render lại) nhưng bẩn console + SSR sai.
- `export const dynamic = "force-dynamic"` **KHÔNG** được Cache Components tôn trọng (đã test build: route vẫn ○ Static; legend chỉ có ○/◐, không có ƒ Dynamic).

## Fix
Tách `PaymentImportClientLoader` dùng `next/dynamic` **`ssr: false`** (cùng pattern `SocketHandler` ở `(dashboard)/layout.tsx`) → server + client-initial cùng render `loading` fallback nên **khớp**; form thật mount sau ở client → hết hydrate lệch.

## Verify
- compile + type-check + lint **sạch** (full build OOM cục bộ do RAM — CI chạy lại với tài nguyên đủ).
- **#418-gone verify trên prod sau deploy** (nơi duy nhất repro được).

## Phạm vi
Chỉ fix trang import (đã xác nhận #418). Các trang `○ Static` finance khác có thể dính pattern tương tự → sẽ rà sau khi confirm fix này trên prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
