### PR TITLE
fix(reports): year-scope + major archived + effective_status (follow-up /review #436)

### DIFF
--- a/Backend_FastAPI/app/repositories/fee_repository.py
+++ b/Backend_FastAPI/app/repositories/fee_repository.py
@@ -741,10 +741,17 @@ class InvoiceRepository(BaseRepository[Invoice]):
             # "HS-000131" or a bare profile id -> match AdmissionProfile.id.
             digits = re.sub(r"\D", "", normalized)
             if digits and (normalized.upper().startswith("HS") or normalized.isdigit()):
-                try:
-                    search_or.append(models.AdmissionProfile.id == int(digits))
-                except (ValueError, OverflowError):
-                    pass
+                # A profile id is a PostgreSQL int4. ``int(digits)`` NEVER raises
+                # in Python (arbitrary precision), so the old try/except was a
+                # no-op: a long numeric search (a pasted phone / mã ~11+ digits)
+                # bound an out-of-int32 value into AdmissionProfile.id → asyncpg
+                # DataError → 500 on BOTH list_invoices and get_status_counts
+                # (observed 126×/72h on prod). Range-guard instead — out of int4
+                # range means "no such profile", so just skip the id branch
+                # (mirrors search_calculable_profiles in fee_calculation_service).
+                pid_val = int(digits)
+                if 1 <= pid_val <= 2147483647:
+                    search_or.append(models.AdmissionProfile.id == pid_val)
             conditions.append(or_(*search_or))
         return conditions
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -59,6 +59,7 @@ from .admission_correction_helpers import (
     safe_serialize,
 )
 from ..utils.admission_status import (
+    effective_status,
     is_admitted_like,
     is_confirmation_eligible,
     is_fee_eligible,
@@ -2186,12 +2187,13 @@ def _compute_frontend_fields(
         # Thu lệ phí xét tuyển - POST /api/admissions/{id}/record-fee-payment.
         # Mirror get_admission_for_fee_collection (deps.py): admin all;
         # manager/accountant same-unit; officer assigned+same-unit. Gate
-        # draft/submitted/resubmitted + le phi thuc su pending -> nut khong hien
-        # cho exempt / da-paid / post-decision. ``resubmitted`` = submitted sau
-        # khi officer nop lai (mirror enforcement record_application_fee_payment
-        # + is_fee_eligible cho hoc phi).
+        # draft + submitted-equivalent (effective_status maps resubmitted →
+        # submitted) + le phi thuc su pending -> nut khong hien cho exempt /
+        # da-paid / post-decision. Normalize via effective_status thay vì hardcode
+        # ("draft","submitted","resubmitted") để khớp enforcement
+        # record_application_fee_payment + tránh drift (xem is_fee_eligible).
         "record_fee_payment": (
-            status in ("draft", "submitted", "resubmitted")
+            (status == "draft" or effective_status(profile) == "submitted")
             and bool((profile.applied_rules or {}).get("requires_application_fee"))
             and (profile.applied_rules or {}).get("fee_status") == "pending"
             and (
@@ -9484,12 +9486,13 @@ async def record_application_fee_payment(
         raise ResourceNotFoundError(f"Admission profile {profile_id} not found")
 
     # Check profile status — only allow fee payment for profiles still in the
-    # pre-decision intake window: draft / submitted / resubmitted. ``resubmitted``
-    # is submitted after an officer re-submit (rejected/revision_requested →
-    # resubmitted); omitting it blocked fee collection on a re-submitted profile
-    # even though it is still being processed (mirrors the FE record_fee_payment
-    # flag + is_fee_eligible for tuition).
-    if profile.status not in ("draft", "submitted", "resubmitted"):
+    # pre-decision intake window: draft + submitted-equivalent. effective_status
+    # maps the legacy ``resubmitted`` (rejected/revision_requested → re-submit)
+    # back to ``submitted``, so a re-submitted profile is accepted without
+    # hardcoding the alias here (mirrors the FE record_fee_payment flag +
+    # is_fee_eligible for tuition; prevents the drift that hid the action on
+    # prod profile 81).
+    if profile.status != "draft" and effective_status(profile) != "submitted":
         raise BadRequest(
             f"Cannot record fee payment for profile in '{profile.status}' status. "
             "Only draft, submitted or resubmitted profiles accept fee payments."

--- a/Backend_FastAPI/app/services/admission_summary_export_service.py
+++ b/Backend_FastAPI/app/services/admission_summary_export_service.py
@@ -69,16 +69,26 @@ _TITLE_FONT = Font(bold=True, size=14, color="1F3864")
 _CTR = Alignment(horizontal="center", vertical="center", wrap_text=True)
 _LEFT = Alignment(horizontal="left", vertical="center", wrap_text=True)
 
-# Lead is year-scoped via its offering's academic year (lead has no year column);
-# leads without an offering are kept (year unknown → '(Chưa xác định ngành)').
+# Lead is year-scoped via its offering's academic year (lead has no year column).
+# A lead WITHOUT an offering has no year of its own → scope it by the VN-tz year of
+# its created_at (a brand-new lead that hasn't picked a ngành still counts in the
+# year it arrived). Without this guard an offering-less lead from ANY prior year
+# would show up in EVERY year's report and inflate "Tổng lead"/"Chưa tư vấn".
+# Shared by _LEAD_SQL and _OFFICER_SQL, so it may reference only lead/po columns
+# (the officer query doesn't join admission_profile) → both sheets stay reconciled.
 # Major attribution: nguyện vọng 1 of the year's profile (display_order=1) if any,
 # else the lead's intent offering. "đã đóng" = paid_amount>0 OR waived (miễn).
 _YEAR_SCOPE = """
       AND (
-          po.id IS NULL
-          OR EXISTS (
+          EXISTS (
               SELECT 1 FROM offering_academic_info oai
               WHERE oai.offering_id = po.id AND oai.academic_year = :year
+          )
+          OR (
+              po.id IS NULL
+              AND EXTRACT(
+                  YEAR FROM l.created_at AT TIME ZONE 'Asia/Ho_Chi_Minh'
+              )::int = :year
           )
       )"""
 _LEAD_SQL = text(
@@ -123,9 +133,13 @@ _OFFICER_SQL = text(
     GROUP BY 1, 2 ORDER BY c DESC, u.id
     """
 )
+# Include inactive majors too: a lead/profile may still point to a major archived
+# mid-year; filtering by is_active would drop it into '(Chưa xác định ngành)' instead
+# of its real name. Majors with no leads are dropped later by the ``ordered`` filter,
+# so this never adds empty rows.
 _MAJOR_SQL = text(
     """
-    SELECT id, code, name, degree_level FROM major_program WHERE is_active
+    SELECT id, code, name, degree_level FROM major_program
     ORDER BY name, CASE degree_level WHEN 'Cao đẳng' THEN 0 ELSE 1 END, code
     """
 )

--- a/Backend_FastAPI/app/utils/admission_status.py
+++ b/Backend_FastAPI/app/utils/admission_status.py
@@ -153,9 +153,17 @@ def is_fee_eligible(profile: "AdmissionProfile") -> bool:
     ``tests/api/test_phase3_pr3d_b_choice_crud.py`` (single-choice→201;
     ≥2-pending / 0-choice → fail-closed).
     """
-    if is_admitted_like(profile) or profile.status in ("confirmed", "enrolled"):
+    # Normalize legacy aliases ONCE via ``effective_status`` instead of hardcoding
+    # the pairs at every gate: ``approved``/``overridden`` → ``admitted`` and
+    # ``resubmitted`` → ``submitted``. Hardcoding the ``("submitted",
+    # "resubmitted")`` pair here while other gates only checked ``"submitted"`` is
+    # exactly what hid the "Tính học phí" button on a re-submitted multi-NV
+    # profile (prod profile 81); routing through the single canonicalizer prevents
+    # that whole class of drift for any future alias added to LEGACY_TO_NEW_STATUS_MAP.
+    eff = effective_status(profile)
+    if eff in ("admitted", "confirmed", "enrolled"):
         return True
-    if profile.status in ("submitted", "resubmitted"):
+    if eff == "submitted":
         if not profile.uses_choice_engine:
             return True
         choices = profile.__dict__.get("choices")

--- a/Backend_FastAPI/tests/repositories/test_invoice_list_repository.py
+++ b/Backend_FastAPI/tests/repositories/test_invoice_list_repository.py
@@ -230,6 +230,26 @@ async def test_search_by_profile_code(db, seeded_invoices):
     assert all(inv.invoice_number.startswith("INV-T-") for inv in invoices)
 
 
+async def test_search_oversized_numeric_does_not_crash(db, seeded_invoices):
+    """A numeric search longer than int4 (e.g. a pasted phone / mã ~11+ digits)
+    must NOT bind an out-of-int32 value into AdmissionProfile.id → asyncpg
+    DataError → 500. Regression: prod hit this 126×/72h on BOTH list_invoices
+    and get_status_counts (the id branch's old try/except never caught it because
+    Python int() doesn't overflow). Out-of-int4 = no such profile → id branch
+    skipped; name/phone/number ilike still run, so the query returns cleanly."""
+    repo = InvoiceRepository(db)
+    big = "66311007745"  # ~66 tỷ, vượt int4 max 2_147_483_647
+    invoices, total = await repo.get_filtered_with_count(
+        unit_id=seeded_invoices["unit_a"], search=big
+    )
+    assert total == 0  # no invoice_number/name/phone contains it; no crash
+    # get_status_counts shares _build_invoice_list_conditions → must also not crash.
+    counts = await repo.get_status_counts(
+        unit_id=seeded_invoices["unit_a"], search=big
+    )
+    assert counts["total"] == 0
+
+
 async def test_fee_type_filter(db, seeded_invoices):
     repo = InvoiceRepository(db)
     invoices, total = await repo.get_filtered_with_count(

--- a/frontend/src/lib/api/reports.ts
+++ b/frontend/src/lib/api/reports.ts
@@ -1,4 +1,5 @@
 import { api } from "./client";
+import { filenameFromDisposition } from "@/lib/utils/download-blob";
 import {
   admissionWeeklyReportSchema,
   reportFiltersSchema,
@@ -43,21 +44,6 @@ export async function getReportFilters(
 export interface ExportedFile {
   blob: Blob;
   filename: string;
-}
-
-/** Lấy filename từ header Content-Disposition (giữ tên có timestamp của backend). */
-function filenameFromDisposition(
-  disposition: string | undefined,
-  fallback: string,
-): string {
-  if (!disposition) return fallback;
-  const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(disposition);
-  if (!match) return fallback;
-  try {
-    return decodeURIComponent(match[1]);
-  } catch {
-    return match[1];
-  }
 }
 
 /**

--- a/frontend/src/lib/utils/download-blob.ts
+++ b/frontend/src/lib/utils/download-blob.ts
@@ -16,6 +16,24 @@ export function downloadBlob(blob: Blob, filename: string): void {
 }
 
 /**
+ * Lấy filename từ header `Content-Disposition` (giữ tên có timestamp do backend đặt).
+ * Dùng chung cho mọi endpoint export blob; fallback khi header thiếu/không parse được.
+ */
+export function filenameFromDisposition(
+  disposition: string | undefined,
+  fallback: string,
+): string {
+  if (!disposition) return fallback
+  const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(disposition)
+  if (!match) return fallback
+  try {
+    return decodeURIComponent(match[1])
+  } catch {
+    return match[1]
+  }
+}
+
+/**
  * Lấy message lỗi khi tải blob: vì `responseType:'blob'`, body lỗi (JSON) bị axios bọc
  * thành Blob → phải đọc `.text()` rồi parse mới ra `detail` thật (không thì luôn fallback).
  */


### PR DESCRIPTION
## 🔴 Hotfix kèm: int32 overflow khi search hóa đơn (commit `0a50cba7`)
Phát hiện khi **điều tra log prod**: `list_invoices` + `get_status_counts` (workspace "Thu học phí") ném **500 — 126 lần/72h** khi kế toán/admin gõ một số dài vào ô tìm kiếm (vd `66311007745`). Nguyên nhân: `_build_invoice_list_conditions` bọc `int(digits)` trong `try/except (ValueError, OverflowError)` — nhưng `int()` Python không overflow nên except là no-op; giá trị vượt int4 bind vào `AdmissionProfile.id` → asyncpg `DataError`. Fix: range-guard `[1, 2147483647]` (mirror `search_calculable_profiles`). Test `test_search_oversized_numeric_does_not_crash` (list + status-counts). Đây là lỗi prod **đang xảy ra**, nên gộp vào PR này để ship cùng.

## Bối cảnh
Follow-up các finding từ `/review` PR #436 (nhóm số liệu báo cáo Excel + altitude). Sửa 4 finding, defer 3 (refactor lớn — đã xác minh 0 ảnh hưởng thực tế).

## Thay đổi
- **#1 year-scope** (`admission_summary_export_service._YEAR_SCOPE`): lead chưa có offering không có "năm" riêng nên trước đây bị giữ ở MỌI năm → phồng "Tổng lead"/"Chưa tư vấn" + đếm trùng qua các năm. Nay scope theo năm VN của `created_at`. Verified dev: year=2025 loại đúng 49 lead-ma, year=2026 giữ đủ 1227. `_YEAR_SCOPE` vẫn chỉ dùng cột `lead`/`po` để `_LEAD_SQL` và `_OFFICER_SQL` khớp nhau.
- **#5 `_MAJOR_SQL`**: bỏ `WHERE is_active` → ngành đã archive nhưng còn lead map đúng tên thay vì gom vào "(Chưa xác định ngành)". Ngành không lead vẫn bị `ordered` loại nên không thêm dòng rỗng.
- **#4 effective_status** (altitude): `is_fee_eligible` + 2 gate record-fee (`record_fee_payment` flag + `record_application_fee_payment` enforcement) dùng `effective_status()` thay hardcode `("submitted","resubmitted")` — chính việc hardcode lệch nhau giữa các gate là nguyên nhân bug ẩn nút "Tính học phí" ở hồ sơ resubmitted (prod hồ sơ 81).
- **#7 reuse**: `filenameFromDisposition` chuyển vào `lib/utils/download-blob.ts` (cạnh `downloadBlob`/`blobErrorMessage`) để mọi endpoint export blob dùng chung.

## Defer (follow-up — đã đo: 0 ảnh hưởng thực tế, hệ thống mới có 1 năm dữ liệu 2026)
- #2 raw SQL → repository (code quality)
- #3 export re-encode lead-stage/fee-overlay (drift nếu tương lai đổi quy tắc)
- #6 `s1` derive từ `s2` (simplification)
- pre-existing: nv1 cross-year attribution + multi-year lead exclusion — query dev xác nhận **0 lead** dính (chỉ kích hoạt khi có dữ liệu ≥2 năm tuyển sinh)

## Verify
- unit 99 (is_fee_eligible effective_status + export) + integration **full 67** (fee-auth 19 + application-fee 48) + SQL #1/#5 trên dev + `tsc` FE
- `/code-review max`: 0 correctness bug mới
- Không migration / không Casbin (deploy = chỉ code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
