### PR TITLE
feat(finance): cancel_fee hoàn thiện đối xứng revert lead + chặn mất tiền (PR-2)

### DIFF
--- a/Backend_FastAPI/alembic/versions/feecancel20260628001_fee_partial_unique_exclude_cancelled.py
+++ b/Backend_FastAPI/alembic/versions/feecancel20260628001_fee_partial_unique_exclude_cancelled.py
@@ -1,0 +1,79 @@
+"""PR-2: fee partial unique indexes exclude cancelled (allow re-calc after cancel)
+
+Narrows the two fee uniqueness partial indexes to ``AND status <> 'cancelled'``:
+  * ``uq_fee_profile_type_year_nontuition`` (non-tuition, by academic_year)
+  * ``uq_fee_profile_type_semester_tuition`` (tuition, by semester_no)
+
+so a CANCELLED fee (e.g. tính nhầm rồi huỷ qua ``cancel_fee``) no longer reserves
+its uniqueness slot — enabling re-calculation of a correct fee without a hard
+DELETE. Pairs with ``FeeRepository.check_duplicate`` (also excludes cancelled).
+
+These are partial ``Index(...)`` objects (NOT a UNIQUE constraint), so upgrade
+uses ``op.drop_index`` (NOT ``op.drop_constraint``).
+
+Revision ID: feecancel20260628001
+Revises: tcf20260627002
+Create Date: 2026-06-28
+
+Upgrade safety
+--------------
+Narrowing the predicate (``WHERE ... AND status <> 'cancelled'``) is a SUBSET of
+the existing index population — every slot was already unique, so creating the
+narrower unique index cannot collide.
+
+Downgrade safety
+----------------
+Widening back to include cancelled rows will FAIL if any uniqueness tuple now
+has BOTH a cancelled and an active fee (a state this migration intentionally
+allows once a fee is re-calculated after cancellation). Resolve such duplicates
+(remove/merge the stale cancelled rows) BEFORE downgrading.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "feecancel20260628001"
+down_revision = "tcf20260627002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("uq_fee_profile_type_year_nontuition", table_name="fee")
+    op.create_index(
+        "uq_fee_profile_type_year_nontuition",
+        "fee",
+        ["admission_profile_id", "fee_type", "academic_year"],
+        unique=True,
+        postgresql_where=sa.text("fee_type <> 'tuition' AND status <> 'cancelled'"),
+    )
+
+    op.drop_index("uq_fee_profile_type_semester_tuition", table_name="fee")
+    op.create_index(
+        "uq_fee_profile_type_semester_tuition",
+        "fee",
+        ["admission_profile_id", "fee_type", "semester_no"],
+        unique=True,
+        postgresql_where=sa.text("fee_type = 'tuition' AND status <> 'cancelled'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_fee_profile_type_year_nontuition", table_name="fee")
+    op.create_index(
+        "uq_fee_profile_type_year_nontuition",
+        "fee",
+        ["admission_profile_id", "fee_type", "academic_year"],
+        unique=True,
+        postgresql_where=sa.text("fee_type <> 'tuition'"),
+    )
+
+    op.drop_index("uq_fee_profile_type_semester_tuition", table_name="fee")
+    op.create_index(
+        "uq_fee_profile_type_semester_tuition",
+        "fee",
+        ["admission_profile_id", "fee_type", "semester_no"],
+        unique=True,
+        postgresql_where=sa.text("fee_type = 'tuition'"),
+    )

--- a/Backend_FastAPI/app/models/finance/fee.py
+++ b/Backend_FastAPI/app/models/finance/fee.py
@@ -93,20 +93,23 @@ class Fee(Base):
 
     __table_args__ = (
         # Partial unique index: preserve pre-PR1 non-tuition behavior.
-        # Matches fee_repository.check_duplicate() semantics exactly.
+        # Excludes cancelled fees so a cancelled (e.g. tính nhầm) fee does NOT
+        # block re-calculating a correct one. Matches
+        # fee_repository.check_duplicate() semantics exactly.
         Index(
             'uq_fee_profile_type_year_nontuition',
             'admission_profile_id', 'fee_type', 'academic_year',
             unique=True,
-            postgresql_where=text("fee_type <> 'tuition'"),
+            postgresql_where=text("fee_type <> 'tuition' AND status <> 'cancelled'"),
         ),
         # Partial unique index: new per-semester uniqueness for tuition.
-        # Allows HK1/HK2/HK3/... on the same profile in the same year.
+        # Allows HK1/HK2/HK3/... on the same profile in the same year, and
+        # allows re-calc after a cancelled (status <> 'cancelled').
         Index(
             'uq_fee_profile_type_semester_tuition',
             'admission_profile_id', 'fee_type', 'semester_no',
             unique=True,
-            postgresql_where=text("fee_type = 'tuition'"),
+            postgresql_where=text("fee_type = 'tuition' AND status <> 'cancelled'"),
         ),
         CheckConstraint(
             'base_amount >= 0 AND total_discount >= 0 AND final_amount >= 0 '

--- a/Backend_FastAPI/app/repositories/fee_repository.py
+++ b/Backend_FastAPI/app/repositories/fee_repository.py
@@ -360,6 +360,11 @@ class FeeRepository(BaseRepository[Fee]):
         Returns:
             True if duplicate exists
         """
+        # Exclude cancelled fees: they no longer occupy the partial unique
+        # index (uq_fee_*_active, status <> 'cancelled'), so a fee that was
+        # cancelled (e.g. tính nhầm) must NOT block re-calculating a correct
+        # one. Keep this predicate in lock-step with those partial indexes.
+        not_cancelled = Fee.status != FeeStatusEnum.cancelled.value
         if fee_type == "tuition" and semester_no is not None:
             query = (
                 select(func.count(Fee.id))
@@ -368,6 +373,7 @@ class FeeRepository(BaseRepository[Fee]):
                         Fee.admission_profile_id == profile_id,
                         Fee.fee_type == fee_type,
                         Fee.semester_no == semester_no,
+                        not_cancelled,
                     )
                 )
             )
@@ -384,6 +390,7 @@ class FeeRepository(BaseRepository[Fee]):
                         Fee.admission_profile_id == profile_id,
                         Fee.fee_type == fee_type,
                         Fee.academic_year == academic_year_int,
+                        not_cancelled,
                     )
                 )
             )

--- a/Backend_FastAPI/app/services/admission_choice_service.py
+++ b/Backend_FastAPI/app/services/admission_choice_service.py
@@ -582,11 +582,10 @@ class AdmissionChoiceService:
         there is no fee delete/supersede flow). Hence only non-cancelled tuition
         fees freeze add/delete/reorder/score-replace.
 
