### PR TITLE
feat(finance): hoàn tất filter Thu học phí (năm/HK/TVV/đơn vị) + resnapshot NV + Casbin picker

### DIFF
--- a/Backend_FastAPI/alembic/versions/tcf20260627001_casbin_accountant_admin_users_picker_grant.py
+++ b/Backend_FastAPI/alembic/versions/tcf20260627001_casbin_accountant_admin_users_picker_grant.py
@@ -1,0 +1,67 @@
+"""Grant accountant GET /api/admin/users for finance picker filters.
+
+The endpoint intentionally returns the sanitized UserPickerSchema for
+non-admin callers. Finance invoice filters need the officer picker, but
+accountant did not have a direct runtime Casbin grant, so Chrome smoke hit
+403 on /api/admin/users even though the UI route was otherwise accessible.
+
+Revision ID: tcf20260627001
+Revises: tcf20260626001
+Create Date: 2026-06-27
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+
+revision = "tcf20260627001"
+down_revision = "tcf20260626001"
+branch_labels = None
+depends_on = None
+
+
+_SUBJECT = "role:accountant"
+_OBJECT = "/api/admin/users"
+_ACTION = "GET"
+
+
+def upgrade() -> None:
+    op.execute(
+        text(
+            f"""
+            INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id, applied_at)
+            SELECT 'p', '{_SUBJECT}', '{_OBJECT}', '{_ACTION}', 'allow', 'accountant', NOW()
+            WHERE NOT EXISTS (
+                SELECT 1 FROM casbin_rule
+                WHERE ptype = 'p' AND v0 = '{_SUBJECT}' AND v1 = '{_OBJECT}' AND v2 = '{_ACTION}'
+            )
+            """
+        )
+    )
+    op.execute(
+        text(
+            f"""
+            UPDATE casbin_rule SET v3 = CAST('allow' AS VARCHAR)
+            WHERE ptype = 'p'
+              AND v0 = '{_SUBJECT}'
+              AND v1 = '{_OBJECT}'
+              AND v2 = '{_ACTION}'
+              AND v3 IS NULL
+            """
+        )
+    )
+    print(f"[tcf20260627001] Seeded {_SUBJECT} {_ACTION} {_OBJECT} (eft=allow)")
+
+
+def downgrade() -> None:
+    op.execute(
+        text(
+            f"""
+            DELETE FROM casbin_rule
+            WHERE ptype = 'p'
+              AND v0 = '{_SUBJECT}'
+              AND v1 = '{_OBJECT}'
+              AND v2 = '{_ACTION}'
+            """
+        )
+    )

--- a/Backend_FastAPI/alembic/versions/tcf20260627002_casbin_smoke_picker_support_grants.py
+++ b/Backend_FastAPI/alembic/versions/tcf20260627002_casbin_smoke_picker_support_grants.py
@@ -7,14 +7,18 @@ queries while the invoice filter picker APIs are loading.
 All three grants below ALREADY exist as template policy
 (``policy_templates.py``): ``/api/notifications/preferences`` GET in
 ``BASIC_USER_TEMPLATE``; ``/api/finance/dashboard`` GET in
-``ACCOUNTANT_TEMPLATE``; ``/api/organization-units`` GET in
+``ACCOUNTANT_TEMPLATE``; ``/api/organization-units`` GET in BOTH
 ``OFFICER_TEMPLATE`` (accountant inherits it via the ``role:accountant ->
-role:officer`` g-edge). This migration only HEALS runtime drift — it re-seeds
-rows the templates guarantee but that a stale runtime policy table may be
-missing. The ``/api/organization-units`` direct accountant grant is also a
-defensive belt-and-braces for the new "Đơn vị" invoice filter dropdown, since
-runtime inheritance has drifted before (cf. ``tcf20260626001`` for
-``/api/programs`` and ``tcf20260627001`` for ``/api/admin/users``).
+role:officer`` g-edge) AND, declared directly, ``ACCOUNTANT_TEMPLATE`` (so a
+``refresh_role_from_template`` re-sync that wipes+re-adds only a role's own
+template rows keeps this direct accountant grant — without the template entry
+the re-sync would drop the runtime row seeded here). This migration only HEALS
+runtime drift — it re-seeds rows the templates guarantee but that a stale
+runtime policy table may be missing. The ``/api/organization-units`` direct
+accountant grant is defensive belt-and-braces for the new "Đơn vị" invoice
+filter dropdown, since runtime inheritance has drifted before (cf.
+``tcf20260626001`` for ``/api/programs`` and ``tcf20260627001`` for
+``/api/admin/users``).
 
 Because the grants are template-owned, ``downgrade()`` is intentionally a
 no-op: ``upgrade()`` is conditional (``WHERE NOT EXISTS``) so on a normal env

--- a/Backend_FastAPI/alembic/versions/tcf20260627002_casbin_smoke_picker_support_grants.py
+++ b/Backend_FastAPI/alembic/versions/tcf20260627002_casbin_smoke_picker_support_grants.py
@@ -1,0 +1,86 @@
+"""Seed missing read grants surfaced by finance Chrome smoke.
+
+The finance invoice page loads inside the shared dashboard shell. For an
+accountant session, Chrome smoke must not produce background 403s from shell
+queries while the invoice filter picker APIs are loading.
+
+All three grants below ALREADY exist as template policy
+(``policy_templates.py``): ``/api/notifications/preferences`` GET in
+``BASIC_USER_TEMPLATE``; ``/api/finance/dashboard`` GET in
+``ACCOUNTANT_TEMPLATE``; ``/api/organization-units`` GET in
+``OFFICER_TEMPLATE`` (accountant inherits it via the ``role:accountant ->
+role:officer`` g-edge). This migration only HEALS runtime drift — it re-seeds
+rows the templates guarantee but that a stale runtime policy table may be
+missing. The ``/api/organization-units`` direct accountant grant is also a
+defensive belt-and-braces for the new "Đơn vị" invoice filter dropdown, since
+runtime inheritance has drifted before (cf. ``tcf20260626001`` for
+``/api/programs`` and ``tcf20260627001`` for ``/api/admin/users``).
+
+Because the grants are template-owned, ``downgrade()`` is intentionally a
+no-op: ``upgrade()`` is conditional (``WHERE NOT EXISTS``) so on a normal env
+the rows pre-date this migration, and an unconditional delete on downgrade
+would strip legitimate template policy (403s on the finance dashboard /
+notification preferences / unit picker) rather than reverting only what this
+migration created.
+
+Revision ID: tcf20260627002
+Revises: tcf20260627001
+Create Date: 2026-06-27
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+
+revision = "tcf20260627002"
+down_revision = "tcf20260627001"
+branch_labels = None
+depends_on = None
+
+
+_GRANTS = [
+    # Basic self-service notification preferences; inherited by staff roles.
+    ("role:user", "/api/notifications/preferences", "GET", "user"),
+    # Finance overview request used by finance workspace shell/cards.
+    ("role:accountant", "/api/finance/dashboard", "GET", "accountant"),
+    # Unit list powering the new "Đơn vị" invoice filter dropdown. Officer-tier
+    # endpoint (accountant inherits) — direct grant heals any runtime drift.
+    ("role:accountant", "/api/organization-units", "GET", "accountant"),
+]
+
+
+def upgrade() -> None:
+    for v0, v1, v2, template_id in _GRANTS:
+        op.execute(
+            text(
+                f"""
+                INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, template_id, applied_at)
+                SELECT 'p', '{v0}', '{v1}', '{v2}', 'allow', '{template_id}', NOW()
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM casbin_rule
+                    WHERE ptype = 'p' AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+                )
+                """
+            )
+        )
+        # Self-heal any pre-existing row with a NULL eft (v3) — without
+        # 'allow' the policy is dropped on load_policy.
+        op.execute(
+            text(
+                f"""
+                UPDATE casbin_rule SET v3 = CAST('allow' AS VARCHAR)
+                WHERE ptype = 'p'
+                  AND v3 IS NULL
+                  AND v0 = '{v0}' AND v1 = '{v1}' AND v2 = '{v2}'
+                """
+            )
+        )
+    print(f"[tcf20260627002] Seeded {len(_GRANTS)} smoke support Casbin grants")
+
+
+def downgrade() -> None:
+    # No-op by design: every grant above is template-owned policy that
+    # pre-dates this migration (upgrade is conditional WHERE NOT EXISTS).
+    # Deleting them on downgrade would remove legitimate template grants,
+    # not revert this migration's own additions.
+    pass

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -346,6 +346,13 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         # Picker data for finance filters. The route returns UserPickerSchema
         # for non-admin roles, so accountant can load TVV dropdowns without PII.
         {"subject": "{role}", "object": "/api/admin/users", "action": "GET"},
