### PR TITLE
docs+ux(finance): hợp đồng Lead↔Finance + note revert + link Chi tiết khoản phí

### DIFF
--- a/Backend_FastAPI/app/services/lead_admission_sync.py
+++ b/Backend_FastAPI/app/services/lead_admission_sync.py
@@ -20,6 +20,24 @@ Usage:
     - reject_profile() → sts16 (Không đạt)
     - request_revision() → sts17 (Yêu cầu bổ sung hồ sơ)
     - enroll_student() → sts11 (Đã xác nhận nhập học)
+
+Finance → Lead projection contract (HK1 tuition lifecycle):
+    Each forward sync that overlays a finance state onto the lead has a matching
+    REVERSE that restores the prior state verbatim from LeadStatusHistory (never
+    a hardcoded target). Keep this table in lock-step when adding a new finance
+    overlay — a forward without a reverse is the bug class this contract guards.
+
+    | Finance event              | Forward                        | Reverse                          |
+    |----------------------------|--------------------------------|----------------------------------|
+    | Lệ phí xét tuyển đã đóng    | sync_lead_fee_paid → sts13     | (lệ phí không hoàn — N/A)         |
+    | Học phí HK1 đã TÍNH         | sync_lead_tuition_calculated → sts14 | revert_lead_tuition_calculated (cancel_fee) |
+    | Học phí HK1 đã đóng ĐỦ      | sync_lead_tuition_paid → sts10 | revert_lead_tuition_paid (void import) |
+    | Học phí HK1 đã hoàn         | sync_lead_tuition_refunded → sts18 | (terminal)                       |
+
+    "Settled" (→ sts10) means remaining ≤ 0 (paid/waived đủ) — a PARTIAL payment
+    stays at sts14. See fee_calculation_service.is_hk1_settled. Both reverts
+    share _revert_lead_projection and only act while the lead is still at the
+    projected status (an advanced lead — enrolled… — is left untouched).
 """
 
 from typing import Optional

--- a/frontend/src/app/(dashboard)/finance/fees/[feeId]/_components/FeeCancelDialog.tsx
+++ b/frontend/src/app/(dashboard)/finance/fees/[feeId]/_components/FeeCancelDialog.tsx
@@ -116,6 +116,10 @@ export function FeeCancelDialog({
             <p className="text-destructive font-medium">
               Hành động này không thể hoàn tác. Tất cả hóa đơn liên quan sẽ bị hủy theo.
             </p>
+            <p className="text-muted-foreground text-sm">
+              Nếu đây là học phí học kỳ 1 chưa thu, trạng thái tuyển sinh của ứng
+              viên sẽ tự động lùi về bước trước khi tính học phí.
+            </p>
           </AlertDialogDescription>
         </AlertDialogHeader>
 


### PR DESCRIPTION
Follow-up cho #441 (is_hk1_settled) + #442 (cancel_fee đối xứng). Tài liệu + 1 UX quick-win, không đổi logic backend.

**Docs (chống drift):**
- `lead_admission_sync.py`: bảng hợp đồng forward/reverse HK1 tuition trong docstring đầu file — mỗi forward overlay phải có reverse.
- `FeeCancelDialog.tsx`: note lead lùi về bước trước khi tính học phí (HK1 tuition chưa thu).

**UX #9 (reachability — backlog finance-reconciliation-pr3):**
- `FinanceProfileDrawer.tsx`: link "Chi tiết" → `/finance/fees/{id}` trên mỗi FeeRow. Lấp gap: fee **chưa có hoá đơn** không tới được trang recalc / **huỷ khoản phí** (role-gated `FeeDetailClient`). Đi cùng cancel_fee #442 — nay có đường UI để dùng.

Verify: BE import OK · FE `tsc --noEmit` sạch · lint không phát sinh warning mới.

🤖 Generated with [Claude Code](https://claude.com/claude-code)