-        Residual (tracked as debt): re-creating an HK1 fee AFTER a cancel is
-        still blocked by ``check_duplicate`` + the partial-unique index
-        ``uq_fee_profile_type_semester_tuition`` (both ignore status, so the
-        cancelled row keeps the ``(profile, tuition, semester_no)`` slot) — that
-        needs a dedicated void/supersede flow.
+        Re-creating an HK1 fee AFTER a cancel IS now allowed: ``check_duplicate``
+        and the partial-unique index ``uq_fee_profile_type_semester_tuition``
+        both exclude ``status = 'cancelled'`` (PR-2), so a cancelled row no
+        longer reserves the ``(profile, tuition, semester_no)`` slot.
         """
         if await self.fee_repo.has_active_tuition_fee(profile.id):
             raise BusinessRuleViolation(

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -940,39 +940,44 @@ class FeeCalculationService:
                 f"Paid amount: {fee.paid_amount} VND"
             )
 
-        # Non-cancelled invoices (draft/issued/partial/overdue). fee.paid_amount
-        # == 0 ⟹ every one of these is unpaid → safe to cancel.
-        active_invoices = await self.invoice_repo.get_by_fee_id(
-            fee_id, unit_id, active_only=True
+        # ALL invoices of the fee (incl cancelled). The guards must see a
+        # payment/intent even on an invoice cancelled INDEPENDENTLY (e.g. the
+        # MISA cancel-and-reissue flow): a still-live intent on a cancelled
+        # invoice would otherwise slip past and later land gateway money the
+        # callback must refuse. The cascade below only re-cancels the
+        # non-cancelled ones.
+        all_invoices = await self.invoice_repo.get_by_fee_id(
+            fee_id, unit_id, active_only=False
         )
-        invoice_ids = [inv.id for inv in active_invoices]
+        all_invoice_ids = [inv.id for inv in all_invoices]
+        active_invoices = [
+            inv for inv in all_invoices
+            if inv.status != InvoiceStatusEnum.cancelled.value
+        ]
 
-        if invoice_ids:
+        if all_invoice_ids:
             # Guard A: a pending (unverified) manual payment must be resolved
-            # first — it is not in fee.paid_amount yet but would write money on
-            # a cancelled fee when verified.
-            pending_payments = (
-                await self.db.execute(
-                    sa.select(sa.func.count(Payment.id)).where(
-                        Payment.invoice_id.in_(invoice_ids),
-                        Payment.status == PaymentStatusEnum.pending.value,
-                    )
-                )
-            ).scalar() or 0
-            if pending_payments:
+            # first — it is not in fee.paid_amount yet but would write money on a
+            # cancelled fee when verified. Invoice.payments is eager-loaded by
+            # get_by_fee_id → check in-Python (no extra round-trip).
+            if any(
+                p.status == PaymentStatusEnum.pending.value
+                for inv in all_invoices
+                for p in inv.payments
+            ):
                 raise BusinessRuleViolation(
                     "Không thể huỷ khoản phí: đang có khoản thanh toán chờ xác "
                     "minh. Vui lòng xác minh hoặc từ chối trước khi huỷ."
                 )
 
-            # Guard B: an active online intent could still report success. If we
-            # cancel now, the late callback is rejected by can_process_callback
-            # (terminal/cancelled) → money received but unrecorded. Block.
+            # Guard B: a still-processable online intent on ANY invoice of the
+            # fee could report success after cancel; the callback would then be
+            # rejected (cancelled target) → money received but unrecorded. Block.
             now = datetime.now(timezone.utc)
             active_intents = (
                 await self.db.execute(
                     sa.select(sa.func.count(PaymentIntent.id)).where(
-                        PaymentIntent.invoice_id.in_(invoice_ids),
+                        PaymentIntent.invoice_id.in_(all_invoice_ids),
                         PaymentIntent.status.in_(
                             [
                                 PaymentIntentStatusEnum.created.value,
@@ -1004,23 +1009,55 @@ class FeeCalculationService:
 
         await self.db.flush()
 
-        # Lead projection reverse: ONLY HK1 tuition projects onto the lead.
-        # Restore the pre-sts14 status from history (symmetric forward sync) —
-        # NOT a hardcoded target. revert_lead_tuition_calculated guards on the
-        # lead still being at sts14, so a lead that advanced (paid/enrolled) is
-        # left untouched. Best-effort: a missing profile/lead never blocks cancel.
+        # Lead projection reverse: ONLY HK1 tuition projects onto the lead, and
+        # ONLY when NO OTHER non-cancelled HK1 tuition fee remains for the lead.
+        # A multi-year lead may still owe HK1 on another profile/year — the
+        # forward sync floors the lead at sts14 once (lead-level idempotent), so
+        # cancelling one HK1 fee must not clear that label while another HK1
+        # obligation stands. revert_lead_tuition_calculated additionally guards
+        # on the lead still being at sts14. Best-effort: wrap in a SAVEPOINT so a
+        # projection failure never rolls back the cancel itself.
         if fee.fee_type == FeeTypeEnum.tuition.value and fee.semester_no == 1:
             profile = await self._get_profile(fee.admission_profile_id, unit_id)
             if profile is not None:
-                from app.services.lead_admission_sync import (
-                    revert_lead_tuition_calculated,
-                )
-                await revert_lead_tuition_calculated(
-                    db=self.db,
-                    profile=profile,
-                    changed_by_user_id=user_id,
-                    reason=f"Huỷ khoản học phí HK1 (tính nhầm). Lý do: {reason}",
-                )
+                other_hk1 = (
+                    await self.db.execute(
+                        sa.select(sa.func.count(Fee.id))
+                        .join(
+                            models.AdmissionProfile,
+                            models.AdmissionProfile.id
+                            == Fee.admission_profile_id,
+                        )
+                        .where(
+                            models.AdmissionProfile.lead_id == profile.lead_id,
+                            Fee.fee_type == FeeTypeEnum.tuition.value,
+                            Fee.semester_no == 1,
+                            Fee.status != FeeStatusEnum.cancelled.value,
+                        )
+                    )
+                ).scalar() or 0
+                if other_hk1 == 0:
+                    from app.services.lead_admission_sync import (
+                        revert_lead_tuition_calculated,
+                    )
+                    try:
+                        async with self.db.begin_nested():
+                            await revert_lead_tuition_calculated(
+                                db=self.db,
+                                profile=profile,
+                                changed_by_user_id=user_id,
+                                reason=(
+                                    "Huỷ khoản học phí HK1 (tính nhầm). "
+                                    f"Lý do: {reason}"
+                                ),
+                            )
+                    except Exception:
+                        log.warning(
+                            "cancel_fee: lead projection revert failed "
+                            "(best-effort, cancel kept)",
+                            fee_id=fee_id,
+                            exc_info=True,
+                        )
 
         log.info(
             "fee_cancelled",

--- a/Backend_FastAPI/app/services/fee_calculation_service.py
+++ b/Backend_FastAPI/app/services/fee_calculation_service.py
@@ -33,7 +33,8 @@ from sqlalchemy.orm import selectinload
 from app import models
 from app.models.finance import (
     Fee, FeeAppliedDiscount, Invoice, Payment, InstallmentPlan,
-    FeeTypeEnum, FeeStatusEnum,
+    FeeTypeEnum, FeeStatusEnum, InvoiceStatusEnum, PaymentStatusEnum,
+    PaymentIntent, PaymentIntentStatusEnum,
 )
 from app.models.tuition_discount_policy import TuitionDiscountPolicy
 from app.repositories.fee_repository import FeeRepository, InvoiceRepository
@@ -899,7 +900,21 @@ class FeeCalculationService:
         unit_id: Optional[int] = None,
     ) -> Tuple[Fee, Optional[Callable]]:
         """
-        Cancel a fee (only if no payments made).
+        Cancel a fee — back out a mistakenly-created/calculated fee.
+
+        Only allowed when nothing has been collected (``fee.paid_amount == 0``)
+        and no payment is mid-flight. Hardening (Nhóm B):
+          * Block if any unverified ``pending`` payment exists on the fee's
+            invoices (would land money on a dead fee once verified).
+          * Block if an active online ``PaymentIntent`` (created/pending, not
+            expired) exists — a late gateway success would be rejected by
+            ``can_process_callback`` AFTER the fee is cancelled, black-holing the
+            money. Let the intent complete/expire first.
+          * Cascade-cancel EVERY non-cancelled invoice of the fee (incl
+            ``draft``) in the SAME transaction — matches the FE FeeCancelDialog
+            promise and removes the payable surface.
+          * For HK1 tuition only, revert the lead off sts14 (symmetric to the
+            forward ``sync_lead_tuition_calculated`` projection).
 
         Args:
             fee_id: Fee to cancel
@@ -912,7 +927,8 @@ class FeeCalculationService:
 
         Raises:
             ResourceNotFoundError: If fee not found
