### PR TITLE
fix(finance): nhãn lead "Đã hoàn tất học phí" chỉ bật khi đóng ĐỦ học phí HK1

### DIFF
--- a/Backend_FastAPI/app/models/finance/fee.py
+++ b/Backend_FastAPI/app/models/finance/fee.py
@@ -362,10 +362,10 @@ class Fee(Base):
         one semester. This property means "this semester's fee is fully
         settled", not "all tuition across all semesters is paid".
 
-        Note: admission pipeline projection uses is_hk1_cleared() from
-        fee_calculation_service instead of this property, because the
-        pipeline fires on first partial payment (cleared state), not
-        only on full payment.
+        Note: admission pipeline projection uses is_hk1_settled() from
+        fee_calculation_service, which (like this property) requires the
+        semester fee to be fully settled (remaining <= 0). A partial
+        payment does NOT project the lead to sts10 — it stays at sts14.
         """
         return self.remaining_amount <= Decimal("0")
 

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -49,29 +49,41 @@ from app.utils.text_helpers import escape_like_pattern, LIKE_ESCAPE_CHAR
 log = structlog.get_logger(__name__)
 
 
-def is_hk1_cleared(
+def is_hk1_settled(
     fee_type: str,
     semester_no: Optional[int],
     status: str,
     paid_amount: Decimal,
+    final_amount: Decimal,
+    waived_amount: Decimal,
 ) -> bool:
-    """Check if a fee is in HK1 cleared state.
+    """Check if an HK1 tuition fee is fully SETTLED (for lead pipeline projection).
 
-    Cleared = tuition + semester_no=1 + one of:
+    Settled = tuition + semester_no=1 + NOT cancelled + one of:
       - status in (paid, waived)
-      - status == partial AND paid_amount > 0
+      - remaining (final - paid - waived) <= 0
 
-    Used by PR 5 (ADR-002) to detect transition into cleared state
-    at payment/waiver call sites. Callers snapshot pre-state, apply
-    mutation, then check post-state: sync only on False -> True.
+    This is the SOLE chokepoint deciding whether the lead reaches sts10
+    "Đã hoàn tất học phí". A PARTIAL payment (remaining > 0) is NOT settled —
+    the lead stays at sts14 "Chưa hoàn tất học phí". This is intentionally
+    STRICTER than the enrollment gate (_check_fee_gate_semester_hk1) which,
+    per ADR-002, still lets a partial payment pass enrollment.
+
+    The ``cancelled`` guard is required: a cancelled fee can be zeroed-out
+    (final=paid=waived=0) so ``remaining <= 0`` would be True — without the
+    guard the void-revert call site would wrongly keep the lead at sts10.
+
+    Used to detect transition into settled state at payment/waiver call sites.
+    Callers snapshot pre-state, apply mutation, then check post-state: sync
+    only on False -> True.
     """
     if fee_type != "tuition" or semester_no != 1:
         return False
+    if status == "cancelled":
+        return False
     if status in ("paid", "waived"):
         return True
-    if status == "partial" and paid_amount > 0:
-        return True
-    return False
+    return (final_amount - paid_amount - waived_amount) <= 0
 
 
 def _academic_info_of_choice(choice: "models.AdmissionProfileChoice") -> Any:

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -86,6 +86,22 @@ def is_hk1_settled(
     return (final_amount - paid_amount - waived_amount) <= 0
 
 
+def is_hk1_settled_fee(fee) -> bool:
+    """``is_hk1_settled`` for a Fee-like object — the form call sites should use.
+
+    The pure ``is_hk1_settled`` takes three ADJACENT same-type Decimal args
+    (paid/final/waived) that are easy to transpose at a call site; a silent swap
+    re-introduces the exact bug this guard fixes (partial wrongly read as
+    settled) with NO TypeError. Every runtime call site has the ``fee`` in hand,
+    so they call THIS wrapper and the positional order lives in exactly one
+    reviewed place.
+    """
+    return is_hk1_settled(
+        fee.fee_type, fee.semester_no, fee.status,
+        fee.paid_amount, fee.final_amount, fee.waived_amount,
+    )
+
+
 def _academic_info_of_choice(choice: "models.AdmissionProfileChoice") -> Any:
     """OfferingAcademicInfo behind a choice's admission_path (or None).
 

--- a/Backend_FastAPI/app/services/lead_admission_sync.py
+++ b/Backend_FastAPI/app/services/lead_admission_sync.py
@@ -548,15 +548,17 @@ async def sync_lead_tuition_paid(
     reason: Optional[str] = None,
 ) -> bool:
     """
-    Sync lead consultation status when HK1 tuition reaches cleared state.
+    Sync lead consultation status when HK1 tuition reaches SETTLED state.
 
     Moves lead to sts10 (Đã hoàn tất học phí).
 
-    ADR-002 PR 5: "Cleared" means paid, waived, or partial with
-    paid_amount > 0. Does NOT require full payment. Callers MUST:
+    "Settled" means paid, waived, or remaining (final - paid - waived) <= 0.
+    A PARTIAL payment is NOT settled — the lead stays at sts14 "Chưa hoàn
+    tất học phí". (This is stricter than the enrollment gate, which per
+    ADR-002 still lets a partial payment pass.) Callers MUST:
     1. Gate invocation to semester_no == 1 (HK1 only)
