### PR TITLE
chore(deps): bump python-socketio + python-engineio (fix 3 CVE pip-audit)

### DIFF
--- a/Backend_FastAPI/requirements.txt
+++ b/Backend_FastAPI/requirements.txt
@@ -77,10 +77,10 @@ PyJWT==2.13.0
 pyotp==2.9.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
-python-engineio==4.12.3
+python-engineio==4.13.3
 python-magic==0.4.27
 python-multipart==0.0.31
-python-socketio==5.14.3
+python-socketio==5.16.3
 pytokens==0.2.0
 pytz==2025.2
 PyYAML==6.0.3


### PR DESCRIPTION
## Vì sao

`pip-audit` (gate **Dependency Audit** trong CI) fail trên mọi branch sau khi DB lỗ hổng refresh — phát hiện **3 CVE mới** không nằm trong allowlist:

| Package | Hiện | CVE | Fix |
|---|---|---|---|
| python-engineio | 4.12.3 | **CVE-2026-48802** (heartbeat thread-DoS) · **CVE-2026-48809** (unbounded message memory-DoS, ASGI long-polling / aiohttp WS) | 4.13.2 |
| python-socketio | 5.14.3 | **CVE-2026-48804** (binary attachment giữ bộ nhớ lâu, unauthenticated) | 5.16.2 |

## Thay đổi
`Backend_FastAPI/requirements.txt` (2 dòng):
- `python-engineio` 4.12.3 → **4.13.3**
- `python-socketio` 5.14.3 → **5.16.3**

Bump lên patch mới nhất cùng dòng minor (đều ≥ fix-version). socketio 5.16.3 yêu cầu `engineio>=4.13.2` → 4.13.3 thoả.

## Kiểm tra kỹ (throwaway container)
- ✅ `pip check`: no broken requirements (resolution sạch, không conflict transitive).
- ✅ `socketio.AsyncServer(...)` construct OK với **đúng kwargs app dùng** (`async_mode`/`cors_allowed_origins`/`engineio_cors_credentials`/`logger`/`engineio_logger`/`client_manager`) — không kwarg nào bị bỏ giữa 5.14→5.16.
- ✅ `import app.socket_manager` OK — dựng server thật (Redis manager + CORS + event handlers đăng ký).
- ✅ Chạy **đúng lệnh pip-audit của CI** (kèm `--ignore-vuln` allowlist) trên requirements đã bump → **0 vuln còn lại → PASS**.
- ✅ **40 socket test pass** (auth / revalidation / force-logout / scoping / offboarding / realtime-emit) — runtime Socket.IO không đổi.

## Ghi chú
- Độc lập với PR #439 (lỗi audit này không do #439 — fail trên main luôn).
- Không đụng allowlist workflow (3 CVE được **fix** bằng bump, không phải ignore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)