-            BusinessRuleViolation: If fee has payments
+            BusinessRuleViolation: If fee has payments / pending payment /
+                active online intent
         """
         fee = await self.fee_repo.get_for_update(fee_id, unit_id)
         if not fee:
@@ -924,18 +940,94 @@ class FeeCalculationService:
                 f"Paid amount: {fee.paid_amount} VND"
             )
 
+        # Non-cancelled invoices (draft/issued/partial/overdue). fee.paid_amount
+        # == 0 ⟹ every one of these is unpaid → safe to cancel.
+        active_invoices = await self.invoice_repo.get_by_fee_id(
+            fee_id, unit_id, active_only=True
+        )
+        invoice_ids = [inv.id for inv in active_invoices]
+
+        if invoice_ids:
+            # Guard A: a pending (unverified) manual payment must be resolved
+            # first — it is not in fee.paid_amount yet but would write money on
+            # a cancelled fee when verified.
+            pending_payments = (
+                await self.db.execute(
+                    sa.select(sa.func.count(Payment.id)).where(
+                        Payment.invoice_id.in_(invoice_ids),
+                        Payment.status == PaymentStatusEnum.pending.value,
+                    )
+                )
+            ).scalar() or 0
+            if pending_payments:
+                raise BusinessRuleViolation(
+                    "Không thể huỷ khoản phí: đang có khoản thanh toán chờ xác "
+                    "minh. Vui lòng xác minh hoặc từ chối trước khi huỷ."
+                )
+
+            # Guard B: an active online intent could still report success. If we
+            # cancel now, the late callback is rejected by can_process_callback
+            # (terminal/cancelled) → money received but unrecorded. Block.
+            now = datetime.now(timezone.utc)
+            active_intents = (
+                await self.db.execute(
+                    sa.select(sa.func.count(PaymentIntent.id)).where(
+                        PaymentIntent.invoice_id.in_(invoice_ids),
+                        PaymentIntent.status.in_(
+                            [
+                                PaymentIntentStatusEnum.created.value,
+                                PaymentIntentStatusEnum.pending.value,
+                            ]
+                        ),
+                        PaymentIntent.expires_at > now,
+                    )
+                )
+            ).scalar() or 0
+            if active_intents:
+                raise BusinessRuleViolation(
+                    "Không thể huỷ khoản phí: đang có giao dịch online chờ xử "
+                    "lý. Vui lòng đợi giao dịch hoàn tất/hết hạn rồi huỷ."
+                )
+
+        now = datetime.now(timezone.utc)
+        # Cascade-cancel every non-cancelled invoice in the same transaction.
+        for inv in active_invoices:
+            inv.status = InvoiceStatusEnum.cancelled.value
+            inv.cancelled_at = now
+            inv.cancelled_by_id = user_id
+            inv.cancelled_reason = reason
+
         fee.status = FeeStatusEnum.cancelled.value
         fee.version += 1
-        fee.notes = f"{fee.notes or ''}\n[{datetime.now(timezone.utc).isoformat()}] " \
+        fee.notes = f"{fee.notes or ''}\n[{now.isoformat()}] " \
                     f"Cancelled by user {user_id}. Reason: {reason}"
 
         await self.db.flush()
+
+        # Lead projection reverse: ONLY HK1 tuition projects onto the lead.
+        # Restore the pre-sts14 status from history (symmetric forward sync) —
+        # NOT a hardcoded target. revert_lead_tuition_calculated guards on the
+        # lead still being at sts14, so a lead that advanced (paid/enrolled) is
+        # left untouched. Best-effort: a missing profile/lead never blocks cancel.
+        if fee.fee_type == FeeTypeEnum.tuition.value and fee.semester_no == 1:
+            profile = await self._get_profile(fee.admission_profile_id, unit_id)
+            if profile is not None:
+                from app.services.lead_admission_sync import (
+                    revert_lead_tuition_calculated,
+                )
+                await revert_lead_tuition_calculated(
+                    db=self.db,
+                    profile=profile,
+                    changed_by_user_id=user_id,
+                    reason=f"Huỷ khoản học phí HK1 (tính nhầm). Lý do: {reason}",
+                )
 
         log.info(
             "fee_cancelled",
             fee_id=fee_id,
             reason=reason,
             user_id=user_id,
+            invoices_cancelled=len(active_invoices),
         )
 
         return fee, None

--- a/Backend_FastAPI/app/services/lead_admission_sync.py
+++ b/Backend_FastAPI/app/services/lead_admission_sync.py
@@ -735,6 +735,100 @@ async def revert_lead_tuition_paid(
     return True
 
 
+async def revert_lead_tuition_calculated(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    changed_by_user_id: Optional[int] = None,
+    reason: Optional[str] = None,
+) -> bool:
+    """Đảo projection "HK1 đã tính học phí": đưa lead VỀ status TRƯỚC khi
+    ``sync_lead_tuition_calculated`` đẩy lên sts14 (Chưa hoàn tất học phí).
+
+    Dùng khi HUỶ khoản học phí HK1 tính NHẦM (``cancel_fee``) — KẾ TOÁN SỬA
+    NHẦM ghi nhận, KHÔNG phải học sinh rút. Đối xứng forward sync. KHÔNG hardcode
+    đích (vd sts09): khôi phục đúng status TRƯỚC đó từ LeadStatusHistory — ca
+    thực tế có thể là sts13 "đã hoàn lệ phí" khi profile vẫn ``submitted``, ÉP
+    sts09 sẽ nâng sai lên "đủ điều kiện".
+
+    An toàn:
+      1. Chỉ lùi khi lead ĐANG ở sts14. Đã chuyển tiếp (đóng đủ → sts10, nhập
+         học…) → tôn trọng trạng thái hiện tại, KHÔNG kéo lùi pipeline.
+      2. Khôi phục từ LeadStatusHistory GẦN NHẤT đã đẩy lead VÀO sts14 (trường
+         old_*). Không có bản ghi → không biết lùi đâu → bỏ qua + log.
+
+    Caller PHẢI gate: chỉ HK1 tuition + chỉ khi fee bị huỷ (paid_amount == 0).
+
+    Returns True nếu đã lùi, False nếu bỏ qua.
+    """
+    lead = profile.lead
+    if not lead:
+        log.warning(
+            "revert_lead_tuition_calculated: Lead not loaded", profile_id=profile.id
+        )
+        return False
+
+    # Guard 1: chỉ lùi khi lead đang ở sts14 (chưa ai chuyển tiếp).
+    if lead.consultation_status_id != TUITION_CALCULATED_STATUS:
+        log.debug(
+            "revert_lead_tuition_calculated: lead not at tuition-calculated, skip",
+            lead_id=lead.id,
+            current_status=lead.consultation_status_id,
+        )
+        return False
+
+    # Bản ghi forward GẦN NHẤT (→ sts14) → biết status TRƯỚC đó.
+    hist = (
+        await db.execute(
+            select(models.LeadStatusHistory)
+            .where(
+                models.LeadStatusHistory.lead_id == lead.id,
+                models.LeadStatusHistory.new_consultation_status_id
+                == TUITION_CALCULATED_STATUS,
+            )
+            .order_by(models.LeadStatusHistory.id.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if hist is None:
+        log.warning(
+            "revert_lead_tuition_calculated: no forward history, skip",
+            lead_id=lead.id,
+        )
+        return False
+
+    cur_status = lead.status
+    cur_consult = lead.consultation_status_id
+    cur_stage = lead.pipeline_stage_id
+
+    # Khôi phục giá trị TRƯỚC forward-sync (verbatim từ history, KHÔNG re-derive).
+    lead.consultation_status_id = hist.old_consultation_status_id
+    lead.pipeline_stage_id = hist.old_pipeline_stage_id
+    lead.status = hist.old_status or cur_status
+
+    db.add(
+        models.LeadStatusHistory(
+            lead_id=lead.id,
+            old_status=cur_status,
+            new_status=lead.status,
+            old_consultation_status_id=cur_consult,
+            new_consultation_status_id=lead.consultation_status_id,
+            old_pipeline_stage_id=cur_stage,
+            new_pipeline_stage_id=lead.pipeline_stage_id,
+            changed_by_user_id=changed_by_user_id,
+            reason=reason or "Huỷ khoản học phí tính nhầm (cancel_fee)",
+        )
+    )
+    await db.flush()
+
+    log.info(
+        "revert_lead_tuition_calculated: lead reverted from tuition-calculated",
+        lead_id=lead.id,
+        profile_id=profile.id,
+        to_consultation_status=lead.consultation_status_id,
+    )
+    return True
+
+
 async def sync_lead_tuition_refunded(
     db: AsyncSession,
     profile: models.AdmissionProfile,

--- a/Backend_FastAPI/app/services/lead_admission_sync.py
+++ b/Backend_FastAPI/app/services/lead_admission_sync.py
@@ -643,70 +643,67 @@ async def sync_lead_tuition_paid(
     return True
 
 
-async def revert_lead_tuition_paid(
+async def _revert_lead_projection(
     db: AsyncSession,
     profile: models.AdmissionProfile,
+    *,
+    projected_status: str,
+    default_reason: str,
+    log_label: str,
     changed_by_user_id: Optional[int] = None,
     reason: Optional[str] = None,
 ) -> bool:
-    """Đảo projection "HK1 đã đóng": đưa lead VỀ status TRƯỚC khi
-    ``sync_lead_tuition_paid`` đẩy lên sts10 (Đã hoàn tất học phí).
+    """Shared body for reverting a finance→lead projection.
 
-    Dùng khi VOID (đảo) lô import đã ghi nhận học phí HK1 — đây là KẾ TOÁN SỬA
-    NHẦM ghi nhận, KHÔNG phải học sinh rút (luồng rút =
-    ``sync_lead_tuition_refunded`` → sts18). Đối xứng forward sync.
+    Restores the lead to the status it held BEFORE it was projected into
+    ``projected_status`` — read VERBATIM (no re-derive) from the most-recent
+    ``LeadStatusHistory`` row that set it. Symmetric to the forward sync.
 
-    An toàn:
-      1. Chỉ lùi khi lead ĐANG ở sts10. Đã chuyển tiếp (nhập học…) → tôn trọng
-         trạng thái hiện tại, KHÔNG kéo lùi pipeline.
-      2. Khôi phục từ LeadStatusHistory GẦN NHẤT đã đẩy lead VÀO sts10 (trường
-         old_*). Không có bản ghi → không biết lùi đâu → bỏ qua + log.
+    Safety (same for both the sts10 and sts14 reverts):
+      1. Only acts when the lead is CURRENTLY at ``projected_status`` — a lead
+         that advanced afterwards is left untouched (never drag the pipeline
+         back).
+      2. No forward history row → cannot know the prior state → skip + log.
 
-    Caller PHẢI gate: chỉ HK1 + chỉ khi fee KHÔNG còn cleared sau khi đảo tiền.
-
-    Returns True nếu đã lùi, False nếu bỏ qua.
+    Returns True if reverted, False if skipped.
     """
     lead = profile.lead
     if not lead:
