### PR TITLE
feat(finance): nâng cấp bảng Thu học phí — filter ngành/trình độ + cột Đã đóng/Còn lại + drawer chi tiết

### DIFF
--- a/Backend_FastAPI/alembic/versions/3a3edf2b968b_fee_resolved_academic_snapshot_columns.py
+++ b/Backend_FastAPI/alembic/versions/3a3edf2b968b_fee_resolved_academic_snapshot_columns.py
@@ -1,0 +1,93 @@
+"""fee resolved academic snapshot columns
+
+Denormalize the resolved admission major onto Fee so the "Thu học phí"
+workspace (filter + list row + drawer + status-counts) shares ONE source of
+truth. For multi-NV profiles the value reflects the ADMITTED choice (via
+``resolve_fee_academic_info``), never the lead's intent offering. All columns
+are nullable + fail-soft: when the resolver can't decide they stay NULL and the
+UI shows "(chưa chốt ngành)".
+
+Hand-written (autogenerate was polluted by unrelated model/DB comment drift) —
+only the three Fee columns + index + FKs.
+
+Revision ID: 3a3edf2b968b
+Revises: bvk20260626001
+Create Date: 2026-06-26 12:09:18.244367
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '3a3edf2b968b'
+down_revision: Union[str, Sequence[str], None] = 'bvk20260626001'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'fee',
+        sa.Column(
+            'resolved_academic_info_id',
+            sa.Integer(),
+            nullable=True,
+            comment='Snapshot: resolved OfferingAcademicInfo (trace source of major)',
+        ),
+    )
+    op.add_column(
+        'fee',
+        sa.Column(
+            'resolved_major_id',
+            sa.Integer(),
+            nullable=True,
+            comment='Snapshot: resolved MajorProgram (filter/display source — NULL = chưa chốt)',
+        ),
+    )
+    op.add_column(
+        'fee',
+        sa.Column(
+            'resolved_degree_level',
+            sa.String(length=50),
+            nullable=True,
+            comment=(
+                "Snapshot: degree level TEXT NAME ('Cao đẳng'…) matching "
+                "MajorProgram.degree_level legacy text + admissions FE filter value"
+            ),
+        ),
+    )
+    op.create_index(
+        op.f('ix_fee_resolved_major_id'),
+        'fee',
+        ['resolved_major_id'],
+        unique=False,
+    )
+    op.create_foreign_key(
+        'fk_fee_resolved_academic_info',
+        'fee',
+        'offering_academic_info',
+        ['resolved_academic_info_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
+    op.create_foreign_key(
+        'fk_fee_resolved_major',
+        'fee',
+        'major_program',
+        ['resolved_major_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint('fk_fee_resolved_major', 'fee', type_='foreignkey')
+    op.drop_constraint('fk_fee_resolved_academic_info', 'fee', type_='foreignkey')
+    op.drop_index(op.f('ix_fee_resolved_major_id'), table_name='fee')
+    op.drop_column('fee', 'resolved_degree_level')
+    op.drop_column('fee', 'resolved_major_id')
+    op.drop_column('fee', 'resolved_academic_info_id')

--- a/Backend_FastAPI/alembic/versions/tcf20260626001_casbin_programs_dropdown_grant.py
+++ b/Backend_FastAPI/alembic/versions/tcf20260626001_casbin_programs_dropdown_grant.py
@@ -1,0 +1,75 @@
+"""Casbin grant GET /api/programs (dropdown ngành cho filter "Thu học phí")
+
+Cấp quyền GET /api/programs (MajorProgram list) cho **officer + manager** — y hệt
+/api/program-offerings (cùng mục đích "Dropdown data"). Accountant kế thừa officer
+(g, role:accountant, role:officer) → cũng có quyền; admin có wildcard.
+
+Service ``get_programs_by_unit_tree`` tự unit-scope manager/officer; accountant
+(finance global read) thấy full list — chủ ý cho filter công nợ toàn đơn vị.
+
+Trước fix này filter Ngành trống cho accountant/manager (403) vì chỉ
+/api/program-offerings được cấp, KHÔNG có /api/programs.
+
+- v3='allow' (eft) BẮT BUỘC — auth_model.conf p=sub,obj,act,eft; thiếu v3 → grant
+  bị bỏ khi load_policy. Casbin nạp lúc startup → RESTART backend sau migration.
+- Idempotent: WHERE NOT EXISTS + sweep NULL v3 (self-heal). Khớp style bvk.
+
+Revision ID: tcf20260626001
+Revises: 3a3edf2b968b
+Create Date: 2026-06-26
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+
+revision = "tcf20260626001"
+down_revision = "3a3edf2b968b"
+branch_labels = None
+depends_on = None
+
+
+_PROGRAMS = "/api/programs"
+
+# (v0 subject, v1 object, v2 action, template_id) — mirror /api/program-offerings.
+_GRANTS = [
+    ("role:officer", _PROGRAMS, "GET", "officer"),
+    ("role:manager", _PROGRAMS, "GET", "manager"),
+]
+
+
+def upgrade() -> None:
+    for v0, v1, v2, tmpl in _GRANTS:
+        op.execute(
+            text(
+                f"""
+            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id, applied_at)
+            SELECT 'p', '{v0}', '{v1}', '{v2}', 'allow', '{tmpl}', NOW()
+            WHERE NOT EXISTS (
+                SELECT 1 FROM casbin_rule
+                WHERE ptype = 'p' AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+            )
+            """
+            )
+        )
+    op.execute(
+        text(
+            f"""
+            UPDATE casbin_rule SET v3 = CAST('allow' AS VARCHAR)
+            WHERE ptype = 'p' AND v3 IS NULL AND v1 = '{_PROGRAMS}'
+            """
+        )
+    )
+    print(f"[tcf20260626001] Seeded {len(_GRANTS)} casbin grant GET {_PROGRAMS} (eft=allow)")
+
+
+def downgrade() -> None:
+    for v0, v1, v2, _tmpl in _GRANTS:
+        op.execute(
+            text(
+                f"""
+            DELETE FROM casbin_rule
+            WHERE ptype = 'p' AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+            """
+            )
+        )

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -257,6 +257,10 @@ OFFICER_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/admissions/pending-diploma", "action": "GET"},
         # Admission config (read-only lookup data)
         {"subject": "{role}", "object": "/api/program-offerings", "action": "GET"},  # Dropdown data
+        # Danh sách ngành (MajorProgram) cho dropdown filter "Thu học phí" +
+        # admission. Service unit-scopes manager/officer; accountant (finance
+        # global read) thấy full list — chủ ý cho filter công nợ toàn đơn vị.
+        {"subject": "{role}", "object": "/api/programs", "action": "GET"},  # Dropdown ngành
         {"subject": "{role}", "object": "/api/admission-config/subjects", "action": "GET"},
         {"subject": "{role}", "object": "/api/admission-config/methods", "action": "GET"},
         {"subject": "{role}", "object": "/api/admission-config/criteria", "action": "GET"},

--- a/Backend_FastAPI/app/models/finance/fee.py
+++ b/Backend_FastAPI/app/models/finance/fee.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     from app.models.tuition_discount_policy import TuitionDiscountPolicy
     from app.models.finance.installment_plan import InstallmentPlan
     from app.models.finance.invoice import Invoice
+    from app.models.major_program import MajorProgram
 
 
 class FeeTypeEnum(str, enum.Enum):
@@ -293,7 +294,7 @@ class Fee(Base):
         ForeignKey("major_program.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
-        comment="Snapshot: resolved MajorProgram (filter/display source — NULL = chưa chốt)"
+        comment="Snapshot: resolved MajorProgram (filter/display — NULL=chưa chốt)"
     )
     resolved_degree_level: Mapped[Optional[str]] = mapped_column(
         String(50),

--- a/Backend_FastAPI/app/models/finance/fee.py
+++ b/Backend_FastAPI/app/models/finance/fee.py
@@ -274,6 +274,34 @@ class Fee(Base):
         comment="Notes for waive/cancel/audit trail"
     )
 