+        # Đơn vị dropdown for the invoice filters. Officer-tier read (accountant
+        # inherits it via the g-edge), but declared DIRECTLY here too so a
+        # template re-sync (refresh_role_from_template wipes a role's runtime
+        # rows then re-adds only its template rows) keeps the defensive grant the
+        # tcf20260627002 migration seeds — otherwise the direct runtime grant
+        # would be dropped on the next sync, leaving inheritance-only.
+        {"subject": "{role}", "object": "/api/organization-units", "action": "GET"},
 
         # FEES - Read + Calculate + Waive + Recalculate (not Cancel - admin only)
         {"subject": "{role}", "object": "/api/fees", "action": "GET"},

--- a/Backend_FastAPI/app/casbin_config/policy_templates.py
+++ b/Backend_FastAPI/app/casbin_config/policy_templates.py
@@ -343,6 +343,10 @@ ACCOUNTANT_TEMPLATE: PolicyTemplate = {
         {"subject": "{role}", "object": "/api/finance/dashboard", "action": "GET"},
         {"subject": "{role}", "object": "/api/finance/debt-report", "action": "GET"},
 
+        # Picker data for finance filters. The route returns UserPickerSchema
+        # for non-admin roles, so accountant can load TVV dropdowns without PII.
+        {"subject": "{role}", "object": "/api/admin/users", "action": "GET"},
+
         # FEES - Read + Calculate + Waive + Recalculate (not Cancel - admin only)
         {"subject": "{role}", "object": "/api/fees", "action": "GET"},
         {"subject": "{role}", "object": "/api/fees/{id}", "action": "GET"},

--- a/Backend_FastAPI/app/services/admission_choice_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_service.py
@@ -235,6 +235,8 @@ class AdmissionChoiceService:
                 "hoặc cùng thứ tự ưu tiên."
             ) from exc
 
+        await self._resnapshot_fee_academic_info(profile)
+
         return choice, _noop_callback
 
     async def list_choices(
@@ -384,6 +386,8 @@ class AdmissionChoiceService:
             changes={"before": snapshot, "reason": reason},
         )
 
+        await self._resnapshot_fee_academic_info(profile)
+
         return ({"choice_id": choice.id, "profile_id": profile.id},
                 _noop_callback)
 
@@ -499,16 +503,32 @@ class AdmissionChoiceService:
                 path_subject_group_config_id=choice.path_subject_group_config_id,
                 scores=scores,
             )
-
-        # Expire choice's loaded scores collection so the subsequent eager
-        # re-fetch in router sees the new rows (identity-map cache safety).
-        self.db.expire(choice, attribute_names=["scores"])
+            # _snapshot_and_store_scores already expires choice.scores.
+        else:
+            # Clear-all path skips the helper, so expire here so the router's
+            # subsequent eager re-fetch sees the empty collection instead of the
+            # stale pre-bulk-delete one (identity-map cache safety).
+            self.db.expire(choice, attribute_names=["scores"])
 
         return choice, _noop_callback
 
     # ============================================================
     # Internal helpers
     # ============================================================
+
+    async def _resnapshot_fee_academic_info(
+        self, profile: AdmissionProfile
+    ) -> None:
+        """Best-effort refresh of Fee.resolved_* after NV structure changes."""
+        from app.services.fee_calculation_service import (
+            resnapshot_fee_academic_info_for_profile,
+        )
+
+        await resnapshot_fee_academic_info_for_profile(
+            self.db,
+            profile.id,
+            profile=profile,
+        )
 
     def _assert_choice_editable(
         self, profile: AdmissionProfile, *, action: str
@@ -675,3 +695,5 @@ class AdmissionChoiceService:
                 weight_snapshot=wt_snap,
                 min_possible_score_snapshot=min_snap,
             )