-        log.warning(
-            "revert_lead_tuition_paid: Lead not loaded", profile_id=profile.id
-        )
+        log.warning(f"{log_label}: Lead not loaded", profile_id=profile.id)
         return False
 
-    # Guard 1: chỉ lùi khi lead đang ở sts10 (chưa ai chuyển tiếp).
-    if lead.consultation_status_id != TUITION_PAID_STATUS:
+    # Guard 1: only revert while the lead still sits at the projected status.
+    if lead.consultation_status_id != projected_status:
         log.debug(
-            "revert_lead_tuition_paid: lead not at tuition-paid, skip",
+            f"{log_label}: lead not at projected status, skip",
             lead_id=lead.id,
             current_status=lead.consultation_status_id,
         )
         return False
 
-    # Bản ghi forward GẦN NHẤT (→ sts10) → biết status TRƯỚC đó.
+    # Most-recent forward row (→ projected_status) carries the prior state.
     hist = (
         await db.execute(
             select(models.LeadStatusHistory)
             .where(
                 models.LeadStatusHistory.lead_id == lead.id,
                 models.LeadStatusHistory.new_consultation_status_id
-                == TUITION_PAID_STATUS,
+                == projected_status,
             )
             .order_by(models.LeadStatusHistory.id.desc())
             .limit(1)
         )
     ).scalar_one_or_none()
     if hist is None:
-        log.warning(
-            "revert_lead_tuition_paid: no forward history, skip", lead_id=lead.id
-        )
+        log.warning(f"{log_label}: no forward history, skip", lead_id=lead.id)
         return False
 
     cur_status = lead.status
     cur_consult = lead.consultation_status_id
     cur_stage = lead.pipeline_stage_id
 
-    # Khôi phục giá trị TRƯỚC forward-sync. lead.status NOT NULL → fallback giữ hiện
-    # tại nếu history old_status rỗng (gần như không xảy ra: Lead.status default 'new').
+    # Restore the pre-projection values. lead.status is NOT NULL → fall back to
+    # the current value if the history old_status is empty (≈never: default 'new').
     lead.consultation_status_id = hist.old_consultation_status_id
     lead.pipeline_stage_id = hist.old_pipeline_stage_id
     lead.status = hist.old_status or cur_status
@@ -721,18 +718,42 @@ async def revert_lead_tuition_paid(
             old_pipeline_stage_id=cur_stage,
             new_pipeline_stage_id=lead.pipeline_stage_id,
             changed_by_user_id=changed_by_user_id,
-            reason=reason or "Đảo ghi nhận học phí (void lô import)",
+            reason=reason or default_reason,
         )
     )
     await db.flush()
 
     log.info(
-        "revert_lead_tuition_paid: lead reverted from tuition-paid",
+        f"{log_label}: lead reverted",
         lead_id=lead.id,
         profile_id=profile.id,
         to_consultation_status=lead.consultation_status_id,
     )
     return True