-    2. Fire only on the first transition into cleared state (use
-       is_hk1_cleared pre/post pattern to avoid duplicate syncs)
+    2. Fire only on the first transition into settled state (use
+       is_hk1_settled pre/post pattern to avoid duplicate syncs)
 
     Args:
         db: Database session (same transaction as caller)

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -1067,7 +1067,7 @@ async def commit_batch(
       savepoint rollback CẢ dòng (không ghi nửa vời).
     - 1 dòng lỗi không abort cả lô (savepoint per-row).
     """
-    from app.services.fee_calculation_service import is_hk1_settled
+    from app.services.fee_calculation_service import is_hk1_settled_fee
     from app.services.lead_admission_sync import sync_lead_tuition_paid
 
     batch = (
@@ -1213,10 +1213,7 @@ async def commit_batch(
                     raise BusinessRuleViolation(
                         "hồ sơ đã bị xóa giữa preview→commit"
                     )
-                was_hk1 = is_hk1_settled(
-                    fee.fee_type, fee.semester_no, fee.status,
-                    fee.paid_amount, fee.final_amount, fee.waived_amount,
-                )
+                was_hk1 = is_hk1_settled_fee(fee)
 
                 left = amount
                 for li in locked:
@@ -1255,10 +1252,7 @@ async def commit_batch(
                     )
 
                 if not was_hk1:
-                    now_hk1 = is_hk1_settled(
-                        fee.fee_type, fee.semester_no, fee.status,
-                        fee.paid_amount, fee.final_amount, fee.waived_amount,
-                    )
+                    now_hk1 = is_hk1_settled_fee(fee)
                     if now_hk1:
                         row_cleared = (
                             fee.admission_profile_id,
@@ -1558,17 +1552,14 @@ async def void_batch(
     # xứng forward sync ở commit. Void = SỬA NHẦM ghi nhận (KHÔNG phải học sinh rút)
     # → lùi về status TRƯỚC sts10, KHÔNG đẩy sts18 (đó là refund thật). Bọc savepoint
     # + try/except MỖI hồ-sơ: lỗi projection KHÔNG hủy đảo tiền cả lô (tiền đã đảo giữ).
-    from app.services.fee_calculation_service import is_hk1_settled
+    from app.services.fee_calculation_service import is_hk1_settled_fee
     from app.services.lead_admission_sync import revert_lead_tuition_paid
 
     reverted_leads = 0
     for fee in fee_by_id.values():
         if fee.fee_type != "tuition" or fee.semester_no != 1:
             continue  # chỉ HK1 đụng pipeline lead
-        if is_hk1_settled(
-            fee.fee_type, fee.semester_no, fee.status,
-            fee.paid_amount, fee.final_amount, fee.waived_amount,
-        ):
+        if is_hk1_settled_fee(fee):
             continue  # HK1 vẫn settled (nguồn thu khác) → giữ lead ở sts10
         try:
             async with db.begin_nested():

--- a/Backend_FastAPI/app/services/payment_import_service.py
+++ b/Backend_FastAPI/app/services/payment_import_service.py
@@ -1067,7 +1067,7 @@ async def commit_batch(
       savepoint rollback CẢ dòng (không ghi nửa vời).
     - 1 dòng lỗi không abort cả lô (savepoint per-row).
     """
-    from app.services.fee_calculation_service import is_hk1_cleared
+    from app.services.fee_calculation_service import is_hk1_settled
     from app.services.lead_admission_sync import sync_lead_tuition_paid
 
     batch = (
@@ -1213,8 +1213,9 @@ async def commit_batch(
                     raise BusinessRuleViolation(
                         "hồ sơ đã bị xóa giữa preview→commit"
                     )
-                was_hk1 = is_hk1_cleared(
-                    fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+                was_hk1 = is_hk1_settled(
+                    fee.fee_type, fee.semester_no, fee.status,
+                    fee.paid_amount, fee.final_amount, fee.waived_amount,
                 )
 
                 left = amount
@@ -1254,8 +1255,9 @@ async def commit_batch(
                     )
 
                 if not was_hk1:
-                    now_hk1 = is_hk1_cleared(
-                        fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+                    now_hk1 = is_hk1_settled(
+                        fee.fee_type, fee.semester_no, fee.status,
+                        fee.paid_amount, fee.final_amount, fee.waived_amount,
                     )
                     if now_hk1:
                         row_cleared = (
@@ -1556,15 +1558,18 @@ async def void_batch(
     # xứng forward sync ở commit. Void = SỬA NHẦM ghi nhận (KHÔNG phải học sinh rút)
     # → lùi về status TRƯỚC sts10, KHÔNG đẩy sts18 (đó là refund thật). Bọc savepoint
     # + try/except MỖI hồ-sơ: lỗi projection KHÔNG hủy đảo tiền cả lô (tiền đã đảo giữ).
-    from app.services.fee_calculation_service import is_hk1_cleared
+    from app.services.fee_calculation_service import is_hk1_settled
     from app.services.lead_admission_sync import revert_lead_tuition_paid
 
     reverted_leads = 0
     for fee in fee_by_id.values():
         if fee.fee_type != "tuition" or fee.semester_no != 1:
             continue  # chỉ HK1 đụng pipeline lead
-        if is_hk1_cleared(fee.fee_type, fee.semester_no, fee.status, fee.paid_amount):
-            continue  # HK1 vẫn còn cleared (nguồn thu khác) → giữ lead ở sts10
+        if is_hk1_settled(
+            fee.fee_type, fee.semester_no, fee.status,
+            fee.paid_amount, fee.final_amount, fee.waived_amount,
+        ):
+            continue  # HK1 vẫn settled (nguồn thu khác) → giữ lead ở sts10
         try:
             async with db.begin_nested():
                 profile = await _load_profile_with_lead(db, fee.admission_profile_id)

--- a/Backend_FastAPI/app/services/payment_intent_service.py
+++ b/Backend_FastAPI/app/services/payment_intent_service.py
@@ -614,10 +614,11 @@ class PaymentIntentService:
         elif invoice.paid_amount > 0:
             invoice.status = InvoiceStatusEnum.partial.value
 
-        # ADR-002 PR 5: snapshot cleared state BEFORE fee mutation
-        from app.services.fee_calculation_service import is_hk1_cleared
-        was_hk1_cleared = is_hk1_cleared(
-            fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+        # ADR-002 PR 5: snapshot settled state BEFORE fee mutation
+        from app.services.fee_calculation_service import is_hk1_settled
+        was_hk1_settled = is_hk1_settled(
+            fee.fee_type, fee.semester_no, fee.status,
+            fee.paid_amount, fee.final_amount, fee.waived_amount,
         )
 
         # Update fee paid_amount
@@ -662,18 +663,20 @@ class PaymentIntentService:
             )
             profile = result.scalar_one_or_none()
 
-        # ADR-002 PR 5: Sync lead only on HK1 cleared-state transition.
-        now_hk1_cleared = is_hk1_cleared(
-            fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+        # ADR-002 PR 5: Sync lead only on HK1 SETTLED-state transition
+        # (remaining<=0). Partial online payment leaves lead at sts14.
+        now_hk1_settled = is_hk1_settled(
+            fee.fee_type, fee.semester_no, fee.status,
+            fee.paid_amount, fee.final_amount, fee.waived_amount,
         )
-        if not was_hk1_cleared and now_hk1_cleared and profile is not None:
+        if not was_hk1_settled and now_hk1_settled and profile is not None:
             from app.services.lead_admission_sync import sync_lead_tuition_paid
             await sync_lead_tuition_paid(
                 db=self.db,
                 profile=profile,
                 transaction_id=payment.reference_code or f"PAY-{payment.id}",
                 changed_by_user_id=1,
-                reason=f"HK1 tuition cleared via online payment ({intent.method.code})",
+                reason=f"HK1 tuition settled via online payment ({intent.method.code})",
             )
 
         return payment, fee, profile

--- a/Backend_FastAPI/app/services/payment_intent_service.py
+++ b/Backend_FastAPI/app/services/payment_intent_service.py
@@ -615,11 +615,8 @@ class PaymentIntentService:
             invoice.status = InvoiceStatusEnum.partial.value
 
         # ADR-002 PR 5: snapshot settled state BEFORE fee mutation
-        from app.services.fee_calculation_service import is_hk1_settled
-        was_hk1_settled = is_hk1_settled(
-            fee.fee_type, fee.semester_no, fee.status,
-            fee.paid_amount, fee.final_amount, fee.waived_amount,
-        )
+        from app.services.fee_calculation_service import is_hk1_settled_fee
+        was_hk1_settled = is_hk1_settled_fee(fee)
 
         # Update fee paid_amount
         fee.paid_amount = fee.paid_amount + intent.amount
@@ -665,10 +662,7 @@ class PaymentIntentService:
 
         # ADR-002 PR 5: Sync lead only on HK1 SETTLED-state transition
         # (remaining<=0). Partial online payment leaves lead at sts14.
-        now_hk1_settled = is_hk1_settled(
-            fee.fee_type, fee.semester_no, fee.status,
-            fee.paid_amount, fee.final_amount, fee.waived_amount,
-        )
+        now_hk1_settled = is_hk1_settled_fee(fee)
         if not was_hk1_settled and now_hk1_settled and profile is not None:
             from app.services.lead_admission_sync import sync_lead_tuition_paid
             await sync_lead_tuition_paid(

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -362,10 +362,11 @@ class PaymentService:
         if not fee:
             raise ResourceNotFoundError("Fee not found")
 
-        # Capture cleared state BEFORE mutation (PR 5 transition detection)
-        from app.services.fee_calculation_service import is_hk1_cleared
-        was_hk1_cleared = is_hk1_cleared(
-            fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+        # Capture settled state BEFORE mutation (PR 5 transition detection)
+        from app.services.fee_calculation_service import is_hk1_settled
+        was_hk1_settled = is_hk1_settled(
+            fee.fee_type, fee.semester_no, fee.status,
+            fee.paid_amount, fee.final_amount, fee.waived_amount,
         )
 
         # Update payment status
@@ -396,13 +397,15 @@ class PaymentService:
 
         await self.db.flush()
 
-        # ADR-002 PR 5: Sync lead only on HK1 cleared-state transition.
-        # "Cleared" = paid OR waived OR (partial + paid_amount > 0).
-        # Only fires once: pre=not-cleared -> post=cleared.
-        now_hk1_cleared = is_hk1_cleared(
-            fee.fee_type, fee.semester_no, fee.status, fee.paid_amount
+        # ADR-002 PR 5: Sync lead only on HK1 SETTLED-state transition.
+        # "Settled" = paid OR waived OR remaining<=0. A PARTIAL payment
+        # (remaining>0) is NOT settled — lead stays at sts14, not sts10.
+        # Only fires once: pre=not-settled -> post=settled.
+        now_hk1_settled = is_hk1_settled(
+            fee.fee_type, fee.semester_no, fee.status,
+            fee.paid_amount, fee.final_amount, fee.waived_amount,
         )
-        if not was_hk1_cleared and now_hk1_cleared:
+        if not was_hk1_settled and now_hk1_settled:
             profile = await self._get_profile_for_fee(fee)
             if profile:
                 from app.services.lead_admission_sync import sync_lead_tuition_paid
@@ -411,7 +414,7 @@ class PaymentService:
                     profile=profile,
                     transaction_id=payment.reference_code or f"PAY-{payment.id}",
                     changed_by_user_id=verifier_id,
-                    reason=f"HK1 tuition cleared. Payment: {payment.amount:,.0f} VND",
+                    reason=f"HK1 tuition settled. Payment: {payment.amount:,.0f} VND",
                 )
 
         log.info(
@@ -436,7 +439,7 @@ class PaymentService:
         # ADR-002 D10: Under the per-semester model, each Fee is one semester.
         # fee_remaining <= 0 means "this semester's fee is fully paid", not
         # "all tuition fully paid". The lead sync above (gated via
-        # is_hk1_cleared transition) handles the pipeline projection;
+        # is_hk1_settled transition) handles the pipeline projection;
         # this notification payload is semester-scoped by construction.
         _notify_payload = {
             "payment_id": payment.id,

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -363,11 +363,8 @@ class PaymentService:
             raise ResourceNotFoundError("Fee not found")
 
         # Capture settled state BEFORE mutation (PR 5 transition detection)
-        from app.services.fee_calculation_service import is_hk1_settled
-        was_hk1_settled = is_hk1_settled(
-            fee.fee_type, fee.semester_no, fee.status,
-            fee.paid_amount, fee.final_amount, fee.waived_amount,
-        )
+        from app.services.fee_calculation_service import is_hk1_settled_fee
+        was_hk1_settled = is_hk1_settled_fee(fee)
 
         # Update payment status
         now = datetime.now(timezone.utc)
@@ -401,10 +398,7 @@ class PaymentService:
         # "Settled" = paid OR waived OR remaining<=0. A PARTIAL payment
         # (remaining>0) is NOT settled — lead stays at sts14, not sts10.
         # Only fires once: pre=not-settled -> post=settled.
-        now_hk1_settled = is_hk1_settled(
-            fee.fee_type, fee.semester_no, fee.status,
-            fee.paid_amount, fee.final_amount, fee.waived_amount,
-        )
+        now_hk1_settled = is_hk1_settled_fee(fee)
         if not was_hk1_settled and now_hk1_settled:
             profile = await self._get_profile_for_fee(fee)
             if profile:

--- a/Backend_FastAPI/scripts/backfill_sts10_partial_to_sts14.py
+++ b/Backend_FastAPI/scripts/backfill_sts10_partial_to_sts14.py
@@ -66,6 +66,8 @@ _AFFECTED_SQL = text(
         ON f.admission_profile_id = ap.id
        AND f.fee_type = 'tuition'
        AND f.semester_no = 1
+       AND f.status <> 'cancelled'
+       AND (f.final_amount - f.paid_amount - f.waived_amount) > 0
     LEFT JOIN LATERAL (
         SELECT old_consultation_status_id
         FROM lead_status_history
@@ -75,7 +77,21 @@ _AFFECTED_SQL = text(
         LIMIT 1
     ) h ON TRUE
     WHERE l.consultation_status_id = :sts10
-      AND (f.final_amount - f.paid_amount - f.waived_amount) > 0
+      -- Only revert when NO HK1 fee justifies the sts10 label: a lead with any
+      -- SETTLED (non-cancelled) HK1 tuition fee genuinely "đã hoàn tất học phí"
+      -- (e.g. a prior year/profile fully paid) — never strip its valid label.
+      -- Cancelled fees are excluded from the offending JOIN above too, so a
+      -- cancelled fee with a residual remaining>0 cannot drag a lead here.
+      AND NOT EXISTS (
+          SELECT 1
+          FROM admission_profile ap2
+          JOIN fee f2 ON f2.admission_profile_id = ap2.id
+          WHERE ap2.lead_id = l.id
+            AND f2.fee_type = 'tuition'
+            AND f2.semester_no = 1
+            AND f2.status <> 'cancelled'
+            AND (f2.final_amount - f2.paid_amount - f2.waived_amount) <= 0
+      )
     ORDER BY l.id
     """
 )

--- a/Backend_FastAPI/scripts/backfill_sts10_partial_to_sts14.py
+++ b/Backend_FastAPI/scripts/backfill_sts10_partial_to_sts14.py
@@ -1,0 +1,163 @@
+"""One-shot backfill: revert leads wrongly at sts10 "Đã hoàn tất học phí".
+
+Companion to the PR-1 code change (``is_hk1_cleared`` → ``is_hk1_settled``):
+before the fix, the FIRST partial HK1 tuition payment projected the lead to
+sts10 "Đã hoàn tất học phí" even though the fee still had a balance. Prod audit
+2026-06-27 found 79/83 sts10 leads in this state (~399tr hidden unpaid HK1).
+
+This script reverts those leads to the status they held BEFORE the (wrong)
+sts10 projection — symmetric to the runtime void path. It REUSES
+``revert_lead_tuition_paid`` so the restore logic + guards are byte-identical to
+production code:
+
+  * Guard: only acts on a lead CURRENTLY at sts10 (a lead that legitimately
+    advanced afterwards — e.g. manual fix, SLA close — is skipped, never
+    overwritten).
+  * Restore: reads the most-recent ``LeadStatusHistory`` row that pushed the
+    lead INTO sts10 and restores its ``old_*`` verbatim (no hardcoded target,
+    no re-derive). For these leads that pre-state is sts14 "Chưa hoàn tất học
+    phí".
+  * The new audit row is written with ``changed_by_user_id = NULL`` (system).
+
+Idempotent: a re-run matches zero rows because reverted leads are no longer at
+sts10. Anomalies (no forward history, or a history row with NULL
+old_consultation_status_id) are ISOLATED and reported — NEVER restored blindly.
+
+⚠️ DEPLOY ORDER: run this ONLY AFTER the PR-1 code is live, otherwise the old
+forward logic will re-mislabel a lead right after it is reverted.
+
+Usage:
+    python scripts/backfill_sts10_partial_to_sts14.py            # DRY-RUN
+    python scripts/backfill_sts10_partial_to_sts14.py --apply    # revert (prompts)
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlalchemy import text, select  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
+from sqlalchemy.orm import selectinload  # noqa: E402
+
+from app import models  # noqa: E402
+from app.database import AsyncSessionLocal  # noqa: E402
+from app.services.lead_admission_sync import (  # noqa: E402
+    TUITION_PAID_STATUS,
+    revert_lead_tuition_paid,
+)
+
+# Leads at sts10 whose HK1 tuition fee still has a positive balance (remaining
+# > 0) — i.e. NOT actually fully settled. ``profile_id`` is the profile that
+# carries the offending fee; the most-recent forward history row gives the
+# restore target (for reporting + the anomaly check). DISTINCT lead so a lead
+# with >1 offending profile is processed once (revert is idempotent anyway).
+_AFFECTED_SQL = text(
+    """
+    SELECT DISTINCT ON (l.id)
+        l.id            AS lead_id,
+        l.full_name     AS full_name,
+        ap.id           AS profile_id,
+        (f.final_amount - f.paid_amount - f.waived_amount) AS remaining,
+        h.old_consultation_status_id AS target_cs
+    FROM lead l
+    JOIN admission_profile ap ON ap.lead_id = l.id
+    JOIN fee f
+        ON f.admission_profile_id = ap.id
+       AND f.fee_type = 'tuition'
+       AND f.semester_no = 1
+    LEFT JOIN LATERAL (
+        SELECT old_consultation_status_id
+        FROM lead_status_history
+        WHERE lead_id = l.id
+          AND new_consultation_status_id = :sts10
+        ORDER BY id DESC
+        LIMIT 1
+    ) h ON TRUE
+    WHERE l.consultation_status_id = :sts10
+      AND (f.final_amount - f.paid_amount - f.waived_amount) > 0
+    ORDER BY l.id
+    """
+)
+
+
+async def select_affected(db: AsyncSession) -> list[dict]:
+    rows = (
+        await db.execute(_AFFECTED_SQL, {"sts10": TUITION_PAID_STATUS})
+    ).mappings().all()
+    return [dict(r) for r in rows]
+
+
+async def main() -> int:
+    apply = "--apply" in sys.argv
+
+    async with AsyncSessionLocal() as db:
+        affected = await select_affected(db)
+        anomalies = [r for r in affected if not r["target_cs"]]
+        actionable = [r for r in affected if r["target_cs"]]
+
+        print(f"Leads at {TUITION_PAID_STATUS} with unpaid HK1 (remaining>0): "
+              f"{len(affected)}")
+        print(f"  actionable (have forward history): {len(actionable)}")
+        print(f"  anomalies (no/NULL forward history — SKIPPED): {len(anomalies)}")
+        print()
+        # Backup snapshot (printed so the run log is the rollback reference).
+        print("--- affected leads (backup snapshot) ---")
+        for r in affected:
+            tag = "" if r["target_cs"] else "  <ANOMALY: skip>"
+            print(f"  lead={r['lead_id']:>5} profile={r['profile_id']:>5} "
+                  f"remaining={r['remaining']:>12} -> {r['target_cs']}{tag} "
+                  f"| {r['full_name']}")
+        print()
+
+        if not apply:
+            print("DRY-RUN — re-run with --apply to revert the actionable leads.")
+            return 0
+        if not actionable:
+            print("Nothing actionable to backfill.")
+            return 0
+
+        print(f"\n⚠️  Will revert {len(actionable)} lead(s) {TUITION_PAID_STATUS} "
+              f"-> pre-state (sts14). Continue? (yes/no): ", end="")
+        if input().strip().lower() != "yes":
+            print("Cancelled.")
+            return 1
+
+        reverted = 0
+        skipped = 0
+        for r in actionable:
+            profile = (
+                await db.execute(
+                    select(models.AdmissionProfile)
+                    .where(models.AdmissionProfile.id == r["profile_id"])
+                    .options(selectinload(models.AdmissionProfile.lead))
+                )
+            ).scalar_one_or_none()
+            if profile is None or profile.lead is None:
+                skipped += 1
+                continue
+            ok = await revert_lead_tuition_paid(
+                db,
+                profile,
+                changed_by_user_id=None,
+                reason=("Backfill: sửa nhãn học phí đóng một phần "
+                        f"{TUITION_PAID_STATUS}->sts14 (PR-1 is_hk1_settled)"),
+            )
+            if ok:
+                reverted += 1
+            else:
+                skipped += 1
+        await db.commit()
+
+        print(f"✅ Backfill done: reverted={reverted}, skipped={skipped}, "
+              f"anomalies={len(anomalies)}")
+
+        # Verification: the actionable bucket must now be empty.
+        remaining = await select_affected(db)
+        still = [x for x in remaining if x["target_cs"]]
+        print(f"Re-check actionable remaining (expect 0): {len(still)}")
+        return 0 if not still else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
+++ b/Backend_FastAPI/tests/api/test_tuition_prepay_flow.py
@@ -15,10 +15,11 @@ Scenarios:
    tuition at ``submitted`` → invoice **auto-issued** (status ``issued``) →
    accountant records a PARTIAL prepay (3,000,000 / 9,200,000) → manager
    verifies → invoice + fee go ``partial`` with the right ``paid_amount`` AND
-   the HK1-cleared lead sync fires (lead advances to TUITION_PAID_STATUS / sts10
-   — the ``sync_lead_tuition_paid`` projection inside ``verify_payment``) →
+   the lead STAYS at ``sts14`` (Chưa hoàn tất học phí) — a partial payment is
+   NOT settled, so ``is_hk1_settled`` keeps the lead off sts10 →
    accountant records the remaining 6,200,000 → manager verifies → invoice +
-   fee go ``paid``.
+   fee go ``paid`` AND the lead now advances to TUITION_PAID_STATUS / sts10
+   (the ``sync_lead_tuition_paid`` projection fires only on FULL settlement).
 
 2. Approve gate in the integrated flow (cross-check C1.5 end-to-end): while the
    document debt is outstanding ``approve`` is blocked (400); after the owed doc
@@ -576,18 +577,21 @@ class TestPrepayHappyPath:
         assert fee["status"] == FeeStatusEnum.partial.value, fee
         assert Decimal(str(fee["paid_amount"])) == PREPAY
 
-        # HK1 cleared-state sync fired: the lead advanced to the
-        # "đã hoàn tất học phí" projection (sts10) on the FIRST partial
-        # clearance (sync_lead_tuition_paid inside verify_payment).
-        from app.services.lead_admission_sync import TUITION_PAID_STATUS
-
-        lead = await _load_lead(lead_id)
-        assert lead.consultation_status_id == TUITION_PAID_STATUS, (
-            f"HK1 sync should advance lead to {TUITION_PAID_STATUS}, "
-            f"got {lead.consultation_status_id}"
+        # A PARTIAL prepay is NOT settled → the lead must STAY at sts14
+        # (Chưa hoàn tất học phí). It must NOT jump to sts10 — that is the
+        # bug this change fixes (is_hk1_settled requires remaining <= 0).
+        from app.services.lead_admission_sync import (
+            TUITION_CALCULATED_STATUS,
+            TUITION_PAID_STATUS,
         )
 
-        # --- Step 4: pay the remainder (6,200,000) → paid -------------------
+        lead = await _load_lead(lead_id)
+        assert lead.consultation_status_id == TUITION_CALCULATED_STATUS, (
+            f"Partial prepay must keep lead at {TUITION_CALCULATED_STATUS} "
+            f"(chưa hoàn tất), got {lead.consultation_status_id}"
+        )
+
+        # --- Step 4: pay the remainder (6,200,000) → paid + sts10 ----------
         await _record_and_verify_payment(
             client, accountant, manager, invoice_id, REMAINDER
         )
@@ -601,6 +605,13 @@ class TestPrepayHappyPath:
         fee2 = (await client.get(f"/api/fees/{fee_id}", headers=accountant)).json()
         assert fee2["status"] == FeeStatusEnum.paid.value, fee2
         assert Decimal(str(fee2["paid_amount"])) == HK1_TUITION
+
+        # Now fully settled → lead advances to sts10 (Đã hoàn tất học phí).
+        lead2 = await _load_lead(lead_id)
+        assert lead2.consultation_status_id == TUITION_PAID_STATUS, (
+            f"Full settlement should advance lead to {TUITION_PAID_STATUS}, "
+            f"got {lead2.consultation_status_id}"
+        )
 
 
 # ===========================================================================

--- a/Backend_FastAPI/tests/integration/test_finance_workflow.py
+++ b/Backend_FastAPI/tests/integration/test_finance_workflow.py
@@ -1142,86 +1142,111 @@ class TestSemesterTuitionRecalculation:
 
 
 # =============================================================================
-# HK1 CLEARED-STATE PIPELINE GATE TESTS (PR 5 — ADR-002)
+# HK1 SETTLED-STATE PIPELINE GATE TESTS (PR 5 — ADR-002; partial != settled)
 # =============================================================================
 
-class TestHK1ClearedStatePipelineGate:
-    """Test that admission pipeline projections use HK1 cleared-state
-    semantics: fires once on first HK1 clearance, never for HK2+."""
+class TestHK1SettledStatePipelineGate:
+    """Admission pipeline projections use HK1 SETTLED-state semantics: the
+    lead reaches sts10 (Đã hoàn tất học phí) only when the HK1 fee is fully
+    settled (remaining <= 0). A PARTIAL payment is NOT settled — the lead
+    stays at sts14 (Chưa hoàn tất học phí). Fires once on first HK1
+    settlement, never for HK2+."""
 
     @pytest.mark.asyncio
-    async def test_is_hk1_cleared_helper(self):
-        """Unit test for the shared is_hk1_cleared helper."""
-        from app.services.fee_calculation_service import is_hk1_cleared
+    async def test_is_hk1_settled_helper(self):
+        """Unit test for the shared is_hk1_settled helper (6-arg signature)."""
+        from app.services.fee_calculation_service import is_hk1_settled
 
-        # Cleared states for HK1
-        assert is_hk1_cleared("tuition", 1, "paid", Decimal("10000000")) is True
-        assert is_hk1_cleared("tuition", 1, "waived", Decimal("0")) is True
-        assert is_hk1_cleared("tuition", 1, "partial", Decimal("100000")) is True
+        FINAL = Decimal("10000000")
+        Z = Decimal("0")
 
-        # Not cleared
-        assert is_hk1_cleared("tuition", 1, "partial", Decimal("0")) is False
-        assert is_hk1_cleared("tuition", 1, "pending", Decimal("0")) is False
-        assert is_hk1_cleared("tuition", 1, "calculated", Decimal("0")) is False
-        assert is_hk1_cleared("tuition", 1, "invoiced", Decimal("0")) is False
-        assert is_hk1_cleared("tuition", 1, "overdue", Decimal("0")) is False
-        assert is_hk1_cleared("tuition", 1, "cancelled", Decimal("0")) is False
+        # Settled states for HK1 (remaining <= 0)
+        assert is_hk1_settled("tuition", 1, "paid", FINAL, FINAL, Z) is True
+        assert is_hk1_settled("tuition", 1, "waived", Z, FINAL, FINAL) is True
+        # 'partial' label but fully covered (remaining <= 0) is still settled
+        assert is_hk1_settled("tuition", 1, "partial", FINAL, FINAL, Z) is True
+
+        # NOT settled — partial payment with remaining > 0. THIS IS THE FIX:
+        # the lead must stay at sts14, NOT jump to sts10.
+        PART = Decimal("3000000")
+        assert is_hk1_settled("tuition", 1, "partial", PART, FINAL, Z) is False
+        assert is_hk1_settled("tuition", 1, "pending", Z, FINAL, Z) is False
+        assert is_hk1_settled("tuition", 1, "calculated", Z, FINAL, Z) is False
+        assert is_hk1_settled("tuition", 1, "invoiced", Z, FINAL, Z) is False
+        assert is_hk1_settled("tuition", 1, "overdue", Z, FINAL, Z) is False
+
+        # Cancelled guard: a cancelled fee zeroed-out (final=paid=waived=0)
+        # would satisfy remaining<=0 — the guard MUST keep it False so the
+        # void-revert call site does not wrongly retain the lead at sts10.
+        assert is_hk1_settled("tuition", 1, "cancelled", Z, Z, Z) is False
+        assert is_hk1_settled("tuition", 1, "cancelled", FINAL, FINAL, Z) is False
 
         # Wrong semester / wrong type
-        assert is_hk1_cleared("tuition", 2, "paid", Decimal("10000000")) is False
-        assert is_hk1_cleared("tuition", 3, "paid", Decimal("10000000")) is False
-        assert is_hk1_cleared("application", 1, "paid", Decimal("10000000")) is False
-        assert is_hk1_cleared("tuition", None, "paid", Decimal("10000000")) is False
+        assert is_hk1_settled("tuition", 2, "paid", FINAL, FINAL, Z) is False
+        assert is_hk1_settled("tuition", 3, "paid", FINAL, FINAL, Z) is False
+        assert is_hk1_settled("application", 1, "paid", FINAL, FINAL, Z) is False
+        assert is_hk1_settled("tuition", None, "paid", FINAL, FINAL, Z) is False
 
     @pytest.mark.asyncio
-    async def test_hk1_first_partial_triggers_transition(self):
-        """First partial HK1 payment: False -> True transition = sync fires."""
-        from app.services.fee_calculation_service import is_hk1_cleared
+    async def test_hk1_first_partial_does_not_trigger(self):
+        """First partial HK1 payment stays NOT settled → no False->True
+        transition → sync does NOT fire → lead stays at sts14. (Bug fix.)"""
+        from app.services.fee_calculation_service import is_hk1_settled
 
-        was = is_hk1_cleared("tuition", 1, "calculated", Decimal("0"))
+        FINAL = Decimal("10000000")
+        Z = Decimal("0")
+        was = is_hk1_settled("tuition", 1, "calculated", Z, FINAL, Z)
+        now = is_hk1_settled("tuition", 1, "partial", Decimal("3000000"), FINAL, Z)
         assert was is False
-
-        now = is_hk1_cleared("tuition", 1, "partial", Decimal("3000000"))
-        assert now is True
-        assert not was and now  # Transition detected
+        assert now is False
+        assert not (not was and now)  # No transition → sync does NOT fire
 
     @pytest.mark.asyncio
-    async def test_hk1_second_payment_no_retrigger(self):
-        """Second payment on already-cleared HK1: True -> True = no sync."""
-        from app.services.fee_calculation_service import is_hk1_cleared
+    async def test_hk1_partial_then_full_triggers_once(self):
+        """Partial (no trigger) then payment to full → settled triggers."""
+        from app.services.fee_calculation_service import is_hk1_settled
 
-        was = is_hk1_cleared("tuition", 1, "partial", Decimal("3000000"))
-        assert was is True
-
-        now = is_hk1_cleared("tuition", 1, "partial", Decimal("6000000"))
+        FINAL = Decimal("10000000")
+        Z = Decimal("0")
+        was = is_hk1_settled("tuition", 1, "partial", Decimal("3000000"), FINAL, Z)
+        now = is_hk1_settled("tuition", 1, "paid", FINAL, FINAL, Z)
+        assert was is False
         assert now is True
-        assert not (not was and now)  # No transition
+        assert not was and now  # Transition only on FULL settlement
 
     @pytest.mark.asyncio
     async def test_hk2_payment_never_triggers(self):
         """HK2 payment: always False, no sync regardless of state."""
-        from app.services.fee_calculation_service import is_hk1_cleared
+        from app.services.fee_calculation_service import is_hk1_settled
 
-        assert is_hk1_cleared("tuition", 2, "paid", Decimal("10000000")) is False
-        assert is_hk1_cleared("tuition", 2, "partial", Decimal("5000000")) is False
-        assert is_hk1_cleared("tuition", 2, "waived", Decimal("0")) is False
+        FINAL = Decimal("10000000")
+        Z = Decimal("0")
+        assert is_hk1_settled("tuition", 2, "paid", FINAL, FINAL, Z) is False
+        assert is_hk1_settled(
+            "tuition", 2, "partial", Decimal("5000000"), FINAL, Z
+        ) is False
+        assert is_hk1_settled("tuition", 2, "waived", Z, FINAL, FINAL) is False
 
     @pytest.mark.asyncio
     async def test_hk1_waiver_triggers_transition(self):
-        """HK1 waiver: False -> True transition = sync fires."""
-        from app.services.fee_calculation_service import is_hk1_cleared
+        """HK1 full waiver: False -> True transition = sync fires."""
+        from app.services.fee_calculation_service import is_hk1_settled
 
-        was = is_hk1_cleared("tuition", 1, "calculated", Decimal("0"))
-        now = is_hk1_cleared("tuition", 1, "waived", Decimal("0"))
+        FINAL = Decimal("10000000")
+        Z = Decimal("0")
+        was = is_hk1_settled("tuition", 1, "calculated", Z, FINAL, Z)
+        now = is_hk1_settled("tuition", 1, "waived", Z, FINAL, FINAL)
         assert not was and now
 
     @pytest.mark.asyncio
     async def test_hk1_full_payment_triggers_transition(self):
         """HK1 full payment: False -> True transition = sync fires."""
-        from app.services.fee_calculation_service import is_hk1_cleared
+        from app.services.fee_calculation_service import is_hk1_settled
 
-        was = is_hk1_cleared("tuition", 1, "invoiced", Decimal("0"))
-        now = is_hk1_cleared("tuition", 1, "paid", Decimal("10000000"))
+        FINAL = Decimal("10000000")
+        Z = Decimal("0")
+        was = is_hk1_settled("tuition", 1, "invoiced", Z, FINAL, Z)
+        now = is_hk1_settled("tuition", 1, "paid", FINAL, FINAL, Z)
         assert not was and now
 
 

--- a/Backend_FastAPI/tests/integration/test_finance_workflow.py
+++ b/Backend_FastAPI/tests/integration/test_finance_workflow.py
@@ -1215,6 +1215,23 @@ class TestHK1SettledStatePipelineGate:
         assert not was and now  # Transition only on FULL settlement
 
     @pytest.mark.asyncio
+    async def test_hk1_already_settled_no_retrigger(self):
+        """Already-settled fee + a further payment stays settled: True->True =
+        NO transition → sync_lead_tuition_paid does NOT re-fire (idempotency).
+        Pins the already-settled branch so a future change that flips a settled
+        fee back to False (e.g. overpaid) can't silently re-fire the sync."""
+        from app.services.fee_calculation_service import is_hk1_settled
+
+        FINAL = Decimal("10000000")
+        Z = Decimal("0")
+        was = is_hk1_settled("tuition", 1, "paid", FINAL, FINAL, Z)
+        # An overpayment keeps remaining <= 0 → still settled.
+        now = is_hk1_settled("tuition", 1, "paid", Decimal("12000000"), FINAL, Z)
+        assert was is True
+        assert now is True
+        assert not (not was and now)  # No transition → sync does NOT re-fire
+
+    @pytest.mark.asyncio
     async def test_hk2_payment_never_triggers(self):
         """HK2 payment: always False, no sync regardless of state."""
         from app.services.fee_calculation_service import is_hk1_settled

--- a/Backend_FastAPI/tests/services/test_payment_import_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_import_service.py
@@ -1666,6 +1666,72 @@ class TestVoidBatch:
         )
         assert len(hist) >= 1
 
+    async def test_void_partial_combo_reverts_lead_off_sts10(
+        self, db, seeded_dependencies, admin_user
+    ):
+        """Combo manual + import: void lô import để lại remaining>0 → LÙI lead.
+
+        Khoá hành vi MỚI (is_hk1_settled, partial != settled): một fee HK1
+        được tất toán bởi CẢ một khoản thu tay (4tr) LẪN một lô import (6tr)
+        → settled → forward sync đẩy lead sts10. Void RIÊNG lô import (6tr)
+        để fee còn remaining 6tr (khoản tay giữ lại) → KHÔNG còn settled →
+        void_batch fall-through → revert lead KHỎI sts10.
+
+        Trước đây is_hk1_cleared coi (partial + paid>0) = cleared nên `continue`
+        GIỮ lead ở sts10 dù còn nợ — nay đã sửa cho đúng contract.
+        """
+        sts10 = await self._seed_sts10(db)
+        await _seed_system_user(db)
+        await _seed_cash_method(db)
+
+        cccd = "001999888777"
+        # Fee 10tr, invoice đã có khoản thu TAY 4tr (partial); fee.paid khớp.
+        prof, fee, _invs = await _seed_tuition(
+            db, seeded_dependencies, citizen_id=cccd,
+            invoices=[(1, "10000000", "partial", "4000000", "0")],
+        )
+        fee.paid_amount = Decimal("4000000")
+        fee.status = "partial"
+        await db.flush()
+        lead_id = prof.lead_id
+        orig = seeded_dependencies["initial_status_id"]
+        await db.commit()
+
+        # Import lô thu nốt 6tr → fee settled (remaining 0) → forward sync sts10.
+        content = _csv_bytes(
+            [pis.TEMPLATE_COLS, [cccd, "Nguyễn Văn An", "6.000.000",
+                                 "05/09/2026", "TM", "", ""]]
+        )
+        batch, _ = await pis.preview_import(
+            db, content=content, filename="thu.csv",
+            academic_year=2026, semester_no=1,
+            created_by_id=admin_user.id, unit_id=None,
+        )
+        batch_id = batch.id
+        await db.commit()
+        await pis.commit_batch(
+            db, batch_id=batch_id, importer_id=admin_user.id, unit_id=None
+        )
+        await db.commit()
+        lead = (
+            await db.execute(select(models.Lead).where(models.Lead.id == lead_id))
+        ).scalar_one()
+        assert lead.consultation_status_id == sts10  # tiền đề: settled → sts10
+
+        # Void RIÊNG lô import → fee còn remaining 6tr (khoản tay) → revert.
+        await pis.void_batch(
+            db, batch_id=batch_id, user_id=admin_user.id, unit_id=None,
+            reason="ghi nhầm lô import",
+        )
+        await db.commit()
+        lead2 = (
+            await db.execute(select(models.Lead).where(models.Lead.id == lead_id))
+        ).scalar_one()
+        assert lead2.consultation_status_id == orig, (
+            "fee còn remaining sau void → partial != settled → lead phải LÙI "
+            f"khỏi sts10, got {lead2.consultation_status_id}"
+        )
+
     async def test_void_skips_lead_revert_when_advanced_past_sts10(
         self, db, seeded_dependencies, admin_user
     ):


### PR DESCRIPTION
## Vấn đề (prod)

Audit prod 27-06: trong **83 lead** mang trạng thái `sts10` "Đã hoàn tất học phí", **79 lead thực ra mới đóng MỘT PHẦN** học phí HK1 (đóng TB 35.5%, max 71%; tổng còn nợ **~399 triệu** bị ẩn sau nhãn "hoàn tất"). Gốc: `is_hk1_cleared` coi `partial + paid>0` = "cleared" → bắn `sync_lead_tuition_paid` → đẩy lead lên sts10 ngay lần đóng đầu tiên.

## Thay đổi

- **`is_hk1_cleared` → `is_hk1_settled`** (`fee_calculation_service.py`): đổi signature (+`final_amount`, +`waived_amount`); "settled" = `paid`/`waived` hoặc `remaining<=0`; **giữ guard `status != cancelled`** (chống fee zero-out `0<=0=True` làm sai void-revert). Bỏ nhánh `partial+paid>0`.
- Cập nhật **đúng 7 call-site** (verify_payment ×2, payment_intent ×2, payment_import ×3) — truyền thêm 2 tham số.
- **Hệ quả:** đóng một phần → lead **giữ sts14** "Chưa hoàn tất học phí"; đóng đủ → sts10.
- **Không đụng** cổng nhập học `_check_fee_gate_semester_hk1` (giữ partial-permissive theo ADR-002 — chỉ đổi NHÃN lead, không đổi điều kiện nhập học).
- Cải thiện kèm: `void_batch` — void để lại remaining>0 nay revert lead khỏi sts10 (test combo manual+import khoá hành vi).

## Backfill (chạy SAU khi merge + deploy code)

`scripts/backfill_sts10_partial_to_sts14.py` — dry-run mặc định + `--apply` (prompt + backup snapshot). Reuse `revert_lead_tuition_paid` (restore-from-history + guard "đang sts10", cô lập anomaly). **⚠️ Thứ tự bắt buộc: code live TRƯỚC, rồi mới backfill** (tránh forward logic cũ re-mislabel).

## Test

- Viết lại block helper `is_hk1_settled` (partial→False + edge cancelled zero-out) + sửa `test_tuition_prepay_flow` (partial→giữ sts14, full→sts10) + test combo `void_batch`.
- **172 + 14 test xanh** (one-off container).

## Deploy

Code-only (không migration, không Casbin) → deploy code → chạy script backfill → verify `MISLABELED_partial = 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)