+
+        self.db.expire(choice, attribute_names=["scores"])

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -286,14 +286,25 @@ async def resnapshot_fee_academic_info_for_profile(
     # is the common state while a draft is built choice-by-choice — the new
     # add_choice/delete_choice callers fire on every NV mutation, long before
     # any fee exists. Bỏ qua fee đã huỷ — không relabel lịch sử theo ngành.
-    fees = (
-        await db.execute(
-            select(Fee).where(
-                Fee.admission_profile_id == profile_id,
-                Fee.status != "cancelled",
+    # Kept under the best-effort umbrella: this function MUST NOT raise into the
+    # money-creating callers, so a failing db.execute here returns 0 (same
+    # fail-soft contract the resolve block below has) rather than propagating.
+    try:
+        fees = (
+            await db.execute(
+                select(Fee).where(
+                    Fee.admission_profile_id == profile_id,
+                    Fee.status != "cancelled",
+                )
             )
+        ).scalars().all()
+    except Exception as exc:  # best-effort: KHÔNG để snapshot vỡ money flow
+        log.error(
+            "resnapshot_fee_academic_info_failed",
+            profile_id=profile_id,
+            error=str(exc),
         )
-    ).scalars().all()
+        return 0
     if not fees:
         return 0
 

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -281,6 +281,22 @@ async def resnapshot_fee_academic_info_for_profile(
     if profile is None:
         return 0
 
+    # Cheap existence guard FIRST: a profile with no non-cancelled fee has
+    # nothing to stamp, so skip the (multi-query) ngành resolve entirely. This
+    # is the common state while a draft is built choice-by-choice — the new
+    # add_choice/delete_choice callers fire on every NV mutation, long before
+    # any fee exists. Bỏ qua fee đã huỷ — không relabel lịch sử theo ngành.
+    fees = (
+        await db.execute(
+            select(Fee).where(
+                Fee.admission_profile_id == profile_id,
+                Fee.status != "cancelled",
+            )
+        )
+    ).scalars().all()
+    if not fees:
+        return 0
+
     resolved_ai_id: Optional[int] = None
     resolved_major_id: Optional[int] = None
     resolved_degree_level: Optional[str] = None
@@ -321,21 +337,11 @@ async def resnapshot_fee_academic_info_for_profile(
         )
         return 0
 
-    # Bỏ qua fee đã huỷ — không relabel lịch sử theo ngành admitted hiện tại.
-    fees = (
-        await db.execute(
-            select(Fee).where(
-                Fee.admission_profile_id == profile_id,
-                Fee.status != "cancelled",
-            )
-        )
-    ).scalars().all()
     for fee in fees:
         fee.resolved_academic_info_id = resolved_ai_id
         fee.resolved_major_id = resolved_major_id
         fee.resolved_degree_level = resolved_degree_level
-    if fees:
-        await db.flush()
+    await db.flush()
     return len(fees)
 
 

--- a/Backend_FastAPI/tests/api/test_finance_api.py
+++ b/Backend_FastAPI/tests/api/test_finance_api.py
@@ -1026,9 +1026,14 @@ class TestDiamondInheritance:
             if p.get("eft", "allow") == "allow"
         }
 
-        # Manager-exclusive objects (user management, admission workflow)
+        # Manager-exclusive objects (user management, admission workflow).
+        # NOTE: ``/api/admin/users`` is NO LONGER object-level manager-exclusive —
+        # accountant now has a GET grant returning the sanitized UserPickerSchema
+        # (no PII, read-only) to power the finance TVV filter picker
+        # (tcf20260627001). The WRITE-side separation (accountant must not MANAGE
+        # users) is still enforced action-level by
+        # ``test_accountant_does_not_have_user_management`` ((/api/admin/users, .*)).
         manager_exclusive = {
-            "/api/admin/users",
             "/api/leads/bulk-assign",
             "/api/leads/distribution-preview",
             "/api/admissions/{id}/approve",

--- a/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
+++ b/Backend_FastAPI/tests/api/test_phase3_pr3d_b_choice_crud.py
@@ -155,6 +155,7 @@ async def pr3a_seed(seed_lead_dependencies: dict) -> dict:
                 "subject_id": subj.id,
                 "round_id": round_id,
                 "lead_id": lead.id,
+                "major_program_id": seed_lead_dependencies["major_program_id"],
             }
 
 
@@ -829,6 +830,115 @@ async def _insert_tuition_fee(profile_id: int, status: str = "calculated") -> in
             s.add(fee)
             await s.flush()
             return fee.id
+
+
+async def _insert_application_fee(profile_id: int) -> int:
+    """Insert a minimal application Fee row that must NOT freeze NV edits."""
+    from app.models.finance import Fee
+
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            fee = Fee(
+                admission_profile_id=profile_id,
+                fee_type="application",
+                academic_year=2026,
+                semester_no=None,
+                base_amount=Decimal("200000"),
+                total_discount=Decimal("0"),
+                final_amount=Decimal("200000"),
+                paid_amount=Decimal("0"),
+                waived_amount=Decimal("0"),
+                status="calculated",
+                version=1,
+            )
+            s.add(fee)
+            await s.flush()
+            return fee.id
+
+
+async def _get_fee_resolved_snapshot(fee_id: int) -> tuple[int | None, str | None]:
+    from app.models.finance import Fee
+
+    async with AsyncSessionLocal() as s:
+        fee = await s.get(Fee, fee_id)
+        assert fee is not None
+        return fee.resolved_major_id, fee.resolved_degree_level
+
+
+@pytest.mark.asyncio
+async def test_add_choice_resnapshots_existing_application_fee(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3a_seed: dict,
+):
+    """Adding the first NV refreshes existing non-tuition fee snapshots.
+
+    Application fees do not freeze NV edits, but their finance workspace row
+    still reads Fee.resolved_*; without this hook the row stays NULL until the
+    next fee operation.
+    """
+    fee_id = await _insert_application_fee(pr3a_seed["profile_id"])
+    before_major_id, before_degree = await _get_fee_resolved_snapshot(fee_id)
+    assert before_major_id is None
+    assert before_degree is None
+
+    resp = await client.post(
+        f"/api/v2/admissions/{pr3a_seed['profile_id']}/choices",
+        headers=manager_token_headers,
+        json={
+            "admission_path_id": pr3a_seed["path_id"],
+            "path_subject_group_config_id": pr3a_seed["config_id"],
+            "display_order": 1,
+            "scores": [{"subject_id": pr3a_seed["subject_id"], "score": "8.50"}],
+        },
+    )
+    assert resp.status_code == 201, resp.text[:300]
+
+    after_major_id, after_degree = await _get_fee_resolved_snapshot(fee_id)
+    assert after_major_id == pr3a_seed["major_program_id"]
+    assert after_degree is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_choice_resnapshots_application_fee_to_null(
+    client: AsyncClient,
+    manager_token_headers: dict,
+    pr3d_b_seed_with_choice: dict,
+):
+    """Deleting the last NV clears existing non-tuition fee snapshots."""
+    from app.services.fee_calculation_service import (
+        resnapshot_fee_academic_info_for_profile,
+    )
+
+    fee_id = await _insert_application_fee(pr3d_b_seed_with_choice["profile_id"])
+
+    async with AsyncSessionLocal() as s:
+        async with s.begin():
+            profile = await s.get(
+                models.AdmissionProfile,
+                pr3d_b_seed_with_choice["profile_id"],
+            )
+            assert profile is not None
+            await resnapshot_fee_academic_info_for_profile(
+                s,
+                profile.id,
+                profile=profile,
+            )
+
+    before_major_id, before_degree = await _get_fee_resolved_snapshot(fee_id)
+    assert before_major_id == pr3d_b_seed_with_choice["major_program_id"]
+    assert before_degree is not None
+
+    resp = await client.delete(
+        f"/api/v2/admissions/{pr3d_b_seed_with_choice['profile_id']}"
+        f"/choices/{pr3d_b_seed_with_choice['choice_id']}",
+        headers=manager_token_headers,
+    )
+    assert resp.status_code == 200, resp.text[:300]
+
+    after_major_id, after_degree = await _get_fee_resolved_snapshot(fee_id)
+    assert after_major_id is None
+    assert after_degree is None
 
 
 @pytest_asyncio.fixture

--- a/Backend_FastAPI/tests/api/test_qa_e2e_findings_2026_05_16.py
+++ b/Backend_FastAPI/tests/api/test_qa_e2e_findings_2026_05_16.py
@@ -24,13 +24,46 @@ testing 2026-05-15 → documented in
 from __future__ import annotations
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy import text
 
+from app import models
 from app.database import AsyncSessionLocal
+from app.main import fastapi_app
+from app.security import get_password_hash
+from tests.fixtures.constants import AuthURLs
+from tests.fixtures.users import create_user_with_role, get_auth_headers
 
 
 pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def accountant_token_headers(client: AsyncClient) -> dict:
+    """Accountant auth headers for picker-shape regression tests."""
+    try:
+        from casbin_async_sqlalchemy_adapter import CasbinRule
+    except ImportError:  # pragma: no cover
+        CasbinRule = None
+
+    info = await create_user_with_role(
+        session_factory=AsyncSessionLocal,
+        user_data={
+            "username": "qa_picker_accountant",
+            "email": "qa_picker_accountant@test.com",
+            "password": "AcctPicker123!",
+            "role": "accountant",
+            "status": "active",
+        },
+        casbin_role="role:accountant",
+        unit_id=None,
+        models=models,
+        get_password_hash=get_password_hash,
+        CasbinRule=CasbinRule,
+        app=fastapi_app,
+    )
+    return await get_auth_headers(client, info, AuthURLs.LOGIN)
 
 
 # =====================================================================
@@ -181,6 +214,57 @@ async def test_admin_users_endpoint_strips_pii_for_officer(
     )
 
     # Required UserPickerSchema fields MUST present (positive contract)
+    required_keys = {"id", "username", "full_name", "role", "status"}
+    missing = required_keys - set(sample_user.keys())
+    assert not missing, (
+        f"UserPickerSchema missing required fields: {missing}. "
+        f"Got: {list(sample_user.keys())}"
+    )
+
+
+async def test_admin_users_endpoint_strips_pii_for_accountant(
+    client: AsyncClient,
+    accountant_token_headers: dict,
+    officer_user_in_db: dict,
+) -> None:
+    """GET /api/admin/users for accountant powers finance TVV picker.
+
+    It must be allowed, but still return the sanitized UserPickerSchema shape.
+
+    ``officer_user_in_db`` seeds a ``role=officer status=active`` user so the
+    ``role=officer&status=active`` query (mirroring the finance TVV picker)
+    returns ≥1 row — otherwise ``body["users"]`` is empty and every PII/shape
+    assertion below would be skipped, leaving the regression sentinel inert.
+    """
+    response = await client.get(
+        "/api/admin/users?page_size=2&role=officer&status=active",
+        headers=accountant_token_headers,
+    )
+    assert response.status_code == 200, (
+        f"Accountant GET /api/admin/users must remain 200 for finance picker; "
+        f"got {response.status_code}: {response.text[:200]}"
+    )
+
+    body = response.json()
+    assert "users" in body and len(body["users"]) > 0, (
+        "Response must contain the seeded active officer so the PII/shape "
+        "assertions actually run; got: " + str(body)
+    )
+
+    forbidden_keys = {
+        "email",
+        "phone_number",
+        "mfa_enabled",
+        "password_reset_required",
+        "max_capacity",
+    }
+    sample_user = body["users"][0]
+    leaked_keys = forbidden_keys & set(sample_user.keys())
+    assert not leaked_keys, (
+        f"F3 regression - accountant response leaks PII keys: {leaked_keys}. "
+        f"Should be UserPickerSchema. Full keys returned: {list(sample_user.keys())}"
+    )
+
     required_keys = {"id", "username", "full_name", "role", "status"}
     missing = required_keys - set(sample_user.keys())
     assert not missing, (

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceFilterBar.test.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceFilterBar.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
+import { fireEvent, render, screen } from "@/test/utils/test-utils"
+
+import { InvoiceFilterBar } from "./InvoiceFilterBar"
+import type { InvoiceWorkspaceFilters } from "@/types/finance.types"
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode
+    onClick?: () => void
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}))
+
+function renderFilterBar(workspaceFilters: InvoiceWorkspaceFilters = {}) {
+  const setWorkspaceFilter = vi.fn()
+
+  render(
+    <InvoiceFilterBar
+      search=""
+      onSearchChange={vi.fn()}
+      feeType=""
+      onFeeTypeChange={vi.fn()}
+      sortBy="priority"
+      sortOrder="asc"
+      onSortChange={vi.fn()}
+      hasActiveFilters={Object.keys(workspaceFilters).length > 0}
+      onReset={vi.fn()}
+      workspaceFilters={workspaceFilters}
+      setWorkspaceFilter={setWorkspaceFilter}
+      majorOptions={[{ id: 11, name: "Công nghệ thông tin", degree_level: "Cao đẳng" }]}
+      academicYearOptions={[2026, 2025]}
+      semesterOptions={[1, 2, 3]}
+      officerOptions={[{ id: 21, name: "Nguyễn Tư Vấn" }]}
+      unitOptions={[{ id: 31, name: "Cơ sở 1", level: 0 }]}
+    />,
+  )
+
+  return setWorkspaceFilter
+}
+
+describe("InvoiceFilterBar", () => {
+  it("sets academic year, semester, officer, and unit workspace filters", () => {
+    const setWorkspaceFilter = renderFilterBar()
+
+    fireEvent.click(screen.getByText("2026"))
+    expect(setWorkspaceFilter).toHaveBeenCalledWith("academic_year", 2026)
+
+    fireEvent.click(screen.getByText("HK2"))
+    expect(setWorkspaceFilter).toHaveBeenCalledWith("semester_no", 2)
+
+    fireEvent.click(screen.getByText("Nguyễn Tư Vấn"))
+    expect(setWorkspaceFilter).toHaveBeenCalledWith("officer_id", 21)
+
+    fireEvent.click(screen.getByText("Cơ sở 1"))
+    expect(setWorkspaceFilter).toHaveBeenCalledWith("unit_id", 31)
+  })
+
+  it("renders chips that clear the new workspace filters", () => {
+    const setWorkspaceFilter = renderFilterBar({
+      academic_year: 2026,
+      semester_no: 2,
+      officer_id: 21,
+      unit_id: 31,
+    })
+
+    fireEvent.click(screen.getByLabelText("Bỏ lọc Năm: 2026"))
+    expect(setWorkspaceFilter).toHaveBeenCalledWith("academic_year", undefined)
+
+    fireEvent.click(screen.getByLabelText("Bỏ lọc HK: 2"))
+    expect(setWorkspaceFilter).toHaveBeenCalledWith("semester_no", undefined)
+
+    fireEvent.click(screen.getByLabelText("Bỏ lọc TVV: Nguyễn Tư Vấn"))
+    expect(setWorkspaceFilter).toHaveBeenCalledWith("officer_id", undefined)
+
+    fireEvent.click(screen.getByLabelText("Bỏ lọc Đơn vị: Cơ sở 1"))
+    expect(setWorkspaceFilter).toHaveBeenCalledWith("unit_id", undefined)
+  })
+})

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceFilterBar.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceFilterBar.tsx
@@ -2,13 +2,14 @@
 /**
  * Filter bar cho workspace "Thu học phí" (phỏng AdmissionsFilterBar).
  *
- * Bố cục: Search (tên HS / mã HS / số HĐ) · Loại phí (dropdown) · Sắp xếp
- * (dropdown) · "Xóa tất cả bộ lọc" · chips active. Thuần trình bày — đẩy qua
- * handler thật của useInvoicesFilter.
+ * Bố cục: Search (tên HS / mã HS / số HĐ) · Loại phí · Năm · HK · Ngành · Trình
+ * độ · TVV · Đơn vị · Hạn · Sắp xếp · "Xóa tất cả bộ lọc" · chips active. Thuần
+ * trình bày — đẩy qua handler thật của useInvoicesFilter.
  */
 
 "use client"
 
+import type { ReactNode } from "react"
 import { ArrowUpDown, Check, ChevronDown, Search, X } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -19,6 +20,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
 import {
   FEE_TYPE_LABELS,
   type FeeType,
@@ -29,6 +31,17 @@ export interface MajorFilterOption {
   id: number
   name: string
   degree_level: string
+}
+
+export interface OfficerFilterOption {
+  id: number
+  name: string
+}
+
+export interface UnitFilterOption {
+  id: number
+  name: string
+  level: number
 }
 
 const DUE_WINDOW_OPTIONS: readonly {
@@ -60,6 +73,89 @@ function feeTypeLabel(feeType: string): string {
   return FEE_TYPE_LABELS[feeType as FeeType] ?? feeType
 }
 
+/** One selectable row of a {@link FilterDropdown}. */
+interface FilterDropdownOption {
+  key: string | number
+  label: string
+  active: boolean
+  onSelect: () => void
+  /** Hierarchy indentation in px (unit tree). Omitted = flat. */
+  indentPx?: number
+}
+
+/**
+ * Single-select dropdown filter (trigger button + "all" reset row + options
+ * with a Check on the active one). Replaces 7 near-identical inline blocks.
+ */
+function FilterDropdown({
+  ariaLabel,
+  triggerLabel,
+  triggerClassName,
+  contentClassName,
+  truncateTrigger = false,
+  allLabel,
+  allActive,
+  onSelectAll,
+  options,
+  truncateItems = false,
+}: {
+  ariaLabel: string
+  triggerLabel: ReactNode
+  triggerClassName?: string
+  contentClassName: string
+  truncateTrigger?: boolean
+  allLabel: string
+  allActive: boolean
+  onSelectAll: () => void
+  options: readonly FilterDropdownOption[]
+  truncateItems?: boolean
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn("h-10 gap-1.5", triggerClassName)}
+          aria-label={ariaLabel}
+        >
+          {truncateTrigger ? <span className="truncate">{triggerLabel}</span> : triggerLabel}
+          <ChevronDown
+            className={cn("size-4 text-muted-foreground", truncateTrigger && "shrink-0")}
+            aria-hidden="true"
+          />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className={contentClassName}>
+        <DropdownMenuItem className="justify-between" onClick={onSelectAll}>
+          {allLabel}
+          {allActive && <Check className="size-4" />}
+        </DropdownMenuItem>
+        {options.map((o) => (
+          <DropdownMenuItem
+            key={o.key}
+            className={cn("justify-between", truncateItems && "gap-2")}
+            onClick={o.onSelect}
+          >
+            {truncateItems ? (
+              <span
+                className="truncate"
+                style={o.indentPx ? { paddingLeft: o.indentPx } : undefined}
+              >
+                {o.label}
+              </span>
+            ) : (
+              o.label
+            )}
+            {o.active && (
+              <Check className={cn("size-4", truncateItems && "shrink-0")} />
+            )}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
 export interface InvoiceFilterBarProps {
   search: string
   onSearchChange: (value: string) => void
@@ -70,14 +166,18 @@ export interface InvoiceFilterBarProps {
   onSortChange: (sortBy: string, sortOrder: "asc" | "desc") => void
   hasActiveFilters: boolean
   onReset: () => void
-  // Workspace filters (ngành/trình độ/hạn). majorOptions = danh sách ngành để
-  // chọn; trình độ derive từ distinct degree_level của majorOptions.
+  // Workspace filters (ngành/trình độ/năm-HK/TVV/đơn vị/hạn). majorOptions =
+  // danh sách ngành; trình độ derive từ distinct degree_level của majorOptions.
   workspaceFilters: InvoiceWorkspaceFilters
   setWorkspaceFilter: <K extends keyof InvoiceWorkspaceFilters>(
     key: K,
     value: InvoiceWorkspaceFilters[K],
   ) => void
   majorOptions: readonly MajorFilterOption[]
+  academicYearOptions: readonly number[]
+  semesterOptions: readonly number[]
+  officerOptions: readonly OfficerFilterOption[]
+  unitOptions: readonly UnitFilterOption[]
 }
 
 export function InvoiceFilterBar({
@@ -93,8 +193,14 @@ export function InvoiceFilterBar({
   workspaceFilters,
   setWorkspaceFilter,
   majorOptions,
+  academicYearOptions,
+  semesterOptions,
+  officerOptions,
+  unitOptions,
 }: InvoiceFilterBarProps) {
   const selectedMajor = majorOptions.find((m) => m.id === workspaceFilters.major_id)
+  const selectedOfficer = officerOptions.find((o) => o.id === workspaceFilters.officer_id)
+  const selectedUnit = unitOptions.find((u) => u.id === workspaceFilters.unit_id)
   // Trình độ: distinct degree_level từ danh sách ngành (gửi TEXT name xuống BE).
   const degreeOptions = Array.from(
     new Set(majorOptions.map((m) => m.degree_level).filter(Boolean)),
@@ -105,6 +211,20 @@ export function InvoiceFilterBar({
   const chips: Chip[] = []
   if (feeType) {
     chips.push({ key: "fee_type", label: `Loại: ${feeTypeLabel(feeType)}`, onRemove: () => onFeeTypeChange("") })
+  }
+  if (workspaceFilters.academic_year) {
+    chips.push({
+      key: "academic_year",
+      label: `Năm: ${workspaceFilters.academic_year}`,
+      onRemove: () => setWorkspaceFilter("academic_year", undefined),
+    })
+  }
+  if (workspaceFilters.semester_no) {
+    chips.push({
+      key: "semester_no",
+      label: `HK: ${workspaceFilters.semester_no}`,
+      onRemove: () => setWorkspaceFilter("semester_no", undefined),
+    })
   }
   if (selectedMajor) {
     chips.push({
@@ -118,6 +238,24 @@ export function InvoiceFilterBar({
       key: "degree",
       label: `Trình độ: ${workspaceFilters.degree_level}`,
       onRemove: () => setWorkspaceFilter("degree_level", undefined),
+    })
+  }
+  // TVV/Đơn vị chips render from the RAW filter value (not the options lookup)
+  // with a #id fallback label — so a selected officer/unit that drops out of
+  // the options list (deactivated, refetch, >500 cap) stays VISIBLE and
+  // clearable instead of silently filtering with no chip.
+  if (workspaceFilters.officer_id) {
+    chips.push({
+      key: "officer",
+      label: `TVV: ${selectedOfficer?.name ?? `#${workspaceFilters.officer_id}`}`,
+      onRemove: () => setWorkspaceFilter("officer_id", undefined),
+    })
+  }
+  if (workspaceFilters.unit_id) {
+    chips.push({
+      key: "unit",
+      label: `Đơn vị: ${selectedUnit?.name ?? `#${workspaceFilters.unit_id}`}`,
+      onRemove: () => setWorkspaceFilter("unit_id", undefined),
     })
   }
   if (workspaceFilters.due_window) {
@@ -161,85 +299,141 @@ export function InvoiceFilterBar({
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
-          {/* Fee type */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" className="h-10 gap-1.5" aria-label="Lọc theo loại phí">
-                {feeType ? feeTypeLabel(feeType) : "Tất cả loại phí"}
-                <ChevronDown className="size-4 text-muted-foreground" aria-hidden="true" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuItem className="justify-between" onClick={() => onFeeTypeChange("")}>
-                Tất cả loại phí
-                {!feeType && <Check className="size-4" />}
-              </DropdownMenuItem>
-              {FEE_TYPE_OPTIONS.map((o) => (
-                <DropdownMenuItem
-                  key={o.value}
-                  className="justify-between"
-                  onClick={() => onFeeTypeChange(o.value)}
-                >
-                  {o.label}
-                  {feeType === o.value && <Check className="size-4" />}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {/* Loại phí */}
+          <FilterDropdown
+            ariaLabel="Lọc theo loại phí"
+            triggerLabel={feeType ? feeTypeLabel(feeType) : "Tất cả loại phí"}
+            contentClassName="w-48"
+            allLabel="Tất cả loại phí"
+            allActive={!feeType}
+            onSelectAll={() => onFeeTypeChange("")}
+            options={FEE_TYPE_OPTIONS.map((o) => ({
+              key: o.value,
+              label: o.label,
+              active: feeType === o.value,
+              onSelect: () => onFeeTypeChange(o.value),
+            }))}
+          />
+
+          {/* Năm học */}
+          <FilterDropdown
+            ariaLabel="Lọc theo năm học"
+            triggerLabel={workspaceFilters.academic_year ?? "Mọi năm"}
+            contentClassName="max-h-80 w-36 overflow-y-auto"
+            allLabel="Mọi năm"
+            allActive={workspaceFilters.academic_year === undefined}
+            onSelectAll={() => setWorkspaceFilter("academic_year", undefined)}
+            options={academicYearOptions.map((year) => ({
+              key: year,
+              label: String(year),
+              active: workspaceFilters.academic_year === year,
+              onSelect: () => setWorkspaceFilter("academic_year", year),
+            }))}
+          />
+
+          {/* Học kỳ */}
+          <FilterDropdown
+            ariaLabel="Lọc theo học kỳ"
+            triggerLabel={workspaceFilters.semester_no ? `HK${workspaceFilters.semester_no}` : "Mọi HK"}
+            contentClassName="w-32"
+            allLabel="Mọi HK"
+            allActive={workspaceFilters.semester_no === undefined}
+            onSelectAll={() => setWorkspaceFilter("semester_no", undefined)}
+            options={semesterOptions.map((semester) => ({
+              key: semester,
+              label: `HK${semester}`,
+              active: workspaceFilters.semester_no === semester,
+              onSelect: () => setWorkspaceFilter("semester_no", semester),
+            }))}
+          />
 
           {/* Ngành */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" className="h-10 max-w-[14rem] gap-1.5" aria-label="Lọc theo ngành">
-                <span className="truncate">{selectedMajor ? selectedMajor.name : "Tất cả ngành"}</span>
-                <ChevronDown className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="max-h-80 w-64 overflow-y-auto">
-              <DropdownMenuItem className="justify-between" onClick={() => setWorkspaceFilter("major_id", undefined)}>
-                Tất cả ngành
-                {workspaceFilters.major_id === undefined && <Check className="size-4" />}
-              </DropdownMenuItem>
-              {majorOptions.map((m) => (
-                <DropdownMenuItem
-                  key={m.id}
-                  className="justify-between gap-2"
-                  onClick={() => setWorkspaceFilter("major_id", m.id)}
-                >
-                  <span className="truncate">{m.name}</span>
-                  {workspaceFilters.major_id === m.id && <Check className="size-4 shrink-0" />}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <FilterDropdown
+            ariaLabel="Lọc theo ngành"
+            triggerLabel={selectedMajor ? selectedMajor.name : "Tất cả ngành"}
+            triggerClassName="max-w-[14rem]"
+            truncateTrigger
+            contentClassName="max-h-80 w-64 overflow-y-auto"
+            allLabel="Tất cả ngành"
+            allActive={workspaceFilters.major_id === undefined}
+            onSelectAll={() => setWorkspaceFilter("major_id", undefined)}
+            options={majorOptions.map((m) => ({
+              key: m.id,
+              label: m.name,
+              active: workspaceFilters.major_id === m.id,
+              onSelect: () => setWorkspaceFilter("major_id", m.id),
+            }))}
+            truncateItems
+          />
 
           {/* Trình độ */}
           {degreeOptions.length > 0 && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" className="h-10 gap-1.5" aria-label="Lọc theo trình độ">
-                  {workspaceFilters.degree_level ?? "Mọi trình độ"}
-                  <ChevronDown className="size-4 text-muted-foreground" aria-hidden="true" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
-                <DropdownMenuItem className="justify-between" onClick={() => setWorkspaceFilter("degree_level", undefined)}>
-                  Mọi trình độ
-                  {!workspaceFilters.degree_level && <Check className="size-4" />}
-                </DropdownMenuItem>
-                {degreeOptions.map((d) => (
-                  <DropdownMenuItem
-                    key={d}
-                    className="justify-between"
-                    onClick={() => setWorkspaceFilter("degree_level", d)}
-                  >
-                    {d}
-                    {workspaceFilters.degree_level === d && <Check className="size-4" />}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <FilterDropdown
+              ariaLabel="Lọc theo trình độ"
+              triggerLabel={workspaceFilters.degree_level ?? "Mọi trình độ"}
+              contentClassName="w-48"
+              allLabel="Mọi trình độ"
+              allActive={!workspaceFilters.degree_level}
+              onSelectAll={() => setWorkspaceFilter("degree_level", undefined)}
+              options={degreeOptions.map((d) => ({
+                key: d,
+                label: d,
+                active: workspaceFilters.degree_level === d,
+                onSelect: () => setWorkspaceFilter("degree_level", d),
+              }))}
+            />
           )}
+
+          {/* Tư vấn viên */}
+          <FilterDropdown
+            ariaLabel="Lọc theo tư vấn viên"
+            triggerLabel={
+              selectedOfficer
+                ? selectedOfficer.name
+                : workspaceFilters.officer_id
+                  ? `TVV #${workspaceFilters.officer_id}`
+                  : "Tất cả TVV"
+            }
+            triggerClassName="max-w-[12rem]"
+            truncateTrigger
+            contentClassName="max-h-80 w-56 overflow-y-auto"
+            allLabel="Tất cả TVV"
+            allActive={workspaceFilters.officer_id === undefined}
+            onSelectAll={() => setWorkspaceFilter("officer_id", undefined)}
+            options={officerOptions.map((officer) => ({
+              key: officer.id,
+              label: officer.name,
+              active: workspaceFilters.officer_id === officer.id,
+              onSelect: () => setWorkspaceFilter("officer_id", officer.id),
+            }))}
+            truncateItems
+          />
+
+          {/* Đơn vị */}
+          <FilterDropdown
+            ariaLabel="Lọc theo đơn vị"
+            triggerLabel={
+              selectedUnit
+                ? selectedUnit.name
+                : workspaceFilters.unit_id
+                  ? `Đơn vị #${workspaceFilters.unit_id}`
+                  : "Tất cả đơn vị"
+            }
+            triggerClassName="max-w-[13rem]"
+            truncateTrigger
+            contentClassName="max-h-80 w-64 overflow-y-auto"
+            allLabel="Tất cả đơn vị"
+            allActive={workspaceFilters.unit_id === undefined}
+            onSelectAll={() => setWorkspaceFilter("unit_id", undefined)}
+            options={unitOptions.map((unit) => ({
+              key: unit.id,
+              label: unit.name,
+              active: workspaceFilters.unit_id === unit.id,
+              onSelect: () => setWorkspaceFilter("unit_id", unit.id),
+              indentPx: unit.level * 12,
+            }))}
+            truncateItems
+          />
 
           {/* Hạn thanh toán */}
           <DropdownMenu>

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceFilterBar.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceFilterBar.tsx
@@ -226,10 +226,15 @@ export function InvoiceFilterBar({
       onRemove: () => setWorkspaceFilter("semester_no", undefined),
     })
   }
-  if (selectedMajor) {
+  // Major/officer/unit chips all render from the RAW filter id with a #id
+  // fallback (not the options lookup) — so a selected value that drops out of
+  // its options list (archived major / deactivated officer / >500 cap /
+  // deep-linked URL) stays VISIBLE and clearable instead of silently filtering
+  // with no chip.
+  if (workspaceFilters.major_id) {
     chips.push({
       key: "major",
-      label: `Ngành: ${selectedMajor.name}`,
+      label: `Ngành: ${selectedMajor?.name ?? `#${workspaceFilters.major_id}`}`,
       onRemove: () => setWorkspaceFilter("major_id", undefined),
     })
   }
@@ -240,10 +245,6 @@ export function InvoiceFilterBar({
       onRemove: () => setWorkspaceFilter("degree_level", undefined),
     })
   }
-  // TVV/Đơn vị chips render from the RAW filter value (not the options lookup)
-  // with a #id fallback label — so a selected officer/unit that drops out of
-  // the options list (deactivated, refetch, >500 cap) stays VISIBLE and
-  // clearable instead of silently filtering with no chip.
   if (workspaceFilters.officer_id) {
     chips.push({
       key: "officer",
@@ -350,7 +351,13 @@ export function InvoiceFilterBar({
           {/* Ngành */}
           <FilterDropdown
             ariaLabel="Lọc theo ngành"
-            triggerLabel={selectedMajor ? selectedMajor.name : "Tất cả ngành"}
+            triggerLabel={
+              selectedMajor
+                ? selectedMajor.name
+                : workspaceFilters.major_id
+                  ? `Ngành #${workspaceFilters.major_id}`
+                  : "Tất cả ngành"
+            }
             triggerClassName="max-w-[14rem]"
             truncateTrigger
             contentClassName="max-h-80 w-64 overflow-y-auto"

--- a/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceListClient.tsx
+++ b/frontend/src/app/(dashboard)/finance/invoices/_components/InvoiceListClient.tsx
@@ -16,6 +16,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Receipt, Plus, ClipboardCheck } from "lucide-react"
 import { useMajorPrograms } from "@/hooks/admissions/useProgramData"
+import { useAdminUsersList } from "@/hooks/useAdminUsers"
+import { flattenOrganizationTree, useOrganizationUnits } from "@/hooks/useOrganization"
 import type { MajorProgram } from "@/types/organization.types"
 
 import { PageContainer } from "@/components/layouts/PageContainer"
@@ -37,6 +39,10 @@ import {
 } from "@/hooks/finance/useInvoiceViewModel"
 import { useInvoicesFilter } from "@/hooks/finance/useInvoicesFilter"
 import { INVOICE_STATUS_TABS } from "@/hooks/finance/filterDefaults"
+import {
+  INVOICE_SEMESTER_OPTIONS,
+  useInvoiceAcademicYears,
+} from "@/hooks/finance/useInvoiceFilterOptions"
 
 import { AdmissionsStatusTabs } from "@/app/(dashboard)/admissions/_components/AdmissionsStatusTabs"
 import {
@@ -108,7 +114,6 @@ export function InvoiceListClient() {
         qs ? `${window.location.pathname}?${qs}` : window.location.pathname,
       )
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // ── Density (SSR-safe; read localStorage after mount) ───────────────────
@@ -181,6 +186,37 @@ export function InvoiceListClient() {
         degree_level: m.degree_level,
       })),
     [majors],
+  )
+  const { data: academicYearOptions = [] } = useInvoiceAcademicYears()
+  // Picker for the "Tư vấn viên" filter. Intentionally NO status:'active'
+  // filter — an officer who handled invoices then got deactivated must stay
+  // selectable (their invoices still exist). Gated off the payment-queue tab
+  // (where the filter bar isn't rendered) so we don't eagerly pull ~500 user
+  // rows the user can't see.
+  const { data: officerPage } = useAdminUsersList(
+    {
+      role: "officer",
+      page_size: 500,
+    },
+    { enabled: !isPendingTab },
+  )
+  const officerOptions = useMemo(
+    () =>
+      (officerPage?.users ?? []).map((user) => ({
+        id: user.id,
+        name: user.full_name || user.username || `#${user.id}`,
+      })),
+    [officerPage],
+  )
+  const { data: unitTree = [] } = useOrganizationUnits()
+  const unitOptions = useMemo(
+    () =>
+      flattenOrganizationTree(unitTree).map(({ unit, level }) => ({
+        id: unit.id,
+        name: unit.name,
+        level,
+      })),
+    [unitTree],
   )
 
   // ── Row interactions (PR2) ──────────────────────────────────────────────
@@ -387,6 +423,10 @@ export function InvoiceListClient() {
             workspaceFilters={state.workspaceFilters}
             setWorkspaceFilter={handlers.setWorkspaceFilter}
             majorOptions={majorOptions}
+            academicYearOptions={academicYearOptions}
+            semesterOptions={INVOICE_SEMESTER_OPTIONS}
+            officerOptions={officerOptions}
+            unitOptions={unitOptions}
           />
         )}
 

--- a/frontend/src/hooks/finance/useInvoiceFilterOptions.ts
+++ b/frontend/src/hooks/finance/useInvoiceFilterOptions.ts
@@ -1,0 +1,27 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+
+import { api } from "@/lib/api/client"
+import { academicYearListResponseSchema } from "@/lib/zod/admission-path"
+
+export const INVOICE_SEMESTER_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8] as const
+
+export function useInvoiceAcademicYears() {
+  return useQuery<number[]>({
+    queryKey: ["finance", "invoice-filter-options", "academic-years"],
+    queryFn: async () => {
+      const response = await api.get("/api/admission-config/years")
+      // Validate against the shared schema (mirrors the backend Pydantic
+      // model). safeParse tolerates a null/empty body (204 / gateway edge)
+      // without throwing — degrade to an empty year list instead.
+      const parsed = academicYearListResponseSchema.safeParse(response.data)
+      if (!parsed.success) return []
+      const years = [parsed.data.current_year, ...parsed.data.years].filter(
+        (year): year is number => Number.isFinite(year),
+      )
+      return Array.from(new Set(years)).sort((a, b) => b - a)
+    },
+    staleTime: 10 * 60 * 1000,
+  })
+}


### PR DESCRIPTION
## Tóm tắt

Follow-up hoàn tất bảng **Thu học phí** (nối tiếp #438): bổ sung 4 dropdown filter còn thiếu (năm học / học kỳ / tư vấn viên / đơn vị) wire vào `_build_invoice_list_conditions` đã có sẵn, resnapshot `Fee.resolved_*` sau khi thêm/xoá nguyện vọng, và 2 Casbin migration mở quyền picker cho accountant.

Đã qua **2 vòng `/code-review max`** (10 angle + sweep mỗi vòng) + **audit luồng tiền** + **Chrome smoke (accountant)**.

## Thay đổi chính
- **FE filter**: dropdown Năm/HK/TVV/Đơn vị + trích `FilterDropdown` gộp 7 dropdown option-list. Chip 3 filter id→name (ngành/TVV/đơn vị) render từ raw value + fallback `#id` (không biến mất khi id rời options).
- **resnapshot**: wire `_resnapshot_fee_academic_info` sau `add_choice`/`delete_choice` (NV structure đổi → refresh `Fee.resolved_*`); best-effort/fail-soft, skip-cancelled, chỉ ghi 3 cột display.
- **Casbin**: `tcf20260627001` (accountant GET `/api/admin/users` picker TVV, +ACCOUNTANT_TEMPLATE) + `tcf20260627002` (heal drift: user notif-prefs + accountant finance/dashboard + accountant `/api/organization-units`; thêm org-units vào ACCOUNTANT_TEMPLATE để durable qua re-sync; downgrade no-op vì grant template-owned).
- **Hook**: `useInvoiceAcademicYears` dùng zod `academicYearListResponseSchema` (`safeParse` null-safe); officer picker bỏ `status:active` (TVV đã nghỉ vẫn lọc được) + `enabled:!isPendingTab`.

## Fix từ /code-review (2 vòng)
Vòng 1 (11 fix): chip TVV/đơn vị raw-value · test PII accountant seed officer + hard-assert · downgrade migration no-op · grant org-units · resnapshot check-fee-trước-resolve · enabled flag · zod safeParse · bỏ double expire · FilterDropdown · ...
Vòng 2 (2 fix): chip "Ngành" cũng raw-value (nhất quán) · grant org-units thêm vào ACCOUNTANT_TEMPLATE (durable).

## Audit luồng tiền officer — SẠCH
- `calculate_fee`: mọi caller flush fee TRƯỚC resnapshot; `no_autoflush`=0 → early-return không bỏ stamp; resnapshot chỉ ghi cột display, không chạm amount/status/version; không đảo lock-order.
- `issue_invoice`: không đọc `resolved_*`; số/tiền/status invoice độc lập. Filter AND scope IDOR.
- Caveat display-only (thiết kế có chủ đích): xoá NV cuối khi có invoice lệ phí đã phát hành → nhãn ngành trống; số/tiền nguyên vẹn, reversible.

## Verify
- FE: type-check ✓ · vitest **1745 pass** ✓ · lint **0 error**
- BE: **71 test** (resnapshot service 8 + choice CRUD + qa_e2e 11) ✓ · alembic single head ✓ · migration apply qlts_dev (3 grant=allow) + no-op downgrade giữ template grant ✓
- **Chrome smoke accountant**: tất cả picker 200 (không 403) · dropdown TVV(12)/Đơn vị(cây) populate · chip render đúng tên + bỏ lọc OK · console 0 error

## ⚠️ Deploy
**KHÔNG code-only**: cần chạy **2 migration** (`tcf20260627001`, `tcf20260627002`) + **RESTART backend** (Casbin nạp policy lúc startup). Không cần backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)