+
+
+async def revert_lead_tuition_paid(
+    db: AsyncSession,
+    profile: models.AdmissionProfile,
+    changed_by_user_id: Optional[int] = None,
+    reason: Optional[str] = None,
+) -> bool:
+    """Đảo projection "HK1 đã đóng": đưa lead VỀ status TRƯỚC khi
+    ``sync_lead_tuition_paid`` đẩy lên sts10 (Đã hoàn tất học phí).
+
+    Dùng khi VOID (đảo) lô import đã ghi nhận học phí HK1 — KẾ TOÁN SỬA NHẦM ghi
+    nhận, KHÔNG phải học sinh rút (luồng rút = ``sync_lead_tuition_refunded`` →
+    sts18). Caller PHẢI gate: chỉ HK1 + chỉ khi fee KHÔNG còn settled sau đảo.
+    """
+    return await _revert_lead_projection(
+        db,
+        profile,
+        projected_status=TUITION_PAID_STATUS,
+        default_reason="Đảo ghi nhận học phí (void lô import)",
+        log_label="revert_lead_tuition_paid",
+        changed_by_user_id=changed_by_user_id,
+        reason=reason,
+    )
 
 
 async def revert_lead_tuition_calculated(
@@ -744,89 +765,21 @@ async def revert_lead_tuition_calculated(
     """Đảo projection "HK1 đã tính học phí": đưa lead VỀ status TRƯỚC khi
     ``sync_lead_tuition_calculated`` đẩy lên sts14 (Chưa hoàn tất học phí).
 
-    Dùng khi HUỶ khoản học phí HK1 tính NHẦM (``cancel_fee``) — KẾ TOÁN SỬA
-    NHẦM ghi nhận, KHÔNG phải học sinh rút. Đối xứng forward sync. KHÔNG hardcode
-    đích (vd sts09): khôi phục đúng status TRƯỚC đó từ LeadStatusHistory — ca
-    thực tế có thể là sts13 "đã hoàn lệ phí" khi profile vẫn ``submitted``, ÉP
-    sts09 sẽ nâng sai lên "đủ điều kiện".
-
-    An toàn:
-      1. Chỉ lùi khi lead ĐANG ở sts14. Đã chuyển tiếp (đóng đủ → sts10, nhập
-         học…) → tôn trọng trạng thái hiện tại, KHÔNG kéo lùi pipeline.
-      2. Khôi phục từ LeadStatusHistory GẦN NHẤT đã đẩy lead VÀO sts14 (trường
-         old_*). Không có bản ghi → không biết lùi đâu → bỏ qua + log.
-
-    Caller PHẢI gate: chỉ HK1 tuition + chỉ khi fee bị huỷ (paid_amount == 0).
-
-    Returns True nếu đã lùi, False nếu bỏ qua.
+    Dùng khi HUỶ khoản học phí HK1 tính NHẦM (``cancel_fee``). KHÔNG hardcode đích
+    (vd sts09): khôi phục đúng status TRƯỚC đó từ history — ca thực tế có thể là
+    sts13 "đã hoàn lệ phí" khi profile vẫn ``submitted``, ÉP sts09 sẽ nâng sai
+    lên "đủ điều kiện". Caller PHẢI gate: chỉ HK1 tuition + fee bị huỷ
+    (paid_amount == 0) + lead không còn nợ HK1 năm/profile khác.
     """
-    lead = profile.lead
-    if not lead:
-        log.warning(
-            "revert_lead_tuition_calculated: Lead not loaded", profile_id=profile.id
-        )
-        return False
-
-    # Guard 1: chỉ lùi khi lead đang ở sts14 (chưa ai chuyển tiếp).
-    if lead.consultation_status_id != TUITION_CALCULATED_STATUS:
-        log.debug(
-            "revert_lead_tuition_calculated: lead not at tuition-calculated, skip",
-            lead_id=lead.id,
-            current_status=lead.consultation_status_id,
-        )
-        return False
-
-    # Bản ghi forward GẦN NHẤT (→ sts14) → biết status TRƯỚC đó.
-    hist = (
-        await db.execute(
-            select(models.LeadStatusHistory)
-            .where(
-                models.LeadStatusHistory.lead_id == lead.id,
-                models.LeadStatusHistory.new_consultation_status_id
-                == TUITION_CALCULATED_STATUS,
-            )
-            .order_by(models.LeadStatusHistory.id.desc())
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-    if hist is None:
-        log.warning(
-            "revert_lead_tuition_calculated: no forward history, skip",
-            lead_id=lead.id,
-        )
-        return False
-
-    cur_status = lead.status
-    cur_consult = lead.consultation_status_id
-    cur_stage = lead.pipeline_stage_id
-
-    # Khôi phục giá trị TRƯỚC forward-sync (verbatim từ history, KHÔNG re-derive).
-    lead.consultation_status_id = hist.old_consultation_status_id
-    lead.pipeline_stage_id = hist.old_pipeline_stage_id
-    lead.status = hist.old_status or cur_status
-
-    db.add(
-        models.LeadStatusHistory(
-            lead_id=lead.id,
-            old_status=cur_status,
-            new_status=lead.status,
-            old_consultation_status_id=cur_consult,
-            new_consultation_status_id=lead.consultation_status_id,
-            old_pipeline_stage_id=cur_stage,
-            new_pipeline_stage_id=lead.pipeline_stage_id,
-            changed_by_user_id=changed_by_user_id,
-            reason=reason or "Huỷ khoản học phí tính nhầm (cancel_fee)",
-        )
+    return await _revert_lead_projection(
+        db,
+        profile,
+        projected_status=TUITION_CALCULATED_STATUS,
+        default_reason="Huỷ khoản học phí tính nhầm (cancel_fee)",
+        log_label="revert_lead_tuition_calculated",
+        changed_by_user_id=changed_by_user_id,
+        reason=reason,
     )
-    await db.flush()
-
-    log.info(
-        "revert_lead_tuition_calculated: lead reverted from tuition-calculated",
-        lead_id=lead.id,
-        profile_id=profile.id,
-        to_consultation_status=lead.consultation_status_id,
-    )
-    return True
 
 
 async def sync_lead_tuition_refunded(

--- a/Backend_FastAPI/app/services/payment_intent_service.py
+++ b/Backend_FastAPI/app/services/payment_intent_service.py
@@ -46,6 +46,7 @@ from app.repositories.payment_repository import (
     PaymentIntentRepository,
     PaymentTransactionRepository,
 )
+from app.services.payment_service import assert_payable_target
 from app.utils.exceptions import (
     ResourceNotFoundError,
     BadRequest,
@@ -209,10 +210,9 @@ class PaymentIntentService:
         # cancelled when we check here (we refuse). create_intent takes only the
         # fee lock (no invoice lock) → no ABBA with verify/callback (invoice→fee).
         fee = await self.fee_repo.get_for_update(invoice.fee_id, unit_id)
-        if fee is None or fee.status == FeeStatusEnum.cancelled.value:
-            raise BusinessRuleViolation(
-                "Không thể tạo giao dịch thanh toán: khoản phí đã bị huỷ."
-            )
+        if fee is None:
+            raise ResourceNotFoundError("Fee not found")
+        assert_payable_target(fee, invoice, action="tạo giao dịch thanh toán")
 
         # Get payment method
         method = await self._get_payment_method(method_id)
@@ -603,13 +603,7 @@ class PaymentIntentService:
         # path can't reach here; this also closes the manual cancel-invoice /
         # cancel-intent surface. A late gateway success on a dead target is
         # refused — the caller marks the intent failed; reconcile out-of-band.
-        if (
-            fee.status == FeeStatusEnum.cancelled.value
-            or invoice.status == InvoiceStatusEnum.cancelled.value
-        ):
-            raise BusinessRuleViolation(
-                "Không thể ghi nhận thanh toán: khoản phí/hoá đơn đã bị huỷ."
-            )
+        assert_payable_target(fee, invoice, action="ghi nhận thanh toán")
 
         # Capture balance before
         fee_balance_before = fee.final_amount - fee.paid_amount - fee.waived_amount

--- a/Backend_FastAPI/app/services/payment_intent_service.py
+++ b/Backend_FastAPI/app/services/payment_intent_service.py
@@ -199,6 +199,21 @@ class PaymentIntentService:
                 f"Payment amount ({amount}) exceeds remaining balance ({remaining})"
             )
 
+        # Serialize against cancel_fee, which holds the fee row lock: acquire it
+        # before creating the intent and refuse if the fee is cancelled. This
+        # closes the race where an intent is created on a fee being cancelled —
+        # the gateway could later collect money the callback must refuse
+        # (reconciliation hole). cancel_fee blocks while an active intent exists,
+        # so with this lock the two operations cannot interleave: either the
+        # intent exists when cancel_fee checks (it blocks), or the fee is already
+        # cancelled when we check here (we refuse). create_intent takes only the
+        # fee lock (no invoice lock) → no ABBA with verify/callback (invoice→fee).
+        fee = await self.fee_repo.get_for_update(invoice.fee_id, unit_id)
+        if fee is None or fee.status == FeeStatusEnum.cancelled.value:
+            raise BusinessRuleViolation(
+                "Không thể tạo giao dịch thanh toán: khoản phí đã bị huỷ."
+            )
+
         # Get payment method
         method = await self._get_payment_method(method_id)
         if not method:

--- a/Backend_FastAPI/app/services/payment_intent_service.py
+++ b/Backend_FastAPI/app/services/payment_intent_service.py
@@ -583,6 +583,19 @@ class PaymentIntentService:
         if not fee:
             raise ResourceNotFoundError("Fee not found")
 
+        # Defense-in-depth (Nhóm B): never write money onto a cancelled fee or
+        # invoice. cancel_fee blocks while an active intent exists, so the normal
+        # path can't reach here; this also closes the manual cancel-invoice /
+        # cancel-intent surface. A late gateway success on a dead target is
+        # refused — the caller marks the intent failed; reconcile out-of-band.
+        if (
+            fee.status == FeeStatusEnum.cancelled.value
+            or invoice.status == InvoiceStatusEnum.cancelled.value
+        ):
+            raise BusinessRuleViolation(
+                "Không thể ghi nhận thanh toán: khoản phí/hoá đơn đã bị huỷ."
+            )
+
         # Capture balance before
         fee_balance_before = fee.final_amount - fee.paid_amount - fee.waived_amount
 

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -130,6 +130,24 @@ def reverse_payment_balances(
     return fee_balance_before, fee_remaining
 
 
+def assert_payable_target(
+    fee: Optional[Fee], invoice: Optional[Invoice], *, action: str
+) -> None:
+    """Refuse to act on a cancelled fee/invoice — the SINGLE invariant every
+    money-touching entry runs right after locking the fee+invoice (manual
+    verify, online callback, intent creation). Centralising it means a future
+    fourth entry point can't silently re-open the "ghi tiền vào fee đã huỷ"
+    hole. ``action`` customises the Vietnamese message.
+    """
+    if (fee is not None and fee.status == FeeStatusEnum.cancelled.value) or (
+        invoice is not None
+        and invoice.status == InvoiceStatusEnum.cancelled.value
+    ):
+        raise BusinessRuleViolation(
+            f"Không thể {action}: khoản phí/hoá đơn đã bị huỷ."
+        )
+
+
 class PaymentService:
     """
     Service for manual payment processing with maker-checker workflow.
@@ -367,13 +385,7 @@ class PaymentService:
         # to write money onto a cancelled target — the pending payment is left
         # for rejection. cancel_fee blocks while a pending payment exists, so
         # this only fires for the narrow record-during-cancel race window.
-        if (
-            fee.status == FeeStatusEnum.cancelled.value
-            or invoice.status == InvoiceStatusEnum.cancelled.value
-        ):
-            raise BusinessRuleViolation(
-                "Không thể xác minh thanh toán: khoản phí/hoá đơn đã bị huỷ."
-            )
+        assert_payable_target(fee, invoice, action="xác minh thanh toán")
 
         # Capture settled state BEFORE mutation (PR 5 transition detection)
         from app.services.fee_calculation_service import is_hk1_settled_fee

--- a/Backend_FastAPI/app/services/payment_service.py
+++ b/Backend_FastAPI/app/services/payment_service.py
@@ -362,6 +362,19 @@ class PaymentService:
         if not fee:
             raise ResourceNotFoundError("Fee not found")
 
+        # Defense-in-depth: the fee/invoice may have been cancelled (cancel_fee)
+        # AFTER this pending payment was recorded but BEFORE verification. Refuse
+        # to write money onto a cancelled target — the pending payment is left
+        # for rejection. cancel_fee blocks while a pending payment exists, so
+        # this only fires for the narrow record-during-cancel race window.
+        if (
+            fee.status == FeeStatusEnum.cancelled.value
+            or invoice.status == InvoiceStatusEnum.cancelled.value
+        ):
+            raise BusinessRuleViolation(
+                "Không thể xác minh thanh toán: khoản phí/hoá đơn đã bị huỷ."
+            )
+
         # Capture settled state BEFORE mutation (PR 5 transition detection)
         from app.services.fee_calculation_service import is_hk1_settled_fee
         was_hk1_settled = is_hk1_settled_fee(fee)

--- a/Backend_FastAPI/tests/services/test_fee_calculation_service.py
+++ b/Backend_FastAPI/tests/services/test_fee_calculation_service.py
@@ -14,20 +14,25 @@ Covers:
 
 import pytest
 import pytest_asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta, date
 from decimal import Decimal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import models
 from app.models.finance import (
-    Fee, PaymentMethod, InstallmentPlan,
-    FeeTypeEnum, FeeStatusEnum,
+    Fee, Invoice, Payment, PaymentMethod, InstallmentPlan, PaymentIntent,
+    FeeTypeEnum, FeeStatusEnum, InvoiceStatusEnum,
+    PaymentStatusEnum, PaymentIntentStatusEnum,
 )
 from app.models.tuition_discount_policy import TuitionDiscountPolicy
 from app.services.fee_calculation_service import (
     FeeCalculationService,
     calculate_installment_amounts,
+)
+from app.services.lead_admission_sync import (
+    TUITION_CALCULATED_STATUS,
+    TUITION_PAID_STATUS,
 )
 from app.utils.exceptions import (
     ResourceNotFoundError,
@@ -528,6 +533,291 @@ class TestFeeCancellation:
             )
 
         assert "existing payments" in str(exc_info.value).lower()
+
+    # ---- PR-2 hardening: cascade invoices, guards, lead revert ------------
+
+    async def _mk_tuition_hk1(
+        self, db, profile, *, final="10000000", invoices=(), status="invoiced"
+    ):
+        """Create an HK1 tuition fee (+ optional invoices) directly."""
+        fee = Fee(
+            admission_profile_id=profile.id,
+            fee_type="tuition",
+            academic_year=2025,
+            semester_no=1,
+            base_amount=Decimal(final),
+            final_amount=Decimal(final),
+            status=status,
+        )
+        db.add(fee)
+        await db.flush()
+        inv_objs = []
+        for i, (amount, st) in enumerate(invoices, start=1):
+            inv = Invoice(
+                fee_id=fee.id,
+                invoice_number=f"INV-CF-{fee.id}-{i}",
+                installment_no=i,
+                amount=Decimal(str(amount)),
+                paid_amount=Decimal("0"),
+                penalty_amount=Decimal("0"),
+                status=st,
+                due_date=date(2025, 9, 5),
+            )
+            db.add(inv)
+            inv_objs.append(inv)
+        await db.flush()
+        return fee, inv_objs
+
+    async def _seed_consult(self, db, status_id, stage_id="stg01"):
+        if await db.get(models.ConsultationStatus, status_id) is None:
+            db.add(models.ConsultationStatus(
+                id=status_id, name=status_id, color_code="#888888",
+                stage_id=stage_id,
+            ))
+            await db.flush()
+
+    async def _put_lead_at_sts14(self, db, lead):
+        """Move lead to sts14 + forward LeadStatusHistory row (old = current)."""
+        await self._seed_consult(db, TUITION_CALCULATED_STATUS)
+        orig_cs = lead.consultation_status_id
+        orig_stage = lead.pipeline_stage_id
+        db.add(models.LeadStatusHistory(
+            lead_id=lead.id,
+            old_status=lead.status,
+            new_status=lead.status,
+            old_consultation_status_id=orig_cs,
+            new_consultation_status_id=TUITION_CALCULATED_STATUS,
+            old_pipeline_stage_id=orig_stage,
+            new_pipeline_stage_id="stg01",
+            changed_by_user_id=None,
+            reason="test setup: forward to sts14",
+        ))
+        lead.consultation_status_id = TUITION_CALCULATED_STATUS
+        lead.pipeline_stage_id = "stg01"
+        await db.flush()
+        return orig_cs
+
+    async def test_cancel_fee_cascades_active_invoices(
+        self, db, fee_fixtures, admin_user
+    ):
+        """cancel_fee huỷ MỌI invoice non-cancelled (gồm cả draft)."""
+        service = FeeCalculationService(db)
+        fee, invs = await self._mk_tuition_hk1(
+            db, fee_fixtures["profile"],
+            invoices=[("6000000", InvoiceStatusEnum.issued.value),
+                      ("4000000", InvoiceStatusEnum.draft.value)],
+        )
+        await db.commit()
+
+        await service.cancel_fee(
+            fee_id=fee.id, reason="tính nhầm", user_id=admin_user.id,
+            unit_id=fee_fixtures["unit_id"],
+        )
+        await db.commit()
+
+        for inv in invs:
+            await db.refresh(inv)
+            assert inv.status == InvoiceStatusEnum.cancelled.value
+            assert inv.cancelled_by_id == admin_user.id
+            assert inv.cancelled_reason == "tính nhầm"
+        await db.refresh(fee)
+        assert fee.status == FeeStatusEnum.cancelled.value
+
+    async def test_cancel_fee_blocked_pending_payment(
+        self, db, fee_fixtures, admin_user
+    ):
+        """Có payment pending trên invoice của fee → chặn huỷ."""
+        service = FeeCalculationService(db)
+        fee, invs = await self._mk_tuition_hk1(
+            db, fee_fixtures["profile"],
+            invoices=[("10000000", InvoiceStatusEnum.issued.value)],
+        )
+        db.add(Payment(
+            invoice_id=invs[0].id,
+            method_id=fee_fixtures["cash_method"].id,
+            amount=Decimal("1000000"),
+            status=PaymentStatusEnum.pending.value,
+            payment_date=datetime.now(timezone.utc),
+            created_by_id=admin_user.id,
+        ))
+        await db.commit()
+
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await service.cancel_fee(
+                fee_id=fee.id, reason="x", user_id=admin_user.id,
+                unit_id=fee_fixtures["unit_id"],
+            )
+        assert "chờ xác minh" in str(exc.value)
+
+    async def test_cancel_fee_blocked_active_intent(
+        self, db, fee_fixtures, admin_user
+    ):
+        """Có PaymentIntent created/pending chưa hết hạn → chặn huỷ."""
+        service = FeeCalculationService(db)
+        fee, invs = await self._mk_tuition_hk1(
+            db, fee_fixtures["profile"],
+            invoices=[("10000000", InvoiceStatusEnum.issued.value)],
+        )
+        db.add(PaymentIntent(
+            invoice_id=invs[0].id,
+            method_id=fee_fixtures["cash_method"].id,
+            amount=Decimal("10000000"),
+            idempotency_key="cf-intent-1",
+            status=PaymentIntentStatusEnum.pending.value,
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        ))
+        await db.commit()
+
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await service.cancel_fee(
+                fee_id=fee.id, reason="x", user_id=admin_user.id,
+                unit_id=fee_fixtures["unit_id"],
+            )
+        assert "giao dịch online" in str(exc.value)
+
+    async def test_cancel_fee_allows_when_intent_expired(
+        self, db, fee_fixtures, admin_user
+    ):
+        """Intent đã hết hạn (can_process_callback=False) → KHÔNG chặn huỷ."""
+        service = FeeCalculationService(db)
+        fee, invs = await self._mk_tuition_hk1(
+            db, fee_fixtures["profile"],
+            invoices=[("10000000", InvoiceStatusEnum.issued.value)],
+        )
+        db.add(PaymentIntent(
+            invoice_id=invs[0].id,
+            method_id=fee_fixtures["cash_method"].id,
+            amount=Decimal("10000000"),
+            idempotency_key="cf-intent-exp",
+            status=PaymentIntentStatusEnum.pending.value,
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        ))
+        await db.commit()
+
+        cancelled, _ = await service.cancel_fee(
+            fee_id=fee.id, reason="x", user_id=admin_user.id,
+            unit_id=fee_fixtures["unit_id"],
+        )
+        await db.commit()
+        assert cancelled.status == FeeStatusEnum.cancelled.value
+
+    async def test_cancel_fee_reverts_hk1_lead_from_sts14(
+        self, db, fee_fixtures, admin_user
+    ):
+        """HK1 tuition + lead đang sts14 → huỷ fee lùi lead về status TRƯỚC."""
+        service = FeeCalculationService(db)
+        lead = fee_fixtures["lead"]
+        orig_cs = await self._put_lead_at_sts14(db, lead)
+        fee, _ = await self._mk_tuition_hk1(db, fee_fixtures["profile"])
+        await db.commit()
+
+        await service.cancel_fee(
+            fee_id=fee.id, reason="tính nhầm", user_id=admin_user.id,
+            unit_id=fee_fixtures["unit_id"],
+        )
+        await db.commit()
+
+        await db.refresh(lead)
+        assert lead.consultation_status_id == orig_cs
+
+    async def test_cancel_fee_no_revert_for_non_tuition(
+        self, db, fee_fixtures, admin_user
+    ):
+        """Phí KHÔNG phải HK1 tuition → KHÔNG đụng lead dù lead ở sts14."""
+        service = FeeCalculationService(db)
+        lead = fee_fixtures["lead"]
+        await self._put_lead_at_sts14(db, lead)
+        fee, _ = await service.calculate_fee(
+            admission_profile_id=fee_fixtures["profile"].id,
+            fee_type=FeeTypeEnum.application,
+            base_amount=Decimal("70000"),
+            academic_year=2025,
+            user_id=admin_user.id,
+            unit_id=fee_fixtures["unit_id"],
+        )
+        await db.commit()
+
+        await service.cancel_fee(
+            fee_id=fee.id, reason="x", user_id=admin_user.id,
+            unit_id=fee_fixtures["unit_id"],
+        )
+        await db.commit()
+
+        await db.refresh(lead)
+        assert lead.consultation_status_id == TUITION_CALCULATED_STATUS
+
+    async def test_cancel_fee_no_revert_when_lead_advanced(
+        self, db, fee_fixtures, admin_user
+    ):
+        """Lead đã tiến tiếp khỏi sts14 (sts10) → huỷ fee KHÔNG kéo lùi."""
+        service = FeeCalculationService(db)
+        lead = fee_fixtures["lead"]
+        await self._seed_consult(db, TUITION_PAID_STATUS)
+        lead.consultation_status_id = TUITION_PAID_STATUS
+        await db.flush()
+        fee, _ = await self._mk_tuition_hk1(db, fee_fixtures["profile"])
+        await db.commit()
+
+        await service.cancel_fee(
+            fee_id=fee.id, reason="x", user_id=admin_user.id,
+            unit_id=fee_fixtures["unit_id"],
+        )
+        await db.commit()
+
+        await db.refresh(lead)
+        assert lead.consultation_status_id == TUITION_PAID_STATUS
+
+    async def test_check_duplicate_excludes_cancelled_tuition(
+        self, db, fee_fixtures, admin_user
+    ):
+        """Fee HK1 đã huỷ KHÔNG tính là trùng → cho phép tính lại."""
+        service = FeeCalculationService(db)
+        fee, _ = await self._mk_tuition_hk1(db, fee_fixtures["profile"])
+        await db.commit()
+        pid = fee_fixtures["profile"].id
+
+        # Còn active → là trùng.
+        assert await service.fee_repo.check_duplicate(
+            pid, "tuition", 2025, semester_no=1
+        ) is True
+
+        await service.cancel_fee(
+            fee_id=fee.id, reason="x", user_id=admin_user.id,
+            unit_id=fee_fixtures["unit_id"],
+        )
+        await db.commit()
+
+        # Đã huỷ → KHÔNG còn trùng.
+        assert await service.fee_repo.check_duplicate(
+            pid, "tuition", 2025, semester_no=1
+        ) is False
+
+    async def test_recalc_nontuition_after_cancel(
+        self, db, fee_fixtures, admin_user
+    ):
+        """Huỷ fee non-tuition rồi tính lại cùng năm → KHÔNG raise trùng."""
+        service = FeeCalculationService(db)
+        pid = fee_fixtures["profile"].id
+        fee1, _ = await service.calculate_fee(
+            admission_profile_id=pid, fee_type=FeeTypeEnum.enrollment,
+            base_amount=Decimal("1000000"), academic_year=2025,
+            user_id=admin_user.id, unit_id=fee_fixtures["unit_id"],
+        )
+        await db.commit()
+        await service.cancel_fee(
+            fee_id=fee1.id, reason="x", user_id=admin_user.id,
+            unit_id=fee_fixtures["unit_id"],
+        )
+        await db.commit()
+
+        fee2, _ = await service.calculate_fee(
+            admission_profile_id=pid, fee_type=FeeTypeEnum.enrollment,
+            base_amount=Decimal("1000000"), academic_year=2025,
+            user_id=admin_user.id, unit_id=fee_fixtures["unit_id"],
+        )
+        await db.commit()
+        assert fee2.id != fee1.id
+        assert fee2.status == FeeStatusEnum.calculated.value
 
 
 # =============================================================================

--- a/Backend_FastAPI/tests/services/test_payment_intent_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_intent_service.py
@@ -356,6 +356,47 @@ class TestProcessCallback:
         assert payment is not None
         assert payment.amount == amount
 
+    async def test_process_callback_refused_on_cancelled_fee(
+        self, db, intent_fixtures, admin_user
+    ):
+        """2b-bis (money-critical): a SUCCESS callback whose fee was cancelled
+        AFTER the intent was created is REFUSED — never write money onto a
+        cancelled target. paid_amount stays 0 (no half-applied payment)."""
+        service = PaymentIntentService(db)
+        invoice = intent_fixtures["invoice"]
+        method = intent_fixtures["online_method"]
+        amount = Decimal("5000000")
+
+        intent, _ = await service.create_intent(
+            invoice_id=invoice.id,
+            method_id=method.id,
+            amount=amount,
+            idempotency_key=str(uuid.uuid4()),
+            return_url=VALID_RETURN_URL,
+            unit_id=intent_fixtures["unit_id"],
+        )
+        await db.commit()
+
+        # Fee cancelled out-of-band AFTER the intent exists (race / reissue).
+        intent_fixtures["fee"].status = FeeStatusEnum.cancelled.value
+        await db.commit()
+
+        callback_data = {
+            "gateway_ref": intent.gateway_ref,
+            "status": "success",
+            "amount": str(amount),
+        }
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await service.process_callback(
+                gateway_code=method.code,
+                callback_data=callback_data,
+                unit_id=intent_fixtures["unit_id"],
+            )
+        assert "đã bị huỷ" in str(exc.value)
+
+        await db.refresh(invoice)
+        assert invoice.paid_amount == Decimal("0")
+
     async def test_process_callback_amount_mismatch(self, db, intent_fixtures, admin_user):
         """Amount mismatch in callback marks intent as failed (C1)."""
         service = PaymentIntentService(db)

--- a/Backend_FastAPI/tests/services/test_payment_intent_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_intent_service.py
@@ -168,6 +168,27 @@ class TestCreateIntent:
         assert intent.pay_url is not None
         assert intent.expires_at is not None
 
+    async def test_create_intent_blocked_when_fee_cancelled(
+        self, db, intent_fixtures, admin_user
+    ):
+        """Race guard: a cancelled fee cannot get a NEW intent (which would let
+        the gateway collect money the callback must later refuse). Invoice is
+        still 'issued' (payable) here — only the fee is cancelled."""
+        service = PaymentIntentService(db)
+        intent_fixtures["fee"].status = FeeStatusEnum.cancelled.value
+        await db.commit()
+
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await service.create_intent(
+                invoice_id=intent_fixtures["invoice"].id,
+                method_id=intent_fixtures["online_method"].id,
+                amount=Decimal("1000000"),
+                idempotency_key=str(uuid.uuid4()),
+                return_url=VALID_RETURN_URL,
+                unit_id=intent_fixtures["unit_id"],
+            )
+        assert "đã bị huỷ" in str(exc.value)
+
     async def test_create_intent_rejects_foreign_return_url(
         self, db, intent_fixtures, admin_user
     ):

--- a/Backend_FastAPI/tests/services/test_payment_service.py
+++ b/Backend_FastAPI/tests/services/test_payment_service.py
@@ -270,6 +270,39 @@ class TestVerifyPayment:
         assert pf["fee"].paid_amount == Decimal("1000000")
         assert pf["fee"].status == FeeStatusEnum.paid.value
 
+    async def test_verify_payment_blocked_when_fee_cancelled(
+        self, db, payment_fixtures
+    ):
+        """Race guard: fee/invoice cancelled AFTER a pending payment was
+        recorded → verify refuses (never write money onto a cancelled target)."""
+        service = PaymentService(db)
+        pf = payment_fixtures
+
+        payment, _ = await service.record_manual_payment(
+            invoice_id=pf["invoice"].id,
+            method_id=pf["cash_method"].id,
+            amount=Decimal("500000"),
+            user_id=pf["maker"].id,
+            unit_id=pf["unit_id"],
+        )
+        await db.commit()
+
+        # Simulate cancel landing AFTER the pending payment (race window).
+        pf["fee"].status = FeeStatusEnum.cancelled.value
+        pf["invoice"].status = InvoiceStatusEnum.cancelled.value
+        await db.commit()
+
+        with pytest.raises(BusinessRuleViolation) as exc:
+            await service.verify_payment(
+                payment_id=payment.id,
+                verifier_id=pf["checker"].id,
+                unit_id=pf["unit_id"],
+            )
+        assert "đã bị huỷ" in str(exc.value)
+
+        await db.refresh(pf["fee"])
+        assert pf["fee"].paid_amount == Decimal("0")
+
     async def test_verify_payment_self_blocked(self, db, payment_fixtures):
         """C3: Maker cannot verify their own payment."""
         service = PaymentService(db)


### PR DESCRIPTION
## Bối cảnh

Tiếp nối #441 (PR-1: nhãn lead sts10 chỉ bật khi đóng ĐỦ HK1). PR này **hoàn thiện hợp đồng đồng bộ HAI CHIỀU Lead↔Finance**: mọi forward sync học phí HK1 (calc→sts14, paid→sts10, refund→sts18) nay có đủ reverse, đều ghi `LeadStatusHistory`. Lấp ca prod "officer tính học phí nhầm → lead kẹt sts14" (trước phải vá tay DB — ca Huỳnh Long Hiếu).

## Thay đổi

### Đối xứng revert
- **`revert_lead_tuition_calculated`** (mới): đưa lead khỏi sts14 về status TRƯỚC đó, đọc **verbatim** từ `LeadStatusHistory` (KHÔNG hardcode sts09 — ca thực tế thường là sts13 khi profile vẫn submitted). Gom chung với `revert_lead_tuition_paid` qua `_revert_lead_projection`.

### `cancel_fee` làm chặt (money-safety)
- Block khi có **pending payment** / **active online intent** (created/pending chưa hết hạn) trên **MỌI** invoice của fee (gồm invoice cancelled độc lập — luồng MISA reissue).
- **Cascade hủy MỌI invoice non-cancelled** (gồm draft) — khớp FE `FeeCancelDialog`.
- **Revert lead** chỉ khi HK1 tuition + lead đang sts14 + **không còn fee HK1 non-cancelled khác** (đa-năm) — bọc `begin_nested` best-effort (revert lỗi KHÔNG rollback cancel).

### Race-safety (chặn ghi tiền vào fee/invoice đã huỷ)
- `verify_payment` + `_create_payment_from_intent` + `create_intent` re-check qua helper chung **`assert_payable_target(fee, invoice, action=…)`** sau khi lock. `create_intent` khóa fee (`get_for_update`) → serialize với `cancel_fee` (đóng race online tại nguồn, không ABBA).

### Cho phép tính lại fee sau khi huỷ
- Migration **`feecancel20260628001`**: 2 partial-index fee thêm `AND status <> 'cancelled'` (`op.drop_index`) + `FeeRepository.check_duplicate` loại cancelled → huỷ fee tính nhầm rồi tính lại được, khỏi hard-delete.

## Phạm vi giữ nguyên
- Cổng nhập học `_check_fee_gate_semester_hk1` KHÔNG đổi (partial vẫn qua, ADR-002).

## Test
- 11 test cancel_fee + 2 race-guard + 2b-bis callback + check_duplicate + re-calc-after-cancel.
- Đã rebase lên main (sau #441), **regression 280 xanh** (fee_calc + payment_intent/service/import + finance_workflow + lead_sync + tuition_prepay).
- /code-review: 8 finding đã vá (guard đa-năm, Guard A/B mọi-invoice, best-effort revert, refactor `_revert_lead_projection` + `assert_payable_target`).

## Deploy
Code + **1 migration** (`alembic upgrade head`) + 0 Casbin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)