+    # Resolved academic snapshot (denormalized — single source for the
+    # "Thu học phí" workspace: filter + list row + drawer + status-counts).
+    # Populated by ``resnapshot_fee_academic_info_for_profile`` (the SAME
+    # ``resolve_fee_academic_info`` used for the tuition amount), so a multi-NV
+    # profile's row/filter reflects the ADMITTED choice — never the lead's
+    # intent offering. ALL nullable + fail-soft: when the resolver can't decide
+    # (multi-NV not-yet-admitted / 0 / ≥2 admitted) the columns stay NULL and
+    # the UI shows "(chưa chốt ngành)" rather than guessing.
+    resolved_academic_info_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("offering_academic_info.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="Snapshot: resolved OfferingAcademicInfo (trace source of major)"
+    )
+    resolved_major_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("major_program.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+        comment="Snapshot: resolved MajorProgram (filter/display source — NULL = chưa chốt)"
+    )
+    resolved_degree_level: Mapped[Optional[str]] = mapped_column(
+        String(50),
+        nullable=True,
+        comment="Snapshot: degree level TEXT NAME ('Cao đẳng'…) matching "
+                "MajorProgram.degree_level legacy text + admissions FE filter value"
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
@@ -297,6 +325,12 @@ class Fee(Base):
     calculated_by: Mapped[Optional["User"]] = relationship(
         "User",
         foreign_keys=[calculated_by_id]
+    )
+    # Resolved-major snapshot relationship (read-only display name source).
+    resolved_major: Mapped[Optional["MajorProgram"]] = relationship(
+        "MajorProgram",
+        foreign_keys=[resolved_major_id],
+        lazy="raise",
     )
     applied_discounts: Mapped[List["FeeAppliedDiscount"]] = relationship(
         "FeeAppliedDiscount",

--- a/Backend_FastAPI/app/repositories/admission_profile_choice_repository.py
+++ b/Backend_FastAPI/app/repositories/admission_profile_choice_repository.py
@@ -227,6 +227,14 @@ class AdmissionProfileChoiceRepository:
 
         Caller (engine) wraps trong begin_nested + SELECT FOR UPDATE per
         GAP-16 atomicity.
+
+        ⚠️ DENORMALIZED MAJOR SNAPSHOT: nếu ``decision`` đổi NV trúng tuyển,
+        caller (service layer — KHÔNG phải repo này) PHẢI gọi
+        ``fee_calculation_service.resnapshot_fee_academic_info_for_profile``
+        sau đó để Fee.resolved_* không stale (workspace "Thu học phí" lọc/hiển
+        thị theo cột này). Hai đường publish LIVE (evaluate_cascade /
+        promote_waitlisted_choice) đã gọi; method này hiện dormant — bất kỳ
+        caller mới nào kích hoạt lại đều phải tuân theo contract trên.
         """
         choice = await self.db.get(AdmissionProfileChoice, choice_id)
         if choice is None:

--- a/Backend_FastAPI/app/repositories/fee_repository.py
+++ b/Backend_FastAPI/app/repositories/fee_repository.py
@@ -15,7 +15,7 @@ Architecture:
 
 import re
 import unicodedata
-from datetime import datetime, date, timezone
+from datetime import datetime, date, timedelta, timezone
 from decimal import Decimal
 from typing import List, Optional, Tuple, Union
 
@@ -701,16 +701,33 @@ class InvoiceRepository(BaseRepository[Invoice]):
         date_from: Optional[date] = None,
         date_to: Optional[date] = None,
         today: Optional[date] = None,
+        major_id: Optional[int] = None,
+        degree_level: Optional[str] = None,
+        academic_year: Optional[int] = None,
+        semester_no: Optional[int] = None,
+        officer_id: Optional[int] = None,
+        unit_id_filter: Optional[int] = None,
+        due_window: Optional[str] = None,
     ) -> list:
         """Build the shared WHERE for the invoice list + status-counts.
 
         Assumes the query joins Invoice -> Fee -> AdmissionProfile -> Lead.
+
+        Filter ngành/trình độ đọc ``Fee.resolved_major_id`` /
+        ``Fee.resolved_degree_level`` (snapshot denormalized — single source of
+        truth, đúng admitted-choice cho multi-NV), KHÔNG join offering/program
+        nên cả list + status-counts dùng chung không cần thêm join → parity.
         """
         today = today or date.today()
         conditions = []
         # IDOR (None = admin/accountant global scope)
         if unit_id is not None:
             conditions.append(models.Lead.unit_id == unit_id)
+        # Unit filter (manager/admin chọn đơn vị cụ thể) — INTERSECT với IDOR
+        # scope ở trên (ANDed): officer bị clamp unit_id của mình nên truyền
+        # unit_id_filter khác cũng ra rỗng, KHÔNG nới quyền.
+        if unit_id_filter is not None:
+            conditions.append(models.Lead.unit_id == unit_id_filter)
         if statuses:
             conditions.append(Invoice.status.in_(statuses))
         if fee_id:
@@ -719,6 +736,25 @@ class InvoiceRepository(BaseRepository[Invoice]):
             conditions.append(Fee.admission_profile_id == profile_id)
         if fee_type:
             conditions.append(Fee.fee_type == fee_type)
+        if major_id is not None:
+            conditions.append(Fee.resolved_major_id == major_id)
+        if degree_level:
+            conditions.append(Fee.resolved_degree_level == degree_level)
+        if academic_year is not None:
+            conditions.append(Fee.academic_year == academic_year)
+        if semester_no is not None:
+            conditions.append(Fee.semester_no == semester_no)
+        if officer_id is not None:
+            conditions.append(models.Lead.assigned_officer_id == officer_id)
+        # Hạn thanh toán: "sắp đến hạn ≤7 ngày" = invoice chưa thu (issued/
+        # partial/overdue-enum) due trong [today, today+7]; "overdue" = derived
+        # predicate. Tự chứa trong builder → list + counts khớp.
+        if due_window == "due_soon_7d":
+            conditions.append(Invoice.due_date >= today)
+            conditions.append(Invoice.due_date <= today + timedelta(days=7))
+            conditions.append(Invoice.status.in_(OVERDUE_DERIVED_STATUSES))
+        elif due_window == "overdue":
+            conditions.append(InvoiceRepository._overdue_predicate(today))
         if overdue_only:
             conditions.append(InvoiceRepository._overdue_predicate(today))
         if date_from:
@@ -772,6 +808,14 @@ class InvoiceRepository(BaseRepository[Invoice]):
             return [direction(Invoice.due_date), asc(Invoice.id)]
         if sort_by == "amount":
             return [direction(Invoice.amount), asc(Invoice.id)]
+        if sort_by == "paid":
+            return [direction(Invoice.paid_amount), asc(Invoice.id)]
+        if sort_by == "remaining":
+            # Khớp Invoice.remaining_amount = amount + penalty - paid (clamp ≥0).
+            remaining_expr = func.greatest(
+                Invoice.amount + Invoice.penalty_amount - Invoice.paid_amount, 0
+            )
+            return [direction(remaining_expr), asc(Invoice.id)]
         if sort_by == "status":
             return [direction(Invoice.status), asc(Invoice.due_date), asc(Invoice.id)]
         if sort_by == "created_at":
@@ -808,6 +852,13 @@ class InvoiceRepository(BaseRepository[Invoice]):
         date_from: Optional[date] = None,
         date_to: Optional[date] = None,
         today: Optional[date] = None,
+        major_id: Optional[int] = None,
+        degree_level: Optional[str] = None,
+        academic_year: Optional[int] = None,
+        semester_no: Optional[int] = None,
+        officer_id: Optional[int] = None,
+        unit_id_filter: Optional[int] = None,
+        due_window: Optional[str] = None,
     ) -> Tuple[List[Invoice], int]:
         """Filtered + paginated invoice list WITH total count (IDOR by unit)."""
         today = today or date.today()  # one "today" → predicate + sort agree
@@ -815,6 +866,10 @@ class InvoiceRepository(BaseRepository[Invoice]):
             unit_id=unit_id, statuses=statuses, fee_id=fee_id,
             profile_id=profile_id, overdue_only=overdue_only, search=search,
             fee_type=fee_type, date_from=date_from, date_to=date_to, today=today,
+            major_id=major_id, degree_level=degree_level,
+            academic_year=academic_year, semester_no=semester_no,
+            officer_id=officer_id, unit_id_filter=unit_id_filter,
+            due_window=due_window,
         )
 
         count_query = (
@@ -833,11 +888,9 @@ class InvoiceRepository(BaseRepository[Invoice]):
                 .joinedload(Fee.admission_profile)
                 .joinedload(models.AdmissionProfile.lead)
                 .joinedload(models.Lead.assigned_officer),
-                joinedload(Invoice.fee)
-                .joinedload(Fee.admission_profile)
-                .joinedload(models.AdmissionProfile.lead)
-                .joinedload(models.Lead.offering)
-                .joinedload(models.ProgramOffering.program),
+                # Ngành/trình độ hiển thị đọc từ snapshot Fee.resolved_major
+                # (single source khớp filter) — KHÔNG còn lead.offering.program.
+                joinedload(Invoice.fee).joinedload(Fee.resolved_major),
             )
             .order_by(*self._invoice_sort_clause(sort_by, sort_order, today))
             .offset(skip)
@@ -860,17 +913,30 @@ class InvoiceRepository(BaseRepository[Invoice]):
         date_from: Optional[date] = None,
         date_to: Optional[date] = None,
         today: Optional[date] = None,
+        major_id: Optional[int] = None,
+        degree_level: Optional[str] = None,
+        academic_year: Optional[int] = None,
+        semester_no: Optional[int] = None,
+        officer_id: Optional[int] = None,
+        unit_id_filter: Optional[int] = None,
+        due_window: Optional[str] = None,
     ) -> dict:
         """Per-status counts + derived overdue count for the workspace tabs.
 
         Uses the SAME conditions as the list (minus status/overdue) so each
-        tab's count matches the rows clicking it would return.
+        tab's count matches the rows clicking it would return. Mọi filter mới
+        (ngành/trình độ/năm-HK/TVV/đơn vị/hạn) PHẢI truyền y hệt list để badge
+        khớp (parity).
         """
         today = today or date.today()
         conditions = self._build_invoice_list_conditions(
             unit_id=unit_id, statuses=None, fee_id=fee_id, profile_id=profile_id,
             overdue_only=None, search=search, fee_type=fee_type,
             date_from=date_from, date_to=date_to, today=today,
+            major_id=major_id, degree_level=degree_level,
+            academic_year=academic_year, semester_no=semester_no,
+            officer_id=officer_id, unit_id_filter=unit_id_filter,
+            due_window=due_window,
         )
 
         group_query = (

--- a/Backend_FastAPI/app/repositories/payment_repository.py
+++ b/Backend_FastAPI/app/repositories/payment_repository.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import List, Optional, Tuple
 
-from sqlalchemy import select, and_, or_, func, desc
+from sqlalchemy import select, and_, or_, func, desc, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -45,6 +45,31 @@ class PaymentRepository(BaseRepository[Payment]):
     def __init__(self, db: AsyncSession):
         """Initialize Payment repository."""
         super().__init__(db, Payment)
+
+    async def get_imported_payment_ids(self, payment_ids: List[int]) -> set:
+        """Trả tập con của ``payment_ids`` là các payment do IMPORT tạo (id nằm
+        trong ``PaymentImportRow.payment_ids`` JSONB). Dùng cho badge nguồn thu
+        ở drawer "Thu học phí".
+
+        An toàn: ``CASE WHEN jsonb_typeof(payment_ids)='array'`` BỌC quanh
+        ``jsonb_array_elements_text`` để hàng có ``payment_ids`` scalar/null
+        KHÔNG làm unnest 500 (guard ở WHERE không đủ — FROM-LATERAL chạy trước).
+        """
+        if not payment_ids:
+            return set()
+        rows = await self.db.execute(
+            text(
+                "SELECT DISTINCT elem::int AS pid "
+                "FROM payment_import_row, "
+                "jsonb_array_elements_text("
+                "  CASE WHEN jsonb_typeof(payment_ids) = 'array' "
+                "       THEN payment_ids ELSE '[]'::jsonb END"
+                ") AS elem "
+                "WHERE elem ~ '^[0-9]+$' AND elem::int = ANY(:ids)"
+            ),
+            {"ids": payment_ids},
+        )
+        return {r[0] for r in rows}
 
     async def get_by_id_with_relations(
         self,

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -23,7 +23,6 @@ from datetime import date, timedelta
 from decimal import Decimal
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
@@ -43,8 +42,10 @@ from app.schemas import finance as finance_schemas
 from app.services.fee_calculation_service import FeeCalculationService
 from app.services.invoice_service import InvoiceService
 from app.repositories.fee_repository import FeeRepository
+from app.repositories.payment_repository import PaymentRepository
 from app.utils.admission_status import is_fee_eligible
 from app.utils.id_helpers import format_profile_code
+from app.utils.masking import mask_citizen_id
 from app.utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
@@ -540,20 +541,6 @@ async def get_profile_finance_summary(
     )
 
 
-def _mask_citizen_id(citizen_id: Optional[str]) -> Optional[str]:
-    """Che CCCD cho PII: giữ 3 số đầu + 3 số cuối, che giữa bằng '*'.
-
-    VD '036204001234' → '036******234'. Chuỗi quá ngắn (<7) che toàn bộ trừ 2
-    số cuối. None/empty → None.
-    """
-    if not citizen_id:
-        return None
-    s = citizen_id.strip()
-    if len(s) < 7:
-        return ("*" * max(0, len(s) - 2)) + s[-2:] if len(s) > 2 else "*" * len(s)
-    return s[:3] + ("*" * (len(s) - 6)) + s[-3:]
-
-
 @limiter.limit(RateLimits.DATA_READ)
 @router.get(
     "/collection/{profile_id}",
@@ -615,7 +602,7 @@ async def get_profile_collection(
         profile_id=profile.id,
         profile_code=format_profile_code(profile.id),
         student_name=lead.full_name if lead else None,
-        citizen_id_masked=_mask_citizen_id(getattr(profile, "citizen_id", None)),
+        citizen_id_masked=mask_citizen_id(getattr(profile, "citizen_id", None)),
         program_name=_resolved_major.name if _resolved_major else None,
         degree_level=_resolved_degree,
         officer_name=officer.full_name if officer else None,
@@ -674,21 +661,11 @@ async def get_profile_collection(
     invoice_items.sort(key=lambda it: (not it.is_overdue, it.due_date, it.id))
 
     # Nguồn thu "import": prefetch các payment.id của hồ sơ nằm trong
-    # PaymentImportRow.payment_ids (JSONB) — 1 query, anti-N+1. intent_id →
-    # online, còn lại → manual (xem _build_payment_list_item).
-    imported_payment_ids: set = set()
-    _pay_ids = [p.id for p in all_payments]
-    if _pay_ids:
-        _rows = await db.execute(
-            text(
-                "SELECT DISTINCT elem::int AS pid "
-                "FROM payment_import_row, "
-                "jsonb_array_elements_text(payment_ids) AS elem "
-                "WHERE payment_ids IS NOT NULL AND elem::int = ANY(:ids)"
-            ),
-            {"ids": _pay_ids},
-        )
-        imported_payment_ids = {r[0] for r in _rows}
+    # PaymentImportRow.payment_ids (JSONB) — 1 query repo (anti-N+1, harden
+    # jsonb). intent_id → online, còn lại → manual (xem _build_payment_list_item).
+    imported_payment_ids = await PaymentRepository(db).get_imported_payment_ids(
+        [p.id for p in all_payments]
+    )
 
     # Payments: newest first (history), enriched + role-aware maker-checker flags.
     all_payments.sort(key=lambda p: p.created_at, reverse=True)

--- a/Backend_FastAPI/app/routers/fees.py
+++ b/Backend_FastAPI/app/routers/fees.py
@@ -23,6 +23,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
@@ -539,6 +540,20 @@ async def get_profile_finance_summary(
     )
 
 
+def _mask_citizen_id(citizen_id: Optional[str]) -> Optional[str]:
+    """Che CCCD cho PII: giữ 3 số đầu + 3 số cuối, che giữa bằng '*'.
+
+    VD '036204001234' → '036******234'. Chuỗi quá ngắn (<7) che toàn bộ trừ 2
+    số cuối. None/empty → None.
+    """
+    if not citizen_id:
+        return None
+    s = citizen_id.strip()
+    if len(s) < 7:
+        return ("*" * max(0, len(s) - 2)) + s[-2:] if len(s) > 2 else "*" * len(s)
+    return s[:3] + ("*" * (len(s) - 6)) + s[-3:]
+
+
 @limiter.limit(RateLimits.DATA_READ)
 @router.get(
     "/collection/{profile_id}",
@@ -581,20 +596,31 @@ async def get_profile_collection(
 
     lead = profile.lead
     officer = lead.assigned_officer if lead else None
-    offering = lead.offering if lead else None
-    program = offering.program if offering else None
+
+    # Flatten the loaded graph: fees → invoices → payments.
+    fees = list(profile.fees or [])
+
+    # Ngành/trình độ header đọc TỪ snapshot Fee.resolved_* (khớp list row +
+    # filter, đúng NV admitted). Lấy fee đầu tiên có snapshot (mọi fee cùng hồ
+    # sơ cùng ngành sau khi hook chạy). NULL → "(chưa chốt ngành)" phía FE.
+    _resolved_major = None
+    _resolved_degree = None
+    for _f in fees:
+        if _f.resolved_major_id:
+            _resolved_major = _f.__dict__.get("resolved_major")
+            _resolved_degree = _f.resolved_degree_level
+            break
 
     identity = finance_schemas.ProfileCollectionIdentity(
         profile_id=profile.id,
         profile_code=format_profile_code(profile.id),
         student_name=lead.full_name if lead else None,
-        program_name=program.name if program else None,
+        citizen_id_masked=_mask_citizen_id(getattr(profile, "citizen_id", None)),
+        program_name=_resolved_major.name if _resolved_major else None,
+        degree_level=_resolved_degree,
         officer_name=officer.full_name if officer else None,
         phone=lead.phone if lead else None,
     )
-
-    # Flatten the loaded graph: fees → invoices → payments.
-    fees = list(profile.fees or [])
     all_invoices = []
     all_payments = []
     for fee in fees:
@@ -647,10 +673,30 @@ async def get_profile_collection(
     ]
     invoice_items.sort(key=lambda it: (not it.is_overdue, it.due_date, it.id))
 
+    # Nguồn thu "import": prefetch các payment.id của hồ sơ nằm trong
+    # PaymentImportRow.payment_ids (JSONB) — 1 query, anti-N+1. intent_id →
+    # online, còn lại → manual (xem _build_payment_list_item).
+    imported_payment_ids: set = set()
+    _pay_ids = [p.id for p in all_payments]
+    if _pay_ids:
+        _rows = await db.execute(
+            text(
+                "SELECT DISTINCT elem::int AS pid "
+                "FROM payment_import_row, "
+                "jsonb_array_elements_text(payment_ids) AS elem "
+                "WHERE payment_ids IS NOT NULL AND elem::int = ANY(:ids)"
+            ),
+            {"ids": _pay_ids},
+        )
+        imported_payment_ids = {r[0] for r in _rows}
+
     # Payments: newest first (history), enriched + role-aware maker-checker flags.
     all_payments.sort(key=lambda p: p.created_at, reverse=True)
     payment_items = [
-        _build_payment_list_item(pmt, current_user.id, current_user.role)
+        _build_payment_list_item(
+            pmt, current_user.id, current_user.role,
+            imported_payment_ids=imported_payment_ids,
+        )
         for pmt in all_payments
     ]
 

--- a/Backend_FastAPI/app/routers/invoices.py
+++ b/Backend_FastAPI/app/routers/invoices.py
@@ -93,10 +93,26 @@ async def list_invoices(
     ),
     sort_by: Optional[str] = Query(
         None,
-        description="priority (default) | due_date | amount | status | created_at",
+        description=(
+            "priority (default) | due_date | amount | paid | remaining | "
+            "status | created_at"
+        ),
     ),
     sort_order: Optional[str] = Query(
         None, description="asc | desc (ignored for the default 'priority' sort)"
+    ),
+    major_id: Optional[int] = Query(None, description="Filter theo ngành (MajorProgram.id)"),
+    degree_level: Optional[str] = Query(
+        None, description="Filter theo trình độ (TEXT name, vd 'Cao đẳng')"
+    ),
+    academic_year: Optional[int] = Query(None, description="Filter theo năm học"),
+    semester_no: Optional[int] = Query(None, description="Filter theo học kỳ (1=HK1...)"),
+    officer_id: Optional[int] = Query(None, description="Filter theo TVV phụ trách"),
+    unit_id: Optional[int] = Query(
+        None, description="Filter theo đơn vị (INTERSECT với scope IDOR)"
+    ),
+    due_window: Optional[str] = Query(
+        None, description="Hạn: due_soon_7d (đến hạn ≤7 ngày, chưa thu) | overdue"
     ),
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = CasbinAuth,
@@ -109,7 +125,7 @@ async def list_invoices(
     - Requires 'invoices:read' permission
     """
     invoice_repo = InvoiceRepository(db)
-    unit_id = finance_scope_unit_id(current_user)
+    scope_unit_id = finance_scope_unit_id(current_user)
 
     # Convert page/page_size to skip/limit
     skip = (page - 1) * page_size
@@ -126,7 +142,7 @@ async def list_invoices(
     invoices, total = await invoice_repo.get_filtered_with_count(
         skip=skip,
         limit=limit,
-        unit_id=unit_id,
+        unit_id=scope_unit_id,
         statuses=statuses,
         fee_id=fee_id,
         profile_id=profile_id,
@@ -136,6 +152,13 @@ async def list_invoices(
         sort_by=sort_by,
         sort_order=sort_order,
         today=today,
+        major_id=major_id,
+        degree_level=degree_level,
+        academic_year=academic_year,
+        semester_no=semester_no,
+        officer_id=officer_id,
+        unit_id_filter=unit_id,
+        due_window=due_window,
     )
 
     # Build enriched list rows (identity + derived urgency + role-aware flags).
@@ -168,6 +191,19 @@ async def get_invoice_status_counts(
         None,
         description="Search by student name, profile code (HS-…) or invoice number",
     ),
+    major_id: Optional[int] = Query(None, description="Filter theo ngành (MajorProgram.id)"),
+    degree_level: Optional[str] = Query(
+        None, description="Filter theo trình độ (TEXT name, vd 'Cao đẳng')"
+    ),
+    academic_year: Optional[int] = Query(None, description="Filter theo năm học"),
+    semester_no: Optional[int] = Query(None, description="Filter theo học kỳ (1=HK1...)"),
+    officer_id: Optional[int] = Query(None, description="Filter theo TVV phụ trách"),
+    unit_id: Optional[int] = Query(
+        None, description="Filter theo đơn vị (INTERSECT với scope IDOR)"
+    ),
+    due_window: Optional[str] = Query(
+        None, description="Hạn: due_soon_7d (đến hạn ≤7 ngày, chưa thu) | overdue"
+    ),
     db: AsyncSession = Depends(database.get_db),
     current_user: models.User = CasbinAuth,
     _finance_staff: models.User = Depends(require_finance_staff),
@@ -179,6 +215,9 @@ async def get_invoice_status_counts(
     rows clicking it returns. ``overdue_derived`` uses the derived predicate
     (issued/partial/overdue past due), NOT the lagging enum 'overdue' bucket.
 
+    PARITY (P1): mọi filter mới (ngành/trình độ/năm-HK/TVV/đơn vị/hạn) phải y hệt
+    list_invoices, nếu không badge tab đếm lệch so với danh sách.
+
     NOTE: declared BEFORE ``/{invoice_id}`` so this literal path is not
     captured as an invoice id.
 
@@ -189,13 +228,20 @@ async def get_invoice_status_counts(
     finance_scope_unit_id.
     """
     invoice_repo = InvoiceRepository(db)
-    unit_id = finance_scope_unit_id(current_user)
+    scope_unit_id = finance_scope_unit_id(current_user)
     counts = await invoice_repo.get_status_counts(
-        unit_id=unit_id,
+        unit_id=scope_unit_id,
         fee_id=fee_id,
         profile_id=profile_id,
         fee_type=fee_type,
         search=search,
+        major_id=major_id,
+        degree_level=degree_level,
+        academic_year=academic_year,
+        semester_no=semester_no,
+        officer_id=officer_id,
+        unit_id_filter=unit_id,
+        due_window=due_window,
     )
     return finance_schemas.InvoiceStatusCounts(**counts)
 
@@ -674,8 +720,11 @@ def _build_invoice_list_item(
     profile = fee.admission_profile if fee else None
     lead = profile.lead if profile else None
     officer = lead.assigned_officer if lead else None
-    offering = lead.offering if lead else None
-    program = offering.program if offering else None
+    # Ngành/trình độ đọc TỪ snapshot Fee.resolved_* (single source khớp filter),
+    # KHÔNG dùng lead.offering.program (NV gốc — sai với multi-NV admitted).
+    # __dict__.get tránh lazy-load (MissingGreenlet) nếu chưa eager-load; NULL
+    # snapshot → program_name None → FE hiển thị "(chưa chốt ngành)".
+    resolved_major = fee.__dict__.get("resolved_major") if fee else None
 
     return finance_schemas.InvoiceListItem(
         id=invoice.id,
@@ -692,7 +741,8 @@ def _build_invoice_list_item(
         profile_id=profile.id if profile else None,
         profile_name=lead.full_name if lead else None,
         profile_code=format_profile_code(profile.id) if profile else None,
-        program_name=program.name if program else None,
+        program_name=resolved_major.name if resolved_major else None,
+        degree_level=fee.resolved_degree_level if fee else None,
         officer_name=officer.full_name if officer else None,
         fee_type=fee.fee_type if fee else None,
         semester_no=fee.semester_no if fee else None,

--- a/Backend_FastAPI/app/routers/payments.py
+++ b/Backend_FastAPI/app/routers/payments.py
@@ -1082,6 +1082,7 @@ def _build_payment_list_item(
     payment,
     current_user_id: Optional[int] = None,
     current_user_role: str = None,
+    imported_payment_ids: Optional[set] = None,
 ) -> finance_schemas.PaymentListItem:
     """Build an enriched ``PaymentListItem`` from a Payment model.
 
@@ -1092,8 +1093,15 @@ def _build_payment_list_item(
     role-aware can_verify/can_reject.
 
     Requires ``payment.invoice.fee.admission_profile.lead`` (profile_name),
-    ``payment.method`` and ``payment.created_by`` eager-loaded — all relationship
-    access happens HERE in async context, never during Pydantic serialization.
+    ``payment.method``, ``payment.created_by`` (and ``verified_by`` for the
+    drawer) eager-loaded — all relationship access happens HERE in async
+    context, never during Pydantic serialization.
+
+    ``source`` (BE-owned): ``online`` khi ``intent_id`` có; ``import`` khi
+    ``payment.id`` nằm trong ``imported_payment_ids`` (prefetch từ
+    ``PaymentImportRow.payment_ids`` — chỉ drawer truyền vào); else ``manual``.
+    Caller không truyền set → import-payment hiện "manual" (chấp nhận ở list/
+    queue; drawer là nơi cần chi tiết nguồn).
     """
     profile_name = None
     if payment.invoice and payment.invoice.fee:
@@ -1105,6 +1113,19 @@ def _build_payment_list_item(
     created_by_name = None
     if payment.created_by:
         created_by_name = payment.created_by.full_name or payment.created_by.email
+    # verified_by may not be eager-loaded in list/queue callers → __dict__.get
+    # avoids a lazy-load (MissingGreenlet); drawer eager-loads it.
+    verified_by = payment.__dict__.get("verified_by")
+    verified_by_name = None
+    if verified_by:
+        verified_by_name = verified_by.full_name or verified_by.email
+
+    if payment.intent_id is not None:
+        source = "online"
+    elif imported_payment_ids and payment.id in imported_payment_ids:
+        source = "import"
+    else:
+        source = "manual"
 
     can_verify, can_reject = _compute_payment_review_flags(
         payment, current_user_id, current_user_role
@@ -1125,6 +1146,9 @@ def _build_payment_list_item(
         profile_name=profile_name,
         method_name=method_name,
         created_by_name=created_by_name,
+        verified_by_name=verified_by_name,
+        verified_at=payment.verified_at,
+        source=source,
         can_verify=can_verify,
         can_reject=can_reject,
     )

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -918,7 +918,12 @@ class PaymentListItem(PaymentSummaryResponse):
     is_own: bool = False
     profile_name: Optional[str] = None
     method_name: Optional[str] = None
-    created_by_name: Optional[str] = None
+    created_by_name: Optional[str] = None    # người thu (maker)
+    verified_by_name: Optional[str] = None   # người duyệt (checker)
+    verified_at: Optional[datetime] = None   # thời điểm duyệt
+    # Nguồn thu (BE-owned, suy ra lúc đọc): online (intent_id) | import
+    # (payment_ids của PaymentImportRow) | manual (thu tay). Mặc định manual.
+    source: str = "manual"
     can_verify: bool = False
     can_reject: bool = False
 
@@ -959,14 +964,16 @@ class ProfileCollectionIdentity(BaseModel):
     """Identity header for the "Thu học phí" drawer.
 
     Mirrors the spine-row identity columns so the drawer header matches the row
-    the user clicked: ``program_name`` is the BATCH-SAFE offering program
-    (``lead.offering.program.name`` — same as the list / admission, may differ
-    from the multi-NV admitted major; that resolver is deferred).
+    the user clicked: ``program_name`` / ``degree_level`` đọc từ snapshot
+    ``Fee.resolved_*`` (đúng NV admitted cho multi-NV, KHỚP filter + list row).
+    ``citizen_id_masked`` = CCCD đã che (PII): chỉ lộ vài số đầu/cuối.
     """
     profile_id: int
     profile_code: str                      # "HS-000131"
     student_name: Optional[str] = None
-    program_name: Optional[str] = None     # ngành (offering gốc, batch-safe)
+    citizen_id_masked: Optional[str] = None  # CCCD đã che giữa (PII-safe)
+    program_name: Optional[str] = None     # ngành (snapshot Fee.resolved_major)
+    degree_level: Optional[str] = None     # trình độ (snapshot, TEXT name)
     officer_name: Optional[str] = None     # TVV phụ trách
     phone: Optional[str] = None            # parent phone (accountant lookup)
 

--- a/Backend_FastAPI/app/schemas/finance.py
+++ b/Backend_FastAPI/app/schemas/finance.py
@@ -851,7 +851,8 @@ class InvoiceListItem(InvoiceSummaryResponse):
     profile_id: Optional[int] = None        # numeric id → opens the drawer
     profile_name: Optional[str] = None
     profile_code: Optional[str] = None      # "HS-000131"
-    program_name: Optional[str] = None      # ngành (batch-safe: lead.offering.program)
+    program_name: Optional[str] = None      # ngành (snapshot Fee.resolved_major — đúng NV admitted)
+    degree_level: Optional[str] = None      # trình độ (snapshot Fee.resolved_degree_level, TEXT name)
     officer_name: Optional[str] = None      # TVV phụ trách
     fee_type: Optional[FeeTypeEnum] = None
     semester_no: Optional[int] = None       # kỳ HK (NULL cho phí non-tuition)

--- a/Backend_FastAPI/app/scripts/backfill_fee_resolved_major.py
+++ b/Backend_FastAPI/app/scripts/backfill_fee_resolved_major.py
@@ -1,0 +1,119 @@
+"""Backfill ``Fee.resolved_*`` (academic_info / major / degree) snapshot.
+
+One-time script: iterates every admission_profile that owns at least one Fee
+and calls the SAME ``resnapshot_fee_academic_info_for_profile`` helper used by
+calculate_fee / the decision hooks. Fail-soft: a profile whose ngành can't be
+resolved (multi-NV not-yet-admitted / 0 / ≥2 admitted, or missing config) leaves
+its fees' snapshot NULL — never guessed. Idempotent → safe to re-run.
+
+Commits per batch (stream log + checkpoint) so a long run on prod can be
+resumed by re-invoking (already-snapshotted profiles just resolve again).
+
+Usage (inside backend container):
+    docker compose exec -T backend \\
+        python -m app.scripts.backfill_fee_resolved_major
+    # prod:
+    docker compose --env-file .env.production exec -T backend \\
+        python -m app.scripts.backfill_fee_resolved_major
+"""
+from __future__ import annotations
+
+import asyncio
+
+import structlog
+from sqlalchemy import func, select
+
+from app.database import AsyncSessionLocal
+from app.models.finance import Fee
+from app.services.fee_calculation_service import (
+    resnapshot_fee_academic_info_for_profile,
+)
+
+log = structlog.get_logger(__name__)
+
+
+async def main(batch_size: int = 200) -> None:
+    total_profiles = 0
+    total_fees_updated = 0
+    total_resolved_profiles = 0
+    total_null_profiles = 0
+
+    async with AsyncSessionLocal() as session:
+        # Distinct profile ids owning a Fee, ordered for stable pagination.
+        profile_ids = [
+            row[0]
+            for row in (
+                await session.execute(
+                    select(Fee.admission_profile_id)
+                    .distinct()
+                    .order_by(Fee.admission_profile_id.asc())
+                )
+            ).all()
+        ]
+        log.info("backfill_fee_resolved_major_start", profiles=len(profile_ids))
+
+        for idx, pid in enumerate(profile_ids, 1):
+            try:
+                n = await resnapshot_fee_academic_info_for_profile(session, pid)
+            except Exception as exc:  # defensive — never abort the whole run
+                log.error(
+                    "backfill_profile_failed", profile_id=pid, error=str(exc)
+                )
+                await session.rollback()
+                continue
+            total_profiles += 1
+            total_fees_updated += n
+            # Did this profile resolve to a major? Peek one fee.
+            sample = (
+                await session.execute(
+                    select(Fee.resolved_major_id)
+                    .where(Fee.admission_profile_id == pid)
+                    .limit(1)
+                )
+            ).scalar()
+            if sample is not None:
+                total_resolved_profiles += 1
+            else:
+                total_null_profiles += 1
+
+            if idx % batch_size == 0:
+                await session.commit()
+                log.info(
+                    "backfill_checkpoint",
+                    done=idx,
+                    total=len(profile_ids),
+                    fees_updated=total_fees_updated,
+                )
+
+        await session.commit()
+
+        # Final audit: how many fees still NULL (expected for unresolved ngành).
+        null_fees = (
+            await session.execute(
+                select(func.count())
+                .select_from(Fee)
+                .where(Fee.resolved_major_id.is_(None))
+            )
+        ).scalar()
+        total_fees = (
+            await session.execute(select(func.count()).select_from(Fee))
+        ).scalar()
+
+    log.info(
+        "backfill_fee_resolved_major_done",
+        profiles_processed=total_profiles,
+        fees_updated=total_fees_updated,
+        profiles_resolved=total_resolved_profiles,
+        profiles_null=total_null_profiles,
+        fees_total=total_fees,
+        fees_still_null=null_fees,
+    )
+    print(
+        f"DONE: {total_profiles} profiles · {total_fees_updated} fees updated · "
+        f"resolved={total_resolved_profiles} null={total_null_profiles} · "
+        f"fees_total={total_fees} fees_null={null_fees}"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -1091,7 +1091,7 @@ async def evaluate_cascade(
     from .fee_calculation_service import (
         resnapshot_fee_academic_info_for_profile,
     )
-    await resnapshot_fee_academic_info_for_profile(db, profile.id)
+    await resnapshot_fee_academic_info_for_profile(db, profile.id, profile=profile)
 
     # Chain callbacks: caller commits + awaits both dispatches
     async def chained_callback() -> None:
@@ -1319,7 +1319,7 @@ async def promote_waitlisted_choice(
     from .fee_calculation_service import (
         resnapshot_fee_academic_info_for_profile,
     )
-    await resnapshot_fee_academic_info_for_profile(db, profile.id)
+    await resnapshot_fee_academic_info_for_profile(db, profile.id, profile=profile)
 
     return (
         {

--- a/Backend_FastAPI/app/services/admission_choice_engine_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_engine_service.py
@@ -1085,6 +1085,14 @@ async def evaluate_cascade(
         reason="Choice engine cascade — publish_result",
     )
 
+    # Admitted choice vừa chốt → re-snapshot Fee.resolved_* để row/filter/drawer
+    # "Thu học phí" phản ánh ĐÚNG ngành trúng tuyển (gồm application fee tạo
+    # pre-decision với snapshot NULL). Same transaction (flush only). Fail-soft.
+    from .fee_calculation_service import (
+        resnapshot_fee_academic_info_for_profile,
+    )
+    await resnapshot_fee_academic_info_for_profile(db, profile.id)
+
     # Chain callbacks: caller commits + awaits both dispatches
     async def chained_callback() -> None:
         if cb1 is not None:
@@ -1304,6 +1312,14 @@ async def promote_waitlisted_choice(
         changed_by_user_id=actor.id if actor else None,
         reason=reason or "Waitlist promote — manual admin",
     )
+
+    # Waitlist promote ĐỔI ngành trúng tuyển → re-snapshot Fee.resolved_* để các
+    # fee đã tồn tại (application/tuition) không stale ngành cũ. Fail-soft, same
+    # transaction (flush only).
+    from .fee_calculation_service import (
+        resnapshot_fee_academic_info_for_profile,
+    )
+    await resnapshot_fee_academic_info_for_profile(db, profile.id)
 
     return (
         {

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -9439,7 +9439,9 @@ async def _create_or_repair_paid_chain(
         from app.services.fee_calculation_service import (
             resnapshot_fee_academic_info_for_profile,
         )
-        await resnapshot_fee_academic_info_for_profile(db, profile.id)
+        await resnapshot_fee_academic_info_for_profile(
+            db, profile.id, profile=profile
+        )
 
     return fee
 

--- a/Backend_FastAPI/app/services/admission_service.py
+++ b/Backend_FastAPI/app/services/admission_service.py
@@ -9432,6 +9432,15 @@ async def _create_or_repair_paid_chain(
         db.add(transaction)
         await db.flush()
 
+    if created_fee:
+        # Application fee tạo trực tiếp (KHÔNG qua calculate_fee) → snapshot ngành
+        # tường minh để row/filter "Thu học phí" nhất quán. Pre-decision thường
+        # resolve None → NULL (fail-soft), sẽ được decision-hook điền sau.
+        from app.services.fee_calculation_service import (
+            resnapshot_fee_academic_info_for_profile,
+        )
+        await resnapshot_fee_academic_info_for_profile(db, profile.id)
+
     return fee
 
 

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -233,19 +233,31 @@ async def resolve_fee_academic_info(
 async def resnapshot_fee_academic_info_for_profile(
     db: AsyncSession,
     profile_id: int,
+    *,
+    profile: "Optional[models.AdmissionProfile]" = None,
 ) -> int:
-    """Re-snapshot ``Fee.resolved_*`` (academic_info / major / degree) for ALL
-    fees of a profile — the SINGLE writer of the denormalized major snapshot the
-    "Thu học phí" workspace reads (filter + list row + drawer + status-counts).
+    """Re-snapshot ``Fee.resolved_*`` (academic_info / major / degree) for the
+    non-cancelled fees of a profile — the SINGLE writer of the denormalized major
+    snapshot the "Thu học phí" workspace reads (filter + list row + drawer +
+    status-counts).
 
     Resolves via the SAME ``resolve_fee_academic_info`` used for pricing, so for
     multi-NV profiles the snapshot reflects the ADMITTED choice — never the
     lead's intent offering.
 
-    **Fail-soft**: when the resolver can't decide the ngành (multi-NV
-    not-yet-admitted / 0 / ≥2 admitted, or missing config) the three columns are
-    set to NULL — never guessed. Idempotent → safe to call repeatedly. Service
-    only ``flush``es; the caller commits.
+    **Best-effort + fail-soft**: any failure resolving the ngành (BadRequest for
+    multi-NV-undecided / 0 / ≥2 admitted, OR an unexpected DB error in the
+    resolve/major-lookup) → snapshot stays NULL and the function still returns,
+    NEVER raising into the caller. This keeps the denormalization (a display
+    nicety) OFF the critical path of the money-creating flows that call it
+    (calculate_fee / fee payment / decision publish). Idempotent. Service only
+    ``flush``es; the caller commits.
+
+    **Cancelled fees are skipped** so a later admit doesn't relabel a historical
+    cancelled fee (e.g. officer cancelled an NV1 fee, profile later admitted NV2).
+
+    ``profile`` may be passed by callers that already hold the ORM object
+    (``calculate_fee`` / decision hooks) to skip a redundant SELECT.
 
     ⚠️ MUST be called by ANY code that (a) creates a Fee outside
     ``calculate_fee`` or (b) changes which ngành a profile is admitted to
@@ -258,13 +270,14 @@ async def resnapshot_fee_academic_info_for_profile(
 
     Returns the number of fees updated.
     """
-    profile = (
-        await db.execute(
-            select(models.AdmissionProfile).where(
-                models.AdmissionProfile.id == profile_id
+    if profile is None:
+        profile = (
+            await db.execute(
+                select(models.AdmissionProfile).where(
+                    models.AdmissionProfile.id == profile_id
+                )
             )
-        )
-    ).scalars().first()
+        ).scalars().first()
     if profile is None:
         return 0
 
@@ -273,36 +286,48 @@ async def resnapshot_fee_academic_info_for_profile(
     resolved_degree_level: Optional[str] = None
     try:
         academic_info = await resolve_fee_academic_info(db, profile)
+        if academic_info is not None:
+            resolved_ai_id = academic_info.id
+            row = (
+                await db.execute(
+                    select(
+                        models.MajorProgram.id,
+                        models.MajorProgram.degree_level,
+                    )
+                    .select_from(models.OfferingAcademicInfo)
+                    .join(
+                        models.ProgramOffering,
+                        models.ProgramOffering.id
+                        == models.OfferingAcademicInfo.offering_id,
+                    )
+                    .join(
+                        models.MajorProgram,
+                        models.MajorProgram.id
+                        == models.ProgramOffering.program_id,
+                    )
+                    .where(models.OfferingAcademicInfo.id == resolved_ai_id)
+                )
+            ).first()
+            if row is not None:
+                resolved_major_id, resolved_degree_level = row
     except BadRequest:
         # Fail-soft: chưa chốt được ngành → để NULL (UI hiện "(chưa chốt ngành)").
-        academic_info = None
-    if academic_info is not None:
-        resolved_ai_id = academic_info.id
-        row = (
-            await db.execute(
-                select(
-                    models.MajorProgram.id,
-                    models.MajorProgram.degree_level,
-                )
-                .select_from(models.OfferingAcademicInfo)
-                .join(
-                    models.ProgramOffering,
-                    models.ProgramOffering.id
-                    == models.OfferingAcademicInfo.offering_id,
-                )
-                .join(
-                    models.MajorProgram,
-                    models.MajorProgram.id == models.ProgramOffering.program_id,
-                )
-                .where(models.OfferingAcademicInfo.id == resolved_ai_id)
-            )
-        ).first()
-        if row is not None:
-            resolved_major_id, resolved_degree_level = row
+        pass
+    except Exception as exc:  # best-effort: KHÔNG để snapshot vỡ money flow
+        log.error(
+            "resnapshot_fee_academic_info_failed",
+            profile_id=profile_id,
+            error=str(exc),
+        )
+        return 0
 
+    # Bỏ qua fee đã huỷ — không relabel lịch sử theo ngành admitted hiện tại.
     fees = (
         await db.execute(
-            select(Fee).where(Fee.admission_profile_id == profile_id)
+            select(Fee).where(
+                Fee.admission_profile_id == profile_id,
+                Fee.status != "cancelled",
+            )
         )
     ).scalars().all()
     for fee in fees:
@@ -590,9 +615,9 @@ class FeeCalculationService:
 
         # Snapshot ngành đã resolve lên Fee.resolved_* (single writer) — giữ
         # filter/list/drawer/status-counts khớp với ngành ĐÚNG (admitted choice
-        # cho multi-NV). Cập nhật MỌI fee của hồ sơ cho nhất quán; fail-soft.
+        # cho multi-NV). Truyền profile đã load (bỏ re-SELECT); best-effort.
         await resnapshot_fee_academic_info_for_profile(
-            self.db, admission_profile_id
+            self.db, admission_profile_id, profile=profile
         )
 
         log.info(
@@ -939,9 +964,9 @@ class FeeCalculationService:
         whether the collection turns out empty.
 
         Bounded eager-load (a handful of selectin/joined queries, NO per-row
-        N+1): lead → assigned_officer / offering → program (identity columns,
-        batch-safe ``program_name``) and fees → invoices → payments → (method,
-        created_by) (the three tiers + the columns the list builders read).
+        N+1): lead → assigned_officer (identity) · fees → resolved_major (ngành/
+        trình độ snapshot) · fees → invoices → payments → (method, created_by,
+        verified_by) (the three tiers + the columns the list builders read).
         """
         query = (
             select(models.AdmissionProfile)
@@ -949,11 +974,9 @@ class FeeCalculationService:
             .options(
                 selectinload(models.AdmissionProfile.lead)
                 .selectinload(models.Lead.assigned_officer),
-                selectinload(models.AdmissionProfile.lead)
-                .selectinload(models.Lead.offering)
-                .selectinload(models.ProgramOffering.program),
                 # Ngành/trình độ drawer đọc snapshot Fee.resolved_major (khớp list
-                # + filter, đúng NV admitted) — không dùng lead.offering.program.
+                # + filter, đúng NV admitted) — KHÔNG còn dùng lead.offering.program
+                # nên bỏ luôn eager-load offering→program (dead load).
                 selectinload(models.AdmissionProfile.fees)
                 .joinedload(Fee.resolved_major),
                 # fees → invoices → payments, with the payment columns the list

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -230,6 +230,90 @@ async def resolve_fee_academic_info(
     )
 
 
+async def resnapshot_fee_academic_info_for_profile(
+    db: AsyncSession,
+    profile_id: int,
+) -> int:
+    """Re-snapshot ``Fee.resolved_*`` (academic_info / major / degree) for ALL
+    fees of a profile — the SINGLE writer of the denormalized major snapshot the
+    "Thu học phí" workspace reads (filter + list row + drawer + status-counts).
+
+    Resolves via the SAME ``resolve_fee_academic_info`` used for pricing, so for
+    multi-NV profiles the snapshot reflects the ADMITTED choice — never the
+    lead's intent offering.
+
+    **Fail-soft**: when the resolver can't decide the ngành (multi-NV
+    not-yet-admitted / 0 / ≥2 admitted, or missing config) the three columns are
+    set to NULL — never guessed. Idempotent → safe to call repeatedly. Service
+    only ``flush``es; the caller commits.
+
+    ⚠️ MUST be called by ANY code that (a) creates a Fee outside
+    ``calculate_fee`` or (b) changes which ngành a profile is admitted to
+    (``AdmissionProfileChoice.decision``) — else the snapshot goes stale and the
+    filter/display disagree. Current callers: ``calculate_fee``,
+    ``recalculate_fee``, ``recalculate_fees_for_semester_tuition_change``,
+    ``_create_or_repair_paid_chain`` (application fee), and the decision writers
+    ``evaluate_cascade`` / ``promote_waitlisted_choice`` /
+    ``AdmissionProfileChoiceRepository.update_decision``.
+
+    Returns the number of fees updated.
+    """
+    profile = (
+        await db.execute(
+            select(models.AdmissionProfile).where(
+                models.AdmissionProfile.id == profile_id
+            )
+        )
+    ).scalars().first()
+    if profile is None:
+        return 0
+
+    resolved_ai_id: Optional[int] = None
+    resolved_major_id: Optional[int] = None
+    resolved_degree_level: Optional[str] = None
+    try:
+        academic_info = await resolve_fee_academic_info(db, profile)
+    except BadRequest:
+        # Fail-soft: chưa chốt được ngành → để NULL (UI hiện "(chưa chốt ngành)").
+        academic_info = None
+    if academic_info is not None:
+        resolved_ai_id = academic_info.id
+        row = (
+            await db.execute(
+                select(
+                    models.MajorProgram.id,
+                    models.MajorProgram.degree_level,
+                )
+                .select_from(models.OfferingAcademicInfo)
+                .join(
+                    models.ProgramOffering,
+                    models.ProgramOffering.id
+                    == models.OfferingAcademicInfo.offering_id,
+                )
+                .join(
+                    models.MajorProgram,
+                    models.MajorProgram.id == models.ProgramOffering.program_id,
+                )
+                .where(models.OfferingAcademicInfo.id == resolved_ai_id)
+            )
+        ).first()
+        if row is not None:
+            resolved_major_id, resolved_degree_level = row
+
+    fees = (
+        await db.execute(
+            select(Fee).where(Fee.admission_profile_id == profile_id)
+        )
+    ).scalars().all()
+    for fee in fees:
+        fee.resolved_academic_info_id = resolved_ai_id
+        fee.resolved_major_id = resolved_major_id
+        fee.resolved_degree_level = resolved_degree_level
+    if fees:
+        await db.flush()
+    return len(fees)
+
+
 class FeeCalculationService:
     """
     Service for fee calculation and lifecycle management.
@@ -504,6 +588,13 @@ class FeeCalculationService:
 
         await self.db.flush()
 
+        # Snapshot ngành đã resolve lên Fee.resolved_* (single writer) — giữ
+        # filter/list/drawer/status-counts khớp với ngành ĐÚNG (admitted choice
+        # cho multi-NV). Cập nhật MỌI fee của hồ sơ cho nhất quán; fail-soft.
+        await resnapshot_fee_academic_info_for_profile(
+            self.db, admission_profile_id
+        )
+
         log.info(
             "fee_calculated",
             fee_id=fee.id,
@@ -626,6 +717,13 @@ class FeeCalculationService:
                     f"Reason: {reason}"
 
         await self.db.flush()
+
+        # Recalc KHÔNG gọi resolver như calculate_fee → snapshot ngành tường minh
+        # (ngành thường không đổi, nhưng đảm bảo điền/refresh resolved_* cho fee
+        # cũ chưa có snapshot). Fail-soft, idempotent.
+        await resnapshot_fee_academic_info_for_profile(
+            self.db, fee.admission_profile_id
+        )
 
         log.info(
             "fee_recalculated",
@@ -1188,6 +1286,7 @@ async def recalculate_fees_for_semester_tuition_change(
     eligible_fees = fee_result.scalars().all()
 
     recalc_count = 0
+    affected_profile_ids: set = set()
     for fee in eligible_fees:
         # Skip if any invoice is beyond draft — recalculating would
         # leave fee.final_amount out of sync with issued invoice totals.
@@ -1259,6 +1358,7 @@ async def recalculate_fees_for_semester_tuition_change(
             )
 
         recalc_count += 1
+        affected_profile_ids.add(fee.admission_profile_id)
         log.info(
             "fee_recalculated_by_semester_change",
             fee_id=fee.id,
@@ -1270,5 +1370,9 @@ async def recalculate_fees_for_semester_tuition_change(
 
     if recalc_count > 0:
         await db.flush()
+        # Recalc path không gọi resolver → refresh snapshot ngành cho từng hồ sơ
+        # bị ảnh hưởng (dùng resolver đúng admitted-choice; fail-soft, idempotent).
+        for pid in affected_profile_ids:
+            await resnapshot_fee_academic_info_for_profile(db, pid)
 
     return recalc_count

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -952,9 +952,14 @@ class FeeCalculationService:
                 selectinload(models.AdmissionProfile.lead)
                 .selectinload(models.Lead.offering)
                 .selectinload(models.ProgramOffering.program),
+                # Ngành/trình độ drawer đọc snapshot Fee.resolved_major (khớp list
+                # + filter, đúng NV admitted) — không dùng lead.offering.program.
+                selectinload(models.AdmissionProfile.fees)
+                .joinedload(Fee.resolved_major),
                 # fees → invoices → payments, with the payment columns the list
-                # builder reads (method/created_by). Explicit chain overrides the
-                # model-level lazy="selectin" so those nested loads are eager too.
+                # builder reads (method/created_by/verified_by). Explicit chain
+                # overrides the model-level lazy="selectin" so nested loads are
+                # eager too.
                 selectinload(models.AdmissionProfile.fees)
                 .selectinload(Fee.invoices)
                 .selectinload(Invoice.payments)
@@ -963,6 +968,10 @@ class FeeCalculationService:
                 .selectinload(Fee.invoices)
                 .selectinload(Invoice.payments)
                 .joinedload(Payment.created_by),
+                selectinload(models.AdmissionProfile.fees)
+                .selectinload(Fee.invoices)
+                .selectinload(Invoice.payments)
+                .joinedload(Payment.verified_by),
                 # Suppress the model-level lazy="selectin" eager-loads the list
                 # builders never read — otherwise opening the drawer fires 2 extra
                 # batched SELECTs (invoice.payment_intents + payment.transactions).

--- a/Backend_FastAPI/tests/services/test_fee_resolved_snapshot.py
+++ b/Backend_FastAPI/tests/services/test_fee_resolved_snapshot.py
@@ -1,0 +1,334 @@
+"""Integration test cho snapshot ngành (Fee.resolved_*) + filter parity.
+
+Phủ các vùng rủi ro P1 của workspace "Thu học phí":
+- ``resnapshot_fee_academic_info_for_profile`` điền đúng major/degree (legacy +
+  multi-NV admitted) · fail-soft NULL khi chưa chốt · skip fee cancelled · refresh
+  khi đổi admitted choice (cơ chế các decision hook dựa vào).
+- Filter ``major_id`` / ``degree_level``: ``get_filtered_with_count`` (list) và
+  ``get_status_counts`` (badge tab) CÙNG điều kiện → CÙNG số (parity P1-1).
+- Application fee tạo trước khi chốt (2 NV pending) → NULL; sau khi admit 1 NV →
+  re-snapshot có ngành.
+"""
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from app import models
+from app.repositories.fee_repository import InvoiceRepository
+from app.services.fee_calculation_service import (
+    resnapshot_fee_academic_info_for_profile,
+)
+
+pytestmark = pytest.mark.integration
+
+_counter = {"n": 0}
+
+
+def _suffix() -> int:
+    _counter["n"] += 1
+    return int(datetime.now(timezone.utc).timestamp() * 1000) % 1_000_000 + _counter["n"]
+
+
+async def _seed_major_chain(db, unit_id, *, degree="Cao đẳng", tuition=1_000_000):
+    """Major + ProgramOffering + OfferingAcademicInfo + Method + AdmissionPath +
+    SubjectGroup + PathSubjectGroupConfig. Trả ids để dựng choice / OAC / fee."""
+    sfx = _suffix()
+    major = models.MajorProgram(
+        id=sfx,
+        name=f"Ngành {sfx}",
+        code=f"MJ{sfx}",
+        degree_level=degree,
+        unit_id=unit_id,
+    )
+    db.add(major)
+    await db.flush()
+
+    offering = models.ProgramOffering(
+        program_id=major.id, offering_type=f"ft_{sfx}", duration_semesters=6,
+    )
+    db.add(offering)
+    await db.flush()
+
+    ai = models.OfferingAcademicInfo(
+        offering_id=offering.id,
+        academic_year=2026,
+        annual_admission_quota=50,
+        tuition_fee_per_year=tuition,
+    )
+    db.add(ai)
+    await db.flush()
+
+    from tests.fixtures.builders import AdmissionRoundBuilder
+    round_id = await AdmissionRoundBuilder.get_or_create_default_round(
+        db, academic_year=2026,
+    )
+    method = models.AdmissionMethod(code=f"MT{sfx}", name=f"PT {sfx}", is_active=True)
+    db.add(method)
+    await db.flush()
+
+    path = models.AdmissionPath(
+        academic_info_id=ai.id,
+        admission_method_id=method.id,
+        admission_round_id=round_id,
+        status="active",
+    )
+    db.add(path)
+    await db.flush()
+
+    sg = models.SubjectGroup(code=f"SG{sfx}"[:20], name=f"Tổ hợp {sfx}")
+    db.add(sg)
+    await db.flush()
+    config = models.PathSubjectGroupConfig(
+        admission_path_id=path.id, subject_group_id=sg.id, min_score=Decimal("0"),
+    )
+    db.add(config)
+    await db.flush()
+
+    return {
+        "major_id": major.id,
+        "degree": degree,
+        "academic_info_id": ai.id,
+        "path_id": path.id,
+        "config_id": config.id,
+    }
+
+
+async def _make_lead_profile(db, unit_id, *, uses_choice_engine, applied_rules=None):
+    sfx = _suffix()
+    lead = models.Lead(
+        full_name=f"HS {sfx}",
+        phone=f"098{sfx:07d}"[:10],
+        unit_id=unit_id,
+        source="walkin",
+    )
+    db.add(lead)
+    await db.flush()
+    profile = models.AdmissionProfile(
+        lead_id=lead.id,
+        citizen_id=f"8{sfx:09d}"[:12],
+        status="submitted",
+        applied_rules=applied_rules or {},
+        academic_year=2026,
+        uses_choice_engine=uses_choice_engine,
+    )
+    db.add(profile)
+    await db.flush()
+    return lead, profile
+
+
+async def _add_choice(db, profile_id, chain, *, order, decision="pending"):
+    choice = models.AdmissionProfileChoice(
+        admission_profile_id=profile_id,
+        admission_path_id=chain["path_id"],
+        path_subject_group_config_id=chain["config_id"],
+        display_order=order,
+        decision=decision,
+    )
+    db.add(choice)
+    await db.flush()
+    return choice
+
+
+async def _add_fee_with_invoice(db, profile_id, *, fee_type="tuition", semester_no=1,
+                                amount=Decimal("1000000"), status="invoiced",
+                                inv_status="issued"):
+    fee = models.Fee(
+        admission_profile_id=profile_id,
+        fee_type=fee_type,
+        academic_year=2026,
+        semester_no=semester_no if fee_type == "tuition" else None,
+        base_amount=amount,
+        total_discount=Decimal("0"),
+        final_amount=amount,
+        paid_amount=Decimal("0"),
+        waived_amount=Decimal("0"),
+        status=status,
+    )
+    db.add(fee)
+    await db.flush()
+    inv = models.Invoice(
+        fee_id=fee.id,
+        invoice_number=f"INV-T-{fee.id}",
+        installment_no=1,
+        amount=amount,
+        paid_amount=Decimal("0"),
+        penalty_amount=Decimal("0"),
+        due_date=date(2026, 9, 1),
+        status=inv_status,
+    )
+    db.add(inv)
+    await db.flush()
+    return fee, inv
+
+
+# ── Snapshot helper ─────────────────────────────────────────────────────────
+
+class TestResnapshotHelper:
+
+    async def test_legacy_profile_resolves_major(self, db, seed_lead_dependencies):
+        unit = seed_lead_dependencies["unit_id"]
+        chain = await _seed_major_chain(db, unit)
+        _, profile = await _make_lead_profile(
+            db, unit, uses_choice_engine=False,
+            applied_rules={"academic_info_id": chain["academic_info_id"]},
+        )
+        fee, _ = await _add_fee_with_invoice(db, profile.id)
+
+        n = await resnapshot_fee_academic_info_for_profile(db, profile.id)
+        await db.refresh(fee)
+        assert n == 1
+        assert fee.resolved_major_id == chain["major_id"]
+        assert fee.resolved_degree_level == chain["degree"]
+        assert fee.resolved_academic_info_id == chain["academic_info_id"]
+
+    async def test_failsoft_null_when_two_pending_choices(self, db, seed_lead_dependencies):
+        unit = seed_lead_dependencies["unit_id"]
+        c1 = await _seed_major_chain(db, unit)
+        c2 = await _seed_major_chain(db, unit, degree="Trung cấp")
+        _, profile = await _make_lead_profile(db, unit, uses_choice_engine=True)
+        await _add_choice(db, profile.id, c1, order=1)
+        await _add_choice(db, profile.id, c2, order=2)  # 2 pending → undetermined
+        fee, _ = await _add_fee_with_invoice(db, profile.id)
+
+        await resnapshot_fee_academic_info_for_profile(db, profile.id)
+        await db.refresh(fee)
+        assert fee.resolved_major_id is None
+        assert fee.resolved_degree_level is None
+
+    async def test_multinv_admitted_uses_admitted_choice(self, db, seed_lead_dependencies):
+        """P1-2: admitted choice KHÁC NV gốc → snapshot = ngành ADMITTED."""
+        unit = seed_lead_dependencies["unit_id"]
+        nv1 = await _seed_major_chain(db, unit, degree="Cao đẳng")
+        nv2 = await _seed_major_chain(db, unit, degree="Trung cấp")
+        _, profile = await _make_lead_profile(db, unit, uses_choice_engine=True)
+        await _add_choice(db, profile.id, nv1, order=1, decision="rejected")
+        await _add_choice(db, profile.id, nv2, order=2, decision="admitted")
+        fee, _ = await _add_fee_with_invoice(db, profile.id)
+
+        await resnapshot_fee_academic_info_for_profile(db, profile.id)
+        await db.refresh(fee)
+        # Đúng NV2 (admitted), KHÔNG phải NV1 gốc.
+        assert fee.resolved_major_id == nv2["major_id"]
+        assert fee.resolved_degree_level == "Trung cấp"
+        assert fee.resolved_major_id != nv1["major_id"]
+
+    async def test_refreshes_after_decision_change(self, db, seed_lead_dependencies):
+        """Cơ chế decision-hook: đổi admitted → re-run helper cập nhật snapshot."""
+        unit = seed_lead_dependencies["unit_id"]
+        nv1 = await _seed_major_chain(db, unit)
+        nv2 = await _seed_major_chain(db, unit, degree="Trung cấp")
+        _, profile = await _make_lead_profile(db, unit, uses_choice_engine=True)
+        ch1 = await _add_choice(db, profile.id, nv1, order=1, decision="admitted")
+        ch2 = await _add_choice(db, profile.id, nv2, order=2, decision="rejected")
+        fee, _ = await _add_fee_with_invoice(db, profile.id)
+
+        await resnapshot_fee_academic_info_for_profile(db, profile.id)
+        await db.refresh(fee)
+        assert fee.resolved_major_id == nv1["major_id"]
+
+        # Đổi admitted sang NV2 (như waitlist promote / cascade) → re-snapshot.
+        ch1.decision = "rejected"
+        ch2.decision = "admitted"
+        await db.flush()
+        await resnapshot_fee_academic_info_for_profile(db, profile.id)
+        await db.refresh(fee)
+        assert fee.resolved_major_id == nv2["major_id"]
+
+    async def test_skips_cancelled_fee(self, db, seed_lead_dependencies):
+        unit = seed_lead_dependencies["unit_id"]
+        chain = await _seed_major_chain(db, unit)
+        _, profile = await _make_lead_profile(
+            db, unit, uses_choice_engine=False,
+            applied_rules={"academic_info_id": chain["academic_info_id"]},
+        )
+        active_fee, _ = await _add_fee_with_invoice(db, profile.id, semester_no=1)
+        cancelled_fee, _ = await _add_fee_with_invoice(
+            db, profile.id, semester_no=2, status="cancelled", inv_status="cancelled",
+        )
+
+        n = await resnapshot_fee_academic_info_for_profile(db, profile.id)
+        await db.refresh(active_fee)
+        await db.refresh(cancelled_fee)
+        assert n == 1  # chỉ fee active
+        assert active_fee.resolved_major_id == chain["major_id"]
+        assert cancelled_fee.resolved_major_id is None  # KHÔNG relabel fee huỷ
+
+    async def test_application_fee_null_predecision_then_resnapshot(self, db, seed_lead_dependencies):
+        """P1: app fee tạo khi 2 NV pending → NULL; admit 1 NV → re-snapshot có ngành."""
+        unit = seed_lead_dependencies["unit_id"]
+        nv1 = await _seed_major_chain(db, unit)
+        nv2 = await _seed_major_chain(db, unit, degree="Trung cấp")
+        _, profile = await _make_lead_profile(db, unit, uses_choice_engine=True)
+        ch1 = await _add_choice(db, profile.id, nv1, order=1)
+        await _add_choice(db, profile.id, nv2, order=2)
+        app_fee, _ = await _add_fee_with_invoice(
+            db, profile.id, fee_type="application", status="paid", inv_status="paid",
+        )
+
+        await resnapshot_fee_academic_info_for_profile(db, profile.id)
+        await db.refresh(app_fee)
+        assert app_fee.resolved_major_id is None  # chưa chốt
+
+        ch1.decision = "admitted"
+        await db.flush()
+        await resnapshot_fee_academic_info_for_profile(db, profile.id)
+        await db.refresh(app_fee)
+        assert app_fee.resolved_major_id == nv1["major_id"]  # đã chốt
+
+
+# ── Filter parity (list == status-counts) ───────────────────────────────────
+
+class TestFilterParity:
+
+    async def test_major_filter_parity(self, db, seed_lead_dependencies):
+        unit = seed_lead_dependencies["unit_id"]
+        chain = await _seed_major_chain(db, unit)
+        other = await _seed_major_chain(db, unit, degree="Trung cấp")
+        # 2 hồ sơ ngành `chain`, 1 hồ sơ ngành `other`.
+        for _ in range(2):
+            _, p = await _make_lead_profile(
+                db, unit, uses_choice_engine=False,
+                applied_rules={"academic_info_id": chain["academic_info_id"]},
+            )
+            await _add_fee_with_invoice(db, p.id)
+            await resnapshot_fee_academic_info_for_profile(db, p.id)
+        _, p2 = await _make_lead_profile(
+            db, unit, uses_choice_engine=False,
+            applied_rules={"academic_info_id": other["academic_info_id"]},
+        )
+        await _add_fee_with_invoice(db, p2.id)
+        await resnapshot_fee_academic_info_for_profile(db, p2.id)
+        await db.flush()
+
+        repo = InvoiceRepository(db)
+        invs, total = await repo.get_filtered_with_count(major_id=chain["major_id"], limit=100)
+        counts = await repo.get_status_counts(major_id=chain["major_id"])
+        # PARITY: list total == status-counts total, đều = 2.
+        assert total == 2
+        assert counts["total"] == 2
+        assert total == counts["total"]
+        assert all(i.fee.resolved_major_id == chain["major_id"] for i in invs)
+
+        # Ngành khác → 1 (parity giữ).
+        _, t_other = await repo.get_filtered_with_count(major_id=other["major_id"], limit=100)
+        c_other = await repo.get_status_counts(major_id=other["major_id"])
+        assert t_other == 1 == c_other["total"]
+
+    async def test_degree_filter_parity(self, db, seed_lead_dependencies):
+        unit = seed_lead_dependencies["unit_id"]
+        cd = await _seed_major_chain(db, unit, degree="Cao đẳng")
+        tc = await _seed_major_chain(db, unit, degree="Trung cấp")
+        for chain in (cd, cd, tc):
+            _, p = await _make_lead_profile(
+                db, unit, uses_choice_engine=False,
+                applied_rules={"academic_info_id": chain["academic_info_id"]},
+            )
+            await _add_fee_with_invoice(db, p.id)
+            await resnapshot_fee_academic_info_for_profile(db, p.id)
+        await db.flush()
+
+        repo = InvoiceRepository(db)
+        _, total = await repo.get_filtered_with_count(degree_level="Cao đẳng", limit=100)
+        counts = await repo.get_status_counts(degree_level="Cao đẳng")
+        assert total == 2 == counts["total"]

--- a/Backend_FastAPI/tests/unit/test_thu_hoc_phi_enhance.py
+++ b/Backend_FastAPI/tests/unit/test_thu_hoc_phi_enhance.py
@@ -1,0 +1,120 @@
+"""Unit tests cho nâng cấp workspace "Thu học phí" (no-DB, pure logic).
+
+Phủ:
+- ``_mask_citizen_id`` — che CCCD PII (giữ 3 đầu/3 cuối).
+- ``_build_payment_list_item`` source resolver — online/import/manual + các field
+  mới (verified_by_name, verified_at).
+
+Các test parity list↔status-counts + snapshot multi-NV admitted (cần fixture
+choice-engine + academic_info) để PR sau (integration).
+"""
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.routers.fees import _mask_citizen_id
+from app.routers.payments import _build_payment_list_item
+
+
+pytestmark = pytest.mark.unit
+
+
+# ── _mask_citizen_id ────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("036204001234", "036******234"),  # 12 số CCCD: che 6 giữa
+        ("123456789", "123***789"),         # 9 số
+        (None, None),
+        ("", None),
+        ("12", "**"),                        # quá ngắn (<3) → che hết
+        ("123456", "****56"),                # <7 → che hết trừ 2 cuối
+    ],
+)
+def test_mask_citizen_id(raw, expected):
+    assert _mask_citizen_id(raw) == expected
+
+
+def test_mask_citizen_id_strips_whitespace():
+    assert _mask_citizen_id("  036204001234  ") == "036******234"
+
+
+# ── _build_payment_list_item: source + field mới ────────────────────────────
+
+def _fake_payment(*, pid=1, intent_id=None, verified_by=None,
+                  verified_at=None, created_by=None):
+    """Dựng object giống Payment ORM (chỉ các attr builder đọc)."""
+    p = SimpleNamespace(
+        id=pid,
+        invoice_id=10,
+        amount="1000000",
+        status="verified",
+        payment_date=datetime(2026, 6, 1, 9, 0, 0),
+        created_at=datetime(2026, 6, 1, 9, 0, 0),
+        reference_code="REF-1",
+        payer_name="Phụ huynh A",
+        intent_id=intent_id,
+        is_own=False,
+        created_by_id=2,
+        created_by=created_by,
+        verified_at=verified_at,
+        method=None,
+        invoice=None,
+    )
+    # __dict__.get("verified_by") path trong builder.
+    p.verified_by = verified_by
+    return p
+
+
+def test_source_online_when_intent_id():
+    item = _build_payment_list_item(_fake_payment(intent_id=99), 1, "admin")
+    assert item.source == "online"
+    assert item.is_online is True
+
+
+def test_source_import_when_id_in_set():
+    p = _fake_payment(pid=55, intent_id=None)
+    item = _build_payment_list_item(p, 1, "admin", imported_payment_ids={55, 77})
+    assert item.source == "import"
+    assert item.is_online is False
+
+
+def test_source_manual_default():
+    p = _fake_payment(pid=55, intent_id=None)
+    # id 55 KHÔNG nằm trong set → manual.
+    item = _build_payment_list_item(p, 1, "admin", imported_payment_ids={77})
+    assert item.source == "manual"
+
+
+def test_source_manual_when_no_set():
+    item = _build_payment_list_item(_fake_payment(intent_id=None), 1, "admin")
+    assert item.source == "manual"
+
+
+def test_online_takes_priority_over_import():
+    # intent_id có → online dù id nằm trong import set (online ưu tiên).
+    p = _fake_payment(pid=55, intent_id=99)
+    item = _build_payment_list_item(p, 1, "admin", imported_payment_ids={55})
+    assert item.source == "online"
+
+
+def test_verified_by_name_and_at():
+    verifier = SimpleNamespace(full_name="Kế toán B", email="kt@x.vn")
+    vat = datetime(2026, 6, 2, 10, 0, 0)
+    p = _fake_payment(verified_by=verifier, verified_at=vat)
+    item = _build_payment_list_item(p, 1, "admin")
+    assert item.verified_by_name == "Kế toán B"
+    assert item.verified_at == vat
+
+
+def test_verified_by_name_falls_back_to_email():
+    verifier = SimpleNamespace(full_name=None, email="kt@x.vn")
+    item = _build_payment_list_item(_fake_payment(verified_by=verifier), 1, "admin")
+    assert item.verified_by_name == "kt@x.vn"
+
+
+def test_verified_by_name_none_when_unverified():
+    item = _build_payment_list_item(_fake_payment(verified_by=None), 1, "admin")
+    assert item.verified_by_name is None

--- a/Backend_FastAPI/tests/unit/test_thu_hoc_phi_enhance.py
+++ b/Backend_FastAPI/tests/unit/test_thu_hoc_phi_enhance.py
@@ -1,44 +1,21 @@
 """Unit tests cho nâng cấp workspace "Thu học phí" (no-DB, pure logic).
 
-Phủ:
-- ``_mask_citizen_id`` — che CCCD PII (giữ 3 đầu/3 cuối).
-- ``_build_payment_list_item`` source resolver — online/import/manual + các field
-  mới (verified_by_name, verified_at).
+Phủ ``_build_payment_list_item`` source resolver — online/import/manual + các
+field mới (verified_by_name, verified_at). CCCD masked dùng util chung
+``app.utils.masking.mask_citizen_id`` (đã có test riêng).
 
-Các test parity list↔status-counts + snapshot multi-NV admitted (cần fixture
-choice-engine + academic_info) để PR sau (integration).
+Parity list↔status-counts + snapshot multi-NV admitted (DB + choice-engine):
+``tests/services/test_fee_resolved_snapshot.py``.
 """
 from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
 
-from app.routers.fees import _mask_citizen_id
 from app.routers.payments import _build_payment_list_item
 
 
 pytestmark = pytest.mark.unit
-
-
-# ── _mask_citizen_id ────────────────────────────────────────────────────────
-
-@pytest.mark.parametrize(
-    "raw,expected",
-    [
-        ("036204001234", "036******234"),  # 12 số CCCD: che 6 giữa
-        ("123456789", "123***789"),         # 9 số
-        (None, None),
-        ("", None),
-        ("12", "**"),                        # quá ngắn (<3) → che hết
-        ("123456", "****56"),                # <7 → che hết trừ 2 cuối
-    ],
-)
-def test_mask_citizen_id(raw, expected):
-    assert _mask_citizen_id(raw) == expected
-
-
-def test_mask_citizen_id_strips_whitespace():
-    assert _mask_citizen_id("  036204001234  ") == "036******234"
 
 
 # ── _build_payment_list_item: source + field mới ────────────────────────────

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/FinanceProfileDrawer.tsx
@@ -211,7 +211,11 @@ export function FinanceProfileDrawer({
 function DrawerIdentity({ collection }: { collection: ProfileCollection }) {
   const { identity } = collection
   const name = identity.student_name ?? "Chưa rõ học sinh"
-  const sub = [identity.profile_code, identity.program_name].filter(Boolean).join(" · ")
+  // Ngành (snapshot Fee.resolved_major) + trình độ. NULL → "(chưa chốt ngành)".
+  const major = identity.program_name ?? "(chưa chốt ngành)"
+  const sub = [identity.profile_code, major, identity.degree_level]
+    .filter(Boolean)
+    .join(" · ")
   return (
     <div className="flex items-center gap-3 pr-10">
       <Monogram name={name} className="size-10" />
@@ -221,6 +225,11 @@ function DrawerIdentity({ collection }: { collection: ProfileCollection }) {
           {sub || "Hồ sơ tài chính"}
           {identity.officer_name ? ` · TVV ${identity.officer_name}` : ""}
         </SheetDescription>
+        {identity.citizen_id_masked ? (
+          <p className="truncate text-xs text-muted-foreground">
+            CCCD: {identity.citizen_id_masked}
+          </p>
+        ) : null}
       </div>
     </div>
   )
@@ -624,6 +633,12 @@ function PaymentSection({
   )
 }
 
+const PAYMENT_SOURCE_LABEL: Record<string, string> = {
+  online: "Online",
+  import: "Qua import",
+  manual: "Thu tay",
+}
+
 function PaymentRow({
   payment,
   onAction,
@@ -639,6 +654,16 @@ function PaymentRow({
     created_by_display: payment.created_by_name ?? "Không rõ",
   }
   const isPending = payment.status === "pending"
+  const sourceLabel = PAYMENT_SOURCE_LABEL[payment.source] ?? "Thu tay"
+  // Chi tiết: ai thu · lúc nào · ai duyệt (drawer chi tiết hơn list).
+  const collectedAt = payment.payment_date
+    ? new Date(payment.payment_date).toLocaleDateString("vi-VN")
+    : null
+  const detailParts = [
+    payment.created_by_name ? `Thu: ${payment.created_by_name}` : null,
+    collectedAt,
+    payment.verified_by_name ? `Duyệt: ${payment.verified_by_name}` : null,
+  ].filter(Boolean)
   return (
     <li className="rounded-xl border border-border bg-card px-3 py-2.5">
       <div className="flex items-start justify-between gap-3">
@@ -650,8 +675,18 @@ function PaymentRow({
             {payment.reference_code || `#${payment.id}`}
             {payment.payer_name ? ` · ${payment.payer_name}` : ""}
           </p>
+          {detailParts.length > 0 ? (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              {detailParts.join(" · ")}
+            </p>
+          ) : null}
         </div>
-        <PaymentStatusBadge status={payment.status as PaymentStatus} size="sm" />
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <PaymentStatusBadge status={payment.status as PaymentStatus} size="sm" />
+          <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+            {sourceLabel}
+          </span>
+        </div>
       </div>
 
       {isPending && payment.is_own && (

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceColumns.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceColumns.tsx
@@ -135,6 +135,63 @@ export function AmountSubline({
 }
 
 /**
+ * Cột "Đã đóng" (tách khỏi "Số tiền") — paid_amount, xanh khi đã thu đủ.
+ */
+export function PaidCell({ invoice }: { invoice: InvoiceListItemViewModel }) {
+  return (
+    <div className="text-right tabular-nums">
+      <span
+        className={cn(
+          "font-medium",
+          invoice.is_paid ? "text-emerald-600" : "text-foreground",
+        )}
+      >
+        {invoice.paid_amount_formatted}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * Cột "Còn lại" — remaining (đỏ nếu quá hạn) + dòng phụ quá-N-ngày / phạt.
+ * "Đã thu đủ" khi is_paid.
+ */
+export function RemainingCell({ invoice }: { invoice: InvoiceListItemViewModel }) {
+  if (invoice.is_paid) {
+    return (
+      <div className="text-right text-xs font-medium tabular-nums text-emerald-600">
+        Đã thu đủ
+      </div>
+    )
+  }
+  return (
+    <div className="text-right tabular-nums">
+      <div
+        className={cn(
+          "flex items-center justify-end gap-1 font-medium",
+          invoice.is_overdue ? "text-error-600" : "text-foreground",
+        )}
+      >
+        {invoice.is_overdue && (
+          <AlertTriangle className="size-3 shrink-0" aria-hidden="true" />
+        )}
+        <span>{invoice.remaining_amount_formatted}</span>
+      </div>
+      {invoice.is_overdue && invoice.overdue_days > 0 && (
+        <div className="text-[11px] text-error-600">
+          quá {invoice.overdue_days} ngày
+        </div>
+      )}
+      {invoice.has_penalty && (
+        <div className="text-[11px] tabular-nums text-muted-foreground">
+          (gồm {formatVND(invoice.penalty_amount)} phạt)
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
  * "Thu tiền" = nút hạng nhất (gate can_record_payment). Desktop: hover-reveal
  * (`opacity-0 group-hover:opacity-100`, luôn hiện khi focus-within). Mobile card:
  * truyền `alwaysVisible` để LUÔN hiện. Keyboard-reachable + aria-label.

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceFilterBar.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceFilterBar.tsx
@@ -19,7 +19,26 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { FEE_TYPE_LABELS, type FeeType } from "@/types/finance.types"
+import {
+  FEE_TYPE_LABELS,
+  type FeeType,
+  type InvoiceWorkspaceFilters,
+} from "@/types/finance.types"
+
+export interface MajorFilterOption {
+  id: number
+  name: string
+  degree_level: string
+}
+
+const DUE_WINDOW_OPTIONS: readonly {
+  value: NonNullable<InvoiceWorkspaceFilters["due_window"]> | ""
+  label: string
+}[] = [
+  { value: "", label: "Mọi hạn" },
+  { value: "due_soon_7d", label: "Đến hạn ≤7 ngày" },
+  { value: "overdue", label: "Quá hạn" },
+]
 
 const FEE_TYPE_OPTIONS: readonly { value: FeeType; label: string }[] = (
   Object.entries(FEE_TYPE_LABELS) as [FeeType, string][]
@@ -31,6 +50,9 @@ const SORT_OPTIONS: readonly { by: string; order: "asc" | "desc"; label: string 
   { by: "due_date", order: "desc", label: "Hạn xa nhất" },
   { by: "amount", order: "desc", label: "Số tiền cao → thấp" },
   { by: "amount", order: "asc", label: "Số tiền thấp → cao" },
+  { by: "remaining", order: "desc", label: "Còn lại nhiều → ít" },
+  { by: "remaining", order: "asc", label: "Còn lại ít → nhiều" },
+  { by: "paid", order: "desc", label: "Đã đóng nhiều → ít" },
   { by: "created_at", order: "desc", label: "Mới nhất" },
 ]
 
@@ -48,6 +70,14 @@ export interface InvoiceFilterBarProps {
   onSortChange: (sortBy: string, sortOrder: "asc" | "desc") => void
   hasActiveFilters: boolean
   onReset: () => void
+  // Workspace filters (ngành/trình độ/hạn). majorOptions = danh sách ngành để
+  // chọn; trình độ derive từ distinct degree_level của majorOptions.
+  workspaceFilters: InvoiceWorkspaceFilters
+  setWorkspaceFilter: <K extends keyof InvoiceWorkspaceFilters>(
+    key: K,
+    value: InvoiceWorkspaceFilters[K],
+  ) => void
+  majorOptions: readonly MajorFilterOption[]
 }
 
 export function InvoiceFilterBar({
@@ -60,11 +90,43 @@ export function InvoiceFilterBar({
   onSortChange,
   hasActiveFilters,
   onReset,
+  workspaceFilters,
+  setWorkspaceFilter,
+  majorOptions,
 }: InvoiceFilterBarProps) {
+  const selectedMajor = majorOptions.find((m) => m.id === workspaceFilters.major_id)
+  // Trình độ: distinct degree_level từ danh sách ngành (gửi TEXT name xuống BE).
+  const degreeOptions = Array.from(
+    new Set(majorOptions.map((m) => m.degree_level).filter(Boolean)),
+  )
+  const dueWindow = workspaceFilters.due_window ?? ""
+
   type Chip = { key: string; label: string; onRemove: () => void }
   const chips: Chip[] = []
   if (feeType) {
     chips.push({ key: "fee_type", label: `Loại: ${feeTypeLabel(feeType)}`, onRemove: () => onFeeTypeChange("") })
+  }
+  if (selectedMajor) {
+    chips.push({
+      key: "major",
+      label: `Ngành: ${selectedMajor.name}`,
+      onRemove: () => setWorkspaceFilter("major_id", undefined),
+    })
+  }
+  if (workspaceFilters.degree_level) {
+    chips.push({
+      key: "degree",
+      label: `Trình độ: ${workspaceFilters.degree_level}`,
+      onRemove: () => setWorkspaceFilter("degree_level", undefined),
+    })
+  }
+  if (workspaceFilters.due_window) {
+    const lbl = DUE_WINDOW_OPTIONS.find((o) => o.value === workspaceFilters.due_window)?.label
+    chips.push({
+      key: "due",
+      label: `Hạn: ${lbl ?? workspaceFilters.due_window}`,
+      onRemove: () => setWorkspaceFilter("due_window", undefined),
+    })
   }
 
   return (
@@ -120,6 +182,84 @@ export function InvoiceFilterBar({
                 >
                   {o.label}
                   {feeType === o.value && <Check className="size-4" />}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {/* Ngành */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="h-10 max-w-[14rem] gap-1.5" aria-label="Lọc theo ngành">
+                <span className="truncate">{selectedMajor ? selectedMajor.name : "Tất cả ngành"}</span>
+                <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="max-h-80 w-64 overflow-y-auto">
+              <DropdownMenuItem className="justify-between" onClick={() => setWorkspaceFilter("major_id", undefined)}>
+                Tất cả ngành
+                {workspaceFilters.major_id === undefined && <Check className="size-4" />}
+              </DropdownMenuItem>
+              {majorOptions.map((m) => (
+                <DropdownMenuItem
+                  key={m.id}
+                  className="justify-between gap-2"
+                  onClick={() => setWorkspaceFilter("major_id", m.id)}
+                >
+                  <span className="truncate">{m.name}</span>
+                  {workspaceFilters.major_id === m.id && <Check className="size-4 shrink-0" />}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {/* Trình độ */}
+          {degreeOptions.length > 0 && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" className="h-10 gap-1.5" aria-label="Lọc theo trình độ">
+                  {workspaceFilters.degree_level ?? "Mọi trình độ"}
+                  <ChevronDown className="size-4 text-muted-foreground" aria-hidden="true" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuItem className="justify-between" onClick={() => setWorkspaceFilter("degree_level", undefined)}>
+                  Mọi trình độ
+                  {!workspaceFilters.degree_level && <Check className="size-4" />}
+                </DropdownMenuItem>
+                {degreeOptions.map((d) => (
+                  <DropdownMenuItem
+                    key={d}
+                    className="justify-between"
+                    onClick={() => setWorkspaceFilter("degree_level", d)}
+                  >
+                    {d}
+                    {workspaceFilters.degree_level === d && <Check className="size-4" />}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+
+          {/* Hạn thanh toán */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="h-10 gap-1.5" aria-label="Lọc theo hạn thanh toán">
+                {DUE_WINDOW_OPTIONS.find((o) => o.value === dueWindow)?.label ?? "Mọi hạn"}
+                <ChevronDown className="size-4 text-muted-foreground" aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-44">
+              {DUE_WINDOW_OPTIONS.map((o) => (
+                <DropdownMenuItem
+                  key={o.value || "all"}
+                  className="justify-between"
+                  onClick={() =>
+                    setWorkspaceFilter("due_window", o.value === "" ? undefined : o.value)
+                  }
+                >
+                  {o.label}
+                  {dueWindow === o.value && <Check className="size-4" />}
                 </DropdownMenuItem>
               ))}
             </DropdownMenuContent>

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceListClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceListClient.tsx
@@ -15,6 +15,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Receipt, Plus, ClipboardCheck } from "lucide-react"
+import { useMajorPrograms } from "@/hooks/admissions/useProgramData"
 
 import { PageContainer } from "@/components/layouts/PageContainer"
 import { EmptyState, ErrorEmptyState } from "@/components/common/EmptyState"
@@ -48,7 +49,8 @@ import { InvoiceStatusDot } from "./InvoiceStatusDot"
 import { InvoiceCard } from "./InvoiceCard"
 import { InvoiceListSkeleton } from "./InvoiceListSkeleton"
 import {
-  AmountCell,
+  PaidCell,
+  RemainingCell,
   FeeCell,
   IdentityCell,
   InvoiceRowActionsMenu,
@@ -165,6 +167,18 @@ export function InvoiceListClient() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPendingTab, data, isFetching, totalCount, items?.length, state.page])
+
+  // Danh sách ngành cho filter dropdown (trình độ derive distinct degree_level).
+  const { data: majors } = useMajorPrograms()
+  const majorOptions = useMemo(
+    () =>
+      (majors ?? []).map((m) => ({
+        id: m.id,
+        name: m.name,
+        degree_level: m.degree_level,
+      })),
+    [majors],
+  )
 
   // ── Row interactions (PR2) ──────────────────────────────────────────────
   // Clicking a row opens the profile drawer (?profile=<id>); the quick "Thu
@@ -367,6 +381,9 @@ export function InvoiceListClient() {
             onSortChange={handlers.handleSortChange}
             hasActiveFilters={hasActiveFilters}
             onReset={handlers.resetFilters}
+            workspaceFilters={state.workspaceFilters}
+            setWorkspaceFilter={handlers.setWorkspaceFilter}
+            majorOptions={majorOptions}
           />
         )}
 
@@ -414,7 +431,8 @@ export function InvoiceListClient() {
                     <th className="px-3 py-3 font-medium">Khoản thu</th>
                     <th className="px-3 py-3 font-medium">Phụ trách</th>
                     <th className="px-3 py-3 font-medium">Trạng thái</th>
-                    <th className="px-3 py-3 text-right font-medium">Số tiền</th>
+                    <th className="px-3 py-3 text-right font-medium">Đã đóng</th>
+                    <th className="px-3 py-3 text-right font-medium">Còn lại</th>
                     <th className="px-3 py-3 font-medium">
                       <span className="sr-only">Thao tác</span>
                     </th>
@@ -454,7 +472,10 @@ export function InvoiceListClient() {
                           <InvoiceStatusDot status={invoice.status} isOverdue={invoice.is_overdue} />
                         </td>
                         <td className={cn("px-3 align-middle", compact ? "py-2" : "py-3")}>
-                          <AmountCell invoice={invoice} />
+                          <PaidCell invoice={invoice} />
+                        </td>
+                        <td className={cn("px-3 align-middle", compact ? "py-2" : "py-3")}>
+                          <RemainingCell invoice={invoice} />
                         </td>
                         <td
                           className={cn("px-3 align-middle", compact ? "py-2" : "py-3")}

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceListClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceListClient.tsx
@@ -16,6 +16,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Receipt, Plus, ClipboardCheck } from "lucide-react"
 import { useMajorPrograms } from "@/hooks/admissions/useProgramData"
+import type { MajorProgram } from "@/types/organization.types"
 
 import { PageContainer } from "@/components/layouts/PageContainer"
 import { EmptyState, ErrorEmptyState } from "@/components/common/EmptyState"
@@ -169,10 +170,12 @@ export function InvoiceListClient() {
   }, [isPendingTab, data, isFetching, totalCount, items?.length, state.page])
 
   // Danh sách ngành cho filter dropdown (trình độ derive distinct degree_level).
+  // useMajorPrograms trả any (API client chưa typed) → ép MajorProgram[] để
+  // tránh implicit-any (CI noImplicitAny).
   const { data: majors } = useMajorPrograms()
   const majorOptions = useMemo(
     () =>
-      (majors ?? []).map((m) => ({
+      ((majors ?? []) as MajorProgram[]).map((m) => ({
         id: m.id,
         name: m.name,
         degree_level: m.degree_level,

--- a/frontend/src/hooks/finance/useInvoicesFilter.ts
+++ b/frontend/src/hooks/finance/useInvoicesFilter.ts
@@ -22,6 +22,7 @@ import type {
   FeeType,
   InvoiceFilters,
   InvoiceStatusCountFilters,
+  InvoiceWorkspaceFilters,
 } from "@/types/finance.types"
 import {
   INVOICES_DEFAULT_PAGE_SIZE,
@@ -55,6 +56,8 @@ export interface InvoicesFilterState extends StoredInvoiceFilters {
    * the workspace. Reflected in the URL for deep-link / back / reload-restore.
    */
   drawerProfileId: number | undefined
+  /** Workspace filters (ngành/trình độ/năm-HK/TVV/đơn vị/hạn). */
+  workspaceFilters: InvoiceWorkspaceFilters
 }
 
 export interface InvoicesFilterHandlers {
@@ -68,6 +71,11 @@ export interface InvoicesFilterHandlers {
   openDrawer: (profileId: number) => void
   /** Close the collection drawer (drops `?profile=`). */
   closeDrawer: () => void
+  /** Set/clear 1 workspace filter (undefined/null/"" = xoá). */
+  setWorkspaceFilter: <K extends keyof InvoiceWorkspaceFilters>(
+    key: K,
+    value: InvoiceWorkspaceFilters[K],
+  ) => void
 }
 
 export interface UseInvoicesFilterReturn {
@@ -268,6 +276,11 @@ export function useInvoicesFilter(
   const [drawerProfileId, setDrawerProfileId] = useState<number | undefined>(
     initialDrawerProfileId,
   )
+  // Workspace filters (ngành/trình độ/năm-HK/TVV/đơn vị/hạn). Session-only state
+  // (URL/localStorage persistence → follow-up). Đưa vào CẢ apiFilters lẫn
+  // countFilters để badge tab khớp danh sách (parity P1).
+  const [workspaceFilters, setWorkspaceFilters] =
+    useState<InvoiceWorkspaceFilters>({})
 
   // Restore persisted filters only after hydration. URL params stay the source
   // of truth (server can render them; localStorage cannot).
@@ -419,6 +432,7 @@ export function useInvoicesFilter(
     setSortOrder(INVOICES_DEFAULT_SORT_ORDER)
     setFeeId(undefined)
     setProfileId(undefined)
+    setWorkspaceFilters({})
     setPage(1)
     clearFiltersFromStorage()
     // NOTE: deliberately does NOT close the drawer — "clear filters" is about the
@@ -428,6 +442,26 @@ export function useInvoicesFilter(
   const openDrawer = useCallback((id: number) => setDrawerProfileId(id), [])
   const closeDrawer = useCallback(() => setDrawerProfileId(undefined), [])
 
+  /** Set/clear 1 workspace filter (undefined/null/"" = xoá). Reset về trang 1. */
+  const setWorkspaceFilter = useCallback(
+    <K extends keyof InvoiceWorkspaceFilters>(
+      key: K,
+      value: InvoiceWorkspaceFilters[K],
+    ) => {
+      setWorkspaceFilters((prev) => {
+        const next = { ...prev }
+        if (value === undefined || value === null || (value as unknown) === "") {
+          delete next[key]
+        } else {
+          next[key] = value
+        }
+        return next
+      })
+      setPage(1)
+    },
+    [],
+  )
+
   // ── COMPUTED VALUES ───────────────────────────────────────────────────
   const hasActiveFilters = useMemo(() => {
     return !!(
@@ -435,9 +469,10 @@ export function useInvoicesFilter(
       feeType ||
       feeId !== undefined ||
       profileId !== undefined ||
-      activeTab !== "all"
+      activeTab !== "all" ||
+      Object.keys(workspaceFilters).length > 0
     )
-  }, [search, feeType, feeId, profileId, activeTab])
+  }, [search, feeType, feeId, profileId, activeTab, workspaceFilters])
 
   /** Params sent to useInvoices (list). */
   const apiFilters: InvoiceFilters = useMemo(() => {
@@ -446,6 +481,8 @@ export function useInvoicesFilter(
       page_size: pageSize,
       sort_by: sortBy as InvoiceFilters["sort_by"],
       sort_order: sortOrder,
+      // Workspace filters (ngành/trình độ/năm-HK/TVV/đơn vị/hạn).
+      ...workspaceFilters,
     }
 
     if (search) params.search = search
@@ -463,23 +500,30 @@ export function useInvoicesFilter(
     }
 
     return params
-  }, [page, pageSize, search, feeType, feeId, profileId, activeTab, sortBy, sortOrder])
+  }, [
+    page, pageSize, search, feeType, feeId, profileId, activeTab,
+    sortBy, sortOrder, workspaceFilters,
+  ])
 
-  /** Params for useInvoiceStatusCounts (context only: no status/page/sort). */
+  /**
+   * Params for useInvoiceStatusCounts (context only: no status/page/sort).
+   * PARITY (P1): workspaceFilters phải spread Y HỆT apiFilters, nếu không badge
+   * tab đếm lệch so với danh sách.
+   */
   const countFilters: InvoiceStatusCountFilters = useMemo(() => {
-    const params: InvoiceStatusCountFilters = {}
+    const params: InvoiceStatusCountFilters = { ...workspaceFilters }
     if (search) params.search = search
     if (feeType) params.fee_type = feeType as FeeType
     if (feeId !== undefined) params.fee_id = feeId
     if (profileId !== undefined) params.profile_id = profileId
     return params
-  }, [search, feeType, feeId, profileId])
+  }, [search, feeType, feeId, profileId, workspaceFilters])
 
   // ── RETURN ────────────────────────────────────────────────────────────
   return {
     state: {
       page, pageSize, search, feeType, activeTab, sortBy, sortOrder,
-      feeId, profileId, drawerProfileId,
+      feeId, profileId, drawerProfileId, workspaceFilters,
     },
     handlers: {
       setPage,
@@ -490,6 +534,7 @@ export function useInvoicesFilter(
       resetFilters,
       openDrawer,
       closeDrawer,
+      setWorkspaceFilter,
     },
     hasActiveFilters,
     apiFilters,

--- a/frontend/src/types/finance.types.ts
+++ b/frontend/src/types/finance.types.ts
@@ -217,7 +217,9 @@ export interface InvoiceListItem {
   profile_id: number | null
   profile_name: string | null
   profile_code: string | null
+  // Ngành/trình độ từ snapshot Fee.resolved_* (BE-owned, đúng NV admitted).
   program_name: string | null
+  degree_level: string | null
   officer_name: string | null
   fee_type: FeeType | null
   semester_no: number | null
@@ -337,10 +339,18 @@ export interface PaymentListItem {
   profile_name: string | null
   method_name: string | null
   created_by_name: string | null
+  // Người duyệt (checker) + thời điểm duyệt (drawer chi tiết).
+  verified_by_name: string | null
+  verified_at: string | null
+  // Nguồn thu (BE-owned): "online" | "import" | "manual".
+  source: PaymentSource
   // Role-aware maker-checker flags (computed by backend)
   can_verify: boolean
   can_reject: boolean
 }
+
+/** Nguồn thu của 1 payment (BE-owned, suy ra lúc đọc). */
+export type PaymentSource = "online" | "import" | "manual"
 
 // ============================================================================
 // OVERPAYMENT (from backend OverpaymentRecordResponse)
@@ -469,7 +479,10 @@ export interface ProfileCollectionIdentity {
   profile_id: number
   profile_code: string
   student_name: string | null
+  // CCCD đã che giữa (PII-safe). Ngành/trình độ từ snapshot Fee.resolved_*.
+  citizen_id_masked: string | null
   program_name: string | null
+  degree_level: string | null
   officer_name: string | null
   phone: string | null
 }
@@ -854,7 +867,24 @@ export interface FeeFilters {
   page_size?: number
 }
 
-export interface InvoiceFilters {
+/**
+ * Filter ngành/trình độ/năm-HK/TVV/đơn vị/hạn — BE đọc Fee.resolved_* (snapshot)
+ * cho ngành/trình độ. PHẢI đồng bộ với InvoiceStatusCountFilters để badge tab khớp.
+ */
+export interface InvoiceWorkspaceFilters {
+  major_id?: number
+  /** Trình độ: TEXT name khớp Fee.resolved_degree_level (vd "Cao đẳng"). */
+  degree_level?: string
+  academic_year?: number
+  semester_no?: number
+  officer_id?: number
+  /** Đơn vị: INTERSECT với scope IDOR (officer vẫn bị clamp). */
+  unit_id?: number
+  /** Hạn thanh toán: "due_soon_7d" (đến hạn ≤7 ngày, chưa thu) | "overdue". */
+  due_window?: "due_soon_7d" | "overdue"
+}
+
+export interface InvoiceFilters extends InvoiceWorkspaceFilters {
   page?: number
   page_size?: number
   /** Comma-separated status enum values (e.g. "issued,partial"). */
@@ -866,12 +896,23 @@ export interface InvoiceFilters {
   /** Derived overdue (issued/partial/overdue AND due<today). Use for "Quá hạn" tab. */
   overdue_only?: boolean
   search?: string
-  sort_by?: "priority" | "due_date" | "amount" | "status" | "created_at"
+  sort_by?:
+    | "priority"
+    | "due_date"
+    | "amount"
+    | "paid"
+    | "remaining"
+    | "status"
+    | "created_at"
   sort_order?: "asc" | "desc"
 }
 
-/** Query params for `GET /api/invoices/status-counts`. */
-export interface InvoiceStatusCountFilters {
+/**
+ * Query params for `GET /api/invoices/status-counts`. PARITY: mọi filter
+ * workspace (ngành/trình độ/năm-HK/TVV/đơn vị/hạn) phải có Ở ĐÂY y hệt list,
+ * nếu không badge tab đếm lệch.
+ */
+export interface InvoiceStatusCountFilters extends InvoiceWorkspaceFilters {
   fee_id?: number
   profile_id?: number
   fee_type?: FeeType


### PR DESCRIPTION
## Mục tiêu
Nâng cấp workspace **Thu học phí** (`/finance/invoices`) theo 4 yêu cầu:
1. **Filter**: Ngành học · Trình độ · Năm học/HK · Phụ trách (TVV) · Đơn vị · Hạn thanh toán.
2. **Tách cột** "Số tiền" → **Đã đóng** / **Còn lại** + sort theo từng cột.
3. **Drawer chi tiết**: CCCD (đã che), Ngành/Trình độ, và mỗi lần thu hiển thị **ai thu · lúc nào · ai duyệt · mã tham chiếu · nguồn** (Online/Qua import/Thu tay).
4. Hoàn thiện hiển thị.

## Kiến trúc cốt lõi — denormalize ngành lên `Fee`
Ngành đúng của hồ sơ **đa nguyện vọng** = NV **trúng tuyển**, chỉ resolve được runtime → không có cột SQL để lọc. Giải: **snapshot `Fee.resolved_major_id` / `resolved_degree_level` / `resolved_academic_info_id`** (migration `3a3edf2b968b`), ghi bởi **single-writer helper** `resnapshot_fee_academic_info_for_profile` (best-effort, fail-soft, skip fee đã huỷ) wire vào 7 site (calc/recalc/recalc-semester/application-fee/evaluate_cascade/promote_waitlist). Filter + list row + drawer + **status-counts đọc CHUNG** `Fee.resolved_*` → "lọc ngành A thì dòng hiện ngành A", badge tab khớp danh sách.

## Thay đổi chính
- **BE**: shared `_build_invoice_list_conditions` (parity list↔status-counts) + sort `paid|remaining` · drawer `ProfileCollectionIdentity` (CCCD masked + ngành snapshot) + `PaymentListItem` (`verified_by_name`/`verified_at`/`source`) · `PaymentRepository.get_imported_payment_ids` (harden jsonb).
- **FE**: hook `workspaceFilters` (parity) · `InvoiceFilterBar` dropdown Ngành/Trình độ/Hạn · `PaidCell`/`RemainingCell` · drawer render CCCD/nguồn/người-duyệt.
- **Casbin**: grant `GET /api/programs` cho finance roles (migration `tcf20260626001`) — filter Ngành hết 403.

## Đã qua /code-review max (10 angle) + 2 blocker → ĐÃ FIX
- Blocker filter Ngành 403 (Casbin grant) · thiếu test P1 (8 integration test) · reuse mask util · raw-SQL→repo+jsonb-harden · best-effort snapshot · skip cancelled fee.

## Test
- Integration **8** (`test_fee_resolved_snapshot.py`: multi-NV admitted≠NV gốc · parity list==counts · fail-soft · skip-cancelled · refresh-after-decision · app-fee-NULL→resnapshot) + unit **8** (source resolver).
- Regression XANH: fee_calc/invoice/app_fee **97** · payment_import **129** · FE vitest **1727** · type-check PASS · lint 0 error.

## ⚠️ Deploy (KHÔNG code-only)
1. `alembic upgrade head` — 2 migration: `3a3edf2b968b` (Fee.resolved_*) + `tcf20260626001` (Casbin /api/programs).
2. `python -m app.scripts.backfill_fee_resolved_major` — điền `resolved_*` cho fee CŨ (nếu không, dữ liệu cũ hiện "(chưa chốt ngành)" + filter rỗng).
3. **Restart backend** — Casbin nạp grant `/api/programs` lúc startup.

## Defer (LOW, follow-up)
FE dropdown Năm-HK/TVV/Đơn vị (BE+hook đã sẵn) · wire resnapshot vào add/delete choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)